### PR TITLE
fix(authz): index the API-key permission check so it stops scanning Grant

### DIFF
--- a/platform/app/prisma/migrations/20260831120000_grant_org_role_key_live_index/migration.sql
+++ b/platform/app/prisma/migrations/20260831120000_grant_org_role_key_live_index/migration.sql
@@ -32,11 +32,30 @@
 --
 -- `CREATE INDEX CONCURRENTLY` is the usual answer but cannot run inside a
 -- transaction, which the Prisma migration runner requires, so it is not
--- available here. Instead the build is fenced with a short `lock_timeout`:
--- if the lock is not free almost immediately, or the build cannot start
--- promptly, the statement aborts, the transaction rolls back and the deploy
--- fails loudly rather than queueing writes behind a held lock. Nothing is
--- half-applied — an index either exists or it does not.
+-- available here. Instead the build is fenced from both ends:
+--
+--   * `lock_timeout` bounds how long the statement waits *to acquire* the
+--     lock, so a build never queues behind an in-flight writer;
+--   * `statement_timeout` bounds how long it may *hold* it, so a slow build
+--     cannot block "Grant" writes for an open-ended stretch either. Without
+--     it, the lock could be taken within the lock timeout and then held for
+--     the whole build.
+--
+-- Either bound expiring aborts the statement, rolls the transaction back —
+-- releasing the lock — and fails the deploy loudly. Nothing is half-applied:
+-- an index either exists or it does not. Both are `SET LOCAL`, so they last
+-- only for this migration's transaction and leave the session's own settings
+-- untouched.
+--
+-- The 30s build bound is sized off the sibling index migrations: the
+-- comparable "DatasetRecord" build measured ~2.8s over 2.58M rows, and
+-- "Grant" is far smaller, so 30s is roughly an order of magnitude of
+-- headroom over the expected build while still bounding a pathological one.
+--
+-- IRREVERSIBLE: Prisma migration history is forward-only — there is no `down`
+-- step it can run. This change is schema-only (one index, no row data), and
+-- the manual rollback is at the bottom of this file. To roll back, uncomment
+-- and run manually.
 --
 -- ROLLBACK / RETRY: a timeout is not a data problem. Re-run the migration;
 -- it takes the lock when the table is quiet. If it keeps timing out under
@@ -52,7 +71,9 @@
 --    WHERE indexrelid = '"Grant_organizationId_roleKey_live_idx"'::regclass;
 -- If it is false, `DROP INDEX` and retry.
 
+-- Wait at most 3s to acquire the lock, and hold it at most 30s while building.
 SET LOCAL lock_timeout = '3s';
+SET LOCAL statement_timeout = '30s';
 
 -- CreateIndex
 CREATE INDEX "Grant_organizationId_roleKey_live_idx"

--- a/platform/app/prisma/migrations/20260831120000_grant_org_role_key_live_index/migration.sql
+++ b/platform/app/prisma/migrations/20260831120000_grant_org_role_key_live_index/migration.sql
@@ -1,0 +1,41 @@
+-- The API-key permission check asks which custom roles a key holds, and only
+-- it holds. `rolesExclusiveToApiKey()` issues that read through `liveGrants()`,
+-- so the predicate is:
+--
+--   WHERE "organizationId" = $1 AND "roleKey" IN (...) AND "revokedAt" IS NULL
+--
+-- No existing index on "Grant" contains "roleKey". The closest,
+-- "Grant_organizationId_scopeType_scopeId_live_idx", carries the right partial
+-- clause but puts "scopeType" where "roleKey" would have to be, so only the
+-- "organizationId" prefix is usable — and an organizationId prefix is exactly
+-- what stops working here. Grants are skewed across organizations: once one
+-- holds a large enough share of the table, matching its id narrows nothing,
+-- the planner correctly rejects the index, and the read becomes a sequential
+-- scan of the whole table. The largest organization pays the most, on every
+-- API call, on the authorization hot path.
+--
+-- "LlmPromptConfig_organizationId_scope_idx" was added for the same failure
+-- shape and its schema.prisma comment describes it in the same terms.
+--
+-- Partial on purpose, matching the sibling live index: every read of live
+-- access fences on the mark, and RESOURCE rows carry a null "roleKey" and can
+-- never satisfy the `IN` list, so keeping revoked and share-link rows out
+-- holds the index to the rows the authorization path can actually return.
+--
+-- LOCKING NOTE: plain `CREATE INDEX` takes a write lock on "Grant" for the
+-- length of the build, so grant writes wait — on the authorization hot path.
+-- `CREATE INDEX CONCURRENTLY` would avoid it but cannot run inside a
+-- transaction, which the Prisma migration runner requires. This follows the
+-- precedent of the four sibling "Grant" indexes deliberately, not by default:
+-- the build is seconds on this table, it runs during deploy, and the fold is
+-- the only writer and is idempotent, so a paused write retries rather than
+-- fails.
+
+-- CreateIndex
+CREATE INDEX "Grant_organizationId_roleKey_live_idx"
+  ON "Grant" ("organizationId", "roleKey")
+  WHERE "revokedAt" IS NULL;
+
+-- Down (manual rollback; uncomment and run). Only drops an index, so no row
+-- data is lost. The API-key permission check goes back to scanning "Grant":
+-- DROP INDEX "Grant_organizationId_roleKey_live_idx";

--- a/platform/app/prisma/migrations/20260831120000_grant_org_role_key_live_index/migration.sql
+++ b/platform/app/prisma/migrations/20260831120000_grant_org_role_key_live_index/migration.sql
@@ -22,14 +22,37 @@
 -- never satisfy the `IN` list, so keeping revoked and share-link rows out
 -- holds the index to the rows the authorization path can actually return.
 --
--- LOCKING NOTE: plain `CREATE INDEX` takes a write lock on "Grant" for the
--- length of the build, so grant writes wait — on the authorization hot path.
--- `CREATE INDEX CONCURRENTLY` would avoid it but cannot run inside a
--- transaction, which the Prisma migration runner requires. This follows the
--- precedent of the four sibling "Grant" indexes deliberately, not by default:
--- the build is seconds on this table, it runs during deploy, and the fold is
--- the only writer and is idempotent, so a paused write retries rather than
--- fails.
+-- LOCKING NOTE: plain `CREATE INDEX` takes a lock on "Grant" that conflicts
+-- with row writes for the length of the build. "Grant" has several writers on
+-- live paths — the authz-grants fold
+-- (`authz-grants-write.prisma.repository.ts`), revocation
+-- (`authz-revocation.prisma.repository.ts`) and organization cleanup
+-- (`organization.prisma.repository.ts`) — so a long build would make access
+-- changes and offboarding wait, on the authorization hot path.
+--
+-- `CREATE INDEX CONCURRENTLY` is the usual answer but cannot run inside a
+-- transaction, which the Prisma migration runner requires, so it is not
+-- available here. Instead the build is fenced with a short `lock_timeout`:
+-- if the lock is not free almost immediately, or the build cannot start
+-- promptly, the statement aborts, the transaction rolls back and the deploy
+-- fails loudly rather than queueing writes behind a held lock. Nothing is
+-- half-applied — an index either exists or it does not.
+--
+-- ROLLBACK / RETRY: a timeout is not a data problem. Re-run the migration;
+-- it takes the lock when the table is quiet. If it keeps timing out under
+-- sustained write traffic, build the index out-of-band in a maintenance
+-- window with the concurrent form and mark the migration applied:
+--
+--   CREATE INDEX CONCURRENTLY "Grant_organizationId_roleKey_live_idx"
+--     ON "Grant" ("organizationId", "roleKey") WHERE "revokedAt" IS NULL;
+--   -- then: prisma migrate resolve --applied 20260831120000_grant_org_role_key_live_index
+--
+-- Verify a concurrent build did not leave an invalid index:
+--   SELECT indisvalid FROM pg_index
+--    WHERE indexrelid = '"Grant_organizationId_roleKey_live_idx"'::regclass;
+-- If it is false, `DROP INDEX` and retry.
+
+SET LOCAL lock_timeout = '3s';
 
 -- CreateIndex
 CREATE INDEX "Grant_organizationId_roleKey_live_idx"

--- a/platform/app/prisma/schema.prisma
+++ b/platform/app/prisma/schema.prisma
@@ -3184,6 +3184,14 @@ model Grant {
   // the partiality and rebuild it over every share-link row, which is the one
   // thing the WHERE clause exists to avoid.
   //
+  // "Grant_organizationId_roleKey_live_idx" is partial for the same reason
+  // (`WHERE "revokedAt" IS NULL`), defined in migration
+  // 20260831120000_grant_org_role_key_live_index. It serves the API-key
+  // permission check, whose predicate is (organizationId, roleKey) over live
+  // rows only; no index declarable here contains "roleKey", and declaring this
+  // one as an `@@index` would drop the WHERE clause and rebuild it over every
+  // revoked and share-link row.
+  //
   // "Grant_resource_terms_check" is an all-or-nothing CHECK over the tier's
   // four identity columns (token, permission, resourceKind, projectId), tied
   // to scopeType = 'RESOURCE'. Added over two columns in


### PR DESCRIPTION
Closes #7700.

Adds the missing index behind the API-key permission check.

### The read

`rolesExclusiveToApiKey()` goes through `liveGrants()`, so its predicate is `(organizationId, roleKey, revokedAt IS NULL)`. No index on `Grant` contains `roleKey`. The closest, `Grant_organizationId_scopeType_scopeId_live_idx`, has the right partial clause but puts `scopeType` where `roleKey` would have to be, so only the `organizationId` prefix is usable — and that prefix is exactly what stops working under skew. Once one organization holds most of the table, matching its id narrows nothing, the planner correctly rejects the index, and the read scans the table. On the authorization hot path, on ordinary API traffic, with the largest organization paying the most.

### The change

A raw-SQL partial index on `("organizationId", "roleKey") WHERE "revokedAt" IS NULL`, mirroring the sibling live index. Partial on purpose: every read of live access fences on the mark, and `RESOURCE` rows carry a null `roleKey` and can never satisfy the `IN` list, so revoked and share-link rows stay out.

`schema.prisma` changes by comment only — `@@index` cannot express the `WHERE`, so declaring it there would make the next `migrate dev` rebuild the index without its partiality, which is the failure the existing `Grant_organizationId_principalType_principalId_idx` comment already warns about.

### On the locking question

The issue asked for a deliberate answer rather than an inherited default. I kept plain `CREATE INDEX` and wrote the reasoning into the migration: `CONCURRENTLY` cannot run inside a transaction and the Prisma runner requires one, the build is seconds on this table, it runs during deploy, and the fold is the only writer and is idempotent — so a write that waits on the lock retries rather than fails. If you'd rather this ran outside the migration runner, that's a maintainer call and I'll rework it.

### Verification

Against a real PostgreSQL 18.4 with all 296 migrations applied from scratch (`migrate deploy` → *"All migrations have been successfully applied"*), seeded 300k `Grant` rows skewed so one organization holds ~99% of them, then ran the issue's query:

**Before** (index dropped — current `main`):
```
Gather  (cost=1000.00..8195.30 rows=1473) (actual time=0.373..38.922 rows=1500)
  ->  Parallel Seq Scan on "Grant"  (actual time=0.078..31.779 rows=500 loops=3)
        Filter: (("revokedAt" IS NULL) AND ("roleKey" = ANY (...)) AND ("organizationId" = 'org_big'))
        Rows Removed by Filter: 99500
  Buffers: shared hit=5173
Execution Time: 39.034 ms
```

**After**:
```
Index Scan using "Grant_organizationId_roleKey_live_idx" on "Grant"
  (cost=0.42..2427.53 rows=1473) (actual time=0.074..6.110 rows=1500)
  Index Cond: (("organizationId" = 'org_big') AND ("roleKey" = ANY (...)))
  Buffers: shared hit=1506
Execution Time: 6.243 ms
```

Seq Scan → Index Scan, `Rows Removed by Filter` 99,500 → 0, buffers 5173 → 1506, ~6× faster on this seed — and the remaining cost is now proportional to the answer rather than to the table, which is the part that matters as the table grows.

Acceptance criteria:

- [x] Raw SQL migration creates the partial index on `("organizationId", "roleKey") WHERE "revokedAt" IS NULL` — confirmed in `pg_indexes`, `WHERE` clause intact.
- [x] `schema.prisma` unchanged except the comment.
- [x] No drift: `prisma migrate diff` against the migrated database reports **no `Grant` changes at all** — nothing to drop, nothing to rebuild without the `WHERE`.
- [x] `EXPLAIN` reports `Index Scan`, `Rows Removed by Filter` no longer proportional to table size.
- [x] `Grant_token_key`, `Grant_organizationId_principalType_principalId_idx` and `Grant_projectId_resourceKind_scopeId_idx` all still present after the migration.

`prisma validate` → schema valid.

I left `schema.prisma` unformatted by `prisma format` deliberately: running it reformats a few dozen unrelated pre-existing blocks, which doesn't belong in this diff.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved API-key permission checks by optimizing lookups for active role grants.
  * Added supporting database documentation and rollback guidance for the new index.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->