### PR TITLE
fix(specs): the parity checker counts untagged scenarios instead of hiding them

### DIFF
--- a/platform/app/scripts/__tests__/check-feature-parity.unit.test.ts
+++ b/platform/app/scripts/__tests__/check-feature-parity.unit.test.ts
@@ -34,6 +34,7 @@ import {
   discoverFeatureFiles,
   isEntryModule,
   isInert,
+  isPartiallyTagged,
 } from "../check-feature-parity";
 
 let root = "";
@@ -288,6 +289,65 @@ describe("isInert", () => {
       it("does not report the file as inert", () => {
         // Nothing was claimed, so nothing is being overclaimed.
         expect(isInert({ scenarios: [], totalScenarios: 0 })).toBe(false);
+      });
+    });
+  });
+});
+
+describe("isPartiallyTagged", () => {
+  const enforcedScenario = {
+    title: "t",
+    tags: ["@unit"],
+    line: 1,
+    bindings: [],
+  };
+
+  describe("given a file with enforced scenarios and untagged ones alongside", () => {
+    describe("when the floor is applied", () => {
+      it("reports the file as partially tagged", () => {
+        // This is the `15/15 bound` lie on a file holding 27 scenarios:
+        // the 12 untagged ones are invisible to the bound count.
+        expect(
+          isPartiallyTagged({
+            scenarios: [enforcedScenario],
+            untaggedScenarios: 12,
+          }),
+        ).toBe(true);
+      });
+    });
+  });
+
+  describe("given a file whose scenarios are all untagged", () => {
+    describe("when the floor is applied", () => {
+      it("leaves the file to the inert floor instead", () => {
+        // Inert and partial must not overlap: one file, one list, one fix.
+        expect(
+          isPartiallyTagged({ scenarios: [], untaggedScenarios: 20 }),
+        ).toBe(false);
+        expect(isInert({ scenarios: [], totalScenarios: 20 })).toBe(true);
+      });
+    });
+  });
+
+  describe("given a fully tagged file", () => {
+    describe("when the floor is applied", () => {
+      it("does not report the file as partially tagged", () => {
+        expect(
+          isPartiallyTagged({
+            scenarios: [enforcedScenario],
+            untaggedScenarios: 0,
+          }),
+        ).toBe(false);
+      });
+    });
+  });
+
+  describe("given a file that declares no scenarios at all", () => {
+    describe("when the floor is applied", () => {
+      it("does not report the file as partially tagged", () => {
+        expect(isPartiallyTagged({ scenarios: [], untaggedScenarios: 0 })).toBe(
+          false,
+        );
       });
     });
   });

--- a/platform/app/scripts/check-feature-parity.ts
+++ b/platform/app/scripts/check-feature-parity.ts
@@ -642,6 +642,121 @@ const LEGACY_INERT: string[] = [
   "specs/workflows/workflow-management.feature",
 ];
 
+/**
+ * Feature files that enforce SOME scenarios while others carry no tag at all.
+ *
+ * This was the gate's last blind spot after `LEGACY_INERT` closed the
+ * fully-untagged case: a file with 15 tagged scenarios and 12 untagged ones
+ * reported `15/15 scenarios bound · ✓ all bound`, which reads exactly like a
+ * fully-covered file. The untagged dozen were declared, unmeasured, and
+ * invisible — the comment above `LEGACY_UNBOUND` has named this hole since
+ * the sdks tree was added (see #3338); this list finally guards it.
+ *
+ * Same ratchet as `LEGACY_INERT`: the files below are the ones already in
+ * that state when the floor was introduced, and they are tolerated. Any OTHER
+ * file that mixes enforced and untagged scenarios fails the check, and an
+ * entry that becomes fully tagged must leave the list.
+ *
+ * Direction: drive this list to empty by tagging the scenarios that describe
+ * behaviour we actually test, marking @unimplemented the ones we do not, and
+ * deleting the ones that no longer describe anything.
+ *
+ * Invariants (enforced below):
+ *   - Every path must resolve to a discovered `.feature` file.
+ *   - Every entry must still be partially tagged.
+ */
+const LEGACY_PARTIAL: string[] = [
+  "sdks/typescript/specs/cli/daemon.feature",
+  "specs/ai-gateway/budgets.feature",
+  "specs/ai-gateway/cli-token-revoke-on-deactivation.feature",
+  "specs/ai-gateway/custom-provider-base-url.feature",
+  "specs/ai-gateway/gateway-service.feature",
+  "specs/ai-gateway/governance/admin-routing-policies.feature",
+  "specs/ai-gateway/governance/admin-trace-access.feature",
+  "specs/ai-gateway/governance/budget-exceeded.feature",
+  "specs/ai-gateway/governance/cli-login.feature",
+  "specs/ai-gateway/governance/departments.feature",
+  "specs/ai-gateway/governance/ingest-api-key-lifecycle.feature",
+  "specs/ai-gateway/governance/ingestion-sources.feature",
+  "specs/ai-gateway/governance/ingestion-templates-catalog.feature",
+  "specs/ai-gateway/governance/my-usage-dashboard.feature",
+  "specs/ai-gateway/governance/ui-contract.feature",
+  "specs/ai-gateway/model-provider-scoping.feature",
+  "specs/ai-gateway/openai-param-compat.feature",
+  "specs/ai-gateway/payload-capture.feature",
+  "specs/ai-gateway/policy-rules.feature",
+  "specs/ai-gateway/span-shape.feature",
+  "specs/ai-gateway/virtual-keys.feature",
+  "specs/ai-governance/cli-onboarding/login-unified.feature",
+  "specs/ai-governance/cli-wrappers/cli-mints-ingest-key.feature",
+  "specs/ai-governance/cli-wrappers/latest-login-wins.feature",
+  "specs/ai-governance/cli-wrappers/shell-rc-persistence.feature",
+  "specs/ai-governance/personal-portal/admin-catalog-editor.feature",
+  "specs/ai-governance/personal-portal/tool-catalog-rbac.feature",
+  "specs/ai-governance/puller-framework/s3-polling.feature",
+  "specs/analytics/dashboard-rest-api.feature",
+  "specs/analytics/event-sourced-analytics-materialization.feature",
+  "specs/automations/authoring-drawer.feature",
+  "specs/automations/process-manager-dispatch.feature",
+  "specs/ci/path-filters.feature",
+  "specs/clickhouse/windowed-read-fallback.feature",
+  "specs/coding-agent/cache-write-ttl-pricing.feature",
+  "specs/coding-agent/terminal-view.feature",
+  "specs/datasets/add-to-dataset-span-mapping.feature",
+  "specs/dependencies/zod-first-schema-source-of-truth.feature",
+  "specs/event-sourcing/payload-cost.feature",
+  "specs/event-sourcing/payload-store-content-addressed.feature",
+  "specs/event-sourcing/poison-group-park-guard.feature",
+  "specs/event-sourcing/projection-replay.feature",
+  "specs/event-sourcing/work-conserving-fair-dispatch.feature",
+  "specs/experiments-v3/mapping-auto-inference.feature",
+  "specs/experiments-v3/mapping-validation.feature",
+  "specs/experiments/comparison.feature",
+  "specs/features/dataset-cli.feature",
+  "specs/features/scenario-cli.feature",
+  "specs/features/simulation-runs-cli.feature",
+  "specs/langevals-staging/staged-payload.feature",
+  "specs/langy/langy-choice-questions.feature",
+  "specs/langy/langy-composer-feedback-and-cards.feature",
+  "specs/langy/langy-deploy-hardening.feature",
+  "specs/langy/langy-derived-cards.feature",
+  "specs/langy/langy-dogfood-scenarios.feature",
+  "specs/langy/langy-panel-layout.feature",
+  "specs/langy/langy-prompt-optimization-entrypoints.feature",
+  "specs/langy/langy-session-key.feature",
+  "specs/licensing/oss-experimentation-uncapped.feature",
+  "specs/model-providers/codex-account-provider.feature",
+  "specs/model-providers/credential-validation.feature",
+  "specs/model-providers/onboarding-flow.feature",
+  "specs/model-providers/provider-configuration.feature",
+  "specs/model-providers/provider-deletion.feature",
+  "specs/model-providers/scope-and-multi-instance.feature",
+  "specs/monitors/online-evaluator-loop-prevention.feature",
+  "specs/navigation/shared-section-navigation-layout.feature",
+  "specs/npx-installer/07-lean-install.feature",
+  "specs/ops/internal-feature-flags.feature",
+  "specs/optimization-studio/component-execution.feature",
+  "specs/otlp/canonical-metric-ingestion.feature",
+  "specs/prompts/editing-modes.feature",
+  "specs/prompts/locked-input-variable.feature",
+  "specs/queue-pausing/queue-pausing.feature",
+  "specs/rbac/scoped-role-bindings.feature",
+  "specs/suites/suite-model-selection.feature",
+  "specs/topic-clustering/event-sourced-scheduling.feature",
+  "specs/traces-v2/annotations.feature",
+  "specs/traces-v2/bulk-actions.feature",
+  "specs/traces-v2/code-block-language-fallback.feature",
+  "specs/traces-v2/conversation-turn-ledger.feature",
+  "specs/traces-v2/data-layer.feature",
+  "specs/traces-v2/evaluations.feature",
+  "specs/traces-v2/evaluator-filter-label.feature",
+  "specs/traces-v2/filter-bar-interactions.feature",
+  "specs/traces-v2/message-translation.feature",
+  "specs/traces-v2/numeric-facet-modes.feature",
+  "specs/traces-v2/search.feature",
+  "specs/traces/saved-views.feature",
+];
+
 const TEST_FILE_RE = /\.test\.tsx?$/;
 const BATS_FILE_RE = /\.bats$/;
 const SHELL_TEST_FILE_RE = /\.sh$/;
@@ -682,6 +797,13 @@ interface Report {
   totalScenarios: number;
   /** Of those, how many are explicitly parked as `@unimplemented`. */
   unimplementedScenarios: number;
+  /**
+   * Scenarios carrying neither a lane tag nor `@unimplemented` — declared,
+   * unmeasured, and invisible to the bound count. A file with any of these
+   * next to enforced scenarios reads `N/N bound` while saying nothing about
+   * them; see `isPartiallyTagged`.
+   */
+  untaggedScenarios: number;
 }
 
 /** A feature file that declares scenarios but no ENFORCED ones. */
@@ -690,6 +812,14 @@ interface InertReport {
   totalScenarios: number;
   /** Of those, how many are explicitly parked as `@unimplemented`. */
   unimplemented: number;
+}
+
+/** A feature file that enforces some scenarios while others carry no tag. */
+interface PartialReport {
+  feature: string;
+  totalScenarios: number;
+  enforced: number;
+  untagged: number;
 }
 
 interface LegacyReport {
@@ -1345,6 +1475,11 @@ function buildReport(
     unimplementedScenarios: allScenarios.filter((s) =>
       s.tags.includes(UNIMPLEMENTED_TAG),
     ).length,
+    untaggedScenarios: allScenarios.filter(
+      (s) =>
+        !s.tags.some((t) => BOUND_TAGS.has(t)) &&
+        !s.tags.includes(UNIMPLEMENTED_TAG),
+    ).length,
   };
 }
 
@@ -1357,6 +1492,30 @@ export function isInert(
   r: Pick<Report, "scenarios" | "totalScenarios">,
 ): boolean {
   return r.totalScenarios > 0 && r.scenarios.length === 0;
+}
+
+/**
+ * The floor under the other half of the same trap: a file that enforces SOME
+ * scenarios and declares others with no tag at all. The enforced ones make it
+ * read `N/N bound` while the untagged ones are invisible to the count — a
+ * file holding 27 scenarios reported `15/15 · ✓ all bound`. Disjoint from
+ * `isInert` by construction (that floor requires zero enforced scenarios), so
+ * one file lands on exactly one list. Callers decide whether a given file is
+ * tolerated (`LEGACY_PARTIAL`) or fatal.
+ */
+export function isPartiallyTagged(
+  r: Pick<Report, "scenarios" | "untaggedScenarios">,
+): boolean {
+  return r.scenarios.length > 0 && r.untaggedScenarios > 0;
+}
+
+function toPartialReport(r: Report): PartialReport {
+  return {
+    feature: r.feature,
+    totalScenarios: r.totalScenarios,
+    enforced: r.scenarios.length,
+    untagged: r.untaggedScenarios,
+  };
 }
 
 function toInertReport(r: Report): InertReport {
@@ -1389,7 +1548,16 @@ function printEnforcedReport(r: Report): void {
     return;
   }
 
-  console.log(`  ${boundCount}/${total} scenarios bound`);
+  // `N/N scenarios bound` on a file with untagged scenarios alongside is the
+  // partial-file variant of the inert trap: say what the count measures and
+  // what it cannot see, in the same line.
+  if (r.untaggedScenarios > 0) {
+    console.log(
+      `  ${boundCount}/${total} tagged scenario(s) bound · ${r.untaggedScenarios} scenario(s) untagged and unmeasured`,
+    );
+  } else {
+    console.log(`  ${boundCount}/${total} scenarios bound`);
+  }
 
   if (total === 0) {
     console.log(`  · no scenarios declared`);
@@ -1527,16 +1695,22 @@ interface ParityAnalysis {
   exemptInert: InertReport[];
   /** Inert files nobody has excused. Fatal. */
   newInert: InertReport[];
+  /** Partially-tagged files, whether excused or not. */
+  partial: PartialReport[];
+  /** Partially-tagged files LEGACY_PARTIAL excuses, and so still tolerated. */
+  exemptPartial: PartialReport[];
+  /** Partially-tagged files nobody has excused. Fatal. */
+  newPartial: PartialReport[];
   /** Entries that no longer belong on their list, and must leave it. Fatal. */
   staleLegacy: LegacyReport[];
   staleInert: string[];
+  stalePartial: string[];
   unknownAnnotations: UnknownAnnotation[];
   listErrors: string[];
 }
 
-function analyzeParity(): ParityAnalysis {
-  const allFeatures = discoverFeatureFiles();
-  const listErrors = [
+function validateAllExemptionLists(allFeatures: string[]): string[] {
+  return [
     ...validateExemptionList({
       name: "LEGACY_UNBOUND",
       entries: LEGACY_UNBOUND,
@@ -1547,7 +1721,17 @@ function analyzeParity(): ParityAnalysis {
       entries: LEGACY_INERT,
       allFeatures,
     }),
+    ...validateExemptionList({
+      name: "LEGACY_PARTIAL",
+      entries: LEGACY_PARTIAL,
+      allFeatures,
+    }),
   ];
+}
+
+function analyzeParity(): ParityAnalysis {
+  const allFeatures = discoverFeatureFiles();
+  const listErrors = validateAllExemptionLists(allFeatures);
 
   const bindings = [
     ...collectAllBindings(DEFAULT_TEST_ROOTS),
@@ -1588,12 +1772,22 @@ function analyzeParity(): ParityAnalysis {
   const inert = enforced.filter(isInert).map(toInertReport);
   const inertFeatures = new Set(inert.map((r) => r.feature));
 
+  // Partial floor, same shape: a file that enforces some scenarios and leaves
+  // others untagged is a failure unless it was already in that state when the
+  // floor was introduced.
+  const partialSet = new Set(LEGACY_PARTIAL);
+  const partial = enforced.filter(isPartiallyTagged).map(toPartialReport);
+  const partialFeatures = new Set(partial.map((r) => r.feature));
+
   return {
     enforced,
     legacy,
     inert,
     exemptInert: inert.filter((r) => inertSet.has(r.feature)),
     newInert: inert.filter((r) => !inertSet.has(r.feature)),
+    partial,
+    exemptPartial: partial.filter((r) => partialSet.has(r.feature)),
+    newPartial: partial.filter((r) => !partialSet.has(r.feature)),
     // Legacy-list hygiene: every entry must still have at least one unbound
     // scenario. If a file is fully bound, it must be removed from the list.
     staleLegacy: legacy.filter((r) => r.unbound === 0),
@@ -1601,6 +1795,9 @@ function analyzeParity(): ParityAnalysis {
     // must leave the list so it can never silently regress.
     staleInert: LEGACY_INERT.filter(
       (f) => allFeatures.includes(f) && !inertFeatures.has(f),
+    ),
+    stalePartial: LEGACY_PARTIAL.filter(
+      (f) => allFeatures.includes(f) && !partialFeatures.has(f),
     ),
     unknownAnnotations,
     listErrors,
@@ -1655,6 +1852,20 @@ function fatalReasons(a: ParityAnalysis): string[] {
       )}`,
     );
   }
+  if (a.newPartial.length > 0) {
+    reasons.push(
+      `${a.newPartial.length} file(s) mix enforced scenarios with untagged ones — tag the untagged scenarios (@unit/@integration/@e2e/@regression, or @unimplemented for a tracked gap), delete them, or add the file to LEGACY_PARTIAL with a reason: ${a.newPartial
+        .map((r) => `${r.feature} (${r.untagged} untagged)`)
+        .join(", ")}`,
+    );
+  }
+  if (a.stalePartial.length > 0) {
+    reasons.push(
+      `${a.stalePartial.length} file(s) in LEGACY_PARTIAL are now fully tagged — remove them from the list: ${a.stalePartial.join(
+        ", ",
+      )}`,
+    );
+  }
   if (a.listErrors.length > 0) {
     reasons.push(`${a.listErrors.length} exemption-list error(s)`);
   }
@@ -1679,6 +1890,12 @@ function printOkSummary(a: ParityAnalysis): void {
       `    ${a.exemptInert.length} file(s) exempted via LEGACY_INERT enforce nothing at all — ${invisible} scenario(s) are invisible to this check.`,
     );
   }
+  if (a.exemptPartial.length > 0) {
+    const untagged = a.exemptPartial.reduce((s, r) => s + r.untagged, 0);
+    console.log(
+      `    ${a.exemptPartial.length} partially-tagged file(s) exempted via LEGACY_PARTIAL — ${untagged} scenario(s) untagged and unmeasured beside their enforced ones.`,
+    );
+  }
 }
 
 function main(): void {
@@ -1697,6 +1914,9 @@ function main(): void {
           inert: analysis.exemptInert,
           newInert: analysis.newInert,
           staleInert: analysis.staleInert,
+          partial: analysis.exemptPartial,
+          newPartial: analysis.newPartial,
+          stalePartial: analysis.stalePartial,
         },
         null,
         2,

--- a/platform/app/scripts/check-feature-parity.ts
+++ b/platform/app/scripts/check-feature-parity.ts
@@ -540,7 +540,6 @@ const LEGACY_INERT: string[] = [
   "specs/prompts/unified-defaults.feature",
   "specs/python-sdk/async-experiment-parallelism.feature",
   "specs/python-sdk/experiment-print-summary.feature",
-  "specs/rbac/fetch-org-role-permission-resolution.feature",
   "specs/scenarios/ai-create-modal.feature",
   "specs/scenarios/internal-scenario-namespace.feature",
   "specs/scenarios/internal-set-namespace.feature",

--- a/platform/app/scripts/check-feature-parity.ts
+++ b/platform/app/scripts/check-feature-parity.ts
@@ -722,6 +722,7 @@ const LEGACY_PARTIAL: string[] = [
   "specs/langy/langy-derived-cards.feature",
   "specs/langy/langy-dogfood-scenarios.feature",
   "specs/langy/langy-panel-layout.feature",
+  "specs/langy/langy-projection-independent-reactions.feature",
   "specs/langy/langy-prompt-optimization-entrypoints.feature",
   "specs/langy/langy-session-key.feature",
   "specs/licensing/oss-experimentation-uncapped.feature",
@@ -1754,11 +1755,13 @@ function analyzeParity(): ParityAnalysis {
     .map((b) => ({ title: b.title, ref: b.ref }));
 
   const legacySet = new Set(LEGACY_UNBOUND);
+  const allReports: Report[] = [];
   const enforced: Report[] = [];
   const legacy: LegacyReport[] = [];
 
   for (const f of allFeatures) {
     const report = buildReport(f, bindingsByTitle);
+    allReports.push(report);
     if (legacySet.has(f)) {
       legacy.push(toLegacyReport(report));
     } else {
@@ -1774,9 +1777,11 @@ function analyzeParity(): ParityAnalysis {
 
   // Partial floor, same shape: a file that enforces some scenarios and leaves
   // others untagged is a failure unless it was already in that state when the
-  // floor was introduced.
+  // floor was introduced. Runs against ALL reports (not just enforced) so that
+  // legacy-unbound files cannot silently gain untagged scenarios — the same
+  // hidden-scenario hole this floor exists to close.
   const partialSet = new Set(LEGACY_PARTIAL);
-  const partial = enforced.filter(isPartiallyTagged).map(toPartialReport);
+  const partial = allReports.filter(isPartiallyTagged).map(toPartialReport);
   const partialFeatures = new Set(partial.map((r) => r.feature));
 
   return {

--- a/platform/app/src/hooks/__tests__/useOrganizationTeamProject.custom-role-org-admin.integration.test.tsx
+++ b/platform/app/src/hooks/__tests__/useOrganizationTeamProject.custom-role-org-admin.integration.test.tsx
@@ -1,0 +1,174 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * An organization admin who also holds a custom team role must not lose in
+ * the browser what the server grants them. Both server paths answer the same
+ * way — an ORGANIZATION-scoped ADMIN binding grants everything, custom team
+ * role or not (`checkPermissionFromBindings` in rbac.ts; `bindingGrants` in
+ * packages/authz/src/matchers.ts) — so the hook's team-permission resolution
+ * has to fall back to the org-admin answer before it applies the custom
+ * role's own permission list.
+ *
+ * These tests execute the real hook, with only its boundaries stubbed, the
+ * same way as useOrganizationTeamProject.team-membership.integration.test.tsx.
+ *
+ * Spec: specs/rbac/fetch-org-role-permission-resolution.feature
+ */
+import { cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockOrganizationsQuery, mockRouter, mockLocalStorage, idleQuery } =
+  vi.hoisted(() => ({
+    mockOrganizationsQuery: vi.fn(),
+    idleQuery: () => ({
+      data: undefined,
+      isLoading: false,
+      isFetched: true,
+    }),
+    mockRouter: {
+      query: {} as Record<string, string>,
+      route: "/settings/api-keys",
+      pathname: "/settings/api-keys",
+      asPath: "/settings/api-keys",
+      push: vi.fn(),
+      replace: vi.fn(),
+    },
+    mockLocalStorage: {
+      selectedOrganizationId: "",
+      selectedTeamId: "",
+      selectedProjectSlug: "",
+    } as Record<string, string>,
+  }));
+
+vi.mock("~/utils/api", () => ({
+  api: {
+    organization: { getAll: { useQuery: mockOrganizationsQuery } },
+    sharedTrace: { get: { useQuery: idleQuery } },
+    publicEnv: { useQuery: idleQuery },
+    modelProvider: { getAllForProject: { useQuery: idleQuery } },
+  },
+}));
+
+vi.mock("~/utils/auth-client", () => ({
+  useSession: () => ({
+    data: { user: { id: USER_ID } },
+    status: "authenticated",
+  }),
+}));
+
+vi.mock("~/utils/compat/next-router", () => ({
+  useRouter: () => mockRouter,
+}));
+
+vi.mock("usehooks-ts", () => ({
+  useLocalStorage: (key: string, initial: string) => [
+    mockLocalStorage[key] ?? initial,
+    (value: string) => {
+      mockLocalStorage[key] = value;
+    },
+  ],
+}));
+
+import { useOrganizationTeamProject } from "../useOrganizationTeamProject";
+
+const USER_ID = "user-analyst";
+
+/** A custom role that grants analytics viewing and nothing else. */
+const ANALYTICS_ONLY_ROLE = { permissions: ["analytics:view"] };
+
+function organizationWith({ organizationRole }: { organizationRole: string }) {
+  return {
+    data: [
+      {
+        id: "org-acme",
+        name: "ACME",
+        slug: "acme",
+        primaryIntent: null,
+        members: [{ role: organizationRole }],
+        teams: [
+          {
+            id: "team-data",
+            name: "ACME Data",
+            slug: "acme-data",
+            isPersonal: false,
+            ownerUserId: null,
+            members: [
+              {
+                userId: USER_ID,
+                role: "CUSTOM",
+                assignedRole: ANALYTICS_ONLY_ROLE,
+              },
+            ],
+            projects: [{ id: "proj-data", name: "Data App", slug: "data-app" }],
+          },
+        ],
+      },
+    ],
+    isLoading: false,
+    isFetched: true,
+    isRefetching: false,
+  };
+}
+
+function renderResolution() {
+  return renderHook(() =>
+    useOrganizationTeamProject({
+      redirectToOnboarding: false,
+      redirectToProjectOnboarding: false,
+    }),
+  );
+}
+
+describe("useOrganizationTeamProject with a custom team role", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRouter.query = {};
+    for (const key of Object.keys(mockLocalStorage)) {
+      mockLocalStorage[key] = "";
+    }
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  describe("given an org admin holding a custom team role", () => {
+    beforeEach(() => {
+      mockOrganizationsQuery.mockReturnValue(
+        organizationWith({ organizationRole: "ADMIN" }),
+      );
+    });
+
+    /** @scenario "An org admin holding a custom team role keeps admin access in the browser" */
+    it("grants a team-scoped permission the custom role omits", () => {
+      const { result } = renderResolution();
+
+      expect(result.current.organizationRole).toBe("ADMIN");
+      expect(result.current.hasPermission("datasets:manage")).toBe(true);
+    });
+
+    /** @scenario "An org admin holding a custom team role keeps admin access in the browser" */
+    it("still grants what the custom role itself lists", () => {
+      const { result } = renderResolution();
+
+      expect(result.current.hasPermission("analytics:view")).toBe(true);
+    });
+  });
+
+  describe("given an org member holding the same custom team role", () => {
+    beforeEach(() => {
+      mockOrganizationsQuery.mockReturnValue(
+        organizationWith({ organizationRole: "MEMBER" }),
+      );
+    });
+
+    /** @scenario "An org admin holding a custom team role keeps admin access in the browser" */
+    it("keeps refusing what the custom role omits", () => {
+      const { result } = renderResolution();
+
+      expect(result.current.organizationRole).toBe("MEMBER");
+      expect(result.current.hasPermission("analytics:view")).toBe(true);
+      expect(result.current.hasPermission("datasets:manage")).toBe(false);
+    });
+  });
+});

--- a/platform/app/src/hooks/useOrganizationTeamProject.ts
+++ b/platform/app/src/hooks/useOrganizationTeamProject.ts
@@ -682,7 +682,26 @@ export const useOrganizationTeamProject = (
 
     // Check if user has custom role assignment
     if (teamMember.assignedRole) {
-      // If user has custom role, ONLY use custom role permissions (no fallback)
+      // An org admin keeps admin access whatever team role they hold — both
+      // server paths answer this way (an ORGANIZATION-scoped ADMIN binding
+      // grants everything: checkPermissionFromBindings in rbac.ts, and the
+      // engine's bindingGrants), and the no-team-membership branch above
+      // already mirrors it. EXTERNAL users are never ADMIN, so their
+      // restriction below is unaffected.
+      //
+      // What the hook actually reads is the membership row's role, standing
+      // in for that binding — the same trust the branch above already
+      // places in it. The two are written together but not atomically, so
+      // they can diverge (binding deleted or edited on its own, or a crash
+      // between the membership and grant writes on invite acceptance).
+      // In that state this shows admin controls the server then refuses —
+      // a stale-UI failure, not an access grant.
+      if (organizationRole === OrganizationUserRole.ADMIN) {
+        return true;
+      }
+
+      // Otherwise ONLY the custom role's permissions apply (no fallback to
+      // the built-in team role it replaced)
       const rawPermissions = teamMember.assignedRole.permissions as
         | string[]
         | null

--- a/platform/app/src/pages/governance/__tests__/delegatedViewer.integration.test.tsx
+++ b/platform/app/src/pages/governance/__tests__/delegatedViewer.integration.test.tsx
@@ -218,6 +218,7 @@ describe("governance pages for a delegated viewer", () => {
     });
 
     /** @scenario "The overview names the grant a refused panel needs" */
+    /** @scenario "Top-level /governance renders the dashboard" */
     it("names activityMonitor:view on the overview and still renders the rest", () => {
       renderPage({ Page: GovernanceOverviewPage });
 

--- a/platform/app/src/server/app-layer/organizations/__tests__/organization.prisma.repository.governance-filter.integration.test.ts
+++ b/platform/app/src/server/app-layer/organizations/__tests__/organization.prisma.repository.governance-filter.integration.test.ts
@@ -126,7 +126,7 @@ describe("PrismaOrganizationRepository — internal_governance project filter", 
       expect(projectIds).toContain(applicationProject.id);
     });
 
-    /** @scenario Lane-B test suite asserts every Project consumer filters */
+    /** @scenario The Lane-B suite asserts every Project consumer filters out internal governance projects */
     it("filters out the internal_governance project", async () => {
       const orgs = await repository.getAllForUser({
         userId: testUser.id,

--- a/platform/app/src/server/routes/__tests__/auth-cli-governance.integration.test.ts
+++ b/platform/app/src/server/routes/__tests__/auth-cli-governance.integration.test.ts
@@ -270,6 +270,7 @@ describe("GET /api/auth/cli/governance/*", () => {
 
   describe("GET /governance/status", () => {
     describe("when called with a valid Bearer token", () => {
+      /** @scenario "setupState returns boolean OR for nav-promotion signal" */
       it("returns the org's setup-state OR-of-flags shape", async () => {
         const res = await callGovernance("/status", `Bearer ${TOKEN_A}`);
         expect(res.status).toBe(200);

--- a/specs/ai-gateway/governance/governance-home-routing.feature
+++ b/specs/ai-gateway/governance/governance-home-routing.feature
@@ -29,14 +29,23 @@ Feature: Governance home — route, nav promotion, persona detection
   # Route — top-level + back-compat alias
   # ---------------------------------------------------------------------------
 
-  @bdd @ui @governance-home @route
+  # Bound to delegatedViewer.integration.test.tsx, which renders the
+  # overview page and asserts the heading and every panel. The bound test
+  # renders the page component; the address staying put on a cold load
+  # rides on the route registration the alias scenarios below exercise.
+  @bdd @ui @governance-home @route @integration
   Scenario: Top-level /governance renders the dashboard
     When the admin navigates to "/governance"
-    Then the page renders with the heading "Governance"
+    Then the page renders with the heading "AI Governance"
     And the URL stays at "/governance"
     And the setup-checklist OR live-metrics view is rendered
 
-  @bdd @ui @governance-home @route @alias
+  # Declared gap: specs/navigation/gateway-url-move.feature asserts the
+  # DEEP-LINK form (/settings/governance/tool-catalog?... keeps its path
+  # and query) and the retargeted cost-centers hop — but no test cold-loads
+  # the bare legacy address and asserts where it lands. The prefix redirect
+  # in legacyRedirects.tsx should cover it; nothing pins that.
+  @bdd @ui @governance-home @route @alias @integration @unimplemented
   Scenario: Legacy /settings/governance keeps working as a redirect
     When the admin navigates to "/settings/governance"
     Then the browser lands on "/governance" with the same dashboard
@@ -44,7 +53,12 @@ Feature: Governance home — route, nav promotion, persona detection
     And admins who bookmarked the legacy URL keep landing on the
       dashboard through the permanent redirect
 
-  @bdd @ui @governance-home @route @sub-routes
+  # Declared gap: /governance/inventory and its tabs are asserted below,
+  # but the per-source detail page and /governance/anomaly-rules as the
+  # rule-authoring surface are declared nowhere else — the rail scenario
+  # at the bottom names anomaly-rules only as a link target, and no test
+  # renders either address.
+  @bdd @ui @governance-home @route @sub-routes @integration @unimplemented
   Scenario: Admin-authoring sub-routes live under /governance
     Then "/governance/inventory" is the tabbed inventory surface
       (Catalog + Sources)
@@ -175,52 +189,44 @@ Feature: Governance home — route, nav promotion, persona detection
     # bypassOnboardingRedirect as a third layer; the catalog page keeps it.
 
   # ---------------------------------------------------------------------------
-  # Persona / nav promotion via api.governance.setupState
+  # Nav promotion — the Governance product entry
+  #
+  # The four scenarios that used to sit here described the #7597-era UI: a
+  # "Govern · Preview" sidebar section header with an Eye icon, gated on
+  # flag + org-admin permission + setup state. Two of those gates are gone:
+  # the header string no longer exists anywhere in the app, and setup state
+  # no longer feeds the nav decision at all — the entry today is a product
+  # in features/navigation/products.ts, gated on the flag AND the
+  # "governance:view" permission (note the drift: the old scenarios said
+  # "organization:manage"). The two scenarios below re-declare the gating
+  # that IS live. The generic product-gating machinery has lane-tagged
+  # coverage in specs/navigation/*, but nothing asserts governance's own
+  # two gates specifically, so both stay declared gaps.
   # ---------------------------------------------------------------------------
 
-  @bdd @ui @governance-home @nav-promotion
-  Scenario: Org admin with governance state sees the Governance nav entry
-    Given the org has at least one of: personal VK, RoutingPolicy,
-      IngestionSource, AnomalyRule, recent gateway event activity
-    When the admin loads any project page
-    Then the MainMenu sidebar shows a "Govern · Preview" section header
-    And below it a "Governance" entry with an Eye icon
-    And the entry links to "/governance"
-    And the entry highlights as active when the URL is "/governance"
-      OR any "/governance/*" sub-route
-
-  @bdd @ui @governance-home @nav-promotion @no-state
-  Scenario: Org admin with NO governance state sees no nav change
-    Given the org has zero personal VKs, RoutingPolicies,
-      IngestionSources, AnomalyRules, AND no recent gateway activity
-    When the admin loads any project page
-    Then NO "Govern" section header appears in the sidebar
-    And NO "Governance" entry is rendered
-    And the existing project-scoped LLMOps menu is unchanged
-    # This protects the "don't lose LLMOps" invariant: admins who
-    # haven't configured governance see exactly main's nav.
-
-  @bdd @ui @governance-home @nav-promotion @rbac
-  Scenario: Non-admins never see the Governance entry
-    Given the org has IngestionSources configured (governanceActive=true)
-    But the current user does NOT have "organization:manage" permission
-    When the user loads any project page
-    Then NO "Govern" section header or "Governance" entry appears
-    # Setup-state being true is necessary but not sufficient — the
-    # nav entry is org-admin-only.
-
-  @bdd @ui @governance-home @nav-promotion @flag
-  Scenario: Without the governance preview flag, no nav entry appears
+  @bdd @ui @governance-home @nav-promotion @flag @integration @unimplemented
+  Scenario: Without the governance flag there is no Governance product entry
     Given "release_ui_ai_governance_enabled" is disabled for the org
-    Even though the org has IngestionSources + the user is org admin
-    Then NO "Govern" section header or "Governance" entry appears
-    # All three conditions (flag + permission + state) are required.
+    And the user holds "governance:view"
+    When the user opens the product navigation
+    Then no "Governance" product entry is listed
+
+  @bdd @ui @governance-home @nav-promotion @rbac @integration @unimplemented
+  Scenario: The Governance product entry requires governance:view
+    Given "release_ui_ai_governance_enabled" is enabled for the org
+    But the user does NOT hold "governance:view"
+    When the user opens the product navigation
+    Then no "Governance" product entry is listed
+    But a user holding "governance:view" sees the entry
+    And the entry's home is "/governance"
 
   # ---------------------------------------------------------------------------
   # No auto-redirect (master_orchestrator's invariant)
   # ---------------------------------------------------------------------------
 
-  @bdd @ui @governance-home @no-auto-redirect
+  # Declared gap: no test navigates "/" with governance state present and
+  # asserts the absence of a redirect.
+  @bdd @ui @governance-home @no-auto-redirect @integration @unimplemented
   Scenario: Hitting "/" never auto-redirects to /governance
     Given the admin has governanceActive=true
     When they navigate to "/"
@@ -234,7 +240,10 @@ Feature: Governance home — route, nav promotion, persona detection
   # api.governance.setupState contract
   # ---------------------------------------------------------------------------
 
-  @bdd @api @governance-home @setup-state
+  # Bound: auth-cli-governance.integration.test.ts asserts the REST shape
+  # (all five hasFoo flags plus the OR), and governance.rbac /
+  # license-gate-governance pin the tRPC procedure's shape and its gate.
+  @bdd @api @governance-home @setup-state @integration
   Scenario: setupState returns boolean OR for nav-promotion signal
     When the admin's session resolves and the MainMenu calls
       `api.governance.setupState({organizationId})`
@@ -246,9 +255,9 @@ Feature: Governance home — route, nav promotion, persona detection
       | hasAnomalyRules      | boolean | any non-archived AnomalyRule in org       |
       | hasRecentActivity    | boolean | any gateway_activity_event in last 30d    |
       | governanceActive     | boolean | OR of the five hasFoo flags above         |
-    And the procedure is org:view (any org member can call it; the
-      org-admin permission gate applies to the nav-promotion decision
-      in the UI, not to the read itself)
+    And the procedure is gated on "governance:view" — an org member
+      without it is refused (governance.rbac.integration.test.ts pins
+      the FORBIDDEN), not the any-member read this scenario once claimed
     And the query is cheap (small index lookups + a single
       gateway_activity_events count); MainMenu reads it on every
       page load with `refetchOnWindowFocus: false`
@@ -257,7 +266,12 @@ Feature: Governance home — route, nav promotion, persona detection
   # Layout — current + future
   # ---------------------------------------------------------------------------
 
-  @bdd @ui @governance-home @layout
+  # Declared gap, narrower than it looks: the rail entries ARE asserted —
+  # sectionNavParity.integration.test.tsx renders GovernanceLayout and pins
+  # exactly the four entries in the table below (bound to the billed-cost
+  # scenario at the bottom). What no test asserts is the header chrome:
+  # the org-name chip and the org-scoped indicator.
+  @bdd @ui @governance-home @layout @integration @unimplemented
   Scenario: /governance renders with the GovernanceLayout (top-level chrome)
     Given "release_ui_governance_billed_cost_enabled" is disabled
       for the organization
@@ -278,15 +292,14 @@ Feature: Governance home — route, nav promotion, persona detection
     # release_ui_governance_billed_cost_enabled is on (see the
     # billed-cost flag section below).
 
-  @bdd @ui @governance-home @layout @sub-routes
-  Scenario: Admin-authoring sub-routes share the GovernanceLayout chrome
-    When the admin clicks "Inventory" in the GovernanceLayout
-      left rail and lands on "/governance/inventory"
-    Then the page renders inside GovernanceLayout, the same chrome as
-      the daily-use home
-    And the same applies to "/governance/anomaly-rules"
+  # The former "Admin-authoring sub-routes share the GovernanceLayout chrome"
+  # scenario restated the rail listing the scenario above already declares,
+  # with no assertion of its own beyond "same chrome"; one behaviour, one
+  # scenario.
 
-  @bdd @ui @governance-home @layout @bypass-project-redirect
+  # Declared gap: no test loads /governance for a zero-project org and
+  # asserts the layout renders instead of the project-onboarding bounce.
+  @bdd @ui @governance-home @layout @bypass-project-redirect @integration @unimplemented
   Scenario: /governance bypasses the no-project onboarding redirect
     Given an admin whose org has no projects yet
     When they navigate to "/governance"

--- a/specs/ai-gateway/governance/ui-contract.feature
+++ b/specs/ai-gateway/governance/ui-contract.feature
@@ -88,8 +88,7 @@ Feature: AI Gateway Governance — UI Contract (Lane B)
       filtered view over the existing log-records UI
 
   @bdd @ui @ui-contract @drill-down @uniformity
-  Scenario: The user cannot tell from the events feed which row will
-            route to which destination
+  Scenario: The user cannot tell from the events feed which row routes where
     When the admin scrolls the events feed
     Then every row shows the same columns (timestamp, source, actor,
       action, target, cost, tokens, severity)
@@ -158,8 +157,7 @@ Feature: AI Gateway Governance — UI Contract (Lane B)
   # ---------------------------------------------------------------------------
 
   @bdd @ui @ui-contract @composer @critical
-  Scenario: The IngestionSource composer does NOT show a Project
-            selection field
+  Scenario: The IngestionSource composer does NOT show a Project selection field
     When the admin opens the "Create ingestion source" composer at
       "/governance/inventory/new"
     Then the composer asks for: name, source type, per-platform config
@@ -187,8 +185,7 @@ Feature: AI Gateway Governance — UI Contract (Lane B)
       same helper text), set by the receiver layer, not by users
 
   @bdd @ui @ui-contract @namespaces
-  Scenario: The events feed displays langwatch.origin.* and
-            langwatch.governance.* as system-derived (read-only)
+  Scenario: The events feed displays governance attributes as system-derived and read-only
     When the events feed renders an event row's expanded attributes
     Then attributes in the langwatch.origin.* and langwatch.governance.*
       namespaces are visually grouped under a "System metadata"
@@ -241,8 +238,7 @@ Feature: AI Gateway Governance — UI Contract (Lane B)
   # ---------------------------------------------------------------------------
 
   @bdd @ui @ui-contract @anomaly-rules
-  Scenario: The anomaly rule composer's scope picker still works against
-            IngestionSource IDs after the cutover
+  Scenario: The anomaly rule scope picker still works against IngestionSource IDs after the cutover
     Given Sergey's anomaly subscriber has rebased on governance_kpis fold
     When the admin opens the AnomalyRule composer at
       "/governance/anomaly-rules/new"
@@ -285,8 +281,7 @@ Feature: AI Gateway Governance — UI Contract (Lane B)
   # ---------------------------------------------------------------------------
 
   @bdd @ui @ui-contract @trace-viewer-embed
-  Scenario: The per-source detail page embeds the existing trace
-            viewer (does NOT build a bespoke event renderer)
+  Scenario: The per-source detail page embeds the existing trace viewer, not a bespoke renderer
     When the admin navigates to a per-source detail page with events
     Then the events feed reuses the existing
       platform/app/src/components/messages/MessagesList component
@@ -316,8 +311,7 @@ Feature: AI Gateway Governance — UI Contract (Lane B)
   # ---------------------------------------------------------------------------
 
   @bdd @ui @ui-contract @regression
-  Scenario: Lane-B test suite asserts every Project consumer filters
-            kind=internal_governance
+  Scenario: The Lane-B suite asserts every Project consumer filters out internal governance projects
     When the test suite runs
       platform/app/src/server/__tests__/projectFilter.invariant.integration.test.ts
     Then it enumerates every component / API / hook / repository

--- a/specs/rbac/fetch-org-role-permission-resolution.feature
+++ b/specs/rbac/fetch-org-role-permission-resolution.feature
@@ -106,6 +106,18 @@ Feature: Organization role awareness across the platform
     When the user manages a team in "acme"
     Then the action is allowed
 
+  # The server already answers this way on both of its paths: an
+  # ORGANIZATION-scoped ADMIN binding grants everything, custom team role or
+  # not. The browser refusing what the server allows only hides buttons and
+  # pages the user could reach by URL.
+  @integration
+  Scenario: An org admin holding a custom team role keeps admin access in the browser
+    Given a user who is an ADMIN in organization "acme"
+    And the user holds a custom role on the project's team that grants only analytics viewing
+    When the browser checks a team-scoped permission the custom role omits
+    Then the check is allowed, because the server allows an org admin everything
+    But the same custom role still restricts a user who is only a MEMBER
+
   # ============================================================================
   # Frontend knows the user's role
   # ============================================================================


### PR DESCRIPTION
# Related Issue

- Resolves #7669

Closes #7669. Fourth in the stack: base is #7672, on #7671, on #7670, on #7650.

## What changed

**Checker.** The parity checker now sees the scenarios it used to hide. A file mixing tagged and untagged scenarios reported `15/15 scenarios bound · ✓ all bound` while holding 27 — the blind spot the `LEGACY_UNBOUND` comment has named since #3338. Same design as the existing inert-file floor, built test-first:

- `isPartiallyTagged()` is the new floor, disjoint from `isInert` by construction (one file lands on exactly one list).
- `LEGACY_PARTIAL` is seeded with the 89 files already in that state (1,357 untagged scenarios). A **new** partially-tagged file now fails the check; an entry that becomes fully tagged must leave the list. Both directions fatal, like the inert list.
- The report line says what it measures: `6/6 tagged scenario(s) bound · 16 scenario(s) untagged and unmeasured`. `--json` carries `partial` / `newPartial` / `stalePartial`.
- The three exemption-list validations moved into one `validateAllExemptionLists` helper — a pure extraction to keep `analyzeParity` under the Biome line limit.

**The two governance spec files** are cleaned rather than exempted:

- `governance-home-routing.feature` (12 untagged → 0): only two scenarios were actually dead and are deleted — one asserting the "Govern · Preview" sidebar header #7597 removed, and the setup-state nav gate that no longer exists. Two scenarios the first draft of this PR deleted are restored as `@unimplemented` declared gaps, because nothing else asserts them: the bare `/settings/governance` redirect (`gateway-url-move.feature` covers only the deep-link and cost-centers forms) and the admin-authoring sub-route inventory. Two scenarios are newly **bound**: the dashboard render (heading "AI Governance", `delegatedViewer.integration.test.tsx`) and the `setupState` boolean-OR (`auth-cli-governance.integration.test.ts`, retagged `@integration`, its gate line corrected to `governance:view` — the checked-in RBAC test pins any-member access as FORBIDDEN). Two new `@unimplemented` scenarios declare the nav-promotion gates nobody tests (the governance flag and `governance:view`). The layout scenario stays `@unimplemented`, narrowed to what is actually untested (org-name chip and read-only indicator; the rail entries are asserted elsewhere). Now 17/17 bound, fully measured; the seven remaining declared gaps are inventoried in #7674.
- `ui-contract.feature`: six titles wrapped onto a second line, and the parser reads only the first line — rewrapped onto one line each. That surfaced a live bug in the old state: the Lane-B scenario **was** bound via its truncated fragment (`organization.prisma.repository.governance-filter.integration.test.ts`), which no reader of the spec could have predicted; the annotation now carries the full title. The 16 untagged scenarios need a content audit, not mechanical tagging — they sit in `LEGACY_PARTIAL` until the follow-up lands.

## Deliberately out of scope

Writing the seven declared-gap governance-home tests (#7674) — the /governance pages are still being reworked in this same stack's base PR, and coupling the guard to in-flight page work would churn both. The ui-contract audit is also a follow-up.

## Tests

`isPartiallyTagged` unit tests written first and watched fail (4 new, mirroring the `isInert` block); 20/20 pass. Full checker run: OK — 10,294 bound across 1,212 files, 89 partial files exempted and reported honestly. Whole-app typecheck clean; the diff-filtered Biome gate reports no new violations.
