### PR TITLE
fix(authz): concurrent prebuild for the Grant roleKey index

### DIFF
--- a/platform/app/package.json
+++ b/platform/app/package.json
@@ -55,7 +55,7 @@
     "task:migrate-object-storage": "NODE_OPTIONS=--max-old-space-size=4096 pnpm run task migrateObjectStorage",
     "prisma:generate:typescript": "pnpm prisma generate",
     "prisma:generate:migration": "pnpm prisma migrate dev --create-only",
-    "prisma:migrate": "sh -c 'if [ \"$SKIP_PRISMA_MIGRATE\" != \"true\" ]; then pnpm prisma migrate deploy; else echo \"Skipping Prisma migrations\"; fi'",
+    "prisma:migrate": "sh -c 'if [ \"$SKIP_PRISMA_MIGRATE\" != \"true\" ]; then node scripts/prisma-premigrate.mjs && pnpm prisma migrate deploy; else echo \"Skipping Prisma migrations\"; fi'",
     "prisma:seed": "tsx --env-file-if-exists=.env --env-file-if-exists=.env.portless prisma/seed.ts",
     "seed:sample-traces": "tsx --env-file-if-exists=.env --env-file-if-exists=.env.portless scripts/seed-sample-traces.ts",
     "seed:realistic-platform": "tsx --env-file-if-exists=.env --env-file-if-exists=.env.portless scripts/seed-realistic-platform-data.ts",

--- a/platform/app/scripts/__tests__/prisma-premigrate.integration.test.ts
+++ b/platform/app/scripts/__tests__/prisma-premigrate.integration.test.ts
@@ -1,0 +1,91 @@
+/**
+ * @vitest-environment node
+ *
+ * The concurrent index prebuild must be a no-op everywhere except the one
+ * case it exists for: an installation with data whose migration has not run
+ * yet. There it must produce a VALID index without a blocking build, so the
+ * migration's IF NOT EXISTS then skips the blocking path entirely.
+ */
+import pg from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+// @ts-expect-error plain .mjs module, runs on plain node in production
+import {
+  CONCURRENT_PREBUILDS,
+  prebuildOne,
+  schemaFromUrl,
+} from "../prisma-premigrate.mjs";
+
+const spec = CONCURRENT_PREBUILDS[0];
+let client: pg.Client;
+
+beforeAll(async () => {
+  client = new pg.Client({ connectionString: process.env.DATABASE_URL });
+  await client.connect();
+  const schema = schemaFromUrl(process.env.DATABASE_URL ?? "");
+  if (schema) await client.query(`SET search_path TO "${schema}", public`);
+});
+
+afterAll(async () => {
+  await client.end();
+});
+
+describe("prisma-premigrate concurrent index prebuild", () => {
+  describe("given the migration is already recorded as applied", () => {
+    it("does nothing", async () => {
+      expect(await prebuildOne(client, spec)).toBe("skip-applied");
+    });
+  });
+
+  describe("given a fresh install where the table does not exist yet", () => {
+    it("leaves the build to the migration itself", async () => {
+      expect(
+        await prebuildOne(client, { ...spec, table: "NoSuchTablePremigrate" }),
+      ).toBe("skip-fresh-install");
+    });
+  });
+
+  describe("given an existing installation the migration has not reached", () => {
+    let savedRow: Record<string, unknown>;
+
+    beforeAll(async () => {
+      const res = await client.query(
+        "DELETE FROM _prisma_migrations WHERE migration_name = $1 RETURNING *",
+        [spec.migration],
+      );
+      savedRow = res.rows[0];
+      await client.query(`DROP INDEX IF EXISTS "${spec.index}"`);
+    });
+
+    afterAll(async () => {
+      // Put the world back: the prebuilt index satisfies the migration, and
+      // the record row is restored verbatim for every suite that follows.
+      if (savedRow) {
+        const cols = Object.keys(savedRow);
+        await client.query(
+          `INSERT INTO _prisma_migrations (${cols.map((c) => `"${c}"`).join(",")})
+           VALUES (${cols.map((_, i) => `$${i + 1}`).join(",")})
+           ON CONFLICT DO NOTHING`,
+          cols.map((c) => savedRow[c]),
+        );
+      }
+    });
+
+    it("builds the index concurrently and it comes out valid", async () => {
+      expect(await prebuildOne(client, spec)).toBe("built");
+      const check = await client.query(
+        `SELECT i.indisvalid AS valid
+           FROM pg_class c JOIN pg_index i ON i.indexrelid = c.oid
+          WHERE c.relname = $1`,
+        [spec.index],
+      );
+      expect(check.rows[0]?.valid).toBe(true);
+    });
+
+    describe("when it runs again after a successful prebuild", () => {
+      it("recognizes its own work and skips", async () => {
+        expect(await prebuildOne(client, spec)).toBe("skip-prebuilt");
+      });
+    });
+  });
+});

--- a/platform/app/scripts/prisma-premigrate.mjs
+++ b/platform/app/scripts/prisma-premigrate.mjs
@@ -1,0 +1,175 @@
+/**
+ * Runs BEFORE `prisma migrate deploy` (wired into the `prisma:migrate`
+ * package.json script), so every caller of that script — the Docker boot
+ * path, the embedded server's migrate service, CI — gets it for free.
+ *
+ * Why it exists: some indexes are too expensive to build with a plain
+ * CREATE INDEX on a live installation. Prisma wraps each migration in a
+ * transaction, and CREATE INDEX CONCURRENTLY refuses to run inside one, so
+ * the migration file itself can only ever do the blocking build. This
+ * script is the nontransactional half of that pair: on an installation
+ * that already has data, it builds the index CONCURRENTLY (writes keep
+ * flowing) before the migration runs, and the migration's IF NOT EXISTS
+ * then no-ops. On a fresh install the target table does not exist yet, the
+ * script skips, and the blocking build inside the migration is instant
+ * because the table is empty.
+ *
+ * Failure is loud on purpose. If the concurrent build fails on a populated
+ * installation, the script drops the invalid leftover index (a failed
+ * CREATE INDEX CONCURRENTLY leaves one behind, and IF NOT EXISTS would
+ * silently match it) and exits non-zero, which stops `migrate deploy` from
+ * running the blocking build as a surprise fallback. What it never does is
+ * hide a failure and let the deployment take a lock nobody planned for.
+ *
+ * Plain .mjs on plain `node`, because the production image prunes
+ * devDependencies and tsx is one. `pg` is a runtime dependency.
+ */
+import pg from "pg";
+
+/**
+ * One entry per index that must never be built with a blocking CREATE INDEX
+ * on a populated installation. `migration` is the Prisma migration that
+ * carries the IF NOT EXISTS fallback; once it is recorded as applied there
+ * is nothing left to prebuild.
+ */
+export const CONCURRENT_PREBUILDS = [
+  {
+    migration: "20260831120000_grant_role_key_live_index",
+    table: "Grant",
+    index: "Grant_organizationId_roleKey_live_idx",
+    build: `CREATE INDEX CONCURRENTLY IF NOT EXISTS "Grant_organizationId_roleKey_live_idx"
+  ON "Grant" ("organizationId", "roleKey")
+  WHERE "revokedAt" IS NULL`,
+  },
+];
+
+/**
+ * Serializes replicas booting at once. Without this, pod B's IF NOT EXISTS
+ * matches pod A's still-building (invalid) index, skips, and B's
+ * `migrate deploy` records the migration while the index is not yet usable.
+ * Session-level (not xact) because CONCURRENTLY runs outside transactions;
+ * released on disconnect.
+ */
+const ADVISORY_LOCK_SQL =
+  "SELECT pg_advisory_lock(hashtext('prisma-premigrate'))";
+
+/** @returns {"skip-fresh-install"|"skip-applied"|"skip-prebuilt"|"built"} */
+export async function prebuildOne(client, spec) {
+  const table = await client.query("SELECT to_regclass($1) AS t", [
+    `"${spec.table}"`,
+  ]);
+  if (table.rows[0].t === null) return "skip-fresh-install";
+
+  const migrations = await client.query(
+    "SELECT to_regclass('_prisma_migrations') AS t",
+  );
+  if (migrations.rows[0].t !== null) {
+    const applied = await client.query(
+      "SELECT 1 FROM _prisma_migrations WHERE migration_name = $1 AND finished_at IS NOT NULL",
+      [spec.migration],
+    );
+    if (applied.rowCount > 0) return "skip-applied";
+  }
+
+  const existing = await client.query(
+    `SELECT i.indisvalid AS valid
+       FROM pg_class c
+       JOIN pg_index i ON i.indexrelid = c.oid
+      WHERE c.relname = $1`,
+    [spec.index],
+  );
+  if (existing.rowCount > 0) {
+    if (existing.rows[0].valid) return "skip-prebuilt";
+    // Leftover from a failed concurrent build (possibly a previous run of
+    // this very script). Invalid indexes are never used by the planner but
+    // WOULD satisfy IF NOT EXISTS — drop before rebuilding. The drop is a
+    // catalog unlink, sub-millisecond.
+    await client.query(`DROP INDEX IF EXISTS "${spec.index}"`);
+  }
+
+  try {
+    await client.query(spec.build);
+  } catch (err) {
+    await client
+      .query(`DROP INDEX IF EXISTS "${spec.index}"`)
+      .catch(() => undefined);
+    throw err;
+  }
+
+  const verify = await client.query(
+    `SELECT i.indisvalid AS valid
+       FROM pg_class c
+       JOIN pg_index i ON i.indexrelid = c.oid
+      WHERE c.relname = $1`,
+    [spec.index],
+  );
+  if (verify.rowCount === 0 || !verify.rows[0].valid) {
+    await client
+      .query(`DROP INDEX IF EXISTS "${spec.index}"`)
+      .catch(() => undefined);
+    throw new Error(
+      `concurrent build of "${spec.index}" finished but the index is not valid`,
+    );
+  }
+  return "built";
+}
+
+/**
+ * Prisma reads the `schema` query param of DATABASE_URL and sets
+ * search_path from it; node-postgres ignores it. Mirror Prisma so
+ * to_regclass and _prisma_migrations resolve in the same schema the
+ * migrations run in.
+ */
+export function schemaFromUrl(databaseUrl) {
+  try {
+    return new URL(databaseUrl).searchParams.get("schema");
+  } catch {
+    return null;
+  }
+}
+
+export async function run(databaseUrl, log = console.error) {
+  if (!databaseUrl) {
+    log("[premigrate] DATABASE_URL not set — skipping (migrate deploy will report it)");
+    return;
+  }
+  const client = new pg.Client({ connectionString: databaseUrl });
+  try {
+    await client.connect();
+  } catch (err) {
+    // Unreachable database is migrate deploy's error to raise, with its own
+    // wording — this script only steps in when a prebuild is possible.
+    log(`[premigrate] cannot connect — skipping (${err.message})`);
+    return;
+  }
+  try {
+    const schema = schemaFromUrl(databaseUrl);
+    if (schema) {
+      await client.query(`SET search_path TO "${schema}", public`);
+    }
+    await client.query(ADVISORY_LOCK_SQL);
+    for (const spec of CONCURRENT_PREBUILDS) {
+      const started = Date.now();
+      const outcome = await prebuildOne(client, spec);
+      log(
+        `[premigrate] ${spec.index}: ${outcome}${
+          outcome === "built" ? ` in ${Date.now() - started}ms` : ""
+        }`,
+      );
+    }
+  } finally {
+    await client.end().catch(() => undefined);
+  }
+}
+
+const invokedDirectly =
+  process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).href;
+if (invokedDirectly) {
+  run(process.env.DATABASE_URL).catch((err) => {
+    console.error(`[premigrate] FAILED: ${err.message}`);
+    console.error(
+      "[premigrate] refusing to fall through to a blocking CREATE INDEX — fix the error above and redeploy",
+    );
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
Addresses the P1 raised on #7703 after merge.

**Problem.** The merged migration runs a plain `CREATE INDEX` on `Grant`. That blocks writes for the length of the build — and `Grant` is the live authorization projection, so a revoke queued behind the build keeps authorizing with its old state. On a saturated instance that window is single-digit seconds, unbounded by the local benchmark.

**Fix.** A nontransactional prebuild step wired into `prisma:migrate`, so every deployment path gets it before `migrate deploy` runs:

- **Existing install, migration not applied:** builds the index with `CREATE INDEX CONCURRENTLY` — writes keep flowing — and the migration's `IF NOT EXISTS` then no-ops.
- **Fresh install:** target table doesn't exist yet → skip; the blocking build inside the migration is instant on an empty table.
- **Failed concurrent build:** drops the invalid leftover index (`IF NOT EXISTS` would silently match it) and exits non-zero — the deploy stops loudly instead of silently taking the blocking lock.
- **Racing replicas:** serialized on a session advisory lock so `IF NOT EXISTS` never matches a sibling's still-building invalid index.

Plain `.mjs` on plain `node` because the production image prunes devDependencies (tsx isn't there); `pg` is a runtime dependency. The applied migration file is untouched — no checksum drift for installs that already ran it.

**Tests.** `scripts/__tests__/prisma-premigrate.integration.test.ts` (pg-integration): already-applied no-op, fresh-install skip, concurrent build produces a valid index, idempotent re-run. All passing. CLI smoke-tested: applied DB → skip + exit 0; unreachable DB → skip + exit 0 (migrate deploy raises its own error).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Database upgrades now prebuild expensive indexes concurrently, reducing disruption on populated installations.
  * Existing, fresh, and already-upgraded installations are handled safely during deployment.

* **Reliability**
  * Index preparation verifies successful completion and cleans up incomplete attempts.
  * Concurrent application instances are coordinated to prevent conflicting upgrade work.

* **Tests**
  * Added integration coverage for skipped, completed, and rebuilt index scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->