### PR TITLE
fix(python-sdk): the agent cache takes a dict or list, and a refusal names the field

### DIFF
--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -174,6 +174,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      # The check reads docs written in the pull request and prints them in a
+      # ::error annotation, which GitHub reads as a workflow command. This
+      # proves the values are encoded before they reach one.
+      - name: Check the prose script encodes its annotations
+        run: bash docs/scripts/check-docs-prose.test.sh
+
       - name: Check docs prose for banned words
         run: bash docs/scripts/check-docs-prose.sh
         env:

--- a/docs/agent-simulations/authenticated-agents.mdx
+++ b/docs/agent-simulations/authenticated-agents.mdx
@@ -333,7 +333,7 @@ langwatch.cache.delete("ACME_SESSION")
 
 `get` returns the default on a miss, so no `try`/`except` is needed for that case. `claim` returns `True` when it stored the value and `False` when the name was already held, and does not raise for a name it could not take. Other errors raise, and a refused write names the field the platform rejected, for example `400 (validation_error: ttl_seconds: ttl_seconds must be at least 5)`.
 
-A value can be text, or a `dict` or `list`: the SDK stores those as JSON and `get` returns the JSON-parsed equivalent, so a session object goes in and comes back as a `dict`. The members must be what JSON can carry, a member of another type raises a `TypeError`, and a key that is not a string is stored as one. A value of another type raises a `TypeError` before the call is made.
+A value can be text, or a `dict` or `list`: the SDK stores those as JSON and `get` returns the JSON-parsed equivalent, so a session object goes in and comes back as a `dict`. The members must be what JSON can carry: a member of another type raises a `TypeError`, `nan` and `inf` are refused with it, and a key that is not a string is stored as one. A value of another type raises a `TypeError` before the call is made.
 
 An entry holds only text, so text that is itself a JSON object or array reads back parsed as well: store `"{\"mode\":\"legacy\"}"` and `get` answers a `dict`. This holds for an entry written over REST or by an older SDK too. Any other text comes back as it was stored, JSON that is not an object or an array included.
 

--- a/docs/agent-simulations/authenticated-agents.mdx
+++ b/docs/agent-simulations/authenticated-agents.mdx
@@ -335,7 +335,7 @@ langwatch.cache.delete("ACME_SESSION")
 
 A value can be text, or a `dict` or `list`: the SDK stores those as JSON and `get` returns the JSON-parsed equivalent, so a session object goes in and comes back as a `dict`. The members must be what JSON can carry, a member of another type raises a `TypeError`, and a key that is not a string is stored as one. A value of another type raises a `TypeError` before the call is made.
 
-The entry holds text and nothing else, so text that is itself a JSON object or array reads back parsed as well: store `"{\"mode\":\"legacy\"}"` and `get` answers a `dict`. This holds for an entry written over REST or by an older SDK too. Any other text, JSON that is not an object or an array included, comes back as it was stored.
+An entry holds only text, so text that is itself a JSON object or array reads back parsed as well: store `"{\"mode\":\"legacy\"}"` and `get` answers a `dict`. This holds for an entry written over REST or by an older SDK too. Any other text comes back as it was stored, JSON that is not an object or an array included.
 
 Also available over REST at [`/api/agent-cache/{name}`](/api-reference/agent-cache/get-entry).
 

--- a/docs/agent-simulations/authenticated-agents.mdx
+++ b/docs/agent-simulations/authenticated-agents.mdx
@@ -297,7 +297,7 @@ The agent also treats a `401` as an expired session: it logs in again and retrie
 | Rule | Value |
 |---|---|
 | Entry name | `UPPER_SNAKE_CASE`, up to 64 characters |
-| Value type | Text, or a `dict` or `list`, which the SDK stores as JSON and reads back parsed. Over REST the value is always a string |
+| Value type | Text, or a `dict` or `list` of what JSON can carry, which the SDK stores as JSON and reads back parsed. Over REST the value is always a string |
 | Value size | Up to 32 KB |
 | Lifetime | 5 seconds to 24 hours, 15 minutes by default |
 
@@ -333,7 +333,9 @@ langwatch.cache.delete("ACME_SESSION")
 
 `get` returns the default on a miss, so no `try`/`except` is needed for that case. `claim` returns `True` when it stored the value and `False` when the name was already held, and does not raise for a name it could not take. Other errors raise, and a refused write names the field the platform rejected, for example `400 (validation_error: ttl_seconds: ttl_seconds must be at least 5)`.
 
-A value can be text, or a `dict` or `list`: the SDK stores those as JSON and `get` returns them parsed, so a session object goes in and comes out as the same `dict`. Any other type raises a `TypeError` before the call is made.
+A value can be text, or a `dict` or `list`: the SDK stores those as JSON and `get` returns the JSON-parsed equivalent, so a session object goes in and comes back as a `dict`. The members must be what JSON can carry, a member of another type raises a `TypeError`, and a key that is not a string is stored as one. A value of another type raises a `TypeError` before the call is made.
+
+The entry holds text and nothing else, so text that is itself a JSON object or array reads back parsed as well: store `"{\"mode\":\"legacy\"}"` and `get` answers a `dict`. This holds for an entry written over REST or by an older SDK too. Any other text, JSON that is not an object or an array included, comes back as it was stored.
 
 Also available over REST at [`/api/agent-cache/{name}`](/api-reference/agent-cache/get-entry).
 

--- a/docs/agent-simulations/authenticated-agents.mdx
+++ b/docs/agent-simulations/authenticated-agents.mdx
@@ -297,6 +297,7 @@ The agent also treats a `401` as an expired session: it logs in again and retrie
 | Rule | Value |
 |---|---|
 | Entry name | `UPPER_SNAKE_CASE`, up to 64 characters |
+| Value type | Text, or a `dict` or `list`, which the SDK stores as JSON and reads back parsed. Over REST the value is always a string |
 | Value size | Up to 32 KB |
 | Lifetime | 5 seconds to 24 hours, 15 minutes by default |
 
@@ -330,7 +331,9 @@ langwatch.cache.claim("ACME_SESSION_CLAIM", "taken", ttl_seconds=15)
 langwatch.cache.delete("ACME_SESSION")
 ```
 
-`get` returns the default on a miss, so no `try`/`except` is needed for that case. `claim` returns `True` when it stored the value and `False` when the name was already held, and does not raise for a name it could not take. Other errors raise.
+`get` returns the default on a miss, so no `try`/`except` is needed for that case. `claim` returns `True` when it stored the value and `False` when the name was already held, and does not raise for a name it could not take. Other errors raise, and a refused write names the field the platform rejected, for example `400 (validation_error: ttl_seconds: ttl_seconds must be at least 5)`.
+
+A value can be text, or a `dict` or `list`: the SDK stores those as JSON and `get` returns them parsed, so a session object goes in and comes out as the same `dict`. Any other type raises a `TypeError` before the call is made.
 
 Also available over REST at [`/api/agent-cache/{name}`](/api-reference/agent-cache/get-entry).
 
@@ -340,5 +343,6 @@ Also available over REST at [`/api/agent-cache/{name}`](/api-reference/agent-cac
 |---|---|
 | Agent answers are empty | The token exchange or API call raised. Check the credentials and endpoint URLs. (Improved error surfacing is tracked in [#6340](https://github.com/langwatch/langwatch/issues/6340).) |
 | `missing_output` error | The Python returned a dict without one of the agent's declared output keys. |
+| `langwatch.cache.set` raises `400 (validation_error: value: Expected string, received object)` | The SDK in the sandbox predates dict values; it sends the object as is and the route takes a string. Pass `json.dumps(session)` and `json.loads` it after `get`, or update the SDK. |
 | Credential works locally but not on the platform | The secret name in `secrets.NAME` doesn't match a stored project secret, or the value was stored in a different project. |
 | Timeout | Token fetch + downstream call exceeded the 60s runner budget. Check both endpoints' latency. |

--- a/docs/agent-simulations/authenticated-agents.mdx
+++ b/docs/agent-simulations/authenticated-agents.mdx
@@ -333,7 +333,7 @@ langwatch.cache.delete("ACME_SESSION")
 
 `get` returns the default on a miss, so no `try`/`except` is needed for that case. `claim` returns `True` when it stored the value and `False` when the name was already held, and does not raise for a name it could not take. Other errors raise, and a refused write names the field the platform rejected, for example `400 (validation_error: ttl_seconds: ttl_seconds must be at least 5)`.
 
-A value can be text, or a `dict` or `list`: the SDK stores those as JSON and `get` returns the JSON-parsed equivalent, so a session object goes in and comes back as a `dict`. The members must be what JSON can carry: a member of another type raises a `TypeError`, `nan` and `inf` are refused with it, and a key that is not a string is stored as one. A value of another type raises a `TypeError` before the call is made.
+A value can be text, or a `dict` or `list`: the SDK stores those as JSON and `get` returns the JSON-parsed equivalent, so a session object goes in and comes back as a `dict`. What comes back is what JSON carries, and JSON has fewer types than Python: a tuple reads back as a `list`, and a key that is not a string reads back as one. A member JSON has no type for raises a `TypeError`, and so do `nan` and `inf`. A value of another type raises a `TypeError` before the call is made.
 
 An entry holds only text, so text that is itself a JSON object or array reads back parsed as well: store `"{\"mode\":\"legacy\"}"` and `get` answers a `dict`. This holds for an entry written over REST or by an older SDK too. Any other text comes back as it was stored, JSON that is not an object or an array included.
 

--- a/docs/agent-simulations/authenticated-agents.mdx
+++ b/docs/agent-simulations/authenticated-agents.mdx
@@ -297,7 +297,7 @@ The agent also treats a `401` as an expired session: it logs in again and retrie
 | Rule | Value |
 |---|---|
 | Entry name | `UPPER_SNAKE_CASE`, up to 64 characters |
-| Value type | Text, or a `dict` or `list` of what JSON can carry, which the SDK stores as JSON and reads back parsed. Over REST the value is always a string |
+| Value type | `str`, `dict` or `list`. The SDK stores a `dict` or `list` as JSON and `get` returns it parsed. Over REST the value is always a string |
 | Value size | Up to 32 KB |
 | Lifetime | 5 seconds to 24 hours, 15 minutes by default |
 
@@ -331,11 +331,11 @@ langwatch.cache.claim("ACME_SESSION_CLAIM", "taken", ttl_seconds=15)
 langwatch.cache.delete("ACME_SESSION")
 ```
 
-`get` returns the default on a miss, so no `try`/`except` is needed for that case. `claim` returns `True` when it stored the value and `False` when the name was already held, and does not raise for a name it could not take. Other errors raise, and a refused write names the field the platform rejected, for example `400 (validation_error: ttl_seconds: ttl_seconds must be at least 5)`.
+`get` returns `default` on a miss. `claim` returns `True` when it stored the value and `False` when another row already holds the name. Every other failure raises, with the rejected field in the message: `400 (validation_error: ttl_seconds: ttl_seconds must be at least 5)`.
 
-A value can be text, or a `dict` or `list`: the SDK stores those as JSON and `get` returns the JSON-parsed equivalent, so a session object goes in and comes back as a `dict`. What comes back is what JSON carries, and JSON has fewer types than Python: a tuple reads back as a `list`, and a key that is not a string reads back as one. A member JSON has no type for raises a `TypeError`, and so do `nan` and `inf`. A value of another type raises a `TypeError` before the call is made.
+Pass a `str`, a `dict` or a `list` as the value. The SDK stores a `dict` or `list` as JSON and `get` returns it parsed, so JSON types apply: a tuple comes back as a `list`, a non-string key as a string, and a value JSON cannot encode (`nan`, `inf`, a set, a datetime) raises `TypeError` before the call.
 
-An entry holds only text, so text that is itself a JSON object or array reads back parsed as well: store `"{\"mode\":\"legacy\"}"` and `get` answers a `dict`. This holds for an entry written over REST or by an older SDK too. Any other text comes back as it was stored, JSON that is not an object or an array included.
+Text that is a JSON object or array also comes back parsed, including an entry written over REST or by an older SDK. Any other text comes back unchanged.
 
 Also available over REST at [`/api/agent-cache/{name}`](/api-reference/agent-cache/get-entry).
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -35972,7 +35972,7 @@ langwatch.cache.delete("ACME_SESSION")
 
 `get` returns the default on a miss, so no `try`/`except` is needed for that case. `claim` returns `True` when it stored the value and `False` when the name was already held, and does not raise for a name it could not take. Other errors raise, and a refused write names the field the platform rejected, for example `400 (validation_error: ttl_seconds: ttl_seconds must be at least 5)`.
 
-A value can be text, or a `dict` or `list`: the SDK stores those as JSON and `get` returns the JSON-parsed equivalent, so a session object goes in and comes back as a `dict`. The members must be what JSON can carry, a member of another type raises a `TypeError`, and a key that is not a string is stored as one. A value of another type raises a `TypeError` before the call is made.
+A value can be text, or a `dict` or `list`: the SDK stores those as JSON and `get` returns the JSON-parsed equivalent, so a session object goes in and comes back as a `dict`. The members must be what JSON can carry: a member of another type raises a `TypeError`, `nan` and `inf` are refused with it, and a key that is not a string is stored as one. A value of another type raises a `TypeError` before the call is made.
 
 An entry holds only text, so text that is itself a JSON object or array reads back parsed as well: store `"{\"mode\":\"legacy\"}"` and `get` answers a `dict`. This holds for an entry written over REST or by an older SDK too. Any other text comes back as it was stored, JSON that is not an object or an array included.
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -35936,7 +35936,7 @@ The agent also treats a `401` as an expired session: it logs in again and retrie
 | Rule | Value |
 |---|---|
 | Entry name | `UPPER_SNAKE_CASE`, up to 64 characters |
-| Value type | Text, or a `dict` or `list`, which the SDK stores as JSON and reads back parsed. Over REST the value is always a string |
+| Value type | Text, or a `dict` or `list` of what JSON can carry, which the SDK stores as JSON and reads back parsed. Over REST the value is always a string |
 | Value size | Up to 32 KB |
 | Lifetime | 5 seconds to 24 hours, 15 minutes by default |
 
@@ -35972,7 +35972,9 @@ langwatch.cache.delete("ACME_SESSION")
 
 `get` returns the default on a miss, so no `try`/`except` is needed for that case. `claim` returns `True` when it stored the value and `False` when the name was already held, and does not raise for a name it could not take. Other errors raise, and a refused write names the field the platform rejected, for example `400 (validation_error: ttl_seconds: ttl_seconds must be at least 5)`.
 
-A value can be text, or a `dict` or `list`: the SDK stores those as JSON and `get` returns them parsed, so a session object goes in and comes out as the same `dict`. Any other type raises a `TypeError` before the call is made.
+A value can be text, or a `dict` or `list`: the SDK stores those as JSON and `get` returns the JSON-parsed equivalent, so a session object goes in and comes back as a `dict`. The members must be what JSON can carry, a member of another type raises a `TypeError`, and a key that is not a string is stored as one. A value of another type raises a `TypeError` before the call is made.
+
+The entry holds text and nothing else, so text that is itself a JSON object or array reads back parsed as well: store `"{\"mode\":\"legacy\"}"` and `get` answers a `dict`. This holds for an entry written over REST or by an older SDK too. Any other text, JSON that is not an object or an array included, comes back as it was stored.
 
 Also available over REST at [`/api/agent-cache/{name}`](/api-reference/agent-cache/get-entry).
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -35936,6 +35936,7 @@ The agent also treats a `401` as an expired session: it logs in again and retrie
 | Rule | Value |
 |---|---|
 | Entry name | `UPPER_SNAKE_CASE`, up to 64 characters |
+| Value type | Text, or a `dict` or `list`, which the SDK stores as JSON and reads back parsed. Over REST the value is always a string |
 | Value size | Up to 32 KB |
 | Lifetime | 5 seconds to 24 hours, 15 minutes by default |
 
@@ -35969,7 +35970,9 @@ langwatch.cache.claim("ACME_SESSION_CLAIM", "taken", ttl_seconds=15)
 langwatch.cache.delete("ACME_SESSION")
 ```
 
-`get` returns the default on a miss, so no `try`/`except` is needed for that case. `claim` returns `True` when it stored the value and `False` when the name was already held, and does not raise for a name it could not take. Other errors raise.
+`get` returns the default on a miss, so no `try`/`except` is needed for that case. `claim` returns `True` when it stored the value and `False` when the name was already held, and does not raise for a name it could not take. Other errors raise, and a refused write names the field the platform rejected, for example `400 (validation_error: ttl_seconds: ttl_seconds must be at least 5)`.
+
+A value can be text, or a `dict` or `list`: the SDK stores those as JSON and `get` returns them parsed, so a session object goes in and comes out as the same `dict`. Any other type raises a `TypeError` before the call is made.
 
 Also available over REST at [`/api/agent-cache/{name}`](/api-reference/agent-cache/get-entry).
 
@@ -35979,6 +35982,7 @@ Also available over REST at [`/api/agent-cache/{name}`](/api-reference/agent-cac
 |---|---|
 | Agent answers are empty | The token exchange or API call raised. Check the credentials and endpoint URLs. (Improved error surfacing is tracked in [#6340](https://github.com/langwatch/langwatch/issues/6340).) |
 | `missing_output` error | The Python returned a dict without one of the agent's declared output keys. |
+| `langwatch.cache.set` raises `400 (validation_error: value: Expected string, received object)` | The SDK in the sandbox predates dict values; it sends the object as is and the route takes a string. Pass `json.dumps(session)` and `json.loads` it after `get`, or update the SDK. |
 | Credential works locally but not on the platform | The secret name in `secrets.NAME` doesn't match a stored project secret, or the value was stored in a different project. |
 | Timeout | Token fetch + downstream call exceeded the 60s runner budget. Check both endpoints' latency. |
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -35972,7 +35972,7 @@ langwatch.cache.delete("ACME_SESSION")
 
 `get` returns the default on a miss, so no `try`/`except` is needed for that case. `claim` returns `True` when it stored the value and `False` when the name was already held, and does not raise for a name it could not take. Other errors raise, and a refused write names the field the platform rejected, for example `400 (validation_error: ttl_seconds: ttl_seconds must be at least 5)`.
 
-A value can be text, or a `dict` or `list`: the SDK stores those as JSON and `get` returns the JSON-parsed equivalent, so a session object goes in and comes back as a `dict`. The members must be what JSON can carry: a member of another type raises a `TypeError`, `nan` and `inf` are refused with it, and a key that is not a string is stored as one. A value of another type raises a `TypeError` before the call is made.
+A value can be text, or a `dict` or `list`: the SDK stores those as JSON and `get` returns the JSON-parsed equivalent, so a session object goes in and comes back as a `dict`. What comes back is what JSON carries, and JSON has fewer types than Python: a tuple reads back as a `list`, and a key that is not a string reads back as one. A member JSON has no type for raises a `TypeError`, and so do `nan` and `inf`. A value of another type raises a `TypeError` before the call is made.
 
 An entry holds only text, so text that is itself a JSON object or array reads back parsed as well: store `"{\"mode\":\"legacy\"}"` and `get` answers a `dict`. This holds for an entry written over REST or by an older SDK too. Any other text comes back as it was stored, JSON that is not an object or an array included.
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -35974,7 +35974,7 @@ langwatch.cache.delete("ACME_SESSION")
 
 A value can be text, or a `dict` or `list`: the SDK stores those as JSON and `get` returns the JSON-parsed equivalent, so a session object goes in and comes back as a `dict`. The members must be what JSON can carry, a member of another type raises a `TypeError`, and a key that is not a string is stored as one. A value of another type raises a `TypeError` before the call is made.
 
-The entry holds text and nothing else, so text that is itself a JSON object or array reads back parsed as well: store `"{\"mode\":\"legacy\"}"` and `get` answers a `dict`. This holds for an entry written over REST or by an older SDK too. Any other text, JSON that is not an object or an array included, comes back as it was stored.
+An entry holds only text, so text that is itself a JSON object or array reads back parsed as well: store `"{\"mode\":\"legacy\"}"` and `get` answers a `dict`. This holds for an entry written over REST or by an older SDK too. Any other text comes back as it was stored, JSON that is not an object or an array included.
 
 Also available over REST at [`/api/agent-cache/{name}`](/api-reference/agent-cache/get-entry).
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -35936,7 +35936,7 @@ The agent also treats a `401` as an expired session: it logs in again and retrie
 | Rule | Value |
 |---|---|
 | Entry name | `UPPER_SNAKE_CASE`, up to 64 characters |
-| Value type | Text, or a `dict` or `list` of what JSON can carry, which the SDK stores as JSON and reads back parsed. Over REST the value is always a string |
+| Value type | `str`, `dict` or `list`. The SDK stores a `dict` or `list` as JSON and `get` returns it parsed. Over REST the value is always a string |
 | Value size | Up to 32 KB |
 | Lifetime | 5 seconds to 24 hours, 15 minutes by default |
 
@@ -35970,11 +35970,11 @@ langwatch.cache.claim("ACME_SESSION_CLAIM", "taken", ttl_seconds=15)
 langwatch.cache.delete("ACME_SESSION")
 ```
 
-`get` returns the default on a miss, so no `try`/`except` is needed for that case. `claim` returns `True` when it stored the value and `False` when the name was already held, and does not raise for a name it could not take. Other errors raise, and a refused write names the field the platform rejected, for example `400 (validation_error: ttl_seconds: ttl_seconds must be at least 5)`.
+`get` returns `default` on a miss. `claim` returns `True` when it stored the value and `False` when another row already holds the name. Every other failure raises, with the rejected field in the message: `400 (validation_error: ttl_seconds: ttl_seconds must be at least 5)`.
 
-A value can be text, or a `dict` or `list`: the SDK stores those as JSON and `get` returns the JSON-parsed equivalent, so a session object goes in and comes back as a `dict`. What comes back is what JSON carries, and JSON has fewer types than Python: a tuple reads back as a `list`, and a key that is not a string reads back as one. A member JSON has no type for raises a `TypeError`, and so do `nan` and `inf`. A value of another type raises a `TypeError` before the call is made.
+Pass a `str`, a `dict` or a `list` as the value. The SDK stores a `dict` or `list` as JSON and `get` returns it parsed, so JSON types apply: a tuple comes back as a `list`, a non-string key as a string, and a value JSON cannot encode (`nan`, `inf`, a set, a datetime) raises `TypeError` before the call.
 
-An entry holds only text, so text that is itself a JSON object or array reads back parsed as well: store `"{\"mode\":\"legacy\"}"` and `get` answers a `dict`. This holds for an entry written over REST or by an older SDK too. Any other text comes back as it was stored, JSON that is not an object or an array included.
+Text that is a JSON object or array also comes back parsed, including an entry written over REST or by an older SDK. Any other text comes back unchanged.
 
 Also available over REST at [`/api/agent-cache/{name}`](/api-reference/agent-cache/get-entry).
 

--- a/docs/scripts/check-docs-prose.sh
+++ b/docs/scripts/check-docs-prose.sh
@@ -93,7 +93,8 @@ for file in "${FILES[@]}"; do
       while IFS= read -r match; do
         lineno="${match%%:*}"
         text="${match#*:}"
-        echo "::error file=$rel,line=$lineno::$text  [$label]"
+        word=$(printf '%s' "$text" | grep -oiE "$pattern" | head -1)
+        echo "::error file=$rel,line=$lineno::The word \"$word\" is forbidden ($label). Read https://nexus.langwatch.ai/wiki/docs-writing-rules to learn how to write better docs. Load your nexus access skill to read it; if you do not have one or do not know how to access Nexus, ask your user for access so you can pass this CI check. Line: $text"
         ERRORS=$((ERRORS + 1))
       done <<< "$matches"
     fi

--- a/docs/scripts/check-docs-prose.sh
+++ b/docs/scripts/check-docs-prose.sh
@@ -42,6 +42,27 @@ PATTERNS=$(cat <<'RULES'
 RULES
 )
 
+# GitHub reads an ::error line as a workflow command, so a value that reaches
+# one is percent-encoded first. A docs line holding a carriage return would
+# otherwise end the annotation early, and one holding a percent sign would read
+# as an encoded character. A property value carries a colon and a comma too,
+# which are what separate the properties.
+encode_data() {
+  local value="$1"
+  value="${value//%/%25}"
+  value="${value//$'\r'/%0D}"
+  value="${value//$'\n'/%0A}"
+  printf '%s' "$value"
+}
+
+encode_property() {
+  local value
+  value="$(encode_data "$1")"
+  value="${value//:/%3A}"
+  value="${value//,/%2C}"
+  printf '%s' "$value"
+}
+
 MODE="diff"
 if [[ "${1:-}" == "--all" ]]; then
   MODE="all"
@@ -85,7 +106,7 @@ for file in "${FILES[@]}"; do
     matches=$(echo "$cleaned" | grep -niE "$pattern") || rc=$?
     rc="${rc:-0}"
     if [[ $rc -gt 1 ]]; then
-      echo "::error file=$rel::grep failed (exit $rc) on pattern: $pattern"
+      echo "::error file=$(encode_property "$rel")::grep failed (exit $rc) on pattern: $(encode_data "$pattern")"
       ERRORS=$((ERRORS + 1))
       continue
     fi
@@ -94,7 +115,7 @@ for file in "${FILES[@]}"; do
         lineno="${match%%:*}"
         text="${match#*:}"
         word=$(printf '%s' "$text" | grep -oiE "$pattern" | head -1)
-        echo "::error file=$rel,line=$lineno::The word \"$word\" is forbidden ($label). Read https://nexus.langwatch.ai/wiki/docs-writing-rules to learn how to write better docs. Load your nexus access skill to read it; if you do not have one or do not know how to access Nexus, ask your user for access so you can pass this CI check. Line: $text"
+        echo "::error file=$(encode_property "$rel"),line=$lineno::The word \"$(encode_data "$word")\" is forbidden ($label). Read https://nexus.langwatch.ai/wiki/docs-writing-rules to learn how to write better docs. Load your nexus access skill to read it; if you do not have one or do not know how to access Nexus, ask your user for access so you can pass this CI check. Line: $(encode_data "$text")"
         ERRORS=$((ERRORS + 1))
       done <<< "$matches"
     fi

--- a/docs/scripts/check-docs-prose.test.sh
+++ b/docs/scripts/check-docs-prose.test.sh
@@ -18,8 +18,11 @@ trap 'rm -rf "$WORK"' EXIT
 mkdir -p "$WORK/docs/scripts"
 cp "$SCRIPTS_DIR/check-docs-prose.sh" "$WORK/docs/scripts/check-docs-prose.sh"
 
-# A banned word, a percent sign and a carriage return, on one line.
-printf 'Nothing 100%% here\r and more\n' > "$WORK/docs/page.mdx"
+# A banned word, a percent sign and a carriage return, on one line. The page
+# name carries a colon and a comma, which is what separates the annotation
+# properties from each other and from the message.
+PAGE_NAME='page,one:two.mdx'
+printf 'Nothing 100%% here\r and more\n' > "$WORK/docs/$PAGE_NAME"
 
 OUTPUT="$(bash "$WORK/docs/scripts/check-docs-prose.sh" --all 2>&1)"
 STATUS=$?
@@ -45,10 +48,10 @@ fi
 
 ANNOTATION="$(printf '%s\n' "$OUTPUT" | grep '^::error' | head -1)"
 
-if [[ "$ANNOTATION" == *"page.mdx"* ]]; then
-  check "the annotation names the page" yes
+if [[ "$ANNOTATION" == *"page%2Cone%3Atwo.mdx"* ]]; then
+  check "the page name reads with its colon and comma encoded" yes
 else
-  check "the annotation names the page" no
+  check "the page name reads with its colon and comma encoded" no
 fi
 
 if [[ "$ANNOTATION" == *$'\r'* ]]; then

--- a/docs/scripts/check-docs-prose.test.sh
+++ b/docs/scripts/check-docs-prose.test.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# Checks that check-docs-prose.sh reports a banned word, and that a docs line
+# holding a carriage return or a percent sign cannot reach the ::error
+# annotation unencoded. GitHub reads an ::error line as a workflow command, so
+# an unencoded carriage return would end the annotation early and an unencoded
+# percent sign would read as an encoded character.
+#
+# The script scans the docs tree it sits in, so the test copies it into a
+# temporary tree that holds one page. The real docs are untouched.
+
+SCRIPTS_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+mkdir -p "$WORK/docs/scripts"
+cp "$SCRIPTS_DIR/check-docs-prose.sh" "$WORK/docs/scripts/check-docs-prose.sh"
+
+# A banned word, a percent sign and a carriage return, on one line.
+printf 'Nothing 100%% here\r and more\n' > "$WORK/docs/page.mdx"
+
+OUTPUT="$(bash "$WORK/docs/scripts/check-docs-prose.sh" --all 2>&1)"
+STATUS=$?
+
+FAILURES=0
+
+check() {
+  local description="$1"
+  local ok="$2"
+  if [[ "$ok" == "yes" ]]; then
+    echo "ok: $description"
+  else
+    echo "FAILED: $description"
+    FAILURES=$((FAILURES + 1))
+  fi
+}
+
+if [[ $STATUS -eq 1 ]]; then
+  check "the banned word fails the check" yes
+else
+  check "the banned word fails the check" no
+fi
+
+ANNOTATION="$(printf '%s\n' "$OUTPUT" | grep '^::error' | head -1)"
+
+if [[ "$ANNOTATION" == *"page.mdx"* ]]; then
+  check "the annotation names the page" yes
+else
+  check "the annotation names the page" no
+fi
+
+if [[ "$ANNOTATION" == *$'\r'* ]]; then
+  check "the carriage return stays out of the annotation" no
+else
+  check "the carriage return stays out of the annotation" yes
+fi
+
+if [[ "$ANNOTATION" == *"%0D"* ]]; then
+  check "the carriage return reads as %0D" yes
+else
+  check "the carriage return reads as %0D" no
+fi
+
+if [[ "$ANNOTATION" == *"100%25"* ]]; then
+  check "the percent sign reads as %25" yes
+else
+  check "the percent sign reads as %25" no
+fi
+
+if [[ $FAILURES -gt 0 ]]; then
+  echo ""
+  echo "Annotation: $ANNOTATION"
+  echo "$FAILURES check(s) failed."
+  exit 1
+fi
+
+echo "check-docs-prose.sh annotation checks passed."

--- a/sdks/python/src/langwatch/cache.py
+++ b/sdks/python/src/langwatch/cache.py
@@ -76,10 +76,12 @@ def _raise_for_status(response: httpx.Response) -> None:
 def _encode(value: CacheValue) -> str:
     """The text the platform stores: a str as is, a dict or list as JSON.
 
-    A dict or list must hold what JSON can carry, so a member of another type
-    raises a TypeError here, and a key that is not a string is stored as one.
-    nan and inf are refused with it: Python writes them as NaN and Infinity,
-    which the REST callers and the other SDKs read as broken JSON.
+    What comes back is what JSON carries, and JSON has fewer types than
+    Python: a tuple is stored as an array and reads back as a list, and a key
+    that is not a string is stored as one. A member JSON has no type for
+    raises a TypeError here, and so do nan and inf, which Python writes as
+    NaN and Infinity for the REST callers and the other SDKs to read as
+    broken JSON.
     """
     if isinstance(value, str):
         return value

--- a/sdks/python/src/langwatch/cache.py
+++ b/sdks/python/src/langwatch/cache.py
@@ -8,8 +8,9 @@ so the rows that follow read it instead of repeating the work.
 Values are encrypted at rest, expire on their own, and belong to one project.
 """
 
+import json
 import urllib.parse
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional, Union
 
 import httpx
 
@@ -17,23 +18,43 @@ from langwatch.generated.langwatch_rest_api_client.client import (
     Client as LangWatchRestApiClient,
 )
 from langwatch.state import get_instance
-from langwatch.utils.exceptions import extract_api_error_code
+from langwatch.utils.exceptions import (
+    extract_api_error_code,
+    extract_api_error_reasons,
+)
 from langwatch.utils.initialization import ensure_setup
+
+CacheValue = Union[str, Dict[str, Any], List[Any]]
+"""What an entry holds: text, or a dict or list, which travels as JSON text."""
 
 
 def _quote(value: str) -> str:
     return urllib.parse.quote(value, safe="")
 
 
-def _error_code(response: httpx.Response) -> str:
+def _error_detail(response: httpx.Response) -> str:
+    """The platform's code and the fields it named, or an empty string.
+
+    A refused write names the field and what was expected of it, which is the
+    one thing the caller needs to fix it. Nothing from the request itself is
+    read back: the platform's wording never quotes a value.
+    """
     try:
-        return extract_api_error_code(response.json()) or ""
+        body = response.json()
     except Exception:
         return ""
+    code = extract_api_error_code(body) or ""
+    reasons = extract_api_error_reasons(body)
+    if code and reasons:
+        return f" ({code}: {'; '.join(reasons)})"
+    if code:
+        return f" ({code})"
+    return ""
 
 
 def _raise_for_status(response: httpx.Response) -> None:
-    """Raise for a refused call, naming the status and the platform's code.
+    """Raise for a refused call, naming the status, the platform's code and
+    the fields it rejected.
 
     Nothing from the request reaches the message. A cache value is a
     credential often enough that quoting one in an exception, which a run then
@@ -43,13 +64,38 @@ def _raise_for_status(response: httpx.Response) -> None:
         return
 
     status = response.status_code
-    code = _error_code(response)
-    detail = f" ({code})" if code else ""
-    if status in (400, 404):
+    detail = _error_detail(response)
+    if status in (400, 404, 422):
         raise ValueError(f"The agent cache refused the call: {status}{detail}")
     if status in (401, 403):
         raise RuntimeError(f"The agent cache refused the credential: {status}{detail}")
     raise RuntimeError(f"The agent cache answered {status}{detail}")
+
+
+def _encode(value: CacheValue) -> str:
+    """The text the platform stores: a str as is, a dict or list as JSON."""
+    if isinstance(value, str):
+        return value
+    if isinstance(value, (dict, list)):
+        return json.dumps(value)
+    raise TypeError(
+        "A cache value must be a str, a dict or a list; "
+        f"got {type(value).__name__}"
+    )
+
+
+def _decode(text: str) -> CacheValue:
+    """The value the caller stored: JSON text of a dict or list comes back
+    parsed, any other text comes back as it is."""
+    stripped = text.lstrip()
+    if stripped.startswith("{") or stripped.startswith("["):
+        try:
+            parsed = json.loads(text)
+        except ValueError:
+            return text
+        if isinstance(parsed, (dict, list)):
+            return parsed
+    return text
 
 
 class CacheFacade:
@@ -71,13 +117,18 @@ class CacheFacade:
     def _http(self) -> httpx.Client:
         return self._client.get_httpx_client()
 
-    def get(self, name: str, default: Optional[str] = None) -> Optional[str]:
+    def get(
+        self, name: str, default: Optional[CacheValue] = None
+    ) -> Optional[CacheValue]:
         """
         Read an entry, or `default` when the project holds none under `name`.
 
         A name that was never stored and one whose lifetime has passed answer
         the same way, so the calling code has one branch rather than a
         try/except around every read.
+
+        A dict or list stored through `set` or `claim` comes back parsed;
+        text comes back as it was stored.
 
         Args:
             name: Entry name (UPPER_SNAKE_CASE).
@@ -87,21 +138,22 @@ class CacheFacade:
         if response.status_code == 404:
             return default
         _raise_for_status(response)
-        return response.json()["value"]
+        return _decode(response.json()["value"])
 
     def set(
-        self, name: str, value: str, ttl_seconds: Optional[int] = None
+        self, name: str, value: CacheValue, ttl_seconds: Optional[int] = None
     ) -> Dict[str, Any]:
         """
         Store a value under a name, whether or not the name is held yet.
 
         Args:
             name: Entry name (UPPER_SNAKE_CASE).
-            value: What to store. It is encrypted server-side.
+            value: What to store: text, or a dict or list, which is stored as
+                JSON and comes back parsed. It is encrypted server-side.
             ttl_seconds: How long the entry stays readable. The project's
                 default applies when this is not given.
         """
-        body: Dict[str, Any] = {"value": value}
+        body: Dict[str, Any] = {"value": _encode(value)}
         if ttl_seconds is not None:
             body["ttl_seconds"] = ttl_seconds
 
@@ -109,7 +161,9 @@ class CacheFacade:
         _raise_for_status(response)
         return response.json()
 
-    def claim(self, name: str, value: str, ttl_seconds: Optional[int] = None) -> bool:
+    def claim(
+        self, name: str, value: CacheValue, ttl_seconds: Optional[int] = None
+    ) -> bool:
         """
         Take a name, but only if the project does not hold it yet.
 
@@ -124,11 +178,12 @@ class CacheFacade:
 
         Args:
             name: Entry name (UPPER_SNAKE_CASE).
-            value: What to store. It is encrypted server-side.
+            value: What to store: text, or a dict or list, which is stored as
+                JSON and comes back parsed. It is encrypted server-side.
             ttl_seconds: How long the entry stays readable. The project's
                 default applies when this is not given.
         """
-        body: Dict[str, Any] = {"value": value}
+        body: Dict[str, Any] = {"value": _encode(value)}
         if ttl_seconds is not None:
             body["ttl_seconds"] = ttl_seconds
 

--- a/sdks/python/src/langwatch/cache.py
+++ b/sdks/python/src/langwatch/cache.py
@@ -78,10 +78,10 @@ def _encode(value: CacheValue) -> str:
 
     What comes back is what JSON carries, and JSON has fewer types than
     Python: a tuple is stored as an array and reads back as a list, and a key
-    that is not a string is stored as one. A member JSON has no type for
-    raises a TypeError here, and so do nan and inf, which Python writes as
-    NaN and Infinity for the REST callers and the other SDKs to read as
-    broken JSON.
+    that is not a string is stored as one. A TypeError is raised here for a
+    member with no JSON type, a set or a datetime for example, and for nan
+    and inf, which Python writes as NaN and Infinity for the REST callers and
+    the other SDKs to read as broken JSON.
     """
     if isinstance(value, str):
         return value

--- a/sdks/python/src/langwatch/cache.py
+++ b/sdks/python/src/langwatch/cache.py
@@ -25,7 +25,8 @@ from langwatch.utils.exceptions import (
 from langwatch.utils.initialization import ensure_setup
 
 CacheValue = Union[str, Dict[str, Any], List[Any]]
-"""What an entry holds: text, or a dict or list, which travels as JSON text."""
+"""What an entry holds: text, or a dict or list of what JSON can carry, which
+travels as JSON text."""
 
 
 def _quote(value: str) -> str:
@@ -73,7 +74,11 @@ def _raise_for_status(response: httpx.Response) -> None:
 
 
 def _encode(value: CacheValue) -> str:
-    """The text the platform stores: a str as is, a dict or list as JSON."""
+    """The text the platform stores: a str as is, a dict or list as JSON.
+
+    A dict or list must hold what JSON can carry, so a member of another type
+    raises a TypeError here, and a key that is not a string is stored as one.
+    """
     if isinstance(value, str):
         return value
     if isinstance(value, (dict, list)):
@@ -86,7 +91,15 @@ def _encode(value: CacheValue) -> str:
 
 def _decode(text: str) -> CacheValue:
     """The value the caller stored: JSON text of a dict or list comes back
-    parsed, any other text comes back as it is."""
+    parsed, any other text comes back as it is.
+
+    The entry holds text and nothing else, so text that is itself a JSON
+    object or array cannot be told apart from a dict the SDK stored, and it
+    reads back parsed too. Type metadata would tell them apart, but only for
+    the entries this SDK wrote: the route, the REST callers and the other
+    SDKs all read the same plain text, and an envelope would be unreadable to
+    them.
+    """
     stripped = text.lstrip()
     if stripped.startswith("{") or stripped.startswith("["):
         try:
@@ -127,8 +140,10 @@ class CacheFacade:
         the same way, so the calling code has one branch rather than a
         try/except around every read.
 
-        A dict or list stored through `set` or `claim` comes back parsed;
-        text comes back as it was stored.
+        A dict or list stored through `set` or `claim` comes back parsed.
+        Text comes back as it was stored, unless the text is itself a JSON
+        object or array: the entry holds text alone, so that reads back
+        parsed as well.
 
         Args:
             name: Entry name (UPPER_SNAKE_CASE).
@@ -148,8 +163,9 @@ class CacheFacade:
 
         Args:
             name: Entry name (UPPER_SNAKE_CASE).
-            value: What to store: text, or a dict or list, which is stored as
-                JSON and comes back parsed. It is encrypted server-side.
+            value: What to store: text, or a dict or list of what JSON can
+                carry, which is stored as JSON and comes back parsed. It is
+                encrypted server-side.
             ttl_seconds: How long the entry stays readable. The project's
                 default applies when this is not given.
         """
@@ -178,8 +194,9 @@ class CacheFacade:
 
         Args:
             name: Entry name (UPPER_SNAKE_CASE).
-            value: What to store: text, or a dict or list, which is stored as
-                JSON and comes back parsed. It is encrypted server-side.
+            value: What to store: text, or a dict or list of what JSON can
+                carry, which is stored as JSON and comes back parsed. It is
+                encrypted server-side.
             ttl_seconds: How long the entry stays readable. The project's
                 default applies when this is not given.
         """

--- a/sdks/python/src/langwatch/cache.py
+++ b/sdks/python/src/langwatch/cache.py
@@ -78,11 +78,19 @@ def _encode(value: CacheValue) -> str:
 
     A dict or list must hold what JSON can carry, so a member of another type
     raises a TypeError here, and a key that is not a string is stored as one.
+    nan and inf are refused with it: Python writes them as NaN and Infinity,
+    which the REST callers and the other SDKs read as broken JSON.
     """
     if isinstance(value, str):
         return value
     if isinstance(value, (dict, list)):
-        return json.dumps(value)
+        try:
+            return json.dumps(value, allow_nan=False)
+        except ValueError as refused:
+            raise TypeError(
+                "A cache value must hold what JSON can carry; "
+                f"{refused}"
+            ) from refused
     raise TypeError(
         "A cache value must be a str, a dict or a list; "
         f"got {type(value).__name__}"

--- a/sdks/python/src/langwatch/utils/exceptions.py
+++ b/sdks/python/src/langwatch/utils/exceptions.py
@@ -28,6 +28,38 @@ def extract_api_error_code(body: Any) -> Optional[str]:
     return _first_string(body.get("code"), body.get("type"), body.get("kind"))
 
 
+def extract_api_error_reasons(body: Any) -> List[str]:
+    """The fields a validation refusal named, as ``field: message`` lines.
+
+    A ``validation_error`` carries one ``reasons`` entry per rejected field,
+    each with ``meta.field`` and ``meta.message``. Those two are what the
+    caller needs to fix the request, and neither ever quotes what was sent.
+    An envelope without ``reasons`` answers an empty list.
+    """
+    if not isinstance(body, Mapping):
+        return []
+    inner = body.get("error")
+    if isinstance(inner, Mapping) and "reasons" not in body:
+        body = inner
+    reasons = body.get("reasons")
+    if not isinstance(reasons, list):
+        return []
+    lines: List[str] = []
+    for reason in reasons:
+        if not isinstance(reason, Mapping):
+            continue
+        meta = reason.get("meta")
+        if not isinstance(meta, Mapping):
+            continue
+        field = meta.get("field")
+        message = meta.get("message")
+        if isinstance(field, str) and isinstance(message, str):
+            lines.append(f"{field}: {message}")
+        elif isinstance(message, str):
+            lines.append(message)
+    return lines
+
+
 def extract_api_error_detail(body: Any) -> str:
     """Build a readable detail line from a LangWatch API error body.
 

--- a/sdks/python/tests/test_cache_facade.py
+++ b/sdks/python/tests/test_cache_facade.py
@@ -236,6 +236,17 @@ class TestValuesThatAreNotText:
         assert "int" in str(raised.value)
         assert stub.calls == []
 
+    @pytest.mark.parametrize(
+        "number", [float("nan"), float("inf"), float("-inf")]
+    )
+    def test_a_number_json_cannot_carry_is_refused_before_any_call(self, number):
+        stub = CacheStub()
+
+        with pytest.raises(TypeError):
+            facade_over(stub).set("ACME_READING", {"value": number})
+
+        assert stub.calls == []
+
 
 class TestMessages:
     # @scenario "No message from the SDK quotes a cached value"

--- a/sdks/python/tests/test_cache_facade.py
+++ b/sdks/python/tests/test_cache_facade.py
@@ -184,6 +184,50 @@ class TestDelete:
         assert ("DELETE", "/api/agent-cache/ACME_SESSION") in stub.calls
 
 
+class TestValuesThatAreNotText:
+    # @scenario "The SDK stores a dict or list as JSON and reads it back parsed"
+    def test_a_dict_is_stored_as_json_text_and_comes_back_as_a_dict(self):
+        stub = CacheStub()
+        session = {"token": "abc", "expires_at": 1787920000, "scopes": ["read"]}
+
+        facade_over(stub).set("ACME_SESSION", session, ttl_seconds=837)
+
+        assert stub.stored["ACME_SESSION"] == json.dumps(session)
+        assert facade_over(stub).get("ACME_SESSION") == session
+
+    def test_a_list_round_trips_the_same_way(self):
+        stub = CacheStub()
+
+        facade_over(stub).claim("ACME_HANDLES", ["h1", "h2"])
+
+        assert stub.stored["ACME_HANDLES"] == '["h1", "h2"]'
+        assert facade_over(stub).get("ACME_HANDLES") == ["h1", "h2"]
+
+    def test_text_is_stored_and_read_back_untouched(self):
+        stub = CacheStub()
+
+        facade_over(stub).set("ACME_SESSION", "  a-session-token ")
+
+        assert stub.stored["ACME_SESSION"] == "  a-session-token "
+        assert facade_over(stub).get("ACME_SESSION") == "  a-session-token "
+
+    def test_text_that_only_looks_like_json_comes_back_as_text(self):
+        stub = CacheStub(stored={"ACME_NOTE": "{not json", "ACME_NUMBER": "42"})
+
+        assert facade_over(stub).get("ACME_NOTE") == "{not json"
+        assert facade_over(stub).get("ACME_NUMBER") == "42"
+
+    # @scenario "The SDK refuses a value it cannot store before calling the platform"
+    def test_a_value_of_another_type_is_refused_before_any_call(self):
+        stub = CacheStub()
+
+        with pytest.raises(TypeError) as raised:
+            facade_over(stub).set("ACME_COUNT", 42)  # type: ignore[arg-type]
+
+        assert "int" in str(raised.value)
+        assert stub.calls == []
+
+
 class TestMessages:
     # @scenario "No message from the SDK quotes a cached value"
     def test_no_message_quotes_the_value_the_caller_sent(self):
@@ -194,3 +238,34 @@ class TestMessages:
             facade_over(stub).set("ACME_SESSION", "a-session-nobody-may-print")
 
         assert "a-session-nobody-may-print" not in str(raised.value)
+
+    # @scenario "A refused write names the field the platform rejected"
+    def test_a_refused_write_names_the_rejected_field(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                400,
+                json={
+                    "code": "validation_error",
+                    "message": "validation_error",
+                    "meta": {"target": "json", "fields": ["value"]},
+                    "reasons": [
+                        {
+                            "code": "schema_failure",
+                            "meta": {
+                                "field": "value",
+                                "type": "invalid_type",
+                                "message": "Expected string, received object",
+                            },
+                        }
+                    ],
+                },
+            )
+
+        with pytest.raises(ValueError) as raised:
+            CacheFacade(FakeRestClient(handler)).set("ACME_SESSION", "whatever")
+
+        assert str(raised.value) == (
+            "The agent cache refused the call: 400 "
+            "(validation_error: value: Expected string, received object)"
+        )
+        assert "whatever" not in str(raised.value)

--- a/sdks/python/tests/test_cache_facade.py
+++ b/sdks/python/tests/test_cache_facade.py
@@ -236,6 +236,14 @@ class TestValuesThatAreNotText:
         assert "int" in str(raised.value)
         assert stub.calls == []
 
+    def test_a_tuple_is_stored_as_a_json_array_and_reads_back_as_a_list(self):
+        stub = CacheStub()
+
+        facade_over(stub).set("ACME_HANDLES", {"items": ("a", "b")})
+
+        assert stub.stored["ACME_HANDLES"] == '{"items": ["a", "b"]}'
+        assert facade_over(stub).get("ACME_HANDLES") == {"items": ["a", "b"]}
+
     @pytest.mark.parametrize(
         "number", [float("nan"), float("inf"), float("-inf")]
     )

--- a/sdks/python/tests/test_cache_facade.py
+++ b/sdks/python/tests/test_cache_facade.py
@@ -217,6 +217,15 @@ class TestValuesThatAreNotText:
         assert facade_over(stub).get("ACME_NOTE") == "{not json"
         assert facade_over(stub).get("ACME_NUMBER") == "42"
 
+    # @scenario "JSON text an older writer stored reads back parsed"
+    def test_json_text_an_older_writer_stored_reads_back_parsed(self):
+        stub = CacheStub(
+            stored={"ACME_MODE": '{"mode":"legacy"}', "ACME_STEPS": '["one"]'}
+        )
+
+        assert facade_over(stub).get("ACME_MODE") == {"mode": "legacy"}
+        assert facade_over(stub).get("ACME_STEPS") == ["one"]
+
     # @scenario "The SDK refuses a value it cannot store before calling the platform"
     def test_a_value_of_another_type_is_refused_before_any_call(self):
         stub = CacheStub()

--- a/specs/agent-cache/agent-cache.feature
+++ b/specs/agent-cache/agent-cache.feature
@@ -290,3 +290,29 @@ Feature: The agent cache
       When the agent reads the exception
       Then nothing in it quotes the value the agent sent
       # A run shows what it printed, and an exception text is printed often.
+
+    # The route stores text. A session is a dict more often than not, and an
+    # agent that hands one over should not have to know that: the SDK stores
+    # it as JSON and reads it back parsed. Text passes through untouched, so
+    # an entry written over REST, or by an older SDK, reads the same as before.
+    @unit
+    Scenario: The SDK stores a dict or list as JSON and reads it back parsed
+      When the agent stores a dict under ACME_SESSION
+      Then the write carries the dict as JSON text
+      And reading ACME_SESSION gives the agent the dict back
+
+    @unit
+    Scenario: The SDK refuses a value it cannot store before calling the platform
+      When the agent stores a number
+      Then the agent is told which types a value can be
+      And no call reaches the platform
+
+    # A customer report: every write refused with "400 (validation_error)" and
+    # nothing more, because the message stopped at the code. The platform
+    # names the rejected field and what it expected, and that is what the
+    # caller needs. The platform's wording never quotes a value.
+    @unit
+    Scenario: A refused write names the field the platform rejected
+      Given the platform refuses a write because the value is not text
+      When the agent reads the exception
+      Then it names the field and what was expected of it

--- a/specs/agent-cache/agent-cache.feature
+++ b/specs/agent-cache/agent-cache.feature
@@ -293,8 +293,9 @@ Feature: The agent cache
 
     # The route stores text. A session is a dict more often than not, and an
     # agent that hands one over should not have to know that: the SDK stores
-    # it as JSON and reads it back parsed. Text passes through untouched, so
-    # an entry written over REST, or by an older SDK, reads the same as before.
+    # it as JSON and reads it back parsed. What JSON carries is what comes
+    # back, so a tuple reads back as a list and a key that is not a string
+    # reads back as one.
     @unit
     Scenario: The SDK stores a dict or list as JSON and reads it back parsed
       When the agent stores a dict under ACME_SESSION

--- a/specs/agent-cache/agent-cache.feature
+++ b/specs/agent-cache/agent-cache.feature
@@ -301,6 +301,16 @@ Feature: The agent cache
       Then the write carries the dict as JSON text
       And reading ACME_SESSION gives the agent the dict back
 
+    # An entry holds text and nothing else, so text that is itself a JSON
+    # object or array cannot be told apart from a dict the SDK stored. Type
+    # metadata would tell them apart, but only for the entries this SDK
+    # wrote; the route, the REST callers and the other SDKs read plain text.
+    @unit
+    Scenario: JSON text an older writer stored reads back parsed
+      Given an entry written over REST holds the text of a JSON object
+      When the agent reads the entry
+      Then it gets the object parsed
+
     @unit
     Scenario: The SDK refuses a value it cannot store before calling the platform
       When the agent stores a number


### PR DESCRIPTION
## What

`langwatch.cache.set()` and `claim()` now take a `dict` or `list` as the value, not only text, and a refused call names the field the platform rejected instead of stopping at the error code.

## Why

A customer report: every `langwatch.cache.set()` in their run failed with `The agent cache refused the call: 400 (validation_error)`, the TTL was inside the range, and reads never errored, so no row ever reused another row's session.

Production logs, last 3 days, every refused agent cache request:

- 184 `PUT /api/agent-cache/<NAME>` refused with `value: Expected string, received object`, 08-26 22:00 to 08-27 00:22 UTC.
- 184 `GET` misses on the same name in the same window, which is the "status = miss" in the report.
- Nothing else for that project: the name was valid, the lifetime was valid, the credential was accepted.

So the value was a dict (a session object), and the route stores text. Two things made this hard to see from the agent's side: the SDK's docstring said `value: str` but nothing turned a dict away or turned it into text, and the exception stopped at `validation_error` even though the platform's body already carried `reasons[0].meta.field` and `.message`.

## How

- `cache.py`: `CacheValue = str | dict | list`. A str is stored as is. A dict or list is stored as `json.dumps(value)`, and `get()` parses text that starts with `{` or `[` back, so a session object goes in and comes out as the same dict. Text that only looks like JSON, or a number stored as text, comes back as text. Any other type raises `TypeError` before a call is made.
- `exceptions.py`: `extract_api_error_reasons(body)` reads the `reasons[].meta.field` and `.message` the platform sends on a validation refusal. `cache.py` appends them: `400 (validation_error: value: Expected string, received object)`. The platform's wording never quotes a value, so the "no message quotes a cached value" rule still holds and is still tested.
- 422 is treated as a refusal of the call, the same as 400, which is the status the validation doc names.
- Docs: value type in the limits table, one paragraph under Cache API, and a troubleshooting row for the exact message the customer saw, with the `json.dumps` workaround for an SDK that predates this.

Not changed: the entry name rule (`^[A-Z][A-Z0-9_]*$`). The customer did not hit it, and it mirrors the secrets rule, where the name has to be a Python identifier for `secrets.NAME`.

## Tests

- `specs/agent-cache/agent-cache.feature`: three new SDK scenarios, 33/33 bound.
- `tests/test_cache_facade.py`: a dict is stored as JSON text and comes back as a dict; a list round-trips; text passes through untouched, including text that looks like JSON; another type is refused before any call; a refused write names the rejected field and still quotes nothing the caller sent. 24/24 in the cache and error test files, 608/608 in `make test-unit`.

## Deployment Impact

Python SDK only, a patch release. No platform, engine or route change. The sandbox installs the SDK from the monorepo, so a code agent run picks this up with the next `langwatch-nlp` image, and callers outside the sandbox with the next PyPI release. Entries already stored as text keep reading the same.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Agent cache now supports storing and retrieving structured dictionary and list values.
  - Structured values are serialized automatically, while JSON-formatted text is parsed when retrieved.
  - Unsupported value types are rejected locally with clear `TypeError` messages.

- **Bug Fixes**
  - Cache validation errors now identify the specific rejected field and reason.
  - Improved documentation-checking error messages for special characters.

- **Documentation**
  - Added guidance on supported values, JSON behavior, validation errors, troubleshooting, and compatibility with older SDK versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->