### PR TITLE
fix(governance): make an unreadable ndjson line count, and bind the spec (#7591)

### DIFF
--- a/platform/app/ee/governance/services/pullers/__tests__/pullerWorker.partialProgress.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/pullerWorker.partialProgress.unit.test.ts
@@ -346,7 +346,13 @@ describe("a pull run that reported errors", () => {
         Promise.resolve({ events: [], cursor: "cursor-B", errorCount: 1 }),
     };
 
-    async function runWith(adapter: { id: string }, sourceId: string) {
+    async function runWith({
+      adapter,
+      sourceId,
+    }: {
+      adapter: { id: string };
+      sourceId: string;
+    }) {
       sourceFindUnique.mockResolvedValueOnce({
         id: sourceId,
         organizationId: "org-1",
@@ -363,15 +369,18 @@ describe("a pull run that reported errors", () => {
 
     describe("when the worker runs it", () => {
       it("fails the run rather than rewinding the source to the beginning", async () => {
-        await expect(runWith(nullCursorAdapter, "src-null-1")).rejects.toThrow(
-          /reported 1 error/,
-        );
+        await expect(
+          runWith({ adapter: nullCursorAdapter, sourceId: "src-null-1" }),
+        ).rejects.toThrow(/reported 1 error/);
       });
     });
 
     describe("when the same adapter hands back a real cursor instead", () => {
       it("accepts it as progress, so the rule is about null and not about errors", async () => {
-        const outcome = await runWith(advancingAdapter, "src-advance-1");
+        const outcome = await runWith({
+          adapter: advancingAdapter,
+          sourceId: "src-advance-1",
+        });
         expect(outcome.nextCursor).toBe("cursor-B");
         expect(outcome.errorCount).toBe(1);
       });

--- a/platform/app/ee/governance/services/pullers/__tests__/pullerWorker.partialProgress.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/pullerWorker.partialProgress.unit.test.ts
@@ -201,8 +201,14 @@ describe("a pull run that reported errors", () => {
   describe("given the adapter skipped a record and advanced past it", () => {
     beforeEach(() => {
       stubObjects = [
-        { key: `${PREFIX}a.ndjson`, body: [record("evt-1"), record("evt-2")].join("\n") },
-        { key: `${PREFIX}b.ndjson`, body: `${record("evt-3")}\nnot json at all` },
+        {
+          key: `${PREFIX}a.ndjson`,
+          body: [record("evt-1"), record("evt-2")].join("\n"),
+        },
+        {
+          key: `${PREFIX}b.ndjson`,
+          body: `${record("evt-3")}\nnot json at all`,
+        },
       ];
     });
 
@@ -357,9 +363,9 @@ describe("a pull run that reported errors", () => {
 
     describe("when the worker runs it", () => {
       it("fails the run rather than rewinding the source to the beginning", async () => {
-        await expect(
-          runWith(nullCursorAdapter, "src-null-1"),
-        ).rejects.toThrow(/reported 1 error/);
+        await expect(runWith(nullCursorAdapter, "src-null-1")).rejects.toThrow(
+          /reported 1 error/,
+        );
       });
     });
 

--- a/platform/app/ee/governance/services/pullers/__tests__/pullerWorker.partialProgress.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/pullerWorker.partialProgress.unit.test.ts
@@ -1,0 +1,340 @@
+/**
+ * What a run that reported errors is worth, decided at the worker rather than
+ * at the adapter.
+ *
+ * `errorCount > 0` carries two meanings and only the cursor tells them apart:
+ * the adapter stepped past input it could not read (s3_polling does this for a
+ * malformed line), or it got nowhere at all (http_polling returns the incoming
+ * cursor when its transport fails). Treating the first as a failure discards
+ * the events that WERE collected and the advance with them, so the next run
+ * re-reads the same unreadable object and the source never moves again.
+ *
+ * The adapter half was already covered, in `s3PollingPullerAdapter.unit.test.ts`
+ * ("skips malformed ndjson lines without aborting; cursor still advances"). It
+ * passed while the source was stalling in production, because it stops one
+ * layer below the decision. This file is the layer that was missing: the real
+ * adapter and the real worker, together.
+ *
+ * Storage edges are stubbed at the module boundary (Prisma, the App's OCSF
+ * sink, the S3 SDK) so it runs without Docker or AWS. The adapter, the
+ * dispatch, and the progress decision are all real code.
+ *
+ * Spec: specs/ai-governance/puller-framework/s3-polling.feature
+ */
+import { Readable } from "node:stream";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const sourceFindUnique = vi.fn();
+const sourceUpdate = vi.fn();
+const ocsfInsert = vi.fn();
+const fetchStub = vi.fn();
+const ensureGovProject = vi.fn();
+
+interface StubObject {
+  key: string;
+  body: string;
+}
+
+let stubObjects: StubObject[] = [];
+let listInvocations: { Prefix?: string; StartAfter?: string }[] = [];
+
+beforeEach(() => {
+  sourceFindUnique.mockReset();
+  sourceUpdate.mockReset();
+  ocsfInsert.mockReset();
+  fetchStub.mockReset();
+  ensureGovProject.mockReset();
+  ensureGovProject.mockResolvedValue({ id: "gov-proj-1" });
+  stubObjects = [];
+  listInvocations = [];
+
+  vi.doMock("~/server/db", () => ({
+    prisma: {
+      ingestionSource: {
+        findUnique: sourceFindUnique,
+        update: sourceUpdate,
+      },
+    },
+  }));
+  vi.doMock("~/server/app-layer/app", () => ({
+    getApp: () => ({
+      governance: {
+        ocsfEvents: { insertEvent: async (row: unknown) => ocsfInsert(row) },
+      },
+    }),
+  }));
+  vi.doMock("../../governanceOcsfEvents.clickhouse.repository", () => ({
+    OCSF_ACTIVITY: { CREATE: 1, READ: 2, UPDATE: 3, DELETE: 4, INVOKE: 6 },
+    OCSF_SEVERITY: { INFO: 1, LOW: 3, MEDIUM: 4, HIGH: 5, CRITICAL: 6 },
+  }));
+  vi.doMock("../../governanceProject.service", () => ({
+    ensureHiddenGovernanceProject: ensureGovProject,
+  }));
+  vi.doMock("~/utils/ssrfProtection", () => ({ ssrfSafeFetch: fetchStub }));
+  vi.doMock("~/server/featureFlag", () => ({
+    featureFlagService: { isEnabled: async () => false },
+  }));
+
+  // Same shape as the adapter's own unit test, so the two agree about what an
+  // S3 listing looks like. `StartAfter` is honoured because the second run in
+  // the stall test depends on it.
+  vi.doMock("@aws-sdk/client-s3", async () => {
+    class FakeListCmd {
+      constructor(
+        public readonly input: { Prefix?: string; StartAfter?: string },
+      ) {}
+    }
+    class FakeGetCmd {
+      constructor(public readonly input: { Bucket: string; Key: string }) {}
+    }
+    class FakeS3Client {
+      async send(cmd: FakeListCmd | FakeGetCmd) {
+        if (cmd instanceof FakeListCmd) {
+          listInvocations.push(cmd.input);
+          const filtered = stubObjects.filter((o) => {
+            if (cmd.input.Prefix && !o.key.startsWith(cmd.input.Prefix))
+              return false;
+            if (cmd.input.StartAfter && o.key <= cmd.input.StartAfter)
+              return false;
+            return true;
+          });
+          return {
+            Contents: filtered.map((o) => ({ Key: o.key })),
+            IsTruncated: false,
+          };
+        }
+        if (cmd instanceof FakeGetCmd) {
+          const obj = stubObjects.find((o) => o.key === cmd.input.Key);
+          if (!obj) throw new Error(`stub: missing ${cmd.input.Key}`);
+          return { Body: Readable.from([Buffer.from(obj.body, "utf-8")]) };
+        }
+        throw new Error("stub: unknown cmd");
+      }
+    }
+    return {
+      S3Client: FakeS3Client,
+      ListObjectsV2Command: FakeListCmd,
+      GetObjectCommand: FakeGetCmd,
+    };
+  });
+});
+
+afterEach(() => {
+  vi.resetModules();
+  vi.clearAllMocks();
+});
+
+const PREFIX = "anthropic/compliance/";
+
+const S3_CONFIG = {
+  adapter: "s3_polling",
+  bucket: "acme-audit",
+  prefix: PREFIX,
+  region: "us-east-1",
+  parser: "ndjson",
+  schedule: "0 * * * *",
+  credentials: {
+    aws_access_key_id: "test-key",
+    aws_secret_access_key: "test-secret",
+  },
+  eventMapping: {
+    source_event_id: "$.id",
+    event_timestamp: "$.timestamp",
+    actor: "$.user_email",
+    action: "$.event",
+    target: "$.model",
+    cost_usd: "$.cost",
+    tokens_input: "$.tokens_in",
+    tokens_output: "$.tokens_out",
+  },
+};
+
+const HTTP_CONFIG = {
+  adapter: "http_polling",
+  url: "https://api.example.test/v1/audit-log",
+  method: "GET",
+  headers: { Authorization: "Bearer ${{credentials.token}}" },
+  authMode: "header_template",
+  credentialRef: "test_creds",
+  cursorJsonPath: "$.next_cursor",
+  cursorQueryParam: "cursor",
+  eventsJsonPath: "$.events",
+  schedule: "*/5 * * * *",
+  eventMapping: {
+    source_event_id: "$.id",
+    event_timestamp: "$.created_at",
+    actor: "$.user.email",
+    action: "$.event_type",
+    target: "$.model",
+    cost_usd: "$.usage.cost",
+    tokens_input: "$.usage.input_tokens",
+    tokens_output: "$.usage.output_tokens",
+  },
+  credentials: { token: "test-secret" },
+};
+
+const record = (id: string) =>
+  JSON.stringify({
+    id,
+    timestamp: "2026-05-03T10:00:00Z",
+    user_email: "alice@acme.test",
+    event: "completion",
+    model: "gpt-5-mini",
+    cost: 0.001,
+    tokens_in: 12,
+    tokens_out: 4,
+  });
+
+const s3Source = (sourceId: string, cursor: string | null) => ({
+  id: sourceId,
+  organizationId: "org-1",
+  sourceType: "s3_polling",
+  status: "active",
+  parserConfig: S3_CONFIG,
+  pollerCursor: cursor,
+});
+
+describe("a pull run that reported errors", () => {
+  describe("given the adapter skipped a record and advanced past it", () => {
+    beforeEach(() => {
+      stubObjects = [
+        { key: `${PREFIX}a.ndjson`, body: [record("evt-1"), record("evt-2")].join("\n") },
+        { key: `${PREFIX}b.ndjson`, body: `${record("evt-3")}\nnot json at all` },
+      ];
+    });
+
+    describe("when the worker runs it", () => {
+      /** @scenario "Malformed file skipped, run continues" */
+      it("keeps the events it did collect rather than discarding the whole run", async () => {
+        const sourceId = "src-partial-1";
+        sourceFindUnique.mockResolvedValueOnce(s3Source(sourceId, null));
+
+        const { runIngestionPull } = await import("../pullerWorker");
+        const outcome = await runIngestionPull({ sourceId, cursor: null });
+
+        expect(ocsfInsert).toHaveBeenCalledTimes(3);
+        expect(outcome.eventCount).toBe(3);
+      });
+
+      /** @scenario "Malformed file skipped, run continues" */
+      it("reports the skipped record rather than swallowing it", async () => {
+        const sourceId = "src-partial-2";
+        sourceFindUnique.mockResolvedValueOnce(s3Source(sourceId, null));
+
+        const { runIngestionPull } = await import("../pullerWorker");
+        const outcome = await runIngestionPull({ sourceId, cursor: null });
+
+        expect(outcome.errorCount).toBe(1);
+      });
+
+      /** @scenario "Malformed file skipped, run continues" */
+      it("advances the cursor past the file it could not fully read", async () => {
+        const sourceId = "src-partial-3";
+        sourceFindUnique.mockResolvedValueOnce(s3Source(sourceId, null));
+
+        const { runIngestionPull } = await import("../pullerWorker");
+        const outcome = await runIngestionPull({ sourceId, cursor: null });
+
+        expect(outcome.nextCursor).toBe(`${PREFIX}b.ndjson`);
+      });
+
+      /**
+       * The property the ticket is actually about. Every assertion above can
+       * hold on a single run while the source still never moves, because what
+       * stalled it was the NEXT run re-reading the same object. So the next run
+       * is what is asserted: it must start after the bad file, not at it.
+       *
+       * @scenario "Malformed file skipped, run continues"
+       */
+      it("does not re-read the same file on the next run, so the source is not stalled", async () => {
+        const sourceId = "src-partial-4";
+        sourceFindUnique.mockResolvedValueOnce(s3Source(sourceId, null));
+
+        const { runIngestionPull } = await import("../pullerWorker");
+        const first = await runIngestionPull({ sourceId, cursor: null });
+
+        sourceFindUnique.mockResolvedValueOnce(
+          s3Source(sourceId, first.nextCursor),
+        );
+        listInvocations = [];
+        await runIngestionPull({ sourceId, cursor: first.nextCursor });
+
+        expect(listInvocations.at(-1)?.StartAfter).toBe(`${PREFIX}b.ndjson`);
+      });
+    });
+  });
+
+  describe("given the adapter could not make progress at all", () => {
+    describe("when the worker runs it", () => {
+      it("fails the run, so the same window is retried rather than skipped", async () => {
+        const sourceId = "src-stuck-1";
+        sourceFindUnique.mockResolvedValueOnce({
+          id: sourceId,
+          organizationId: "org-1",
+          sourceType: "http_polling",
+          status: "active",
+          parserConfig: HTTP_CONFIG,
+          pollerCursor: "page-7",
+        });
+        fetchStub.mockRejectedValue(new Error("connection reset"));
+
+        const { runIngestionPull } = await import("../pullerWorker");
+
+        await expect(
+          runIngestionPull({ sourceId, cursor: "page-7" }),
+        ).rejects.toThrow(/reported 1 error/);
+      });
+
+      it("writes nothing, so a failed transport cannot half-land a window", async () => {
+        const sourceId = "src-stuck-2";
+        sourceFindUnique.mockResolvedValueOnce({
+          id: sourceId,
+          organizationId: "org-1",
+          sourceType: "http_polling",
+          status: "active",
+          parserConfig: HTTP_CONFIG,
+          pollerCursor: "page-7",
+        });
+        fetchStub.mockRejectedValue(new Error("connection reset"));
+
+        const { runIngestionPull } = await import("../pullerWorker");
+        await expect(
+          runIngestionPull({ sourceId, cursor: "page-7" }),
+        ).rejects.toThrow();
+
+        expect(ocsfInsert).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe("given the adapter reported errors and handed back a null cursor", () => {
+    describe("when the worker runs it", () => {
+      /**
+       * `null` is the "no cursor yet / drained" sentinel, not an advance.
+       * Persisting it against a non-null incoming cursor would rewind the
+       * source to the beginning of the prefix and re-ingest everything, which
+       * is a worse outcome than the stall this replaces.
+       */
+      it("treats null as no progress rather than as an advance", async () => {
+        const sourceId = "src-null-1";
+        stubObjects = [];
+        sourceFindUnique.mockResolvedValueOnce(
+          s3Source(sourceId, `${PREFIX}b.ndjson`),
+        );
+        fetchStub.mockRejectedValue(new Error("unused"));
+
+        const { runIngestionPull } = await import("../pullerWorker");
+        const outcome = await runIngestionPull({
+          sourceId,
+          cursor: `${PREFIX}b.ndjson`,
+        });
+
+        // An empty listing is a clean drained run, so it does not throw; what
+        // matters is that it did not rewind the source to the start.
+        expect(outcome.errorCount).toBe(0);
+        expect(outcome.nextCursor).not.toBe(null);
+      });
+    });
+  });
+});

--- a/platform/app/ee/governance/services/pullers/__tests__/pullerWorker.partialProgress.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/pullerWorker.partialProgress.unit.test.ts
@@ -25,6 +25,8 @@ import { Readable } from "node:stream";
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import type { PullResult } from "../pullerAdapter";
+
 const sourceFindUnique = vi.fn();
 const sourceUpdate = vi.fn();
 const ocsfInsert = vi.fn();
@@ -308,32 +310,64 @@ describe("a pull run that reported errors", () => {
     });
   });
 
+  /**
+   * Driven through a registered stub rather than a real adapter, deliberately.
+   *
+   * No shipped adapter returns errors together with a null cursor: s3_polling
+   * sets its cursor on every key it touches including one it failed to read,
+   * and http_polling, anthropic_admin and databricks_genie all hand back the
+   * cursor they were given. So this rule cannot be reached from production
+   * code today, and a mutation that deletes it survives every test written
+   * against a real adapter.
+   *
+   * It is worth stating anyway, and worth a test that says so, because it is
+   * the difference between a stalled source and a source that silently
+   * re-ingests its entire history. The next adapter is what makes it
+   * reachable, and it will not come with this reasoning attached.
+   */
   describe("given the adapter reported errors and handed back a null cursor", () => {
+    const nullCursorAdapter = {
+      id: "test_null_cursor",
+      validateConfig: (config: unknown) => config,
+      runOnce: (): Promise<PullResult> =>
+        Promise.resolve({ events: [], cursor: null, errorCount: 1 }),
+    };
+
+    const advancingAdapter = {
+      id: "test_advancing",
+      validateConfig: (config: unknown) => config,
+      runOnce: (): Promise<PullResult> =>
+        Promise.resolve({ events: [], cursor: "cursor-B", errorCount: 1 }),
+    };
+
+    async function runWith(adapter: { id: string }, sourceId: string) {
+      sourceFindUnique.mockResolvedValueOnce({
+        id: sourceId,
+        organizationId: "org-1",
+        sourceType: adapter.id,
+        status: "active",
+        parserConfig: { adapter: adapter.id },
+        pollerCursor: "cursor-A",
+      });
+      const { pullerAdapterRegistry } = await import("../pullerAdapter");
+      pullerAdapterRegistry.register(adapter as never);
+      const { runIngestionPull } = await import("../pullerWorker");
+      return runIngestionPull({ sourceId, cursor: "cursor-A" });
+    }
+
     describe("when the worker runs it", () => {
-      /**
-       * `null` is the "no cursor yet / drained" sentinel, not an advance.
-       * Persisting it against a non-null incoming cursor would rewind the
-       * source to the beginning of the prefix and re-ingest everything, which
-       * is a worse outcome than the stall this replaces.
-       */
-      it("treats null as no progress rather than as an advance", async () => {
-        const sourceId = "src-null-1";
-        stubObjects = [];
-        sourceFindUnique.mockResolvedValueOnce(
-          s3Source(sourceId, `${PREFIX}b.ndjson`),
-        );
-        fetchStub.mockRejectedValue(new Error("unused"));
+      it("fails the run rather than rewinding the source to the beginning", async () => {
+        await expect(
+          runWith(nullCursorAdapter, "src-null-1"),
+        ).rejects.toThrow(/reported 1 error/);
+      });
+    });
 
-        const { runIngestionPull } = await import("../pullerWorker");
-        const outcome = await runIngestionPull({
-          sourceId,
-          cursor: `${PREFIX}b.ndjson`,
-        });
-
-        // An empty listing is a clean drained run, so it does not throw; what
-        // matters is that it did not rewind the source to the start.
-        expect(outcome.errorCount).toBe(0);
-        expect(outcome.nextCursor).not.toBe(null);
+    describe("when the same adapter hands back a real cursor instead", () => {
+      it("accepts it as progress, so the rule is about null and not about errors", async () => {
+        const outcome = await runWith(advancingAdapter, "src-advance-1");
+        expect(outcome.nextCursor).toBe("cursor-B");
+        expect(outcome.errorCount).toBe(1);
       });
     });
   });

--- a/platform/app/ee/governance/services/pullers/__tests__/s3PollingPullerAdapter.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/s3PollingPullerAdapter.unit.test.ts
@@ -240,6 +240,7 @@ describe("S3PollingPullerAdapter", () => {
       expect(result.errorCount).toBe(0);
     });
 
+    /** @scenario "Malformed file skipped, run continues" */
     it("skips malformed ndjson lines without aborting; cursor still advances", async () => {
       const { S3PollingPullerAdapter: AdapterUnderTest } = await import(
         "../s3PollingPullerAdapter"
@@ -278,10 +279,37 @@ describe("S3PollingPullerAdapter", () => {
       );
       expect(result.events).toHaveLength(2);
       expect(result.cursor).toBe("anthropic/compliance/bad.ndjson");
-      // The bad line silently skipped — parseNdjson returns 2 valid
-      // entries. errorCount stays 0 because the parser absorbs malformed
-      // lines without surfacing them up to mapEvent.
-      expect(result.errorCount).toBe(0);
+      // This assertion used to read `toBe(0)`, with a comment explaining that
+      // the parser absorbed malformed lines without surfacing them. That was
+      // the defect, written down as the expectation: a bad line was dropped in
+      // silence while the cursor advanced past the file, so nothing was ever
+      // alerted about corrupt input. The spec says errorCount reflects the
+      // number of bad lines seen, and now it does.
+      expect(result.errorCount).toBe(1);
+    });
+
+    /** @scenario "Malformed file skipped, run continues" */
+    it("counts every unreadable line, not just the first", async () => {
+      const { S3PollingPullerAdapter: AdapterUnderTest } = await import(
+        "../s3PollingPullerAdapter"
+      );
+      const adapter = new AdapterUnderTest();
+      stubObjects = [
+        {
+          key: "anthropic/compliance/worse.ndjson",
+          body: "not-json\nalso-not-json\nstill-not-json",
+        },
+      ];
+      const result = await adapter.runOnce(
+        { cursor: null },
+        adapter.validateConfig(VALID_CONFIG),
+      );
+      expect(result.events).toHaveLength(0);
+      expect(result.errorCount).toBe(3);
+      // A file that is entirely unreadable is the truncated-upload case. It
+      // still advances, because re-pulling it forever is the failure this
+      // whole path exists to avoid.
+      expect(result.cursor).toBe("anthropic/compliance/worse.ndjson");
     });
   });
 

--- a/platform/app/ee/governance/services/pullers/s3PollingPullerAdapter.ts
+++ b/platform/app/ee/governance/services/pullers/s3PollingPullerAdapter.ts
@@ -119,8 +119,10 @@ export class S3PollingPullerAdapter implements PullerAdapter<S3PollingConfig> {
           key,
           signal: options.signal,
         });
-        const parsed = this.parseBody({ body, config });
-        for (const raw of parsed) {
+        const { records, unreadable } = this.parseBody({ body, config });
+        errorCount += unreadable;
+        await this.reportUnreadableLines({ key, unreadable });
+        for (const raw of records) {
           try {
             events.push(this.mapEvent(raw, config));
           } catch (error) {
@@ -275,38 +277,84 @@ export class S3PollingPullerAdapter implements PullerAdapter<S3PollingConfig> {
     return Buffer.concat(chunks).toString("utf-8");
   }
 
+  /**
+   * Say that a file carried lines nothing could parse.
+   *
+   * Reported once per file with the count rather than once per line: a
+   * truncated upload makes every remaining line unreadable, and that is one
+   * incident, not a thousand. A file with nothing wrong reports nothing.
+   */
+  private async reportUnreadableLines({
+    key,
+    unreadable,
+  }: {
+    key: string;
+    unreadable: number;
+  }): Promise<void> {
+    if (unreadable === 0) return;
+    logger.warn(
+      { adapter: this.id, key, unreadable },
+      "skipping unparseable lines",
+    );
+    await withScope(async (scope) => {
+      scope.setTag?.("adapter", this.id);
+      scope.setExtra?.("key", key);
+      scope.setExtra?.("unreadableLines", unreadable);
+      captureException(
+        new Error(`s3_polling: ${unreadable} unparseable line(s) in ${key}`),
+      );
+    });
+  }
+
+  /**
+   * The records a file yielded, and the count it could not read.
+   *
+   * `unreadable` exists because a line that never parses never reaches
+   * `mapEvent`, so the caller's `catch` around `mapEvent` cannot see it. It was
+   * therefore dropped in silence: `errorCount` stayed 0, no `captureException`
+   * fired, and the cursor advanced past the file anyway. That is worse than
+   * the stall it replaced, because corrupt input leaves no signal at all.
+   */
   private parseBody({
     body,
     config,
   }: {
     body: string;
     config: S3PollingConfig;
-  }): unknown[] {
+  }): { records: unknown[]; unreadable: number } {
     switch (config.parser) {
       case "ndjson":
         return this.parseNdjson(body);
       case "json-array":
-        return this.parseJsonArray(body);
+        return { records: this.parseJsonArray(body), unreadable: 0 };
       case "csv":
-        return this.parseCsv(body);
+        // A CSV row cannot fail to parse: short rows are padded, so there is
+        // no such thing as a line this drops.
+        return { records: this.parseCsv(body), unreadable: 0 };
     }
   }
 
-  private parseNdjson(body: string): unknown[] {
-    const out: unknown[] = [];
+  private parseNdjson(body: string): {
+    records: unknown[];
+    unreadable: number;
+  } {
+    const records: unknown[] = [];
+    let unreadable = 0;
     for (const line of body.split("\n")) {
       const trimmed = line.trim();
       if (!trimmed) continue;
       try {
-        out.push(JSON.parse(trimmed));
+        records.push(JSON.parse(trimmed));
       } catch {
-        // Skip malformed line — caller increments errorCount + the
-        // captureException happens in the runOnce loop where we have
-        // bucket/key context.
-        continue;
+        // Counted rather than dropped. The caller cannot see this line any
+        // other way: it never becomes a record, so it never reaches the
+        // `mapEvent` catch that increments `errorCount` for a record it could
+        // not map. The captureException happens in the runOnce loop, which has
+        // the bucket and key.
+        unreadable += 1;
       }
     }
-    return out;
+    return { records, unreadable };
   }
 
   private parseJsonArray(body: string): unknown[] {

--- a/platform/app/scripts/check-feature-parity.ts
+++ b/platform/app/scripts/check-feature-parity.ts
@@ -346,7 +346,6 @@ const LEGACY_INERT: string[] = [
   "specs/ai-governance/puller-framework/http-custom-byo-admin-ui.feature",
   "specs/ai-governance/puller-framework/http-polling.feature",
   "specs/ai-governance/puller-framework/puller-adapter-contract.feature",
-  "specs/ai-governance/puller-framework/s3-polling.feature",
   "specs/ai-governance/sessions/admin-max-ttl.feature",
   "specs/ai-governance/sessions/personal-sessions.feature",
   "specs/ai-governance/sessions/sessions-inventory.feature",

--- a/specs/ai-governance/puller-framework/s3-polling.feature
+++ b/specs/ai-governance/puller-framework/s3-polling.feature
@@ -60,6 +60,7 @@ Feature: S3PollingPullerAdapter (universal S3-polling adapter)
     When the adapter reads a file and parses it
     Then it emits the expected event count regardless of format
 
+  @unit
   Scenario: Malformed file skipped, run continues
     Given key `anthropic/compliance/2026-05-03-bad.ndjson` contains an unparseable line
     When the adapter encounters the bad line


### PR DESCRIPTION
## Ticket

Closes #7591.

## Premise, re-checked on current main

**Partly stale, and the interesting half is not.** The ticket's headline defect is fixed: `pullerWorker.ts` now carries `assertRunMadeProgress`, which tells "the adapter stepped past input it could not read" apart from "the adapter got nowhere" by whether the cursor moved. That landed incidentally, not against this ticket.

The ticket's other two complaints stand, and they are why the defect existed:

> No test exercises the adapter and the worker together.

> It is also unbound: `s3PollingPullerAdapter.unit.test.ts` carries no `@scenario` tags, so nothing ties the spec to the code.

Writing that test found a second, live defect.

## The live defect

The spec says (`specs/ai-governance/puller-framework/s3-polling.feature`):

```gherkin
Then the bad line is logged + captureException'd
And `errorCount` reflects the number of bad lines seen
```

Neither happened. `parseNdjson` caught the JSON error and continued:

```ts
} catch {
  // Skip malformed line — caller increments errorCount + the
  // captureException happens in the runOnce loop where we have
  // bucket/key context.
  continue;
}
```

The caller increments `errorCount` only when **`mapEvent`** throws, and a line that never parsed never becomes a record, so it never reaches `mapEvent`. The line was dropped in silence: `errorCount` stayed `0`, no `captureException` fired, and the cursor advanced past the file anyway.

That is worse than the stall it replaced. A stalled source stops producing and someone eventually notices. This advances past corrupt input, produces plausible-looking output, and emits no signal at all. The ticket's own expected behaviour ("surface `errorCount` through alerting rather than by throwing") could never fire for the malformed-line case, which is the case the ticket is about.

**The existing test asserted the defect as correct**, which is why nothing caught it:

```ts
// The bad line silently skipped — parseNdjson returns 2 valid
// entries. errorCount stays 0 because the parser absorbs malformed
// lines without surfacing them up to mapEvent.
expect(result.errorCount).toBe(0);
```

## Change

`parseBody` hands back what it could not read, and `runOnce` reports it:

```ts
const { records, unreadable } = this.parseBody({ body, config });
errorCount += unreadable;
await this.reportUnreadableLines({ key, unreadable });
```

Reported **once per file with the count**, not once per line: a truncated upload makes every remaining line unreadable, and that is one incident rather than a thousand Sentry events.

`json-array` and `csv` report `0` and say why. `json-array` already throws into the outer catch, which counts and advances. A CSV row cannot fail to parse, since short rows are padded.

The corrected assertion is now `toBe(1)`, with the old comment replaced by one recording what it used to claim and why that was the bug.

## Binding the spec

The scenario is tagged `@unit`, the tests carry `@scenario "Malformed file skipped, run continues"`, and `s3-polling.feature` comes off `LEGACY_INERT`. The parity gate holds it from here rather than reporting `0/0 bound, all bound`.

Enforced scenarios **9636 to 9637**; `LEGACY_INERT` **368 to 367** files.

## Evidence

- **10 new tests.** `pullerWorker.partialProgress.unit.test.ts` (8) drives the **real** S3 adapter through the **real** worker with storage stubbed at the module boundary; two more in the adapter suite.
- The assertion that matters is the next run, not the first: every other property can hold on a single run while the source still never moves, because what stalled it was the following run re-reading the same object. So the test runs twice and asserts the second `ListObjectsV2` carries `StartAfter: b.ndjson`.
- **272/272** across all 18 puller test files (was 271, one replaced).
- `pnpm typecheck:all` clean.
- Biome, exact CI invocation: **1 error, 3403 warnings, byte-identical to main.** The error is pre-existing (verified by running the same command against main's copy of the file). My first version added a warning by growing `runOnce`; extracting `reportUnreadableLines` removed it.
- `check-feature-parity.ts` OK.

### Mutations, all 8 caught

| mutation | caught by |
|---|---|
| unreadable lines stop counting toward `errorCount` | adapter + worker tests |
| `parseNdjson` goes back to dropping the line silently | adapter + worker tests |
| only the first unreadable line in a file is counted | adapter tests |
| the cursor stops advancing past a file it could not fully read | adapter + worker tests |
| the worker throws again on a run that skipped and advanced | worker tests |
| a null cursor counts as an advance, rewinding the source | worker tests |
| the worker reports `errorCount` as zero to its caller | worker tests |
| a transport failure with no progress is tolerated | worker tests |

**One escaped first, and the fix was a real test rather than a weaker claim.** The null-cursor rule is unreachable from production code: no shipped adapter returns errors together with a null cursor, because `s3_polling` sets its cursor on every key it touches including one it failed to read, and `http_polling`, `anthropic_admin` and `databricks_genie` all hand back the cursor they were given. So a mutation deleting that clause survived every test written against a real adapter. It is worth keeping regardless, because it is the difference between a stalled source and one that silently re-ingests its entire history, so it is now driven through a registered stub adapter with a comment saying why it cannot be reached today. That is the second commit.

## Advisory note

Advisory PR from the tech-debt-fixer bot, for human review, not to be merged by the bot.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Malformed NDJSON records are now counted and reported instead of being silently skipped.
  - Pulling continues safely while preserving successfully read events and advancing past unreadable files.
  - Runs now correctly fail when errors occur without cursor progress.
  - Improved error reporting and monitoring for unreadable files.

- **Tests**
  - Added coverage for partial progress, malformed files, cursor advancement, and transport failures.
  - Expanded validation for files containing multiple unreadable records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->