### PR TITLE
test(process-manager): the fencing test waits for the lease instead of sleeping

### DIFF
--- a/platform/app/src/server/event-sourcing/process-manager/outbox/__tests__/outboxBacklogDrain.integration.test.ts
+++ b/platform/app/src/server/event-sourcing/process-manager/outbox/__tests__/outboxBacklogDrain.integration.test.ts
@@ -169,26 +169,51 @@ describe("outbox backlog drain under slow deliveries", () => {
       const result = await store.commit(commit(messages(1)));
       expect(result.outcome).toBe("committed");
 
+      // Two facts have to hold before the rival is allowed to run: the slow
+      // delivery holds the lease, and it is already past the lease-budget
+      // guard so it cannot be shed un-attempted. Waiting for its handler to be
+      // entered establishes both, because the guard runs before the handler
+      // does. Sleeping only hopes for both, and on a loaded runner the slow
+      // dispatcher can lease nothing at all or shed the message on the way to
+      // the handler, either of which reports an empty `fenced`.
+      let announceDeliveryStarted!: () => void;
+      const deliveryStarted = new Promise<void>((resolve) => {
+        announceDeliveryStarted = resolve;
+      });
       let releaseGate!: () => void;
       const gate = new Promise<void>((resolve) => {
         releaseGate = resolve;
       });
+      // Wide enough that the slow dispatcher cannot plausibly run out of lease
+      // budget between leasing and its handler. Nothing waits for this to
+      // expire: the lapse is produced by advancing the rival's clock.
+      const leaseDurationMs = 5_000;
       const slow = new OutboxDispatcherService({
         store,
         processNames: [processName],
-        leaseDurationMs: 100,
-        handlers: { "test.persist": () => gate },
+        leaseDurationMs,
+        handlers: {
+          "test.persist": () => {
+            announceDeliveryStarted();
+            return gate;
+          },
+        },
       });
       const fast = new OutboxDispatcherService({
         store,
         processNames: [processName],
-        leaseDurationMs: 100,
+        leaseDurationMs,
         handlers: { "test.persist": async () => undefined },
       });
 
       const slowRun = slow.runOnce({ now: Date.now() });
-      await sleep(150);
-      const fastReport = await fast.runOnce({ now: Date.now() });
+      await deliveryStarted;
+      // A lease is due again once `leasedUntil <= now`, and `now` is the
+      // caller's, so the rival sees a lapsed lease without the test sleeping
+      // through one.
+      const fastReport = await fast.runOnce({
+        now: Date.now() + leaseDurationMs + 1,
+      });
       expect(fastReport.dispatched).toEqual(["match-000"]);
 
       releaseGate();

--- a/platform/app/src/server/event-sourcing/process-manager/outbox/__tests__/outboxBacklogDrain.integration.test.ts
+++ b/platform/app/src/server/event-sourcing/process-manager/outbox/__tests__/outboxBacklogDrain.integration.test.ts
@@ -207,7 +207,21 @@ describe("outbox backlog drain under slow deliveries", () => {
       });
 
       const slowRun = slow.runOnce({ now: Date.now() });
-      await deliveryStarted;
+      // If the delivery never starts there is no race to observe, and waiting
+      // on the signal alone would spend the whole 60s test timeout finding
+      // that out. Racing the run against the signal turns it into an
+      // assertion that names what went wrong instead. The rejection is
+      // absorbed here on purpose: `slowRun` is awaited again below, which is
+      // where a thrown error belongs.
+      const slowRunSettled = slowRun.then(
+        () => "settled without delivering" as const,
+        () => "settled without delivering" as const,
+      );
+      const raceSetUp = await Promise.race([
+        deliveryStarted.then(() => "delivery started" as const),
+        slowRunSettled,
+      ]);
+      expect(raceSetUp).toBe("delivery started");
       // A lease is due again once `leasedUntil <= now`, and `now` is the
       // caller's, so the rival sees a lapsed lease without the test sleeping
       // through one.


### PR DESCRIPTION
Closes #7526.

## The problem

`outboxBacklogDrain.integration.test.ts` pins that a delivery still running when its lease lapses has its superseded acknowledgement reported as `fenced`, not silently dropped. It set that race up by hoping:

```ts
const slowRun = slow.runOnce({ now: Date.now() });  // not awaited
await sleep(150);                                   // 100ms lease
const fastReport = await fast.runOnce({ now: Date.now() });
```

Nothing makes the slow dispatcher hold the lease before the rival is let loose. Two ways that goes wrong on a loaded runner, both reporting an empty `fenced`:

1. The slow dispatcher loses the race to lease at all and returns the all-empty report.
2. It leases, but reaches the lease-budget guard with less than the 20% safety margin left — 20ms of its 100ms lease — so the message is shed into `released` and the handler never runs.

## The fix

The gated handler signals on entry and the test waits for that signal. That establishes both facts the race needs at once: the lease is held, and the budget guard has already been cleared, because the guard runs before the handler does.

The lapse no longer comes from waiting either. A lease is due again once `leasedUntil <= now`, and `now` is the caller's, so the rival just runs with its clock advanced past the lease. The lease is widened to 5s to put the budget guard out of reach; nothing waits for it to expire.

Behaviour under test is unchanged — same assertions, same three cases.

## Verification

Run locally against real Postgres/ClickHouse containers.

| | idle | under load (30 busy processes on 10 cpus) |
|---|---|---|
| before | 8/8 pass | **0/6 pass** — `fenced` empty every time |
| after | 8/8 pass | **6/6 pass** |

The failure reproduces on the fencing case only; the other two cases in the file pass throughout. The fenced path is genuinely exercised after the fix — the dispatcher's "acknowledgement was fenced by a lapsed lease" warning fires on every run.

`pnpm typecheck:all` exit 0. Biome clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved integration test reliability by replacing timing-dependent delays with deterministic event synchronization.
  * Added explicit lease-expiration simulation to make fenced-acknowledgement scenarios more consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->