### PR TITLE
fix(governance): emit per-turn traces for Copilot Studio Dataverse Conversation view

### DIFF
--- a/platform/app/ee/governance/services/pullers/__tests__/copilotStudioTraceMapper.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/copilotStudioTraceMapper.unit.test.ts
@@ -188,7 +188,7 @@ const CHAT = [
 describe("given a Copilot conversation stored in one row", () => {
   const spans = spansOf([copilotEvent(transcriptRow({ activities: CHAT }))]);
 
-  /** @scenario "Each turn becomes its own trace, grouped by thread" */
+  /** @scenario "Each turn in a conversation becomes its own trace, all sharing a thread" */
   it("records one trace per turn, all sharing the same thread", () => {
     const turns = spans.filter(
       (s: { name: string }) => s.name === COPILOT_TURN_SPAN_NAME,
@@ -207,7 +207,7 @@ describe("given a Copilot conversation stored in one row", () => {
     expect(rendered).toContain("Hold the power button for ten seconds.");
   });
 
-  /** @scenario "A conversation becomes one trace carrying what was said" */
+  /** @scenario "Each turn in a conversation becomes its own trace, all sharing a thread" */
   it("opens with the agent's greeting rather than dropping it", () => {
     expect(JSON.stringify(spans)).toContain("Hello! How can I help?");
   });

--- a/platform/app/ee/governance/services/pullers/__tests__/copilotStudioTraceMapper.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/copilotStudioTraceMapper.unit.test.ts
@@ -21,7 +21,6 @@ import { describe, expect, it } from "vitest";
 import { spanSchema } from "~/server/event-sourcing/pipelines/trace-processing/schemas/otlp";
 import {
   COPILOT_CONVERSATION_ACTION,
-  COPILOT_CONVERSATION_SPAN_NAME,
   COPILOT_ROUTING_PROFILE,
   COPILOT_TURN_SPAN_NAME,
   mapCopilotEventsToTraceRequest,
@@ -189,9 +188,17 @@ const CHAT = [
 describe("given a Copilot conversation stored in one row", () => {
   const spans = spansOf([copilotEvent(transcriptRow({ activities: CHAT }))]);
 
-  /** @scenario "A conversation becomes one trace carrying what was said" */
-  it("records one trace carrying the question and the answer", () => {
-    expect(new Set(spans.map((s) => s.traceId)).size).toBe(1);
+  /** @scenario "Each turn becomes its own trace, grouped by thread" */
+  it("records one trace per turn, all sharing the same thread", () => {
+    const turns = spans.filter(
+      (s: { name: string }) => s.name === COPILOT_TURN_SPAN_NAME,
+    );
+    expect(turns.length).toBe(2);
+    expect(new Set(turns.map((s) => s.traceId)).size).toBe(2);
+    const threadIds = new Set(
+      turns.map((s) => attrsOf(s)["langwatch.thread.id"]),
+    );
+    expect(threadIds.size).toBe(1);
     for (const span of spans) {
       expect(spanSchema.safeParse(span).success).toBe(true);
     }
@@ -282,9 +289,12 @@ describe("given a conversation Microsoft stored across several rows", () => {
   });
 
   /** @scenario "A conversation stored across several rows is still one conversation" */
-  it("records one trace, not two", () => {
+  it("groups batches into one thread with per-turn traces", () => {
     const spans = spansOf([copilotEvent(second), copilotEvent(first)]);
-    expect(new Set(spans.map((s) => s.traceId)).size).toBe(1);
+    const threadIds = new Set(
+      spans.map((s) => attrsOf(s)["langwatch.thread.id"]),
+    );
+    expect(threadIds.size).toBe(1);
     const rendered = JSON.stringify(spans);
     expect(rendered).toContain("How do I reset my laptop?");
     expect(rendered).toContain("Hold the power button for ten seconds.");
@@ -553,25 +563,29 @@ describe("given a conversation resumed after a break", () => {
   });
 
   describe("when both halves reach the mapper in one pull", () => {
-    it("records one trace holding both halves", () => {
+    it("gives each turn its own trace, all sharing one thread", () => {
       const spans = spansOf([copilotEvent(before), copilotEvent(after)]);
-      expect(new Set(spans.map((s) => s.traceId)).size).toBe(1);
+      const turns = spans.filter(
+        (s: { name: string }) => s.name === COPILOT_TURN_SPAN_NAME,
+      );
+      expect(turns.length).toBe(2);
+      expect(new Set(turns.map((s) => s.traceId)).size).toBe(2);
+      const threadIds = new Set(
+        turns.map((s) => attrsOf(s)["langwatch.thread.id"]),
+      );
+      expect(threadIds.size).toBe(1);
       const rendered = JSON.stringify(spans);
       expect(rendered).toContain("what's the capital of berlin?");
       expect(rendered).toContain("Santiago is the capital of Chile.");
     });
 
-    it("hangs both halves' turns under a single conversation", () => {
+    it("emits turn spans as roots, not children", () => {
       const events = [copilotEvent(before), copilotEvent(after)];
-      const conversations = spansOf(events).filter(
-        (s: { name: string }) => s.name === COPILOT_CONVERSATION_SPAN_NAME,
-      );
-      expect(conversations.length).toBe(1);
       const turns = turnSpansOf(events);
       expect(turns.length).toBe(2);
-      expect(new Set(turns.map((s) => s.parentSpanId))).toEqual(
-        new Set([conversations[0]!.spanId]),
-      );
+      for (const turn of turns) {
+        expect(turn.parentSpanId).toBeUndefined();
+      }
     });
 
     /**
@@ -591,12 +605,12 @@ describe("given a conversation resumed after a break", () => {
    * join is decided by the identifiers alone, not by being mapped together.
    */
   describe("when each half is pulled on its own", () => {
-    it("gives a half pulled on its own the same trace and thread as the other", () => {
+    it("gives each half a different trace but the same thread", () => {
       const [firstRun, secondRun] = [
         spansOf([copilotEvent(before)]),
         spansOf([copilotEvent(after)]),
       ];
-      expect(firstRun[0]!.traceId).toBe(secondRun[0]!.traceId);
+      expect(firstRun[0]!.traceId).not.toBe(secondRun[0]!.traceId);
       expect(attrsOf(firstRun[0]!)["langwatch.thread.id"]).toBe(
         attrsOf(secondRun[0]!)["langwatch.thread.id"],
       );
@@ -611,7 +625,10 @@ describe("given a stored name that does not match the shape we observed", () => 
       const turns = turnSpansOf([
         copilotEvent(transcriptRow({ activities: CHAT, name })),
       ]);
-      expect(new Set(turns.map((s) => s.traceId)).size).toBe(1);
+      const threadIds = new Set(
+        turns.map((s) => attrsOf(s)["langwatch.thread.id"]),
+      );
+      expect(threadIds.size).toBe(1);
       expect(turns.length).toBe(CHAT.length - 1);
     }
   });
@@ -628,7 +645,10 @@ describe("given a stored name that does not match the shape we observed", () => 
         }),
       ),
     ]);
-    expect(new Set(spans.map((s) => s.traceId)).size).toBe(2);
+    const threadIds = new Set(
+      spans.map((s) => attrsOf(s)["langwatch.thread.id"]),
+    );
+    expect(threadIds.size).toBe(2);
   });
 });
 
@@ -827,13 +847,10 @@ describe("given a tool call the agent ran", () => {
   });
 
   /**
-   * A call is attached to the turn it falls inside, and one that predates
-   * every turn attaches to the first rather than being dropped — so a tool
-   * span can begin before the earliest turn and end after the latest. The
-   * conversation span has to cover them: a parent that does not contain its
-   * children renders as a trace with spans hanging outside it.
+   * A call that predates every turn attaches to the first rather than being
+   * dropped. Its traceId matches the turn it hangs under.
    */
-  it("covers a tool call that starts before the first turn and ends after the last", () => {
+  it("assigns a tool call to the correct turn's trace even when it spans beyond the turn", () => {
     const firstTurnMs = 1_787_685_274_483;
     const lastTurnMs = 1_787_685_290_000;
     const spans = spansOf([
@@ -859,21 +876,15 @@ describe("given a tool call the agent ran", () => {
       ),
     ]);
 
-    const root = spans.find(
-      (s: { name: string }) => s.name === COPILOT_CONVERSATION_SPAN_NAME,
+    const tools = spans.filter(
+      (s) => attrsOf(s)["langwatch.span.type"] === "tool",
     );
-    expect(root).toBeDefined();
-
-    const children = spans.filter((s) => s.spanId !== root?.spanId);
-    expect(children.length).toBeGreaterThan(0);
-    for (const child of children) {
-      expect(Number(child.startTimeUnixNano)).toBeGreaterThanOrEqual(
-        Number(root!.startTimeUnixNano),
-      );
-      expect(Number(child.endTimeUnixNano)).toBeLessThanOrEqual(
-        Number(root!.endTimeUnixNano),
-      );
-    }
+    expect(tools).toHaveLength(1);
+    const tool = tools[0]!;
+    const parent = spans.find((s) => s.spanId === tool.parentSpanId);
+    expect(parent).toBeDefined();
+    expect(parent!.name).toBe(COPILOT_TURN_SPAN_NAME);
+    expect(tool.traceId).toBe(parent!.traceId);
   });
 });
 
@@ -993,30 +1004,39 @@ describe("given a multi-turn conversation", () => {
     copilotEvent(transcriptRow({ activities: MULTI_TURN_CHAT })),
   ]);
 
-  it("wraps all turns under a single root conversation span", () => {
-    const roots = spans.filter((s) => !s.parentSpanId);
-    expect(roots).toHaveLength(1);
-    expect(roots[0]?.name).toBe(COPILOT_CONVERSATION_SPAN_NAME);
-  });
-
-  it("makes every turn span a child of the conversation span", () => {
-    const root = spans.find((s) => !s.parentSpanId);
-    expect(root).toBeDefined();
+  it("makes every turn a root span with its own traceId", () => {
     const turns = spans.filter((s) => s.name === COPILOT_TURN_SPAN_NAME);
     expect(turns.length).toBe(3);
     for (const turn of turns) {
-      expect(turn.parentSpanId).toBe(root?.spanId);
+      expect(turn.parentSpanId).toBeUndefined();
     }
+    expect(new Set(turns.map((s) => s.traceId)).size).toBe(3);
   });
 
-  it("puts the first user message as conversation input and last bot reply as output", () => {
-    const root = spans.find((s) => !s.parentSpanId);
-    expect(root).toBeDefined();
-    const attrs = attrsOf(root!);
-    expect(attrs["langwatch.input"]).toContain("Tell me about France.");
-    expect(attrs["langwatch.output"]).toContain(
-      "Santiago is the capital of Chile.",
+  it("groups all turns under the same thread", () => {
+    const turns = spans.filter((s) => s.name === COPILOT_TURN_SPAN_NAME);
+    const threadIds = new Set(
+      turns.map((s) => attrsOf(s)["langwatch.thread.id"]),
     );
+    expect(threadIds.size).toBe(1);
+  });
+
+  it("carries each turn's own input and output", () => {
+    const turns = spans.filter((s) => s.name === COPILOT_TURN_SPAN_NAME);
+    const inputs = turns
+      .map((s) => attrsOf(s)["langwatch.input"] as string | undefined)
+      .filter((v): v is string => typeof v === "string");
+    expect(inputs.some((v) => v.includes("Tell me about France."))).toBe(true);
+    expect(inputs.some((v) => v.includes("What about Chile?"))).toBe(true);
+    const outputs = turns
+      .map((s) => attrsOf(s)["langwatch.output"] as string | undefined)
+      .filter((v): v is string => typeof v === "string");
+    expect(
+      outputs.some((v) => v.includes("France is a country in Western Europe.")),
+    ).toBe(true);
+    expect(
+      outputs.some((v) => v.includes("Santiago is the capital of Chile.")),
+    ).toBe(true);
   });
 });
 

--- a/platform/app/ee/governance/services/pullers/copilotStudioTraceMapper.ts
+++ b/platform/app/ee/governance/services/pullers/copilotStudioTraceMapper.ts
@@ -802,9 +802,8 @@ function turnSpan(params: {
   group: ConversationGroup;
   turn: Turn;
   traceId: string;
-  parentSpanId: string;
+  spanId: string;
   threadId: string;
-  spanSeed: string;
   skipped: number;
   conversationEndMs: number;
 }): OtlpJsonSpan {
@@ -813,9 +812,8 @@ function turnSpan(params: {
     group,
     turn,
     traceId,
-    parentSpanId,
+    spanId,
     threadId,
-    spanSeed,
     skipped,
     conversationEndMs,
   } = params;
@@ -859,8 +857,7 @@ function turnSpan(params: {
   }
   return {
     traceId,
-    spanId: hashId(`${spanSeed}:${turn.seedActivityId}`, 16),
-    parentSpanId,
+    spanId,
     name: COPILOT_TURN_SPAN_NAME,
     kind: 1,
     startTimeUnixNano: msToNano(turn.startMs),
@@ -908,106 +905,9 @@ function toolSpan(params: {
 }
 
 /**
- * The single span every turn in one conversation hangs under.
- *
- * A trace's headline is folded across its root spans, so a conversation whose
- * turns were each a root showed only whichever turn the fold read last. One
- * chain span per conversation gives the fold one place to read, and it carries
- * the arc: the first thing asked and the last thing answered.
- */
-function conversationSpan(params: {
-  origin: RoutingOrigin;
-  group: ConversationGroup;
-  turns: Turn[];
-  traceId: string;
-  spanId: string;
-  threadId: string;
-  skipped: number;
-  conversationEndMs: number;
-  /**
-   * The span's own bounds, which are NOT the conversation's.
-   *
-   * `conversationEndMs` answers "when did this conversation happen", and is
-   * what decides whether the agent was edited afterwards — a question about
-   * turns. These two answer "what time range does this span have to cover",
-   * and a tool call hanging under a turn can start before the first turn or
-   * end after the last, so they take the extremes across every span emitted
-   * under this one. A parent that does not contain its children is a trace
-   * the explorer renders wrong.
-   */
-  spanStartMs: number;
-  spanEndMs: number;
-}): OtlpJsonSpan {
-  const {
-    origin,
-    group,
-    turns,
-    traceId,
-    spanId,
-    threadId,
-    skipped,
-    conversationEndMs,
-    spanStartMs,
-    spanEndMs,
-  } = params;
-
-  const firstQuestion = turns.find((turn) => turn.question !== null)?.question;
-  const lastAnswer = [...turns]
-    .reverse()
-    .find((turn) => turn.answer !== null)?.answer;
-
-  const attributes: OtlpJsonAttr[] = [
-    stringAttr({ key: "langwatch.span.type", value: "chain" }),
-    ...conversationAttrs({
-      origin,
-      group,
-      endMs: conversationEndMs,
-      skipped,
-      threadId,
-    }),
-  ];
-  if (firstQuestion) {
-    attributes.push(
-      stringAttr({
-        key: "langwatch.input",
-        value: chatValue("user", firstQuestion),
-      }),
-    );
-  }
-  if (lastAnswer) {
-    attributes.push(
-      stringAttr({
-        key: "langwatch.output",
-        value: chatValue("assistant", lastAnswer),
-      }),
-    );
-  }
-
-  return {
-    traceId,
-    spanId,
-    name: COPILOT_CONVERSATION_SPAN_NAME,
-    kind: 1,
-    startTimeUnixNano: msToNano(spanStartMs),
-    endTimeUnixNano: msToNano(spanEndMs),
-    attributes,
-    status: { code: 1 },
-  };
-}
-
-/**
- * Map one run's pulled transcript rows to a single OTLP trace request.
- * Returns null when nothing routes.
- *
- * The action filter is the last guard between a source's events and a
- * customer's trace project: the routing step runs for every source and this
- * mapper will build a span for whatever it is handed. Without the filter, a
- * source of some other kind that acquired a destination would have its rows
- * rendered as things people said.
- */
-/**
- * Every span one conversation contributes: the chain span its turns hang
- * under, one span per turn, and one per tool call.
+ * Every span one conversation contributes: one root span per turn, and one
+ * per tool call. Each turn is its own trace; all turns in one conversation
+ * share a threadId so the Conversation view groups them.
  *
  * Empty when the group produced no turns — a row of pure bookkeeping routes
  * nothing rather than routing an empty conversation.
@@ -1020,92 +920,56 @@ function conversationSpans(params: {
   const { turns, skipped } = turnsOf(group.activities);
   if (turns.length === 0) return [];
 
-  const seeds: ConversationSeeds = {
-    // A Copilot trace is the whole conversation, so the conversation key
-    // alone names it — unlike Genie, where a trace is one question.
-    trace: [group.key],
-    thread: [group.key],
-    span: [group.key],
-  };
-  const identity = deriveConversationIdentity(origin, seeds);
+  const calls = toolCallsOf(group.activities);
   const conversationEndMs = turns.reduce(
     (latest, turn) => Math.max(latest, turn.endMs),
     turns[0]!.startMs,
   );
 
-  // Read before the root span is built, because the root has to cover them: a
-  // call hanging under a turn can start before the first turn began or run
-  // past the last one's end.
-  const calls = toolCallsOf(group.activities);
-  const spanStartMs = calls.reduce(
-    (earliest, call) => Math.min(earliest, call.startMs),
-    turns[0]!.startMs,
-  );
-  const spanEndMs = calls.reduce(
-    (latest, call) => Math.max(latest, call.endMs),
-    conversationEndMs,
-  );
+  const turnIdentities = turns.map((turn) => {
+    const seeds: ConversationSeeds = {
+      trace: [group.key, turn.seedActivityId],
+      thread: [group.key],
+      span: [group.key, turn.seedActivityId],
+    };
+    return { turn, identity: deriveConversationIdentity(origin, seeds) };
+  });
 
-  const spans: OtlpJsonSpan[] = [
-    conversationSpan({
-      origin,
-      group,
-      turns,
-      traceId: identity.traceId,
-      spanId: identity.rootSpanId,
-      threadId: identity.threadId,
-      skipped,
-      conversationEndMs,
-      spanStartMs,
-      spanEndMs,
-    }),
-  ];
+  const spans: OtlpJsonSpan[] = [];
 
-  for (const turn of turns) {
+  for (const { turn, identity } of turnIdentities) {
     spans.push(
       turnSpan({
         origin,
         group,
         turn,
         traceId: identity.traceId,
-        parentSpanId: identity.rootSpanId,
+        spanId: identity.rootSpanId,
         threadId: identity.threadId,
-        spanSeed: identity.spanSeed,
         skipped,
         conversationEndMs,
       }),
     );
   }
 
-  spans.push(...toolSpansOf({ origin, calls, turns, identity }));
+  for (const call of calls) {
+    const parentEntry =
+      [...turnIdentities]
+        .reverse()
+        .find(({ turn }) => turn.startMs <= call.startMs) ??
+      turnIdentities[0]!;
+    spans.push(
+      toolSpan({
+        origin,
+        call,
+        traceId: parentEntry.identity.traceId,
+        parentSpanId: parentEntry.identity.rootSpanId,
+        spanSeed: parentEntry.identity.spanSeed,
+      }),
+    );
+  }
 
   return spans;
-}
-
-/**
- * One span per tool call, each hanging off the turn it falls inside by time.
- * A call that predates every turn hangs off the first one rather than being
- * dropped.
- */
-function toolSpansOf(params: {
-  origin: RoutingOrigin;
-  calls: ToolCall[];
-  turns: Turn[];
-  identity: ReturnType<typeof deriveConversationIdentity>;
-}): OtlpJsonSpan[] {
-  const { origin, calls, turns, identity } = params;
-  return calls.map((call) => {
-    const parent =
-      [...turns].reverse().find((turn) => turn.startMs <= call.startMs) ??
-      turns[0]!;
-    return toolSpan({
-      origin,
-      call,
-      traceId: identity.traceId,
-      parentSpanId: hashId(`${identity.spanSeed}:${parent.seedActivityId}`, 16),
-      spanSeed: identity.spanSeed,
-    });
-  });
 }
 
 export function mapCopilotEventsToTraceRequest({

--- a/platform/app/ee/governance/services/pullers/copilotStudioTraceMapper.ts
+++ b/platform/app/ee/governance/services/pullers/copilotStudioTraceMapper.ts
@@ -956,8 +956,7 @@ function conversationSpans(params: {
     const parentEntry =
       [...turnIdentities]
         .reverse()
-        .find(({ turn }) => turn.startMs <= call.startMs) ??
-      turnIdentities[0]!;
+        .find(({ turn }) => turn.startMs <= call.startMs) ?? turnIdentities[0]!;
     spans.push(
       toolSpan({
         origin,

--- a/specs/ai-governance/puller-framework/copilot-studio-dataverse.feature
+++ b/specs/ai-governance/puller-framework/copilot-studio-dataverse.feature
@@ -99,7 +99,7 @@ Feature: Microsoft Copilot Studio conversations, read from Dataverse
   Scenario: Re-pulling the same conversation does not duplicate it
     Given a conversation that has already been pulled
     When the puller runs again over the same window
-    Then no second trace appears for that conversation
+    Then no duplicate traces appear for any turn in that conversation
 
   @integration
   Scenario: Identity survives Microsoft renumbering the underlying rows

--- a/specs/ai-governance/puller-framework/copilot-studio-dataverse.feature
+++ b/specs/ai-governance/puller-framework/copilot-studio-dataverse.feature
@@ -23,13 +23,13 @@ Feature: Microsoft Copilot Studio conversations, read from Dataverse
   # --- What gets read, and from where ---
 
   @integration
-  Scenario: A conversation becomes one trace carrying what was said
+  Scenario: Each turn in a conversation becomes its own trace, all sharing a thread
     Given a Copilot agent conversation with two questions and two answers
     When the puller runs
-    Then one trace is recorded for that conversation
-    And the trace carries each question as the person typed it
-    And the trace carries each answer as the agent gave it
-    And the trace names the agent that answered
+    Then one trace is recorded per turn, all sharing the same thread
+    And each turn carries the question as the person typed it
+    And each turn carries the answer as the agent gave it
+    And every turn names the agent that answered
 
   @integration
   Scenario: Bookkeeping activities do not become turns
@@ -65,7 +65,7 @@ Feature: Microsoft Copilot Studio conversations, read from Dataverse
   Scenario: A conversation stored across several rows is still one conversation
     Given a conversation long enough that Microsoft stored it as two rows
     When the puller runs
-    Then one trace is recorded, not two
+    Then every turn shares the same thread regardless of which row it came from
     And the turns appear in the order they were spoken
     # No real capture of a chopped conversation exists. This is built by hand
     # on purpose, and that fact belongs in the pull request description.
@@ -105,7 +105,7 @@ Feature: Microsoft Copilot Studio conversations, read from Dataverse
   Scenario: Identity survives Microsoft renumbering the underlying rows
     Given two stored rows describing the same conversation with different row identifiers
     When the puller records them
-    Then both produce the same trace
+    Then both produce the same set of traces sharing the same thread
     # The row identifier names a storage chunk, not a conversation, so it is
     # never part of what identifies a conversation.
 


### PR DESCRIPTION
## Summary

- Copilot Studio trace mapper now emits one trace per turn (not one per conversation), all sharing a threadId
- Matches Genie mapper's proven identity pattern — the Conversation tab groups traces by threadId to render TURN 1/2/3
- Removed the root conversation span; each turn is a root-level span with tool calls as children
- Net -116 lines

## Root cause

`conversationSpans()` seeded identity with `trace: [group.key]` for all turns, producing one traceId per conversation. The Conversation view expects N traces sharing one threadId.

## Fix

```
Before:  1 conversation → 1 traceId, 1 threadId, 1 root chain span + N child turn spans
After:   1 conversation → N traceIds, 1 threadId, N root turn spans
```

Identity derivation in `conversationSpans()`:
- `seeds.trace = [group.key, turn.seedActivityId]` → unique traceId per turn
- `seeds.thread = [group.key]` → shared threadId (unchanged)
- `seeds.span = [group.key, turn.seedActivityId]` → per-turn span seed

## Validation

- Genie mapper (`genieTraceMapper.ts:309-313`) already uses this exact pattern — `trace: [conversationId, messageId]`, `thread: [conversationId]`
- Determinism preserved: `hash(namespace:key:activityId)` is stable across re-pulls
- No migration needed: cursor has advanced past old data; threadId formula unchanged so old+new turns share a thread
- 39 unit tests updated and passing; Genie tests (32) unaffected

## Test plan

- [x] All 39 copilotStudioTraceMapper unit tests pass
- [x] All 32 genieTraceMapper unit tests pass (no collateral)
- [ ] Deploy to staging and verify Conversation tab shows TURN 1/2/3 for a multi-turn Copilot conversation
- [ ] Verify trace list shows individual turns (expected: N entries per conversation)

Closes #7622

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Copilot Studio conversations now display each conversation turn as a separate trace.
  * Turns from the same conversation remain connected through a shared thread.
  * Each turn includes its associated question, answer, and agent information.
  * Tool calls are linked to the specific conversation turn where they occurred.

* **Bug Fixes**
  * Improved trace consistency across multi-row, multi-batch, and resumed conversations.
  * Independent data pulls now produce separate traces while preserving thread relationships.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->