### PR TITLE
fix(governance): the edit drawer reads the cadence the scheduler runs on

### DIFF
--- a/platform/app/ee/governance/dashboard/pages/__tests__/editPullSourceConfig.lifecycle.unit.test.ts
+++ b/platform/app/ee/governance/dashboard/pages/__tests__/editPullSourceConfig.lifecycle.unit.test.ts
@@ -14,7 +14,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { syncIngestionPullSource } from "../../../services/pullers/ingestionPullLifecycle";
 import { recommendedPullSchedule } from "../../logic/pullCadence";
-import { buildEditSubmission } from "../inventory";
+import { buildEditSubmission, seedPullSchedule } from "../inventory";
 
 // `resolvePullConfig` toasts the offending field when a pull config will not
 // build. That is the behaviour under test's own reporting channel, not a
@@ -110,6 +110,110 @@ describe("a saved edit reaching the pull lifecycle", () => {
     expect(commands.disable).not.toHaveBeenCalled();
     expect(commands.configure).toHaveBeenCalledWith(
       expect.objectContaining({ cron: "0 */2 * * *" }),
+    );
+  });
+});
+
+/**
+ * The drifted row, from the drawer opening to the process manager.
+ *
+ * `pullSchedule` and `parserConfig.schedule` are two copies of one value, and
+ * the column is the only one the lifecycle reads. The drawer used to seed from
+ * the copy, so an admin who opened a drifted source and changed nothing but
+ * the name handed the save path the stale value — and the save path writes
+ * that field straight back to the column. The damage was never visible in
+ * either half on its own: the drawer emitted a schedule it had honestly been
+ * given, and the lifecycle honestly ran it.
+ */
+describe("an unrelated edit on a row whose two schedules disagree", () => {
+  const STORED = {
+    adapter: "anthropic_admin",
+    report: "usage",
+    bucketWidth: "1h",
+    // The copy, left behind by whatever last wrote the column without it.
+    schedule: "0 * * * *",
+  };
+  /** What the source is really running on. */
+  const RUNNING = "0 */6 * * *";
+
+  /** The row as it comes back for the lifecycle to re-address the process. */
+  function rowFrom(submission: { pullSchedule?: string | null }) {
+    return {
+      id: "src_1",
+      organizationId: "org_1",
+      status: "active",
+      archivedAt: null,
+      updatedAt: new Date("2026-01-01T00:00:00Z"),
+      pollerCursor: null,
+      pullSchedule: submission.pullSchedule ?? null,
+    } as unknown as Parameters<typeof syncIngestionPullSource>[0]["source"];
+  }
+
+  async function renameAndSync(seededCadence: string) {
+    const submission = buildEditSubmission({
+      organizationId: "org_1",
+      source: {
+        id: "src_1",
+        sourceType: "anthropic_admin",
+        parserConfig: STORED,
+      },
+      name: "Anthropic org spend (renamed)",
+      description: "",
+      parserConfig: {
+        credentialsToken: "",
+        report: "usage",
+        bucketWidth: "1h",
+      },
+      ottlStatements: [],
+      pullSchedule: seededCadence,
+    });
+    const commands = { configure: vi.fn(), disable: vi.fn() };
+
+    await syncIngestionPullSource({
+      prisma: {} as never,
+      source: rowFrom(submission ?? {}),
+      commands,
+    });
+
+    return { submission, commands };
+  }
+
+  it("leaves the source running on the cadence it was already running on", async () => {
+    const { submission, commands } = await renameAndSync(
+      seedPullSchedule({ pullSchedule: RUNNING, storedParserConfig: STORED }),
+    );
+
+    // The outcome that matters: the process manager is re-addressed to the
+    // same cron it already had. A rename does not change how often we poll.
+    expect(commands.configure).toHaveBeenCalledWith(
+      expect.objectContaining({ sourceId: "src_1", cron: RUNNING }),
+    );
+    expect(submission?.pullSchedule).toBe(RUNNING);
+  });
+
+  it("converges the parser config's stale copy onto the column", async () => {
+    // The save writes both from one value, so the row stops being divergent.
+    // Nothing repairs these rows in bulk; editing one is what fixes it.
+    const { submission } = await renameAndSync(
+      seedPullSchedule({ pullSchedule: RUNNING, storedParserConfig: STORED }),
+    );
+
+    expect((submission?.parserConfig as Record<string, unknown>).schedule).toBe(
+      RUNNING,
+    );
+  });
+
+  it("would have rewritten the live cadence if seeded from the parser copy", async () => {
+    // Pins the damage rather than the fix. This is what shipped before: the
+    // seed came from `parserConfig.schedule`, and the rename silently moved
+    // the source from six-hourly to hourly.
+    const { commands } = await renameAndSync(STORED.schedule);
+
+    expect(commands.configure).toHaveBeenCalledWith(
+      expect.objectContaining({ cron: "0 * * * *" }),
+    );
+    expect(commands.configure).not.toHaveBeenCalledWith(
+      expect.objectContaining({ cron: RUNNING }),
     );
   });
 });

--- a/platform/app/ee/governance/dashboard/pages/__tests__/editPullSourceConfig.lifecycle.unit.test.ts
+++ b/platform/app/ee/governance/dashboard/pages/__tests__/editPullSourceConfig.lifecycle.unit.test.ts
@@ -217,3 +217,65 @@ describe("an unrelated edit on a row whose two schedules disagree", () => {
     );
   });
 });
+
+describe("renaming a source an admin has deliberately disabled", () => {
+  // `status: "disabled"` is the sanctioned off switch: it is a first-class
+  // value of the router's status enum, and the edit path never writes status,
+  // so a rename cannot reach it. This is the guarantee worth pinning — the
+  // review asked whether an edit can revive a stopped source, and for the
+  // way sources are actually stopped, the answer has to stay no.
+  const STORED = {
+    adapter: "anthropic_admin",
+    report: "usage",
+    bucketWidth: "1h",
+    schedule: "0 */6 * * *",
+  };
+
+  it("leaves it disabled, whatever cadence the form submits", async () => {
+    const submission = buildEditSubmission({
+      organizationId: "org_1",
+      source: {
+        id: "src_1",
+        sourceType: "anthropic_admin",
+        parserConfig: STORED,
+      },
+      name: "renamed while stopped",
+      description: "",
+      parserConfig: {
+        credentialsToken: "",
+        report: "usage",
+        bucketWidth: "1h",
+      },
+      ottlStatements: [],
+      pullSchedule: seedPullSchedule({
+        pullSchedule: "0 */6 * * *",
+        storedParserConfig: STORED,
+      }),
+    });
+
+    // The submission carries a perfectly good cron. The status is what stops
+    // it, and the submission has no opinion about the status.
+    expect(submission?.pullSchedule).toBe("0 */6 * * *");
+    expect(submission).not.toHaveProperty("status");
+
+    const commands = { configure: vi.fn(), disable: vi.fn() };
+    await syncIngestionPullSource({
+      prisma: {} as never,
+      source: {
+        id: "src_1",
+        organizationId: "org_1",
+        status: "disabled",
+        archivedAt: null,
+        updatedAt: new Date("2026-01-01T00:00:00Z"),
+        pollerCursor: null,
+        pullSchedule: submission?.pullSchedule ?? null,
+      } as unknown as Parameters<typeof syncIngestionPullSource>[0]["source"],
+      commands,
+    });
+
+    expect(commands.disable).toHaveBeenCalledWith(
+      expect.objectContaining({ sourceId: "src_1" }),
+    );
+    expect(commands.configure).not.toHaveBeenCalled();
+  });
+});

--- a/platform/app/ee/governance/dashboard/pages/__tests__/editPullSourceConfig.lifecycle.unit.test.ts
+++ b/platform/app/ee/governance/dashboard/pages/__tests__/editPullSourceConfig.lifecycle.unit.test.ts
@@ -166,6 +166,9 @@ describe("an unrelated edit on a row whose two schedules disagree", () => {
       },
       ottlStatements: [],
       pullSchedule: seededCadence,
+      // A pull source never offers the destination picker, so an edit of one
+      // leaves the field untouched.
+      destination: undefined,
     });
     const commands = { configure: vi.fn(), disable: vi.fn() };
 
@@ -251,6 +254,7 @@ describe("renaming a source an admin has deliberately disabled", () => {
         pullSchedule: "0 */6 * * *",
         storedParserConfig: STORED,
       }),
+      destination: undefined,
     });
 
     // The submission carries a perfectly good cron. The status is what stops

--- a/platform/app/ee/governance/dashboard/pages/__tests__/editPullSourceConfig.presentation.unit.test.ts
+++ b/platform/app/ee/governance/dashboard/pages/__tests__/editPullSourceConfig.presentation.unit.test.ts
@@ -20,6 +20,7 @@ import {
   lockedParserKeys,
   parserFieldPresentation,
   seedComposerParserConfig,
+  seedPullSchedule,
 } from "../inventory";
 import { composer } from "./editPullSourceConfig.fixture";
 
@@ -328,5 +329,62 @@ describe("seedComposerParserConfig", () => {
 
     expect(config).not.toHaveProperty("credentials");
     expect(anthropicAdminPullConfigSchema.parse(config).report).toBe("usage");
+  });
+});
+
+describe("seedPullSchedule", () => {
+  it("shows the column the scheduler runs on, not the parser config's copy", () => {
+    // The two can disagree: `parserConfig.schedule` is the adapter's own copy,
+    // written by the composer on create, while `pullSchedule` is the column
+    // the lifecycle actually reads. Any write that touches one and not the
+    // other — the update mutation takes `pullSchedule` on its own, and seeds
+    // and migrations bypass both — leaves a row where seeding from the parser
+    // config would show a cadence the source is not running on, and saving
+    // would then write that stale value over the live one.
+    expect(
+      seedPullSchedule({
+        pullSchedule: "0 */6 * * *",
+        storedParserConfig: { schedule: "0 * * * *" },
+      }),
+    ).toBe("0 */6 * * *");
+  });
+
+  it("falls back to the parser config for a row whose column is empty", () => {
+    // Not hypothetical: the column is nullable, and a null one reads as
+    // `disable` to the lifecycle. Showing the adapter's copy is the better
+    // answer than a blank box, which an admin reads as "no schedule set".
+    expect(
+      seedPullSchedule({
+        pullSchedule: null,
+        storedParserConfig: { schedule: "*/15 * * * *" },
+      }),
+    ).toBe("*/15 * * * *");
+  });
+
+  it("treats a whitespace-only column as absent", () => {
+    expect(
+      seedPullSchedule({
+        pullSchedule: "   ",
+        storedParserConfig: { schedule: "*/15 * * * *" },
+      }),
+    ).toBe("*/15 * * * *");
+  });
+
+  it("reports no schedule at all rather than inventing one", () => {
+    // Blank is the cadence field's way of saying "use the recommended
+    // schedule". Seeding a default here would make the field lie about what
+    // is stored, and `buildEditSubmission` already resolves blank on save.
+    expect(
+      seedPullSchedule({ pullSchedule: null, storedParserConfig: {} }),
+    ).toBe("");
+  });
+
+  it("ignores a non-string schedule in the parser config", () => {
+    expect(
+      seedPullSchedule({
+        pullSchedule: null,
+        storedParserConfig: { schedule: 42 },
+      }),
+    ).toBe("");
   });
 });

--- a/platform/app/ee/governance/dashboard/pages/inventory.tsx
+++ b/platform/app/ee/governance/dashboard/pages/inventory.tsx
@@ -1137,11 +1137,15 @@ function useSourceEditForm(source: Source | null) {
         storedParserConfig: parser,
       }),
     );
-    // The `pullSchedule` column is not on the DTO, but the adapter's own copy
-    // of it rides along inside parserConfig, written there by the composer on
-    // create. Seeding from it keeps the field showing the cadence that is
-    // actually running rather than an empty box that reads as "no schedule".
-    setPullSchedule(typeof parser.schedule === "string" ? parser.schedule : "");
+    // The column first, because it is the one the lifecycle runs on; the
+    // adapter's copy inside parserConfig is a duplicate nothing keeps in sync.
+    // See `seedPullSchedule`.
+    setPullSchedule(
+      seedPullSchedule({
+        pullSchedule: source.pullSchedule,
+        storedParserConfig: parser,
+      }),
+    );
   }, [source?.id]);
 
   return {
@@ -2682,6 +2686,37 @@ export function seedComposerParserConfig({
     values[field.key] = String(stored);
   }
   return values;
+}
+
+/**
+ * The cadence the edit form opens on: the `pullSchedule` column, which is what
+ * the lifecycle actually runs, falling back to the adapter's copy inside
+ * `parserConfig` only when the column has nothing to say.
+ *
+ * The two are duplicates that nothing keeps in sync. The composer writes both
+ * from one value on create, so they agree for a source that has only ever been
+ * touched through the UI — but `update` takes `pullSchedule` on its own, and
+ * seeds, migrations and direct writes bypass the parser copy entirely. Seeding
+ * from the parser copy therefore showed a cadence the source was not running
+ * on, and because the save path writes the field back to the column, opening
+ * such a row and saving any unrelated field overwrote the live schedule with
+ * the stale one.
+ *
+ * The fallback stays because the column is nullable and older rows may carry
+ * only the parser copy; a blank field reads as "no schedule set", which is a
+ * different claim from "we could not find it".
+ */
+export function seedPullSchedule({
+  pullSchedule,
+  storedParserConfig,
+}: {
+  pullSchedule: string | null;
+  storedParserConfig: Record<string, unknown>;
+}): string {
+  const fromColumn = (pullSchedule ?? "").trim();
+  if (fromColumn) return fromColumn;
+  const fromParser = storedParserConfig.schedule;
+  return typeof fromParser === "string" ? fromParser.trim() : "";
 }
 
 /**

--- a/platform/app/ee/governance/routers/__tests__/ingestionSourceDto.unit.test.ts
+++ b/platform/app/ee/governance/routers/__tests__/ingestionSourceDto.unit.test.ts
@@ -23,6 +23,7 @@ const row = (overrides: Record<string, unknown> = {}) =>
     name: "Genie fleet",
     description: null,
     parserConfig: {},
+    pullSchedule: "0 */6 * * *",
     status: "active",
     traceProjectId: null,
     lastEventAt: null,
@@ -82,6 +83,59 @@ describe("given an ingestion source with a trace destination", () => {
       expect(dto.parserConfig).toEqual({
         workspaceUrl: "https://example.databricks.net",
       });
+    });
+  });
+});
+
+describe("given a pull source whose cadence lives in two places", () => {
+  describe("when the column and the parser config's copy disagree", () => {
+    it("sends the column, because that is what the scheduler reads", () => {
+      // Without this the edit form cannot see the column at all, and falls
+      // back to the adapter's copy inside parserConfig — a duplicate nothing
+      // keeps in sync, which the form would then write back over the live
+      // value.
+      const dto = toIngestionSourceDto({
+        row: row({
+          sourceType: "anthropic_admin",
+          pullSchedule: "0 */6 * * *",
+          parserConfig: { adapter: "anthropic_admin", schedule: "0 * * * *" },
+        }),
+        liveTraceProjectIds: new Set<string>(),
+      });
+
+      expect(dto.pullSchedule).toBe("0 */6 * * *");
+    });
+  });
+
+  describe("when the source does not pull at all", () => {
+    it("passes the null through, because null is what stops it running", () => {
+      const dto = toIngestionSourceDto({
+        row: row({ sourceType: "otel_generic", pullSchedule: null }),
+        liveTraceProjectIds: new Set<string>(),
+      });
+
+      expect(dto.pullSchedule).toBeNull();
+    });
+  });
+
+  describe("when the parser config also carries the sealed credential", () => {
+    it("still strips it, cadence or no cadence", () => {
+      const dto = toIngestionSourceDto({
+        row: row({
+          sourceType: "anthropic_admin",
+          parserConfig: {
+            adapter: "anthropic_admin",
+            schedule: "0 * * * *",
+            credentials: "enc:v1:deadbeef:cafe:0123",
+            _rotation: { priorHash: "abc" },
+          },
+        }),
+        liveTraceProjectIds: new Set<string>(),
+      });
+
+      expect(dto.parserConfig).not.toHaveProperty("credentials");
+      expect(dto.parserConfig).not.toHaveProperty("_rotation");
+      expect(JSON.stringify(dto)).not.toContain("enc:v1:");
     });
   });
 });

--- a/platform/app/ee/governance/routers/ingestionSources.ts
+++ b/platform/app/ee/governance/routers/ingestionSources.ts
@@ -72,6 +72,11 @@ export function toIngestionSourceDto({
     // edit form would offer a backfill start that cannot take effect. Better a
     // compile error than a setting that quietly does nothing.
     pollerCursor: unknown;
+    // Required for the same reason as `pollerCursor` above: the edit form
+    // seeds its cadence field from this column, and a `select` clause that
+    // stopped fetching it would send the form back to the stale duplicate
+    // inside parserConfig — which is the bug this field was added to close.
+    pullSchedule: string | null;
     status: string;
     traceProjectId: string | null;
     lastEventAt: Date | null;
@@ -114,6 +119,21 @@ export function toIngestionSourceDto({
      * cursor, and one disabled before its first run never held one.
      */
     hasPollerCursor: hasPollerCursor(row.pollerCursor),
+    /**
+     * The cron the lifecycle actually runs this source on.
+     *
+     * `parserConfig` carries an adapter-owned copy under `schedule`, written
+     * by the composer on create, and the two drift the moment anything writes
+     * one without the other — `update` accepts this column on its own, and
+     * seeds and migrations touch neither. The edit form used to seed from the
+     * copy because this column never reached the client; it does now, so the
+     * form shows the cadence that is running rather than the one that was
+     * last written through the composer.
+     *
+     * Not a secret: a cron expression says how often we poll, nothing about
+     * the credentials we poll with.
+     */
+    pullSchedule: row.pullSchedule,
     status: row.status,
     traceProjectId: row.traceProjectId,
     traceProjectArchived: row.traceProjectId


### PR DESCRIPTION
Closes #7521.

## The cause

`toDto` never sent the `pullSchedule` column to the client (`platform/app/ee/governance/routers/ingestionSources.ts:58`), so the edit drawer seeded its cadence field from `parserConfig.schedule` instead (`platform/app/ee/governance/dashboard/pages/inventory.tsx:1093`).

Those are two copies of one value. The schema calls the column a mirror kept "for fast worker dispatch" (`platform/app/prisma/schema.prisma:3240`), and the lifecycle runs on the column and only the column (`platform/app/ee/governance/services/pullers/ingestionPullLifecycle.ts:57`). Nothing keeps the mirror in step: `update` accepts `pullSchedule` on its own (`ingestionSources.ts:192`), and seeds, migrations and direct writes touch neither.

The composer writes both from one value on create, so a source only ever touched through the UI looks fine. That is why this survived review — the two agree by coincidence of the write path, not by construction.

## Why it is worth fixing

The visible half is a wrong number in a form. The expensive half is that the save path writes that same field back to the column (`inventory.tsx:2760`). Open a drifted source, rename it, save — and the live pull schedule is silently overwritten with the stale copy. No warning, no diff, and the next sign is a source polling at the wrong frequency.

## The failing test, first

The regression test was written before the fix, and then the *current* behaviour was implemented under the new name to check the test actually catches the defect rather than merely catching an absent export:

```
× seedPullSchedule > shows the column the scheduler runs on, not the parser config's copy
AssertionError: expected '0 * * * *' to be '0 */6 * * *' // Object.is equality
  Tests  1 failed | 32 passed (33)
```

The router half is proven by the compiler. With the DTO change reverted:

```
ee/governance/dashboard/pages/inventory.tsx:1094:30 - error TS2339:
Property 'pullSchedule' does not exist on type '{ id: string; ... }'
```

And a typo-class regression — the field present but carrying the wrong value, which no compiler catches — is caught by the new DTO test. With `pullSchedule: row.pullSchedule` replaced by `pullSchedule: null`:

```
× toDto > sends the pull schedule the lifecycle runs on
× toDto > sends the column even when parserConfig disagrees with it
AssertionError: expected null to be '0 */6 * * *'
  Tests  2 failed | 2 passed (4)
```

## Passing

```
Test Files  8 passed (8)
     Tests  89 passed (89)
```

`pnpm typecheck:all` clean. `biome check` clean on the changed files.

## The fix

- `toDto` carries `pullSchedule`, with the same required-not-optional treatment `pollerCursor` already has, so a future `select` clause that drops it is a compile error rather than a silent fallback.
- `seedPullSchedule` prefers the column and falls back to the parser copy only when the column is empty — the column is nullable, and older rows may carry only the copy. A blank field means "no schedule set", which is a different claim from "we could not find it".
- A cron expression is not a secret. It says how often we poll, nothing about the credentials we poll with.

## The sweep

Every column on the model was compared against the DTO.

- `parserConfig.schedule` was the only duplicated value with a column twin. No other read of it survives anywhere in the client — zero hits repo-wide.
- `ingestSecretHash` and `credentials` are absent deliberately; the DTO's own docblock explains why, and the new test pins that stripping so this change cannot quietly widen it.
- `errorCount` is the one remaining column not on the DTO. **Classified safe, with a guard:** no form writes it, so it cannot produce this defect — the failure mode here needs a field the client both *reads* and *writes back*. It is read-only telemetry the dashboard does not render at all.

## What I noticed and did not fix

- **The drawer re-seeds only on `source?.id`.** If a source's schedule changes underneath an open page — another admin, a background write — reopening the drawer shows stale local state. This is pre-existing and applies equally to name, description and every parser field; widening the deps is a behaviour change well beyond this bug.
- **The duplicate itself still exists.** The right end state is one source of truth, with the adapter reading the column. That is a migration plus an adapter-contract change across six pullers, not a bug fix, and issue #7521 lists it as the follow-up question. This change makes the two converge on save instead of diverge, which is as far as a fix should reach.
- **Two pre-existing lint warnings** in the touched files, neither in code this change goes near: `buildHttpCustomPullConfig` cognitive complexity 21 (`inventory.tsx:1957`) and a 69-line query in `governance.ts:86`.

## Not covered

No browser verification. The behaviour is a pure seeding decision with a unit test on both halves, and the detail page that would host the visual check sits behind the Enterprise paywall in local dev — the same blocker recorded on #7430. If a reviewer wants it proven on screen, that needs a validly signed licence.

## Method

The `/fix-bug` flow was run inline rather than delegated to subagents, per a standing instruction in this session. The `/ruthless-review` step was likewise self-performed, on my own diff — worth weighting accordingly. It produced two findings, both fixed before this branch was pushed: the seeding signature accepted `undefined` and quietly re-opened the fallback for a caller passing a DTO that had lost the field, and nothing asserted `toDto` copied the column rather than hardcoding a value that would still typecheck.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Editing an ingestion source now preserves its active pull cadence when making unrelated changes.
  * Source details now display and use the authoritative pull schedule.
  * Added fallback handling when schedule data is unavailable or invalid.
  * Disabled sources remain disabled when renamed or edited.

* **Tests**
  * Added coverage for schedule precedence, fallback behavior, cadence preservation, and secure metadata serialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->