### PR TITLE
test(governance): guard pull schedule coverage

### DIFF
--- a/platform/app/ee/governance/dashboard/logic/__tests__/pullCadence.unit.test.ts
+++ b/platform/app/ee/governance/dashboard/logic/__tests__/pullCadence.unit.test.ts
@@ -64,12 +64,14 @@ describe("given the pull-cadence cron mapping", () => {
      * a source that looks configured, reports no error, and returns nothing.
      */
     it("recommends a schedule for every pull-mode source the catalog offers", () => {
-      const missing = SOURCE_TYPE_OPTIONS.filter(
-        (option) =>
-          option.mode === "pull" &&
-          !option.deprecated &&
-          recommendedPullSchedule(option.value) === null,
-      ).map((option) => option.value);
+      const pullOptions = SOURCE_TYPE_OPTIONS.filter(
+        (option) => option.mode === "pull" && !option.deprecated,
+      );
+      expect(pullOptions.length).toBeGreaterThan(0);
+
+      const missing = pullOptions
+        .filter((option) => recommendedPullSchedule(option.value) === null)
+        .map((option) => option.value);
       expect(missing).toEqual([]);
     });
   });


### PR DESCRIPTION
## Why

The pull-schedule coverage test could pass vacuously if its catalog filter selected no active pull-mode sources. In that state, it would stop protecting the contract that every offered pull source has a recommended schedule.

Closes #7593

## What changed

- Collect the non-deprecated pull-mode options before checking schedule coverage.
- Assert that the candidate set is non-empty as a positive control.
- Keep the existing missing-schedule assertion over those candidates.

## Test plan

- `pnpm test:unit run ee/governance/dashboard/logic/__tests__/pullCadence.unit.test.ts` — 11 tests passed.
- `pnpm --filter @langwatch/web check:feature-parity` — all 10,744 enforced scenarios bound.
- `pnpm --filter @langwatch/web exec biome check ee/governance/dashboard/logic/__tests__/pullCadence.unit.test.ts` — passed.
- Forced the candidate filter to return no options and confirmed the new positive control fails with `expected 0 to be greater than 0`.
- Forced every pull option into the missing-schedule list and confirmed the coverage assertion fails while naming all six candidates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test clarity when verifying that every available pull-mode source receives a recommended schedule.
  * Added validation that eligible pull-mode sources are available before performing the check.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->