### PR TITLE
perf(clickhouse): read event-attribute keys from the keys subcolumn

### DIFF
--- a/platform/app/src/server/app-layer/traces/facets/__tests__/event-attribute-keys.integration.test.ts
+++ b/platform/app/src/server/app-layer/traces/facets/__tests__/event-attribute-keys.integration.test.ts
@@ -152,7 +152,7 @@ describe("event-attribute-keys facet integration", () => {
         expect(new Set(keys).size).toBe(keys.length); // GROUP BY => no dupes
         expect(keys).toContain("event_key_0");
         expect(keys).toContain(`event_key_${KEYS_PER_EVENT - 1}`);
-        expect(keys).not.toContain(""); // empty keys filtered out
+        expect(keys).not.toContain("");
         expect(rows).toHaveLength(EXPECTED_DISTINCT_KEYS);
         expect(Number(rows[0]?.total_distinct)).toBe(EXPECTED_DISTINCT_KEYS);
       });

--- a/platform/app/src/server/app-layer/traces/facets/__tests__/event-attribute-keys.integration.test.ts
+++ b/platform/app/src/server/app-layer/traces/facets/__tests__/event-attribute-keys.integration.test.ts
@@ -48,7 +48,11 @@ const MEMORY_CAP = "40000000"; // 40 MB
 
 type FacetRow = { facet_value: string; cnt: string; total_distinct: string };
 
-async function seedSpansWithEvents(ch: ClickHouseClient): Promise<void> {
+async function seedSpansWithEvents({
+  ch,
+}: {
+  ch: ClickHouseClient;
+}): Promise<void> {
   const now = Date.now();
   const value = "v".repeat(VALUE_SIZE);
   const eventAttributes = Object.fromEntries(
@@ -117,7 +121,7 @@ describe("event-attribute-keys facet integration", () => {
     const rawClient = getTestClickHouseClient();
     if (!rawClient) throw new Error("ClickHouse client not available");
     ch = wrapWithDefaultSettings(rawClient);
-    await seedSpansWithEvents(ch);
+    await seedSpansWithEvents({ ch });
   }, 180_000);
 
   afterAll(async () => {
@@ -132,73 +136,75 @@ describe("event-attribute-keys facet integration", () => {
     offset: 0,
   };
 
-  describe("when discovering keys under a tight memory budget", () => {
-    it("completes and returns every distinct key exactly once", async () => {
-      const query = buildEventAttributeKeysFacetQuery(ctx);
-      const result = await ch.query({
-        query: query.sql,
-        query_params: query.params,
-        format: "JSONEachRow",
-        clickhouse_settings: { max_memory_usage: MEMORY_CAP },
-      });
-      const rows = await result.json<FacetRow>();
+  describe("given seeded spans with event attributes", () => {
+    describe("when discovering keys under a tight memory budget", () => {
+      it("completes and returns every distinct key exactly once", async () => {
+        const query = buildEventAttributeKeysFacetQuery(ctx);
+        const result = await ch.query({
+          query: query.sql,
+          query_params: query.params,
+          format: "JSONEachRow",
+          clickhouse_settings: { max_memory_usage: MEMORY_CAP },
+        });
+        const rows = await result.json<FacetRow>();
 
-      const keys = rows.map((r) => r.facet_value);
-      expect(new Set(keys).size).toBe(keys.length); // GROUP BY => no dupes
-      expect(keys).toContain("event_key_0");
-      expect(keys).toContain(`event_key_${KEYS_PER_EVENT - 1}`);
-      expect(keys).not.toContain(""); // empty keys filtered out
-      expect(rows).toHaveLength(EXPECTED_DISTINCT_KEYS);
-      expect(Number(rows[0]?.total_distinct)).toBe(EXPECTED_DISTINCT_KEYS);
+        const keys = rows.map((r) => r.facet_value);
+        expect(new Set(keys).size).toBe(keys.length); // GROUP BY => no dupes
+        expect(keys).toContain("event_key_0");
+        expect(keys).toContain(`event_key_${KEYS_PER_EVENT - 1}`);
+        expect(keys).not.toContain(""); // empty keys filtered out
+        expect(rows).toHaveLength(EXPECTED_DISTINCT_KEYS);
+        expect(Number(rows[0]?.total_distinct)).toBe(EXPECTED_DISTINCT_KEYS);
+      });
+
+      it("counts every (span, event) occurrence of a key, as before the fix", async () => {
+        // The subcolumn must not change multiplicity: one row per key per event
+        // per span, which is what orders the sidebar by frequency.
+        const query = buildEventAttributeKeysFacetQuery(ctx);
+        const result = await ch.query({
+          query: query.sql,
+          query_params: query.params,
+          format: "JSONEachRow",
+          clickhouse_settings: { max_memory_usage: MEMORY_CAP },
+        });
+        const rows = await result.json<FacetRow>();
+
+        for (const row of rows) {
+          expect(Number(row.cnt)).toBe(SPAN_COUNT * EVENTS_PER_SPAN);
+        }
+      });
     });
 
-    it("counts every (span, event) occurrence of a key, as before the fix", async () => {
-      // The subcolumn must not change multiplicity: one row per key per event
-      // per span, which is what orders the sidebar by frequency.
-      const query = buildEventAttributeKeysFacetQuery(ctx);
-      const result = await ch.query({
-        query: query.sql,
-        query_params: query.params,
-        format: "JSONEachRow",
-        clickhouse_settings: { max_memory_usage: MEMORY_CAP },
+    describe("when reading the whole Map instead of the keys subcolumn", () => {
+      it("blows the same memory budget (the bug this fixes)", async () => {
+        // Identical query except both the projection and the empty
+        // short-circuit go through the Map, dragging the values column in.
+        // This is the pre-fix shape; it must exceed the budget the
+        // subcolumn query clears.
+        const query = buildEventAttributeKeysFacetQuery(ctx);
+        const preFixSql = query.sql
+          .replace(
+            "arrayJoin(arrayJoin(`Events.Attributes`.keys))",
+            "arrayJoin(mapKeys(arrayJoin(`Events.Attributes`)))",
+          )
+          .replace(
+            "length(`Events.Attributes`.keys) > 0",
+            "length(`Events.Attributes`) > 0",
+          );
+        expect(preFixSql).not.toBe(query.sql); // guard: the replaces actually hit
+        expect(preFixSql).not.toContain(".keys");
+
+        await expect(
+          ch
+            .query({
+              query: preFixSql,
+              query_params: query.params,
+              format: "JSONEachRow",
+              clickhouse_settings: { max_memory_usage: MEMORY_CAP },
+            })
+            .then((r) => r.json()),
+        ).rejects.toThrow(/memory limit exceeded/i);
       });
-      const rows = await result.json<FacetRow>();
-
-      for (const row of rows) {
-        expect(Number(row.cnt)).toBe(SPAN_COUNT * EVENTS_PER_SPAN);
-      }
-    });
-  });
-
-  describe("when reading the whole Map instead of the keys subcolumn", () => {
-    it("blows the same memory budget (the bug this fixes)", async () => {
-      // Identical query except both the projection and the empty
-      // short-circuit go through the Map, dragging the values column in.
-      // This is the pre-fix shape; it must exceed the budget the
-      // subcolumn query clears.
-      const query = buildEventAttributeKeysFacetQuery(ctx);
-      const preFixSql = query.sql
-        .replace(
-          "arrayJoin(arrayJoin(`Events.Attributes`.keys))",
-          "arrayJoin(mapKeys(arrayJoin(`Events.Attributes`)))",
-        )
-        .replace(
-          "length(`Events.Attributes`.keys) > 0",
-          "length(`Events.Attributes`) > 0",
-        );
-      expect(preFixSql).not.toBe(query.sql); // guard: the replaces actually hit
-      expect(preFixSql).not.toContain(".keys");
-
-      await expect(
-        ch
-          .query({
-            query: preFixSql,
-            query_params: query.params,
-            format: "JSONEachRow",
-            clickhouse_settings: { max_memory_usage: MEMORY_CAP },
-          })
-          .then((r) => r.json()),
-      ).rejects.toThrow(/memory limit exceeded/i);
     });
   });
 });

--- a/platform/app/src/server/app-layer/traces/facets/__tests__/event-attribute-keys.integration.test.ts
+++ b/platform/app/src/server/app-layer/traces/facets/__tests__/event-attribute-keys.integration.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Integration coverage for the event-attribute-keys discovery facet against a
+ * real ClickHouse.
+ *
+ * `Events.Attributes` is `Array(Map(LowCardinality(String), String))` — one
+ * map per event per span. Listing the distinct keys needs only the keys, but
+ * touching the Map itself makes ClickHouse materialise the `String` values
+ * beside them. On a tenant with busy events that is what tips the facet into
+ * MEMORY_LIMIT_EXCEEDED against the ceiling in KEY_DISCOVERY_SETTINGS
+ * (observed 18x in one day in prod, all one tenant, all this facet).
+ *
+ * Reading `Events.Attributes.keys` instead gives
+ * `Array(Array(LowCardinality(String)))` and never opens the values column.
+ *
+ * The assertion is behavioural, not a string check: under a memory budget
+ * tight enough to expose the difference, the subcolumn query completes and
+ * returns the correct key list while the pre-fix shape blows the same budget.
+ * The budget is scaled down to container size; prod hits the identical wall
+ * at 2 GiB.
+ */
+
+import type { ClickHouseClient } from "@clickhouse/client";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { wrapWithDefaultSettings } from "~/server/clickhouse/safeClickhouseClient";
+import {
+  cleanupTestData,
+  getTestClickHouseClient,
+} from "../../../../event-sourcing/__tests__/integration/testContainers";
+import { buildEventAttributeKeysFacetQuery } from "../event-attribute-keys";
+
+const TENANT_ID = "facet-event-attr-keys-test";
+
+// Deliberately small in rows and lopsided in shape: few distinct keys, very
+// large values. What separates the two queries is the values-to-keys ratio,
+// not the row count, so this discriminates sharply while staying light enough
+// to seed alongside the sibling facet suite in one container.
+const SPAN_COUNT = 800;
+const EVENTS_PER_SPAN = 4;
+const KEYS_PER_EVENT = 5;
+/** Heavy, so the values column is what makes the difference. */
+const VALUE_SIZE = 4096;
+
+const EXPECTED_DISTINCT_KEYS = KEYS_PER_EVENT;
+
+// Tight enough that dragging in the values column OOMs, loose enough that the
+// keys-only read completes. Tuned against CH 25.10 on the seed below.
+const MEMORY_CAP = "40000000"; // 40 MB
+
+type FacetRow = { facet_value: string; cnt: string; total_distinct: string };
+
+async function seedSpansWithEvents(ch: ClickHouseClient): Promise<void> {
+  const now = Date.now();
+  const value = "v".repeat(VALUE_SIZE);
+  const eventAttributes = Object.fromEntries(
+    Array.from({ length: KEYS_PER_EVENT }, (_, k) => [`event_key_${k}`, value]),
+  );
+
+  const rows: Array<Record<string, unknown>> = [];
+  for (let i = 0; i < SPAN_COUNT; i++) {
+    rows.push({
+      ProjectionId: `proj-event-attr-${i}`,
+      TenantId: TENANT_ID,
+      TraceId: `${TENANT_ID}-trace-${i % 200}`,
+      SpanId: `span-${i}`,
+      ParentSpanId: null,
+      ParentTraceId: null,
+      ParentIsRemote: null,
+      Sampled: 1,
+      StartTime: new Date(now - i * 10),
+      EndTime: new Date(now - i * 10 + 5),
+      DurationMs: 5,
+      SpanName: "test-span",
+      SpanKind: 1,
+      ServiceName: "test-service",
+      ResourceAttributes: {},
+      SpanAttributes: {},
+      StatusCode: 1,
+      StatusMessage: "",
+      ScopeName: "",
+      ScopeVersion: null,
+      "Events.Timestamp": Array.from(
+        { length: EVENTS_PER_SPAN },
+        () => new Date(now - i * 10),
+      ),
+      "Events.Name": Array.from(
+        { length: EVENTS_PER_SPAN },
+        (_, e) => `event-${e}`,
+      ),
+      "Events.Attributes": Array.from(
+        { length: EVENTS_PER_SPAN },
+        () => eventAttributes,
+      ),
+      "Links.TraceId": [],
+      "Links.SpanId": [],
+      "Links.Attributes": [],
+      DroppedAttributesCount: 0,
+      DroppedEventsCount: 0,
+      DroppedLinksCount: 0,
+    });
+  }
+
+  const BATCH = 200;
+  for (let i = 0; i < rows.length; i += BATCH) {
+    await ch.insert({
+      table: "stored_spans",
+      values: rows.slice(i, i + BATCH),
+      format: "JSONEachRow",
+      clickhouse_settings: { async_insert: 0, wait_for_async_insert: 0 },
+    });
+  }
+}
+
+describe("event-attribute-keys facet integration", () => {
+  let ch: ClickHouseClient;
+
+  beforeAll(async () => {
+    const rawClient = getTestClickHouseClient();
+    if (!rawClient) throw new Error("ClickHouse client not available");
+    ch = wrapWithDefaultSettings(rawClient);
+    await seedSpansWithEvents(ch);
+  }, 180_000);
+
+  afterAll(async () => {
+    await cleanupTestData(TENANT_ID);
+  });
+
+  const ctx = {
+    tenantId: TENANT_ID,
+    // Wide window: seeded spans land within a few minutes of now.
+    timeRange: { from: Date.now() - 60 * 60 * 1000, to: Date.now() + 60_000 },
+    limit: 1000,
+    offset: 0,
+  };
+
+  describe("when discovering keys under a tight memory budget", () => {
+    it("completes and returns every distinct key exactly once", async () => {
+      const query = buildEventAttributeKeysFacetQuery(ctx);
+      const result = await ch.query({
+        query: query.sql,
+        query_params: query.params,
+        format: "JSONEachRow",
+        clickhouse_settings: { max_memory_usage: MEMORY_CAP },
+      });
+      const rows = await result.json<FacetRow>();
+
+      const keys = rows.map((r) => r.facet_value);
+      expect(new Set(keys).size).toBe(keys.length); // GROUP BY => no dupes
+      expect(keys).toContain("event_key_0");
+      expect(keys).toContain(`event_key_${KEYS_PER_EVENT - 1}`);
+      expect(keys).not.toContain(""); // empty keys filtered out
+      expect(rows).toHaveLength(EXPECTED_DISTINCT_KEYS);
+      expect(Number(rows[0]?.total_distinct)).toBe(EXPECTED_DISTINCT_KEYS);
+    });
+
+    it("counts every (span, event) occurrence of a key, as before the fix", async () => {
+      // The subcolumn must not change multiplicity: one row per key per event
+      // per span, which is what orders the sidebar by frequency.
+      const query = buildEventAttributeKeysFacetQuery(ctx);
+      const result = await ch.query({
+        query: query.sql,
+        query_params: query.params,
+        format: "JSONEachRow",
+        clickhouse_settings: { max_memory_usage: MEMORY_CAP },
+      });
+      const rows = await result.json<FacetRow>();
+
+      for (const row of rows) {
+        expect(Number(row.cnt)).toBe(SPAN_COUNT * EVENTS_PER_SPAN);
+      }
+    });
+  });
+
+  describe("when reading the whole Map instead of the keys subcolumn", () => {
+    it("blows the same memory budget (the bug this fixes)", async () => {
+      // Identical query except both the projection and the empty
+      // short-circuit go through the Map, dragging the values column in.
+      // This is the pre-fix shape; it must exceed the budget the
+      // subcolumn query clears.
+      const query = buildEventAttributeKeysFacetQuery(ctx);
+      const preFixSql = query.sql
+        .replace(
+          "arrayJoin(arrayJoin(`Events.Attributes`.keys))",
+          "arrayJoin(mapKeys(arrayJoin(`Events.Attributes`)))",
+        )
+        .replace(
+          "length(`Events.Attributes`.keys) > 0",
+          "length(`Events.Attributes`) > 0",
+        );
+      expect(preFixSql).not.toBe(query.sql); // guard: the replaces actually hit
+      expect(preFixSql).not.toContain(".keys");
+
+      await expect(
+        ch
+          .query({
+            query: preFixSql,
+            query_params: query.params,
+            format: "JSONEachRow",
+            clickhouse_settings: { max_memory_usage: MEMORY_CAP },
+          })
+          .then((r) => r.json()),
+      ).rejects.toThrow(/memory limit exceeded/i);
+    });
+  });
+});

--- a/platform/app/src/server/app-layer/traces/facets/__tests__/registry-invariants.unit.test.ts
+++ b/platform/app/src/server/app-layer/traces/facets/__tests__/registry-invariants.unit.test.ts
@@ -148,7 +148,27 @@ describe("FACET_REGISTRY shape", () => {
       }
       const { sql } = def.queryBuilder(baseCtx);
       expect(sql).toContain("Events.Attributes");
-      expect(sql).toMatch(/arrayJoin\s*\(\s*mapKeys\s*\(\s*arrayJoin/);
+      expect(sql).toMatch(/arrayJoin\s*\(\s*arrayJoin\s*\(/);
+    });
+
+    it("flattens through the keys subcolumn, never the Map itself", () => {
+      // `Events.Attributes` is Array(Map(LowCardinality(String), String)).
+      // Reading the Map to list keys materialises the String values beside
+      // them, which is MEMORY_LIMIT_EXCEEDED on a tenant with busy events.
+      // `.keys` is Array(Array(LowCardinality(String))) and never opens the
+      // values column. Same invariant span-attribute-keys and metadata-keys
+      // already hold for their flat Maps. Behavioural coverage lives in
+      // event-attribute-keys.integration.test.ts.
+      const def = FACET_REGISTRY.find((d) => d.key === "eventAttributeKeys");
+      if (def?.kind !== "dynamic_keys") {
+        throw new Error("expected eventAttributeKeys to be dynamic_keys");
+      }
+      const { sql } = def.queryBuilder(baseCtx);
+      expect(sql).toContain("`Events.Attributes`.keys");
+      expect(sql).not.toContain("mapKeys");
+      expect(sql).not.toContain("mapValues");
+      expect(sql).toMatch(/length\(`Events\.Attributes`\.keys\)\s*>\s*0/);
+      expect(sql).not.toMatch(/length\(`Events\.Attributes`\)\s*>\s*0/);
     });
   });
 });

--- a/platform/app/src/server/app-layer/traces/facets/__tests__/registry-invariants.unit.test.ts
+++ b/platform/app/src/server/app-layer/traces/facets/__tests__/registry-invariants.unit.test.ts
@@ -164,7 +164,12 @@ describe("FACET_REGISTRY shape", () => {
         throw new Error("expected eventAttributeKeys to be dynamic_keys");
       }
       const { sql } = def.queryBuilder(baseCtx);
-      expect(sql).toContain("`Events.Attributes`.keys");
+      // Matched as one shape on purpose. Asserting the fragments separately
+      // would pass on a query that flattened the whole Map and only mentioned
+      // `.keys` in the filter, which is the exact bug being pinned out.
+      expect(sql).toMatch(
+        /arrayJoin\(\s*arrayJoin\(\s*`Events\.Attributes`\.keys\s*\)\s*\)\s+AS\s+key/,
+      );
       expect(sql).not.toContain("mapKeys");
       expect(sql).not.toContain("mapValues");
       expect(sql).toMatch(/length\(`Events\.Attributes`\.keys\)\s*>\s*0/);

--- a/platform/app/src/server/app-layer/traces/facets/event-attribute-keys.ts
+++ b/platform/app/src/server/app-layer/traces/facets/event-attribute-keys.ts
@@ -12,6 +12,24 @@ import { baseParams, buildTimeWhere, KEY_DISCOVERY_SETTINGS } from "./helpers";
  * span — so we double-`arrayJoin` to flatten down to a single key column
  * before deduping.
  *
+ * Both the projection and the empty short-circuit go through the
+ * `.keys` subcolumn, never `Events.Attributes` itself:
+ *
+ *   - `Events.Attributes.keys` is `Array(Array(LowCardinality(String)))` —
+ *     the keys of every event's map, without the `String` values beside
+ *     them. Reading the Map itself pulls those values into memory to
+ *     produce a key list that never mentions them.
+ *   - `length(Events.Attributes.keys)` counts events exactly as
+ *     `length(Events.Attributes)` does, and reads the same lightweight
+ *     column the projection already needs.
+ *
+ * This is the same trap `span-attribute-keys.ts` and `metadata-keys.ts`
+ * document for their flat Maps. It survived here longer because the
+ * subcolumn has to be reached through the outer array, so the fix does not
+ * look identical to theirs. Untreated it is worth 2 GiB+ on a tenant with
+ * busy events, which is MEMORY_LIMIT_EXCEEDED against the ceiling in
+ * KEY_DISCOVERY_SETTINGS.
+ *
  * Mirrors `span-attribute-keys.ts`: returns just the key list, with values
  * loaded lazily once the user expands a key. Keeping discovery cheap is
  * the whole point — a tenant can have unbounded distinct event-attribute
@@ -36,10 +54,10 @@ export function buildEventAttributeKeysFacetQuery(
         count() AS cnt,
         count() OVER () AS total_distinct
       FROM (
-        SELECT arrayJoin(mapKeys(arrayJoin(\`Events.Attributes\`))) AS key
+        SELECT arrayJoin(arrayJoin(\`Events.Attributes\`.keys)) AS key
         FROM stored_spans
         WHERE ${where}
-          AND length(\`Events.Attributes\`) > 0
+          AND length(\`Events.Attributes\`.keys) > 0
       )
       WHERE key != ''
         ${prefixFilter}


### PR DESCRIPTION
## Evidence

The event-attribute-keys discovery facet started failing in prod. Over the trailing 7 days ClickHouse logged **18 `MEMORY_LIMIT_EXCEEDED` failures**, and the concentration is total:

| | |
| --- | --- |
| all 18 | this one facet shape |
| all 18 | a single day |
| all 18 | a single tenant (id redacted) |
| other facet shapes | 0 |

It fails at **2.11 GiB against the 2.00 GiB** ceiling in `KEY_DISCOVERY_SETTINGS`, on a 256 MiB allocation inside `MergeTreeSelect`. That location matters: the failure is in the read, not the aggregation, so the `max_bytes_before_external_group_by` half of those settings cannot help. It only spills the aggregation hash table.

Not a regression. The facet files have not changed except for the workspace restructure, so this is a tenant whose event volume crossed the threshold.

User-visible effect: the trace sidebar's event-attribute key list fails to load for that tenant.

## Suspected cause

`Events.Attributes` is `Array(Map(LowCardinality(String), String))` — one map per event per span. The facet needs only the keys, but it arrayJoin-ed the Map itself, so ClickHouse materialised the `String` values alongside every key to produce a key list that never mentions them.

This is the same trap `span-attribute-keys.ts` and `metadata-keys.ts` already document for their flat Maps, and both were fixed by probing `.keys`. This one survived because the subcolumn has to be reached through the outer array, so the fix does not look identical to theirs. A sweep of the facet directory confirms it was the only remaining instance; `events.ts` probes `Events.Name`, which is already a lightweight column.

## Proposed fix

Read `Events.Attributes.keys` for both the projection and the empty short-circuit.

```diff
-        SELECT arrayJoin(mapKeys(arrayJoin(`Events.Attributes`))) AS key
+        SELECT arrayJoin(arrayJoin(`Events.Attributes`.keys)) AS key
         FROM stored_spans
         WHERE ${where}
-          AND length(`Events.Attributes`) > 0
+          AND length(`Events.Attributes`.keys) > 0
```

Semantics are unchanged. `.keys` yields one key array per event, so the double `arrayJoin` produces exactly the same rows with the same multiplicity, and `length()` counts events on either expression.

## Expected impact

The values column stops being read. Partition pruning is already effective here and does not change: **21 parts / 676 granules before and after.** This is a read-width fix, not a pruning fix, so the win is bytes per granule rather than granules.

`KEY_DISCOVERY_SETTINGS` stays as it is. It remains a sensible guard; it was simply aimed at the aggregation while the cost was in the read.

## EXPLAIN check

`EXPLAIN PLAN indexes = 1, actions = 1` against the affected tenant (id redacted), showing the column each shape actually reads.

Before:

```
Actions: INPUT : 0 -> Events.Attributes Array(Map(LowCardinality(String), String))
         ARRAY JOIN Events.Attributes -> Map(LowCardinality(String), String)
         FUNCTION mapKeys(...) -> Array(String)
    Parts: 21   Granules: 676
```

After:

```
Actions: INPUT : 0 -> Events.Attributes.keys Array(Array(LowCardinality(String)))
         ARRAY JOIN Events.Attributes.keys -> Array(LowCardinality(String))
    Parts: 21   Granules: 676
```

The read type goes from `Array(Map(LowCardinality(String), String))` to `Array(Array(LowCardinality(String)))`. The `String` values are gone from the plan. Both shapes get the same PREWHERE and the same granule count.

## Test plan

`event-attribute-keys.integration.test.ts`, against a real ClickHouse via testcontainers, modelled on the sibling suite. The assertion is behavioural rather than a string check:

- Under a memory budget tight enough to expose the difference, the subcolumn query completes and returns every distinct key exactly once, with `total_distinct` correct.
- Occurrence counts are asserted to be unchanged, so the subcolumn cannot silently alter the multiplicity that orders the sidebar by frequency.
- **The pre-fix shape is asserted to blow the same budget.** Without that, the suite would pass just as happily against the unfixed query.

The fixture is deliberately small in rows and lopsided in shape — few distinct keys, large values — because what separates the two queries is the values-to-keys ratio, not the row count. The budget is scaled to container size; prod hits the identical wall at 2 GiB.

3/3 pass on a fresh container. Typecheck and lint clean.

One thing worth flagging for whoever runs the suite locally: `span-attribute-keys.integration.test.ts` fails on my machine on a fresh container **with this branch's test not loaded at all**, because its 40,000-span fixture exhausts the 1 GiB test container. That is pre-existing and unrelated to this change, and I have left it alone rather than reshape someone else's fixture without evidence it is red in CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced memory usage when discovering event-attribute keys, especially for spans with large event values.
  * Prevented memory-limit errors during event-attribute exploration across large trace datasets.
  * Ensured distinct event-attribute keys are displayed with accurate occurrence counts.
  * Improved reliability and performance when discovering keys from trace events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->