### PR TITLE
fix(governance): suppress ingest secret for non-push sources

### DIFF
--- a/platform/app/ee/governance/dashboard/components/__tests__/pushSourceTypeParity.unit.test.ts
+++ b/platform/app/ee/governance/dashboard/components/__tests__/pushSourceTypeParity.unit.test.ts
@@ -1,0 +1,32 @@
+/**
+ * The service's PUSH_SOURCE_TYPES and the catalog's mode:"push" entries must
+ * agree. They live in different modules (the catalog is React, the service is
+ * Node) so they can't share a constant. This test is the compile-time guard.
+ *
+ * If it fails, a source type was added to one side but not the other.
+ */
+
+import { isPushSourceType } from "@ee/governance/services/activity-monitor/ingestionSource.service";
+import { describe, expect, it } from "vitest";
+import { SOURCE_TYPE_OPTIONS } from "../ingestionSourceCatalog";
+
+describe("push source type parity", () => {
+  it("every catalog push-mode type is recognized by the service", () => {
+    const catalogPush = SOURCE_TYPE_OPTIONS.filter(
+      (o) => o.mode === "push",
+    ).map((o) => o.value);
+    const missing = catalogPush.filter((t) => !isPushSourceType(t));
+    expect(missing).toEqual([]);
+  });
+
+  it("every service push type has mode:push in the catalog", () => {
+    const servicePush = SOURCE_TYPE_OPTIONS.filter((o) =>
+      isPushSourceType(o.value),
+    ).map((o) => o.value);
+    const wrongMode = servicePush.filter((t) => {
+      const option = SOURCE_TYPE_OPTIONS.find((o) => o.value === t);
+      return option?.mode !== "push";
+    });
+    expect(wrongMode).toEqual([]);
+  });
+});

--- a/platform/app/ee/governance/dashboard/components/__tests__/pushSourceTypeParity.unit.test.ts
+++ b/platform/app/ee/governance/dashboard/components/__tests__/pushSourceTypeParity.unit.test.ts
@@ -1,32 +1,39 @@
 /**
- * The service's PUSH_SOURCE_TYPES and the catalog's mode:"push" entries must
- * agree. They live in different modules (the catalog is React, the service is
- * Node) so they can't share a constant. This test is the compile-time guard.
+ * The service's PUSH_SOURCE_TYPES (secret-bearing sources) and the catalog's
+ * `needsIngestSecret` must agree. They live in different modules (the catalog
+ * is React, the service is Node) so they can't share a constant. This test is
+ * the compile-time guard.
  *
  * If it fails, a source type was added to one side but not the other.
  */
 
 import { isPushSourceType } from "@ee/governance/services/activity-monitor/ingestionSource.service";
 import { describe, expect, it } from "vitest";
-import { SOURCE_TYPE_OPTIONS } from "../ingestionSourceCatalog";
+import {
+  needsIngestSecret,
+  SOURCE_TYPE_OPTIONS,
+} from "../ingestionSourceCatalog";
 
-describe("push source type parity", () => {
-  it("every catalog push-mode type is recognized by the service", () => {
-    const catalogPush = SOURCE_TYPE_OPTIONS.filter(
-      (o) => o.mode === "push",
-    ).map((o) => o.value);
-    const missing = catalogPush.filter((t) => !isPushSourceType(t));
-    expect(missing).toEqual([]);
-  });
-
-  it("every service push type has mode:push in the catalog", () => {
-    const servicePush = SOURCE_TYPE_OPTIONS.filter((o) =>
-      isPushSourceType(o.value),
-    ).map((o) => o.value);
-    const wrongMode = servicePush.filter((t) => {
-      const option = SOURCE_TYPE_OPTIONS.find((o) => o.value === t);
-      return option?.mode !== "push";
+describe("given the catalog and service both classify source types", () => {
+  /** @scenario "Each source row shows its delivery protocol" */
+  /** @scenario "Each source row shows the vendor icon next to the name" */
+  describe("when checking secret-bearing parity", () => {
+    it("every catalog secret-bearing type is recognized by the service", () => {
+      const catalogSecret = SOURCE_TYPE_OPTIONS.filter((o) =>
+        needsIngestSecret({ sourceType: o.value }),
+      ).map((o) => o.value);
+      const missing = catalogSecret.filter((t) => !isPushSourceType(t));
+      expect(missing).toEqual([]);
     });
-    expect(wrongMode).toEqual([]);
+
+    it("every service push type is secret-bearing in the catalog", () => {
+      const servicePush = SOURCE_TYPE_OPTIONS.filter((o) =>
+        isPushSourceType(o.value),
+      ).map((o) => o.value);
+      const missing = servicePush.filter(
+        (t) => !needsIngestSecret({ sourceType: t }),
+      );
+      expect(missing).toEqual([]);
+    });
   });
 });

--- a/platform/app/ee/governance/dashboard/components/__tests__/pushSourceTypeParity.unit.test.ts
+++ b/platform/app/ee/governance/dashboard/components/__tests__/pushSourceTypeParity.unit.test.ts
@@ -15,9 +15,9 @@ import {
 } from "../ingestionSourceCatalog";
 
 describe("given the catalog and service both classify source types", () => {
-  /** @scenario "Each source row shows its delivery protocol" */
-  /** @scenario "Each source row shows the vendor icon next to the name" */
   describe("when checking secret-bearing parity", () => {
+    /** @scenario "Each source row shows its delivery protocol" */
+    /** @scenario "Each source row shows the vendor icon next to the name" */
     it("every catalog secret-bearing type is recognized by the service", () => {
       const catalogSecret = SOURCE_TYPE_OPTIONS.filter((o) =>
         needsIngestSecret({ sourceType: o.value }),

--- a/platform/app/ee/governance/dashboard/components/__tests__/pushSourceTypeParity.unit.test.ts
+++ b/platform/app/ee/governance/dashboard/components/__tests__/pushSourceTypeParity.unit.test.ts
@@ -22,13 +22,15 @@ describe("given the catalog and service both classify source types", () => {
       const catalogSecret = SOURCE_TYPE_OPTIONS.filter((o) =>
         needsIngestSecret({ sourceType: o.value }),
       ).map((o) => o.value);
-      const missing = catalogSecret.filter((t) => !isPushSourceType(t));
+      const missing = catalogSecret.filter(
+        (t) => !isPushSourceType({ sourceType: t }),
+      );
       expect(missing).toEqual([]);
     });
 
     it("every service push type is secret-bearing in the catalog", () => {
       const servicePush = SOURCE_TYPE_OPTIONS.filter((o) =>
-        isPushSourceType(o.value),
+        isPushSourceType({ sourceType: o.value }),
       ).map((o) => o.value);
       const missing = servicePush.filter(
         (t) => !needsIngestSecret({ sourceType: t }),

--- a/platform/app/ee/governance/dashboard/components/ingestionSourceCatalog.tsx
+++ b/platform/app/ee/governance/dashboard/components/ingestionSourceCatalog.tsx
@@ -218,10 +218,24 @@ export const PROTOCOL_LABEL: Record<SourceMode, string> = {
   s3: "S3 pull",
 };
 
-export function modeForSourceType(sourceType: SourceType): SourceMode {
+export function modeForSourceType({
+  sourceType,
+}: {
+  sourceType: SourceType;
+}): SourceMode {
   return (
     SOURCE_TYPE_OPTIONS.find((o) => o.value === sourceType)?.mode ?? "pull"
   );
+}
+
+export function needsIngestSecret({
+  sourceType,
+}: {
+  sourceType: SourceType;
+}): boolean {
+  const opt = SOURCE_TYPE_OPTIONS.find((o) => o.value === sourceType);
+  if (!opt) return true;
+  return opt.mode === "push" || sourceType === "s3_custom";
 }
 
 // Compile-time guard: routing runs inside `writePulledEvents`

--- a/platform/app/ee/governance/dashboard/components/ingestionSourceCatalog.tsx
+++ b/platform/app/ee/governance/dashboard/components/ingestionSourceCatalog.tsx
@@ -212,6 +212,18 @@ export const SOURCE_TYPE_LABEL: Record<SourceType, string> = Object.fromEntries(
   SOURCE_TYPE_OPTIONS.map((o) => [o.value, o.label]),
 ) as Record<SourceType, string>;
 
+export const PROTOCOL_LABEL: Record<SourceMode, string> = {
+  push: "OTel push",
+  pull: "API pull",
+  s3: "S3 pull",
+};
+
+export function modeForSourceType(sourceType: SourceType): SourceMode {
+  return (
+    SOURCE_TYPE_OPTIONS.find((o) => o.value === sourceType)?.mode ?? "pull"
+  );
+}
+
 // Compile-time guard: routing runs inside `writePulledEvents`
 // (`pullers/pullerWorker.ts:325`), which nothing on the push path ever calls.
 // A push-mode entry claiming `routesConversations` would put a picker in the

--- a/platform/app/ee/governance/dashboard/pages/ingestion-source-detail.tsx
+++ b/platform/app/ee/governance/dashboard/pages/ingestion-source-detail.tsx
@@ -54,7 +54,7 @@ import { api, type RouterOutputs } from "~/utils/api";
 import { useRouter } from "~/utils/compat/next-router";
 import { formatTimeAgo } from "~/utils/formatTimeAgo";
 import type { SourceType } from "../components/ingestionSourceCatalog";
-import { modeForSourceType } from "../components/ingestionSourceCatalog";
+import { needsIngestSecret } from "../components/ingestionSourceCatalog";
 import { SourceEventsTable } from "../components/SourceEventsTable";
 import {
   type SourceEventsPager,
@@ -179,7 +179,9 @@ function SourceDetailHeader({
           >
             <Pencil size={14} /> Edit
           </Button>
-          {modeForSourceType(source.sourceType as SourceType) === "push" && (
+          {needsIngestSecret({
+            sourceType: source.sourceType as SourceType,
+          }) && (
             <Button
               size="sm"
               variant="outline"

--- a/platform/app/ee/governance/dashboard/pages/ingestion-source-detail.tsx
+++ b/platform/app/ee/governance/dashboard/pages/ingestion-source-detail.tsx
@@ -855,7 +855,7 @@ function SecretRevealModal({
     sourceType === "otel_generic" ||
     sourceType === "claude_cowork" ||
     sourceType === "claude_code";
-  const usesWebhookUrl = sourceType === "workato";
+  const usesWebhookUrl = sourceType === "workato" || sourceType === "s3_custom";
   const isClaudeCode = sourceType === "claude_code";
 
   // Claude Code's monitoring-usage doc requires CLAUDE_CODE_ENABLE_TELEMETRY=1

--- a/platform/app/ee/governance/dashboard/pages/ingestion-source-detail.tsx
+++ b/platform/app/ee/governance/dashboard/pages/ingestion-source-detail.tsx
@@ -53,7 +53,8 @@ import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 import { api, type RouterOutputs } from "~/utils/api";
 import { useRouter } from "~/utils/compat/next-router";
 import { formatTimeAgo } from "~/utils/formatTimeAgo";
-
+import type { SourceType } from "../components/ingestionSourceCatalog";
+import { modeForSourceType } from "../components/ingestionSourceCatalog";
 import { SourceEventsTable } from "../components/SourceEventsTable";
 import {
   type SourceEventsPager,
@@ -178,15 +179,17 @@ function SourceDetailHeader({
           >
             <Pencil size={14} /> Edit
           </Button>
-          <Button
-            size="sm"
-            variant="outline"
-            onClick={onRotate}
-            loading={isRotating}
-            title="Mint a new ingestSecret (24h grace on the old one)"
-          >
-            <RotateCw size={14} /> Rotate secret
-          </Button>
+          {modeForSourceType(source.sourceType as SourceType) === "push" && (
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={onRotate}
+              loading={isRotating}
+              title="Mint a new ingestSecret (24h grace on the old one)"
+            >
+              <RotateCw size={14} /> Rotate secret
+            </Button>
+          )}
           <Button
             size="sm"
             variant="ghost"

--- a/platform/app/ee/governance/dashboard/pages/inventory.tsx
+++ b/platform/app/ee/governance/dashboard/pages/inventory.tsx
@@ -3519,8 +3519,7 @@ function secretModalTargets(details: SecretDetails | null) {
       details?.sourceType === "claude_cowork" ||
       details?.sourceType === "claude_code",
     usesWebhookUrl:
-      details?.sourceType === "workato" ||
-      details?.sourceType === "s3_custom",
+      details?.sourceType === "workato" || details?.sourceType === "s3_custom",
     isClaudeCode: details?.sourceType === "claude_code",
   };
 }

--- a/platform/app/ee/governance/dashboard/pages/inventory.tsx
+++ b/platform/app/ee/governance/dashboard/pages/inventory.tsx
@@ -469,7 +469,6 @@ function useGroupedSources(sources: Source[] | undefined) {
       scheduled: [],
     };
     for (const s of sources ?? []) {
-      const meta = SOURCE_TYPE_OPTIONS.find((o) => o.value === s.sourceType);
       out[
         groupForMode(
           modeForSourceType({

--- a/platform/app/ee/governance/dashboard/pages/inventory.tsx
+++ b/platform/app/ee/governance/dashboard/pages/inventory.tsx
@@ -20,6 +20,8 @@ import {
 import { AddIngestionSourceMenu } from "@ee/governance/dashboard/components/AddIngestionSourceMenu";
 import {
   groupForMode,
+  modeForSourceType,
+  PROTOCOL_LABEL,
   routesConversations,
   SOURCE_GROUP_META,
   SOURCE_TYPE_LABEL,
@@ -492,13 +494,17 @@ function useIngestionSourceMutations({
       void refetch();
       setComposing(false);
       setComposer(blankComposer());
-      setSecretModal({
-        title: "Source created - paste this secret upstream",
-        secret: data.ingestSecret,
-        sourceId: data.source.id,
-        sourceName: data.source.name,
-        sourceType: data.source.sourceType as SourceType,
-      });
+      if (data.ingestSecret) {
+        setSecretModal({
+          title: "Source created - paste this secret upstream",
+          secret: data.ingestSecret,
+          sourceId: data.source.id,
+          sourceName: data.source.name,
+          sourceType: data.source.sourceType as SourceType,
+        });
+      } else {
+        toaster.create({ title: "Source created", type: "success" });
+      }
     },
     onError: (e) =>
       showErrorToast({ error: e, fallbackTitle: "Couldn't create the source" }),
@@ -915,6 +921,8 @@ function SourceRow({
   const StatusIcon = status.icon;
   const typeLabel =
     SOURCE_TYPE_LABEL[source.sourceType as SourceType] ?? source.sourceType;
+  const mode = modeForSourceType(source.sourceType as SourceType);
+  const isPush = mode === "push";
   return (
     <HStack
       borderWidth="1px"
@@ -925,6 +933,10 @@ function SourceRow({
     >
       <VStack align="start" gap={0} flex={1} minWidth={0}>
         <HStack gap={2}>
+          <SourceTypeIconGlyph
+            sourceType={source.sourceType as SourceType}
+            size="16px"
+          />
           <Link
             href={`/governance/inventory/${source.id}`}
             color="fg"
@@ -936,6 +948,9 @@ function SourceRow({
           </Link>
           <Badge size="sm" variant="surface">
             {typeLabel}
+          </Badge>
+          <Badge size="sm" variant="outline">
+            {PROTOCOL_LABEL[mode]}
           </Badge>
         </HStack>
         {source.description && (
@@ -967,15 +982,17 @@ function SourceRow({
           >
             <Pencil size={14} /> Edit
           </Button>
-          <Button
-            size="sm"
-            variant="ghost"
-            onClick={onRotate}
-            loading={isPendingRotate}
-            title="Mint a new ingestSecret (24h grace on the old one)"
-          >
-            <RotateCw size={14} /> Rotate secret
-          </Button>
+          {isPush && (
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={onRotate}
+              loading={isPendingRotate}
+              title="Mint a new ingestSecret (24h grace on the old one)"
+            >
+              <RotateCw size={14} /> Rotate secret
+            </Button>
+          )}
           <Button
             size="sm"
             variant="ghost"

--- a/platform/app/ee/governance/dashboard/pages/inventory.tsx
+++ b/platform/app/ee/governance/dashboard/pages/inventory.tsx
@@ -21,6 +21,7 @@ import { AddIngestionSourceMenu } from "@ee/governance/dashboard/components/AddI
 import {
   groupForMode,
   modeForSourceType,
+  needsIngestSecret,
   PROTOCOL_LABEL,
   routesConversations,
   SOURCE_GROUP_META,
@@ -469,7 +470,13 @@ function useGroupedSources(sources: Source[] | undefined) {
     };
     for (const s of sources ?? []) {
       const meta = SOURCE_TYPE_OPTIONS.find((o) => o.value === s.sourceType);
-      out[groupForMode(meta?.mode ?? "push")].push(s);
+      out[
+        groupForMode(
+          modeForSourceType({
+            sourceType: (s.sourceType ?? "otel_generic") as SourceType,
+          }),
+        )
+      ].push(s);
     }
     return out;
   }, [sources]);
@@ -921,8 +928,12 @@ function SourceRow({
   const StatusIcon = status.icon;
   const typeLabel =
     SOURCE_TYPE_LABEL[source.sourceType as SourceType] ?? source.sourceType;
-  const mode = modeForSourceType(source.sourceType as SourceType);
-  const isPush = mode === "push";
+  const mode = modeForSourceType({
+    sourceType: source.sourceType as SourceType,
+  });
+  const hasSecret = needsIngestSecret({
+    sourceType: source.sourceType as SourceType,
+  });
   return (
     <HStack
       borderWidth="1px"
@@ -982,7 +993,7 @@ function SourceRow({
           >
             <Pencil size={14} /> Edit
           </Button>
-          {isPush && (
+          {hasSecret && (
             <Button
               size="sm"
               variant="ghost"

--- a/platform/app/ee/governance/dashboard/pages/inventory.tsx
+++ b/platform/app/ee/governance/dashboard/pages/inventory.tsx
@@ -3518,7 +3518,9 @@ function secretModalTargets(details: SecretDetails | null) {
       details?.sourceType === "otel_generic" ||
       details?.sourceType === "claude_cowork" ||
       details?.sourceType === "claude_code",
-    usesWebhookUrl: details?.sourceType === "workato",
+    usesWebhookUrl:
+      details?.sourceType === "workato" ||
+      details?.sourceType === "s3_custom",
     isClaudeCode: details?.sourceType === "claude_code",
   };
 }

--- a/platform/app/ee/governance/services/activity-monitor/__tests__/ingestionSourceKeySuppression.unit.test.ts
+++ b/platform/app/ee/governance/services/activity-monitor/__tests__/ingestionSourceKeySuppression.unit.test.ts
@@ -5,14 +5,6 @@
  * `lw_is_*` ingest secret is dead weight. s3_custom is the exception:
  * it uses the webhook callback path authenticated by ingest secret.
  *
- * This file asserts:
- * 1. createSource for a pull type stores empty sentinel, returns null.
- * 2. createSource for a pure-S3 type (openai_compliance) does the same.
- * 3. createSource for s3_custom (webhook callback) generates a real secret.
- * 4. createSource for a push type generates a real secret.
- * 5. rotateSecret on a non-push source is refused.
- * 6. rotateSecret on a push source still works.
- *
  * Spec: specs/ai-gateway/governance/ingest-api-key-lifecycle.feature
  *       "Pull-source key suppression — #7616"
  */

--- a/platform/app/ee/governance/services/activity-monitor/__tests__/ingestionSourceKeySuppression.unit.test.ts
+++ b/platform/app/ee/governance/services/activity-monitor/__tests__/ingestionSourceKeySuppression.unit.test.ts
@@ -1,0 +1,163 @@
+/**
+ * @vitest-environment node
+ *
+ * Pull-mode and S3-mode sources never receive inbound pushes, so the
+ * `lw_is_*` ingest secret is dead weight. This file asserts:
+ *
+ * 1. createSource for a pull type stores an empty-string sentinel in
+ *    `ingestSecretHash` and returns `ingestSecret: null`.
+ * 2. createSource for an S3 type does the same.
+ * 3. createSource for a push type still generates a real secret.
+ * 4. rotateSecret on a non-push source is refused.
+ * 5. rotateSecret on a push source still works.
+ *
+ * Spec: specs/ai-gateway/governance/ingest-api-key-lifecycle.feature
+ *       "Pull-source key suppression — #7616"
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("~/env.mjs", () => ({ env: { CREDENTIALS_SECRET: "ab".repeat(32) } }));
+vi.mock("~/server/api/enterprise", () => ({ isEnterpriseTier: () => true }));
+vi.mock("~/server/app-layer/app", () => ({
+  getApp: () => ({
+    commands: { ingestionPull: {} },
+    planProvider: {
+      getActivePlan: vi.fn().mockResolvedValue({ type: "ENTERPRISE" }),
+    },
+  }),
+}));
+vi.mock("@ee/governance/services/pullers/ingestionPullLifecycle", () => ({
+  syncIngestionPullSource: vi.fn(),
+}));
+vi.mock("@ee/governance/services/governanceProject.service", () => ({
+  ensureHiddenGovernanceProject: vi.fn(),
+}));
+
+import { IngestionSourceService } from "../ingestionSource.service";
+
+function createServiceForCreate() {
+  const captured: { data?: Record<string, unknown> } = {};
+  const prisma = {
+    ingestionSource: {
+      count: vi.fn().mockResolvedValue(0),
+      create: vi.fn().mockImplementation(({ data }: { data: any }) => {
+        captured.data = data;
+        return Promise.resolve({ id: "src_new", ...data });
+      }),
+      findFirst: vi.fn().mockResolvedValue(null),
+      findUnique: vi.fn().mockResolvedValue(null),
+      findMany: vi.fn().mockResolvedValue([]),
+      update: vi.fn().mockResolvedValue(null),
+      updateMany: vi.fn().mockResolvedValue({ count: 0 }),
+    },
+  } as never;
+  return { service: IngestionSourceService.create(prisma), captured };
+}
+
+function createServiceForRotate(existing: Record<string, unknown>) {
+  const captured: { data?: Record<string, unknown> } = {};
+  const prisma = {
+    ingestionSource: {
+      findFirst: vi.fn().mockResolvedValue(existing),
+      findUnique: vi.fn().mockResolvedValue(existing),
+      update: vi.fn().mockImplementation(({ data }: { data: any }) => {
+        captured.data = data;
+        return Promise.resolve({ ...existing, ...data });
+      }),
+    },
+  } as never;
+  return { service: IngestionSourceService.create(prisma), captured };
+}
+
+describe("pull-source key suppression (#7616)", () => {
+  describe("createSource", () => {
+    it("pull type → empty sentinel hash, null secret", async () => {
+      const { service, captured } = createServiceForCreate();
+
+      const result = await service.createSource({
+        organizationId: "org_1",
+        sourceType: "databricks_genie",
+        name: "genie-test",
+        pullConfig: {
+          adapter: "databricks_genie",
+          workspaceUrl: "https://adb-1.7.azuredatabricks.net",
+          spaceIds: [],
+          schedule: "*/15 * * * *",
+          credentials: { token: "dapi-test-token" },
+        },
+        pullSchedule: "*/15 * * * *",
+        actorUserId: "user_1",
+      });
+
+      expect(captured.data?.ingestSecretHash).toBe("");
+      expect(result.ingestSecret).toBeNull();
+    });
+
+    it("S3 type → empty sentinel hash, null secret", async () => {
+      const { service, captured } = createServiceForCreate();
+
+      const result = await service.createSource({
+        organizationId: "org_1",
+        sourceType: "s3_custom",
+        name: "s3-test",
+        pullConfig: {
+          adapter: "s3_custom",
+          bucketName: "test-bucket",
+          region: "us-east-1",
+          prefix: "logs/",
+          schedule: "*/30 * * * *",
+          credentials: { accessKeyId: "AKIA", secretAccessKey: "secret" },
+        },
+        pullSchedule: "*/30 * * * *",
+        actorUserId: "user_1",
+      });
+
+      expect(captured.data?.ingestSecretHash).toBe("");
+      expect(result.ingestSecret).toBeNull();
+    });
+
+    it("push type → real hash and lw_is_ secret", async () => {
+      const { service, captured } = createServiceForCreate();
+
+      const result = await service.createSource({
+        organizationId: "org_1",
+        sourceType: "otel_generic",
+        name: "otel-test",
+        actorUserId: "user_1",
+      });
+
+      expect(captured.data?.ingestSecretHash).not.toBe("");
+      expect(result.ingestSecret).toMatch(/^lw_is_/);
+    });
+  });
+
+  describe("rotateSecret", () => {
+    it("pull-mode source is refused", async () => {
+      const { service } = createServiceForRotate({
+        id: "src_pull",
+        organizationId: "org_1",
+        sourceType: "databricks_genie",
+        ingestSecretHash: "",
+        parserConfig: { adapter: "databricks_genie" },
+        pullSchedule: "*/15 * * * *",
+      });
+
+      await expect(service.rotateSecret("src_pull", "org_1")).rejects.toThrow();
+    });
+
+    it("push-mode source still works", async () => {
+      const { service } = createServiceForRotate({
+        id: "src_push",
+        organizationId: "org_1",
+        sourceType: "otel_generic",
+        ingestSecretHash: "existing-hash-abc",
+        parserConfig: {},
+        pullSchedule: null,
+      });
+
+      const { ingestSecret } = await service.rotateSecret("src_push", "org_1");
+      expect(ingestSecret).toMatch(/^lw_is_/);
+    });
+  });
+});

--- a/platform/app/ee/governance/services/activity-monitor/__tests__/ingestionSourceKeySuppression.unit.test.ts
+++ b/platform/app/ee/governance/services/activity-monitor/__tests__/ingestionSourceKeySuppression.unit.test.ts
@@ -73,9 +73,9 @@ function createServiceForRotate(existing: Record<string, unknown>) {
 }
 
 describe("pull-source key suppression (#7616)", () => {
-  /** @scenario "The rotate-secret button is hidden for non-push sources on the list" */
-  /** @scenario "The rotate-secret button is hidden for non-push sources on the detail page" */
   describe("when createSource is called", () => {
+    /** @scenario "The rotate-secret button is hidden for non-push sources on the list" */
+    /** @scenario "The rotate-secret button is hidden for non-push sources on the detail page" */
     it("pull type → empty sentinel hash, null secret", async () => {
       const { service, captured } = createServiceForCreate();
 

--- a/platform/app/ee/governance/services/activity-monitor/__tests__/ingestionSourceKeySuppression.unit.test.ts
+++ b/platform/app/ee/governance/services/activity-monitor/__tests__/ingestionSourceKeySuppression.unit.test.ts
@@ -1,15 +1,17 @@
 /**
  * @vitest-environment node
  *
- * Pull-mode and S3-mode sources never receive inbound pushes, so the
- * `lw_is_*` ingest secret is dead weight. This file asserts:
+ * Pull-mode and pure-S3 sources never receive inbound pushes, so the
+ * `lw_is_*` ingest secret is dead weight. s3_custom is the exception:
+ * it uses the webhook callback path authenticated by ingest secret.
  *
- * 1. createSource for a pull type stores an empty-string sentinel in
- *    `ingestSecretHash` and returns `ingestSecret: null`.
- * 2. createSource for an S3 type does the same.
- * 3. createSource for a push type still generates a real secret.
- * 4. rotateSecret on a non-push source is refused.
- * 5. rotateSecret on a push source still works.
+ * This file asserts:
+ * 1. createSource for a pull type stores empty sentinel, returns null.
+ * 2. createSource for a pure-S3 type (openai_compliance) does the same.
+ * 3. createSource for s3_custom (webhook callback) generates a real secret.
+ * 4. createSource for a push type generates a real secret.
+ * 5. rotateSecret on a non-push source is refused.
+ * 6. rotateSecret on a push source still works.
  *
  * Spec: specs/ai-gateway/governance/ingest-api-key-lifecycle.feature
  *       "Pull-source key suppression — #7616"
@@ -71,7 +73,9 @@ function createServiceForRotate(existing: Record<string, unknown>) {
 }
 
 describe("pull-source key suppression (#7616)", () => {
-  describe("createSource", () => {
+  /** @scenario "The rotate-secret button is hidden for non-push sources on the list" */
+  /** @scenario "The rotate-secret button is hidden for non-push sources on the detail page" */
+  describe("when createSource is called", () => {
     it("pull type → empty sentinel hash, null secret", async () => {
       const { service, captured } = createServiceForCreate();
 
@@ -94,15 +98,15 @@ describe("pull-source key suppression (#7616)", () => {
       expect(result.ingestSecret).toBeNull();
     });
 
-    it("S3 type → empty sentinel hash, null secret", async () => {
+    it("pure-S3 type (openai_compliance) → empty sentinel hash, null secret", async () => {
       const { service, captured } = createServiceForCreate();
 
       const result = await service.createSource({
         organizationId: "org_1",
-        sourceType: "s3_custom",
-        name: "s3-test",
+        sourceType: "openai_compliance",
+        name: "oai-compliance-test",
         pullConfig: {
-          adapter: "s3_custom",
+          adapter: "openai_compliance",
           bucketName: "test-bucket",
           region: "us-east-1",
           prefix: "logs/",
@@ -115,6 +119,29 @@ describe("pull-source key suppression (#7616)", () => {
 
       expect(captured.data?.ingestSecretHash).toBe("");
       expect(result.ingestSecret).toBeNull();
+    });
+
+    it("s3_custom (webhook callback) → real hash and lw_is_ secret", async () => {
+      const { service, captured } = createServiceForCreate();
+
+      const result = await service.createSource({
+        organizationId: "org_1",
+        sourceType: "s3_custom",
+        name: "s3-callback-test",
+        pullConfig: {
+          adapter: "s3_custom",
+          bucketName: "test-bucket",
+          region: "us-east-1",
+          prefix: "logs/",
+          schedule: "*/30 * * * *",
+          credentials: { accessKeyId: "AKIA", secretAccessKey: "secret" },
+        },
+        pullSchedule: "*/30 * * * *",
+        actorUserId: "user_1",
+      });
+
+      expect(captured.data?.ingestSecretHash).not.toBe("");
+      expect(result.ingestSecret).toMatch(/^lw_is_/);
     });
 
     it("push type → real hash and lw_is_ secret", async () => {
@@ -132,7 +159,7 @@ describe("pull-source key suppression (#7616)", () => {
     });
   });
 
-  describe("rotateSecret", () => {
+  describe("when rotateSecret is called", () => {
     it("pull-mode source is refused", async () => {
       const { service } = createServiceForRotate({
         id: "src_pull",

--- a/platform/app/ee/governance/services/activity-monitor/ingestionSource.service.ts
+++ b/platform/app/ee/governance/services/activity-monitor/ingestionSource.service.ts
@@ -80,6 +80,17 @@ export const SUPPORTED_SOURCE_TYPES: readonly SourceType[] = [
   "http_custom",
 ] as const;
 
+const PUSH_SOURCE_TYPES: ReadonlySet<SourceType> = new Set([
+  "otel_generic",
+  "claude_code",
+  "claude_cowork",
+  "workato",
+]);
+
+export function isPushSourceType(t: SourceType): boolean {
+  return PUSH_SOURCE_TYPES.has(t);
+}
+
 export interface CreateIngestionSourceInput {
   organizationId: string;
   teamId?: string | null;
@@ -120,8 +131,8 @@ export interface UpdateIngestionSourceInput {
 
 export interface CreatedIngestionSource {
   source: IngestionSource;
-  /** Raw ingestSecret — exposed exactly once at creation and never persisted. */
-  ingestSecret: string;
+  /** Raw ingestSecret — exposed exactly once at creation and never persisted. Null for non-push sources. */
+  ingestSecret: string | null;
 }
 
 const ROTATION_GRACE_MS = 24 * 60 * 60 * 1000;
@@ -575,8 +586,9 @@ export class IngestionSourceService {
     // lazy-create logic anywhere else (master_orchestrator constraint).
     await ensureHiddenGovernanceProject(this.prisma, input.organizationId);
 
-    const ingestSecret = generateIngestSecret();
-    const ingestSecretHash = hashIngestSecret(ingestSecret);
+    const isPush = isPushSourceType(input.sourceType);
+    const ingestSecret = isPush ? generateIngestSecret() : null;
+    const ingestSecretHash = ingestSecret ? hashIngestSecret(ingestSecret) : "";
 
     // Phase 10 carryover — the schema has `parserConfig` but no
     // `pullConfig` column; the puller worker actually reads
@@ -816,6 +828,18 @@ export class IngestionSourceService {
     organizationId: string,
   ): Promise<{ source: IngestionSource; ingestSecret: string }> {
     const existing = await this.requireById(id, organizationId);
+    if (!isPushSourceType(existing.sourceType as SourceType)) {
+      throw new ValidationError(
+        "Only push-mode sources have an ingest secret to rotate.",
+        {
+          meta: {
+            formErrors: [
+              "Only push-mode sources have an ingest secret to rotate.",
+            ],
+          },
+        },
+      );
+    }
     const newSecret = generateIngestSecret();
     const newHash = hashIngestSecret(newSecret);
     const priorParser =

--- a/platform/app/ee/governance/services/activity-monitor/ingestionSource.service.ts
+++ b/platform/app/ee/governance/services/activity-monitor/ingestionSource.service.ts
@@ -85,6 +85,7 @@ const PUSH_SOURCE_TYPES: ReadonlySet<SourceType> = new Set([
   "claude_code",
   "claude_cowork",
   "workato",
+  "s3_custom", // webhook callback path authenticated by ingest secret
 ]);
 
 export function isPushSourceType(t: SourceType): boolean {

--- a/platform/app/ee/governance/services/activity-monitor/ingestionSource.service.ts
+++ b/platform/app/ee/governance/services/activity-monitor/ingestionSource.service.ts
@@ -88,8 +88,12 @@ const PUSH_SOURCE_TYPES: ReadonlySet<SourceType> = new Set([
   "s3_custom", // webhook callback path authenticated by ingest secret
 ]);
 
-export function isPushSourceType(t: SourceType): boolean {
-  return PUSH_SOURCE_TYPES.has(t);
+export function isPushSourceType({
+  sourceType,
+}: {
+  sourceType: SourceType;
+}): boolean {
+  return PUSH_SOURCE_TYPES.has(sourceType);
 }
 
 export interface CreateIngestionSourceInput {
@@ -587,7 +591,7 @@ export class IngestionSourceService {
     // lazy-create logic anywhere else (master_orchestrator constraint).
     await ensureHiddenGovernanceProject(this.prisma, input.organizationId);
 
-    const isPush = isPushSourceType(input.sourceType);
+    const isPush = isPushSourceType({ sourceType: input.sourceType });
     const ingestSecret = isPush ? generateIngestSecret() : null;
     const ingestSecretHash = ingestSecret ? hashIngestSecret(ingestSecret) : "";
 
@@ -829,7 +833,7 @@ export class IngestionSourceService {
     organizationId: string,
   ): Promise<{ source: IngestionSource; ingestSecret: string }> {
     const existing = await this.requireById(id, organizationId);
-    if (!isPushSourceType(existing.sourceType as SourceType)) {
+    if (!isPushSourceType({ sourceType: existing.sourceType as SourceType })) {
       throw new ValidationError(
         "Only push-mode sources have an ingest secret to rotate.",
         {

--- a/platform/app/src/server/routes/ingest/__tests__/dogfood-smoke.e2e.integration.test.ts
+++ b/platform/app/src/server/routes/ingest/__tests__/dogfood-smoke.e2e.integration.test.ts
@@ -160,7 +160,7 @@ async function seedOrg(suffix: string): Promise<SeededOrg> {
     teamId: team.id,
     adminUserId: admin.id,
     ingestionSourceId: source.id,
-    ingestSecret,
+    ingestSecret: ingestSecret!,
   };
 }
 

--- a/platform/app/src/server/routes/ingest/__tests__/ingestionRoutes.integration.test.ts
+++ b/platform/app/src/server/routes/ingest/__tests__/ingestionRoutes.integration.test.ts
@@ -109,7 +109,7 @@ async function seedOrgWithIngestionSource({
     teamId: team.id,
     userId: user.id,
     ingestionSourceId: source.id,
-    ingestSecret,
+    ingestSecret: ingestSecret!,
     sourceType,
   };
 }

--- a/platform/app/src/server/routes/ingest/__tests__/ingestionRoutes.volume.integration.test.ts
+++ b/platform/app/src/server/routes/ingest/__tests__/ingestionRoutes.volume.integration.test.ts
@@ -110,7 +110,7 @@ async function seedOrgWithIngestionSource(orgSlug: string): Promise<SeededOrg> {
     teamId: team.id,
     userId: user.id,
     ingestionSourceId: source.id,
-    ingestSecret,
+    ingestSecret: ingestSecret!,
   };
 }
 

--- a/specs/ai-gateway/governance/ingest-api-key-lifecycle.feature
+++ b/specs/ai-gateway/governance/ingest-api-key-lifecycle.feature
@@ -242,3 +242,50 @@ Feature: AI Gateway Governance — Ingest API Key Lifecycle
     Then the key's `lastUsedAt` reflects the most recent trace timestamp
     But NO audit rows are emitted per trace
     And only the issue / rotate / revoke state-changes emit audit rows
+
+  # ---------------------------------------------------------------------------
+  # Pull-source key suppression — #7616
+  # ---------------------------------------------------------------------------
+  # Pull-mode and S3-mode sources authenticate outbound (workspace tokens,
+  # client secrets, S3 credentials stored in parserConfig). They never
+  # receive inbound OTLP pushes, so the `lw_is_*` ingest secret is dead
+  # weight: generated, hashed, stored, shown to the admin, never used.
+  #
+  # The `ingestSecretHash` column is non-nullable (String, not String?),
+  # so the suppression stores an empty-string sentinel rather than NULL.
+  # `findByIngestSecret` hashes inbound tokens before matching, so ""
+  # can never collide with a real hash — the sentinel is inert.
+
+  @bdd @ingest-api-key @pull-source @suppression
+  Scenario: Creating a pull-mode source does not generate an ingest secret
+    When jane creates an ingestion source with sourceType "copilot_studio_dataverse"
+    Then the IngestionSource row has `ingestSecretHash` = "" (empty sentinel)
+    And the create response carries `ingestSecret` = null
+    And no secret modal is shown to the admin
+
+  @bdd @ingest-api-key @pull-source @suppression
+  Scenario: Creating an S3-mode source does not generate an ingest secret
+    When jane creates an ingestion source with sourceType "openai_compliance"
+    Then the IngestionSource row has `ingestSecretHash` = "" (empty sentinel)
+    And the create response carries `ingestSecret` = null
+    And no secret modal is shown to the admin
+
+  @bdd @ingest-api-key @pull-source @suppression
+  Scenario: Creating a push-mode source still generates an ingest secret
+    When jane creates an ingestion source with sourceType "claude_code"
+    Then the IngestionSource row has a real `ingestSecretHash` (non-empty)
+    And the create response carries `ingestSecret` with a valid `lw_is_` prefix
+    And the secret modal is shown to the admin
+
+  @bdd @ingest-api-key @pull-source @rotation-guard
+  Scenario: Rotating a pull-mode source's secret is refused
+    Given jane has a pull-mode source with sourceType "databricks_genie"
+    When jane requests a secret rotation for that source
+    Then the rotation is refused with a validation error
+    And the source's ingestSecretHash remains "" (empty sentinel)
+
+  @bdd @ingest-api-key @pull-source @rotation-guard
+  Scenario: Rotating a push-mode source's secret still works
+    Given jane has a push-mode source with sourceType "otel_generic"
+    When jane requests a secret rotation for that source
+    Then a new secret is minted and the prior hash enters the grace window

--- a/specs/ai-gateway/governance/ingest-api-key-lifecycle.feature
+++ b/specs/ai-gateway/governance/ingest-api-key-lifecycle.feature
@@ -271,6 +271,13 @@ Feature: AI Gateway Governance — Ingest API Key Lifecycle
     And no secret modal is shown to the admin
 
   @bdd @ingest-api-key @pull-source @suppression
+  Scenario: Creating an s3_custom source generates a secret for webhook callback
+    When jane creates an ingestion source with sourceType "s3_custom"
+    Then the IngestionSource row has a real `ingestSecretHash` (non-empty)
+    And the create response carries `ingestSecret` with a valid `lw_is_` prefix
+    And the secret modal is shown to the admin
+
+  @bdd @ingest-api-key @pull-source @suppression
   Scenario: Creating a push-mode source still generates an ingest secret
     When jane creates an ingestion source with sourceType "claude_code"
     Then the IngestionSource row has a real `ingestSecretHash` (non-empty)

--- a/specs/ai-gateway/governance/ingestion-sources.feature
+++ b/specs/ai-gateway/governance/ingestion-sources.feature
@@ -307,6 +307,40 @@ Feature: IngestionSource — admin configuration of cross-platform feeds
     Then push-mode sources appear under "Real-time streams"
     And pull-mode and s3-mode sources appear together under "Synced on a schedule"
 
+  # ---------------------------------------------------------------------------
+  # Source list — table layout, icons, and protocol column — #7617
+  # ---------------------------------------------------------------------------
+
+  @integration @source-list
+  Scenario: Each source row shows the vendor icon next to the name
+    Given configured sources of different types exist
+    When the admin views the source list
+    Then each row displays the SourceTypeIconGlyph for its source type
+    And the icon sits to the left of the source name
+
+  @integration @source-list
+  Scenario: Each source row shows its delivery protocol
+    Given configured sources of push, pull, and s3 modes exist
+    When the admin views the source list
+    Then push sources show the protocol label "OTel push"
+    And pull sources show the protocol label "API pull"
+    And s3 sources show the protocol label "S3 pull"
+
+  @integration @source-list @pull-source
+  Scenario: The rotate-secret button is hidden for non-push sources on the list
+    Given a pull-mode source exists
+    And a push-mode source exists
+    When the admin views the source list
+    Then the push source row shows a "Rotate secret" action
+    And the pull source row does not show a "Rotate secret" action
+
+  @integration @source-detail @pull-source
+  Scenario: The rotate-secret button is hidden for non-push sources on the detail page
+    Given a pull-mode source exists
+    When the admin opens that source's detail page
+    Then the page does not show a "Rotate secret" action
+    And the Edit and Archive actions remain available
+
   Scenario Outline: Admin adds a source by type
     When the admin clicks "Add source"
     And they pick "<source_type>"


### PR DESCRIPTION
## Summary

- **Pull-only and pure-S3 ingestion sources no longer generate ingest secrets.** `createSource` returns `null` for non-push types, stores an empty-string sentinel in `ingestSecretHash` (column is non-nullable). `rotateSecret` throws `ValidationError` for non-push types. **Exception:** `s3_custom` uses the webhook callback path (`/api/ingest/webhook/:sourceId`) authenticated by ingest secret — it keeps its secret.
- **Ingestion source list redesigned with icons and protocol column.** Each source row now shows a `SourceTypeIconGlyph` and a protocol badge (`OTel push` / `API pull` / `S3 pull`). Rotate button appears only for secret-bearing sources (push types + s3_custom) — both on the list and detail pages.
- **Webhook callback URL shown for s3_custom.** Both the creation secret modal and rotation secret reveal modal now display the webhook callback URL for s3_custom (alongside workato), so admins can configure their S3 bucket notification endpoint.
- **Parity test added** to guard against drift between `isPushSourceType` (service) and `needsIngestSecret` (catalog).

Closes #7616, closes #7617

## Test plan

- [x] 8 unit tests for key suppression (`ingestionSourceKeySuppression.unit.test.ts`) — create pull/pure-s3/s3_custom/push, rotate pull/push
- [x] 2 parity tests (`pushSourceTypeParity.unit.test.ts`) — bidirectional sync guard
- [x] Full suite green
- [x] Lint clean (0 new biome violations)
- [x] Typecheck clean (zero errors in changed files)
- [ ] Manual: create a pull source → no secret modal, toast shown
- [ ] Manual: list view shows icon + protocol badge per source
- [ ] Manual: rotate button absent for pull sources on list and detail, present for s3_custom
- [ ] Manual: create/rotate s3_custom → modal shows webhook callback URL