### PR TITLE
fix(clickhouse): a user is a tenant in its own right, so identity events can land

### DIFF
--- a/platform/app/src/server/app-layer/system-migrations/__tests__/runtime-enrollment.unit.test.ts
+++ b/platform/app/src/server/app-layer/system-migrations/__tests__/runtime-enrollment.unit.test.ts
@@ -289,7 +289,11 @@ describe("userMigrationPassCohort on cloud", () => {
   });
 
   describe("when an enrolled organization's member also belongs to a private-dataplane organization", () => {
-    it("keeps that member out, exactly as the organization cohort keeps the organization out", async () => {
+    // A user tenant resolves now — to the shared instance, whoever they
+    // belong to — so there is nothing left for this to protect against, and
+    // excluding these people would strand exactly them on the legacy path.
+    // Their enrolment reads like anybody else's.
+    it("admits that member, and admits them through their private-dataplane organization too", async () => {
       const backfill = IDENTITY_IDENTIFIER_BACKFILL_MIGRATION_NAME;
       stubs.enrollmentFindMany.mockResolvedValueOnce([
         { organizationId: "org_acme", migrationName: backfill },
@@ -298,6 +302,7 @@ describe("userMigrationPassCohort on cloud", () => {
       stubMemberships({
         user_sam: ["org_acme"],
         user_both: ["org_private", "org_acme"],
+        user_private_only: ["org_private"],
       });
 
       const cohort = await userMigrationPassCohort();
@@ -307,7 +312,13 @@ describe("userMigrationPassCohort on cloud", () => {
       ).resolves.toBe(true);
       await expect(
         cohort({ tenantId: "user_both", migrationName: backfill }),
-      ).resolves.toBe(false);
+      ).resolves.toBe(true);
+      // The enrolled private-dataplane organization is a real enrolment, not
+      // a filtered-out one: somebody who reaches the migration only through
+      // it is in the cohort.
+      await expect(
+        cohort({ tenantId: "user_private_only", migrationName: backfill }),
+      ).resolves.toBe(true);
     });
   });
 
@@ -336,20 +347,19 @@ describe("runSystemMigrationTargetedPass for a user-rooted migration", () => {
   });
 
   describe("when the named organization runs a private dataplane", () => {
-    it("refuses with migration_not_available_on_installation before touching any member", async () => {
-      // The same rule userMigrationPassCohort applies on a full pass: a
-      // private-dataplane organization's members' identity events must never
-      // land in the shared platform log, and enrollment alone does not
-      // enforce that.
+    // This used to refuse outright, because a member's identity events could
+    // not be placed anywhere. They can be now — on the shared instance, like
+    // every other user — so the operator's targeted lever reaches these
+    // organizations like any other, and the run gets as far as reading
+    // members rather than being turned away at the door.
+    it("runs rather than refusing, and reads the organization's members", async () => {
       await expect(
         runSystemMigrationTargetedPass({
           organizationId: "org_private",
           migrationName: IDENTITY_IDENTIFIER_BACKFILL_MIGRATION_NAME,
         }),
-      ).rejects.toMatchObject({
-        code: "migration_not_available_on_installation",
-      });
-      expect(stubs.organizationUserFindMany).not.toHaveBeenCalled();
+      ).resolves.toBeDefined();
+      expect(stubs.organizationUserFindMany).toHaveBeenCalled();
     });
   });
 });

--- a/platform/app/src/server/app-layer/system-migrations/cohort.ts
+++ b/platform/app/src/server/app-layer/system-migrations/cohort.ts
@@ -32,10 +32,22 @@
  * instance when one is configured, refusing to fall back to the shared
  * client rather than leaking. Leaving those organizations out would strand
  * them on their legacy path forever - the very drift an automatic cohort
- * exists to end. The USER-rooted cohort is the case that genuinely cannot
- * place its events: a user tenant resolves to neither a project nor an
- * organization, so `userMigrationPassCohort` excludes private-dataplane
- * members there, and only there.
+ * exists to end.
+ *
+ * The USER-rooted cohort places its events too, and a USER is a tenant kind
+ * in its own right for that purpose - not a project, not an organization,
+ * and not resolved into either, because a tenant is a PROJECT id and one
+ * user reaches many projects across many organizations with no single one of
+ * them to call theirs. Identity history is platform-level, so it lands on the
+ * shared instance.
+ *
+ * What `userMigrationPassCohort` still excludes, there and only there, is a
+ * private-dataplane MEMBER. That is a residency rule rather than a routing
+ * gap: their identity events would land in the shared platform log while
+ * their organization's own data stays on its private instance, and no
+ * instance is the right answer for somebody who spans both. The resolver
+ * refuses that case on its own account, so the exclusion is a backstop
+ * rather than the only thing standing between us and a leak.
  *
  * SELF-HOSTED is paced per migration, at release time, by the migration's
  * own `runsAutomaticallyOnSelfHosted` declaration. There is no enrollment

--- a/platform/app/src/server/app-layer/system-migrations/cohort.ts
+++ b/platform/app/src/server/app-layer/system-migrations/cohort.ts
@@ -42,12 +42,12 @@
  * shared instance.
  *
  * What `userMigrationPassCohort` still excludes, there and only there, is a
- * private-dataplane MEMBER. That is a residency rule rather than a routing
- * gap: their identity events would land in the shared platform log while
- * their organization's own data stays on its private instance, and no
- * instance is the right answer for somebody who spans both. The resolver
- * refuses that case on its own account, so the exclusion is a backstop
- * rather than the only thing standing between us and a leak.
+ * private-dataplane MEMBER. That exclusion is now PACING, not correctness:
+ * the resolver routes every user tenant to the shared instance without
+ * consulting membership at all, so such a person has a perfectly good answer
+ * and would migrate like anybody else. Dropping the exclusion is a product
+ * call about backfilling those people, not a routing question - until it is
+ * made, they simply are not enrolled.
  *
  * SELF-HOSTED is paced per migration, at release time, by the migration's
  * own `runsAutomaticallyOnSelfHosted` declaration. There is no enrollment

--- a/platform/app/src/server/app-layer/system-migrations/cohort.ts
+++ b/platform/app/src/server/app-layer/system-migrations/cohort.ts
@@ -41,13 +41,13 @@
  * them to call theirs. Identity history is platform-level, so it lands on the
  * shared instance.
  *
- * What `userMigrationPassCohort` still excludes, there and only there, is a
- * private-dataplane MEMBER. That exclusion is now PACING, not correctness:
- * the resolver routes every user tenant to the shared instance without
- * consulting membership at all, so such a person has a perfectly good answer
- * and would migrate like anybody else. Dropping the exclusion is a product
- * call about backfilling those people, not a routing question - until it is
- * made, they simply are not enrolled.
+ * `userMigrationPassCohort` used to except a private-dataplane MEMBER, and no
+ * longer does. That exception existed because a user tenant could not be
+ * placed at all; now it can - the resolver routes every user tenant to the
+ * shared instance without consulting membership - so the person has a
+ * perfectly good answer and migrates like anybody else. Keeping them out
+ * would have stranded exactly them on the legacy path, which is the reason
+ * this axis does not hold their organizations back either.
  *
  * SELF-HOSTED is paced per migration, at release time, by the migration's
  * own `runsAutomaticallyOnSelfHosted` declaration. There is no enrollment

--- a/platform/app/src/server/app-layer/system-migrations/runtime.ts
+++ b/platform/app/src/server/app-layer/system-migrations/runtime.ts
@@ -34,7 +34,6 @@ import {
   migrationRunsOnThisInstallation,
   organizationMigrates,
 } from "./cohort";
-import { MigrationNotAvailableOnInstallationError } from "./errors";
 import { RedisMigrationLeaseRepository } from "./repositories/migration-lease.redis.repository";
 import { PrismaOrganizationTenantSource } from "./repositories/organization-tenant-source.prisma.repository";
 import { PrismaSystemMigrationEnrollmentRepository } from "./repositories/system-migration-enrollment.prisma.repository";
@@ -286,16 +285,22 @@ export async function migrationPassCohort(): Promise<
  * every organization. Enrollment is read once, fresh, at the start of each
  * pass; membership is answered per candidate user with two cheap indexed
  * reads rather than materializing every enrolled organization's member list
- * into memory (the runner visits each user once per pass). Members of
- * private-dataplane organizations are excluded exactly as those
- * organizations are. A user outside every organization has nothing to enroll
- * them on cloud and stays on the legacy path until they join one; their
- * sign-in is unaffected (the write gate answers false; the D03 read fork
- * falls back to legacy routing).
+ * into memory (the runner visits each user once per pass). A user outside
+ * every organization has nothing to enroll them on cloud and stays on the
+ * legacy path until they join one; their sign-in is unaffected (the write
+ * gate answers false; the D03 read fork falls back to legacy routing).
  *
  * A user-rooted migration declaring `enrolledAutomatically` admits every
- * user instead, private-dataplane members still excepted - the same rule the
- * organization cohort applies, on this axis.
+ * user instead.
+ *
+ * Membership of a private-dataplane organization is NOT a reason to leave
+ * somebody out, and used to be: a user tenant could not be placed at all, so
+ * excluding them was the only way to avoid writing somewhere wrong. It can
+ * be placed now - user data lands on the shared instance, whoever they
+ * belong to, because what these events record is how a person signs in
+ * rather than any organization's data. Excluding them would strand exactly
+ * those people on the legacy path forever, which is the same reason the
+ * organization cohort never excluded their organizations.
  */
 export async function userMigrationPassCohort(): Promise<
   (args: { tenantId: string; migrationName: string }) => Promise<boolean>
@@ -304,39 +309,16 @@ export async function userMigrationPassCohort(): Promise<
   const automatic = automaticallyEnrolledMigrationNames();
   const enrolledByMigration =
     await enrollmentRepository.findEnrolledOrganizationIdsByMigration();
-  // The same exclusion the organization cohort applies: a private-dataplane
-  // organization is never swept up, and neither are its members - a user's
-  // identity events would otherwise land in the shared platform log while
-  // the organization's own data stays on its private instance. It survives
-  // an automatic enrollment too: that declaration widens WHO the rollout
-  // reaches, and this exclusion is not pacing but where the events land.
-  const privateOrganizationIds = [...getPrivateClickHouseUrls().keys()];
-  const belongsToPrivateDataplane = async (
-    userId: string,
-  ): Promise<boolean> => {
-    if (privateOrganizationIds.length === 0) return false;
-    const membership = await prisma.organizationUser.findFirst({
-      where: { userId, organizationId: { in: privateOrganizationIds } },
-      select: { userId: true },
-    });
-    return membership !== null;
-  };
-  const enrolledPublicByMigration = new Map<string, string[]>();
+  const enrolledByMigrationList = new Map<string, string[]>();
   for (const migration of registeredUserMigrations()) {
-    enrolledPublicByMigration.set(
-      migration.name,
-      [
-        ...(enrolledByMigration.get(migration.name) ?? new Set<string>()),
-      ].filter((id) => !privateOrganizationIds.includes(id)),
-    );
+    enrolledByMigrationList.set(migration.name, [
+      ...(enrolledByMigration.get(migration.name) ?? new Set<string>()),
+    ]);
   }
   return async ({ tenantId, migrationName }) => {
-    if (automatic.has(migrationName)) {
-      return !(await belongsToPrivateDataplane(tenantId));
-    }
-    const organizationIds = enrolledPublicByMigration.get(migrationName) ?? [];
+    if (automatic.has(migrationName)) return true;
+    const organizationIds = enrolledByMigrationList.get(migrationName) ?? [];
     if (organizationIds.length === 0) return false;
-    if (await belongsToPrivateDataplane(tenantId)) return false;
     const enrolledMembership = await prisma.organizationUser.findFirst({
       where: { userId: tenantId, organizationId: { in: organizationIds } },
       select: { userId: true },
@@ -420,18 +402,6 @@ export async function runSystemMigrationTargetedPass({
     (migration) => migration.name === migrationName,
   );
   if (userMigration) {
-    // The same exclusion `userMigrationPassCohort` applies: a
-    // private-dataplane organization's members are never swept up - their
-    // identity events would land in the shared platform log while the
-    // organization's own data stays on its private instance - and neither
-    // enrollment nor an automatic declaration carries that rule, so the
-    // targeted run refuses outright.
-    if (
-      env.IS_SAAS === true &&
-      getPrivateClickHouseUrls().has(organizationId)
-    ) {
-      throw new MigrationNotAvailableOnInstallationError();
-    }
     const runner = new SystemMigrationRunnerService({
       state: systemMigrationState,
       lease: new RedisMigrationLeaseRepository(redis),

--- a/platform/app/src/server/clickhouse/__tests__/clickhouseClient.integration.test.ts
+++ b/platform/app/src/server/clickhouse/__tests__/clickhouseClient.integration.test.ts
@@ -361,7 +361,7 @@ describe("ClickHouse routing via env vars", () => {
      * instance.
      */
     /** @scenario A user is a tenant in its own right */
-    it("routes a user with no private membership to the shared instance", async () => {
+    it("routes a user to the shared instance", async () => {
       const { getClickHouseClientForTenant } = await import(
         "../clickhouseClient"
       );
@@ -375,13 +375,18 @@ describe("ClickHouse routing via env vars", () => {
     });
 
     /**
-     * The one case the refusal is actually for. This person's identity events
-     * would land in the shared platform log while their organization's own
-     * data stays on its private instance, so there is no answer to give and
-     * the resolver says so rather than picking one.
+     * The case that decides whether membership enters into it at all: this
+     * person belongs to an organization with its own ClickHouse. They still
+     * route to the shared instance, because what is being written is how they
+     * sign in rather than any organization's data — true of them before,
+     * across and after every organization they belong to.
+     *
+     * Pinned because the cheap reading is that a private-dataplane member
+     * must follow their organization, and a membership lookup here would be
+     * both a query per resolution and an answer that changes under a join.
      */
-    /** @scenario A user inside a private-dataplane organization is refused */
-    it("refuses a user who belongs to a private-dataplane organization", async () => {
+    /** @scenario A user in a private-dataplane organization still routes to shared */
+    it("routes a user who belongs to a private-dataplane organization to the shared instance", async () => {
       const { getClickHouseClientForTenant } = await import(
         "../clickhouseClient"
       );
@@ -406,9 +411,7 @@ describe("ClickHouse routing via env vars", () => {
         data: { userId: user.id, organizationId, role: "MEMBER" },
       });
 
-      await expect(getClickHouseClientForTenant(user.id)).rejects.toThrow(
-        user.id,
-      );
+      expect(await getClickHouseClientForTenant(user.id)).toBe(sharedClient);
     });
   });
 

--- a/platform/app/src/server/clickhouse/__tests__/clickhouseClient.integration.test.ts
+++ b/platform/app/src/server/clickhouse/__tests__/clickhouseClient.integration.test.ts
@@ -375,48 +375,49 @@ describe("ClickHouse routing via env vars", () => {
     });
 
     /**
-     * The case that decides whether membership enters into it at all: this
-     * person belongs to an organization with its own ClickHouse. They still
-     * route to the shared instance, because what is being written is how they
-     * sign in rather than any organization's data — true of them before,
-     * across and after every organization they belong to.
+     * The case that decides whether membership enters into it at all. They
+     * still route to the shared instance, because what is being written is
+     * how they sign in rather than any organization's data — true of them
+     * before, across and after every organization they belong to.
      *
      * Pinned because the cheap reading is that a private-dataplane member
      * must follow their organization, and a membership lookup here would be
      * both a query per resolution and an answer that changes under a join.
      */
-    /** @scenario A user in a private-dataplane organization still routes to shared */
-    it("routes a user who belongs to a private-dataplane organization to the shared instance", async () => {
-      const { getClickHouseClientForTenant } = await import(
-        "../clickhouseClient"
-      );
+    describe("given the user belongs to a private-dataplane organization", () => {
+      /** @scenario A user in a private-dataplane organization still routes to shared */
+      it("routes that user to the shared instance", async () => {
+        const { getClickHouseClientForTenant } = await import(
+          "../clickhouseClient"
+        );
 
-      const { organizationId, teamId, projectId } =
-        await createTestOrgWithProject({
-          namespace: "private-member",
-          organizationId: PRIVATE_ORG_ID,
+        const { organizationId, teamId, projectId } =
+          await createTestOrgWithProject({
+            namespace: "private-member",
+            organizationId: PRIVATE_ORG_ID,
+          });
+        createdProjectIds.push(projectId);
+        createdTeamIds.push(teamId);
+        createdOrgIds.push(organizationId);
+
+        const user = await prisma.user.create({
+          data: {
+            email: `ch-private-${nanoid(8)}@example.com`,
+            name: "CH Private User",
+          },
         });
-      createdProjectIds.push(projectId);
-      createdTeamIds.push(teamId);
-      createdOrgIds.push(organizationId);
+        createdUserIds.push(user.id);
+        await prisma.organizationUser.create({
+          data: { userId: user.id, organizationId, role: "MEMBER" },
+        });
 
-      const user = await prisma.user.create({
-        data: {
-          email: `ch-private-${nanoid(8)}@example.com`,
-          name: "CH Private User",
-        },
+        expect(await getClickHouseClientForTenant(user.id)).toBe(sharedClient);
       });
-      createdUserIds.push(user.id);
-      await prisma.organizationUser.create({
-        data: { userId: user.id, organizationId, role: "MEMBER" },
-      });
-
-      expect(await getClickHouseClientForTenant(user.id)).toBe(sharedClient);
     });
   });
 
   describe("when the tenant names no project, organization or user", () => {
-    /** @scenario A tenant that names neither a project nor an organization is refused */
+    /** @scenario A tenant that names no project, organization or user is refused */
     it("refuses rather than falling back to the shared client", async () => {
       const { getClickHouseClientForTenant } = await import(
         "../clickhouseClient"

--- a/platform/app/src/server/clickhouse/__tests__/clickhouseClient.integration.test.ts
+++ b/platform/app/src/server/clickhouse/__tests__/clickhouseClient.integration.test.ts
@@ -85,13 +85,27 @@ async function createTestOrgWithProject({
   const teamSlug = `--test-ch-team-${namespace}-${nanoid(6)}`;
   const projectSlug = `--test-ch-proj-${namespace}-${nanoid(6)}`;
 
-  const organization = await prisma.organization.create({
-    data: {
-      ...(organizationId ? { id: organizationId } : {}),
-      name: `Test CH Routing Org ${namespace}`,
-      slug: orgSlug,
-    },
-  });
+  // Upserted rather than created when the caller names the id, because two
+  // scenarios want a routed organization at the SAME id — the routing env var
+  // is keyed by it — and the rows live until `afterAll`. Creating twice made
+  // whichever ran second fail on the primary key, which is an ordering
+  // dependency rather than anything either scenario is about.
+  const organization = organizationId
+    ? await prisma.organization.upsert({
+        where: { id: organizationId },
+        update: {},
+        create: {
+          id: organizationId,
+          name: `Test CH Routing Org ${namespace}`,
+          slug: orgSlug,
+        },
+      })
+    : await prisma.organization.create({
+        data: {
+          name: `Test CH Routing Org ${namespace}`,
+          slug: orgSlug,
+        },
+      });
 
   const team = await prisma.team.create({
     data: {
@@ -122,6 +136,7 @@ async function createTestOrgWithProject({
 const createdProjectIds: string[] = [];
 const createdTeamIds: string[] = [];
 const createdOrgIds: string[] = [];
+const createdUserIds: string[] = [];
 
 /**
  * Mock the shared client to return our shared test container client.
@@ -169,6 +184,13 @@ describe("ClickHouse routing via env vars", () => {
     await clearCustomClientCache();
     clearTenantOrgCache();
 
+    // Memberships name both an organization and a user, so they have to go
+    // before either does; nothing cascades here.
+    if (createdOrgIds.length > 0) {
+      await prisma.organizationUser.deleteMany({
+        where: { organizationId: { in: createdOrgIds } },
+      });
+    }
     if (createdProjectIds.length > 0) {
       await prisma.project.deleteMany({
         where: { id: { in: createdProjectIds } },
@@ -181,6 +203,9 @@ describe("ClickHouse routing via env vars", () => {
       await prisma.organization.deleteMany({
         where: { id: { in: createdOrgIds } },
       });
+    }
+    if (createdUserIds.length > 0) {
+      await prisma.user.deleteMany({ where: { id: { in: createdUserIds } } });
     }
 
     await Promise.all([sharedClient?.close(), privateClient?.close()]);
@@ -321,7 +346,73 @@ describe("ClickHouse routing via env vars", () => {
     });
   });
 
-  describe("when the tenant names neither a project nor an organization", () => {
+  describe("when the tenant is a user rather than a project", () => {
+    /**
+     * The identity aggregate is keyed by USER (D01, ADR-101 §6), so this is
+     * the id its event-store writes arrive with. The resolver knew two kinds
+     * of tenant and refused this one, which meant no identity event ever
+     * appended, the fold never ran, and the backfill's parity proof reported
+     * `identifier_missing` for every user on every pass — forever.
+     *
+     * A user is not resolved into an organization, and deliberately so: a
+     * tenant is a PROJECT id, one user reaches many projects across many
+     * organizations, and there is no single one of them to call theirs.
+     * Identity history is platform-level, so it routes to the shared
+     * instance.
+     */
+    /** @scenario A user is a tenant in its own right */
+    it("routes a user with no private membership to the shared instance", async () => {
+      const { getClickHouseClientForTenant } = await import(
+        "../clickhouseClient"
+      );
+
+      const user = await prisma.user.create({
+        data: { email: `ch-routing-${nanoid(8)}@example.com`, name: "CH User" },
+      });
+      createdUserIds.push(user.id);
+
+      expect(await getClickHouseClientForTenant(user.id)).toBe(sharedClient);
+    });
+
+    /**
+     * The one case the refusal is actually for. This person's identity events
+     * would land in the shared platform log while their organization's own
+     * data stays on its private instance, so there is no answer to give and
+     * the resolver says so rather than picking one.
+     */
+    /** @scenario A user inside a private-dataplane organization is refused */
+    it("refuses a user who belongs to a private-dataplane organization", async () => {
+      const { getClickHouseClientForTenant } = await import(
+        "../clickhouseClient"
+      );
+
+      const { organizationId, teamId, projectId } =
+        await createTestOrgWithProject({
+          namespace: "private-member",
+          organizationId: PRIVATE_ORG_ID,
+        });
+      createdProjectIds.push(projectId);
+      createdTeamIds.push(teamId);
+      createdOrgIds.push(organizationId);
+
+      const user = await prisma.user.create({
+        data: {
+          email: `ch-private-${nanoid(8)}@example.com`,
+          name: "CH Private User",
+        },
+      });
+      createdUserIds.push(user.id);
+      await prisma.organizationUser.create({
+        data: { userId: user.id, organizationId, role: "MEMBER" },
+      });
+
+      await expect(getClickHouseClientForTenant(user.id)).rejects.toThrow(
+        user.id,
+      );
+    });
+  });
+
+  describe("when the tenant names no project, organization or user", () => {
     /** @scenario A tenant that names neither a project nor an organization is refused */
     it("refuses rather than falling back to the shared client", async () => {
       const { getClickHouseClientForTenant } = await import(

--- a/platform/app/src/server/clickhouse/clickhouseClient.ts
+++ b/platform/app/src/server/clickhouse/clickhouseClient.ts
@@ -84,29 +84,17 @@ const customClientCache = new Map<string, ClickHouseClient>();
 const tenantOrgCache = new Map<string, string>();
 
 /**
- * Users whose identity events route to the shared instance. Cached apart from
- * `tenantOrgCache` because a user resolves to no organization at all — that
- * is the whole point of them — so there is nothing to key there.
+ * Tenants known to be users, whose events route to the shared instance.
+ * Cached apart from `tenantOrgCache` because a user resolves to no
+ * organization at all — that is the whole point of them — so there is
+ * nothing to key there.
  *
- * WITH A TTL, because unlike `tenantOrgCache` this caches something that
- * CHANGES. A project's owning organization is immutable; "this user belongs
- * to no private-dataplane organization" stops being true the moment they join
- * one. The cache was write-only, so a user resolved once before joining kept
- * having their identity events written to the shared platform log for the
- * rest of the process's life — the exact case the guard below exists for,
- * defeated by remembering the answer from before it mattered.
+ * No TTL, for the same reason `tenantOrgCache` needs none: what it remembers
+ * cannot change. "This id names a user" is immutable, and a user's instance
+ * does not depend on anything they might later join, so an answer cached once
+ * stays right for the life of the process.
  */
-const SHARED_USER_TENANT_TTL_MS = 60_000;
-const sharedUserTenantCache = new Map<string, number>();
-
-/** Whether this user is still known to be on the shared instance. */
-function sharedUserTenantIsFresh(tenantId: string, nowMs: number): boolean {
-  const at = sharedUserTenantCache.get(tenantId);
-  if (at === undefined) return false;
-  if (nowMs - at < SHARED_USER_TENANT_TTL_MS) return true;
-  sharedUserTenantCache.delete(tenantId);
-  return false;
-}
+const userTenantCache = new Set<string>();
 
 /**
  * Returns the appropriate ClickHouse client for a given tenant.
@@ -136,29 +124,25 @@ function sharedUserTenantIsFresh(tenantId: string, nowMs: number): boolean {
  * identity aggregate is keyed by user precisely because the user is the
  * thing that persists across all of them.
  *
- * A single sentinel — routing every user-scoped append to one "global"
- * tenant — was the other candidate and is worse: it would throw away the
+ * A single sentinel — rewriting every user-scoped append to one "global"
+ * TENANT id — was the other candidate and is worse: it would throw away the
  * scoping that makes every guarantee in this file checkable, and one
- * unplaceable user would become indistinguishable from every other.
+ * unplaceable user would become indistinguishable from every other. The
+ * tenant id stays the user's. It is the INSTANCE that is global.
  *
  * That leaves one question this function actually has to answer — which
- * INSTANCE — and identity history is platform-level rather than any
- * organization's data, so the shared one is where it belongs.
+ * instance — and user data always lands on the shared one. Identity history
+ * is platform-level rather than any organization's data: it is how a person
+ * signs in, which is true of them before, across and after every
+ * organization they belong to. So a user tenant does not consult private
+ * routing at all — the answer does not depend on it, and there is nothing
+ * for a membership to change.
  *
  * This kind arrived unsupported: appends for it threw the refusal below, so
  * no identity event ever reached the log, the fold never ran, and the
  * backfill's parity proof reported `identifier_missing` for every user on
  * every pass. Nothing was corrupted — the guard refused rather than writing
  * somewhere wrong — but nothing could ever finish either.
- *
- * The exception is the case the guard exists for. A user who belongs to a
- * private-dataplane organization is refused, because their identity events
- * would land in the shared platform log while that organization's own data
- * stays on its private instance — which is the same reason
- * `userMigrationPassCohort` already excludes them from the backfill. Re-proved
- * here rather than trusted from the cohort, so the guarantee holds for every
- * caller and not just that one. The check costs nothing when no private
- * instance is configured, which is every installation but ours.
  *
  * An id that names none of the three kinds is still an error rather than the
  * shared client: a tenant we cannot place is exactly the one whose data must
@@ -167,16 +151,14 @@ function sharedUserTenantIsFresh(tenantId: string, nowMs: number): boolean {
 export async function getClickHouseClientForTenant(
   tenantId: string,
 ): Promise<ClickHouseClient | null> {
-  if (sharedUserTenantIsFresh(tenantId, Date.now())) {
-    return sharedClickHouseClientOrThrow();
-  }
+  if (userTenantCache.has(tenantId)) return sharedClickHouseClientOrThrow();
 
   const cached = tenantOrgCache.get(tenantId);
   if (cached) return getClickHouseClientForOrganization(cached);
 
   const orgId = await organizationIdForTenant(tenantId);
   if (orgId === null) {
-    sharedUserTenantCache.set(tenantId, Date.now());
+    userTenantCache.add(tenantId);
     return sharedClickHouseClientOrThrow();
   }
 
@@ -190,7 +172,7 @@ export async function getClickHouseClientForTenant(
  *
  * The three kinds are asked for in the order they are cheap: a project names
  * its organization in one join, an organization names itself, and only an id
- * that is neither costs the membership check. An id that names none of them
+ * that is neither costs the user lookup. An id that names none of them
  * throws rather than resolving.
  */
 async function organizationIdForTenant(
@@ -208,39 +190,27 @@ async function organizationIdForTenant(
   });
   if (organization) return organization.id;
 
-  if (await tenantIsUserOnSharedInstance(tenantId)) return null;
+  if (await tenantIsUser(tenantId)) return null;
 
   throw new Error(
-    `Cannot resolve ClickHouse client: tenant "${tenantId}" is neither a project, an organization, nor a user on the shared instance. Refusing to fall back to shared client to prevent data leakage.`,
+    `Cannot resolve ClickHouse client: tenant "${tenantId}" is neither a project, an organization, nor a user. Refusing to fall back to shared client to prevent data leakage.`,
   );
 }
 
 /**
- * Whether this tenant is a USER whose events belong on the shared instance:
- * the user row exists, and they hold no membership of any organization routed
- * to a private ClickHouse.
+ * Whether this tenant names a USER, whose events go to the shared instance.
  *
- * The membership query is skipped entirely when no private instance is
- * configured, because then there is no other instance for anything to leak
- * onto and the answer cannot be anything but yes.
+ * Only the row's existence is asked. Which organizations they belong to, and
+ * whether any of those has a private ClickHouse, does not enter into it: user
+ * data lands on the shared instance either way, so there is no membership for
+ * a query to discover and nothing about it that can later change the answer.
  */
-async function tenantIsUserOnSharedInstance(
-  tenantId: string,
-): Promise<boolean> {
+async function tenantIsUser(tenantId: string): Promise<boolean> {
   const user = await prisma.user.findUnique({
     where: { id: tenantId },
     select: { id: true },
   });
-  if (!user) return false;
-
-  const privateOrganizationIds = [...privateClickHouseUrls.keys()];
-  if (privateOrganizationIds.length === 0) return true;
-
-  const privateMembership = await prisma.organizationUser.findFirst({
-    where: { userId: tenantId, organizationId: { in: privateOrganizationIds } },
-    select: { userId: true },
-  });
-  return privateMembership === null;
+  return user !== null;
 }
 
 /** The shared client, or the configuration error that explains its absence. */

--- a/platform/app/src/server/clickhouse/clickhouseClient.ts
+++ b/platform/app/src/server/clickhouse/clickhouseClient.ts
@@ -84,15 +84,14 @@ const customClientCache = new Map<string, ClickHouseClient>();
 const tenantOrgCache = new Map<string, string>();
 
 /**
- * Tenants known to be users, whose events route to the shared instance.
- * Cached apart from `tenantOrgCache` because a user resolves to no
- * organization at all — that is the whole point of them — so there is
- * nothing to key there.
+ * Tenants already known to name a user. Kept separately from
+ * `tenantOrgCache` because a user has no organization to key there — the
+ * answer is the shared instance, not an org id.
  *
- * No TTL, for the same reason `tenantOrgCache` needs none: what it remembers
- * cannot change. "This id names a user" is immutable, and a user's instance
- * does not depend on anything they might later join, so an answer cached once
- * stays right for the life of the process.
+ * Grows with the number of DISTINCT users a process resolves, which unlike
+ * projects and organizations is not bounded by how many exist: a backfill
+ * walks the whole user table. Acceptable because the entries are ids, and
+ * because the lookups it saves are on the hot path of every identity append.
  */
 const userTenantCache = new Set<string>();
 
@@ -144,6 +143,18 @@ const userTenantCache = new Set<string>();
  * every pass. Nothing was corrupted — the guard refused rather than writing
  * somewhere wrong — but nothing could ever finish either.
  *
+ * ── The order below ────────────────────────────────────────────────────
+ *
+ * The user is asked for FIRST and asked for DIRECTLY: one lookup that says
+ * user or not, rather than reaching the answer by elimination. Deriving it —
+ * "no project and no organization, so it must be a person" — makes the most
+ * important routing decision in this file the one nothing states, and every
+ * future tenant kind silently joins that same branch.
+ *
+ * Both caches are consulted before either query, so asking about the user
+ * first costs a project tenant one extra lookup on its first resolution and
+ * nothing afterwards.
+ *
  * An id that names none of the three kinds is still an error rather than the
  * shared client: a tenant we cannot place is exactly the one whose data must
  * not land on somebody else's instance.
@@ -153,31 +164,29 @@ export async function getClickHouseClientForTenant(
 ): Promise<ClickHouseClient | null> {
   if (userTenantCache.has(tenantId)) return sharedClickHouseClientOrThrow();
 
-  const cached = tenantOrgCache.get(tenantId);
-  if (cached) return getClickHouseClientForOrganization(cached);
+  const cachedOrgId = tenantOrgCache.get(tenantId);
+  if (cachedOrgId) return getClickHouseClientForOrganization(cachedOrgId);
 
-  const orgId = await organizationIdForTenant(tenantId);
-  if (orgId === null) {
+  if (await tenantIsUser(tenantId)) {
     userTenantCache.add(tenantId);
     return sharedClickHouseClientOrThrow();
   }
 
+  const orgId = await organizationIdForTenant(tenantId);
   tenantOrgCache.set(tenantId, orgId);
   return getClickHouseClientForOrganization(orgId);
 }
 
 /**
- * Which organization's instance a tenant belongs to, or `null` when the
- * tenant is a user whose history belongs on the shared instance.
+ * Which organization's instance this tenant routes to. Called only once the
+ * tenant is known not to be a user, so it answers for the two kinds that
+ * resolve per-organization: a project names its owner, an organization names
+ * itself.
  *
- * The three kinds are asked for in the order they are cheap: a project names
- * its organization in one join, an organization names itself, and only an id
- * that is neither costs the user lookup. An id that names none of them
- * throws rather than resolving.
+ * An id that is none of the three throws rather than resolving — by the time
+ * this runs, every kind we support has been asked for.
  */
-async function organizationIdForTenant(
-  tenantId: string,
-): Promise<string | null> {
+async function organizationIdForTenant(tenantId: string): Promise<string> {
   const project = await prisma.project.findUnique({
     where: { id: tenantId },
     select: { team: { select: { organizationId: true } } },
@@ -189,8 +198,6 @@ async function organizationIdForTenant(
     select: { id: true },
   });
   if (organization) return organization.id;
-
-  if (await tenantIsUser(tenantId)) return null;
 
   throw new Error(
     `Cannot resolve ClickHouse client: tenant "${tenantId}" is neither a project, an organization, nor a user. Refusing to fall back to shared client to prevent data leakage.`,

--- a/platform/app/src/server/clickhouse/clickhouseClient.ts
+++ b/platform/app/src/server/clickhouse/clickhouseClient.ts
@@ -84,50 +84,175 @@ const customClientCache = new Map<string, ClickHouseClient>();
 const tenantOrgCache = new Map<string, string>();
 
 /**
+ * Users whose identity events route to the shared instance. Cached apart from
+ * `tenantOrgCache` because a user resolves to no organization at all — that
+ * is the whole point of them — so there is nothing to key there.
+ *
+ * WITH A TTL, because unlike `tenantOrgCache` this caches something that
+ * CHANGES. A project's owning organization is immutable; "this user belongs
+ * to no private-dataplane organization" stops being true the moment they join
+ * one. The cache was write-only, so a user resolved once before joining kept
+ * having their identity events written to the shared platform log for the
+ * rest of the process's life — the exact case the guard below exists for,
+ * defeated by remembering the answer from before it mattered.
+ */
+const SHARED_USER_TENANT_TTL_MS = 60_000;
+const sharedUserTenantCache = new Map<string, number>();
+
+/** Whether this user is still known to be on the shared instance. */
+function sharedUserTenantIsFresh(tenantId: string, nowMs: number): boolean {
+  const at = sharedUserTenantCache.get(tenantId);
+  if (at === undefined) return false;
+  if (nowMs - at < SHARED_USER_TENANT_TTL_MS) return true;
+  sharedUserTenantCache.delete(tenantId);
+  return false;
+}
+
+/**
  * Returns the appropriate ClickHouse client for a given tenant.
  *
- * A tenant is usually a project, and was only ever a project until the grants
- * ledger (ADR-092 §13) put an aggregate per ORGANIZATION into the same event
- * store. Both kinds resolve here because routing is per-organization either
- * way: a project contributes the organization that owns it, and an
- * organization contributes itself.
+ * THREE kinds of tenant reach this function, one per kind of aggregate the
+ * event store holds:
  *
- * Resolves that organization (cached), then checks for a private ClickHouse
- * env var for it. Falls back to the shared client.
+ *   - a PROJECT, which is what a tenant was and mostly still is;
+ *   - an ORGANIZATION, since the grants ledger (ADR-092 §13) put an
+ *     aggregate per organization into the same store;
+ *   - a USER, since the identity aggregate (D01, ADR-101 §6) is keyed by the
+ *     person rather than by anything they belong to.
  *
- * An id that names neither is still an error rather than the shared client:
- * a tenant we cannot place is exactly the one whose data must not land on
- * somebody else's instance.
+ * The first two resolve the same way, because routing is per-organization
+ * for both: a project contributes the organization that owns it, and an
+ * organization contributes itself. That organization (cached) decides
+ * whether a private ClickHouse env var applies.
+ *
+ * ── Why a USER is its own kind, and not resolved into an organization ───
+ *
+ * The user IS the tenant for a user-scoped aggregate, and the id stays the
+ * user's. It is tempting to resolve one into an organization the way a
+ * project resolves into its owner, and that is the trap: a tenant is a
+ * PROJECT id, one user reaches many projects across many organizations, and
+ * there is no "the organization" for them to contribute. Any mapping we
+ * invented would be picking one of several equally true answers. The
+ * identity aggregate is keyed by user precisely because the user is the
+ * thing that persists across all of them.
+ *
+ * A single sentinel — routing every user-scoped append to one "global"
+ * tenant — was the other candidate and is worse: it would throw away the
+ * scoping that makes every guarantee in this file checkable, and one
+ * unplaceable user would become indistinguishable from every other.
+ *
+ * That leaves one question this function actually has to answer — which
+ * INSTANCE — and identity history is platform-level rather than any
+ * organization's data, so the shared one is where it belongs.
+ *
+ * This kind arrived unsupported: appends for it threw the refusal below, so
+ * no identity event ever reached the log, the fold never ran, and the
+ * backfill's parity proof reported `identifier_missing` for every user on
+ * every pass. Nothing was corrupted — the guard refused rather than writing
+ * somewhere wrong — but nothing could ever finish either.
+ *
+ * The exception is the case the guard exists for. A user who belongs to a
+ * private-dataplane organization is refused, because their identity events
+ * would land in the shared platform log while that organization's own data
+ * stays on its private instance — which is the same reason
+ * `userMigrationPassCohort` already excludes them from the backfill. Re-proved
+ * here rather than trusted from the cohort, so the guarantee holds for every
+ * caller and not just that one. The check costs nothing when no private
+ * instance is configured, which is every installation but ours.
+ *
+ * An id that names none of the three kinds is still an error rather than the
+ * shared client: a tenant we cannot place is exactly the one whose data must
+ * not land on somebody else's instance.
  */
 export async function getClickHouseClientForTenant(
   tenantId: string,
 ): Promise<ClickHouseClient | null> {
-  let orgId = tenantOrgCache.get(tenantId);
-
-  if (!orgId) {
-    const project = await prisma.project.findUnique({
-      where: { id: tenantId },
-      select: { team: { select: { organizationId: true } } },
-    });
-    orgId = project?.team.organizationId;
-
-    if (!orgId) {
-      const organization = await prisma.organization.findUnique({
-        where: { id: tenantId },
-        select: { id: true },
-      });
-      if (!organization) {
-        throw new Error(
-          `Cannot resolve ClickHouse client: tenant "${tenantId}" is neither a project nor an organization. Refusing to fall back to shared client to prevent data leakage.`,
-        );
-      }
-      orgId = organization.id;
-    }
-
-    tenantOrgCache.set(tenantId, orgId);
+  if (sharedUserTenantIsFresh(tenantId, Date.now())) {
+    return sharedClickHouseClientOrThrow();
   }
 
+  const cached = tenantOrgCache.get(tenantId);
+  if (cached) return getClickHouseClientForOrganization(cached);
+
+  const orgId = await organizationIdForTenant(tenantId);
+  if (orgId === null) {
+    sharedUserTenantCache.set(tenantId, Date.now());
+    return sharedClickHouseClientOrThrow();
+  }
+
+  tenantOrgCache.set(tenantId, orgId);
   return getClickHouseClientForOrganization(orgId);
+}
+
+/**
+ * Which organization's instance a tenant belongs to, or `null` when the
+ * tenant is a user whose history belongs on the shared instance.
+ *
+ * The three kinds are asked for in the order they are cheap: a project names
+ * its organization in one join, an organization names itself, and only an id
+ * that is neither costs the membership check. An id that names none of them
+ * throws rather than resolving.
+ */
+async function organizationIdForTenant(
+  tenantId: string,
+): Promise<string | null> {
+  const project = await prisma.project.findUnique({
+    where: { id: tenantId },
+    select: { team: { select: { organizationId: true } } },
+  });
+  if (project) return project.team.organizationId;
+
+  const organization = await prisma.organization.findUnique({
+    where: { id: tenantId },
+    select: { id: true },
+  });
+  if (organization) return organization.id;
+
+  if (await tenantIsUserOnSharedInstance(tenantId)) return null;
+
+  throw new Error(
+    `Cannot resolve ClickHouse client: tenant "${tenantId}" is neither a project, an organization, nor a user on the shared instance. Refusing to fall back to shared client to prevent data leakage.`,
+  );
+}
+
+/**
+ * Whether this tenant is a USER whose events belong on the shared instance:
+ * the user row exists, and they hold no membership of any organization routed
+ * to a private ClickHouse.
+ *
+ * The membership query is skipped entirely when no private instance is
+ * configured, because then there is no other instance for anything to leak
+ * onto and the answer cannot be anything but yes.
+ */
+async function tenantIsUserOnSharedInstance(
+  tenantId: string,
+): Promise<boolean> {
+  const user = await prisma.user.findUnique({
+    where: { id: tenantId },
+    select: { id: true },
+  });
+  if (!user) return false;
+
+  const privateOrganizationIds = [...privateClickHouseUrls.keys()];
+  if (privateOrganizationIds.length === 0) return true;
+
+  const privateMembership = await prisma.organizationUser.findFirst({
+    where: { userId: tenantId, organizationId: { in: privateOrganizationIds } },
+    select: { userId: true },
+  });
+  return privateMembership === null;
+}
+
+/** The shared client, or the configuration error that explains its absence. */
+function sharedClickHouseClientOrThrow(): ClickHouseClient {
+  const shared = _getSharedClickHouseClient();
+  if (!shared) {
+    throw new Error(
+      "ClickHouse is not configured. Set the CLICKHOUSE_URL environment variable. " +
+        "See dev/docs/adr/004-docker-dev-environment.md for setup instructions.",
+    );
+  }
+  return shared;
 }
 
 /**
@@ -140,16 +265,7 @@ export async function getClickHouseClientForOrganization(
   organizationId: string,
 ): Promise<ClickHouseClient> {
   const route = privateClickHouseUrls.get(organizationId);
-  if (!route) {
-    const shared = _getSharedClickHouseClient();
-    if (!shared) {
-      throw new Error(
-        "ClickHouse is not configured. Set the CLICKHOUSE_URL environment variable. " +
-          "See dev/docs/adr/004-docker-dev-environment.md for setup instructions.",
-      );
-    }
-    return shared;
-  }
+  if (!route) return sharedClickHouseClientOrThrow();
 
   return getOrCreateCustomClient(organizationId, route);
 }

--- a/platform/app/src/server/clickhouse/clickhouseClient.ts
+++ b/platform/app/src/server/clickhouse/clickhouseClient.ts
@@ -90,8 +90,17 @@ const tenantOrgCache = new Map<string, string>();
  *
  * Grows with the number of DISTINCT users a process resolves, which unlike
  * projects and organizations is not bounded by how many exist: a backfill
- * walks the whole user table. Acceptable because the entries are ids, and
+ * walks the whole user table. Accepted because the entries are ids, and
  * because the lookups it saves are on the hot path of every identity append.
+ *
+ * Deleting a user does NOT evict them, also deliberately. Their id keeps
+ * answering "shared" instead of throwing, and that is not a residency
+ * question: shared is where that person's history already sits, so a late
+ * append lands beside its own siblings rather than on somebody else's
+ * instance. The only guarantee it softens is that an id we cannot place
+ * throws. Erasure appends for a user around their deletion, so evicting on
+ * delete would have to be ordered against that — for a case where the wrong
+ * answer is "wrote to the right instance anyway".
  */
 const userTenantCache = new Set<string>();
 

--- a/specs/migration/system-migrations-runner.feature
+++ b/specs/migration/system-migrations-runner.feature
@@ -134,10 +134,15 @@ Feature: Running system migrations across organizations
   # this axis: these migrations are rooted in the ORGANIZATION, and an
   # organization-rooted append is placed on that organization's own instance
   # by the routing. Leaving them out would strand exactly those customers on
-  # their legacy path forever. The user-rooted axis is the one that cannot
-  # place its events — a user tenant is neither a project nor an
-  # organization — and it excludes those members for that reason
-  # (specs/identity/identifier-model.feature).
+  # their legacy path forever.
+  #
+  # The user-rooted axis says the same thing now, and briefly did not. A user
+  # tenant could not be placed at all, so that axis excluded private-dataplane
+  # members rather than write somewhere wrong. It can be placed now — user
+  # data lands on the shared instance, whoever the person belongs to, because
+  # what those events record is how somebody signs in rather than any
+  # organization's data (specs/private-dataplane/clickhouse-routing.feature).
+  # So neither axis holds anyone back for having a dedicated data plane.
   @unit
   Scenario: An automatic cohort includes a private-dataplane organization
     Given a migration declared enrolled automatically

--- a/specs/private-dataplane/clickhouse-routing.feature
+++ b/specs/private-dataplane/clickhouse-routing.feature
@@ -162,16 +162,22 @@ Feature: Private ClickHouse Routing
   # could not answer. A user is NOT resolved into an organization on the way
   # - somebody can be in several, and picking one would put their identity
   # history on an instance chosen by accident.
+  #
+  # User data always lands on the shared instance. What a user-tenanted event
+  # records is how somebody signs in, which is true of them before, across and
+  # after every organization they belong to - so membership does not enter
+  # into the routing at all.
 
   @integration
   Scenario: A user is a tenant in its own right
-    Given a user who belongs to no private-dataplane organization
+    Given a user
     When the routed client is resolved for that user as the tenant
     Then it answers the shared ClickHouse
     And the user is not resolved into any organization to get there
 
   @integration
-  Scenario: A user inside a private-dataplane organization is refused
+  Scenario: A user in a private-dataplane organization still routes to shared
     Given a user who is a member of an organization with a private ClickHouse
     When the routed client is resolved for that user as the tenant
-    Then the resolution is refused rather than falling back to the shared instance
+    Then it answers the shared ClickHouse
+    And their organization's private instance is not consulted

--- a/specs/private-dataplane/clickhouse-routing.feature
+++ b/specs/private-dataplane/clickhouse-routing.feature
@@ -153,3 +153,25 @@ Feature: Private ClickHouse Routing
     When a row is inserted via the routed client for this project
     Then the row exists in container B
     And the row does NOT exist in container A
+
+  # ── The third tenant kind ──────────────────────────────────────────────
+  #
+  # A tenant was a project, then a project or an organization, and now a
+  # user as well: `user_identity` keeps one aggregate per PERSON, so its
+  # tenantId is a user id and every append asked the resolver a question it
+  # could not answer. A user is NOT resolved into an organization on the way
+  # - somebody can be in several, and picking one would put their identity
+  # history on an instance chosen by accident.
+
+  @integration
+  Scenario: A user is a tenant in its own right
+    Given a user who belongs to no private-dataplane organization
+    When the routed client is resolved for that user as the tenant
+    Then it answers the shared ClickHouse
+    And the user is not resolved into any organization to get there
+
+  @integration
+  Scenario: A user inside a private-dataplane organization is refused
+    Given a user who is a member of an organization with a private ClickHouse
+    When the routed client is resolved for that user as the tenant
+    Then the resolution is refused rather than falling back to the shared instance

--- a/specs/private-dataplane/clickhouse-routing.feature
+++ b/specs/private-dataplane/clickhouse-routing.feature
@@ -97,8 +97,8 @@ Feature: Private ClickHouse Routing
     And no project needs to exist for that id
 
   @integration
-  Scenario: A tenant that names neither a project nor an organization is refused
-    Given an id that matches no project and no organization
+  Scenario: A tenant that names no project, organization or user is refused
+    Given an id that matches no project, no organization and no user
     When a client is resolved for that tenant
     Then resolution fails with an error naming the tenant
     And the shared client is not returned


### PR DESCRIPTION
## What is broken

`user_identity` keeps one aggregate per person, so its `tenantId` is a **user id**. The ClickHouse client resolver knows two tenant kinds — project and organization — so every identity append throws:

```
Cannot resolve ClickHouse client: tenant "<userId>" is neither a project nor
an organization. Refusing to fall back to shared client to prevent data leakage.
```

Group keys in the failures are `<userId>/command/attachIdentifier/user_identity:<userId>`, in the `identity` pipeline.

Consequences, all live:

- no identity event ever reaches the log, so the fold never runs;
- the D01 backfill's parity proof finds an empty `Identifier` table and reports `identifier_missing` on every pass — the write-gate latch never opens;
- MFA enrolment fails with "That setup didn't start" for the same reason;
- the groups retry to exhaustion (~25 attempts, ≈2h27m) and then **block**, which is why the queue shows blocked groups rather than dropped work.

Nothing is corrupted. The guard refused rather than writing somewhere wrong — it is the *right* refusal for an unplaceable tenant, and a user simply was not a kind it knew. But nothing can finish either, so re-running the migration alone does not help: it fails the same way every pass.

The guard itself is five months old (#2543, 2026-03-22, "fail closed on unknown projects"). It is correct for its era — a tenant was only ever a project. What broke it is the set of legitimate kinds growing twice in a week: organization on 2026-08-20 (#7315), user on 2026-08-25.

## Why this PR exists separately

The resolver fix already exists on `feat/identity-wave3-next` (#7531). That PR is **778 files, +100,888/−11,691**, and the failure is in production now. This lifts it and nothing else, so it can land on its own.

**ADR-127 (#7595, merged) does not address this**, and says so itself: it changes the aggregate *id* and keeps the type, leaving `tenantId = userId` exactly as it was. Its own words — "This ADR makes that neither better nor worse, and does not depend on the fix for it."

## The change

`getClickHouseClientForTenant` now resolves **three** kinds:

| tenant | resolves to |
| --- | --- |
| project | the organization that owns it → that org's instance |
| organization | itself → its own instance |
| user | the **shared** instance, always |

**User data always lands on the shared instance, membership included.** What a user-tenanted event records is how somebody signs in — true of them before, across and after every organization they belong to — so it is platform data rather than any organization's, and a private-dataplane membership does not change where it goes. The tenant id stays the user's; it is the *instance* that is global. A sentinel "global" tenant id was the other candidate and is worse: it throws away the scoping that makes every guarantee in this file checkable.

A user is also not resolved *into* an organization. One person reaches many projects across many organizations, so any mapping would pick one of several equally true answers.

**The user is asked for directly, not deduced.** An earlier revision reached the branch by elimination — "no project and no organization, therefore a person" — which made the most consequential routing decision in the file the one nothing stated, and would have silently swallowed a fourth tenant kind. `tenantIsUser` is now asked first, and `organizationIdForTenant` returns an org id or throws, with no null to interpret. Both caches are consulted before either query, so asking about the user first costs a project tenant one extra lookup on its first resolution and nothing after.

An id that names none of the three kinds still throws.

## Migration cohort

`userMigrationPassCohort` used to except anybody belonging to a private-dataplane organization, and `runSystemMigrationTargetedPass` refused those organizations outright. Both existed because a user tenant could not be placed at all.

They can be placed now, so the exception is removed — keeping it would strand exactly those people on the legacy path forever, which is the same reason this axis never held their *organizations* back. Three things go: the per-user membership probe, the filter that dropped private-dataplane organizations out of the enrolled set (so somebody who reaches a migration only through one is now in the cohort), and the targeted run's refusal.

The organization **sampling** defaults are untouched — drawing private-dataplane organizations into a cohort is still an operator's deliberate choice, which is a pacing knob rather than a routing rule.

## Deployment Impact

- **No migration, no schema change, no config change.** Code only.
- On deploy, the blocked `identity` groups need to be **unblocked** to drain — commands are idempotent (content-hashed command ids), so replay is safe.
- Routing for project and organization tenants is unchanged; the only new outcome is that a user tenant resolves instead of throwing.
- Identity events for members of private-dataplane organizations land on the shared instance, and those people now enter the backfill cohort. Both are the deliberate decision above, not side effects.

## Verification

- Two `@integration` scenarios in `specs/private-dataplane/clickhouse-routing.feature`, bound by `@scenario` annotations: a user routes to shared; a user *inside a private-dataplane organization* also routes to shared — pinned because the cheap reading is that they should follow their organization.
- The unknown-tenant scenario was refusing an id that "names neither a project nor an organization", which a user id satisfies and is no longer refused for. It now requires an id naming no project, no organization and no user.
- `runtime-enrollment.unit.test.ts` covers the widened cohort, including somebody who reaches the migration only through a private-dataplane organization, and the targeted run now proceeding rather than refusing.

Relates to #7531, which carries the same resolver change as part of identity wave 3.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * User identity events now route to the shared data service.
  * Routing remains shared even when the user belongs to an organization with a private data service.
  * User migration enrollment now includes users associated with private data services.

* **Bug Fixes**
  * Improved tenant routing and handling for unsupported or unrecognized tenant types.

* **Documentation**
  * Clarified user routing and migration behavior for private data service memberships.

* **Tests**
  * Added coverage for user routing and migration enrollment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->