### PR TITLE
feat(experiments-v3): the active dataset offers Switch Dataset

### DIFF
--- a/platform/app/src/experiments-v3/__tests__/DatasetTabsInteraction.integration.test.tsx
+++ b/platform/app/src/experiments-v3/__tests__/DatasetTabsInteraction.integration.test.tsx
@@ -7,21 +7,98 @@
 import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { useState } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SelectDatasetDrawer } from "~/components/datasets/SelectDatasetDrawer";
 import { DatasetTabs } from "../components/DatasetSection/DatasetTabs";
 import { useEvaluationsV3Store } from "../hooks/useEvaluationsV3Store";
 import { type DatasetReference, DEFAULT_TEST_DATA_ID } from "../types";
+
+vi.mock("~/hooks/useDrawer", () => ({
+  useDrawer: () => ({
+    openDrawer: vi.fn(),
+    closeDrawer: mockCloseDrawer,
+    goBack: vi.fn(),
+    canGoBack: false,
+    drawerOpen: vi.fn(() => false),
+  }),
+  getComplexProps: () => ({}),
+  useDrawerParams: () => ({}),
+}));
+
+vi.mock("~/hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({
+    project: { id: "project-1", name: "Test Project" },
+  }),
+}));
+
+vi.mock("~/utils/api", () => ({
+  api: {
+    dataset: {
+      getAll: {
+        useQuery: () => ({
+          data: [
+            {
+              id: "ds-1",
+              name: "Production Samples",
+              status: "ready",
+              columnTypes: [
+                { name: "input", type: "string" },
+                { name: "expected_output", type: "string" },
+              ],
+              updatedAt: new Date("2026-08-01T00:00:00Z"),
+              contentLayout: null,
+              useS3: false,
+              rowCount: 5,
+              s3RecordCount: null,
+              _count: { datasetRecords: 5 },
+            },
+          ],
+          isLoading: false,
+        }),
+      },
+    },
+  },
+}));
 
 // Mock callbacks
 const mockOnSelectExisting = vi.fn();
 const mockOnUploadCSV = vi.fn();
 const mockOnEditDataset = vi.fn();
 const mockOnSaveAsDataset = vi.fn();
+const mockCloseDrawer = vi.fn();
+const mockOnPickDataset = vi.fn();
 
 // Wrapper with Chakra provider
 const Wrapper = ({ children }: { children: React.ReactNode }) => (
   <ChakraProvider value={defaultSystem}>{children}</ChakraProvider>
 );
+
+/**
+ * The real wiring of the workbench header: choosing to pick an existing
+ * dataset opens the same Choose Dataset drawer the Add button uses. Mirrors
+ * EvaluationsV3Table's datasetHandlers.onSelectExisting.
+ */
+const SwitchableWorkbenchHeader = () => {
+  const [pickerOpen, setPickerOpen] = useState(false);
+  return (
+    <>
+      <DatasetTabs
+        onSelectExisting={() => setPickerOpen(true)}
+        onUploadCSV={mockOnUploadCSV}
+        onEditDataset={mockOnEditDataset}
+        onSaveAsDataset={mockOnSaveAsDataset}
+      />
+      {pickerOpen && (
+        <SelectDatasetDrawer
+          open
+          onClose={() => setPickerOpen(false)}
+          onSelect={mockOnPickDataset}
+        />
+      )}
+    </>
+  );
+};
 
 const renderDatasetTabs = () => {
   return render(
@@ -262,7 +339,7 @@ describe("DatasetTabs user interactions", () => {
     });
   });
 
-  describe("Feature: Switch Dataset from the active tab menu", () => {
+  describe("when the active tab menu is opened", () => {
     /** @scenario Switching to another dataset from the active dataset's menu */
     it("offers Switch Dataset on the active tab's dropdown", async () => {
       const user = userEvent.setup();
@@ -278,9 +355,9 @@ describe("DatasetTabs user interactions", () => {
     });
 
     /** @scenario Switching to another dataset from the active dataset's menu */
-    it("opens the dataset picker when clicking Switch Dataset", async () => {
+    it("opens the Choose Dataset drawer and loads a picked dataset into the workbench on Switch Dataset", async () => {
       const user = userEvent.setup();
-      renderDatasetTabs();
+      render(<SwitchableWorkbenchHeader />, { wrapper: Wrapper });
 
       await user.click(
         screen.getByTestId(`dataset-tab-${DEFAULT_TEST_DATA_ID}`),
@@ -292,7 +369,16 @@ describe("DatasetTabs user interactions", () => {
       await user.click(screen.getByText("Switch Dataset"));
 
       // The same picker the Add button's "Select existing dataset" opens.
-      expect(mockOnSelectExisting).toHaveBeenCalledTimes(1);
+      await waitFor(() => {
+        expect(screen.getByText("Choose Dataset")).toBeInTheDocument();
+      });
+      await user.click(screen.getByText("Production Samples"));
+      expect(mockOnPickDataset).toHaveBeenCalledWith(
+        expect.objectContaining({
+          datasetId: "ds-1",
+          name: "Production Samples",
+        }),
+      );
     });
 
     /** @scenario Switching to another dataset from the active dataset's menu */

--- a/platform/app/src/experiments-v3/__tests__/DatasetTabsInteraction.test.tsx
+++ b/platform/app/src/experiments-v3/__tests__/DatasetTabsInteraction.test.tsx
@@ -262,6 +262,57 @@ describe("DatasetTabs user interactions", () => {
     });
   });
 
+  describe("Feature: Switch Dataset from the active tab menu", () => {
+    /** @scenario Switching to another dataset from the active dataset's menu */
+    it("offers Switch Dataset on the active tab's dropdown", async () => {
+      const user = userEvent.setup();
+      renderDatasetTabs();
+
+      await user.click(
+        screen.getByTestId(`dataset-tab-${DEFAULT_TEST_DATA_ID}`),
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("Switch Dataset")).toBeInTheDocument();
+      });
+    });
+
+    /** @scenario Switching to another dataset from the active dataset's menu */
+    it("opens the dataset picker when clicking Switch Dataset", async () => {
+      const user = userEvent.setup();
+      renderDatasetTabs();
+
+      await user.click(
+        screen.getByTestId(`dataset-tab-${DEFAULT_TEST_DATA_ID}`),
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("Switch Dataset")).toBeInTheDocument();
+      });
+      await user.click(screen.getByText("Switch Dataset"));
+
+      // The same picker the Add button's "Select existing dataset" opens.
+      expect(mockOnSelectExisting).toHaveBeenCalledTimes(1);
+    });
+
+    /** @scenario Switching to another dataset from the active dataset's menu */
+    it("offers Switch Dataset for saved datasets too", async () => {
+      const user = userEvent.setup();
+      const store = useEvaluationsV3Store.getState();
+
+      store.addDataset(createSavedDataset("saved-ds", "Saved Dataset"));
+      store.setActiveDataset("saved-ds");
+
+      renderDatasetTabs();
+
+      await user.click(screen.getByTestId("dataset-tab-saved-ds"));
+
+      await waitFor(() => {
+        expect(screen.getByText("Switch Dataset")).toBeInTheDocument();
+      });
+    });
+  });
+
   describe("Feature: Remove dataset from workbench", () => {
     it("removes dataset when clicking Remove from workbench", async () => {
       const user = userEvent.setup();

--- a/platform/app/src/experiments-v3/components/DatasetSection/DatasetTabs.tsx
+++ b/platform/app/src/experiments-v3/components/DatasetSection/DatasetTabs.tsx
@@ -1,6 +1,7 @@
 import { Box, Button, HStack, Spacer, Text } from "@chakra-ui/react";
 import { generate } from "@langwatch/ksuid";
 import {
+  ArrowLeftRight,
   ChevronDown,
   Database,
   Download,
@@ -25,7 +26,9 @@ type DatasetTabsProps = {
 /**
  * Dataset tabs component for switching between multiple datasets.
  * - Clicking a tab switches to that dataset
- * - Dropdown menu only appears on the active/selected tab
+ * - Dropdown menu only appears on the active/selected tab, offering
+ *   Switch Dataset (the picker), Save as dataset (inline only) and
+ *   Remove from workbench
  * - Shows "Datasets" label with database icon
  */
 export function DatasetTabs({
@@ -111,6 +114,7 @@ export function DatasetTabs({
           dataset={dataset}
           isActive={dataset.id === activeDatasetId}
           onSelect={() => setActiveDataset(dataset.id)}
+          onSwitch={onSelectExisting}
           onRemove={() => handleRemoveDataset(dataset.id)}
           onSaveAs={() => onSaveAsDataset(dataset)}
           canRemove={datasets.length > 1}
@@ -177,6 +181,8 @@ type DatasetTabProps = {
   dataset: DatasetReference;
   isActive: boolean;
   onSelect: () => void;
+  /** Opens the dataset picker; the active tab offers it as "Switch Dataset". */
+  onSwitch: () => void;
   onRemove: () => void;
   onSaveAs: () => void;
   canRemove: boolean;
@@ -186,6 +192,7 @@ function DatasetTab({
   dataset,
   isActive,
   onSelect,
+  onSwitch,
   onRemove,
   onSaveAs,
   canRemove,
@@ -246,6 +253,12 @@ function DatasetTab({
         </Button>
       </Menu.Trigger>
       <Menu.Content minWidth="180px">
+        <Menu.Item value="switch" onClick={onSwitch}>
+          <HStack gap={2}>
+            <ArrowLeftRight size={14} />
+            <Text>Switch Dataset</Text>
+          </HStack>
+        </Menu.Item>
         {dataset.type === "inline" && (
           <Menu.Item value="save" onClick={onSaveAs}>
             <HStack gap={2}>

--- a/platform/app/src/experiments-v3/components/DatasetSection/DatasetTabs.tsx
+++ b/platform/app/src/experiments-v3/components/DatasetSection/DatasetTabs.tsx
@@ -181,7 +181,6 @@ type DatasetTabProps = {
   dataset: DatasetReference;
   isActive: boolean;
   onSelect: () => void;
-  /** Opens the dataset picker; the active tab offers it as "Switch Dataset". */
   onSwitch: () => void;
   onRemove: () => void;
   onSaveAs: () => void;

--- a/specs/experiments-v3/dataset-management.feature
+++ b/specs/experiments-v3/dataset-management.feature
@@ -75,6 +75,16 @@ Feature: Dataset management in evaluations workbench
     When I click on the active "Test Data" tab dropdown
     Then I do NOT see "Remove from workbench" option
 
+  # The active tab's menu is where per-dataset actions live. Before it
+  # offered only save and remove, so pointing the workbench at a different
+  # existing dataset hid behind the Add button's menu.
+  @unit
+  Scenario: Switching to another dataset from the active dataset's menu
+    Given the workbench shows its active dataset tab
+    When I open that tab's dropdown menu
+    Then the menu offers "Switch Dataset"
+    And choosing it opens the dataset picker
+
   # ============================================================================
   # Save as dataset
   # ============================================================================


### PR DESCRIPTION
Before: the active dataset chip's menu offered only "Save as dataset" and "Remove from workbench", so pointing the workbench at a different existing dataset meant knowing to open the separate "+ Add" button's menu. Nothing on the chip itself said switching was possible.

Now the chip's menu leads with **Switch Dataset**, which opens the same dataset picker the Add button uses. It mirrors the Switch Prompt / Switch Evaluator / Switch Agent entries on the target header menus, so both headers in the workbench follow one pattern:

| Menu | Entries |
| --- | --- |
| Target header (prompt) | Edit Prompt, Duplicate, Switch Prompt, Remove from Workbench |
| Active dataset chip | Switch Dataset, Save as dataset (inline only), Remove from workbench |

Switch Dataset shows for inline and saved datasets alike; Save as dataset stays inline-only as before.

## Spec and tests

- `specs/experiments-v3/dataset-management.feature` gains one `@unit` scenario, "Switching to another dataset from the active dataset's menu", bound in `DatasetTabsInteraction.test.tsx`: the menu offers the entry, choosing it calls the picker handler, and the entry appears for saved datasets too.
- Existing 19 interaction tests unchanged and passing; 22 total in the file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Switch Dataset” action to the active dataset tab menu.
  * Opening the action displays the dataset picker, allowing users to select an existing or saved dataset.

* **Tests**
  * Added coverage for switching datasets through the tab menu and dataset picker.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->