### PR TITLE
refactor(governance): activity-monitor repos take the standard client resolver

### DIFF
--- a/dev/docs/best_practices/clickhouse-queries.md
+++ b/dev/docs/best_practices/clickhouse-queries.md
@@ -203,6 +203,22 @@ It is allowed to lead with `OrganizationId` **only** because all of these hold:
 
 A new table wanting this carve-out needs all six, plus a line here. Anything that merely *finds it convenient* to skip `TenantId` does not qualify.
 
+## Validate Rows at the Boundary with Zod
+
+Parse every `result.json()` through a Zod schema before the rows leave the
+repository, and derive the returned type with `z.infer<>` — one source of truth
+for shape and validation. ClickHouse is a trust boundary: JSONEachRow renders
+aggregated numerics (`sum`, `count`, `uniqExact`) as strings once they exceed
+JS-safe range, LEFT-JOIN gaps surface as nulls where the interface said
+`string`, and a migration can rename a column under you. `.parse()` at the read
+boundary catches all three; `.catch()` on individual fields provides safe
+defaults for expected variations, while fields without one fail fast on drift.
+
+Reference implementation: `platform/app/ee/governance/services/activity-monitor/activityMonitor.clickhouse.schemas.ts`
+and its three repositories (PR #7146). New `*.clickhouse.repository.ts` files
+should follow it; existing ones migrate opportunistically when their queries
+change anyway.
+
 ## JOINs — Prefer Not To, Then Prefer `IN`
 
 ClickHouse is not Postgres here. The planner streams the **right-hand** side into

--- a/platform/app/ee/governance/routers/activityMonitor.ts
+++ b/platform/app/ee/governance/routers/activityMonitor.ts
@@ -44,10 +44,10 @@ export const activityMonitorRouter = createTRPCRouter({
     .permission("activityMonitor:view")
     .use(enterpriseGate)
     .query(async ({ ctx, input }) => {
-      const service = ActivityMonitorService.create(
-        ctx.prisma,
-        getApp().governance.activityMonitor,
-      );
+      const service = ActivityMonitorService.create({
+        prisma: ctx.prisma,
+        repository: getApp().governance.activityMonitor,
+      });
       return await service.summary({
         organizationId: input.organizationId,
         windowDays: input.windowDays,
@@ -75,10 +75,10 @@ export const activityMonitorRouter = createTRPCRouter({
     .permission("activityMonitor:view")
     .use(enterpriseGate)
     .query(async ({ ctx, input }) => {
-      const service = ActivityMonitorService.create(
-        ctx.prisma,
-        getApp().governance.activityMonitor,
-      );
+      const service = ActivityMonitorService.create({
+        prisma: ctx.prisma,
+        repository: getApp().governance.activityMonitor,
+      });
       return await service.spendByUser({
         organizationId: input.organizationId,
         windowDays: input.windowDays,
@@ -111,10 +111,10 @@ export const activityMonitorRouter = createTRPCRouter({
     .permission("activityMonitor:view")
     .use(enterpriseGate)
     .query(async ({ ctx, input }) => {
-      const service = ActivityMonitorService.create(
-        ctx.prisma,
-        getApp().governance.activityMonitor,
-      );
+      const service = ActivityMonitorService.create({
+        prisma: ctx.prisma,
+        repository: getApp().governance.activityMonitor,
+      });
       return await service.spendByTeam({
         organizationId: input.organizationId,
         windowDays: input.windowDays,
@@ -144,10 +144,10 @@ export const activityMonitorRouter = createTRPCRouter({
     .permission("activityMonitor:view")
     .use(enterpriseGate)
     .query(async ({ ctx, input }) => {
-      const service = ActivityMonitorService.create(
-        ctx.prisma,
-        getApp().governance.activityMonitor,
-      );
+      const service = ActivityMonitorService.create({
+        prisma: ctx.prisma,
+        repository: getApp().governance.activityMonitor,
+      });
       return await service.spendByDepartment({
         organizationId: input.organizationId,
         windowDays: input.windowDays,
@@ -174,10 +174,10 @@ export const activityMonitorRouter = createTRPCRouter({
     .permission("activityMonitor:view")
     .use(enterpriseGate)
     .query(async ({ ctx, input }) => {
-      const service = ActivityMonitorService.create(
-        ctx.prisma,
-        getApp().governance.activityMonitor,
-      );
+      const service = ActivityMonitorService.create({
+        prisma: ctx.prisma,
+        repository: getApp().governance.activityMonitor,
+      });
       return await service.spendOverTime({
         organizationId: input.organizationId,
         windowDays: input.windowDays,
@@ -193,10 +193,10 @@ export const activityMonitorRouter = createTRPCRouter({
     .permission("activityMonitor:view")
     .use(enterpriseGate)
     .query(async ({ ctx, input }) => {
-      const service = ActivityMonitorService.create(
-        ctx.prisma,
-        getApp().governance.activityMonitor,
-      );
+      const service = ActivityMonitorService.create({
+        prisma: ctx.prisma,
+        repository: getApp().governance.activityMonitor,
+      });
       return await service.ingestionSourcesHealth({
         organizationId: input.organizationId,
       });
@@ -218,10 +218,10 @@ export const activityMonitorRouter = createTRPCRouter({
     .permission("activityMonitor:view")
     .use(enterpriseGate)
     .query(async ({ ctx, input }) => {
-      const service = ActivityMonitorService.create(
-        ctx.prisma,
-        getApp().governance.activityMonitor,
-      );
+      const service = ActivityMonitorService.create({
+        prisma: ctx.prisma,
+        repository: getApp().governance.activityMonitor,
+      });
       return await service.recentAnomalies({
         organizationId: input.organizationId,
         limit: input.limit,
@@ -245,10 +245,10 @@ export const activityMonitorRouter = createTRPCRouter({
     .permission("activityMonitor:view")
     .use(enterpriseGate)
     .query(async ({ ctx, input }) => {
-      const service = ActivityMonitorService.create(
-        ctx.prisma,
-        getApp().governance.activityMonitor,
-      );
+      const service = ActivityMonitorService.create({
+        prisma: ctx.prisma,
+        repository: getApp().governance.activityMonitor,
+      });
       return await service.eventsForSource(input);
     }),
 
@@ -266,10 +266,10 @@ export const activityMonitorRouter = createTRPCRouter({
     .permission("activityMonitor:view")
     .use(enterpriseGate)
     .query(async ({ ctx, input }) => {
-      const service = ActivityMonitorService.create(
-        ctx.prisma,
-        getApp().governance.activityMonitor,
-      );
+      const service = ActivityMonitorService.create({
+        prisma: ctx.prisma,
+        repository: getApp().governance.activityMonitor,
+      });
       return await service.sourceHealthMetrics(input);
     }),
 });

--- a/platform/app/ee/governance/routers/activityMonitor.ts
+++ b/platform/app/ee/governance/routers/activityMonitor.ts
@@ -23,6 +23,7 @@ import {
   requireEnterprisePlan,
 } from "~/server/api/enterprise";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
+import { getApp } from "~/server/app-layer/app";
 
 const enterpriseGate = requireEnterprisePlan(
   ENTERPRISE_FEATURE_ERRORS.ACTIVITY_MONITOR,
@@ -43,7 +44,10 @@ export const activityMonitorRouter = createTRPCRouter({
     .permission("activityMonitor:view")
     .use(enterpriseGate)
     .query(async ({ ctx, input }) => {
-      const service = ActivityMonitorService.create(ctx.prisma);
+      const service = ActivityMonitorService.create(
+        ctx.prisma,
+        getApp().governance.activityMonitor,
+      );
       return await service.summary({
         organizationId: input.organizationId,
         windowDays: input.windowDays,
@@ -71,7 +75,10 @@ export const activityMonitorRouter = createTRPCRouter({
     .permission("activityMonitor:view")
     .use(enterpriseGate)
     .query(async ({ ctx, input }) => {
-      const service = ActivityMonitorService.create(ctx.prisma);
+      const service = ActivityMonitorService.create(
+        ctx.prisma,
+        getApp().governance.activityMonitor,
+      );
       return await service.spendByUser({
         organizationId: input.organizationId,
         windowDays: input.windowDays,
@@ -104,7 +111,10 @@ export const activityMonitorRouter = createTRPCRouter({
     .permission("activityMonitor:view")
     .use(enterpriseGate)
     .query(async ({ ctx, input }) => {
-      const service = ActivityMonitorService.create(ctx.prisma);
+      const service = ActivityMonitorService.create(
+        ctx.prisma,
+        getApp().governance.activityMonitor,
+      );
       return await service.spendByTeam({
         organizationId: input.organizationId,
         windowDays: input.windowDays,
@@ -134,7 +144,10 @@ export const activityMonitorRouter = createTRPCRouter({
     .permission("activityMonitor:view")
     .use(enterpriseGate)
     .query(async ({ ctx, input }) => {
-      const service = ActivityMonitorService.create(ctx.prisma);
+      const service = ActivityMonitorService.create(
+        ctx.prisma,
+        getApp().governance.activityMonitor,
+      );
       return await service.spendByDepartment({
         organizationId: input.organizationId,
         windowDays: input.windowDays,
@@ -161,7 +174,10 @@ export const activityMonitorRouter = createTRPCRouter({
     .permission("activityMonitor:view")
     .use(enterpriseGate)
     .query(async ({ ctx, input }) => {
-      const service = ActivityMonitorService.create(ctx.prisma);
+      const service = ActivityMonitorService.create(
+        ctx.prisma,
+        getApp().governance.activityMonitor,
+      );
       return await service.spendOverTime({
         organizationId: input.organizationId,
         windowDays: input.windowDays,
@@ -177,7 +193,10 @@ export const activityMonitorRouter = createTRPCRouter({
     .permission("activityMonitor:view")
     .use(enterpriseGate)
     .query(async ({ ctx, input }) => {
-      const service = ActivityMonitorService.create(ctx.prisma);
+      const service = ActivityMonitorService.create(
+        ctx.prisma,
+        getApp().governance.activityMonitor,
+      );
       return await service.ingestionSourcesHealth({
         organizationId: input.organizationId,
       });
@@ -199,7 +218,10 @@ export const activityMonitorRouter = createTRPCRouter({
     .permission("activityMonitor:view")
     .use(enterpriseGate)
     .query(async ({ ctx, input }) => {
-      const service = ActivityMonitorService.create(ctx.prisma);
+      const service = ActivityMonitorService.create(
+        ctx.prisma,
+        getApp().governance.activityMonitor,
+      );
       return await service.recentAnomalies({
         organizationId: input.organizationId,
         limit: input.limit,
@@ -223,7 +245,10 @@ export const activityMonitorRouter = createTRPCRouter({
     .permission("activityMonitor:view")
     .use(enterpriseGate)
     .query(async ({ ctx, input }) => {
-      const service = ActivityMonitorService.create(ctx.prisma);
+      const service = ActivityMonitorService.create(
+        ctx.prisma,
+        getApp().governance.activityMonitor,
+      );
       return await service.eventsForSource(input);
     }),
 
@@ -241,7 +266,10 @@ export const activityMonitorRouter = createTRPCRouter({
     .permission("activityMonitor:view")
     .use(enterpriseGate)
     .query(async ({ ctx, input }) => {
-      const service = ActivityMonitorService.create(ctx.prisma);
+      const service = ActivityMonitorService.create(
+        ctx.prisma,
+        getApp().governance.activityMonitor,
+      );
       return await service.sourceHealthMetrics(input);
     }),
 });

--- a/platform/app/ee/governance/services/__tests__/activityMonitor.service.integration.test.ts
+++ b/platform/app/ee/governance/services/__tests__/activityMonitor.service.integration.test.ts
@@ -32,7 +32,7 @@ import type { ClickHouseClient } from "@clickhouse/client";
 import { nanoid } from "nanoid";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import type { Organization, Project } from "~/generated/prisma/client";
-
+import { getApp } from "~/server/app-layer/app";
 import { prisma } from "~/server/db";
 import {
   cleanupTestData,
@@ -423,7 +423,10 @@ describe("ActivityMonitorService — read-side queries against unified trace sto
         },
       });
       try {
-        const service = ActivityMonitorService.create(prisma);
+        const service = ActivityMonitorService.create(
+          prisma,
+          getApp().governance.activityMonitor,
+        );
         const summary = await service.summary({
           organizationId: orphanOrg.id,
           windowDays: 7,
@@ -440,7 +443,10 @@ describe("ActivityMonitorService — read-side queries against unified trace sto
 
   describe("when querying summary() with governance-origin traces seeded", () => {
     it("returns spend rolled up from governance-origin traces in the window", async () => {
-      const service = ActivityMonitorService.create(prisma);
+      const service = ActivityMonitorService.create(
+        prisma,
+        getApp().governance.activityMonitor,
+      );
       const summary = await service.summary({
         organizationId: primaryOrg.id,
         windowDays: 7,
@@ -452,7 +458,10 @@ describe("ActivityMonitorService — read-side queries against unified trace sto
     });
 
     it("rolls up active users from langwatch.user_id in governance traces only", async () => {
-      const service = ActivityMonitorService.create(prisma);
+      const service = ActivityMonitorService.create(
+        prisma,
+        getApp().governance.activityMonitor,
+      );
       const summary = await service.summary({
         organizationId: primaryOrg.id,
         windowDays: 7,
@@ -463,7 +472,10 @@ describe("ActivityMonitorService — read-side queries against unified trace sto
     });
 
     it("excludes cross-org governance traces (TenantId isolation)", async () => {
-      const service = ActivityMonitorService.create(prisma);
+      const service = ActivityMonitorService.create(
+        prisma,
+        getApp().governance.activityMonitor,
+      );
       const summary = await service.summary({
         organizationId: primaryOrg.id,
         windowDays: 30,
@@ -476,7 +488,10 @@ describe("ActivityMonitorService — read-side queries against unified trace sto
 
   describe("when querying spendByUser()", () => {
     it("returns per-user spend rollup sorted by spend desc", async () => {
-      const service = ActivityMonitorService.create(prisma);
+      const service = ActivityMonitorService.create(
+        prisma,
+        getApp().governance.activityMonitor,
+      );
       const rows = await service.spendByUser({
         organizationId: primaryOrg.id,
         windowDays: 7,
@@ -497,7 +512,10 @@ describe("ActivityMonitorService — read-side queries against unified trace sto
 
   describe("when querying spendByTeam()", () => {
     it("rolls up spend by IngestionSource.teamId with an Org-wide bucket for null-teamId sources", async () => {
-      const service = ActivityMonitorService.create(prisma);
+      const service = ActivityMonitorService.create(
+        prisma,
+        getApp().governance.activityMonitor,
+      );
       // windowDays=15 (not 14) to comfortably include Carol's row at
       // `now - 14 * day` regardless of test-execution latency between
       // fixture insert and query — at exactly windowDays=14 the row
@@ -537,7 +555,10 @@ describe("ActivityMonitorService — read-side queries against unified trace sto
     });
 
     it("excludes cross-org governance traces (TenantId isolation)", async () => {
-      const service = ActivityMonitorService.create(prisma);
+      const service = ActivityMonitorService.create(
+        prisma,
+        getApp().governance.activityMonitor,
+      );
       const rows = await service.spendByTeam({
         organizationId: primaryOrg.id,
         windowDays: 30,
@@ -561,7 +582,10 @@ describe("ActivityMonitorService — read-side queries against unified trace sto
           slug: `no-gov-${nanoid(6)}`,
         },
       });
-      const service = ActivityMonitorService.create(prisma);
+      const service = ActivityMonitorService.create(
+        prisma,
+        getApp().governance.activityMonitor,
+      );
       const rows = await service.spendByTeam({
         organizationId: orgNoGov.id,
         windowDays: 30,
@@ -573,7 +597,10 @@ describe("ActivityMonitorService — read-side queries against unified trace sto
 
   describe("when querying spendByUser() with pagination + sort args (v2 spec line 157)", () => {
     it("limit + offset paginate the same ordering — sortBy='spend' desc returns bob ($1.50) on page 0, alice ($0.50) on page 1", async () => {
-      const service = ActivityMonitorService.create(prisma);
+      const service = ActivityMonitorService.create(
+        prisma,
+        getApp().governance.activityMonitor,
+      );
       const page0 = await service.spendByUser({
         organizationId: primaryOrg.id,
         windowDays: 30,
@@ -597,7 +624,10 @@ describe("ActivityMonitorService — read-side queries against unified trace sto
     });
 
     it("sortDir='asc' inverts the ordering — carol ($0.25) is the smallest spender so she comes first", async () => {
-      const service = ActivityMonitorService.create(prisma);
+      const service = ActivityMonitorService.create(
+        prisma,
+        getApp().governance.activityMonitor,
+      );
       const rows = await service.spendByUser({
         organizationId: primaryOrg.id,
         windowDays: 30,
@@ -611,7 +641,10 @@ describe("ActivityMonitorService — read-side queries against unified trace sto
     });
 
     it("sortBy='lastActivity' desc puts the recently-active users before carol's 14d-old row", async () => {
-      const service = ActivityMonitorService.create(prisma);
+      const service = ActivityMonitorService.create(
+        prisma,
+        getApp().governance.activityMonitor,
+      );
       const rows = await service.spendByUser({
         organizationId: primaryOrg.id,
         windowDays: 30,
@@ -628,7 +661,10 @@ describe("ActivityMonitorService — read-side queries against unified trace sto
     });
 
     it("legacy callers (no pagination/sort args) still get the v1 default — top-N by spend desc", async () => {
-      const service = ActivityMonitorService.create(prisma);
+      const service = ActivityMonitorService.create(
+        prisma,
+        getApp().governance.activityMonitor,
+      );
       const rows = await service.spendByUser({
         organizationId: primaryOrg.id,
         windowDays: 30,
@@ -645,7 +681,10 @@ describe("ActivityMonitorService — read-side queries against unified trace sto
 
   describe("when querying spendByTeam() with pagination + sort args (v2 spec line 157)", () => {
     it("limit caps the page; offset paginates — limit=1 offset=0 gets primary team, offset=1 gets Org-wide", async () => {
-      const service = ActivityMonitorService.create(prisma);
+      const service = ActivityMonitorService.create(
+        prisma,
+        getApp().governance.activityMonitor,
+      );
       const page0 = await service.spendByTeam({
         organizationId: primaryOrg.id,
         windowDays: 30,
@@ -669,7 +708,10 @@ describe("ActivityMonitorService — read-side queries against unified trace sto
     });
 
     it("sortDir='asc' inverts the ordering — Org-wide ($0.25) before primary team ($2.00)", async () => {
-      const service = ActivityMonitorService.create(prisma);
+      const service = ActivityMonitorService.create(
+        prisma,
+        getApp().governance.activityMonitor,
+      );
       const rows = await service.spendByTeam({
         organizationId: primaryOrg.id,
         windowDays: 30,
@@ -682,7 +724,10 @@ describe("ActivityMonitorService — read-side queries against unified trace sto
     });
 
     it("sortBy='lastActivity' desc puts the team with the recent activity first", async () => {
-      const service = ActivityMonitorService.create(prisma);
+      const service = ActivityMonitorService.create(
+        prisma,
+        getApp().governance.activityMonitor,
+      );
       const rows = await service.spendByTeam({
         organizationId: primaryOrg.id,
         windowDays: 30,
@@ -697,7 +742,10 @@ describe("ActivityMonitorService — read-side queries against unified trace sto
     });
 
     it("sortBy='requests' desc orders by raw request count, not spend", async () => {
-      const service = ActivityMonitorService.create(prisma);
+      const service = ActivityMonitorService.create(
+        prisma,
+        getApp().governance.activityMonitor,
+      );
       const rows = await service.spendByTeam({
         organizationId: primaryOrg.id,
         windowDays: 30,
@@ -711,7 +759,10 @@ describe("ActivityMonitorService — read-side queries against unified trace sto
     });
 
     it("legacy callers (no pagination/sort args) still get the v1 default — top-N by spend desc", async () => {
-      const service = ActivityMonitorService.create(prisma);
+      const service = ActivityMonitorService.create(
+        prisma,
+        getApp().governance.activityMonitor,
+      );
       const rows = await service.spendByTeam({
         organizationId: primaryOrg.id,
         windowDays: 30,
@@ -725,7 +776,10 @@ describe("ActivityMonitorService — read-side queries against unified trace sto
 
   describe("when querying ingestionSourcesHealth()", () => {
     it("returns per-source eventsLast24h across pushed and pulled event stores", async () => {
-      const service = ActivityMonitorService.create(prisma);
+      const service = ActivityMonitorService.create(
+        prisma,
+        getApp().governance.activityMonitor,
+      );
       const rows = await service.ingestionSourcesHealth({
         organizationId: primaryOrg.id,
       });
@@ -740,7 +794,10 @@ describe("ActivityMonitorService — read-side queries against unified trace sto
 
   describe("when querying sourceHealthMetrics() for a single source", () => {
     it("returns 24h/7d/30d event counts + lastSuccessIso", async () => {
-      const service = ActivityMonitorService.create(prisma);
+      const service = ActivityMonitorService.create(
+        prisma,
+        getApp().governance.activityMonitor,
+      );
       const metrics = await service.sourceHealthMetrics({
         organizationId: primaryOrg.id,
         sourceId: primarySourceId,
@@ -755,7 +812,10 @@ describe("ActivityMonitorService — read-side queries against unified trace sto
 
   describe("when querying eventsForSource() for the trace drill-down list", () => {
     it("returns governance-origin traces matching the sourceId filter", async () => {
-      const service = ActivityMonitorService.create(prisma);
+      const service = ActivityMonitorService.create(
+        prisma,
+        getApp().governance.activityMonitor,
+      );
       const rows = await service.eventsForSource({
         organizationId: primaryOrg.id,
         sourceId: primarySourceId,
@@ -785,7 +845,10 @@ describe("ActivityMonitorService — read-side queries against unified trace sto
 
   describe("when querying spendOverTime() for the bird's-eye stacked-area chart", () => {
     it("returns dense daily buckets covering windowDays — empty days emit `points: []` so the X axis has no gaps", async () => {
-      const service = ActivityMonitorService.create(prisma);
+      const service = ActivityMonitorService.create(
+        prisma,
+        getApp().governance.activityMonitor,
+      );
       const result = await service.spendOverTime({
         organizationId: primaryOrg.id,
         windowDays: 30,
@@ -815,7 +878,10 @@ describe("ActivityMonitorService — read-side queries against unified trace sto
     });
 
     it("groups by team — primary team appears in the recent bucket; Org-wide in the 14d-ago bucket", async () => {
-      const service = ActivityMonitorService.create(prisma);
+      const service = ActivityMonitorService.create(
+        prisma,
+        getApp().governance.activityMonitor,
+      );
       const result = await service.spendOverTime({
         organizationId: primaryOrg.id,
         windowDays: 30,
@@ -850,7 +916,10 @@ describe("ActivityMonitorService — read-side queries against unified trace sto
     });
 
     it("groups by user — alice + bob in recent bucket, carol in 14d-ago bucket", async () => {
-      const service = ActivityMonitorService.create(prisma);
+      const service = ActivityMonitorService.create(
+        prisma,
+        getApp().governance.activityMonitor,
+      );
       const result = await service.spendOverTime({
         organizationId: primaryOrg.id,
         windowDays: 30,
@@ -877,7 +946,10 @@ describe("ActivityMonitorService — read-side queries against unified trace sto
     });
 
     it("groups by model — claude-sonnet-4 only; app-model is excluded by origin filter", async () => {
-      const service = ActivityMonitorService.create(prisma);
+      const service = ActivityMonitorService.create(
+        prisma,
+        getApp().governance.activityMonitor,
+      );
       const result = await service.spendOverTime({
         organizationId: primaryOrg.id,
         windowDays: 30,
@@ -893,7 +965,10 @@ describe("ActivityMonitorService — read-side queries against unified trace sto
     });
 
     it("honors TenantId isolation — cross-org $50 spend never appears in primary org's series", async () => {
-      const service = ActivityMonitorService.create(prisma);
+      const service = ActivityMonitorService.create(
+        prisma,
+        getApp().governance.activityMonitor,
+      );
       const result = await service.spendOverTime({
         organizationId: primaryOrg.id,
         windowDays: 30,
@@ -915,7 +990,10 @@ describe("ActivityMonitorService — read-side queries against unified trace sto
     });
 
     it("orders points within a bucket by spend desc — largest contributor first for stable Recharts stack rendering", async () => {
-      const service = ActivityMonitorService.create(prisma);
+      const service = ActivityMonitorService.create(
+        prisma,
+        getApp().governance.activityMonitor,
+      );
       const result = await service.spendOverTime({
         organizationId: primaryOrg.id,
         windowDays: 30,
@@ -939,7 +1017,10 @@ describe("ActivityMonitorService — read-side queries against unified trace sto
         },
       });
       try {
-        const service = ActivityMonitorService.create(prisma);
+        const service = ActivityMonitorService.create(
+          prisma,
+          getApp().governance.activityMonitor,
+        );
         const result = await service.spendOverTime({
           organizationId: orphan.id,
           windowDays: 7,

--- a/platform/app/ee/governance/services/__tests__/activityMonitor.service.integration.test.ts
+++ b/platform/app/ee/governance/services/__tests__/activityMonitor.service.integration.test.ts
@@ -423,10 +423,10 @@ describe("ActivityMonitorService — read-side queries against unified trace sto
         },
       });
       try {
-        const service = ActivityMonitorService.create(
+        const service = ActivityMonitorService.create({
           prisma,
-          getApp().governance.activityMonitor,
-        );
+          repository: getApp().governance.activityMonitor,
+        });
         const summary = await service.summary({
           organizationId: orphanOrg.id,
           windowDays: 7,
@@ -443,10 +443,10 @@ describe("ActivityMonitorService — read-side queries against unified trace sto
 
   describe("when querying summary() with governance-origin traces seeded", () => {
     it("returns spend rolled up from governance-origin traces in the window", async () => {
-      const service = ActivityMonitorService.create(
+      const service = ActivityMonitorService.create({
         prisma,
-        getApp().governance.activityMonitor,
-      );
+        repository: getApp().governance.activityMonitor,
+      });
       const summary = await service.summary({
         organizationId: primaryOrg.id,
         windowDays: 7,
@@ -458,10 +458,10 @@ describe("ActivityMonitorService — read-side queries against unified trace sto
     });
 
     it("rolls up active users from langwatch.user_id in governance traces only", async () => {
-      const service = ActivityMonitorService.create(
+      const service = ActivityMonitorService.create({
         prisma,
-        getApp().governance.activityMonitor,
-      );
+        repository: getApp().governance.activityMonitor,
+      });
       const summary = await service.summary({
         organizationId: primaryOrg.id,
         windowDays: 7,
@@ -472,10 +472,10 @@ describe("ActivityMonitorService — read-side queries against unified trace sto
     });
 
     it("excludes cross-org governance traces (TenantId isolation)", async () => {
-      const service = ActivityMonitorService.create(
+      const service = ActivityMonitorService.create({
         prisma,
-        getApp().governance.activityMonitor,
-      );
+        repository: getApp().governance.activityMonitor,
+      });
       const summary = await service.summary({
         organizationId: primaryOrg.id,
         windowDays: 30,
@@ -488,10 +488,10 @@ describe("ActivityMonitorService — read-side queries against unified trace sto
 
   describe("when querying spendByUser()", () => {
     it("returns per-user spend rollup sorted by spend desc", async () => {
-      const service = ActivityMonitorService.create(
+      const service = ActivityMonitorService.create({
         prisma,
-        getApp().governance.activityMonitor,
-      );
+        repository: getApp().governance.activityMonitor,
+      });
       const rows = await service.spendByUser({
         organizationId: primaryOrg.id,
         windowDays: 7,
@@ -512,10 +512,10 @@ describe("ActivityMonitorService — read-side queries against unified trace sto
 
   describe("when querying spendByTeam()", () => {
     it("rolls up spend by IngestionSource.teamId with an Org-wide bucket for null-teamId sources", async () => {
-      const service = ActivityMonitorService.create(
+      const service = ActivityMonitorService.create({
         prisma,
-        getApp().governance.activityMonitor,
-      );
+        repository: getApp().governance.activityMonitor,
+      });
       // windowDays=15 (not 14) to comfortably include Carol's row at
       // `now - 14 * day` regardless of test-execution latency between
       // fixture insert and query — at exactly windowDays=14 the row
@@ -555,10 +555,10 @@ describe("ActivityMonitorService — read-side queries against unified trace sto
     });
 
     it("excludes cross-org governance traces (TenantId isolation)", async () => {
-      const service = ActivityMonitorService.create(
+      const service = ActivityMonitorService.create({
         prisma,
-        getApp().governance.activityMonitor,
-      );
+        repository: getApp().governance.activityMonitor,
+      });
       const rows = await service.spendByTeam({
         organizationId: primaryOrg.id,
         windowDays: 30,
@@ -582,10 +582,10 @@ describe("ActivityMonitorService — read-side queries against unified trace sto
           slug: `no-gov-${nanoid(6)}`,
         },
       });
-      const service = ActivityMonitorService.create(
+      const service = ActivityMonitorService.create({
         prisma,
-        getApp().governance.activityMonitor,
-      );
+        repository: getApp().governance.activityMonitor,
+      });
       const rows = await service.spendByTeam({
         organizationId: orgNoGov.id,
         windowDays: 30,
@@ -597,10 +597,10 @@ describe("ActivityMonitorService — read-side queries against unified trace sto
 
   describe("when querying spendByUser() with pagination + sort args (v2 spec line 157)", () => {
     it("limit + offset paginate the same ordering — sortBy='spend' desc returns bob ($1.50) on page 0, alice ($0.50) on page 1", async () => {
-      const service = ActivityMonitorService.create(
+      const service = ActivityMonitorService.create({
         prisma,
-        getApp().governance.activityMonitor,
-      );
+        repository: getApp().governance.activityMonitor,
+      });
       const page0 = await service.spendByUser({
         organizationId: primaryOrg.id,
         windowDays: 30,
@@ -624,10 +624,10 @@ describe("ActivityMonitorService — read-side queries against unified trace sto
     });
 
     it("sortDir='asc' inverts the ordering — carol ($0.25) is the smallest spender so she comes first", async () => {
-      const service = ActivityMonitorService.create(
+      const service = ActivityMonitorService.create({
         prisma,
-        getApp().governance.activityMonitor,
-      );
+        repository: getApp().governance.activityMonitor,
+      });
       const rows = await service.spendByUser({
         organizationId: primaryOrg.id,
         windowDays: 30,
@@ -641,10 +641,10 @@ describe("ActivityMonitorService — read-side queries against unified trace sto
     });
 
     it("sortBy='lastActivity' desc puts the recently-active users before carol's 14d-old row", async () => {
-      const service = ActivityMonitorService.create(
+      const service = ActivityMonitorService.create({
         prisma,
-        getApp().governance.activityMonitor,
-      );
+        repository: getApp().governance.activityMonitor,
+      });
       const rows = await service.spendByUser({
         organizationId: primaryOrg.id,
         windowDays: 30,
@@ -661,10 +661,10 @@ describe("ActivityMonitorService — read-side queries against unified trace sto
     });
 
     it("legacy callers (no pagination/sort args) still get the v1 default — top-N by spend desc", async () => {
-      const service = ActivityMonitorService.create(
+      const service = ActivityMonitorService.create({
         prisma,
-        getApp().governance.activityMonitor,
-      );
+        repository: getApp().governance.activityMonitor,
+      });
       const rows = await service.spendByUser({
         organizationId: primaryOrg.id,
         windowDays: 30,
@@ -681,10 +681,10 @@ describe("ActivityMonitorService — read-side queries against unified trace sto
 
   describe("when querying spendByTeam() with pagination + sort args (v2 spec line 157)", () => {
     it("limit caps the page; offset paginates — limit=1 offset=0 gets primary team, offset=1 gets Org-wide", async () => {
-      const service = ActivityMonitorService.create(
+      const service = ActivityMonitorService.create({
         prisma,
-        getApp().governance.activityMonitor,
-      );
+        repository: getApp().governance.activityMonitor,
+      });
       const page0 = await service.spendByTeam({
         organizationId: primaryOrg.id,
         windowDays: 30,
@@ -708,10 +708,10 @@ describe("ActivityMonitorService — read-side queries against unified trace sto
     });
 
     it("sortDir='asc' inverts the ordering — Org-wide ($0.25) before primary team ($2.00)", async () => {
-      const service = ActivityMonitorService.create(
+      const service = ActivityMonitorService.create({
         prisma,
-        getApp().governance.activityMonitor,
-      );
+        repository: getApp().governance.activityMonitor,
+      });
       const rows = await service.spendByTeam({
         organizationId: primaryOrg.id,
         windowDays: 30,
@@ -724,10 +724,10 @@ describe("ActivityMonitorService — read-side queries against unified trace sto
     });
 
     it("sortBy='lastActivity' desc puts the team with the recent activity first", async () => {
-      const service = ActivityMonitorService.create(
+      const service = ActivityMonitorService.create({
         prisma,
-        getApp().governance.activityMonitor,
-      );
+        repository: getApp().governance.activityMonitor,
+      });
       const rows = await service.spendByTeam({
         organizationId: primaryOrg.id,
         windowDays: 30,
@@ -742,10 +742,10 @@ describe("ActivityMonitorService — read-side queries against unified trace sto
     });
 
     it("sortBy='requests' desc orders by raw request count, not spend", async () => {
-      const service = ActivityMonitorService.create(
+      const service = ActivityMonitorService.create({
         prisma,
-        getApp().governance.activityMonitor,
-      );
+        repository: getApp().governance.activityMonitor,
+      });
       const rows = await service.spendByTeam({
         organizationId: primaryOrg.id,
         windowDays: 30,
@@ -759,10 +759,10 @@ describe("ActivityMonitorService — read-side queries against unified trace sto
     });
 
     it("legacy callers (no pagination/sort args) still get the v1 default — top-N by spend desc", async () => {
-      const service = ActivityMonitorService.create(
+      const service = ActivityMonitorService.create({
         prisma,
-        getApp().governance.activityMonitor,
-      );
+        repository: getApp().governance.activityMonitor,
+      });
       const rows = await service.spendByTeam({
         organizationId: primaryOrg.id,
         windowDays: 30,
@@ -776,10 +776,10 @@ describe("ActivityMonitorService — read-side queries against unified trace sto
 
   describe("when querying ingestionSourcesHealth()", () => {
     it("returns per-source eventsLast24h across pushed and pulled event stores", async () => {
-      const service = ActivityMonitorService.create(
+      const service = ActivityMonitorService.create({
         prisma,
-        getApp().governance.activityMonitor,
-      );
+        repository: getApp().governance.activityMonitor,
+      });
       const rows = await service.ingestionSourcesHealth({
         organizationId: primaryOrg.id,
       });
@@ -794,10 +794,10 @@ describe("ActivityMonitorService — read-side queries against unified trace sto
 
   describe("when querying sourceHealthMetrics() for a single source", () => {
     it("returns 24h/7d/30d event counts + lastSuccessIso", async () => {
-      const service = ActivityMonitorService.create(
+      const service = ActivityMonitorService.create({
         prisma,
-        getApp().governance.activityMonitor,
-      );
+        repository: getApp().governance.activityMonitor,
+      });
       const metrics = await service.sourceHealthMetrics({
         organizationId: primaryOrg.id,
         sourceId: primarySourceId,
@@ -812,10 +812,10 @@ describe("ActivityMonitorService — read-side queries against unified trace sto
 
   describe("when querying eventsForSource() for the trace drill-down list", () => {
     it("returns governance-origin traces matching the sourceId filter", async () => {
-      const service = ActivityMonitorService.create(
+      const service = ActivityMonitorService.create({
         prisma,
-        getApp().governance.activityMonitor,
-      );
+        repository: getApp().governance.activityMonitor,
+      });
       const rows = await service.eventsForSource({
         organizationId: primaryOrg.id,
         sourceId: primarySourceId,
@@ -845,10 +845,10 @@ describe("ActivityMonitorService — read-side queries against unified trace sto
 
   describe("when querying spendOverTime() for the bird's-eye stacked-area chart", () => {
     it("returns dense daily buckets covering windowDays — empty days emit `points: []` so the X axis has no gaps", async () => {
-      const service = ActivityMonitorService.create(
+      const service = ActivityMonitorService.create({
         prisma,
-        getApp().governance.activityMonitor,
-      );
+        repository: getApp().governance.activityMonitor,
+      });
       const result = await service.spendOverTime({
         organizationId: primaryOrg.id,
         windowDays: 30,
@@ -878,10 +878,10 @@ describe("ActivityMonitorService — read-side queries against unified trace sto
     });
 
     it("groups by team — primary team appears in the recent bucket; Org-wide in the 14d-ago bucket", async () => {
-      const service = ActivityMonitorService.create(
+      const service = ActivityMonitorService.create({
         prisma,
-        getApp().governance.activityMonitor,
-      );
+        repository: getApp().governance.activityMonitor,
+      });
       const result = await service.spendOverTime({
         organizationId: primaryOrg.id,
         windowDays: 30,
@@ -916,10 +916,10 @@ describe("ActivityMonitorService — read-side queries against unified trace sto
     });
 
     it("groups by user — alice + bob in recent bucket, carol in 14d-ago bucket", async () => {
-      const service = ActivityMonitorService.create(
+      const service = ActivityMonitorService.create({
         prisma,
-        getApp().governance.activityMonitor,
-      );
+        repository: getApp().governance.activityMonitor,
+      });
       const result = await service.spendOverTime({
         organizationId: primaryOrg.id,
         windowDays: 30,
@@ -946,10 +946,10 @@ describe("ActivityMonitorService — read-side queries against unified trace sto
     });
 
     it("groups by model — claude-sonnet-4 only; app-model is excluded by origin filter", async () => {
-      const service = ActivityMonitorService.create(
+      const service = ActivityMonitorService.create({
         prisma,
-        getApp().governance.activityMonitor,
-      );
+        repository: getApp().governance.activityMonitor,
+      });
       const result = await service.spendOverTime({
         organizationId: primaryOrg.id,
         windowDays: 30,
@@ -965,10 +965,10 @@ describe("ActivityMonitorService — read-side queries against unified trace sto
     });
 
     it("honors TenantId isolation — cross-org $50 spend never appears in primary org's series", async () => {
-      const service = ActivityMonitorService.create(
+      const service = ActivityMonitorService.create({
         prisma,
-        getApp().governance.activityMonitor,
-      );
+        repository: getApp().governance.activityMonitor,
+      });
       const result = await service.spendOverTime({
         organizationId: primaryOrg.id,
         windowDays: 30,
@@ -990,10 +990,10 @@ describe("ActivityMonitorService — read-side queries against unified trace sto
     });
 
     it("orders points within a bucket by spend desc — largest contributor first for stable Recharts stack rendering", async () => {
-      const service = ActivityMonitorService.create(
+      const service = ActivityMonitorService.create({
         prisma,
-        getApp().governance.activityMonitor,
-      );
+        repository: getApp().governance.activityMonitor,
+      });
       const result = await service.spendOverTime({
         organizationId: primaryOrg.id,
         windowDays: 30,
@@ -1017,10 +1017,10 @@ describe("ActivityMonitorService — read-side queries against unified trace sto
         },
       });
       try {
-        const service = ActivityMonitorService.create(
+        const service = ActivityMonitorService.create({
           prisma,
-          getApp().governance.activityMonitor,
-        );
+          repository: getApp().governance.activityMonitor,
+        });
         const result = await service.spendOverTime({
           organizationId: orphan.id,
           windowDays: 7,

--- a/platform/app/ee/governance/services/__tests__/departmentSpend.service.integration.test.ts
+++ b/platform/app/ee/governance/services/__tests__/departmentSpend.service.integration.test.ts
@@ -252,10 +252,10 @@ describe("ActivityMonitorService.spendByDepartment", () => {
   describe("given spend across personal, team, and agent projects", () => {
     /** @scenario Spend by department aggregates across every project in the org */
     it("rolls personal, agent, and unattributed spend up by department across all projects", async () => {
-      const service = ActivityMonitorService.create(
+      const service = ActivityMonitorService.create({
         prisma,
-        getApp().governance.activityMonitor,
-      );
+        repository: getApp().governance.activityMonitor,
+      });
       const rows = await service.spendByDepartment({
         organizationId: org.id,
         windowDays: 7,
@@ -276,10 +276,10 @@ describe("ActivityMonitorService.spendByDepartment", () => {
   describe("given another org with spend under a like-named department", () => {
     /** @scenario Spend-by-department query stays tenant-isolated */
     it("never includes the other org's spend in this org's rollup", async () => {
-      const service = ActivityMonitorService.create(
+      const service = ActivityMonitorService.create({
         prisma,
-        getApp().governance.activityMonitor,
-      );
+        repository: getApp().governance.activityMonitor,
+      });
       const rows = await service.spendByDepartment({
         organizationId: org.id,
         windowDays: 7,
@@ -297,10 +297,10 @@ describe("ActivityMonitorService.spendByDepartment", () => {
   describe("given members with personal spend in different departments", () => {
     /** @scenario Marketing-versus-engineering comparison reads from departments */
     it("shows each department's combined personal and project spend", async () => {
-      const service = ActivityMonitorService.create(
+      const service = ActivityMonitorService.create({
         prisma,
-        getApp().governance.activityMonitor,
-      );
+        repository: getApp().governance.activityMonitor,
+      });
       const rows = await service.spendByDepartment({
         organizationId: org.id,
         windowDays: 7,

--- a/platform/app/ee/governance/services/__tests__/departmentSpend.service.integration.test.ts
+++ b/platform/app/ee/governance/services/__tests__/departmentSpend.service.integration.test.ts
@@ -13,7 +13,7 @@ import type { ClickHouseClient } from "@clickhouse/client";
 import { nanoid } from "nanoid";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import type { Organization } from "~/generated/prisma/client";
-
+import { getApp } from "~/server/app-layer/app";
 import { prisma } from "~/server/db";
 import {
   cleanupTestData,
@@ -252,7 +252,10 @@ describe("ActivityMonitorService.spendByDepartment", () => {
   describe("given spend across personal, team, and agent projects", () => {
     /** @scenario Spend by department aggregates across every project in the org */
     it("rolls personal, agent, and unattributed spend up by department across all projects", async () => {
-      const service = ActivityMonitorService.create(prisma);
+      const service = ActivityMonitorService.create(
+        prisma,
+        getApp().governance.activityMonitor,
+      );
       const rows = await service.spendByDepartment({
         organizationId: org.id,
         windowDays: 7,
@@ -273,7 +276,10 @@ describe("ActivityMonitorService.spendByDepartment", () => {
   describe("given another org with spend under a like-named department", () => {
     /** @scenario Spend-by-department query stays tenant-isolated */
     it("never includes the other org's spend in this org's rollup", async () => {
-      const service = ActivityMonitorService.create(prisma);
+      const service = ActivityMonitorService.create(
+        prisma,
+        getApp().governance.activityMonitor,
+      );
       const rows = await service.spendByDepartment({
         organizationId: org.id,
         windowDays: 7,
@@ -291,7 +297,10 @@ describe("ActivityMonitorService.spendByDepartment", () => {
   describe("given members with personal spend in different departments", () => {
     /** @scenario Marketing-versus-engineering comparison reads from departments */
     it("shows each department's combined personal and project spend", async () => {
-      const service = ActivityMonitorService.create(prisma);
+      const service = ActivityMonitorService.create(
+        prisma,
+        getApp().governance.activityMonitor,
+      );
       const rows = await service.spendByDepartment({
         organizationId: org.id,
         windowDays: 7,

--- a/platform/app/ee/governance/services/activity-monitor/__tests__/activityMonitor.clickhouse.repository.unit.test.ts
+++ b/platform/app/ee/governance/services/activity-monitor/__tests__/activityMonitor.clickhouse.repository.unit.test.ts
@@ -9,36 +9,31 @@
  * 3. Schema drift — if a CH column is renamed, the cast silently succeeds
  *    and the bug surfaces downstream.
  *
- * Each test feeds the mock CH client responses with realistic type
- * variations and asserts the repository returns properly typed values.
+ * Each test builds a repository whose injected resolver hands back a mock
+ * ClickHouse client serving the given rows, through the same constructor
+ * contract production uses.
  */
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { ActivityMonitorClickHouseRepository } from "../activityMonitor.clickhouse.repository";
 
-function mockCh(rows: unknown[]) {
-  return {
+function makeRepo(rows: unknown[]) {
+  const ch = {
     query: vi.fn(async () => ({
       json: async () => rows,
     })),
   } as never;
+  return new ActivityMonitorClickHouseRepository(async () => ch);
 }
 
 describe("ActivityMonitorClickHouseRepository", () => {
-  let repo: ActivityMonitorClickHouseRepository;
-
-  beforeEach(() => {
-    repo = new ActivityMonitorClickHouseRepository();
-  });
-
   describe("when CH returns string-typed numerics (risk #1: silent type mismatch)", () => {
     it("coerces summary spend strings to numbers", async () => {
-      const ch = mockCh([
+      const repo = makeRepo([
         { thisSpend: "1.5", prevSpend: "0.75", thisUsers: "3" },
       ]);
 
       const row = await repo.findSummarySpend({
-        ch,
         tenantId: "t",
         thisStart: 0,
         prevStart: 0,
@@ -51,12 +46,11 @@ describe("ActivityMonitorClickHouseRepository", () => {
     });
 
     it("coerces window count strings to numbers", async () => {
-      const ch = mockCh([
+      const repo = makeRepo([
         { c24: "42", c7: "200", c30: "800", lastMs: "1700000000000" },
       ]);
 
       const row = await repo.findTracedEventWindowCounts({
-        ch,
         tenantId: "t",
         sourceId: "s",
         since24h: 0,
@@ -74,7 +68,7 @@ describe("ActivityMonitorClickHouseRepository", () => {
     });
 
     it("coerces pushed event numeric fields from CH number to typed output", async () => {
-      const ch = mockCh([
+      const repo = makeRepo([
         {
           eventId: "e1",
           eventType: "otel_generic",
@@ -89,7 +83,6 @@ describe("ActivityMonitorClickHouseRepository", () => {
       ]);
 
       const rows = await repo.findPushedEventsForSource({
-        ch,
         tenantId: "t",
         sourceId: "s",
         beforeMs: Date.now(),
@@ -105,12 +98,11 @@ describe("ActivityMonitorClickHouseRepository", () => {
 
   describe("when CH returns nulls (risk #2: null propagation)", () => {
     it("defaults null summary values to 0", async () => {
-      const ch = mockCh([
+      const repo = makeRepo([
         { thisSpend: null, prevSpend: null, thisUsers: null },
       ]);
 
       const row = await repo.findSummarySpend({
-        ch,
         tenantId: "t",
         thisStart: 0,
         prevStart: 0,
@@ -120,7 +112,7 @@ describe("ActivityMonitorClickHouseRepository", () => {
     });
 
     it("defaults null mostUsedTarget to null (preserved nullable)", async () => {
-      const ch = mockCh([
+      const repo = makeRepo([
         {
           actor: "user@test.com",
           spendUsdStr: "1.00",
@@ -131,7 +123,6 @@ describe("ActivityMonitorClickHouseRepository", () => {
       ]);
 
       const rows = await repo.findSpendByUser({
-        ch,
         tenantId: "t",
         windowStart: 0,
         sortBy: "spend",
@@ -144,10 +135,9 @@ describe("ActivityMonitorClickHouseRepository", () => {
     });
 
     it("defaults null window count lastMs to null (preserved nullable)", async () => {
-      const ch = mockCh([{ c24: 0, c7: 0, c30: 0, lastMs: null }]);
+      const repo = makeRepo([{ c24: 0, c7: 0, c30: 0, lastMs: null }]);
 
       const row = await repo.findLoggedEventWindowCounts({
-        ch,
         tenantId: "t",
         sourceId: "s",
         since24h: 0,
@@ -160,10 +150,9 @@ describe("ActivityMonitorClickHouseRepository", () => {
     });
 
     it("returns empty summary when CH returns no rows", async () => {
-      const ch = mockCh([]);
+      const repo = makeRepo([]);
 
       const row = await repo.findSummarySpend({
-        ch,
         tenantId: "t",
         thisStart: 0,
         prevStart: 0,
@@ -173,10 +162,9 @@ describe("ActivityMonitorClickHouseRepository", () => {
     });
 
     it("returns undefined when window count has no rows", async () => {
-      const ch = mockCh([]);
+      const repo = makeRepo([]);
 
       const row = await repo.findPulledEventWindowCounts({
-        ch,
         tenantId: "t",
         sourceId: "s",
         since24h: 0,
@@ -190,13 +178,12 @@ describe("ActivityMonitorClickHouseRepository", () => {
 
   describe("when CH returns unexpected shapes (risk #3: schema drift)", () => {
     it("falls back to zero when summary columns are renamed", async () => {
-      const ch = mockCh([{ wrong_column: "value" }]);
+      const repo = makeRepo([{ wrong_column: "value" }]);
 
       // thisSpend/prevSpend/thisUsers are all chNumeric with .catch(0),
       // so a missing field falls back to 0 rather than throwing.
       // This is intentional: individual field defaults are the first defense.
       const row = await repo.findSummarySpend({
-        ch,
         tenantId: "t",
         thisStart: 0,
         prevStart: 0,
@@ -209,13 +196,12 @@ describe("ActivityMonitorClickHouseRepository", () => {
       // fast via .parse() rather than silently default, proving risk #3
       // (schema drift) is actually caught, not just the per-field
       // defaulting exercised above.
-      const ch = mockCh([
+      const repo = makeRepo([
         { spendUsdStr: "1.00", requests: "5", lastActivityMs: "0" },
       ]);
 
       await expect(
         repo.findSpendByUser({
-          ch,
           tenantId: "t",
           windowStart: 0,
           sortBy: "spend",
@@ -227,12 +213,11 @@ describe("ActivityMonitorClickHouseRepository", () => {
     });
 
     it("catches NaN from garbage numeric input", async () => {
-      const ch = mockCh([
+      const repo = makeRepo([
         { thisSpend: "not-a-number", prevSpend: {}, thisUsers: undefined },
       ]);
 
       const row = await repo.findSummarySpend({
-        ch,
         tenantId: "t",
         thisStart: 0,
         prevStart: 0,
@@ -245,7 +230,7 @@ describe("ActivityMonitorClickHouseRepository", () => {
     });
 
     it("defaults missing optional fields on pushed event rows", async () => {
-      const ch = mockCh([
+      const repo = makeRepo([
         {
           eventId: "e1",
           // eventType, actor, target all missing
@@ -255,7 +240,6 @@ describe("ActivityMonitorClickHouseRepository", () => {
       ]);
 
       const rows = await repo.findPushedEventsForSource({
-        ch,
         tenantId: "t",
         sourceId: "s",
         beforeMs: Date.now(),
@@ -270,7 +254,7 @@ describe("ActivityMonitorClickHouseRepository", () => {
     });
 
     it("defaults missing optional fields on pulled event rows", async () => {
-      const ch = mockCh([
+      const repo = makeRepo([
         {
           eventId: "e1",
           // all optional fields missing
@@ -280,7 +264,6 @@ describe("ActivityMonitorClickHouseRepository", () => {
       ]);
 
       const rows = await repo.findPulledEventsForSource({
-        ch,
         tenantId: "t",
         sourceId: "s",
         beforeMs: Date.now(),
@@ -295,7 +278,7 @@ describe("ActivityMonitorClickHouseRepository", () => {
 
   describe("when CH returns well-typed data (happy path)", () => {
     it("passes through spend-by-user rows unchanged", async () => {
-      const ch = mockCh([
+      const repo = makeRepo([
         {
           actor: "alice@acme.com",
           spendUsdStr: "42.50",
@@ -306,7 +289,6 @@ describe("ActivityMonitorClickHouseRepository", () => {
       ]);
 
       const rows = await repo.findSpendByUser({
-        ch,
         tenantId: "t",
         windowStart: 0,
         sortBy: "spend",
@@ -327,13 +309,12 @@ describe("ActivityMonitorClickHouseRepository", () => {
     });
 
     it("passes through source event counts", async () => {
-      const ch = mockCh([
+      const repo = makeRepo([
         { sourceId: "src-1", c: "42" },
         { sourceId: "src-2", c: "7" },
       ]);
 
       const rows = await repo.countTracedEventsBySource({
-        ch,
         tenantId: "t",
         sourceIds: ["src-1", "src-2"],
         since: 0,
@@ -344,7 +325,7 @@ describe("ActivityMonitorClickHouseRepository", () => {
     });
 
     it("passes through spend-over-time rows", async () => {
-      const ch = mockCh([
+      const repo = makeRepo([
         {
           bucketMs: "1700000000000",
           groupKey: "team-1",
@@ -353,7 +334,6 @@ describe("ActivityMonitorClickHouseRepository", () => {
       ]);
 
       const rows = await repo.findSpendOverTime({
-        ch,
         tenantId: "t",
         windowStart: 0,
         groupBy: "team",

--- a/platform/app/ee/governance/services/activity-monitor/__tests__/activityMonitorPulledEvents.unit.test.ts
+++ b/platform/app/ee/governance/services/activity-monitor/__tests__/activityMonitorPulledEvents.unit.test.ts
@@ -16,6 +16,7 @@ vi.mock("~/server/app-layer/app", () => {
   return { getApp: app, tryGetApp: app };
 });
 
+import { ActivityMonitorClickHouseRepository } from "../activityMonitor.clickhouse.repository";
 import { ActivityMonitorService } from "../activityMonitor.service";
 
 describe("ActivityMonitorService pulled and pushed source events", () => {
@@ -76,7 +77,10 @@ describe("ActivityMonitorService pulled and pushed source events", () => {
     const prisma = {
       project: { findFirst: vi.fn(async () => ({ id: "gov-project" })) },
     };
-    const service = ActivityMonitorService.create(prisma as never);
+    const service = ActivityMonitorService.create(
+      prisma as never,
+      new ActivityMonitorClickHouseRepository(async () => ({ query }) as never),
+    );
 
     const rows = await service.eventsForSource({
       organizationId: "org",
@@ -136,7 +140,10 @@ describe("ActivityMonitorService pulled and pushed source events", () => {
     const prisma = {
       project: { findFirst: vi.fn(async () => ({ id: "gov-project" })) },
     };
-    const service = ActivityMonitorService.create(prisma as never);
+    const service = ActivityMonitorService.create(
+      prisma as never,
+      new ActivityMonitorClickHouseRepository(async () => ({ query }) as never),
+    );
 
     const rows = await service.eventsForSource({
       organizationId: "org",
@@ -198,7 +205,10 @@ describe("ActivityMonitorService pulled and pushed source events", () => {
     const prisma = {
       project: { findFirst: vi.fn(async () => ({ id: "gov-project" })) },
     };
-    const service = ActivityMonitorService.create(prisma as never);
+    const service = ActivityMonitorService.create(
+      prisma as never,
+      new ActivityMonitorClickHouseRepository(async () => ({ query }) as never),
+    );
 
     const rows = await service.eventsForSource({
       organizationId: "org",
@@ -220,7 +230,10 @@ describe("ActivityMonitorService pulled and pushed source events", () => {
     const prisma = {
       project: { findFirst: vi.fn(async () => ({ id: "gov-project" })) },
     };
-    const service = ActivityMonitorService.create(prisma as never);
+    const service = ActivityMonitorService.create(
+      prisma as never,
+      new ActivityMonitorClickHouseRepository(async () => ({ query }) as never),
+    );
 
     const metrics = await service.sourceHealthMetrics({
       organizationId: "org",

--- a/platform/app/ee/governance/services/activity-monitor/__tests__/activityMonitorPulledEvents.unit.test.ts
+++ b/platform/app/ee/governance/services/activity-monitor/__tests__/activityMonitorPulledEvents.unit.test.ts
@@ -77,10 +77,12 @@ describe("ActivityMonitorService pulled and pushed source events", () => {
     const prisma = {
       project: { findFirst: vi.fn(async () => ({ id: "gov-project" })) },
     };
-    const service = ActivityMonitorService.create(
-      prisma as never,
-      new ActivityMonitorClickHouseRepository(async () => ({ query }) as never),
-    );
+    const service = ActivityMonitorService.create({
+      prisma: prisma as never,
+      repository: new ActivityMonitorClickHouseRepository(
+        async () => ({ query }) as never,
+      ),
+    });
 
     const rows = await service.eventsForSource({
       organizationId: "org",
@@ -140,10 +142,12 @@ describe("ActivityMonitorService pulled and pushed source events", () => {
     const prisma = {
       project: { findFirst: vi.fn(async () => ({ id: "gov-project" })) },
     };
-    const service = ActivityMonitorService.create(
-      prisma as never,
-      new ActivityMonitorClickHouseRepository(async () => ({ query }) as never),
-    );
+    const service = ActivityMonitorService.create({
+      prisma: prisma as never,
+      repository: new ActivityMonitorClickHouseRepository(
+        async () => ({ query }) as never,
+      ),
+    });
 
     const rows = await service.eventsForSource({
       organizationId: "org",
@@ -205,10 +209,12 @@ describe("ActivityMonitorService pulled and pushed source events", () => {
     const prisma = {
       project: { findFirst: vi.fn(async () => ({ id: "gov-project" })) },
     };
-    const service = ActivityMonitorService.create(
-      prisma as never,
-      new ActivityMonitorClickHouseRepository(async () => ({ query }) as never),
-    );
+    const service = ActivityMonitorService.create({
+      prisma: prisma as never,
+      repository: new ActivityMonitorClickHouseRepository(
+        async () => ({ query }) as never,
+      ),
+    });
 
     const rows = await service.eventsForSource({
       organizationId: "org",
@@ -230,10 +236,12 @@ describe("ActivityMonitorService pulled and pushed source events", () => {
     const prisma = {
       project: { findFirst: vi.fn(async () => ({ id: "gov-project" })) },
     };
-    const service = ActivityMonitorService.create(
-      prisma as never,
-      new ActivityMonitorClickHouseRepository(async () => ({ query }) as never),
-    );
+    const service = ActivityMonitorService.create({
+      prisma: prisma as never,
+      repository: new ActivityMonitorClickHouseRepository(
+        async () => ({ query }) as never,
+      ),
+    });
 
     const metrics = await service.sourceHealthMetrics({
       organizationId: "org",

--- a/platform/app/ee/governance/services/activity-monitor/__tests__/moneyTypeLossless.unit.test.ts
+++ b/platform/app/ee/governance/services/activity-monitor/__tests__/moneyTypeLossless.unit.test.ts
@@ -26,6 +26,7 @@ vi.mock("~/server/app-layer/app", () => {
   return { getApp: app, tryGetApp: app };
 });
 
+import { ActivityMonitorClickHouseRepository } from "../activityMonitor.clickhouse.repository";
 import { ActivityMonitorService } from "../activityMonitor.service";
 
 /**
@@ -66,7 +67,12 @@ describe("money type lossless round-trip", () => {
       const prisma = {
         project: { findFirst: vi.fn(async () => ({ id: "gov-project" })) },
       };
-      const service = ActivityMonitorService.create(prisma as never);
+      const service = ActivityMonitorService.create(
+        prisma as never,
+        new ActivityMonitorClickHouseRepository(
+          async () => ({ query }) as never,
+        ),
+      );
 
       const rows = await service.eventsForSource({
         organizationId: "org",
@@ -113,7 +119,12 @@ describe("money type lossless round-trip", () => {
       const prisma = {
         project: { findFirst: vi.fn(async () => ({ id: "gov-project" })) },
       };
-      const service = ActivityMonitorService.create(prisma as never);
+      const service = ActivityMonitorService.create(
+        prisma as never,
+        new ActivityMonitorClickHouseRepository(
+          async () => ({ query }) as never,
+        ),
+      );
 
       const rows = await service.eventsForSource({
         organizationId: "org",
@@ -143,7 +154,12 @@ describe("money type lossless round-trip", () => {
       const prisma = {
         project: { findFirst: vi.fn(async () => ({ id: "gov-project" })) },
       };
-      const service = ActivityMonitorService.create(prisma as never);
+      const service = ActivityMonitorService.create(
+        prisma as never,
+        new ActivityMonitorClickHouseRepository(
+          async () => ({ query }) as never,
+        ),
+      );
 
       const rows = await service.spendByUser({
         organizationId: "org",
@@ -183,7 +199,12 @@ describe("money type lossless round-trip", () => {
           findMany: vi.fn(async () => [{ id: "dep-1", name: "Engineering" }]),
         },
       };
-      const service = ActivityMonitorService.create(prisma as never);
+      const service = ActivityMonitorService.create(
+        prisma as never,
+        new ActivityMonitorClickHouseRepository(
+          async () => ({ query }) as never,
+        ),
+      );
 
       const rows = await service.spendByDepartment({
         organizationId: "org",

--- a/platform/app/ee/governance/services/activity-monitor/__tests__/moneyTypeLossless.unit.test.ts
+++ b/platform/app/ee/governance/services/activity-monitor/__tests__/moneyTypeLossless.unit.test.ts
@@ -67,12 +67,12 @@ describe("money type lossless round-trip", () => {
       const prisma = {
         project: { findFirst: vi.fn(async () => ({ id: "gov-project" })) },
       };
-      const service = ActivityMonitorService.create(
-        prisma as never,
-        new ActivityMonitorClickHouseRepository(
+      const service = ActivityMonitorService.create({
+        prisma: prisma as never,
+        repository: new ActivityMonitorClickHouseRepository(
           async () => ({ query }) as never,
         ),
-      );
+      });
 
       const rows = await service.eventsForSource({
         organizationId: "org",
@@ -119,12 +119,12 @@ describe("money type lossless round-trip", () => {
       const prisma = {
         project: { findFirst: vi.fn(async () => ({ id: "gov-project" })) },
       };
-      const service = ActivityMonitorService.create(
-        prisma as never,
-        new ActivityMonitorClickHouseRepository(
+      const service = ActivityMonitorService.create({
+        prisma: prisma as never,
+        repository: new ActivityMonitorClickHouseRepository(
           async () => ({ query }) as never,
         ),
-      );
+      });
 
       const rows = await service.eventsForSource({
         organizationId: "org",
@@ -154,12 +154,12 @@ describe("money type lossless round-trip", () => {
       const prisma = {
         project: { findFirst: vi.fn(async () => ({ id: "gov-project" })) },
       };
-      const service = ActivityMonitorService.create(
-        prisma as never,
-        new ActivityMonitorClickHouseRepository(
+      const service = ActivityMonitorService.create({
+        prisma: prisma as never,
+        repository: new ActivityMonitorClickHouseRepository(
           async () => ({ query }) as never,
         ),
-      );
+      });
 
       const rows = await service.spendByUser({
         organizationId: "org",
@@ -199,12 +199,12 @@ describe("money type lossless round-trip", () => {
           findMany: vi.fn(async () => [{ id: "dep-1", name: "Engineering" }]),
         },
       };
-      const service = ActivityMonitorService.create(
-        prisma as never,
-        new ActivityMonitorClickHouseRepository(
+      const service = ActivityMonitorService.create({
+        prisma: prisma as never,
+        repository: new ActivityMonitorClickHouseRepository(
           async () => ({ query }) as never,
         ),
-      );
+      });
 
       const rows = await service.spendByDepartment({
         organizationId: "org",

--- a/platform/app/ee/governance/services/activity-monitor/activityMonitor.clickhouse.repository.ts
+++ b/platform/app/ee/governance/services/activity-monitor/activityMonitor.clickhouse.repository.ts
@@ -15,7 +15,7 @@
  * Pairs with: activityMonitor.service.ts (orchestration + PG queries)
  * Spec: specs/ai-gateway/governance/folds.feature
  */
-import type { ClickHouseClient } from "@clickhouse/client";
+import type { ClickHouseClientResolver } from "~/server/clickhouse/clickhouseClient";
 import type {
   PulledEventChRow,
   PushedEventChRow,
@@ -35,12 +35,17 @@ import { ActivityMonitorHealthClickHouseRepository } from "./activityMonitor.hea
 import { ActivityMonitorSpendClickHouseRepository } from "./activityMonitor.spend.clickhouse.repository";
 
 export class ActivityMonitorClickHouseRepository {
-  private readonly spend = new ActivityMonitorSpendClickHouseRepository();
-  private readonly events = new ActivityMonitorEventsClickHouseRepository();
-  private readonly health = new ActivityMonitorHealthClickHouseRepository();
+  private readonly spend: ActivityMonitorSpendClickHouseRepository;
+  private readonly events: ActivityMonitorEventsClickHouseRepository;
+  private readonly health: ActivityMonitorHealthClickHouseRepository;
+
+  constructor(resolveClient: ClickHouseClientResolver) {
+    this.spend = new ActivityMonitorSpendClickHouseRepository(resolveClient);
+    this.events = new ActivityMonitorEventsClickHouseRepository(resolveClient);
+    this.health = new ActivityMonitorHealthClickHouseRepository(resolveClient);
+  }
 
   findSummarySpend(params: {
-    ch: ClickHouseClient;
     tenantId: string;
     thisStart: number;
     prevStart: number;
@@ -49,7 +54,6 @@ export class ActivityMonitorClickHouseRepository {
   }
 
   findSpendByUser(params: {
-    ch: ClickHouseClient;
     tenantId: string;
     windowStart: number;
     sortBy: SpendSortField;
@@ -61,7 +65,6 @@ export class ActivityMonitorClickHouseRepository {
   }
 
   findSpendByDepartment(params: {
-    ch: ClickHouseClient;
     tenantIds: string[];
     windowStart: number;
   }): Promise<SpendByDepartmentChRow[]> {
@@ -69,7 +72,6 @@ export class ActivityMonitorClickHouseRepository {
   }
 
   findSpendByTeamSource(params: {
-    ch: ClickHouseClient;
     tenantId: string;
     thisStart: number;
     prevStart: number;
@@ -78,7 +80,6 @@ export class ActivityMonitorClickHouseRepository {
   }
 
   findSpendOverTime(params: {
-    ch: ClickHouseClient;
     tenantId: string;
     windowStart: number;
     groupBy: SpendOverTimeGroupBy;
@@ -87,7 +88,6 @@ export class ActivityMonitorClickHouseRepository {
   }
 
   countTracedEventsBySource(params: {
-    ch: ClickHouseClient;
     tenantId: string;
     sourceIds: string[];
     since: number;
@@ -96,7 +96,6 @@ export class ActivityMonitorClickHouseRepository {
   }
 
   countLoggedEventsBySource(params: {
-    ch: ClickHouseClient;
     tenantId: string;
     sourceIds: string[];
     since: number;
@@ -105,7 +104,6 @@ export class ActivityMonitorClickHouseRepository {
   }
 
   countPulledEventsBySource(params: {
-    ch: ClickHouseClient;
     tenantId: string;
     sourceIds: string[];
     since: number;
@@ -114,7 +112,6 @@ export class ActivityMonitorClickHouseRepository {
   }
 
   findPushedEventsForSource(params: {
-    ch: ClickHouseClient;
     tenantId: string;
     sourceId: string;
     beforeMs: number;
@@ -124,7 +121,6 @@ export class ActivityMonitorClickHouseRepository {
   }
 
   findPulledEventsForSource(params: {
-    ch: ClickHouseClient;
     tenantId: string;
     sourceId: string;
     beforeMs: number;
@@ -134,7 +130,6 @@ export class ActivityMonitorClickHouseRepository {
   }
 
   findTracedEventWindowCounts(params: {
-    ch: ClickHouseClient;
     tenantId: string;
     sourceId: string;
     since24h: number;
@@ -145,7 +140,6 @@ export class ActivityMonitorClickHouseRepository {
   }
 
   findLoggedEventWindowCounts(params: {
-    ch: ClickHouseClient;
     tenantId: string;
     sourceId: string;
     since24h: number;
@@ -156,7 +150,6 @@ export class ActivityMonitorClickHouseRepository {
   }
 
   findPulledEventWindowCounts(params: {
-    ch: ClickHouseClient;
     tenantId: string;
     sourceId: string;
     since24h: number;

--- a/platform/app/ee/governance/services/activity-monitor/activityMonitor.events.clickhouse.repository.ts
+++ b/platform/app/ee/governance/services/activity-monitor/activityMonitor.events.clickhouse.repository.ts
@@ -11,7 +11,7 @@
  * Pairs with: activityMonitor.service.ts (orchestration + PG queries)
  * Spec: specs/ai-gateway/governance/folds.feature
  */
-import type { ClickHouseClient } from "@clickhouse/client";
+import type { ClickHouseClientResolver } from "~/server/clickhouse/clickhouseClient";
 
 import {
   ATTR_INGESTION_SOURCE_ID,
@@ -28,18 +28,19 @@ import {
 } from "./activityMonitor.clickhouse.schemas";
 
 export class ActivityMonitorEventsClickHouseRepository {
+  constructor(private readonly resolveClient: ClickHouseClientResolver) {}
+
   /** Traced-event count per source, from `trace_summaries`. */
   async countTracedEventsBySource({
-    ch,
     tenantId,
     sourceIds,
     since,
   }: {
-    ch: ClickHouseClient;
     tenantId: string;
     sourceIds: string[];
     since: number;
   }): Promise<SourceEventCountChRow[]> {
+    const ch = await this.resolveClient(tenantId);
     const result = await ch.query({
       query: `
         SELECT ts.Attributes[{sourceKey:String}] AS sourceId, toString(count()) AS c
@@ -72,16 +73,15 @@ export class ActivityMonitorEventsClickHouseRepository {
 
   /** Logged-record count per source, from `stored_log_records`. */
   async countLoggedEventsBySource({
-    ch,
     tenantId,
     sourceIds,
     since,
   }: {
-    ch: ClickHouseClient;
     tenantId: string;
     sourceIds: string[];
     since: number;
   }): Promise<SourceEventCountChRow[]> {
+    const ch = await this.resolveClient(tenantId);
     const result = await ch.query({
       query: `
         SELECT lr.Attributes[{sourceKey:String}] AS sourceId, toString(count()) AS c
@@ -107,16 +107,15 @@ export class ActivityMonitorEventsClickHouseRepository {
 
   /** Pulled OCSF-event count per source, from `governance_ocsf_events`. */
   async countPulledEventsBySource({
-    ch,
     tenantId,
     sourceIds,
     since,
   }: {
-    ch: ClickHouseClient;
     tenantId: string;
     sourceIds: string[];
     since: number;
   }): Promise<SourceEventCountChRow[]> {
+    const ch = await this.resolveClient(tenantId);
     const result = await ch.query({
       query: `
         SELECT SourceId AS sourceId, toString(count()) AS c
@@ -147,18 +146,17 @@ export class ActivityMonitorEventsClickHouseRepository {
    * cursor-paged via `beforeMs`.
    */
   async findPushedEventsForSource({
-    ch,
     tenantId,
     sourceId,
     beforeMs,
     limit,
   }: {
-    ch: ClickHouseClient;
     tenantId: string;
     sourceId: string;
     beforeMs: number;
     limit: number;
   }): Promise<PushedEventChRow[]> {
+    const ch = await this.resolveClient(tenantId);
     const result = await ch.query({
       query: `
         SELECT
@@ -207,18 +205,17 @@ export class ActivityMonitorEventsClickHouseRepository {
    * cursor-paged via `beforeMs`.
    */
   async findPulledEventsForSource({
-    ch,
     tenantId,
     sourceId,
     beforeMs,
     limit,
   }: {
-    ch: ClickHouseClient;
     tenantId: string;
     sourceId: string;
     beforeMs: number;
     limit: number;
   }): Promise<PulledEventChRow[]> {
+    const ch = await this.resolveClient(tenantId);
     const result = await ch.query({
       query: `
         SELECT

--- a/platform/app/ee/governance/services/activity-monitor/activityMonitor.health.clickhouse.repository.ts
+++ b/platform/app/ee/governance/services/activity-monitor/activityMonitor.health.clickhouse.repository.ts
@@ -10,7 +10,7 @@
  * Pairs with: activityMonitor.service.ts (orchestration + PG queries)
  * Spec: specs/ai-gateway/governance/folds.feature
  */
-import type { ClickHouseClient } from "@clickhouse/client";
+import type { ClickHouseClientResolver } from "~/server/clickhouse/clickhouseClient";
 
 import {
   ATTR_INGESTION_SOURCE_ID,
@@ -21,22 +21,23 @@ import {
 } from "./activityMonitor.clickhouse.schemas";
 
 export class ActivityMonitorHealthClickHouseRepository {
+  constructor(private readonly resolveClient: ClickHouseClientResolver) {}
+
   /** Traced-event window counts (24h/7d/30d) for one source, from `trace_summaries`. */
   async findTracedEventWindowCounts({
-    ch,
     tenantId,
     sourceId,
     since24h,
     since7d,
     since30d,
   }: {
-    ch: ClickHouseClient;
     tenantId: string;
     sourceId: string;
     since24h: number;
     since7d: number;
     since30d: number;
   }): Promise<WindowCountChRow | undefined> {
+    const ch = await this.resolveClient(tenantId);
     const result = await ch.query({
       query: `
         SELECT
@@ -75,20 +76,19 @@ export class ActivityMonitorHealthClickHouseRepository {
 
   /** Logged-record window counts (24h/7d/30d) for one source, from `stored_log_records`. */
   async findLoggedEventWindowCounts({
-    ch,
     tenantId,
     sourceId,
     since24h,
     since7d,
     since30d,
   }: {
-    ch: ClickHouseClient;
     tenantId: string;
     sourceId: string;
     since24h: number;
     since7d: number;
     since30d: number;
   }): Promise<WindowCountChRow | undefined> {
+    const ch = await this.resolveClient(tenantId);
     const result = await ch.query({
       query: `
         SELECT
@@ -120,20 +120,19 @@ export class ActivityMonitorHealthClickHouseRepository {
 
   /** Pulled OCSF-event window counts (24h/7d/30d) for one source. */
   async findPulledEventWindowCounts({
-    ch,
     tenantId,
     sourceId,
     since24h,
     since7d,
     since30d,
   }: {
-    ch: ClickHouseClient;
     tenantId: string;
     sourceId: string;
     since24h: number;
     since7d: number;
     since30d: number;
   }): Promise<WindowCountChRow | undefined> {
+    const ch = await this.resolveClient(tenantId);
     const result = await ch.query({
       query: `
         SELECT

--- a/platform/app/ee/governance/services/activity-monitor/activityMonitor.service.ts
+++ b/platform/app/ee/governance/services/activity-monitor/activityMonitor.service.ts
@@ -383,21 +383,33 @@ function emptyDenseBuckets(
 // ---------------------------------------------------------------------------
 
 export class ActivityMonitorService {
-  constructor(
-    private readonly prisma: PrismaClient,
-    /**
-     * The activity-monitor read side, from the App. `undefined` on a
-     * deployment without ClickHouse — every method degrades to its
-     * empty-state shape, same as the pre-repository "no client" fallback.
-     */
-    private readonly repository?: ActivityMonitorClickHouseRepository,
-  ) {}
+  private readonly prisma: PrismaClient;
+  /**
+   * The activity-monitor read side, from the App. `undefined` on a
+   * deployment without ClickHouse — every method degrades to its
+   * empty-state shape, same as the pre-repository "no client" fallback.
+   */
+  private readonly repository?: ActivityMonitorClickHouseRepository;
 
-  static create(
-    prisma: PrismaClient,
-    repository?: ActivityMonitorClickHouseRepository,
-  ): ActivityMonitorService {
-    return new ActivityMonitorService(prisma, repository);
+  constructor({
+    prisma,
+    repository,
+  }: {
+    prisma: PrismaClient;
+    repository?: ActivityMonitorClickHouseRepository;
+  }) {
+    this.prisma = prisma;
+    this.repository = repository;
+  }
+
+  static create({
+    prisma,
+    repository,
+  }: {
+    prisma: PrismaClient;
+    repository?: ActivityMonitorClickHouseRepository;
+  }): ActivityMonitorService {
+    return new ActivityMonitorService({ prisma, repository });
   }
 
   /**

--- a/platform/app/ee/governance/services/activity-monitor/activityMonitor.service.ts
+++ b/platform/app/ee/governance/services/activity-monitor/activityMonitor.service.ts
@@ -31,11 +31,9 @@
  *   - specs/ai-gateway/governance/architecture-invariants.feature
  *     (single trace store, reserved namespaces)
  */
-import type { ClickHouseClient } from "@clickhouse/client";
 import { z } from "zod";
 import type { PrismaClient } from "~/generated/prisma/client";
 
-import { tryGetApp } from "~/server/app-layer/app";
 import {
   nanoUsdToDecimalString,
   usdToNanoUsd,
@@ -45,7 +43,7 @@ import {
   UNASSIGNED_DEPARTMENT,
 } from "../department/departmentAttribution";
 import { PROJECT_KIND } from "../governanceProject.service";
-import { ActivityMonitorClickHouseRepository } from "./activityMonitor.clickhouse.repository";
+import type { ActivityMonitorClickHouseRepository } from "./activityMonitor.clickhouse.repository";
 import type {
   PulledEventChRow,
   PushedEventChRow,
@@ -385,12 +383,21 @@ function emptyDenseBuckets(
 // ---------------------------------------------------------------------------
 
 export class ActivityMonitorService {
-  private readonly repo = new ActivityMonitorClickHouseRepository();
+  constructor(
+    private readonly prisma: PrismaClient,
+    /**
+     * The activity-monitor read side, from the App. `undefined` on a
+     * deployment without ClickHouse — every method degrades to its
+     * empty-state shape, same as the pre-repository "no client" fallback.
+     */
+    private readonly repository?: ActivityMonitorClickHouseRepository,
+  ) {}
 
-  constructor(private readonly prisma: PrismaClient) {}
-
-  static create(prisma: PrismaClient): ActivityMonitorService {
-    return new ActivityMonitorService(prisma);
+  static create(
+    prisma: PrismaClient,
+    repository?: ActivityMonitorClickHouseRepository,
+  ): ActivityMonitorService {
+    return new ActivityMonitorService(prisma, repository);
   }
 
   /**
@@ -410,14 +417,6 @@ export class ActivityMonitorService {
       select: { id: true },
     });
     return project?.id ?? null;
-  }
-
-  private async getClickhouse(
-    organizationId: string,
-  ): Promise<ClickHouseClient | null> {
-    const app = tryGetApp();
-    if (!app?.clickhouse.enabled) return null;
-    return app.clickhouse.resolveOrganizationClient(organizationId);
   }
 
   // -----------------------------------------------------------------------
@@ -440,9 +439,7 @@ export class ActivityMonitorService {
     if (!govProjectId) {
       return { ...EMPTY_SUMMARY, openAnomalyCount, anomalyBreakdown };
     }
-
-    const ch = await this.getClickhouse(input.organizationId);
-    if (!ch) {
+    if (!this.repository) {
       return { ...EMPTY_SUMMARY, openAnomalyCount, anomalyBreakdown };
     }
 
@@ -451,8 +448,7 @@ export class ActivityMonitorService {
     const thisWindowStart = now - windowMs;
     const previousWindowStart = now - 2 * windowMs;
 
-    const row = await this.repo.findSummarySpend({
-      ch,
+    const row = await this.repository.findSummarySpend({
       tenantId: govProjectId,
       thisStart: thisWindowStart,
       prevStart: previousWindowStart,
@@ -503,15 +499,12 @@ export class ActivityMonitorService {
   }): Promise<SpendByUserRow[]> {
     const govProjectId = await this.resolveGovProjectId(input.organizationId);
     if (!govProjectId) return [];
-
-    const ch = await this.getClickhouse(input.organizationId);
-    if (!ch) return [];
+    if (!this.repository) return [];
 
     const now = Date.now();
     const windowMs = input.windowDays * 24 * 60 * 60 * 1000;
 
-    const rows = await this.repo.findSpendByUser({
-      ch,
+    const rows = await this.repository.findSpendByUser({
       tenantId: govProjectId,
       windowStart: now - windowMs,
       sortBy: input.sortBy ?? "spend",
@@ -569,9 +562,7 @@ export class ActivityMonitorService {
       select: { id: true, departmentId: true },
     });
     if (projects.length === 0) return [];
-
-    const ch = await this.getClickhouse(input.organizationId);
-    if (!ch) return [];
+    if (!this.repository) return [];
 
     const projectDepartmentById = new Map(
       projects.map((p) => [p.id, p.departmentId] as const),
@@ -587,8 +578,7 @@ export class ActivityMonitorService {
     const now = Date.now();
     const windowStart = now - input.windowDays * 24 * 60 * 60 * 1000;
 
-    const rows = await this.repo.findSpendByDepartment({
-      ch,
+    const rows = await this.repository.findSpendByDepartment({
       tenantIds,
       windowStart,
     });
@@ -740,20 +730,17 @@ export class ActivityMonitorService {
     const govProjectId = await this.resolveGovProjectId(input.organizationId);
     if (!govProjectId) return [];
 
-    const ch = await this.getClickhouse(input.organizationId);
-    if (!ch) return [];
-
     const now = Date.now();
     const windowMs = input.windowDays * 24 * 60 * 60 * 1000;
     const limit = input.limit ?? 50;
     const offset = Math.max(0, input.offset ?? 0);
     const sortBy = input.sortBy ?? "spend";
     const sortDir = input.sortDir ?? "desc";
+    if (!this.repository) return [];
 
     const previousWindowStart = now - 2 * windowMs;
 
-    const sourceRows = await this.repo.findSpendByTeamSource({
-      ch,
+    const sourceRows = await this.repository.findSpendByTeamSource({
       tenantId: govProjectId,
       thisStart: now - windowMs,
       prevStart: previousWindowStart,
@@ -885,13 +872,11 @@ export class ActivityMonitorService {
       return { buckets: emptyDenseBuckets(windowStart, windowDays) };
     }
 
-    const ch = await this.getClickhouse(input.organizationId);
-    if (!ch) {
+    if (!this.repository) {
       return { buckets: emptyDenseBuckets(windowStart, windowDays) };
     }
 
-    const rows = await this.repo.findSpendOverTime({
-      ch,
+    const rows = await this.repository.findSpendOverTime({
       tenantId: govProjectId,
       windowStart,
       groupBy: input.groupBy,
@@ -1055,29 +1040,23 @@ export class ActivityMonitorService {
     if (sources.length === 0) return [];
 
     const govProjectId = await this.resolveGovProjectId(input.organizationId);
-    const ch = govProjectId
-      ? await this.getClickhouse(input.organizationId)
-      : null;
 
     const eventsBySource = new Map<string, number>();
-    if (ch && govProjectId) {
+    if (this.repository && govProjectId) {
       const sourceIds = sources.map((s) => s.id);
       const since = Date.now() - 24 * 60 * 60 * 1000;
       const counts = await Promise.all([
-        this.repo.countTracedEventsBySource({
-          ch,
+        this.repository.countTracedEventsBySource({
           tenantId: govProjectId,
           sourceIds,
           since,
         }),
-        this.repo.countLoggedEventsBySource({
-          ch,
+        this.repository.countLoggedEventsBySource({
           tenantId: govProjectId,
           sourceIds,
           since,
         }),
-        this.repo.countPulledEventsBySource({
-          ch,
+        this.repository.countPulledEventsBySource({
           tenantId: govProjectId,
           sourceIds,
           since,
@@ -1113,9 +1092,7 @@ export class ActivityMonitorService {
   }): Promise<ActivityEventDetailRow[]> {
     const govProjectId = await this.resolveGovProjectId(input.organizationId);
     if (!govProjectId) return [];
-
-    const ch = await this.getClickhouse(input.organizationId);
-    if (!ch) return [];
+    if (!this.repository) return [];
 
     const limit = input.limit ?? 50;
     const parsedBeforeMs = input.beforeIso
@@ -1126,18 +1103,16 @@ export class ActivityMonitorService {
       : Date.now();
 
     const [pushedEvents, pulledEvents] = await Promise.all([
-      this.repo
+      this.repository
         .findPushedEventsForSource({
-          ch,
           tenantId: govProjectId,
           sourceId: input.sourceId,
           beforeMs,
           limit,
         })
         .then((rows) => rows.map(toPushedEvent)),
-      this.repo
+      this.repository
         .findPulledEventsForSource({
-          ch,
           tenantId: govProjectId,
           sourceId: input.sourceId,
           beforeMs,
@@ -1172,14 +1147,11 @@ export class ActivityMonitorService {
   }): Promise<SourceHealthMetrics> {
     const govProjectId = await this.resolveGovProjectId(input.organizationId);
     if (!govProjectId) return emptySourceHealthMetrics();
-
-    const ch = await this.getClickhouse(input.organizationId);
-    if (!ch) return emptySourceHealthMetrics();
+    if (!this.repository) return emptySourceHealthMetrics();
 
     const now = Date.now();
     const day = 24 * 60 * 60 * 1000;
     const windowParams = {
-      ch,
       tenantId: govProjectId,
       sourceId: input.sourceId,
       since24h: now - day,
@@ -1188,9 +1160,9 @@ export class ActivityMonitorService {
     };
 
     const windows = await Promise.all([
-      this.repo.findTracedEventWindowCounts(windowParams),
-      this.repo.findLoggedEventWindowCounts(windowParams),
-      this.repo.findPulledEventWindowCounts(windowParams),
+      this.repository.findTracedEventWindowCounts(windowParams),
+      this.repository.findLoggedEventWindowCounts(windowParams),
+      this.repository.findPulledEventWindowCounts(windowParams),
     ]);
 
     const total = (pick: (row: WindowCountChRow) => number) =>

--- a/platform/app/ee/governance/services/activity-monitor/activityMonitor.spend.clickhouse.repository.ts
+++ b/platform/app/ee/governance/services/activity-monitor/activityMonitor.spend.clickhouse.repository.ts
@@ -11,7 +11,7 @@
  * Pairs with: activityMonitor.service.ts (orchestration + PG queries)
  * Spec: specs/ai-gateway/governance/folds.feature
  */
-import type { ClickHouseClient } from "@clickhouse/client";
+import type { ClickHouseClientResolver } from "~/server/clickhouse/clickhouseClient";
 
 import {
   ATTR_INGESTION_SOURCE_ID,
@@ -36,21 +36,22 @@ import {
 } from "./activityMonitor.clickhouse.schemas";
 
 export class ActivityMonitorSpendClickHouseRepository {
+  constructor(private readonly resolveClient: ClickHouseClientResolver) {}
+
   /**
    * Summary aggregation: total spend in current + previous windows, active
    * user count. Returns a single row (CH aggregates always produce one).
    */
   async findSummarySpend({
-    ch,
     tenantId,
     thisStart,
     prevStart,
   }: {
-    ch: ClickHouseClient;
     tenantId: string;
     thisStart: number;
     prevStart: number;
   }): Promise<SummarySpendChRow> {
+    const ch = await this.resolveClient(tenantId);
     const result = await ch.query({
       query: `
         SELECT
@@ -99,7 +100,6 @@ export class ActivityMonitorSpendClickHouseRepository {
    * subquery's Float64 spendUsd column.
    */
   async findSpendByUser({
-    ch,
     tenantId,
     windowStart,
     sortBy,
@@ -107,7 +107,6 @@ export class ActivityMonitorSpendClickHouseRepository {
     limit,
     offset,
   }: {
-    ch: ClickHouseClient;
     tenantId: string;
     windowStart: number;
     sortBy: SpendSortField;
@@ -115,6 +114,7 @@ export class ActivityMonitorSpendClickHouseRepository {
     limit: number;
     offset: number;
   }): Promise<SpendByUserChRow[]> {
+    const ch = await this.resolveClient(tenantId);
     // Fails closed: SORT_FIELD_TO_AGG_EXPR is Record<SpendSortField, string>
     // so this is exhaustive at compile time, but sortBy crosses a tRPC
     // boundary — an erased/loosened type upstream must never turn into an
@@ -174,14 +174,15 @@ export class ActivityMonitorSpendClickHouseRepository {
    * aggregates the whole org's AI spend.
    */
   async findSpendByDepartment({
-    ch,
     tenantIds,
     windowStart,
   }: {
-    ch: ClickHouseClient;
     tenantIds: string[];
     windowStart: number;
   }): Promise<SpendByDepartmentChRow[]> {
+    // Multi-tenant read across the org's projects; the shared client serves
+    // every project, so resolving by any one of them routes identically.
+    const ch = await this.resolveClient(tenantIds[0] ?? "");
     const result = await ch.query({
       query: `
         SELECT
@@ -217,16 +218,15 @@ export class ActivityMonitorSpendClickHouseRepository {
    * up by team via a PG join (CH only sees sourceId).
    */
   async findSpendByTeamSource({
-    ch,
     tenantId,
     thisStart,
     prevStart,
   }: {
-    ch: ClickHouseClient;
     tenantId: string;
     thisStart: number;
     prevStart: number;
   }): Promise<SpendByTeamSourceChRow[]> {
+    const ch = await this.resolveClient(tenantId);
     const result = await ch.query({
       query: `
         SELECT
@@ -273,16 +273,15 @@ export class ActivityMonitorSpendClickHouseRepository {
    * spend-over-time stacked-area chart.
    */
   async findSpendOverTime({
-    ch,
     tenantId,
     windowStart,
     groupBy,
   }: {
-    ch: ClickHouseClient;
     tenantId: string;
     windowStart: number;
     groupBy: SpendOverTimeGroupBy;
   }): Promise<SpendOverTimeChRow[]> {
+    const ch = await this.resolveClient(tenantId);
     const groupExpr =
       groupBy === "team"
         ? `ts.Attributes[{sourceKey:String}]`

--- a/platform/app/src/server/app-layer/dependencies.ts
+++ b/platform/app/src/server/app-layer/dependencies.ts
@@ -15,6 +15,7 @@ import type { UsageLimitService } from "../../../ee/billing/notifications/usage-
 import type { NurturingService } from "../../../ee/billing/nurturing/nurturing.service";
 import type { BillableEventsClickHouseRepository } from "../../../ee/billing/services/billableEvents.clickhouse.repository";
 import type { WebhookService } from "../../../ee/billing/services/webhookService";
+import type { ActivityMonitorClickHouseRepository } from "../../../ee/governance/services/activity-monitor/activityMonitor.clickhouse.repository";
 import type { GovernanceKpisClickHouseRepository } from "../../../ee/governance/services/governanceKpis.clickhouse.repository";
 import type { GovernanceOcsfEventsClickHouseRepository } from "../../../ee/governance/services/governanceOcsfEvents.clickhouse.repository";
 import type { GovernanceTraceActivityClickHouseRepository } from "../../../ee/governance/services/governanceTraceActivity.clickhouse.repository";
@@ -274,6 +275,9 @@ export interface AppDependencies {
     kpis: GovernanceKpisClickHouseRepository | undefined;
     /** The /me dashboard's spend/token/model rollups. */
     personalUsage: PersonalUsageClickHouseRepository | undefined;
+    /** The /governance activity-monitor read side (spend rollups, per-source
+     *  events and health). Undefined on a deployment without ClickHouse. */
+    activityMonitor: ActivityMonitorClickHouseRepository | undefined;
   };
   /** Billing-month usage rollups (billable_events + trace_summaries) behind
    *  `billableEventsQuery.ts`'s exported query functions. */

--- a/platform/app/src/server/app-layer/presets.ts
+++ b/platform/app/src/server/app-layer/presets.ts
@@ -1,6 +1,7 @@
 import type { ClickHouseClient } from "@clickhouse/client";
 import { BillableEventsClickHouseRepository } from "@ee/billing/services/billableEvents.clickhouse.repository";
 import { createNoopEnterprisePipelineCommands } from "@ee/event-sourcing/pipelineSet";
+import { ActivityMonitorClickHouseRepository } from "@ee/governance/services/activity-monitor/activityMonitor.clickhouse.repository";
 import { resolveSourceNonBillable } from "@ee/governance/services/costAttributionPolicy.service";
 import { GovernanceKpisClickHouseRepository } from "@ee/governance/services/governanceKpis.clickhouse.repository";
 import { GovernanceOcsfEventsClickHouseRepository } from "@ee/governance/services/governanceOcsfEvents.clickhouse.repository";
@@ -1038,6 +1039,14 @@ export function initializeDefaultApp(options?: {
     ? new PersonalUsageClickHouseRepository(resolveClickHouseClient)
     : undefined;
 
+  // The /governance activity-monitor read side (spend rollups, per-source
+  // events and health). Org-scoped aggregates, but the queries key on the
+  // hidden governance Project, so it takes the standard per-tenant resolver —
+  // getClickHouseClientForTenant maps a project id to its org's route.
+  const activityMonitorRepository = clickhouseEnabled
+    ? new ActivityMonitorClickHouseRepository(resolveClickHouseClient)
+    : undefined;
+
   // Billing-month usage rollups (billable_events + trace_summaries),
   // read by the billing pipeline and the usage-limit services.
   const billableEventsRepository = clickhouseEnabled
@@ -1839,6 +1848,7 @@ export function initializeDefaultApp(options?: {
       traceActivity: governanceTraceActivityRepository,
       kpis: governanceKpisRepository,
       personalUsage: personalUsageRepository,
+      activityMonitor: activityMonitorRepository,
     },
     billableEvents: billableEventsRepository,
     codingAgents: {
@@ -2175,6 +2185,7 @@ export function createTestApp(overrides?: Partial<AppDependencies>): App {
       traceActivity: undefined,
       kpis: undefined,
       personalUsage: undefined,
+      activityMonitor: undefined,
     },
     billableEvents: undefined,
     codingAgents: {

--- a/platform/app/src/server/routes/auth-cli.ts
+++ b/platform/app/src/server/routes/auth-cli.ts
@@ -1947,7 +1947,7 @@ secured
       );
     }
 
-    const monitor = new ActivityMonitorService(prisma);
+    const monitor = new ActivityMonitorService({ prisma });
     const events = await monitor.eventsForSource({
       organizationId: tokenRecord.organization_id,
       sourceId,
@@ -2006,7 +2006,7 @@ secured
         404,
       );
     }
-    const monitor = new ActivityMonitorService(prisma);
+    const monitor = new ActivityMonitorService({ prisma });
     const health = await monitor.sourceHealthMetrics({
       organizationId: tokenRecord.organization_id,
       sourceId,

--- a/platform/app/src/server/routes/auth-cli.ts
+++ b/platform/app/src/server/routes/auth-cli.ts
@@ -1947,7 +1947,10 @@ secured
       );
     }
 
-    const monitor = new ActivityMonitorService({ prisma });
+    const monitor = new ActivityMonitorService({
+      prisma,
+      repository: getApp().governance.activityMonitor,
+    });
     const events = await monitor.eventsForSource({
       organizationId: tokenRecord.organization_id,
       sourceId,
@@ -2006,7 +2009,10 @@ secured
         404,
       );
     }
-    const monitor = new ActivityMonitorService({ prisma });
+    const monitor = new ActivityMonitorService({
+      prisma,
+      repository: getApp().governance.activityMonitor,
+    });
     const health = await monitor.sourceHealthMetrics({
       organizationId: tokenRecord.organization_id,
       sourceId,

--- a/platform/app/src/test-utils/clickhouseTestApp.ts
+++ b/platform/app/src/test-utils/clickhouseTestApp.ts
@@ -1,5 +1,6 @@
 import type { ClickHouseClient } from "@clickhouse/client";
 import { BillableEventsClickHouseRepository } from "@ee/billing/services/billableEvents.clickhouse.repository";
+import { ActivityMonitorClickHouseRepository } from "@ee/governance/services/activity-monitor/activityMonitor.clickhouse.repository";
 import { GovernanceKpisClickHouseRepository } from "@ee/governance/services/governanceKpis.clickhouse.repository";
 import { GovernanceOcsfEventsClickHouseRepository } from "@ee/governance/services/governanceOcsfEvents.clickhouse.repository";
 import { GovernanceTraceActivityClickHouseRepository } from "@ee/governance/services/governanceTraceActivity.clickhouse.repository";
@@ -101,6 +102,7 @@ export function installClickHouseTestApp({
       traceActivity: new GovernanceTraceActivityClickHouseRepository(required),
       kpis: new GovernanceKpisClickHouseRepository(required),
       personalUsage: new PersonalUsageClickHouseRepository(required),
+      activityMonitor: new ActivityMonitorClickHouseRepository(required),
     },
     billableEvents: new BillableEventsClickHouseRepository(
       required,


### PR DESCRIPTION
## For humans

The activity-monitor admin dashboard's ClickHouse reads were built slightly off-pattern: they took a database handle on every call instead of getting it the way every other module does, and the dashboard service fetched it itself from a global. This PR makes them work like their 43 siblings — nothing changes for users.

## Why

Follow-up to #7146 (merged). A convention survey of all 47 `*.clickhouse.repository.ts` files found the activity-monitor family was the only one (a) taking a per-call `ch: ClickHouseClient` argument and (b) self-fetching its client via `tryGetApp()` inside the service, while the documented pattern (`dev/docs/best_practices/clickhouse-queries.md`) is a constructor-injected `ClickHouseClientResolver`, with services receiving repositories from the App composition root (`app.governance.*`), optional when ClickHouse is disabled.

## What changed

- The three concern-scoped repositories (`spend` / `events` / `health`) and their facade now take a `ClickHouseClientResolver` in the constructor; methods take `{tenantId, ...}` only and resolve internally.
- `ActivityMonitorService` receives `ActivityMonitorClickHouseRepository | undefined` via `create(prisma, repository)` — the same optional-repository degradation shape as `PersonalUsageService`.
- Router passes `getApp().governance.activityMonitor`; presets builds it gated on `clickhouseEnabled` with the standard tenant resolver (`resolveClickHouseClient`, which maps the governance project id through `getClickHouseClientForTenant` to the org's private route).
- `installClickHouseTestApp` fixture exposes the same slot so integration tests keep driving real ClickHouse.
- Service no longer imports `tryGetApp`; deleted its private `getClickhouse()`.

## How it works

Routing behavior is preserved: previously the service resolved an **org** client with `organizationId`; now repositories resolve by the **tenant** id they already receive — `resolveClickHouseClient` → `getClickHouseClientForTenant` maps a project id to its organization's route (cached), so private-instance routing for orgs with `CLICKHOUSE_URL__*` still applies. The multi-tenant department query resolves by its first project id, which serves the same shared/private decision.

## Test plan

- Repository unit tests rebuilt over the injected-resolver contract (17 tests).
- Both integration suites (`activityMonitor.service.integration.test.ts`, `departmentSpend.service.integration.test.ts`) pass the repository explicitly; 198/198 tests green across both directories.
- `pnpm typecheck` + `typecheck:all` clean.
- CI-exact Biome gate vs merge base: no new violations.
- Evidence: this PR's CI run (test-unit / test-component / test-integration shards green on commit 79854d775a; the one red unit shard was a runner-slowness cutoff — its own log reads "shard too slow for the floor, not a hang", all 3 flagged files pass locally in seconds and none are touched by this diff — and cleared on re-run). Local verification on d0f6065e63: `pnpm typecheck` → 0 errors; `pnpm test:unit run ee/governance/services/activity-monitor/__tests__ ee/governance/services/__tests__` → 23 files / 198 tests passed; `.github/scripts/biome-new-violations.sh` → "no new Biome violations".

## Anything surprising?

Also adds a "Validate Rows at the Boundary with Zod" section to `dev/docs/best_practices/clickhouse-queries.md`, codifying the Zod-at-the-read-boundary pattern this PR's parent (#7146) introduced as the standard for new repositories.

## Deployment Impact

No deployment impact — repo metadata and internal wiring only. No env vars added or changed (`CLICKHOUSE_URL__*` private-route behavior is preserved via the existing tenant-to-org resolver chain), no helm values touched, default `helm install` behavior unchanged, no BYOC dataplane impact: orgs with private ClickHouse instances keep their routing because repositories now resolve through `resolveClickHouseClient` → `getClickHouseClientForTenant`, which maps a project id to its organization's private route exactly as the previous org-keyed resolution did.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Activity Monitor data access now automatically uses tenant-aware ClickHouse connections.
  * Activity Monitor services consistently use the application’s configured data repositories.
  * Existing spend, event, health metrics, validation, and empty-state behavior is preserved.

* **Documentation**
  * Added best practices for validating ClickHouse query results and safely handling schema changes.

* **Tests**
  * Updated Activity Monitor integration and unit tests for the streamlined repository configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->