### PR TITLE
fix(auth): an org with no SSO provider stops flagging a banner nobody can clear

### DIFF
--- a/platform/app/prisma/migrations/20260826120000_clear_unclearable_pending_sso_setup/migration.sql
+++ b/platform/app/prisma/migrations/20260826120000_clear_unclearable_pending_sso_setup/migration.sql
@@ -1,0 +1,34 @@
+-- Releases the people held behind an SSO banner that nothing could dismiss.
+--
+-- `beforeAccountCreate` read an organization holding a `ssoDomain` with a null
+-- `ssoProvider` as a provider MISMATCH and set `pendingSsoSetup = true`.
+-- Nothing could then unset it: `isSsoProviderMatch` returns false for every
+-- account when `ssoProvider` is null, and the only writer of
+-- `pendingSsoSetup = false` sits behind that same match. The flag went up on
+-- one sign-in and no later sign-in took it down, whatever provider the person
+-- used, leaving "Action Required: Link your SSO account" with no action that
+-- cleared it.
+--
+-- The hook now returns before that write, so no new rows reach this state.
+-- This clears the ones already stranded.
+--
+-- Scoped to organizations that still name no provider. Where one IS
+-- configured the flag is a live SSO migration doing its job -- the next
+-- sign-in through the configured provider clears it -- so those rows are left
+-- exactly as they are. Rows whose email domain matches no organization at all
+-- are also left alone: the hook never wrote them, so they are an operator's
+-- own doing (the self-hosting SSO runbook flags users by domain) and not ours
+-- to undo.
+--
+-- Idempotent: every row it selects it sets to false, so a second run matches
+-- nothing. The domain join mirrors the hook's own `extractEmailDomain`, which
+-- lowercases the domain before the lookup.
+UPDATE "User"
+SET "pendingSsoSetup" = false
+WHERE "pendingSsoSetup" = true
+  AND EXISTS (
+    SELECT 1
+    FROM "Organization"
+    WHERE "Organization"."ssoDomain" = lower(split_part("User"."email", '@', 2))
+      AND "Organization"."ssoProvider" IS NULL
+  );

--- a/platform/app/prisma/migrations/20260826120000_clear_unclearable_pending_sso_setup/migration.sql
+++ b/platform/app/prisma/migrations/20260826120000_clear_unclearable_pending_sso_setup/migration.sql
@@ -23,6 +23,20 @@
 -- Idempotent: every row it selects it sets to false, so a second run matches
 -- nothing. The domain join mirrors the hook's own `extractEmailDomain`, which
 -- lowercases the domain before the lookup.
+--
+-- IRREVERSIBLE: the prior value of every row it touches is the constant `true`
+-- and is not recorded anywhere, so after this runs those rows are
+-- indistinguishable from users who were never flagged. A down step could only
+-- guess at the set, and re-flagging the wrong people would put the same
+-- undismissable banner back in front of them. Reapplying the flag is a
+-- deliberate operator action, not an automatic rollback.
+--
+-- Null and empty string both mean "no provider configured": the hook's guard
+-- is a falsy check (`!org.ssoProvider`), so an organization storing `''` lands
+-- in the identical unclearable state and has to be cleared with the same
+-- sweep. A whitespace-only value is deliberately NOT matched -- it is truthy
+-- in the hook, so those organizations are treated as having named a provider
+-- and their flags are still live.
 UPDATE "User"
 SET "pendingSsoSetup" = false
 WHERE "pendingSsoSetup" = true
@@ -30,5 +44,6 @@ WHERE "pendingSsoSetup" = true
     SELECT 1
     FROM "Organization"
     WHERE "Organization"."ssoDomain" = lower(split_part("User"."email", '@', 2))
-      AND "Organization"."ssoProvider" IS NULL
+      AND ("Organization"."ssoProvider" IS NULL
+        OR "Organization"."ssoProvider" = '')
   );

--- a/platform/app/src/server/better-auth/__tests__/hooks.test.ts
+++ b/platform/app/src/server/better-auth/__tests__/hooks.test.ts
@@ -598,6 +598,87 @@ describe("beforeAccountCreate", () => {
     });
   });
 
+  describe("when the org has a ssoDomain but no ssoProvider", () => {
+    /** @scenario Org with ssoDomain but no ssoProvider never flags a user */
+    it("leaves pendingSsoSetup alone rather than setting a flag nothing can clear", async () => {
+      // Four production orgs reached this state: staff set `ssoDomain` and left
+      // `ssoProvider` null. Every account then failed `isSsoProviderMatch` (it
+      // returns false on a null ssoProvider), so the soft-block fired and the
+      // only path that clears the flag — reachable solely behind that same
+      // match — could never run again. The banner became permanent.
+      const update = vi.fn().mockResolvedValue(undefined);
+      const prisma = makePrismaMock({
+        user: {
+          findUnique: vi.fn().mockResolvedValue({
+            id: "user_1",
+            email: "existing@acme.com",
+            deactivatedAt: null,
+          }),
+          update,
+        },
+        organization: {
+          findUnique: vi.fn().mockResolvedValue({
+            id: "org_1",
+            ssoDomain: "acme.com",
+            ssoProvider: null,
+          }),
+        },
+        account: {
+          deleteMany: vi.fn(),
+          count: vi.fn().mockResolvedValue(1),
+        },
+      });
+
+      await beforeAccountCreate({
+        prisma,
+        account: { userId: "user_1", providerId: "google", accountId: "sub-1" },
+      });
+
+      expect(update).not.toHaveBeenCalled();
+    });
+
+    /** @scenario Org with ssoDomain but no ssoProvider never flags a user */
+    it("does not hard-block a first-time signup either", async () => {
+      // The hard block was already guarded on `org.ssoProvider`, so a brand new
+      // user got in. Pinned so the new early return cannot turn a signup that
+      // used to succeed into an SSO_PROVIDER_NOT_ALLOWED rejection.
+      const update = vi.fn().mockResolvedValue(undefined);
+      const prisma = makePrismaMock({
+        user: {
+          findUnique: vi.fn().mockResolvedValue({
+            id: "user_1",
+            email: "brand-new@acme.com",
+            deactivatedAt: null,
+          }),
+          update,
+        },
+        organization: {
+          findUnique: vi.fn().mockResolvedValue({
+            id: "org_1",
+            ssoDomain: "acme.com",
+            ssoProvider: null,
+          }),
+        },
+        account: {
+          deleteMany: vi.fn(),
+          count: vi.fn().mockResolvedValue(0),
+        },
+      });
+
+      await expect(
+        beforeAccountCreate({
+          prisma,
+          account: {
+            userId: "user_1",
+            providerId: "google",
+            accountId: "sub-1",
+          },
+        }),
+      ).resolves.toBeUndefined();
+      expect(update).not.toHaveBeenCalled();
+    });
+  });
+
   describe("when the platform SSO gate DENIES (unlicensed deployment)", () => {
     /** @scenario Existing users on an unlicensed deployment self-recover via password reset */
     it("does not set pendingSsoSetup for a credential account at a matching ssoDomain", async () => {

--- a/platform/app/src/server/better-auth/hooks.ts
+++ b/platform/app/src/server/better-auth/hooks.ts
@@ -405,6 +405,17 @@ export const beforeAccountCreate = async ({
   });
   if (!org) return;
 
+  // An org with a `ssoDomain` but no `ssoProvider` has not named a provider to
+  // be wrong about, so there is nothing here to soft-block. Falling through
+  // would be a one-way door: `isSsoProviderMatch` returns false for every
+  // account when `ssoProvider` is null, and the only writer of
+  // `pendingSsoSetup: false` — `reconcileSsoAccounts` — is reachable solely
+  // behind that same match, from here and from `afterAccountUpdate`. So the
+  // flag below would be set on the next sign-in and could never be cleared by
+  // any subsequent one: a permanent "Link your SSO account" banner with no
+  // action that dismisses it.
+  if (!org.ssoProvider) return;
+
   const matchesSso = isSsoProviderMatch(org, {
     providerId: account.providerId,
     accountId: account.accountId,

--- a/specs/auth/phase-1-better-auth-config.feature
+++ b/specs/auth/phase-1-better-auth-config.feature
@@ -147,6 +147,19 @@ Feature: BetterAuth config (unmounted)
     Then signin succeeds
     And pendingSsoSetup is set to true
 
+  # An org can hold a `ssoDomain` with no `ssoProvider` — staff set the domain
+  # and never named the provider. There is then no provider to be wrong about,
+  # and flagging would be a one-way door: the flag is only ever cleared behind
+  # a provider match that a null `ssoProvider` can never satisfy, so the banner
+  # would stand forever with nothing the person could do to dismiss it.
+  @unit
+  Scenario: Org with ssoDomain but no ssoProvider never flags a user
+    Given an organization with ssoDomain "acme.com" and no ssoProvider exists
+    And a user exists with email "existing@acme.com" and pendingSsoSetup=false
+    When that user signs in via Google
+    Then signin succeeds
+    And pendingSsoSetup remains false
+
   # ============================================================================
   # Admin impersonation via the legacy Session.impersonating JSON column
   #


### PR DESCRIPTION
Four production organizations hold a `ssoDomain` with no `ssoProvider` — staff
set the domain and never named the provider. Every user at those domains has
been showing "Action Required: Link your SSO account" with nothing they can do
to dismiss it.

`beforeAccountCreate` treats a null `ssoProvider` as a provider mismatch. The
hard block below it is already guarded on `org.ssoProvider`, so the signup
succeeds and execution falls through to the soft block, which writes
`pendingSsoSetup: true`. That write is a one-way door. `isSsoProviderMatch`
returns false on its first line when `ssoProvider` is null, and the only writer
of `pendingSsoSetup: false` — `reconcileSsoAccounts` — is reachable solely
behind that same match, from this hook and from `afterAccountUpdate`. So the
flag goes up on the next sign-in and no subsequent sign-in can ever take it
down, whatever provider the person uses.

An org that has not named a provider has no wrong provider to soft-block
against, so the hook now returns before the flag is written. Orgs that do name
one are untouched: the match, the hard block for first-time signups, and the
soft block all behave exactly as before.

Nothing in the hard-block path changes. It was already conditional on
`org.ssoProvider` being truthy, so a brand new user at one of these domains got
in before this change and still gets in after it — pinned by a test, because an
early return placed one line higher would have turned those signups into
`SSO_PROVIDER_NOT_ALLOWED` rejections.

## Releasing the users already stranded

The guard only stops new rows reaching that state, so a migration clears the
ones already in it — otherwise this ships and those people keep the banner
forever.

It is scoped to organizations that still name no provider. Where one **is**
configured the flag is a live SSO migration doing its job, and the next sign-in
through the configured provider clears it, so those rows are left alone. Rows
whose email domain matches no organization at all are left alone too: the hook
never wrote them, so they came from an operator following the self-hosting SSO
runbook and are not ours to undo.

"No provider configured" means null **or** empty string, matching the hook's own
falsy guard (`!org.ssoProvider`) — an org storing `''` lands in the identical
unclearable state. A whitespace-only value is deliberately excluded: `' '` is
truthy in the hook, so those orgs count as having named a provider and their
flags are live rather than stranded.

Idempotent by construction — every row it selects it sets to false, so a repeat
run matches nothing. Verified against Postgres with fixtures covering a null
provider, an empty provider, an uppercase email domain, a whitespace provider, a
configured provider, an orphan domain, an already-false row and a null email:
three cleared, five untouched, `UPDATE 0` on the second run.

Marked `IRREVERSIBLE:` with its reason, following the convention the repo's other
seventeen data migrations use — the prior value is the constant `true` and is
recorded nowhere, so no down step could tell these rows from users who were
never flagged.

## Not in scope

Users at orgs that *do* name a provider can still be flagged by signing in
through a second connection in the same IdP tenant, and clear it by signing in
through the configured one. That behaviour is unchanged here and is worth a
separate look, along with the `deleteMany` in `reconcileSsoAccounts` that
silently unlinks the other account when the flag clears.

Spec: `specs/auth/phase-1-better-auth-config.feature` — "Org with ssoDomain but
no ssoProvider never flags a user", bound `@unit` in
`server/better-auth/__tests__/hooks.test.ts`. The migration is a one-off
correction of the rows this bug produced rather than ongoing behaviour, so it
carries no scenario of its own.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Users can sign in with Google when an organization has an SSO domain but no configured SSO provider.
  * Accounts are no longer incorrectly flagged for pending SSO setup.
  * Existing users continue signing in without unwanted account changes.
  * Previously affected accounts have inaccurate pending SSO setup flags cleared.
  * Accounts connected to configured SSO providers remain unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->