### PR TITLE
test(governance): give the pull-schedule coverage test a positive control (#7593)

### DIFF
--- a/platform/app/ee/governance/dashboard/logic/__tests__/pullCadence.unit.test.ts
+++ b/platform/app/ee/governance/dashboard/logic/__tests__/pullCadence.unit.test.ts
@@ -64,12 +64,19 @@ describe("given the pull-cadence cron mapping", () => {
      * a source that looks configured, reports no error, and returns nothing.
      */
     it("recommends a schedule for every pull-mode source the catalog offers", () => {
-      const missing = SOURCE_TYPE_OPTIONS.filter(
-        (option) =>
-          option.mode === "pull" &&
-          !option.deprecated &&
-          recommendedPullSchedule(option.value) === null,
-      ).map((option) => option.value);
+      const pullOptions = SOURCE_TYPE_OPTIONS.filter(
+        (option) => option.mode === "pull" && !option.deprecated,
+      );
+      // The candidate set has to be proven non-empty first, the same way the
+      // round-trip test above proves it. Folding the selection and the check
+      // into one filter makes an empty result mean either "every pull source
+      // has a schedule" or "nothing is a pull source any more", and the
+      // assertion cannot tell those apart.
+      expect(pullOptions.length).toBeGreaterThan(0);
+
+      const missing = pullOptions
+        .filter((option) => recommendedPullSchedule(option.value) === null)
+        .map((option) => option.value);
       expect(missing).toEqual([]);
     });
   });


### PR DESCRIPTION
## Ticket

Closes #7593.

A test meant to catch a pull-mode source shipping without a poll cadence passed whether or not it checked anything.

## Premise, re-checked on current main

Holds exactly as written. The test is still there, still folded into one filter:

```ts
const missing = SOURCE_TYPE_OPTIONS.filter(
  (option) =>
    option.mode === "pull" &&
    !option.deprecated &&
    recommendedPullSchedule(option.value) === null,
).map((option) => option.value);
expect(missing).toEqual([]);
```

`missing` is empty in two unrelated situations and the assertion cannot tell them apart: every pull source has a schedule, which is the property under test, or nothing in the catalog is a non-deprecated pull source at all, because the field was renamed, the literal drifted, the export moved, or everything got deprecated.

That second reading is not hypothetical. The mapping is a `Partial<Record<…>>`, so a pull-mode type added without an entry compiles fine and resolves to no recommendation, and the composer then creates a source with no cadence that never polls. The docblock above the test already says so. The guard for it was unsound.

## Change

Select first, prove the selection is non-empty, then check the property. One test, one file.

The shape is not invented for this PR. The round-trip test eleven lines above already does exactly this:

```ts
expect(RECOMMENDED_SCHEDULES.length).toBeGreaterThan(0);
```

So this is the file's own convention, applied to the one test that missed it.

## Evidence

- `pnpm test:unit run ee/governance/dashboard/logic/__tests__/pullCadence.unit.test.ts`: **11 passed**, before and after.
- `pnpm test:unit run ee/governance`: **758 passed across 72 files**.
- `pnpm typecheck:all`: clean. Verified live rather than assumed, by injecting a deliberate type error and confirming it was reported (exit 1) and that the clean tree exits 0.
- `pnpm check:feature-parity`: OK, 10744 enforced scenarios bound. This PR adds and removes no annotations.
- Biome: **0 diagnostics of any severity** on the changed file.

### The mutations the acceptance criteria ask for

Each condition broken in turn, against both the old test and the new one. The middle column is the point of the PR.

| mutation | test on `main` | test in this PR |
|---|---|---|
| the catalog stops yielding any pull-mode source (`mode: "pull"` drifts to `"poll"`) | **11 passed, notices nothing** | **1 failed**, 10 passed |
| a pull-mode source is added with no schedule mapping | 1 failed, 10 passed | 1 failed, 10 passed |

Exactly one failure each time, and no detection traded away: the second row is the property the test already had, and it still holds.

The first row is the whole ticket. Renaming the mode literal removes every candidate, the old assertion sees an empty list, and it reports success on a catalog where nothing would ever poll.

## One thing I looked at and deliberately did not fold in

The `filter(...)` then `toEqual([])` shape without a positive control is not unique to this test. A crude scan across `src` and `ee` flags on the order of a hundred blocks in dozens of files.

I did not touch any of them and I am not claiming they are all defective: most assert on a value that is genuinely allowed to be empty, such as an API response that should contain no rows, where an empty result is the property rather than an accident. Separating the real cases from the safe ones needs judgement per test, which is a different piece of work from this ticket and should be scoped as its own if someone wants it. Flagging it here only so the pattern is on the record.

## Advisory note

Advisory PR from the tech-debt-fixer bot, for human review, not to be merged by the bot.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved validation coverage for pull-source scheduling options.
  * Added checks to ensure available pull-mode options are present and evaluated for recommended schedules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->