### PR TITLE
feat(authz): a grant states which surface authored it

### DIFF
--- a/packages/actor/src/index.ts
+++ b/packages/actor/src/index.ts
@@ -33,6 +33,9 @@ export const SYSTEM_ACTORS = {
   readThroughMint: "system:read-through-mint",
   ssoAutoJoin: "system:sso-auto-join",
   scim: "system:scim",
+  /** Policy-driven auto-approval of a join request. An approval a person
+   *  made carries that person as a user actor instead. */
+  joinRequests: "system:join-requests",
 } as const satisfies Record<string, `system:${string}`>;
 
 export type SystemActorName = keyof typeof SYSTEM_ACTORS;

--- a/packages/authz-server/src/__tests__/grants.unit.test.ts
+++ b/packages/authz-server/src/__tests__/grants.unit.test.ts
@@ -10,6 +10,7 @@ import type { AuthzReadRepository } from "../authz-read.repository";
 import { AuthzService } from "../authz.service";
 import { GrantValidationError } from "../grant-validation";
 import { GrantsService } from "../grants.service";
+import { GRANT_EVENT_SOURCES } from "../ledger/facts";
 import { OffboardIncompleteError } from "../offboard";
 import { makeReader } from "./support/authz-read.stub";
 
@@ -104,6 +105,7 @@ describe("GrantsService.attach", () => {
           principal: { userId: "alice" },
         },
         actor: WRITE_ACTOR,
+        source: "grants-service",
       });
       expect(bumpEpoch).toHaveBeenCalledWith({ organizationId: ORG });
     });
@@ -172,6 +174,67 @@ describe("GrantsService.attach", () => {
       });
 
       expect(repository.createBinding).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("when the caller states where the grant came from", () => {
+    /** @scenario "A grant states which surface authored it" */
+    it("stamps that source onto the write", async () => {
+      const repository = makeRepository();
+      const { service } = makeService(repository);
+
+      await service.attach({
+        actor,
+        who: { type: "user", id: "alice" },
+        role: { builtin: "MEMBER" },
+        where: { type: "team", id: TEAM, organizationId: ORG },
+        source: "join-request",
+      });
+
+      expect(repository.createBinding).toHaveBeenCalledWith(
+        expect.objectContaining({ source: "join-request" }),
+      );
+    });
+
+    /** Every vocabulary entry reaches the port unchanged: the seam is the
+     *  vocabulary's, not a private list of the two callers that exist today.
+     *  @scenario "A grant states which surface authored it" */
+    it("carries every source the vocabulary names", async () => {
+      for (const source of GRANT_EVENT_SOURCES) {
+        const repository = makeRepository();
+        const { service } = makeService(repository);
+
+        await service.attach({
+          actor,
+          who: { type: "user", id: "alice" },
+          role: { builtin: "MEMBER" },
+          where: { type: "team", id: TEAM, organizationId: ORG },
+          source,
+        });
+
+        expect(repository.createBinding).toHaveBeenCalledWith(
+          expect.objectContaining({ source }),
+        );
+      }
+    });
+  });
+
+  describe("when the caller states no source", () => {
+    /** @scenario "A grant nobody attributed is the grants service's own" */
+    it("attributes the grant to the grants service", async () => {
+      const repository = makeRepository();
+      const { service } = makeService(repository);
+
+      await service.attach({
+        actor,
+        who: { type: "user", id: "alice" },
+        role: { builtin: "MEMBER" },
+        where: { type: "team", id: TEAM, organizationId: ORG },
+      });
+
+      expect(repository.createBinding).toHaveBeenCalledWith(
+        expect.objectContaining({ source: "grants-service" }),
+      );
     });
   });
 

--- a/packages/authz-server/src/__tests__/grants.unit.test.ts
+++ b/packages/authz-server/src/__tests__/grants.unit.test.ts
@@ -1,3 +1,4 @@
+import { SYSTEM_ACTORS } from "@langwatch/actor";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { AuthzCollectorService } from "../authz-collector.service";
 import {
@@ -234,6 +235,71 @@ describe("GrantsService.attach", () => {
 
       expect(repository.createBinding).toHaveBeenCalledWith(
         expect.objectContaining({ source: "grants-service" }),
+      );
+    });
+  });
+
+  describe("when the caller is a surface rather than a person", () => {
+    /** The registry's name, never a hand-built `"system:..."` string: what
+     *  reaches the port is what `toLedgerActor` renders it as.
+     *  @scenario "A write with no person behind it names the surface that made it" */
+    it("stamps the registry's system principal onto the write", async () => {
+      const repository = makeRepository();
+      const { service } = makeService(repository);
+
+      await service.attach({
+        actor: { type: "system", name: "scim" },
+        who: { type: "user", id: "alice" },
+        role: { builtin: "MEMBER" },
+        where: { type: "team", id: TEAM, organizationId: ORG },
+        source: "scim",
+      });
+
+      expect(repository.createBinding).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actor: { type: "system", id: SYSTEM_ACTORS.scim },
+          source: "scim",
+        }),
+      );
+    });
+
+    /** @scenario "A write with no person behind it names the surface that made it" */
+    it("carries the join-requests principal the auto-approval path acts as", async () => {
+      const repository = makeRepository();
+      const { service } = makeService(repository);
+
+      await service.attach({
+        actor: { type: "system", name: "joinRequests" },
+        who: { type: "user", id: "alice" },
+        role: { builtin: "MEMBER" },
+        where: { type: "team", id: TEAM, organizationId: ORG },
+        source: "join-request",
+      });
+
+      expect(repository.createBinding).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actor: { type: "system", id: SYSTEM_ACTORS.joinRequests },
+          source: "join-request",
+        }),
+      );
+    });
+
+    /** The raw-id shape every boundary already passes is untouched by the
+     *  widening — that is the whole constraint on this change.
+     *  @scenario "A write with no person behind it names the surface that made it" */
+    it("still records a person from the raw id shape", async () => {
+      const repository = makeRepository();
+      const { service } = makeService(repository);
+
+      await service.attach({
+        actor,
+        who: { type: "user", id: "alice" },
+        role: { builtin: "MEMBER" },
+        where: { type: "team", id: TEAM, organizationId: ORG },
+      });
+
+      expect(repository.createBinding).toHaveBeenCalledWith(
+        expect.objectContaining({ actor: WRITE_ACTOR }),
       );
     });
   });
@@ -525,6 +591,31 @@ describe("GrantsService.offboard", () => {
         }),
       );
       expect(bumpEpoch).toHaveBeenCalledWith({ organizationId: ORG });
+    });
+  });
+
+  describe("when a directory sync offboards the member", () => {
+    /** D08's de-enroll. The revocation says which surface removed the
+     *  member through its ACTOR — `grant_revoked` has no `source` field and
+     *  does not need one, because the offboarding fact already names the
+     *  surface here and the reason alongside it.
+     *  @scenario "A revocation names the surface that made it without a source of its own" */
+    it("hands the port the surface as the offboarding actor", async () => {
+      const repository = makeRepository();
+      const { service } = makeService(repository);
+
+      await service.offboard({
+        actor: { type: "system", name: "scim" },
+        userId: "dave",
+        organizationId: ORG,
+      });
+
+      expect(repository.offboardUser).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: "dave",
+          actor: { type: "system", id: SYSTEM_ACTORS.scim },
+        }),
+      );
     });
   });
 

--- a/packages/authz-server/src/authz-grants.repository.ts
+++ b/packages/authz-server/src/authz-grants.repository.ts
@@ -10,6 +10,7 @@ import type {
   AuthzReadRepository,
   ScopeLineageRepository,
 } from "./authz-read.repository";
+import type { GrantEventSource } from "./ledger/facts";
 
 /** Which principal a binding row points at. Exactly one, by construction -
  *  the `?: never` exclusions are what make "two principals on one row"
@@ -87,10 +88,17 @@ export type OffboardCounts = {
 };
 
 export interface AuthzGrantsRepository extends ScopeLineageRepository {
-  /** @throws DuplicateBindingError on a unique-index collision. */
+  /**
+   * @throws DuplicateBindingError on a unique-index collision.
+   *
+   * `source` is the grant's provenance — which surface authored the fact,
+   * stamped onto it alongside the actor. Optional so every existing caller
+   * keeps its meaning; GrantsService fills it with `"grants-service"`.
+   */
   createBinding(args: {
     row: RoleBindingWrite;
     actor: LedgerActor;
+    source?: GrantEventSource;
   }): Promise<void>;
   /**
    * @throws DuplicateBindingError on a unique-index collision.

--- a/packages/authz-server/src/grants.service.ts
+++ b/packages/authz-server/src/grants.service.ts
@@ -18,6 +18,7 @@ import type {
   RoleBindingWrite,
 } from "./authz-grants.repository";
 import type { AuthzReadRepository } from "./authz-read.repository";
+import type { GrantEventSource } from "./ledger/facts";
 import {
   assertBindingInOrganization,
   assertRoleUsable,
@@ -96,17 +97,27 @@ export class GrantsService {
     await this.deps.bumpEpoch({ organizationId });
   }
 
-  /** INSERT (who, role, where) — visible on the next check. */
+  /**
+   * INSERT (who, role, where) — visible on the next check.
+   *
+   * `source` is WHERE the grant came from, which the actor cannot say: a
+   * SCIM reconciler and a join-request approval both act as the platform,
+   * and only the source separates "the directory says so" from "an admin
+   * approved a request". It defaults to this service, which is what a
+   * hand-made grant through the settings UI or the REST API is.
+   */
   async attach({
     actor,
     who,
     role,
     where,
+    source = "grants-service",
   }: {
     actor: Actor;
     who: GrantPrincipal;
     role: GrantRole;
     where: AuthzScopeRef;
+    source?: GrantEventSource;
   }): Promise<{ bindingId: string }> {
     if (where.type === "resource") {
       throw new GrantValidationError(RESOURCE_SCOPE_REJECTION, {
@@ -125,7 +136,7 @@ export class GrantsService {
 
     const row = this.bindingRow({ who, role, where, organizationId });
     try {
-      await repository.createBinding({ row, actor: writeActor(actor) });
+      await repository.createBinding({ row, actor: writeActor(actor), source });
     } catch (error) {
       rethrowKnownWriteFailure(error, {
         scopeType: where.type,

--- a/packages/authz-server/src/grants.service.ts
+++ b/packages/authz-server/src/grants.service.ts
@@ -9,7 +9,11 @@
  * ./grant-validation.ts owns what a write must satisfy, and ./offboard.ts
  * owns the offboarding flow and its proof.
  */
-import type { LedgerActor } from "@langwatch/actor";
+import {
+  type Actor,
+  type LedgerActor,
+  toLedgerActor,
+} from "@langwatch/actor";
 import { type AuthzScopeRef, scopeOrganizationId } from "@langwatch/authz";
 import type { AuthzCollectorService } from "./authz-collector.service";
 import type {
@@ -56,7 +60,25 @@ export type GrantRole =
   | { builtin: "ADMIN" | "MEMBER" | "VIEWER" }
   | { customRoleId: string };
 
-type Actor = { userId: string };
+/**
+ * Who caused a grant write.
+ *
+ * Two shapes, and the second is the whole point of the union. `{ userId }`
+ * is what every boundary holding a raw session id already passes, and it
+ * stays valid unchanged. Everything else is the shared vocabulary from
+ * `@langwatch/actor` — which is how a write with no person behind it names
+ * the surface that made it: `{ type: "system", name: "scim" }` for a
+ * directory sync, `{ type: "system", name: "joinRequests" }` for a
+ * policy-driven approval. The name comes from that package's closed
+ * `SYSTEM_ACTORS` registry, so no call site here can invent a
+ * `"system:..."` string, and `toLedgerActor` stays the one seam that
+ * serializes either half.
+ *
+ * Taking the package's union OUTRIGHT would have invalidated every existing
+ * `{ userId }` call site, which is the one thing this must not do — so it is
+ * admitted alongside rather than in place of it.
+ */
+export type GrantActor = { userId: string } | Actor;
 
 /**
  * The app-owned effect seams, composed once in the app's runtime
@@ -113,7 +135,7 @@ export class GrantsService {
     where,
     source = "grants-service",
   }: {
-    actor: Actor;
+    actor: GrantActor;
     who: GrantPrincipal;
     role: GrantRole;
     where: AuthzScopeRef;
@@ -155,7 +177,7 @@ export class GrantsService {
     organizationId,
     role,
   }: {
-    actor: Actor;
+    actor: GrantActor;
     bindingId: string;
     organizationId: string;
     role: GrantRole;
@@ -189,7 +211,7 @@ export class GrantsService {
     bindingId,
     organizationId,
   }: {
-    actor: Actor;
+    actor: GrantActor;
     bindingId: string;
     organizationId: string;
   }): Promise<void> {
@@ -223,7 +245,7 @@ export class GrantsService {
     to,
     role,
   }: {
-    actor: Actor;
+    actor: GrantActor;
     who: GrantPrincipal;
     from: AuthzScopeRef;
     to: AuthzScopeRef;
@@ -277,7 +299,7 @@ export class GrantsService {
     userId,
     organizationId,
   }: {
-    actor: Actor;
+    actor: GrantActor;
     userId: string;
     organizationId: string;
   }): Promise<{
@@ -324,6 +346,14 @@ export class GrantsService {
 
 }
 
-function writeActor(actor: Actor): LedgerActor {
-  return { type: "user", id: actor.userId };
+/**
+ * The durable record, minted through the ONE seam that owns that mapping.
+ * The raw-id shape is lifted into the vocabulary first rather than
+ * shortcut to a literal, so both halves serialize by exactly the same rule
+ * — and a change to how an actor is stored stays a change in one file.
+ */
+function writeActor(actor: GrantActor): LedgerActor {
+  return toLedgerActor(
+    "userId" in actor ? { type: "user", id: actor.userId } : actor,
+  );
 }

--- a/packages/authz-server/src/index.ts
+++ b/packages/authz-server/src/index.ts
@@ -65,6 +65,7 @@ export { GrantsService } from "./grants.service";
 export type {
   AuthzAuditWriter,
   AuthzEpochBumper,
+  GrantActor,
   GrantPrincipal,
   GrantRole,
   GrantsServiceDeps,

--- a/packages/authz-server/src/ledger/facts.ts
+++ b/packages/authz-server/src/ledger/facts.ts
@@ -32,11 +32,16 @@ export type LedgerScopeType = StoredScopeTier;
  * backfill-b and cutover-import of the three-migration model ADR-110 folded
  * into one. The audit subscriber skips it, so a customer's audit page does
  * not fill with thousands of rows for changes nobody made.
+ *
+ * `join-request` is the opposite case, and deliberately so: somebody asked
+ * to join and the request was approved, which is a live change a customer
+ * should see. It stays auditable.
  */
 export const GRANT_EVENT_SOURCES = [
   "grants-service",
   "scim",
   "invite",
+  "join-request",
   "read-through-mint",
   "migration",
 ] as const;

--- a/platform/app/prisma/schema.prisma
+++ b/platform/app/prisma/schema.prisma
@@ -2502,7 +2502,7 @@ model Grant {
   // lets a projection reloaded from these rows reconstruct the fact rather
   // than a lossy copy. Null on everything ledger-born; retired at cutover.
   legacyRole String? // ADMIN | MEMBER | VIEWER | CUSTOM
-  source     String // which writer emitted the fact: grants-service | scim | invite | backfill-b | genesis-import | read-through-mint | cutover-import
+  source     String // which writer emitted the fact: grants-service | scim | invite | join-request | read-through-mint | migration (the vocabulary is GRANT_EVENT_SOURCES in @langwatch/authz-server; ADR-110 folded backfill-b, genesis-import and cutover-import into `migration`)
 
   scopeType GrantScopeType
   scopeId   String

--- a/platform/app/src/server/app-layer/authz/__tests__/grant-provenance.unit.test.ts
+++ b/platform/app/src/server/app-layer/authz/__tests__/grant-provenance.unit.test.ts
@@ -1,0 +1,91 @@
+/**
+ * A grant's PROVENANCE: which surface authored the fact, as distinct from
+ * the actor who caused it. A SCIM reconciler and a join-request approval
+ * both act as the platform, so the actor alone cannot tell "the directory
+ * says so" from "the request was approved".
+ *
+ * This drives the real chain — GrantsService, over the ledger-backed
+ * repository, over the writer — and asserts on the command the writer
+ * actually emits, because a value that stops one layer short of the fact is
+ * indistinguishable from one that never travelled at all.
+ *
+ * @see specs/rbac/authz-grants.feature
+ */
+import {
+  type AuthzCollectorService,
+  GrantsService,
+} from "@langwatch/authz-server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../epoch", () => ({
+  bumpAuthzEpoch: vi.fn().mockResolvedValue(undefined),
+}));
+
+import type { PrismaClient } from "~/generated/prisma/client";
+import { LedgerAuthzGrantsRepository } from "../repositories/authz-grants.ledger.repository";
+import { harness, ORG_ID } from "./ledger-write-fork.harness";
+
+const ADMIN = { userId: "user_admin" };
+
+function service() {
+  const { writer, db, sent } = harness({ onLedger: true });
+  const repository = new LedgerAuthzGrantsRepository(
+    db as unknown as PrismaClient,
+    writer,
+  );
+  const grants = new GrantsService(repository, {
+    newBindingId: () => "rb_provenance",
+    bumpEpoch: vi.fn().mockResolvedValue(undefined),
+    // Offboarding's proof only; no test here reaches it.
+    collectorFor: () => ({}) as AuthzCollectorService,
+  });
+  return { grants, sent };
+}
+
+/** The `source` on each `attachGrant` command the writer emitted. */
+function emittedSources(
+  sent: Array<{ verb: string; data: unknown }>,
+): unknown[] {
+  return sent
+    .filter(({ verb }) => verb === "attachGrant")
+    .map(({ data }) => (data as { grant: { source: unknown } }).grant.source);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("given a grant attached through the grants service", () => {
+  describe("when the caller states which surface authored it", () => {
+    /** @scenario "A grant states which surface authored it" */
+    it("carries that source on the emitted fact", async () => {
+      const { grants, sent } = service();
+
+      await grants.attach({
+        actor: ADMIN,
+        who: { type: "user", id: "user_alice" },
+        role: { builtin: "MEMBER" },
+        where: { type: "organization", id: ORG_ID },
+        source: "join-request",
+      });
+
+      expect(emittedSources(sent)).toEqual(["join-request"]);
+    });
+  });
+
+  describe("when the caller states no source", () => {
+    /** @scenario "A grant nobody attributed is the grants service's own" */
+    it("carries the grants service on the emitted fact", async () => {
+      const { grants, sent } = service();
+
+      await grants.attach({
+        actor: ADMIN,
+        who: { type: "user", id: "user_alice" },
+        role: { builtin: "MEMBER" },
+        where: { type: "organization", id: ORG_ID },
+      });
+
+      expect(emittedSources(sent)).toEqual(["grants-service"]);
+    });
+  });
+});

--- a/platform/app/src/server/app-layer/authz/__tests__/grant-provenance.unit.test.ts
+++ b/platform/app/src/server/app-layer/authz/__tests__/grant-provenance.unit.test.ts
@@ -1,16 +1,20 @@
 /**
- * A grant's PROVENANCE: which surface authored the fact, as distinct from
- * the actor who caused it. A SCIM reconciler and a join-request approval
- * both act as the platform, so the actor alone cannot tell "the directory
- * says so" from "the request was approved".
+ * A grant's PROVENANCE, which is two facts rather than one.
  *
- * This drives the real chain — GrantsService, over the ledger-backed
- * repository, over the writer — and asserts on the command the writer
+ * `source` is WHICH SURFACE authored it — a SCIM reconciler and a
+ * join-request approval both act as the platform, so the actor alone cannot
+ * tell "the directory says so" from "the request was approved". The ACTOR is
+ * who caused it, and for those same two surfaces that is nobody: a system
+ * principal from the closed registry, not a person.
+ *
+ * These drive the real chain — GrantsService, over the ledger-backed
+ * repository, over the writer — and assert on the command the writer
  * actually emits, because a value that stops one layer short of the fact is
  * indistinguishable from one that never travelled at all.
  *
  * @see specs/rbac/authz-grants.feature
  */
+import { SYSTEM_ACTORS } from "@langwatch/actor";
 import {
   type AuthzCollectorService,
   GrantsService,
@@ -26,6 +30,7 @@ import { LedgerAuthzGrantsRepository } from "../repositories/authz-grants.ledger
 import { harness, ORG_ID } from "./ledger-write-fork.harness";
 
 const ADMIN = { userId: "user_admin" };
+const BINDING_ID = "rb_provenance";
 
 function service() {
   const { writer, db, sent } = harness({ onLedger: true });
@@ -34,21 +39,35 @@ function service() {
     writer,
   );
   const grants = new GrantsService(repository, {
-    newBindingId: () => "rb_provenance",
+    newBindingId: () => BINDING_ID,
     bumpEpoch: vi.fn().mockResolvedValue(undefined),
     // Offboarding's proof only; no test here reaches it.
     collectorFor: () => ({}) as AuthzCollectorService,
   });
-  return { grants, sent };
+  return { grants, db, sent };
 }
 
+type Sent = Array<{ verb: string; data: unknown }>;
+
 /** The `source` on each `attachGrant` command the writer emitted. */
-function emittedSources(
-  sent: Array<{ verb: string; data: unknown }>,
-): unknown[] {
+function attachedSources(sent: Sent): unknown[] {
   return sent
     .filter(({ verb }) => verb === "attachGrant")
     .map(({ data }) => (data as { grant: { source: unknown } }).grant.source);
+}
+
+/** The `actor` on each `attachGrant` command the writer emitted. */
+function attachedActors(sent: Sent): unknown[] {
+  return sent
+    .filter(({ verb }) => verb === "attachGrant")
+    .map(({ data }) => (data as { grant: { actor: unknown } }).grant.actor);
+}
+
+/** The `actor` on each `revokeGrant` command the writer emitted. */
+function revokedActors(sent: Sent): unknown[] {
+  return sent
+    .filter(({ verb }) => verb === "revokeGrant")
+    .map(({ data }) => (data as { actor: unknown }).actor);
 }
 
 beforeEach(() => {
@@ -69,7 +88,7 @@ describe("given a grant attached through the grants service", () => {
         source: "join-request",
       });
 
-      expect(emittedSources(sent)).toEqual(["join-request"]);
+      expect(attachedSources(sent)).toEqual(["join-request"]);
     });
   });
 
@@ -85,7 +104,73 @@ describe("given a grant attached through the grants service", () => {
         where: { type: "organization", id: ORG_ID },
       });
 
-      expect(emittedSources(sent)).toEqual(["grants-service"]);
+      expect(attachedSources(sent)).toEqual(["grants-service"]);
+    });
+  });
+
+  describe("when a surface rather than a person made it", () => {
+    /** @scenario "A write with no person behind it names the surface that made it" */
+    it("carries the registry's system principal on the emitted fact", async () => {
+      const { grants, sent } = service();
+
+      await grants.attach({
+        actor: { type: "system", name: "joinRequests" },
+        who: { type: "user", id: "user_alice" },
+        role: { builtin: "MEMBER" },
+        where: { type: "organization", id: ORG_ID },
+        source: "join-request",
+      });
+
+      expect(attachedActors(sent)).toEqual([
+        { type: "system", id: SYSTEM_ACTORS.joinRequests },
+      ]);
+      expect(attachedSources(sent)).toEqual(["join-request"]);
+    });
+  });
+
+  describe("when a person made it", () => {
+    /** @scenario "A write with no person behind it names the surface that made it" */
+    it("still carries that person, from the raw id shape every boundary passes", async () => {
+      const { grants, sent } = service();
+
+      await grants.attach({
+        actor: ADMIN,
+        who: { type: "user", id: "user_alice" },
+        role: { builtin: "MEMBER" },
+        where: { type: "organization", id: ORG_ID },
+      });
+
+      expect(attachedActors(sent)).toEqual([
+        { type: "user", id: "user_admin" },
+      ]);
+    });
+  });
+});
+
+describe("given a grant revoked through the grants service", () => {
+  describe("when a directory sync revokes it", () => {
+    /** The revocation fact has no `source` field and needs none: the ACTOR
+     *  already names the surface, and `reason` carries the rest. This is
+     *  what makes D08's de-enroll attributable without touching the durable
+     *  `grant_revoked` event.
+     *  @scenario "A revocation names the surface that made it without a source of its own" */
+    it("carries the surface as the emitted revocation's actor", async () => {
+      const { grants, db, sent } = service();
+      db.roleBinding.findUnique.mockResolvedValue({
+        id: BINDING_ID,
+        organizationId: ORG_ID,
+      });
+      db.roleBinding.findFirst.mockResolvedValue({ id: BINDING_ID });
+
+      await grants.revoke({
+        actor: { type: "system", name: "scim" },
+        bindingId: BINDING_ID,
+        organizationId: ORG_ID,
+      });
+
+      expect(revokedActors(sent)).toEqual([
+        { type: "system", id: SYSTEM_ACTORS.scim },
+      ]);
     });
   });
 });

--- a/platform/app/src/server/app-layer/authz/__tests__/ledger-write-fork.harness.ts
+++ b/platform/app/src/server/app-layer/authz/__tests__/ledger-write-fork.harness.ts
@@ -59,6 +59,9 @@ export function harness({
   const db = {
     roleBinding: {
       findFirst: vi.fn().mockResolvedValue(null),
+      // The tenancy pre-read `GrantsService` does before a revoke, when a
+      // test drives the writer through the service rather than directly.
+      findUnique: vi.fn().mockResolvedValue(null),
       findMany: vi.fn().mockResolvedValue([]),
       count: vi.fn().mockResolvedValue(0),
       create: vi.fn().mockResolvedValue(undefined),

--- a/platform/app/src/server/app-layer/authz/ledger.ts
+++ b/platform/app/src/server/app-layer/authz/ledger.ts
@@ -46,6 +46,7 @@ import {
   BindingMissingError,
   type BindingPrincipalWhere,
   DuplicateBindingError,
+  type GrantEventSource,
   type LedgerScopeType,
   type RoleBindingWrite,
 } from "@langwatch/authz-server";
@@ -71,6 +72,7 @@ import {
   AUTHZ_GRANT_PIPELINE_NAME,
   type AuthzAuditVerb,
 } from "~/server/event-sourcing/pipelines/authz-grants/schemas/constants";
+import { NON_AUDITABLE_SOURCES } from "~/server/event-sourcing/pipelines/authz-grants/subscribers/authzAuditTrail.subscriber";
 import { prisma as appPrisma } from "../../db";
 import { RoleDuplicateNameError } from "../../role/errors/role-duplicate-name.error";
 import { tryGetApp } from "../app";
@@ -80,19 +82,6 @@ import { PrismaAuthzRevocationRepository } from "./repositories/authz-revocation
 import { liveGrants } from "./repositories/live-rows";
 
 const logger = createLogger("langwatch:authz:ledger");
-
-/**
- * Which writer authored a runtime fact — the event's `source` field.
- *
- * `read-through-mint` is the compatibility path (decision 1: no legacy-key
- * sunset): a credential whose access predates the ledger states it the first
- * time it is used, rather than being asked to be re-issued.
- */
-export type LedgerWriteSource =
-  | "grants-service"
-  | "scim"
-  | "invite"
-  | "read-through-mint";
 
 type Sender<T> = { send: (data: T) => Promise<unknown> };
 
@@ -392,7 +381,15 @@ export class GrantsLedgerWriter {
     organizationId: string;
     bindings: LedgerBindingAttach[];
     actor: LedgerActor;
-    source?: LedgerWriteSource;
+    /**
+     * Which surface authored the fact — the provenance the actor cannot
+     * state. `read-through-mint` is the compatibility path (decision 1: no
+     * legacy-key sunset): a credential whose access predates the ledger
+     * states it the first time it is used, rather than being asked to be
+     * re-issued. Defaults to the grants service, which is what a hand-made
+     * grant is.
+     */
+    source?: GrantEventSource;
     onDuplicate: "reject" | "skip";
     /**
      * A caller-derived command id, for writes that are not a user action and
@@ -594,7 +591,7 @@ export class GrantsLedgerWriter {
     fresh: LedgerBindingAttach[];
     duplicates: string[];
     actor: LedgerActor;
-    source: LedgerWriteSource;
+    source: GrantEventSource;
     onDuplicate: "reject" | "skip";
     occurredAtMs: number;
   }): Promise<AttachOutcome> {
@@ -1593,7 +1590,7 @@ function attachAuditFacts({
   source,
 }: {
   fresh: LedgerBindingAttach[];
-  source: LedgerWriteSource;
+  source: GrantEventSource;
 }): Record<string, unknown>[] {
   if (!auditableSource(source)) return [];
   return fresh.map((binding) => ({
@@ -1642,13 +1639,15 @@ export function isRecordNotFound(error: unknown): boolean {
 
 /**
  * The subscriber's relevance guard, on the pre-ledger side (decision 17).
- * `genesis-import` and `backfill-b` never reach this writer at all, and the
- * read-through mint is gated off for an unmigrated organization, so in
- * practice nothing is filtered here — the rule is stated anyway so the two
- * audit paths cannot drift into disagreeing about what earns a row.
+ * The migration never reaches this writer at all, and the read-through mint
+ * is gated off for an unmigrated organization, so in practice nothing is
+ * filtered here — the rule is stated anyway so the two audit paths cannot
+ * drift into disagreeing about what earns a row. It reads the subscriber's
+ * OWN list rather than restating it, which is what makes that guarantee
+ * mechanical instead of a promise in a comment.
  */
-function auditableSource(source: LedgerWriteSource): boolean {
-  return source !== "read-through-mint";
+function auditableSource(source: GrantEventSource): boolean {
+  return !NON_AUDITABLE_SOURCES.includes(source);
 }
 
 function roleKeyFor({

--- a/platform/app/src/server/app-layer/authz/repositories/authz-grants.ledger.repository.ts
+++ b/platform/app/src/server/app-layer/authz/repositories/authz-grants.ledger.repository.ts
@@ -21,6 +21,7 @@ import type {
   AuthzGrantsRepository,
   AuthzReadRepository,
   BindingPrincipalWhere,
+  GrantEventSource,
   OffboardCounts,
   RoleBindingWrite,
 } from "@langwatch/authz-server";
@@ -139,9 +140,11 @@ export class LedgerAuthzGrantsRepository implements AuthzGrantsRepository {
   async createBinding({
     row,
     actor,
+    source,
   }: {
     row: RoleBindingWrite;
     actor: LedgerActor;
+    source?: GrantEventSource;
   }): Promise<void> {
     const { organizationId, ...binding } = row;
     await withPortFailures(() =>
@@ -149,6 +152,9 @@ export class LedgerAuthzGrantsRepository implements AuthzGrantsRepository {
         organizationId,
         bindings: [binding],
         actor,
+        // Omitted rather than defaulted here: the writer owns the default,
+        // and stating it twice is how the two drift apart.
+        ...(source ? { source } : {}),
         onDuplicate: "reject",
       }),
     );

--- a/platform/app/src/server/event-sourcing/pipelines/authz-grants/__tests__/wireInvariants.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/authz-grants/__tests__/wireInvariants.unit.test.ts
@@ -1,3 +1,4 @@
+import { GRANT_EVENT_SOURCES } from "@langwatch/authz-server";
 import { describe, expect, it } from "vitest";
 import {
   attachGrantCommandDataSchema,
@@ -256,6 +257,25 @@ describe("the grants ledger's wire boundary", () => {
           },
         }).success,
       ).toBe(false);
+    });
+  });
+
+  describe("when the grant names where it came from", () => {
+    /** The wire derives its enum from `GRANT_EVENT_SOURCES` rather than
+     *  restating it, so adding a source to the vocabulary is the whole
+     *  change. Driving the vocabulary itself is what pins that: a restated
+     *  union would pass for the sources it copied and fail for the new one.
+     *  @scenario "The wire accepts every source the vocabulary names" */
+    it("accepts every source the vocabulary names", () => {
+      for (const source of GRANT_EVENT_SOURCES) {
+        expect(parse({}, { source }).success).toBe(true);
+      }
+    });
+
+    it("refuses a source the vocabulary does not name", () => {
+      expect(parse({}, { source: "a-surface-nobody-declared" }).success).toBe(
+        false,
+      );
     });
   });
 });

--- a/platform/app/src/server/event-sourcing/pipelines/authz-grants/subscribers/__tests__/authzAuditTrail.subscriber.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/authz-grants/subscribers/__tests__/authzAuditTrail.subscriber.unit.test.ts
@@ -1,3 +1,4 @@
+import { GRANT_EVENT_SOURCES } from "@langwatch/authz-server";
 import { describe, expect, it } from "vitest";
 import { createTenantId } from "../../../..";
 import {
@@ -20,6 +21,7 @@ import {
   type AuthzAuditRow,
   type AuthzAuditTrailStore,
   createAuthzAuditTrailSubscriber,
+  NON_AUDITABLE_SOURCES,
 } from "../authzAuditTrail.subscriber";
 
 const ORG = "org_acme";
@@ -163,12 +165,21 @@ describe("authz audit trail subscriber", () => {
       expect(store.inserts).toHaveLength(0);
     });
 
-    /** @scenario "Facts stated by the platform itself never reach the audit trail" */
-    it("still writes a row for a live source", async () => {
+    /** Driven from the vocabulary rather than from a list of the sources
+     *  that exist today: a source added to `GRANT_EVENT_SOURCES` and left
+     *  out of the skip list is a change a customer made, and it audits by
+     *  default. A new one that ought to be skipped has to say so.
+     *  @scenario "A grant an automated surface made still reaches the audit trail" */
+    it.each(
+      GRANT_EVENT_SOURCES.filter(
+        (source) => !NON_AUDITABLE_SOURCES.includes(source),
+      ),
+    )("still writes a row for %s", async (source) => {
       const store = recordingStore();
-      await deliver(store, attached({ source: "invite" }));
+      await deliver(store, attached({ source }));
 
       expect(store.inserts).toHaveLength(1);
+      expect(store.inserts[0]!.metadata).toMatchObject({ source });
     });
   });
 

--- a/platform/app/src/server/event-sourcing/pipelines/authz-grants/subscribers/__tests__/authzAuditTrail.subscriber.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/authz-grants/subscribers/__tests__/authzAuditTrail.subscriber.unit.test.ts
@@ -1,3 +1,4 @@
+import { SYSTEM_ACTORS } from "@langwatch/actor";
 import { GRANT_EVENT_SOURCES } from "@langwatch/authz-server";
 import { describe, expect, it } from "vitest";
 import { createTenantId } from "../../../..";
@@ -239,6 +240,33 @@ describe("authz audit trail subscriber", () => {
       await deliver(store, event(type, { actor: USER_ACTOR }));
 
       expect(store.inserts[0]!.action).toBe(action);
+    });
+  });
+
+  describe("when a surface rather than a person revokes a grant", () => {
+    /** `grant_revoked` carries no `source`, so what makes a revocation
+     *  attributable is its actor plus its reason. Only the migration runner
+     *  is filtered by actor — a directory sync's de-enroll is a change the
+     *  customer's own directory made, and it belongs on their audit page.
+     *  @scenario "A revocation names the surface that made it without a source of its own" */
+    it("records the row, with the reason and no invented person", async () => {
+      const store = recordingStore();
+      await deliver(
+        store,
+        event(GRANT_REVOKED_EVENT_TYPE, {
+          grantId: "grant_1",
+          reason: "offboarded:user_dave",
+          actor: { type: "system", id: SYSTEM_ACTORS.scim },
+        }),
+      );
+
+      expect(store.inserts).toHaveLength(1);
+      expect(store.inserts[0]!.action).toBe("authz.grants.revoke");
+      expect(store.inserts[0]!.userId).toBeNull();
+      expect(store.inserts[0]!.metadata).toEqual({
+        grantId: "grant_1",
+        reason: "offboarded:user_dave",
+      });
     });
   });
 

--- a/platform/app/src/server/event-sourcing/pipelines/authz-grants/subscribers/authzAuditTrail.subscriber.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/authz-grants/subscribers/authzAuditTrail.subscriber.ts
@@ -57,8 +57,14 @@ const logger = createLogger("langwatch:authz:audit-trail");
 /** Every fact these sources author is backdated history that already
  *  happened somewhere else — the legacy tables, an earlier backfill, or a
  *  key the resolver minted on read. Auditing them would fill the customer's
- *  audit page with thousands of rows for changes nobody made. */
-const NON_AUDITABLE_SOURCES: readonly GrantEventSource[] = [
+ *  audit page with thousands of rows for changes nobody made.
+ *
+ *  Exported because the pre-ledger writer applies the same rule to the
+ *  `AuditLog` rows it writes itself (`auditableSource` in
+ *  `app-layer/authz/ledger.ts`), and the two audit paths must not be able to
+ *  disagree about what earns a row. Every OTHER source states a change
+ *  somebody actually made and is audited. */
+export const NON_AUDITABLE_SOURCES: readonly GrantEventSource[] = [
   "migration",
   "read-through-mint",
 ];

--- a/specs/rbac/authz-grants.feature
+++ b/specs/rbac/authz-grants.feature
@@ -519,6 +519,31 @@ Feature: Authorization grants
     Then the actor names the code path that decided to act
     And the platform is never an anonymous actor
 
+  # ═══ Provenance ═══════════════════════════════════════════════════════
+  # WHERE a grant came from, which the actor cannot say: a directory sync
+  # and an approved request to join both act as the platform, and only the
+  # source separates them. The vocabulary is closed and shared, so a surface
+  # states which one it is rather than inventing a label.
+
+  @unit
+  Scenario: A grant states which surface authored it
+    Given a surface that grants access on a customer's behalf
+    When it states the grant
+    Then the fact carries that surface as its source
+
+  @unit
+  Scenario: A grant nobody attributed is the grants service's own
+    Given a grant made through the ordinary access surfaces
+    When no source is stated
+    Then the fact is attributed to the grants service
+
+  @unit
+  Scenario: The wire accepts every source the vocabulary names
+    Given a source is added to the shared vocabulary
+    When a grant arrives naming it
+    Then the wire accepts it with no second list to edit
+    And a source the vocabulary does not name is refused
+
   # ═══ Audit ════════════════════════════════════════════════════════════
 
   @integration
@@ -530,6 +555,13 @@ Feature: Authorization grants
   Scenario: Facts stated by the platform itself never reach the audit trail
     When the platform states grants on its own behalf
     Then no audit row is written for them
+
+  @unit
+  Scenario: A grant an automated surface made still reaches the audit trail
+    Given a surface grants access on a customer's behalf
+    When the grant is stated
+    Then an audit row records it and names the surface
+    And only backdated history is left out
 
   @unit
   Scenario: A write on the legacy path still records its audit row

--- a/specs/rbac/authz-grants.feature
+++ b/specs/rbac/authz-grants.feature
@@ -520,10 +520,12 @@ Feature: Authorization grants
     And the platform is never an anonymous actor
 
   # ═══ Provenance ═══════════════════════════════════════════════════════
-  # WHERE a grant came from, which the actor cannot say: a directory sync
-  # and an approved request to join both act as the platform, and only the
-  # source separates them. The vocabulary is closed and shared, so a surface
-  # states which one it is rather than inventing a label.
+  # Two facts, not one. The SOURCE is which surface authored the grant, which
+  # the actor cannot say: a directory sync and an approved request to join
+  # both act as the platform. The ACTOR is who caused it, and for those same
+  # two surfaces that is nobody — a system principal, named from the closed
+  # registry. Both vocabularies are shared, so a surface states which entry
+  # it is rather than inventing a label.
 
   @unit
   Scenario: A grant states which surface authored it
@@ -543,6 +545,24 @@ Feature: Authorization grants
     When a grant arrives naming it
     Then the wire accepts it with no second list to edit
     And a source the vocabulary does not name is refused
+
+  @unit
+  Scenario: A write with no person behind it names the surface that made it
+    Given a grant write with no person or credential behind it
+    When the surface states the write
+    Then the fact names the surface from the closed registry
+    And a write made by a person still names that person
+
+  # A revocation carries no source of its own, and does not need one: the
+  # actor already names the surface and the reason carries the rest, so
+  # attributing an automated removal needs no new field on the fact.
+
+  @unit
+  Scenario: A revocation names the surface that made it without a source of its own
+    Given a surface removes access it granted earlier
+    When the revocation is stated
+    Then the fact names the surface as its actor
+    And the audit trail records it rather than treating it as backdated history
 
   # ═══ Audit ════════════════════════════════════════════════════════════
 


### PR DESCRIPTION
A grant records **who** attached it and, now, **which surface** authored it. Both are needed by work that follows — the SCIM reconciler and join requests each attach membership on somebody's behalf rather than their own — and neither was expressible before.

## What was actually broken

Two separate gaps, one of which was not where it looked:

1. **`source` never reached the fact.** `GRANT_EVENT_SOURCES` already listed `scim` and `invite`, but nothing routed through `GrantsService` could set them. The break was not the two hardcoded `source: "grants-service"` sites in `ledger.ts` — those are share-link attachment and stranded-role-change adoption, on different paths — it was `LedgerAuthzGrantsRepository.createBinding`, which simply never passed one. A **second copy of the vocabulary** in `ledger.ts` (`LedgerWriteSource`, four members) would have blocked any new value regardless; it is deleted, and the vocabulary is single-source again.

2. **The actor could only ever be a person.** `GrantsService`'s actor parameter was `{ userId: string }` and its serializer stamped `{ type: "user", … }` unconditionally. A directory-driven write had no way to say a directory made it.

## What changed

- `attach()` takes an optional `source`, defaulting to `"grants-service"`. Every existing call site is untouched.
- `GrantActor = { userId: string } | Actor` — the `@langwatch/actor` vocabulary admitted **alongside** the raw-id shape rather than replacing it, so nothing existing had to change. `writeActor` routes both halves through `toLedgerActor`.
- `"join-request"` added to `GRANT_EVENT_SOURCES`; `joinRequests` added to the `SYSTEM_ACTORS` registry. The registry stays closed — no call site builds a `system:…` string.

## Revocation needed nothing

With a system actor available, `offboard` and `revoke` name the surface through `actor`, and `reason` carries the rest — both already fields on the durable `grant_revoked` event. **No change to the event schema, the command schema, or the audit metadata allow-list.** A `system:scim` revocation is not filtered by the audit subscriber, so it reaches the customer's audit page, which is right for a directory-driven removal.

One honest limit, pinned by a test rather than left to be discovered: the audit *row* for such a revocation carries the reason but not the surface, because `source` is not a `grant_revoked` field and a system actor collapses to a null user id. The surface is fully on the durable event. Rendering it on the audit page is a deliberate one-line addition when a consumer wants it.

## Verification

- `@langwatch/authz-server` — 8 files, 102 tests pass.
- `@langwatch/actor` — 4 tests pass.
- `pnpm test:unit run src/server/app-layer/authz/ src/server/event-sourcing/pipelines/authz-grants/` — 31 files, 367 tests pass.
- `specs/rbac/authz-grants.feature` — 44/44 bound.
- biome and ast-grep clean on touched paths.

End-to-end coverage drives the real chain (`GrantsService` → `LedgerAuthzGrantsRepository` → `GrantsLedgerWriter`) and asserts on the command the writer actually emits, for both `attachGrant` and `revokeGrant`.

Not run here: integration tests (no container runtime available), including `ledger-instant-revoke.integration.test.ts`, which touches this area. No whole-tree typecheck was run; a scoped check covered every touched file and its transitive imports.

## Deployment Impact

None. Additive to two workspace packages and their app-side callers; no schema change (`Grant.source` is already a plain string column — its stale comment listing the pre-ADR-110 vocabulary is corrected here), no migration, no configuration, no infrastructure.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added provenance tracking for grant changes, including join requests and automated actions.
  * Grant operations now support registered system actors and preserve actor attribution.
  * Added a system actor for automatic join-request approvals.
  * Automated, live grant changes now appear in audit records, while backdated history remains excluded.

* **Improvements**
  * Standardized grant event sources and default attribution across grant operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->