### PR TITLE
fix(nlpgo): bound undici dispatcher timeouts so 630s deadline works

### DIFF
--- a/platform/app/src/server/nlpgo/__tests__/timeouts.unit.test.ts
+++ b/platform/app/src/server/nlpgo/__tests__/timeouts.unit.test.ts
@@ -1,5 +1,25 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { Agent } from "undici";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Undici's Agent does not read back the timeouts it was constructed with, so
+// the only way to assert on them is to record the constructor's arguments.
+const agentOptions = vi.hoisted(() => [] as Record<string, unknown>[]);
+
+vi.mock("undici", async () => {
+  const actual = await vi.importActual<typeof import("undici")>("undici");
+  return {
+    ...actual,
+    Agent: class RecordingAgent extends actual.Agent {
+      constructor(opts?: Record<string, unknown>) {
+        agentOptions.push(opts ?? {});
+        super(opts);
+      }
+    },
+  };
+});
+
 import {
+  createNlpFetchDispatcher,
   NLP_FETCH_HEADROOM_MS,
   NLPGO_ENGINE_CODE_BLOCK_TIMEOUT_DEFAULT_SECONDS,
   NLPGO_ENGINE_CODE_BLOCK_TIMEOUT_SECONDS_ENV,
@@ -53,5 +73,22 @@ describe("resolveFloorFetchTimeoutMs", () => {
   ])("falls back on the unusable value %p", (raw) => {
     vi.stubEnv(NLPGO_ENGINE_CODE_BLOCK_TIMEOUT_SECONDS_ENV, raw);
     expect(resolveFloorFetchTimeoutMs()).toBe(DEFAULT_FLOOR_MS);
+  });
+});
+
+describe("createNlpFetchDispatcher", () => {
+  beforeEach(() => {
+    agentOptions.length = 0;
+  });
+
+  it("sizes undici's own headers and body timeouts to the caller's deadline", () => {
+    createNlpFetchDispatcher(500_000);
+
+    expect(agentOptions.at(-1)?.headersTimeout).toBe(500_000);
+    expect(agentOptions.at(-1)?.bodyTimeout).toBe(500_000);
+  });
+
+  it("returns an undici dispatcher", () => {
+    expect(createNlpFetchDispatcher(500_000)).toBeInstanceOf(Agent);
   });
 });

--- a/platform/app/src/server/nlpgo/__tests__/timeouts.unit.test.ts
+++ b/platform/app/src/server/nlpgo/__tests__/timeouts.unit.test.ts
@@ -19,6 +19,7 @@ vi.mock("undici", async () => {
 });
 
 import {
+  closeNlpFetchDispatchers,
   createNlpFetchDispatcher,
   NLP_FETCH_HEADROOM_MS,
   NLPGO_ENGINE_CODE_BLOCK_TIMEOUT_DEFAULT_SECONDS,
@@ -77,8 +78,12 @@ describe("resolveFloorFetchTimeoutMs", () => {
 });
 
 describe("createNlpFetchDispatcher", () => {
-  beforeEach(() => {
+  // Dispatchers are memoized module-wide (see timeouts.ts), so each test
+  // must start from an empty cache or it would silently observe a dispatcher
+  // built - and recorded into agentOptions - by a previous test.
+  beforeEach(async () => {
     agentOptions.length = 0;
+    await closeNlpFetchDispatchers();
   });
 
   it("sizes undici's own headers and body timeouts to the caller's deadline", () => {
@@ -92,5 +97,47 @@ describe("createNlpFetchDispatcher", () => {
     expect(createNlpFetchDispatcher({ timeoutMs: 500_000 })).toBeInstanceOf(
       Agent,
     );
+  });
+
+  it("memoizes: the same timeoutMs returns the same dispatcher instance", () => {
+    const first = createNlpFetchDispatcher({ timeoutMs: 42_000 });
+    const second = createNlpFetchDispatcher({ timeoutMs: 42_000 });
+
+    expect(second).toBe(first);
+    // Only the first call should have constructed a new Agent.
+    expect(agentOptions).toHaveLength(1);
+  });
+
+  it("does not memoize across different timeoutMs values", () => {
+    const first = createNlpFetchDispatcher({ timeoutMs: 10_000 });
+    const second = createNlpFetchDispatcher({ timeoutMs: 20_000 });
+
+    expect(second).not.toBe(first);
+    expect(agentOptions).toHaveLength(2);
+  });
+
+  it("a memoized dispatcher still carries headersTimeout/bodyTimeout equal to timeoutMs", () => {
+    createNlpFetchDispatcher({ timeoutMs: 77_000 });
+    createNlpFetchDispatcher({ timeoutMs: 77_000 }); // served from cache
+
+    expect(agentOptions.at(-1)?.headersTimeout).toBe(77_000);
+    expect(agentOptions.at(-1)?.bodyTimeout).toBe(77_000);
+  });
+});
+
+describe("closeNlpFetchDispatchers", () => {
+  beforeEach(async () => {
+    agentOptions.length = 0;
+    await closeNlpFetchDispatchers();
+  });
+
+  it("empties the cache so a later call constructs a fresh instance", async () => {
+    const first = createNlpFetchDispatcher({ timeoutMs: 99_000 });
+
+    await closeNlpFetchDispatchers();
+    const second = createNlpFetchDispatcher({ timeoutMs: 99_000 });
+
+    expect(second).not.toBe(first);
+    expect(agentOptions).toHaveLength(2);
   });
 });

--- a/platform/app/src/server/nlpgo/__tests__/timeouts.unit.test.ts
+++ b/platform/app/src/server/nlpgo/__tests__/timeouts.unit.test.ts
@@ -82,13 +82,15 @@ describe("createNlpFetchDispatcher", () => {
   });
 
   it("sizes undici's own headers and body timeouts to the caller's deadline", () => {
-    createNlpFetchDispatcher(500_000);
+    createNlpFetchDispatcher({ timeoutMs: 500_000 });
 
     expect(agentOptions.at(-1)?.headersTimeout).toBe(500_000);
     expect(agentOptions.at(-1)?.bodyTimeout).toBe(500_000);
   });
 
   it("returns an undici dispatcher", () => {
-    expect(createNlpFetchDispatcher(500_000)).toBeInstanceOf(Agent);
+    expect(createNlpFetchDispatcher({ timeoutMs: 500_000 })).toBeInstanceOf(
+      Agent,
+    );
   });
 });

--- a/platform/app/src/server/nlpgo/timeouts.ts
+++ b/platform/app/src/server/nlpgo/timeouts.ts
@@ -19,6 +19,8 @@
  * headroom. One operator-set number, read on both sides of the socket.
  */
 
+import { Agent, type Dispatcher } from "undici";
+
 /**
  * The engine's own knob for the code block's execution ceiling — see
  * `services/nlpgo/config.go` (`Engine.CodeBlockTimeoutSeconds`, tag
@@ -191,6 +193,30 @@ export function resolveMaxFetchTimeoutMs(): number {
     fallbackMs: NLP_FETCH_MAX_TIMEOUT_DEFAULT_MS,
   });
 }
+
+/**
+ * Undici's own per-request timeouts — `headersTimeout`/`bodyTimeout`, default
+ * 300_000ms each — live on the DISPATCHER (the `Agent`), not on the request.
+ * An `AbortController` deadline passed as `signal` cannot raise them: past
+ * 300s of a still-open connection, undici throws `HeadersTimeoutError`
+ * regardless of how far out the abort is armed. This is what let a client
+ * deadline raised to 630s (`resolveFloorFetchTimeoutMs`, lw#7640) still get
+ * cut off at 300s in production — the abort signal was never the ceiling
+ * that mattered.
+ *
+ * Callers of the bare global `fetch` (not the named `undici` export) must
+ * pass this as `dispatcher` explicitly; the global's own `RequestInit` type
+ * (from the `dom` lib) has no `dispatcher` field, hence {@link FetchInitWithDispatcher}.
+ */
+export function createNlpFetchDispatcher(timeoutMs: number): Dispatcher {
+  return new Agent({ headersTimeout: timeoutMs, bodyTimeout: timeoutMs });
+}
+
+/**
+ * Widens the DOM-lib `RequestInit` the global `fetch` is typed with to admit
+ * the undici-only `dispatcher` option. See {@link createNlpFetchDispatcher}.
+ */
+export type FetchInitWithDispatcher = RequestInit & { dispatcher?: Dispatcher };
 
 /**
  * Lambda's own hard invocation ceiling. The code-block timeout override must

--- a/platform/app/src/server/nlpgo/timeouts.ts
+++ b/platform/app/src/server/nlpgo/timeouts.ts
@@ -195,6 +195,18 @@ export function resolveMaxFetchTimeoutMs(): number {
 }
 
 /**
+ * Cache for {@link createNlpFetchDispatcher}, keyed by the effective
+ * `timeoutMs`. An `Agent` owns its own connection pool, so building a fresh
+ * one per call — the original behaviour here — opened a new pool on every
+ * scenario fetch that was never reused and never destroyed: a socket/FD
+ * leak under load that also defeated keep-alive to nlpgo. `timeoutMs` comes
+ * from env-derived config (`resolveFloorFetchTimeoutMs`,
+ * `resolveMaxFetchTimeoutMs`), so the key cardinality is small and fixed
+ * for the process's life — no eviction policy is needed.
+ */
+const dispatchersByTimeoutMs = new Map<number, Dispatcher>();
+
+/**
  * Undici's own per-request timeouts — `headersTimeout`/`bodyTimeout`, default
  * 300_000ms each — live on the DISPATCHER (the `Agent`), not on the request.
  * An `AbortController` deadline passed as `signal` cannot raise them: past
@@ -207,13 +219,38 @@ export function resolveMaxFetchTimeoutMs(): number {
  * Callers of the bare global `fetch` (not the named `undici` export) must
  * pass this as `dispatcher` explicitly; the global's own `RequestInit` type
  * (from the `dom` lib) has no `dispatcher` field, hence {@link FetchInitWithDispatcher}.
+ *
+ * Memoized by `timeoutMs` — see {@link dispatchersByTimeoutMs}. Call
+ * {@link closeNlpFetchDispatchers} on shutdown to release the pooled
+ * connections this holds open.
  */
 export function createNlpFetchDispatcher({
   timeoutMs,
 }: {
   timeoutMs: number;
 }): Dispatcher {
-  return new Agent({ headersTimeout: timeoutMs, bodyTimeout: timeoutMs });
+  const cached = dispatchersByTimeoutMs.get(timeoutMs);
+  if (cached) {
+    return cached;
+  }
+  const dispatcher = new Agent({
+    headersTimeout: timeoutMs,
+    bodyTimeout: timeoutMs,
+  });
+  dispatchersByTimeoutMs.set(timeoutMs, dispatcher);
+  return dispatcher;
+}
+
+/**
+ * Closes every dispatcher {@link createNlpFetchDispatcher} has cached and
+ * clears the cache, so a later call builds a fresh `Agent` instead of
+ * reusing a closed one. Wired into process shutdown from
+ * `~/server/workers/startWorkers.ts`.
+ */
+export async function closeNlpFetchDispatchers(): Promise<void> {
+  const dispatchers = [...dispatchersByTimeoutMs.values()];
+  dispatchersByTimeoutMs.clear();
+  await Promise.all(dispatchers.map((dispatcher) => dispatcher.close()));
 }
 
 /**

--- a/platform/app/src/server/nlpgo/timeouts.ts
+++ b/platform/app/src/server/nlpgo/timeouts.ts
@@ -208,7 +208,11 @@ export function resolveMaxFetchTimeoutMs(): number {
  * pass this as `dispatcher` explicitly; the global's own `RequestInit` type
  * (from the `dom` lib) has no `dispatcher` field, hence {@link FetchInitWithDispatcher}.
  */
-export function createNlpFetchDispatcher(timeoutMs: number): Dispatcher {
+export function createNlpFetchDispatcher({
+  timeoutMs,
+}: {
+  timeoutMs: number;
+}): Dispatcher {
   return new Agent({ headersTimeout: timeoutMs, bodyTimeout: timeoutMs });
 }
 

--- a/platform/app/src/server/scenarios/execution/serialized-adapters/__tests__/code-agent.adapter.unit.test.ts
+++ b/platform/app/src/server/scenarios/execution/serialized-adapters/__tests__/code-agent.adapter.unit.test.ts
@@ -77,6 +77,24 @@ const mockInjectTraceContextHeaders = vi.mocked(injectTraceContextHeaders);
 const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
 
+// Undici's Agent does not read back the timeouts it was constructed with, so
+// the only way to assert on the dispatcher the adapter passes is to record the
+// constructor's arguments. The global fetch above stays the interception point.
+const agentOptions = vi.hoisted(() => [] as Record<string, unknown>[]);
+
+vi.mock("undici", async () => {
+  const actual = await vi.importActual<typeof import("undici")>("undici");
+  return {
+    ...actual,
+    Agent: class RecordingAgent extends actual.Agent {
+      constructor(opts?: Record<string, unknown>) {
+        agentOptions.push(opts ?? {});
+        super(opts);
+      }
+    },
+  };
+});
+
 describe("SerializedCodeAgentAdapter", () => {
   const defaultConfig: CodeAgentData = {
     type: "code",
@@ -115,6 +133,7 @@ describe("SerializedCodeAgentAdapter", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     withActiveSpanCalls.length = 0;
+    agentOptions.length = 0;
     // Pin the timeout explicitly so the test doesn't rely on ambient env.
     // Stubbed, not assigned: a raw assignment here outlives the file and
     // reaches whatever else shares this vitest worker.
@@ -388,6 +407,26 @@ describe("SerializedCodeAgentAdapter", () => {
 
       const fetchOptions = mockFetch.mock.calls[0]![1];
       expect(fetchOptions.signal).toBeInstanceOf(AbortSignal);
+    });
+
+    // The abort signal above is not the only deadline in play: undici's own
+    // headersTimeout lives on the dispatcher and defaults to 300s, so without
+    // one sized to this adapter's deadline a longer run dies at 300s no matter
+    // how far out the abort is armed.
+    it("passes a dispatcher whose headers timeout matches the adapter's own fetch timeout", async () => {
+      const adapter = new SerializedCodeAgentAdapter({
+        config: defaultConfig,
+        nlpServiceUrl: nlpServiceUrl,
+        projectApiKey: apiKey,
+      });
+      await adapter.call(defaultInput);
+
+      const fetchOptions = mockFetch.mock.calls[0]![1];
+      expect(fetchOptions.dispatcher).toBeDefined();
+      expect(agentOptions.at(-1)?.headersTimeout).toBeGreaterThan(300_000);
+      expect(agentOptions.at(-1)?.headersTimeout).toBe(
+        agentOptions.at(-1)?.bodyTimeout,
+      );
     });
 
     it("sets run_evaluations to false and do_not_trace to true", async () => {

--- a/platform/app/src/server/scenarios/execution/serialized-adapters/__tests__/code-agent.adapter.unit.test.ts
+++ b/platform/app/src/server/scenarios/execution/serialized-adapters/__tests__/code-agent.adapter.unit.test.ts
@@ -4,6 +4,7 @@
 
 import { type AgentInput, AgentRole } from "@langwatch/scenario";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { closeNlpFetchDispatchers } from "../../../../nlpgo/timeouts";
 import type { CodeAgentData } from "../../types";
 
 // Capture withActiveSpan calls so the timeout/error paths can be verified.
@@ -130,10 +131,16 @@ describe("SerializedCodeAgentAdapter", () => {
     scenarioConfig: {} as AgentInput["scenarioConfig"],
   };
 
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.clearAllMocks();
     withActiveSpanCalls.length = 0;
     agentOptions.length = 0;
+    // createNlpFetchDispatcher now memoizes by timeoutMs at module scope
+    // (nlpgo/timeouts.ts). Without clearing the cache here, a dispatcher
+    // built by an earlier test for the same timeoutMs is returned again
+    // without touching the mocked undici.Agent constructor, so agentOptions
+    // stays empty and this test's assertions see stale/undefined values.
+    await closeNlpFetchDispatchers();
     // Pin the timeout explicitly so the test doesn't rely on ambient env.
     // Stubbed, not assigned: a raw assignment here outlives the file and
     // reaches whatever else shares this vitest worker.

--- a/platform/app/src/server/scenarios/execution/serialized-adapters/__tests__/workflow-agent.adapter.unit.test.ts
+++ b/platform/app/src/server/scenarios/execution/serialized-adapters/__tests__/workflow-agent.adapter.unit.test.ts
@@ -4,6 +4,7 @@
 
 import { type AgentInput, AgentRole } from "@langwatch/scenario";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { closeNlpFetchDispatchers } from "../../../../nlpgo/timeouts";
 import type { WorkflowAgentData } from "../../types";
 
 vi.mock("@langwatch/observability/tracing", () => ({
@@ -122,9 +123,15 @@ describe("SerializedWorkflowAgentAdapter", () => {
     scenarioConfig: {} as AgentInput["scenarioConfig"],
   };
 
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.clearAllMocks();
     agentOptions.length = 0;
+    // createNlpFetchDispatcher now memoizes by timeoutMs at module scope
+    // (nlpgo/timeouts.ts). Without clearing the cache here, a dispatcher
+    // built by an earlier test for the same timeoutMs is returned again
+    // without touching the mocked undici.Agent constructor, so agentOptions
+    // stays empty and this test's assertions see stale/undefined values.
+    await closeNlpFetchDispatchers();
     // Pin the timeout explicitly so the test doesn't rely on ambient env.
     // Stubbed, not assigned: a raw assignment here outlives the file and
     // reaches whatever else shares this vitest worker.

--- a/platform/app/src/server/scenarios/execution/serialized-adapters/__tests__/workflow-agent.adapter.unit.test.ts
+++ b/platform/app/src/server/scenarios/execution/serialized-adapters/__tests__/workflow-agent.adapter.unit.test.ts
@@ -24,6 +24,24 @@ const mockInjectTraceContextHeaders = vi.mocked(injectTraceContextHeaders);
 const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
 
+// Undici's Agent does not read back the timeouts it was constructed with, so
+// the only way to assert on the dispatcher the adapter passes is to record the
+// constructor's arguments. The global fetch above stays the interception point.
+const agentOptions = vi.hoisted(() => [] as Record<string, unknown>[]);
+
+vi.mock("undici", async () => {
+  const actual = await vi.importActual<typeof import("undici")>("undici");
+  return {
+    ...actual,
+    Agent: class RecordingAgent extends actual.Agent {
+      constructor(opts?: Record<string, unknown>) {
+        agentOptions.push(opts ?? {});
+        super(opts);
+      }
+    },
+  };
+});
+
 describe("SerializedWorkflowAgentAdapter", () => {
   /** Minimal published workflow DSL with an entry node, a signature node, and an end node. */
   const defaultDsl: Record<string, unknown> = {
@@ -106,6 +124,7 @@ describe("SerializedWorkflowAgentAdapter", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    agentOptions.length = 0;
     // Pin the timeout explicitly so the test doesn't rely on ambient env.
     // Stubbed, not assigned: a raw assignment here outlives the file and
     // reaches whatever else shares this vitest worker.
@@ -599,6 +618,24 @@ describe("SerializedWorkflowAgentAdapter", () => {
       vi.stubEnv("NLPGO_ENGINE_CODE_BLOCK_TIMEOUT_SECONDS", "1200");
 
       expect(await abortsWithin(900_001)).toBe(true);
+    });
+
+    // The abort deadline is only one of the two clocks on this call: undici's
+    // own headersTimeout lives on the dispatcher and defaults to 300s, which no
+    // AbortSignal can raise. A run past 300s died with HeadersTimeoutError well
+    // inside the 630s abort, so the dispatcher must carry the same deadline.
+    it("passes a dispatcher whose headers timeout matches the 630s default deadline", async () => {
+      const adapter = new SerializedWorkflowAgentAdapter({
+        config: defaultConfig,
+        nlpServiceUrl,
+        projectApiKey: apiKey,
+      });
+      await adapter.call(defaultInput);
+
+      const fetchOptions = mockFetch.mock.calls[0]![1];
+      expect(fetchOptions.dispatcher).toBeDefined();
+      expect(agentOptions.at(-1)?.headersTimeout).toBe(630_000);
+      expect(agentOptions.at(-1)?.bodyTimeout).toBe(630_000);
     });
   });
 

--- a/platform/app/src/server/scenarios/execution/serialized-adapters/code-agent.adapter.ts
+++ b/platform/app/src/server/scenarios/execution/serialized-adapters/code-agent.adapter.ts
@@ -397,7 +397,9 @@ export class SerializedCodeAgentAdapter extends SerializedAgentAdapter {
               headers: { "Content-Type": "application/json" },
               body: JSON.stringify(event),
               signal: controller.signal,
-              dispatcher: createNlpFetchDispatcher(fetchTimeoutMs),
+              dispatcher: createNlpFetchDispatcher({
+                timeoutMs: fetchTimeoutMs,
+              }),
             };
             response = await fetch(url, fetchInit);
           } catch (fetchError) {

--- a/platform/app/src/server/scenarios/execution/serialized-adapters/code-agent.adapter.ts
+++ b/platform/app/src/server/scenarios/execution/serialized-adapters/code-agent.adapter.ts
@@ -17,6 +17,8 @@ import { randomBytes } from "crypto";
 import { getLangWatchTracer } from "langwatch";
 import { LATEST_SPEC_VERSION } from "../../../../optimization_studio/types/dsl";
 import {
+  createNlpFetchDispatcher,
+  type FetchInitWithDispatcher,
   NLP_FETCH_HEADROOM_MS,
   resolveFloorFetchTimeoutMs,
   resolveMaxFetchTimeoutMs,
@@ -390,12 +392,14 @@ export class SerializedCodeAgentAdapter extends SerializedAgentAdapter {
         try {
           let response: Response;
           try {
-            response = await fetch(url, {
+            const fetchInit: FetchInitWithDispatcher = {
               method: "POST",
               headers: { "Content-Type": "application/json" },
               body: JSON.stringify(event),
               signal: controller.signal,
-            });
+              dispatcher: createNlpFetchDispatcher(fetchTimeoutMs),
+            };
+            response = await fetch(url, fetchInit);
           } catch (fetchError) {
             if (timedOut) {
               span.setAttribute(

--- a/platform/app/src/server/scenarios/execution/serialized-adapters/workflow-agent.adapter.ts
+++ b/platform/app/src/server/scenarios/execution/serialized-adapters/workflow-agent.adapter.ts
@@ -23,6 +23,8 @@ import type { AgentInput } from "@langwatch/scenario";
 import { AgentRole } from "@langwatch/scenario";
 import { randomBytes } from "crypto";
 import {
+  createNlpFetchDispatcher,
+  type FetchInitWithDispatcher,
   resolveFloorFetchTimeoutMs,
   resolveMaxFetchTimeoutMs,
 } from "../../../nlpgo/timeouts";
@@ -225,17 +227,23 @@ export class SerializedWorkflowAgentAdapter extends SerializedAgentAdapter {
     };
 
     const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), fetchTimeoutMs());
+    const timeoutMs = fetchTimeoutMs();
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
 
     try {
       let response: Response;
       try {
-        response = await fetch(`${this.nlpServiceUrl}/go/studio/execute_sync`, {
+        const fetchInit: FetchInitWithDispatcher = {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify(event),
           signal: controller.signal,
-        });
+          dispatcher: createNlpFetchDispatcher(timeoutMs),
+        };
+        response = await fetch(
+          `${this.nlpServiceUrl}/go/studio/execute_sync`,
+          fetchInit,
+        );
       } catch (fetchError) {
         const cause =
           fetchError instanceof Error && "cause" in fetchError

--- a/platform/app/src/server/scenarios/execution/serialized-adapters/workflow-agent.adapter.ts
+++ b/platform/app/src/server/scenarios/execution/serialized-adapters/workflow-agent.adapter.ts
@@ -231,34 +231,11 @@ export class SerializedWorkflowAgentAdapter extends SerializedAgentAdapter {
     const timeout = setTimeout(() => controller.abort(), timeoutMs);
 
     try {
-      let response: Response;
-      try {
-        const fetchInit: FetchInitWithDispatcher = {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(event),
-          signal: controller.signal,
-          dispatcher: createNlpFetchDispatcher(timeoutMs),
-        };
-        response = await fetch(
-          `${this.nlpServiceUrl}/go/studio/execute_sync`,
-          fetchInit,
-        );
-      } catch (fetchError) {
-        const cause =
-          fetchError instanceof Error && "cause" in fetchError
-            ? ` (cause: ${String(
-                (fetchError as Error & { cause?: unknown }).cause,
-              )})`
-            : "";
-        throw new Error(
-          `Workflow execution failed: fetch to ${this.nlpServiceUrl}/go/studio/execute_sync failed - ${
-            fetchError instanceof Error
-              ? fetchError.message
-              : String(fetchError)
-          }${cause}`,
-        );
-      }
+      const response = await this.postExecuteSync(
+        JSON.stringify(event),
+        controller.signal,
+        timeoutMs,
+      );
 
       if (!response.ok) {
         let errorMessage = "";
@@ -288,6 +265,38 @@ export class SerializedWorkflowAgentAdapter extends SerializedAgentAdapter {
       return result.result;
     } finally {
       clearTimeout(timeout);
+    }
+  }
+
+  private async postExecuteSync(
+    body: string,
+    signal: AbortSignal,
+    timeoutMs: number,
+  ): Promise<Response> {
+    try {
+      const fetchInit: FetchInitWithDispatcher = {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body,
+        signal,
+        dispatcher: createNlpFetchDispatcher(timeoutMs),
+      };
+      return await fetch(
+        `${this.nlpServiceUrl}/go/studio/execute_sync`,
+        fetchInit,
+      );
+    } catch (fetchError) {
+      const cause =
+        fetchError instanceof Error && "cause" in fetchError
+          ? ` (cause: ${String(
+              (fetchError as Error & { cause?: unknown }).cause,
+            )})`
+          : "";
+      throw new Error(
+        `Workflow execution failed: fetch to ${this.nlpServiceUrl}/go/studio/execute_sync failed - ${
+          fetchError instanceof Error ? fetchError.message : String(fetchError)
+        }${cause}`,
+      );
     }
   }
 

--- a/platform/app/src/server/scenarios/execution/serialized-adapters/workflow-agent.adapter.ts
+++ b/platform/app/src/server/scenarios/execution/serialized-adapters/workflow-agent.adapter.ts
@@ -231,11 +231,11 @@ export class SerializedWorkflowAgentAdapter extends SerializedAgentAdapter {
     const timeout = setTimeout(() => controller.abort(), timeoutMs);
 
     try {
-      const response = await this.postExecuteSync(
-        JSON.stringify(event),
-        controller.signal,
+      const response = await this.postExecuteSync({
+        body: JSON.stringify(event),
+        signal: controller.signal,
         timeoutMs,
-      );
+      });
 
       if (!response.ok) {
         let errorMessage = "";
@@ -268,18 +268,22 @@ export class SerializedWorkflowAgentAdapter extends SerializedAgentAdapter {
     }
   }
 
-  private async postExecuteSync(
-    body: string,
-    signal: AbortSignal,
-    timeoutMs: number,
-  ): Promise<Response> {
+  private async postExecuteSync({
+    body,
+    signal,
+    timeoutMs,
+  }: {
+    body: string;
+    signal: AbortSignal;
+    timeoutMs: number;
+  }): Promise<Response> {
     try {
       const fetchInit: FetchInitWithDispatcher = {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body,
         signal,
-        dispatcher: createNlpFetchDispatcher(timeoutMs),
+        dispatcher: createNlpFetchDispatcher({ timeoutMs }),
       };
       return await fetch(
         `${this.nlpServiceUrl}/go/studio/execute_sync`,

--- a/platform/app/src/server/workers/startWorkers.ts
+++ b/platform/app/src/server/workers/startWorkers.ts
@@ -92,6 +92,18 @@ async function bootScenarioProcessor(
   logger.info("scenario processor ready");
 }
 
+// NLP fetch dispatchers (undici Agents, memoized per timeoutMs by
+// ~/server/nlpgo/timeouts.ts) hold pooled sockets to nlpgo open for the
+// scenario adapters bootScenarioProcessor just started. Nothing to start
+// here, only a teardown to register, so every dispatcher the process built
+// gets closed on shutdown instead of leaking its connection pool.
+async function bootNlpFetchDispatcherTeardown(
+  shutdownHandles: ShutdownHandles,
+): Promise<void> {
+  const { closeNlpFetchDispatchers } = await import("~/server/nlpgo/timeouts");
+  shutdownHandles.push(() => closeNlpFetchDispatchers());
+}
+
 // Per-tenant enqueue-rate anomaly detector (surfaces runaway tenants on
 // the Ops page).
 async function bootAnomalyWorker(
@@ -463,10 +475,10 @@ async function respondToLivenessThread(
 
 /**
  * Boots the background worker stack: ingestion pullers, topic clustering,
- * ClickHouse storage-stats collection, the scenario executor pool, the
- * enqueue-rate anomaly detector, the governance spend-spike detector, the
- * self-hosted usage-stats telemetry, and (optionally) the Prometheus metrics
- * HTTP server.
+ * ClickHouse storage-stats collection, the scenario executor pool (plus its
+ * NLP fetch dispatcher cleanup), the enqueue-rate anomaly detector, the
+ * governance spend-spike detector, the self-hosted usage-stats telemetry,
+ * and (optionally) the Prometheus metrics HTTP server.
  *
  * Assumes the App has ALREADY been initialized by the caller with a
  * worker-capable role — `initializeWorkerApp()` for the standalone deployment,
@@ -512,6 +524,7 @@ export async function startWorkers(
     // execution; there is no separate queue worker to boot.
     await bootStorageStatsCollection(shutdownHandles);
     await bootScenarioProcessor(shutdownHandles);
+    await bootNlpFetchDispatcherTeardown(shutdownHandles);
     // Langy turns self-drive: the process outbox dispatches to the Go manager,
     // which pushes signed frames to the relay. No in-process pool/executor to
     // boot; heartbeat recovery belongs to the direct liveness subscriber.


### PR DESCRIPTION
## Reviewer cockpit

| | |
|---|---|
| **Risk** | Low — two call sites, additive |
| **Files** | 6 (2 adapters, 1 shared helper, 3 test files) |
| **Behaviour change** | Scenario runs against nlp-go can now actually last the full 630s the code already asked for |
| **Env vars added** | **Zero** |
| **Read this first** | `platform/app/src/server/nlpgo/timeouts.ts` → `createNlpFetchDispatcher` |

## Why

lw#7640 raised the scenario fetch deadline to 630s (`resolveFloorFetchTimeoutMs`). It never took effect. Production still fails at 300s:

```
HeadersTimeoutError: Headers Timeout Error
  code: 'UND_ERR_HEADERS_TIMEOUT'
  at SerializedCodeAgentAdapter
```

Both adapters call the **bare global `fetch`** and arm only an `AbortController`. But undici's `headersTimeout`/`bodyTimeout` (300_000ms each, by default) live on the **dispatcher**, not on the request — an `AbortSignal` cannot raise them. Past 300s on a still-open connection undici throws, no matter how far out the abort is armed.

A user probe with `time.sleep(615)` died at **300,815ms**. That is the undici default, not our 630s deadline.

## What changed

- **Pass a dispatcher with matching timeouts** at both `fetch` call sites — decision: derive `headersTimeout`/`bodyTimeout` from the *existing* `fetchTimeoutMs()` value, so there is exactly one number. Alternative not taken: a new `UNDICI_HEADERS_TIMEOUT_MS` env var — consequence would be a second knob that can silently disagree with the first.
- **One shared factory**, `createNlpFetchDispatcher({ timeoutMs })`, in `timeouts.ts` next to the constants it must agree with. Alternative not taken: constructing an `Agent` inline in each adapter — consequence: two copies to drift apart.
- **The factory memoizes by `timeoutMs`** in a module-level `Map`. An undici `Agent` owns its own connection pool, so the first version of this PR opened a fresh pool per request and never destroyed it — a socket/FD leak that also defeated keep-alive to nlp-go. Caught in review before it shipped. Decision: no eviction policy, because `timeoutMs` derives from env-resolved config and its key cardinality is small and fixed for the process's life. Alternative not taken: an LRU/TTL cache — consequence: machinery guarding a set that cannot grow.
- **`closeNlpFetchDispatchers()` is registered on the existing `shutdownHandles` array** in `startWorkers.ts`, immediately after `bootScenarioProcessor`. Alternative not taken: a module-scope `process.on('SIGTERM')` — consequence: a second, competing shutdown path next to the one the workers already have.
- **`FetchInitWithDispatcher` type** widens the DOM-lib `RequestInit` to admit undici's `dispatcher`. The init object is hoisted to a typed `const` rather than passed inline, because a fresh object literal passed directly to `fetch()` trips TS2769 excess-property checking.

## How it works

`fetchTimeoutMs()` already resolves to `Math.min(resolveMaxFetchTimeoutMs(), resolveFloorFetchTimeoutMs())` = `min(900_000, 630_000)` = **630_000ms**. That same number now feeds three things instead of one: the `setTimeout` abort, and undici's `headersTimeout` and `bodyTimeout`. No new configuration surface.

## Deployment Impact

Scenario requests to nlp-go may now hold a socket open for up to 630s where they previously died at 300s. This is the intended behaviour of lw#7640, arriving for the first time. Any proxy hop with its own sub-630s idle timeout (ingress, ALB, envoy) becomes the next binding ceiling — **not ruled out by this PR**, tracked as a follow-up in https://github.com/langwatch/langwatch/issues/7707. Connections to nlp-go are now pooled and reused across scenario requests instead of each request opening its own pool. Expect fewer open sockets under load, not more.

On teardown, precisely: the dispatcher cache is a module-level `Map`, so it is **per-process**, and there are two processes that build dispatchers. The app/worker process builds them via `agent-test-turn.ts`, and those are closed by the `closeNlpFetchDispatchers()` handle registered on `shutdownHandles`. Scenario execution proper runs in a **separate spawned child** (`scenario-child-process.ts`, the process named in the original production stack trace); it holds its own cache, which the worker's shutdown handle cannot reach and which is released when the child exits. The memoization — the actual leak fix — applies in both.

No env var, chart, or Terraform change is required to deploy this.

<!-- no-ui-surface -->

## Human verification

```
$ pnpm vitest run .../code-agent.adapter.unit.test.ts .../workflow-agent.adapter.unit.test.ts .../timeouts.unit.test.ts
Test Files  3 passed (3)
     Tests  110 passed (110)
```

Red-green. **Correcting an earlier version of this section:** it reported `Tests 2 failed | 94 passed (96)` from a mutation that deleted the matching *line*. In `code-agent.adapter.ts` that line opens a multi-line property, so deleting it left dangling syntax — that file failed to **parse**, not to **assert**. A parse error proves nothing about assertion strength, so that figure was not valid evidence. Re-measured at `0c10d7e0d7`, each adapter mutated as a whole construct and run in isolation, with `tsc` confirming the mutated file still compiles:

```
# code-agent: full 3-line `dispatcher:` property removed
SYNTAX_ERRS_IN_FILE=0
AssertionError: expected undefined to be defined
Tests  1 failed | 61 passed (62)

# workflow-agent: self-contained `dispatcher:` line removed
SYNTAX_ERRS_IN_FILE=0
AssertionError: expected undefined to be defined
Tests  1 failed | 33 passed (34)
```

Both files restored byte-identical; working tree clean at `0c10d7e0d7`. The conclusion (the dispatcher assertions are non-vacuous) holds — the earlier evidence for it did not.

## How I can prove I was successful

All figures below were re-measured at head `0c10d7e0d7` in a worktree with codegen present.

| Claim | Status |
|---|---|
| Timeout tests fail without the change (non-vacuous) | **proven** — deleting `dispatcher:` from the call sites fails 2 tests asserting `headersTimeout === 630_000` |
| Memoization tests fail without the change (non-vacuous) | **proven** — deleting the cache lookup fails exactly 1 test on `Object.is equality` |
| No new type errors | **proven** — `typecheck`, `typecheck:tests` and `typecheck:all` each exit 0 with 0 errors |
| Lint clean | **proven** — the CI gate (`biome-new-violations.sh` vs merge-base, *not* `pnpm lint`) exits 0: base 3386, head 3385, net −1 |
| Tests green | **proven** — vitest 239/239, exit 0 |
| Zero new env vars | **proven** — `git diff 0602dda468..HEAD` adds no `process.env` reference |
| Resolves the production incident when deployed | **claimed** — no live nlp-go endpoint available to reproduce end-to-end |

An earlier revision of this section cited a typecheck baseline of "2278 errors on base and head". That figure was measured in a worktree missing generated files (Prisma client, `tasks.generated.ts`); it was environment noise on both sides, not a clean delta. It has been replaced with counts from a fully generated tree.

## Anything surprising?

Yes — two things.

1. The 630s deadline from lw#7640 has been **dead code since it merged**. Nothing was wrong with the arithmetic; the value simply had no path to the socket. Raising a client deadline while leaving the dispatcher at its default is a silent no-op, which is why the earlier fix looked correct in review and changed nothing in production.
2. `headersTimeout` and `bodyTimeout` are *separate* 300s budgets. Only `headersTimeout` fired here, because nlp-go held the connection without sending a status line. Both are set, so a slow-body variant of the same failure is covered too.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timeout handling for NLP requests, allowing longer operations to complete reliably.
  * Ensured request header and response body timeouts consistently match configured deadlines.
  * Applied consistent timeout behavior across code-agent and workflow-agent operations.
  * Improved connection cleanup during normal and interrupted worker shutdowns.

* **Tests**
  * Added coverage for dispatcher creation, timeout configuration, reuse, and cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



