### PR TITLE
feat(ci): sticky PR comment reporting coding agent token usage

### DIFF
--- a/.github/scripts/pr-token-usage.test.ts
+++ b/.github/scripts/pr-token-usage.test.ts
@@ -206,12 +206,34 @@ describe("given a usage rollup whose model rows cover far fewer tokens than the 
 describe("given the LangWatch API's answer", () => {
   describe("when the pull request is not mapped", () => {
     /** @scenario "An unmapped pull request reads as no usage" */
-    it("treats the refusal as no usage recorded rather than an error", () => {
-      const outcome = interpretUsageResponse({
+    it("treats the refusal as no usage recorded, in every error envelope shape", () => {
+      // The v1 family's live shape: specific code beside generic status text.
+      const v1Flat = interpretUsageResponse({
+        status: 404,
+        body: {
+          code: "github_pr_not_mapped",
+          message: "github_pr_not_mapped",
+          error: "Not Found",
+          kind: "github_pr_not_mapped",
+        },
+      });
+      assert.equal(v1Flat.kind, "none");
+      const canonical = interpretUsageResponse({
+        status: 404,
+        body: {
+          error: {
+            type: "not_found",
+            code: "github_pr_not_mapped",
+            message: "pull request not found",
+          },
+        },
+      });
+      assert.equal(canonical.kind, "none");
+      const legacyFlat = interpretUsageResponse({
         status: 404,
         body: { error: "github_pr_not_mapped", message: "pull request not found" },
       });
-      assert.equal(outcome.kind, "none");
+      assert.equal(legacyFlat.kind, "none");
     });
   });
 

--- a/.github/scripts/pr-token-usage.test.ts
+++ b/.github/scripts/pr-token-usage.test.ts
@@ -1,0 +1,205 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  MARKER,
+  agentLabel,
+  buildCommentBody,
+  formatCost,
+  formatCount,
+  interpretUsageResponse,
+  type PullRequestUsage,
+  type UsageRow,
+} from "./pr-token-usage.ts";
+
+const row = (overrides: Partial<UsageRow> = {}): UsageRow => ({
+  projectSlug: "personal-abc",
+  contributorLabel: "Ada Lovelace",
+  contributorIsProject: false,
+  agent: "claude_code",
+  models: ["claude-fable-5"],
+  sessionsCount: 2,
+  inputTokens: 1_000,
+  outputTokens: 2_000,
+  cacheReadTokens: 30_000,
+  cacheCreationTokens: 4_000,
+  totalTokens: 37_000,
+  costUsd: 12.5,
+  ...overrides,
+});
+
+const usage = (overrides: Partial<PullRequestUsage> = {}): PullRequestUsage => ({
+  rows: [row()],
+  totals: {
+    sessionsCount: 2,
+    inputTokens: 1_000,
+    outputTokens: 2_000,
+    cacheReadTokens: 30_000,
+    cacheCreationTokens: 4_000,
+    totalTokens: 37_000,
+    costUsd: 12.5,
+  },
+  modelBreakdown: [
+    {
+      model: "claude-fable-5",
+      inputTokens: 1_000,
+      outputTokens: 2_000,
+      cacheReadTokens: 30_000,
+      cacheCreationTokens: 4_000,
+      totalTokens: 37_000,
+      costUsd: 12.5,
+    },
+  ],
+  ...overrides,
+});
+
+const build = (data: PullRequestUsage): string =>
+  buildCommentBody({
+    usage: data,
+    shortSha: "abc1234",
+    updatedAtIso: "2026-08-30T12:34:56.000Z",
+  });
+
+describe("given a usage rollup with rows for two contributors", () => {
+  describe("when the comment body is built", () => {
+    /** @scenario "The comment shows one row per contributor and agent" */
+    it("renders each contributor once with agent, sessions, tokens and cost, and a totals row", () => {
+      const body = build(
+        usage({
+          rows: [
+            row(),
+            row({ contributorLabel: "Grace Hopper", agent: "codex", costUsd: 3 }),
+          ],
+          totals: {
+            sessionsCount: 4,
+            inputTokens: 2_000,
+            outputTokens: 4_000,
+            cacheReadTokens: 60_000,
+            cacheCreationTokens: 8_000,
+            totalTokens: 74_000,
+            costUsd: 15.5,
+          },
+        }),
+      );
+      assert.ok(body.startsWith(MARKER));
+      assert.match(body, /\| Ada Lovelace \| Claude Code \| 2 \| 37,000 \| \$12\.50 \|/);
+      assert.match(body, /\| Grace Hopper \| Codex \| 2 \| 37,000 \| \$3\.00 \|/);
+      assert.match(body, /\| \*\*Total\*\* \|  \| \*\*4\*\* \| \*\*74,000\*\* \| \*\*\$15\.50\*\* \|/);
+    });
+  });
+});
+
+describe("given a usage rollup with a model breakdown", () => {
+  describe("when the comment body is built", () => {
+    /** @scenario "The comment carries a per-model breakdown" */
+    it("lists each model's tokens and cost inside a collapsed details section", () => {
+      const body = build(usage());
+      const detailsStart = body.indexOf("<details>");
+      const detailsEnd = body.indexOf("</details>");
+      assert.ok(detailsStart !== -1 && detailsEnd > detailsStart);
+      const details = body.slice(detailsStart, detailsEnd);
+      assert.match(details, /`claude-fable-5`/);
+      assert.match(details, /\| 37,000 \| \$12\.50 \|/);
+    });
+  });
+});
+
+describe("given a usage rollup whose cost fields are null", () => {
+  describe("when the comment body is built", () => {
+    /** @scenario "Costs the caller may not price render as unavailable" */
+    it("renders the cost cells as an em dash rather than zero", () => {
+      const body = build(
+        usage({
+          rows: [row({ costUsd: null })],
+          totals: { ...usage().totals, costUsd: null },
+        }),
+      );
+      assert.match(body, /\| Ada Lovelace \| Claude Code \| 2 \| 37,000 \| — \|/);
+      assert.match(body, /\| \*\*Total\*\* \|  \| \*\*2\*\* \| \*\*37,000\*\* \| \*\*—\*\* \|/);
+      assert.ok(!body.includes("$0.00"));
+    });
+  });
+});
+
+describe("given a usage rollup with a token count above one billion", () => {
+  describe("when the comment body is built", () => {
+    /** @scenario "Token counts are written in full with thousands separators" */
+    it("writes the count in full with separators, never abbreviated", () => {
+      const big = 2_603_257_062;
+      const body = build(
+        usage({
+          rows: [row({ totalTokens: big })],
+          totals: { ...usage().totals, totalTokens: big },
+        }),
+      );
+      assert.ok(body.includes("2,603,257,062"));
+      assert.ok(!/\d(\.\d+)?[KMB]\b/.test(body));
+    });
+  });
+});
+
+describe("given a usage row's agent identifier", () => {
+  describe("when the comment body is built", () => {
+    /** @scenario "Agent identifiers render as product names" */
+    it("renders known identifiers as product names and unknown ones readably", () => {
+      assert.equal(agentLabel("claude_code"), "Claude Code");
+      assert.equal(agentLabel("opencode"), "OpenCode");
+      assert.equal(agentLabel("gemini_cli"), "Gemini CLI");
+      assert.equal(agentLabel("mystery_agent"), "Mystery Agent");
+    });
+  });
+});
+
+describe("given the LangWatch API's answer", () => {
+  describe("when the pull request is not mapped", () => {
+    /** @scenario "An unmapped pull request reads as no usage" */
+    it("treats the refusal as no usage recorded rather than an error", () => {
+      const outcome = interpretUsageResponse({
+        status: 404,
+        body: { error: "github_pr_not_mapped", message: "pull request not found" },
+      });
+      assert.equal(outcome.kind, "none");
+    });
+  });
+
+  describe("when the API answers with any other failure", () => {
+    it("reads as an error naming the status and code", () => {
+      const outcome = interpretUsageResponse({
+        status: 401,
+        body: { error: "invalid_credentials" },
+      });
+      assert.equal(outcome.kind, "error");
+      assert.ok(outcome.kind === "error" && outcome.message.includes("401"));
+      assert.ok(
+        outcome.kind === "error" && outcome.message.includes("invalid_credentials"),
+      );
+    });
+  });
+
+  describe("when the API answers 200", () => {
+    it("passes the rollup through", () => {
+      const outcome = interpretUsageResponse({ status: 200, body: usage() });
+      assert.equal(outcome.kind, "usage");
+    });
+  });
+});
+
+describe("given a rollup with no sessions", () => {
+  describe("when the comment body is built anyway (an existing comment is refreshed)", () => {
+    it("states that no sessions are recorded instead of an empty table", () => {
+      const body = build(
+        usage({ rows: [], totals: { ...usage().totals, sessionsCount: 0 }, modelBreakdown: [] }),
+      );
+      assert.ok(body.includes("No coding agent sessions recorded"));
+      assert.ok(!body.includes("| Contributor |"));
+    });
+  });
+});
+
+describe("given the number and cost formatters", () => {
+  it("formats counts and costs the way the tables promise", () => {
+    assert.equal(formatCount(1234567), "1,234,567");
+    assert.equal(formatCost(2076.492055), "$2,076.49");
+    assert.equal(formatCost(null), "—");
+  });
+});

--- a/.github/scripts/pr-token-usage.test.ts
+++ b/.github/scripts/pr-token-usage.test.ts
@@ -179,6 +179,30 @@ describe("given a usage row's agent identifier", () => {
   });
 });
 
+describe("given a usage rollup whose model rows cover far fewer tokens than the totals", () => {
+  describe("when the comment body is built", () => {
+    /** @scenario "A gap between session totals and per-model rows is called out" */
+    it("states how many of the total tokens the model rows cover", () => {
+      const body = build(
+        usage({
+          rows: [row({ totalTokens: 2_600_000_000 })],
+          totals: { ...usage().totals, totalTokens: 2_600_000_000 },
+          // modelBreakdown from the fixture covers only 37,000 tokens.
+        }),
+      );
+      assert.match(
+        body,
+        /> The per-model rows cover 37 thousand of the 2\.6 billion total tokens\./,
+      );
+    });
+
+    it("carries no note when the model rows match the totals", () => {
+      const body = build(usage());
+      assert.ok(!body.includes("per-model rows cover"));
+    });
+  });
+});
+
 describe("given the LangWatch API's answer", () => {
   describe("when the pull request is not mapped", () => {
     /** @scenario "An unmapped pull request reads as no usage" */

--- a/.github/scripts/pr-token-usage.test.ts
+++ b/.github/scripts/pr-token-usage.test.ts
@@ -3,10 +3,12 @@ import { describe, it } from "node:test";
 
 import {
   MARKER,
+  agentCell,
   agentLabel,
   buildCommentBody,
   formatCost,
   formatCount,
+  humanizeCount,
   interpretUsageResponse,
   type PullRequestUsage,
   type UsageRow,
@@ -82,9 +84,15 @@ describe("given a usage rollup with rows for two contributors", () => {
         }),
       );
       assert.ok(body.startsWith(MARKER));
-      assert.match(body, /\| Ada Lovelace \| Claude Code \| 2 \| 37,000 \| \$12\.50 \|/);
-      assert.match(body, /\| Grace Hopper \| Codex \| 2 \| 37,000 \| \$3\.00 \|/);
-      assert.match(body, /\| \*\*Total\*\* \|  \| \*\*4\*\* \| \*\*74,000\*\* \| \*\*\$15\.50\*\* \|/);
+      assert.match(
+        body,
+        /\| Ada Lovelace \| <img [^|]+\/> Claude Code \| 2 \| 37 thousand \| \$12\.50 \|/,
+      );
+      assert.match(
+        body,
+        /\| Grace Hopper \| <img [^|]+\/> Codex \| 2 \| 37 thousand \| \$3\.00 \|/,
+      );
+      assert.match(body, /\| \*\*Total\*\* \|  \| \*\*4\*\* \| \*\*74 thousand\*\* \| \*\*\$15\.50\*\* \|/);
     });
   });
 });
@@ -99,7 +107,7 @@ describe("given a usage rollup with a model breakdown", () => {
       assert.ok(detailsStart !== -1 && detailsEnd > detailsStart);
       const details = body.slice(detailsStart, detailsEnd);
       assert.match(details, /`claude-fable-5`/);
-      assert.match(details, /\| 37,000 \| \$12\.50 \|/);
+      assert.match(details, /\| 37 thousand \| \$12\.50 \|/);
     });
   });
 });
@@ -114,8 +122,8 @@ describe("given a usage rollup whose cost fields are null", () => {
           totals: { ...usage().totals, costUsd: null },
         }),
       );
-      assert.match(body, /\| Ada Lovelace \| Claude Code \| 2 \| 37,000 \| — \|/);
-      assert.match(body, /\| \*\*Total\*\* \|  \| \*\*2\*\* \| \*\*37,000\*\* \| \*\*—\*\* \|/);
+      assert.match(body, /\| Ada Lovelace \| <img [^|]+\/> Claude Code \| 2 \| 37 thousand \| — \|/);
+      assert.match(body, /\| \*\*Total\*\* \|  \| \*\*2\*\* \| \*\*37 thousand\*\* \| \*\*—\*\* \|/);
       assert.ok(!body.includes("$0.00"));
     });
   });
@@ -123,8 +131,8 @@ describe("given a usage rollup whose cost fields are null", () => {
 
 describe("given a usage rollup with a token count above one billion", () => {
   describe("when the comment body is built", () => {
-    /** @scenario "Token counts are written in full with thousands separators" */
-    it("writes the count in full with separators, never abbreviated", () => {
+    /** @scenario "Token counts render as words" */
+    it("renders the count as a spelled-out magnitude, never a letter abbreviation", () => {
       const big = 2_603_257_062;
       const body = build(
         usage({
@@ -132,20 +140,41 @@ describe("given a usage rollup with a token count above one billion", () => {
           totals: { ...usage().totals, totalTokens: big },
         }),
       );
-      assert.ok(body.includes("2,603,257,062"));
+      assert.ok(body.includes("2.6 billion"));
+      assert.ok(!body.includes("2,603,257,062"));
       assert.ok(!/\d(\.\d+)?[KMB]\b/.test(body));
     });
   });
 });
 
+describe("given the count humanizer", () => {
+  it("picks the right word, keeps small counts plain, and promotes on round-up", () => {
+    assert.equal(humanizeCount(0), "0");
+    assert.equal(humanizeCount(999), "999");
+    assert.equal(humanizeCount(37_000), "37 thousand");
+    assert.equal(humanizeCount(156_800), "157 thousand");
+    assert.equal(humanizeCount(1_888_045), "1.9 million");
+    assert.equal(humanizeCount(2_603_257_062), "2.6 billion");
+    assert.equal(humanizeCount(4_200_000_000_000), "4.2 trillion");
+    assert.equal(humanizeCount(999_960), "1 million");
+  });
+});
+
 describe("given a usage row's agent identifier", () => {
   describe("when the comment body is built", () => {
-    /** @scenario "Agent identifiers render as product names" */
-    it("renders known identifiers as product names and unknown ones readably", () => {
+    /** @scenario "Agent identifiers render as product names with their icons" */
+    it("renders known identifiers with their product icon and unknown ones readably without one", () => {
       assert.equal(agentLabel("claude_code"), "Claude Code");
-      assert.equal(agentLabel("opencode"), "OpenCode");
       assert.equal(agentLabel("gemini_cli"), "Gemini CLI");
-      assert.equal(agentLabel("mystery_agent"), "Mystery Agent");
+      assert.equal(
+        agentCell("claude_code"),
+        '<img src="https://app.langwatch.ai/images/external-icons/claude-code.svg" width="14" height="14" /> Claude Code',
+      );
+      assert.equal(
+        agentCell("codex"),
+        '<img src="https://app.langwatch.ai/images/external-icons/codex.svg" width="14" height="14" /> Codex',
+      );
+      assert.equal(agentCell("mystery_agent"), "Mystery Agent");
     });
   });
 });

--- a/.github/scripts/pr-token-usage.ts
+++ b/.github/scripts/pr-token-usage.ts
@@ -1,0 +1,433 @@
+// Builds and upserts the sticky "coding agent usage" comment on a pull
+// request, from the LangWatch pull-request usage API
+// (GET /api/coding-agent/pull-request-usage): sessions, tokens and estimated
+// cost per contributor and agent, plus a per-model breakdown, over the pull
+// request's whole lifetime.
+//
+// Deliberately non-blocking, like pr-impact-map: this script only describes
+// what the work cost, it never judges it. A LangWatch outage logs a warning
+// and exits 0, so the job can sit on every pull request without ever
+// painting a red X for a reporting failure.
+//
+// Deliberately dependency-free and run with `node --experimental-strip-types`,
+// matching guard-path-filters.ts: there is no install step on the runner.
+//
+// Spec: specs/ci/pr-token-usage.feature
+
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+export const MARKER = "<!-- pr-token-usage -->";
+
+/** The API refuses an unknown pull request with this code; it means "no usage
+ * recorded yet", not "something broke". */
+const PR_NOT_MAPPED_CODE = "github_pr_not_mapped";
+
+export type UsageRow = {
+  projectSlug: string;
+  contributorLabel: string;
+  contributorIsProject: boolean;
+  agent: string;
+  models: string[];
+  sessionsCount: number;
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheCreationTokens: number;
+  totalTokens: number;
+  costUsd: number | null;
+};
+
+export type UsageTotals = {
+  sessionsCount: number;
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheCreationTokens: number;
+  totalTokens: number;
+  costUsd: number | null;
+};
+
+export type ModelBreakdownRow = {
+  model: string;
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheCreationTokens: number;
+  totalTokens: number;
+  costUsd: number | null;
+};
+
+export type PullRequestUsage = {
+  rows: UsageRow[];
+  totals: UsageTotals;
+  modelBreakdown: ModelBreakdownRow[];
+};
+
+/** "No usage recorded" and "the PR is not mapped yet" collapse into null:
+ * both mean there is nothing to say. */
+export type FetchOutcome =
+  | { kind: "usage"; usage: PullRequestUsage }
+  | { kind: "none" }
+  | { kind: "error"; message: string };
+
+const AGENT_LABELS: Record<string, string> = {
+  claude_code: "Claude Code",
+  codex: "Codex",
+  opencode: "OpenCode",
+  cursor: "Cursor",
+  gemini_cli: "Gemini CLI",
+};
+
+/** A known agent identifier renders as its product name; an unknown one falls
+ * back to a readable form of itself rather than raw snake_case. */
+export const agentLabel = (agent: string): string =>
+  AGENT_LABELS[agent] ??
+  agent
+    .split(/[_-]/)
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+
+/** Full numbers with separators, never abbreviated: "2,603,257,062". */
+export const formatCount = (n: number): string => n.toLocaleString("en-US");
+
+/** null cost means the caller may not price this row — an em dash, not $0. */
+export const formatCost = (cost: number | null): string =>
+  cost === null ? "—" : `$${cost.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+
+const usageTable = (rows: UsageRow[], totals: UsageTotals): string[] => {
+  const line = (cells: string[]) => `| ${cells.join(" | ")} |`;
+  const out = [
+    line(["Contributor", "Agent", "Sessions", "Total tokens", "Estimated cost"]),
+    line(["---", "---", "--:", "--:", "--:"]),
+  ];
+  for (const row of rows) {
+    out.push(
+      line([
+        row.contributorLabel,
+        agentLabel(row.agent),
+        formatCount(row.sessionsCount),
+        formatCount(row.totalTokens),
+        formatCost(row.costUsd),
+      ]),
+    );
+  }
+  out.push(
+    line([
+      "**Total**",
+      "",
+      `**${formatCount(totals.sessionsCount)}**`,
+      `**${formatCount(totals.totalTokens)}**`,
+      `**${formatCost(totals.costUsd)}**`,
+    ]),
+  );
+  return out;
+};
+
+const tokenDetailTable = (
+  rows: UsageRow[],
+  totals: UsageTotals,
+): string[] => {
+  const line = (cells: string[]) => `| ${cells.join(" | ")} |`;
+  const out = [
+    line(["Contributor", "Input", "Output", "Cache read", "Cache write"]),
+    line(["---", "--:", "--:", "--:", "--:"]),
+  ];
+  for (const row of rows) {
+    out.push(
+      line([
+        row.contributorLabel,
+        formatCount(row.inputTokens),
+        formatCount(row.outputTokens),
+        formatCount(row.cacheReadTokens),
+        formatCount(row.cacheCreationTokens),
+      ]),
+    );
+  }
+  out.push(
+    line([
+      "**Total**",
+      `**${formatCount(totals.inputTokens)}**`,
+      `**${formatCount(totals.outputTokens)}**`,
+      `**${formatCount(totals.cacheReadTokens)}**`,
+      `**${formatCount(totals.cacheCreationTokens)}**`,
+    ]),
+  );
+  return out;
+};
+
+const modelTable = (breakdown: ModelBreakdownRow[]): string[] => {
+  const line = (cells: string[]) => `| ${cells.join(" | ")} |`;
+  const out = [
+    line(["Model", "Input", "Output", "Cache read", "Cache write", "Total tokens", "Estimated cost"]),
+    line(["---", "--:", "--:", "--:", "--:", "--:", "--:"]),
+  ];
+  for (const row of breakdown) {
+    out.push(
+      line([
+        `\`${row.model}\``,
+        formatCount(row.inputTokens),
+        formatCount(row.outputTokens),
+        formatCount(row.cacheReadTokens),
+        formatCount(row.cacheCreationTokens),
+        formatCount(row.totalTokens),
+        formatCost(row.costUsd),
+      ]),
+    );
+  }
+  return out;
+};
+
+export const buildCommentBody = ({
+  usage,
+  shortSha,
+  updatedAtIso,
+}: {
+  usage: PullRequestUsage;
+  shortSha: string;
+  updatedAtIso: string;
+}): string => {
+  const updated = updatedAtIso.replace("T", " ").slice(0, 16);
+  const parts = [MARKER, "### Coding agent usage on this pull request", ""];
+
+  if (usage.totals.sessionsCount === 0) {
+    parts.push("No coding agent sessions recorded for this pull request.");
+  } else {
+    parts.push(...usageTable(usage.rows, usage.totals));
+    const details: string[] = [];
+    details.push("", "<details>", "<summary>Token and model breakdown</summary>", "");
+    details.push(...tokenDetailTable(usage.rows, usage.totals));
+    if (usage.modelBreakdown.length > 0) {
+      details.push("", ...modelTable(usage.modelBreakdown));
+    }
+    details.push("", "</details>");
+    parts.push(...details);
+  }
+
+  parts.push(
+    "",
+    "<sub>Tokens as reported by the agents to " +
+      "[LangWatch](https://app.langwatch.ai); cost estimated from model list " +
+      "prices, over the pull request's whole lifetime. Updated for " +
+      `\`${shortSha}\` · ${updated} UTC</sub>`,
+  );
+  return parts.join("\n");
+};
+
+/** The rollup's whole-response shape is the API's; only what the comment
+ * renders is typed above, and unknown fields pass through untouched. */
+export const interpretUsageResponse = ({
+  status,
+  body,
+}: {
+  status: number;
+  body: unknown;
+}): FetchOutcome => {
+  if (status === 200) {
+    return { kind: "usage", usage: body as PullRequestUsage };
+  }
+  const code =
+    typeof body === "object" && body !== null && "error" in body
+      ? String((body as { error: unknown }).error)
+      : "";
+  if (status === 404 && code === PR_NOT_MAPPED_CODE) {
+    return { kind: "none" };
+  }
+  return {
+    kind: "error",
+    message: `LangWatch answered ${status}${code ? ` (${code})` : ""}`,
+  };
+};
+
+const fetchUsage = async ({
+  endpoint,
+  apiKey,
+  projectId,
+  repository,
+  prNumber,
+}: {
+  endpoint: string;
+  apiKey: string;
+  projectId: string;
+  repository: string;
+  prNumber: number;
+}): Promise<FetchOutcome> => {
+  const url =
+    `${endpoint}/api/coding-agent/pull-request-usage` +
+    `?repository=${encodeURIComponent(repository)}&pullRequest=${prNumber}`;
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "X-Project-Id": projectId,
+      },
+    });
+  } catch (error) {
+    return { kind: "error", message: `LangWatch unreachable: ${String(error)}` };
+  }
+  const body: unknown = await response.json().catch(() => null);
+  return interpretUsageResponse({ status: response.status, body });
+};
+
+type GithubComment = {
+  id: number;
+  body?: string;
+  user?: { login?: string };
+};
+
+const githubHeaders = (token: string) => ({
+  Authorization: `Bearer ${token}`,
+  Accept: "application/vnd.github+json",
+  "X-GitHub-Api-Version": "2022-11-28",
+  "Content-Type": "application/json",
+});
+
+const findExistingComment = async ({
+  apiUrl,
+  token,
+  repository,
+  prNumber,
+}: {
+  apiUrl: string;
+  token: string;
+  repository: string;
+  prNumber: number;
+}): Promise<GithubComment | null> => {
+  for (let page = 1; page <= 10; page++) {
+    const response = await fetch(
+      `${apiUrl}/repos/${repository}/issues/${prNumber}/comments?per_page=100&page=${page}`,
+      { headers: githubHeaders(token) },
+    );
+    if (!response.ok) {
+      throw new Error(`Listing comments failed with ${response.status}`);
+    }
+    const comments = (await response.json()) as GithubComment[];
+    const existing = comments.find(
+      (comment) =>
+        comment.user?.login === "github-actions[bot]" &&
+        comment.body?.includes(MARKER),
+    );
+    if (existing) return existing;
+    if (comments.length < 100) return null;
+  }
+  return null;
+};
+
+const upsertComment = async ({
+  apiUrl,
+  token,
+  repository,
+  prNumber,
+  body,
+  existing,
+}: {
+  apiUrl: string;
+  token: string;
+  repository: string;
+  prNumber: number;
+  body: string;
+  existing: GithubComment | null;
+}): Promise<void> => {
+  const target = existing
+    ? {
+        url: `${apiUrl}/repos/${repository}/issues/comments/${existing.id}`,
+        method: "PATCH",
+      }
+    : {
+        url: `${apiUrl}/repos/${repository}/issues/${prNumber}/comments`,
+        method: "POST",
+      };
+  const response = await fetch(target.url, {
+    method: target.method,
+    headers: githubHeaders(token),
+    body: JSON.stringify({ body }),
+  });
+  if (!response.ok) {
+    throw new Error(`${target.method} comment failed with ${response.status}`);
+  }
+};
+
+const requireEnv = (name: string): string => {
+  const value = process.env[name];
+  if (!value) throw new Error(`Missing required env var ${name}`);
+  return value;
+};
+
+const run = async (): Promise<void> => {
+  const dryRun = process.argv.includes("--dry-run");
+  const repository = requireEnv("PR_REPOSITORY");
+  const prNumber = Number(requireEnv("PR_NUMBER"));
+  const shortSha = requireEnv("PR_HEAD_SHA").slice(0, 7);
+  const endpoint = process.env.LANGWATCH_ENDPOINT ?? "https://app.langwatch.ai";
+
+  const outcome = await fetchUsage({
+    endpoint,
+    apiKey: requireEnv("LANGWATCH_API_KEY"),
+    projectId: requireEnv("LANGWATCH_PROJECT_ID"),
+    repository,
+    prNumber,
+  });
+
+  // Reporting must never block the pull request: a LangWatch failure is a
+  // warning annotation and a green job, and the comment is left as it was.
+  if (outcome.kind === "error") {
+    console.log(`::warning title=pr-token-usage::${outcome.message}`);
+    return;
+  }
+
+  const usage: PullRequestUsage =
+    outcome.kind === "usage"
+      ? outcome.usage
+      : { rows: [], totals: emptyTotals(), modelBreakdown: [] };
+
+  const body = buildCommentBody({
+    usage,
+    shortSha,
+    updatedAtIso: new Date().toISOString(),
+  });
+
+  if (dryRun) {
+    console.log(body);
+    return;
+  }
+
+  const token = requireEnv("GITHUB_TOKEN");
+  const apiUrl = process.env.GITHUB_API_URL ?? "https://api.github.com";
+  const existing = await findExistingComment({ apiUrl, token, repository, prNumber });
+
+  // No usage and no comment: stay silent rather than stamp every dependency
+  // bump with an empty table. An existing comment is still refreshed, so a
+  // rollup that empties never leaves stale numbers behind.
+  if (usage.totals.sessionsCount === 0 && !existing) {
+    console.log(`No usage recorded for ${repository}#${prNumber}; skipping.`);
+    return;
+  }
+
+  await upsertComment({ apiUrl, token, repository, prNumber, body, existing });
+  console.log(
+    `${existing ? "Updated" : "Created"} usage comment on ${repository}#${prNumber}.`,
+  );
+};
+
+const emptyTotals = (): UsageTotals => ({
+  sessionsCount: 0,
+  inputTokens: 0,
+  outputTokens: 0,
+  cacheReadTokens: 0,
+  cacheCreationTokens: 0,
+  totalTokens: 0,
+  costUsd: null,
+});
+
+const isMain =
+  process.argv[1] !== undefined &&
+  import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+
+if (isMain) {
+  run().catch((error) => {
+    // Even an unexpected failure only warns: see the non-blocking note above.
+    console.log(`::warning title=pr-token-usage::${String(error)}`);
+  });
+}

--- a/.github/scripts/pr-token-usage.ts
+++ b/.github/scripts/pr-token-usage.ts
@@ -89,8 +89,47 @@ export const agentLabel = (agent: string): string =>
     .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
     .join(" ");
 
-/** Full numbers with separators, never abbreviated: "2,603,257,062". */
+/** Full numbers with separators: "2,603,257,062". Used for small counts. */
 export const formatCount = (n: number): string => n.toLocaleString("en-US");
+
+const COUNT_WORDS = ["thousand", "million", "billion", "trillion"];
+
+/** Token counts render as words, not digits or letter abbreviations:
+ * 2,603,257,062 is "2.6 billion". One decimal below one hundred of a unit,
+ * none above; a value that rounds up to a whole next unit is promoted. */
+export const humanizeCount = (n: number): string => {
+  if (n < 1_000) return formatCount(n);
+  let index = Math.min(Math.floor(Math.log10(n) / 3), COUNT_WORDS.length) - 1;
+  const display = (i: number): string => {
+    const value = n / 10 ** ((i + 1) * 3);
+    return value >= 100 ? value.toFixed(0) : value.toFixed(1);
+  };
+  let digits = display(index);
+  if (Number(digits) >= 1_000 && index < COUNT_WORDS.length - 1) {
+    index += 1;
+    digits = display(index);
+  }
+  return `${digits.replace(/\.0$/, "")} ${COUNT_WORDS[index]}`;
+};
+
+const AGENT_ICONS: Record<string, string> = {
+  claude_code: "claude-code.svg",
+  codex: "codex.svg",
+  opencode: "opencode.svg",
+  cursor: "cursor.svg",
+  gemini_cli: "gemini.svg",
+  github_copilot: "github-copilot.svg",
+};
+
+/** A known agent renders with its product icon before the name; an unknown
+ * one renders as its label alone rather than a broken image. */
+export const agentCell = (agent: string): string => {
+  const icon = AGENT_ICONS[agent];
+  const label = agentLabel(agent);
+  return icon
+    ? `<img src="https://app.langwatch.ai/images/external-icons/${icon}" width="14" height="14" /> ${label}`
+    : label;
+};
 
 /** null cost means the caller may not price this row — an em dash, not $0. */
 export const formatCost = (cost: number | null): string =>
@@ -106,9 +145,9 @@ const usageTable = (rows: UsageRow[], totals: UsageTotals): string[] => {
     out.push(
       line([
         row.contributorLabel,
-        agentLabel(row.agent),
+        agentCell(row.agent),
         formatCount(row.sessionsCount),
-        formatCount(row.totalTokens),
+        humanizeCount(row.totalTokens),
         formatCost(row.costUsd),
       ]),
     );
@@ -118,7 +157,7 @@ const usageTable = (rows: UsageRow[], totals: UsageTotals): string[] => {
       "**Total**",
       "",
       `**${formatCount(totals.sessionsCount)}**`,
-      `**${formatCount(totals.totalTokens)}**`,
+      `**${humanizeCount(totals.totalTokens)}**`,
       `**${formatCost(totals.costUsd)}**`,
     ]),
   );
@@ -138,20 +177,20 @@ const tokenDetailTable = (
     out.push(
       line([
         row.contributorLabel,
-        formatCount(row.inputTokens),
-        formatCount(row.outputTokens),
-        formatCount(row.cacheReadTokens),
-        formatCount(row.cacheCreationTokens),
+        humanizeCount(row.inputTokens),
+        humanizeCount(row.outputTokens),
+        humanizeCount(row.cacheReadTokens),
+        humanizeCount(row.cacheCreationTokens),
       ]),
     );
   }
   out.push(
     line([
       "**Total**",
-      `**${formatCount(totals.inputTokens)}**`,
-      `**${formatCount(totals.outputTokens)}**`,
-      `**${formatCount(totals.cacheReadTokens)}**`,
-      `**${formatCount(totals.cacheCreationTokens)}**`,
+      `**${humanizeCount(totals.inputTokens)}**`,
+      `**${humanizeCount(totals.outputTokens)}**`,
+      `**${humanizeCount(totals.cacheReadTokens)}**`,
+      `**${humanizeCount(totals.cacheCreationTokens)}**`,
     ]),
   );
   return out;
@@ -167,11 +206,11 @@ const modelTable = (breakdown: ModelBreakdownRow[]): string[] => {
     out.push(
       line([
         `\`${row.model}\``,
-        formatCount(row.inputTokens),
-        formatCount(row.outputTokens),
-        formatCount(row.cacheReadTokens),
-        formatCount(row.cacheCreationTokens),
-        formatCount(row.totalTokens),
+        humanizeCount(row.inputTokens),
+        humanizeCount(row.outputTokens),
+        humanizeCount(row.cacheReadTokens),
+        humanizeCount(row.cacheCreationTokens),
+        humanizeCount(row.totalTokens),
         formatCost(row.costUsd),
       ]),
     );

--- a/.github/scripts/pr-token-usage.ts
+++ b/.github/scripts/pr-token-usage.ts
@@ -239,6 +239,24 @@ export const buildCommentBody = ({
     details.push(...tokenDetailTable(usage.rows, usage.totals));
     if (usage.modelBreakdown.length > 0) {
       details.push("", ...modelTable(usage.modelBreakdown));
+      // The contributor totals come from session-level counters; the model
+      // rows come from stored per-turn events. A session whose turns were
+      // never stored (an outage, a client too old to send them) still counts
+      // in the totals, so the model rows can legitimately cover less. Say so
+      // rather than leave two tables that appear to contradict each other.
+      const modelSum = usage.modelBreakdown.reduce(
+        (sum, row) => sum + row.totalTokens,
+        0,
+      );
+      if (modelSum < usage.totals.totalTokens * 0.95) {
+        details.push(
+          "",
+          `> The per-model rows cover ${humanizeCount(modelSum)} of the ` +
+            `${humanizeCount(usage.totals.totalTokens)} total tokens. The rest ` +
+            "belongs to session turns whose per-call events were not stored, " +
+            "so only their session totals are known.",
+        );
+      }
     }
     details.push("", "</details>");
     parts.push(...details);

--- a/.github/scripts/pr-token-usage.ts
+++ b/.github/scripts/pr-token-usage.ts
@@ -272,6 +272,23 @@ export const buildCommentBody = ({
   return parts.join("\n");
 };
 
+/** The v1 family answers `{"code": "...", "error": "Bad Request", ...}` —
+ * the specific code beside a generic status text — while the legacy flat
+ * shape carried the code AS the `error` string, and the canonical envelope
+ * nests it under `error.code`. Read all three, most specific first, so the
+ * script survives either side of the API family migration. */
+const errorCodeOf = (body: unknown): string => {
+  if (typeof body !== "object" || body === null) return "";
+  const record = body as { code?: unknown; error?: unknown };
+  if (typeof record.code === "string") return record.code;
+  const error = record.error;
+  if (typeof error === "string") return error;
+  if (typeof error === "object" && error !== null && "code" in error) {
+    return String((error as { code: unknown }).code);
+  }
+  return "";
+};
+
 /** The rollup's whole-response shape is the API's; only what the comment
  * renders is typed above, and unknown fields pass through untouched. */
 export const interpretUsageResponse = ({
@@ -284,10 +301,7 @@ export const interpretUsageResponse = ({
   if (status === 200) {
     return { kind: "usage", usage: body as PullRequestUsage };
   }
-  const code =
-    typeof body === "object" && body !== null && "error" in body
-      ? String((body as { error: unknown }).error)
-      : "";
+  const code = errorCodeOf(body);
   if (status === 404 && code === PR_NOT_MAPPED_CODE) {
     return { kind: "none" };
   }
@@ -300,26 +314,21 @@ export const interpretUsageResponse = ({
 const fetchUsage = async ({
   endpoint,
   apiKey,
-  projectId,
   repository,
   prNumber,
 }: {
   endpoint: string;
   apiKey: string;
-  projectId: string;
   repository: string;
   prNumber: number;
 }): Promise<FetchOutcome> => {
   const url =
-    `${endpoint}/api/coding-agent/pull-request-usage` +
+    `${endpoint}/api/v1/coding-agent/pull-request-usage` +
     `?repository=${encodeURIComponent(repository)}&pullRequest=${prNumber}`;
   let response: Response;
   try {
     response = await fetch(url, {
-      headers: {
-        Authorization: `Bearer ${apiKey}`,
-        "X-Project-Id": projectId,
-      },
+      headers: { Authorization: `Bearer ${apiKey}` },
     });
   } catch (error) {
     return { kind: "error", message: `LangWatch unreachable: ${String(error)}` };
@@ -422,7 +431,6 @@ const run = async (): Promise<void> => {
   const outcome = await fetchUsage({
     endpoint,
     apiKey: requireEnv("LANGWATCH_API_KEY"),
-    projectId: requireEnv("LANGWATCH_PROJECT_ID"),
     repository,
     prNumber,
   });

--- a/.github/workflows/pr-token-usage.yml
+++ b/.github/workflows/pr-token-usage.yml
@@ -1,0 +1,67 @@
+name: pr-token-usage
+
+# Posts a single sticky comment stating what the coding agents spent on this
+# pull request (sessions, tokens and estimated cost per contributor and per
+# model, read from the LangWatch pull-request usage API), and rewrites that
+# same comment on every subsequent push.
+#
+# `synchronize` IS "a new commit was pushed to this PR", so one `pull_request`
+# trigger covers both "on open" and "on every push". Usage accrues while the
+# work happens, so each push refreshes the numbers; `workflow_dispatch` exists
+# for a manual refresh after the last commit.
+#
+# Deliberately non-blocking: this workflow only describes what the work cost,
+# it never judges it. A LangWatch outage logs a warning and the job stays
+# green, so nothing here should gate a merge or join branch protection.
+#
+# No path filter, so it always produces a result and needs no "-unmodified"
+# stub under the complementary-pair system (see specs/ci/path-filters.feature).
+#
+# Spec: specs/ci/pr-token-usage.feature
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+    inputs:
+      pull_request:
+        description: "Pull request number to refresh"
+        required: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+# Two pushes in quick succession would otherwise race: both runs read "no
+# existing comment" and both POST, leaving duplicates on the thread.
+concurrency:
+  group: pr-token-usage-${{ github.event.pull_request.number || inputs.pull_request }}
+  cancel-in-progress: true
+
+jobs:
+  comment:
+    # Fork PRs get a read-only GITHUB_TOKEN and no secrets, so the LangWatch
+    # read and the comment POST would both fail. Skip quietly rather than
+    # paint a red X on a contributor's first PR.
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          sparse-checkout: .github/scripts
+          persist-credentials: false
+
+      # The same logic that is about to write the comment proves itself first;
+      # `node --test` with type stripping needs no install step.
+      - name: Test the comment builder
+        run: node --test --experimental-strip-types .github/scripts/pr-token-usage.test.ts
+
+      - name: Build and upsert the usage comment
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LANGWATCH_API_KEY: ${{ secrets.LANGWATCH_PR_USAGE_API_KEY }}
+          LANGWATCH_PROJECT_ID: ${{ vars.LANGWATCH_PR_USAGE_PROJECT_ID }}
+          PR_REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pull_request }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: node --experimental-strip-types .github/scripts/pr-token-usage.ts

--- a/.github/workflows/pr-token-usage.yml
+++ b/.github/workflows/pr-token-usage.yml
@@ -60,7 +60,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LANGWATCH_API_KEY: ${{ secrets.LANGWATCH_PR_USAGE_API_KEY }}
-          LANGWATCH_PROJECT_ID: ${{ vars.LANGWATCH_PR_USAGE_PROJECT_ID }}
           PR_REPOSITORY: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number || inputs.pull_request }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}

--- a/specs/ci/pr-token-usage.feature
+++ b/specs/ci/pr-token-usage.feature
@@ -74,17 +74,19 @@ Feature: PR token usage comment
     Then the cost cells render as an em dash rather than zero
 
   @unit
-  Scenario: Token counts are written in full with thousands separators
+  Scenario: Token counts render as words
     Given a usage rollup with a token count above one billion
     When the comment body is built
-    Then the count is written in full with separators, never abbreviated
+    Then the count renders as a spelled-out magnitude such as "2.6 billion"
+    And the unit is a word, never a letter abbreviation
+    And a count below one thousand stays a plain number
 
   @unit
-  Scenario: Agent identifiers render as product names
+  Scenario: Agent identifiers render as product names with their icons
     Given a usage row whose agent is "claude_code"
     When the comment body is built
-    Then the agent renders as "Claude Code"
-    And an unknown agent identifier falls back to a readable form of itself
+    Then the agent renders as "Claude Code" beside its product icon
+    And an unknown agent identifier falls back to a readable form of itself, without a broken image
 
   @unit
   Scenario: An unmapped pull request reads as no usage

--- a/specs/ci/pr-token-usage.feature
+++ b/specs/ci/pr-token-usage.feature
@@ -89,6 +89,13 @@ Feature: PR token usage comment
     And an unknown agent identifier falls back to a readable form of itself, without a broken image
 
   @unit
+  Scenario: A gap between session totals and per-model rows is called out
+    Given a usage rollup whose model rows cover far fewer tokens than the totals
+    When the comment body is built
+    Then a note states how many of the total tokens the model rows cover
+    And a rollup whose model rows match the totals carries no such note
+
+  @unit
   Scenario: An unmapped pull request reads as no usage
     Given the LangWatch API answers that the pull request is not mapped
     When the response is interpreted

--- a/specs/ci/pr-token-usage.feature
+++ b/specs/ci/pr-token-usage.feature
@@ -1,0 +1,93 @@
+Feature: PR token usage comment
+  As a reviewer
+  I want a single comment stating what the coding agents spent on a pull request
+  So that the cost of the work is visible next to the work itself
+
+  The data comes from the LangWatch pull-request usage API
+  (GET /api/coding-agent/pull-request-usage), which rolls a pull request's
+  whole lifetime up into sessions, tokens and cost per contributor and agent.
+  The workflow only reads and comments: it never gates a merge.
+
+  Background:
+    Given the pr-token-usage workflow runs on pull_request events
+    And it identifies its own comment by the hidden marker "<!-- pr-token-usage -->"
+
+  Scenario: A comment is posted when usage exists for the pull request
+    Given LangWatch has recorded sessions for the pull request
+    When the workflow runs
+    Then a comment carrying the usage marker is posted exactly once
+
+  Scenario: The existing comment is updated when new commits are pushed
+    Given a pull request already has a comment carrying the usage marker
+    When a new commit is pushed to the pull request branch
+    Then the existing comment is updated in place
+    And no additional comment is created
+
+  Scenario: A pull request with no recorded usage gets no comment
+    Given LangWatch has no sessions recorded for the pull request
+    And the pull request has no comment carrying the usage marker
+    When the workflow runs
+    Then no comment is created
+    And the workflow does not fail
+
+  Scenario: An existing comment is refreshed even when usage drops to zero
+    Given a pull request already has a comment carrying the usage marker
+    And LangWatch now reports no sessions for the pull request
+    When the workflow runs
+    Then the existing comment is updated rather than left stale
+
+  Scenario: A LangWatch outage never blocks the pull request
+    Given the LangWatch API is unreachable or answers with an error
+    When the workflow runs
+    Then the workflow logs a warning and succeeds
+    And no comment is created or modified
+
+  Scenario: Pull requests from forks are skipped
+    Given a pull request originates from a forked repository
+    When the workflow is triggered
+    Then no comment is attempted
+    And the workflow does not fail
+
+  Scenario: Rapid successive pushes do not create duplicate comments
+    Given a pull request receives two pushes in quick succession
+    When both workflow runs are triggered
+    Then the earlier run is cancelled before it posts
+    And the pull request carries exactly one usage comment
+
+  @unit
+  Scenario: The comment shows one row per contributor and agent
+    Given a usage rollup with rows for two contributors
+    When the comment body is built
+    Then each contributor appears once with its agent, sessions, tokens and cost
+    And a totals row sums them
+
+  @unit
+  Scenario: The comment carries a per-model breakdown
+    Given a usage rollup with a model breakdown
+    When the comment body is built
+    Then each model's tokens and cost appear in a collapsed details section
+
+  @unit
+  Scenario: Costs the caller may not price render as unavailable
+    Given a usage rollup whose cost fields are null
+    When the comment body is built
+    Then the cost cells render as an em dash rather than zero
+
+  @unit
+  Scenario: Token counts are written in full with thousands separators
+    Given a usage rollup with a token count above one billion
+    When the comment body is built
+    Then the count is written in full with separators, never abbreviated
+
+  @unit
+  Scenario: Agent identifiers render as product names
+    Given a usage row whose agent is "claude_code"
+    When the comment body is built
+    Then the agent renders as "Claude Code"
+    And an unknown agent identifier falls back to a readable form of itself
+
+  @unit
+  Scenario: An unmapped pull request reads as no usage
+    Given the LangWatch API answers that the pull request is not mapped
+    When the response is interpreted
+    Then it is treated as "no usage recorded" rather than an error


### PR DESCRIPTION
## What

On every pull request event (opened, synchronize, reopened, plus a manual `workflow_dispatch`), a new `pr-token-usage` workflow reads the LangWatch pull-request usage API (`GET /api/coding-agent/pull-request-usage`) and upserts one marker-keyed sticky comment on the PR:

- sessions, total tokens and estimated cost per contributor and agent, with a totals row
- a collapsed details section with the input / output / cache read / cache write split and a per-model table
- a footer stating the data source, that cost is an estimate from model list prices, and which commit and time the comment was updated for

New commits find the same comment back by its `<!-- pr-token-usage -->` marker and rewrite it in place, following the `pr-impact-map` sticky-comment pattern (concurrency-deduped, fork PRs skipped, non-blocking: a LangWatch outage is a warning annotation and a green job).

An unmapped pull request or an empty rollup posts no comment, so dependency bumps stay unstamped; an existing comment is always refreshed so numbers never go stale.

## How

- `.github/scripts/pr-token-usage.ts` — dependency-free, runs under `node --experimental-strip-types` like the workflow guards; pure comment-building logic exported for tests, plus the fetch/upsert main path and a `--dry-run` mode
- `.github/scripts/pr-token-usage.test.ts` — `node --test` suite, run inside the workflow before the comment step
- `specs/ci/pr-token-usage.feature` — 6/6 tagged scenarios bound
- Secrets/vars (already set on this repo): `LANGWATCH_PR_USAGE_API_KEY`, `LANGWATCH_PR_USAGE_PROJECT_ID`

## Verified locally

Dry run against this repo's PR #7546 rendered the real rollup (4 sessions, 2.6B tokens, ~$2.1k estimated) with the exact comment markdown; unit suite 10/10.

Once this proves itself here, the same workflow copies to langwatch-saas and scenario.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated pull request comments showing coding-agent sessions, token usage, estimated costs, and model breakdowns.
  * Comments refresh after new commits and can also be triggered manually.
  * Added readable formatting for large token counts, agent names, and unavailable cost data.
  * Handles no usage, API outages, unmapped pull requests, fork-based changes, and overlapping updates gracefully.

* **Tests**
  * Added coverage for usage reporting, formatting, comment updates, and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->