### PR TITLE
fix(langy): the panel stops mounting on the CLI device approval screen

### DIFF
--- a/platform/app/src/__tests__/langyMountScope.unit.test.ts
+++ b/platform/app/src/__tests__/langyMountScope.unit.test.ts
@@ -1,0 +1,50 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * createBrowserRouter touches `document` while building the router, so this
+ * file runs under jsdom even though it only matches paths, never renders.
+ */
+import { matchRoutes } from "react-router";
+import { describe, expect, it } from "vitest";
+
+import { router } from "~/routes";
+
+/**
+ * Langy mounts once per layout route; every route below a layout gets the
+ * panel. Special-purpose screens (the CLI device approval) must sit outside
+ * it, or the panel draws itself over a screen whose only job is one
+ * confirmation.
+ *
+ * Both Langy layouts are the route table's only PATHLESS page() routes: a
+ * matched ancestor carrying `lazy` but no `path` is a Langy layout. The
+ * root route is pathless too but carries `Component`, not `lazy`.
+ *
+ * Spec: specs/langy/langy-mount-scope.feature
+ */
+
+function langyLayoutAncestors(path: string): number {
+  const matches = matchRoutes(router.routes, path);
+  if (!matches) {
+    return 0;
+  }
+  return matches.filter(
+    (match) => !match.route.path && typeof match.route.lazy === "function",
+  ).length;
+}
+
+describe("given the application's route table", () => {
+  describe("when the route for /cli/auth is matched", () => {
+    // @scenario "The CLI device approval screen carries no assistant panel"
+    it("sits under no Langy layout route", () => {
+      expect(matchRoutes(router.routes, "/cli/auth")).not.toBeNull();
+      expect(langyLayoutAncestors("/cli/auth")).toBe(0);
+    });
+  });
+
+  describe("when a settings route is matched", () => {
+    // @scenario "The CLI device approval screen carries no assistant panel"
+    it("sits under exactly one Langy layout route, proving the detector works", () => {
+      expect(langyLayoutAncestors("/settings/members")).toBe(1);
+    });
+  });
+});

--- a/platform/app/src/routes.tsx
+++ b/platform/app/src/routes.tsx
@@ -325,12 +325,6 @@ const routes: RouteObject[] = [
         ...page(() => import("./pages/me/budget/request")),
       },
 
-      // CLI device-flow approval (RFC 8628 user-facing screen)
-      {
-        path: "/cli/auth",
-        ...page(() => import("./pages/cli/auth")),
-      },
-
       // AI Gateway: org-scoped admin pages live under /gateway/** at the top
       // level, like /governance. Every gateway resource (VirtualKey /
       // GatewayBudget / ModelProvider) is org-keyed by the schema, so the
@@ -384,6 +378,14 @@ const routes: RouteObject[] = [
       },
       ...legacyRedirectRoutes,
     ],
+  },
+
+  // CLI device-flow approval (RFC 8628 user-facing screen). Top level, like
+  // /onboarding: it is a confirm-a-code screen, not a page of the app, and
+  // the Langy panel must not mount on it.
+  {
+    path: "/cli/auth",
+    ...page(() => import("./pages/cli/auth")),
   },
 
   // Project routes — wrapped in a layout route that mounts Langy ONCE per

--- a/specs/langy/langy-mount-scope.feature
+++ b/specs/langy/langy-mount-scope.feature
@@ -1,0 +1,13 @@
+Feature: Langy mounts with the product pages, not the special screens
+  As a reader of the CLI device approval screen
+  I want no assistant panel over the confirmation
+  So that the screen shows only the approval decision
+
+  Background:
+    Given the application's route table
+
+  @unit
+  Scenario: The CLI device approval screen carries no assistant panel
+    When the route for /cli/auth is matched against the route table
+    Then no Langy layout route is among its ancestors
+    And a settings route still resolves under the Langy layout route


### PR DESCRIPTION
The Langy assistant panel rendered on the `/cli/auth` device-approval screen: the route sat inside the settings-and-governance `ProjectLangyLayout` block, and everything under a Langy layout route gets the panel. A screen whose only job is confirming one code should not have a chat panel drawn over it.

The route moves to the top level, next to `/onboarding`, which is the same class of screen: a focused flow, not a page of the app. The `/gateway` block's existing comment already states the rule ("Langy must not mount on" non-product routes); `/cli/auth` now follows it.

## Spec and tests

New `specs/langy/langy-mount-scope.feature` with one `@unit` scenario, bound by a structural test that matches paths against the real router:

- matching `/cli/auth` resolves under no Langy layout route
- matching `/settings/members` still resolves under exactly one, so the detector cannot pass vacuously

The detector identifies a Langy layout structurally (a pathless `page()` route; the two Langy layouts are the route table's only ones), not by string-matching import paths. All 16 existing cli-auth page tests pass unchanged; the panel was never part of their assertions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented the Langy assistant panel from appearing on the CLI authentication approval screen.
  * Preserved the assistant panel on applicable settings pages.

* **Tests**
  * Added coverage verifying the assistant panel appears only within intended settings routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->