### PR TITLE
refactor(governance): let a pulled source carry its own conversation shape

### DIFF
--- a/platform/app/ee/governance/services/pullers/__tests__/genieTraceMapper.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/genieTraceMapper.unit.test.ts
@@ -22,6 +22,8 @@ import {
   GENIE_AGENT_MODEL,
   GENIE_MESSAGE_SPAN_NAME,
   GENIE_QUERY_SPAN_NAME,
+  GENIE_ROUTING_PROFILE,
+  KNOWN_AGENT_IDENTITIES,
   mapGenieEventsToTraceRequest,
 } from "../genieTraceMapper";
 import type { NormalizedPullEvent } from "../pullerAdapter";
@@ -30,6 +32,7 @@ const ORIGIN = {
   ingestionSourceId: "source-1",
   organizationId: "org-1",
   sourceType: "databricks_genie",
+  profile: GENIE_ROUTING_PROFILE,
 };
 
 function genieEvent(
@@ -410,6 +413,26 @@ describe("given the pricing table (Decision 14(d) pin)", () => {
     const cost = computeSpanCost({
       attrs: {},
       model: GENIE_AGENT_MODEL,
+      promptTokens: 100_000,
+      completionTokens: 100_000,
+    });
+    expect(cost).toBe(0);
+  });
+
+  /**
+   * The pin has to cover every agent a routing profile may name, not just
+   * Genie's. The agent label became a per-source value when the mapper
+   * started serving more than one source, and a name that matched a price
+   * row would put real dollars on conversations nobody was charged for.
+   * Adding an agent to the set without checking that is what this catches.
+   */
+  /** @scenario "A source cannot name a real model as its agent" */
+  it.each([
+    ...KNOWN_AGENT_IDENTITIES,
+  ])("%s resolves to no price either", (agent) => {
+    const cost = computeSpanCost({
+      attrs: {},
+      model: agent,
       promptTokens: 100_000,
       completionTokens: 100_000,
     });

--- a/platform/app/ee/governance/services/pullers/__tests__/genieTraceMapper.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/genieTraceMapper.unit.test.ts
@@ -127,7 +127,10 @@ function attrsOf(span: { attributes?: { key: string; value: unknown }[] }) {
 }
 
 function spansOf(events: NormalizedPullEvent[]) {
-  const request = mapGenieEventsToTraceRequest(events, ORIGIN);
+  const request = mapGenieEventsToTraceRequest({
+    events: events,
+    origin: ORIGIN,
+  });
   return request?.resourceSpans?.[0]?.scopeSpans?.[0]?.spans ?? [];
 }
 
@@ -328,7 +331,9 @@ describe("given events that are not conversations", () => {
       ...genieEvent(completedMessage()),
       action: "usage_bucket",
     };
-    expect(mapGenieEventsToTraceRequest([aggregate], ORIGIN)).toBeNull();
+    expect(
+      mapGenieEventsToTraceRequest({ events: [aggregate], origin: ORIGIN }),
+    ).toBeNull();
   });
 });
 
@@ -338,14 +343,19 @@ describe("given a message a sweep caught mid-answer", () => {
       const inFlight = genieEvent(
         completedMessage({ status: "ASKING_AI", attachments: [] }),
       );
-      expect(mapGenieEventsToTraceRequest([inFlight], ORIGIN)).toBeNull();
+      expect(
+        mapGenieEventsToTraceRequest({ events: [inFlight], origin: ORIGIN }),
+      ).toBeNull();
     });
   });
 
   describe("when the re-read finds the status settled", () => {
     it("routes the message", () => {
       const settled = genieEvent(completedMessage());
-      const request = mapGenieEventsToTraceRequest([settled], ORIGIN);
+      const request = mapGenieEventsToTraceRequest({
+        events: [settled],
+        origin: ORIGIN,
+      });
       expect(request).not.toBeNull();
     });
   });
@@ -355,7 +365,9 @@ describe("given a message a sweep caught mid-answer", () => {
       const unknown = genieEvent(
         completedMessage({ status: "SOMETHING_NEW", attachments: [] }),
       );
-      expect(mapGenieEventsToTraceRequest([unknown], ORIGIN)).toBeNull();
+      expect(
+        mapGenieEventsToTraceRequest({ events: [unknown], origin: ORIGIN }),
+      ).toBeNull();
     });
   });
 
@@ -364,7 +376,10 @@ describe("given a message a sweep caught mid-answer", () => {
       const statusless = genieEvent(
         completedMessage({ status: undefined, attachments: [] }),
       );
-      const request = mapGenieEventsToTraceRequest([statusless], ORIGIN);
+      const request = mapGenieEventsToTraceRequest({
+        events: [statusless],
+        origin: ORIGIN,
+      });
       expect(request).not.toBeNull();
     });
   });
@@ -378,7 +393,10 @@ describe("given two ingestion sources routing into one destination project", () 
   const message = completedMessage();
 
   function rootOf(origin: typeof ORIGIN) {
-    const request = mapGenieEventsToTraceRequest([genieEvent(message)], origin);
+    const request = mapGenieEventsToTraceRequest({
+      events: [genieEvent(message)],
+      origin: origin,
+    });
     const spans = request?.resourceSpans?.[0]?.scopeSpans?.[0]?.spans ?? [];
     return spans.find((s) => s.name === GENIE_MESSAGE_SPAN_NAME)!;
   }

--- a/platform/app/ee/governance/services/pullers/__tests__/genieTraceMapperRoutingProfile.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/genieTraceMapperRoutingProfile.unit.test.ts
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+
+/**
+ * The mapper serves more than one source, so the four things that used to be
+ * Databricks constants now travel with the source: which events count as
+ * conversations, the agent that answered, the provenance tag, and the scope
+ * name. Genie keeps its own values by holding the profile that carries them,
+ * so nothing about what it produces changes.
+ *
+ * The load-bearing one is the agent name. Decision 14(d) relies on it never
+ * resolving in the pricing table, which held for free while it was a constant
+ * no caller could reach. A profile that accepted any string would hand that
+ * property away — a source naming a real model would put a price on a
+ * conversation nobody was charged for — so profiles may only name an agent
+ * from a closed set.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  type ConversationRoutingProfile,
+  GENIE_ROUTING_PROFILE,
+  KNOWN_AGENT_IDENTITIES,
+  mapGenieEventsToTraceRequest,
+} from "../genieTraceMapper";
+import type { NormalizedPullEvent } from "../pullerAdapter";
+
+const ORIGIN = {
+  ingestionSourceId: "source-1",
+  organizationId: "org-1",
+  sourceType: "databricks_genie",
+  profile: GENIE_ROUTING_PROFILE,
+};
+
+/** A second source's profile, shaped the way a real one would be. */
+const OTHER_PROFILE: ConversationRoutingProfile = {
+  conversationAction: "copilot_conversation",
+  agentModel: "microsoft/copilot-studio",
+  provenanceSource: "copilot_studio",
+  scopeName: "langwatch.ingestion.copilot_studio",
+};
+
+function conversationEvent(action: string): NormalizedPullEvent {
+  return {
+    source_event_id: "msg-1",
+    event_timestamp: "2026-08-20T10:00:00.000Z",
+    actor: "analyst@acme.example",
+    action,
+    target: "Sales space",
+    cost_usd: "0",
+    tokens_input: 0,
+    tokens_output: 0,
+    raw_payload: JSON.stringify({
+      message_id: "msg-1",
+      conversation_id: "conv-1",
+      content: "Which region sold most?",
+      status: "COMPLETED",
+      created_timestamp: 1755684000,
+      attachments: [{ text: { content: "EMEA.", purpose: "ANSWER" } }],
+    }),
+    extra: { conversationId: "conv-1", messageId: "msg-1" },
+  };
+}
+
+function attributesOf(request: unknown) {
+  const span = (request as any).resourceSpans[0].scopeSpans[0].spans[0];
+  return (span.attributes as Array<{ key: string; value: any }>).reduce<
+    Record<string, string | undefined>
+  >((acc, attr) => {
+    acc[attr.key] = attr.value?.stringValue;
+    return acc;
+  }, {});
+}
+
+describe("given a source mapping its own conversations", () => {
+  it("routes the events its own profile recognises", () => {
+    const request = mapGenieEventsToTraceRequest(
+      [conversationEvent("copilot_conversation")],
+      { ...ORIGIN, sourceType: "copilot_studio", profile: OTHER_PROFILE },
+    );
+
+    expect(request).not.toBeNull();
+    expect((request as any).resourceSpans[0].scopeSpans[0].scope.name).toBe(
+      "langwatch.ingestion.copilot_studio",
+    );
+  });
+
+  /** @scenario "A second kind of source routes its own conversations" */
+  it("names its own agent and provenance rather than inheriting Genie's", () => {
+    const request = mapGenieEventsToTraceRequest(
+      [conversationEvent("copilot_conversation")],
+      { ...ORIGIN, sourceType: "copilot_studio", profile: OTHER_PROFILE },
+    );
+
+    const attrs = attributesOf(request);
+    expect(attrs["gen_ai.request.model"]).toBe("microsoft/copilot-studio");
+    expect(attrs["langwatch.source"]).toBe("copilot_studio");
+  });
+
+  it("leaves another source's events alone", () => {
+    const request = mapGenieEventsToTraceRequest(
+      [conversationEvent("genie_query")],
+      {
+        ...ORIGIN,
+        sourceType: "copilot_studio",
+        profile: OTHER_PROFILE,
+      },
+    );
+
+    expect(request).toBeNull();
+  });
+});
+
+describe("given Genie's own profile", () => {
+  it("produces exactly what it produced before profiles existed", () => {
+    const request = mapGenieEventsToTraceRequest(
+      [conversationEvent("genie_query")],
+      ORIGIN,
+    );
+
+    const scopeSpan = (request as any).resourceSpans[0].scopeSpans[0];
+    expect(scopeSpan.scope.name).toBe("langwatch.ingestion.databricks_genie");
+
+    const attrs = attributesOf(request);
+    expect(attrs["gen_ai.request.model"]).toBe("databricks/genie");
+    expect(attrs["langwatch.source"]).toBe("databricks_genie");
+  });
+
+  it("still carries the author through for the identity stack to resolve", () => {
+    const event = conversationEvent("genie_query");
+    const request = mapGenieEventsToTraceRequest(
+      [{ ...event, extra: { ...event.extra, actorUserId: "entra-object-id" } }],
+      ORIGIN,
+    );
+
+    expect(attributesOf(request)["langwatch.user.id"]).toBe("entra-object-id");
+  });
+});
+
+describe("given the set of agents a profile may name", () => {
+  /**
+   * That none of these resolves to a price is pinned against the real
+   * pricing table in genieTraceMapper.unit.test.ts, which is the assertion
+   * that matters. This one only fixes the membership, so that adding an
+   * agent is a deliberate edit here rather than a quiet one elsewhere.
+   */
+  it("is exactly the agents we have decided on", () => {
+    expect([...KNOWN_AGENT_IDENTITIES]).toEqual([
+      "databricks/genie",
+      "microsoft/copilot-studio",
+    ]);
+  });
+});

--- a/platform/app/ee/governance/services/pullers/__tests__/genieTraceMapperRoutingProfile.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/genieTraceMapperRoutingProfile.unit.test.ts
@@ -73,96 +73,114 @@ function attributesOf(request: unknown) {
 }
 
 describe("given a source mapping its own conversations", () => {
-  it("routes the events its own profile recognises", () => {
-    const request = mapGenieEventsToTraceRequest(
-      [conversationEvent("copilot_conversation")],
-      { ...ORIGIN, sourceType: "copilot_studio", profile: OTHER_PROFILE },
-    );
+  describe("when the batch carries the events its own profile recognises", () => {
+    it("routes the events its own profile recognises", () => {
+      const request = mapGenieEventsToTraceRequest(
+        [conversationEvent("copilot_conversation")],
+        { ...ORIGIN, sourceType: "copilot_studio", profile: OTHER_PROFILE },
+      );
 
-    expect(request).not.toBeNull();
-    expect((request as any).resourceSpans[0].scopeSpans[0].scope.name).toBe(
-      "langwatch.ingestion.copilot_studio",
-    );
+      expect(request).not.toBeNull();
+      expect((request as any).resourceSpans[0].scopeSpans[0].scope.name).toBe(
+        "langwatch.ingestion.copilot_studio",
+      );
+    });
+
+    it("emits spans a second source's batch can actually be ingested from", () => {
+      const request = mapGenieEventsToTraceRequest(
+        [conversationEvent("copilot_conversation")],
+        { ...ORIGIN, sourceType: "copilot_studio", profile: OTHER_PROFILE },
+      );
+
+      // The same gate Genie's own mapping is held to. Without it the assertions
+      // below could pass on a span the trace pipeline would reject on arrival.
+      const spans = (request as any).resourceSpans[0].scopeSpans[0].spans;
+      expect(spans.length).toBeGreaterThan(0);
+      for (const span of spans) {
+        expect(spanSchema.safeParse(span).success).toBe(true);
+      }
+    });
+
+    /** @scenario "The conversation shape travels with the source, not with Genie" */
+    it("names its own agent and provenance rather than inheriting Genie's", () => {
+      const request = mapGenieEventsToTraceRequest(
+        [conversationEvent("copilot_conversation")],
+        { ...ORIGIN, sourceType: "copilot_studio", profile: OTHER_PROFILE },
+      );
+
+      const attrs = attributesOf(request);
+      expect(attrs["gen_ai.request.model"]).toBe("microsoft/copilot-studio");
+      expect(attrs["langwatch.source"]).toBe("copilot_studio");
+    });
   });
 
-  it("emits spans a second source's batch can actually be ingested from", () => {
-    const request = mapGenieEventsToTraceRequest(
-      [conversationEvent("copilot_conversation")],
-      { ...ORIGIN, sourceType: "copilot_studio", profile: OTHER_PROFILE },
-    );
+  describe("when the batch carries a Genie question instead", () => {
+    /** @scenario "The conversation shape travels with the source, not with Genie" */
+    it("leaves another source's events alone", () => {
+      const request = mapGenieEventsToTraceRequest(
+        [conversationEvent("genie_query")],
+        {
+          ...ORIGIN,
+          sourceType: "copilot_studio",
+          profile: OTHER_PROFILE,
+        },
+      );
 
-    // The same gate Genie's own mapping is held to. Without it the assertions
-    // below could pass on a span the trace pipeline would reject on arrival.
-    const spans = (request as any).resourceSpans[0].scopeSpans[0].spans;
-    expect(spans.length).toBeGreaterThan(0);
-    for (const span of spans) {
-      expect(spanSchema.safeParse(span).success).toBe(true);
-    }
-  });
-
-  /** @scenario "A second kind of source routes its own conversations" */
-  it("names its own agent and provenance rather than inheriting Genie's", () => {
-    const request = mapGenieEventsToTraceRequest(
-      [conversationEvent("copilot_conversation")],
-      { ...ORIGIN, sourceType: "copilot_studio", profile: OTHER_PROFILE },
-    );
-
-    const attrs = attributesOf(request);
-    expect(attrs["gen_ai.request.model"]).toBe("microsoft/copilot-studio");
-    expect(attrs["langwatch.source"]).toBe("copilot_studio");
-  });
-
-  it("leaves another source's events alone", () => {
-    const request = mapGenieEventsToTraceRequest(
-      [conversationEvent("genie_query")],
-      {
-        ...ORIGIN,
-        sourceType: "copilot_studio",
-        profile: OTHER_PROFILE,
-      },
-    );
-
-    expect(request).toBeNull();
+      expect(request).toBeNull();
+    });
   });
 });
 
 describe("given Genie's own profile", () => {
-  it("produces exactly what it produced before profiles existed", () => {
-    const request = mapGenieEventsToTraceRequest(
-      [conversationEvent("genie_query")],
-      ORIGIN,
-    );
+  describe("when a question is mapped", () => {
+    it("produces exactly what it produced before profiles existed", () => {
+      const request = mapGenieEventsToTraceRequest(
+        [conversationEvent("genie_query")],
+        ORIGIN,
+      );
 
-    const scopeSpan = (request as any).resourceSpans[0].scopeSpans[0];
-    expect(scopeSpan.scope.name).toBe("langwatch.ingestion.databricks_genie");
+      const scopeSpan = (request as any).resourceSpans[0].scopeSpans[0];
+      expect(scopeSpan.scope.name).toBe("langwatch.ingestion.databricks_genie");
 
-    const attrs = attributesOf(request);
-    expect(attrs["gen_ai.request.model"]).toBe("databricks/genie");
-    expect(attrs["langwatch.source"]).toBe("databricks_genie");
+      const attrs = attributesOf(request);
+      expect(attrs["gen_ai.request.model"]).toBe("databricks/genie");
+      expect(attrs["langwatch.source"]).toBe("databricks_genie");
+    });
   });
 
-  it("still carries the author through for the identity stack to resolve", () => {
-    const event = conversationEvent("genie_query");
-    const request = mapGenieEventsToTraceRequest(
-      [{ ...event, extra: { ...event.extra, actorUserId: "entra-object-id" } }],
-      ORIGIN,
-    );
+  describe("when the event names the author's directory id", () => {
+    it("still carries the author through for the identity stack to resolve", () => {
+      const event = conversationEvent("genie_query");
+      const request = mapGenieEventsToTraceRequest(
+        [
+          {
+            ...event,
+            extra: { ...event.extra, actorUserId: "entra-object-id" },
+          },
+        ],
+        ORIGIN,
+      );
 
-    expect(attributesOf(request)["langwatch.user.id"]).toBe("entra-object-id");
+      expect(attributesOf(request)["langwatch.user.id"]).toBe(
+        "entra-object-id",
+      );
+    });
   });
 });
 
 describe("given the set of agents a profile may name", () => {
-  /**
-   * That none of these resolves to a price is pinned against the real
-   * pricing table in genieTraceMapper.unit.test.ts, which is the assertion
-   * that matters. This one only fixes the membership, so that adding an
-   * agent is a deliberate edit here rather than a quiet one elsewhere.
-   */
-  it("is exactly the agents we have decided on", () => {
-    expect([...KNOWN_AGENT_IDENTITIES]).toEqual([
-      "databricks/genie",
-      "microsoft/copilot-studio",
-    ]);
+  describe("when the set is read back", () => {
+    /**
+     * That none of these resolves to a price is pinned against the real
+     * pricing table in genieTraceMapper.unit.test.ts, which is the assertion
+     * that matters. This one only fixes the membership, so that adding an
+     * agent is a deliberate edit here rather than a quiet one elsewhere.
+     */
+    it("is exactly the agents we have decided on", () => {
+      expect([...KNOWN_AGENT_IDENTITIES]).toEqual([
+        "databricks/genie",
+        "microsoft/copilot-studio",
+      ]);
+    });
   });
 });

--- a/platform/app/ee/governance/services/pullers/__tests__/genieTraceMapperRoutingProfile.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/genieTraceMapperRoutingProfile.unit.test.ts
@@ -75,10 +75,14 @@ function attributesOf(request: unknown) {
 describe("given a source mapping its own conversations", () => {
   describe("when the batch carries the events its own profile recognises", () => {
     it("routes the events its own profile recognises", () => {
-      const request = mapGenieEventsToTraceRequest(
-        [conversationEvent("copilot_conversation")],
-        { ...ORIGIN, sourceType: "copilot_studio", profile: OTHER_PROFILE },
-      );
+      const request = mapGenieEventsToTraceRequest({
+        events: [conversationEvent("copilot_conversation")],
+        origin: {
+          ...ORIGIN,
+          sourceType: "copilot_studio",
+          profile: OTHER_PROFILE,
+        },
+      });
 
       expect(request).not.toBeNull();
       expect((request as any).resourceSpans[0].scopeSpans[0].scope.name).toBe(
@@ -87,10 +91,14 @@ describe("given a source mapping its own conversations", () => {
     });
 
     it("emits spans a second source's batch can actually be ingested from", () => {
-      const request = mapGenieEventsToTraceRequest(
-        [conversationEvent("copilot_conversation")],
-        { ...ORIGIN, sourceType: "copilot_studio", profile: OTHER_PROFILE },
-      );
+      const request = mapGenieEventsToTraceRequest({
+        events: [conversationEvent("copilot_conversation")],
+        origin: {
+          ...ORIGIN,
+          sourceType: "copilot_studio",
+          profile: OTHER_PROFILE,
+        },
+      });
 
       // The same gate Genie's own mapping is held to. Without it the assertions
       // below could pass on a span the trace pipeline would reject on arrival.
@@ -103,10 +111,14 @@ describe("given a source mapping its own conversations", () => {
 
     /** @scenario "The conversation shape travels with the source, not with Genie" */
     it("names its own agent and provenance rather than inheriting Genie's", () => {
-      const request = mapGenieEventsToTraceRequest(
-        [conversationEvent("copilot_conversation")],
-        { ...ORIGIN, sourceType: "copilot_studio", profile: OTHER_PROFILE },
-      );
+      const request = mapGenieEventsToTraceRequest({
+        events: [conversationEvent("copilot_conversation")],
+        origin: {
+          ...ORIGIN,
+          sourceType: "copilot_studio",
+          profile: OTHER_PROFILE,
+        },
+      });
 
       const attrs = attributesOf(request);
       expect(attrs["gen_ai.request.model"]).toBe("microsoft/copilot-studio");
@@ -117,14 +129,14 @@ describe("given a source mapping its own conversations", () => {
   describe("when the batch carries a Genie question instead", () => {
     /** @scenario "The conversation shape travels with the source, not with Genie" */
     it("leaves another source's events alone", () => {
-      const request = mapGenieEventsToTraceRequest(
-        [conversationEvent("genie_query")],
-        {
+      const request = mapGenieEventsToTraceRequest({
+        events: [conversationEvent("genie_query")],
+        origin: {
           ...ORIGIN,
           sourceType: "copilot_studio",
           profile: OTHER_PROFILE,
         },
-      );
+      });
 
       expect(request).toBeNull();
     });
@@ -134,10 +146,10 @@ describe("given a source mapping its own conversations", () => {
 describe("given Genie's own profile", () => {
   describe("when a question is mapped", () => {
     it("produces exactly what it produced before profiles existed", () => {
-      const request = mapGenieEventsToTraceRequest(
-        [conversationEvent("genie_query")],
-        ORIGIN,
-      );
+      const request = mapGenieEventsToTraceRequest({
+        events: [conversationEvent("genie_query")],
+        origin: ORIGIN,
+      });
 
       const scopeSpan = (request as any).resourceSpans[0].scopeSpans[0];
       expect(scopeSpan.scope.name).toBe("langwatch.ingestion.databricks_genie");
@@ -151,15 +163,15 @@ describe("given Genie's own profile", () => {
   describe("when the event names the author's directory id", () => {
     it("still carries the author through for the identity stack to resolve", () => {
       const event = conversationEvent("genie_query");
-      const request = mapGenieEventsToTraceRequest(
-        [
+      const request = mapGenieEventsToTraceRequest({
+        events: [
           {
             ...event,
             extra: { ...event.extra, actorUserId: "entra-object-id" },
           },
         ],
-        ORIGIN,
-      );
+        origin: ORIGIN,
+      });
 
       expect(attributesOf(request)["langwatch.user.id"]).toBe(
         "entra-object-id",

--- a/platform/app/ee/governance/services/pullers/__tests__/genieTraceMapperRoutingProfile.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/genieTraceMapperRoutingProfile.unit.test.ts
@@ -16,6 +16,7 @@
  */
 
 import { describe, expect, it } from "vitest";
+import { spanSchema } from "~/server/event-sourcing/pipelines/trace-processing/schemas/otlp";
 import {
   type ConversationRoutingProfile,
   GENIE_ROUTING_PROFILE,
@@ -82,6 +83,21 @@ describe("given a source mapping its own conversations", () => {
     expect((request as any).resourceSpans[0].scopeSpans[0].scope.name).toBe(
       "langwatch.ingestion.copilot_studio",
     );
+  });
+
+  it("emits spans a second source's batch can actually be ingested from", () => {
+    const request = mapGenieEventsToTraceRequest(
+      [conversationEvent("copilot_conversation")],
+      { ...ORIGIN, sourceType: "copilot_studio", profile: OTHER_PROFILE },
+    );
+
+    // The same gate Genie's own mapping is held to. Without it the assertions
+    // below could pass on a span the trace pipeline would reject on arrival.
+    const spans = (request as any).resourceSpans[0].scopeSpans[0].spans;
+    expect(spans.length).toBeGreaterThan(0);
+    for (const span of spans) {
+      expect(spanSchema.safeParse(span).success).toBe(true);
+    }
   });
 
   /** @scenario "A second kind of source routes its own conversations" */

--- a/platform/app/ee/governance/services/pullers/__tests__/pullerWorkerConversationRouting.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/pullerWorkerConversationRouting.unit.test.ts
@@ -187,6 +187,35 @@ describe("given a source type the worker has no conversation shape for", () => {
     });
     expect(handleOtlpTraceRequest).not.toHaveBeenCalled();
   });
+
+  /**
+   * `sourceType` is a free-form column read back from the database, so the
+   * lookup must not answer names every object inherits. Held as an object
+   * literal it did: "constructor" resolved to a truthy function, whose
+   * `conversationAction` is undefined, which an event carrying no action of
+   * its own then matched — routing a span nobody's source ever emitted.
+   */
+  it.each([
+    "constructor",
+    "toString",
+    "__proto__",
+    "valueOf",
+    "hasOwnProperty",
+  ])("routes nothing for the inherited name %s", async (sourceType) => {
+    await routeConversationsToTraceDestination({
+      events: [{ ...genieEvent(), action: undefined as unknown as string }],
+      source: { ...SOURCE, sourceType },
+    });
+    expect(handleOtlpTraceRequest).not.toHaveBeenCalled();
+  });
+
+  it("routes nothing for an event that carries no action at all", async () => {
+    await routeConversationsToTraceDestination({
+      events: [{ ...genieEvent(), action: undefined as unknown as string }],
+      source: SOURCE,
+    });
+    expect(handleOtlpTraceRequest).not.toHaveBeenCalled();
+  });
 });
 
 describe("given a source without a destination", () => {

--- a/platform/app/ee/governance/services/pullers/__tests__/pullerWorkerConversationRouting.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/pullerWorkerConversationRouting.unit.test.ts
@@ -36,7 +36,7 @@ vi.mock("~/server/featureFlag", () => ({
 }));
 
 // The worker module pulls in the whole app graph; import after the mocks.
-const { routeConversationsToTraceDestination, CONVERSATION_ROUTING_PROFILES } =
+const { routeConversationsToTraceDestination, conversationRoutingProfileFor } =
   await import("../pullerWorker");
 
 /** Names every object answers to, which no source is ever stored as. */
@@ -222,7 +222,7 @@ describe("given a source type the worker has no conversation shape for", () => {
     it.each(
       INHERITED_NAMES,
     )("finds no profile at all for the inherited name %s", (sourceType) => {
-      expect(CONVERSATION_ROUTING_PROFILES.get(sourceType)).toBeUndefined();
+      expect(conversationRoutingProfileFor(sourceType)).toBeUndefined();
     });
 
     it.each(

--- a/platform/app/ee/governance/services/pullers/__tests__/pullerWorkerConversationRouting.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/pullerWorkerConversationRouting.unit.test.ts
@@ -36,9 +36,17 @@ vi.mock("~/server/featureFlag", () => ({
 }));
 
 // The worker module pulls in the whole app graph; import after the mocks.
-const { routeConversationsToTraceDestination } = await import(
-  "../pullerWorker"
-);
+const { routeConversationsToTraceDestination, CONVERSATION_ROUTING_PROFILES } =
+  await import("../pullerWorker");
+
+/** Names every object answers to, which no source is ever stored as. */
+const INHERITED_NAMES = [
+  "constructor",
+  "toString",
+  "__proto__",
+  "valueOf",
+  "hasOwnProperty",
+];
 
 const SOURCE = {
   id: "source-1",
@@ -204,17 +212,24 @@ describe("given a source type the worker has no conversation shape for", () => {
    * literal it did: "constructor" resolved to a truthy function, whose
    * `conversationAction` is undefined, which an event carrying no action of
    * its own then matched — routing a span nobody's source ever emitted.
+   *
+   * Routing nothing is what a missing action does too, so the behaviour on its
+   * own cannot tell the two apart: the event here carries a real action, and
+   * the lookup is read directly, so an object literal fails the first case
+   * rather than passing for the wrong reason.
    */
   describe("when the stored source type is a name every object inherits", () => {
-    it.each([
-      "constructor",
-      "toString",
-      "__proto__",
-      "valueOf",
-      "hasOwnProperty",
-    ])("routes nothing for the inherited name %s", async (sourceType) => {
+    it.each(
+      INHERITED_NAMES,
+    )("finds no profile at all for the inherited name %s", (sourceType) => {
+      expect(CONVERSATION_ROUTING_PROFILES.get(sourceType)).toBeUndefined();
+    });
+
+    it.each(
+      INHERITED_NAMES,
+    )("routes nothing for the inherited name %s, even carrying a real conversation", async (sourceType) => {
       await routeConversationsToTraceDestination({
-        events: [{ ...genieEvent(), action: undefined as unknown as string }],
+        events: [genieEvent()],
         source: { ...SOURCE, sourceType },
       });
       expect(handleOtlpTraceRequest).not.toHaveBeenCalled();

--- a/platform/app/ee/governance/services/pullers/__tests__/pullerWorkerConversationRouting.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/pullerWorkerConversationRouting.unit.test.ts
@@ -123,6 +123,70 @@ describe("given a source with a live trace destination", () => {
     expect(handleOtlpTraceRequest).not.toHaveBeenCalled();
     expect(projectFindFirst).not.toHaveBeenCalled();
   });
+
+  /** @scenario "A run routes only the events belonging to its own source" */
+  it("routes only its own source's events when the batch also carries another kind", async () => {
+    await routeConversationsToTraceDestination({
+      events: [
+        genieEvent(),
+        { ...genieEvent(), source_event_id: "rep-1", action: "cost_report" },
+      ],
+      source: SOURCE,
+    });
+
+    const [, request] = handleOtlpTraceRequest.mock.calls[0]!;
+    expect(request.resourceSpans[0].scopeSpans[0].spans).toHaveLength(1);
+  });
+});
+
+/**
+ * A destination is an ordinary stored column and nothing on the write path
+ * checks the source type against it (`ingestionSource.service.ts` asserts the
+ * project is this org's and live, and that a pull URL is allowed — never that
+ * this kind of source routes conversations at all). So the run cannot treat
+ * the composer's picker as the only way a destination arrives, and decides
+ * for itself which sources have conversations to route.
+ *
+ * Without this, an Anthropic Admin source that acquired a destination by any
+ * route would have its billing rows rendered as messages someone said, in a
+ * customer's project, permanently — `mapMessage` builds a span with no guard
+ * and `frameOf` labels it "unknown_conversation".
+ */
+describe("given a counts-pulling source that has a destination anyway", () => {
+  beforeEach(() => {
+    projectFindFirst.mockResolvedValue({ id: "proj-dest" });
+  });
+
+  /** @scenario "A counts-pulling source with a destination still routes nothing" */
+  it.each([
+    "cost_report",
+    "usage_report",
+  ])("routes no %s row, because a total is not a conversation", async (action) => {
+    await routeConversationsToTraceDestination({
+      events: [{ ...genieEvent(), action }],
+      source: { ...SOURCE, sourceType: "anthropic_admin" },
+    });
+    expect(handleOtlpTraceRequest).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * A source type nobody has taught the worker to route is the same case as a
+ * counts-pulling one: it has no conversations the worker can recognise, so a
+ * destination on it routes nothing rather than guessing.
+ */
+describe("given a source type the worker has no conversation shape for", () => {
+  beforeEach(() => {
+    projectFindFirst.mockResolvedValue({ id: "proj-dest" });
+  });
+
+  it("routes nothing, even for an event that would suit another source", async () => {
+    await routeConversationsToTraceDestination({
+      events: [genieEvent()],
+      source: { ...SOURCE, sourceType: "s3_custom" },
+    });
+    expect(handleOtlpTraceRequest).not.toHaveBeenCalled();
+  });
 });
 
 describe("given a source without a destination", () => {

--- a/platform/app/ee/governance/services/pullers/__tests__/pullerWorkerConversationRouting.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/pullerWorkerConversationRouting.unit.test.ts
@@ -85,57 +85,63 @@ describe("given a source with a live trace destination", () => {
     projectFindFirst.mockResolvedValue({ id: "proj-dest" });
   });
 
-  it("routes through the trace door with the destination as tenant and the ROUTE DEFAULT redaction level", async () => {
-    await routeConversationsToTraceDestination({
-      events: [genieEvent()],
-      source: SOURCE,
+  describe("when a run hands over the source's own conversations", () => {
+    it("routes through the trace door with the destination as tenant and the ROUTE DEFAULT redaction level", async () => {
+      await routeConversationsToTraceDestination({
+        events: [genieEvent()],
+        source: SOURCE,
+      });
+
+      expect(handleOtlpTraceRequest).toHaveBeenCalledTimes(1);
+      const [tenantId, request, level] = handleOtlpTraceRequest.mock.calls[0]!;
+      expect(tenantId).toBe("proj-dest");
+      expect(level).toBe(DEFAULT_PII_REDACTION_LEVEL);
+      expect(
+        request.resourceSpans?.[0]?.scopeSpans?.[0]?.spans?.length,
+      ).toBeGreaterThan(0);
     });
 
-    expect(handleOtlpTraceRequest).toHaveBeenCalledTimes(1);
-    const [tenantId, request, level] = handleOtlpTraceRequest.mock.calls[0]!;
-    expect(tenantId).toBe("proj-dest");
-    expect(level).toBe(DEFAULT_PII_REDACTION_LEVEL);
-    expect(
-      request.resourceSpans?.[0]?.scopeSpans?.[0]?.spans?.length,
-    ).toBeGreaterThan(0);
+    it("re-checks the destination against the source's own org, ignoring archived projects", async () => {
+      await routeConversationsToTraceDestination({
+        events: [genieEvent()],
+        source: SOURCE,
+      });
+      expect(projectFindFirst).toHaveBeenCalledWith({
+        where: {
+          id: "proj-dest",
+          archivedAt: null,
+          team: { organizationId: "org-1" },
+        },
+        select: { id: true },
+      });
+    });
   });
 
-  it("re-checks the destination against the source's own org, ignoring archived projects", async () => {
-    await routeConversationsToTraceDestination({
-      events: [genieEvent()],
-      source: SOURCE,
-    });
-    expect(projectFindFirst).toHaveBeenCalledWith({
-      where: {
-        id: "proj-dest",
-        archivedAt: null,
-        team: { organizationId: "org-1" },
-      },
-      select: { id: true },
+  describe("when the batch carries no conversation-bearing events", () => {
+    it("routes nothing when the batch carries no conversation-bearing events", async () => {
+      await routeConversationsToTraceDestination({
+        events: [{ ...genieEvent(), action: "usage_bucket" }],
+        source: SOURCE,
+      });
+      expect(handleOtlpTraceRequest).not.toHaveBeenCalled();
+      expect(projectFindFirst).not.toHaveBeenCalled();
     });
   });
 
-  it("routes nothing when the batch carries no conversation-bearing events", async () => {
-    await routeConversationsToTraceDestination({
-      events: [{ ...genieEvent(), action: "usage_bucket" }],
-      source: SOURCE,
-    });
-    expect(handleOtlpTraceRequest).not.toHaveBeenCalled();
-    expect(projectFindFirst).not.toHaveBeenCalled();
-  });
+  describe("when the batch also carries another kind of source's events", () => {
+    /** @scenario "A run routes only the events belonging to its own source" */
+    it("routes only its own source's events when the batch also carries another kind", async () => {
+      await routeConversationsToTraceDestination({
+        events: [
+          genieEvent(),
+          { ...genieEvent(), source_event_id: "rep-1", action: "cost_report" },
+        ],
+        source: SOURCE,
+      });
 
-  /** @scenario "A run routes only the events belonging to its own source" */
-  it("routes only its own source's events when the batch also carries another kind", async () => {
-    await routeConversationsToTraceDestination({
-      events: [
-        genieEvent(),
-        { ...genieEvent(), source_event_id: "rep-1", action: "cost_report" },
-      ],
-      source: SOURCE,
+      const [, request] = handleOtlpTraceRequest.mock.calls[0]!;
+      expect(request.resourceSpans[0].scopeSpans[0].spans).toHaveLength(1);
     });
-
-    const [, request] = handleOtlpTraceRequest.mock.calls[0]!;
-    expect(request.resourceSpans[0].scopeSpans[0].spans).toHaveLength(1);
   });
 });
 
@@ -157,16 +163,18 @@ describe("given a counts-pulling source that has a destination anyway", () => {
     projectFindFirst.mockResolvedValue({ id: "proj-dest" });
   });
 
-  /** @scenario "A counts-pulling source with a destination still routes nothing" */
-  it.each([
-    "cost_report",
-    "usage_report",
-  ])("routes no %s row, because a total is not a conversation", async (action) => {
-    await routeConversationsToTraceDestination({
-      events: [{ ...genieEvent(), action }],
-      source: { ...SOURCE, sourceType: "anthropic_admin" },
+  describe("when a run pulls its usage and cost totals", () => {
+    /** @scenario "A counts-pulling source with a destination still routes nothing" */
+    it.each([
+      "cost_report",
+      "usage_report",
+    ])("routes no %s row, because a total is not a conversation", async (action) => {
+      await routeConversationsToTraceDestination({
+        events: [{ ...genieEvent(), action }],
+        source: { ...SOURCE, sourceType: "anthropic_admin" },
+      });
+      expect(handleOtlpTraceRequest).not.toHaveBeenCalled();
     });
-    expect(handleOtlpTraceRequest).not.toHaveBeenCalled();
   });
 });
 
@@ -180,12 +188,14 @@ describe("given a source type the worker has no conversation shape for", () => {
     projectFindFirst.mockResolvedValue({ id: "proj-dest" });
   });
 
-  it("routes nothing, even for an event that would suit another source", async () => {
-    await routeConversationsToTraceDestination({
-      events: [genieEvent()],
-      source: { ...SOURCE, sourceType: "s3_custom" },
+  describe("when the batch carries an event another source would recognise", () => {
+    it("routes nothing, even for an event that would suit another source", async () => {
+      await routeConversationsToTraceDestination({
+        events: [genieEvent()],
+        source: { ...SOURCE, sourceType: "s3_custom" },
+      });
+      expect(handleOtlpTraceRequest).not.toHaveBeenCalled();
     });
-    expect(handleOtlpTraceRequest).not.toHaveBeenCalled();
   });
 
   /**
@@ -195,47 +205,55 @@ describe("given a source type the worker has no conversation shape for", () => {
    * `conversationAction` is undefined, which an event carrying no action of
    * its own then matched — routing a span nobody's source ever emitted.
    */
-  it.each([
-    "constructor",
-    "toString",
-    "__proto__",
-    "valueOf",
-    "hasOwnProperty",
-  ])("routes nothing for the inherited name %s", async (sourceType) => {
-    await routeConversationsToTraceDestination({
-      events: [{ ...genieEvent(), action: undefined as unknown as string }],
-      source: { ...SOURCE, sourceType },
+  describe("when the stored source type is a name every object inherits", () => {
+    it.each([
+      "constructor",
+      "toString",
+      "__proto__",
+      "valueOf",
+      "hasOwnProperty",
+    ])("routes nothing for the inherited name %s", async (sourceType) => {
+      await routeConversationsToTraceDestination({
+        events: [{ ...genieEvent(), action: undefined as unknown as string }],
+        source: { ...SOURCE, sourceType },
+      });
+      expect(handleOtlpTraceRequest).not.toHaveBeenCalled();
     });
-    expect(handleOtlpTraceRequest).not.toHaveBeenCalled();
   });
 
-  it("routes nothing for an event that carries no action at all", async () => {
-    await routeConversationsToTraceDestination({
-      events: [{ ...genieEvent(), action: undefined as unknown as string }],
-      source: SOURCE,
+  describe("when the event carries no action at all", () => {
+    it("routes nothing for an event that carries no action at all", async () => {
+      await routeConversationsToTraceDestination({
+        events: [{ ...genieEvent(), action: undefined as unknown as string }],
+        source: SOURCE,
+      });
+      expect(handleOtlpTraceRequest).not.toHaveBeenCalled();
     });
-    expect(handleOtlpTraceRequest).not.toHaveBeenCalled();
   });
 });
 
 describe("given a source without a destination", () => {
-  it("never touches the trace door — routing is off by default", async () => {
-    await routeConversationsToTraceDestination({
-      events: [genieEvent()],
-      source: { ...SOURCE, traceProjectId: null },
+  describe("when a run hands over its conversations", () => {
+    it("never touches the trace door — routing is off by default", async () => {
+      await routeConversationsToTraceDestination({
+        events: [genieEvent()],
+        source: { ...SOURCE, traceProjectId: null },
+      });
+      expect(handleOtlpTraceRequest).not.toHaveBeenCalled();
     });
-    expect(handleOtlpTraceRequest).not.toHaveBeenCalled();
   });
 });
 
 describe("given a destination that is archived, deleted, or another org's", () => {
-  it("skips routing instead of failing the run or landing elsewhere", async () => {
-    projectFindFirst.mockResolvedValue(null);
-    await routeConversationsToTraceDestination({
-      events: [genieEvent()],
-      source: SOURCE,
+  describe("when a run hands over its conversations", () => {
+    it("skips routing instead of failing the run or landing elsewhere", async () => {
+      projectFindFirst.mockResolvedValue(null);
+      await routeConversationsToTraceDestination({
+        events: [genieEvent()],
+        source: SOURCE,
+      });
+      expect(handleOtlpTraceRequest).not.toHaveBeenCalled();
     });
-    expect(handleOtlpTraceRequest).not.toHaveBeenCalled();
   });
 });
 

--- a/platform/app/ee/governance/services/pullers/genieTraceMapper.ts
+++ b/platform/app/ee/governance/services/pullers/genieTraceMapper.ts
@@ -285,10 +285,13 @@ function extraString(
  * Without this line an Anthropic Admin source that acquired a destination
  * would have its billing rows rendered as messages someone said.
  */
-export function mapGenieEventsToTraceRequest(
-  events: NormalizedPullEvent[],
-  origin: GenieRoutingOrigin,
-): IExportTraceServiceRequest | null {
+export function mapGenieEventsToTraceRequest({
+  events,
+  origin,
+}: {
+  events: NormalizedPullEvent[];
+  origin: GenieRoutingOrigin;
+}): IExportTraceServiceRequest | null {
   // `action` is typed as a string but arrives from a puller's own mapping, so
   // an event that never set one reads as undefined at runtime. Requiring a
   // non-empty action on both sides keeps two absences from matching each

--- a/platform/app/ee/governance/services/pullers/genieTraceMapper.ts
+++ b/platform/app/ee/governance/services/pullers/genieTraceMapper.ts
@@ -59,6 +59,51 @@ export const GENIE_AGENT_MODEL = "databricks/genie" as const;
 export const GENIE_QUERY_ACTION = "genie_query" as const;
 
 /**
+ * Every agent a routing profile is allowed to name.
+ *
+ * Decision 14(d) rests on the agent identity never resolving in the pricing
+ * table, which held for free while it was one constant nobody outside this
+ * file could reach. Now that a profile carries it, a free-form string would
+ * hand that property away: a source naming `openai/gpt-4o` would put a real
+ * price on a conversation nobody was charged for. Keeping the set closed
+ * moves the question to review time — adding an agent here is the moment to
+ * check the name cannot match a price.
+ */
+export const KNOWN_AGENT_IDENTITIES = [
+  GENIE_AGENT_MODEL,
+  "microsoft/copilot-studio",
+] as const;
+
+export type KnownAgentIdentity = (typeof KNOWN_AGENT_IDENTITIES)[number];
+
+/**
+ * What one source contributes to the shape of a routed conversation.
+ *
+ * These four were Databricks constants while Genie was the only source that
+ * routed. They travel with the source now so a second source's conversations
+ * are not filed under a product the customer does not have — and, in the case
+ * of `conversationAction`, so that one source's events can never be rendered
+ * as another's.
+ */
+export interface ConversationRoutingProfile {
+  /** The puller action that marks an event as a conversation to route. */
+  conversationAction: string;
+  /** Product label for the agent that answered. Never a priced model. */
+  agentModel: KnownAgentIdentity;
+  /** Value of `langwatch.source` — where this conversation came from. */
+  provenanceSource: string;
+  /** OTLP scope name for the batch this source produces. */
+  scopeName: string;
+}
+
+export const GENIE_ROUTING_PROFILE: ConversationRoutingProfile = {
+  conversationAction: GENIE_QUERY_ACTION,
+  agentModel: GENIE_AGENT_MODEL,
+  provenanceSource: GENIE_PROVENANCE_SOURCE,
+  scopeName: "langwatch.ingestion.databricks_genie",
+};
+
+/**
  * The wire shape (verified against the 35-message capture,
  * 30_genie_messages.raw.jsonl) keys thoughts by `thought_type` with
  * enum-prefixed values ("THOUGHT_TYPE_UNDERSTANDING"); `type`/bare values
@@ -192,6 +237,8 @@ export interface GenieRoutingOrigin {
   ingestionSourceId: string;
   organizationId: string;
   sourceType: string;
+  /** What this source contributes to the conversations it routes. */
+  profile: ConversationRoutingProfile;
 }
 
 function originAttrs(origin: GenieRoutingOrigin) {
@@ -203,7 +250,7 @@ function originAttrs(origin: GenieRoutingOrigin) {
       origin.organizationId,
     ),
     stringAttr("langwatch.ingestion_source.source_type", origin.sourceType),
-    stringAttr(PROVENANCE_ATTR_SOURCE, GENIE_PROVENANCE_SOURCE),
+    stringAttr(PROVENANCE_ATTR_SOURCE, origin.profile.provenanceSource),
   ];
 }
 
@@ -228,15 +275,22 @@ function extraString(
 }
 
 /**
- * Map one run's Genie events to a single OTLP trace request. Returns null
- * when nothing routes (no conversation-bearing events in the batch).
+ * Map one run's conversation events to a single OTLP trace request. Returns
+ * null when nothing routes (no conversation-bearing events in the batch).
+ *
+ * The action filter is the last guard standing between a source's events and
+ * a customer's trace project: `routeConversationsToTraceDestination` runs for
+ * every source, the destination column is written without any check of the
+ * source type, and `mapMessage` below builds a span for whatever it is given.
+ * Without this line an Anthropic Admin source that acquired a destination
+ * would have its billing rows rendered as messages someone said.
  */
 export function mapGenieEventsToTraceRequest(
   events: NormalizedPullEvent[],
   origin: GenieRoutingOrigin,
 ): IExportTraceServiceRequest | null {
   const spans = events
-    .filter((event) => event.action === GENIE_QUERY_ACTION)
+    .filter((event) => event.action === origin.profile.conversationAction)
     .filter((event) => isSettledForRouting(event))
     .flatMap((event) => mapMessage(event, origin));
   if (spans.length === 0) return null;
@@ -246,7 +300,7 @@ export function mapGenieEventsToTraceRequest(
         resource: { attributes: [], droppedAttributesCount: 0 },
         scopeSpans: [
           {
-            scope: { name: "langwatch.ingestion.databricks_genie" },
+            scope: { name: origin.profile.scopeName },
             spans,
           },
         ],
@@ -413,7 +467,8 @@ function rootAttributesOf(
       JSON.stringify({ type: "chat_messages", value: [assistantMessage] }),
     ),
     // Agent identity, not a priced model (Decision 14(d) pins no price match).
-    stringAttr("gen_ai.request.model", GENIE_AGENT_MODEL),
+    // `KNOWN_AGENT_IDENTITIES` is what keeps that true now the value varies.
+    stringAttr("gen_ai.request.model", frame.origin.profile.agentModel),
     stringAttr("databricks.genie.message_id", frame.messageId),
     stringAttr("databricks.genie.conversation_id", frame.conversationId),
     ...originAttrs(frame.origin),

--- a/platform/app/ee/governance/services/pullers/genieTraceMapper.ts
+++ b/platform/app/ee/governance/services/pullers/genieTraceMapper.ts
@@ -289,8 +289,13 @@ export function mapGenieEventsToTraceRequest(
   events: NormalizedPullEvent[],
   origin: GenieRoutingOrigin,
 ): IExportTraceServiceRequest | null {
-  const spans = events
-    .filter((event) => event.action === origin.profile.conversationAction)
+  // `action` is typed as a string but arrives from a puller's own mapping, so
+  // an event that never set one reads as undefined at runtime. Requiring a
+  // non-empty action on both sides keeps two absences from matching each
+  // other and routing an event nothing ever claimed.
+  const wanted = origin.profile.conversationAction;
+  const spans = (wanted ? events : [])
+    .filter((event) => !!event.action && event.action === wanted)
     .filter((event) => isSettledForRouting(event))
     .flatMap((event) => mapMessage(event, origin));
   if (spans.length === 0) return null;

--- a/platform/app/ee/governance/services/pullers/genieTraceMapper.ts
+++ b/platform/app/ee/governance/services/pullers/genieTraceMapper.ts
@@ -55,7 +55,7 @@ export const GENIE_PROVENANCE_SOURCE = "databricks_genie" as const;
  */
 export const GENIE_AGENT_MODEL = "databricks/genie" as const;
 
-/** The puller action this mapper understands. Aggregate pulls never route. */
+/** The action Genie's own profile counts as a conversation. */
 export const GENIE_QUERY_ACTION = "genie_query" as const;
 
 /**
@@ -472,7 +472,9 @@ function rootAttributesOf(
       JSON.stringify({ type: "chat_messages", value: [assistantMessage] }),
     ),
     // Agent identity, not a priced model (Decision 14(d) pins no price match).
-    // `KNOWN_AGENT_IDENTITIES` is what keeps that true now the value varies.
+    // Now that the value varies, `KNOWN_AGENT_IDENTITIES` is what keeps it
+    // true — at compile time only. Every profile is a code literal the
+    // compiler checks, so nothing re-checks this at runtime.
     stringAttr("gen_ai.request.model", frame.origin.profile.agentModel),
     stringAttr("databricks.genie.message_id", frame.messageId),
     stringAttr("databricks.genie.conversation_id", frame.conversationId),

--- a/platform/app/ee/governance/services/pullers/pullerWorker.ts
+++ b/platform/app/ee/governance/services/pullers/pullerWorker.ts
@@ -350,7 +350,10 @@ async function writePulledEvents({
 // Keys are declared `SourceType` so a misspelled entry fails the build, but the
 // map is held as `ReadonlyMap<string, …>` because the lookup value is the raw
 // database column: narrowing the lookup would only force a cast at the call.
-const CONVERSATION_ROUTING_PROFILES: ReadonlyMap<
+// Exported for the test that pins the prototype-key hazard: routing nothing is
+// also what a missing action does, so only reading the lookup itself can tell
+// the two apart and fail if this ever stops being a Map.
+export const CONVERSATION_ROUTING_PROFILES: ReadonlyMap<
   string,
   ConversationRoutingProfile
 > = new Map<SourceType, ConversationRoutingProfile>([

--- a/platform/app/ee/governance/services/pullers/pullerWorker.ts
+++ b/platform/app/ee/governance/services/pullers/pullerWorker.ts
@@ -350,15 +350,29 @@ async function writePulledEvents({
 // Keys are declared `SourceType` so a misspelled entry fails the build, but the
 // map is held as `ReadonlyMap<string, …>` because the lookup value is the raw
 // database column: narrowing the lookup would only force a cast at the call.
-// Exported for the test that pins the prototype-key hazard: routing nothing is
-// also what a missing action does, so only reading the lookup itself can tell
-// the two apart and fail if this ever stops being a Map.
-export const CONVERSATION_ROUTING_PROFILES: ReadonlyMap<
+const CONVERSATION_ROUTING_PROFILES: ReadonlyMap<
   string,
   ConversationRoutingProfile
 > = new Map<SourceType, ConversationRoutingProfile>([
   ["databricks_genie", GENIE_ROUTING_PROFILE],
 ]);
+
+/**
+ * The registry's only reader outside this module.
+ *
+ * Routing nothing is also what a missing action does, so a test that only
+ * watches behaviour cannot tell the prototype-key guard from the action one —
+ * it needs to read the lookup. It reads it through here rather than through
+ * the map itself: `ReadonlyMap` is a compile-time promise, so exporting the
+ * map would hand every module a registry one cast away from accepting a
+ * source type nobody wrote a conversation shape for. Which is the thing this
+ * whole path exists to refuse.
+ */
+export function conversationRoutingProfileFor(
+  sourceType: string,
+): ConversationRoutingProfile | undefined {
+  return CONVERSATION_ROUTING_PROFILES.get(sourceType);
+}
 
 /**
  * ADR-088 v7 (Decisions 8–14): conversation-bearing pulled events additionally

--- a/platform/app/ee/governance/services/pullers/pullerWorker.ts
+++ b/platform/app/ee/governance/services/pullers/pullerWorker.ts
@@ -39,7 +39,11 @@ import {
   OCSF_SEVERITY,
 } from "../governanceOcsfEvents.clickhouse.repository";
 import { ensureHiddenGovernanceProject } from "../governanceProject.service";
-import { mapGenieEventsToTraceRequest } from "./genieTraceMapper";
+import {
+  type ConversationRoutingProfile,
+  GENIE_ROUTING_PROFILE,
+  mapGenieEventsToTraceRequest,
+} from "./genieTraceMapper";
 import {
   type NormalizedPullEvent,
   type PullResult,
@@ -358,6 +362,23 @@ async function writePulledEvents({
  * the run on those would stall the audit pull on the exact history the door
  * exists to let through.
  */
+/**
+ * The source types that carry conversations, and what each contributes to
+ * the ones it routes. A type absent from here routes nothing — which is the
+ * honest answer for a source that pulls totals rather than conversations.
+ *
+ * The composer keeps its own list (`routesConversations` in
+ * ingestionSourceCatalog.tsx) for deciding whether to offer the picker at
+ * all. The two are deliberately separate: that one shapes a form, this one
+ * decides what reaches a customer's project.
+ */
+const CONVERSATION_ROUTING_PROFILES: Record<
+  string,
+  ConversationRoutingProfile | undefined
+> = {
+  databricks_genie: GENIE_ROUTING_PROFILE,
+};
+
 export async function routeConversationsToTraceDestination({
   events,
   source,
@@ -367,10 +388,19 @@ export async function routeConversationsToTraceDestination({
 }): Promise<void> {
   if (!source.traceProjectId) return;
 
+  // A destination is an ordinary stored column: the write path checks the
+  // project is this org's and live, never that this kind of source carries
+  // conversations at all — only the composer declines to offer the picker.
+  // So the source type has to earn its way in here, and one we have no
+  // conversation shape for routes nothing rather than being guessed at.
+  const profile = CONVERSATION_ROUTING_PROFILES[source.sourceType];
+  if (!profile) return;
+
   const request = mapGenieEventsToTraceRequest(events, {
     ingestionSourceId: source.id,
     organizationId: source.organizationId,
     sourceType: source.sourceType,
+    profile,
   });
   if (!request) return;
 

--- a/platform/app/ee/governance/services/pullers/pullerWorker.ts
+++ b/platform/app/ee/governance/services/pullers/pullerWorker.ts
@@ -33,6 +33,7 @@ import {
   withScope,
 } from "~/utils/posthogErrorCapture";
 import { decryptCredentials } from "../activity-monitor/ingestionCredentials";
+import type { SourceType } from "../activity-monitor/ingestionSource.service";
 import {
   type GovernanceOcsfEventInput,
   OCSF_ACTIVITY,
@@ -330,10 +331,38 @@ async function writePulledEvents({
 }
 
 /**
+ * The source types that carry conversations, and what each contributes to
+ * the ones it routes. A type absent from here routes nothing — which is the
+ * honest answer for a source that pulls totals rather than conversations.
+ *
+ * The composer keeps its own list (`routesConversations` in
+ * ingestionSourceCatalog.tsx) for deciding whether to offer the picker at
+ * all. The two are deliberately separate: that one shapes a form, this one
+ * decides what reaches a customer's project.
+ */
+// A Map, not an object literal: `sourceType` is a free-form column read back
+// from the database, and indexing an object with it answers "constructor",
+// "toString" or "__proto__" with a truthy prototype member. That would pass
+// the guard below with a profile whose `conversationAction` is undefined —
+// which an event carrying no action then matches, routing a fabricated span
+// into a customer's project. A Map has no prototype keys to inherit.
+//
+// Keys are declared `SourceType` so a misspelled entry fails the build, but the
+// map is held as `ReadonlyMap<string, …>` because the lookup value is the raw
+// database column: narrowing the lookup would only force a cast at the call.
+const CONVERSATION_ROUTING_PROFILES: ReadonlyMap<
+  string,
+  ConversationRoutingProfile
+> = new Map<SourceType, ConversationRoutingProfile>([
+  ["databricks_genie", GENIE_ROUTING_PROFILE],
+]);
+
+/**
  * ADR-088 v7 (Decisions 8–14): conversation-bearing pulled events additionally
  * flow through the standard trace door into the source's chosen destination
- * project. Aggregate pulls never route — only `genie_query` events are
- * conversations.
+ * project. Aggregate pulls never route, and neither does a source with no
+ * entry in `CONVERSATION_ROUTING_PROFILES`; a source that has one routes the
+ * events its own profile names as conversations.
  *
  * Tenancy + redaction (Decision 13): the destination project id is the tenant,
  * and the redaction level passed is the same `DEFAULT_PII_REDACTION_LEVEL`
@@ -362,27 +391,6 @@ async function writePulledEvents({
  * the run on those would stall the audit pull on the exact history the door
  * exists to let through.
  */
-/**
- * The source types that carry conversations, and what each contributes to
- * the ones it routes. A type absent from here routes nothing — which is the
- * honest answer for a source that pulls totals rather than conversations.
- *
- * The composer keeps its own list (`routesConversations` in
- * ingestionSourceCatalog.tsx) for deciding whether to offer the picker at
- * all. The two are deliberately separate: that one shapes a form, this one
- * decides what reaches a customer's project.
- */
-// A Map, not an object literal: `sourceType` is a free-form column read back
-// from the database, and indexing an object with it answers "constructor",
-// "toString" or "__proto__" with a truthy prototype member. That would pass
-// the guard below with a profile whose `conversationAction` is undefined —
-// which an event carrying no action then matches, routing a fabricated span
-// into a customer's project. A Map has no prototype keys to inherit.
-const CONVERSATION_ROUTING_PROFILES = new Map<
-  string,
-  ConversationRoutingProfile
->([["databricks_genie", GENIE_ROUTING_PROFILE]]);
-
 export async function routeConversationsToTraceDestination({
   events,
   source,

--- a/platform/app/ee/governance/services/pullers/pullerWorker.ts
+++ b/platform/app/ee/governance/services/pullers/pullerWorker.ts
@@ -372,12 +372,16 @@ async function writePulledEvents({
  * all. The two are deliberately separate: that one shapes a form, this one
  * decides what reaches a customer's project.
  */
-const CONVERSATION_ROUTING_PROFILES: Record<
+// A Map, not an object literal: `sourceType` is a free-form column read back
+// from the database, and indexing an object with it answers "constructor",
+// "toString" or "__proto__" with a truthy prototype member. That would pass
+// the guard below with a profile whose `conversationAction` is undefined —
+// which an event carrying no action then matches, routing a fabricated span
+// into a customer's project. A Map has no prototype keys to inherit.
+const CONVERSATION_ROUTING_PROFILES = new Map<
   string,
-  ConversationRoutingProfile | undefined
-> = {
-  databricks_genie: GENIE_ROUTING_PROFILE,
-};
+  ConversationRoutingProfile
+>([["databricks_genie", GENIE_ROUTING_PROFILE]]);
 
 export async function routeConversationsToTraceDestination({
   events,
@@ -393,7 +397,7 @@ export async function routeConversationsToTraceDestination({
   // conversations at all — only the composer declines to offer the picker.
   // So the source type has to earn its way in here, and one we have no
   // conversation shape for routes nothing rather than being guessed at.
-  const profile = CONVERSATION_ROUTING_PROFILES[source.sourceType];
+  const profile = CONVERSATION_ROUTING_PROFILES.get(source.sourceType);
   if (!profile) return;
 
   const request = mapGenieEventsToTraceRequest(events, {

--- a/platform/app/ee/governance/services/pullers/pullerWorker.ts
+++ b/platform/app/ee/governance/services/pullers/pullerWorker.ts
@@ -411,11 +411,14 @@ export async function routeConversationsToTraceDestination({
   const profile = CONVERSATION_ROUTING_PROFILES.get(source.sourceType);
   if (!profile) return;
 
-  const request = mapGenieEventsToTraceRequest(events, {
-    ingestionSourceId: source.id,
-    organizationId: source.organizationId,
-    sourceType: source.sourceType,
-    profile,
+  const request = mapGenieEventsToTraceRequest({
+    events,
+    origin: {
+      ingestionSourceId: source.id,
+      organizationId: source.organizationId,
+      sourceType: source.sourceType,
+      profile,
+    },
   });
   if (!request) return;
 

--- a/specs/ai-gateway/governance/ingestion-sources.feature
+++ b/specs/ai-gateway/governance/ingestion-sources.feature
@@ -226,6 +226,65 @@ Feature: IngestionSource — admin configuration of cross-platform feeds
       And a destination outside it, reaching the API by any other route,
         is refused at write time with the destination named as the reason
 
+  Rule: A source routes only the events it recognises as its own conversations
+
+    The destination picker is offered only to sources that carry
+    conversations, but the destination itself is an ordinary stored
+    setting, and nothing at the moment it is written checks what kind of
+    source it was written on. So the run cannot treat the picker as the
+    only way a destination arrives. It decides for itself, per source,
+    which of that source's events are conversations, and routes nothing
+    else.
+
+    This is what keeps a source that pulls counts from turning billing
+    rows into readable conversations if a destination reaches it by some
+    other route. Such a source has no conversation events at all, so the
+    honest outcome is that nothing is routed — not that its totals are
+    rendered as though someone had said them.
+
+    Each source also names the agent that answered, and states which
+    source the conversation came from. Both travel with the conversation
+    rather than being assumed, because a second source reusing the first
+    one's labels would file its conversations under a product the
+    customer does not have.
+
+    The agent name is an identity, not a model anyone is billed for, and
+    a source may only name an agent from the set the platform knows. It
+    cannot supply the name of a real model, because a name that matched
+    a price would put a charge on a conversation nobody was charged for.
+
+    @unit
+    Scenario: A counts-pulling source with a destination still routes nothing
+      Given an "Anthropic Admin API (usage & cost)" source has a
+        destination project stored on it, which its own drawer never
+        offered and nothing on the way in refused
+      When a run pulls its usage and cost totals
+      Then nothing is routed to that project, because none of those
+        totals is a conversation
+
+    @unit
+    Scenario: A run routes only the events belonging to its own source
+      Given a "Databricks AI/BI Genie" source lands in "Analytics"
+      When a run hands over both its questions and events belonging to
+        another kind of source
+      Then only the Genie questions reach "Analytics"
+
+    @unit
+    Scenario: A second kind of source routes its own conversations
+      Given a source that recognises its own conversations, which are not
+        Genie questions, lands in "Support"
+      When a run pulls those conversations
+      Then they reach "Support"
+      And each one names that source as where it came from, and that
+        source's agent as what answered — neither of them Genie's
+
+    @unit
+    Scenario: A source cannot name a real model as its agent
+      When a source is set up to route conversations
+      Then the agent it names must be one the platform already knows
+      And a real model's name cannot be used as an agent name, so no
+        routed conversation can be given a price by naming one
+
   @unit
   Scenario: The configured-source list groups under the same two headings
     Given configured sources of push, pull, and s3 modes exist

--- a/specs/ai-gateway/governance/ingestion-sources.feature
+++ b/specs/ai-gateway/governance/ingestion-sources.feature
@@ -270,12 +270,17 @@ Feature: IngestionSource — admin configuration of cross-platform feeds
       Then only the Genie questions reach "Analytics"
 
     The shape a source routes by — which of its events are conversations,
-    the agent that answered, where they came from, and under what name the
-    conversation is recorded — is supplied per source rather than being
-    Genie's constants. Genie is the only source that supplies one today,
-    so no other source routes anything in production; what the scenario
-    below fixes is that the shape is the source's own and is never
-    inherited, which is what a second source will rely on when it arrives.
+    the agent that answered, where they came from, and the name of the batch
+    they arrive in — is supplied per source rather than being Genie's
+    constants. Genie is the only source that supplies one today, so no other
+    source routes anything in production; what the scenario below fixes is
+    that the shape is the source's own and is never inherited, which is what
+    a second source will rely on when it arrives.
+
+    Not everything is per-source yet: the individual conversation spans still
+    carry Genie's own names and labels whatever the source. That is invisible
+    while Genie is the only source routing, and it is what the second source
+    has to finish before its conversations can be told apart from Genie's.
 
     @unit
     Scenario: The conversation shape travels with the source, not with Genie

--- a/specs/ai-gateway/governance/ingestion-sources.feature
+++ b/specs/ai-gateway/governance/ingestion-sources.feature
@@ -269,14 +269,24 @@ Feature: IngestionSource — admin configuration of cross-platform feeds
         another kind of source
       Then only the Genie questions reach "Analytics"
 
+    The shape a source routes by — which of its events are conversations,
+    the agent that answered, where they came from, and under what name the
+    conversation is recorded — is supplied per source rather than being
+    Genie's constants. Genie is the only source that supplies one today,
+    so no other source routes anything in production; what the scenario
+    below fixes is that the shape is the source's own and is never
+    inherited, which is what a second source will rely on when it arrives.
+
     @unit
-    Scenario: A second kind of source routes its own conversations
-      Given a source that recognises its own conversations, which are not
-        Genie questions, lands in "Support"
-      When a run pulls those conversations
-      Then they reach "Support"
-      And each one names that source as where it came from, and that
-        source's agent as what answered — neither of them Genie's
+    Scenario: The conversation shape travels with the source, not with Genie
+      Given a second source that supplies its own conversation shape: which
+        of its events are conversations, the agent that answered, and where
+        they came from
+      When a batch is routed by that shape
+      Then each conversation names that source as where it came from, and
+        that source's agent as what answered — neither of them Genie's
+      And a Genie question handed to that shape is not one of its
+        conversations, so nothing is routed for it
 
     @unit
     Scenario: A source cannot name a real model as its agent


### PR DESCRIPTION
## For humans

Conversations pulled from an outside system can be sent into a LangWatch project so people can read them in the trace explorer. The code that turns those conversations into traces was written for one specific source and had that source's name baked into it in four places. A second source could not use it without either wearing the first source's labels or having a safety check removed.

This change lets each source bring its own four values. The existing source keeps exactly what it had, so nothing about it changes.

No new screens, no new settings, nothing for a user to do differently.

## Why the obvious version of this would have been damaging

The plan was to delete one line — a filter that only lets events named `genie_query` through. It reads like leftover coupling. It is not.

That routing function runs for **every** source that has a destination project, with no check of what kind of source it is. So that line is the last thing on the server standing between one source's events and a customer's project. The mapper below it builds a trace span out of whatever it is handed and labels an unrecognisable one `unknown_conversation`.

Delete the line, and a source that pulls billing totals — which emits `cost_report` and `usage_report` rows — has those rows rendered as messages a person supposedly said, inside a customer's project. Traces cannot be unwritten.

The only reason that is not possible today is a check in the **user interface**: the destination picker is only offered for one source type. The server never checks it. Filed separately as #7568.

So nothing was deleted. The four values are now supplied by the caller, with the existing source's values as its own profile:

| | Was | Now |
|---|---|---|
| Which events are conversations | `genie_query`, hardcoded | supplied per source |
| The agent that answered | one constant | supplied, from a closed set |
| Which source it came from | one constant | supplied per source |
| Batch scope name | one constant | supplied per source |

The worker resolves one profile per source type. A source type with no profile routes nothing, which closes the same gap from the other side without touching the write path.

## A bug found while reviewing this change

The profile registry was first written as a plain object, looked up by source type — a free-form text column read back from the database. Names that every object inherits answered that lookup. A source type of `constructor`, `toString`, `__proto__`, `valueOf` or `hasOwnProperty` each returned something truthy whose "which events are conversations" value was empty — and an event that carried no action of its own then matched it.

Measured through the real code path: **each of those five routed one invented span. All five now route none.**

Fixed two ways, kept both because they fail differently: the registry is a `Map`, which has no inherited names to answer with, and the match now requires a real action on both sides so two blanks cannot match each other. Not reachable through the API today — source type is validated against a fixed list on create — but the column is free text, and not trusting that write path is the entire reason this guard exists. A guard that fails open is worse than no guard, because it reads as protection.

Both cases are now tests.

## Money safety

The agent name is a closed set rather than free text. The whole reason routed conversations cost nothing is that the agent label matches no row in the pricing table. While it was a single constant nobody could reach, that held for free. Once a source supplies it, free text would let a source name a real model and put a real price on conversations nobody was charged for. The existing pricing check now runs over every name in the set.

## Verification

- `pnpm test:unit run ee/governance/services/pullers` — 14 files, 183 tests, all pass.
- `pnpm test:unit run ee/governance` — 443 tests pass, no assertion failures.
- `pnpm check:feature-parity` — clean, every scenario this change touches is bound.
- Typecheck — 349 errors tree-wide, identical to the baseline before this change, none in any file it touches.
- Biome — the CI gate (`biome-new-violations.sh` against the merge base) reports no new violations.

Pre-existing in this environment and unrelated: one workspace package is unbuilt, so some governance suites fail to load and most of those typecheck errors are unresolved imports. The baseline count is unchanged by this work.

## Scope

First of two. The second adds the source this was made for, and is deliberately separate because it introduces a place where a customer-supplied address receives a customer secret — the check that exists for the current source only recognises that source's addresses.

Deliberately not done here: the file and function keep their original names (a rename would bury the diff in live code), and two attribute names are still prefixed for the original source.

Refs #6980

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added source-specific conversation tracing for supported AI routing profiles.
  * Trace records now include the originating source and approved agent identity.
  * Unsupported, count-only, malformed, or unrelated events are excluded from tracing.
  * Existing Genie tracing behavior remains supported, including settled-message filtering and actor identity.

* **Tests**
  * Expanded coverage for routing profiles, event filtering, provenance, agent identity, and destination validation.
  * Added governance scenarios validating source-specific routing and agent naming rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
