### PR TITLE
fix(ci): reformat expect() call to unbreak lint gate on main

### DIFF
--- a/platform/app/scripts/__tests__/bug-report-discovery.unit.test.ts
+++ b/platform/app/scripts/__tests__/bug-report-discovery.unit.test.ts
@@ -53,10 +53,9 @@ describe("agent report discovery notices", () => {
     /** @scenario "The attribution footer carries the report line on every page" */
     it("injects the agent report line above the Powered by note", () => {
       const script = read("docs/posthog.js");
-      expect(
-        script,
-        "posthog.js lost the footer injection",
-      ).toContain("lw-agent-report");
+      expect(script, "posthog.js lost the footer injection").toContain(
+        "lw-agent-report",
+      );
       expect(script).toContain("npx langwatch report");
       expect(script).toContain('href="/support"');
 


### PR DESCRIPTION
## Cause

PR #7546 committed `scripts/__tests__/bug-report-discovery.unit.test.ts` with an `expect()` line break that biome's formatter disagrees with. `biome check` treats format diffs as errors → lint gate red on main since `058882c08c`.

The `zodSalvage.ts` complexity warnings visible in the same CI output are **warnings** (exit 0) — they do not contribute to the failure.

## Fix

`pnpm lint:fix` on the one file. 4 lines removed, 3 added — biome moves the message arg onto the same line as `expect(script,` and wraps after `.toContain(`.

## Failing output (before)

```
scripts/__tests__/bug-report-discovery.unit.test.ts format ━━━━━━━━━━━━━━

  × Formatter would have printed the following content:
```

## Passing output (after)

```
Checked 1 file in 5ms. No fixes applied.
```

## Not fixed

- `zodSalvage.ts` complexity (68 vs max 10) and line count (66 vs max 60) — these are **warn**-level, not blocking. They will become errors once their baseline reaches zero per the biome config policy.

Fixes #7605

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reformatted a test assertion for improved readability.
  * No behavioral changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->