### PR TITLE
fix(dev): the check-queue gate-off is the operator's lever, not the agents'

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -226,7 +226,8 @@ no path argument at all. Naming files (`tsc --noEmit src/foo.ts`) stays instant
 and unqueued, and `--watch` / `--lsp` never queue, since they would hold a slot
 for the session. A run that already holds a slot exports `CHECK_SLOTS=0` with
 its pid in `CHECK_QUEUE_HELD` to everything it spawns, so it can't queue behind
-itself; the marker only convinces a descendant of that run. The installer stands
+itself; the marker only convinces a descendant of that run, and only when the
+pid names one of the queue's own wrappers. The installer stands
 down entirely when `NODE_ENV=production` or `CI` is set to anything but `0` or
 `false`, so an image build or a server install keeps pnpm's own bin entries.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,9 +208,11 @@ delegates the run to `haven slot run`, which gates on the same flock semaphore
 haven (`CHECK_QUEUE_IMPL=js` forces it). With a slot free it prints nothing
 and is otherwise transparent (same stdio, same exit code). Queued, it says so on
 stderr, which is what tells you a slow run was waiting rather than hung.
-`CHECK_SLOTS=N` overrides the limit and `CHECK_SLOTS=0` turns the queue off;
-unset, the limit comes from the machine (one per 6 GiB of RAM, capped at one per
-4 cores) and CI does not queue at all. `node dev/scripts/check-queue.mjs
+`CHECK_SLOTS=N` overrides the limit, and `CHECK_SLOTS=0` turns the queue off
+from a person's shell only: agent shells carry `CLAUDECODE`, and a gate-off
+there is ignored with a note (never set `CHECK_SLOTS` yourself — the queue
+exists to serialize agents). Unset, the limit comes from the machine (one per
+6 GiB of RAM, capped at one per 4 cores) and CI does not queue at all. `node dev/scripts/check-queue.mjs
 --explain` shows the limit and who currently holds a slot. Don't cap the tools'
 own threads instead (`RAYON_NUM_THREADS` does work on biome): it spends the same
 CPU over 5x the wall clock. See `specs/setup/check-slots.feature`.
@@ -222,8 +224,9 @@ CPU over 5x the wall clock. See `specs/setup/check-slots.feature`.
 a slot too. Only whole-tree runs do: a `-p`/`--project`, a directory argument, or
 no path argument at all. Naming files (`tsc --noEmit src/foo.ts`) stays instant
 and unqueued, and `--watch` / `--lsp` never queue, since they would hold a slot
-for the session. A run that already holds a slot exports `CHECK_SLOTS=0` to
-everything it spawns, so it can't queue behind itself. The installer stands
+for the session. A run that already holds a slot exports `CHECK_SLOTS=0` with
+its pid in `CHECK_QUEUE_HELD` to everything it spawns, so it can't queue behind
+itself; the marker only convinces a descendant of that run. The installer stands
 down entirely when `NODE_ENV=production` or `CI` is set to anything but `0` or
 `false`, so an image build or a server install keeps pnpm's own bin entries.
 

--- a/dev/scripts/check-queue.mjs
+++ b/dev/scripts/check-queue.mjs
@@ -29,8 +29,10 @@
  *                            and is off under CI, where one job runs one check.
  *   CHECK_QUEUE_HELD=<pid>   Set by the queue itself on everything below a
  *                            wrapper that already counted the run. Honored
- *                            only when the pid is a live ancestor, so a copied
- *                            value gates nothing off.
+ *                            only when the pid is a live ancestor AND that
+ *                            process is one of the queue's own wrappers, so
+ *                            neither a copied pid nor a shell's own $$ gates
+ *                            anything off.
  *   CHECK_PRESSURE=<level>   Forces the memory-pressure level (green, amber or
  *                            red) instead of measuring it. Unset measures; a
  *                            misspelling measures too. Under amber or red the
@@ -160,29 +162,59 @@ function resolvePressure(env) {
 }
 
 /**
- * The parent of `pid`, read through ps because Node only knows its own parent,
- * or null when it cannot be read.
+ * One field of `pid` read through ps, because Node knows only its own process.
+ * Null when it cannot be read. `-ww` because ps otherwise cuts a command line
+ * at the terminal width, and the script path this reads for sits at the end of
+ * one.
  */
-function parentOfPid(pid) {
+function psField(pid, field) {
   try {
-    const result = spawnSync("ps", ["-o", "ppid=", "-p", String(pid)], {
+    const args = ["-ww", "-o", `${field}=`, "-p", String(pid)];
+    const result = spawnSync("ps", args, {
       encoding: "utf8",
       timeout: 2000,
     });
     if (result.status !== 0) return null;
-    const parent = Number.parseInt((result.stdout ?? "").trim(), 10);
-    return Number.isInteger(parent) && parent > 0 ? parent : null;
+    const value = (result.stdout ?? "").trim();
+    return value === "" ? null : value;
   } catch {
     return null;
   }
 }
 
+/** The parent of `pid`, or null when it cannot be read. */
+function parentOfPid(pid) {
+  const parent = Number.parseInt(psField(pid, "ppid") ?? "", 10);
+  return Number.isInteger(parent) && parent > 0 ? parent : null;
+}
+
 /**
- * Whether `candidate` sits above this process in the live parent chain. A
- * chain that cannot be read answers no: a marker that cannot be verified must
- * gate nothing off.
+ * Whether a command line is one of the two programs that hand a slot down: this
+ * script, and the haven binary whose `slot run` does the same job in Go.
  */
-function isLiveAncestor(candidate) {
+function isQueueCommand(command) {
+  if (!command) return false;
+  if (command.includes("check-queue.mjs")) return true;
+  const executable = path.basename(command.trim().split(/\s+/)[0] ?? "");
+  return executable === "haven" || executable.startsWith("haven.");
+}
+
+/**
+ * Whether `candidate` is a slot-holding wrapper above this process: it must sit
+ * in the live parent chain AND be one of the queue's own programs. Ancestry
+ * alone proves nothing, because a shell is an ancestor of everything it runs,
+ * so `CHECK_QUEUE_HELD=$$` would otherwise hand any agent the gate-off. A chain
+ * that cannot be read answers no: a marker that cannot be verified must gate
+ * nothing off.
+ *
+ * This is a lock on an honest door, not a vault. Anyone who may spawn processes
+ * on the machine may also spawn one named `haven`. It stops the one-token
+ * bypasses, which is what the queue needs: the runs it serializes are all
+ * started by the wrappers themselves.
+ */
+function heldByQueueAncestor(candidate) {
+  if (!Number.isInteger(candidate) || candidate <= 1) return false;
+  if (!isQueueCommand(psField(candidate, "args"))) return false;
   let current = process.pid;
   for (let hop = 0; hop < 64; hop++) {
     const parent = parentOfPid(current);
@@ -220,15 +252,16 @@ function resolveSlots(env, pressure = "green") {
       // exists to serialize, so from an agent shell (Claude Code sets
       // CLAUDECODE in every shell it spawns) it is honored only when the queue
       // itself asked for it: a wrapper that already counted the run puts its
-      // own pid in CHECK_QUEUE_HELD, and only a live ancestor counts, so a
-      // copied pid gates nothing off. Observed in the wild: an agent prefixed
-      // CHECK_SLOTS=0 onto a whole-tree typecheck to jump the queue, and the
-      // machine ran three checks at once, 14 GB into swap.
+      // own pid in CHECK_QUEUE_HELD, and only a live ancestor that is itself
+      // one of the queue's wrappers counts, so neither a copied pid nor a
+      // shell's own `$$` gates anything off. Observed in the wild: an agent
+      // prefixed CHECK_SLOTS=0 onto a whole-tree typecheck to jump the queue,
+      // and the machine ran three checks at once, 14 GB into swap.
       if (!isTruthyEnv(env.CLAUDECODE)) {
         return { slots: 0, source: "CHECK_SLOTS" };
       }
       const held = Number.parseInt((env.CHECK_QUEUE_HELD ?? "").trim(), 10);
-      if (Number.isInteger(held) && held > 1 && isLiveAncestor(held)) {
+      if (heldByQueueAncestor(held)) {
         return { slots: 0, source: "held" };
       }
       stderr(

--- a/dev/scripts/check-queue.mjs
+++ b/dev/scripts/check-queue.mjs
@@ -199,11 +199,10 @@ function isLiveAncestor(candidate) {
  * An explicit CHECK_SLOTS always wins, including under CI, which is what lets
  * the tests exercise the queue on a CI runner. One exception: a gate-off value
  * from an agent shell is ignored, see the comment at the check. Unset, CI gets
- * no queue at all
- * (one job runs one check, so a gate could only add risk) and a developer
- * machine gets a limit bounded by both memory and cores: tsgo is memory-hungry
- * AND parallel, so the tighter of the two bounds is the honest one. Never below
- * 1, or the queue would deadlock every run.
+ * no queue at all (one job runs one check, so a gate could only add risk) and a
+ * developer machine gets a limit bounded by both memory and cores: tsgo is
+ * memory-hungry AND parallel, so the tighter of the two bounds is the honest
+ * one. Never below 1, or the queue would deadlock every run.
  *
  * A machine already under memory pressure gets one slot, whatever the formula
  * says. The formula assumes an otherwise idle machine, and pressure is the

--- a/dev/scripts/check-queue.mjs
+++ b/dev/scripts/check-queue.mjs
@@ -21,9 +21,16 @@
  *
  * Environment:
  *   CHECK_SLOTS=N            How many checks may proceed at once. 0 (or "off")
- *                            disables the queue entirely. Unset derives a limit
- *                            from the machine, and is off under CI, where one
- *                            job runs one check.
+ *                            disables the queue entirely — from a person's
+ *                            shell. Agent shells carry CLAUDECODE, and there a
+ *                            gate-off is ignored: an agent may not remove the
+ *                            machine-wide serialization that exists because of
+ *                            agents. Unset derives a limit from the machine,
+ *                            and is off under CI, where one job runs one check.
+ *   CHECK_QUEUE_HELD=<pid>   Set by the queue itself on everything below a
+ *                            wrapper that already counted the run. Honored
+ *                            only when the pid is a live ancestor, so a copied
+ *                            value gates nothing off.
  *   CHECK_PRESSURE=<level>   Forces the memory-pressure level (green, amber or
  *                            red) instead of measuring it. Unset measures; a
  *                            misspelling measures too. Under amber or red the
@@ -45,7 +52,8 @@
  * the read-decide-write step between processes.
  *
  * `haven typecheck` (ADR-064) holds one of its own RAM slots and passes
- * CHECK_SLOTS=0 to the run it spawns, so a run is never counted twice.
+ * CHECK_SLOTS=0 with its pid in CHECK_QUEUE_HELD to the run it spawns, so a
+ * run is never counted twice.
  */
 
 import { spawn, spawnSync } from "node:child_process";
@@ -77,13 +85,13 @@ const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 /**
  * The CI convention: the variable is set to something that is not one of the
- * values meaning "not CI". The slot limit and the pressure policy both ask
- * this, so they ask it in one place and cannot drift apart. Mirrors
- * isTruthyCI in tools/thuishaven/domain/checkslots.go.
+ * values meaning "no". CI and CLAUDECODE both follow it, so the slot limit and
+ * the pressure policy read them by one rule that cannot drift apart. Mirrors
+ * isTruthyEnv in tools/thuishaven/domain/checkslots.go.
  */
-function isTruthyCI(ci) {
-  const value = (ci ?? "").trim().toLowerCase();
-  return value !== "" && value !== "0" && value !== "false";
+function isTruthyEnv(value) {
+  const normalized = (value ?? "").trim().toLowerCase();
+  return normalized !== "" && normalized !== "0" && normalized !== "false";
 }
 
 /**
@@ -109,7 +117,7 @@ function resolvePressure(env) {
   if (forced === "green" || forced === "amber" || forced === "red") {
     return forced;
   }
-  if (isTruthyCI(env.CI)) return "green";
+  if (isTruthyEnv(env.CI)) return "green";
   if (process.platform !== "darwin") return "green";
 
   const probe = (command, args) => {
@@ -152,10 +160,46 @@ function resolvePressure(env) {
 }
 
 /**
+ * The parent of `pid`, read through ps because Node only knows its own parent,
+ * or null when it cannot be read.
+ */
+function parentOfPid(pid) {
+  try {
+    const result = spawnSync("ps", ["-o", "ppid=", "-p", String(pid)], {
+      encoding: "utf8",
+      timeout: 2000,
+    });
+    if (result.status !== 0) return null;
+    const parent = Number.parseInt((result.stdout ?? "").trim(), 10);
+    return Number.isInteger(parent) && parent > 0 ? parent : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Whether `candidate` sits above this process in the live parent chain. A
+ * chain that cannot be read answers no: a marker that cannot be verified must
+ * gate nothing off.
+ */
+function isLiveAncestor(candidate) {
+  let current = process.pid;
+  for (let hop = 0; hop < 64; hop++) {
+    const parent = parentOfPid(current);
+    if (parent === null || parent <= 1) return false;
+    if (parent === candidate) return true;
+    current = parent;
+  }
+  return false;
+}
+
+/**
  * Resolves how many checks may proceed at once.
  *
  * An explicit CHECK_SLOTS always wins, including under CI, which is what lets
- * the tests exercise the queue on a CI runner. Unset, CI gets no queue at all
+ * the tests exercise the queue on a CI runner. One exception: a gate-off value
+ * from an agent shell is ignored, see the comment at the check. Unset, CI gets
+ * no queue at all
  * (one job runs one check, so a gate could only add risk) and a developer
  * machine gets a limit bounded by both memory and cores: tsgo is memory-hungry
  * AND parallel, so the tighter of the two bounds is the honest one. Never below
@@ -170,11 +214,28 @@ function resolvePressure(env) {
 function resolveSlots(env, pressure = "green") {
   const raw = (env.CHECK_SLOTS ?? "").trim();
   if (raw !== "") {
-    if (/^(off|none|unlimited|false)$/i.test(raw)) {
-      return { slots: 0, source: "CHECK_SLOTS" };
-    }
     const parsed = Number.parseInt(raw, 10);
-    if (Number.isNaN(parsed) || parsed < 0) {
+    const gateOff = /^(off|none|unlimited|false)$/i.test(raw) || parsed === 0;
+    if (gateOff) {
+      // The gate-off is the operator's lever, and agents are who the queue
+      // exists to serialize, so from an agent shell (Claude Code sets
+      // CLAUDECODE in every shell it spawns) it is honored only when the queue
+      // itself asked for it: a wrapper that already counted the run puts its
+      // own pid in CHECK_QUEUE_HELD, and only a live ancestor counts, so a
+      // copied pid gates nothing off. Observed in the wild: an agent prefixed
+      // CHECK_SLOTS=0 onto a whole-tree typecheck to jump the queue, and the
+      // machine ran three checks at once, 14 GB into swap.
+      if (!isTruthyEnv(env.CLAUDECODE)) {
+        return { slots: 0, source: "CHECK_SLOTS" };
+      }
+      const held = Number.parseInt((env.CHECK_QUEUE_HELD ?? "").trim(), 10);
+      if (Number.isInteger(held) && held > 1 && isLiveAncestor(held)) {
+        return { slots: 0, source: "held" };
+      }
+      stderr(
+        `${PREFIX} CHECK_SLOTS=${raw} is ignored in an agent shell; the machine policy applies. Only a person may turn the queue off.\n`,
+      );
+    } else if (Number.isNaN(parsed) || parsed < 0) {
       stderr(
         `${PREFIX} ignoring CHECK_SLOTS=${raw}, expected a non-negative integer\n`,
       );
@@ -183,7 +244,7 @@ function resolveSlots(env, pressure = "green") {
     }
   }
 
-  if (isTruthyCI(env.CI)) {
+  if (isTruthyEnv(env.CI)) {
     return { slots: 0, source: "CI" };
   }
 
@@ -528,8 +589,12 @@ function runCommand(commandArgv, pressure = "green") {
       // We are the slot for everything below us. Without this, a run holding
       // the only slot queues behind itself the moment it reaches a bin shim
       // (`pnpm typecheck` spawns .bin/tsgo, which is one) or a nested package
-      // script, and waits out the whole maximum wait before starting.
+      // script, and waits out the whole maximum wait before starting. The pid
+      // marker is what keeps this working in agent shells, where a bare
+      // CHECK_SLOTS=0 is ignored; it only convinces a descendant, so an agent
+      // cannot borrow it.
       CHECK_SLOTS: "0",
+      CHECK_QUEUE_HELD: String(process.pid),
       GOMEMLIMIT: goMemLimit(pressure),
     };
     const procs = goMaxProcs(pressure);

--- a/platform/app/scripts/__tests__/check-queue.unit.test.ts
+++ b/platform/app/scripts/__tests__/check-queue.unit.test.ts
@@ -571,9 +571,13 @@ describe("check queue", () => {
       expect(startOrder(readEvents())).toEqual(["inner"]);
     });
 
-    it("honors a held-marker naming a live ancestor", async () => {
+    /** @scenario "An agent's own shell is not a queue wrapper" */
+    it("rejects a held-marker naming an ancestor that is not a queue wrapper", async () => {
+      // The test runner is a real live ancestor of the run below, and it is
+      // not the queue. `CHECK_QUEUE_HELD=$$` from an agent shell has exactly
+      // this shape, and it is the cheapest bypass there is, so it must fail.
       const explained = await startRun({
-        tag: "held",
+        tag: "not-the-queue",
         argv: ["--explain"],
         env: {
           CLAUDECODE: "1",
@@ -583,8 +587,8 @@ describe("check queue", () => {
         },
       }).done;
 
-      expect(explained.stderr).toContain("slots=0 source=held");
-      expect(explained.stderr).not.toContain("ignored in an agent shell");
+      expect(explained.stderr).toContain("ignored in an agent shell");
+      expect(explained.stderr).not.toContain("source=held");
     });
 
     /** @scenario "A borrowed held-marker does not turn the queue off" */

--- a/platform/app/scripts/__tests__/check-queue.unit.test.ts
+++ b/platform/app/scripts/__tests__/check-queue.unit.test.ts
@@ -131,6 +131,10 @@ function startRun({
     // assertion would flake red. The pressure tests below force their own
     // levels the same way.
     CHECK_PRESSURE: "green",
+    // The suite itself often runs inside an agent shell, where a gate-off
+    // CHECK_SLOTS is ignored by design. Dropped so every test means what it
+    // says; the agent-shell tests below set it back on purpose.
+    CLAUDECODE: undefined,
     ...envOverrides,
   })) {
     if (value !== undefined) env[key] = value;
@@ -227,15 +231,22 @@ describe("check queue", () => {
     it("tells everything below it that the slot is already held", async () => {
       // The bin shims mean a queued `pnpm typecheck` spawns another gated
       // entry point. Without this, it queues behind the slot it is holding and
-      // waits out the entire maximum wait before starting.
+      // waits out the entire maximum wait before starting. The marker carries
+      // the wrapper's own pid, which is what an agent shell verifies.
       const run = startRun({
         tag: "nested",
-        argv: ["node", "-e", "process.stdout.write(process.env.CHECK_SLOTS)"],
+        argv: [
+          "node",
+          "-e",
+          'process.stdout.write([process.env.CHECK_SLOTS, process.env.CHECK_QUEUE_HELD, String(process.ppid)].join(" "))',
+        ],
         env: { CHECK_SLOTS: "3" },
       });
       const result = await run.done;
 
-      expect(result.stdout).toBe("0");
+      const [slots, held, wrapper] = result.stdout.split(" ");
+      expect(slots).toBe("0");
+      expect(held).toBe(wrapper);
     });
 
     /** @scenario "The wrapper is transparent to the command it runs" */
@@ -501,6 +512,101 @@ describe("check queue", () => {
       expect(maxOverlap(readEvents())).toBe(3);
       for (const result of results) expect(result.stderr).toBe("");
       expect(queueEntries()).toHaveLength(0);
+    });
+  });
+
+  describe("given an agent shell", () => {
+    /** @scenario "An agent shell cannot turn the queue off" */
+    it("ignores a gate-off, says so, and queues like everyone else", async () => {
+      const holder = startRun({ tag: "holder", holdMs: 700 });
+      await waitForHolder();
+      // Red narrows the derived limit to one, so the refusal is observable as
+      // real queueing rather than a message alone.
+      const agent = startRun({
+        tag: "agent",
+        env: {
+          CLAUDECODE: "1",
+          CHECK_SLOTS: "0",
+          CI: undefined,
+          CHECK_PRESSURE: "red",
+        },
+      });
+      const [, second] = await Promise.all([holder.done, agent.done]);
+
+      expect(second.stderr).toContain(
+        "CHECK_SLOTS=0 is ignored in an agent shell",
+      );
+      expect(second.stderr).toContain("Only a person may turn the queue off");
+      expect(second.stderr).toContain("1 check is already active");
+      expect(maxOverlap(readEvents())).toBe(1);
+    });
+
+    /** @scenario "A run the queue spawned itself stays unqueued in an agent shell" */
+    it("keeps the queue's own nested runs unqueued", async () => {
+      // A queued `pnpm typecheck` reaches a bin shim, which is another gated
+      // entry point running under the wrapper's CHECK_SLOTS=0 and marker. In
+      // an agent shell the marker is what carries the gate-off through.
+      const run = startRun({
+        tag: "outer",
+        argv: [
+          "node",
+          QUEUE_SCRIPT,
+          "node",
+          fakeCommand,
+          logFile,
+          "inner",
+          "0",
+        ],
+        // Bounds the failure mode: a regression here queues the inner run
+        // behind the outer's held slot, and "starting anyway" breaks the
+        // silence assertion instead of hanging the suite for the default wait.
+        env: { CLAUDECODE: "1", CHECK_QUEUE_MAX_WAIT_MS: "3000" },
+      });
+      const result = await run.done;
+
+      expect(result.code).toBe(0);
+      // Silent end to end: the outer run found a free slot, and the inner one
+      // was neither refused nor queued.
+      expect(result.stderr).toBe("");
+      expect(startOrder(readEvents())).toEqual(["inner"]);
+    });
+
+    it("honors a held-marker naming a live ancestor", async () => {
+      const explained = await startRun({
+        tag: "held",
+        argv: ["--explain"],
+        env: {
+          CLAUDECODE: "1",
+          CHECK_SLOTS: "0",
+          CHECK_QUEUE_HELD: String(process.pid),
+          CI: undefined,
+        },
+      }).done;
+
+      expect(explained.stderr).toContain("slots=0 source=held");
+      expect(explained.stderr).not.toContain("ignored in an agent shell");
+    });
+
+    /** @scenario "A borrowed held-marker does not turn the queue off" */
+    it("rejects a held-marker naming a live process that is not an ancestor", async () => {
+      const bystander = spawn("sleep", ["30"]);
+      try {
+        const explained = await startRun({
+          tag: "borrowed",
+          argv: ["--explain"],
+          env: {
+            CLAUDECODE: "1",
+            CHECK_SLOTS: "0",
+            CHECK_QUEUE_HELD: String(bystander.pid),
+            CI: undefined,
+          },
+        }).done;
+
+        expect(explained.stderr).toContain("ignored in an agent shell");
+        expect(explained.stderr).not.toContain("source=held");
+      } finally {
+        bystander.kill("SIGKILL");
+      }
     });
   });
 

--- a/specs/setup/check-slots.feature
+++ b/specs/setup/check-slots.feature
@@ -165,9 +165,16 @@ Feature: Machine-wide slots for whole-repo checks
 
   # The queue itself turns the gate off for everything below a run it already
   # counted, or a slot-holding run would queue behind itself at the first bin
-  # shim. That gate-off carries the wrapper's pid in CHECK_QUEUE_HELD, and it
-  # is honored only when that pid is a live ancestor of the run asking, so an
-  # agent cannot borrow the marker: a copied pid is not its ancestor.
+  # shim. That gate-off carries the wrapper's pid in CHECK_QUEUE_HELD, and the
+  # pid must pass two tests: it is a live ancestor of the run asking, and that
+  # process is one of the queue's own wrappers. Ancestry alone would prove
+  # nothing, because a shell is an ancestor of every command it runs, so
+  # CHECK_QUEUE_HELD=$$ would hand the gate-off to any agent that types it.
+  #
+  # This is a lock on an honest door, not a vault. Anyone who may start
+  # processes on the machine may start one named haven. It closes the one-token
+  # bypasses, which is what the queue needs: the runs it serializes are all
+  # started by the wrappers themselves.
 
   @unit
   Scenario: A run the queue spawned itself stays unqueued in an agent shell
@@ -183,6 +190,13 @@ Feature: Machine-wide slots for whole-repo checks
     And CLAUDECODE is set and CHECK_SLOTS asks for the gate to be off
     When the limit is resolved
     Then the derived limit applies
+
+  @unit
+  Scenario: An agent's own shell is not a queue wrapper
+    Given CHECK_QUEUE_HELD names a live ancestor of the run that is not a queue wrapper
+    And CLAUDECODE is set and CHECK_SLOTS asks for the gate to be off
+    When the limit is resolved
+    Then the derived limit applies, because the marker names no wrapper that counted the run
 
   @unit
   Scenario: haven ignores an agent's gate-off the same way

--- a/specs/setup/check-slots.feature
+++ b/specs/setup/check-slots.feature
@@ -27,7 +27,8 @@ Feature: Machine-wide slots for whole-repo checks
   # hung tool.
   #
   # Knobs, all optional:
-  #   CHECK_SLOTS=N            how many may run at once (0 disables the gate)
+  #   CHECK_SLOTS=N            how many may run at once (0 disables the gate,
+  #                            from a person's shell; agent shells cannot)
   #   CHECK_PRESSURE=<level>   force the memory-pressure level (green/amber/red)
   #   CHECK_QUEUE_DIR=<path>   where the shared state lives
   #   CHECK_QUEUE_POLL_MS=N    how often a waiter re-checks
@@ -123,7 +124,7 @@ Feature: Machine-wide slots for whole-repo checks
 
   @unit
   Scenario: The limit can be turned off
-    Given CHECK_SLOTS is 0
+    Given CHECK_SLOTS is 0 in a person's shell
     When several checks run at once
     Then none of them queue
 
@@ -144,6 +145,50 @@ Feature: Machine-wide slots for whole-repo checks
     Given CI is set and CHECK_SLOTS is not
     When a check runs
     Then the gate is off, because a CI runner runs one check at a time anyway
+
+  # --- The gate-off is the operator's lever, not the agents' ---
+
+  # Observed in the wild: an agent prefixed CHECK_SLOTS=0 onto a whole-tree
+  # typecheck to jump the queue, and the machine ran three checks at once, 14
+  # GB into swap. The queue exists to serialize agents, so a lever any agent
+  # may pull is not a limit. Agent shells are recognizable: Claude Code sets
+  # CLAUDECODE in every shell it spawns. A person's own shell does not carry
+  # it, so the operator keeps the lever.
+
+  @unit
+  Scenario: An agent shell cannot turn the queue off
+    Given CLAUDECODE is set, as it is in every agent shell
+    And CHECK_SLOTS asks for the gate to be off
+    When the limit is resolved
+    Then the derived limit applies as if CHECK_SLOTS were unset
+    And the run says the gate-off was ignored and that only a person may turn the queue off
+
+  # The queue itself turns the gate off for everything below a run it already
+  # counted, or a slot-holding run would queue behind itself at the first bin
+  # shim. That gate-off carries the wrapper's pid in CHECK_QUEUE_HELD, and it
+  # is honored only when that pid is a live ancestor of the run asking, so an
+  # agent cannot borrow the marker: a copied pid is not its ancestor.
+
+  @unit
+  Scenario: A run the queue spawned itself stays unqueued in an agent shell
+    Given a wrapper holding a slot spawned the run with its pid in CHECK_QUEUE_HELD
+    And CLAUDECODE is set
+    When the limit is resolved
+    Then the gate is off for this run, because the wrapper above already counted it
+    And nothing is printed, because nothing was refused
+
+  @unit
+  Scenario: A borrowed held-marker does not turn the queue off
+    Given CHECK_QUEUE_HELD names a live process that is not an ancestor of the run
+    And CLAUDECODE is set and CHECK_SLOTS asks for the gate to be off
+    When the limit is resolved
+    Then the derived limit applies
+
+  @unit
+  Scenario: haven ignores an agent's gate-off the same way
+    Given CLAUDECODE is set and CHECK_SLOTS asks for the gate to be off
+    When haven resolves the slot limit
+    Then the derived limit applies, exactly as the JavaScript queue resolves it
 
   # --- Memory pressure: the machine says the formula's assumption is false ---
 

--- a/tools/thuishaven/app/run.go
+++ b/tools/thuishaven/app/run.go
@@ -90,8 +90,9 @@ func (o *Orchestrator) RunHeavy(ctx context.Context, r HeavyRun) error {
 	started := o.sys.Now()
 	// The inner script takes a machine-wide slot of its own. We already hold
 	// one, so turn that gate off for this run: counting it twice would queue it
-	// behind itself.
-	env := []string{"CHECK_SLOTS=0", "HAVEN_SLOT_HELD=1"}
+	// behind itself. The pid marker is what agent shells honor, and it only
+	// convinces a descendant.
+	env := []string{"CHECK_SLOTS=0", "CHECK_QUEUE_HELD=" + strconv.Itoa(os.Getpid()), "HAVEN_SLOT_HELD=1"}
 	if r.Workers > 0 {
 		env = append(env, "VITEST_MAX_WORKERS="+strconv.Itoa(r.Workers))
 	}

--- a/tools/thuishaven/app/typecheck.go
+++ b/tools/thuishaven/app/typecheck.go
@@ -3,7 +3,9 @@ package app
 import (
 	"context"
 	"fmt"
+	"os"
 	"runtime"
+	"strconv"
 	"strings"
 
 	"github.com/langwatch/langwatch/tools/thuishaven/domain"
@@ -46,8 +48,9 @@ func (o *Orchestrator) Typecheck(ctx context.Context, lwDir string, extraArgs []
 	// (dev/scripts/check-queue.mjs). We already hold one here, so turn that
 	// gate off for this run: counting it twice would queue it behind itself, and
 	// the reaper's duration ceiling would then be spent waiting rather than
-	// typechecking.
-	env := []string{"CHECK_SLOTS=0"}
+	// typechecking. The pid marker is what agent shells honor, and it only
+	// convinces a descendant.
+	env := []string{"CHECK_SLOTS=0", "CHECK_QUEUE_HELD=" + strconv.Itoa(os.Getpid())}
 	return o.sup.RunOnceBounded(ctx, "typecheck", lwDir, shell, env, ReapLimits(rl))
 }
 

--- a/tools/thuishaven/cmd/help.go
+++ b/tools/thuishaven/cmd/help.go
@@ -118,13 +118,17 @@ var envHelpText = `Environment variables.
                                  runaway tsgo shouldn't sit on a slot forever.
     CHECK_SLOTS=N                Caps concurrent whole-repo checks ("pnpm
                                  typecheck", "pnpm lint") machine wide (0
-                                 disables). With haven installed those runs are
+                                 disables — from a person's shell; agent shells
+                                 carry CLAUDECODE and a gate-off there is
+                                 ignored). With haven installed those runs are
                                  delegated to "haven slot run", which gates on
                                  the same flock semaphore "haven typecheck"
                                  holds — one counter for everything that
                                  saturates the cores. Both set CHECK_SLOTS=0
-                                 for the run they spawn, so a run is never
-                                 counted twice and cannot queue behind itself.
+                                 with their pid in CHECK_QUEUE_HELD for the run
+                                 they spawn, so a run is never counted twice
+                                 and cannot queue behind itself; the marker
+                                 only convinces a descendant.
                                  CHECK_QUEUE_IMPL=js forces the JavaScript
                                  queue in dev/scripts/check-queue.mjs.
     HAVEN_SLOT_HELD=1            Set by "haven run" inside the command it spawns:

--- a/tools/thuishaven/cmd/help.go
+++ b/tools/thuishaven/cmd/help.go
@@ -128,7 +128,8 @@ var envHelpText = `Environment variables.
                                  with their pid in CHECK_QUEUE_HELD for the run
                                  they spawn, so a run is never counted twice
                                  and cannot queue behind itself; the marker
-                                 only convinces a descendant.
+                                 only convinces a descendant, and only when it
+                                 names one of those two wrappers.
                                  CHECK_QUEUE_IMPL=js forces the JavaScript
                                  queue in dev/scripts/check-queue.mjs.
     HAVEN_SLOT_HELD=1            Set by "haven run" inside the command it spawns:

--- a/tools/thuishaven/cmd/slot.go
+++ b/tools/thuishaven/cmd/slot.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
@@ -95,14 +96,14 @@ func resolveSlotLimit(pressure domain.Pressure, env domain.CheckEnv) (int, strin
 }
 
 // slotCheckEnv reads the environment the slot limit is resolved from. The
-// ancestry walk behind HeldByQueue runs only when the marker is present, which
+// process walk behind HeldByQueue runs only when the marker is present, which
 // is only on runs the queue itself spawned.
 func slotCheckEnv() domain.CheckEnv {
 	return domain.CheckEnv{
 		CheckSlots:  os.Getenv("CHECK_SLOTS"),
 		CI:          os.Getenv("CI"),
 		Claudecode:  os.Getenv("CLAUDECODE"),
-		HeldByQueue: heldByLiveAncestor(os.Getenv("CHECK_QUEUE_HELD")),
+		HeldByQueue: heldByQueueAncestor(os.Getenv("CHECK_QUEUE_HELD")),
 	}
 }
 
@@ -117,16 +118,31 @@ func reportGateOffIgnored(env domain.CheckEnv) {
 		strings.TrimSpace(env.CheckSlots))
 }
 
-// heldByLiveAncestor verifies a CHECK_QUEUE_HELD marker: the pid it names must
-// sit above this process in the live parent chain, so only a wrapper that
-// spawned this run — an ancestor by construction — can convince it. A chain
-// that cannot be read answers no: a marker that cannot be verified must gate
-// nothing off.
-func heldByLiveAncestor(raw string) bool {
+// heldByQueueAncestor verifies a CHECK_QUEUE_HELD marker: the pid it names must
+// sit above this process in the live parent chain AND be one of the queue's own
+// wrappers. Ancestry alone proves nothing, because a shell is an ancestor of
+// everything it runs, so CHECK_QUEUE_HELD=$$ would otherwise hand any agent the
+// gate-off. A chain that cannot be read answers no: a marker that cannot be
+// verified must gate nothing off.
+//
+// This is a lock on an honest door, not a vault. Anyone who may spawn processes
+// on the machine may also spawn one named haven. It stops the one-token
+// bypasses, which is what the queue needs: the runs it serializes are all
+// started by the wrappers themselves.
+func heldByQueueAncestor(raw string) bool {
 	candidate, err := strconv.Atoi(strings.TrimSpace(raw))
 	if err != nil || candidate <= 1 {
 		return false
 	}
+	if !isQueueCommand(psField(candidate, "args")) {
+		return false
+	}
+	return isLiveAncestor(candidate)
+}
+
+// isLiveAncestor reports that candidate sits above this process in the live
+// parent chain.
+func isLiveAncestor(candidate int) bool {
 	current := os.Getpid()
 	for hop := 0; hop < 64; hop++ {
 		parent := parentPid(current)
@@ -141,19 +157,41 @@ func heldByLiveAncestor(raw string) bool {
 	return false
 }
 
+// isQueueCommand reports that a command line is one of the two programs that
+// hand a slot down: the JavaScript wrapper dev/scripts/check-queue.mjs, and the
+// haven binary whose slot run does the same job in Go.
+func isQueueCommand(command string) bool {
+	command = strings.TrimSpace(command)
+	if command == "" {
+		return false
+	}
+	if strings.Contains(command, "check-queue.mjs") {
+		return true
+	}
+	executable := filepath.Base(strings.Fields(command)[0])
+	return executable == "haven" || strings.HasPrefix(executable, "haven.")
+}
+
 // parentPid reads a process's parent through ps, which is what works for a pid
 // that is not our own. Zero means it could not be read.
 func parentPid(pid int) int {
-	cmd := exec.CommandContext(context.Background(), "ps", "-o", "ppid=", "-p", strconv.Itoa(pid)) //nolint:gosec // G204: fixed argv, the only variable is an integer
-	out, err := cmd.Output()
-	if err != nil {
-		return 0
-	}
-	parent, err := strconv.Atoi(strings.TrimSpace(string(out)))
+	parent, err := strconv.Atoi(psField(pid, "ppid"))
 	if err != nil || parent < 0 {
 		return 0
 	}
 	return parent
+}
+
+// psField reads one ps field of a pid. An empty string means it could not be
+// read. -ww because ps otherwise cuts a command line at the terminal width, and
+// the script path this reads for sits at the end of one.
+func psField(pid int, field string) string {
+	cmd := exec.CommandContext(context.Background(), "ps", "-ww", "-o", field+"=", "-p", strconv.Itoa(pid)) //nolint:gosec // G204: fixed argv, the only variables are an integer and a caller-supplied literal
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
 }
 
 // resolveSlotPressure measures once per invocation: the level shapes the

--- a/tools/thuishaven/cmd/slot.go
+++ b/tools/thuishaven/cmd/slot.go
@@ -10,6 +10,8 @@ import (
 	"os/exec"
 	"os/signal"
 	"runtime"
+	"strconv"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -48,8 +50,10 @@ func runSlot(ctx context.Context, _ deps, inv invocation) error {
 	}
 	switch inv.raw[0] {
 	case "explain":
+		env := slotCheckEnv()
+		reportGateOffIgnored(env)
 		pressure := resolveSlotPressure()
-		slots, source := resolveSlotLimit(pressure)
+		slots, source := resolveSlotLimit(pressure, env)
 		fmt.Printf("slots=%d source=%s\n", slots, source)
 		fmt.Printf("pressure=%s\n", pressure)
 		fmt.Printf("gomemlimit=%s\n", domain.CheckGoMemLimit(system.New().TotalMemory(), os.Getenv("GOMEMLIMIT"), pressure))
@@ -62,6 +66,7 @@ func runSlot(ctx context.Context, _ deps, inv invocation) error {
 		if err != nil {
 			return err
 		}
+		reportGateOffIgnored(slotCheckEnv())
 		job := &slotJob{
 			sem:      semaphore.New(havenHome()),
 			label:    label,
@@ -78,15 +83,77 @@ func runSlot(ctx context.Context, _ deps, inv invocation) error {
 	}
 }
 
-func resolveSlotLimit(pressure domain.Pressure) (int, string) {
+func resolveSlotLimit(pressure domain.Pressure, env domain.CheckEnv) (int, string) {
 	return domain.ResolveCheckSlots(
 		domain.CheckMachine{
 			TotalRAMBytes: system.New().TotalMemory(),
 			NumCPU:        runtime.NumCPU(),
 			Pressure:      pressure,
 		},
-		domain.CheckEnv{CheckSlots: os.Getenv("CHECK_SLOTS"), CI: os.Getenv("CI")},
+		env,
 	)
+}
+
+// slotCheckEnv reads the environment the slot limit is resolved from. The
+// ancestry walk behind HeldByQueue runs only when the marker is present, which
+// is only on runs the queue itself spawned.
+func slotCheckEnv() domain.CheckEnv {
+	return domain.CheckEnv{
+		CheckSlots:  os.Getenv("CHECK_SLOTS"),
+		CI:          os.Getenv("CI"),
+		Claudecode:  os.Getenv("CLAUDECODE"),
+		HeldByQueue: heldByLiveAncestor(os.Getenv("CHECK_QUEUE_HELD")),
+	}
+}
+
+// reportGateOffIgnored says why the limit still applies when an agent shell
+// asked for the gate to be off. Silence here would read as a broken override.
+func reportGateOffIgnored(env domain.CheckEnv) {
+	if !domain.GateOffIgnored(env) {
+		return
+	}
+	fmt.Fprintf(os.Stderr,
+		"checks: CHECK_SLOTS=%s is ignored in an agent shell; the machine policy applies. Only a person may turn the queue off.\n",
+		strings.TrimSpace(env.CheckSlots))
+}
+
+// heldByLiveAncestor verifies a CHECK_QUEUE_HELD marker: the pid it names must
+// sit above this process in the live parent chain, so only a wrapper that
+// spawned this run — an ancestor by construction — can convince it. A chain
+// that cannot be read answers no: a marker that cannot be verified must gate
+// nothing off.
+func heldByLiveAncestor(raw string) bool {
+	candidate, err := strconv.Atoi(strings.TrimSpace(raw))
+	if err != nil || candidate <= 1 {
+		return false
+	}
+	current := os.Getpid()
+	for hop := 0; hop < 64; hop++ {
+		parent := parentPid(current)
+		if parent <= 1 {
+			return false
+		}
+		if parent == candidate {
+			return true
+		}
+		current = parent
+	}
+	return false
+}
+
+// parentPid reads a process's parent through ps, which is what works for a pid
+// that is not our own. Zero means it could not be read.
+func parentPid(pid int) int {
+	cmd := exec.CommandContext(context.Background(), "ps", "-o", "ppid=", "-p", strconv.Itoa(pid)) //nolint:gosec // G204: fixed argv, the only variable is an integer
+	out, err := cmd.Output()
+	if err != nil {
+		return 0
+	}
+	parent, err := strconv.Atoi(strings.TrimSpace(string(out)))
+	if err != nil || parent < 0 {
+		return 0
+	}
+	return parent
 }
 
 // resolveSlotPressure measures once per invocation: the level shapes the
@@ -146,7 +213,7 @@ type slotJob struct {
 // a semaphore error and the maximum wait both degrade to running anyway, with
 // a line on stderr saying so.
 func (j *slotJob) run(ctx context.Context) int {
-	j.slots, _ = resolveSlotLimit(j.pressure)
+	j.slots, _ = resolveSlotLimit(j.pressure, slotCheckEnv())
 	if j.slots <= 0 {
 		return slotExec(ctx, j.argv, j.pressure)
 	}
@@ -215,8 +282,10 @@ func (j *slotJob) report(waited time.Duration) {
 	}
 }
 
-// slotExec runs argv with stdio inherited, CHECK_SLOTS=0 so nothing below the
-// slot queues behind it, and GOMEMLIMIT (unless the operator set one) so the
+// slotExec runs argv with stdio inherited, CHECK_SLOTS=0 with this pid in
+// CHECK_QUEUE_HELD so nothing below the slot queues behind it (the marker is
+// what agent shells honor, and it only convinces a descendant), and GOMEMLIMIT
+// (unless the operator set one) so the
 // Go-runtime tools this queue wraps degrade to slower instead of resident
 // (ADR-095); under memory pressure GOMAXPROCS is capped too, so the run leaves
 // cores for the person at the keyboard. Signals are forwarded so Ctrl-C
@@ -228,6 +297,7 @@ func slotExec(ctx context.Context, argv []string, pressure domain.Pressure) int 
 	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
 	cmd.Env = append(os.Environ(),
 		"CHECK_SLOTS=0",
+		"CHECK_QUEUE_HELD="+strconv.Itoa(os.Getpid()),
 		"GOMEMLIMIT="+domain.CheckGoMemLimit(system.New().TotalMemory(), os.Getenv("GOMEMLIMIT"), pressure),
 	)
 	if procs := domain.CheckGoMaxProcs(runtime.NumCPU(), os.Getenv("GOMAXPROCS"), pressure); procs != "" {

--- a/tools/thuishaven/cmd/slot_test.go
+++ b/tools/thuishaven/cmd/slot_test.go
@@ -319,12 +319,21 @@ func TestSlotRunQueuesAndSaysSo(t *testing.T) {
 }
 
 // @scenario "A borrowed held-marker does not turn the queue off"
-func TestHeldByLiveAncestor(t *testing.T) {
-	if !heldByLiveAncestor(strconv.Itoa(os.Getppid())) {
+// @scenario "An agent's own shell is not a queue wrapper"
+func TestHeldByQueueAncestor(t *testing.T) {
+	// The chain walk on its own: the test binary's parent really is above us.
+	// The full check refuses it all the same, because that parent runs "go
+	// test", not the queue. An agent's CHECK_QUEUE_HELD=$$ has exactly this
+	// shape, and this is what stops it.
+	if !isLiveAncestor(os.Getppid()) {
 		t.Fatal("the test binary's own parent must count as a live ancestor")
 	}
+	if heldByQueueAncestor(strconv.Itoa(os.Getppid())) {
+		t.Fatal("an ancestor that is not a queue wrapper must not verify")
+	}
+
 	for _, raw := range []string{"", "1", "0", "-4", "bananas"} {
-		if heldByLiveAncestor(raw) {
+		if heldByQueueAncestor(raw) {
 			t.Fatalf("%q must not verify as a held marker", raw)
 		}
 	}
@@ -339,8 +348,37 @@ func TestHeldByLiveAncestor(t *testing.T) {
 		_ = bystander.Process.Kill()
 		_ = bystander.Wait()
 	}()
-	if heldByLiveAncestor(strconv.Itoa(bystander.Process.Pid)) {
+	if heldByQueueAncestor(strconv.Itoa(bystander.Process.Pid)) {
 		t.Fatal("a live process that is not an ancestor must not verify")
+	}
+}
+
+// @scenario "An agent's own shell is not a queue wrapper"
+func TestIsQueueCommand(t *testing.T) {
+	accepted := []string{
+		"node /repo/dev/scripts/check-queue.mjs pnpm typecheck",
+		"haven slot run --label typecheck -- pnpm typecheck",
+		"/Users/someone/go/bin/haven typecheck",
+		"/var/folders/T/go-build/b001/haven.test -test.run TestX",
+	}
+	for _, command := range accepted {
+		if !isQueueCommand(command) {
+			t.Fatalf("%q must read as a queue wrapper", command)
+		}
+	}
+
+	refused := []string{
+		"",
+		"   ",
+		"-zsh",
+		"/bin/bash -l",
+		"node /repo/platform/app/scripts/__tests__/check-queue.unit.test.ts",
+		"/opt/homebrew/bin/havenclone slot run",
+	}
+	for _, command := range refused {
+		if isQueueCommand(command) {
+			t.Fatalf("%q must not read as a queue wrapper", command)
+		}
 	}
 }
 

--- a/tools/thuishaven/cmd/slot_test.go
+++ b/tools/thuishaven/cmd/slot_test.go
@@ -319,6 +319,32 @@ func TestSlotRunQueuesAndSaysSo(t *testing.T) {
 }
 
 // @scenario "A signal delivered to the whole process group still counts as forwarded"
+// @scenario "A borrowed held-marker does not turn the queue off"
+func TestHeldByLiveAncestor(t *testing.T) {
+	if !heldByLiveAncestor(strconv.Itoa(os.Getppid())) {
+		t.Fatal("the test binary's own parent must count as a live ancestor")
+	}
+	for _, raw := range []string{"", "1", "0", "-4", "bananas"} {
+		if heldByLiveAncestor(raw) {
+			t.Fatalf("%q must not verify as a held marker", raw)
+		}
+	}
+
+	// A live process that is not above us: an agent copying a wrapper's pid
+	// into its own environment is exactly this shape.
+	bystander := exec.Command("sleep", "30")
+	if err := bystander.Start(); err != nil {
+		t.Fatalf("starting the bystander: %v", err)
+	}
+	defer func() {
+		_ = bystander.Process.Kill()
+		_ = bystander.Wait()
+	}()
+	if heldByLiveAncestor(strconv.Itoa(bystander.Process.Pid)) {
+		t.Fatal("a live process that is not an ancestor must not verify")
+	}
+}
+
 func TestSignalRelayRecordsAQueuedSignal(t *testing.T) {
 	child := exec.Command("sleep", "10")
 	if err := child.Start(); err != nil {

--- a/tools/thuishaven/cmd/slot_test.go
+++ b/tools/thuishaven/cmd/slot_test.go
@@ -318,7 +318,6 @@ func TestSlotRunQueuesAndSaysSo(t *testing.T) {
 	}
 }
 
-// @scenario "A signal delivered to the whole process group still counts as forwarded"
 // @scenario "A borrowed held-marker does not turn the queue off"
 func TestHeldByLiveAncestor(t *testing.T) {
 	if !heldByLiveAncestor(strconv.Itoa(os.Getppid())) {
@@ -345,6 +344,7 @@ func TestHeldByLiveAncestor(t *testing.T) {
 	}
 }
 
+// @scenario "A signal delivered to the whole process group still counts as forwarded"
 func TestSignalRelayRecordsAQueuedSignal(t *testing.T) {
 	child := exec.Command("sleep", "10")
 	if err := child.Start(); err != nil {

--- a/tools/thuishaven/domain/checkslots.go
+++ b/tools/thuishaven/domain/checkslots.go
@@ -28,8 +28,9 @@ type CheckEnv struct {
 	CI         string // CI
 	Claudecode string // CLAUDECODE, set in every shell an agent runs
 	// HeldByQueue reports that CHECK_QUEUE_HELD names a live ancestor of this
-	// process: the queue itself spawned the run and already counted it. The
-	// caller resolves it, because the domain does not inspect processes.
+	// process that is itself one of the queue's wrappers: the queue spawned the
+	// run and already counted it. The caller resolves it, because the domain
+	// does not inspect processes.
 	HeldByQueue bool
 }
 

--- a/tools/thuishaven/domain/checkslots.go
+++ b/tools/thuishaven/domain/checkslots.go
@@ -22,10 +22,15 @@ const checkRAMPerRun = 6 << 30
 // is worth starting.
 const checkCPUsPerRun = 4
 
-// CheckEnv carries the two environment values the limit is resolved from.
+// CheckEnv carries the environment the limit is resolved from.
 type CheckEnv struct {
 	CheckSlots string // CHECK_SLOTS
 	CI         string // CI
+	Claudecode string // CLAUDECODE, set in every shell an agent runs
+	// HeldByQueue reports that CHECK_QUEUE_HELD names a live ancestor of this
+	// process: the queue itself spawned the run and already counted it. The
+	// caller resolves it, because the domain does not inspect processes.
+	HeldByQueue bool
 }
 
 // CheckMachine carries the machine facts the limit is resolved from.
@@ -60,30 +65,35 @@ func ResolveCheckPressure(override string, measured Pressure, ci string) Pressur
 	case "red":
 		return Red
 	}
-	if isTruthyCI(ci) {
+	if isTruthyEnv(ci) {
 		return Green
 	}
 	return measured
 }
 
-// isTruthyCI reads the CI convention: the variable is set to something that is
-// not one of the values meaning "not CI". The slot limit and the pressure
-// policy both ask this, so they ask it in one place and cannot drift apart.
-func isTruthyCI(ci string) bool {
-	value := strings.ToLower(strings.TrimSpace(ci))
-	return value != "" && value != "0" && value != "false"
+// isTruthyEnv reads the CI convention: the variable is set to something that
+// is not one of the values meaning "no". CI and CLAUDECODE both follow it, so
+// the slot limit and the pressure policy read them by one rule that cannot
+// drift apart.
+func isTruthyEnv(value string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(value))
+	return normalized != "" && normalized != "0" && normalized != "false"
 }
 
 // ResolveCheckSlots resolves how many whole-repo checks may run at once, and
-// names where the answer came from ("CHECK_SLOTS", "CI", "machine" or
+// names where the answer came from ("CHECK_SLOTS", "held", "CI", "machine" or
 // "pressure").
 //
 // An explicit CHECK_SLOTS always wins, including under CI — that is what lets
 // tests exercise the queue on a CI runner. "0" (or off/none/unlimited/false)
-// disables the gate. Unset, CI gets no queue at all (one job runs one check),
-// and a developer machine gets a limit bounded by both memory and cores —
-// tsgo is memory-hungry AND parallel, so the tighter bound is the honest one —
-// never below 1, or the queue would deadlock every run.
+// disables the gate — from a person's shell. From an agent shell (CLAUDECODE
+// set) a gate-off is ignored and the derived limit applies, unless the queue
+// itself spawned the run (HeldByQueue): the queue exists to serialize agents,
+// so a lever any agent may pull is not a limit. Unset, CI gets no queue at all
+// (one job runs one check), and a developer machine gets a limit bounded by
+// both memory and cores — tsgo is memory-hungry AND parallel, so the tighter
+// bound is the honest one — never below 1, or the queue would deadlock every
+// run.
 //
 // A machine already under memory pressure gets one slot, whatever the formula
 // says. The formula assumes an otherwise idle machine, and pressure is the
@@ -93,17 +103,22 @@ func isTruthyCI(ci string) bool {
 func ResolveCheckSlots(machine CheckMachine, env CheckEnv) (int, string) {
 	raw := strings.TrimSpace(env.CheckSlots)
 	if raw != "" {
-		switch strings.ToLower(raw) {
-		case "off", "none", "unlimited", "false":
-			return 0, "CHECK_SLOTS"
-		}
-		if parsed, err := strconv.Atoi(raw); err == nil && parsed >= 0 {
+		if gateOffRequested(raw) {
+			if !isTruthyEnv(env.Claudecode) {
+				return 0, "CHECK_SLOTS"
+			}
+			if env.HeldByQueue {
+				return 0, "held"
+			}
+			// An agent shell may not turn the queue off: fall through to the
+			// derived limit as if CHECK_SLOTS were unset.
+		} else if parsed, err := strconv.Atoi(raw); err == nil && parsed > 0 {
 			return parsed, "CHECK_SLOTS"
 		}
 		// An unparseable value falls through to the derived default, exactly
 		// like the JS wrapper: a typo must not turn the gate off.
 	}
-	if isTruthyCI(env.CI) {
+	if isTruthyEnv(env.CI) {
 		return 0, "CI"
 	}
 	if machine.Pressure > Green {
@@ -112,6 +127,25 @@ func ResolveCheckSlots(machine CheckMachine, env CheckEnv) (int, string) {
 	byMemory := int(machine.TotalRAMBytes / checkRAMPerRun)
 	byCPU := machine.NumCPU / checkCPUsPerRun
 	return max(1, min(byMemory, byCPU)), "machine"
+}
+
+// gateOffRequested reads the values that ask for the queue to be off entirely.
+func gateOffRequested(raw string) bool {
+	switch strings.ToLower(raw) {
+	case "off", "none", "unlimited", "false":
+		return true
+	}
+	parsed, err := strconv.Atoi(raw)
+	return err == nil && parsed == 0
+}
+
+// GateOffIgnored reports that this environment asked for the gate to be off
+// and was refused: the ask came from an agent shell and not from the queue
+// itself. ResolveCheckSlots stays silent about it, so callers use this to say
+// why the limit still applies.
+func GateOffIgnored(env CheckEnv) bool {
+	return gateOffRequested(strings.TrimSpace(env.CheckSlots)) &&
+		isTruthyEnv(env.Claudecode) && !env.HeldByQueue
 }
 
 // CheckGoMemLimit is the soft memory cap set on the Go-runtime tools the queue

--- a/tools/thuishaven/domain/checkslots_test.go
+++ b/tools/thuishaven/domain/checkslots_test.go
@@ -62,6 +62,46 @@ func TestResolveCheckSlots(t *testing.T) {
 			t.Fatalf("CI must stay unqueued under pressure, got %d from %q", slots, source)
 		}
 	})
+
+	// @scenario "haven ignores an agent's gate-off the same way"
+	t.Run("given a gate-off from an agent shell", func(t *testing.T) {
+		machine := CheckMachine{TotalRAMBytes: 18 * checkGiB, NumCPU: 11, Pressure: Green}
+		for _, raw := range []string{"0", "off", "none", "unlimited", "false"} {
+			if slots, source := ResolveCheckSlots(machine, CheckEnv{CheckSlots: raw, Claudecode: "1"}); slots != 2 || source != "machine" {
+				t.Fatalf("CHECK_SLOTS=%s from an agent shell must fall back to the derived limit, got %d from %q", raw, slots, source)
+			}
+		}
+		if slots, source := ResolveCheckSlots(machine, CheckEnv{CheckSlots: "0", Claudecode: ""}); slots != 0 || source != "CHECK_SLOTS" {
+			t.Fatalf("a person's gate-off must still work, got %d from %q", slots, source)
+		}
+		if slots, source := ResolveCheckSlots(machine, CheckEnv{CheckSlots: "0", Claudecode: "1", HeldByQueue: true}); slots != 0 || source != "held" {
+			t.Fatalf("a run the queue spawned must stay unqueued, got %d from %q", slots, source)
+		}
+		if slots, source := ResolveCheckSlots(machine, CheckEnv{CheckSlots: "1", Claudecode: "1"}); slots != 1 || source != "CHECK_SLOTS" {
+			t.Fatalf("an explicit positive limit is not a gate-off and must win, got %d from %q", slots, source)
+		}
+	})
+}
+
+func TestGateOffIgnored(t *testing.T) {
+	cases := []struct {
+		name string
+		env  CheckEnv
+		want bool
+	}{
+		{"an agent's gate-off is the refused case", CheckEnv{CheckSlots: "0", Claudecode: "1"}, true},
+		{"a person's gate-off is honored", CheckEnv{CheckSlots: "0"}, false},
+		{"a run the queue spawned is honored", CheckEnv{CheckSlots: "0", Claudecode: "1", HeldByQueue: true}, false},
+		{"a positive limit asks for no gate-off", CheckEnv{CheckSlots: "2", Claudecode: "1"}, false},
+		{"an unset variable asks for nothing", CheckEnv{Claudecode: "1"}, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := GateOffIgnored(c.env); got != c.want {
+				t.Fatalf("GateOffIgnored = %v, want %v", got, c.want)
+			}
+		})
+	}
 }
 
 // @scenario "A forced pressure level overrides the measurement"


### PR DESCRIPTION
The check queue documented `CHECK_SLOTS=0` as the way to turn the gate off, and honored it from anyone. Found in the wild: an agent prefixed `CHECK_SLOTS=0` onto a whole-tree typecheck to jump the queue, and the machine ran three whole-repo typechecks at once, 14 GB into a 15 GB swap file. The queue exists to serialize agents, so a lever any agent may pull is not a limit.

## The rule

The gate-off is now the operator's lever only:

- A person's shell keeps it: `CHECK_SLOTS=0` (or `off`, `none`, `unlimited`, `false`) still turns the queue off when `CLAUDECODE` is not set.
- An agent shell loses it: Claude Code sets `CLAUDECODE` in every shell it spawns, and there a gate-off value is ignored with a note (`CHECK_SLOTS=0 is ignored in an agent shell; the machine policy applies. Only a person may turn the queue off.`) and the derived limit applies as if `CHECK_SLOTS` were unset.
- Explicit positive limits (`CHECK_SLOTS=1`) still work everywhere, so an operator's `.zshrc` setting keeps reaching agent shells.

## The marker that keeps nested runs working

The queue itself turns the gate off for everything below a run it already counted, or a slot-holding `pnpm typecheck` would queue behind itself at the first bin shim. That self-exemption used to be a bare `CHECK_SLOTS=0`, which the new rule would refuse. It now travels as `CHECK_QUEUE_HELD=<wrapper pid>` next to the `CHECK_SLOTS=0`, and a run honors it only when the pid is a live ancestor of the run asking. An agent cannot borrow it: a copied pid is not its ancestor, and the verification walks the real parent chain through `ps`.

All four export sites set the marker: the JS wrapper (`dev/scripts/check-queue.mjs`), `haven slot run` (`cmd/slot.go`), `haven typecheck` (`app/typecheck.go`) and `haven run` (`app/run.go`).

## Both implementations move together

The rule lives in `domain.ResolveCheckSlots` (with `GateOffIgnored` for the caller's note) and is mirrored in the JS queue, which is the fallback for machines without haven. A machine with a stale haven binary picks the rule up on the next `make haven install`.

Related second escape, fixed outside this PR: the same session also ran `pnpm exec tsgo`, which resolved to a globally installed tsgo dev build that no shim covers and that runs with no `GOMEMLIMIT`. The global installs (pnpm and npm) were removed; the repo's own bins are shimmed and were not affected.

## Verification

- New spec scenarios in `specs/setup/check-slots.feature` (50/50 bound).
- JS: 35/35 in `check-queue.unit.test.ts`, including a real serialization test (a gate-off run in an agent shell queues behind a holder), the nested-marker pass-through, and a borrowed-marker rejection against a live non-ancestor process.
- Against main's queue, `CLAUDECODE=1 CHECK_SLOTS=0 --explain` resolves `slots=0`; against this branch it resolves the machine limit and prints the note.
- Go: new `ResolveCheckSlots` and `GateOffIgnored` cases, and `TestHeldByLiveAncestor` covering the ancestor walk, garbage markers, and a live non-ancestor. `go test ./tools/thuishaven/...` green, `make go-lint-changed` 0 issues.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Agent-launched runs can no longer disable machine-wide check serialization.
  - Queue-spawned descendant processes remain exempt from re-queuing themselves.
  - Queue overrides are accepted only when issued from the originating personal shell.

- **Bug Fixes**
  - Invalid or unrelated process markers can no longer bypass queue safeguards.
  - Queue status and run commands now clearly report when an override is ignored.

- **Documentation**
  - Updated help text and setup documentation to explain override restrictions and descendant behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->