### PR TITLE
build(nlpgo): install the Python SDK from the monorepo, not from PyPI

### DIFF
--- a/infra/docker/Dockerfile.langwatch_nlp
+++ b/infra/docker/Dockerfile.langwatch_nlp
@@ -44,6 +44,7 @@ RUN --mount=type=cache,target=/go/pkg/mod,id=go-mod-${TARGETARCH} \
 # This prune block is shared verbatim with the production Lambda image so both
 # artifacts install byte-identically from the one requirements file.
 FROM python:3.11-slim-bookworm AS sandbox-build
+COPY sdks/python/ /tmp/langwatch-sdk/
 COPY services/nlpgo/app/engine/blocks/codeblock/sandbox-requirements.txt /tmp/sandbox-requirements.txt
 RUN pip install --no-cache-dir --target=/pylibs -r /tmp/sandbox-requirements.txt
 RUN set -eux; \

--- a/services/nlpgo/app/engine/blocks/codeblock/sandbox-requirements.txt
+++ b/services/nlpgo/app/engine/blocks/codeblock/sandbox-requirements.txt
@@ -24,4 +24,8 @@ pydantic
 # The LangWatch Python SDK, so code blocks can fetch prompts, datasets, and
 # emit traces. Pulls pydantic + httpx (already here) + otel + python-liquid;
 # it does NOT require pandas/numpy.
-langwatch
+#
+# Installed from sdks/python/ in the monorepo, not from PyPI. The Dockerfile
+# COPYs it into /tmp/langwatch-sdk/ so the sandbox gets the same version as
+# the commit that built the image.
+/tmp/langwatch-sdk


### PR DESCRIPTION
## Summary

- The sandbox-build stage in the nlpgo Dockerfile installed `langwatch` from
  PyPI. A new SDK feature (like `langwatch.cache`) required a PyPI release
  before a rebuild would pick it up, and nothing in the pipeline triggered
  that rebuild automatically.
- COPY `sdks/python/` into the sandbox-build stage and point the requirements
  file at `/tmp/langwatch-sdk`. The sandbox now gets the exact SDK from the
  same commit that built the image.
- The langwatch-saas Dockerfiles (service + lambda) need the same change,
  see langwatch-saas#1174.

## Deployment Impact

Build-time only. The nlpgo image sandbox-build stage now COPYs `sdks/python/`
from the build context instead of pulling `langwatch` from PyPI. No runtime
change, no configuration, no migration. The image produces the same
`/opt/sandbox-libs` directory with the same packages; only the source of the
`langwatch` package changes from PyPI to the monorepo.

Rollback: revert sandbox-requirements.txt back to `langwatch` and remove the
COPY line from the Dockerfile.

## Test plan

- [ ] `docker build -f infra/docker/Dockerfile.langwatch_nlp .` succeeds
      and `import langwatch; langwatch.cache` is importable inside the sandbox
- [ ] No PyPI dependency on `langwatch` remains in sandbox-requirements.txt

https://claude.ai/code/session_01BAVTFiou8np4D5kfK2KsNm