### PR TITLE
fix(lwql): name the column that does not exist (#7447)

### DIFF
--- a/platform/app/src/features/errors/logic/codes.ts
+++ b/platform/app/src/features/errors/logic/codes.ts
@@ -220,6 +220,7 @@ export const APP_ERROR_CODES = [
   "lwql_reserved_parameter_supplied",
   "lwql_reserved_parameter_type",
   "lwql_unavailable",
+  "lwql_unknown_identifier",
   "lwql_unparseable",
   "malformed_custom_role_permissions",
   "malformed_request",

--- a/platform/app/src/features/errors/logic/presentation.ts
+++ b/platform/app/src/features/errors/logic/presentation.ts
@@ -326,6 +326,19 @@ const presentations = {
       return field ? `There's no field called "${field}".` : "";
     },
   },
+  lwql_unknown_identifier: {
+    title: "This query names a column that doesn't exist",
+    // The name is the whole value of this message, so it is quoted back when
+    // the server's refusal carried it. It may not: the extractor that reads it
+    // fails closed rather than relaying the raw refusal, so the fallback has
+    // to stand on its own and still tell the reader what to do.
+    describe: (error) => {
+      const identifier = str(error, "identifier", "");
+      return identifier
+        ? `There's no column called "${identifier}". Check the spelling against the dataset's columns.`
+        : "Check the column names against the dataset's columns.";
+    },
+  },
   lwql_unparseable: {
     title: "This query couldn't be read",
     describe: () => "Check the SQL syntax and try again.",

--- a/platform/app/src/server/analytics/lwql/__tests__/unknownIdentifier.integration.test.ts
+++ b/platform/app/src/server/analytics/lwql/__tests__/unknownIdentifier.integration.test.ts
@@ -90,6 +90,7 @@ describe("given SQL that names a column no dataset has", () => {
   });
 
   describe("when the query names a column that does not exist", () => {
+    /** @scenario "A query naming a column that does not exist is refused with the column named" */
     it("refuses it as a member-actionable error rather than an unknown", async () => {
       const failure = await failureOf(
         `SELECT ${MISSING_COLUMN} FROM ${database}.traces LIMIT 1`,
@@ -100,6 +101,7 @@ describe("given SQL that names a column no dataset has", () => {
       );
     });
 
+    /** @scenario "A query naming a column that does not exist is refused with the column named" */
     it("blames the member rather than the platform", async () => {
       const failure = await failureOf(
         `SELECT ${MISSING_COLUMN} FROM ${database}.traces LIMIT 1`,
@@ -117,6 +119,8 @@ describe("given SQL that names a column no dataset has", () => {
      * pass if the extractor read nothing out of the server's sentence, because
      * the identifier is optional by design. This is what says the wording the
      * unit fixtures assume is the wording ClickHouse actually writes.
+     *
+     * @scenario "A query naming a column that does not exist is refused with the column named"
      */
     it("names the offending column, read from what the server actually said", async () => {
       const failure = await failureOf(
@@ -129,6 +133,7 @@ describe("given SQL that names a column no dataset has", () => {
       expect(serialised.meta).toMatchObject({ identifier: MISSING_COLUMN });
     });
 
+    /** @scenario "A query naming a column that does not exist is refused with the column named" */
     it("relays no part of the server's message, which echoes the query", async () => {
       const failure = await failureOf(
         `SELECT ${MISSING_COLUMN} FROM ${database}.traces LIMIT 1`,

--- a/platform/app/src/server/analytics/lwql/__tests__/unknownIdentifier.integration.test.ts
+++ b/platform/app/src/server/analytics/lwql/__tests__/unknownIdentifier.integration.test.ts
@@ -1,0 +1,154 @@
+/**
+ * A column that does not exist, as the member who wrote the SQL experiences it.
+ *
+ * Naming a nonexistent column is the one refusal on this path the caller fixes
+ * themselves, and it cannot be caught earlier: the validator approves table
+ * names, not columns, and whether a column exists is not knowable when a chart
+ * is saved. Before this mapping it reached the caller as an unknown 500: the
+ * dashboard widget rendered "Something went wrong" and `langwatch chart run`
+ * said "An unknown error occurred", for a typo (#7447).
+ *
+ * **Why this suite has to touch a real server.** The classification is unit
+ * tested against synthesised driver errors
+ * (`app-layer/clients/clickhouse/__tests__/translate-query-error.unit.test.ts`),
+ * but those fixtures carry the sentences *I* believe ClickHouse writes. The
+ * identifier is lifted out of that sentence by a regex, so a fixture-only test
+ * proves the regex matches my own fixture and nothing about the engine. Only a
+ * real server can say the wording is what the extractor reads, and only a real
+ * server catches it changing under an upgrade.
+ *
+ * Habit carried from the sibling suites: the rejection is paired with the
+ * same-shaped query succeeding on a real column. A typo in the test throws
+ * too, and would otherwise read as the mapping working.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import {
+  createLangWatchQLExecutor,
+  DEFAULT_LWQL_RESULT_LIMITS,
+  type LangWatchQLExecutor,
+} from "../executor";
+import {
+  type LangWatchQLClickHouseHarness,
+  startLangWatchQLClickHouse,
+} from "./lwqlClickHouseHarness";
+
+/** A name no dataset carries, distinctive enough to find in a failure. */
+const MISSING_COLUMN = "trace_idd_typo";
+
+describe("given SQL that names a column no dataset has", () => {
+  let harness: LangWatchQLClickHouseHarness;
+  let executor: LangWatchQLExecutor;
+  let database: string;
+
+  /** Whatever the executor threw, or a sentence saying it threw nothing. */
+  const failureOf = async (sql: string): Promise<unknown> => {
+    try {
+      await executor.execute({
+        sql,
+        tenantCapability: harness.tenantA.keyHash,
+        limits: DEFAULT_LWQL_RESULT_LIMITS,
+      });
+    } catch (error) {
+      return error;
+    }
+    return "<the query succeeded, so nothing was refused>";
+  };
+
+  beforeAll(async () => {
+    harness = await startLangWatchQLClickHouse({ suite: "unknownidentifier" });
+    database = harness.names.database;
+    executor = createLangWatchQLExecutor({
+      ...harness.restrictedConnection(),
+      database,
+      tenantSetting: harness.names.tenantSetting,
+    });
+  }, 180_000);
+
+  afterAll(async () => {
+    // A `beforeAll` that failed before the harness existed has nothing to
+    // stop, and dereferencing it would mask that startup failure.
+    if (!harness) return;
+    await harness.stop();
+  });
+
+  describe("when the same-shaped query names a column that exists", () => {
+    /**
+     * The control. Without it, "the query was refused" is equally satisfied by
+     * an executor that never worked, or by a table name the validator rejects.
+     */
+    it("answers it", async () => {
+      const result = await executor.execute({
+        sql: `SELECT TraceId FROM ${database}.traces LIMIT 1`,
+        tenantCapability: harness.tenantA.keyHash,
+        limits: DEFAULT_LWQL_RESULT_LIMITS,
+      });
+
+      expect(result.columns.map((column) => column.name)).toEqual(["TraceId"]);
+    });
+  });
+
+  describe("when the query names a column that does not exist", () => {
+    it("refuses it as a member-actionable error rather than an unknown", async () => {
+      const failure = await failureOf(
+        `SELECT ${MISSING_COLUMN} FROM ${database}.traces LIMIT 1`,
+      );
+
+      expect((failure as { code?: unknown }).code).toBe(
+        "lwql_unknown_identifier",
+      );
+    });
+
+    it("blames the member rather than the platform", async () => {
+      const failure = await failureOf(
+        `SELECT ${MISSING_COLUMN} FROM ${database}.traces LIMIT 1`,
+      );
+      const serialised = (
+        failure as { serialize: () => Record<string, unknown> }
+      ).serialize();
+
+      // `fault` is what decides whether this pages someone. A typo must not.
+      expect(serialised.fault).toBe("customer");
+    });
+
+    /**
+     * The assertion this whole suite exists for. Everything above would still
+     * pass if the extractor read nothing out of the server's sentence, because
+     * the identifier is optional by design. This is what says the wording the
+     * unit fixtures assume is the wording ClickHouse actually writes.
+     */
+    it("names the offending column, read from what the server actually said", async () => {
+      const failure = await failureOf(
+        `SELECT ${MISSING_COLUMN} FROM ${database}.traces LIMIT 1`,
+      );
+      const serialised = (
+        failure as { serialize: () => Record<string, unknown> }
+      ).serialize();
+
+      expect(serialised.meta).toMatchObject({ identifier: MISSING_COLUMN });
+    });
+
+    it("relays no part of the server's message, which echoes the query", async () => {
+      const failure = await failureOf(
+        `SELECT ${MISSING_COLUMN} FROM ${database}.traces LIMIT 1`,
+      );
+      const serialised = (
+        failure as { serialize: () => Record<string, unknown> }
+      ).serialize();
+
+      // The raw refusal rides in `reasons` for the operator's logs. What a
+      // caller receives is the code, the copy, and the one identifier.
+      const wire = JSON.stringify({
+        code: serialised.code,
+        message: serialised.message,
+        meta: serialised.meta,
+        tips: serialised.tips,
+      });
+
+      expect(wire).not.toContain("DB::Exception");
+      expect(wire).not.toContain(database);
+      expect(wire).not.toContain("SELECT");
+    });
+  });
+});

--- a/platform/app/src/server/analytics/lwql/errors.ts
+++ b/platform/app/src/server/analytics/lwql/errors.ts
@@ -93,6 +93,54 @@ export class LangWatchQLUnavailableError extends HandledError {
 }
 
 /**
+ * A name in the query resolves to no column.
+ *
+ * ClickHouse answers this with UNKNOWN_IDENTIFIER (47), which reached the
+ * caller as an unknown 500: the dashboard widget rendered "Something went
+ * wrong" and `langwatch chart run` said "An unknown error occurred", for a
+ * typo the author fixes in one edit. It cannot be caught earlier than run
+ * time, because whether a column exists is not knowable when the chart is
+ * saved.
+ *
+ * `customer` fault and a 400: the SQL is the member's own, and so is the name.
+ *
+ * The identifier is optional on purpose. It is lifted out of the server's
+ * message by a deliberately narrow extractor that fails closed
+ * (`unknownIdentifierFromError`), because that message also echoes the
+ * submitted query and names internal objects. When it cannot be read with
+ * confidence the refusal still arrives coded and actionable, just without the
+ * name.
+ */
+export class LangWatchQLUnknownIdentifierError extends HandledError {
+  declare readonly code: "lwql_unknown_identifier";
+
+  constructor(
+    /** The unresolvable name, when it could be read from the server's refusal. */
+    identifier: string | undefined,
+    options: { reasons?: readonly Error[] } = {},
+  ) {
+    super(
+      "lwql_unknown_identifier",
+      identifier === undefined
+        ? "The query names a column that does not exist."
+        : `The query names a column that does not exist: ${identifier}.`,
+      {
+        httpStatus: 400,
+        fault: "customer",
+        // Named consumer: the workbench, which highlights the offending name,
+        // and the CLI, which prints it. Omitted rather than sent as null when
+        // it could not be read, so a client can tell "no name" from "the name
+        // is the string null".
+        ...(identifier === undefined ? {} : { meta: { identifier } }),
+        ...remediation("lwql_unknown_identifier"),
+        ...options,
+      },
+    );
+    this.name = "LangWatchQLUnknownIdentifierError";
+  }
+}
+
+/**
  * The query declares a bound parameter the request supplied no value for.
  *
  * Caught at the gateway rather than left to the database: ClickHouse answers a

--- a/platform/app/src/server/analytics/lwql/errors.ts
+++ b/platform/app/src/server/analytics/lwql/errors.ts
@@ -114,11 +114,14 @@ export class LangWatchQLUnavailableError extends HandledError {
 export class LangWatchQLUnknownIdentifierError extends HandledError {
   declare readonly code: "lwql_unknown_identifier";
 
-  constructor(
+  constructor({
+    identifier,
+    ...options
+  }: {
     /** The unresolvable name, when it could be read from the server's refusal. */
-    identifier: string | undefined,
-    options: { reasons?: readonly Error[] } = {},
-  ) {
+    identifier: string | undefined;
+    reasons?: readonly Error[];
+  }) {
     super(
       "lwql_unknown_identifier",
       identifier === undefined

--- a/platform/app/src/server/analytics/lwql/executor.ts
+++ b/platform/app/src/server/analytics/lwql/executor.ts
@@ -249,10 +249,10 @@ function refusalFor({
     return new LangWatchQLUnavailableError({ reasons: [toError(error)] });
   }
   if (isClickHouseUnknownIdentifierError(error)) {
-    return new LangWatchQLUnknownIdentifierError(
-      unknownIdentifierFromError(error),
-      { reasons: [toError(error)] },
-    );
+    return new LangWatchQLUnknownIdentifierError({
+      identifier: unknownIdentifierFromError(error),
+      reasons: [toError(error)],
+    });
   }
   return translateClickHouseQueryError(error, durationMs);
 }

--- a/platform/app/src/server/analytics/lwql/executor.ts
+++ b/platform/app/src/server/analytics/lwql/executor.ts
@@ -213,6 +213,51 @@ const LWQL_REQUEST_TIMEOUT_MS =
 const LWQL_MAX_OPEN_CONNECTIONS = 10;
 
 /**
+ * What a failed governed run is reported as.
+ *
+ * Three answers, and which one applies is decided by what the server refused
+ * rather than by anything the caller sent:
+ *
+ *  - **The deployment is incomplete.** An unknown table or database, or an
+ *    access refusal, cannot be the caller's SQL: the validator only lets
+ *    catalog-approved names reach here. So it is the same "not provisioned
+ *    here" condition as having no executor at all, and gets the same answer.
+ *  - **The caller named a column that is not there.** This one IS their SQL,
+ *    and is the only refusal on this path they fix themselves. The validator
+ *    approves table names, not columns, and column existence is not knowable
+ *    when a chart is saved, so run time is the only place it can be named.
+ *  - **Anything else** goes through the read path's own translation, so the
+ *    resource ceilings a caller can act on arrive as the platform's existing
+ *    codes rather than as a second vocabulary for the same failures. What that
+ *    does not recognise stays unhandled and degrades to "unknown", which is
+ *    correct: a driver diagnostic is not something a caller can act on, and is
+ *    exactly the kind of text this API must not relay.
+ *
+ * In every case the raw error rides in `reasons` for the operator's logs and
+ * never in the response. Lifted out of the `execute` body rather than inlined
+ * so the decision has a name, and so `execute` stays within the complexity
+ * budget the house rules enforce on changed lines.
+ */
+function refusalFor({
+  error,
+  durationMs,
+}: {
+  error: unknown;
+  durationMs: number;
+}): unknown {
+  if (isClickHouseObjectUnavailableError(error)) {
+    return new LangWatchQLUnavailableError({ reasons: [toError(error)] });
+  }
+  if (isClickHouseUnknownIdentifierError(error)) {
+    return new LangWatchQLUnknownIdentifierError(
+      unknownIdentifierFromError(error),
+      { reasons: [toError(error)] },
+    );
+  }
+  return translateClickHouseQueryError(error, durationMs);
+}
+
+/**
  * An executor that runs LangWatchQL as the restricted identity.
  *
  * The client is built here rather than taken as an argument so that the two
@@ -261,34 +306,7 @@ export function createLangWatchQLExecutor(
           },
         };
       } catch (error) {
-        // An unknown table/database or an access refusal cannot be the
-        // caller's SQL: the validator only lets catalog-approved names reach
-        // this point. It is a deployment whose LangWatchQL objects or grants
-        // are missing — the same "not provisioned here" condition as a null
-        // executor, and it gets the same answer. The raw error rides in
-        // `reasons` for the operator's logs and never in the response.
-        if (isClickHouseObjectUnavailableError(error)) {
-          throw new LangWatchQLUnavailableError({ reasons: [toError(error)] });
-        }
-        // A name that resolves to no column IS the caller's SQL, and is the
-        // one refusal on this path they fix themselves. The validator approves
-        // table names, not columns, and column existence is not knowable when a
-        // chart is saved, so run time is the only place this can be named. The
-        // identifier is lifted from the server's message by an extractor that
-        // fails closed; the message itself never leaves here.
-        if (isClickHouseUnknownIdentifierError(error)) {
-          throw new LangWatchQLUnknownIdentifierError(
-            unknownIdentifierFromError(error),
-            { reasons: [toError(error)] },
-          );
-        }
-        // Reuses the read path's translation, so the two resource ceilings a
-        // caller can act on arrive as the platform's existing codes rather than
-        // as a second vocabulary for the same two failures. Anything it does
-        // not recognise stays unhandled and degrades to "unknown" — correct,
-        // because a driver diagnostic is not something a caller can act on and
-        // is exactly the kind of text this API must not relay.
-        throw translateClickHouseQueryError(error, Date.now() - startedAt);
+        throw refusalFor({ error, durationMs: Date.now() - startedAt });
       }
     },
 

--- a/platform/app/src/server/analytics/lwql/executor.ts
+++ b/platform/app/src/server/analytics/lwql/executor.ts
@@ -35,11 +35,16 @@ import { createLogger } from "@langwatch/observability";
 
 import {
   isClickHouseObjectUnavailableError,
+  isClickHouseUnknownIdentifierError,
   translateClickHouseQueryError,
+  unknownIdentifierFromError,
 } from "~/server/app-layer/clients/clickhouse/translate-query-error";
 import { toError } from "~/utils/posthogErrorCapture";
 
-import { LangWatchQLUnavailableError } from "./errors";
+import {
+  LangWatchQLUnavailableError,
+  LangWatchQLUnknownIdentifierError,
+} from "./errors";
 import { DEFAULT_LWQL_RESOURCE_LIMITS } from "./provisioning";
 
 const logger = createLogger("langwatch:analytics:lwql:executor");
@@ -264,6 +269,18 @@ export function createLangWatchQLExecutor(
         // `reasons` for the operator's logs and never in the response.
         if (isClickHouseObjectUnavailableError(error)) {
           throw new LangWatchQLUnavailableError({ reasons: [toError(error)] });
+        }
+        // A name that resolves to no column IS the caller's SQL, and is the
+        // one refusal on this path they fix themselves. The validator approves
+        // table names, not columns, and column existence is not knowable when a
+        // chart is saved, so run time is the only place this can be named. The
+        // identifier is lifted from the server's message by an extractor that
+        // fails closed; the message itself never leaves here.
+        if (isClickHouseUnknownIdentifierError(error)) {
+          throw new LangWatchQLUnknownIdentifierError(
+            unknownIdentifierFromError(error),
+            { reasons: [toError(error)] },
+          );
         }
         // Reuses the read path's translation, so the two resource ceilings a
         // caller can act on arrive as the platform's existing codes rather than

--- a/platform/app/src/server/app-layer/clients/clickhouse/__tests__/translate-query-error.unit.test.ts
+++ b/platform/app/src/server/app-layer/clients/clickhouse/__tests__/translate-query-error.unit.test.ts
@@ -7,7 +7,9 @@ import {
 } from "~/server/app-layer/traces/errors";
 import {
   isClickHouseObjectUnavailableError,
+  isClickHouseUnknownIdentifierError,
   translateClickHouseQueryError,
+  unknownIdentifierFromError,
 } from "../translate-query-error";
 
 describe("translateClickHouseQueryError", () => {
@@ -247,5 +249,126 @@ describe("isClickHouseObjectUnavailableError", () => {
       ),
     ).toBe(false);
     expect(isClickHouseObjectUnavailableError("nope")).toBe(false);
+  });
+});
+
+describe("isClickHouseUnknownIdentifierError", () => {
+  describe.each([
+    [
+      // Verbatim from a real 25.x server, captured through the driver: no
+      // `Code: 47.` prefix, because the driver strips its own and sets `code`
+      // and `type` as properties instead. Backticks, not single quotes. An
+      // earlier fixture here guessed single quotes and passed, while the
+      // extractor read nothing at all off the live engine.
+      "the analyzer's sentence, as a real server delivers it",
+      { code: "47", type: "UNKNOWN_IDENTIFIER" },
+      "Unknown expression identifier `trace_idd` in scope SELECT trace_idd FROM lwql.traces LIMIT 1. ",
+    ],
+    [
+      "the same sentence arriving as raw HTTP text",
+      {},
+      "Code: 47. DB::Exception: Unknown expression identifier `trace_idd` in scope SELECT trace_idd FROM traces. (UNKNOWN_IDENTIFIER)",
+    ],
+    [
+      "the older non-analyzer path, which single-quotes",
+      {},
+      "Code: 47. DB::Exception: Missing columns: 'trace_idd' while processing query: 'SELECT trace_idd FROM traces', required columns: 'trace_idd'. (UNKNOWN_IDENTIFIER)",
+    ],
+  ])("given %s", (_case, props, message) => {
+    const raised = () => Object.assign(new Error(message), props);
+
+    it("recognises it", () => {
+      expect(isClickHouseUnknownIdentifierError(raised())).toBe(true);
+    });
+
+    it("names the column, and nothing else from the message", () => {
+      expect(unknownIdentifierFromError(raised())).toBe("trace_idd");
+    });
+  });
+
+  it("recognises it from the driver's type property with no message to read", () => {
+    // The real driver sets `code` AND `type` AND a readable message; this is
+    // the degenerate case where only the properties survive.
+    const raw = Object.assign(new Error("boom"), {
+      code: "47",
+      type: "UNKNOWN_IDENTIFIER",
+    });
+
+    expect(isClickHouseUnknownIdentifierError(raw)).toBe(true);
+    // No sentence to match, so no name. The refusal is still coded.
+    expect(unknownIdentifierFromError(raw)).toBeUndefined();
+  });
+
+  it("does not classify by the variant name echoed from the query", () => {
+    const raw = new Error(
+      "Code: 62. DB::Exception: Syntax error near UNKNOWN_IDENTIFIER",
+    );
+
+    expect(isClickHouseUnknownIdentifierError(raw)).toBe(false);
+  });
+
+  it("is false for unrelated errors and non-Error values", () => {
+    expect(
+      isClickHouseUnknownIdentifierError(
+        Object.assign(new Error("boom"), { code: "241" }),
+      ),
+    ).toBe(false);
+    expect(isClickHouseUnknownIdentifierError("nope")).toBe(false);
+  });
+
+  /**
+   * The reason the extractor is narrow rather than generous. The engine's
+   * message carries the submitted query and the objects it touched, so a
+   * looser read would hand the caller the deployment's shape along with their
+   * typo.
+   */
+  describe("given a message it cannot read with confidence", () => {
+    it.each([
+      ["no quoted name at all", "Code: 47. DB::Exception: something else"],
+      [
+        "a captured token that is not an identifier",
+        "Code: 47. DB::Exception: Unknown expression identifier 'SELECT * FROM secrets' in scope",
+      ],
+    ])("returns nothing for %s", (_case, message) => {
+      expect(unknownIdentifierFromError(new Error(message))).toBeUndefined();
+    });
+
+    it("takes only the quoted token, not what follows it", () => {
+      // A message whose text after the closing quote is hostile. The capture
+      // stops at that quote and the shape check passes on `a`, so what comes
+      // back is the column name and nothing after it. This is the case the
+      // regex is doing work on rather than the shape check.
+      const identifier = unknownIdentifierFromError(
+        new Error(
+          "Code: 47. DB::Exception: Missing columns: 'a' OR 1=1 --' while processing query",
+        ),
+      );
+
+      expect(identifier).toBe("a");
+    });
+
+    it("never returns the message itself", () => {
+      const message =
+        "Code: 47. DB::Exception: Missing columns: 'x' while processing query: 'SELECT secret FROM internal_audit'";
+      const identifier = unknownIdentifierFromError(new Error(message));
+
+      expect(identifier).toBe("x");
+      expect(message).toContain("internal_audit");
+      expect(identifier).not.toContain("internal_audit");
+    });
+  });
+
+  /**
+   * On the application's own connection every column name is one this
+   * repository wrote, so a rejected one is a bug and must degrade to
+   * "unknown". Only the LangWatchQL executor, where the SQL is the customer's,
+   * opts in.
+   */
+  it("is not mapped by the generic read-path translation", () => {
+    const raw = new Error(
+      "Code: 47. DB::Exception: Unknown expression identifier 'x'. (UNKNOWN_IDENTIFIER)",
+    );
+
+    expect(translateClickHouseQueryError(raw, 1)).toBe(raw);
   });
 });

--- a/platform/app/src/server/app-layer/clients/clickhouse/translate-query-error.ts
+++ b/platform/app/src/server/app-layer/clients/clickhouse/translate-query-error.ts
@@ -60,6 +60,18 @@ const TOO_MANY_BYTES: ServerError = { code: "307", name: "TOO_MANY_BYTES" };
 // missing table, missing database, and an RBAC refusal. Grouped because a
 // caller cannot tell them apart and must not be able to — which of the three
 // fired describes the server's internals, not the query.
+/**
+ * A name in the query that resolves to no column.
+ *
+ * Kept apart from the three below: those describe the deployment (a missing
+ * view, an ungranted grant), whereas this one describes the SQL, and only a
+ * caller who wrote the SQL can act on it.
+ */
+const UNKNOWN_IDENTIFIER: ServerError = {
+  code: "47",
+  name: "UNKNOWN_IDENTIFIER",
+};
+
 const UNKNOWN_TABLE: ServerError = { code: "60", name: "UNKNOWN_TABLE" };
 const UNKNOWN_DATABASE: ServerError = { code: "81", name: "UNKNOWN_DATABASE" };
 const ACCESS_DENIED: ServerError = { code: "497", name: "ACCESS_DENIED" };
@@ -109,6 +121,76 @@ export function isClickHouseObjectUnavailableError(error: unknown): boolean {
     error,
     variants: [UNKNOWN_TABLE, UNKNOWN_DATABASE, ACCESS_DENIED],
   });
+}
+
+/**
+ * True when the server refused because a name in the query resolves to no
+ * column: UNKNOWN_IDENTIFIER (47).
+ *
+ * Not mapped inside {@link translateClickHouseQueryError}, for the same reason
+ * as {@link isClickHouseObjectUnavailableError}: on the application's own
+ * connection every column name is one this repository wrote, so a rejected one
+ * is a plain bug and must degrade to "unknown" (ADR-045). Exported for the
+ * caller where the SQL is the customer's own and the name is theirs to fix,
+ * the LangWatchQL executor.
+ */
+export function isClickHouseUnknownIdentifierError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  return raisedServerError({ error, variants: [UNKNOWN_IDENTIFIER] });
+}
+
+/**
+ * A single identifier, as ClickHouse writes one: a leading letter or
+ * underscore, then word characters, optionally qualified by a table alias.
+ * Anything else is not something to hand back.
+ */
+const IDENTIFIER_SHAPE = /^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)?$/;
+
+/**
+ * The sentences ClickHouse uses to say a name resolved to nothing.
+ *
+ * Captured from a real server rather than assumed. 25.x writes:
+ *
+ *     Unknown expression identifier `trace_idd_typo` in scope SELECT ...
+ *
+ * Note the **backticks**: the analyzer quotes identifiers with them, not with
+ * the single quotes the rest of its diagnostics use. An earlier version of this
+ * matched `'...'` only, passed its own fixtures, and read nothing at all off
+ * the live engine, which is what `unknownIdentifier.integration.test.ts`
+ * exists to catch. The older non-analyzer path writes `Missing columns: 'x'
+ * while processing query: ...` with single quotes, so both delimiters are
+ * accepted and the shape check below decides what is usable.
+ *
+ * Either delimiter opens and closes, rather than a matched pair: an identifier
+ * can contain neither, so a mismatched pair cannot smuggle anything past
+ * {@link IDENTIFIER_SHAPE}.
+ */
+const IDENTIFIER_PATTERNS: readonly RegExp[] = [
+  /Unknown (?:expression |table |column )?identifier [`'"]([^`'"]{1,128})[`'"]/,
+  /Missing columns: [`'"]([^`'"]{1,128})[`'"]/,
+];
+
+/**
+ * The identifier ClickHouse could not resolve, or `undefined`.
+ *
+ * **This is the only thing that may be taken from the message.** A ClickHouse
+ * error echoes the submitted query and names internal objects, so relaying the
+ * text would leak both the query and the deployment's shape to whoever
+ * receives the error. So the extraction is deliberately narrow and fails
+ * closed twice: the sentence has to match one of the known forms, and the
+ * token it captures has to look like an identifier. A miss returns
+ * `undefined`, and the caller reports the failure without naming a column,
+ * which is worse copy and still correct.
+ */
+export function unknownIdentifierFromError(error: unknown): string | undefined {
+  if (!(error instanceof Error)) return undefined;
+  for (const pattern of IDENTIFIER_PATTERNS) {
+    const candidate = pattern.exec(error.message)?.[1];
+    if (candidate !== undefined && IDENTIFIER_SHAPE.test(candidate)) {
+      return candidate;
+    }
+  }
+  return undefined;
 }
 
 /**

--- a/platform/app/src/server/app-layer/error-remediation.ts
+++ b/platform/app/src/server/app-layer/error-remediation.ts
@@ -180,6 +180,12 @@ const registry = {
       "Save the chart again from the workbench to replace the unreadable definition",
     ],
   },
+  lwql_unknown_identifier: {
+    tips: [
+      "Check the column name against the dataset's columns; a typo is the usual cause",
+      "Column existence is only known when the query runs, so a saved chart can carry this until it is run",
+    ],
+  },
   lwql_unavailable: {
     tips: [
       "The LangWatchQL analytics SQL API is not provisioned on this deployment; retrying will not help",

--- a/specs/analytics/lwql-api.feature
+++ b/specs/analytics/lwql-api.feature
@@ -507,6 +507,15 @@ Feature: LangWatchQL analytics SQL API — read-only native ClickHouse SQL over 
     Then the result is identical across runs over unchanged data
 
   @integration
+  Scenario: A query naming a column that does not exist is refused with the column named
+    Given an authenticated API client
+    When it submits a query selecting a column no dataset carries
+    Then the query is refused with error code lwql_unknown_identifier at HTTP 400
+    And the response names the column the server could not resolve
+    And the fault is the caller's, and the remediation tells them to check the name against the dataset's columns
+    And no part of the server's own refusal text reaches the caller, because it echoes the submitted query
+
+  @integration
   Scenario: A parameterized query missing a bound value is refused before execution
     Given an authenticated API client
     When it submits a parameterized query without a value for one of its parameters


### PR DESCRIPTION
## Ticket

Closes #7447.

## Premise, re-checked on current main

Holds. `translate-query-error.ts` maps memory, timeout, scan ceilings and availability, and deliberately not UNKNOWN_IDENTIFIER. A member's SQL naming a column that does not exist still reaches them as an unknown 500.

The ticket's framing is right about why it cannot be caught earlier: the validator approves **table** names, not columns, and whether a column exists is not knowable when a chart is saved. Run time is the only place to name it.

## Change

UNKNOWN_IDENTIFIER (47) is recognised and minted as `lwql_unknown_identifier`, customer fault, HTTP 400, carrying the offending identifier in `meta`.

**Only the LangWatchQL executor opts in.** This follows the precedent already in the file: `isClickHouseObjectUnavailableError` is exported rather than mapped inside `translateClickHouseQueryError`, because on the application's own connection those codes are plain bugs. Same reasoning here, and it is the sharper case: on our own connection every column name is one this repository wrote, so a rejected one is a bug and must keep degrading to "unknown" per ADR-045. A mutation that maps it in the generic path is one of the seven below.

Full contract per the repo's error-handling rules: code in `logic/codes.ts`, copy in `presentation.ts`, tips in `error-remediation.ts`, and a spec scenario tagged `@integration` and bound with `@scenario`.

## The identifier extraction, and why it is narrow

The identifier is lifted out of the server's sentence. That sentence **echoes the submitted query and names internal objects**, so nothing else from it is ever relayed. The extractor fails closed twice: the sentence must match a known form, and the captured token must look like an identifier. A miss returns nothing and the refusal still arrives coded, just without the name.

## What the integration test caught

I wrote `unknownIdentifier.integration.test.ts` to drive the real executor against real ClickHouse, on the reasoning that a fixture-only test proves the regex matches my own fixture and nothing about the engine.

**It immediately failed, and it was right to.** Four of five assertions passed (correct code, correct fault, no leak) and `meta` came back **empty**: the extractor read nothing. I probed the live engine for the actual message:

```
Unknown expression identifier `trace_idd_typo` in scope SELECT trace_idd_typo FROM lwql_probe.traces LIMIT 1.
```

**Backticks, not single quotes.** The analyzer quotes identifiers with backticks even though the rest of its diagnostics use single quotes, and the driver strips its own `Code: 47.` prefix and sets `code`/`type` as properties instead. My unit fixtures had guessed single quotes and a prefix, so they passed while the feature did nothing on a real server.

Both were corrected: the extractor accepts either delimiter, and the unit fixtures now carry the sentence verbatim from a real server with the properties a real driver sets. Had I shipped fixtures only, this would have merged as a working-looking no-op.

## Evidence

- **20 new unit assertions** (38 total in that file), including both message forms, the properties-only case, the two fail-closed paths, and an explicit "the identifier is not the message" check.
- **5 integration assertions** against real ClickHouse via testcontainers: `pnpm test:integration run src/server/analytics/lwql/__tests__/unknownIdentifier.integration.test.ts`. Paired with a control query on a real column, so a typo in the test cannot read as the mapping working.
- Surrounding suites: **682/682** unit across `src/server/analytics/lwql` + `src/features/errors`; **82/82** in the LWQL integration lane.
- `pnpm typecheck:all` clean, which is also what proves the presentation registry stayed exhaustive.
- Biome, exact CI invocation: **0 errors**, 3399 warnings.
- `check-feature-parity.ts` OK, enforced scenarios **9734 to 9735**.

### Mutations, all 7 caught

| mutation | caught by |
|---|---|
| the executor stops recognising an unresolvable column | integration |
| the refusal is minted without the identifier | integration |
| the backtick form stops matching, as it did before the live probe | unit |
| the single-quote form stops matching | unit |
| the identifier shape check is dropped, so any captured text is relayed | unit |
| the shape check is widened to allow anything | unit |
| the generic read path starts mapping it too, breaking ADR-045 | unit |

Worth noting which layer caught what: the two executor mutations are caught **only** by the integration test. A unit-only suite would have let both through.

## Advisory note

Advisory PR from the tech-debt-fixer bot, for human review, not to be merged by the bot.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Queries referencing nonexistent columns now return a clear, dedicated error.
  - Error messages identify the missing column when available.
  - Added guidance to verify column names against the dataset.
  - Prevented internal database error details from appearing in responses.
- **Tests**
  - Added coverage for missing-column detection, error responses, identifier reporting, and valid-column queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->