### PR TITLE
fix(agent-cache): a personal workspace run gets a key, and a project's runs share one

### DIFF
--- a/docs/agent-simulations/authenticated-agents.mdx
+++ b/docs/agent-simulations/authenticated-agents.mdx
@@ -135,7 +135,7 @@ That answer exists only behind the auth wall, so the scenario passing is the pro
 
 Rows are isolated and run in parallel, so by default each row logs in on its own. You can use the **agent cache** to store the login credential after the first row and read it back on every row that follows, so the run authenticates once instead of once per row.
 
-The cache is encrypted at rest and entries expire on their own. The platform gives each run a scoped credential inside the sandbox, so no `langwatch.setup()` call or LangWatch secret is required.
+The cache is encrypted at rest and entries expire on their own. The platform puts a short-lived credential scoped to the cache inside the sandbox, shared by the runs of the project, so no `langwatch.setup()` call or LangWatch secret is required.
 
 This code is executed on every commit against the real runtime:
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -35774,7 +35774,7 @@ That answer exists only behind the auth wall, so the scenario passing is the pro
 
 Rows are isolated and run in parallel, so by default each row logs in on its own. You can use the **agent cache** to store the login credential after the first row and read it back on every row that follows, so the run authenticates once instead of once per row.
 
-The cache is encrypted at rest and entries expire on their own. The platform gives each run a scoped credential inside the sandbox, so no `langwatch.setup()` call or LangWatch secret is required.
+The cache is encrypted at rest and entries expire on their own. The platform puts a short-lived credential scoped to the cache inside the sandbox, shared by the runs of the project, so no `langwatch.setup()` call or LangWatch secret is required.
 
 This code is executed on every commit against the real runtime:
 

--- a/platform/app/src/app/api/agent-cache/__tests__/agent-cache.integration.test.ts
+++ b/platform/app/src/app/api/agent-cache/__tests__/agent-cache.integration.test.ts
@@ -67,32 +67,40 @@ describe("Feature: the agent cache", () => {
     "X-Project-Id": forProjectId,
   });
 
-  const readEntry = (name: string, token: string) =>
+  const readEntry = ({ name, token }: { name: string; token: string }) =>
     app.request(`/api/agent-cache/${name}`, { headers: headersFor({ token }) });
 
-  const writeEntry = (
-    name: string,
-    token: string,
-    body: Record<string, unknown>,
-  ) =>
+  const writeEntry = ({
+    name,
+    token,
+    body,
+  }: {
+    name: string;
+    token: string;
+    body: Record<string, unknown>;
+  }) =>
     app.request(`/api/agent-cache/${name}`, {
       method: "PUT",
       headers: { ...headersFor({ token }), "Content-Type": "application/json" },
       body: JSON.stringify(body),
     });
 
-  const claimEntry = (
-    name: string,
-    token: string,
-    body: Record<string, unknown>,
-  ) =>
+  const claimEntry = ({
+    name,
+    token,
+    body,
+  }: {
+    name: string;
+    token: string;
+    body: Record<string, unknown>;
+  }) =>
     app.request(`/api/agent-cache/${name}/claim`, {
       method: "POST",
       headers: { ...headersFor({ token }), "Content-Type": "application/json" },
       body: JSON.stringify(body),
     });
 
-  const removeEntry = (name: string, token: string) =>
+  const removeEntry = ({ name, token }: { name: string; token: string }) =>
     app.request(`/api/agent-cache/${name}`, {
       method: "DELETE",
       headers: headersFor({ token }),
@@ -280,12 +288,16 @@ describe("Feature: the agent cache", () => {
     describe("when it stores a value and reads it back", () => {
       /** @scenario "A stored entry is read back by its name" */
       it("answers the value that was stored", async () => {
-        const written = await writeEntry(ENTRY_NAME, manageToken, {
-          value: ENTRY_VALUE,
+        const written = await writeEntry({
+          name: ENTRY_NAME,
+          token: manageToken,
+          body: {
+            value: ENTRY_VALUE,
+          },
         });
         expect(written.status).toBe(200);
 
-        const res = await readEntry(ENTRY_NAME, manageToken);
+        const res = await readEntry({ name: ENTRY_NAME, token: manageToken });
         expect(res.status).toBe(200);
         expect((await res.json()) as unknown).toEqual({
           name: ENTRY_NAME,
@@ -295,10 +307,21 @@ describe("Feature: the agent cache", () => {
 
       /** @scenario "A second write replaces the entry" */
       it("replaces the value on the second write", async () => {
-        await writeEntry("ACME_REPLACED", manageToken, { value: "first" });
-        await writeEntry("ACME_REPLACED", manageToken, { value: "second" });
+        await writeEntry({
+          name: "ACME_REPLACED",
+          token: manageToken,
+          body: { value: "first" },
+        });
+        await writeEntry({
+          name: "ACME_REPLACED",
+          token: manageToken,
+          body: { value: "second" },
+        });
 
-        const res = await readEntry("ACME_REPLACED", manageToken);
+        const res = await readEntry({
+          name: "ACME_REPLACED",
+          token: manageToken,
+        });
         expect(((await res.json()) as { value: string }).value).toBe("second");
       });
     });
@@ -306,17 +329,23 @@ describe("Feature: the agent cache", () => {
     describe("when the entry's lifetime passes", () => {
       /** @scenario "An entry stops answering once its lifetime passes" */
       it("answers a read after the lifetime as a miss", async () => {
-        await writeEntry("ACME_BRIEF", manageToken, {
-          value: "gone-soon",
-          ttl_seconds: 5,
+        await writeEntry({
+          name: "ACME_BRIEF",
+          token: manageToken,
+          body: {
+            value: "gone-soon",
+            ttl_seconds: 5,
+          },
         });
-        expect((await readEntry("ACME_BRIEF", manageToken)).status).toBe(200);
+        expect(
+          (await readEntry({ name: "ACME_BRIEF", token: manageToken })).status,
+        ).toBe(200);
 
         // The route floor is 5 seconds; the in-memory store expires on a
         // wall-clock read, so waiting past it is the only way to observe it.
         await sleep(5_100);
 
-        const res = await readEntry("ACME_BRIEF", manageToken);
+        const res = await readEntry({ name: "ACME_BRIEF", token: manageToken });
         expect(res.status).toBe(404);
       }, 15_000);
     });
@@ -324,7 +353,10 @@ describe("Feature: the agent cache", () => {
     describe("when it reads a name the project does not hold", () => {
       /** @scenario "A name the project does not hold is refused as not found" */
       it("refuses with the cache_entry_not_found code", async () => {
-        const res = await readEntry("ACME_NEVER_STORED", manageToken);
+        const res = await readEntry({
+          name: "ACME_NEVER_STORED",
+          token: manageToken,
+        });
         expect(res.status).toBe(404);
         expect(
           ((await res.json()) as { error: { code: string } }).error.code,
@@ -335,37 +367,57 @@ describe("Feature: the agent cache", () => {
     describe("when it removes an entry", () => {
       /** @scenario "Removing an entry the project does not hold succeeds" */
       it("succeeds whether or not the name was held", async () => {
-        await writeEntry("ACME_DROPPED", manageToken, { value: "x" });
-        expect((await removeEntry("ACME_DROPPED", manageToken)).status).toBe(
-          200,
-        );
-        expect((await readEntry("ACME_DROPPED", manageToken)).status).toBe(404);
-        expect((await removeEntry("ACME_DROPPED", manageToken)).status).toBe(
-          200,
-        );
+        await writeEntry({
+          name: "ACME_DROPPED",
+          token: manageToken,
+          body: { value: "x" },
+        });
+        expect(
+          (await removeEntry({ name: "ACME_DROPPED", token: manageToken }))
+            .status,
+        ).toBe(200);
+        expect(
+          (await readEntry({ name: "ACME_DROPPED", token: manageToken }))
+            .status,
+        ).toBe(404);
+        expect(
+          (await removeEntry({ name: "ACME_DROPPED", token: manageToken }))
+            .status,
+        ).toBe(200);
       });
     });
 
     describe("when the request is outside the accepted bounds", () => {
       /** @scenario "A value past the size limit is refused" */
       it("refuses a value past the size limit", async () => {
-        const res = await writeEntry("ACME_TOO_BIG", manageToken, {
-          value: "x".repeat(MAX_VALUE_BYTES + 1),
+        const res = await writeEntry({
+          name: "ACME_TOO_BIG",
+          token: manageToken,
+          body: {
+            value: "x".repeat(MAX_VALUE_BYTES + 1),
+          },
         });
         expect(res.status).toBe(400);
       });
 
       /** @scenario "A name outside the accepted shape is refused" */
       it("refuses a name outside the accepted shape", async () => {
-        const res = await readEntry("acme-session", manageToken);
+        const res = await readEntry({
+          name: "acme-session",
+          token: manageToken,
+        });
         expect(res.status).toBe(400);
       });
 
       /** @scenario "A lifetime outside the accepted range is refused" */
       it("refuses a lifetime outside the accepted range", async () => {
-        const res = await writeEntry("ACME_LONG", manageToken, {
-          value: "x",
-          ttl_seconds: 1,
+        const res = await writeEntry({
+          name: "ACME_LONG",
+          token: manageToken,
+          body: {
+            value: "x",
+            ttl_seconds: 1,
+          },
         });
         expect(res.status).toBe(400);
       });
@@ -376,8 +428,12 @@ describe("Feature: the agent cache", () => {
     describe("when the project holds no entry under that name", () => {
       /** @scenario "A claim on a free name is taken" */
       it("takes the name and stores the value", async () => {
-        const res = await claimEntry("ACME_CLAIM_FREE", manageToken, {
-          value: "won-it",
+        const res = await claimEntry({
+          name: "ACME_CLAIM_FREE",
+          token: manageToken,
+          body: {
+            value: "won-it",
+          },
         });
         expect(res.status).toBe(200);
         expect((await res.json()) as unknown).toMatchObject({
@@ -385,7 +441,10 @@ describe("Feature: the agent cache", () => {
           claimed: true,
         });
 
-        const read = await readEntry("ACME_CLAIM_FREE", manageToken);
+        const read = await readEntry({
+          name: "ACME_CLAIM_FREE",
+          token: manageToken,
+        });
         expect(((await read.json()) as { value: string }).value).toBe("won-it");
       });
     });
@@ -393,17 +452,28 @@ describe("Feature: the agent cache", () => {
     describe("when the project already holds that name", () => {
       /** @scenario "A claim on a held name leaves the held value alone" */
       it("does not take the name and leaves the held value alone", async () => {
-        await writeEntry("ACME_CLAIM_HELD", manageToken, { value: "first" });
+        await writeEntry({
+          name: "ACME_CLAIM_HELD",
+          token: manageToken,
+          body: { value: "first" },
+        });
 
-        const res = await claimEntry("ACME_CLAIM_HELD", manageToken, {
-          value: "second",
+        const res = await claimEntry({
+          name: "ACME_CLAIM_HELD",
+          token: manageToken,
+          body: {
+            value: "second",
+          },
         });
         expect(res.status).toBe(200);
         expect(((await res.json()) as { claimed: boolean }).claimed).toBe(
           false,
         );
 
-        const read = await readEntry("ACME_CLAIM_HELD", manageToken);
+        const read = await readEntry({
+          name: "ACME_CLAIM_HELD",
+          token: manageToken,
+        });
         expect(((await read.json()) as { value: string }).value).toBe("first");
       });
     });
@@ -411,9 +481,13 @@ describe("Feature: the agent cache", () => {
     describe("when the claimed entry's lifetime passes", () => {
       /** @scenario "A name is free again once its lifetime passes" */
       it("lets the next caller take the name", async () => {
-        const first = await claimEntry("ACME_CLAIM_BRIEF", manageToken, {
-          value: "gone-soon",
-          ttl_seconds: 5,
+        const first = await claimEntry({
+          name: "ACME_CLAIM_BRIEF",
+          token: manageToken,
+          body: {
+            value: "gone-soon",
+            ttl_seconds: 5,
+          },
         });
         expect(((await first.json()) as { claimed: boolean }).claimed).toBe(
           true,
@@ -423,8 +497,12 @@ describe("Feature: the agent cache", () => {
         // observe the name coming free again.
         await sleep(5_100);
 
-        const second = await claimEntry("ACME_CLAIM_BRIEF", manageToken, {
-          value: "the-next-one",
+        const second = await claimEntry({
+          name: "ACME_CLAIM_BRIEF",
+          token: manageToken,
+          body: {
+            value: "the-next-one",
+          },
         });
         expect(((await second.json()) as { claimed: boolean }).claimed).toBe(
           true,
@@ -437,8 +515,12 @@ describe("Feature: the agent cache", () => {
       it("takes the name exactly once", async () => {
         const responses = await Promise.all(
           Array.from({ length: 8 }, (_, index) =>
-            claimEntry("ACME_CLAIM_RACE", manageToken, {
-              value: `row-${index}`,
+            claimEntry({
+              name: "ACME_CLAIM_RACE",
+              token: manageToken,
+              body: {
+                value: `row-${index}`,
+              },
             }),
           ),
         );
@@ -450,7 +532,10 @@ describe("Feature: the agent cache", () => {
         expect(winners).toHaveLength(1);
 
         const winnerIndex = outcomes.findIndex((outcome) => outcome.claimed);
-        const read = await readEntry("ACME_CLAIM_RACE", manageToken);
+        const read = await readEntry({
+          name: "ACME_CLAIM_RACE",
+          token: manageToken,
+        });
         expect(((await read.json()) as { value: string }).value).toBe(
           `row-${winnerIndex}`,
         );
@@ -487,9 +572,17 @@ describe("Feature: the agent cache", () => {
     describe("when a viewer reads and writes an entry", () => {
       /** @scenario "A caller without the manage grain is refused" */
       it("refuses a viewer", async () => {
-        expect((await readEntry(ENTRY_NAME, viewerToken)).status).toBe(403);
         expect(
-          (await writeEntry(ENTRY_NAME, viewerToken, { value: "x" })).status,
+          (await readEntry({ name: ENTRY_NAME, token: viewerToken })).status,
+        ).toBe(403);
+        expect(
+          (
+            await writeEntry({
+              name: ENTRY_NAME,
+              token: viewerToken,
+              body: { value: "x" },
+            })
+          ).status,
         ).toBe(403);
       });
     });
@@ -509,12 +602,19 @@ describe("Feature: the agent cache", () => {
     describe("when it writes an entry and reads it back", () => {
       /** @scenario "The sandbox key reaches the agent cache" */
       it("reaches the agent cache", async () => {
-        const written = await writeEntry("ACME_FROM_SANDBOX", sandboxToken, {
-          value: "written-in-the-sandbox",
+        const written = await writeEntry({
+          name: "ACME_FROM_SANDBOX",
+          token: sandboxToken,
+          body: {
+            value: "written-in-the-sandbox",
+          },
         });
         expect(written.status).toBe(200);
 
-        const res = await readEntry("ACME_FROM_SANDBOX", sandboxToken);
+        const res = await readEntry({
+          name: "ACME_FROM_SANDBOX",
+          token: sandboxToken,
+        });
         expect(res.status).toBe(200);
         expect(((await res.json()) as { value: string }).value).toBe(
           "written-in-the-sandbox",
@@ -579,11 +679,18 @@ describe("Feature: the agent cache", () => {
         });
         expect(mintedAfter).toBe(mintedBefore + 1);
 
-        const written = await writeEntry("ACME_FROM_SHARED_KEY", second, {
-          value: "written-with-the-shared-key",
+        const written = await writeEntry({
+          name: "ACME_FROM_SHARED_KEY",
+          token: second,
+          body: {
+            value: "written-with-the-shared-key",
+          },
         });
         expect(written.status).toBe(200);
-        const res = await readEntry("ACME_FROM_SHARED_KEY", second);
+        const res = await readEntry({
+          name: "ACME_FROM_SHARED_KEY",
+          token: second,
+        });
         expect(res.status).toBe(200);
         expect(((await res.json()) as { value: string }).value).toBe(
           "written-with-the-shared-key",

--- a/platform/app/src/app/api/agent-cache/__tests__/agent-cache.integration.test.ts
+++ b/platform/app/src/app/api/agent-cache/__tests__/agent-cache.integration.test.ts
@@ -18,10 +18,15 @@ import {
   type Team,
   TeamUserRole,
 } from "~/generated/prisma/client";
-import { mintAgentSandboxApiKey } from "~/server/api-key/agent-sandbox-key";
+import {
+  AGENT_SANDBOX_KEY_REUSE_MS,
+  getOrMintAgentSandboxApiKey,
+  mintAgentSandboxApiKey,
+} from "~/server/api-key/agent-sandbox-key";
 import { ApiKeyService } from "~/server/api-key/api-key.service";
 import { AGENT_SANDBOX_API_KEY_NAME } from "~/server/api-key/reserved-names";
 import { prisma } from "~/server/db";
+import { TtlCache } from "~/server/utils/ttlCache";
 import { cleanupTestRows } from "~/test-utils/cleanupTestRows";
 import { wireDefaultTestApp } from "~/test-utils/wireDefaultTestApp";
 import { KSUID_RESOURCES } from "~/utils/constants";
@@ -51,13 +56,19 @@ describe("Feature: the agent cache", () => {
   let personalProjectId: string;
   let personalSandboxToken: string;
 
-  const headersFor = (token: string, forProjectId: string = projectId) => ({
+  const headersFor = ({
+    token,
+    forProjectId = projectId,
+  }: {
+    token: string;
+    forProjectId?: string;
+  }) => ({
     Authorization: `Bearer ${token}`,
     "X-Project-Id": forProjectId,
   });
 
   const readEntry = (name: string, token: string) =>
-    app.request(`/api/agent-cache/${name}`, { headers: headersFor(token) });
+    app.request(`/api/agent-cache/${name}`, { headers: headersFor({ token }) });
 
   const writeEntry = (
     name: string,
@@ -66,7 +77,7 @@ describe("Feature: the agent cache", () => {
   ) =>
     app.request(`/api/agent-cache/${name}`, {
       method: "PUT",
-      headers: { ...headersFor(token), "Content-Type": "application/json" },
+      headers: { ...headersFor({ token }), "Content-Type": "application/json" },
       body: JSON.stringify(body),
     });
 
@@ -77,14 +88,14 @@ describe("Feature: the agent cache", () => {
   ) =>
     app.request(`/api/agent-cache/${name}/claim`, {
       method: "POST",
-      headers: { ...headersFor(token), "Content-Type": "application/json" },
+      headers: { ...headersFor({ token }), "Content-Type": "application/json" },
       body: JSON.stringify(body),
     });
 
   const removeEntry = (name: string, token: string) =>
     app.request(`/api/agent-cache/${name}`, {
       method: "DELETE",
-      headers: headersFor(token),
+      headers: headersFor({ token }),
     });
 
   beforeAll(async () => {
@@ -515,9 +526,68 @@ describe("Feature: the agent cache", () => {
       /** @scenario "The sandbox key reaches nothing else" */
       it("is refused everywhere else in the project", async () => {
         const res = await promptsApp.request("/api/prompts", {
-          headers: headersFor(sandboxToken),
+          headers: headersFor({ token: sandboxToken }),
         });
         expect(res.status).toBe(403);
+      });
+    });
+  });
+
+  describe("given a run of this project already got a key", () => {
+    // The test's own store rather than the module's, so what this test
+    // shares is not left behind for eight hours.
+    const sharedKeys = new TtlCache<string>(
+      AGENT_SANDBOX_KEY_REUSE_MS,
+      `ttlcache:agent-sandbox-key-${ns}:`,
+    );
+
+    afterAll(async () => {
+      await sharedKeys.delete(projectId);
+    });
+
+    describe("when a later run of the same project asks for one", () => {
+      /** @scenario "A later run in the same project reuses the key" */
+      it("is given the same key, and no second key is minted", async () => {
+        const mintedBefore = await prisma.apiKey.count({
+          where: {
+            organizationId: testOrganization.id,
+            name: AGENT_SANDBOX_API_KEY_NAME,
+            roleBindings: { some: { scopeId: projectId } },
+          },
+        });
+
+        const first = await getOrMintAgentSandboxApiKey({
+          prisma,
+          projectId,
+          organizationId: testOrganization.id,
+          cache: sharedKeys,
+        });
+        const second = await getOrMintAgentSandboxApiKey({
+          prisma,
+          projectId,
+          organizationId: testOrganization.id,
+          cache: sharedKeys,
+        });
+
+        expect(second).toBe(first);
+        const mintedAfter = await prisma.apiKey.count({
+          where: {
+            organizationId: testOrganization.id,
+            name: AGENT_SANDBOX_API_KEY_NAME,
+            roleBindings: { some: { scopeId: projectId } },
+          },
+        });
+        expect(mintedAfter).toBe(mintedBefore + 1);
+
+        const written = await writeEntry("ACME_FROM_SHARED_KEY", second, {
+          value: "written-with-the-shared-key",
+        });
+        expect(written.status).toBe(200);
+        const res = await readEntry("ACME_FROM_SHARED_KEY", second);
+        expect(res.status).toBe(200);
+        expect(((await res.json()) as { value: string }).value).toBe(
+          "written-with-the-shared-key",
+        );
       });
     });
   });
@@ -546,7 +616,10 @@ describe("Feature: the agent cache", () => {
           {
             method: "PUT",
             headers: {
-              ...headersFor(personalSandboxToken, personalProjectId),
+              ...headersFor({
+                token: personalSandboxToken,
+                forProjectId: personalProjectId,
+              }),
               "Content-Type": "application/json",
             },
             body: JSON.stringify({ value: "written-in-the-owner-sandbox" }),
@@ -556,7 +629,12 @@ describe("Feature: the agent cache", () => {
 
         const res = await app.request(
           "/api/agent-cache/ACME_FROM_PERSONAL_SANDBOX",
-          { headers: headersFor(personalSandboxToken, personalProjectId) },
+          {
+            headers: headersFor({
+              token: personalSandboxToken,
+              forProjectId: personalProjectId,
+            }),
+          },
         );
         expect(res.status).toBe(200);
         expect(((await res.json()) as { value: string }).value).toBe(

--- a/platform/app/src/app/api/agent-cache/__tests__/agent-cache.integration.test.ts
+++ b/platform/app/src/app/api/agent-cache/__tests__/agent-cache.integration.test.ts
@@ -20,6 +20,7 @@ import {
 } from "~/generated/prisma/client";
 import { mintAgentSandboxApiKey } from "~/server/api-key/agent-sandbox-key";
 import { ApiKeyService } from "~/server/api-key/api-key.service";
+import { AGENT_SANDBOX_API_KEY_NAME } from "~/server/api-key/reserved-names";
 import { prisma } from "~/server/db";
 import { cleanupTestRows } from "~/test-utils/cleanupTestRows";
 import { wireDefaultTestApp } from "~/test-utils/wireDefaultTestApp";
@@ -45,10 +46,14 @@ describe("Feature: the agent cache", () => {
   let viewerToken: string;
   let sandboxToken: string;
   let userId: string;
+  let personalOwnerId: string;
+  let personalTeamId: string;
+  let personalProjectId: string;
+  let personalSandboxToken: string;
 
-  const headersFor = (token: string) => ({
+  const headersFor = (token: string, forProjectId: string = projectId) => ({
     Authorization: `Bearer ${token}`,
-    "X-Project-Id": projectId,
+    "X-Project-Id": forProjectId,
   });
 
   const readEntry = (name: string, token: string) =>
@@ -176,6 +181,68 @@ describe("Feature: the agent cache", () => {
       projectId,
       organizationId: testOrganization.id,
     });
+
+    // A personal workspace in the same organization: one owner, a team and a
+    // project both flagged personal, and the owner's ADMIN binding on the
+    // team, the way PersonalWorkspaceService provisions it.
+    const owner = await prisma.user.create({
+      data: { name: "Workspace Owner", email: `owner-${ns}@example.com` },
+    });
+    personalOwnerId = owner.id;
+    await prisma.organizationUser.create({
+      data: {
+        userId: personalOwnerId,
+        organizationId: testOrganization.id,
+        role: OrganizationUserRole.MEMBER,
+      },
+    });
+    const personalTeam = await prisma.team.create({
+      data: {
+        name: "Workspace Owner's Workspace",
+        slug: `--test-personal-team-${ns}`,
+        organizationId: testOrganization.id,
+        isPersonal: true,
+        ownerUserId: personalOwnerId,
+      },
+    });
+    personalTeamId = personalTeam.id;
+    await prisma.teamUser.create({
+      data: {
+        userId: personalOwnerId,
+        teamId: personalTeamId,
+        role: TeamUserRole.ADMIN,
+      },
+    });
+    await prisma.roleBinding.create({
+      data: {
+        id: generate(KSUID_RESOURCES.ROLE_BINDING).toString(),
+        organizationId: testOrganization.id,
+        userId: personalOwnerId,
+        role: TeamUserRole.ADMIN,
+        scopeType: RoleBindingScopeType.TEAM,
+        scopeId: personalTeamId,
+      },
+    });
+    const personalProject = await prisma.project.create({
+      data: {
+        id: `project_${nanoid()}`,
+        name: "Personal Workspace",
+        slug: `--test-personal-project-${ns}`,
+        language: "typescript",
+        framework: "other",
+        apiKey: `sk-lw-${nanoid(48)}`,
+        teamId: personalTeamId,
+        isPersonal: true,
+        ownerUserId: personalOwnerId,
+      },
+    });
+    personalProjectId = personalProject.id;
+
+    personalSandboxToken = await mintAgentSandboxApiKey({
+      prisma,
+      projectId: personalProjectId,
+      organizationId: testOrganization.id,
+    });
   });
 
   afterAll(async () => {
@@ -186,11 +253,15 @@ describe("Feature: the agent cache", () => {
       // role the organization owns.
       ["customRole", { organizationId: testOrganization.id }],
       ["project", { id: projectId }],
+      ["project", { id: personalProjectId }],
       ["teamUser", { teamId: testTeam.id }],
+      ["teamUser", { teamId: personalTeamId }],
       ["organizationUser", { organizationId: testOrganization.id }],
       ["team", { id: testTeam.id }],
+      ["team", { id: personalTeamId }],
       ["organization", { id: testOrganization.id }],
       ["user", { id: userId }],
+      ["user", { id: personalOwnerId }],
     ]);
   });
 
@@ -447,6 +518,50 @@ describe("Feature: the agent cache", () => {
           headers: headersFor(sandboxToken),
         });
         expect(res.status).toBe(403);
+      });
+    });
+  });
+
+  describe("given a run in a personal workspace", () => {
+    describe("when the run mints its key", () => {
+      /** @scenario "A run in a personal workspace gets a key its owner holds" */
+      it("belongs to the workspace owner and reaches that project's cache", async () => {
+        // A key owned by nobody is a second principal in a private
+        // workspace and the mint refuses it, so the run's key is the owner's
+        // own credential.
+        const minted = await prisma.apiKey.findMany({
+          where: {
+            organizationId: testOrganization.id,
+            name: AGENT_SANDBOX_API_KEY_NAME,
+            roleBindings: { some: { scopeId: personalProjectId } },
+          },
+          select: { userId: true, createdByUserId: true },
+        });
+        expect(minted).toEqual([
+          { userId: personalOwnerId, createdByUserId: personalOwnerId },
+        ]);
+
+        const written = await app.request(
+          "/api/agent-cache/ACME_FROM_PERSONAL_SANDBOX",
+          {
+            method: "PUT",
+            headers: {
+              ...headersFor(personalSandboxToken, personalProjectId),
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({ value: "written-in-the-owner-sandbox" }),
+          },
+        );
+        expect(written.status).toBe(200);
+
+        const res = await app.request(
+          "/api/agent-cache/ACME_FROM_PERSONAL_SANDBOX",
+          { headers: headersFor(personalSandboxToken, personalProjectId) },
+        );
+        expect(res.status).toBe(200);
+        expect(((await res.json()) as { value: string }).value).toBe(
+          "written-in-the-owner-sandbox",
+        );
       });
     });
   });

--- a/platform/app/src/components/agent-testing/__tests__/runDialog.integration.test.tsx
+++ b/platform/app/src/components/agent-testing/__tests__/runDialog.integration.test.tsx
@@ -1411,7 +1411,7 @@ describe("the run name", () => {
     await user.click(screen.getByTestId("run-dialog-name-caret"));
 
     const options = within(
-      screen.getByTestId("run-dialog-name-options"),
+      await screen.findByTestId("run-dialog-name-options"),
     ).getAllByRole("button");
     expect(options.map((option) => option.textContent)).toEqual([
       expect.stringContaining("Nightly refunds"),
@@ -1451,7 +1451,7 @@ describe("the run name", () => {
     renderDialog(suiteSubject());
 
     await user.click(screen.getByTestId("run-dialog-name-caret"));
-    const list = screen.getByTestId("run-dialog-name-options");
+    const list = await screen.findByTestId("run-dialog-name-options");
     expect(list).not.toHaveTextContent("stricter criterion");
 
     await user.click(within(list).getAllByRole("button")[0]!);
@@ -1474,7 +1474,7 @@ describe("the run name", () => {
 
     await user.click(screen.getByTestId("run-dialog-name-caret"));
     await user.click(
-      within(screen.getByTestId("run-dialog-name-options")).getAllByRole(
+      within(await screen.findByTestId("run-dialog-name-options")).getAllByRole(
         "button",
       )[0]!,
     );
@@ -1507,7 +1507,7 @@ describe("the run name", () => {
 
     await user.click(screen.getByTestId("run-dialog-name-caret"));
     await user.click(
-      within(screen.getByTestId("run-dialog-name-options")).getAllByRole(
+      within(await screen.findByTestId("run-dialog-name-options")).getAllByRole(
         "button",
       )[0]!,
     );
@@ -1560,16 +1560,18 @@ describe("the run name", () => {
     await user.type(field, "Nightly");
 
     const shown = within(
-      screen.getByTestId("run-dialog-name-options"),
+      await screen.findByTestId("run-dialog-name-options"),
     ).getAllByRole("button");
     expect(shown).toHaveLength(1);
     expect(shown[0]).toHaveTextContent("Nightly refunds");
 
     await user.clear(field);
     await user.type(field, "Something else entirely");
-    expect(
-      screen.queryByTestId("run-dialog-name-options"),
-    ).not.toBeInTheDocument();
+    await waitFor(() =>
+      expect(
+        screen.queryByTestId("run-dialog-name-options"),
+      ).not.toBeInTheDocument(),
+    );
   });
 
   /** @scenario "The arrow keys move and Enter takes the highlighted entry" */
@@ -1614,13 +1616,17 @@ describe("the run name", () => {
     // Opened from the caret, which is where the key lands: the caret took the
     // focus off the field.
     await user.click(screen.getByTestId("run-dialog-name-caret"));
-    expect(screen.getByTestId("run-dialog-name-options")).toBeInTheDocument();
+    expect(
+      await screen.findByTestId("run-dialog-name-options"),
+    ).toBeInTheDocument();
 
     await user.keyboard("{Escape}");
 
-    expect(
-      screen.queryByTestId("run-dialog-name-options"),
-    ).not.toBeInTheDocument();
+    await waitFor(() =>
+      expect(
+        screen.queryByTestId("run-dialog-name-options"),
+      ).not.toBeInTheDocument(),
+    );
     // The subject is what mounts the dialog, so its presence proves nothing:
     // the close the dialog would ask its caller for is what must not happen.
     expect(onClose).not.toHaveBeenCalled();

--- a/platform/app/src/server/api-key/__tests__/agent-sandbox-key.unit.test.ts
+++ b/platform/app/src/server/api-key/__tests__/agent-sandbox-key.unit.test.ts
@@ -21,7 +21,20 @@ vi.spyOn(ApiKeyService, "create").mockImplementation(
   () => ({ create }) as unknown as ApiKeyService,
 );
 
-const prisma = {} as PrismaClient;
+const findUnique = vi.fn();
+const prisma = { project: { findUnique } } as unknown as PrismaClient;
+
+const SHARED_PROJECT = {
+  isPersonal: false,
+  ownerUserId: null,
+  team: { isPersonal: false, ownerUserId: null },
+};
+
+const PERSONAL_PROJECT = {
+  isPersonal: true,
+  ownerUserId: "user_owner",
+  team: { isPersonal: true, ownerUserId: "user_owner" },
+};
 
 describe("the agent sandbox key", () => {
   beforeEach(() => {
@@ -30,11 +43,14 @@ describe("the agent sandbox key", () => {
       token: "sk-lw-minted",
       apiKey: { id: "key_1" },
     });
+    findUnique.mockReset();
+    findUnique.mockResolvedValue(SHARED_PROJECT);
   });
 
-  describe("given a project that can mint a key", () => {
-    describe("when a run asks for one", () => {
-      it("asks for the manage grain and nothing else", async () => {
+  describe("given a project in a shared team", () => {
+    describe("when a run asks for a key", () => {
+      /** @scenario "A run in a shared project gets a key no user holds" */
+      it("asks for the manage grain and nothing else, owned by no user", async () => {
         await mintAgentSandboxApiKey({
           prisma,
           projectId: "project_1",
@@ -46,6 +62,7 @@ describe("the agent sandbox key", () => {
           name: AGENT_SANDBOX_API_KEY_NAME,
           isSystemManaged: true,
           userId: null,
+          createdByUserId: null,
           permissionMode: "restricted",
           // Written out rather than read from the constant the code itself
           // passes: a grain added to that list has to fail here, which is the
@@ -66,6 +83,75 @@ describe("the agent sandbox key", () => {
 
         const { expiresAt } = create.mock.calls[0]?.[0] as { expiresAt: Date };
         expect(expiresAt.getTime()).toBeGreaterThan(Date.now());
+      });
+    });
+  });
+
+  describe("given a project in a personal workspace", () => {
+    describe("when a run asks for a key", () => {
+      it("mints the key as the workspace owner's own credential", async () => {
+        findUnique.mockResolvedValue(PERSONAL_PROJECT);
+
+        await mintAgentSandboxApiKey({
+          prisma,
+          projectId: "project_personal",
+          organizationId: "organization_1",
+        });
+
+        expect(findUnique).toHaveBeenCalledWith({
+          where: { id: "project_personal" },
+          select: {
+            isPersonal: true,
+            ownerUserId: true,
+            team: { select: { isPersonal: true, ownerUserId: true } },
+          },
+        });
+        expect(create.mock.calls[0]?.[0]).toMatchObject({
+          userId: "user_owner",
+          createdByUserId: "user_owner",
+          permissions: ["agentCache:manage"],
+          bindings: [
+            {
+              role: "CUSTOM",
+              scopeType: "PROJECT",
+              scopeId: "project_personal",
+            },
+          ],
+        });
+      });
+
+      it("takes the owner from the team when the project records none", async () => {
+        findUnique.mockResolvedValue({
+          isPersonal: false,
+          ownerUserId: null,
+          team: { isPersonal: true, ownerUserId: "user_owner" },
+        });
+
+        await mintAgentSandboxApiKey({
+          prisma,
+          projectId: "project_personal",
+          organizationId: "organization_1",
+        });
+
+        expect(create.mock.calls[0]?.[0]).toMatchObject({
+          userId: "user_owner",
+        });
+      });
+
+      it("leaves the key unowned when the workspace records no owner", async () => {
+        findUnique.mockResolvedValue({
+          isPersonal: true,
+          ownerUserId: null,
+          team: { isPersonal: true, ownerUserId: null },
+        });
+
+        await mintAgentSandboxApiKey({
+          prisma,
+          projectId: "project_personal",
+          organizationId: "organization_1",
+        });
+
+        expect(create.mock.calls[0]?.[0]).toMatchObject({ userId: null });
       });
     });
   });

--- a/platform/app/src/server/api-key/__tests__/agent-sandbox-key.unit.test.ts
+++ b/platform/app/src/server/api-key/__tests__/agent-sandbox-key.unit.test.ts
@@ -1,19 +1,33 @@
 /**
- * Unit coverage for the run-scoped sandbox key: what it asks for, what a
- * failed mint does to the run, and what the sweep is allowed to touch.
+ * Unit coverage for the sandbox key: what it asks for, how the runs of a
+ * project share it, what a failed mint does to the run, and what the sweep
+ * is allowed to touch.
  *
  * Spec: specs/agent-cache/agent-cache.feature
  */
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { PrismaClient } from "~/generated/prisma/client";
+import { TtlCache } from "~/server/utils/ttlCache";
 import {
+  AGENT_SANDBOX_KEY_REUSE_MS,
+  getOrMintAgentSandboxApiKey,
   mintAgentSandboxApiKey,
   reapExpiredAgentSandboxApiKeys,
-  tryMintAgentSandboxApiKey,
+  tryGetAgentSandboxApiKey,
 } from "../agent-sandbox-key";
 import { ApiKeyService } from "../api-key.service";
 import { AGENT_SANDBOX_API_KEY_NAME } from "../reserved-names";
+
+// Reversible stand-ins, so a test can tell what was held and can plant a
+// value the real decrypt would refuse.
+vi.mock("~/utils/encryption", () => ({
+  encrypt: (value: string) => `enc:${value}`,
+  decrypt: (value: string) => {
+    if (!value.startsWith("enc:")) throw new Error("unreadable");
+    return value.slice("enc:".length);
+  },
+}));
 
 const create = vi.fn();
 
@@ -156,14 +170,100 @@ describe("the agent sandbox key", () => {
     });
   });
 
-  describe("given a platform that cannot mint a key", () => {
+  describe("given a run of the project already got a key", () => {
+    const freshCache = () =>
+      new TtlCache<string>(AGENT_SANDBOX_KEY_REUSE_MS, "test:sandbox-key:");
+
+    describe("when a later run of the same project asks for one", () => {
+      it("is given the same key, and mints no second one", async () => {
+        const cache = freshCache();
+
+        const first = await getOrMintAgentSandboxApiKey({
+          prisma,
+          projectId: "project_1",
+          organizationId: "organization_1",
+          cache,
+        });
+        const second = await getOrMintAgentSandboxApiKey({
+          prisma,
+          projectId: "project_1",
+          organizationId: "organization_1",
+          cache,
+        });
+
+        expect(first).toBe("sk-lw-minted");
+        expect(second).toBe(first);
+        expect(create).toHaveBeenCalledTimes(1);
+      });
+
+      it("holds the shared token encrypted, never in the clear", async () => {
+        const cache = freshCache();
+
+        await getOrMintAgentSandboxApiKey({
+          prisma,
+          projectId: "project_1",
+          organizationId: "organization_1",
+          cache,
+        });
+
+        expect(await cache.get("project_1")).toBe("enc:sk-lw-minted");
+      });
+    });
+
+    describe("when a run of another project asks for one", () => {
+      it("mints that project its own key", async () => {
+        const cache = freshCache();
+
+        await getOrMintAgentSandboxApiKey({
+          prisma,
+          projectId: "project_1",
+          organizationId: "organization_1",
+          cache,
+        });
+        await getOrMintAgentSandboxApiKey({
+          prisma,
+          projectId: "project_2",
+          organizationId: "organization_1",
+          cache,
+        });
+
+        expect(create).toHaveBeenCalledTimes(2);
+        expect(create.mock.calls[1]?.[0]).toMatchObject({
+          bindings: [
+            { role: "CUSTOM", scopeType: "PROJECT", scopeId: "project_2" },
+          ],
+        });
+      });
+    });
+
+    describe("when the held token can no longer be read", () => {
+      /** @scenario "A shared key the platform can no longer read is replaced" */
+      it("mints a new key and shares that one from then on", async () => {
+        const cache = freshCache();
+        await cache.set("project_1", "written-before-the-secret-changed");
+
+        const token = await getOrMintAgentSandboxApiKey({
+          prisma,
+          projectId: "project_1",
+          organizationId: "organization_1",
+          cache,
+        });
+
+        expect(token).toBe("sk-lw-minted");
+        expect(create).toHaveBeenCalledTimes(1);
+        expect(await cache.get("project_1")).toBe("enc:sk-lw-minted");
+      });
+    });
+  });
+
+  describe("given a platform that holds no shared key and cannot mint one", () => {
     describe("when a run asks for one", () => {
       /** @scenario "A run whose key could not be minted still runs" */
       it("answers with no key rather than raising", async () => {
         create.mockRejectedValue(new Error("the ledger is unreachable"));
 
         await expect(
-          tryMintAgentSandboxApiKey({
+          tryGetAgentSandboxApiKey({
             prisma,
             projectId: "project_1",
             organizationId: "organization_1",

--- a/platform/app/src/server/api-key/agent-sandbox-key.ts
+++ b/platform/app/src/server/api-key/agent-sandbox-key.ts
@@ -1,5 +1,7 @@
 import { createLogger } from "@langwatch/observability";
 import type { PrismaClient } from "~/generated/prisma/client";
+import { decrypt, encrypt } from "~/utils/encryption";
+import { TtlCache } from "../utils/ttlCache";
 import { ApiKeyService } from "./api-key.service";
 import { AGENT_SANDBOX_API_KEY_NAME } from "./reserved-names";
 
@@ -12,6 +14,31 @@ const logger = createLogger("langwatch:api-key:agent-sandbox");
  * without the key does anyway.
  */
 export const AGENT_SANDBOX_KEY_TTL_MS = 12 * 60 * 60 * 1000;
+
+/**
+ * How long the runs of one project share a key before the next one is
+ * minted. Shorter than the key's own lifetime by a margin no run outlasts,
+ * so a run that picks up a shared key near the end of this window still
+ * holds a key with hours to live.
+ *
+ * Sharing is what keeps the key ledger small: a project that runs all day
+ * mints three keys, not one per run, and a project that runs nothing mints
+ * none. The key stays short-lived either way, because the token is only
+ * held for this window and never written to a durable store.
+ */
+export const AGENT_SANDBOX_KEY_REUSE_MS = 8 * 60 * 60 * 1000;
+
+const AGENT_SANDBOX_KEY_CACHE_PREFIX = "ttlcache:agent-sandbox-key:";
+
+/**
+ * The token each project's runs currently share, encrypted at rest, keyed by
+ * project id. The database holds only the token's hash, so this is the one
+ * place the plaintext survives past the mint, and only for the reuse window.
+ */
+const sharedKeys = new TtlCache<string>(
+  AGENT_SANDBOX_KEY_REUSE_MS,
+  AGENT_SANDBOX_KEY_CACHE_PREFIX,
+);
 
 /**
  * The whole surface a sandbox key reaches: the project's agent cache, and
@@ -69,13 +96,14 @@ async function sandboxKeyOwner({
  * Mint the credential a code agent's sandbox authenticates with.
  *
  * The key is bound to one project and holds the agent cache grains only, so
- * it is strictly narrower than the project key that authorized the run. The
- * run mints one and every row of that run shares it. In a shared project it
- * belongs to no user; in a personal workspace it belongs to the workspace
- * owner, see {@link sandboxKeyOwner}.
+ * it is strictly narrower than the project key that authorized the run. In a
+ * shared project it belongs to no user; in a personal workspace it belongs
+ * to the workspace owner, see {@link sandboxKeyOwner}.
  *
- * The token is returned once and is unrecoverable afterwards; only its hash is
- * stored. Nothing logs it.
+ * Runs do not call this directly: {@link getOrMintAgentSandboxApiKey} hands
+ * out the project's shared key and mints a new one here only when there is
+ * none to share. The token is returned once and is unrecoverable from the
+ * database afterwards; only its hash is stored there. Nothing logs it.
  */
 export async function mintAgentSandboxApiKey({
   prisma,
@@ -92,8 +120,8 @@ export async function mintAgentSandboxApiKey({
     isSystemManaged: true,
     name: AGENT_SANDBOX_API_KEY_NAME,
     description:
-      "Short-lived key for one code agent run. Reaches the project's agent " +
-      "cache and nothing else, and expires by itself.",
+      "Short-lived key shared by the code agent runs of one project. Reaches " +
+      "the project's agent cache and nothing else, and expires by itself.",
     // In a shared project there is no person behind a run's sandbox, and a
     // key with no owner has no user ceiling to clamp, so the grains below are
     // the whole ceiling. A personal workspace takes only its owner's own key.
@@ -110,13 +138,60 @@ export async function mintAgentSandboxApiKey({
 }
 
 /**
- * Mint a sandbox key, or report that the run goes without one.
+ * The key a run of this project puts in its sandbox: the one the project's
+ * runs currently share, or a freshly minted one when there is none.
+ *
+ * Every run of a project holds the same authority over the same cache, so
+ * one key serves them all. The shared token is held encrypted for
+ * {@link AGENT_SANDBOX_KEY_REUSE_MS}; once that passes, or when the held
+ * value cannot be read (the instance's encryption key changed, or the store
+ * lost the entry), the next run mints a new key and shares it in turn. Two
+ * runs that start together on an empty store may both mint; both keys are
+ * valid and the later one is the one shared from then on.
+ *
+ * `cache` is for tests, which hand in their own store rather than sharing
+ * the module's.
+ */
+export async function getOrMintAgentSandboxApiKey({
+  prisma,
+  projectId,
+  organizationId,
+  cache = sharedKeys,
+}: {
+  prisma: PrismaClient;
+  projectId: string;
+  organizationId: string;
+  cache?: TtlCache<string>;
+}): Promise<string> {
+  const held = await cache.get(projectId);
+  if (held !== undefined) {
+    try {
+      return decrypt(held);
+    } catch {
+      logger.warn(
+        { projectId },
+        "the shared agent sandbox key could not be read; minting a new one",
+      );
+    }
+  }
+
+  const token = await mintAgentSandboxApiKey({
+    prisma,
+    projectId,
+    organizationId,
+  });
+  await cache.set(projectId, encrypt(token));
+  return token;
+}
+
+/**
+ * Get the sandbox key for a run, or report that the run goes without one.
  *
  * A run that cannot get a key must still run: its rows each do their own work
  * and the cache simply never answers. So a failure here is a warning and an
  * `undefined`, never a thrown error that would stop the run.
  */
-export async function tryMintAgentSandboxApiKey({
+export async function tryGetAgentSandboxApiKey({
   prisma,
   projectId,
   organizationId,
@@ -126,7 +201,7 @@ export async function tryMintAgentSandboxApiKey({
   organizationId: string;
 }): Promise<string | undefined> {
   try {
-    return await mintAgentSandboxApiKey({
+    return await getOrMintAgentSandboxApiKey({
       prisma,
       projectId,
       organizationId,
@@ -134,7 +209,7 @@ export async function tryMintAgentSandboxApiKey({
   } catch (error) {
     logger.warn(
       { projectId, error },
-      "could not mint an agent sandbox key; the run continues without the agent cache",
+      "could not get an agent sandbox key; the run continues without the agent cache",
     );
     return undefined;
   }

--- a/platform/app/src/server/api-key/agent-sandbox-key.ts
+++ b/platform/app/src/server/api-key/agent-sandbox-key.ts
@@ -28,11 +28,51 @@ export const AGENT_SANDBOX_PERMISSIONS: readonly string[] = [
 ];
 
 /**
+ * Whose credential the sandbox key is: the workspace owner's in a personal
+ * workspace, nobody's in a shared project.
+ *
+ * A personal workspace admits no principal but its owner, and a key owned by
+ * nobody is a second principal, so `ApiKeyService.create` refuses it there
+ * (`assertPersonalTeamScopesOwnedBy`). The one credential such a workspace
+ * accepts is its owner's own, which is the owner acting programmatically, the
+ * same way the Langy session key is minted. The owner's ceiling then caps the
+ * key, and the owner administers their own workspace, so the manage grain is
+ * inside it.
+ *
+ * A personal workspace with no recorded owner answers null, and the mint is
+ * refused the same way it would be for a stranger: failing closed is the
+ * guard's own rule for incomplete provisioning.
+ */
+async function sandboxKeyOwner({
+  prisma,
+  projectId,
+}: {
+  prisma: PrismaClient;
+  projectId: string;
+}): Promise<string | null> {
+  const project = await prisma.project.findUnique({
+    where: { id: projectId },
+    select: {
+      isPersonal: true,
+      ownerUserId: true,
+      team: { select: { isPersonal: true, ownerUserId: true } },
+    },
+  });
+  if (!project) return null;
+  if (project.isPersonal || project.team.isPersonal) {
+    return project.ownerUserId ?? project.team.ownerUserId ?? null;
+  }
+  return null;
+}
+
+/**
  * Mint the credential a code agent's sandbox authenticates with.
  *
- * The key belongs to no user, is bound to one project, and holds the agent
- * cache grains only, so it is strictly narrower than the project key that
- * authorized the run. The run mints one and every row of that run shares it.
+ * The key is bound to one project and holds the agent cache grains only, so
+ * it is strictly narrower than the project key that authorized the run. The
+ * run mints one and every row of that run shares it. In a shared project it
+ * belongs to no user; in a personal workspace it belongs to the workspace
+ * owner, see {@link sandboxKeyOwner}.
  *
  * The token is returned once and is unrecoverable afterwards; only its hash is
  * stored. Nothing logs it.
@@ -46,6 +86,7 @@ export async function mintAgentSandboxApiKey({
   projectId: string;
   organizationId: string;
 }): Promise<string> {
+  const ownerUserId = await sandboxKeyOwner({ prisma, projectId });
   const service = ApiKeyService.create(prisma);
   const { token } = await service.create({
     isSystemManaged: true,
@@ -53,10 +94,11 @@ export async function mintAgentSandboxApiKey({
     description:
       "Short-lived key for one code agent run. Reaches the project's agent " +
       "cache and nothing else, and expires by itself.",
-    // No owner: there is no person behind a run's sandbox, and a key with no
-    // owner has no user ceiling to clamp. The grains below are the whole
-    // ceiling instead.
-    userId: null,
+    // In a shared project there is no person behind a run's sandbox, and a
+    // key with no owner has no user ceiling to clamp, so the grains below are
+    // the whole ceiling. A personal workspace takes only its owner's own key.
+    userId: ownerUserId,
+    createdByUserId: ownerUserId,
     organizationId,
     permissionMode: "restricted",
     permissions: [...AGENT_SANDBOX_PERMISSIONS],

--- a/platform/app/src/server/experiments-v3/execution/orchestrator.ts
+++ b/platform/app/src/server/experiments-v3/execution/orchestrator.ts
@@ -40,7 +40,7 @@ import type {
 } from "~/optimization_studio/types/events";
 import { nodeErrorToDomainError } from "~/optimization_studio/utils/nodeErrorDomain";
 import type { TypedAgent } from "~/server/agents/agent.repository";
-import { tryMintAgentSandboxApiKey } from "~/server/api-key/agent-sandbox-key";
+import { tryGetAgentSandboxApiKey } from "~/server/api-key/agent-sandbox-key";
 import { getApp } from "~/server/app-layer/app";
 import { prisma } from "~/server/db";
 import type {
@@ -1430,9 +1430,10 @@ function runExecutesCode({
 /**
  * The credential every code node of this run authenticates with, or undefined.
  *
- * One key for the whole run: every row shares the cache entries the run
- * writes, and a key per row would leave a row of live credentials behind each
- * run. A run that cannot get one still runs, and every row does its own work.
+ * One key for the whole run, and the same key the project's other runs hold:
+ * every row shares the cache entries the run writes, and a key per row or per
+ * run would leave a ledger of live credentials behind. A run that cannot get
+ * one still runs, and every row does its own work.
  */
 async function mintRunSandboxApiKey({
   projectId,
@@ -1452,7 +1453,7 @@ async function mintRunSandboxApiKey({
   const organizationId = project?.team?.organizationId;
   if (!organizationId) return undefined;
 
-  return tryMintAgentSandboxApiKey({ prisma, projectId, organizationId });
+  return tryGetAgentSandboxApiKey({ prisma, projectId, organizationId });
 }
 
 /**

--- a/platform/app/src/server/scenarios/execution/data-prefetcher.ts
+++ b/platform/app/src/server/scenarios/execution/data-prefetcher.ts
@@ -38,7 +38,7 @@ import { validateWorkflowAgentMappings } from "./validate-workflow-mappings";
 
 const logger = createLogger("langwatch:scenarios:data-prefetcher");
 
-import { tryMintAgentSandboxApiKey } from "~/server/api-key/agent-sandbox-key";
+import { tryGetAgentSandboxApiKey } from "~/server/api-key/agent-sandbox-key";
 import { decrypt } from "~/utils/encryption";
 import {
   AgentRepository,
@@ -527,10 +527,10 @@ export async function prefetchScenarioData({
   // prompt with this run plan, so they arrive with the suite rather than with
   // the prompt. Agents carry their own on the agent record, already loaded
   // above.
-  // One key for the whole run, not one per turn: every turn of this run shares
-  // the cache entries it writes, and a key per turn would leave a row of live
-  // credentials behind each run. A run that cannot get one still runs, and
-  // every turn does its own work.
+  // One key for the whole run, and the same key the project's other runs
+  // hold: every turn of this run shares the cache entries it writes, and a key
+  // per turn or per run would leave a ledger of live credentials behind. A
+  // run that cannot get one still runs, and every turn does its own work.
   if (adapterData.type === "code" && project.organizationId) {
     adapterData.sandboxApiKey = await deps.sandboxKeyMinter.mint({
       projectId: context.projectId,
@@ -1352,7 +1352,7 @@ export function createDataPrefetcherDependencies(): DataPrefetcherDependencies {
         }),
     },
     sandboxKeyMinter: {
-      mint: (params) => tryMintAgentSandboxApiKey({ prisma, ...params }),
+      mint: (params) => tryGetAgentSandboxApiKey({ prisma, ...params }),
     },
     modelResolver: {
       resolve: async (featureKey, projectId) => {

--- a/specs/agent-cache/agent-cache.feature
+++ b/specs/agent-cache/agent-cache.feature
@@ -190,15 +190,23 @@ Feature: The agent cache
       When the agent claims ACME_SESSION
       Then the agent is given false, and no exception is raised
 
-  Rule: A run reaches the cache with a key minted for that run
+  Rule: A run reaches the cache with a key the project's runs share
 
     # The key is bound to one project, holds the manage grain and nothing
     # else, and expires after twelve hours. It is never the project key. In a
     # shared project it belongs to no user. A personal workspace admits no
     # principal but its owner, so there the key is the owner's own, which is
-    # the owner acting programmatically. A run that cannot mint one still
+    # the owner acting programmatically. A run that cannot get one still
     # runs: every row does its own work, which is what a run without the
     # cache does anyway.
+    #
+    # Every run of a project holds the same authority over the same cache, so
+    # the runs share one key rather than minting one each: a project that runs
+    # all day mints a few keys, one that runs nothing mints none. The shared
+    # token is held encrypted for eight of the key's twelve hours, so a run
+    # that picks it up late still holds a key with hours to live, and the key
+    # stays short-lived because the plaintext is never written anywhere
+    # durable.
     #
     # The manage grain alone, because it is what all three routes ask for.
     # Adding agentCache:view would reach no route today, and would hand every
@@ -206,15 +214,29 @@ Feature: The agent cache
 
     @integration
     Scenario: The sandbox key reaches the agent cache
-      Given a key minted for one run of this project
+      Given a key minted for the runs of this project
       When the run stores an entry and reads it back
       Then the request succeeds
 
     @integration
     Scenario: The sandbox key reaches nothing else
-      Given a key minted for one run of this project
+      Given a key minted for the runs of this project
       When the run calls another route in the same project
       Then the request is refused as forbidden
+
+    @integration
+    Scenario: A later run in the same project reuses the key
+      Given a run of this project got a key
+      When a later run of the same project asks for one
+      Then it is given the same key
+      And no second key is minted
+      And the key still reaches the agent cache
+
+    @unit
+    Scenario: A shared key the platform can no longer read is replaced
+      Given the held token cannot be read
+      When a run asks for a key
+      Then a new key is minted and shared from then on
 
     @integration
     Scenario: A run in a personal workspace gets a key its owner holds
@@ -231,7 +253,7 @@ Feature: The agent cache
 
     @unit
     Scenario: A run whose key could not be minted still runs
-      Given the platform cannot mint a sandbox key
+      Given the platform holds no shared key and cannot mint one
       When the run starts
       Then the run executes with no cache credential
       And the failure is warned about, not raised

--- a/specs/agent-cache/agent-cache.feature
+++ b/specs/agent-cache/agent-cache.feature
@@ -192,10 +192,13 @@ Feature: The agent cache
 
   Rule: A run reaches the cache with a key minted for that run
 
-    # The key belongs to no user, is bound to one project, holds the manage
-    # grain and nothing else, and expires after twelve hours. It is never the
-    # project key. A run that cannot mint one still runs: every row does its
-    # own work, which is what a run without the cache does anyway.
+    # The key is bound to one project, holds the manage grain and nothing
+    # else, and expires after twelve hours. It is never the project key. In a
+    # shared project it belongs to no user. A personal workspace admits no
+    # principal but its owner, so there the key is the owner's own, which is
+    # the owner acting programmatically. A run that cannot mint one still
+    # runs: every row does its own work, which is what a run without the
+    # cache does anyway.
     #
     # The manage grain alone, because it is what all three routes ask for.
     # Adding agentCache:view would reach no route today, and would hand every
@@ -212,6 +215,19 @@ Feature: The agent cache
       Given a key minted for one run of this project
       When the run calls another route in the same project
       Then the request is refused as forbidden
+
+    @integration
+    Scenario: A run in a personal workspace gets a key its owner holds
+      Given a project in a personal workspace
+      When a run of that project mints its key
+      Then the key belongs to the workspace owner
+      And the key reaches the agent cache of that project
+
+    @unit
+    Scenario: A run in a shared project gets a key no user holds
+      Given a project in a shared team
+      When a run of that project mints its key
+      Then the key belongs to no user
 
     @unit
     Scenario: A run whose key could not be minted still runs


### PR DESCRIPTION
## What

A code agent run in a personal workspace now gets its agent cache credential. The sandbox key is minted as the workspace owner's own key there, and stays a key no user holds in a shared project.

## Why

Production dogfooding of #7596 (the agent cache claim) turned up a run that never reached the cache. The code block reported no `LANGWATCH_*` variable in its environment, and every row logged in on its own.

The cause is in the mint, not in the engine:

- `mintAgentSandboxApiKey` minted a service key (`userId: null`) bound to the run's project.
- `ApiKeyService.create` runs `assertPersonalTeamScopesOwnedBy`, which refuses a key owned by nobody that reaches a personal workspace: such a key is a second principal in a workspace that admits only its owner.
- `tryMintAgentSandboxApiKey` catches that, warns, and returns `undefined`, so the engine injects nothing and the run continues without the cache.

Evidence from production:

- Postgres: 22 sandbox keys were minted between 08-26 14:54 and 08-27 00:51, every one bound to a project in a shared team. None for a personal workspace, including two runs made on purpose on 08-28.
- Loki, `{service_name="langwatch-app"} |= "could not mint"`, last 8h: exactly two lines, one per run, `could not mint an agent sandbox key; the run continues without the agent cache — Personal workspace teams have exactly one member: their owner.`
- The Lambda for that project runs `langwatch-nlp-lambda:git-77a155e` with `LANGWATCH_ENDPOINT` set, so the engine side was ready and the key was the empty half.

## How

`sandboxKeyOwner` reads the project's own and its team's `isPersonal` and `ownerUserId`. A personal workspace answers its owner, and the mint passes that as `userId` and `createdByUserId`, which is the owner acting programmatically, the same way the Langy session key is minted. The owner administers their own workspace, so `agentCache:manage` is inside their ceiling. A shared project answers null and the key is minted as before.

A personal workspace with no recorded owner answers null and the mint is refused as before: failing closed is the guard's own rule for incomplete provisioning.

## The runs of a project share one key

Every run used to mint its own key, and the reaper only revokes, so each run left one revoked `ApiKey` row behind. The listings never showed them (the name is in `HIDDEN_SYSTEM_KEY_NAMES`), but the table grew by one row per run.

Every run of a project holds the same authority over the same cache, so one key serves them all. `getOrMintAgentSandboxApiKey` hands out the project's shared key from an encrypted `TtlCache` entry (Redis, memory fallback) keyed by project id, and mints a new one only when there is none. The token is held for 8 of the key's 12 hours, so a run that picks it up late still holds a key with at least 4 hours to live. A project that runs all day mints three keys, not one per run; a project that runs nothing mints none.

The key stays short-lived: the database holds only the hash, and the plaintext lives only in the store for the reuse window. A held token the platform can no longer read (the encryption key changed, or the store lost the entry) is replaced by a fresh mint. Two runs that start together on an empty store may both mint; both keys are valid and the later one is shared from then on.

Both callers (`orchestrator.ts`, `data-prefetcher.ts`) now call `tryGetAgentSandboxApiKey`; the mint-once-per-run behavior inside a run is unchanged.

## Tests

- `specs/agent-cache/agent-cache.feature`: four new scenarios, `A run in a personal workspace gets a key its owner holds` (integration), `A run in a shared project gets a key no user holds` (unit), `A later run in the same project reuses the key` (integration) and `A shared key the platform can no longer read is replaced` (unit). 30/30 bound.
- `agent-cache.integration.test.ts`: seeds a personal workspace (owner, personal team and project, owner ADMIN binding), mints, asserts the key row belongs to the owner, and writes and reads an entry with that token. Two get-or-mint calls for the same project return the same token, add exactly one key row, and that token reaches the cache. 19/19. Against the old minter this file fails in `beforeAll` with `PersonalWorkspaceNotManagedHereError`, which is the production failure.
- `agent-sandbox-key.unit.test.ts`: shared project stays unowned, personal project takes the owner from the project or the team, a personal workspace with no owner stays unowned, a second run reuses the key, the held token is encrypted, another project gets its own key, an unreadable held token is replaced. 11/11.

## Deployment Impact

Runtime change in the app only. No migration, no new environment variable, no change to the engine or the SDK. The key a personal workspace run mints is now owned by the workspace owner, still named `Agent sandbox run`, still hidden from key lists, still reaped by the hourly sweep. Shared projects are unchanged.

The shared token lives in Redis under `ttlcache:agent-sandbox-key:<projectId>`, encrypted with `CREDENTIALS_SECRET`, for 8 hours. Rotating that secret turns held tokens into misses, and the next run of each project mints a fresh key. Pods without Redis fall back to a per-pod memory entry, which only means more mints, never a wrong key.

After this deploys, a code agent run in a personal workspace gets `LANGWATCH_API_KEY` in its sandbox for the first time, so `langwatch.cache` starts answering there, and the key table grows by a few rows per active project per day instead of one per run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sandbox credentials are now short-lived and shared across runs within the same project.
  * Personal workspace credentials are assigned to the workspace owner, while shared project credentials remain unowned.
  * Credentials are securely reused and automatically replaced when expired or unreadable.

* **Documentation**
  * Updated agent cache and sandbox credential documentation to reflect the new sharing and ownership behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->