### PR TITLE
fix(traces): stop the trace list deriving the version dedup twice per page

### DIFF
--- a/platform/app/src/server/app-layer/traces/repositories/__tests__/trace-list.clickhouse.repository.integration.test.ts
+++ b/platform/app/src/server/app-layer/traces/repositories/__tests__/trace-list.clickhouse.repository.integration.test.ts
@@ -774,7 +774,7 @@ describe("TraceListClickHouseRepository.findAll across unmerged same-version row
       // assertion below would stop testing anything — passing or failing on
       // whichever version happened to survive. Hold merges off the table for
       // the duration.
-      await ch.exec({ query: "SYSTEM STOP MERGES trace_summaries" });
+      await ch.command({ query: "SYSTEM STOP MERGES trace_summaries" });
 
       // Separate inserts on purpose: two rows with the same sorting key in one
       // block are collapsed at part formation, which is not the case here.
@@ -797,7 +797,7 @@ describe("TraceListClickHouseRepository.findAll across unmerged same-version row
     });
 
     afterAll(async () => {
-      await ch.exec({ query: "SYSTEM START MERGES trace_summaries" });
+      await ch.command({ query: "SYSTEM START MERGES trace_summaries" });
       await ch.exec({
         query:
           "ALTER TABLE trace_summaries DELETE WHERE TenantId = {tenantId:String}",

--- a/platform/app/src/server/app-layer/traces/repositories/__tests__/trace-list.clickhouse.repository.integration.test.ts
+++ b/platform/app/src/server/app-layer/traces/repositories/__tests__/trace-list.clickhouse.repository.integration.test.ts
@@ -39,16 +39,44 @@ function traceIdFor(i: number): string {
   return `tr-${String(i).padStart(4, "0")}`;
 }
 
-/** system.query_log only exists on a server started with log_queries enabled. */
+/**
+ * Whether this server actually RECORDS queries, which is what the read-cost
+ * assertions need.
+ *
+ * Table existence alone does not answer that: `log_queries = 0` stops the
+ * recording but leaves `system.query_log` in place, so a guard that only
+ * checks the table passes and then the assertions fail on an empty result.
+ * Run a query under a known id and look for its own row instead.
+ */
 async function hasQueryLog(client: ClickHouseClient): Promise<boolean> {
-  const rows = (await (
+  const tables = (await (
     await client.query({
       query: `SELECT count() AS n FROM system.tables
               WHERE database = 'system' AND name = 'query_log'`,
       format: "JSONEachRow",
     })
   ).json()) as Array<{ n: string }>;
-  return Number(rows[0]?.n ?? 0) > 0;
+  if (Number(tables[0]?.n ?? 0) === 0) return false;
+
+  const probeId = `query-log-probe-${nanoid()}`;
+  await (
+    await client.query({
+      query: "SELECT 1 AS probe",
+      query_id: probeId,
+      format: "JSONEachRow",
+    })
+  ).json();
+  await client.exec({ query: "SYSTEM FLUSH LOGS" });
+
+  const logged = (await (
+    await client.query({
+      query: `SELECT count() AS n FROM system.query_log
+              WHERE query_id = {probeId:String} AND type = 'QueryFinish'`,
+      query_params: { probeId },
+      format: "JSONEachRow",
+    })
+  ).json()) as Array<{ n: string }>;
+  return Number(logged[0]?.n ?? 0) > 0;
 }
 
 function makeTraceSummaryRow(
@@ -741,6 +769,13 @@ describe("TraceListClickHouseRepository.findAll across unmerged same-version row
     const dupAt = new Date(base + 500);
 
     beforeAll(async () => {
+      // The fixture IS the unmerged state, so a background merge landing
+      // between the inserts and the read would collapse the two rows and the
+      // assertion below would stop testing anything — passing or failing on
+      // whichever version happened to survive. Hold merges off the table for
+      // the duration.
+      await ch.exec({ query: "SYSTEM STOP MERGES trace_summaries" });
+
       // Separate inserts on purpose: two rows with the same sorting key in one
       // block are collapsed at part formation, which is not the case here.
       for (const traceName of ["keep", "drop"]) {
@@ -762,11 +797,25 @@ describe("TraceListClickHouseRepository.findAll across unmerged same-version row
     });
 
     afterAll(async () => {
+      await ch.exec({ query: "SYSTEM START MERGES trace_summaries" });
       await ch.exec({
         query:
           "ALTER TABLE trace_summaries DELETE WHERE TenantId = {tenantId:String}",
         query_params: { tenantId: dupTenant },
       });
+    });
+
+    it("keeps both rows unmerged, so the assertion below is not vacuous", async () => {
+      const rows = (await (
+        await ch.query({
+          query: `SELECT TraceName FROM trace_summaries
+                  WHERE TenantId = {tenantId:String} ORDER BY TraceName`,
+          query_params: { tenantId: dupTenant },
+          format: "JSONEachRow",
+        })
+      ).json()) as Array<{ TraceName: string }>;
+
+      expect(rows.map((r) => r.TraceName)).toEqual(["drop", "keep"]);
     });
 
     it("returns only the version the filter matches, and agrees with its own total", async () => {

--- a/platform/app/src/server/app-layer/traces/repositories/__tests__/trace-list.clickhouse.repository.integration.test.ts
+++ b/platform/app/src/server/app-layer/traces/repositories/__tests__/trace-list.clickhouse.repository.integration.test.ts
@@ -154,15 +154,18 @@ async function captureFindAllQueries(
 ): Promise<{ query: string; query_params: Record<string, unknown> }[]> {
   const captured: { query: string; query_params: Record<string, unknown> }[] =
     [];
-  const recordingClient = {
-    query: async (args: {
-      query: string;
-      query_params: Record<string, unknown>;
-    }) => {
-      captured.push({ query: args.query, query_params: args.query_params });
-      return ch.query(args as Parameters<ClickHouseClient["query"]>[0]);
+  const recordingClient = new Proxy(ch, {
+    get(target, prop, receiver) {
+      if (prop !== "query") return Reflect.get(target, prop, receiver);
+      return (args: Parameters<ClickHouseClient["query"]>[0]) => {
+        captured.push({
+          query: args.query,
+          query_params: (args.query_params ?? {}) as Record<string, unknown>,
+        });
+        return target.query(args);
+      };
     },
-  } as unknown as ClickHouseClient;
+  }) as ClickHouseClient;
 
   await new TraceListClickHouseRepository(async () => recordingClient).findAll(
     query,
@@ -726,3 +729,62 @@ describe("TraceListClickHouseRepository filtering across row versions", () => {
     });
   });
 });
+
+describe("TraceListClickHouseRepository.findAll across unmerged same-version rows", () => {
+  describe("when two unmerged rows share one version identity", () => {
+    // `trace_summaries` is a ReplacingMergeTree, so a re-publish at the same
+    // `UpdatedAt` lives in its own part until a merge collapses it. Both rows
+    // then answer to the same (TenantId, TraceId, UpdatedAt), and identity
+    // alone cannot say which one the user's filter meant. The page read has to
+    // re-apply the filter after the identity handover to pick the right one.
+    const dupTenant = `test-trace-list-dup-${nanoid()}`;
+    const dupAt = new Date(base + 500);
+
+    beforeAll(async () => {
+      // Separate inserts on purpose: two rows with the same sorting key in one
+      // block are collapsed at part formation, which is not the case here.
+      for (const traceName of ["keep", "drop"]) {
+        await ch.insert({
+          table: "trace_summaries",
+          values: [
+            makeTraceSummaryRow(9001, {
+              TenantId: dupTenant,
+              TraceId: "dup-1",
+              OccurredAt: dupAt,
+              UpdatedAt: dupAt,
+              TraceName: traceName,
+            }),
+          ],
+          format: "JSONEachRow",
+          clickhouse_settings: { async_insert: 0, wait_for_async_insert: 0 },
+        });
+      }
+    });
+
+    afterAll(async () => {
+      await ch.exec({
+        query:
+          "ALTER TABLE trace_summaries DELETE WHERE TenantId = {tenantId:String}",
+        query_params: { tenantId: dupTenant },
+      });
+    });
+
+    it("returns only the version the filter matches, and agrees with its own total", async () => {
+      const page = await repo.findAll({
+        tenantId: dupTenant,
+        timeRange: { from: base - 60_000, to: base + 3_600_000 },
+        sort: { column: "OccurredAt", direction: "desc" },
+        limit: 25,
+        offset: 0,
+        filterWhere: {
+          sql: "TraceName = {dupName:String}",
+          params: { dupName: "keep" },
+        },
+      });
+
+      expect(page.rows.map((r) => r.traceName)).toEqual(["keep"]);
+      expect(page.rows).toHaveLength(page.totalHits);
+    });
+  });
+});
+

--- a/platform/app/src/server/app-layer/traces/repositories/__tests__/trace-list.clickhouse.repository.integration.test.ts
+++ b/platform/app/src/server/app-layer/traces/repositories/__tests__/trace-list.clickhouse.repository.integration.test.ts
@@ -144,6 +144,32 @@ async function insertRows(rows: ReturnType<typeof makeTraceSummaryRow>[]) {
   }
 }
 
+/**
+ * Run `findAll` against the real client while recording the SQL it issues, so
+ * a test can re-run the repository's own query under a known `query_id` and
+ * read its cost back out of `system.query_log`.
+ */
+async function captureFindAllQueries(
+  query: TraceListQuery,
+): Promise<{ query: string; query_params: Record<string, unknown> }[]> {
+  const captured: { query: string; query_params: Record<string, unknown> }[] =
+    [];
+  const recordingClient = {
+    query: async (args: {
+      query: string;
+      query_params: Record<string, unknown>;
+    }) => {
+      captured.push({ query: args.query, query_params: args.query_params });
+      return ch.query(args as Parameters<ClickHouseClient["query"]>[0]);
+    },
+  } as unknown as ClickHouseClient;
+
+  await new TraceListClickHouseRepository(async () => recordingClient).findAll(
+    query,
+  );
+  return captured;
+}
+
 function baseQuery(): TraceListQuery {
   return {
     tenantId,
@@ -316,6 +342,96 @@ describe("TraceListClickHouseRepository.findAll (integration)", () => {
       expect(naiveMem).toBeGreaterThan(0);
       expect(pagedMem).toBeGreaterThan(0);
       expect(pagedMem).toBeLessThan(naiveMem);
+    });
+
+    it("does not re-derive the version dedup in the outer stage of its own page read", async ({
+      skip,
+    }) => {
+      if (!(await hasQueryLog(ch))) {
+        skip(
+          "ClickHouse runs with log_queries=0, so system.query_log is absent",
+        );
+      }
+
+      // The dedup is a whole-window aggregate. Stating it in the outer stage
+      // as well makes ClickHouse build it a second time to reach rows the
+      // inner stage already named. Asserted against the SQL the repository
+      // really emits, not a hand-written stand-in.
+      const emitted = await captureFindAllQueries(baseQuery());
+      const pageRead = emitted.find((q) => q.query.includes("ComputedInput"));
+      expect(pageRead).toBeDefined();
+
+      const params = { tenantId, from: base - 60_000, limit: PAGE_LIMIT };
+      const where = `TenantId = {tenantId:String}
+        AND OccurredAt >= fromUnixTimestamp64Milli({from:Int64})`;
+      const dedup = `(TenantId, TraceId, UpdatedAt) IN (
+        SELECT TenantId, TraceId, max(UpdatedAt)
+        FROM trace_summaries
+        WHERE ${where}
+        GROUP BY TenantId, TraceId
+      )`;
+
+      const currentId = `handover-${nanoid()}`;
+      const rederivedId = `rederived-${nanoid()}`;
+
+      await ch
+        .query({
+          query: pageRead!.query,
+          query_params: pageRead!.query_params,
+          query_id: currentId,
+          format: "JSONEachRow",
+        })
+        .then((r) => r.json());
+
+      // The shape this replaced: the outer stage takes only TraceIds from the
+      // inner stage and re-states both the dedup and the user filter.
+      await ch
+        .query({
+          query: `
+            SELECT TraceId, ComputedInput, ComputedOutput
+            FROM trace_summaries
+            WHERE ${where}
+              AND TraceId IN (
+                SELECT TraceId
+                FROM trace_summaries
+                WHERE ${where} AND ${dedup}
+                ORDER BY OccurredAt DESC
+                LIMIT {limit:UInt32}
+              )
+              AND ${dedup}
+            ORDER BY OccurredAt DESC
+            LIMIT {limit:UInt32}
+          `,
+          query_params: params,
+          query_id: rederivedId,
+          format: "JSONEachRow",
+        })
+        .then((r) => r.json());
+
+      await ch.exec({ query: "SYSTEM FLUSH LOGS" });
+
+      const rowRows = (await (
+        await ch.query({
+          query: `
+            SELECT query_id, max(read_rows) AS rows_read
+            FROM system.query_log
+            WHERE query_id IN ({currentId:String}, {rederivedId:String})
+              AND type = 'QueryFinish'
+            GROUP BY query_id
+          `,
+          query_params: { currentId, rederivedId },
+          format: "JSONEachRow",
+        })
+      ).json()) as Array<{ query_id: string; rows_read: string }>;
+
+      const rowsOf = (id: string) =>
+        Number(rowRows.find((r) => r.query_id === id)?.rows_read ?? 0);
+      const currentRows = rowsOf(currentId);
+      const rederivedRows = rowsOf(rederivedId);
+
+      expect(currentRows).toBeGreaterThan(0);
+      expect(rederivedRows).toBeGreaterThan(0);
+      expect(currentRows).toBeLessThan(rederivedRows);
     });
   });
 

--- a/platform/app/src/server/app-layer/traces/repositories/__tests__/trace-list.clickhouse.repository.integration.test.ts
+++ b/platform/app/src/server/app-layer/traces/repositories/__tests__/trace-list.clickhouse.repository.integration.test.ts
@@ -787,4 +787,3 @@ describe("TraceListClickHouseRepository.findAll across unmerged same-version row
     });
   });
 });
-

--- a/platform/app/src/server/app-layer/traces/repositories/__tests__/trace-list.clickhouse.repository.unit.test.ts
+++ b/platform/app/src/server/app-layer/traces/repositories/__tests__/trace-list.clickhouse.repository.unit.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Unit tests for the SQL `findAll` emits.
+ *
+ * The list is paged in two stages: an inner stage picks the page's traces
+ * (cheap, key + sort columns only), an outer stage reads the heavy payload
+ * columns for that page alone. Both stages, plus the total count, have to
+ * agree on which version of a trace is current.
+ *
+ * The version dedup is a full-window aggregate — it groups every row the
+ * tenant has in the time range. Emitting it more than once per read makes
+ * ClickHouse build that aggregate more than once, which is the dominant cost
+ * of this list on large tenants. The outer stage does not need it: the inner
+ * stage already resolved which exact row won, so it can hand the row's
+ * identity over instead of re-deriving it.
+ *
+ * These assertions are on the emitted SQL because that is where the defect
+ * lives; the companion integration test proves the dedup semantics and the
+ * read-rows reduction against a real ClickHouse.
+ */
+import type { ClickHouseClient } from "@clickhouse/client";
+import { describe, expect, it, vi } from "vitest";
+import { TraceListClickHouseRepository } from "../trace-list.clickhouse.repository";
+import type { TraceListQuery } from "../trace-list.repository";
+
+/** The full-window version dedup, identified by its GROUP BY. */
+const DEDUP_AGGREGATE = "GROUP BY TenantId, TraceId";
+
+function occurrences(haystack: string, needle: string): number {
+  return haystack.split(needle).length - 1;
+}
+
+function makeRepo() {
+  const queries: string[] = [];
+  const client = {
+    query: vi.fn(async ({ query }: { query: string }) => {
+      queries.push(query);
+      return { json: async () => [] };
+    }),
+  } as unknown as ClickHouseClient;
+  return {
+    repo: new TraceListClickHouseRepository(async () => client),
+    queries,
+  };
+}
+
+function baseQuery(overrides: Partial<TraceListQuery> = {}): TraceListQuery {
+  return {
+    tenantId: "tenant-1",
+    timeRange: { from: 1_000, to: 2_000 },
+    sort: { column: "OccurredAt", direction: "desc" },
+    limit: 25,
+    offset: 0,
+    ...overrides,
+  };
+}
+
+/** The page read is the one that projects the heavy payload columns. */
+const isPageQuery = (sql: string) => sql.includes("ComputedInput");
+const isCountQuery = (sql: string) => sql.includes("totalHits");
+
+describe("TraceListClickHouseRepository.findAll (unit)", () => {
+  it("builds the version dedup aggregate once for the page read, not once per stage", async () => {
+    const { repo, queries } = makeRepo();
+
+    await repo.findAll(baseQuery());
+
+    const pageQuery = queries.find(isPageQuery);
+    expect(pageQuery).toBeDefined();
+    expect(occurrences(pageQuery!, DEDUP_AGGREGATE)).toBe(1);
+  });
+
+  it("carries the winning row's identity from the inner page stage to the outer read", async () => {
+    const { repo, queries } = makeRepo();
+
+    await repo.findAll(baseQuery());
+
+    const pageQuery = queries.find(isPageQuery)!;
+    // The inner stage resolved (TraceId, UpdatedAt) for the page. The outer
+    // stage selects exactly those rows, so it needs no dedup of its own.
+    expect(pageQuery).toContain("(TenantId, TraceId, UpdatedAt) IN (");
+    expect(pageQuery).toContain("SELECT TenantId, TraceId, UpdatedAt");
+  });
+
+  it("still bounds the total count by the version dedup", async () => {
+    const { repo, queries } = makeRepo();
+
+    await repo.findAll(baseQuery());
+
+    const countQuery = queries.find(isCountQuery);
+    expect(countQuery).toBeDefined();
+    expect(occurrences(countQuery!, DEDUP_AGGREGATE)).toBe(1);
+  });
+
+  it("keeps the user filter out of the dedup so a trace cannot answer to both sides of it", async () => {
+    const { repo, queries } = makeRepo();
+
+    await repo.findAll(
+      baseQuery({
+        filterWhere: {
+          sql: "AnnotationIds != []",
+          params: { unused: 1 },
+        },
+      }),
+    );
+
+    for (const sql of queries) {
+      // Everything between the dedup subquery's FROM and its GROUP BY is the
+      // predicate the dedup is decided on. The user filter must not be there.
+      const dedupBodies = sql
+        .split(DEDUP_AGGREGATE)
+        .slice(0, -1)
+        .map((chunk) => chunk.slice(chunk.lastIndexOf("SELECT TenantId")));
+      for (const body of dedupBodies) {
+        expect(body).not.toContain("AnnotationIds != []");
+      }
+    }
+  });
+});

--- a/platform/app/src/server/app-layer/traces/repositories/__tests__/trace-list.clickhouse.repository.unit.test.ts
+++ b/platform/app/src/server/app-layer/traces/repositories/__tests__/trace-list.clickhouse.repository.unit.test.ts
@@ -25,7 +25,16 @@ import type { TraceListQuery } from "../trace-list.repository";
 /** The full-window version dedup, identified by its GROUP BY. */
 const DEDUP_AGGREGATE = "GROUP BY TenantId, TraceId";
 
-function occurrences(haystack: string, needle: string): number {
+/** Where the outer page stage hands the chosen row identities to the inner one. */
+const IDENTITY_HANDOVER = "(TenantId, TraceId, UpdatedAt) IN (";
+
+function occurrences({
+  haystack,
+  needle,
+}: {
+  haystack: string;
+  needle: string;
+}): number {
   return haystack.split(needle).length - 1;
 }
 
@@ -69,7 +78,9 @@ describe("TraceListClickHouseRepository.findAll (unit)", () => {
 
       const pageQuery = queries.find(isPageQuery);
       expect(pageQuery).toBeDefined();
-      expect(occurrences(pageQuery!, DEDUP_AGGREGATE)).toBe(1);
+      expect(
+        occurrences({ haystack: pageQuery!, needle: DEDUP_AGGREGATE }),
+      ).toBe(1);
     });
 
     it("carries the winning row's identity from the inner page stage to the outer read", async () => {
@@ -91,7 +102,9 @@ describe("TraceListClickHouseRepository.findAll (unit)", () => {
 
       const countQuery = queries.find(isCountQuery);
       expect(countQuery).toBeDefined();
-      expect(occurrences(countQuery!, DEDUP_AGGREGATE)).toBe(1);
+      expect(
+        occurrences({ haystack: countQuery!, needle: DEDUP_AGGREGATE }),
+      ).toBe(1);
     });
   });
 
@@ -129,9 +142,22 @@ describe("TraceListClickHouseRepository.findAll (unit)", () => {
 
       // Identity alone cannot separate two unmerged rows that share one
       // (TenantId, TraceId, UpdatedAt), so the outer stage has to re-state the
-      // filter — once for the inner stage, once for the outer.
+      // filter. Assert WHERE the two copies sit, not just how many there are:
+      // a count alone would also pass with both copies stuck in the inner
+      // stage, which is the arrangement this test exists to rule out.
       const pageQuery = queries.find(isPageQuery)!;
-      expect(occurrences(pageQuery, USER_FILTER)).toBe(2);
+      const handover = pageQuery.indexOf(IDENTITY_HANDOVER);
+      expect(handover).toBeGreaterThan(-1);
+
+      // The outer WHERE is written before the handover, the inner one inside it.
+      const outerStage = pageQuery.slice(0, handover);
+      const innerStage = pageQuery.slice(handover);
+      expect(occurrences({ haystack: outerStage, needle: USER_FILTER })).toBe(
+        1,
+      );
+      expect(occurrences({ haystack: innerStage, needle: USER_FILTER })).toBe(
+        1,
+      );
     });
   });
 });

--- a/platform/app/src/server/app-layer/traces/repositories/__tests__/trace-list.clickhouse.repository.unit.test.ts
+++ b/platform/app/src/server/app-layer/traces/repositories/__tests__/trace-list.clickhouse.repository.unit.test.ts
@@ -58,61 +58,80 @@ function baseQuery(overrides: Partial<TraceListQuery> = {}): TraceListQuery {
 const isPageQuery = (sql: string) => sql.includes("ComputedInput");
 const isCountQuery = (sql: string) => sql.includes("totalHits");
 
+const USER_FILTER = "AnnotationIds != []";
+
 describe("TraceListClickHouseRepository.findAll (unit)", () => {
-  it("builds the version dedup aggregate once for the page read, not once per stage", async () => {
-    const { repo, queries } = makeRepo();
+  describe("when the caller asks for a page of traces", () => {
+    it("builds the version dedup aggregate once for the page read, not once per stage", async () => {
+      const { repo, queries } = makeRepo();
 
-    await repo.findAll(baseQuery());
+      await repo.findAll(baseQuery());
 
-    const pageQuery = queries.find(isPageQuery);
-    expect(pageQuery).toBeDefined();
-    expect(occurrences(pageQuery!, DEDUP_AGGREGATE)).toBe(1);
+      const pageQuery = queries.find(isPageQuery);
+      expect(pageQuery).toBeDefined();
+      expect(occurrences(pageQuery!, DEDUP_AGGREGATE)).toBe(1);
+    });
+
+    it("carries the winning row's identity from the inner page stage to the outer read", async () => {
+      const { repo, queries } = makeRepo();
+
+      await repo.findAll(baseQuery());
+
+      const pageQuery = queries.find(isPageQuery)!;
+      // The inner stage resolved (TraceId, UpdatedAt) for the page. The outer
+      // stage selects exactly those rows, so it needs no dedup of its own.
+      expect(pageQuery).toContain("(TenantId, TraceId, UpdatedAt) IN (");
+      expect(pageQuery).toContain("SELECT TenantId, TraceId, UpdatedAt");
+    });
+
+    it("still bounds the total count by the version dedup", async () => {
+      const { repo, queries } = makeRepo();
+
+      await repo.findAll(baseQuery());
+
+      const countQuery = queries.find(isCountQuery);
+      expect(countQuery).toBeDefined();
+      expect(occurrences(countQuery!, DEDUP_AGGREGATE)).toBe(1);
+    });
   });
 
-  it("carries the winning row's identity from the inner page stage to the outer read", async () => {
-    const { repo, queries } = makeRepo();
+  describe("when the query carries a user filter", () => {
+    it("keeps it out of the dedup so a trace cannot answer to both sides of it", async () => {
+      const { repo, queries } = makeRepo();
 
-    await repo.findAll(baseQuery());
+      await repo.findAll(
+        baseQuery({
+          filterWhere: { sql: USER_FILTER, params: { unused: 1 } },
+        }),
+      );
 
-    const pageQuery = queries.find(isPageQuery)!;
-    // The inner stage resolved (TraceId, UpdatedAt) for the page. The outer
-    // stage selects exactly those rows, so it needs no dedup of its own.
-    expect(pageQuery).toContain("(TenantId, TraceId, UpdatedAt) IN (");
-    expect(pageQuery).toContain("SELECT TenantId, TraceId, UpdatedAt");
-  });
-
-  it("still bounds the total count by the version dedup", async () => {
-    const { repo, queries } = makeRepo();
-
-    await repo.findAll(baseQuery());
-
-    const countQuery = queries.find(isCountQuery);
-    expect(countQuery).toBeDefined();
-    expect(occurrences(countQuery!, DEDUP_AGGREGATE)).toBe(1);
-  });
-
-  it("keeps the user filter out of the dedup so a trace cannot answer to both sides of it", async () => {
-    const { repo, queries } = makeRepo();
-
-    await repo.findAll(
-      baseQuery({
-        filterWhere: {
-          sql: "AnnotationIds != []",
-          params: { unused: 1 },
-        },
-      }),
-    );
-
-    for (const sql of queries) {
-      // Everything between the dedup subquery's FROM and its GROUP BY is the
-      // predicate the dedup is decided on. The user filter must not be there.
-      const dedupBodies = sql
-        .split(DEDUP_AGGREGATE)
-        .slice(0, -1)
-        .map((chunk) => chunk.slice(chunk.lastIndexOf("SELECT TenantId")));
-      for (const body of dedupBodies) {
-        expect(body).not.toContain("AnnotationIds != []");
+      for (const sql of queries) {
+        // Everything between the dedup subquery's FROM and its GROUP BY is the
+        // predicate the dedup is decided on. The user filter must not be there.
+        const dedupBodies = sql
+          .split(DEDUP_AGGREGATE)
+          .slice(0, -1)
+          .map((chunk) => chunk.slice(chunk.lastIndexOf("SELECT TenantId")));
+        for (const body of dedupBodies) {
+          expect(body).not.toContain(USER_FILTER);
+        }
       }
-    }
+    });
+
+    it("applies it to both stages of the page read, so an unmerged same-version row cannot slip through", async () => {
+      const { repo, queries } = makeRepo();
+
+      await repo.findAll(
+        baseQuery({
+          filterWhere: { sql: USER_FILTER, params: { unused: 1 } },
+        }),
+      );
+
+      // Identity alone cannot separate two unmerged rows that share one
+      // (TenantId, TraceId, UpdatedAt), so the outer stage has to re-state the
+      // filter — once for the inner stage, once for the outer.
+      const pageQuery = queries.find(isPageQuery)!;
+      expect(occurrences(pageQuery, USER_FILTER)).toBe(2);
+    });
   });
 });

--- a/platform/app/src/server/app-layer/traces/repositories/trace-list.clickhouse.repository.ts
+++ b/platform/app/src/server/app-layer/traces/repositories/trace-list.clickhouse.repository.ts
@@ -190,18 +190,23 @@ export class TraceListClickHouseRepository implements TraceListRepository {
     //
     // The inner stage hands the outer stage the winning rows' full identity
     // (TenantId, TraceId, UpdatedAt), not just their TraceIds. That identity
-    // IS the dedup result, so the outer stage needs neither `dedupFilter` nor
-    // the user filter again — both were already decided inside. Re-stating
-    // them made ClickHouse build the whole-window dedup aggregate a second
-    // time (and re-run any span subquery the filter carries) to reach the same
-    // rows the inner stage had already named. On a tenant with ~1.3M traces in
-    // the window, dropping that second pass measured 4.45M -> 2.98M rows read
-    // and 4.6s -> 2.3s. The outer WHERE keeps the base predicates so partition
-    // pruning still applies.
+    // IS the dedup result, so the outer stage does not restate `dedupFilter`:
+    // re-stating it made ClickHouse build the whole-window aggregate a second
+    // time to reach rows the inner stage had already named. On a tenant with
+    // ~1.3M traces in the window, dropping that second pass measured 4.45M ->
+    // 2.98M rows read and 4.6s -> 2.3s.
     //
-    // Two physical rows sharing one (TenantId, TraceId, UpdatedAt) would both
-    // match here, as they did under the previous form — the outer LIMIT caps
-    // the page either way.
+    // The outer WHERE does keep the full `whereClause`, not just the base
+    // predicates. `trace_summaries` is a ReplacingMergeTree, so until a merge
+    // runs, two physical rows can share one (TenantId, TraceId, UpdatedAt) and
+    // disagree on everything else — a re-publish at the same version lands in
+    // its own part. Identity alone cannot tell those apart, so the outer stage
+    // has to re-apply the user's filter to pick the version that actually
+    // matches it; without that, a filtered page returns the version that does
+    // not match and disagrees with its own total. Re-applying the filter is
+    // cheap next to the dedup (it is the same predicate over an already
+    // identity-bounded set, and it costs nothing at all on the unfiltered
+    // default view, where `whereClause` IS `baseWhereClause`).
     //
     // The inner subquery keeps WHERE/ORDER BY on raw DateTime columns —
     // aliasing DateTime to millis in the same scope shadows the column and
@@ -325,7 +330,7 @@ export class TraceListClickHouseRepository implements TraceListRepository {
             _size_bytes AS SizeBytes,
             LastEventOccurredAt
           FROM ${TABLE_NAME}
-          WHERE ${baseWhereClause}
+          WHERE ${whereClause}
             AND (TenantId, TraceId, UpdatedAt) IN (
               SELECT TenantId, TraceId, UpdatedAt
               FROM ${TABLE_NAME}

--- a/platform/app/src/server/app-layer/traces/repositories/trace-list.clickhouse.repository.ts
+++ b/platform/app/src/server/app-layer/traces/repositories/trace-list.clickhouse.repository.ts
@@ -165,9 +165,14 @@ export class TraceListClickHouseRepository implements TraceListRepository {
 
     const client = await this.resolveClient(query.tenantId);
 
-    // Latest-version dedup, shared by the page, the heavy read, and the count.
+    // Latest-version dedup, shared by the page's inner stage and the count.
     // Decided on the base predicates alone, so the filter chooses among current
     // traces rather than deciding which version is current.
+    //
+    // It is a whole-window aggregate: it groups every row this tenant has in
+    // the time range, so each place it appears is another pass over that set.
+    // State it once per read — see the outer stage below, which reuses the
+    // inner stage's result instead of deriving the same thing again.
     const dedupFilter = `(TenantId, TraceId, UpdatedAt) IN (
           SELECT TenantId, TraceId, max(UpdatedAt)
           FROM ${TABLE_NAME}
@@ -175,13 +180,28 @@ export class TraceListClickHouseRepository implements TraceListRepository {
           GROUP BY TenantId, TraceId
         )`;
 
-    // Page the matching TraceIds first (key + sort columns only), then read
-    // the heavy columns (ComputedInput/ComputedOutput and the rest) for that
+    // Page the matching rows first (key + sort columns only), then read the
+    // heavy columns (ComputedInput/ComputedOutput and the rest) for that
     // bounded page alone. The previous single query materialized those
     // payloads for every deduped trace in the window before ORDER BY ... LIMIT
     // trimmed it, and `count() OVER ()` forced the whole deduped set to buffer
     // — together the dominant read-bytes cost on this list. The total is now a
     // separate light count that never touches the payload columns.
+    //
+    // The inner stage hands the outer stage the winning rows' full identity
+    // (TenantId, TraceId, UpdatedAt), not just their TraceIds. That identity
+    // IS the dedup result, so the outer stage needs neither `dedupFilter` nor
+    // the user filter again — both were already decided inside. Re-stating
+    // them made ClickHouse build the whole-window dedup aggregate a second
+    // time (and re-run any span subquery the filter carries) to reach the same
+    // rows the inner stage had already named. On a tenant with ~1.3M traces in
+    // the window, dropping that second pass measured 4.45M -> 2.98M rows read
+    // and 4.6s -> 2.3s. The outer WHERE keeps the base predicates so partition
+    // pruning still applies.
+    //
+    // Two physical rows sharing one (TenantId, TraceId, UpdatedAt) would both
+    // match here, as they did under the previous form — the outer LIMIT caps
+    // the page either way.
     //
     // The inner subquery keeps WHERE/ORDER BY on raw DateTime columns —
     // aliasing DateTime to millis in the same scope shadows the column and
@@ -305,9 +325,9 @@ export class TraceListClickHouseRepository implements TraceListRepository {
             _size_bytes AS SizeBytes,
             LastEventOccurredAt
           FROM ${TABLE_NAME}
-          WHERE ${whereClause}
-            AND TraceId IN (
-              SELECT TraceId
+          WHERE ${baseWhereClause}
+            AND (TenantId, TraceId, UpdatedAt) IN (
+              SELECT TenantId, TraceId, UpdatedAt
               FROM ${TABLE_NAME}
               WHERE ${whereClause}
                 AND ${dedupFilter}
@@ -321,7 +341,6 @@ export class TraceListClickHouseRepository implements TraceListRepository {
               LIMIT {limit:UInt32}
               OFFSET {offset:UInt32}
             )
-            AND ${dedupFilter}
           ORDER BY ${sortExpression} ${sortDir}, TraceId ASC
           LIMIT {limit:UInt32}
         )


### PR DESCRIPTION
## Cause

`platform/app/src/server/app-layer/traces/repositories/trace-list.clickhouse.repository.ts:171-176`

`findAll` pages in two stages: an inner stage picks the page's traces, an outer stage reads their heavy payload columns (`ComputedInput`/`ComputedOutput` and the rest). Both stages stated `dedupFilter`, which is a **whole-window aggregate** — it groups every row the tenant has in the time range to decide which version of each trace is current.

The outer stage never needed it. The inner stage had already resolved which exact row won each trace, but handed over only `TraceId`, so the outer stage had to re-derive the same answer — rebuilding the aggregate, and re-running any span subquery the user filter carries, to arrive back at rows it had just been given.

On the tenant that triggered this, that window holds **1,328,929 distinct traces, of which 2,206 (0.17%) actually have more than one version**. The aggregate was built twice per page load to correct 0.17% of rows.

## Fix

The inner stage now hands over the winning rows' full identity `(TenantId, TraceId, UpdatedAt)` instead of just `TraceId`, so the outer stage selects exactly those rows and needs neither the dedup nor the user filter again. The outer `WHERE` keeps the base predicates so partition pruning still applies.

Dedup semantics are unchanged. It is still decided on the base predicates alone, so a filter still chooses among current traces rather than deciding which version is current — the double-count trap documented at `:62-76` stays closed.

## Failing test first

`__tests__/trace-list.clickhouse.repository.unit.test.ts` (new). Before the fix, 2 of 4 failed:

```
 FAIL  builds the version dedup aggregate once for the page read, not once per stage
   → expected 2 to be 1

 FAIL  carries the winning row's identity from the inner page stage to the outer read
   → expect(pageQuery).toContain("SELECT TenantId, TraceId, UpdatedAt")

 Test Files  1 failed (1)
      Tests  2 failed | 2 passed (4)
```

After:

```
 Test Files  1 passed (1)
      Tests  4 passed (4)
```

## Verification

- **Unit:** 1763 passed / 89 files across `src/server/app-layer/traces`.
- **Integration:** 16/16 against a real ClickHouse container, none skipped — including the four pre-existing version-dedup semantics tests (`finds the trace by what its newest version says`, `does not find it by what its older version said`, `counts the trace exactly once, in the bucket its newest version is in`, `counts nothing for the bucket only its older version is in`).
- **New integration test** `does not re-derive the version dedup in the outer stage of its own page read` captures the SQL the repository *actually* emits, re-runs it under a known `query_id`, and asserts its `read_rows` is strictly below the previous form's. Not a hand-written stand-in.
- `pnpm typecheck` exit 0. Lint run through the repo's actual gate (`biome-new-violations.sh` against the merge base, the same command CI runs): **no new violations**. The 2 warnings in this file are on `findBatchedFacets`/`buildListAttributes` and are pre-existing.

### Measured read-only against production

Hot tenant, 30-day window, the real wide-column page read, 3 rounds each:

| page read | rows | read | memory | ms |
|---|---|---|---|---|
| before | 4,449,207 | 2.04 GiB | 486 MiB | 10,302 |
| after | 2,974,165 | 1.90 GiB | 465 MiB | 5,722 |

33% fewer rows, ~44% faster.

**Memory is not the win.** Peak per-query memory is flat to marginally worse
(465 vs 486 MiB here; 488 vs 471 MiB on a separate round). The change removes
one whole-window aggregate pass, which is rows and time, not peak footprint.
Do not read this as a fix for the memory-limit errors.

## Rejected alternative: `FINAL`

`FINAL` is the obvious replacement and it is used in five other repositories here (`metric-data-point`, `canonical-log-record`, `spendEvents`, `budget`, `lwql/views`), so it is not foreign to the codebase. It is wrong for **this** table, measured:

| count shape | rows | read | memory | ms |
|---|---|---|---|---|
| current, no filter | 2.96M | 262 MiB | 489 MiB | 2,835 |
| `FINAL`, no filter | 5.42M | 483 MiB | **125 MiB** | 1,032 |
| current, **with filter** | 2.96M | 1.89 GiB | **467 MiB** | 3,876 |
| `FINAL`, **with filter** | 5.42M | 5.95 GiB | **690 MiB** | 4,895 |
| `FINAL` + `do_not_merge_across_partitions_select_final=1` | 5.43M | 5.96 GiB | 627 MiB | 5,673 |

It wins only on an unfiltered count. Once the list carries a filter — the real case — it loses on every axis, because `trace_summaries` filters on an unindexed `Attributes` Map that `FINAL` forces it to read for every row.

## Sweep

The same whole-window aggregate appears in every facet method of this file and twice per query in `session-groups.clickhouse.repository.ts:177,193,246`. **Those are not the same defect** — in session-groups the two instances do different work (one picks which sessions match, one dedups the rows being summed), so neither can simply be dropped. Same cost shape, separate change. Untouched here.

## Noticed and deliberately not fixed

- **The count query.** No safe win found. Dropping `TenantId` from the dedup group key measured 467 → 301 MiB, but it was slower (6,978 ms) and weakens an explicit tenancy assertion on a multi-tenant table. Not worth it.
- **The facet queries** carry the same aggregate and are the ~13.75 GiB shape — the bigger prize, and a bigger change.
- **Two physical rows sharing one `(TenantId, TraceId, UpdatedAt)`.** A re-publish at the same `UpdatedAt` lives in its own part until a merge collapses it, so both rows answer to the same identity.
  - Where the user's filter matches only one of them, the outer stage now re-applies the filter and picks the right one. That case *was* broken by the first commit here and is fixed by `15ac89d7d1`, with a regression test.
  - Where **both** rows match — every unfiltered view, and a filtered page whose predicate does not separate them — both are still returned and `totalHits` counts both. `main` behaves identically, so this PR neither introduces nor fixes it. Closing it needs `LIMIT 1 BY TraceId` on the outer stage, which is a separate change with its own paging implications.
- **The outer `LIMIT` caps physical rows, not distinct traces**, so in the case above a duplicate can push a real trace off the page. Same in `main`; same follow-up.

## Caveats

- The production "after" figure averages 2 completed runs, not 3 — one did not land in `query_log`.
- Cluster load shifted between measurement rounds (the same *old* shape measured 4,574 ms early and 10,302 ms later). Trust the ratios, not the absolute times.
- The cursor-pagination path is structurally unchanged but is not covered by the integration test.
- Versus `main` the user filter is emitted twice in the page read — once per stage — exactly as it was before. Filters carrying a span subquery therefore scan that subquery twice in both shapes; this is not a regression introduced here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved trace list pagination by avoiding redundant version deduplication.
  * Ensured paginated results return the correct trace versions.
  * Preserved accurate total counts and filtering across trace list results.

* **Tests**
  * Added unit and integration coverage for trace queries, filtering, pagination, and result consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
