### PR TITLE
fix(rbac): an org admin holding a custom team role keeps admin access in the browser

### DIFF
--- a/platform/app/scripts/check-feature-parity.ts
+++ b/platform/app/scripts/check-feature-parity.ts
@@ -540,7 +540,6 @@ const LEGACY_INERT: string[] = [
   "specs/prompts/unified-defaults.feature",
   "specs/python-sdk/async-experiment-parallelism.feature",
   "specs/python-sdk/experiment-print-summary.feature",
-  "specs/rbac/fetch-org-role-permission-resolution.feature",
   "specs/scenarios/ai-create-modal.feature",
   "specs/scenarios/internal-scenario-namespace.feature",
   "specs/scenarios/internal-set-namespace.feature",

--- a/platform/app/src/hooks/__tests__/useOrganizationTeamProject.custom-role-org-admin.integration.test.tsx
+++ b/platform/app/src/hooks/__tests__/useOrganizationTeamProject.custom-role-org-admin.integration.test.tsx
@@ -1,0 +1,174 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * An organization admin who also holds a custom team role must not lose in
+ * the browser what the server grants them. Both server paths answer the same
+ * way — an ORGANIZATION-scoped ADMIN binding grants everything, custom team
+ * role or not (`checkPermissionFromBindings` in rbac.ts; `bindingGrants` in
+ * packages/authz/src/matchers.ts) — so the hook's team-permission resolution
+ * has to fall back to the org-admin answer before it applies the custom
+ * role's own permission list.
+ *
+ * These tests execute the real hook, with only its boundaries stubbed, the
+ * same way as useOrganizationTeamProject.team-membership.integration.test.tsx.
+ *
+ * Spec: specs/rbac/fetch-org-role-permission-resolution.feature
+ */
+import { cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockOrganizationsQuery, mockRouter, mockLocalStorage, idleQuery } =
+  vi.hoisted(() => ({
+    mockOrganizationsQuery: vi.fn(),
+    idleQuery: () => ({
+      data: undefined,
+      isLoading: false,
+      isFetched: true,
+    }),
+    mockRouter: {
+      query: {} as Record<string, string>,
+      route: "/settings/api-keys",
+      pathname: "/settings/api-keys",
+      asPath: "/settings/api-keys",
+      push: vi.fn(),
+      replace: vi.fn(),
+    },
+    mockLocalStorage: {
+      selectedOrganizationId: "",
+      selectedTeamId: "",
+      selectedProjectSlug: "",
+    } as Record<string, string>,
+  }));
+
+vi.mock("~/utils/api", () => ({
+  api: {
+    organization: { getAll: { useQuery: mockOrganizationsQuery } },
+    sharedTrace: { get: { useQuery: idleQuery } },
+    publicEnv: { useQuery: idleQuery },
+    modelProvider: { getAllForProject: { useQuery: idleQuery } },
+  },
+}));
+
+vi.mock("~/utils/auth-client", () => ({
+  useSession: () => ({
+    data: { user: { id: USER_ID } },
+    status: "authenticated",
+  }),
+}));
+
+vi.mock("~/utils/compat/next-router", () => ({
+  useRouter: () => mockRouter,
+}));
+
+vi.mock("usehooks-ts", () => ({
+  useLocalStorage: (key: string, initial: string) => [
+    mockLocalStorage[key] ?? initial,
+    (value: string) => {
+      mockLocalStorage[key] = value;
+    },
+  ],
+}));
+
+import { useOrganizationTeamProject } from "../useOrganizationTeamProject";
+
+const USER_ID = "user-analyst";
+
+/** A custom role that grants analytics viewing and nothing else. */
+const ANALYTICS_ONLY_ROLE = { permissions: ["analytics:view"] };
+
+function organizationWith({ organizationRole }: { organizationRole: string }) {
+  return {
+    data: [
+      {
+        id: "org-acme",
+        name: "ACME",
+        slug: "acme",
+        primaryIntent: null,
+        members: [{ role: organizationRole }],
+        teams: [
+          {
+            id: "team-data",
+            name: "ACME Data",
+            slug: "acme-data",
+            isPersonal: false,
+            ownerUserId: null,
+            members: [
+              {
+                userId: USER_ID,
+                role: "CUSTOM",
+                assignedRole: ANALYTICS_ONLY_ROLE,
+              },
+            ],
+            projects: [{ id: "proj-data", name: "Data App", slug: "data-app" }],
+          },
+        ],
+      },
+    ],
+    isLoading: false,
+    isFetched: true,
+    isRefetching: false,
+  };
+}
+
+function renderResolution() {
+  return renderHook(() =>
+    useOrganizationTeamProject({
+      redirectToOnboarding: false,
+      redirectToProjectOnboarding: false,
+    }),
+  );
+}
+
+describe("useOrganizationTeamProject with a custom team role", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRouter.query = {};
+    for (const key of Object.keys(mockLocalStorage)) {
+      mockLocalStorage[key] = "";
+    }
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  describe("given an org admin holding a custom team role", () => {
+    beforeEach(() => {
+      mockOrganizationsQuery.mockReturnValue(
+        organizationWith({ organizationRole: "ADMIN" }),
+      );
+    });
+
+    /** @scenario "An org admin holding a custom team role keeps admin access in the browser" */
+    it("grants a team-scoped permission the custom role omits", () => {
+      const { result } = renderResolution();
+
+      expect(result.current.organizationRole).toBe("ADMIN");
+      expect(result.current.hasPermission("datasets:manage")).toBe(true);
+    });
+
+    /** @scenario "An org admin holding a custom team role keeps admin access in the browser" */
+    it("still grants what the custom role itself lists", () => {
+      const { result } = renderResolution();
+
+      expect(result.current.hasPermission("analytics:view")).toBe(true);
+    });
+  });
+
+  describe("given an org member holding the same custom team role", () => {
+    beforeEach(() => {
+      mockOrganizationsQuery.mockReturnValue(
+        organizationWith({ organizationRole: "MEMBER" }),
+      );
+    });
+
+    /** @scenario "An org admin holding a custom team role keeps admin access in the browser" */
+    it("keeps refusing what the custom role omits", () => {
+      const { result } = renderResolution();
+
+      expect(result.current.organizationRole).toBe("MEMBER");
+      expect(result.current.hasPermission("analytics:view")).toBe(true);
+      expect(result.current.hasPermission("datasets:manage")).toBe(false);
+    });
+  });
+});

--- a/platform/app/src/hooks/useOrganizationTeamProject.ts
+++ b/platform/app/src/hooks/useOrganizationTeamProject.ts
@@ -682,7 +682,26 @@ export const useOrganizationTeamProject = (
 
     // Check if user has custom role assignment
     if (teamMember.assignedRole) {
-      // If user has custom role, ONLY use custom role permissions (no fallback)
+      // An org admin keeps admin access whatever team role they hold — both
+      // server paths answer this way (an ORGANIZATION-scoped ADMIN binding
+      // grants everything: checkPermissionFromBindings in rbac.ts, and the
+      // engine's bindingGrants), and the no-team-membership branch above
+      // already mirrors it. EXTERNAL users are never ADMIN, so their
+      // restriction below is unaffected.
+      //
+      // What the hook actually reads is the membership row's role, standing
+      // in for that binding — the same trust the branch above already
+      // places in it. The two are written together but not atomically, so
+      // they can diverge (binding deleted or edited on its own, or a crash
+      // between the membership and grant writes on invite acceptance).
+      // In that state this shows admin controls the server then refuses —
+      // a stale-UI failure, not an access grant.
+      if (organizationRole === OrganizationUserRole.ADMIN) {
+        return true;
+      }
+
+      // Otherwise ONLY the custom role's permissions apply (no fallback to
+      // the built-in team role it replaced)
       const rawPermissions = teamMember.assignedRole.permissions as
         | string[]
         | null

--- a/specs/rbac/fetch-org-role-permission-resolution.feature
+++ b/specs/rbac/fetch-org-role-permission-resolution.feature
@@ -106,6 +106,18 @@ Feature: Organization role awareness across the platform
     When the user manages a team in "acme"
     Then the action is allowed
 
+  # The server already answers this way on both of its paths: an
+  # ORGANIZATION-scoped ADMIN binding grants everything, custom team role or
+  # not. The browser refusing what the server allows only hides buttons and
+  # pages the user could reach by URL.
+  @integration
+  Scenario: An org admin holding a custom team role keeps admin access in the browser
+    Given a user who is an ADMIN in organization "acme"
+    And the user holds a custom role on the project's team that grants only analytics viewing
+    When the browser checks a team-scoped permission the custom role omits
+    Then the check is allowed, because the server allows an org admin everything
+    But the same custom role still restricts a user who is only a MEMBER
+
   # ============================================================================
   # Frontend knows the user's role
   # ============================================================================


### PR DESCRIPTION
# Related Issue

- Resolves #7668

Closes #7668. Third in the stack: base is #7671 (permission-list deletion), on #7670, on #7650.

## What changed

In `useOrganizationTeamProject`, the branch that resolves team permissions through a custom role now checks the organization role first: an ADMIN gets the permission, whatever the custom role says. One conditional plus a comment.

## Why this direction

This reverses a deliberate client rule ("If user has custom role, ONLY use custom role permissions (no fallback)") — on purpose. The server made the opposite call on **both** of its paths: an ORGANIZATION-scoped ADMIN binding grants everything (`checkPermissionFromBindings` in `rbac.ts`, `bindingGrants` in the engine's matchers), and the hook's own adjacent no-team-membership branch already falls back to org-admin. The browser refusing what the server allows only hides buttons and pages the user could reach by URL; server parity wins.

The reverse disagreement (browser allows an org-scoped permission the legacy server path refuses for an admin without a role binding) gets **no code change**: migrating an organization onto the permission engine synthesizes the missing grant, so it closes itself, and every normal signup path writes the binding anyway. Documented in #7668.

## Guard rails

- EXTERNAL users are never ADMIN, so the lite-member restriction is untouched.
- An org MEMBER holding the same custom role keeps being refused what the role omits — pinned by test.

## Contract and tests

New scenario "An org admin holding a custom team role keeps admin access in the browser" in `specs/rbac/fetch-org-role-permission-resolution.feature`, which therefore leaves the checker's inert-file exemption list (its first bound scenario). New jsdom test executes the real hook with only boundaries stubbed; watched fail on exactly the admin case, then pass. All four hook integration files 35 passed; parity checker OK (10,291 bound); whole-app typecheck clean.
