### PR TITLE
fix(cli-auth): ask for the code check before showing anything else

### DIFF
--- a/platform/app/src/pages/cli/__tests__/cliAuthFirstTraceRedirect.integration.test.tsx
+++ b/platform/app/src/pages/cli/__tests__/cliAuthFirstTraceRedirect.integration.test.tsx
@@ -221,8 +221,18 @@ describe("/cli/auth first-trace watch", () => {
     mockRouter.query = {};
   });
 
+  // Step one of the screen: the code check gates everything below it.
+  const confirmCode = async () => {
+    const user = userEvent.setup();
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Confirm" })).toBeDefined(),
+    );
+    await user.click(screen.getByRole("button", { name: "Confirm" }));
+  };
+
   const approveDeviceSession = async () => {
     const user = userEvent.setup();
+    await confirmCode();
     await waitFor(() =>
       expect(screen.getByRole("button", { name: "Approve" })).toBeDefined(),
     );
@@ -283,6 +293,7 @@ describe("/cli/auth first-trace watch", () => {
     renderPage();
 
     const user = userEvent.setup();
+    await confirmCode();
     await waitFor(() =>
       expect(
         screen.getByRole("button", { name: "Send API key" }),

--- a/platform/app/src/pages/cli/__tests__/cliAuthKeySelection.integration.test.tsx
+++ b/platform/app/src/pages/cli/__tests__/cliAuthKeySelection.integration.test.tsx
@@ -167,9 +167,12 @@ const serveCliAuthEndpoints = () => {
     async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
       if (url.includes("/api/auth/cli/lookup")) {
+        // Echo the requested code back, so a test can open the screen for a
+        // second code and observe the difference.
+        const echoed = /user_code=([^&]+)/.exec(url)?.[1] ?? "WDJB-MJHT";
         return new Response(
           JSON.stringify({
-            user_code: "WDJB-MJHT",
+            user_code: echoed,
             status: "pending",
             expires_at: Date.now() + 10 * 60_000,
             credential_type: "device_session",
@@ -204,6 +207,23 @@ const renderPage = () =>
 const approveButton = () =>
   screen.getByRole("button", { name: "Approve" }) as HTMLButtonElement;
 
+/**
+ * Step one of the screen: the code check. The organization picker, the
+ * access selection and the approve action do not exist until it passes, so
+ * every flow below confirms the terminal code right after rendering.
+ */
+const confirmCode = async (user: ReturnType<typeof userEvent.setup>) => {
+  await waitFor(() =>
+    expect(screen.getByText("WDJB-MJHT")).toBeInTheDocument(),
+  );
+  await user.click(screen.getByRole("button", { name: "Confirm" }));
+  await waitFor(() =>
+    expect(
+      screen.queryByText(/Confirm this matches the code shown in your/),
+    ).toBeNull(),
+  );
+};
+
 beforeEach(() => {
   fetchMock.mockReset();
   (mockRouter.push as unknown as Mock).mockClear();
@@ -231,6 +251,7 @@ describe("/cli/auth key selection, given an organization admin", () => {
   it("preselects the whole organization and approves with an organization binding", async () => {
     const user = userEvent.setup();
     renderPage();
+    await confirmCode(user);
 
     await waitFor(() =>
       expect(screen.getAllByText("Acme Org").length).toBeGreaterThan(0),
@@ -252,6 +273,7 @@ describe("/cli/auth key selection, given an organization admin", () => {
   it("sends a default permission list without the organization-management set", async () => {
     const user = userEvent.setup();
     renderPage();
+    await confirmCode(user);
 
     await waitFor(() => expect(approveButton().disabled).toBe(false));
     await user.click(approveButton());
@@ -279,6 +301,7 @@ describe("/cli/auth key selection, given an organization admin", () => {
   it("disables the approve action when every scope is deselected", async () => {
     const user = userEvent.setup();
     renderPage();
+    await confirmCode(user);
 
     await waitFor(() => expect(approveButton().disabled).toBe(false));
 
@@ -295,6 +318,7 @@ describe("/cli/auth key selection, given an organization admin", () => {
   it("sends the customized permission list after narrowing traces to read", async () => {
     const user = userEvent.setup();
     renderPage();
+    await confirmCode(user);
 
     await waitFor(() => expect(approveButton().disabled).toBe(false));
     await user.click(screen.getByRole("button", { name: "Customize" }));
@@ -324,6 +348,7 @@ describe("/cli/auth key selection, given a regular member of two shared teams", 
   it("preselects the shared teams plus the personal workspace, not the organization", async () => {
     const user = userEvent.setup();
     renderPage();
+    await confirmCode(user);
 
     await waitFor(() =>
       expect(screen.getAllByText("Engineering").length).toBeGreaterThan(0),
@@ -366,6 +391,7 @@ describe("/cli/auth key selection, given teams the user holds different roles on
   it("sends only the permissions every selected team grants", async () => {
     const user = userEvent.setup();
     renderPage();
+    await confirmCode(user);
 
     await waitFor(() => expect(approveButton().disabled).toBe(false));
     await user.click(approveButton());
@@ -392,6 +418,7 @@ describe("/cli/auth key selection, given teams the user holds different roles on
   it("locks the write level on rows only one team grants", async () => {
     const user = userEvent.setup();
     renderPage();
+    await confirmCode(user);
 
     await waitFor(() => expect(approveButton().disabled).toBe(false));
     await user.click(screen.getByRole("button", { name: "Customize" }));
@@ -404,5 +431,54 @@ describe("/cli/auth key selection, given teams the user holds different roles on
       await screen.findByRole("menuitem", { name: "Read" }),
     ).toBeInTheDocument();
     expect(screen.queryByRole("menuitem", { name: "Write" })).toBeNull();
+  });
+});
+
+describe("/cli/auth code confirmation, given a pending device code", () => {
+  /** @scenario "the screen asks for the code check first" */
+  it("shows only the code and the confirm action before anything else", async () => {
+    renderPage();
+
+    await waitFor(() =>
+      expect(screen.getByText("WDJB-MJHT")).toBeInTheDocument(),
+    );
+    expect(screen.getByRole("button", { name: "Confirm" })).toBeInTheDocument();
+    expect(
+      screen.getByText(/Confirm this matches the code shown in your/),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Approve" })).toBeNull();
+    expect(screen.queryByText("What the CLI can access")).toBeNull();
+  });
+
+  /** @scenario "confirming the code reveals the access selection" */
+  it("hides the code section and shows the access selection after confirming", async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await confirmCode(user);
+
+    expect(screen.queryByText("WDJB-MJHT")).toBeNull();
+    expect(
+      screen.queryByText(/Confirm this matches the code shown in your/),
+    ).toBeNull();
+    expect(screen.getByRole("button", { name: "Approve" })).toBeInTheDocument();
+    expect(screen.getByText("What the CLI can access")).toBeInTheDocument();
+  });
+
+  /** @scenario "a new device code starts the confirmation over" */
+  it("asks for confirmation again when a different code is opened", async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await confirmCode(user);
+    expect(screen.getByRole("button", { name: "Approve" })).toBeInTheDocument();
+
+    cleanup();
+    mockRouter.query = { user_code: "AAAA-BBBB" };
+    renderPage();
+
+    await waitFor(() =>
+      expect(screen.getByText("AAAA-BBBB")).toBeInTheDocument(),
+    );
+    expect(screen.getByRole("button", { name: "Confirm" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Approve" })).toBeNull();
   });
 });

--- a/platform/app/src/pages/cli/__tests__/cliAuthKeySelection.integration.test.tsx
+++ b/platform/app/src/pages/cli/__tests__/cliAuthKeySelection.integration.test.tsx
@@ -197,12 +197,13 @@ const serveCliAuthEndpoints = () => {
   );
 };
 
-const renderPage = () =>
-  render(
-    <ChakraProvider value={defaultSystem}>
-      <CliAuthPage />
-    </ChakraProvider>,
-  );
+const pageElement = () => (
+  <ChakraProvider value={defaultSystem}>
+    <CliAuthPage />
+  </ChakraProvider>
+);
+
+const renderPage = () => render(pageElement());
 
 const approveButton = () =>
   screen.getByRole("button", { name: "Approve" }) as HTMLButtonElement;
@@ -434,51 +435,81 @@ describe("/cli/auth key selection, given teams the user holds different roles on
   });
 });
 
-describe("/cli/auth code confirmation, given a pending device code", () => {
-  /** @scenario "the screen asks for the code check first" */
-  it("shows only the code and the confirm action before anything else", async () => {
-    renderPage();
+describe("/cli/auth code confirmation", () => {
+  describe("given a pending device code", () => {
+    describe("when the page opens", () => {
+      /** @scenario "the screen asks for the code check first" */
+      it("shows only the code and the confirm action before anything else", async () => {
+        renderPage();
 
-    await waitFor(() =>
-      expect(screen.getByText("WDJB-MJHT")).toBeInTheDocument(),
-    );
-    expect(screen.getByRole("button", { name: "Confirm" })).toBeInTheDocument();
-    expect(
-      screen.getByText(/Confirm this matches the code shown in your/),
-    ).toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Approve" })).toBeNull();
-    expect(screen.queryByText("What the CLI can access")).toBeNull();
-  });
+        await waitFor(() =>
+          expect(screen.getByText("WDJB-MJHT")).toBeInTheDocument(),
+        );
+        expect(
+          screen.getByRole("button", { name: "Confirm" }),
+        ).toBeInTheDocument();
+        expect(
+          screen.getByText(/Confirm this matches the code shown in your/),
+        ).toBeInTheDocument();
+        expect(screen.queryByRole("button", { name: "Approve" })).toBeNull();
+        expect(screen.queryByText("What the CLI can access")).toBeNull();
+      });
+    });
 
-  /** @scenario "confirming the code reveals the access selection" */
-  it("hides the code section and shows the access selection after confirming", async () => {
-    const user = userEvent.setup();
-    renderPage();
-    await confirmCode(user);
+    describe("when the user confirms the code", () => {
+      /** @scenario "confirming the code reveals the access selection" */
+      it("hides the code section and shows the access selection", async () => {
+        const user = userEvent.setup();
+        renderPage();
+        await confirmCode(user);
 
-    expect(screen.queryByText("WDJB-MJHT")).toBeNull();
-    expect(
-      screen.queryByText(/Confirm this matches the code shown in your/),
-    ).toBeNull();
-    expect(screen.getByRole("button", { name: "Approve" })).toBeInTheDocument();
-    expect(screen.getByText("What the CLI can access")).toBeInTheDocument();
-  });
+        expect(screen.queryByText("WDJB-MJHT")).toBeNull();
+        expect(
+          screen.queryByText(/Confirm this matches the code shown in your/),
+        ).toBeNull();
+        expect(
+          screen.getByRole("button", { name: "Approve" }),
+        ).toBeInTheDocument();
+        expect(screen.getByText("What the CLI can access")).toBeInTheDocument();
+      });
+    });
 
-  /** @scenario "a new device code starts the confirmation over" */
-  it("asks for confirmation again when a different code is opened", async () => {
-    const user = userEvent.setup();
-    renderPage();
-    await confirmCode(user);
-    expect(screen.getByRole("button", { name: "Approve" })).toBeInTheDocument();
+    describe("when a different code is opened in the same tab", () => {
+      beforeEach(() => {
+        bindingsRef.current = [
+          { scopeType: "ORGANIZATION", scopeId: "org-1", role: "ADMIN" },
+        ];
+      });
 
-    cleanup();
-    mockRouter.query = { user_code: "AAAA-BBBB" };
-    renderPage();
+      /** @scenario "a new device code starts the confirmation over" */
+      it("returns to the confirmation step with no trace of the old flow", async () => {
+        const user = userEvent.setup();
+        const view = renderPage();
+        await confirmCode(user);
 
-    await waitFor(() =>
-      expect(screen.getByText("AAAA-BBBB")).toBeInTheDocument(),
-    );
-    expect(screen.getByRole("button", { name: "Confirm" })).toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Approve" })).toBeNull();
+        // The old code runs its whole course first: approve reaches the
+        // success screen, so the reset below has real finished state to clear.
+        await waitFor(() => expect(approveButton().disabled).toBe(false));
+        await user.click(approveButton());
+        await waitFor(() =>
+          expect(screen.getByText("You're signed in!")).toBeInTheDocument(),
+        );
+
+        mockRouter.query = { user_code: "AAAA-BBBB" };
+        view.rerender(pageElement());
+
+        await waitFor(() =>
+          expect(screen.getByText("AAAA-BBBB")).toBeInTheDocument(),
+        );
+        expect(
+          screen.getByRole("button", { name: "Confirm" }),
+        ).toBeInTheDocument();
+        expect(screen.queryByRole("button", { name: "Approve" })).toBeNull();
+        expect(screen.queryByText("You're signed in!")).toBeNull();
+        expect(
+          screen.queryByText(/Confirm this matches the code shown in your/),
+        ).toBeInTheDocument();
+      });
+    });
   });
 });

--- a/platform/app/src/pages/cli/__tests__/cliAuthProjectPicker.integration.test.tsx
+++ b/platform/app/src/pages/cli/__tests__/cliAuthProjectPicker.integration.test.tsx
@@ -174,9 +174,12 @@ const serveCliAuthEndpoints = () => {
     async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
       if (url.includes("/api/auth/cli/lookup")) {
+        // Echo the requested code back, so a test can open the screen for a
+        // second code and observe the difference.
+        const echoed = /user_code=([^&]+)/.exec(url)?.[1] ?? "WDJB-MJHT";
         return new Response(
           JSON.stringify({
-            user_code: "WDJB-MJHT",
+            user_code: echoed,
             status: "pending",
             expires_at: Date.now() + 10 * 60_000,
             credential_type: "project_api_key",
@@ -211,6 +214,25 @@ const renderPage = () =>
 const approveButton = () =>
   screen.getByRole("button", { name: "Send API key" }) as HTMLButtonElement;
 
+/**
+ * Step one of the screen: the code check. The project picker and the send
+ * action do not exist until it passes, so every flow below confirms the
+ * terminal code right after rendering.
+ */
+const confirmCode = async (user: ReturnType<typeof userEvent.setup>) => {
+  await waitFor(() =>
+    expect(screen.getByText("WDJB-MJHT")).toBeInTheDocument(),
+  );
+  await user.click(screen.getByRole("button", { name: "Confirm" }));
+  await waitFor(() =>
+    expect(
+      screen.queryByText(
+        "Confirm this matches the code shown in your terminal.",
+      ),
+    ).toBeNull(),
+  );
+};
+
 beforeEach(() => {
   fetchMock.mockReset();
   (mockRouter.push as unknown as Mock).mockClear();
@@ -234,7 +256,9 @@ describe("/cli/auth project picker, given an organization with no shared project
 
   /** @scenario a user with no shared projects gets their personal project preselected */
   it("preselects the personal project, explains it, and enables the approve button", async () => {
+    const user = userEvent.setup();
     renderPage();
+    await confirmCode(user);
 
     await waitFor(() =>
       expect(screen.getAllByText("Personal Workspace").length).toBeGreaterThan(
@@ -251,6 +275,7 @@ describe("/cli/auth project picker, given an organization with no shared project
   it("offers Create project, passes the picked org, and adopts the created project", async () => {
     const user = userEvent.setup();
     renderPage();
+    await confirmCode(user);
 
     await waitFor(() =>
       expect(
@@ -291,6 +316,7 @@ describe("/cli/auth project picker, given an organization with no shared project
   it("approves with the preselected personal project id", async () => {
     const user = userEvent.setup();
     renderPage();
+    await confirmCode(user);
 
     await waitFor(() =>
       expect(screen.getAllByText("Personal Workspace").length).toBeGreaterThan(
@@ -321,6 +347,7 @@ describe("/cli/auth project picker, given a switched-to organization whose proje
       ]),
     ];
     renderPage();
+    await confirmCode(user);
     // Two orgs render the org chooser; move onto the org under test. Its
     // offered projects cannot match the ambient project (Home Org's), so
     // the picker legitimately starts with nothing selected.

--- a/platform/app/src/pages/cli/auth.tsx
+++ b/platform/app/src/pages/cli/auth.tsx
@@ -544,6 +544,10 @@ export default function CliAuthPage() {
     if (!selectedOrgId || !userCode) return;
     if (requiresProject && !selectedProjectId) return;
     if (isDeviceSessionSelectionIncomplete) return;
+    // Same binding as the render gates, restated on the action itself: the
+    // approval may only go out for the code the user confirmed.
+    if (lookup.kind !== "ready" || lookup.userCode !== userCode) return;
+    if (confirmedUserCode !== userCode) return;
     setAction({ kind: "submitting" });
     try {
       const r = await fetch("/api/auth/cli/approve", {
@@ -630,12 +634,17 @@ export default function CliAuthPage() {
       : `Expires in ${seconds}s`;
   }, [lookup]);
 
+  // Every gate binds to userCode, not just to the lookup: the reset effect
+  // runs after paint, so a route change first renders with the previous
+  // code's lookup and confirmation. Comparing against userCode here keeps
+  // that render from showing either step.
   const isApprovalReady =
     lookup.kind === "ready" &&
+    lookup.userCode === userCode &&
     action.kind !== "success" &&
     action.kind !== "denied";
   const isCodeConfirmed =
-    lookup.kind === "ready" && confirmedUserCode === lookup.userCode;
+    lookup.kind === "ready" && confirmedUserCode === userCode;
 
   if (sessionStatus === "loading" || (!session && userCode)) {
     return <FullPageSpinner />;

--- a/platform/app/src/pages/cli/auth.tsx
+++ b/platform/app/src/pages/cli/auth.tsx
@@ -6,17 +6,18 @@
  *   2. CLI prints: "Open https://app.langwatch.com/cli/auth?user_code=WDJB-MJHT"
  *   3. User clicks → lands here. If unauthenticated, gets bounced through SSO.
  *   4. Page calls GET /api/auth/cli/lookup to verify the code is still pending.
- *   5. User picks an organization (if they're in multiple), reviews what the
+ *   5. User confirms the code matches the one in their terminal.
+ *   6. User picks an organization (if they're in multiple), reviews what the
  *      CLI key will be able to access (scopes + permissions, preselected to
  *      the widest access they hold minus organization management), and clicks
  *      "Approve".
- *   6. Page calls POST /api/auth/cli/approve which:
+ *   7. Page calls POST /api/auth/cli/approve which:
  *        a. Mints (or returns existing) personal VK
  *        b. Flips the device-code record to `approved` with the VK secret and
  *           the reviewed `key_selection` (scopes + permissions); the exchange
  *           endpoint mints the user-scoped CLI key from it
- *   7. CLI's polling /exchange returns 200 with the secret on its next poll.
- *   8. Done, user closes the browser tab.
+ *   8. CLI's polling /exchange returns 200 with the secret on its next poll.
+ *   9. Done, user closes the browser tab.
  *
  * Mirrors the screens-1-thru-4 storyboard in gateway.md.
  */
@@ -208,8 +209,20 @@ export default function CliAuthPage() {
   // Step one of the screen: the code check. The organization picker, the
   // access selection and the approve action only appear once the user
   // confirms the code matches their terminal, so the phishing check is not
-  // one card among many but the gate to the rest of the page.
-  const [isCodeConfirmed, setIsCodeConfirmed] = useState(false);
+  // one card among many but the gate to the rest of the page. Confirmed as a
+  // value rather than a flag: step two only opens when the confirmed code is
+  // still the code being looked at.
+  const [confirmedUserCode, setConfirmedUserCode] = useState<string | null>(
+    null,
+  );
+
+  // A second login opened in this tab replaces the whole flow: any finished
+  // approve/deny outcome and the previous lookup belong to the old code.
+  useEffect(() => {
+    setConfirmedUserCode(null);
+    setAction({ kind: "idle" });
+    setLookup({ kind: "loading" });
+  }, [userCode]);
 
   // Auto-pick the first org if there's only one. The chooser is only
   // necessary when the user is in 2+.
@@ -316,9 +329,6 @@ export default function CliAuthPage() {
   // Look up the device code once we have a session.
   useEffect(() => {
     if (!session || !userCode) return;
-    // A fresh code always starts at the confirmation step, even when the
-    // page is reused for a second login in the same tab.
-    setIsCodeConfirmed(false);
     let cancelled = false;
     void (async () => {
       try {
@@ -624,6 +634,8 @@ export default function CliAuthPage() {
     lookup.kind === "ready" &&
     action.kind !== "success" &&
     action.kind !== "denied";
+  const isCodeConfirmed =
+    lookup.kind === "ready" && confirmedUserCode === lookup.userCode;
 
   if (sessionStatus === "loading" || (!session && userCode)) {
     return <FullPageSpinner />;
@@ -725,7 +737,11 @@ export default function CliAuthPage() {
                 <Button
                   colorPalette="orange"
                   flex={1}
-                  onClick={() => setIsCodeConfirmed(true)}
+                  onClick={() => {
+                    if (lookup.kind === "ready") {
+                      setConfirmedUserCode(lookup.userCode);
+                    }
+                  }}
                 >
                   Confirm
                 </Button>

--- a/platform/app/src/pages/cli/auth.tsx
+++ b/platform/app/src/pages/cli/auth.tsx
@@ -205,6 +205,11 @@ export default function CliAuthPage() {
   const [permissionSelections, setPermissionSelections] = useState<
     Record<string, PermissionSelection>
   >({});
+  // Step one of the screen: the code check. The organization picker, the
+  // access selection and the approve action only appear once the user
+  // confirms the code matches their terminal, so the phishing check is not
+  // one card among many but the gate to the rest of the page.
+  const [isCodeConfirmed, setIsCodeConfirmed] = useState(false);
 
   // Auto-pick the first org if there's only one. The chooser is only
   // necessary when the user is in 2+.
@@ -311,6 +316,9 @@ export default function CliAuthPage() {
   // Look up the device code once we have a session.
   useEffect(() => {
     if (!session || !userCode) return;
+    // A fresh code always starts at the confirmation step, even when the
+    // page is reused for a second login in the same tab.
+    setIsCodeConfirmed(false);
     let cancelled = false;
     void (async () => {
       try {
@@ -612,6 +620,11 @@ export default function CliAuthPage() {
       : `Expires in ${seconds}s`;
   }, [lookup]);
 
+  const isApprovalReady =
+    lookup.kind === "ready" &&
+    action.kind !== "success" &&
+    action.kind !== "denied";
+
   if (sessionStatus === "loading" || (!session && userCode)) {
     return <FullPageSpinner />;
   }
@@ -677,260 +690,272 @@ export default function CliAuthPage() {
             </>
           )}
 
-          {lookup.kind === "ready" &&
-            action.kind !== "success" &&
-            action.kind !== "denied" && (
-              <>
-                <Text textStyle="sm" color="fg.muted" lineHeight="tall">
-                  {requiresProject
-                    ? "Pick a project, its API key flows back to your terminal automatically, with no copy-paste."
-                    : "Approving signs in this device for AI-tool wrappers (Claude, Codex, etc.) and governance commands."}
-                </Text>
-                <Box
-                  bg="bg.subtle"
-                  borderWidth="1px"
-                  borderColor="border.muted"
-                  borderRadius="lg"
-                  p={4}
-                  fontFamily="mono"
-                  fontSize="2xl"
-                  fontWeight="bold"
-                  textAlign="center"
-                  letterSpacing="0.2em"
-                  color="fg"
+          {isApprovalReady && !isCodeConfirmed && (
+            <>
+              <Text textStyle="sm" color="fg.muted" lineHeight="tall">
+                {requiresProject
+                  ? "Pick a project, its API key flows back to your terminal automatically, with no copy-paste."
+                  : "Approving signs in this device for AI-tool wrappers (Claude, Codex, etc.) and governance commands."}
+              </Text>
+              <Box
+                bg="bg.subtle"
+                borderWidth="1px"
+                borderColor="border.muted"
+                borderRadius="lg"
+                p={4}
+                fontFamily="mono"
+                fontSize="2xl"
+                fontWeight="bold"
+                textAlign="center"
+                letterSpacing="0.2em"
+                color="fg"
+              >
+                {lookup.userCode}
+              </Box>
+              <Text textStyle="xs" color="fg.muted" textAlign="center">
+                Confirm this matches the code shown in your terminal.
+                {expiryText ? (
+                  <>
+                    <br />
+                    {expiryText}.
+                  </>
+                ) : null}
+              </Text>
+              <Stack direction={{ base: "column", sm: "row" }} gap={3}>
+                <Button
+                  colorPalette="orange"
+                  flex={1}
+                  onClick={() => setIsCodeConfirmed(true)}
                 >
-                  {lookup.userCode}
-                </Box>
-                <Text textStyle="xs" color="fg.muted" textAlign="center">
-                  Confirm this matches the code shown in your terminal.
-                  {expiryText ? (
-                    <>
-                      <br />
-                      {expiryText}.
-                    </>
-                  ) : null}
-                </Text>
+                  Confirm
+                </Button>
+                <Button
+                  variant="outline"
+                  color="fg.muted"
+                  borderColor="border.emphasized"
+                  onClick={handleDeny}
+                  loading={action.kind === "submitting"}
+                >
+                  Deny
+                </Button>
+              </Stack>
+            </>
+          )}
 
-                {organizations && organizations.length > 1 && (
+          {isApprovalReady && isCodeConfirmed && (
+            <>
+              {organizations && organizations.length > 1 && (
+                <Box>
+                  <Text textStyle="sm" fontWeight="semibold" color="fg" mb={2}>
+                    Organization
+                  </Text>
+                  <VStack align="stretch" gap={2}>
+                    {organizations.map((org) => (
+                      <Button
+                        key={org.id}
+                        size="sm"
+                        colorPalette={
+                          selectedOrgId === org.id ? "orange" : "gray"
+                        }
+                        variant={
+                          selectedOrgId === org.id ? "surface" : "outline"
+                        }
+                        onClick={() => setSelectedOrgId(org.id)}
+                        justifyContent="flex-start"
+                      >
+                        {org.name}
+                      </Button>
+                    ))}
+                  </VStack>
+                </Box>
+              )}
+
+              {requiresProject && (
+                <Box>
+                  <HStack mb={2} justify="space-between" align="center">
+                    <Text textStyle="sm" fontWeight="semibold" color="fg">
+                      Project
+                    </Text>
+                    <Button
+                      size="xs"
+                      variant="ghost"
+                      color="fg.muted"
+                      onClick={() => setCreateProjectOpen(true)}
+                    >
+                      <Icon as={Plus} boxSize={3.5} />
+                      Create project
+                    </Button>
+                  </HStack>
+                  {offeredProjects.length === 0 ? (
+                    <StatusCard
+                      palette="orange"
+                      icon={CircleAlert}
+                      title="No projects yet"
+                    >
+                      Create a project in this organization first, then pick it
+                      here; the key flows back to your terminal automatically.
+                    </StatusCard>
+                  ) : (
+                    <>
+                      <ScopeChipPicker
+                        variant="single-select"
+                        label=""
+                        placeholder="None selected"
+                        allowedScopeTypes={["PROJECT"]}
+                        organizationId={selectedOrgId ?? undefined}
+                        availableProjects={offeredProjects}
+                        availableTeams={teamsForOrg}
+                        value={
+                          selectedProjectId
+                            ? [
+                                {
+                                  scopeType: "PROJECT",
+                                  scopeId: selectedProjectId,
+                                },
+                              ]
+                            : []
+                        }
+                        onChange={(next) =>
+                          setSelectedProjectId(next[0]?.scopeId ?? null)
+                        }
+                        showSummary={false}
+                      />
+                      {projectsForOrg.length === 0 &&
+                        personalProject &&
+                        selectedProjectId === personalProject.id && (
+                          <Text textStyle="xs" color="fg.muted" mt={1.5}>
+                            No shared projects in this organization yet, so your
+                            personal project is preselected. Only you can read
+                            what lands there.
+                          </Text>
+                        )}
+                    </>
+                  )}
+                </Box>
+              )}
+
+              {!requiresProject && (
+                <>
                   <Box>
                     <Text
                       textStyle="sm"
                       fontWeight="semibold"
                       color="fg"
-                      mb={2}
+                      mb={1}
                     >
-                      Organization
+                      What the CLI can access
                     </Text>
-                    <VStack align="stretch" gap={2}>
-                      {organizations.map((org) => (
-                        <Button
-                          key={org.id}
-                          size="sm"
-                          colorPalette={
-                            selectedOrgId === org.id ? "orange" : "gray"
-                          }
-                          variant={
-                            selectedOrgId === org.id ? "surface" : "outline"
-                          }
-                          onClick={() => setSelectedOrgId(org.id)}
-                          justifyContent="flex-start"
-                        >
-                          {org.name}
-                        </Button>
-                      ))}
-                    </VStack>
+                    <Text textStyle="xs" color="fg.muted" mb={2}>
+                      The key works inside these scopes, always limited to your
+                      own access.
+                    </Text>
+                    {myBindings.isLoading ? (
+                      <HStack>
+                        <Spinner size="sm" />
+                        <Text textStyle="sm" color="fg.muted">
+                          Loading your access…
+                        </Text>
+                      </HStack>
+                    ) : (
+                      <ScopeChipPicker
+                        value={selectedScopes}
+                        onChange={setSelectedScopes}
+                        organizationId={selectedOrgId ?? undefined}
+                        organizationName={selectedOrgName}
+                        availableTeams={sharedTeams}
+                        availableProjects={offeredProjects}
+                        label=""
+                        showSummary={false}
+                      />
+                    )}
+                    {!myBindings.isLoading &&
+                      selectedScopes.length === 0 &&
+                      !hasAnyScopeToOffer && (
+                        <Text textStyle="xs" color="orange.fg" mt={2}>
+                          Your account holds no access in this organization, so
+                          there is nothing to give the CLI. Ask an administrator
+                          to add you to a team, then run{" "}
+                          <code>langwatch login</code> again.
+                        </Text>
+                      )}
                   </Box>
-                )}
 
-                {requiresProject && (
                   <Box>
-                    <HStack mb={2} justify="space-between" align="center">
+                    <HStack justify="space-between" align="center" mb={1}>
                       <Text textStyle="sm" fontWeight="semibold" color="fg">
-                        Project
+                        Permissions
                       </Text>
                       <Button
                         size="xs"
                         variant="ghost"
                         color="fg.muted"
-                        onClick={() => setCreateProjectOpen(true)}
+                        onClick={handleToggleCustomizePermissions}
                       >
-                        <Icon as={Plus} boxSize={3.5} />
-                        Create project
+                        {arePermissionsCustomized ? "Use default" : "Customize"}
                       </Button>
                     </HStack>
-                    {offeredProjects.length === 0 ? (
-                      <StatusCard
-                        palette="orange"
-                        icon={CircleAlert}
-                        title="No projects yet"
-                      >
-                        Create a project in this organization first, then pick
-                        it here; the key flows back to your terminal
-                        automatically.
-                      </StatusCard>
-                    ) : (
-                      <>
-                        <ScopeChipPicker
-                          variant="single-select"
-                          label=""
-                          placeholder="None selected"
-                          allowedScopeTypes={["PROJECT"]}
-                          organizationId={selectedOrgId ?? undefined}
-                          availableProjects={offeredProjects}
-                          availableTeams={teamsForOrg}
-                          value={
-                            selectedProjectId
-                              ? [
-                                  {
-                                    scopeType: "PROJECT",
-                                    scopeId: selectedProjectId,
-                                  },
-                                ]
-                              : []
-                          }
-                          onChange={(next) =>
-                            setSelectedProjectId(next[0]?.scopeId ?? null)
-                          }
-                          showSummary={false}
+                    {arePermissionsCustomized ? (
+                      <VStack align="stretch" gap={2}>
+                        <PermissionCounter count={cliKeyPermissions.length} />
+                        <PermissionCategoryList
+                          selections={effectivePermissionSelections}
+                          userPermissions={cliKeyUserPermissions}
+                          onChange={setPermissionSelections}
                         />
-                        {projectsForOrg.length === 0 &&
-                          personalProject &&
-                          selectedProjectId === personalProject.id && (
-                            <Text textStyle="xs" color="fg.muted" mt={1.5}>
-                              No shared projects in this organization yet, so
-                              your personal project is preselected. Only you can
-                              read what lands there.
-                            </Text>
-                          )}
-                      </>
-                    )}
-                  </Box>
-                )}
-
-                {!requiresProject && (
-                  <>
-                    <Box>
-                      <Text
-                        textStyle="sm"
-                        fontWeight="semibold"
-                        color="fg"
-                        mb={1}
-                      >
-                        What the CLI can access
-                      </Text>
-                      <Text textStyle="xs" color="fg.muted" mb={2}>
-                        The key works inside these scopes, always limited to
-                        your own access.
-                      </Text>
-                      {myBindings.isLoading ? (
-                        <HStack>
-                          <Spinner size="sm" />
-                          <Text textStyle="sm" color="fg.muted">
-                            Loading your access…
-                          </Text>
-                        </HStack>
-                      ) : (
-                        <ScopeChipPicker
-                          value={selectedScopes}
-                          onChange={setSelectedScopes}
-                          organizationId={selectedOrgId ?? undefined}
-                          organizationName={selectedOrgName}
-                          availableTeams={sharedTeams}
-                          availableProjects={offeredProjects}
-                          label=""
-                          showSummary={false}
-                        />
-                      )}
-                      {!myBindings.isLoading &&
-                        selectedScopes.length === 0 &&
-                        !hasAnyScopeToOffer && (
-                          <Text textStyle="xs" color="orange.fg" mt={2}>
-                            Your account holds no access in this organization,
-                            so there is nothing to give the CLI. Ask an
-                            administrator to add you to a team, then run{" "}
-                            <code>langwatch login</code> again.
+                        {cliKeyPermissions.length === 0 && (
+                          <Text textStyle="xs" color="fg.muted">
+                            Select at least one permission to approve.
                           </Text>
                         )}
-                    </Box>
+                      </VStack>
+                    ) : (
+                      <Text textStyle="xs" color="fg.muted" lineHeight="tall">
+                        The key gets your access for everyday work: traces,
+                        datasets, prompts, evaluations, the AI Gateway, and
+                        project settings. It cannot manage members and roles, or
+                        manage the organization.
+                      </Text>
+                    )}
+                  </Box>
+                </>
+              )}
 
-                    <Box>
-                      <HStack justify="space-between" align="center" mb={1}>
-                        <Text textStyle="sm" fontWeight="semibold" color="fg">
-                          Permissions
-                        </Text>
-                        <Button
-                          size="xs"
-                          variant="ghost"
-                          color="fg.muted"
-                          onClick={handleToggleCustomizePermissions}
-                        >
-                          {arePermissionsCustomized
-                            ? "Use default"
-                            : "Customize"}
-                        </Button>
-                      </HStack>
-                      {arePermissionsCustomized ? (
-                        <VStack align="stretch" gap={2}>
-                          <PermissionCounter count={cliKeyPermissions.length} />
-                          <PermissionCategoryList
-                            selections={effectivePermissionSelections}
-                            userPermissions={cliKeyUserPermissions}
-                            onChange={setPermissionSelections}
-                          />
-                          {cliKeyPermissions.length === 0 && (
-                            <Text textStyle="xs" color="fg.muted">
-                              Select at least one permission to approve.
-                            </Text>
-                          )}
-                        </VStack>
-                      ) : (
-                        <Text textStyle="xs" color="fg.muted" lineHeight="tall">
-                          The key gets your access for everyday work: traces,
-                          datasets, prompts, evaluations, the AI Gateway, and
-                          project settings. It cannot manage members and roles,
-                          or manage the organization.
-                        </Text>
-                      )}
-                    </Box>
-                  </>
-                )}
+              {action.kind === "error" && (
+                <StatusCard
+                  palette="red"
+                  icon={TriangleAlert}
+                  title="Approval failed"
+                >
+                  {action.message}
+                </StatusCard>
+              )}
 
-                {action.kind === "error" && (
-                  <StatusCard
-                    palette="red"
-                    icon={TriangleAlert}
-                    title="Approval failed"
-                  >
-                    {action.message}
-                  </StatusCard>
-                )}
-
-                <Stack direction={{ base: "column", sm: "row" }} gap={3}>
-                  <Button
-                    colorPalette="orange"
-                    flex={1}
-                    onClick={handleApprove}
-                    loading={action.kind === "submitting"}
-                    disabled={
-                      !selectedOrgId ||
-                      (requiresProject && !selectedProjectId) ||
-                      isDeviceSessionSelectionIncomplete
-                    }
-                  >
-                    {requiresProject ? "Send API key" : "Approve"}
-                  </Button>
-                  <Button
-                    variant="outline"
-                    color="fg.muted"
-                    borderColor="border.emphasized"
-                    onClick={handleDeny}
-                    loading={action.kind === "submitting"}
-                  >
-                    Deny
-                  </Button>
-                </Stack>
-              </>
-            )}
+              <Stack direction={{ base: "column", sm: "row" }} gap={3}>
+                <Button
+                  colorPalette="orange"
+                  flex={1}
+                  onClick={handleApprove}
+                  loading={action.kind === "submitting"}
+                  disabled={
+                    !selectedOrgId ||
+                    (requiresProject && !selectedProjectId) ||
+                    isDeviceSessionSelectionIncomplete
+                  }
+                >
+                  {requiresProject ? "Send API key" : "Approve"}
+                </Button>
+                <Button
+                  variant="outline"
+                  color="fg.muted"
+                  borderColor="border.emphasized"
+                  onClick={handleDeny}
+                  loading={action.kind === "submitting"}
+                >
+                  Deny
+                </Button>
+              </Stack>
+            </>
+          )}
 
           {action.kind === "success" && (
             <>

--- a/specs/ai-governance/cli-onboarding/login-user-scoped-key.feature
+++ b/specs/ai-governance/cli-onboarding/login-user-scoped-key.feature
@@ -29,6 +29,29 @@ Feature: CLI login mints a user-scoped API key that inherits the user's permissi
   # Authorize screen defaults
   # ─────────────────────────────────────────────────────────────────────
 
+  Rule: the code is confirmed before anything else is shown
+
+    @integration
+    Scenario: the screen asks for the code check first
+      Given the user opened the authorize screen for the device code
+      Then the screen shows only the code, the confirmation question and the
+        confirm action
+      And the organization picker, the access selection and the approve
+        action are not shown yet
+
+    @integration
+    Scenario: confirming the code reveals the access selection
+      When the user confirms the code matches the one in their terminal
+      Then the code section goes away
+      And the organization picker, the access selection and the approve
+        action are shown
+
+    @integration
+    Scenario: a new device code starts the confirmation over
+      Given the user confirmed one device code
+      When the screen is opened for a different device code
+      Then the confirmation is asked again before anything else is shown
+
   Rule: the authorize screen preselects the widest scope the user holds
 
     @integration


### PR DESCRIPTION
## What

The CLI authorize screen (`/cli/auth`) opened with the device code, the confirmation question, the organization picker, the access selection and the approve action all on one page, which read as one tall wall of decisions. The code check is now step one, and everything else is step two.

- **Step 1** shows only the code, "Confirm this matches the code shown in your terminal." with the expiry, a **Confirm** button and **Deny**. Deny stays on this step on purpose: refusing a code you do not recognize is the point of the check, and now it is the first thing on the page rather than the last.
- **Step 2**, after confirming, shows the organization picker, "What the CLI can access" and the permission summary, with Approve and Deny. The code section goes away entirely.
- A fresh device code opened in the same tab starts the confirmation over, so a second login can never inherit a confirmation meant for the first code.

No API changes: approve, deny, lookup and exchange behave exactly as before. This is a presentation split of the same page.

## Specs

- `specs/ai-governance/cli-onboarding/login-user-scoped-key.feature`: new rule "the code is confirmed before anything else is shown" with 3 scenarios (24/24 bound in the file).

## QA (dogfooded in a real browser on a local stack)

Walked the device flow end to end as a logged-in org admin: step 1 shows only the code and the confirm action (verified in the DOM: no Approve, no organization heading, no access heading), Confirm reveals step 2 with the code section gone, Approve completes the login and the exchange returns the user-scoped `cli_api_key` with the organization scope. A second device code in the same tab asks for confirmation again before showing anything else.

Step 1, the code check:

![step 1](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-7531/two-step/step-1-confirm-code.png)

Step 2, after confirming:

![step 2](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-7531/two-step/step-2-access.png)

## Test plan

- [x] `pnpm test:component` on the three `/cli/auth` suites (19 tests): every existing flow now passes the gate, plus 3 new tests binding the new scenarios (only the code shows before confirming; confirming reveals the selection and hides the code; a new code restarts the confirmation)
- [x] `pnpm typecheck`, `pnpm typecheck:all`
- [x] biome new-violations gate: the touched files carry exactly the same diagnostics as on main
- [x] feature parity: 24/24 scenarios bound in the touched feature file


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a confirmation step to the CLI authorization flow, requiring users to verify the displayed code matches their terminal.
  - Access, project, organization, scope, and permission options remain hidden until confirmation.
  - Confirmation is required again when opening a different device code.
  - Denial remains available from the confirmation screen.

- **Bug Fixes**
  - Approval controls are now hidden after authorization is approved or denied, preventing unintended follow-up actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->