### PR TITLE
fix(nlpgo): SSE heartbeat cadence is hardcoded to 15s; operator knob is dead code

### DIFF
--- a/services/nlpgo/adapters/httpapi/handlers.go
+++ b/services/nlpgo/adapters/httpapi/handlers.go
@@ -374,9 +374,9 @@ func normalizeInputs(v any) map[string]any {
 // executeStreamHandler is the entry point for /go/studio/execute.
 // Returns Server-Sent Events: one `execution_state_change` per node
 // transition (running → success/error), `is_alive_response` heartbeats every
-// NLP_STREAM_HEARTBEAT_SECONDS, and a final `done` (or `error`) frame
-// when the run completes. Closes when the client disconnects.
-func executeStreamHandler(application *app.App) http.HandlerFunc {
+// NLPGO_ENGINE_STREAM_HEARTBEAT_SECONDS, and a final `done` (or `error`)
+// frame when the run completes. Closes when the client disconnects.
+func executeStreamHandler(application *app.App, configuredHeartbeat time.Duration) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		executor := application.Executor()
 		if executor == nil {
@@ -453,7 +453,7 @@ func executeStreamHandler(application *app.App) http.HandlerFunc {
 		}()
 
 		events, err := executor.ExecuteStream(streamCtx, *req, app.WorkflowStreamOptions{
-			Heartbeat: streamHeartbeat(r),
+			Heartbeat: streamHeartbeat(r, configuredHeartbeat),
 		})
 		if err != nil {
 			// The SSE error frame reaches the client; this line is the
@@ -496,17 +496,32 @@ func writeSSE(w http.ResponseWriter, flusher http.Flusher, eventType string, pay
 	flusher.Flush()
 }
 
-// streamHeartbeat returns the heartbeat interval, defaulting to 15s
-// when the request didn't override it via header. Tests use a tiny
-// interval to verify ticking.
-func streamHeartbeat(r *http.Request) time.Duration {
+// DefaultStreamHeartbeat is the is_alive_response cadence applied when
+// neither the request header nor the operator config names one. Matches
+// specs/nlp-go/_shared/contract.md §6; clients detect a dead stream by
+// missed heartbeats, so changing it is a contract change.
+const DefaultStreamHeartbeat = 15 * time.Second
+
+// streamHeartbeat returns the heartbeat interval for one stream. The
+// per-request header wins (tests use a tiny interval to verify
+// ticking), then the operator's configured cadence, then the default.
+//
+// A non-positive `configured` falls through to DefaultStreamHeartbeat
+// rather than reaching the engine: engine.ExecuteStream only starts the
+// heartbeat goroutine when the interval is positive, so passing zero
+// through would silently disable heartbeats entirely and let idle
+// proxies tear healthy streams down.
+func streamHeartbeat(r *http.Request, configured time.Duration) time.Duration {
 	if v := r.Header.Get("X-LangWatch-NLPGO-Heartbeat-MS"); v != "" {
 		var ms int
 		if _, err := fmt.Sscanf(v, "%d", &ms); err == nil && ms > 0 {
 			return time.Duration(ms) * time.Millisecond
 		}
 	}
-	return 15 * time.Second
+	if configured > 0 {
+		return configured
+	}
+	return DefaultStreamHeartbeat
 }
 
 // PlaygroundProxy is the dispatcher surface the playground-proxy

--- a/services/nlpgo/adapters/httpapi/handlers_logging_test.go
+++ b/services/nlpgo/adapters/httpapi/handlers_logging_test.go
@@ -152,7 +152,7 @@ func TestExecuteSyncHandlerLogsEngineErrorWithEnrichedContext(t *testing.T) {
 // error frame the client sees.
 func TestExecuteStreamHandlerLogsStartFailureWithEnrichedContext(t *testing.T) {
 	application := app.New(app.WithWorkflowExecutor(&failingExecutor{streamErr: errors.New("stream refused to start")}))
-	logs := observedHandlerRequest(t, executeStreamHandler(application))
+	logs := observedHandlerRequest(t, executeStreamHandler(application, DefaultStreamHeartbeat))
 
 	entries := logs.FilterMessage("studio_stream_failed").All()
 	if len(entries) != 1 {

--- a/services/nlpgo/adapters/httpapi/handlers_stream_heartbeat_test.go
+++ b/services/nlpgo/adapters/httpapi/handlers_stream_heartbeat_test.go
@@ -1,0 +1,109 @@
+package httpapi
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/langwatch/langwatch/services/nlpgo/app"
+)
+
+// heartbeatRecordingExecutor is a fake app.WorkflowExecutor that records
+// the stream options the handler built and immediately ends the stream.
+// A fake rather than a mock: the assertion is on the value that reached
+// the engine port, not on the call sequence.
+type heartbeatRecordingExecutor struct {
+	gotHeartbeat time.Duration
+}
+
+func (e *heartbeatRecordingExecutor) Execute(context.Context, app.WorkflowRequest) (*app.WorkflowResult, error) {
+	return &app.WorkflowResult{Status: "success"}, nil
+}
+
+func (e *heartbeatRecordingExecutor) ExecuteStream(_ context.Context, _ app.WorkflowRequest, opts app.WorkflowStreamOptions) (<-chan app.WorkflowStreamEvent, error) {
+	e.gotHeartbeat = opts.Heartbeat
+	ch := make(chan app.WorkflowStreamEvent)
+	close(ch)
+	return ch, nil
+}
+
+const heartbeatProbeBody = `{
+	"type": "execute_flow",
+	"payload": {
+		"trace_id": "abc",
+		"workflow": {"workflow_id": "wf", "api_key": "k", "spec_version": "1.3"}
+	}
+}`
+
+// postExecuteStream drives the real router so the assertion covers the
+// whole RouterDeps → handler → engine-port path, not just the helper.
+func postExecuteStream(t *testing.T, deps RouterDeps, header string) {
+	t.Helper()
+	r := httptest.NewRequest(http.MethodPost, "/go/studio/execute", strings.NewReader(heartbeatProbeBody))
+	if header != "" {
+		r.Header.Set("X-LangWatch-NLPGO-Heartbeat-MS", header)
+	}
+	rec := httptest.NewRecorder()
+	NewRouter(deps).ServeHTTP(rec, r)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestExecuteStreamHandler_UsesTheConfiguredHeartbeat pins the second
+// half of the wiring: the cadence carried on RouterDeps must be the one
+// handed to the engine, replacing the 15s the handler used to hardcode.
+func TestExecuteStreamHandler_UsesTheConfiguredHeartbeat(t *testing.T) {
+	exec := &heartbeatRecordingExecutor{}
+	postExecuteStream(t, RouterDeps{
+		App:             app.New(app.WithWorkflowExecutor(exec)),
+		StreamHeartbeat: 30 * time.Second,
+	}, "")
+
+	if want := 30 * time.Second; exec.gotHeartbeat != want {
+		t.Errorf("engine heartbeat = %v; want %v (RouterDeps.StreamHeartbeat)", exec.gotHeartbeat, want)
+	}
+}
+
+// TestExecuteStreamHandler_UnsetHeartbeatFallsBackToTheDefault pins that
+// an unconfigured router still emits is_alive_response at the contract
+// cadence, rather than handing the engine a zero that disables the
+// heartbeat goroutine outright.
+func TestExecuteStreamHandler_UnsetHeartbeatFallsBackToTheDefault(t *testing.T) {
+	exec := &heartbeatRecordingExecutor{}
+	postExecuteStream(t, RouterDeps{App: app.New(app.WithWorkflowExecutor(exec))}, "")
+
+	if exec.gotHeartbeat != DefaultStreamHeartbeat {
+		t.Errorf("engine heartbeat = %v; want %v", exec.gotHeartbeat, DefaultStreamHeartbeat)
+	}
+}
+
+// TestExecuteStreamHandler_HeaderStillOverridesTheConfiguredHeartbeat
+// keeps the per-request test hook working after the config knob landed:
+// the integration suite drives a 250ms cadence through this header.
+func TestExecuteStreamHandler_HeaderStillOverridesTheConfiguredHeartbeat(t *testing.T) {
+	exec := &heartbeatRecordingExecutor{}
+	postExecuteStream(t, RouterDeps{
+		App:             app.New(app.WithWorkflowExecutor(exec)),
+		StreamHeartbeat: 30 * time.Second,
+	}, "250")
+
+	if want := 250 * time.Millisecond; exec.gotHeartbeat != want {
+		t.Errorf("engine heartbeat = %v; want %v (header must win)", exec.gotHeartbeat, want)
+	}
+}
+
+// TestStreamHeartbeat_NegativeConfigDoesNotReachTheEngine is the edge
+// the config helper guards, asserted at the point of use: a negative
+// duration must never be handed on, because the engine starts no
+// heartbeat goroutine for one.
+func TestStreamHeartbeat_NegativeConfigDoesNotReachTheEngine(t *testing.T) {
+	r := httptest.NewRequest(http.MethodPost, "/", nil)
+
+	if got := streamHeartbeat(r, -30*time.Second); got != DefaultStreamHeartbeat {
+		t.Errorf("streamHeartbeat(-30s) = %v; want %v", got, DefaultStreamHeartbeat)
+	}
+}

--- a/services/nlpgo/adapters/httpapi/router.go
+++ b/services/nlpgo/adapters/httpapi/router.go
@@ -33,6 +33,10 @@ type RouterDeps struct {
 	// in-process aigateway dispatcher. nil → /go/proxy/v1/* returns the
 	// 501 stub (used by tests that don't exercise the playground path).
 	PlaygroundProxy PlaygroundProxy
+	// StreamHeartbeat is the is_alive_response cadence for
+	// /go/studio/execute, from the operator's
+	// NLPGO_ENGINE_STREAM_HEARTBEAT_SECONDS. Zero → DefaultStreamHeartbeat.
+	StreamHeartbeat time.Duration
 	// OTel is the OpenTelemetry provider whose `ForceFlush` is called
 	// after each /go/studio/* request, so spans for the just-finished
 	// workflow ship to the collector before the Lambda runtime freezes
@@ -70,7 +74,7 @@ func NewRouter(deps RouterDeps) http.Handler {
 				s.Use(forceFlushMiddleware(deps.OTel))
 			}
 			s.Post("/execute_sync", executeSyncHandler(deps.App))
-			s.Post("/execute", executeStreamHandler(deps.App))
+			s.Post("/execute", executeStreamHandler(deps.App, deps.StreamHeartbeat))
 		})
 		g.HandleFunc("/proxy/v1/*", proxyPassthroughHandler(deps.PlaygroundProxy))
 		g.HandleFunc("/proxy/v1beta/*", proxyPassthroughHandler(deps.PlaygroundProxy))

--- a/services/nlpgo/serve.go
+++ b/services/nlpgo/serve.go
@@ -23,15 +23,7 @@ func Serve(ctx context.Context, application *app.App, deps *Deps, cfg Config, pl
 	deps.Logger.Info("nlpgo_starting", zap.String("addr", cfg.Server.Addr))
 
 	info := contexts.MustGetServiceInfo(ctx)
-	handler := httpapi.NewRouter(httpapi.RouterDeps{
-		App:                 application,
-		Logger:              deps.Logger,
-		Health:              deps.Health,
-		Version:             info.Version,
-		MaxRequestBodyBytes: cfg.Server.MaxRequestBodyBytes,
-		PlaygroundProxy:     playground,
-		OTel:                deps.OTel,
-	})
+	handler := httpapi.NewRouter(newRouterDeps(application, deps, cfg, info.Version, playground))
 
 	srv := &http.Server{
 		Handler:           handler,
@@ -50,6 +42,40 @@ func Serve(ctx context.Context, application *app.App, deps *Deps, cfg Config, pl
 	)
 	g.Add(buildServices(deps, srv)...)
 	return g.Run(ctx)
+}
+
+// newRouterDeps maps the service config onto the HTTP adapter's
+// dependencies. Extracted from Serve so a test can assert which
+// operator knob reaches which transport option without binding a
+// listener or standing up the engine.
+func newRouterDeps(application *app.App, deps *Deps, cfg Config, version string, playground httpapi.PlaygroundProxy) httpapi.RouterDeps {
+	return httpapi.RouterDeps{
+		App:                 application,
+		Logger:              deps.Logger,
+		Health:              deps.Health,
+		Version:             version,
+		MaxRequestBodyBytes: cfg.Server.MaxRequestBodyBytes,
+		PlaygroundProxy:     playground,
+		OTel:                deps.OTel,
+		StreamHeartbeat:     resolveStreamHeartbeat(cfg.Engine.StreamHeartbeatSeconds),
+	}
+}
+
+// resolveStreamHeartbeat converts the operator's
+// NLPGO_ENGINE_STREAM_HEARTBEAT_SECONDS into the is_alive_response
+// cadence the SSE handler applies.
+//
+// Zero or negative returns zero, which defers to the handler's own
+// DefaultStreamHeartbeat — one default, in one place. Passing a
+// non-positive duration on instead would reach engine.ExecuteStream,
+// which starts no heartbeat goroutine at all below zero, so a typo in a
+// config file would silently stop every is_alive_response frame and let
+// intermediate proxies tear down healthy long-running streams.
+func resolveStreamHeartbeat(seconds int) time.Duration {
+	if seconds <= 0 {
+		return 0
+	}
+	return time.Duration(seconds) * time.Second
 }
 
 // buildServices returns the lifecycle services Serve registers.

--- a/services/nlpgo/serve_router_deps_test.go
+++ b/services/nlpgo/serve_router_deps_test.go
@@ -1,0 +1,83 @@
+package nlpgo
+
+import (
+	"testing"
+	"time"
+
+	"github.com/langwatch/langwatch/services/nlpgo/adapters/httpapi"
+	"github.com/langwatch/langwatch/services/nlpgo/app"
+)
+
+// TestNewRouterDeps_AppliesConfiguredStreamHeartbeat pins the operator
+// knob to the transport option that enforces it.
+// NLPGO_ENGINE_STREAM_HEARTBEAT_SECONDS was declared, defaulted,
+// documented and unit-tested, but no runtime component ever read it:
+// the SSE handler carried its own hardcoded 15s, so an operator who
+// shortened the cadence to survive a proxy with a tighter read timeout
+// changed nothing.
+func TestNewRouterDeps_AppliesConfiguredStreamHeartbeat(t *testing.T) {
+	cfg := defaultConfig()
+	cfg.Engine.StreamHeartbeatSeconds = 30
+
+	got := newRouterDeps(app.New(), newTestDeps(t), cfg, "test", nil)
+
+	if want := 30 * time.Second; got.StreamHeartbeat != want {
+		t.Errorf("StreamHeartbeat = %v; want %v (NLPGO_ENGINE_STREAM_HEARTBEAT_SECONDS=30)",
+			got.StreamHeartbeat, want)
+	}
+}
+
+// TestNewRouterDeps_UnsetHeartbeatDefersToTheAdapterDefault guards the
+// wiring against turning an unset knob into a zero cadence: the engine
+// starts no heartbeat goroutine below one, so zero must mean "the
+// adapter decides", not "no heartbeats".
+func TestNewRouterDeps_UnsetHeartbeatDefersToTheAdapterDefault(t *testing.T) {
+	cfg := defaultConfig()
+	cfg.Engine.StreamHeartbeatSeconds = 0
+
+	got := newRouterDeps(app.New(), newTestDeps(t), cfg, "test", nil)
+
+	if got.StreamHeartbeat != 0 {
+		t.Errorf("StreamHeartbeat = %v; want 0 so httpapi.DefaultStreamHeartbeat (%v) applies",
+			got.StreamHeartbeat, httpapi.DefaultStreamHeartbeat)
+	}
+}
+
+// TestNewRouterDeps_DefaultConfigCarriesTheContractCadence closes the
+// loop on the shipped default: an operator who sets nothing must still
+// get contract.md §6's 15s, now sourced from config rather than from a
+// constant buried in the handler.
+func TestNewRouterDeps_DefaultConfigCarriesTheContractCadence(t *testing.T) {
+	got := newRouterDeps(app.New(), newTestDeps(t), defaultConfig(), "test", nil)
+
+	if want := httpapi.DefaultStreamHeartbeat; got.StreamHeartbeat != want {
+		t.Errorf("StreamHeartbeat = %v; want %v (contract.md §6)", got.StreamHeartbeat, want)
+	}
+}
+
+// TestResolveStreamHeartbeat covers the misconfiguration edge. A
+// negative NLPGO_ENGINE_STREAM_HEARTBEAT_SECONDS must not travel to the
+// engine as a negative duration: ExecuteStream only starts the
+// heartbeat goroutine for a positive interval, so a typo would silently
+// stop every is_alive_response frame instead of being corrected.
+func TestResolveStreamHeartbeat(t *testing.T) {
+	cases := []struct {
+		name    string
+		seconds int
+		want    time.Duration
+	}{
+		{name: "a configured value is seconds", seconds: 30, want: 30 * time.Second},
+		{name: "one second is honored", seconds: 1, want: time.Second},
+		{name: "the shipped default", seconds: 15, want: 15 * time.Second},
+		{name: "unset defers to the adapter default", seconds: 0, want: 0},
+		{name: "negative defers rather than disabling", seconds: -1, want: 0},
+		{name: "a large negative still defers", seconds: -3600, want: 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := resolveStreamHeartbeat(tc.seconds); got != tc.want {
+				t.Errorf("resolveStreamHeartbeat(%d) = %v; want %v", tc.seconds, got, tc.want)
+			}
+		})
+	}
+}

--- a/specs/nlp-go/_shared/contract.md
+++ b/specs/nlp-go/_shared/contract.md
@@ -105,12 +105,12 @@ Server-Sent Events. Event shapes match `langwatch_nlp.studio.types.events.Studio
 
 | event | data |
 |---|---|
-| `is_alive_response` | `{}` — heartbeat every `NLP_STREAM_HEARTBEAT_SECONDS` (default 15). Matches Python `IsAliveResponse.type`. |
+| `is_alive_response` | `{}` — heartbeat every `NLPGO_ENGINE_STREAM_HEARTBEAT_SECONDS` (default 15). Matches Python `IsAliveResponse.type`. |
 | `execution_state_change` | `{ trace_id, state: { status, nodes: { <node_id>: { status, inputs, outputs, error?, cost?, duration_ms? } } } }` |
 | `done` | `{ trace_id, status: "success" \| "error", result }` |
 | `error` | `{ trace_id, payload: { stack?, message } }` |
 
-- Idle timeout = `NLP_STREAM_IDLE_TIMEOUT_SECONDS` (default 900). On timeout, emit `error` then close.
+- Idle timeout = `NLPGO_ENGINE_STREAM_IDLE_TIMEOUT_SECONDS` (default 720). On timeout, emit `error` then close. **Not implemented.** The knob is read into config and `domain.ErrIdleTimeout` is registered for a 504, but nothing raises it: the SSE drain loop in `adapters/httpapi/handlers.go` has no timer, and `app/engine/stream.go` explicitly defers idle detection to the handler. The scenario is tagged `@unimplemented` in `specs/nlp-go/engine.feature`. Treat this line as intent, not behavior.
 - Client cancellation: closing the connection MUST cancel in-flight node executions (cooperative; nodes check ctx).
 - The sync endpoint `/go/studio/execute_sync` runs the same engine and returns the final `done` payload as JSON when complete.
 


### PR DESCRIPTION
## Summary

`NLPGO_ENGINE_STREAM_HEARTBEAT_SECONDS` now reaches the SSE handler. It never did before — the value was parsed, defaulted and validated, then dropped on the floor while the handler used a hardcoded `15 * time.Second`.

This is the same defect as #7614, in the same config struct. Of the three knobs in `EngineConfig`, all three were dead. #7614 fixed the code-block timeout. This fixes the heartbeat. The third is discussed below and is **not** fixed here, deliberately.

## Diagnosis

`services/nlpgo/serve.go` built `httpapi.RouterDeps` inline and never consulted `cfg.Engine` at all, so no engine-scoped knob had any path to the transport layer. The heartbeat cadence was decided at `adapters/httpapi/handlers.go:509`:

```go
func streamHeartbeat(r *http.Request) time.Duration {
	if v := r.Header.Get("X-LangWatch-NLPGO-Heartbeat-MS"); v != "" { ... }
	return 15 * time.Second
}
```

`serve.go` is the only production caller of `httpapi.NewRouter` — every other caller is a test, and they pass zero, which now resolves to `DefaultStreamHeartbeat` (15s). Behavior for tests is unchanged.

## The fix

- `services/nlpgo/serve.go` — new `newRouterDeps` constructor, extracted from `Serve` so a test can assert which operator knob reaches which transport option without binding a listener or standing up the engine. New pure `resolveStreamHeartbeat`.
- `services/nlpgo/adapters/httpapi/router.go` — `RouterDeps.StreamHeartbeat`.
- `services/nlpgo/adapters/httpapi/handlers.go` — the magic number is now the named `DefaultStreamHeartbeat`, threaded as a parameter. Precedence is: per-request header, then operator config, then default.

**Zero and negative defer to the default rather than passing through.** This is load-bearing, not defensive habit: `engine.ExecuteStream` starts no heartbeat goroutine at all when the interval is non-positive, so passing a typo'd `0` or `-1` straight through would silently stop every `is_alive_response` frame and let intermediate proxies tear down healthy long-running streams. A config typo would read as a network fault.

## `StreamIdleTimeoutSeconds` is NOT fixed here, and needs a decision

The third knob has **no runtime implementation at all** — not a hardcoded one, none:

- The SSE drain loop (`adapters/httpapi/handlers.go:466-468`) is a bare `for ev := range events`. No timer, no deadline, no `time.After`.
- `app/engine/stream.go:38-39` states in a comment that "Idle-timeout detection lives in the handler (not here)." The handler does not implement it. Both sides point at each other.
- `domain.ErrIdleTimeout` is declared (`domain/errors.go:40`) and registered for a 504 (`adapters/httpapi/router.go:146`) but is **never raised**. Those three references are the only ones in the repo.
- The spec scenario is tagged `@unimplemented` (`specs/nlp-go/engine.feature:146-152`).

Wiring the knob would have meant inventing the mechanism, so it was left alone. Either implement the idle timeout — the error code, the 504 mapping and the spec scenario are all already waiting for it — or delete the knob. That is a product call, not a refactor.

## Documentation defects, fixed

`specs/nlp-go/_shared/contract.md` named both variables three ways wrong: `NLP_STREAM_HEARTBEAT_SECONDS` and `NLP_STREAM_IDLE_TIMEOUT_SECONDS` are spellings that have never existed, and the stated idle default of 900 does not match the actual 720. Corrected, and the idle-timeout line is now explicitly marked **not implemented** so it reads as intent rather than behavior. A stale doc naming a variable that does nothing is what produced this whole class of bug.

## Tests

The serve-seam tests were genuinely red first, as value mismatches:

```
=== RUN   TestNewRouterDeps_AppliesConfiguredStreamHeartbeat
    serve_router_deps_test.go:25: StreamHeartbeat = 0s; want 30s (NLPGO_ENGINE_STREAM_HEARTBEAT_SECONDS=30)
--- FAIL: TestNewRouterDeps_AppliesConfiguredStreamHeartbeat (0.00s)
=== RUN   TestNewRouterDeps_DefaultConfigCarriesTheContractCadence
    serve_router_deps_test.go:54: StreamHeartbeat = 0s; want 15s (contract.md §6)
--- FAIL: TestNewRouterDeps_DefaultConfigCarriesTheContractCadence (0.00s)
```

**One honest caveat.** The three handler-seam tests passed on their first run, because that plumbing was built correctly in the same scaffold pass — so they were never red for the right reason. Rather than present red output that was not produced, they were proven load-bearing by temporarily making `streamHeartbeat` ignore its `configured` argument and re-running:

```
--- FAIL: TestExecuteStreamHandler_UsesTheConfiguredHeartbeat (0.00s)
    handlers_stream_heartbeat_test.go:67: engine heartbeat = 15s; want 30s (RouterDeps.StreamHeartbeat)
```

That temporary edit was reverted and does not appear in this diff.

## Verification

`go build ./...`, `go vet ./...`, `gofmt -l .` (empty), and the `nlpgo` and `adapters/httpapi` package tests all pass, re-run independently of the authoring session. `go test ./...` is green except for 8 `TestSharedSessionCodeAgent_*` failures in `app/engine/blocks/codeblock`, **proven** pre-existing by capturing the failing set on the untouched worktree before any edit — identical 8, same package. They shell out to a `python3` lacking the langwatch SDK in this environment.

**Unverified:** no end-to-end exercise against a live nlpgo service. No client was observed receiving `is_alive_response` at a configured cadence. The evidence is Go unit tests at the seams, not runtime.

## Deployment Impact

**Environment variables:** no new variable is introduced. `NLPGO_ENGINE_STREAM_HEARTBEAT_SECONDS` already existed, was already parsed, and was already documented — it simply had no effect. After this change it takes effect. Any operator who set it previously, saw nothing happen, and left it set at an unintended value will see that value start applying on upgrade. That is the one upgrade risk worth naming.

**Helm values:** unchanged. No chart template or value is touched. The chart exposes no heartbeat setting, so operators reach it through `langwatch_nlp.extraEnvs`, as with the other engine knobs.

**Default `helm install`:** behavior is identical. Unset resolves to `DefaultStreamHeartbeat`, 15s, exactly the previously hardcoded value. A vanilla install cannot observe this change.

**BYOC dataplane:** no impact. No new network call, image requirement, IAM permission, or secret. The change is confined to how an existing in-process ticker interval is chosen.

**Rollback:** revert the commit. No migration and no persisted state. Note the value is read once at startup, so any change requires a pod restart.

## Follow-ups

- Decide `StreamIdleTimeoutSeconds`: implement or delete.
- The `NLPGO_ENGINE` prefix is the root cause of this whole bug class. `cmd/root.go` already carries two compatibility shims (`resolveLangWatchBaseURL`, `resolveSandboxPython`) that exist purely to rescue operators who set the unprefixed name — one of them traces to a live incident. Renaming the prefix is breaking and out of scope, but the pattern will keep producing dead knobs until it is addressed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable heartbeat intervals for streaming executions.
  * Request-level heartbeat settings can override the configured cadence.
  * A 15-second default is applied when no valid interval is provided.

* **Documentation**
  * Updated the streaming contract with heartbeat and idle-timeout defaults and current behavior.

* **Tests**
  * Added coverage for configured, overridden, default, and invalid heartbeat settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->