### PR TITLE
feat(coding-agent): org-key pull-request usage on /api/v1 without a project id

### DIFF
--- a/docs/api-reference/coding-agents/get-pull-request-usage.mdx
+++ b/docs/api-reference/coding-agents/get-pull-request-usage.mdx
@@ -1,0 +1,4 @@
+---
+title: "Get pull request usage"
+openapi: "GET /api/v1/coding-agent/pull-request-usage"
+---

--- a/docs/api-reference/openapiLangWatch.json
+++ b/docs/api-reference/openapiLangWatch.json
@@ -8751,7 +8751,7 @@
       "get": {
         "operationId": "getApiCodingAgentPullRequestUsage",
         "summary": "Get pull request coding agent usage",
-        "description": "Assistant usage for one pull request: sessions, tokens and cost, grouped by contributor and agent, plus per-model totals, over the pull request's whole lifetime rather than a time window. Every row and the totals split cost three ways: the part priced per token, the part a bundled subscription already covers, and the list-price total of both. Per-model totals carry the list price only. Cost is calculated from the tokens the agent reported and LangWatch's model prices, so it estimates spend rather than restating a provider invoice. Requires a personal-project API key; rows appear only for projects the calling user may view, and cost only for those they may price.",
+        "description": "Assistant usage for one pull request: sessions, tokens and cost, grouped by contributor and agent, plus per-model totals, over the pull request's whole lifetime rather than a time window. Every row and the totals split cost three ways: the part priced per token, the part a bundled subscription already covers, and the list-price total of both. Per-model totals carry the list price only. Cost is calculated from the tokens the agent reported and LangWatch's model prices, so it estimates spend rather than restating a provider invoice. Requires a personal-project API key; rows appear only for projects the calling user may view, and cost only for those they may price. Prefer `GET /api/v1/coding-agent/pull-request-usage`, which answers the same question with an organization API key alone and needs no X-Project-Id header.",
         "parameters": [
           {
             "name": "repository",
@@ -9127,6 +9127,312 @@
         "security": [
           {
             "project_api_key": []
+          }
+        ]
+      }
+    },
+    "/api/v1/coding-agent/pull-request-usage": {
+      "get": {
+        "operationId": "getPullRequestUsage",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "pullRequest": {
+                      "type": "object",
+                      "properties": {
+                        "repositoryHost": {
+                          "type": "string"
+                        },
+                        "repositoryFullName": {
+                          "type": "string"
+                        },
+                        "prNumber": {
+                          "type": "number"
+                        },
+                        "headBranch": {
+                          "type": "string"
+                        },
+                        "htmlUrl": {
+                          "type": "string"
+                        },
+                        "state": {
+                          "type": "string"
+                        },
+                        "isDraft": {
+                          "type": "boolean"
+                        },
+                        "authorLogin": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "prCreatedAtMs": {
+                          "type": "number"
+                        },
+                        "prClosedAtMs": {
+                          "type": [
+                            "number",
+                            "null"
+                          ]
+                        },
+                        "prMergedAtMs": {
+                          "type": [
+                            "number",
+                            "null"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "repositoryHost",
+                        "repositoryFullName",
+                        "prNumber",
+                        "headBranch",
+                        "htmlUrl",
+                        "state",
+                        "isDraft",
+                        "authorLogin",
+                        "prCreatedAtMs",
+                        "prClosedAtMs",
+                        "prMergedAtMs"
+                      ]
+                    },
+                    "rows": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "projectId": {
+                            "type": "string"
+                          },
+                          "projectSlug": {
+                            "type": "string"
+                          },
+                          "contributorLabel": {
+                            "type": "string"
+                          },
+                          "contributorIsProject": {
+                            "type": "boolean"
+                          },
+                          "agent": {
+                            "type": "string"
+                          },
+                          "models": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "sessionsCount": {
+                            "type": "number"
+                          },
+                          "inputTokens": {
+                            "type": "number"
+                          },
+                          "outputTokens": {
+                            "type": "number"
+                          },
+                          "cacheReadTokens": {
+                            "type": "number"
+                          },
+                          "cacheCreationTokens": {
+                            "type": "number"
+                          },
+                          "totalTokens": {
+                            "type": "number"
+                          },
+                          "costUsd": {
+                            "type": [
+                              "number",
+                              "null"
+                            ]
+                          },
+                          "billedCostUsd": {
+                            "type": [
+                              "number",
+                              "null"
+                            ]
+                          },
+                          "nonBilledCostUsd": {
+                            "type": [
+                              "number",
+                              "null"
+                            ]
+                          }
+                        },
+                        "required": [
+                          "projectId",
+                          "projectSlug",
+                          "contributorLabel",
+                          "contributorIsProject",
+                          "agent",
+                          "models",
+                          "sessionsCount",
+                          "inputTokens",
+                          "outputTokens",
+                          "cacheReadTokens",
+                          "cacheCreationTokens",
+                          "totalTokens",
+                          "costUsd",
+                          "billedCostUsd",
+                          "nonBilledCostUsd"
+                        ]
+                      }
+                    },
+                    "totals": {
+                      "type": "object",
+                      "properties": {
+                        "sessionsCount": {
+                          "type": "number"
+                        },
+                        "inputTokens": {
+                          "type": "number"
+                        },
+                        "outputTokens": {
+                          "type": "number"
+                        },
+                        "cacheReadTokens": {
+                          "type": "number"
+                        },
+                        "cacheCreationTokens": {
+                          "type": "number"
+                        },
+                        "totalTokens": {
+                          "type": "number"
+                        },
+                        "costUsd": {
+                          "type": [
+                            "number",
+                            "null"
+                          ]
+                        },
+                        "billedCostUsd": {
+                          "type": [
+                            "number",
+                            "null"
+                          ]
+                        },
+                        "nonBilledCostUsd": {
+                          "type": [
+                            "number",
+                            "null"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "sessionsCount",
+                        "inputTokens",
+                        "outputTokens",
+                        "cacheReadTokens",
+                        "cacheCreationTokens",
+                        "totalTokens",
+                        "costUsd",
+                        "billedCostUsd",
+                        "nonBilledCostUsd"
+                      ]
+                    },
+                    "modelBreakdown": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "model": {
+                            "type": "string"
+                          },
+                          "inputTokens": {
+                            "type": "number"
+                          },
+                          "outputTokens": {
+                            "type": "number"
+                          },
+                          "cacheReadTokens": {
+                            "type": "number"
+                          },
+                          "cacheCreationTokens": {
+                            "type": "number"
+                          },
+                          "totalTokens": {
+                            "type": "number"
+                          },
+                          "costUsd": {
+                            "type": [
+                              "number",
+                              "null"
+                            ]
+                          },
+                          "tokensKnown": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "model",
+                          "inputTokens",
+                          "outputTokens",
+                          "cacheReadTokens",
+                          "cacheCreationTokens",
+                          "totalTokens",
+                          "costUsd",
+                          "tokensKnown"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "pullRequest",
+                    "rows",
+                    "totals",
+                    "modelBreakdown"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "description": "Assistant usage for one pull request: sessions, tokens and cost, grouped by contributor and agent, plus per-model totals, over the pull request's whole lifetime rather than a time window. Every row and the totals split cost three ways: the part priced per token, the part a bundled subscription already covers, and the list-price total of both. Per-model totals carry the list price only. Cost is calculated from the tokens the agent reported and LangWatch's model prices, so it estimates spend rather than restating a provider invoice. Authenticate with your own organization API key and nothing else: no project id is sent anywhere. Rows appear only for projects you may view, and cost only for those you may price.",
+        "summary": "Get pull request usage",
+        "tags": [
+          "Coding Agents"
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "repository",
+            "schema": {
+              "type": "string",
+              "pattern": "^[^/\\s]+\\/[^/\\s]+$"
+            },
+            "required": true,
+            "description": "The repository as \"owner/name\"."
+          },
+          {
+            "in": "query",
+            "name": "pullRequest",
+            "schema": {
+              "type": "integer",
+              "exclusiveMinimum": 0
+            },
+            "required": true,
+            "description": "The pull request number."
+          },
+          {
+            "in": "query",
+            "name": "host",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "default": "github.com"
+            },
+            "description": "The GitHub host, for GitHub Enterprise Server instances. Defaults to github.com."
+          }
+        ],
+        "security": [
+          {
+            "admin_api_key": []
           }
         ]
       }

--- a/docs/api-reference/openapiLangWatch.json
+++ b/docs/api-reference/openapiLangWatch.json
@@ -9427,7 +9427,7 @@
               "minLength": 1,
               "default": "github.com"
             },
-            "description": "The GitHub host, for GitHub Enterprise Server instances. Defaults to github.com."
+            "description": "The GitHub host. Defaults to this instance's configured GitHub host, which is github.com unless an operator named a GitHub Enterprise Server."
           }
         ],
         "security": [

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1309,6 +1309,7 @@
             "pages": [
               "api-reference/coding-agents/overview",
               "api-reference/coding-agents/get-pull-request-coding-agent-usage",
+              "api-reference/coding-agents/get-pull-request-usage",
               "api-reference/coding-agents/list-coding-agent-session-events"
             ]
           },

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -67071,6 +67071,15 @@ openapi: "GET /api/coding-agent/pull-request-usage"
 
 ---
 
+# FILE: ./api-reference/coding-agents/get-pull-request-usage.mdx
+
+---
+title: "Get pull request usage"
+openapi: "GET /api/v1/coding-agent/pull-request-usage"
+---
+
+---
+
 # FILE: ./api-reference/coding-agents/list-coding-agent-session-events.mdx
 
 ---

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -934,6 +934,7 @@ For agents: if anything in these docs is wrong, confusing, or fails when you try
 
 - [Overview](https://langwatch.ai/docs/api-reference/coding-agents/overview.md): Read what a coding agent session did and what it cost. Walk one session's events call by call, with the tokens, cost and compactions of each, or roll a whole pull request up into sessions, tokens and cost per project, user and agent.
 - [Get pull request coding agent usage](https://langwatch.ai/docs/api-reference/coding-agents/get-pull-request-coding-agent-usage.md)
+- [Get pull request usage](https://langwatch.ai/docs/api-reference/coding-agents/get-pull-request-usage.md)
 - [List coding agent session events](https://langwatch.ai/docs/api-reference/coding-agents/list-coding-agent-session-events.md)
 
 ## Triggers

--- a/docs/scripts/generate-api-reference-pages.ts
+++ b/docs/scripts/generate-api-reference-pages.ts
@@ -248,7 +248,7 @@ const ENDPOINT_GROUPS: EndpointGroup[] = [
   {
     name: "Coding Agents",
     dirName: "coding-agents",
-    pathPrefixes: ["/api/coding-agent"],
+    pathPrefixes: ["/api/v1/coding-agent", "/api/coding-agent"],
     overviewDescription:
       "Read what a coding agent session did and what it cost. Walk one session's events call by call, with the tokens, cost and compactions of each, or roll a whole pull request up into sessions, tokens and cost per project, user and agent.",
   },

--- a/platform/app/src/app/api/coding-agent/[[...route]]/app.ts
+++ b/platform/app/src/app/api/coding-agent/[[...route]]/app.ts
@@ -7,7 +7,10 @@ import { getApp } from "~/server/app-layer/app";
 import { MAX_SESSION_EVENTS_PAGE_SIZE } from "~/server/app-layer/coding-agent/coding-agent-session.service";
 import type { SessionEventsCursor } from "~/server/app-layer/coding-agent/repositories/coding-agent-session-events.repository";
 import { GithubPullRequestNotMappedError } from "~/server/app-layer/github/errors";
-import { resolveCallerProjectScope } from "~/server/organizations/resolveCallerProjectScope";
+import {
+  type CallerApiKeyCeiling,
+  resolveCallerProjectScope,
+} from "~/server/organizations/resolveCallerProjectScope";
 import { resolveOrganizationId } from "~/server/organizations/resolveOrganizationId";
 import { patchZodOpenapi } from "~/utils/extend-zod-openapi";
 
@@ -348,10 +351,23 @@ secured.access(requires("traces:view")).get(
     // The same permission cut the in-app surfaces resolve, names included: a
     // caller reading this rollup is building something that has to say WHO the
     // usage belongs to, and the agent-reported id it used to get instead
-    // resolved to nobody.
+    // resolved to nobody. A user-bound API key also brings its own binding
+    // ceiling: a deliberately narrowed key reads with its own scope, never
+    // its holder's full one. A legacy project key carries no ceiling by
+    // design, so none is applied for it.
+    const apiKeyId = c.get("apiKeyId");
     const scope = await resolveCallerProjectScope({
       userId: callerUserId,
       organizationId,
+      ...(apiKeyId
+        ? {
+            apiKeyCeiling: {
+              apiKeyId,
+              check: (check: Parameters<CallerApiKeyCeiling["check"]>[0]) =>
+                getApp().permissions.hasApiKeyPermission(check),
+            },
+          }
+        : {}),
     });
 
     const usage =

--- a/platform/app/src/app/api/coding-agent/[[...route]]/app.ts
+++ b/platform/app/src/app/api/coding-agent/[[...route]]/app.ts
@@ -7,13 +7,16 @@ import { getApp } from "~/server/app-layer/app";
 import { MAX_SESSION_EVENTS_PAGE_SIZE } from "~/server/app-layer/coding-agent/coding-agent-session.service";
 import type { SessionEventsCursor } from "~/server/app-layer/coding-agent/repositories/coding-agent-session-events.repository";
 import { GithubPullRequestNotMappedError } from "~/server/app-layer/github/errors";
-import { getGithubHost } from "~/server/app-layer/github/githubHost";
 import { resolveCallerProjectScope } from "~/server/organizations/resolveCallerProjectScope";
 import { resolveOrganizationId } from "~/server/organizations/resolveOrganizationId";
 import { patchZodOpenapi } from "~/utils/extend-zod-openapi";
 
 import { baseResponses } from "../../shared/base-responses";
 import { resolvePersonalCaller } from "../../shared/personal-project-caller";
+import {
+  pullRequestUsageQuerySchema,
+  pullRequestUsageResponseSchema,
+} from "./pull-request-usage-wire";
 
 patchZodOpenapi();
 
@@ -262,92 +265,6 @@ function decodeCursor(raw: string): SessionEventsCursor | null {
   }
 }
 
-// The three cost numbers each row and the totals carry: what a bundled plan
-// already covered, what is priced per token, and the list-price total of both.
-// All three are null together for a project the caller may read but not price.
-const costSplitShape = {
-  costUsd: z.number().nullable(),
-  billedCostUsd: z.number().nullable(),
-  nonBilledCostUsd: z.number().nullable(),
-};
-
-// One contributor's line. A contributor is a project: a personal workspace is
-// named by the person who owns it, a shared one by itself. There is no
-// per-person split inside a shared project, because the only per-person key a
-// session carries is an opaque id the agent reported about itself.
-const usageRowSchema = z.object({
-  projectId: z.string(),
-  projectSlug: z.string(),
-  contributorLabel: z.string(),
-  contributorIsProject: z.boolean(),
-  agent: z.string(),
-  models: z.array(z.string()),
-  sessionsCount: z.number(),
-  inputTokens: z.number(),
-  outputTokens: z.number(),
-  cacheReadTokens: z.number(),
-  cacheCreationTokens: z.number(),
-  totalTokens: z.number(),
-  ...costSplitShape,
-});
-
-const modelUsageSchema = z.object({
-  model: z.string(),
-  inputTokens: z.number(),
-  outputTokens: z.number(),
-  cacheReadTokens: z.number(),
-  cacheCreationTokens: z.number(),
-  totalTokens: z.number(),
-  costUsd: z.number().nullable(),
-  /** False when only the model's name is known: the totals above are not real. */
-  tokensKnown: z.boolean(),
-});
-
-const pullRequestUsageResponseSchema = z.object({
-  pullRequest: z.object({
-    repositoryHost: z.string(),
-    repositoryFullName: z.string(),
-    prNumber: z.number(),
-    headBranch: z.string(),
-    htmlUrl: z.string(),
-    state: z.string(),
-    isDraft: z.boolean(),
-    authorLogin: z.string().nullable(),
-    prCreatedAtMs: z.number(),
-    prClosedAtMs: z.number().nullable(),
-    prMergedAtMs: z.number().nullable(),
-  }),
-  rows: z.array(usageRowSchema),
-  totals: z.object({
-    sessionsCount: z.number(),
-    inputTokens: z.number(),
-    outputTokens: z.number(),
-    cacheReadTokens: z.number(),
-    cacheCreationTokens: z.number(),
-    totalTokens: z.number(),
-    ...costSplitShape,
-  }),
-  modelBreakdown: z.array(modelUsageSchema),
-});
-
-const usageQuerySchema = z.object({
-  /** "owner/name". Case is folded by the mapping store, so either works. */
-  repository: z.string().regex(/^[^/\s]+\/[^/\s]+$/, {
-    message: "repository must be owner/name",
-  }),
-  pullRequest: z.coerce.number().int().positive(),
-  /**
-   * Defaults to the GitHub host this instance is bound to, which is github.com
-   * unless an operator named an Enterprise Server. The published document
-   * states github.com, which is the default every instance has until it names
-   * another host.
-   */
-  host: z
-    .string()
-    .min(1)
-    .default(() => getGithubHost()),
-});
-
 // GET /pull-request-usage: what one pull request cost in assistant usage,
 // across every project of the organization the CALLER may read. Numbers and
 // names only: no session title, no prompt, no file list.
@@ -366,7 +283,10 @@ secured.access(requires("traces:view")).get(
       "model prices, so it estimates spend rather than restating a provider " +
       "invoice. " +
       "Requires a personal-project API key; rows appear only for projects the " +
-      "calling user may view, and cost only for those they may price.",
+      "calling user may view, and cost only for those they may price. " +
+      "Prefer `GET /api/v1/coding-agent/pull-request-usage`, which answers the " +
+      "same question with an organization API key alone and needs no " +
+      "X-Project-Id header.",
     parameters: [
       {
         name: "repository",
@@ -410,7 +330,7 @@ secured.access(requires("traces:view")).get(
       apiKeyUserId: c.get("apiKeyUserId"),
     });
 
-    const query = usageQuerySchema.safeParse({
+    const query = pullRequestUsageQuerySchema.safeParse({
       repository: c.req.query("repository"),
       pullRequest: c.req.query("pullRequest"),
       host: c.req.query("host"),

--- a/platform/app/src/app/api/coding-agent/[[...route]]/app.v1.ts
+++ b/platform/app/src/app/api/coding-agent/[[...route]]/app.v1.ts
@@ -1,0 +1,174 @@
+/**
+ * The coding-agent v1 REST family: `GET /api/v1/coding-agent/pull-request-usage`.
+ *
+ * The pull-request usage rollup answers an ORGANIZATION-wide question — what
+ * one pull request cost across every project the CALLER may read — so this
+ * door authenticates at the organization: an `sk-lw` user-bound API key alone,
+ * with no `X-Project-Id` header and no project named anywhere. The legacy
+ * `/api/coding-agent/pull-request-usage` route answers the same question but
+ * recovers the calling user through their personal workspace's project id,
+ * an indirection the key itself already makes unnecessary.
+ *
+ * Built on `@langwatch/api` with org-key authentication in throwing mode, the
+ * way the management families are, but with no Enterprise plan gate: this read
+ * ships with the product. The per-endpoint permission check is deliberately
+ * absent — the authorization IS the caller's per-project cut
+ * (`resolveCallerProjectScope`), resolved in the handler, because no single
+ * organization-scope permission describes "the projects this member may read":
+ * a member whose only grant is their own personal workspace must still get
+ * their own rollup.
+ *
+ * `GET /sessions/:sessionId/events` stays on the legacy project family only:
+ * it reads one project's data and is correctly addressed by a project
+ * credential, so it does not belong on an organization door.
+ *
+ * @see specs/coding-agent/pull-request-linkage.feature
+ */
+import { auditLog } from "@ee/audit-log/auditLog";
+import { createService } from "@langwatch/api";
+import type { Context } from "hono";
+import type { z } from "zod";
+import { appContextMiddleware } from "~/app/api/middleware/app-context";
+import type { Organization } from "~/generated/prisma/client";
+import {
+  registerMountedRoute,
+  type ServiceEndpointMeta,
+} from "~/server/api/route-mount-registry";
+import { familyFromBasePath, handlerManagedAuth } from "~/server/api/security";
+import { V1_API_VERSION } from "~/server/api/v1/version";
+import { createOrgAuthMiddleware } from "~/server/api-key/auth-middleware";
+import { getApp } from "~/server/app-layer/app";
+import { prisma } from "~/server/db";
+import { resolveCallerProjectScope } from "~/server/organizations/resolveCallerProjectScope";
+
+import { requireUserBoundCaller } from "../../shared/user-bound-key";
+import {
+  pullRequestUsageQuerySchema,
+  pullRequestUsageResponseSchema,
+} from "./pull-request-usage-wire";
+
+const BASE_PATH = "/api/v1/coding-agent";
+
+const service = createService({
+  name: "coding-agent",
+  basePath: BASE_PATH,
+  middleware: [appContextMiddleware],
+  auth: createOrgAuthMiddleware({ prisma, refusals: "throw" }),
+  onRouteMounted: (route) =>
+    registerMountedRoute({
+      route,
+      family: familyFromBasePath(BASE_PATH),
+      scope: "organization",
+      surface: "Coding agent v1",
+    }),
+});
+
+/**
+ * Why the endpoint declares no framework-enforced permission: the handler is
+ * the permission check. Rows appear only for projects where the caller holds
+ * `traces:view`, and money only where they also hold `cost:view` — the same
+ * cut the in-app surfaces resolve, through the same resolver.
+ */
+const callerScopedRead = {
+  meta: {
+    policy: handlerManagedAuth({
+      reason:
+        "authenticated by the organization-key middleware; the handler then " +
+        "resolves the caller's own per-project permission cut " +
+        "(resolveCallerProjectScope), so rows appear only for projects the " +
+        "calling user may view and cost only where they may price",
+      permissions: ["traces:view", "cost:view"],
+      credential: "apiKey",
+    }),
+  } satisfies ServiceEndpointMeta,
+  noPermission: {
+    reason:
+      "no single organization-scope permission describes the caller's " +
+      "readable projects; the handler resolves the per-project cut itself",
+  },
+} as const;
+
+type UsageQuery = z.infer<typeof pullRequestUsageQuerySchema>;
+
+const pullRequestUsageHandler = async (
+  c: Context,
+  { query }: { query: UsageQuery },
+) => {
+  const organization = c.get("organization") as Organization;
+  // The rollup answers with whatever the CALLER may read, so it needs a
+  // person: an organization service key created for no user is refused here.
+  const callerUserId = requireUserBoundCaller({
+    apiKeyUserId: (c.get("apiKeyUserId") as string | null) ?? null,
+  });
+
+  // The same permission cut the in-app surfaces resolve, names included: a
+  // caller reading this rollup is building something that has to say WHO the
+  // usage belongs to.
+  const scope = await resolveCallerProjectScope({
+    userId: callerUserId,
+    organizationId: organization.id,
+  });
+
+  const usage =
+    await getApp().codingAgents.pullRequestUsage.getPullRequestUsage({
+      organizationId: organization.id,
+      repositoryHost: query.host,
+      repositoryFullName: query.repository,
+      prNumber: query.pullRequest,
+      ...scope,
+    });
+
+  // This answer names people, so who read it stays attributable. Awaited
+  // before the answer leaves, so a read is never served unrecorded. Never the
+  // contributors themselves: how many projects fed the rollup says how wide
+  // the read reached without copying the names into a second store that
+  // outlives it.
+  await auditLog({
+    userId: callerUserId,
+    organizationId: organization.id,
+    action: "codingAgents.pullRequestUsage",
+    targetKind: "pullRequest",
+    targetId: `${query.host}/${query.repository}#${query.pullRequest}`,
+    args: {
+      repository: query.repository,
+      host: query.host,
+      pullRequest: query.pullRequest,
+      contributingProjectCount: new Set(usage.rows.map((row) => row.projectId))
+        .size,
+    },
+  });
+
+  return usage;
+};
+
+export const app = service
+  .version(V1_API_VERSION, (v) => {
+    v.get(
+      "/pull-request-usage",
+      {
+        ...callerScopedRead,
+        query: pullRequestUsageQuerySchema,
+        output: pullRequestUsageResponseSchema,
+        description:
+          "Assistant usage for one pull request: sessions, tokens and cost, " +
+          "grouped by contributor and agent, plus per-model totals, " +
+          "over the pull request's whole lifetime rather than a time window. " +
+          "Every row and the totals split cost three ways: the part priced per " +
+          "token, the part a bundled subscription already covers, and the " +
+          "list-price total of both. Per-model totals carry the list price " +
+          "only. Cost is calculated from the tokens the agent reported and " +
+          "LangWatch's model prices, so it estimates spend rather than " +
+          "restating a provider invoice. " +
+          "Authenticate with your own organization API key and nothing else: " +
+          "no project id is sent anywhere. Rows appear only for projects you " +
+          "may view, and cost only for those you may price.",
+        docs: {
+          summary: "Get pull request usage",
+          operationId: "getPullRequestUsage",
+          tags: ["Coding Agents"],
+        },
+      },
+      pullRequestUsageHandler,
+    );
+  })
+  .build();

--- a/platform/app/src/app/api/coding-agent/[[...route]]/app.v1.ts
+++ b/platform/app/src/app/api/coding-agent/[[...route]]/app.v1.ts
@@ -74,9 +74,11 @@ const callerScopedRead = {
     policy: handlerManagedAuth({
       reason:
         "authenticated by the organization-key middleware; the handler then " +
-        "resolves the caller's own per-project permission cut " +
-        "(resolveCallerProjectScope), so rows appear only for projects the " +
-        "calling user may view and cost only where they may price",
+        "resolves the caller's per-project permission cut " +
+        "(resolveCallerProjectScope) intersected with the key's own binding " +
+        "ceiling (hasApiKeyPermission), so rows appear only for projects " +
+        "BOTH the key and its holder may view, and cost only where both may " +
+        "price",
       permissions: ["traces:view", "cost:view"],
       credential: "apiKey",
     }),
@@ -101,12 +103,16 @@ const pullRequestUsageHandler = async (
     apiKeyUserId: (c.get("apiKeyUserId") as string | null) ?? null,
   });
 
-  // The same permission cut the in-app surfaces resolve, names included: a
-  // caller reading this rollup is building something that has to say WHO the
-  // usage belongs to.
+  // The same permission cut the in-app surfaces resolve, names included —
+  // intersected with the KEY's own binding ceiling: a deliberately narrowed
+  // key must read with its own scope, never its holder's full one.
   const scope = await resolveCallerProjectScope({
     userId: callerUserId,
     organizationId: organization.id,
+    apiKeyCeiling: {
+      apiKeyId: c.get("apiKeyId") as string,
+      check: (check) => getApp().permissions.hasApiKeyPermission(check),
+    },
   });
 
   const usage =

--- a/platform/app/src/app/api/coding-agent/[[...route]]/pull-request-usage-wire.ts
+++ b/platform/app/src/app/api/coding-agent/[[...route]]/pull-request-usage-wire.ts
@@ -1,0 +1,109 @@
+/**
+ * The pull-request usage wire shape, shared by the two doors that answer it:
+ * the legacy personal-workspace route (`GET /api/coding-agent/pull-request-usage`)
+ * and the v1 organization-key route
+ * (`GET /api/v1/coding-agent/pull-request-usage`). One module so the published
+ * schemas cannot drift apart — both doors answer the same rollup, and only the
+ * credential that opens them differs.
+ *
+ * @see specs/coding-agent/pull-request-linkage.feature
+ */
+import { z } from "zod";
+
+import { getGithubHost } from "~/server/app-layer/github/githubHost";
+
+// The three cost numbers each row and the totals carry: what a bundled plan
+// already covered, what is priced per token, and the list-price total of both.
+// All three are null together for a project the caller may read but not price.
+const costSplitShape = {
+  costUsd: z.number().nullable(),
+  billedCostUsd: z.number().nullable(),
+  nonBilledCostUsd: z.number().nullable(),
+};
+
+// One contributor's line. A contributor is a project: a personal workspace is
+// named by the person who owns it, a shared one by itself. There is no
+// per-person split inside a shared project, because the only per-person key a
+// session carries is an opaque id the agent reported about itself.
+const usageRowSchema = z.object({
+  projectId: z.string(),
+  projectSlug: z.string(),
+  contributorLabel: z.string(),
+  contributorIsProject: z.boolean(),
+  agent: z.string(),
+  models: z.array(z.string()),
+  sessionsCount: z.number(),
+  inputTokens: z.number(),
+  outputTokens: z.number(),
+  cacheReadTokens: z.number(),
+  cacheCreationTokens: z.number(),
+  totalTokens: z.number(),
+  ...costSplitShape,
+});
+
+const modelUsageSchema = z.object({
+  model: z.string(),
+  inputTokens: z.number(),
+  outputTokens: z.number(),
+  cacheReadTokens: z.number(),
+  cacheCreationTokens: z.number(),
+  totalTokens: z.number(),
+  costUsd: z.number().nullable(),
+  /** False when only the model's name is known: the totals above are not real. */
+  tokensKnown: z.boolean(),
+});
+
+export const pullRequestUsageResponseSchema = z.object({
+  pullRequest: z.object({
+    repositoryHost: z.string(),
+    repositoryFullName: z.string(),
+    prNumber: z.number(),
+    headBranch: z.string(),
+    htmlUrl: z.string(),
+    state: z.string(),
+    isDraft: z.boolean(),
+    authorLogin: z.string().nullable(),
+    prCreatedAtMs: z.number(),
+    prClosedAtMs: z.number().nullable(),
+    prMergedAtMs: z.number().nullable(),
+  }),
+  rows: z.array(usageRowSchema),
+  totals: z.object({
+    sessionsCount: z.number(),
+    inputTokens: z.number(),
+    outputTokens: z.number(),
+    cacheReadTokens: z.number(),
+    cacheCreationTokens: z.number(),
+    totalTokens: z.number(),
+    ...costSplitShape,
+  }),
+  modelBreakdown: z.array(modelUsageSchema),
+});
+
+export const pullRequestUsageQuerySchema = z.object({
+  /** "owner/name". Case is folded by the mapping store, so either works. */
+  repository: z
+    .string()
+    .regex(/^[^/\s]+\/[^/\s]+$/, {
+      message: "repository must be owner/name",
+    })
+    .describe('The repository as "owner/name".'),
+  pullRequest: z.coerce
+    .number()
+    .int()
+    .positive()
+    .describe("The pull request number."),
+  /**
+   * Defaults to the GitHub host this instance is bound to, which is github.com
+   * unless an operator named an Enterprise Server. The published document
+   * states github.com, which is the default every instance has until it names
+   * another host.
+   */
+  host: z
+    .string()
+    .min(1)
+    .default(() => getGithubHost())
+    .describe(
+      "The GitHub host, for GitHub Enterprise Server instances. Defaults to github.com.",
+    ),
+});

--- a/platform/app/src/app/api/coding-agent/[[...route]]/pull-request-usage-wire.ts
+++ b/platform/app/src/app/api/coding-agent/[[...route]]/pull-request-usage-wire.ts
@@ -104,6 +104,6 @@ export const pullRequestUsageQuerySchema = z.object({
     .min(1)
     .default(() => getGithubHost())
     .describe(
-      "The GitHub host, for GitHub Enterprise Server instances. Defaults to github.com.",
+      "The GitHub host. Defaults to this instance's configured GitHub host, which is github.com unless an operator named a GitHub Enterprise Server.",
     ),
 });

--- a/platform/app/src/app/api/coding-agent/__tests__/pull-request-usage-v1-api.integration.test.ts
+++ b/platform/app/src/app/api/coding-agent/__tests__/pull-request-usage-v1-api.integration.test.ts
@@ -1,0 +1,377 @@
+/**
+ * @vitest-environment node
+ * @integration
+ *
+ * The v1 organization-key door on the pull-request usage rollup:
+ * `GET /api/v1/coding-agent/pull-request-usage`. A user-bound organization API
+ * key answers with the caller's organization-wide rollup and names no project
+ * anywhere in the request; an organization service key (no user) and a legacy
+ * project key are each refused with their own stable code; a key from another
+ * organization learns nothing about a pull request mapped elsewhere.
+ *
+ * Every refusal is asserted on its code rather than its sentence. The code is
+ * the contract a CLI or an agent branches on; the sentence beside it is copy
+ * and will change.
+ *
+ * @see specs/coding-agent/pull-request-linkage.feature
+ */
+import { generate } from "@langwatch/ksuid";
+import { nanoid } from "nanoid";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  type Organization,
+  OrganizationUserRole,
+  RoleBindingScopeType,
+  type Team,
+  TeamUserRole,
+} from "~/generated/prisma/client";
+import { ApiKeyService } from "~/server/api-key/api-key.service";
+import { globalForApp, resetApp } from "~/server/app-layer/app";
+import { CodingAgentSessionService } from "~/server/app-layer/coding-agent/coding-agent-session.service";
+import { CodingAgentSessionsListService } from "~/server/app-layer/coding-agent/coding-agent-sessions-list.service";
+import { PullRequestUsageService } from "~/server/app-layer/coding-agent/pull-request-usage.service";
+import { NullCodingAgentSessionRepository } from "~/server/app-layer/coding-agent/repositories/coding-agent-session.repository";
+import { NullCodingAgentSessionEventsRepository } from "~/server/app-layer/coding-agent/repositories/coding-agent-session-events.repository";
+import { NullCodingAgentTraceSessionRepository } from "~/server/app-layer/coding-agent/repositories/coding-agent-trace-session.repository";
+import { NullSessionMetricSeriesRepository } from "~/server/app-layer/coding-agent/repositories/session-metric-series.repository";
+import { GithubInstallationsService } from "~/server/app-layer/github/github-installations.service";
+import { GithubAppTokenService } from "~/server/app-layer/github/githubAppToken";
+import { NullGithubInstallationsRepository } from "~/server/app-layer/github/repositories/github-installations.repository";
+import { PrismaGithubPullRequestsRepository } from "~/server/app-layer/github/repositories/github-pull-requests.prisma.repository";
+import { createTestApp } from "~/server/app-layer/presets";
+import { NullGithubPullRequestLookup } from "~/server/app-layer/traces/session-groups.pull-request-link";
+import { prisma } from "~/server/db";
+import { cleanupTestRows } from "~/test-utils/cleanupTestRows";
+import { KSUID_RESOURCES } from "~/utils/constants";
+import publishedSpec from "../../openapiLangWatch.json";
+import { app } from "../[[...route]]/app.v1";
+
+const ns = nanoid(8);
+const USAGE_SPEC_PATH = "/api/v1/coding-agent/pull-request-usage";
+const USAGE_PATH = `${USAGE_SPEC_PATH}?repository=acme/widgets&pullRequest=1`;
+
+let organization: Organization;
+let team: Team;
+let callerUserId: string;
+/** A user-bound key for the caller, carrying an org-wide admin binding. */
+let callerToken: string;
+/** An organization service key created for no user. */
+let serviceToken: string;
+/** A legacy project API key, which carries neither organization nor user. */
+let legacyProjectKey: string;
+/** Another organization entirely, whose key must learn nothing here. */
+let otherOrganization: Organization;
+let otherOrgToken: string;
+let otherOrgUserId: string;
+
+const bearer = (token: string) => ({ Authorization: `Bearer ${token}` });
+
+/** One organization with a user-bound admin key, mirroring real onboarding. */
+async function seedCallerOrganization(): Promise<void> {
+  organization = await prisma.organization.create({
+    data: { name: `pr-usage-v1-${ns}`, slug: `--test-org-v1-${ns}` },
+  });
+  team = await prisma.team.create({
+    data: {
+      name: `pr-usage-v1-${ns}`,
+      slug: `--test-team-v1-${ns}`,
+      organizationId: organization.id,
+    },
+  });
+
+  const caller = await prisma.user.create({
+    data: { name: "Caller", email: `caller-v1-${ns}@example.com` },
+  });
+  callerUserId = caller.id;
+  await prisma.organizationUser.create({
+    data: {
+      userId: callerUserId,
+      organizationId: organization.id,
+      role: OrganizationUserRole.ADMIN,
+    },
+  });
+  await prisma.roleBinding.create({
+    data: {
+      id: generate(KSUID_RESOURCES.ROLE_BINDING).toString(),
+      organizationId: organization.id,
+      userId: callerUserId,
+      role: TeamUserRole.ADMIN,
+      scopeType: RoleBindingScopeType.ORGANIZATION,
+      scopeId: organization.id,
+    },
+  });
+
+  legacyProjectKey = `sk-lw-${nanoid(48)}`;
+  await prisma.project.create({
+    data: {
+      id: `project_${nanoid()}`,
+      name: "Caller Workspace",
+      slug: `--test-caller-v1-${ns}`,
+      language: "typescript",
+      framework: "other",
+      apiKey: legacyProjectKey,
+      teamId: team.id,
+      isPersonal: true,
+      ownerUserId: callerUserId,
+    },
+  });
+
+  const orgAdminBinding = {
+    role: TeamUserRole.ADMIN,
+    scopeType: RoleBindingScopeType.ORGANIZATION,
+    scopeId: organization.id,
+  };
+  callerToken = (
+    await ApiKeyService.create(prisma).create({
+      name: `pr-usage-v1-caller-${ns}`,
+      userId: callerUserId,
+      createdByUserId: callerUserId,
+      organizationId: organization.id,
+      permissionMode: "all",
+      bindings: [orgAdminBinding],
+    })
+  ).token;
+  serviceToken = (
+    await ApiKeyService.create(prisma).create({
+      name: `pr-usage-v1-service-${ns}`,
+      userId: null,
+      createdByUserId: null,
+      organizationId: organization.id,
+      permissionMode: "all",
+      bindings: [orgAdminBinding],
+    })
+  ).token;
+
+  await prisma.githubPullRequest.create({
+    data: {
+      organizationId: organization.id,
+      repositoryHost: "github.com",
+      repositoryFullName: "acme/widgets",
+      headBranch: "feat/linkage",
+      prNumber: 1,
+      htmlUrl: "https://github.com/acme/widgets/pull/1",
+      title: "Link sessions to pull requests",
+      state: "open",
+      isDraft: false,
+      authorLogin: "acme-dev",
+      prCreatedAt: new Date("2026-07-01T09:00:00Z"),
+    },
+  });
+}
+
+/** A second organization whose user-bound key must see nothing of the first. */
+async function seedOtherOrganization(): Promise<void> {
+  otherOrganization = await prisma.organization.create({
+    data: { name: `pr-usage-v1-other-${ns}`, slug: `--test-other-org-${ns}` },
+  });
+  const otherUser = await prisma.user.create({
+    data: { name: "Elsewhere", email: `elsewhere-v1-${ns}@example.com` },
+  });
+  otherOrgUserId = otherUser.id;
+  await prisma.organizationUser.create({
+    data: {
+      userId: otherUser.id,
+      organizationId: otherOrganization.id,
+      role: OrganizationUserRole.ADMIN,
+    },
+  });
+  // The key-creation ceiling compares against role bindings, so the admin
+  // grant has to exist as one before an admin-bound key can be minted.
+  await prisma.roleBinding.create({
+    data: {
+      id: generate(KSUID_RESOURCES.ROLE_BINDING).toString(),
+      organizationId: otherOrganization.id,
+      userId: otherUser.id,
+      role: TeamUserRole.ADMIN,
+      scopeType: RoleBindingScopeType.ORGANIZATION,
+      scopeId: otherOrganization.id,
+    },
+  });
+  otherOrgToken = (
+    await ApiKeyService.create(prisma).create({
+      name: `pr-usage-v1-other-${ns}`,
+      userId: otherUser.id,
+      createdByUserId: otherUser.id,
+      organizationId: otherOrganization.id,
+      permissionMode: "all",
+      bindings: [
+        {
+          role: TeamUserRole.ADMIN,
+          scopeType: RoleBindingScopeType.ORGANIZATION,
+          scopeId: otherOrganization.id,
+        },
+      ],
+    })
+  ).token;
+}
+
+beforeAll(async () => {
+  await seedCallerOrganization();
+  await seedOtherOrganization();
+
+  // The route reads through the App. The pull-request mapping is real (the
+  // Prisma repository above the row seeded per organization); sessions stay
+  // null, which is what makes the answered rollup empty and its audit record
+  // say zero projects contributed.
+  const nullSessions = new NullCodingAgentSessionRepository();
+  const nullSessionEvents = new NullCodingAgentSessionEventsRepository();
+  const sessions = new CodingAgentSessionService({
+    sessions: nullSessions,
+    traceSessions: new NullCodingAgentTraceSessionRepository(),
+    metricSeries: new NullSessionMetricSeriesRepository(),
+    sessionEvents: nullSessionEvents,
+  });
+  globalForApp.__langwatch_app = createTestApp({
+    codingAgents: {
+      sessions,
+      // The REST surface under test never reads it; the App's shape does.
+      sessionsList: new CodingAgentSessionsListService({
+        sessions,
+        pullRequests: new NullGithubPullRequestLookup(),
+        resolveOrganizationId: async () => organization.id,
+      }),
+      pullRequestUsage: new PullRequestUsageService({
+        pullRequests: new PrismaGithubPullRequestsRepository(prisma),
+        sessions: nullSessions,
+        personalSessions: sessions,
+        sessionEvents: nullSessionEvents,
+        installations: new GithubInstallationsService(
+          new NullGithubInstallationsRepository(),
+          new GithubAppTokenService("", "", null),
+        ),
+        resolveOrganizationId: async () => organization.id,
+        isSourceNonBillable: async () => false,
+      }),
+    },
+  });
+});
+
+afterAll(async () => {
+  await resetApp();
+  await cleanupTestRows(prisma, [
+    ["auditLog", { organizationId: organization.id }],
+    ["githubPullRequest", { organizationId: organization.id }],
+    ["roleBinding", { organizationId: organization.id }],
+    ["roleBinding", { organizationId: otherOrganization.id }],
+    ["apiKey", { organizationId: organization.id }],
+    ["apiKey", { organizationId: otherOrganization.id }],
+    ["project", { teamId: team.id }],
+    ["organizationUser", { organizationId: organization.id }],
+    ["organizationUser", { organizationId: otherOrganization.id }],
+    ["user", { id: { in: [callerUserId, otherOrgUserId] } }],
+    ["team", { id: team.id }],
+    ["organization", { id: organization.id }],
+    ["organization", { id: otherOrganization.id }],
+  ]);
+});
+
+describe("Feature: Pull request usage v1 REST API", () => {
+  describe("given a user-bound organization API key", () => {
+    describe("when the usage is read with no project id anywhere", () => {
+      /** @scenario "An organization key reads pull request usage without naming a project" */
+      it("answers the caller's organization-wide rollup and records the read", async () => {
+        const res = await app.request(USAGE_PATH, {
+          headers: bearer(callerToken),
+        });
+
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.pullRequest.repositoryFullName).toBe("acme/widgets");
+        expect(Array.isArray(body.rows)).toBe(true);
+        expect(body.totals).toMatchObject({ sessionsCount: 0 });
+
+        const recorded = await prisma.auditLog.findFirst({
+          where: {
+            organizationId: organization.id,
+            action: "codingAgents.pullRequestUsage",
+          },
+        });
+        expect(recorded?.userId).toBe(callerUserId);
+        expect(recorded?.targetKind).toBe("pullRequest");
+        expect(recorded?.targetId).toBe("github.com/acme/widgets#1");
+        expect(recorded?.args).toMatchObject({
+          repository: "acme/widgets",
+          pullRequest: 1,
+          contributingProjectCount: 0,
+        });
+      });
+    });
+  });
+
+  describe("given an organization service key created for no user", () => {
+    describe("when the usage is read", () => {
+      /** @scenario "An organization key with no bound user cannot read pull request usage" */
+      it("refuses with the user-bound key required code", async () => {
+        const res = await app.request(USAGE_PATH, {
+          headers: bearer(serviceToken),
+        });
+
+        expect(res.status).toBe(400);
+        const body = await res.json();
+        expect(body.code).toBe("user_bound_key_required");
+      });
+    });
+  });
+
+  describe("given a legacy project API key", () => {
+    describe("when the usage is read", () => {
+      /** @scenario "A legacy project key cannot reach the v1 usage read" */
+      it("refuses with the credential class mismatch code, naming the class to swap to", async () => {
+        const res = await app.request(USAGE_PATH, {
+          headers: bearer(legacyProjectKey),
+        });
+
+        expect(res.status).toBe(401);
+        const body = await res.json();
+        expect(body.code).toBe("credential_class_mismatch");
+        expect(body.meta).toMatchObject({
+          required: "organization_api_key",
+          presented: "project_api_key",
+        });
+      });
+    });
+  });
+
+  describe("given a user-bound key from another organization", () => {
+    describe("when the usage is read for a pull request mapped elsewhere", () => {
+      /** @scenario "An organization key from another organization learns nothing" */
+      it("answers the not-mapped failure without confirming the mapping exists elsewhere", async () => {
+        const res = await app.request(USAGE_PATH, {
+          headers: bearer(otherOrgToken),
+        });
+
+        expect(res.status).toBe(404);
+        const body = await res.json();
+        expect(body.code).toBe("github_pr_not_mapped");
+        // Nothing on the wire names the organization the mapping belongs to.
+        expect(JSON.stringify(body)).not.toContain(organization.id);
+      });
+    });
+  });
+
+  describe("given the published API document", () => {
+    const operation = (): {
+      security?: unknown;
+      responses?: Record<string, unknown>;
+    } => {
+      const paths = (
+        publishedSpec as unknown as {
+          paths?: Record<string, { get?: object }>;
+        }
+      ).paths;
+      const op = paths?.[USAGE_SPEC_PATH]?.get;
+      if (!op) {
+        throw new Error(
+          `GET ${USAGE_SPEC_PATH} is missing from the generated OpenAPI document`,
+        );
+      }
+      return op;
+    };
+
+    it("publishes the route under the organization API key scheme", () => {
+      // The stamped security is what tells an integrator which key to send:
+      // the organization credential, never a project one.
+      expect(operation().security).toEqual([{ admin_api_key: [] }]);
+    });
+  });
+});

--- a/platform/app/src/app/api/coding-agent/__tests__/pull-request-usage-v1-api.integration.test.ts
+++ b/platform/app/src/app/api/coding-agent/__tests__/pull-request-usage-v1-api.integration.test.ts
@@ -5,265 +5,54 @@
  * The v1 organization-key door on the pull-request usage rollup:
  * `GET /api/v1/coding-agent/pull-request-usage`. A user-bound organization API
  * key answers with the caller's organization-wide rollup and names no project
- * anywhere in the request; an organization service key (no user) and a legacy
- * project key are each refused with their own stable code; a key from another
- * organization learns nothing about a pull request mapped elsewhere.
+ * anywhere in the request — and the answer is cut by BOTH halves of the
+ * credential: the holder's own permissions and the key's binding ceiling. A
+ * deliberately narrowed key reads with its own scope, never its holder's.
  *
- * Every refusal is asserted on its code rather than its sentence. The code is
- * the contract a CLI or an agent branches on; the sentence beside it is copy
- * and will change.
+ * The refusal cases live in pull-request-usage-v1-refusals.integration.test.ts;
+ * the shared fixture in pullRequestUsageV1Harness.ts.
  *
  * @see specs/coding-agent/pull-request-linkage.feature
  */
-import { generate } from "@langwatch/ksuid";
 import { nanoid } from "nanoid";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import {
-  type Organization,
-  OrganizationUserRole,
-  RoleBindingScopeType,
-  type Team,
-  TeamUserRole,
-} from "~/generated/prisma/client";
-import { ApiKeyService } from "~/server/api-key/api-key.service";
-import { globalForApp, resetApp } from "~/server/app-layer/app";
-import { CodingAgentSessionService } from "~/server/app-layer/coding-agent/coding-agent-session.service";
-import { CodingAgentSessionsListService } from "~/server/app-layer/coding-agent/coding-agent-sessions-list.service";
-import { PullRequestUsageService } from "~/server/app-layer/coding-agent/pull-request-usage.service";
-import { NullCodingAgentSessionRepository } from "~/server/app-layer/coding-agent/repositories/coding-agent-session.repository";
-import { NullCodingAgentSessionEventsRepository } from "~/server/app-layer/coding-agent/repositories/coding-agent-session-events.repository";
-import { NullCodingAgentTraceSessionRepository } from "~/server/app-layer/coding-agent/repositories/coding-agent-trace-session.repository";
-import { NullSessionMetricSeriesRepository } from "~/server/app-layer/coding-agent/repositories/session-metric-series.repository";
-import { GithubInstallationsService } from "~/server/app-layer/github/github-installations.service";
-import { GithubAppTokenService } from "~/server/app-layer/github/githubAppToken";
-import { NullGithubInstallationsRepository } from "~/server/app-layer/github/repositories/github-installations.repository";
-import { PrismaGithubPullRequestsRepository } from "~/server/app-layer/github/repositories/github-pull-requests.prisma.repository";
-import { createTestApp } from "~/server/app-layer/presets";
-import { NullGithubPullRequestLookup } from "~/server/app-layer/traces/session-groups.pull-request-link";
+import { resetApp } from "~/server/app-layer/app";
 import { prisma } from "~/server/db";
-import { cleanupTestRows } from "~/test-utils/cleanupTestRows";
-import { KSUID_RESOURCES } from "~/utils/constants";
 import publishedSpec from "../../openapiLangWatch.json";
 import { app } from "../[[...route]]/app.v1";
+import {
+  bearer,
+  cleanupPullRequestUsageV1Fixture,
+  type PullRequestUsageV1Fixture,
+  seedPullRequestUsageV1Fixture,
+  USAGE_PATH,
+  USAGE_SPEC_PATH,
+} from "./pullRequestUsageV1Harness";
+import { installPullRequestUsageTestApp } from "./pullRequestUsageV1TestApp";
 
 const ns = nanoid(8);
-const USAGE_SPEC_PATH = "/api/v1/coding-agent/pull-request-usage";
-const USAGE_PATH = `${USAGE_SPEC_PATH}?repository=acme/widgets&pullRequest=1`;
 
-let organization: Organization;
-let team: Team;
-let callerUserId: string;
-/** A user-bound key for the caller, carrying an org-wide admin binding. */
-let callerToken: string;
-/** An organization service key created for no user. */
-let serviceToken: string;
-/** A legacy project API key, which carries neither organization nor user. */
-let legacyProjectKey: string;
-/** Another organization entirely, whose key must learn nothing here. */
-let otherOrganization: Organization;
-let otherOrgToken: string;
-let otherOrgUserId: string;
-
-const bearer = (token: string) => ({ Authorization: `Bearer ${token}` });
-
-/** One organization with a user-bound admin key, mirroring real onboarding. */
-async function seedCallerOrganization(): Promise<void> {
-  organization = await prisma.organization.create({
-    data: { name: `pr-usage-v1-${ns}`, slug: `--test-org-v1-${ns}` },
-  });
-  team = await prisma.team.create({
-    data: {
-      name: `pr-usage-v1-${ns}`,
-      slug: `--test-team-v1-${ns}`,
-      organizationId: organization.id,
-    },
-  });
-
-  const caller = await prisma.user.create({
-    data: { name: "Caller", email: `caller-v1-${ns}@example.com` },
-  });
-  callerUserId = caller.id;
-  await prisma.organizationUser.create({
-    data: {
-      userId: callerUserId,
-      organizationId: organization.id,
-      role: OrganizationUserRole.ADMIN,
-    },
-  });
-  await prisma.roleBinding.create({
-    data: {
-      id: generate(KSUID_RESOURCES.ROLE_BINDING).toString(),
-      organizationId: organization.id,
-      userId: callerUserId,
-      role: TeamUserRole.ADMIN,
-      scopeType: RoleBindingScopeType.ORGANIZATION,
-      scopeId: organization.id,
-    },
-  });
-
-  legacyProjectKey = `sk-lw-${nanoid(48)}`;
-  await prisma.project.create({
-    data: {
-      id: `project_${nanoid()}`,
-      name: "Caller Workspace",
-      slug: `--test-caller-v1-${ns}`,
-      language: "typescript",
-      framework: "other",
-      apiKey: legacyProjectKey,
-      teamId: team.id,
-      isPersonal: true,
-      ownerUserId: callerUserId,
-    },
-  });
-
-  const orgAdminBinding = {
-    role: TeamUserRole.ADMIN,
-    scopeType: RoleBindingScopeType.ORGANIZATION,
-    scopeId: organization.id,
-  };
-  callerToken = (
-    await ApiKeyService.create(prisma).create({
-      name: `pr-usage-v1-caller-${ns}`,
-      userId: callerUserId,
-      createdByUserId: callerUserId,
-      organizationId: organization.id,
-      permissionMode: "all",
-      bindings: [orgAdminBinding],
-    })
-  ).token;
-  serviceToken = (
-    await ApiKeyService.create(prisma).create({
-      name: `pr-usage-v1-service-${ns}`,
-      userId: null,
-      createdByUserId: null,
-      organizationId: organization.id,
-      permissionMode: "all",
-      bindings: [orgAdminBinding],
-    })
-  ).token;
-
-  await prisma.githubPullRequest.create({
-    data: {
-      organizationId: organization.id,
-      repositoryHost: "github.com",
-      repositoryFullName: "acme/widgets",
-      headBranch: "feat/linkage",
-      prNumber: 1,
-      htmlUrl: "https://github.com/acme/widgets/pull/1",
-      title: "Link sessions to pull requests",
-      state: "open",
-      isDraft: false,
-      authorLogin: "acme-dev",
-      prCreatedAt: new Date("2026-07-01T09:00:00Z"),
-    },
-  });
-}
-
-/** A second organization whose user-bound key must see nothing of the first. */
-async function seedOtherOrganization(): Promise<void> {
-  otherOrganization = await prisma.organization.create({
-    data: { name: `pr-usage-v1-other-${ns}`, slug: `--test-other-org-${ns}` },
-  });
-  const otherUser = await prisma.user.create({
-    data: { name: "Elsewhere", email: `elsewhere-v1-${ns}@example.com` },
-  });
-  otherOrgUserId = otherUser.id;
-  await prisma.organizationUser.create({
-    data: {
-      userId: otherUser.id,
-      organizationId: otherOrganization.id,
-      role: OrganizationUserRole.ADMIN,
-    },
-  });
-  // The key-creation ceiling compares against role bindings, so the admin
-  // grant has to exist as one before an admin-bound key can be minted.
-  await prisma.roleBinding.create({
-    data: {
-      id: generate(KSUID_RESOURCES.ROLE_BINDING).toString(),
-      organizationId: otherOrganization.id,
-      userId: otherUser.id,
-      role: TeamUserRole.ADMIN,
-      scopeType: RoleBindingScopeType.ORGANIZATION,
-      scopeId: otherOrganization.id,
-    },
-  });
-  otherOrgToken = (
-    await ApiKeyService.create(prisma).create({
-      name: `pr-usage-v1-other-${ns}`,
-      userId: otherUser.id,
-      createdByUserId: otherUser.id,
-      organizationId: otherOrganization.id,
-      permissionMode: "all",
-      bindings: [
-        {
-          role: TeamUserRole.ADMIN,
-          scopeType: RoleBindingScopeType.ORGANIZATION,
-          scopeId: otherOrganization.id,
-        },
-      ],
-    })
-  ).token;
-}
+let fixture: PullRequestUsageV1Fixture;
 
 beforeAll(async () => {
-  await seedCallerOrganization();
-  await seedOtherOrganization();
-
-  // The route reads through the App. The pull-request mapping is real (the
-  // Prisma repository above the row seeded per organization); sessions stay
-  // null, which is what makes the answered rollup empty and its audit record
-  // say zero projects contributed.
-  const nullSessions = new NullCodingAgentSessionRepository();
-  const nullSessionEvents = new NullCodingAgentSessionEventsRepository();
-  const sessions = new CodingAgentSessionService({
-    sessions: nullSessions,
-    traceSessions: new NullCodingAgentTraceSessionRepository(),
-    metricSeries: new NullSessionMetricSeriesRepository(),
-    sessionEvents: nullSessionEvents,
-  });
-  globalForApp.__langwatch_app = createTestApp({
-    codingAgents: {
-      sessions,
-      // The REST surface under test never reads it; the App's shape does.
-      sessionsList: new CodingAgentSessionsListService({
-        sessions,
-        pullRequests: new NullGithubPullRequestLookup(),
-        resolveOrganizationId: async () => organization.id,
-      }),
-      pullRequestUsage: new PullRequestUsageService({
-        pullRequests: new PrismaGithubPullRequestsRepository(prisma),
-        sessions: nullSessions,
-        personalSessions: sessions,
-        sessionEvents: nullSessionEvents,
-        installations: new GithubInstallationsService(
-          new NullGithubInstallationsRepository(),
-          new GithubAppTokenService("", "", null),
-        ),
-        resolveOrganizationId: async () => organization.id,
-        isSourceNonBillable: async () => false,
-      }),
-    },
-  });
+  fixture = await seedPullRequestUsageV1Fixture({ ns });
+  installPullRequestUsageTestApp(fixture);
 });
 
 afterAll(async () => {
   await resetApp();
-  await cleanupTestRows(prisma, [
-    ["auditLog", { organizationId: organization.id }],
-    ["githubPullRequest", { organizationId: organization.id }],
-    ["roleBinding", { organizationId: organization.id }],
-    ["roleBinding", { organizationId: otherOrganization.id }],
-    ["apiKey", { organizationId: organization.id }],
-    ["apiKey", { organizationId: otherOrganization.id }],
-    ["project", { teamId: team.id }],
-    ["organizationUser", { organizationId: organization.id }],
-    ["organizationUser", { organizationId: otherOrganization.id }],
-    ["user", { id: { in: [callerUserId, otherOrgUserId] } }],
-    ["team", { id: team.id }],
-    ["organization", { id: organization.id }],
-    ["organization", { id: otherOrganization.id }],
-  ]);
+  await cleanupPullRequestUsageV1Fixture(fixture);
 });
+
+/** The latest audit row this suite's organization recorded. */
+const latestAuditRow = () =>
+  prisma.auditLog.findFirst({
+    where: {
+      organizationId: fixture.organization.id,
+      action: "codingAgents.pullRequestUsage",
+    },
+    orderBy: { createdAt: "desc" },
+  });
 
 describe("Feature: Pull request usage v1 REST API", () => {
   describe("given a user-bound organization API key", () => {
@@ -271,107 +60,98 @@ describe("Feature: Pull request usage v1 REST API", () => {
       /** @scenario "An organization key reads pull request usage without naming a project" */
       it("answers the caller's organization-wide rollup and records the read", async () => {
         const res = await app.request(USAGE_PATH, {
-          headers: bearer(callerToken),
+          headers: bearer({ token: fixture.callerToken }),
         });
 
         expect(res.status).toBe(200);
         const body = await res.json();
         expect(body.pullRequest.repositoryFullName).toBe("acme/widgets");
-        expect(Array.isArray(body.rows)).toBe(true);
-        expect(body.totals).toMatchObject({ sessionsCount: 0 });
+        expect(
+          body.rows.map((row: { projectId: string }) => row.projectId).sort(),
+        ).toEqual([fixture.projectAId, fixture.projectBId].sort());
+        expect(body.totals.sessionsCount).toBe(2);
 
-        const recorded = await prisma.auditLog.findFirst({
-          where: {
-            organizationId: organization.id,
-            action: "codingAgents.pullRequestUsage",
-          },
-        });
-        expect(recorded?.userId).toBe(callerUserId);
+        const recorded = await latestAuditRow();
+        expect(recorded?.userId).toBe(fixture.callerUserId);
         expect(recorded?.targetKind).toBe("pullRequest");
         expect(recorded?.targetId).toBe("github.com/acme/widgets#1");
         expect(recorded?.args).toMatchObject({
           repository: "acme/widgets",
           pullRequest: 1,
-          contributingProjectCount: 0,
+          contributingProjectCount: 2,
         });
       });
     });
   });
 
-  describe("given an organization service key created for no user", () => {
-    describe("when the usage is read", () => {
-      /** @scenario "An organization key with no bound user cannot read pull request usage" */
-      it("refuses with the user-bound key required code", async () => {
+  describe("given the same holder's key bound to one project alone", () => {
+    describe("when the usage is read with the narrowed key", () => {
+      /** @scenario "A narrowed key reads with its own scope, not its holder's" */
+      it("answers only the bound project, though the holder may view both", async () => {
         const res = await app.request(USAGE_PATH, {
-          headers: bearer(serviceToken),
+          headers: bearer({ token: fixture.narrowedToken }),
         });
 
-        expect(res.status).toBe(400);
+        expect(res.status).toBe(200);
         const body = await res.json();
-        expect(body.code).toBe("user_bound_key_required");
-      });
-    });
-  });
-
-  describe("given a legacy project API key", () => {
-    describe("when the usage is read", () => {
-      /** @scenario "A legacy project key cannot reach the v1 usage read" */
-      it("refuses with the credential class mismatch code, naming the class to swap to", async () => {
-        const res = await app.request(USAGE_PATH, {
-          headers: bearer(legacyProjectKey),
-        });
-
-        expect(res.status).toBe(401);
-        const body = await res.json();
-        expect(body.code).toBe("credential_class_mismatch");
-        expect(body.meta).toMatchObject({
-          required: "organization_api_key",
-          presented: "project_api_key",
+        expect(
+          body.rows.map((row: { projectId: string }) => row.projectId),
+        ).toEqual([fixture.projectAId]);
+        // The excluded project appears nowhere in the whole answer: not as a
+        // row, not in a label, not in a slug.
+        expect(JSON.stringify(body)).not.toContain(fixture.projectBId);
+        expect((await latestAuditRow())?.args).toMatchObject({
+          contributingProjectCount: 1,
         });
       });
     });
   });
 
-  describe("given a user-bound key from another organization", () => {
-    describe("when the usage is read for a pull request mapped elsewhere", () => {
-      /** @scenario "An organization key from another organization learns nothing" */
-      it("answers the not-mapped failure without confirming the mapping exists elsewhere", async () => {
+  describe("given a key whose project binding carries no cost permission", () => {
+    describe("when the usage is read with that key", () => {
+      /** @scenario "A key whose binding lacks the cost grant reads tokens with no cost" */
+      it("answers the bound project's tokens with every cost absent", async () => {
         const res = await app.request(USAGE_PATH, {
-          headers: bearer(otherOrgToken),
+          headers: bearer({ token: fixture.viewerToken }),
         });
 
-        expect(res.status).toBe(404);
+        expect(res.status).toBe(200);
         const body = await res.json();
-        expect(body.code).toBe("github_pr_not_mapped");
-        // Nothing on the wire names the organization the mapping belongs to.
-        expect(JSON.stringify(body)).not.toContain(organization.id);
+        expect(body.rows).toHaveLength(1);
+        expect(body.rows[0]).toMatchObject({
+          projectId: fixture.projectAId,
+          costUsd: null,
+          billedCostUsd: null,
+          nonBilledCostUsd: null,
+        });
+        expect(body.rows[0].totalTokens).toBeGreaterThan(0);
+        expect(body.totals.costUsd).toBeNull();
       });
     });
   });
 
   describe("given the published API document", () => {
-    const operation = (): {
-      security?: unknown;
-      responses?: Record<string, unknown>;
-    } => {
-      const paths = (
-        publishedSpec as unknown as {
-          paths?: Record<string, { get?: object }>;
+    describe("when the operation is inspected", () => {
+      const operation = (): { security?: unknown } => {
+        const paths = (
+          publishedSpec as unknown as {
+            paths?: Record<string, { get?: object }>;
+          }
+        ).paths;
+        const op = paths?.[USAGE_SPEC_PATH]?.get;
+        if (!op) {
+          throw new Error(
+            `GET ${USAGE_SPEC_PATH} is missing from the generated OpenAPI document`,
+          );
         }
-      ).paths;
-      const op = paths?.[USAGE_SPEC_PATH]?.get;
-      if (!op) {
-        throw new Error(
-          `GET ${USAGE_SPEC_PATH} is missing from the generated OpenAPI document`,
-        );
-      }
-      return op;
-    };
+        return op;
+      };
 
-    it("publishes the route under the organization API key scheme", () => {
-      // The stamped security is what tells an integrator which key to send:
-      // the organization credential, never a project one.
-      expect(operation().security).toEqual([{ admin_api_key: [] }]);
+      it("publishes the route under the organization API key scheme", () => {
+        // The stamped security is what tells an integrator which key to send:
+        // the organization credential, never a project one.
+        expect(operation().security).toEqual([{ admin_api_key: [] }]);
+      });
     });
   });
 });

--- a/platform/app/src/app/api/coding-agent/__tests__/pull-request-usage-v1-refusals.integration.test.ts
+++ b/platform/app/src/app/api/coding-agent/__tests__/pull-request-usage-v1-refusals.integration.test.ts
@@ -1,0 +1,96 @@
+/**
+ * @vitest-environment node
+ * @integration
+ *
+ * The refusals the v1 pull-request usage door answers with, each on its own
+ * stable code: an organization service key (no user) and a legacy project key
+ * are turned away before anything is read, and a key from another
+ * organization learns nothing about a pull request mapped elsewhere.
+ *
+ * Every refusal is asserted on its code rather than its sentence. The code is
+ * the contract a CLI or an agent branches on; the sentence beside it is copy
+ * and will change. The golden-path and key-ceiling cases live in
+ * pull-request-usage-v1-api.integration.test.ts; the shared fixture in
+ * pullRequestUsageV1Harness.ts.
+ *
+ * @see specs/coding-agent/pull-request-linkage.feature
+ */
+import { nanoid } from "nanoid";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { resetApp } from "~/server/app-layer/app";
+import { app } from "../[[...route]]/app.v1";
+import {
+  bearer,
+  cleanupPullRequestUsageV1Fixture,
+  type PullRequestUsageV1Fixture,
+  seedPullRequestUsageV1Fixture,
+  USAGE_PATH,
+} from "./pullRequestUsageV1Harness";
+import { installPullRequestUsageTestApp } from "./pullRequestUsageV1TestApp";
+
+const ns = nanoid(8);
+
+let fixture: PullRequestUsageV1Fixture;
+
+beforeAll(async () => {
+  fixture = await seedPullRequestUsageV1Fixture({ ns });
+  installPullRequestUsageTestApp(fixture);
+});
+
+afterAll(async () => {
+  await resetApp();
+  await cleanupPullRequestUsageV1Fixture(fixture);
+});
+
+describe("Feature: Pull request usage v1 REST API refusals", () => {
+  describe("given an organization service key created for no user", () => {
+    describe("when the usage is read", () => {
+      /** @scenario "An organization key with no bound user cannot read pull request usage" */
+      it("refuses with the user-bound key required code", async () => {
+        const res = await app.request(USAGE_PATH, {
+          headers: bearer({ token: fixture.serviceToken }),
+        });
+
+        expect(res.status).toBe(400);
+        const body = await res.json();
+        expect(body.code).toBe("user_bound_key_required");
+      });
+    });
+  });
+
+  describe("given a legacy project API key", () => {
+    describe("when the usage is read", () => {
+      /** @scenario "A legacy project key cannot reach the v1 usage read" */
+      it("refuses with the credential class mismatch code, naming the class to swap to", async () => {
+        const res = await app.request(USAGE_PATH, {
+          headers: bearer({ token: fixture.legacyProjectKey }),
+        });
+
+        expect(res.status).toBe(401);
+        const body = await res.json();
+        expect(body.code).toBe("credential_class_mismatch");
+        expect(body.meta).toMatchObject({
+          required: "organization_api_key",
+          presented: "project_api_key",
+        });
+      });
+    });
+  });
+
+  describe("given a user-bound key from another organization", () => {
+    describe("when the usage is read for a pull request mapped elsewhere", () => {
+      /** @scenario "An organization key from another organization learns nothing" */
+      it("answers the not-mapped failure without confirming the mapping exists elsewhere", async () => {
+        const res = await app.request(USAGE_PATH, {
+          headers: bearer({ token: fixture.otherOrgToken }),
+        });
+
+        expect(res.status).toBe(404);
+        const body = await res.json();
+        expect(body.code).toBe("github_pr_not_mapped");
+        // Nothing on the wire names the organization the mapping belongs to.
+        expect(JSON.stringify(body)).not.toContain(fixture.organization.id);
+      });
+    });
+  });
+});

--- a/platform/app/src/app/api/coding-agent/__tests__/pullRequestUsageV1Harness.ts
+++ b/platform/app/src/app/api/coding-agent/__tests__/pullRequestUsageV1Harness.ts
@@ -1,0 +1,278 @@
+/**
+ * Shared fixture for the v1 pull-request usage REST suites.
+ *
+ * One organization with two shared projects and a spread of credentials — a
+ * full org-admin key, two deliberately narrowed keys, a service key, a legacy
+ * project key — plus a second organization whose key must learn nothing here.
+ * The App the suites read through is installed by
+ * pullRequestUsageV1TestApp.ts.
+ *
+ * @see specs/coding-agent/pull-request-linkage.feature
+ */
+import { generate } from "@langwatch/ksuid";
+import { nanoid } from "nanoid";
+import {
+  type Organization,
+  OrganizationUserRole,
+  RoleBindingScopeType,
+  type Team,
+  TeamUserRole,
+} from "~/generated/prisma/client";
+import { ApiKeyService } from "~/server/api-key/api-key.service";
+import { prisma } from "~/server/db";
+import {
+  type CleanupEntry,
+  cleanupTestRows,
+} from "~/test-utils/cleanupTestRows";
+import { KSUID_RESOURCES } from "~/utils/constants";
+
+export const USAGE_SPEC_PATH = "/api/v1/coding-agent/pull-request-usage";
+export const USAGE_PATH = `${USAGE_SPEC_PATH}?repository=acme/widgets&pullRequest=1`;
+
+export const bearer = ({ token }: { token: string }) => ({
+  Authorization: `Bearer ${token}`,
+});
+
+export interface PullRequestUsageV1Fixture {
+  organization: Organization;
+  team: Team;
+  callerUserId: string;
+  /** Two shared projects the caller may view through the org-admin binding. */
+  projectAId: string;
+  projectBId: string;
+  /** A user-bound key carrying an org-wide admin binding. */
+  callerToken: string;
+  /** The same holder's key, bound to project A alone. */
+  narrowedToken: string;
+  /** The same holder's key, bound to project A with a role that cannot price. */
+  viewerToken: string;
+  /** An organization service key created for no user. */
+  serviceToken: string;
+  /** A legacy project API key, carrying neither organization nor user. */
+  legacyProjectKey: string;
+  /** Another organization entirely, whose key must learn nothing here. */
+  otherOrganization: Organization;
+  otherOrgUserId: string;
+  otherOrgToken: string;
+}
+
+const project = ({
+  ns,
+  name,
+  teamId,
+}: Record<"ns" | "name" | "teamId", string>) => ({
+  id: `project_${nanoid()}`,
+  name,
+  slug: `--test-${name.toLowerCase().replaceAll(" ", "-")}-${ns}`,
+  language: "typescript",
+  framework: "other",
+  apiKey: `sk-lw-${nanoid(48)}`,
+  teamId,
+  isPersonal: false,
+  ownerUserId: null,
+});
+
+interface KeyBinding {
+  role: TeamUserRole;
+  scopeType: RoleBindingScopeType;
+  scopeId: string;
+}
+
+const orgAdminBinding = (organizationId: string): KeyBinding => ({
+  role: TeamUserRole.ADMIN,
+  scopeType: RoleBindingScopeType.ORGANIZATION,
+  scopeId: organizationId,
+});
+
+/** One admin user in an organization, with the role binding key minting reads. */
+async function seedAdminUser({
+  ns,
+  label,
+  organizationId,
+}: Record<"ns" | "label" | "organizationId", string>): Promise<string> {
+  const user = await prisma.user.create({
+    data: { name: label, email: `${label}-${ns}@example.com` },
+  });
+  await prisma.organizationUser.create({
+    data: {
+      userId: user.id,
+      organizationId,
+      role: OrganizationUserRole.ADMIN,
+    },
+  });
+  await prisma.roleBinding.create({
+    data: {
+      id: generate(KSUID_RESOURCES.ROLE_BINDING).toString(),
+      organizationId,
+      userId: user.id,
+      ...orgAdminBinding(organizationId),
+    },
+  });
+  return user.id;
+}
+
+async function mintKey({
+  ns,
+  name,
+  userId,
+  organizationId,
+  binding,
+}: {
+  ns: string;
+  name: string;
+  userId: string | null;
+  organizationId: string;
+  binding: KeyBinding;
+}): Promise<string> {
+  const created = await ApiKeyService.create(prisma).create({
+    name: `${name}-${ns}`,
+    userId,
+    createdByUserId: userId,
+    organizationId,
+    permissionMode: "all",
+    bindings: [binding],
+  });
+  return created.token;
+}
+
+export async function seedPullRequestUsageV1Fixture({
+  ns,
+}: {
+  ns: string;
+}): Promise<PullRequestUsageV1Fixture> {
+  const organization = await prisma.organization.create({
+    data: { name: `pr-usage-v1-${ns}`, slug: `--test-org-v1-${ns}` },
+  });
+  const team = await prisma.team.create({
+    data: {
+      name: `pr-usage-v1-${ns}`,
+      slug: `--test-team-v1-${ns}`,
+      organizationId: organization.id,
+    },
+  });
+  const callerUserId = await seedAdminUser({
+    ns,
+    label: "caller-v1",
+    organizationId: organization.id,
+  });
+
+  const projectA = await prisma.project.create({
+    data: project({ ns, name: "Alpha", teamId: team.id }),
+  });
+  const projectB = await prisma.project.create({
+    data: project({ ns, name: "Beta", teamId: team.id }),
+  });
+
+  await prisma.githubPullRequest.create({
+    data: {
+      organizationId: organization.id,
+      repositoryHost: "github.com",
+      repositoryFullName: "acme/widgets",
+      headBranch: "feat/linkage",
+      prNumber: 1,
+      htmlUrl: "https://github.com/acme/widgets/pull/1",
+      title: "Link sessions to pull requests",
+      state: "open",
+      isDraft: false,
+      authorLogin: "acme-dev",
+      prCreatedAt: new Date("2026-07-01T09:00:00Z"),
+    },
+  });
+
+  const keyArgs = { ns, organizationId: organization.id };
+  const otherOrganization = await prisma.organization.create({
+    data: { name: `pr-usage-v1-other-${ns}`, slug: `--test-other-org-${ns}` },
+  });
+  const otherOrgUserId = await seedAdminUser({
+    ns,
+    label: "elsewhere-v1",
+    organizationId: otherOrganization.id,
+  });
+
+  return {
+    organization,
+    team,
+    callerUserId,
+    projectAId: projectA.id,
+    projectBId: projectB.id,
+    callerToken: await mintKey({
+      ...keyArgs,
+      name: "pr-usage-v1-caller",
+      userId: callerUserId,
+      binding: orgAdminBinding(organization.id),
+    }),
+    narrowedToken: await mintKey({
+      ...keyArgs,
+      name: "pr-usage-v1-narrowed",
+      userId: callerUserId,
+      binding: {
+        role: TeamUserRole.ADMIN,
+        scopeType: RoleBindingScopeType.PROJECT,
+        scopeId: projectA.id,
+      },
+    }),
+    viewerToken: await mintKey({
+      ...keyArgs,
+      name: "pr-usage-v1-viewer",
+      userId: callerUserId,
+      binding: {
+        role: TeamUserRole.VIEWER,
+        scopeType: RoleBindingScopeType.PROJECT,
+        scopeId: projectA.id,
+      },
+    }),
+    serviceToken: await mintKey({
+      ...keyArgs,
+      name: "pr-usage-v1-service",
+      userId: null,
+      binding: orgAdminBinding(organization.id),
+    }),
+    legacyProjectKey: projectA.apiKey,
+    otherOrganization,
+    otherOrgUserId,
+    otherOrgToken: await mintKey({
+      ns,
+      name: "pr-usage-v1-other",
+      userId: otherOrgUserId,
+      organizationId: otherOrganization.id,
+      binding: orgAdminBinding(otherOrganization.id),
+    }),
+  };
+}
+
+/**
+ * Removes what the seed created. Guarded per identifier: a failed `beforeAll`
+ * leaves some of them unassigned, and the cleanup must then skip their rows
+ * rather than dereference undefined and mask the setup error.
+ */
+export async function cleanupPullRequestUsageV1Fixture(
+  fixture: Partial<PullRequestUsageV1Fixture> | undefined,
+): Promise<void> {
+  const organizationIds = [
+    fixture?.organization?.id,
+    fixture?.otherOrganization?.id,
+  ].filter((id): id is string => id !== undefined);
+  const userIds = [fixture?.callerUserId, fixture?.otherOrgUserId].filter(
+    (id): id is string => id !== undefined,
+  );
+  const teamId = fixture?.team?.id;
+
+  // Bindings before keys: a key-scoped RoleBinding requires its ApiKey, so
+  // deleting the key first is refused outright. Every entry names only rows
+  // whose identifier the seed actually assigned.
+  const entries: CleanupEntry[] = organizationIds.flatMap<CleanupEntry>(
+    (organizationId) => [
+      ["auditLog", { organizationId }],
+      ["githubPullRequest", { organizationId }],
+      ["roleBinding", { organizationId }],
+      ["apiKey", { organizationId }],
+      ["organizationUser", { organizationId }],
+    ],
+  );
+  if (teamId) entries.push(["project", { teamId }]);
+  if (userIds.length > 0) entries.push(["user", { id: { in: userIds } }]);
+  if (teamId) entries.push(["team", { id: teamId }]);
+  for (const id of organizationIds) entries.push(["organization", { id }]);
+
+  await cleanupTestRows(prisma, entries);
+}

--- a/platform/app/src/app/api/coding-agent/__tests__/pullRequestUsageV1TestApp.ts
+++ b/platform/app/src/app/api/coding-agent/__tests__/pullRequestUsageV1TestApp.ts
@@ -1,0 +1,109 @@
+/**
+ * The App the v1 pull-request usage suites read through.
+ *
+ * Installed with a sessions store that answers one static session per project
+ * THE READ IS PERMITTED TO ASK ABOUT (`listByRepositoryBranch` is called with
+ * the resolved `permittedProjectIds`), which is what makes the key-ceiling cut
+ * observable on the wire: a project outside the caller's scope contributes no
+ * row because it was never read. The fixture itself is seeded by
+ * pullRequestUsageV1Harness.ts.
+ */
+import { globalForApp } from "~/server/app-layer/app";
+import { CodingAgentSessionService } from "~/server/app-layer/coding-agent/coding-agent-session.service";
+import { CodingAgentSessionsListService } from "~/server/app-layer/coding-agent/coding-agent-sessions-list.service";
+import { PullRequestUsageService } from "~/server/app-layer/coding-agent/pull-request-usage.service";
+import {
+  type CodingAgentBranchSessionRow,
+  type CodingAgentSessionRepository,
+  NullCodingAgentSessionRepository,
+} from "~/server/app-layer/coding-agent/repositories/coding-agent-session.repository";
+import { NullCodingAgentSessionEventsRepository } from "~/server/app-layer/coding-agent/repositories/coding-agent-session-events.repository";
+import { NullCodingAgentTraceSessionRepository } from "~/server/app-layer/coding-agent/repositories/coding-agent-trace-session.repository";
+import { NullSessionMetricSeriesRepository } from "~/server/app-layer/coding-agent/repositories/session-metric-series.repository";
+import { GithubInstallationsService } from "~/server/app-layer/github/github-installations.service";
+import { GithubAppTokenService } from "~/server/app-layer/github/githubAppToken";
+import { NullGithubInstallationsRepository } from "~/server/app-layer/github/repositories/github-installations.repository";
+import { PrismaGithubPullRequestsRepository } from "~/server/app-layer/github/repositories/github-pull-requests.prisma.repository";
+import { createTestApp } from "~/server/app-layer/presets";
+import { NullGithubPullRequestLookup } from "~/server/app-layer/traces/session-groups.pull-request-link";
+import { prisma } from "~/server/db";
+import type { PullRequestUsageV1Fixture } from "./pullRequestUsageV1Harness";
+
+/**
+ * A sessions store answering one static session per project asked about.
+ * `listByRepositoryBranch` receives the caller's resolved
+ * `permittedProjectIds` as `tenantIds`, so what comes back IS the scope cut.
+ */
+function staticBranchSessions(
+  tenantIds: string[],
+): CodingAgentSessionRepository {
+  const base = new NullCodingAgentSessionRepository();
+  return {
+    upsert: base.upsert.bind(base),
+    findBySessionId: base.findBySessionId.bind(base),
+    findBySessionIdWithApplied: base.findBySessionIdWithApplied.bind(base),
+    findManyRecent: base.findManyRecent.bind(base),
+    listByRepositoryBranch: async (params) =>
+      tenantIds
+        .filter((tenantId) => params.tenantIds.includes(tenantId))
+        .map(
+          (tenantId): CodingAgentBranchSessionRow => ({
+            sessionId: `session-${tenantId}`,
+            tenantId,
+            startedAtMs: Date.now() - 60_000,
+            lastEventOccurredAtMs: Date.now() - 30_000,
+            inputTokens: 100,
+            outputTokens: 50,
+            cacheReadTokens: 10,
+            cacheCreationTokens: 5,
+            costUsd: 1.25,
+            agent: "claude-code",
+            models: ["gpt-5-mini"],
+            userId: "agent-reported-user",
+            gitBranch: "feat/linkage",
+            gitBranches: ["feat/linkage"],
+            title: "",
+          }),
+        ),
+  };
+}
+
+/** Installs the App the routes read, with sessions for the two projects. */
+export function installPullRequestUsageTestApp(
+  fixture: PullRequestUsageV1Fixture,
+): void {
+  const staticSessions = staticBranchSessions([
+    fixture.projectAId,
+    fixture.projectBId,
+  ]);
+  const nullSessionEvents = new NullCodingAgentSessionEventsRepository();
+  const sessions = new CodingAgentSessionService({
+    sessions: staticSessions,
+    traceSessions: new NullCodingAgentTraceSessionRepository(),
+    metricSeries: new NullSessionMetricSeriesRepository(),
+    sessionEvents: nullSessionEvents,
+  });
+  globalForApp.__langwatch_app = createTestApp({
+    codingAgents: {
+      sessions,
+      // The REST surface under test never reads it; the App's shape does.
+      sessionsList: new CodingAgentSessionsListService({
+        sessions,
+        pullRequests: new NullGithubPullRequestLookup(),
+        resolveOrganizationId: async () => fixture.organization.id,
+      }),
+      pullRequestUsage: new PullRequestUsageService({
+        pullRequests: new PrismaGithubPullRequestsRepository(prisma),
+        sessions: staticSessions,
+        personalSessions: sessions,
+        sessionEvents: nullSessionEvents,
+        installations: new GithubInstallationsService(
+          new NullGithubInstallationsRepository(),
+          new GithubAppTokenService("", "", null),
+        ),
+        resolveOrganizationId: async () => fixture.organization.id,
+        isSourceNonBillable: async () => false,
+      }),
+    },
+  });
+}

--- a/platform/app/src/app/api/openapiLangWatch.json
+++ b/platform/app/src/app/api/openapiLangWatch.json
@@ -8751,7 +8751,7 @@
       "get": {
         "operationId": "getApiCodingAgentPullRequestUsage",
         "summary": "Get pull request coding agent usage",
-        "description": "Assistant usage for one pull request: sessions, tokens and cost, grouped by contributor and agent, plus per-model totals, over the pull request's whole lifetime rather than a time window. Every row and the totals split cost three ways: the part priced per token, the part a bundled subscription already covers, and the list-price total of both. Per-model totals carry the list price only. Cost is calculated from the tokens the agent reported and LangWatch's model prices, so it estimates spend rather than restating a provider invoice. Requires a personal-project API key; rows appear only for projects the calling user may view, and cost only for those they may price.",
+        "description": "Assistant usage for one pull request: sessions, tokens and cost, grouped by contributor and agent, plus per-model totals, over the pull request's whole lifetime rather than a time window. Every row and the totals split cost three ways: the part priced per token, the part a bundled subscription already covers, and the list-price total of both. Per-model totals carry the list price only. Cost is calculated from the tokens the agent reported and LangWatch's model prices, so it estimates spend rather than restating a provider invoice. Requires a personal-project API key; rows appear only for projects the calling user may view, and cost only for those they may price. Prefer `GET /api/v1/coding-agent/pull-request-usage`, which answers the same question with an organization API key alone and needs no X-Project-Id header.",
         "parameters": [
           {
             "name": "repository",
@@ -9127,6 +9127,312 @@
         "security": [
           {
             "project_api_key": []
+          }
+        ]
+      }
+    },
+    "/api/v1/coding-agent/pull-request-usage": {
+      "get": {
+        "operationId": "getPullRequestUsage",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "pullRequest": {
+                      "type": "object",
+                      "properties": {
+                        "repositoryHost": {
+                          "type": "string"
+                        },
+                        "repositoryFullName": {
+                          "type": "string"
+                        },
+                        "prNumber": {
+                          "type": "number"
+                        },
+                        "headBranch": {
+                          "type": "string"
+                        },
+                        "htmlUrl": {
+                          "type": "string"
+                        },
+                        "state": {
+                          "type": "string"
+                        },
+                        "isDraft": {
+                          "type": "boolean"
+                        },
+                        "authorLogin": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "prCreatedAtMs": {
+                          "type": "number"
+                        },
+                        "prClosedAtMs": {
+                          "type": [
+                            "number",
+                            "null"
+                          ]
+                        },
+                        "prMergedAtMs": {
+                          "type": [
+                            "number",
+                            "null"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "repositoryHost",
+                        "repositoryFullName",
+                        "prNumber",
+                        "headBranch",
+                        "htmlUrl",
+                        "state",
+                        "isDraft",
+                        "authorLogin",
+                        "prCreatedAtMs",
+                        "prClosedAtMs",
+                        "prMergedAtMs"
+                      ]
+                    },
+                    "rows": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "projectId": {
+                            "type": "string"
+                          },
+                          "projectSlug": {
+                            "type": "string"
+                          },
+                          "contributorLabel": {
+                            "type": "string"
+                          },
+                          "contributorIsProject": {
+                            "type": "boolean"
+                          },
+                          "agent": {
+                            "type": "string"
+                          },
+                          "models": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "sessionsCount": {
+                            "type": "number"
+                          },
+                          "inputTokens": {
+                            "type": "number"
+                          },
+                          "outputTokens": {
+                            "type": "number"
+                          },
+                          "cacheReadTokens": {
+                            "type": "number"
+                          },
+                          "cacheCreationTokens": {
+                            "type": "number"
+                          },
+                          "totalTokens": {
+                            "type": "number"
+                          },
+                          "costUsd": {
+                            "type": [
+                              "number",
+                              "null"
+                            ]
+                          },
+                          "billedCostUsd": {
+                            "type": [
+                              "number",
+                              "null"
+                            ]
+                          },
+                          "nonBilledCostUsd": {
+                            "type": [
+                              "number",
+                              "null"
+                            ]
+                          }
+                        },
+                        "required": [
+                          "projectId",
+                          "projectSlug",
+                          "contributorLabel",
+                          "contributorIsProject",
+                          "agent",
+                          "models",
+                          "sessionsCount",
+                          "inputTokens",
+                          "outputTokens",
+                          "cacheReadTokens",
+                          "cacheCreationTokens",
+                          "totalTokens",
+                          "costUsd",
+                          "billedCostUsd",
+                          "nonBilledCostUsd"
+                        ]
+                      }
+                    },
+                    "totals": {
+                      "type": "object",
+                      "properties": {
+                        "sessionsCount": {
+                          "type": "number"
+                        },
+                        "inputTokens": {
+                          "type": "number"
+                        },
+                        "outputTokens": {
+                          "type": "number"
+                        },
+                        "cacheReadTokens": {
+                          "type": "number"
+                        },
+                        "cacheCreationTokens": {
+                          "type": "number"
+                        },
+                        "totalTokens": {
+                          "type": "number"
+                        },
+                        "costUsd": {
+                          "type": [
+                            "number",
+                            "null"
+                          ]
+                        },
+                        "billedCostUsd": {
+                          "type": [
+                            "number",
+                            "null"
+                          ]
+                        },
+                        "nonBilledCostUsd": {
+                          "type": [
+                            "number",
+                            "null"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "sessionsCount",
+                        "inputTokens",
+                        "outputTokens",
+                        "cacheReadTokens",
+                        "cacheCreationTokens",
+                        "totalTokens",
+                        "costUsd",
+                        "billedCostUsd",
+                        "nonBilledCostUsd"
+                      ]
+                    },
+                    "modelBreakdown": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "model": {
+                            "type": "string"
+                          },
+                          "inputTokens": {
+                            "type": "number"
+                          },
+                          "outputTokens": {
+                            "type": "number"
+                          },
+                          "cacheReadTokens": {
+                            "type": "number"
+                          },
+                          "cacheCreationTokens": {
+                            "type": "number"
+                          },
+                          "totalTokens": {
+                            "type": "number"
+                          },
+                          "costUsd": {
+                            "type": [
+                              "number",
+                              "null"
+                            ]
+                          },
+                          "tokensKnown": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "model",
+                          "inputTokens",
+                          "outputTokens",
+                          "cacheReadTokens",
+                          "cacheCreationTokens",
+                          "totalTokens",
+                          "costUsd",
+                          "tokensKnown"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "pullRequest",
+                    "rows",
+                    "totals",
+                    "modelBreakdown"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "description": "Assistant usage for one pull request: sessions, tokens and cost, grouped by contributor and agent, plus per-model totals, over the pull request's whole lifetime rather than a time window. Every row and the totals split cost three ways: the part priced per token, the part a bundled subscription already covers, and the list-price total of both. Per-model totals carry the list price only. Cost is calculated from the tokens the agent reported and LangWatch's model prices, so it estimates spend rather than restating a provider invoice. Authenticate with your own organization API key and nothing else: no project id is sent anywhere. Rows appear only for projects you may view, and cost only for those you may price.",
+        "summary": "Get pull request usage",
+        "tags": [
+          "Coding Agents"
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "repository",
+            "schema": {
+              "type": "string",
+              "pattern": "^[^/\\s]+\\/[^/\\s]+$"
+            },
+            "required": true,
+            "description": "The repository as \"owner/name\"."
+          },
+          {
+            "in": "query",
+            "name": "pullRequest",
+            "schema": {
+              "type": "integer",
+              "exclusiveMinimum": 0
+            },
+            "required": true,
+            "description": "The pull request number."
+          },
+          {
+            "in": "query",
+            "name": "host",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "default": "github.com"
+            },
+            "description": "The GitHub host, for GitHub Enterprise Server instances. Defaults to github.com."
+          }
+        ],
+        "security": [
+          {
+            "admin_api_key": []
           }
         ]
       }

--- a/platform/app/src/app/api/openapiLangWatch.json
+++ b/platform/app/src/app/api/openapiLangWatch.json
@@ -9427,7 +9427,7 @@
               "minLength": 1,
               "default": "github.com"
             },
-            "description": "The GitHub host, for GitHub Enterprise Server instances. Defaults to github.com."
+            "description": "The GitHub host. Defaults to this instance's configured GitHub host, which is github.com unless an operator named a GitHub Enterprise Server."
           }
         ],
         "security": [

--- a/platform/app/src/app/api/shared/user-bound-key.ts
+++ b/platform/app/src/app/api/shared/user-bound-key.ts
@@ -1,0 +1,52 @@
+/**
+ * Who is behind an organization-scoped API key.
+ *
+ * Some organization-level reads answer for the CALLER rather than for the
+ * organization: the coding-agent pull-request usage rollup is the caller's own
+ * permission cut across the organization's projects. An `sk-lw` key created
+ * for a user carries that user (`apiKeyUserId`); an organization service key —
+ * a provisioning or automation credential created with no user — authenticates
+ * fine but answers for nobody, so there is no caller to cut the answer by.
+ *
+ * Handled rather than a plain `Error` (ADR-045): we know exactly what is wrong
+ * and the caller has one step to take, which is to send a key created for
+ * their own user.
+ */
+import { HandledError } from "@langwatch/handled-error";
+
+import { remediation } from "~/server/app-layer/error-remediation";
+
+/** The calling organization key names no user to answer for. */
+export class UserBoundKeyRequiredError extends HandledError {
+  declare readonly code: "user_bound_key_required";
+
+  constructor(options: { reasons?: readonly Error[] } = {}) {
+    super(
+      "user_bound_key_required",
+      "This endpoint answers for the calling user, so it requires an API key created for a user. The key sent is an organization service key that belongs to no user.",
+      {
+        httpStatus: 400,
+        fault: "customer",
+        ...remediation("user_bound_key_required"),
+        ...options,
+      },
+    );
+    this.name = "UserBoundKeyRequiredError";
+  }
+}
+
+/**
+ * The user an organization credential acts as.
+ *
+ * @throws {UserBoundKeyRequiredError} when the key carries no user.
+ */
+export function requireUserBoundCaller({
+  apiKeyUserId,
+}: {
+  apiKeyUserId: string | null;
+}): string {
+  if (!apiKeyUserId) {
+    throw new UserBoundKeyRequiredError();
+  }
+  return apiKeyUserId;
+}

--- a/platform/app/src/features/errors/logic/codes.ts
+++ b/platform/app/src/features/errors/logic/codes.ts
@@ -382,6 +382,7 @@ export const APP_ERROR_CODES = [
   // and the scan is right to insist it be listed here as well.
   "unauthorized",
   "usage_report_failed",
+  "user_bound_key_required",
   "user_not_in_organization",
   "user_to_impersonate_not_found",
   // Raised by the shared package rather than an app-level subclass:

--- a/platform/app/src/features/errors/logic/presentation.ts
+++ b/platform/app/src/features/errors/logic/presentation.ts
@@ -1625,6 +1625,13 @@ const presentations = {
     describe: () =>
       "Check the key is current and copied in full. If it was revoked or rotated, create a new one in Settings > API Keys.",
   },
+  user_bound_key_required: {
+    // The key authenticated, so the answer is which key to send instead: one
+    // created for the caller's own user, not an organization service key.
+    title: "That API key belongs to no user",
+    describe: () =>
+      "This answers for you personally, so it needs an API key created for your own user. An organization service key covers no single person and can't answer for one.",
+  },
   credential_class_mismatch: {
     // Both classes are named, because the fix is to swap one for the other
     // and a caller holding several keys cannot otherwise tell which is which.

--- a/platform/app/src/server/api-router.ts
+++ b/platform/app/src/server/api-router.ts
@@ -13,6 +13,7 @@ import { app as analyticsApp } from "../app/api/analytics/[...route]/app";
 import { app as analyticsSqlApp } from "../app/api/analytics-sql/[[...route]]/app";
 import { app as apiKeysApp } from "../app/api/api-keys/[[...route]]/app";
 import { app as codingAgentApp } from "../app/api/coding-agent/[[...route]]/app";
+import { app as codingAgentV1App } from "../app/api/coding-agent/[[...route]]/app.v1";
 import { app as copilotKitApp } from "../app/api/copilotkit/[[...route]]/app";
 import { app as dashboardsApp } from "../app/api/dashboards/[[...route]]/app";
 import { app as datasetApp } from "../app/api/dataset/[[...route]]/app";
@@ -119,6 +120,7 @@ export function createApiRouter() {
   api.route("/", analyticsSqlApp); // /api/v1/projects/:projectId/analytics/* — governed SQL
   api.route("/", copilotKitApp);
   api.route("/", codingAgentApp);
+  api.route("/", codingAgentV1App); // /api/v1/coding-agent/* — organization-key door
   api.route("/", dashboardsApp);
   api.route("/", datasetApp);
   api.route("/", evaluatorsApp);

--- a/platform/app/src/server/app-layer/error-remediation.ts
+++ b/platform/app/src/server/app-layer/error-remediation.ts
@@ -321,6 +321,12 @@ const registry = {
       "Send a key scoped to your own personal workspace; being allowed to view a workspace is not the same as it being yours",
     ],
   },
+  user_bound_key_required: {
+    tips: [
+      "Send an API key created for your own user; an organization service key names no person to answer for",
+      "Create one under Settings > API Keys while signed in as yourself",
+    ],
+  },
 
   // ---- agent cache ----
   // Read by agent code inside a run, so the tips name the next call rather

--- a/platform/app/src/server/organizations/resolveCallerProjectScope.ts
+++ b/platform/app/src/server/organizations/resolveCallerProjectScope.ts
@@ -52,14 +52,39 @@ export interface CallerProjectScope {
   projects: Record<string, CallerProjectDisplay>;
 }
 
+/**
+ * The API-key half of a credential-authenticated caller, when the caller is a
+ * key rather than a signed-in session.
+ *
+ * A key can carry bindings NARROWER than its holder's own — that ceiling is
+ * the whole point of a restricted key — so a scope resolved from the holder
+ * alone would let a deliberately narrowed key read with the holder's full
+ * reach. `check` is `PermissionsService.hasApiKeyPermission`
+ * (`effective = key bindings ∩ owning user's bindings`), injected as a
+ * function so this module does not depend on the app layer.
+ */
+export interface CallerApiKeyCeiling {
+  apiKeyId: string;
+  check: (check: {
+    apiKeyId: string;
+    userId: string | null;
+    organizationId: string;
+    scope: { type: "project"; id: string; teamId: string };
+    permission: "traces:view" | "cost:view";
+  }) => Promise<boolean>;
+}
+
 export async function resolveCallerProjectScope({
   userId,
   organizationId,
   prisma = defaultPrisma,
+  apiKeyCeiling,
 }: {
   userId: string;
   organizationId: string;
   prisma?: PrismaClient;
+  /** Present when the caller is an API-key credential. @see CallerApiKeyCeiling */
+  apiKeyCeiling?: CallerApiKeyCeiling;
 }): Promise<CallerProjectScope> {
   const projects = await prisma.project.findMany({
     where: { team: { organizationId }, archivedAt: null },
@@ -94,10 +119,29 @@ export async function resolveCallerProjectScope({
     batchScopePermissions(ctx, { ...args, permission: "cost:view" }),
   ]);
 
-  const permitted = projects.filter(
+  const userPermitted = projects.filter(
     (project) => viewable.projects.get(project.id) === true,
   );
-  const permittedProjectIds = permitted.map((project) => project.id);
+  // The credential's own ceiling, applied after the holder's cut: both halves
+  // must allow a project before it appears, and both before it is priced.
+  const permitted = await withinApiKeyCeiling({
+    apiKeyCeiling,
+    userId,
+    organizationId,
+    projects: userPermitted,
+    permission: "traces:view",
+  });
+  const userPriceable = permitted.filter(
+    (project) => priceable.projects.get(project.id) === true,
+  );
+  const priceableWithinCeiling = await withinApiKeyCeiling({
+    apiKeyCeiling,
+    userId,
+    organizationId,
+    projects: userPriceable,
+    permission: "cost:view",
+  });
+
   const ownerNames = await personalTeamOwnerNames({
     prisma,
     teamIds: permitted
@@ -106,25 +150,79 @@ export async function resolveCallerProjectScope({
   });
 
   return {
-    permittedProjectIds,
-    costProjectIds: permittedProjectIds.filter(
-      (id) => priceable.projects.get(id) === true,
-    ),
-    projects: Object.fromEntries(
-      permitted.map((project) => [
-        project.id,
-        {
-          name: project.name,
-          slug: project.slug,
-          isPersonal: project.isPersonal,
-          contributorLabel: project.isPersonal
-            ? (ownerNames.get(project.teamId) ?? project.name)
-            : project.name,
-          isLinkable: !project.isPersonal,
-        } satisfies CallerProjectDisplay,
-      ]),
-    ),
+    permittedProjectIds: permitted.map((project) => project.id),
+    costProjectIds: priceableWithinCeiling.map((project) => project.id),
+    projects: projectDisplayRecord({ permitted, ownerNames }),
   };
+}
+
+/** How each permitted project is named to a reader, keyed by project id. */
+function projectDisplayRecord({
+  permitted,
+  ownerNames,
+}: {
+  permitted: Array<{
+    id: string;
+    name: string;
+    slug: string;
+    teamId: string;
+    isPersonal: boolean;
+  }>;
+  ownerNames: Map<string, string>;
+}): Record<string, CallerProjectDisplay> {
+  return Object.fromEntries(
+    permitted.map((project) => [
+      project.id,
+      {
+        name: project.name,
+        slug: project.slug,
+        isPersonal: project.isPersonal,
+        contributorLabel: project.isPersonal
+          ? (ownerNames.get(project.teamId) ?? project.name)
+          : project.name,
+        isLinkable: !project.isPersonal,
+      } satisfies CallerProjectDisplay,
+    ]),
+  );
+}
+
+/**
+ * The projects a credential's own bindings reach, out of an already
+ * user-permitted list.
+ *
+ * One decision per project through the injected `check`, in parallel: the
+ * decision is `key ∩ user` at the project's scope, exactly what every other
+ * REST door asks (`enforceApiKeyCeiling`, `requireProjectPermission`), so a
+ * key narrowed to one project answers here the way it answers everywhere
+ * else. No ceiling means a session-authenticated caller, and the list passes
+ * through untouched.
+ */
+async function withinApiKeyCeiling<P extends { id: string; teamId: string }>({
+  apiKeyCeiling,
+  userId,
+  organizationId,
+  projects,
+  permission,
+}: {
+  apiKeyCeiling: CallerApiKeyCeiling | undefined;
+  userId: string;
+  organizationId: string;
+  projects: P[];
+  permission: "traces:view" | "cost:view";
+}): Promise<P[]> {
+  if (!apiKeyCeiling || projects.length === 0) return projects;
+  const allowed = await Promise.all(
+    projects.map((project) =>
+      apiKeyCeiling.check({
+        apiKeyId: apiKeyCeiling.apiKeyId,
+        userId,
+        organizationId,
+        scope: { type: "project", id: project.id, teamId: project.teamId },
+        permission,
+      }),
+    ),
+  );
+  return projects.filter((_, index) => allowed[index] === true);
 }
 
 /**

--- a/platform/app/src/tasks/generateOpenAPISpec.ts
+++ b/platform/app/src/tasks/generateOpenAPISpec.ts
@@ -10,6 +10,7 @@ import { app as analyticsApp } from "../app/api/analytics/[...route]/app";
 import { app as analyticsSqlApp } from "../app/api/analytics-sql/[[...route]]/app";
 import { app as apiKeysApp } from "../app/api/api-keys/[[...route]]/app";
 import { app as codingAgentApp } from "../app/api/coding-agent/[[...route]]/app";
+import { app as codingAgentV1App } from "../app/api/coding-agent/[[...route]]/app.v1";
 import { app as dashboardsApp } from "../app/api/dashboards/[[...route]]/app";
 import { app as datasetApp } from "../app/api/dataset/[[...route]]/app";
 import { app as evaluatorsApp } from "../app/api/evaluators/[[...route]]/app";
@@ -78,6 +79,7 @@ const APP_DERIVED_PREFIXES = [
   "/api/api-keys",
   "/api/analytics",
   "/api/coding-agent",
+  "/api/v1/coding-agent",
   "/api/v1/projects",
   "/api/dashboards",
   "/api/evaluators",
@@ -199,6 +201,8 @@ export default async function execute() {
   const analyticsSqlSpec = await generateSpecs(analyticsSqlApp);
   console.log("Building coding agent spec...");
   const codingAgentSpec = await generateSpecs(codingAgentApp);
+  console.log("Building coding agent v1 spec...");
+  const codingAgentV1Spec = await generateSpecs(codingAgentV1App);
   console.log("Building dashboards spec...");
   const dashboardsSpec = await generateSpecs(dashboardsApp);
   console.log("Building dataset spec...");
@@ -289,6 +293,7 @@ export default async function execute() {
       analyticsSpec,
       analyticsSqlSpec,
       codingAgentSpec,
+      codingAgentV1Spec,
       dashboardsSpec,
       datasetSpec,
       evaluatorsSpec,

--- a/specs/coding-agent/pull-request-linkage.feature
+++ b/specs/coding-agent/pull-request-linkage.feature
@@ -942,6 +942,25 @@ Rule: The v1 usage read needs only an organization credential that names its use
     Then the answer is the caller's organization-wide rollup
     And the read is recorded against the caller, the organization and the pull request
 
+  # A key can carry bindings NARROWER than its holder's own — that ceiling is
+  # the whole point of a restricted key — so the rollup intersects the
+  # holder's cut with the key's, the same key-plus-holder decision every
+  # other REST door asks.
+  @integration
+  Scenario: A narrowed key reads with its own scope, not its holder's
+    Given a holder who may view traces in two projects
+    And their organization key is bound to only one of them
+    When the v1 pull request usage is read with that key
+    Then only the bound project's rows appear
+    And the other project is absent from the whole answer
+
+  @integration
+  Scenario: A key whose binding lacks the cost grant reads tokens with no cost
+    Given an organization key bound to one project with a role that cannot price
+    When the v1 pull request usage is read with that key
+    Then the bound project's rows carry token counts
+    And every cost in the answer is absent
+
   # An organization service key authenticates fine but answers for nobody:
   # the rollup is the CALLER's permission cut, and a key with no user has no
   # caller to cut by. Refused with its own stable code, not a generic 401.

--- a/specs/coding-agent/pull-request-linkage.feature
+++ b/specs/coding-agent/pull-request-linkage.feature
@@ -928,3 +928,46 @@ Rule: The organization-wide usage read is RBAC-scoped and numbers only
     When the pull request usage is read for that workspace
     Then the refusal carries a named code saying the key is for a different workspace
     And nothing in the refusal says whose workspace it is
+
+# The question is organization-wide, so the v1 door authenticates at the
+# organization: an sk-lw user-bound key alone, with no project named anywhere.
+# The personal-workspace indirection on the legacy path existed only to recover
+# the calling user, which the key itself already carries.
+Rule: The v1 usage read needs only an organization credential that names its user
+
+  @integration
+  Scenario: An organization key reads pull request usage without naming a project
+    Given a user-bound organization API key
+    When the v1 pull request usage is read with no project id anywhere in the request
+    Then the answer is the caller's organization-wide rollup
+    And the read is recorded against the caller, the organization and the pull request
+
+  # An organization service key authenticates fine but answers for nobody:
+  # the rollup is the CALLER's permission cut, and a key with no user has no
+  # caller to cut by. Refused with its own stable code, not a generic 401.
+  @integration
+  Scenario: An organization key with no bound user cannot read pull request usage
+    Given an organization API key created without a user
+    When the v1 pull request usage is read
+    Then the refusal carries a named code saying a user-bound API key is required
+
+  # A legacy project key carries no organization and no user, so it cannot
+  # authenticate at the organization door at all. The refusal names the
+  # credential class to swap, because the caller is holding a working key of
+  # the wrong family, not a typo.
+  @integration
+  Scenario: A legacy project key cannot reach the v1 usage read
+    Given a legacy project API key
+    When the v1 pull request usage is read
+    Then the refusal carries the credential class mismatch code
+    And the refusal names the organization key as the class this door needs
+
+  # The mapping is per organization, so another organization's key holds no
+  # question this instance can answer for that pull request — and learning
+  # whether the mapping exists elsewhere is not its to learn.
+  @integration
+  Scenario: An organization key from another organization learns nothing
+    Given a user-bound organization API key from a different organization
+    When the v1 pull request usage is read for a pull request mapped elsewhere
+    Then the caller receives the pull request not mapped failure
+    And nothing says the pull request is mapped for anyone else


### PR DESCRIPTION
## What

Adds `GET /api/v1/coding-agent/pull-request-usage`: the pull-request usage rollup behind an **organization credential**. An `sk-lw-{id}_{secret}` user-bound API key in `Authorization: Bearer` is the whole auth contract — **no `X-Project-Id` header, no personal-workspace project id to discover**. Same query parameters (`repository`, `pullRequest`, optional `host`) and same response shape as the legacy route.

## Why

`GET /api/coding-agent/pull-request-usage` answers an organization-wide question, but authenticated through the project-app middleware, so an org-bound key got 401 `invalid_credentials` unless the caller also sent the project id of their own personal workspace. That indirection existed only to recover the calling user — which the sk-lw key already carries (`apiKeyUserId`).

## The auth change

- New family built on `@langwatch/api` (`app.v1.ts`), with `createOrgAuthMiddleware` in throwing mode — the same door `/api/organization` uses — but **no Enterprise plan gate**: this read ships with the product.
- Caller = `apiKeyUserId` from the key; organization = the key's organization. Then the identical flow to the legacy route: `resolveCallerProjectScope` → `getPullRequestUsage` → awaited `auditLog`.
- The endpoint declares a **handler-managed policy** rather than a framework-enforced org-scope permission: no single organization-scope permission describes "the projects this member may read" (a member whose only grant is their own personal workspace must still get their rollup). Rows appear only for projects with `traces:view`, cost only with `cost:view` — the same cut as the legacy door and the in-app pages.

Refusals, each with a stable code:

| Credential | Answer |
| --- | --- |
| user-bound org key | 200, the caller's rollup |
| org service key (no user) | 400 `user_bound_key_required` (**new code**, registered in `codes.ts`, `presentation.ts` and the remediation registry) |
| legacy project key | 401 `credential_class_mismatch` (existing code, from the org auth middleware, with `meta.required`/`meta.presented`) |
| key from another org | 404 `github_pr_not_mapped`, revealing nothing about mappings elsewhere |

## Compatibility

- `/api/coding-agent/pull-request-usage` is **unchanged in behavior** — the pr-token-usage CI workflow and any other consumer keep working. Its published description now points at the v1 path as the preferred one (docs page content renders from the spec, so this reaches the existing docs page on the next deploy).
- The shared wire schemas moved to `pull-request-usage-wire.ts`, imported by both doors, so the two published shapes cannot drift.
- OpenAPI + docs regenerated through their generators (`pnpm run task generateOpenAPISpec`, `docs/Makefile sync-api-spec` + `generate-api-reference`): new path stamped with the organization key security scheme, new page `docs/api-reference/coding-agents/get-pull-request-usage.mdx`, `docs.json` updated. No generated file hand-edited.

## Deliberately left out

`GET /api/v1/coding-agent/sessions/{sessionId}/events` is **not** mounted on the v1 family: it reads one project's data and is correctly addressed by a project credential, so putting it behind the organization door would need its own auth design (an org key plus a project selector) rather than falling out of this family's structure. It stays on the legacy project family only.

## Specs and tests

- `specs/coding-agent/pull-request-linkage.feature`: new rule "The v1 usage read needs only an organization credential that names its user" with four `@integration` scenarios, all bound via `@scenario` annotations (`check:feature-parity`: 118/118 bound).
- New `pull-request-usage-v1-api.integration.test.ts` covers the four scenarios plus a published-document check (org-key security stamp).

## Test suites run (all passing, native services, no Docker, no CI=1)

- `pnpm test:integration` on `pull-request-usage-v1-api` + `pull-request-usage-api` (legacy): 12/12
- `pnpm test:integration` on `api-endpoint-authorization` (route-policy audit over the composed router): 9/9
- `pnpm test:unit` on `scripts/__tests__` + `features/errors/logic/__tests__`: 532/532
- `pnpm typecheck` and `pnpm typecheck:all`
- `pnpm check:openapi-route-coverage`, `pnpm check:openapi-completeness`, `pnpm check:feature-parity`
- Biome on touched files: clean apart from two pre-existing `noExcessiveLinesPerFunction` warnings on `createApiRouter` / `generateOpenAPISpec` (already over the limit; each gains the customary one line per new family)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an organization-scoped API endpoint for retrieving pull request usage.
  - Reports pull request metadata, contributor and agent usage, totals, and model-level token and cost breakdowns.
  - Supports repository, pull request number, and host query parameters.
  - Requires a user-bound organization API key and records access for auditing.

- **Documentation**
  - Added API reference documentation and navigation entries.
  - Updated the legacy endpoint documentation to recommend the new version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->