### PR TITLE
fix(feature-flags): make every flag read state its project and organization

### DIFF
--- a/dev/docs/adr/005-feature-flags.md
+++ b/dev/docs/adr/005-feature-flags.md
@@ -63,7 +63,7 @@ PostHog is **never** called on the SYSTEM path. PRODUCT keeps PostHog as the sou
 ### Adding a new flag
 
 1. Add a `FEATURE_FLAGS` entry with `scope: "SYSTEM" | "PRODUCT"`, `defaultValue`, `description`. For SYSTEM flags migrated from an existing env variable, set `legacyEnvVar` so the old name keeps working.
-2. Call `featureFlagService.isEnabled("your_new_flag_key", { distinctId, defaultValue?, projectId?, organizationId?, cacheTtlMs? })`. The key is type-checked against `FeatureFlagKey` via the shared `FeatureFlagServiceInterface`, so unregistered keys fail at compile time even when the service is dependency-injected.
+2. Call `featureFlagService.isEnabled("your_new_flag_key", { distinctId, projectId, organizationId, defaultValue?, cacheTtlMs? })`. The key is type-checked against `FeatureFlagKey` via the shared `FeatureFlagServiceInterface`, so unregistered keys fail at compile time even when the service is dependency-injected. `projectId` and `organizationId` are required: a rule that names a scope the read left out can never match, so an omitted field would turn a rollout into a silent no-op. A caller with no such scope passes `NOT_TARGETED` (`src/server/featureFlag/targeting.ts`).
 3. Flip from `/ops/feature-flags` at runtime without a redeploy. For PRODUCT flags, prefer flipping in PostHog directly so user targeting rules apply.
 
 ### Adding a new family
@@ -102,20 +102,33 @@ FeatureFlagService                                 env override
                     fallback to FeatureFlagStorePostgres on PostHog error
 ```
 
-## Targeting via personProperties
+## Targeting
 
-PRODUCT flags target users / projects / orgs through PostHog `personProperties`:
+Rules on a flag row name a project or an organization. The read states both, so a rule written for either one can match:
 
 ```typescript
 await featureFlagService.isEnabled("release_ui_simulations_menu_enabled", {
   distinctId: userId,
-  defaultValue: false,
   projectId: "proj_123",
   organizationId: "org_456",
+  defaultValue: false,
 });
 ```
 
-PostHog receives these as `personProperties.project_id` and `personProperties.organization_id` for release condition evaluation. SYSTEM flags ignore `projectId` / `organizationId` since they're cluster-wide.
+Both fields are required. A surface that has no such scope states the opt-out instead, and no rule naming that scope can match it:
+
+```typescript
+await featureFlagService.isEnabled("release_ui_ai_governance_enabled", {
+  distinctId: userId,
+  projectId: NOT_TARGETED, // an organization page holds no project
+  organizationId: "org_456",
+  defaultValue: false,
+});
+```
+
+The same rule holds on the client: `useFeatureFlag(flag, { projectId, organizationId, enabled? })` requires both ids. `undefined` is legal for an id that is still loading, and pairs with `enabled: false`. The tRPC input carries both fields as required and uses `null` for "no such scope", because JSON has no `undefined`.
+
+The server never derives one id from the other. A read that wants the organization of a project resolves it at the call site (`resolveOrganizationId`), so the context stays explicit.
 
 ## Environment Overrides
 

--- a/platform/app/ee/governance/routers/governance.ts
+++ b/platform/app/ee/governance/routers/governance.ts
@@ -38,6 +38,7 @@ import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { getApp } from "~/server/app-layer/app";
 import { probeOrganizationPermission } from "~/server/app-layer/permissions/imperative";
 import { featureFlagService } from "~/server/featureFlag";
+import { NOT_TARGETED } from "~/server/featureFlag/targeting";
 import { UsageStatsService } from "~/server/license-enforcement/usage-stats.service";
 
 export const governanceRouter = createTRPCRouter({
@@ -137,6 +138,9 @@ export const governanceRouter = createTRPCRouter({
           .isEnabled("release_ui_ai_governance_enabled", {
             distinctId: userId,
             defaultValue: false,
+            // The landing destination is picked for an organization. No
+            // project takes part in it.
+            projectId: NOT_TARGETED,
             organizationId: input.organizationId,
           })
           .catch(() => false),

--- a/platform/app/ee/governance/services/pullers/pullerWorker.ts
+++ b/platform/app/ee/governance/services/pullers/pullerWorker.ts
@@ -27,6 +27,7 @@ import { getApp } from "~/server/app-layer/app";
 import { prisma } from "~/server/db";
 import { DEFAULT_PII_REDACTION_LEVEL } from "~/server/event-sourcing/pipelines/trace-processing/schemas/commands";
 import { featureFlagService } from "~/server/featureFlag";
+import { NOT_TARGETED } from "~/server/featureFlag/targeting";
 import {
   captureException,
   toError,
@@ -444,7 +445,12 @@ async function pulledUsageCostEnabled(
 ): Promise<boolean> {
   return await featureFlagService.isEnabled(
     "release_pulled_usage_cost_enabled",
-    { distinctId: organizationId, organizationId },
+    {
+      distinctId: organizationId,
+      // Pulled usage is priced for a whole organization.
+      projectId: NOT_TARGETED,
+      organizationId,
+    },
   );
 }
 

--- a/platform/app/src/components/AppHeaderUserMenu.tsx
+++ b/platform/app/src/components/AppHeaderUserMenu.tsx
@@ -5,6 +5,7 @@ import {
   type NavigationMode,
   useNavigationModeStore,
 } from "~/features/navigation/navigationModeStore";
+import { NOT_TARGETED } from "~/server/featureFlag/targeting";
 import { ImpersonationSwitchBackMenuItem } from "../../ee/admin/ImpersonationSwitchBackMenuItem";
 import { useFeatureFlag } from "../hooks/useFeatureFlag";
 import { useLiteMemberGuard } from "../hooks/useLiteMemberGuard";
@@ -55,11 +56,14 @@ export function AppHeaderUserMenu({
 }) {
   const { data: session } = useRequiredSession({ required: !publicPage });
   const user = session?.user;
-  const { organization, isLoading: isOrganizationLoading } =
-    useOrganizationTeamProject({
-      redirectToOnboarding: false,
-      redirectToProjectOnboarding: false,
-    });
+  const {
+    project,
+    organization,
+    isLoading: isOrganizationLoading,
+  } = useOrganizationTeamProject({
+    redirectToOnboarding: false,
+    redirectToProjectOnboarding: false,
+  });
   const { isLiteMember } = useLiteMemberGuard();
 
   // The "My Workspace" entry in the user-avatar dropdown is part of the
@@ -70,7 +74,13 @@ export function AppHeaderUserMenu({
   // show the menu entry while the page it links to 404s.
   const { enabled: governancePreviewEnabled } = useFeatureFlag(
     "release_ui_ai_governance_enabled",
-    { organizationId: organization?.id, enabled: !!organization?.id },
+    {
+      // The header renders on organization pages too, where no project
+      // exists, so the project is only stated when there is one.
+      projectId: project?.id ?? NOT_TARGETED,
+      organizationId: organization?.id,
+      enabled: !!organization?.id,
+    },
   );
 
   // The navigation-mode picker only appears once the v2 flag is on; the
@@ -81,6 +91,7 @@ export function AppHeaderUserMenu({
   const { enabled: navigationV2Enabled } = useFeatureFlag(
     "release_ui_navigation_v2_enabled",
     {
+      projectId: project?.id ?? NOT_TARGETED,
       organizationId: organization?.id,
       enabled: !isOrganizationLoading,
     },

--- a/platform/app/src/components/AppHeaderUserMenu.tsx
+++ b/platform/app/src/components/AppHeaderUserMenu.tsx
@@ -75,9 +75,11 @@ export function AppHeaderUserMenu({
   const { enabled: governancePreviewEnabled } = useFeatureFlag(
     "release_ui_ai_governance_enabled",
     {
-      // The header renders on organization pages too, where no project
-      // exists, so the project is only stated when there is one.
-      projectId: project?.id ?? NOT_TARGETED,
+      // The landing destination is decided at the organization, and
+      // governance.resolveHome reads the flag with the project opted
+      // out. The menu link matches so a project-scoped rule cannot
+      // send a person to a page that resolves as unavailable.
+      projectId: NOT_TARGETED,
       organizationId: organization?.id,
       enabled: !!organization?.id,
     },

--- a/platform/app/src/components/MainMenu.tsx
+++ b/platform/app/src/components/MainMenu.tsx
@@ -223,6 +223,49 @@ function ObserveSection({
   );
 }
 
+function SimulationsMenuGroup({
+  project,
+  pathname,
+  showExpanded,
+}: {
+  project: Project | undefined;
+  pathname: string;
+  showExpanded: boolean;
+}) {
+  return (
+    <CollapsibleMenuGroup
+      icon={featureIcons.simulations.icon}
+      label={projectRoutes.simulations.title}
+      project={project}
+      showLabel={showExpanded}
+      children={[
+        {
+          icon: featureIcons.scenarios.icon,
+          label: projectRoutes.scenarios.title,
+          ...projectScopedDestination({
+            path: projectRoutes.scenarios.path,
+            label: projectRoutes.scenarios.title,
+            project,
+          }),
+          isActive: pathname.includes("/simulations/scenarios"),
+        },
+        {
+          icon: featureIcons.simulation_runs.icon,
+          label: projectRoutes.simulation_runs.title,
+          ...projectScopedDestination({
+            path: projectRoutes.simulation_runs.path,
+            label: projectRoutes.simulation_runs.title,
+            project,
+          }),
+          isActive:
+            pathname.includes("/simulations") &&
+            !pathname.includes("/simulations/scenarios"),
+        },
+      ]}
+    />
+  );
+}
+
 function TestSection({
   showExpanded,
   project,
@@ -261,35 +304,10 @@ function TestSection({
           showLabel={showExpanded}
         />
       ) : (
-        <CollapsibleMenuGroup
-          icon={featureIcons.simulations.icon}
-          label={projectRoutes.simulations.title}
+        <SimulationsMenuGroup
           project={project}
-          showLabel={showExpanded}
-          children={[
-            {
-              icon: featureIcons.scenarios.icon,
-              label: projectRoutes.scenarios.title,
-              ...projectScopedDestination({
-                path: projectRoutes.scenarios.path,
-                label: projectRoutes.scenarios.title,
-                project,
-              }),
-              isActive: pathname.includes("/simulations/scenarios"),
-            },
-            {
-              icon: featureIcons.simulation_runs.icon,
-              label: projectRoutes.simulation_runs.title,
-              ...projectScopedDestination({
-                path: projectRoutes.simulation_runs.path,
-                label: projectRoutes.simulation_runs.title,
-                project,
-              }),
-              isActive:
-                pathname.includes("/simulations") &&
-                !pathname.includes("/simulations/scenarios"),
-            },
-          ]}
+          pathname={pathname}
+          showExpanded={showExpanded}
         />
       )}
 

--- a/platform/app/src/components/MainMenu.tsx
+++ b/platform/app/src/components/MainMenu.tsx
@@ -12,6 +12,7 @@ import {
 } from "lucide-react";
 import React, { useState } from "react";
 import type { Project } from "~/generated/prisma/client";
+import { NOT_TARGETED } from "~/server/featureFlag/targeting";
 import { useRouter } from "~/utils/compat/next-router";
 import { useFeatureFlag } from "../hooks/useFeatureFlag";
 import { useOpsPermission } from "../hooks/useOpsPermission";
@@ -134,6 +135,7 @@ function useCodingAgentLinks(): CodingAgentLinks {
   const { enabled: codingAgentPagesEnabled } = useFeatureFlag(
     "release_ui_ai_governance_enabled",
     {
+      projectId: project?.id,
       organizationId: organization?.id,
       enabled: !!organization?.id,
     },
@@ -230,9 +232,16 @@ function TestSection({
   // One destination replaces the Simulations group, and the two cannot both
   // be offered: they address the same runs through different routes, so a menu
   // holding both would give a person two links to the same work.
+  const { organization } = useOrganizationTeamProject();
   const { enabled: agentTestingEnabled } = useFeatureFlag(
     "release_ui_agent_testing_v2_enabled",
-    { projectId: project?.id, enabled: !!project?.id },
+    {
+      projectId: project?.id,
+      organizationId: organization?.id,
+      // Both ids come from the same workspace query, and a rule may name
+      // either one, so the read waits until both are known.
+      enabled: !!project?.id && !!organization?.id,
+    },
   );
 
   return (
@@ -478,6 +487,10 @@ const OpsSection = ({ showExpanded }: { showExpanded: boolean }) => {
   // chrome retires.
   const envAlwaysShow = publicEnv.data?.SHOW_OPS_IN_MAIN_SIDEBAR ?? false;
   const { enabled: opsMenuPinned } = useFeatureFlag("ops_ui_ops_menu_pinned", {
+    // A per-browser pin for an operator, decided by ops access alone. No
+    // tenant takes part in it, so neither scope is targeted.
+    projectId: NOT_TARGETED,
+    organizationId: NOT_TARGETED,
     enabled: hasAccess,
   });
   const alwaysShow = envAlwaysShow || opsMenuPinned;

--- a/platform/app/src/components/WithFeatureFlagGuard.tsx
+++ b/platform/app/src/components/WithFeatureFlagGuard.tsx
@@ -1,5 +1,5 @@
 import type React from "react";
-
+import { NOT_TARGETED } from "~/server/featureFlag/targeting";
 import { useFeatureFlag } from "../hooks/useFeatureFlag";
 import { useOrganizationTeamProject } from "../hooks/useOrganizationTeamProject";
 import type { FrontendFeatureFlag } from "../server/featureFlag/frontendFeatureFlags";
@@ -44,17 +44,25 @@ export function withFeatureFlagGuard(
     const { bypassOnboardingRedirect = false } = options ?? {};
 
     const GuardedComponent = (props: P) => {
-      const { organization, isLoading: orgLoading } =
-        useOrganizationTeamProject(
-          bypassOnboardingRedirect
-            ? {
-                redirectToOnboarding: false,
-                redirectToProjectOnboarding: false,
-              }
-            : undefined,
-        );
+      const {
+        project,
+        organization,
+        isLoading: orgLoading,
+      } = useOrganizationTeamProject(
+        bypassOnboardingRedirect
+          ? {
+              redirectToOnboarding: false,
+              redirectToProjectOnboarding: false,
+            }
+          : undefined,
+      );
       const orgId = organization?.id ?? "";
       const { enabled, isLoading: ffLoading } = useFeatureFlag(flag, {
+        // The guard covers project pages and organization pages alike. It
+        // states the project when the page has one, so a project rule and an
+        // organization rule both reach the page the same way they reach the
+        // menu item that links to it.
+        projectId: project?.id ?? NOT_TARGETED,
         organizationId: orgId,
         enabled: !!orgId,
       });

--- a/platform/app/src/components/__tests__/MainMenu.orgScopedFlag.integration.test.tsx
+++ b/platform/app/src/components/__tests__/MainMenu.orgScopedFlag.integration.test.tsx
@@ -161,21 +161,17 @@ describe("<MainMenu /> with an organization-scoped rule on the release flag", ()
   });
 
   describe("given the flag is off by default and one rule names the organization", () => {
-    /** @scenario "A rule that names the organization lights up the main menu" */
-    it("shows the Agent Testing destination", () => {
-      render(<MainMenu />, { wrapper: Wrapper });
+    describe("when the main menu is read", () => {
+      /** @scenario "A rule that names the organization lights up the main menu" */
+      it("shows Agent Testing and drops the Simulations group it replaces", () => {
+        render(<MainMenu />, { wrapper: Wrapper });
 
-      expect(linkNamed("Agent Testing")).toHaveAttribute(
-        "href",
-        "/demo/agent-testing",
-      );
-    });
-
-    /** @scenario "A rule that names the organization lights up the main menu" */
-    it("drops the Simulations group the destination replaces", () => {
-      render(<MainMenu />, { wrapper: Wrapper });
-
-      expect(linkNamed("Simulations")).toBeNull();
+        expect(linkNamed("Agent Testing")).toHaveAttribute(
+          "href",
+          "/demo/agent-testing",
+        );
+        expect(linkNamed("Simulations")).toBeNull();
+      });
     });
   });
 });

--- a/platform/app/src/components/__tests__/MainMenu.orgScopedFlag.integration.test.tsx
+++ b/platform/app/src/components/__tests__/MainMenu.orgScopedFlag.integration.test.tsx
@@ -1,0 +1,181 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The Agent Testing release flag is off by default and carries one rule that
+ * names an organization. The menu must state the organization it reads the
+ * flag for, or the rule matches nothing and the rollout reaches no one.
+ *
+ * The flag hook is NOT stubbed here: the fake tRPC query runs the real rule
+ * matcher over the input the hook sends, so a read that drops a scope fails
+ * this test the way it failed in production.
+ *
+ * @see specs/features/agent-testing/page-structure.feature
+ * @see specs/ops/internal-feature-flags.feature
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, screen } from "@testing-library/react";
+import type React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type * as NextRouterModule from "~/utils/compat/next-router";
+
+const ids = vi.hoisted(() => ({
+  organizationId: "organization-1",
+  projectId: "project-1",
+}));
+
+vi.mock("~/utils/compat/next-router", async () => {
+  const actual = await vi.importActual<typeof NextRouterModule>(
+    "~/utils/compat/next-router",
+  );
+  return {
+    ...actual,
+    useRouter: () => ({ pathname: actual.resolvePathname("/demo") }),
+  };
+});
+
+vi.mock("~/hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({
+    project: { id: ids.projectId, slug: "demo" },
+    organization: { id: ids.organizationId },
+    hasPermission: () => true,
+    isPublicRoute: false,
+  }),
+}));
+
+vi.mock("~/hooks/useOpsPermission", () => ({
+  useOpsPermission: () => ({ hasAccess: false }),
+}));
+
+vi.mock("~/hooks/usePublicEnv", () => ({
+  usePublicEnv: () => ({ data: {} }),
+}));
+
+vi.mock("~/utils/api", async () => {
+  // The real matcher, so the rule below decides the answer exactly as the
+  // postgres store decides it at runtime.
+  const { evaluateRules } = await vi.importActual<
+    typeof import("~/server/featureFlag/rules")
+  >("~/server/featureFlag/rules");
+
+  const row = {
+    enabled: false,
+    rules: [
+      { match: { organizationId: ids.organizationId }, enabled: true },
+    ] as const,
+  };
+
+  return {
+    api: {
+      featureFlag: {
+        isEnabled: {
+          useQuery: (
+            input: {
+              flag: string;
+              projectId: string | null;
+              organizationId: string | null;
+            },
+            options?: { enabled?: boolean },
+          ) => {
+            if (options?.enabled === false) {
+              return { data: undefined, isLoading: false };
+            }
+            if (input.flag !== "release_ui_agent_testing_v2_enabled") {
+              return { data: { enabled: false }, isLoading: false };
+            }
+            const hit = evaluateRules([...row.rules], {
+              projectId: input.projectId ?? undefined,
+              organizationId: input.organizationId ?? undefined,
+            });
+            return { data: { enabled: hit ?? row.enabled }, isLoading: false };
+          },
+        },
+      },
+      annotation: {
+        getPendingItemsCount: { useQuery: () => ({ data: 0 }) },
+      },
+      ops: {
+        getBadgeCounts: { useQuery: () => ({ data: undefined }) },
+        getDashboardSnapshot: { useQuery: () => ({ data: undefined }) },
+      },
+      user: {
+        isAdmin: { useQuery: () => ({ data: { isAdmin: false } }) },
+      },
+    },
+  };
+});
+
+vi.mock("~/components/sidebar/CollapsibleMenuGroup", () => ({
+  CollapsibleMenuGroup: ({
+    label,
+    children,
+  }: {
+    label: string;
+    children: { label: string; href: string }[];
+  }) => (
+    <div>
+      <a href="/demo/simulations" aria-label={label}>
+        {label}
+      </a>
+      {children.map((child) => (
+        <a key={child.label} href={child.href} aria-label={child.label}>
+          {child.label}
+        </a>
+      ))}
+    </div>
+  ),
+}));
+
+vi.mock("~/components/sidebar/SideMenuLink", () => ({
+  SideMenuLink: ({ label, href }: { label: string; href: string }) => (
+    <a href={href} aria-label={label}>
+      {label}
+    </a>
+  ),
+}));
+
+vi.mock("~/components/sidebar/UsageIndicator", () => ({
+  UsageIndicator: () => null,
+}));
+
+vi.mock("~/components/sidebar/SupportMenu", () => ({
+  SupportMenu: () => null,
+}));
+
+vi.mock("~/components/sidebar/ThemeToggle", () => ({
+  ThemeToggle: () => null,
+}));
+
+import { MainMenu } from "../MainMenu";
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <ChakraProvider value={defaultSystem}>{children}</ChakraProvider>
+);
+
+const linkNamed = (label: string) =>
+  screen.queryByRole("link", { name: label });
+
+describe("<MainMenu /> with an organization-scoped rule on the release flag", () => {
+  afterEach(() => {
+    cleanup();
+    localStorage.clear();
+  });
+
+  describe("given the flag is off by default and one rule names the organization", () => {
+    /** @scenario "A rule that names the organization lights up the main menu" */
+    it("shows the Agent Testing destination", () => {
+      render(<MainMenu />, { wrapper: Wrapper });
+
+      expect(linkNamed("Agent Testing")).toHaveAttribute(
+        "href",
+        "/demo/agent-testing",
+      );
+    });
+
+    /** @scenario "A rule that names the organization lights up the main menu" */
+    it("drops the Simulations group the destination replaces", () => {
+      render(<MainMenu />, { wrapper: Wrapper });
+
+      expect(linkNamed("Simulations")).toBeNull();
+    });
+  });
+});

--- a/platform/app/src/components/batch-evaluation-results/useShowComparisonLeaderboard.ts
+++ b/platform/app/src/components/batch-evaluation-results/useShowComparisonLeaderboard.ts
@@ -1,5 +1,6 @@
 import { useFeatureFlag } from "~/hooks/useFeatureFlag";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
+import { NOT_TARGETED } from "~/server/featureFlag/targeting";
 
 /**
  * The rollout flag the Bradley-Terry leaderboard hangs off (issue #5103).
@@ -29,11 +30,12 @@ export const COMPARISON_LEADERBOARD_FLAG =
  * state on its own.
  */
 export function useShowComparisonLeaderboard(): boolean {
-  const { organization } = useOrganizationTeamProject({
+  const { project, organization } = useOrganizationTeamProject({
     redirectToOnboarding: false,
     redirectToProjectOnboarding: false,
   });
   const { enabled } = useFeatureFlag(COMPARISON_LEADERBOARD_FLAG, {
+    projectId: project?.id ?? NOT_TARGETED,
     organizationId: organization?.id,
     // Without the organization there is nothing for an org-targeted rule to
     // match, so the query would only ever answer false.

--- a/platform/app/src/components/settings/ModelProviderForm.tsx
+++ b/platform/app/src/components/settings/ModelProviderForm.tsx
@@ -9,6 +9,7 @@ import {
 } from "@chakra-ui/react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { z } from "zod";
+import { NOT_TARGETED } from "~/server/featureFlag/targeting";
 import {
   findModelProviderById,
   isResolvableProviderId,
@@ -107,6 +108,7 @@ export const EditModelProviderForm = ({
   const { enabled: gatewayMenuEnabled } = useFeatureFlag(
     "release_ui_ai_gateway_menu_enabled",
     {
+      projectId: project?.id ?? NOT_TARGETED,
       organizationId: organization?.id,
       enabled: !!organization?.id,
     },

--- a/platform/app/src/components/settings/useDepartmentColumn.ts
+++ b/platform/app/src/components/settings/useDepartmentColumn.ts
@@ -1,4 +1,5 @@
 import { useFeatureFlag } from "~/hooks/useFeatureFlag";
+import { NOT_TARGETED } from "~/server/featureFlag/targeting";
 import { api, type RouterOutputs } from "~/utils/api";
 
 export type DepartmentOption = RouterOutputs["departments"]["list"][number];
@@ -13,6 +14,9 @@ export type DepartmentOption = RouterOutputs["departments"]["list"][number];
  */
 export function useDepartmentColumn(organizationId: string) {
   const { enabled: ffOn } = useFeatureFlag("release_ui_ai_governance_enabled", {
+    // Members and departments are organization settings. No project takes
+    // part in the read.
+    projectId: NOT_TARGETED,
     organizationId,
     enabled: !!organizationId,
   });

--- a/platform/app/src/components/sidebar/GovernSection.tsx
+++ b/platform/app/src/components/sidebar/GovernSection.tsx
@@ -3,6 +3,7 @@ import React from "react";
 
 import { useFeatureFlag } from "~/hooks/useFeatureFlag";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
+import { NOT_TARGETED } from "~/server/featureFlag/targeting";
 import { useRouter } from "~/utils/compat/next-router";
 import { featureIcons } from "~/utils/featureIcons";
 import { SidebarSection } from "./SidebarSection";
@@ -20,13 +21,14 @@ export const GovernSection = React.memo(function GovernSection({
   showExpanded: boolean;
 }) {
   const router = useRouter();
-  const { organization, hasPermission } = useOrganizationTeamProject({
+  const { project, organization, hasPermission } = useOrganizationTeamProject({
     redirectToOnboarding: false,
     redirectToProjectOnboarding: false,
   });
   const { enabled: gatewayMenuEnabled } = useFeatureFlag(
     "release_ui_ai_gateway_menu_enabled",
     {
+      projectId: project?.id ?? NOT_TARGETED,
       organizationId: organization?.id,
       enabled: !!organization?.id,
     },
@@ -34,6 +36,7 @@ export const GovernSection = React.memo(function GovernSection({
   const { enabled: governancePreviewEnabled } = useFeatureFlag(
     "release_ui_ai_governance_enabled",
     {
+      projectId: project?.id ?? NOT_TARGETED,
       organizationId: organization?.id,
       enabled: !!organization?.id,
     },

--- a/platform/app/src/experiments-v3/hooks/useOptimizeWithLangy.ts
+++ b/platform/app/src/experiments-v3/hooks/useOptimizeWithLangy.ts
@@ -3,6 +3,7 @@ import { useCallback } from "react";
 import { absorbContextTarget } from "~/features/langy/stores/langyContextTargetStore";
 import { useLangyStore } from "~/features/langy/stores/langyStore";
 import { useFeatureFlag } from "~/hooks/useFeatureFlag";
+import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 import type { TargetConfig } from "../types";
 import { useEvaluationsV3Store } from "./useEvaluationsV3Store";
 
@@ -25,7 +26,15 @@ type OptimizeHandler = ({
 }) => void;
 
 export const useOptimizeWithLangy = (): OptimizeHandler | undefined => {
-  const uiActionsEnabled = useFeatureFlag("release_langy_ui_actions");
+  const { project, organization } = useOrganizationTeamProject({
+    redirectToOnboarding: false,
+    redirectToProjectOnboarding: false,
+  });
+  const uiActionsEnabled = useFeatureFlag("release_langy_ui_actions", {
+    projectId: project?.id,
+    organizationId: organization?.id,
+    enabled: !!project?.id,
+  });
 
   const optimize = useCallback<OptimizeHandler>(({ target, name }) => {
     const slug = useEvaluationsV3Store.getState().experimentSlug;

--- a/platform/app/src/features/automations/AutomationDrawer.tsx
+++ b/platform/app/src/features/automations/AutomationDrawer.tsx
@@ -257,6 +257,7 @@ export function AutomationDrawer({
   const { enabled: webhookEnabled, isLoading: webhookFlagLoading } =
     useFeatureFlag("release_webhook_automations", {
       projectId: project?.id,
+      organizationId: organization?.id,
       enabled: !!project,
     });
 

--- a/platform/app/src/features/automations/AutomationDrawer.tsx
+++ b/platform/app/src/features/automations/AutomationDrawer.tsx
@@ -258,7 +258,10 @@ export function AutomationDrawer({
     useFeatureFlag("release_webhook_automations", {
       projectId: project?.id,
       organizationId: organization?.id,
-      enabled: !!project,
+      // Both ids come from the same workspace query, and an
+      // organization-targeted rule cannot resolve until the
+      // organization is known.
+      enabled: !!project?.id && !!organization?.id,
     });
 
   const draft = useDraft();

--- a/platform/app/src/features/command-bar/__tests__/CommandPaletteAskLangy.integration.test.tsx
+++ b/platform/app/src/features/command-bar/__tests__/CommandPaletteAskLangy.integration.test.tsx
@@ -17,6 +17,12 @@ const routerPushMock = vi.fn(async () => true);
 vi.mock("~/features/langy/hooks/useCanAskLangy", () => ({
   useCanAskLangy: () => true,
 }));
+vi.mock("~/hooks/useFeatureFlag", () => ({
+  // The palette resolves release flags over tRPC, which this render has no
+  // provider for. The flag state is not what these tests are about.
+  useFeatureFlag: () => ({ enabled: false, isLoading: false }),
+}));
+
 vi.mock("~/hooks/useDrawer", () => ({
   useDrawer: () => ({ openDrawer: openDrawerMock }),
 }));

--- a/platform/app/src/features/command-bar/__tests__/CommandPaletteInlinePanel.integration.test.tsx
+++ b/platform/app/src/features/command-bar/__tests__/CommandPaletteInlinePanel.integration.test.tsx
@@ -15,6 +15,12 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 vi.mock("~/features/langy/hooks/useCanAskLangy", () => ({
   useCanAskLangy: () => false,
 }));
+vi.mock("~/hooks/useFeatureFlag", () => ({
+  // The palette resolves release flags over tRPC, which this render has no
+  // provider for. The flag state is not what these tests are about.
+  useFeatureFlag: () => ({ enabled: false, isLoading: false }),
+}));
+
 vi.mock("~/hooks/useDrawer", () => ({
   useDrawer: () => ({ openDrawer: vi.fn() }),
 }));

--- a/platform/app/src/features/command-bar/__tests__/CommandPaletteOpenChat.integration.test.tsx
+++ b/platform/app/src/features/command-bar/__tests__/CommandPaletteOpenChat.integration.test.tsx
@@ -19,6 +19,12 @@ vi.mock("~/utils/crispBubblePolicy", () => ({
 vi.mock("~/features/langy/hooks/useCanAskLangy", () => ({
   useCanAskLangy: () => true,
 }));
+vi.mock("~/hooks/useFeatureFlag", () => ({
+  // The palette resolves release flags over tRPC, which this render has no
+  // provider for. The flag state is not what these tests are about.
+  useFeatureFlag: () => ({ enabled: false, isLoading: false }),
+}));
+
 vi.mock("~/hooks/useDrawer", () => ({
   useDrawer: () => ({ openDrawer: vi.fn() }),
 }));

--- a/platform/app/src/features/command-bar/__tests__/commandBarAgentTesting.integration.test.tsx
+++ b/platform/app/src/features/command-bar/__tests__/commandBarAgentTesting.integration.test.tsx
@@ -56,31 +56,29 @@ describe("Quick Search and the Agent Testing release flag", () => {
       state.agentTestingEnabled = true;
     });
 
-    /** @scenario "Quick Search offers Agent Testing while the flag is on" */
-    it("offers the Agent Testing page", () => {
-      expect(navigationIdsFor("agent testing")).toContain("nav-agent-testing");
-    });
+    describe("when a term reaches Quick Search", () => {
+      /** @scenario "Quick Search offers Agent Testing while the flag is on" */
+      it("offers Agent Testing and hides the Simulations entries it replaces", () => {
+        expect(navigationIdsFor("agent testing")).toContain(
+          "nav-agent-testing",
+        );
 
-    /** @scenario "Quick Search offers Agent Testing while the flag is on" */
-    it("offers neither Simulations nor Scenarios", () => {
-      const ids = navigationIdsFor("simulation");
-
-      expect(ids).not.toContain("nav-simulations");
-      expect(ids).not.toContain("nav-scenarios");
+        const simulationIds = navigationIdsFor("simulation");
+        expect(simulationIds).not.toContain("nav-simulations");
+        expect(simulationIds).not.toContain("nav-scenarios");
+      });
     });
   });
 
   describe("given the flag is off", () => {
-    /** @scenario "Quick Search keeps the Simulations entries while the flag is off" */
-    it("offers Simulations", () => {
-      expect(navigationIdsFor("simulations")).toContain("nav-simulations");
-    });
-
-    /** @scenario "Quick Search keeps the Simulations entries while the flag is off" */
-    it("offers no Agent Testing page", () => {
-      expect(navigationIdsFor("agent testing")).not.toContain(
-        "nav-agent-testing",
-      );
+    describe("when a term reaches Quick Search", () => {
+      /** @scenario "Quick Search keeps the Simulations entries while the flag is off" */
+      it("offers Simulations and hides Agent Testing", () => {
+        expect(navigationIdsFor("simulations")).toContain("nav-simulations");
+        expect(navigationIdsFor("agent testing")).not.toContain(
+          "nav-agent-testing",
+        );
+      });
     });
   });
 });

--- a/platform/app/src/features/command-bar/__tests__/commandBarAgentTesting.integration.test.tsx
+++ b/platform/app/src/features/command-bar/__tests__/commandBarAgentTesting.integration.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Quick Search offers the Agent Testing destination behind the same release
+ * flag as the main menu, and drops the Simulations entries it replaces.
+ *
+ * @see specs/features/agent-testing/page-structure.feature
+ */
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const state = vi.hoisted(() => ({ agentTestingEnabled: false }));
+
+vi.mock("~/hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({
+    project: { id: "project-1", slug: "demo" },
+    organization: { id: "organization-1" },
+  }),
+}));
+
+vi.mock("~/hooks/useFeatureFlag", () => ({
+  useFeatureFlag: (flag: string) => ({
+    enabled:
+      flag === "release_ui_agent_testing_v2_enabled"
+        ? state.agentTestingEnabled
+        : false,
+    isLoading: false,
+  }),
+}));
+
+vi.mock("~/hooks/useOpsPermission", () => ({
+  useOpsPermission: () => ({ hasAccess: false }),
+}));
+
+vi.mock("~/utils/compat/next-router", () => ({
+  useRouter: () => ({ pathname: "/[project]" }),
+}));
+
+import { useFilteredCommands } from "../hooks/useFilteredCommands";
+
+const navigationIdsFor = (query: string): string[] => {
+  const { result } = renderHook(() =>
+    useFilteredCommands(query, true, "project-1", false),
+  );
+  return result.current.navigation.map((command) => command.id);
+};
+
+describe("Quick Search and the Agent Testing release flag", () => {
+  beforeEach(() => {
+    state.agentTestingEnabled = false;
+    localStorage.clear();
+  });
+
+  describe("given the flag is on", () => {
+    beforeEach(() => {
+      state.agentTestingEnabled = true;
+    });
+
+    /** @scenario "Quick Search offers Agent Testing while the flag is on" */
+    it("offers the Agent Testing page", () => {
+      expect(navigationIdsFor("agent testing")).toContain("nav-agent-testing");
+    });
+
+    /** @scenario "Quick Search offers Agent Testing while the flag is on" */
+    it("offers neither Simulations nor Scenarios", () => {
+      const ids = navigationIdsFor("simulation");
+
+      expect(ids).not.toContain("nav-simulations");
+      expect(ids).not.toContain("nav-scenarios");
+    });
+  });
+
+  describe("given the flag is off", () => {
+    /** @scenario "Quick Search keeps the Simulations entries while the flag is off" */
+    it("offers Simulations", () => {
+      expect(navigationIdsFor("simulations")).toContain("nav-simulations");
+    });
+
+    /** @scenario "Quick Search keeps the Simulations entries while the flag is off" */
+    it("offers no Agent Testing page", () => {
+      expect(navigationIdsFor("agent testing")).not.toContain(
+        "nav-agent-testing",
+      );
+    });
+  });
+});

--- a/platform/app/src/features/command-bar/command-registry.ts
+++ b/platform/app/src/features/command-bar/command-registry.ts
@@ -41,6 +41,7 @@ import {
   Users,
   Workflow,
 } from "lucide-react";
+import type { FrontendFeatureFlag } from "~/server/featureFlag/frontendFeatureFlags";
 import type { Command } from "./types";
 
 /**
@@ -88,6 +89,19 @@ export const navigationCommands: Command[] = [
     path: "/[project]/traces",
   },
   {
+    id: "nav-agent-testing",
+    label: "Agent Testing",
+    description: "Test cases and their results",
+    icon: FlaskConical,
+    category: "navigation",
+    keywords: ["test", "cases", "agent", "simulation", "scenario", "run"],
+    path: "/[project]/agent-testing",
+    featureFlag: {
+      flag: "release_ui_agent_testing_v2_enabled",
+      enabled: true,
+    },
+  },
+  {
     id: "nav-simulations",
     label: "Simulations",
     description: "Simulation runs",
@@ -95,6 +109,12 @@ export const navigationCommands: Command[] = [
     category: "navigation",
     keywords: ["test", "run", "execute"],
     path: "/[project]/simulations",
+    // Agent Testing replaces this destination. The two lead to the same runs
+    // by different routes, so exactly one of them is offered.
+    featureFlag: {
+      flag: "release_ui_agent_testing_v2_enabled",
+      enabled: false,
+    },
   },
   {
     id: "nav-scenarios",
@@ -104,6 +124,10 @@ export const navigationCommands: Command[] = [
     category: "navigation",
     keywords: ["test", "simulation", "scenario"],
     path: "/[project]/simulations/scenarios",
+    featureFlag: {
+      flag: "release_ui_agent_testing_v2_enabled",
+      enabled: false,
+    },
   },
   {
     id: "nav-online-evaluations",
@@ -682,6 +706,7 @@ const topLevelNavIds = new Set([
   "nav-analytics",
   "nav-traces",
   "nav-traces-v2",
+  "nav-agent-testing",
   "nav-simulations",
   "nav-online-evaluations",
   "nav-experiments",
@@ -711,6 +736,33 @@ export const allStaticCommands: Command[] = [
   ...supportCommands,
   ...themeCommands,
 ];
+
+/**
+ * Values of the release flags the command list reads, as resolved for the
+ * person using it. A flag missing from the map has not answered yet.
+ */
+export type CommandFeatureFlagValues = Partial<
+  Record<FrontendFeatureFlag, boolean>
+>;
+
+/**
+ * Drops the commands whose release flag does not hold the value they need.
+ * A command with no flag is always offered, and a flag that has not answered
+ * yet keeps its command out until it does, so the bar never lists two routes
+ * to the same work while the flag is in flight.
+ */
+export function filterCommandsByFeatureFlags({
+  commands,
+  flags,
+}: {
+  commands: Command[];
+  flags: CommandFeatureFlagValues;
+}): Command[] {
+  return commands.filter((command) => {
+    if (!command.featureFlag) return true;
+    return flags[command.featureFlag.flag] === command.featureFlag.enabled;
+  });
+}
 
 /**
  * Filter commands by query string.

--- a/platform/app/src/features/command-bar/components/CommandBarResults.tsx
+++ b/platform/app/src/features/command-bar/components/CommandBarResults.tsx
@@ -1,8 +1,8 @@
 import { Box, HStack, Spinner, Text, VStack } from "@chakra-ui/react";
 import { forwardRef, useMemo } from "react";
-import { topLevelNavigationCommands } from "../command-registry";
 import { COMMAND_BAR_MAX_HEIGHT } from "../constants";
 import type { ListItem } from "../getIconInfo";
+import { useTopLevelNavigationCommands } from "../hooks/useCommandFeatureFlags";
 import type { FilteredProject } from "../hooks/useFilteredProjects";
 import type { Command, RecentItem, SearchResult } from "../types";
 import { CommandGroup } from "./CommandGroup";
@@ -72,6 +72,8 @@ export const CommandBarResults = forwardRef<
   },
   ref,
 ) {
+  const topLevelNavigation = useTopLevelNavigationCommands();
+
   // Build group configurations for empty query state
   const emptyQueryGroups = useMemo<GroupConfig[]>(
     () => [
@@ -84,13 +86,13 @@ export const CommandBarResults = forwardRef<
       },
       {
         label: "Navigation",
-        items: topLevelNavigationCommands.map((d) => ({
+        items: topLevelNavigation.map((d) => ({
           type: "command" as const,
           data: d,
         })),
       },
     ],
-    [recentItemsLimited],
+    [recentItemsLimited, topLevelNavigation],
   );
 
   // Build group configurations for query state

--- a/platform/app/src/features/command-bar/hooks/useCommandBarItems.ts
+++ b/platform/app/src/features/command-bar/hooks/useCommandBarItems.ts
@@ -1,6 +1,6 @@
 import { BookOpen, Search, Sparkles } from "lucide-react";
 import { useMemo } from "react";
-import { topLevelNavigationCommands } from "../command-registry";
+
 import {
   MIN_SEARCH_QUERY_LENGTH,
   RECENT_ITEMS_DISPLAY_LIMIT,
@@ -9,6 +9,7 @@ import { findEasterEgg } from "../easterEggs";
 import type { ListItem } from "../getIconInfo";
 import type { Command, RecentItem, SearchResult } from "../types";
 import type { GroupedRecentItems } from "../useRecentItems";
+import { useTopLevelNavigationCommands } from "./useCommandFeatureFlags";
 import type { FilteredCommands } from "./useFilteredCommands";
 import type { FilteredProject } from "./useFilteredProjects";
 
@@ -32,7 +33,7 @@ export function useCommandBarItems(
   easterEggItem: ListItem | null;
   askLangyItem: ListItem | null;
 } {
-  const availableTopLevelNav = topLevelNavigationCommands;
+  const availableTopLevelNav = useTopLevelNavigationCommands();
 
   // The "Ask Langy" activation — the command bar's door into Langy. Synthesized
   // (not a static registry command) so it can carry the live query and only

--- a/platform/app/src/features/command-bar/hooks/useCommandFeatureFlags.ts
+++ b/platform/app/src/features/command-bar/hooks/useCommandFeatureFlags.ts
@@ -1,0 +1,56 @@
+import { useMemo } from "react";
+import { useFeatureFlag } from "~/hooks/useFeatureFlag";
+import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
+import { NOT_TARGETED } from "~/server/featureFlag/targeting";
+import {
+  type CommandFeatureFlagValues,
+  filterCommandsByFeatureFlags,
+  topLevelNavigationCommands,
+} from "../command-registry";
+import type { Command } from "../types";
+
+/**
+ * Release flags the command list reads.
+ *
+ * The read states the project and the organization it is about, so a rollout
+ * written for either one reaches Quick Search exactly as it reaches the main
+ * menu. A flag that has not answered yet is absent from the map.
+ */
+export function useCommandFeatureFlags(): CommandFeatureFlagValues {
+  const { project, organization } = useOrganizationTeamProject({
+    redirectToOnboarding: false,
+    redirectToProjectOnboarding: false,
+  });
+  const agentTesting = useFeatureFlag("release_ui_agent_testing_v2_enabled", {
+    projectId: project?.id,
+    // Quick Search also opens on organization pages, which hold no project.
+    organizationId: organization?.id ?? NOT_TARGETED,
+    enabled: !!project?.id,
+  });
+
+  return useMemo(
+    () => ({
+      release_ui_agent_testing_v2_enabled: agentTesting.isLoading
+        ? undefined
+        : agentTesting.enabled,
+    }),
+    [agentTesting.isLoading, agentTesting.enabled],
+  );
+}
+
+/**
+ * The navigation commands offered on an empty bar, with the flagged ones
+ * resolved for this person.
+ */
+export function useTopLevelNavigationCommands(): Command[] {
+  const flags = useCommandFeatureFlags();
+
+  return useMemo(
+    () =>
+      filterCommandsByFeatureFlags({
+        commands: topLevelNavigationCommands,
+        flags,
+      }),
+    [flags],
+  );
+}

--- a/platform/app/src/features/command-bar/hooks/useFilteredCommands.ts
+++ b/platform/app/src/features/command-bar/hooks/useFilteredCommands.ts
@@ -11,6 +11,7 @@ import { useRouter } from "~/utils/compat/next-router";
 import {
   actionCommands,
   filterCommands,
+  filterCommandsByFeatureFlags,
   navigationCommands,
   supportCommands,
   themeCommands,
@@ -21,6 +22,7 @@ import {
 } from "../constants";
 import { getPageCommands } from "../pageCommands";
 import type { Command } from "../types";
+import { useCommandFeatureFlags } from "./useCommandFeatureFlags";
 
 export interface FilteredCommands {
   navigation: Command[];
@@ -41,13 +43,17 @@ export function useFilteredCommands(
   isDevMode: boolean,
 ): FilteredCommands {
   const { hasAccess: hasOpsAccess } = useOpsPermission();
+  const commandFeatureFlags = useCommandFeatureFlags();
 
   const availableNavCommands = useMemo(() => {
     const commands = hasOpsAccess
       ? navigationCommands
       : navigationCommands.filter((cmd) => !cmd.id.startsWith("nav-ops"));
-    return commands;
-  }, [hasOpsAccess]);
+    return filterCommandsByFeatureFlags({
+      commands,
+      flags: commandFeatureFlags,
+    });
+  }, [hasOpsAccess, commandFeatureFlags]);
 
   const filteredNavigation = useMemo(() => {
     if (!query.trim()) return [];

--- a/platform/app/src/features/command-bar/types.ts
+++ b/platform/app/src/features/command-bar/types.ts
@@ -1,6 +1,7 @@
 import type { LucideIcon } from "lucide-react";
 import { z } from "zod";
 import type { DrawerType } from "~/components/drawerRegistry";
+import type { FrontendFeatureFlag } from "~/server/featureFlag/frontendFeatureFlags";
 
 export type CommandCategory = "navigation" | "actions" | "search" | "projects";
 
@@ -18,6 +19,13 @@ export interface Command {
   externalUrl?: string;
   /** Action function for action commands */
   action?: () => void;
+  /**
+   * Release flag that decides whether the command is offered, and the value
+   * the command needs. A destination that replaces another one is offered on
+   * `enabled: true`, and the one it replaces on `enabled: false`, so Quick
+   * Search never lists two routes to the same work.
+   */
+  featureFlag?: { flag: FrontendFeatureFlag; enabled: boolean };
 }
 
 export const RecentItemTypeSchema = z.enum([

--- a/platform/app/src/features/langy/components/LangyPanel.tsx
+++ b/platform/app/src/features/langy/components/LangyPanel.tsx
@@ -181,6 +181,7 @@ import { StreamingStatusLine } from "./StreamingStatusLine";
 // Langy's own skin: scoped warm/cream palette + serif display face. The
 // `.langy-root` class (below) is where the Chakra semantic-token overrides land.
 import "../langyTheme.css";
+import { NOT_TARGETED } from "~/server/featureFlag/targeting";
 
 // The same feature key Langy's chat route resolves against. Used to seed the
 // composer's model picker with whatever's actually resolving today — opening
@@ -382,7 +383,14 @@ export function LangySidecar({
   // classic corner launcher orb. ONE renders at a time — never both — and
   // only the closed state differs: opening, the panel and Cmd/Ctrl+I are
   // identical on either side of the flag.
-  const peekDock = useFeatureFlag("release_ui_langy_peek_dock_enabled");
+  const { project, organization } = useOrganizationTeamProject({
+    redirectToOnboarding: false,
+    redirectToProjectOnboarding: false,
+  });
+  const peekDock = useFeatureFlag("release_ui_langy_peek_dock_enabled", {
+    projectId: project?.id ?? NOT_TARGETED,
+    organizationId: organization?.id ?? NOT_TARGETED,
+  });
 
   return (
     <>

--- a/platform/app/src/features/navigation/__tests__/sectionNavParity.integration.test.tsx
+++ b/platform/app/src/features/navigation/__tests__/sectionNavParity.integration.test.tsx
@@ -57,6 +57,7 @@ vi.mock("~/components/ui/layouts/SectionNavigationLayout", () => ({
 
 import AiGatewayLayout from "~/components/gateway/AiGatewayLayout";
 import GovernanceLayout from "~/components/governance/GovernanceLayout";
+import { NOT_TARGETED } from "~/server/featureFlag/targeting";
 
 describe("given the gateway section navigation data", () => {
   describe("when the gateway layout renders", () => {
@@ -98,7 +99,11 @@ describe("given the gateway section navigation data", () => {
       // is disabled rather than round-tripping for a result never read.
       expect(
         harness.flagCallOptions.release_ui_governance_billed_cost_enabled,
-      ).toEqual({ organizationId: "org-1", enabled: false });
+      ).toEqual({
+        projectId: NOT_TARGETED,
+        organizationId: "org-1",
+        enabled: false,
+      });
     });
   });
 });
@@ -143,10 +148,15 @@ describe("given the governance section navigation data", () => {
       ]);
 
       // The flag must resolve in organization context, gated on the org
-      // being loaded — flags resolved without it silently read as off.
+      // being loaded — flags resolved without it silently read as off. The
+      // layout holds no project, and says so.
       expect(
         harness.flagCallOptions.release_ui_governance_billed_cost_enabled,
-      ).toEqual({ organizationId: "org-1", enabled: true });
+      ).toEqual({
+        projectId: NOT_TARGETED,
+        organizationId: "org-1",
+        enabled: true,
+      });
     });
   });
 });

--- a/platform/app/src/features/navigation/useNavigationMode.ts
+++ b/platform/app/src/features/navigation/useNavigationMode.ts
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import { useFeatureFlag } from "~/hooks/useFeatureFlag";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
+import { NOT_TARGETED } from "~/server/featureFlag/targeting";
 import {
   type NavigationModeResolution,
   resolveNavigationMode,
@@ -42,15 +43,20 @@ export function useNavigationMode(): NavigationModeResolution {
 
   // The same organization queries the dashboard layout itself runs; react-query
   // dedupes them, so the opted-out path stays at zero extra requests.
-  const { organization, isLoading: isOrganizationLoading } =
-    useOrganizationTeamProject({
-      redirectToOnboarding: false,
-      redirectToProjectOnboarding: false,
-    });
+  const {
+    project,
+    organization,
+    isLoading: isOrganizationLoading,
+  } = useOrganizationTeamProject({
+    redirectToOnboarding: false,
+    redirectToProjectOnboarding: false,
+  });
 
   const { enabled: isFlagEnabled, isLoading: isFlagLoading } = useFeatureFlag(
     "release_ui_navigation_v2_enabled",
     {
+      // The shell also renders on organization pages, which hold no project.
+      projectId: project?.id ?? NOT_TARGETED,
       organizationId: organization?.id,
       // A reader who opted out of the new navigation pays for no flag
       // check, and the check waits until the organization is known (an

--- a/platform/app/src/features/navigation/useReachableProducts.ts
+++ b/platform/app/src/features/navigation/useReachableProducts.ts
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import { useFeatureFlag } from "~/hooks/useFeatureFlag";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 import type { FrontendFeatureFlag } from "~/server/featureFlag/frontendFeatureFlags";
+import { NOT_TARGETED } from "~/server/featureFlag/targeting";
 import { PRODUCTS, type ProductId } from "./products";
 
 /**
@@ -23,6 +24,7 @@ export function useReachableProducts({
   isLoading: boolean;
 } {
   const {
+    project,
     organization,
     hasPermission,
     isLoading: isOrganizationLoading,
@@ -33,10 +35,12 @@ export function useReachableProducts({
 
   const isQueryEnabled = enabled && !!organization?.id;
   const gatewayFlag = useFeatureFlag("release_ui_ai_gateway_menu_enabled", {
+    projectId: project?.id ?? NOT_TARGETED,
     organizationId: organization?.id,
     enabled: isQueryEnabled,
   });
   const governanceFlag = useFeatureFlag("release_ui_ai_governance_enabled", {
+    projectId: project?.id ?? NOT_TARGETED,
     organizationId: organization?.id,
     enabled: isQueryEnabled,
   });

--- a/platform/app/src/features/navigation/useVisibleSectionNavItems.ts
+++ b/platform/app/src/features/navigation/useVisibleSectionNavItems.ts
@@ -1,6 +1,6 @@
 import { useFeatureFlag } from "~/hooks/useFeatureFlag";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
-
+import { NOT_TARGETED } from "~/server/featureFlag/targeting";
 import type { SectionNavItemData } from "./sectionNavItems";
 
 /**
@@ -28,7 +28,7 @@ export function useVisibleSectionNavItems(
   // matching fails closed without ctx.organizationId), so the check must
   // carry the same org context the page guards pass — otherwise a per-org
   // enable shows the pages but never their nav items.
-  const { organization } = useOrganizationTeamProject({
+  const { project, organization } = useOrganizationTeamProject({
     redirectToOnboarding: false,
     redirectToProjectOnboarding: false,
   });
@@ -41,6 +41,7 @@ export function useVisibleSectionNavItems(
   const billedCost = useFeatureFlag(
     "release_ui_governance_billed_cost_enabled",
     {
+      projectId: project?.id ?? NOT_TARGETED,
       organizationId: organization?.id,
       enabled: !!organization?.id && needsBilledCost,
     },

--- a/platform/app/src/features/onboarding/hooks/use-onboarding-flow.ts
+++ b/platform/app/src/features/onboarding/hooks/use-onboarding-flow.ts
@@ -2,6 +2,7 @@ import { useMemo, useState } from "react";
 import type { OrganizationIntent } from "~/generated/prisma/client";
 import { useFeatureFlag } from "~/hooks/useFeatureFlag";
 import { usePublicEnv } from "~/hooks/usePublicEnv";
+import { NOT_TARGETED } from "~/server/featureFlag/targeting";
 import { readAttribution } from "~/utils/attribution";
 import { getOnboardingFlowConfig } from "../constants/onboarding-flow";
 import {
@@ -43,7 +44,12 @@ export const useOnboardingFlow = () => {
   // pre-fork flow. User-level evaluation — there is no org yet during
   // onboarding.
   const { enabled: intentForkEnabled, isLoading: intentForkLoading } =
-    useFeatureFlag("release_ui_ai_governance_enabled");
+    useFeatureFlag("release_ui_ai_governance_enabled", {
+      // Onboarding runs before the person has either an organization or a
+      // project, so neither scope can target this read.
+      projectId: NOT_TARGETED,
+      organizationId: NOT_TARGETED,
+    });
 
   // Flow configuration — recomputed when the intent changes (ADR-038 fork).
   // Safe mid-flow: intent only changes while ON the INTENT screen, whose

--- a/platform/app/src/hooks/__tests__/useFeatureFlag.unit.test.ts
+++ b/platform/app/src/hooks/__tests__/useFeatureFlag.unit.test.ts
@@ -4,6 +4,7 @@
 
 import { renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NOT_TARGETED } from "../../server/featureFlag/targeting";
 import { CLIENT_FLAG_STALE_TIME_MS, useFeatureFlag } from "../useFeatureFlag";
 
 vi.mock("../../utils/api", () => ({
@@ -35,7 +36,10 @@ describe("useFeatureFlag()", () => {
 
     it("returns isLoading true", () => {
       const { result } = renderHook(() =>
-        useFeatureFlag("release_ui_ai_gateway_menu_enabled"),
+        useFeatureFlag("release_ui_ai_gateway_menu_enabled", {
+          projectId: NOT_TARGETED,
+          organizationId: NOT_TARGETED,
+        }),
       );
 
       expect(result.current.isLoading).toBe(true);
@@ -43,7 +47,10 @@ describe("useFeatureFlag()", () => {
 
     it("returns enabled false", () => {
       const { result } = renderHook(() =>
-        useFeatureFlag("release_ui_ai_gateway_menu_enabled"),
+        useFeatureFlag("release_ui_ai_gateway_menu_enabled", {
+          projectId: NOT_TARGETED,
+          organizationId: NOT_TARGETED,
+        }),
       );
 
       expect(result.current.enabled).toBe(false);
@@ -60,7 +67,10 @@ describe("useFeatureFlag()", () => {
 
     it("returns enabled false", () => {
       const { result } = renderHook(() =>
-        useFeatureFlag("release_ui_ai_gateway_menu_enabled"),
+        useFeatureFlag("release_ui_ai_gateway_menu_enabled", {
+          projectId: NOT_TARGETED,
+          organizationId: NOT_TARGETED,
+        }),
       );
 
       expect(result.current.enabled).toBe(false);
@@ -68,7 +78,10 @@ describe("useFeatureFlag()", () => {
 
     it("returns isLoading false", () => {
       const { result } = renderHook(() =>
-        useFeatureFlag("release_ui_ai_gateway_menu_enabled"),
+        useFeatureFlag("release_ui_ai_gateway_menu_enabled", {
+          projectId: NOT_TARGETED,
+          organizationId: NOT_TARGETED,
+        }),
       );
 
       expect(result.current.isLoading).toBe(false);
@@ -85,7 +98,10 @@ describe("useFeatureFlag()", () => {
 
     it("returns enabled true", () => {
       const { result } = renderHook(() =>
-        useFeatureFlag("release_ui_ai_gateway_menu_enabled"),
+        useFeatureFlag("release_ui_ai_gateway_menu_enabled", {
+          projectId: NOT_TARGETED,
+          organizationId: NOT_TARGETED,
+        }),
       );
 
       expect(result.current.enabled).toBe(true);
@@ -93,7 +109,10 @@ describe("useFeatureFlag()", () => {
 
     it("returns isLoading false", () => {
       const { result } = renderHook(() =>
-        useFeatureFlag("release_ui_ai_gateway_menu_enabled"),
+        useFeatureFlag("release_ui_ai_gateway_menu_enabled", {
+          projectId: NOT_TARGETED,
+          organizationId: NOT_TARGETED,
+        }),
       );
 
       expect(result.current.isLoading).toBe(false);
@@ -132,7 +151,7 @@ describe("useFeatureFlag()", () => {
     });
   });
 
-  describe("when options are not provided", () => {
+  describe("when neither scope targets the read", () => {
     beforeEach(() => {
       mockUseQuery.mockReturnValue({
         data: { enabled: false },
@@ -140,14 +159,19 @@ describe("useFeatureFlag()", () => {
       } as any);
     });
 
-    it("passes undefined for optional params", () => {
-      renderHook(() => useFeatureFlag("release_ui_ai_gateway_menu_enabled"));
+    it("sends null for both scopes", () => {
+      renderHook(() =>
+        useFeatureFlag("release_ui_ai_gateway_menu_enabled", {
+          projectId: NOT_TARGETED,
+          organizationId: NOT_TARGETED,
+        }),
+      );
 
       expect(mockUseQuery).toHaveBeenCalledWith(
         {
           flag: "release_ui_ai_gateway_menu_enabled",
-          projectId: undefined,
-          organizationId: undefined,
+          projectId: null,
+          organizationId: null,
         },
         {
           staleTime: CLIENT_FLAG_STALE_TIME_MS,
@@ -171,6 +195,7 @@ describe("useFeatureFlag()", () => {
       renderHook(() =>
         useFeatureFlag("release_ui_ai_gateway_menu_enabled", {
           projectId: undefined,
+          organizationId: undefined,
           enabled: false,
         }),
       );
@@ -186,6 +211,8 @@ describe("useFeatureFlag()", () => {
     it("returns enabled false", () => {
       const { result } = renderHook(() =>
         useFeatureFlag("release_ui_ai_gateway_menu_enabled", {
+          projectId: undefined,
+          organizationId: undefined,
           enabled: false,
         }),
       );
@@ -196,6 +223,8 @@ describe("useFeatureFlag()", () => {
     it("returns isLoading false", () => {
       const { result } = renderHook(() =>
         useFeatureFlag("release_ui_ai_gateway_menu_enabled", {
+          projectId: undefined,
+          organizationId: undefined,
           enabled: false,
         }),
       );

--- a/platform/app/src/hooks/useFeatureFlag.ts
+++ b/platform/app/src/hooks/useFeatureFlag.ts
@@ -1,4 +1,8 @@
 import type { FrontendFeatureFlag } from "../server/featureFlag/frontendFeatureFlags";
+import {
+  type FeatureFlagTargetId,
+  NOT_TARGETED,
+} from "../server/featureFlag/targeting";
 import { api } from "../utils/api";
 import { useFeatureFlagOverrides } from "./useFeatureFlagOverrides";
 
@@ -10,14 +14,41 @@ import { useFeatureFlagOverrides } from "./useFeatureFlagOverrides";
 // re-fetch storm we observed on /traces.
 export const CLIENT_FLAG_STALE_TIME_MS = 5 * 60_000;
 
+/**
+ * Targeting identity and query control for one flag read.
+ *
+ * `projectId` and `organizationId` are both required. A targeting rule that
+ * names a scope the read left out can never match, so an omitted field turns
+ * a per-organization or per-project rollout into a silent no-op. Requiring
+ * both makes a forgotten field a compile error.
+ *
+ * Each id takes one of three values:
+ * - a real id, so rules that name it can match.
+ * - `NOT_TARGETED`, when the surface has no such id at all. Rules that name
+ *   this scope never match, which is the point of saying it out loud.
+ * - `undefined`, when the id is still loading. Write it out and pair it with
+ *   `enabled: false`, so the read waits for the id instead of resolving
+ *   against an empty context.
+ */
 interface UseFeatureFlagOptions {
-  projectId?: string;
-  organizationId?: string;
+  /** The project this read is about, or `NOT_TARGETED`. */
+  projectId: FeatureFlagTargetId;
+  /** The organization this read is about, or `NOT_TARGETED`. */
+  organizationId: FeatureFlagTargetId;
   /**
    * Set to false to disable the query (e.g., while waiting for projectId).
    * Defaults to true.
    */
   enabled?: boolean;
+}
+
+/**
+ * JSON carries no `undefined`, so both "no such scope" and "not known yet"
+ * travel as `null`. The wire field itself stays required, so the request
+ * always states what it targets.
+ */
+function toWireTargetId(id: FeatureFlagTargetId): string | null {
+  return id === undefined || id === NOT_TARGETED ? null : id;
 }
 
 interface UseFeatureFlagResult {
@@ -30,24 +61,25 @@ interface UseFeatureFlagResult {
 /**
  * React hook to check if a feature flag is enabled for the current user.
  *
- * Makes a tRPC call to check the flag server-side with PostHog, with optional
- * project/organization context for targeted feature rollouts.
+ * Makes a tRPC call that resolves the flag server-side, with the project and
+ * the organization the read is about so targeting rules can match.
  *
  * ## Usage
  *
  * ```tsx
- * // Basic usage - user-level flag
- * const { enabled } = useFeatureFlag("release_ui_ai_gateway_menu_enabled");
- *
- * // Project-level targeting
- * const { enabled } = useFeatureFlag("release_ui_ai_gateway_menu_enabled", {
- *   projectId: project.id,
- * });
- *
- * // Conditional fetching (e.g., wait for project to load)
+ * // The usual case: both ids are known, both are stated.
+ * const { project, organization } = useOrganizationTeamProject();
  * const { enabled } = useFeatureFlag("release_ui_ai_gateway_menu_enabled", {
  *   projectId: project?.id,
- *   enabled: !!project,
+ *   organizationId: organization?.id,
+ *   enabled: !!project?.id && !!organization?.id,
+ * });
+ *
+ * // A surface with no project of its own opts that scope out by name.
+ * const { enabled } = useFeatureFlag("release_ui_ai_gateway_menu_enabled", {
+ *   projectId: NOT_TARGETED,
+ *   organizationId: organization?.id,
+ *   enabled: !!organization?.id,
  * });
  * ```
  *
@@ -67,9 +99,9 @@ interface UseFeatureFlagResult {
  */
 export function useFeatureFlag(
   flag: FrontendFeatureFlag,
-  options?: UseFeatureFlagOptions,
+  options: UseFeatureFlagOptions,
 ): UseFeatureFlagResult {
-  const queryEnabled = options?.enabled ?? true;
+  const queryEnabled = options.enabled ?? true;
 
   const overrides = useFeatureFlagOverrides();
   const override = overrides[flag];
@@ -77,8 +109,8 @@ export function useFeatureFlag(
   const { data, isLoading } = api.featureFlag.isEnabled.useQuery(
     {
       flag,
-      projectId: options?.projectId,
-      organizationId: options?.organizationId,
+      projectId: toWireTargetId(options.projectId),
+      organizationId: toWireTargetId(options.organizationId),
     },
     {
       staleTime: CLIENT_FLAG_STALE_TIME_MS,

--- a/platform/app/src/pages/settings.tsx
+++ b/platform/app/src/pages/settings.tsx
@@ -18,6 +18,7 @@ import { Controller, type SubmitHandler, useForm } from "react-hook-form";
 import { HorizontalFormControl } from "~/components/HorizontalFormControl";
 import { Tooltip } from "~/components/ui/tooltip";
 import type { OrganizationIntent, Project } from "~/generated/prisma/client";
+import { NOT_TARGETED } from "~/server/featureFlag/targeting";
 import { ProjectSelector } from "../components/DashboardLayout";
 import SettingsLayout from "../components/SettingsLayout";
 import { DepartmentPicker } from "../components/settings/DepartmentPicker";
@@ -108,7 +109,11 @@ function SettingsForm({
   // surface it routes to is reachable (flag on, which is the default).
   const { enabled: governanceEnabled } = useFeatureFlag(
     "release_ui_ai_governance_enabled",
-    { organizationId: organization.id },
+    {
+      // Organization settings. The page holds no project of its own.
+      projectId: NOT_TARGETED,
+      organizationId: organization.id,
+    },
   );
   const [defaultValues, setDefaultValues] = useState<OrganizationFormData>({
     name: organization.name,

--- a/platform/app/src/server/analytics/lwql/__tests__/access.unit.test.ts
+++ b/platform/app/src/server/analytics/lwql/__tests__/access.unit.test.ts
@@ -23,6 +23,7 @@ vi.mock("~/server/featureFlag", () => ({
   featureFlagService: { isEnabled: mockIsEnabled },
 }));
 
+import { NOT_TARGETED } from "~/server/featureFlag/targeting";
 import { LWQL_FLAG, lwqlEnabled } from "../access";
 
 /** A Prisma stand-in that resolves the given team, or none at all. */
@@ -58,7 +59,7 @@ describe("the LangWatchQL feature gate's identity", () => {
 
   describe("given a project that cannot be read", () => {
     /** @scenario "The switch is decided for the project's organization, not for the project alone" */
-    it("omits the organization key rather than passing it as undefined", async () => {
+    it("states the organization as not targeted rather than guessing one", async () => {
       await lwqlEnabled({
         prisma: prismaResolving(null),
         projectId: "project-1",
@@ -68,9 +69,9 @@ describe("the LangWatchQL feature gate's identity", () => {
         string,
         Record<string, unknown>,
       ];
-      // `in` is the distinction that matters: a rule matching on the
-      // organization must not be handed a key this function guessed at.
-      expect("organizationId" in identity).toBe(false);
+      // A rule matching on the organization must not be handed a value this
+      // function guessed at, and the opt-out matches no such rule.
+      expect(identity.organizationId).toBe(NOT_TARGETED);
       expect(identity.distinctId).toBe("project-1");
     });
   });

--- a/platform/app/src/server/analytics/lwql/access.ts
+++ b/platform/app/src/server/analytics/lwql/access.ts
@@ -1,5 +1,6 @@
 import type { PrismaClient } from "~/generated/prisma/client";
 import { featureFlagService } from "~/server/featureFlag";
+import { NOT_TARGETED } from "~/server/featureFlag/targeting";
 
 /**
  * The experimental gate over the whole LangWatchQL surface.
@@ -46,9 +47,8 @@ export async function lwqlEnabled({
   return featureFlagService.isEnabled(LWQL_FLAG, {
     distinctId: projectId,
     projectId,
-    // Omitted rather than passed as undefined when the project cannot be read:
-    // a rule matching on the organization should not be handed a value this
-    // function guessed at.
-    ...(organizationId ? { organizationId } : {}),
+    // A project that cannot be read has no organization to state, and a rule
+    // that names an organization must not be handed a guess.
+    organizationId: organizationId ?? NOT_TARGETED,
   });
 }

--- a/platform/app/src/server/api/routers/automations.ts
+++ b/platform/app/src/server/api/routers/automations.ts
@@ -65,7 +65,9 @@ import { MonitorService } from "~/server/app-layer/monitors/monitor.service";
 import { translateFilterToClickHouse } from "~/server/app-layer/traces/filter-to-clickhouse";
 import { isDispatchError } from "~/server/event-sourcing/queues/dispatchError";
 import { featureFlagService } from "~/server/featureFlag";
+import { NOT_TARGETED } from "~/server/featureFlag/targeting";
 import { hasActionableTriggerFilters } from "~/server/filters/triggerFilter.matcher";
+import { resolveOrganizationId } from "~/server/organizations/resolveOrganizationId";
 import { KSUID_RESOURCES } from "~/utils/constants";
 import {
   sanitizeTriggerFilters,
@@ -839,7 +841,15 @@ export const automationRouter = createTRPCRouter({
         if (input.channel === "webhook") {
           const allowed = await featureFlagService.isEnabled(
             "release_webhook_automations",
-            { distinctId: ctx.session.user.id, projectId: input.projectId },
+            {
+              distinctId: ctx.session.user.id,
+              projectId: input.projectId,
+              // The drawer reads the same flag with both ids, so the route
+              // resolves the organization too. Without it an organization
+              // rollout would open the picker and the route would refuse it.
+              organizationId:
+                (await resolveOrganizationId(input.projectId)) ?? NOT_TARGETED,
+            },
           );
           if (!allowed) {
             throw new TRPCError({
@@ -1025,7 +1035,15 @@ export const automationRouter = createTRPCRouter({
         if (input.action === TriggerAction.SEND_WEBHOOK) {
           const allowed = await featureFlagService.isEnabled(
             "release_webhook_automations",
-            { distinctId: ctx.session.user.id, projectId: input.projectId },
+            {
+              distinctId: ctx.session.user.id,
+              projectId: input.projectId,
+              // The drawer reads the same flag with both ids, so the route
+              // resolves the organization too. Without it an organization
+              // rollout would open the picker and the route would refuse it.
+              organizationId:
+                (await resolveOrganizationId(input.projectId)) ?? NOT_TARGETED,
+            },
           );
           if (!allowed) {
             throw new TRPCError({

--- a/platform/app/src/server/api/routers/featureFlag.ts
+++ b/platform/app/src/server/api/routers/featureFlag.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { featureFlagService } from "../../featureFlag";
 import { FRONTEND_FEATURE_FLAGS } from "../../featureFlag/frontendFeatureFlags";
 import type { FeatureFlagKey } from "../../featureFlag/registry";
+import { NOT_TARGETED } from "../../featureFlag/targeting";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
 
 const logger = createLogger("langwatch:feature-flag-router");
@@ -15,8 +16,9 @@ const frontendFeatureFlagSchema = z.enum([...FRONTEND_FEATURE_FLAGS] as [
 /**
  * tRPC router for feature flag checks.
  *
- * Resolves through the in-code registry and the operator flag store, with
- * optional project/organization targeting.
+ * Resolves through the in-code registry and the operator flag store. Every
+ * read states the project and the organization it is about, so targeting
+ * rules can match.
  * Results are cached server-side (5s TTL) and client-side (React Query).
  *
  * @see dev/docs/adr/005-feature-flags.md for architecture decisions
@@ -25,17 +27,23 @@ export const featureFlagRouter = createTRPCRouter({
   /**
    * Check if a feature flag is enabled for the current user.
    *
+   * Both targeting fields are required on the wire, and `null` states that
+   * the calling surface has no such scope. An optional field would let a
+   * caller drop the organization by accident, and an organization rule would
+   * then match nothing. JSON has no `undefined`, so `null` also carries the
+   * "not known yet" case; the client disables the query in that case.
+   *
    * @param flag - The feature flag key (must be in FRONTEND_FEATURE_FLAGS)
-   * @param projectId - Optional project ID for project-level targeting
-   * @param organizationId - Optional organization ID for org-level targeting
+   * @param projectId - Project ID for project-level targeting, or null
+   * @param organizationId - Organization ID for org-level targeting, or null
    * @returns { enabled: boolean }
    */
   isEnabled: protectedProcedure
     .input(
       z.object({
         flag: frontendFeatureFlagSchema,
-        projectId: z.string().optional(),
-        organizationId: z.string().optional(),
+        projectId: z.string().nullable(),
+        organizationId: z.string().nullable(),
       }),
     )
     .noPermission({
@@ -73,8 +81,8 @@ export const featureFlagRouter = createTRPCRouter({
         {
           distinctId: userId,
           defaultValue: false,
-          projectId: input.projectId,
-          organizationId: input.organizationId,
+          projectId: input.projectId ?? NOT_TARGETED,
+          organizationId: input.organizationId ?? NOT_TARGETED,
         },
       );
 
@@ -152,6 +160,9 @@ export const featureFlagRouter = createTRPCRouter({
           featureFlagService.isEnabled(input.flag as FeatureFlagKey, {
             distinctId: userId,
             defaultValue: false,
+            // The procedure asks one organization at a time by design, and
+            // the surfaces that call it have no project of their own.
+            projectId: NOT_TARGETED,
             organizationId,
           }),
         ),
@@ -213,6 +224,9 @@ export const featureFlagRouter = createTRPCRouter({
             await featureFlagService.isEnabled(input.flag as FeatureFlagKey, {
               distinctId: userId,
               defaultValue: false,
+              // Same as above: an organization-at-a-time read from a
+              // workspace surface that has no project.
+              projectId: NOT_TARGETED,
               organizationId,
             }),
           ],

--- a/platform/app/src/server/app-layer/analytics/analytics.service.ts
+++ b/platform/app/src/server/app-layer/analytics/analytics.service.ts
@@ -34,6 +34,7 @@ import type {
 import { currentVsPreviousDates } from "~/server/api/routers/analytics/common";
 import type { ClickHouseClientResolver } from "~/server/clickhouse/clickhouseClient";
 import { featureFlagService } from "~/server/featureFlag";
+import { NOT_TARGETED } from "~/server/featureFlag/targeting";
 import type { FilterField } from "~/server/filters/types";
 import { TtlCache } from "~/server/utils/ttlCache";
 import { adjustTimeScaleForBucketCap } from "./query-builders/_shared";
@@ -333,7 +334,9 @@ export class AnalyticsService {
 async function isTripwireEnabled(projectId: string): Promise<boolean> {
   return featureFlagService.isEnabled(
     "release_event_sourced_analytics_read_tripwire",
-    { distinctId: projectId, projectId },
+    // A read tripwire on the analytics hot path. It takes no organization
+    // lookup, so only the project targets it.
+    { distinctId: projectId, projectId, organizationId: NOT_TARGETED },
   );
 }
 

--- a/platform/app/src/server/app-layer/identity/runtime.ts
+++ b/platform/app/src/server/app-layer/identity/runtime.ts
@@ -113,6 +113,8 @@ export {
   resolveSignInMethodPolicy,
 } from "./signin-method-policy";
 
+import { NOT_TARGETED } from "~/server/featureFlag/targeting";
+
 const identityHeads = new PrismaIdentityHeadsRepository(prisma);
 const identityUsers = new PrismaIdentityUsersRepository(prisma);
 const identityAccounts = new PrismaIdentityAccountsRepository(prisma);
@@ -418,7 +420,12 @@ export function joinRequestsService(): JoinRequestsService {
     // self-hosted deployments that have no other way out.
     autoJoinLicensed: () => platformSSOAllowed(),
     enabled: ({ userId }) =>
-      featureFlagService.isEnabled("join_requests", { distinctId: userId }),
+      featureFlagService.isEnabled("join_requests", {
+        distinctId: userId,
+        // A person asks to join before they belong to anything.
+        projectId: NOT_TARGETED,
+        organizationId: NOT_TARGETED,
+      }),
   });
 }
 

--- a/platform/app/src/server/app-layer/langy/__tests__/langyAccessGate.unit.test.ts
+++ b/platform/app/src/server/app-layer/langy/__tests__/langyAccessGate.unit.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { NOT_TARGETED } from "~/server/featureFlag/targeting";
 import { hasLangyAccess } from "../langyAccessGate";
 
 describe("hasLangyAccess", () => {
@@ -17,6 +18,7 @@ describe("hasLangyAccess", () => {
       expect(isEnabled).toHaveBeenCalledWith("release_langy_enabled", {
         distinctId: "customer-1",
         projectId: "project-1",
+        organizationId: NOT_TARGETED,
       });
     });
   });
@@ -35,6 +37,7 @@ describe("hasLangyAccess", () => {
 
       expect(isEnabled).toHaveBeenCalledWith("release_langy_enabled", {
         distinctId: "customer-2",
+        projectId: NOT_TARGETED,
         organizationId: "org-1",
       });
     });
@@ -64,7 +67,7 @@ describe("hasLangyAccess", () => {
       const isEnabled = vi.fn().mockResolvedValue(false);
 
       // The GitHub install route has neither a projectId nor an organizationId
-      // in hand, so the gate evaluates at user scope only.
+      // in hand, so the gate states both scopes as not targeted.
       await expect(
         hasLangyAccess({
           user: { id: "customer-3" },
@@ -74,6 +77,8 @@ describe("hasLangyAccess", () => {
 
       expect(isEnabled).toHaveBeenCalledWith("release_langy_enabled", {
         distinctId: "customer-3",
+        projectId: NOT_TARGETED,
+        organizationId: NOT_TARGETED,
       });
     });
   });

--- a/platform/app/src/server/app-layer/langy/langyAccessGate.ts
+++ b/platform/app/src/server/app-layer/langy/langyAccessGate.ts
@@ -1,4 +1,5 @@
 import { featureFlagService } from "~/server/featureFlag";
+import { NOT_TARGETED } from "~/server/featureFlag/targeting";
 import { LANGY_RELEASE_FLAG } from "~/utils/langyReleaseFlag";
 
 type LangyAccessUser = {
@@ -39,7 +40,7 @@ export async function hasLangyAccess({
 }): Promise<boolean> {
   return flags.isEnabled(LANGY_RELEASE_FLAG, {
     distinctId: user.id,
-    ...(projectId ? { projectId } : {}),
-    ...(organizationId ? { organizationId } : {}),
+    projectId: projectId ?? NOT_TARGETED,
+    organizationId: organizationId ?? NOT_TARGETED,
   });
 }

--- a/platform/app/src/server/app-layer/traces/edge-media-extraction.ts
+++ b/platform/app/src/server/app-layer/traces/edge-media-extraction.ts
@@ -43,6 +43,7 @@ import type {
   OtlpSpan,
 } from "~/server/event-sourcing/pipelines/trace-processing/schemas/otlp";
 import { featureFlagService } from "~/server/featureFlag";
+import { NOT_TARGETED } from "~/server/featureFlag/targeting";
 import { getEdgeMediaExtractFailOpenCounter } from "~/server/metrics";
 import type { ExtractedRef } from "~/server/stored-objects/content-extractor";
 import type { StoredObjectsService } from "~/server/stored-objects/stored-objects.service";
@@ -82,6 +83,9 @@ async function defaultIsEnabled(projectId: string): Promise<boolean> {
   return await featureFlagService.isEnabled("release_trace_media_extraction", {
     distinctId: projectId,
     projectId,
+    // A per-project opt-in on the ingestion path. It takes no organization
+    // lookup, so only the project targets it.
+    organizationId: NOT_TARGETED,
   });
 }
 

--- a/platform/app/src/server/app-layer/traces/span-pii-redaction.service.ts
+++ b/platform/app/src/server/app-layer/traces/span-pii-redaction.service.ts
@@ -34,6 +34,7 @@ const STRICT_ONLY_PII_ENTITIES: readonly string[] =
 
 import { createLogger } from "@langwatch/observability";
 import { featureFlagService } from "~/server/featureFlag";
+import { NOT_TARGETED } from "~/server/featureFlag/targeting";
 import type { PIIRedactionLevel } from "../../event-sourcing/pipelines/trace-processing/schemas/commands";
 import type {
   OtlpAnyValue,
@@ -793,7 +794,13 @@ export class OtlpSpanPiiRedactionService {
   ): Promise<PIICheckOptions | null> {
     const disabled = await featureFlagService.isEnabled(
       "ops_pii_strict_presidio_redaction_disabled",
-      { distinctId: "span-pii-service", defaultValue: false },
+      {
+        distinctId: "span-pii-service",
+        defaultValue: false,
+        // A global kill switch for the whole service, not for one tenant.
+        projectId: NOT_TARGETED,
+        organizationId: NOT_TARGETED,
+      },
     );
     if (disabled) return null;
     if (piiRedactionLevel === "DISABLED") return null;

--- a/platform/app/src/server/app-layer/traces/span-token-estimation.service.ts
+++ b/platform/app/src/server/app-layer/traces/span-token-estimation.service.ts
@@ -1,3 +1,4 @@
+import { NOT_TARGETED } from "~/server/featureFlag/targeting";
 import type { OtlpSpan } from "../../event-sourcing/pipelines/trace-processing/schemas/otlp";
 import { KILL_SWITCH_CACHE_TTL_MS } from "../../featureFlag/constants";
 import type { FeatureFlagServiceInterface } from "../../featureFlag/types";
@@ -154,6 +155,9 @@ export class OtlpSpanTokenEstimationService {
       {
         distinctId: "global",
         defaultValue: false,
+        // A global switch: no tenant takes part in it.
+        projectId: NOT_TARGETED,
+        organizationId: NOT_TARGETED,
         cacheTtlMs: KILL_SWITCH_CACHE_TTL_MS,
       },
     );
@@ -167,6 +171,9 @@ export class OtlpSpanTokenEstimationService {
           distinctId: tenantId,
           defaultValue: false,
           projectId: tenantId,
+          // A per-span hot path. It buys no organization lookup, so an
+          // operator stops one project by project id.
+          organizationId: NOT_TARGETED,
           cacheTtlMs: KILL_SWITCH_CACHE_TTL_MS,
         },
       );

--- a/platform/app/src/server/better-auth/bornFinalizedOptIn.ts
+++ b/platform/app/src/server/better-auth/bornFinalizedOptIn.ts
@@ -3,6 +3,7 @@ import { normalizedRequestPathname } from "@ee/sso/ssoPathGate";
 import { createLogger } from "@langwatch/observability";
 import { prisma } from "~/server/db";
 import { featureFlagService } from "~/server/featureFlag";
+import { NOT_TARGETED } from "~/server/featureFlag/targeting";
 
 const logger = createLogger("langwatch:identity:born-finalized-opt-in");
 
@@ -82,7 +83,10 @@ export async function isBornFinalizedSignUp({
     return await featureFlagService.isEnabled(BORN_FINALIZED_SIGNUP_FLAG, {
       distinctId: email,
       defaultValue: false,
-      ...(organizationId === null ? {} : { organizationId }),
+      // Sign-up time: the person has no project yet, and an organization
+      // only when their email domain matches one.
+      projectId: NOT_TARGETED,
+      organizationId: organizationId ?? NOT_TARGETED,
     });
   } catch (error) {
     // Never fail the sign-up over the flag itself: an unreadable flag means

--- a/platform/app/src/server/event-sourcing/pipelineRegistry.ts
+++ b/platform/app/src/server/event-sourcing/pipelineRegistry.ts
@@ -1223,6 +1223,9 @@ export class PipelineRegistry {
           {
             distinctId: "evaluator-settings-recovery",
             defaultValue: false,
+            // A pipeline-wide switch, flipped for the fleet and not per tenant.
+            projectId: NOT_TARGETED,
+            organizationId: NOT_TARGETED,
           },
         ),
       // ADR-040: offload oversized evaluator inputs to durable object storage
@@ -1243,7 +1246,13 @@ export class PipelineRegistry {
           try {
             disabled = await featureFlagService.isEnabled(
               "ops_evaluation_payload_offload_disabled",
-              { distinctId: "evaluation-inputs-offload", defaultValue: false },
+              {
+                distinctId: "evaluation-inputs-offload",
+                defaultValue: false,
+                // A pipeline-wide switch, flipped for the fleet.
+                projectId: NOT_TARGETED,
+                organizationId: NOT_TARGETED,
+              },
             );
           } catch {
             // Unreadable kill switch: stay on the default (offload enabled).
@@ -1807,6 +1816,7 @@ export type AppCommands = ReturnType<PipelineRegistry["registerAll"]>;
 // Introspection — derived from the live EventSourcing runtime
 // ============================================================================
 
+import { NOT_TARGETED } from "~/server/featureFlag/targeting";
 import { getApp } from "../app-layer/app";
 // StaticPipelineDefinition is already imported at the top of the file.
 

--- a/platform/app/src/server/event-sourcing/pipelines/trace-processing/subscribers/evaluationTrigger.subscriber.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/trace-processing/subscribers/evaluationTrigger.subscriber.ts
@@ -1,6 +1,7 @@
 import { generate } from "@langwatch/ksuid";
 import { createLogger } from "@langwatch/observability";
 import type { MonitorService } from "~/server/app-layer/monitors/monitor.service";
+import { NOT_TARGETED } from "~/server/featureFlag/targeting";
 import { SYNTHETIC_SPAN_NAMES } from "~/server/tracer/constants";
 import { KSUID_RESOURCES } from "../../../../../utils/constants";
 import { featureFlagService } from "../../../../featureFlag";
@@ -167,7 +168,13 @@ async function causalityLoopGuardFired({
 }): Promise<boolean> {
   const guardDisabled = await featureFlagService.isEnabled(
     CAUSALITY_LOOP_GUARD_DISABLED_FLAG,
-    { distinctId: tenantId, defaultValue: false },
+    {
+      distinctId: tenantId,
+      defaultValue: false,
+      // The event-sourcing tenant id is the project id on this platform.
+      projectId: tenantId,
+      organizationId: NOT_TARGETED,
+    },
   );
 
   if (guardDisabled) {

--- a/platform/app/src/server/event-sourcing/utils/killSwitch.ts
+++ b/platform/app/src/server/event-sourcing/utils/killSwitch.ts
@@ -1,4 +1,5 @@
 import type { createLogger } from "@langwatch/observability";
+import { NOT_TARGETED } from "~/server/featureFlag/targeting";
 import { KILL_SWITCH_CACHE_TTL_MS } from "../../featureFlag/constants";
 import type {
   EsKillSwitchKey,
@@ -70,6 +71,9 @@ export async function isComponentDisabled({
     const isDisabled = await featureFlagService.isEnabled(flagKey, {
       distinctId: tenantId,
       projectId: tenantId,
+      // A per-event hot path. It buys no organization lookup, so an operator
+      // stops one tenant by project id.
+      organizationId: NOT_TARGETED,
       defaultValue: false,
       cacheTtlMs: KILL_SWITCH_CACHE_TTL_MS,
     });

--- a/platform/app/src/server/featureFlag/__tests__/featureFlag.service.lazy-legacy.unit.test.ts
+++ b/platform/app/src/server/featureFlag/__tests__/featureFlag.service.lazy-legacy.unit.test.ts
@@ -11,6 +11,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { FeatureFlagService } from "../featureFlag.service";
 import type { FeatureFlagStorePostgres } from "../featureFlagStore.postgres";
+import { NOT_TARGETED } from "../targeting";
 
 const { memoryCreateSpy } = vi.hoisted(() => ({
   memoryCreateSpy: vi.fn(),
@@ -74,6 +75,8 @@ describe("FeatureFlagService legacy backend construction", () => {
 
         await service.isEnabled(SYSTEM_FLAG, {
           distinctId: "tenant-a",
+          projectId: NOT_TARGETED,
+          organizationId: NOT_TARGETED,
           defaultValue: false,
         });
 
@@ -97,10 +100,14 @@ describe("FeatureFlagService legacy backend construction", () => {
 
         const first = await service.isEnabled(PRODUCT_FLAG, {
           distinctId: "user-1",
+          projectId: NOT_TARGETED,
+          organizationId: NOT_TARGETED,
           defaultValue: false,
         });
         const second = await service.isEnabled(PRODUCT_FLAG, {
           distinctId: "user-2",
+          projectId: NOT_TARGETED,
+          organizationId: NOT_TARGETED,
           defaultValue: false,
         });
 
@@ -118,6 +125,8 @@ describe("FeatureFlagService legacy backend construction", () => {
 
         await service.isEnabled(UNREGISTERED_FLAG as never, {
           distinctId: "user-1",
+          projectId: NOT_TARGETED,
+          organizationId: NOT_TARGETED,
           defaultValue: false,
         });
 
@@ -129,10 +138,14 @@ describe("FeatureFlagService legacy backend construction", () => {
 
         await service.isEnabled(UNREGISTERED_FLAG as never, {
           distinctId: "user-1",
+          projectId: NOT_TARGETED,
+          organizationId: NOT_TARGETED,
           defaultValue: false,
         });
         await service.isEnabled(UNREGISTERED_FLAG as never, {
           distinctId: "user-2",
+          projectId: NOT_TARGETED,
+          organizationId: NOT_TARGETED,
           defaultValue: false,
         });
 

--- a/platform/app/src/server/featureFlag/__tests__/featureFlag.service.resolver.unit.test.ts
+++ b/platform/app/src/server/featureFlag/__tests__/featureFlag.service.resolver.unit.test.ts
@@ -25,6 +25,7 @@ import {
   type FeatureFlagRules,
   type RuleEvaluationContext,
 } from "../rules";
+import { NOT_TARGETED } from "../targeting";
 import type { FeatureFlagServiceInterface } from "../types";
 
 const SYSTEM_FLAG = "ops_es_causality_loop_guard_disabled";
@@ -107,6 +108,8 @@ describe("FeatureFlagService", () => {
         process.env[NON_ENV_OVERRIDABLE_FLAG.toUpperCase()] = "1";
         const enabled = await service.isEnabled(NON_ENV_OVERRIDABLE_FLAG, {
           distinctId: "user-1",
+          projectId: NOT_TARGETED,
+          organizationId: NOT_TARGETED,
           defaultValue: false,
         });
         expect(enabled).toBe(false);
@@ -121,6 +124,8 @@ describe("FeatureFlagService", () => {
         const { service, legacy } = buildService();
         const enabled = await service.isEnabled(SYSTEM_FLAG, {
           distinctId: "tenant-a",
+          projectId: NOT_TARGETED,
+          organizationId: NOT_TARGETED,
           defaultValue: true,
         });
         expect(enabled).toBe(false);
@@ -134,6 +139,8 @@ describe("FeatureFlagService", () => {
         await store.set(SYSTEM_FLAG, true);
         const enabled = await service.isEnabled(SYSTEM_FLAG, {
           distinctId: "tenant-a",
+          projectId: NOT_TARGETED,
+          organizationId: NOT_TARGETED,
           defaultValue: false,
         });
         expect(enabled).toBe(true);
@@ -148,6 +155,8 @@ describe("FeatureFlagService", () => {
         process.env.OPS_ES_CAUSALITY_LOOP_GUARD_DISABLED = "1";
         const enabled = await service.isEnabled(SYSTEM_FLAG, {
           distinctId: "tenant-a",
+          projectId: NOT_TARGETED,
+          organizationId: NOT_TARGETED,
           defaultValue: false,
         });
         expect(enabled).toBe(true);
@@ -161,6 +170,8 @@ describe("FeatureFlagService", () => {
         process.env.LANGWATCH_DISABLE_CAUSALITY_LOOP_GUARD = "1";
         const enabled = await service.isEnabled(SYSTEM_FLAG, {
           distinctId: "tenant-a",
+          projectId: NOT_TARGETED,
+          organizationId: NOT_TARGETED,
           defaultValue: false,
         });
         expect(enabled).toBe(true);
@@ -175,6 +186,8 @@ describe("FeatureFlagService", () => {
         const { service, legacy } = buildService();
         const enabled = await service.isEnabled(FAMILY_FLAG, {
           distinctId: "tenant-a",
+          projectId: NOT_TARGETED,
+          organizationId: NOT_TARGETED,
           defaultValue: false,
         });
         expect(enabled).toBe(false);
@@ -188,6 +201,8 @@ describe("FeatureFlagService", () => {
         await store.set(FAMILY_FLAG, true);
         const enabled = await service.isEnabled(FAMILY_FLAG, {
           distinctId: "tenant-a",
+          projectId: NOT_TARGETED,
+          organizationId: NOT_TARGETED,
           defaultValue: false,
         });
         expect(enabled).toBe(true);
@@ -202,6 +217,8 @@ describe("FeatureFlagService", () => {
         const { service, legacy } = buildService();
         const enabled = await service.isEnabled(PRODUCT_FLAG, {
           distinctId: "user-1",
+          projectId: NOT_TARGETED,
+          organizationId: NOT_TARGETED,
           defaultValue: false,
         });
         expect(enabled).toBe(true);
@@ -215,6 +232,8 @@ describe("FeatureFlagService", () => {
         await store.set(PRODUCT_FLAG, true);
         const enabled = await service.isEnabled(PRODUCT_FLAG, {
           distinctId: "user-1",
+          projectId: NOT_TARGETED,
+          organizationId: NOT_TARGETED,
           defaultValue: false,
         });
         expect(enabled).toBe(true);
@@ -231,6 +250,8 @@ describe("FeatureFlagService", () => {
         );
         const enabled = await service.isEnabled(PRODUCT_FLAG, {
           distinctId: "user-1",
+          projectId: NOT_TARGETED,
+          organizationId: NOT_TARGETED,
           defaultValue: true,
         });
         expect(enabled).toBe(false);
@@ -246,6 +267,7 @@ describe("FeatureFlagService", () => {
         ]);
         const enabled = await service.isEnabled(PRODUCT_FLAG, {
           distinctId: "user-1",
+          projectId: NOT_TARGETED,
           organizationId: "org_lw",
           defaultValue: false,
         });
@@ -265,6 +287,7 @@ describe("FeatureFlagService", () => {
         ]);
         const enabled = await service.isEnabled(PRODUCT_FLAG, {
           distinctId: "user-1",
+          projectId: NOT_TARGETED,
           organizationId: "org_other",
           defaultValue: false,
         });
@@ -282,6 +305,7 @@ describe("FeatureFlagService", () => {
         ]);
         const enabled = await service.isEnabled(PRODUCT_FLAG, {
           distinctId: "user-1",
+          projectId: NOT_TARGETED,
           organizationId: "org_self",
           defaultValue: true,
         });
@@ -302,6 +326,8 @@ describe("FeatureFlagService", () => {
       // because the FeatureFlagKey signature wouldn't accept the key.
       const enabled = await service.isEnabled(UNREGISTERED_FLAG as never, {
         distinctId: "user-1",
+        projectId: NOT_TARGETED,
+        organizationId: NOT_TARGETED,
         defaultValue: false,
       });
       expect(enabled).toBe(true);

--- a/platform/app/src/server/featureFlag/__tests__/featureFlag.service.test.ts
+++ b/platform/app/src/server/featureFlag/__tests__/featureFlag.service.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { FeatureFlagService } from "../featureFlag.service";
 import type { FeatureFlagStorePostgres } from "../featureFlagStore.postgres";
+import { NOT_TARGETED } from "../targeting";
 import type { FeatureFlagServiceInterface } from "../types";
 
 vi.mock("../featureFlagService.memory", () => ({
@@ -53,12 +54,16 @@ describe("FeatureFlagService", () => {
 
         const result = await service.isEnabled("some-flag" as never, {
           distinctId: "user-1",
+          projectId: NOT_TARGETED,
+          organizationId: NOT_TARGETED,
           defaultValue: false,
         });
 
         expect(result).toBe(true);
         expect(legacy.isEnabled).toHaveBeenCalledWith("some-flag", {
           distinctId: "user-1",
+          projectId: NOT_TARGETED,
+          organizationId: NOT_TARGETED,
           defaultValue: false,
         });
       });
@@ -72,12 +77,14 @@ describe("FeatureFlagService", () => {
 
         await service.isEnabled("some-flag" as never, {
           distinctId: "user-1",
+          organizationId: NOT_TARGETED,
           defaultValue: true,
           projectId: "proj-123",
         });
 
         expect(legacy.isEnabled).toHaveBeenCalledWith("some-flag", {
           distinctId: "user-1",
+          organizationId: NOT_TARGETED,
           defaultValue: true,
           projectId: "proj-123",
         });
@@ -92,12 +99,14 @@ describe("FeatureFlagService", () => {
 
         await service.isEnabled("some-flag" as never, {
           distinctId: "user-1",
+          projectId: NOT_TARGETED,
           defaultValue: false,
           organizationId: "org-456",
         });
 
         expect(legacy.isEnabled).toHaveBeenCalledWith("some-flag", {
           distinctId: "user-1",
+          projectId: NOT_TARGETED,
           defaultValue: false,
           organizationId: "org-456",
         });
@@ -122,7 +131,12 @@ describe("FeatureFlagService", () => {
 
           const result = await service.isEnabled(
             "release_ui_simulations_menu_enabled" as never,
-            { distinctId: "user-123", defaultValue: false },
+            {
+              distinctId: "user-123",
+              defaultValue: false,
+              projectId: NOT_TARGETED,
+              organizationId: NOT_TARGETED,
+            },
           );
 
           expect(result).toBe(true);
@@ -136,7 +150,12 @@ describe("FeatureFlagService", () => {
 
           const result = await service.isEnabled(
             "release_ui_simulations_menu_enabled" as never,
-            { distinctId: "user-123", defaultValue: true },
+            {
+              distinctId: "user-123",
+              defaultValue: true,
+              projectId: NOT_TARGETED,
+              organizationId: NOT_TARGETED,
+            },
           );
 
           expect(result).toBe(false);
@@ -165,6 +184,8 @@ describe("FeatureFlagService", () => {
 
         const result = await service.isEnabled("some_flag" as never, {
           distinctId: "user-1",
+          projectId: NOT_TARGETED,
+          organizationId: NOT_TARGETED,
           defaultValue: false,
         });
 
@@ -182,6 +203,8 @@ describe("FeatureFlagService", () => {
 
         const result = await service.isEnabled("different_flag" as never, {
           distinctId: "u",
+          projectId: NOT_TARGETED,
+          organizationId: NOT_TARGETED,
           defaultValue: false,
         });
 
@@ -199,6 +222,8 @@ describe("FeatureFlagService", () => {
 
         const result = await service.isEnabled("spaced_flag" as never, {
           distinctId: "u",
+          projectId: NOT_TARGETED,
+          organizationId: NOT_TARGETED,
           defaultValue: false,
         });
 
@@ -216,7 +241,12 @@ describe("FeatureFlagService", () => {
 
         const result = await service.isEnabled(
           "release_ui_ai_gateway_menu_enabled",
-          { distinctId: "u", defaultValue: false },
+          {
+            distinctId: "u",
+            defaultValue: false,
+            projectId: NOT_TARGETED,
+            organizationId: NOT_TARGETED,
+          },
         );
 
         expect(result).toBe(true);
@@ -231,7 +261,12 @@ describe("FeatureFlagService", () => {
 
         const result = await service.isEnabled(
           "release_ui_simulations_menu_enabled" as never,
-          { distinctId: "u", defaultValue: true },
+          {
+            distinctId: "u",
+            defaultValue: true,
+            projectId: NOT_TARGETED,
+            organizationId: NOT_TARGETED,
+          },
         );
 
         expect(result).toBe(false);

--- a/platform/app/src/server/featureFlag/__tests__/targeting.unit.test.ts
+++ b/platform/app/src/server/featureFlag/__tests__/targeting.unit.test.ts
@@ -1,0 +1,136 @@
+/**
+ * @vitest-environment node
+ *
+ * The targeting identity of a feature flag read: both scopes are stated,
+ * and a caller with no such scope says so.
+ *
+ * @see specs/ops/internal-feature-flags.feature
+ */
+import { describe, expect, it, vi } from "vitest";
+import { FeatureFlagService } from "../featureFlag.service";
+import type { FeatureFlagStorePostgres } from "../featureFlagStore.postgres";
+import {
+  evaluateRules,
+  type FeatureFlagRules,
+  type RuleEvaluationContext,
+} from "../rules";
+import { NOT_TARGETED, toRuleContextId } from "../targeting";
+import type {
+  FeatureFlagEvaluateOptions,
+  FeatureFlagServiceInterface,
+} from "../types";
+
+const PRODUCT_FLAG = "release_ui_agent_testing_v2_enabled";
+
+function buildService(row: { enabled: boolean; rules: FeatureFlagRules }) {
+  const legacy: FeatureFlagServiceInterface = {
+    isEnabled: vi.fn().mockResolvedValue(false),
+  };
+  const store = {
+    async get(
+      _key: string,
+      ctx: RuleEvaluationContext = {},
+    ): Promise<boolean | null> {
+      return evaluateRules(row.rules, ctx) ?? row.enabled;
+    },
+  };
+  return new FeatureFlagService({
+    legacy,
+    store: store as unknown as FeatureFlagStorePostgres,
+  });
+}
+
+describe("feature flag targeting", () => {
+  describe("given a read that leaves a scope out", () => {
+    /** @scenario "a read that omits an id does not compile" */
+    it("is rejected by the type of the options", () => {
+      // @ts-expect-error organizationId is required on every flag read.
+      const withoutOrganization: FeatureFlagEvaluateOptions = {
+        distinctId: "user-1",
+        projectId: "project-1",
+      };
+      // @ts-expect-error projectId is required on every flag read.
+      const withoutProject: FeatureFlagEvaluateOptions = {
+        distinctId: "user-1",
+        organizationId: "organization-1",
+      };
+
+      expect(withoutOrganization.distinctId).toBe("user-1");
+      expect(withoutProject.distinctId).toBe("user-1");
+    });
+  });
+
+  describe("given a surface that has no project of its own", () => {
+    /** @scenario "a caller with no project of its own opts that scope out by name" */
+    it("states the exported opt-out value for the project", () => {
+      const options: FeatureFlagEvaluateOptions = {
+        distinctId: "user-1",
+        projectId: NOT_TARGETED,
+        organizationId: "organization-1",
+      };
+
+      expect(options.projectId).toBe(NOT_TARGETED);
+      expect(toRuleContextId(options.projectId)).toBeUndefined();
+    });
+
+    /** @scenario "an opted-out scope matches no rule that names that scope" */
+    it("matches no rule that names a project", () => {
+      const rules: FeatureFlagRules = [
+        { match: { projectId: "project-1" }, enabled: true },
+      ];
+
+      const hit = evaluateRules(rules, {
+        projectId: toRuleContextId(NOT_TARGETED),
+        organizationId: toRuleContextId("organization-1"),
+      });
+
+      expect(hit).toBeNull();
+    });
+  });
+
+  describe("given an id that is not known yet", () => {
+    /** @scenario "an id that is not known yet is written out, not left out" */
+    it("is written out and reaches the matcher as no context", () => {
+      const options: FeatureFlagEvaluateOptions = {
+        distinctId: "user-1",
+        projectId: "project-1",
+        organizationId: undefined,
+      };
+
+      expect(toRuleContextId(options.organizationId)).toBeUndefined();
+    });
+  });
+
+  describe("given a flag that is off by default with one organization rule", () => {
+    /** @scenario "a read that carries the organization matches an organization rule" */
+    it("resolves enabled for a read that carries that organization", async () => {
+      const service = buildService({
+        enabled: false,
+        rules: [{ match: { organizationId: "organization-1" }, enabled: true }],
+      });
+
+      const enabled = await service.isEnabled(PRODUCT_FLAG, {
+        distinctId: "user-1",
+        projectId: "project-1",
+        organizationId: "organization-1",
+      });
+
+      expect(enabled).toBe(true);
+    });
+
+    it("resolves disabled for a read that opts the organization out", async () => {
+      const service = buildService({
+        enabled: false,
+        rules: [{ match: { organizationId: "organization-1" }, enabled: true }],
+      });
+
+      const enabled = await service.isEnabled(PRODUCT_FLAG, {
+        distinctId: "user-1",
+        projectId: "project-1",
+        organizationId: NOT_TARGETED,
+      });
+
+      expect(enabled).toBe(false);
+    });
+  });
+});

--- a/platform/app/src/server/featureFlag/__tests__/targeting.unit.test.ts
+++ b/platform/app/src/server/featureFlag/__tests__/targeting.unit.test.ts
@@ -22,7 +22,13 @@ import type {
 
 const PRODUCT_FLAG = "release_ui_agent_testing_v2_enabled";
 
-function buildService(row: { enabled: boolean; rules: FeatureFlagRules }) {
+function buildService({
+  enabled,
+  rules,
+}: {
+  enabled: boolean;
+  rules: FeatureFlagRules;
+}) {
   const legacy: FeatureFlagServiceInterface = {
     isEnabled: vi.fn().mockResolvedValue(false),
   };
@@ -31,7 +37,7 @@ function buildService(row: { enabled: boolean; rules: FeatureFlagRules }) {
       _key: string,
       ctx: RuleEvaluationContext = {},
     ): Promise<boolean | null> {
-      return evaluateRules(row.rules, ctx) ?? row.enabled;
+      return evaluateRules(rules, ctx) ?? enabled;
     },
   };
   return new FeatureFlagService({

--- a/platform/app/src/server/featureFlag/featureFlag.service.ts
+++ b/platform/app/src/server/featureFlag/featureFlag.service.ts
@@ -6,6 +6,7 @@ import {
 } from "./featureFlagStore.postgres";
 import type { FeatureFlagKey } from "./registry";
 import { resolveFlagDefinition } from "./registry";
+import { toRuleContextId } from "./targeting";
 import type {
   FeatureFlagEvaluateOptions,
   FeatureFlagServiceInterface,
@@ -99,8 +100,8 @@ export class FeatureFlagService implements FeatureFlagServiceInterface {
     }
 
     const storeCtx = {
-      projectId: opts.projectId,
-      organizationId: opts.organizationId,
+      projectId: toRuleContextId(opts.projectId),
+      organizationId: toRuleContextId(opts.organizationId),
     };
 
     if (definition?.scope === "SYSTEM" || definition?.scope === "PRODUCT") {

--- a/platform/app/src/server/featureFlag/index.ts
+++ b/platform/app/src/server/featureFlag/index.ts
@@ -36,6 +36,8 @@ export {
   parseRules,
   resolveEffectiveForListing,
 } from "./rules";
+export type { FeatureFlagTargetId, NotTargeted } from "./targeting";
+export { NOT_TARGETED, toRuleContextId } from "./targeting";
 export type {
   FeatureFlagEvaluateOptions,
   FeatureFlagServiceInterface,

--- a/platform/app/src/server/featureFlag/targeting.ts
+++ b/platform/app/src/server/featureFlag/targeting.ts
@@ -1,0 +1,45 @@
+/**
+ * Targeting identity of a single feature flag read.
+ *
+ * A targeting rule on a flag names a project or an organization. The rule
+ * can only match when the read carries that id, so a read that leaves an id
+ * out silently loses every rule written for it. To stop that, every read
+ * states both ids, and a caller that has no such id says so with
+ * `NOT_TARGETED`.
+ *
+ * @see specs/ops/internal-feature-flags.feature
+ */
+
+/**
+ * Explicit opt-out for a targeting scope that does not exist on the calling
+ * surface, for example a page outside any project, or a screen shown before
+ * login.
+ *
+ * A rule that names a project or an organization never matches a read that
+ * opts that scope out, so the opt-out is a decision the caller makes on
+ * purpose and not a value that can be forgotten.
+ */
+export const NOT_TARGETED = "__not_targeted__" as const;
+
+export type NotTargeted = typeof NOT_TARGETED;
+
+/**
+ * The project or organization a flag read is about.
+ *
+ * - a real id: rules that name this project or organization can match.
+ * - `NOT_TARGETED`: the surface has no such id at all. No rule that names
+ *   this scope can match.
+ * - `undefined`: the id is not known yet. Write it out and pair it with
+ *   `enabled: false` so the read waits for the id instead of resolving
+ *   against an empty context.
+ */
+export type FeatureFlagTargetId = string | NotTargeted | undefined;
+
+/**
+ * Converts a target id into the value the rule matcher compares against.
+ * An opted-out or still-unknown scope becomes `undefined`, which no rule
+ * naming that scope can match.
+ */
+export function toRuleContextId(id: FeatureFlagTargetId): string | undefined {
+  return id === NOT_TARGETED ? undefined : id;
+}

--- a/platform/app/src/server/featureFlag/types.ts
+++ b/platform/app/src/server/featureFlag/types.ts
@@ -1,11 +1,15 @@
 import type { FeatureFlagKey } from "./registry";
+import type { FeatureFlagTargetId } from "./targeting";
 
 /**
  * Options for evaluating a single feature flag.
  *
- * `distinctId` is the only required field — every flag resolution
- * needs an identity to evaluate against (audit log, cache key
- * salting). The rest are optional knobs.
+ * `distinctId` identifies the caller (audit log, cache key salting).
+ * `projectId` and `organizationId` are the targeting identity of the
+ * read and are both required: a targeting rule that names a scope the
+ * read left out can never match, so leaving one out turns a rollout
+ * into a silent no-op. A caller with no such scope passes
+ * `NOT_TARGETED`.
  */
 export interface FeatureFlagEvaluateOptions {
   distinctId: string;
@@ -14,8 +18,10 @@ export interface FeatureFlagEvaluateOptions {
    * flags always use their `defaultValue` from `registry.ts`).
    */
   defaultValue?: boolean;
-  projectId?: string;
-  organizationId?: string;
+  /** The project this read is about, or `NOT_TARGETED`. */
+  projectId: FeatureFlagTargetId;
+  /** The organization this read is about, or `NOT_TARGETED`. */
+  organizationId: FeatureFlagTargetId;
   /**
    * Override the cache TTL (ms) for this evaluation. Used by hot-path
    * callers (kill switches checked per span/event) to control how

--- a/platform/app/src/server/gateway/budgetOverview.service.ts
+++ b/platform/app/src/server/gateway/budgetOverview.service.ts
@@ -35,7 +35,7 @@ import type {
   PrismaClient,
 } from "~/generated/prisma/client";
 import { featureFlagService } from "~/server/featureFlag/featureFlag.service";
-
+import { NOT_TARGETED } from "~/server/featureFlag/targeting";
 import {
   type ApplicableBudget,
   resolveApplicableBudgetsForTarget,
@@ -155,6 +155,9 @@ export class BudgetOverviewService {
     const governanceEnabled = await featureFlagService
       .isEnabled("release_ui_ai_governance_enabled", {
         distinctId: input.userId,
+        // The member budget surfaces are organization pages. No project
+        // takes part in the read.
+        projectId: NOT_TARGETED,
         organizationId: input.organizationId,
         defaultValue: true,
       })

--- a/platform/app/src/server/observability/anomalyDetector.ts
+++ b/platform/app/src/server/observability/anomalyDetector.ts
@@ -1,4 +1,5 @@
 import { createLogger } from "@langwatch/observability";
+import { NOT_TARGETED } from "~/server/featureFlag/targeting";
 import { KILL_SWITCH_CACHE_TTL_MS } from "../featureFlag/constants";
 import type { FeatureFlagServiceInterface } from "../featureFlag/types";
 import type { Anomaly, AnomalyStateStore } from "./anomalyState";
@@ -110,6 +111,9 @@ export class AnomalyDetector {
         {
           distinctId: tenantId,
           defaultValue: false,
+          // The observability tenant id is the project id on this platform.
+          projectId: tenantId,
+          organizationId: NOT_TARGETED,
           cacheTtlMs: KILL_SWITCH_CACHE_TTL_MS,
         },
       );

--- a/platform/app/src/server/observability/tenantRateTracker.ts
+++ b/platform/app/src/server/observability/tenantRateTracker.ts
@@ -1,6 +1,7 @@
 import { createLogger } from "@langwatch/observability";
 import type IORedis from "ioredis";
 import type { Cluster } from "ioredis";
+import { NOT_TARGETED } from "~/server/featureFlag/targeting";
 import { KILL_SWITCH_CACHE_TTL_MS } from "../featureFlag/constants";
 import type { FeatureFlagServiceInterface } from "../featureFlag/types";
 
@@ -100,6 +101,9 @@ export class TenantRateTracker {
         {
           distinctId: tenantId,
           defaultValue: false,
+          // The observability tenant id is the project id on this platform.
+          projectId: tenantId,
+          organizationId: NOT_TARGETED,
           cacheTtlMs: KILL_SWITCH_CACHE_TTL_MS,
         },
       );

--- a/platform/app/src/server/routes/auth-cli.ts
+++ b/platform/app/src/server/routes/auth-cli.ts
@@ -69,6 +69,7 @@ import {
 import { getServerAuthSession } from "~/server/auth";
 import { prisma } from "~/server/db";
 import { featureFlagService } from "~/server/featureFlag";
+import { NOT_TARGETED } from "~/server/featureFlag/targeting";
 import { GatewayBudgetService } from "~/server/gateway/budget.service";
 import { BudgetOverviewService } from "~/server/gateway/budgetOverview.service";
 import { resolveSupportContact } from "~/server/organizations/resolveSupportContact";
@@ -2754,6 +2755,8 @@ secured.access(cliApproveAuth).post("/approve", async (c: Context) => {
   const governanceEnabled = await featureFlagService
     .isEnabled("release_ui_ai_governance_enabled", {
       distinctId: session.user.id,
+      // Device login picks an organization, not a project.
+      projectId: NOT_TARGETED,
       organizationId: organization_id,
       defaultValue: true,
     })

--- a/specs/features/agent-testing/page-structure.feature
+++ b/specs/features/agent-testing/page-structure.feature
@@ -51,8 +51,7 @@ Feature: The Agent Testing page
         the person who reads the menu
     When the main menu is read
     Then one item named "Agent Testing" is shown
-    And the rule matches because the menu states the organization it reads
-        the flag for
+    And the Simulations group is not shown
 
   @integration
   Scenario: Quick Search offers Agent Testing while the flag is on

--- a/specs/features/agent-testing/page-structure.feature
+++ b/specs/features/agent-testing/page-structure.feature
@@ -45,6 +45,31 @@ Feature: The Agent Testing page
     And no Agent Testing item is shown
 
   @integration
+  Scenario: A rule that names the organization lights up the main menu
+    Given the Agent Testing release flag is off by default
+    And the flag carries one targeting rule that names the organization of
+        the person who reads the menu
+    When the main menu is read
+    Then one item named "Agent Testing" is shown
+    And the rule matches because the menu states the organization it reads
+        the flag for
+
+  @integration
+  Scenario: Quick Search offers Agent Testing while the flag is on
+    Given the Agent Testing release flag is on
+    When Quick Search is opened and "agent testing" is typed
+    Then Quick Search offers the Agent Testing page
+    And Quick Search offers neither Simulations nor Scenarios, because they
+        lead to the same runs by another route
+
+  @integration
+  Scenario: Quick Search keeps the Simulations entries while the flag is off
+    Given the Agent Testing release flag is off
+    When Quick Search is opened and "simulations" is typed
+    Then Quick Search offers Simulations
+    And Quick Search offers no Agent Testing page
+
+  @integration
   Scenario: A person without permission to read test cases cannot open the page
     Given the Agent Testing release flag is on
     And a person without permission to read test cases

--- a/specs/ops/internal-feature-flags.feature
+++ b/specs/ops/internal-feature-flags.feature
@@ -154,6 +154,51 @@ Feature: Internal feature flag system for system-level kill switches
       Then the flag resolves disabled from the row-level enabled value
       And PostHog is not consulted because the postgres row was present
 
+  Rule: A flag read states the project and the organization it is about
+
+    # A rule that names an organization can only match a read that carries
+    # that organization. A read that leaves the id out loses every rule
+    # written for it and falls through to the row-level default, which is how
+    # an organization rollout reached nobody in a customer report. The type of
+    # a flag read therefore holds both ids, and a caller with no such id says
+    # so instead of leaving the field out.
+
+    @unit
+    Scenario: a read that omits an id does not compile
+      Given a caller reads a feature flag
+      When the caller writes neither the project nor the organization
+      Then the code does not compile, because both fields are required
+
+    @unit
+    Scenario: a caller with no project of its own opts that scope out by name
+      Given a surface that exists outside any project, such as a screen shown
+            before a project is chosen
+      When it reads a flag
+      Then it states the opt-out value for the project
+      And the value it states is the one the flag module exports for this
+          purpose, so the choice is readable at the call site
+
+    @unit
+    Scenario: an opted-out scope matches no rule that names that scope
+      Given a flag with one rule that names a project
+      When the flag is read with the project scope opted out
+      Then the rule does not match
+      And the read falls through to the row-level default
+
+    @unit
+    Scenario: an id that is not known yet is written out, not left out
+      Given a caller whose organization is still loading
+      When it reads a flag
+      Then it writes the organization as not known yet
+      And it disables the read until the organization arrives, so the read
+          never resolves against an empty context by accident
+
+    @unit
+    Scenario: a read that carries the organization matches an organization rule
+      Given a flag that is off by default with one rule naming an organization
+      When the flag is read with that organization and with a project
+      Then the flag resolves enabled from the rule
+
   Rule: Every registered flag resolves from our own store, whatever its scope
 
     Scenario: a SYSTEM flag takes per-organization targeting like any other


### PR DESCRIPTION
## The symptom

A customer turned on the `release_ui_agent_testing_v2_enabled` release flag with one targeting rule scoped to their organization. Nothing appeared in the menu.

The rule was correct. The read was not. The main menu asked for the flag with the project only, so the rule that named an organization matched no context, and the flag fell through to the row default, which is off. The page guard asked with the organization only, so the same flag could answer differently for the page and for the menu that links to it.

A rule can only match a scope the read states. Leaving a scope out is not a smaller question, it is a different one.

## What changed in the type

A flag read now states both scopes. Leaving one out is a compile error.

```ts
// platform/app/src/server/featureFlag/targeting.ts
export const NOT_TARGETED = "__not_targeted__" as const;
export type FeatureFlagTargetId = string | typeof NOT_TARGETED | undefined;
```

```ts
interface UseFeatureFlagOptions {
  projectId: FeatureFlagTargetId;
  organizationId: FeatureFlagTargetId;
  enabled?: boolean;
}
```

Each id takes one of three values:

- a real id, so rules that name it can match.
- `NOT_TARGETED`, when the surface has no such id at all. A page outside any project, or a screen shown before login. No rule that names this scope matches an opted-out read, so the opt-out is a decision, not an oversight.
- `undefined`, when the id is still loading. It stays legal, but it must be written out and it pairs with `enabled: false`.

A caller with a real project and organization writes:

```ts
const { project, organization } = useOrganizationTeamProject();
const { enabled } = useFeatureFlag("release_ui_agent_testing_v2_enabled", {
  projectId: project?.id,
  organizationId: organization?.id,
  enabled: !!project?.id && !!organization?.id,
});
```

A caller on an organization page writes `projectId: NOT_TARGETED` and says why in one line.

## Call sites that were half-scoped

These read the flag with one scope and now read it with both, or state the opt-out:

- `src/components/MainMenu.tsx` (the reported bug: the Test section, plus the coding-agent links and the ops pin)
- `src/components/WithFeatureFlagGuard.tsx` (organization only, so a project rule never reached a guarded page)
- `src/features/navigation/useVisibleSectionNavItems.ts` (organization only)
- `src/features/navigation/useNavigationMode.ts`, `useReachableProducts.ts`
- `src/components/AppHeaderUserMenu.tsx`, `src/components/sidebar/GovernSection.tsx`
- `src/components/settings/ModelProviderForm.tsx`, `src/components/settings/useDepartmentColumn.ts`, `src/pages/settings.tsx`
- `src/components/batch-evaluation-results/useShowComparisonLeaderboard.ts`
- `src/features/automations/AutomationDrawer.tsx` (project only)
- `src/features/langy/components/LangyPanel.tsx`, `src/experiments-v3/hooks/useOptimizeWithLangy.ts`, `src/features/onboarding/hooks/use-onboarding-flow.ts` (read with no options at all)

On the server the same sweep covers the LangWatchQL gate, the analytics tripwire, the langy access gate, the trace media and PII and token-estimation switches, the event-sourcing kill switches, the born-finalized sign-up flag, the budget overview, the anomaly detector, the tenant rate tracker, the CLI device-login gate, and the two governance readers under `ee/`.

One server gate gained a real id rather than an opt-out: the automations router refused a webhook channel after reading the flag with the project only, while the drawer read it with both. It now resolves the organization through the cached `resolveOrganizationId` before the read, so the picker and the route agree.

## What we decided about the server and the wire

`featureFlagService.isEnabled` takes the same required fields as the hook. Backend reads are where the kill switches live, and a kill switch that silently ignores an operator rule is the same defect in a worse place.

The tRPC input carries both fields as required, with `null` for "no such scope". JSON has no `undefined`, so `null` also carries the "not known yet" case; the client disables the query there. An optional field on the wire would have let the exact mistake back in through the one door the type system does not watch.

The server never derives one id from the other. A read that wants the organization of a project resolves it at the call site. A silent derivation would hide the same class of mistake again, one layer down.

## Quick Search

`MainMenuSections` is shared, so the navigation v2 sidebar gets the fix with the menu. The command bar had no Agent Testing entry at all. It now carries one behind the same flag, and the Simulations and Scenarios entries it replaces are hidden while the flag is on, so Quick Search never offers two routes to the same runs.

## Tests

The regression test drives the real rule matcher, not a stubbed hook: `platform/app/src/components/__tests__/MainMenu.orgScopedFlag.integration.test.tsx` renders the menu with the flag off by default and one rule naming the organization, and the fake tRPC query runs `evaluateRules` over the input the hook sends. With the old project-only read it fails.

New scenarios are in `specs/ops/internal-feature-flags.feature` (a new rule: a flag read states the project and the organization it is about) and `specs/features/agent-testing/page-structure.feature`, each bound to a test.

`pnpm typecheck:all`, `pnpm lint` and `pnpm check:feature-parity` all exit 0.

## Deployment Impact

No deployment impact. This change is application code plus one ADR update.

- Environment variables: none added or changed. The per-flag env override and `FEATURE_FLAG_FORCE_ENABLE` keep working exactly as before.
- Helm values: none added or changed.
- Default `helm install` with no overrides: unchanged. Every flag keeps the same registry default, and no migration runs.
- BYOC dataplane: no impact. Nothing in the dataplane reads this contract, and no new service call or network path is added.
- Existing operator rows and targeting rules in the `FeatureFlag` table are read the same way. A rule that names an organization now matches more reads than before, which is the fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Agent Testing to navigation and Quick Search when enabled.
  * Simulations and Scenarios are hidden when Agent Testing replaces them.
  * Feature flags now support explicit project and organization targeting, including intentionally unscoped evaluations.

* **Bug Fixes**
  * Improved feature-flag behavior across organization-level, project-level, and global settings.

* **Tests**
  * Added coverage for targeted feature flags and Agent Testing navigation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Deployment Impact

No deployment impact. No env vars change, no helm values change, no default `helm install` behavior changes, and no BYOC dataplane change. The touched ADR (`dev/docs/adr/005-feature-flags.md`) is documentation only.
