### PR TITLE
fix(scenarios): pair the nlpgo dispatcher with undici's own fetch

### DIFF
--- a/platform/app/src/server/nlpgo/timeouts.ts
+++ b/platform/app/src/server/nlpgo/timeouts.ts
@@ -19,7 +19,11 @@
  * headroom. One operator-set number, read on both sides of the socket.
  */
 
-import { Agent, type Dispatcher } from "undici";
+import {
+  Agent,
+  type Dispatcher,
+  type RequestInit as UndiciRequestInit,
+} from "undici";
 
 /**
  * The engine's own knob for the code block's execution ceiling — see
@@ -216,9 +220,13 @@ const dispatchersByTimeoutMs = new Map<number, Dispatcher>();
  * cut off at 300s in production — the abort signal was never the ceiling
  * that mattered.
  *
- * Callers of the bare global `fetch` (not the named `undici` export) must
- * pass this as `dispatcher` explicitly; the global's own `RequestInit` type
- * (from the `dom` lib) has no `dispatcher` field, hence {@link FetchInitWithDispatcher}.
+ * This dispatcher may only be given to the `fetch` exported by `undici`, never
+ * to the global one. Node's global `fetch` is bound to the undici bundled with
+ * the Node runtime — 7.29.0 on Node 24, against 8.x here — and builds a request
+ * handler of the older shape, which this package rejects up front with
+ * `InvalidArgumentError: invalid onRequestStart method`. Pairing the two failed
+ * every scenario agent call in about a second, before a byte left the process.
+ * {@link FetchInitWithDispatcher} is typed so that mistake cannot compile.
  *
  * Memoized by `timeoutMs` — see {@link dispatchersByTimeoutMs}. Call
  * {@link closeNlpFetchDispatchers} on shutdown to release the pooled
@@ -254,10 +262,16 @@ export async function closeNlpFetchDispatchers(): Promise<void> {
 }
 
 /**
- * Widens the DOM-lib `RequestInit` the global `fetch` is typed with to admit
- * the undici-only `dispatcher` option. See {@link createNlpFetchDispatcher}.
+ * The request init for a call that carries {@link createNlpFetchDispatcher}'s
+ * dispatcher.
+ *
+ * Deliberately undici's own `RequestInit` (which already declares
+ * `dispatcher`), not the DOM-lib one the global `fetch` takes. The two are not
+ * assignable to each other, so this type is what makes handing the dispatcher
+ * to the global `fetch` a compile error rather than a production outage — see
+ * {@link createNlpFetchDispatcher} for what that outage looked like.
  */
-export type FetchInitWithDispatcher = RequestInit & { dispatcher?: Dispatcher };
+export type FetchInitWithDispatcher = UndiciRequestInit;
 
 /**
  * Lambda's own hard invocation ceiling. The code-block timeout override must

--- a/platform/app/src/server/scenarios/execution/__tests__/serialized-adapter.registry.projectApiKey.unit.test.ts
+++ b/platform/app/src/server/scenarios/execution/__tests__/serialized-adapter.registry.projectApiKey.unit.test.ts
@@ -30,8 +30,28 @@ import type {
   WorkflowAgentData,
 } from "../types";
 
-const mockFetch = vi.fn();
-vi.stubGlobal("fetch", mockFetch);
+// The workflow and code adapters call undici's own fetch, so that export is
+// the interception point. Hoisted, because the vi.mock factory below is
+// hoisted above this file.
+const mockFetch = vi.hoisted(() => vi.fn());
+
+vi.mock("undici", async () => {
+  const actual = await vi.importActual<typeof import("undici")>("undici");
+  return { ...actual, fetch: mockFetch };
+});
+
+// The global fetch must never be used with an npm-undici dispatcher: Node's
+// global fetch is bound to the undici bundled with Node, and rejects one with
+// "invalid onRequestStart method". Pointing the global at the same mock would
+// let a regression back to it pass this suite.
+vi.stubGlobal(
+  "fetch",
+  vi.fn(() => {
+    throw new Error(
+      "the adapter must call undici's fetch, not the global fetch",
+    );
+  }),
+);
 
 const defaultInput = {
   threadId: "thread_1",

--- a/platform/app/src/server/scenarios/execution/serialized-adapters/__tests__/code-agent.adapter.unit.test.ts
+++ b/platform/app/src/server/scenarios/execution/serialized-adapters/__tests__/code-agent.adapter.unit.test.ts
@@ -74,19 +74,20 @@ import {
 
 const mockInjectTraceContextHeaders = vi.mocked(injectTraceContextHeaders);
 
-// Mock global fetch
-const mockFetch = vi.fn();
-vi.stubGlobal("fetch", mockFetch);
+// The adapter calls undici's own fetch, so that export is the interception
+// point. Hoisted, because the vi.mock factory below is hoisted above this file.
+const mockFetch = vi.hoisted(() => vi.fn());
 
 // Undici's Agent does not read back the timeouts it was constructed with, so
 // the only way to assert on the dispatcher the adapter passes is to record the
-// constructor's arguments. The global fetch above stays the interception point.
+// constructor's arguments.
 const agentOptions = vi.hoisted(() => [] as Record<string, unknown>[]);
 
 vi.mock("undici", async () => {
   const actual = await vi.importActual<typeof import("undici")>("undici");
   return {
     ...actual,
+    fetch: mockFetch,
     Agent: class RecordingAgent extends actual.Agent {
       constructor(opts?: Record<string, unknown>) {
         agentOptions.push(opts ?? {});
@@ -95,6 +96,20 @@ vi.mock("undici", async () => {
     },
   };
 });
+
+// The global fetch must never be used with an npm-undici dispatcher: Node's
+// global fetch is bound to the undici bundled with Node, and rejects one with
+// "invalid onRequestStart method". Pointing the global at the same mock would
+// let a regression back to it pass this suite, which is how that bug reached
+// production once already.
+vi.stubGlobal(
+  "fetch",
+  vi.fn(() => {
+    throw new Error(
+      "the adapter must call undici's fetch, not the global fetch",
+    );
+  }),
+);
 
 describe("SerializedCodeAgentAdapter", () => {
   const defaultConfig: CodeAgentData = {

--- a/platform/app/src/server/scenarios/execution/serialized-adapters/__tests__/nlp-fetch-transport.unit.test.ts
+++ b/platform/app/src/server/scenarios/execution/serialized-adapters/__tests__/nlp-fetch-transport.unit.test.ts
@@ -1,0 +1,201 @@
+/**
+ * @vitest-environment node
+ *
+ * Transport-level regression guard for the two scenario adapters that post to
+ * nlpgo.
+ *
+ * Both adapters send their request with a `dispatcher` built by the `undici`
+ * npm package, so that undici's own `headersTimeout`/`bodyTimeout` can be
+ * raised past its 300s default. That dispatcher can only be given to a `fetch`
+ * from the SAME package: Node's global `fetch` is bound to the undici bundled
+ * with the Node runtime (7.29.0 on Node 24), which builds a request handler of
+ * a different shape, and the npm undici (8.x) rejects it immediately with
+ * `InvalidArgumentError: invalid onRequestStart method`. Every agent call then
+ * failed in about a second, before a byte reached the network.
+ *
+ * The rest of the adapter suites mock `fetch`, so a mismatch between the fetch
+ * and the dispatcher is invisible to them - that is exactly how the fault
+ * reached production. This file mocks NO part of the transport: real undici,
+ * real dispatcher, real sockets, against a real loopback server.
+ */
+
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { type AgentInput, AgentRole } from "@langwatch/scenario";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { closeNlpFetchDispatchers } from "../../../../nlpgo/timeouts";
+import type { CodeAgentData, WorkflowAgentData } from "../../types";
+
+// Tracing is not the boundary under test, and the real tracer would need a
+// configured exporter. undici and the global fetch are deliberately left alone.
+vi.mock("langwatch", () => ({
+  getLangWatchTracer: () => ({
+    withActiveSpan: async (
+      _name: string,
+      _opts: unknown,
+      fn: (span: {
+        setAttribute: () => void;
+        setAttributes: () => void;
+        setStatus: () => void;
+        recordException: () => void;
+        end: () => void;
+      }) => unknown,
+    ) =>
+      await fn({
+        setAttribute: () => void 0,
+        setAttributes: () => void 0,
+        setStatus: () => void 0,
+        recordException: () => void 0,
+        end: () => void 0,
+      }),
+  }),
+}));
+
+vi.mock("@langwatch/observability/tracing", () => ({
+  injectTraceContextHeaders: ({
+    headers,
+  }: {
+    headers: Record<string, string>;
+  }) => ({
+    headers,
+    traceId: undefined,
+  }),
+}));
+
+import { SerializedCodeAgentAdapter } from "../code-agent.adapter";
+import { SerializedWorkflowAgentAdapter } from "../workflow-agent.adapter";
+
+/** Bodies the fake nlpgo received, so the request itself can be asserted on. */
+const receivedBodies: string[] = [];
+
+let server: Server;
+let nlpServiceUrl: string;
+
+beforeAll(async () => {
+  server = createServer((req, res) => {
+    let body = "";
+    req.on("data", (chunk) => {
+      body += chunk;
+    });
+    req.on("end", () => {
+      receivedBodies.push(body);
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(
+        JSON.stringify({
+          trace_id: "trace_abc123",
+          status: "success",
+          result: { output: "pong" },
+          nodes: {},
+        }),
+      );
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address() as AddressInfo;
+  nlpServiceUrl = `http://127.0.0.1:${port}`;
+});
+
+afterAll(async () => {
+  await closeNlpFetchDispatchers();
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+afterEach(() => {
+  receivedBodies.length = 0;
+});
+
+const input: AgentInput = {
+  threadId: "thread_123",
+  messages: [{ role: "user", content: "ping" }],
+  newMessages: [{ role: "user", content: "ping" }],
+  requestedRole: AgentRole.AGENT,
+  scenarioState: {} as AgentInput["scenarioState"],
+  scenarioConfig: {} as AgentInput["scenarioConfig"],
+};
+
+describe("given a dispatcher built by the undici package", () => {
+  describe("when the code agent adapter calls nlpgo", () => {
+    const config: CodeAgentData = {
+      type: "code",
+      agentId: "agent_123",
+      code: 'def execute(input):\n    return "pong"',
+      inputs: [{ identifier: "input", type: "str" }],
+      outputs: [{ identifier: "output", type: "str" }],
+      secrets: {},
+    };
+
+    /** @scenario "A code agent turn reaches the NLP service" */
+    it("reaches the service and returns its output", async () => {
+      const adapter = new SerializedCodeAgentAdapter({
+        config,
+        nlpServiceUrl,
+        projectApiKey: "test-api-key",
+      });
+
+      await expect(adapter.call(input)).resolves.toBe("pong");
+    });
+
+    /** @scenario "A code agent turn reaches the NLP service" */
+    it("sends the execute_flow event the service expects", async () => {
+      const adapter = new SerializedCodeAgentAdapter({
+        config,
+        nlpServiceUrl,
+        projectApiKey: "test-api-key",
+      });
+
+      await adapter.call(input);
+
+      expect(receivedBodies).toHaveLength(1);
+      expect(JSON.parse(receivedBodies[0]!).type).toBe("execute_flow");
+    });
+
+    // The agent whose code sleeps past undici's 300s default is the one the
+    // dispatcher exists for, so the long deadline must survive a real request.
+    /** @scenario "A code agent with a deadline past undici's own default still reaches the service" */
+    it("still reaches the service with a deadline past undici's 300s default", async () => {
+      const adapter = new SerializedCodeAgentAdapter({
+        config: { ...config, timeoutMs: 615_000 },
+        nlpServiceUrl,
+        projectApiKey: "test-api-key",
+      });
+
+      await expect(adapter.call(input)).resolves.toBe("pong");
+    });
+  });
+
+  describe("when the workflow agent adapter calls nlpgo", () => {
+    const config: WorkflowAgentData = {
+      type: "workflow",
+      agentId: "agent_456",
+      workflowId: "wf_1",
+      workflow: {
+        workflow_id: "wf_1",
+        name: "Greeter",
+        nodes: [],
+        edges: [],
+      },
+      inputs: [{ identifier: "input", type: "str" }],
+      outputs: [{ identifier: "output", type: "str" }],
+      secrets: {},
+    };
+
+    /** @scenario "A workflow agent turn reaches the NLP service" */
+    it("reaches the service and returns its output", async () => {
+      const adapter = new SerializedWorkflowAgentAdapter({
+        config,
+        nlpServiceUrl,
+        projectApiKey: "test-api-key",
+      });
+
+      await expect(adapter.call(input)).resolves.toBe("pong");
+    });
+  });
+});

--- a/platform/app/src/server/scenarios/execution/serialized-adapters/__tests__/workflow-agent.adapter.unit.test.ts
+++ b/platform/app/src/server/scenarios/execution/serialized-adapters/__tests__/workflow-agent.adapter.unit.test.ts
@@ -21,19 +21,20 @@ import { SerializedWorkflowAgentAdapter } from "../workflow-agent.adapter";
 
 const mockInjectTraceContextHeaders = vi.mocked(injectTraceContextHeaders);
 
-// Mock global fetch
-const mockFetch = vi.fn();
-vi.stubGlobal("fetch", mockFetch);
+// The adapter calls undici's own fetch, so that export is the interception
+// point. Hoisted, because the vi.mock factory below is hoisted above this file.
+const mockFetch = vi.hoisted(() => vi.fn());
 
 // Undici's Agent does not read back the timeouts it was constructed with, so
 // the only way to assert on the dispatcher the adapter passes is to record the
-// constructor's arguments. The global fetch above stays the interception point.
+// constructor's arguments.
 const agentOptions = vi.hoisted(() => [] as Record<string, unknown>[]);
 
 vi.mock("undici", async () => {
   const actual = await vi.importActual<typeof import("undici")>("undici");
   return {
     ...actual,
+    fetch: mockFetch,
     Agent: class RecordingAgent extends actual.Agent {
       constructor(opts?: Record<string, unknown>) {
         agentOptions.push(opts ?? {});
@@ -42,6 +43,20 @@ vi.mock("undici", async () => {
     },
   };
 });
+
+// The global fetch must never be used with an npm-undici dispatcher: Node's
+// global fetch is bound to the undici bundled with Node, and rejects one with
+// "invalid onRequestStart method". Pointing the global at the same mock would
+// let a regression back to it pass this suite, which is how that bug reached
+// production once already.
+vi.stubGlobal(
+  "fetch",
+  vi.fn(() => {
+    throw new Error(
+      "the adapter must call undici's fetch, not the global fetch",
+    );
+  }),
+);
 
 describe("SerializedWorkflowAgentAdapter", () => {
   /** Minimal published workflow DSL with an entry node, a signature node, and an end node. */

--- a/platform/app/src/server/scenarios/execution/serialized-adapters/code-agent.adapter.ts
+++ b/platform/app/src/server/scenarios/execution/serialized-adapters/code-agent.adapter.ts
@@ -15,6 +15,7 @@ import { AgentRole } from "@langwatch/scenario";
 import { SpanKind } from "@opentelemetry/api";
 import { randomBytes } from "crypto";
 import { getLangWatchTracer } from "langwatch";
+import { type Response as UndiciResponse, fetch as undiciFetch } from "undici";
 import { LATEST_SPEC_VERSION } from "../../../../optimization_studio/types/dsl";
 import {
   createNlpFetchDispatcher,
@@ -390,7 +391,7 @@ export class SerializedCodeAgentAdapter extends SerializedAgentAdapter {
         }, fetchTimeoutMs);
 
         try {
-          let response: Response;
+          let response: UndiciResponse;
           try {
             const fetchInit: FetchInitWithDispatcher = {
               method: "POST",
@@ -401,7 +402,11 @@ export class SerializedCodeAgentAdapter extends SerializedAgentAdapter {
                 timeoutMs: fetchTimeoutMs,
               }),
             };
-            response = await fetch(url, fetchInit);
+            // undici's own fetch, not the global one: Node's global fetch is
+            // bound to the undici bundled with Node, which rejects a
+            // dispatcher built by this package with "invalid onRequestStart
+            // method" (see mailer/providers/resend.ts for the same fix).
+            response = await undiciFetch(url, fetchInit);
           } catch (fetchError) {
             if (timedOut) {
               span.setAttribute(

--- a/platform/app/src/server/scenarios/execution/serialized-adapters/workflow-agent.adapter.ts
+++ b/platform/app/src/server/scenarios/execution/serialized-adapters/workflow-agent.adapter.ts
@@ -22,6 +22,7 @@ import { injectTraceContextHeaders } from "@langwatch/observability/tracing";
 import type { AgentInput } from "@langwatch/scenario";
 import { AgentRole } from "@langwatch/scenario";
 import { randomBytes } from "crypto";
+import { type Response as UndiciResponse, fetch as undiciFetch } from "undici";
 import {
   createNlpFetchDispatcher,
   type FetchInitWithDispatcher,
@@ -276,7 +277,7 @@ export class SerializedWorkflowAgentAdapter extends SerializedAgentAdapter {
     body: string;
     signal: AbortSignal;
     timeoutMs: number;
-  }): Promise<Response> {
+  }): Promise<UndiciResponse> {
     try {
       const fetchInit: FetchInitWithDispatcher = {
         method: "POST",
@@ -285,7 +286,11 @@ export class SerializedWorkflowAgentAdapter extends SerializedAgentAdapter {
         signal,
         dispatcher: createNlpFetchDispatcher({ timeoutMs }),
       };
-      return await fetch(
+      // undici's own fetch, not the global one: Node's global fetch is bound
+      // to the undici bundled with Node, which rejects a dispatcher built by
+      // this package with "invalid onRequestStart method" (see
+      // mailer/providers/resend.ts for the same fix).
+      return await undiciFetch(
         `${this.nlpServiceUrl}/go/studio/execute_sync`,
         fetchInit,
       );

--- a/specs/scenarios/nlp-fetch-transport.feature
+++ b/specs/scenarios/nlp-fetch-transport.feature
@@ -1,0 +1,42 @@
+Feature: Scenario adapters reach nlpgo with their own undici dispatcher
+  As a customer running a code or workflow agent in a simulation
+  I want every turn to reach the NLP service
+  So that a long-running agent is bounded by its deadline, not cut off before it starts
+
+  # Context: the code and workflow adapters raise undici's own
+  # headersTimeout/bodyTimeout past its 300s default by passing a `dispatcher`
+  # built with the `undici` npm package (see server/nlpgo/timeouts.ts). An
+  # AbortController deadline alone cannot raise those, which is what cut long
+  # code blocks off at 300s.
+  #
+  # That dispatcher only works with a fetch from the SAME package. Node's
+  # global fetch is bound to the undici bundled with the Node runtime (7.29.0
+  # on Node 24), whose request handler has a different shape, and the npm
+  # undici (8.x) rejects it up front with
+  # "InvalidArgumentError: invalid onRequestStart method". Pairing the two
+  # failed every agent call in about a second, before a byte left the process:
+  # the test call in the agent editor and every simulation turn alike.
+  #
+  # The adapter suites mock fetch, so they cannot see a mismatch between the
+  # fetch and the dispatcher. These scenarios are bound to a test that mocks no
+  # part of the transport: real undici, real dispatcher, real sockets, against
+  # a loopback server.
+
+  @unit
+  Scenario: A code agent turn reaches the NLP service
+    Given a code agent whose NLP service is reachable
+    When the simulator sends the agent a message
+    Then the agent's output is returned to the simulator
+    And the service receives an execute_flow event
+
+  @unit
+  Scenario: A code agent with a deadline past undici's own default still reaches the service
+    Given a code agent whose code budget is longer than undici's 300s default
+    When the simulator sends the agent a message
+    Then the agent's output is returned to the simulator
+
+  @unit
+  Scenario: A workflow agent turn reaches the NLP service
+    Given a workflow agent whose NLP service is reachable
+    When the simulator sends the agent a message
+    Then the agent's output is returned to the simulator


### PR DESCRIPTION
## What broke

[langwatch#7705](https://github.com/langwatch/langwatch/pull/7705) gave the code and workflow scenario adapters an undici dispatcher, to raise undici's 300s `headersTimeout`/`bodyTimeout` to the 630s deadline. But it passed that dispatcher to the global `fetch`. Node's global fetch is bound to the undici bundled with the Node runtime (7.29.0 on Node 24). The dispatcher comes from the npm `undici` package (8.10.0). The npm package rejects the runtime's older handler shape up front:

```
SerializedCodeAgentAdapterError: Code execution failed: fetch to
http://langwatch-nlp-service/go/studio/execute_sync failed - fetch failed
(cause: InvalidArgumentError: invalid onRequestStart method)
```

The error is thrown before a byte leaves the process. That is why every code and workflow agent call failed in about 1 second: the test call in the agent editor and every simulation turn alike. Customer report confirmed the 1.1s failures.

The adapter unit suites stubbed the global `fetch`, so they kept passing while the shipped pairing was broken. `mailer/providers/resend.ts` already documents this exact error and the fix for it.

## The fix

Import `fetch` from the `undici` package at both call sites, so the fetch and the dispatcher share one implementation. Same pattern as `resend.ts` and `ssrfProtection.ts`.

## Guards so this cannot come back

1. **A transport test with nothing mocked.** `nlp-fetch-transport.unit.test.ts` drives both real adapters over real sockets against a loopback server: real undici, real dispatcher. With the bug present it fails with the exact production error. Bound to `specs/scenarios/nlp-fetch-transport.feature` (3/3 scenarios).
2. **The unit suites now fail on a regression.** They intercept undici's `fetch` export, and the global `fetch` is stubbed to throw. Reverting the adapters to the global fetch fails 59 tests (verified).
3. **A regression no longer compiles.** `FetchInitWithDispatcher` is now undici's own `RequestInit`, which is not assignable to the DOM `RequestInit` the global fetch takes. Reverting an adapter to the global fetch is a `tsc` error (verified).

## Verification

- Raw repro on Node 24.19.0: global fetch + npm Agent reproduces the production error byte for byte; undici fetch + the same Agent returns 200.
- Built the production `scenario-child-process.cjs` (the artifact in the customer stack trace) and inspected it: both call sites go through the single inlined undici copy. An adapter bundled with the same esbuild options completes a real request end to end.
- Swept the whole repo: no other call site mixes the two packages, no `setGlobalDispatcher` anywhere. `resend.ts` and `ssrfProtection.ts` already pair correctly.
- `pnpm typecheck:all` passes. 243 tests across the adapter and nlpgo suites pass. Biome clean on changed files.

The 630s deadline work from [langwatch#7705](https://github.com/langwatch/langwatch/pull/7705) is preserved: the dispatcher still carries `headersTimeout`/`bodyTimeout` equal to the resolved deadline, memoized per timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability for code and workflow agent requests to the NLP service.
  - Fixed failures that could occur when requests used extended timeouts, including operations lasting longer than five minutes.
  - Ensured requests reach the service correctly and return expected results across supported agent scenarios.

- **Tests**
  - Added coverage for standard, long-running, and workflow agent requests using real network transport.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->