### PR TITLE
fix(python-sdk): read the rejected field out of the REST refusal envelope

### DIFF
--- a/sdks/python/src/langwatch/utils/exceptions.py
+++ b/sdks/python/src/langwatch/utils/exceptions.py
@@ -35,14 +35,18 @@ def extract_api_error_reasons(body: Any) -> List[str]:
     each with ``meta.field`` and ``meta.message``. Those two are what the
     caller needs to fix the request, and neither ever quotes what was sent.
     An envelope without ``reasons`` answers an empty list.
+
+    Three envelope spellings carry the same list: ``reasons`` at the top, the
+    whole object nested under ``error``, and the list under ``meta`` beside the
+    ``fields`` it names, which is what the REST routes send.
     """
     if not isinstance(body, Mapping):
         return []
-    inner = body.get("error")
-    if isinstance(inner, Mapping) and "reasons" not in body:
-        body = inner
-    reasons = body.get("reasons")
-    if not isinstance(reasons, list):
+    reasons = _reasons_list(body)
+    if reasons is None:
+        inner = body.get("error")
+        reasons = _reasons_list(inner) if isinstance(inner, Mapping) else None
+    if reasons is None:
         return []
     lines: List[str] = []
     for reason in reasons:
@@ -58,6 +62,17 @@ def extract_api_error_reasons(body: Any) -> List[str]:
         elif isinstance(message, str):
             lines.append(message)
     return lines
+
+
+def _reasons_list(body: Mapping) -> Optional[list]:
+    """The ``reasons`` list of one envelope, at the top or under ``meta``."""
+    reasons = body.get("reasons")
+    if isinstance(reasons, list):
+        return reasons
+    meta = body.get("meta")
+    if isinstance(meta, Mapping) and isinstance(meta.get("reasons"), list):
+        return cast(list, meta["reasons"])
+    return None
 
 
 def extract_api_error_detail(body: Any) -> str:

--- a/sdks/python/tests/test_cache_facade.py
+++ b/sdks/python/tests/test_cache_facade.py
@@ -298,7 +298,7 @@ class TestMessages:
         )
         assert "whatever" not in str(raised.value)
 
-    # @scenario "A refusal read from the REST envelope names the field too"
+    # @scenario "A write refused for a bad time to live names that field too"
     def test_a_refusal_under_error_meta_names_the_rejected_field(self):
         # The body the production route answers, field for field.
         def handler(request: httpx.Request) -> httpx.Response:

--- a/sdks/python/tests/test_cache_facade.py
+++ b/sdks/python/tests/test_cache_facade.py
@@ -297,3 +297,45 @@ class TestMessages:
             "(validation_error: value: Expected string, received object)"
         )
         assert "whatever" not in str(raised.value)
+
+    # @scenario "A refusal read from the REST envelope names the field too"
+    def test_a_refusal_under_error_meta_names_the_rejected_field(self):
+        # The body the production route answers, field for field.
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                400,
+                json={
+                    "error": {
+                        "type": "bad_request",
+                        "code": "validation_error",
+                        "message": "The request body didn't match the expected shape.",
+                        "meta": {
+                            "target": "json",
+                            "fields": ["ttl_seconds"],
+                            "reasons": [
+                                {
+                                    "code": "schema_failure",
+                                    "message": "ttl_seconds must be at least 5",
+                                    "meta": {
+                                        "field": "ttl_seconds",
+                                        "type": "too_small",
+                                        "message": "ttl_seconds must be at least 5",
+                                    },
+                                }
+                            ],
+                        },
+                        "trace_id": "15ed8c22c5c1ce30fd38065a07a80a7e",
+                    }
+                },
+            )
+
+        with pytest.raises(ValueError) as raised:
+            CacheFacade(FakeRestClient(handler)).set(
+                "ACME_SESSION", "whatever", ttl_seconds=1
+            )
+
+        assert str(raised.value) == (
+            "The agent cache refused the call: 400 "
+            "(validation_error: ttl_seconds: ttl_seconds must be at least 5)"
+        )
+        assert "whatever" not in str(raised.value)

--- a/specs/agent-cache/agent-cache.feature
+++ b/specs/agent-cache/agent-cache.feature
@@ -327,3 +327,12 @@ Feature: The agent cache
       Given the platform refuses a write because the value is not text
       When the agent reads the exception
       Then it names the field and what was expected of it
+
+    # The REST routes send the refusal under "error", with the reasons beside
+    # the fields they name in "meta". A reader that only looks at the top of
+    # the envelope finds no reason there and answers the bare code again.
+    @unit
+    Scenario: A refusal read from the REST envelope names the field too
+      Given the platform refuses a write and puts the reasons under error meta
+      When the agent reads the exception
+      Then it names the field and what was expected of it

--- a/specs/agent-cache/agent-cache.feature
+++ b/specs/agent-cache/agent-cache.feature
@@ -328,11 +328,10 @@ Feature: The agent cache
       When the agent reads the exception
       Then it names the field and what was expected of it
 
-    # The REST routes send the refusal under "error", with the reasons beside
-    # the fields they name in "meta". A reader that only looks at the top of
-    # the envelope finds no reason there and answers the bare code again.
+    # The platform gives the same refusal in more than one form. Every form
+    # must reach the caller with the reason, not with the bare code.
     @unit
-    Scenario: A refusal read from the REST envelope names the field too
-      Given the platform refuses a write and puts the reasons under error meta
+    Scenario: A write refused for a bad time to live names that field too
+      Given the platform refuses a write because the time to live is too small
       When the agent reads the exception
       Then it names the field and what was expected of it


### PR DESCRIPTION
## What

A refused agent cache call now names the rejected field when the platform sends its refusal in the REST envelope, which is every call from the sandbox.

## Why

[#7641](https://github.com/langwatch/langwatch/pull/7641) added the field name to the message, and a production run of the sandbox showed it is still missing:

```
langwatch.cache.set(NAME, "text", ttl_seconds=1)
ValueError: The agent cache refused the call: 400 (validation_error)
```

The route answers this, read from production:

```json
{"error":{"type":"bad_request","code":"validation_error",
  "message":"The request body didn't match the expected shape.",
  "meta":{"target":"json","fields":["ttl_seconds"],
    "reasons":[{"code":"schema_failure","message":"ttl_seconds must be at least 5",
      "meta":{"field":"ttl_seconds","type":"too_small","message":"ttl_seconds must be at least 5"}}]},
  "trace_id":"..."}}
```

`extract_api_error_reasons` looked for `reasons` at the top of the envelope, and after unwrapping `error` it looked there again. In this body the list sits under `meta`, beside the `fields` it names, so the reader found none and the message fell back to the bare code.

## How

`_reasons_list` reads the list from the top of an envelope or from its `meta`, and the reader tries the outer envelope and then the one nested under `error`. All three spellings answer the same lines.

## Tests

- `test_a_refusal_under_error_meta_names_the_rejected_field` carries the production body field for field and asserts the message reads `400 (validation_error: ttl_seconds: ttl_seconds must be at least 5)`, and that nothing the caller sent reaches it.
- `specs/agent-cache/agent-cache.feature`: one new scenario, 35/35 bound.
- 95 passed in `tests/test_cache_facade.py` and `tests/utils`.

## Deployment Impact

Python SDK only, a patch release. No platform, engine or route change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for rejected requests across supported response formats.
  * Error messages now identify the affected field and explain the validation reason without exposing the submitted value.

* **Tests**
  * Added coverage for REST-style validation errors and rejected cache writes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->