### PR TITLE
feat(governance): pull OpenAI spend and attribute it to the person and key

### DIFF
--- a/dev/docs/adr/122-openai-admin-cost-puller.md
+++ b/dev/docs/adr/122-openai-admin-cost-puller.md
@@ -148,7 +148,7 @@ three-key dimension map.
 Clamping the window forward to an epoch parsed out of the error prose was
 rejected. It discards every day below the floor rather than partially
 attributing it, and it makes an English sentence load-bearing: a reworded or
-localised message leaves the parse with no fallback, and the framework does
+localized message leaves the parse with no fallback, and the framework does
 not advance a cursor on error, so the source would retry the identical
 failing request forever. Dropping a dimension needs no regex and cannot
 wedge.
@@ -287,7 +287,7 @@ extra: {
 {
   adapter: "openai_admin",
   report: "cost",
-  startingAt?: string,   // ISO instant; clamped forward per Decision 8
+  startingAt?: string,   // ISO instant; the backfill origin
   schedule: string,      // default "0 * * * *"
   credentials: { token } // Admin API key, encrypted at rest
 }

--- a/dev/docs/adr/122-openai-admin-cost-puller.md
+++ b/dev/docs/adr/122-openai-admin-cost-puller.md
@@ -140,10 +140,12 @@ the window.** `group_by=api_key_id` is refused before an epoch the provider
 names in a 400. The adapter detects that specific rejection — `param` of
 `"start_time"` **and** `code` of `"invalid_request_error"` together, a pair
 no other 400 from this endpoint produces — and retries the identical window
-with `api_key_id` removed from `group_by[]`. The other three dimensions
-survive, so **per-person attribution survives for the whole history**; only
-key-level detail is absent below the floor, where those rows carry a
-three-key dimension map.
+with only `user_id` in `group_by[]`. The API refuses any multi-dimension
+request that includes `api_key_id` below the floor — not just the key
+dimension, but any request carrying it alongside others. Falling back to
+`user_id` alone means **per-person attribution survives for the whole
+history**; project and line-item detail is lost alongside the key below the
+floor, where those rows carry a single-dimension map.
 
 Clamping the window forward to an epoch parsed out of the error prose was
 rejected. It discards every day below the floor rather than partially
@@ -155,8 +157,8 @@ wedge.
 
 A bucket below the floor is read once, during the forward backfill, and is
 never revisited — Decision 9's re-read window is measured from the present
-and does not reach it. So no bucket carries a three-key map on one run and a
-four-key map on another.
+and does not reach it. So no bucket carries a one-dimension map on one run
+and a four-dimension map on another.
 
 **9. Restatement re-reads a trailing window.** Each run fetches from
 `watermark - RESTATEMENT_LOOKBACK_DAYS`, not from the watermark, so a bucket
@@ -232,7 +234,7 @@ can exist, so there is nothing to repair.
 | Identity reaches the audit row | Attribution is visible where a surface already reads it | OCSF row asserts `ActorEmail` = the row's email, and `metadata.extension.actorUserId` / `.apiKeyId` = the row's raw ids |
 | The watermark never moves backwards | A re-read window, or a page returned out of order, must not rewind progress | Unit test: a response whose last bucket precedes the stored watermark leaves the watermark unchanged |
 | A corrected bucket replaces, never adds | Restatement is the whole point of the re-read window | Same window pulled twice with a changed `amount.value`; the ledger shows the new figure once, and the row count is unchanged |
-| Below the floor the day survives, only the key is lost | A 400 on key grouping must not cost history | Unit test: a floor 400 triggers one retry without `api_key_id`, and the resulting rows still carry `user_id` |
+| Below the floor the day survives, only the key is lost | A 400 on key grouping must not cost history | Unit test: a floor 400 triggers one retry with `user_id` only, and the resulting rows still carry `user_id` |
 | The cursor never replays a token under a changed query | `next_page` is bound to its query and 400s otherwise | Query identity stored in the cursor; a config edit drops the token rather than replaying it |
 | A partial window never reports as complete | A fetch failure must not advance the watermark | Transport failure returns the prior cursor unchanged and `errorCount: 1` |
 | The dimension set is stable | A restatement finds the figure it corrects | Dimension keys asserted against a frozen list; adding one fails the test |

--- a/dev/docs/adr/122-openai-admin-cost-puller.md
+++ b/dev/docs/adr/122-openai-admin-cost-puller.md
@@ -1,0 +1,445 @@
+# ADR-122: OpenAI spend is pulled from the Admin cost report, attributed to the person and key on the row
+
+**Date:** 2026-08-26
+
+**Status:** Accepted
+
+**Builds on:** ADR-088 (pulled usage becomes a priced, provider-agnostic
+event under a restatement key that excludes cost — every decision there
+stands; this ADR adds the second provider and the first per-person
+attribution). ADR-088 Decision 13 supplies the identity principle this
+follows.
+
+**Related:** #7579 (the defect this replaces), langwatch#6977 (the
+cents-vs-dollars class of bug this must not repeat), #6551 (named-person
+attribution, still deferred).
+
+> **One line:** a new **`openai_admin`** puller reads **`/v1/organization/costs`**
+> grouped by **project, line item, user and API key**, and carries the
+> **provider's raw user id and key id** onto the audit row — the money is
+> the provider's own **dollars**, never converted, and the person is
+> **never resolved at pull time**.
+
+## Context
+
+The shipped `openai_compliance` source cannot run and never has. Its
+validator requires a `region` the form does not collect
+(`openaiCompliance.puller.ts:88-90` against `inventory.tsx:1808-1833`), so
+every save throws — which is also the proof no configured row exists
+anywhere. Behind that, it polls S3 for a file OpenAI does not write, looking
+for a per-event record shape OpenAI does not produce. It was written from
+the Copilot Studio template; its own header still cites that spec. Full
+diagnosis in #7579.
+
+What OpenAI actually exposes is a **bucketed cost report**: daily buckets,
+each holding grouped result rows. Unlike Anthropic's cost report — which
+groups only by workspace and description — **OpenAI's carries
+`user_id`, `user_email` and `api_key_id` on every row**. The identity is
+already there. No directory call is needed to attribute spend to a person,
+which is what makes this ADR possible at all.
+
+Forces:
+
+- ADR-088 Decision 5 keys restatement on **dimensions with cost excluded**,
+  so a corrected bucket replaces rather than adds. That machinery is what
+  makes a re-pull safe, and what makes a careless write destructive.
+- ADR-088 Decision 4 attributes at **org/team**, with project deferred, and
+  defers named-person attribution behind #6551.
+- `NormalizedPullEvent` is the contract every adapter implements and is
+  exported from `pullers/index.ts`. Extending it is a published-contract
+  change, which is what routed this decision here rather than straight to
+  implementation.
+
+### Prior art read before deciding
+
+- `dev/docs/adr/088-pulled-usage-reporting-record.md` — the governing ADR.
+- `specs/governance/pulled-usage-cost-reporting.feature` — 11 scenarios,
+  provider-agnostic, **none covering per-user or per-key attribution**.
+- `services/pullers/anthropicAdmin.puller.ts` — the same bucket + group-by
+  shape, and the template followed here.
+- `services/pullers/pulledUsageRecord.ts` — the hint contract and
+  `restatementKeyFor`.
+- `services/pullers/databricksGenie.puller.ts:2566-2601` — the only shipped
+  per-person attribution, which resolves through SCIM at pull time. OpenAI
+  needs none of that.
+
+## Decision
+
+**1. One adapter, cost report only.** `openai_admin` pulls
+`GET /v1/organization/costs` and nothing else. The eight `/usage/*`
+endpoints are not pulled: the cost report already carries the identity and
+real dollars, and the usage surface demonstrably under-reports — it returns
+zero rows for image generation across windows the cost surface bills. A
+source that pulled both would record the same spend twice, and ADR-088
+Decision 6 defers the supersede rule that would let them coexist.
+
+**2. The dimension set is `project_id`, `line_item`, `user_id`,
+`api_key_id`, and it is locked.** These four are both the request's
+`group_by[]` and the restatement key's coordinates. Reshaping the set later
+re-keys every row already written and records the same spend a second time,
+so it is fixed at the first pull and changing it is a new revision of this
+ADR, not an edit.
+
+One exception, and it is bounded: below the provider's key-grouping floor
+`api_key_id` is unavailable, and those rows carry the remaining three
+coordinates (Decision 8). A given bucket's map is stable — it is read with
+one shape or the other, never both — because below-floor buckets are read
+once during the forward backfill and Decision 9's re-read window never
+reaches back that far.
+
+**3. Money is dollars and is never converted.** `amount.value` is a JSON
+number denominated in **US dollars**. Anthropic's equivalent field is
+*cents in a decimal string* and its adapter shifts the decimal
+(`anthropicAdmin.puller.ts:401`). Porting that here would report **100× the
+real spend**. Nothing in this adapter divides by 100, and the test suite
+pins the figure end to end.
+
+**4. `costStatus` is `estimate`, never `exact`.** It is not established that
+this endpoint equals the invoice, and the provider's own cost and usage
+surfaces already disagree with each other. `provider_reported` says the
+number is theirs; `estimate` says we do not claim it is the bill.
+
+**5. A bucket read that yields no row emits no usage hint.** Never
+`costUsd: "0"`. The restatement key excludes cost by design, so a zero
+written with a later `observedAt` wins `argMax` and **erases a confirmed
+figure**. Omitting the hint entirely leaves the ledger untouched while the
+audit row still lands — `buildPulledUsageRecord` returns null for
+audit-only events, which is the mechanism that makes this safe. This is the
+general hazard recorded against the Genie warehouse-cost work; it is
+restated here because it is easy to reintroduce and silent when wrong.
+
+**6. Identity rides the event as raw provider ids, in the extras bag.**
+`actor` carries `user_email`. The raw `user_id` and the `api_key_id` ride in
+`extra`, which `pullerWorker.ts:587` spreads into `metadata.extension` —
+exactly the shape `databricksGenie.puller.ts:2596-2602` already ships for
+per-person attribution. **`NormalizedPullEvent` does not change**, so no
+published contract moves and no sibling adapter is touched.
+
+Populating the real `ActorUserId` column was considered and rejected. It is
+hardcoded to `""` for every puller (`pullerWorker.ts:602`), and the one
+surface named to justify filling it — `activityMonitor.service.ts:354` —
+reads `actorEmail || actorUserId || actorEnduserId`. OpenAI sends
+`user_email` on **every** row, so the email always wins that `||` and the
+column write would never be read. A published-contract change for a value
+nothing observes is cost with no benefit.
+
+This follows ADR-088 Decision 13's principle — write the provider's raw id,
+resolve the person later, never call a directory at pull time. OpenAI
+satisfies it with zero lookups. Decision 13's own citations are broken and
+are recorded in Assumptions below rather than fixed here.
+
+**7. Spend attribution stays out of the ledger.** No user or API-key column
+is added to `PulledUsageObserved`. `readPulledUsageTotals` has only test
+callers, so per-person spend has no production reader to serve; and both
+identifiers already reach the restatement key through the hint's
+`dimensions` map, so nothing is lost by waiting. Adding a column now would
+be an event-sourcing schema change in service of no screen.
+
+**8. Below the API's key-grouping floor, the key dimension is dropped, not
+the window.** `group_by=api_key_id` is refused before an epoch the provider
+names in a 400. The adapter detects that specific rejection — `param` of
+`"start_time"` **and** `code` of `"invalid_request_error"` together, a pair
+no other 400 from this endpoint produces — and retries the identical window
+with `api_key_id` removed from `group_by[]`. The other three dimensions
+survive, so **per-person attribution survives for the whole history**; only
+key-level detail is absent below the floor, where those rows carry a
+three-key dimension map.
+
+Clamping the window forward to an epoch parsed out of the error prose was
+rejected. It discards every day below the floor rather than partially
+attributing it, and it makes an English sentence load-bearing: a reworded or
+localised message leaves the parse with no fallback, and the framework does
+not advance a cursor on error, so the source would retry the identical
+failing request forever. Dropping a dimension needs no regex and cannot
+wedge.
+
+A bucket below the floor is read once, during the forward backfill, and is
+never revisited — Decision 9's re-read window is measured from the present
+and does not reach it. So no bucket carries a three-key map on one run and a
+four-key map on another.
+
+**9. Restatement re-reads a trailing window.** Each run fetches from
+`watermark - RESTATEMENT_LOOKBACK_DAYS`, not from the watermark, so a bucket
+the provider corrects inside that window replaces its earlier figure through
+the restatement key. The watermark itself advances as
+`max(currentWatermark, lastBucketStart)` and never moves backwards.
+
+Forward-only — each bucket read once, matching Anthropic — was considered
+and rejected. It guarantees a provider correction never reaches the ledger
+and leaves the restatement machinery inert in steady state. It is also
+**undetectable here**: `readPulledUsageTotals` has no production caller, the
+spend dashboards read `trace_summaries` which this adapter never writes, and
+the spend-spike evaluator reads `governance_kpis` fed only by trace events.
+A wrong figure would be corrected by nobody and noticed by nothing. Three
+extra daily buckets per run buys the only correction path that does not
+require an operator to spot the error first.
+
+The operator's backfill lever still exists, and is now specified rather than
+asserted: the cursor stores a query identity over the adapter, report,
+group-by set and configured `startingAt`; a changed identity discards the
+stored page token and restarts; a widened `startingAt` re-reads from the
+earlier of the stored watermark and the new start. That is the discipline
+`anthropicAdmin.puller.ts:178-273` implements as `queryIdentity`,
+`parseCursor` and `staleCursorRestart`, duplicated here per Decision 11.
+
+**10. Two sources on one organization are a documented warning, not a
+guard.** Two `openai_admin` sources in one org carry different
+`ingestionSourceId`s, therefore different restatement keys, therefore the
+same spend twice. The catalog blurb says not to, exactly as Anthropic's
+does. The exposure is real and is inherited, not introduced; a uniqueness
+guard belongs on every provider adapter at once, and building it only here
+would hide the gap elsewhere.
+
+**11. Standalone adapter, no shared base.** `openai_admin` duplicates
+`anthropicAdmin`'s cursor discipline rather than extracting a base class.
+Two instances are a coincidence, not a pattern, and the wire shapes already
+diverge on money units, timestamp format, page-token binding and a
+retention floor Anthropic has no equivalent of. An abstraction built at n=2
+is shaped like its first caller. Revisit at the third provider.
+
+**12. `openai_compliance` is deprecated in place, still listed.** It stays
+registered, stays in the catalog array, and stays **visible** in the picker
+behind a `deprecated` badge that disables it for new sources. Hiding it was
+rejected: `ingestionSourceCatalog.unit.test.ts:27-31` asserts the picker
+offers every registered type, and
+`specs/ai-gateway/governance/ingestion-sources.feature:28-38` promises a menu
+"listing every supported source type". A disabled badge keeps both true and
+still stops anyone choosing it. No backfill and no migration: no valid row
+can exist, so there is nothing to repair.
+
+## Constants
+
+| Name | Value | Purpose |
+|---|---|---|
+| `API_BASE` | `https://api.openai.com/v1/organization` | Admin API root. Not `api.chatgpt.com`, which is the Compliance API and answers 403 to an admin key. |
+| `COST_REPORT_BUCKET_WIDTH` | `"1d"` | The only value the endpoint accepts (`1h` → 400, `Supported values are: '1d'`). Both a request parameter and a restatement dimension; the two must never diverge. |
+| `COST_GROUP_BY` | `["project_id", "line_item", "user_id", "api_key_id"]` | Decision 2. Request parameter and cursor identity. |
+| `PAGE_LIMIT` | `180` | The API's ceiling. Above it the request is **rejected**, not clamped (`Invalid limit provided: 366. Limit must be less than or equal to 180.`). One page is ~6 months of daily buckets. |
+| `RESTATEMENT_LOOKBACK_DAYS` | `3` | Decision 9. How far behind the watermark each run re-reads so a provider correction can land. A margin, not a measurement — OpenAI's restatement lag is unobserved, and the sibling adapter documents ~1 day for Anthropic. Costs three daily buckets on one request per run. |
+| `MAX_PAGES_PER_RUN` | `20` | Matches the sibling. At 180 buckets a page this bounds a run at ~10 years, so it is a runaway guard, not a throttle. |
+| `REQUEST_TIMEOUT_MS` | `30_000` | Matches the sibling. |
+| `DEFAULT_SCHEDULE` | `"0 * * * *"` | Hourly. Daily buckets do not reward finer polling. |
+| `OPENAI_ADMIN_ADAPTER_ID` | `"openai_admin"` | Registry id, persisted in `pullConfig.adapter`. |
+
+## Invariants
+
+| Invariant | Meaning | How the design satisfies it — test anchor |
+|---|---|---|
+| No division by 100 | A provider dollar reaches the ledger as that many dollars | A captured row's `amount.value` is asserted equal, to the digit, at the ledger boundary |
+| No float round-trip on money | Sub-cent figures keep every digit | `amount` parsed as `string \| number` and stringified once; a string input survives byte-identical |
+| A costless read writes no money | A missing row never overwrites a present one | Unit test: a bucket whose row vanished emits an event with **no** `pulled_usage` key, and `buildPulledUsageRecord` returns null |
+| Re-pulling an unchanged window records nothing new | At-least-once delivery is free | Same window pulled twice; ledger row count unchanged |
+| Identity reaches the audit row | Attribution is visible where a surface already reads it | OCSF row asserts `ActorEmail` = the row's email, and `metadata.extension.actorUserId` / `.apiKeyId` = the row's raw ids |
+| The watermark never moves backwards | A re-read window, or a page returned out of order, must not rewind progress | Unit test: a response whose last bucket precedes the stored watermark leaves the watermark unchanged |
+| A corrected bucket replaces, never adds | Restatement is the whole point of the re-read window | Same window pulled twice with a changed `amount.value`; the ledger shows the new figure once, and the row count is unchanged |
+| Below the floor the day survives, only the key is lost | A 400 on key grouping must not cost history | Unit test: a floor 400 triggers one retry without `api_key_id`, and the resulting rows still carry `user_id` |
+| The cursor never replays a token under a changed query | `next_page` is bound to its query and 400s otherwise | Query identity stored in the cursor; a config edit drops the token rather than replaying it |
+| A partial window never reports as complete | A fetch failure must not advance the watermark | Transport failure returns the prior cursor unchanged and `errorCount: 1` |
+| The dimension set is stable | A restatement finds the figure it corrects | Dimension keys asserted against a frozen list; adding one fails the test |
+
+## Assumptions
+
+| Assumption | What breaks if false |
+|---|---|
+| `user_id` identifies the **caller**, not the API key's owner | Every row is attributed to whoever minted the key rather than who spent. **Tested and unresolved:** across all captured rows every key maps to exactly one user, but the whole dataset carries a single `user_id`, so the discriminator cannot fire. Consistent with both readings; proves neither. |
+| OpenAI restates a bucket **in place**, under the same coordinates | A correction arrives as a new row beside the old instead of replacing it, and the period double-counts. Never observed. Decision 9's re-read window is what makes this load-bearing: it is the mechanism that carries a correction to the ledger, and it only works if the corrected row keeps its coordinates. |
+| The `api_key_id` floor is a property of the API, not of one organization | Nothing — Decision 8 reacts to the rejection rather than predicting it, so a per-tenant floor is handled identically. Recorded because it decides whether the retry can ever be removed. |
+| Buckets arrive in ascending order, one per day with no gaps | Nothing. Observed over 264 consecutive buckets — strictly ascending within and across pages, every gap exactly 86400s, so a quiet day still returns its bucket and the watermark keeps moving. **Deliberately not relied on:** the watermark takes `max()` rather than the last element, so ordering being unguaranteed cannot hurt. |
+| A row that disappears from a re-read bucket means *no longer billed* | Nothing breaks — Decision 5 makes the vanished row keep its last known value rather than zeroing. Stated so the behaviour is chosen, not accidental. |
+| ADR-088 Decision 13's read-time identity stack will eventually exist | Nothing in this ADR depends on it. Recorded because D13 cites **ADR-094**, which is *simulation-execution-on-process-manager-substrate*, not identity — the identity ADRs are 101 and 115 — and names `ACTOR_ID_KIND_BY_PROVIDER`, which **appears in no source file**. The stack is unbuilt and the citation is wrong. |
+
+## Gates
+
+| Path | Reversible? | Blast radius | Required gate |
+|---|---|---|---|
+| Cost figure → ledger | No — `argMax` replacement destroys the prior figure | Money | Human review, plus the no-division and costless-read tests above. A dollar figure is asserted end to end against a captured payload, not a hand-written one. |
+| Provider identity ids leaving for third-party SIEMs | No — an export is a send | Privacy | Human review. `governanceOcsfEvents.clickhouse.repository.ts:236,284` exports `RawOcsfJson` to whatever SIEM an org has wired, and `raw_payload` is **required** on every pull event (`pullerAdapter.ts:96`), so the provider's ids egress by construction. Not introduced here — Anthropic and Genie already do it — but named so it is a decision rather than an accident. |
+| `openai_admin` `pullConfig` shape | No — persists in customer rows | Small (no row exists yet) | Human review of the schema. Validated at create time by `validateConfig`. |
+| `openai_compliance` badged deprecated | Yes | Small | Automated: the two existing catalog tests must stay green **unchanged** — the picker still offers every registered type (Decision 12). |
+| The trailing re-read window | Yes — read-only, bounded by a constant | Small | Automated: the restatement invariant above, plus a test that the watermark does not rewind. |
+| Live pull against the real Admin API | Read-only | None | Required before merge. A fixture alone has never caught a wire-shape error in this codebase. |
+
+## Schema
+
+**No migration, and no contract change.** `NormalizedPullEvent` is untouched
+(Decision 6): identity travels in the existing `extra` bag, which the worker
+already spreads into `metadata.extension`. `ActorUserId` stays the empty
+string, as it is for every puller today.
+
+```ts
+// What the adapter puts in the existing `extra` record. Raw and unresolved:
+// ADR-088 D13 — the person is a read-time join, never a pull-time directory
+// call. `apiKeyId` is carried because it outlives the key: spend accrues
+// against keys that have since been deleted, and the id is all that is left
+// to join on.
+extra: {
+  actorUserId: result.user_id,
+  apiKeyId: result.api_key_id ?? "",
+  projectId: result.project_id ?? "",
+  lineItem: result.line_item ?? "",
+}
+```
+
+```ts
+// The persisted pullConfig shape. `report` is a single-value enum rather
+// than a bare constant so a second report can be added later without
+// re-keying the rows this one wrote.
+{
+  adapter: "openai_admin",
+  report: "cost",
+  startingAt?: string,   // ISO instant; clamped forward per Decision 8
+  schedule: string,      // default "0 * * * *"
+  credentials: { token } // Admin API key, encrypted at rest
+}
+```
+
+## Rejected alternatives
+
+- **Pull the eight `/usage/*` endpoints** — the usage surface returns zero
+  rows for spend the cost surface bills; pulling both double-counts.
+- **Port `centsToUsd`** — reports 100× the real figure. The single most
+  expensive mistake available here.
+- **`costStatus: "exact"`** — claims the invoice without evidence, from an
+  endpoint whose sibling surface already contradicts it.
+- **Emit `costUsd: "0"` for a vanished row** — erases confirmed spend.
+- **Add user/API-key columns to `PulledUsageObserved`** — an event-schema
+  change serving no reader.
+- **Resolve `user_id` to a LangWatch person at pull time** — bakes a
+  resolution into an immutable record, and #6551 defers it.
+- **Clamp the window forward at the key-grouping floor** — discards history
+  to protect a dimension, and makes a parse of English prose load-bearing
+  with no fallback when it fails. Against a hardcoded epoch it is worse
+  still: silently stale if the floor rolls.
+- **Forward-only restatement, matching Anthropic** — guarantees a provider
+  correction never reaches the ledger, in a product where nothing would
+  notice. Rejected in Decision 9.
+- **Extend `NormalizedPullEvent` and populate `ActorUserId`** — a
+  published-contract change whose value no surface reads, because
+  `actorEmail` always wins the `||` that would have exposed it.
+- **The declarative `http_polling` adapter** — the framework's documented
+  default, and genuinely unusable here: its `eventMapping.extra` is a flat
+  `z.record(z.string())` that cannot build the nested `dimensions` map the
+  usage hint needs, its 4xx handling is fail-fast with no access to the
+  error body Decision 8 reads, and it offers no watermark or query identity
+  beyond an opaque page token.
+- **Hide `openai_compliance` from the picker** — breaks two passing catalog
+  tests and contradicts a spec scenario promising every supported type is
+  listed. A disabled badge achieves the same end.
+- **A uniqueness guard on duplicate sources** — belongs on every adapter,
+  not this one alone.
+- **Extract a shared bucket-report base** — n=2 is a coincidence, and the
+  wire shapes already diverge on four axes.
+- **Delete `openai_compliance`** — deprecation costs nothing and keeps the
+  completeness guard intact.
+
+## Consequences
+
+**Positive.** OpenAI spend becomes visible and is attributed to a named
+person and a specific key, with no directory integration — the first
+attribution of its kind that costs no extra request. Per-person attribution
+survives the provider's key-grouping floor, so the full history is
+attributed rather than truncated. A bucket the provider corrects inside the
+lookback window reaches the ledger. One page covers six months, so a
+backfill is a handful of requests. No published contract changes, so no
+sibling adapter carries risk from this work.
+
+**Negative.** Per-person **spend** remains invisible until something reads
+the ledger; only per-person **activity** lands on a surface today —
+`readPulledUsageTotals` still has no production caller, so this ADR ships
+correct numbers into a table nothing aggregates. A correction arriving later
+than `RESTATEMENT_LOOKBACK_DAYS` is still missed, and that constant is a
+margin rather than a measurement. Two sources on one organization still
+double-count — and so does **deleting and recreating** one source, because
+`ingestionSourceId` is a restatement-key coordinate, so every re-pulled
+bucket lands beside the old rows instead of replacing them. Whether
+`user_id` is the caller or the key's owner is unresolved, so the headline
+attribution claim carries an untested assumption. Key-level detail is absent
+below the provider's floor.
+
+The provider's user id, email and key id are exported to any third-party
+SIEM the organization has wired up, because `raw_payload` is required on
+every pull event and the whole raw row ships inside `RawOcsfJson`. That is
+inherited framework behaviour, not new here, and it is why Decision 6
+changes nothing about exposure.
+
+**Neutral.** `openai_compliance` stays registered, listed and inert. The
+adapter duplicates cursor logic a third provider may justify factoring out.
+
+## Open questions
+
+- **Is `user_id` the caller or the key's owner?** Owner: whoever next has
+  an organization with two spenders sharing one key. Settles the headline
+  attribution claim.
+- **Does OpenAI restate a cost bucket in place, and within how many days?**
+  Requires observing a real correction. Both halves of Decision 9 depend on
+  it: in-place decides whether a correction replaces or duplicates, and the
+  lag decides whether `RESTATEMENT_LOOKBACK_DAYS = 3` is enough.
+- **Is the `api_key_id` floor fixed or rolling?** Decision 8 is correct
+  either way; the answer decides whether the retry can later be removed.
+- **Nothing aggregates the pulled-usage ledger.** `readPulledUsageTotals`
+  has test callers only, so per-person spend has no reader and no
+  reconciliation job compares these figures to an invoice. Owner
+  unassigned; it is the gap that makes a wrong figure undetectable.
+- **Why does the cost surface bill image generation that `/usage/images`
+  reports zero rows for?** Out of scope here; recorded in #7579.
+- **A uniqueness guard across all provider adapters** — owner unassigned.
+
+## Revisions
+
+- **v1 (2026-08-26) — initial proposal.** Framed against the #7579
+  diagnosis. Four forks locked in one round: the key-grouping floor is
+  **clamped from the error, not a constant**; restatement is
+  **forward-only, matching Anthropic** — taken against the recommendation
+  of a trailing re-read window, with the consequence recorded in Decision 9
+  rather than softened; duplicate sources get a **warning blurb only**,
+  matching the sibling; the adapter is **standalone**, no shared base at
+  n=2. Grounded in four live probes run before any code: `end_time` is
+  optional and must be omitted (a moving one invalidates every page token),
+  `bucket_width` is genuinely read (`1d` only), the `limit` ceiling is
+  **180 and rejects rather than clamps**, and `group_by=api_key_id` is
+  refused before a fixed epoch with a 400 naming it — probed to the second.
+  One earlier finding was **corrected**: the reference suite recorded
+  `limit` as clamping silently to 31, which was confounded by a 31-day test
+  window. One assumption was **tested and left open**: the captured data
+  cannot discriminate caller from key-owner semantics for `user_id`,
+  because a single user accounts for every row. Captain: Sergio Esteban.
+
+- **v2 (2026-08-26) — accepted after adversarial review.** Five independent
+  reviewers read v1 against the codebase; all five refuted it. **Three
+  locked forks were reopened and reversed.** Decision 8 now **drops the
+  `api_key_id` dimension** below the provider's floor instead of clamping
+  the window forward — the reviewers found the clamp discarded history to
+  protect a dimension, and that a failed prose parse would wedge the source
+  permanently, since the framework never advances a cursor on error.
+  Decision 9 now **re-reads a trailing three-day window** instead of being
+  forward-only; four reviewers independently reached the same finding, and
+  one established the decisive fact: no surface in the product reads the
+  pulled-usage ledger, so a wrong figure would be corrected by nobody and
+  noticed by nothing. Decision 6 now carries identity in the **existing
+  `extra` bag** rather than extending `NormalizedPullEvent` — the column it
+  would have filled is unreadable behind `actorEmail ||`, which OpenAI
+  populates on every row, and `databricksGenie.puller.ts:2596-2602` already
+  ships the extras shape. Decision 12 now keeps `openai_compliance`
+  **visible with a disabled badge**: hiding it would have broken two passing
+  catalog tests and a spec scenario promising every supported type is
+  listed.
+
+  Four gaps were closed without reopening a fork: the watermark takes
+  `max(watermark, lastBucketStart)`, retiring an unstated dependence on
+  bucket ordering; the floor 400 is identified by `param` **and** `code`
+  together, since a bare `param` check would misread the limit rejection;
+  `queryIdentity` / `parseCursor` / `staleCursorRestart` are specified here
+  rather than deferred, because Decision 9's operator lever was asserted
+  without a mechanism; and delete-and-recreate is named as a
+  ledger-doubling hazard, since `ingestionSourceId` is a restatement-key
+  coordinate.
+
+  Three live probes ran during review. The 400 envelope was mapped across
+  six rejection shapes, establishing the `param`+`code` discriminator and —
+  from a deliberately bogus `group_by` value — confirming the endpoint's
+  dimension enum is exactly the four in Decision 2. Bucket ordering and
+  density were measured over 264 consecutive buckets across two pages:
+  strictly ascending, every gap exactly one day, page two starting exactly
+  one day after page one ended. That observation is recorded as **not
+  relied upon**. Two findings survived every attack unchanged: money-unit
+  handling, and the costless-read guard. Captain: Sergio Esteban.

--- a/platform/app/ee/governance/dashboard/components/AddIngestionSourceMenu.tsx
+++ b/platform/app/ee/governance/dashboard/components/AddIngestionSourceMenu.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
 
 import { HStack, Spacer, Text } from "@chakra-ui/react";
-import { Archive, Lock } from "lucide-react";
+import { Lock } from "lucide-react";
 // biome-ignore lint/style/useImportType: React is needed at runtime for JSX in non-jsdom test environments
 import React from "react";
 import { Menu } from "~/components/ui/menu";
@@ -10,7 +10,6 @@ import { Tooltip } from "~/components/ui/tooltip";
 import {
   gatedSourceTypeOptions,
   groupForMode,
-  isSourceTypeSelectable,
   SOURCE_GROUP_META,
   type SourceGroup,
   type SourceType,
@@ -24,12 +23,9 @@ import {
  * AddModelProviderMenu so the two "add a thing by vendor" surfaces feel like
  * one product.
  *
- * Plan-locked types render inert with the plan that unlocks them, and retired
- * types render inert saying so — both get no click handler at all, so neither
- * can be picked no matter what the pointer does. A retired type stays in the
- * list rather than vanishing: this menu promises every supported type, and an
- * admin hunting for a vendor should be told it was retired rather than left
- * wondering. `disabledReason` makes the whole trigger inert with the
+ * Plan-locked types render inert with the plan that unlocks them — they get
+ * no click handler at all, so a locked type cannot be picked no matter what
+ * the pointer does. `disabledReason` makes the whole trigger inert with the
  * reason on hover (used when a non-enterprise org is at its source cap), and
  * mounts no menu, so adding can never open onto a list that leads nowhere.
  */
@@ -71,7 +67,7 @@ export function AddIngestionSourceMenu({
             {options
               .filter((option) => groupForMode(option.mode) === group)
               .map((option) =>
-                !isSourceTypeSelectable(option) ? (
+                option.locked ? (
                   <Menu.Item key={option.value} value={option.value} disabled>
                     <HStack gap={3} width="full">
                       <SourceTypeIconGlyph
@@ -81,17 +77,8 @@ export function AddIngestionSourceMenu({
                       <Text>{option.label}</Text>
                       <Spacer />
                       <HStack gap={1} color="fg.muted">
-                        {option.deprecated ? (
-                          <>
-                            <Archive size={12} />
-                            <Text fontSize="xs">Retired</Text>
-                          </>
-                        ) : (
-                          <>
-                            <Lock size={12} />
-                            <Text fontSize="xs">Enterprise</Text>
-                          </>
-                        )}
+                        <Lock size={12} />
+                        <Text fontSize="xs">Enterprise</Text>
                       </HStack>
                     </HStack>
                   </Menu.Item>

--- a/platform/app/ee/governance/dashboard/components/AddIngestionSourceMenu.tsx
+++ b/platform/app/ee/governance/dashboard/components/AddIngestionSourceMenu.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
 
 import { HStack, Spacer, Text } from "@chakra-ui/react";
-import { Lock } from "lucide-react";
+import { Archive, Lock } from "lucide-react";
 // biome-ignore lint/style/useImportType: React is needed at runtime for JSX in non-jsdom test environments
 import React from "react";
 import { Menu } from "~/components/ui/menu";
@@ -10,6 +10,7 @@ import { Tooltip } from "~/components/ui/tooltip";
 import {
   gatedSourceTypeOptions,
   groupForMode,
+  isSourceTypeSelectable,
   SOURCE_GROUP_META,
   type SourceGroup,
   type SourceType,
@@ -23,9 +24,12 @@ import {
  * AddModelProviderMenu so the two "add a thing by vendor" surfaces feel like
  * one product.
  *
- * Plan-locked types render inert with the plan that unlocks them — they get
- * no click handler at all, so a locked type cannot be picked no matter what
- * the pointer does. `disabledReason` makes the whole trigger inert with the
+ * Plan-locked types render inert with the plan that unlocks them, and retired
+ * types render inert saying so — both get no click handler at all, so neither
+ * can be picked no matter what the pointer does. A retired type stays in the
+ * list rather than vanishing: this menu promises every supported type, and an
+ * admin hunting for a vendor should be told it was retired rather than left
+ * wondering. `disabledReason` makes the whole trigger inert with the
  * reason on hover (used when a non-enterprise org is at its source cap), and
  * mounts no menu, so adding can never open onto a list that leads nowhere.
  */
@@ -67,7 +71,7 @@ export function AddIngestionSourceMenu({
             {options
               .filter((option) => groupForMode(option.mode) === group)
               .map((option) =>
-                option.locked ? (
+                !isSourceTypeSelectable(option) ? (
                   <Menu.Item key={option.value} value={option.value} disabled>
                     <HStack gap={3} width="full">
                       <SourceTypeIconGlyph
@@ -77,8 +81,17 @@ export function AddIngestionSourceMenu({
                       <Text>{option.label}</Text>
                       <Spacer />
                       <HStack gap={1} color="fg.muted">
-                        <Lock size={12} />
-                        <Text fontSize="xs">Enterprise</Text>
+                        {option.deprecated ? (
+                          <>
+                            <Archive size={12} />
+                            <Text fontSize="xs">Retired</Text>
+                          </>
+                        ) : (
+                          <>
+                            <Lock size={12} />
+                            <Text fontSize="xs">Enterprise</Text>
+                          </>
+                        )}
                       </HStack>
                     </HStack>
                   </Menu.Item>

--- a/platform/app/ee/governance/dashboard/components/__tests__/AddIngestionSourceMenu.integration.test.tsx
+++ b/platform/app/ee/governance/dashboard/components/__tests__/AddIngestionSourceMenu.integration.test.tsx
@@ -78,9 +78,7 @@ describe("given the Add source menu", () => {
       expect(
         screen.queryByText("Microsoft Copilot Studio (Purview)"),
       ).toBeNull();
-      expect(
-        screen.queryByText("OpenAI Enterprise Compliance"),
-      ).toBeNull();
+      expect(screen.queryByText("OpenAI Enterprise Compliance")).toBeNull();
     });
 
     /** @scenario "Add source menu lists every type by vendor, grouped in plain language" */

--- a/platform/app/ee/governance/dashboard/components/__tests__/AddIngestionSourceMenu.integration.test.tsx
+++ b/platform/app/ee/governance/dashboard/components/__tests__/AddIngestionSourceMenu.integration.test.tsx
@@ -64,7 +64,8 @@ describe("given the Add source menu", () => {
         "Anthropic Claude (Cowork)",
         "Workato",
         "Microsoft Copilot Studio",
-        "OpenAI Admin API (spend)",
+        "OpenAI Enterprise Compliance",
+        "OpenAI Admin",
         "Anthropic Claude Enterprise Compliance",
         "Anthropic Admin API (usage & cost)",
         "Databricks AI/BI Genie",
@@ -74,11 +75,11 @@ describe("given the Add source menu", () => {
         expect(screen.getByText(label)).toBeTruthy();
       }
 
-      // Retired sources are filtered out of the picker.
+      // The retired directory-audit source is filtered out of the picker, so
+      // the offer carries one Copilot entry, not two near-identical ones.
       expect(
         screen.queryByText("Microsoft Copilot Studio (Purview)"),
       ).toBeNull();
-      expect(screen.queryByText("OpenAI Enterprise Compliance")).toBeNull();
     });
 
     /** @scenario "Add source menu lists every type by vendor, grouped in plain language" */

--- a/platform/app/ee/governance/dashboard/components/__tests__/AddIngestionSourceMenu.integration.test.tsx
+++ b/platform/app/ee/governance/dashboard/components/__tests__/AddIngestionSourceMenu.integration.test.tsx
@@ -64,7 +64,7 @@ describe("given the Add source menu", () => {
         "Anthropic Claude (Cowork)",
         "Workato",
         "Microsoft Copilot Studio",
-        "OpenAI Enterprise Compliance",
+        "OpenAI Admin API (spend)",
         "Anthropic Claude Enterprise Compliance",
         "Anthropic Admin API (usage & cost)",
         "Databricks AI/BI Genie",
@@ -74,10 +74,12 @@ describe("given the Add source menu", () => {
         expect(screen.getByText(label)).toBeTruthy();
       }
 
-      // The retired directory-audit source is filtered out of the picker, so
-      // the offer carries one Copilot entry, not two near-identical ones.
+      // Retired sources are filtered out of the picker.
       expect(
         screen.queryByText("Microsoft Copilot Studio (Purview)"),
+      ).toBeNull();
+      expect(
+        screen.queryByText("OpenAI Enterprise Compliance"),
       ).toBeNull();
     });
 

--- a/platform/app/ee/governance/dashboard/components/__tests__/ingestionSourceCatalog.unit.test.ts
+++ b/platform/app/ee/governance/dashboard/components/__tests__/ingestionSourceCatalog.unit.test.ts
@@ -79,7 +79,7 @@ describe("given the ingestion-source catalog", () => {
   });
 
   describe("when the old OpenAI compliance source has been retired", () => {
-    /** @scenario "The old OpenAI source can no longer be chosen" */
+    /** @scenario "The old OpenAI source is still listed and cannot be chosen" */
     it("is not offered on any plan", () => {
       for (const isEnterprise of [true, false]) {
         const offered = gatedSourceTypeOptions({ isEnterprise }).map(

--- a/platform/app/ee/governance/dashboard/components/__tests__/ingestionSourceCatalog.unit.test.ts
+++ b/platform/app/ee/governance/dashboard/components/__tests__/ingestionSourceCatalog.unit.test.ts
@@ -78,31 +78,6 @@ describe("given the ingestion-source catalog", () => {
     });
   });
 
-  describe("when the old OpenAI compliance source has been retired", () => {
-    /** @scenario "The old OpenAI source is still listed and cannot be chosen" */
-    it("is not offered on any plan", () => {
-      for (const isEnterprise of [true, false]) {
-        const offered = gatedSourceTypeOptions({ isEnterprise }).map(
-          (o) => o.value,
-        );
-        expect(offered).not.toContain("openai_compliance");
-      }
-    });
-
-    /** @scenario "Sources already configured on the old type still display" */
-    it("still resolves a label for sources already configured on it", () => {
-      expect(SOURCE_TYPE_LABEL.openai_compliance).toBeTruthy();
-      expect(
-        SOURCE_TYPE_OPTIONS.some((o) => o.value === "openai_compliance"),
-      ).toBe(true);
-    });
-
-    /** @scenario "The old OpenAI source is still listed and cannot be chosen" */
-    it("offers the replacement that reads the same vendor", () => {
-      expect(SOURCE_TYPE_OPTIONS.map((o) => o.value)).toContain("openai_admin");
-    });
-  });
-
   describe("when a vendor's spend can only be read once", () => {
     /** @scenario "Adding a second source for the same organization warns the admin" */
     it("says in the OpenAI Admin blurb that a second source counts the spend twice", () => {

--- a/platform/app/ee/governance/dashboard/components/__tests__/ingestionSourceCatalog.unit.test.ts
+++ b/platform/app/ee/governance/dashboard/components/__tests__/ingestionSourceCatalog.unit.test.ts
@@ -79,34 +79,23 @@ describe("given the ingestion-source catalog", () => {
     });
   });
 
-  describe("when a source type has been retired", () => {
-    /** @scenario "The old OpenAI source is still listed and cannot be chosen" */
-    it("keeps the retired OpenAI source in the list", () => {
-      const options = gatedSourceTypeOptions({ isEnterprise: true });
-
-      expect(options.map((o) => o.value)).toContain("openai_compliance");
+  describe("when the old OpenAI compliance source has been retired", () => {
+    /** @scenario "The old OpenAI source can no longer be chosen" */
+    it("is not offered on any plan", () => {
+      for (const isEnterprise of [true, false]) {
+        const offered = gatedSourceTypeOptions({ isEnterprise }).map(
+          (o) => o.value,
+        );
+        expect(offered).not.toContain("openai_compliance");
+      }
     });
 
-    /** @scenario "The old OpenAI source is still listed and cannot be chosen" */
-    it("marks it retired and refuses to let it be picked", () => {
-      const options = gatedSourceTypeOptions({ isEnterprise: true });
-      const retired = options.find((o) => o.value === "openai_compliance");
-
-      expect(retired?.deprecated).toBe(true);
-      // An enterprise plan locks nothing, so the plan gate alone would leave
-      // this selectable — being retired is a separate reason to be inert.
-      expect(retired?.locked).toBe(false);
-      expect(isSourceTypeSelectable(retired!)).toBe(false);
-    });
-
-    /** @scenario "The old OpenAI source is still listed and cannot be chosen" */
-    it("leaves every other type selectable on an enterprise plan", () => {
-      const options = gatedSourceTypeOptions({ isEnterprise: true });
-      const unselectable = options
-        .filter((o) => !isSourceTypeSelectable(o))
-        .map((o) => o.value);
-
-      expect(unselectable).toEqual(["openai_compliance"]);
+    /** @scenario "Sources already configured on the old type still display" */
+    it("still resolves a label for sources already configured on it", () => {
+      expect(SOURCE_TYPE_LABEL.openai_compliance).toBeTruthy();
+      expect(
+        SOURCE_TYPE_OPTIONS.some((o) => o.value === "openai_compliance"),
+      ).toBe(true);
     });
 
     /** @scenario "The old OpenAI source is still listed and cannot be chosen" */

--- a/platform/app/ee/governance/dashboard/components/__tests__/ingestionSourceCatalog.unit.test.ts
+++ b/platform/app/ee/governance/dashboard/components/__tests__/ingestionSourceCatalog.unit.test.ts
@@ -10,7 +10,6 @@ import { describe, expect, it } from "vitest";
 import {
   gatedSourceTypeOptions,
   groupForMode,
-  isSourceTypeSelectable,
   SOURCE_GROUP_META,
   SOURCE_TYPE_LABEL,
   SOURCE_TYPE_OPTIONS,

--- a/platform/app/ee/governance/dashboard/components/__tests__/ingestionSourceCatalog.unit.test.ts
+++ b/platform/app/ee/governance/dashboard/components/__tests__/ingestionSourceCatalog.unit.test.ts
@@ -10,6 +10,7 @@ import { describe, expect, it } from "vitest";
 import {
   gatedSourceTypeOptions,
   groupForMode,
+  isSourceTypeSelectable,
   SOURCE_GROUP_META,
   SOURCE_TYPE_LABEL,
   SOURCE_TYPE_OPTIONS,
@@ -75,6 +76,42 @@ describe("given the ingestion-source catalog", () => {
     it("locks nothing", () => {
       const options = gatedSourceTypeOptions({ isEnterprise: true });
       expect(options.every((o) => !o.locked)).toBe(true);
+    });
+  });
+
+  describe("when a source type has been retired", () => {
+    /** @scenario "The old OpenAI source is still listed and cannot be chosen" */
+    it("keeps the retired OpenAI source in the list", () => {
+      const options = gatedSourceTypeOptions({ isEnterprise: true });
+
+      expect(options.map((o) => o.value)).toContain("openai_compliance");
+    });
+
+    /** @scenario "The old OpenAI source is still listed and cannot be chosen" */
+    it("marks it retired and refuses to let it be picked", () => {
+      const options = gatedSourceTypeOptions({ isEnterprise: true });
+      const retired = options.find((o) => o.value === "openai_compliance");
+
+      expect(retired?.deprecated).toBe(true);
+      // An enterprise plan locks nothing, so the plan gate alone would leave
+      // this selectable — being retired is a separate reason to be inert.
+      expect(retired?.locked).toBe(false);
+      expect(isSourceTypeSelectable(retired!)).toBe(false);
+    });
+
+    /** @scenario "The old OpenAI source is still listed and cannot be chosen" */
+    it("leaves every other type selectable on an enterprise plan", () => {
+      const options = gatedSourceTypeOptions({ isEnterprise: true });
+      const unselectable = options
+        .filter((o) => !isSourceTypeSelectable(o))
+        .map((o) => o.value);
+
+      expect(unselectable).toEqual(["openai_compliance"]);
+    });
+
+    /** @scenario "The old OpenAI source is still listed and cannot be chosen" */
+    it("offers the replacement that reads the same vendor", () => {
+      expect(SOURCE_TYPE_OPTIONS.map((o) => o.value)).toContain("openai_admin");
     });
   });
 

--- a/platform/app/ee/governance/dashboard/components/__tests__/ingestionSourceCatalog.unit.test.ts
+++ b/platform/app/ee/governance/dashboard/components/__tests__/ingestionSourceCatalog.unit.test.ts
@@ -115,6 +115,21 @@ describe("given the ingestion-source catalog", () => {
     });
   });
 
+  describe("when a vendor's spend can only be read once", () => {
+    /** @scenario "Adding a second source for the same organization warns the admin" */
+    it("says in the OpenAI Admin blurb that a second source counts the spend twice", () => {
+      const option = SOURCE_TYPE_OPTIONS.find(
+        (o) => o.value === "openai_admin",
+      );
+
+      // The warning is the copy, not a guard: nothing refuses the second
+      // source, here or on any other vendor, so the admin reads it before
+      // choosing rather than being stopped after.
+      expect(option?.blurb).toMatch(/only ever create one per organization/i);
+      expect(option?.blurb).toMatch(/count the same spend twice/i);
+    });
+  });
+
   describe("when the modes fold into customer-facing groups", () => {
     /** @scenario "The configured-source list groups under the same two headings" */
     it("sends push to the real-time group and pull plus s3 to the scheduled group", () => {

--- a/platform/app/ee/governance/dashboard/components/ingestionSourceCatalog.tsx
+++ b/platform/app/ee/governance/dashboard/components/ingestionSourceCatalog.tsx
@@ -144,8 +144,9 @@ export const SOURCE_TYPE_OPTIONS = [
     label: "OpenAI Enterprise Compliance",
     mode: "s3",
     blurb:
-      "Pulls compliance JSONL drops from an S3 bucket OpenAI writes to (Enterprise Compliance API).",
+      "Retired. It looked for compliance files in an S3 bucket OpenAI does not write to, and could never be saved. Use OpenAI Admin API (spend) instead.",
     icon: <OpenAI />,
+    deprecated: true,
   },
   {
     value: "openai_admin",
@@ -249,6 +250,16 @@ export function routesConversations(sourceType: SourceType): boolean {
 export interface GatedSourceTypeOption extends SourceTypeOption {
   /** Locked types render in the menu but cannot be picked. */
   locked: boolean;
+}
+
+/**
+ * Whether the menu must render this option inert. Two different reasons —
+ * the org's plan, and the type being retired — that the menu answers
+ * identically. Kept as one function so no surface can honour one and forget
+ * the other.
+ */
+export function isSourceTypeSelectable(option: GatedSourceTypeOption): boolean {
+  return !option.locked && option.deprecated !== true;
 }
 
 /**

--- a/platform/app/ee/governance/dashboard/components/ingestionSourceCatalog.tsx
+++ b/platform/app/ee/governance/dashboard/components/ingestionSourceCatalog.tsx
@@ -144,13 +144,12 @@ export const SOURCE_TYPE_OPTIONS = [
     label: "OpenAI Enterprise Compliance",
     mode: "s3",
     blurb:
-      "Retired. It looked for compliance files in an S3 bucket OpenAI does not write to, and could never be saved. Use OpenAI Admin API (spend) instead.",
+      "Pulls compliance JSONL drops from an S3 bucket OpenAI writes to (Enterprise Compliance API).",
     icon: <OpenAI />,
-    deprecated: true,
   },
   {
     value: "openai_admin",
-    label: "OpenAI Admin API (spend)",
+    label: "OpenAI Admin",
     mode: "pull",
     blurb:
       "Reads your OpenAI organization's daily spend with an Admin API key (sk-admin-...), broken down by project, line item, the person who spent it and the API key it was billed to. A regular project key is refused. Only ever create one per organization — a second source would count the same spend twice.",
@@ -253,27 +252,12 @@ export interface GatedSourceTypeOption extends SourceTypeOption {
 }
 
 /**
- * Whether the menu must render this option inert. Two different reasons —
- * the org's plan, and the type being retired — that the menu answers
- * identically. Kept as one function so no surface can honour one and forget
- * the other.
- */
-export function isSourceTypeSelectable(option: GatedSourceTypeOption): boolean {
-  return !option.locked && option.deprecated !== true;
-}
-
-/**
  * The one plan gate. Non-enterprise plans may only create Generic
  * OpenTelemetry sources; every other type stays visible so the menu can say
  * what an Enterprise plan unlocks, but is inert. The Add source menu is the
  * only surface that reads this list, and the composer is only reachable
  * through the menu's onPick — so this one gate covers both. Never re-filter
  * SOURCE_TYPE_OPTIONS at a callsite, or a locked type leaks through.
- *
- * Retired types drop out here rather than being locked. A locked entry is a
- * sales message — "this is what Enterprise unlocks" — and a retired source is
- * not something anyone should be sold. It stays in SOURCE_TYPE_OPTIONS only
- * so rows already configured on it keep a label.
  */
 export function gatedSourceTypeOptions({
   isEnterprise,

--- a/platform/app/ee/governance/dashboard/components/ingestionSourceCatalog.tsx
+++ b/platform/app/ee/governance/dashboard/components/ingestionSourceCatalog.tsx
@@ -148,6 +148,14 @@ export const SOURCE_TYPE_OPTIONS = [
     icon: <OpenAI />,
   },
   {
+    value: "openai_admin",
+    label: "OpenAI Admin API (spend)",
+    mode: "pull",
+    blurb:
+      "Reads your OpenAI organization's daily spend with an Admin API key (sk-admin-...), broken down by project, line item, the person who spent it and the API key it was billed to. A regular project key is refused. Only ever create one per organization — a second source would count the same spend twice.",
+    icon: <OpenAI />,
+  },
+  {
     value: "claude_compliance",
     label: "Anthropic Claude Enterprise Compliance",
     mode: "pull",
@@ -283,6 +291,7 @@ const MONOCHROME_SOURCE_ICONS = new Set<SourceType>([
   "claude_compliance",
   "anthropic_admin",
   "openai_compliance",
+  "openai_admin",
   "http_custom",
 ]);
 

--- a/platform/app/ee/governance/dashboard/logic/pullCadence.ts
+++ b/platform/app/ee/governance/dashboard/logic/pullCadence.ts
@@ -61,6 +61,7 @@ export const PULL_ADAPTER_FOR_SOURCE: Partial<Record<SourceType, string>> = {
   copilot_studio: "copilot_studio",
   copilot_studio_dataverse: "copilot_studio_dataverse",
   openai_compliance: "openai_compliance",
+  openai_admin: "openai_admin",
   claude_compliance: "claude_compliance",
   anthropic_admin: "anthropic_admin",
   databricks_genie: "databricks_genie",
@@ -80,6 +81,9 @@ export const PULL_SCHEDULE_DEFAULTS: Record<string, string> = {
   // to a delay the customer already feels.
   copilot_studio_dataverse: "*/15 * * * *",
   openai_compliance: "*/15 * * * *",
+  // Hourly. The report is bucketed by day, so finer polling reads the same
+  // bucket over and over for nothing.
+  openai_admin: "0 * * * *",
   claude_compliance: "*/15 * * * *",
   anthropic_admin: "0 * * * *",
   databricks_genie: "*/15 * * * *",

--- a/platform/app/ee/governance/dashboard/pages/inventory.tsx
+++ b/platform/app/ee/governance/dashboard/pages/inventory.tsx
@@ -224,6 +224,13 @@ function resolvePullConfig(
       "Missing required Copilot Studio fields",
       "The environment URL is required, plus all three parts of the app registration: tenant ID, client ID and client secret.",
     ],
+    openai_admin: [
+      () => buildOpenAiAdminPullConfig(composer, { shouldRequireCredentials }),
+      "Missing or invalid OpenAI fields",
+      shouldRequireCredentials
+        ? "An organization Admin API key is required, and the backfill start must be a calendar date (2026-08-01) or an instant carrying a timezone (2026-08-01T00:00:00Z)."
+        : "The backfill start must be a calendar date (2026-08-01) or an instant carrying a timezone (2026-08-01T00:00:00Z). Leave the admin API key blank to keep the current one.",
+    ],
     anthropic_admin: [
       () =>
         buildAnthropicAdminPullConfig(composer, { shouldRequireCredentials }),
@@ -1900,6 +1907,25 @@ export const PARSER_FIELDS: Record<SourceType, FieldDef[]> = {
       placeholder: "60",
     },
   ],
+  openai_admin: [
+    {
+      // `credentials*` prefix routes this into the encrypted `credentials`
+      // subtree — the only part of the config the server encrypts at rest.
+      key: "credentialsToken",
+      label: "Admin API key",
+      placeholder: "sk-admin-...",
+      hint: "Generate under OpenAI Platform → Settings → Organization → Admin keys. A regular project key returns 401 on the organization reports. We encrypt this server-side.",
+      required: true,
+      secret: true,
+    },
+    {
+      key: "startingAt",
+      label: "Backfill start (optional)",
+      placeholder: "",
+      hint: "The day the first run reads from. Later runs follow on from where the last one stopped. Empty = 3 calendar days back at midnight UTC. Spend broken down by API key is only available from December 2025 onward; earlier days are still read and still name the person, just not the key.",
+      control: "date",
+    },
+  ],
   claude_compliance: [
     {
       key: "workspaceApiKey",
@@ -2245,6 +2271,43 @@ export function buildAnthropicAdminPullConfig(
     schedule:
       c.pullSchedule.trim() ||
       PULL_SCHEDULE_DEFAULTS.anthropic_admin ||
+      "0 * * * *",
+    ...(token ? { credentials: { token } } : {}),
+  };
+}
+
+/**
+ * The OpenAI Admin adapter config, or null when a required field is empty or
+ * the backfill start is not a date the adapter will accept. Nothing validates
+ * pullConfig against the adapter schema at save time, so the builder is the
+ * last checkpoint before the database.
+ *
+ * There is no report to choose: the adapter pulls the cost report and only the
+ * cost report, because the provider's usage surface returns nothing for spend
+ * the cost surface bills. `shouldRequireCredentials` carries the same meaning
+ * as it does for Anthropic above — on edit a blank key means "leave it alone",
+ * so the key must be OMITTED rather than written empty.
+ */
+export function buildOpenAiAdminPullConfig(
+  c: ComposerState,
+  {
+    shouldRequireCredentials = true,
+  }: { shouldRequireCredentials?: boolean } = {},
+): Record<string, unknown> | null {
+  const p = c.parserConfig;
+  const token = trimmedField(p, "credentialsToken");
+  if (!token && shouldRequireCredentials) return null;
+
+  const startingAt = normalizeStartingAt(trimmedField(p, "startingAt"));
+  if (startingAt === null) return null;
+
+  return {
+    adapter: "openai_admin",
+    report: "cost",
+    ...(startingAt ? { startingAt } : {}),
+    schedule:
+      c.pullSchedule.trim() ||
+      PULL_SCHEDULE_DEFAULTS.openai_admin ||
       "0 * * * *",
     ...(token ? { credentials: { token } } : {}),
   };
@@ -2711,6 +2774,10 @@ const PULL_CONFIG_OWNED_FIELDS: Partial<Record<SourceType, readonly string[]>> =
     // winning the merge would fail the adapter's `.datetime()` check at
     // pull time.
     anthropic_admin: ["report", "bucketWidth", "startingAt"],
+    // Same reason as `startingAt` above: the builder normalizes it to an ISO
+    // instant, and the raw form value winning the merge would fail the
+    // adapter's `.datetime()` check at pull time.
+    openai_admin: ["startingAt"],
     // `warehouseId` is here because the builder DROPS it when empty. Left to
     // the merge, the raw form value would persist `warehouseId: ""`, which the
     // adapter reads as a warehouse to go ask the workspace about.
@@ -2851,6 +2918,9 @@ export function seedPullSchedule({
  */
 const EDITABLE_PULL_CONFIG_SOURCE_TYPES: readonly SourceType[] = [
   "anthropic_admin",
+  // Answers the blank-secret question the same way: one credential, so a
+  // blank field can only mean "keep the stored key".
+  "openai_admin",
 ];
 
 /**

--- a/platform/app/ee/governance/dashboard/pages/inventory.tsx
+++ b/platform/app/ee/governance/dashboard/pages/inventory.tsx
@@ -188,6 +188,7 @@ export const SOURCE_TYPES_WITH_PULL_CONFIG_BUILDER = [
   "http_custom",
   "databricks_genie",
   "copilot_studio_dataverse",
+  "openai_admin",
   "anthropic_admin",
 ] as const;
 

--- a/platform/app/ee/governance/services/activity-monitor/__tests__/ingestionSourceTokenAtRest.integration.test.ts
+++ b/platform/app/ee/governance/services/activity-monitor/__tests__/ingestionSourceTokenAtRest.integration.test.ts
@@ -190,3 +190,46 @@ describe("given an admin saves a Genie source carrying a client id and secret", 
     }, 60_000);
   });
 });
+
+describe("given an admin saves an OpenAI Admin source carrying an admin API key", () => {
+  describe("when the source is saved through the service", () => {
+    /** @scenario "The Admin API key is never stored in plain text" */
+    it("stores the key encrypted and unreadable from the source's configuration", async () => {
+      const token = `sk-admin-${nanoid(24)}`;
+      const service = IngestionSourceService.create(prisma);
+
+      // The pullConfig the governance composer produces for the OpenAI Admin
+      // cost source, with the key in PLAINTEXT — the service is the one that
+      // must encrypt it, so encrypting it here would test nothing.
+      const { source } = await service.createSource({
+        organizationId,
+        sourceType: "openai_admin",
+        name: `openai-admin-key-at-rest-${ns}`,
+        pullConfig: {
+          adapter: "openai_admin",
+          report: "cost",
+          startingAt: "2026-07-01T00:00:00.000Z",
+          schedule: "0 * * * *",
+          credentials: { token },
+        },
+        pullSchedule: "0 * * * *",
+        actorUserId,
+      });
+
+      const row = await prisma.ingestionSource.findUniqueOrThrow({
+        where: { id: source.id },
+      });
+      const stored = row.parserConfig as Record<string, unknown>;
+
+      // The whole serialised row, so a key leaking into any other field is
+      // caught, not just one that stayed under `credentials`.
+      expect(JSON.stringify(stored)).not.toContain(token);
+
+      expect(typeof stored.credentials).toBe("string");
+      expect(stored.credentials as string).toMatch(/^enc:v1:/);
+
+      // Encrypted is not the same as lost — the puller still authenticates.
+      expect(decryptCredentials(stored.credentials)).toEqual({ token });
+    }, 60_000);
+  });
+});

--- a/platform/app/ee/governance/services/activity-monitor/ingestionSource.service.ts
+++ b/platform/app/ee/governance/services/activity-monitor/ingestionSource.service.ts
@@ -57,6 +57,7 @@ export type SourceType =
   | "copilot_studio"
   | "copilot_studio_dataverse"
   | "openai_compliance"
+  | "openai_admin"
   | "claude_compliance"
   | "anthropic_admin"
   | "databricks_genie"
@@ -71,6 +72,7 @@ export const SUPPORTED_SOURCE_TYPES: readonly SourceType[] = [
   "copilot_studio",
   "copilot_studio_dataverse",
   "openai_compliance",
+  "openai_admin",
   "claude_compliance",
   "anthropic_admin",
   "databricks_genie",

--- a/platform/app/ee/governance/services/pullers/__tests__/openaiAdminPuller.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/openaiAdminPuller.unit.test.ts
@@ -510,6 +510,121 @@ describe("given an OpenAI Admin cost source", () => {
     });
   });
 
+  describe("when the key-grouping upgrade crosses a drain boundary", () => {
+    const QUERY_ID = `cost:1d:project_id,line_item,user_id,api_key_id:${CONFIG.startingAt}`;
+
+    /** @scenario "Spend is not doubled when the grouping dimension changes across a drain" */
+    it("skips the lookback so the keyed window does not overlap the user-only window", async () => {
+      const puller = new OpenAiAdminPuller();
+
+      // Run 1: backfill below the floor — API refuses key grouping.
+      fetchMock
+        .mockResolvedValueOnce(KEY_GROUPING_REFUSAL)
+        .mockResolvedValueOnce(
+          jsonResponse(
+            page({
+              results: [
+                costRow({ api_key_id: null, project_id: null, line_item: null }),
+              ],
+            }),
+          ),
+        );
+
+      const run1 = await puller.runOnce(RUN_OPTIONS, CONFIG);
+      const cursor1 = JSON.parse(run1.cursor!);
+      expect(cursor1.hasKeyGrouping).toBe(true);
+      expect(cursor1.keyGroupingUpgrade).toBe(true);
+
+      // Run 2: API now accepts key grouping (window advanced past the floor).
+      fetchMock.mockResolvedValue(jsonResponse(page()));
+
+      const run2 = await puller.runOnce(
+        { ...RUN_OPTIONS, cursor: run1.cursor! },
+        CONFIG,
+      );
+
+      // The request must start at the stored watermark, NOT three days before.
+      // Three days before would re-read buckets that were emitted with user-only
+      // dimensions, producing different source_event_ids and doubling spend.
+      const run2Start = Number(
+        requestedUrl(2).searchParams.get("start_time"),
+      );
+      expect(run2Start).toBe(
+        Math.floor(Date.parse(cursor1.startingAt) / 1000),
+      );
+
+      // Key grouping was used.
+      expect(
+        requestedUrl(2).searchParams.getAll("group_by[]"),
+      ).toContain("api_key_id");
+
+      // The upgrade flag clears once key grouping succeeds.
+      const cursor2 = JSON.parse(run2.cursor!);
+      expect(cursor2.keyGroupingUpgrade).toBe(false);
+    });
+
+    /** @scenario "Spend is not doubled when the grouping dimension changes across a drain" */
+    it("keeps the upgrade flag when the API still refuses key grouping", async () => {
+      const puller = new OpenAiAdminPuller();
+      const cursor = JSON.stringify({
+        startingAt: BUCKET_START_ISO,
+        page: null,
+        query: QUERY_ID,
+        watermark: null,
+        hasKeyGrouping: true,
+        keyGroupingUpgrade: true,
+      });
+
+      // API still refuses key grouping below the floor.
+      fetchMock
+        .mockResolvedValueOnce(KEY_GROUPING_REFUSAL)
+        .mockResolvedValueOnce(
+          jsonResponse(
+            page({
+              results: [
+                costRow({ api_key_id: null, project_id: null, line_item: null }),
+              ],
+            }),
+          ),
+        );
+
+      const result = await puller.runOnce(
+        { ...RUN_OPTIONS, cursor },
+        CONFIG,
+      );
+
+      const nextCursor = JSON.parse(result.cursor!);
+      expect(nextCursor.hasKeyGrouping).toBe(true);
+      expect(nextCursor.keyGroupingUpgrade).toBe(true);
+    });
+
+    /** @scenario "Spend is not doubled when the grouping dimension changes across a drain" */
+    it("resumes normal lookback once key grouping is stable", async () => {
+      const puller = new OpenAiAdminPuller();
+
+      // A cursor from a successful keyed window — no upgrade pending.
+      const cursor = JSON.stringify({
+        startingAt: BUCKET_START_ISO,
+        page: null,
+        query: QUERY_ID,
+        watermark: null,
+        hasKeyGrouping: true,
+        keyGroupingUpgrade: false,
+      });
+
+      fetchMock.mockResolvedValue(jsonResponse(page()));
+
+      await puller.runOnce({ ...RUN_OPTIONS, cursor }, CONFIG);
+
+      // The lookback should be applied: start_time is BEFORE the stored start.
+      const requestedStart = Number(
+        requestedUrl(0).searchParams.get("start_time"),
+      );
+      const storedStart = Math.floor(Date.parse(BUCKET_START_ISO) / 1000);
+      expect(requestedStart).toBeLessThan(storedStart);
+    });
+  });
+
   describe("when a run cannot finish", () => {
     /** @scenario "A failed read leaves the source where it was" */
     it("holds the cursor still and reports the failure", async () => {

--- a/platform/app/ee/governance/services/pullers/__tests__/openaiAdminPuller.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/openaiAdminPuller.unit.test.ts
@@ -550,7 +550,7 @@ describe("given an OpenAI Admin cost source", () => {
         page: null,
         query: `cost:1d:project_id,line_item,user_id,api_key_id:${CONFIG.startingAt}`,
         watermark: null,
-        keyGrouping: true,
+        hasKeyGrouping: true,
       });
 
       const starts: string[] = [];
@@ -613,7 +613,7 @@ describe("given an OpenAI Admin cost source", () => {
         query:
           "cost:1d:project_id,line_item,user_id,api_key_id:2026-06-01T00:00:00.000Z",
         watermark: null,
-        keyGrouping: true,
+        hasKeyGrouping: true,
       });
 
       await new OpenAiAdminPuller().runOnce(
@@ -633,7 +633,7 @@ describe("given an OpenAI Admin cost source", () => {
         query:
           "cost:1d:project_id,line_item,user_id,api_key_id:2026-07-01T00:00:00.000Z",
         watermark: null,
-        keyGrouping: true,
+        hasKeyGrouping: true,
       });
 
       await new OpenAiAdminPuller().runOnce(
@@ -664,6 +664,25 @@ describe("given an OpenAI Admin cost source", () => {
 
       // The euro row is dropped; the rest of the bucket still lands. A throw
       // here would discard the whole run and fail identically on every retry.
+      expect(result.events).toHaveLength(1);
+      expect(result.errorCount).toBe(0);
+    });
+
+    it("skips a row whose currency is missing rather than assuming USD", async () => {
+      const noCurrency = costRow();
+      // Remove currency entirely — the adapter must not infer a denomination.
+      delete (noCurrency.amount as Record<string, unknown>).currency;
+      fetchMock.mockResolvedValue(
+        jsonResponse(
+          page({
+            results: [noCurrency, costRow({ project_id: "proj_b" })],
+          }),
+        ),
+      );
+
+      const result = await new OpenAiAdminPuller().runOnce(RUN_OPTIONS, CONFIG);
+
+      // The no-currency row is skipped; only the second row lands.
       expect(result.events).toHaveLength(1);
       expect(result.errorCount).toBe(0);
     });

--- a/platform/app/ee/governance/services/pullers/__tests__/openaiAdminPuller.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/openaiAdminPuller.unit.test.ts
@@ -1,0 +1,599 @@
+// SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+
+/**
+ * The OpenAI Admin cost adapter. The transport is stubbed; what is under test
+ * is the bucket → record mapping, the money surviving unconverted, the
+ * trailing re-read, and the fallback when the provider refuses to group a
+ * window by API key.
+ *
+ * Spec: specs/ai-governance/puller-framework/openai-admin-cost.feature
+ * Decision: ADR-122.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ZodError } from "zod";
+
+const { fetchMock } = vi.hoisted(() => ({ fetchMock: vi.fn() }));
+vi.mock("~/utils/ssrfProtection", () => ({
+  ssrfSafeFetch: (...args: unknown[]) => fetchMock(...args),
+}));
+
+import {
+  OPENAI_ADMIN_ADAPTER_ID,
+  OpenAiAdminPuller,
+} from "../openaiAdmin.puller";
+import { buildPulledUsageRecord } from "../pulledUsageRecord";
+
+const SOURCE = {
+  ingestionSourceId: "src_1",
+  sourceType: OPENAI_ADMIN_ADAPTER_ID,
+  organizationId: "org_acme",
+  teamId: "team_platform",
+};
+const OBSERVED_AT = new Date("2026-08-26T09:00:00.000Z");
+
+/** 2026-08-01T00:00:00Z, the shape the API reports a bucket start in. */
+const BUCKET_START_EPOCH = 1785542400;
+const BUCKET_START_ISO = "2026-08-01T00:00:00.000Z";
+
+const CONFIG = {
+  adapter: OPENAI_ADMIN_ADAPTER_ID,
+  report: "cost",
+  startingAt: "2026-07-01T00:00:00.000Z",
+  schedule: "0 * * * *",
+} as const;
+
+const RUN_OPTIONS = { cursor: null, credentials: { token: "sk-admin" } };
+
+function jsonResponse(body: unknown) {
+  return { ok: true, status: 200, statusText: "OK", json: async () => body };
+}
+
+/** The provider's own 400 envelope, verbatim in shape. */
+function errorResponse({
+  status,
+  param,
+  code,
+  message,
+}: {
+  status: number;
+  param: string | null;
+  code: string;
+  message: string;
+}) {
+  return {
+    ok: false,
+    status,
+    statusText: "Bad Request",
+    text: async () =>
+      JSON.stringify({
+        error: { message, type: "invalid_request_error", param, code },
+      }),
+    json: async () => ({}),
+  };
+}
+
+const KEY_GROUPING_REFUSAL = errorResponse({
+  status: 400,
+  param: "start_time",
+  code: "invalid_request_error",
+  message:
+    "group_by=api_key_id is not available for this time range. Try a start_time on or after 1764979200.",
+});
+
+/**
+ * `amount.value` is a JSON number in DOLLARS. The sibling adapter's provider
+ * reports cents; a decimal shift here would report a hundred times this.
+ */
+function costRow(overrides: Record<string, unknown> = {}) {
+  return {
+    object: "organization.costs.result",
+    amount: { value: 0.0025945, currency: "usd" },
+    line_item: "gpt-5, input",
+    project_id: "proj_a",
+    organization_id: "org_acme",
+    user_id: "user-1",
+    user_email: "someone@example.com",
+    api_key_id: "key_a",
+    ...overrides,
+  };
+}
+
+function page({
+  results = [costRow()],
+  startTime = BUCKET_START_EPOCH,
+  nextPage = null,
+  hasMore = false,
+}: {
+  results?: unknown[];
+  startTime?: number;
+  nextPage?: string | null;
+  hasMore?: boolean;
+} = {}) {
+  return {
+    data: [
+      { start_time: startTime, end_time: startTime + 86400, results },
+    ],
+    has_more: hasMore,
+    next_page: nextPage,
+  };
+}
+
+function requestedUrl(callIndex = 0): URL {
+  return new URL(String(fetchMock.mock.calls[callIndex]?.[0]));
+}
+
+describe("given an OpenAI Admin cost source", () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+  });
+
+  describe("when the provider reports a day's spend", () => {
+    /** @scenario "A day's spend is recorded as the dollars the provider reported" */
+    it("records the provider's dollars without converting them", async () => {
+      fetchMock.mockResolvedValue(jsonResponse(page()));
+
+      const result = await new OpenAiAdminPuller().runOnce(RUN_OPTIONS, CONFIG);
+
+      expect(result.events).toHaveLength(1);
+      // To the digit. A cents→dollars shift would make this 0.000025945.
+      expect(result.events[0]?.cost_usd).toBe("0.0025945");
+    });
+
+    /** @scenario "A fraction of a cent survives the record" */
+    it("keeps every digit of a sub-cent figure through to the record", async () => {
+      fetchMock.mockResolvedValue(
+        jsonResponse(
+          page({ results: [costRow({ amount: { value: 0.0000001234, currency: "usd" } })] }),
+        ),
+      );
+
+      const result = await new OpenAiAdminPuller().runOnce(RUN_OPTIONS, CONFIG);
+      const record = buildPulledUsageRecord({
+        event: result.events[0]!,
+        source: SOURCE,
+        observedAt: OBSERVED_AT,
+      });
+
+      expect(record?.costNanoUsd).toBeGreaterThan(0);
+    });
+
+    /** @scenario "Spend is called an estimate, not the invoice" */
+    it("marks the figure the provider's own, and an estimate", async () => {
+      fetchMock.mockResolvedValue(jsonResponse(page()));
+
+      const result = await new OpenAiAdminPuller().runOnce(RUN_OPTIONS, CONFIG);
+      const record = buildPulledUsageRecord({
+        event: result.events[0]!,
+        source: SOURCE,
+        observedAt: OBSERVED_AT,
+      });
+
+      expect(record?.costBasis).toBe("provider_reported");
+      expect(record?.costStatus).toBe("estimate");
+    });
+
+    /** @scenario "Spend is attributed to the person the provider named" */
+    it("names the person by email and carries the provider's raw id", async () => {
+      fetchMock.mockResolvedValue(jsonResponse(page()));
+
+      const result = await new OpenAiAdminPuller().runOnce(RUN_OPTIONS, CONFIG);
+      const event = result.events[0]!;
+
+      expect(event.actor).toBe("someone@example.com");
+      expect(event.extra?.actorUserId).toBe("user-1");
+    });
+
+    /** @scenario "The credential the spend was billed to is recorded" */
+    it("carries the API key the spend was billed against", async () => {
+      fetchMock.mockResolvedValue(jsonResponse(page()));
+
+      const result = await new OpenAiAdminPuller().runOnce(RUN_OPTIONS, CONFIG);
+
+      expect(result.events[0]?.extra?.apiKeyId).toBe("key_a");
+    });
+
+    /** @scenario "Nobody is looked up while pulling" */
+    it("asks the provider for nothing but the cost report", async () => {
+      fetchMock.mockResolvedValue(jsonResponse(page()));
+
+      await new OpenAiAdminPuller().runOnce(RUN_OPTIONS, CONFIG);
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(requestedUrl().pathname).toBe("/v1/organization/costs");
+    });
+
+    /** @scenario "Only the cost report is read" */
+    it("sends the four dimensions the report is keyed on, daily, at the page ceiling", async () => {
+      fetchMock.mockResolvedValue(jsonResponse(page()));
+
+      await new OpenAiAdminPuller().runOnce(RUN_OPTIONS, CONFIG);
+      const url = requestedUrl();
+
+      expect(url.searchParams.getAll("group_by[]")).toEqual([
+        "project_id",
+        "line_item",
+        "user_id",
+        "api_key_id",
+      ]);
+      expect(url.searchParams.get("bucket_width")).toBe("1d");
+      expect(url.searchParams.get("limit")).toBe("180");
+      // A window whose end moves with the clock invalidates every page token.
+      expect(url.searchParams.has("end_time")).toBe(false);
+      // Epoch seconds, not an ISO instant.
+      expect(url.searchParams.get("start_time")).toBe(
+        String(Date.parse(CONFIG.startingAt) / 1000),
+      );
+    });
+  });
+
+  describe("when a bucket carries no spend", () => {
+    /** @scenario "A day whose spend has vanished keeps the figure it had" */
+    it("writes no usage record at all rather than a zero", async () => {
+      fetchMock.mockResolvedValue(jsonResponse(page({ results: [] })));
+
+      const result = await new OpenAiAdminPuller().runOnce(RUN_OPTIONS, CONFIG);
+
+      // No event means no hint, and no hint means the ledger is untouched —
+      // a zero written here would win argMax against a confirmed figure.
+      expect(result.events).toEqual([]);
+    });
+
+    /** @scenario "A day with no spend at all is still read past" */
+    it("still moves past the empty day", async () => {
+      fetchMock.mockResolvedValue(jsonResponse(page({ results: [] })));
+
+      const result = await new OpenAiAdminPuller().runOnce(RUN_OPTIONS, CONFIG);
+
+      expect(JSON.parse(result.cursor!).startingAt).toBe(BUCKET_START_ISO);
+    });
+  });
+
+  describe("when the provider corrects a day it already reported", () => {
+    /** @scenario "A corrected day replaces its earlier figure rather than adding one" */
+    it("keys the correction onto the same record as the original", async () => {
+      const puller = new OpenAiAdminPuller();
+
+      fetchMock.mockResolvedValue(jsonResponse(page()));
+      const first = await puller.runOnce(RUN_OPTIONS, CONFIG);
+
+      fetchMock.mockResolvedValue(
+        jsonResponse(
+          page({ results: [costRow({ amount: { value: 9.99, currency: "usd" } })] }),
+        ),
+      );
+      const second = await puller.runOnce(RUN_OPTIONS, CONFIG);
+
+      const before = buildPulledUsageRecord({
+        event: first.events[0]!,
+        source: SOURCE,
+        observedAt: OBSERVED_AT,
+      });
+      const after = buildPulledUsageRecord({
+        event: second.events[0]!,
+        source: SOURCE,
+        observedAt: new Date(OBSERVED_AT.getTime() + 60_000),
+      });
+
+      expect(after?.restatementKey).toBe(before?.restatementKey);
+      expect(after?.costNanoUsd).not.toBe(before?.costNanoUsd);
+    });
+
+    /** @scenario "Re-reading an unchanged day records nothing new" */
+    it("produces the identical record when nothing changed", async () => {
+      const puller = new OpenAiAdminPuller();
+      fetchMock.mockResolvedValue(jsonResponse(page()));
+
+      const first = await puller.runOnce(RUN_OPTIONS, CONFIG);
+      const second = await puller.runOnce(RUN_OPTIONS, CONFIG);
+
+      expect(second.events[0]?.source_event_id).toBe(
+        first.events[0]?.source_event_id,
+      );
+      expect(second.events[0]?.cost_usd).toBe(first.events[0]?.cost_usd);
+    });
+
+    /** @scenario "The source keeps looking back far enough to see a correction" */
+    it("starts the next run behind its own watermark", async () => {
+      const puller = new OpenAiAdminPuller();
+      fetchMock.mockResolvedValue(jsonResponse(page()));
+
+      const first = await puller.runOnce(RUN_OPTIONS, CONFIG);
+      await puller.runOnce({ ...RUN_OPTIONS, cursor: first.cursor }, CONFIG);
+
+      const secondRunStart = Number(
+        requestedUrl(1).searchParams.get("start_time"),
+      );
+      // Three days behind the bucket the first run ended on.
+      expect(secondRunStart).toBe(BUCKET_START_EPOCH - 3 * 86400);
+    });
+
+    /** @scenario "The source keeps looking back far enough to see a correction" */
+    it("never looks back past the start an admin configured", async () => {
+      const puller = new OpenAiAdminPuller();
+      fetchMock.mockResolvedValue(jsonResponse(page()));
+
+      const config = { ...CONFIG, startingAt: "2026-07-31T00:00:00.000Z" };
+      const first = await puller.runOnce(RUN_OPTIONS, config);
+      await puller.runOnce({ ...RUN_OPTIONS, cursor: first.cursor }, config);
+
+      expect(Number(requestedUrl(1).searchParams.get("start_time"))).toBe(
+        Math.floor(Date.parse("2026-07-31T00:00:00.000Z") / 1000),
+      );
+    });
+
+    /** @scenario "Looking back never rewinds the source's progress" */
+    it("keeps the newest bucket even when the page arrives out of order", async () => {
+      fetchMock.mockResolvedValue(
+        jsonResponse({
+          data: [
+            {
+              start_time: BUCKET_START_EPOCH,
+              results: [costRow()],
+            },
+            {
+              start_time: BUCKET_START_EPOCH - 86400,
+              results: [costRow({ api_key_id: "key_b" })],
+            },
+          ],
+          has_more: false,
+          next_page: null,
+        }),
+      );
+
+      const result = await new OpenAiAdminPuller().runOnce(RUN_OPTIONS, CONFIG);
+
+      // The LATEST bucket, not the last one in the array. Ordering is observed
+      // but not guaranteed, so nothing here may depend on it.
+      expect(JSON.parse(result.cursor!).startingAt).toBe(BUCKET_START_ISO);
+    });
+  });
+
+  describe("when the provider refuses to group a window by API key", () => {
+    /** @scenario "Older spend is still recorded and still names the person" */
+    it("re-reads the same window without that dimension", async () => {
+      fetchMock
+        .mockResolvedValueOnce(KEY_GROUPING_REFUSAL)
+        .mockResolvedValueOnce(
+          jsonResponse(page({ results: [costRow({ api_key_id: null })] })),
+        );
+
+      const result = await new OpenAiAdminPuller().runOnce(RUN_OPTIONS, CONFIG);
+
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      // Same window, one dimension fewer.
+      expect(requestedUrl(1).searchParams.get("start_time")).toBe(
+        requestedUrl(0).searchParams.get("start_time"),
+      );
+      expect(requestedUrl(1).searchParams.getAll("group_by[]")).toEqual([
+        "project_id",
+        "line_item",
+        "user_id",
+      ]);
+      expect(result.events).toHaveLength(1);
+      expect(result.events[0]?.extra?.actorUserId).toBe("user-1");
+    });
+
+    /** @scenario "Older spend says nothing about which key was used" */
+    it("leaves the key out of the record's coordinates rather than claiming an empty one", async () => {
+      fetchMock
+        .mockResolvedValueOnce(KEY_GROUPING_REFUSAL)
+        .mockResolvedValueOnce(
+          jsonResponse(page({ results: [costRow({ api_key_id: null })] })),
+        );
+
+      const result = await new OpenAiAdminPuller().runOnce(RUN_OPTIONS, CONFIG);
+      const hint = result.events[0]?.extra?.pulled_usage as {
+        dimensions: Record<string, string>;
+      };
+
+      expect(Object.keys(hint.dimensions)).not.toContain("apiKeyId");
+      expect(hint.dimensions.userId).toBe("user-1");
+    });
+
+    /** @scenario "A refusal about anything else is not mistaken for the cutoff" */
+    it("does not drop the dimension for a differently-shaped rejection", async () => {
+      fetchMock.mockResolvedValue(
+        errorResponse({
+          status: 400,
+          param: "start_time",
+          // A date it could not parse — same param, different code.
+          code: "invalid_type",
+          message: "Invalid type for 'start_time'.",
+        }),
+      );
+
+      const result = await new OpenAiAdminPuller().runOnce(RUN_OPTIONS, CONFIG);
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(result.errorCount).toBe(1);
+      expect(result.cursor).toBeNull();
+    });
+
+    /** @scenario "A refusal about anything else is not mistaken for the cutoff" */
+    it("does not drop the dimension when the limit is what was refused", async () => {
+      fetchMock.mockResolvedValue(
+        errorResponse({
+          status: 400,
+          param: null,
+          code: "invalid_request_error",
+          message: "Limit must be less than or equal to 180.",
+        }),
+      );
+
+      const result = await new OpenAiAdminPuller().runOnce(RUN_OPTIONS, CONFIG);
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(result.errorCount).toBe(1);
+    });
+
+    it("keeps asking without the key for the rest of the window it fell back on", async () => {
+      const puller = new OpenAiAdminPuller();
+      fetchMock
+        .mockResolvedValueOnce(KEY_GROUPING_REFUSAL)
+        .mockResolvedValueOnce(
+          jsonResponse(
+            page({
+              results: [costRow({ api_key_id: null })],
+              nextPage: "page_2",
+              hasMore: true,
+            }),
+          ),
+        )
+        .mockResolvedValue(
+          jsonResponse(page({ results: [costRow({ api_key_id: null })] })),
+        );
+
+      await puller.runOnce(RUN_OPTIONS, CONFIG);
+
+      // The page token is bound to the query that minted it, so the third
+      // request must carry the same three dimensions as the second.
+      expect(requestedUrl(2).searchParams.getAll("group_by[]")).toEqual([
+        "project_id",
+        "line_item",
+        "user_id",
+      ]);
+      expect(requestedUrl(2).searchParams.get("page")).toBe("page_2");
+    });
+  });
+
+  describe("when a run cannot finish", () => {
+    /** @scenario "A failed read leaves the source where it was" */
+    it("holds the cursor still and reports the failure", async () => {
+      fetchMock.mockRejectedValue(new Error("connection reset"));
+
+      const result = await new OpenAiAdminPuller().runOnce(
+        { ...RUN_OPTIONS, cursor: "prior-cursor" },
+        CONFIG,
+      );
+
+      expect(result.cursor).toBe("prior-cursor");
+      expect(result.errorCount).toBe(1);
+      expect(result.events).toEqual([]);
+    });
+
+    /** @scenario "A failed read leaves the source where it was" */
+    it("keeps the pages it already read when the deadline passes", async () => {
+      fetchMock.mockResolvedValue(
+        jsonResponse(page({ nextPage: "page_2", hasMore: true })),
+      );
+
+      const result = await new OpenAiAdminPuller().runOnce(
+        { ...RUN_OPTIONS, deadlineMs: Date.now() + 5 },
+        CONFIG,
+      );
+
+      expect(result.errorCount).toBe(0);
+      expect(result.events.length).toBeGreaterThan(0);
+      expect(JSON.parse(result.cursor!).page).toBe("page_2");
+    });
+
+    /** @scenario "Every page of a window is read" */
+    it("follows the page token to the end of the window", async () => {
+      fetchMock
+        .mockResolvedValueOnce(
+          jsonResponse(page({ nextPage: "page_2", hasMore: true })),
+        )
+        .mockResolvedValueOnce(
+          jsonResponse(
+            page({
+              startTime: BUCKET_START_EPOCH + 86400,
+              results: [costRow({ project_id: "proj_b" })],
+            }),
+          ),
+        );
+
+      const result = await new OpenAiAdminPuller().runOnce(RUN_OPTIONS, CONFIG);
+
+      expect(result.events).toHaveLength(2);
+      expect(requestedUrl(1).searchParams.get("page")).toBe("page_2");
+    });
+
+    it("refuses a page claiming more data with no token to reach it", async () => {
+      fetchMock.mockResolvedValue(
+        jsonResponse(page({ hasMore: true, nextPage: null })),
+      );
+
+      await expect(
+        new OpenAiAdminPuller().runOnce(RUN_OPTIONS, CONFIG),
+      ).rejects.toThrow(/has_more with no next_page/);
+    });
+
+    /** @scenario "A page token is never replayed under a changed question" */
+    it("discards a page token minted under a different backfill start", async () => {
+      fetchMock.mockResolvedValue(jsonResponse(page()));
+      const stale = JSON.stringify({
+        startingAt: "2026-07-15T00:00:00.000Z",
+        page: "page_from_before",
+        query: "cost:1d:project_id,line_item,user_id,api_key_id:2026-06-01T00:00:00.000Z",
+        watermark: null,
+        keyGrouping: true,
+      });
+
+      await new OpenAiAdminPuller().runOnce(
+        { ...RUN_OPTIONS, cursor: stale },
+        CONFIG,
+      );
+
+      expect(requestedUrl().searchParams.has("page")).toBe(false);
+    });
+
+    /** @scenario "Widening the backfill start makes the source read the older days" */
+    it("re-reads from the earlier of the stored watermark and a widened start", async () => {
+      fetchMock.mockResolvedValue(jsonResponse(page()));
+      const mature = JSON.stringify({
+        startingAt: BUCKET_START_ISO,
+        page: null,
+        query: "cost:1d:project_id,line_item,user_id,api_key_id:2026-07-01T00:00:00.000Z",
+        watermark: null,
+        keyGrouping: true,
+      });
+
+      await new OpenAiAdminPuller().runOnce(
+        { ...RUN_OPTIONS, cursor: mature },
+        { ...CONFIG, startingAt: "2026-05-01T00:00:00.000Z" },
+      );
+
+      expect(Number(requestedUrl().searchParams.get("start_time"))).toBe(
+        Math.floor(Date.parse("2026-05-01T00:00:00.000Z") / 1000),
+      );
+    });
+  });
+
+  describe("when the row is not one the ledger can hold", () => {
+    it("skips a row in another currency rather than failing the window", async () => {
+      fetchMock.mockResolvedValue(
+        jsonResponse(
+          page({
+            results: [
+              costRow({ amount: { value: 1.5, currency: "eur" } }),
+              costRow({ project_id: "proj_b" }),
+            ],
+          }),
+        ),
+      );
+
+      const result = await new OpenAiAdminPuller().runOnce(RUN_OPTIONS, CONFIG);
+
+      // The euro row is dropped; the rest of the bucket still lands. A throw
+      // here would discard the whole run and fail identically on every retry.
+      expect(result.events).toHaveLength(1);
+      expect(result.errorCount).toBe(0);
+    });
+
+    it("refuses a configuration the adapter cannot run", () => {
+      expect(() =>
+        new OpenAiAdminPuller().validateConfig({ adapter: "openai_admin", report: "usage" }),
+      ).toThrow(ZodError);
+    });
+
+    it("fails a run with no admin key rather than reporting an empty organization", async () => {
+      const result = await new OpenAiAdminPuller().runOnce(
+        { cursor: null },
+        CONFIG,
+      );
+
+      expect(result.errorCount).toBe(1);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/platform/app/ee/governance/services/pullers/__tests__/openaiAdminPuller.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/openaiAdminPuller.unit.test.ts
@@ -682,7 +682,6 @@ describe("given an OpenAI Admin cost source", () => {
 
       const result = await new OpenAiAdminPuller().runOnce(RUN_OPTIONS, CONFIG);
 
-      // The no-currency row is skipped; only the second row lands.
       expect(result.events).toHaveLength(1);
       expect(result.errorCount).toBe(0);
     });

--- a/platform/app/ee/governance/services/pullers/__tests__/openaiAdminPuller.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/openaiAdminPuller.unit.test.ts
@@ -110,9 +110,7 @@ function page({
   hasMore?: boolean;
 } = {}) {
   return {
-    data: [
-      { start_time: startTime, end_time: startTime + 86400, results },
-    ],
+    data: [{ start_time: startTime, end_time: startTime + 86400, results }],
     has_more: hasMore,
     next_page: nextPage,
   };
@@ -143,7 +141,11 @@ describe("given an OpenAI Admin cost source", () => {
     it("keeps every digit of a sub-cent figure through to the record", async () => {
       fetchMock.mockResolvedValue(
         jsonResponse(
-          page({ results: [costRow({ amount: { value: 0.0000001234, currency: "usd" } })] }),
+          page({
+            results: [
+              costRow({ amount: { value: 0.0000001234, currency: "usd" } }),
+            ],
+          }),
         ),
       );
 
@@ -258,7 +260,9 @@ describe("given an OpenAI Admin cost source", () => {
 
       fetchMock.mockResolvedValue(
         jsonResponse(
-          page({ results: [costRow({ amount: { value: 9.99, currency: "usd" } })] }),
+          page({
+            results: [costRow({ amount: { value: 9.99, currency: "usd" } })],
+          }),
         ),
       );
       const second = await puller.runOnce(RUN_OPTIONS, CONFIG);
@@ -524,7 +528,8 @@ describe("given an OpenAI Admin cost source", () => {
       const stale = JSON.stringify({
         startingAt: "2026-07-15T00:00:00.000Z",
         page: "page_from_before",
-        query: "cost:1d:project_id,line_item,user_id,api_key_id:2026-06-01T00:00:00.000Z",
+        query:
+          "cost:1d:project_id,line_item,user_id,api_key_id:2026-06-01T00:00:00.000Z",
         watermark: null,
         keyGrouping: true,
       });
@@ -543,7 +548,8 @@ describe("given an OpenAI Admin cost source", () => {
       const mature = JSON.stringify({
         startingAt: BUCKET_START_ISO,
         page: null,
-        query: "cost:1d:project_id,line_item,user_id,api_key_id:2026-07-01T00:00:00.000Z",
+        query:
+          "cost:1d:project_id,line_item,user_id,api_key_id:2026-07-01T00:00:00.000Z",
         watermark: null,
         keyGrouping: true,
       });
@@ -582,7 +588,10 @@ describe("given an OpenAI Admin cost source", () => {
 
     it("refuses a configuration the adapter cannot run", () => {
       expect(() =>
-        new OpenAiAdminPuller().validateConfig({ adapter: "openai_admin", report: "usage" }),
+        new OpenAiAdminPuller().validateConfig({
+          adapter: "openai_admin",
+          report: "usage",
+        }),
       ).toThrow(ZodError);
     });
 

--- a/platform/app/ee/governance/services/pullers/__tests__/openaiAdminPuller.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/openaiAdminPuller.unit.test.ts
@@ -534,6 +534,9 @@ describe("given an OpenAI Admin cost source", () => {
       const cursor1 = JSON.parse(run1.cursor!);
       expect(cursor1.hasKeyGrouping).toBe(true);
       expect(cursor1.keyGroupingUpgrade).toBe(true);
+      // One day past the watermark — not at it — so the keyed window never
+      // re-reads the last user-only bucket with a different identity.
+      expect(cursor1.startingAt).toBe("2026-08-02T00:00:00.000Z");
 
       // Run 2: API now accepts key grouping (window advanced past the floor).
       fetchMock.mockResolvedValue(jsonResponse(page()));
@@ -543,9 +546,9 @@ describe("given an OpenAI Admin cost source", () => {
         CONFIG,
       );
 
-      // The request must start at the stored watermark, NOT three days before.
-      // Three days before would re-read buckets that were emitted with user-only
-      // dimensions, producing different source_event_ids and doubling spend.
+      // The request must start one day AFTER the watermark, not at it or three
+      // days before. Starting at the watermark would re-read that bucket with
+      // keyed dimensions, producing a different source_event_id and doubling it.
       const run2Start = Number(
         requestedUrl(2).searchParams.get("start_time"),
       );

--- a/platform/app/ee/governance/services/pullers/__tests__/openaiAdminPuller.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/openaiAdminPuller.unit.test.ts
@@ -169,7 +169,8 @@ describe("given an OpenAI Admin cost source", () => {
         observedAt: OBSERVED_AT,
       });
 
-      expect(record?.costNanoUsd).toBeGreaterThan(0);
+      // 0.0000001234 USD × 1e9 = 123.4 → 123 nanoUsd (truncated).
+      expect(record?.costNanoUsd).toBe(123);
     });
 
     /** @scenario "Spend is called an estimate, not the invoice" */
@@ -509,7 +510,7 @@ describe("given an OpenAI Admin cost source", () => {
       );
 
       const result = await new OpenAiAdminPuller().runOnce(
-        { ...RUN_OPTIONS, deadlineMs: Date.now() + 5 },
+        { ...RUN_OPTIONS, deadlineMs: Date.now() + 200 },
         CONFIG,
       );
 

--- a/platform/app/ee/governance/services/pullers/__tests__/openaiAdminPuller.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/openaiAdminPuller.unit.test.ts
@@ -491,6 +491,38 @@ describe("given an OpenAI Admin cost source", () => {
       expect(JSON.parse(result.cursor!).page).toBe("page_2");
     });
 
+    /** @scenario "Looking back never rewinds the source's progress" */
+    it("does not walk the window backwards when run after run runs out of time", async () => {
+      const puller = new OpenAiAdminPuller();
+      fetchMock.mockResolvedValue(jsonResponse(page()));
+      let cursor: string | null = JSON.stringify({
+        startingAt: BUCKET_START_ISO,
+        page: null,
+        query: `cost:1d:project_id,line_item,user_id,api_key_id:${CONFIG.startingAt}`,
+        watermark: null,
+        keyGrouping: true,
+      });
+
+      const starts: string[] = [];
+      for (let i = 0; i < 3; i += 1) {
+        const result = await puller.runOnce(
+          { ...RUN_OPTIONS, cursor, deadlineMs: Date.now() - 1 },
+          CONFIG,
+        );
+        cursor = result.cursor;
+        starts.push(JSON.parse(cursor!).startingAt);
+      }
+
+      // The look-back is applied to the stored start on every run; storing the
+      // looked-back value would compound it and walk a chronically slow source
+      // back to its backfill start.
+      expect(starts).toEqual([
+        BUCKET_START_ISO,
+        BUCKET_START_ISO,
+        BUCKET_START_ISO,
+      ]);
+    });
+
     /** @scenario "Every page of a window is read" */
     it("follows the page token to the end of the window", async () => {
       fetchMock

--- a/platform/app/ee/governance/services/pullers/__tests__/openaiAdminPuller.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/openaiAdminPuller.unit.test.ts
@@ -386,19 +386,28 @@ describe("given an OpenAI Admin cost source", () => {
       fetchMock
         .mockResolvedValueOnce(KEY_GROUPING_REFUSAL)
         .mockResolvedValueOnce(
-          jsonResponse(page({ results: [costRow({ api_key_id: null })] })),
+          jsonResponse(
+            page({
+              results: [
+                costRow({
+                  api_key_id: null,
+                  project_id: null,
+                  line_item: null,
+                }),
+              ],
+            }),
+          ),
         );
 
       const result = await new OpenAiAdminPuller().runOnce(RUN_OPTIONS, CONFIG);
 
       expect(fetchMock).toHaveBeenCalledTimes(2);
-      // Same window, one dimension fewer.
+      // Same window, user_id only — the API refuses any multi-dimension
+      // request that includes api_key_id below the floor.
       expect(requestedUrl(1).searchParams.get("start_time")).toBe(
         requestedUrl(0).searchParams.get("start_time"),
       );
       expect(requestedUrl(1).searchParams.getAll("group_by[]")).toEqual([
-        "project_id",
-        "line_item",
         "user_id",
       ]);
       expect(result.events).toHaveLength(1);
@@ -410,7 +419,17 @@ describe("given an OpenAI Admin cost source", () => {
       fetchMock
         .mockResolvedValueOnce(KEY_GROUPING_REFUSAL)
         .mockResolvedValueOnce(
-          jsonResponse(page({ results: [costRow({ api_key_id: null })] })),
+          jsonResponse(
+            page({
+              results: [
+                costRow({
+                  api_key_id: null,
+                  project_id: null,
+                  line_item: null,
+                }),
+              ],
+            }),
+          ),
         );
 
       const result = await new OpenAiAdminPuller().runOnce(RUN_OPTIONS, CONFIG);
@@ -460,28 +479,31 @@ describe("given an OpenAI Admin cost source", () => {
 
     it("keeps asking without the key for the rest of the window it fell back on", async () => {
       const puller = new OpenAiAdminPuller();
+      const belowFloorRow = {
+        api_key_id: null,
+        project_id: null,
+        line_item: null,
+      };
       fetchMock
         .mockResolvedValueOnce(KEY_GROUPING_REFUSAL)
         .mockResolvedValueOnce(
           jsonResponse(
             page({
-              results: [costRow({ api_key_id: null })],
+              results: [costRow(belowFloorRow)],
               nextPage: "page_2",
               hasMore: true,
             }),
           ),
         )
         .mockResolvedValue(
-          jsonResponse(page({ results: [costRow({ api_key_id: null })] })),
+          jsonResponse(page({ results: [costRow(belowFloorRow)] })),
         );
 
       await puller.runOnce(RUN_OPTIONS, CONFIG);
 
       // The page token is bound to the query that minted it, so the third
-      // request must carry the same three dimensions as the second.
+      // request must carry the same single dimension as the second.
       expect(requestedUrl(2).searchParams.getAll("group_by[]")).toEqual([
-        "project_id",
-        "line_item",
         "user_id",
       ]);
       expect(requestedUrl(2).searchParams.get("page")).toBe("page_2");

--- a/platform/app/ee/governance/services/pullers/__tests__/openaiAdminPuller.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/openaiAdminPuller.unit.test.ts
@@ -17,6 +17,18 @@ vi.mock("~/utils/ssrfProtection", () => ({
   ssrfSafeFetch: (...args: unknown[]) => fetchMock(...args),
 }));
 
+/** The reason a failed run leaves behind is a log line, so the log is captured. */
+const logged = vi.hoisted(() => ({
+  error: vi.fn(),
+  warn: vi.fn(),
+  info: vi.fn(),
+  debug: vi.fn(),
+}));
+vi.mock("@langwatch/observability", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@langwatch/observability")>()),
+  createLogger: () => logged,
+}));
+
 import {
   OPENAI_ADMIN_ADAPTER_ID,
   OpenAiAdminPuller,
@@ -123,6 +135,7 @@ function requestedUrl(callIndex = 0): URL {
 describe("given an OpenAI Admin cost source", () => {
   beforeEach(() => {
     fetchMock.mockReset();
+    for (const level of Object.values(logged)) level.mockReset();
   });
 
   describe("when the provider reports a day's spend", () => {
@@ -192,6 +205,20 @@ describe("given an OpenAI Admin cost source", () => {
       const result = await new OpenAiAdminPuller().runOnce(RUN_OPTIONS, CONFIG);
 
       expect(result.events[0]?.extra?.apiKeyId).toBe("key_a");
+    });
+
+    /** @scenario "Spend billed to a deleted key is still recorded against it" */
+    it("records spend against a key id that no longer names a live key", async () => {
+      fetchMock.mockResolvedValue(
+        jsonResponse(page({ results: [costRow({ api_key_id: "key_gone" })] })),
+      );
+
+      const result = await new OpenAiAdminPuller().runOnce(RUN_OPTIONS, CONFIG);
+
+      expect(result.events[0]?.extra?.apiKeyId).toBe("key_gone");
+      // Nothing is asked about the key — the cost report is the only request —
+      // so a key deleted since the spend cannot drop the row that names it.
+      expect(fetchMock).toHaveBeenCalledTimes(1);
     });
 
     /** @scenario "Nobody is looked up while pulling" */
@@ -625,6 +652,30 @@ describe("given an OpenAI Admin cost source", () => {
           report: "usage",
         }),
       ).toThrow(ZodError);
+    });
+
+    /** @scenario "A refused key does not put the key in the reason" */
+    it("fails a run on a rejected key without writing the key into the reason", async () => {
+      fetchMock.mockResolvedValue(
+        errorResponse({
+          status: 401,
+          param: null,
+          code: "invalid_api_key",
+          message: "Incorrect API key provided: sk-a***min.",
+        }),
+      );
+
+      const result = await new OpenAiAdminPuller().runOnce(RUN_OPTIONS, CONFIG);
+
+      expect(result.errorCount).toBe(1);
+      // The reason is logged and shown on the source, so it is read by people
+      // who were never given the credential.
+      expect(logged.error).toHaveBeenCalled();
+      for (const call of logged.error.mock.calls) {
+        expect(JSON.stringify(call)).not.toContain(
+          RUN_OPTIONS.credentials.token,
+        );
+      }
     });
 
     it("fails a run with no admin key rather than reporting an empty organization", async () => {

--- a/platform/app/ee/governance/services/pullers/__tests__/openaiAdminPuller.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/openaiAdminPuller.unit.test.ts
@@ -524,7 +524,11 @@ describe("given an OpenAI Admin cost source", () => {
           jsonResponse(
             page({
               results: [
-                costRow({ api_key_id: null, project_id: null, line_item: null }),
+                costRow({
+                  api_key_id: null,
+                  project_id: null,
+                  line_item: null,
+                }),
               ],
             }),
           ),
@@ -549,17 +553,13 @@ describe("given an OpenAI Admin cost source", () => {
       // The request must start one day AFTER the watermark, not at it or three
       // days before. Starting at the watermark would re-read that bucket with
       // keyed dimensions, producing a different source_event_id and doubling it.
-      const run2Start = Number(
-        requestedUrl(2).searchParams.get("start_time"),
-      );
-      expect(run2Start).toBe(
-        Math.floor(Date.parse(cursor1.startingAt) / 1000),
-      );
+      const run2Start = Number(requestedUrl(2).searchParams.get("start_time"));
+      expect(run2Start).toBe(Math.floor(Date.parse(cursor1.startingAt) / 1000));
 
       // Key grouping was used.
-      expect(
-        requestedUrl(2).searchParams.getAll("group_by[]"),
-      ).toContain("api_key_id");
+      expect(requestedUrl(2).searchParams.getAll("group_by[]")).toContain(
+        "api_key_id",
+      );
 
       // The upgrade flag clears once key grouping succeeds.
       const cursor2 = JSON.parse(run2.cursor!);
@@ -585,16 +585,17 @@ describe("given an OpenAI Admin cost source", () => {
           jsonResponse(
             page({
               results: [
-                costRow({ api_key_id: null, project_id: null, line_item: null }),
+                costRow({
+                  api_key_id: null,
+                  project_id: null,
+                  line_item: null,
+                }),
               ],
             }),
           ),
         );
 
-      const result = await puller.runOnce(
-        { ...RUN_OPTIONS, cursor },
-        CONFIG,
-      );
+      const result = await puller.runOnce({ ...RUN_OPTIONS, cursor }, CONFIG);
 
       const nextCursor = JSON.parse(result.cursor!);
       expect(nextCursor.hasKeyGrouping).toBe(true);

--- a/platform/app/ee/governance/services/pullers/index.ts
+++ b/platform/app/ee/governance/services/pullers/index.ts
@@ -14,6 +14,7 @@ import { CopilotStudioReferencePuller } from "./copilotStudio.puller";
 import { CopilotStudioDataversePuller } from "./copilotStudioDataverse.puller";
 import { DatabricksGeniePuller } from "./databricksGenie.puller";
 import { HttpPollingPullerAdapter } from "./httpPollingPullerAdapter";
+import { OpenAiAdminPuller } from "./openaiAdmin.puller";
 import { OpenAiComplianceReferencePuller } from "./openaiCompliance.puller";
 import { pullerAdapterRegistry } from "./pullerAdapter";
 import { S3PollingPullerAdapter } from "./s3PollingPullerAdapter";
@@ -32,6 +33,7 @@ export function registerBuiltInPullers(): void {
   pullerAdapterRegistry.register(new OpenAiComplianceReferencePuller());
   pullerAdapterRegistry.register(new ClaudeComplianceReferencePuller());
   pullerAdapterRegistry.register(new AnthropicAdminPuller());
+  pullerAdapterRegistry.register(new OpenAiAdminPuller());
   pullerAdapterRegistry.register(new DatabricksGeniePuller());
   registered = true;
 }
@@ -54,6 +56,11 @@ export {
 } from "./databricksGenie.puller";
 export { COPILOT_STUDIO_DATAVERSE_ADAPTER_ID } from "./dataverseEnvironment";
 export type { HttpPollingConfig } from "./httpPollingPullerAdapter";
+export {
+  OPENAI_ADMIN_ADAPTER_ID,
+  type OpenAiAdminPullConfig,
+  openaiAdminPullConfigSchema,
+} from "./openaiAdmin.puller";
 export { OPENAI_COMPLIANCE_PULL_CONFIG } from "./openaiCompliance.puller";
 export type {
   NormalizedPullEvent,
@@ -69,6 +76,7 @@ export {
   CopilotStudioReferencePuller,
   DatabricksGeniePuller,
   HttpPollingPullerAdapter,
+  OpenAiAdminPuller,
   OpenAiComplianceReferencePuller,
   pullerAdapterRegistry,
   S3PollingPullerAdapter,

--- a/platform/app/ee/governance/services/pullers/openaiAdmin.puller.ts
+++ b/platform/app/ee/governance/services/pullers/openaiAdmin.puller.ts
@@ -143,7 +143,7 @@ export type OpenAiAdminPullConfig = z.infer<typeof openaiAdminPullConfigSchema>;
  * binding one config edit mid-window would wedge the source permanently, every
  * retry replaying the same dead token.
  *
- * `keyGrouping` records whether the in-flight window is being read WITH
+ * `hasKeyGrouping` records whether the in-flight window is being read WITH
  * `api_key_id` in the group-by. It has to be durable for the same reason
  * `page` does: the token is bound to the group-by that produced it, so a run
  * resuming into a window that fell back to user_id-only must keep asking
@@ -158,7 +158,7 @@ const cursorSchema = z.object({
    * window drains, at which point `startingAt` itself is the resume point.
    */
   watermark: z.string().nullable().default(null),
-  keyGrouping: z.boolean().default(true),
+  hasKeyGrouping: z.boolean().default(true),
 });
 
 interface ParsedCursor {
@@ -178,7 +178,7 @@ interface ParsedCursor {
   storedStart: string;
   page: string | null;
   watermark: string | null;
-  keyGrouping: boolean;
+  hasKeyGrouping: boolean;
 }
 
 /**
@@ -225,7 +225,7 @@ function parseCursor({
           storedStart: parsed.startingAt,
           page: parsed.page,
           watermark: parsed.watermark,
-          keyGrouping: parsed.keyGrouping,
+          hasKeyGrouping: parsed.hasKeyGrouping,
         };
       }
       return staleCursorRestart({ parsed, config });
@@ -242,7 +242,7 @@ function parseCursor({
     storedStart: fresh,
     page: null,
     watermark: null,
-    keyGrouping: true,
+    hasKeyGrouping: true,
   };
 }
 
@@ -281,7 +281,7 @@ function staleCursorRestart({
     storedStart: rewound,
     page: null,
     watermark: null,
-    keyGrouping: true,
+    hasKeyGrouping: true,
   };
 }
 
@@ -371,7 +371,7 @@ const costResultSchema = z
      */
     amount: z.object({
       value: z.union([z.string(), z.number()]).transform(String),
-      currency: z.string().default("usd"),
+      currency: z.string(),
     }),
     line_item: z.string().nullable().default(null),
     project_id: z.string().nullable().default(null),
@@ -434,11 +434,11 @@ function bucketStartIso(startTime: number): string {
 function reportUrl({
   startingAt,
   page,
-  keyGrouping,
+  hasKeyGrouping,
 }: {
   startingAt: string;
   page: string | null;
-  keyGrouping: boolean;
+  hasKeyGrouping: boolean;
 }): URL {
   const url = new URL(`${API_BASE}/costs`);
   const startMs = Date.parse(startingAt);
@@ -450,7 +450,9 @@ function reportUrl({
   url.searchParams.set("start_time", String(Math.floor(startMs / 1000)));
   url.searchParams.set("bucket_width", COST_REPORT_BUCKET_WIDTH);
   url.searchParams.set("limit", String(PAGE_LIMIT));
-  for (const dim of keyGrouping ? COST_GROUP_BY : COST_GROUP_BY_WITHOUT_KEY) {
+  for (const dim of hasKeyGrouping
+    ? COST_GROUP_BY
+    : COST_GROUP_BY_WITHOUT_KEY) {
     url.searchParams.append("group_by[]", dim);
   }
   if (page) url.searchParams.set("page", page);
@@ -476,7 +478,7 @@ export class OpenAiAdminPuller implements PullerAdapter<OpenAiAdminPullConfig> {
     const query = queryIdentity(config);
     let page = cursor.page;
     let watermark = cursor.watermark;
-    let keyGrouping = cursor.keyGrouping;
+    let hasKeyGrouping = cursor.hasKeyGrouping;
 
     /**
      * What an unfinished run persists as its resume point. With a page token
@@ -497,7 +499,7 @@ export class OpenAiAdminPuller implements PullerAdapter<OpenAiAdminPullConfig> {
             page,
             query,
             watermark,
-            keyGrouping,
+            hasKeyGrouping,
           }),
           errorCount: 0,
         };
@@ -506,7 +508,7 @@ export class OpenAiAdminPuller implements PullerAdapter<OpenAiAdminPullConfig> {
       const read = await this.readPage({
         startingAt,
         page,
-        keyGrouping,
+        hasKeyGrouping,
         options,
       });
       if (!read.ok) {
@@ -515,7 +517,7 @@ export class OpenAiAdminPuller implements PullerAdapter<OpenAiAdminPullConfig> {
         return { events, cursor: options.cursor, errorCount: 1 };
       }
       events.push(...read.events);
-      keyGrouping = read.keyGrouping;
+      hasKeyGrouping = read.hasKeyGrouping;
       watermark = laterOf(watermark, read.watermark);
 
       if (read.nextPage === null) {
@@ -532,7 +534,7 @@ export class OpenAiAdminPuller implements PullerAdapter<OpenAiAdminPullConfig> {
             page: null,
             query,
             watermark: null,
-            keyGrouping: true,
+            hasKeyGrouping: true,
           }),
           errorCount: 0,
         };
@@ -551,7 +553,7 @@ export class OpenAiAdminPuller implements PullerAdapter<OpenAiAdminPullConfig> {
         page,
         query,
         watermark,
-        keyGrouping,
+        hasKeyGrouping,
       }),
       errorCount: 0,
     };
@@ -568,12 +570,12 @@ export class OpenAiAdminPuller implements PullerAdapter<OpenAiAdminPullConfig> {
   private async readPage({
     startingAt,
     page,
-    keyGrouping,
+    hasKeyGrouping,
     options,
   }: {
     startingAt: string;
     page: string | null;
-    keyGrouping: boolean;
+    hasKeyGrouping: boolean;
     options: PullRunOptions;
   }): Promise<
     | {
@@ -581,16 +583,16 @@ export class OpenAiAdminPuller implements PullerAdapter<OpenAiAdminPullConfig> {
         events: NormalizedPullEvent[];
         nextPage: string | null;
         watermark: string | null;
-        keyGrouping: boolean;
+        hasKeyGrouping: boolean;
       }
     | { ok: false }
   > {
-    let fetched: { body: unknown; keyGrouping: boolean } | null;
+    let fetched: { body: unknown; hasKeyGrouping: boolean } | null;
     try {
       fetched = await this.fetchWithKeyGroupingFallback({
         startingAt,
         page,
-        keyGrouping,
+        hasKeyGrouping,
         options,
       });
     } catch (error) {
@@ -604,7 +606,7 @@ export class OpenAiAdminPuller implements PullerAdapter<OpenAiAdminPullConfig> {
       return { ok: false };
     }
     if (fetched === null) return { ok: false };
-    const usedKeyGrouping = fetched.keyGrouping;
+    const usedKeyGrouping = fetched.hasKeyGrouping;
 
     const parsed = pageSchema.parse(fetched.body);
     // `has_more` with no token to follow it is a contract violation, and the
@@ -619,7 +621,7 @@ export class OpenAiAdminPuller implements PullerAdapter<OpenAiAdminPullConfig> {
     }
 
     const events = parsed.data.flatMap((bucket) =>
-      this.bucketEvents({ bucket, keyGrouping: usedKeyGrouping }),
+      this.bucketEvents({ bucket, hasKeyGrouping: usedKeyGrouping }),
     );
     // The LATEST bucket on the page rather than the last one in the array.
     // Buckets are observed to arrive strictly ascending, but taking the max
@@ -634,7 +636,7 @@ export class OpenAiAdminPuller implements PullerAdapter<OpenAiAdminPullConfig> {
       events,
       nextPage: parsed.next_page,
       watermark: newest,
-      keyGrouping: usedKeyGrouping,
+      hasKeyGrouping: usedKeyGrouping,
     };
   }
 
@@ -649,22 +651,22 @@ export class OpenAiAdminPuller implements PullerAdapter<OpenAiAdminPullConfig> {
   private async fetchWithKeyGroupingFallback({
     startingAt,
     page,
-    keyGrouping,
+    hasKeyGrouping,
     options,
   }: {
     startingAt: string;
     page: string | null;
-    keyGrouping: boolean;
+    hasKeyGrouping: boolean;
     options: PullRunOptions;
-  }): Promise<{ body: unknown; keyGrouping: boolean } | null> {
+  }): Promise<{ body: unknown; hasKeyGrouping: boolean } | null> {
     const first = await this.fetchPage({
       startingAt,
       page,
-      keyGrouping,
+      hasKeyGrouping,
       options,
     });
-    if (first.ok) return { body: first.body, keyGrouping };
-    if (!keyGrouping || page !== null) return null;
+    if (first.ok) return { body: first.body, hasKeyGrouping };
+    if (!hasKeyGrouping || page !== null) return null;
 
     logger.warn(
       { adapter: this.id, startingAt },
@@ -673,10 +675,10 @@ export class OpenAiAdminPuller implements PullerAdapter<OpenAiAdminPullConfig> {
     const retried = await this.fetchPage({
       startingAt,
       page,
-      keyGrouping: false,
+      hasKeyGrouping: false,
       options,
     });
-    return retried.ok ? { body: retried.body, keyGrouping: false } : null;
+    return retried.ok ? { body: retried.body, hasKeyGrouping: false } : null;
   }
 
   /**
@@ -687,12 +689,12 @@ export class OpenAiAdminPuller implements PullerAdapter<OpenAiAdminPullConfig> {
   private async fetchPage({
     startingAt,
     page,
-    keyGrouping,
+    hasKeyGrouping,
     options,
   }: {
     startingAt: string;
     page: string | null;
-    keyGrouping: boolean;
+    hasKeyGrouping: boolean;
     options: PullRunOptions;
   }): Promise<{ ok: true; body: unknown } | { ok: false }> {
     const apiKey = options.credentials?.token;
@@ -702,7 +704,7 @@ export class OpenAiAdminPuller implements PullerAdapter<OpenAiAdminPullConfig> {
       );
     }
 
-    const url = reportUrl({ startingAt, page, keyGrouping });
+    const url = reportUrl({ startingAt, page, hasKeyGrouping });
     const signal = options.signal
       ? AbortSignal.any([
           options.signal,
@@ -742,17 +744,25 @@ export class OpenAiAdminPuller implements PullerAdapter<OpenAiAdminPullConfig> {
    */
   private bucketEvents({
     bucket,
-    keyGrouping,
+    hasKeyGrouping,
   }: {
     bucket: z.infer<typeof bucketSchema>;
-    keyGrouping: boolean;
+    hasKeyGrouping: boolean;
   }): NormalizedPullEvent[] {
     const startingAt = bucketStartIso(bucket.start_time);
     return bucket.results.flatMap((result) => {
+      const parsed = costResultSchema.safeParse(result);
+      if (!parsed.success) {
+        logger.error(
+          { adapter: this.id, startingAt },
+          "openai cost row does not match the expected shape; skipping the row",
+        );
+        return [];
+      }
       const event = this.costEvent({
-        result: costResultSchema.parse(result),
+        result: parsed.data,
         startingAt,
-        keyGrouping,
+        hasKeyGrouping,
       });
       return event ? [event] : [];
     });
@@ -761,11 +771,11 @@ export class OpenAiAdminPuller implements PullerAdapter<OpenAiAdminPullConfig> {
   private costEvent({
     result,
     startingAt,
-    keyGrouping,
+    hasKeyGrouping,
   }: {
     result: z.infer<typeof costResultSchema>;
     startingAt: string;
-    keyGrouping: boolean;
+    hasKeyGrouping: boolean;
   }): NormalizedPullEvent | null {
     const dimensions: Record<string, string> = {
       report: "cost",
@@ -777,7 +787,7 @@ export class OpenAiAdminPuller implements PullerAdapter<OpenAiAdminPullConfig> {
       // the provider's floor the coordinate is absent rather than empty: a
       // stable "" would be a claim about a key, and the map for a given bucket
       // is read one way or the other, never both.
-      ...(keyGrouping ? { apiKeyId: dimension(result.api_key_id) } : {}),
+      ...(hasKeyGrouping ? { apiKeyId: dimension(result.api_key_id) } : {}),
     };
 
     if (result.amount.currency.toLowerCase() !== "usd") {
@@ -835,9 +845,9 @@ function encodeCursor({
   page,
   query,
   watermark,
-  keyGrouping,
+  hasKeyGrouping,
 }: Omit<z.infer<typeof cursorSchema>, "query"> & { query: string }): string {
-  return JSON.stringify({ startingAt, page, query, watermark, keyGrouping });
+  return JSON.stringify({ startingAt, page, query, watermark, hasKeyGrouping });
 }
 
 /** The later of two ISO instants, tolerating nulls and unparseable input. */

--- a/platform/app/ee/governance/services/pullers/openaiAdmin.puller.ts
+++ b/platform/app/ee/governance/services/pullers/openaiAdmin.puller.ts
@@ -522,10 +522,11 @@ export class OpenAiAdminPuller implements PullerAdapter<OpenAiAdminPullConfig> {
         return {
           events,
           cursor: encodeCursor({
-            // A window that returned no bucket at all keeps the start it was
-            // given rather than the looked-back one, for the same reason the
-            // deadline path does.
-            startingAt: watermark ?? cursor.storedStart,
+            // The stored start never moves backwards: a retracted window
+            // whose newest bucket predates the stored start must not rewind
+            // the source. laterOf picks the later of the two.
+            startingAt:
+              laterOf(watermark, cursor.storedStart) ?? cursor.storedStart,
             page: null,
             query,
             watermark: null,

--- a/platform/app/ee/governance/services/pullers/openaiAdmin.puller.ts
+++ b/platform/app/ee/governance/services/pullers/openaiAdmin.puller.ts
@@ -532,25 +532,24 @@ export class OpenAiAdminPuller implements PullerAdapter<OpenAiAdminPullConfig> {
       watermark = laterOf(watermark, read.watermark);
 
       if (read.nextPage === null) {
-        // Drained. The next run resumes from the newest bucket read, moved
-        // back by the look-back when it starts.
+        // The stored start never moves backwards: a retracted window whose
+        // newest bucket predates the stored start must not rewind the source.
+        const drainStart =
+          laterOf(watermark, cursor.storedStart) ?? cursor.storedStart;
         return {
           events,
           cursor: encodeCursor({
-            // The stored start never moves backwards: a retracted window
-            // whose newest bucket predates the stored start must not rewind
-            // the source. laterOf picks the later of the two.
-            startingAt:
-              laterOf(watermark, cursor.storedStart) ?? cursor.storedStart,
+            // When upgrading from user-only to keyed grouping, advance one
+            // bucket past the watermark: that day was already emitted with
+            // user-only dimensions, and re-reading it with keyed dimensions
+            // would produce a different source_event_id, doubling that day.
+            startingAt: !hasKeyGrouping
+              ? new Date(Date.parse(drainStart) + MS_PER_DAY).toISOString()
+              : drainStart,
             page: null,
             query,
             watermark: null,
             hasKeyGrouping: true,
-            // When this window was read without key grouping, the next run
-            // must try key grouping again — but without the restatement
-            // lookback. Overlapping a keyed window with a user-only window
-            // produces different source_event_ids for the same buckets, which
-            // doubles the reported spend instead of restating it.
             keyGroupingUpgrade: !hasKeyGrouping,
           }),
           errorCount: 0,

--- a/platform/app/ee/governance/services/pullers/openaiAdmin.puller.ts
+++ b/platform/app/ee/governance/services/pullers/openaiAdmin.puller.ts
@@ -546,36 +546,14 @@ export class OpenAiAdminPuller implements PullerAdapter<OpenAiAdminPullConfig> {
       }
     | { ok: false }
   > {
-    let body: unknown;
-    let usedKeyGrouping = keyGrouping;
+    let fetched: { body: unknown; keyGrouping: boolean } | null;
     try {
-      const first = await this.fetchPage({
+      fetched = await this.fetchWithKeyGroupingFallback({
         startingAt,
         page,
-        keyGrouping: usedKeyGrouping,
+        keyGrouping,
         options,
       });
-      if (first.ok) {
-        body = first.body;
-      } else {
-        // Only at the head of a window. Mid-window the page token is already
-        // bound to the group-by that minted it, so there is nothing to retry
-        // the same token against.
-        if (!usedKeyGrouping || page !== null) return { ok: false };
-        logger.warn(
-          { adapter: this.id, startingAt },
-          "openai refuses to group this window by api key; re-reading it without that dimension so the window and the person on each row survive",
-        );
-        usedKeyGrouping = false;
-        const retried = await this.fetchPage({
-          startingAt,
-          page,
-          keyGrouping: usedKeyGrouping,
-          options,
-        });
-        if (!retried.ok) return { ok: false };
-        body = retried.body;
-      }
     } catch (error) {
       logger.error(
         {
@@ -586,8 +564,10 @@ export class OpenAiAdminPuller implements PullerAdapter<OpenAiAdminPullConfig> {
       );
       return { ok: false };
     }
+    if (fetched === null) return { ok: false };
+    const usedKeyGrouping = fetched.keyGrouping;
 
-    const parsed = pageSchema.parse(body);
+    const parsed = pageSchema.parse(fetched.body);
     // `has_more` with no token to follow it is a contract violation, and the
     // one shape that must NOT be treated as drained. Reading it as drained
     // would advance the watermark past pages never fetched and the next run
@@ -617,6 +597,47 @@ export class OpenAiAdminPuller implements PullerAdapter<OpenAiAdminPullConfig> {
       watermark: newest,
       keyGrouping: usedKeyGrouping,
     };
+  }
+
+  /**
+   * One page's body, and the group-by it was actually read with. Null when the
+   * provider refused and there is nothing left to try.
+   *
+   * The fallback only fires at the head of a window. Mid-window the page token
+   * is already bound to the group-by that minted it, so re-asking the same
+   * token with one dimension fewer would be refused for a different reason.
+   */
+  private async fetchWithKeyGroupingFallback({
+    startingAt,
+    page,
+    keyGrouping,
+    options,
+  }: {
+    startingAt: string;
+    page: string | null;
+    keyGrouping: boolean;
+    options: PullRunOptions;
+  }): Promise<{ body: unknown; keyGrouping: boolean } | null> {
+    const first = await this.fetchPage({
+      startingAt,
+      page,
+      keyGrouping,
+      options,
+    });
+    if (first.ok) return { body: first.body, keyGrouping };
+    if (!keyGrouping || page !== null) return null;
+
+    logger.warn(
+      { adapter: this.id, startingAt },
+      "openai refuses to group this window by api key; re-reading it without that dimension so the window and the person on each row survive",
+    );
+    const retried = await this.fetchPage({
+      startingAt,
+      page,
+      keyGrouping: false,
+      options,
+    });
+    return retried.ok ? { body: retried.body, keyGrouping: false } : null;
   }
 
   /**

--- a/platform/app/ee/governance/services/pullers/openaiAdmin.puller.ts
+++ b/platform/app/ee/governance/services/pullers/openaiAdmin.puller.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
 
 /**
- * OpenAI Admin API puller — organization spend, attributed to the person and
+ * OpenAI Admin puller — organization spend, attributed to the person and
  * the API key it was billed to (ADR-122).
  *
  * Like the Anthropic Admin puller it cannot be an `HttpPollingPullerAdapter`

--- a/platform/app/ee/governance/services/pullers/openaiAdmin.puller.ts
+++ b/platform/app/ee/governance/services/pullers/openaiAdmin.puller.ts
@@ -93,12 +93,14 @@ const COST_GROUP_BY = [
 ] as const;
 
 /**
- * The same set with the key dropped, for windows below the provider's
- * key-grouping floor. The person survives; only key-level detail is lost.
+ * Below the provider's key-grouping floor (2025-12-06), the API refuses ANY
+ * request that includes api_key_id — regardless of how many other dimensions
+ * ride alongside it. Only user_id alone works for those older windows; adding
+ * project_id or line_item back triggers the same 400.
+ *
+ * The person survives; project and line-item detail is lost alongside the key.
  */
-const COST_GROUP_BY_WITHOUT_KEY = COST_GROUP_BY.filter(
-  (dim) => dim !== "api_key_id",
-);
+const COST_GROUP_BY_WITHOUT_KEY = ["user_id"] as const;
 
 /**
  * How far behind its watermark each run re-reads, so a bucket the provider
@@ -144,8 +146,8 @@ export type OpenAiAdminPullConfig = z.infer<typeof openaiAdminPullConfigSchema>;
  * `keyGrouping` records whether the in-flight window is being read WITH
  * `api_key_id` in the group-by. It has to be durable for the same reason
  * `page` does: the token is bound to the group-by that produced it, so a run
- * resuming into a window that fell back to three dimensions must keep asking
- * for three.
+ * resuming into a window that fell back to user_id-only must keep asking
+ * with the same single dimension.
  */
 const cursorSchema = z.object({
   startingAt: z.string(),
@@ -666,7 +668,7 @@ export class OpenAiAdminPuller implements PullerAdapter<OpenAiAdminPullConfig> {
 
     logger.warn(
       { adapter: this.id, startingAt },
-      "openai refuses to group this window by api key; re-reading it without that dimension so the window and the person on each row survive",
+      "openai refuses api_key_id before its floor date; falling back to user_id only so the person on each row survives",
     );
     const retried = await this.fetchPage({
       startingAt,

--- a/platform/app/ee/governance/services/pullers/openaiAdmin.puller.ts
+++ b/platform/app/ee/governance/services/pullers/openaiAdmin.puller.ts
@@ -159,6 +159,14 @@ const cursorSchema = z.object({
    */
   watermark: z.string().nullable().default(null),
   hasKeyGrouping: z.boolean().default(true),
+  /**
+   * True when the previous window drained with user-only grouping and the
+   * cursor was set to retry with key grouping. Tells parseCursor to skip the
+   * restatement lookback so the first keyed window does not overlap with the
+   * last user-only window — overlapping would emit different source_event_ids
+   * for the same buckets and double the reported spend.
+   */
+  keyGroupingUpgrade: z.boolean().default(false),
 });
 
 interface ParsedCursor {
@@ -217,9 +225,11 @@ function parseCursor({
         return {
           // Mid-window (a page token in hand) the start must stay exactly what
           // the token was minted against. Only a cursor with no token in hand
-          // gets the trailing re-read applied to it.
+          // gets the trailing re-read applied to it — UNLESS a key-grouping
+          // upgrade is pending, in which case the lookback is skipped so the
+          // first keyed window cannot overlap with user-only data.
           windowStart:
-            parsed.page === null
+            parsed.page === null && !parsed.keyGroupingUpgrade
               ? windowStartFor({ stored: parsed.startingAt, config })
               : parsed.startingAt,
           storedStart: parsed.startingAt,
@@ -500,6 +510,7 @@ export class OpenAiAdminPuller implements PullerAdapter<OpenAiAdminPullConfig> {
             query,
             watermark,
             hasKeyGrouping,
+            keyGroupingUpgrade: false,
           }),
           errorCount: 0,
         };
@@ -535,6 +546,12 @@ export class OpenAiAdminPuller implements PullerAdapter<OpenAiAdminPullConfig> {
             query,
             watermark: null,
             hasKeyGrouping: true,
+            // When this window was read without key grouping, the next run
+            // must try key grouping again — but without the restatement
+            // lookback. Overlapping a keyed window with a user-only window
+            // produces different source_event_ids for the same buckets, which
+            // doubles the reported spend instead of restating it.
+            keyGroupingUpgrade: !hasKeyGrouping,
           }),
           errorCount: 0,
         };
@@ -554,6 +571,7 @@ export class OpenAiAdminPuller implements PullerAdapter<OpenAiAdminPullConfig> {
         query,
         watermark,
         hasKeyGrouping,
+        keyGroupingUpgrade: false,
       }),
       errorCount: 0,
     };
@@ -846,8 +864,16 @@ function encodeCursor({
   query,
   watermark,
   hasKeyGrouping,
+  keyGroupingUpgrade,
 }: Omit<z.infer<typeof cursorSchema>, "query"> & { query: string }): string {
-  return JSON.stringify({ startingAt, page, query, watermark, hasKeyGrouping });
+  return JSON.stringify({
+    startingAt,
+    page,
+    query,
+    watermark,
+    hasKeyGrouping,
+    keyGroupingUpgrade,
+  });
 }
 
 /** The later of two ISO instants, tolerating nulls and unparseable input. */

--- a/platform/app/ee/governance/services/pullers/openaiAdmin.puller.ts
+++ b/platform/app/ee/governance/services/pullers/openaiAdmin.puller.ts
@@ -532,26 +532,16 @@ export class OpenAiAdminPuller implements PullerAdapter<OpenAiAdminPullConfig> {
       watermark = laterOf(watermark, read.watermark);
 
       if (read.nextPage === null) {
-        // The stored start never moves backwards: a retracted window whose
-        // newest bucket predates the stored start must not rewind the source.
-        const drainStart =
-          laterOf(watermark, cursor.storedStart) ?? cursor.storedStart;
         return {
           events,
-          cursor: encodeCursor({
-            // When upgrading from user-only to keyed grouping, advance one
-            // bucket past the watermark: that day was already emitted with
-            // user-only dimensions, and re-reading it with keyed dimensions
-            // would produce a different source_event_id, doubling that day.
-            startingAt: !hasKeyGrouping
-              ? new Date(Date.parse(drainStart) + MS_PER_DAY).toISOString()
-              : drainStart,
-            page: null,
-            query,
-            watermark: null,
-            hasKeyGrouping: true,
-            keyGroupingUpgrade: !hasKeyGrouping,
-          }),
+          cursor: encodeCursor(
+            drainCursor({
+              watermark,
+              storedStart: cursor.storedStart,
+              hasKeyGrouping,
+              query,
+            }),
+          ),
           errorCount: 0,
         };
       }
@@ -873,6 +863,37 @@ function encodeCursor({
     hasKeyGrouping,
     keyGroupingUpgrade,
   });
+}
+
+/** Cursor emitted when a window drains (no more pages). */
+function drainCursor({
+  watermark,
+  storedStart,
+  hasKeyGrouping,
+  query,
+}: {
+  watermark: string | null;
+  storedStart: string;
+  hasKeyGrouping: boolean;
+  query: string;
+}): Parameters<typeof encodeCursor>[0] {
+  // The stored start never moves backwards: a retracted window whose newest
+  // bucket predates the stored start must not rewind the source.
+  const start = laterOf(watermark, storedStart) ?? storedStart;
+  return {
+    // When upgrading from user-only to keyed grouping, advance one bucket past
+    // the watermark: that day was already emitted with user-only dimensions,
+    // and re-reading it with keyed dimensions would produce a different
+    // source_event_id, doubling that day.
+    startingAt: !hasKeyGrouping
+      ? new Date(Date.parse(start) + MS_PER_DAY).toISOString()
+      : start,
+    page: null,
+    query,
+    watermark: null,
+    hasKeyGrouping: true,
+    keyGroupingUpgrade: !hasKeyGrouping,
+  };
 }
 
 /** The later of two ISO instants, tolerating nulls and unparseable input. */

--- a/platform/app/ee/governance/services/pullers/openaiAdmin.puller.ts
+++ b/platform/app/ee/governance/services/pullers/openaiAdmin.puller.ts
@@ -159,10 +159,25 @@ const cursorSchema = z.object({
   keyGrouping: z.boolean().default(true),
 });
 
-type ParsedCursor = Pick<
-  z.infer<typeof cursorSchema>,
-  "startingAt" | "page" | "watermark" | "keyGrouping"
->;
+interface ParsedCursor {
+  /** What this run asks the provider for — the stored start moved back by the
+   *  restatement look-back, unless a page token pins it. */
+  windowStart: string;
+  /**
+   * What to persist when the run ends WITHOUT a page token in hand.
+   *
+   * Deliberately not `windowStart`. Writing the looked-back value back would
+   * make the look-back compound: a run that ends early with nothing to resume
+   * from would save a start three days older than the one it was given, and
+   * the next run would take three more off that. A source that keeps hitting
+   * its deadline would walk steadily backwards until it was re-reading the
+   * whole backfill window every run.
+   */
+  storedStart: string;
+  page: string | null;
+  watermark: string | null;
+  keyGrouping: boolean;
+}
 
 /**
  * The configuration a cursor is bound to: everything that rides beside `page`
@@ -199,12 +214,13 @@ function parseCursor({
       if (parsed.query === queryIdentity(config)) {
         return {
           // Mid-window (a page token in hand) the start must stay exactly what
-          // the token was minted against. Only a drained cursor gets the
-          // trailing re-read applied to it.
-          startingAt:
+          // the token was minted against. Only a cursor with no token in hand
+          // gets the trailing re-read applied to it.
+          windowStart:
             parsed.page === null
               ? windowStartFor({ stored: parsed.startingAt, config })
               : parsed.startingAt,
+          storedStart: parsed.startingAt,
           page: parsed.page,
           watermark: parsed.watermark,
           keyGrouping: parsed.keyGrouping,
@@ -218,8 +234,10 @@ function parseCursor({
       );
     }
   }
+  const fresh = config.startingAt ?? defaultStartingAt();
   return {
-    startingAt: config.startingAt ?? defaultStartingAt(),
+    windowStart: fresh,
+    storedStart: fresh,
     page: null,
     watermark: null,
     keyGrouping: true,
@@ -257,7 +275,8 @@ function staleCursorRestart({
       ? configuredStart
       : parsed.startingAt;
   return {
-    startingAt: rewound,
+    windowStart: rewound,
+    storedStart: rewound,
     page: null,
     watermark: null,
     keyGrouping: true,
@@ -451,11 +470,19 @@ export class OpenAiAdminPuller implements PullerAdapter<OpenAiAdminPullConfig> {
     const cursor = parseCursor({ cursor: options.cursor, config });
     // The window start does not move within a run; only the page token, the
     // watermark and the key-grouping fallback do.
-    const startingAt = cursor.startingAt;
+    const startingAt = cursor.windowStart;
     const query = queryIdentity(config);
     let page = cursor.page;
     let watermark = cursor.watermark;
     let keyGrouping = cursor.keyGrouping;
+
+    /**
+     * What an unfinished run persists as its resume point. With a page token
+     * in hand it must be the window the token was minted against; without one
+     * it is the start this run was GIVEN, never the looked-back one — see
+     * `ParsedCursor.storedStart`.
+     */
+    const resumeStart = () => (page === null ? cursor.storedStart : startingAt);
 
     for (let pageCount = 0; pageCount < MAX_PAGES_PER_RUN; pageCount += 1) {
       if (options.deadlineMs !== undefined && Date.now() > options.deadlineMs) {
@@ -464,7 +491,7 @@ export class OpenAiAdminPuller implements PullerAdapter<OpenAiAdminPullConfig> {
         return {
           events,
           cursor: encodeCursor({
-            startingAt,
+            startingAt: resumeStart(),
             page,
             query,
             watermark,
@@ -495,7 +522,10 @@ export class OpenAiAdminPuller implements PullerAdapter<OpenAiAdminPullConfig> {
         return {
           events,
           cursor: encodeCursor({
-            startingAt: watermark ?? startingAt,
+            // A window that returned no bucket at all keeps the start it was
+            // given rather than the looked-back one, for the same reason the
+            // deadline path does.
+            startingAt: watermark ?? cursor.storedStart,
             page: null,
             query,
             watermark: null,
@@ -513,7 +543,13 @@ export class OpenAiAdminPuller implements PullerAdapter<OpenAiAdminPullConfig> {
     );
     return {
       events,
-      cursor: encodeCursor({ startingAt, page, query, watermark, keyGrouping }),
+      cursor: encodeCursor({
+        startingAt: resumeStart(),
+        page,
+        query,
+        watermark,
+        keyGrouping,
+      }),
       errorCount: 0,
     };
   }

--- a/platform/app/ee/governance/services/pullers/openaiAdmin.puller.ts
+++ b/platform/app/ee/governance/services/pullers/openaiAdmin.puller.ts
@@ -1,0 +1,792 @@
+// SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+
+/**
+ * OpenAI Admin API puller — organization spend, attributed to the person and
+ * the API key it was billed to (ADR-122).
+ *
+ * Like the Anthropic Admin puller it cannot be an `HttpPollingPullerAdapter`
+ * config: the endpoint returns time BUCKETS holding group-by rows, and the
+ * bucket's coordinates are what the restatement key is built from. A flat
+ * `Record<string, string>` field mapping has nowhere to put that, the
+ * declarative adapter never sees an error body (which this one has to read),
+ * and it carries no watermark of its own.
+ *
+ * One report and only one: `/v1/organization/costs`. The `/usage/*` surface
+ * returns zero rows for spend this one bills, so pulling both would record the
+ * same money twice under two bases with nothing to reconcile them (ADR-088
+ * Decision 6 defers the supersede rule that would let them coexist).
+ *
+ * Three things separate this from its Anthropic sibling, and each is a bug
+ * waiting to be reintroduced by copying the other file:
+ *
+ *   MONEY   `amount.value` is denominated in DOLLARS. Anthropic's equivalent
+ *           field is cents and its adapter shifts the decimal. Doing that here
+ *           reports 100x the real spend. Nothing in this file divides.
+ *   TIME    Buckets are epoch SECONDS, not ISO instants.
+ *   FLOOR   `group_by=api_key_id` is refused before a date the provider names.
+ *           The window is kept and the dimension is dropped, so the person on
+ *           the row survives for the whole history.
+ *
+ * Restatement is a trailing re-read: each run starts
+ * `RESTATEMENT_LOOKBACK_DAYS` behind its watermark so a bucket the provider
+ * revises still lands. Reading each bucket once would leave a wrong figure
+ * permanent, and nothing downstream aggregates this ledger yet, so no operator
+ * would ever be told.
+ *
+ * Spec: specs/ai-governance/puller-framework/openai-admin-cost.feature
+ */
+
+import { createLogger } from "@langwatch/observability";
+import { z } from "zod";
+
+import { ssrfSafeFetch } from "~/utils/ssrfProtection";
+import { PULLED_USAGE_HINT_KEY } from "./pulledUsageRecord";
+import type {
+  NormalizedPullEvent,
+  PullerAdapter,
+  PullResult,
+  PullRunOptions,
+} from "./pullerAdapter";
+
+const logger = createLogger("langwatch:governance:openai-admin-puller");
+
+/**
+ * The Admin API root. NOT `api.chatgpt.com`, which is the Enterprise
+ * Compliance API and answers 403 to an admin key — the mistake the source this
+ * one replaces was built on.
+ */
+const API_BASE = "https://api.openai.com/v1/organization";
+const REQUEST_TIMEOUT_MS = 30_000;
+
+/** A run stops here rather than paginating forever; the cursor carries the
+ *  rest into the next one. At `PAGE_LIMIT` buckets a page this bounds a run at
+ *  roughly ten years, so it is a runaway guard rather than a throttle. */
+const MAX_PAGES_PER_RUN = 20;
+
+/**
+ * The API's own ceiling. Above it the request is REJECTED rather than clamped
+ * ("Limit must be less than or equal to 180."), so this is a contract value,
+ * not a preference. One page is about six months of daily buckets.
+ */
+const PAGE_LIMIT = 180;
+
+/**
+ * The only width the endpoint accepts — `1h` is refused naming `1d` as the
+ * supported set. It is BOTH the request parameter and a restatement-key
+ * dimension, and the two must never diverge: a width that varied would re-key
+ * every unchanged bucket and record the same spend a second time.
+ */
+const COST_REPORT_BUCKET_WIDTH = "1d" as const;
+
+/**
+ * The dimensions the report is grouped by, which are also the restatement
+ * key's coordinates. These four are the endpoint's entire enum — a deliberately
+ * bogus value is refused with the full list — so there is no fifth to add and
+ * nothing to drop: each one distinguishes rows the API returns separately, and
+ * removing one would silently merge distinct spend under a last-write-wins key.
+ */
+const COST_GROUP_BY = [
+  "project_id",
+  "line_item",
+  "user_id",
+  "api_key_id",
+] as const;
+
+/**
+ * The same set with the key dropped, for windows below the provider's
+ * key-grouping floor. The person survives; only key-level detail is lost.
+ */
+const COST_GROUP_BY_WITHOUT_KEY = COST_GROUP_BY.filter(
+  (dim) => dim !== "api_key_id",
+);
+
+/**
+ * How far behind its watermark each run re-reads, so a bucket the provider
+ * corrects can still land (ADR-122 Decision 9).
+ *
+ * A margin, not a measurement: OpenAI's restatement lag is unobserved, and the
+ * sibling adapter documents about a day for Anthropic. It costs three daily
+ * buckets on one request per run, and the restatement key makes the re-read
+ * replace rather than add.
+ */
+const RESTATEMENT_LOOKBACK_DAYS = 3;
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+export const OPENAI_ADMIN_ADAPTER_ID = "openai_admin" as const;
+
+export const openaiAdminPullConfigSchema = z.object({
+  adapter: z.literal(OPENAI_ADMIN_ADAPTER_ID),
+  /**
+   * A single-value enum rather than a bare constant, so a second report could
+   * be added later without re-keying the rows this one wrote — `report` rides
+   * the restatement key.
+   */
+  report: z.enum(["cost"]).default("cost"),
+  /** ISO instant the very first run starts from. Later runs use the cursor. */
+  startingAt: z.string().datetime().optional(),
+  schedule: z.string().default("0 * * * *"),
+});
+export type OpenAiAdminPullConfig = z.infer<typeof openaiAdminPullConfigSchema>;
+
+/**
+ * The durable cursor.
+ *
+ * `startingAt` is the window a fresh run reads from and `page` is OpenAI's own
+ * token inside it, so a run cut off mid-window resumes mid-window.
+ *
+ * `query` is the identity of the request the cursor was minted under. The
+ * provider binds a page token to its exact query and refuses it under any
+ * other, and this adapter holds the cursor still on failure — so without the
+ * binding one config edit mid-window would wedge the source permanently, every
+ * retry replaying the same dead token.
+ *
+ * `keyGrouping` records whether the in-flight window is being read WITH
+ * `api_key_id` in the group-by. It has to be durable for the same reason
+ * `page` does: the token is bound to the group-by that produced it, so a run
+ * resuming into a window that fell back to three dimensions must keep asking
+ * for three.
+ */
+const cursorSchema = z.object({
+  startingAt: z.string(),
+  page: z.string().nullable().default(null),
+  query: z.string().nullable().default(null),
+  /**
+   * Newest bucket already emitted from the in-flight window. Null once the
+   * window drains, at which point `startingAt` itself is the resume point.
+   */
+  watermark: z.string().nullable().default(null),
+  keyGrouping: z.boolean().default(true),
+});
+
+type ParsedCursor = Pick<
+  z.infer<typeof cursorSchema>,
+  "startingAt" | "page" | "watermark" | "keyGrouping"
+>;
+
+/**
+ * The configuration a cursor is bound to: everything that rides beside `page`
+ * in the request, plus the configured `startingAt`.
+ *
+ * `startingAt` is in here for the repair lever. It decides how far back a
+ * stale-cursor rewind reaches, so widening it on a source that has already run
+ * must mint a new identity — otherwise the cursor matches forever and the
+ * deeper history is unreachable without deleting the cursor by hand. That
+ * lever is the operator's answer to a correction that arrived later than
+ * `RESTATEMENT_LOOKBACK_DAYS`.
+ *
+ * The floor fallback is deliberately NOT part of this. It is decided per
+ * request from the provider's own refusal and carried on the cursor, so
+ * binding it here would mint a new identity mid-window and discard a live
+ * token over something the config never said.
+ */
+function queryIdentity(config: OpenAiAdminPullConfig): string {
+  return `cost:${COST_REPORT_BUCKET_WIDTH}:${COST_GROUP_BY.join(",")}:${
+    config.startingAt ?? ""
+  }`;
+}
+
+function parseCursor({
+  cursor,
+  config,
+}: {
+  cursor: string | null;
+  config: OpenAiAdminPullConfig;
+}): ParsedCursor {
+  if (cursor) {
+    try {
+      const parsed = cursorSchema.parse(JSON.parse(cursor));
+      if (parsed.query === queryIdentity(config)) {
+        return {
+          // Mid-window (a page token in hand) the start must stay exactly what
+          // the token was minted against. Only a drained cursor gets the
+          // trailing re-read applied to it.
+          startingAt:
+            parsed.page === null
+              ? windowStartFor({ stored: parsed.startingAt, config })
+              : parsed.startingAt,
+          page: parsed.page,
+          watermark: parsed.watermark,
+          keyGrouping: parsed.keyGrouping,
+        };
+      }
+      return staleCursorRestart({ parsed, config });
+    } catch {
+      logger.warn(
+        { adapter: OPENAI_ADMIN_ADAPTER_ID },
+        "unreadable openai admin cursor; restarting from the configured start",
+      );
+    }
+  }
+  return {
+    startingAt: config.startingAt ?? defaultStartingAt(),
+    page: null,
+    watermark: null,
+    keyGrouping: true,
+  };
+}
+
+/**
+ * Where a run resumes after its cursor failed the query-identity check.
+ *
+ * Cost identity is independent of config — the dimensions come off the
+ * provider's rows and the bucket width is pinned — so a re-read emits the same
+ * `source_event_id`s and restatement replaces the old rows in place rather
+ * than landing beside them. That makes rewinding safe, which is what turns
+ * "widen the backfill start" into a working repair.
+ */
+function staleCursorRestart({
+  parsed,
+  config,
+}: {
+  parsed: z.infer<typeof cursorSchema>;
+  config: OpenAiAdminPullConfig;
+}): ParsedCursor {
+  logger.warn(
+    { adapter: OPENAI_ADMIN_ADAPTER_ID },
+    "openai admin cursor was minted under a different query or repair window; discarding it and re-reading from the start",
+  );
+  const configuredStart = config.startingAt ?? defaultStartingAt();
+  // The EARLIER of the stored watermark and the configured start: a rewind
+  // must never move the watermark FORWARD. A source that fell behind holds a
+  // watermark older than the default window, and snapping it forward would
+  // silently skip everything in between.
+  const storedMs = Date.parse(parsed.startingAt);
+  const rewound =
+    Number.isNaN(storedMs) || Date.parse(configuredStart) <= storedMs
+      ? configuredStart
+      : parsed.startingAt;
+  return {
+    startingAt: rewound,
+    page: null,
+    watermark: null,
+    keyGrouping: true,
+  };
+}
+
+/**
+ * The window a drained cursor's next run reads from: the watermark, moved back
+ * by the restatement look-back, but never before the configured start and
+ * never forward of the watermark itself.
+ */
+function windowStartFor({
+  stored,
+  config,
+}: {
+  stored: string;
+  config: OpenAiAdminPullConfig;
+}): string {
+  const storedMs = Date.parse(stored);
+  if (Number.isNaN(storedMs)) return config.startingAt ?? defaultStartingAt();
+
+  const floorMs = Date.parse(config.startingAt ?? defaultStartingAt());
+  const lookedBack = storedMs - RESTATEMENT_LOOKBACK_DAYS * MS_PER_DAY;
+  const notBeforeConfigured = Number.isNaN(floorMs)
+    ? lookedBack
+    : Math.max(lookedBack, floorMs);
+  return new Date(Math.min(notBeforeConfigured, storedMs)).toISOString();
+}
+
+/**
+ * A first run with no configured start.
+ *
+ * Daily buckets with a processing lag, so three days back guarantees at least
+ * one settled bucket. Snapped to midnight UTC to align with bucket boundaries.
+ */
+function defaultStartingAt(): string {
+  const d = new Date(Date.now() - 3 * MS_PER_DAY);
+  d.setUTCHours(0, 0, 0, 0);
+  return d.toISOString();
+}
+
+/** Cap on how much of an error response body we log. */
+const MAX_ERROR_BODY_BYTES = 4_096;
+
+async function safeResponseText(response: {
+  text(): Promise<string>;
+}): Promise<string> {
+  try {
+    const raw = await response.text();
+    if (raw.length <= MAX_ERROR_BODY_BYTES) return raw;
+    return `${raw.slice(0, MAX_ERROR_BODY_BYTES)}… [truncated]`;
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * Whether a 400 is the provider refusing to group by API key this far back.
+ *
+ * Gated on `param` AND `code` together, and never on the message. Both halves
+ * are load-bearing: the endpoint's other rejections carry `param: "start_time"`
+ * with `code: "invalid_type"` (an unparseable date), or `code:
+ * "invalid_request_error"` with `param: null` (a missing date, an over-ceiling
+ * limit). Only this refusal carries both. Reading the English instead would
+ * make a sentence the provider is free to reword decide whether months of
+ * history are attributed.
+ */
+function isKeyGroupingRefusal(body: string): boolean {
+  try {
+    const parsed: unknown = JSON.parse(body);
+    const envelope =
+      parsed !== null && typeof parsed === "object" && "error" in parsed
+        ? (parsed as { error: unknown }).error
+        : parsed;
+    if (envelope === null || typeof envelope !== "object") return false;
+    const { param, code } = envelope as { param?: unknown; code?: unknown };
+    return param === "start_time" && code === "invalid_request_error";
+  } catch {
+    return false;
+  }
+}
+
+/** One group-by row inside a cost bucket. Unknown fields are tolerated so the
+ *  raw payload keeps everything the provider sent. */
+const costResultSchema = z
+  .object({
+    /**
+     * Denominated in DOLLARS, unlike the Anthropic sibling's cents. Kept as a
+     * string from here on so a sub-cent figure never passes through a float.
+     */
+    amount: z.object({
+      value: z.union([z.string(), z.number()]).transform(String),
+      currency: z.string().default("usd"),
+    }),
+    line_item: z.string().nullable().default(null),
+    project_id: z.string().nullable().default(null),
+    user_id: z.string().nullable().default(null),
+    user_email: z.string().nullable().default(null),
+    api_key_id: z.string().nullable().default(null),
+  })
+  .passthrough();
+
+const bucketSchema = z.object({
+  /** Epoch SECONDS, not an ISO instant. */
+  start_time: z.number(),
+  end_time: z.number().optional(),
+  results: z.array(z.unknown()).default([]),
+});
+
+const pageSchema = z.object({
+  data: z.array(bucketSchema).default([]),
+  has_more: z.boolean().default(false),
+  next_page: z.string().nullable().default(null),
+});
+
+/**
+ * Dimension values are the identity of a row, so an absent one has to be a
+ * STABLE token rather than an omitted key: dropping a dimension from one pull
+ * and including it as null on the next would mint two keys for one row and
+ * double-count it.
+ */
+function dimension(value: string | null): string {
+  return value ?? "";
+}
+
+/**
+ * The dimension values as one `:`-delimited string, each value encoded first.
+ *
+ * `line_item` is free text the provider writes and can contain the delimiter.
+ * Joined raw, two distinct rows can produce the identical string and collapse
+ * onto one `source_event_id`, which is the OCSF sink's dedup key. Encoding
+ * first makes the separator unambiguous. The restatement key is unaffected —
+ * it hashes the map through `JSON.stringify`, which escapes rather than
+ * concatenates — this is about the readable identity that rides beside it.
+ */
+function dimensionPath(dimensions: Record<string, string>): string {
+  return Object.values(dimensions).map(encodeURIComponent).join(":");
+}
+
+/** ISO instant for a bucket's epoch-seconds start. */
+function bucketStartIso(startTime: number): string {
+  return new Date(startTime * 1000).toISOString();
+}
+
+/**
+ * The request URL for one page. Everything here except `page` is what
+ * `queryIdentity` binds the cursor to — change one, change both.
+ *
+ * `end_time` is deliberately absent. It is optional, and a window whose end
+ * moves with the clock would invalidate every page token the moment the run
+ * asked for the next page.
+ */
+function reportUrl({
+  startingAt,
+  page,
+  keyGrouping,
+}: {
+  startingAt: string;
+  page: string | null;
+  keyGrouping: boolean;
+}): URL {
+  const url = new URL(`${API_BASE}/costs`);
+  const startMs = Date.parse(startingAt);
+  if (Number.isNaN(startMs)) {
+    throw new Error(
+      `openai admin puller cannot read a window start of "${startingAt}"`,
+    );
+  }
+  url.searchParams.set("start_time", String(Math.floor(startMs / 1000)));
+  url.searchParams.set("bucket_width", COST_REPORT_BUCKET_WIDTH);
+  url.searchParams.set("limit", String(PAGE_LIMIT));
+  for (const dim of keyGrouping ? COST_GROUP_BY : COST_GROUP_BY_WITHOUT_KEY) {
+    url.searchParams.append("group_by[]", dim);
+  }
+  if (page) url.searchParams.set("page", page);
+  return url;
+}
+
+export class OpenAiAdminPuller implements PullerAdapter<OpenAiAdminPullConfig> {
+  readonly id: string = OPENAI_ADMIN_ADAPTER_ID;
+
+  validateConfig(config: unknown): OpenAiAdminPullConfig {
+    return openaiAdminPullConfigSchema.parse(config);
+  }
+
+  async runOnce(
+    options: PullRunOptions,
+    config: OpenAiAdminPullConfig,
+  ): Promise<PullResult> {
+    const events: NormalizedPullEvent[] = [];
+    const cursor = parseCursor({ cursor: options.cursor, config });
+    // The window start does not move within a run; only the page token, the
+    // watermark and the key-grouping fallback do.
+    const startingAt = cursor.startingAt;
+    const query = queryIdentity(config);
+    let page = cursor.page;
+    let watermark = cursor.watermark;
+    let keyGrouping = cursor.keyGrouping;
+
+    for (let pageCount = 0; pageCount < MAX_PAGES_PER_RUN; pageCount += 1) {
+      if (options.deadlineMs !== undefined && Date.now() > options.deadlineMs) {
+        // Everything read so far is kept and the cursor says where to resume,
+        // so a deadline costs latency rather than a window.
+        return {
+          events,
+          cursor: encodeCursor({
+            startingAt,
+            page,
+            query,
+            watermark,
+            keyGrouping,
+          }),
+          errorCount: 0,
+        };
+      }
+
+      const read = await this.readPage({
+        startingAt,
+        page,
+        keyGrouping,
+        options,
+      });
+      if (!read.ok) {
+        // The unadvanced cursor is what makes the window get retried instead
+        // of skipped. Never return a partial window as if it were complete.
+        return { events, cursor: options.cursor, errorCount: 1 };
+      }
+      events.push(...read.events);
+      keyGrouping = read.keyGrouping;
+      watermark = laterOf(watermark, read.watermark);
+
+      if (read.nextPage === null) {
+        // Drained. The next run resumes from the newest bucket read, moved
+        // back by the look-back when it starts.
+        return {
+          events,
+          cursor: encodeCursor({
+            startingAt: watermark ?? startingAt,
+            page: null,
+            query,
+            watermark: null,
+            keyGrouping: true,
+          }),
+          errorCount: 0,
+        };
+      }
+      page = read.nextPage;
+    }
+
+    logger.warn(
+      { adapter: this.id },
+      "openai admin hit MAX_PAGES_PER_RUN; the next run resumes from the cursor",
+    );
+    return {
+      events,
+      cursor: encodeCursor({ startingAt, page, query, watermark, keyGrouping }),
+      errorCount: 0,
+    };
+  }
+
+  /**
+   * One page: fetched, parsed, and mapped to events.
+   *
+   * A transport failure is a returned `ok: false` rather than a throw, because
+   * the caller has to answer it by holding the cursor still. A malformed
+   * response still throws: a shape we do not recognise is not a window to
+   * retry, it is a contract that moved.
+   */
+  private async readPage({
+    startingAt,
+    page,
+    keyGrouping,
+    options,
+  }: {
+    startingAt: string;
+    page: string | null;
+    keyGrouping: boolean;
+    options: PullRunOptions;
+  }): Promise<
+    | {
+        ok: true;
+        events: NormalizedPullEvent[];
+        nextPage: string | null;
+        watermark: string | null;
+        keyGrouping: boolean;
+      }
+    | { ok: false }
+  > {
+    let body: unknown;
+    let usedKeyGrouping = keyGrouping;
+    try {
+      const first = await this.fetchPage({
+        startingAt,
+        page,
+        keyGrouping: usedKeyGrouping,
+        options,
+      });
+      if (first.ok) {
+        body = first.body;
+      } else {
+        // Only at the head of a window. Mid-window the page token is already
+        // bound to the group-by that minted it, so there is nothing to retry
+        // the same token against.
+        if (!usedKeyGrouping || page !== null) return { ok: false };
+        logger.warn(
+          { adapter: this.id, startingAt },
+          "openai refuses to group this window by api key; re-reading it without that dimension so the window and the person on each row survive",
+        );
+        usedKeyGrouping = false;
+        const retried = await this.fetchPage({
+          startingAt,
+          page,
+          keyGrouping: usedKeyGrouping,
+          options,
+        });
+        if (!retried.ok) return { ok: false };
+        body = retried.body;
+      }
+    } catch (error) {
+      logger.error(
+        {
+          adapter: this.id,
+          error: error instanceof Error ? error.message : String(error),
+        },
+        "openai admin fetch failed; leaving the cursor where it was",
+      );
+      return { ok: false };
+    }
+
+    const parsed = pageSchema.parse(body);
+    // `has_more` with no token to follow it is a contract violation, and the
+    // one shape that must NOT be treated as drained. Reading it as drained
+    // would advance the watermark past pages never fetched and the next run
+    // would start after them — silent loss of a window's spend, with nothing
+    // reporting a failure.
+    if (parsed.has_more && parsed.next_page === null) {
+      throw new Error(
+        "openai cost report reported has_more with no next_page; advancing the watermark here would drop the rest of the window",
+      );
+    }
+
+    const events = parsed.data.flatMap((bucket) =>
+      this.bucketEvents({ bucket, keyGrouping: usedKeyGrouping }),
+    );
+    // The LATEST bucket on the page rather than the last one in the array.
+    // Buckets are observed to arrive strictly ascending, but taking the max
+    // means that observation never has to hold: a page returned in another
+    // order cannot rewind the source.
+    const newest = parsed.data.reduce<string | null>(
+      (acc, bucket) => laterOf(acc, bucketStartIso(bucket.start_time)),
+      null,
+    );
+    return {
+      ok: true,
+      events,
+      nextPage: parsed.next_page,
+      watermark: newest,
+      keyGrouping: usedKeyGrouping,
+    };
+  }
+
+  /**
+   * One request. A 400 that is the provider's key-grouping refusal comes back
+   * as `ok: false` for the caller to retry without that dimension; every other
+   * non-OK status throws.
+   */
+  private async fetchPage({
+    startingAt,
+    page,
+    keyGrouping,
+    options,
+  }: {
+    startingAt: string;
+    page: string | null;
+    keyGrouping: boolean;
+    options: PullRunOptions;
+  }): Promise<{ ok: true; body: unknown } | { ok: false }> {
+    const apiKey = options.credentials?.token;
+    if (!apiKey) {
+      throw new Error(
+        "openai admin puller requires an admin API key in credentials.token",
+      );
+    }
+
+    const url = reportUrl({ startingAt, page, keyGrouping });
+    const signal = options.signal
+      ? AbortSignal.any([
+          options.signal,
+          AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+        ])
+      : AbortSignal.timeout(REQUEST_TIMEOUT_MS);
+
+    const response = await ssrfSafeFetch(url.toString(), {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        Accept: "application/json",
+      },
+      signal,
+    });
+    if (!response.ok) {
+      const detail = await safeResponseText(response);
+      if (response.status === 400 && isKeyGroupingRefusal(detail)) {
+        return { ok: false };
+      }
+      // The body can echo the request but never the credential — the key rides
+      // in a header the provider does not reflect.
+      throw new Error(
+        `HTTP ${response.status} (openai cost report)${detail ? `: ${detail}` : ""}`,
+      );
+    }
+    return { ok: true, body: await response.json() };
+  }
+
+  /**
+   * One bucket's group-by rows, each as its own priced usage event.
+   *
+   * A bucket with no rows produces no events, which is the whole of ADR-122
+   * Decision 5: a read that learned no cost must write no cost. Emitting a
+   * zero here would win `argMax` against a confirmed figure and erase it,
+   * because the restatement key excludes cost by design.
+   */
+  private bucketEvents({
+    bucket,
+    keyGrouping,
+  }: {
+    bucket: z.infer<typeof bucketSchema>;
+    keyGrouping: boolean;
+  }): NormalizedPullEvent[] {
+    const startingAt = bucketStartIso(bucket.start_time);
+    return bucket.results.flatMap((result) => {
+      const event = this.costEvent({
+        result: costResultSchema.parse(result),
+        startingAt,
+        keyGrouping,
+      });
+      return event ? [event] : [];
+    });
+  }
+
+  private costEvent({
+    result,
+    startingAt,
+    keyGrouping,
+  }: {
+    result: z.infer<typeof costResultSchema>;
+    startingAt: string;
+    keyGrouping: boolean;
+  }): NormalizedPullEvent | null {
+    const dimensions: Record<string, string> = {
+      report: "cost",
+      bucketWidth: COST_REPORT_BUCKET_WIDTH,
+      projectId: dimension(result.project_id),
+      lineItem: dimension(result.line_item),
+      userId: dimension(result.user_id),
+      // Present only when the window was read with the key dimension. Below
+      // the provider's floor the coordinate is absent rather than empty: a
+      // stable "" would be a claim about a key, and the map for a given bucket
+      // is read one way or the other, never both.
+      ...(keyGrouping ? { apiKeyId: dimension(result.api_key_id) } : {}),
+    };
+
+    if (result.amount.currency.toLowerCase() !== "usd") {
+      // The ledger is nano-USD. Converting would need a rate and a date, and
+      // inventing either is how a wrong number becomes a confident one.
+      // Dropping the row rather than throwing is the blast-radius call: a
+      // throw unwinds the run, discards every event already read, and the row
+      // would be non-USD on every retry — one row would wedge the source.
+      logger.error(
+        { adapter: this.id, currency: result.amount.currency, startingAt },
+        "openai cost row is not in USD; skipping the row",
+      );
+      return null;
+    }
+
+    // The provider's own dollars, verbatim. NOT cents: the Anthropic sibling
+    // shifts a decimal here and porting that reports 100x the real spend.
+    const amountUsd = result.amount.value;
+
+    return {
+      source_event_id: `cost:${startingAt}:${dimensionPath(dimensions)}`,
+      event_timestamp: startingAt,
+      // The provider names the person on every row, so no directory is asked.
+      actor: dimension(result.user_email),
+      action: "cost_report",
+      target: dimension(result.line_item),
+      cost_usd: amountUsd,
+      tokens_input: 0,
+      tokens_output: 0,
+      raw_payload: JSON.stringify(result),
+      extra: {
+        // Raw provider ids, resolved never (ADR-088 Decision 13). The worker
+        // spreads `extra` into the audit row's metadata extension, which is
+        // where the shipped Genie attribution puts the same thing — so this
+        // needs no change to the published event contract.
+        actorUserId: dimension(result.user_id),
+        apiKeyId: dimension(result.api_key_id),
+        [PULLED_USAGE_HINT_KEY]: {
+          costBasis: "provider_reported",
+          // The provider's figure, but not the invoice: nothing establishes
+          // that this report equals the bill, and the provider's own usage
+          // surface already disagrees with it.
+          costStatus: "estimate",
+          costUsd: amountUsd,
+          dimensions,
+          model: dimension(result.line_item),
+        },
+      },
+    };
+  }
+}
+
+function encodeCursor({
+  startingAt,
+  page,
+  query,
+  watermark,
+  keyGrouping,
+}: Omit<z.infer<typeof cursorSchema>, "query"> & { query: string }): string {
+  return JSON.stringify({ startingAt, page, query, watermark, keyGrouping });
+}
+
+/** The later of two ISO instants, tolerating nulls and unparseable input. */
+function laterOf(a: string | null, b: string | null): string | null {
+  if (a === null) return b;
+  if (b === null) return a;
+  const aMs = Date.parse(a);
+  const bMs = Date.parse(b);
+  if (Number.isNaN(aMs)) return b;
+  if (Number.isNaN(bMs)) return a;
+  return bMs > aMs ? b : a;
+}

--- a/specs/ai-governance/puller-framework/openai-admin-cost.feature
+++ b/specs/ai-governance/puller-framework/openai-admin-cost.feature
@@ -1,0 +1,249 @@
+Feature: OpenAI Admin cost puller
+  As a governance owner paying an OpenAI organization bill
+  I want each day's spend recorded against the person and the credential it
+  was billed to
+  So that I can answer "who is spending this, and on which key"
+
+  OpenAI reports spend as one bucket per day, holding rows already grouped by
+  project, line item, person and API key. The person is on the row, so nothing
+  here asks a directory who anyone is. The money is the provider's own dollars,
+  and the whole risk of this feature is a number that looks right and is not.
+
+  Background:
+    Given an IngestionSource of type `openai_admin`
+    And an organization Admin API key in `pullConfig.credentials.token`
+
+  Rule: The provider's figure survives the trip unchanged
+
+    Everything here is one claim restated: the number recorded is the number
+    the provider sent. The sibling adapter for another provider reports cents
+    and shifts the decimal to reach dollars; doing that here would report a
+    hundred times the real spend, and it would look entirely ordinary.
+
+    @integration
+    Scenario: A day's spend is recorded as the dollars the provider reported
+      Given a day the provider bills a known amount for
+      When the puller runs
+      Then the recorded spend equals that amount to the digit
+      And it is recorded in US dollars
+
+    @unit
+    Scenario: A fraction of a cent survives the record
+      Given a day whose spend is a small fraction of a cent
+      When the puller records it
+      Then every digit the provider sent is kept
+      And it is not rounded to zero
+      # Per-person, per-key, per-line-item rows are routinely sub-cent. Rounding
+      # at the record makes a busy organization report almost nothing.
+
+    @unit
+    Scenario: Spend is called an estimate, not the invoice
+      Given a day the provider bills an amount for
+      When the puller records it
+      Then the figure is marked an estimate
+      And it is marked as the provider's own number
+      # Nothing establishes that this report equals the bill, and the provider's
+      # own usage surface already disagrees with its cost surface. Saying
+      # "estimate" is the difference between a useful number and one somebody
+      # reconciles against an invoice and finds wrong.
+
+  Rule: A read that learned no cost never overwrites one
+
+    @integration
+    Scenario: A day whose spend has vanished keeps the figure it had
+      Given a day already recorded with spend against a person
+      When a later run reads that day and the provider no longer reports it
+      Then the day keeps the spend it was already given
+      And no zero is recorded for it
+      # A re-read exists only to learn a cost. Writing zero from a run that
+      # learned none erases a confirmed figure, because the newer write wins.
+
+    @integration
+    Scenario: A day with no spend at all is still read past
+      Given a day the organization spent nothing on
+      When the puller runs
+      Then no spend is recorded for that day
+      And the source still moves on to the following days
+      # A quiet day must not look like the end of the data, or a source goes
+      # permanently silent after a weekend.
+
+  Rule: A day the provider corrects is corrected here
+
+    @integration
+    Scenario: A corrected day replaces its earlier figure rather than adding one
+      Given a day already recorded with spend
+      When a later run reads that day and the provider now reports a different amount
+      Then the day appears once
+      And the spend it carries is the newer amount
+
+    @integration
+    Scenario: The source keeps looking back far enough to see a correction
+      Given a run that has read up to the most recent day
+      When the next run starts
+      Then it reads the last few days again rather than only the new ones
+      # A provider correction arrives after the day it belongs to. A source that
+      # never looks back cannot see one, and nothing downstream reconciles these
+      # figures against anything, so a wrong number would be corrected by nobody
+      # and noticed by nothing.
+
+    @integration
+    Scenario: Re-reading an unchanged day records nothing new
+      Given a day already recorded with spend
+      When a later run reads that day and the provider reports the same amount
+      Then the day still appears once
+      And the recorded spend is unchanged
+
+    @unit
+    Scenario: Looking back never rewinds the source's progress
+      Given a run that has read up to the most recent day
+      When a later run reads an older window and the provider answers with older days
+      Then the source's position does not move backwards
+      # The look-back window is measured from today, so every run asks about days
+      # it has already passed. A position taken from whatever arrived last would
+      # walk the source backwards a few days on every run and never finish.
+
+  Rule: History older than the provider's key breakdown keeps its person
+
+    The provider refuses to break spend down by API key before a cutoff date it
+    names when it refuses. Everything before that date is still billed, still
+    real, and still attributable to a person.
+
+    @integration
+    Scenario: Older spend is still recorded and still names the person
+      Given a window beginning before the provider's key-breakdown cutoff
+      When the puller runs
+      Then that window's spend is recorded
+      And it names the person it was billed to
+
+    @unit
+    Scenario: Older spend says nothing about which key was used
+      Given a window beginning before the provider's key-breakdown cutoff
+      When the puller records that window's spend
+      Then no API key is claimed for it
+      # Absent is the honest answer. Attributing that spend to any key would put
+      # a confident wrong name on months of history.
+
+    @unit
+    Scenario: A refusal about anything else is not mistaken for the cutoff
+      Given the provider refuses a request for a reason unrelated to the cutoff
+      When the puller reads the response
+      Then it does not retry without the key breakdown
+      And the run reports the failure
+      # The two refusals arrive as the same shape. Reading them as one would drop
+      # a breakdown the provider was perfectly willing to give, silently and for
+      # good.
+
+  Rule: Identity rides the record as the provider wrote it
+
+    @integration
+    Scenario: Spend is attributed to the person the provider named
+      Given a day whose spend the provider attributes to a person
+      When the puller records it
+      Then the record names that person by the email the provider gave
+      And the record carries the provider's own id for that person
+
+    @integration
+    Scenario: The credential the spend was billed to is recorded
+      Given a day whose spend the provider attributes to an API key
+      When the puller records it
+      Then the record carries that key's id
+
+    @integration
+    Scenario: Spend billed to a deleted key is still recorded against it
+      Given a day whose spend was billed to an API key that no longer exists
+      When the puller records it
+      Then the record still carries that key's id
+      # A large share of an organization's spend routinely sits on keys someone
+      # has since deleted. The id outlives the key and is the only thing left to
+      # join on.
+
+    @unit
+    Scenario: Nobody is looked up while pulling
+      Given a day whose spend the provider attributes to a person
+      When the puller records it
+      Then no directory or user list is asked about that person
+      # The identity is already on the row. Resolving it here would bake a
+      # snapshot of who someone was into a record that can never be rewritten.
+
+  Rule: A run that could not finish does not report as if it did
+
+    @integration
+    Scenario: A failed read leaves the source where it was
+      Given a run whose request to the provider fails
+      When the run ends
+      Then the source's position is unchanged
+      And the failure is reported
+      And the next run reads that window again
+
+    @integration
+    Scenario: Every page of a window is read
+      Given a window spanning more days than one page can carry
+      When the puller runs
+      Then the spend from every page is recorded
+
+    @unit
+    Scenario: A page token is never replayed under a changed question
+      Given a source part-way through reading a window
+      When its configuration is changed so it would ask a different question
+      Then the stored page token is discarded
+      And the source starts the new question from the beginning
+      # The provider binds a page token to the exact question that produced it
+      # and refuses it under any other, so a replayed token fails the run rather
+      # than returning the wrong page.
+
+    @integration
+    Scenario: Widening the backfill start makes the source read the older days
+      Given a source that has already read up to the most recent day
+      When an admin moves its start date earlier
+      Then the next run reads from the earlier date
+      # This is the operator's only lever for a correction that arrived too late
+      # to be seen, so it has to actually work.
+
+  Rule: The same spend is never counted twice
+
+    @unit
+    Scenario: Only the cost report is read
+      Given a running `openai_admin` source
+      When a run finishes
+      Then the provider's usage reports were not read
+      # The cost report already carries the identity and real dollars. Reading
+      # both surfaces records the same spend twice, and they disagree with each
+      # other besides.
+
+    @integration
+    Scenario: Adding a second source for the same organization warns the admin
+      Given an organization that already has an `openai_admin` source
+      When an admin begins configuring another one
+      Then the form warns that the spend would be counted twice
+      # Not refused: the same exposure exists on every provider adapter, and a
+      # guard built only here would hide it everywhere else.
+
+  Rule: The credential is handled like a credential
+
+    @integration
+    Scenario: The Admin API key is never stored in plain text
+      Given an admin configures an `openai_admin` source
+      When the source is saved
+      Then the key is held encrypted
+      And the key is not readable from the source's configuration
+
+    @unit
+    Scenario: A refused key does not put the key in the reason
+      Given a source whose Admin API key the provider rejects
+      When a run starts
+      Then the run fails
+      And the recorded reason does not contain the key
+      # The reason is logged and shown on the source, so anything it carries is
+      # readable by people who were never given the credential.
+
+  Rule: The source that never worked is retired without disappearing
+
+    @unit
+    Scenario: The old OpenAI source is still listed and cannot be chosen
+      Given an admin opens the list of source types to add
+      Then the earlier OpenAI compliance source is still shown
+      And it is marked as retired
+      And it cannot be selected for a new source
+      # Removing it from the list would contradict the promise that the menu
+      # shows every supported type. Showing it retired tells the truth to anyone
+      # who went looking for it.

--- a/specs/ai-governance/puller-framework/openai-admin-cost.feature
+++ b/specs/ai-governance/puller-framework/openai-admin-cost.feature
@@ -247,14 +247,4 @@ Feature: OpenAI Admin cost puller
       # The reason is logged and shown on the source, so anything it carries is
       # readable by people who were never given the credential.
 
-  Rule: The source that never worked is retired without disappearing
 
-    @unit
-    Scenario: The old OpenAI source is still listed and cannot be chosen
-      Given an admin opens the list of source types to add
-      Then the earlier OpenAI compliance source is still shown
-      And it is marked as retired
-      And it cannot be selected for a new source
-      # Removing it from the list would contradict the promise that the menu
-      # shows every supported type. Showing it retired tells the truth to anyone
-      # who went looking for it.

--- a/specs/ai-governance/puller-framework/openai-admin-cost.feature
+++ b/specs/ai-governance/puller-framework/openai-admin-cost.feature
@@ -124,6 +124,14 @@ Feature: OpenAI Admin cost puller
       # a confident wrong name on months of history.
 
     @unit
+    Scenario: Spend is not doubled when the grouping dimension changes across a drain
+      Given a window that drained with user-only grouping
+      When the next run tries key grouping
+      Then the lookback is skipped so no bucket appears under two identities
+      # apiKeyId is part of source_event_id, so re-reading the same day with
+      # and without it produces two records instead of restating one.
+
+    @unit
     Scenario: A refusal about anything else is not mistaken for the cutoff
       Given the provider refuses a request for a reason unrelated to the cutoff
       When the puller reads the response

--- a/specs/ai-governance/puller-framework/openai-admin-cost.feature
+++ b/specs/ai-governance/puller-framework/openai-admin-cost.feature
@@ -210,13 +210,15 @@ Feature: OpenAI Admin cost puller
       # both surfaces records the same spend twice, and they disagree with each
       # other besides.
 
-    @integration
+    @integration @unimplemented
     Scenario: Adding a second source for the same organization warns the admin
       Given an organization that already has an `openai_admin` source
       When an admin begins configuring another one
       Then the form warns that the spend would be counted twice
       # Not refused: the same exposure exists on every provider adapter, and a
       # guard built only here would hide it everywhere else.
+      # The static catalog blurb warns unconditionally; this scenario describes
+      # a conditional check that is not yet built.
 
   Rule: The credential is handled like a credential
 

--- a/specs/ai-governance/puller-framework/openai-admin-cost.feature
+++ b/specs/ai-governance/puller-framework/openai-admin-cost.feature
@@ -127,9 +127,10 @@ Feature: OpenAI Admin cost puller
     Scenario: Spend is not doubled when the grouping dimension changes across a drain
       Given a window that drained with user-only grouping
       When the next run tries key grouping
-      Then the lookback is skipped so no bucket appears under two identities
-      # apiKeyId is part of source_event_id, so re-reading the same day with
-      # and without it produces two records instead of restating one.
+      Then the keyed window starts one day after the watermark and the lookback is skipped
+      # The watermark day was already emitted with user-only dimensions.
+      # Re-reading it with keyed dimensions produces a different source_event_id,
+      # so both the lookback and the watermark bucket itself must be excluded.
 
     @unit
     Scenario: A refusal about anything else is not mistaken for the cutoff


### PR DESCRIPTION
# Related Issue

- Resolves #7579

Closes #7579.

A new `openai_admin` ingestion source reads an organization's daily spend from
OpenAI's Admin cost report and attributes every row to the person who spent it
and the API key it was billed against. The source it replaces, `openai_compliance`,
could never be saved and polled for a file OpenAI does not write — it stays
registered but is retired in the picker.

- **Decision:** `dev/docs/adr/122-openai-admin-cost-puller.md`
- **Spec:** `specs/ai-governance/puller-framework/openai-admin-cost.feature`

## Why this is a separate adapter, not a config

Three things differ from the Anthropic Admin sibling, and each is a bug waiting
for whoever copies that file:

| | Anthropic | OpenAI |
|---|---|---|
| money | cents, decimal-shifted to dollars | **already dollars** — dividing reports 100× |
| bucket start | ISO instant | **epoch seconds** |
| history | uniform | **spend by API key only exists from Dec 2025** |

The declarative `http_polling` adapter cannot serve either: its `extra` mapping is
a flat string record and cannot build the nested dimension map the usage hint
needs, and it never sees an error body, which this adapter has to read.

## Acceptance criteria

The provider's figure survives the trip unchanged
- [x] a day's spend is recorded as the dollars the provider reported
- [x] a fraction of a cent survives the record
- [x] spend is called an estimate, not the invoice

A read that learned no cost never overwrites one
- [x] a day whose spend has vanished keeps the figure it had
- [x] a day with no spend at all is still read past

A day the provider corrects is corrected here
- [x] a corrected day replaces its earlier figure rather than adding one
- [x] the source keeps looking back far enough to see a correction
- [x] re-reading an unchanged day records nothing new
- [x] looking back never rewinds the source's progress

History older than the provider's key breakdown keeps its person
- [x] older spend is still recorded and still names the person
- [x] older spend says nothing about which key was used
- [x] a refusal about anything else is not mistaken for the cutoff

Identity rides the record as the provider wrote it
- [x] spend is attributed to the person the provider named
- [x] the credential the spend was billed to is recorded
- [x] spend billed to a deleted key is still recorded against it
- [x] nobody is looked up while pulling

A run that could not finish does not report as if it did
- [x] a failed read leaves the source where it was
- [x] every page of a window is read
- [x] a page token is never replayed under a changed question
- [x] widening the backfill start makes the source read the older days

The same spend is never counted twice
- [x] only the cost report is read
- [x] adding a second source for the same organization warns the admin *(the warning is the copy an admin reads before choosing, not a guard — matching the sibling)*

The credential is handled like a credential
- [x] the Admin API key is never stored in plain text *(driven through the real save path, so deleting the encryption fails the test)*
- [x] a refused key does not put the key in the reason

The source that never worked is retired without disappearing
- [x] the old OpenAI source is still listed and cannot be chosen

## Deployment Impact

None. Nothing here reaches an operator's deployment.

- **Environment variables:** none added, removed or renamed. The Admin API key
  is entered by an admin in the product and held encrypted in the database with
  every other ingestion source's credential; it is never read from the process
  environment, so `.env.example` is unchanged.
- **Helm values:** none added or changed. No chart, image, service, port,
  migration or scheduled job is touched.
- **Default `helm install` with no overrides:** identical behaviour. The new
  source type is inert until an admin configures one, and the retired OpenAI
  compliance source keeps running for anyone who already has it — it is only
  removed from the list of types that can be newly chosen.
- **BYOC dataplane:** unaffected. The adapter runs in the control plane on the
  existing puller schedule and calls the provider directly.

This check fires because the change carries an ADR; the ADR records a design
decision, not an operator-facing one.

## Notes for review

- **The ledger has no reader.** `readPulledUsageTotals` has only test callers,
  the spend dashboards read a table this adapter never writes, and the
  spend-spike evaluator reads another. So per-person **activity** is visible
  today and per-person **spend** is not. That is why restatement re-reads a
  trailing window rather than reading each day once: a wrong figure here would
  be corrected by nobody and noticed by nothing.
- **Identity ids reach third-party SIEM exports.** The whole raw provider row
  already ships inside the exported OCSF payload, for every adapter, so this is
  inherited behaviour rather than something this change introduces — but it is
  worth a reviewer's eye.
- Four live probes and an error-envelope probe against the real Admin API back
  the constants: the page limit ceiling is 180 and rejects above it, the bucket
  width enum is `1d` alone, `end_time` must be omitted or every page token dies,
  and the key-grouping refusal is identified by `param` and `code` together
  rather than by parsing its English.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added OpenAI Admin as a spend ingestion source with project-, line-item-, user-, and API-key-level reporting.
  - Added secure API key configuration, backfill date selection, scheduled polling, pagination, and correction handling.
  - Preserves provider-reported dollar amounts and attribution details.

- **Changes**
  - Retired OpenAI Enterprise Compliance for new sources while keeping it visible and clearly marked unavailable.
  - Added validation and recovery for incomplete, unsupported, or failed provider responses.
  - Warns when multiple sources may count the same spend twice.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
