### PR TITLE
fix(simulations): hide empty criteria metrics

### DIFF
--- a/platform/app/src/components/simulations/simulation-console/MetricsSummary.tsx
+++ b/platform/app/src/components/simulations/simulation-console/MetricsSummary.tsx
@@ -15,36 +15,42 @@ export function MetricsSummary({ results, durationInMs }: MetricsSummaryProps) {
   const metCount = results?.metCriteria?.length || 0;
   const unmetCount = results?.unmetCriteria?.length || 0;
   const totalCriteria = metCount + unmetCount;
-  const successRate =
-    totalCriteria > 0 ? ((metCount / totalCriteria) * 100).toFixed(1) : "0.0";
+  const hasCriteria = totalCriteria > 0;
+  const successRate = hasCriteria
+    ? ((metCount / totalCriteria) * 100).toFixed(1)
+    : "0.0";
   const duration = durationInMs ? (durationInMs / 1000).toFixed(2) : "0.00";
 
   return (
     <VStack align="start" gap={1} mb={3}>
-      <HStack>
-        <Text color="white">Success Criteria:</Text>
-        <Text
-          color={
-            metCount > 0
-              ? CONSOLE_COLORS.successColor
-              : CONSOLE_COLORS.failureColor
-          }
-        >
-          {metCount}/{totalCriteria}
-        </Text>
-      </HStack>
-      <HStack>
-        <Text color="white">Success Rate:</Text>
-        <Text
-          color={
-            parseFloat(successRate) > 50
-              ? CONSOLE_COLORS.successColor
-              : CONSOLE_COLORS.failureColor
-          }
-        >
-          {successRate}%
-        </Text>
-      </HStack>
+      {hasCriteria && (
+        <>
+          <HStack>
+            <Text color="white">Success Criteria:</Text>
+            <Text
+              color={
+                metCount > 0
+                  ? CONSOLE_COLORS.successColor
+                  : CONSOLE_COLORS.failureColor
+              }
+            >
+              {metCount}/{totalCriteria}
+            </Text>
+          </HStack>
+          <HStack>
+            <Text color="white">Success Rate:</Text>
+            <Text
+              color={
+                parseFloat(successRate) > 50
+                  ? CONSOLE_COLORS.successColor
+                  : CONSOLE_COLORS.failureColor
+              }
+            >
+              {successRate}%
+            </Text>
+          </HStack>
+        </>
+      )}
       <HStack>
         <Text color="white">Duration:</Text>
         <Text color={CONSOLE_COLORS.consoleText}>{duration}s</Text>

--- a/platform/app/src/components/simulations/simulation-console/__tests__/SimulationConsole.integration.test.tsx
+++ b/platform/app/src/components/simulations/simulation-console/__tests__/SimulationConsole.integration.test.tsx
@@ -22,49 +22,53 @@ describe("<SimulationConsole />", () => {
   afterEach(cleanup);
 
   describe("given a completed run with scored criteria", () => {
-    it("shows the score rows", () => {
-      render(
-        <SimulationConsole
-          results={{
-            verdict: Verdict.FAILURE,
-            metCriteria: ["Stayed polite"],
-            unmetCriteria: ["Solved the problem"],
-            reasoning: "The run missed one criterion.",
-          }}
-          status={ScenarioRunStatus.FAILED}
-          durationInMs={6300}
-        />,
-        { wrapper: Wrapper },
-      );
+    describe("when the detail drawer opens", () => {
+      it("shows the score rows", () => {
+        render(
+          <SimulationConsole
+            results={{
+              verdict: Verdict.FAILURE,
+              metCriteria: ["Stayed polite"],
+              unmetCriteria: ["Solved the problem"],
+              reasoning: "The run missed one criterion.",
+            }}
+            status={ScenarioRunStatus.FAILED}
+            durationInMs={6300}
+          />,
+          { wrapper: Wrapper },
+        );
 
-      expect(screen.getByText("Success Criteria:")).toBeInTheDocument();
-      expect(screen.getByText("1/2")).toBeInTheDocument();
-      expect(screen.getByText("Success Rate:")).toBeInTheDocument();
-      expect(screen.getByText("50.0%")).toBeInTheDocument();
+        expect(screen.getByText("Success Criteria:")).toBeInTheDocument();
+        expect(screen.getByText("1/2")).toBeInTheDocument();
+        expect(screen.getByText("Success Rate:")).toBeInTheDocument();
+        expect(screen.getByText("50.0%")).toBeInTheDocument();
+      });
     });
   });
 
   describe("given a completed run with no success criteria", () => {
-    /** @scenario "A run with no success criteria hides misleading score lines" */
-    it("hides the score rows and keeps the duration", () => {
-      render(
-        <SimulationConsole
-          results={{
-            verdict: Verdict.SUCCESS,
-            metCriteria: [],
-            unmetCriteria: [],
-            reasoning: "The scripted run finished successfully.",
-          }}
-          status={ScenarioRunStatus.SUCCESS}
-          durationInMs={6300}
-        />,
-        { wrapper: Wrapper },
-      );
+    describe("when the detail drawer opens", () => {
+      /** @scenario "A run with no success criteria hides misleading score lines" */
+      it("hides the score rows and keeps the duration", () => {
+        render(
+          <SimulationConsole
+            results={{
+              verdict: Verdict.SUCCESS,
+              metCriteria: [],
+              unmetCriteria: [],
+              reasoning: "The scripted run finished successfully.",
+            }}
+            status={ScenarioRunStatus.SUCCESS}
+            durationInMs={6300}
+          />,
+          { wrapper: Wrapper },
+        );
 
-      expect(screen.queryByText("Success Criteria:")).not.toBeInTheDocument();
-      expect(screen.queryByText("Success Rate:")).not.toBeInTheDocument();
-      expect(screen.getByText("Duration:")).toBeInTheDocument();
-      expect(screen.getByText("6.30s")).toBeInTheDocument();
+        expect(screen.queryByText("Success Criteria:")).not.toBeInTheDocument();
+        expect(screen.queryByText("Success Rate:")).not.toBeInTheDocument();
+        expect(screen.getByText("Duration:")).toBeInTheDocument();
+        expect(screen.getByText("6.30s")).toBeInTheDocument();
+      });
     });
   });
 });

--- a/platform/app/src/components/simulations/simulation-console/__tests__/SimulationConsole.integration.test.tsx
+++ b/platform/app/src/components/simulations/simulation-console/__tests__/SimulationConsole.integration.test.tsx
@@ -1,0 +1,70 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Integration tests for the v1 simulation console.
+ *
+ * @see specs/features/scenarios/run-view-side-by-side-layout.feature
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  ScenarioRunStatus,
+  Verdict,
+} from "~/server/scenarios/scenario-event.enums";
+import { SimulationConsole } from "../SimulationConsole";
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <ChakraProvider value={defaultSystem}>{children}</ChakraProvider>
+);
+
+describe("<SimulationConsole />", () => {
+  afterEach(cleanup);
+
+  describe("given a completed run with scored criteria", () => {
+    it("shows the score rows", () => {
+      render(
+        <SimulationConsole
+          results={{
+            verdict: Verdict.FAILURE,
+            metCriteria: ["Stayed polite"],
+            unmetCriteria: ["Solved the problem"],
+            reasoning: "The run missed one criterion.",
+          }}
+          status={ScenarioRunStatus.FAILED}
+          durationInMs={6300}
+        />,
+        { wrapper: Wrapper },
+      );
+
+      expect(screen.getByText("Success Criteria:")).toBeInTheDocument();
+      expect(screen.getByText("1/2")).toBeInTheDocument();
+      expect(screen.getByText("Success Rate:")).toBeInTheDocument();
+      expect(screen.getByText("50.0%")).toBeInTheDocument();
+    });
+  });
+
+  describe("given a completed run with no success criteria", () => {
+    /** @scenario "A run with no success criteria hides misleading score lines" */
+    it("hides the score rows and keeps the duration", () => {
+      render(
+        <SimulationConsole
+          results={{
+            verdict: Verdict.SUCCESS,
+            metCriteria: [],
+            unmetCriteria: [],
+            reasoning: "The scripted run finished successfully.",
+          }}
+          status={ScenarioRunStatus.SUCCESS}
+          durationInMs={6300}
+        />,
+        { wrapper: Wrapper },
+      );
+
+      expect(screen.queryByText("Success Criteria:")).not.toBeInTheDocument();
+      expect(screen.queryByText("Success Rate:")).not.toBeInTheDocument();
+      expect(screen.getByText("Duration:")).toBeInTheDocument();
+      expect(screen.getByText("6.30s")).toBeInTheDocument();
+    });
+  });
+});

--- a/specs/features/scenarios/run-view-side-by-side-layout.feature
+++ b/specs/features/scenarios/run-view-side-by-side-layout.feature
@@ -3,7 +3,7 @@ Feature: Scenario run detail drawer
   I want to see run details in a drawer overlaying the list/grid
   So that I can review criteria, conversation, and actions without leaving the runs view
 
-  # Parity status: 2 of 6 scenarios bound to existing tests.
+  # Parity status: 3 of 7 scenarios bound to existing tests.
   # The remaining 4 @unimplemented scenarios describe shipped behavior
   # that does not yet have an integration test (#3458):
   #   - "Clicking a run opens the detail drawer"
@@ -32,6 +32,14 @@ Feature: Scenario run detail drawer
     When the detail drawer opens for that run
     Then the criteria section shows "0/4 passed"
     And each criterion displays its name and pass/fail indicator
+
+  @integration
+  Scenario: A run with no success criteria hides misleading score lines
+    Given a completed scenario run whose criteria list is empty
+    When the detail drawer opens for that run
+    Then no "Success Criteria:" line is shown
+    And no "Success Rate:" line is shown
+    And the duration is still shown
 
   @integration @unimplemented
   Scenario: Failed criteria show expandable reasoning


### PR DESCRIPTION
## Why

Scripted scenario runs can complete without success criteria. The results console currently renders "Success Criteria: 0/0" and "Success Rate: 0.0%" in the failure color for those runs, making a successful run look failed.

Closes #7662

## What changed

- Hide the criteria count and success-rate rows when a run has no criteria.
- Continue showing the run duration.
- Add a bound feature scenario and component regression coverage.
- Preserve the existing score rows for runs that do have criteria.

## Test plan

- Added a regression test that failed before the component change because "Success Criteria:" was still rendered.
- pnpm --filter @langwatch/web test:component src/components/simulations/simulation-console/__tests__/SimulationConsole.integration.test.tsx --watch=false — 2 passed
- pnpm --filter @langwatch/web check:feature-parity --json — passed; the new scenario is bound
- pnpm --filter @langwatch/web exec biome check src/components/simulations/simulation-console/MetricsSummary.tsx src/components/simulations/simulation-console/__tests__/SimulationConsole.integration.test.tsx — passed
- git diff --check — passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hidden Success Criteria and Success Rate details when a simulation has no criteria.
  * Kept Duration information visible for runs without criteria.

* **Tests**
  * Added coverage for scored runs and runs without success criteria.
  * Updated scenario coverage for the run view’s side-by-side layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->