### PR TITLE
fix(event-sourcing): let a queue drain accept the work it produces

### DIFF
--- a/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.drainSendGate.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.drainSendGate.unit.test.ts
@@ -1,0 +1,195 @@
+/**
+ * The producer gate must close when the DRAIN ends, not when shutdown is
+ * requested.
+ *
+ * Prod, 2026-08-24: every worker rollout shed a burst of "Failed to dispatch
+ * event to subscriber queue" carrying "Cannot send to queue after shutdown has
+ * been requested" — 1,185 across two deploys in one morning, none outside a
+ * rollout. There is one global group queue and the projection, subscriber, map
+ * and fold queues are facades over it, so close() barred sends on the very
+ * queue it was draining and jobs still in flight had their projection
+ * dispatches rejected. Nothing above retried: the router collects the failure,
+ * the event-sourcing service catches the AggregateError and carries on, so the
+ * job succeeded while its projections never saw the events.
+ *
+ * These tests drive close() while holding the drain open, which is the only
+ * window the defect lives in.
+ *
+ * @see specs/background/queue-drain-send-gate.feature
+ */
+
+import { Redis as IORedis } from "ioredis";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { EventSourcedQueueDefinition } from "../../queue.types";
+import { GroupQueueProcessor } from "../groupQueue";
+
+/** Released by hand so the drain can be held open mid-close. */
+let releaseDrain: (() => void) | undefined;
+const requestShutdown = vi.fn();
+
+vi.mock("../dispatcher", () => ({
+  GroupQueueDispatcher: class {
+    start(): void {}
+    requestShutdown(): void {
+      requestShutdown();
+    }
+    async waitUntilStopped(): Promise<void> {
+      await new Promise<void>((resolve) => {
+        releaseDrain = resolve;
+      });
+    }
+  },
+}));
+
+vi.mock("../metricsCollector", () => ({
+  GroupQueueMetricsCollector: class {
+    start(): void {}
+    stop(): void {}
+  },
+}));
+
+type TestPayload = { id: string; groupId: string };
+
+/** Thrown by groupKey, which send() reaches only after passing the gate. */
+class PastTheGate extends Error {
+  constructor() {
+    super("past the gate");
+  }
+}
+
+function makeDefinition(): EventSourcedQueueDefinition<TestPayload> {
+  return {
+    name: `{test/gq/gate/${crypto.randomUUID().slice(0, 8)}}`,
+    process: async () => {},
+    // Staging needs Redis, which a unit test has no business reaching. The
+    // first thing send() does after the gate is resolve the group key, so
+    // throwing here proves the gate let the call through without this test
+    // having to stage anything.
+    groupKey: () => {
+      throw new PastTheGate();
+    },
+  };
+}
+
+/**
+ * Waits until the drain is genuinely open.
+ *
+ * NOT `requestShutdown` — close() calls that before it starts draining, so a
+ * test keying off it races ahead of the window it means to observe and the
+ * drain then runs to its full budget.
+ */
+async function drainIsOpen(): Promise<void> {
+  await vi.waitUntil(() => releaseDrain !== undefined);
+}
+
+describe("GroupQueueProcessor staging gate during shutdown", () => {
+  const connections: IORedis[] = [];
+
+  function makeProcessor(): GroupQueueProcessor<TestPayload> {
+    const conn = new IORedis({ lazyConnect: true, maxRetriesPerRequest: 0 });
+    connections.push(conn);
+    vi.spyOn(conn, "lpush").mockResolvedValue(1 as never);
+    vi.spyOn(conn, "duplicate").mockReturnValue({
+      quit: vi.fn().mockResolvedValue("OK"),
+    } as never);
+
+    const processor = new GroupQueueProcessor<TestPayload>(
+      makeDefinition(),
+      conn,
+      { consumerEnabled: true },
+    );
+    vi.spyOn(
+      (processor as unknown as { scripts: { retireWorker: () => unknown } })
+        .scripts,
+      "retireWorker",
+    ).mockResolvedValue(undefined as never);
+    return processor;
+  }
+
+  afterEach(() => {
+    releaseDrain?.();
+    releaseDrain = undefined;
+    requestShutdown.mockClear();
+    for (const conn of connections.splice(0)) conn.disconnect();
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  describe("given a queue that has begun draining", () => {
+    /** @scenario Work produced by an in-flight job during the drain is still staged */
+    it("lets an in-flight job stage downstream work", async () => {
+      const processor = makeProcessor();
+      const closing = processor.close();
+      await drainIsOpen();
+
+      await expect(processor.send({ id: "a", groupId: "g" })).rejects.toThrow(
+        PastTheGate,
+      );
+
+      releaseDrain?.();
+      await closing;
+    });
+
+    /** @scenario Batched work produced during the drain is also staged */
+    it("lets an in-flight job stage a batch of downstream work", async () => {
+      const processor = makeProcessor();
+      const closing = processor.close();
+      await drainIsOpen();
+
+      await expect(
+        processor.sendBatch([{ id: "a", groupId: "g" }]),
+      ).rejects.toThrow(PastTheGate);
+
+      releaseDrain?.();
+      await closing;
+    });
+
+    /** @scenario The dispatcher stops claiming new jobs as soon as shutdown starts */
+    it("stops the dispatcher claiming further jobs", async () => {
+      const processor = makeProcessor();
+      const closing = processor.close();
+      await drainIsOpen();
+
+      expect(requestShutdown).toHaveBeenCalledTimes(1);
+
+      releaseDrain?.();
+      await closing;
+    });
+  });
+
+  describe("given a queue whose drain has finished", () => {
+    /** @scenario Staging is refused once the drain is over */
+    it("refuses further work, naming shutdown as the reason", async () => {
+      const processor = makeProcessor();
+      const closing = processor.close();
+      await drainIsOpen();
+      releaseDrain?.();
+      await closing;
+
+      await expect(processor.send({ id: "a", groupId: "g" })).rejects.toThrow(
+        /drain has finished/,
+      );
+      await expect(
+        processor.sendBatch([{ id: "a", groupId: "g" }]),
+      ).rejects.toThrow(/drain has finished/);
+    });
+  });
+
+  describe("given a queue whose drain overran its budget", () => {
+    /** @scenario A drain that overran its budget still closes the gate */
+    it("refuses further work even though the drain never finished", async () => {
+      vi.useFakeTimers();
+      const processor = makeProcessor();
+      // Never released, so close() loses its race against the shutdown budget.
+      const closing = processor.close();
+      const settled = expect(closing).rejects.toThrow(/timed out/);
+
+      await vi.advanceTimersByTimeAsync(60_000);
+      await settled;
+
+      await expect(processor.send({ id: "a", groupId: "g" })).rejects.toThrow(
+        /drain has finished/,
+      );
+    });
+  });
+});

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
@@ -360,6 +360,27 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
   private readonly deathThreshold = readConfirmedDeathThreshold();
 
   private shutdownRequested = false;
+  /**
+   * Whether `send`/`sendBatch` may still stage work.
+   *
+   * NOT the same thing as `shutdownRequested`, and the difference is the whole
+   * point. Shutdown is requested at the START of close(), while the drain that
+   * follows is still running jobs — and those jobs store events and dispatch
+   * them onward, into this same queue, because the projection, subscriber, map
+   * and fold queues are all facades over it. Gating sends on
+   * `shutdownRequested` meant the queue refused the work its own drain was
+   * producing, and nothing above retried it: every rollout quietly dropped a
+   * burst of projection dispatches (prod, 2026-08-24).
+   *
+   * Accepting them is safe. `send` stages into Redis over `redisConnection`,
+   * which the drain leaves alone — only the blocking connection is closed here,
+   * and the shared connections go afterwards, in App.close. Staged work is
+   * durable and shared, so anything staged during a drain is picked up by
+   * another pod rather than lost with this one.
+   *
+   * So the gate closes when the drain is over, however it ended.
+   */
+  private stagingClosed = false;
   /** Tracks in-flight jobs for active count metrics. */
   private activeJobCount = 0;
 
@@ -618,11 +639,11 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
     payload: Payload,
     options?: QueueSendOptions<Payload>,
   ): Promise<void> {
-    if (this.shutdownRequested) {
+    if (this.stagingClosed) {
       throw new QueueError(
         this.queueName,
         "send",
-        "Cannot send to queue after shutdown has been requested",
+        "Cannot send to queue after its drain has finished",
       );
     }
     assertNoReservedKeys(
@@ -734,11 +755,11 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
     payloads: Payload[],
     options?: QueueSendOptions<Payload>,
   ): Promise<void> {
-    if (this.shutdownRequested) {
+    if (this.stagingClosed) {
       throw new QueueError(
         this.queueName,
         "sendBatch",
-        "Cannot send to queue after shutdown has been requested",
+        "Cannot send to queue after its drain has finished",
       );
     }
 
@@ -2816,6 +2837,12 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
       throw error;
     } finally {
       clearTimeout(shutdownTimer);
+      // Here, not at the top of close(): until this point the drain was still
+      // running jobs whose fan-out has to be allowed to stage. Past it the
+      // shared transports are about to go, so staging more is pointless. The
+      // timeout path lands here too — a drain that overran was abandoned, not
+      // finished, and either way nothing further should be staged.
+      this.stagingClosed = true;
     }
   }
 

--- a/specs/background/queue-drain-send-gate.feature
+++ b/specs/background/queue-drain-send-gate.feature
@@ -1,0 +1,70 @@
+Feature: A queue drain accepts the work it is producing
+
+  When a worker pod receives SIGTERM the group queue stops claiming new jobs
+  and drains the ones it holds. Those jobs are not inert while they finish:
+  they store events and dispatch them onward. The queue must accept that
+  fan-out, because it is the work the drain exists to complete.
+
+  # Why this exists — 2026-08-24 prod
+  #
+  # Every worker rollout shed a burst of "Failed to dispatch event to
+  # subscriber queue", all carrying the same cause:
+  #
+  #   Cannot send to queue after shutdown has been requested
+  #
+  # 1,185 of them across two deploys in one morning, ~200 more on the next,
+  # and none outside a rollout window.
+  #
+  # There is ONE global group queue. The projection, subscriber, map and fold
+  # "queues" are facades over it, so close() set shutdownRequested on the very
+  # queue it was about to drain, and send() refused from that instant. A job
+  # still in flight stored its events, dispatched them onward, and the queue
+  # rejected the work its own drain was producing.
+  #
+  # Nothing above retried it. The projection router collects the failure, the
+  # event-sourcing service catches the AggregateError and carries on, so the
+  # job SUCCEEDS while its projections never see those events. The events are
+  # durable in the event store; the projections built from them quietly skip a
+  # rollout's worth, and nothing reports a gap.
+  #
+  # Refusing was never protecting anything. send() stages into Redis over
+  # redisConnection, and the drain does not close it — only the blocking
+  # connection goes, and the shared connections are closed afterwards by
+  # App.close, once the drain has finished. Staged work is durable and shared,
+  # so a job staged during a drain is picked up by another pod. Throwing turned
+  # work that would have survived into work that was lost.
+  #
+  # The gate belongs at the END of the drain, not the start of it.
+
+  @unit @drain-send-gate
+  Scenario: Work produced by an in-flight job during the drain is still staged
+    Given a queue that has begun draining
+    When a job still in flight stages downstream work
+    Then the work is staged rather than refused
+    So that a drain cannot destroy the work it exists to finish
+
+  @unit @drain-send-gate
+  Scenario: Batched work produced during the drain is also staged
+    Given a queue that has begun draining
+    When a job still in flight stages a batch of downstream work
+    Then the batch is staged rather than refused
+
+  @unit @drain-send-gate
+  Scenario: Staging is refused once the drain is over
+    Given a queue whose drain has finished
+    When anything tries to stage more work
+    Then it is refused, naming shutdown as the reason
+    So that nothing stages into transports that are about to go
+
+  @unit @drain-send-gate
+  Scenario: A drain that overran its budget still closes the gate
+    Given a queue whose drain overran its budget and was abandoned
+    When anything tries to stage more work
+    Then it is refused
+    So that the gate does not depend on the drain ending well
+
+  @unit @drain-send-gate
+  Scenario: The dispatcher stops claiming new jobs as soon as shutdown starts
+    Given a queue that has begun draining
+    Then it claims no further jobs
+    So that accepting the fan-out finishes in-flight work without starting more


### PR DESCRIPTION
Every worker rollout silently drops a burst of projection dispatches. This fixes the cause.

## What happens today

Each deploy sheds errors that look like shutdown noise and are not:

```
Failed to dispatch event to subscriber queue
  error_cause: "Cannot send to queue after shutdown has been requested"
  projection: spanStorage   subscriber: spanStorageBroadcast
```

**1,185 of them across two deploys on the morning of 24 August**, ~200 more on the next, and **none outside a rollout window** — attributable to `git-067c49a` (998) and `git-a12f6fe` (187).

## Why

There is **one** global group queue. The projection, subscriber, map and fold "queues" are facades over it. `close()` sets `shutdownRequested` at the top, and `send()` refuses from that instant — so for the whole length of the drain, the queue rejects the work its own drain is producing. A job still in flight stores its events, dispatches them onward, and is turned away by the queue that is draining it.

**Nothing above retries it.** `projectionRouter` collects the failure into an `AggregateError`; `eventSourcingService` catches it and carries on:

```ts
try {
  await this.router.dispatch(leanedEvents, context);
} catch (error) {
  // ...logged, never rethrown
  this.logger.error({ ... }, "Failed to dispatch events to projections");
}
```

So the job **succeeds** while its projections never see those events. The events themselves are durable in the event store — it is the projections built from them that quietly skip a rollout's worth, and nothing reports the gap.

This is the same family as the two ordering defects already recorded in the shutdown spec (2026-08-10 concurrent close, 2026-08-17 registry-before-queue), one layer further out: this time the queue outlives the drain but bars its own producers.

## Why refusing never protected anything

`send()` stages into Redis over `redisConnection`, and the drain **leaves that connection open** — `drainAndDisconnect` closes only the *blocking* connection:

```ts
if (this.blockingConnection !== this.redisConnection) {
  await this.blockingConnection.quit();
}
```

The shared connections go afterwards, in `App.close`, once the drain has finished — that ordering is already deliberate and tested. And staged work is durable and shared, so anything staged during a drain is picked up by another pod. Throwing turned work that would have survived into work that was lost.

## The change

The gate moves from the *start of shutdown* to the *end of the drain*. A new `stagingClosed` flag is set in `close()`'s `finally`, which the timeout path reaches too — a drain that overran was abandoned, not finished, and either way nothing further should be staged.

`shutdownRequested` keeps its other job: stopping the liveness beacon re-arming after the tombstone is written.

**Accepting the fan-out cannot prolong the drain.** The dispatcher has already been told to stop claiming, and staging writes to Redis rather than adding to the `processingQueue` that the drain waits on.

## Tests

`specs/background/queue-drain-send-gate.feature`, **5/5 scenarios bound** (verified with `check-feature-parity.ts` — not the vacuous kind).

The tests hold the drain open by controlling the dispatcher's `waitUntilStopped`, which is the only window the defect lives in. Getting that wrong is easy: keying off `requestShutdown` races ahead of the window, because `close()` calls it *before* it starts draining — the helper is commented so the next person does not repeat it.

Mutation-checked: reverting the flag alone (leaving everything else, including the message) makes exactly the two tests that encode the bug fail.

```
✓ lets an in-flight job stage downstream work
✓ lets an in-flight job stage a batch of downstream work
✓ stops the dispatcher claiming further jobs
✓ refuses further work, naming shutdown as the reason
✓ refuses further work even though the drain never finished
```

No regressions: 242 group-queue unit tests and 8,303 event-sourcing unit tests pass.

## Related, not in this PR

`Failed to close EventSourcing — Shutdown timed out after 25000ms` appeared once on 24 August. That is the drain using its full budget rather than the gate, and one occurrence is not enough to tune a budget on. Worth watching once this lands, since some of that time was being spent on dispatches that were doomed to be refused.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Queue shutdown now allows in-flight work to finish staging downstream tasks during the drain period.
  - New work is blocked only after draining completes or the shutdown time limit is exceeded.
  - The queue stops accepting new jobs as soon as shutdown begins, preventing lost downstream work.

- **Tests**
  - Added coverage for single-item and batched task staging during shutdown, drain completion, and timeout scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->