### PR TITLE
fix(metrics): stop the rollup bucket read scanning retention with every column

### DIFF
--- a/platform/app/src/server/app-layer/metrics/repositories/__tests__/metric-data-point.clickhouse.repository.integration.test.ts
+++ b/platform/app/src/server/app-layer/metrics/repositories/__tests__/metric-data-point.clickhouse.repository.integration.test.ts
@@ -354,11 +354,17 @@ describe("given a cumulative series long enough to span several rollup buckets",
       }).recomputeAffectedRollupsMany({ points: samples(countedSeriesId) });
     }, 60_000);
 
-    it("reads once for the successors and once for the affected buckets", async () => {
+    it("keeps its read count flat however many points the chunk holds", async () => {
       // The seek budget folds all twelve successor seeks into one statement
       // and every affected bucket into a second. Reading per point would make
       // this grow with the chunk instead.
-      expect(reads).toBe(2);
+      //
+      // The third is the wide predecessor pass. This series is new, so no
+      // bucket finds a predecessor in the near window and every one of them
+      // falls through to it — the common path under series churn, and one
+      // extra round trip whatever the chunk size. What matters here is that
+      // three does not become four when the chunk grows.
+      expect(reads).toBe(3);
     });
 
     it("still produces the same rollups as the uncounted chunk", async () => {

--- a/platform/app/src/server/app-layer/metrics/repositories/__tests__/metric-data-point.clickhouse.repository.unit.test.ts
+++ b/platform/app/src/server/app-layer/metrics/repositories/__tests__/metric-data-point.clickhouse.repository.unit.test.ts
@@ -118,6 +118,59 @@ function encodedParamLength(params: Record<string, unknown>): number {
  */
 const PARAM_BUDGET_CHARS = 3500;
 
+/**
+ * A reader whose bucket reads answer with the point just before the chunk,
+ * which is what a live series looks like: the near predecessor pass finds
+ * something, so nothing falls through to the retention-wide one.
+ */
+function readerWithPredecessor() {
+  const predecessor = {
+    ...dataPoint(),
+    timeUnixMs: base - METRIC_ROLLUP_INTERVAL_MS,
+    timeUnixNano: String(BigInt(base - METRIC_ROLLUP_INTERVAL_MS) * 1_000_000n),
+  };
+  const query = vi.fn<
+    (args: { query: string }) => Promise<{ json: () => Promise<unknown[]> }>
+  >(async ({ query: sql }) => ({
+    json: async () =>
+      isSuccessorRead(sql)
+        ? []
+        : [
+            {
+              TenantId: predecessor.tenantId,
+              PointId: predecessor.pointId,
+              SeriesId: predecessor.seriesId,
+              MetricName: predecessor.metricName,
+              MetricUnit: predecessor.metricUnit,
+              MetricKind: predecessor.metricKind,
+              AggregationTemporality: predecessor.aggregationTemporality,
+              IsMonotonic: predecessor.isMonotonic,
+              StartTimeUnixNano: predecessor.startTimeUnixNano,
+              TimeUnixNano: predecessor.timeUnixNano,
+              TimeUnixMs: predecessor.timeUnixMs,
+              ValueType: predecessor.valueType,
+              ValueInt: predecessor.valueInt,
+              ValueDouble: predecessor.valueDouble,
+              Count: predecessor.count,
+              Sum: predecessor.sum,
+              Min: predecessor.min,
+              Max: predecessor.max,
+              ExplicitBounds: predecessor.explicitBounds,
+              BucketCounts: predecessor.bucketCounts,
+              ExponentialScale: predecessor.exponentialScale,
+              ExponentialZeroThreshold: predecessor.exponentialZeroThreshold,
+              ZeroCount: predecessor.zeroCount,
+              PositiveOffset: predecessor.positiveOffset,
+              PositiveBucketCounts: predecessor.positiveBucketCounts,
+              NegativeOffset: predecessor.negativeOffset,
+              NegativeBucketCounts: predecessor.negativeBucketCounts,
+            },
+          ],
+  }));
+  const insert = vi.fn(async () => {});
+  return { query, client: { query, insert } as never };
+}
+
 describe("MetricDataPointClickHouseRepository", () => {
   it("writes authoritative raw data before a payload-free shadow estimate", async () => {
     const insert = vi.fn<
@@ -320,7 +373,10 @@ describe("MetricDataPointClickHouseRepository", () => {
 
       await repository.recomputeAffectedRollupsMany({ points: chunkOf(12) });
 
-      expect(query).toHaveBeenCalledTimes(2);
+      // Successors, then the bucket's own rows with a near predecessor seek,
+      // then — because this table is empty and so no near seek resolves — the
+      // retention-wide seek for the buckets the near one left open.
+      expect(query).toHaveBeenCalledTimes(3);
     });
 
     it("keeps the reads flat as the chunk grows within the seek budget", async () => {
@@ -332,7 +388,7 @@ describe("MetricDataPointClickHouseRepository", () => {
 
       await repository.recomputeAffectedRollupsMany({ points: chunkOf(64) });
 
-      expect(query).toHaveBeenCalledTimes(2);
+      expect(query).toHaveBeenCalledTimes(3);
     });
 
     it("reads one series' successors in a single request however long the chunk", async () => {
@@ -347,7 +403,7 @@ describe("MetricDataPointClickHouseRepository", () => {
       // batch of series, and these 130 points are all one series.
       await repository.recomputeAffectedRollupsMany({ points: chunkOf(130) });
 
-      expect(query).toHaveBeenCalledTimes(2);
+      expect(query).toHaveBeenCalledTimes(3);
     });
 
     it("asks for each point's own successor rather than its predecessor", async () => {
@@ -1064,7 +1120,7 @@ describe("MetricDataPointClickHouseRepository", () => {
           query: string;
           query_params: Record<string, unknown>;
         }) => {
-          if (!isSuccessorRead(sql)) bucketRead = params;
+          if (!isSuccessorRead(sql)) bucketRead ??= params;
           return { json: async () => [] };
         },
       );
@@ -1081,14 +1137,135 @@ describe("MetricDataPointClickHouseRepository", () => {
 
       const names = Object.keys(bucketRead!).sort();
       expect(names).toEqual(
-        ["tenantId", "bucketMs", "retentionMs", "series0", "from0"].sort(),
+        [
+          "tenantId",
+          "bucketMs",
+          "lookbackFromMs",
+          "lookbackToMs",
+          "series0",
+          "from0",
+        ].sort(),
       );
-      // The bucket end and the retention floor are the same arithmetic on
+      // The bucket end and both lookback bounds are the same arithmetic on
       // either side of the wire, so they travel once as shared scalars.
       expect(bucketRead!.bucketMs).toBe(METRIC_ROLLUP_INTERVAL_MS);
-      expect(bucketRead!.retentionMs).toBe(49 * 24 * 60 * 60 * 1000);
+      expect(bucketRead!.lookbackFromMs).toBe(60 * 60 * 1000);
+      expect(bucketRead!.lookbackToMs).toBe(0);
       expect(names).not.toContain("to0");
       expect(names).not.toContain("cutoff0");
+    });
+
+    /** @scenario "A rollup bucket read asks only for the columns a rollup uses" */
+    it("leaves behind every column the fold never reads", async () => {
+      let bucketRead: string | undefined;
+      const query = vi.fn(async ({ query: sql }: { query: string }) => {
+        if (!isSuccessorRead(sql)) bucketRead ??= sql;
+        return { json: async () => [] };
+      });
+      const client = { query, insert: vi.fn(async () => {}) } as never;
+      const repository = new MetricDataPointClickHouseRepository({
+        resolveClient: async () => client,
+        resolveOrganizationClient: async () => client,
+      });
+
+      await repository.recomputeAffectedRollupsMany({
+        points: [{ ...dataPoint(), timeUnixMs: base + 1 }],
+      });
+
+      // FINAL materialises every selected column for every row a granule
+      // covers, not for the rows returned, and this read returns on the order
+      // of a hundred rows out of millions scanned. Each column here was being
+      // decompressed millions of times and discarded; the server ran out of
+      // memory inside one of them by name (`while reading column
+      // PointAttributesJson`).
+      for (const column of [
+        "CanonicalPayload",
+        "PointAttributesJson",
+        "PointAttributeKeys",
+        "ResourceAttributesJson",
+        "ResourceAttributeKeys",
+        "ScopeAttributesJson",
+        "ScopeAttributeKeys",
+        "SummaryQuantilesJson",
+        "MetricDescription",
+        "Flags",
+        "_size_bytes",
+        "OccurredAt",
+        "AcceptedAt",
+      ]) {
+        expect(bucketRead).not.toContain(column);
+      }
+      // What a rollup is made of still arrives.
+      for (const column of [
+        "MetricKind",
+        "AggregationTemporality",
+        "ValueDouble",
+        "BucketCounts",
+        "ExplicitBounds",
+        "StartTimeUnixNano",
+      ]) {
+        expect(bucketRead).toContain(column);
+      }
+    });
+
+    /** @scenario "A rollup bucket read looks close before it looks far" */
+    it("does not widen to retention when the near seek resolves", async () => {
+      const { query, client } = readerWithPredecessor();
+      const repository = new MetricDataPointClickHouseRepository({
+        resolveClient: async () => client,
+        resolveOrganizationClient: async () => client,
+      });
+
+      await repository.recomputeAffectedRollupsMany({
+        points: [{ ...dataPoint(), timeUnixMs: base + 1 }],
+        retentionDays: 49,
+      });
+
+      // Successors, then one bucket read. A live series never opens the
+      // partitions a retention-wide reverse seek would.
+      expect(query).toHaveBeenCalledTimes(2);
+    });
+
+    /** @scenario "A rollup bucket read looks close before it looks far" */
+    it("widens to the rest of retention only where the near seek found nothing", async () => {
+      const reads: { sql: string; params: Record<string, unknown> }[] = [];
+      const query = vi.fn(
+        async ({
+          query: sql,
+          query_params: params,
+        }: {
+          query: string;
+          query_params: Record<string, unknown>;
+        }) => {
+          if (!isSuccessorRead(sql)) reads.push({ sql, params });
+          return { json: async () => [] };
+        },
+      );
+      const client = { query, insert: vi.fn(async () => {}) } as never;
+      const repository = new MetricDataPointClickHouseRepository({
+        resolveClient: async () => client,
+        resolveOrganizationClient: async () => client,
+      });
+
+      await repository.recomputeAffectedRollupsMany({
+        points: [{ ...dataPoint(), timeUnixMs: base + 1 }],
+        retentionDays: 49,
+      });
+
+      expect(reads).toHaveLength(2);
+      const [near, far] = reads;
+      // The two windows abut and do not overlap, so together they are the one
+      // retention-wide window this replaced: no row is read twice and none is
+      // missed.
+      expect(near!.params.lookbackToMs).toBe(0);
+      expect(near!.params.lookbackFromMs).toBe(60 * 60 * 1000);
+      expect(far!.params.lookbackToMs).toBe(near!.params.lookbackFromMs);
+      expect(far!.params.lookbackFromMs).toBe(49 * 24 * 60 * 60 * 1000);
+      // The far pass is only ever looking for a predecessor: the bucket's own
+      // rows came back in the near pass, and asking again would double the
+      // statement to return what it just returned.
+      expect(far!.sql).not.toContain("UNION ALL");
+      expect(far!.sql).toContain("DESC LIMIT 1");
     });
 
     /**

--- a/platform/app/src/server/app-layer/metrics/repositories/metric-data-point.clickhouse.repository.ts
+++ b/platform/app/src/server/app-layer/metrics/repositories/metric-data-point.clickhouse.repository.ts
@@ -822,12 +822,21 @@ export class MetricDataPointClickHouseRepository
    * would otherwise scan every partition between them only to discard the rows.
    *
    * The predecessor is sought in two passes, near before far, because the far
-   * pass is the expensive one and almost no bucket needs it. The first pass
-   * looks back {@link PREDECESSOR_LOOKBACK_MS}; the second looks from there to
-   * the edge of retention, and only for the buckets the first pass left without
-   * a predecessor. The two ranges abut and do not overlap, so their union is
-   * the single retention-wide range this replaced — the same rows, reached
-   * without making every bucket pay the wide read.
+   * pass is the expensive one and a bucket in a series that is being written to
+   * does not need it. The first pass looks back
+   * {@link PREDECESSOR_LOOKBACK_MS}; the second looks from there to the edge of
+   * retention, and only for the buckets the first pass left without a
+   * predecessor. The two ranges abut and do not overlap, so their union is the
+   * single retention-wide range this replaced — the same rows, reached without
+   * making every bucket pay the wide read.
+   *
+   * Two cases do reach the far pass every time, and both are bounded. A series
+   * whose first points are arriving has no predecessor at any distance, so its
+   * buckets fall through and the wide seek returns nothing; under series churn
+   * this is the common path, not the rare one, and it costs one extra round
+   * trip on top of what the single-pass read already cost. A gap longer than
+   * the near window is the other, and it is the case the far pass exists for.
+   * Neither is a regression, but neither is rare either.
    *
    * What the wide read costs is partitions. The table partitions by ISO week,
    * so a retention-wide reverse seek opens every weekly part the series appears
@@ -872,7 +881,7 @@ export class MetricDataPointClickHouseRepository
       seeks,
       unique,
       predecessor: { fromMs: nearMs, toMs: 0 },
-      withBucketRows: true,
+      shouldReadBucketRows: true,
     });
 
     const unresolved =
@@ -890,7 +899,7 @@ export class MetricDataPointClickHouseRepository
         seeks: unresolved,
         unique,
         predecessor: { fromMs: retentionMs, toMs: nearMs },
-        withBucketRows: false,
+        shouldReadBucketRows: false,
       });
     }
 
@@ -907,7 +916,7 @@ export class MetricDataPointClickHouseRepository
    *
    * `predecessor` is the half-open window behind each bucket start the reverse
    * seek may look in, as distances rather than instants so both bounds stay
-   * shared scalars however many buckets the chunk holds. `withBucketRows` is
+   * shared scalars however many buckets the chunk holds. `shouldReadBucketRows` is
    * off for a pass that only widens the predecessor search: those buckets'
    * own rows are already in hand, and re-reading them would double the
    * statement to return what it just returned.
@@ -918,14 +927,14 @@ export class MetricDataPointClickHouseRepository
     seeks,
     unique,
     predecessor,
-    withBucketRows,
+    shouldReadBucketRows,
   }: {
     client: Awaited<ReturnType<ClickHouseClientResolver>>;
     tenantId: string;
     seeks: readonly { seriesId: string; start: number }[];
     unique: Map<string, MetricRollupSourcePoint>;
     predecessor: { fromMs: number; toMs: number };
-    withBucketRows: boolean;
+    shouldReadBucketRows: boolean;
   }): Promise<void> {
     // Half the cap, and the divisor is a size bound rather than a
     // statement-count one: the successor read emits one statement whatever its
@@ -964,7 +973,7 @@ export class MetricDataPointClickHouseRepository
               AND metric_data_points.TimeUnixMs < fromUnixTimestamp64Milli({from${index}:Int64} - {lookbackToMs:Int64})
               AND metric_data_points.TimeUnixMs >= fromUnixTimestamp64Milli({from${index}:Int64} - {lookbackFromMs:Int64})
             ORDER BY metric_data_points.TimeUnixMs DESC, TimeUnixNano DESC, PointId DESC LIMIT 1)`;
-        if (!withBucketRows) return [predecessorSeek];
+        if (!shouldReadBucketRows) return [predecessorSeek];
         return [
           predecessorSeek,
           `(SELECT ${ROLLUP_SELECT}

--- a/platform/app/src/server/app-layer/metrics/repositories/metric-data-point.clickhouse.repository.ts
+++ b/platform/app/src/server/app-layer/metrics/repositories/metric-data-point.clickhouse.repository.ts
@@ -88,6 +88,43 @@ const SUCCESSOR_PARAM_BUDGET_CHARS = 3500;
 const PREDECESSOR_LOOKBACK_MS = 60 * 60 * 1000;
 
 /**
+ * The seeks whose predecessor the near pass failed to find.
+ *
+ * A bucket whose near pass returned nothing in [start - lookbackMs, start) has
+ * no stored point in that window at all — the branch returns the newest there
+ * is — so whatever precedes it is older than the window, and only then is the
+ * wide seek worth its partitions.
+ *
+ * A row from a neighbouring affected bucket answers this just as well: if
+ * anything at all sits in the window, then the newest thing in it does too,
+ * and that is precisely what the near seek returned. So the check is against
+ * every point the pass collected, indexed by series to keep it off the
+ * seeks × points path.
+ */
+function seeksWithoutPredecessor({
+  seeks,
+  points,
+  lookbackMs,
+}: {
+  seeks: readonly { seriesId: string; start: number }[];
+  points: Iterable<MetricRollupSourcePoint>;
+  lookbackMs: number;
+}): { seriesId: string; start: number }[] {
+  const seenBySeries = new Map<string, number[]>();
+  for (const point of points) {
+    const times = seenBySeries.get(point.seriesId);
+    if (times) times.push(point.timeUnixMs);
+    else seenBySeries.set(point.seriesId, [point.timeUnixMs]);
+  }
+  return seeks.filter(
+    ({ seriesId, start }) =>
+      !(seenBySeries.get(seriesId) ?? []).some(
+        (timeUnixMs) => timeUnixMs < start && timeUnixMs >= start - lookbackMs,
+      ),
+  );
+}
+
+/**
  * The successor read's whole statement, emitted once at module load rather than
  * rebuilt per chunk, because nothing in it varies with the chunk any more.
  *
@@ -838,30 +875,14 @@ export class MetricDataPointClickHouseRepository
       withBucketRows: true,
     });
 
-    // A bucket whose near pass returned nothing in [start - nearMs, start) has
-    // no stored point in that window at all — the branch returns the newest
-    // there is — so whatever precedes it is older than the window, and only
-    // then is the wide seek worth its partitions.
-    //
-    // A row from a neighbouring affected bucket answers this just as well: if
-    // anything at all sits in the window, then the newest thing in it does
-    // too, and that is precisely what the near seek returned.
-    const seenBySeries = new Map<string, number[]>();
-    for (const point of unique.values()) {
-      const times = seenBySeries.get(point.seriesId);
-      if (times) times.push(point.timeUnixMs);
-      else seenBySeries.set(point.seriesId, [point.timeUnixMs]);
-    }
     const unresolved =
       nearMs >= retentionMs
         ? []
-        : seeks.filter(
-            ({ seriesId, start }) =>
-              !(seenBySeries.get(seriesId) ?? []).some(
-                (timeUnixMs) =>
-                  timeUnixMs < start && timeUnixMs >= start - nearMs,
-              ),
-          );
+        : seeksWithoutPredecessor({
+            seeks,
+            points: unique.values(),
+            lookbackMs: nearMs,
+          });
     if (unresolved.length > 0) {
       await this.readAffectedBuckets({
         client,

--- a/platform/app/src/server/app-layer/metrics/repositories/metric-data-point.clickhouse.repository.ts
+++ b/platform/app/src/server/app-layer/metrics/repositories/metric-data-point.clickhouse.repository.ts
@@ -7,6 +7,7 @@ import {
 } from "~/server/event-sourcing/pipelines/metric-processing/rollup";
 import {
   comparePoints,
+  type MetricRollupSourcePoint,
   type MetricSequencePoint,
 } from "~/server/event-sourcing/pipelines/metric-processing/rollup/sequence";
 import { METRIC_ROLLUP_INTERVAL_MS } from "~/server/event-sourcing/pipelines/metric-processing/schemas/constants";
@@ -24,10 +25,10 @@ import type {
   SeriesTotalByPointAttribute,
 } from "./metric-data-point.repository";
 import {
-  AUTHORITATIVE_SELECT,
-  fromRaw,
+  fromRollupRow,
   fromSeekRow,
-  type RawMetricRow,
+  ROLLUP_SELECT,
+  type RollupSourceRow,
   rawRow,
   rollupRow,
   SEEK_SELECT,
@@ -72,6 +73,19 @@ const SEEKS_PER_QUERY = 64;
  * without crossing this one first.
  */
 const SUCCESSOR_PARAM_BUDGET_CHARS = 3500;
+
+/**
+ * How far behind a bucket the first predecessor seek looks before the second
+ * one widens to the retention window.
+ *
+ * An hour, which is two orders of magnitude more than the rollup interval and
+ * so covers any series still being written to, however coarsely it is scraped.
+ * It is a latency/partition trade and nothing depends on the exact value: too
+ * small only sends more buckets into the second pass, too large only widens
+ * the first, and either way the pair reads the same range and the fold sees
+ * the same predecessor.
+ */
+const PREDECESSOR_LOOKBACK_MS = 60 * 60 * 1000;
 
 /**
  * The successor read's whole statement, emitted once at module load rather than
@@ -605,7 +619,6 @@ export class MetricDataPointClickHouseRepository
     const authoritative = await this.pointsForAffectedBuckets({
       affectedBySeries,
       tenantId: points[0]!.tenantId,
-      organizationId: points[0]!.organizationId,
       retentionDays,
     });
 
@@ -771,29 +784,36 @@ export class MetricDataPointClickHouseRepository
    * narrow ranges rather than one span: a late point and a distant next sample
    * would otherwise scan every partition between them only to discard the rows.
    *
-   * The predecessor seek is bounded below by the series' retention window: a
-   * predecessor older than that is expired (or about to be), and the fold
-   * already treats an absent predecessor as a reset/gap. Without the bound a
-   * sparse series pays a reverse scan across every partition — including
-   * S3-tiered cold storage — hunting for a row that no longer matters.
+   * The predecessor is sought in two passes, near before far, because the far
+   * pass is the expensive one and almost no bucket needs it. The first pass
+   * looks back {@link PREDECESSOR_LOOKBACK_MS}; the second looks from there to
+   * the edge of retention, and only for the buckets the first pass left without
+   * a predecessor. The two ranges abut and do not overlap, so their union is
+   * the single retention-wide range this replaced — the same rows, reached
+   * without making every bucket pay the wide read.
+   *
+   * What the wide read costs is partitions. The table partitions by ISO week,
+   * so a retention-wide reverse seek opens every weekly part the series appears
+   * in — on the default retention, seven of them — to return one row. An hour
+   * of lookback opens one, or two across a week boundary. A live series is
+   * resolved by the near pass; only a series with an hour-wide hole in it pays
+   * for the far one, and it pays exactly what it paid before.
    */
   private async pointsForAffectedBuckets({
     affectedBySeries,
     tenantId,
-    organizationId,
     retentionDays,
   }: {
     affectedBySeries: ReadonlyMap<string, ReadonlySet<number>>;
     tenantId: string;
-    organizationId: string;
     retentionDays: number;
-  }): Promise<Map<string, CanonicalMetricDataPoint[]>> {
+  }): Promise<Map<string, MetricRollupSourcePoint[]>> {
     const seeks = [...affectedBySeries].flatMap(([seriesId, buckets]) =>
       [...buckets]
         .sort((a, b) => a - b)
         .map((start) => ({ seriesId, start }) as const),
     );
-    const found = new Map<string, CanonicalMetricDataPoint[]>();
+    const found = new Map<string, MetricRollupSourcePoint[]>();
     if (seeks.length === 0) return found;
 
     const client = await this.resolveClient(tenantId);
@@ -801,8 +821,91 @@ export class MetricDataPointClickHouseRepository
     // the ranges overlap by design; the fold needs each point exactly once.
     // Identity is (series, point) because one query now spans many series, and
     // a point id is only ever unique within its own.
-    const unique = new Map<string, CanonicalMetricDataPoint>();
+    const unique = new Map<string, MetricRollupSourcePoint>();
 
+    const retentionMs = retentionDays * 24 * 60 * 60 * 1000;
+    // A retention window shorter than the near pass would make that pass read
+    // past the edge of retention, so the near pass never reaches further than
+    // retention does and the far pass has nothing left to cover.
+    const nearMs = Math.min(PREDECESSOR_LOOKBACK_MS, retentionMs);
+
+    await this.readAffectedBuckets({
+      client,
+      tenantId,
+      seeks,
+      unique,
+      predecessor: { fromMs: nearMs, toMs: 0 },
+      withBucketRows: true,
+    });
+
+    // A bucket whose near pass returned nothing in [start - nearMs, start) has
+    // no stored point in that window at all — the branch returns the newest
+    // there is — so whatever precedes it is older than the window, and only
+    // then is the wide seek worth its partitions.
+    //
+    // A row from a neighbouring affected bucket answers this just as well: if
+    // anything at all sits in the window, then the newest thing in it does
+    // too, and that is precisely what the near seek returned.
+    const seenBySeries = new Map<string, number[]>();
+    for (const point of unique.values()) {
+      const times = seenBySeries.get(point.seriesId);
+      if (times) times.push(point.timeUnixMs);
+      else seenBySeries.set(point.seriesId, [point.timeUnixMs]);
+    }
+    const unresolved =
+      nearMs >= retentionMs
+        ? []
+        : seeks.filter(
+            ({ seriesId, start }) =>
+              !(seenBySeries.get(seriesId) ?? []).some(
+                (timeUnixMs) =>
+                  timeUnixMs < start && timeUnixMs >= start - nearMs,
+              ),
+          );
+    if (unresolved.length > 0) {
+      await this.readAffectedBuckets({
+        client,
+        tenantId,
+        seeks: unresolved,
+        unique,
+        predecessor: { fromMs: retentionMs, toMs: nearMs },
+        withBucketRows: false,
+      });
+    }
+
+    for (const point of unique.values()) {
+      const existing = found.get(point.seriesId);
+      if (existing) existing.push(point);
+      else found.set(point.seriesId, [point]);
+    }
+    return found;
+  }
+
+  /**
+   * One pass of the affected-bucket read, collecting into `unique`.
+   *
+   * `predecessor` is the half-open window behind each bucket start the reverse
+   * seek may look in, as distances rather than instants so both bounds stay
+   * shared scalars however many buckets the chunk holds. `withBucketRows` is
+   * off for a pass that only widens the predecessor search: those buckets'
+   * own rows are already in hand, and re-reading them would double the
+   * statement to return what it just returned.
+   */
+  private async readAffectedBuckets({
+    client,
+    tenantId,
+    seeks,
+    unique,
+    predecessor,
+    withBucketRows,
+  }: {
+    client: Awaited<ReturnType<ClickHouseClientResolver>>;
+    tenantId: string;
+    seeks: readonly { seriesId: string; start: number }[];
+    unique: Map<string, MetricRollupSourcePoint>;
+    predecessor: { fromMs: number; toMs: number };
+    withBucketRows: boolean;
+  }): Promise<void> {
     // Half the cap, and the divisor is a size bound rather than a
     // statement-count one: the successor read emits one statement whatever its
     // chunk holds, so there is no statement ceiling left here to match. What
@@ -811,35 +914,39 @@ export class MetricDataPointClickHouseRepository
     // characters of `param_*` entries - inside the client's own 4096-character
     // ceiling on them, where 64 buckets would be half as far outside it again.
     for (const chunk of chunked(seeks, Math.floor(SEEKS_PER_QUERY / 2))) {
-      // Two shared scalars replace the per-seek end and cutoff bounds: both
-      // were derived from the bucket start, so the server can derive them too
-      // and the parameter fan-out halves without the statement changing shape.
+      // Shared scalars replace the per-seek end and cutoff bounds: all were
+      // derived from the bucket start, so the server can derive them too and
+      // the parameter fan-out stays at two per bucket whatever the chunk holds.
       const params: Record<string, unknown> = {
         tenantId,
         bucketMs: METRIC_ROLLUP_INTERVAL_MS,
-        retentionMs: retentionDays * 24 * 60 * 60 * 1000,
+        lookbackFromMs: predecessor.fromMs,
+        lookbackToMs: predecessor.toMs,
       };
       const selects = chunk.flatMap(({ seriesId, start }, index) => {
         params[`series${index}`] = seriesId;
         params[`from${index}`] = start;
         // Both branches keep a seek per bucket rather than folding into one
         // joined statement the way the successor read does. The predecessor
-        // branch is why: its lower bound is the retention window, and a join
-        // can only apply a per-seek bound after the rows are read, so the
-        // single-row reverse index seek would become a read of every point in
-        // the series across that whole window — the memory class #6493 fixed.
+        // branch is why: its bounds are per-seek, and a join can only apply
+        // those after the rows are read, so the single-row reverse index seek
+        // would become a read of every point in the series across the whole
+        // window - the memory class #6493 fixed.
         // The successor read folds safely because every bound there is the
-        // chunk's own span. AUTHORITATIVE_SELECT is everything the fold reads
-        // without the payload column, which is what made these FINAL reads
-        // memory-heavy.
-        return [
-          `(SELECT ${AUTHORITATIVE_SELECT}
+        // chunk's own span. ROLLUP_SELECT is exactly what the fold reads and
+        // nothing else: FINAL materialises every selected column for every row
+        // a granule covers, so a column the fold ignores is decompressed
+        // millions of times to be discarded.
+        const predecessorSeek = `(SELECT ${ROLLUP_SELECT}
             FROM metric_data_points FINAL
             WHERE TenantId = {tenantId:String} AND SeriesId = {series${index}:String}
-              AND metric_data_points.TimeUnixMs < fromUnixTimestamp64Milli({from${index}:Int64})
-              AND metric_data_points.TimeUnixMs >= fromUnixTimestamp64Milli({from${index}:Int64} - {retentionMs:Int64})
-            ORDER BY metric_data_points.TimeUnixMs DESC, TimeUnixNano DESC, PointId DESC LIMIT 1)`,
-          `(SELECT ${AUTHORITATIVE_SELECT}
+              AND metric_data_points.TimeUnixMs < fromUnixTimestamp64Milli({from${index}:Int64} - {lookbackToMs:Int64})
+              AND metric_data_points.TimeUnixMs >= fromUnixTimestamp64Milli({from${index}:Int64} - {lookbackFromMs:Int64})
+            ORDER BY metric_data_points.TimeUnixMs DESC, TimeUnixNano DESC, PointId DESC LIMIT 1)`;
+        if (!withBucketRows) return [predecessorSeek];
+        return [
+          predecessorSeek,
+          `(SELECT ${ROLLUP_SELECT}
             FROM metric_data_points FINAL
             WHERE TenantId = {tenantId:String} AND SeriesId = {series${index}:String}
               AND metric_data_points.TimeUnixMs >= fromUnixTimestamp64Milli({from${index}:Int64})
@@ -852,21 +959,9 @@ export class MetricDataPointClickHouseRepository
         query_params: params,
         format: "JSONEachRow",
       });
-      for (const row of await result.json<
-        Omit<RawMetricRow, "CanonicalPayload">
-      >()) {
-        unique.set(
-          `${row.SeriesId}\u0000${row.PointId}`,
-          fromRaw({ row, organizationId }),
-        );
+      for (const row of await result.json<RollupSourceRow>()) {
+        unique.set(`${row.SeriesId}\u0000${row.PointId}`, fromRollupRow(row));
       }
     }
-
-    for (const point of unique.values()) {
-      const existing = found.get(point.seriesId);
-      if (existing) existing.push(point);
-      else found.set(point.seriesId, [point]);
-    }
-    return found;
   }
 }

--- a/platform/app/src/server/app-layer/metrics/repositories/metric-data-point.rows.ts
+++ b/platform/app/src/server/app-layer/metrics/repositories/metric-data-point.rows.ts
@@ -1,4 +1,7 @@
-import type { MetricSequencePoint } from "~/server/event-sourcing/pipelines/metric-processing/rollup/sequence";
+import type {
+  MetricRollupSourcePoint,
+  MetricSequencePoint,
+} from "~/server/event-sourcing/pipelines/metric-processing/rollup/sequence";
 import type {
   AggregationTemporality,
   CanonicalMetricDataPoint,
@@ -69,22 +72,6 @@ export interface RawMetricRow {
   OccurredAt: string | number;
   AcceptedAt: string | number;
 }
-
-export const RAW_SELECT = `
-  TenantId, PointId, SeriesId,
-  ResourceSchemaUrl, ResourceAttributesJson, ResourceAttributeKeys,
-  ScopeSchemaUrl, ScopeName, ScopeVersion, ScopeAttributesJson, ScopeAttributeKeys,
-  MetricName, MetricDescription, MetricUnit, MetricKind,
-  AggregationTemporality, IsMonotonic,
-  PointAttributesJson, PointAttributeKeys,
-  StartTimeUnixNano, TimeUnixNano, toUnixTimestamp64Milli(TimeUnixMs) AS TimeUnixMs,
-  Flags, ValueType, ValueInt, ValueDouble, Count, Sum, Min, Max,
-  ExplicitBounds, BucketCounts, ExponentialScale, ExponentialZeroThreshold, ZeroCount,
-  PositiveOffset, PositiveBucketCounts, NegativeOffset, NegativeBucketCounts,
-  SummaryQuantilesJson, CanonicalPayload, _size_bytes,
-  toUnixTimestamp64Milli(OccurredAt) AS OccurredAt,
-  toUnixTimestamp64Milli(AcceptedAt) AS AcceptedAt
-`;
 
 export function rawRow({
   point,
@@ -240,7 +227,8 @@ export function rollupRow({
  * One of the three `Array(UInt64)` count columns, refusing to decode a row that
  * does not carry it.
  *
- * These are the only fields `fromRaw` dereferences without a null check, so a
+ * These are the only fields `fromRollupRow` dereferences without a null check,
+ * so a
  * row arriving without them used to surface as a bare
  * `Cannot read properties of undefined (reading 'map')` — no column, no series,
  * no query, and a stack the queue drops in favour of the message alone. Naming
@@ -277,16 +265,98 @@ function countsColumn({
 }
 
 /**
- * The columns the rollup fold actually reads. Identical to {@link RAW_SELECT}
- * minus CanonicalPayload: the fold never touches the payload, and it is the
- * one megabyte-scale column, so fetching it through `FINAL` was what pushed
- * the folded seek queries past the server's per-query memory cap
- * (MEMORY_LIMIT_EXCEEDED while executing ReplacingSorted).
+ * The columns the rollup fold actually reads — {@link MetricRollupSourcePoint},
+ * spelled as SQL.
+ *
+ * Dropping the payload column was not enough. `FINAL` materialises every
+ * selected column for every row a seek's granules cover, not for the rows it
+ * returns, and the authoritative bucket read returns on the order of a hundred
+ * rows out of millions scanned. So each of the columns left out here — the two
+ * attribute JSON blobs, the resource and scope identity, the description,
+ * flags, the quantile JSON, the size and acceptance bookkeeping — was being
+ * decompressed for every scanned row and thrown away. That is the allocation
+ * the server ran out of memory inside: `Code: 241 ... (while reading column
+ * PointAttributesJson)`.
+ *
+ * None of them is a rollup input: a rollup carries identity, kind, temporality
+ * and aggregatable values, and quantiles are explicitly not aggregatable (see
+ * `buildSummaryRow`). The type is what enforces that — adding a column here
+ * without adding it to {@link MetricRollupSourcePoint} gains nothing, and
+ * reading one in a builder without adding it here will not compile.
  */
-export const AUTHORITATIVE_SELECT = RAW_SELECT.replace(
-  "SummaryQuantilesJson, CanonicalPayload, _size_bytes,",
-  "SummaryQuantilesJson, _size_bytes,",
-);
+export const ROLLUP_SELECT = `
+  TenantId, PointId, SeriesId,
+  MetricName, MetricUnit, MetricKind, AggregationTemporality, IsMonotonic,
+  StartTimeUnixNano, TimeUnixNano, toUnixTimestamp64Milli(TimeUnixMs) AS TimeUnixMs,
+  ValueType, ValueInt, ValueDouble, Count, Sum, Min, Max,
+  ExplicitBounds, BucketCounts,
+  ExponentialScale, ExponentialZeroThreshold, ZeroCount,
+  PositiveOffset, PositiveBucketCounts, NegativeOffset, NegativeBucketCounts
+`;
+
+/** A row of {@link ROLLUP_SELECT}, which is a strict subset of the raw row. */
+export type RollupSourceRow = Pick<
+  RawMetricRow,
+  | "TenantId"
+  | "PointId"
+  | "SeriesId"
+  | "MetricName"
+  | "MetricUnit"
+  | "MetricKind"
+  | "AggregationTemporality"
+  | "IsMonotonic"
+  | "StartTimeUnixNano"
+  | "TimeUnixNano"
+  | "TimeUnixMs"
+  | "ValueType"
+  | "ValueInt"
+  | "ValueDouble"
+  | "Count"
+  | "Sum"
+  | "Min"
+  | "Max"
+  | "ExplicitBounds"
+  | "BucketCounts"
+  | "ExponentialScale"
+  | "ExponentialZeroThreshold"
+  | "ZeroCount"
+  | "PositiveOffset"
+  | "PositiveBucketCounts"
+  | "NegativeOffset"
+  | "NegativeBucketCounts"
+>;
+
+export function fromRollupRow(row: RollupSourceRow): MetricRollupSourcePoint {
+  return {
+    tenantId: row.TenantId,
+    pointId: row.PointId,
+    seriesId: row.SeriesId,
+    metricName: row.MetricName,
+    metricUnit: row.MetricUnit,
+    metricKind: row.MetricKind,
+    aggregationTemporality: row.AggregationTemporality,
+    isMonotonic: row.IsMonotonic === null ? null : Boolean(row.IsMonotonic),
+    startTimeUnixNano: String(row.StartTimeUnixNano),
+    timeUnixNano: String(row.TimeUnixNano),
+    timeUnixMs: Number(row.TimeUnixMs),
+    valueType: row.ValueType,
+    valueInt: row.ValueInt === null ? null : String(row.ValueInt),
+    valueDouble: row.ValueDouble,
+    count: row.Count === null ? null : String(row.Count),
+    sum: row.Sum,
+    min: row.Min,
+    max: row.Max,
+    explicitBounds: row.ExplicitBounds,
+    bucketCounts: countsColumn({ row, column: "BucketCounts" }),
+    exponentialScale: row.ExponentialScale,
+    exponentialZeroThreshold: row.ExponentialZeroThreshold,
+    zeroCount: row.ZeroCount === null ? null : String(row.ZeroCount),
+    positiveOffset: row.PositiveOffset,
+    positiveBucketCounts: countsColumn({ row, column: "PositiveBucketCounts" }),
+    negativeOffset: row.NegativeOffset,
+    negativeBucketCounts: countsColumn({ row, column: "NegativeBucketCounts" }),
+  };
+}
 
 /**
  * The columns a successor seek needs: just enough to order points
@@ -318,67 +388,6 @@ export function fromSeekRow(row: SeekMetricRow): MetricSequencePoint {
     timeUnixNano: String(row.TimeUnixNano),
     metricKind: row.MetricKind,
     aggregationTemporality: row.AggregationTemporality,
-  };
-}
-
-export function fromRaw({
-  row,
-  organizationId,
-}: {
-  // CanonicalPayload is optional on purpose: the authoritative bucket reads
-  // deliberately do not select it (see AUTHORITATIVE_SELECT), and the fold
-  // never reads the decoded field.
-  row: Omit<RawMetricRow, "CanonicalPayload"> & { CanonicalPayload?: string };
-  organizationId: string;
-}): CanonicalMetricDataPoint {
-  return {
-    tenantId: row.TenantId,
-    // Organization identity is deliberately absent from authoritative metric
-    // storage. It is carried only long enough to write the shadow ledger.
-    organizationId,
-    pointId: row.PointId,
-    seriesId: row.SeriesId,
-    resourceSchemaUrl: row.ResourceSchemaUrl,
-    resourceAttributesJson: row.ResourceAttributesJson,
-    resourceAttributeKeys: row.ResourceAttributeKeys,
-    scopeSchemaUrl: row.ScopeSchemaUrl,
-    scopeName: row.ScopeName,
-    scopeVersion: row.ScopeVersion,
-    scopeAttributesJson: row.ScopeAttributesJson,
-    scopeAttributeKeys: row.ScopeAttributeKeys,
-    metricName: row.MetricName,
-    metricDescription: row.MetricDescription,
-    metricUnit: row.MetricUnit,
-    metricKind: row.MetricKind,
-    aggregationTemporality: row.AggregationTemporality,
-    isMonotonic: row.IsMonotonic === null ? null : Boolean(row.IsMonotonic),
-    pointAttributesJson: row.PointAttributesJson,
-    pointAttributeKeys: row.PointAttributeKeys,
-    startTimeUnixNano: String(row.StartTimeUnixNano),
-    timeUnixNano: String(row.TimeUnixNano),
-    timeUnixMs: Number(row.TimeUnixMs),
-    flags: row.Flags,
-    valueType: row.ValueType,
-    valueInt: row.ValueInt === null ? null : String(row.ValueInt),
-    valueDouble: row.ValueDouble,
-    count: row.Count === null ? null : String(row.Count),
-    sum: row.Sum,
-    min: row.Min,
-    max: row.Max,
-    explicitBounds: row.ExplicitBounds,
-    bucketCounts: countsColumn({ row, column: "BucketCounts" }),
-    exponentialScale: row.ExponentialScale,
-    exponentialZeroThreshold: row.ExponentialZeroThreshold,
-    zeroCount: row.ZeroCount === null ? null : String(row.ZeroCount),
-    positiveOffset: row.PositiveOffset,
-    positiveBucketCounts: countsColumn({ row, column: "PositiveBucketCounts" }),
-    negativeOffset: row.NegativeOffset,
-    negativeBucketCounts: countsColumn({ row, column: "NegativeBucketCounts" }),
-    summaryQuantilesJson: row.SummaryQuantilesJson,
-    canonicalPayload: row.CanonicalPayload ?? "",
-    canonicalSizeBytes: Number(row._size_bytes),
-    occurredAt: Number(row.OccurredAt),
-    acceptedAt: Number(row.AcceptedAt),
   };
 }
 

--- a/platform/app/src/server/event-sourcing/pipelines/metric-processing/rollup.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/metric-processing/rollup.ts
@@ -5,14 +5,12 @@ import { buildGaugeRow, buildSumRow } from "./rollup/scalar";
 import {
   comparePoints,
   floorBucket,
+  type MetricRollupSourcePoint,
   type MetricSequencePoint,
   usesPredecessor,
 } from "./rollup/sequence";
 import { buildSummaryRow } from "./rollup/summary";
-import type {
-  CanonicalMetricDataPoint,
-  MetricRollupRow,
-} from "./schemas/metricDataPoint";
+import type { MetricRollupRow } from "./schemas/metricDataPoint";
 
 const BUILDERS = {
   gauge: buildGaugeRow,
@@ -31,7 +29,7 @@ export function buildMetricRollups({
   points,
   affectedBuckets,
 }: {
-  points: CanonicalMetricDataPoint[];
+  points: MetricRollupSourcePoint[];
   affectedBuckets?: ReadonlySet<number>;
 }): MetricRollupRow[] {
   const all = [...points].sort(comparePoints);

--- a/platform/app/src/server/event-sourcing/pipelines/metric-processing/rollup/explicitHistogram.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/metric-processing/rollup/explicitHistogram.ts
@@ -1,11 +1,13 @@
-import type {
-  CanonicalMetricDataPoint,
-  MetricRollupRow,
-} from "../schemas/metricDataPoint";
+import type { MetricRollupRow } from "../schemas/metricDataPoint";
 import { type BucketEntry, extendExtrema, resetOrGap } from "./row";
-import { bigint, previousPoint, startsNewSequence } from "./sequence";
+import {
+  bigint,
+  type MetricRollupSourcePoint,
+  previousPoint,
+  startsNewSequence,
+} from "./sequence";
 
-function commonExplicitBounds(points: CanonicalMetricDataPoint[]): number[] {
+function commonExplicitBounds(points: MetricRollupSourcePoint[]): number[] {
   if (points.length === 0) return [];
   let common = new Set(points[0]!.explicitBounds);
   for (const point of points.slice(1)) {
@@ -24,7 +26,7 @@ function coarsenExplicit({
   point,
   targetBounds,
 }: {
-  point: CanonicalMetricDataPoint;
+  point: MetricRollupSourcePoint;
   targetBounds: number[];
 }): bigint[] {
   const sourceCounts = point.bucketCounts.map(bigint);
@@ -54,10 +56,10 @@ function usablePredecessor({
   all,
   index,
 }: {
-  point: CanonicalMetricDataPoint;
-  all: CanonicalMetricDataPoint[];
+  point: MetricRollupSourcePoint;
+  all: MetricRollupSourcePoint[];
   index: number;
-}): CanonicalMetricDataPoint | undefined {
+}): MetricRollupSourcePoint | undefined {
   if (point.aggregationTemporality !== "cumulative") return undefined;
   const previous = previousPoint(all, index);
   if (previous?.metricKind !== "histogram") return undefined;
@@ -70,9 +72,9 @@ function usablePredecessors({
   all,
 }: {
   entries: BucketEntry[];
-  all: CanonicalMetricDataPoint[];
-}): CanonicalMetricDataPoint[] {
-  const predecessors: CanonicalMetricDataPoint[] = [];
+  all: MetricRollupSourcePoint[];
+}): MetricRollupSourcePoint[] {
+  const predecessors: MetricRollupSourcePoint[] = [];
   for (const { point, index } of entries) {
     const previous = usablePredecessor({ point, all, index });
     if (previous) predecessors.push(previous);
@@ -87,9 +89,9 @@ function differenceHistogramPoint({
   all,
   bounds,
 }: {
-  point: CanonicalMetricDataPoint;
+  point: MetricRollupSourcePoint;
   index: number;
-  all: CanonicalMetricDataPoint[];
+  all: MetricRollupSourcePoint[];
   bounds: number[];
 }): { counts: bigint[]; count: bigint; sum: number | null } | null {
   const previous = usablePredecessor({ point, all, index });
@@ -122,7 +124,7 @@ export function buildHistogramRow({
 }: {
   row: MetricRollupRow;
   entries: BucketEntry[];
-  all: CanonicalMetricDataPoint[];
+  all: MetricRollupSourcePoint[];
 }): void {
   // Cumulative points are subtracted only after both sides have been coarsened
   // onto the same exactly mergeable boundary set, so each usable predecessor

--- a/platform/app/src/server/event-sourcing/pipelines/metric-processing/rollup/exponentialHistogram.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/metric-processing/rollup/exponentialHistogram.ts
@@ -1,7 +1,4 @@
-import type {
-  CanonicalMetricDataPoint,
-  MetricRollupRow,
-} from "../schemas/metricDataPoint";
+import type { MetricRollupRow } from "../schemas/metricDataPoint";
 import {
   absorbZeroBuckets,
   type BucketMap,
@@ -13,7 +10,12 @@ import {
   subtractMaps,
 } from "./exponentialBuckets";
 import { type BucketEntry, extendExtrema, resetOrGap } from "./row";
-import { bigint, previousPoint, startsNewSequence } from "./sequence";
+import {
+  bigint,
+  type MetricRollupSourcePoint,
+  previousPoint,
+  startsNewSequence,
+} from "./sequence";
 
 /** A point re-expressed at the bucket's common scale and zero threshold. */
 interface NormalizedPoint {
@@ -39,7 +41,7 @@ function mergedIndexSpan({
   points,
   scale,
 }: {
-  points: CanonicalMetricDataPoint[];
+  points: MetricRollupSourcePoint[];
   scale: number;
 }): number {
   let span = 0;
@@ -65,7 +67,7 @@ function mergedIndexSpan({
 }
 
 function selectCommonLayout(
-  contributors: Map<string, CanonicalMetricDataPoint>,
+  contributors: Map<string, MetricRollupSourcePoint>,
 ): CommonLayout {
   const points = [...contributors.values()];
   let scale = Math.min(...points.map((point) => point.exponentialScale ?? 0));
@@ -114,7 +116,7 @@ function normalizePoint({
   point,
   layout,
 }: {
-  point: CanonicalMetricDataPoint;
+  point: MetricRollupSourcePoint;
   layout: CommonLayout;
 }): NormalizedPoint {
   const buckets = layout.downscaled.get(point.pointId)!;
@@ -173,10 +175,10 @@ function usablePredecessor({
   all,
   index,
 }: {
-  point: CanonicalMetricDataPoint;
-  all: CanonicalMetricDataPoint[];
+  point: MetricRollupSourcePoint;
+  all: MetricRollupSourcePoint[];
   index: number;
-}): CanonicalMetricDataPoint | undefined {
+}): MetricRollupSourcePoint | undefined {
   if (point.aggregationTemporality !== "cumulative") return undefined;
   const previous = previousPoint(all, index);
   if (previous?.metricKind !== "exponential_histogram") {
@@ -191,17 +193,17 @@ function collectContributors({
   all,
 }: {
   entries: BucketEntry[];
-  all: CanonicalMetricDataPoint[];
-}): Map<string, CanonicalMetricDataPoint> {
-  const predecessors = new Map<string, CanonicalMetricDataPoint>();
+  all: MetricRollupSourcePoint[];
+}): Map<string, MetricRollupSourcePoint> {
+  const predecessors = new Map<string, MetricRollupSourcePoint>();
   for (const { point, index } of entries) {
     const previous = usablePredecessor({ point, all, index });
     if (previous) predecessors.set(previous.pointId, previous);
   }
-  return new Map<string, CanonicalMetricDataPoint>([
+  return new Map<string, MetricRollupSourcePoint>([
     ...entries.map(
       ({ point }) =>
-        [point.pointId, point] as [string, CanonicalMetricDataPoint],
+        [point.pointId, point] as [string, MetricRollupSourcePoint],
     ),
     ...predecessors,
   ]);
@@ -220,7 +222,7 @@ export function buildExponentialHistogramRow({
 }: {
   row: MetricRollupRow;
   entries: BucketEntry[];
-  all: CanonicalMetricDataPoint[];
+  all: MetricRollupSourcePoint[];
 }): void {
   const layout = selectCommonLayout(collectContributors({ entries, all }));
 

--- a/platform/app/src/server/event-sourcing/pipelines/metric-processing/rollup/row.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/metric-processing/rollup/row.ts
@@ -1,13 +1,10 @@
 import { METRIC_ROLLUP_INTERVAL_MS } from "../schemas/constants";
-import type {
-  CanonicalMetricDataPoint,
-  MetricRollupRow,
-} from "../schemas/metricDataPoint";
-import { bigint, isGap } from "./sequence";
+import type { MetricRollupRow } from "../schemas/metricDataPoint";
+import { bigint, isGap, type MetricRollupSourcePoint } from "./sequence";
 
 /** One point of a bucket, with its index into the whole ordered series. */
 export interface BucketEntry {
-  point: CanonicalMetricDataPoint;
+  point: MetricRollupSourcePoint;
   index: number;
 }
 
@@ -15,7 +12,7 @@ export function baseRow({
   point,
   bucketStartMs,
 }: {
-  point: CanonicalMetricDataPoint;
+  point: MetricRollupSourcePoint;
   bucketStartMs: number;
 }): MetricRollupRow {
   return {
@@ -63,8 +60,8 @@ export function resetOrGap({
   current,
 }: {
   row: MetricRollupRow;
-  previous: CanonicalMetricDataPoint | undefined;
-  current: CanonicalMetricDataPoint;
+  previous: MetricRollupSourcePoint | undefined;
+  current: MetricRollupSourcePoint;
 }): void {
   if (isGap(previous, current)) row.gapCount++;
   else if (previous) row.resetCount++;
@@ -79,7 +76,7 @@ export function extendExtrema({
   point,
 }: {
   row: MetricRollupRow;
-  point: CanonicalMetricDataPoint;
+  point: MetricRollupSourcePoint;
 }): void {
   if (point.min !== null) {
     row.min = row.min === null ? point.min : Math.min(row.min, point.min);

--- a/platform/app/src/server/event-sourcing/pipelines/metric-processing/rollup/scalar.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/metric-processing/rollup/scalar.ts
@@ -1,9 +1,11 @@
-import type {
-  CanonicalMetricDataPoint,
-  MetricRollupRow,
-} from "../schemas/metricDataPoint";
+import type { MetricRollupRow } from "../schemas/metricDataPoint";
 import { addStats, type BucketEntry, resetOrGap } from "./row";
-import { numberValue, previousPoint, startsNewSequence } from "./sequence";
+import {
+  type MetricRollupSourcePoint,
+  numberValue,
+  previousPoint,
+  startsNewSequence,
+} from "./sequence";
 
 export function buildGaugeRow({
   row,
@@ -27,7 +29,7 @@ export function buildSumRow({
 }: {
   row: MetricRollupRow;
   entries: BucketEntry[];
-  all: CanonicalMetricDataPoint[];
+  all: MetricRollupSourcePoint[];
 }): void {
   for (const { point, index } of entries) {
     const current = numberValue(point);

--- a/platform/app/src/server/event-sourcing/pipelines/metric-processing/rollup/sequence.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/metric-processing/rollup/sequence.ts
@@ -10,7 +10,7 @@ export function bigint(value: string | null | undefined): bigint {
   }
 }
 
-export function numberValue(point: CanonicalMetricDataPoint): number | null {
+export function numberValue(point: MetricRollupSourcePoint): number | null {
   if (point.valueType === "double") return point.valueDouble;
   if (point.valueType === "int" && point.valueInt !== null) {
     const value = Number(point.valueInt);
@@ -42,6 +42,45 @@ export type MetricSequencePoint = Pick<
   | "aggregationTemporality"
 >;
 
+/**
+ * The fields the rollup fold actually reads, on top of the ordering fields a
+ * seek needs. Naming them is what lets the authoritative read stop asking for
+ * the rest: attributes, schema urls, scope identity, flags, quantiles and the
+ * accounting timestamps are stored on every point and read by none of the
+ * builders below, yet `FINAL` materialised all of them for every row a seek
+ * scanned — the megabytes-per-granule that pushed the reads over the server's
+ * memory cap (`while reading column PointAttributesJson`).
+ *
+ * `MetricRollupSourcePoint` stays assignable to this, so a caller holding a
+ * whole point still folds; the type only bounds what a caller *must* supply,
+ * and so what a read has to fetch.
+ */
+export type MetricRollupSourcePoint = MetricSequencePoint &
+  Pick<
+    CanonicalMetricDataPoint,
+    | "tenantId"
+    | "metricName"
+    | "metricUnit"
+    | "isMonotonic"
+    | "startTimeUnixNano"
+    | "valueType"
+    | "valueInt"
+    | "valueDouble"
+    | "count"
+    | "sum"
+    | "min"
+    | "max"
+    | "explicitBounds"
+    | "bucketCounts"
+    | "exponentialScale"
+    | "exponentialZeroThreshold"
+    | "zeroCount"
+    | "positiveOffset"
+    | "positiveBucketCounts"
+    | "negativeOffset"
+    | "negativeBucketCounts"
+  >;
+
 /** Mirrors the ClickHouse ORDER BY, which collates PointId by bytes. */
 export function comparePoints(
   left: MetricSequencePoint,
@@ -55,8 +94,8 @@ export function comparePoints(
 }
 
 export function isGap(
-  previous: CanonicalMetricDataPoint | undefined,
-  current: CanonicalMetricDataPoint,
+  previous: MetricRollupSourcePoint | undefined,
+  current: MetricRollupSourcePoint,
 ): boolean {
   return (
     !!previous &&
@@ -65,8 +104,8 @@ export function isGap(
 }
 
 export function startsNewSequence(
-  previous: CanonicalMetricDataPoint | undefined,
-  current: CanonicalMetricDataPoint,
+  previous: MetricRollupSourcePoint | undefined,
+  current: MetricRollupSourcePoint,
 ): boolean {
   return (
     !previous ||
@@ -90,8 +129,8 @@ export function usesPredecessor(point: MetricSequencePoint): boolean {
 }
 
 export function previousPoint(
-  all: CanonicalMetricDataPoint[],
+  all: MetricRollupSourcePoint[],
   index: number,
-): CanonicalMetricDataPoint | undefined {
+): MetricRollupSourcePoint | undefined {
   return index > 0 ? all[index - 1] : undefined;
 }

--- a/platform/app/src/server/event-sourcing/pipelines/metric-processing/rollup/summary.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/metric-processing/rollup/summary.ts
@@ -1,9 +1,11 @@
-import type {
-  CanonicalMetricDataPoint,
-  MetricRollupRow,
-} from "../schemas/metricDataPoint";
+import type { MetricRollupRow } from "../schemas/metricDataPoint";
 import { type BucketEntry, resetOrGap } from "./row";
-import { bigint, previousPoint, startsNewSequence } from "./sequence";
+import {
+  bigint,
+  type MetricRollupSourcePoint,
+  previousPoint,
+  startsNewSequence,
+} from "./sequence";
 
 /**
  * OTLP summaries are cumulative even though they carry no temporality field.
@@ -17,7 +19,7 @@ export function buildSummaryRow({
 }: {
   row: MetricRollupRow;
   entries: BucketEntry[];
-  all: CanonicalMetricDataPoint[];
+  all: MetricRollupSourcePoint[];
 }): void {
   let count = 0n;
   let sum = 0;

--- a/specs/otlp/canonical-metric-ingestion.feature
+++ b/specs/otlp/canonical-metric-ingestion.feature
@@ -94,6 +94,12 @@ Feature: Canonical OTLP metric ingestion
   # window by design, because folding it would trade a single-row index seek
   # for a scan of the whole retention window. What every scenario here holds to
   # is a stated ceiling the batch cannot push a request past.
+  #
+  # A bounded request is not yet a bounded read. Those seeks still read the
+  # whole retention span looking backwards, and fetched every stored column to
+  # do it, so a request that never grew could still read millions of rows to
+  # return a hundred — and storage ran out of memory doing it. The last two
+  # scenarios bound the read as well: what a seek looks at, and how far.
   Rule: Rebuilding summaries sends a request bounded independently of the batch
 
     @unit
@@ -139,6 +145,23 @@ Feature: Canonical OTLP metric ingestion
       Then the request carries the window size and the retention span once,
         not once per window
       And a full request of window seeks still fits the size a request may be
+
+    @unit
+    Scenario: A rollup bucket read asks only for the columns a rollup uses
+      Given a summary window has to be recomputed
+      When the platform reads the points that window covers
+      Then it asks for the values and identity a summary is built from
+      And it asks for none of the attributes, labels or descriptions it never
+        reads
+
+    @unit
+    Scenario: A rollup bucket read looks close before it looks far
+      Given a summary window has to be recomputed
+      When the platform looks for the sample preceding that window
+      Then it first looks back a short way
+      And it searches the rest of the retention span only for the windows the
+        short look left unanswered
+      And the two searches together cover the same span as one wide search
 
     @integration
     Scenario: A batch folds to the summaries a point-at-a-time rebuild produces


### PR DESCRIPTION
## Why

The authoritative read behind `recomputeAffectedRollupsMany` is bounded in
request size but not in what it reads. Every bound in this file so far —
`SEEKS_PER_QUERY`, `SUCCESSOR_PARAM_BUDGET_CHARS`, the fixed successor
statement — caps how large a request may be. None caps how much a request may
read, and this one reads a lot:

| | |
|---|---|
| branches in one statement | 64 |
| rows read | 2.2M – 3.2M |
| rows returned | 78 – 116 |
| peak memory | 3.45 GiB |
| duration | 7.6 – 17.4 s |

About 25,000 rows read per row returned, ~37,000 rows per branch. At enough
concurrency this table alone accounts for the large majority of the server's
memory, and queries start failing on `MEMORY_LIMIT_EXCEEDED`. The failing
allocation names the column: `Code: 241 ... (while reading column
PointAttributesJson)` — a column no rollup reads.

Two things make one seek that expensive.

`FINAL` materialises every selected column for every row a granule covers, not
for the rows returned. The read selected essentially the whole row, so the
attribute JSON blobs were decompressed for millions of scanned rows and
discarded.

And the predecessor seek's lower bound was the entire retention window — 49
days by default. The table partitions by ISO week, so one reverse seek looking
for a single row opened every weekly part the series appears in.

Neither is a traffic problem. A busier series only makes an already-wrong read
run more often.

## What changed

Two bounds, both on what a seek looks at.

**1. Ask for the columns a rollup is made of, and no others.**

`ROLLUP_SELECT` replaces `AUTHORITATIVE_SELECT`. Dropped: both attribute JSON
blobs, the attribute key arrays, resource and scope identity, the description,
flags, the quantile JSON, and the size/acceptance bookkeeping. None is a rollup
input — quantiles are explicitly not aggregatable, see `buildSummaryRow`.

A new type, `MetricRollupSourcePoint`, names that contract the way
`MetricSequencePoint` already does for seeks, so a builder cannot read a column
the read does not fetch without failing to compile.

**2. Look close before looking far.**

The predecessor seek now looks back an hour first, and widens to the rest of
retention only for the buckets that found nothing there. The two windows abut
and do not overlap, so their union is exactly the single window this replaced:
same rows, same predecessor, without every bucket paying for the wide read. A
live series resolves in the near pass. Two cases always reach the far pass and
both are bounded: a series whose first points are arriving has no predecessor
at any distance, and a gap wider than an hour is the case the far pass exists
for. Both cost one round trip on top of what the single-pass read already cost.
Under series churn the first is the common path, not a rare one.

`RAW_SELECT` and `fromRaw` are removed — nothing reads whole rows any more.

## Test plan

- `specs/otlp/canonical-metric-ingestion.feature`: two new `@unit` scenarios,
  one per bound. `check-feature-parity.ts` reports 10/10 bound.
- New unit tests: the bucket read asks for none of the 13 dropped columns and
  still asks for what a rollup needs; a resolved near seek sends no far read;
  the far read's window abuts the near one and carries only the predecessor
  branch.
- Updated the three "flat reads" tests — against an empty table no near seek
  resolves, so the count is 3 rather than 2, and what they assert (it does not
  grow with the chunk) still holds.
- `pnpm vitest run src/server/app-layer/metrics` — 32 passed.
- Every statement the changed code generates was executed against a real
  ClickHouse with the real schema, with its bound parameters; each parsed and
  ran.
- Typecheck clean for every touched path.
- CI ran the integration suite: 1936 of 1937 passed. The one failure was the
  counted-reads assertion, which folds a brand new series and so reaches the far
  pass for every bucket — 3 reads, not 2. Expectation and comment corrected; the
  equivalence tests (folded batch vs. point-at-a-time rebuild) passed unchanged.

## Anything surprising?

**The integration tests could not be run locally, so CI ran them first.** The
local test Postgres has a failed migration
(`20260215183000_add_billing_schema_to_oss`) that will not replay — its enum
type is missing — which is local state, not something this branch introduced.
CI ran the suite and it earned its keep: the equivalence check (folded batch
vs. point-at-a-time rebuild) passed, and the counted-reads test caught that a
series with no history reaches the far pass for every bucket. That is real
behaviour, now stated in the code and expected by the test, rather than
something discovered in production.

One judgement call worth a reviewer's eye: `PREDECESSOR_LOOKBACK_MS` is one
hour. Nothing depends on the exact value — too small only sends more buckets to
the second pass, too large only widens the first — but it is the one number
here that is chosen rather than derived.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Rollup rebuilding now reads only the data needed to calculate each summary.
  * Predecessor searches use a short lookback before selectively expanding across the retention period.
  * Reduced unnecessary data retrieval, improving memory usage and efficiency.

* **Bug Fixes**
  * Improved handling of live metric series and predecessor points during rollup reconstruction.

* **Tests**
  * Added coverage for optimized column selection, bounded lookback behavior, and fallback searches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
