### PR TITLE
fix(ci): a manual usage refresh names the pull request's own commit

### DIFF
--- a/.github/scripts/pr-token-usage.test.ts
+++ b/.github/scripts/pr-token-usage.test.ts
@@ -10,6 +10,8 @@ import {
   formatCount,
   humanizeCount,
   interpretUsageResponse,
+  nextPageUrl,
+  readPullRequestHead,
   type PullRequestUsage,
   type UsageRow,
 } from "./pr-token-usage.ts";
@@ -267,6 +269,67 @@ describe("given a rollup with no sessions", () => {
       );
       assert.ok(body.includes("No coding agent sessions recorded"));
       assert.ok(!body.includes("| Contributor |"));
+    });
+  });
+});
+
+describe("given a comment listing that spans more pages than a fixed cap", () => {
+  describe("when the next page is read from the Link header", () => {
+    /** @scenario "The whole comment listing is searched for the marker" */
+    it("follows rel=next until the listing ends", () => {
+      assert.equal(
+        nextPageUrl(
+          '<https://api.github.com/repositories/1/issues/2/comments?page=12>; rel="next", ' +
+            '<https://api.github.com/repositories/1/issues/2/comments?page=40>; rel="last"',
+        ),
+        "https://api.github.com/repositories/1/issues/2/comments?page=12",
+      );
+      // The last page carries prev and first, never next: that ends the walk.
+      assert.equal(
+        nextPageUrl(
+          '<https://api.github.com/repositories/1/issues/2/comments?page=39>; rel="prev", ' +
+            '<https://api.github.com/repositories/1/issues/2/comments?page=1>; rel="first"',
+        ),
+        null,
+      );
+      assert.equal(nextPageUrl(null), null);
+    });
+  });
+});
+
+describe("given a manual refresh, which names only a pull request number", () => {
+  describe("when the pull request is read", () => {
+    /** @scenario "A manual refresh reports the pull request's own head commit" */
+    it("takes the head sha from the pull request, not from the dispatch ref", () => {
+      const head = readPullRequestHead({
+        repository: "acme/widgets",
+        pullRequest: {
+          head: { sha: "f00ba12345", repo: { full_name: "acme/widgets" } },
+        },
+      });
+      assert.equal(head.headSha, "f00ba12345");
+      assert.equal(head.isFork, false);
+    });
+
+    /** @scenario "A manual refresh still refuses a fork pull request" */
+    it("reads a head branch from another repository as a fork", () => {
+      assert.equal(
+        readPullRequestHead({
+          repository: "acme/widgets",
+          pullRequest: {
+            head: { sha: "f00ba12", repo: { full_name: "contributor/widgets" } },
+          },
+        }).isFork,
+        true,
+      );
+      // A deleted fork leaves no head repository at all.
+      assert.equal(
+        readPullRequestHead({
+          repository: "acme/widgets",
+          pullRequest: { head: { sha: "f00ba12", repo: null } },
+        }).isFork,
+        true,
+      );
     });
   });
 });

--- a/.github/scripts/pr-token-usage.ts
+++ b/.github/scripts/pr-token-usage.ts
@@ -1,6 +1,6 @@
 // Builds and upserts the sticky "coding agent usage" comment on a pull
 // request, from the LangWatch pull-request usage API
-// (GET /api/coding-agent/pull-request-usage): sessions, tokens and estimated
+// (GET /api/v1/coding-agent/pull-request-usage): sessions, tokens and estimated
 // cost per contributor and agent, plus a per-model breakdown, over the pull
 // request's whole lifetime.
 //
@@ -343,6 +343,42 @@ type GithubComment = {
   user?: { login?: string };
 };
 
+export type PullRequestHead = { headSha: string; isFork: boolean };
+
+/** A manual refresh names a pull request number and nothing else. The
+ * dispatch ref's sha belongs to the default branch rather than to the pull
+ * request, and the workflow's fork guard reads an event payload that a
+ * dispatch does not have. Both answers come from the pull request itself. */
+export const readPullRequestHead = ({
+  repository,
+  pullRequest,
+}: {
+  repository: string;
+  pullRequest: {
+    head?: { sha?: string; repo?: { full_name?: string } | null } | null;
+  };
+}): PullRequestHead => {
+  const head = pullRequest.head ?? {};
+  return {
+    headSha: head.sha ?? "",
+    // An absent head repository means the fork was deleted. Treating that as
+    // a fork is the safe reading: there is no branch here to trust.
+    isFork: (head.repo?.full_name ?? "") !== repository,
+  };
+};
+
+/** GitHub's `Link` header is the only reliable end-of-listing signal. A fixed
+ * page cap stops looking while the marker may still be ahead, and the upsert
+ * then POSTs a second comment onto a pull request that already carries one. */
+export const nextPageUrl = (linkHeader: string | null): string | null => {
+  if (!linkHeader) return null;
+  for (const part of linkHeader.split(",")) {
+    const match = part.match(/<([^>]+)>\s*;\s*rel="next"/);
+    if (match?.[1]) return match[1];
+  }
+  return null;
+};
+
 const githubHeaders = (token: string) => ({
   Authorization: `Bearer ${token}`,
   Accept: "application/vnd.github+json",
@@ -361,11 +397,12 @@ const findExistingComment = async ({
   repository: string;
   prNumber: number;
 }): Promise<GithubComment | null> => {
-  for (let page = 1; page <= 10; page++) {
-    const response = await fetch(
-      `${apiUrl}/repos/${repository}/issues/${prNumber}/comments?per_page=100&page=${page}`,
-      { headers: githubHeaders(token) },
-    );
+  let url: string | null =
+    `${apiUrl}/repos/${repository}/issues/${prNumber}/comments?per_page=100`;
+  while (url) {
+    const response: Response = await fetch(url, {
+      headers: githubHeaders(token),
+    });
     if (!response.ok) {
       throw new Error(`Listing comments failed with ${response.status}`);
     }
@@ -376,9 +413,32 @@ const findExistingComment = async ({
         comment.body?.includes(MARKER),
     );
     if (existing) return existing;
-    if (comments.length < 100) return null;
+    url = nextPageUrl(response.headers.get("link"));
   }
   return null;
+};
+
+const fetchPullRequest = async ({
+  apiUrl,
+  token,
+  repository,
+  prNumber,
+}: {
+  apiUrl: string;
+  token: string;
+  repository: string;
+  prNumber: number;
+}): Promise<Parameters<typeof readPullRequestHead>[0]["pullRequest"]> => {
+  const response = await fetch(
+    `${apiUrl}/repos/${repository}/pulls/${prNumber}`,
+    { headers: githubHeaders(token) },
+  );
+  if (!response.ok) {
+    throw new Error(`Reading the pull request failed with ${response.status}`);
+  }
+  return (await response.json()) as Parameters<
+    typeof readPullRequestHead
+  >[0]["pullRequest"];
 };
 
 const upsertComment = async ({
@@ -425,8 +485,30 @@ const run = async (): Promise<void> => {
   const dryRun = process.argv.includes("--dry-run");
   const repository = requireEnv("PR_REPOSITORY");
   const prNumber = Number(requireEnv("PR_NUMBER"));
-  const shortSha = requireEnv("PR_HEAD_SHA").slice(0, 7);
   const endpoint = process.env.LANGWATCH_ENDPOINT ?? "https://app.langwatch.ai";
+  const apiUrl = process.env.GITHUB_API_URL ?? "https://api.github.com";
+
+  // A `pull_request` run carries its own head sha and the workflow has
+  // already refused fork pull requests from the event payload. A manual
+  // refresh carries neither, so the pull request answers both questions.
+  let headSha = process.env.PR_HEAD_SHA ?? "";
+  if (!headSha) {
+    const head = readPullRequestHead({
+      repository,
+      pullRequest: await fetchPullRequest({
+        apiUrl,
+        token: requireEnv("GITHUB_TOKEN"),
+        repository,
+        prNumber,
+      }),
+    });
+    if (head.isFork) {
+      console.log(`${repository}#${prNumber} comes from a fork; skipping.`);
+      return;
+    }
+    headSha = head.headSha;
+  }
+  const shortSha = headSha.slice(0, 7);
 
   const outcome = await fetchUsage({
     endpoint,
@@ -459,7 +541,6 @@ const run = async (): Promise<void> => {
   }
 
   const token = requireEnv("GITHUB_TOKEN");
-  const apiUrl = process.env.GITHUB_API_URL ?? "https://api.github.com";
   const existing = await findExistingComment({ apiUrl, token, repository, prNumber });
 
   // No usage and no comment: stay silent rather than stamp every dependency

--- a/.github/workflows/pr-token-usage.yml
+++ b/.github/workflows/pr-token-usage.yml
@@ -42,7 +42,8 @@ jobs:
   comment:
     # Fork PRs get a read-only GITHUB_TOKEN and no secrets, so the LangWatch
     # read and the comment POST would both fail. Skip quietly rather than
-    # paint a red X on a contributor's first PR.
+    # paint a red X on a contributor's first PR. A dispatch has no event
+    # payload to read, so the script re-checks the fork question itself.
     if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
@@ -62,5 +63,8 @@ jobs:
           LANGWATCH_API_KEY: ${{ secrets.LANGWATCH_PR_USAGE_API_KEY }}
           PR_REPOSITORY: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number || inputs.pull_request }}
-          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          # Empty on a manual refresh, where `github.sha` would be the default
+          # branch rather than the pull request. The script then reads the head
+          # sha from the pull request, and refuses it if it is a fork.
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: node --experimental-strip-types .github/scripts/pr-token-usage.ts

--- a/specs/ci/pr-token-usage.feature
+++ b/specs/ci/pr-token-usage.feature
@@ -4,7 +4,7 @@ Feature: PR token usage comment
   So that the cost of the work is visible next to the work itself
 
   The data comes from the LangWatch pull-request usage API
-  (GET /api/coding-agent/pull-request-usage), which rolls a pull request's
+  (GET /api/v1/coding-agent/pull-request-usage), which rolls a pull request's
   whole lifetime up into sessions, tokens and cost per contributor and agent.
   The workflow only reads and comments: it never gates a merge.
 
@@ -47,6 +47,27 @@ Feature: PR token usage comment
     When the workflow is triggered
     Then no comment is attempted
     And the workflow does not fail
+
+  @unit
+  Scenario: A manual refresh reports the pull request's own head commit
+    Given a manual refresh names a pull request number and nothing else
+    When the pull request is read
+    Then the commit named in the comment is the pull request's head commit
+    And never the branch the refresh was dispatched from
+
+  @unit
+  Scenario: A manual refresh still refuses a fork pull request
+    Given a manual refresh names a pull request whose head branch is in another repository
+    When the pull request is read
+    Then it is treated as a fork and no comment is attempted
+    And a pull request whose fork was deleted is treated the same way
+
+  @unit
+  Scenario: The whole comment listing is searched for the marker
+    Given a pull request carries more comments than one listing page holds
+    When the next page is read from the Link header
+    Then the search follows every page until the listing ends
+    And the marker is never missed into a duplicate comment
 
   Scenario: Rapid successive pushes do not create duplicate comments
     Given a pull request receives two pushes in quick succession


### PR DESCRIPTION
Follows #7676, which is merged. Two defects in `pr-token-usage`, both found by review on the copies of this workflow going to `langwatch/scenario` (langwatch/scenario#957) and `langwatch/langwatch-saas` (langwatch/langwatch-saas#1192). Fixed here first so all three stay identical.

## A manual refresh named the wrong commit

`workflow_dispatch` passes a pull request number and nothing else. The workflow fell back to `github.sha` for the footer, which on a dispatch is the branch the refresh ran from, so every manually refreshed comment ended `Updated for <default branch sha>` and named a commit that has nothing to do with the work it reports.

The same gap defeated the fork guard. `github.event.pull_request` is absent on a dispatch, so the job-level `if` let every dispatched number through, fork or not.

The pull request itself answers both questions, so the script asks it. The workflow now passes the head sha only when the event carries one; an empty value sends the script to the API for the head sha and the head repository. A head branch in another repository is refused, and so is a head repository that is gone because the fork was deleted.

Proven against the live API. With `PR_HEAD_SHA` unset, a dry run for this repository's #7676 resolves `148850c`, which is that pull request's real head sha, where the old code would have printed the default branch.

## The comment search stopped after ten pages

`findExistingComment` capped at page 10. A pull request with more than a thousand comments hides the marker past the cap, the search reports "no existing comment", and the upsert POSTs a second report instead of updating the first. GitHub's `Link` header is the listing's own end signal, so the walk follows `rel="next"` and stops when there is no next.

## Tests

16 pass, up from 13. Three new scenarios, all bound by `@scenario` annotations:

- the head sha comes from the pull request, never from the dispatch ref
- a head branch in another repository, and a deleted fork, both read as a fork
- `rel="next"` is followed and its absence ends the walk

Everything the merged version covered still passes unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Manual usage refreshes now identify the pull request’s actual commit instead of the branch used to start the workflow.
  - Refreshes correctly reject pull requests from forked repositories, including cases where the fork has been deleted.
  - Comment searches now scan all available pages, ensuring usage markers are found reliably.
  - Updated the usage service endpoint to the current API path.

- **Tests**
  - Added coverage for pagination, commit detection, and fork handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->