### PR TITLE
fix(analytics): name the no-verdict evaluation bucket, and stop rendering "undefined" (#5080)

### DIFF
--- a/platform/app/src/components/analytics/CustomGraph.tsx
+++ b/platform/app/src/components/analytics/CustomGraph.tsx
@@ -62,7 +62,6 @@ import type { AppRouter } from "../../server/api/root";
 import { api } from "../../utils/api";
 import { buildMetadataFilterParams } from "../../utils/buildMetadataFilterParams";
 import type { RotatingColorSet } from "../../utils/rotatingColors";
-import { uppercaseFirstLetter } from "../../utils/stringCasing";
 import type { Unpacked } from "../../utils/types";
 import { Delayed } from "../Delayed";
 import { usePeriodSelector } from "../PeriodSelector";
@@ -70,6 +69,10 @@ import { ChartErrorState } from "./ChartErrorState";
 import { ChartTooltip } from "./ChartTooltip";
 import { formatChartDate } from "./formatChartDate";
 import { SummaryMetric } from "./SummaryMetric";
+import {
+  formatSeriesGroupName,
+  formatSingleSeriesName,
+} from "./seriesGroupName";
 
 type Series = Unpacked<z.infer<typeof timeseriesSeriesInput>["series"]> & {
   name: string;
@@ -527,24 +530,19 @@ const CustomGraph_ = React.memo(
       (aggKey: string) => {
         const { series, groupKey } = getSeries(seriesByKey, aggKey);
 
-        const group =
-          input.groupBy && groupKey ? getGroup(input.groupBy) : undefined;
-        const displayGroupKey = groupKey || "unknown";
-        const groupName =
-          groupKey !== undefined
-            ? `${
-                hideGroupLabel ? "" : group?.label.toLowerCase() + " "
-              }${displayGroupKey}`
-            : "";
+        const groupName = formatSeriesGroupName({
+          groupBy: input.groupBy,
+          groupKey,
+          groupLabel: input.groupBy
+            ? getGroup(input.groupBy)?.label
+            : undefined,
+          hideGroupLabel,
+        });
+
         return input.series.length > 1
           ? (series?.name ?? aggKey) + (groupName ? ` (${groupName})` : "")
           : groupName
-            ? uppercaseFirstLetter(groupName)
-                .replace("Evaluation passed passed", "Evaluation Passed")
-                .replace("Evaluation passed failed", "Evaluation Failed")
-                .replace("Contains error", "Traces")
-                .replace(/^Evaluation label /i, "")
-                .replace(/^Thumbs up\/down /i, "")
+            ? formatSingleSeriesName(groupName)
             : (series?.name ?? aggKey);
       },
       [seriesByKey, input.groupBy, input.series.length, hideGroupLabel],

--- a/platform/app/src/components/analytics/__tests__/seriesGroupName.unit.test.ts
+++ b/platform/app/src/components/analytics/__tests__/seriesGroupName.unit.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  formatSeriesGroupName,
+  formatSingleSeriesName,
+} from "../seriesGroupName";
+
+const groupName = (
+  overrides: Partial<Parameters<typeof formatSeriesGroupName>[0]> = {},
+) =>
+  formatSeriesGroupName({
+    groupBy: "evaluations.evaluation_passed",
+    groupKey: "passed",
+    groupLabel: "Evaluation Passed",
+    hideGroupLabel: false,
+    ...overrides,
+  });
+
+/** What the chart actually renders for a chart carrying one series. */
+const rendered = (
+  overrides: Partial<Parameters<typeof formatSeriesGroupName>[0]> = {},
+) => formatSingleSeriesName(groupName(overrides));
+
+describe("formatSeriesGroupName", () => {
+  describe("given the evaluation verdict group-by", () => {
+    it("names the no-verdict bucket for what it is, not 'unknown'", () => {
+      expect(rendered({ groupKey: "unknown" })).toBe("No verdict");
+    });
+
+    it("does not say the evaluation passed unknown", () => {
+      expect(rendered({ groupKey: "unknown" })).not.toContain("unknown");
+    });
+
+    it("keeps naming the two real verdicts", () => {
+      expect(rendered({ groupKey: "passed" })).toBe("Evaluation Passed");
+      expect(rendered({ groupKey: "failed" })).toBe("Evaluation Failed");
+    });
+
+    // The verdict is the whole label, so hiding the group label cannot leave
+    // a bare "unknown" behind.
+    it("names the bucket the same way when the group label is hidden", () => {
+      expect(groupName({ groupKey: "unknown", hideGroupLabel: true })).toBe(
+        "No verdict",
+      );
+    });
+
+    // The verdict column never emits an empty bucket, but if it ever did, the
+    // generic path would rebuild "evaluation passed unknown", which is the
+    // string this whole change exists to remove.
+    it("names an empty verdict bucket 'No verdict' too", () => {
+      expect(rendered({ groupKey: "" })).toBe("No verdict");
+    });
+
+    it("leaves a bucket it does not know alone", () => {
+      expect(groupName({ groupKey: "skipped" })).toBe(
+        "evaluation passed skipped",
+      );
+    });
+  });
+
+  describe("given a different group-by that happens to bucket on 'passed'", () => {
+    /**
+     * The verdict labels are keyed to the evaluation verdict group-by, not to
+     * the words. An evaluation label, or a metadata value, may legitimately be
+     * the string "passed" and must keep reading as its own bucket rather than
+     * being relabelled as an evaluation verdict.
+     */
+    it("does not borrow the evaluation verdict labels", () => {
+      expect(
+        groupName({
+          groupBy: "evaluations.evaluation_label",
+          groupKey: "passed",
+          groupLabel: "Evaluation Label",
+        }),
+      ).toBe("evaluation label passed");
+    });
+
+    it("does not borrow the no-verdict label either", () => {
+      expect(
+        groupName({
+          groupBy: "metadata.user_id",
+          groupKey: "unknown",
+          groupLabel: "User ID",
+        }),
+      ).toBe("user id unknown");
+    });
+  });
+
+  describe("given a series that is not grouped", () => {
+    it("contributes no name at all, so the series keeps its own", () => {
+      expect(groupName({ groupKey: undefined })).toBe("");
+    });
+  });
+
+  describe("given a row whose group value is empty", () => {
+    /**
+     * Regression: the label prefix was `group?.label.toLowerCase() + " "`, and
+     * the group was only looked up when the key was truthy. An empty key made
+     * that `undefined + " "`, so the chart rendered the string "Undefined
+     * unknown" at the user.
+     */
+    it("does not render the word 'undefined' at the user", () => {
+      const name = rendered({
+        groupBy: "metadata.user_id",
+        groupKey: "",
+        groupLabel: undefined,
+      });
+
+      expect(name.toLowerCase()).not.toContain("undefined");
+      expect(name).toBe("Unknown");
+    });
+
+    it("still labels the bucket when the group label is known", () => {
+      expect(
+        groupName({
+          groupBy: "metadata.user_id",
+          groupKey: "",
+          groupLabel: "User ID",
+        }),
+      ).toBe("user id unknown");
+    });
+  });
+
+  describe("given any other group-by", () => {
+    it("prefixes the bucket with the group's own label", () => {
+      expect(
+        groupName({
+          groupBy: "metadata.user_id",
+          groupKey: "u-1",
+          groupLabel: "User ID",
+        }),
+      ).toBe("user id u-1");
+    });
+
+    it("drops the prefix when the caller hides the group label", () => {
+      expect(
+        groupName({
+          groupBy: "metadata.user_id",
+          groupKey: "u-1",
+          groupLabel: "User ID",
+          hideGroupLabel: true,
+        }),
+      ).toBe("u-1");
+    });
+  });
+});
+
+describe("formatSingleSeriesName", () => {
+  it("keeps the existing shortenings", () => {
+    expect(formatSingleSeriesName("contains error true")).toBe("Traces true");
+    expect(formatSingleSeriesName("evaluation label helpful")).toBe("helpful");
+    expect(formatSingleSeriesName("thumbs up/down positive")).toBe("positive");
+  });
+
+  it("uppercases the first letter of everything else", () => {
+    expect(formatSingleSeriesName("user id u-1")).toBe("User id u-1");
+  });
+
+  it("passes an empty group through, so the series keeps its own name", () => {
+    expect(formatSingleSeriesName("")).toBe("");
+  });
+});

--- a/platform/app/src/components/analytics/__tests__/seriesGroupName.unit.test.ts
+++ b/platform/app/src/components/analytics/__tests__/seriesGroupName.unit.test.ts
@@ -146,17 +146,25 @@ describe("formatSeriesGroupName", () => {
 });
 
 describe("formatSingleSeriesName", () => {
-  it("keeps the existing shortenings", () => {
-    expect(formatSingleSeriesName("contains error true")).toBe("Traces true");
-    expect(formatSingleSeriesName("evaluation label helpful")).toBe("helpful");
-    expect(formatSingleSeriesName("thumbs up/down positive")).toBe("positive");
+  describe("given a group name carrying a recognised prefix", () => {
+    it.each([
+      { groupName: "contains error true", expected: "Traces true" },
+      { groupName: "evaluation label helpful", expected: "helpful" },
+      { groupName: "thumbs up/down positive", expected: "positive" },
+    ])("shortens $groupName to $expected", ({ groupName, expected }) => {
+      expect(formatSingleSeriesName(groupName)).toBe(expected);
+    });
   });
 
-  it("uppercases the first letter of everything else", () => {
-    expect(formatSingleSeriesName("user id u-1")).toBe("User id u-1");
+  describe("given an ordinary group name", () => {
+    it("uppercases the first letter and leaves the rest alone", () => {
+      expect(formatSingleSeriesName("user id u-1")).toBe("User id u-1");
+    });
   });
 
-  it("passes an empty group through, so the series keeps its own name", () => {
-    expect(formatSingleSeriesName("")).toBe("");
+  describe("given an empty group name", () => {
+    it("passes it through, so the series keeps its own name", () => {
+      expect(formatSingleSeriesName("")).toBe("");
+    });
   });
 });

--- a/platform/app/src/components/analytics/seriesGroupName.ts
+++ b/platform/app/src/components/analytics/seriesGroupName.ts
@@ -1,0 +1,89 @@
+import { uppercaseFirstLetter } from "../../utils/stringCasing";
+
+/**
+ * Display naming for the group-by bucket of a chart series.
+ *
+ * This was a chain of `.replace()` calls applied to an already-composed
+ * sentence, so reading it meant reconstructing which sentence each
+ * replacement was aimed at, and nothing covered it. It is a pure function
+ * here so the cases can be stated once and tested.
+ */
+
+/**
+ * `evaluations.evaluation_passed` buckets rows by verdict, and the bucket
+ * names are query values rather than display copy.
+ *
+ * `unknown` is the one that reads wrong. ClickHouse puts every processed
+ * evaluation with no boolean verdict there: a score-only evaluator that
+ * reports a number and never a pass/fail, an evaluation still processing,
+ * and one that errored. Rendered literally the chart said "Evaluation passed
+ * unknown", which reads as an evaluation that broke rather than one that
+ * never had a verdict to give.
+ *
+ * The label stays deliberately vague because the bucket is genuinely those
+ * three populations at once. Naming it "score-only" would be false for the
+ * processing and error rows. Splitting the bucket into its three real
+ * populations is the correctness fix and is a separate, backend change; this
+ * is the display-layer half. See #5080.
+ */
+const VERDICT_LABELS: Record<string, string> = {
+  passed: "Evaluation Passed",
+  failed: "Evaluation Failed",
+  unknown: "No verdict",
+};
+
+const GROUP_BY_WITH_VERDICT_LABELS = "evaluations.evaluation_passed";
+
+/** Shown when a row carries no group value at all, rather than "undefined". */
+export const MISSING_GROUP_KEY_LABEL = "unknown";
+
+export interface SeriesGroupNameInput {
+  /** The group-by field, for example `evaluations.evaluation_passed`. */
+  groupBy: string | undefined;
+  /** The bucket value for this series. `undefined` means "not grouped". */
+  groupKey: string | undefined;
+  /** The group's registry label, for example `Evaluation Passed`. */
+  groupLabel: string | undefined;
+  hideGroupLabel: boolean;
+}
+
+/**
+ * The group fragment for a series, or `""` when the series is not grouped.
+ *
+ * Callers with a single series render this as the whole series name; callers
+ * with several render it parenthesised after the series name.
+ */
+export const formatSeriesGroupName = ({
+  groupBy,
+  groupKey,
+  groupLabel,
+  hideGroupLabel,
+}: SeriesGroupNameInput): string => {
+  if (groupKey === undefined) return "";
+
+  if (groupBy === GROUP_BY_WITH_VERDICT_LABELS) {
+    const verdict = VERDICT_LABELS[groupKey];
+    if (verdict) return verdict;
+  }
+
+  // An empty group key still names a bucket, so it is labelled rather than
+  // dropped. The label prefix is omitted when it is unknown, because
+  // `undefined + " "` used to render the string "undefined " in front of it.
+  const key = groupKey === "" ? MISSING_GROUP_KEY_LABEL : groupKey;
+  const prefix =
+    hideGroupLabel || !groupLabel ? "" : `${groupLabel.toLowerCase()} `;
+
+  return `${prefix}${key}`;
+};
+
+/**
+ * The series name for a chart carrying exactly one series, where the group
+ * fragment is the whole name.
+ */
+export const formatSingleSeriesName = (groupName: string): string => {
+  if (!groupName) return "";
+  return uppercaseFirstLetter(groupName)
+    .replace("Contains error", "Traces")
+    .replace(/^Evaluation label /i, "")
+    .replace(/^Thumbs up\/down /i, "");
+};

--- a/platform/app/src/components/analytics/seriesGroupName.ts
+++ b/platform/app/src/components/analytics/seriesGroupName.ts
@@ -62,7 +62,10 @@ export const formatSeriesGroupName = ({
   if (groupKey === undefined) return "";
 
   if (groupBy === GROUP_BY_WITH_VERDICT_LABELS) {
-    const verdict = VERDICT_LABELS[groupKey];
+    // A row with no verdict at all belongs in the same bucket as one the
+    // query labelled `unknown`, otherwise the generic path below rebuilds
+    // exactly the "evaluation passed unknown" string this replaces.
+    const verdict = VERDICT_LABELS[groupKey === "" ? "unknown" : groupKey];
     if (verdict) return verdict;
   }
 


### PR DESCRIPTION
## Ticket

Closes #5080. The eval analytics cross-evaluator chart labelled a bucket **"Evaluation passed unknown"**.

## Premise, re-checked on current main

Holds. `'unknown'` is a **query value**, not display copy: `aggregation-builder.ts` emits `... AND Passed IS NULL THEN 'unknown'`, and two ClickHouse integration tests assert on that exact group key. So this is the display-layer half the ticket asks for (Option A), and the stored value is untouched.

The ticket's own framing is the reason the label is vague rather than clever:

> A score-only evaluator, a still-processing evaluation, and an error evaluation are three distinct populations that the rest of the codebase already distinguishes ... but the analytics groupBy collapses all three into one `'unknown'` bucket.

"No verdict" is true of all three. The ticket explicitly rejects `"score-only"`, which would be false for the processing and error rows. Splitting the bucket into its three real populations is the backend correctness fix and stays separate work.

## Change

The bucket now reads **"No verdict"**.

Getting there meant extracting the naming, because it was a chain of `.replace()` calls applied to an already-composed sentence:

```ts
uppercaseFirstLetter(groupName)
  .replace("Evaluation passed passed", "Evaluation Passed")
  .replace("Evaluation passed failed", "Evaluation Failed")
  .replace("Contains error", "Traces")
  ...
```

Reading that meant reconstructing which sentence each replacement was aimed at, and **nothing covered any of it**: there is no test in the repo that names `nameForSeries`. It is a pure function in `seriesGroupName.ts` now, with the cases stated once.

### A second bug, found by extracting it

The label prefix was `group?.label.toLowerCase() + " "`, and the group was only looked up when the key was truthy:

```ts
const group = input.groupBy && groupKey ? getGroup(input.groupBy) : undefined;
```

So a row whose group value is the empty string made that `undefined + " "`, and the chart rendered the word **"Undefined"** at the user. Reproduced by running main's expression as-is:

```
$ node -e '<the expression from origin/main, with groupKey = "">'
main renders: "undefined unknown"
```

An empty group value now labels its bucket without the stray prefix.

### One deliberate behaviour change beyond the ticket

Charts carrying several series render the group parenthesised, and that branch never went through the replacements, so it showed `(evaluation passed passed)`. It now shows `(Evaluation Passed)`. Flagging it because it is a visible change the ticket did not ask for; the alternative was to keep one branch reading correctly and the other not.

## Evidence

- **15 unit tests**, none of which existed before: `pnpm run test:unit --run src/components/analytics/__tests__/seriesGroupName.unit.test.ts`
- **907/907** in the surrounding suites, 44 files: `pnpm run test:unit --run src/components/analytics src/server/analytics`
- `pnpm typecheck:all` clean.
- Biome: findings on `CustomGraph.tsx` are **identical before and after** (8 `noExcessiveCognitiveComplexity`, 4 `noExcessiveLinesPerFunction`, 1 `useMaxParams`), measured by checking main's file at the same path rather than through `--stdin-file-path`, which does not resolve the project config and silently reports nothing. The two new files are clean.

### Mutations, all 6 caught

| mutation | caught by |
| --- | --- |
| revert the bucket label to `unknown` | names the no-verdict bucket for what it is |
| drop the empty-key fix | does not render the word "undefined" at the user |
| drop the missing-label guard | does not render the word "undefined" at the user |
| drop the passed/failed labels | keeps naming the two real verdicts |
| drop the "Contains error" shortening | keeps the existing shortenings |
| apply the verdict labels to every group-by | does not borrow the evaluation verdict labels |

The last one **escaped first**. The guard tying the verdict labels to the evaluation verdict group-by was untested, so nothing stopped an `evaluation_label` of `"passed"`, or any metadata value of `"unknown"`, from being relabelled as an evaluation verdict. That is now two tests.

## What I did not do

No browser QA. Reaching this label in a real chart needs a project with evaluations that have `Passed IS NULL` rows in ClickHouse, and I judged the seeding disproportionate for a pure string function that is now fully covered and whose wiring is typechecked. Saying so rather than implying a visual check happened.

## Advisory note

Advisory PR from the tech-debt-fixer bot, for human review, not to be merged by the bot.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved chart series labels for grouped and ungrouped analytics data.
  * Added clearer verdict labels, including “Passed,” “Failed,” and “No verdict.”
  * Improved handling of missing, hidden, and empty group values.
  * Simplified single-series names by removing redundant prefixes and standardizing capitalization.

* **Tests**
  * Added coverage for verdicts, missing values, hidden labels, ungrouped series, and single-series formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->