### PR TITLE
test(event-sourcing): expect the post-drain send refusal #7520 renamed

### DIFF
--- a/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.integration.test.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.integration.test.ts
@@ -461,7 +461,7 @@ describe.skipIf(!hasTestcontainers)(
               groupId: "group-a",
               value: "after-close",
             }),
-          ).rejects.toThrow(/shutdown/i);
+          ).rejects.toThrow(/drain has finished/i);
         });
       });
     });


### PR DESCRIPTION
Main is red. `test-integration (shared 2/2)` fails deterministically on `main` ([run 32793982767](https://github.com/langwatch/langwatch/actions/runs/32793982767)) and, because CI tests the merge ref, on every open PR as well.

## What broke

#7520 (`1f51c56eb8`, "fix(event-sourcing): let a queue drain accept the work it produces") moved the send gate from the *start* of the drain to the *end* of it, and renamed the refusal along the way:

- before: `Cannot send to queue after shutdown has been requested`
- after: `Cannot send to queue after its drain has finished`

The unit tests added by that PR were written against the new wording, but the existing integration test was not updated. `groupQueue.integration.test.ts` -> `close()` -> "when close is called after processing" -> "resolves and stops accepting new jobs" still asserted `.rejects.toThrow(/shutdown/i)`, which no longer matches.

## The fix

One line — match the new message:

```diff
-          ).rejects.toThrow(/shutdown/i);
+          ).rejects.toThrow(/drain has finished/i);
```

The behaviour the test covers is unchanged: `close()` sets `stagingClosed = true` in its `finally` block, so a `send()` after `close()` still throws. Only the wording moved.

## Notes

- No restructuring, no new scenarios. `specs/background/queue-drain-send-gate.feature` already covers "Staging is refused once the drain is over" under `@unit`, and it is bound by an `@scenario` annotation in `groupQueue.drainSendGate.unit.test.ts`, so binding is left alone.
- The feature file's "Why this exists" comment quotes the *old* production message as historical context for the incident. That is correct as written and deliberately not touched.
- Unblocks `main` and the merge-ref CI on every open PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated integration test expectations to reflect the current message shown when sending a job after queue draining has completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->