### PR TITLE
fix(experiments): persist browser-run results to the server

### DIFF
--- a/dev/scripts/lib/plan-langy-lane.sh
+++ b/dev/scripts/lib/plan-langy-lane.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+# Decide whether `pnpm dev` starts the Langy agent manager, and on which port.
+#
+# The decision has more branches than the other Go lanes, so it lives here
+# rather than inline in start.sh: langyagent takes its listen port from PORT
+# (which the launcher already uses for the app) and fails fast without its
+# secret and its two roots, so a lane started into a setup that cannot run it
+# restarts for as long as the stack is up.
+#
+# Usage from platform/app/scripts/start.sh:
+#
+#   . "$(dirname "$0")/../../../dev/scripts/lib/plan-langy-lane.sh"
+#   plan_langy_lane "$(dirname "$0")/.." "$_APP_PORT"
+#   # reads LANGY_LANE_DECISION, LANGY_LANE_REASON, LANGY_LANE_PORT
+#
+# See specs/setup/dev-langy-agent-lane.feature.
+
+. "$(dirname "${BASH_SOURCE[0]}")/resolve-service-address.sh"
+
+# The manager's own defaults are the production ones: twenty workers reaped
+# after ten idle minutes. Each worker is about 600 MB, so on a laptop that is
+# up to twelve gigabytes held for ten minutes after a chat ends. These are
+# haven's local numbers for the same service.
+LANGY_LOCAL_MAX_WORKERS=2
+LANGY_LOCAL_WORKER_IDLE_MS=120000
+LANGY_LOCAL_REAPER_INTERVAL_MS=2000
+
+# The port slot the manager takes when nothing pins an address. The app is at
+# PORT, the NLP engine at PORT+1 and the gateway at PORT+3, which leaves PORT+4
+# free. It is also what the standalone server package defaults to.
+LANGY_PORT_OFFSET=4
+
+# Overridable so the lane can be planned in a test without a Go toolchain or a
+# live listener.
+_langy_have_go() { command -v go >/dev/null 2>&1; }
+_langy_port_listening() { lsof -i ":$1" -sTCP:LISTEN >/dev/null 2>&1; }
+
+# True when the setting has a value in the shell or in either env file, which
+# is what the manager will see: `make service` sources .env into its process.
+_langy_setting_present() {
+  local var="$1" app_dir="$2" file
+  [ -n "${!var}" ] && return 0
+  for file in "$app_dir/.env.portless" "$app_dir/.env"; do
+    _service_address_from_env_file "$var" "$file" >/dev/null && return 0
+  done
+  return 1
+}
+
+_langy_skip() {
+  LANGY_LANE_DECISION="skip"
+  LANGY_LANE_REASON="$1"
+}
+
+plan_langy_lane() {
+  local app_dir="${1:-.}"
+  local app_port="${2:-5560}"
+
+  LANGY_LANE_DECISION="skip"
+  LANGY_LANE_REASON=""
+  LANGY_LANE_PORT=""
+
+  if [ "$LANGWATCH_SKIP_LANGY" = "1" ]; then
+    _langy_skip "skipped (LANGWATCH_SKIP_LANGY=1)"
+    return 0
+  fi
+
+  resolve_service_address OPENCODE_AGENT_URL "$app_dir" langy
+
+  local port=""
+  if [ -z "$OPENCODE_AGENT_URL" ]; then
+    port=$((app_port + LANGY_PORT_OFFSET))
+    export OPENCODE_AGENT_URL="http://localhost:${port}"
+  elif [[ "$OPENCODE_AGENT_URL" =~ ^https?://(localhost|127\.0\.0\.1):([0-9]+) ]]; then
+    port="${BASH_REMATCH[2]}"
+  else
+    _langy_skip "external OPENCODE_AGENT_URL=${OPENCODE_AGENT_URL}, not starting a local one"
+    return 0
+  fi
+  LANGY_LANE_PORT="$port"
+
+  # A manager that is already up answers for this stack too, so it is reused
+  # before the setup is judged: a running service is proof the setup works.
+  if _langy_port_listening "$port"; then
+    _langy_skip "already running on :${port}, reusing"
+    return 0
+  fi
+
+  if ! _langy_have_go; then
+    _langy_skip "skipped (Go toolchain not in PATH); run \`make service svc=langyagent\` manually"
+    return 0
+  fi
+
+  local var missing=""
+  for var in LANGY_INTERNAL_SECRET SESSIONS_ROOT LANGY_WORKSPACE_ROOT; do
+    if ! _langy_setting_present "$var" "$app_dir"; then
+      missing="${missing:+$missing, }${var}"
+    fi
+  done
+  if [ -n "$missing" ]; then
+    _langy_skip "skipped (platform/app/.env has no ${missing}); run \`bash dev/scripts/dogfood/langy-local.sh\` for the block to paste"
+    return 0
+  fi
+
+  LANGY_LANE_DECISION="start"
+  LANGY_LANE_REASON="auto-start on :${port}"
+
+  # The manager spawns this binary per conversation. Without it the manager
+  # boots, accepts the dispatch and fails the turn with `exec: "langy-worker"`,
+  # which reaches the reader as "Langy stopped mid-reply" and says nothing
+  # about a missing build. Name the repo's copy and say when it is not there.
+  LANGY_LANE_WORKER_BINARY="$(cd "$app_dir/../.." 2>/dev/null && pwd)/services/langyworker/out/langy-worker"
+  if [ ! -x "$LANGY_LANE_WORKER_BINARY" ]; then
+    LANGY_LANE_REASON="${LANGY_LANE_REASON}, chats need \`pnpm --filter @langwatch/langyworker build:binary\` first"
+  fi
+  return 0
+}
+
+# The command the lane runs. Every cap is applied only when the developer has
+# not set one, so a pinned value in the environment still wins.
+langy_lane_command() {
+  local repo_from_app="$1"
+  local port="$2"
+  printf '%s' "PORT=\"${port}\" \
+LANGY_PI_WORKER_BINARY_PATH=\"\${LANGY_PI_WORKER_BINARY_PATH:-${LANGY_LANE_WORKER_BINARY}}\" \
+LANGY_MAX_WORKERS=\"\${LANGY_MAX_WORKERS:-${LANGY_LOCAL_MAX_WORKERS}}\" \
+LANGY_WORKER_IDLE_MS=\"\${LANGY_WORKER_IDLE_MS:-${LANGY_LOCAL_WORKER_IDLE_MS}}\" \
+LANGY_REAPER_INTERVAL_MS=\"\${LANGY_REAPER_INTERVAL_MS:-${LANGY_LOCAL_REAPER_INTERVAL_MS}}\" \
+make -C ${repo_from_app} service svc=langyagent"
+}

--- a/dev/scripts/lib/plan-langy-lane.sh
+++ b/dev/scripts/lib/plan-langy-lane.sh
@@ -30,25 +30,52 @@ LANGY_LOCAL_REAPER_INTERVAL_MS=2000
 # free. It is also what the standalone server package defaults to.
 LANGY_PORT_OFFSET=4
 
-# Overridable so the lane can be planned in a test without a Go toolchain or a
-# live listener.
+# Overridable so the lane can be planned in a test without a Go toolchain, a
+# live listener, or a particular python on PATH.
 _langy_have_go() { command -v go >/dev/null 2>&1; }
 _langy_port_listening() { lsof -i ":$1" -sTCP:LISTEN >/dev/null 2>&1; }
 
-# True when the setting has a value in the shell or in either env file, which
-# is what the manager will see: `make service` sources .env into its process.
+# True when the manager will have a value for the setting.
+#
+# This reads fewer files than the address does, and the difference is the point.
+# The address is resolved the way the APP reads it, because the app decides
+# where to dial, and the app loads the haven overlay. These settings are read by
+# the MANAGER, and `make service` sources .env alone. A value that lives only in
+# .env.portless would count as present here, start the lane, and the manager
+# would still exit for a missing setting, on every restart.
 _langy_setting_present() {
-  local var="$1" app_dir="$2" file
-  [ -n "${!var}" ] && return 0
-  for file in "$app_dir/.env.portless" "$app_dir/.env"; do
-    _service_address_from_env_file "$var" "$file" >/dev/null && return 0
-  done
-  return 1
+  local var="$1" app_dir="$2"
+  [ -n "${!var:-}" ] && return 0
+  _service_address_from_env_file "$var" "$app_dir/.env" >/dev/null
 }
 
 _langy_skip() {
   LANGY_LANE_DECISION="skip"
   LANGY_LANE_REASON="$1"
+}
+
+# A directory holding a `python` that runs `python3`, or nothing.
+#
+# The worker's model reaches for `python` on its own. macOS ships `python3`
+# only, so that first call fails, and the model spends another turn and another
+# tool call finding out. Putting the name it expects on the worker's PATH makes
+# the first call work. Nothing is shadowed: the shim is built only when the
+# machine has no `python` of its own, and it points at the `python3` already
+# installed.
+_langy_have_python() { command -v python >/dev/null 2>&1; }
+_langy_python3_path() { command -v python3 2>/dev/null; }
+
+_langy_python_shim_dir() {
+  local repo="$1" dir target
+  _langy_have_python && return 1
+  target=$(_langy_python3_path) || return 1
+  [ -n "$target" ] || return 1
+  dir="$repo/node_modules/.cache/langy-shims/bin"
+  mkdir -p "$dir" 2>/dev/null || return 1
+  # Relinked every time rather than only when absent, so a shim left over from
+  # an interpreter that has since moved does not outlive it.
+  ln -sfn "$target" "$dir/python" 2>/dev/null || return 1
+  printf '%s' "$dir"
 }
 
 plan_langy_lane() {
@@ -59,7 +86,7 @@ plan_langy_lane() {
   LANGY_LANE_REASON=""
   LANGY_LANE_PORT=""
 
-  if [ "$LANGWATCH_SKIP_LANGY" = "1" ]; then
+  if [ "${LANGWATCH_SKIP_LANGY:-}" = "1" ]; then
     _langy_skip "skipped (LANGWATCH_SKIP_LANGY=1)"
     return 0
   fi
@@ -67,10 +94,10 @@ plan_langy_lane() {
   resolve_service_address OPENCODE_AGENT_URL "$app_dir" langy
 
   local port=""
-  if [ -z "$OPENCODE_AGENT_URL" ]; then
+  if [ -z "${OPENCODE_AGENT_URL:-}" ]; then
     port=$((app_port + LANGY_PORT_OFFSET))
     export OPENCODE_AGENT_URL="http://localhost:${port}"
-  elif [[ "$OPENCODE_AGENT_URL" =~ ^https?://(localhost|127\.0\.0\.1):([0-9]+) ]]; then
+  elif [[ "${OPENCODE_AGENT_URL:-}" =~ ^https?://(localhost|127\.0\.0\.1):([0-9]+) ]]; then
     port="${BASH_REMATCH[2]}"
   else
     _langy_skip "external OPENCODE_AGENT_URL=${OPENCODE_AGENT_URL}, not starting a local one"
@@ -108,10 +135,14 @@ plan_langy_lane() {
   # boots, accepts the dispatch and fails the turn with `exec: "langy-worker"`,
   # which reaches the reader as "Langy stopped mid-reply" and says nothing
   # about a missing build. Name the repo's copy and say when it is not there.
-  LANGY_LANE_WORKER_BINARY="$(cd "$app_dir/../.." 2>/dev/null && pwd)/services/langyworker/out/langy-worker"
+  local repo
+  repo="$(cd "$app_dir/../.." 2>/dev/null && pwd)"
+  LANGY_LANE_WORKER_BINARY="${repo}/services/langyworker/out/langy-worker"
   if [ ! -x "$LANGY_LANE_WORKER_BINARY" ]; then
     LANGY_LANE_REASON="${LANGY_LANE_REASON}, chats need \`pnpm --filter @langwatch/langyworker build:binary\` first"
   fi
+
+  LANGY_LANE_PYTHON_SHIM="$(_langy_python_shim_dir "$repo" || true)"
   return 0
 }
 
@@ -120,7 +151,11 @@ plan_langy_lane() {
 langy_lane_command() {
   local repo_from_app="$1"
   local port="$2"
-  printf '%s' "PORT=\"${port}\" \
+  local path_prefix=""
+  if [ -n "${LANGY_LANE_PYTHON_SHIM:-}" ]; then
+    path_prefix="PATH=\"${LANGY_LANE_PYTHON_SHIM}:\$PATH\" "
+  fi
+  printf '%s' "${path_prefix}PORT=\"${port}\" \
 LANGY_PI_WORKER_BINARY_PATH=\"\${LANGY_PI_WORKER_BINARY_PATH:-${LANGY_LANE_WORKER_BINARY}}\" \
 LANGY_MAX_WORKERS=\"\${LANGY_MAX_WORKERS:-${LANGY_LOCAL_MAX_WORKERS}}\" \
 LANGY_WORKER_IDLE_MS=\"\${LANGY_WORKER_IDLE_MS:-${LANGY_LOCAL_WORKER_IDLE_MS}}\" \

--- a/dev/scripts/lib/resolve-nlp-service.sh
+++ b/dev/scripts/lib/resolve-nlp-service.sh
@@ -2,67 +2,17 @@
 # Resolve the NLP engine address the app is going to dial, so `pnpm dev` starts
 # its engine on that port instead of one nothing talks to.
 #
-# platform/app/scripts/start.sh runs before any Node entry point, and the shell
-# never loads platform/app/.env. The app does, with `override: true`
-# (platform/app/src/env-load.ts), so a LANGWATCH_NLP_SERVICE pinned in .env is
-# the address it dials and the launcher cannot see it. Without this the launcher
-# reads an unset variable, derives PORT+1, starts an engine there, and every
-# optimization-studio or playground run fails with "LangWatch NLP is
-# unreachable" while a healthy engine sits on the other port.
-#
-# Precedence mirrors env-load.ts exactly, because the goal is to predict what
-# the app will resolve: .env.portless (the haven overlay, loaded last) beats
-# .env, and both beat the calling shell. Leaving the variable untouched means
-# nothing pinned an address, which is the launcher's cue to derive PORT+1 and
-# point the app at it.
+# The reading itself is generic and lives in resolve-service-address.sh; this
+# names the variable and the label for the engine. See that file for why the
+# launcher has to read the env files at all.
 #
 # Usage from platform/app/scripts/start.sh:
 #
 #   . "$(dirname "$0")/../../../dev/scripts/lib/resolve-nlp-service.sh"
 #   resolve_nlp_service "$(dirname "$0")/.."
 
-# Reads LANGWATCH_NLP_SERVICE out of one env file the way dotenv would: last
-# assignment wins, an optional `export` prefix, single or double quotes, and an
-# inline comment after an unquoted value. Prints the value, or fails when the
-# file has no usable one.
-_nlp_service_from_env_file() {
-  local file="$1"
-  [ -f "$file" ] || return 1
-
-  local raw
-  raw=$(sed -n -E 's/^[[:space:]]*(export[[:space:]]+)?LANGWATCH_NLP_SERVICE[[:space:]]*=[[:space:]]*(.*)$/\2/p' "$file" | tail -n 1)
-  raw="${raw%$'\r'}"
-
-  case "$raw" in
-    \"*)
-      raw="${raw#\"}"
-      raw="${raw%%\"*}"
-      ;;
-    \'*)
-      raw="${raw#\'}"
-      raw="${raw%%\'*}"
-      ;;
-    *)
-      raw="${raw%%#*}"
-      raw="${raw%"${raw##*[![:space:]]}"}"
-      ;;
-  esac
-
-  [ -n "$raw" ] || return 1
-  printf '%s' "$raw"
-}
+. "$(dirname "${BASH_SOURCE[0]}")/resolve-service-address.sh"
 
 resolve_nlp_service() {
-  local app_dir="${1:-.}"
-  local file value
-
-  for file in "$app_dir/.env.portless" "$app_dir/.env"; do
-    if value=$(_nlp_service_from_env_file "$file"); then
-      export LANGWATCH_NLP_SERVICE="$value"
-      echo "  ✓ nlpgo: LANGWATCH_NLP_SERVICE=${value} (from $(basename "$file"))"
-      return 0
-    fi
-  done
-
-  return 0
+  resolve_service_address LANGWATCH_NLP_SERVICE "${1:-.}" nlpgo
 }

--- a/dev/scripts/lib/resolve-service-address.sh
+++ b/dev/scripts/lib/resolve-service-address.sh
@@ -21,14 +21,21 @@
 
 # Reads one variable out of one env file the way dotenv would: last assignment
 # wins, an optional `export` prefix, single or double quotes, and an inline
-# comment after an unquoted value. Prints the value, or fails when the file has
-# no usable one.
+# comment after an unquoted value.
+#
+# Prints the value and returns 0. Returns 1 when the file assigns the variable
+# nowhere, and 2 when it assigns it an empty value, which is a different answer:
+# dotenv gives the app an empty string there, so the file has cleared whatever a
+# lower-precedence file said rather than saying nothing about it.
 _service_address_from_env_file() {
   local var="$1"
   local file="$2"
   [ -f "$file" ] || return 1
 
-  local raw
+  local assigned raw
+  assigned=$(sed -n -E "s/^[[:space:]]*(export[[:space:]]+)?${var}[[:space:]]*=.*\$/y/p" "$file" | tail -n 1)
+  [ -n "$assigned" ] || return 1
+
   raw=$(sed -n -E "s/^[[:space:]]*(export[[:space:]]+)?${var}[[:space:]]*=[[:space:]]*(.*)\$/\\2/p" "$file" | tail -n 1)
   raw="${raw%$'\r'}"
 
@@ -47,7 +54,7 @@ _service_address_from_env_file() {
       ;;
   esac
 
-  [ -n "$raw" ] || return 1
+  [ -n "$raw" ] || return 2
   printf '%s' "$raw"
 }
 
@@ -57,12 +64,23 @@ resolve_service_address() {
   local var="$1"
   local app_dir="${2:-.}"
   local label="${3:-$1}"
-  local file value
+  local file value status
 
   for file in "$app_dir/.env.portless" "$app_dir/.env"; do
-    if value=$(_service_address_from_env_file "$var" "$file"); then
+    # `|| status=$?` keeps this out of `set -e`'s reach: a bare assignment from
+    # a failing command substitution ends the caller's script.
+    status=0
+    value=$(_service_address_from_env_file "$var" "$file") || status=$?
+    if [ "$status" -eq 0 ]; then
       export "$var=$value"
       echo "  ✓ ${label}: ${var}=${value} (from $(basename "$file"))"
+      return 0
+    fi
+    # An empty assignment is this file's answer, not a gap to look past. The app
+    # would read an empty string here, so the launcher derives its own address
+    # rather than exporting the value a lower-precedence file still holds.
+    if [ "$status" -eq 2 ]; then
+      echo "  ✓ ${label}: ${var} cleared by $(basename "$file")"
       return 0
     fi
   done

--- a/dev/scripts/lib/resolve-service-address.sh
+++ b/dev/scripts/lib/resolve-service-address.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# Resolve the address a service is going to be dialed at, so `pnpm dev` starts
+# that service on the port something actually talks to.
+#
+# platform/app/scripts/start.sh runs before any Node entry point, and the shell
+# never loads platform/app/.env. The app does, with `override: true`
+# (platform/app/src/env-load.ts), so an address pinned in .env is what it dials
+# and the launcher cannot see it. Without this the launcher reads an unset
+# variable, derives a port from its own slot, starts a service there, and every
+# call fails while a healthy service sits on the other port.
+#
+# Precedence mirrors env-load.ts exactly, because the goal is to predict what
+# the app will resolve: .env.portless (the haven overlay, loaded last) beats
+# .env, and both beat the calling shell. Leaving the variable untouched means
+# nothing pinned an address, which is the caller's cue to derive its own.
+#
+# Usage:
+#
+#   . "$(dirname "$0")/../../../dev/scripts/lib/resolve-service-address.sh"
+#   resolve_service_address LANGWATCH_NLP_SERVICE "$app_dir" nlpgo
+
+# Reads one variable out of one env file the way dotenv would: last assignment
+# wins, an optional `export` prefix, single or double quotes, and an inline
+# comment after an unquoted value. Prints the value, or fails when the file has
+# no usable one.
+_service_address_from_env_file() {
+  local var="$1"
+  local file="$2"
+  [ -f "$file" ] || return 1
+
+  local raw
+  raw=$(sed -n -E "s/^[[:space:]]*(export[[:space:]]+)?${var}[[:space:]]*=[[:space:]]*(.*)\$/\\2/p" "$file" | tail -n 1)
+  raw="${raw%$'\r'}"
+
+  case "$raw" in
+    \"*)
+      raw="${raw#\"}"
+      raw="${raw%%\"*}"
+      ;;
+    \'*)
+      raw="${raw#\'}"
+      raw="${raw%%\'*}"
+      ;;
+    *)
+      raw="${raw%%#*}"
+      raw="${raw%"${raw##*[![:space:]]}"}"
+      ;;
+  esac
+
+  [ -n "$raw" ] || return 1
+  printf '%s' "$raw"
+}
+
+# Exports `var` with the address the app will read, and says where it came from.
+# Leaves it untouched when no env file pins one.
+resolve_service_address() {
+  local var="$1"
+  local app_dir="${2:-.}"
+  local label="${3:-$1}"
+  local file value
+
+  for file in "$app_dir/.env.portless" "$app_dir/.env"; do
+    if value=$(_service_address_from_env_file "$var" "$file"); then
+      export "$var=$value"
+      echo "  ✓ ${label}: ${var}=${value} (from $(basename "$file"))"
+      return 0
+    fi
+  done
+
+  return 0
+}

--- a/dev/scripts/lib/resolve-service-address.sh
+++ b/dev/scripts/lib/resolve-service-address.sh
@@ -78,8 +78,10 @@ resolve_service_address() {
     fi
     # An empty assignment is this file's answer, not a gap to look past. The app
     # would read an empty string here, so the launcher derives its own address
-    # rather than exporting the value a lower-precedence file still holds.
+    # rather than exporting the value a lower-precedence file still holds. An
+    # address exported into the shell goes too, because the file overrides it.
     if [ "$status" -eq 2 ]; then
+      unset "$var"
       echo "  ✓ ${label}: ${var} cleared by $(basename "$file")"
       return 0
     fi

--- a/platform/app/scripts/__tests__/plan-langy-lane.unit.test.ts
+++ b/platform/app/scripts/__tests__/plan-langy-lane.unit.test.ts
@@ -47,18 +47,46 @@ afterEach(() => {
   }
 });
 
+/**
+ * Expands the lane command the way the shell that runs it would, so a test can
+ * see which value the manager ends up with.
+ *
+ * The command goes through an unquoted heredoc: bash expands `${VAR:-default}`
+ * there and leaves every quote literal, so the command needs no escaping on the
+ * way in. Interpolating it into a `bash -c '...'` string would need escaping for
+ * both quotes and backslashes, and getting that half right is its own bug.
+ */
+function expandLaneCommand({
+  command,
+  env,
+}: {
+  command: string;
+  env: Record<string, string>;
+}): string {
+  return execSync("bash -s", {
+    encoding: "utf8",
+    input: `cat <<EOF\n${command}\nEOF\n`,
+    stdio: ["pipe", "pipe", "pipe"],
+    env: { PATH: process.env.PATH ?? "", ...env },
+  });
+}
+
 function plan({
   appDir,
   appPort = "5560",
   env = {},
   hasGo = true,
   listening = false,
+  hasPython = false,
+  python3 = "/usr/bin/python3",
 }: {
   appDir: string;
   appPort?: string;
   env?: Record<string, string | undefined>;
   hasGo?: boolean;
   listening?: boolean;
+  hasPython?: boolean;
+  python3?: string;
 }): {
   stdout: string;
   decision: string;
@@ -81,6 +109,8 @@ ${exports}
 . "${PLANNER}"
 _langy_have_go() { return ${hasGo ? 0 : 1}; }
 _langy_port_listening() { return ${listening ? 0 : 1}; }
+_langy_have_python() { return ${hasPython ? 0 : 1}; }
+_langy_python3_path() { printf '%s' "${python3}"; }
 plan_langy_lane "${appDir}" "${appPort}"
 echo "__DECISION=\${LANGY_LANE_DECISION:-}"
 echo "__REASON=\${LANGY_LANE_REASON:-}"
@@ -107,6 +137,7 @@ echo "__COMMAND=$(echo '')\$(langy_lane_command '../..' "\${LANGY_LANE_PORT:-0}"
   }
   const read = (key: string) =>
     stdout.match(new RegExp(`__${key}=(.*)`))?.[1] ?? "";
+
   return {
     stdout,
     decision: read("DECISION"),
@@ -195,6 +226,19 @@ describe("plan-langy-lane.sh", () => {
       expect(r.agentUrl).toBe("http://127.0.0.1:41234");
       expect(r.port).toBe("41234");
     });
+
+    /** @scenario "An overlay that clears the agent address is not read past" */
+    it("derives the port when the overlay clears the address", () => {
+      const appDir = appDirWith({
+        ".env": `OPENCODE_AGENT_URL="http://localhost:8080"\n${FULL_ENV}`,
+        ".env.portless": "OPENCODE_AGENT_URL=\n",
+      });
+
+      const r = plan({ appDir, appPort: "5570" });
+
+      expect(r.port).toBe("5574");
+      expect(r.agentUrl).toBe("http://localhost:5574");
+    });
   });
 
   describe("given nothing pins an agent address", () => {
@@ -255,6 +299,19 @@ describe("plan-langy-lane.sh", () => {
       const r = plan({ appDir, env: { LANGY_INTERNAL_SECRET: "from-shell" } });
 
       expect(r.decision).toBe("start");
+    });
+
+    /** @scenario "A setting only the haven overlay carries does not count as present" */
+    it("does not count a secret that only the haven overlay carries", () => {
+      const appDir = appDirWith({
+        ".env": 'SESSIONS_ROOT="/tmp/s"\nLANGY_WORKSPACE_ROOT="/tmp/w"\n',
+        ".env.portless": 'LANGY_INTERNAL_SECRET="from-overlay"\n',
+      });
+
+      const r = plan({ appDir });
+
+      expect(r.decision).toBe("skip");
+      expect(r.reason).toMatch(/LANGY_INTERNAL_SECRET/);
     });
 
     /** @scenario "No Go toolchain skips the lane with the manual command" */
@@ -333,10 +390,10 @@ describe("plan-langy-lane.sh", () => {
       const appDir = appDirWith({ ".env": FULL_ENV });
 
       const r = plan({ appDir });
-      const expanded = execSync(
-        `bash -c 'export LANGY_PI_WORKER_BINARY_PATH=/opt/mine; echo "${r.command.replace(/"/g, '\\"')}"'`,
-        { encoding: "utf8", env: { PATH: process.env.PATH ?? "" } },
-      );
+      const expanded = expandLaneCommand({
+        command: r.command,
+        env: { LANGY_PI_WORKER_BINARY_PATH: "/opt/mine" },
+      });
 
       expect(expanded).toMatch(/LANGY_PI_WORKER_BINARY_PATH="\/opt\/mine"/);
     });
@@ -354,43 +411,85 @@ describe("plan-langy-lane.sh", () => {
     });
   });
 
-  describe("when the lane is started", () => {
-    /** @scenario "The lane caps the pool and reaps idle workers quickly" */
-    it("caps the worker pool to the local size", () => {
+  describe("given the command names the worker's model reaches for", () => {
+    /** @scenario "A machine with only python3 gets a python that runs it" */
+    it("puts a python on the worker's PATH when the machine has only python3", () => {
       const appDir = appDirWith({ ".env": FULL_ENV });
 
-      const r = plan({ appDir });
+      const r = plan({ appDir, hasPython: false });
 
-      expect(r.command).toMatch(
-        /LANGY_MAX_WORKERS="\$\{LANGY_MAX_WORKERS:-2\}"/,
-      );
+      expect(r.command).toMatch(/^PATH="[^"]*langy-shims\/bin:\$PATH" /);
     });
 
-    /** @scenario "The lane caps the pool and reaps idle workers quickly" */
-    it("reaps an idle worker in minutes rather than the production wait", () => {
+    /** @scenario "A machine with only python3 gets a python that runs it" */
+    it("points that python at the python3 already installed", () => {
       const appDir = appDirWith({ ".env": FULL_ENV });
 
-      const r = plan({ appDir });
+      const r = plan({
+        appDir,
+        hasPython: false,
+        python3: "/opt/homebrew/bin/python3",
+      });
+      const shimDir = r.command.match(/^PATH="([^:]*)/)?.[1] ?? "";
+      const target = execSync(`readlink ${shimDir}/python`, {
+        encoding: "utf8",
+        env: { PATH: process.env.PATH ?? "" },
+      }).trim();
 
-      expect(r.command).toMatch(
-        /LANGY_WORKER_IDLE_MS="\$\{LANGY_WORKER_IDLE_MS:-120000\}"/,
-      );
-      expect(r.command).toMatch(/svc=langyagent/);
+      expect(target).toBe("/opt/homebrew/bin/python3");
     });
 
-    /** @scenario "The lane caps the pool and reaps idle workers quickly" */
-    it("lets a cap set in the environment win over the local default", () => {
+    /** @scenario "A machine that has its own python is left alone" */
+    it("adds nothing to the PATH when the machine already has a python", () => {
       const appDir = appDirWith({ ".env": FULL_ENV });
 
-      const r = plan({ appDir, env: { LANGY_MAX_WORKERS: "8" } });
+      const r = plan({ appDir, hasPython: true });
 
-      // The lane expands the override where it runs, so the local number is
-      // only a fallback and the developer's value survives.
-      const expanded = execSync(
-        `bash -c 'export LANGY_MAX_WORKERS=8; echo "${r.command.replace(/"/g, '\\"')}"'`,
-        { encoding: "utf8", env: { PATH: process.env.PATH ?? "" } },
-      );
-      expect(expanded).toMatch(/LANGY_MAX_WORKERS="8"/);
+      expect(r.command).not.toMatch(/^PATH=/);
+      expect(r.command).toMatch(/^PORT=/);
+    });
+  });
+
+  describe("given a lane that will start", () => {
+    describe("when the lane is started", () => {
+      /** @scenario "The lane caps the pool and reaps idle workers quickly" */
+      it("caps the worker pool to the local size", () => {
+        const appDir = appDirWith({ ".env": FULL_ENV });
+
+        const r = plan({ appDir });
+
+        expect(r.command).toMatch(
+          /LANGY_MAX_WORKERS="\$\{LANGY_MAX_WORKERS:-2\}"/,
+        );
+      });
+
+      /** @scenario "The lane caps the pool and reaps idle workers quickly" */
+      it("reaps an idle worker in minutes rather than the production wait", () => {
+        const appDir = appDirWith({ ".env": FULL_ENV });
+
+        const r = plan({ appDir });
+
+        expect(r.command).toMatch(
+          /LANGY_WORKER_IDLE_MS="\$\{LANGY_WORKER_IDLE_MS:-120000\}"/,
+        );
+        expect(r.command).toMatch(/svc=langyagent/);
+      });
+
+      /** @scenario "The lane caps the pool and reaps idle workers quickly" */
+      it("lets a cap set in the environment win over the local default", () => {
+        const appDir = appDirWith({ ".env": FULL_ENV });
+
+        const r = plan({ appDir, env: { LANGY_MAX_WORKERS: "8" } });
+
+        // The lane expands the override where it runs, so the local number is
+        // only a fallback and the developer's value survives.
+        const expanded = expandLaneCommand({
+          command: r.command,
+          env: { LANGY_MAX_WORKERS: "8" },
+        });
+
+        expect(expanded).toMatch(/LANGY_MAX_WORKERS="8"/);
+      });
     });
   });
 });

--- a/platform/app/scripts/__tests__/plan-langy-lane.unit.test.ts
+++ b/platform/app/scripts/__tests__/plan-langy-lane.unit.test.ts
@@ -159,302 +159,340 @@ echo "__COMMAND=$(echo '')\$(langy_lane_command '../..' "\${LANGY_LANE_PORT:-0}"
 
 describe("plan-langy-lane.sh", () => {
   describe("given the app's env file pins an agent address", () => {
-    /** @scenario "The manager follows the address pinned in the app's env file" */
-    it("resolves the pinned address rather than this worktree's port slot", () => {
-      const appDir = appDirWith({
-        ".env": `OPENCODE_AGENT_URL="http://localhost:8080"\n${FULL_ENV}`,
+    describe("when the lane is planned", () => {
+      /** @scenario "The manager follows the address pinned in the app's env file" */
+      it("resolves the pinned address rather than this worktree's port slot", () => {
+        const appDir = appDirWith({
+          ".env": `OPENCODE_AGENT_URL="http://localhost:8080"\n${FULL_ENV}`,
+        });
+
+        const r = plan({ appDir, appPort: "5590" });
+
+        expect(r.exitCode).toBe(0);
+        expect(r.agentUrl).toBe("http://localhost:8080");
+        expect(r.port).toBe("8080");
       });
 
-      const r = plan({ appDir, appPort: "5590" });
+      /** @scenario "The manager follows the address pinned in the app's env file" */
+      it("names the file it read the address from", () => {
+        const appDir = appDirWith({
+          ".env": `OPENCODE_AGENT_URL="http://localhost:8080"\n${FULL_ENV}`,
+        });
 
-      expect(r.exitCode).toBe(0);
-      expect(r.agentUrl).toBe("http://localhost:8080");
-      expect(r.port).toBe("8080");
-    });
+        const r = plan({ appDir });
 
-    /** @scenario "The manager follows the address pinned in the app's env file" */
-    it("names the file it read the address from", () => {
-      const appDir = appDirWith({
-        ".env": `OPENCODE_AGENT_URL="http://localhost:8080"\n${FULL_ENV}`,
+        expect(r.stdout).toMatch(/from \.env/);
       });
 
-      const r = plan({ appDir });
+      /** @scenario "A pinned address decides the port the lane sets" */
+      it("sets the manager's port to the pinned one", () => {
+        const appDir = appDirWith({
+          ".env": `OPENCODE_AGENT_URL="http://localhost:8080"\n${FULL_ENV}`,
+        });
 
-      expect(r.stdout).toMatch(/from \.env/);
-    });
+        const r = plan({ appDir, appPort: "5570" });
 
-    /** @scenario "A pinned address decides the port the lane sets" */
-    it("sets the manager's port to the pinned one", () => {
-      const appDir = appDirWith({
-        ".env": `OPENCODE_AGENT_URL="http://localhost:8080"\n${FULL_ENV}`,
+        expect(r.decision).toBe("start");
+        expect(r.command).toMatch(/PORT="8080"/);
       });
 
-      const r = plan({ appDir, appPort: "5570" });
+      /** @scenario "An agent address pinned in a file beats one exported for a single run" */
+      it("keeps the pinned address over one exported into the shell", () => {
+        const appDir = appDirWith({
+          ".env": `OPENCODE_AGENT_URL="http://localhost:8080"\n${FULL_ENV}`,
+        });
 
-      expect(r.decision).toBe("start");
-      expect(r.command).toMatch(/PORT="8080"/);
-    });
+        const r = plan({
+          appDir,
+          env: { OPENCODE_AGENT_URL: "http://localhost:9999" },
+        });
 
-    /** @scenario "An agent address pinned in a file beats one exported for a single run" */
-    it("keeps the pinned address over one exported into the shell", () => {
-      const appDir = appDirWith({
-        ".env": `OPENCODE_AGENT_URL="http://localhost:8080"\n${FULL_ENV}`,
+        expect(r.agentUrl).toBe("http://localhost:8080");
       });
 
-      const r = plan({
-        appDir,
-        env: { OPENCODE_AGENT_URL: "http://localhost:9999" },
+      /** @scenario "A commented-out pin is not an agent address" */
+      it("treats a commented-out pin as nothing pinned", () => {
+        const appDir = appDirWith({
+          ".env": `# OPENCODE_AGENT_URL="http://localhost:8080"\n${FULL_ENV}`,
+        });
+
+        const r = plan({ appDir, appPort: "5570" });
+
+        expect(r.port).toBe("5574");
       });
-
-      expect(r.agentUrl).toBe("http://localhost:8080");
-    });
-
-    /** @scenario "A commented-out pin is not an agent address" */
-    it("treats a commented-out pin as nothing pinned", () => {
-      const appDir = appDirWith({
-        ".env": `# OPENCODE_AGENT_URL="http://localhost:8080"\n${FULL_ENV}`,
-      });
-
-      const r = plan({ appDir, appPort: "5570" });
-
-      expect(r.port).toBe("5574");
     });
   });
 
   describe("given the haven overlay also pins one", () => {
-    /** @scenario "The haven overlay wins over the plain env file for the agent address" */
-    it("resolves the overlay's address, the one the app loads last", () => {
-      const appDir = appDirWith({
-        ".env": `OPENCODE_AGENT_URL="http://localhost:8080"\n${FULL_ENV}`,
-        ".env.portless": 'OPENCODE_AGENT_URL="http://127.0.0.1:41234"\n',
+    describe("when the lane is planned", () => {
+      /** @scenario "The haven overlay wins over the plain env file for the agent address" */
+      it("resolves the overlay's address, the one the app loads last", () => {
+        const appDir = appDirWith({
+          ".env": `OPENCODE_AGENT_URL="http://localhost:8080"\n${FULL_ENV}`,
+          ".env.portless": 'OPENCODE_AGENT_URL="http://127.0.0.1:41234"\n',
+        });
+
+        const r = plan({ appDir });
+
+        expect(r.agentUrl).toBe("http://127.0.0.1:41234");
+        expect(r.port).toBe("41234");
       });
 
-      const r = plan({ appDir });
+      /** @scenario "An overlay that clears the agent address is not read past" */
+      it("derives the port when the overlay clears the address", () => {
+        const appDir = appDirWith({
+          ".env": `OPENCODE_AGENT_URL="http://localhost:8080"\n${FULL_ENV}`,
+          ".env.portless": "OPENCODE_AGENT_URL=\n",
+        });
 
-      expect(r.agentUrl).toBe("http://127.0.0.1:41234");
-      expect(r.port).toBe("41234");
-    });
+        const r = plan({ appDir, appPort: "5570" });
 
-    /** @scenario "An overlay that clears the agent address is not read past" */
-    it("derives the port when the overlay clears the address", () => {
-      const appDir = appDirWith({
-        ".env": `OPENCODE_AGENT_URL="http://localhost:8080"\n${FULL_ENV}`,
-        ".env.portless": "OPENCODE_AGENT_URL=\n",
+        expect(r.port).toBe("5574");
+        expect(r.agentUrl).toBe("http://localhost:5574");
       });
 
-      const r = plan({ appDir, appPort: "5570" });
+      /** @scenario "An overlay that clears the agent address drops one exported for a single run" */
+      it("derives the port when the overlay clears an exported address", () => {
+        const appDir = appDirWith({
+          ".env": FULL_ENV,
+          ".env.portless": "OPENCODE_AGENT_URL=\n",
+        });
 
-      expect(r.port).toBe("5574");
-      expect(r.agentUrl).toBe("http://localhost:5574");
+        const r = plan({
+          appDir,
+          appPort: "5570",
+          env: { OPENCODE_AGENT_URL: "http://localhost:8080" },
+        });
+
+        expect(r.port).toBe("5574");
+        expect(r.agentUrl).toBe("http://localhost:5574");
+      });
     });
   });
 
   describe("given nothing pins an agent address", () => {
-    /** @scenario "Nothing pinned leaves the launcher to derive the manager port slot" */
-    it("derives the port from this worktree's slot", () => {
-      const appDir = appDirWith({ ".env": FULL_ENV });
+    describe("when the lane is planned", () => {
+      /** @scenario "Nothing pinned leaves the launcher to derive the manager port slot" */
+      it("derives the port from this worktree's slot", () => {
+        const appDir = appDirWith({ ".env": FULL_ENV });
 
-      const r = plan({ appDir, appPort: "5590" });
+        const r = plan({ appDir, appPort: "5590" });
 
-      expect(r.port).toBe("5594");
-      expect(r.agentUrl).toBe("http://localhost:5594");
-    });
+        expect(r.port).toBe("5594");
+        expect(r.agentUrl).toBe("http://localhost:5594");
+      });
 
-    /** @scenario "The lane sets the manager's port instead of inheriting the app's" */
-    it("never gives the manager the port the app is on", () => {
-      const appDir = appDirWith({ ".env": FULL_ENV });
+      /** @scenario "The lane sets the manager's port instead of inheriting the app's" */
+      it("never gives the manager the port the app is on", () => {
+        const appDir = appDirWith({ ".env": FULL_ENV });
 
-      const r = plan({ appDir, appPort: "5570", env: { PORT: "5570" } });
+        const r = plan({ appDir, appPort: "5570", env: { PORT: "5570" } });
 
-      expect(r.decision).toBe("start");
-      expect(r.port).not.toBe("5570");
-      expect(r.command).toMatch(/PORT="5574"/);
+        expect(r.decision).toBe("start");
+        expect(r.port).not.toBe("5570");
+        expect(r.command).toMatch(/PORT="5574"/);
+      });
     });
   });
 
   describe("given the setup cannot run the manager", () => {
-    /** @scenario "A missing Langy env block skips the lane and names the doctor" */
-    it("skips naming the missing secret and the doctor that fixes it", () => {
-      const appDir = appDirWith({
-        ".env": 'SESSIONS_ROOT="/tmp/s"\nLANGY_WORKSPACE_ROOT="/tmp/w"\n',
+    describe("when the lane is planned", () => {
+      /** @scenario "A missing Langy env block skips the lane and names the doctor" */
+      it("skips naming the missing secret and the doctor that fixes it", () => {
+        const appDir = appDirWith({
+          ".env": 'SESSIONS_ROOT="/tmp/s"\nLANGY_WORKSPACE_ROOT="/tmp/w"\n',
+        });
+
+        const r = plan({ appDir });
+
+        expect(r.decision).toBe("skip");
+        expect(r.reason).toMatch(/LANGY_INTERNAL_SECRET/);
+        expect(r.reason).toMatch(/langy-local\.sh/);
       });
 
-      const r = plan({ appDir });
+      /** @scenario "A missing workspace root skips the lane the same way" */
+      it("skips naming the missing workspace root", () => {
+        const appDir = appDirWith({
+          ".env": 'LANGY_INTERNAL_SECRET="s"\nSESSIONS_ROOT="/tmp/s"\n',
+        });
 
-      expect(r.decision).toBe("skip");
-      expect(r.reason).toMatch(/LANGY_INTERNAL_SECRET/);
-      expect(r.reason).toMatch(/langy-local\.sh/);
-    });
+        const r = plan({ appDir });
 
-    /** @scenario "A missing workspace root skips the lane the same way" */
-    it("skips naming the missing workspace root", () => {
-      const appDir = appDirWith({
-        ".env": 'LANGY_INTERNAL_SECRET="s"\nSESSIONS_ROOT="/tmp/s"\n',
+        expect(r.decision).toBe("skip");
+        expect(r.reason).toMatch(/LANGY_WORKSPACE_ROOT/);
       });
 
-      const r = plan({ appDir });
+      /** @scenario "A missing Langy env block skips the lane and names the doctor" */
+      it("counts a setting exported into the shell as present", () => {
+        const appDir = appDirWith({
+          ".env": 'SESSIONS_ROOT="/tmp/s"\nLANGY_WORKSPACE_ROOT="/tmp/w"\n',
+        });
 
-      expect(r.decision).toBe("skip");
-      expect(r.reason).toMatch(/LANGY_WORKSPACE_ROOT/);
-    });
+        const r = plan({
+          appDir,
+          env: { LANGY_INTERNAL_SECRET: "from-shell" },
+        });
 
-    /** @scenario "A missing Langy env block skips the lane and names the doctor" */
-    it("counts a setting exported into the shell as present", () => {
-      const appDir = appDirWith({
-        ".env": 'SESSIONS_ROOT="/tmp/s"\nLANGY_WORKSPACE_ROOT="/tmp/w"\n',
+        expect(r.decision).toBe("start");
       });
 
-      const r = plan({ appDir, env: { LANGY_INTERNAL_SECRET: "from-shell" } });
+      /** @scenario "A setting only the haven overlay carries does not count as present" */
+      it("does not count a secret that only the haven overlay carries", () => {
+        const appDir = appDirWith({
+          ".env": 'SESSIONS_ROOT="/tmp/s"\nLANGY_WORKSPACE_ROOT="/tmp/w"\n',
+          ".env.portless": 'LANGY_INTERNAL_SECRET="from-overlay"\n',
+        });
 
-      expect(r.decision).toBe("start");
-    });
+        const r = plan({ appDir });
 
-    /** @scenario "A setting only the haven overlay carries does not count as present" */
-    it("does not count a secret that only the haven overlay carries", () => {
-      const appDir = appDirWith({
-        ".env": 'SESSIONS_ROOT="/tmp/s"\nLANGY_WORKSPACE_ROOT="/tmp/w"\n',
-        ".env.portless": 'LANGY_INTERNAL_SECRET="from-overlay"\n',
+        expect(r.decision).toBe("skip");
+        expect(r.reason).toMatch(/LANGY_INTERNAL_SECRET/);
       });
 
-      const r = plan({ appDir });
+      /** @scenario "No Go toolchain skips the lane with the manual command" */
+      it("skips with the make command when Go is not on PATH", () => {
+        const appDir = appDirWith({ ".env": FULL_ENV });
 
-      expect(r.decision).toBe("skip");
-      expect(r.reason).toMatch(/LANGY_INTERNAL_SECRET/);
-    });
+        const r = plan({ appDir, hasGo: false });
 
-    /** @scenario "No Go toolchain skips the lane with the manual command" */
-    it("skips with the make command when Go is not on PATH", () => {
-      const appDir = appDirWith({ ".env": FULL_ENV });
-
-      const r = plan({ appDir, hasGo: false });
-
-      expect(r.decision).toBe("skip");
-      expect(r.reason).toMatch(/make service svc=langyagent/);
+        expect(r.decision).toBe("skip");
+        expect(r.reason).toMatch(/make service svc=langyagent/);
+      });
     });
   });
 
   describe("given a manager is already listening", () => {
-    /** @scenario "A manager already listening is reused" */
-    it("reuses it rather than starting a second one", () => {
-      const appDir = appDirWith({ ".env": FULL_ENV });
+    describe("when the lane is planned", () => {
+      /** @scenario "A manager already listening is reused" */
+      it("reuses it rather than starting a second one", () => {
+        const appDir = appDirWith({ ".env": FULL_ENV });
 
-      const r = plan({ appDir, appPort: "5570", listening: true });
+        const r = plan({ appDir, appPort: "5570", listening: true });
 
-      expect(r.decision).toBe("skip");
-      expect(r.reason).toMatch(/already running on :5574, reusing/);
-    });
+        expect(r.decision).toBe("skip");
+        expect(r.reason).toMatch(/already running on :5574, reusing/);
+      });
 
-    /** @scenario "A manager already listening is reused" */
-    it("reuses it even when this worktree's env block is incomplete", () => {
-      const appDir = appDirWith({ ".env": "" });
+      /** @scenario "A manager already listening is reused" */
+      it("reuses it even when this worktree's env block is incomplete", () => {
+        const appDir = appDirWith({ ".env": "" });
 
-      const r = plan({ appDir, listening: true });
+        const r = plan({ appDir, listening: true });
 
-      expect(r.decision).toBe("skip");
-      expect(r.reason).toMatch(/reusing/);
+        expect(r.decision).toBe("skip");
+        expect(r.reason).toMatch(/reusing/);
+      });
     });
   });
 
   describe("given the agent address is not on this machine", () => {
-    /** @scenario "An external agent URL leaves the manager alone" */
-    it("skips rather than starting a local manager nothing dials", () => {
-      const appDir = appDirWith({
-        ".env": `OPENCODE_AGENT_URL="https://langy.example.com"\n${FULL_ENV}`,
+    describe("when the lane is planned", () => {
+      /** @scenario "An external agent URL leaves the manager alone" */
+      it("skips rather than starting a local manager nothing dials", () => {
+        const appDir = appDirWith({
+          ".env": `OPENCODE_AGENT_URL="https://langy.example.com"\n${FULL_ENV}`,
+        });
+
+        const r = plan({ appDir });
+
+        expect(r.decision).toBe("skip");
+        expect(r.reason).toMatch(/external/);
       });
-
-      const r = plan({ appDir });
-
-      expect(r.decision).toBe("skip");
-      expect(r.reason).toMatch(/external/);
     });
   });
 
   describe("given the developer opted out", () => {
-    /** @scenario "The developer can opt out for one stack" */
-    it("skips and says the developer asked for it", () => {
-      const appDir = appDirWith({ ".env": FULL_ENV });
+    describe("when the lane is planned", () => {
+      /** @scenario "The developer can opt out for one stack" */
+      it("skips and says the developer asked for it", () => {
+        const appDir = appDirWith({ ".env": FULL_ENV });
 
-      const r = plan({ appDir, env: { LANGWATCH_SKIP_LANGY: "1" } });
+        const r = plan({ appDir, env: { LANGWATCH_SKIP_LANGY: "1" } });
 
-      expect(r.decision).toBe("skip");
-      expect(r.reason).toMatch(/LANGWATCH_SKIP_LANGY=1/);
+        expect(r.decision).toBe("skip");
+        expect(r.reason).toMatch(/LANGWATCH_SKIP_LANGY=1/);
+      });
     });
   });
 
   describe("given the worker binary the manager spawns", () => {
-    /** @scenario "The lane points the manager at the built worker in this checkout" */
-    it("tells the manager where the built worker is", () => {
-      const appDir = appDirWith({ ".env": FULL_ENV });
+    describe("when the lane is planned", () => {
+      /** @scenario "The lane points the manager at the built worker in this checkout" */
+      it("tells the manager where the built worker is", () => {
+        const appDir = appDirWith({ ".env": FULL_ENV });
 
-      const r = plan({ appDir });
+        const r = plan({ appDir });
 
-      expect(r.command).toMatch(
-        /LANGY_PI_WORKER_BINARY_PATH="\$\{LANGY_PI_WORKER_BINARY_PATH:-.*services\/langyworker\/out\/langy-worker\}"/,
-      );
-    });
-
-    /** @scenario "The lane points the manager at the built worker in this checkout" */
-    it("lets a path set in the environment win", () => {
-      const appDir = appDirWith({ ".env": FULL_ENV });
-
-      const r = plan({ appDir });
-      const expanded = expandLaneCommand({
-        command: r.command,
-        env: { LANGY_PI_WORKER_BINARY_PATH: "/opt/mine" },
+        expect(r.command).toMatch(
+          /LANGY_PI_WORKER_BINARY_PATH="\$\{LANGY_PI_WORKER_BINARY_PATH:-.*services\/langyworker\/out\/langy-worker\}"/,
+        );
       });
 
-      expect(expanded).toMatch(/LANGY_PI_WORKER_BINARY_PATH="\/opt\/mine"/);
-    });
+      /** @scenario "The lane points the manager at the built worker in this checkout" */
+      it("lets a path set in the environment win", () => {
+        const appDir = appDirWith({ ".env": FULL_ENV });
 
-    /** @scenario "A worker binary that was never built is called out at startup" */
-    it("still starts, and says which build a chat needs first", () => {
-      // The app dir is under a temp root, so the checkout's built worker is not
-      // on the path the planner derives from it, which is the un-built case.
-      const appDir = appDirWith({ ".env": FULL_ENV });
+        const r = plan({ appDir });
+        const expanded = expandLaneCommand({
+          command: r.command,
+          env: { LANGY_PI_WORKER_BINARY_PATH: "/opt/mine" },
+        });
 
-      const r = plan({ appDir });
+        expect(expanded).toMatch(/LANGY_PI_WORKER_BINARY_PATH="\/opt\/mine"/);
+      });
 
-      expect(r.decision).toBe("start");
-      expect(r.reason).toMatch(/build:binary/);
+      /** @scenario "A worker binary that was never built is called out at startup" */
+      it("still starts, and says which build a chat needs first", () => {
+        // The app dir is under a temp root, so the checkout's built worker is not
+        // on the path the planner derives from it, which is the un-built case.
+        const appDir = appDirWith({ ".env": FULL_ENV });
+
+        const r = plan({ appDir });
+
+        expect(r.decision).toBe("start");
+        expect(r.reason).toMatch(/build:binary/);
+      });
     });
   });
 
   describe("given the command names the worker's model reaches for", () => {
-    /** @scenario "A machine with only python3 gets a python that runs it" */
-    it("puts a python on the worker's PATH when the machine has only python3", () => {
-      const appDir = appDirWith({ ".env": FULL_ENV });
+    describe("when the lane is planned", () => {
+      /** @scenario "A machine with only python3 gets a python that runs it" */
+      it("puts a python on the worker's PATH when the machine has only python3", () => {
+        const appDir = appDirWith({ ".env": FULL_ENV });
 
-      const r = plan({ appDir, hasPython: false });
+        const r = plan({ appDir, hasPython: false });
 
-      expect(r.command).toMatch(/^PATH="[^"]*langy-shims\/bin:\$PATH" /);
-    });
-
-    /** @scenario "A machine with only python3 gets a python that runs it" */
-    it("points that python at the python3 already installed", () => {
-      const appDir = appDirWith({ ".env": FULL_ENV });
-
-      const r = plan({
-        appDir,
-        hasPython: false,
-        python3: "/opt/homebrew/bin/python3",
+        expect(r.command).toMatch(/^PATH="[^"]*langy-shims\/bin:\$PATH" /);
       });
-      const shimDir = r.command.match(/^PATH="([^:]*)/)?.[1] ?? "";
-      const target = execSync(`readlink ${shimDir}/python`, {
-        encoding: "utf8",
-        env: { PATH: process.env.PATH ?? "" },
-      }).trim();
 
-      expect(target).toBe("/opt/homebrew/bin/python3");
-    });
+      /** @scenario "A machine with only python3 gets a python that runs it" */
+      it("points that python at the python3 already installed", () => {
+        const appDir = appDirWith({ ".env": FULL_ENV });
 
-    /** @scenario "A machine that has its own python is left alone" */
-    it("adds nothing to the PATH when the machine already has a python", () => {
-      const appDir = appDirWith({ ".env": FULL_ENV });
+        const r = plan({
+          appDir,
+          hasPython: false,
+          python3: "/opt/homebrew/bin/python3",
+        });
+        const shimDir = r.command.match(/^PATH="([^:]*)/)?.[1] ?? "";
+        const target = execSync(`readlink ${shimDir}/python`, {
+          encoding: "utf8",
+          env: { PATH: process.env.PATH ?? "" },
+        }).trim();
 
-      const r = plan({ appDir, hasPython: true });
+        expect(target).toBe("/opt/homebrew/bin/python3");
+      });
 
-      expect(r.command).not.toMatch(/^PATH=/);
-      expect(r.command).toMatch(/^PORT=/);
+      /** @scenario "A machine that has its own python is left alone" */
+      it("adds nothing to the PATH when the machine already has a python", () => {
+        const appDir = appDirWith({ ".env": FULL_ENV });
+
+        const r = plan({ appDir, hasPython: true });
+
+        expect(r.command).not.toMatch(/^PATH=/);
+        expect(r.command).toMatch(/^PORT=/);
+      });
     });
   });
 

--- a/platform/app/scripts/__tests__/plan-langy-lane.unit.test.ts
+++ b/platform/app/scripts/__tests__/plan-langy-lane.unit.test.ts
@@ -1,0 +1,396 @@
+/**
+ * @vitest-environment node
+ *
+ * Tests for dev/scripts/lib/plan-langy-lane.sh, sourced the way
+ * platform/app/scripts/start.sh sources it: before the launcher decides whether
+ * to start the Langy agent manager and on which port.
+ *
+ * See specs/setup/dev-langy-agent-lane.feature.
+ *
+ * The planner is bash; we drive it by sourcing it from `bash -s` and reading
+ * the decision it exports, the same technique as resolve-nlp-service.unit.test.ts.
+ * The two facts the planner cannot cheaply determine, a Go toolchain and a live
+ * listener, are overridable functions, so a test states them instead of
+ * depending on the machine it runs on.
+ */
+
+import { execSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+const REPO_ROOT = path.resolve(__dirname, "../../../..");
+const PLANNER = path.join(REPO_ROOT, "dev/scripts/lib/plan-langy-lane.sh");
+
+const FULL_ENV = [
+  'LANGY_INTERNAL_SECRET="secret"',
+  'SESSIONS_ROOT="/tmp/langy/sessions"',
+  'LANGY_WORKSPACE_ROOT="/tmp/langy/workspace"',
+  "",
+].join("\n");
+
+const appDirs: string[] = [];
+
+function appDirWith(files: Record<string, string>): string {
+  const dir = mkdtempSync(path.join(tmpdir(), "plan-langy-lane-"));
+  appDirs.push(dir);
+  for (const [name, contents] of Object.entries(files)) {
+    writeFileSync(path.join(dir, name), contents);
+  }
+  return dir;
+}
+
+afterEach(() => {
+  while (appDirs.length) {
+    rmSync(appDirs.pop()!, { recursive: true, force: true });
+  }
+});
+
+function plan({
+  appDir,
+  appPort = "5560",
+  env = {},
+  hasGo = true,
+  listening = false,
+}: {
+  appDir: string;
+  appPort?: string;
+  env?: Record<string, string | undefined>;
+  hasGo?: boolean;
+  listening?: boolean;
+}): {
+  stdout: string;
+  decision: string;
+  reason: string;
+  port: string;
+  agentUrl: string;
+  command: string;
+  exitCode: number;
+} {
+  const exports = Object.entries(env)
+    .map(([k, v]) =>
+      v === undefined
+        ? `unset ${k}`
+        : `export ${k}='${v.replace(/'/g, "'\\''")}'`,
+    )
+    .join("\n");
+  const script = `
+set -e
+${exports}
+. "${PLANNER}"
+_langy_have_go() { return ${hasGo ? 0 : 1}; }
+_langy_port_listening() { return ${listening ? 0 : 1}; }
+plan_langy_lane "${appDir}" "${appPort}"
+echo "__DECISION=\${LANGY_LANE_DECISION:-}"
+echo "__REASON=\${LANGY_LANE_REASON:-}"
+echo "__PORT=\${LANGY_LANE_PORT:-}"
+echo "__AGENT_URL=\${OPENCODE_AGENT_URL:-}"
+echo "__COMMAND=$(echo '')\$(langy_lane_command '../..' "\${LANGY_LANE_PORT:-0}")"
+`;
+  let stdout = "";
+  let exitCode = 0;
+  try {
+    stdout = execSync("bash -s", {
+      encoding: "utf8",
+      input: script,
+      stdio: ["pipe", "pipe", "pipe"],
+      // Isolate the subprocess env: a developer's own shell often carries
+      // OPENCODE_AGENT_URL and the Langy block, and inheriting them would make
+      // these assertions depend on the machine.
+      env: { PATH: process.env.PATH ?? "" },
+    });
+  } catch (e) {
+    const err = e as { status?: number; stdout?: string; stderr?: string };
+    exitCode = err.status ?? 1;
+    stdout = (err.stdout ?? "") + (err.stderr ?? "");
+  }
+  const read = (key: string) =>
+    stdout.match(new RegExp(`__${key}=(.*)`))?.[1] ?? "";
+  return {
+    stdout,
+    decision: read("DECISION"),
+    reason: read("REASON"),
+    port: read("PORT"),
+    agentUrl: read("AGENT_URL"),
+    command: read("COMMAND"),
+    exitCode,
+  };
+}
+
+describe("plan-langy-lane.sh", () => {
+  describe("given the app's env file pins an agent address", () => {
+    /** @scenario "The manager follows the address pinned in the app's env file" */
+    it("resolves the pinned address rather than this worktree's port slot", () => {
+      const appDir = appDirWith({
+        ".env": `OPENCODE_AGENT_URL="http://localhost:8080"\n${FULL_ENV}`,
+      });
+
+      const r = plan({ appDir, appPort: "5590" });
+
+      expect(r.exitCode).toBe(0);
+      expect(r.agentUrl).toBe("http://localhost:8080");
+      expect(r.port).toBe("8080");
+    });
+
+    /** @scenario "The manager follows the address pinned in the app's env file" */
+    it("names the file it read the address from", () => {
+      const appDir = appDirWith({
+        ".env": `OPENCODE_AGENT_URL="http://localhost:8080"\n${FULL_ENV}`,
+      });
+
+      const r = plan({ appDir });
+
+      expect(r.stdout).toMatch(/from \.env/);
+    });
+
+    /** @scenario "A pinned address decides the port the lane sets" */
+    it("sets the manager's port to the pinned one", () => {
+      const appDir = appDirWith({
+        ".env": `OPENCODE_AGENT_URL="http://localhost:8080"\n${FULL_ENV}`,
+      });
+
+      const r = plan({ appDir, appPort: "5570" });
+
+      expect(r.decision).toBe("start");
+      expect(r.command).toMatch(/PORT="8080"/);
+    });
+
+    /** @scenario "An agent address pinned in a file beats one exported for a single run" */
+    it("keeps the pinned address over one exported into the shell", () => {
+      const appDir = appDirWith({
+        ".env": `OPENCODE_AGENT_URL="http://localhost:8080"\n${FULL_ENV}`,
+      });
+
+      const r = plan({
+        appDir,
+        env: { OPENCODE_AGENT_URL: "http://localhost:9999" },
+      });
+
+      expect(r.agentUrl).toBe("http://localhost:8080");
+    });
+
+    /** @scenario "A commented-out pin is not an agent address" */
+    it("treats a commented-out pin as nothing pinned", () => {
+      const appDir = appDirWith({
+        ".env": `# OPENCODE_AGENT_URL="http://localhost:8080"\n${FULL_ENV}`,
+      });
+
+      const r = plan({ appDir, appPort: "5570" });
+
+      expect(r.port).toBe("5574");
+    });
+  });
+
+  describe("given the haven overlay also pins one", () => {
+    /** @scenario "The haven overlay wins over the plain env file for the agent address" */
+    it("resolves the overlay's address, the one the app loads last", () => {
+      const appDir = appDirWith({
+        ".env": `OPENCODE_AGENT_URL="http://localhost:8080"\n${FULL_ENV}`,
+        ".env.portless": 'OPENCODE_AGENT_URL="http://127.0.0.1:41234"\n',
+      });
+
+      const r = plan({ appDir });
+
+      expect(r.agentUrl).toBe("http://127.0.0.1:41234");
+      expect(r.port).toBe("41234");
+    });
+  });
+
+  describe("given nothing pins an agent address", () => {
+    /** @scenario "Nothing pinned leaves the launcher to derive the manager port slot" */
+    it("derives the port from this worktree's slot", () => {
+      const appDir = appDirWith({ ".env": FULL_ENV });
+
+      const r = plan({ appDir, appPort: "5590" });
+
+      expect(r.port).toBe("5594");
+      expect(r.agentUrl).toBe("http://localhost:5594");
+    });
+
+    /** @scenario "The lane sets the manager's port instead of inheriting the app's" */
+    it("never gives the manager the port the app is on", () => {
+      const appDir = appDirWith({ ".env": FULL_ENV });
+
+      const r = plan({ appDir, appPort: "5570", env: { PORT: "5570" } });
+
+      expect(r.decision).toBe("start");
+      expect(r.port).not.toBe("5570");
+      expect(r.command).toMatch(/PORT="5574"/);
+    });
+  });
+
+  describe("given the setup cannot run the manager", () => {
+    /** @scenario "A missing Langy env block skips the lane and names the doctor" */
+    it("skips naming the missing secret and the doctor that fixes it", () => {
+      const appDir = appDirWith({
+        ".env": 'SESSIONS_ROOT="/tmp/s"\nLANGY_WORKSPACE_ROOT="/tmp/w"\n',
+      });
+
+      const r = plan({ appDir });
+
+      expect(r.decision).toBe("skip");
+      expect(r.reason).toMatch(/LANGY_INTERNAL_SECRET/);
+      expect(r.reason).toMatch(/langy-local\.sh/);
+    });
+
+    /** @scenario "A missing workspace root skips the lane the same way" */
+    it("skips naming the missing workspace root", () => {
+      const appDir = appDirWith({
+        ".env": 'LANGY_INTERNAL_SECRET="s"\nSESSIONS_ROOT="/tmp/s"\n',
+      });
+
+      const r = plan({ appDir });
+
+      expect(r.decision).toBe("skip");
+      expect(r.reason).toMatch(/LANGY_WORKSPACE_ROOT/);
+    });
+
+    /** @scenario "A missing Langy env block skips the lane and names the doctor" */
+    it("counts a setting exported into the shell as present", () => {
+      const appDir = appDirWith({
+        ".env": 'SESSIONS_ROOT="/tmp/s"\nLANGY_WORKSPACE_ROOT="/tmp/w"\n',
+      });
+
+      const r = plan({ appDir, env: { LANGY_INTERNAL_SECRET: "from-shell" } });
+
+      expect(r.decision).toBe("start");
+    });
+
+    /** @scenario "No Go toolchain skips the lane with the manual command" */
+    it("skips with the make command when Go is not on PATH", () => {
+      const appDir = appDirWith({ ".env": FULL_ENV });
+
+      const r = plan({ appDir, hasGo: false });
+
+      expect(r.decision).toBe("skip");
+      expect(r.reason).toMatch(/make service svc=langyagent/);
+    });
+  });
+
+  describe("given a manager is already listening", () => {
+    /** @scenario "A manager already listening is reused" */
+    it("reuses it rather than starting a second one", () => {
+      const appDir = appDirWith({ ".env": FULL_ENV });
+
+      const r = plan({ appDir, appPort: "5570", listening: true });
+
+      expect(r.decision).toBe("skip");
+      expect(r.reason).toMatch(/already running on :5574, reusing/);
+    });
+
+    /** @scenario "A manager already listening is reused" */
+    it("reuses it even when this worktree's env block is incomplete", () => {
+      const appDir = appDirWith({ ".env": "" });
+
+      const r = plan({ appDir, listening: true });
+
+      expect(r.decision).toBe("skip");
+      expect(r.reason).toMatch(/reusing/);
+    });
+  });
+
+  describe("given the agent address is not on this machine", () => {
+    /** @scenario "An external agent URL leaves the manager alone" */
+    it("skips rather than starting a local manager nothing dials", () => {
+      const appDir = appDirWith({
+        ".env": `OPENCODE_AGENT_URL="https://langy.example.com"\n${FULL_ENV}`,
+      });
+
+      const r = plan({ appDir });
+
+      expect(r.decision).toBe("skip");
+      expect(r.reason).toMatch(/external/);
+    });
+  });
+
+  describe("given the developer opted out", () => {
+    /** @scenario "The developer can opt out for one stack" */
+    it("skips and says the developer asked for it", () => {
+      const appDir = appDirWith({ ".env": FULL_ENV });
+
+      const r = plan({ appDir, env: { LANGWATCH_SKIP_LANGY: "1" } });
+
+      expect(r.decision).toBe("skip");
+      expect(r.reason).toMatch(/LANGWATCH_SKIP_LANGY=1/);
+    });
+  });
+
+  describe("given the worker binary the manager spawns", () => {
+    /** @scenario "The lane points the manager at the built worker in this checkout" */
+    it("tells the manager where the built worker is", () => {
+      const appDir = appDirWith({ ".env": FULL_ENV });
+
+      const r = plan({ appDir });
+
+      expect(r.command).toMatch(
+        /LANGY_PI_WORKER_BINARY_PATH="\$\{LANGY_PI_WORKER_BINARY_PATH:-.*services\/langyworker\/out\/langy-worker\}"/,
+      );
+    });
+
+    /** @scenario "The lane points the manager at the built worker in this checkout" */
+    it("lets a path set in the environment win", () => {
+      const appDir = appDirWith({ ".env": FULL_ENV });
+
+      const r = plan({ appDir });
+      const expanded = execSync(
+        `bash -c 'export LANGY_PI_WORKER_BINARY_PATH=/opt/mine; echo "${r.command.replace(/"/g, '\\"')}"'`,
+        { encoding: "utf8", env: { PATH: process.env.PATH ?? "" } },
+      );
+
+      expect(expanded).toMatch(/LANGY_PI_WORKER_BINARY_PATH="\/opt\/mine"/);
+    });
+
+    /** @scenario "A worker binary that was never built is called out at startup" */
+    it("still starts, and says which build a chat needs first", () => {
+      // The app dir is a temp dir, so the checkout's built worker is not on the
+      // path the planner derives from it, which is the un-built case.
+      const appDir = appDirWith({ ".env": FULL_ENV });
+
+      const r = plan({ appDir });
+
+      expect(r.decision).toBe("start");
+      expect(r.reason).toMatch(/build:binary/);
+    });
+  });
+
+  describe("when the lane is started", () => {
+    /** @scenario "The lane caps the pool and reaps idle workers quickly" */
+    it("caps the worker pool to the local size", () => {
+      const appDir = appDirWith({ ".env": FULL_ENV });
+
+      const r = plan({ appDir });
+
+      expect(r.command).toMatch(
+        /LANGY_MAX_WORKERS="\$\{LANGY_MAX_WORKERS:-2\}"/,
+      );
+    });
+
+    /** @scenario "The lane caps the pool and reaps idle workers quickly" */
+    it("reaps an idle worker in minutes rather than the production wait", () => {
+      const appDir = appDirWith({ ".env": FULL_ENV });
+
+      const r = plan({ appDir });
+
+      expect(r.command).toMatch(
+        /LANGY_WORKER_IDLE_MS="\$\{LANGY_WORKER_IDLE_MS:-120000\}"/,
+      );
+      expect(r.command).toMatch(/svc=langyagent/);
+    });
+
+    /** @scenario "The lane caps the pool and reaps idle workers quickly" */
+    it("lets a cap set in the environment win over the local default", () => {
+      const appDir = appDirWith({ ".env": FULL_ENV });
+
+      const r = plan({ appDir, env: { LANGY_MAX_WORKERS: "8" } });
+
+      // The lane expands the override where it runs, so the local number is
+      // only a fallback and the developer's value survives.
+      const expanded = execSync(
+        `bash -c 'export LANGY_MAX_WORKERS=8; echo "${r.command.replace(/"/g, '\\"')}"'`,
+        { encoding: "utf8", env: { PATH: process.env.PATH ?? "" } },
+      );
+      expect(expanded).toMatch(/LANGY_MAX_WORKERS="8"/);
+    });
+  });
+});

--- a/platform/app/scripts/__tests__/plan-langy-lane.unit.test.ts
+++ b/platform/app/scripts/__tests__/plan-langy-lane.unit.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { execSync } from "node:child_process";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -32,9 +32,17 @@ const FULL_ENV = [
 
 const appDirs: string[] = [];
 
+/**
+ * The app directory sits under a `platform/app` of its own, because the planner
+ * derives the repo root from it and writes the python shim there. A flat temp
+ * directory makes the root the parent of the temp directory, which is `/` on a
+ * Linux runner and not writable.
+ */
 function appDirWith(files: Record<string, string>): string {
-  const dir = mkdtempSync(path.join(tmpdir(), "plan-langy-lane-"));
-  appDirs.push(dir);
+  const root = mkdtempSync(path.join(tmpdir(), "plan-langy-lane-"));
+  appDirs.push(root);
+  const dir = path.join(root, "platform/app");
+  mkdirSync(dir, { recursive: true });
   for (const [name, contents] of Object.entries(files)) {
     writeFileSync(path.join(dir, name), contents);
   }
@@ -400,8 +408,8 @@ describe("plan-langy-lane.sh", () => {
 
     /** @scenario "A worker binary that was never built is called out at startup" */
     it("still starts, and says which build a chat needs first", () => {
-      // The app dir is a temp dir, so the checkout's built worker is not on the
-      // path the planner derives from it, which is the un-built case.
+      // The app dir is under a temp root, so the checkout's built worker is not
+      // on the path the planner derives from it, which is the un-built case.
       const appDir = appDirWith({ ".env": FULL_ENV });
 
       const r = plan({ appDir });

--- a/platform/app/scripts/__tests__/resolve-nlp-service.unit.test.ts
+++ b/platform/app/scripts/__tests__/resolve-nlp-service.unit.test.ts
@@ -159,6 +159,18 @@ describe("resolve-nlp-service.sh", () => {
 
       expect(r.nlpService).toBe("http://nlp.plum.langwatch.localhost");
     });
+
+    /** @scenario "An overlay that clears the address is not read past" */
+    it("treats an empty overlay assignment as the answer, not as a gap", () => {
+      const appDir = appDirWith({
+        ".env": 'LANGWATCH_NLP_SERVICE="http://localhost:5571"\n',
+        ".env.portless": "LANGWATCH_NLP_SERVICE=\n",
+      });
+
+      const r = runHelper({ appDir });
+
+      expect(r.nlpService).toBe("");
+    });
   });
 
   describe("given nothing pins an address", () => {

--- a/platform/app/scripts/__tests__/resolve-nlp-service.unit.test.ts
+++ b/platform/app/scripts/__tests__/resolve-nlp-service.unit.test.ts
@@ -84,133 +84,155 @@ echo "__LANGWATCH_NLP_SERVICE=\${LANGWATCH_NLP_SERVICE:-}"
 
 describe("resolve-nlp-service.sh", () => {
   describe("given the app's env file pins an address", () => {
-    /** @scenario "The engine follows the address pinned in the app's env file" */
-    it("resolves the pinned address rather than this worktree's port slot", () => {
-      const appDir = appDirWith({
-        ".env": 'PORT=5560\nLANGWATCH_NLP_SERVICE="http://localhost:5571"\n',
+    describe("when the launcher resolves the address", () => {
+      /** @scenario "The engine follows the address pinned in the app's env file" */
+      it("resolves the pinned address rather than this worktree's port slot", () => {
+        const appDir = appDirWith({
+          ".env": 'PORT=5560\nLANGWATCH_NLP_SERVICE="http://localhost:5571"\n',
+        });
+
+        const r = runHelper({
+          appDir,
+          env: { PORT: "5590", LANGWATCH_NLP_SERVICE: undefined },
+        });
+
+        expect(r.exitCode).toBe(0);
+        expect(r.nlpService).toBe("http://localhost:5571");
       });
 
-      const r = runHelper({
-        appDir,
-        env: { PORT: "5590", LANGWATCH_NLP_SERVICE: undefined },
+      /** @scenario "The engine follows the address pinned in the app's env file" */
+      it("names the file it read the address from", () => {
+        const appDir = appDirWith({
+          ".env": 'LANGWATCH_NLP_SERVICE="http://localhost:5571"\n',
+        });
+
+        const r = runHelper({ appDir });
+
+        expect(r.stdout).toMatch(
+          /LANGWATCH_NLP_SERVICE=http:\/\/localhost:5571/,
+        );
+        expect(r.stdout).toMatch(/from \.env/);
       });
 
-      expect(r.exitCode).toBe(0);
-      expect(r.nlpService).toBe("http://localhost:5571");
-    });
+      /** @scenario "An address pinned in a file beats one exported for a single run" */
+      it("keeps the pinned address over one exported into the shell", () => {
+        const appDir = appDirWith({
+          ".env": 'LANGWATCH_NLP_SERVICE="http://localhost:5571"\n',
+        });
 
-    /** @scenario "The engine follows the address pinned in the app's env file" */
-    it("names the file it read the address from", () => {
-      const appDir = appDirWith({
-        ".env": 'LANGWATCH_NLP_SERVICE="http://localhost:5571"\n',
+        const r = runHelper({
+          appDir,
+          env: { LANGWATCH_NLP_SERVICE: "http://localhost:5591" },
+        });
+
+        expect(r.nlpService).toBe("http://localhost:5571");
       });
 
-      const r = runHelper({ appDir });
+      it("reads an unquoted value with an inline comment", () => {
+        const appDir = appDirWith({
+          ".env": "LANGWATCH_NLP_SERVICE=http://localhost:5571 # the engine\n",
+        });
 
-      expect(r.stdout).toMatch(/LANGWATCH_NLP_SERVICE=http:\/\/localhost:5571/);
-      expect(r.stdout).toMatch(/from \.env/);
-    });
+        const r = runHelper({ appDir });
 
-    /** @scenario "An address pinned in a file beats one exported for a single run" */
-    it("keeps the pinned address over one exported into the shell", () => {
-      const appDir = appDirWith({
-        ".env": 'LANGWATCH_NLP_SERVICE="http://localhost:5571"\n',
+        expect(r.nlpService).toBe("http://localhost:5571");
       });
 
-      const r = runHelper({
-        appDir,
-        env: { LANGWATCH_NLP_SERVICE: "http://localhost:5591" },
+      it("reads an external host the same way, so no local engine is started", () => {
+        const appDir = appDirWith({
+          ".env": "LANGWATCH_NLP_SERVICE='https://nlp.example.internal'\n",
+        });
+
+        const r = runHelper({ appDir });
+
+        expect(r.nlpService).toBe("https://nlp.example.internal");
       });
-
-      expect(r.nlpService).toBe("http://localhost:5571");
-    });
-
-    it("reads an unquoted value with an inline comment", () => {
-      const appDir = appDirWith({
-        ".env": "LANGWATCH_NLP_SERVICE=http://localhost:5571 # the engine\n",
-      });
-
-      const r = runHelper({ appDir });
-
-      expect(r.nlpService).toBe("http://localhost:5571");
-    });
-
-    it("reads an external host the same way, so no local engine is started", () => {
-      const appDir = appDirWith({
-        ".env": "LANGWATCH_NLP_SERVICE='https://nlp.example.internal'\n",
-      });
-
-      const r = runHelper({ appDir });
-
-      expect(r.nlpService).toBe("https://nlp.example.internal");
     });
   });
 
   describe("given a haven overlay alongside the env file", () => {
-    /** @scenario "The haven overlay wins over the plain env file" */
-    it("resolves the overlay's address, the one the app loads last", () => {
-      const appDir = appDirWith({
-        ".env": 'LANGWATCH_NLP_SERVICE="http://localhost:5571"\n',
-        ".env.portless":
-          'LANGWATCH_NLP_SERVICE="http://nlp.plum.langwatch.localhost"\n',
+    describe("when the launcher resolves the address", () => {
+      /** @scenario "The haven overlay wins over the plain env file" */
+      it("resolves the overlay's address, the one the app loads last", () => {
+        const appDir = appDirWith({
+          ".env": 'LANGWATCH_NLP_SERVICE="http://localhost:5571"\n',
+          ".env.portless":
+            'LANGWATCH_NLP_SERVICE="http://nlp.plum.langwatch.localhost"\n',
+        });
+
+        const r = runHelper({ appDir });
+
+        expect(r.nlpService).toBe("http://nlp.plum.langwatch.localhost");
       });
 
-      const r = runHelper({ appDir });
+      /** @scenario "An overlay that clears the address is not read past" */
+      it("treats an empty overlay assignment as the answer, not as a gap", () => {
+        const appDir = appDirWith({
+          ".env": 'LANGWATCH_NLP_SERVICE="http://localhost:5571"\n',
+          ".env.portless": "LANGWATCH_NLP_SERVICE=\n",
+        });
 
-      expect(r.nlpService).toBe("http://nlp.plum.langwatch.localhost");
-    });
+        const r = runHelper({ appDir });
 
-    /** @scenario "An overlay that clears the address is not read past" */
-    it("treats an empty overlay assignment as the answer, not as a gap", () => {
-      const appDir = appDirWith({
-        ".env": 'LANGWATCH_NLP_SERVICE="http://localhost:5571"\n',
-        ".env.portless": "LANGWATCH_NLP_SERVICE=\n",
+        expect(r.nlpService).toBe("");
       });
 
-      const r = runHelper({ appDir });
+      /** @scenario "An overlay that clears the address drops one exported for a single run" */
+      it("clears an address the shell exported", () => {
+        const appDir = appDirWith({
+          ".env.portless": "LANGWATCH_NLP_SERVICE=\n",
+        });
 
-      expect(r.nlpService).toBe("");
+        const r = runHelper({
+          appDir,
+          env: { LANGWATCH_NLP_SERVICE: "http://localhost:5591" },
+        });
+
+        expect(r.nlpService).toBe("");
+      });
     });
   });
 
   describe("given nothing pins an address", () => {
-    /** @scenario "Nothing pinned leaves the launcher to derive the port slot" */
-    it("leaves the address unset for the launcher to derive", () => {
-      const appDir = appDirWith({ ".env": "PORT=5560\n" });
+    describe("when the launcher resolves the address", () => {
+      /** @scenario "Nothing pinned leaves the launcher to derive the port slot" */
+      it("leaves the address unset for the launcher to derive", () => {
+        const appDir = appDirWith({ ".env": "PORT=5560\n" });
 
-      const r = runHelper({ appDir });
+        const r = runHelper({ appDir });
 
-      expect(r.exitCode).toBe(0);
-      expect(r.nlpService).toBe("");
-    });
-
-    /** @scenario "Nothing pinned leaves the launcher to derive the port slot" */
-    it("says nothing", () => {
-      const appDir = appDirWith({ ".env": "PORT=5560\n" });
-
-      const r = runHelper({ appDir });
-
-      expect(r.stdout).not.toMatch(/nlpgo:/);
-    });
-
-    /** @scenario "A commented-out pin is not an address" */
-    it("ignores a commented-out pin", () => {
-      const appDir = appDirWith({
-        ".env": '# LANGWATCH_NLP_SERVICE="http://localhost:5571"\n',
+        expect(r.exitCode).toBe(0);
+        expect(r.nlpService).toBe("");
       });
 
-      const r = runHelper({ appDir });
+      /** @scenario "Nothing pinned leaves the launcher to derive the port slot" */
+      it("says nothing", () => {
+        const appDir = appDirWith({ ".env": "PORT=5560\n" });
 
-      expect(r.nlpService).toBe("");
-    });
+        const r = runHelper({ appDir });
 
-    it("survives an app directory with no env file at all", () => {
-      const appDir = appDirWith({});
+        expect(r.stdout).not.toMatch(/nlpgo:/);
+      });
 
-      const r = runHelper({ appDir });
+      /** @scenario "A commented-out pin is not an address" */
+      it("ignores a commented-out pin", () => {
+        const appDir = appDirWith({
+          ".env": '# LANGWATCH_NLP_SERVICE="http://localhost:5571"\n',
+        });
 
-      expect(r.exitCode).toBe(0);
-      expect(r.nlpService).toBe("");
+        const r = runHelper({ appDir });
+
+        expect(r.nlpService).toBe("");
+      });
+
+      it("survives an app directory with no env file at all", () => {
+        const appDir = appDirWith({});
+
+        const r = runHelper({ appDir });
+
+        expect(r.exitCode).toBe(0);
+        expect(r.nlpService).toBe("");
+      });
     });
   });
 });

--- a/platform/app/scripts/start.sh
+++ b/platform/app/scripts/start.sh
@@ -201,6 +201,29 @@ if [[ "$NODE_ENV" = "development" && "$LANGWATCH_SKIP_NLP" != "1" ]]; then
   fi
 fi
 
+# langyagent (Go agent manager). Bundled into pnpm dev so a chat with Langy in
+# a local app reaches a live manager instead of a dead port. The manager itself
+# is cheap: no database client, about 30 MB idle, and it spawns a worker only
+# when a person chats. The lane caps that pool to the local size.
+#
+# The decision has more branches than the lanes above, so it lives in
+# dev/scripts/lib/plan-langy-lane.sh: langyagent takes its listen port from
+# PORT, which is the app's here, and fails fast without its secret and roots.
+# Opt-out: LANGWATCH_SKIP_LANGY=1.
+START_LANGY_COMMAND=""
+if [[ "$NODE_ENV" = "development" ]]; then
+  . "$(dirname "$0")/../../../dev/scripts/lib/plan-langy-lane.sh"
+  plan_langy_lane "$(dirname "$0")/.." "$_APP_PORT"
+  if [ "$LANGY_LANE_DECISION" = "start" ]; then
+    START_LANGY_COMMAND=$(langy_lane_command "../.." "$LANGY_LANE_PORT")
+    echo "  ✓ langyagent: $LANGY_LANE_REASON"
+  elif [[ "$LANGY_LANE_REASON" == skipped* ]]; then
+    echo "  ! langyagent: $LANGY_LANE_REASON"
+  else
+    echo "  ✓ langyagent: $LANGY_LANE_REASON"
+  fi
+fi
+
 pnpm run start:prepare:db
 
 COMMANDS=()
@@ -221,6 +244,10 @@ if [ -n "$START_NLP_COMMAND" ]; then
   COMMANDS+=("$START_NLP_COMMAND")
   NAMES+=("nlpgo")
 fi
+if [ -n "$START_LANGY_COMMAND" ]; then
+  COMMANDS+=("$START_LANGY_COMMAND")
+  NAMES+=("langy")
+fi
 if [ -n "$START_APP_COMMAND" ]; then
   COMMANDS+=("$RUNTIME_ENV $START_APP_COMMAND")
   NAMES+=("api")
@@ -231,5 +258,5 @@ if [ ${#COMMANDS[@]} -eq 1 ]; then
   eval "$RUNTIME_ENV exec $START_APP_COMMAND"
 else
   NAMES_STR=$(IFS=,; echo "${NAMES[*]}")
-  concurrently --restart-tries -1 --names "$NAMES_STR" --prefix-colors "green,blue,yellow,magenta,cyan" "${COMMANDS[@]}"
+  concurrently --restart-tries -1 --names "$NAMES_STR" --prefix-colors "green,blue,yellow,magenta,red,cyan" "${COMMANDS[@]}"
 fi

--- a/platform/app/src/server/experiments-v3/execution/__tests__/runResultsWriter.unit.test.ts
+++ b/platform/app/src/server/experiments-v3/execution/__tests__/runResultsWriter.unit.test.ts
@@ -1,0 +1,99 @@
+/**
+ * @see specs/experiments-v3/workbench-versioning.feature
+ *
+ * The writer a streaming run feeds its frames into. The route decides whether
+ * a run writes its cells at all; this decides what one frame stream turns into.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ExperimentService } from "~/server/experiments/experiment.service";
+import { createRunResultsWriter } from "../runResultsWriter";
+import type { EvaluationV3Event } from "../types";
+
+const applyWorkbenchTransform = vi.fn();
+
+const writerFor = () =>
+  createRunResultsWriter({
+    persistence: {
+      experiments: { applyWorkbenchTransform } as unknown as ExperimentService,
+      actor: { userId: "user_1", label: "user" },
+    },
+    projectId: "project_1",
+    experimentId: "experiment_1",
+    scope: { type: "full" },
+  });
+
+const feed = async (events: EvaluationV3Event[]) => {
+  const writer = writerFor();
+  for (const event of events) await writer.record(event);
+  return writer;
+};
+
+const started = {
+  type: "execution_started",
+  runId: "swift-bold-fox",
+  total: 1,
+} as unknown as EvaluationV3Event;
+
+const anOutput = {
+  type: "target_result",
+  rowIndex: 0,
+  targetId: "target-1",
+  output: "an answer",
+} as unknown as EvaluationV3Event;
+
+const done = {
+  type: "done",
+  summary: { total: 1, completed: 1 },
+} as unknown as EvaluationV3Event;
+
+beforeEach(() => {
+  applyWorkbenchTransform.mockReset();
+  applyWorkbenchTransform.mockResolvedValue({ version: 4 });
+});
+
+describe("createRunResultsWriter", () => {
+  describe("when the run ends before it names itself", () => {
+    /** @scenario "A run that ends before it names itself writes nothing" */
+    it("writes nothing into the saved state", async () => {
+      await feed([anOutput, done]);
+
+      expect(applyWorkbenchTransform).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when the run has not ended yet", () => {
+    /** @scenario "A run started from the open page writes its cells too" */
+    it("holds the cells rather than writing each frame", async () => {
+      await feed([started, anOutput]);
+
+      expect(applyWorkbenchTransform).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when the run produced no cells", () => {
+    /** @scenario "A run started from the open page writes its cells too" */
+    it("writes nothing into the saved state", async () => {
+      await feed([started, done]);
+
+      expect(applyWorkbenchTransform).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when the run reports it ended twice", () => {
+    /** @scenario "A run started from the open page writes its cells too" */
+    it("writes once, so the cells take one version and not two", async () => {
+      await feed([started, anOutput, done, done]);
+
+      expect(applyWorkbenchTransform).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("when the write fails", () => {
+    /** @scenario "A failure to write the cells back does not fail the run" */
+    it("swallows the failure, because the stream must reach the page", async () => {
+      applyWorkbenchTransform.mockRejectedValue(new Error("postgres is down"));
+
+      await expect(feed([started, anOutput, done])).resolves.toBeDefined();
+    });
+  });
+});

--- a/platform/app/src/server/experiments-v3/execution/experimentRunner.ts
+++ b/platform/app/src/server/experiments-v3/execution/experimentRunner.ts
@@ -9,11 +9,6 @@
  */
 
 import { createLogger } from "@langwatch/observability";
-import { StaleWorkbenchStateError } from "~/server/experiments/errors";
-import type {
-  ExperimentService,
-  WorkbenchActor,
-} from "~/server/experiments/experiment.service";
 import { generateHumanReadableId } from "~/utils/humanReadableId";
 import { captureException, toError } from "~/utils/posthogErrorCapture";
 import {
@@ -22,14 +17,11 @@ import {
   runOrchestrator,
 } from "./orchestrator";
 import { mapThrownErrorEvent } from "./resultMapper";
+import { applyRunEvent, emptyRunResultsDraft } from "./runResults";
 import {
-  applyRunEvent,
-  emptyRunResultsDraft,
-  mergeRunResults,
-  planRunMerge,
-  type RunResultsDraft,
-  runResultsAreEmpty,
-} from "./runResults";
+  persistRunResults,
+  type RunResultsPersistence,
+} from "./runResultsWriter";
 import { runStateManager } from "./runStateManager";
 import { getRunUrl } from "./runUrl";
 import {
@@ -40,21 +32,6 @@ import {
 } from "./types";
 
 const logger = createLogger("langwatch:experiments-v3:runner");
-
-/**
- * Where a completed run writes its cells so an open page can show them.
- *
- * The workbench state is the canonical home of a run's cells: a browser run
- * autosaves them there, and a page that opens later reads them back. A backend
- * run has no page to stream to, so it writes them itself through the same
- * server-owned seam, which validates the state, advances the version and tells
- * the tenant the experiment moved.
- */
-export interface RunResultsPersistence {
-  experiments: ExperimentService;
-  /** Who the workbench write is attributed to in the version history. */
-  actor: WorkbenchActor;
-}
 
 export type StartPollingRunInput = Omit<
   OrchestratorInput,
@@ -71,92 +48,6 @@ export type StartPollingRunInput = Omit<
    * shows, so it leaves the saved state alone.
    */
   persistResults?: RunResultsPersistence;
-};
-
-/**
- * Writes a completed run's cells into the saved workbench state.
- *
- * Never throws: the cells are already stored, so a workbench that could not be
- * updated costs the open page a refresh, not the run. One retry covers the
- * concurrent write (a person typing in the same experiment), which is the same
- * answer the assistant's backend edits give a stale read.
- */
-const persistRunResults = async ({
-  persistence,
-  projectId,
-  experimentId,
-  runId,
-  scope,
-  draft,
-  isRetry = false,
-}: {
-  persistence: RunResultsPersistence;
-  projectId: string;
-  experimentId: string;
-  runId: string;
-  scope: ExecutionScope;
-  draft: RunResultsDraft;
-  isRetry?: boolean;
-}): Promise<void> => {
-  if (runResultsAreEmpty(draft)) {
-    logger.info(
-      { runId, experimentId },
-      "Run produced no cells to write into the workbench state",
-    );
-    return;
-  }
-
-  const plan = planRunMerge(scope);
-
-  try {
-    const saved = await persistence.experiments.applyWorkbenchTransform({
-      projectId,
-      id: experimentId,
-      // The run names itself on the write. A page that started this run then
-      // reads the version bump as its own and adopts it, rather than standing
-      // down and asking the reader to reload over their unsaved edits.
-      actor: { ...persistence.actor, runId },
-      commitMessage: `Results from run ${runId}`,
-      transform: (state) => ({
-        ...state,
-        results: mergeRunResults({ existing: state.results, draft, plan }),
-      }),
-    });
-    logger.info(
-      {
-        runId,
-        experimentId,
-        version: saved.version,
-        targets: Object.keys(draft.targetOutputs).length,
-      },
-      "Wrote the run results into the workbench state",
-    );
-  } catch (error) {
-    if (error instanceof StaleWorkbenchStateError && !isRetry) {
-      logger.info(
-        { runId, experimentId },
-        "Workbench moved while the run was writing its results, retrying once",
-      );
-      await persistRunResults({
-        persistence,
-        projectId,
-        experimentId,
-        runId,
-        scope,
-        draft,
-        isRetry: true,
-      });
-      return;
-    }
-
-    logger.error(
-      { error, runId, experimentId, projectId },
-      "Failed to write the run results into the workbench state",
-    );
-    captureException(toError(error), {
-      extra: { runId, experimentId, projectId },
-    });
-  }
 };
 
 /** Everything the orchestrator itself takes, minus what the runner decides. */

--- a/platform/app/src/server/experiments-v3/execution/runResultsWriter.ts
+++ b/platform/app/src/server/experiments-v3/execution/runResultsWriter.ts
@@ -50,6 +50,71 @@ export interface RunResultsPersistence {
   actor: WorkbenchActor;
 }
 
+/** What one attempt at the write needs to know. */
+interface WriteAttempt {
+  persistence: RunResultsPersistence;
+  projectId: string;
+  experimentId: string;
+  runId: string;
+  scope: ExecutionScope;
+  draft: RunResultsDraft;
+}
+
+/** Folds the run's cells into the saved state and takes the next version. */
+const writeCells = async ({
+  persistence,
+  projectId,
+  experimentId,
+  runId,
+  scope,
+  draft,
+}: WriteAttempt): Promise<void> => {
+  const plan = planRunMerge(scope);
+  const saved = await persistence.experiments.applyWorkbenchTransform({
+    projectId,
+    id: experimentId,
+    // The run names itself on the write. A page that started this run then
+    // reads the version bump as its own and adopts it, rather than standing
+    // down and asking the reader to reload over their unsaved edits.
+    actor: { ...persistence.actor, runId },
+    commitMessage: `Results from run ${runId}`,
+    transform: (state) => ({
+      ...state,
+      results: mergeRunResults({ existing: state.results, draft, plan }),
+    }),
+  });
+  logger.info(
+    {
+      runId,
+      experimentId,
+      version: saved.version,
+      targets: Object.keys(draft.targetOutputs).length,
+    },
+    "Wrote the run results into the workbench state",
+  );
+};
+
+/** Where a write that could not be retried stops, without failing the run. */
+const reportWriteFailure = ({
+  error,
+  projectId,
+  experimentId,
+  runId,
+}: {
+  error: unknown;
+  projectId: string;
+  experimentId: string;
+  runId: string;
+}): void => {
+  logger.error(
+    { error, runId, experimentId, projectId },
+    "Failed to write the run results into the workbench state",
+  );
+  captureException(toError(error), {
+    extra: { runId, experimentId, projectId },
+  });
+};
+
 /**
  * Writes a completed run's cells into the saved workbench state.
  *
@@ -58,23 +123,11 @@ export interface RunResultsPersistence {
  * concurrent write (a person typing in the same experiment), which is the same
  * answer the assistant's backend edits give a stale read.
  */
-export const persistRunResults = async ({
-  persistence,
-  projectId,
-  experimentId,
-  runId,
-  scope,
-  draft,
-  isRetry = false,
-}: {
-  persistence: RunResultsPersistence;
-  projectId: string;
-  experimentId: string;
-  runId: string;
-  scope: ExecutionScope;
-  draft: RunResultsDraft;
-  isRetry?: boolean;
-}): Promise<void> => {
+export const persistRunResults = async (
+  attempt: WriteAttempt & { isRetry?: boolean },
+): Promise<void> => {
+  const { draft, runId, experimentId, projectId, isRetry = false } = attempt;
+
   if (runResultsAreEmpty(draft)) {
     logger.info(
       { runId, experimentId },
@@ -83,56 +136,18 @@ export const persistRunResults = async ({
     return;
   }
 
-  const plan = planRunMerge(scope);
-
   try {
-    const saved = await persistence.experiments.applyWorkbenchTransform({
-      projectId,
-      id: experimentId,
-      // The run names itself on the write. A page that started this run then
-      // reads the version bump as its own and adopts it, rather than standing
-      // down and asking the reader to reload over their unsaved edits.
-      actor: { ...persistence.actor, runId },
-      commitMessage: `Results from run ${runId}`,
-      transform: (state) => ({
-        ...state,
-        results: mergeRunResults({ existing: state.results, draft, plan }),
-      }),
-    });
-    logger.info(
-      {
-        runId,
-        experimentId,
-        version: saved.version,
-        targets: Object.keys(draft.targetOutputs).length,
-      },
-      "Wrote the run results into the workbench state",
-    );
+    await writeCells(attempt);
   } catch (error) {
     if (error instanceof StaleWorkbenchStateError && !isRetry) {
       logger.info(
         { runId, experimentId },
         "Workbench moved while the run was writing its results, retrying once",
       );
-      await persistRunResults({
-        persistence,
-        projectId,
-        experimentId,
-        runId,
-        scope,
-        draft,
-        isRetry: true,
-      });
+      await persistRunResults({ ...attempt, isRetry: true });
       return;
     }
-
-    logger.error(
-      { error, runId, experimentId, projectId },
-      "Failed to write the run results into the workbench state",
-    );
-    captureException(toError(error), {
-      extra: { runId, experimentId, projectId },
-    });
+    reportWriteFailure({ error, projectId, experimentId, runId });
   }
 };
 

--- a/platform/app/src/server/experiments-v3/execution/runResultsWriter.ts
+++ b/platform/app/src/server/experiments-v3/execution/runResultsWriter.ts
@@ -1,0 +1,232 @@
+/**
+ * Where a run's cells reach the saved workbench state.
+ *
+ * Both execution paths end here. The polling runner calls the write directly
+ * at the point it decides the run ended; a streaming run started by an open
+ * page feeds its frames through the writer, which folds them and writes them
+ * when the last frame arrives.
+ *
+ * The page saves the same cells itself, so the streaming write looks like a
+ * duplicate. It is not: the page's save depends on the tab. A browser that
+ * puts a background tab to sleep holds the save timer, and a connection that
+ * drops before the last frame loses the cells the page had. Either way the run
+ * is complete in its own record and the board still reads "No output yet". The
+ * server holds every frame it sent, so it can write what the page could not.
+ */
+
+import { createLogger } from "@langwatch/observability";
+import { StaleWorkbenchStateError } from "~/server/experiments/errors";
+import type {
+  ExperimentService,
+  WorkbenchActor,
+} from "~/server/experiments/experiment.service";
+import { captureException, toError } from "~/utils/posthogErrorCapture";
+import {
+  applyRunEvent,
+  emptyRunResultsDraft,
+  mergeRunResults,
+  planRunMerge,
+  type RunResultsDraft,
+  runResultsAreEmpty,
+} from "./runResults";
+import {
+  type EvaluationV3Event,
+  type ExecutionScope,
+  runsSavedDataset,
+} from "./types";
+
+const logger = createLogger("langwatch:experiments-v3:run-results-writer");
+
+/**
+ * Who writes the cells, and through what.
+ *
+ * The service is the one every other workbench write goes through, so a run's
+ * cells are validated against the same schema, take the next version number
+ * and tell the tenant the experiment moved.
+ */
+export interface RunResultsPersistence {
+  experiments: ExperimentService;
+  /** Who the workbench write is attributed to in the version history. */
+  actor: WorkbenchActor;
+}
+
+/**
+ * Writes a completed run's cells into the saved workbench state.
+ *
+ * Never throws: the cells are already stored, so a workbench that could not be
+ * updated costs the open page a refresh, not the run. One retry covers the
+ * concurrent write (a person typing in the same experiment), which is the same
+ * answer the assistant's backend edits give a stale read.
+ */
+export const persistRunResults = async ({
+  persistence,
+  projectId,
+  experimentId,
+  runId,
+  scope,
+  draft,
+  isRetry = false,
+}: {
+  persistence: RunResultsPersistence;
+  projectId: string;
+  experimentId: string;
+  runId: string;
+  scope: ExecutionScope;
+  draft: RunResultsDraft;
+  isRetry?: boolean;
+}): Promise<void> => {
+  if (runResultsAreEmpty(draft)) {
+    logger.info(
+      { runId, experimentId },
+      "Run produced no cells to write into the workbench state",
+    );
+    return;
+  }
+
+  const plan = planRunMerge(scope);
+
+  try {
+    const saved = await persistence.experiments.applyWorkbenchTransform({
+      projectId,
+      id: experimentId,
+      // The run names itself on the write. A page that started this run then
+      // reads the version bump as its own and adopts it, rather than standing
+      // down and asking the reader to reload over their unsaved edits.
+      actor: { ...persistence.actor, runId },
+      commitMessage: `Results from run ${runId}`,
+      transform: (state) => ({
+        ...state,
+        results: mergeRunResults({ existing: state.results, draft, plan }),
+      }),
+    });
+    logger.info(
+      {
+        runId,
+        experimentId,
+        version: saved.version,
+        targets: Object.keys(draft.targetOutputs).length,
+      },
+      "Wrote the run results into the workbench state",
+    );
+  } catch (error) {
+    if (error instanceof StaleWorkbenchStateError && !isRetry) {
+      logger.info(
+        { runId, experimentId },
+        "Workbench moved while the run was writing its results, retrying once",
+      );
+      await persistRunResults({
+        persistence,
+        projectId,
+        experimentId,
+        runId,
+        scope,
+        draft,
+        isRetry: true,
+      });
+      return;
+    }
+
+    logger.error(
+      { error, runId, experimentId, projectId },
+      "Failed to write the run results into the workbench state",
+    );
+    captureException(toError(error), {
+      extra: { runId, experimentId, projectId },
+    });
+  }
+};
+
+/** What a streaming run feeds its frames into so its cells reach the board. */
+export interface RunResultsWriter {
+  /**
+   * Record one frame. The cells are written when the run reports it ended,
+   * which is `done` or `stopped`.
+   */
+  record(event: EvaluationV3Event): Promise<void>;
+}
+
+/**
+ * The writer a streaming run gets, or none when the run must leave the board
+ * alone.
+ *
+ * An experiment that was never saved has no state to write into. A run given
+ * its own rows, another saved dataset or constant parameters produces cells
+ * that do not line up with the rows the workbench shows, which is the same
+ * rule the polling runner applies before it passes its persistence.
+ */
+export const runResultsWriterFor = ({
+  persistence,
+  projectId,
+  experimentId,
+  scope,
+  data,
+  datasetId,
+  parameters,
+}: {
+  persistence: RunResultsPersistence;
+  projectId: string;
+  experimentId?: string | undefined;
+  scope: ExecutionScope;
+  data?: Array<Record<string, unknown>> | undefined;
+  datasetId?: string | undefined;
+  parameters?: Record<string, string | number | boolean> | undefined;
+}): RunResultsWriter | undefined => {
+  if (!experimentId) return undefined;
+
+  const runsTheBoard = runsSavedDataset({
+    ...(data !== undefined ? { data } : {}),
+    ...(datasetId !== undefined ? { dataset_id: datasetId } : {}),
+    ...(parameters !== undefined ? { parameters } : {}),
+  });
+  if (!runsTheBoard) return undefined;
+
+  return createRunResultsWriter({
+    persistence,
+    projectId,
+    experimentId,
+    scope,
+  });
+};
+
+/** Open a writer for one streaming run of one experiment. */
+export const createRunResultsWriter = ({
+  persistence,
+  projectId,
+  experimentId,
+  scope,
+}: {
+  persistence: RunResultsPersistence;
+  projectId: string;
+  experimentId: string;
+  scope: ExecutionScope;
+}): RunResultsWriter => {
+  const draft = emptyRunResultsDraft();
+  let written = false;
+
+  return {
+    async record(event: EvaluationV3Event): Promise<void> {
+      applyRunEvent({ draft, event });
+
+      if (event.type !== "done" && event.type !== "stopped") return;
+      // A run reports it ended once. A second terminal frame would write the
+      // same cells again and take a second version number for them.
+      if (written) return;
+      written = true;
+
+      // The frame that names the run is the first one the orchestrator sends.
+      // A stream that ended before it arrived carries no cells either, so
+      // there is nothing to write.
+      const runId = draft.runId;
+      if (!runId) return;
+
+      await persistRunResults({
+        persistence,
+        projectId,
+        experimentId,
+        runId,
+        scope,
+        draft,
+      });
+    },
+  };
+};

--- a/platform/app/src/server/experiments-v3/execution/runResultsWriter.ts
+++ b/platform/app/src/server/experiments-v3/execution/runResultsWriter.ts
@@ -50,7 +50,6 @@ export interface RunResultsPersistence {
   actor: WorkbenchActor;
 }
 
-/** What one attempt at the write needs to know. */
 interface WriteAttempt {
   persistence: RunResultsPersistence;
   projectId: string;
@@ -60,7 +59,6 @@ interface WriteAttempt {
   draft: RunResultsDraft;
 }
 
-/** Folds the run's cells into the saved state and takes the next version. */
 const writeCells = async ({
   persistence,
   projectId,

--- a/platform/app/src/server/routes/__tests__/experiments-execute-writes-cells.integration.test.ts
+++ b/platform/app/src/server/routes/__tests__/experiments-execute-writes-cells.integration.test.ts
@@ -1,0 +1,272 @@
+/**
+ * @vitest-environment node
+ *
+ * @see specs/experiments-v3/workbench-versioning.feature
+ *
+ * A run started by an open workbench tab used to reach the board only through
+ * that tab. A background tab holds its save timer and a dropped connection
+ * loses the cells the page held, so the run read as complete in its own record
+ * while the board still read "No output yet". The streaming route now writes
+ * the cells itself, the same way the polling runner does.
+ *
+ * The route, not the writer, is what this file guards: the wiring is the part
+ * that was missing.
+ */
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { globalForApp } from "~/server/app-layer/app";
+import { createTestApp } from "~/server/app-layer/presets";
+import type { ExperimentService } from "~/server/experiments/experiment.service";
+
+vi.mock("~/server/auth", () => ({
+  getServerAuthSession: vi.fn().mockResolvedValue({ user: { id: "user_1" } }),
+}));
+
+vi.mock("~/server/app-layer/permissions/imperative", async (importActual) => {
+  const actual =
+    await importActual<
+      typeof import("~/server/app-layer/permissions/imperative")
+    >();
+  return { ...actual, probeProjectPermission: vi.fn().mockResolvedValue(true) };
+});
+
+vi.mock("~/server/experiments-v3/execution/dataLoader", () => ({
+  loadExecutionData: vi.fn().mockResolvedValue({
+    datasetRows: [{ input: "one" }],
+    datasetColumns: [{ id: "input", name: "input", type: "string" }],
+    loadedPrompts: new Map(),
+    loadedAgents: new Map(),
+    loadedEvaluators: new Map(),
+    loadedWorkflows: new Map(),
+  }),
+}));
+
+vi.mock("~/server/posthog", () => ({ trackServerEvent: vi.fn() }));
+vi.mock("../../../../ee/billing/nurturing/hooks/featureAdoption", () => ({
+  fireExperimentRanNurturing: vi.fn(),
+}));
+
+const orchestratorEvents = vi.hoisted(() => ({ events: [] as unknown[] }));
+vi.mock("~/server/experiments-v3/execution/orchestrator", () => ({
+  requestAbort: vi.fn(),
+  runOrchestrator: vi.fn(async function* () {
+    for (const event of orchestratorEvents.events) yield event;
+  }),
+}));
+
+// The run-state store is Redis in production and is not what this file is
+// about. Its writes are stubbed so the route's own decisions are all that
+// reaches an assertion.
+vi.mock("~/server/experiments-v3/execution/runStateManager", () => ({
+  runStateManager: {
+    createRun: vi.fn().mockResolvedValue(undefined),
+    addEvent: vi.fn().mockResolvedValue(undefined),
+    completeRun: vi.fn().mockResolvedValue(undefined),
+    stopRun: vi.fn().mockResolvedValue(undefined),
+    failRun: vi.fn().mockResolvedValue(undefined),
+    getRunState: vi.fn().mockResolvedValue(null),
+  },
+}));
+
+const applyWorkbenchTransform = vi.fn();
+
+const executionRequest = {
+  projectId: "project_1",
+  experimentId: "experiment_1",
+  experimentSlug: "my-evaluation",
+  name: "My Evaluation",
+  dataset: {
+    id: "ds-1",
+    name: "Data",
+    type: "inline" as const,
+    columns: [{ id: "input", name: "input", type: "string" }],
+  },
+  targets: [],
+  evaluators: [],
+  scope: { type: "full" as const },
+};
+
+/** Drives the route to completion, so the handler has finished when it returns. */
+const execute = async (overrides: Record<string, unknown> = {}) => {
+  const { app } = await import("../experiments-v3");
+  const res = await app.request("/api/experiments/execute", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ ...executionRequest, ...overrides }),
+  });
+  await res.text();
+  return res;
+};
+
+const savedState = () => ({
+  name: "My Evaluation",
+  datasets: [],
+  activeDatasetId: "ds-1",
+  targets: [],
+  evaluators: [],
+  results: {
+    status: "idle",
+    targetOutputs: {},
+    targetMetadata: {},
+    evaluatorResults: {},
+    errors: {},
+  },
+  pendingSavedChanges: {},
+});
+
+/** What the route asked the workbench to save, run through its own transform. */
+const savedResults = () => {
+  const call = applyWorkbenchTransform.mock.calls[0]?.[0] as {
+    transform: (state: unknown) => { results: Record<string, unknown> };
+  };
+  return call.transform(savedState()).results;
+};
+
+beforeAll(() => {
+  globalForApp.__langwatch_app = createTestApp({
+    experiments: {
+      applyWorkbenchTransform,
+    } as unknown as ExperimentService,
+  });
+});
+
+afterAll(() => {
+  globalForApp.__langwatch_app = null;
+});
+
+beforeEach(() => {
+  applyWorkbenchTransform.mockReset();
+  applyWorkbenchTransform.mockResolvedValue({ version: 4 });
+  orchestratorEvents.events = [];
+});
+
+describe("POST /api/experiments/execute", () => {
+  describe("when a run started from the page finishes", () => {
+    /** @scenario "A run started from the open page writes its cells too" */
+    it("writes the run's cells into the saved state without the tab", async () => {
+      orchestratorEvents.events = [
+        { type: "execution_started", runId: "swift-bold-fox", total: 1 },
+        {
+          type: "target_result",
+          rowIndex: 0,
+          targetId: "target-1",
+          output: "an answer",
+          cost: 0.5,
+        },
+        {
+          type: "evaluator_result",
+          rowIndex: 0,
+          targetId: "target-1",
+          evaluatorId: "evaluator-1",
+          result: { status: "processed", passed: true, score: 1 },
+        },
+        { type: "done", summary: { total: 1, completed: 1 } },
+      ];
+
+      await execute();
+
+      expect(applyWorkbenchTransform).toHaveBeenCalledTimes(1);
+      const results = savedResults();
+      expect(results.targetOutputs).toEqual({ "target-1": ["an answer"] });
+      expect(results.evaluatorResults).toEqual({
+        "target-1": {
+          "evaluator-1": [{ status: "processed", passed: true, score: 1 }],
+        },
+      });
+    });
+
+    /** @scenario "A version a run wrote names that run" */
+    it("names the run on the version it writes", async () => {
+      orchestratorEvents.events = [
+        { type: "execution_started", runId: "quick-plain-doe", total: 1 },
+        {
+          type: "target_result",
+          rowIndex: 0,
+          targetId: "target-1",
+          output: "an answer",
+        },
+        { type: "done", summary: { total: 1, completed: 1 } },
+      ];
+
+      await execute();
+
+      expect(applyWorkbenchTransform).toHaveBeenCalledWith(
+        expect.objectContaining({
+          projectId: "project_1",
+          id: "experiment_1",
+          actor: { userId: "user_1", label: "user", runId: "quick-plain-doe" },
+        }),
+      );
+    });
+  });
+
+  describe("when a run started from the page is stopped", () => {
+    /** @scenario "A stopped run started from the open page keeps the cells it produced" */
+    it("writes the cells it produced before the stop", async () => {
+      orchestratorEvents.events = [
+        { type: "execution_started", runId: "calm-eager-owl", total: 2 },
+        {
+          type: "target_result",
+          rowIndex: 0,
+          targetId: "target-1",
+          output: "the row that finished",
+        },
+        { type: "stopped", reason: "user" },
+      ];
+
+      await execute();
+
+      expect(applyWorkbenchTransform).toHaveBeenCalledTimes(1);
+      expect(savedResults().targetOutputs).toEqual({
+        "target-1": ["the row that finished"],
+      });
+    });
+  });
+
+  describe("when the run is given its own rows", () => {
+    /** @scenario "A run started from the open page with its own rows is not written back" */
+    it("writes nothing into the saved state", async () => {
+      orchestratorEvents.events = [
+        { type: "execution_started", runId: "bold-keen-elk", total: 1 },
+        {
+          type: "target_result",
+          rowIndex: 0,
+          targetId: "target-1",
+          output: "an answer to a row the board does not hold",
+        },
+        { type: "done", summary: { total: 1, completed: 1 } },
+      ];
+
+      await execute({ data: [{ input: "a row sent in the request" }] });
+
+      expect(applyWorkbenchTransform).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when the page names no saved experiment", () => {
+    /** @scenario "A run started from a page with no saved experiment is not written back" */
+    it("writes nothing into the saved state", async () => {
+      orchestratorEvents.events = [
+        { type: "execution_started", runId: "keen-plain-ram", total: 1 },
+        {
+          type: "target_result",
+          rowIndex: 0,
+          targetId: "target-1",
+          output: "an answer",
+        },
+        { type: "done", summary: { total: 1, completed: 1 } },
+      ];
+
+      await execute({ experimentId: undefined });
+
+      expect(applyWorkbenchTransform).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/platform/app/src/server/routes/experiments-v3.ts
+++ b/platform/app/src/server/routes/experiments-v3.ts
@@ -38,7 +38,10 @@ import {
   ExperimentVersionNotFoundError,
   RunNotFoundError,
 } from "~/server/experiments/errors";
-import { ExperimentService } from "~/server/experiments/experiment.service";
+import {
+  ExperimentService,
+  type WorkbenchActor,
+} from "~/server/experiments/experiment.service";
 import { workbenchActorFrom } from "~/server/experiments/workbenchActor";
 import { abortManager } from "~/server/experiments-v3/execution/abortManager";
 import { loadExecutionData } from "~/server/experiments-v3/execution/dataLoader";
@@ -48,6 +51,7 @@ import {
   runOrchestrator,
 } from "~/server/experiments-v3/execution/orchestrator";
 import { mapThrownErrorEvent } from "~/server/experiments-v3/execution/resultMapper";
+import { runResultsWriterFor } from "~/server/experiments-v3/execution/runResultsWriter";
 import { runStateManager } from "~/server/experiments-v3/execution/runStateManager";
 import { createRunStateMirror } from "~/server/experiments-v3/execution/runStateMirror";
 import {
@@ -372,6 +376,24 @@ secured.access(sessionAuth).post(
       experimentSlug: request.experimentSlug ?? "",
     });
 
+    // The page saves these cells too, and it is the faster of the two. The
+    // server writes them so the board does not depend on the tab surviving:
+    // a background tab holds its save timer, and a dropped connection loses
+    // the cells the page was holding, while the run reads as complete.
+    const actor: WorkbenchActor = {
+      ...(session.user?.id ? { userId: session.user.id } : {}),
+      label: "user",
+    };
+    const resultsWriter = runResultsWriterFor({
+      persistence: { experiments: getApp().experiments, actor },
+      projectId,
+      experimentId: request.experimentId,
+      scope: request.scope,
+      data: request.data,
+      datasetId: request.dataset_id,
+      parameters: request.parameters,
+    });
+
     return streamSSE(c, async (stream) => {
       try {
         const isFullRun = request.scope.type === "full";
@@ -397,13 +419,18 @@ secured.access(sessionAuth).post(
         });
 
         for await (const event of orchestrator) {
-          // The store first, the customer second. The `execution_started`
-          // frame names the run, and the page hands that id to a poller as
-          // soon as it reads it, so a frame released before the store knows
-          // the run makes the first poll read 404 on a healthy run. Ordering
-          // it this way keeps the store a superset of what the page has seen.
-          // The mirror swallows its own failures, so a store outage still
-          // cannot stop the run.
+          // The board first, then the run store, then the customer. The cells
+          // go in before the run reports it ended, for the same reason the
+          // backend runner writes them first: a caller that reads "done" and
+          // then reads the workbench finds them there. The writer swallows its
+          // own failures, so a write that fails costs the page a refresh and
+          // never the run.
+          await resultsWriter?.record(event);
+          // The `execution_started` frame names the run, and the page hands
+          // that id to a poller as soon as it reads it, so a frame released
+          // before the store knows the run makes the first poll read 404 on a
+          // healthy run. Ordering it this way keeps the store a superset of
+          // what the page has seen. The mirror swallows its own failures too.
           await mirror.record(event);
           await stream.writeSSE({
             data: JSON.stringify(event),

--- a/specs/experiments-v3/workbench-versioning.feature
+++ b/specs/experiments-v3/workbench-versioning.feature
@@ -191,13 +191,22 @@ Feature: Versioned workbench saves
       When the caller restores that row
       Then the version the restore writes reads "Restored from the autosave"
 
-  Rule: A run with no browser writes its cells into the saved state
+  Rule: Every run writes its cells into the saved state
 
     A run started over REST, from the command line or by the assistant has no
     page to stream its cells to, so the workbench state knew nothing about them
     and the table read "No output yet" after the run finished. The runner
-    writes the cells back through the same seam every other write uses, and the
-    update signal lets an open page pick them up.
+    writes the cells back through the same route every other write uses, and
+    the update signal lets an open page pick them up.
+
+    A run started from an open page has the same result for a different reason.
+    The page holds the cells and saves them itself, so a tab the browser puts
+    to sleep, or a connection that drops before the last frame, leaves the run
+    complete in its own record while the board still reads "No output yet".
+    The streaming route writes the cells back the same way the runner does, so
+    the board no longer depends on the tab. A page that started the run reads
+    the version it wrote as its own and takes it, which the adopt rule below
+    covers.
 
     @regression @integration
     Scenario: A completed backend run fills the cells the workbench shows
@@ -249,6 +258,40 @@ Feature: Versioned workbench saves
       Given a backend run that fails before any cell runs
       When the run completes
       Then no cell is marked, because the run's own status carries the failure
+
+    @regression @integration
+    Scenario: A run started from the open page writes its cells too
+      Given a run started from an open workbench page
+      When the run completes
+      Then the server writes the run's cells into the saved state
+      And the version it writes names the run
+
+    @regression @integration
+    Scenario: A stopped run started from the open page keeps the cells it produced
+      Given a run started from an open workbench page that filled some cells
+      When the run is stopped
+      Then the server writes the cells it produced into the saved state
+
+    @regression @integration
+    Scenario: A run started from the open page with its own rows is not written back
+      Given a run started from an open workbench page with rows sent in the request
+      When the run completes
+      Then the server writes nothing into the saved state
+
+    @regression @integration
+    Scenario: A run started from a page with no saved experiment is not written back
+      Given a run started from an open workbench page that names no experiment
+      When the run completes
+      Then the server writes nothing into the saved state
+
+    # The frame that names the run is the first one. A stream that ends before
+    # it arrives carries no cells either, so there is nothing to write and no
+    # run to attribute the write to.
+    @regression @unit
+    Scenario: A run that ends before it names itself writes nothing
+      Given a stream that ends without naming its run
+      When the run ends
+      Then nothing is written into the saved state
 
   Rule: The same seam is reachable over REST
 

--- a/specs/setup/dev-langy-agent-lane.feature
+++ b/specs/setup/dev-langy-agent-lane.feature
@@ -64,6 +64,14 @@ Feature: `pnpm dev` starts the Langy agent manager
       Then it leaves the address unset for the launcher to derive from the port
 
     @unit
+    Scenario: An overlay that clears the agent address is not read past
+      Given platform/app/.env pins the agent URL
+      And the haven overlay assigns it an empty value
+      When the launcher resolves the agent address
+      Then it derives the port slot, because the app reads the empty overlay too
+      And it does not fall back to the address in the plain env file
+
+    @unit
     Scenario: A commented-out pin is not an agent address
       Given platform/app/.env has its agent URL commented out
       When the launcher resolves the agent address
@@ -111,6 +119,17 @@ Feature: `pnpm dev` starts the Langy agent manager
       When the launcher plans the langy lane
       Then the lane is skipped
       And the reason names the missing setting
+
+    @unit
+    Scenario: A setting only the haven overlay carries does not count as present
+      Given the Langy secret is only in the haven overlay, not in the app's env file
+      When the launcher plans the langy lane
+      Then the lane is skipped
+      And the reason names the missing setting
+      # The manager reads its settings from the app's env file alone, so a value
+      # that lives only in the overlay would start a lane that cannot boot. The
+      # agent address is resolved from the overlay on purpose, because the app
+      # reads the overlay to decide where to dial.
 
     @unit
     Scenario: No Go toolchain skips the lane with the manual command
@@ -161,6 +180,26 @@ Feature: `pnpm dev` starts the Langy agent manager
       When the launcher plans the langy lane
       Then the lane still starts, because the manager answers health checks
       And the startup line says which build command a chat needs first
+
+  Rule: The worker finds the command names its model expects
+
+    # The worker's model reaches for `python` on its own. macOS ships `python3`
+    # only, so the first call fails and the model spends another turn and
+    # another tool call finding that out. The name it expects goes on the
+    # worker's PATH so the first call works.
+
+    @unit
+    Scenario: A machine with only python3 gets a python that runs it
+      Given the machine has python3 and no python
+      When the launcher plans the langy lane
+      Then the lane puts a python on the worker's PATH
+      And that python runs the python3 already installed
+
+    @unit
+    Scenario: A machine that has its own python is left alone
+      Given the machine already has a python
+      When the launcher plans the langy lane
+      Then the lane adds nothing to the worker's PATH
 
   Rule: A local manager is capped to a local worker pool
 

--- a/specs/setup/dev-langy-agent-lane.feature
+++ b/specs/setup/dev-langy-agent-lane.feature
@@ -72,6 +72,13 @@ Feature: `pnpm dev` starts the Langy agent manager
       And it does not fall back to the address in the plain env file
 
     @unit
+    Scenario: An overlay that clears the agent address drops one exported for a single run
+      Given an agent URL exported into the shell
+      And the haven overlay assigns the agent URL an empty value
+      When the launcher resolves the agent address
+      Then it derives the port slot, because the file beats the exported value
+
+    @unit
     Scenario: A commented-out pin is not an agent address
       Given platform/app/.env has its agent URL commented out
       When the launcher resolves the agent address

--- a/specs/setup/dev-langy-agent-lane.feature
+++ b/specs/setup/dev-langy-agent-lane.feature
@@ -1,0 +1,178 @@
+Feature: `pnpm dev` starts the Langy agent manager
+  As a developer who wants to use Langy in the app I am running
+  I want the agent manager to come up with the rest of the stack
+  So that a chat with Langy answers instead of stopping mid-reply
+
+  # Langy needs three parts: the app, the AI gateway, and the langyagent
+  # manager. `pnpm dev` started the first two and not the third, so a chat
+  # opened in a local app dispatched to a dead port, the turn was left to the
+  # liveness subscriber, and the chat said "Langy stopped mid-reply". Nothing
+  # in the app log names the missing service. The only local launcher was
+  # haven, and only after `haven up +langy`.
+  #
+  # The manager is cheap enough to start every time: it opens no database
+  # client, reads its embedded skills once, and sits at about 30 MB with no
+  # measurable CPU. What is expensive is the per-conversation worker, about
+  # 600 MB, and that is spawned when a person chats, not at boot. So the lane
+  # starts the manager always and caps the pool to the local size, which keeps
+  # the always-on cost near zero and bounds the cost of a chat.
+  #
+  # The lane follows the nlpgo lane, with two differences that come from
+  # langyagent itself. It takes its listen port from PORT, which `pnpm dev`
+  # already uses for vite, so the port has to be set for the lane instead of
+  # inherited. And it fails fast without its secret and its two roots, so a
+  # setup that is missing them must be skipped rather than started into a
+  # restart loop.
+
+  Background:
+    Given a developer running the stack with `pnpm dev`
+
+  Rule: The manager starts on the address the app dials
+
+    # The launcher runs before every Node entry point and sees only the
+    # calling shell, while the app loads platform/app/.env and then the
+    # .env.portless haven overlay with override. A pinned agent URL is
+    # therefore invisible to the launcher and authoritative for the app, the
+    # same split the NLP engine had.
+
+    @unit
+    Scenario: The manager follows the address pinned in the app's env file
+      Given platform/app/.env pins the agent URL to port 8080
+      And this worktree runs on port slot 5590
+      When the launcher resolves the agent address
+      Then it resolves to the pinned port 8080
+      And it says which file that came from
+
+    @unit
+    Scenario: The haven overlay wins over the plain env file for the agent address
+      Given platform/app/.env pins one agent URL
+      And the haven overlay pins another
+      When the launcher resolves the agent address
+      Then it resolves to the overlay's address, the one the app loads last
+
+    @unit
+    Scenario: An agent address pinned in a file beats one exported for a single run
+      Given platform/app/.env pins the agent URL
+      And a different address is exported into the shell
+      When the launcher resolves the agent address
+      Then it resolves to the pinned one, because that is what the app will read
+
+    @unit
+    Scenario: Nothing pinned leaves the launcher to derive the manager port slot
+      Given no env file pins an agent URL
+      When the launcher resolves the agent address
+      Then it leaves the address unset for the launcher to derive from the port
+
+    @unit
+    Scenario: A commented-out pin is not an agent address
+      Given platform/app/.env has its agent URL commented out
+      When the launcher resolves the agent address
+      Then it leaves the address unset for the launcher to derive from the port
+
+  Rule: The lane never takes the port the app is using
+
+    # langyagent reads PORT for its own listen address and ignores SERVER_ADDR,
+    # unlike the gateway and the NLP engine. `pnpm dev` exports PORT for the
+    # app, so a lane that inherits it binds the port vite already holds and
+    # dies with "address already in use" on every restart.
+
+    @unit
+    Scenario: The lane sets the manager's port instead of inheriting the app's
+      Given the app runs on port 5570
+      And no env file pins an agent URL
+      When the launcher plans the langy lane
+      Then the lane sets the manager's port to the derived slot
+      And that port is not the app's port
+
+    @unit
+    Scenario: A pinned address decides the port the lane sets
+      Given platform/app/.env pins the agent URL to port 8080
+      When the launcher plans the langy lane
+      Then the lane sets the manager's port to 8080
+
+  Rule: A setup that cannot run the manager is skipped, never restarted forever
+
+    # The lanes run under `concurrently --restart-tries -1`. A manager that
+    # exits at boot for a missing secret is restarted for as long as the stack
+    # is up, and its error scrolls the output of every other lane. Each of
+    # these skips prints the one command that fixes it.
+
+    @unit
+    Scenario: A missing Langy env block skips the lane and names the doctor
+      Given platform/app/.env has no LANGY_INTERNAL_SECRET
+      When the launcher plans the langy lane
+      Then the lane is skipped
+      And the reason names the missing setting
+      And it points at the Langy dogfood doctor
+
+    @unit
+    Scenario: A missing workspace root skips the lane the same way
+      Given platform/app/.env has no LANGY_WORKSPACE_ROOT
+      When the launcher plans the langy lane
+      Then the lane is skipped
+      And the reason names the missing setting
+
+    @unit
+    Scenario: No Go toolchain skips the lane with the manual command
+      Given the Go toolchain is not on PATH
+      When the launcher plans the langy lane
+      Then the lane is skipped
+      And the reason gives the make command that starts the manager
+
+    @unit
+    Scenario: A manager already listening is reused
+      Given another worktree already runs a manager on the resolved port
+      When the launcher plans the langy lane
+      Then the lane is skipped
+      And the reason says the running manager is reused
+
+    @unit
+    Scenario: An external agent URL leaves the manager alone
+      Given the agent URL points at a host that is not this machine
+      When the launcher plans the langy lane
+      Then the lane is skipped
+      And the reason says the address is external
+
+    @unit
+    Scenario: The developer can opt out for one stack
+      Given LANGWATCH_SKIP_LANGY is set
+      When the launcher plans the langy lane
+      Then the lane is skipped
+      And the reason says the developer asked for it
+
+  Rule: The lane names the worker binary the manager spawns
+
+    # The manager spawns a separate binary for each conversation and looks for
+    # it on PATH by name. A repo checkout does not put it there, so a manager
+    # started without the path boots, accepts the dispatch, and fails the turn
+    # with `exec: "langy-worker"`. The reader sees only "Langy stopped
+    # mid-reply", which names neither the binary nor the build that makes it.
+
+    @unit
+    Scenario: The lane points the manager at the built worker in this checkout
+      Given the launcher plans the langy lane
+      When the lane is started
+      Then the manager is told where the worker binary is
+      And a path set in the environment still wins
+
+    @unit
+    Scenario: A worker binary that was never built is called out at startup
+      Given the worker binary has not been built in this checkout
+      When the launcher plans the langy lane
+      Then the lane still starts, because the manager answers health checks
+      And the startup line says which build command a chat needs first
+
+  Rule: A local manager is capped to a local worker pool
+
+    # The manager's defaults are the production ones: twenty workers, reaped
+    # after ten idle minutes. On a laptop that is up to twelve gigabytes of
+    # workers held for ten minutes after a chat ends. haven already caps its
+    # own langy stack, and the `pnpm dev` lane uses the same numbers.
+
+    @unit
+    Scenario: The lane caps the pool and reaps idle workers quickly
+      Given the launcher plans the langy lane
+      When the lane is started
+      Then the worker pool is capped to the local size
+      And an idle worker is reaped in minutes rather than the production wait
+      And the caps can still be overridden from the environment

--- a/specs/setup/dev-nlp-engine-port.feature
+++ b/specs/setup/dev-nlp-engine-port.feature
@@ -52,6 +52,14 @@ Feature: The NLP engine `pnpm dev` starts is the one the app talks to
     And it says nothing
 
   @unit
+  Scenario: An overlay that clears the address is not read past
+    Given platform/app/.env pins the NLP address
+    And the haven overlay assigns it an empty value
+    When the launcher resolves the NLP address
+    Then it leaves the address unset for the launcher to derive from the port
+    And it does not fall back to the address in the plain env file
+
+  @unit
   Scenario: A commented-out pin is not an address
     Given platform/app/.env has its NLP address commented out
     When the launcher resolves the NLP address

--- a/specs/setup/dev-nlp-engine-port.feature
+++ b/specs/setup/dev-nlp-engine-port.feature
@@ -60,6 +60,13 @@ Feature: The NLP engine `pnpm dev` starts is the one the app talks to
     And it does not fall back to the address in the plain env file
 
   @unit
+  Scenario: An overlay that clears the address drops one exported for a single run
+    Given an NLP address exported into the shell
+    And the haven overlay assigns it an empty value
+    When the launcher resolves the NLP address
+    Then it leaves the address unset, because the file beats the exported value
+
+  @unit
   Scenario: A commented-out pin is not an address
     Given platform/app/.env has its NLP address commented out
     When the launcher resolves the NLP address


### PR DESCRIPTION
## Why

A production run finished with every column filled, and the workbench board showed one of them as empty:

- The board read `No output yet` on the first rows of one column, with grey pending evaluator chips, while the column header read `11/40`.
- The results page, for the same run, held the outputs.

The run was complete. The board was not. The report said "idk if my browser was out of focus or what", which is the right guess.

## What was happening

Two paths start a run, and only one of them wrote its cells to the board.

`POST /:slug/run` is the backend path. It passes `persistResults`, so the runner writes the run's cells into the saved workbench state itself.

`POST /execute` is the browser path. It streams the frames over SSE and mirrors them into the run store, and it passed nothing. The board was updated only by the tab: the page reads its own stream and autosaves what it holds. So the run's own record was complete while the board was not, whenever the tab could not finish that save. A browser that puts a background tab to sleep holds its save timer, and a connection that drops before the last frame loses the cells the page held.

## The fix

The streaming route now writes the cells the same way the runner does. It folds the frames it sends into a draft and writes them when the run reports it ended.

A few points that are part of the behaviour, not details:

- **A stopped run writes too.** The rows that finished before the stop are real output, and dropping them is what leaves the board reading `No output yet` for work that ran.
- **The write is refused for a run that must leave the board alone.** An experiment that was never saved has no state to write into, and a run given its own rows, another saved dataset or constant parameters produces cells that do not line up with the rows the board shows. This is the same rule the backend path already applies.
- **The double write is safe.** The page saves the same cells, and it is the faster of the two. The version the server writes names the run, so the page reads it as its own and takes it rather than asking the reader to reload over unsaved edits. That adopt path shipped in #7577 and, until now, no browser run reached it.
- **A failed write costs a refresh, never the run.** The write swallows its own failures, the same as the run-state mirror beside it.

`persistRunResults` moves out of `experimentRunner.ts` into a new `runResultsWriter.ts`, so both paths write through one implementation instead of two.

## What this does not fix

The same report showed evaluator chips missing on some rows of the results page. That is a different bug and it is already fixed, by #7606, merged earlier the same day. The run in the report predates the deploy.

For the record, the mechanism there is sharper than the #7606 description says. `commands.ts` sets the group key to `${experimentId}:${runId}:item:${index}`, which is per row and not per column, so every column's results for one row coalesce into one batch. `collapseByJobId` then keeps only the last delivery per job id in that batch. Before #7606 the evaluator job id carried no target id, so all columns' verdicts for one row shared an id and all but one were discarded. It collapses only when the verdicts land in the same drained batch, which is why some rows kept their chips on both columns and some kept them on one. That mixed picture is the signature, not a contradiction.

## Dogfood

Driven in a real browser against a local stack, on a board built the way the
report was: two columns of one prompt, same name, disambiguated to
`category-classifier (1)` and `(2)`, and two named exact-match evaluators on
each.

**The bug, reproduced.** The page's own save was blocked for the whole run, so
the tab held the cells and could not write them. This is what a background tab
does on its own. The run finished and the header reads "Failed to save":

![run finished, tab failed to save](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-7629/dogfood/01-run-finished-tab-failed-to-save.png)

**The fix.** After a full reload, which reads only what the server holds, the
board carries every cell and every verdict. Before this change the same reload
read "No output yet", because the tab was the only writer:

![after reload the board has the cells](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-7629/dogfood/02-after-reload-board-has-cells.png)

The version history shows who wrote it. `v2 · Results from run
vivid-mighty-tide` is the server's write, attributed to the person who started
the run and naming the run, which is what lets the page adopt it instead of
asking the reader to reload:

![the version names the run](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-7629/dogfood/03-version-names-the-run.png)

**The two merged fixes, checked on the same run.** Every row keeps both
evaluator chips on both columns, and the charts label the two same-named
columns apart:

![results page keeps both columns' verdicts](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-7629/dogfood/04-results-both-columns-keep-verdicts.png)

The event log is the real proof for #7606, because the projection dedupes on
read and looks correct on both builds. Counting distinct idempotency keys for
this run:

```
kind       distinct_events
complete   1
evaluator  12
start      1
target     6
```

12 = 3 rows x 2 columns x 2 evaluators, and 6 = 3 rows x 2 columns. Before
#7606 the evaluator key carried no target id, so the two columns' verdicts for
one row shared a key and half of them were dropped.

Last, #7615's fallback, on the exact state that produced the id in production.
An evaluator with no workbench name and no database evaluator now reads its
type name, never `evaluator_AzPF-HSd`:

![an unnamed evaluator reads its type name](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-7629/dogfood/05-unnamed-evaluator-reads-type-name.png)

## Langy starts with `pnpm dev`

The first pass of this dogfood could not ask Langy to add the evaluators,
because Langy's agent manager did not start with `pnpm dev`. A chat dispatched
to a dead port and read "Langy stopped mid-reply", and nothing in the app log
named the missing service. haven was the only local launcher, and only after
`haven up +langy`. So this PR adds the lane.

The question was whether the manager is cheap enough to start every time.
Measured on one stack:

| Process | RSS | CPU idle |
|---|---|---|
| api (node) | 530 MB | 2.3% |
| vite | 44.7 MB | 30.8% |
| **langyagent (Go)** | **29.7 MB** | **0.0%** |
| aigateway (Go) | 8.3 MB | 0.0% |
| nlpgo (Go) | 8.1 MB | 0.0% |

It boots in under a second, opens no database client and spawns nothing at
boot. The expensive part is the per-conversation worker, about 600 MB, and that
starts only when a person chats. So the manager starts every time, and the lane
caps the pool to haven's local numbers rather than the production defaults of
twenty workers held for ten idle minutes.

Two traps come from langyagent itself, and both are covered by the new
scenarios:

- **It takes its listen port from `PORT`,** which the launcher already uses for
  the app. A lane that inherits it binds the port vite holds and dies with
  `address already in use` on every restart. Reproduced before the fix.
- **It fails fast without its secret and its two roots.** The lanes run under
  `concurrently --restart-tries -1`, so a setup missing them would restart for
  as long as the stack is up. Those setups are skipped with the command that
  fixes them.

Dogfooding it also found a third: the manager spawns a separate worker binary
and looks for it on PATH by name, which a checkout does not provide. Without
it the manager boots, accepts the dispatch and fails the turn with
`exec: "langy-worker"`. The lane now names the built copy in this checkout and
says at startup when it has not been built.

The env-file address reader moves into `resolve-service-address.sh`, so the NLP
engine and the manager share one implementation instead of two copies.

**Langy answering on a plain `pnpm dev` stack**, no service started by hand: a
three-step plan, 10 tool calls, and a real analysis of the project.

![Langy answers on a plain pnpm dev stack](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-7629/langy/01-langy-answers-on-plain-pnpm-dev.png)

That also closes #7615's requirement that the agent name every evaluator, which
was covered by tests only. Asked to add one, Langy created **Exact Match
Expected Output** and reported that name back, rather than an id:

![Langy names the evaluator it creates](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-7629/langy/02-langy-names-the-evaluator.png)

One step in that turn failed with `/bin/bash: python: command not found`. No
Langy skill and nothing in the manager's embedded assets calls bare `python`,
so that was the model reaching for the name it expects on a machine that ships
`python3` only. Rather than leave it, the lane now puts a `python` that runs
`python3` on the worker's PATH, built only when the machine has none of its
own, so the model's first call works instead of costing a turn and a tool call
to discover. Verified on the running manager: the shim directory is on its
PATH, and `python -V` through it answers Python 3.14.3 on a machine with no
`python` of its own.

## Testing

Every guard here was first made to fail on the broken code, then restored.

| Check | Result |
|---|---|
| `experiments-execute-writes-cells.integration.test.ts` | 5 passed; **3 fail** with the route wiring removed, which is the exact bug |
| `runResultsWriter.unit.test.ts` | 5 passed, covering a run that ends before it names itself, a run that produced no cells, a second terminal frame, and a write that fails |
| CodeRabbit round | 1 finding, valid against the repo's own 60-line rule for a new exported function; `persistRunResults` split into named steps, behaviour unchanged |
| `runResultsPersistence.integration.test.ts` | 5 passed, unchanged by the move |
| `experiments-execute-run-state.integration.test.ts` | 5 passed, so the mirror ordering is unchanged |
| `plan-langy-lane.unit.test.ts` | 28 passed; the port guard and the missing-env guard each **fail** when their branch is removed |
| `pnpm test:unit` (launcher scripts) | 281 passed, including the NLP resolver tests after the shared-reader refactor |
| `pnpm test:unit` (experiments-v3 server) | 317 passed |
| `pnpm test:component` (experiments-v3) | 462 passed, 1 skipped |
| `pnpm test:integration` (experiments-v3 execution, experiments routes) | 33 passed |
| `pnpm typecheck:all` | clean |
| Biome, full CI path | 0 errors; added-violations gate reports base 3403, head 3403, no new violations |
| `check:feature-parity` | `workbench-versioning` 71/71, `dev-langy-agent-lane` 21/21 and `dev-nlp-engine-port` 7/7 bound, each verified by tampering with every title and seeing them all reported unbound. That check caught 4 langy scenarios binding vacuously to the NLP tests through identical titles, which is why those 4 are worded for the agent address |

Two integration files in the same directory fail on this machine, `workflowExecution` and `orchestrator`, with `openai model provider is disabled`. Both fail identically on the merge base with this branch set aside, so they are local test data and not this change.

## Deployment Impact

**Env vars added or changed:** none.

**Helm values added or changed:** none.

**Default behaviour on a vanilla `helm install`:** unchanged.

**Migrations:** none. The cells are written into the existing workbench state through the service every other write already uses.

**Behaviour change to note:** a run started from the browser now writes one workbench version when it ends, attributed to the person who started it and naming the run. That version is what the page adopts, so it does not appear to the reader as another person's write. A run of rows sent in the request writes nothing, exactly as before.

**Dev environment:** `pnpm dev` gains a `langy` lane. It adds about 30 MB to the stack and is skipped, with the reason printed, for any setup that cannot run it. `LANGWATCH_SKIP_LANGY=1` opts out. haven's own default is unchanged: `haven up` still leaves langy out, because its default tier runs the worker in a container and starting it by default would pull up a container runtime.

**Rollback:** safe. Reverting returns the browser path to depending on the tab. Nothing is stored in a new shape, so a board written by this version reads the same on the old one.
