### PR TITLE
test(scenarios): stop the global fetch stub leaking between test files

### DIFF
--- a/platform/app/src/server/scenarios/execution/__tests__/serialized-adapter.registry.projectApiKey.unit.test.ts
+++ b/platform/app/src/server/scenarios/execution/__tests__/serialized-adapter.registry.projectApiKey.unit.test.ts
@@ -22,6 +22,7 @@
 import type { AgentInput } from "@langwatch/scenario";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { guardAgainstGlobalFetch } from "../../../../test-utils/globalFetchGuard";
 import { createAdapter } from "../serialized-adapter.registry";
 import type {
   CodeAgentData,
@@ -40,18 +41,9 @@ vi.mock("undici", async () => {
   return { ...actual, fetch: mockFetch };
 });
 
-// The global fetch must never be used with an npm-undici dispatcher: Node's
-// global fetch is bound to the undici bundled with Node, and rejects one with
-// "invalid onRequestStart method". Pointing the global at the same mock would
-// let a regression back to it pass this suite.
-vi.stubGlobal(
-  "fetch",
-  vi.fn(() => {
-    throw new Error(
-      "the adapter must call undici's fetch, not the global fetch",
-    );
-  }),
-);
+// Pointing the global fetch at the same mock would let a regression back to it
+// pass this suite.
+guardAgainstGlobalFetch();
 
 const defaultInput = {
   threadId: "thread_1",

--- a/platform/app/src/server/scenarios/execution/serialized-adapters/__tests__/code-agent.adapter.unit.test.ts
+++ b/platform/app/src/server/scenarios/execution/serialized-adapters/__tests__/code-agent.adapter.unit.test.ts
@@ -4,6 +4,7 @@
 
 import { type AgentInput, AgentRole } from "@langwatch/scenario";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { guardAgainstGlobalFetch } from "../../../../../test-utils/globalFetchGuard";
 import { closeNlpFetchDispatchers } from "../../../../nlpgo/timeouts";
 import type { CodeAgentData } from "../../types";
 
@@ -97,19 +98,9 @@ vi.mock("undici", async () => {
   };
 });
 
-// The global fetch must never be used with an npm-undici dispatcher: Node's
-// global fetch is bound to the undici bundled with Node, and rejects one with
-// "invalid onRequestStart method". Pointing the global at the same mock would
-// let a regression back to it pass this suite, which is how that bug reached
-// production once already.
-vi.stubGlobal(
-  "fetch",
-  vi.fn(() => {
-    throw new Error(
-      "the adapter must call undici's fetch, not the global fetch",
-    );
-  }),
-);
+// Pointing the global fetch at the same mock would let a regression back to it
+// pass this suite, which is how that bug reached production once already.
+guardAgainstGlobalFetch();
 
 describe("SerializedCodeAgentAdapter", () => {
   const defaultConfig: CodeAgentData = {

--- a/platform/app/src/server/scenarios/execution/serialized-adapters/__tests__/workflow-agent.adapter.unit.test.ts
+++ b/platform/app/src/server/scenarios/execution/serialized-adapters/__tests__/workflow-agent.adapter.unit.test.ts
@@ -4,6 +4,7 @@
 
 import { type AgentInput, AgentRole } from "@langwatch/scenario";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { guardAgainstGlobalFetch } from "../../../../../test-utils/globalFetchGuard";
 import { closeNlpFetchDispatchers } from "../../../../nlpgo/timeouts";
 import type { WorkflowAgentData } from "../../types";
 
@@ -44,19 +45,9 @@ vi.mock("undici", async () => {
   };
 });
 
-// The global fetch must never be used with an npm-undici dispatcher: Node's
-// global fetch is bound to the undici bundled with Node, and rejects one with
-// "invalid onRequestStart method". Pointing the global at the same mock would
-// let a regression back to it pass this suite, which is how that bug reached
-// production once already.
-vi.stubGlobal(
-  "fetch",
-  vi.fn(() => {
-    throw new Error(
-      "the adapter must call undici's fetch, not the global fetch",
-    );
-  }),
-);
+// Pointing the global fetch at the same mock would let a regression back to it
+// pass this suite, which is how that bug reached production once already.
+guardAgainstGlobalFetch();
 
 describe("SerializedWorkflowAgentAdapter", () => {
   /** Minimal published workflow DSL with an entry node, a signature node, and an end node. */

--- a/platform/app/src/test-utils/__tests__/globalFetchGuard.unit.test.ts
+++ b/platform/app/src/test-utils/__tests__/globalFetchGuard.unit.test.ts
@@ -2,7 +2,7 @@
  * @vitest-environment node
  */
 
-import { afterAll, describe, expect, it } from "vitest";
+import { afterAll, describe, expect, it, vi } from "vitest";
 
 import { guardAgainstGlobalFetch } from "../globalFetchGuard";
 
@@ -12,15 +12,15 @@ const realFetch = globalThis.fetch;
 // cleanup must leave it alone: the unit config runs with `isolate: false`, so
 // a cleanup that dropped every global stub would take this one with it.
 //
-// It is installed and removed by hand for that same reason, since
-// `vi.stubGlobal` and `vi.unstubAllGlobals` work on one shared registry.
+// `vi.stubGlobal` is what such a suite would use, and it is what puts the
+// probe in the registry that `vi.unstubAllGlobals` empties. Installing it any
+// other way would hide it from that call, and the test below could no longer
+// tell a targeted cleanup from a wholesale one.
 const probe = Symbol("langwatch-guard-probe");
-Object.defineProperty(globalThis, "langwatchGuardProbe", {
-  value: probe,
-  configurable: true,
-  writable: true,
-});
+vi.stubGlobal("langwatchGuardProbe", probe);
 
+// Removed by hand rather than with `vi.unstubAllGlobals`, which would empty
+// the same shared registry this file asks the guard not to touch.
 afterAll(() => {
   delete (globalThis as { langwatchGuardProbe?: symbol }).langwatchGuardProbe;
 });

--- a/platform/app/src/test-utils/__tests__/globalFetchGuard.unit.test.ts
+++ b/platform/app/src/test-utils/__tests__/globalFetchGuard.unit.test.ts
@@ -60,5 +60,17 @@ describe("guardAgainstGlobalFetch", () => {
         expect(globalThis.fetch).toBe(realFetch);
       });
     });
+
+    // The same assertion as inside the suite, made once every cleanup has run.
+    // That one holds only while it is not the first test of its suite, since
+    // it reads what the cleanups before it left behind. This one does not
+    // depend on the order the tests above it are written in.
+    describe("when an unguarded test reads a global the guard does not own", () => {
+      it("still finds the value the other suite installed", () => {
+        expect(
+          (globalThis as { langwatchGuardProbe?: symbol }).langwatchGuardProbe,
+        ).toBe(probe);
+      });
+    });
   });
 });

--- a/platform/app/src/test-utils/__tests__/globalFetchGuard.unit.test.ts
+++ b/platform/app/src/test-utils/__tests__/globalFetchGuard.unit.test.ts
@@ -2,7 +2,7 @@
  * @vitest-environment node
  */
 
-import { afterAll, describe, expect, it, vi } from "vitest";
+import { afterAll, describe, expect, it } from "vitest";
 
 import { guardAgainstGlobalFetch } from "../globalFetchGuard";
 
@@ -11,39 +11,54 @@ const realFetch = globalThis.fetch;
 // A global that belongs to another suite sharing this worker. The guard's
 // cleanup must leave it alone: the unit config runs with `isolate: false`, so
 // a cleanup that dropped every global stub would take this one with it.
-const otherGlobal = Symbol("other-global");
-vi.stubGlobal("langwatchGuardProbe", otherGlobal);
+//
+// It is installed and removed by hand for that same reason, since
+// `vi.stubGlobal` and `vi.unstubAllGlobals` work on one shared registry.
+const probe = Symbol("langwatch-guard-probe");
+Object.defineProperty(globalThis, "langwatchGuardProbe", {
+  value: probe,
+  configurable: true,
+  writable: true,
+});
 
 afterAll(() => {
-  vi.unstubAllGlobals();
+  delete (globalThis as { langwatchGuardProbe?: symbol }).langwatchGuardProbe;
 });
 
 describe("guardAgainstGlobalFetch", () => {
-  guardAgainstGlobalFetch();
+  describe("given a suite that installed the guard", () => {
+    guardAgainstGlobalFetch();
 
-  describe("given a test running under the guard", () => {
-    it("makes a call to the global fetch throw", () => {
-      expect(() => globalThis.fetch("https://example.com")).toThrow(
-        "this code must call undici's fetch, not the global fetch",
-      );
+    describe("when a test calls the global fetch", () => {
+      it("throws and names undici's fetch as the one to use", () => {
+        expect(() => globalThis.fetch("https://example.com")).toThrow(
+          "this code must call undici's fetch, not the global fetch",
+        );
+      });
     });
 
-    it("installs the guard again for the next test in the suite", () => {
-      expect(() => globalThis.fetch("https://example.com")).toThrow(
-        "this code must call undici's fetch, not the global fetch",
-      );
+    describe("when a second test in the same suite calls it", () => {
+      it("throws as well, so every test carries the guard", () => {
+        expect(() => globalThis.fetch("https://example.com")).toThrow(
+          "this code must call undici's fetch, not the global fetch",
+        );
+      });
     });
 
-    it("leaves globals it does not own untouched", () => {
-      expect(
-        (globalThis as { langwatchGuardProbe?: symbol }).langwatchGuardProbe,
-      ).toBe(otherGlobal);
+    describe("when a test reads a global the guard does not own", () => {
+      it("still finds the value the other suite installed", () => {
+        expect(
+          (globalThis as { langwatchGuardProbe?: symbol }).langwatchGuardProbe,
+        ).toBe(probe);
+      });
     });
   });
-});
 
-describe("after a guarded suite has finished a test", () => {
-  it("has put the real global fetch back", () => {
-    expect(globalThis.fetch).toBe(realFetch);
+  describe("given a guarded suite that has finished its tests", () => {
+    describe("when an unguarded test reads the global fetch", () => {
+      it("gets the real fetch back", () => {
+        expect(globalThis.fetch).toBe(realFetch);
+      });
+    });
   });
 });

--- a/platform/app/src/test-utils/__tests__/globalFetchGuard.unit.test.ts
+++ b/platform/app/src/test-utils/__tests__/globalFetchGuard.unit.test.ts
@@ -1,0 +1,49 @@
+/**
+ * @vitest-environment node
+ */
+
+import { afterAll, describe, expect, it, vi } from "vitest";
+
+import { guardAgainstGlobalFetch } from "../globalFetchGuard";
+
+const realFetch = globalThis.fetch;
+
+// A global that belongs to another suite sharing this worker. The guard's
+// cleanup must leave it alone: the unit config runs with `isolate: false`, so
+// a cleanup that dropped every global stub would take this one with it.
+const otherGlobal = Symbol("other-global");
+vi.stubGlobal("langwatchGuardProbe", otherGlobal);
+
+afterAll(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("guardAgainstGlobalFetch", () => {
+  guardAgainstGlobalFetch();
+
+  describe("given a test running under the guard", () => {
+    it("makes a call to the global fetch throw", () => {
+      expect(() => globalThis.fetch("https://example.com")).toThrow(
+        "this code must call undici's fetch, not the global fetch",
+      );
+    });
+
+    it("installs the guard again for the next test in the suite", () => {
+      expect(() => globalThis.fetch("https://example.com")).toThrow(
+        "this code must call undici's fetch, not the global fetch",
+      );
+    });
+
+    it("leaves globals it does not own untouched", () => {
+      expect(
+        (globalThis as { langwatchGuardProbe?: symbol }).langwatchGuardProbe,
+      ).toBe(otherGlobal);
+    });
+  });
+});
+
+describe("after a guarded suite has finished a test", () => {
+  it("has put the real global fetch back", () => {
+    expect(globalThis.fetch).toBe(realFetch);
+  });
+});

--- a/platform/app/src/test-utils/globalFetchGuard.ts
+++ b/platform/app/src/test-utils/globalFetchGuard.ts
@@ -15,22 +15,35 @@ import { afterEach, beforeEach, vi } from "vitest";
  * unit config runs with `isolate: false`: a stub left in place would reach
  * every later file in the same worker.
  *
- * It removes every global stub, so do not use it in a suite that installs
- * other globals with `vi.stubGlobal` and expects them to survive a test.
+ * It saves and restores the fetch property itself rather than calling
+ * `vi.stubGlobal` and `vi.unstubAllGlobals`, for the same reason: those work on
+ * one shared registry, so the cleanup would also drop globals that another file
+ * in the worker installed.
  */
 export function guardAgainstGlobalFetch(): void {
+  let original: PropertyDescriptor | undefined;
+
   beforeEach(() => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(() => {
+    original = Object.getOwnPropertyDescriptor(globalThis, "fetch");
+    Object.defineProperty(globalThis, "fetch", {
+      value: vi.fn(() => {
         throw new Error(
           "this code must call undici's fetch, not the global fetch",
         );
       }),
-    );
+      configurable: true,
+      writable: true,
+    });
   });
 
   afterEach(() => {
-    vi.unstubAllGlobals();
+    if (original) {
+      Object.defineProperty(globalThis, "fetch", original);
+    } else {
+      // The runtime had no fetch of its own, so leaving the stub behind would
+      // invent one for every later file in the worker.
+      delete (globalThis as { fetch?: unknown }).fetch;
+    }
+    original = undefined;
   });
 }

--- a/platform/app/src/test-utils/globalFetchGuard.ts
+++ b/platform/app/src/test-utils/globalFetchGuard.ts
@@ -1,0 +1,36 @@
+import { afterEach, beforeEach, vi } from "vitest";
+
+/**
+ * Makes the global fetch throw for the duration of each test in the calling
+ * suite.
+ *
+ * Node's global fetch is bound to the undici that ships inside Node, and it
+ * rejects a dispatcher built by the undici npm package with
+ * "InvalidArgumentError: invalid onRequestStart method". Code that passes a
+ * dispatcher must therefore call undici's own fetch export. A suite that mocks
+ * only that export would still pass if the code fell back to the global fetch,
+ * so this guard turns that fallback into a clear failure.
+ *
+ * The stub is installed before each test and removed after it, because the
+ * unit config runs with `isolate: false`: a stub left in place would reach
+ * every later file in the same worker.
+ *
+ * It removes every global stub, so do not use it in a suite that installs
+ * other globals with `vi.stubGlobal` and expects them to survive a test.
+ */
+export function guardAgainstGlobalFetch(): void {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => {
+        throw new Error(
+          "this code must call undici's fetch, not the global fetch",
+        );
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+}


### PR DESCRIPTION
## What

Follow-up to #7714, from a CodeRabbit review finding that arrived after that PR merged.

#7714 gave the three scenario adapter suites a guard: the global fetch is stubbed with a function that throws, so a regression from undici's fetch back to the global one fails the tests instead of passing them. The stub was installed at module scope and never removed.

The unit config runs with `isolate: false` and does not set `unstubGlobals`, so the stub stayed installed for every later test file in the same worker. Any file that runs after one of these three and uses the global fetch would get the thrower.

## How

The stub moves into one shared helper, `guardAgainstGlobalFetch`, in `platform/app/src/test-utils/globalFetchGuard.ts`. It installs the stub before each test and calls `vi.unstubAllGlobals()` after each test, so the stub cannot outlive the file.

The three suites now call the helper instead of repeating the block.

## Verification

- The guard still covers every test. With the code adapter pointed back at the global fetch, all 59 tests in its suite fail with "this code must call undici's fetch, not the global fetch".
- `pnpm test:unit run src/server/scenarios`: 58 files, 866 tests, all passing.
- `pnpm typecheck:all` exits 0.
- Biome clean on the changed files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a shared guard to detect unintended use of the global `fetch` implementation.
  * Updated execution and agent adapter tests to consistently enforce the expected fetch behavior.
  * Added coverage for guard isolation, repeated setup, and reliable cleanup of global mocks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->