### PR TITLE
feat(agent-cache): take a name with a claim, so one row does the work

### DIFF
--- a/docs/agent-simulations/authenticated-agents.mdx
+++ b/docs/agent-simulations/authenticated-agents.mdx
@@ -343,9 +343,16 @@ The rows that start at the same moment all read an empty cache, so without a cla
 
 Use a name for the claim that is not the name of the entry. The claim is taken before the login, and the session can only be written after it.
 
-`CLAIM_TTL_SECONDS` is what a row waits for before it takes the login itself. Set it above the time your login takes. A row that takes the claim and then stops does not hold the others for good: the claim expires, the next row takes it, and that row does the work.
+Two settings control the wait, and they do different things:
 
-Set it too low and the claim stops arbitrating: a login that runs longer than the claim's lifetime lets a second row take the name and log in as well, and the last session written is the one the rows that follow read. Both sessions are valid, so the cost is extra logins, which is the result with no claim at all. The same applies when the cache itself cannot answer.
+| Setting | What it does |
+|---|---|
+| `CLAIM_TTL_SECONDS` | How long the claim holds the name. Set it above the time your login takes. |
+| `LOGIN_WAIT_TICKS` | How many seconds a waiting row gives the row that took the name before it logs in itself. Keep it above `CLAIM_TTL_SECONDS`. |
+
+A row that takes the claim and then stops does not hold the others for good. Its claim expires after `CLAIM_TTL_SECONDS`, the next tick of a waiting row takes the name, and that row does the work.
+
+Set `CLAIM_TTL_SECONDS` below your login time and the claim stops arbitrating: the name comes free while the first row is still logging in, so a second row takes it and logs in as well, and the last session written is the one the rows that follow read. Both sessions are valid, so the cost is extra logins, which is the result with no claim at all. The same applies when the cache itself cannot answer.
 
 ### Cache API
 

--- a/docs/agent-simulations/authenticated-agents.mdx
+++ b/docs/agent-simulations/authenticated-agents.mdx
@@ -291,21 +291,58 @@ The agent also treats a `401` as an expired session: it logs in again and retrie
 ### Behavior
 
 - Each run logs in only once. Every later row reads the stored session from the cache.
-- When rows start at the same time, each one can find the cache empty and log in. Both sessions are valid and the last write wins. Keep the login idempotent on the target, or lower the run's parallelism.
+- When rows start at the same time, each one can find the cache empty and log in. Both sessions are valid and the last write wins. Keep the login idempotent on the target, lower the run's parallelism, or take a claim as shown below.
 - Entries belong to the project, not to a single run. A second run reuses the session the first run stored. If two concurrent runs write the same entry name, the last write wins. Use distinct names per agent (for example `BILLING_SESSION` and `SUPPORT_SESSION`) to avoid collisions.
 - If a read fails, the row treats it as a miss and logs in. If a write fails, the row still succeeds; only the next row has to log in again.
 
 Source: [`shared_session_code_agent.py`](https://github.com/langwatch/langwatch/blob/main/services/nlpgo/app/engine/blocks/codeblock/examples/shared_session_code_agent.py).
+
+### One login when rows start together
+
+The rows that start at the same moment all read an empty cache, so they all log in. To make one of them do it, take a claim on a second name first. A claim writes only if the project does not hold that name yet, and returns `True` for the row that took it and `False` for the rows that did not.
+
+Replace `get_session()` in the agent above with this:
+
+```python
+import time
+
+LOGIN_CLAIM_NAME = "ACME_LOGIN_CLAIM"  # the name one row takes to log in
+CLAIM_TTL_SECONDS = 60  # a row that stops before it stores frees the name
+
+
+def get_session():
+    stored = langwatch.cache.get(SESSION_ENTRY_NAME)
+    if stored:
+        return stored
+
+    if langwatch.cache.claim(LOGIN_CLAIM_NAME, "taken", ttl_seconds=CLAIM_TTL_SECONDS):
+        return renew_session()
+
+    # Another row took the name and is logging in. Wait for what it stores.
+    for _ in range(CLAIM_TTL_SECONDS):
+        time.sleep(1)
+        stored = langwatch.cache.get(SESSION_ENTRY_NAME)
+        if stored:
+            return stored
+
+    # It did not finish in time, so this row logs in on its own.
+    return renew_session()
+```
+
+The last branch is what keeps the row answering: if the row that took the name stops before it stores a session, every other row logs in, which is the same result as no claim at all.
+
+Use a name for the claim that is not the name of the entry. The claim is taken before the login, and the entry can only be written after it.
 
 ### Cache API
 
 ```python
 langwatch.cache.set("ACME_SESSION", session, ttl_seconds=840)
 langwatch.cache.get("ACME_SESSION", default=None)
+langwatch.cache.claim("ACME_LOGIN_CLAIM", "taken", ttl_seconds=60)
 langwatch.cache.delete("ACME_SESSION")
 ```
 
-`get` returns the default on a miss, so no `try`/`except` is needed for that case. Other errors raise.
+`get` returns the default on a miss, so no `try`/`except` is needed for that case. `claim` returns `True` when it stored the value and `False` when the name was already held, and does not raise for a name it could not take. Other errors raise.
 
 Also available over REST at [`/api/agent-cache/{name}`](/api-reference/agent-cache/get-entry).
 

--- a/docs/agent-simulations/authenticated-agents.mdx
+++ b/docs/agent-simulations/authenticated-agents.mdx
@@ -144,10 +144,11 @@ This code is executed on every commit against the real runtime:
 #
 # Rows are isolated, so each one starts cold and a login on every row is the
 # default result. This agent keeps one session in the project's agent cache and
-# reads it back at the start of every row, so only the rows that start at the
-# same moment log in. A row that finds the target no longer accepts the stored
-# session logs in again and stores the new one, so a session the target ends
-# early costs one login rather than the run.
+# reads it back at the start of every row. The rows that start at the same
+# moment all read an empty cache, so one of them takes a claim and logs in
+# while the rest wait for what it stores. A row that finds the target no longer
+# accepts the stored session logs in again and stores the new one, so a session
+# the target ends early costs one login rather than the run.
 #
 # The platform gives the sandbox its own LangWatch credential, so there is no
 # setup call to write and no LangWatch secret to create. The runner injects
@@ -156,13 +157,17 @@ This code is executed on every commit against the real runtime:
 # returned.
 
 import sys
+import time
 
 import langwatch
 import requests
 
 SESSION_ENTRY_NAME = "ACME_SESSION"  # the cache entry that holds the session
-SESSION_TTL_SECONDS = 15 * 60  # what the target system promises
+LOGIN_CLAIM_NAME = "ACME_LOGIN_CLAIM"  # the name one row takes to log in
+SESSION_TTL_SECONDS = 15 * 60  # the lifetime the target system returns
 REFRESH_MARGIN_SECONDS = 60  # store it for less, so it is never sent stale
+CLAIM_TTL_SECONDS = 15  # a row that stops before it stores frees the name
+LOGIN_WAIT_TICKS = 20  # how long a row waits for the row that took the name
 REFUSED = object()  # the target would not accept the session this row sent
 
 
@@ -172,7 +177,7 @@ class Code:
         if reply is REFUSED:
             # The stored session is no longer one the target accepts. A target
             # ends a session whenever it likes: a restart, an operator closing
-            # it, a password change. The lifetime it promised is the most this
+            # it, a password change. The lifetime it returned is the most this
             # agent can assume, never a guarantee. So log in again and send
             # this row once more, which also stores the new session for the
             # rows that follow.
@@ -201,15 +206,50 @@ class Code:
 
 def get_session():
     """Return a session token. This is the one line each row calls."""
-    try:
-        stored = langwatch.cache.get(SESSION_ENTRY_NAME)
-    except Exception:  # noqa: BLE001 - a cache that cannot answer is a miss
-        report("could not be read", "this row logs in")
-        stored = None
+    stored = read_session()
     if stored:
         return stored
 
+    # A claim writes only when the name is free, so of the rows that read the
+    # empty cache together exactly one takes it and logs in. The rows that did
+    # not take it wait for the session that row stores, and claim again on
+    # every tick: a row that stops before it stores frees the name, and the
+    # next tick is where another row picks the work up.
+    for _ in range(LOGIN_WAIT_TICKS):
+        if take_the_login():
+            return renew_session()
+        time.sleep(1)
+        stored = read_session()
+        if stored:
+            return stored
+
+    # No row stored a session inside the window. This row logs in on its own,
+    # which is the result every row gets with no claim at all.
+    report("was not stored in time", "this row logs in")
     return renew_session()
+
+
+def read_session():
+    """Read the stored session. A cache that cannot answer reads as a miss."""
+    try:
+        return langwatch.cache.get(SESSION_ENTRY_NAME)
+    except Exception:  # noqa: BLE001 - a cache that cannot answer is a miss
+        report("could not be read", "this row logs in")
+        return None
+
+
+def take_the_login():
+    """Answer whether this row is the one that logs in.
+
+    A cache that cannot answer means every row logs in, which is the result
+    with no claim at all, so the row goes on rather than stopping.
+    """
+    try:
+        return langwatch.cache.claim(
+            LOGIN_CLAIM_NAME, "taken", ttl_seconds=CLAIM_TTL_SECONDS
+        )
+    except Exception:  # noqa: BLE001 - the row must still answer
+        return True
 
 
 def renew_session():
@@ -237,9 +277,9 @@ def login():
 
 def store_session(session):
     """Store the session for the rows that follow, for a little less than the
-    target system promises. A failure here does not fail the row: this row
-    holds a working session already, and the only cost is that the next row
-    logs in again."""
+    lifetime the target system returned. A failure here does not fail the row:
+    this row holds a working session already, and the only cost is that the
+    next row logs in again."""
     try:
         langwatch.cache.set(
             SESSION_ENTRY_NAME,
@@ -291,7 +331,7 @@ The agent also treats a `401` as an expired session: it logs in again and retrie
 ### Behavior
 
 - Each run logs in only once. Every later row reads the stored session from the cache.
-- When rows start at the same time, each one can find the cache empty and log in. Both sessions are valid and the last write wins. Keep the login idempotent on the target, lower the run's parallelism, or take a claim as shown below.
+- When rows start at the same time, one of them takes the claim and logs in. The rest wait and read the session it stores.
 - Entries belong to the project, not to a single run. A second run reuses the session the first run stored. If two concurrent runs write the same entry name, the last write wins. Use distinct names per agent (for example `BILLING_SESSION` and `SUPPORT_SESSION`) to avoid collisions.
 - If a read fails, the row treats it as a miss and logs in. If a write fails, the row still succeeds; only the next row has to log in again.
 
@@ -299,39 +339,13 @@ Source: [`shared_session_code_agent.py`](https://github.com/langwatch/langwatch/
 
 ### One login when rows start together
 
-The rows that start at the same moment all read an empty cache, so they all log in. To make one of them do it, take a claim on a second name first. A claim writes only if the project does not hold that name yet, and returns `True` for the row that took it and `False` for the rows that did not.
+The rows that start at the same moment all read an empty cache, so without a claim they all log in. The agent above takes a claim on a second name first. A claim writes only when the project does not hold that name yet, and answers `True` for the row that took it and `False` for the rows that did not, so one row logs in and the rest wait for the session it stores.
 
-Replace `get_session()` in the agent above with this:
+Use a name for the claim that is not the name of the entry. The claim is taken before the login, and the session can only be written after it.
 
-```python
-import time
+`CLAIM_TTL_SECONDS` is what a row waits for before it takes the login itself. Set it above the time your login takes. A row that takes the claim and then stops does not hold the others for good: the claim expires, the next row takes it, and that row does the work.
 
-LOGIN_CLAIM_NAME = "ACME_LOGIN_CLAIM"  # the name one row takes to log in
-CLAIM_TTL_SECONDS = 60  # a row that stops before it stores frees the name
-
-
-def get_session():
-    stored = langwatch.cache.get(SESSION_ENTRY_NAME)
-    if stored:
-        return stored
-
-    if langwatch.cache.claim(LOGIN_CLAIM_NAME, "taken", ttl_seconds=CLAIM_TTL_SECONDS):
-        return renew_session()
-
-    # Another row took the name and is logging in. Wait for what it stores.
-    for _ in range(CLAIM_TTL_SECONDS):
-        time.sleep(1)
-        stored = langwatch.cache.get(SESSION_ENTRY_NAME)
-        if stored:
-            return stored
-
-    # It did not finish in time, so this row logs in on its own.
-    return renew_session()
-```
-
-The last branch is what keeps the row answering: if the row that took the name stops before it stores a session, every other row logs in, which is the same result as no claim at all.
-
-Use a name for the claim that is not the name of the entry. The claim is taken before the login, and the entry can only be written after it.
+Set it too low and the claim stops arbitrating: a login that runs longer than the claim's lifetime lets a second row take the name and log in as well, and the last session written is the one the rows that follow read. Both sessions are valid, so the cost is extra logins, which is the result with no claim at all. The same applies when the cache itself cannot answer.
 
 ### Cache API
 

--- a/docs/agent-simulations/authenticated-agents.mdx
+++ b/docs/agent-simulations/authenticated-agents.mdx
@@ -142,13 +142,10 @@ This code is executed on every commit against the real runtime:
 ```python shared_session_code_agent.py
 # Log in once and share the session across the rows of a run.
 #
-# Rows are isolated, so each one starts cold and a login on every row is the
-# default result. This agent keeps one session in the project's agent cache and
-# reads it back at the start of every row. The rows that start at the same
-# moment all read an empty cache, so one of them takes a claim and logs in
-# while the rest wait for what it stores. A row that finds the target no longer
-# accepts the stored session logs in again and stores the new one, so a session
-# the target ends early costs one login rather than the run.
+# Rows are isolated, so each one starts cold and logs in on its own. This agent
+# keeps the session in the project's agent cache. Of the rows that start
+# together, one takes the claim and logs in while the rest wait for what it
+# stores. A row the target refuses logs in again and stores the new session.
 #
 # The platform gives the sandbox its own LangWatch credential, so there is no
 # setup call to write and no LangWatch secret to create. The runner injects
@@ -162,31 +159,23 @@ import time
 import langwatch
 import requests
 
-SESSION_ENTRY_NAME = "ACME_SESSION"  # the cache entry that holds the session
-LOGIN_CLAIM_NAME = "ACME_LOGIN_CLAIM"  # the name one row takes to log in
-SESSION_TTL_SECONDS = 15 * 60  # the lifetime the target system returns
-REFRESH_MARGIN_SECONDS = 60  # store it for less, so it is never sent stale
-CLAIM_TTL_SECONDS = 15  # a row that stops before it stores frees the name
-LOGIN_WAIT_TICKS = 20  # how long a row waits for the row that took the name
-REFUSED = object()  # the target would not accept the session this row sent
+SESSION_NAME = "ACME_SESSION"  # the cache entry, and the claim that guards it
+SESSION_TTL_SECONDS = 14 * 60  # under what the target gives, so it is never stale
+LOGIN_SECONDS = 15  # over what a login takes: how long one row holds the claim
+REFUSED = object()
 
 
 class Code:
     def __call__(self, message: str):
         reply = self.ask(message, get_session())
         if reply is REFUSED:
-            # The stored session is no longer one the target accepts. A target
-            # ends a session whenever it likes: a restart, an operator closing
-            # it, a password change. The lifetime it returned is the most this
-            # agent can assume, never a guarantee. So log in again and send
-            # this row once more, which also stores the new session for the
-            # rows that follow.
+            # A target ends a session whenever it likes: a restart, an operator
+            # closing it, a password change. The lifetime it returned is the
+            # most this agent can assume, so a refusal costs one login.
             report("was refused", "this row logs in again")
             reply = self.ask(message, renew_session())
             if reply is REFUSED:
-                raise RuntimeError(
-                    "ACME refused a session this row obtained a moment ago."
-                )
+                raise RuntimeError("ACME refused a session obtained a moment ago.")
         return {"output": reply}
 
     def ask(self, message, session):
@@ -205,55 +194,46 @@ class Code:
 
 
 def get_session():
-    """Return a session token. This is the one line each row calls."""
-    stored = read_session()
-    if stored:
-        return stored
+    """Return a session, stored by another row or obtained by this one.
 
-    # A claim writes only when the name is free, so of the rows that read the
-    # empty cache together exactly one takes it and logs in. The rows that did
-    # not take it wait for the session that row stores, and claim again on
-    # every tick: a row that stops before it stores frees the name, and the
-    # next tick is where another row picks the work up.
-    for _ in range(LOGIN_WAIT_TICKS):
-        if take_the_login():
-            return renew_session()
-        time.sleep(1)
+    The loop always ends: either a session appears, or the claim comes free.
+    A row that takes the claim and then stops frees it after LOGIN_SECONDS,
+    and the next pass is where another row picks the work up.
+    """
+    while True:
         stored = read_session()
         if stored:
             return stored
-
-    # No row stored a session inside the window. This row logs in on its own,
-    # which is the result every row gets with no claim at all.
-    report("was not stored in time", "this row logs in")
-    return renew_session()
+        if take_the_login():
+            return renew_session()
+        time.sleep(1)
 
 
 def read_session():
-    """Read the stored session. A cache that cannot answer reads as a miss."""
+    """The stored session, or None. A cache that cannot answer is a miss."""
     try:
-        return langwatch.cache.get(SESSION_ENTRY_NAME)
-    except Exception:  # noqa: BLE001 - a cache that cannot answer is a miss
+        return langwatch.cache.get(SESSION_NAME)
+    except Exception:  # noqa: BLE001 - the row must still answer
         report("could not be read", "this row logs in")
         return None
 
 
 def take_the_login():
-    """Answer whether this row is the one that logs in.
+    """Whether this row is the one that logs in.
 
     A cache that cannot answer means every row logs in, which is the result
     with no claim at all, so the row goes on rather than stopping.
     """
     try:
         return langwatch.cache.claim(
-            LOGIN_CLAIM_NAME, "taken", ttl_seconds=CLAIM_TTL_SECONDS
+            f"{SESSION_NAME}_CLAIM", "taken", ttl_seconds=LOGIN_SECONDS
         )
     except Exception:  # noqa: BLE001 - the row must still answer
         return True
 
 
 def renew_session():
-    """Log in and store the session, for this row and the rows that follow."""
+    """Log in, and store the session for the rows that follow."""
     session = login()
     store_session(session)
     return session
@@ -276,27 +256,19 @@ def login():
 
 
 def store_session(session):
-    """Store the session for the rows that follow, for a little less than the
-    lifetime the target system returned. A failure here does not fail the row:
-    this row holds a working session already, and the only cost is that the
-    next row logs in again."""
+    """Store it for the rows that follow. A failure here costs the next row a
+    login, never this row's answer."""
     try:
-        langwatch.cache.set(
-            SESSION_ENTRY_NAME,
-            session,
-            ttl_seconds=SESSION_TTL_SECONDS - REFRESH_MARGIN_SECONDS,
-        )
+        langwatch.cache.set(SESSION_NAME, session, ttl_seconds=SESSION_TTL_SECONDS)
     except Exception:  # noqa: BLE001 - the row must still answer
         report("could not be stored", "the next row will log in again")
 
 
 def report(state, consequence):
-    """Say on stderr what the cache did, in this agent's own words.
-
-    Nothing from the exception reaches the output. An error message can quote
-    the credential that caused it, and a run shows stderr.
-    """
-    print(f"{SESSION_ENTRY_NAME} {state}, {consequence}", file=sys.stderr)
+    """Say on stderr what the cache did, in this agent's own fixed words. An
+    exception text can quote the credential that caused it, and a run shows
+    what it printed."""
+    print(f"{SESSION_NAME} {state}, {consequence}", file=sys.stderr)
 
 
 def secret(name):
@@ -339,27 +311,22 @@ Source: [`shared_session_code_agent.py`](https://github.com/langwatch/langwatch/
 
 ### One login when rows start together
 
-The rows that start at the same moment all read an empty cache, so without a claim they all log in. The agent above takes a claim on a second name first. A claim writes only when the project does not hold that name yet, and answers `True` for the row that took it and `False` for the rows that did not, so one row logs in and the rest wait for the session it stores.
+The rows that start at the same moment all read an empty cache, so without a claim they all log in. The agent above takes a claim first. A claim writes only when the project does not hold that name yet, and answers `True` for the row that took it and `False` for the rows that did not, so one row logs in and the rest wait for the session it stores.
 
-Use a name for the claim that is not the name of the entry. The claim is taken before the login, and the session can only be written after it.
+`LOGIN_SECONDS` is the one number to set: how long a row holds the claim. Put it above the time your login takes.
 
-Two settings control the wait, and they do different things:
+That single number also ends the wait. A row that takes the claim and then stops does not hold the others for good, because the claim expires and the next pass of a waiting row takes the name.
 
-| Setting | What it does |
-|---|---|
-| `CLAIM_TTL_SECONDS` | How long the claim holds the name. Set it above the time your login takes. |
-| `LOGIN_WAIT_TICKS` | How many seconds a waiting row gives the row that took the name before it logs in itself. Keep it above `CLAIM_TTL_SECONDS`. |
+Set it below your login time and the claim stops arbitrating: the name comes free while the first row is still logging in, so a second row takes it and logs in as well, and the last session written is the one the rows that follow read. Both sessions are valid, so the cost is extra logins, which is the result with no claim at all. The same applies when the cache itself cannot answer.
 
-A row that takes the claim and then stops does not hold the others for good. Its claim expires after `CLAIM_TTL_SECONDS`, the next tick of a waiting row takes the name, and that row does the work.
-
-Set `CLAIM_TTL_SECONDS` below your login time and the claim stops arbitrating: the name comes free while the first row is still logging in, so a second row takes it and logs in as well, and the last session written is the one the rows that follow read. Both sessions are valid, so the cost is extra logins, which is the result with no claim at all. The same applies when the cache itself cannot answer.
+The claim uses the entry's own name with `_CLAIM` after it, so there is no second name to pick. It has to be a separate entry: the claim is taken before the login, and the session can only be stored after it.
 
 ### Cache API
 
 ```python
 langwatch.cache.set("ACME_SESSION", session, ttl_seconds=840)
 langwatch.cache.get("ACME_SESSION", default=None)
-langwatch.cache.claim("ACME_LOGIN_CLAIM", "taken", ttl_seconds=60)
+langwatch.cache.claim("ACME_SESSION_CLAIM", "taken", ttl_seconds=15)
 langwatch.cache.delete("ACME_SESSION")
 ```
 

--- a/docs/api-reference/agent-cache/claim-entry.mdx
+++ b/docs/api-reference/agent-cache/claim-entry.mdx
@@ -1,0 +1,4 @@
+---
+title: "Claim a cache entry"
+openapi: "POST /api/agent-cache/{name}/claim"
+---

--- a/docs/api-reference/agent-cache/overview.mdx
+++ b/docs/api-reference/agent-cache/overview.mdx
@@ -15,6 +15,10 @@ names none.
 
 There is no listing route: names come from the agent code that wrote them.
 
+A write replaces whatever the name held. To write only when the name is free,
+claim it instead: the claim route answers whether this caller is the one that
+took the name, which is how one row does work the rows beside it then reuse.
+
 Every route needs an API key that can manage the agent cache. A read returns the
 value, so a caller that can overwrite an entry can already choose what the next
 read answers.

--- a/docs/api-reference/openapiLangWatch.json
+++ b/docs/api-reference/openapiLangWatch.json
@@ -2071,6 +2071,258 @@
         ]
       }
     },
+    "/api/agent-cache/{name}/claim": {
+      "post": {
+        "operationId": "postApiAgentCacheByNameClaim",
+        "description": "Store a value under a name only if the project does not hold that name yet. The answer says whether this caller is the one that took it: `claimed` is true when the value was written, and false when the name was already held, which leaves the held value alone. Losing is an ordinary answer and not a refusal, so a caller branches on `claimed` rather than on an error. This is what one row of a run uses to do work the rows beside it then reuse, instead of every row doing it at once. The value is encrypted at rest and expires by itself after ttl_seconds, which defaults to 900 seconds.",
+        "responses": {
+          "200": {
+            "description": "Claim resolved, taken or not",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "claimed": {
+                      "type": "boolean"
+                    },
+                    "ttl_seconds": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "claimed",
+                    "ttl_seconds"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string"
+                        },
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "meta": {
+                          "type": "object",
+                          "additionalProperties": {}
+                        },
+                        "trace_id": {
+                          "type": "string"
+                        },
+                        "span_id": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "code",
+                        "message"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string"
+                        },
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "meta": {
+                          "type": "object",
+                          "additionalProperties": {}
+                        },
+                        "trace_id": {
+                          "type": "string"
+                        },
+                        "span_id": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "code",
+                        "message"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string"
+                        },
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "meta": {
+                          "type": "object",
+                          "additionalProperties": {}
+                        },
+                        "trace_id": {
+                          "type": "string"
+                        },
+                        "span_id": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "code",
+                        "message"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string"
+                        },
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "meta": {
+                          "type": "object",
+                          "additionalProperties": {}
+                        },
+                        "trace_id": {
+                          "type": "string"
+                        },
+                        "span_id": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "code",
+                        "message"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "in": "path",
+            "name": "name",
+            "schema": {
+              "type": "string",
+              "pattern": "^[A-Z][A-Z0-9_]*$",
+              "minLength": 1,
+              "maxLength": 64
+            },
+            "required": true
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "value": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "ttl_seconds": {
+                    "type": "integer",
+                    "minimum": 5,
+                    "maximum": 86400
+                  }
+                },
+                "required": [
+                  "value"
+                ]
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "project_api_key": []
+          }
+        ]
+      }
+    },
     "/api/agents": {
       "get": {
         "operationId": "getApiAgents",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1290,6 +1290,7 @@
               "api-reference/agent-cache/overview",
               "api-reference/agent-cache/get-entry",
               "api-reference/agent-cache/put-entry",
+              "api-reference/agent-cache/claim-entry",
               "api-reference/agent-cache/delete-entry"
             ]
           },

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -34763,13 +34763,10 @@ This code is executed on every commit against the real runtime:
 ```python shared_session_code_agent.py
 # Log in once and share the session across the rows of a run.
 #
-# Rows are isolated, so each one starts cold and a login on every row is the
-# default result. This agent keeps one session in the project's agent cache and
-# reads it back at the start of every row. The rows that start at the same
-# moment all read an empty cache, so one of them takes a claim and logs in
-# while the rest wait for what it stores. A row that finds the target no longer
-# accepts the stored session logs in again and stores the new one, so a session
-# the target ends early costs one login rather than the run.
+# Rows are isolated, so each one starts cold and logs in on its own. This agent
+# keeps the session in the project's agent cache. Of the rows that start
+# together, one takes the claim and logs in while the rest wait for what it
+# stores. A row the target refuses logs in again and stores the new session.
 #
 # The platform gives the sandbox its own LangWatch credential, so there is no
 # setup call to write and no LangWatch secret to create. The runner injects
@@ -34783,31 +34780,23 @@ import time
 import langwatch
 import requests
 
-SESSION_ENTRY_NAME = "ACME_SESSION"  # the cache entry that holds the session
-LOGIN_CLAIM_NAME = "ACME_LOGIN_CLAIM"  # the name one row takes to log in
-SESSION_TTL_SECONDS = 15 * 60  # the lifetime the target system returns
-REFRESH_MARGIN_SECONDS = 60  # store it for less, so it is never sent stale
-CLAIM_TTL_SECONDS = 15  # a row that stops before it stores frees the name
-LOGIN_WAIT_TICKS = 20  # how long a row waits for the row that took the name
-REFUSED = object()  # the target would not accept the session this row sent
+SESSION_NAME = "ACME_SESSION"  # the cache entry, and the claim that guards it
+SESSION_TTL_SECONDS = 14 * 60  # under what the target gives, so it is never stale
+LOGIN_SECONDS = 15  # over what a login takes: how long one row holds the claim
+REFUSED = object()
 
 
 class Code:
     def __call__(self, message: str):
         reply = self.ask(message, get_session())
         if reply is REFUSED:
-            # The stored session is no longer one the target accepts. A target
-            # ends a session whenever it likes: a restart, an operator closing
-            # it, a password change. The lifetime it returned is the most this
-            # agent can assume, never a guarantee. So log in again and send
-            # this row once more, which also stores the new session for the
-            # rows that follow.
+            # A target ends a session whenever it likes: a restart, an operator
+            # closing it, a password change. The lifetime it returned is the
+            # most this agent can assume, so a refusal costs one login.
             report("was refused", "this row logs in again")
             reply = self.ask(message, renew_session())
             if reply is REFUSED:
-                raise RuntimeError(
-                    "ACME refused a session this row obtained a moment ago."
-                )
+                raise RuntimeError("ACME refused a session obtained a moment ago.")
         return {"output": reply}
 
     def ask(self, message, session):
@@ -34826,55 +34815,46 @@ class Code:
 
 
 def get_session():
-    """Return a session token. This is the one line each row calls."""
-    stored = read_session()
-    if stored:
-        return stored
+    """Return a session, stored by another row or obtained by this one.
 
-    # A claim writes only when the name is free, so of the rows that read the
-    # empty cache together exactly one takes it and logs in. The rows that did
-    # not take it wait for the session that row stores, and claim again on
-    # every tick: a row that stops before it stores frees the name, and the
-    # next tick is where another row picks the work up.
-    for _ in range(LOGIN_WAIT_TICKS):
-        if take_the_login():
-            return renew_session()
-        time.sleep(1)
+    The loop always ends: either a session appears, or the claim comes free.
+    A row that takes the claim and then stops frees it after LOGIN_SECONDS,
+    and the next pass is where another row picks the work up.
+    """
+    while True:
         stored = read_session()
         if stored:
             return stored
-
-    # No row stored a session inside the window. This row logs in on its own,
-    # which is the result every row gets with no claim at all.
-    report("was not stored in time", "this row logs in")
-    return renew_session()
+        if take_the_login():
+            return renew_session()
+        time.sleep(1)
 
 
 def read_session():
-    """Read the stored session. A cache that cannot answer reads as a miss."""
+    """The stored session, or None. A cache that cannot answer is a miss."""
     try:
-        return langwatch.cache.get(SESSION_ENTRY_NAME)
-    except Exception:  # noqa: BLE001 - a cache that cannot answer is a miss
+        return langwatch.cache.get(SESSION_NAME)
+    except Exception:  # noqa: BLE001 - the row must still answer
         report("could not be read", "this row logs in")
         return None
 
 
 def take_the_login():
-    """Answer whether this row is the one that logs in.
+    """Whether this row is the one that logs in.
 
     A cache that cannot answer means every row logs in, which is the result
     with no claim at all, so the row goes on rather than stopping.
     """
     try:
         return langwatch.cache.claim(
-            LOGIN_CLAIM_NAME, "taken", ttl_seconds=CLAIM_TTL_SECONDS
+            f"{SESSION_NAME}_CLAIM", "taken", ttl_seconds=LOGIN_SECONDS
         )
     except Exception:  # noqa: BLE001 - the row must still answer
         return True
 
 
 def renew_session():
-    """Log in and store the session, for this row and the rows that follow."""
+    """Log in, and store the session for the rows that follow."""
     session = login()
     store_session(session)
     return session
@@ -34897,27 +34877,19 @@ def login():
 
 
 def store_session(session):
-    """Store the session for the rows that follow, for a little less than the
-    lifetime the target system returned. A failure here does not fail the row:
-    this row holds a working session already, and the only cost is that the
-    next row logs in again."""
+    """Store it for the rows that follow. A failure here costs the next row a
+    login, never this row's answer."""
     try:
-        langwatch.cache.set(
-            SESSION_ENTRY_NAME,
-            session,
-            ttl_seconds=SESSION_TTL_SECONDS - REFRESH_MARGIN_SECONDS,
-        )
+        langwatch.cache.set(SESSION_NAME, session, ttl_seconds=SESSION_TTL_SECONDS)
     except Exception:  # noqa: BLE001 - the row must still answer
         report("could not be stored", "the next row will log in again")
 
 
 def report(state, consequence):
-    """Say on stderr what the cache did, in this agent's own words.
-
-    Nothing from the exception reaches the output. An error message can quote
-    the credential that caused it, and a run shows stderr.
-    """
-    print(f"{SESSION_ENTRY_NAME} {state}, {consequence}", file=sys.stderr)
+    """Say on stderr what the cache did, in this agent's own fixed words. An
+    exception text can quote the credential that caused it, and a run shows
+    what it printed."""
+    print(f"{SESSION_NAME} {state}, {consequence}", file=sys.stderr)
 
 
 def secret(name):
@@ -34960,27 +34932,22 @@ Source: [`shared_session_code_agent.py`](https://github.com/langwatch/langwatch/
 
 ### One login when rows start together
 
-The rows that start at the same moment all read an empty cache, so without a claim they all log in. The agent above takes a claim on a second name first. A claim writes only when the project does not hold that name yet, and answers `True` for the row that took it and `False` for the rows that did not, so one row logs in and the rest wait for the session it stores.
+The rows that start at the same moment all read an empty cache, so without a claim they all log in. The agent above takes a claim first. A claim writes only when the project does not hold that name yet, and answers `True` for the row that took it and `False` for the rows that did not, so one row logs in and the rest wait for the session it stores.
 
-Use a name for the claim that is not the name of the entry. The claim is taken before the login, and the session can only be written after it.
+`LOGIN_SECONDS` is the one number to set: how long a row holds the claim. Put it above the time your login takes.
 
-Two settings control the wait, and they do different things:
+That single number also ends the wait. A row that takes the claim and then stops does not hold the others for good, because the claim expires and the next pass of a waiting row takes the name.
 
-| Setting | What it does |
-|---|---|
-| `CLAIM_TTL_SECONDS` | How long the claim holds the name. Set it above the time your login takes. |
-| `LOGIN_WAIT_TICKS` | How many seconds a waiting row gives the row that took the name before it logs in itself. Keep it above `CLAIM_TTL_SECONDS`. |
+Set it below your login time and the claim stops arbitrating: the name comes free while the first row is still logging in, so a second row takes it and logs in as well, and the last session written is the one the rows that follow read. Both sessions are valid, so the cost is extra logins, which is the result with no claim at all. The same applies when the cache itself cannot answer.
 
-A row that takes the claim and then stops does not hold the others for good. Its claim expires after `CLAIM_TTL_SECONDS`, the next tick of a waiting row takes the name, and that row does the work.
-
-Set `CLAIM_TTL_SECONDS` below your login time and the claim stops arbitrating: the name comes free while the first row is still logging in, so a second row takes it and logs in as well, and the last session written is the one the rows that follow read. Both sessions are valid, so the cost is extra logins, which is the result with no claim at all. The same applies when the cache itself cannot answer.
+The claim uses the entry's own name with `_CLAIM` after it, so there is no second name to pick. It has to be a separate entry: the claim is taken before the login, and the session can only be stored after it.
 
 ### Cache API
 
 ```python
 langwatch.cache.set("ACME_SESSION", session, ttl_seconds=840)
 langwatch.cache.get("ACME_SESSION", default=None)
-langwatch.cache.claim("ACME_LOGIN_CLAIM", "taken", ttl_seconds=60)
+langwatch.cache.claim("ACME_SESSION_CLAIM", "taken", ttl_seconds=15)
 langwatch.cache.delete("ACME_SESSION")
 ```
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -34964,9 +34964,16 @@ The rows that start at the same moment all read an empty cache, so without a cla
 
 Use a name for the claim that is not the name of the entry. The claim is taken before the login, and the session can only be written after it.
 
-`CLAIM_TTL_SECONDS` is what a row waits for before it takes the login itself. Set it above the time your login takes. A row that takes the claim and then stops does not hold the others for good: the claim expires, the next row takes it, and that row does the work.
+Two settings control the wait, and they do different things:
 
-Set it too low and the claim stops arbitrating: a login that runs longer than the claim's lifetime lets a second row take the name and log in as well, and the last session written is the one the rows that follow read. Both sessions are valid, so the cost is extra logins, which is the result with no claim at all. The same applies when the cache itself cannot answer.
+| Setting | What it does |
+|---|---|
+| `CLAIM_TTL_SECONDS` | How long the claim holds the name. Set it above the time your login takes. |
+| `LOGIN_WAIT_TICKS` | How many seconds a waiting row gives the row that took the name before it logs in itself. Keep it above `CLAIM_TTL_SECONDS`. |
+
+A row that takes the claim and then stops does not hold the others for good. Its claim expires after `CLAIM_TTL_SECONDS`, the next tick of a waiting row takes the name, and that row does the work.
+
+Set `CLAIM_TTL_SECONDS` below your login time and the claim stops arbitrating: the name comes free while the first row is still logging in, so a second row takes it and logs in as well, and the last session written is the one the rows that follow read. Both sessions are valid, so the cost is extra logins, which is the result with no claim at all. The same applies when the cache itself cannot answer.
 
 ### Cache API
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -34765,10 +34765,11 @@ This code is executed on every commit against the real runtime:
 #
 # Rows are isolated, so each one starts cold and a login on every row is the
 # default result. This agent keeps one session in the project's agent cache and
-# reads it back at the start of every row, so only the rows that start at the
-# same moment log in. A row that finds the target no longer accepts the stored
-# session logs in again and stores the new one, so a session the target ends
-# early costs one login rather than the run.
+# reads it back at the start of every row. The rows that start at the same
+# moment all read an empty cache, so one of them takes a claim and logs in
+# while the rest wait for what it stores. A row that finds the target no longer
+# accepts the stored session logs in again and stores the new one, so a session
+# the target ends early costs one login rather than the run.
 #
 # The platform gives the sandbox its own LangWatch credential, so there is no
 # setup call to write and no LangWatch secret to create. The runner injects
@@ -34777,13 +34778,17 @@ This code is executed on every commit against the real runtime:
 # returned.
 
 import sys
+import time
 
 import langwatch
 import requests
 
 SESSION_ENTRY_NAME = "ACME_SESSION"  # the cache entry that holds the session
-SESSION_TTL_SECONDS = 15 * 60  # what the target system promises
+LOGIN_CLAIM_NAME = "ACME_LOGIN_CLAIM"  # the name one row takes to log in
+SESSION_TTL_SECONDS = 15 * 60  # the lifetime the target system returns
 REFRESH_MARGIN_SECONDS = 60  # store it for less, so it is never sent stale
+CLAIM_TTL_SECONDS = 15  # a row that stops before it stores frees the name
+LOGIN_WAIT_TICKS = 20  # how long a row waits for the row that took the name
 REFUSED = object()  # the target would not accept the session this row sent
 
 
@@ -34793,7 +34798,7 @@ class Code:
         if reply is REFUSED:
             # The stored session is no longer one the target accepts. A target
             # ends a session whenever it likes: a restart, an operator closing
-            # it, a password change. The lifetime it promised is the most this
+            # it, a password change. The lifetime it returned is the most this
             # agent can assume, never a guarantee. So log in again and send
             # this row once more, which also stores the new session for the
             # rows that follow.
@@ -34822,15 +34827,50 @@ class Code:
 
 def get_session():
     """Return a session token. This is the one line each row calls."""
-    try:
-        stored = langwatch.cache.get(SESSION_ENTRY_NAME)
-    except Exception:  # noqa: BLE001 - a cache that cannot answer is a miss
-        report("could not be read", "this row logs in")
-        stored = None
+    stored = read_session()
     if stored:
         return stored
 
+    # A claim writes only when the name is free, so of the rows that read the
+    # empty cache together exactly one takes it and logs in. The rows that did
+    # not take it wait for the session that row stores, and claim again on
+    # every tick: a row that stops before it stores frees the name, and the
+    # next tick is where another row picks the work up.
+    for _ in range(LOGIN_WAIT_TICKS):
+        if take_the_login():
+            return renew_session()
+        time.sleep(1)
+        stored = read_session()
+        if stored:
+            return stored
+
+    # No row stored a session inside the window. This row logs in on its own,
+    # which is the result every row gets with no claim at all.
+    report("was not stored in time", "this row logs in")
     return renew_session()
+
+
+def read_session():
+    """Read the stored session. A cache that cannot answer reads as a miss."""
+    try:
+        return langwatch.cache.get(SESSION_ENTRY_NAME)
+    except Exception:  # noqa: BLE001 - a cache that cannot answer is a miss
+        report("could not be read", "this row logs in")
+        return None
+
+
+def take_the_login():
+    """Answer whether this row is the one that logs in.
+
+    A cache that cannot answer means every row logs in, which is the result
+    with no claim at all, so the row goes on rather than stopping.
+    """
+    try:
+        return langwatch.cache.claim(
+            LOGIN_CLAIM_NAME, "taken", ttl_seconds=CLAIM_TTL_SECONDS
+        )
+    except Exception:  # noqa: BLE001 - the row must still answer
+        return True
 
 
 def renew_session():
@@ -34858,9 +34898,9 @@ def login():
 
 def store_session(session):
     """Store the session for the rows that follow, for a little less than the
-    target system promises. A failure here does not fail the row: this row
-    holds a working session already, and the only cost is that the next row
-    logs in again."""
+    lifetime the target system returned. A failure here does not fail the row:
+    this row holds a working session already, and the only cost is that the
+    next row logs in again."""
     try:
         langwatch.cache.set(
             SESSION_ENTRY_NAME,
@@ -34912,7 +34952,7 @@ The agent also treats a `401` as an expired session: it logs in again and retrie
 ### Behavior
 
 - Each run logs in only once. Every later row reads the stored session from the cache.
-- When rows start at the same time, each one can find the cache empty and log in. Both sessions are valid and the last write wins. Keep the login idempotent on the target, lower the run's parallelism, or take a claim as shown below.
+- When rows start at the same time, one of them takes the claim and logs in. The rest wait and read the session it stores.
 - Entries belong to the project, not to a single run. A second run reuses the session the first run stored. If two concurrent runs write the same entry name, the last write wins. Use distinct names per agent (for example `BILLING_SESSION` and `SUPPORT_SESSION`) to avoid collisions.
 - If a read fails, the row treats it as a miss and logs in. If a write fails, the row still succeeds; only the next row has to log in again.
 
@@ -34920,39 +34960,13 @@ Source: [`shared_session_code_agent.py`](https://github.com/langwatch/langwatch/
 
 ### One login when rows start together
 
-The rows that start at the same moment all read an empty cache, so they all log in. To make one of them do it, take a claim on a second name first. A claim writes only if the project does not hold that name yet, and returns `True` for the row that took it and `False` for the rows that did not.
+The rows that start at the same moment all read an empty cache, so without a claim they all log in. The agent above takes a claim on a second name first. A claim writes only when the project does not hold that name yet, and answers `True` for the row that took it and `False` for the rows that did not, so one row logs in and the rest wait for the session it stores.
 
-Replace `get_session()` in the agent above with this:
+Use a name for the claim that is not the name of the entry. The claim is taken before the login, and the session can only be written after it.
 
-```python
-import time
+`CLAIM_TTL_SECONDS` is what a row waits for before it takes the login itself. Set it above the time your login takes. A row that takes the claim and then stops does not hold the others for good: the claim expires, the next row takes it, and that row does the work.
 
-LOGIN_CLAIM_NAME = "ACME_LOGIN_CLAIM"  # the name one row takes to log in
-CLAIM_TTL_SECONDS = 60  # a row that stops before it stores frees the name
-
-
-def get_session():
-    stored = langwatch.cache.get(SESSION_ENTRY_NAME)
-    if stored:
-        return stored
-
-    if langwatch.cache.claim(LOGIN_CLAIM_NAME, "taken", ttl_seconds=CLAIM_TTL_SECONDS):
-        return renew_session()
-
-    # Another row took the name and is logging in. Wait for what it stores.
-    for _ in range(CLAIM_TTL_SECONDS):
-        time.sleep(1)
-        stored = langwatch.cache.get(SESSION_ENTRY_NAME)
-        if stored:
-            return stored
-
-    # It did not finish in time, so this row logs in on its own.
-    return renew_session()
-```
-
-The last branch is what keeps the row answering: if the row that took the name stops before it stores a session, every other row logs in, which is the same result as no claim at all.
-
-Use a name for the claim that is not the name of the entry. The claim is taken before the login, and the entry can only be written after it.
+Set it too low and the claim stops arbitrating: a login that runs longer than the claim's lifetime lets a second row take the name and log in as well, and the last session written is the one the rows that follow read. Both sessions are valid, so the cost is extra logins, which is the result with no claim at all. The same applies when the cache itself cannot answer.
 
 ### Cache API
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -34912,21 +34912,58 @@ The agent also treats a `401` as an expired session: it logs in again and retrie
 ### Behavior
 
 - Each run logs in only once. Every later row reads the stored session from the cache.
-- When rows start at the same time, each one can find the cache empty and log in. Both sessions are valid and the last write wins. Keep the login idempotent on the target, or lower the run's parallelism.
+- When rows start at the same time, each one can find the cache empty and log in. Both sessions are valid and the last write wins. Keep the login idempotent on the target, lower the run's parallelism, or take a claim as shown below.
 - Entries belong to the project, not to a single run. A second run reuses the session the first run stored. If two concurrent runs write the same entry name, the last write wins. Use distinct names per agent (for example `BILLING_SESSION` and `SUPPORT_SESSION`) to avoid collisions.
 - If a read fails, the row treats it as a miss and logs in. If a write fails, the row still succeeds; only the next row has to log in again.
 
 Source: [`shared_session_code_agent.py`](https://github.com/langwatch/langwatch/blob/main/services/nlpgo/app/engine/blocks/codeblock/examples/shared_session_code_agent.py).
+
+### One login when rows start together
+
+The rows that start at the same moment all read an empty cache, so they all log in. To make one of them do it, take a claim on a second name first. A claim writes only if the project does not hold that name yet, and returns `True` for the row that took it and `False` for the rows that did not.
+
+Replace `get_session()` in the agent above with this:
+
+```python
+import time
+
+LOGIN_CLAIM_NAME = "ACME_LOGIN_CLAIM"  # the name one row takes to log in
+CLAIM_TTL_SECONDS = 60  # a row that stops before it stores frees the name
+
+
+def get_session():
+    stored = langwatch.cache.get(SESSION_ENTRY_NAME)
+    if stored:
+        return stored
+
+    if langwatch.cache.claim(LOGIN_CLAIM_NAME, "taken", ttl_seconds=CLAIM_TTL_SECONDS):
+        return renew_session()
+
+    # Another row took the name and is logging in. Wait for what it stores.
+    for _ in range(CLAIM_TTL_SECONDS):
+        time.sleep(1)
+        stored = langwatch.cache.get(SESSION_ENTRY_NAME)
+        if stored:
+            return stored
+
+    # It did not finish in time, so this row logs in on its own.
+    return renew_session()
+```
+
+The last branch is what keeps the row answering: if the row that took the name stops before it stores a session, every other row logs in, which is the same result as no claim at all.
+
+Use a name for the claim that is not the name of the entry. The claim is taken before the login, and the entry can only be written after it.
 
 ### Cache API
 
 ```python
 langwatch.cache.set("ACME_SESSION", session, ttl_seconds=840)
 langwatch.cache.get("ACME_SESSION", default=None)
+langwatch.cache.claim("ACME_LOGIN_CLAIM", "taken", ttl_seconds=60)
 langwatch.cache.delete("ACME_SESSION")
 ```
 
-`get` returns the default on a miss, so no `try`/`except` is needed for that case. Other errors raise.
+`get` returns the default on a miss, so no `try`/`except` is needed for that case. `claim` returns `True` when it stored the value and `False` when the name was already held, and does not raise for a name it could not take. Other errors raise.
 
 Also available over REST at [`/api/agent-cache/{name}`](/api-reference/agent-cache/get-entry).
 
@@ -65104,6 +65141,15 @@ The hybrid setup requires coordination with our team to configure the secure con
 
 ---
 
+# FILE: ./api-reference/agent-cache/claim-entry.mdx
+
+---
+title: "Claim a cache entry"
+openapi: "POST /api/agent-cache/{name}/claim"
+---
+
+---
+
 # FILE: ./api-reference/agent-cache/delete-entry.mdx
 
 ---
@@ -65140,6 +65186,10 @@ lifetime is between 5 seconds and 24 hours, and is 15 minutes when the request
 names none.
 
 There is no listing route: names come from the agent code that wrote them.
+
+A write replaces whatever the name held. To write only when the name is free,
+claim it instead: the claim route answers whether this caller is the one that
+took the name, which is how one row does work the rows beside it then reuse.
 
 Every route needs an API key that can manage the agent cache. A read returns the
 value, so a caller that can overwrite an entry can already choose what the next

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -935,6 +935,7 @@ For agents: if anything in these docs is wrong, confusing, or fails when you try
 - [Overview](https://langwatch.ai/docs/api-reference/agent-cache/overview.md): A per-project store an agent keeps its own run state in. Values are encrypted at rest and each entry expires by itself.
 - [Read a cache entry](https://langwatch.ai/docs/api-reference/agent-cache/get-entry.md)
 - [Store a cache entry](https://langwatch.ai/docs/api-reference/agent-cache/put-entry.md)
+- [Claim a cache entry](https://langwatch.ai/docs/api-reference/agent-cache/claim-entry.md)
 - [Remove a cache entry](https://langwatch.ai/docs/api-reference/agent-cache/delete-entry.md)
 
 ## Model Providers

--- a/platform/app/src/app/api/agent-cache/[[...route]]/app.ts
+++ b/platform/app/src/app/api/agent-cache/[[...route]]/app.ts
@@ -41,6 +41,12 @@ const cacheEntryWrittenSchema = z.object({
   ttl_seconds: z.number(),
 });
 
+const cacheEntryClaimedSchema = z.object({
+  name: z.string(),
+  claimed: z.boolean(),
+  ttl_seconds: z.number(),
+});
+
 const cacheEntryDeletedSchema = z.object({
   name: z.string(),
   deleted: z.boolean(),
@@ -156,6 +162,45 @@ secured.access(requires("agentCache:manage")).put(
       ttlSeconds: body.ttl_seconds,
     });
     return c.json(written);
+  },
+);
+
+secured.access(requires("agentCache:manage")).post(
+  "/:name/claim",
+  describeRoute({
+    description: [
+      "Store a value under a name only if the project does not hold that name yet.",
+      "The answer says whether this caller is the one that took it: `claimed` is true when the value was written, and false when the name was already held, which leaves the held value alone.",
+      "Losing is an ordinary answer and not a refusal, so a caller branches on `claimed` rather than on an error.",
+      "This is what one row of a run uses to do work the rows beside it then reuse, instead of every row doing it at once.",
+      `The value is encrypted at rest and expires by itself after ttl_seconds, which defaults to ${DEFAULT_TTL_SECONDS} seconds.`,
+    ].join(" "),
+    responses: {
+      ...canonicalBaseResponses,
+      200: {
+        description: "Claim resolved, taken or not",
+        content: {
+          "application/json": {
+            schema: resolver(cacheEntryClaimedSchema),
+          },
+        },
+      },
+    },
+  }),
+  zValidator("param", nameParamSchema),
+  zValidator("json", putEntrySchema),
+  async (c) => {
+    const project = c.get("project");
+    const { name } = c.req.valid("param");
+    const body = c.req.valid("json");
+
+    const outcome = await agentCacheService.claim({
+      projectId: project.id,
+      name,
+      value: body.value,
+      ttlSeconds: body.ttl_seconds,
+    });
+    return c.json(outcome);
   },
 );
 

--- a/platform/app/src/app/api/agent-cache/__tests__/agent-cache.integration.test.ts
+++ b/platform/app/src/app/api/agent-cache/__tests__/agent-cache.integration.test.ts
@@ -65,6 +65,17 @@ describe("Feature: the agent cache", () => {
       body: JSON.stringify(body),
     });
 
+  const claimEntry = (
+    name: string,
+    token: string,
+    body: Record<string, unknown>,
+  ) =>
+    app.request(`/api/agent-cache/${name}/claim`, {
+      method: "POST",
+      headers: { ...headersFor(token), "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+
   const removeEntry = (name: string, token: string) =>
     app.request(`/api/agent-cache/${name}`, {
       method: "DELETE",
@@ -275,6 +286,92 @@ describe("Feature: the agent cache", () => {
           ttl_seconds: 1,
         });
         expect(res.status).toBe(400);
+      });
+    });
+  });
+
+  describe("given a caller that takes a name with a claim", () => {
+    describe("when the project holds no entry under that name", () => {
+      /** @scenario "A claim on a free name is taken" */
+      it("takes the name and stores the value", async () => {
+        const res = await claimEntry("ACME_CLAIM_FREE", manageToken, {
+          value: "won-it",
+        });
+        expect(res.status).toBe(200);
+        expect((await res.json()) as unknown).toMatchObject({
+          name: "ACME_CLAIM_FREE",
+          claimed: true,
+        });
+
+        const read = await readEntry("ACME_CLAIM_FREE", manageToken);
+        expect(((await read.json()) as { value: string }).value).toBe("won-it");
+      });
+    });
+
+    describe("when the project already holds that name", () => {
+      /** @scenario "A claim on a held name leaves the held value alone" */
+      it("does not take the name and leaves the held value alone", async () => {
+        await writeEntry("ACME_CLAIM_HELD", manageToken, { value: "first" });
+
+        const res = await claimEntry("ACME_CLAIM_HELD", manageToken, {
+          value: "second",
+        });
+        expect(res.status).toBe(200);
+        expect(((await res.json()) as { claimed: boolean }).claimed).toBe(
+          false,
+        );
+
+        const read = await readEntry("ACME_CLAIM_HELD", manageToken);
+        expect(((await read.json()) as { value: string }).value).toBe("first");
+      });
+    });
+
+    describe("when the claimed entry's lifetime passes", () => {
+      /** @scenario "A name is free again once its lifetime passes" */
+      it("lets the next caller take the name", async () => {
+        const first = await claimEntry("ACME_CLAIM_BRIEF", manageToken, {
+          value: "gone-soon",
+          ttl_seconds: 5,
+        });
+        expect(((await first.json()) as { claimed: boolean }).claimed).toBe(
+          true,
+        );
+
+        // The route floor is 5 seconds, so waiting past it is the only way to
+        // observe the name coming free again.
+        await sleep(5_100);
+
+        const second = await claimEntry("ACME_CLAIM_BRIEF", manageToken, {
+          value: "the-next-one",
+        });
+        expect(((await second.json()) as { claimed: boolean }).claimed).toBe(
+          true,
+        );
+      }, 15_000);
+    });
+
+    describe("when several callers claim the same name at once", () => {
+      /** @scenario "Only one of several claims sent at once takes the name" */
+      it("takes the name exactly once", async () => {
+        const responses = await Promise.all(
+          Array.from({ length: 8 }, (_, index) =>
+            claimEntry("ACME_CLAIM_RACE", manageToken, {
+              value: `row-${index}`,
+            }),
+          ),
+        );
+
+        const outcomes = await Promise.all(
+          responses.map((res) => res.json() as Promise<{ claimed: boolean }>),
+        );
+        const winners = outcomes.filter((outcome) => outcome.claimed);
+        expect(winners).toHaveLength(1);
+
+        const winnerIndex = outcomes.findIndex((outcome) => outcome.claimed);
+        const read = await readEntry("ACME_CLAIM_RACE", manageToken);
+        expect(((await read.json()) as { value: string }).value).toBe(
+          `row-${winnerIndex}`,
+        );
       });
     });
   });

--- a/platform/app/src/app/api/agent-cache/agent-cache.repository.ts
+++ b/platform/app/src/app/api/agent-cache/agent-cache.repository.ts
@@ -56,6 +56,28 @@ export class AgentCacheRepository {
     await this.cache.set(this.key({ projectId, name }), encryptedValue, ttlMs);
   }
 
+  /**
+   * Write only when the project holds no live entry under this name.
+   * Answers whether this caller is the one that took it.
+   */
+  async claim({
+    projectId,
+    name,
+    encryptedValue,
+    ttlMs,
+  }: {
+    projectId: string;
+    name: string;
+    encryptedValue: string;
+    ttlMs: number;
+  }): Promise<boolean> {
+    return this.cache.claim(
+      this.key({ projectId, name }),
+      encryptedValue,
+      ttlMs,
+    );
+  }
+
   async delete({
     projectId,
     name,

--- a/platform/app/src/app/api/agent-cache/agent-cache.service.ts
+++ b/platform/app/src/app/api/agent-cache/agent-cache.service.ts
@@ -86,6 +86,37 @@ export class AgentCacheService {
     return { name, ttl_seconds: lifetimeSeconds };
   }
 
+  /**
+   * Take a name, but only if the project does not hold it yet.
+   *
+   * This is what one row uses to do work the other rows then reuse. Losing is
+   * an ordinary answer rather than a refusal: the caller reads `claimed` and
+   * either does the work or reads back what the winner stored, so agent code
+   * branches on a boolean instead of catching an exception.
+   */
+  async claim({
+    projectId,
+    name,
+    value,
+    ttlSeconds,
+  }: {
+    projectId: string;
+    name: string;
+    value: string;
+    ttlSeconds?: number;
+  }): Promise<{ name: string; claimed: boolean; ttl_seconds: number }> {
+    const lifetimeSeconds = ttlSeconds ?? DEFAULT_TTL_SECONDS;
+
+    const claimed = await this.repository.claim({
+      projectId,
+      name,
+      encryptedValue: encrypt(value),
+      ttlMs: lifetimeSeconds * 1000,
+    });
+
+    return { name, claimed, ttl_seconds: lifetimeSeconds };
+  }
+
   /** Idempotent: a name the project does not hold deletes nothing and is not
    * an error, so a caller can clear an entry without reading it first. */
   async delete({

--- a/platform/app/src/app/api/openapiLangWatch.json
+++ b/platform/app/src/app/api/openapiLangWatch.json
@@ -2071,6 +2071,258 @@
         ]
       }
     },
+    "/api/agent-cache/{name}/claim": {
+      "post": {
+        "operationId": "postApiAgentCacheByNameClaim",
+        "description": "Store a value under a name only if the project does not hold that name yet. The answer says whether this caller is the one that took it: `claimed` is true when the value was written, and false when the name was already held, which leaves the held value alone. Losing is an ordinary answer and not a refusal, so a caller branches on `claimed` rather than on an error. This is what one row of a run uses to do work the rows beside it then reuse, instead of every row doing it at once. The value is encrypted at rest and expires by itself after ttl_seconds, which defaults to 900 seconds.",
+        "responses": {
+          "200": {
+            "description": "Claim resolved, taken or not",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "claimed": {
+                      "type": "boolean"
+                    },
+                    "ttl_seconds": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "claimed",
+                    "ttl_seconds"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string"
+                        },
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "meta": {
+                          "type": "object",
+                          "additionalProperties": {}
+                        },
+                        "trace_id": {
+                          "type": "string"
+                        },
+                        "span_id": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "code",
+                        "message"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string"
+                        },
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "meta": {
+                          "type": "object",
+                          "additionalProperties": {}
+                        },
+                        "trace_id": {
+                          "type": "string"
+                        },
+                        "span_id": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "code",
+                        "message"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string"
+                        },
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "meta": {
+                          "type": "object",
+                          "additionalProperties": {}
+                        },
+                        "trace_id": {
+                          "type": "string"
+                        },
+                        "span_id": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "code",
+                        "message"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string"
+                        },
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "meta": {
+                          "type": "object",
+                          "additionalProperties": {}
+                        },
+                        "trace_id": {
+                          "type": "string"
+                        },
+                        "span_id": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "code",
+                        "message"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "in": "path",
+            "name": "name",
+            "schema": {
+              "type": "string",
+              "pattern": "^[A-Z][A-Z0-9_]*$",
+              "minLength": 1,
+              "maxLength": 64
+            },
+            "required": true
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "value": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "ttl_seconds": {
+                    "type": "integer",
+                    "minimum": 5,
+                    "maximum": 86400
+                  }
+                },
+                "required": [
+                  "value"
+                ]
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "project_api_key": []
+          }
+        ]
+      }
+    },
     "/api/agents": {
       "get": {
         "operationId": "getApiAgents",

--- a/platform/app/src/server/utils/__tests__/ttlCache.unit.test.ts
+++ b/platform/app/src/server/utils/__tests__/ttlCache.unit.test.ts
@@ -144,20 +144,40 @@ describe("TtlCache", () => {
         "NX",
       );
     });
+
+    it("carries the lifetime the caller named, not the cache's own", async () => {
+      const cache = new TtlCache<boolean>(60_000, "test:");
+
+      await cache.claim("lock1", true, 30_000);
+
+      expect(mockRedis.set).toHaveBeenCalledWith(
+        "test:lock1",
+        JSON.stringify(true),
+        "EX",
+        30,
+        "NX",
+      );
+    });
   });
 
   describe("when Redis fails on claim", () => {
-    it("falls back to in-memory claim", async () => {
+    /** @scenario "A claim the store cannot answer raises rather than naming a winner" */
+    it("raises rather than naming this caller the winner", async () => {
       const cache = new TtlCache<boolean>(30_000, "test:");
       mockRedis.set.mockRejectedValueOnce(new Error("connection reset"));
 
-      const result = await cache.claim("lock1", true);
+      // A read and a write fall back to memory here, and the worst that
+      // costs is a stale answer. A claim that fell back the same way would
+      // name one winner per process, which is the one outcome it exists to
+      // prevent, so it refuses instead and the caller decides.
+      await expect(cache.claim("lock1", true)).rejects.toThrow(
+        "connection reset",
+      );
 
-      expect(result).toBe(true);
-
-      // Redis also fails on get, so memory fallback is used
+      // Nothing was recorded, so no later read finds a key this process
+      // alone believes it holds.
       mockRedis.get.mockRejectedValueOnce(new Error("connection reset"));
-      expect(await cache.get("lock1")).toBe(true);
+      expect(await cache.get("lock1")).toBeUndefined();
     });
   });
 
@@ -227,6 +247,25 @@ describe("TtlCache", () => {
       await cache.delete("key1");
 
       expect(await cache.get("key1")).toBeUndefined();
+    });
+
+    // With no connection the memory map is the whole cache, so a claim
+    // inside the one process is atomic and answers rather than refusing.
+    it("claims in memory, and takes a key only once", async () => {
+      const cache = new TtlCache<boolean>(30_000, "test:");
+
+      expect(await cache.claim("lock1", true)).toBe(true);
+      expect(await cache.claim("lock1", true)).toBe(false);
+      expect(mockRedis.set).not.toHaveBeenCalled();
+    });
+
+    it("frees a claimed key once its lifetime passes", async () => {
+      const cache = new TtlCache<boolean>(30_000, "test:");
+
+      expect(await cache.claim("lock1", true, 50)).toBe(true);
+      await new Promise((r) => setTimeout(r, 60));
+
+      expect(await cache.claim("lock1", true)).toBe(true);
     });
   });
 });

--- a/platform/app/src/server/utils/ttlCache.ts
+++ b/platform/app/src/server/utils/ttlCache.ts
@@ -77,8 +77,14 @@ export class TtlCache<T> {
   /**
    * Atomically set `key` only if it does not already exist (Redis SET NX EX).
    * Returns `true` if this call claimed the key, `false` if it was already taken.
+   *
+   * `ttlMs` overrides the cache's own lifetime for this entry only, the same
+   * way `set` takes one, so a caller that knows how long its value stays good
+   * says so on the call that writes it.
    */
-  async claim(key: string, value: T): Promise<boolean> {
+  async claim(key: string, value: T, ttlMs?: number): Promise<boolean> {
+    const lifetimeMs = ttlMs ?? this.ttlMs;
+
     const r = this.redis;
     if (r) {
       try {
@@ -86,11 +92,11 @@ export class TtlCache<T> {
           `${this.prefix}${key}`,
           JSON.stringify(value),
           "EX",
-          this.ttlSeconds,
+          Math.ceil(lifetimeMs / 1000),
           "NX",
         );
         if (result === "OK") {
-          this.memory.set(key, { value, expiresAt: Date.now() + this.ttlMs });
+          this.memory.set(key, { value, expiresAt: Date.now() + lifetimeMs });
           return true;
         }
         return false;
@@ -100,7 +106,7 @@ export class TtlCache<T> {
     }
 
     if (this.memoryGet(key) !== undefined) return false;
-    this.memory.set(key, { value, expiresAt: Date.now() + this.ttlMs });
+    this.memory.set(key, { value, expiresAt: Date.now() + lifetimeMs });
     return true;
   }
 

--- a/platform/app/src/server/utils/ttlCache.ts
+++ b/platform/app/src/server/utils/ttlCache.ts
@@ -81,28 +81,35 @@ export class TtlCache<T> {
    * `ttlMs` overrides the cache's own lifetime for this entry only, the same
    * way `set` takes one, so a caller that knows how long its value stays good
    * says so on the call that writes it.
+   *
+   * This is the one method that does NOT fall back to memory on a Redis
+   * error. Every other method degrades to a per-process answer that is at
+   * worst stale; a claim that degrades that way hands `true` to one caller
+   * per process and produces exactly the several winners it exists to
+   * prevent. So a configured Redis that cannot answer raises, and the caller
+   * decides: the agent cache's own caller treats it as "nothing arbitrated
+   * this, so do the work", which is the result with no claim at all.
+   *
+   * With no Redis configured the memory map IS the cache, the same as it is
+   * for `get` and `set`, and a claim inside one process is atomic.
    */
   async claim(key: string, value: T, ttlMs?: number): Promise<boolean> {
     const lifetimeMs = ttlMs ?? this.ttlMs;
 
     const r = this.redis;
     if (r) {
-      try {
-        const result = await r.set(
-          `${this.prefix}${key}`,
-          JSON.stringify(value),
-          "EX",
-          Math.ceil(lifetimeMs / 1000),
-          "NX",
-        );
-        if (result === "OK") {
-          this.memory.set(key, { value, expiresAt: Date.now() + lifetimeMs });
-          return true;
-        }
-        return false;
-      } catch {
-        // Redis failed, fall through to memory
+      const result = await r.set(
+        `${this.prefix}${key}`,
+        JSON.stringify(value),
+        "EX",
+        Math.ceil(lifetimeMs / 1000),
+        "NX",
+      );
+      if (result === "OK") {
+        this.memory.set(key, { value, expiresAt: Date.now() + lifetimeMs });
+        return true;
       }
+      return false;
     }
 
     if (this.memoryGet(key) !== undefined) return false;

--- a/sdks/python/src/langwatch/cache.py
+++ b/sdks/python/src/langwatch/cache.py
@@ -109,6 +109,35 @@ class CacheFacade:
         _raise_for_status(response)
         return response.json()
 
+    def claim(self, name: str, value: str, ttl_seconds: Optional[int] = None) -> bool:
+        """
+        Take a name, but only if the project does not hold it yet.
+
+        Answers True when this call stored the value, and False when the name
+        was already held, which leaves the held value alone. Losing is an
+        ordinary answer rather than a refusal, so the calling code reads a
+        boolean instead of catching an exception.
+
+        Rows that start together all read an empty cache and all do the work
+        the entry was meant to save. This is how one row does that work while
+        the rows beside it wait and then read what it stored.
+
+        Args:
+            name: Entry name (UPPER_SNAKE_CASE).
+            value: What to store. It is encrypted server-side.
+            ttl_seconds: How long the entry stays readable. The project's
+                default applies when this is not given.
+        """
+        body: Dict[str, Any] = {"value": value}
+        if ttl_seconds is not None:
+            body["ttl_seconds"] = ttl_seconds
+
+        response = self._http().post(
+            f"/api/agent-cache/{_quote(name)}/claim", json=body
+        )
+        _raise_for_status(response)
+        return bool(response.json()["claimed"])
+
     def delete(self, name: str) -> Dict[str, Any]:
         """Remove an entry. A name the project does not hold is not an error."""
         response = self._http().delete(f"/api/agent-cache/{_quote(name)}")

--- a/sdks/python/tests/test_cache_facade.py
+++ b/sdks/python/tests/test_cache_facade.py
@@ -54,8 +54,22 @@ class CacheStub:
                 },
             )
 
-        name = path.removeprefix("/api/agent-cache/")
+        name = path.removeprefix("/api/agent-cache/").removesuffix("/claim")
         body: Dict[str, Any] = json.loads(request.content) if request.content else {}
+
+        if request.method == "POST" and path.endswith("/claim"):
+            claimed = name not in self.stored
+            if claimed:
+                self.stored[name] = body["value"]
+                self.written_ttls.append(body.get("ttl_seconds"))
+            return httpx.Response(
+                200,
+                json={
+                    "name": name,
+                    "claimed": claimed,
+                    "ttl_seconds": body.get("ttl_seconds", 900),
+                },
+            )
 
         if request.method == "GET":
             if name not in self.stored:
@@ -135,6 +149,29 @@ class TestSet:
         facade_over(stub).set("ACME_SESSION", "second")
 
         assert stub.stored == {"ACME_SESSION": "second"}
+
+
+class TestClaim:
+    def test_takes_a_name_the_project_does_not_hold(self):
+        stub = CacheStub()
+
+        assert facade_over(stub).claim("ACME_SESSION", "session-1") is True
+        assert stub.stored == {"ACME_SESSION": "session-1"}
+        assert ("POST", "/api/agent-cache/ACME_SESSION/claim") in stub.calls
+
+    # @scenario "The SDK answers a lost claim with false"
+    def test_answers_false_when_the_name_is_already_held(self):
+        stub = CacheStub(stored={"ACME_SESSION": "first"})
+
+        assert facade_over(stub).claim("ACME_SESSION", "second") is False
+        assert stub.stored == {"ACME_SESSION": "first"}
+
+    def test_carries_the_lifetime_the_caller_named(self):
+        stub = CacheStub()
+
+        facade_over(stub).claim("ACME_SESSION", "session-1", ttl_seconds=840)
+
+        assert stub.written_ttls == [840]
 
 
 class TestDelete:

--- a/sdks/typescript/src/internal/generated/openapi/api-client.ts
+++ b/sdks/typescript/src/internal/generated/openapi/api-client.ts
@@ -669,6 +669,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/agent-cache/{name}/claim": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** @description Store a value under a name only if the project does not hold that name yet. The answer says whether this caller is the one that took it: `claimed` is true when the value was written, and false when the name was already held, which leaves the held value alone. Losing is an ordinary answer and not a refusal, so a caller branches on `claimed` rather than on an error. This is what one row of a run uses to do work the rows beside it then reuse, instead of every row doing it at once. The value is encrypted at rest and expires by itself after ttl_seconds, which defaults to 900 seconds. */
+        post: operations["postApiAgentCacheByNameClaim"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/agents": {
         parameters: {
             query?: never;
@@ -4557,6 +4574,119 @@ export interface operations {
                     "application/json": {
                         name: string;
                         deleted: boolean;
+                    };
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: {
+                            type: string;
+                            code: string;
+                            message: string;
+                            meta?: {
+                                [key: string]: unknown;
+                            };
+                            trace_id?: string;
+                            span_id?: string;
+                        };
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: {
+                            type: string;
+                            code: string;
+                            message: string;
+                            meta?: {
+                                [key: string]: unknown;
+                            };
+                            trace_id?: string;
+                            span_id?: string;
+                        };
+                    };
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: {
+                            type: string;
+                            code: string;
+                            message: string;
+                            meta?: {
+                                [key: string]: unknown;
+                            };
+                            trace_id?: string;
+                            span_id?: string;
+                        };
+                    };
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: {
+                            type: string;
+                            code: string;
+                            message: string;
+                            meta?: {
+                                [key: string]: unknown;
+                            };
+                            trace_id?: string;
+                            span_id?: string;
+                        };
+                    };
+                };
+            };
+        };
+    };
+    postApiAgentCacheByNameClaim: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                name: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    value: string;
+                    ttl_seconds?: number;
+                };
+            };
+        };
+        responses: {
+            /** @description Claim resolved, taken or not */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        name: string;
+                        claimed: boolean;
+                        ttl_seconds: number;
                     };
                 };
             };

--- a/services/nlpgo/app/engine/blocks/codeblock/examples/shared_session_code_agent.py
+++ b/services/nlpgo/app/engine/blocks/codeblock/examples/shared_session_code_agent.py
@@ -1,12 +1,9 @@
 # Log in once and share the session across the rows of a run.
 #
-# Rows are isolated, so each one starts cold and a login on every row is the
-# default result. This agent keeps one session in the project's agent cache and
-# reads it back at the start of every row. The rows that start at the same
-# moment all read an empty cache, so one of them takes a claim and logs in
-# while the rest wait for what it stores. A row that finds the target no longer
-# accepts the stored session logs in again and stores the new one, so a session
-# the target ends early costs one login rather than the run.
+# Rows are isolated, so each one starts cold and logs in on its own. This agent
+# keeps the session in the project's agent cache. Of the rows that start
+# together, one takes the claim and logs in while the rest wait for what it
+# stores. A row the target refuses logs in again and stores the new session.
 #
 # The platform gives the sandbox its own LangWatch credential, so there is no
 # setup call to write and no LangWatch secret to create. The runner injects
@@ -20,31 +17,23 @@ import time
 import langwatch
 import requests
 
-SESSION_ENTRY_NAME = "ACME_SESSION"  # the cache entry that holds the session
-LOGIN_CLAIM_NAME = "ACME_LOGIN_CLAIM"  # the name one row takes to log in
-SESSION_TTL_SECONDS = 15 * 60  # the lifetime the target system returns
-REFRESH_MARGIN_SECONDS = 60  # store it for less, so it is never sent stale
-CLAIM_TTL_SECONDS = 15  # a row that stops before it stores frees the name
-LOGIN_WAIT_TICKS = 20  # how long a row waits for the row that took the name
-REFUSED = object()  # the target would not accept the session this row sent
+SESSION_NAME = "ACME_SESSION"  # the cache entry, and the claim that guards it
+SESSION_TTL_SECONDS = 14 * 60  # under what the target gives, so it is never stale
+LOGIN_SECONDS = 15  # over what a login takes: how long one row holds the claim
+REFUSED = object()
 
 
 class Code:
     def __call__(self, message: str):
         reply = self.ask(message, get_session())
         if reply is REFUSED:
-            # The stored session is no longer one the target accepts. A target
-            # ends a session whenever it likes: a restart, an operator closing
-            # it, a password change. The lifetime it returned is the most this
-            # agent can assume, never a guarantee. So log in again and send
-            # this row once more, which also stores the new session for the
-            # rows that follow.
+            # A target ends a session whenever it likes: a restart, an operator
+            # closing it, a password change. The lifetime it returned is the
+            # most this agent can assume, so a refusal costs one login.
             report("was refused", "this row logs in again")
             reply = self.ask(message, renew_session())
             if reply is REFUSED:
-                raise RuntimeError(
-                    "ACME refused a session this row obtained a moment ago."
-                )
+                raise RuntimeError("ACME refused a session obtained a moment ago.")
         return {"output": reply}
 
     def ask(self, message, session):
@@ -63,55 +52,46 @@ class Code:
 
 
 def get_session():
-    """Return a session token. This is the one line each row calls."""
-    stored = read_session()
-    if stored:
-        return stored
+    """Return a session, stored by another row or obtained by this one.
 
-    # A claim writes only when the name is free, so of the rows that read the
-    # empty cache together exactly one takes it and logs in. The rows that did
-    # not take it wait for the session that row stores, and claim again on
-    # every tick: a row that stops before it stores frees the name, and the
-    # next tick is where another row picks the work up.
-    for _ in range(LOGIN_WAIT_TICKS):
-        if take_the_login():
-            return renew_session()
-        time.sleep(1)
+    The loop always ends: either a session appears, or the claim comes free.
+    A row that takes the claim and then stops frees it after LOGIN_SECONDS,
+    and the next pass is where another row picks the work up.
+    """
+    while True:
         stored = read_session()
         if stored:
             return stored
-
-    # No row stored a session inside the window. This row logs in on its own,
-    # which is the result every row gets with no claim at all.
-    report("was not stored in time", "this row logs in")
-    return renew_session()
+        if take_the_login():
+            return renew_session()
+        time.sleep(1)
 
 
 def read_session():
-    """Read the stored session. A cache that cannot answer reads as a miss."""
+    """The stored session, or None. A cache that cannot answer is a miss."""
     try:
-        return langwatch.cache.get(SESSION_ENTRY_NAME)
-    except Exception:  # noqa: BLE001 - a cache that cannot answer is a miss
+        return langwatch.cache.get(SESSION_NAME)
+    except Exception:  # noqa: BLE001 - the row must still answer
         report("could not be read", "this row logs in")
         return None
 
 
 def take_the_login():
-    """Answer whether this row is the one that logs in.
+    """Whether this row is the one that logs in.
 
     A cache that cannot answer means every row logs in, which is the result
     with no claim at all, so the row goes on rather than stopping.
     """
     try:
         return langwatch.cache.claim(
-            LOGIN_CLAIM_NAME, "taken", ttl_seconds=CLAIM_TTL_SECONDS
+            f"{SESSION_NAME}_CLAIM", "taken", ttl_seconds=LOGIN_SECONDS
         )
     except Exception:  # noqa: BLE001 - the row must still answer
         return True
 
 
 def renew_session():
-    """Log in and store the session, for this row and the rows that follow."""
+    """Log in, and store the session for the rows that follow."""
     session = login()
     store_session(session)
     return session
@@ -134,27 +114,19 @@ def login():
 
 
 def store_session(session):
-    """Store the session for the rows that follow, for a little less than the
-    lifetime the target system returned. A failure here does not fail the row:
-    this row holds a working session already, and the only cost is that the
-    next row logs in again."""
+    """Store it for the rows that follow. A failure here costs the next row a
+    login, never this row's answer."""
     try:
-        langwatch.cache.set(
-            SESSION_ENTRY_NAME,
-            session,
-            ttl_seconds=SESSION_TTL_SECONDS - REFRESH_MARGIN_SECONDS,
-        )
+        langwatch.cache.set(SESSION_NAME, session, ttl_seconds=SESSION_TTL_SECONDS)
     except Exception:  # noqa: BLE001 - the row must still answer
         report("could not be stored", "the next row will log in again")
 
 
 def report(state, consequence):
-    """Say on stderr what the cache did, in this agent's own words.
-
-    Nothing from the exception reaches the output. An error message can quote
-    the credential that caused it, and a run shows stderr.
-    """
-    print(f"{SESSION_ENTRY_NAME} {state}, {consequence}", file=sys.stderr)
+    """Say on stderr what the cache did, in this agent's own fixed words. An
+    exception text can quote the credential that caused it, and a run shows
+    what it printed."""
+    print(f"{SESSION_NAME} {state}, {consequence}", file=sys.stderr)
 
 
 def secret(name):

--- a/services/nlpgo/app/engine/blocks/codeblock/examples/shared_session_code_agent.py
+++ b/services/nlpgo/app/engine/blocks/codeblock/examples/shared_session_code_agent.py
@@ -2,10 +2,11 @@
 #
 # Rows are isolated, so each one starts cold and a login on every row is the
 # default result. This agent keeps one session in the project's agent cache and
-# reads it back at the start of every row, so only the rows that start at the
-# same moment log in. A row that finds the target no longer accepts the stored
-# session logs in again and stores the new one, so a session the target ends
-# early costs one login rather than the run.
+# reads it back at the start of every row. The rows that start at the same
+# moment all read an empty cache, so one of them takes a claim and logs in
+# while the rest wait for what it stores. A row that finds the target no longer
+# accepts the stored session logs in again and stores the new one, so a session
+# the target ends early costs one login rather than the run.
 #
 # The platform gives the sandbox its own LangWatch credential, so there is no
 # setup call to write and no LangWatch secret to create. The runner injects
@@ -14,13 +15,17 @@
 # returned.
 
 import sys
+import time
 
 import langwatch
 import requests
 
 SESSION_ENTRY_NAME = "ACME_SESSION"  # the cache entry that holds the session
-SESSION_TTL_SECONDS = 15 * 60  # what the target system promises
+LOGIN_CLAIM_NAME = "ACME_LOGIN_CLAIM"  # the name one row takes to log in
+SESSION_TTL_SECONDS = 15 * 60  # the lifetime the target system returns
 REFRESH_MARGIN_SECONDS = 60  # store it for less, so it is never sent stale
+CLAIM_TTL_SECONDS = 15  # a row that stops before it stores frees the name
+LOGIN_WAIT_TICKS = 20  # how long a row waits for the row that took the name
 REFUSED = object()  # the target would not accept the session this row sent
 
 
@@ -30,7 +35,7 @@ class Code:
         if reply is REFUSED:
             # The stored session is no longer one the target accepts. A target
             # ends a session whenever it likes: a restart, an operator closing
-            # it, a password change. The lifetime it promised is the most this
+            # it, a password change. The lifetime it returned is the most this
             # agent can assume, never a guarantee. So log in again and send
             # this row once more, which also stores the new session for the
             # rows that follow.
@@ -59,15 +64,50 @@ class Code:
 
 def get_session():
     """Return a session token. This is the one line each row calls."""
-    try:
-        stored = langwatch.cache.get(SESSION_ENTRY_NAME)
-    except Exception:  # noqa: BLE001 - a cache that cannot answer is a miss
-        report("could not be read", "this row logs in")
-        stored = None
+    stored = read_session()
     if stored:
         return stored
 
+    # A claim writes only when the name is free, so of the rows that read the
+    # empty cache together exactly one takes it and logs in. The rows that did
+    # not take it wait for the session that row stores, and claim again on
+    # every tick: a row that stops before it stores frees the name, and the
+    # next tick is where another row picks the work up.
+    for _ in range(LOGIN_WAIT_TICKS):
+        if take_the_login():
+            return renew_session()
+        time.sleep(1)
+        stored = read_session()
+        if stored:
+            return stored
+
+    # No row stored a session inside the window. This row logs in on its own,
+    # which is the result every row gets with no claim at all.
+    report("was not stored in time", "this row logs in")
     return renew_session()
+
+
+def read_session():
+    """Read the stored session. A cache that cannot answer reads as a miss."""
+    try:
+        return langwatch.cache.get(SESSION_ENTRY_NAME)
+    except Exception:  # noqa: BLE001 - a cache that cannot answer is a miss
+        report("could not be read", "this row logs in")
+        return None
+
+
+def take_the_login():
+    """Answer whether this row is the one that logs in.
+
+    A cache that cannot answer means every row logs in, which is the result
+    with no claim at all, so the row goes on rather than stopping.
+    """
+    try:
+        return langwatch.cache.claim(
+            LOGIN_CLAIM_NAME, "taken", ttl_seconds=CLAIM_TTL_SECONDS
+        )
+    except Exception:  # noqa: BLE001 - the row must still answer
+        return True
 
 
 def renew_session():
@@ -95,9 +135,9 @@ def login():
 
 def store_session(session):
     """Store the session for the rows that follow, for a little less than the
-    target system promises. A failure here does not fail the row: this row
-    holds a working session already, and the only cost is that the next row
-    logs in again."""
+    lifetime the target system returned. A failure here does not fail the row:
+    this row holds a working session already, and the only cost is that the
+    next row logs in again."""
     try:
         langwatch.cache.set(
             SESSION_ENTRY_NAME,

--- a/services/nlpgo/app/engine/blocks/codeblock/shared_session_example_test.go
+++ b/services/nlpgo/app/engine/blocks/codeblock/shared_session_example_test.go
@@ -197,6 +197,47 @@ func TestSharedSessionCodeAgent_RowsThatStartTogetherLogInOnce(t *testing.T) {
 	}
 }
 
+// @scenario "Rows that start together log in once when the login is slow"
+//
+// The claim only earns its keep while a login is in flight, and a login that
+// answers instantly barely opens that window. Here it takes three seconds,
+// which is inside the lifetime the example gives the claim, so the rows beside
+// the winner wait through it rather than logging in themselves.
+func TestSharedSessionCodeAgent_RowsThatStartTogetherLogInOnceOnASlowLogin(t *testing.T) {
+	const rows = 4
+
+	stubs := newSharedSessionStubs(t, "p4ssw0rd")
+	stubs.loginDelay = 3 * time.Second
+	code := loadSharedSessionExample(t)
+
+	executor := sharedSessionExec(t, stubs.cacheServer.URL)
+	results := make([]*codeblock.Result, rows)
+	errs := make([]error, rows)
+	var wg sync.WaitGroup
+	wg.Add(rows)
+	for i := range results {
+		go func(index int) {
+			defer wg.Done()
+			results[index], errs[index] = executor.Execute(
+				context.Background(), stubs.rowRequest(code))
+		}(i)
+	}
+	wg.Wait()
+
+	for i := range results {
+		require.NoError(t, errs[i], "row %d", i)
+		require.Nil(t, results[i].Error, "row %d: %+v", i, results[i].Error)
+	}
+
+	assert.Equal(t, 1, stubs.loginCount(),
+		"the rows beside the winner wait out the login rather than repeating it")
+	assert.Equal(t, 1, stubs.claimsTaken())
+	require.Len(t, stubs.apiSessions, rows)
+	for _, presented := range stubs.apiSessions {
+		assert.Equal(t, "session-1", presented)
+	}
+}
+
 // @scenario "A row logs in itself when the row that took the login stores nothing"
 //
 // A claim that is never followed by a write would otherwise hold every other

--- a/services/nlpgo/app/engine/blocks/codeblock/shared_session_example_test.go
+++ b/services/nlpgo/app/engine/blocks/codeblock/shared_session_example_test.go
@@ -151,16 +151,23 @@ func TestSharedSessionCodeAgent_RowReadsASessionStoredAfterItStarted(t *testing.
 	assert.Equal(t, "session-written-after-the-snapshot", stubs.apiSessions[0])
 }
 
-// @scenario "Rows that race each other log in at most once each"
-func TestSharedSessionCodeAgent_RacingRowsLogInAtMostOnceEach(t *testing.T) {
+// @scenario "Rows that start together log in once between them"
+//
+// Before the claim this was the one bound this suite could not tighten: every
+// row of the first wave read the empty cache and logged in, so the assertion
+// could only say "between one and one per row". The claim is what turns it
+// into a number.
+func TestSharedSessionCodeAgent_RowsThatStartTogetherLogInOnce(t *testing.T) {
+	const rows = 4
+
 	stubs := newSharedSessionStubs(t, "p4ssw0rd")
 	code := loadSharedSessionExample(t)
 
 	executor := sharedSessionExec(t, stubs.cacheServer.URL)
-	results := make([]*codeblock.Result, 2)
-	errs := make([]error, 2)
+	results := make([]*codeblock.Result, rows)
+	errs := make([]error, rows)
 	var wg sync.WaitGroup
-	wg.Add(2)
+	wg.Add(rows)
 	for i := range results {
 		go func(index int) {
 			defer wg.Done()
@@ -175,13 +182,51 @@ func TestSharedSessionCodeAgent_RacingRowsLogInAtMostOnceEach(t *testing.T) {
 		require.Nil(t, results[i].Error, "row %d: %+v", i, results[i].Error)
 		assert.Equal(t, "hello from the protected api", results[i].Outputs["output"])
 	}
-	// Both rows read the cache first. Whether the second one finds a session
-	// depends on how far the first got, so the count is bounded rather than
-	// fixed: never more than one login per row, and never zero.
-	assert.Equal(t, 2, stubs.cacheReadCount())
-	assert.LessOrEqual(t, stubs.loginCount(), 2, "no row logs in twice")
-	assert.GreaterOrEqual(t, stubs.loginCount(), 1, "an empty cache means at least one login")
+
+	assert.Equal(t, 1, stubs.loginCount(),
+		"one row takes the claim and logs in; the rest read what it stored")
+	assert.Equal(t, 1, stubs.claimsTaken(),
+		"the claim is taken exactly once, however many rows ask for it")
+	assert.Len(t, stubs.writes(), 1, "one login means one session written")
 	assert.NotEmpty(t, stubs.storedSession(), "the session was written")
+
+	// Every row answered from the one session, not from one of its own.
+	require.Len(t, stubs.apiSessions, rows)
+	for _, presented := range stubs.apiSessions {
+		assert.Equal(t, "session-1", presented)
+	}
+}
+
+// @scenario "A row logs in itself when the row that took the login stores nothing"
+//
+// A claim that is never followed by a write would otherwise hold every other
+// row until its own lifetime passed and then leave them with nothing. The
+// claim expires, the next tick takes it, and that row does the work, so the
+// worst case is the result every row gets with no claim at all.
+func TestSharedSessionCodeAgent_RowLogsInWhenTheClaimHolderStoresNothing(t *testing.T) {
+	stubs := newSharedSessionStubs(t, "p4ssw0rd")
+	// Held by a row that stops before it stores a session. Two asks rather
+	// than the example's own lifetime, so the test observes the recovery
+	// instead of waiting out the full window.
+	stubs.holdLoginFor(2)
+
+	res, err := sharedSessionExec(t, stubs.cacheServer.URL).
+		Execute(context.Background(), stubs.rowRequest(loadSharedSessionExample(t)))
+	require.NoError(t, err)
+	require.Nil(t, res.Error, "expected success, got %+v", res.Error)
+
+	assert.Equal(t, 1, stubs.loginCount(),
+		"the row takes the name once it is free and logs in")
+	assert.Equal(t, "session-1", stubs.storedSession())
+	assert.Equal(t, "hello from the protected api", res.Outputs["output"])
+
+	// It waited rather than logging in at once, which is what makes this the
+	// recovery path and not simply an empty cache.
+	claims := stubs.claims()
+	require.Len(t, claims, 3, "two asks found the name taken, the third took it")
+	assert.False(t, claims[0].Claimed, "the first ask found the name taken")
+	assert.False(t, claims[1].Claimed, "so did the second")
+	assert.True(t, claims[2].Claimed, "the third took it, and that row logged in")
 }
 
 // @scenario "A rejected login names the failure and keeps the password out of it"

--- a/services/nlpgo/app/engine/blocks/codeblock/shared_session_stubs_test.go
+++ b/services/nlpgo/app/engine/blocks/codeblock/shared_session_stubs_test.go
@@ -25,7 +25,7 @@ import (
 const (
 	sharedSessionEntryName = "ACME_SESSION"
 	// The name one row takes to be the row that logs in.
-	sharedSessionClaimName = "ACME_LOGIN_CLAIM"
+	sharedSessionClaimName = "ACME_SESSION_CLAIM"
 	// The credential the platform mints for one run. It is not the project
 	// key: the cache stub accepts this and nothing else.
 	sharedSessionSandboxKey = "sk-lw-test-sandbox-run-key"

--- a/services/nlpgo/app/engine/blocks/codeblock/shared_session_stubs_test.go
+++ b/services/nlpgo/app/engine/blocks/codeblock/shared_session_stubs_test.go
@@ -118,9 +118,12 @@ type sharedSessionStubs struct {
 	cacheWrites     []cacheWrite
 	cacheClaims     []cacheClaim
 	holdLoginClaims int
-	rejectLogin     bool
-	rejectWrite     bool
-	failCache       bool
+	// How long the login service takes to answer. A real login is not
+	// instant, and the claim only earns its keep while one is in flight.
+	loginDelay  time.Duration
+	rejectLogin bool
+	rejectWrite bool
+	failCache   bool
 
 	// stored mirrors the agent cache: name -> entry, each with its own expiry.
 	stored map[string]cacheEntry
@@ -151,11 +154,18 @@ func newSharedSessionStubs(t *testing.T, password string) *sharedSessionStubs {
 		s.mu.Lock()
 		s.loginRequests = append(s.loginRequests, req)
 		reject := s.rejectLogin
+		delay := s.loginDelay
 		minted := fmt.Sprintf("session-%d", len(s.loginRequests))
 		if !reject && req.Password == s.password {
 			s.mintedSessions = append(s.mintedSessions, minted)
 		}
 		s.mu.Unlock()
+
+		// Outside the lock, so several logins in flight overlap the way they
+		// would against a real target.
+		if delay > 0 {
+			time.Sleep(delay)
+		}
 		if reject || req.Password != s.password {
 			w.WriteHeader(http.StatusUnauthorized)
 			fmt.Fprint(w, `{"error":"invalid_credentials"}`)

--- a/services/nlpgo/app/engine/blocks/codeblock/shared_session_stubs_test.go
+++ b/services/nlpgo/app/engine/blocks/codeblock/shared_session_stubs_test.go
@@ -24,6 +24,8 @@ import (
 
 const (
 	sharedSessionEntryName = "ACME_SESSION"
+	// The name one row takes to be the row that logs in.
+	sharedSessionClaimName = "ACME_LOGIN_CLAIM"
 	// The credential the platform mints for one run. It is not the project
 	// key: the cache stub accepts this and nothing else.
 	sharedSessionSandboxKey = "sk-lw-test-sandbox-run-key"
@@ -91,6 +93,13 @@ type cacheWrite struct {
 	TTLSeconds int
 }
 
+// cacheClaim is one claim the example made, and whether it took the name.
+type cacheClaim struct {
+	Name       string
+	TTLSeconds int
+	Claimed    bool
+}
+
 // sharedSessionStubs is a stub login service, a stub protected API and a stub
 // agent cache. The login service mints a new session per login, and the
 // protected API accepts every session it has minted, so a row that presents an
@@ -100,16 +109,18 @@ type sharedSessionStubs struct {
 	apiServer   *httptest.Server
 	cacheServer *httptest.Server
 
-	mu             sync.Mutex
-	password       string
-	loginRequests  []loginRequest
-	mintedSessions []string
-	apiSessions    []string
-	cacheReads     []string
-	cacheWrites    []cacheWrite
-	rejectLogin    bool
-	rejectWrite    bool
-	failCache      bool
+	mu              sync.Mutex
+	password        string
+	loginRequests   []loginRequest
+	mintedSessions  []string
+	apiSessions     []string
+	cacheReads      []string
+	cacheWrites     []cacheWrite
+	cacheClaims     []cacheClaim
+	holdLoginClaims int
+	rejectLogin     bool
+	rejectWrite     bool
+	failCache       bool
 
 	// stored mirrors the agent cache: name -> entry, each with its own expiry.
 	stored map[string]cacheEntry
@@ -200,7 +211,12 @@ func (s *sharedSessionStubs) serveCache(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	name := strings.TrimPrefix(r.URL.Path, "/api/agent-cache/")
+	claiming := strings.HasSuffix(name, "/claim")
+	name = strings.TrimSuffix(name, "/claim")
 
+	// One mutex for the whole call, so two claims that arrive together are
+	// resolved one after the other. That is what the platform's own claim
+	// does, and it is what makes the racing scenario a real assertion.
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -212,6 +228,44 @@ func (s *sharedSessionStubs) serveCache(w http.ResponseWriter, r *http.Request) 
 	if s.rejectWrite && r.Method != http.MethodGet {
 		w.WriteHeader(http.StatusForbidden)
 		fmt.Fprint(w, `{"error":{"type":"permission_denied","code":"insufficient_permissions","message":"insufficient_permissions"}}`)
+		return
+	}
+
+	if claiming {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		var body struct {
+			Value      string `json:"value"`
+			TTLSeconds *int   `json:"ttl_seconds"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		ttl := 15 * 60
+		if body.TTLSeconds != nil {
+			ttl = *body.TTLSeconds
+		}
+		entry, held := s.stored[name]
+		claimed := !held || !time.Now().Before(entry.expiresAt)
+		if s.holdLoginClaims > 0 && name == sharedSessionClaimName {
+			s.holdLoginClaims--
+			claimed = false
+		}
+		if claimed {
+			s.stored[name] = cacheEntry{
+				value:     body.Value,
+				expiresAt: time.Now().Add(time.Duration(ttl) * time.Second),
+			}
+		}
+		s.cacheClaims = append(s.cacheClaims, cacheClaim{
+			Name: name, TTLSeconds: ttl, Claimed: claimed,
+		})
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"name": name, "claimed": claimed, "ttl_seconds": ttl,
+		})
 		return
 	}
 
@@ -283,6 +337,19 @@ func (s *sharedSessionStubs) seedSession(session string, ttl time.Duration) {
 	s.mintedSessions = append(s.mintedSessions, session)
 }
 
+// holdLoginFor answers the next `asks` claims on the login name as taken, then
+// leaves the name free. That is the sequence a row sees when another row holds
+// the claim and stores no session: the name reads as taken on each ask, then
+// as free once that claim's own lifetime passes. Counting the asks rather
+// than seeding a lifetime keeps
+// the scenario off the wall clock, which the interpreter's start-up time would
+// otherwise decide.
+func (s *sharedSessionStubs) holdLoginFor(asks int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.holdLoginClaims = asks
+}
+
 // seedForgottenSession puts a session in the cache that the protected API will
 // refuse, which is what an earlier row's session looks like after the target
 // system restarts, an operator closes the session, or the password changes.
@@ -331,4 +398,21 @@ func (s *sharedSessionStubs) writes() []cacheWrite {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return append([]cacheWrite(nil), s.cacheWrites...)
+}
+
+func (s *sharedSessionStubs) claims() []cacheClaim {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]cacheClaim(nil), s.cacheClaims...)
+}
+
+// claimsTaken counts the claims that took the name.
+func (s *sharedSessionStubs) claimsTaken() int {
+	taken := 0
+	for _, claim := range s.claims() {
+		if claim.Claimed {
+			taken++
+		}
+	}
+	return taken
 }

--- a/specs/agent-cache/agent-cache.feature
+++ b/specs/agent-cache/agent-cache.feature
@@ -173,6 +173,17 @@ Feature: The agent cache
       Then exactly one response says the name was taken
       And a read answers the value that caller sent
 
+    # A read and a write degrade to a per-process answer when the store
+    # cannot answer, and the worst that costs is a stale read. A claim that
+    # degraded the same way would name one winner per process, which is the
+    # one outcome it exists to prevent.
+    @unit
+    Scenario: A claim the store cannot answer raises rather than naming a winner
+      Given a store that cannot answer
+      When the caller claims a name
+      Then the call is refused
+      And the caller is never told it took the name
+
     @unit
     Scenario: The SDK answers a lost claim with false
       Given the project already holds an entry named ACME_SESSION

--- a/specs/agent-cache/agent-cache.feature
+++ b/specs/agent-cache/agent-cache.feature
@@ -39,6 +39,11 @@ Feature: The agent cache
   # authors to pick collision-resistant entry names when a project runs
   # several distinct agents concurrently.
   #
+  # A caller that needs one row rather than all of them to do the work takes
+  # the name with a claim, which writes only when the name is free. That is
+  # the answer to rows that start together, and it stays opt-in: the plain
+  # write is still last-write-wins.
+  #
   # ACCEPTED: a legacy sk-lw- project key reaches these routes, as it reaches
   # the rest of the project surface. Such a key already holds full project
   # access, and the cache holds only state an agent wrote, so the passthrough
@@ -132,6 +137,47 @@ Feature: The agent cache
       Given a request that carries the legacy project API key
       When the caller stores an entry and reads it back
       Then the request succeeds
+
+  Rule: A caller can take a name only if the project does not hold it
+
+    # Rows that start together all read an empty cache and all do the work
+    # the entry was meant to save. A claim is how one of them takes the name
+    # first: the write happens only if the name is free, and the answer says
+    # whether this caller is the one that took it. Losing is not a refusal,
+    # so agent code reads a boolean rather than catching an exception.
+
+    @integration
+    Scenario: A claim on a free name is taken
+      Given the project holds no entry named ACME_SESSION
+      When the caller claims ACME_SESSION
+      Then the response says the name was taken
+      And a read answers the claimed value
+
+    @integration
+    Scenario: A claim on a held name leaves the held value alone
+      Given the project holds an entry named ACME_SESSION
+      When the caller claims ACME_SESSION with a different value
+      Then the response says the name was not taken
+      And a read still answers the value that was already there
+
+    @integration
+    Scenario: A name is free again once its lifetime passes
+      Given the caller claims ACME_SESSION with a lifetime of five seconds
+      When the caller claims ACME_SESSION after that lifetime has passed
+      Then the response says the name was taken
+
+    @integration
+    Scenario: Only one of several claims sent at once takes the name
+      Given the project holds no entry named ACME_SESSION
+      When several callers claim ACME_SESSION at the same moment
+      Then exactly one response says the name was taken
+      And a read answers the value that caller sent
+
+    @unit
+    Scenario: The SDK answers a lost claim with false
+      Given the project already holds an entry named ACME_SESSION
+      When the agent claims ACME_SESSION
+      Then the agent is given false, and no exception is raised
 
   Rule: A run reaches the cache with a key minted for that run
 

--- a/specs/agents/code-agent-shared-session.feature
+++ b/specs/agents/code-agent-shared-session.feature
@@ -74,8 +74,8 @@ Feature: A code agent logs in once for a whole run
       Then exactly one row logs in
       And the claim is taken exactly once
       And every row answers with the session that row stored
-      # The rows of the first wave all read the empty cache, so before the
-      # claim they all logged in. The claim is what makes this a number: it
+      # The rows of the first wave all read the empty cache, so without the
+      # claim they would all log in. The claim is what makes this a number: it
       # writes only when the name is free, so one row does the work and the
       # rows beside it read what it stored.
 

--- a/specs/agents/code-agent-shared-session.feature
+++ b/specs/agents/code-agent-shared-session.feature
@@ -68,15 +68,27 @@ Feature: A code agent logs in once for a whole run
       # The read happens while the row runs, not when the row is prepared.
 
     @integration
-    Scenario: Rows that race each other log in at most once each
+    Scenario: Rows that start together log in once between them
       Given the cache holds no session
-      When two rows start at the same moment
-      Then neither row logs in twice
-      And at least one row logs in
-      And a session is stored
-      # No lock prevents the first wave from racing. Both sessions are valid and
-      # the last write wins, so the login has to be idempotent on the target
-      # system, or the run's parallelism has to be lowered.
+      When four rows start at the same moment
+      Then exactly one row logs in
+      And the claim is taken exactly once
+      And every row answers with the session that row stored
+      # The rows of the first wave all read the empty cache, so before the
+      # claim they all logged in. The claim is what makes this a number: it
+      # writes only when the name is free, so one row does the work and the
+      # rows beside it read what it stored.
+
+    @integration
+    Scenario: A row logs in itself when the row that took the login stores nothing
+      Given another row took the login and stored no session
+      When the row runs
+      Then the row waits rather than logging in at once
+      And the row takes the login once that claim's lifetime passes
+      And the row logs in and stores the session
+      # A claim that no write follows must not hold the rows beside it for
+      # good. The claim expires, the next row takes it, and the worst case is
+      # the result every row gets with no claim at all.
 
   Rule: A cache that does not answer costs a login, never a row
 

--- a/specs/agents/code-agent-shared-session.feature
+++ b/specs/agents/code-agent-shared-session.feature
@@ -80,6 +80,17 @@ Feature: A code agent logs in once for a whole run
       # rows beside it read what it stored.
 
     @integration
+    Scenario: Rows that start together log in once when the login is slow
+      Given the cache holds no session
+      And the target system takes seconds to answer a login
+      When four rows start at the same moment
+      Then exactly one row logs in
+      And every row answers with the session that row stored
+      # The claim only earns its keep while a login is in flight. The rows
+      # beside the winner wait through the login rather than starting their
+      # own, for as long as the claim's lifetime covers it.
+
+    @integration
     Scenario: A row logs in itself when the row that took the login stores nothing
       Given another row took the login and stored no session
       When the row runs


### PR DESCRIPTION
## What

Adds a **claim** to the agent cache: a write that happens only when the project holds no live entry under that name, and an answer that says whether this caller is the one that took it.

`POST /api/agent-cache/{name}/claim` answers `200` in both outcomes:

```json
{ "name": "ACME_LOGIN_CLAIM", "claimed": true, "ttl_seconds": 60 }
```

Losing is an ordinary answer rather than a refusal, so agent code branches on a boolean instead of catching an exception. The plain `PUT` is unchanged and stays last-write-wins.

The committed shared-session example uses it, which is what makes the behavior reach customers: the docs publish that file byte for byte and the Go tests run it through the real sandbox.

## Why

The rows of a run are isolated and start together, so they all read an empty cache and they all do the work the entry was meant to save. A production dogfood of #7545 measured it: a cold run of 4 parallel rows logged in 4 times, and the warm run that followed logged in 0 times with all 4 rows on one session. Session reuse worked; the first wave did not have an answer.

`TtlCache.claim` already did the atomic Redis `SET NX EX`. It had one caller, the discover-refresh lease in `trace-list.service.ts`; the agent cache never reached it. This exposes it.

## Proof

Four rows of the committed example, started together, each its own `runner.py` subprocess the way nlpgo runs a row, against a local LangWatch app on its real Redis and a stub ACME whose login takes 2 seconds:

| Wave | Logins | What each row answered |
|---|---|---|
| Control, no cache credential | **4** | four different sessions |
| Cold, empty cache, claim in play | **1** | all four on `session-5` |
| Warm, session still stored | **0** | all four on `session-5` |

The control wave is what says the measurement is real: the same four rows against the same stub cost four logins with no cache, and one with it.

The route itself, against the same app: eight concurrent claims on a fresh name returned exactly one `claimed: true`, the read answered that caller's value, and the entry was in Redis (`ttlcache:agent-cache:proj_qa_search_1:...`, TTL 55) rather than in process memory.

## How

| Layer | Change |
|---|---|
| `TtlCache.claim` | takes a per-call lifetime, the same way `set` does |
| Repository | `claim({projectId, name, encryptedValue, ttlMs})` |
| Service | `claim({projectId, name, value, ttlSeconds})`, encrypts the value like `put` |
| Route | `POST /:name/claim`, gated `agentCache:manage`, same name and body rules as the write |
| Python SDK | `langwatch.cache.claim(name, value, ttl_seconds=None) -> bool` |
| Example | takes the login claim, waits for the session, claims again each tick |

A claim does **not** fall back to per-process memory when a configured Redis cannot answer. A read and a write degrade to a stale answer, which is safe; a claim that degraded the same way would name one winner per process, which is the one outcome it exists to prevent. It raises instead, and the caller decides. With no Redis configured the memory map is the whole cache and a claim inside one process stays atomic.

## Where the bound ends

A login that runs longer than `CLAIM_TTL_SECONDS` lets a second row take the name and log in as well, and the last session written is the one the rows that follow read. Both sessions are valid, so the cost is extra logins, which is the result with no claim at all. Same when the cache cannot answer. The docs say this next to the instruction to set the lifetime above your login time.

## Tests

`specs/agent-cache/agent-cache.feature` gains 6 bound scenarios (26/26 bound), and `specs/agents/code-agent-shared-session.feature` gains one and tightens another (13/13 bound):

- a claim on a free name is taken; a claim on a held name leaves the held value alone
- a name is free again once its lifetime passes
- only one of several claims sent at once takes the name (8 concurrent, exactly one `true`)
- a claim the store cannot answer raises rather than naming a winner
- the SDK answers a lost claim with `false`
- **four rows that start together log in once between them**, which replaces the old "at least one login and no more than one per row"
- a row logs in itself when the row that took the login stores nothing

Run locally: 17/17 platform integration, 18/18 `ttlCache` unit, 11/11 Python SDK, 12/12 Go shared-session scenarios plus the docs-fence guard, `typecheck:all`, `check:feature-parity`, both OpenAPI checks, `golangci-lint` on the touched package, `docscheck` and the docs prose check.

## Deployment Impact

None. A new REST route on an existing app, no migration, no configuration, no environment variable. The route is additive, so an older SDK keeps working against a new deployment and a newer SDK against an older deployment answers `404` on the claim path, which agent code treats as a cache that cannot answer.

One behavior change outside the new route: `TtlCache.claim` now raises on a Redis error instead of claiming in memory. Its one existing caller, the discover-refresh lease, already catches and degrades to "cached value still served", so an outage now skips one background refresh rather than having every pod believe it holds the lease.

The Python SDK needs a release before agent code in the sandbox can call `langwatch.cache.claim`. The sandbox installs the SDK from the monorepo since #7581, so the version it gets is the one the nlpgo image was built from.

## Related

- #7545 the agent cache itself
- #7575 the accepted note on concurrent writes, and the docs trim
- #7581 the sandbox installs the Python SDK from the monorepo, not from PyPI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cache claims to atomically reserve available entries, with optional expiration and clear success status.
  * Added a REST API endpoint and Python SDK support for claiming cache entries.
  * Concurrent session workflows now coordinate login so only one row logs in, with recovery after claim expiration.

* **Documentation**
  * Added API reference, usage guidance, OpenAPI details, and examples for cache claims.

* **Tests**
  * Added coverage for successful, competing, expired, and TTL-specific claims.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->