### PR TITLE
fix(haven): the TypeScript compiler is governed under both of its names

### DIFF
--- a/dev/docs/adr/095-haven-tsgo-governor.md
+++ b/dev/docs/adr/095-haven-tsgo-governor.md
@@ -107,6 +107,32 @@ Every kill is logged with the reason, class, RSS and age, and counted in the
 kill metric by reason — so "did the Prisma 7 upgrade make types cheaper" is
 answered from the recorded per-class footprint history rather than a hunch.
 
+## Amendment (2026-08-25): the compiler answers to two names
+
+TypeScript 7 shipped as the `typescript` package and **renamed the native
+binary from `tsgo` to `tsc`** (`lib/getExePath.js` picks the name from the
+package it was published in; `lib/tsc.js` then `execve()`s it, so the live
+process image IS the compiler and its argv[0] ends in `/tsc`). The governor
+selected on `binaryBase(command) == "tsgo"`, so on a machine that had moved to
+typescript@7 it selected **nothing**: no per-run ceiling, no combined budget,
+no runaway reclamation, and the compiler did not even reach the dev-tooling
+dashboards, because it matched no watched class either.
+
+The selection rule is now name-neutral — `domain.IsTypeScriptCompilerCommand`
+accepts `tsc` and `tsgo`, still matched on the binary's base name and never on
+the args — and both land in the **same** watched class, so one compiler is one
+budget however it was installed. Nothing above changes: the knobs keep their
+`HAVEN_TSGO_*` names, the class attribute and the reap Kind stay spelled
+`tsgo`, and a machine still running the preview package (or a local build of
+the TypeScript repo, which still produces `tsgo`) behaves exactly as before.
+Splitting the two names into two classes was rejected for the same reason:
+each half of a machine's compilers would then be weighed against the whole
+budget, and the recorded history would be cut in two.
+
+`haven gate` gained the compiler by binary name rather than by substring —
+`tsc` is a substring of `tsconfig.json`, and a gate that queues `cat` is its
+own outage. See ADR-099 for the compiler move itself.
+
 ## Consequences
 
 - No spawn path can take the machine down: unshimmed binaries, editors and
@@ -131,5 +157,6 @@ answered from the recorded per-class footprint history rather than a hunch.
 
 - ADR-090 — machine-wide resource governance (pressure, demotion, no kills for stacks)
 - ADR-091 — haven gate (agent-session admission)
+- ADR-099 — TypeScript 7 is the compiler (the rename this governor was amended for)
 - `specs/setup/haven-tsgo-governor.feature` — the behavioural contract
 - `specs/setup/check-slots.feature` — the whole-tree check queue this backstops

--- a/specs/setup/check-slots.feature
+++ b/specs/setup/check-slots.feature
@@ -4,7 +4,7 @@ Feature: Machine-wide slots for whole-repo checks
   So that N parallel checks never take the machine down, and a slow one
   explains itself instead of looking hung
 
-  # Both checks saturate the machine on purpose. A tsgo run peaks around 3 to 4
+  # Both checks saturate the machine on purpose. A typecheck peaks around 3 to 4
   # GiB and uses every core; a biome run over 6,800 files spends 38 CPU-seconds
   # in 4 seconds of wall clock. That is the right trade for one run, and capping
   # either tool's threads only stretches the same CPU cost over 5x the wall
@@ -256,11 +256,15 @@ Feature: Machine-wide slots for whole-repo checks
   # --- The bin shims: the package scripts are not the only way in ---
 
   # Wrapping the scripts left every other route to the binary uncounted, and
-  # they get used: `pnpm exec tsgo --noEmit -p tsconfig.tsgo.json`,
-  # `./node_modules/.bin/tsgo`, and the standing advice to iterate with
+  # they get used: `pnpm exec tsc --noEmit -p tsconfig.tsgo.json`,
+  # `./node_modules/.bin/tsc`, and the standing advice to iterate with
   # targeted checks, widened to the whole project. Observed in the wild as
-  # three tsgo processes on an 18 GB laptop with the limit set to 2, one of
+  # three compiler processes on an 18 GB laptop with the limit set to 2, one of
   # them started from the same worktree as a properly queued run.
+  #
+  # The compiler answers to two names — typescript@7 installs it as `tsc`,
+  # @typescript/native-preview as `tsgo` — so the shims cover both and so does
+  # haven's gate (ADR-095).
   #
   # dev/scripts/install-check-shims.mjs makes platform/app's bin entries
   # themselves the boundary, so the route into the tool stops mattering. Only
@@ -270,7 +274,7 @@ Feature: Machine-wide slots for whole-repo checks
 
   @unit
   Scenario: A whole-project run counts however it was started
-    When I run "pnpm exec tsgo --noEmit -p tsconfig.tsgo.json" instead of "pnpm typecheck"
+    When I run "pnpm exec tsc --noEmit -p tsconfig.tsgo.json" instead of "pnpm typecheck"
     Then the run counts against the limit, exactly as the script would have
 
   @unit
@@ -287,12 +291,12 @@ Feature: Machine-wide slots for whole-repo checks
   # file to check is what turns a whole-project run into one nothing waits for.
   @unit
   Scenario: A subcommand or a flag's value is not a target
-    When I run "biome check" with no paths, or "tsgo --pretty false"
+    When I run "biome check" with no paths, or "tsc --pretty false"
     Then the run counts against the limit, because neither names a file and both walk the project
 
   @unit
   Scenario: A run that names files starts immediately
-    When I run "tsgo --noEmit src/foo.ts"
+    When I run "tsc --noEmit src/foo.ts"
     Then it starts without waiting, so the iterate-fast loop never sits behind a full run
 
   @unit
@@ -303,7 +307,7 @@ Feature: Machine-wide slots for whole-repo checks
   @unit
   Scenario: A check does not queue behind itself
     Given "pnpm typecheck" holds the only slot
-    When the tsgo it runs would otherwise ask for a slot of its own
+    When the compiler it runs would otherwise ask for a slot of its own
     Then it starts without waiting
     And the check does not sit out the maximum wait before starting
 

--- a/specs/setup/haven-tsgo-governor.feature
+++ b/specs/setup/haven-tsgo-governor.feature
@@ -1,13 +1,18 @@
-Feature: tsgo can never take the machine down
-  A whole-tree tsgo run peaks around ten gigabytes, the check queue bounds how
+Feature: The TypeScript compiler can never take the machine down
+  A whole-tree typecheck peaks around ten gigabytes, the check queue bounds how
   many run at once but not how big each gets, and language-server instances
   accumulate one per worktree, exempt from every admission control by design.
   Gating spawn paths is whack-a-mole — every new package, editor or daemon
-  that spawns tsgo reopens the hole. So the guarantee moves to where every
-  process is visible: the haven daemon watches tsgo itself, caps it softly at
-  spawn where haven owns the spawn, and reclaims it forcibly when the machine
-  is at stake. See dev/docs/adr/095-haven-tsgo-governor.md.
+  that spawns the compiler reopens the hole. So the guarantee moves to where
+  every process is visible: the haven daemon watches the compiler itself, caps
+  it softly at spawn where haven owns the spawn, and reclaims it forcibly when
+  the machine is at stake. See dev/docs/adr/095-haven-tsgo-governor.md.
 
+  # The compiler is one binary under two names: @typescript/native-preview
+  # published it as `tsgo`, typescript@7 renamed it to `tsc`, and a local build
+  # of the TypeScript repo still produces `tsgo`. Both are governed as ONE
+  # class against ONE budget — the knobs keep their HAVEN_TSGO_ names.
+  #
   # Behavior lives in tools/thuishaven: `domain/tsgowatch.go` decides what to
   # reclaim, `app/daemon.go` samples and enforces on the monitor tick, and
   # `dev/scripts/check-queue.mjs` sets the soft memory cap on the runs it
@@ -16,28 +21,28 @@ Feature: tsgo can never take the machine down
 
   @unit
   Scenario: A runaway whole-tree run is stopped at the hard ceiling
-    Given a whole-tree tsgo run whose memory exceeds the per-run ceiling
+    Given a whole-tree compiler run whose memory exceeds the per-run ceiling
     When the daemon takes its next sample
     Then that run is stopped
     And the reason, size and age are logged
 
   @unit
   Scenario: A run under every ceiling is left alone
-    Given a whole-tree tsgo run within the per-run ceiling
-    And the combined tsgo footprint is within the machine budget
+    Given a whole-tree compiler run within the per-run ceiling
+    And the combined compiler footprint is within the machine budget
     When the daemon takes its next sample
     Then nothing is stopped
 
   @unit
   Scenario: Over the machine budget, idle language servers go first
-    Given the combined tsgo footprint exceeds the machine budget
+    Given the combined compiler footprint exceeds the machine budget
     And an idle language server and two whole-tree runs are live
     When the daemon takes its next sample
     Then the idle language server is reclaimed before any run
 
   @unit
   Scenario: Over the machine budget, the youngest run goes before the oldest
-    Given the combined tsgo footprint exceeds the machine budget
+    Given the combined compiler footprint exceeds the machine budget
     And no idle language server is left to reclaim
     When the daemon takes its next sample
     Then the youngest whole-tree run is stopped first
@@ -57,10 +62,24 @@ Feature: tsgo can never take the machine down
     Then it is evicted
 
   @unit
-  Scenario: The governor only ever touches tsgo
+  Scenario: The governor only ever touches the TypeScript compiler
     Given processes of every other kind on the machine
     When the daemon takes its next sample
     Then none of them is ever a candidate
+
+  # TypeScript 7 renamed the native binary from `tsgo` to `tsc`, which silently
+  # emptied a governor that selected on the old name: the machine's largest
+  # transient memory consumer was neither capped nor observed. One name is not
+  # two classes — two classes would weigh each half of the machine's compilers
+  # against the whole budget and reclaim neither.
+  @unit
+  Scenario: The compiler is governed under both of its names
+    Given a run of the compiler installed as "tsc" and one installed as "tsgo"
+    And they exceed the machine budget only when counted together
+    When the daemon takes its next sample
+    Then both are watched as one class
+    And the youngest of the two is reclaimed
+    And a language server keeps its own ceiling and idle period under either name
 
   @unit
   Scenario: Coding agents, dev servers and test workers are observed, never touched
@@ -80,11 +99,11 @@ Feature: tsgo can never take the machine down
   Scenario: The operator can disable the governor
     Given the per-run ceiling is disabled via the environment
     When the daemon takes its next sample
-    Then no tsgo process is considered at all
+    Then no compiler process is considered at all
 
   @unit
   Scenario: Queued whole-tree runs get a soft memory cap at spawn
-    Given the check queue spawns a whole-tree tsgo run
+    Given the check queue spawns a whole-tree compiler run
     Then the Go runtime memory limit is set from the machine's memory
     But an operator's explicit limit is never overridden
 

--- a/tools/thuishaven/README.md
+++ b/tools/thuishaven/README.md
@@ -264,8 +264,10 @@ registry, and dashboard stay the same.
   server once no stack is running (opt-in: native-mode tests and
   `haven db url clickhouse` reach it with no stack up) — the next `up`
   restarts it over the same data in seconds.
-- **tsgo can never take the machine down.** The daemon watches every tsgo
-  process on the machine — however it was spawned — and reclaims runaways: a
+- **The TypeScript compiler can never take the machine down.** The daemon
+  watches every compiler process on the machine — `tsc` (typescript@7) and
+  `tsgo` (the preview package) alike, as one class against one budget, however
+  it was spawned — and reclaims runaways: a
   whole-tree run past `HAVEN_TSGO_RUN_MAX_RSS_MB` (default 12 GiB), a language
   server past `HAVEN_TSGO_LSP_MAX_RSS_MB` (default 4 GiB) or idle past
   `HAVEN_TSGO_LSP_IDLE_TTL` (default 45m), and — over
@@ -338,7 +340,7 @@ registry, and dashboard stay the same.
   `--yes` skips the picker and applies only the safe categories. Agents (and
   any non-TTY) get the read-only report and delete nothing.
 - **`haven typecheck`.** Run `pnpm typecheck` under a machine-wide slot so parallel
-  tsgo runs across worktrees don't exhaust RAM (bounded by memory / CPU). The
+  typechecks across worktrees don't exhaust RAM (bounded by memory / CPU). The
   `typecheck` script slots itself too (`dev/scripts/check-queue.mjs`,
   `CHECK_SLOTS`), so this command passes `CHECK_SLOTS=0` to the run it
   spawns and stays the only thing counting it.

--- a/tools/thuishaven/app/daemon_procwatch_test.go
+++ b/tools/thuishaven/app/daemon_procwatch_test.go
@@ -71,6 +71,104 @@ func TestProcessWatchKillsARunawayTsgo(t *testing.T) {
 	})
 }
 
+// TypeScript 7 renamed the native compiler from `tsgo` to `tsc` and
+// lib/tsc.js execve()s it, so this — argv[0] and all — is what ps reports for
+// an ordinary `pnpm typecheck` today. It went ungoverned and unobserved while
+// the governor selected on the old name.
+// @scenario "The compiler is governed under both of its names"
+func TestProcessWatchGovernsTheCompilerUnderBothNames(t *testing.T) {
+	now := time.Date(2026, 8, 25, 12, 0, 0, 0, time.UTC)
+
+	t.Run("given a runaway typescript@7 run", func(t *testing.T) {
+		sys := &fakeSystem{now: now, procSamples: []ProcessSample{
+			{PID: 10, RSSBytes: 13 << 30, CPUTime: time.Minute, Elapsed: 5 * time.Minute,
+				Command: "/Users/x/repo/node_modules/.pnpm/@typescript+typescript-darwin-arm64@7.0.2/node_modules/@typescript/typescript-darwin-arm64/lib/tsc --noEmit --project ./tsconfig.tsgo.json"},
+		}}
+		tel := &fakeProcTel{}
+		o := watchOrch(sys, tel)
+
+		t.Run("when the daemon takes its sample", func(t *testing.T) {
+			o.governProcesses()
+
+			t.Run("it is reclaimed at the per-run ceiling", func(t *testing.T) {
+				if len(sys.killed) != 1 || sys.killed[0] != 10 {
+					t.Fatalf("killed = %v, want the runaway tsc run", sys.killed)
+				}
+			})
+
+			t.Run("and it is observed under the compiler class", func(t *testing.T) {
+				if len(tel.samples) != 1 || len(tel.samples[0]) != 1 {
+					t.Fatalf("expected one sample of one watched process, got %+v", tel.samples)
+				}
+				got := tel.samples[0][0]
+				if got.Class != domain.TypeScriptCompilerClass || got.Role != domain.TsgoRun {
+					t.Fatalf("classed %q/%q, want %q/run", got.Class, got.Role, domain.TypeScriptCompilerClass)
+				}
+				want := [2]string{domain.TypeScriptCompilerClass, "run exceeds the per-run memory ceiling"}
+				if len(tel.kills) != 1 || tel.kills[0] != want {
+					t.Fatalf("expected the kill counted as %v, got %v", want, tel.kills)
+				}
+			})
+		})
+	})
+
+	t.Run("given a tsc run and a tsgo run that only exceed the budget together", func(t *testing.T) {
+		// 7 + 7 = 14 GiB against the 12 GiB budget of an 18 GiB machine, with
+		// neither over the per-run ceiling: one combined budget over both
+		// names, or each name is weighed against the whole machine alone.
+		sys := &fakeSystem{now: now, procSamples: []ProcessSample{
+			{PID: 20, RSSBytes: 7 << 30, CPUTime: time.Minute, Elapsed: 10 * time.Minute,
+				Command: "/x/lib/tsc --noEmit -p tsconfig.tsgo.json"},
+			{PID: 21, RSSBytes: 7 << 30, CPUTime: time.Minute, Elapsed: time.Minute,
+				Command: "/y/lib/tsgo --noEmit -p tsconfig.tsgo.tests.json"},
+		}}
+		tel := &fakeProcTel{}
+		o := watchOrch(sys, tel)
+
+		t.Run("when the daemon takes its sample", func(t *testing.T) {
+			o.governProcesses()
+
+			t.Run("the youngest of the two is reclaimed", func(t *testing.T) {
+				if len(sys.killed) != 1 || sys.killed[0] != 21 {
+					t.Fatalf("killed = %v, want the youngest compiler run", sys.killed)
+				}
+			})
+
+			t.Run("and both were recorded under one class", func(t *testing.T) {
+				if len(tel.samples) != 1 || len(tel.samples[0]) != 2 {
+					t.Fatalf("expected one sample of two watched processes, got %+v", tel.samples)
+				}
+				for _, p := range tel.samples[0] {
+					if p.Class != domain.TypeScriptCompilerClass {
+						t.Fatalf("pid %d classed %q, want %q", p.PID, p.Class, domain.TypeScriptCompilerClass)
+					}
+				}
+			})
+		})
+	})
+
+	t.Run("given an active typescript@7 language server", func(t *testing.T) {
+		sys := &fakeSystem{now: now, procSamples: []ProcessSample{
+			{PID: 30, RSSBytes: 2 << 30, CPUTime: time.Minute, Elapsed: time.Hour,
+				Command: "/x/lib/tsc --lsp --stdio"},
+		}}
+		o := watchOrch(sys, &fakeProcTel{})
+
+		t.Run("when the daemon takes its sample", func(t *testing.T) {
+			o.governProcesses()
+			sys.now = now.Add(50 * time.Minute)
+			sys.procSamples[0].CPUTime = 2 * time.Minute // the clock moved
+			o.governProcesses()
+
+			t.Run("it keeps the protection its role has always had", func(t *testing.T) {
+				if len(sys.killed) != 0 {
+					t.Fatalf("an active language server must never be evicted, got %v", sys.killed)
+				}
+			})
+		})
+	})
+}
+
 // @scenario "Coding agents, dev servers and test workers are observed, never touched"
 func TestProcessWatchNeverKillsObserveOnlyClasses(t *testing.T) {
 	now := time.Date(2026, 8, 13, 12, 0, 0, 0, time.UTC)

--- a/tools/thuishaven/app/daemon_tsgo.go
+++ b/tools/thuishaven/app/daemon_tsgo.go
@@ -10,12 +10,12 @@ import (
 )
 
 // The process watch (ADR-095): every daemon tick samples the machine's
-// dev-tooling processes — tsgo, gopls, biome, vitest workers, node, bun,
-// claude — however they were spawned, ships the footprint to the local
-// observability stack, and enforces limits on the one class that has them
-// (tsgo). Admission controls bound how much tooling *starts*; this bounds how
-// much *exists*, and records enough history to decide which class earns
-// limits next.
+// dev-tooling processes — the TypeScript compiler (`tsc` or `tsgo`, one
+// class), gopls, biome, vitest workers, node, bun, claude — however they were
+// spawned, ships the footprint to the local observability stack, and enforces
+// limits on the one class that has them (the compiler). Admission controls
+// bound how much tooling *starts*; this bounds how much *exists*, and records
+// enough history to decide which class earns limits next.
 
 // tsgoSeen is the cross-tick memory behind idle detection: a process whose CPU
 // clock moved since the last tick was active then.
@@ -41,9 +41,9 @@ func (o *Orchestrator) governProcesses() {
 	for _, k := range domain.GovernTsgo(tsgo, o.cfg.Tsgo) {
 		o.sys.Kill(k.PID)
 		if o.procTel != nil {
-			o.procTel.RecordKill("tsgo", k.Reason)
+			o.procTel.RecordKill(domain.TypeScriptCompilerClass, k.Reason)
 		}
-		o.recordReap("tsgo", fmt.Sprintf("pid %d (%s, %s)", k.PID, k.Class, domain.HumanBytes(k.RSS)), k.Reason)
+		o.recordReap(domain.TypeScriptCompilerClass, fmt.Sprintf("pid %d (%s, %s)", k.PID, k.Class, domain.HumanBytes(k.RSS)), k.Reason)
 		o.log.Warn("process governor reclaimed tsgo",
 			zap.Int("pid", k.PID),
 			zap.String("role", string(k.Class)),
@@ -54,8 +54,9 @@ func (o *Orchestrator) governProcesses() {
 }
 
 // sampleWatched classifies the live process listing and maintains the
-// cross-tick idle memory. Returns every watched process plus the tsgo subset
-// the governor rules on.
+// cross-tick idle memory. Returns every watched process plus the compiler
+// subset the governor rules on — both binary names land in that one subset, so
+// a `tsc` run and a `tsgo` run are weighed against one combined budget.
 func (o *Orchestrator) sampleWatched(now time.Time) (watched []domain.WatchedProcess, tsgo []domain.TsgoProcess) {
 	live := map[int]bool{}
 	for _, s := range o.sys.ProcessSamples() {
@@ -76,7 +77,7 @@ func (o *Orchestrator) sampleWatched(now time.Time) (watched []domain.WatchedPro
 		w.PID, w.RSS = s.PID, s.RSSBytes
 		w.Started, w.IdleFor = now.Add(-s.Elapsed), now.Sub(seen.activeAt)
 		watched = append(watched, w)
-		if w.Class == "tsgo" {
+		if w.Class == domain.TypeScriptCompilerClass {
 			tsgo = append(tsgo, domain.TsgoProcess{
 				PID: w.PID, Class: w.Role, RSS: w.RSS, Started: w.Started, IdleFor: w.IdleFor,
 			})

--- a/tools/thuishaven/app/ports.go
+++ b/tools/thuishaven/app/ports.go
@@ -214,7 +214,8 @@ type System interface {
 	RestoreGroup(pid int)
 	// ProcessSamples lists every live process with the facts the tsgo governor
 	// needs (ADR-095): resident set, CPU clock, elapsed age, command line.
-	// Filtering to tsgo is the caller's job via domain.IsTsgoCommand — the
+	// Filtering to the compiler is the caller's job via
+	// domain.IsTypeScriptCompilerCommand — the
 	// sampler stays generic and the selection rule stays in one testable place.
 	ProcessSamples() []ProcessSample
 	// Kill SIGKILLs one process — never its group. The tsgo governor's targets

--- a/tools/thuishaven/cmd/help.go
+++ b/tools/thuishaven/cmd/help.go
@@ -115,7 +115,8 @@ var envHelpText = `Environment variables.
                                  one per ~4 GiB RAM, capped at CPU count).
     HAVEN_TYPECHECK_MAX_RSS_MB   Kill a typecheck run over this RSS (default 6144
                                  = 6 GiB) or over 10 minutes wall-clock — a
-                                 runaway tsgo shouldn't sit on a slot forever.
+                                 runaway typecheck shouldn't sit on a slot
+                                 forever.
     CHECK_SLOTS=N                Caps concurrent whole-repo checks ("pnpm
                                  typecheck", "pnpm lint") machine wide (0
                                  disables). With haven installed those runs are

--- a/tools/thuishaven/domain/gate.go
+++ b/tools/thuishaven/domain/gate.go
@@ -2,6 +2,7 @@ package domain
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 	"unicode"
 )
@@ -53,6 +54,22 @@ var heavyCommands = []string{
 	"docker build",
 }
 
+// heavyBinaries are heavy runs matched on the BINARY INVOKED rather than by
+// substring, and they are the TypeScript compiler's two names because "tsc"
+// cannot go in the list above: it is a substring of "tsconfig.json", so `cat
+// tsconfig.json` and every `-p tsconfig.tsgo.json` argument would class heavy.
+// That is precisely the over-match heavyCommands' comment warns about, and the
+// developer wondering why `cat` was queued would be right.
+//
+// Matching the last path segment of a word keeps the rule as predictable as a
+// substring while staying honest about a three-letter name:
+// `./node_modules/.bin/tsc`, `pnpm exec tsc` and `/x/lib/tsc --noEmit` all
+// count, `tsconfig.json`, `mytsc`, `tsclint` and the shim's own `tsc.real`
+// (already inside the queue) do not. `tsgo` is here too rather than only in
+// heavyCommands: one compiler, one rule. It stays in heavyCommands as well, so
+// nothing that classes heavy today stops doing so.
+var heavyBinaries = typeScriptCompilerBinaries
+
 // integrationMarkers say a command drives the integration suite, which is never
 // narrowed: specs/setup/integration-file-serialism.feature owns its concurrency
 // and treats a worker count arriving from the environment as something to
@@ -69,7 +86,7 @@ var workerFlags = []string{"--maxWorkers", "--max-workers", "VITEST_MAX_WORKERS"
 
 // ClassifyCommand reports whether a command is heavy and, if so, what kind.
 func ClassifyCommand(command string) (RunKind, bool) {
-	if !containsAny(command, heavyCommands) {
+	if !containsAny(command, heavyCommands) && !invokesAny(command, heavyBinaries) {
 		return SingleProcessRun, false
 	}
 	switch {
@@ -321,8 +338,28 @@ func DurationKey(command string) string {
 				return marker
 			}
 		}
+		// A run reached only by binary name is the compiler, and the compiler
+		// is one population under both its names — a `tsc` run belongs in the
+		// same bucket its `tsgo` predecessor filled, not in no bucket at all
+		// (an unobserved command is treated as long, which disables narrowing).
+		if invokesAny(command, heavyBinaries) {
+			return TypeScriptCompilerClass
+		}
 		return ""
 	}
+}
+
+// invokesAny reports whether any word of the command invokes one of the named
+// binaries, comparing the word's last path segment so a binary is matched
+// however it was reached. A word is not a substring: `tsconfig.json` and
+// `tsc.real` are not `tsc`.
+func invokesAny(command string, binaries []string) bool {
+	for _, word := range strings.Fields(command) {
+		if slices.Contains(binaries, binaryBase(word)) {
+			return true
+		}
+	}
+	return false
 }
 
 func containsAny(s string, needles []string) bool {

--- a/tools/thuishaven/domain/gate_test.go
+++ b/tools/thuishaven/domain/gate_test.go
@@ -35,6 +35,42 @@ func TestClassifyCommandGatesOnlyWhatIsHeavy(t *testing.T) {
 			}
 		})
 	})
+
+	// TypeScript 7 renamed the compiler binary to `tsc`, so the route around
+	// the package scripts is spelled differently now and costs exactly as
+	// much as it did.
+	t.Run("given the compiler invoked directly under either name", func(t *testing.T) {
+		t.Run("each is heavy", func(t *testing.T) {
+			for _, cmd := range []string{
+				"./node_modules/.bin/tsc --noEmit --project ./tsconfig.tsgo.json",
+				"pnpm exec tsc --noEmit -p tsconfig.json",
+				"pnpm exec tsgo --noEmit -p tsconfig.tsgo.json",
+				"cd platform/app && tsc -p tsconfig.tsgo.tests.json",
+			} {
+				if _, heavy := ClassifyCommand(cmd); !heavy {
+					t.Fatalf("%q should be gated", cmd)
+				}
+			}
+		})
+
+		// "tsc" is three letters and a substring of "tsconfig.json", so it is
+		// matched as the binary a word invokes rather than as text anywhere in
+		// the line. Reading a project file as a compiler run is the over-match
+		// that has a developer wondering why `cat` was queued.
+		t.Run("but naming the config file is not running the compiler", func(t *testing.T) {
+			for _, cmd := range []string{
+				"cat platform/app/tsconfig.json",
+				"grep -n strict platform/app/tsconfig.json",
+				"git diff tsconfig.json",
+				"/x/bin/mytsc --noEmit",
+				"node dev/scripts/check-queue.mjs ./node_modules/.bin/tsc.real --noEmit -p tsconfig.json",
+			} {
+				if _, heavy := ClassifyCommand(cmd); heavy {
+					t.Fatalf("%q must not be gated", cmd)
+				}
+			}
+		})
+	})
 }
 
 // @scenario "An integration run is never narrowed"
@@ -74,6 +110,22 @@ func TestClassifyCommandSeparatesIntegrationFromUnit(t *testing.T) {
 }
 
 // @scenario "A caller's own worker count is respected but still admitted"
+// One compiler is one population: a `tsc` run has to file its duration where
+// its `tsgo` predecessor filed, or the estimate that decides whether a run is
+// narrowed has no prior observation and treats it as long.
+func TestDurationKeyBucketsBothCompilerNamesTogether(t *testing.T) {
+	t.Run("given the compiler invoked under each of its names", func(t *testing.T) {
+		tsc := DurationKey("./node_modules/.bin/tsc --noEmit -p tsconfig.json")
+		tsgo := DurationKey("./node_modules/.bin/tsgo --noEmit -p tsconfig.json")
+
+		t.Run("both land in one bucket", func(t *testing.T) {
+			if tsc != TypeScriptCompilerClass || tsgo != TypeScriptCompilerClass {
+				t.Fatalf("tsc = %q, tsgo = %q, want both %q", tsc, tsgo, TypeScriptCompilerClass)
+			}
+		})
+	})
+}
+
 func TestCallerSetWorkersIsDetected(t *testing.T) {
 	t.Run("given a command that already chose its width", func(t *testing.T) {
 		t.Run("the gate notices, and will not override it", func(t *testing.T) {

--- a/tools/thuishaven/domain/tsgowatch.go
+++ b/tools/thuishaven/domain/tsgowatch.go
@@ -1,17 +1,24 @@
 package domain
 
 import (
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
 	"time"
 )
 
-// The tsgo governor (ADR-095). tsgo is the single largest transient memory
-// consumer on a dev machine, and admission controls only see the spawns they
-// wrap. This is the other half: policy over a sample of every live tsgo
-// process, wherever it came from. The decisions here are pure; the daemon
-// samples and enforces.
+// The TypeScript compiler governor (ADR-095). The compiler is the single
+// largest transient memory consumer on a dev machine, and admission controls
+// only see the spawns they wrap. This is the other half: policy over a sample
+// of every live compiler process, wherever it came from. The decisions here
+// are pure; the daemon samples and enforces.
+//
+// The types keep the Tsgo name the governor was born with, because the knobs
+// (HAVEN_TSGO_*), the metric attribute and the persisted reap Kind are all
+// spelled that way and are a contract with machines that already carry
+// history. What the governor SELECTS is name-neutral: see
+// typeScriptCompilerBinaries.
 
 // TsgoClass is the crude-on-purpose classification: an --lsp instance is a
 // language server, anything else is a run. Single-file checks are tiny and
@@ -38,15 +45,43 @@ type TsgoProcess struct {
 	IdleFor time.Duration
 }
 
-// IsTsgoCommand reports whether a process command line is a tsgo binary
-// invocation — the whole selection rule, so the governor can never touch
-// anything else. Matched on the binary path, not the args: an unrelated
-// process mentioning "tsgo" in an argument is not a candidate.
-func IsTsgoCommand(command string) bool {
-	return binaryBase(command) == "tsgo"
+// typeScriptCompilerBinaries are the names the native TypeScript compiler is
+// installed under. They are one binary under two package identities:
+// @typescript/native-preview published it as `tsgo`, and typescript@7 renamed
+// it to `tsc` — the package picks the name (`lib/getExePath.js`:
+// `baseName === "typescript" ? "tsc" : "tsgo"`), and a local repo build still
+// produces `tsgo`, so both names stay live on real machines. One compiler is
+// one class with one set of limits: two classes would split the machine budget
+// in half and govern neither half of it.
+var typeScriptCompilerBinaries = []string{"tsc", "tsgo"}
+
+// TypeScriptCompilerClass is the single process class both compiler binaries
+// land in. Deliberately still spelled "tsgo" after the rename: the string is
+// the `class` attribute on every haven_proc_* series, the Kind of a persisted
+// reap event, and the key the daemon selects the governed subset by — renaming
+// it would cut the recorded history in two at exactly the moment the point of
+// the change is to join the two binaries together.
+const TypeScriptCompilerClass = "tsgo"
+
+// IsTypeScriptCompilerCommand reports whether a process command line invokes
+// the native TypeScript compiler under either of its names — the whole
+// selection rule, so the governor can never touch anything else. Matched on
+// the binary path, not the args: an unrelated process mentioning "tsc" or
+// "tsgo" in an argument is not a candidate, and neither is the `tsc.real` /
+// `tsgo.real` launcher the check-queue shim runs, which is a shell and then a
+// node process — the compiler it finally becomes is the process governed.
+func IsTypeScriptCompilerCommand(command string) bool {
+	return isTypeScriptCompilerBinary(binaryBase(command))
 }
 
-// ClassifyTsgo reads the class off a tsgo command line.
+// isTypeScriptCompilerBinary reports whether a binary base name is the
+// compiler's, under either name.
+func isTypeScriptCompilerBinary(base string) bool {
+	return slices.Contains(typeScriptCompilerBinaries, base)
+}
+
+// ClassifyTsgo reads the class off a compiler command line. Arg-based, so it
+// reads the same under either binary name.
 func ClassifyTsgo(command string) TsgoClass {
 	if strings.Contains(command, "--lsp") {
 		return TsgoLSP
@@ -79,17 +114,21 @@ type WatchedProcess struct {
 // ClassifyWatchedProcess maps a command line to the process class haven
 // tracks, or ok=false for everything haven has no interest in. The class list
 // is deliberately the dev-tooling that shapes machine health: compilers and
-// checkers (tsgo, gopls, biome), test workers (vitest — matched on the worker
-// path, the same marker the orphan sweep uses), the JS runtimes every dev
-// server and script runs on (node, bun), and coding agents (claude). Only
-// tsgo carries kill limits (ADR-095); every other class is observe-only —
-// node and claude in particular are the user's own work and are never
-// touched.
+// checkers (the TypeScript compiler under either name, gopls, biome), test
+// workers (vitest — matched on the worker path, the same marker the orphan
+// sweep uses), the JS runtimes every dev server and script runs on (node,
+// bun), and coding agents (claude). Only the TypeScript compiler carries kill
+// limits (ADR-095); every other class is observe-only — node and claude in
+// particular are the user's own work and are never touched.
+//
+// `tsc` and `tsgo` return the SAME class, so limits, dashboards and reap
+// events aggregate the one compiler into one budget however it was installed.
 func ClassifyWatchedProcess(command string) (WatchedProcess, bool) {
 	base := binaryBase(command)
+	if isTypeScriptCompilerBinary(base) {
+		return WatchedProcess{Class: TypeScriptCompilerClass, Role: ClassifyTsgo(command)}, true
+	}
 	switch base {
-	case "tsgo":
-		return WatchedProcess{Class: "tsgo", Role: ClassifyTsgo(command)}, true
 	case "gopls":
 		return WatchedProcess{Class: "gopls", Role: TsgoLSP}, true
 	case "biome":

--- a/tools/thuishaven/domain/tsgowatch_test.go
+++ b/tools/thuishaven/domain/tsgowatch_test.go
@@ -11,26 +11,39 @@ func tsgoAt(pid int, class TsgoClass, rssGiB int64, started time.Time) TsgoProce
 	return TsgoProcess{PID: pid, Class: class, RSS: rssGiB * tsgoGiB, Started: started}
 }
 
-// @scenario "The governor only ever touches tsgo"
-func TestIsTsgoCommand(t *testing.T) {
+// @scenario "The governor only ever touches the TypeScript compiler"
+// @scenario "The compiler is governed under both of its names"
+func TestIsTypeScriptCompilerCommand(t *testing.T) {
 	t.Run("matches the binary path, not the arguments", func(t *testing.T) {
 		yes := []string{
+			// The preview package's name, still live on machines that have it
+			// and on a local build of the TypeScript repo.
 			"/x/node_modules/@typescript/native-preview-darwin-arm64/lib/tsgo --lsp --stdio",
 			"tsgo --noEmit --project ./tsconfig.tsgo.json",
+			// typescript@7 publishes the same Go binary as `tsc`, and
+			// lib/tsc.js execve()s it, so the live process IS the compiler.
+			"/Users/x/repo/node_modules/.pnpm/@typescript+typescript-darwin-arm64@7.0.2/node_modules/@typescript/typescript-darwin-arm64/lib/tsc --noEmit --project ./tsconfig.tsgo.json",
+			"./node_modules/.bin/tsc --noEmit -p tsconfig.tsgo.json",
+			"tsc --lsp --stdio",
 		}
 		no := []string{
 			"node dev/scripts/check-queue.mjs ./node_modules/.bin/tsgo.real",
+			"node dev/scripts/check-queue.mjs ./node_modules/.bin/tsc.real --noEmit",
 			"grep tsgo server.log",
+			"grep -rn tsc dev/scripts",
 			"/usr/bin/vim tsgo.go",
+			"/x/bin/tsclint --fix",
+			"/x/bin/mytsc --noEmit",
+			"/x/node --tsc",
 			"clickhouse-server --daemon",
 		}
 		for _, c := range yes {
-			if !IsTsgoCommand(c) {
-				t.Errorf("expected tsgo: %q", c)
+			if !IsTypeScriptCompilerCommand(c) {
+				t.Errorf("expected the TypeScript compiler: %q", c)
 			}
 		}
 		for _, c := range no {
-			if IsTsgoCommand(c) {
+			if IsTypeScriptCompilerCommand(c) {
 				t.Errorf("must never be a candidate: %q", c)
 			}
 		}
@@ -38,12 +51,64 @@ func TestIsTsgoCommand(t *testing.T) {
 }
 
 func TestClassifyTsgo(t *testing.T) {
-	if ClassifyTsgo("/lib/tsgo --lsp --stdio") != TsgoLSP {
-		t.Error("an --lsp invocation is a language server")
-	}
-	if ClassifyTsgo("/lib/tsgo --noEmit -p tsconfig.json") != TsgoRun {
-		t.Error("everything else is a run")
-	}
+	t.Run("given the preview binary name", func(t *testing.T) {
+		if ClassifyTsgo("/lib/tsgo --lsp --stdio") != TsgoLSP {
+			t.Error("an --lsp invocation is a language server")
+		}
+		if ClassifyTsgo("/lib/tsgo --noEmit -p tsconfig.json") != TsgoRun {
+			t.Error("everything else is a run")
+		}
+	})
+
+	// The split is arg-based, so the rename cannot have touched it — pinned
+	// because an LSP's protection (its own ceiling, its own idle TTL) hangs
+	// off the role and not off the binary's name.
+	t.Run("given the typescript@7 binary name", func(t *testing.T) {
+		if ClassifyTsgo("/lib/tsc --lsp --stdio") != TsgoLSP {
+			t.Error("an --lsp invocation is a language server")
+		}
+		if ClassifyTsgo("/lib/tsc --noEmit -p tsconfig.tsgo.json") != TsgoRun {
+			t.Error("everything else is a run")
+		}
+	})
+}
+
+// @scenario "The compiler is governed under both of its names"
+func TestClassifyWatchedProcessPutsBothCompilerNamesInOneClass(t *testing.T) {
+	t.Run("given the compiler under each of its names", func(t *testing.T) {
+		cases := map[string]TsgoClass{
+			"/Users/x/repo/node_modules/.pnpm/@typescript+typescript-darwin-arm64@7.0.2/node_modules/@typescript/typescript-darwin-arm64/lib/tsc --noEmit --project ./tsconfig.tsgo.json": TsgoRun,
+			"/x/lib/tsgo --noEmit -p tsconfig.tsgo.json": TsgoRun,
+			"/x/lib/tsc --lsp --stdio":                   TsgoLSP,
+			"/x/lib/tsgo --lsp --stdio":                  TsgoLSP,
+		}
+
+		t.Run("each lands in the one class, with its own role", func(t *testing.T) {
+			for command, role := range cases {
+				w, ok := ClassifyWatchedProcess(command)
+				if !ok {
+					t.Fatalf("%q must be watched", command)
+				}
+				// One class, so limits, dashboards and reap events aggregate
+				// the one compiler instead of splitting the budget in two.
+				if w.Class != TypeScriptCompilerClass {
+					t.Errorf("%q classed %q, want %q", command, w.Class, TypeScriptCompilerClass)
+				}
+				if w.Role != role {
+					t.Errorf("%q role %q, want %q", command, w.Role, role)
+				}
+			}
+		})
+	})
+
+	t.Run("given a process that only mentions the compiler", func(t *testing.T) {
+		t.Run("it is not watched as the compiler", func(t *testing.T) {
+			w, ok := ClassifyWatchedProcess("/usr/bin/grep -rn tsc dev/scripts")
+			if ok && w.Class == TypeScriptCompilerClass {
+				t.Fatalf("an argument mention must never be the compiler, got %+v", w)
+			}
+		})
+	})
 }
 
 func TestGovernTsgo(t *testing.T) {
@@ -139,6 +204,28 @@ func TestGovernTsgo(t *testing.T) {
 		}
 	})
 
+	// One compiler, one budget: the two names have to be weighed together or
+	// each half of a machine's compilers is governed against the whole budget.
+	// @scenario "The compiler is governed under both of its names"
+	t.Run("given a tsc run and a tsgo run that only exceed the budget together", func(t *testing.T) {
+		procs := governedSubset(t, []sampled{
+			{command: "/x/lib/tsc --noEmit -p tsconfig.tsgo.json", rssGiB: 7, started: now.Add(-10 * time.Minute)},
+			{command: "/y/lib/tsgo --noEmit -p tsconfig.tsgo.json", rssGiB: 7, started: now.Add(-1 * time.Minute)},
+		})
+
+		// 7 + 7 = 14 GiB against a 12 GiB budget, and neither is over the
+		// 12 GiB per-run ceiling on its own: drop either from the sum and
+		// nothing would be reclaimed at all.
+		kills := GovernTsgo(procs, limits)
+
+		if len(kills) != 1 || kills[0].PID != 2 {
+			t.Fatalf("expected the youngest of the two compilers stopped, got %+v", kills)
+		}
+		if kills[0].Reason != "combined tsgo footprint exceeds the machine budget" {
+			t.Fatalf("expected the combined-budget reason, got %q", kills[0].Reason)
+		}
+	})
+
 	// @scenario "The operator can disable the governor"
 	t.Run("given the per-run ceiling is disabled", func(t *testing.T) {
 		off := limits
@@ -148,6 +235,33 @@ func TestGovernTsgo(t *testing.T) {
 			t.Fatalf("a disabled governor considers nothing, got %+v", kills)
 		}
 	})
+}
+
+// sampled is one live process as ps would report it, for the tests that start
+// from a command line rather than from an already-classified process.
+type sampled struct {
+	command string
+	rssGiB  int64
+	started time.Time
+}
+
+// governedSubset is what the daemon's tick does, in the two lines that matter
+// here: classify every sampled process and keep the ones in the compiler
+// class. Going through the classifier is the point — it is what decides
+// whether a `tsc` process reaches the governor at all.
+func governedSubset(t *testing.T, samples []sampled) []TsgoProcess {
+	t.Helper()
+	var procs []TsgoProcess
+	for i, s := range samples {
+		w, ok := ClassifyWatchedProcess(s.command)
+		if !ok || w.Class != TypeScriptCompilerClass {
+			t.Fatalf("%q must reach the governor, got %+v ok=%v", s.command, w, ok)
+		}
+		procs = append(procs, TsgoProcess{
+			PID: i + 1, Class: w.Role, RSS: s.rssGiB * tsgoGiB, Started: s.started,
+		})
+	}
+	return procs
 }
 
 func TestParsePSDuration(t *testing.T) {


### PR DESCRIPTION
## The bug

TypeScript 7 shipped, and the native compiler binary was renamed — which silently switched off haven's ADR-095 governor.

`node_modules/typescript/lib/getExePath.js` picks the executable name from the package identity:

```js
const expectedBinName = baseName === "typescript" ? "tsc" : "tsgo";
```

The old preview package was `@typescript/native-preview` (hence `tsgo`). The published package is plain `typescript`, so an installed `typescript@7` resolves to a 23 MB Go executable called **`tsc`**. And `lib/tsc.js` hands the process straight to it with `process.execve`, so there is no `node` wrapper left in the process table — the live command line is `…/lib/tsc --noEmit --project …`.

haven selected governor candidates with `binaryBase(command) == "tsgo"`. On a TS7 machine that matches nothing, so:

- **The governor governed zero processes** — no per-run memory ceiling, no combined-budget kill, no runaway reclamation, over the single largest transient memory consumer in the repo.
- **`ClassifyWatchedProcess` didn't know the name either**, so a typecheck wasn't even *observed* — it returned `ok=false` and never reached the dashboards. It did not fall through to the `node` class, because `execve` took the wrapper away.

Not broken, and untouched here: the slot semaphore was already one contract (`checkSlotName = "checks"` covers `haven slot run` and `haven typecheck` alike), and the shim installer already covered `tsc`. Queueing worked throughout; the governor and the observability are what went dark.

## The fix

**One name-neutral predicate** over both binaries (`IsTsgoCommand` → `IsTypeScriptCompilerCommand`), still matched on the binary base name rather than args — so `grep tsgo server.log` is still not a compiler.

**One class for both names**, so a mixed sample is one budget instead of two half-budgets. The class string stays spelled `"tsgo"`, now behind a single constant: it is an OTel attribute on four `haven_proc_*` metrics and a persisted `ReapEvent.Kind`, so renaming it would cut the recorded history in two at exactly the moment the point of the change is to join the two binaries. The governor's types and its four documented `HAVEN_TSGO_*` knobs keep their spelling for the same reason.

**The gate could not take the same shortcut.** `heavyCommands` is matched with `strings.Contains`, and `tsc` is a substring of `tsconfig.json` — so `cat tsconfig.json`, `git diff tsconfig.json` and every `-p tsconfig.tsgo.json` argument would have classed heavy, which is precisely the over-match that list's own comment warns about. Binaries are matched as **words, by last path segment**, instead.

**`DurationKey` needed the same treatment** — a binary-matched run fell through to no bucket, and an unbucketed command is treated as long, which silently disables narrowing. Both names now file under one duration population.

## Verification

```
go build ./tools/thuishaven/...     ok
go test  ./tools/thuishaven/...     ok (domain, app, cmd)
gofmt -l tools/thuishaven           (no output)
```

Narrowing the predicate back to `{"tsgo"}` fails six tests across two packages (`TestIsTypeScriptCompilerCommand`, `TestClassifyWatchedProcessPutsBothCompilerNamesInOneClass`, `TestGovernTsgo`, `TestClassifyCommandGatesOnlyWhatIsHeavy`, `TestDurationKeyBucketsBothCompilerNamesTogether`, `TestProcessWatchGovernsTheCompilerUnderBothNames`) — confirmed by reverting and re-running, so the suite bites rather than merely passing.

Tests cover the real TS7 command line verbatim, the `--lsp`/run split under both names (an active `tsc --lsp --stdio` survives two ticks, preserving the LSP protection the `tsgo` case already had), a mixed `tsc`+`tsgo` sample aggregated into one budget, and the over-match cases pinned as **not** heavy.

`golangci-lint` on `tools/thuishaven` reports 347 issues, all pre-existing: this package tree is not in CI's lint path (`./services/aigateway/... ./services/nlpgo/... ./pkg/... ./cmd/... ./tools/migrationorder/...`), so it is red before this change. Zero issues fall on any line added here.

## Regression safety

Nothing changes for `tsgo`. The preview package is still live on the development machine this was written on — both `…/native-preview-darwin-arm64/lib/tsgo --noEmit` and `…/lib/tsgo --lsp --stdio` were running during the work — so both paths stay governed, and a local TypeScript repo build (which still produces `tsgo`) is unaffected.

## Docs

- `dev/docs/adr/095-haven-tsgo-governor.md` — a dated amendment, not a rewrite: the rename, the `execve` mechanics, that the governor selected nothing, the name-neutral rule, and why the class string and knobs keep their spelling.
- `specs/setup/haven-tsgo-governor.feature` — scenario retitled to name the compiler rather than `tsgo`, binding moved with it; a new scenario for both names. 13/13 bound.
- `specs/setup/check-slots.feature` — the shim scenarios named `tsgo` invocations that no longer exist on a `typescript@7` machine. 46/46 still bound.
- `tools/thuishaven/README.md` and `cmd/help.go` — user-facing text.

## Known, deliberately not changed

`adapters/procsupervisor`'s `knownDevRuntime` token list contains `tsgo` but not `tsc`. It is left alone on purpose: that sweep `SIGKILL`s process *groups* by substring, and `tsc` there would match any orphan whose command mentions `tsconfig`. It is not a gap in practice either — a TS7 compiler path contains `node_modules`, so it already matches the list's `node` token. Worth revisiting only if that sweep moves to exact binary matching.

`dev/scripts/check-queue.mjs` has stale comments naming `.bin/tsgo`; the code already handles `tsc` (`TOOLS = ["tsgo", "tsc", "biome"]`).

## Deployment Impact

None. Developer tooling only — no service, image, chart or migration is touched. The effect is local: on a machine running `typescript@7`, haven's governor and process dashboards start seeing typecheck runs again, and the per-run/combined memory ceilings (`HAVEN_TSGO_*`, unchanged in name and default) begin applying to them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * TypeScript compiler monitoring now supports both `tsc` and `tsgo`.
  * Both compiler names share the same resource limits, monitoring class, and budget.
  * Compiler detection now matches the executable name accurately, avoiding unrelated commands or filenames.

* **Documentation**
  * Updated setup guidance, help text, and feature documentation to reflect support for both compiler names.

* **Tests**
  * Added coverage for resource enforcement, combined budgeting, telemetry, and language-server protection across both compiler variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->