### PR TITLE
feat(clickhouse-serverless): refuse the unsupported replicas 1 -> 3 transition

### DIFF
--- a/charts/clickhouse-serverless/templates/_helpers.tpl
+++ b/charts/clickhouse-serverless/templates/_helpers.tpl
@@ -88,6 +88,57 @@ app.kubernetes.io/component: keeper
   {{- if and (gt (int .Values.replicas) 1) (eq (mod (int .Values.replicas) 2) 0) }}
     {{- fail "replicas must be odd when greater than 1 (required for Keeper raft quorum)" }}
   {{- end }}
+  {{- include "clickhouse-serverless.validateTransition" . }}
+{{- end -}}
+
+{{/* Transition guard: refuse to scale an EXISTING single-node release into a
+     replicated topology.
+
+     Measured on kind against langwatch/clickhouse-serverless (issue #1168,
+     P1.7), upgrading a release from replicas=1 to replicas=3 leaves the
+     existing tables as plain MergeTree on pod-0 only. The new replicas come up
+     with empty data directories: per-pod `SELECT count()` returned the full
+     count on pod-0 and `Code: 81 ... Database up does not exist
+     (UNKNOWN_DATABASE)` on pods 1 and 2, and five identical distributed
+     `SELECT count()` calls returned the full count four times and
+     UNKNOWN_DATABASE once. A user issuing the same query twice gets different
+     answers, with no error to tell them the topology changed underneath. The
+     five SQL-defined access-entity classes are likewise not migrated. There is
+     no migration code on this path, so the chart refuses it rather than letting
+     it half-succeed.
+
+     LOOKUP SOURCE. The current replica count is read from the live
+     StatefulSet's spec.replicas, not from the release's recorded values: Helm
+     does not expose the previous release's values to templates, and
+     spec.replicas is the topology that actually exists — it stays correct even
+     if someone scaled the StatefulSet outside Helm.
+
+     WHEN THE GUARD IS INERT, DECLARED. `lookup` returns nil whenever the
+     renderer has no cluster access. Under ArgoCD the repo-server renders
+     without a cluster connection (see secret.yaml's HISTORY note — the same
+     nil-lookup behaviour caused the credential-rotation postmortem), and
+     `helm template` behaves the same way. In those contexts this guard is
+     SILENTLY INERT and a 1 -> 3 transition will not be blocked. That is
+     accepted deliberately: a lookup-based guard cannot do better, and failing
+     closed on nil would break every ArgoCD sync and every `helm template`,
+     including legitimate ones. The guard is a safety net for the interactive
+     `helm upgrade` path, not a security boundary.
+
+     It is also scoped to upgrades only (.Release.IsUpgrade), so a fresh
+     install at any replica count is never blocked — including a fresh install
+     into a namespace where an unrelated StatefulSet of the same name lingers. */}}
+{{- define "clickhouse-serverless.validateTransition" -}}
+  {{- if .Release.IsUpgrade }}
+    {{- $desired := int .Values.replicas }}
+    {{- if gt $desired 1 }}
+      {{- $sts := lookup "apps/v1" "StatefulSet" .Release.Namespace (include "clickhouse-serverless.fullname" .) }}
+      {{- if $sts }}
+        {{- if eq (int $sts.spec.replicas) 1 }}
+          {{- fail (printf "unsupported transition: this release is running replicas=1 and this upgrade requests replicas=%d. Scaling an existing single-node ClickHouse release into a replicated topology is not supported: existing tables stay plain MergeTree on pod-0, so the new replicas start with empty data directories and identical distributed queries return different answers depending on which replica they land on. SQL-defined access entities (users, grants, row policies, settings profiles, named collections) are not migrated either. To run replicated, install a NEW release at replicas=%d and migrate data explicitly; or set replicas=1 to leave this release unchanged." $desired $desired) }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
 {{- end -}}
 
 {{/* Auth wiring fail-fast: hard-stop the render when neither path to a

--- a/charts/clickhouse-serverless/tests/ac11d-transition-guard.sh
+++ b/charts/clickhouse-serverless/tests/ac11d-transition-guard.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# AC11-D — the chart blocks the unsupported replicas:1 -> replicas:3 transition.
+#
+# Plan authority: /tmp/1168-draft3-comment.md line 134. The AC is falsifiable by
+# command, which is why it was chosen over a docs branch:
+#
+#   (a) `helm upgrade --set replicas=3` against a release installed at
+#       replicas:1 MUST exit non-zero with stderr containing the literal string
+#       "unsupported transition";
+#   (b) the same command against a release already at replicas:3 MUST exit 0,
+#       so the guard does not block legitimate upgrades.
+#
+# This script additionally captures (c): a FRESH install at replicas:3 on an
+# empty namespace MUST exit 0, because a lookup-based guard that fired on
+# install would break every first install.
+#
+# Exit codes: 0 all three cases behaved as required; 1 at least one did not;
+# 10 harness/environment problem (the cases were never measured).
+set -euo pipefail
+
+CLUSTER_NAME="${CLUSTER_NAME:-ch-ac11d}"
+NAMESPACE="${NAMESPACE:-ch-ac11d}"
+RELEASE="${RELEASE:-ch}"
+IMAGE_REPO="${IMAGE_REPO:-langwatch/clickhouse-serverless}"
+TAG="${TAG:-0.3.0}"
+KEEP_CLUSTER="${KEEP_CLUSTER:-false}"
+TIMEOUT="${TIMEOUT:-600}"
+
+CHART_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+VALUES="${CHART_DIR}/tests/values-ac11d.yaml"
+KUBE_CTX="kind-${CLUSTER_NAME}"
+RUN_DIR="$(mktemp -d /tmp/ac11d-XXXXXX)"
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; CYAN='\033[0;36m'; YELLOW='\033[0;33m'; NC='\033[0m'
+ts() { date -u +%Y-%m-%dT%H:%M:%SZ; }
+info() { echo -e "${CYAN}[INFO]${NC}  $(ts) $*"; }
+pass() { echo -e "${GREEN}[PASS]${NC}  $*"; }
+# shellcheck disable=SC2317  # reached via the EXIT trap
+warn() { echo -e "${YELLOW}[WARN]${NC}  $*"; }
+FAILURES=0
+fail() { echo -e "${RED}[FAIL]${NC}  $*" >&2; FAILURES=$((FAILURES + 1)); }
+harness_error() { echo -e "${RED}[HARNESS-ERROR]${NC} $*" >&2; exit 10; }
+
+kc() { env -u KUBECONFIG kubectl --context "$KUBE_CTX" -n "$NAMESPACE" "$@"; }
+hc() { env -u KUBECONFIG helm --kube-context "$KUBE_CTX" -n "$NAMESPACE" "$@"; }
+
+# `kind load docker-image` is broken where the docker containerd store holds
+# only the native child of a multi-platform list: it shells out with
+# --all-platforms and dies on the missing sibling digest. Saving the one
+# platform we need and loading the archive is the path that works.
+load_image() {
+  local ref="$1"
+  local platform archive
+  archive="${RUN_DIR}/$(echo "$ref" | tr '/:' '__').tar"
+  platform="linux/$(docker version --format '{{.Server.Arch}}' 2>/dev/null || echo amd64)"
+  docker image inspect "$ref" >/dev/null 2>&1 || docker pull --platform "$platform" "$ref" >/dev/null 2>&1 \
+    || harness_error "could not obtain ${ref} for ${platform}"
+  docker save --platform "$platform" -o "$archive" "$ref" \
+    || harness_error "docker save failed for ${ref}"
+  kind load image-archive "$archive" --name "$CLUSTER_NAME" >/dev/null \
+    || harness_error "kind load image-archive failed for ${ref}"
+  info "side-loaded ${ref} (${platform})"
+}
+
+# Every case is recorded with its exact command, exit code and full stderr, so a
+# verdict can be checked against evidence rather than taken on trust.
+run_case() {
+  local name="$1" expect="$2"; shift 2
+  local out rc=0
+  info "── case ${name}: \$ $*"
+  out="$("$@" 2>&1)" || rc=$?
+  printf '%s\n' "$out" > "${RUN_DIR}/${name}.out"
+  echo "    exit=${rc}"
+  printf '%s\n' "$out" | sed 's/^/    | /'
+  CASE_OUT="$out"
+  case "$expect" in
+    zero)     [[ "$rc" -eq 0 ]] || fail "${name}: expected exit 0, got ${rc}" ;;
+    non-zero) [[ "$rc" -ne 0 ]] || fail "${name}: expected a non-zero exit, got 0 — the guard did not fire" ;;
+  esac
+}
+
+purge() {
+  hc uninstall "$RELEASE" --wait --timeout "${TIMEOUT}s" >/dev/null 2>&1 || true
+  kc delete pvc --all --ignore-not-found >/dev/null 2>&1 || true
+  # helm.sh/resource-policy=keep leaves the credentials Secret behind; a stale
+  # one would carry a clusterSecret from the previous topology into the next
+  # case and make the next install a different experiment than it claims to be.
+  kc delete secret "${RELEASE}-clickhouse" --ignore-not-found >/dev/null 2>&1 || true
+  kc delete sts --all --ignore-not-found >/dev/null 2>&1 || true
+}
+
+# shellcheck disable=SC2317  # reached via the EXIT trap, not by fallthrough
+cleanup() {
+  if [[ "$KEEP_CLUSTER" == "true" ]]; then
+    warn "KEEP_CLUSTER=true — leaving cluster ${CLUSTER_NAME} up"
+  else
+    kind delete cluster --name "$CLUSTER_NAME" >/dev/null 2>&1 || true
+  fi
+  info "evidence: ${RUN_DIR}"
+}
+trap cleanup EXIT
+
+command -v kind >/dev/null || harness_error "kind not found"
+command -v helm >/dev/null || harness_error "helm not found"
+command -v docker >/dev/null || harness_error "docker not found"
+
+info "AC11-D transition guard — cluster=${CLUSTER_NAME} tag=${TAG}"
+kind get clusters 2>/dev/null | grep -qx "$CLUSTER_NAME" \
+  || kind create cluster --name "$CLUSTER_NAME" --wait 120s >/dev/null \
+  || harness_error "kind create cluster failed"
+load_image "${IMAGE_REPO}:${TAG}"
+kc get ns "$NAMESPACE" >/dev/null 2>&1 \
+  || env -u KUBECONFIG kubectl --context "$KUBE_CTX" create namespace "$NAMESPACE" >/dev/null
+
+# ── (c) fresh install at replicas:3 must NOT be blocked ──────────────────────
+purge
+run_case "c-fresh-install-replicas3" zero \
+  hc install "$RELEASE" "$CHART_DIR" -f "$VALUES" --set replicas=3 --wait --timeout "${TIMEOUT}s"
+
+# ── (b) 3 -> 3 upgrade must NOT be blocked ───────────────────────────────────
+run_case "b-upgrade-3-to-3" zero \
+  hc upgrade "$RELEASE" "$CHART_DIR" -f "$VALUES" --set replicas=3 --wait --timeout "${TIMEOUT}s"
+
+# ── (a) 1 -> 3 upgrade MUST be blocked, naming the transition ────────────────
+purge
+run_case "a-install-replicas1" zero \
+  hc install "$RELEASE" "$CHART_DIR" -f "$VALUES" --set replicas=1 --wait --timeout "${TIMEOUT}s"
+
+run_case "a-upgrade-1-to-3" non-zero \
+  hc upgrade "$RELEASE" "$CHART_DIR" -f "$VALUES" --set replicas=3 --wait --timeout "${TIMEOUT}s"
+# The exit code alone is not evidence: a timeout, an image pull failure or a
+# quota rejection would also be non-zero. The AC names the string for exactly
+# this reason, so assert on it.
+if [[ "$CASE_OUT" == *"unsupported transition"* ]]; then
+  pass "AC11-D(a) the 1 -> 3 upgrade was refused, stderr names 'unsupported transition'"
+else
+  fail "AC11-D(a) the upgrade exited non-zero but stderr does NOT contain 'unsupported transition' — a non-zero exit for some other reason is not evidence the guard fired"
+fi
+
+# The blocked upgrade must also be a no-op: a guard that fails AFTER mutating
+# the StatefulSet would leave the release in the state it just refused to create.
+STS_AFTER="$(kc get sts "${RELEASE}-clickhouse" -o jsonpath='{.spec.replicas}' 2>/dev/null || echo "<none>")"
+info "StatefulSet spec.replicas after the refused upgrade: ${STS_AFTER}"
+if [[ "$STS_AFTER" == "1" ]]; then
+  pass "AC11-D(a) the refused upgrade left the release at replicas=1"
+else
+  fail "AC11-D(a) the refused upgrade left spec.replicas='${STS_AFTER}', expected '1' — the guard fired after mutating the cluster"
+fi
+
+echo
+if [[ "$FAILURES" -eq 0 ]]; then
+  pass "AC11-D: all three cases behaved as the AC requires"
+  exit 0
+fi
+echo -e "${RED}[SUMMARY]${NC} ${FAILURES} case(s) did not behave as required" >&2
+exit 1

--- a/charts/clickhouse-serverless/tests/values-ac11d.yaml
+++ b/charts/clickhouse-serverless/tests/values-ac11d.yaml
@@ -1,0 +1,31 @@
+# Fixture for the AC11-D transition-guard test (issue langwatch/langwatch-saas#1168).
+#
+# The guard being tested is chart-level, not binary-level, so the image tag here
+# only has to be an image that exists locally and starts: 0.3.0 is the released
+# tag the upgrade experiment used as its "old" side. replicas is deliberately
+# NOT pinned — the test supplies it per case via --set, which is the whole point
+# of the assertion.
+image:
+  tag: "0.3.0"
+  pullPolicy: Never
+memory: 1Gi
+cpu: "500m"
+storage:
+  size: 1Gi
+
+auth:
+  password: "ac11d-test"
+
+autogen:
+  enabled: true
+
+keeper:
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      cpu: 250m
+      memory: 256Mi
+  storage:
+    size: 1Gi


### PR DESCRIPTION
Stacked on #7331 — targets `issue6635/lwql-helm-enablement`, not `main`, because this guard protects the Keeper-backed access relocation #7331 introduces. Do not merge before #7331 merges; this branch retargets to `main` once that lands.

Part of the langwatch-saas#1168 plan (https://github.com/langwatch/langwatch-saas/issues/1168), AC11-D. Sibling PR: #7620 (the upgrade-access proof harness this guard's P1.7 rationale draws its measurement from) — independent of this PR, no merge-order dependency between the two.

## What this does

Upgrading an existing single-node (`replicas=1`) release to `replicas=3` half-succeeds today. Measured on kind (issue #1168, P1.7): existing tables stay plain MergeTree on pod-0, so the new replicas come up with empty data directories. Per-pod `SELECT count()` returned the full count on pod-0 and `Code: 81 ... Database up does not exist (UNKNOWN_DATABASE)` on pods 1 and 2 — five identical distributed `SELECT count()` calls returned the full count four times and `UNKNOWN_DATABASE` once, the same query giving different answers with no error saying the topology moved. The five SQL-defined access-entity classes are not migrated either, and the scale-up crashlooped the new pods until Keeper accepted connections. There is no migration code on this path.

Adds `clickhouse-serverless.validateTransition` (`templates/_helpers.tpl:130`, called from `validate` at `:91`, gated on `.Release.IsUpgrade`): on upgrade, if the requested replica count is greater than 1, it `lookup`s the live StatefulSet's `spec.replicas` and `fail`s the render when that was `1`, naming the transition in the error message. It reads the *live* StatefulSet rather than the release's recorded values (Helm does not expose the previous release's values to templates), so it stays correct even if the topology was changed outside Helm. Scoped to upgrades only, so fresh installs are never blocked, and follows the existing odd-replicas fail already in `clickhouse-serverless.validate`.

`tests/ac11d-transition-guard.sh` (156 lines) drives a real kind cluster through 3 cases:
- **(a)** install at `replicas=1`, upgrade to `replicas=3` -> must exit non-zero AND stderr must contain the literal string `"unsupported transition"`; also asserts `spec.replicas` is still `1` afterwards, so a guard that fired *after* mutating the StatefulSet would be caught.
- **(b)** install at `replicas=3`, upgrade at `replicas=3` -> must exit 0 (the guard does not block legitimate upgrades).
- **(c)** fresh install at `replicas=3` on an empty namespace -> must exit 0 (a lookup-based guard firing on install would break every first install).

Verified manually (not automated in the script) with a **guard-removed negative control**: same cluster, same release at `replicas=1`, same upgrade command, with the `validateTransition` include removed from `validate` — exits 0 where the guard exits 1, so the refusal is attributable to the guard itself and not to anything incidental in the transition.

## Deployment Impact

No new environment variables and no new Helm values — the guard reads only the existing `.Values.replicas` and the live cluster via Helm's built-in `lookup`.

**Fresh installs (`helm install`, no overrides):** no impact. `validateTransition` is gated on `.Release.IsUpgrade` and never evaluates on install.

**`helm upgrade` behavior change:** upgrading an existing `replicas=1` release to `replicas>1` now fails the render with an explicit "unsupported transition" error instead of silently proceeding into the broken half-migrated state described above (data stuck on pod-0, new pods reporting `UNKNOWN_DATABASE`, access entities not migrated). Same-count upgrades (`1->1`, `3->3`) and any transition starting from `replicas>1` are unaffected.

**BYOC dataplane:** this chart deploys into customer clusters via the same Helm path. Under ArgoCD or `helm template`, `lookup` returns nil (no live cluster access at render time), so the guard is silently inert there — see Known Limitation below. It is a safety net for interactive `helm upgrade`, not a hard boundary, and does not change ArgoCD sync behavior either way.

## Known limitation

Under ArgoCD or `helm template`, Helm's `lookup` returns nil, so the guard is silently inert and enforces nothing.

This is accepted deliberately (documented at the definition in `_helpers.tpl`): a lookup-based guard cannot do better without cluster access, and failing closed on nil would break every ArgoCD sync and every `helm template`, including legitimate ones. The guard is a safety net for the interactive `helm upgrade` path, not a security boundary.

## How I can prove I was successful

Run on kind: `bash charts/clickhouse-serverless/tests/ac11d-transition-guard.sh` (script header has the full env contract and exit codes: `0` all three cases behaved as required, `1` at least one did not, `10` harness/environment problem).

🤖 Generated with [Claude Code](https://claude.com/claude-code)