### PR TITLE
fix(security): move the connected-agent example onto the ai 6 line (13 alerts, 3 HIGH)

### DIFF
--- a/sdks/typescript/examples/agent/package-lock.json
+++ b/sdks/typescript/examples/agent/package-lock.json
@@ -9,9 +9,10 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@ai-sdk/openai": "^2.0.6",
-        "ai": "^5.0.52",
-        "langwatch": "file:../../"
+        "@ai-sdk/openai": "^3.0.79",
+        "ai": "^6.0.0",
+        "langwatch": "file:../../",
+        "zod": "^4.0.14"
       },
       "devDependencies": {
         "tsx": "^4.20.0",
@@ -20,7 +21,7 @@
     },
     "../..": {
       "name": "langwatch",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",
@@ -129,14 +130,14 @@
       }
     },
     "node_modules/@ai-sdk/gateway": {
-      "version": "2.0.143",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-2.0.143.tgz",
-      "integrity": "sha512-ULaaBnXviDDKdpQdPyiiRv8fOxoNiSLoCLpVi35CiWlPgbkgJN8ME0PG5D08KO+Ad0X4x2wTrw0CxQLtnfC5Vw==",
+      "version": "3.0.186",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.186.tgz",
+      "integrity": "sha512-l8+DAYaSQ4ph/kbAem3GEu/C5WstoMQqSPuAcHfyFwXNBkh+oN+qGsVxFQdUViJ7W5USoMr6XrQiu+RX1A9Yyw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "2.0.3",
-        "@ai-sdk/provider-utils": "3.0.35",
-        "@vercel/oidc": "3.1.0"
+        "@ai-sdk/provider": "3.0.15",
+        "@ai-sdk/provider-utils": "4.0.50",
+        "@vercel/oidc": "3.2.0"
       },
       "engines": {
         "node": ">=18"
@@ -146,13 +147,13 @@
       }
     },
     "node_modules/@ai-sdk/openai": {
-      "version": "2.0.122",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-2.0.122.tgz",
-      "integrity": "sha512-/s0KGIbpQvjWgMQaUqmQOt0sdgnE8vFdnxz4tI5r/ICUvvCyCmT5CWrmwIVPEYvKSMMsAyDutal4SW3LarAZsQ==",
+      "version": "3.0.106",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.106.tgz",
+      "integrity": "sha512-sfqRcDDAeoAqA7RbVihZ10obDOia8+mZKjBdpFK95wpvsF0Izkqtne2MP2yeMnWI0DHBT3gGLT9+YUyG00DZmg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "2.0.3",
-        "@ai-sdk/provider-utils": "3.0.35"
+        "@ai-sdk/provider": "3.0.15",
+        "@ai-sdk/provider-utils": "4.0.50"
       },
       "engines": {
         "node": ">=18"
@@ -162,9 +163,9 @@
       }
     },
     "node_modules/@ai-sdk/provider": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-2.0.3.tgz",
-      "integrity": "sha512-h88OPkavHTiN9tMn2l5awAznGB0lXzjcLhgR1/rvjB2zlLprsNxbM2tt6OJsHUxduLC3klq0/eqaSf6fX5XVww==",
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.15.tgz",
+      "integrity": "sha512-XeZW1CcDF2GMbH4wejW6xBRI2QCOgnkVYUnxoeDadB1mf85riL2bMUeDoh+6gJ/r4mjNfzUPW8OjLjvwTP0u1Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "json-schema": "^0.4.0"
@@ -174,18 +175,18 @@
       }
     },
     "node_modules/@ai-sdk/provider-utils": {
-      "version": "3.0.35",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.35.tgz",
-      "integrity": "sha512-/5z8tRGuYXwFy0ID+WtiWiECJzH5x/rI/g/3H8x3GQvE4i4etnZfKWAiU23VZEymInh+4l7uMNQJyaNN/54QFw==",
+      "version": "4.0.50",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.50.tgz",
+      "integrity": "sha512-YAcB+7M1JhAYsHorTrWyldCyZihjCKr/QRXH2vFrara/+lwqNE7q5KzoucKLZ7ktFiUonhnhFhRoiymsq/2K2Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "2.0.3",
-        "@standard-schema/spec": "^1.0.0",
-        "eventsource-parser": "^3.0.6",
-        "undici": "^5.29.0"
+        "@ai-sdk/provider": "3.0.15",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.8",
+        "undici": "^6.28.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=18.17"
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
@@ -633,15 +634,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@fastify/busboy": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
-      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@opentelemetry/api": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
@@ -658,24 +650,24 @@
       "license": "MIT"
     },
     "node_modules/@vercel/oidc": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.1.0.tgz",
-      "integrity": "sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
+      "integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 20"
       }
     },
     "node_modules/ai": {
-      "version": "5.0.249",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-5.0.249.tgz",
-      "integrity": "sha512-FDiGfFRKRcMMDMhPZ7MEQnCqcXOzDfc1Rlq8TV/2bkbWgwcH0iBmdjQdNfrYH1z3kqgubJdW+L/U2OHIW3mY2w==",
+      "version": "6.0.273",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.273.tgz",
+      "integrity": "sha512-FbX1TxGbhKbu14T+rzXxUjYnR6BzDq91Ve7A/71EngmpwVP2Df8z42M0sXqE7HJTinrz31JhjqSnGy5V8tVReQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/gateway": "2.0.143",
-        "@ai-sdk/provider": "2.0.3",
-        "@ai-sdk/provider-utils": "3.0.35",
-        "@opentelemetry/api": "1.9.0"
+        "@ai-sdk/gateway": "3.0.186",
+        "@ai-sdk/provider": "3.0.15",
+        "@ai-sdk/provider-utils": "4.0.50",
+        "@opentelemetry/api": "^1.9.0"
       },
       "engines": {
         "node": ">=18"
@@ -794,15 +786,12 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.29.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
       "license": "MIT",
-      "dependencies": {
-        "@fastify/busboy": "^2.0.0"
-      },
       "engines": {
-        "node": ">=14.0"
+        "node": ">=18.17"
       }
     },
     "node_modules/zod": {
@@ -810,7 +799,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.5.4.tgz",
       "integrity": "sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/sdks/typescript/examples/agent/package.json
+++ b/sdks/typescript/examples/agent/package.json
@@ -11,8 +11,8 @@
   "author": "LangWatch",
   "license": "MIT",
   "dependencies": {
-    "@ai-sdk/openai": "^2.0.6",
-    "ai": "^5.0.52",
+    "@ai-sdk/openai": "^3.0.79",
+    "ai": "^6.0.0",
     "langwatch": "file:../../",
     "zod": "^4.0.14"
   },


### PR DESCRIPTION
## What

Moves `sdks/typescript/examples/agent` onto the ai 6 line, clearing all thirteen alerts on its lockfile.

## Deployment Impact

No operator action required. No environment variable, helm value, chart or migration changes, and no new service surface.

Nothing ships from this directory. It is a `private: true` example, it is not a member of the pnpm workspace, and no workflow installs it. The change is user-facing only in the sense that the README tells a reader to run `npm install` here, so the committed lockfile is what they get.

## Why the whole chain has to move

All thirteen alerts trace to one path:

```
@ai-sdk/openai 2.0.122 -> @ai-sdk/provider-utils 3.0.35 -> undici 5.29.0
```

Neither end can be patched in place:

- **provider-utils cannot be fixed on 3.x.** The advisory range is `<= 3.0.97`, and the highest version ever published on that line is 3.0.36. There is no 3.x fix, which is why the alert reports no `firstPatchedVersion`. The escape is 4.x.
- **undici cannot be overridden in place.** `@ai-sdk/provider-utils@3.0.35` declares `undici: ^5.29.0`, so forcing 6.x would violate its own declared range rather than fix anything.

`@ai-sdk/provider-utils@4.0.x` declares `undici: ^6.28.0`, and it arrives with `@ai-sdk/openai` 3.x and `ai` 6. So the version pair is what fixes this, not an override.

## Alerts closed

All thirteen, checked by interval-testing the resolved version against each alert's own `vulnerableVersionRange`:

| Alerts | Severity | Package | Resolves to |
|---|---|---|---|
| #2145, #2146, #2149 | HIGH | undici | 6.28.0 |
| #2142, #2143, #2144, #2150, #2152, #2153, #2154 | MODERATE | undici | 6.28.0 |
| #2148, #2151 | LOW | undici | 6.28.0 |
| #2147 | LOW | @ai-sdk/provider-utils | 4.0.50 |

undici 6.28.0 sits exactly on the fix boundary of the three `< 6.28.0` advisories and above every other range for that package, so it enters clean.

## Compatibility

The example uses four things from the bumped packages: `openai()`, `generateText`, `tool` and `ModelMessage`. All four are unchanged on ai 6, and I typechecked that exact surface against the installed packages rather than reading a changelog:

```
tsc --noEmit --strict --module nodenext --moduleResolution nodenext ...  -> exit 0
```

`sdks/typescript` peer-declares `@ai-sdk/openai` at `>=2.0.0 <5.0.0`, so 3.x needs no change there. This example is the only one of the eight with a committed lockfile, which is why it is the only one carrying alerts; the others resolve fresh and are unaffected either way.

## Lockfile

Full version-set diff:

```
@ai-sdk/openai:         2.0.122 -> 3.0.106
@ai-sdk/provider-utils: 3.0.35  -> 4.0.50
@ai-sdk/provider:       2.0.3   -> 3.0.15
@ai-sdk/gateway:        2.0.143 -> 3.0.186
ai:                     5.0.249 -> 6.0.273
undici:                 5.29.0  -> 6.28.0
@vercel/oidc:           3.1.0   -> 3.2.0
langwatch:              1.10.0  -> 1.11.0
@fastify/busboy:        2.1.1   -> (gone, undici 6 no longer needs it)
```

Every newly present version was checked against the full advisory list for its package, not just against the alerts that fired: `@ai-sdk/gateway`, `@ai-sdk/provider`, `@ai-sdk/openai` and `@vercel/oidc` have no advisories at all; `ai` 6.0.273 is above both of its ranges; `undici` and `provider-utils` are covered above. So this closes thirteen alerts without opening any.

## Verified

- `npm install --package-lock-only` exit 0, version-set diff as above
- `npm install` exit 0, resolving ai 6.0.273 / @ai-sdk/openai 3.0.106 / undici 6.28.0
- the example's ai surface typechecked against the installed packages, exit 0
- all thirteen alerts interval-tested to closed, zero remaining

## Not included: the go.mod alert

Alert #2140 (HIGH, `github.com/maximhq/bifrost/core < 1.5.17`) is live on `go.mod` and I deliberately have not fixed it here. 1.5.17 removes API this repo depends on:

```
services/aigateway/adapters/providers/bifrost.go:1134  ProxyConfig.URL   string -> *schemas.EnvVar
services/aigateway/adapters/providers/bifrost.go:1162  AzureKeyConfig.Deployments   removed
services/aigateway/adapters/providers/bifrost.go:1166  AzureKeyConfig.APIVersion    removed
services/aigateway/adapters/providers/bifrost.go:1179  BedrockKeyConfig.Deployments removed
services/aigateway/adapters/providers/bifrost_error.go:197,368  ExtraFields.ModelRequested removed
```

`Deployments` is the per-credential map from model name to Azure deployment or Bedrock inference profile, and 1.5.x drops it from Azure, Bedrock and Vertex key configs with no replacement in `schemas` (the new `UseDeploymentsEndpoint bool` is a different thing). Migrating it means deciding where a customer's deployment map lives now, which is a product call rather than a code change I should make inside a security PR. Filed separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the example agent to use newer versions of its AI SDK dependencies.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->