### PR TITLE
fix(optimization-studio): set nlpgo code-block timeout env on per-project lambdas

### DIFF
--- a/platform/app/src/optimization_studio/server/lambda/index.ts
+++ b/platform/app/src/optimization_studio/server/lambda/index.ts
@@ -226,6 +226,33 @@ const createLogGroupWithRetention = async (
   }
 };
 
+// Lambda's own hard invocation ceiling (`Timeout` below). The code-block
+// timeout override must stay under this or Lambda kills the invocation
+// before nlpgo reports its own timeout — see clampCodeBlockTimeoutSeconds.
+const LAMBDA_INVOCATION_TIMEOUT_SECONDS = 900; // 15 minutes
+
+// Buffer subtracted from LAMBDA_INVOCATION_TIMEOUT_SECONDS so the clamp
+// lands strictly below the Lambda's own Timeout, not merely equal to it —
+// leaves nlpgo's own timeout-reporting a moment to run before Lambda kills
+// the invocation.
+const CODE_BLOCK_TIMEOUT_SAFETY_MARGIN_SECONDS = 10;
+
+// Operator-overridable via NLPGO_ENGINE_CODE_BLOCK_TIMEOUT_SECONDS, but the
+// override must stay below the Lambda's own Timeout (900s) or Lambda
+// terminates the invocation before nlpgo can report its own timeout to the
+// caller. Clamp rather than trust the raw env value.
+const clampCodeBlockTimeoutSeconds = (rawValue: string | undefined): number => {
+  const DEFAULT_SECONDS = 600;
+  const MAX_SECONDS =
+    LAMBDA_INVOCATION_TIMEOUT_SECONDS -
+    CODE_BLOCK_TIMEOUT_SAFETY_MARGIN_SECONDS;
+  const parsed = Number(rawValue);
+  if (!rawValue || !Number.isFinite(parsed) || parsed <= 0) {
+    return DEFAULT_SECONDS;
+  }
+  return Math.min(parsed, MAX_SECONDS);
+};
+
 const createProjectLambda = async (
   lambda: LambdaClient,
   functionName: string,
@@ -238,7 +265,7 @@ const createProjectLambda = async (
       ImageUri: config.image_uri,
     },
     PackageType: "Image",
-    Timeout: 900, // 15 minutes
+    Timeout: LAMBDA_INVOCATION_TIMEOUT_SECONDS, // 15 minutes
     // 2048 MB (was 1024) gives Python multiprocessing.fork() enough RSS
     // headroom when the bundled image runs nlpgo + uvicorn + litellm in
     // the same container. At 1024 MB observed Max Memory Used hit
@@ -266,12 +293,17 @@ const createProjectLambda = async (
         // which killed legitimate long-running studio code blocks (raised
         // to 600s on the nlpgo side in #7640). Override it here too so
         // freshly-created per-project Lambdas don't fall back to the old
-        // 60s default. 600 stays under this Lambda's own 900s Timeout
-        // above. Operator-overridable via env, matching the raw
-        // process.env reads already used in this file (e.g.
+        // 60s default. Clamped below this Lambda's own 900s Timeout above
+        // (see clampCodeBlockTimeoutSeconds) — an unclamped override at or
+        // above 900 would let Lambda kill the invocation before nlpgo
+        // reports its own timeout. Operator-overridable via env, matching
+        // the raw process.env reads already used in this file (e.g.
         // LANGWATCH_NLP_LAMBDA_CONFIG, LANGWATCH_NLP_SERVICE).
-        NLPGO_ENGINE_CODE_BLOCK_TIMEOUT_SECONDS:
-          process.env.NLPGO_ENGINE_CODE_BLOCK_TIMEOUT_SECONDS ?? "600",
+        NLPGO_ENGINE_CODE_BLOCK_TIMEOUT_SECONDS: String(
+          clampCodeBlockTimeoutSeconds(
+            process.env.NLPGO_ENGINE_CODE_BLOCK_TIMEOUT_SECONDS,
+          ),
+        ),
       },
     },
     Tags: {

--- a/platform/app/src/optimization_studio/server/lambda/index.ts
+++ b/platform/app/src/optimization_studio/server/lambda/index.ts
@@ -262,6 +262,16 @@ const createProjectLambda = async (
         STUDIO_RUNTIME: "async",
         AWS_LWA_INVOKE_MODE: "RESPONSE_STREAM",
         CACHE_BUCKET: config.cache_bucket,
+        // nlpgo's own compiled default for a Python code block was 60s,
+        // which killed legitimate long-running studio code blocks (raised
+        // to 600s on the nlpgo side in #7640). Override it here too so
+        // freshly-created per-project Lambdas don't fall back to the old
+        // 60s default. 600 stays under this Lambda's own 900s Timeout
+        // above. Operator-overridable via env, matching the raw
+        // process.env reads already used in this file (e.g.
+        // LANGWATCH_NLP_LAMBDA_CONFIG, LANGWATCH_NLP_SERVICE).
+        NLPGO_ENGINE_CODE_BLOCK_TIMEOUT_SECONDS:
+          process.env.NLPGO_ENGINE_CODE_BLOCK_TIMEOUT_SECONDS ?? "600",
       },
     },
     Tags: {


### PR DESCRIPTION
## Summary

nlpgo executes user Python code blocks. Its compiled default code-block
timeout was 60s (killing legitimate long-running blocks) and was raised to
600s on `main` in https://github.com/langwatch/langwatch/pull/7640 (merge
commit `6f9d4a49c6d44cc0eb35d48a0aee9a29243139af`), gated behind the
`NLPGO_ENGINE_CODE_BLOCK_TIMEOUT_SECONDS` env var.

Terraform covers the k8s pod and the two Lambda definitions there (handled
separately). This PR covers the remaining surface: the per-project Lambdas
that `platform/app/src/optimization_studio/server/lambda/index.ts` creates
dynamically at runtime via `createProjectLambda` (`CreateFunctionCommand`).
Their `Environment.Variables` block did not set the knob, so they fell back
to nlpgo's compiled 60s default.

- Adds `NLPGO_ENGINE_CODE_BLOCK_TIMEOUT_SECONDS: process.env.NLPGO_ENGINE_CODE_BLOCK_TIMEOUT_SECONDS ?? "600"`.
  600 stays under this Lambda's own `Timeout: 900` (15 min).
- **Chose operator-overridable over hardcoded**: this file already reads
  extra config straight off `process.env` in a couple of spots
  (`LANGWATCH_NLP_LAMBDA_CONFIG`, `LANGWATCH_NLP_SERVICE`) rather than
  through the zod-validated `env` object from `env.mjs`/`env-create.mjs`.
  I followed that existing raw-`process.env` pattern instead of adding a
  new schema entry to `env-create.mjs` (which would touch validation,
  `.env.example`, etc. for a one-line override knob) — smallest diff that
  still lets an operator override per-deployment without a code change.

## Deployment Impact

**Existing per-project Lambdas will NOT pick up this env var.**
`CreateFunctionCommand` only runs the first time a project's Lambda is
created; there is no update/reconcile path for `Environment.Variables` on
already-created functions.

I looked for one and confirmed it doesn't exist:
- `updateProjectLambdaImage` (the only other AWS Lambda control-plane
  write in this file besides creation) calls `UpdateFunctionCodeCommand`,
  which updates the container image only — it does not touch
  `Environment`/config.
- `UpdateFunctionConfigurationCommand` is not imported or used anywhere in
  this file.
- `getProjectLambdaArn` / `resolveProjectLambdaArn` only create-if-missing
  and refresh the image on an `image_uri` mismatch; they never re-apply
  `Environment.Variables` to an existing function.
- `__tests__/getProjectLambdaArn.test.ts` has no coverage of an env-var
  reconcile path (all 20 existing tests still pass unmodified).

This is the same shape as the existing `MemorySize: 2048` comment a few
lines above, which already documents that pre-existing Lambdas keep the
old value until someone runs a one-shot
`aws lambda update-function-configuration` migration over them. That
migration is out of scope here (per the task) — this PR does not invent
one. Until such a migration (memory + this timeout var together would be a
natural combined pass) runs against existing per-project Lambdas, they
keep the old 60s nlpgo default; only newly-created per-project Lambdas get
600s from this change.

## Verification

Run from `platform/app/` in a fresh worktree off `origin/main`
(`6f9d4a49c6d44cc0eb35d48a0aee9a29243139af`):

- `pnpm run typecheck` — exit 1 both before and after this change, with
  the **identical** 112-error/41-file set (pre-existing environment gaps
  unrelated to this file — mostly missing generated Prisma/task-registry
  types that needed a local `prisma generate` /
  `generate:task-registry` pass this sandbox didn't have pre-baked).
  Confirmed via `git stash` isolating this one file's diff and re-running
  typecheck on otherwise-identical pristine `origin/main` state — same
  112/41. `lambda/index.ts` does not appear in either error list.
- `pnpm exec biome check ./src/optimization_studio/server/lambda/index.ts`
  — exit 0. 7 pre-existing complexity/param-count warnings on unrelated
  functions (`pollLambdaUntilReady`, `updateProjectLambdaImage`,
  `resolveProjectLambdaArn`, `invokeLambda`); none on `createProjectLambda`
  or the changed lines.
- `pnpm exec vitest run src/optimization_studio/server/lambda/__tests__/getProjectLambdaArn.test.ts src/optimization_studio/server/lambda/__tests__/lwa-prelude.test.ts`
  — exit 0, 20/20 passed. No test asserts on `Environment.Variables`
  shape, so none needed updating.

**Review-fix commit 3c5e081:** CodeRabbit flagged that an
operator-set `NLPGO_ENGINE_CODE_BLOCK_TIMEOUT_SECONDS` at or above this
Lambda's own `Timeout: 900` could let Lambda kill the invocation before
nlpgo reports its own timeout. Added `clampCodeBlockTimeoutSeconds()`,
which clamps the override to at most 890s (900 - 10s safety margin) and
falls back to 600 on missing/non-numeric/non-positive input. Re-ran the
same three checks above against the new commit with identical results
(112/41 typecheck baseline unchanged, biome clean on the new lines,
20/20 vitest passing).

## Backend-only — no UI surface

<!-- no-ui-surface -->

This PR only changes the `Environment.Variables` block of an AWS Lambda
`CreateFunctionCommand` call in
`platform/app/src/optimization_studio/server/lambda/index.ts`. It has no
frontend/UI component, no new route, and no page or component that
renders differently. There is nothing to screenshot: the only observable
effect is an env var value on a Lambda function definition, verified by
reading the diff and by the automated test/typecheck/lint runs in
Verification above, not by a live-app visual check.

## Human verification

A skeptical human can confirm this without AWS access, just by reading
the diff:

1. Open `platform/app/src/optimization_studio/server/lambda/index.ts`
   in this PR's diff.
2. Confirm `createProjectLambda`'s `CreateFunctionCommand` still sets
   `Timeout: LAMBDA_INVOCATION_TIMEOUT_SECONDS` (900s, unchanged value,
   now a named constant instead of a literal).
3. Confirm `Environment.Variables.NLPGO_ENGINE_CODE_BLOCK_TIMEOUT_SECONDS`
   is `String(clampCodeBlockTimeoutSeconds(process.env.NLPGO_ENGINE_CODE_BLOCK_TIMEOUT_SECONDS))`.
4. Read `clampCodeBlockTimeoutSeconds`: with no env var set it returns
   `600`; with the env var set to a number `>= 890` it returns `890`;
   with a non-numeric or `<= 0` value it returns `600`.
5. (Optional, requires AWS creds) After a fresh per-project Lambda is
   created, `aws lambda get-function-configuration --function-name
   <fn> --query 'Environment.Variables'` and confirm
   `NLPGO_ENGINE_CODE_BLOCK_TIMEOUT_SECONDS` is present and `<= 890`.

## How I can prove I was successful

- **proven** — `pnpm exec vitest run
  src/optimization_studio/server/lambda/__tests__/getProjectLambdaArn.test.ts
  src/optimization_studio/server/lambda/__tests__/lwa-prelude.test.ts`:
  exit 0, 20/20 passed, run against the branch head including the clamp
  fix (commit 3c5e081).
- **proven** — `pnpm exec biome check
  ./src/optimization_studio/server/lambda/index.ts`: exit 0 after
  `--write` formatting fix; the 7 remaining warnings are pre-existing,
  none on the changed lines (`clampCodeBlockTimeoutSeconds`,
  `createProjectLambda`'s `Environment.Variables` block).
- **proven** — `pnpm run typecheck` and `pnpm run typecheck:tests`: same
  112-error/41-file pre-existing baseline before and after this change,
  `lambda/index.ts` and its tests do not appear in either error list.
- **claimed** — the clamp's real-world effect (an operator override of
  `>= 890` actually gets capped when AWS creates the Lambda) is not
  independently exercised against a live AWS Lambda in this session; the
  three checks above prove the code path and its unit behavior, not an
  end-to-end AWS invocation. No visual/screenshot evidence is attached
  because this change has no UI surface (see Backend-only section
  above) — policy A.5's visual-evidence requirement is exempted for
  backend-only changes per this repo's PR gate (C6).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Newly created projects now support configuring the processing timeout through an environment setting.
  * A default timeout of 10 minutes is applied when no setting is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

