### PR TITLE
fix(openapi): preserve scenario parameter descriptions

### DIFF
--- a/.github/workflows/langwatch-app-ci.yml
+++ b/.github/workflows/langwatch-app-ci.yml
@@ -1234,8 +1234,8 @@ jobs:
         run: bash .github/scripts/notify-slack-job-failure.sh feature-parity
 
   # The generated OpenAPI document is what external integrators compile
-  # clients from, and an operation missing its body, parameters or success
-  # response still appears in it. This turns each omission into a failure.
+  # clients from. Keep it in sync with the generator, then reject operations
+  # missing their body, parameters or success response.
   openapi-completeness:
     needs: changes
     if: needs.changes.outputs.relevant == 'true'
@@ -1257,6 +1257,19 @@ jobs:
           install: "@langwatch/web..."
 
       - uses: ./.github/actions/prepare-generated-files
+
+      # The checks below read the committed document, so on their own they can
+      # pass while the generator would write something different. Regenerate
+      # first and refuse that drift before validating the document's contents.
+      - name: Check that the generated OpenAPI document is current
+        working-directory: platform/app
+        env:
+          # Route imports validate the app environment; generation needs no
+          # live services, so use the same build-time relaxation as app builds.
+          BUILD_TIME: "true"
+        run: |
+          pnpm run task generateOpenAPISpec
+          git diff --exit-code -- src/app/api/openapiLangWatch.json
 
       - name: Check OpenAPI completeness
         working-directory: platform/app

--- a/docs/api-reference/openapiLangWatch.json
+++ b/docs/api-reference/openapiLangWatch.json
@@ -49430,10 +49430,12 @@
                                 {
                                   "type": "boolean"
                                 }
-                              ]
+                              ],
+                              "description": "The value the run uses when it supplies none. A secret parameter cannot carry one."
                             },
                             "secret": {
-                              "type": "boolean"
+                              "type": "boolean",
+                              "description": "Whether the value is a credential, supplied when the run starts and delivered to the target as secrets.NAME. A secret parameter is rejected when it also carries defaultValue."
                             }
                           },
                           "required": [
@@ -49645,10 +49647,12 @@
                               {
                                 "type": "boolean"
                               }
-                            ]
+                            ],
+                            "description": "The value the run uses when it supplies none. A secret parameter cannot carry one."
                           },
                           "secret": {
-                            "type": "boolean"
+                            "type": "boolean",
+                            "description": "Whether the value is a credential, supplied when the run starts and delivered to the target as secrets.NAME. A secret parameter is rejected when it also carries defaultValue."
                           }
                         },
                         "required": [
@@ -49849,10 +49853,12 @@
                             {
                               "type": "boolean"
                             }
-                          ]
+                          ],
+                          "description": "The value the run uses when it supplies none. A secret parameter cannot carry one."
                         },
                         "secret": {
-                          "type": "boolean"
+                          "type": "boolean",
+                          "description": "Whether the value is a credential, supplied when the run starts and delivered to the target as secrets.NAME. A secret parameter is rejected when it also carries defaultValue."
                         }
                       },
                       "required": [
@@ -49981,10 +49987,12 @@
                               {
                                 "type": "boolean"
                               }
-                            ]
+                            ],
+                            "description": "The value the run uses when it supplies none. A secret parameter cannot carry one."
                           },
                           "secret": {
-                            "type": "boolean"
+                            "type": "boolean",
+                            "description": "Whether the value is a credential, supplied when the run starts and delivered to the target as secrets.NAME. A secret parameter is rejected when it also carries defaultValue."
                           }
                         },
                         "required": [
@@ -50226,10 +50234,12 @@
                               {
                                 "type": "boolean"
                               }
-                            ]
+                            ],
+                            "description": "The value the run uses when it supplies none. A secret parameter cannot carry one."
                           },
                           "secret": {
-                            "type": "boolean"
+                            "type": "boolean",
+                            "description": "Whether the value is a credential, supplied when the run starts and delivered to the target as secrets.NAME. A secret parameter is rejected when it also carries defaultValue."
                           }
                         },
                         "required": [
@@ -50449,10 +50459,12 @@
                             {
                               "type": "boolean"
                             }
-                          ]
+                          ],
+                          "description": "The value the run uses when it supplies none. A secret parameter cannot carry one."
                         },
                         "secret": {
-                          "type": "boolean"
+                          "type": "boolean",
+                          "description": "Whether the value is a credential, supplied when the run starts and delivered to the target as secrets.NAME. A secret parameter is rejected when it also carries defaultValue."
                         }
                       },
                       "required": [
@@ -50585,10 +50597,12 @@
                               {
                                 "type": "boolean"
                               }
-                            ]
+                            ],
+                            "description": "The value the run uses when it supplies none. A secret parameter cannot carry one."
                           },
                           "secret": {
-                            "type": "boolean"
+                            "type": "boolean",
+                            "description": "Whether the value is a credential, supplied when the run starts and delivered to the target as secrets.NAME. A secret parameter is rejected when it also carries defaultValue."
                           }
                         },
                         "required": [
@@ -50808,10 +50822,12 @@
                             {
                               "type": "boolean"
                             }
-                          ]
+                          ],
+                          "description": "The value the run uses when it supplies none. A secret parameter cannot carry one."
                         },
                         "secret": {
-                          "type": "boolean"
+                          "type": "boolean",
+                          "description": "Whether the value is a credential, supplied when the run starts and delivered to the target as secrets.NAME. A secret parameter is rejected when it also carries defaultValue."
                         }
                       },
                       "required": [
@@ -51362,10 +51378,12 @@
                                   {
                                     "type": "boolean"
                                   }
-                                ]
+                                ],
+                                "description": "The value the run uses when it supplies none. A secret parameter cannot carry one."
                               },
                               "secret": {
-                                "type": "boolean"
+                                "type": "boolean",
+                                "description": "Whether the value is a credential, supplied when the run starts and delivered to the target as secrets.NAME. A secret parameter is rejected when it also carries defaultValue."
                               }
                             },
                             "required": [

--- a/platform/app/src/app/api/openapiLangWatch.json
+++ b/platform/app/src/app/api/openapiLangWatch.json
@@ -49430,10 +49430,12 @@
                                 {
                                   "type": "boolean"
                                 }
-                              ]
+                              ],
+                              "description": "The value the run uses when it supplies none. A secret parameter cannot carry one."
                             },
                             "secret": {
-                              "type": "boolean"
+                              "type": "boolean",
+                              "description": "Whether the value is a credential, supplied when the run starts and delivered to the target as secrets.NAME. A secret parameter is rejected when it also carries defaultValue."
                             }
                           },
                           "required": [
@@ -49645,10 +49647,12 @@
                               {
                                 "type": "boolean"
                               }
-                            ]
+                            ],
+                            "description": "The value the run uses when it supplies none. A secret parameter cannot carry one."
                           },
                           "secret": {
-                            "type": "boolean"
+                            "type": "boolean",
+                            "description": "Whether the value is a credential, supplied when the run starts and delivered to the target as secrets.NAME. A secret parameter is rejected when it also carries defaultValue."
                           }
                         },
                         "required": [
@@ -49849,10 +49853,12 @@
                             {
                               "type": "boolean"
                             }
-                          ]
+                          ],
+                          "description": "The value the run uses when it supplies none. A secret parameter cannot carry one."
                         },
                         "secret": {
-                          "type": "boolean"
+                          "type": "boolean",
+                          "description": "Whether the value is a credential, supplied when the run starts and delivered to the target as secrets.NAME. A secret parameter is rejected when it also carries defaultValue."
                         }
                       },
                       "required": [
@@ -49981,10 +49987,12 @@
                               {
                                 "type": "boolean"
                               }
-                            ]
+                            ],
+                            "description": "The value the run uses when it supplies none. A secret parameter cannot carry one."
                           },
                           "secret": {
-                            "type": "boolean"
+                            "type": "boolean",
+                            "description": "Whether the value is a credential, supplied when the run starts and delivered to the target as secrets.NAME. A secret parameter is rejected when it also carries defaultValue."
                           }
                         },
                         "required": [
@@ -50226,10 +50234,12 @@
                               {
                                 "type": "boolean"
                               }
-                            ]
+                            ],
+                            "description": "The value the run uses when it supplies none. A secret parameter cannot carry one."
                           },
                           "secret": {
-                            "type": "boolean"
+                            "type": "boolean",
+                            "description": "Whether the value is a credential, supplied when the run starts and delivered to the target as secrets.NAME. A secret parameter is rejected when it also carries defaultValue."
                           }
                         },
                         "required": [
@@ -50449,10 +50459,12 @@
                             {
                               "type": "boolean"
                             }
-                          ]
+                          ],
+                          "description": "The value the run uses when it supplies none. A secret parameter cannot carry one."
                         },
                         "secret": {
-                          "type": "boolean"
+                          "type": "boolean",
+                          "description": "Whether the value is a credential, supplied when the run starts and delivered to the target as secrets.NAME. A secret parameter is rejected when it also carries defaultValue."
                         }
                       },
                       "required": [
@@ -50585,10 +50597,12 @@
                               {
                                 "type": "boolean"
                               }
-                            ]
+                            ],
+                            "description": "The value the run uses when it supplies none. A secret parameter cannot carry one."
                           },
                           "secret": {
-                            "type": "boolean"
+                            "type": "boolean",
+                            "description": "Whether the value is a credential, supplied when the run starts and delivered to the target as secrets.NAME. A secret parameter is rejected when it also carries defaultValue."
                           }
                         },
                         "required": [
@@ -50808,10 +50822,12 @@
                             {
                               "type": "boolean"
                             }
-                          ]
+                          ],
+                          "description": "The value the run uses when it supplies none. A secret parameter cannot carry one."
                         },
                         "secret": {
-                          "type": "boolean"
+                          "type": "boolean",
+                          "description": "Whether the value is a credential, supplied when the run starts and delivered to the target as secrets.NAME. A secret parameter is rejected when it also carries defaultValue."
                         }
                       },
                       "required": [
@@ -51362,10 +51378,12 @@
                                   {
                                     "type": "boolean"
                                   }
-                                ]
+                                ],
+                                "description": "The value the run uses when it supplies none. A secret parameter cannot carry one."
                               },
                               "secret": {
-                                "type": "boolean"
+                                "type": "boolean",
+                                "description": "Whether the value is a credential, supplied when the run starts and delivered to the target as secrets.NAME. A secret parameter is rejected when it also carries defaultValue."
                               }
                             },
                             "required": [

--- a/platform/app/src/server/scenarios/__tests__/parameters-openapi.unit.test.ts
+++ b/platform/app/src/server/scenarios/__tests__/parameters-openapi.unit.test.ts
@@ -1,0 +1,134 @@
+/**
+ * @vitest-environment node
+ *
+ * `scenarioParameterDefinitionSchema` is shared by the scenarios and suites
+ * REST families. Before this guard, another module could import
+ * `server/scenarios/parameters.ts` before `zod-openapi/extend` had run, so the
+ * schema objects were constructed unpatched and a later OpenAPI conversion
+ * dropped the descriptions on `defaultValue` and `secret`.
+ *
+ * Drive the real module in fresh processes so module cache and import order are
+ * both real, and pin the two orders that matter.
+ *
+ * @see specs/api-reference/scenario-parameter-openapi-descriptions.feature
+ */
+
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+const APP_ROOT = path.resolve(__dirname, "../../../..");
+const TSX = path.join(APP_ROOT, "node_modules", ".bin", "tsx");
+const TSCONFIG = path.join(APP_ROOT, "tsconfig.json");
+const DEFAULT_VALUE_DESCRIPTION =
+  "The value the run uses when it supplies none. A secret parameter cannot carry one.";
+const SECRET_DESCRIPTION =
+  "Whether the value is a credential, supplied when the run starts and delivered to the target as secrets.NAME. A secret parameter is rejected when it also carries defaultValue.";
+
+let scratch: string;
+
+afterEach(() => {
+  if (scratch) rmSync(scratch, { recursive: true, force: true });
+});
+
+function runProbe(order: "extend-first" | "schema-first"): {
+  status: number | null;
+  stderr: string;
+  stdout: string;
+  schema: {
+    defaultValue?: { description?: string };
+    secret?: { description?: string };
+  } | null;
+} {
+  scratch = mkdtempSync(path.join(APP_ROOT, ".parameters-openapi-"));
+  const probe = path.join(scratch, "probe.ts");
+  writeFileSync(
+    probe,
+    `import { createSchema } from "zod-openapi";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const appRoot = ${JSON.stringify(APP_ROOT)};
+const order = process.argv[2];
+
+async function importFromApp(rel) {
+  return import(pathToFileURL(path.join(appRoot, rel)).href);
+}
+
+async function main() {
+  if (order === "extend-first") {
+    await import("zod-openapi/extend");
+  }
+  const { scenarioParameterDefinitionSchema } = await importFromApp(
+    "src/server/scenarios/parameters.ts",
+  );
+  if (order === "schema-first") {
+    await import("zod-openapi/extend");
+  }
+  const { schema } = createSchema(scenarioParameterDefinitionSchema, {
+    schemaType: "input",
+  });
+  console.log(
+    JSON.stringify({
+      defaultValue: schema?.properties?.defaultValue ?? null,
+      secret: schema?.properties?.secret ?? null,
+    }),
+  );
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});
+`,
+    "utf8",
+  );
+
+  const result = spawnSync(TSX, ["--tsconfig", TSCONFIG, probe, order], {
+    cwd: APP_ROOT,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      NODE_ENV: "test",
+    },
+  });
+
+  return {
+    status: result.status,
+    stderr: result.stderr,
+    stdout: result.stdout,
+    schema: result.stdout
+      ? (JSON.parse(result.stdout) as {
+          defaultValue?: { description?: string };
+          secret?: { description?: string };
+        })
+      : null,
+  };
+}
+
+describe("scenario parameter OpenAPI descriptions", () => {
+  /** @scenario "Loading zod-openapi before the schema keeps the descriptions" */
+  it("keeps both descriptions when the patch loads first", () => {
+    const result = runProbe("extend-first");
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).not.toBe("");
+    expect(result.schema?.defaultValue?.description).toBe(
+      DEFAULT_VALUE_DESCRIPTION,
+    );
+    expect(result.schema?.secret?.description).toBe(SECRET_DESCRIPTION);
+  });
+
+  /** @scenario "Another module may import the schema before the patch and the descriptions still survive" */
+  it("keeps both descriptions even when another module loads the schema first", () => {
+    const result = runProbe("schema-first");
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).not.toBe("");
+    expect(result.schema?.defaultValue?.description).toBe(
+      DEFAULT_VALUE_DESCRIPTION,
+    );
+    expect(result.schema?.secret?.description).toBe(SECRET_DESCRIPTION);
+  });
+});

--- a/platform/app/src/server/scenarios/__tests__/parameters-openapi.unit.test.ts
+++ b/platform/app/src/server/scenarios/__tests__/parameters-openapi.unit.test.ts
@@ -108,27 +108,35 @@ main().catch((error) => {
 }
 
 describe("scenario parameter OpenAPI descriptions", () => {
-  /** @scenario "Loading zod-openapi before the schema keeps the descriptions" */
-  it("keeps both descriptions when the patch loads first", () => {
-    const result = runProbe("extend-first");
-    expect(result.status).toBe(0);
-    expect(result.stderr).toBe("");
-    expect(result.stdout).not.toBe("");
-    expect(result.schema?.defaultValue?.description).toBe(
-      DEFAULT_VALUE_DESCRIPTION,
-    );
-    expect(result.schema?.secret?.description).toBe(SECRET_DESCRIPTION);
+  describe("given zod-openapi loads before the schema", () => {
+    describe("when the schema is converted to OpenAPI", () => {
+      /** @scenario "Loading zod-openapi before the schema keeps the descriptions" */
+      it("keeps both descriptions", () => {
+        const result = runProbe("extend-first");
+        expect(result.status).toBe(0);
+        expect(result.stderr).toBe("");
+        expect(result.stdout).not.toBe("");
+        expect(result.schema?.defaultValue?.description).toBe(
+          DEFAULT_VALUE_DESCRIPTION,
+        );
+        expect(result.schema?.secret?.description).toBe(SECRET_DESCRIPTION);
+      });
+    });
   });
 
-  /** @scenario "Another module may import the schema before the patch and the descriptions still survive" */
-  it("keeps both descriptions even when another module loads the schema first", () => {
-    const result = runProbe("schema-first");
-    expect(result.status).toBe(0);
-    expect(result.stderr).toBe("");
-    expect(result.stdout).not.toBe("");
-    expect(result.schema?.defaultValue?.description).toBe(
-      DEFAULT_VALUE_DESCRIPTION,
-    );
-    expect(result.schema?.secret?.description).toBe(SECRET_DESCRIPTION);
+  describe("given another module loads the schema before zod-openapi", () => {
+    describe("when the schema is later converted to OpenAPI", () => {
+      /** @scenario "Another module may import the schema before the patch and the descriptions still survive" */
+      it("keeps both descriptions", () => {
+        const result = runProbe("schema-first");
+        expect(result.status).toBe(0);
+        expect(result.stderr).toBe("");
+        expect(result.stdout).not.toBe("");
+        expect(result.schema?.defaultValue?.description).toBe(
+          DEFAULT_VALUE_DESCRIPTION,
+        );
+        expect(result.schema?.secret?.description).toBe(SECRET_DESCRIPTION);
+      });
+    });
   });
 });

--- a/platform/app/src/server/scenarios/parameters.ts
+++ b/platform/app/src/server/scenarios/parameters.ts
@@ -16,6 +16,12 @@
  * @see specs/scenarios/secret-run-parameters.feature
  */
 
+// This schema module is imported by route apps and by other shared helpers. If
+// another module loads it before a route app calls `patchZodOpenapi()`, the
+// schema objects are constructed before zod-openapi patches Zod and the later
+// OpenAPI conversion drops the `defaultValue` and `secret` descriptions. Load
+// the patch here so schema construction never depends on who imported us first.
+import "zod-openapi/extend";
 import { z } from "zod";
 
 /** How many parameters one scenario may declare. */

--- a/specs/api-reference/scenario-parameter-openapi-descriptions.feature
+++ b/specs/api-reference/scenario-parameter-openapi-descriptions.feature
@@ -1,0 +1,21 @@
+@unit
+Feature: Scenario-parameter descriptions reach the OpenAPI document
+  As an integrator reading the scenarios API reference
+  I want shared scenario-parameter schemas to keep their field descriptions
+  So that regenerating the OpenAPI document does not silently erase what
+  `defaultValue` and `secret` mean.
+
+  Background:
+    Given the shared scenario-parameter schema module is imported in-process
+
+  Scenario: Loading zod-openapi before the schema keeps the descriptions
+    Given the zod-openapi patch module loads before the schema is constructed
+    When the schema is converted to the OpenAPI input document
+    Then the `defaultValue` field keeps its description
+    And the `secret` field keeps its description
+
+  Scenario: Another module may import the schema before the patch and the descriptions still survive
+    Given another module loads the shared schema before zod-openapi
+    When the schema is later converted to the OpenAPI input document
+    Then the `defaultValue` field keeps its description
+    And the `secret` field keeps its description


### PR DESCRIPTION
## Why

The OpenAPI generator could drop the `defaultValue` and `secret` descriptions from the shared scenario-parameter schema. The result depended on whether another module imported that schema before `zod-openapi` patched Zod, and CI never regenerated the canonical document to catch future drift.

Closes #7566

## What changed

- load `zod-openapi/extend` in the shared scenario-parameter schema module before its schemas are constructed
- add a fresh-process regression test for both relevant import orders
- regenerate the canonical OpenAPI document and the docs copy
- make the existing OpenAPI CI job regenerate the canonical document and fail on a diff before running its completeness checks

## How it works

The schema module now establishes its own prerequisite instead of relying on route-app import order. The regression test uses separate `tsx` processes so each case gets a real module cache and evaluation order. The CI gate uses the existing generated-file preparation action, runs `generateOpenAPISpec` with the build-time environment relaxation, and diffs the committed canonical JSON.

## Test plan

- fail-first: the `schema-first` regression probe produced schemas without either description before the side-effect import
- `pnpm exec vitest run src/server/scenarios/__tests__/parameters-openapi.unit.test.ts` — 2 passed
- `pnpm exec biome check` on both changed TypeScript files — passed
- `pnpm run typecheck:all` — passed
- `NODE_ENV=test BUILD_TIME=true pnpm run task generateOpenAPISpec`, followed by a clean working-tree diff against the staged generated document — passed
- `pnpm check:openapi-completeness` — passed
- `pnpm check:openapi-route-coverage` — passed
- `make generate-api-reference` — 0 new pages, 304 existing pages retained, docs navigation unchanged
- feature-parity report for the new spec — 2/2 scenarios bound

## Anything surprising?

The full feature-parity command cannot produce a clean repository-wide result from this intentionally sparse checkout because several test roots are absent; its JSON report confirms both scenarios introduced here are bound.

AI assistance: I used Codex to help investigate the issue, draft the implementation and tests, and run validation. I reviewed the resulting changes and test output.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified OpenAPI documentation for scenario parameter defaults and secrets, including usage rules and restrictions.

* **Bug Fixes**
  * Preserved parameter field descriptions in generated API documentation regardless of module loading order.

* **Tests**
  * Added coverage for OpenAPI descriptions across supported schema-loading scenarios.
  * Added automated validation to detect differences between generated and committed API specifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->