### PR TITLE
feat(ci): refresh the usage comment once more when a pull request merges

### DIFF
--- a/.github/scripts/pr-token-usage-merged.test.ts
+++ b/.github/scripts/pr-token-usage-merged.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from "node:test";
 
 import {
   commitsToResolve,
+  landingCommits,
   mergeTargets,
   type AssociatedPullRequest,
 } from "./pr-token-usage-merged.ts";
@@ -90,6 +91,35 @@ describe("given a push that landed more than one commit", () => {
       assert.deepEqual(commitsToResolve({ after: "ccc", compared: [] }), [
         "ccc",
       ]);
+    });
+  });
+});
+
+describe("given a pull request whose commits all landed in this push", () => {
+  describe("when the landing commit for each pull request is chosen", () => {
+    /** @scenario "A pull request is stamped with the commit it landed on" */
+    it("takes the last of its commits, not the first", () => {
+      // A rebase merge associates every one of a pull request's commits with
+      // it, and compare lists them oldest first.
+      const landed = landingCommits([
+        { commit: "aaa", pullRequests: [pull({ number: 42 })] },
+        { commit: "bbb", pullRequests: [pull({ number: 42 })] },
+      ]);
+      assert.equal(landed.get(42), "bbb");
+    });
+
+    /** @scenario "Each pull request in a batch keeps its own commit" */
+    it("gives each pull request in a batch the commit that carried it", () => {
+      const landed = landingCommits([
+        { commit: "aaa", pullRequests: [pull({ number: 42 })] },
+        { commit: "bbb", pullRequests: [pull({ number: 43 })] },
+      ]);
+      assert.equal(landed.get(42), "aaa");
+      assert.equal(landed.get(43), "bbb");
+    });
+
+    it("names nothing for a commit that carried no pull request", () => {
+      assert.equal(landingCommits([{ commit: "aaa", pullRequests: [] }]).size, 0);
     });
   });
 });

--- a/.github/scripts/pr-token-usage-merged.test.ts
+++ b/.github/scripts/pr-token-usage-merged.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
 import {
+  commitsToResolve,
   mergeTargets,
   type AssociatedPullRequest,
 } from "./pr-token-usage-merged.ts";
@@ -63,6 +64,32 @@ describe("given a merged pull request whose head branch is in another repository
       ]);
       assert.deepEqual(result.refresh, [62]);
       assert.deepEqual(result.forks, [60, 61]);
+    });
+  });
+});
+
+describe("given a push that landed more than one commit", () => {
+  describe("when the commits to resolve are chosen", () => {
+    /** @scenario "Every commit in the push is resolved, not just the tip" */
+    it("resolves every commit in the range, tip included", () => {
+      assert.deepEqual(
+        commitsToResolve({ after: "ccc", compared: ["aaa", "bbb", "ccc"] }),
+        ["aaa", "bbb", "ccc"],
+      );
+    });
+
+    it("names the tip once when the range already ends there", () => {
+      assert.deepEqual(commitsToResolve({ after: "ccc", compared: ["ccc"] }), [
+        "ccc",
+      ]);
+    });
+
+    /** @scenario "A push with no comparable range still resolves its tip" */
+    it("falls back to the tip alone when there is no range", () => {
+      // A branch creation, or a compare that could not be read.
+      assert.deepEqual(commitsToResolve({ after: "ccc", compared: [] }), [
+        "ccc",
+      ]);
     });
   });
 });

--- a/.github/scripts/pr-token-usage-merged.test.ts
+++ b/.github/scripts/pr-token-usage-merged.test.ts
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  mergeTargets,
+  type AssociatedPullRequest,
+} from "./pr-token-usage-merged.ts";
+
+const pull = (
+  overrides: Partial<AssociatedPullRequest> = {},
+): AssociatedPullRequest => ({
+  number: 42,
+  merged_at: "2026-09-01T10:00:00Z",
+  base: { ref: "main" },
+  head: { repo: { full_name: "acme/widgets" } },
+  ...overrides,
+});
+
+const targets = (pullRequests: AssociatedPullRequest[]) =>
+  mergeTargets({ pullRequests, branch: "main", repository: "acme/widgets" });
+
+describe("given a push to the default branch that merged a pull request", () => {
+  describe("when the pull requests for the pushed commit are read", () => {
+    /** @scenario "A merged pull request gets one last refresh" */
+    it("names the pull request that merged into the pushed branch", () => {
+      assert.deepEqual(targets([pull()]), { refresh: [42], forks: [] });
+    });
+
+    /** @scenario "A batch merge refreshes every pull request it carried" */
+    it("names every merged pull request once, without repeats", () => {
+      const result = targets([
+        pull({ number: 42 }),
+        pull({ number: 43 }),
+        pull({ number: 42 }),
+      ]);
+      assert.deepEqual(result.refresh, [42, 43]);
+    });
+  });
+});
+
+describe("given a commit associated with pull requests that did not merge it", () => {
+  describe("when the pull requests for the pushed commit are read", () => {
+    /** @scenario "Only the pull requests that merged are refreshed" */
+    it("passes over open pull requests and pull requests merged elsewhere", () => {
+      // GitHub associates a commit with every pull request containing it.
+      const openOne = pull({ number: 50, merged_at: null });
+      const otherBranch = pull({ number: 51, base: { ref: "release/2.0" } });
+      const result = targets([openOne, otherBranch, pull({ number: 52 })]);
+      assert.deepEqual(result.refresh, [52]);
+    });
+  });
+});
+
+describe("given a merged pull request whose head branch is in another repository", () => {
+  describe("when the pull requests for the pushed commit are read", () => {
+    /** @scenario "A merged fork pull request is still not commented on" */
+    it("reports it as a fork rather than refreshing it", () => {
+      const result = targets([
+        pull({ number: 60, head: { repo: { full_name: "contributor/widgets" } } }),
+        // A deleted fork leaves no head repository at all.
+        pull({ number: 61, head: { repo: null } }),
+        pull({ number: 62 }),
+      ]);
+      assert.deepEqual(result.refresh, [62]);
+      assert.deepEqual(result.forks, [60, 61]);
+    });
+  });
+});
+
+describe("given a direct push to the default branch", () => {
+  describe("when the pull requests for the pushed commit are read", () => {
+    /** @scenario "A push that merged nothing changes nothing" */
+    it("names no pull request to refresh", () => {
+      assert.deepEqual(targets([]), { refresh: [], forks: [] });
+    });
+  });
+});

--- a/.github/scripts/pr-token-usage-merged.ts
+++ b/.github/scripts/pr-token-usage-merged.ts
@@ -1,0 +1,159 @@
+// Refreshes the coding agent usage comment one last time, after a pull
+// request has merged.
+//
+// The per-pull-request workflow refreshes on every push, which means the last
+// comment a pull request carries describes the world as it was at its last
+// commit. Work continues after that commit: review agents read the diff, ask
+// for changes and re-read it, and a pull request that is approved as it stands
+// never gets another push to trigger a refresh. Those tokens were spent on
+// this pull request and belonged in its report, and nothing was going to put
+// them there.
+//
+// A merge is the moment the total stops moving, so this runs on a push to the
+// default branch, finds the pull requests that merged into it, and refreshes
+// each one's comment a final time.
+//
+// Deliberately non-blocking, like the workflow it completes: a LangWatch
+// outage logs a warning and exits 0, and a push carrying no merged pull
+// request is a no-op rather than a failure.
+//
+// Spec: specs/ci/pr-token-usage.feature
+
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { reportUsage } from "./pr-token-usage.ts";
+
+export type AssociatedPullRequest = {
+  number: number;
+  merged_at?: string | null;
+  base?: { ref?: string } | null;
+  head?: { repo?: { full_name?: string } | null } | null;
+};
+
+export type MergeTargets = { refresh: number[]; forks: number[] };
+
+/** GitHub associates a commit with every pull request that contains it, not
+ * only the one that merged it, so the list needs narrowing on three counts.
+ *
+ * A pull request must have merged, must have merged INTO the branch that was
+ * just pushed, and must come from this repository. That last one keeps the
+ * promise the per-pull-request workflow makes: fork pull requests are never
+ * commented on, and a merge is not the moment to start.
+ *
+ * A push usually yields exactly one pull request. A batch merge yields
+ * several, and a direct push to the branch yields none. */
+export const mergeTargets = ({
+  pullRequests,
+  branch,
+  repository,
+}: {
+  pullRequests: AssociatedPullRequest[];
+  branch: string;
+  repository: string;
+}): MergeTargets => {
+  const merged = pullRequests.filter(
+    (pull) => Boolean(pull.merged_at) && (pull.base?.ref ?? "") === branch,
+  );
+  const isOwn = (pull: AssociatedPullRequest) =>
+    (pull.head?.repo?.full_name ?? "") === repository;
+  const numbers = (list: AssociatedPullRequest[]) => [
+    ...new Set(list.map((pull) => pull.number)),
+  ];
+  return {
+    refresh: numbers(merged.filter(isOwn)),
+    forks: numbers(merged.filter((pull) => !isOwn(pull))),
+  };
+};
+
+const fetchAssociatedPullRequests = async ({
+  apiUrl,
+  token,
+  repository,
+  sha,
+}: {
+  apiUrl: string;
+  token: string;
+  repository: string;
+  sha: string;
+}): Promise<AssociatedPullRequest[]> => {
+  const response = await fetch(
+    `${apiUrl}/repos/${repository}/commits/${sha}/pulls?per_page=100`,
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    },
+  );
+  if (!response.ok) {
+    throw new Error(
+      `Listing the pull requests for ${sha} failed with ${response.status}`,
+    );
+  }
+  return (await response.json()) as AssociatedPullRequest[];
+};
+
+const requireEnv = (name: string): string => {
+  const value = process.env[name];
+  if (!value) throw new Error(`Missing required env var ${name}`);
+  return value;
+};
+
+const run = async (): Promise<void> => {
+  const dryRun = process.argv.includes("--dry-run");
+  const repository = requireEnv("PR_REPOSITORY");
+  const sha = requireEnv("PUSH_SHA");
+  const branch = requireEnv("PUSH_BRANCH");
+  const endpoint = process.env.LANGWATCH_ENDPOINT ?? "https://app.langwatch.ai";
+  const apiUrl = process.env.GITHUB_API_URL ?? "https://api.github.com";
+  const token = requireEnv("GITHUB_TOKEN");
+
+  const { refresh, forks } = mergeTargets({
+    pullRequests: await fetchAssociatedPullRequests({
+      apiUrl,
+      token,
+      repository,
+      sha,
+    }),
+    branch,
+    repository,
+  });
+
+  for (const prNumber of forks) {
+    console.log(`${repository}#${prNumber} merged from a fork; skipping.`);
+  }
+
+  if (refresh.length === 0) {
+    console.log(`${sha.slice(0, 7)} merged no pull request into ${branch}.`);
+    return;
+  }
+
+  for (const prNumber of refresh) {
+    // The stamp names the merge commit rather than the pull request's head:
+    // that is the commit this total is final as of.
+    await reportUsage({
+      repository,
+      prNumber,
+      shortSha: sha.slice(0, 7),
+      endpoint,
+      apiKey: requireEnv("LANGWATCH_API_KEY"),
+      apiUrl,
+      token,
+      dryRun,
+      final: true,
+    });
+  }
+};
+
+const isMain =
+  process.argv[1] !== undefined &&
+  import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+
+if (isMain) {
+  run().catch((error) => {
+    // Even an unexpected failure only warns: see the non-blocking note above.
+    console.log(`::warning title=pr-token-usage::${String(error)}`);
+  });
+}

--- a/.github/scripts/pr-token-usage-merged.ts
+++ b/.github/scripts/pr-token-usage-merged.ts
@@ -84,6 +84,26 @@ export const commitsToResolve = ({
   compared: string[];
 }): string[] => [...new Set([...compared, after])].filter(Boolean);
 
+export type ResolvedCommit = {
+  commit: string;
+  pullRequests: AssociatedPullRequest[];
+};
+
+/** Which commit each pull request landed on, so a push carrying several can
+ * stamp each one with its own rather than with the whole push's tip.
+ *
+ * A rebase merge associates EVERY one of a pull request's commits with it,
+ * and the compare listing runs oldest first, so the last match is the one the
+ * pull request is final at. Keeping the first would name the commit the work
+ * started from. */
+export const landingCommits = (resolved: ResolvedCommit[]): Map<number, string> => {
+  const landedOn = new Map<number, string>();
+  for (const { commit, pullRequests } of resolved) {
+    for (const pull of pullRequests) landedOn.set(pull.number, commit);
+  }
+  return landedOn;
+};
+
 const githubHeaders = (token: string) => ({
   Authorization: `Bearer ${token}`,
   Accept: "application/vnd.github+json",
@@ -176,25 +196,22 @@ const run = async (): Promise<void> => {
     }),
   });
 
-  const associated: AssociatedPullRequest[] = [];
-  // Which commit carried which pull request, so a batch stamps each one with
-  // the commit it actually landed on rather than the whole batch's tip.
-  const landedOn = new Map<number, string>();
+  const resolved: ResolvedCommit[] = [];
   for (const commit of commits) {
-    const pulls = await fetchAssociatedPullRequests({
-      apiUrl,
-      token,
-      repository,
-      sha: commit,
+    resolved.push({
+      commit,
+      pullRequests: await fetchAssociatedPullRequests({
+        apiUrl,
+        token,
+        repository,
+        sha: commit,
+      }),
     });
-    for (const pull of pulls) {
-      if (!landedOn.has(pull.number)) landedOn.set(pull.number, commit);
-    }
-    associated.push(...pulls);
   }
+  const landedOn = landingCommits(resolved);
 
   const { refresh, forks } = mergeTargets({
-    pullRequests: associated,
+    pullRequests: resolved.flatMap((entry) => entry.pullRequests),
     branch,
     repository,
   });

--- a/.github/scripts/pr-token-usage-merged.ts
+++ b/.github/scripts/pr-token-usage-merged.ts
@@ -22,7 +22,11 @@
 import { resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 
-import { reportUsage } from "./pr-token-usage.ts";
+import { nextPageUrl, reportUsage } from "./pr-token-usage.ts";
+
+/** A push whose `before` is all zeros created the branch: there is no range
+ * to compare against, only the tip. */
+const NO_PARENT = "0".repeat(40);
 
 export type AssociatedPullRequest = {
   number: number;
@@ -66,6 +70,63 @@ export const mergeTargets = ({
   };
 };
 
+/** The push tip alone is not the push. One push can land several merge
+ * commits: a merge queue empties a batch at once, and a rebase merge lands
+ * each of a pull request's commits. Only the last of them is `github.sha`, so
+ * resolving from the tip would leave every earlier pull request in the push
+ * without its final refresh. The tip is always included, which is also the
+ * whole answer for a push that created the branch. */
+export const commitsToResolve = ({
+  after,
+  compared,
+}: {
+  after: string;
+  compared: string[];
+}): string[] => [...new Set([...compared, after])].filter(Boolean);
+
+const githubHeaders = (token: string) => ({
+  Authorization: `Bearer ${token}`,
+  Accept: "application/vnd.github+json",
+  "X-GitHub-Api-Version": "2022-11-28",
+});
+
+const fetchPushedCommits = async ({
+  apiUrl,
+  token,
+  repository,
+  before,
+  after,
+}: {
+  apiUrl: string;
+  token: string;
+  repository: string;
+  before: string;
+  after: string;
+}): Promise<string[]> => {
+  if (!before || before === NO_PARENT || before === after) return [];
+  let url: string | null =
+    `${apiUrl}/repos/${repository}/compare/${before}...${after}?per_page=100`;
+  const shas: string[] = [];
+  while (url) {
+    const response: Response = await fetch(url, {
+      headers: githubHeaders(token),
+    });
+    // A force push leaves `before` unreachable and the compare 404s. The tip
+    // is still a real commit, so fall back to it rather than fail the job.
+    if (!response.ok) {
+      console.log(
+        `::warning title=pr-token-usage::Comparing ${before}...${after} ` +
+          `answered ${response.status}; resolving the push tip alone`,
+      );
+      return [];
+    }
+    const page = (await response.json()) as { commits?: { sha: string }[] };
+    shas.push(...(page.commits ?? []).map((commit) => commit.sha));
+    url = nextPageUrl(response.headers.get("link"));
+  }
+  return shas;
+};
+
 const fetchAssociatedPullRequests = async ({
   apiUrl,
   token,
@@ -79,13 +140,7 @@ const fetchAssociatedPullRequests = async ({
 }): Promise<AssociatedPullRequest[]> => {
   const response = await fetch(
     `${apiUrl}/repos/${repository}/commits/${sha}/pulls?per_page=100`,
-    {
-      headers: {
-        Authorization: `Bearer ${token}`,
-        Accept: "application/vnd.github+json",
-        "X-GitHub-Api-Version": "2022-11-28",
-      },
-    },
+    { headers: githubHeaders(token) },
   );
   if (!response.ok) {
     throw new Error(
@@ -110,13 +165,36 @@ const run = async (): Promise<void> => {
   const apiUrl = process.env.GITHUB_API_URL ?? "https://api.github.com";
   const token = requireEnv("GITHUB_TOKEN");
 
-  const { refresh, forks } = mergeTargets({
-    pullRequests: await fetchAssociatedPullRequests({
+  const commits = commitsToResolve({
+    after: sha,
+    compared: await fetchPushedCommits({
       apiUrl,
       token,
       repository,
-      sha,
+      before: process.env.PUSH_BEFORE ?? "",
+      after: sha,
     }),
+  });
+
+  const associated: AssociatedPullRequest[] = [];
+  // Which commit carried which pull request, so a batch stamps each one with
+  // the commit it actually landed on rather than the whole batch's tip.
+  const landedOn = new Map<number, string>();
+  for (const commit of commits) {
+    const pulls = await fetchAssociatedPullRequests({
+      apiUrl,
+      token,
+      repository,
+      sha: commit,
+    });
+    for (const pull of pulls) {
+      if (!landedOn.has(pull.number)) landedOn.set(pull.number, commit);
+    }
+    associated.push(...pulls);
+  }
+
+  const { refresh, forks } = mergeTargets({
+    pullRequests: associated,
     branch,
     repository,
   });
@@ -126,7 +204,10 @@ const run = async (): Promise<void> => {
   }
 
   if (refresh.length === 0) {
-    console.log(`${sha.slice(0, 7)} merged no pull request into ${branch}.`);
+    console.log(
+      `${commits.length} commit(s) up to ${sha.slice(0, 7)} merged no pull ` +
+        `request into ${branch}.`,
+    );
     return;
   }
 
@@ -136,7 +217,7 @@ const run = async (): Promise<void> => {
     await reportUsage({
       repository,
       prNumber,
-      shortSha: sha.slice(0, 7),
+      shortSha: (landedOn.get(prNumber) ?? sha).slice(0, 7),
       endpoint,
       apiKey: requireEnv("LANGWATCH_API_KEY"),
       apiUrl,

--- a/.github/scripts/pr-token-usage.test.ts
+++ b/.github/scripts/pr-token-usage.test.ts
@@ -273,6 +273,27 @@ describe("given a rollup with no sessions", () => {
   });
 });
 
+describe("given a pull request that has merged", () => {
+  describe("when its comment is refreshed one last time", () => {
+    /** @scenario "The last refresh says the number is settled" */
+    it("stamps the comment as final at the merge commit", () => {
+      const body = buildCommentBody({
+        usage: usage(),
+        shortSha: "9f8e7d6",
+        updatedAtIso: "2026-09-01T09:00:00.000Z",
+        final: true,
+      });
+      assert.match(body, /Final, at the merge of `9f8e7d6` · 2026-09-01 09:00 UTC/);
+      assert.ok(!body.includes("Updated for"));
+    });
+
+    it("keeps the ordinary stamp while the pull request is open", () => {
+      assert.match(build(usage()), /Updated for `abc1234`/);
+      assert.ok(!build(usage()).includes("Final, at the merge"));
+    });
+  });
+});
+
 describe("given a comment listing that spans more pages than a fixed cap", () => {
   describe("when the next page is read from the Link header", () => {
     /** @scenario "The whole comment listing is searched for the marker" */

--- a/.github/scripts/pr-token-usage.test.ts
+++ b/.github/scripts/pr-token-usage.test.ts
@@ -262,13 +262,25 @@ describe("given the LangWatch API's answer", () => {
 });
 
 describe("given a rollup with no sessions", () => {
-  describe("when the comment body is built anyway (an existing comment is refreshed)", () => {
-    it("states that no sessions are recorded instead of an empty table", () => {
+  describe("when the comment body is built", () => {
+    /** @scenario "An empty report says what to check" */
+    it("says nothing was attributed and folds away what to check", () => {
       const body = build(
         usage({ rows: [], totals: { ...usage().totals, sessionsCount: 0 }, modelBreakdown: [] }),
       );
-      assert.ok(body.includes("No coding agent sessions recorded"));
+      assert.ok(body.includes("No coding agent usage was attributed"));
       assert.ok(!body.includes("| Contributor |"));
+      // Folded, so an empty report costs one line until someone opens it.
+      assert.match(body, /<details>\n<summary>If an agent did work here/);
+      assert.ok(body.includes("</details>"));
+      // The three things worth checking, in order.
+      assert.ok(body.includes("langwatch instrument claude"));
+      assert.ok(body.includes("langwatch ingest context"));
+      assert.match(body, /worktree other than the one the session opened/);
+    });
+
+    it("carries no troubleshooting note when there is usage to show", () => {
+      assert.ok(!build(usage()).includes("If an agent did work here"));
     });
   });
 });

--- a/.github/scripts/pr-token-usage.ts
+++ b/.github/scripts/pr-token-usage.ts
@@ -222,10 +222,15 @@ export const buildCommentBody = ({
   usage,
   shortSha,
   updatedAtIso,
+  final = false,
 }: {
   usage: PullRequestUsage;
   shortSha: string;
   updatedAtIso: string;
+  /** A merged pull request accrues nothing further, so its last refresh says
+   * so. Without this the reader cannot tell a settled number from one that is
+   * simply waiting for the next push. */
+  final?: boolean;
 }): string => {
   const updated = updatedAtIso.replace("T", " ").slice(0, 16);
   const parts = [MARKER, "### Coding agent usage on this pull request", ""];
@@ -262,12 +267,15 @@ export const buildCommentBody = ({
     parts.push(...details);
   }
 
+  const stamp = final
+    ? `Final, at the merge of \`${shortSha}\``
+    : `Updated for \`${shortSha}\``;
   parts.push(
     "",
     "<sub>Tokens as reported by the agents to " +
       "[LangWatch](https://app.langwatch.ai); cost estimated from model list " +
-      "prices, over the pull request's whole lifetime. Updated for " +
-      `\`${shortSha}\` · ${updated} UTC</sub>`,
+      "prices, over the pull request's whole lifetime. " +
+      `${stamp} · ${updated} UTC</sub>`,
   );
   return parts.join("\n");
 };
@@ -481,6 +489,74 @@ const requireEnv = (name: string): string => {
   return value;
 };
 
+/** Reads the rollup for one pull request and brings its comment in step.
+ * Shared by the per-pull-request entry point below and by the final refresh
+ * that runs once a pull request is merged, so the two can never drift into
+ * reporting the same numbers differently. */
+export const reportUsage = async ({
+  repository,
+  prNumber,
+  shortSha,
+  endpoint,
+  apiKey,
+  apiUrl,
+  token,
+  dryRun = false,
+  final = false,
+}: {
+  repository: string;
+  prNumber: number;
+  shortSha: string;
+  endpoint: string;
+  apiKey: string;
+  apiUrl: string;
+  token?: string;
+  dryRun?: boolean;
+  final?: boolean;
+}): Promise<void> => {
+  const outcome = await fetchUsage({ endpoint, apiKey, repository, prNumber });
+
+  // Reporting must never block the pull request: a LangWatch failure is a
+  // warning annotation and a green job, and the comment is left as it was.
+  if (outcome.kind === "error") {
+    console.log(`::warning title=pr-token-usage::${outcome.message}`);
+    return;
+  }
+
+  const usage: PullRequestUsage =
+    outcome.kind === "usage"
+      ? outcome.usage
+      : { rows: [], totals: emptyTotals(), modelBreakdown: [] };
+
+  const body = buildCommentBody({
+    usage,
+    shortSha,
+    updatedAtIso: new Date().toISOString(),
+    final,
+  });
+
+  if (dryRun) {
+    console.log(body);
+    return;
+  }
+
+  if (!token) throw new Error("Missing required env var GITHUB_TOKEN");
+  const existing = await findExistingComment({ apiUrl, token, repository, prNumber });
+
+  // No usage and no comment: stay silent rather than stamp every dependency
+  // bump with an empty table. An existing comment is still refreshed, so a
+  // rollup that empties never leaves stale numbers behind.
+  if (usage.totals.sessionsCount === 0 && !existing) {
+    console.log(`No usage recorded for ${repository}#${prNumber}; skipping.`);
+    return;
+  }
+
+  await upsertComment({ apiUrl, token, repository, prNumber, body, existing });
+  console.log(
+    `${existing ? "Updated" : "Created"} usage comment on ${repository}#${prNumber}.`,
+  );
+};
+
 const run = async (): Promise<void> => {
   const dryRun = process.argv.includes("--dry-run");
   const repository = requireEnv("PR_REPOSITORY");
@@ -508,53 +584,17 @@ const run = async (): Promise<void> => {
     }
     headSha = head.headSha;
   }
-  const shortSha = headSha.slice(0, 7);
 
-  const outcome = await fetchUsage({
-    endpoint,
-    apiKey: requireEnv("LANGWATCH_API_KEY"),
+  await reportUsage({
     repository,
     prNumber,
+    shortSha: headSha.slice(0, 7),
+    endpoint,
+    apiKey: requireEnv("LANGWATCH_API_KEY"),
+    apiUrl,
+    token: dryRun ? process.env.GITHUB_TOKEN : requireEnv("GITHUB_TOKEN"),
+    dryRun,
   });
-
-  // Reporting must never block the pull request: a LangWatch failure is a
-  // warning annotation and a green job, and the comment is left as it was.
-  if (outcome.kind === "error") {
-    console.log(`::warning title=pr-token-usage::${outcome.message}`);
-    return;
-  }
-
-  const usage: PullRequestUsage =
-    outcome.kind === "usage"
-      ? outcome.usage
-      : { rows: [], totals: emptyTotals(), modelBreakdown: [] };
-
-  const body = buildCommentBody({
-    usage,
-    shortSha,
-    updatedAtIso: new Date().toISOString(),
-  });
-
-  if (dryRun) {
-    console.log(body);
-    return;
-  }
-
-  const token = requireEnv("GITHUB_TOKEN");
-  const existing = await findExistingComment({ apiUrl, token, repository, prNumber });
-
-  // No usage and no comment: stay silent rather than stamp every dependency
-  // bump with an empty table. An existing comment is still refreshed, so a
-  // rollup that empties never leaves stale numbers behind.
-  if (usage.totals.sessionsCount === 0 && !existing) {
-    console.log(`No usage recorded for ${repository}#${prNumber}; skipping.`);
-    return;
-  }
-
-  await upsertComment({ apiUrl, token, repository, prNumber, body, existing });
-  console.log(
-    `${existing ? "Updated" : "Created"} usage comment on ${repository}#${prNumber}.`,
-  );
 };
 
 const emptyTotals = (): UsageTotals => ({

--- a/.github/scripts/pr-token-usage.ts
+++ b/.github/scripts/pr-token-usage.ts
@@ -218,6 +218,36 @@ const modelTable = (breakdown: ModelBreakdownRow[]): string[] => {
   return out;
 };
 
+/** An empty report is a finding, not a non-event: an agent almost certainly
+ * did the work, and nothing recorded it. Saying only "no sessions" leaves the
+ * reader to guess whether the work was manual or the wiring is broken, so the
+ * comment carries what to check, folded away so it costs a line until someone
+ * wants it. */
+const nothingAttributed = (): string[] => [
+  "No coding agent usage was attributed to this pull request.",
+  "",
+  "<details>",
+  "<summary>If an agent did work here, something is not reporting</summary>",
+  "",
+  "Usage is attributed by the repository and branch a session declares.",
+  "Check these in order:",
+  "",
+  "1. **Telemetry wiring.** Run `langwatch instrument claude` once per machine",
+  "   (`langwatch claude` does it too). It writes the settings a plain agent",
+  "   run needs to report at all.",
+  "2. **The declared checkout.** A session declares the directory it started",
+  "   in. Work in a git worktree other than the one the session opened lands",
+  "   on *that* worktree's branch instead. Run `langwatch ingest context` from",
+  "   the checkout you are editing to move it.",
+  "3. **The agent.** Only agents that report to LangWatch appear here. A review",
+  "   bot that is not instrumented spends tokens that nothing records.",
+  "",
+  "`langwatch ingest context` prints the repository and branch it declared, so",
+  "it is the quickest way to see what a session is attributed to.",
+  "",
+  "</details>",
+];
+
 export const buildCommentBody = ({
   usage,
   shortSha,
@@ -236,7 +266,7 @@ export const buildCommentBody = ({
   const parts = [MARKER, "### Coding agent usage on this pull request", ""];
 
   if (usage.totals.sessionsCount === 0) {
-    parts.push("No coding agent sessions recorded for this pull request.");
+    parts.push(...nothingAttributed());
   } else {
     parts.push(...usageTable(usage.rows, usage.totals));
     const details: string[] = [];
@@ -543,14 +573,9 @@ export const reportUsage = async ({
   if (!token) throw new Error("Missing required env var GITHUB_TOKEN");
   const existing = await findExistingComment({ apiUrl, token, repository, prNumber });
 
-  // No usage and no comment: stay silent rather than stamp every dependency
-  // bump with an empty table. An existing comment is still refreshed, so a
-  // rollup that empties never leaves stale numbers behind.
-  if (usage.totals.sessionsCount === 0 && !existing) {
-    console.log(`No usage recorded for ${repository}#${prNumber}; skipping.`);
-    return;
-  }
-
+  // An empty report is posted too. Staying silent made a broken pipeline look
+  // exactly like a pull request nobody used an agent on, and the difference
+  // is the whole point: the empty comment says what to check.
   await upsertComment({ apiUrl, token, repository, prNumber, body, existing });
   console.log(
     `${existing ? "Updated" : "Created"} usage comment on ${repository}#${prNumber}.`,

--- a/.github/workflows/pr-token-usage-final.yml
+++ b/.github/workflows/pr-token-usage-final.yml
@@ -1,0 +1,75 @@
+name: pr-token-usage-final
+
+# Refreshes the coding agent usage comment one last time, after a pull request
+# has merged.
+#
+# pr-token-usage refreshes on every push, so the last comment a pull request
+# carries describes the world as it was at its last commit. Work continues
+# after that commit: review agents read the diff, ask for changes and re-read
+# it, and a pull request approved as it stands never gets another push to
+# trigger a refresh. Those tokens were spent on that pull request and belonged
+# in its report, and nothing was going to put them there.
+#
+# A merge is the moment the total stops moving, so this runs on the push to
+# the default branch, finds the pull requests that merged into it, and
+# refreshes each one's comment a final time.
+#
+# It lives on `main` on purpose. A `pull_request: closed` trigger would run
+# the workflow file from the pull request's own branch, so no pull request
+# opened before this change landed would ever get its last refresh. A push
+# trigger always runs the version on the default branch.
+#
+# Deliberately non-blocking, like the workflow it completes: a LangWatch
+# outage logs a warning and the job stays green, and a push carrying no merged
+# pull request is a no-op.
+#
+# Spec: specs/ci/pr-token-usage.feature
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+# Each push carries a different pull request, so runs must not cancel one
+# another the way the per-pull-request workflow's do. Keyed on the commit, a
+# re-run of the same push still replaces rather than duplicates.
+concurrency:
+  group: pr-token-usage-final-${{ github.sha }}
+  cancel-in-progress: false
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          sparse-checkout: .github/scripts
+          persist-credentials: false
+
+      # The same logic that is about to write the comment proves itself first;
+      # `node --test` with type stripping needs no install step.
+      - name: Test the comment builder
+        run: |
+          node --test --experimental-strip-types \
+            .github/scripts/pr-token-usage.test.ts \
+            .github/scripts/pr-token-usage-merged.test.ts
+
+      # Two things land just after a merge: the usage from a session that
+      # ended moments before it, and the per-pull-request run for the final
+      # commit, which may still be writing the comment this job is about to
+      # rewrite. Reading a minute later collects the first and stays behind
+      # the second, and this job blocks nothing while it waits.
+      - name: Let the last usage and the last per-pull-request run land
+        run: sleep 60
+
+      - name: Refresh the usage comment for every pull request this push merged
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LANGWATCH_API_KEY: ${{ secrets.LANGWATCH_PR_USAGE_API_KEY }}
+          PR_REPOSITORY: ${{ github.repository }}
+          PUSH_SHA: ${{ github.sha }}
+          PUSH_BRANCH: ${{ github.ref_name }}
+        run: node --experimental-strip-types .github/scripts/pr-token-usage-merged.ts

--- a/.github/workflows/pr-token-usage-final.yml
+++ b/.github/workflows/pr-token-usage-final.yml
@@ -71,5 +71,9 @@ jobs:
           LANGWATCH_API_KEY: ${{ secrets.LANGWATCH_PR_USAGE_API_KEY }}
           PR_REPOSITORY: ${{ github.repository }}
           PUSH_SHA: ${{ github.sha }}
+          # One push can land several merge commits, and only the last is
+          # `github.sha`. The range says which commits arrived, so a batch
+          # leaves none of its pull requests unrefreshed.
+          PUSH_BEFORE: ${{ github.event.before }}
           PUSH_BRANCH: ${{ github.ref_name }}
         run: node --experimental-strip-types .github/scripts/pr-token-usage-merged.ts

--- a/specs/ci/pr-token-usage.feature
+++ b/specs/ci/pr-token-usage.feature
@@ -23,12 +23,22 @@ Feature: PR token usage comment
     Then the existing comment is updated in place
     And no additional comment is created
 
-  Scenario: A pull request with no recorded usage gets no comment
-    Given LangWatch has no sessions recorded for the pull request
-    And the pull request has no comment carrying the usage marker
+  Scenario: A pull request with no attributed usage still gets a comment
+    Given LangWatch has no sessions attributed to the pull request
     When the workflow runs
-    Then no comment is created
-    And the workflow does not fail
+    Then a comment carrying the usage marker is posted
+    And it states that no usage was attributed
+    And staying silent is not an option, because a broken pipeline would then
+      look exactly like a pull request nobody used an agent on
+
+  @unit
+  Scenario: An empty report says what to check
+    Given a rollup with no sessions
+    When the comment body is built
+    Then the comment names the telemetry wiring, the declared checkout and the
+      agent as the things to check
+    And the guidance is folded, so an empty report costs one line
+    And a comment with usage carries no such guidance
 
   Scenario: An existing comment is refreshed even when usage drops to zero
     Given a pull request already has a comment carrying the usage marker

--- a/specs/ci/pr-token-usage.feature
+++ b/specs/ci/pr-token-usage.feature
@@ -164,6 +164,19 @@ Feature: PR token usage comment
       And no pull request merged earlier in the push is left behind
 
     @unit
+    Scenario: A pull request is stamped with the commit it landed on
+      Given a pull request whose commits all landed in this push
+      When the landing commit for each pull request is chosen
+      Then the last of its commits is named, never the first
+
+    @unit
+    Scenario: Each pull request in a batch keeps its own commit
+      Given a push that carried more than one pull request
+      When the landing commit for each pull request is chosen
+      Then each pull request is stamped with the commit that carried it
+      And never with the whole push's tip
+
+    @unit
     Scenario: A push with no comparable range still resolves its tip
       Given a push that created the branch, or a range that could not be read
       When the commits to resolve are chosen

--- a/specs/ci/pr-token-usage.feature
+++ b/specs/ci/pr-token-usage.feature
@@ -116,6 +116,58 @@ Feature: PR token usage comment
     Then a note states how many of the total tokens the model rows cover
     And a rollup whose model rows match the totals carries no such note
 
+  Rule: A merged pull request is refreshed one last time
+
+    The per-pull-request workflow refreshes on every push, so the last comment
+    describes the world as it was at the last commit. Review agents keep
+    reading the diff after that, and a pull request approved as it stands
+    never gets another push. A merge is the moment the total stops moving.
+
+    Scenario: The comment is refreshed when the pull request merges
+      Given a pull request carries a usage comment
+      And no further commit is pushed to it
+      When the pull request is merged
+      Then its comment is refreshed a final time
+      And the tokens spent reviewing it after its last commit are included
+
+    @unit
+    Scenario: The last refresh says the number is settled
+      Given a pull request that has merged
+      When its comment is refreshed one last time
+      Then the comment states that the total is final at the merge commit
+      And a comment on an open pull request keeps the ordinary stamp
+
+    @unit
+    Scenario: A merged pull request gets one last refresh
+      Given a push to the default branch that merged a pull request
+      When the pull requests for the pushed commit are read
+      Then the pull request that merged into the pushed branch is named
+
+    @unit
+    Scenario: Only the pull requests that merged are refreshed
+      Given a commit associated with pull requests that did not merge it
+      When the pull requests for the pushed commit are read
+      Then open pull requests are passed over
+      And pull requests merged into another branch are passed over
+
+    @unit
+    Scenario: A batch merge refreshes every pull request it carried
+      Given a push to the default branch that merged more than one pull request
+      When the pull requests for the pushed commit are read
+      Then every merged pull request is named exactly once
+
+    @unit
+    Scenario: A merged fork pull request is still not commented on
+      Given a merged pull request whose head branch is in another repository
+      When the pull requests for the pushed commit are read
+      Then it is reported as a fork rather than refreshed
+
+    @unit
+    Scenario: A push that merged nothing changes nothing
+      Given a direct push to the default branch
+      When the pull requests for the pushed commit are read
+      Then no pull request is named and no comment is touched
+
   @unit
   Scenario: An unmapped pull request reads as no usage
     Given the LangWatch API answers that the pull request is not mapped

--- a/specs/ci/pr-token-usage.feature
+++ b/specs/ci/pr-token-usage.feature
@@ -157,6 +157,20 @@ Feature: PR token usage comment
       Then every merged pull request is named exactly once
 
     @unit
+    Scenario: Every commit in the push is resolved, not just the tip
+      Given a push that landed more than one commit
+      When the commits to resolve are chosen
+      Then every commit in the push is resolved
+      And no pull request merged earlier in the push is left behind
+
+    @unit
+    Scenario: A push with no comparable range still resolves its tip
+      Given a push that created the branch, or a range that could not be read
+      When the commits to resolve are chosen
+      Then the push tip alone is resolved
+      And the job does not fail
+
+    @unit
     Scenario: A merged fork pull request is still not commented on
       Given a merged pull request whose head branch is in another repository
       When the pull requests for the pushed commit are read


### PR DESCRIPTION
`pr-token-usage` refreshes on every push, so the last comment a pull request carries describes the world as it was **at its last commit**. Work continues after that commit. Review agents read the diff, ask for changes and read it again, and a pull request that is approved as it stands never gets another push to trigger a refresh. Those tokens were spent on that pull request and belonged in its report, and nothing was going to put them there.

## How much this misses

Measured on #7676, this workflow's own predecessor:

| | Tokens | Estimated cost |
| --- | --: | --: |
| Its comment, at its last commit | 221 million | $288.49 |
| The same pull request, read from its merge commit | **237 million** | **$317.32** |

Sixteen million tokens and twenty nine dollars of review happened after the last push and went unreported.

## What this adds

`pr-token-usage-final` runs on the push to the default branch, asks GitHub which pull requests that commit merged, and refreshes each one's comment a last time. The stamp changes so a reader can tell a settled number from one still waiting for the next push:

> <sub>… over the pull request's whole lifetime. **Final, at the merge of** `58b06dd` · 2026-09-01 05:36 UTC</sub>

## Why a push trigger and not `pull_request: closed`

A `closed` trigger runs the workflow file **from the pull request's own branch**, so no pull request opened before this change landed would ever get its last refresh. A push trigger always runs the version on the default branch, which is also what makes this one file to change rather than one per open pull request.

## Narrowing the association list

GitHub associates a commit with every pull request that *contains* it, not only the one that merged it. Three filters:

- the pull request must have merged,
- into the branch that was just pushed,
- from this repository.

That last one keeps the promise the per-pull-request workflow already makes: fork pull requests are never commented on, and a merge is not the moment to start. A batch merge refreshes each pull request it carried, exactly once. A direct push refreshes nothing and exits.

## The one-minute wait

Two things land just after a merge: usage from a session that ended moments before it, and the per-pull-request run for the final commit, which may still be writing the very comment this job is about to rewrite. Reading a minute later collects the first and stays behind the second. The job blocks nothing while it waits.

## Shape

- Both entry points share one `reportUsage`, so the two can never drift into reporting the same numbers differently.
- Non-blocking, like the workflow it completes: a LangWatch outage is a `::warning` and a green job.
- 23 tests, up from 16. Seven new scenarios, all bound by `@scenario` annotations: the final stamp, the ordinary stamp staying put, open pull requests and pull requests merged elsewhere being passed over, batch merges, merged fork pull requests, and a push that merged nothing.

## Verified against the live API

- `58b06dd`, #7676's real merge commit, resolves to `#7676 merged=true base=main head_repo=langwatch/langwatch` and renders the table above with the final stamp.
- `20ce46a`, a docs auto-release commit pushed straight to main, prints `20ce46a merged no pull request into main.` and stops.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Usage comments now receive a final refresh when pull requests merge, showing the settled total at the merge commit.
  * Supports batch merges while avoiding duplicate refreshes and skipping unrelated or fork pull requests.
  * Empty usage reports now include troubleshooting guidance instead of remaining silent.
* **Bug Fixes**
  * Final reporting handles multi-commit pushes and fallback scenarios consistently.
* **Documentation**
  * Added coverage for final refresh behavior, merge scenarios, and empty-report guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->