### PR TITLE
fix(feature-flags): resolve org memberships in one read instead of one per org

### DIFF
--- a/platform/app/src/server/api/routers/__tests__/featureFlag.isEnabledForAnyOrganization.unit.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/featureFlag.isEnabledForAnyOrganization.unit.test.ts
@@ -62,7 +62,7 @@ const FLAG = "release_ui_ai_governance_enabled" as const;
  * the whole list, not one per organization — so the mock answers
  * `user.findUnique` and applies the nested `organizationId in:` filter itself.
  */
-function buildMockPrisma(memberOf: Set<string>) {
+function buildMockPrisma({ memberOf }: { memberOf: Set<string> }) {
   return {
     user: {
       findUnique: vi.fn(({ where, select }: any) => {
@@ -79,7 +79,7 @@ function buildMockPrisma(memberOf: Set<string>) {
   } as unknown as PrismaClient;
 }
 
-function buildCaller(prisma: PrismaClient) {
+function buildCaller({ prisma }: { prisma: PrismaClient }) {
   const ctx = createInnerTRPCContext({
     session: { user: { id: USER_ID }, expires: "1" },
     req: undefined,
@@ -99,9 +99,9 @@ describe("featureFlag.isEnabledForAnyOrganization", () => {
 
   describe("when the user is a member of every input organization", () => {
     it("evaluates the flag for those organizations", async () => {
-      const caller = buildCaller(
-        buildMockPrisma(new Set([OWN_ORG_A, OWN_ORG_B])),
-      );
+      const caller = buildCaller({
+        prisma: buildMockPrisma({ memberOf: new Set([OWN_ORG_A, OWN_ORG_B]) }),
+      });
       mockIsEnabled.mockImplementation(
         async (_flag, opts: any) => opts.organizationId === OWN_ORG_B,
       );
@@ -121,7 +121,9 @@ describe("featureFlag.isEnabledForAnyOrganization", () => {
 
   describe("when the input mixes member and non-member organizations", () => {
     it("silently filters non-member ids before evaluating the flag", async () => {
-      const caller = buildCaller(buildMockPrisma(new Set([OWN_ORG_A])));
+      const caller = buildCaller({
+        prisma: buildMockPrisma({ memberOf: new Set([OWN_ORG_A]) }),
+      });
       mockIsEnabled.mockImplementation(
         async (_flag, opts: any) => opts.organizationId === OWN_ORG_A,
       );
@@ -142,7 +144,9 @@ describe("featureFlag.isEnabledForAnyOrganization", () => {
 
   describe("when the user is a member of none of the input organizations", () => {
     it("returns enabled:false without evaluating the flag", async () => {
-      const caller = buildCaller(buildMockPrisma(new Set()));
+      const caller = buildCaller({
+        prisma: buildMockPrisma({ memberOf: new Set() }),
+      });
 
       const result = await caller.isEnabledForAnyOrganization({
         flag: FLAG,
@@ -154,8 +158,12 @@ describe("featureFlag.isEnabledForAnyOrganization", () => {
     });
 
     it("returns the same shape as a member with the flag off, so the response cannot oracle membership", async () => {
-      const nonMemberCaller = buildCaller(buildMockPrisma(new Set()));
-      const memberCaller = buildCaller(buildMockPrisma(new Set([OWN_ORG_A])));
+      const nonMemberCaller = buildCaller({
+        prisma: buildMockPrisma({ memberOf: new Set() }),
+      });
+      const memberCaller = buildCaller({
+        prisma: buildMockPrisma({ memberOf: new Set([OWN_ORG_A]) }),
+      });
       mockIsEnabled.mockResolvedValue(false);
 
       const nonMemberResult = await nonMemberCaller.isEnabledForAnyOrganization(
@@ -180,8 +188,8 @@ describe("featureFlag.isEnabledForAnyOrganization", () => {
         { length: 65 },
         (_, index) => `org_${index}`,
       );
-      const prisma = buildMockPrisma(new Set(organizationIds));
-      const caller = buildCaller(prisma);
+      const prisma = buildMockPrisma({ memberOf: new Set(organizationIds) });
+      const caller = buildCaller({ prisma });
 
       await caller.isEnabledForAnyOrganization({
         flag: FLAG,
@@ -194,8 +202,8 @@ describe("featureFlag.isEnabledForAnyOrganization", () => {
 
   describe("when the input list is empty", () => {
     it("returns enabled:false without touching prisma or featureFlagService", async () => {
-      const prisma = buildMockPrisma(new Set([OWN_ORG_A]));
-      const caller = buildCaller(prisma);
+      const prisma = buildMockPrisma({ memberOf: new Set([OWN_ORG_A]) });
+      const caller = buildCaller({ prisma });
 
       const result = await caller.isEnabledForAnyOrganization({
         flag: FLAG,

--- a/platform/app/src/server/api/routers/__tests__/featureFlag.isEnabledForEachOrganization.unit.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/featureFlag.isEnabledForEachOrganization.unit.test.ts
@@ -59,7 +59,7 @@ const FLAG = "release_ui_ai_governance_enabled" as const;
  * the whole list, not one per organization — so the mock answers
  * `user.findUnique` and applies the nested `organizationId in:` filter itself.
  */
-function buildMockPrisma(memberOf: Set<string>) {
+function buildMockPrisma({ memberOf }: { memberOf: Set<string> }) {
   return {
     user: {
       findUnique: vi.fn(({ where, select }: any) => {
@@ -76,7 +76,7 @@ function buildMockPrisma(memberOf: Set<string>) {
   } as unknown as PrismaClient;
 }
 
-function buildCaller(prisma: PrismaClient) {
+function buildCaller({ prisma }: { prisma: PrismaClient }) {
   const ctx = createInnerTRPCContext({
     session: { user: { id: USER_ID }, expires: "1" },
     req: undefined,
@@ -96,9 +96,9 @@ describe("featureFlag.isEnabledForEachOrganization", () => {
 
   describe("when the user is a member of every input organization", () => {
     it("returns the flag state per organization", async () => {
-      const caller = buildCaller(
-        buildMockPrisma(new Set([OWN_ORG_A, OWN_ORG_B])),
-      );
+      const caller = buildCaller({
+        prisma: buildMockPrisma({ memberOf: new Set([OWN_ORG_A, OWN_ORG_B]) }),
+      });
       mockIsEnabled.mockImplementation(
         async (_flag, opts: any) => opts.organizationId === OWN_ORG_B,
       );
@@ -119,7 +119,9 @@ describe("featureFlag.isEnabledForEachOrganization", () => {
 
   describe("when the input mixes member and non-member organizations", () => {
     it("omits non-member ids from the map rather than reporting them false", async () => {
-      const caller = buildCaller(buildMockPrisma(new Set([OWN_ORG_A])));
+      const caller = buildCaller({
+        prisma: buildMockPrisma({ memberOf: new Set([OWN_ORG_A]) }),
+      });
       mockIsEnabled.mockResolvedValue(true);
 
       const result = await caller.isEnabledForEachOrganization({
@@ -144,8 +146,8 @@ describe("featureFlag.isEnabledForEachOrganization", () => {
         { length: 65 },
         (_, index) => `org_${index}`,
       );
-      const prisma = buildMockPrisma(new Set(organizationIds));
-      const caller = buildCaller(prisma);
+      const prisma = buildMockPrisma({ memberOf: new Set(organizationIds) });
+      const caller = buildCaller({ prisma });
 
       await caller.isEnabledForEachOrganization({
         flag: FLAG,
@@ -158,8 +160,8 @@ describe("featureFlag.isEnabledForEachOrganization", () => {
 
   describe("when the input list is empty", () => {
     it("returns an empty map without touching prisma or featureFlagService", async () => {
-      const prisma = buildMockPrisma(new Set([OWN_ORG_A]));
-      const caller = buildCaller(prisma);
+      const prisma = buildMockPrisma({ memberOf: new Set([OWN_ORG_A]) });
+      const caller = buildCaller({ prisma });
 
       const result = await caller.isEnabledForEachOrganization({
         flag: FLAG,

--- a/platform/app/src/server/api/routers/__tests__/featureFlag.isEnabledForEachOrganization.unit.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/featureFlag.isEnabledForEachOrganization.unit.test.ts
@@ -1,19 +1,16 @@
 /**
  * @vitest-environment node
  *
- * Unit tests for the featureFlag.isEnabledForAnyOrganization tRPC procedure.
+ * Unit tests for the featureFlag.isEnabledForEachOrganization tRPC procedure.
  *
- * The procedure receives a list of organization ids from the client. It MUST
- * intersect that list with the caller's actual `OrganizationUser` memberships
- * before evaluating the flag — otherwise an authenticated user could probe
- * the flag state of arbitrary organizations they don't belong to, which leaks
- * business information (e.g. which organizations use governance).
+ * This is the variant every client surface actually calls (the workspace
+ * switcher and the product shell), so the membership filtering and the
+ * single-read membership resolution are pinned here as well as on the
+ * `isEnabledForAnyOrganization` sibling — both procedures share one resolver.
  *
- * Failure mode under test (pre-fix regression): the resolver fanned out
- * `featureFlagService.isEnabled` over every input id without a membership
- * check, so an attacker who knew (or guessed) another org's id could read
- * its flag state. The fix silently drops non-member ids and returns
- * `{ enabled: false }` when the filtered set is empty.
+ * Organizations the caller does not belong to must be absent from the result
+ * map entirely, never present as `false`: a `false` entry would tell the
+ * caller the organization exists and they are not in it.
  */
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -91,14 +88,14 @@ function buildCaller(prisma: PrismaClient) {
   return featureFlagRouter.createCaller(ctx);
 }
 
-describe("featureFlag.isEnabledForAnyOrganization", () => {
+describe("featureFlag.isEnabledForEachOrganization", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockIsEnabled.mockResolvedValue(false);
   });
 
   describe("when the user is a member of every input organization", () => {
-    it("evaluates the flag for those organizations", async () => {
+    it("returns the flag state per organization", async () => {
       const caller = buildCaller(
         buildMockPrisma(new Set([OWN_ORG_A, OWN_ORG_B])),
       );
@@ -106,71 +103,38 @@ describe("featureFlag.isEnabledForAnyOrganization", () => {
         async (_flag, opts: any) => opts.organizationId === OWN_ORG_B,
       );
 
-      const result = await caller.isEnabledForAnyOrganization({
+      const result = await caller.isEnabledForEachOrganization({
         flag: FLAG,
         organizationIds: [OWN_ORG_A, OWN_ORG_B],
       });
 
-      expect(result).toEqual({ enabled: true });
-      const evaluatedOrgIds = mockIsEnabled.mock.calls.map(
-        ([, opts]: any) => opts.organizationId,
-      );
-      expect(evaluatedOrgIds.sort()).toEqual([OWN_ORG_A, OWN_ORG_B].sort());
+      expect(result).toEqual({
+        enabledByOrganizationId: {
+          [OWN_ORG_A]: false,
+          [OWN_ORG_B]: true,
+        },
+      });
     });
   });
 
   describe("when the input mixes member and non-member organizations", () => {
-    it("silently filters non-member ids before evaluating the flag", async () => {
+    it("omits non-member ids from the map rather than reporting them false", async () => {
       const caller = buildCaller(buildMockPrisma(new Set([OWN_ORG_A])));
-      mockIsEnabled.mockImplementation(
-        async (_flag, opts: any) => opts.organizationId === OWN_ORG_A,
-      );
+      mockIsEnabled.mockResolvedValue(true);
 
-      const result = await caller.isEnabledForAnyOrganization({
+      const result = await caller.isEnabledForEachOrganization({
         flag: FLAG,
         organizationIds: [OWN_ORG_A, FOREIGN_ORG],
       });
 
-      expect(result).toEqual({ enabled: true });
+      expect(result).toEqual({
+        enabledByOrganizationId: { [OWN_ORG_A]: true },
+      });
+      expect(result.enabledByOrganizationId).not.toHaveProperty(FOREIGN_ORG);
       const evaluatedOrgIds = mockIsEnabled.mock.calls.map(
         ([, opts]: any) => opts.organizationId,
       );
       expect(evaluatedOrgIds).toEqual([OWN_ORG_A]);
-      expect(evaluatedOrgIds).not.toContain(FOREIGN_ORG);
-    });
-  });
-
-  describe("when the user is a member of none of the input organizations", () => {
-    it("returns enabled:false without evaluating the flag", async () => {
-      const caller = buildCaller(buildMockPrisma(new Set()));
-
-      const result = await caller.isEnabledForAnyOrganization({
-        flag: FLAG,
-        organizationIds: [FOREIGN_ORG, "org_other_foreign"],
-      });
-
-      expect(result).toEqual({ enabled: false });
-      expect(mockIsEnabled).not.toHaveBeenCalled();
-    });
-
-    it("returns the same shape as a member with the flag off, so the response cannot oracle membership", async () => {
-      const nonMemberCaller = buildCaller(buildMockPrisma(new Set()));
-      const memberCaller = buildCaller(buildMockPrisma(new Set([OWN_ORG_A])));
-      mockIsEnabled.mockResolvedValue(false);
-
-      const nonMemberResult = await nonMemberCaller.isEnabledForAnyOrganization(
-        {
-          flag: FLAG,
-          organizationIds: [FOREIGN_ORG],
-        },
-      );
-      const memberResult = await memberCaller.isEnabledForAnyOrganization({
-        flag: FLAG,
-        organizationIds: [OWN_ORG_A],
-      });
-
-      expect(nonMemberResult).toEqual(memberResult);
-      expect(nonMemberResult).toEqual({ enabled: false });
     });
   });
 
@@ -183,7 +147,7 @@ describe("featureFlag.isEnabledForAnyOrganization", () => {
       const prisma = buildMockPrisma(new Set(organizationIds));
       const caller = buildCaller(prisma);
 
-      await caller.isEnabledForAnyOrganization({
+      await caller.isEnabledForEachOrganization({
         flag: FLAG,
         organizationIds,
       });
@@ -193,16 +157,16 @@ describe("featureFlag.isEnabledForAnyOrganization", () => {
   });
 
   describe("when the input list is empty", () => {
-    it("returns enabled:false without touching prisma or featureFlagService", async () => {
+    it("returns an empty map without touching prisma or featureFlagService", async () => {
       const prisma = buildMockPrisma(new Set([OWN_ORG_A]));
       const caller = buildCaller(prisma);
 
-      const result = await caller.isEnabledForAnyOrganization({
+      const result = await caller.isEnabledForEachOrganization({
         flag: FLAG,
         organizationIds: [],
       });
 
-      expect(result).toEqual({ enabled: false });
+      expect(result).toEqual({ enabledByOrganizationId: {} });
       expect(prisma.user.findUnique).not.toHaveBeenCalled();
       expect(mockIsEnabled).not.toHaveBeenCalled();
     });

--- a/platform/app/src/server/api/routers/featureFlag.ts
+++ b/platform/app/src/server/api/routers/featureFlag.ts
@@ -37,11 +37,15 @@ const frontendFeatureFlagSchema = z.enum([...FRONTEND_FEATURE_FLAGS] as [
  * Input order is preserved and ids the caller is not a member of are dropped
  * silently, so the result cannot be used as a membership oracle.
  */
-async function resolveMemberOrganizationIds(
-  prisma: PrismaClient,
-  userId: string,
-  organizationIds: string[],
-): Promise<string[]> {
+async function resolveMemberOrganizationIds({
+  prisma,
+  userId,
+  organizationIds,
+}: {
+  prisma: PrismaClient;
+  userId: string;
+  organizationIds: string[];
+}): Promise<string[]> {
   const person = await prisma.user.findUnique({
     where: { id: userId },
     select: {
@@ -185,11 +189,11 @@ export const featureFlagRouter = createTRPCRouter({
         return { enabled: false };
       }
 
-      const allowedOrganizationIds = await resolveMemberOrganizationIds(
-        ctx.prisma,
+      const allowedOrganizationIds = await resolveMemberOrganizationIds({
+        prisma: ctx.prisma,
         userId,
-        input.organizationIds,
-      );
+        organizationIds: input.organizationIds,
+      });
 
       if (allowedOrganizationIds.length === 0) {
         return { enabled: false };
@@ -245,11 +249,11 @@ export const featureFlagRouter = createTRPCRouter({
         return { enabledByOrganizationId: {} as Record<string, boolean> };
       }
 
-      const allowedOrganizationIds = await resolveMemberOrganizationIds(
-        ctx.prisma,
+      const allowedOrganizationIds = await resolveMemberOrganizationIds({
+        prisma: ctx.prisma,
         userId,
-        input.organizationIds,
-      );
+        organizationIds: input.organizationIds,
+      });
 
       const entries = await Promise.all(
         allowedOrganizationIds.map(

--- a/platform/app/src/server/api/routers/featureFlag.ts
+++ b/platform/app/src/server/api/routers/featureFlag.ts
@@ -1,5 +1,6 @@
 import { createLogger } from "@langwatch/observability";
 import { z } from "zod";
+import type { PrismaClient } from "~/generated/prisma/client";
 import { featureFlagService } from "../../featureFlag";
 import { FRONTEND_FEATURE_FLAGS } from "../../featureFlag/frontendFeatureFlags";
 import type { FeatureFlagKey } from "../../featureFlag/registry";
@@ -12,6 +13,55 @@ const frontendFeatureFlagSchema = z.enum([...FRONTEND_FEATURE_FLAGS] as [
   string,
   ...string[],
 ]);
+
+/**
+ * Intersect the requested organization ids with the caller's real
+ * `OrganizationUser` memberships, in one round trip.
+ *
+ * Read as a NESTED select off the person rather than as a top-level
+ * `organizationUser` call. The question spans every organization one person
+ * belongs to, so it has no single-organization predicate to offer and
+ * `guardOrganizationId` (ADR-021) refuses it — a refusal that surfaces as a
+ * 500, not as a skipped check. The guard sees top-level model operations only
+ * (`$allOperations` in `src/server/db.ts`), so going through the person asks
+ * the same question in a shape the guard is right not to inspect. Same shape
+ * as `identity/repositories/mfa-enrollment.prisma.repository.ts`.
+ *
+ * This replaces a fan-out of one `organizationUser.findUnique` per id. Prisma
+ * batched those into a single `userId = $1 AND organizationId IN (...)`
+ * statement, but the planner still probed the composite key once per
+ * organization, and the two procedures below run three times per page load.
+ * For a caller with a large workspace list that made this statement the
+ * heaviest read on the database. One nested select asks once.
+ *
+ * Input order is preserved and ids the caller is not a member of are dropped
+ * silently, so the result cannot be used as a membership oracle.
+ */
+async function resolveMemberOrganizationIds(
+  prisma: PrismaClient,
+  userId: string,
+  organizationIds: string[],
+): Promise<string[]> {
+  const person = await prisma.user.findUnique({
+    where: { id: userId },
+    select: {
+      orgMemberships: {
+        where: { organizationId: { in: organizationIds } },
+        select: { organizationId: true },
+      },
+    },
+  });
+
+  const memberOf = new Set(
+    (person?.orgMemberships ?? []).map(
+      (membership) => membership.organizationId,
+    ),
+  );
+
+  return organizationIds.filter((organizationId) =>
+    memberOf.has(organizationId),
+  );
+}
 
 /**
  * tRPC router for feature flag checks.
@@ -135,21 +185,11 @@ export const featureFlagRouter = createTRPCRouter({
         return { enabled: false };
       }
 
-      // OrganizationUser is org-scoped under the single-organization
-      // invariant of guardOrganizationId, so a single `in:` query would
-      // be rejected for spanning multiple orgs. Resolve memberships
-      // per-id; the user's org count is bounded by their workspace list.
-      const memberships = await Promise.all(
-        input.organizationIds.map((organizationId) =>
-          ctx.prisma.organizationUser.findUnique({
-            where: { userId_organizationId: { userId, organizationId } },
-            select: { organizationId: true },
-          }),
-        ),
+      const allowedOrganizationIds = await resolveMemberOrganizationIds(
+        ctx.prisma,
+        userId,
+        input.organizationIds,
       );
-      const allowedOrganizationIds = memberships
-        .filter((m): m is { organizationId: string } => m !== null)
-        .map((m) => m.organizationId);
 
       if (allowedOrganizationIds.length === 0) {
         return { enabled: false };
@@ -205,17 +245,11 @@ export const featureFlagRouter = createTRPCRouter({
         return { enabledByOrganizationId: {} as Record<string, boolean> };
       }
 
-      const memberships = await Promise.all(
-        input.organizationIds.map((organizationId) =>
-          ctx.prisma.organizationUser.findUnique({
-            where: { userId_organizationId: { userId, organizationId } },
-            select: { organizationId: true },
-          }),
-        ),
+      const allowedOrganizationIds = await resolveMemberOrganizationIds(
+        ctx.prisma,
+        userId,
+        input.organizationIds,
       );
-      const allowedOrganizationIds = memberships
-        .filter((m): m is { organizationId: string } => m !== null)
-        .map((m) => m.organizationId);
 
       const entries = await Promise.all(
         allowedOrganizationIds.map(


### PR DESCRIPTION
## Problem

The two feature-flag procedures verified organization membership by mapping over the input list and issuing one `organizationUser.findUnique` per organization:

```ts
await Promise.all(
  input.organizationIds.map((organizationId) =>
    ctx.prisma.organizationUser.findUnique({
      where: { userId_organizationId: { userId, organizationId } },
      select: { organizationId: true },
    }),
  ),
);
```

Prisma batches those into a single `IN (...)` statement, so this does not look like an N+1 in the query log — but the planner still probes the composite primary key once per organization, and the page issues three of these calls per load (`useWorkspaceData.ts:84`, `useProductFlagsByOrganization.ts:29` and `:33`).

For an account belonging to many organizations this became the single heaviest read on the primary database — the top statement by average active sessions, with the waits almost entirely CPU rather than IO or locks. There is no index to add: `@@id([userId, organizationId])` at `prisma/schema.prisma:611` already covers the lookup exactly. The cost is the repetition, not a missing index.

## Change

Resolve the whole list in **one** read, via a nested select off the person:

```ts
const person = await prisma.user.findUnique({
  where: { id: userId },
  select: {
    orgMemberships: {
      where: { organizationId: { in: organizationIds } },
      select: { organizationId: true },
    },
  },
});
```

The obvious version — a single top-level `organizationUser.findMany` with `organizationId: { in: [...] }` — is rejected by `guardOrganizationId` and surfaces as a 500. The guard inspects top-level model operations only, so the nested read is the same shape `mfa-enrollment.prisma.repository.ts:49` already uses for cross-organization questions. That rationale is recorded in the helper's doc comment so the next reader does not re-derive it.

Behaviour is preserved: input order is kept, and organizations the caller does not belong to are dropped silently rather than returned as `false`, so the response cannot be used as a membership oracle.

The remaining per-organization loop into `featureFlagService.isEnabled` is unchanged and does **not** touch Postgres — the flag row is cached per flag behind an in-process and Redis TTL cache, with targeting rules evaluated in memory (`featureFlagStore.postgres.ts:45-50`, `featureFlag.service.ts:112`). This removes the whole database cost, not part of it.

## Tests

- Existing `isEnabledForAnyOrganization` suite updated for the new shape, plus a case asserting 65 organizations resolve in a single read.
- **New** `isEnabledForEachOrganization` suite. This is the variant every client surface actually calls and it had no coverage at all; both procedures now share one resolver, so the untested path carried the risk. Covers the per-organization map, non-members omitted rather than reported `false`, one read for 65 organizations, and an empty input list touching neither the database nor the flag service.

10/10 pass. `biome check` clean on all three files. Full typecheck clean apart from a pre-existing `src/task.ts:8` missing-codegen error unrelated to this diff.

## Not in this PR

- `useProductFlagsByOrganization` fetches `release_ui_ai_governance_enabled` twice per render (`:29` and `:33`); deduping it removes a third of the remaining calls.
- The `Grant` table has no index containing `roleKey` — `WHERE organizationId = $1 AND roleKey IN (...) AND revokedAt IS NULL` is the second-heaviest read. Confirmed against the migrations, worth its own change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved feature-flag checks across organizations by resolving memberships in a single read, reducing delays for large organization lists.
  * Preserved the requested organization order while excluding organizations where the caller is not a member.

* **Bug Fixes**
  * Improved handling of empty organization lists and non-member organizations.

* **Tests**
  * Added coverage for bulk membership resolution, membership filtering, ordering, and feature-flag checks across multiple organizations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->