### PR TITLE
fix(system-migrations): answer the user cohort from the user's own memberships

### DIFF
--- a/platform/app/src/server/app-layer/system-migrations/__tests__/runtime-enrollment.unit.test.ts
+++ b/platform/app/src/server/app-layer/system-migrations/__tests__/runtime-enrollment.unit.test.ts
@@ -14,11 +14,13 @@ const stubs = vi.hoisted(() => {
   const warnings: Array<[string, unknown, unknown]> = [];
   const organizationUserFindMany = vi.fn().mockResolvedValue([]);
   const organizationUserFindFirst = vi.fn().mockResolvedValue(null);
+  const userFindUnique = vi.fn().mockResolvedValue(null);
   return {
     enrollmentFindMany,
     enrollmentFindUnique,
     organizationUserFindMany,
     organizationUserFindFirst,
+    userFindUnique,
     warnings,
     prisma: {
       systemMigrationEnrollment: {
@@ -30,9 +32,11 @@ const stubs = vi.hoisted(() => {
       organization: {
         findMany: vi.fn().mockResolvedValue([]),
       },
-      // The user-rooted leg pages users the same way.
+      // The user-rooted leg pages users the same way; the cohort reads a
+      // candidate's memberships as a relation off their own row.
       user: {
         findMany: vi.fn().mockResolvedValue([]),
+        findUnique: userFindUnique,
       },
       organizationUser: {
         findMany: organizationUserFindMany,
@@ -44,11 +48,15 @@ const stubs = vi.hoisted(() => {
 
 /** Answers the cohort's per-user membership probes from a plain map. */
 function stubMemberships(memberships: Record<string, string[]>): void {
-  stubs.organizationUserFindMany.mockImplementation(
-    async ({ where }: { where: { userId: string } }) =>
-      (memberships[where.userId] ?? []).map((organizationId) => ({
-        organizationId,
-      })),
+  stubs.userFindUnique.mockImplementation(
+    async ({ where }: { where: { id: string } }) =>
+      where.id in memberships
+        ? {
+            orgMemberships: memberships[where.id]!.map((organizationId) => ({
+              organizationId,
+            })),
+          }
+        : null,
   );
 }
 
@@ -87,6 +95,7 @@ vi.mock("@langwatch/observability", async (importOriginal) => {
   };
 });
 
+import { guardOrganizationId } from "~/utils/dbOrganizationIdProtection";
 import { AUTHZ_ENGINE_MIGRATION_NAME } from "../../authz/migration-name";
 import { IDENTITY_IDENTIFIER_BACKFILL_MIGRATION_NAME } from "../../identity/migration-name";
 import {
@@ -95,6 +104,21 @@ import {
   runSystemMigrationTargetedPass,
   userMigrationPassCohort,
 } from "../runtime";
+
+// The production client refuses tenancy-unbounded queries (guardOrganizationId
+// in db.ts); route every stubbed delegate through the real guard so a query
+// shape that throws on cloud throws here too. The cohort probe once read
+// OrganizationUser by userId alone — a shape the guard rejects — and this
+// suite could not see that while the stubs bypassed the guard.
+for (const [delegateName, delegate] of Object.entries(stubs.prisma)) {
+  const model = delegateName.charAt(0).toUpperCase() + delegateName.slice(1);
+  for (const [action, fn] of Object.entries(delegate)) {
+    (delegate as Record<string, unknown>)[action] = (args: unknown) =>
+      guardOrganizationId({ model, action, args }, (params) =>
+        (fn as (a: unknown) => Promise<unknown>)(params.args),
+      );
+  }
+}
 
 describe("migrationPassCohort on cloud", () => {
   beforeEach(() => {
@@ -266,14 +290,18 @@ describe("userMigrationPassCohort on cloud", () => {
       await expect(
         cohort({ tenantId: "user_solo", migrationName: backfill }),
       ).resolves.toBe(false);
-      // Membership is probed by the user's own memberships alone — the
-      // enrolled set stays in memory and never rides along as an IN list
-      // (whose planning cost scales with every enrolled organization).
-      expect(stubs.organizationUserFindMany).toHaveBeenCalledWith(
+      // Membership is probed off the user's own row alone — the enrolled set
+      // stays in memory and never rides along as an IN list (whose planning
+      // cost scales with every enrolled organization). Reading it as a
+      // relation of the user is also what keeps the probe inside the
+      // organization guard: a top-level OrganizationUser read bounded only by
+      // userId has no admitted shape there.
+      expect(stubs.userFindUnique).toHaveBeenCalledWith(
         expect.objectContaining({
-          where: { userId: "user_sam" },
+          where: { id: "user_sam" },
         }),
       );
+      expect(stubs.organizationUserFindMany).not.toHaveBeenCalled();
       expect(stubs.organizationUserFindFirst).not.toHaveBeenCalled();
     });
   });
@@ -303,9 +331,10 @@ describe("userMigrationPassCohort on cloud", () => {
       // The regression #7709 guards against: one parameter per probe, no
       // organizationId filter, regardless of how many organizations are
       // enrolled.
-      for (const call of stubs.organizationUserFindMany.mock.calls) {
-        expect(call[0].where).toEqual({ userId: expect.any(String) });
+      for (const call of stubs.userFindUnique.mock.calls) {
+        expect(call[0].where).toEqual({ id: expect.any(String) });
       }
+      expect(stubs.organizationUserFindMany).not.toHaveBeenCalled();
       expect(stubs.organizationUserFindFirst).not.toHaveBeenCalled();
     });
   });
@@ -357,6 +386,7 @@ describe("userMigrationPassCohort on cloud", () => {
         }),
       ).resolves.toBe(false);
       // An empty enrolled set answers false before any membership probe.
+      expect(stubs.userFindUnique).not.toHaveBeenCalled();
       expect(stubs.organizationUserFindFirst).not.toHaveBeenCalled();
       expect(stubs.organizationUserFindMany).not.toHaveBeenCalled();
     });

--- a/platform/app/src/server/app-layer/system-migrations/__tests__/runtime-enrollment.unit.test.ts
+++ b/platform/app/src/server/app-layer/system-migrations/__tests__/runtime-enrollment.unit.test.ts
@@ -44,19 +44,11 @@ const stubs = vi.hoisted(() => {
 
 /** Answers the cohort's per-user membership probes from a plain map. */
 function stubMemberships(memberships: Record<string, string[]>): void {
-  stubs.organizationUserFindFirst.mockImplementation(
-    async ({
-      where,
-    }: {
-      where: { userId: string; organizationId: { in: string[] } };
-    }) => {
-      const organizations = memberships[where.userId] ?? [];
-      return organizations.some((organizationId) =>
-        where.organizationId.in.includes(organizationId),
-      )
-        ? { userId: where.userId }
-        : null;
-    },
+  stubs.organizationUserFindMany.mockImplementation(
+    async ({ where }: { where: { userId: string } }) =>
+      (memberships[where.userId] ?? []).map((organizationId) => ({
+        organizationId,
+      })),
   );
 }
 
@@ -274,17 +266,47 @@ describe("userMigrationPassCohort on cloud", () => {
       await expect(
         cohort({ tenantId: "user_solo", migrationName: backfill }),
       ).resolves.toBe(false);
-      // Membership is probed per user against the enrolled organizations
-      // only - never materialized fleet-wide.
-      expect(stubs.organizationUserFindFirst).toHaveBeenCalledWith(
+      // Membership is probed by the user's own memberships alone — the
+      // enrolled set stays in memory and never rides along as an IN list
+      // (whose planning cost scales with every enrolled organization).
+      expect(stubs.organizationUserFindMany).toHaveBeenCalledWith(
         expect.objectContaining({
-          where: expect.objectContaining({
-            userId: "user_sam",
-            organizationId: { in: ["org_acme"] },
-          }),
+          where: { userId: "user_sam" },
         }),
       );
-      expect(stubs.organizationUserFindMany).not.toHaveBeenCalled();
+      expect(stubs.organizationUserFindFirst).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when many organizations are enrolled and the user belongs to a few", () => {
+    /** @scenario "The membership probe does not scale with enrollment" — langwatch/langwatch#7709 */
+    it("answers from the user's memberships without shipping the enrolled set to the database", async () => {
+      const backfill = IDENTITY_IDENTIFIER_BACKFILL_MIGRATION_NAME;
+      const enrolled = Array.from({ length: 500 }, (_, i) => ({
+        organizationId: `org_${i}`,
+        migrationName: backfill,
+      }));
+      stubs.enrollmentFindMany.mockResolvedValueOnce(enrolled);
+      stubMemberships({
+        user_multi: ["org_unenrolled", "org_7"],
+        user_out: ["org_unenrolled"],
+      });
+
+      const cohort = await userMigrationPassCohort();
+
+      await expect(
+        cohort({ tenantId: "user_multi", migrationName: backfill }),
+      ).resolves.toBe(true);
+      await expect(
+        cohort({ tenantId: "user_out", migrationName: backfill }),
+      ).resolves.toBe(false);
+      // The regression #7709 guards against: one parameter per probe, no
+      // organizationId filter, regardless of how many organizations are
+      // enrolled.
+      for (const call of stubs.organizationUserFindMany.mock.calls) {
+        expect(call[0].where).toEqual({ userId: expect.any(String) });
+      }
+      expect(stubs.organizationUserFindFirst).not.toHaveBeenCalled();
     });
   });
 

--- a/platform/app/src/server/app-layer/system-migrations/__tests__/runtime-enrollment.unit.test.ts
+++ b/platform/app/src/server/app-layer/system-migrations/__tests__/runtime-enrollment.unit.test.ts
@@ -279,7 +279,7 @@ describe("userMigrationPassCohort on cloud", () => {
   });
 
   describe("when many organizations are enrolled and the user belongs to a few", () => {
-    /** @scenario "The membership probe does not scale with enrollment" — langwatch/langwatch#7709 */
+    // Regression for langwatch/langwatch#7709 — the cohort probe must not inline the enrolled set.
     it("answers from the user's memberships without shipping the enrolled set to the database", async () => {
       const backfill = IDENTITY_IDENTIFIER_BACKFILL_MIGRATION_NAME;
       const enrolled = Array.from({ length: 500 }, (_, i) => ({

--- a/platform/app/src/server/app-layer/system-migrations/runtime.ts
+++ b/platform/app/src/server/app-layer/system-migrations/runtime.ts
@@ -318,11 +318,14 @@ export async function userMigrationPassCohort(): Promise<
     if (automatic.has(migrationName)) return true;
     const enrolled = enrolledByMigration.get(migrationName);
     if (!enrolled || enrolled.size === 0) return false;
-    const memberships = await prisma.organizationUser.findMany({
-      where: { userId: tenantId },
-      select: { organizationId: true },
+    // Read as a relation of the user, not as a top-level OrganizationUser
+    // query: that model is org-guarded (dbOrganizationIdProtection), and a
+    // userId-only predicate has no admitted shape there.
+    const user = await prisma.user.findUnique({
+      where: { id: tenantId },
+      select: { orgMemberships: { select: { organizationId: true } } },
     });
-    return memberships.some((membership) =>
+    return (user?.orgMemberships ?? []).some((membership) =>
       enrolled.has(membership.organizationId),
     );
   };

--- a/platform/app/src/server/app-layer/system-migrations/runtime.ts
+++ b/platform/app/src/server/app-layer/system-migrations/runtime.ts
@@ -283,9 +283,14 @@ export async function migrationPassCohort(): Promise<
  * ORGANIZATIONS, and a user is in the cohort when any organization they
  * belong to is enrolled for it. Self-hosted admits every user, as it admits
  * every organization. Enrollment is read once, fresh, at the start of each
- * pass; membership is answered per candidate user with two cheap indexed
- * reads rather than materializing every enrolled organization's member list
- * into memory (the runner visits each user once per pass). A user outside
+ * pass; membership is answered per candidate user by reading that user's own
+ * organization ids (a handful of rows behind one parameter) and intersecting
+ * them in memory with the enrolled set. It used to ride the enrolled set
+ * along as an IN list instead, which read the same rows but made Postgres
+ * PLAN a many-thousand-parameter statement per user per pass - a cost that
+ * scales with every enrolled organization and that execution-time stats
+ * never show (pg_stat_statements.track_planning is off by default). A user
+ * outside
  * every organization has nothing to enroll them on cloud and stays on the
  * legacy path until they join one; their sign-in is unaffected (the write
  * gate answers false; the D03 read fork falls back to legacy routing).
@@ -309,21 +314,17 @@ export async function userMigrationPassCohort(): Promise<
   const automatic = automaticallyEnrolledMigrationNames();
   const enrolledByMigration =
     await enrollmentRepository.findEnrolledOrganizationIdsByMigration();
-  const enrolledByMigrationList = new Map<string, string[]>();
-  for (const migration of registeredUserMigrations()) {
-    enrolledByMigrationList.set(migration.name, [
-      ...(enrolledByMigration.get(migration.name) ?? new Set<string>()),
-    ]);
-  }
   return async ({ tenantId, migrationName }) => {
     if (automatic.has(migrationName)) return true;
-    const organizationIds = enrolledByMigrationList.get(migrationName) ?? [];
-    if (organizationIds.length === 0) return false;
-    const enrolledMembership = await prisma.organizationUser.findFirst({
-      where: { userId: tenantId, organizationId: { in: organizationIds } },
-      select: { userId: true },
+    const enrolled = enrolledByMigration.get(migrationName);
+    if (!enrolled || enrolled.size === 0) return false;
+    const memberships = await prisma.organizationUser.findMany({
+      where: { userId: tenantId },
+      select: { organizationId: true },
     });
-    return enrolledMembership !== null;
+    return memberships.some((membership) =>
+      enrolled.has(membership.organizationId),
+    );
   };
 }
 


### PR DESCRIPTION
Fixes #7709.

## Cause

`userMigrationPassCohort()` (`platform/app/src/server/app-layer/system-migrations/runtime.ts:322` pre-fix) built an array of **every enrolled organization id** per migration purely to feed `organizationId: { in: [...] }` into a per-user `findFirst`. With thousands of organizations enrolled, each probe is a many-thousand-parameter statement Postgres must **plan** on every call — planning dominates execution by ~45× at that scale (`EXPLAIN (ANALYZE, SUMMARY)`: ~30ms planning vs <1ms execution) and is invisible to `pg_stat_statements` unless `track_planning` is on. The pass loop repeats this `users × passes` at every worker boot.

## Fix

Fetch the user's own organization ids (one parameter, a handful of rows) and intersect in memory with the `Map<string, Set<string>>` of enrolled orgs the pass already loads. `enrolledByMigrationList` is deleted — it existed only to feed the IN list. All short-circuits keep identical semantics. The doc comment claiming the old shape was "two cheap indexed reads" is rewritten to say why it wasn't.

## Failing test first

Regression test pins the probe to `where: { userId }` with no `organizationId` filter, regardless of enrollment size. Before the fix:

```
Tests  3 failed | 7 passed (10)
AssertionError: expected false to be true  (cohort membership answered via the removed findFirst path)
```

After:

```
Tests  10 passed (10)
```

Full `system-migrations/__tests__` suite: 80 passed, 1 skipped. Typecheck clean.

## Sweep

Checked every other `organizationId: { in: ... }` site (`join-request.prisma.repository.ts`, `access-listing.grants.repository.ts`, `access-listing.prisma.repository.ts`, `featureFlag.ts`, `governanceSignals.service.ts`): all are bounded by the user's own memberships or the request/batch at hand, and none runs in a per-row loop. The fleet-scaling shape existed only here.

## Noticed, deliberately not changed

The old code pre-filtered enrollment to registered migrations before building its lists; the new code reads the enrollment map directly. Unreachable difference — the pass runner only invokes the cohort closure with registered user-migration names.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved migration enrollment checks for users belonging to many organizations.
  * Reduced database query planning overhead during large enrollment migrations.
  * Improved scalability for migrations involving hundreds of organizations.

* **Reliability**
  * Strengthened tenant-safe membership checks during enrollment migrations.

* **Tests**
  * Added coverage for scenarios involving up to 500 organizations.
  * Added safeguards to prevent oversized organization lists from being included in queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->