### PR TITLE
chore(governance): the review followups that are not about the cadence fix

### DIFF
--- a/platform/app/ee/governance/dashboard/pages/__tests__/editPullSourceConfig.lifecycle.unit.test.ts
+++ b/platform/app/ee/governance/dashboard/pages/__tests__/editPullSourceConfig.lifecycle.unit.test.ts
@@ -212,8 +212,8 @@ describe("given a row whose column and parser copy disagree", () => {
     });
   });
 
-  describe("when a rename is seeded from the parser copy instead", () => {
-    it("moves the live cadence onto the stale copy", async () => {
+  describe("when a rename is seeded from the parser copy, as it once was", () => {
+    it("silently moves the live cadence onto the stale copy", async () => {
       // Pins the damage rather than the fix. This is what shipped before: the
       // seed came from `parserConfig.schedule`, and the rename silently moved
       // the source from six-hourly to hourly.

--- a/platform/app/ee/governance/dashboard/pages/__tests__/editPullSourceConfig.lifecycle.unit.test.ts
+++ b/platform/app/ee/governance/dashboard/pages/__tests__/editPullSourceConfig.lifecycle.unit.test.ts
@@ -14,7 +14,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { syncIngestionPullSource } from "../../../services/pullers/ingestionPullLifecycle";
 import { recommendedPullSchedule } from "../../logic/pullCadence";
-import { buildEditSubmission } from "../inventory";
+import { buildEditSubmission, seedPullSchedule } from "../inventory";
 
 // `resolvePullConfig` toasts the offending field when a pull config will not
 // build. That is the behaviour under test's own reporting channel, not a
@@ -110,6 +110,110 @@ describe("a saved edit reaching the pull lifecycle", () => {
     expect(commands.disable).not.toHaveBeenCalled();
     expect(commands.configure).toHaveBeenCalledWith(
       expect.objectContaining({ cron: "0 */2 * * *" }),
+    );
+  });
+});
+
+/**
+ * The drifted row, from the drawer opening to the process manager.
+ *
+ * `pullSchedule` and `parserConfig.schedule` are two copies of one value, and
+ * the column is the only one the lifecycle reads. The drawer used to seed from
+ * the copy, so an admin who opened a drifted source and changed nothing but
+ * the name handed the save path the stale value — and the save path writes
+ * that field straight back to the column. The damage was never visible in
+ * either half on its own: the drawer emitted a schedule it had honestly been
+ * given, and the lifecycle honestly ran it.
+ */
+describe("an unrelated edit on a row whose two schedules disagree", () => {
+  const STORED = {
+    adapter: "anthropic_admin",
+    report: "usage",
+    bucketWidth: "1h",
+    // The copy, left behind by whatever last wrote the column without it.
+    schedule: "0 * * * *",
+  };
+  /** What the source is really running on. */
+  const RUNNING = "0 */6 * * *";
+
+  /** The row as it comes back for the lifecycle to re-address the process. */
+  function rowFrom(submission: { pullSchedule?: string | null }) {
+    return {
+      id: "src_1",
+      organizationId: "org_1",
+      status: "active",
+      archivedAt: null,
+      updatedAt: new Date("2026-01-01T00:00:00Z"),
+      pollerCursor: null,
+      pullSchedule: submission.pullSchedule ?? null,
+    } as unknown as Parameters<typeof syncIngestionPullSource>[0]["source"];
+  }
+
+  async function renameAndSync(seededCadence: string) {
+    const submission = buildEditSubmission({
+      organizationId: "org_1",
+      source: {
+        id: "src_1",
+        sourceType: "anthropic_admin",
+        parserConfig: STORED,
+      },
+      name: "Anthropic org spend (renamed)",
+      description: "",
+      parserConfig: {
+        credentialsToken: "",
+        report: "usage",
+        bucketWidth: "1h",
+      },
+      ottlStatements: [],
+      pullSchedule: seededCadence,
+    });
+    const commands = { configure: vi.fn(), disable: vi.fn() };
+
+    await syncIngestionPullSource({
+      prisma: {} as never,
+      source: rowFrom(submission ?? {}),
+      commands,
+    });
+
+    return { submission, commands };
+  }
+
+  it("leaves the source running on the cadence it was already running on", async () => {
+    const { submission, commands } = await renameAndSync(
+      seedPullSchedule({ pullSchedule: RUNNING, storedParserConfig: STORED }),
+    );
+
+    // The outcome that matters: the process manager is re-addressed to the
+    // same cron it already had. A rename does not change how often we poll.
+    expect(commands.configure).toHaveBeenCalledWith(
+      expect.objectContaining({ sourceId: "src_1", cron: RUNNING }),
+    );
+    expect(submission?.pullSchedule).toBe(RUNNING);
+  });
+
+  it("converges the parser config's stale copy onto the column", async () => {
+    // The save writes both from one value, so the row stops being divergent.
+    // Nothing repairs these rows in bulk; editing one is what fixes it.
+    const { submission } = await renameAndSync(
+      seedPullSchedule({ pullSchedule: RUNNING, storedParserConfig: STORED }),
+    );
+
+    expect((submission?.parserConfig as Record<string, unknown>).schedule).toBe(
+      RUNNING,
+    );
+  });
+
+  it("would have rewritten the live cadence if seeded from the parser copy", async () => {
+    // Pins the damage rather than the fix. This is what shipped before: the
+    // seed came from `parserConfig.schedule`, and the rename silently moved
+    // the source from six-hourly to hourly.
+    const { commands } = await renameAndSync(STORED.schedule);
+
+    expect(commands.configure).toHaveBeenCalledWith(
+      expect.objectContaining({ cron: "0 * * * *" }),
+    );
+    expect(commands.configure).not.toHaveBeenCalledWith(
+      expect.objectContaining({ cron: RUNNING }),
     );
   });
 });

--- a/platform/app/ee/governance/dashboard/pages/__tests__/editPullSourceConfig.lifecycle.unit.test.ts
+++ b/platform/app/ee/governance/dashboard/pages/__tests__/editPullSourceConfig.lifecycle.unit.test.ts
@@ -217,3 +217,65 @@ describe("an unrelated edit on a row whose two schedules disagree", () => {
     );
   });
 });
+
+describe("renaming a source an admin has deliberately disabled", () => {
+  // `status: "disabled"` is the sanctioned off switch: it is a first-class
+  // value of the router's status enum, and the edit path never writes status,
+  // so a rename cannot reach it. This is the guarantee worth pinning — the
+  // review asked whether an edit can revive a stopped source, and for the
+  // way sources are actually stopped, the answer has to stay no.
+  const STORED = {
+    adapter: "anthropic_admin",
+    report: "usage",
+    bucketWidth: "1h",
+    schedule: "0 */6 * * *",
+  };
+
+  it("leaves it disabled, whatever cadence the form submits", async () => {
+    const submission = buildEditSubmission({
+      organizationId: "org_1",
+      source: {
+        id: "src_1",
+        sourceType: "anthropic_admin",
+        parserConfig: STORED,
+      },
+      name: "renamed while stopped",
+      description: "",
+      parserConfig: {
+        credentialsToken: "",
+        report: "usage",
+        bucketWidth: "1h",
+      },
+      ottlStatements: [],
+      pullSchedule: seedPullSchedule({
+        pullSchedule: "0 */6 * * *",
+        storedParserConfig: STORED,
+      }),
+    });
+
+    // The submission carries a perfectly good cron. The status is what stops
+    // it, and the submission has no opinion about the status.
+    expect(submission?.pullSchedule).toBe("0 */6 * * *");
+    expect(submission).not.toHaveProperty("status");
+
+    const commands = { configure: vi.fn(), disable: vi.fn() };
+    await syncIngestionPullSource({
+      prisma: {} as never,
+      source: {
+        id: "src_1",
+        organizationId: "org_1",
+        status: "disabled",
+        archivedAt: null,
+        updatedAt: new Date("2026-01-01T00:00:00Z"),
+        pollerCursor: null,
+        pullSchedule: submission?.pullSchedule ?? null,
+      } as unknown as Parameters<typeof syncIngestionPullSource>[0]["source"],
+      commands,
+    });
+
+    expect(commands.disable).toHaveBeenCalledWith(
+      expect.objectContaining({ sourceId: "src_1" }),
+    );
+    expect(commands.configure).not.toHaveBeenCalled();
+  });
+});

--- a/platform/app/ee/governance/dashboard/pages/__tests__/editPullSourceConfig.lifecycle.unit.test.ts
+++ b/platform/app/ee/governance/dashboard/pages/__tests__/editPullSourceConfig.lifecycle.unit.test.ts
@@ -36,7 +36,7 @@ vi.mock("../../../services/governanceProject.service", () => ({
  * and the lifecycle correctly read `null` as "disable". Only a test that runs
  * the edit path's output through the thing that consumes it can fail.
  */
-describe("a saved edit reaching the pull lifecycle", () => {
+describe("given a saved edit that reaches the pull lifecycle", () => {
   function sourceRowFrom(submission: { pullSchedule?: string | null }) {
     return {
       id: "src_1",
@@ -86,31 +86,35 @@ describe("a saved edit reaching the pull lifecycle", () => {
     return { submission, commands };
   }
 
-  it("keeps pulling after an admin clears the cadence field", async () => {
-    const { submission, commands } = await syncAfterEdit("   ");
+  describe("when the admin clears the cadence field", () => {
+    it("keeps the source pulling on the recommended cadence", async () => {
+      const { submission, commands } = await syncAfterEdit("   ");
 
-    // The lifecycle outcome first: this is the assertion that fails when the
-    // edit path goes back to saving null, and the one that says what the
-    // admin actually loses — a source that has stopped pulling.
-    expect(commands.disable).not.toHaveBeenCalled();
-    expect(commands.configure).toHaveBeenCalledWith(
-      expect.objectContaining({
-        sourceId: "src_1",
-        cron: recommendedPullSchedule("anthropic_admin"),
-      }),
-    );
-    expect(submission?.pullSchedule).toBe(
-      recommendedPullSchedule("anthropic_admin"),
-    );
+      // The lifecycle outcome first: this is the assertion that fails when the
+      // edit path goes back to saving null, and the one that says what the
+      // admin actually loses — a source that has stopped pulling.
+      expect(commands.disable).not.toHaveBeenCalled();
+      expect(commands.configure).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sourceId: "src_1",
+          cron: recommendedPullSchedule("anthropic_admin"),
+        }),
+      );
+      expect(submission?.pullSchedule).toBe(
+        recommendedPullSchedule("anthropic_admin"),
+      );
+    });
   });
 
-  it("still runs on an explicitly typed cadence", async () => {
-    const { commands } = await syncAfterEdit("0 */2 * * *");
+  describe("when the admin types an explicit cadence", () => {
+    it("runs the source on the cadence that was typed", async () => {
+      const { commands } = await syncAfterEdit("0 */2 * * *");
 
-    expect(commands.disable).not.toHaveBeenCalled();
-    expect(commands.configure).toHaveBeenCalledWith(
-      expect.objectContaining({ cron: "0 */2 * * *" }),
-    );
+      expect(commands.disable).not.toHaveBeenCalled();
+      expect(commands.configure).toHaveBeenCalledWith(
+        expect.objectContaining({ cron: "0 */2 * * *" }),
+      );
+    });
   });
 });
 
@@ -125,7 +129,7 @@ describe("a saved edit reaching the pull lifecycle", () => {
  * either half on its own: the drawer emitted a schedule it had honestly been
  * given, and the lifecycle honestly ran it.
  */
-describe("an unrelated edit on a row whose two schedules disagree", () => {
+describe("given a row whose column and parser copy disagree", () => {
   const STORED = {
     adapter: "anthropic_admin",
     report: "usage",
@@ -181,52 +185,58 @@ describe("an unrelated edit on a row whose two schedules disagree", () => {
     return { submission, commands };
   }
 
-  it("leaves the source running on the cadence it was already running on", async () => {
-    const { submission, commands } = await renameAndSync(
-      seedPullSchedule({ pullSchedule: RUNNING, storedParserConfig: STORED }),
-    );
+  describe("when a rename is seeded from the column", () => {
+    it("leaves the source running on the cadence it was already running on", async () => {
+      const { submission, commands } = await renameAndSync(
+        seedPullSchedule({ pullSchedule: RUNNING, storedParserConfig: STORED }),
+      );
 
-    // The outcome that matters: the process manager is re-addressed to the
-    // same cron it already had. A rename does not change how often we poll.
-    expect(commands.configure).toHaveBeenCalledWith(
-      expect.objectContaining({ sourceId: "src_1", cron: RUNNING }),
-    );
-    expect(submission?.pullSchedule).toBe(RUNNING);
+      // The outcome that matters: the process manager is re-addressed to the
+      // same cron it already had. A rename does not change how often we poll.
+      expect(commands.configure).toHaveBeenCalledWith(
+        expect.objectContaining({ sourceId: "src_1", cron: RUNNING }),
+      );
+      expect(submission?.pullSchedule).toBe(RUNNING);
+    });
+
+    it("converges the parser config's stale copy onto the column", async () => {
+      // The save writes both from one value, so the row stops being divergent.
+      // Nothing repairs these rows in bulk; editing one is what fixes it.
+      const { submission } = await renameAndSync(
+        seedPullSchedule({ pullSchedule: RUNNING, storedParserConfig: STORED }),
+      );
+
+      expect(
+        (submission?.parserConfig as Record<string, unknown>).schedule,
+      ).toBe(RUNNING);
+    });
   });
 
-  it("converges the parser config's stale copy onto the column", async () => {
-    // The save writes both from one value, so the row stops being divergent.
-    // Nothing repairs these rows in bulk; editing one is what fixes it.
-    const { submission } = await renameAndSync(
-      seedPullSchedule({ pullSchedule: RUNNING, storedParserConfig: STORED }),
-    );
+  describe("when a rename is seeded from the parser copy instead", () => {
+    it("moves the live cadence onto the stale copy", async () => {
+      // Pins the damage rather than the fix. This is what shipped before: the
+      // seed came from `parserConfig.schedule`, and the rename silently moved
+      // the source from six-hourly to hourly.
+      const { commands } = await renameAndSync(STORED.schedule);
 
-    expect((submission?.parserConfig as Record<string, unknown>).schedule).toBe(
-      RUNNING,
-    );
-  });
-
-  it("would have rewritten the live cadence if seeded from the parser copy", async () => {
-    // Pins the damage rather than the fix. This is what shipped before: the
-    // seed came from `parserConfig.schedule`, and the rename silently moved
-    // the source from six-hourly to hourly.
-    const { commands } = await renameAndSync(STORED.schedule);
-
-    expect(commands.configure).toHaveBeenCalledWith(
-      expect.objectContaining({ cron: "0 * * * *" }),
-    );
-    expect(commands.configure).not.toHaveBeenCalledWith(
-      expect.objectContaining({ cron: RUNNING }),
-    );
+      expect(commands.configure).toHaveBeenCalledWith(
+        expect.objectContaining({ cron: "0 * * * *" }),
+      );
+      expect(commands.configure).not.toHaveBeenCalledWith(
+        expect.objectContaining({ cron: RUNNING }),
+      );
+    });
   });
 });
 
-describe("renaming a source an admin has deliberately disabled", () => {
-  // `status: "disabled"` is the sanctioned off switch: it is a first-class
-  // value of the router's status enum, and the edit path never writes status,
-  // so a rename cannot reach it. This is the guarantee worth pinning — the
-  // review asked whether an edit can revive a stopped source, and for the
-  // way sources are actually stopped, the answer has to stay no.
+/**
+ * `status: "disabled"` is the sanctioned off switch: it is a first-class value
+ * of the router's status enum, and the edit path never writes status, so a
+ * rename cannot reach it. This is the guarantee worth pinning — the review
+ * asked whether an edit can revive a stopped source, and for the way sources
+ * are actually stopped, the answer has to stay no.
+ */
+describe("given a source an admin has deliberately disabled", () => {
   const STORED = {
     adapter: "anthropic_admin",
     report: "usage",
@@ -234,52 +244,54 @@ describe("renaming a source an admin has deliberately disabled", () => {
     schedule: "0 */6 * * *",
   };
 
-  it("leaves it disabled, whatever cadence the form submits", async () => {
-    const submission = buildEditSubmission({
-      organizationId: "org_1",
-      source: {
-        id: "src_1",
-        sourceType: "anthropic_admin",
-        parserConfig: STORED,
-      },
-      name: "renamed while stopped",
-      description: "",
-      parserConfig: {
-        credentialsToken: "",
-        report: "usage",
-        bucketWidth: "1h",
-      },
-      ottlStatements: [],
-      pullSchedule: seedPullSchedule({
-        pullSchedule: "0 */6 * * *",
-        storedParserConfig: STORED,
-      }),
-      destination: undefined,
-    });
-
-    // The submission carries a perfectly good cron. The status is what stops
-    // it, and the submission has no opinion about the status.
-    expect(submission?.pullSchedule).toBe("0 */6 * * *");
-    expect(submission).not.toHaveProperty("status");
-
-    const commands = { configure: vi.fn(), disable: vi.fn() };
-    await syncIngestionPullSource({
-      prisma: {} as never,
-      source: {
-        id: "src_1",
+  describe("when an unrelated edit renames it", () => {
+    it("leaves it disabled, whatever cadence the form submits", async () => {
+      const submission = buildEditSubmission({
         organizationId: "org_1",
-        status: "disabled",
-        archivedAt: null,
-        updatedAt: new Date("2026-01-01T00:00:00Z"),
-        pollerCursor: null,
-        pullSchedule: submission?.pullSchedule ?? null,
-      } as unknown as Parameters<typeof syncIngestionPullSource>[0]["source"],
-      commands,
-    });
+        source: {
+          id: "src_1",
+          sourceType: "anthropic_admin",
+          parserConfig: STORED,
+        },
+        name: "renamed while stopped",
+        description: "",
+        parserConfig: {
+          credentialsToken: "",
+          report: "usage",
+          bucketWidth: "1h",
+        },
+        ottlStatements: [],
+        pullSchedule: seedPullSchedule({
+          pullSchedule: "0 */6 * * *",
+          storedParserConfig: STORED,
+        }),
+        destination: undefined,
+      });
 
-    expect(commands.disable).toHaveBeenCalledWith(
-      expect.objectContaining({ sourceId: "src_1" }),
-    );
-    expect(commands.configure).not.toHaveBeenCalled();
+      // The submission carries a perfectly good cron. The status is what stops
+      // it, and the submission has no opinion about the status.
+      expect(submission?.pullSchedule).toBe("0 */6 * * *");
+      expect(submission).not.toHaveProperty("status");
+
+      const commands = { configure: vi.fn(), disable: vi.fn() };
+      await syncIngestionPullSource({
+        prisma: {} as never,
+        source: {
+          id: "src_1",
+          organizationId: "org_1",
+          status: "disabled",
+          archivedAt: null,
+          updatedAt: new Date("2026-01-01T00:00:00Z"),
+          pollerCursor: null,
+          pullSchedule: submission?.pullSchedule ?? null,
+        } as unknown as Parameters<typeof syncIngestionPullSource>[0]["source"],
+        commands,
+      });
+
+      expect(commands.disable).toHaveBeenCalledWith(
+        expect.objectContaining({ sourceId: "src_1" }),
+      );
+      expect(commands.configure).not.toHaveBeenCalled();
+    });
   });
 });

--- a/platform/app/ee/governance/dashboard/pages/__tests__/editPullSourceConfig.lifecycle.unit.test.ts
+++ b/platform/app/ee/governance/dashboard/pages/__tests__/editPullSourceConfig.lifecycle.unit.test.ts
@@ -166,6 +166,9 @@ describe("an unrelated edit on a row whose two schedules disagree", () => {
       },
       ottlStatements: [],
       pullSchedule: seededCadence,
+      // A pull source never offers the destination picker, so an edit of one
+      // leaves the field untouched.
+      destination: undefined,
     });
     const commands = { configure: vi.fn(), disable: vi.fn() };
 
@@ -251,6 +254,7 @@ describe("renaming a source an admin has deliberately disabled", () => {
         pullSchedule: "0 */6 * * *",
         storedParserConfig: STORED,
       }),
+      destination: undefined,
     });
 
     // The submission carries a perfectly good cron. The status is what stops

--- a/platform/app/ee/governance/dashboard/pages/__tests__/editPullSourceConfig.presentation.unit.test.ts
+++ b/platform/app/ee/governance/dashboard/pages/__tests__/editPullSourceConfig.presentation.unit.test.ts
@@ -20,6 +20,7 @@ import {
   lockedParserKeys,
   parserFieldPresentation,
   seedComposerParserConfig,
+  seedPullSchedule,
 } from "../inventory";
 import { composer } from "./editPullSourceConfig.fixture";
 
@@ -328,5 +329,62 @@ describe("seedComposerParserConfig", () => {
 
     expect(config).not.toHaveProperty("credentials");
     expect(anthropicAdminPullConfigSchema.parse(config).report).toBe("usage");
+  });
+});
+
+describe("seedPullSchedule", () => {
+  it("shows the column the scheduler runs on, not the parser config's copy", () => {
+    // The two can disagree: `parserConfig.schedule` is the adapter's own copy,
+    // written by the composer on create, while `pullSchedule` is the column
+    // the lifecycle actually reads. Any write that touches one and not the
+    // other — the update mutation takes `pullSchedule` on its own, and seeds
+    // and migrations bypass both — leaves a row where seeding from the parser
+    // config would show a cadence the source is not running on, and saving
+    // would then write that stale value over the live one.
+    expect(
+      seedPullSchedule({
+        pullSchedule: "0 */6 * * *",
+        storedParserConfig: { schedule: "0 * * * *" },
+      }),
+    ).toBe("0 */6 * * *");
+  });
+
+  it("falls back to the parser config for a row whose column is empty", () => {
+    // Not hypothetical: the column is nullable, and a null one reads as
+    // `disable` to the lifecycle. Showing the adapter's copy is the better
+    // answer than a blank box, which an admin reads as "no schedule set".
+    expect(
+      seedPullSchedule({
+        pullSchedule: null,
+        storedParserConfig: { schedule: "*/15 * * * *" },
+      }),
+    ).toBe("*/15 * * * *");
+  });
+
+  it("treats a whitespace-only column as absent", () => {
+    expect(
+      seedPullSchedule({
+        pullSchedule: "   ",
+        storedParserConfig: { schedule: "*/15 * * * *" },
+      }),
+    ).toBe("*/15 * * * *");
+  });
+
+  it("reports no schedule at all rather than inventing one", () => {
+    // Blank is the cadence field's way of saying "use the recommended
+    // schedule". Seeding a default here would make the field lie about what
+    // is stored, and `buildEditSubmission` already resolves blank on save.
+    expect(
+      seedPullSchedule({ pullSchedule: null, storedParserConfig: {} }),
+    ).toBe("");
+  });
+
+  it("ignores a non-string schedule in the parser config", () => {
+    expect(
+      seedPullSchedule({
+        pullSchedule: null,
+        storedParserConfig: { schedule: 42 },
+      }),
+    ).toBe("");
   });
 });

--- a/platform/app/ee/governance/dashboard/pages/inventory.tsx
+++ b/platform/app/ee/governance/dashboard/pages/inventory.tsx
@@ -1117,8 +1117,8 @@ function useSourceEditForm(source: Source | null) {
     undefined,
   );
 
-  // Sync local state when the drawer opens for a new source - drives
-  // the form fields off whatever the row carries on the wire.
+  // Keyed on `source?.id`, not `source`: a re-render that hands back an equal
+  // row must not discard what the admin has typed since the drawer opened.
   useEffect(() => {
     if (!source) return;
     setName(source.name);

--- a/platform/app/ee/governance/dashboard/pages/inventory.tsx
+++ b/platform/app/ee/governance/dashboard/pages/inventory.tsx
@@ -1137,11 +1137,15 @@ function useSourceEditForm(source: Source | null) {
         storedParserConfig: parser,
       }),
     );
-    // The `pullSchedule` column is not on the DTO, but the adapter's own copy
-    // of it rides along inside parserConfig, written there by the composer on
-    // create. Seeding from it keeps the field showing the cadence that is
-    // actually running rather than an empty box that reads as "no schedule".
-    setPullSchedule(typeof parser.schedule === "string" ? parser.schedule : "");
+    // The column first, because it is the one the lifecycle runs on; the
+    // adapter's copy inside parserConfig is a duplicate nothing keeps in sync.
+    // See `seedPullSchedule`.
+    setPullSchedule(
+      seedPullSchedule({
+        pullSchedule: source.pullSchedule,
+        storedParserConfig: parser,
+      }),
+    );
   }, [source?.id]);
 
   return {
@@ -2682,6 +2686,37 @@ export function seedComposerParserConfig({
     values[field.key] = String(stored);
   }
   return values;
+}
+
+/**
+ * The cadence the edit form opens on: the `pullSchedule` column, which is what
+ * the lifecycle actually runs, falling back to the adapter's copy inside
+ * `parserConfig` only when the column has nothing to say.
+ *
+ * The two are duplicates that nothing keeps in sync. The composer writes both
+ * from one value on create, so they agree for a source that has only ever been
+ * touched through the UI — but `update` takes `pullSchedule` on its own, and
+ * seeds, migrations and direct writes bypass the parser copy entirely. Seeding
+ * from the parser copy therefore showed a cadence the source was not running
+ * on, and because the save path writes the field back to the column, opening
+ * such a row and saving any unrelated field overwrote the live schedule with
+ * the stale one.
+ *
+ * The fallback stays because the column is nullable and older rows may carry
+ * only the parser copy; a blank field reads as "no schedule set", which is a
+ * different claim from "we could not find it".
+ */
+export function seedPullSchedule({
+  pullSchedule,
+  storedParserConfig,
+}: {
+  pullSchedule: string | null;
+  storedParserConfig: Record<string, unknown>;
+}): string {
+  const fromColumn = (pullSchedule ?? "").trim();
+  if (fromColumn) return fromColumn;
+  const fromParser = storedParserConfig.schedule;
+  return typeof fromParser === "string" ? fromParser.trim() : "";
 }
 
 /**

--- a/platform/app/ee/governance/routers/__tests__/ingestionSourceDto.unit.test.ts
+++ b/platform/app/ee/governance/routers/__tests__/ingestionSourceDto.unit.test.ts
@@ -23,6 +23,7 @@ const row = (overrides: Record<string, unknown> = {}) =>
     name: "Genie fleet",
     description: null,
     parserConfig: {},
+    pullSchedule: "0 */6 * * *",
     status: "active",
     traceProjectId: null,
     lastEventAt: null,
@@ -82,6 +83,59 @@ describe("given an ingestion source with a trace destination", () => {
       expect(dto.parserConfig).toEqual({
         workspaceUrl: "https://example.databricks.net",
       });
+    });
+  });
+});
+
+describe("given a pull source whose cadence lives in two places", () => {
+  describe("when the column and the parser config's copy disagree", () => {
+    it("sends the column, because that is what the scheduler reads", () => {
+      // Without this the edit form cannot see the column at all, and falls
+      // back to the adapter's copy inside parserConfig — a duplicate nothing
+      // keeps in sync, which the form would then write back over the live
+      // value.
+      const dto = toIngestionSourceDto({
+        row: row({
+          sourceType: "anthropic_admin",
+          pullSchedule: "0 */6 * * *",
+          parserConfig: { adapter: "anthropic_admin", schedule: "0 * * * *" },
+        }),
+        liveTraceProjectIds: new Set<string>(),
+      });
+
+      expect(dto.pullSchedule).toBe("0 */6 * * *");
+    });
+  });
+
+  describe("when the source does not pull at all", () => {
+    it("passes the null through, because null is what stops it running", () => {
+      const dto = toIngestionSourceDto({
+        row: row({ sourceType: "otel_generic", pullSchedule: null }),
+        liveTraceProjectIds: new Set<string>(),
+      });
+
+      expect(dto.pullSchedule).toBeNull();
+    });
+  });
+
+  describe("when the parser config also carries the sealed credential", () => {
+    it("still strips it, cadence or no cadence", () => {
+      const dto = toIngestionSourceDto({
+        row: row({
+          sourceType: "anthropic_admin",
+          parserConfig: {
+            adapter: "anthropic_admin",
+            schedule: "0 * * * *",
+            credentials: "enc:v1:deadbeef:cafe:0123",
+            _rotation: { priorHash: "abc" },
+          },
+        }),
+        liveTraceProjectIds: new Set<string>(),
+      });
+
+      expect(dto.parserConfig).not.toHaveProperty("credentials");
+      expect(dto.parserConfig).not.toHaveProperty("_rotation");
+      expect(JSON.stringify(dto)).not.toContain("enc:v1:");
     });
   });
 });

--- a/platform/app/ee/governance/routers/ingestionSources.ts
+++ b/platform/app/ee/governance/routers/ingestionSources.ts
@@ -147,7 +147,6 @@ export function toIngestionSourceDto({
   };
 }
 
-/** {@link toIngestionSourceDto} for a single row, resolving its destination. */
 async function dtoForRow(
   service: IngestionSourceService,
   row: Parameters<typeof toIngestionSourceDto>[0]["row"],

--- a/platform/app/ee/governance/routers/ingestionSources.ts
+++ b/platform/app/ee/governance/routers/ingestionSources.ts
@@ -72,6 +72,11 @@ export function toIngestionSourceDto({
     // edit form would offer a backfill start that cannot take effect. Better a
     // compile error than a setting that quietly does nothing.
     pollerCursor: unknown;
+    // Required for the same reason as `pollerCursor` above: the edit form
+    // seeds its cadence field from this column, and a `select` clause that
+    // stopped fetching it would send the form back to the stale duplicate
+    // inside parserConfig — which is the bug this field was added to close.
+    pullSchedule: string | null;
     status: string;
     traceProjectId: string | null;
     lastEventAt: Date | null;
@@ -114,6 +119,21 @@ export function toIngestionSourceDto({
      * cursor, and one disabled before its first run never held one.
      */
     hasPollerCursor: hasPollerCursor(row.pollerCursor),
+    /**
+     * The cron the lifecycle actually runs this source on.
+     *
+     * `parserConfig` carries an adapter-owned copy under `schedule`, written
+     * by the composer on create, and the two drift the moment anything writes
+     * one without the other — `update` accepts this column on its own, and
+     * seeds and migrations touch neither. The edit form used to seed from the
+     * copy because this column never reached the client; it does now, so the
+     * form shows the cadence that is running rather than the one that was
+     * last written through the composer.
+     *
+     * Not a secret: a cron expression says how often we poll, nothing about
+     * the credentials we poll with.
+     */
+    pullSchedule: row.pullSchedule,
     status: row.status,
     traceProjectId: row.traceProjectId,
     traceProjectArchived: row.traceProjectId


### PR DESCRIPTION
Two review findings raised on #7522 that are worth doing and are not about that PR's diff.

## Test structure

`editPullSourceConfig.lifecycle.unit.test.ts` carried each scenario's setup in a narrative comment above a flat `describe`. The house rule is the opposite — the nesting carries the given and the when, and the `it` says only what happens.

Split into `describe("given …")` with a `describe("when …")` per distinct edit. The comments that state *why* stay: why the suite reaches across into the poller at all, why the parser copy is stale, why one case pins the damage rather than the fix.

103 tests before, 103 after. No assertion added, removed, or changed.

## Two comments that only said what the code said

- `dtoForRow` was introduced by a doc comment repeating its own name. Gone.
- The edit drawer's seeding effect was introduced by a line saying that a `useEffect` syncs state. Replaced with the one thing not visible from the body: it is keyed on `source?.id` rather than `source`, so a re-render handing back an equal row cannot wipe what the admin has typed.

Both lines predate #7522 — one arrived from main on an unrelated PR, the other in the original commit from July. That is why they are fixed here and not there.

## What is deliberately not here

The two P1 comments on #7522 about a null cadence being revived by an unrelated edit. The behaviour is real and predates both branches. Fixing it means first deciding what a null cadence *means*, because a deliberate null and a legacy null are the same shape in the database. Written up as #7523.

## Verification

- `npx vitest run ee/governance/dashboard/pages/__tests__/ ee/governance/routers/__tests__/` — 9 files, 103 passed
- `pnpm typecheck:all` — exit 0
- `pnpm exec biome check` on the three touched files — 1 warning, pre-existing (`buildHttpCustomPullConfig` complexity, main's code)

## Stacking

Based on `fix/pull-cadence-source-of-truth` (#7522). Merge that first; this PR's diff is only the two changes above.
