### PR TITLE
fix(feature-parity): report annotations hidden in JSDoc

### DIFF
--- a/platform/app/scripts/__tests__/check-feature-parity.unit.test.ts
+++ b/platform/app/scripts/__tests__/check-feature-parity.unit.test.ts
@@ -276,13 +276,36 @@ describe("collectMalformedJsdocAnnotations", () => {
       "utf8",
     );
 
-    expect(collectMalformedJsdocAnnotations([tests])).toEqual([
+    expect(collectMalformedJsdocAnnotations({ testRoots: [tests] })).toEqual([
       expect.objectContaining({
         title: "A scenario in a JSDoc body",
         ref: expect.objectContaining({
           file: expect.stringContaining("parity.test.ts"),
+          line: 3,
         }),
-        reason: expect.stringContaining("multi-line JSDoc"),
+        reason: expect.stringContaining("put it on its own annotation line"),
+      }),
+    ]);
+  });
+
+  it("reports an unquoted scenario tag embedded in a multi-line JSDoc block", () => {
+    const tests = join(root, "tests");
+    mkdirSync(tests);
+    writeFileSync(
+      join(tests, "parity.test.ts"),
+      [
+        "/**",
+        " * @scenario A bare scenario title",
+        " */",
+        'it("covers the case", () => {});',
+      ].join("\n"),
+      "utf8",
+    );
+
+    expect(collectMalformedJsdocAnnotations({ testRoots: [tests] })).toEqual([
+      expect.objectContaining({
+        title: "A bare scenario title",
+        ref: expect.objectContaining({ line: 2 }),
       }),
     ]);
   });
@@ -296,7 +319,7 @@ describe("collectMalformedJsdocAnnotations", () => {
       "utf8",
     );
 
-    expect(collectMalformedJsdocAnnotations([tests])).toEqual([]);
+    expect(collectMalformedJsdocAnnotations({ testRoots: [tests] })).toEqual([]);
   });
 });
 

--- a/platform/app/scripts/__tests__/check-feature-parity.unit.test.ts
+++ b/platform/app/scripts/__tests__/check-feature-parity.unit.test.ts
@@ -31,6 +31,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import {
   collectGoBindings,
+  collectMalformedJsdocAnnotations,
   discoverFeatureFiles,
   isEntryModule,
   isInert,
@@ -256,6 +257,46 @@ describe("discoverFeatureFiles", () => {
         expect(discoverFeatureFiles([specs]).length).toBe(1);
       });
     });
+  });
+});
+
+describe("collectMalformedJsdocAnnotations", () => {
+  it("reports a scenario tag embedded in a multi-line JSDoc block", () => {
+    const tests = join(root, "tests");
+    mkdirSync(tests);
+    writeFileSync(
+      join(tests, "parity.test.ts"),
+      [
+        "/**",
+        " * Explains the case.",
+        ' * @scenario "A scenario in a JSDoc body"',
+        " */",
+        'it("covers the case", () => {});',
+      ].join("\n"),
+      "utf8",
+    );
+
+    expect(collectMalformedJsdocAnnotations([tests])).toEqual([
+      expect.objectContaining({
+        title: "A scenario in a JSDoc body",
+        ref: expect.objectContaining({
+          file: expect.stringContaining("parity.test.ts"),
+        }),
+        reason: expect.stringContaining("multi-line JSDoc"),
+      }),
+    ]);
+  });
+
+  it("does not report the supported single-line JSDoc form", () => {
+    const tests = join(root, "tests");
+    mkdirSync(tests);
+    writeFileSync(
+      join(tests, "parity.test.ts"),
+      '/** @scenario "A supported annotation" */\nit("covers the case", () => {});',
+      "utf8",
+    );
+
+    expect(collectMalformedJsdocAnnotations([tests])).toEqual([]);
   });
 });
 

--- a/platform/app/scripts/__tests__/check-feature-parity.unit.test.ts
+++ b/platform/app/scripts/__tests__/check-feature-parity.unit.test.ts
@@ -310,6 +310,23 @@ describe("collectMalformedJsdocAnnotations", () => {
     ]);
   });
 
+  it("ignores JSDoc examples inside template strings", () => {
+    const tests = join(root, "tests");
+    mkdirSync(tests);
+    writeFileSync(
+      join(tests, "parity.test.ts"),
+      [
+        "const example = `/**",
+        " * @scenario \\\"not a real annotation\\\"",
+        " */`;",
+        'it("covers the case", () => {});',
+      ].join("\n"),
+      "utf8",
+    );
+
+    expect(collectMalformedJsdocAnnotations({ testRoots: [tests] })).toEqual([]);
+  });
+
   it("does not report the supported single-line JSDoc form", () => {
     const tests = join(root, "tests");
     mkdirSync(tests);

--- a/platform/app/scripts/__tests__/check-feature-parity.unit.test.ts
+++ b/platform/app/scripts/__tests__/check-feature-parity.unit.test.ts
@@ -310,6 +310,31 @@ describe("collectMalformedJsdocAnnotations", () => {
     ]);
   });
 
+  it("reports a titleless scenario tag embedded in a multi-line JSDoc block", () => {
+    const tests = join(root, "tests");
+    mkdirSync(tests);
+    writeFileSync(
+      join(tests, "parity.test.ts"),
+      [
+        "/**",
+        " * @scenario",
+        " */",
+        'it("covers the case", () => {});',
+      ].join("\n"),
+      "utf8",
+    );
+
+    expect(collectMalformedJsdocAnnotations({ testRoots: [tests] })).toEqual([
+      expect.objectContaining({
+        title: "",
+        ref: expect.objectContaining({ line: 2 }),
+        reason: expect.stringContaining(
+          "put it on its own annotation line directly above the test",
+        ),
+      }),
+    ]);
+  });
+
   it("ignores JSDoc examples inside template strings", () => {
     const tests = join(root, "tests");
     mkdirSync(tests);

--- a/platform/app/scripts/check-feature-parity.ts
+++ b/platform/app/scripts/check-feature-parity.ts
@@ -868,9 +868,11 @@ function isFollowedByTestCall(src: string, start: number): boolean {
   return false;
 }
 
-export function collectMalformedJsdocAnnotations(
-  testRoots: string[],
-): MalformedAnnotation[] {
+export function collectMalformedJsdocAnnotations({
+  testRoots,
+}: {
+  testRoots: string[];
+}): MalformedAnnotation[] {
   const malformed: MalformedAnnotation[] = [];
   const files: string[] = [];
   for (const r of testRoots) {
@@ -1628,9 +1630,9 @@ function analyzeParity(): ParityAnalysis {
   const unknownAnnotations: UnknownAnnotation[] = bindings
     .filter((b) => !allKnownTitles.has(b.title))
     .map((b) => ({ title: b.title, ref: b.ref }));
-  const malformedAnnotations = collectMalformedJsdocAnnotations([
-    ...DEFAULT_TEST_ROOTS,
-  ]);
+  const malformedAnnotations = collectMalformedJsdocAnnotations({
+    testRoots: [...DEFAULT_TEST_ROOTS],
+  });
 
   const legacySet = new Set(LEGACY_UNBOUND);
   const enforced: Report[] = [];

--- a/platform/app/scripts/check-feature-parity.ts
+++ b/platform/app/scripts/check-feature-parity.ts
@@ -838,7 +838,7 @@ const ANNOTATION_RE =
 
 const JSDOC_BLOCK_RE = /\/\*\*[\s\S]*?\*\//g;
 const JSDOC_ANNOTATION_LINE_RE =
-  /^[ \t]*\*[ \t]*@scenario[ \t]+(?:"([^"\r\n]+)"|'([^'\r\n]+)')[ \t]*(?:\r)?$/;
+  /^[ \t]*\*[ \t]*@scenario[ \t]+(?:"([^"\r\n]+)"|'([^'\r\n]+)'|([^*\r\n]+?))[ \t]*(?:\r)?$/;
 
 function isFollowedByTestCall(src: string, start: number): boolean {
   const len = src.length;
@@ -889,7 +889,7 @@ export function collectMalformedJsdocAnnotations(
       for (const [lineIndex, lineText] of lines.entries()) {
         const match = lineText.match(JSDOC_ANNOTATION_LINE_RE);
         if (!match) continue;
-        const title = (match[1] ?? match[2] ?? "").trim();
+        const title = (match[1] ?? match[2] ?? match[3] ?? "").trim();
         malformed.push({
           title,
           ref: {

--- a/platform/app/scripts/check-feature-parity.ts
+++ b/platform/app/scripts/check-feature-parity.ts
@@ -706,6 +706,12 @@ interface UnknownAnnotation {
   ref: BindingRef;
 }
 
+export interface MalformedAnnotation {
+  title: string;
+  ref: BindingRef;
+  reason: string;
+}
+
 export interface CollectedBinding {
   title: string;
   ref: BindingRef;
@@ -830,6 +836,10 @@ export function discoverFeatureFiles(
 const ANNOTATION_RE =
   /@scenario[ \t]+(?:"([^"\n]+)"|'([^'\n]+)'|([^\n*]+?))[ \t]*(?:\*\/|$)/gm;
 
+const JSDOC_BLOCK_RE = /\/\*\*[\s\S]*?\*\//g;
+const JSDOC_ANNOTATION_LINE_RE =
+  /^[ \t]*\*[ \t]*@scenario[ \t]+(?:"([^"\r\n]+)"|'([^'\r\n]+)')[ \t]*(?:\r)?$/;
+
 function isFollowedByTestCall(src: string, start: number): boolean {
   const len = src.length;
   let i = start;
@@ -856,6 +866,44 @@ function isFollowedByTestCall(src: string, start: number): boolean {
     return m !== null;
   }
   return false;
+}
+
+export function collectMalformedJsdocAnnotations(
+  testRoots: string[],
+): MalformedAnnotation[] {
+  const malformed: MalformedAnnotation[] = [];
+  const files: string[] = [];
+  for (const r of testRoots) {
+    files.push(
+      ...walkFiles(resolve(REPO_ROOT, r), (n) => TEST_FILE_RE.test(n)),
+    );
+  }
+
+  for (const file of files) {
+    const src = readFileSync(file, "utf8");
+    JSDOC_BLOCK_RE.lastIndex = 0;
+    let block: RegExpExecArray | null;
+    while ((block = JSDOC_BLOCK_RE.exec(src)) !== null) {
+      const blockStartLine = src.slice(0, block.index).split("\n").length;
+      const lines = block[0].split("\n");
+      for (const [lineIndex, lineText] of lines.entries()) {
+        const match = lineText.match(JSDOC_ANNOTATION_LINE_RE);
+        if (!match) continue;
+        const title = (match[1] ?? match[2] ?? "").trim();
+        malformed.push({
+          title,
+          ref: {
+            file: relative(REPO_ROOT, file),
+            line: blockStartLine + lineIndex,
+          },
+          reason:
+            "@scenario is inside a multi-line JSDoc block; put it on its own annotation line directly above the test",
+        });
+      }
+    }
+  }
+
+  return malformed;
 }
 
 function collectAllBindings(testRoots: string[]): CollectedBinding[] {
@@ -1481,6 +1529,16 @@ function printUnknownAnnotations(unknown: UnknownAnnotation[]): void {
   }
 }
 
+function printMalformedAnnotations(malformed: MalformedAnnotation[]): void {
+  if (malformed.length === 0) return;
+  console.log(`\nMalformed @scenario annotations:`);
+  for (const a of malformed) {
+    console.log(`  ✗ @scenario "${a.title}"`);
+    console.log(`    ${a.ref.file}:${a.ref.line}`);
+    console.log(`    ${a.reason}`);
+  }
+}
+
 function validateExemptionList({
   name,
   entries,
@@ -1532,6 +1590,7 @@ interface ParityAnalysis {
   staleLegacy: LegacyReport[];
   staleInert: string[];
   unknownAnnotations: UnknownAnnotation[];
+  malformedAnnotations: MalformedAnnotation[];
   listErrors: string[];
 }
 
@@ -1569,6 +1628,9 @@ function analyzeParity(): ParityAnalysis {
   const unknownAnnotations: UnknownAnnotation[] = bindings
     .filter((b) => !allKnownTitles.has(b.title))
     .map((b) => ({ title: b.title, ref: b.ref }));
+  const malformedAnnotations = collectMalformedJsdocAnnotations([
+    ...DEFAULT_TEST_ROOTS,
+  ]);
 
   const legacySet = new Set(LEGACY_UNBOUND);
   const enforced: Report[] = [];
@@ -1604,6 +1666,7 @@ function analyzeParity(): ParityAnalysis {
       (f) => allFeatures.includes(f) && !inertFeatures.has(f),
     ),
     unknownAnnotations,
+    malformedAnnotations,
     listErrors,
   };
 }
@@ -1620,6 +1683,7 @@ function printParityReport(a: ParityAnalysis): void {
   printInertSummary(a.exemptInert);
   printNewInert(a.newInert);
   printUnknownAnnotations(a.unknownAnnotations);
+  printMalformedAnnotations(a.malformedAnnotations);
 }
 
 /**
@@ -1636,6 +1700,11 @@ function fatalReasons(a: ParityAnalysis): string[] {
   }
   if (a.unknownAnnotations.length > 0) {
     reasons.push(`${a.unknownAnnotations.length} unknown annotation(s)`);
+  }
+  if (a.malformedAnnotations.length > 0) {
+    reasons.push(
+      `${a.malformedAnnotations.length} malformed annotation(s) inside multi-line JSDoc blocks`,
+    );
   }
   if (a.staleLegacy.length > 0) {
     reasons.push(
@@ -1693,6 +1762,7 @@ function main(): void {
           enforced: analysis.enforced,
           legacy: analysis.legacy,
           unknownAnnotations: analysis.unknownAnnotations,
+          malformedAnnotations: analysis.malformedAnnotations,
           listErrors: analysis.listErrors,
           staleLegacy: analysis.staleLegacy.map((r) => r.feature),
           inert: analysis.exemptInert,

--- a/platform/app/scripts/check-feature-parity.ts
+++ b/platform/app/scripts/check-feature-parity.ts
@@ -837,7 +837,7 @@ const ANNOTATION_RE =
   /@scenario[ \t]+(?:"([^"\n]+)"|'([^'\n]+)'|([^\n*]+?))[ \t]*(?:\*\/|$)/gm;
 
 const JSDOC_ANNOTATION_LINE_RE =
-  /^[ \t]*\*[ \t]*@scenario[ \t]+(?:"([^"\r\n]+)"|'([^'\r\n]+)'|([^*\r\n]+?))[ \t]*(?:\r)?$/;
+  /^[ \t]*\*[ \t]*@scenario(?:[ \t]+(?:"([^"\r\n]+)"|'([^'\r\n]+)'|([^*\r\n]+?)))?[ \t]*(?:\r)?$/;
 
 function collectJsdocBlocks({
   src,

--- a/platform/app/scripts/check-feature-parity.ts
+++ b/platform/app/scripts/check-feature-parity.ts
@@ -839,7 +839,11 @@ const ANNOTATION_RE =
 const JSDOC_ANNOTATION_LINE_RE =
   /^[ \t]*\*[ \t]*@scenario[ \t]+(?:"([^"\r\n]+)"|'([^'\r\n]+)'|([^*\r\n]+?))[ \t]*(?:\r)?$/;
 
-function collectJsdocBlocks(src: string): Array<{ text: string; index: number }> {
+function collectJsdocBlocks({
+  src,
+}: {
+  src: string;
+}): Array<{ text: string; index: number }> {
   const blocks: Array<{ text: string; index: number }> = [];
   let i = 0;
   while (i < src.length) {
@@ -921,7 +925,7 @@ export function collectMalformedJsdocAnnotations({
 
   for (const file of files) {
     const src = readFileSync(file, "utf8");
-    for (const block of collectJsdocBlocks(src)) {
+    for (const block of collectJsdocBlocks({ src })) {
       const blockStartLine = src.slice(0, block.index).split("\n").length;
       const lines = block.text.split("\n");
       for (const [lineIndex, lineText] of lines.entries()) {

--- a/platform/app/scripts/check-feature-parity.ts
+++ b/platform/app/scripts/check-feature-parity.ts
@@ -836,9 +836,47 @@ export function discoverFeatureFiles(
 const ANNOTATION_RE =
   /@scenario[ \t]+(?:"([^"\n]+)"|'([^'\n]+)'|([^\n*]+?))[ \t]*(?:\*\/|$)/gm;
 
-const JSDOC_BLOCK_RE = /\/\*\*[\s\S]*?\*\//g;
 const JSDOC_ANNOTATION_LINE_RE =
   /^[ \t]*\*[ \t]*@scenario[ \t]+(?:"([^"\r\n]+)"|'([^'\r\n]+)'|([^*\r\n]+?))[ \t]*(?:\r)?$/;
+
+function collectJsdocBlocks(src: string): Array<{ text: string; index: number }> {
+  const blocks: Array<{ text: string; index: number }> = [];
+  let i = 0;
+  while (i < src.length) {
+    const ch = src[i];
+    if (ch === "'" || ch === '"' || ch === "`") {
+      const quote = ch;
+      i++;
+      while (i < src.length) {
+        if (src[i] === "\\") {
+          i += 2;
+        } else if (src[i] === quote) {
+          i++;
+          break;
+        } else {
+          i++;
+        }
+      }
+      continue;
+    }
+    if (ch === "/" && src[i + 1] === "/") {
+      const newline = src.indexOf("\n", i + 2);
+      i = newline === -1 ? src.length : newline + 1;
+      continue;
+    }
+    if (ch === "/" && src[i + 1] === "*") {
+      const end = src.indexOf("*/", i + 2);
+      if (end === -1) break;
+      if (src[i + 2] === "*") {
+        blocks.push({ text: src.slice(i, end + 2), index: i });
+      }
+      i = end + 2;
+      continue;
+    }
+    i++;
+  }
+  return blocks;
+}
 
 function isFollowedByTestCall(src: string, start: number): boolean {
   const len = src.length;
@@ -883,11 +921,9 @@ export function collectMalformedJsdocAnnotations({
 
   for (const file of files) {
     const src = readFileSync(file, "utf8");
-    JSDOC_BLOCK_RE.lastIndex = 0;
-    let block: RegExpExecArray | null;
-    while ((block = JSDOC_BLOCK_RE.exec(src)) !== null) {
+    for (const block of collectJsdocBlocks(src)) {
       const blockStartLine = src.slice(0, block.index).split("\n").length;
-      const lines = block[0].split("\n");
+      const lines = block.text.split("\n");
       for (const [lineIndex, lineText] of lines.entries()) {
         const match = lineText.match(JSDOC_ANNOTATION_LINE_RE);
         if (!match) continue;


### PR DESCRIPTION
## Summary
- detect @scenario tags placed on * lines inside multi-line JSDoc blocks
- report the source file, line, and correction instead of silently dropping the binding
- include the diagnostic in human-readable output, JSON output, and the failure verdict
- add coverage for malformed and supported annotation forms

Fixes #7610.

## Validation
- git diff --check passed
- focused Vitest execution was attempted, but the sparse checkout cannot resolve the repository's workspace packages and dependency installation failed before tests could start
- remote CI is required for the complete repository validation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved feature-parity checks to detect incorrectly formatted `@scenario` annotations in multi-line JSDoc comments.
  * Reports now identify malformed annotations and include them in JSON results.
  * Feature-parity checks fail when malformed annotations are detected.

* **Tests**
  * Added coverage for detecting malformed multi-line annotations and accepting supported single-line annotations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->