### PR TITLE
fix(nlpgo): raise Code block default timeout from 60s to 600s

### DIFF
--- a/services/nlpgo/app/engine/blocks/codeblock/codeblock.go
+++ b/services/nlpgo/app/engine/blocks/codeblock/codeblock.go
@@ -112,7 +112,7 @@ func New(opts Options) (*Executor, error) {
 		opts.Python = "python3"
 	}
 	if opts.DefaultTimeout == 0 {
-		opts.DefaultTimeout = 60 * time.Second
+		opts.DefaultTimeout = 600 * time.Second
 	}
 	// Secure default: a nil allowlist means "the caller didn't opt out of
 	// the safe default", NOT "inherit everything". A non-nil empty slice is

--- a/services/nlpgo/cmd/root_test.go
+++ b/services/nlpgo/cmd/root_test.go
@@ -135,9 +135,9 @@ func TestResolveSandboxPython_HonorsTheUnprefixedImageSetting(t *testing.T) {
 // TestNewCodeExecutor_AppliesConfiguredCodeBlockTimeout pins the operator
 // knob to the executor that enforces it. `CodeBlockTimeoutSeconds` was
 // declared, defaulted and documented but never read: `codeblock.New` was
-// called without `DefaultTimeout`, so the executor's own 60s fallback won
-// every time and a long-running code block could not be given more room
-// from configuration.
+// called without `DefaultTimeout`, so the executor's own default fallback
+// won every time and a long-running code block could not be given more
+// room from configuration.
 func TestNewCodeExecutor_AppliesConfiguredCodeBlockTimeout(t *testing.T) {
 	getenv := func(string) string { return "" }
 
@@ -153,10 +153,10 @@ func TestNewCodeExecutor_AppliesConfiguredCodeBlockTimeout(t *testing.T) {
 	}
 }
 
-// TestNewCodeExecutor_UnsetTimeoutKeepsTheSixtySecondDefault guards the
+// TestNewCodeExecutor_UnsetTimeoutKeepsTheTenMinuteDefault guards the
 // wiring against turning an unset knob into a zero-length — that is,
 // already-expired — timeout.
-func TestNewCodeExecutor_UnsetTimeoutKeepsTheSixtySecondDefault(t *testing.T) {
+func TestNewCodeExecutor_UnsetTimeoutKeepsTheTenMinuteDefault(t *testing.T) {
 	getenv := func(string) string { return "" }
 
 	exec, err := newCodeExecutor(nlpgo.EngineConfig{
@@ -165,7 +165,7 @@ func TestNewCodeExecutor_UnsetTimeoutKeepsTheSixtySecondDefault(t *testing.T) {
 	if err != nil {
 		t.Fatalf("newCodeExecutor: %v", err)
 	}
-	if got, want := exec.DefaultTimeout(), 60*time.Second; got != want {
+	if got, want := exec.DefaultTimeout(), 600*time.Second; got != want {
 		t.Errorf("DefaultTimeout() = %v; want %v", got, want)
 	}
 }
@@ -174,7 +174,7 @@ func TestNewCodeExecutor_UnsetTimeoutKeepsTheSixtySecondDefault(t *testing.T) {
 // negative NLPGO_ENGINE_CODE_BLOCK_TIMEOUT_SECONDS must not become a negative duration.
 // codeblock.Execute feeds this straight into context.WithTimeout, so a
 // negative value would produce an already-expired context and kill every
-// code block instantly. Zero defers to codeblock.New's 60s fallback.
+// code block instantly. Zero defers to codeblock.New's 600s fallback.
 func TestResolveCodeBlockTimeout(t *testing.T) {
 	cases := []struct {
 		name    string
@@ -212,7 +212,7 @@ func TestNewCodeExecutor_NegativeTimeoutDoesNotExpireImmediately(t *testing.T) {
 	if got := exec.DefaultTimeout(); got <= 0 {
 		t.Errorf("DefaultTimeout() = %v; want a positive duration", got)
 	}
-	if got, want := exec.DefaultTimeout(), 60*time.Second; got != want {
+	if got, want := exec.DefaultTimeout(), 600*time.Second; got != want {
 		t.Errorf("DefaultTimeout() = %v; want %v", got, want)
 	}
 }

--- a/services/nlpgo/config.go
+++ b/services/nlpgo/config.go
@@ -105,7 +105,13 @@ func defaultConfig() Config {
 			// anchored both at 12min (under Lambda's 15min cap with
 			// margin for the outer connection to drain).
 			StreamIdleTimeoutSeconds: 720,
-			CodeBlockTimeoutSeconds:  60,
+			// 10min: raised from 60s because 60s was breaking legitimate
+			// user code blocks. Kept strictly below StreamIdleTimeoutSeconds
+			// (12min) rather than matched to it, since a long-running code
+			// block emits no SSE events while it runs and a ceiling at or
+			// above the idle timeout would race the stream shutting down
+			// mid-run.
+			CodeBlockTimeoutSeconds: 600,
 			// 12min for every block that calls out of the process, for the
 			// same reason the idle timeout above is 12min: a customer agent
 			// backend, sub-workflow or evaluator chain legitimately runs


### PR DESCRIPTION
## What

Raises the nlpgo Code block's default execution timeout from 60s to 600s (10 minutes).

Two sites changed:
- `services/nlpgo/config.go:108` — `Engine.CodeBlockTimeoutSeconds` default, resolved into the operator-facing env var `NLPGO_ENGINE_CODE_BLOCK_TIMEOUT_SECONDS`.
- `services/nlpgo/app/engine/blocks/codeblock/codeblock.go:115` — the executor's own fallback when `Options.DefaultTimeout` is unset (kept in sync with the config default, per the existing pattern the file already documents for the other blocks).

`services/nlpgo/cmd/root_test.go` pins these defaults in `TestNewCodeExecutor_UnsetTimeoutKeepsTheSixtySecondDefault` (renamed to `...TenMinuteDefault`) and `TestNewCodeExecutor_NegativeTimeoutDoesNotExpireImmediately`; both updated to assert 600s instead of 60s. Comments referencing the old fallback value were updated too. `services/nlpgo/config_test.go`'s `TestBlockTimeoutDefaultsMatchTodaysHardcodedValues` does not cover the Code block (it only pins HTTP/agent-workflow/evaluator at 720s) so it needed no change.

## Why 600s and not 720s (matching the sibling blocks)

`Engine.StreamIdleTimeoutSeconds` also defaults to 720s. `config_test.go` already documents this as a load-bearing invariant:

> `StreamIdleTimeoutSeconds = 720 (12min) — must outlive the slowest single agent HTTP call (httpblock.DefaultTimeout = 12min) so customers running slow agent backends don't see the inbound SSE stream torn down mid-call.`

A running code block emits no SSE events for its whole duration. If the code-block ceiling were set to 720s — equal to the idle timeout — a code block that ran the full duration would race the stream idle-closing at the same instant it finishes, rather than safely outliving it. 600s keeps a real margin under 720s so the stream cannot close out from under a legitimately slow block.

Side note for the reviewer, not something this PR touches: the same comment already claims 720 "must outlive" the 720s HTTP-block timeout, but those two values are equal, not one strictly greater than the other. Flagging it as a pre-existing observation only.

Also: the TS-side ceiling `NLP_FETCH_MAX_TIMEOUT_DEFAULT_MS` is 900_000ms (900s), so 600s comfortably fits under it.

## The tradeoff — please push back if this is wrong

Code blocks execute untrusted customer Python and hold a worker for the whole duration they run. Raising the default from 60s to 600s means a single hostile or pathological block can now occupy a worker up to 10x longer than before — a real capacity and abuse-surface change, not just a UX tweak.

Counter-argument for why I think this is still the right default:
- 60s was breaking legitimate user workflows — this was a real user-reported failure, not a hypothetical.
- Every sibling block (HTTP, agent-workflow, evaluator) already defaults to 720s; Code was the outlier at 60s.
- The value stays fully operator-configurable via `NLPGO_ENGINE_CODE_BLOCK_TIMEOUT_SECONDS`, so any deployment that wants a tighter worker-occupancy ceiling can lower it without a code change.

Not overselling this — it's a real capacity tradeoff, and if the abuse-surface concern outweighs the UX fix for this deployment, happy to adjust.

## Verification (services/nlpgo)

```
$ go build ./...
(no output — success)

$ go vet ./...
(no output — success)

$ gofmt -l .
(no output — success)

$ go test -count=1 ./...
```

Full `go test` run: all packages pass except `app/engine/blocks/codeblock`, which fails on 8 `TestSharedSessionCodeAgent_*` tests. Confirmed pre-existing and unrelated: same 8 tests fail identically on a pristine `origin/main` checkout with none of this PR's changes applied (verified in a separate worktree, ran `go test -count=1 ./app/engine/blocks/codeblock/...`, identical failures/counts). Every timeout/clamp-related test passes, including `cmd` (root_test.go, updated in this PR) and `app/engine/blocks/blocktimeout`.

Failing (pre-existing, not from this PR):
- TestSharedSessionCodeAgent_FirstRowLogsInAndStoresTheSession
- TestSharedSessionCodeAgent_LaterRowReusesTheStoredSession
- TestSharedSessionCodeAgent_RowLogsInAgainOnceTheEntryHasLapsed
- TestSharedSessionCodeAgent_RowLogsInAgainWhenTheTargetRefusesTheSession
- TestSharedSessionCodeAgent_RowReadsASessionStoredAfterItStarted
- TestSharedSessionCodeAgent_RowsThatStartTogetherLogInOnce
- TestSharedSessionCodeAgent_RowsThatStartTogetherLogInOnceOnASlowLogin
- TestSharedSessionCodeAgent_RowLogsInWhenTheClaimHolderStoresNothing


## Deployment Impact

This changes a **compiled default** in the `nlpgo` service, so it only takes effect once a new image is built and deployed. There is no schema change, no migration, and no config file to update.

**What changes on deploy:** any Code block that previously ran with the implicit 60s ceiling now gets 600s. Deployments that already set `NLPGO_ENGINE_CODE_BLOCK_TIMEOUT_SECONDS` are unaffected — the env var still wins.

**Who is affected:** self-hosted and SaaS operators who never set the env var. A hostile or runaway Code block can now hold a sandbox worker for 10x longer before being killed. Operators who want the old behaviour can pin it back with `NLPGO_ENGINE_CODE_BLOCK_TIMEOUT_SECONDS=60`.

**Rollback:** revert the commit, or set the env var to `60` — no data migration to undo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Increased the default code-block execution timeout from 1 minute to 10 minutes.
  * Longer-running code blocks can now complete without timing out prematurely.

* **Bug Fixes**
  * Reduced interruptions for legitimate code executions that require more than 60 seconds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
