### PR TITLE
fix(redaction): preserve Better Auth span attributes

### DIFF
--- a/platform/app/src/server/data-privacy/redaction/__tests__/applyContentRedaction.unit.test.ts
+++ b/platform/app/src/server/data-privacy/redaction/__tests__/applyContentRedaction.unit.test.ts
@@ -185,6 +185,82 @@ describe("redactAttributeNative", () => {
     });
   });
 
+  describe("given Better Auth observability attributes", () => {
+    describe("when an exact non-credential name holds an ordinary value", () => {
+      /** @scenario "Better Auth observability attributes keep non-sensitive values" */
+      it.each([
+        ["better_auth.hook.type", "create.before"],
+        ["better_auth.context", "plugin:bearer"],
+      ])("keeps %s holding %s", (key, value) => {
+        expect(
+          redactAttributeNative({ key, value, policy: policy({}) }).text,
+        ).toBe(value);
+      });
+    });
+
+    describe("when a sibling name says it holds a credential", () => {
+      /** @scenario "A credential attribute beside Better Auth observability attributes is still redacted" */
+      it("replaces an ordinary value by name", () => {
+        expect(
+          redactAttributeNative({
+            key: "better_auth.token",
+            value: "ordinary text",
+            policy: policy({}),
+          }).text,
+        ).toBe("[SECRET]");
+      });
+    });
+
+    describe("when an exempt name holds a secret", () => {
+      /** @scenario "A secret under a Better Auth observability attribute is still redacted" */
+      it("keeps the shape-only secret rules active", () => {
+        expect(
+          redactAttributeNative({
+            key: "better_auth.context",
+            value: SHAPED_TOKEN,
+            policy: policy({}),
+          }).text,
+        ).toBe("[SECRET]");
+      });
+
+      /** @scenario "A secret under a Better Auth observability attribute is still redacted" */
+      it("keeps vendor-specific secret rules active", () => {
+        const { text } = redactAttributeNative({
+          key: "better_auth.hook.type",
+          value: `sk-ant-${"A".repeat(40)}`,
+          policy: policy({}),
+        });
+        expect(text).toBe("[SECRET]");
+      });
+
+      /** @scenario "A secret under a Better Auth observability attribute is still redacted" */
+      it("keeps customer secret patterns active", () => {
+        const p = policy({ customPatterns: ["acme_live_[A-Za-z0-9]+"] });
+        expect(
+          redactAttributeNative({
+            key: "better_auth.context",
+            value: "acme_live_9f8e7d6c5b4a39281706",
+            policy: p,
+            compiledSecretPatterns: compilePolicySecretPatterns(p),
+          }).text,
+        ).toBe("[SECRET]");
+      });
+    });
+
+    describe("when an exempt name holds personal data", () => {
+      /** @scenario "Personal data under a Better Auth observability attribute is still redacted" */
+      it("keeps the personal-data pass active", () => {
+        expect(
+          redactAttributeNative({
+            key: "better_auth.context",
+            value: "test@example.com",
+            policy: policy({}),
+          }).text,
+        ).toBe("[EMAIL_ADDRESS]");
+      });
+    });
+  });
+
   describe("given an attribute whose name says it is an identifier", () => {
     describe("when the value is an id the product minted", () => {
       /** @scenario "An identifier attribute keeps the id it holds" */

--- a/platform/app/src/server/data-privacy/redaction/applyContentRedaction.ts
+++ b/platform/app/src/server/data-privacy/redaction/applyContentRedaction.ts
@@ -17,6 +17,16 @@ const NATIVE_PII_ENTITY_SET: ReadonlySet<string> = new Set(
 );
 
 /**
+ * Attributes whose exact names describe non-credential Better Auth
+ * observability values. They bypass only the sensitive-name deny-list; their
+ * values still run through every secret and personal-data rule below.
+ */
+const SENSITIVE_NAME_RULE_EXEMPT_ATTRIBUTES: ReadonlySet<string> = new Set([
+  "better_auth.context",
+  "better_auth.hook.type",
+]);
+
+/**
  * The native essential identifiers a resolved policy redacts in-process:
  * `"all"` for the essential and strict levels (the full floor), the selected
  * native subset for custom, or `null` when PII is disabled. Identifiers the
@@ -157,8 +167,9 @@ export function isIdentifierAttributeName(key: string): boolean {
  * that go on shape alone.
  *
  * A name {@link isIdentifierAttributeName} accepts skips both the deny-list and
- * the shape-only value rules. Every other rule runs as it does on any other
- * attribute.
+ * the shape-only value rules. An exact name in
+ * {@link SENSITIVE_NAME_RULE_EXEMPT_ATTRIBUTES} skips only the deny-list; every
+ * value rule still runs. Every other attribute runs all rules.
  */
 export function redactAttributeNative({
   key,
@@ -174,10 +185,12 @@ export function redactAttributeNative({
   compiledPiiExceptions?: readonly RegExp[];
 }): { text: string; redactedCount: number } {
   const namesAnIdentifier = isIdentifierAttributeName(key);
+  const isExemptFromSensitiveNameRule =
+    namesAnIdentifier || SENSITIVE_NAME_RULE_EXEMPT_ATTRIBUTES.has(key);
   if (
     policy.secrets.enabled &&
     value.length > 0 &&
-    !namesAnIdentifier &&
+    !isExemptFromSensitiveNameRule &&
     isSensitiveAttributeKey(key)
   ) {
     return { text: SECRETS_REDACTION_MARKER, redactedCount: 1 };

--- a/specs/data-privacy/secrets-redaction.feature
+++ b/specs/data-privacy/secrets-redaction.feature
@@ -478,6 +478,36 @@ Feature: Redacting secrets from traces
     When the attribute is redacted
     Then the email address is replaced
 
+  # Better Auth writes two observability attributes whose names contain
+  # "auth" but whose values are short, non-credential enumerations. They need
+  # to bypass only the sensitive-name rule. Every value-based secret rule,
+  # customer pattern and personal-data rule must keep running, and no sibling
+  # name in the namespace inherits the exemption.
+
+  @regression @unit
+  Scenario: Better Auth observability attributes keep non-sensitive values
+    Given a Better Auth observability attribute with a non-sensitive value
+    When the attribute is redacted
+    Then the value is left exactly as written
+
+  @regression @unit
+  Scenario: A credential attribute beside Better Auth observability attributes is still redacted
+    Given another Better Auth attribute whose name says it holds a credential
+    When the attribute is redacted
+    Then the value is replaced even when it has no secret shape
+
+  @regression @unit
+  Scenario: A secret under a Better Auth observability attribute is still redacted
+    Given a Better Auth observability attribute holding a secret
+    When the attribute is redacted
+    Then the secret is replaced
+
+  @regression @unit
+  Scenario: Personal data under a Better Auth observability attribute is still redacted
+    Given a Better Auth observability attribute holding personal data
+    When the attribute is redacted
+    Then the personal data is replaced
+
   # A handle and a version number are not identifier names, and they do not need
   # to be. A handle accepts lowercase letters, digits, hyphens, underscores and
   # one slash, and the shape rule needs two uppercase characters before it


### PR DESCRIPTION
## Why

Better Auth emits `better_auth.hook.type` and `better_auth.context` as non-credential observability metadata. The sensitive attribute-name rule tokenizes `auth` and redacts these values before inspecting them, which removes the hook and context details from auth traces.

Fixes #7544

## What changed

- Exempt only `better_auth.hook.type` and `better_auth.context` from the sensitive attribute-name rule.
- Keep shape-based, vendor-specific, custom secret, and personal-data scans active for values under both names.
- Add regression scenarios and focused tests for safe Better Auth values, a credential-named sibling, secret-shaped values, custom patterns, and personal data.

## How it works

The exact-name set affects only the initial sensitive-name deny-list check. It does not reuse the broader identifier exemption, so shape-only secret rules still run. The rest of the `better_auth.*` namespace remains protected by the normal name rule.

## Test plan

The focused regression suite produced three failures before the source change: both observability values were replaced with `[SECRET]`, and personal data under an exempt name was short-circuited to `[SECRET]` instead of the PII marker.

- [x] `corepack pnpm test:unit run src/server/data-privacy/redaction/__tests__/applyContentRedaction.unit.test.ts` — 61 passed
- [x] `corepack pnpm --filter @langwatch/web check:feature-parity` — 9,578 enforced scenarios bound
- [x] `corepack pnpm lint`
- [x] `corepack pnpm typecheck:all`
- [x] `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved privacy redaction for Better Auth observability attributes.
  * Ordinary values in designated observability fields remain visible, while credentials, secrets, custom sensitive patterns, and personal data continue to be redacted.
  * Sensitive sibling attributes remain protected, preserving consistent privacy safeguards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->