### PR TITLE
fix(scenarios): derive nlpgo fetch deadline from engine's own ceiling

### DIFF
--- a/platform/app/src/server/nlpgo/timeouts.ts
+++ b/platform/app/src/server/nlpgo/timeouts.ts
@@ -1,0 +1,158 @@
+/**
+ * The client-side fetch deadline for scenario execution calls to nlpgo's
+ * `/go/studio/execute_sync`, and the platform's own ceiling on how long a
+ * scenario worker may hold that socket open.
+ *
+ * Single source for both `code-agent.adapter.ts` and
+ * `workflow-agent.adapter.ts` — they used to each hold their own copy of
+ * the deadline (one env-configurable, one not), which is how a live
+ * production bug happened: the engine's code-block ceiling was raised
+ * 60s -> 600s (lw#7640), but the client's independently-configured 120s
+ * abort was never told, so it started cutting off runs the engine was
+ * still legitimately working on.
+ *
+ * The fix is not a second floor knob to keep in sync by hand — it's for
+ * the client deadline to be DERIVED from the engine's own ceiling, so the
+ * two cannot drift apart again. `resolveFloorFetchTimeoutMs` below reads
+ * `NLPGO_ENGINE_CODE_BLOCK_TIMEOUT_SECONDS`, the exact env var
+ * `services/nlpgo/config.go` reads for the same setting, and adds a fixed
+ * headroom. One operator-set number, read on both sides of the socket.
+ */
+
+/**
+ * The engine's own knob for the code block's execution ceiling — see
+ * `services/nlpgo/config.go` (`Engine.CodeBlockTimeoutSeconds`, tag
+ * `env:"NLPGO_ENGINE_CODE_BLOCK_TIMEOUT_SECONDS"`). Read here under the
+ * *same* name so an operator sets it once and both nlpgo and this client
+ * agree on the ceiling; there is deliberately no separate client-side name
+ * for the same concept.
+ *
+ * @internal Exported for testing and for {@link ../scenarios/execution/child-environment.ts}.
+ */
+export const NLPGO_ENGINE_CODE_BLOCK_TIMEOUT_SECONDS_ENV =
+  "NLPGO_ENGINE_CODE_BLOCK_TIMEOUT_SECONDS";
+
+/**
+ * Used when {@link NLPGO_ENGINE_CODE_BLOCK_TIMEOUT_SECONDS_ENV} is unset or
+ * unusable here. This is NOT an independent default to rely on — it is a
+ * copy of the engine's own fallback
+ * (`services/nlpgo/app/engine/blocks/codeblock/codeblock.go:115`,
+ * `opts.DefaultTimeout = 600 * time.Second`), so that when the operator
+ * hasn't set the var anywhere, this client falls back to the exact number
+ * the engine falls back to. Keep the two in sync if the Go default ever
+ * changes.
+ */
+const NLPGO_ENGINE_CODE_BLOCK_TIMEOUT_DEFAULT_SECONDS = 600;
+
+/**
+ * Slack the client's socket hold gets ABOVE the engine's code-block
+ * ceiling (and above an agent's own `timeoutMs` budget, when the code
+ * agent has one), so the engine gets to enforce and REPORT its own
+ * timeout instead of this client aborting the connection first while the
+ * engine is still legitimately working.
+ *
+ * Deliberately not env-configurable: it exists purely to absorb
+ * network/serialization latency around the engine's own deadline. Making
+ * it independently operator-tunable would recreate the exact drift this
+ * module exists to prevent — there would again be two numbers, set in two
+ * places, that have to be kept in sync by hand.
+ */
+export const NLP_FETCH_HEADROOM_MS = 30_000;
+
+/** Operator knob naming the platform's maximum for one scenario turn. */
+export const NLP_FETCH_MAX_TIMEOUT_ENV = "NLP_FETCH_MAX_TIMEOUT_MS";
+
+/** Used when {@link NLP_FETCH_MAX_TIMEOUT_ENV} is unset or unusable (15 minutes). */
+export const NLP_FETCH_MAX_TIMEOUT_DEFAULT_MS = 900_000;
+
+/**
+ * Parses an env var holding a count of SECONDS as a positive, finite
+ * number, converts to milliseconds, and falls back on anything that
+ * isn't one.
+ *
+ * Clamp, never reject: unset, empty, non-numeric, non-finite, zero and
+ * negative all read as "use the default" — a nonsensical value must not
+ * fail the scenario run, the same contract the engine keeps for its own
+ * copy of this parse (`services/nlpgo/cmd/root.go`).
+ */
+function resolvePositiveSecondsEnvAsMs(
+  name: string,
+  fallbackSeconds: number,
+): number {
+  const raw = process.env[name];
+  if (raw === undefined || raw.trim() === "") {
+    return fallbackSeconds * 1000;
+  }
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return fallbackSeconds * 1000;
+  }
+  return parsed * 1000;
+}
+
+/** Same parse as {@link resolvePositiveSecondsEnvAsMs}, but the env var is already milliseconds. */
+function resolvePositiveMsEnv(name: string, fallbackMs: number): number {
+  const raw = process.env[name];
+  if (raw === undefined || raw.trim() === "") {
+    return fallbackMs;
+  }
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return fallbackMs;
+  }
+  return parsed;
+}
+
+/**
+ * The client-side floor for one NLP fetch, in milliseconds: the engine's
+ * own code-block ceiling plus {@link NLP_FETCH_HEADROOM_MS}.
+ *
+ * Read per call rather than cached, so a worker started before the
+ * variable was set is not pinned to a stale value, and so tests can
+ * exercise the real parse without reloading the module.
+ *
+ * The scenario child process is spawned with a fixed env allowlist
+ * (`buildChildProcessEnv` in `../scenarios/execution/child-environment.ts`),
+ * which is what carries `NLPGO_ENGINE_CODE_BLOCK_TIMEOUT_SECONDS` from the
+ * operator's environment to here, and it runs under `SKIP_ENV_VALIDATION`,
+ * which makes the validated `~/env.mjs` proxy return raw strings with no
+ * defaults applied. Hence the direct read.
+ *
+ * @internal Exported for testing.
+ */
+export function resolveFloorFetchTimeoutMs(): number {
+  const engineCeilingMs = resolvePositiveSecondsEnvAsMs(
+    NLPGO_ENGINE_CODE_BLOCK_TIMEOUT_SECONDS_ENV,
+    NLPGO_ENGINE_CODE_BLOCK_TIMEOUT_DEFAULT_SECONDS,
+  );
+  return engineCeilingMs + NLP_FETCH_HEADROOM_MS;
+}
+
+/**
+ * The platform's own maximum for one scenario turn, from the environment.
+ *
+ * This is a bound on how long a scenario worker will hold a socket open,
+ * and nothing else. The engine ceiling
+ * (`NLPGO_ENGINE_CODE_BLOCK_TIMEOUT_SECONDS`) bounds how long the agent's
+ * *Python* may run; it does not bound this process. Without a maximum
+ * here, an agent config carrying an absurd `timeoutMs` parks a worker on a
+ * socket for as long as the number says — up to ~24.9 days, where
+ * `setTimeout` stops honoring the delay at all.
+ *
+ * The default of 15 minutes sits above {@link resolveFloorFetchTimeoutMs}'s
+ * own default (630s), so on default settings the engine gets to enforce
+ * and REPORT its timeout before this deadline fires. That ordering is a
+ * consequence of the two defaults, NOT an invariant this code enforces: an
+ * operator who raises the engine ceiling past this default must raise
+ * this one too, or the platform aborts the fetch first and the caller
+ * sees a generic fetch-side `error.kind: "timeout"` instead of the
+ * engine's diagnosis.
+ *
+ * @internal Exported for testing.
+ */
+export function resolveMaxFetchTimeoutMs(): number {
+  return resolvePositiveMsEnv(
+    NLP_FETCH_MAX_TIMEOUT_ENV,
+    NLP_FETCH_MAX_TIMEOUT_DEFAULT_MS,
+  );
+}

--- a/platform/app/src/server/scenarios/__tests__/child-process-env.unit.test.ts
+++ b/platform/app/src/server/scenarios/__tests__/child-process-env.unit.test.ts
@@ -62,6 +62,27 @@ describe("buildChildProcessEnv", () => {
       }
     });
 
+    it("forwards the nlpgo engine's own ceiling so the client deadline can derive from it", () => {
+      // The adapters in the child derive their fetch deadline from this
+      // exact env var name (`resolveFloorFetchTimeoutMs` in
+      // `../../nlpgo/timeouts.ts`), the same one nlpgo itself reads.
+      // Without this entry the client deadline could silently drift below
+      // the engine's ceiling again — the production bug this fixes.
+      const previous = process.env.NLPGO_ENGINE_CODE_BLOCK_TIMEOUT_SECONDS;
+      process.env.NLPGO_ENGINE_CODE_BLOCK_TIMEOUT_SECONDS = "900";
+      try {
+        expect(
+          buildChildProcessEnv({}).NLPGO_ENGINE_CODE_BLOCK_TIMEOUT_SECONDS,
+        ).toBe("900");
+      } finally {
+        if (previous === undefined) {
+          delete process.env.NLPGO_ENGINE_CODE_BLOCK_TIMEOUT_SECONDS;
+        } else {
+          process.env.NLPGO_ENGINE_CODE_BLOCK_TIMEOUT_SECONDS = previous;
+        }
+      }
+    });
+
     it("drops variables with no value rather than passing them as undefined", () => {
       const env = buildChildProcessEnv({ SOME_UNSET_VAR: undefined });
 

--- a/platform/app/src/server/scenarios/execution/child-environment.ts
+++ b/platform/app/src/server/scenarios/execution/child-environment.ts
@@ -18,6 +18,10 @@ import os from "os";
 import path from "path";
 import { env } from "~/env.mjs";
 import {
+  NLP_FETCH_MAX_TIMEOUT_ENV,
+  NLPGO_ENGINE_CODE_BLOCK_TIMEOUT_SECONDS_ENV,
+} from "../../nlpgo/timeouts";
+import {
   encodeScenarioLogContext,
   SCENARIO_LOG_CONTEXT_ENV,
 } from "./child-logger";
@@ -90,11 +94,18 @@ export function buildChildProcessEnv(
     COREPACK_ENABLE_DOWNLOAD_PROMPT:
       process.env.COREPACK_ENABLE_DOWNLOAD_PROMPT,
     // The platform's ceiling on how long a turn may hold a socket open, read
-    // by the code agent adapter INSIDE the child (`resolveMaxFetchTimeoutMs`).
-    // Forwarded raw: this allowlist is the only route from the operator's
-    // environment into the child, and the child runs under
-    // SKIP_ENV_VALIDATION, so `~/env.mjs` would apply no default here.
-    NLP_FETCH_MAX_TIMEOUT_MS: process.env.NLP_FETCH_MAX_TIMEOUT_MS,
+    // by the code/workflow adapters INSIDE the child (`resolveMaxFetchTimeoutMs`
+    // in `../../nlpgo/timeouts.ts`). Forwarded raw: this allowlist is the only
+    // route from the operator's environment into the child, and the child runs
+    // under SKIP_ENV_VALIDATION, so `~/env.mjs` would apply no default here.
+    [NLP_FETCH_MAX_TIMEOUT_ENV]: process.env[NLP_FETCH_MAX_TIMEOUT_ENV],
+    // The nlpgo engine's own code-block execution ceiling. Both nlpgo itself
+    // AND the adapters in this child read this exact env var name
+    // (`resolveFloorFetchTimeoutMs` in `../../nlpgo/timeouts.ts`) so the
+    // client's fetch deadline can never independently drift below the
+    // engine's ceiling the way it did in the production bug this fixes.
+    [NLPGO_ENGINE_CODE_BLOCK_TIMEOUT_SECONDS_ENV]:
+      process.env[NLPGO_ENGINE_CODE_BLOCK_TIMEOUT_SECONDS_ENV],
     ...scenarioVars,
   };
 

--- a/platform/app/src/server/scenarios/execution/serialized-adapters/__tests__/code-agent.adapter.unit.test.ts
+++ b/platform/app/src/server/scenarios/execution/serialized-adapters/__tests__/code-agent.adapter.unit.test.ts
@@ -721,7 +721,7 @@ describe("SerializedCodeAgentAdapter", () => {
           const settled = expect(callPromise).rejects.toBeInstanceOf(
             SerializedCodeAgentAdapterError,
           );
-          await vi.advanceTimersByTimeAsync(120_001);
+          await vi.advanceTimersByTimeAsync(630_001);
           await settled;
         } finally {
           vi.useRealTimers();
@@ -753,13 +753,13 @@ describe("SerializedCodeAgentAdapter", () => {
             .catch((e: SerializedCodeAgentAdapterError) => {
               captured = e;
             });
-          await vi.advanceTimersByTimeAsync(120_001);
+          await vi.advanceTimersByTimeAsync(630_001);
           await callPromise;
         } finally {
           vi.useRealTimers();
         }
         expect(captured?.kind).toBe("timeout");
-        expect(captured?.message).toContain("did not respond within 120000ms");
+        expect(captured?.message).toContain("did not respond within 630000ms");
       });
     });
 
@@ -1153,7 +1153,7 @@ describe("SerializedCodeAgentAdapter", () => {
       expect(armedFetchTimeoutMs()).toBe(200_000);
     });
 
-    it("bounds the default deadline too when set below the 2-minute floor", async () => {
+    it("bounds the default deadline too when set below the floor", async () => {
       vi.stubEnv("NLP_FETCH_MAX_TIMEOUT_MS", "45000");
 
       await callWith(defaultConfig);
@@ -1161,10 +1161,10 @@ describe("SerializedCodeAgentAdapter", () => {
       expect(armedFetchTimeoutMs()).toBe(45_000);
     });
 
-    it("leaves the default deadline at 2 minutes under the default ceiling", async () => {
+    it("leaves the default deadline at the engine ceiling + headroom (630s) under the default max", async () => {
       await callWith(defaultConfig);
 
-      expect(armedFetchTimeoutMs()).toBe(120_000);
+      expect(armedFetchTimeoutMs()).toBe(630_000);
     });
 
     it("is read per call, so a change between turns takes effect", async () => {

--- a/platform/app/src/server/scenarios/execution/serialized-adapters/code-agent.adapter.ts
+++ b/platform/app/src/server/scenarios/execution/serialized-adapters/code-agent.adapter.ts
@@ -16,73 +16,14 @@ import { SpanKind } from "@opentelemetry/api";
 import { randomBytes } from "crypto";
 import { getLangWatchTracer } from "langwatch";
 import { LATEST_SPEC_VERSION } from "../../../../optimization_studio/types/dsl";
+import {
+  NLP_FETCH_HEADROOM_MS,
+  resolveFloorFetchTimeoutMs,
+  resolveMaxFetchTimeoutMs,
+} from "../../../nlpgo/timeouts";
 import type { RunParameterValues } from "../../parameters";
 import { resolveFieldMappings } from "../resolve-field-mappings";
 import type { CodeAgentData } from "../types";
-
-/** Timeout for NLP service requests (2 minutes) */
-const NLP_FETCH_TIMEOUT_MS = 120_000;
-
-/**
- * Slack added to the fetch deadline when the agent asks for a code budget
- * longer than {@link NLP_FETCH_TIMEOUT_MS}, so this adapter never becomes a
- * second, lower ceiling that aborts the request while the engine is still
- * inside the budget it was given.
- */
-const NLP_FETCH_HEADROOM_MS = 30_000;
-
-/** Operator knob naming the platform's maximum for one scenario turn. */
-const NLP_FETCH_MAX_TIMEOUT_ENV = "NLP_FETCH_MAX_TIMEOUT_MS";
-
-/** Used when {@link NLP_FETCH_MAX_TIMEOUT_ENV} is unset or unusable (15 minutes). */
-const NLP_FETCH_MAX_TIMEOUT_DEFAULT_MS = 900_000;
-
-/**
- * The platform's own maximum for one scenario turn, from the environment.
- *
- * This is a bound on how long a scenario worker will hold a socket open, and
- * nothing else. The engine ceiling
- * (`NLPGO_ENGINE_CODE_BLOCK_TIMEOUT_SECONDS`) bounds how long the agent's
- * *Python* may run; it does not bound this process. Without a maximum here, an
- * agent config carrying an absurd `timeoutMs` parks a worker on a socket for as
- * long as the number says — up to ~24.9 days, where `setTimeout` stops honoring
- * the delay at all.
- *
- * The default of 15 minutes sits above the engine's shipped 12-minute ceiling
- * family, so on default settings the engine gets to enforce and REPORT its
- * timeout before this deadline fires. That ordering is a consequence of the two
- * defaults, NOT an invariant this code enforces: an operator who raises
- * `NLPGO_ENGINE_CODE_BLOCK_TIMEOUT_SECONDS` above this value must raise this
- * one too, or the platform aborts the fetch first and the caller sees a generic
- * fetch-side `error.kind: "timeout"` instead of the engine's diagnosis.
- *
- * Clamp, never reject — the same contract the engine keeps for its own knobs.
- * Unset, empty, non-numeric, non-finite, zero and negative all read as "use the
- * default"; a nonsensical ceiling must not fail the scenario run.
- *
- * Read per call rather than at module load so a worker started before the
- * variable was set is not pinned to a stale value, and so tests can exercise
- * the real parse without reloading the module.
- *
- * The scenario child process is spawned with a fixed env allowlist
- * (`buildChildProcessEnv` in ../child-environment.ts), which is what carries
- * this variable from the operator's environment to here, and it runs under
- * `SKIP_ENV_VALIDATION`, which makes the validated `~/env.mjs` proxy return raw
- * strings with no defaults applied. Hence the direct read.
- *
- * @internal Exported for testing.
- */
-export function resolveMaxFetchTimeoutMs(): number {
-  const raw = process.env[NLP_FETCH_MAX_TIMEOUT_ENV];
-  if (raw === undefined || raw.trim() === "") {
-    return NLP_FETCH_MAX_TIMEOUT_DEFAULT_MS;
-  }
-  const parsed = Number(raw);
-  if (!Number.isFinite(parsed) || parsed <= 0) {
-    return NLP_FETCH_MAX_TIMEOUT_DEFAULT_MS;
-  }
-  return parsed;
-}
 
 /** Categories for adapter failures, surfaced as the `error.kind` span attribute. */
 type AdapterErrorKind = "timeout" | "fetch" | "http" | "nlp_error";
@@ -342,8 +283,9 @@ export class SerializedCodeAgentAdapter extends AgentAdapter {
   /**
    * How long to wait on the NLP service for one turn.
    *
-   * Always at least {@link NLP_FETCH_TIMEOUT_MS}, and above the agent's own
-   * code budget when that budget is longer, so the engine gets to enforce (and
+   * Always at least {@link resolveFloorFetchTimeoutMs}'s result — the engine's
+   * own code-block ceiling plus headroom — and above the agent's own code
+   * budget when that budget is longer, so the engine gets to enforce (and
    * report) the timeout rather than the request being aborted from here —
    * bounded by {@link resolveMaxFetchTimeoutMs}, this platform's operator-
    * configurable maximum for one turn.
@@ -358,18 +300,19 @@ export class SerializedCodeAgentAdapter extends AgentAdapter {
    * a `.max()` any more, since the ceiling is now read from the environment.
    *
    * The ceiling bounds the deadline whether or not the agent named a budget:
-   * an operator who sets it below {@link NLP_FETCH_TIMEOUT_MS} has asked for a
-   * shorter socket hold than the default floor, and gets it.
+   * an operator who sets it below the floor has asked for a shorter socket
+   * hold than the engine's own ceiling, and gets it.
    */
   private fetchTimeoutMs(): number {
     const { timeoutMs } = this.config;
+    const floorTimeoutMs = resolveFloorFetchTimeoutMs();
     const maxTimeoutMs = resolveMaxFetchTimeoutMs();
     if (timeoutMs === undefined) {
-      return Math.min(maxTimeoutMs, NLP_FETCH_TIMEOUT_MS);
+      return Math.min(maxTimeoutMs, floorTimeoutMs);
     }
     return Math.min(
       maxTimeoutMs,
-      Math.max(NLP_FETCH_TIMEOUT_MS, timeoutMs + NLP_FETCH_HEADROOM_MS),
+      Math.max(floorTimeoutMs, timeoutMs + NLP_FETCH_HEADROOM_MS),
     );
   }
 

--- a/platform/app/src/server/scenarios/execution/serialized-adapters/workflow-agent.adapter.ts
+++ b/platform/app/src/server/scenarios/execution/serialized-adapters/workflow-agent.adapter.ts
@@ -22,12 +22,30 @@ import { injectTraceContextHeaders } from "@langwatch/observability/tracing";
 import type { AgentInput } from "@langwatch/scenario";
 import { AgentAdapter, AgentRole } from "@langwatch/scenario";
 import { randomBytes } from "crypto";
+import {
+  resolveFloorFetchTimeoutMs,
+  resolveMaxFetchTimeoutMs,
+} from "../../../nlpgo/timeouts";
 import type { RunParameterValues } from "../../parameters";
 import { resolveFieldMappings } from "../resolve-field-mappings";
 import type { WorkflowAgentData } from "../types";
 
-/** Timeout for NLP service requests (2 minutes) — matches code adapter. */
-const NLP_FETCH_TIMEOUT_MS = 120_000;
+/**
+ * How long to wait on the NLP service for one turn.
+ *
+ * This adapter has no per-agent `timeoutMs` budget to add headroom above
+ * (unlike the code adapter's `CodeAgentData`, `WorkflowAgentData` carries
+ * none) — so the deadline is simply the floor, bounded by the platform's
+ * operator-configurable maximum. See `../../../nlpgo/timeouts.ts` for what
+ * the floor derives from and why: it used to be this file's own hardcoded
+ * `NLP_FETCH_TIMEOUT_MS = 120_000`, entirely independent of the code
+ * adapter's copy and with no env override, which is exactly the drift that
+ * caused a live production timeout when the engine's own ceiling was
+ * raised and this one wasn't told.
+ */
+function fetchTimeoutMs(): number {
+  return Math.min(resolveMaxFetchTimeoutMs(), resolveFloorFetchTimeoutMs());
+}
 
 /**
  * Serialized workflow agent adapter that uses pre-fetched workflow DSL.
@@ -206,7 +224,7 @@ export class SerializedWorkflowAgentAdapter extends AgentAdapter {
     };
 
     const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), NLP_FETCH_TIMEOUT_MS);
+    const timeout = setTimeout(() => controller.abort(), fetchTimeoutMs());
 
     try {
       let response: Response;


### PR DESCRIPTION
## Summary

A scenario failed in prod after 121.13s with `SerializedCodeAgentAdapterError: Code execution failed: NLP service http://langwatch-nlp-service/go/studio/execute_sync did not respond within 120000ms (request aborted)`.

`nlpgo`'s own code-block execution ceiling was already raised 60s -> 600s in #7640 (server-side default, confirmed via `services/nlpgo/app/engine/blocks/codeblock/codeblock.go:115`). But the TypeScript client's fetch deadline was a hardcoded `NLP_FETCH_TIMEOUT_MS = 120_000` floor in `code-agent.adapter.ts`, and `NLP_FETCH_MAX_TIMEOUT_MS` could only *lower* it via `Math.min`, never raise it. Studio-authored scenarios can't set `timeoutMs` at all (UI limitation), so most scenarios hit the flat 120s floor regardless of how long the engine was willing to keep working. `workflow-agent.adapter.ts` had its own separate, undocumented copy of the same `120_000` constant, with no env override and no headroom logic whatsoever.

## Fix

Rather than adding a second independently-configured floor knob (which is how these two numbers drifted apart in the first place), `platform/app/src/server/nlpgo/timeouts.ts` makes the client deadline **derive** from the engine's own ceiling:

- `resolveFloorFetchTimeoutMs()` reads `NLPGO_ENGINE_CODE_BLOCK_TIMEOUT_SECONDS` — the *exact* env var name `services/nlpgo/config.go` already reads for the same setting — and adds a fixed 30s headroom (`NLP_FETCH_HEADROOM_MS`), so the engine gets to enforce and report its own timeout before the client aborts the socket.
- Default: 600s (mirrors nlpgo's own Go-side fallback) + 30s headroom = **630s**, when the env var is unset.
- `resolveMaxFetchTimeoutMs()` is unchanged (still reads `NLP_FETCH_MAX_TIMEOUT_MS`, still the platform's own upper bound, still 900s default).
- Both `code-agent.adapter.ts` and `workflow-agent.adapter.ts` import from this one module. Neither holds its own copy of any timeout number anymore.
- Headroom (`NLP_FETCH_HEADROOM_MS`) is deliberately **not** env-configurable — making it independently tunable would recreate the exact two-numbers-that-can-drift problem this PR exists to eliminate. It exists purely to absorb network/serialization latency around the engine's own deadline.

Both env vars are forwarded through the scenario child process's env allowlist (`child-environment.ts`), since the child runs under `SKIP_ENV_VALIDATION` and has no other route to the operator's environment.

Both `resolveFloorFetchTimeoutMs()` and `resolveMaxFetchTimeoutMs()` are read **per call**, not cached — a running worker started before an operator changes the env var is not pinned to a stale value.

### Env var inventory

| | Before | After |
|---|---|---|
| Client floor source | `NLP_FETCH_TIMEOUT_MS` (code adapter only; workflow adapter had no env override at all) | `NLPGO_ENGINE_CODE_BLOCK_TIMEOUT_SECONDS` (shared with nlpgo itself, already exists) |
| Client ceiling source | `NLP_FETCH_MAX_TIMEOUT_MS` | `NLP_FETCH_MAX_TIMEOUT_MS` (unchanged) |
| Headroom | hardcoded `30_000` (code adapter only) | hardcoded `NLP_FETCH_HEADROOM_MS = 30_000` (shared, both adapters) |

**Net new env vars: zero.** `NLPGO_ENGINE_CODE_BLOCK_TIMEOUT_SECONDS` already existed as nlpgo's own operator knob (already plumbed via terraform to k8s and via #7643 to per-project Lambdas) — this PR is the client reading the same name, not inventing one.

## Other hardcoded deadlines on this path — audit

Grepped every file touching `nlpServiceUrl` / `execute_sync` for `setTimeout`/`AbortController`:

- `code-agent.adapter.ts`, `workflow-agent.adapter.ts` — the two fixed above.
- `prompt-config.adapter.ts` — carries `nlpServiceUrl` through but issues no fetch itself; no deadline to fix.
- `nlpgoFetch.ts` — a *different* call path (per-project Lambda ARN routing), not used by the scenario code/workflow adapters (confirmed by tracing `data-prefetcher.ts:681`'s `nlpServiceUrl: env.LANGWATCH_NLP_SERVICE`, a static k8s URL, separate from `nlpgoFetch.ts`'s Lambda branching). Has no client-side timeout at all today — left alone, out of scope for this bug, flagging for a follow-up.

## Two things I verified rather than assumed

**Does scenario execution route to k8s or a per-project Lambda?** Traced `nlpServiceUrl` from the adapters through `serialized-adapter.registry.ts` -> `scenario-child-process.ts` -> `data-prefetcher.ts:681`, which sets it to `env.LANGWATCH_NLP_SERVICE` — a single static URL, always the k8s `langwatch-nlp-service` ClusterIP. Scenario execution never routes through `nlpgoFetch.ts`'s Lambda logic. So the 600s engine ceiling (in effect on the k8s deployment) is the one that governs the path that failed in prod.

**Is a ~630s held socket survivable end to end?** From source inspection: `services/nlpgo/serve.go` sets only `ReadHeaderTimeout: 10s` on the Go `http.Server` — no `WriteTimeout`/`IdleTimeout` (Go defaults these to unlimited). The `StreamIdleTimeoutSeconds`/720s setting applies only to the separate SSE `/go/studio/execute` endpoint, not the `/go/studio/execute_sync` endpoint these adapters call — confirmed via `router.go`/`handlers.go`, `executeSyncHandler` has no additional timeout wrapper. No service mesh (Istio/VirtualService) found in the charts. The only `proxy-read-timeout` (120s, nginx) I found is on an *example* overlay for the platform-app's **public** ingress, irrelevant to this internal pod-to-pod ClusterIP call, which bypasses any ingress controller. **Caveat**: this is source-only verification — cloud/node-level network idle timeouts aren't visible in this repo and I could not confirm those independently.

## Deployment Impact

**This needs a platform redeploy.** No terraform/helm changes are required for this fix to work at its defaults — `NLPGO_ENGINE_CODE_BLOCK_TIMEOUT_SECONDS` is not currently set anywhere in `charts/langwatch/templates/langwatch_nlp/deployment.yaml`, so both nlpgo (via its own Go-side default) and this client (via its mirrored fallback) land on the same 600s default with no operator action needed. Both `NLPGO_ENGINE_CODE_BLOCK_TIMEOUT_SECONDS` and `NLP_FETCH_MAX_TIMEOUT_MS` are read fresh on every call, not cached at process start — so once the platform app is redeployed with this change, a later env var change takes effect on the next scenario run with no further restart required for *that* part. The redeploy itself is still needed to ship the new derived-timeout code.

## Tests

- `child-process-env.unit.test.ts` — new test asserting `NLPGO_ENGINE_CODE_BLOCK_TIMEOUT_SECONDS` is forwarded through the child env allowlist.
- `code-agent.adapter.unit.test.ts` — pinned literals updated from 120s/120000ms to 630s/630000ms (the new default floor); ceiling-clamping tests (`NLP_FETCH_MAX_TIMEOUT_MS`) unchanged, still exercise the unmodified ceiling logic.

## Verification

Run from a fresh worktree off current `origin/main`, gated differentially against a pristine baseline worktree at the same commit:

- **typecheck** (`tsc --noEmit --project ./tsconfig.tsgo.json`, after `node scripts/generate-task-registry.mjs`): baseline exit 0 / 0 errors, branch exit 0 / 0 errors. Zero new errors.
- **lint** (`biome check ./src --max-diagnostics=1000`): baseline exit 0 / 3288 warnings, branch exit 0 / 3288 warnings. Zero new warnings.
- **targeted tests** (`vitest run` on the 3 touched test files): exit 0, 92/92 passed.
- **feature-parity** (`pnpm check:feature-parity`): exit 0.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved timeout handling for AI-powered code and workflow executions.
  - Requests now remain active long enough to accommodate the configured engine execution limit, reducing premature timeout failures.
  - Added a configurable maximum fetch timeout with safe defaults and fallback behavior.
  - Timeout settings are consistently applied across execution environments and related services.
  - Updated automated coverage to verify timeout propagation and the new default deadline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Human verification

<!-- no-ui-surface -->
Backend-only change (client fetch deadline derivation in `platform/app/src/server/nlpgo/timeouts.ts` and the two adapters). No UI surface, so no screenshot/recording applies.

To verify by hand after deploy:
1. Run a Studio-authored scenario whose code block takes longer than 120s and less than 600s.
2. Before this change it aborts at ~120s with `NLP service ... did not respond within 120000ms (request aborted)`. After it, the run completes.
3. Set `NLPGO_ENGINE_CODE_BLOCK_TIMEOUT_SECONDS` to a small value (e.g. `30`) on the platform app and re-run — the client now aborts at ~60s (30s + 30s headroom), proving the deadline derives from the engine's own knob and is read per call, not cached.

## How I can prove I was successful

- typecheck (`tsc --noEmit --project ./tsconfig.tsgo.json`) run differentially against a pristine baseline worktree at the same commit: baseline exit 0 / 0 errors, branch exit 0 / 0 errors.
- lint (`biome check ./src --max-diagnostics=1000`): baseline exit 0 / 3288 warnings, branch exit 0 / 3288 warnings — zero new.
- targeted tests (`vitest run` on the 3 touched test files): exit 0, 92/92 passed.
- `pnpm check:feature-parity`: exit 0.
- CI on this PR is green on the per-SHA check-runs surface.

Not proven here: the end-to-end prod path. The ~630s socket survivability is source-only verification — cloud/node-level network idle timeouts are not visible in this repo and were not independently confirmed.
