### PR TITLE
refactor(suites): make the scenario output-field tri-state a type, not a comment (#3119)

### DIFF
--- a/platform/app/src/components/suites/ScenarioInputMappingSection.tsx
+++ b/platform/app/src/components/suites/ScenarioInputMappingSection.tsx
@@ -22,6 +22,11 @@ import type {
 } from "~/components/variables/VariableMappingInput";
 import type { Variable } from "~/components/variables/VariablesSection";
 import { VariablesSection } from "~/components/variables/VariablesSection";
+import {
+  fromOutputFieldState,
+  resolveOutputField,
+  toOutputFieldState,
+} from "./outputFieldState";
 
 /** The three scenario fields shown as input mapping rows. */
 const SCENARIO_FIELDS: Variable[] = [
@@ -167,15 +172,15 @@ export function ScenarioInputMappingSection({
   );
 
   const hasOutputs = (outputs ?? []).length > 0;
-  const autoOutputLabel = outputs?.[0]?.identifier ?? "output";
-  // undefined = not yet set (auto-populate), "" = explicitly cleared, string = user selection
-  const selectedOutput =
-    outputField === undefined ? autoOutputLabel : outputField;
-  const hasOutputMapping = selectedOutput !== "" && hasOutputs;
+  const selectedOutput = resolveOutputField({
+    state: toOutputFieldState(outputField),
+    firstDeclaredOutput: outputs?.[0]?.identifier,
+  });
+  const hasOutputMapping = selectedOutput !== null && hasOutputs;
 
   const outputDisplayMappings = useMemo<Record<string, FieldMapping>>(
     () =>
-      hasOutputMapping
+      hasOutputMapping && selectedOutput !== null
         ? {
             output: {
               type: "source",
@@ -204,12 +209,13 @@ export function ScenarioInputMappingSection({
     _scenarioField: string,
     displayMapping: FieldMapping | undefined,
   ) => {
-    if (displayMapping?.type === "source" && displayMapping.path[0]) {
-      onOutputFieldChange?.(displayMapping.path[0]);
-    } else {
-      // Empty string signals "explicitly cleared" vs undefined which means "not yet set"
-      onOutputFieldChange?.("");
-    }
+    const selected =
+      displayMapping?.type === "source" && displayMapping.path[0];
+    onOutputFieldChange?.(
+      fromOutputFieldState(
+        selected ? { kind: "set", value: selected } : { kind: "cleared" },
+      ),
+    );
   };
 
   const handleDisplayMappingChange = (

--- a/platform/app/src/components/suites/__tests__/ScenarioInputMapping.integration.test.tsx
+++ b/platform/app/src/components/suites/__tests__/ScenarioInputMapping.integration.test.tsx
@@ -92,6 +92,54 @@ describe("ScenarioInputMappingSection", () => {
   // Scenario: Dropdown offers agent inputs as targets
   // ============================================================================
 
+  describe("given an agent declaring the output 'answer'", () => {
+    /**
+     * The stored value carries three states in one optional string, and these
+     * two are the pair that must not collapse: `undefined` means the user has
+     * not chosen and the first output is auto-populated, `""` means they
+     * cleared it on purpose. Reading `""` as "not chosen" would silently
+     * re-map the output the user just unmapped. See #3119.
+     */
+    describe("when the output field has not been chosen yet", () => {
+      it("maps the agent's first output automatically", () => {
+        renderSection({
+          outputs: [{ identifier: "answer", type: "str" }],
+          outputField: undefined,
+          onOutputFieldChange: vi.fn(),
+        });
+
+        expect(screen.getAllByText(/answer/i)).toHaveLength(1);
+      });
+    });
+
+    describe("when the user has cleared the output field", () => {
+      it("maps nothing, rather than falling back to the first output", () => {
+        renderSection({
+          outputs: [{ identifier: "answer", type: "str" }],
+          outputField: "",
+          onOutputFieldChange: vi.fn(),
+        });
+
+        expect(screen.queryByText(/answer/i)).not.toBeInTheDocument();
+      });
+    });
+
+    describe("when the user has chosen a specific output", () => {
+      it("maps that one rather than the first", () => {
+        renderSection({
+          outputs: [
+            { identifier: "answer", type: "str" },
+            { identifier: "reply", type: "str" },
+          ],
+          outputField: "reply",
+          onOutputFieldChange: vi.fn(),
+        });
+
+        expect(screen.getAllByText(/reply/i)).toHaveLength(1);
+      });
+    });
+  });
+
   describe("given the mapping UI with agent inputs 'query' and 'context'", () => {
     describe("when the user opens the input mapping dropdown", () => {
       /** @scenario Mapping dropdown offers the agent's inputs as targets */

--- a/platform/app/src/components/suites/__tests__/outputFieldState.unit.test.ts
+++ b/platform/app/src/components/suites/__tests__/outputFieldState.unit.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_OUTPUT_IDENTIFIER,
+  fromOutputFieldState,
+  type OutputFieldState,
+  resolveOutputField,
+  toOutputFieldState,
+} from "../outputFieldState";
+
+describe("toOutputFieldState", () => {
+  describe("given the value stored on the agent config", () => {
+    describe("when nothing has been stored", () => {
+      it("reads it as not yet chosen", () => {
+        expect(toOutputFieldState(undefined)).toEqual({ kind: "auto" });
+      });
+    });
+
+    describe("when the stored value is the empty string", () => {
+      it("reads it as cleared on purpose", () => {
+        expect(toOutputFieldState("")).toEqual({ kind: "cleared" });
+      });
+    });
+
+    describe("when the stored value names an output", () => {
+      it("reads it as the user's choice", () => {
+        expect(toOutputFieldState("answer")).toEqual({
+          kind: "set",
+          value: "answer",
+        });
+      });
+    });
+
+    // The whole point: these two used to be one falsy string.
+    describe("when comparing the two states that used to collapse", () => {
+      it("tells apart not-yet-chosen from cleared", () => {
+        expect(toOutputFieldState(undefined)).not.toEqual(
+          toOutputFieldState(""),
+        );
+      });
+    });
+  });
+});
+
+describe("fromOutputFieldState", () => {
+  describe("given each state", () => {
+    describe("when writing it back to the stored shape", () => {
+      it.each([
+        { state: { kind: "auto" } as OutputFieldState, stored: undefined },
+        { state: { kind: "cleared" } as OutputFieldState, stored: "" },
+        {
+          state: { kind: "set", value: "answer" } as OutputFieldState,
+          stored: "answer",
+        },
+      ])("writes $state.kind back as $stored", ({ state, stored }) => {
+        expect(fromOutputFieldState(state)).toBe(stored);
+      });
+    });
+  });
+
+  // The stored shape is persisted on the agent config, so this refactor must
+  // not move any saved value.
+  describe("given a value already stored on an agent", () => {
+    describe("when it is read and written back unchanged", () => {
+      it.each([
+        { stored: undefined },
+        { stored: "" },
+        { stored: "answer" },
+      ])("round-trips $stored unchanged", ({ stored }) => {
+        expect(fromOutputFieldState(toOutputFieldState(stored))).toBe(stored);
+      });
+    });
+  });
+});
+
+describe("resolveOutputField", () => {
+  describe("given the user has not chosen an output", () => {
+    describe("when the agent declares one", () => {
+      it("falls back to the agent's first declared output", () => {
+        expect(
+          resolveOutputField({
+            state: { kind: "auto" },
+            firstDeclaredOutput: "answer",
+          }),
+        ).toBe("answer");
+      });
+    });
+
+    describe("when the agent declares none", () => {
+      it("falls back to the default identifier", () => {
+        expect(
+          resolveOutputField({
+            state: { kind: "auto" },
+            firstDeclaredOutput: undefined,
+          }),
+        ).toBe(DEFAULT_OUTPUT_IDENTIFIER);
+      });
+    });
+  });
+
+  describe("given the user cleared the selection", () => {
+    describe("when an output is still declared", () => {
+      it("maps nothing", () => {
+        expect(
+          resolveOutputField({
+            state: { kind: "cleared" },
+            firstDeclaredOutput: "answer",
+          }),
+        ).toBeNull();
+      });
+
+      // Cleared must beat the fallback, otherwise clearing silently
+      // re-selects the first output and the result cannot be unmapped at all.
+      it("does not fall back to the first output", () => {
+        expect(
+          resolveOutputField({
+            state: { kind: "cleared" },
+            firstDeclaredOutput: "answer",
+          }),
+        ).not.toBe("answer");
+      });
+    });
+  });
+
+  describe("given the user chose a specific output", () => {
+    describe("when the agent declares a different one first", () => {
+      it("uses the user's choice", () => {
+        expect(
+          resolveOutputField({
+            state: { kind: "set", value: "reply" },
+            firstDeclaredOutput: "answer",
+          }),
+        ).toBe("reply");
+      });
+    });
+  });
+});

--- a/platform/app/src/components/suites/outputFieldState.ts
+++ b/platform/app/src/components/suites/outputFieldState.ts
@@ -52,10 +52,14 @@ export const fromOutputFieldState = (
  * The agent output the scenario result reads, or `null` when the user cleared
  * the selection and nothing should be mapped.
  */
-export const resolveOutputField = (
-  state: OutputFieldState,
-  firstDeclaredOutput: string | undefined,
-): string | null => {
+export const resolveOutputField = ({
+  state,
+  firstDeclaredOutput,
+}: {
+  state: OutputFieldState;
+  /** The first output the agent declares, used when nothing was chosen. */
+  firstDeclaredOutput: string | undefined;
+}): string | null => {
   switch (state.kind) {
     case "cleared":
       return null;

--- a/platform/app/src/components/suites/outputFieldState.ts
+++ b/platform/app/src/components/suites/outputFieldState.ts
@@ -49,8 +49,15 @@ export const fromOutputFieldState = (
 };
 
 /**
- * The agent output the scenario result reads, or `null` when the user cleared
- * the selection and nothing should be mapped.
+ * The output this editor shows as mapped, or `null` when the user cleared the
+ * selection and the editor should show no mapping row.
+ *
+ * This is the editor's reading of the stored value, not the executor's. The
+ * serialized adapters branch on `if (scenarioOutputField)`, so at execution
+ * time `""` takes the same path as `undefined` and falls back to the agent's
+ * first declared output. Whether a cleared selection should keep falling back
+ * or should mean something else at execution is a behaviour question this
+ * refactor deliberately does not answer.
  */
 export const resolveOutputField = ({
   state,

--- a/platform/app/src/components/suites/outputFieldState.ts
+++ b/platform/app/src/components/suites/outputFieldState.ts
@@ -1,0 +1,67 @@
+/**
+ * The three states the scenario output-field selection can be in.
+ *
+ * The stored shape is one optional string carrying three meanings:
+ * `undefined` is "the user has not chosen, fall back to the agent's first
+ * output", `""` is "the user cleared it on purpose", and any other string is
+ * their choice. Those are three different states, and which was which was
+ * carried by a comment rather than by the type:
+ *
+ *     // undefined = not yet set (auto-populate), "" = explicitly cleared,
+ *     // string = user selection
+ *
+ * so every branch had to re-derive the rule, and an `if (!outputField)` reads
+ * as correct while collapsing "not chosen" into "cleared".
+ *
+ * The stored shape is deliberately unchanged. This is a mapper at the
+ * boundary, so the serialized agent config and this component's props stay
+ * `string | undefined` and no persisted value has to move. See #3119.
+ */
+export type OutputFieldState =
+  | { kind: "auto" }
+  | { kind: "cleared" }
+  | { kind: "set"; value: string };
+
+/** The agent output used when nothing declares one. */
+export const DEFAULT_OUTPUT_IDENTIFIER = "output";
+
+/** Reads the stored shape. Total: every string is one of the three states. */
+export const toOutputFieldState = (
+  stored: string | undefined,
+): OutputFieldState => {
+  if (stored === undefined) return { kind: "auto" };
+  if (stored === "") return { kind: "cleared" };
+  return { kind: "set", value: stored };
+};
+
+/** Writes the stored shape back, so callers never spell the `""` themselves. */
+export const fromOutputFieldState = (
+  state: OutputFieldState,
+): string | undefined => {
+  switch (state.kind) {
+    case "auto":
+      return undefined;
+    case "cleared":
+      return "";
+    case "set":
+      return state.value;
+  }
+};
+
+/**
+ * The agent output the scenario result reads, or `null` when the user cleared
+ * the selection and nothing should be mapped.
+ */
+export const resolveOutputField = (
+  state: OutputFieldState,
+  firstDeclaredOutput: string | undefined,
+): string | null => {
+  switch (state.kind) {
+    case "cleared":
+      return null;
+    case "set":
+      return state.value;
+    case "auto":
+      return firstDeclaredOutput ?? DEFAULT_OUTPUT_IDENTIFIER;
+  }
+};


### PR DESCRIPTION
## Ticket

Closes #3119. `outputField` was a tri-state carried by overloaded string semantics.

## Premise, re-checked on current main

Holds, and it is live rather than theoretical: `AgentCodeEditorDrawer` and `AgentWorkflowEditorDrawer` both pass `outputField` and `onOutputFieldChange`, and the value is persisted on the agent config (`CodeComponentConfig.scenarioOutputField`).

The path is now `platform/app/src/components/suites/`, not the `langwatch/src/` the ticket names, after the ADR-076 restructure.

## Change

One optional string carried three states, and which was which lived in a comment:

```ts
// undefined = not yet set (auto-populate), "" = explicitly cleared, string = user selection
const selectedOutput = outputField === undefined ? autoOutputLabel : outputField;
const hasOutputMapping = selectedOutput !== "" && hasOutputs;
```

`OutputFieldState` is that union now, with a mapper at the boundary:

```ts
export type OutputFieldState =
  | { kind: "auto" }
  | { kind: "cleared" }
  | { kind: "set"; value: string };
```

The pair that must not collapse is `auto` and `cleared`. An `if (!outputField)` reads as correct and merges them, and merging them in the editor means clearing the output silently re-selects the agent's first one in the mapping UI.

**Scoped to the editor, and only the editor.** An earlier version of this description claimed the result "cannot be unmapped at all", which overstates it. At execution time the two serialized adapters already branch on `if (scenarioOutputField)`, and `""` is falsy, so a cleared selection takes the same path as an unset one and falls back to the first declared output. That is the behaviour on `main` today, in files this PR does not touch, and whether it is correct is a product question rather than a refactor. It is filed as #7574, cross-linked with the existing #3117 on the same method. `resolveOutputField` now says so in its doc comment rather than implying a guarantee that stops at the drawer.

**The stored shape does not move.** This is the ticket's "or add a mapper at the boundary": the serialized agent config and this component's props stay `string | undefined`, and the round trip is tested for all three values, so nothing persisted changes. That was the option worth taking over redefining the stored shape, because the alternative migrates saved agent configs for a readability win.

## Evidence

- **17 new tests**: 14 on the mapper, 3 on the component.
- Unit lane, `src/components/suites`: **235/235**, 14 files.
- Component lane, same path: **269/269**, 35 files.
- `pnpm typecheck:all` clean. Biome findings on both changed files are identical before and after.

### A note on which lane runs what

`test:unit` excludes `**/*.integration.test.{ts,tsx}`, and the integration lane's config is an explicit allowlist that does not name this file. `ScenarioInputMapping.integration.test.tsx` runs in **`test:component`** and nowhere else. I checked this because my first run of `test:unit` reported everything green while silently never loading the file the new component tests live in.

### Mutations, 6 of 7 caught

| mutation | caught by |
| --- | --- |
| read `""` as not-yet-chosen | reads the empty string as cleared on purpose |
| cleared falls back to the first output | maps nothing when the user cleared the selection |
| `auto` writes back `""` | writes `{ kind: 'auto' }` back as undefined |
| `cleared` writes back `undefined` | writes `{ kind: 'cleared' }` back as `""` |
| `auto` ignores the declared output | falls back to the agent's first declared output |
| map the output even when cleared | maps nothing, rather than falling back |

**One published escape.** Removing `selectedOutput !== null` from the display-mapping memo changes nothing observable, and neither the tests nor `typecheck:all` notice. It is redundant depth: when the selection is cleared `resolveOutputField` already returns `null`, and a mapping whose path is `[null]` renders nothing, so the user-visible outcome is identical either way. The behaviour it looks like it protects is enforced upstream and is covered by the second mutation above. Keeping it, and saying so rather than inventing an assertion that would only restate the mutation.

## Advisory note

Advisory PR from the tech-debt-fixer bot, for human review, not to be merged by the bot.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved scenario output-field mapping with clear handling for automatic, cleared, and explicitly selected outputs.
  * Automatically maps the first available output when no selection is specified.
  * Supports intentionally leaving output mapping empty.
  * Preserves explicitly selected output fields during mapping and state updates.

* **Tests**
  * Added coverage for automatic, cleared, and explicit output-field selections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
