### PR TITLE
docs(agent-testing): connect from a function beside your service startup

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -15,7 +15,10 @@ regenerated_docs_pages=0
 if echo "$staged_before" | grep -qE '^skills/.*\.mdx?$|^skills/_shared/|^docs/skills/skills-pages-manifest\.json$'; then
   echo "pre-commit: Regenerating docs/skills pages from skill sources..."
   bash docs/scripts/sync-prompts.sh
-  git add docs/skills/directory.mdx docs/skills/pms-and-domain-experts.mdx
+  # The manifest decides which pages carry generated blocks, and it has grown
+  # past docs/skills/. Ask the generator which pages it wrote rather than
+  # keeping a second copy of the list here, which went stale once already.
+  node docs/scripts/generate-skills-pages.mjs --list-pages | xargs git add
   regenerated_docs_pages=1
 fi
 

--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -232,8 +232,11 @@ jobs:
       - name: Check for stale generated files
         run: |
           STALE=0
+          # Every page the skills manifest drives, read from the generator, so
+          # a new entry in the manifest is covered without editing this list.
+          SKILL_PAGES=$(node docs/scripts/generate-skills-pages.mjs --list-pages)
           if ! git diff --exit-code \
-            docs/skills/directory.mdx docs/skills/pms-and-domain-experts.mdx \
+            $SKILL_PAGES \
             docs/llms.txt docs/llms-full.txt \
             docs/api-reference/openapiLangWatch.json docs/docs.json; then
             STALE=1

--- a/docs/agent-testing/connect-your-agent.mdx
+++ b/docs/agent-testing/connect-your-agent.mdx
@@ -2,7 +2,7 @@
 title: Connect Your Agent
 sidebarTitle: Overview
 keywords: langwatch, agent simulations, connected agent, connect_agent, connectAgent, agent decorator, run parameters, environments, scenario suite, coding agent prompt
-description: Decorate the function that runs your agent to connect it to LangWatch, so your team can run test suites from the platform against your actual agent.
+description: Add a small connect function beside your service startup that calls the agent you already have, so your team can run test suites from the platform against the real agent.
 ---
 
 ## Getting Started
@@ -56,7 +56,7 @@ Use the `langwatch` CLI for everything: documentation (`langwatch docs ...`, `la
 
 Connect the agent in this codebase to LangWatch, so test suites run from the platform against the real agent process. The SDK opens an outbound connection to LangWatch from the process that already runs the agent, registers the agent with its environment and its run parameters, and receives one call per conversation turn. The simulation exercises the real code, dependencies, secrets and traces.
 
-Three steps: install the SDK, decorate the function, start the process. Work through them in order, confirm the agent reads Online, run one test suite, then report what changed and the result.
+Three steps: install the SDK, add the connect function where the service starts, start the service the way the user always starts it. Work through them in order, confirm the agent reads Online, run one test suite, then report what changed and the result.
 
 Use the HTTP fallback at the bottom of this skill ONLY when the agent cannot import the SDK: the agent is written in a language with no LangWatch SDK, or you have no access to its code.
 
@@ -105,7 +105,7 @@ LangWatch.
 
 ## Step 2: Install the SDK
 
-Read the codebase first. Find the function that takes a conversation and returns the agent's reply, and the file it lives in. That function is what you decorate; do not write a second one beside it.
+Read the codebase first. Find two things: the entry point that runs the agent, which is what the connect function calls, and the file that starts the service, which is where the connect function goes.
 
 ```bash
 pip install langwatch          # Python
@@ -114,46 +114,66 @@ npm install langwatch zod      # TypeScript, Node only
 
 The process needs `LANGWATCH_API_KEY` in its environment. It is the same project key the CLI uses. Without a key the SDK logs one line and opens no connection.
 
-## Step 3: Decorate the function
+## Step 3: Add the connect function where the service starts
+
+Write a small function beside the code that starts the service. LangWatch calls it once per conversation turn, and it calls the agent the codebase already has. It is an adapter: build the input the agent expects, pass the run parameters into it, and return the reply text out of what the agent gives back.
+
+Put it in the file that starts the service, or in a module that file imports at startup. The connection opens with the process, so the code has to run when the process runs.
 
 **Python**
 
 ```python
+# main.py, beside the server startup
 import langwatch
 
+from my_app.agent import SupportAgent
+
 @langwatch.connect_agent(name="support-agent")
-async def support_agent(messages: list[dict], thread_id: str) -> str:
-    return await run_my_agent(messages)
+async def support_agent(
+    messages: list[dict],
+    thread_id: str,
+    *,
+    model: str = "gpt-5-mini",
+) -> str:
+    result = await SupportAgent(model=model).run(messages, conversation_id=thread_id)
+    return result.output_text
 ```
 
 **TypeScript**
 
 ```typescript
+// server.ts, beside the server startup
 import { z } from "zod";
 import { connectAgent } from "langwatch/agent";
 
-export const supportAgent = connectAgent(
+import { runSupportAgent } from "./agent";
+
+connectAgent(
   {
     name: "support-agent",
     parameters: z.object({
       model: z.enum(["gpt-5", "gpt-5-mini"]).default("gpt-5-mini"),
-      plan: z.string().default("free").describe("Customer plan"),
-      maxTools: z.number().int().default(5),
     }),
   },
-  async ({ messages, params }) => {
-    // params is typed: { model: "gpt-5" | "gpt-5-mini"; plan: string; maxTools: number }
-    return await runMyAgent(messages, { model: params.model });
+  async ({ messages, threadId, params }) => {
+    const result = await runSupportAgent({
+      messages,
+      conversationId: threadId,
+      model: params.model,
+    });
+    return result.text;
   },
 );
 ```
 
-Rules for the decorated function:
+Rules for the connect function:
 
 - `name` is required. Use the name the team calls the agent, in lower case with dashes.
+- Call the agent the product already runs. Do not reimplement it in the connect function, and do not call a simplified copy of it, or the suite tests code no customer reaches.
+- Change nothing about how the service starts. The connect function runs on the startup path, and the start command stays the same.
 - **Turn fields** are what the platform sends on every call: `messages` (the whole conversation, OpenAI-style), `new_messages` (`newMessages`, the delta since the last turn), `thread_id` (`threadId`), `session`, `trace_id` (`traceId`). In Python, declare only the ones you use and the SDK passes exactly those. In TypeScript, they arrive as one object, so destructure what you need.
 - Return a string, one message, a list of messages, or `langwatch.AgentReply(output, session=...)` (`{ output, session }` in TypeScript).
-- Do not remove or weaken the function's own behavior. The decorator wraps it; the direct callers keep working.
+- Do not change the agent's own code to fit the connect function. Map the turn onto the agent's existing call in the connect function instead.
 - Do NOT add a `traceparent` middleware. The SDK adopts the turn's trace context before it calls the function, so the agent's spans land in the turn's trace and the judge reads them.
 
 ### Run parameters
@@ -174,7 +194,7 @@ async def support_agent(
     ...
 ```
 
-TypeScript declares them with a zod schema in `parameters`, the way Step 3 shows. The schema types `params` in the handler, and the SDK validates the values a run supplies against it. Add `zod` to the project (`npm install zod`) if it is not there yet. Read the schema this way:
+TypeScript declares them with a zod schema in `parameters`, the way Step 3 shows. Read the values out of `params` in the connect function and pass them into the agent's own call. The schema types `params` in the handler, and the SDK validates the values a run supplies against it. Add `zod` to the project (`npm install zod`) if it is not there yet. Read the schema this way:
 
 - `z.enum([...])` becomes a closed option list in the run dialog. A value outside the list is refused.
 - `.default(value)` sets the default.
@@ -211,16 +231,18 @@ The SDK reads the environment from the `environment` argument, then `LANGWATCH_A
 
 Leave `environment` out when the service already sets `LANGWATCH_AGENT_ENVIRONMENT`, `APP_ENV`, `ENVIRONMENT` or `NODE_ENV`. The SDK reads them on its own.
 
-## Step 4: Start the process and confirm the agent is Online
+## Step 4: Start the service and confirm the agent is Online
 
-Start the service the way the user starts it. A web server keeps the connection alive by itself. For a script whose only job is the agent, block it:
+Start the service the way the user starts it. Do not add a start command, and do not write a separate runner script: the connect function is already on the startup path, and a web server holds the connection open by itself.
+
+The exception is an agent that is a library with no process of its own. Put the connect function in a small script and keep the script alive:
 
 ```python
 langwatch.agent.serve()   # Python, at the bottom of the script
 ```
 
 ```typescript
-// TypeScript: the socket keeps the event loop alive, `node agent.ts` serves until Ctrl-C
+// TypeScript: the connection holds the event loop open, `node agent.ts` serves until Ctrl-C
 ```
 
 Then confirm from the CLI, in another terminal:
@@ -381,13 +403,14 @@ Run it with `--target http:<agent-id>`, and follow Step 5 and Step 6 otherwise u
 | The run is refused with `agent_offline` | No instance was connected when the run started. | Start the agent process and run again. |
 | The run is refused with `agent_owner_only` | The agent registered under `development` with a personal key, so only its owner can run it. | Run it as the owner, or register it under a shared environment name such as `dev-shared`. |
 | The run is refused with `scenario_parameter_option_invalid` | A value is outside the closed option list the agent declares. | Use one of the listed options, or widen the `Literal` (Python) or `z.enum` (TypeScript) list in the code. |
-| A turn fails with `agent_call_timeout` | The function took longer than the agent's timeout. | Raise `timeout` on the decorator (up to 300 seconds), or make the agent answer faster. |
+| A turn fails with `agent_call_timeout` | The call took longer than the agent's timeout. | Raise `timeout` on the connect function (up to 300 seconds), or make the agent answer faster. |
 | Trace-dependent criteria come back inconclusive | The agent reports its traces to a different LangWatch project, or it reports none at all. | Point the agent's tracing at the same project's API key. Set it up with the `tracing` skill. |
 
 ## Common Mistakes
 
-- Do NOT write a second wrapper function for LangWatch to call. Decorate the function the product already runs, so the simulation exercises the real code path.
-- Do NOT add a `traceparent` middleware for a decorated agent. The SDK adopts the trace context itself; the middleware belongs to the HTTP fallback only.
+- Do NOT reimplement the agent inside the connect function, and do NOT point it at a simplified copy. It calls the agent the product already runs, so the simulation exercises the real code path.
+- Do NOT add a runner script or a second start command when the service already has one. The connect function goes on the existing startup path.
+- Do NOT add a `traceparent` middleware for a connected agent. The SDK adopts the trace context itself; the middleware belongs to the HTTP fallback only.
 - Do NOT hardcode an environment string, and do NOT write a fallback such as `process.env.APP_ENV ?? "development"`. It overrides `LANGWATCH_AGENT_ENVIRONMENT` and registers a production process under `development`. Let the SDK resolve the environment.
 - Do NOT declare a run parameter for a value the tests never vary. Every declared parameter appears in the run dialog.
 - Do NOT use a turn field name (`messages`, `new_messages`, `thread_id`, `session`, `trace_id`) as a run parameter name.
@@ -433,70 +456,80 @@ The steps below are the same setup by hand, and what to check when the skill's r
 
 The process needs `LANGWATCH_API_KEY` in its environment. It is the project API key from **Settings > API Keys**, the same one the CLI and the SDK use for tracing. Without a key the SDK logs one line and opens no connection, so a build that has no key runs unchanged.
 
-## 2. Decorate the function
+## 2. Connect it where your service starts
 
-Decorate the function that already takes a conversation and returns your agent's reply. There is no second function to write and no endpoint to add.
+Write a small function beside the code that starts your service. LangWatch calls it once per conversation turn, and it calls the agent you already have.
+
+That function is the adapter, and it is the only new code. Build the input your agent expects, pass the run parameters into it, and return the reply text out of whatever your agent gives back. The agent itself does not change.
 
 <Tabs>
   <Tab title="Python">
     ```python
+    # main.py, beside your server startup
     import langwatch
 
+    from my_app.agent import SupportAgent
+
     @langwatch.connect_agent(name="support-agent")
-    async def support_agent(messages: list[dict], thread_id: str) -> str:
-        return await run_my_agent(messages)
+    async def support_agent(
+        messages: list[dict],
+        thread_id: str,
+        *,
+        model: str = "gpt-5-mini",
+    ) -> str:
+        result = await SupportAgent(model=model).run(messages, conversation_id=thread_id)
+        return result.output_text
     ```
+
+    `model` is a run parameter, so a run can select it. `messages` and `thread_id` are turn fields that LangWatch sends. See [What the agent receives](#what-the-agent-receives) and [Run parameters](#run-parameters) below.
 
     A synchronous function works the same way. It runs in a worker thread, so the connection stays responsive.
   </Tab>
   <Tab title="TypeScript">
     ```typescript
+    // server.ts, beside your server startup
     import { z } from "zod";
     import { connectAgent } from "langwatch/agent";
 
-    export const supportAgent = connectAgent(
+    import { runSupportAgent } from "./agent";
+
+    connectAgent(
       {
         name: "support-agent",
-        environment: process.env.APP_ENV ?? "development",
         parameters: z.object({
           model: z.enum(["gpt-5", "gpt-5-mini"]).default("gpt-5-mini"),
-          plan: z.string().default("free").describe("Customer plan"),
-          maxTools: z.number().int().default(5),
         }),
       },
-      async ({ messages, params }) => {
-        // params is typed: { model: "gpt-5" | "gpt-5-mini"; plan: string; maxTools: number }
-        return await runMyAgent(messages, { model: params.model });
+      async ({ messages, threadId, params }) => {
+        const result = await runSupportAgent({
+          messages,
+          conversationId: threadId,
+          model: params.model,
+        });
+        return result.text;
       },
     );
     ```
 
     The zod schema declares the run parameters, and it types `params` in the handler. See [Run parameters](#run-parameters) below for what each part of the schema does. An agent whose tests vary no value takes `parameters` away and keeps the rest.
 
-    `connectAgent` returns the handler, so `supportAgent({ messages })` still calls it directly. Unit tests and code-first scenario runs use the same function.
+    `connectAgent` returns the function, so a code-first scenario run and a unit test can call it directly.
   </Tab>
 </Tabs>
 
-## 3. Start the process
+Put this on the startup path: the file that starts your service, or a module that file imports at startup. The connection opens with the process, so the code has to run when the process runs.
 
-Start the service the way you always start it. A web server keeps the connection alive by itself, and one process serves every agent it declares over a single connection.
+Then start your service the way you always start it. The start command does not change, and there is no new process to run. A web server holds the connection open by itself, and one process serves every agent it declares over a single connection.
 
-For a script whose only job is the agent, block at the end of the file:
+<Note>
+  **No long-running service?** When the agent is a library with no process of its own, put the connect function in a small script and keep the script alive.
 
-<Tabs>
-  <Tab title="Python">
-    ```python
-    langwatch.agent.serve()
-    ```
-  </Tab>
-  <Tab title="TypeScript">
-    ```bash
-    node agent.ts
-    ```
+  In Python, call `langwatch.agent.serve()` at the end of the script. It blocks until Ctrl-C.
 
-    The connection keeps the event loop alive, so the process serves until Ctrl-C.
-  </Tab>
-</Tabs>
+  In TypeScript the connection holds the event loop open by itself, so `node agent.ts` serves until Ctrl-C.
+</Note>
+
+## 3. Confirm it is online
 
 The agent appears on the **Agents** page with a green **Online** mark, its environment, and the number of connected instances. From the terminal:
 
@@ -720,7 +753,7 @@ One deployment with several pods is one row and several instances. The platform 
 |---|---|
 | `concurrency` | How many calls one instance takes at the same time. Default 1 in `development`, 4 elsewhere. When every instance is full, the platform waits and retries within the call's deadline. |
 | `instance_label` (`instanceLabel`) | A name for this instance in the instances table, for example the pod name. Also read from `LANGWATCH_AGENT_INSTANCE_LABEL`. |
-| `enabled` | Whether this process connects. Default true, and false when `CI` is set, because a CI job is not a service anyone runs suites against. Pass `enabled=True` to override that. |
+| `enabled` | Whether this process connects. It takes any boolean, so one expression decides which deployments connect: `enabled=os.environ.get("APP_ENV") != "production"` connects everywhere but production. Default true, and false when `CI` is set, because a CI job is not a service anyone runs suites against. Pass `enabled=True` to override that. |
 | `LANGWATCH_AGENT_CONNECT=0` | Turns the connection off for a deployment without a code change. |
 
 The platform delivers each call at most once. The SDK confirms a call when the function starts, and the platform never sends a confirmed call to a second instance, so a turn with side effects runs one time.
@@ -781,7 +814,7 @@ The decorator never stops the application from starting. Every problem is one wa
     | `name` | required | The agent's name, and the first half of a `connected:<name>@<environment>` target. |
     | `environment` | resolved, see above | Which environment row this process registers under. |
     | `parameters` | read from the signature | An explicit parameter declaration that replaces what the signature declares. |
-    | `enabled` | `True`, `False` under `CI` | Whether this process connects at all. |
+    | `enabled` | `True`, `False` under `CI` | Whether this process connects at all. Takes any boolean, for example `os.environ.get("APP_ENV") != "production"`. |
     | `instance_label` | none | A name for this instance in the instances table. |
     | `timeout` | `120` seconds | How long one call may take. The ceiling is 300 seconds. |
     | `concurrency` | `1` in `development`, `4` elsewhere | Calls this instance takes at the same time. |
@@ -800,7 +833,7 @@ The decorator never stops the application from starting. Every problem is one wa
     | `name` | required | The agent's name, and the first half of a `connected:<name>@<environment>` target. |
     | `environment` | resolved, see above | Which environment row this process registers under. |
     | `parameters` | none | A zod schema, a definition map, or a JSON Schema object. |
-    | `enabled` | `true`, `false` under `CI` | Whether this process connects at all. |
+    | `enabled` | `true`, `false` under `CI` | Whether this process connects at all. Takes any boolean, for example `process.env.APP_ENV !== "production"`. |
     | `instanceLabel` | none | A name for this instance in the instances table. |
     | `timeoutMs` | `120000` | How long one call may take. The ceiling is 300000. |
     | `concurrency` | `1` in `development`, `4` elsewhere | Calls this instance takes at the same time. |

--- a/docs/agent-testing/connect-your-agent.mdx
+++ b/docs/agent-testing/connect-your-agent.mdx
@@ -242,7 +242,8 @@ langwatch.agent.serve()   # Python, at the bottom of the script
 ```
 
 ```typescript
-// TypeScript: the connection holds the event loop open, `node agent.ts` serves until Ctrl-C
+// TypeScript: the connection holds the event loop open, so the script serves until Ctrl-C
+// Run it with the project's TypeScript runner, for example `tsx agent.ts`
 ```
 
 Then confirm from the CLI, in another terminal:
@@ -524,7 +525,7 @@ Then start your service the way you always start it. The start command does not 
 
   In Python, call `langwatch.agent.serve()` at the end of the script. It blocks until Ctrl-C.
 
-  In TypeScript the connection holds the event loop open by itself, so `node agent.ts` serves until Ctrl-C.
+  In TypeScript the connection holds the event loop open by itself, so the script serves until Ctrl-C. Run it with whatever runner the project uses, for example `tsx agent.ts`.
 </Note>
 
 ## 3. Confirm it is online
@@ -751,7 +752,7 @@ One deployment with several pods is one row and several instances. The platform 
 |---|---|
 | `concurrency` | How many calls one instance takes at the same time. Default 1 in `development`, 4 elsewhere. When every instance is full, the platform waits and retries within the call's deadline. |
 | `instance_label` (`instanceLabel`) | A name for this instance in the instances table, for example the pod name. Also read from `LANGWATCH_AGENT_INSTANCE_LABEL`. |
-| `enabled` | Whether this process connects. It takes any boolean, so one expression decides which deployments connect: `enabled=os.environ.get("APP_ENV") != "production"` connects everywhere but production. Default true, and false when `CI` is set, because a CI job is not a service anyone runs suites against. Pass `enabled=True` to override that. |
+| `enabled` | Whether this process connects. It takes any boolean, so one expression decides which deployments connect: `enabled=os.environ.get("APP_ENV") != "production" and not os.environ.get("CI")` connects everywhere but production and CI. Without the argument the default is true, and false when `CI` is set. An `enabled` argument replaces that rule, so keep the `CI` half unless a CI job is deliberately the target. |
 | `LANGWATCH_AGENT_CONNECT=0` | Turns the connection off for a deployment without a code change. |
 
 The platform delivers each call at most once. The SDK confirms a call when the function starts, and the platform never sends a confirmed call to a second instance, so a turn with side effects runs one time.
@@ -812,7 +813,7 @@ The decorator never stops the application from starting. Every problem is one wa
     | `name` | required | The agent's name, and the first half of a `connected:<name>@<environment>` target. |
     | `environment` | resolved, see above | Which environment row this process registers under. |
     | `parameters` | read from the signature | An explicit parameter declaration that replaces what the signature declares. |
-    | `enabled` | `True`, `False` under `CI` | Whether this process connects at all. Takes any boolean, for example `os.environ.get("APP_ENV") != "production"`. |
+    | `enabled` | `True`, `False` under `CI` | Whether this process connects at all. Takes any boolean, and replaces the `CI` default rather than adding to it. |
     | `instance_label` | none | A name for this instance in the instances table. |
     | `timeout` | `120` seconds | How long one call may take. The ceiling is 300 seconds. |
     | `concurrency` | `1` in `development`, `4` elsewhere | Calls this instance takes at the same time. |
@@ -831,7 +832,7 @@ The decorator never stops the application from starting. Every problem is one wa
     | `name` | required | The agent's name, and the first half of a `connected:<name>@<environment>` target. |
     | `environment` | resolved, see above | Which environment row this process registers under. |
     | `parameters` | none | A zod schema, a definition map, or a JSON Schema object. |
-    | `enabled` | `true`, `false` under `CI` | Whether this process connects at all. Takes any boolean, for example `process.env.APP_ENV !== "production"`. |
+    | `enabled` | `true`, `false` under `CI` | Whether this process connects at all. Takes any boolean, and replaces the `CI` default rather than adding to it. |
     | `instanceLabel` | none | A name for this instance in the instances table. |
     | `timeoutMs` | `120000` | How long one call may take. The ceiling is 300000. |
     | `concurrency` | `1` in `development`, `4` elsewhere | Calls this instance takes at the same time. |

--- a/docs/agent-testing/connect-your-agent.mdx
+++ b/docs/agent-testing/connect-your-agent.mdx
@@ -116,7 +116,7 @@ The process needs `LANGWATCH_API_KEY` in its environment. It is the same project
 
 ## Step 3: Add the connect function where the service starts
 
-Write a small function beside the code that starts the service. LangWatch calls it once per conversation turn, and it calls the agent the codebase already has. It is an adapter: build the input the agent expects, pass the run parameters into it, and return the reply text out of what the agent gives back.
+Write a small function beside the code that starts the service. It is the adapter between the messages that come from a scenario test and the agent in the codebase.
 
 Put it in the file that starts the service, or in a module that file imports at startup. The connection opens with the process, so the code has to run when the process runs.
 
@@ -458,9 +458,7 @@ The process needs `LANGWATCH_API_KEY` in its environment. It is the project API 
 
 ## 2. Connect it where your service starts
 
-Write a small function beside the code that starts your service. LangWatch calls it once per conversation turn, and it calls the agent you already have.
-
-That function is the adapter, and it is the only new code. Build the input your agent expects, pass the run parameters into it, and return the reply text out of whatever your agent gives back. The agent itself does not change.
+Write a small function beside the code that starts your service. This is the adapter between the messages that come from a scenario test and your agent.
 
 <Tabs>
   <Tab title="Python">

--- a/docs/agent-testing/connect-your-agent.mdx
+++ b/docs/agent-testing/connect-your-agent.mdx
@@ -242,7 +242,9 @@ langwatch.agent.serve()   # Python, at the bottom of the script
 ```
 
 ```typescript
-// TypeScript: the connection holds the event loop open, so the script serves until Ctrl-C
+// TypeScript: keep the script alive yourself. The WebSocket holds the event loop
+// while connected, but the HTTP fallback and the reconnect wait do not.
+setInterval(() => {}, 1 << 30);
 // Run it with the project's TypeScript runner, for example `tsx agent.ts`
 ```
 
@@ -525,7 +527,13 @@ Then start your service the way you always start it. The start command does not 
 
   In Python, call `langwatch.agent.serve()` at the end of the script. It blocks until Ctrl-C.
 
-  In TypeScript the connection holds the event loop open by itself, so the script serves until Ctrl-C. Run it with whatever runner the project uses, for example `tsx agent.ts`.
+  In TypeScript, keep the script alive yourself. An open WebSocket holds the event loop while it is connected, but the HTTP fallback and the reconnect wait use unreferenced timers, so a script with no server of its own can exit between polls.
+
+  ```typescript
+  setInterval(() => {}, 1 << 30);
+  ```
+
+  Run the script with whatever runner the project uses, for example `tsx agent.ts`.
 </Note>
 
 ## 3. Confirm it is online

--- a/docs/agent-testing/environments.mdx
+++ b/docs/agent-testing/environments.mdx
@@ -97,13 +97,37 @@ Turn the connection off for a deployment without a code change:
 LANGWATCH_AGENT_CONNECT=0
 ```
 
-`enabled=False` on the decorator does the same in code, and the SDK defaults it to false when `CI` is set, because a CI job is not a service anyone runs suites against. Pass `enabled=True` when a CI job is deliberately the target.
+`enabled` on the connect function does the same in code. It takes any boolean, so one expression decides which deployments connect:
+
+<Tabs>
+  <Tab title="Python">
+    ```python
+    @langwatch.connect_agent(
+        name="support-agent",
+        enabled=os.environ.get("APP_ENV") != "production",
+    )
+    ```
+  </Tab>
+  <Tab title="TypeScript">
+    ```typescript
+    connectAgent(
+      {
+        name: "support-agent",
+        enabled: process.env.APP_ENV !== "production",
+      },
+      handler,
+    );
+    ```
+  </Tab>
+</Tabs>
+
+The SDK defaults `enabled` to false when `CI` is set, because a CI job is not a service anyone runs suites against. Pass it true when a CI job is deliberately the target.
 
 ## Next steps
 
 <CardGroup cols={2}>
   <Card title="Connect your agent" icon="plug" href="/agent-testing/connect-your-agent">
-    Decorate the function that runs your agent
+    Call your agent from a connect function beside your service startup
   </Card>
   <Card title="Run parameters" icon="sliders" href="/agent-testing/run-parameters">
     Values a run supplies, declared by the scenario or by the agent

--- a/docs/agent-testing/environments.mdx
+++ b/docs/agent-testing/environments.mdx
@@ -104,20 +104,26 @@ LANGWATCH_AGENT_CONNECT=0
     ```python
     import os
 
+    import langwatch
+
     @langwatch.connect_agent(
         name="support-agent",
         enabled=os.environ.get("APP_ENV") != "production" and not os.environ.get("CI"),
     )
+    async def support_agent(messages: list[dict]) -> str:
+        return await run_my_agent(messages)
     ```
   </Tab>
   <Tab title="TypeScript">
     ```typescript
+    import { connectAgent } from "langwatch/agent";
+
     connectAgent(
       {
         name: "support-agent",
         enabled: process.env.APP_ENV !== "production" && !process.env.CI,
       },
-      handler,
+      async ({ messages }) => await runMyAgent(messages),
     );
     ```
   </Tab>

--- a/docs/agent-testing/environments.mdx
+++ b/docs/agent-testing/environments.mdx
@@ -102,9 +102,11 @@ LANGWATCH_AGENT_CONNECT=0
 <Tabs>
   <Tab title="Python">
     ```python
+    import os
+
     @langwatch.connect_agent(
         name="support-agent",
-        enabled=os.environ.get("APP_ENV") != "production",
+        enabled=os.environ.get("APP_ENV") != "production" and not os.environ.get("CI"),
     )
     ```
   </Tab>
@@ -113,7 +115,7 @@ LANGWATCH_AGENT_CONNECT=0
     connectAgent(
       {
         name: "support-agent",
-        enabled: process.env.APP_ENV !== "production",
+        enabled: process.env.APP_ENV !== "production" && !process.env.CI,
       },
       handler,
     );
@@ -121,7 +123,7 @@ LANGWATCH_AGENT_CONNECT=0
   </Tab>
 </Tabs>
 
-The SDK defaults `enabled` to false when `CI` is set, because a CI job is not a service anyone runs suites against. Pass it true when a CI job is deliberately the target.
+The `CI` half of each expression keeps the default the SDK applies on its own. Without an `enabled` argument the SDK connects, except when `CI` is set, because a CI job is not a service anyone runs suites against. An `enabled` argument replaces that rule instead of adding to it, so an expression that ignores `CI` connects CI jobs. Leave the `CI` half out when a CI job is deliberately the target.
 
 ## Next steps
 

--- a/docs/agent-testing/linking-your-traces.mdx
+++ b/docs/agent-testing/linking-your-traces.mdx
@@ -142,7 +142,7 @@ For the full SDK reference, see the [Scenario documentation](https://langwatch.a
 
 <CardGroup cols={2}>
   <Card title="Connect your agent" icon="plug" href="/agent-testing/connect-your-agent">
-    Decorate the function that runs your agent, and the SDK adopts the trace context
+    Connect your agent from your service startup, and the SDK adopts the trace context
   </Card>
   <Card title="Environments" icon="laptop-code" href="/agent-testing/environments">
     Your machine, staging and production as separate targets

--- a/docs/agent-testing/other-ways-to-connect.mdx
+++ b/docs/agent-testing/other-ways-to-connect.mdx
@@ -268,7 +268,7 @@ The mapped input is `None` on the first turn of a conversation, and afterwards e
 
 <CardGroup cols={2}>
   <Card title="Connect your agent" icon="plug" href="/agent-testing/connect-your-agent">
-    Decorate the function that runs your agent
+    Call your agent from a connect function beside your service startup
   </Card>
   <Card title="Authenticated agents" icon="key" href="/agent-testing/authenticated-agents">
     Reference project secrets, and exchange OAuth2 credentials

--- a/docs/agent-testing/overview.mdx
+++ b/docs/agent-testing/overview.mdx
@@ -41,7 +41,7 @@ Both use the same simulated user, the same judge and the same results pages. The
 
 <CardGroup cols={2}>
   <Card title="Test from the platform" icon="globe" href="/agent-testing/test-from-the-platform">
-    Decorate the function that runs your agent, then write, run and see scenarios in the LangWatch interface. No test code in your repository.
+    Connect your agent from your service startup, then write, run and see scenarios in the LangWatch interface. No test code in your repository.
   </Card>
   <Card title="Write scenarios in code" icon="code" href="/agent-testing/scenarios-in-code">
     Write scenarios with the Scenario SDK in Python or TypeScript, run them with your test runner and in CI, and see every run in LangWatch.

--- a/docs/integration/typescript/agent-reference.mdx
+++ b/docs/integration/typescript/agent-reference.mdx
@@ -131,7 +131,7 @@ Values arrive validated against the declaration. A value the declaration refuses
 
 ### Lifecycle
 
-The connection starts on the next tick after the first `connectAgent` call, once per process, and one connection carries every agent the process declares. It uses the global `WebSocket` when the runtime has one and the `ws` package otherwise. While connected, it keeps the event loop alive, so a script that only declares an agent serves until Ctrl-C.
+The connection starts on the next tick after the first `connectAgent` call, once per process, and one connection carries every agent the process declares. It uses the global `WebSocket` when the runtime has one and the `ws` package otherwise. An open WebSocket keeps the event loop alive while it is connected. The HTTP fallback waits between empty polls on an unreferenced timer, and so does the reconnect backoff, so a script that only declares an agent needs its own keep-alive, for example `setInterval(() => {}, 1 << 30)`.
 
 SIGINT, SIGTERM and normal exit send a deregistration, so the agent reads Offline at once. A dropped connection is retried with a growing wait, from 1 second to 30 seconds.
 

--- a/docs/integration/typescript/agent-reference.mdx
+++ b/docs/integration/typescript/agent-reference.mdx
@@ -131,7 +131,7 @@ Values arrive validated against the declaration. A value the declaration refuses
 
 ### Lifecycle
 
-The connection starts on the next tick after the first `connectAgent` call, once per process, and one connection carries every agent the process declares. It uses the global `WebSocket` when the runtime has one and the `ws` package otherwise. While connected, it keeps the event loop alive, so `node agent.ts` serves until Ctrl-C.
+The connection starts on the next tick after the first `connectAgent` call, once per process, and one connection carries every agent the process declares. It uses the global `WebSocket` when the runtime has one and the `ws` package otherwise. While connected, it keeps the event loop alive, so a script that only declares an agent serves until Ctrl-C.
 
 SIGINT, SIGTERM and normal exit send a deregistration, so the agent reads Offline at once. A dropped connection is retried with a growing wait, from 1 second to 30 seconds.
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -36296,7 +36296,8 @@ langwatch.agent.serve()   # Python, at the bottom of the script
 ```
 
 ```typescript
-// TypeScript: the connection holds the event loop open, `node agent.ts` serves until Ctrl-C
+// TypeScript: the connection holds the event loop open, so the script serves until Ctrl-C
+// Run it with the project's TypeScript runner, for example `tsx agent.ts`
 ```
 
 Then confirm from the CLI, in another terminal:
@@ -36582,7 +36583,7 @@ Then start your service the way you always start it. The start command does not 
 
   In Python, call `langwatch.agent.serve()` at the end of the script. It blocks until Ctrl-C.
 
-  In TypeScript the connection holds the event loop open by itself, so `node agent.ts` serves until Ctrl-C.
+  In TypeScript the connection holds the event loop open by itself, so the script serves until Ctrl-C. Run it with whatever runner the project uses, for example `tsx agent.ts`.
 </Note>
 
 ## 3. Confirm it is online
@@ -36815,7 +36816,7 @@ One deployment with several pods is one row and several instances. The platform 
 |---|---|
 | `concurrency` | How many calls one instance takes at the same time. Default 1 in `development`, 4 elsewhere. When every instance is full, the platform waits and retries within the call's deadline. |
 | `instance_label` (`instanceLabel`) | A name for this instance in the instances table, for example the pod name. Also read from `LANGWATCH_AGENT_INSTANCE_LABEL`. |
-| `enabled` | Whether this process connects. It takes any boolean, so one expression decides which deployments connect: `enabled=os.environ.get("APP_ENV") != "production"` connects everywhere but production. Default true, and false when `CI` is set, because a CI job is not a service anyone runs suites against. Pass `enabled=True` to override that. |
+| `enabled` | Whether this process connects. It takes any boolean, so one expression decides which deployments connect: `enabled=os.environ.get("APP_ENV") != "production" and not os.environ.get("CI")` connects everywhere but production and CI. Without the argument the default is true, and false when `CI` is set. An `enabled` argument replaces that rule, so keep the `CI` half unless a CI job is deliberately the target. |
 | `LANGWATCH_AGENT_CONNECT=0` | Turns the connection off for a deployment without a code change. |
 
 The platform delivers each call at most once. The SDK confirms a call when the function starts, and the platform never sends a confirmed call to a second instance, so a turn with side effects runs one time.
@@ -36877,7 +36878,7 @@ The decorator never stops the application from starting. Every problem is one wa
     | `name` | required | The agent's name, and the first half of a `connected:<name>@<environment>` target. |
     | `environment` | resolved, see above | Which environment row this process registers under. |
     | `parameters` | read from the signature | An explicit parameter declaration that replaces what the signature declares. |
-    | `enabled` | `True`, `False` under `CI` | Whether this process connects at all. Takes any boolean, for example `os.environ.get("APP_ENV") != "production"`. |
+    | `enabled` | `True`, `False` under `CI` | Whether this process connects at all. Takes any boolean, and replaces the `CI` default rather than adding to it. |
     | `instance_label` | none | A name for this instance in the instances table. |
     | `timeout` | `120` seconds | How long one call may take. The ceiling is 300 seconds. |
     | `concurrency` | `1` in `development`, `4` elsewhere | Calls this instance takes at the same time. |
@@ -36897,7 +36898,7 @@ The decorator never stops the application from starting. Every problem is one wa
     | `name` | required | The agent's name, and the first half of a `connected:<name>@<environment>` target. |
     | `environment` | resolved, see above | Which environment row this process registers under. |
     | `parameters` | none | A zod schema, a definition map, or a JSON Schema object. |
-    | `enabled` | `true`, `false` under `CI` | Whether this process connects at all. Takes any boolean, for example `process.env.APP_ENV !== "production"`. |
+    | `enabled` | `true`, `false` under `CI` | Whether this process connects at all. Takes any boolean, and replaces the `CI` default rather than adding to it. |
     | `instanceLabel` | none | A name for this instance in the instances table. |
     | `timeoutMs` | `120000` | How long one call may take. The ceiling is 300000. |
     | `concurrency` | `1` in `development`, `4` elsewhere | Calls this instance takes at the same time. |
@@ -37077,9 +37078,11 @@ LANGWATCH_AGENT_CONNECT=0
   ### Python
 
     ```python
+    import os
+
     @langwatch.connect_agent(
         name="support-agent",
-        enabled=os.environ.get("APP_ENV") != "production",
+        enabled=os.environ.get("APP_ENV") != "production" and not os.environ.get("CI"),
     )
     ```
 
@@ -37089,7 +37092,7 @@ LANGWATCH_AGENT_CONNECT=0
     connectAgent(
       {
         name: "support-agent",
-        enabled: process.env.APP_ENV !== "production",
+        enabled: process.env.APP_ENV !== "production" && !process.env.CI,
       },
       handler,
     );
@@ -37097,7 +37100,7 @@ LANGWATCH_AGENT_CONNECT=0
 
 
 
-The SDK defaults `enabled` to false when `CI` is set, because a CI job is not a service anyone runs suites against. Pass it true when a CI job is deliberately the target.
+The `CI` half of each expression keeps the default the SDK applies on its own. Without an `enabled` argument the SDK connects, except when `CI` is set, because a CI job is not a service anyone runs suites against. An `enabled` argument replaces that rule instead of adding to it, so an expression that ignores `CI` connects CI jobs. Leave the `CI` half out when a CI job is deliberately the target.
 
 ## Next steps
 
@@ -54291,7 +54294,8 @@ langwatch.agent.serve()   # Python, at the bottom of the script
 ```
 
 ```typescript
-// TypeScript: the connection holds the event loop open, `node agent.ts` serves until Ctrl-C
+// TypeScript: the connection holds the event loop open, so the script serves until Ctrl-C
+// Run it with the project's TypeScript runner, for example `tsx agent.ts`
 ```
 
 Then confirm from the CLI, in another terminal:

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -36056,7 +36056,7 @@ Also check: [Run plans](/agent-testing/run-plans), [Results](/agent-testing/resu
 title: Connect Your Agent
 sidebarTitle: Overview
 keywords: langwatch, agent simulations, connected agent, connect_agent, connectAgent, agent decorator, run parameters, environments, scenario suite, coding agent prompt
-description: Decorate the function that runs your agent to connect it to LangWatch, so your team can run test suites from the platform against your actual agent.
+description: Add a small connect function beside your service startup that calls the agent you already have, so your team can run test suites from the platform against the real agent.
 ---
 
 ## Getting Started
@@ -36110,7 +36110,7 @@ Use the `langwatch` CLI for everything: documentation (`langwatch docs ...`, `la
 
 Connect the agent in this codebase to LangWatch, so test suites run from the platform against the real agent process. The SDK opens an outbound connection to LangWatch from the process that already runs the agent, registers the agent with its environment and its run parameters, and receives one call per conversation turn. The simulation exercises the real code, dependencies, secrets and traces.
 
-Three steps: install the SDK, decorate the function, start the process. Work through them in order, confirm the agent reads Online, run one test suite, then report what changed and the result.
+Three steps: install the SDK, add the connect function where the service starts, start the service the way the user always starts it. Work through them in order, confirm the agent reads Online, run one test suite, then report what changed and the result.
 
 Use the HTTP fallback at the bottom of this skill ONLY when the agent cannot import the SDK: the agent is written in a language with no LangWatch SDK, or you have no access to its code.
 
@@ -36159,7 +36159,7 @@ LangWatch.
 
 ## Step 2: Install the SDK
 
-Read the codebase first. Find the function that takes a conversation and returns the agent's reply, and the file it lives in. That function is what you decorate; do not write a second one beside it.
+Read the codebase first. Find two things: the entry point that runs the agent, which is what the connect function calls, and the file that starts the service, which is where the connect function goes.
 
 ```bash
 pip install langwatch          # Python
@@ -36168,46 +36168,66 @@ npm install langwatch zod      # TypeScript, Node only
 
 The process needs `LANGWATCH_API_KEY` in its environment. It is the same project key the CLI uses. Without a key the SDK logs one line and opens no connection.
 
-## Step 3: Decorate the function
+## Step 3: Add the connect function where the service starts
+
+Write a small function beside the code that starts the service. LangWatch calls it once per conversation turn, and it calls the agent the codebase already has. It is an adapter: build the input the agent expects, pass the run parameters into it, and return the reply text out of what the agent gives back.
+
+Put it in the file that starts the service, or in a module that file imports at startup. The connection opens with the process, so the code has to run when the process runs.
 
 **Python**
 
 ```python
+# main.py, beside the server startup
 import langwatch
 
+from my_app.agent import SupportAgent
+
 @langwatch.connect_agent(name="support-agent")
-async def support_agent(messages: list[dict], thread_id: str) -> str:
-    return await run_my_agent(messages)
+async def support_agent(
+    messages: list[dict],
+    thread_id: str,
+    *,
+    model: str = "gpt-5-mini",
+) -> str:
+    result = await SupportAgent(model=model).run(messages, conversation_id=thread_id)
+    return result.output_text
 ```
 
 **TypeScript**
 
 ```typescript
+// server.ts, beside the server startup
 import { z } from "zod";
 import { connectAgent } from "langwatch/agent";
 
-export const supportAgent = connectAgent(
+import { runSupportAgent } from "./agent";
+
+connectAgent(
   {
     name: "support-agent",
     parameters: z.object({
       model: z.enum(["gpt-5", "gpt-5-mini"]).default("gpt-5-mini"),
-      plan: z.string().default("free").describe("Customer plan"),
-      maxTools: z.number().int().default(5),
     }),
   },
-  async ({ messages, params }) => {
-    // params is typed: { model: "gpt-5" | "gpt-5-mini"; plan: string; maxTools: number }
-    return await runMyAgent(messages, { model: params.model });
+  async ({ messages, threadId, params }) => {
+    const result = await runSupportAgent({
+      messages,
+      conversationId: threadId,
+      model: params.model,
+    });
+    return result.text;
   },
 );
 ```
 
-Rules for the decorated function:
+Rules for the connect function:
 
 - `name` is required. Use the name the team calls the agent, in lower case with dashes.
+- Call the agent the product already runs. Do not reimplement it in the connect function, and do not call a simplified copy of it, or the suite tests code no customer reaches.
+- Change nothing about how the service starts. The connect function runs on the startup path, and the start command stays the same.
 - **Turn fields** are what the platform sends on every call: `messages` (the whole conversation, OpenAI-style), `new_messages` (`newMessages`, the delta since the last turn), `thread_id` (`threadId`), `session`, `trace_id` (`traceId`). In Python, declare only the ones you use and the SDK passes exactly those. In TypeScript, they arrive as one object, so destructure what you need.
 - Return a string, one message, a list of messages, or `langwatch.AgentReply(output, session=...)` (`{ output, session }` in TypeScript).
-- Do not remove or weaken the function's own behavior. The decorator wraps it; the direct callers keep working.
+- Do not change the agent's own code to fit the connect function. Map the turn onto the agent's existing call in the connect function instead.
 - Do NOT add a `traceparent` middleware. The SDK adopts the turn's trace context before it calls the function, so the agent's spans land in the turn's trace and the judge reads them.
 
 ### Run parameters
@@ -36228,7 +36248,7 @@ async def support_agent(
     ...
 ```
 
-TypeScript declares them with a zod schema in `parameters`, the way Step 3 shows. The schema types `params` in the handler, and the SDK validates the values a run supplies against it. Add `zod` to the project (`npm install zod`) if it is not there yet. Read the schema this way:
+TypeScript declares them with a zod schema in `parameters`, the way Step 3 shows. Read the values out of `params` in the connect function and pass them into the agent's own call. The schema types `params` in the handler, and the SDK validates the values a run supplies against it. Add `zod` to the project (`npm install zod`) if it is not there yet. Read the schema this way:
 
 - `z.enum([...])` becomes a closed option list in the run dialog. A value outside the list is refused.
 - `.default(value)` sets the default.
@@ -36265,16 +36285,18 @@ The SDK reads the environment from the `environment` argument, then `LANGWATCH_A
 
 Leave `environment` out when the service already sets `LANGWATCH_AGENT_ENVIRONMENT`, `APP_ENV`, `ENVIRONMENT` or `NODE_ENV`. The SDK reads them on its own.
 
-## Step 4: Start the process and confirm the agent is Online
+## Step 4: Start the service and confirm the agent is Online
 
-Start the service the way the user starts it. A web server keeps the connection alive by itself. For a script whose only job is the agent, block it:
+Start the service the way the user starts it. Do not add a start command, and do not write a separate runner script: the connect function is already on the startup path, and a web server holds the connection open by itself.
+
+The exception is an agent that is a library with no process of its own. Put the connect function in a small script and keep the script alive:
 
 ```python
 langwatch.agent.serve()   # Python, at the bottom of the script
 ```
 
 ```typescript
-// TypeScript: the socket keeps the event loop alive, `node agent.ts` serves until Ctrl-C
+// TypeScript: the connection holds the event loop open, `node agent.ts` serves until Ctrl-C
 ```
 
 Then confirm from the CLI, in another terminal:
@@ -36435,13 +36457,14 @@ Run it with `--target http:<agent-id>`, and follow Step 5 and Step 6 otherwise u
 | The run is refused with `agent_offline` | No instance was connected when the run started. | Start the agent process and run again. |
 | The run is refused with `agent_owner_only` | The agent registered under `development` with a personal key, so only its owner can run it. | Run it as the owner, or register it under a shared environment name such as `dev-shared`. |
 | The run is refused with `scenario_parameter_option_invalid` | A value is outside the closed option list the agent declares. | Use one of the listed options, or widen the `Literal` (Python) or `z.enum` (TypeScript) list in the code. |
-| A turn fails with `agent_call_timeout` | The function took longer than the agent's timeout. | Raise `timeout` on the decorator (up to 300 seconds), or make the agent answer faster. |
+| A turn fails with `agent_call_timeout` | The call took longer than the agent's timeout. | Raise `timeout` on the connect function (up to 300 seconds), or make the agent answer faster. |
 | Trace-dependent criteria come back inconclusive | The agent reports its traces to a different LangWatch project, or it reports none at all. | Point the agent's tracing at the same project's API key. Set it up with the `tracing` skill. |
 
 ## Common Mistakes
 
-- Do NOT write a second wrapper function for LangWatch to call. Decorate the function the product already runs, so the simulation exercises the real code path.
-- Do NOT add a `traceparent` middleware for a decorated agent. The SDK adopts the trace context itself; the middleware belongs to the HTTP fallback only.
+- Do NOT reimplement the agent inside the connect function, and do NOT point it at a simplified copy. It calls the agent the product already runs, so the simulation exercises the real code path.
+- Do NOT add a runner script or a second start command when the service already has one. The connect function goes on the existing startup path.
+- Do NOT add a `traceparent` middleware for a connected agent. The SDK adopts the trace context itself; the middleware belongs to the HTTP fallback only.
 - Do NOT hardcode an environment string, and do NOT write a fallback such as `process.env.APP_ENV ?? "development"`. It overrides `LANGWATCH_AGENT_ENVIRONMENT` and registers a production process under `development`. Let the SDK resolve the environment.
 - Do NOT declare a run parameter for a value the tests never vary. Every declared parameter appears in the run dialog.
 - Do NOT use a turn field name (`messages`, `new_messages`, `thread_id`, `session`, `trace_id`) as a run parameter name.
@@ -36489,74 +36512,82 @@ The steps below are the same setup by hand, and what to check when the skill's r
 
 The process needs `LANGWATCH_API_KEY` in its environment. It is the project API key from **Settings > API Keys**, the same one the CLI and the SDK use for tracing. Without a key the SDK logs one line and opens no connection, so a build that has no key runs unchanged.
 
-## 2. Decorate the function
+## 2. Connect it where your service starts
 
-Decorate the function that already takes a conversation and returns your agent's reply. There is no second function to write and no endpoint to add.
+Write a small function beside the code that starts your service. LangWatch calls it once per conversation turn, and it calls the agent you already have.
+
+That function is the adapter, and it is the only new code. Build the input your agent expects, pass the run parameters into it, and return the reply text out of whatever your agent gives back. The agent itself does not change.
 
 
   ### Python
 
     ```python
+    # main.py, beside your server startup
     import langwatch
 
+    from my_app.agent import SupportAgent
+
     @langwatch.connect_agent(name="support-agent")
-    async def support_agent(messages: list[dict], thread_id: str) -> str:
-        return await run_my_agent(messages)
+    async def support_agent(
+        messages: list[dict],
+        thread_id: str,
+        *,
+        model: str = "gpt-5-mini",
+    ) -> str:
+        result = await SupportAgent(model=model).run(messages, conversation_id=thread_id)
+        return result.output_text
     ```
+
+    `model` is a run parameter, so a run can select it. `messages` and `thread_id` are turn fields that LangWatch sends. See [What the agent receives](#what-the-agent-receives) and [Run parameters](#run-parameters) below.
 
     A synchronous function works the same way. It runs in a worker thread, so the connection stays responsive.
 
   ### TypeScript
 
     ```typescript
+    // server.ts, beside your server startup
     import { z } from "zod";
     import { connectAgent } from "langwatch/agent";
 
-    export const supportAgent = connectAgent(
+    import { runSupportAgent } from "./agent";
+
+    connectAgent(
       {
         name: "support-agent",
-        environment: process.env.APP_ENV ?? "development",
         parameters: z.object({
           model: z.enum(["gpt-5", "gpt-5-mini"]).default("gpt-5-mini"),
-          plan: z.string().default("free").describe("Customer plan"),
-          maxTools: z.number().int().default(5),
         }),
       },
-      async ({ messages, params }) => {
-        // params is typed: { model: "gpt-5" | "gpt-5-mini"; plan: string; maxTools: number }
-        return await runMyAgent(messages, { model: params.model });
+      async ({ messages, threadId, params }) => {
+        const result = await runSupportAgent({
+          messages,
+          conversationId: threadId,
+          model: params.model,
+        });
+        return result.text;
       },
     );
     ```
 
     The zod schema declares the run parameters, and it types `params` in the handler. See [Run parameters](#run-parameters) below for what each part of the schema does. An agent whose tests vary no value takes `parameters` away and keeps the rest.
 
-    `connectAgent` returns the handler, so `supportAgent({ messages })` still calls it directly. Unit tests and code-first scenario runs use the same function.
+    `connectAgent` returns the function, so a code-first scenario run and a unit test can call it directly.
 
 
 
-## 3. Start the process
+Put this on the startup path: the file that starts your service, or a module that file imports at startup. The connection opens with the process, so the code has to run when the process runs.
 
-Start the service the way you always start it. A web server keeps the connection alive by itself, and one process serves every agent it declares over a single connection.
+Then start your service the way you always start it. The start command does not change, and there is no new process to run. A web server holds the connection open by itself, and one process serves every agent it declares over a single connection.
 
-For a script whose only job is the agent, block at the end of the file:
+<Note>
+  **No long-running service?** When the agent is a library with no process of its own, put the connect function in a small script and keep the script alive.
 
+  In Python, call `langwatch.agent.serve()` at the end of the script. It blocks until Ctrl-C.
 
-  ### Python
+  In TypeScript the connection holds the event loop open by itself, so `node agent.ts` serves until Ctrl-C.
+</Note>
 
-    ```python
-    langwatch.agent.serve()
-    ```
-
-  ### TypeScript
-
-    ```bash
-    node agent.ts
-    ```
-
-    The connection keeps the event loop alive, so the process serves until Ctrl-C.
-
-
+## 3. Confirm it is online
 
 The agent appears on the **Agents** page with a green **Online** mark, its environment, and the number of connected instances. From the terminal:
 
@@ -36786,7 +36817,7 @@ One deployment with several pods is one row and several instances. The platform 
 |---|---|
 | `concurrency` | How many calls one instance takes at the same time. Default 1 in `development`, 4 elsewhere. When every instance is full, the platform waits and retries within the call's deadline. |
 | `instance_label` (`instanceLabel`) | A name for this instance in the instances table, for example the pod name. Also read from `LANGWATCH_AGENT_INSTANCE_LABEL`. |
-| `enabled` | Whether this process connects. Default true, and false when `CI` is set, because a CI job is not a service anyone runs suites against. Pass `enabled=True` to override that. |
+| `enabled` | Whether this process connects. It takes any boolean, so one expression decides which deployments connect: `enabled=os.environ.get("APP_ENV") != "production"` connects everywhere but production. Default true, and false when `CI` is set, because a CI job is not a service anyone runs suites against. Pass `enabled=True` to override that. |
 | `LANGWATCH_AGENT_CONNECT=0` | Turns the connection off for a deployment without a code change. |
 
 The platform delivers each call at most once. The SDK confirms a call when the function starts, and the platform never sends a confirmed call to a second instance, so a turn with side effects runs one time.
@@ -36848,7 +36879,7 @@ The decorator never stops the application from starting. Every problem is one wa
     | `name` | required | The agent's name, and the first half of a `connected:<name>@<environment>` target. |
     | `environment` | resolved, see above | Which environment row this process registers under. |
     | `parameters` | read from the signature | An explicit parameter declaration that replaces what the signature declares. |
-    | `enabled` | `True`, `False` under `CI` | Whether this process connects at all. |
+    | `enabled` | `True`, `False` under `CI` | Whether this process connects at all. Takes any boolean, for example `os.environ.get("APP_ENV") != "production"`. |
     | `instance_label` | none | A name for this instance in the instances table. |
     | `timeout` | `120` seconds | How long one call may take. The ceiling is 300 seconds. |
     | `concurrency` | `1` in `development`, `4` elsewhere | Calls this instance takes at the same time. |
@@ -36868,7 +36899,7 @@ The decorator never stops the application from starting. Every problem is one wa
     | `name` | required | The agent's name, and the first half of a `connected:<name>@<environment>` target. |
     | `environment` | resolved, see above | Which environment row this process registers under. |
     | `parameters` | none | A zod schema, a definition map, or a JSON Schema object. |
-    | `enabled` | `true`, `false` under `CI` | Whether this process connects at all. |
+    | `enabled` | `true`, `false` under `CI` | Whether this process connects at all. Takes any boolean, for example `process.env.APP_ENV !== "production"`. |
     | `instanceLabel` | none | A name for this instance in the instances table. |
     | `timeoutMs` | `120000` | How long one call may take. The ceiling is 300000. |
     | `concurrency` | `1` in `development`, `4` elsewhere | Calls this instance takes at the same time. |
@@ -37042,13 +37073,39 @@ Turn the connection off for a deployment without a code change:
 LANGWATCH_AGENT_CONNECT=0
 ```
 
-`enabled=False` on the decorator does the same in code, and the SDK defaults it to false when `CI` is set, because a CI job is not a service anyone runs suites against. Pass `enabled=True` when a CI job is deliberately the target.
+`enabled` on the connect function does the same in code. It takes any boolean, so one expression decides which deployments connect:
+
+
+  ### Python
+
+    ```python
+    @langwatch.connect_agent(
+        name="support-agent",
+        enabled=os.environ.get("APP_ENV") != "production",
+    )
+    ```
+
+  ### TypeScript
+
+    ```typescript
+    connectAgent(
+      {
+        name: "support-agent",
+        enabled: process.env.APP_ENV !== "production",
+      },
+      handler,
+    );
+    ```
+
+
+
+The SDK defaults `enabled` to false when `CI` is set, because a CI job is not a service anyone runs suites against. Pass it true when a CI job is deliberately the target.
 
 ## Next steps
 
 <CardGroup cols={2}>
   <Card title="Connect your agent" icon="plug" href="/agent-testing/connect-your-agent">
-    Decorate the function that runs your agent
+    Call your agent from a connect function beside your service startup
   </Card>
   <Card title="Run parameters" icon="sliders" href="/agent-testing/run-parameters">
     Values a run supplies, declared by the scenario or by the agent
@@ -37213,7 +37270,7 @@ For the full SDK reference, see the [Scenario documentation](https://langwatch.a
 
 <CardGroup cols={2}>
   <Card title="Connect your agent" icon="plug" href="/agent-testing/connect-your-agent">
-    Decorate the function that runs your agent, and the SDK adopts the trace context
+    Connect your agent from your service startup, and the SDK adopts the trace context
   </Card>
   <Card title="Environments" icon="laptop-code" href="/agent-testing/environments">
     Your machine, staging and production as separate targets
@@ -37496,7 +37553,7 @@ The mapped input is `None` on the first turn of a conversation, and afterwards e
 
 <CardGroup cols={2}>
   <Card title="Connect your agent" icon="plug" href="/agent-testing/connect-your-agent">
-    Decorate the function that runs your agent
+    Call your agent from a connect function beside your service startup
   </Card>
   <Card title="Authenticated agents" icon="key" href="/agent-testing/authenticated-agents">
     Reference project secrets, and exchange OAuth2 credentials
@@ -37556,7 +37613,7 @@ Both use the same simulated user, the same judge and the same results pages. The
 
 <CardGroup cols={2}>
   <Card title="Test from the platform" icon="globe" href="/agent-testing/test-from-the-platform">
-    Decorate the function that runs your agent, then write, run and see scenarios in the LangWatch interface. No test code in your repository.
+    Connect your agent from your service startup, then write, run and see scenarios in the LangWatch interface. No test code in your repository.
   </Card>
   <Card title="Write scenarios in code" icon="code" href="/agent-testing/scenarios-in-code">
     Write scenarios with the Scenario SDK in Python or TypeScript, run them with your test runner and in CI, and see every run in LangWatch.
@@ -54050,7 +54107,7 @@ Use the `langwatch` CLI for everything: documentation (`langwatch docs ...`, `la
 
 Connect the agent in this codebase to LangWatch, so test suites run from the platform against the real agent process. The SDK opens an outbound connection to LangWatch from the process that already runs the agent, registers the agent with its environment and its run parameters, and receives one call per conversation turn. The simulation exercises the real code, dependencies, secrets and traces.
 
-Three steps: install the SDK, decorate the function, start the process. Work through them in order, confirm the agent reads Online, run one test suite, then report what changed and the result.
+Three steps: install the SDK, add the connect function where the service starts, start the service the way the user always starts it. Work through them in order, confirm the agent reads Online, run one test suite, then report what changed and the result.
 
 Use the HTTP fallback at the bottom of this skill ONLY when the agent cannot import the SDK: the agent is written in a language with no LangWatch SDK, or you have no access to its code.
 
@@ -54099,7 +54156,7 @@ LangWatch.
 
 ## Step 2: Install the SDK
 
-Read the codebase first. Find the function that takes a conversation and returns the agent's reply, and the file it lives in. That function is what you decorate; do not write a second one beside it.
+Read the codebase first. Find two things: the entry point that runs the agent, which is what the connect function calls, and the file that starts the service, which is where the connect function goes.
 
 ```bash
 pip install langwatch          # Python
@@ -54108,46 +54165,66 @@ npm install langwatch zod      # TypeScript, Node only
 
 The process needs `LANGWATCH_API_KEY` in its environment. It is the same project key the CLI uses. Without a key the SDK logs one line and opens no connection.
 
-## Step 3: Decorate the function
+## Step 3: Add the connect function where the service starts
+
+Write a small function beside the code that starts the service. LangWatch calls it once per conversation turn, and it calls the agent the codebase already has. It is an adapter: build the input the agent expects, pass the run parameters into it, and return the reply text out of what the agent gives back.
+
+Put it in the file that starts the service, or in a module that file imports at startup. The connection opens with the process, so the code has to run when the process runs.
 
 **Python**
 
 ```python
+# main.py, beside the server startup
 import langwatch
 
+from my_app.agent import SupportAgent
+
 @langwatch.connect_agent(name="support-agent")
-async def support_agent(messages: list[dict], thread_id: str) -> str:
-    return await run_my_agent(messages)
+async def support_agent(
+    messages: list[dict],
+    thread_id: str,
+    *,
+    model: str = "gpt-5-mini",
+) -> str:
+    result = await SupportAgent(model=model).run(messages, conversation_id=thread_id)
+    return result.output_text
 ```
 
 **TypeScript**
 
 ```typescript
+// server.ts, beside the server startup
 import { z } from "zod";
 import { connectAgent } from "langwatch/agent";
 
-export const supportAgent = connectAgent(
+import { runSupportAgent } from "./agent";
+
+connectAgent(
   {
     name: "support-agent",
     parameters: z.object({
       model: z.enum(["gpt-5", "gpt-5-mini"]).default("gpt-5-mini"),
-      plan: z.string().default("free").describe("Customer plan"),
-      maxTools: z.number().int().default(5),
     }),
   },
-  async ({ messages, params }) => {
-    // params is typed: { model: "gpt-5" | "gpt-5-mini"; plan: string; maxTools: number }
-    return await runMyAgent(messages, { model: params.model });
+  async ({ messages, threadId, params }) => {
+    const result = await runSupportAgent({
+      messages,
+      conversationId: threadId,
+      model: params.model,
+    });
+    return result.text;
   },
 );
 ```
 
-Rules for the decorated function:
+Rules for the connect function:
 
 - `name` is required. Use the name the team calls the agent, in lower case with dashes.
+- Call the agent the product already runs. Do not reimplement it in the connect function, and do not call a simplified copy of it, or the suite tests code no customer reaches.
+- Change nothing about how the service starts. The connect function runs on the startup path, and the start command stays the same.
 - **Turn fields** are what the platform sends on every call: `messages` (the whole conversation, OpenAI-style), `new_messages` (`newMessages`, the delta since the last turn), `thread_id` (`threadId`), `session`, `trace_id` (`traceId`). In Python, declare only the ones you use and the SDK passes exactly those. In TypeScript, they arrive as one object, so destructure what you need.
 - Return a string, one message, a list of messages, or `langwatch.AgentReply(output, session=...)` (`{ output, session }` in TypeScript).
-- Do not remove or weaken the function's own behavior. The decorator wraps it; the direct callers keep working.
+- Do not change the agent's own code to fit the connect function. Map the turn onto the agent's existing call in the connect function instead.
 - Do NOT add a `traceparent` middleware. The SDK adopts the turn's trace context before it calls the function, so the agent's spans land in the turn's trace and the judge reads them.
 
 ### Run parameters
@@ -54168,7 +54245,7 @@ async def support_agent(
     ...
 ```
 
-TypeScript declares them with a zod schema in `parameters`, the way Step 3 shows. The schema types `params` in the handler, and the SDK validates the values a run supplies against it. Add `zod` to the project (`npm install zod`) if it is not there yet. Read the schema this way:
+TypeScript declares them with a zod schema in `parameters`, the way Step 3 shows. Read the values out of `params` in the connect function and pass them into the agent's own call. The schema types `params` in the handler, and the SDK validates the values a run supplies against it. Add `zod` to the project (`npm install zod`) if it is not there yet. Read the schema this way:
 
 - `z.enum([...])` becomes a closed option list in the run dialog. A value outside the list is refused.
 - `.default(value)` sets the default.
@@ -54205,16 +54282,18 @@ The SDK reads the environment from the `environment` argument, then `LANGWATCH_A
 
 Leave `environment` out when the service already sets `LANGWATCH_AGENT_ENVIRONMENT`, `APP_ENV`, `ENVIRONMENT` or `NODE_ENV`. The SDK reads them on its own.
 
-## Step 4: Start the process and confirm the agent is Online
+## Step 4: Start the service and confirm the agent is Online
 
-Start the service the way the user starts it. A web server keeps the connection alive by itself. For a script whose only job is the agent, block it:
+Start the service the way the user starts it. Do not add a start command, and do not write a separate runner script: the connect function is already on the startup path, and a web server holds the connection open by itself.
+
+The exception is an agent that is a library with no process of its own. Put the connect function in a small script and keep the script alive:
 
 ```python
 langwatch.agent.serve()   # Python, at the bottom of the script
 ```
 
 ```typescript
-// TypeScript: the socket keeps the event loop alive, `node agent.ts` serves until Ctrl-C
+// TypeScript: the connection holds the event loop open, `node agent.ts` serves until Ctrl-C
 ```
 
 Then confirm from the CLI, in another terminal:
@@ -54375,13 +54454,14 @@ Run it with `--target http:<agent-id>`, and follow Step 5 and Step 6 otherwise u
 | The run is refused with `agent_offline` | No instance was connected when the run started. | Start the agent process and run again. |
 | The run is refused with `agent_owner_only` | The agent registered under `development` with a personal key, so only its owner can run it. | Run it as the owner, or register it under a shared environment name such as `dev-shared`. |
 | The run is refused with `scenario_parameter_option_invalid` | A value is outside the closed option list the agent declares. | Use one of the listed options, or widen the `Literal` (Python) or `z.enum` (TypeScript) list in the code. |
-| A turn fails with `agent_call_timeout` | The function took longer than the agent's timeout. | Raise `timeout` on the decorator (up to 300 seconds), or make the agent answer faster. |
+| A turn fails with `agent_call_timeout` | The call took longer than the agent's timeout. | Raise `timeout` on the connect function (up to 300 seconds), or make the agent answer faster. |
 | Trace-dependent criteria come back inconclusive | The agent reports its traces to a different LangWatch project, or it reports none at all. | Point the agent's tracing at the same project's API key. Set it up with the `tracing` skill. |
 
 ## Common Mistakes
 
-- Do NOT write a second wrapper function for LangWatch to call. Decorate the function the product already runs, so the simulation exercises the real code path.
-- Do NOT add a `traceparent` middleware for a decorated agent. The SDK adopts the trace context itself; the middleware belongs to the HTTP fallback only.
+- Do NOT reimplement the agent inside the connect function, and do NOT point it at a simplified copy. It calls the agent the product already runs, so the simulation exercises the real code path.
+- Do NOT add a runner script or a second start command when the service already has one. The connect function goes on the existing startup path.
+- Do NOT add a `traceparent` middleware for a connected agent. The SDK adopts the trace context itself; the middleware belongs to the HTTP fallback only.
 - Do NOT hardcode an environment string, and do NOT write a fallback such as `process.env.APP_ENV ?? "development"`. It overrides `LANGWATCH_AGENT_ENVIRONMENT` and registers a production process under `development`. Let the SDK resolve the environment.
 - Do NOT declare a run parameter for a value the tests never vary. Every declared parameter appears in the run dialog.
 - Do NOT use a turn field name (`messages`, `new_messages`, `thread_id`, `session`, `trace_id`) as a run parameter name.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -36296,7 +36296,9 @@ langwatch.agent.serve()   # Python, at the bottom of the script
 ```
 
 ```typescript
-// TypeScript: the connection holds the event loop open, so the script serves until Ctrl-C
+// TypeScript: keep the script alive yourself. The WebSocket holds the event loop
+// while connected, but the HTTP fallback and the reconnect wait do not.
+setInterval(() => {}, 1 << 30);
 // Run it with the project's TypeScript runner, for example `tsx agent.ts`
 ```
 
@@ -36583,7 +36585,13 @@ Then start your service the way you always start it. The start command does not 
 
   In Python, call `langwatch.agent.serve()` at the end of the script. It blocks until Ctrl-C.
 
-  In TypeScript the connection holds the event loop open by itself, so the script serves until Ctrl-C. Run it with whatever runner the project uses, for example `tsx agent.ts`.
+  In TypeScript, keep the script alive yourself. An open WebSocket holds the event loop while it is connected, but the HTTP fallback and the reconnect wait use unreferenced timers, so a script with no server of its own can exit between polls.
+
+  ```typescript
+  setInterval(() => {}, 1 << 30);
+  ```
+
+  Run the script with whatever runner the project uses, for example `tsx agent.ts`.
 </Note>
 
 ## 3. Confirm it is online
@@ -37080,21 +37088,27 @@ LANGWATCH_AGENT_CONNECT=0
     ```python
     import os
 
+    import langwatch
+
     @langwatch.connect_agent(
         name="support-agent",
         enabled=os.environ.get("APP_ENV") != "production" and not os.environ.get("CI"),
     )
+    async def support_agent(messages: list[dict]) -> str:
+        return await run_my_agent(messages)
     ```
 
   ### TypeScript
 
     ```typescript
+    import { connectAgent } from "langwatch/agent";
+
     connectAgent(
       {
         name: "support-agent",
         enabled: process.env.APP_ENV !== "production" && !process.env.CI,
       },
-      handler,
+      async ({ messages }) => await runMyAgent(messages),
     );
     ```
 
@@ -54294,7 +54308,9 @@ langwatch.agent.serve()   # Python, at the bottom of the script
 ```
 
 ```typescript
-// TypeScript: the connection holds the event loop open, so the script serves until Ctrl-C
+// TypeScript: keep the script alive yourself. The WebSocket holds the event loop
+// while connected, but the HTTP fallback and the reconnect wait do not.
+setInterval(() => {}, 1 << 30);
 // Run it with the project's TypeScript runner, for example `tsx agent.ts`
 ```
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -36170,7 +36170,7 @@ The process needs `LANGWATCH_API_KEY` in its environment. It is the same project
 
 ## Step 3: Add the connect function where the service starts
 
-Write a small function beside the code that starts the service. LangWatch calls it once per conversation turn, and it calls the agent the codebase already has. It is an adapter: build the input the agent expects, pass the run parameters into it, and return the reply text out of what the agent gives back.
+Write a small function beside the code that starts the service. It is the adapter between the messages that come from a scenario test and the agent in the codebase.
 
 Put it in the file that starts the service, or in a module that file imports at startup. The connection opens with the process, so the code has to run when the process runs.
 
@@ -36514,9 +36514,7 @@ The process needs `LANGWATCH_API_KEY` in its environment. It is the project API 
 
 ## 2. Connect it where your service starts
 
-Write a small function beside the code that starts your service. LangWatch calls it once per conversation turn, and it calls the agent you already have.
-
-That function is the adapter, and it is the only new code. Build the input your agent expects, pass the run parameters into it, and return the reply text out of whatever your agent gives back. The agent itself does not change.
+Write a small function beside the code that starts your service. This is the adapter between the messages that come from a scenario test and your agent.
 
 
   ### Python
@@ -54167,7 +54165,7 @@ The process needs `LANGWATCH_API_KEY` in its environment. It is the same project
 
 ## Step 3: Add the connect function where the service starts
 
-Write a small function beside the code that starts the service. LangWatch calls it once per conversation turn, and it calls the agent the codebase already has. It is an adapter: build the input the agent expects, pass the run parameters into it, and return the reply text out of what the agent gives back.
+Write a small function beside the code that starts the service. It is the adapter between the messages that come from a scenario test and the agent in the codebase.
 
 Put it in the file that starts the service, or in a module that file imports at startup. The connection opens with the process, so the code has to run when the process runs.
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -30,7 +30,7 @@ For agents: if anything in these docs is wrong, confusing, or fails when you try
 
 ### Connect your agent
 
-- [Connect Your Agent](https://langwatch.ai/docs/agent-testing/connect-your-agent.md): Decorate the function that runs your agent to connect it to LangWatch, so your team can run test suites from the platform against your actual agent.
+- [Connect Your Agent](https://langwatch.ai/docs/agent-testing/connect-your-agent.md): Add a small connect function beside your service startup that calls the agent you already have, so your team can run test suites from the platform against the real agent.
 - [Targets](https://langwatch.ai/docs/agent-testing/targets.md): A target is the agent, prompt, code agent or workflow a run sends the conversation to, together with the parameters it runs with.
 - [Environments and Personal Agents](https://langwatch.ai/docs/agent-testing/environments.md): One agent name, one row per environment. Your machine, staging and production are separate targets that a single run compares.
 - [Linking Your Traces](https://langwatch.ai/docs/agent-testing/linking-your-traces.md): Judge scenario criteria against what your agent did, tool calls, writes and retrievals, read from its own traces rather than from its reply text.

--- a/docs/scripts/generate-skills-pages.mjs
+++ b/docs/scripts/generate-skills-pages.mjs
@@ -34,11 +34,9 @@ const manifest = JSON.parse(
 // `--list-pages` prints the repo-relative pages this script writes. The
 // pre-commit hook stages them and CI checks them for staleness, so both read
 // the list from here instead of keeping their own copy that the manifest can
-// grow past.
-if (process.argv.includes("--list-pages")) {
-  for (const pageFile of Object.keys(manifest)) console.log(`docs/${pageFile}`);
-  process.exit(0);
-}
+// grow past. It returns instead of calling process.exit, which can truncate a
+// piped stdout before it drains.
+const listPages = process.argv.includes("--list-pages");
 
 // Escape text that lands in JSX text position so MDX cannot reinterpret it
 // as markup, expressions, or markdown emphasis.
@@ -201,9 +199,20 @@ function renderAccordion(entry, open = false) {
   return lines.join("\n");
 }
 
+if (listPages) {
+  for (const pageFile of Object.keys(manifest)) console.log(`docs/${pageFile}`);
+}
+
 let failed = false;
-for (const [pageFile, sections] of Object.entries(manifest)) {
+for (const [pageFile, sections] of listPages ? [] : Object.entries(manifest)) {
   const pagePath = path.join(docsRoot, pageFile);
+  if (!fs.existsSync(pagePath)) {
+    // A manifest entry whose page is missing, which is what an uncommitted new
+    // page looks like to a fresh checkout. Name it rather than throwing ENOENT.
+    console.error(`ERROR: the manifest names docs/${pageFile}, which does not exist`);
+    failed = true;
+    continue;
+  }
   let content = fs.readFileSync(pagePath, "utf8");
   for (const [sectionId, entries] of Object.entries(sections)) {
     const start = `{/* lw-generated:${sectionId}:start */}`;

--- a/docs/scripts/generate-skills-pages.mjs
+++ b/docs/scripts/generate-skills-pages.mjs
@@ -31,6 +31,15 @@ const manifest = JSON.parse(
   fs.readFileSync(path.join(docsRoot, "skills", "skills-pages-manifest.json"), "utf8")
 );
 
+// `--list-pages` prints the repo-relative pages this script writes. The
+// pre-commit hook stages them and CI checks them for staleness, so both read
+// the list from here instead of keeping their own copy that the manifest can
+// grow past.
+if (process.argv.includes("--list-pages")) {
+  for (const pageFile of Object.keys(manifest)) console.log(`docs/${pageFile}`);
+  process.exit(0);
+}
+
 // Escape text that lands in JSX text position so MDX cannot reinterpret it
 // as markup, expressions, or markdown emphasis.
 const escapeText = (s) =>

--- a/docs/skills/directory.mdx
+++ b/docs/skills/directory.mdx
@@ -1962,7 +1962,7 @@ The process needs `LANGWATCH_API_KEY` in its environment. It is the same project
 
 ## Step 3: Add the connect function where the service starts
 
-Write a small function beside the code that starts the service. LangWatch calls it once per conversation turn, and it calls the agent the codebase already has. It is an adapter: build the input the agent expects, pass the run parameters into it, and return the reply text out of what the agent gives back.
+Write a small function beside the code that starts the service. It is the adapter between the messages that come from a scenario test and the agent in the codebase.
 
 Put it in the file that starts the service, or in a module that file imports at startup. The connection opens with the process, so the code has to run when the process runs.
 

--- a/docs/skills/directory.mdx
+++ b/docs/skills/directory.mdx
@@ -2088,7 +2088,9 @@ langwatch.agent.serve()   # Python, at the bottom of the script
 ```
 
 ```typescript
-// TypeScript: the connection holds the event loop open, so the script serves until Ctrl-C
+// TypeScript: keep the script alive yourself. The WebSocket holds the event loop
+// while connected, but the HTTP fallback and the reconnect wait do not.
+setInterval(() => {}, 1 << 30);
 // Run it with the project's TypeScript runner, for example `tsx agent.ts`
 ```
 

--- a/docs/skills/directory.mdx
+++ b/docs/skills/directory.mdx
@@ -1902,7 +1902,7 @@ Use the `langwatch` CLI for everything: documentation (`langwatch docs ...`, `la
 
 Connect the agent in this codebase to LangWatch, so test suites run from the platform against the real agent process. The SDK opens an outbound connection to LangWatch from the process that already runs the agent, registers the agent with its environment and its run parameters, and receives one call per conversation turn. The simulation exercises the real code, dependencies, secrets and traces.
 
-Three steps: install the SDK, decorate the function, start the process. Work through them in order, confirm the agent reads Online, run one test suite, then report what changed and the result.
+Three steps: install the SDK, add the connect function where the service starts, start the service the way the user always starts it. Work through them in order, confirm the agent reads Online, run one test suite, then report what changed and the result.
 
 Use the HTTP fallback at the bottom of this skill ONLY when the agent cannot import the SDK: the agent is written in a language with no LangWatch SDK, or you have no access to its code.
 
@@ -1951,7 +1951,7 @@ LangWatch.
 
 ## Step 2: Install the SDK
 
-Read the codebase first. Find the function that takes a conversation and returns the agent's reply, and the file it lives in. That function is what you decorate; do not write a second one beside it.
+Read the codebase first. Find two things: the entry point that runs the agent, which is what the connect function calls, and the file that starts the service, which is where the connect function goes.
 
 ```bash
 pip install langwatch          # Python
@@ -1960,46 +1960,66 @@ npm install langwatch zod      # TypeScript, Node only
 
 The process needs `LANGWATCH_API_KEY` in its environment. It is the same project key the CLI uses. Without a key the SDK logs one line and opens no connection.
 
-## Step 3: Decorate the function
+## Step 3: Add the connect function where the service starts
+
+Write a small function beside the code that starts the service. LangWatch calls it once per conversation turn, and it calls the agent the codebase already has. It is an adapter: build the input the agent expects, pass the run parameters into it, and return the reply text out of what the agent gives back.
+
+Put it in the file that starts the service, or in a module that file imports at startup. The connection opens with the process, so the code has to run when the process runs.
 
 **Python**
 
 ```python
+# main.py, beside the server startup
 import langwatch
 
+from my_app.agent import SupportAgent
+
 @langwatch.connect_agent(name="support-agent")
-async def support_agent(messages: list[dict], thread_id: str) -> str:
-    return await run_my_agent(messages)
+async def support_agent(
+    messages: list[dict],
+    thread_id: str,
+    *,
+    model: str = "gpt-5-mini",
+) -> str:
+    result = await SupportAgent(model=model).run(messages, conversation_id=thread_id)
+    return result.output_text
 ```
 
 **TypeScript**
 
 ```typescript
+// server.ts, beside the server startup
 import { z } from "zod";
 import { connectAgent } from "langwatch/agent";
 
-export const supportAgent = connectAgent(
+import { runSupportAgent } from "./agent";
+
+connectAgent(
   {
     name: "support-agent",
     parameters: z.object({
       model: z.enum(["gpt-5", "gpt-5-mini"]).default("gpt-5-mini"),
-      plan: z.string().default("free").describe("Customer plan"),
-      maxTools: z.number().int().default(5),
     }),
   },
-  async ({ messages, params }) => {
-    // params is typed: { model: "gpt-5" | "gpt-5-mini"; plan: string; maxTools: number }
-    return await runMyAgent(messages, { model: params.model });
+  async ({ messages, threadId, params }) => {
+    const result = await runSupportAgent({
+      messages,
+      conversationId: threadId,
+      model: params.model,
+    });
+    return result.text;
   },
 );
 ```
 
-Rules for the decorated function:
+Rules for the connect function:
 
 - `name` is required. Use the name the team calls the agent, in lower case with dashes.
+- Call the agent the product already runs. Do not reimplement it in the connect function, and do not call a simplified copy of it, or the suite tests code no customer reaches.
+- Change nothing about how the service starts. The connect function runs on the startup path, and the start command stays the same.
 - **Turn fields** are what the platform sends on every call: `messages` (the whole conversation, OpenAI-style), `new_messages` (`newMessages`, the delta since the last turn), `thread_id` (`threadId`), `session`, `trace_id` (`traceId`). In Python, declare only the ones you use and the SDK passes exactly those. In TypeScript, they arrive as one object, so destructure what you need.
 - Return a string, one message, a list of messages, or `langwatch.AgentReply(output, session=...)` (`{ output, session }` in TypeScript).
-- Do not remove or weaken the function's own behavior. The decorator wraps it; the direct callers keep working.
+- Do not change the agent's own code to fit the connect function. Map the turn onto the agent's existing call in the connect function instead.
 - Do NOT add a `traceparent` middleware. The SDK adopts the turn's trace context before it calls the function, so the agent's spans land in the turn's trace and the judge reads them.
 
 ### Run parameters
@@ -2020,7 +2040,7 @@ async def support_agent(
     ...
 ```
 
-TypeScript declares them with a zod schema in `parameters`, the way Step 3 shows. The schema types `params` in the handler, and the SDK validates the values a run supplies against it. Add `zod` to the project (`npm install zod`) if it is not there yet. Read the schema this way:
+TypeScript declares them with a zod schema in `parameters`, the way Step 3 shows. Read the values out of `params` in the connect function and pass them into the agent's own call. The schema types `params` in the handler, and the SDK validates the values a run supplies against it. Add `zod` to the project (`npm install zod`) if it is not there yet. Read the schema this way:
 
 - `z.enum([...])` becomes a closed option list in the run dialog. A value outside the list is refused.
 - `.default(value)` sets the default.
@@ -2057,16 +2077,18 @@ The SDK reads the environment from the `environment` argument, then `LANGWATCH_A
 
 Leave `environment` out when the service already sets `LANGWATCH_AGENT_ENVIRONMENT`, `APP_ENV`, `ENVIRONMENT` or `NODE_ENV`. The SDK reads them on its own.
 
-## Step 4: Start the process and confirm the agent is Online
+## Step 4: Start the service and confirm the agent is Online
 
-Start the service the way the user starts it. A web server keeps the connection alive by itself. For a script whose only job is the agent, block it:
+Start the service the way the user starts it. Do not add a start command, and do not write a separate runner script: the connect function is already on the startup path, and a web server holds the connection open by itself.
+
+The exception is an agent that is a library with no process of its own. Put the connect function in a small script and keep the script alive:
 
 ```python
 langwatch.agent.serve()   # Python, at the bottom of the script
 ```
 
 ```typescript
-// TypeScript: the socket keeps the event loop alive, `node agent.ts` serves until Ctrl-C
+// TypeScript: the connection holds the event loop open, `node agent.ts` serves until Ctrl-C
 ```
 
 Then confirm from the CLI, in another terminal:
@@ -2227,13 +2249,14 @@ Run it with `--target http:<agent-id>`, and follow Step 5 and Step 6 otherwise u
 | The run is refused with `agent_offline` | No instance was connected when the run started. | Start the agent process and run again. |
 | The run is refused with `agent_owner_only` | The agent registered under `development` with a personal key, so only its owner can run it. | Run it as the owner, or register it under a shared environment name such as `dev-shared`. |
 | The run is refused with `scenario_parameter_option_invalid` | A value is outside the closed option list the agent declares. | Use one of the listed options, or widen the `Literal` (Python) or `z.enum` (TypeScript) list in the code. |
-| A turn fails with `agent_call_timeout` | The function took longer than the agent's timeout. | Raise `timeout` on the decorator (up to 300 seconds), or make the agent answer faster. |
+| A turn fails with `agent_call_timeout` | The call took longer than the agent's timeout. | Raise `timeout` on the connect function (up to 300 seconds), or make the agent answer faster. |
 | Trace-dependent criteria come back inconclusive | The agent reports its traces to a different LangWatch project, or it reports none at all. | Point the agent's tracing at the same project's API key. Set it up with the `tracing` skill. |
 
 ## Common Mistakes
 
-- Do NOT write a second wrapper function for LangWatch to call. Decorate the function the product already runs, so the simulation exercises the real code path.
-- Do NOT add a `traceparent` middleware for a decorated agent. The SDK adopts the trace context itself; the middleware belongs to the HTTP fallback only.
+- Do NOT reimplement the agent inside the connect function, and do NOT point it at a simplified copy. It calls the agent the product already runs, so the simulation exercises the real code path.
+- Do NOT add a runner script or a second start command when the service already has one. The connect function goes on the existing startup path.
+- Do NOT add a `traceparent` middleware for a connected agent. The SDK adopts the trace context itself; the middleware belongs to the HTTP fallback only.
 - Do NOT hardcode an environment string, and do NOT write a fallback such as `process.env.APP_ENV ?? "development"`. It overrides `LANGWATCH_AGENT_ENVIRONMENT` and registers a production process under `development`. Let the SDK resolve the environment.
 - Do NOT declare a run parameter for a value the tests never vary. Every declared parameter appears in the run dialog.
 - Do NOT use a turn field name (`messages`, `new_messages`, `thread_id`, `session`, `trace_id`) as a run parameter name.

--- a/docs/skills/directory.mdx
+++ b/docs/skills/directory.mdx
@@ -2088,7 +2088,8 @@ langwatch.agent.serve()   # Python, at the bottom of the script
 ```
 
 ```typescript
-// TypeScript: the connection holds the event loop open, `node agent.ts` serves until Ctrl-C
+// TypeScript: the connection holds the event loop open, so the script serves until Ctrl-C
+// Run it with the project's TypeScript runner, for example `tsx agent.ts`
 ```
 
 Then confirm from the CLI, in another terminal:

--- a/sdks/python/src/langwatch/agent/decorator.py
+++ b/sdks/python/src/langwatch/agent/decorator.py
@@ -278,10 +278,11 @@ def connect_agent(
             `ENVIRONMENT` and `NODE_ENV`; defaults to `development`.
         parameters: Replaces the run parameters read from the signature.
         enabled: Whether this process connects. Takes any boolean, so one
-            expression can gate the deployments that connect, for example
-            `os.environ.get("APP_ENV") != "production"`. Defaults to true,
-            except when `CI` is truthy; `LANGWATCH_AGENT_CONNECT=0` always
-            disables.
+            expression can gate the deployments that connect. Without it the
+            default is true, except when `CI` is truthy; a value given here
+            replaces that rule rather than adding to it, so keep the `CI` half:
+            `os.environ.get("APP_ENV") != "production" and not os.environ.get("CI")`.
+            `LANGWATCH_AGENT_CONNECT=0` always disables.
         instance_label: Names this process; also `LANGWATCH_AGENT_INSTANCE_LABEL`.
         timeout: Seconds one call may take, default 120, at most 300.
         concurrency: Calls in flight per process, default 1 in development and 4 elsewhere.

--- a/sdks/python/src/langwatch/agent/decorator.py
+++ b/sdks/python/src/langwatch/agent/decorator.py
@@ -277,8 +277,11 @@ def connect_agent(
         environment: Overrides `LANGWATCH_AGENT_ENVIRONMENT`, `APP_ENV`,
             `ENVIRONMENT` and `NODE_ENV`; defaults to `development`.
         parameters: Replaces the run parameters read from the signature.
-        enabled: Defaults to true, except when `CI` is truthy;
-            `LANGWATCH_AGENT_CONNECT=0` always disables.
+        enabled: Whether this process connects. Takes any boolean, so one
+            expression can gate the deployments that connect, for example
+            `os.environ.get("APP_ENV") != "production"`. Defaults to true,
+            except when `CI` is truthy; `LANGWATCH_AGENT_CONNECT=0` always
+            disables.
         instance_label: Names this process; also `LANGWATCH_AGENT_INSTANCE_LABEL`.
         timeout: Seconds one call may take, default 120, at most 300.
         concurrency: Calls in flight per process, default 1 in development and 4 elsewhere.

--- a/sdks/typescript/src/agent/define.ts
+++ b/sdks/typescript/src/agent/define.ts
@@ -83,8 +83,10 @@ export interface ConnectAgentOptions<P extends ParameterInput = ParameterDefinit
   parameters?: P;
   /**
    * Whether this process connects. Takes any boolean, so one expression can
-   * gate the deployments that connect: `process.env.APP_ENV !== "production"`.
-   * Default true, except when CI is truthy. LANGWATCH_AGENT_CONNECT=0 always disables.
+   * gate the deployments that connect. Without it the default is true, except
+   * when CI is truthy; a value given here replaces that rule rather than adding
+   * to it, so keep the CI half: `process.env.APP_ENV !== "production" && !process.env.CI`.
+   * LANGWATCH_AGENT_CONNECT=0 always disables.
    */
   enabled?: boolean;
   /** Names this instance in the platform. Also LANGWATCH_AGENT_INSTANCE_LABEL. */

--- a/sdks/typescript/src/agent/define.ts
+++ b/sdks/typescript/src/agent/define.ts
@@ -81,7 +81,11 @@ export interface ConnectAgentOptions<P extends ParameterInput = ParameterDefinit
   environment?: string;
   /** A definition map, a Standard JSON Schema object, or a JSON Schema object. */
   parameters?: P;
-  /** Default true, except when CI is truthy. LANGWATCH_AGENT_CONNECT=0 always disables. */
+  /**
+   * Whether this process connects. Takes any boolean, so one expression can
+   * gate the deployments that connect: `process.env.APP_ENV !== "production"`.
+   * Default true, except when CI is truthy. LANGWATCH_AGENT_CONNECT=0 always disables.
+   */
   enabled?: boolean;
   /** Names this instance in the platform. Also LANGWATCH_AGENT_INSTANCE_LABEL. */
   instanceLabel?: string;

--- a/services/langyagent/internal/assets/skills/connect-agent/SKILL.md
+++ b/services/langyagent/internal/assets/skills/connect-agent/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: connect-agent
 user-prompt: "Connect my agent to LangWatch simulations"
-description: Connect the codebase's AI agent to LangWatch agent simulations, so test suites run against the real agent process. Decorates the function that runs the agent with the LangWatch SDK, which opens an outbound connection and registers the agent with its environment and its run parameters, confirms the agent is Online, and runs the first test suite. Falls back to an HTTP registration when the agent cannot import the SDK. Use when the user wants platform scenarios to test their real agent.
+description: Connect the codebase's AI agent to LangWatch agent simulations, so test suites run against the real agent process. Adds a small connect function beside the service startup that calls the agent already in the codebase, which opens an outbound connection and registers the agent with its environment and its run parameters, confirms the agent is Online, and runs the first test suite. Falls back to an HTTP registration when the agent cannot import the SDK. Use when the user wants platform scenarios to test their real agent.
 license: MIT
 compatibility: Works with Claude Code and similar coding agents. The `langwatch` CLI is the only interface for platform operations.
 ---
@@ -10,7 +10,7 @@ compatibility: Works with Claude Code and similar coding agents. The `langwatch`
 
 Connect the agent in this codebase to LangWatch, so test suites run from the platform against the real agent process. The SDK opens an outbound connection to LangWatch from the process that already runs the agent, registers the agent with its environment and its run parameters, and receives one call per conversation turn. The simulation exercises the real code, dependencies, secrets and traces.
 
-Three steps: install the SDK, decorate the function, start the process. Work through them in order, confirm the agent reads Online, run one test suite, then report what changed and the result.
+Three steps: install the SDK, add the connect function where the service starts, start the service the way the user always starts it. Work through them in order, confirm the agent reads Online, run one test suite, then report what changed and the result.
 
 Use the HTTP fallback at the bottom of this skill ONLY when the agent cannot import the SDK: the agent is written in a language with no LangWatch SDK, or you have no access to its code.
 
@@ -18,7 +18,7 @@ Use the HTTP fallback at the bottom of this skill ONLY when the agent cannot imp
 
 ## Step 2: Install the SDK
 
-Read the codebase first. Find the function that takes a conversation and returns the agent's reply, and the file it lives in. That function is what you decorate; do not write a second one beside it.
+Read the codebase first. Find two things: the entry point that runs the agent, which is what the connect function calls, and the file that starts the service, which is where the connect function goes.
 
 ```bash
 pip install langwatch          # Python
@@ -27,46 +27,66 @@ npm install langwatch zod      # TypeScript, Node only
 
 The process needs `LANGWATCH_API_KEY` in its environment. It is the same project key the CLI uses. Without a key the SDK logs one line and opens no connection.
 
-## Step 3: Decorate the function
+## Step 3: Add the connect function where the service starts
+
+Write a small function beside the code that starts the service. LangWatch calls it once per conversation turn, and it calls the agent the codebase already has. It is an adapter: build the input the agent expects, pass the run parameters into it, and return the reply text out of what the agent gives back.
+
+Put it in the file that starts the service, or in a module that file imports at startup. The connection opens with the process, so the code has to run when the process runs.
 
 **Python**
 
 ```python
+# main.py, beside the server startup
 import langwatch
 
+from my_app.agent import SupportAgent
+
 @langwatch.connect_agent(name="support-agent")
-async def support_agent(messages: list[dict], thread_id: str) -> str:
-    return await run_my_agent(messages)
+async def support_agent(
+    messages: list[dict],
+    thread_id: str,
+    *,
+    model: str = "gpt-5-mini",
+) -> str:
+    result = await SupportAgent(model=model).run(messages, conversation_id=thread_id)
+    return result.output_text
 ```
 
 **TypeScript**
 
 ```typescript
+// server.ts, beside the server startup
 import { z } from "zod";
 import { connectAgent } from "langwatch/agent";
 
-export const supportAgent = connectAgent(
+import { runSupportAgent } from "./agent";
+
+connectAgent(
   {
     name: "support-agent",
     parameters: z.object({
       model: z.enum(["gpt-5", "gpt-5-mini"]).default("gpt-5-mini"),
-      plan: z.string().default("free").describe("Customer plan"),
-      maxTools: z.number().int().default(5),
     }),
   },
-  async ({ messages, params }) => {
-    // params is typed: { model: "gpt-5" | "gpt-5-mini"; plan: string; maxTools: number }
-    return await runMyAgent(messages, { model: params.model });
+  async ({ messages, threadId, params }) => {
+    const result = await runSupportAgent({
+      messages,
+      conversationId: threadId,
+      model: params.model,
+    });
+    return result.text;
   },
 );
 ```
 
-Rules for the decorated function:
+Rules for the connect function:
 
 - `name` is required. Use the name the team calls the agent, in lower case with dashes.
+- Call the agent the product already runs. Do not reimplement it in the connect function, and do not call a simplified copy of it, or the suite tests code no customer reaches.
+- Change nothing about how the service starts. The connect function runs on the startup path, and the start command stays the same.
 - **Turn fields** are what the platform sends on every call: `messages` (the whole conversation, OpenAI-style), `new_messages` (`newMessages`, the delta since the last turn), `thread_id` (`threadId`), `session`, `trace_id` (`traceId`). In Python, declare only the ones you use and the SDK passes exactly those. In TypeScript, they arrive as one object, so destructure what you need.
 - Return a string, one message, a list of messages, or `langwatch.AgentReply(output, session=...)` (`{ output, session }` in TypeScript).
-- Do not remove or weaken the function's own behavior. The decorator wraps it; the direct callers keep working.
+- Do not change the agent's own code to fit the connect function. Map the turn onto the agent's existing call in the connect function instead.
 - Do NOT add a `traceparent` middleware. The SDK adopts the turn's trace context before it calls the function, so the agent's spans land in the turn's trace and the judge reads them.
 
 ### Run parameters
@@ -87,7 +107,7 @@ async def support_agent(
     ...
 ```
 
-TypeScript declares them with a zod schema in `parameters`, the way Step 3 shows. The schema types `params` in the handler, and the SDK validates the values a run supplies against it. Add `zod` to the project (`npm install zod`) if it is not there yet. Read the schema this way:
+TypeScript declares them with a zod schema in `parameters`, the way Step 3 shows. Read the values out of `params` in the connect function and pass them into the agent's own call. The schema types `params` in the handler, and the SDK validates the values a run supplies against it. Add `zod` to the project (`npm install zod`) if it is not there yet. Read the schema this way:
 
 - `z.enum([...])` becomes a closed option list in the run dialog. A value outside the list is refused.
 - `.default(value)` sets the default.
@@ -124,16 +144,18 @@ The SDK reads the environment from the `environment` argument, then `LANGWATCH_A
 
 Leave `environment` out when the service already sets `LANGWATCH_AGENT_ENVIRONMENT`, `APP_ENV`, `ENVIRONMENT` or `NODE_ENV`. The SDK reads them on its own.
 
-## Step 4: Start the process and confirm the agent is Online
+## Step 4: Start the service and confirm the agent is Online
 
-Start the service the way the user starts it. A web server keeps the connection alive by itself. For a script whose only job is the agent, block it:
+Start the service the way the user starts it. Do not add a start command, and do not write a separate runner script: the connect function is already on the startup path, and a web server holds the connection open by itself.
+
+The exception is an agent that is a library with no process of its own. Put the connect function in a small script and keep the script alive:
 
 ```python
 langwatch.agent.serve()   # Python, at the bottom of the script
 ```
 
 ```typescript
-// TypeScript: the socket keeps the event loop alive, `node agent.ts` serves until Ctrl-C
+// TypeScript: the connection holds the event loop open, `node agent.ts` serves until Ctrl-C
 ```
 
 Then confirm from the CLI, in another terminal:
@@ -294,13 +316,14 @@ Run it with `--target http:<agent-id>`, and follow Step 5 and Step 6 otherwise u
 | The run is refused with `agent_offline` | No instance was connected when the run started. | Start the agent process and run again. |
 | The run is refused with `agent_owner_only` | The agent registered under `development` with a personal key, so only its owner can run it. | Run it as the owner, or register it under a shared environment name such as `dev-shared`. |
 | The run is refused with `scenario_parameter_option_invalid` | A value is outside the closed option list the agent declares. | Use one of the listed options, or widen the `Literal` (Python) or `z.enum` (TypeScript) list in the code. |
-| A turn fails with `agent_call_timeout` | The function took longer than the agent's timeout. | Raise `timeout` on the decorator (up to 300 seconds), or make the agent answer faster. |
+| A turn fails with `agent_call_timeout` | The call took longer than the agent's timeout. | Raise `timeout` on the connect function (up to 300 seconds), or make the agent answer faster. |
 | Trace-dependent criteria come back inconclusive | The agent reports its traces to a different LangWatch project, or it reports none at all. | Point the agent's tracing at the same project's API key. Set it up with the `tracing` skill. |
 
 ## Common Mistakes
 
-- Do NOT write a second wrapper function for LangWatch to call. Decorate the function the product already runs, so the simulation exercises the real code path.
-- Do NOT add a `traceparent` middleware for a decorated agent. The SDK adopts the trace context itself; the middleware belongs to the HTTP fallback only.
+- Do NOT reimplement the agent inside the connect function, and do NOT point it at a simplified copy. It calls the agent the product already runs, so the simulation exercises the real code path.
+- Do NOT add a runner script or a second start command when the service already has one. The connect function goes on the existing startup path.
+- Do NOT add a `traceparent` middleware for a connected agent. The SDK adopts the trace context itself; the middleware belongs to the HTTP fallback only.
 - Do NOT hardcode an environment string, and do NOT write a fallback such as `process.env.APP_ENV ?? "development"`. It overrides `LANGWATCH_AGENT_ENVIRONMENT` and registers a production process under `development`. Let the SDK resolve the environment.
 - Do NOT declare a run parameter for a value the tests never vary. Every declared parameter appears in the run dialog.
 - Do NOT use a turn field name (`messages`, `new_messages`, `thread_id`, `session`, `trace_id`) as a run parameter name.

--- a/services/langyagent/internal/assets/skills/connect-agent/SKILL.md
+++ b/services/langyagent/internal/assets/skills/connect-agent/SKILL.md
@@ -29,7 +29,7 @@ The process needs `LANGWATCH_API_KEY` in its environment. It is the same project
 
 ## Step 3: Add the connect function where the service starts
 
-Write a small function beside the code that starts the service. LangWatch calls it once per conversation turn, and it calls the agent the codebase already has. It is an adapter: build the input the agent expects, pass the run parameters into it, and return the reply text out of what the agent gives back.
+Write a small function beside the code that starts the service. It is the adapter between the messages that come from a scenario test and the agent in the codebase.
 
 Put it in the file that starts the service, or in a module that file imports at startup. The connection opens with the process, so the code has to run when the process runs.
 

--- a/services/langyagent/internal/assets/skills/connect-agent/SKILL.md
+++ b/services/langyagent/internal/assets/skills/connect-agent/SKILL.md
@@ -155,7 +155,9 @@ langwatch.agent.serve()   # Python, at the bottom of the script
 ```
 
 ```typescript
-// TypeScript: the connection holds the event loop open, so the script serves until Ctrl-C
+// TypeScript: keep the script alive yourself. The WebSocket holds the event loop
+// while connected, but the HTTP fallback and the reconnect wait do not.
+setInterval(() => {}, 1 << 30);
 // Run it with the project's TypeScript runner, for example `tsx agent.ts`
 ```
 

--- a/services/langyagent/internal/assets/skills/connect-agent/SKILL.md
+++ b/services/langyagent/internal/assets/skills/connect-agent/SKILL.md
@@ -155,7 +155,8 @@ langwatch.agent.serve()   # Python, at the bottom of the script
 ```
 
 ```typescript
-// TypeScript: the connection holds the event loop open, `node agent.ts` serves until Ctrl-C
+// TypeScript: the connection holds the event loop open, so the script serves until Ctrl-C
+// Run it with the project's TypeScript runner, for example `tsx agent.ts`
 ```
 
 Then confirm from the CLI, in another terminal:

--- a/skills/_compiled/native/connect-agent/SKILL.md
+++ b/skills/_compiled/native/connect-agent/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: connect-agent
 user-prompt: "Connect my agent to LangWatch simulations"
-description: Connect the codebase's AI agent to LangWatch agent simulations, so test suites run against the real agent process. Decorates the function that runs the agent with the LangWatch SDK, which opens an outbound connection and registers the agent with its environment and its run parameters, confirms the agent is Online, and runs the first test suite. Falls back to an HTTP registration when the agent cannot import the SDK. Use when the user wants platform scenarios to test their real agent.
+description: Connect the codebase's AI agent to LangWatch agent simulations, so test suites run against the real agent process. Adds a small connect function beside the service startup that calls the agent already in the codebase, which opens an outbound connection and registers the agent with its environment and its run parameters, confirms the agent is Online, and runs the first test suite. Falls back to an HTTP registration when the agent cannot import the SDK. Use when the user wants platform scenarios to test their real agent.
 license: MIT
 compatibility: Works with Claude Code and similar coding agents. The `langwatch` CLI is the only interface for platform operations.
 ---
@@ -10,7 +10,7 @@ compatibility: Works with Claude Code and similar coding agents. The `langwatch`
 
 Connect the agent in this codebase to LangWatch, so test suites run from the platform against the real agent process. The SDK opens an outbound connection to LangWatch from the process that already runs the agent, registers the agent with its environment and its run parameters, and receives one call per conversation turn. The simulation exercises the real code, dependencies, secrets and traces.
 
-Three steps: install the SDK, decorate the function, start the process. Work through them in order, confirm the agent reads Online, run one test suite, then report what changed and the result.
+Three steps: install the SDK, add the connect function where the service starts, start the service the way the user always starts it. Work through them in order, confirm the agent reads Online, run one test suite, then report what changed and the result.
 
 Use the HTTP fallback at the bottom of this skill ONLY when the agent cannot import the SDK: the agent is written in a language with no LangWatch SDK, or you have no access to its code.
 
@@ -18,7 +18,7 @@ Use the HTTP fallback at the bottom of this skill ONLY when the agent cannot imp
 
 ## Step 2: Install the SDK
 
-Read the codebase first. Find the function that takes a conversation and returns the agent's reply, and the file it lives in. That function is what you decorate; do not write a second one beside it.
+Read the codebase first. Find two things: the entry point that runs the agent, which is what the connect function calls, and the file that starts the service, which is where the connect function goes.
 
 ```bash
 pip install langwatch          # Python
@@ -27,46 +27,66 @@ npm install langwatch zod      # TypeScript, Node only
 
 The process needs `LANGWATCH_API_KEY` in its environment. It is the same project key the CLI uses. Without a key the SDK logs one line and opens no connection.
 
-## Step 3: Decorate the function
+## Step 3: Add the connect function where the service starts
+
+Write a small function beside the code that starts the service. LangWatch calls it once per conversation turn, and it calls the agent the codebase already has. It is an adapter: build the input the agent expects, pass the run parameters into it, and return the reply text out of what the agent gives back.
+
+Put it in the file that starts the service, or in a module that file imports at startup. The connection opens with the process, so the code has to run when the process runs.
 
 **Python**
 
 ```python
+# main.py, beside the server startup
 import langwatch
 
+from my_app.agent import SupportAgent
+
 @langwatch.connect_agent(name="support-agent")
-async def support_agent(messages: list[dict], thread_id: str) -> str:
-    return await run_my_agent(messages)
+async def support_agent(
+    messages: list[dict],
+    thread_id: str,
+    *,
+    model: str = "gpt-5-mini",
+) -> str:
+    result = await SupportAgent(model=model).run(messages, conversation_id=thread_id)
+    return result.output_text
 ```
 
 **TypeScript**
 
 ```typescript
+// server.ts, beside the server startup
 import { z } from "zod";
 import { connectAgent } from "langwatch/agent";
 
-export const supportAgent = connectAgent(
+import { runSupportAgent } from "./agent";
+
+connectAgent(
   {
     name: "support-agent",
     parameters: z.object({
       model: z.enum(["gpt-5", "gpt-5-mini"]).default("gpt-5-mini"),
-      plan: z.string().default("free").describe("Customer plan"),
-      maxTools: z.number().int().default(5),
     }),
   },
-  async ({ messages, params }) => {
-    // params is typed: { model: "gpt-5" | "gpt-5-mini"; plan: string; maxTools: number }
-    return await runMyAgent(messages, { model: params.model });
+  async ({ messages, threadId, params }) => {
+    const result = await runSupportAgent({
+      messages,
+      conversationId: threadId,
+      model: params.model,
+    });
+    return result.text;
   },
 );
 ```
 
-Rules for the decorated function:
+Rules for the connect function:
 
 - `name` is required. Use the name the team calls the agent, in lower case with dashes.
+- Call the agent the product already runs. Do not reimplement it in the connect function, and do not call a simplified copy of it, or the suite tests code no customer reaches.
+- Change nothing about how the service starts. The connect function runs on the startup path, and the start command stays the same.
 - **Turn fields** are what the platform sends on every call: `messages` (the whole conversation, OpenAI-style), `new_messages` (`newMessages`, the delta since the last turn), `thread_id` (`threadId`), `session`, `trace_id` (`traceId`). In Python, declare only the ones you use and the SDK passes exactly those. In TypeScript, they arrive as one object, so destructure what you need.
 - Return a string, one message, a list of messages, or `langwatch.AgentReply(output, session=...)` (`{ output, session }` in TypeScript).
-- Do not remove or weaken the function's own behavior. The decorator wraps it; the direct callers keep working.
+- Do not change the agent's own code to fit the connect function. Map the turn onto the agent's existing call in the connect function instead.
 - Do NOT add a `traceparent` middleware. The SDK adopts the turn's trace context before it calls the function, so the agent's spans land in the turn's trace and the judge reads them.
 
 ### Run parameters
@@ -87,7 +107,7 @@ async def support_agent(
     ...
 ```
 
-TypeScript declares them with a zod schema in `parameters`, the way Step 3 shows. The schema types `params` in the handler, and the SDK validates the values a run supplies against it. Add `zod` to the project (`npm install zod`) if it is not there yet. Read the schema this way:
+TypeScript declares them with a zod schema in `parameters`, the way Step 3 shows. Read the values out of `params` in the connect function and pass them into the agent's own call. The schema types `params` in the handler, and the SDK validates the values a run supplies against it. Add `zod` to the project (`npm install zod`) if it is not there yet. Read the schema this way:
 
 - `z.enum([...])` becomes a closed option list in the run dialog. A value outside the list is refused.
 - `.default(value)` sets the default.
@@ -124,16 +144,18 @@ The SDK reads the environment from the `environment` argument, then `LANGWATCH_A
 
 Leave `environment` out when the service already sets `LANGWATCH_AGENT_ENVIRONMENT`, `APP_ENV`, `ENVIRONMENT` or `NODE_ENV`. The SDK reads them on its own.
 
-## Step 4: Start the process and confirm the agent is Online
+## Step 4: Start the service and confirm the agent is Online
 
-Start the service the way the user starts it. A web server keeps the connection alive by itself. For a script whose only job is the agent, block it:
+Start the service the way the user starts it. Do not add a start command, and do not write a separate runner script: the connect function is already on the startup path, and a web server holds the connection open by itself.
+
+The exception is an agent that is a library with no process of its own. Put the connect function in a small script and keep the script alive:
 
 ```python
 langwatch.agent.serve()   # Python, at the bottom of the script
 ```
 
 ```typescript
-// TypeScript: the socket keeps the event loop alive, `node agent.ts` serves until Ctrl-C
+// TypeScript: the connection holds the event loop open, `node agent.ts` serves until Ctrl-C
 ```
 
 Then confirm from the CLI, in another terminal:
@@ -294,13 +316,14 @@ Run it with `--target http:<agent-id>`, and follow Step 5 and Step 6 otherwise u
 | The run is refused with `agent_offline` | No instance was connected when the run started. | Start the agent process and run again. |
 | The run is refused with `agent_owner_only` | The agent registered under `development` with a personal key, so only its owner can run it. | Run it as the owner, or register it under a shared environment name such as `dev-shared`. |
 | The run is refused with `scenario_parameter_option_invalid` | A value is outside the closed option list the agent declares. | Use one of the listed options, or widen the `Literal` (Python) or `z.enum` (TypeScript) list in the code. |
-| A turn fails with `agent_call_timeout` | The function took longer than the agent's timeout. | Raise `timeout` on the decorator (up to 300 seconds), or make the agent answer faster. |
+| A turn fails with `agent_call_timeout` | The call took longer than the agent's timeout. | Raise `timeout` on the connect function (up to 300 seconds), or make the agent answer faster. |
 | Trace-dependent criteria come back inconclusive | The agent reports its traces to a different LangWatch project, or it reports none at all. | Point the agent's tracing at the same project's API key. Set it up with the `tracing` skill. |
 
 ## Common Mistakes
 
-- Do NOT write a second wrapper function for LangWatch to call. Decorate the function the product already runs, so the simulation exercises the real code path.
-- Do NOT add a `traceparent` middleware for a decorated agent. The SDK adopts the trace context itself; the middleware belongs to the HTTP fallback only.
+- Do NOT reimplement the agent inside the connect function, and do NOT point it at a simplified copy. It calls the agent the product already runs, so the simulation exercises the real code path.
+- Do NOT add a runner script or a second start command when the service already has one. The connect function goes on the existing startup path.
+- Do NOT add a `traceparent` middleware for a connected agent. The SDK adopts the trace context itself; the middleware belongs to the HTTP fallback only.
 - Do NOT hardcode an environment string, and do NOT write a fallback such as `process.env.APP_ENV ?? "development"`. It overrides `LANGWATCH_AGENT_ENVIRONMENT` and registers a production process under `development`. Let the SDK resolve the environment.
 - Do NOT declare a run parameter for a value the tests never vary. Every declared parameter appears in the run dialog.
 - Do NOT use a turn field name (`messages`, `new_messages`, `thread_id`, `session`, `trace_id`) as a run parameter name.

--- a/skills/_compiled/native/connect-agent/SKILL.md
+++ b/skills/_compiled/native/connect-agent/SKILL.md
@@ -29,7 +29,7 @@ The process needs `LANGWATCH_API_KEY` in its environment. It is the same project
 
 ## Step 3: Add the connect function where the service starts
 
-Write a small function beside the code that starts the service. LangWatch calls it once per conversation turn, and it calls the agent the codebase already has. It is an adapter: build the input the agent expects, pass the run parameters into it, and return the reply text out of what the agent gives back.
+Write a small function beside the code that starts the service. It is the adapter between the messages that come from a scenario test and the agent in the codebase.
 
 Put it in the file that starts the service, or in a module that file imports at startup. The connection opens with the process, so the code has to run when the process runs.
 

--- a/skills/_compiled/native/connect-agent/SKILL.md
+++ b/skills/_compiled/native/connect-agent/SKILL.md
@@ -155,7 +155,9 @@ langwatch.agent.serve()   # Python, at the bottom of the script
 ```
 
 ```typescript
-// TypeScript: the connection holds the event loop open, so the script serves until Ctrl-C
+// TypeScript: keep the script alive yourself. The WebSocket holds the event loop
+// while connected, but the HTTP fallback and the reconnect wait do not.
+setInterval(() => {}, 1 << 30);
 // Run it with the project's TypeScript runner, for example `tsx agent.ts`
 ```
 

--- a/skills/_compiled/native/connect-agent/SKILL.md
+++ b/skills/_compiled/native/connect-agent/SKILL.md
@@ -155,7 +155,8 @@ langwatch.agent.serve()   # Python, at the bottom of the script
 ```
 
 ```typescript
-// TypeScript: the connection holds the event loop open, `node agent.ts` serves until Ctrl-C
+// TypeScript: the connection holds the event loop open, so the script serves until Ctrl-C
+// Run it with the project's TypeScript runner, for example `tsx agent.ts`
 ```
 
 Then confirm from the CLI, in another terminal:

--- a/skills/connect-agent/SKILL.mdx
+++ b/skills/connect-agent/SKILL.mdx
@@ -1,7 +1,7 @@
 ---
 name: connect-agent
 user-prompt: "Connect my agent to LangWatch simulations"
-description: Connect the codebase's AI agent to LangWatch agent simulations, so test suites run against the real agent process. Decorates the function that runs the agent with the LangWatch SDK, which opens an outbound connection and registers the agent with its environment and its run parameters, confirms the agent is Online, and runs the first test suite. Falls back to an HTTP registration when the agent cannot import the SDK. Use when the user wants platform scenarios to test their real agent.
+description: Connect the codebase's AI agent to LangWatch agent simulations, so test suites run against the real agent process. Adds a small connect function beside the service startup that calls the agent already in the codebase, which opens an outbound connection and registers the agent with its environment and its run parameters, confirms the agent is Online, and runs the first test suite. Falls back to an HTTP registration when the agent cannot import the SDK. Use when the user wants platform scenarios to test their real agent.
 license: MIT
 compatibility: Works with Claude Code and similar coding agents. The `langwatch` CLI is the only interface for platform operations.
 ---
@@ -14,7 +14,7 @@ import PlanLimits from "../_shared/plan-limits.mdx";
 
 Connect the agent in this codebase to LangWatch, so test suites run from the platform against the real agent process. The SDK opens an outbound connection to LangWatch from the process that already runs the agent, registers the agent with its environment and its run parameters, and receives one call per conversation turn. The simulation exercises the real code, dependencies, secrets and traces.
 
-Three steps: install the SDK, decorate the function, start the process. Work through them in order, confirm the agent reads Online, run one test suite, then report what changed and the result.
+Three steps: install the SDK, add the connect function where the service starts, start the service the way the user always starts it. Work through them in order, confirm the agent reads Online, run one test suite, then report what changed and the result.
 
 Use the HTTP fallback at the bottom of this skill ONLY when the agent cannot import the SDK: the agent is written in a language with no LangWatch SDK, or you have no access to its code.
 
@@ -26,7 +26,7 @@ Use the HTTP fallback at the bottom of this skill ONLY when the agent cannot imp
 
 ## Step 2: Install the SDK
 
-Read the codebase first. Find the function that takes a conversation and returns the agent's reply, and the file it lives in. That function is what you decorate; do not write a second one beside it.
+Read the codebase first. Find two things: the entry point that runs the agent, which is what the connect function calls, and the file that starts the service, which is where the connect function goes.
 
 ```bash
 pip install langwatch          # Python
@@ -35,46 +35,66 @@ npm install langwatch zod      # TypeScript, Node only
 
 The process needs `LANGWATCH_API_KEY` in its environment. It is the same project key the CLI uses. Without a key the SDK logs one line and opens no connection.
 
-## Step 3: Decorate the function
+## Step 3: Add the connect function where the service starts
+
+Write a small function beside the code that starts the service. LangWatch calls it once per conversation turn, and it calls the agent the codebase already has. It is an adapter: build the input the agent expects, pass the run parameters into it, and return the reply text out of what the agent gives back.
+
+Put it in the file that starts the service, or in a module that file imports at startup. The connection opens with the process, so the code has to run when the process runs.
 
 **Python**
 
 ```python
+# main.py, beside the server startup
 import langwatch
 
+from my_app.agent import SupportAgent
+
 @langwatch.connect_agent(name="support-agent")
-async def support_agent(messages: list[dict], thread_id: str) -> str:
-    return await run_my_agent(messages)
+async def support_agent(
+    messages: list[dict],
+    thread_id: str,
+    *,
+    model: str = "gpt-5-mini",
+) -> str:
+    result = await SupportAgent(model=model).run(messages, conversation_id=thread_id)
+    return result.output_text
 ```
 
 **TypeScript**
 
 ```typescript
+// server.ts, beside the server startup
 import { z } from "zod";
 import { connectAgent } from "langwatch/agent";
 
-export const supportAgent = connectAgent(
+import { runSupportAgent } from "./agent";
+
+connectAgent(
   {
     name: "support-agent",
     parameters: z.object({
       model: z.enum(["gpt-5", "gpt-5-mini"]).default("gpt-5-mini"),
-      plan: z.string().default("free").describe("Customer plan"),
-      maxTools: z.number().int().default(5),
     }),
   },
-  async ({ messages, params }) => {
-    // params is typed: { model: "gpt-5" | "gpt-5-mini"; plan: string; maxTools: number }
-    return await runMyAgent(messages, { model: params.model });
+  async ({ messages, threadId, params }) => {
+    const result = await runSupportAgent({
+      messages,
+      conversationId: threadId,
+      model: params.model,
+    });
+    return result.text;
   },
 );
 ```
 
-Rules for the decorated function:
+Rules for the connect function:
 
 - `name` is required. Use the name the team calls the agent, in lower case with dashes.
+- Call the agent the product already runs. Do not reimplement it in the connect function, and do not call a simplified copy of it, or the suite tests code no customer reaches.
+- Change nothing about how the service starts. The connect function runs on the startup path, and the start command stays the same.
 - **Turn fields** are what the platform sends on every call: `messages` (the whole conversation, OpenAI-style), `new_messages` (`newMessages`, the delta since the last turn), `thread_id` (`threadId`), `session`, `trace_id` (`traceId`). In Python, declare only the ones you use and the SDK passes exactly those. In TypeScript, they arrive as one object, so destructure what you need.
 - Return a string, one message, a list of messages, or `langwatch.AgentReply(output, session=...)` (`{ output, session }` in TypeScript).
-- Do not remove or weaken the function's own behavior. The decorator wraps it; the direct callers keep working.
+- Do not change the agent's own code to fit the connect function. Map the turn onto the agent's existing call in the connect function instead.
 - Do NOT add a `traceparent` middleware. The SDK adopts the turn's trace context before it calls the function, so the agent's spans land in the turn's trace and the judge reads them.
 
 ### Run parameters
@@ -95,7 +115,7 @@ async def support_agent(
     ...
 ```
 
-TypeScript declares them with a zod schema in `parameters`, the way Step 3 shows. The schema types `params` in the handler, and the SDK validates the values a run supplies against it. Add `zod` to the project (`npm install zod`) if it is not there yet. Read the schema this way:
+TypeScript declares them with a zod schema in `parameters`, the way Step 3 shows. Read the values out of `params` in the connect function and pass them into the agent's own call. The schema types `params` in the handler, and the SDK validates the values a run supplies against it. Add `zod` to the project (`npm install zod`) if it is not there yet. Read the schema this way:
 
 - `z.enum([...])` becomes a closed option list in the run dialog. A value outside the list is refused.
 - `.default(value)` sets the default.
@@ -132,16 +152,18 @@ The SDK reads the environment from the `environment` argument, then `LANGWATCH_A
 
 Leave `environment` out when the service already sets `LANGWATCH_AGENT_ENVIRONMENT`, `APP_ENV`, `ENVIRONMENT` or `NODE_ENV`. The SDK reads them on its own.
 
-## Step 4: Start the process and confirm the agent is Online
+## Step 4: Start the service and confirm the agent is Online
 
-Start the service the way the user starts it. A web server keeps the connection alive by itself. For a script whose only job is the agent, block it:
+Start the service the way the user starts it. Do not add a start command, and do not write a separate runner script: the connect function is already on the startup path, and a web server holds the connection open by itself.
+
+The exception is an agent that is a library with no process of its own. Put the connect function in a small script and keep the script alive:
 
 ```python
 langwatch.agent.serve()   # Python, at the bottom of the script
 ```
 
 ```typescript
-// TypeScript: the socket keeps the event loop alive, `node agent.ts` serves until Ctrl-C
+// TypeScript: the connection holds the event loop open, `node agent.ts` serves until Ctrl-C
 ```
 
 Then confirm from the CLI, in another terminal:
@@ -295,13 +317,14 @@ Run it with `--target http:<agent-id>`, and follow Step 5 and Step 6 otherwise u
 | The run is refused with `agent_offline` | No instance was connected when the run started. | Start the agent process and run again. |
 | The run is refused with `agent_owner_only` | The agent registered under `development` with a personal key, so only its owner can run it. | Run it as the owner, or register it under a shared environment name such as `dev-shared`. |
 | The run is refused with `scenario_parameter_option_invalid` | A value is outside the closed option list the agent declares. | Use one of the listed options, or widen the `Literal` (Python) or `z.enum` (TypeScript) list in the code. |
-| A turn fails with `agent_call_timeout` | The function took longer than the agent's timeout. | Raise `timeout` on the decorator (up to 300 seconds), or make the agent answer faster. |
+| A turn fails with `agent_call_timeout` | The call took longer than the agent's timeout. | Raise `timeout` on the connect function (up to 300 seconds), or make the agent answer faster. |
 | Trace-dependent criteria come back inconclusive | The agent reports its traces to a different LangWatch project, or it reports none at all. | Point the agent's tracing at the same project's API key. Set it up with the `tracing` skill. |
 
 ## Common Mistakes
 
-- Do NOT write a second wrapper function for LangWatch to call. Decorate the function the product already runs, so the simulation exercises the real code path.
-- Do NOT add a `traceparent` middleware for a decorated agent. The SDK adopts the trace context itself; the middleware belongs to the HTTP fallback only.
+- Do NOT reimplement the agent inside the connect function, and do NOT point it at a simplified copy. It calls the agent the product already runs, so the simulation exercises the real code path.
+- Do NOT add a runner script or a second start command when the service already has one. The connect function goes on the existing startup path.
+- Do NOT add a `traceparent` middleware for a connected agent. The SDK adopts the trace context itself; the middleware belongs to the HTTP fallback only.
 - Do NOT hardcode an environment string, and do NOT write a fallback such as `process.env.APP_ENV ?? "development"`. It overrides `LANGWATCH_AGENT_ENVIRONMENT` and registers a production process under `development`. Let the SDK resolve the environment.
 - Do NOT declare a run parameter for a value the tests never vary. Every declared parameter appears in the run dialog.
 - Do NOT use a turn field name (`messages`, `new_messages`, `thread_id`, `session`, `trace_id`) as a run parameter name.

--- a/skills/connect-agent/SKILL.mdx
+++ b/skills/connect-agent/SKILL.mdx
@@ -37,7 +37,7 @@ The process needs `LANGWATCH_API_KEY` in its environment. It is the same project
 
 ## Step 3: Add the connect function where the service starts
 
-Write a small function beside the code that starts the service. LangWatch calls it once per conversation turn, and it calls the agent the codebase already has. It is an adapter: build the input the agent expects, pass the run parameters into it, and return the reply text out of what the agent gives back.
+Write a small function beside the code that starts the service. It is the adapter between the messages that come from a scenario test and the agent in the codebase.
 
 Put it in the file that starts the service, or in a module that file imports at startup. The connection opens with the process, so the code has to run when the process runs.
 

--- a/skills/connect-agent/SKILL.mdx
+++ b/skills/connect-agent/SKILL.mdx
@@ -163,7 +163,8 @@ langwatch.agent.serve()   # Python, at the bottom of the script
 ```
 
 ```typescript
-// TypeScript: the connection holds the event loop open, `node agent.ts` serves until Ctrl-C
+// TypeScript: the connection holds the event loop open, so the script serves until Ctrl-C
+// Run it with the project's TypeScript runner, for example `tsx agent.ts`
 ```
 
 Then confirm from the CLI, in another terminal:

--- a/skills/connect-agent/SKILL.mdx
+++ b/skills/connect-agent/SKILL.mdx
@@ -163,7 +163,9 @@ langwatch.agent.serve()   # Python, at the bottom of the script
 ```
 
 ```typescript
-// TypeScript: the connection holds the event loop open, so the script serves until Ctrl-C
+// TypeScript: keep the script alive yourself. The WebSocket holds the event loop
+// while connected, but the HTTP fallback and the reconnect wait do not.
+setInterval(() => {}, 1 << 30);
 // Run it with the project's TypeScript runner, for example `tsx agent.ts`
 ```
 


### PR DESCRIPTION
## What

The connect step on **Connect Your Agent** said "decorate the function that runs your agent. There is no second function to write." That is not what a customer writes. They write a small function beside the code that starts their service, and that function calls the agent they already have.

The page, the `connect-agent` skill and the cross-page links now say that.

## Why

Three problems in the old copy, all reported from reading the shipped page:

1. **"Decorate the function"** made it sound like the SDK goes on the agent's own function. In practice the new function is an adapter between the messages that come from a scenario test and the agent. Both examples now call an existing agent instead of standing in for one.

2. **Where the code goes was never stated.** It has to be on the startup path, because the connection opens with the process. The step now says so, and the examples carry a `# main.py, beside your server startup` comment.

3. **Two start instructions contradicted each other.** "Start the service the way you always start it" sat right above a `node agent.ts` block, so the reader could not tell whether to keep their own start command or run a new one. Starting is no longer a step of its own: the start command does not change, and the standalone-script case moved into a note.

## Corrections found during review

Three of these came from CodeRabbit and one from reading the SDK while checking them. Each was verified against the code before the fix.

| Claim in the docs | What the code does | Fix |
|---|---|---|
| `enabled=APP_ENV != "production"` gates deployments | `resolveEnabled` returns the explicit value **before** it reads `CI` (`sdks/typescript/src/agent/identity.ts:83`), so that expression connects CI jobs | Both examples carry the `CI` half, and the text says an `enabled` argument replaces the default rather than adding to it |
| `node agent.ts` serves the agent | Native type stripping is stable from Node 22.18; the SDK declares `node >=20` | The sentence no longer names a command; where a command helps it points at the project's own runner |
| The connection holds the event loop open | True of an open WebSocket. `wait()` in `HttpLongPollSocket.pollLoop` and the reconnect backoff in `client.ts` both `.unref()`, so a script can exit in the 250 ms gap after an empty poll or while reconnecting | All three copies tell the reader to keep the script alive; the SDK reference names the two waits |
| The `enabled` snippets are copyable | The Python block ended after the decorator, the TypeScript block passed an undefined `handler` | Both are complete, and the Python one imports `os` |

The TypeScript SDK has no `serve()` helper, which is why the advice is an explicit keep-alive rather than one call. Adding one would change the SDK's public API, so it is not in this documentation PR.

## Also in here: a CI gate that covered two of five pages

The skills manifest drives five pages. The pre-commit hook staged two of them by name and the CI staleness gate checked the same two, so editing a skill left `agent-testing/connect-your-agent.mdx` and the two `coding-agents/` pages regenerated but unstaged, and CI reported green with the published page behind its source.

`generate-skills-pages.mjs --list-pages` prints the pages it writes. The hook stages that list and CI checks it.

Measured, with the generated block in `connect-your-agent.mdx` made stale:

```
--- old gate (two docs/skills pages only) ---
PASSES, so the stale page was invisible to it
--- new gate (pages from the manifest) ---
FAILS, so the stale page is caught
```

## Changes

| File | Change |
|---|---|
| `docs/agent-testing/connect-your-agent.mdx` | Steps 2 and 3 merged and rewritten. Examples call an existing agent |
| `docs/agent-testing/environments.mdx` | `enabled` gets complete Python and TypeScript examples that gate on the environment and on CI |
| `docs/integration/typescript/agent-reference.mdx` | The keep-alive claim, corrected against the transport code |
| `skills/connect-agent/SKILL.mdx` | Same rewrite for the coding agent, plus two new Common Mistakes: do not reimplement the agent in the connect function, and do not add a runner script when the service already starts |
| `overview.mdx`, `linking-your-traces.mdx`, `other-ways-to-connect.mdx` | Card copy, so no page still says "decorate" |
| `.githooks/pre-commit`, `.github/workflows/docs-ci.yml`, `docs/scripts/generate-skills-pages.mjs` | The staleness gate covers every generated page |
| `sdks/python/.../decorator.py`, `sdks/typescript/.../define.ts` | Doc comment for `enabled`. Comments only, no behavior change |
| Generated | `docs/skills/directory.mdx`, `docs/llms*.txt`, compiled skills, langyagent skill assets |

## Verification

```
$ bash docs/scripts/check-docs-prose.sh
Docs prose check passed (7 file(s) checked).

$ go run ./cmd/docscheck
docs is sound: 713 pages, 713 navigation entries, 85 redirects, release 3.17.0.

$ pnpm --filter ./skills exec vitest run _tests/docs-skills-pages.test.ts \
    _tests/native-skills.test.ts _tests/publish-sync.test.ts \
    _tests/claude-code-adapter.test.ts _tests/evaluation-skill-boundaries.test.ts \
    _tests/lwql-charts-routing.test.ts _tests/voice-factories.test.ts
 Test Files  7 passed (7)
      Tests  54 passed (54)
```

`bash docs/scripts/sync-prompts.sh` and `docs/llms.txt.cjs` were re-run after every edit, so the generated files in this branch are current. The `docs-ci` run on `ec90ae7` passed with the changed staleness step, checked in the job log rather than by job name.

`_tests/connect-agent.scenario.test.ts` is `skipIf(isCI)` and did not pass locally. It drives a real agent through the **HTTP fallback**, which this PR does not touch, and it failed for missing credentials in the shell: first no `OPENAI_API_KEY`, so the judge never ran, then no `LANGWATCH_API_KEY`, so `langwatch secret create` was refused and the run result could not be read. Its four hard assertions did pass on both runs, under the edited skill: the skill was read, traceparent adoption landed in the fixture's Python, a `SCENARIO_API_KEY` path exists, `require_session` survived, and `langwatch agent create` appears in the transcript.

## Deployment Impact

None. Documentation, two doc comments, and a CI gate that now checks three more generated files.
