### PR TITLE
feat(nlpgo): code nodes can request a shorter timeout via timeout_ms

### DIFF
--- a/services/nlpgo/app/engine/blocks/codeblock/codeblock.go
+++ b/services/nlpgo/app/engine/blocks/codeblock/codeblock.go
@@ -169,7 +169,11 @@ type Request struct {
 	// every agent wiring it up by hand. The engine scrubs the value out of
 	// captured stdout and stderr, so printing the environment stores nothing.
 	SandboxAPIKey string
-	Timeout       time.Duration
+	// Timeout asks for LESS time than the operator allows; it can never buy
+	// more. Options.DefaultTimeout carries the deployment's ceiling on how
+	// long untrusted customer code may hold a worker, so Execute clamps this
+	// value to it. Zero or negative means "no request of my own".
+	Timeout time.Duration
 }
 
 // Result is what the executor returns.
@@ -248,9 +252,15 @@ func withSandboxCredential(env []string, apiKey, endpoint string) []string {
 
 // Execute runs the request. Wall-clock timeout kills the subprocess.
 func (e *Executor) Execute(ctx context.Context, req Request) (*Result, error) {
-	timeout := req.Timeout
-	if timeout == 0 {
-		timeout = e.opts.DefaultTimeout
+	// The operator's ceiling wins. A per-request value only ever shortens the
+	// budget: a workflow author must not be able to escape
+	// NLPGO_ENGINE_CODE_BLOCK_TIMEOUT_SECONDS by writing a bigger number into
+	// their own node. A non-positive request means no request at all — and in
+	// particular keeps a negative duration away from context.WithTimeout,
+	// which would expire the run before the subprocess starts.
+	timeout := e.opts.DefaultTimeout
+	if req.Timeout > 0 && req.Timeout < timeout {
+		timeout = req.Timeout
 	}
 	runCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()

--- a/services/nlpgo/app/engine/blocks/codeblock/timeout_clamp_test.go
+++ b/services/nlpgo/app/engine/blocks/codeblock/timeout_clamp_test.go
@@ -1,0 +1,78 @@
+package codeblock_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/langwatch/langwatch/services/nlpgo/app/engine/blocks/codeblock"
+)
+
+// TestCodeBlock_RequestTimeoutCannotExceedTheOperatorCeiling pins that a
+// per-request timeout is a way to ask for LESS time than the operator allows,
+// never more. Options.DefaultTimeout carries
+// NLPGO_ENGINE_CODE_BLOCK_TIMEOUT_SECONDS — the bound on how long untrusted
+// customer code may hold a worker — so a larger number arriving from a
+// workflow node must not win.
+// @scenario "A per-node code timeout cannot exceed the operator's ceiling"
+func TestCodeBlock_RequestTimeoutCannotExceedTheOperatorCeiling(t *testing.T) {
+	requirePython(t)
+	e, err := codeblock.New(codeblock.Options{DefaultTimeout: 500 * time.Millisecond})
+	require.NoError(t, err)
+
+	start := time.Now()
+	res, err := e.Execute(context.Background(), codeblock.Request{
+		Code:            "def execute():\n    import time\n    time.sleep(10)\n    return {'ok': True}\n",
+		DeclaredOutputs: []string{"ok"},
+		Timeout:         30 * time.Second,
+	})
+	elapsed := time.Since(start)
+	require.NoError(t, err)
+	assert.True(t, res.TimedOut, "the ceiling, not the request, must decide")
+	require.NotNil(t, res.Error)
+	assert.Equal(t, codeblock.TimeoutType, res.Error.Type)
+	assert.Less(t, elapsed, 3*time.Second, "the run must be stopped at the ceiling")
+}
+
+// TestCodeBlock_RequestTimeoutBelowTheCeilingIsHonored pins the other half:
+// asking for less than the ceiling still shortens the run.
+func TestCodeBlock_RequestTimeoutBelowTheCeilingIsHonored(t *testing.T) {
+	requirePython(t)
+	e, err := codeblock.New(codeblock.Options{DefaultTimeout: 30 * time.Second})
+	require.NoError(t, err)
+
+	start := time.Now()
+	res, err := e.Execute(context.Background(), codeblock.Request{
+		Code:            "def execute():\n    import time\n    time.sleep(10)\n    return {'ok': True}\n",
+		DeclaredOutputs: []string{"ok"},
+		Timeout:         500 * time.Millisecond,
+	})
+	elapsed := time.Since(start)
+	require.NoError(t, err)
+	assert.True(t, res.TimedOut)
+	assert.Less(t, elapsed, 3*time.Second)
+}
+
+// TestCodeBlock_NegativeRequestTimeoutFallsBackToTheDefault pins that a
+// negative duration never reaches context.WithTimeout, where it would expire
+// the context before the subprocess starts and report a timeout for code that
+// was never given a chance to run.
+// @scenario "A negative per-node code timeout falls back to the default"
+func TestCodeBlock_NegativeRequestTimeoutFallsBackToTheDefault(t *testing.T) {
+	requirePython(t)
+	e, err := codeblock.New(codeblock.Options{DefaultTimeout: 30 * time.Second})
+	require.NoError(t, err)
+
+	res, err := e.Execute(context.Background(), codeblock.Request{
+		Code:            "def execute():\n    return {'ok': 'done'}\n",
+		DeclaredOutputs: []string{"ok"},
+		Timeout:         -1 * time.Second,
+	})
+	require.NoError(t, err)
+	assert.False(t, res.TimedOut, "a negative timeout is not a zero budget")
+	require.Nil(t, res.Error)
+	assert.Equal(t, "done", res.Outputs["ok"])
+}

--- a/services/nlpgo/app/engine/code_timeout_test.go
+++ b/services/nlpgo/app/engine/code_timeout_test.go
@@ -1,0 +1,92 @@
+package engine
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/langwatch/langwatch/services/nlpgo/app/engine/blocks/codeblock"
+	"github.com/langwatch/langwatch/services/nlpgo/app/engine/dsl"
+)
+
+// withTimeoutMS adds a `timeout_ms` parameter to a code node, the same
+// identifier, type and units the HTTP block already reads.
+func withTimeoutMS(node *dsl.Node, ms int) *dsl.Node {
+	value, _ := json.Marshal(ms)
+	node.Data.Parameters = append(node.Data.Parameters, dsl.Field{
+		Identifier: "timeout_ms",
+		Type:       dsl.FieldTypeInt,
+		Value:      value,
+	})
+	return node
+}
+
+const sleepTenSeconds = "def execute():\n    import time\n    time.sleep(10)\n    return {'ok': 'done'}\n"
+
+// TestRunCode_HonorsTheNodeTimeout pins that a code node declaring
+// `timeout_ms` is stopped at that budget instead of running to the executor
+// default — the same per-node knob the HTTP block already offers.
+// @scenario "A code node's timeout_ms shortens its budget"
+func TestRunCode_HonorsTheNodeTimeout(t *testing.T) {
+	requirePythonForRedaction(t)
+	codeExec, err := codeblock.New(codeblock.Options{DefaultTimeout: 30 * time.Second})
+	require.NoError(t, err)
+	eng := New(Options{Code: codeExec})
+
+	node := withTimeoutMS(codeNode("code-1", sleepTenSeconds, "ok"), 500)
+	start := time.Now()
+	_, nodeErr := eng.runCode(context.Background(), node, nodeRun{ns: &NodeState{ID: "code-1"}})
+	elapsed := time.Since(start)
+
+	require.NotNil(t, nodeErr, "the node must be stopped at its declared budget")
+	assert.Equal(t, "code_block_timeout", nodeErr.Type)
+	assert.Less(t, elapsed, 3*time.Second)
+}
+
+// TestRunCode_NodeTimeoutCannotExceedTheOperatorCeiling pins the security
+// property end to end: a workflow author writing a number larger than
+// NLPGO_ENGINE_CODE_BLOCK_TIMEOUT_SECONDS does not buy their code more time.
+// @scenario "A code node cannot raise its own timeout above the operator ceiling"
+func TestRunCode_NodeTimeoutCannotExceedTheOperatorCeiling(t *testing.T) {
+	requirePythonForRedaction(t)
+	codeExec, err := codeblock.New(codeblock.Options{DefaultTimeout: 500 * time.Millisecond})
+	require.NoError(t, err)
+	eng := New(Options{Code: codeExec})
+
+	node := withTimeoutMS(codeNode("code-1", sleepTenSeconds, "ok"), 30_000)
+	start := time.Now()
+	_, nodeErr := eng.runCode(context.Background(), node, nodeRun{ns: &NodeState{ID: "code-1"}})
+	elapsed := time.Since(start)
+
+	require.NotNil(t, nodeErr)
+	assert.Equal(t, "code_block_timeout", nodeErr.Type)
+	assert.Less(t, elapsed, 3*time.Second, "the ceiling still bounds the run")
+}
+
+// TestRunCode_NonPositiveNodeTimeoutFallsBackToTheDefault pins that a missing,
+// zero or negative `timeout_ms` leaves the executor default in charge, and in
+// particular that a negative value never becomes a zero budget.
+// @scenario "A missing or negative code timeout_ms falls back to the default"
+func TestRunCode_NonPositiveNodeTimeoutFallsBackToTheDefault(t *testing.T) {
+	requirePythonForRedaction(t)
+	codeExec, err := codeblock.New(codeblock.Options{DefaultTimeout: 30 * time.Second})
+	require.NoError(t, err)
+	eng := New(Options{Code: codeExec})
+
+	quick := "def execute():\n    return {'ok': 'done'}\n"
+	for name, node := range map[string]*dsl.Node{
+		"missing":  codeNode("code-1", quick, "ok"),
+		"zero":     withTimeoutMS(codeNode("code-1", quick, "ok"), 0),
+		"negative": withTimeoutMS(codeNode("code-1", quick, "ok"), -5000),
+	} {
+		t.Run(name, func(t *testing.T) {
+			outputs, nodeErr := eng.runCode(context.Background(), node, nodeRun{ns: &NodeState{ID: "code-1"}})
+			require.Nil(t, nodeErr, "expected the node to succeed, got %+v", nodeErr)
+			assert.Equal(t, "done", outputs["ok"])
+		})
+	}
+}

--- a/services/nlpgo/app/engine/engine.go
+++ b/services/nlpgo/app/engine/engine.go
@@ -596,6 +596,7 @@ func (e *Engine) runCode(ctx context.Context, node *dsl.Node, run nodeRun) (map[
 		Secrets:         run.secrets,
 		Params:          run.params,
 		SandboxAPIKey:   run.sandboxAPIKey,
+		Timeout:         nodeTimeout(node.Data.Parameters),
 	})
 	if err != nil {
 		return nil, run.storeError(&NodeError{Type: "code_runner_error", Message: err.Error()})
@@ -605,6 +606,19 @@ func (e *Engine) runCode(ctx context.Context, node *dsl.Node, run nodeRun) (map[
 		return nil, run.storeError(nodeErrorFromCodeBlock(res.Error))
 	}
 	return res.Outputs, nil
+}
+
+// nodeTimeout reads the node's `timeout_ms` parameter — the same identifier
+// and units the HTTP block uses — as a duration. Missing, zero and negative
+// all yield 0, which the executors read as "use the configured default". The
+// value is a request for a SHORTER budget only; the code executor clamps it to
+// the operator's ceiling.
+func nodeTimeout(params []dsl.Field) time.Duration {
+	ms := paramInt(params, "timeout_ms")
+	if ms <= 0 {
+		return 0
+	}
+	return time.Duration(ms) * time.Millisecond
 }
 
 func (e *Engine) runHTTP(ctx context.Context, node *dsl.Node, inputs map[string]any, ns *NodeState, secrets map[string]string) (map[string]any, *NodeError) {


### PR DESCRIPTION
## Summary

Code nodes can now declare `timeout_ms`, the same parameter the HTTP block already accepts. Unlike the HTTP block, the node value can only ever ask for **less** time than the operator allows.

## The gap

`codeblock.Request` has carried a `Timeout time.Duration` field, and `Executor.Execute` has honored it, for as long as the block has existed. Nothing ever set it. `runCode` (`services/nlpgo/app/engine/engine.go`) built the `Request` and left `Timeout` zero on every path, so the field was unreachable capability — every code node in every workflow ran on the executor default, with no way to say "this one is a long job" or "kill this one early."

`runHTTP` in the same file already reads a `timeout_ms` parameter off the node. The convention existed; the code block just wasn't wired into it.

## The security decision, which is the part worth reviewing

The three sibling blocks all let the node override the default **outright and unbounded**:

- `app/engine/blocks/httpblock/executor.go:152-155` — `if req.TimeoutMS > 0 { timeout = ... }`
- `app/engine/blocks/agentblock/workflow_runner.go:162`
- `app/engine/blocks/evaluatorblock/executor.go:190`

That is defensible for those three. They bound an outbound call to an endpoint the customer already controls, and Lambda's own ceiling backstops them.

It is **not** defensible for the code block. `NLPGO_ENGINE_CODE_BLOCK_TIMEOUT_SECONDS` exists to bound how long *untrusted customer Python* may hold a worker. Copying the sibling pattern would have meant any workflow author could write `timeout_ms: 86400000` into their own node and escape the operator's limit entirely.

So this diff deliberately diverges. The per-node value **clamps**:

| `timeout_ms` | effective budget |
|---|---|
| missing / `0` / negative | `Options.DefaultTimeout` |
| below the ceiling | the node value |
| above the ceiling | the ceiling |

The clamp lives in the **executor**, next to `context.WithTimeout` — not in the engine — so no future caller of `codeblock.Request` can route around it. `nodeTimeout` in the engine independently normalizes non-positive to `0`, so a negative duration is guarded at both ends and can never reach `context.WithTimeout` to produce an already-expired context.

If reviewers want the sibling blocks to clamp too, that is a reasonable follow-up, but it is a behavior change to three shipped features and is not in this diff.

## Merge order matters

This PR should land **after** #7614. On current `main`, `Options.DefaultTimeout` is hardcoded to 60s, so the ceiling this clamps to is a constant no operator can raise — a node asking for 5 minutes would silently get 60 seconds. #7614 is what makes the ceiling configurable, and only together do these two give an operator a raisable limit and an author a way to opt below it.

## The fix

- `services/nlpgo/app/engine/engine.go` — `runCode` sets `Timeout: nodeTimeout(node.Data.Parameters)`; new `nodeTimeout` helper reads `timeout_ms` through the existing `paramInt`, so it accepts `30000` and `"30000"` alike, exactly as `runHTTP` does.
- `services/nlpgo/app/engine/blocks/codeblock/codeblock.go` — `Execute` starts from the ceiling and only lowers it. `Request.Timeout`'s doc comment now states the contract.

## Tests

Three tests were genuinely red before the fix, as value mismatches rather than compile errors:

```
--- FAIL: TestCodeBlock_RequestTimeoutCannotExceedTheOperatorCeiling (10.05s)
    timeout_clamp_test.go:34: Should be true
        Messages: the ceiling, not the request, must decide
--- FAIL: TestCodeBlock_NegativeRequestTimeoutFallsBackToTheDefault (0.00s)
    timeout_clamp_test.go:75: Should be false
        Messages: a negative timeout is not a zero budget
--- FAIL: TestRunCode_HonorsTheNodeTimeout (10.05s)
    code_timeout_test.go:45: Expected value not to be nil.
        Messages: the node must be stopped at its declared budget
```

The 10.05s runtimes are the point: pre-fix, a 10-second sleep ran to completion because the requested budget was ignored.

Three further tests pass before and after and are labelled in-file as regression pins, not proof of the fix.

## Verification

`go build ./...`, `go vet ./...`, `gofmt -l .` (empty), and `go test ./...` all run from `services/nlpgo`. Every package `ok` except `app/engine/blocks/codeblock`, which reports 8 `TestSharedSessionCodeAgent_*` failures. Those are **proven** pre-existing, not assumed: unmodified `origin/main` was extracted to a scratch dir and produced the identical 8. They shell out to a `python3` that lacks the langwatch SDK in this environment.

**Unverified:** no TypeScript build, typecheck, or test was run. No end-to-end exercise against a live nlpgo service or a real Studio workflow — the evidence is Go unit and engine tests only.

## TypeScript side

No schema change was needed and none was made. `codeComponentSchema.parameters` (`platform/app/src/optimization_studio/types/dsl.ts:544`) is a union that already admits `fieldSchema`, whose `identifier` is an arbitrary string and whose `type` enum includes `"int"` — so `{ identifier: "timeout_ms", type: "int", value: 5000 }` already validates on a code node today. That conclusion comes from reading the Zod schemas, not from running a check.

`code-agent.adapter.ts` emits no `timeout_ms`, so scenario code agents keep the operator default. Surfacing this as a Studio control or a `CodeAgentData.timeoutMs` is a product decision, deliberately not made here — the wire format is ready for it.

## Deployment Impact

**Environment variables:** none added, removed, or renamed. This PR consumes `Options.DefaultTimeout` as a ceiling; #7614 is what connects that option to `NLPGO_ENGINE_CODE_BLOCK_TIMEOUT_SECONDS`.

**Helm values:** unchanged. No chart template, value, or default is touched.

**Default `helm install`:** behavior is unchanged for every existing workflow. No workflow in the field sets `timeout_ms` on a code node today, and a missing parameter resolves to `0`, which means "use the default" — the same 60s budget as before.

**BYOC dataplane:** no impact. No new network calls, no new image requirement, no new IAM or secret surface. The change is confined to how an existing in-process context deadline is computed.

**Rollback:** revert the commit. No migration, no persisted state, no config to unwind.

## Follow-ups, not in this diff

- The HTTP, agent, and evaluator blocks still let a node override their timeout without a ceiling. Same question, three more places, three shipped behaviors to change.
- No user-facing control for `timeout_ms` on code nodes in Studio.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring execution timeouts per code node.
  * Positive timeout values can shorten the default execution limit.

* **Bug Fixes**
  * Prevented requested timeouts from exceeding the configured execution ceiling.
  * Invalid, zero, or negative timeout values now safely use the default limit.
  * Improved handling of timeout values provided as text.

* **Tests**
  * Added coverage for timeout limits, overrides, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->