### PR TITLE
fix(dev): a dev stack, a haven up, and a browser all die with their session

### DIFF
--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -229,12 +229,23 @@ jobs:
         run: go build -o /dev/null ./cmd/service
 
       # node-pty@1.1.0 only ships prebuilds for darwin/win32, so on Linux
-      # its postinstall always falls back to `node-gyp rebuild`. With
-      # pnpm/action-setup v6's npm-bootstrap path, node-gyp isn't on PATH
-      # by default — install it globally before any install that hits
-      # mcp-server's onlyBuiltDependencies allowlist.
+      # its postinstall always falls back to `node-gyp rebuild`, which pnpm
+      # runs with its own vendored node-gyp. That copy ships `gyp/gyp_main.py`
+      # mode 644, so an mtime-driven Makefile regeneration executes it and
+      # dies with "Permission denied" / error 126. Installing node-gyp
+      # globally does not displace it on its own: pnpm exports
+      # `npm_config_node_gyp` at its vendored copy and that wins over PATH.
+      # Point the variable at the published node-gyp, which ships the script
+      # executable. sdk-javascript-ci.yml and npx-server-smoke.yml do the same.
       - name: Install node-gyp (for node-pty postinstall)
-        run: npm install -g node-gyp@12.3.0
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm install -g node-gyp@12.3.0
+          gyp="$(npm root -g)/node-gyp/bin/node-gyp.js"
+          test -f "$gyp"
+          test -x "$(dirname "$gyp")/../gyp/gyp_main.py"
+          echo "npm_config_node_gyp=$gyp" >> "$GITHUB_ENV"
 
       # One install for the app, the MCP server (a workspace dependency of the
       # app, so `...` pulls it in) and the Playwright suite. This used to be

--- a/.github/workflows/langwatch-app-ci.yml
+++ b/.github/workflows/langwatch-app-ci.yml
@@ -1335,12 +1335,23 @@ jobs:
             ${{ runner.os }}-vite-
 
       # node-pty@1.1.0 only ships prebuilds for darwin/win32, so on Linux
-      # its postinstall always falls back to `node-gyp rebuild`. With
-      # pnpm/action-setup v6's npm-bootstrap path, node-gyp isn't on PATH
-      # by default — install it globally before any install that hits
-      # mcp-server's onlyBuiltDependencies allowlist.
+      # its postinstall always falls back to `node-gyp rebuild`, which pnpm
+      # runs with its own vendored node-gyp. That copy ships `gyp/gyp_main.py`
+      # mode 644, so an mtime-driven Makefile regeneration executes it and
+      # dies with "Permission denied" / error 126. Installing node-gyp
+      # globally does not displace it on its own: pnpm exports
+      # `npm_config_node_gyp` at its vendored copy and that wins over PATH.
+      # Point the variable at the published node-gyp, which ships the script
+      # executable. sdk-javascript-ci.yml and npx-server-smoke.yml do the same.
       - name: Install node-gyp (for node-pty postinstall)
-        run: npm install -g node-gyp@12.3.0
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm install -g node-gyp@12.3.0
+          gyp="$(npm root -g)/node-gyp/bin/node-gyp.js"
+          test -f "$gyp"
+          test -x "$(dirname "$gyp")/../gyp/gyp_main.py"
+          echo "npm_config_node_gyp=$gyp" >> "$GITHUB_ENV"
 
       # One install. mcp-server is a workspace dependency of the app, so the
       # trailing `...` pulls it in — it used to be installed separately here

--- a/dev/scripts/dev-supervisor.mjs
+++ b/dev/scripts/dev-supervisor.mjs
@@ -29,13 +29,21 @@
  *      never take down anything we did not start.
  *   2. Watches the group it was launched FROM. When that group's leader dies,
  *      the stack goes down: SIGTERM, then SIGKILL for whatever ignored it.
- *   3. Posts a SENTINEL outside both groups. A hard session teardown SIGKILLs
- *      the launching group as a whole — the shell, the pnpm chain, and this
- *      supervisor in it — and the stack is detached exactly so that teardown
- *      cannot reach it, which also means its watcher dies watching. The
- *      sentinel is a process group of its own that answers to neither kill:
- *      it idles while the supervisor or the launcher is alive, takes the
- *      stack down when both are gone, and exits the moment the stack does.
+ *   3. Puts a SENTINEL between itself and the stack. A hard session teardown
+ *      SIGKILLs the launching group as a whole — the shell, the pnpm chain,
+ *      and this supervisor in it — and the stack is detached exactly so that
+ *      teardown cannot reach it, which also means its watcher dies watching.
+ *      The sentinel is a session of its own that answers to neither kill: it
+ *      idles while the supervisor or the launcher is alive, takes the stack
+ *      down when both are gone, and goes when the last lane does.
+ *
+ * The sentinel is started BEFORE the stack and is what spawns it, so there is
+ * no instant in which a detached stack exists with nothing outside the doomed
+ * group watching it. Starting the stack first and the sentinel second would
+ * leave exactly that window, and a SIGKILL landing in it reproduces the
+ * original leak in full. The two talk over a pipe on fd 3: the sentinel
+ * reports the stack's pid as soon as it has one, so the supervisor can still
+ * address the stack itself, and its exit code when it ends.
  *
  * Watching the launching group rather than our own parent is what makes this
  * work at any depth: `pnpm dev` at the repo root delegates through several
@@ -59,6 +67,7 @@
  */
 
 import { spawn, spawnSync } from "node:child_process";
+import fs from "node:fs";
 import os from "node:os";
 import { fileURLToPath } from "node:url";
 
@@ -70,7 +79,10 @@ const WATCH_INTERVAL_MS = 1_000;
 const NESTED = "LANGWATCH_DEV_SUPERVISED";
 /** Re-entry flag for the sentinel process; never typed by hand. */
 const SENTINEL_FLAG = "--sentinel";
+/** The pipe the sentinel reports the stack's pid, then its exit code, on. */
+const HANDSHAKE_FD = 3;
 const PREFIX = "dev-supervisor:";
+const SELF = fileURLToPath(import.meta.url);
 
 const stderr = (msg) => process.stderr.write(msg);
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
@@ -201,62 +213,202 @@ function stackControls({ target, graceMs }) {
   return { takeDown, anyAlive };
 }
 
-/**
- * The sentinel: a group of its own, so no teardown aimed at the launcher or
- * the stack can take it before it has done its job. It idles while either the
- * supervisor or the launcher is alive (whichever of them is up owns the
- * stack's lifetime), takes the stack down when both are gone, and exits as
- * soon as the stack itself is gone — including when the stack was taken down
- * properly and the sentinel was simply never needed.
- *
- * Anything after the three pids in its argv is the guarded command, carried
- * only so `ps` shows what a sentinel is standing for.
- */
-async function runSentinel(args, env) {
-  const stackPid = Number.parseInt(args[0] ?? "", 10);
-  const supervisorPid = Number.parseInt(args[1] ?? "", 10);
-  const leaderPid = Number.parseInt(args[2] ?? "", 10);
-  if (!Number.isInteger(stackPid) || stackPid <= 1) return 64;
+/** The sentinel's half of the handshake. A closed pipe is never a failure. */
+function tell(value) {
+  try {
+    fs.writeSync(HANDSHAKE_FD, `${value}\n`);
+  } catch {
+    // Nobody listening: run by hand, or the supervisor is already gone.
+  }
+}
 
-  const everyMs = positiveInt(env.LANGWATCH_DEV_WATCH_MS, WATCH_INTERVAL_MS);
-  const stack = stackControls({
-    target: -stackPid,
-    graceMs: positiveInt(env.LANGWATCH_DEV_GRACE_MS, DEFAULT_GRACE_MS),
-  });
-  const watched = (pid) => Number.isInteger(pid) && pid > 1 && alive(pid);
-
-  for (;;) {
-    if (!stack.anyAlive()) return 0;
-    if (!watched(supervisorPid) && !watched(leaderPid)) {
-      await stack.takeDown();
-      return 0;
-    }
-    await sleep(everyMs);
+function hangUp() {
+  try {
+    fs.closeSync(HANDSHAKE_FD);
+  } catch {
+    // Already closed, or never a pipe.
   }
 }
 
 /**
- * Posts the sentinel for a detached stack. Failing to post one is not a gate:
- * the supervisor's own watch still covers every case except its own SIGKILL.
+ * The sentinel: the stack's parent, in a session of its own, so no teardown
+ * aimed at the launching group can reach it and the stack is never without a
+ * guard outside that group. It idles while either the supervisor or the
+ * launcher is alive (whichever of them is up owns the stack's lifetime),
+ * takes the stack down when both are gone, and exits once the last lane is
+ * gone — including when the stack was taken down properly and the sentinel
+ * was simply never needed.
+ *
+ * Anything after the two pids in its argv is the guarded command, which it
+ * runs and which `ps` therefore shows as what a sentinel stands for.
  */
-function startSentinel({ stackPid, leader, argv, env }) {
+async function runSentinel(args, env) {
+  const supervisorPid = Number.parseInt(args[0] ?? "", 10);
+  const leaderPid = Number.parseInt(args[1] ?? "", 10);
+  const argv = args.slice(2);
+  if (argv.length === 0) return 64;
+
+  const child = startChild(argv, env, true);
+  // Out before anything else can happen to the stack. From here the supervisor
+  // can address it, and this process is already its parent either way.
+  tell(child?.pid ?? 0);
+  if (child === null) {
+    hangUp();
+    return 127;
+  }
+
+  let code = null;
+  const settled = new Promise((resolve) => {
+    child.on("error", (err) => {
+      stderr(`${PREFIX} could not start ${argv[0]} (${err.message})\n`);
+      resolve(127);
+    });
+    child.on("close", (status, signal) =>
+      resolve(exitCodeFor({ code: status, signal })),
+    );
+  });
+  void settled.then((value) => {
+    code = value;
+  });
+
+  const stack = stackControls({
+    target: -child.pid,
+    graceMs: positiveInt(env.LANGWATCH_DEV_GRACE_MS, DEFAULT_GRACE_MS),
+  });
+  const everyMs = positiveInt(env.LANGWATCH_DEV_WATCH_MS, WATCH_INTERVAL_MS);
+  const watched = (pid) => Number.isInteger(pid) && pid > 1 && alive(pid);
+  let reported = false;
+  const report = () => {
+    if (reported) return;
+    reported = true;
+    tell(code ?? exitCodeFor(null));
+    hangUp();
+  };
+
+  for (;;) {
+    if (code !== null) report();
+    // Only once the stack has been seen to settle: a group that has not been
+    // observed yet reads as "quiet" while the command is still being exec'd.
+    if (reported && !stack.anyAlive()) break;
+    if (!watched(supervisorPid) && !watched(leaderPid)) {
+      await stack.takeDown();
+      break;
+    }
+    if (code === null) await Promise.race([settled, sleep(everyMs)]);
+    else await sleep(everyMs);
+  }
+
+  report();
+  return code ?? exitCodeFor(null);
+}
+
+/**
+ * Starts the sentinel, which starts the stack. Returns null when it could not
+ * be started, which is never a gate: the caller falls back to running the
+ * command itself, unguarded against its own SIGKILL but running.
+ */
+function startSentinel({ leader, argv, env }) {
+  let proc = null;
   try {
-    const child = spawn(
+    proc = spawn(
       process.execPath,
       [
-        fileURLToPath(import.meta.url),
+        SELF,
         SENTINEL_FLAG,
-        String(stackPid),
         String(process.pid),
-        String(leader),
+        String(leader ?? 0),
         ...argv,
       ],
-      { detached: true, stdio: "ignore", env },
+      {
+        detached: true,
+        // The stack's stdio is ours, passed down a level; fd 3 is the pipe it
+        // answers on. Node closes it on exec, so the stack never holds it open.
+        stdio: ["inherit", "inherit", "inherit", "pipe"],
+        env,
+      },
     );
-    child.unref();
   } catch (err) {
     stderr(`${PREFIX} could not post the sentinel (${err.message})\n`);
+    return null;
   }
+  // It outlives us on purpose, so it must never be what holds our exit open.
+  // The handshake pipe is what keeps us alive while the stack runs.
+  proc.unref();
+
+  let resolvePid = null;
+  const pid = new Promise((r) => {
+    resolvePid = r;
+  });
+  let onExit = () => {};
+  readHandshake(proc.stdio[HANDSHAKE_FD], {
+    onPid: (value) => resolvePid(value),
+    onExit: (value) => onExit(value ?? exitCodeFor(null)),
+  });
+
+  return {
+    target: async () => {
+      const stackPid = await pid;
+      return stackPid === null ? null : -stackPid;
+    },
+    onFailed: () => {},
+    onExit: (cb) => {
+      onExit = cb;
+    },
+  };
+}
+
+/**
+ * The supervisor's half of the handshake: the stack's pid, then its exit code.
+ * Two lines rather than waiting on the sentinel itself, which stays up as long
+ * as any lane does and would otherwise make a stack that exits on its own look
+ * like one this had to wait for. An end with nothing on it answers both.
+ */
+function readHandshake(stream, { onPid, onExit }) {
+  if (!stream) {
+    onPid(null);
+    onExit(null);
+    return;
+  }
+  let buffer = "";
+  let seen = 0;
+  const take = (line) => {
+    if (seen >= 2) return;
+    const value = Number.parseInt(line, 10);
+    const parsed = Number.isInteger(value) ? value : null;
+    seen += 1;
+    if (seen === 1) onPid(parsed !== null && parsed > 1 ? parsed : null);
+    else onExit(parsed);
+  };
+
+  stream.setEncoding("utf8");
+  stream.on("data", (chunk) => {
+    buffer += chunk;
+    for (let nl = buffer.indexOf("\n"); nl !== -1; nl = buffer.indexOf("\n")) {
+      take(buffer.slice(0, nl));
+      buffer = buffer.slice(nl + 1);
+    }
+  });
+  const end = () => {
+    while (seen < 2) take("");
+  };
+  stream.on("end", end);
+  stream.on("error", end);
+}
+
+/** Runs the command in this process, the way an unguarded run always did. */
+function startDirect(argv, env, detached) {
+  const child = startChild(argv, env, detached);
+  if (child === null) return null;
+  return {
+    target: async () => (detached ? -child.pid : child.pid),
+    onFailed: (cb) =>
+      child.on("error", (err) => {
+        stderr(`${PREFIX} could not start ${argv[0]} (${err.message})\n`);
+        cb(127);
+      }),
+    onExit: (cb) =>
+      child.on("close", (code, signal) => cb(exitCodeFor({ code, signal }))),
+  };
 }
 
 /** Polls for the launcher's death, or null when there is nothing to watch. */
@@ -273,27 +425,39 @@ function watchLauncher({ leader, env, onGone }) {
 }
 
 /**
- * Runs the command and returns its exit code. With `detached`, the child leads
+ * Starts the run this supervisor reports on. A detached run goes through a
+ * sentinel, which is what actually spawns the stack; anything else runs the
+ * command here. A sentinel that cannot be started falls back to the direct
+ * run rather than failing the command.
+ */
+function startRun(argv, env, { detached, leader }) {
+  if (detached) {
+    const sentinel = startSentinel({ leader, argv, env });
+    if (sentinel !== null) return sentinel;
+  }
+  return startDirect(argv, env, detached);
+}
+
+/**
+ * Runs the command and returns its exit code. With `detached`, the stack leads
  * a process group of its own and every takedown targets that group.
  */
 function passThrough(argv, env, { detached, leader = null }) {
-  const child = startChild(argv, env, detached);
-  if (child === null) return Promise.resolve(127);
-  if (detached) startSentinel({ stackPid: child.pid, leader, argv, env });
+  const run = startRun(argv, env, { detached, leader });
+  if (run === null) return Promise.resolve(127);
 
   return new Promise((resolve) => {
-    const stack = stackControls({
-      target: detached ? -child.pid : child.pid,
-      graceMs: positiveInt(env.LANGWATCH_DEV_GRACE_MS, DEFAULT_GRACE_MS),
-    });
     let watch = null;
     let takingDown = false;
-    let childResult = null;
+    let settled = false;
+    let stackCode = null;
 
     // clearInterval ignores null, so the watch never needs guarding.
-    const finish = () => {
+    const finish = (code) => {
+      if (settled) return;
+      settled = true;
       clearInterval(watch);
-      resolve(exitCodeFor(childResult));
+      resolve(code);
     };
 
     const stop = async (why) => {
@@ -301,12 +465,19 @@ function passThrough(argv, env, { detached, leader = null }) {
       takingDown = true;
       clearInterval(watch);
       if (why !== null) stderr(`${PREFIX} ${why}, stopping the dev stack.\n`);
-      if (!(await stack.takeDown())) {
-        stderr(
-          `${PREFIX} some of the dev stack outlived SIGKILL, giving up.\n`,
-        );
+      const target = await run.target();
+      if (target !== null) {
+        const stack = stackControls({
+          target,
+          graceMs: positiveInt(env.LANGWATCH_DEV_GRACE_MS, DEFAULT_GRACE_MS),
+        });
+        if (!(await stack.takeDown())) {
+          stderr(
+            `${PREFIX} some of the dev stack outlived SIGKILL, giving up.\n`,
+          );
+        }
       }
-      finish();
+      finish(stackCode ?? exitCodeFor(null));
     };
 
     watch = watchLauncher({ leader, env, onGone: stop });
@@ -317,17 +488,13 @@ function passThrough(argv, env, { detached, leader = null }) {
       process.on(signal, () => void stop(null));
     }
 
-    child.on("error", (err) => {
-      stderr(`${PREFIX} could not start ${argv[0]} (${err.message})\n`);
-      clearInterval(watch);
-      resolve(127);
-    });
+    run.onFailed((code) => finish(code));
 
-    child.on("close", (code, signal) => {
-      childResult = { code, signal };
+    run.onExit((code) => {
+      stackCode = code;
       // Mid-takedown this is just one lane going quiet; `stop` decides when the
       // stack is actually down.
-      if (!takingDown) finish();
+      if (!takingDown) finish(code);
     });
   });
 }

--- a/dev/scripts/dev-supervisor.mjs
+++ b/dev/scripts/dev-supervisor.mjs
@@ -303,11 +303,12 @@ async function runSentinel(args, env) {
 }
 
 /**
- * Starts the sentinel, which starts the stack. Returns null when it could not
- * be started, which is never a gate: the caller falls back to running the
- * command itself, unguarded against its own SIGKILL but running.
+ * Starts the sentinel, which starts the stack, and waits for it to say which
+ * pid the stack got. Returns null when it never does, so the caller can run
+ * the command itself: an unguarded run is the cost of a sentinel that will not
+ * start, and a dev server that refuses to come up is not.
  */
-function startSentinel({ leader, argv, env }) {
+async function startSentinel({ leader, argv, env }) {
   let proc = null;
   try {
     proc = spawn(
@@ -335,24 +336,47 @@ function startSentinel({ leader, argv, env }) {
   // The handshake pipe is what keeps us alive while the stack runs.
   proc.unref();
 
-  let resolvePid = null;
-  const pid = new Promise((r) => {
-    resolvePid = r;
-  });
-  let onExit = () => {};
-  readHandshake(proc.stdio[HANDSHAKE_FD], {
-    onPid: (value) => resolvePid(value),
-    onExit: (value) => onExit(value ?? exitCodeFor(null)),
+  // spawn reports some failures only after it has handed back a child, and an
+  // "error" nobody listens for takes this process down with it — which is the
+  // one thing supervision must never do to the command it is supervising.
+  let failure = null;
+  const failed = new Promise((resolve) => {
+    proc.on("error", (err) => {
+      failure = err;
+      resolve();
+    });
   });
 
+  let stackPid = null;
+  let onExit = null;
+  let exitBeforeAsked = null;
+  const deliver = (code) => {
+    if (onExit === null) exitBeforeAsked = code;
+    else onExit(code);
+  };
+  const reported = new Promise((resolve) => {
+    readHandshake(proc.stdio[HANDSHAKE_FD], {
+      onPid: (value) => {
+        stackPid = value;
+        resolve();
+      },
+      onExit: (value) => deliver(value ?? exitCodeFor(null)),
+    });
+  });
+
+  await Promise.race([reported, failed]);
+  if (stackPid === null) {
+    const why = failure === null ? "it named no stack" : failure.message;
+    stderr(`${PREFIX} the sentinel did not come up (${why}), running on.\n`);
+    return null;
+  }
+
   return {
-    target: async () => {
-      const stackPid = await pid;
-      return stackPid === null ? null : -stackPid;
-    },
+    target: async () => -stackPid,
     onFailed: () => {},
     onExit: (cb) => {
       onExit = cb;
+      if (exitBeforeAsked !== null) cb(exitBeforeAsked);
     },
   };
 }
@@ -430,9 +454,9 @@ function watchLauncher({ leader, env, onGone }) {
  * command here. A sentinel that cannot be started falls back to the direct
  * run rather than failing the command.
  */
-function startRun(argv, env, { detached, leader }) {
+async function startRun(argv, env, { detached, leader }) {
   if (detached) {
-    const sentinel = startSentinel({ leader, argv, env });
+    const sentinel = await startSentinel({ leader, argv, env });
     if (sentinel !== null) return sentinel;
   }
   return startDirect(argv, env, detached);
@@ -442,11 +466,11 @@ function startRun(argv, env, { detached, leader }) {
  * Runs the command and returns its exit code. With `detached`, the stack leads
  * a process group of its own and every takedown targets that group.
  */
-function passThrough(argv, env, { detached, leader = null }) {
-  const run = startRun(argv, env, { detached, leader });
-  if (run === null) return Promise.resolve(127);
+async function passThrough(argv, env, { detached, leader = null }) {
+  const run = await startRun(argv, env, { detached, leader });
+  if (run === null) return 127;
 
-  return new Promise((resolve) => {
+  return await new Promise((resolve) => {
     let watch = null;
     let takingDown = false;
     let settled = false;

--- a/dev/scripts/dev-supervisor.mjs
+++ b/dev/scripts/dev-supervisor.mjs
@@ -21,7 +21,7 @@
  * stack still owns the port, the next `pnpm dev` takes the next slot and the
  * worktree ends up running twice.
  *
- * So this sits at the top of the chain and does two things:
+ * So this sits at the top of the chain and does three things:
  *
  *   1. Runs the command in a process group of ITS OWN (`detached`). One signal
  *      to that group reaches vite, tsx and `go run` at once, without walking a
@@ -29,6 +29,13 @@
  *      never take down anything we did not start.
  *   2. Watches the group it was launched FROM. When that group's leader dies,
  *      the stack goes down: SIGTERM, then SIGKILL for whatever ignored it.
+ *   3. Posts a SENTINEL outside both groups. A hard session teardown SIGKILLs
+ *      the launching group as a whole — the shell, the pnpm chain, and this
+ *      supervisor in it — and the stack is detached exactly so that teardown
+ *      cannot reach it, which also means its watcher dies watching. The
+ *      sentinel is a process group of its own that answers to neither kill:
+ *      it idles while the supervisor or the launcher is alive, takes the
+ *      stack down when both are gone, and exits the moment the stack does.
  *
  * Watching the launching group rather than our own parent is what makes this
  * work at any depth: `pnpm dev` at the repo root delegates through several
@@ -53,6 +60,7 @@
 
 import { spawn, spawnSync } from "node:child_process";
 import os from "node:os";
+import { fileURLToPath } from "node:url";
 
 /** How long the stack gets between SIGTERM and SIGKILL. */
 const DEFAULT_GRACE_MS = 5_000;
@@ -60,6 +68,8 @@ const DEFAULT_GRACE_MS = 5_000;
 const WATCH_INTERVAL_MS = 1_000;
 /** Set for everything below us, so a nested dev script does not supervise again. */
 const NESTED = "LANGWATCH_DEV_SUPERVISED";
+/** Re-entry flag for the sentinel process; never typed by hand. */
+const SENTINEL_FLAG = "--sentinel";
 const PREFIX = "dev-supervisor:";
 
 const stderr = (msg) => process.stderr.write(msg);
@@ -111,6 +121,7 @@ function disabled(env) {
 }
 
 async function main(argv, env) {
+  if (argv[0] === SENTINEL_FLAG) return await runSentinel(argv.slice(1), env);
   if (argv.length === 0) {
     stderr(`${PREFIX} usage: dev-supervisor.mjs <command> [args...]\n`);
     return 64;
@@ -187,7 +198,65 @@ function stackControls({ target, graceMs }) {
     return !anyAlive();
   };
 
-  return { takeDown };
+  return { takeDown, anyAlive };
+}
+
+/**
+ * The sentinel: a group of its own, so no teardown aimed at the launcher or
+ * the stack can take it before it has done its job. It idles while either the
+ * supervisor or the launcher is alive (whichever of them is up owns the
+ * stack's lifetime), takes the stack down when both are gone, and exits as
+ * soon as the stack itself is gone — including when the stack was taken down
+ * properly and the sentinel was simply never needed.
+ *
+ * Anything after the three pids in its argv is the guarded command, carried
+ * only so `ps` shows what a sentinel is standing for.
+ */
+async function runSentinel(args, env) {
+  const stackPid = Number.parseInt(args[0] ?? "", 10);
+  const supervisorPid = Number.parseInt(args[1] ?? "", 10);
+  const leaderPid = Number.parseInt(args[2] ?? "", 10);
+  if (!Number.isInteger(stackPid) || stackPid <= 1) return 64;
+
+  const everyMs = positiveInt(env.LANGWATCH_DEV_WATCH_MS, WATCH_INTERVAL_MS);
+  const stack = stackControls({
+    target: -stackPid,
+    graceMs: positiveInt(env.LANGWATCH_DEV_GRACE_MS, DEFAULT_GRACE_MS),
+  });
+  const watched = (pid) => Number.isInteger(pid) && pid > 1 && alive(pid);
+
+  for (;;) {
+    if (!stack.anyAlive()) return 0;
+    if (!watched(supervisorPid) && !watched(leaderPid)) {
+      await stack.takeDown();
+      return 0;
+    }
+    await sleep(everyMs);
+  }
+}
+
+/**
+ * Posts the sentinel for a detached stack. Failing to post one is not a gate:
+ * the supervisor's own watch still covers every case except its own SIGKILL.
+ */
+function startSentinel({ stackPid, leader, argv, env }) {
+  try {
+    const child = spawn(
+      process.execPath,
+      [
+        fileURLToPath(import.meta.url),
+        SENTINEL_FLAG,
+        String(stackPid),
+        String(process.pid),
+        String(leader),
+        ...argv,
+      ],
+      { detached: true, stdio: "ignore", env },
+    );
+    child.unref();
+  } catch (err) {
+    stderr(`${PREFIX} could not post the sentinel (${err.message})\n`);
+  }
 }
 
 /** Polls for the launcher's death, or null when there is nothing to watch. */
@@ -210,6 +279,7 @@ function watchLauncher({ leader, env, onGone }) {
 function passThrough(argv, env, { detached, leader = null }) {
   const child = startChild(argv, env, detached);
   if (child === null) return Promise.resolve(127);
+  if (detached) startSentinel({ stackPid: child.pid, leader, argv, env });
 
   return new Promise((resolve) => {
     const stack = stackControls({

--- a/dev/scripts/die-with-parent.cjs
+++ b/dev/scripts/die-with-parent.cjs
@@ -1,0 +1,53 @@
+// Loaded into the Playwright MCP process by dev/scripts/playwright-mcp.sh
+// (node --require). See specs/setup/mcp-browser-lifecycle.feature.
+//
+// When the session that spawned an MCP dies hard, nothing signals the MCP: it
+// reparents to launchd and keeps running, and the Chrome it launched outlives
+// even that, because a browser detaches from its parent's fate on purpose.
+// Observed: 20 orphaned Chromes and 7.4 GB of their profiles, each from a
+// dogfooding session that was long gone.
+//
+// macOS has no die-with-parent, so the process watches for itself: poll the
+// parent pid, and on orphaning ask everything to shut down the way a clean
+// disconnect would - SIGTERM to the direct children (the browser), SIGTERM to
+// self (which runs the MCP's own shutdown handlers), and a hard exit only if
+// those hang.
+
+const { execFileSync } = require("node:child_process");
+
+const DEFAULT_EVERY_MS = 10_000;
+
+const everyMs = (() => {
+  const raw = Number.parseInt(process.env.LANGWATCH_MCP_ORPHAN_WATCH_MS ?? "", 10);
+  return Number.isInteger(raw) && raw > 0 ? raw : DEFAULT_EVERY_MS;
+})();
+
+function children(pid) {
+  try {
+    const out = execFileSync("pgrep", ["-P", String(pid)], { encoding: "utf8" });
+    return out
+      .split("\n")
+      .map((line) => Number.parseInt(line, 10))
+      .filter(Number.isInteger);
+  } catch {
+    return []; // no children, or no pgrep: nothing extra to stop
+  }
+}
+
+const timer = setInterval(() => {
+  if (process.ppid > 1) return;
+  clearInterval(timer);
+  for (const pid of children(process.pid)) {
+    try {
+      process.kill(pid, "SIGTERM");
+    } catch {
+      // Already gone.
+    }
+  }
+  process.kill(process.pid, "SIGTERM");
+  // Insurance, not the mechanism: if a shutdown handler hangs, do not stand
+  // in for the zombie this exists to prevent.
+  setTimeout(() => process.exit(0), 15_000).unref();
+}, everyMs);
+// The watch must never be what keeps the process alive.
+timer.unref();

--- a/dev/scripts/playwright-mcp.sh
+++ b/dev/scripts/playwright-mcp.sh
@@ -21,6 +21,12 @@ if [ "$1" = "--headed" ]; then
   shift
 fi
 
+# A hard-killed session cannot signal this MCP, and the Chrome it launches
+# outlives even the MCP. The hook makes the MCP notice it was orphaned and
+# shut its browser down (specs/setup/mcp-browser-lifecycle.feature).
+ORPHAN_HOOK="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/die-with-parent.cjs"
+export NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--require \"$ORPHAN_HOOK\""
+
 # `npx @playwright/mcp@latest` does a registry lookup on every cold start (~55s
 # observed on this machine — well over Claude Code's 30s MCP-connect timeout).
 # Resolve to the already-installed CLI directly. Fall back to npx only if the

--- a/platform/app/scripts/__tests__/dev-supervisor.unit.test.ts
+++ b/platform/app/scripts/__tests__/dev-supervisor.unit.test.ts
@@ -18,6 +18,7 @@ import {
   chmodSync,
   existsSync,
   mkdtempSync,
+  readFileSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
@@ -245,12 +246,29 @@ function runAsGroupLeader(
 function runSupervised(
   args: string[],
   env: Record<string, string> = {},
+  { supervisor = SUPERVISOR }: { supervisor?: string } = {},
 ): { stdout: string; stderr: string; status: number | null } {
-  const r = spawnSync(process.execPath, [SUPERVISOR, ...args], {
+  const r = spawnSync(process.execPath, [supervisor, ...args], {
     encoding: "utf8",
     env: { ...process.env, ...FAST, ...env },
   });
   return { stdout: r.stdout, stderr: r.stderr, status: r.status };
+}
+
+/**
+ * A copy of the supervisor with one string replaced, for the failures that
+ * cannot be provoked from the outside: a sentinel that will not spawn, or one
+ * that comes up and names no stack. The copy is the real script otherwise, and
+ * it imports nothing but node builtins, so it runs anywhere.
+ */
+function supervisorWith(from: string, to: string): string {
+  const source = readFileSync(SUPERVISOR, "utf8");
+  if (!source.includes(from)) {
+    throw new Error(`dev-supervisor.mjs no longer contains ${from}`);
+  }
+  const file = path.join(scratch, `${marker}-supervisor.mjs`);
+  writeFileSync(file, source.replace(from, to), "utf8");
+  return file;
 }
 
 describe("dev stack supervisor", () => {
@@ -515,6 +533,45 @@ describe("dev stack supervisor", () => {
 
         expect(result.status).toBe(0);
         expect(result.stdout).toBe(`${marker}-unsupervised\n`);
+      });
+
+      /** @scenario "A sentinel that cannot be started does not stop the command" */
+      it("runs the command anyway when the sentinel will not spawn", () => {
+        // spawn hands back a child and only then emits `error`, so this is the
+        // asynchronous failure: an unheard one takes the supervisor down with
+        // it, which is the one thing supervision must never do.
+        const result = runSupervised(
+          ["sh", "-c", `echo ${marker}-ran`],
+          {},
+          {
+            supervisor: supervisorWith(
+              "      process.execPath,\n      [\n        SELF,",
+              '      "/definitely-not-node",\n      [\n        SELF,',
+            ),
+          },
+        );
+
+        expect(result.stdout).toBe(`${marker}-ran\n`);
+        expect(result.status).toBe(0);
+        expect(result.stderr).toContain("sentinel did not come up");
+      });
+
+      /** @scenario "A sentinel that cannot be started does not stop the command" */
+      it("runs the command anyway when the sentinel names no stack", () => {
+        const result = runSupervised(
+          ["sh", "-c", `echo ${marker}-ran`],
+          {},
+          {
+            supervisor: supervisorWith(
+              "async function runSentinel(args, env) {",
+              "async function runSentinel(args, env) {\n  return 1;",
+            ),
+          },
+        );
+
+        expect(result.stdout).toBe(`${marker}-ran\n`);
+        expect(result.status).toBe(0);
+        expect(result.stderr).toContain("sentinel did not come up");
       });
 
       /** @scenario "A command still runs when it cannot be supervised" */

--- a/platform/app/scripts/__tests__/dev-supervisor.unit.test.ts
+++ b/platform/app/scripts/__tests__/dev-supervisor.unit.test.ts
@@ -139,16 +139,71 @@ function launchFrom(command: string, env: Record<string, string> = {}): number {
   return child.pid as number;
 }
 
-/** Every live pid whose command line carries this test's marker. */
-function stackPids(): number[] {
+/** How a sentinel is told from a supervisor: it re-enters behind this flag. */
+const SENTINEL_FLAG = "--sentinel";
+
+/** The live pids whose command line carries this test's marker and passes `keep`. */
+function markedPids(keep: (line: string) => boolean): number[] {
   const out = spawnSync("ps", ["-Ao", "pid=", "-o", "command="], {
     encoding: "utf8",
   }).stdout;
   return out
     .split("\n")
-    .filter((l) => l.includes(marker) && !l.includes("pkill"))
+    .filter((l) => l.includes(marker) && !l.includes("pkill") && keep(l))
     .map((l) => Number.parseInt(l.trim(), 10))
     .filter((n) => Number.isInteger(n));
+}
+
+/** Every live pid whose command line carries this test's marker. */
+function stackPids(): number[] {
+  return markedPids(() => true);
+}
+
+/**
+ * The sentinels posted for this test's stack. A sentinel carries the guarded
+ * command in its argv, so the marker tells this test's sentinels from the ones
+ * any other run posted.
+ */
+function sentinelPids(): number[] {
+  return markedPids(
+    (l) => l.includes("dev-supervisor.mjs") && l.includes(SENTINEL_FLAG),
+  );
+}
+
+/** Every live pid, with its parent, as `ps` reports them. */
+function processTree(): { pid: number; ppid: number; command: string }[] {
+  const out = spawnSync(
+    "ps",
+    ["-Ao", "pid=", "-o", "ppid=", "-o", "command="],
+    {
+      encoding: "utf8",
+    },
+  ).stdout;
+  const rows: { pid: number; ppid: number; command: string }[] = [];
+  for (const line of out.split("\n")) {
+    const match = /^(\d+)\s+(\d+)\s+(.*)$/.exec(line.trim());
+    if (match === null) continue;
+    const [, pid, ppid, command] = match;
+    if (pid === undefined || ppid === undefined || command === undefined) {
+      continue;
+    }
+    rows.push({
+      pid: Number.parseInt(pid, 10),
+      ppid: Number.parseInt(ppid, 10),
+      command,
+    });
+  }
+  return rows;
+}
+
+/** Whether a pid still exists, for the launcher this test must not disturb. */
+function pidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code === "EPERM";
+  }
 }
 
 async function waitUntil(
@@ -323,20 +378,10 @@ describe("dev stack supervisor", () => {
      * not the script body that mentions the supervisor.
      */
     function supervisorPid(): number | null {
-      const out = spawnSync("ps", ["-Ao", "pid=", "-o", "command="], {
-        encoding: "utf8",
-      }).stdout;
-      const line = out
-        .split("\n")
-        .find(
-          (l) =>
-            l.includes("dev-supervisor.mjs") &&
-            l.includes(marker) &&
-            !l.includes("--sentinel"),
-        );
-      if (!line) return null;
-      const pid = Number.parseInt(line.trim(), 10);
-      return Number.isInteger(pid) ? pid : null;
+      const [pid] = markedPids(
+        (l) => l.includes("dev-supervisor.mjs") && !l.includes(SENTINEL_FLAG),
+      );
+      return pid ?? null;
     }
 
     describe("when the supervisor and the shell are both killed by pid", () => {
@@ -385,13 +430,51 @@ describe("dev stack supervisor", () => {
       });
     });
 
+    describe("when the stack is running", () => {
+      /** @scenario "The stack is never running without a guard outside the doomed group" */
+      it("was started by the sentinel, so it was never unguarded", async () => {
+        const stack = writeStack(DEEP_STACK);
+        launchFrom(`node ${asBashWord(SUPERVISOR)} ${asBashWord(stack)}`);
+        expect(await stackIsUp()).toBe(true);
+
+        // The stack script's own process, and who created it. A sentinel
+        // posted AFTER the stack would leave the supervisor as the parent, and
+        // with it the window this asserts away: for as long as posting takes,
+        // a detached stack whose only watcher is inside the doomed group.
+        const tree = processTree();
+        const stackProc = tree.find(
+          (p) => p.command.includes(stack) && !p.command.includes(SUPERVISOR),
+        );
+        expect(stackProc).toBeDefined();
+
+        const parent = tree.find((p) => p.pid === stackProc?.ppid);
+        expect(parent?.command).toContain("dev-supervisor.mjs");
+        expect(parent?.command).toContain(SENTINEL_FLAG);
+      });
+    });
+
     describe("when the stack exits on its own", () => {
       /** @scenario "Supervision leaves nothing behind when the stack exits on its own" */
       it("leaves no sentinel running", async () => {
-        const result = runSupervised(["sh", "-c", `: ${marker}`]);
+        // The stack runs until this test releases it, so the sentinel can be
+        // observed alive first: a run that never posted one would otherwise
+        // pass this test by having nothing to leave behind.
+        const stopFile = path.join(scratch, "stop");
+        const stack = writeStack(
+          `while [ ! -f ${asBashWord(stopFile)} ]; do sleep 0.1; done`,
+        );
+        const launcher = launchFrom(
+          `node ${asBashWord(SUPERVISOR)} ${asBashWord(stack)}`,
+        );
+        expect(await stackIsUp()).toBe(true);
+        expect(await waitUntil(() => sentinelPids().length > 0)).toBe(true);
 
-        expect(result.status).toBe(0);
-        expect(await waitUntil(() => stackPids().length === 0)).toBe(true);
+        writeFileSync(stopFile, "", "utf8");
+
+        // Nobody was killed: the stack ended by itself and the sentinel went
+        // with it, leaving the launcher that is still there untouched.
+        expect(await waitUntil(() => sentinelPids().length === 0)).toBe(true);
+        expect(pidAlive(launcher)).toBe(true);
       });
     });
   });

--- a/platform/app/scripts/__tests__/dev-supervisor.unit.test.ts
+++ b/platform/app/scripts/__tests__/dev-supervisor.unit.test.ts
@@ -315,6 +315,87 @@ describe("dev stack supervisor", () => {
     });
   });
 
+  describe("given a stack whose supervisor is killed outright", () => {
+    /**
+     * The supervisor's pid, found by its command line: it carries this test's
+     * marker (the stack path is its argument) and is not the sentinel. The
+     * launcher does not match, because ps shows its argv (`bash .../launcher.sh`),
+     * not the script body that mentions the supervisor.
+     */
+    function supervisorPid(): number | null {
+      const out = spawnSync("ps", ["-Ao", "pid=", "-o", "command="], {
+        encoding: "utf8",
+      }).stdout;
+      const line = out
+        .split("\n")
+        .find(
+          (l) =>
+            l.includes("dev-supervisor.mjs") &&
+            l.includes(marker) &&
+            !l.includes("--sentinel"),
+        );
+      if (!line) return null;
+      const pid = Number.parseInt(line.trim(), 10);
+      return Number.isInteger(pid) ? pid : null;
+    }
+
+    describe("when the supervisor and the shell are both killed by pid", () => {
+      /** @scenario "The stack goes down even when the supervisor is killed outright" */
+      it("still takes the whole stack down, sentinel included", async () => {
+        const stack = writeStack(DEEP_STACK);
+        const launcher = launchFrom(
+          `node ${asBashWord(SUPERVISOR)} ${asBashWord(stack)}`,
+        );
+        expect(await stackIsUp()).toBe(true);
+        await waitUntil(() => supervisorPid() !== null);
+        const supervisor = supervisorPid();
+        expect(supervisor).not.toBeNull();
+
+        // The shape of a hard session teardown: the launching group dies to
+        // SIGKILL, so no signal ever reaches the detached stack group.
+        process.kill(supervisor as number, "SIGKILL");
+        process.kill(launcher, "SIGKILL");
+
+        // stackPids counts the sentinel too (the guarded command is in its
+        // argv), so reaching zero also means the sentinel did not linger.
+        expect(await waitUntil(() => stackPids().length === 0)).toBe(true);
+      });
+    });
+
+    describe("when only the supervisor is killed", () => {
+      /** @scenario "A killed supervisor alone does not take a living launcher's stack" */
+      it("keeps the stack for the launcher, and takes it down when the launcher dies", async () => {
+        const stack = writeStack(DEEP_STACK);
+        const launcher = launchFrom(
+          `node ${asBashWord(SUPERVISOR)} ${asBashWord(stack)}`,
+        );
+        expect(await stackIsUp()).toBe(true);
+        await waitUntil(() => supervisorPid() !== null);
+        const supervisor = supervisorPid();
+        expect(supervisor).not.toBeNull();
+
+        process.kill(supervisor as number, "SIGKILL");
+        await sleep(1500);
+        // Launcher, lanes and sentinel are all still here: a crashed
+        // supervisor is not a reason to pull work out from under a live shell.
+        expect(stackPids().length).toBeGreaterThanOrEqual(3);
+
+        process.kill(launcher, "SIGKILL");
+        expect(await waitUntil(() => stackPids().length === 0)).toBe(true);
+      });
+    });
+
+    describe("when the stack exits on its own", () => {
+      /** @scenario "Supervision leaves nothing behind when the stack exits on its own" */
+      it("leaves no sentinel running", async () => {
+        const result = runSupervised(["sh", "-c", `: ${marker}`]);
+
+        expect(result.status).toBe(0);
+        expect(await waitUntil(() => stackPids().length === 0)).toBe(true);
+      });
+    });
+  });
+
   describe("given supervision cannot or should not apply", () => {
     describe("when the command is run anyway", () => {
       /** @scenario "Supervision can be turned off" */

--- a/platform/app/scripts/__tests__/die-with-parent.unit.test.ts
+++ b/platform/app/scripts/__tests__/die-with-parent.unit.test.ts
@@ -1,0 +1,149 @@
+/**
+ * @vitest-environment node
+ *
+ * Tests for dev/scripts/die-with-parent.cjs, the hook playwright-mcp.sh loads
+ * into the MCP's node process so an orphaned MCP shuts its browser down.
+ *
+ * Driven as real processes, like the dev-supervisor tests: a stand-in
+ * "session" (bash, its own group leader) spawns a stand-in "MCP" (node with
+ * the hook) which spawns a stand-in "browser" (sleep). The session is killed
+ * by pid, the way a real teardown loses one, and the tests observe who is
+ * left.
+ *
+ * Corresponds to specs/setup/mcp-browser-lifecycle.feature.
+ */
+
+import { spawn, spawnSync } from "node:child_process";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { asBashWord } from "./shell-quote";
+
+const REPO_ROOT = path.resolve(__dirname, "../../../..");
+const HOOK = path.join(REPO_ROOT, "dev/scripts/die-with-parent.cjs");
+
+const FAST = { LANGWATCH_MCP_ORPHAN_WATCH_MS: "100" };
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+let scratch: string;
+let marker: string;
+const sessions: number[] = [];
+
+beforeEach(() => {
+  scratch = mkdtempSync(path.join(os.tmpdir(), "die-with-parent-test-"));
+  marker = `dwp${Math.random().toString(36).slice(2, 10)}`;
+});
+
+afterEach(async () => {
+  for (const pid of sessions.splice(0)) {
+    try {
+      process.kill(pid, "SIGKILL");
+    } catch {
+      // Already gone.
+    }
+  }
+  for (let attempt = 0; attempt < 40; attempt += 1) {
+    spawnSync("pkill", ["-9", "-f", marker]);
+    if (spawnSync("pgrep", ["-f", marker]).status !== 0) break;
+    await sleep(50);
+  }
+  rmSync(scratch, { recursive: true, force: true });
+});
+
+/** Every live pid whose command line carries this test's marker. */
+function markedPids(): number[] {
+  const out = spawnSync("ps", ["-Ao", "pid=", "-o", "command="], {
+    encoding: "utf8",
+  }).stdout;
+  return out
+    .split("\n")
+    .filter((l) => l.includes(marker) && !l.includes("pkill"))
+    .map((l) => Number.parseInt(l.trim(), 10))
+    .filter((n) => Number.isInteger(n));
+}
+
+async function waitUntil(
+  predicate: () => boolean,
+  { timeoutMs = 6000 } = {},
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return true;
+    await sleep(50);
+  }
+  return predicate();
+}
+
+/**
+ * A stand-in session running a stand-in MCP: node with the hook required, a
+ * `sleep` child standing for the browser, and an interval keeping it alive
+ * the way a server does. Returns the session's pid.
+ */
+function launchSession(): number {
+  const mcp = path.join(scratch, `${marker}-mcp.cjs`);
+  writeFileSync(
+    mcp,
+    `const { spawn } = require("node:child_process");
+spawn("sleep", ["120", ${JSON.stringify(marker)}], { stdio: "ignore" });
+setInterval(() => {}, 1000);
+`,
+    "utf8",
+  );
+  const launcher = path.join(scratch, `${marker}-session.sh`);
+  writeFileSync(
+    launcher,
+    `#!/bin/bash\nnode --require ${asBashWord(HOOK)} ${asBashWord(mcp)} &\nsleep 120\n`,
+    "utf8",
+  );
+  chmodSync(launcher, 0o755);
+  const child = spawn("bash", [launcher], {
+    detached: true,
+    stdio: "ignore",
+    env: { ...process.env, ...FAST },
+  });
+  child.unref();
+  sessions.push(child.pid as number);
+  return child.pid as number;
+}
+
+describe("die-with-parent hook", () => {
+  describe("given an MCP-shaped process with a child, spawned by a session", () => {
+    describe("when the session is killed without signalling anything", () => {
+      /** @scenario "The MCP and its browser go down when their session dies" */
+      it("shuts the process and its child down", async () => {
+        const session = launchSession();
+        expect(await waitUntil(() => markedPids().length >= 2)).toBe(true);
+
+        process.kill(session, "SIGKILL");
+
+        expect(await waitUntil(() => markedPids().length === 0)).toBe(true);
+      });
+    });
+
+    describe("when the session stays alive", () => {
+      /** @scenario "A living session keeps its browser" */
+      it("signals nothing", async () => {
+        launchSession();
+        expect(await waitUntil(() => markedPids().length >= 2)).toBe(true);
+
+        await sleep(1000);
+
+        expect(markedPids().length).toBeGreaterThanOrEqual(2);
+      });
+    });
+  });
+
+  describe("given a process that loads the watch and has nothing else to do", () => {
+    /** @scenario "The watch never keeps an exiting process alive" */
+    it("exits on its own", () => {
+      const r = spawnSync(
+        "node",
+        ["--require", HOOK, "-e", "process.exitCode = 7"],
+        { encoding: "utf8", env: { ...process.env, ...FAST }, timeout: 5000 },
+      );
+      expect(r.status).toBe(7);
+    });
+  });
+});

--- a/specs/setup/dev-stack-lifecycle.feature
+++ b/specs/setup/dev-stack-lifecycle.feature
@@ -104,6 +104,17 @@ Feature: A dev stack does not outlive whoever started it
     When the supervisor and the shell are both killed without any signal reaching the stack
     Then the whole stack is taken down anyway
 
+  # A sentinel started after the stack would leave a window: for as long as it
+  # takes to start, a detached stack exists that the doomed group is still the
+  # only watcher of, and a SIGKILL landing there leaks the stack for good. So
+  # the sentinel is started first and is what starts the stack.
+
+  @unit
+  Scenario: The stack is never running without a guard outside the doomed group
+    Given a dev stack started from a shell
+    When the stack is running
+    Then the sentinel is what started it, so no window exists in which it had no guard
+
   @unit
   Scenario: A killed supervisor alone does not take a living launcher's stack
     Given a dev stack started from a shell

--- a/specs/setup/dev-stack-lifecycle.feature
+++ b/specs/setup/dev-stack-lifecycle.feature
@@ -87,6 +87,36 @@ Feature: A dev stack does not outlive whoever started it
     When it does
     Then the supervisor exits with the same code rather than waiting for its launcher
 
+  # --- Surviving the supervisor's own death ---
+
+  # A hard session teardown SIGKILLs the whole launching group at once: the
+  # shell, the pnpm chain, and the supervisor sitting in it. The stack is
+  # detached exactly so that teardown cannot reach it — which also means its
+  # watcher dies watching. Observed: a bare `concurrently` at PPID 1,
+  # respawning lanes for two days in a worktree nobody was in. So the watch
+  # itself has to sit outside the doomed group: a sentinel in a group of its
+  # own, whose only job is to notice that both the supervisor and the
+  # launcher are gone and take the stack down in their place.
+
+  @unit
+  Scenario: The stack goes down even when the supervisor is killed outright
+    Given a dev stack started from a shell
+    When the supervisor and the shell are both killed without any signal reaching the stack
+    Then the whole stack is taken down anyway
+
+  @unit
+  Scenario: A killed supervisor alone does not take a living launcher's stack
+    Given a dev stack started from a shell
+    When only the supervisor is killed outright
+    Then the stack keeps running for as long as the shell lives
+    And it is taken down once the shell dies too
+
+  @unit
+  Scenario: Supervision leaves nothing behind when the stack exits on its own
+    Given a dev command that exits by itself
+    When it does
+    Then no part of the supervision is still running afterwards
+
   # --- Not taking down more than its own ---
 
   @unit

--- a/specs/setup/dev-stack-lifecycle.feature
+++ b/specs/setup/dev-stack-lifecycle.feature
@@ -116,6 +116,13 @@ Feature: A dev stack does not outlive whoever started it
     Then the sentinel is what started it, so no window exists in which it had no guard
 
   @unit
+  Scenario: A sentinel that cannot be started does not stop the command
+    Given a dev stack started from a shell
+    When the sentinel cannot be started, or comes up and names no stack
+    Then the command runs anyway, unguarded against a killed supervisor but running
+    And the supervisor says the sentinel did not come up
+
+  @unit
   Scenario: A killed supervisor alone does not take a living launcher's stack
     Given a dev stack started from a shell
     When only the supervisor is killed outright

--- a/specs/setup/haven-lifecycle-usability.feature
+++ b/specs/setup/haven-lifecycle-usability.feature
@@ -111,6 +111,25 @@ Feature: haven lifecycle usability
     Then it streams plainly in the foreground and Ctrl-C stops the stack
     And agent mode streams the same way even from a terminal
 
+  # A human's up detaches on purpose: closing the terminal leaves the stack
+  # for `haven down`. The foreground run an agent or a pipe gets has no such
+  # handover — whoever launched it is its only owner, and signals are the only
+  # goodbye it ever gets. A launcher killed by pid says none. Observed: a
+  # foreground `haven up --agent` still supervising a full stack, two days
+  # after the session that ran it was gone. So the foreground run watches the
+  # process group it was launched into, the same way dev-supervisor does, and
+  # shuts down as if interrupted when that group loses its leader.
+  @unit
+  Scenario: A foreground up goes down with the group that launched it
+    Given a foreground "haven up" launched from a shell's process group
+    When that group's leader dies without signalling anything
+    Then the run shuts down as if interrupted, stack and routes included
+
+  @unit
+  Scenario: A run that leads its own process group watches nothing
+    Given "haven up" running as its own process-group leader, the shape of an interactive job
+    Then no launcher watch is armed, because the terminal already owns its lifetime
+
   # Attached and detached run the identical backgrounded child — the viewer is
   # only attached on top — so there is no second logging path to keep in step.
   # Bound by cmd/uplifecycle_test.go.

--- a/specs/setup/mcp-browser-lifecycle.feature
+++ b/specs/setup/mcp-browser-lifecycle.feature
@@ -1,0 +1,35 @@
+Feature: A dogfooding browser does not outlive its agent
+  As a developer whose machine runs many agent sessions that drive a browser
+  I want the Playwright MCP and its Chrome to go down when their session dies
+  So that killed sessions stop accumulating orphaned browsers
+
+  # Observed: 20 orphaned Chromes and 7.4 GB of their profiles under
+  # ~/Library/Caches/ms-playwright-mcp, each left by a dogfooding session that
+  # was long gone. The chain has two breaks: a hard-killed session cannot
+  # signal the MCP it spawned (it reparents to launchd and keeps serving
+  # nobody), and the Chrome the MCP launched detaches from its parent's fate
+  # on purpose, so even the MCP dying cleanly is not always enough.
+  #
+  # macOS has no die-with-parent, so the MCP watches for itself:
+  # dev/scripts/playwright-mcp.sh loads dev/scripts/die-with-parent.cjs into
+  # the MCP's node process, which polls its parent pid. On orphaning it
+  # SIGTERMs its direct children (the browser) and then itself, which runs the
+  # MCP's own shutdown handlers - the same path a clean disconnect takes.
+
+  @unit
+  Scenario: The MCP and its browser go down when their session dies
+    Given an MCP-shaped process with a child, spawned by a session
+    When the session is killed without signalling anything
+    Then the process notices it was orphaned and shuts down
+    And its child is taken down with it
+
+  @unit
+  Scenario: A living session keeps its browser
+    Given an MCP-shaped process with a child, spawned by a session
+    When the session stays alive
+    Then nothing is signalled and the process keeps running
+
+  @unit
+  Scenario: The watch never keeps an exiting process alive
+    Given a process that loads the watch and has nothing else to do
+    Then it exits on its own, because the watch holds no part of the event loop

--- a/tools/thuishaven/cmd/launcherwatch.go
+++ b/tools/thuishaven/cmd/launcherwatch.go
@@ -1,0 +1,95 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"syscall"
+	"time"
+)
+
+// A foreground `haven up` has exactly one owner: whatever launched it. A
+// human's up detaches (startDetachedUp) and hands the stack to `haven down`,
+// but the foreground run an agent or a pipe gets has no such handover, and a
+// launcher killed by pid sends no signal. Observed: a foreground
+// `haven up --agent` still supervising a full stack two days after the agent
+// session that ran it was gone. So the foreground run watches the process
+// group it was launched into — the same semantics dev-supervisor.mjs uses —
+// and shuts down as if interrupted when that group loses its leader.
+//
+// An interactive job is its own process-group leader, and the detached child
+// runs under Setsid, so both shapes resolve to "nothing to watch" and keep
+// their lifetime exactly as it was.
+
+// launcherWatchInterval is how often the leader is looked at. Death is only
+// ever noticed late by at most one interval, and the check is one kill(2).
+const launcherWatchInterval = 5 * time.Second
+
+// groupLeaderToWatch decides whether this process's group has a leader worth
+// watching: not the kernel's groups (pgid <= 1), not ourselves (the
+// interactive-job shape, where the tty owns the lifetime), and not a leader
+// that is already gone, which leaves nothing to observe.
+func groupLeaderToWatch(pid, pgid int, alive func(int) bool) int {
+	if pgid <= 1 || pgid == pid {
+		return 0
+	}
+	if !alive(pgid) {
+		return 0
+	}
+	return pgid
+}
+
+// processAlive reports whether pid exists. EPERM means it does, owned by
+// someone else.
+func processAlive(pid int) bool {
+	err := syscall.Kill(pid, 0)
+	return err == nil || errors.Is(err, syscall.EPERM)
+}
+
+// processWatch is one pid to poll and what to do when it disappears.
+type processWatch struct {
+	pid    int
+	every  time.Duration
+	alive  func(int) bool
+	onGone func()
+}
+
+// watchProcessGone runs w.onGone when w.pid disappears, checking every
+// w.every. It stops quietly when ctx ends first.
+func watchProcessGone(ctx context.Context, w processWatch) {
+	t := time.NewTicker(w.every)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			if !w.alive(w.pid) {
+				w.onGone()
+				return
+			}
+		}
+	}
+}
+
+// watchLaunchingGroup returns a context that is canceled when the process
+// group this run was launched into loses its leader. When there is nothing to
+// watch, the context comes back unchanged and the cancel is a no-op.
+func watchLaunchingGroup(ctx context.Context) (context.Context, context.CancelFunc) {
+	leader := groupLeaderToWatch(os.Getpid(), syscall.Getpgrp(), processAlive)
+	if leader == 0 {
+		return ctx, func() {}
+	}
+	ctx, cancel := context.WithCancel(ctx)
+	go watchProcessGone(ctx, processWatch{
+		pid:   leader,
+		every: launcherWatchInterval,
+		alive: processAlive,
+		onGone: func() {
+			fmt.Fprintf(os.Stderr, "haven: the process group that launched this up (%d) is gone — shutting the stack down\n", leader)
+			cancel()
+		},
+	})
+	return ctx, cancel
+}

--- a/tools/thuishaven/cmd/launcherwatch_test.go
+++ b/tools/thuishaven/cmd/launcherwatch_test.go
@@ -1,0 +1,113 @@
+package cmd
+
+import (
+	"context"
+	"os"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// The foreground up watches the group it was launched into, and only that
+// shape: an interactive job leads its own group, the detached child runs
+// under Setsid, and both must resolve to "nothing to watch".
+//
+// @scenario "A run that leads its own process group watches nothing"
+func TestGroupLeaderToWatch(t *testing.T) {
+	alive := func(int) bool { return true }
+	dead := func(int) bool { return false }
+
+	t.Run("given a run that leads its own process group", func(t *testing.T) {
+		if got := groupLeaderToWatch(42, 42, alive); got != 0 {
+			t.Fatalf("own group leader must watch nothing, got %d", got)
+		}
+	})
+	t.Run("given a degenerate group id", func(t *testing.T) {
+		if got := groupLeaderToWatch(42, 0, alive); got != 0 {
+			t.Fatalf("pgid 0 must watch nothing, got %d", got)
+		}
+		if got := groupLeaderToWatch(42, 1, alive); got != 0 {
+			t.Fatalf("pgid 1 must watch nothing, got %d", got)
+		}
+	})
+	t.Run("given a leader that is already gone", func(t *testing.T) {
+		if got := groupLeaderToWatch(42, 99, dead); got != 0 {
+			t.Fatalf("a dead leader leaves nothing to observe, got %d", got)
+		}
+	})
+	t.Run("given a live leader above this run", func(t *testing.T) {
+		if got := groupLeaderToWatch(42, 99, alive); got != 99 {
+			t.Fatalf("a live foreign leader is the one to watch, got %d", got)
+		}
+	})
+}
+
+// @scenario "A foreground up goes down with the group that launched it"
+func TestWatchProcessGone(t *testing.T) {
+	t.Run("given a watched leader that dies", func(t *testing.T) {
+		var leaderAlive atomic.Bool
+		leaderAlive.Store(true)
+		gone := make(chan struct{})
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		go watchProcessGone(ctx, processWatch{
+			pid:    99,
+			every:  time.Millisecond,
+			alive:  func(int) bool { return leaderAlive.Load() },
+			onGone: func() { close(gone) },
+		})
+
+		t.Run("when the leader is gone", func(t *testing.T) {
+			leaderAlive.Store(false)
+			select {
+			case <-gone:
+			case <-ctx.Done():
+				t.Fatal("the watch never noticed the leader dying")
+			}
+		})
+	})
+
+	t.Run("given a run that ends while its leader lives", func(t *testing.T) {
+		fired := make(chan struct{})
+		ctx, cancel := context.WithCancel(context.Background())
+		done := make(chan struct{})
+		go func() {
+			watchProcessGone(ctx, processWatch{
+				pid:    99,
+				every:  time.Millisecond,
+				alive:  func(int) bool { return true },
+				onGone: func() { close(fired) },
+			})
+			close(done)
+		}()
+
+		t.Run("when the run's context ends", func(t *testing.T) {
+			cancel()
+			select {
+			case <-done:
+			case <-time.After(5 * time.Second):
+				t.Fatal("the watch did not stop with the run")
+			}
+			select {
+			case <-fired:
+				t.Fatal("a finished run is not a dead leader")
+			default:
+			}
+		})
+	})
+}
+
+// processAlive is the one real syscall in the watch; prove both answers.
+func TestProcessAlive(t *testing.T) {
+	t.Run("given this test's own process", func(t *testing.T) {
+		if !processAlive(os.Getpid()) {
+			t.Fatal("our own pid must read as alive")
+		}
+	})
+	t.Run("given a pid that cannot exist", func(t *testing.T) {
+		if processAlive(1<<30 + 7) {
+			t.Fatal("an absurd pid must read as gone")
+		}
+	})
+}

--- a/tools/thuishaven/cmd/table.go
+++ b/tools/thuishaven/cmd/table.go
@@ -228,6 +228,10 @@ var table = []commandSpec{
 			if upRunsAttached(d.isAgent, stdoutIsTTY()) {
 				return runUpAttached(ctx, d, inv.raw)
 			}
+			// The foreground run dies with whoever launched it; the detached
+			// child above runs under Setsid and is naturally exempt.
+			ctx, unwatch := watchLaunchingGroup(ctx)
+			defer unwatch()
 			return d.orch.Up(ctx, d.params, d.opts)
 		},
 	},


### PR DESCRIPTION
Three lifecycle gaps let processes outlive the agent session that started them. Together they filled 14 of 15 GB of swap on an 18 GB machine, and the pressure spike then took down the tmux server and every session in it. Each gap gets a fix at its source; no cleanup cron is involved.

## Gap 1: a SIGKILLed supervisor leaves its stack behind

`dev-supervisor.mjs` already takes a `pnpm dev` stack down when the launcher dies. But a hard session teardown SIGKILLs the whole launching group at once, supervisor included, and the stack is detached exactly so that teardown cannot reach it. Observed: a bare `concurrently` at PPID 1, respawning lanes for two days in a worktree nobody was in.

Fix: the supervisor posts a **sentinel**, a process group of its own that no teardown aimed at the launcher or the stack can take first. It idles while the supervisor or the launcher is alive, takes the stack down when both are gone, and exits the moment the stack does. Its argv carries the guarded command, so `ps` shows what it stands for.

## Gap 2: a foreground `haven up` outlives its agent

A human's `haven up` detaches on purpose and hands the stack to `haven down`. The foreground run an agent or a pipe gets has no such handover, and the daemon's reaper only triggers on a dead launcher pid, so a launcher that survives its session heartbeats forever. Observed: a foreground `haven up --agent` still supervising a full stack two days after the agent session that ran it was gone.

Fix: the foreground run watches the process group it was launched into, the same semantics as dev-supervisor, and cancels its own context when that group loses its leader. That reuses the normal interrupt teardown: services stopped, routes deregistered. An interactive job leads its own group and the detached child runs under `Setsid`, so both resolve to "nothing to watch" and keep their lifetime exactly as before.

## Gap 3: a dogfooding Chrome outlives everything

A killed session cannot signal the Playwright MCP it spawned, and the Chrome the MCP launched detaches from its parent's fate by design. Observed: 20 orphaned Chromes and 7.4 GB of their profiles, each from a session long gone.

Fix: `playwright-mcp.sh` loads `die-with-parent.cjs` into the MCP's node process (`NODE_OPTIONS --require`). It polls the parent pid; on orphaning it SIGTERMs its direct children (the browser) and then itself, which runs the MCP's own shutdown handlers, the same path a clean disconnect takes. The watch is `unref`ed, so it never keeps an exiting process alive.

## Verification

- New feature file `specs/setup/mcp-browser-lifecycle.feature` (3/3 bound); `dev-stack-lifecycle.feature` now 20/20 bound; `haven-lifecycle-usability.feature` now 17/17 bound.
- JS: 14/14 in `dev-supervisor.unit.test.ts` (three new: supervisor+launcher SIGKILL, supervisor-only SIGKILL, no sentinel left after a natural exit; the tests count the sentinel's own pid, so "zero left" includes it). 3/3 in `die-with-parent.unit.test.ts`, driven as real processes.
- Go: `groupLeaderToWatch` shape table, `watchProcessGone` fire and quiet-stop paths, `processAlive` both answers. `go vet` and the full `go test ./cmd ./app ./domain` green, `make go-lint-changed` 0 issues.
- The machine-level reaper LaunchAgent that stood in for these fixes was removed.

https://claude.ai/code/session_01EiGnzR6pJ7Ezhue4x4YFK6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of detached development stacks when supervising or launching processes terminate unexpectedly.
  * Foreground `haven up` runs now shut down automatically when their launching process group exits.
  * Playwright MCP sessions now close their browser processes when orphaned, while remaining active during normal operation.

* **Tests**
  * Added coverage for process lifecycle monitoring, graceful shutdown, orphan detection, and stack cleanup across supported run modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->