### PR TITLE
fix(admin): read impersonation's second-factor check off the target row

### DIFF
--- a/platform/app/ee/admin/__tests__/impersonation.service.unit.test.ts
+++ b/platform/app/ee/admin/__tests__/impersonation.service.unit.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { PrismaClient } from "~/generated/prisma/client";
+import { guardOrganizationId } from "~/utils/dbOrganizationIdProtection";
 import {
   type AuditLogFn,
   CannotImpersonateAdminError,
@@ -46,9 +47,26 @@ function makePrisma(): StubPrisma {
       findUnique: vi.fn(),
       update: vi.fn().mockResolvedValue({}),
     },
-    // No organization of the target's requires a second factor by default,
-    // so the operator's own enrollment is not consulted (D06).
-    organizationUser: { findMany: vi.fn().mockResolvedValue([]) },
+    /**
+     * Not a stub that answers — the REAL organization-tenancy guard.
+     *
+     * This delegate used to resolve `[]` unconditionally, and that is exactly
+     * how a top-level `organizationUser.findMany({ where: { userId, ... } })`
+     * reached production: the guard refuses a query with no
+     * single-organization predicate (ADR-021), so every impersonation answered
+     * 500 while this suite stayed green. Running the guard here means a query
+     * the database would refuse is a query these tests refuse too — the
+     * service is expected to read memberships nested off the target row, which
+     * never lands on this delegate at all.
+     */
+    organizationUser: {
+      findMany: vi.fn(async (args: unknown) =>
+        guardOrganizationId(
+          { model: "OrganizationUser", action: "findMany", args },
+          async () => [],
+        ),
+      ),
+    },
   };
 }
 
@@ -75,25 +93,30 @@ describe("ImpersonationService", () => {
 
   describe("start", () => {
     describe("given the target belongs to an organization requiring a second factor", () => {
-      const healthyTarget = {
+      /**
+       * The target row as the service now reads it: the memberships that
+       * require a second factor ride along as a nested select, so the slugs
+       * are part of the target rather than a second query.
+       */
+      const healthyTarget = (requiringOrganizationSlugs: string[] = []) => ({
         id: "user_target",
         name: "Target",
         email: "target@example.com",
         image: null,
         deactivatedAt: null,
-      };
+        orgMemberships: requiringOrganizationSlugs.map((slug) => ({
+          organization: { slug },
+        })),
+      });
 
       /** @scenario "Impersonating into an organization that requires it takes the operator's own" */
       it("refuses when the operator has not set one up, and stamps nothing", async () => {
         const prisma = makePrisma();
         prisma.user.findUnique
-          .mockResolvedValueOnce(healthyTarget)
+          .mockResolvedValueOnce(healthyTarget(["acme"]))
           // The operator's own account, read only because the target's
           // organization requires one.
           .mockResolvedValueOnce({ twoFactorEnabled: false });
-        prisma.organizationUser.findMany.mockResolvedValue([
-          { organization: { slug: "acme" } },
-        ]);
         const auditLog = makeAuditLog();
         const service = ImpersonationService.create(
           prisma as unknown as PrismaClient,
@@ -118,11 +141,8 @@ describe("ImpersonationService", () => {
       it("allows it when the operator has one of their own", async () => {
         const prisma = makePrisma();
         prisma.user.findUnique
-          .mockResolvedValueOnce(healthyTarget)
+          .mockResolvedValueOnce(healthyTarget(["acme"]))
           .mockResolvedValueOnce({ twoFactorEnabled: true });
-        prisma.organizationUser.findMany.mockResolvedValue([
-          { organization: { slug: "acme" } },
-        ]);
         const service = ImpersonationService.create(
           prisma as unknown as PrismaClient,
           makeAuditLog(),
@@ -141,8 +161,7 @@ describe("ImpersonationService", () => {
 
       it("does not consult the operator when no organization requires one", async () => {
         const prisma = makePrisma();
-        prisma.user.findUnique.mockResolvedValue(healthyTarget);
-        prisma.organizationUser.findMany.mockResolvedValue([]);
+        prisma.user.findUnique.mockResolvedValue(healthyTarget());
         const service = ImpersonationService.create(
           prisma as unknown as PrismaClient,
           makeAuditLog(),
@@ -161,6 +180,52 @@ describe("ImpersonationService", () => {
         expect(prisma.user.findUnique).toHaveBeenCalledTimes(1);
         expect(prisma.session.update).toHaveBeenCalled();
       });
+
+      /**
+       * The regression that took production down, executed rather than
+       * asserted about.
+       *
+       * "Which of this person's organizations require a factor" spans every
+       * organization they belong to, so asking it as a top-level
+       * `organizationUser.findMany` presents `guardOrganizationId` a query with
+       * no single-organization predicate and the guard refuses it — a refusal
+       * the customer met as "Couldn't impersonate the user", not as a skipped
+       * check. The stub delegate above runs the real guard, so restoring that
+       * query fails this test with the production error instead of shipping.
+       *
+       * The delegate going untouched is the invariant, not a detail: the
+       * memberships have to arrive nested off the target row, where the guard
+       * is right not to look. The clause itself is deliberately NOT compared
+       * against a re-typed copy of itself — a hand-copied literal matches its
+       * own copy no matter how far the real query drifts, which is the failure
+       * mode this whole file exists to stop.
+       */
+      /** @scenario "Looking up the requirement decides the request rather than failing it" */
+      it("asks for the memberships without a top-level OrganizationUser query", async () => {
+        const prisma = makePrisma();
+        prisma.user.findUnique
+          // "acme" requires a factor, so the check runs in full rather than
+          // short-circuiting on an empty membership list.
+          .mockResolvedValueOnce(healthyTarget(["acme"]))
+          .mockResolvedValueOnce({ twoFactorEnabled: true });
+        const service = ImpersonationService.create(
+          prisma as unknown as PrismaClient,
+          makeAuditLog(),
+        );
+
+        await service.start({
+          sessionId: "sess_1",
+          impersonatorUserId: "user_admin",
+          userIdToImpersonate: "user_target",
+          reason: "Debugging trace #42",
+          req: {},
+        });
+
+        expect(prisma.organizationUser.findMany).not.toHaveBeenCalled();
+        const [targetRead] = prisma.user.findUnique.mock.calls[0]!;
+        expect(targetRead.select).toHaveProperty("orgMemberships");
+        expect(prisma.session.update).toHaveBeenCalled();
+      });
     });
 
     describe("given a healthy, non-admin, non-deactivated target", () => {
@@ -172,6 +237,8 @@ describe("ImpersonationService", () => {
           email: "target@example.com",
           image: null,
           deactivatedAt: null,
+          // Belongs to nothing that requires a second factor.
+          orgMemberships: [],
         });
         const auditLog = makeAuditLog();
         const service = ImpersonationService.create(

--- a/platform/app/ee/admin/impersonation.service.ts
+++ b/platform/app/ee/admin/impersonation.service.ts
@@ -131,23 +131,19 @@ export class ImpersonationService {
    * to it.
    *
    * Reads the TARGET's organizations, because those are the ones whose data
-   * the operator is about to see.
+   * the operator is about to see. Those slugs are read off the target row in
+   * `start` rather than here — see the note on that query.
    */
   private async assertOperatorCanProveSecondFactor({
     operatorUserId,
     targetUserId,
+    requiringOrganizationSlugs,
   }: {
     operatorUserId: string;
     targetUserId: string;
+    requiringOrganizationSlugs: readonly string[];
   }): Promise<void> {
-    const requiring = await this.prisma.organizationUser.findMany({
-      where: {
-        userId: targetUserId,
-        organization: { mfaRequired: true },
-      },
-      select: { organization: { select: { slug: true } } },
-    });
-    if (requiring.length === 0) return;
+    if (requiringOrganizationSlugs.length === 0) return;
 
     const operator = await this.prisma.user.findUnique({
       where: { id: operatorUserId },
@@ -156,13 +152,31 @@ export class ImpersonationService {
     if (operator?.twoFactorEnabled) return;
 
     throw new CannotImpersonateWithoutSecondFactorError(
-      `impersonate: operator ${operatorUserId} has no second factor; target ${targetUserId} belongs to ${requiring
-        .map((membership) => membership.organization.slug)
-        .join(", ")}`,
+      `impersonate: operator ${operatorUserId} has no second factor; target ${targetUserId} belongs to ${requiringOrganizationSlugs.join(
+        ", ",
+      )}`,
     );
   }
 
   async start(input: StartImpersonationInput): Promise<void> {
+    /**
+     * The target, plus the memberships that decide whether the operator needs
+     * a second factor of their own.
+     *
+     * The memberships ride along as a NESTED read on purpose. "Which of this
+     * person's organizations require a factor" is a question about one person
+     * across many organizations, so a top-level
+     * `organizationUser.findMany({ where: { userId, ... } })` carries no
+     * single-organization predicate and `guardOrganizationId` (ADR-021)
+     * rejects it outright — which is exactly what took every impersonation
+     * down with a 500 rather than merely skipping the check. The guard runs on
+     * top-level model operations (`$allOperations` in `src/server/db.ts`), so
+     * reading the memberships through the target row asks the same question
+     * without presenting the guard a query it must refuse. Same reason, same
+     * shape as the nurturing lookup in `src/server/better-auth/hooks.ts`.
+     *
+     * It also costs one round trip instead of two.
+     */
     const target = await this.prisma.user.findUnique({
       where: { id: input.userIdToImpersonate },
       select: {
@@ -171,6 +185,10 @@ export class ImpersonationService {
         email: true,
         image: true,
         deactivatedAt: true,
+        orgMemberships: {
+          where: { organization: { mfaRequired: true } },
+          select: { organization: { select: { slug: true } } },
+        },
       },
     });
 
@@ -186,6 +204,9 @@ export class ImpersonationService {
     await this.assertOperatorCanProveSecondFactor({
       operatorUserId: input.impersonatorUserId,
       targetUserId: target.id,
+      requiringOrganizationSlugs: target.orgMemberships.map(
+        (membership) => membership.organization.slug,
+      ),
     });
 
     await this.auditLog({

--- a/platform/app/src/server/app-layer/identity/repositories/__tests__/mfa-enrollment.prisma.repository.unit.test.ts
+++ b/platform/app/src/server/app-layer/identity/repositories/__tests__/mfa-enrollment.prisma.repository.unit.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from "vitest";
+import type { PrismaClient } from "~/generated/prisma/client";
+import { guardOrganizationId } from "~/utils/dbOrganizationIdProtection";
+import { PrismaMfaEnrollmentRepository } from "../mfa-enrollment.prisma.repository";
+
+/**
+ * `findRequiringOrganizationSlugs` asks which of ONE person's organizations
+ * require a second factor. That question spans every organization they belong
+ * to, so it has no single-organization predicate to offer and
+ * `guardOrganizationId` (ADR-021) refuses to serve it as a top-level
+ * `organizationUser.findMany` — the refusal being a thrown `Error`, which the
+ * boundary degrades to a generic 500 rather than to a skipped check.
+ *
+ * The identical query shape in the Backoffice impersonation service did exactly
+ * that in production. This read is reachable from `disableMfa`, behind
+ * `MFA_ENROLLMENT_OPEN`, so it would have waited for the flag to do the same.
+ *
+ * The stub below therefore runs the REAL guard rather than answering: the
+ * repository is expected to read the memberships nested off the person, which
+ * never reaches that delegate at all, and a regression to the top-level query
+ * fails here with the production error.
+ */
+
+function makeGuardedPrisma(person: unknown) {
+  return {
+    user: { findUnique: vi.fn().mockResolvedValue(person) },
+    organizationUser: {
+      findMany: vi.fn(async (args: unknown) =>
+        guardOrganizationId(
+          { model: "OrganizationUser", action: "findMany", args },
+          async () => [],
+        ),
+      ),
+    },
+  };
+}
+
+describe("PrismaMfaEnrollmentRepository", () => {
+  describe("given the organization-tenancy guard is in force", () => {
+    describe("when asked which of a person's organizations require a second factor", () => {
+      it("answers with the slugs and issues no top-level OrganizationUser query", async () => {
+        const prisma = makeGuardedPrisma({
+          orgMemberships: [
+            { organization: { slug: "acme" } },
+            { organization: { slug: "globex" } },
+          ],
+        });
+        const repository = new PrismaMfaEnrollmentRepository(
+          prisma as unknown as PrismaClient,
+        );
+
+        const slugs = await repository.findRequiringOrganizationSlugs({
+          userId: "user_1",
+        });
+
+        expect(slugs).toEqual(["acme", "globex"]);
+        expect(prisma.organizationUser.findMany).not.toHaveBeenCalled();
+      });
+
+      it("answers empty for somebody the row lookup does not find", async () => {
+        const prisma = makeGuardedPrisma(null);
+        const repository = new PrismaMfaEnrollmentRepository(
+          prisma as unknown as PrismaClient,
+        );
+
+        const slugs = await repository.findRequiringOrganizationSlugs({
+          userId: "user_missing",
+        });
+
+        // Nobody's memberships is not the same as an error, and a person who
+        // belongs to nothing requires nothing.
+        expect(slugs).toEqual([]);
+        expect(prisma.organizationUser.findMany).not.toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/platform/app/src/server/app-layer/identity/repositories/mfa-enrollment.prisma.repository.ts
+++ b/platform/app/src/server/app-layer/identity/repositories/mfa-enrollment.prisma.repository.ts
@@ -32,16 +32,31 @@ export class PrismaMfaEnrollmentRepository implements MfaEnrollmentRepository {
    * The organizations this person belongs to that require a second factor.
    * Read here rather than trusted from the command, so a caller working from
    * a stale membership list cannot turn the factor off and keep the access.
+   *
+   * Read as a NESTED select off the person, not as a top-level
+   * `organizationUser.findMany`. The question spans every organization one
+   * person belongs to, so it has no single-organization predicate to offer and
+   * `guardOrganizationId` (ADR-021) refuses it — a refusal that surfaces as a
+   * 500, not as a skipped check. The guard sees top-level model operations
+   * only (`$allOperations` in `src/server/db.ts`), so going through the person
+   * asks the same question in a shape the guard is right not to inspect.
    */
   async findRequiringOrganizationSlugs({
     userId,
   }: {
     userId: string;
   }): Promise<readonly string[]> {
-    const memberships = await this.prisma.organizationUser.findMany({
-      where: { userId, organization: { mfaRequired: true } },
-      select: { organization: { select: { slug: true } } },
+    const person = await this.prisma.user.findUnique({
+      where: { id: userId },
+      select: {
+        orgMemberships: {
+          where: { organization: { mfaRequired: true } },
+          select: { organization: { select: { slug: true } } },
+        },
+      },
     });
-    return memberships.map((membership) => membership.organization.slug);
+    return (person?.orgMemberships ?? []).map(
+      (membership) => membership.organization.slug,
+    );
   }
 }

--- a/specs/identity/mfa-and-session-shape.feature
+++ b/specs/identity/mfa-and-session-shape.feature
@@ -448,6 +448,19 @@ Feature: Two-step verification - one setup per person, and organizations that re
     And the operator is told to set one up on their own account first
     But an operator who has set one up may impersonate "sam"
 
+  # Asking which of somebody's organizations require a factor is a question
+  # about one person across many organizations. Asked the wrong way it is a
+  # question the tenancy rules refuse to answer at all, and a refusal to
+  # answer is not the same as an answer of "no": it took every impersonation
+  # down as an unexplained failure, including the ones no organization had
+  # any requirement for.
+  @unit
+  Scenario: Looking up the requirement decides the request rather than failing it
+    Given "sam" belongs to organizations that the operator must be checked against
+    When the operator tries to impersonate "sam"
+    Then the request is decided on the operator's own second factor
+    And it never fails as an unexplained error
+
   @integration @unimplemented
   Scenario: The one revoke at deploy is the impersonating sessions
     Given sessions exist carrying the legacy impersonation payload


### PR DESCRIPTION
## Why

Every Backoffice impersonation has answered 500 since #7528 landed. The operator sees "Couldn't impersonate the user / We've been notified" and a trace id, with no named cause.

The D06 pre-flight added in that PR asks which of the target's organizations require a second factor, and asked it as a top-level query:

```ts
organizationUser.findMany({
  where: { userId: targetUserId, organization: { mfaRequired: true } },
})
```

That question spans every organization one person belongs to, so it carries no single-organization predicate and `guardOrganizationId` (ADR-021) refuses it. The refusal is a plain `Error`, so it degrades to a generic "unknown" at the boundary, which is why the failure reached a customer-facing surface with nothing useful in it.

Two things make it worse than a broken policy check:

- **It failed for every target**, not only members of organizations that require a factor. The guard rejects the query before any result is inspected, so the early return was unreachable.
- **The check could only ever have been a no-op.** Nothing in the codebase writes `Organization.mfaRequired`; the column landed `DEFAULT false` in `20260825020005_mfa_and_passkeys` with no setter, no mutation, no admin surface. Its sole observable effect in production was taking impersonation down.

Diagnosed from trace `19568efc2c884d5f297455494a3bf185`: five attempts in a 64-second window, all identical, and across seven days of production logs no other endpoint trips this guard.

## What changed

The memberships are now read as a nested `select` off the target row, folded into the `user.findUnique` that `start` was already doing. The guard runs on top-level model operations (`$allOperations` in `src/server/db.ts`), so a nested read asks the same question in a shape the guard is right not to inspect. `src/server/better-auth/hooks.ts` already relies on exactly this, and has done in production since before D06.

The check itself is unchanged: an operator borrowing access into an organization that requires a second factor still needs one on their own account. Only the way the question is asked has moved.

Two smaller things ride along:

- **The same query shape sat in `PrismaMfaEnrollmentRepository`**, reachable from `disableMfa` behind `MFA_ENROLLMENT_OPEN`. Fixed there too, before the flag flipped and found it.
- **The pre-flight now costs one round trip instead of two**, since the memberships arrive with the target.

## How it works

The guard admits a query on an org-scoped model when it carries an `organizationId`, a row id, a composite key embedding one, or a model-specific bound. `OrganizationUser` is configured `{}`, so it grants none of the last three, and "one person's memberships across all their organizations" has no `organizationId` to offer by construction. There is no way to write that query top-level and have it admitted, short of widening the guard.

Widening it was the alternative, via `platformScopeActions: ["findMany"]`. That is the widest hatch in the file, it is meant for tables carrying no customer data, and `OrganizationUser` is squarely customer data. Reading through the person costs nothing and gives up nothing.

## Test plan

- [x] `pnpm test:unit run ee/admin/__tests__/impersonation.service.unit.test.ts` - 9 pass
- [x] `pnpm test:unit run src/server/app-layer/identity/repositories/__tests__/mfa-enrollment.prisma.repository.unit.test.ts` - 2 pass
- [x] `pnpm test:unit run src/utils/__tests__/dbOrganizationIdProtection.unit.test.ts` - 40 pass, guard behaviour unchanged
- [x] Scoped typecheck extending `tsconfig.tsgo.tests.json` over all four touched files, including the tests - clean
- [x] Biome clean on all four files
- [x] `pnpm check:feature-parity` - `specs/identity/mfa-and-session-shape.feature` 27/27 bound

**The regression test, and whether it fails without the fix: yes, with the production error.**

Both suites stubbed `organizationUser.findMany` to resolve `[]`, which is precisely why this shipped green. That stub now runs the real `guardOrganizationId` instead of answering, so the tests refuse a query the database would refuse.

Reverting each fix and re-running gives 5 failures in the impersonation suite and 2 in the repository suite, every one of them carrying the literal string from the production log:

```
The findMany action on the OrganizationUser model requires an 'organizationId',
row id, or model-specific tenancy key in the where clause
```

The code path executes and throws; this is not a test asserting that a generated string looks different.

## Anything surprising?

**A third instance of the same shape is still out there, deliberately not fixed here.** `src/server/app-layer/identity/repositories/join-request.prisma.repository.ts:140` writes `where: { userId: { in: userIds }, disabledAt: null }`, which the guard refuses for the same reason. It is D12, it ships dark behind `JOIN_REQUESTS`, and its fix is not the same mechanical move (it starts from many user ids, so it needs a `user.findMany`, not a nested read off one row). Separate deliverable, separate change.

**The D06 impersonation rule arrived ahead of the deliverable it belongs to.** D06 is Wave 3 in `dev/docs/identity-platform/delivery-plan.md` and ships behind `MFA_ENROLLMENT_OPEN`, which defaults off. This one check landed inside the Wave 2 PR without that flag, bolted onto the legacy `Session.impersonating` path that D06 explicitly says it deletes, and ADR-121 still lists the rule as an open question belonging "with D06's impersonation rewrite". Reverting it was the other reasonable option and arguably the tidier one. Fixing the query is the call here because the rule should be in force the day somebody sets `mfaRequired`, and the fix is smaller than the revert.

**`feat/strict-feature-layout-v0` will silently drop this.** That branch moves `ee/admin/impersonation.service.ts` to `packages/features/ops/server/src/services/`, and it forked before #7528. A rebase takes the deletion and loses both this fix and `assertOperatorCanProveSecondFactor` with no conflict to warn anybody. Worth carrying across deliberately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved impersonation across organizations when the target belongs to multiple organizations with MFA requirements.
  * Requests now correctly use the operator’s verified second factor instead of failing with an unexplained error.
  * Impersonation no longer performs unnecessary organization membership lookups.

* **Tests**
  * Added coverage for cross-organization MFA checks and missing-user scenarios.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->