### PR TITLE
fix(identity): accept better-auth 1.7's restated providerId on OAuth sign-in

### DIFF
--- a/packages/identity-server/src/__tests__/identity-storage-adapter-identity.unit.test.ts
+++ b/packages/identity-server/src/__tests__/identity-storage-adapter-identity.unit.test.ts
@@ -18,6 +18,7 @@
  * branch and for the `Account` rows the bridge mirror writes.
  */
 import { IDENTIFIER_ATTACHED_EVENT_TYPE } from "@langwatch/identity";
+import { handleOAuthUserInfo } from "better-auth/oauth2";
 import { beforeEach, describe, expect, it } from "vitest";
 import { IdentityUnsupportedStorageQueryError } from "../better-auth/account-queries";
 import type { IdentityStack } from "./support/storage-adapter-stack";
@@ -614,6 +615,136 @@ describe("better-auth over the identity storage adapter", () => {
         expect(
           stack.storage.credentials.get(google?.id as string)?.secrets,
         ).toMatchObject({ accessToken: "at-2", refreshToken: "rt-2" });
+      });
+    });
+
+    describe("when the sign-in token refresh restates the account's own provider", () => {
+      /** @scenario "A sign-in that echoes the account's own provider back is served, not refused" */
+      it("writes the tokens instead of refusing the echo", async () => {
+        await signUp(stack.auth, EMAIL);
+        const userId = userIdOf(stack);
+        const context = await stack.auth.$context;
+        await context.internalAdapter.linkAccount({
+          userId,
+          providerId: "google",
+          issuer: oauthIssuer("google"),
+          accountId: "sub-google-1",
+        });
+        const google = (await context.internalAdapter.findAccounts(userId)).find(
+          (row) => row.providerId === "google",
+        );
+        const statedBefore = stack.commands.length;
+
+        // better-auth 1.7's `oauth2/link-account` sends `providerId` in the
+        // same payload as the rotated tokens, echoing back the value it just
+        // read. 1.6 did not, and refusing the echo failed every OAuth
+        // sign-in for a latched user.
+        await context.adapter.update({
+          model: "account",
+          where: [{ field: "id", value: google?.id as string }],
+          update: {
+            providerId: "google",
+            accessToken: "at-2",
+            refreshToken: "rt-2",
+          },
+        });
+
+        expect(
+          stack.storage.credentials.get(google?.id as string)?.secrets,
+        ).toMatchObject({ accessToken: "at-2", refreshToken: "rt-2" });
+        // The restated provider wrote nothing: linkage is still the fold's,
+        // so no command was stated for it.
+        expect(stack.commands).toHaveLength(statedBefore);
+      });
+
+      /** @scenario "A sign-in that changes the account's provider is still refused" */
+      it("still refuses a provider that differs from the row it names", async () => {
+        await signUp(stack.auth, EMAIL);
+        const userId = userIdOf(stack);
+        const context = await stack.auth.$context;
+        await context.internalAdapter.linkAccount({
+          userId,
+          providerId: "google",
+          issuer: oauthIssuer("google"),
+          accountId: "sub-google-1",
+        });
+        const google = (await context.internalAdapter.findAccounts(userId)).find(
+          (row) => row.providerId === "google",
+        );
+
+        // Equality is the whole safety argument: an echo writes nothing, but
+        // a DIFFERENT provider is a real linkage rewrite and would repoint
+        // the row at another IdP.
+        await expect(
+          context.adapter.update({
+            model: "account",
+            where: [{ field: "id", value: google?.id as string }],
+            update: { providerId: "github", accessToken: "at-2" },
+          }),
+        ).rejects.toMatchObject({
+          body: { code: "identity_unsupported_storage_query" },
+        });
+
+        expect(
+          (await context.internalAdapter.findAccounts(userId)).find(
+            (row) => row.id === google?.id,
+          )?.providerId,
+        ).toBe("google");
+      });
+    });
+
+    describe("when better-auth's own sign-in path refreshes an OAuth account", () => {
+      /** @scenario "A sign-in that echoes the account's own provider back is served, not refused" */
+      it("completes the sign-in better-auth 1.7 actually issues", async () => {
+        await signUp(stack.auth, EMAIL);
+        const userId = userIdOf(stack);
+        const context = await stack.auth.$context;
+        await context.internalAdapter.linkAccount({
+          userId,
+          providerId: "google",
+          issuer: oauthIssuer("google"),
+          accountId: "sub-google-1",
+        });
+        const google = (await context.internalAdapter.findAccounts(userId)).find(
+          (row) => row.providerId === "google",
+        );
+
+        // better-auth's OWN payload, not one this test hand-builds: 1.7's
+        // `handleOAuthUserInfo` is where the sign-in token refresh is
+        // constructed, and it is what added `providerId` beside the tokens.
+        // Driving it here is the difference between pinning the fix and
+        // pinning this test's guess about the fix.
+        const result = await handleOAuthUserInfo(
+          { context } as unknown as Parameters<typeof handleOAuthUserInfo>[0],
+          {
+            userInfo: {
+              id: "sub-google-1",
+              email: EMAIL,
+              emailVerified: true,
+              name: "Sam",
+              image: null,
+            },
+            account: {
+              providerId: "google",
+              issuer: oauthIssuer("google"),
+              accountId: "sub-google-1",
+              accessToken: "at-rotated",
+              refreshToken: "rt-rotated",
+            },
+          },
+        );
+
+        // A refusal reaches here as a throw, so arriving at all is half the
+        // claim; the session is the other half — this is a completed
+        // sign-in, not merely an update that did not explode.
+        expect(result.error).toBeFalsy();
+        expect(result.data?.session).toBeDefined();
+        expect(
+          stack.storage.credentials.get(google?.id as string)?.secrets,
+        ).toMatchObject({
+          accessToken: "at-rotated",
+          refreshToken: "rt-rotated",
+        });
       });
     });
 

--- a/packages/identity-server/src/__tests__/identity-storage-adapter-refusal-logging.unit.test.ts
+++ b/packages/identity-server/src/__tests__/identity-storage-adapter-refusal-logging.unit.test.ts
@@ -1,0 +1,103 @@
+/**
+ * A storage refusal is logged before it reaches the customer.
+ *
+ * better-auth catches an adapter throw and turns it into a redirect carrying
+ * the error CODE and nothing else, so the customer lands on the sign-in error
+ * page while the detail naming the offending shape stays on the error's own
+ * `reasons` — unread. Production ran exactly that failure with zero log lines
+ * naming it, which is what made it undiagnosable from the logs alone.
+ *
+ * Its own file because it mocks the logger factory, and the mock has to be
+ * hoisted above the adapter's module-level `createLogger` call.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const logged = vi.hoisted(() => ({
+  error: vi.fn(),
+  warn: vi.fn(),
+  info: vi.fn(),
+  debug: vi.fn(),
+}));
+
+vi.mock("@langwatch/observability", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@langwatch/observability")>()),
+  createLogger: () => logged,
+}));
+
+const { identityStack, signUp } = await import(
+  "./support/storage-adapter-stack"
+);
+
+const EMAIL = "member@acme.com";
+
+describe("given a finalized user on the identity branch", () => {
+  let stack: ReturnType<typeof identityStack>;
+
+  beforeEach(() => {
+    logged.error.mockClear();
+    stack = identityStack();
+    stack.gate.open = () => true;
+  });
+
+  describe("when better-auth issues an account operation the branch cannot serve", () => {
+    /** @scenario "A refused account operation is logged before it reaches the customer" */
+    it("logs the refusal at error with the shape that caused it", async () => {
+      await signUp(stack.auth, EMAIL);
+      const context = await stack.auth.$context;
+
+      await expect(
+        context.adapter.findMany({
+          model: "account",
+          where: [
+            { field: "userId", value: stack.db.user?.[0]?.id as string },
+            { field: "scope", value: "openid" },
+          ],
+        }),
+      ).rejects.toMatchObject({
+        body: { code: "identity_unsupported_storage_query" },
+      });
+
+      expect(logged.error).toHaveBeenCalledTimes(1);
+      const [fields, message] = logged.error.mock.calls[0] ?? [];
+      // The shape is the whole diagnostic value: without it the log says
+      // only that something was refused, which is what the error page
+      // already said.
+      expect(fields).toMatchObject({
+        detail: expect.stringContaining("scope eq, userId eq"),
+      });
+      expect(message).toContain("refused a better-auth account operation");
+    });
+
+    /** @scenario "A refused account operation is logged before it reaches the customer" */
+    it("logs the linkage rewrite that broke production sign-in", async () => {
+      await signUp(stack.auth, EMAIL);
+      const userId = stack.db.user?.[0]?.id as string;
+      const context = await stack.auth.$context;
+      await context.internalAdapter.linkAccount({
+        userId,
+        providerId: "google",
+        issuer: "local:oauth:google",
+        accountId: "sub-google-1",
+      });
+      const google = (await context.internalAdapter.findAccounts(userId)).find(
+        (row) => row.providerId === "google",
+      );
+      logged.error.mockClear();
+
+      await expect(
+        context.adapter.update({
+          model: "account",
+          where: [{ field: "id", value: google?.id as string }],
+          update: { providerId: "github" },
+        }),
+      ).rejects.toMatchObject({
+        body: { code: "identity_unsupported_storage_query" },
+      });
+
+      expect(logged.error).toHaveBeenCalledTimes(1);
+      expect(logged.error.mock.calls[0]?.[0]).toMatchObject({
+        detail: expect.stringContaining("linkage columns (providerId)"),
+      });
+    });
+  });
+});

--- a/packages/identity-server/src/better-auth/identity-storage-adapter.ts
+++ b/packages/identity-server/src/better-auth/identity-storage-adapter.ts
@@ -37,6 +37,31 @@ import type {
 
 const logger = createLogger("langwatch:identity:storage-adapter");
 
+/**
+ * A refusal, logged on its way out.
+ *
+ * better-auth catches an adapter throw and turns it into a redirect carrying
+ * the error CODE and nothing else, so an unlogged refusal reaches the
+ * customer as a sign-in error page and leaves NOTHING behind to diagnose it
+ * with. That is not hypothetical: `identity_unsupported_storage_query` broke
+ * production sign-in and appeared zero times in the logs for the whole
+ * outage, while the detail naming the exact shape sat unread on the error's
+ * own `reasons`. It is logged at error because it is `fault: "platform"` —
+ * nothing the customer did caused it and nothing they can do fixes it.
+ *
+ * Returns the error so a caller can `throw refused(...)` and keep the throw
+ * visible at the site it happens.
+ */
+const refused = <T>(error: T): T => {
+  if (error instanceof IdentityUnsupportedStorageQueryError) {
+    logger.error(
+      { err: error, detail: error.reasons[0]?.message },
+      "the identity storage adapter refused a better-auth account operation; the sign-in or account write it belongs to fails",
+    );
+  }
+  return error;
+};
+
 /** The secret set the identity branch owns. Everything else on the `account`
  *  model is linkage, and linkage is a command rather than a column write. */
 const SECRET_FIELDS = [
@@ -52,6 +77,47 @@ const SECRET_FIELDS = [
 /** Written by the store itself, so an update naming it is not a linkage
  *  rewrite and does not have to refuse. */
 const UPDATE_PASSTHROUGH_FIELDS = ["createdAt", "updatedAt"] as const;
+
+/**
+ * Linkage columns better-auth RESTATES on an update it means as a secret
+ * write — accepted when the value it carries already matches the row, and
+ * refused when it differs.
+ *
+ * A restatement is not a rewrite. better-auth 1.7 rebuilt the sign-in token
+ * refresh (`oauth2/link-account`) to send `providerId` alongside the tokens,
+ * echoing back the value it just read; 1.6 sent `scope` and no linkage at
+ * all. Refusing the echo failed EVERY OAuth sign-in for a latched user, so
+ * the field alone cannot decide this — only the field and its value together
+ * can. Equality is what makes accepting it safe: a matching value writes
+ * nothing, and a differing one is a real rewrite and still refuses.
+ */
+const LINKAGE_RESTATEMENT_FIELDS = [
+  "providerId",
+  "issuer",
+  "accountId",
+  "userId",
+] as const;
+
+type LinkageRestatementField = (typeof LINKAGE_RESTATEMENT_FIELDS)[number];
+
+const isLinkageRestatementField = (
+  field: string,
+): field is LinkageRestatementField =>
+  LINKAGE_RESTATEMENT_FIELDS.some((known) => known === field);
+
+/**
+ * The value a row states for a linkage field, with `issuer` resolved the
+ * same way the served row resolves it — a row attached before the fact
+ * carried an issuer answers with the synthetic form better-auth minted, and
+ * that is the value better-auth is echoing back.
+ */
+const linkageValueOf = (
+  row: IdentityAccountRow,
+  field: LinkageRestatementField,
+): string =>
+  field === "issuer"
+    ? (row.issuer ?? issuerForProviderId(row.providerId))
+    : row[field];
 
 export interface IdentityStorageAdapterDeps {
   /**
@@ -295,16 +361,27 @@ function identityCustomAdapter({
     const secretsOfUpdate = (
       operation: string,
       update: Row,
+      rows: readonly IdentityAccountRow[],
     ): IdentityAccountSecrets => {
+      /** A linkage field whose value every named row already states — an
+       *  echo of what better-auth just read, which writes nothing. */
+      const restatesItself = (field: string): boolean =>
+        isLinkageRestatementField(field) &&
+        rows.length > 0 &&
+        rows.every((row) => linkageValueOf(row, field) === update[field]);
+
       const foreign = Object.keys(update).filter(
         (field) =>
           !SECRET_FIELDS.some((secret) => secret === field) &&
-          !UPDATE_PASSTHROUGH_FIELDS.some((passed) => passed === field),
+          !UPDATE_PASSTHROUGH_FIELDS.some((passed) => passed === field) &&
+          !restatesItself(field),
       );
       if (foreign.length > 0) {
-        throw new IdentityUnsupportedStorageQueryError(
-          `identity storage adapter: better-auth issued an account ${operation} that writes linkage columns (${foreign.sort().join(", ")}). ` +
-            "Linkage is event-truth on the identity branch, so it can only be stated as a command, never written as a column.",
+        throw refused(
+          new IdentityUnsupportedStorageQueryError(
+            `identity storage adapter: better-auth issued an account ${operation} that writes linkage columns (${foreign.sort().join(", ")}). ` +
+              "Linkage is event-truth on the identity branch, so it can only be stated as a command, never written as a column.",
+          ),
         );
       }
       return secretsOf(update);
@@ -424,9 +501,13 @@ function identityCustomAdapter({
         // operator has enrolled anyone.
         return null;
       }
-      const served = await serveAccounts(
-        parseAccountQuery({ operation, where: canonical }),
-      );
+      let query: AccountQuery;
+      try {
+        query = parseAccountQuery({ operation, where: canonical });
+      } catch (error) {
+        throw refused(error);
+      }
+      const served = await serveAccounts(query);
       return served === null ? null : served.map(withIssuer);
     };
 
@@ -742,6 +823,7 @@ function identityCustomAdapter({
               secrets: secretsOfUpdate(
                 "update",
                 toCanonicalKeys(model, update as Row),
+                [first],
               ),
             });
             const [fresh] = await accounts.findByAccountIds({
@@ -797,6 +879,7 @@ function identityCustomAdapter({
               secrets: secretsOfUpdate(
                 "updateMany",
                 toCanonicalKeys(model, update),
+                rows,
               ),
             });
             return rows.length;

--- a/specs/identity/identity-storage-adapter.feature
+++ b/specs/identity/identity-storage-adapter.feature
@@ -137,6 +137,28 @@ Feature: The identity storage adapter - one adapter, two branches, Account retir
     And a from-scratch replay reproduces the Identifier row and never touches the credential row
 
   @unit
+  Scenario: A sign-in that echoes the account's own provider back is served, not refused
+    Given a finalized user "sam" with an Auth0 account on the identity branch
+    When the sign-in token refresh restates "sam"'s provider alongside the new tokens
+    Then the tokens are written to the AccountCredential row
+    And the restated provider changes nothing
+    And "sam" is signed in
+
+  @unit
+  Scenario: A sign-in that changes the account's provider is still refused
+    Given a finalized user "sam" with an Auth0 account on the identity branch
+    When an account update names a different provider than the row holds
+    Then the update is refused
+    And the refusal names the offending column
+
+  @unit
+  Scenario: A refused account operation is logged before it reaches the customer
+    Given a finalized user "sam" on the identity branch
+    When better-auth issues an account operation the branch cannot serve
+    Then the refusal is logged at error with the shape that caused it
+    And the customer sees the sign-in error page
+
+  @unit
   Scenario: Bridge mirroring keeps the fail-closed direction safe
     Given a finalized user "sam" changes their password on the identity branch
     And the Account bridge table still exists


### PR DESCRIPTION
## What broke

Every OAuth sign-in for a user on the identity branch fails. The customer lands on
`/auth/error?error=identity_unsupported_storage_query` with "Something went wrong
signing you in" and cannot get back in.

## Why

better-auth 1.7 rebuilt the sign-in token refresh in `oauth2/link-account.mjs`:

```js
// 1.7 — providerId is new here
{ providerId, idToken, accessToken, refreshToken, accessTokenExpiresAt, refreshTokenExpiresAt }
// 1.6 — secrets only
{ idToken, accessToken, refreshToken, accessTokenExpiresAt, refreshTokenExpiresAt, scope }
```

It echoes back the `providerId` it just read. The storage adapter treats every
non-secret field on an `account` update as a linkage rewrite and refuses it, so
the echo fails the sign-in.

**No LangWatch commit caused this** — it arrived with the `better-auth: ^1.7.1`
bump, which is why a commit hunt turns up nothing. The
[1.7 upgrade guide](https://better-auth.com/docs/guides/1-7-upgrade-guide)
documents scopes accumulating across refresh (why `scope` left the payload) but
not `providerId` joining it.

## The fix

The field alone cannot decide this; the field and its value together can.

- A linkage column whose value **already matches the row** is a restatement. It
  writes nothing, and is accepted.
- One that **differs** is a real rewrite — it would repoint the row at another
  IdP — and still refuses.

Equality is the whole safety argument.

### Event sourcing is preserved

The restated field is dropped from the payload rather than written, so linkage
remains event-truth: no command is skipped, and a replay reproduces the same
projection. The test asserts `stack.commands` is unchanged. The legacy branch is
untouched — `routeAccount` returns `null` and the full update flows to
`legacy.update` as before.

## The refusal now logs

Both throw sites were silent. better-auth catches the throw and converts it to a
redirect carrying only the code, so this ran in production with **zero log lines
naming it**, while the detail identifying the exact shape sat unread on the
error's own `reasons`. Every other handled code was logging normally at the same
time, so the gap read as "no errors".

It logs at `error` because it is `fault: "platform"`.

## Tests

- Drives better-auth's own `handleOAuthUserInfo` rather than a hand-built
  payload, so it binds to what the library actually issues.
- A differing `providerId` is still refused, and the row keeps its provider.
- Two tests pin the logging, including the exact production message
  (`linkage columns (providerId)`).

**Negative control:** with the fix disabled, both new behaviour tests fail and
the other 33 pass.

`24 files / 242 tests` green, package typecheck clean (src + tests),
`53/53` spec scenarios bound.

## Deployment Impact

None. No migration, no schema change, no config. Code-only fix in
`@langwatch/identity-server`; behaviour changes only for accounts on the
identity branch, and only to stop refusing a write that was already a no-op.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved sign-in token refresh handling when an account restates its existing provider.
  - Continued to reject account updates that specify a different provider.
  - Improved error reporting for unsupported account operations, including clearer details about the rejected request.
  - Ensured refused identity operations are logged before the sign-in error is displayed.

- **Tests**
  - Added coverage for token rotation, provider validation, refusal logging, and OAuth sign-in flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->