### PR TITLE
fix(governance): keep a resumed Copilot Studio conversation as one trace

### DIFF
--- a/platform/app/ee/governance/services/pullers/__tests__/copilotStudioTraceMapper.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/copilotStudioTraceMapper.unit.test.ts
@@ -507,6 +507,11 @@ describe("given a conversation Microsoft stored across several rows", () => {
  * messages under `2026-08-26T14:45:41Z` and 2 more under
  * `2026-08-26T16:29:56Z`. Grouping on the start time as well as the name
  * split it into two traces, and the trace list showed only the newer half.
+ *
+ * The rows below keep that shape — one name, one batch number, two start
+ * times — and carry a single exchange each. The message counts are not what
+ * splits the conversation; the second start time is, and one exchange per row
+ * is enough to show it.
  */
 describe("given a conversation resumed after a break", () => {
   const RESUMED_NAME = "98396e1f-0000-4000-8000-000000000002_14a3a0cf-bot";
@@ -547,51 +552,55 @@ describe("given a conversation resumed after a break", () => {
     transcriptId: "row-after-break",
   });
 
-  it("records one trace holding both halves", () => {
-    const spans = spansOf([copilotEvent(before), copilotEvent(after)]);
-    expect(new Set(spans.map((s) => s.traceId)).size).toBe(1);
-    const rendered = JSON.stringify(spans);
-    expect(rendered).toContain("what's the capital of berlin?");
-    expect(rendered).toContain("Santiago is the capital of Chile.");
-  });
+  describe("when both halves reach the mapper in one pull", () => {
+    it("records one trace holding both halves", () => {
+      const spans = spansOf([copilotEvent(before), copilotEvent(after)]);
+      expect(new Set(spans.map((s) => s.traceId)).size).toBe(1);
+      const rendered = JSON.stringify(spans);
+      expect(rendered).toContain("what's the capital of berlin?");
+      expect(rendered).toContain("Santiago is the capital of Chile.");
+    });
 
-  it("hangs both halves' turns under a single conversation", () => {
-    const events = [copilotEvent(before), copilotEvent(after)];
-    const conversations = spansOf(events).filter(
-      (s: { name: string }) => s.name === COPILOT_CONVERSATION_SPAN_NAME,
-    );
-    expect(conversations.length).toBe(1);
-    const turns = turnSpansOf(events);
-    expect(turns.length).toBe(2);
-    expect(new Set(turns.map((s) => s.parentSpanId))).toEqual(
-      new Set([conversations[0]!.spanId]),
-    );
-  });
+    it("hangs both halves' turns under a single conversation", () => {
+      const events = [copilotEvent(before), copilotEvent(after)];
+      const conversations = spansOf(events).filter(
+        (s: { name: string }) => s.name === COPILOT_CONVERSATION_SPAN_NAME,
+      );
+      expect(conversations.length).toBe(1);
+      const turns = turnSpansOf(events);
+      expect(turns.length).toBe(2);
+      expect(new Set(turns.map((s) => s.parentSpanId))).toEqual(
+        new Set([conversations[0]!.spanId]),
+      );
+    });
 
-  /**
-   * Both halves are numbered batch 0, which is two rows carrying the same
-   * number rather than a hole in the numbering. Nothing is missing here.
-   */
-  it("does not read the repeated batch number as a missing piece", () => {
-    const spans = spansOf([copilotEvent(before), copilotEvent(after)]);
-    expect(
-      attrsOf(spans[0]!)["copilot_studio.conversation_incomplete"],
-    ).toBeUndefined();
+    /**
+     * Both halves are numbered batch 0, which is two rows carrying the same
+     * number rather than a hole in the numbering. Nothing is missing here.
+     */
+    it("does not read the repeated batch number as a missing piece", () => {
+      const spans = spansOf([copilotEvent(before), copilotEvent(after)]);
+      expect(
+        attrsOf(spans[0]!)["copilot_studio.conversation_incomplete"],
+      ).toBeUndefined();
+    });
   });
 
   /**
    * The two halves land in different pull runs in practice, so the trace they
    * join is decided by the identifiers alone, not by being mapped together.
    */
-  it("gives a half pulled on its own the same trace and thread as the other", () => {
-    const [firstRun, secondRun] = [
-      spansOf([copilotEvent(before)]),
-      spansOf([copilotEvent(after)]),
-    ];
-    expect(firstRun[0]!.traceId).toBe(secondRun[0]!.traceId);
-    expect(attrsOf(firstRun[0]!)["langwatch.thread.id"]).toBe(
-      attrsOf(secondRun[0]!)["langwatch.thread.id"],
-    );
+  describe("when each half is pulled on its own", () => {
+    it("gives a half pulled on its own the same trace and thread as the other", () => {
+      const [firstRun, secondRun] = [
+        spansOf([copilotEvent(before)]),
+        spansOf([copilotEvent(after)]),
+      ];
+      expect(firstRun[0]!.traceId).toBe(secondRun[0]!.traceId);
+      expect(attrsOf(firstRun[0]!)["langwatch.thread.id"]).toBe(
+        attrsOf(secondRun[0]!)["langwatch.thread.id"],
+      );
+    });
   });
 });
 

--- a/platform/app/ee/governance/services/pullers/__tests__/copilotStudioTraceMapper.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/copilotStudioTraceMapper.unit.test.ts
@@ -500,6 +500,101 @@ describe("given a conversation Microsoft stored across several rows", () => {
   });
 });
 
+/**
+ * Observed, not hand-built. One conversation with the agent, left idle past
+ * the session timeout and then picked up again, was stored as two rows: the
+ * same `name`, both numbered batch 0, and two different start times — 15
+ * messages under `2026-08-26T14:45:41Z` and 2 more under
+ * `2026-08-26T16:29:56Z`. Grouping on the start time as well as the name
+ * split it into two traces, and the trace list showed only the newer half.
+ */
+describe("given a conversation resumed after a break", () => {
+  const RESUMED_NAME = "98396e1f-0000-4000-8000-000000000002_14a3a0cf-bot";
+  const before = transcriptRow({
+    activities: [
+      userMessage({
+        id: "e1111111-1111-4111-8111-111111111111",
+        text: "what's the capital of berlin?",
+        ms: 1_787_755_541_000,
+      }),
+      agentMessage({
+        id: "e2222222-2222-4222-8222-222222222222",
+        text: "Berlin is a city, and it is the capital of Germany.",
+        ms: 1_787_755_545_000,
+      }),
+    ],
+    batchId: 0,
+    name: RESUMED_NAME,
+    start: "2026-08-26T14:45:41Z",
+    transcriptId: "row-before-break",
+  });
+  const after = transcriptRow({
+    activities: [
+      userMessage({
+        id: "e3333333-3333-4333-8333-333333333333",
+        text: "what about chile.",
+        ms: 1_787_761_796_000,
+      }),
+      agentMessage({
+        id: "e4444444-4444-4444-8444-444444444444",
+        text: "Santiago is the capital of Chile.",
+        ms: 1_787_761_800_000,
+      }),
+    ],
+    batchId: 0,
+    name: RESUMED_NAME,
+    start: "2026-08-26T16:29:56Z",
+    transcriptId: "row-after-break",
+  });
+
+  it("records one trace holding both halves", () => {
+    const spans = spansOf([copilotEvent(before), copilotEvent(after)]);
+    expect(new Set(spans.map((s) => s.traceId)).size).toBe(1);
+    const rendered = JSON.stringify(spans);
+    expect(rendered).toContain("what's the capital of berlin?");
+    expect(rendered).toContain("Santiago is the capital of Chile.");
+  });
+
+  it("hangs both halves' turns under a single conversation", () => {
+    const events = [copilotEvent(before), copilotEvent(after)];
+    const conversations = spansOf(events).filter(
+      (s: { name: string }) => s.name === COPILOT_CONVERSATION_SPAN_NAME,
+    );
+    expect(conversations.length).toBe(1);
+    const turns = turnSpansOf(events);
+    expect(turns.length).toBe(2);
+    expect(new Set(turns.map((s) => s.parentSpanId))).toEqual(
+      new Set([conversations[0]!.spanId]),
+    );
+  });
+
+  /**
+   * Both halves are numbered batch 0, which is two rows carrying the same
+   * number rather than a hole in the numbering. Nothing is missing here.
+   */
+  it("does not read the repeated batch number as a missing piece", () => {
+    const spans = spansOf([copilotEvent(before), copilotEvent(after)]);
+    expect(
+      attrsOf(spans[0]!)["copilot_studio.conversation_incomplete"],
+    ).toBeUndefined();
+  });
+
+  /**
+   * The two halves land in different pull runs in practice, so the trace they
+   * join is decided by the identifiers alone, not by being mapped together.
+   */
+  it("gives a half pulled on its own the same trace and thread as the other", () => {
+    const [firstRun, secondRun] = [
+      spansOf([copilotEvent(before)]),
+      spansOf([copilotEvent(after)]),
+    ];
+    expect(firstRun[0]!.traceId).toBe(secondRun[0]!.traceId);
+    expect(attrsOf(firstRun[0]!)["langwatch.thread.id"]).toBe(
+      attrsOf(secondRun[0]!)["langwatch.thread.id"],
+    );
+  });
+});
+
 describe("given a stored name that does not match the shape we observed", () => {
   /** @scenario "The conversation's stored label is used whole, never taken apart" */
   it("groups a name with no underscore and one with several", () => {

--- a/platform/app/ee/governance/services/pullers/copilotStudioTraceMapper.ts
+++ b/platform/app/ee/governance/services/pullers/copilotStudioTraceMapper.ts
@@ -138,6 +138,12 @@ interface Activity {
 interface TranscriptRow {
   /** Opaque grouping key. Never parsed — see `conversationKeyOf`. */
   name?: string | null;
+  /**
+   * Declared to record that the field exists and is deliberately unread. It
+   * dates a session, not a conversation, so it is never an identity input —
+   * two rows of one conversation carry different values here and must still
+   * produce one trace. The puller reads it, as the event's timestamp.
+   */
   conversationstarttime?: string | null;
   /**
    * Declared to record that the field exists and is deliberately unread. It
@@ -222,8 +228,7 @@ function batchIdOf(row: TranscriptRow): number | null {
 }
 
 /**
- * What groups rows into one conversation: the stored name together with the
- * conversation's start time, both used whole.
+ * What groups rows into one conversation: the stored name, used whole.
  *
  * The name happens to look like a conversation id and a bot id joined by an
  * underscore. Microsoft documents that as a shape they observed, not one they
@@ -231,15 +236,18 @@ function batchIdOf(row: TranscriptRow): number | null {
  * on a format nobody committed to — and the failure would be silent, since a
  * name that stopped matching the shape would still produce *an* identifier,
  * just a different one, orphaning every conversation pulled before the change.
+ *
+ * The start time was part of this key and had to come out. Someone who leaves
+ * a conversation idle past the session timeout and then keeps talking gets a
+ * second row: same name, same batch number, a later start time. Keying on the
+ * start time made that one conversation into two traces on two thread ids,
+ * and the trace list showed only the newer half — which is exactly what the
+ * whole `name` is for, since it already carries the conversation's own id.
  */
 function conversationKeyOf(row: TranscriptRow): string | null {
   const name = typeof row.name === "string" ? row.name.trim() : "";
-  const start =
-    typeof row.conversationstarttime === "string"
-      ? row.conversationstarttime.trim()
-      : "";
-  if (!name || !start) return null;
-  return `${name}|${start}`;
+  if (!name) return null;
+  return name;
 }
 
 interface ConversationGroup {


### PR DESCRIPTION
Closes #7598.

## Cause

`ee/governance/services/pullers/copilotStudioTraceMapper.ts:241` — `conversationKeyOf` built the grouping key from the stored `name` **and** `conversationstarttime`. That key is the seed for the trace id, the thread id and the span seed.

Copilot Studio writes a second transcript row when someone leaves a conversation idle past the session timeout and then keeps talking: same `name`, same `BatchId 0`, a **later** `conversationstarttime`. Mixing the start time into the key made that one conversation into two traces on two thread ids, so the trace list showed only the newer half.

The issue's `🤖 For Agents` plan is about turn spans having no parent. That was true when the issue was written and #7576 fixed it — turn spans have hung under a conversation span since `copilotStudioTraceMapper.ts:1063`. The split key is what was left.

### Confirmed against the live environment

One conversation in the environment the issue came from is stored as two rows:

| row | `conversationstarttime` | messages | batch |
|---|---|---|---|
| `443c68c0…` | `2026-08-26T14:45:41Z` | 15 | 0 |
| `f348f874…` | `2026-08-26T16:29:56Z` | 2 | 0 |

Both carry the same `name`. Reproducing the identity derivation by hand over those two rows gives:

- `443c68c0…` → trace `86950c1f79f2ddffa28d7b5e47671a81`
- `f348f874…` → trace `011ffe46daf29693e341017643a6a4fb`

The second is the trace in the bug report — the two-message half. The other 8 turns were sitting in a trace nobody was looking at.

## The fix

Group on `name` alone. It already carries the conversation's own id, and it is the field the mapper's own docblock says must never be taken apart.

## Tests

Four cases added under *given a conversation resumed after a break*, shaped from the two real rows above. Three of them fail on `main` and pass here:

```
× records one trace holding both halves
    AssertionError: expected 2 to be 1
× hangs both halves' turns under a single conversation
    AssertionError: expected 2 to be 1
× gives a half pulled on its own the same trace and thread as the other
    AssertionError: expected 'e8cb3e483809d19a11ea3319a037004c'
                        to be 'cf332e092dc4f79c4e0ef09929eb4bb0'

Tests  3 failed | 35 skipped (38)
```

The fourth, *does not read the repeated batch number as a missing piece*, passes on both sides. It is there to pin behaviour the wider grouping key could plausibly break: two rows of one conversation both carrying batch number 0 must not be read as a gap and flagged incomplete.

After:

```
Test Files  18 passed (18)
     Tests  269 passed (269)
```

(the whole `ee/governance/services/pullers/` suite). `tsc --noEmit` clean, biome clean, feature-parity gate OK.

## Identifiers change

Trace and thread ids for Copilot Studio conversations move, because the start time was an input to both. Conversations already pulled keep their old ids; a re-pull writes them again under the new ones. Dataverse deletes transcripts after a month and this puller landed days ago, so the window that can be orphaned is small — but it is not zero, and it is the same orphaning the docblock warns about for the underscore-split case.

## Sweep

The shape is a session-scoped timestamp used as part of a conversation identity. The only other conversation mapper, `genieTraceMapper.ts:310`, seeds trace/thread/span from ids alone — no timestamp. Nothing else derives a conversation identity.

## Noticed, not fixed

**The headline still comes from whichever half was pulled last.** The two halves normally arrive in *different* pull runs, and the mapper only ever sees one run's rows. Run 2 re-emits the conversation span under the same span id holding only its own turns, so the conversation span's input/output — and its time window — get rewritten to the newer half. After this change the full conversation is in one trace under one thread and every turn is there when you open it, but the summary line in the trace list can still read as the newest exchange rather than the first question and the last answer.

Fixing that means the conversation span has to be folded across runs rather than rewritten by the last one, which is a change to how spans merge downstream, not to this mapper. Worth its own issue.

**The 8 lost spans from the earlier proof run** (3 of 9 root spans never landed) are still unexplained and unrelated to this.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Copilot conversation tracing across session breaks.
  - Conversation segments with the same name are now combined into one trace, even when start times differ.
  - Prevented valid resumed conversations from being incorrectly marked incomplete.
  - Ensured conversation segments retain consistent trace and thread identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
