### PR TITLE
fix(authz): index the column an API-key permission check filters on

### DIFF
--- a/platform/app/prisma/migrations/20260831120000_grant_role_key_live_index/migration.sql
+++ b/platform/app/prisma/migrations/20260831120000_grant_role_key_live_index/migration.sql
@@ -25,8 +25,28 @@
 -- concurrent path must check
 --   SELECT indisvalid FROM pg_index WHERE indexrelid =
 --     '"Grant_organizationId_roleKey_live_idx"'::regclass;
--- and DROP INDEX before retrying. Left alone, the plain build below is safe:
--- it takes a lock that blocks writes to Grant, not reads, for the build.
+-- and DROP INDEX before retrying.
+--
+-- LOCKING NOTE: left alone, the plain build takes a SHARE lock on "Grant".
+-- Reads keep working; writes wait. That matters more here than on an ordinary
+-- table, because "Grant" is the live authorization projection and a revoke is
+-- a write - so the length of the build is the length of the worst-case delay
+-- on a revoke landing. Measured on a 600,000-row reproduction of the shape
+-- this index serves: 575 ms to build, 4 MB of index. The partial predicate is
+-- doing most of that work, since it is a two-column btree over rows that are
+-- almost all live. A sub-second pause during a deploy is the same order as
+-- every other migration in this directory, and the two comparable index
+-- migrations (20260804120000_dataset_record_project_dataset_index at ~2.8s,
+-- 20260814120002_llm_prompt_config_org_scope_index) accepted the same trade
+-- for the same reason: CONCURRENTLY cannot run inside the transaction Prisma
+-- wraps a migration in. Making the concurrent prebuild mandatory instead
+-- would fail this migration on every fresh install, which is a worse outcome
+-- than a sub-second wait.
 CREATE INDEX IF NOT EXISTS "Grant_organizationId_roleKey_live_idx"
   ON "Grant" ("organizationId", "roleKey")
   WHERE "revokedAt" IS NULL;
+
+-- Down (manual rollback; uncomment and run). The index carries no row data of
+-- its own, so dropping it loses nothing - the API-key permission check goes
+-- back to reading every live grant the organization owns on every call:
+-- DROP INDEX IF EXISTS "Grant_organizationId_roleKey_live_idx";

--- a/platform/app/prisma/migrations/20260831120000_grant_role_key_live_index/migration.sql
+++ b/platform/app/prisma/migrations/20260831120000_grant_role_key_live_index/migration.sql
@@ -31,17 +31,25 @@
 -- Reads keep working; writes wait. That matters more here than on an ordinary
 -- table, because "Grant" is the live authorization projection and a revoke is
 -- a write - so the length of the build is the length of the worst-case delay
--- on a revoke landing. Measured on a 600,000-row reproduction of the shape
--- this index serves: 575 ms to build, 4 MB of index. The partial predicate is
--- doing most of that work, since it is a two-column btree over rows that are
--- almost all live. A sub-second pause during a deploy is the same order as
--- every other migration in this directory, and the two comparable index
--- migrations (20260804120000_dataset_record_project_dataset_index at ~2.8s,
--- 20260814120002_llm_prompt_config_org_scope_index) accepted the same trade
--- for the same reason: CONCURRENTLY cannot run inside the transaction Prisma
--- wraps a migration in. Making the concurrent prebuild mandatory instead
--- would fail this migration on every fresh install, which is a worse outcome
--- than a sub-second wait.
+-- on a revoke landing.
+--
+-- Measured on a local Postgres 16 container on developer hardware, over a
+-- 600,000-row reproduction: 400-575 ms to build, 4 MB of index. Two
+-- distributions were tried, because a btree deduplicates repeated keys and a
+-- lopsided seed would flatter the result - one organization holding every row
+-- built in 524 ms, a 7,000-organization spread in 399 ms. The shape barely
+-- moves it, so the range above is the honest one.
+--
+-- Read that as an order of magnitude, not as a production figure: a smaller
+-- or already-saturated instance should expect single-digit seconds, the same
+-- extrapolation 20260804120000_dataset_record_project_dataset_index made from
+-- its own reproduction. Plan the deploy window for seconds.
+--
+-- That trade is the one this directory already takes - see that migration and
+-- 20260814120002_llm_prompt_config_org_scope_index - and for the same reason:
+-- CONCURRENTLY cannot run inside the transaction Prisma wraps a migration in.
+-- Making the concurrent prebuild mandatory instead would fail this migration
+-- on every fresh install, which is worse than a wait of that length.
 CREATE INDEX IF NOT EXISTS "Grant_organizationId_roleKey_live_idx"
   ON "Grant" ("organizationId", "roleKey")
   WHERE "revokedAt" IS NULL;

--- a/platform/app/prisma/migrations/20260831120000_grant_role_key_live_index/migration.sql
+++ b/platform/app/prisma/migrations/20260831120000_grant_role_key_live_index/migration.sql
@@ -16,6 +16,17 @@
 -- this ahead of the release with CREATE INDEX CONCURRENTLY - which cannot
 -- run here, because Prisma wraps each migration in a transaction - and this
 -- statement then becomes the no-op that records the same intent.
+--
+-- That escape hatch has one trap, and it is the reason this comment is long:
+-- a CREATE INDEX CONCURRENTLY that FAILS leaves an invalid index behind
+-- under this exact name. IF NOT EXISTS would then match it and skip, and the
+-- planner never uses an invalid index - so the migration would report success
+-- while the read stayed broken, which is the worst of both. Anyone taking the
+-- concurrent path must check
+--   SELECT indisvalid FROM pg_index WHERE indexrelid =
+--     '"Grant_organizationId_roleKey_live_idx"'::regclass;
+-- and DROP INDEX before retrying. Left alone, the plain build below is safe:
+-- it takes a lock that blocks writes to Grant, not reads, for the build.
 CREATE INDEX IF NOT EXISTS "Grant_organizationId_roleKey_live_idx"
   ON "Grant" ("organizationId", "roleKey")
   WHERE "revokedAt" IS NULL;

--- a/platform/app/prisma/migrations/20260831120000_grant_role_key_live_index/migration.sql
+++ b/platform/app/prisma/migrations/20260831120000_grant_role_key_live_index/migration.sql
@@ -1,0 +1,21 @@
+-- An API-key permission check asks who else holds a key's private role:
+-- `(organizationId, roleKey)`, fenced on the row not being revoked. Every
+-- index on Grant led with organizationId and then went somewhere else
+-- (scopeType, principalType, projectId), so for an organization that holds
+-- more than a handful of grants the leading column selects everything and
+-- there is nothing left to descend. Postgres read every live grant the
+-- organization owned, on every check, to return a few rows.
+--
+-- The fence belongs in the index rather than as a filter over it, for the
+-- same reason it does on "Grant_organizationId_scopeType_scopeId_live_idx"
+-- (20260820180000_grants_revoke_marks_the_row): every read that decides
+-- access excludes marked rows, so an index that still carries them is an
+-- index the planner has to filter after descending.
+--
+-- IF NOT EXISTS is deliberate. A deployment with no CPU headroom can build
+-- this ahead of the release with CREATE INDEX CONCURRENTLY - which cannot
+-- run here, because Prisma wraps each migration in a transaction - and this
+-- statement then becomes the no-op that records the same intent.
+CREATE INDEX IF NOT EXISTS "Grant_organizationId_roleKey_live_idx"
+  ON "Grant" ("organizationId", "roleKey")
+  WHERE "revokedAt" IS NULL;

--- a/platform/app/prisma/migrations/20260831120000_grant_role_key_live_index/migration.sql
+++ b/platform/app/prisma/migrations/20260831120000_grant_role_key_live_index/migration.sql
@@ -56,5 +56,14 @@ CREATE INDEX IF NOT EXISTS "Grant_organizationId_roleKey_live_idx"
 
 -- Down (manual rollback; uncomment and run). The index carries no row data of
 -- its own, so dropping it loses nothing - the API-key permission check goes
--- back to reading every live grant the organization owns on every call:
+-- back to reading every live grant the organization owns on every call.
+--
+-- Note the lock is the other way round from the build above: a plain DROP
+-- INDEX takes ACCESS EXCLUSIVE and blocks reads as well as writes, where the
+-- build blocked only writes. On this index that is immaterial - dropping it
+-- took 0.458 ms on the same reproduction, because the work is unlinking a
+-- catalog entry rather than scanning a heap - but if it ever needs to happen
+-- on a running system, DROP INDEX CONCURRENTLY is the form that does not
+-- block, and it works here because a manual rollback is not inside Prisma's
+-- transaction:
 -- DROP INDEX IF EXISTS "Grant_organizationId_roleKey_live_idx";

--- a/platform/app/prisma/schema.prisma
+++ b/platform/app/prisma/schema.prisma
@@ -3184,6 +3184,16 @@ model Grant {
   // the partiality and rebuild it over every share-link row, which is the one
   // thing the WHERE clause exists to avoid.
   //
+  // The API-key permission check's holder lookup - who else holds this key's
+  // private role - is served by "Grant_organizationId_roleKey_live_idx",
+  // partial on `WHERE "revokedAt" IS NULL`, from migration
+  // 20260831120000_grant_role_key_live_index. Partial for the same reason and
+  // undeclarable here for the same reason as the principal scan above: every
+  // read that decides access fences on the mark, and an `@@index` would strip
+  // the WHERE on the next `prisma migrate dev`. Without it the leading column
+  // selects the whole organization and the read degrades to a full scan on
+  // every check.
+  //
   // "Grant_resource_terms_check" is an all-or-nothing CHECK over the tier's
   // four identity columns (token, permission, resourceKind, projectId), tied
   // to scopeType = 'RESOURCE'. Added over two columns in

--- a/platform/app/src/server/app-layer/authz/__tests__/grant-rolekey-index.integration.test.ts
+++ b/platform/app/src/server/app-layer/authz/__tests__/grant-rolekey-index.integration.test.ts
@@ -22,8 +22,10 @@
  *
  * @see specs/rbac/unified-authorization-engine.feature
  */
+import type { AuthzPrincipalRef } from "@langwatch/authz";
 import { nanoid } from "nanoid";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { Prisma } from "~/generated/prisma/client";
 import { PrismaClient } from "~/generated/prisma/client";
 import { createPrismaPgAdapter } from "~/server/prismaPgAdapter";
 import { GrantsAuthzReadRepository } from "../repositories/authz-read.grants.repository";
@@ -148,15 +150,14 @@ describe("given an organization holding many live grants", () => {
 
   it("answers an API-key permission check without reading every grant", async () => {
     const repository = new GrantsAuthzReadRepository(
-      prisma as unknown as ConstructorParameters<
-        typeof GrantsAuthzReadRepository
-      >[0],
+      prisma as unknown as Prisma.TransactionClient,
     );
+    const principal: AuthzPrincipalRef = { type: "apiKey", id: apiKeyId };
 
     grantQueries.length = 0;
     const permissions = await repository.findCustomRolePermissions({
       organizationId,
-      principal: { type: "apiKey", id: apiKeyId } as never,
+      principal,
       customRoleIds: [roleId],
     });
 

--- a/platform/app/src/server/app-layer/authz/__tests__/grant-rolekey-index.integration.test.ts
+++ b/platform/app/src/server/app-layer/authz/__tests__/grant-rolekey-index.integration.test.ts
@@ -148,37 +148,41 @@ describe("given an organization holding many live grants", () => {
     await prisma.$disconnect();
   });
 
-  it("answers an API-key permission check without reading every grant", async () => {
-    const repository = new GrantsAuthzReadRepository(
-      prisma as unknown as Prisma.TransactionClient,
-    );
-    const principal: AuthzPrincipalRef = { type: "apiKey", id: apiKeyId };
+  describe("when an API key asks which of its custom roles it holds alone", () => {
+    it("answers without reading every grant", async () => {
+      const repository = new GrantsAuthzReadRepository(
+        prisma as unknown as Prisma.TransactionClient,
+      );
+      const principal: AuthzPrincipalRef = { type: "apiKey", id: apiKeyId };
 
-    grantQueries.length = 0;
-    const permissions = await repository.findCustomRolePermissions({
-      organizationId,
-      principal,
-      customRoleIds: [roleId],
+      grantQueries.length = 0;
+      const permissions = await repository.findCustomRolePermissions({
+        organizationId,
+        principal,
+        customRoleIds: [roleId],
+      });
+
+      // The key holds its private role exclusively, so the role survives the
+      // filter. If this ever stops holding, the plan below is measuring the
+      // wrong query.
+      expect(permissions.map((row) => row.id)).toEqual([roleId]);
+
+      const holderQuery = grantQueries.find((query) =>
+        query.sql.includes(`"roleKey"`),
+      );
+      expect(holderQuery, "the holder lookup should have run").toBeDefined();
+
+      const explained = await prisma.$queryRawUnsafe<
+        Array<{ "QUERY PLAN": PlanNode[] | Array<{ Plan: PlanNode }> }>
+      >(
+        `EXPLAIN (ANALYZE, FORMAT JSON) ${holderQuery!.sql}`,
+        ...holderQuery!.params,
+      );
+
+      const root = explained[0]!["QUERY PLAN"][0] as { Plan: PlanNode };
+      expect(grantRowsExamined(root.Plan)).toBeLessThan(
+        ROWS_A_CHECK_MAY_EXAMINE,
+      );
     });
-
-    // The key holds its private role exclusively, so the role survives the
-    // filter. If this ever stops holding, the plan below is measuring the
-    // wrong query.
-    expect(permissions.map((row) => row.id)).toEqual([roleId]);
-
-    const holderQuery = grantQueries.find((query) =>
-      query.sql.includes(`"roleKey"`),
-    );
-    expect(holderQuery, "the holder lookup should have run").toBeDefined();
-
-    const explained = await prisma.$queryRawUnsafe<
-      Array<{ "QUERY PLAN": PlanNode[] | Array<{ Plan: PlanNode }> }>
-    >(
-      `EXPLAIN (ANALYZE, FORMAT JSON) ${holderQuery!.sql}`,
-      ...holderQuery!.params,
-    );
-
-    const root = explained[0]!["QUERY PLAN"][0] as { Plan: PlanNode };
-    expect(grantRowsExamined(root.Plan)).toBeLessThan(ROWS_A_CHECK_MAY_EXAMINE);
   });
 });

--- a/platform/app/src/server/app-layer/authz/__tests__/grant-rolekey-index.integration.test.ts
+++ b/platform/app/src/server/app-layer/authz/__tests__/grant-rolekey-index.integration.test.ts
@@ -1,0 +1,183 @@
+/**
+ * @vitest-environment node
+ *
+ * An API-key permission check must not read the whole `Grant` table.
+ *
+ * `findCustomRolePermissions` asks who else holds a key's private role, and
+ * that question is answered by `(organizationId, roleKey)`. No index carried
+ * `roleKey`, so Postgres had nothing selective to descend and fell back to
+ * reading every live grant the organization owns - on every check, to return
+ * a handful of rows.
+ *
+ * The defect is invisible at demo scale and invisible in a unit test: it is a
+ * planner decision, so proving it needs a real Postgres, real statistics, and
+ * enough rows that "reads everything" and "reads what it needs" are different
+ * numbers. So this suite seeds a lopsided organization, drives the real public
+ * method, captures the SQL Prisma actually emitted, and asks the planner what
+ * it did with it.
+ *
+ * The assertion is rows EXAMINED, not the name of an index or the absence of
+ * a sequential scan. Those are shapes a future plan is allowed to change; the
+ * promise is that a check for a few rows does not pay for the whole table.
+ *
+ * @see specs/rbac/unified-authorization-engine.feature
+ */
+import { nanoid } from "nanoid";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { PrismaClient } from "~/generated/prisma/client";
+import { createPrismaPgAdapter } from "~/server/prismaPgAdapter";
+import { GrantsAuthzReadRepository } from "../repositories/authz-read.grants.repository";
+
+const ns = `authz-rolekey-${nanoid(8)}`;
+const organizationId = `${ns}-org`;
+const apiKeyId = `${ns}-key`;
+const roleId = `${ns}-role`;
+
+/**
+ * One organization holding far more grants than the rest is not a pathological
+ * case invented for the test - it is the ordinary shape of a tenant that has
+ * been used, and it is the shape under which this read stops being cheap.
+ */
+const FILLER_GRANTS = 20_000;
+
+/**
+ * The check wants a handful of holders. Anything of this order is "read what
+ * you need"; the whole table is three orders of magnitude above it, so the
+ * threshold does not have to be delicate to separate the two.
+ */
+const ROWS_A_CHECK_MAY_EXAMINE = 1_000;
+
+type LoggedQuery = { sql: string; params: unknown[] };
+
+/** Postgres's own account of one plan node. */
+type PlanNode = {
+  "Relation Name"?: string;
+  "Actual Rows"?: number;
+  "Actual Loops"?: number;
+  "Rows Removed by Filter"?: number;
+  Plans?: PlanNode[];
+};
+
+/**
+ * Rows the executor actually touched on `Grant`, across every node that read
+ * it. A node reports what it returned; what it threw away is accounted for
+ * separately, and both were read. Per-loop figures are multiplied back out so
+ * a parallel or repeated scan is not undercounted.
+ */
+function grantRowsExamined(node: PlanNode): number {
+  const loops = node["Actual Loops"] ?? 1;
+  const own =
+    node["Relation Name"] === "Grant"
+      ? ((node["Actual Rows"] ?? 0) + (node["Rows Removed by Filter"] ?? 0)) *
+        loops
+      : 0;
+  return (node.Plans ?? []).reduce(
+    (total, child) => total + grantRowsExamined(child),
+    own,
+  );
+}
+
+describe("given an organization holding many live grants", () => {
+  let prisma: PrismaClient;
+  const grantQueries: LoggedQuery[] = [];
+
+  beforeAll(async () => {
+    prisma = new PrismaClient({
+      adapter: createPrismaPgAdapter(process.env.DATABASE_URL ?? ""),
+      log: [{ emit: "event", level: "query" }],
+    });
+
+    // The SQL under test is the SQL Prisma emits, not a paraphrase of it, so
+    // it is taken from the client rather than written here.
+    (
+      prisma as unknown as { $on: (e: string, cb: (q: never) => void) => void }
+    ).$on("query", (event: never) => {
+      const e = event as unknown as { query: string; params?: string };
+      if (!e.query.includes('"Grant"')) return;
+      grantQueries.push({
+        sql: e.query,
+        params: JSON.parse(e.params ?? "[]") as unknown[],
+      });
+    });
+
+    await prisma.$executeRawUnsafe(
+      `INSERT INTO "Role" (id, "organizationId", name, permissions, kind, "occurredAt", "createdAt", "updatedAt")
+       VALUES ($1, $2, $3, '[]'::jsonb, 'system_api_key', now(), now(), now())`,
+      roleId,
+      organizationId,
+      `${ns}-role-name`,
+    );
+
+    // The key's own grant on its private role: the row the check exists to
+    // find, and the only row it should have to look at.
+    await prisma.$executeRawUnsafe(
+      `INSERT INTO "Grant" (id, "organizationId", "principalType", "principalId", "roleKey", source, "scopeType", "scopeId", "occurredAt", "createdAt", "updatedAt")
+       VALUES ($1, $2, 'API_KEY', $3, $4, 'grants-service', 'ORGANIZATION', $2, now(), now(), now())`,
+      `${ns}-own`,
+      organizationId,
+      apiKeyId,
+      `custom:${roleId}`,
+    );
+
+    // Everything else the organization holds. Distinct role keys on purpose:
+    // the column is selective, which is exactly why not indexing it costs.
+    await prisma.$executeRawUnsafe(
+      `INSERT INTO "Grant" (id, "organizationId", "principalType", "principalId", "roleKey", source, "scopeType", "scopeId", "occurredAt", "createdAt", "updatedAt")
+       SELECT $1 || '-' || i, $2, 'USER', 'user-' || i, 'custom:role-' || (i % 500),
+              'grants-service', 'ORGANIZATION', $2, now(), now(), now()
+       FROM generate_series(1, ${FILLER_GRANTS}) AS i`,
+      ns,
+      organizationId,
+    );
+
+    // Without statistics the planner is guessing, and a guess is not evidence.
+    await prisma.$executeRawUnsafe(`ANALYZE "Grant"`);
+  }, 120_000);
+
+  afterAll(async () => {
+    await prisma.$executeRawUnsafe(
+      `DELETE FROM "Grant" WHERE "organizationId" = $1`,
+      organizationId,
+    );
+    await prisma.$executeRawUnsafe(
+      `DELETE FROM "Role" WHERE "organizationId" = $1`,
+      organizationId,
+    );
+    await prisma.$disconnect();
+  });
+
+  it("answers an API-key permission check without reading every grant", async () => {
+    const repository = new GrantsAuthzReadRepository(
+      prisma as unknown as ConstructorParameters<
+        typeof GrantsAuthzReadRepository
+      >[0],
+    );
+
+    grantQueries.length = 0;
+    const permissions = await repository.findCustomRolePermissions({
+      organizationId,
+      principal: { type: "apiKey", id: apiKeyId } as never,
+      customRoleIds: [roleId],
+    });
+
+    // The key holds its private role exclusively, so the role survives the
+    // filter. If this ever stops holding, the plan below is measuring the
+    // wrong query.
+    expect(permissions.map((row) => row.id)).toEqual([roleId]);
+
+    const holderQuery = grantQueries.find((query) =>
+      query.sql.includes(`"roleKey"`),
+    );
+    expect(holderQuery, "the holder lookup should have run").toBeDefined();
+
+    const explained = await prisma.$queryRawUnsafe<
+      Array<{ "QUERY PLAN": PlanNode[] | Array<{ Plan: PlanNode }> }>
+    >(
+      `EXPLAIN (ANALYZE, FORMAT JSON) ${holderQuery!.sql}`,
+      ...holderQuery!.params,
+    );
+
+    const root = explained[0]!["QUERY PLAN"][0] as { Plan: PlanNode };
+    expect(grantRowsExamined(root.Plan)).toBeLessThan(ROWS_A_CHECK_MAY_EXAMINE);
+  });
+});


### PR DESCRIPTION
Closes #7700.

## Cause

`platform/app/src/server/app-layer/authz/repositories/authz-read.grants.repository.ts:438` asks who else holds an API key's private role — `(organizationId, roleKey)`, fenced on `revokedAt IS NULL`. No index on `Grant` carried `roleKey`. Every one of them led with `organizationId` and then went somewhere else (`scopeType`, `principalType`, `projectId`), so for an organization holding more than a handful of grants the leading column selects everything and there is nothing left to descend.

The read is on the API-key permission path, so it runs on ordinary traffic.

## The fix

One partial index, in a raw SQL migration:

```sql
CREATE INDEX IF NOT EXISTS "Grant_organizationId_roleKey_live_idx"
  ON "Grant" ("organizationId", "roleKey")
  WHERE "revokedAt" IS NULL;
```

Raw SQL rather than `@@index`, for the reason the model comment already gives for `Grant_organizationId_principalType_principalId_idx`: Prisma cannot express a partial index, so the next `prisma migrate dev` would drop the `WHERE` and rebuild it over every row. The comment block on the model is extended to say the same thing about this one.

`IF NOT EXISTS` is deliberate. A deployment with no processor headroom can build this ahead of the release with `CREATE INDEX CONCURRENTLY` — which cannot run in the migration itself, because Prisma wraps each one in a transaction — and the statement then becomes a no-op recording the same intent.

The plain build takes a lock that blocks writes to `Grant` while it runs — and a revoke is a write, so the build length is the worst-case delay on a revoke landing. Measured on a local Postgres 16 container over a 600,000-row reproduction: **400–575 ms**, 4 MB of index — checked against two distributions, since a btree deduplicates repeated keys and a lopsided seed would flatter it (one organization holding every row: 524 ms; a 7,000-organization spread: 399 ms). Read it as an order of magnitude, not a production figure: a smaller or already-saturated instance should expect single-digit seconds, the same extrapolation `20260804120000_dataset_record_project_dataset_index` makes from its own reproduction. That is the same trade, for the same Prisma reason, that `20260804120000_dataset_record_project_dataset_index` and `20260814120002_llm_prompt_config_org_scope_index` already took. Making the concurrent prebuild mandatory instead would fail this migration on every fresh install.

## The test

`platform/app/src/server/app-layer/authz/__tests__/grant-rolekey-index.integration.test.ts` seeds one organization holding 20,000 live grants, drives the real public method, captures the SQL Prisma actually emitted, and asks the planner what it did with it.

It asserts rows **examined**, not an index name and not the absence of a sequential scan — those are shapes a future plan is allowed to change. Reading the whole table to return one row is not.

Before the fix:

```
AssertionError: expected 20001 to be less than 1000
 ❯ grant-rolekey-index.integration.test.ts:180:42
 Test Files  1 failed (1)
```

After:

```
 Test Files  1 passed (1)
      Tests  1 passed (1)
```

The plan on the same seed, before and after:

| | plan | rows examined | time |
|---|---|---|---|
| before | full read of `Grant` | 20,001 | — |
| after | index scan on the new index | 40 | 0.050 ms |

Surrounding suite: 25 files / 281 tests in `src/server/app-layer/authz`, all passing.

## Sweep

Twelve live `Grant` / `Role` reads checked against the indexes that exist:

- **One defective** — the one fixed here. It was the only read filtering on a selective column that no index carried at all.
- **Nine covered** — the principal scans (`:83`, `:114`, `:141`) land on the partial principal index; the share-token reads (`:333`, `share.ledger.repository.ts:523`) land on the token unique and the resource index; `ledger.ts:915` is a primary-key lookup.
- **Two share the shape but are not this bug** — `access-listing.grants.repository.ts:338` and `:470` also lead with `organizationId` and then filter on columns the index does not carry. They are listing endpoints rather than a per-request permission check, and I have no measurement showing they are hot, so fixing them here would be a guess. Noted, not touched.

## Not fixed here, deliberately

- The two listing reads above.
- Nothing was dropped. Three `Grant` indexes take no reads, and all three should stay: `Grant_token_key` is a global unique enforcing that a revoked share token cannot be reissued (checked on write, hence no reads), the principal index serves the offboarding scan which is rare by design, and the resource index is the share tier's documented access shape.

## Note

This changes which plan Postgres picks; it does not change any result. The test asserts the returned permissions are unchanged before it looks at the plan at all.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Accelerated API-key permission checks by optimizing lookups of active role grants.
  * Reduced unnecessary scanning of grant records in large datasets.

* **Tests**
  * Added integration coverage to verify efficient permission lookups with high-volume grant data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

