### PR TITLE
fix(optimization-studio): reconcile per-project Lambda config on every touch

### DIFF
--- a/platform/app/src/optimization_studio/server/lambda/__tests__/getProjectLambdaArn.test.ts
+++ b/platform/app/src/optimization_studio/server/lambda/__tests__/getProjectLambdaArn.test.ts
@@ -1,11 +1,17 @@
 import { CloudWatchLogsClient } from "@aws-sdk/client-cloudwatch-logs";
-import { LambdaClient } from "@aws-sdk/client-lambda";
+import {
+  LambdaClient,
+  UpdateFunctionCodeCommand,
+  UpdateFunctionConfigurationCommand,
+} from "@aws-sdk/client-lambda";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { env } from "../../../../env.mjs";
 import {
   clearLambdaArnCache,
   createLambdaClient,
   getProjectLambdaArn,
   LAMBDA_ARN_CACHE_TTL_MS,
+  LANGWATCH_NLP_LAMBDA_MEMORY_SIZE,
 } from "../index";
 
 const setConfig = (imageUri: string) => {
@@ -21,12 +27,28 @@ const setConfig = (imageUri: string) => {
   });
 };
 
+/** The env vars the module reconciles onto every per-project Lambda. Built from
+ *  `env.BASE_HOST` rather than a literal because that value is supplied by the
+ *  environment (unset locally, "localhost:3000" in CI), so a hardcoded string
+ *  would make the fixture drift in one of the two. */
+const desiredEnvVars = {
+  LANGWATCH_ENDPOINT: env.BASE_HOST,
+  STUDIO_RUNTIME: "async",
+  AWS_LWA_INVOKE_MODE: "RESPONSE_STREAM",
+  CACHE_BUCKET: "test-bucket",
+};
+
 describe("getProjectLambdaArn", () => {
   const mockProjectId = "test-project-123";
+  // Already matches the desired configuration, so the reconcile path is a
+  // no-op for every test that doesn't deliberately introduce drift — keeping
+  // their exact AWS call counts intact.
   const mockLambdaConfig = {
     FunctionArn: "arn:aws:lambda:us-east-1:123456789012:function:test-function",
     State: "Active",
     LastUpdateStatus: "Successful",
+    MemorySize: 2048,
+    Environment: { Variables: { ...desiredEnvVars } },
   };
 
   beforeEach(async () => {
@@ -244,6 +266,10 @@ describe("getProjectLambdaArn", () => {
           FunctionArn: arn,
           State: "Active",
           LastUpdateStatus: "Successful",
+          // Matches the desired config so reconcile stays a no-op and the
+          // mock chain below keeps its 1:1 mapping to AWS calls.
+          MemorySize: 2048,
+          Environment: { Variables: { ...desiredEnvVars } },
         },
         Code: {
           ImageUri: "123456789012.dkr.ecr.us-east-1.amazonaws.com/test:latest",
@@ -268,6 +294,163 @@ describe("getProjectLambdaArn", () => {
     it("exposes a TTL constant tuned for minute-scale burst absorption", () => {
       expect(LAMBDA_ARN_CACHE_TTL_MS).toBeGreaterThanOrEqual(60_000);
       expect(LAMBDA_ARN_CACHE_TTL_MS).toBeLessThanOrEqual(60 * 60_000);
+    });
+  });
+
+  describe("config reconcile", () => {
+    const currentImageUri =
+      "123456789012.dkr.ecr.us-east-1.amazonaws.com/test:latest";
+
+    /** Indices of the UpdateFunctionConfiguration calls in send order. */
+    const configUpdateCalls = (send: any) =>
+      send.mock.calls.filter(
+        (call: any[]) => call[0] instanceof UpdateFunctionConfigurationCommand,
+      );
+
+    /** @scenario A pre-existing Lambda carrying a stale env var is reconciled,
+     *  without clobbering env vars this code does not manage */
+    it("updates drifted env vars and preserves unmanaged ones", async () => {
+      const drifted = {
+        ...mockLambdaConfig,
+        Environment: {
+          Variables: {
+            ...desiredEnvVars,
+            CACHE_BUCKET: "stale-bucket",
+            SOME_OTHER_VAR: "keep-me",
+          },
+        },
+      };
+
+      const send = vi
+        .spyOn(LambdaClient.prototype as any, "send")
+        // checkLambdaExists
+        .mockResolvedValueOnce({ Configuration: drifted })
+        // GetFunction for image/config details
+        .mockResolvedValueOnce({
+          Configuration: drifted,
+          Code: { ImageUri: currentImageUri },
+        })
+        // UpdateFunctionConfiguration
+        .mockResolvedValueOnce(mockLambdaConfig)
+        // Final poll
+        .mockResolvedValue({ Configuration: mockLambdaConfig });
+
+      const arn = await getProjectLambdaArn("reconcile-env");
+      expect(arn).toBe(mockLambdaConfig.FunctionArn);
+
+      const updates = configUpdateCalls(send);
+      expect(updates).toHaveLength(1);
+      expect(updates[0][0].input.FunctionName).toBe(
+        "langwatch_nlp-reconcile-env",
+      );
+      expect(updates[0][0].input.Environment.Variables).toEqual({
+        ...desiredEnvVars,
+        SOME_OTHER_VAR: "keep-me",
+      });
+    });
+
+    /** @scenario A Lambda still on the old 1024 MB default is raised to 2048 */
+    it("raises a drifted MemorySize to the desired value", async () => {
+      const drifted = { ...mockLambdaConfig, MemorySize: 1024 };
+
+      const send = vi
+        .spyOn(LambdaClient.prototype as any, "send")
+        .mockResolvedValueOnce({ Configuration: drifted })
+        .mockResolvedValueOnce({
+          Configuration: drifted,
+          Code: { ImageUri: currentImageUri },
+        })
+        .mockResolvedValueOnce(mockLambdaConfig)
+        .mockResolvedValue({ Configuration: mockLambdaConfig });
+
+      const arn = await getProjectLambdaArn("reconcile-memory");
+      expect(arn).toBe(mockLambdaConfig.FunctionArn);
+
+      const updates = configUpdateCalls(send);
+      expect(updates).toHaveLength(1);
+      expect(updates[0][0].input.MemorySize).toBe(
+        LANGWATCH_NLP_LAMBDA_MEMORY_SIZE,
+      );
+      expect(LANGWATCH_NLP_LAMBDA_MEMORY_SIZE).toBe(2048);
+    });
+
+    /** @scenario No drift means no AWS write at all — the common path */
+    it("issues no configuration update when nothing has drifted", async () => {
+      const send = vi
+        .spyOn(LambdaClient.prototype as any, "send")
+        .mockResolvedValueOnce({ Configuration: mockLambdaConfig })
+        .mockResolvedValueOnce({
+          Configuration: mockLambdaConfig,
+          Code: { ImageUri: currentImageUri },
+        })
+        .mockResolvedValue({ Configuration: mockLambdaConfig });
+
+      const arn = await getProjectLambdaArn("reconcile-none");
+      expect(arn).toBe(mockLambdaConfig.FunctionArn);
+      expect(configUpdateCalls(send)).toHaveLength(0);
+    });
+
+    /** @scenario AWS rejects a config update while a code update is in flight,
+     *  so the code update must land (poll) before the config update is sent */
+    it("waits for the code update to land before updating configuration", async () => {
+      const drifted = { ...mockLambdaConfig, MemorySize: 1024 };
+
+      const send = vi
+        .spyOn(LambdaClient.prototype as any, "send")
+        .mockResolvedValueOnce({ Configuration: drifted })
+        // Image URI differs from the configured one, forcing a code update.
+        .mockResolvedValueOnce({
+          Configuration: drifted,
+          Code: { ImageUri: "ecr/foo:old" },
+        })
+        // UpdateFunctionCode
+        .mockResolvedValueOnce(mockLambdaConfig)
+        // Post-code-update poll
+        .mockResolvedValueOnce({ Configuration: mockLambdaConfig })
+        // UpdateFunctionConfiguration
+        .mockResolvedValueOnce(mockLambdaConfig)
+        // Final poll
+        .mockResolvedValue({ Configuration: mockLambdaConfig });
+
+      const arn = await getProjectLambdaArn("reconcile-ordering");
+      expect(arn).toBe(mockLambdaConfig.FunctionArn);
+
+      const commands = send.mock.calls.map((call: any[]) => call[0]);
+      const codeIdx = commands.findIndex(
+        (c: any) => c instanceof UpdateFunctionCodeCommand,
+      );
+      const configIdx = commands.findIndex(
+        (c: any) => c instanceof UpdateFunctionConfigurationCommand,
+      );
+      expect(codeIdx).toBeGreaterThanOrEqual(0);
+      expect(configIdx).toBeGreaterThan(codeIdx);
+      // At least one GetFunction poll sits between them.
+      const pollsBetween = commands
+        .slice(codeIdx + 1, configIdx)
+        .filter(
+          (c: any) =>
+            !(c instanceof UpdateFunctionCodeCommand) &&
+            !(c instanceof UpdateFunctionConfigurationCommand),
+        );
+      expect(pollsBetween.length).toBeGreaterThanOrEqual(1);
+    });
+
+    /** @scenario A concurrent update makes AWS reject the reconcile; the
+     *  resolution still succeeds rather than surfacing the error to Studio */
+    it("swallows an in-progress conflict on the configuration update", async () => {
+      const drifted = { ...mockLambdaConfig, MemorySize: 1024 };
+
+      vi.spyOn(LambdaClient.prototype as any, "send")
+        .mockResolvedValueOnce({ Configuration: drifted })
+        .mockResolvedValueOnce({
+          Configuration: drifted,
+          Code: { ImageUri: currentImageUri },
+        })
+        .mockRejectedValueOnce(new Error("An update is in progress"))
+        .mockResolvedValue({ Configuration: mockLambdaConfig });
+
+      const arn = await getProjectLambdaArn("reconcile-conflict");
+      expect(arn).toBe(mockLambdaConfig.FunctionArn);
     });
   });
 });

--- a/platform/app/src/optimization_studio/server/lambda/__tests__/getProjectLambdaArn.test.ts
+++ b/platform/app/src/optimization_studio/server/lambda/__tests__/getProjectLambdaArn.test.ts
@@ -307,8 +307,7 @@ describe("getProjectLambdaArn", () => {
         (call: any[]) => call[0] instanceof UpdateFunctionConfigurationCommand,
       );
 
-    /** @scenario A pre-existing Lambda carrying a stale env var is reconciled,
-     *  without clobbering env vars this code does not manage */
+    /** @scenario A pre-existing Lambda carrying a stale env var is reconciled without clobbering unmanaged vars */
     it("updates drifted env vars and preserves unmanaged ones", async () => {
       const drifted = {
         ...mockLambdaConfig,
@@ -390,8 +389,7 @@ describe("getProjectLambdaArn", () => {
       expect(configUpdateCalls(send)).toHaveLength(0);
     });
 
-    /** @scenario AWS rejects a config update while a code update is in flight,
-     *  so the code update must land (poll) before the config update is sent */
+    /** @scenario The code update lands and is polled to completion before the config update is sent */
     it("waits for the code update to land before updating configuration", async () => {
       const drifted = { ...mockLambdaConfig, MemorySize: 1024 };
 
@@ -435,8 +433,7 @@ describe("getProjectLambdaArn", () => {
       expect(pollsBetween.length).toBeGreaterThanOrEqual(1);
     });
 
-    /** @scenario A concurrent update makes AWS reject the reconcile; the
-     *  resolution still succeeds rather than surfacing the error to Studio */
+    /** @scenario A concurrent update makes AWS reject the reconcile but resolution still succeeds */
     it("swallows an in-progress conflict on the configuration update", async () => {
       const drifted = { ...mockLambdaConfig, MemorySize: 1024 };
 

--- a/platform/app/src/optimization_studio/server/lambda/index.ts
+++ b/platform/app/src/optimization_studio/server/lambda/index.ts
@@ -10,6 +10,7 @@ import {
   InvokeWithResponseStreamCommand,
   LambdaClient,
   UpdateFunctionCodeCommand,
+  UpdateFunctionConfigurationCommand,
 } from "@aws-sdk/client-lambda";
 import { createLogger } from "@langwatch/observability";
 import { env } from "../../../env.mjs";
@@ -226,6 +227,36 @@ const createLogGroupWithRetention = async (
   }
 };
 
+/**
+ * Desired memory allocation, in MB, for every per-project langwatch_nlp Lambda.
+ *
+ * 2048 MB (was 1024) gives Python multiprocessing.fork() enough RSS headroom
+ * when the bundled image runs nlpgo + uvicorn + litellm in the same container.
+ * At 1024 MB observed Max Memory Used hit 805/1024 MB mid-request on lw-dev
+ * (TEST H, 2026-04-28); fork() would fail to clone parent pages and the uvicorn
+ * worker pool crashed, cascading to /studio/* 502s. 2048 MB also doubles
+ * Lambda's allocated CPU (Lambda allocates CPU proportional to memory;
+ * ~0.58 vCPU at 1024 → ~1.17 vCPU at 2048), shaving cold-start init time too.
+ *
+ * Already-created Lambdas are brought up to this value automatically by
+ * `reconcileProjectLambdaConfig` on the next ARN resolution.
+ */
+export const LANGWATCH_NLP_LAMBDA_MEMORY_SIZE = 2048;
+
+/**
+ * The single source of truth for the environment variables every per-project
+ * langwatch_nlp Lambda must carry. Used both when creating a function and when
+ * reconciling an existing one, so the two can never drift apart.
+ */
+const buildDesiredLambdaEnvironmentVariables = (
+  config: LangWatchLambdaConfig,
+): Record<string, string> => ({
+  LANGWATCH_ENDPOINT: env.BASE_HOST,
+  STUDIO_RUNTIME: "async",
+  AWS_LWA_INVOKE_MODE: "RESPONSE_STREAM",
+  CACHE_BUCKET: config.cache_bucket,
+});
+
 const createProjectLambda = async (
   lambda: LambdaClient,
   functionName: string,
@@ -239,30 +270,14 @@ const createProjectLambda = async (
     },
     PackageType: "Image",
     Timeout: 900, // 15 minutes
-    // 2048 MB (was 1024) gives Python multiprocessing.fork() enough RSS
-    // headroom when the bundled image runs nlpgo + uvicorn + litellm in
-    // the same container. At 1024 MB observed Max Memory Used hit
-    // 805/1024 MB mid-request on lw-dev (TEST H, 2026-04-28); fork()
-    // would fail to clone parent pages and the uvicorn worker pool
-    // crashed, cascading to /studio/* 502s. 2048 MB also doubles
-    // Lambda's allocated CPU (Lambda allocates CPU proportional to
-    // memory; ~0.58 vCPU at 1024 → ~1.17 vCPU at 2048), shaving cold-
-    // start init time too. Existing per-project Lambdas keep 1024 until
-    // a one-shot migration runs `aws lambda update-function-configuration
-    // --memory-size 2048` over each.
-    MemorySize: 2048,
+    MemorySize: LANGWATCH_NLP_LAMBDA_MEMORY_SIZE,
     Architectures: ["arm64"],
     VpcConfig: {
       SubnetIds: config.subnet_ids,
       SecurityGroupIds: config.security_group_ids,
     },
     Environment: {
-      Variables: {
-        LANGWATCH_ENDPOINT: env.BASE_HOST,
-        STUDIO_RUNTIME: "async",
-        AWS_LWA_INVOKE_MODE: "RESPONSE_STREAM",
-        CACHE_BUCKET: config.cache_bucket,
-      },
+      Variables: buildDesiredLambdaEnvironmentVariables(config),
     },
     Tags: {
       Project: "langwatch",
@@ -340,6 +355,56 @@ const updateProjectLambdaImage = async (
 
   const response = await lambda.send(command);
   return response;
+};
+
+/**
+ * Bring an already-created Lambda's env vars and memory size up to the values
+ * this code wants. `CreateFunctionCommand` only runs once, and
+ * `UpdateFunctionCodeCommand` touches the container image only, so without this
+ * every pre-existing per-project Lambda would keep whatever configuration it
+ * was born with forever.
+ *
+ * @returns the updated configuration, or `null` when nothing had drifted (the
+ *   common case — no AWS call is made then).
+ */
+const reconcileProjectLambdaConfig = async (
+  lambda: LambdaClient,
+  functionName: string,
+  config: LangWatchLambdaConfig,
+  currentConfig: FunctionConfiguration,
+  projectId: string,
+): Promise<FunctionConfiguration | null> => {
+  const desiredEnv = buildDesiredLambdaEnvironmentVariables(config);
+  const currentEnv = currentConfig.Environment?.Variables ?? {};
+  const envDrifted = Object.entries(desiredEnv).some(
+    ([key, value]) => currentEnv[key] !== value,
+  );
+  const memoryDrifted =
+    currentConfig.MemorySize !== LANGWATCH_NLP_LAMBDA_MEMORY_SIZE;
+
+  if (!envDrifted && !memoryDrifted) {
+    return null;
+  }
+
+  logger.info(
+    { projectId, envDrifted, memoryDrifted },
+    `Reconciling Lambda function configuration for ${functionName}`,
+  );
+
+  const command = new UpdateFunctionConfigurationCommand({
+    FunctionName: functionName,
+    Environment: {
+      // Merge, never replace: preserve any env var this code doesn't
+      // manage (e.g. one set out-of-band) instead of clobbering it.
+      Variables: {
+        ...currentEnv,
+        ...desiredEnv,
+      },
+    },
+    MemorySize: LANGWATCH_NLP_LAMBDA_MEMORY_SIZE,
+  });
+
+  return lambda.send(command);
 };
 
 // Cluster-wide ARN cache, plus per-pod single-flight.
@@ -495,6 +560,10 @@ const resolveProjectLambdaArn = async (
           config.image_uri,
           projectId,
         );
+        // AWS rejects UpdateFunctionConfiguration while a code update is still
+        // in flight ("ResourceConflictException: An update is in progress"), so
+        // the code update must fully land before the reconcile below fires.
+        await pollLambdaUntilReady(lambda, functionName);
       } catch (error) {
         if (
           error instanceof Error &&
@@ -503,6 +572,36 @@ const resolveProjectLambdaArn = async (
           logger.info(
             { projectId },
             "Lambda function update in progress, skipping update",
+          );
+        } else {
+          throw error;
+        }
+      }
+    }
+
+    // `functionDetails.Configuration` was fetched before either update, and is
+    // a correct drift baseline regardless: UpdateFunctionCode never changes
+    // Environment or MemorySize.
+    if (functionDetails.Configuration) {
+      try {
+        const reconciled = await reconcileProjectLambdaConfig(
+          lambda,
+          functionName,
+          config,
+          functionDetails.Configuration,
+          projectId,
+        );
+        if (reconciled) {
+          lambdaConfig = reconciled;
+        }
+      } catch (error) {
+        if (
+          error instanceof Error &&
+          error.message.includes("An update is in progress")
+        ) {
+          logger.info(
+            { projectId },
+            "Lambda function config reconcile skipped, update in progress",
           );
         } else {
           throw error;

--- a/platform/app/src/optimization_studio/server/lambda/index.ts
+++ b/platform/app/src/optimization_studio/server/lambda/index.ts
@@ -370,10 +370,13 @@ const updateProjectLambdaImage = async (
 const reconcileProjectLambdaConfig = async (
   lambda: LambdaClient,
   functionName: string,
-  config: LangWatchLambdaConfig,
-  currentConfig: FunctionConfiguration,
-  projectId: string,
+  params: {
+    config: LangWatchLambdaConfig;
+    currentConfig: FunctionConfiguration;
+    projectId: string;
+  },
 ): Promise<FunctionConfiguration | null> => {
+  const { config, currentConfig, projectId } = params;
   const desiredEnv = buildDesiredLambdaEnvironmentVariables(config);
   const currentEnv = currentConfig.Environment?.Variables ?? {};
   const envDrifted = Object.entries(desiredEnv).some(
@@ -500,6 +503,148 @@ export const getProjectLambdaArn = async (
   return resolution;
 };
 
+/**
+ * Swap a Lambda's container image when the desired URI has drifted from
+ * what's deployed. Returns the updated configuration, or `null` when no
+ * update was needed or attempted.
+ */
+const updateProjectLambdaImageIfDrifted = async (
+  lambda: LambdaClient,
+  functionName: string,
+  params: {
+    config: LangWatchLambdaConfig;
+    projectId: string;
+    currentImageUri: string | undefined;
+  },
+): Promise<FunctionConfiguration | null> => {
+  const { config, projectId, currentImageUri } = params;
+
+  if (!currentImageUri || currentImageUri === config.image_uri) {
+    return null;
+  }
+
+  logger.info(
+    { projectId },
+    `Image URI mismatch for ${functionName}. Current: ${currentImageUri}, Expected: ${config.image_uri}. Updating lambda image`,
+  );
+
+  try {
+    const updated = await updateProjectLambdaImage(
+      lambda,
+      functionName,
+      config.image_uri,
+      projectId,
+    );
+    // AWS rejects UpdateFunctionConfiguration while a code update is still in
+    // flight ("ResourceConflictException: An update is in progress"), so the
+    // code update must fully land before a reconcile can follow.
+    await pollLambdaUntilReady(lambda, functionName);
+    return updated;
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      error.message.includes("An update is in progress")
+    ) {
+      logger.info(
+        { projectId },
+        "Lambda function update in progress, skipping update",
+      );
+      return null;
+    }
+    throw error;
+  }
+};
+
+/**
+ * `reconcileProjectLambdaConfig`, tolerant of a concurrent update: AWS
+ * rejects `UpdateFunctionConfiguration` while another update is in flight,
+ * which is expected under overlapping reconcile attempts and not an error.
+ */
+const reconcileProjectLambdaConfigSafely = async (
+  lambda: LambdaClient,
+  functionName: string,
+  params: {
+    config: LangWatchLambdaConfig;
+    currentConfig: FunctionConfiguration;
+    projectId: string;
+  },
+): Promise<FunctionConfiguration | null> => {
+  try {
+    return await reconcileProjectLambdaConfig(lambda, functionName, params);
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      error.message.includes("An update is in progress")
+    ) {
+      logger.info(
+        { projectId: params.projectId },
+        "Lambda function config reconcile skipped, update in progress",
+      );
+      return null;
+    }
+    throw error;
+  }
+};
+
+/**
+ * Bring an already-existing Lambda's container image and configuration in
+ * line with what this invocation wants: swap the image if the URI drifted,
+ * then reconcile env vars / memory against the pre-update configuration
+ * baseline. Split out of `resolveProjectLambdaArn` to keep that function
+ * under the house line-count limit.
+ */
+const syncExistingProjectLambda = async (
+  lambda: LambdaClient,
+  functionName: string,
+  params: {
+    config: LangWatchLambdaConfig;
+    projectId: string;
+    existingConfig: FunctionConfiguration;
+  },
+): Promise<FunctionConfiguration> => {
+  const { config, projectId, existingConfig } = params;
+  let lambdaConfig = existingConfig;
+
+  // Get complete function details to check image URI
+  const getFunctionCommand = new GetFunctionCommand({
+    FunctionName: functionName,
+  });
+  const functionDetails = await lambda.send(getFunctionCommand);
+
+  const updatedByImage = await updateProjectLambdaImageIfDrifted(
+    lambda,
+    functionName,
+    {
+      config,
+      projectId,
+      currentImageUri: functionDetails.Code?.ImageUri,
+    },
+  );
+  if (updatedByImage) {
+    lambdaConfig = updatedByImage;
+  }
+
+  // `functionDetails.Configuration` was fetched before either update, and is
+  // a correct drift baseline regardless: UpdateFunctionCode never changes
+  // Environment or MemorySize.
+  if (functionDetails.Configuration) {
+    const reconciled = await reconcileProjectLambdaConfigSafely(
+      lambda,
+      functionName,
+      {
+        config,
+        currentConfig: functionDetails.Configuration,
+        projectId,
+      },
+    );
+    if (reconciled) {
+      lambdaConfig = reconciled;
+    }
+  }
+
+  return lambdaConfig;
+};
+
 const resolveProjectLambdaArn = async (
   projectId: string,
   config: LangWatchLambdaConfig,
@@ -540,74 +685,11 @@ const resolveProjectLambdaArn = async (
       }
     }
   } else {
-    // Get complete function details to check image URI
-    const getFunctionCommand = new GetFunctionCommand({
-      FunctionName: functionName,
+    lambdaConfig = await syncExistingProjectLambda(lambda, functionName, {
+      config,
+      projectId,
+      existingConfig: lambdaConfig,
     });
-    const functionDetails = await lambda.send(getFunctionCommand);
-
-    const currentImageUri = functionDetails.Code?.ImageUri;
-    if (currentImageUri && currentImageUri !== config.image_uri) {
-      logger.info(
-        { projectId },
-        `Image URI mismatch for ${functionName}. Current: ${currentImageUri}, Expected: ${config.image_uri}. Updating lambda image`,
-      );
-
-      try {
-        lambdaConfig = await updateProjectLambdaImage(
-          lambda,
-          functionName,
-          config.image_uri,
-          projectId,
-        );
-        // AWS rejects UpdateFunctionConfiguration while a code update is still
-        // in flight ("ResourceConflictException: An update is in progress"), so
-        // the code update must fully land before the reconcile below fires.
-        await pollLambdaUntilReady(lambda, functionName);
-      } catch (error) {
-        if (
-          error instanceof Error &&
-          error.message.includes("An update is in progress")
-        ) {
-          logger.info(
-            { projectId },
-            "Lambda function update in progress, skipping update",
-          );
-        } else {
-          throw error;
-        }
-      }
-    }
-
-    // `functionDetails.Configuration` was fetched before either update, and is
-    // a correct drift baseline regardless: UpdateFunctionCode never changes
-    // Environment or MemorySize.
-    if (functionDetails.Configuration) {
-      try {
-        const reconciled = await reconcileProjectLambdaConfig(
-          lambda,
-          functionName,
-          config,
-          functionDetails.Configuration,
-          projectId,
-        );
-        if (reconciled) {
-          lambdaConfig = reconciled;
-        }
-      } catch (error) {
-        if (
-          error instanceof Error &&
-          error.message.includes("An update is in progress")
-        ) {
-          logger.info(
-            { projectId },
-            "Lambda function config reconcile skipped, update in progress",
-          );
-        } else {
-          throw error;
-        }
-      }
-    }
   }
 
   // Poll until Lambda is ready

--- a/specs/nlp-go/studio-lambda-cache.feature
+++ b/specs/nlp-go/studio-lambda-cache.feature
@@ -83,3 +83,46 @@ Feature: getProjectLambdaArn — per-project ARN cache + single-flight
     When getProjectLambdaArn("projectA") and getProjectLambdaArn("projectB") both resolve
     Then the cache holds two independent entries
     And neither project's resolution shortcuts the other's
+
+  # Config reconcile — after resolveProjectLambdaArn finds an existing Lambda,
+  # it compares the desired env vars / MemorySize (the same source
+  # createProjectLambda uses) against the live FunctionConfiguration and
+  # pushes only what has drifted, via UpdateFunctionConfigurationCommand.
+  # This is what brings pre-existing (already-created) Lambdas up to date
+  # with config the create path has since gained — the same "MemorySize
+  # migration" gap that used to only be gestured at in a comment.
+
+  @integration @unit
+  Scenario: A pre-existing Lambda carrying a stale env var is reconciled without clobbering unmanaged vars
+    Given a Lambda function exists whose CACHE_BUCKET env var is stale
+    And the function also carries an env var this code does not manage
+    When getProjectLambdaArn resolves that project
+    Then exactly one UpdateFunctionConfiguration call is issued
+    And the call's env vars match the desired set
+    And the unmanaged env var is preserved unchanged
+
+  @integration @unit
+  Scenario: A Lambda still on the old 1024 MB default is raised to 2048
+    Given a Lambda function exists with MemorySize 1024
+    When getProjectLambdaArn resolves that project
+    Then an UpdateFunctionConfiguration call sets MemorySize to 2048
+
+  @integration @unit
+  Scenario: No drift means no AWS write at all — the common path
+    Given a Lambda function exists whose env vars and MemorySize already match the desired config
+    When getProjectLambdaArn resolves that project
+    Then no UpdateFunctionConfiguration call is issued
+
+  @integration @unit
+  Scenario: The code update lands and is polled to completion before the config update is sent
+    Given a Lambda function exists with a stale image URI and a drifted MemorySize
+    When getProjectLambdaArn resolves that project
+    Then UpdateFunctionCode is called and polled to completion
+    And only then is UpdateFunctionConfiguration called
+
+  @integration @unit
+  Scenario: A concurrent update makes AWS reject the reconcile but resolution still succeeds
+    Given a Lambda function exists with a drifted MemorySize
+    And AWS rejects the UpdateFunctionConfiguration call with "An update is in progress"
+    When getProjectLambdaArn resolves that project
+    Then the resolution still succeeds and returns a valid ARN


### PR DESCRIPTION
## Summary

`createProjectLambda` sets `Environment.Variables` (LANGWATCH_ENDPOINT, STUDIO_RUNTIME, AWS_LWA_INVOKE_MODE, CACHE_BUCKET) and `MemorySize` only at Lambda creation time (`platform/app/src/optimization_studio/server/lambda/index.ts`). The only update path, `updateProjectLambdaImage`, calls `UpdateFunctionCodeCommand`, which touches the container image only — nothing else. Every per-project Lambda created before either value changed keeps its original config forever.

This was already a documented gap: the `MemorySize` comment on `createProjectLambda` described the exact same 1024→2048 problem and said a manual one-shot migration (`aws lambda update-function-configuration --memory-size 2048`) needed to run over every existing function. That migration was apparently never run — the fleet is still silently split between 1024 MB and 2048 MB Lambdas today.

This PR closes the gap with an automatic reconcile instead of another manual-migration promise.

## Changes

- Extracted the 4-key env var object out of `createProjectLambda` into `buildDesiredLambdaEnvironmentVariables(config)` — the single source of truth both the create and update paths now use, so they cannot drift apart again.
- Extracted the memory target into `export const LANGWATCH_NLP_LAMBDA_MEMORY_SIZE = 2048`.
- Added `reconcileProjectLambdaConfig(...)`: diffs a Lambda's live `Environment.Variables`/`MemorySize` against the desired values.
  - No drift → returns `null`, no AWS call (the common case).
  - Drift → issues one `UpdateFunctionConfigurationCommand`, **merging** rather than replacing `Environment.Variables` (`{...currentEnv, ...desiredEnv}`) so any environment variable this code doesn't manage is preserved.
- Wired into `resolveProjectLambdaArn`'s existing-Lambda branch, which already runs on every ARN resolution (behind the Redis/in-process cache) — so an existing Lambda self-heals to the desired config the next time it's invoked, no separate migration script or ops action needed.
- **Ordering safety**: AWS rejects `UpdateFunctionConfigurationCommand` while `UpdateFunctionCodeCommand` is still in flight (`ResourceConflictException: An update is in progress`). When both an image update and a config reconcile are needed, the code now calls `pollLambdaUntilReady` (existing helper, waits for `LastUpdateStatus === "Successful"`) after the image update completes and before attempting the config reconcile. A race that still hits "An update is in progress" is caught and logged, matching the existing pattern for the image-update path — it does not fail the request.
- Added 5 new tests in `getProjectLambdaArn.test.ts` covering: env-var drift + reconcile, memory drift + reconcile, no-drift no-op, code-then-config ordering (with a poll between them), and the in-progress-conflict swallow path. Updated the shared `mockLambdaConfig`/`cfg()` fixtures to already match the desired config so pre-existing tests' exact AWS-call-count assertions are unaffected by the new reconcile call.

## Out of scope

This intentionally does **not** touch or build on #7643 (which adds `NLPGO_ENGINE_CODE_BLOCK_TIMEOUT_SECONDS` to the same `Environment.Variables` block). `buildDesiredLambdaEnvironmentVariables` only carries the 4 keys that exist on `main` today. Once #7643 lands, adding its new key to that one shared function is all that's needed for both create and reconcile to pick it up — that's the whole point of factoring it out.

## Deployment Impact

- **No infra/config changes required.** This is app-code-only; no new env vars, no Terraform/CDK changes, no manual migration step.
- **Behavior change on the hot path**: `resolveProjectLambdaArn` (called on every Studio Lambda invoke, cached ~10 min per project) now does one extra config diff for existing Lambdas, and — only on drift — one extra `UpdateFunctionConfigurationCommand` AWS API call plus a wait for it to land. First invoke against any Lambda still on the stale 1024 MB / stale env vars will pay this extra round trip once; subsequent invokes are no-ops (diff finds no drift).
- **Existing per-project Lambdas will be silently reconfigured** the first time each is invoked after this deploys: any still on `MemorySize: 1024` move to `2048`, and env vars are brought in line with `buildDesiredLambdaEnvironmentVariables`. This is the intended fix (closing the exact gap the pre-existing `MemorySize` comment described) but is a live-traffic config change to production Lambdas, not opt-in.
- **Non-destructive**: any environment variable not in the managed set (`LANGWATCH_ENDPOINT`, `STUDIO_RUNTIME`, `AWS_LWA_INVOKE_MODE`, `CACHE_BUCKET`) is preserved via merge, not clobbered.
- No database migration, no API contract change, no new external dependency.

## Test plan

- [x] `pnpm exec vitest run src/optimization_studio/server/lambda` — 25/25 passing (20 pre-existing + 5 new), verified in the working branch.
- [x] `pnpm run typecheck:all` compared against a pristine `origin/main` worktree — identical 113-error/42-file baseline in both; zero errors in the touched files in either.
- [x] `pnpm exec biome check` on the touched directory — exit 0 in both baseline and branch (warning-only; two new warnings are `useMaxParams`/`noExcessiveLinesPerFunction` on the new/grown functions, matching the file's pre-existing accepted pattern of flagged-but-allowed complexity on several other functions in this same file).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Standardized serverless function configuration with consistent memory allocation and required environment settings.
  * Existing functions are automatically reconciled when configuration values drift.
  * Unmanaged environment variables are preserved during updates.
  * Configuration updates wait for code updates to complete, improving deployment reliability.
  * Updates are skipped when no changes are needed.
  * Temporary in-progress update conflicts are handled without interrupting deployments.
  * New functions use the same standardized configuration automatically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Human verification

<!-- no-ui-surface -->
Backend-only change (per-project Lambda config reconcile in `platform/app/src/optimization_studio/server/lambda/index.ts`). No UI surface, so no screenshot/recording applies.

To verify by hand after deploy:
1. Pick a project whose Lambda is still on the old config: `aws lambda get-function-configuration --function-name <name> --query '[MemorySize, Environment.Variables]'`.
2. Invoke that project's Studio workflow once.
3. Re-run the same `get-function-configuration` — `MemorySize` is now `2048` and the four managed env vars match `buildDesiredLambdaEnvironmentVariables`; any unmanaged variable is still present.

## How I can prove I was successful

- `pnpm exec vitest run src/optimization_studio/server/lambda` — 25/25 passing (20 pre-existing + 5 new covering env drift, memory drift, no-drift no-op, code-then-config ordering, and the in-progress-conflict swallow path).
- `pnpm run typecheck:all` run differentially against a pristine `origin/main` worktree — identical 113-error/42-file baseline on both sides; zero errors in the touched files in either.
- `pnpm exec biome check` on the touched directory — exit 0 on both baseline and branch.
- CI on this PR is green on the per-SHA check-runs surface.

Not proven here: live AWS behaviour. The reconcile path is covered by tests against a mocked Lambda client, not against a real function.
