### PR TITLE
fix(docs): align self-hosting version references with shipped chart 3.17.0

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -61699,7 +61699,7 @@ The langwatch chart needs two operator-managed Secrets in your target namespace 
 - `langwatch-app-secrets` holds the app keys + the AI gateway shared-auth keys. Both `langwatch-app` and the gateway pod mount from this Secret.
 - A ClickHouse credentials Secret (any name, referenced from values via `clickhouse.auth.existingSecret`) holds the ClickHouse password and the Keeper inter-node cluster secret. The deployment composes `CLICKHOUSE_URL` at runtime from the password key, so the Secret name must be a non-default name (the chart's render-time validator fails fast if you leave it at the default `<release>-clickhouse` while `autogen.enabled=false`).
 
-This is the same pre-create-then-install pattern that the Kubernetes (Helm) [production deployment](/self-hosting/deployment/kubernetes-helm#production-deployment) uses: the chart never renders these Secrets, so Argo has nothing to reconcile and nothing rotates on subsequent syncs.
+This is the same pre-create-then-install pattern that the Kubernetes (Helm) [production deployment](/self-hosting/deployment/kubernetes-helm#production-deployment) uses: the chart never renders these Secrets, so Argo treats them as external and leaves them alone across syncs.
 
 Create the namespace and the Secrets:
 
@@ -62133,7 +62133,7 @@ graph LR
 | Tag | Description |
 |-----|-------------|
 | `latest` | Latest stable release |
-| `x.y.z` | A specific release, recommended for production — pick one from [Releases](https://github.com/langwatch/langwatch/releases) |
+| `x.y.z` | A specific release, recommended for production: pick one from [Releases](https://github.com/langwatch/langwatch/releases) |
 | `local` | Built locally via `make images` (development only) |
 
 <Tip>

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -61737,7 +61737,7 @@ spec:
   source:
     repoURL: https://langwatch.github.io/langwatch
     chart: langwatch
-    targetRevision: 3.16.0
+    targetRevision: 3.17.0
     helm:
       releaseName: langwatch
       values: |
@@ -61786,7 +61786,7 @@ spec:
   sources:
     - repoURL: https://langwatch.github.io/langwatch
       chart: langwatch
-      targetRevision: 3.16.0
+      targetRevision: 3.17.0
       helm:
         releaseName: langwatch
         valueFiles:
@@ -62147,7 +62147,7 @@ For air-gapped or private environments, mirror the images to your own registry:
 ```bash
 # The release you are mirroring. Every tag below follows it, so set it once.
 # Pick the version from https://github.com/langwatch/langwatch/releases
-VERSION=3.16.0
+VERSION=3.17.0
 REGISTRY=registry.example.com
 
 for image in langwatch langwatch_nlp langevals; do
@@ -62163,13 +62163,13 @@ Then configure the Helm chart, giving every tag the version you mirrored:
 images:
   app:
     repository: registry.example.com/langwatch/langwatch
-    tag: "3.16.0"
+    tag: "3.17.0"
   langwatch_nlp:
     repository: registry.example.com/langwatch/langwatch_nlp
-    tag: "3.16.0"
+    tag: "3.17.0"
   langevals:
     repository: registry.example.com/langwatch/langevals
-    tag: "3.16.0"
+    tag: "3.17.0"
 
 imagePullSecrets:
   - name: registry-credentials
@@ -65836,7 +65836,7 @@ helm repo update
 
 helm upgrade langwatch langwatch/langwatch \
   --namespace langwatch \
-  --version 3.16.0 \
+  --version 3.17.0 \
   -f values-production.yaml \
   --wait --timeout 10m
 ```
@@ -66168,7 +66168,7 @@ helm search repo langwatch/langwatch --versions
 # Install a specific chart version
 helm upgrade langwatch langwatch/langwatch \
   --namespace langwatch \
-  --version 3.16.0 \
+  --version 3.17.0 \
   -f values-production.yaml
 ```
 

--- a/docs/self-hosting/deployment/argocd.mdx
+++ b/docs/self-hosting/deployment/argocd.mdx
@@ -20,7 +20,7 @@ The langwatch chart needs two operator-managed Secrets in your target namespace 
 - `langwatch-app-secrets` holds the app keys + the AI gateway shared-auth keys. Both `langwatch-app` and the gateway pod mount from this Secret.
 - A ClickHouse credentials Secret (any name, referenced from values via `clickhouse.auth.existingSecret`) holds the ClickHouse password and the Keeper inter-node cluster secret. The deployment composes `CLICKHOUSE_URL` at runtime from the password key, so the Secret name must be a non-default name (the chart's render-time validator fails fast if you leave it at the default `<release>-clickhouse` while `autogen.enabled=false`).
 
-This is the same pre-create-then-install pattern that the Kubernetes (Helm) [production deployment](/self-hosting/deployment/kubernetes-helm#production-deployment) uses: the chart never renders these Secrets, so Argo has nothing to reconcile and nothing rotates on subsequent syncs.
+This is the same pre-create-then-install pattern that the Kubernetes (Helm) [production deployment](/self-hosting/deployment/kubernetes-helm#production-deployment) uses: the chart never renders these Secrets, so Argo treats them as external and leaves them alone across syncs.
 
 Create the namespace and the Secrets:
 

--- a/docs/self-hosting/deployment/argocd.mdx
+++ b/docs/self-hosting/deployment/argocd.mdx
@@ -58,7 +58,7 @@ spec:
   source:
     repoURL: https://langwatch.github.io/langwatch
     chart: langwatch
-    targetRevision: 3.16.0
+    targetRevision: 3.17.0
     helm:
       releaseName: langwatch
       values: |
@@ -107,7 +107,7 @@ spec:
   sources:
     - repoURL: https://langwatch.github.io/langwatch
       chart: langwatch
-      targetRevision: 3.16.0
+      targetRevision: 3.17.0
       helm:
         releaseName: langwatch
         valueFiles:

--- a/docs/self-hosting/deployment/docker-images.mdx
+++ b/docs/self-hosting/deployment/docker-images.mdx
@@ -106,7 +106,7 @@ For air-gapped or private environments, mirror the images to your own registry:
 ```bash
 # The release you are mirroring. Every tag below follows it, so set it once.
 # Pick the version from https://github.com/langwatch/langwatch/releases
-VERSION=3.16.0
+VERSION=3.17.0
 REGISTRY=registry.example.com
 
 for image in langwatch langwatch_nlp langevals; do
@@ -122,13 +122,13 @@ Then configure the Helm chart, giving every tag the version you mirrored:
 images:
   app:
     repository: registry.example.com/langwatch/langwatch
-    tag: "3.16.0"
+    tag: "3.17.0"
   langwatch_nlp:
     repository: registry.example.com/langwatch/langwatch_nlp
-    tag: "3.16.0"
+    tag: "3.17.0"
   langevals:
     repository: registry.example.com/langwatch/langevals
-    tag: "3.16.0"
+    tag: "3.17.0"
 
 imagePullSecrets:
   - name: registry-credentials

--- a/docs/self-hosting/deployment/docker-images.mdx
+++ b/docs/self-hosting/deployment/docker-images.mdx
@@ -92,7 +92,7 @@ graph LR
 | Tag | Description |
 |-----|-------------|
 | `latest` | Latest stable release |
-| `x.y.z` | A specific release, recommended for production — pick one from [Releases](https://github.com/langwatch/langwatch/releases) |
+| `x.y.z` | A specific release, recommended for production: pick one from [Releases](https://github.com/langwatch/langwatch/releases) |
 | `local` | Built locally via `make images` (development only) |
 
 <Tip>

--- a/docs/self-hosting/upgrade-v3.mdx
+++ b/docs/self-hosting/upgrade-v3.mdx
@@ -100,7 +100,7 @@ helm repo update
 
 helm upgrade langwatch langwatch/langwatch \
   --namespace langwatch \
-  --version 3.16.0 \
+  --version 3.17.0 \
   -f values-production.yaml \
   --wait --timeout 10m
 ```

--- a/docs/self-hosting/upgrade.mdx
+++ b/docs/self-hosting/upgrade.mdx
@@ -43,7 +43,7 @@ helm search repo langwatch/langwatch --versions
 # Install a specific chart version
 helm upgrade langwatch langwatch/langwatch \
   --namespace langwatch \
-  --version 3.16.0 \
+  --version 3.17.0 \
   -f values-production.yaml
 ```
 


### PR DESCRIPTION
## Summary

Release PR #7399 (`chore(main): release langwatch 3.17.0`) bumped the Helm chart `appVersion` to 3.17.0 but left 8 self-hosting doc references naming the old 3.16.0. `docs-ci` (`check_structure` / `go run ./cmd/docscheck`) has been failing on `main` and on every open PR ever since, reporting 8 `version-drift` findings.

This PR updates only those 8 version references, in 4 files, to 3.17.0 — the version the chart ships today:

- `docs/self-hosting/deployment/argocd.mdx` (2 `targetRevision` refs)
- `docs/self-hosting/deployment/docker-images.mdx` (1 `VERSION=` + 3 `tag:` refs)
- `docs/self-hosting/upgrade-v3.mdx` (1 `--version` ref)
- `docs/self-hosting/upgrade.mdx` (1 `--version` ref)

3.17.0 is chosen (not 3.17.1) because `docscheck` compares against `charts/langwatch/Chart.yaml`'s `appVersion` as it stands today, which is 3.17.0. Open release PR #7628 will bump the chart to 3.17.1, which will require a follow-up doc bump at that time.

A second commit fixes 2 pre-existing `check_prose` violations (banned em dash, banned `nothing`) that lived elsewhere in `argocd.mdx` and `docker-images.mdx`. These are unrelated to the version drift, but the prose linter scans a touched `.mdx` file's entire content, so `docs-complete` could not go green on this PR without clearing them too. Wording only, no technical meaning changed; verified with a diff.

## Deployment Impact

No deployment impact. This is a docs-only change: it corrects version strings (3.16.0 to 3.17.0) in self-hosting documentation examples (ArgoCD `targetRevision`, Docker image `tag`/`VERSION`, and `helm upgrade --version` commands) so they match the chart's current `appVersion`, plus two wording-only edits to clear pre-existing prose-linter violations. No env vars, Helm values, chart templates, default install behavior, or BYOC dataplane behavior change.

## Test plan

- [x] `go run ./cmd/docscheck` — before: `docs has 8 problems` (all `version-drift`, 3.16.0 vs 3.17.0)
- [x] `go run ./cmd/docscheck` — after: `docs is sound: 683 pages, 683 navigation entries, 74 redirects, release 3.17.0.` (exit 0)
- [x] `gh pr checks` — `check_structure`, `check_links`, `check_generated_files`, `check_prose`, `docs-complete`, and the deployment-impact `check` gate all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated self-hosted deployment and upgrade guides to reference Helm chart version 3.17.0.
  * Updated Argo CD examples, Docker image mirroring instructions, and upgrade commands for the latest chart release.
  * Clarified that externally managed Secrets remain untouched across Argo CD syncs.
  * Synchronized documented image tags and version references across deployment examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
