### PR TITLE
fix(model-providers): a latest alias resolves at the LiteLLM boundary

### DIFF
--- a/platform/app/src/server/api/routers/__tests__/modelProviders.unit.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/modelProviders.unit.test.ts
@@ -3,6 +3,7 @@ import { MASKED_KEY_PLACEHOLDER } from "../../../../utils/constants";
 import { isSecretCredentialField } from "../../../../utils/modelProviderHelpers";
 import type { CustomModelEntry } from "../../../modelProviders/customModel.schema";
 import { customModelUpdateInputSchema } from "../../../modelProviders/customModel.schema";
+import { expandLatestAlias } from "../../../modelProviders/latestAliases";
 import type { MaybeStoredModelProvider } from "../../../modelProviders/registry";
 import {
   getModelMetadataForFrontend,
@@ -328,6 +329,41 @@ describe("prepareLitellmParams", () => {
       });
 
       expect(result.api_base).toBe("https://custom-llm.example.com/v1");
+    });
+  });
+
+  describe("when the model is a latest alias", () => {
+    /** @scenario "The LiteLLM params carry the concrete model for an alias" */
+    it("names the model the alias currently resolves to", async () => {
+      vi.stubEnv("OPENAI_API_KEY", "test-key");
+
+      const modelProvider = createMockProvider("openai");
+      const result = await prepareLitellmParams({
+        model: "openai/latest-mini",
+        modelProvider,
+        projectId: "test-project",
+      });
+
+      // The catalog decides what the alias means today, so the expectation
+      // reads the same resolver instead of pinning a model that retires.
+      const resolved = expandLatestAlias("openai/latest-mini");
+      expect(resolved).not.toBe("openai/latest-mini");
+      expect(result.model).toBe(resolved);
+      expect(result.model).not.toContain("latest");
+    });
+
+    /** @scenario "A concrete model id is not rewritten" */
+    it("passes a concrete model id through unchanged", async () => {
+      vi.stubEnv("OPENAI_API_KEY", "test-key");
+
+      const modelProvider = createMockProvider("openai");
+      const result = await prepareLitellmParams({
+        model: "openai/gpt-5-mini",
+        modelProvider,
+        projectId: "test-project",
+      });
+
+      expect(result.model).toBe("openai/gpt-5-mini");
     });
   });
 });

--- a/platform/app/src/server/api/routers/modelProviders.utils.ts
+++ b/platform/app/src/server/api/routers/modelProviders.utils.ts
@@ -4,6 +4,7 @@ import { prisma } from "../../db";
 import { CODING_ASSISTANT_SURFACES_ONLY_NEEDLE } from "../../modelProviders/codexRefusalMessage";
 import { isCodexModel } from "../../modelProviders/codexRestrictions";
 import { geminiAgentPlatformPair } from "../../modelProviders/geminiDoor";
+import { expandLatestAlias } from "../../modelProviders/latestAliases";
 import type {
   LLMModelEntry,
   ReasoningConfig,
@@ -311,7 +312,7 @@ async function resolveServingRow({
 }
 
 export const prepareLitellmParams = async ({
-  model,
+  model: requestedModel,
   modelProvider: givenModelProvider,
   projectId,
 }: {
@@ -319,6 +320,13 @@ export const prepareLitellmParams = async ({
   modelProvider: MaybeStoredModelProvider;
   projectId: string;
 }) => {
+  // A stored `<provider>/latest` or `<provider>/latest-mini` alias resolves to
+  // the concrete model here, at the last stop before the wire. The pickers
+  // resolve it on their own, but the prompts API, the CLI and agent-written
+  // configs store the alias verbatim, and no provider knows the word
+  // "latest". Runs before the serving-row selection so the row is picked for
+  // the concrete model. A concrete id passes through unchanged.
+  const model = expandLatestAlias(requestedModel);
   // Execution backstop for the terms-restricted provider: every general
   // inference path (workflows, evaluations, playground, optimization
   // studio) funnels through here on its way to litellm/nlpgo, and codex

--- a/platform/app/src/server/modelProviders/__tests__/utils.unit.test.ts
+++ b/platform/app/src/server/modelProviders/__tests__/utils.unit.test.ts
@@ -31,8 +31,12 @@ vi.mock("../codexGatewayModel", () => ({
   getCodexVercelAIModel: vi.fn().mockResolvedValue("codex-model-handle"),
 }));
 
-import { getProjectModelProviders } from "~/server/api/routers/modelProviders.utils";
+import {
+  getProjectModelProviders,
+  prepareLitellmParams,
+} from "~/server/api/routers/modelProviders.utils";
 import { prisma } from "~/server/db";
+import { expandLatestAlias } from "../latestAliases";
 import { getVercelAIModel } from "../utils";
 
 const mockPrismaFindUnique = prisma.project.findUnique as ReturnType<
@@ -76,6 +80,26 @@ describe("getVercelAIModel", () => {
           model: "azure/my-gpt4-deployment",
         }),
       ).rejects.toThrow('Model provider "azure" is configured but disabled.');
+    });
+  });
+
+  describe("when an explicit latest alias is requested", () => {
+    /** @scenario "An explicit alias handed to the model factory resolves before the provider lookup" */
+    it("prepares the LiteLLM params for the model the alias resolves to", async () => {
+      mockGetProjectModelProviders.mockResolvedValue({
+        openai: { provider: "openai", enabled: true, customKeys: null },
+      });
+
+      await getVercelAIModel({
+        projectId: "project-123",
+        model: "openai/latest",
+      });
+
+      const resolved = expandLatestAlias("openai/latest");
+      expect(resolved).not.toBe("openai/latest");
+      expect(prepareLitellmParams).toHaveBeenCalledWith(
+        expect.objectContaining({ model: resolved }),
+      );
     });
   });
 

--- a/platform/app/src/server/modelProviders/utils.ts
+++ b/platform/app/src/server/modelProviders/utils.ts
@@ -9,6 +9,7 @@ import { nlpgoProxyBaseURL } from "../nlpgo/nlpgoFetch";
 import { getCodexVercelAIModel } from "./codexGatewayModel";
 import { isCodexModel } from "./codexRestrictions";
 import { featureByKey } from "./featureRegistry";
+import { expandLatestAlias } from "./latestAliases";
 import { ModelNotConfiguredError } from "./modelNotConfiguredError";
 import { ModelProviderDisabledError } from "./modelProviderDisabledError";
 import type { MaybeStoredModelProvider } from "./registry";
@@ -117,8 +118,9 @@ async function resolveModel({
   featureKey: string;
   modelProviders: Record<string, MaybeStoredModelProvider>;
 }): Promise<string> {
-  // 1. Explicit model always wins.
-  if (explicit) return explicit;
+  // 1. Explicit model always wins. A latest alias resolves to the concrete
+  //    model here so the provider lookup below reads the real prefix.
+  if (explicit) return expandLatestAlias(explicit);
 
   // 2. Cascade-resolved default for the given feature key. Throws
   //    ModelNotConfiguredError when nothing is set at any scope —

--- a/specs/model-providers/latest-alias-resolution.feature
+++ b/specs/model-providers/latest-alias-resolution.feature
@@ -71,3 +71,29 @@ Feature: Latest-alias model resolution
       Then the named flagship tier wins
       # Without an explicit tier ranking the two sort equal and the
       # winner falls out of catalog iteration order.
+
+  Rule: Every read-time boundary hands a provider the concrete model
+
+    The pickers resolve an alias before they store a default, but the
+    prompts API, the CLI and agent-written configs store the alias
+    verbatim. No provider knows the word "latest", so the last stop before
+    the wire resolves it. A concrete model id passes through unchanged.
+
+    @unit
+    Scenario: The LiteLLM params carry the concrete model for an alias
+      Given a project with the OpenAI provider enabled
+      When LiteLLM params are prepared for the model "openai/latest-mini"
+      Then the params name the model the alias currently resolves to
+      And they do not name "latest-mini"
+
+    @unit
+    Scenario: A concrete model id is not rewritten
+      When LiteLLM params are prepared for the model "openai/gpt-5-mini"
+      Then the params name "openai/gpt-5-mini"
+
+    @unit
+    Scenario: An explicit alias handed to the model factory resolves before the provider lookup
+      Given a project with the OpenAI provider enabled
+      When a Vercel AI model is requested for the explicit model "openai/latest"
+      Then the LiteLLM params are prepared for the model the alias resolves to
+      And the provider is read from the resolved model


### PR DESCRIPTION
## Summary

A stored `<provider>/latest` or `<provider>/latest-mini` alias now resolves to the concrete model at the last stop before the wire.

The model pickers resolve the alias before they store a default, but the prompts API, the CLI and agent-written configs store the alias verbatim. Every in-platform inference path (playground, evaluations, optimization studio, topic clustering, the Vercel AI model factory) goes through `prepareLitellmParams`, and that function passed the alias through unchanged, so the provider received the literal word `latest` and answered with a model-not-found error.

`expandLatestAlias` was called in exactly one place, `resolveModelForFeature`. This change adds it at the two remaining boundaries:

- `prepareLitellmParams` expands the model before the serving-row selection, so the row is picked for the concrete model.
- `getVercelAIModel` expands an explicit model before the provider lookup, so the lookup reads the real provider prefix.

A concrete model id passes through both unchanged. The scenario simulator and judge chain gets the same expansion in langwatch#7271.

## Spec

`specs/model-providers/latest-alias-resolution.feature`, new rule "Every read-time boundary hands a provider the concrete model", three `@unit` scenarios bound to `modelProviders.unit.test.ts` and `utils.unit.test.ts`.

## Test plan

- `pnpm test:unit run src/server/api/routers/__tests__/modelProviders.unit.test.ts src/server/modelProviders/__tests__/utils.unit.test.ts`: 43 passed.
- `pnpm check:feature-parity`: 9/9 scenarios bound.
- `pnpm typecheck:all` clean.

## Deployment Impact

No migration and no config change. The only behavior change is for a model id that is one of the six alias strings; every concrete model id keeps the same LiteLLM params as before. An alias that reached a provider before this change failed with a model-not-found error, so no working request changes its model.

https://claude.ai/code/session_01X2mpfKNKua66eZ2WNLr1tj


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for resolving `latest` and `latest-mini` model aliases to their current concrete model IDs.
  * Ensured provider selection and model configuration use the resolved model.

* **Bug Fixes**
  * Concrete model IDs continue to pass through unchanged.
  * Improved handling of explicit aliases during model provider lookup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->