### PR TITLE
feat(datasets): search a dataset's rows from the editor (#7731)

### DIFF
--- a/platform/app/src/components/datasets/editor/DatasetEditorTable.tsx
+++ b/platform/app/src/components/datasets/editor/DatasetEditorTable.tsx
@@ -207,17 +207,62 @@ export function DatasetEditorTable({
   // would leave a selection pointing at rows the user never picked. A draft is
   // also entirely on screen already, so there is nothing to search for.
   const [searchInput, setSearchInput] = useState("");
-  const [debouncedSearch] = useDebounce(searchInput, 300);
-  const activeSearch = datasetId
-    ? debouncedSearch.trim() || undefined
-    : undefined;
+  // The term is debounced TOGETHER with the dataset it was typed against. A
+  // bare-string debounce leaves the previous dataset's term in the debounced
+  // value for 300ms after the user moves to another dataset without leaving the
+  // editor — long enough to fetch the new dataset narrowed by a word that was
+  // never typed against it. Pairing them lets the term be discarded the instant
+  // it stops belonging to what is on screen, without waiting for the debounce.
+  const searchScope = useMemo(
+    () => ({ datasetId, text: searchInput }),
+    [datasetId, searchInput],
+  );
+  const [debouncedSearch] = useDebounce(searchScope, 300);
+  const activeSearch =
+    datasetId && debouncedSearch.datasetId === datasetId
+      ? debouncedSearch.text.trim() || undefined
+      : undefined;
   const isSearching = !!activeSearch;
+
+  // Where the user was before the search started, so clearing it puts them back
+  // rather than on page 1 — see `onSearchChange` below, which maintains it.
+  const pageBeforeSearch = useRef<number | undefined>(undefined);
+  // The dataset's own total, remembered from its last unsearched read — see the
+  // count derivation below, which maintains it.
+  const unsearchedRecordCount = useRef<number | undefined>(undefined);
+
+  // Search term, page and the remembered dataset total each describe ONE
+  // dataset. The editor stays mounted when the user moves between datasets
+  // client-side — the route param changes underneath it — so unless they are
+  // dropped here they carry over: the new dataset opens narrowed by a word
+  // typed against the old one, at a page it may not have, with the old one's
+  // size on the count chip and nothing on screen explaining any of it.
+  //
+  // Reset during render, not in an effect: an effect runs after the render that
+  // has already put the stale page into the query key, so the request for it
+  // goes out regardless. `setData` clears the row selection when the new
+  // dataset's rows land, so there is nothing to clear here.
+  const [openDatasetId, setOpenDatasetId] = useState(datasetId);
+  const datasetChanged = openDatasetId !== datasetId;
+  if (datasetChanged) {
+    setOpenDatasetId(datasetId);
+    setSearchInput("");
+    setPage(1);
+    pageBeforeSearch.current = undefined;
+    unsearchedRecordCount.current = undefined;
+  }
+  // The state reset above only lands on the re-render React schedules; the
+  // query below reads its arguments from THIS render, which still holds the
+  // previous dataset's page. Derive what to ask for so the new dataset is never
+  // requested at a page that belonged to another one. (`activeSearch` needs no
+  // equivalent — it is already gated on the term belonging to this dataset.)
+  const requestedPage = datasetChanged ? 1 : page;
 
   const databaseDataset = api.datasetRecord.listPaginated.useQuery(
     {
       projectId: project?.id ?? "",
       datasetId: datasetId ?? "",
-      page,
+      page: requestedPage,
       limit: pageSize,
       search: activeSearch,
     },
@@ -267,14 +312,6 @@ export function DatasetEditorTable({
   // otherwise the header could only say how many rows matched, which reads as
   // the dataset having shrunk. The editor always loads unsearched first (the
   // box starts empty), so this is populated before any search can run.
-  const unsearchedRecordCount = useRef<number | undefined>(undefined);
-  if (!isSearching && serverRecordCount != null) {
-    unsearchedRecordCount.current = serverRecordCount;
-  }
-
-  const pageCount = Math.max(1, Math.ceil((serverRecordCount ?? 0) / pageSize));
-  const currentPage = Math.min(page, pageCount);
-  const isLastPage = currentPage >= pageCount;
   // While `keepPreviousData` serves the prior key's result during a key change,
   // `isPlaceholderData` is true. Skip hydrating from it: a `datasetId` switch
   // would otherwise populate the grid with the OLD dataset's rows under the NEW
@@ -282,6 +319,17 @@ export function DatasetEditorTable({
   // same-dataset page switch this just holds the current page until the next one
   // lands.
   const holdingPreviousData = databaseDataset.isPlaceholderData;
+  // Only ever remembered from a SETTLED read of the dataset being shown. Held
+  // over from a placeholder, the number belongs to whichever dataset was open
+  // before, and a later search would report "3 of 679" about a dataset with 3
+  // rows in it — a total the user has no way to recognise as the wrong one.
+  if (!isSearching && !holdingPreviousData && serverRecordCount != null) {
+    unsearchedRecordCount.current = serverRecordCount;
+  }
+
+  const pageCount = Math.max(1, Math.ceil((serverRecordCount ?? 0) / pageSize));
+  const currentPage = Math.min(page, pageCount);
+  const isLastPage = currentPage >= pageCount;
   // Snap a now-out-of-range page back into range — e.g. the last page's rows
   // were all deleted under us (the post-delete refetch shrinks the count) or a
   // navigation refetch returned a smaller dataset. Acts ONLY on an authoritative
@@ -410,7 +458,6 @@ export function DatasetEditorTable({
   // LAST page, so returning a multi-page dataset to page 1 would withdraw them
   // for the rest of the session — a search would silently cost the user their
   // place and their way of adding a row.
-  const pageBeforeSearch = useRef<number | undefined>(undefined);
   // The bookkeeping is done HERE, in the event handler, and not inside a
   // `setPage` updater: React replays updaters in StrictMode to surface impurity,
   // and an updater that writes this ref reads it back as `undefined` on the

--- a/platform/app/src/components/datasets/editor/DatasetEditorTable.tsx
+++ b/platform/app/src/components/datasets/editor/DatasetEditorTable.tsx
@@ -223,6 +223,14 @@ export function DatasetEditorTable({
       ? debouncedSearch.text.trim() || undefined
       : undefined;
   const isSearching = !!activeSearch;
+  // Whether a search OWNS the grid — the settled one, or the one the user has
+  // already typed and the debounce has not run yet. `isSearching` alone is the
+  // wrong gate for withdrawing the ways of adding a row: it trails the box by
+  // 300ms, so for that long the editor still offers a row that the search
+  // landing a moment later removes from the grid. Presentation of search
+  // RESULTS stays on `isSearching`, which is the right gate for it: there is
+  // nothing to say about matches until the search has actually run.
+  const searchOwnsTheGrid = !!datasetId && (!!searchInput.trim() || isSearching);
 
   // Where the user was before the search started, so clearing it puts them back
   // rather than on page 1 — see `onSearchChange` below, which maintains it.
@@ -531,6 +539,18 @@ export function DatasetEditorTable({
       : undefined,
   });
 
+  // A search withdraws the CSV import (see its render gate at the bottom), but
+  // the gate only unmounts the dialog — the disclosure goes on believing it is
+  // open. Left that way the flag outlives the dialog, and clearing the search
+  // reopens it on its own: a dialog the user last touched a search ago, back on
+  // screen without being asked for and empty of whatever they had chosen in it.
+  // Tell the disclosure it closed, so "withdrawn" and "closed" cannot disagree.
+  const csvModalOpen = addRowsFromCSVModal.open;
+  const closeCsvModal = addRowsFromCSVModal.onClose;
+  useEffect(() => {
+    if (searchOwnsTheGrid && csvModalOpen) closeCsvModal();
+  }, [searchOwnsTheGrid, csvModalOpen, closeCsvModal]);
+
   // ── Table assembly ────────────────────────────────────────────────
 
   const rowCount = records.length;
@@ -538,12 +558,12 @@ export function DatasetEditorTable({
   // the dataset, so on the paged saved view it belongs only on the last page —
   // adding it on an earlier full page would create a row the user can't see.
   // In-memory mode (no datasetId) is one local list, so it always shows it.
-  // ...and never while a search is in effect: a new row is empty, so it would
+  // ...and never once a search owns the grid: a new row is empty, so it would
   // not match the search and would appear to vanish the moment it was created.
   // This one flag covers both the button and the phantom row (via
   // `displayRowCount`); the CSV import is withdrawn alongside them, for the same
   // reason — its rows land at the end of the dataset, outside the matches.
-  const showAddRow = (!datasetId || isLastPage) && !isSearching;
+  const showAddRow = (!datasetId || isLastPage) && !searchOwnsTheGrid;
   // A refused search leaves the rows read BEFORE it on screen: the store is only
   // written from a settled `data` (see the effect above), so an error leaves the
   // previous page in place. Those rows were never matched against the search,
@@ -878,7 +898,7 @@ export function DatasetEditorTable({
             >
               <Download size={16} /> Download as CSV
             </Button>
-            {datasetId && !isSearching && (
+            {datasetId && !searchOwnsTheGrid && (
               <Button
                 size="sm"
                 variant="ghost"
@@ -1091,11 +1111,12 @@ export function DatasetEditorTable({
         />
       )}
 
-      {/* Withdrawn while a search is in effect for the same reason its toolbar
-          button is: a click landing inside the search debounce opens this while
-          `isSearching` is still false, and rows imported here land at the end of
-          the dataset — outside the matches on screen. */}
-      {datasetId && addRowsFromCSVModal.open && !isSearching && (
+      {/* Withdrawn once a search owns the grid, for the same reason its toolbar
+          button is: rows imported here land at the end of the dataset, outside
+          the matches on screen. The effect above is what makes the withdrawal
+          stick — unmounting alone would leave the disclosure believing it is
+          still open, and clearing the search would bring it back. */}
+      {datasetId && addRowsFromCSVModal.open && !searchOwnsTheGrid && (
         <AddRowsFromCSVModal
           isOpen={addRowsFromCSVModal.open}
           onClose={() => {

--- a/platform/app/src/components/datasets/editor/DatasetEditorTable.tsx
+++ b/platform/app/src/components/datasets/editor/DatasetEditorTable.tsx
@@ -230,7 +230,8 @@ export function DatasetEditorTable({
   // landing a moment later removes from the grid. Presentation of search
   // RESULTS stays on `isSearching`, which is the right gate for it: there is
   // nothing to say about matches until the search has actually run.
-  const searchOwnsTheGrid = !!datasetId && (!!searchInput.trim() || isSearching);
+  const searchOwnsTheGrid =
+    !!datasetId && (!!searchInput.trim() || isSearching);
 
   // Where the user was before the search started, so clearing it puts them back
   // rather than on page 1 — see `onSearchChange` below, which maintains it.

--- a/platform/app/src/components/datasets/editor/DatasetEditorTable.tsx
+++ b/platform/app/src/components/datasets/editor/DatasetEditorTable.tsx
@@ -230,7 +230,7 @@ export function DatasetEditorTable({
   // landing a moment later removes from the grid. Presentation of search
   // RESULTS stays on `isSearching`, which is the right gate for it: there is
   // nothing to say about matches until the search has actually run.
-  const searchOwnsTheGrid =
+  const hasSearchTakenTheGrid =
     !!datasetId && (!!searchInput.trim() || isSearching);
 
   // Where the user was before the search started, so clearing it puts them back
@@ -353,13 +353,19 @@ export function DatasetEditorTable({
   // back to page 1 — undoing the restore it was meant to protect.
   //
   // Floored at 1, so it never drives the page to 0.
-  const searchSettling = (searchInput.trim() || undefined) !== activeSearch;
+  const isSearchSettling = (searchInput.trim() || undefined) !== activeSearch;
   useEffect(() => {
-    if (serverRecordCount == null || holdingPreviousData || searchSettling)
+    if (serverRecordCount == null || holdingPreviousData || isSearchSettling)
       return;
     const count = Math.max(1, Math.ceil(serverRecordCount / pageSize));
     if (page > count) setPage(count);
-  }, [serverRecordCount, pageSize, page, holdingPreviousData, searchSettling]);
+  }, [
+    serverRecordCount,
+    pageSize,
+    page,
+    holdingPreviousData,
+    isSearchSettling,
+  ]);
 
   const datasetName = datasetId
     ? databaseDataset.data?.name
@@ -546,11 +552,11 @@ export function DatasetEditorTable({
   // reopens it on its own: a dialog the user last touched a search ago, back on
   // screen without being asked for and empty of whatever they had chosen in it.
   // Tell the disclosure it closed, so "withdrawn" and "closed" cannot disagree.
-  const csvModalOpen = addRowsFromCSVModal.open;
+  const isCsvModalOpen = addRowsFromCSVModal.open;
   const closeCsvModal = addRowsFromCSVModal.onClose;
   useEffect(() => {
-    if (searchOwnsTheGrid && csvModalOpen) closeCsvModal();
-  }, [searchOwnsTheGrid, csvModalOpen, closeCsvModal]);
+    if (hasSearchTakenTheGrid && isCsvModalOpen) closeCsvModal();
+  }, [hasSearchTakenTheGrid, isCsvModalOpen, closeCsvModal]);
 
   // ── Table assembly ────────────────────────────────────────────────
 
@@ -564,13 +570,13 @@ export function DatasetEditorTable({
   // This one flag covers both the button and the phantom row (via
   // `displayRowCount`); the CSV import is withdrawn alongside them, for the same
   // reason — its rows land at the end of the dataset, outside the matches.
-  const showAddRow = (!datasetId || isLastPage) && !searchOwnsTheGrid;
+  const showAddRow = (!datasetId || isLastPage) && !hasSearchTakenTheGrid;
   // A refused search leaves the rows read BEFORE it on screen: the store is only
   // written from a settled `data` (see the effect above), so an error leaves the
   // previous page in place. Those rows were never matched against the search,
   // and leaving them under a search box reads as "here is what matched" — a
   // complete, confident, false answer. Withdraw them and say what happened.
-  const searchFailed = isSearching && !!databaseDatasetError;
+  const hasSearchFailed = isSearching && !!databaseDatasetError;
   // A number of matches is the search's OWN answer, so it can only be reported
   // once the search's own read has settled. Two states have no such answer and
   // both used to report one anyway:
@@ -584,8 +590,8 @@ export function DatasetEditorTable({
   //
   // In both, fall back to the dataset's own size, which is what the chip says
   // with no search in effect and is true either way.
-  const matchCountKnown = !searchFailed && !holdingPreviousData;
-  const displayRowCount = searchFailed
+  const isMatchCountKnown = !hasSearchFailed && !holdingPreviousData;
+  const displayRowCount = hasSearchFailed
     ? 0
     : showAddRow
       ? Math.max(rowCount + 1, 3)
@@ -846,12 +852,12 @@ export function DatasetEditorTable({
           title
         )}
         <Text fontSize="13px" color="fg.muted" data-testid="dataset-row-count">
-          {/* With no match count to report (see `matchCountKnown`), the count
+          {/* With no match count to report (see `isMatchCountKnown`), the count
               on hand describes unsearched rows, so reporting it as the result
               of the search would be false. Report the dataset's own size
               instead, and say nothing at all when even that is not known. */}
           {isSearching
-            ? matchCountKnown
+            ? isMatchCountKnown
               ? formatSearchRecordCount({
                   matched: totalRecordCount,
                   total: unsearchedRecordCount.current,
@@ -912,7 +918,7 @@ export function DatasetEditorTable({
             >
               <Download size={16} /> Download as CSV
             </Button>
-            {datasetId && !searchOwnsTheGrid && (
+            {datasetId && !hasSearchTakenTheGrid && (
               <Button
                 size="sm"
                 variant="ghost"
@@ -1003,7 +1009,7 @@ export function DatasetEditorTable({
               missing rows would have been: below it, the reader gets a blank
               box with an unattached sentence under it. Held until the read
               settles so the message does not flash between keystrokes. */}
-          {searchFailed && (
+          {hasSearchFailed && (
             <Text
               fontSize="13px"
               color="fg.muted"
@@ -1016,7 +1022,7 @@ export function DatasetEditorTable({
           )}
 
           {isSearching &&
-            !searchFailed &&
+            !hasSearchFailed &&
             !databaseDataset.isLoading &&
             !holdingPreviousData &&
             rowCount === 0 && (
@@ -1130,7 +1136,7 @@ export function DatasetEditorTable({
           the matches on screen. The effect above is what makes the withdrawal
           stick — unmounting alone would leave the disclosure believing it is
           still open, and clearing the search would bring it back. */}
-      {datasetId && addRowsFromCSVModal.open && !searchOwnsTheGrid && (
+      {datasetId && addRowsFromCSVModal.open && !hasSearchTakenTheGrid && (
         <AddRowsFromCSVModal
           isOpen={addRowsFromCSVModal.open}
           onClose={() => {

--- a/platform/app/src/components/datasets/editor/DatasetEditorTable.tsx
+++ b/platform/app/src/components/datasets/editor/DatasetEditorTable.tsx
@@ -43,11 +43,13 @@ import {
   useState,
 } from "react";
 import { Check, Download, Edit2, Plus, Trash2, Upload, X } from "react-feather";
+import { useDebounce } from "use-debounce";
 import { useStore } from "zustand";
 
 import { AddOrEditDatasetDrawer } from "~/components/AddOrEditDatasetDrawer";
 import { ColumnTypeIcon } from "~/components/shared/ColumnTypeIcon";
 import { Pagination } from "~/components/ui/Pagination";
+import { SearchInput } from "~/components/ui/SearchInput";
 import { SelectionActionBar } from "~/components/ui/SelectionActionBar";
 import { Tooltip } from "~/components/ui/tooltip";
 import { showErrorToast } from "~/features/errors";
@@ -64,7 +66,12 @@ import {
   DatasetTableProvider,
   type DatasetTableRowData,
 } from "./DatasetTableContext";
-import { formatRecordCount } from "./datasetEditorCopy";
+import {
+  formatSearchRecordCount,
+  noSearchMatchesMessage,
+  plainRecordCount,
+  searchFailedMessage,
+} from "./datasetEditorCopy";
 import { datasetTableCss } from "./datasetTableStyles";
 import {
   createDatasetEditorStore,
@@ -187,12 +194,32 @@ export function DatasetEditorTable({
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState(DATASET_EDITOR_PAGE_SIZE);
 
+  // ── Row search ────────────────────────────────────────────────────
+  //
+  // Paging is how you read a dataset in order and a poor way to find one row in
+  // hundreds. The search is served by the same paged read: the server returns
+  // the matching rows and a `count` of the matches, so the pager pages the
+  // matches with no changes of its own.
+  //
+  // Saved datasets only. Narrowing an in-memory draft would mean filtering the
+  // local store, and rows are addressed by their POSITION in it (`selectedRows`
+  // is a Set of indices, `rowData` reads `records[index]`) — a filtered view
+  // would leave a selection pointing at rows the user never picked. A draft is
+  // also entirely on screen already, so there is nothing to search for.
+  const [searchInput, setSearchInput] = useState("");
+  const [debouncedSearch] = useDebounce(searchInput, 300);
+  const activeSearch = datasetId
+    ? debouncedSearch.trim() || undefined
+    : undefined;
+  const isSearching = !!activeSearch;
+
   const databaseDataset = api.datasetRecord.listPaginated.useQuery(
     {
       projectId: project?.id ?? "",
       datasetId: datasetId ?? "",
       page,
       limit: pageSize,
+      search: activeSearch,
     },
     {
       // Gated on `readEnabled` so a still-preparing/failed dataset is never read
@@ -234,19 +261,48 @@ export function DatasetEditorTable({
   // `currentPage` is the page actually shown, clamped so it can never exceed the
   // count.
   const serverRecordCount = datasetId ? databaseDataset.data?.count : undefined;
+
+  // While a search is in effect `count` is the number of MATCHES, so the
+  // dataset's own total has to be remembered from the last unsearched read —
+  // otherwise the header could only say how many rows matched, which reads as
+  // the dataset having shrunk. The editor always loads unsearched first (the
+  // box starts empty), so this is populated before any search can run.
+  const unsearchedRecordCount = useRef<number | undefined>(undefined);
+  if (!isSearching && serverRecordCount != null) {
+    unsearchedRecordCount.current = serverRecordCount;
+  }
+
   const pageCount = Math.max(1, Math.ceil((serverRecordCount ?? 0) / pageSize));
   const currentPage = Math.min(page, pageCount);
   const isLastPage = currentPage >= pageCount;
+  // While `keepPreviousData` serves the prior key's result during a key change,
+  // `isPlaceholderData` is true. Skip hydrating from it: a `datasetId` switch
+  // would otherwise populate the grid with the OLD dataset's rows under the NEW
+  // id (a data-integrity mismatch until the new query settles). For a
+  // same-dataset page switch this just holds the current page until the next one
+  // lands.
+  const holdingPreviousData = databaseDataset.isPlaceholderData;
   // Snap a now-out-of-range page back into range — e.g. the last page's rows
   // were all deleted under us (the post-delete refetch shrinks the count) or a
   // navigation refetch returned a smaller dataset. Acts ONLY on an authoritative
-  // count — never on absent data — so an in-flight page switch can't bounce
-  // navigation back to page 1. Floored at 1, so it never drives the page to 0.
+  // count — never on absent data, never on data held over from the previous
+  // request, and never while the debounce is still catching up with the search
+  // box — so an in-flight change can't bounce navigation back to page 1.
+  //
+  // That last guard is the one with teeth. Clearing a search restores the page
+  // the user searched from, but `activeSearch` trails the input by the debounce,
+  // so for those 300ms the count on hand is still the MATCH count. Without the
+  // guard the clamp reads "page 3 of 1" and snaps a user who was three pages in
+  // back to page 1 — undoing the restore it was meant to protect.
+  //
+  // Floored at 1, so it never drives the page to 0.
+  const searchSettling = (searchInput.trim() || undefined) !== activeSearch;
   useEffect(() => {
-    if (serverRecordCount == null) return;
+    if (serverRecordCount == null || holdingPreviousData || searchSettling)
+      return;
     const count = Math.max(1, Math.ceil(serverRecordCount / pageSize));
     if (page > count) setPage(count);
-  }, [serverRecordCount, pageSize, page]);
+  }, [serverRecordCount, pageSize, page, holdingPreviousData, searchSettling]);
 
   const datasetName = datasetId
     ? databaseDataset.data?.name
@@ -265,12 +321,6 @@ export function DatasetEditorTable({
   // other way via onUpdateDataset).
   const loadedRef = useRef(false);
   const lastPropagatedRef = useRef<EditorRecord[] | null>(null);
-  // While `keepPreviousData` serves the prior key's result during a key change,
-  // `isPlaceholderData` is true. Skip hydrating from it: a `datasetId` switch would
-  // otherwise populate the grid with the OLD dataset's rows under the NEW id
-  // (a data-integrity mismatch until the new query settles). For a same-dataset
-  // page switch this just holds the current page until the next one lands.
-  const holdingPreviousData = databaseDataset.isPlaceholderData;
   useEffect(() => {
     if (datasetId && databaseDataset.data && !holdingPreviousData) {
       const columns = toEditorColumns(
@@ -344,6 +394,43 @@ export function DatasetEditorTable({
     setAutosave,
   } = store.getState();
 
+  // Typing in the search box resets the page and drops the selection
+  // IMMEDIATELY, before the debounce lets the search reach the query.
+  //
+  // Both have to happen ahead of the read, not after it. Resetting the page
+  // afterwards fires a real request for (old page, new search) — a page that
+  // usually does not exist within the matches, so it returns an empty one.
+  // Dropping the selection afterwards is worse: rows are selected by their
+  // POSITION (`selectedRows` holds indices, `deleteSelectedRows` filters by
+  // index), so for the moment the new rows are in place under an old selection,
+  // a delete would remove records the user never picked. Paging clears the
+  // selection for the same reason.
+  // Where the user was before the search started, so clearing it puts them back
+  // rather than on page 1. Not cosmetic: the add-row affordances live on the
+  // LAST page, so returning a multi-page dataset to page 1 would withdraw them
+  // for the rest of the session — a search would silently cost the user their
+  // place and their way of adding a row.
+  const pageBeforeSearch = useRef<number | undefined>(undefined);
+  // The bookkeeping is done HERE, in the event handler, and not inside a
+  // `setPage` updater: React replays updaters in StrictMode to surface impurity,
+  // and an updater that writes this ref reads it back as `undefined` on the
+  // replay — so clearing a search would land on page 1 in development and on the
+  // remembered page in production. Event handlers are not replayed.
+  const onSearchChange = useCallback(
+    (next: string) => {
+      setSearchInput(next);
+      if (next.trim()) {
+        pageBeforeSearch.current ??= page;
+        setPage(1);
+      } else {
+        setPage(pageBeforeSearch.current ?? 1);
+        pageBeforeSearch.current = undefined;
+      }
+      clearRowSelection();
+    },
+    [clearRowSelection, page],
+  );
+
   // ── In-memory propagation ─────────────────────────────────────────
 
   const onUpdateDatasetRef = useRef(onUpdateDataset);
@@ -404,8 +491,23 @@ export function DatasetEditorTable({
   // the dataset, so on the paged saved view it belongs only on the last page —
   // adding it on an earlier full page would create a row the user can't see.
   // In-memory mode (no datasetId) is one local list, so it always shows it.
-  const showAddRow = !datasetId || isLastPage;
-  const displayRowCount = showAddRow ? Math.max(rowCount + 1, 3) : rowCount;
+  // ...and never while a search is in effect: a new row is empty, so it would
+  // not match the search and would appear to vanish the moment it was created.
+  // This one flag covers both the button and the phantom row (via
+  // `displayRowCount`); the CSV import is withdrawn alongside them, for the same
+  // reason — its rows land at the end of the dataset, outside the matches.
+  const showAddRow = (!datasetId || isLastPage) && !isSearching;
+  // A refused search leaves the rows read BEFORE it on screen: the store is only
+  // written from a settled `data` (see the effect above), so an error leaves the
+  // previous page in place. Those rows were never matched against the search,
+  // and leaving them under a search box reads as "here is what matched" — a
+  // complete, confident, false answer. Withdraw them and say what happened.
+  const searchFailed = isSearching && !!databaseDatasetError;
+  const displayRowCount = searchFailed
+    ? 0
+    : showAddRow
+      ? Math.max(rowCount + 1, 3)
+      : rowCount;
 
   // Block page navigation while a record save is queued or in flight: switching
   // pages reloads the store (setData drops the prior page's records), so an
@@ -662,13 +764,50 @@ export function DatasetEditorTable({
           title
         )}
         <Text fontSize="13px" color="fg.muted" data-testid="dataset-row-count">
-          {formatRecordCount(totalRecordCount)}{" "}
-          {totalRecordCount === 1 ? "record" : "records"}
+          {/* A refused search has no match count to report, and the count it
+              would otherwise fall back to is the stale store's row count — the
+              rows read before the search. Reporting either passes unsearched
+              rows off as the result, so it reports the dataset's own size when
+              that is known and says nothing when it is not. */}
+          {searchFailed
+            ? unsearchedRecordCount.current === undefined
+              ? ""
+              : plainRecordCount(unsearchedRecordCount.current)
+            : isSearching
+              ? formatSearchRecordCount({
+                  matched: totalRecordCount,
+                  total: unsearchedRecordCount.current,
+                })
+              : plainRecordCount(totalRecordCount)}
         </Text>
         {datasetId && (
           <SaveStatusChip state={autosave.state} error={autosave.error} />
         )}
         <Spacer />
+        {/* Saved datasets only — see the `activeSearch` note above. Placed
+            outside the `!hideButtons` group on purpose: that group is the
+            dataset-management toolbar, and search is a way of reading the grid,
+            not of managing the dataset. */}
+        {datasetId && (
+          <Box maxWidth="240px">
+            <SearchInput
+              size="sm"
+              // `SearchInput` carries `role="searchbox"`, which keeps this
+              // distinct from the grid's cell editors (`textbox`) for both
+              // assistive tech and role-based queries.
+              aria-label="Search rows"
+              placeholder="Search rows"
+              data-testid="dataset-row-search"
+              value={searchInput}
+              // Gated on pending writes for the same reason page navigation is:
+              // a new search reloads the store, and an edit still on its way to
+              // being saved refers to a row that reload drops — it would be
+              // discarded with nothing shown. The autosave debounce is short.
+              disabled={hasPendingWrites}
+              onChange={(e) => onSearchChange(e.target.value)}
+            />
+          </Box>
+        )}
         {!floatingSelectionBar && selectedRows.size > 0 && (
           <Button
             size="sm"
@@ -692,7 +831,7 @@ export function DatasetEditorTable({
             >
               <Download size={16} /> Download as CSV
             </Button>
-            {datasetId && (
+            {datasetId && !isSearching && (
               <Button
                 size="sm"
                 variant="ghost"
@@ -774,6 +913,42 @@ export function DatasetEditorTable({
               />
             </tbody>
           </table>
+
+          {/* A search with no matches leaves the grid empty: the phantom
+              add-row is withdrawn during a search, so `displayRowCount` is 0
+              and the body renders nothing. An empty grid alone is unreadable —
+              it looks the same as a dataset that has no rows, and does not say
+              which search produced it. Sits INSIDE the grid's border, where the
+              missing rows would have been: below it, the reader gets a blank
+              box with an unattached sentence under it. Held until the read
+              settles so the message does not flash between keystrokes. */}
+          {searchFailed && (
+            <Text
+              fontSize="13px"
+              color="fg.muted"
+              paddingX={3}
+              paddingY={4}
+              data-testid="dataset-search-failed"
+            >
+              {searchFailedMessage(activeSearch)}
+            </Text>
+          )}
+
+          {isSearching &&
+            !searchFailed &&
+            !databaseDataset.isLoading &&
+            !holdingPreviousData &&
+            rowCount === 0 && (
+              <Text
+                fontSize="13px"
+                color="fg.muted"
+                paddingX={3}
+                paddingY={4}
+                data-testid="dataset-search-empty"
+              >
+                {noSearchMatchesMessage(activeSearch)}
+              </Text>
+            )}
         </DatasetTableProvider>
       </Box>
 
@@ -869,7 +1044,11 @@ export function DatasetEditorTable({
         />
       )}
 
-      {datasetId && addRowsFromCSVModal.open && (
+      {/* Withdrawn while a search is in effect for the same reason its toolbar
+          button is: a click landing inside the search debounce opens this while
+          `isSearching` is still false, and rows imported here land at the end of
+          the dataset — outside the matches on screen. */}
+      {datasetId && addRowsFromCSVModal.open && !isSearching && (
         <AddRowsFromCSVModal
           isOpen={addRowsFromCSVModal.open}
           onClose={() => {

--- a/platform/app/src/components/datasets/editor/DatasetEditorTable.tsx
+++ b/platform/app/src/components/datasets/editor/DatasetEditorTable.tsx
@@ -570,6 +570,20 @@ export function DatasetEditorTable({
   // and leaving them under a search box reads as "here is what matched" — a
   // complete, confident, false answer. Withdraw them and say what happened.
   const searchFailed = isSearching && !!databaseDatasetError;
+  // A number of matches is the search's OWN answer, so it can only be reported
+  // once the search's own read has settled. Two states have no such answer and
+  // both used to report one anyway:
+  //
+  //   - a refusal, which never produces a count at all;
+  //   - a read still in flight, where `keepPreviousData` is serving the last
+  //     unsearched page and the `count` riding with it is the DATASET's size.
+  //     Fed to the two-number chip that renders "54,000 of 54,000 records" —
+  //     every row matched — over rows that were never searched. On a large
+  //     dataset that read takes seconds.
+  //
+  // In both, fall back to the dataset's own size, which is what the chip says
+  // with no search in effect and is true either way.
+  const matchCountKnown = !searchFailed && !holdingPreviousData;
   const displayRowCount = searchFailed
     ? 0
     : showAddRow
@@ -831,21 +845,20 @@ export function DatasetEditorTable({
           title
         )}
         <Text fontSize="13px" color="fg.muted" data-testid="dataset-row-count">
-          {/* A refused search has no match count to report, and the count it
-              would otherwise fall back to is the stale store's row count — the
-              rows read before the search. Reporting either passes unsearched
-              rows off as the result, so it reports the dataset's own size when
-              that is known and says nothing when it is not. */}
-          {searchFailed
-            ? unsearchedRecordCount.current === undefined
-              ? ""
-              : plainRecordCount(unsearchedRecordCount.current)
-            : isSearching
+          {/* With no match count to report (see `matchCountKnown`), the count
+              on hand describes unsearched rows, so reporting it as the result
+              of the search would be false. Report the dataset's own size
+              instead, and say nothing at all when even that is not known. */}
+          {isSearching
+            ? matchCountKnown
               ? formatSearchRecordCount({
                   matched: totalRecordCount,
                   total: unsearchedRecordCount.current,
                 })
-              : plainRecordCount(totalRecordCount)}
+              : unsearchedRecordCount.current === undefined
+                ? ""
+                : plainRecordCount(unsearchedRecordCount.current)
+            : plainRecordCount(totalRecordCount)}
         </Text>
         {datasetId && (
           <SaveStatusChip state={autosave.state} error={autosave.error} />

--- a/platform/app/src/components/datasets/editor/__tests__/DatasetEditorTable.search.integration.test.tsx
+++ b/platform/app/src/components/datasets/editor/__tests__/DatasetEditorTable.search.integration.test.tsx
@@ -332,9 +332,18 @@ describe("given a saved dataset", () => {
 
       await typeSearch(user, "zzzznope");
 
-      const empty = await screen.findByTestId("dataset-search-empty");
+      // Waited for by its full text, not asserted on the first appearance of
+      // the message. `typeSearch` enters one character at a time and the search
+      // waits 300ms after each, so an early prefix — "z", "zz" — can settle
+      // mid-typing and put up its own "no records match" first. Asserting on
+      // whichever message appeared first is a race, and it is the one that
+      // failed this file on CI.
+      const empty = await waitFor(() => {
+        const message = screen.getByTestId("dataset-search-empty");
+        expect(message).toHaveTextContent("zzzznope");
+        return message;
+      });
       expect(empty).toHaveTextContent(/no records match/i);
-      expect(empty).toHaveTextContent("zzzznope");
       // "in the grid", not under it: rendered below, the reader is left with a
       // blank bordered box and a sentence that looks unattached to it.
       const grid = screen.getByTestId("dataset-editor-grid");

--- a/platform/app/src/components/datasets/editor/__tests__/DatasetEditorTable.search.integration.test.tsx
+++ b/platform/app/src/components/datasets/editor/__tests__/DatasetEditorTable.search.integration.test.tsx
@@ -1,0 +1,566 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Row search in the dataset editor. The transport is mocked, so what these
+ * tests pin is the editor's half of the contract: what it asks the server for,
+ * and what it does to the grid around a search that is in effect.
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { DatasetColumns } from "~/server/datasets/types";
+import { DatasetEditorTable } from "../DatasetEditorTable";
+
+vi.mock("~/hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({
+    project: { id: "proj-1", slug: "acme-app" },
+    organization: { id: "org-1", name: "Acme" },
+    team: { id: "team-1", name: "Platform" },
+    hasPermission: () => true,
+  }),
+}));
+
+const updateMutate = vi.fn();
+const deleteManyMutate = vi.fn();
+const listPaginatedQuery = vi.fn();
+
+vi.mock("~/utils/api", () => ({
+  api: {
+    datasetRecord: {
+      getAll: { useQuery: (...args: unknown[]) => listPaginatedQuery(...args) },
+      listPaginated: {
+        useQuery: (...args: unknown[]) => listPaginatedQuery(...args),
+      },
+      update: { useMutation: () => ({ mutate: updateMutate }) },
+      deleteMany: { useMutation: () => ({ mutate: deleteManyMutate }) },
+      create: { useMutation: () => ({ mutate: vi.fn() }) },
+      download: {
+        useMutation: () => ({ mutateAsync: vi.fn(), isLoading: false }),
+      },
+    },
+    dataset: {
+      upsert: { useMutation: () => ({ mutate: vi.fn(), isLoading: false }) },
+      validateDatasetName: {
+        useQuery: () => ({ data: null, isLoading: false }),
+      },
+    },
+    licenseEnforcement: {
+      checkLimit: { useQuery: () => ({ data: null, isLoading: false }) },
+    },
+    useUtils: () => ({}),
+  },
+}));
+
+const columnTypes: DatasetColumns = [
+  { name: "input", type: "string" },
+  { name: "expected_output", type: "string" },
+];
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <ChakraProvider value={defaultSystem}>{children}</ChakraProvider>
+);
+
+/**
+ * Serves whatever page the editor asks for. When the request carries a
+ * `search`, it answers with the matching subset and a `count` of the matches —
+ * the server contract the editor is written against.
+ */
+const serveDataset = (
+  records: { id: string; entry: Record<string, string> }[],
+  { pageSize = 50 }: { pageSize?: number } = {},
+) => {
+  const requests: { page?: number; search?: string }[] = [];
+  // Results are cached per (page, search) so repeated renders get the SAME
+  // object reference, as react-query would. A fresh object per render feeds the
+  // editor's data-keyed effects a new value every time and spins the component
+  // into an update loop that has nothing to do with what is under test.
+  const cache = new Map<string, unknown>();
+
+  listPaginatedQuery.mockImplementation(
+    (input: { page?: number; search?: string }) => {
+      const page = input?.page ?? 1;
+      const search = input?.search?.trim().toLowerCase();
+      const key = `${page}::${search ?? ""}`;
+      requests.push({ page, search: input?.search });
+
+      const cached = cache.get(key);
+      if (cached) return cached;
+
+      const matching = search
+        ? records.filter((r) =>
+            Object.values(r.entry).some((v) =>
+              v.toLowerCase().includes(search),
+            ),
+          )
+        : records;
+      const result = {
+        data: {
+          id: "ds",
+          name: "ds",
+          columnTypes,
+          count: matching.length,
+          totalPages: Math.ceil(matching.length / pageSize),
+          page,
+          datasetRecords: matching.slice(
+            (page - 1) * pageSize,
+            page * pageSize,
+          ),
+        },
+        isLoading: false,
+        refetch: vi.fn(),
+      };
+      cache.set(key, result);
+      return result;
+    },
+  );
+  return requests;
+};
+
+const manyRecords = Array.from({ length: 120 }, (_, i) => ({
+  id: `r${i}`,
+  entry: {
+    input: i === 119 ? "needs escalation" : `question ${i}`,
+    expected_output: `answer ${i}`,
+  },
+}));
+
+/**
+ * 120 rows of which 60 say "flagged": the matches span two pages at the default
+ * page size while the dataset spans three, so the pager can only be right about
+ * one of them.
+ */
+const twoPagesOfMatches = Array.from({ length: 120 }, (_, i) => ({
+  id: `f${i}`,
+  entry: {
+    input: i < 60 ? `flagged question ${i}` : `plain question ${i}`,
+    expected_output: `answer ${i}`,
+  },
+}));
+
+/** Fits on one page, so the add-row affordances are on screen to begin with. */
+const singlePageRecords = [
+  { id: "a", entry: { input: "billing question", expected_output: "answer" } },
+  { id: "b", entry: { input: "needs escalation", expected_output: "answer" } },
+  { id: "c", entry: { input: "password reset", expected_output: "answer" } },
+];
+
+const typeSearch = async (
+  user: ReturnType<typeof userEvent.setup>,
+  text: string,
+) => {
+  const box = screen.getByTestId("dataset-row-search");
+  await user.type(box, text);
+};
+
+beforeEach(() => {
+  updateMutate.mockReset();
+  deleteManyMutate.mockReset();
+  listPaginatedQuery.mockReset();
+  // In-memory mode still calls the hook (gated by `enabled`), so it needs a
+  // settled-but-empty result rather than undefined.
+  listPaginatedQuery.mockReturnValue({
+    data: undefined,
+    isLoading: false,
+    refetch: vi.fn(),
+  });
+});
+
+afterEach(() => cleanup());
+
+describe("given a saved dataset", () => {
+  describe("when I search for text in a row that is not on this page", () => {
+    /** @scenario Find a record that is not on the page I am looking at */
+    it("asks the server for the matches and shows the row", async () => {
+      const user = userEvent.setup();
+      serveDataset(manyRecords);
+      render(<DatasetEditorTable datasetId="ds" />, { wrapper: Wrapper });
+
+      await typeSearch(user, "escalation");
+
+      await waitFor(() =>
+        expect(screen.getByText("needs escalation")).toBeInTheDocument(),
+      );
+      expect(screen.queryByText("question 0")).not.toBeInTheDocument();
+    });
+
+    /** @scenario Searching returns me to the first page of results */
+    it("returns to the first page of the matches", async () => {
+      const user = userEvent.setup();
+      const requests = serveDataset(manyRecords);
+      render(<DatasetEditorTable datasetId="ds" />, { wrapper: Wrapper });
+
+      await user.click(await screen.findByTestId("pagination-next"));
+      await waitFor(() => expect(requests.at(-1)?.page).toBe(2));
+
+      await typeSearch(user, "escalation");
+
+      await waitFor(() => expect(requests.at(-1)?.search).toBe("escalation"));
+      expect(requests.at(-1)?.page).toBe(1);
+    });
+
+    it("never asks for a page of matches the search has not been applied to", async () => {
+      // The page must be reset BEFORE the search reaches the query, not after.
+      // Resetting it afterwards fires a real request for (old page, new search)
+      // — a page that usually does not exist within the matches, so the answer
+      // is an empty page the user briefly sees.
+      const user = userEvent.setup();
+      const requests = serveDataset(manyRecords);
+      render(<DatasetEditorTable datasetId="ds" />, { wrapper: Wrapper });
+
+      await user.click(await screen.findByTestId("pagination-next"));
+      await waitFor(() => expect(requests.at(-1)?.page).toBe(2));
+
+      await typeSearch(user, "escalation");
+      await waitFor(() => expect(requests.at(-1)?.search).toBe("escalation"));
+
+      expect(requests.filter((r) => r.search && (r.page ?? 1) > 1)).toEqual([]);
+    });
+  });
+
+  describe("when a search is in effect", () => {
+    /** @scenario The record count reports the matches, not the whole dataset */
+    it("reports the matches alongside the dataset total", async () => {
+      const user = userEvent.setup();
+      serveDataset(manyRecords);
+      render(<DatasetEditorTable datasetId="ds" />, { wrapper: Wrapper });
+
+      await typeSearch(user, "escalation");
+
+      await waitFor(() =>
+        expect(screen.getByTestId("dataset-row-count")).toHaveTextContent(
+          "1 of 120",
+        ),
+      );
+    });
+
+    /** @scenario No way to add a row is offered during a search */
+    it("withdraws every way of adding a row", async () => {
+      // A single-page dataset on purpose: `showAddRow` is already false on any
+      // page but the last, so a multi-page fixture would pass this without the
+      // search doing anything.
+      const user = userEvent.setup();
+      serveDataset(singlePageRecords);
+      render(<DatasetEditorTable datasetId="ds" />, { wrapper: Wrapper });
+
+      expect(await screen.findByTestId("add-row")).toBeInTheDocument();
+      expect(screen.getByTestId("add-rows-from-csv")).toBeInTheDocument();
+
+      await typeSearch(user, "escalation");
+
+      await waitFor(() =>
+        expect(screen.queryByTestId("add-row")).not.toBeInTheDocument(),
+      );
+      await waitFor(() =>
+        expect(
+          screen.queryByTestId("add-rows-from-csv"),
+        ).not.toBeInTheDocument(),
+      );
+    });
+
+    /** @scenario A search that matches nothing says so in the grid */
+    it("says nothing matched, and repeats what was searched for", async () => {
+      const user = userEvent.setup();
+      serveDataset(manyRecords);
+      render(<DatasetEditorTable datasetId="ds" />, { wrapper: Wrapper });
+
+      await typeSearch(user, "zzzznope");
+
+      const empty = await screen.findByTestId("dataset-search-empty");
+      expect(empty).toHaveTextContent(/no records match/i);
+      expect(empty).toHaveTextContent("zzzznope");
+      // "in the grid", not under it: rendered below, the reader is left with a
+      // blank bordered box and a sentence that looks unattached to it.
+      const grid = screen.getByTestId("dataset-editor-grid");
+      expect(grid.parentElement?.contains(empty)).toBe(true);
+    });
+  });
+
+  describe("when the matches span more than one page", () => {
+    /** @scenario The pager pages the matches */
+    it("pages the matches rather than the whole dataset", async () => {
+      const user = userEvent.setup();
+      const requests = serveDataset(twoPagesOfMatches);
+      render(<DatasetEditorTable datasetId="ds" />, { wrapper: Wrapper });
+
+      // Three pages before the search.
+      expect(
+        await screen.findByTestId("pagination-page-3"),
+      ).toBeInTheDocument();
+
+      await typeSearch(user, "flagged");
+      await waitFor(() => expect(requests.at(-1)?.search).toBe("flagged"));
+
+      // Two after it: the pager follows the matches, not the dataset.
+      await waitFor(() =>
+        expect(
+          screen.queryByTestId("pagination-page-3"),
+        ).not.toBeInTheDocument(),
+      );
+      expect(screen.getByTestId("pagination-page-2")).toBeInTheDocument();
+
+      await user.click(screen.getByTestId("pagination-next"));
+      await waitFor(() => expect(requests.at(-1)?.page).toBe(2));
+      expect(requests.at(-1)?.search).toBe("flagged");
+    });
+  });
+
+  describe("when a row is selected and I then search", () => {
+    /** @scenario A selection made before a search does not survive it */
+    it("clears the selection, so a delete cannot hit rows I never picked", async () => {
+      const user = userEvent.setup();
+      serveDataset(singlePageRecords);
+      render(<DatasetEditorTable datasetId="ds" />, { wrapper: Wrapper });
+
+      const firstRowCheckbox = (await screen.findAllByRole("checkbox")).at(1)!;
+      await user.click(firstRowCheckbox);
+      await waitFor(() =>
+        expect(screen.getByTestId("delete-selected-rows")).toBeInTheDocument(),
+      );
+
+      await typeSearch(user, "escalation");
+
+      await waitFor(() =>
+        expect(
+          screen.queryByTestId("delete-selected-rows"),
+        ).not.toBeInTheDocument(),
+      );
+    });
+  });
+
+  describe("when an edit has not finished saving", () => {
+    /** @scenario Searching waits for a pending save */
+    it("holds the search until the save settles, so the edit is not stranded", async () => {
+      // The mutation never calls back, so the write stays pending — the state
+      // in which reloading the grid would drop the edited row's record.
+      updateMutate.mockImplementation(() => undefined);
+      const user = userEvent.setup();
+      serveDataset(singlePageRecords);
+      render(<DatasetEditorTable datasetId="ds" />, { wrapper: Wrapper });
+
+      await screen.findByText("billing question");
+      await user.dblClick(screen.getByTestId("cell-0-input_0"));
+      const editor = await screen.findByRole("textbox");
+      await user.clear(editor);
+      await user.type(editor, "edited{Enter}");
+
+      await waitFor(() =>
+        expect(screen.getByTestId("dataset-row-search")).toBeDisabled(),
+      );
+    });
+  });
+
+  describe("when I clear the search", () => {
+    /** @scenario Clearing the search restores the whole dataset */
+    it("restores the whole dataset and the ways to add a row", async () => {
+      const user = userEvent.setup();
+      const requests = serveDataset(manyRecords);
+      render(<DatasetEditorTable datasetId="ds" />, { wrapper: Wrapper });
+
+      await typeSearch(user, "escalation");
+      await waitFor(() => expect(requests.at(-1)?.search).toBe("escalation"));
+
+      await user.clear(screen.getByTestId("dataset-row-search"));
+
+      await waitFor(() => expect(requests.at(-1)?.search).toBeUndefined());
+      await waitFor(() =>
+        expect(screen.getByTestId("dataset-row-count")).toHaveTextContent(
+          "120 records",
+        ),
+      );
+      expect(screen.getByTestId("add-rows-from-csv")).toBeInTheDocument();
+    });
+
+    /** @scenario Clearing the search offers adding rows again */
+    it("puts me back on the page I searched from, so the add row I had returns", async () => {
+      // The add-row affordances live on the LAST page. Searching from there and
+      // returning to page 1 would silently withdraw them for good — the search
+      // would have cost the user their place, and the count of pages is the only
+      // reason they cannot see it.
+      const user = userEvent.setup();
+      const requests = serveDataset(manyRecords);
+      render(<DatasetEditorTable datasetId="ds" />, { wrapper: Wrapper });
+
+      await screen.findByText("question 0");
+      await user.click(screen.getByTestId("pagination-page-3"));
+      await waitFor(() =>
+        expect(screen.getByTestId("add-row")).toBeInTheDocument(),
+      );
+
+      await typeSearch(user, "escalation");
+      await waitFor(() =>
+        expect(screen.queryByTestId("add-row")).not.toBeInTheDocument(),
+      );
+
+      await user.clear(screen.getByTestId("dataset-row-search"));
+
+      await waitFor(() =>
+        expect(screen.getByTestId("add-row")).toBeInTheDocument(),
+      );
+      expect(screen.getByTestId("add-rows-from-csv")).toBeInTheDocument();
+      // Assert the PAGE, not just the add row. The single match makes page 3
+      // out of range for the search, so a clamp that fires while the debounce is
+      // still catching up would restore the page and then immediately undo it —
+      // and every add-row assertion above would still pass on page 1 of a
+      // one-page result. The requested page is the only witness that survives.
+      await waitFor(() => expect(requests.at(-1)?.search).toBeUndefined());
+      expect(requests.at(-1)?.page).toBe(3);
+    });
+  });
+});
+
+describe("given the dataset's own total is not known yet", () => {
+  /** @scenario The record count reports the matches, not the whole dataset */
+  it("does not pass the match count off as the dataset's total", async () => {
+    // The two-number chip remembers the total from the last UNSEARCHED read. If
+    // no unsearched read has settled — a slow whole-dataset read, or a remount
+    // while a search is active — there is no total to report, and reusing the
+    // match count for both halves would state "1 of 1 records" for a dataset of
+    // 120: precisely the "the dataset has shrunk" misreading the two numbers
+    // exist to prevent. Saying less is the only honest option.
+    const user = userEvent.setup();
+    // Stable refs per branch — a fresh object each render feeds the editor's
+    // data-keyed effects a new value every time and spins it into an update
+    // loop, as the note on `serveDataset` describes.
+    const pending = { data: undefined, isLoading: true };
+    const matched = {
+      data: {
+        id: "ds",
+        name: "ds",
+        columnTypes,
+        count: 1,
+        totalPages: 1,
+        page: 1,
+        datasetRecords: [{ id: "r119", entry: { input: "needs escalation" } }],
+      },
+      isLoading: false,
+      refetch: vi.fn(),
+    };
+    listPaginatedQuery.mockImplementation(
+      (input: { search?: string } | undefined) =>
+        input?.search ? matched : pending,
+    );
+    render(<DatasetEditorTable datasetId="ds" />, { wrapper: Wrapper });
+
+    await typeSearch(user, "escalation");
+
+    await waitFor(() =>
+      expect(screen.getByTestId("dataset-row-count")).toHaveTextContent(
+        /matching/,
+      ),
+    );
+    expect(screen.getByTestId("dataset-row-count")).not.toHaveTextContent(
+      "1 of 1",
+    );
+  });
+});
+
+describe("given the CSV import was opened just before a search landed", () => {
+  /** @scenario An import already open when the search lands is withdrawn too */
+  it("withdraws the import dialog too, not just the button", async () => {
+    // The toolbar button is withdrawn when a search takes effect, but a click
+    // landing inside the debounce opens the dialog while `isSearching` is still
+    // false. Leaving it mounted is the same hole the button gate exists to
+    // close: rows land at the end of the dataset, outside the matches on screen.
+    const user = userEvent.setup();
+    serveDataset(singlePageRecords);
+    render(<DatasetEditorTable datasetId="ds" />, { wrapper: Wrapper });
+
+    await screen.findByText("billing question");
+    // Typed in one event rather than keystroke by keystroke: this is the click
+    // that lands INSIDE the debounce, so the test has to reach the button while
+    // the search is still pending. Typing character by character spends most of
+    // that window, and the dialog traps focus once open — so opening it first
+    // and typing behind it exercises an ordering a user cannot perform.
+    fireEvent.change(screen.getByTestId("dataset-row-search"), {
+      target: { value: "escalation" },
+    });
+    await user.click(screen.getByTestId("add-rows-from-csv"));
+    await waitFor(() => expect(screen.getAllByRole("dialog").length).toBe(1));
+
+    await waitFor(() =>
+      expect(screen.queryByTestId("add-rows-from-csv")).not.toBeInTheDocument(),
+    );
+    // Waited for, not asserted outright: the dialog's unmount is animated, so a
+    // bare assertion here races the exit transition and fails intermittently.
+    await waitFor(() =>
+      expect(screen.queryAllByRole("dialog")).toHaveLength(0),
+    );
+  });
+});
+
+describe("given the server refuses the search", () => {
+  /** @scenario A refused search does not leave unsearched rows on screen as if they matched */
+  it("stops presenting the pre-search rows as the result", async () => {
+    // The rows on screen were read before the search and never matched against
+    // it. The store is only written from a settled `data`, so on error it keeps
+    // them — and the chip, fed by the same stale count, labels them as the
+    // matches. "50 of 60,000 records" under a search box containing
+    // "escalation" is a complete, confident, false answer; the toast that
+    // explains it dismisses after 12s and leaves only the falsehood.
+    const user = userEvent.setup();
+    const loaded = {
+      data: {
+        id: "ds",
+        name: "ds",
+        columnTypes,
+        count: 120,
+        totalPages: 3,
+        page: 1,
+        datasetRecords: manyRecords.slice(0, 50),
+      },
+      isLoading: false,
+      refetch: vi.fn(),
+    };
+    const refused = {
+      data: undefined,
+      error: { message: "This dataset is too large to search" },
+      isLoading: false,
+      refetch: vi.fn(),
+    };
+    listPaginatedQuery.mockImplementation(
+      (input: { search?: string } | undefined) =>
+        input?.search ? refused : loaded,
+    );
+    render(<DatasetEditorTable datasetId="ds" />, { wrapper: Wrapper });
+
+    await screen.findByText("question 0");
+    await typeSearch(user, "escalation");
+
+    await waitFor(() =>
+      expect(screen.getByTestId("dataset-search-failed")).toBeInTheDocument(),
+    );
+    // No match claim: the chip must not report a count of matches it never got.
+    expect(screen.getByTestId("dataset-row-count")).not.toHaveTextContent(
+      /\bof\b|matching/,
+    );
+    expect(screen.queryByText("question 0")).not.toBeInTheDocument();
+  });
+});
+
+describe("given a draft dataset that has not been saved", () => {
+  /** @scenario A draft dataset offers no search */
+  it("offers no search, and still offers the ways to add a row", () => {
+    render(
+      <DatasetEditorTable
+        inMemoryDataset={{
+          name: "My Draft",
+          columnTypes,
+          datasetRecords: [{ id: "r1", input: "hello", expected_output: "x" }],
+        }}
+        onUpdateDataset={vi.fn()}
+      />,
+      { wrapper: Wrapper },
+    );
+
+    expect(screen.queryByTestId("dataset-row-search")).not.toBeInTheDocument();
+    expect(screen.getByTestId("add-row")).toBeInTheDocument();
+  });
+});

--- a/platform/app/src/components/datasets/editor/__tests__/DatasetEditorTable.search.integration.test.tsx
+++ b/platform/app/src/components/datasets/editor/__tests__/DatasetEditorTable.search.integration.test.tsx
@@ -556,6 +556,53 @@ describe("given the dataset's own total is not known yet", () => {
   });
 });
 
+describe("given the search's own read has not come back yet", () => {
+  /** @scenario The record count reports the matches, not the whole dataset */
+  it("does not report the held-over rows as the matches", async () => {
+    // While the search's read is in flight, `keepPreviousData` keeps serving
+    // the last unsearched page, and the `count` that comes with it is the
+    // DATASET's size, not a number of matches. Rendered through the two-number
+    // chip that becomes "120 of 120 records" — every row matched — over rows
+    // that were never searched at all. On a large dataset that read takes
+    // seconds, and a refused one used to hold this state for the whole retry
+    // backoff.
+    const user = userEvent.setup();
+    const unsearched = {
+      data: {
+        id: "ds",
+        name: "ds",
+        columnTypes,
+        count: 120,
+        totalPages: 3,
+        page: 1,
+        datasetRecords: manyRecords.slice(0, 50),
+      },
+      isLoading: false,
+      refetch: vi.fn(),
+    };
+    // What react-query serves during a key change: the previous key's result,
+    // flagged as a placeholder, with the new key's read still in flight.
+    const inFlight = { ...unsearched, isPlaceholderData: true };
+    listPaginatedQuery.mockImplementation(
+      (input: { search?: string } | undefined) =>
+        input?.search ? inFlight : unsearched,
+    );
+    render(<DatasetEditorTable datasetId="ds" />, { wrapper: Wrapper });
+
+    await screen.findByText("question 0");
+    await typeSearch(user, "escalation");
+
+    // The self-check: without it, an editor that never ran the search at all
+    // would satisfy the assertion below by simply never entering search mode.
+    await waitFor(() =>
+      expect(screen.queryByTestId("add-rows-from-csv")).not.toBeInTheDocument(),
+    );
+    expect(screen.getByTestId("dataset-row-count")).not.toHaveTextContent(
+      "120 of 120",
+    );
+  });
+});
+
 describe("given I have typed a search term that has not run yet", () => {
   /** @scenario The ways to add a row go the moment I start typing */
   it("withdraws every way of adding a row on the keystroke, not on the debounce", async () => {

--- a/platform/app/src/components/datasets/editor/__tests__/DatasetEditorTable.search.integration.test.tsx
+++ b/platform/app/src/components/datasets/editor/__tests__/DatasetEditorTable.search.integration.test.tsx
@@ -152,6 +152,59 @@ const singlePageRecords = [
   { id: "c", entry: { input: "password reset", expected_output: "answer" } },
 ];
 
+/**
+ * Serves a different set of records per `datasetId`, so a switch between
+ * datasets on a still-mounted editor can be observed.
+ */
+const serveDatasetsById = (
+  byId: Record<string, { id: string; entry: Record<string, string> }[]>,
+  { pageSize = 50 }: { pageSize?: number } = {},
+) => {
+  const requests: { datasetId?: string; page?: number; search?: string }[] = [];
+  const cache = new Map<string, unknown>();
+
+  listPaginatedQuery.mockImplementation(
+    (input: { datasetId?: string; page?: number; search?: string }) => {
+      const datasetId = input?.datasetId ?? "";
+      const page = input?.page ?? 1;
+      const search = input?.search?.trim().toLowerCase();
+      const key = `${datasetId}::${page}::${search ?? ""}`;
+      requests.push({ datasetId, page, search: input?.search });
+
+      const cached = cache.get(key);
+      if (cached) return cached;
+
+      const records = byId[datasetId] ?? [];
+      const matching = search
+        ? records.filter((r) =>
+            Object.values(r.entry).some((v) =>
+              v.toLowerCase().includes(search),
+            ),
+          )
+        : records;
+      const result = {
+        data: {
+          id: datasetId,
+          name: datasetId,
+          columnTypes,
+          count: matching.length,
+          totalPages: Math.ceil(matching.length / pageSize),
+          page,
+          datasetRecords: matching.slice(
+            (page - 1) * pageSize,
+            page * pageSize,
+          ),
+        },
+        isLoading: false,
+        refetch: vi.fn(),
+      };
+      cache.set(key, result);
+      return result;
+    },
+  );
+  return requests;
+};
+
 const typeSearch = async (
   user: ReturnType<typeof userEvent.setup>,
   text: string,
@@ -542,6 +595,91 @@ describe("given the server refuses the search", () => {
       /\bof\b|matching/,
     );
     expect(screen.queryByText("question 0")).not.toBeInTheDocument();
+  });
+});
+
+describe("given I open another dataset without leaving the editor", () => {
+  /** @scenario Opening another dataset starts it unsearched */
+  it("drops the previous dataset's search rather than applying it to the new one", async () => {
+    // The editor stays mounted across a client-side move between datasets, so
+    // every piece of search state is carried over unless it is reset. Carried
+    // over, the new dataset is fetched already narrowed by a word the user
+    // typed against a different dataset — rows are missing and nothing on
+    // screen says why.
+    const user = userEvent.setup();
+    const requests = serveDatasetsById({
+      "ds-a": manyRecords,
+      "ds-b": singlePageRecords,
+    });
+    const { rerender } = render(<DatasetEditorTable datasetId="ds-a" />, {
+      wrapper: Wrapper,
+    });
+
+    await typeSearch(user, "escalation");
+    await waitFor(() => expect(requests.at(-1)?.search).toBe("escalation"));
+
+    rerender(<DatasetEditorTable datasetId="ds-b" />);
+
+    await waitFor(() => expect(requests.at(-1)?.datasetId).toBe("ds-b"));
+    expect(requests.filter((r) => r.datasetId === "ds-b" && r.search)).toEqual(
+      [],
+    );
+    expect(screen.getByTestId("dataset-row-search")).toHaveValue("");
+  });
+
+  /** @scenario Opening another dataset starts it unsearched */
+  it("does not report the new dataset's size as the previous one's", async () => {
+    // `unsearchedRecordCount` is remembered so a search can say "3 of 679". Kept
+    // across a dataset switch it says "3 of 679" about a dataset that holds 3
+    // rows in total — a number the user has no way to recognise as stale.
+    const user = userEvent.setup();
+    serveDatasetsById({ "ds-a": manyRecords, "ds-b": singlePageRecords });
+    const { rerender } = render(<DatasetEditorTable datasetId="ds-a" />, {
+      wrapper: Wrapper,
+    });
+
+    await typeSearch(user, "escalation");
+    await waitFor(() =>
+      expect(screen.getByTestId("dataset-row-count")).toHaveTextContent(
+        "1 of 120",
+      ),
+    );
+
+    rerender(<DatasetEditorTable datasetId="ds-b" />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("dataset-row-count")).toHaveTextContent(
+        "3 records",
+      ),
+    );
+    expect(screen.getByTestId("dataset-row-count")).not.toHaveTextContent(
+      "120",
+    );
+  });
+
+  /** @scenario Opening another dataset starts it unsearched */
+  it("starts the new dataset at its first page", async () => {
+    // Page is per-dataset too: page 3 of a 120-row dataset is past the end of a
+    // 3-row one, and the clamp only corrects it after a request for a page that
+    // does not exist has already gone out.
+    const user = userEvent.setup();
+    const requests = serveDatasetsById({
+      "ds-a": manyRecords,
+      "ds-b": singlePageRecords,
+    });
+    const { rerender } = render(<DatasetEditorTable datasetId="ds-a" />, {
+      wrapper: Wrapper,
+    });
+
+    await user.click(await screen.findByTestId("pagination-next"));
+    await waitFor(() => expect(requests.at(-1)?.page).toBe(2));
+
+    rerender(<DatasetEditorTable datasetId="ds-b" />);
+
+    await waitFor(() => expect(requests.at(-1)?.datasetId).toBe("ds-b"));
+    expect(
+      requests.filter((r) => r.datasetId === "ds-b" && (r.page ?? 1) > 1),
+    ).toEqual([]);
   });
 });
 

--- a/platform/app/src/components/datasets/editor/__tests__/DatasetEditorTable.search.integration.test.tsx
+++ b/platform/app/src/components/datasets/editor/__tests__/DatasetEditorTable.search.integration.test.tsx
@@ -601,22 +601,24 @@ describe("given the search's own read has not come back yet", () => {
       // What react-query serves during a key change: the previous key's result,
       // flagged as a placeholder, with the new key's read still in flight.
       const inFlight = { ...unsearched, isPlaceholderData: true };
+      const requests: { search?: string }[] = [];
       listPaginatedQuery.mockImplementation(
-        (input: { search?: string } | undefined) =>
-          input?.search ? inFlight : unsearched,
+        (input: { search?: string } | undefined) => {
+          requests.push(input ?? {});
+          return input?.search ? inFlight : unsearched;
+        },
       );
       render(<DatasetEditorTable datasetId="ds" />, { wrapper: Wrapper });
 
       await screen.findByText("question 0");
       await typeSearch(user, "escalation");
 
-      // The self-check: without it, an editor that never ran the search at all
-      // would satisfy the assertion below by simply never entering search mode.
-      await waitFor(() =>
-        expect(
-          screen.queryByTestId("add-rows-from-csv"),
-        ).not.toBeInTheDocument(),
-      );
+      // The self-check, asserted on the read rather than on the toolbar: the
+      // searched read has to have actually gone out, or the assertion below
+      // holds for the wrong reason — the chip still sitting in its unsearched
+      // state. The add-row affordances are no use for this, because they now go
+      // on the keystroke; their absence proves only that the term was typed.
+      await waitFor(() => expect(requests.at(-1)?.search).toBe("escalation"));
       expect(screen.getByTestId("dataset-row-count")).not.toHaveTextContent(
         "120 of 120",
       );

--- a/platform/app/src/components/datasets/editor/__tests__/DatasetEditorTable.search.integration.test.tsx
+++ b/platform/app/src/components/datasets/editor/__tests__/DatasetEditorTable.search.integration.test.tsx
@@ -31,6 +31,11 @@ vi.mock("~/hooks/useOrganizationTeamProject", () => ({
 const updateMutate = vi.fn();
 const deleteManyMutate = vi.fn();
 const listPaginatedQuery = vi.fn();
+/** Shared across every served result, so "did the editor re-read?" is
+ *  observable. A per-result `vi.fn()` is not: nothing can tell the difference
+ *  between an editor that never refetched and one that refetched into a mock
+ *  that does nothing. */
+const refetchSpy = vi.fn();
 
 vi.mock("~/utils/api", () => ({
   api: {
@@ -115,7 +120,7 @@ const serveDataset = (
           ),
         },
         isLoading: false,
-        refetch: vi.fn(),
+        refetch: refetchSpy,
       };
       cache.set(key, result);
       return result;
@@ -196,7 +201,7 @@ const serveDatasetsById = (
           ),
         },
         isLoading: false,
-        refetch: vi.fn(),
+        refetch: refetchSpy,
       };
       cache.set(key, result);
       return result;
@@ -217,6 +222,7 @@ beforeEach(() => {
   updateMutate.mockReset();
   deleteManyMutate.mockReset();
   listPaginatedQuery.mockReset();
+  refetchSpy.mockReset();
   // In-memory mode still calls the hook (gated by `enabled`), so it needs a
   // settled-but-empty result rather than undefined.
   listPaginatedQuery.mockReturnValue({
@@ -435,7 +441,13 @@ describe("given a saved dataset", () => {
       await user.type(editor, "resolved{Enter}");
 
       await waitFor(() => expect(updateMutate).toHaveBeenCalled());
+      // The row is still on screen with what was typed in it — and, the part
+      // that actually guards the decision, the editor did not re-read. Without
+      // this second assertion the test passes against an editor that refetches
+      // on every save: the mocked `refetch` returns nothing, so the grid keeps
+      // the row either way and the pixels cannot tell the two apart.
       expect(screen.getByText("resolved")).toBeInTheDocument();
+      expect(refetchSpy).not.toHaveBeenCalled();
     });
   });
 

--- a/platform/app/src/components/datasets/editor/__tests__/DatasetEditorTable.search.integration.test.tsx
+++ b/platform/app/src/components/datasets/editor/__tests__/DatasetEditorTable.search.integration.test.tsx
@@ -556,37 +556,92 @@ describe("given the dataset's own total is not known yet", () => {
   });
 });
 
-describe("given the CSV import was opened just before a search landed", () => {
+describe("given I have typed a search term that has not run yet", () => {
+  /** @scenario The ways to add a row go the moment I start typing */
+  it("withdraws every way of adding a row on the keystroke, not on the debounce", async () => {
+    // The gate used to read the DEBOUNCED term, so for the 300ms between the
+    // keystroke and the search running, the add-row button, the trailing row
+    // and the CSV import were all still offered. A row added in that window is
+    // empty, so the search arriving a moment later removes it from the grid.
+    const requests = serveDataset(singlePageRecords);
+    render(<DatasetEditorTable datasetId="ds" />, { wrapper: Wrapper });
+
+    expect(await screen.findByTestId("add-row")).toBeInTheDocument();
+    expect(screen.getByTestId("add-rows-from-csv")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByTestId("dataset-row-search"), {
+      target: { value: "escalation" },
+    });
+
+    // Asserted outright rather than waited for: waiting would let the debounce
+    // fire and the test would pass on the old behaviour too.
+    expect(screen.queryByTestId("add-row")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("add-rows-from-csv")).not.toBeInTheDocument();
+    // The self-check that keeps the two assertions above honest: if the search
+    // had already run, they would hold for the wrong reason. No searched read
+    // has gone out, so the debounce is still pending.
+    expect(requests.at(-1)?.search).toBeUndefined();
+  });
+});
+
+describe("given the CSV import was open when a search landed", () => {
   /** @scenario An import already open when the search lands is withdrawn too */
   it("withdraws the import dialog too, not just the button", async () => {
-    // The toolbar button is withdrawn when a search takes effect, but a click
-    // landing inside the debounce opens the dialog while `isSearching` is still
-    // false. Leaving it mounted is the same hole the button gate exists to
-    // close: rows land at the end of the dataset, outside the matches on screen.
+    // Rows imported here land at the end of the dataset, outside the matches on
+    // screen. Withdrawing only the toolbar button leaves the door open behind
+    // it for an import the user started before they started searching.
     const user = userEvent.setup();
     serveDataset(singlePageRecords);
     render(<DatasetEditorTable datasetId="ds" />, { wrapper: Wrapper });
 
     await screen.findByText("billing question");
-    // Typed in one event rather than keystroke by keystroke: this is the click
-    // that lands INSIDE the debounce, so the test has to reach the button while
-    // the search is still pending. Typing character by character spends most of
-    // that window, and the dialog traps focus once open — so opening it first
-    // and typing behind it exercises an ordering a user cannot perform.
+    await user.click(await screen.findByTestId("add-rows-from-csv"));
+    await waitFor(() => expect(screen.getAllByRole("dialog").length).toBe(1));
+
+    // The dialog traps focus, so the search box cannot be typed into while it
+    // is open — a change event is how this ordering is reachable at all.
     fireEvent.change(screen.getByTestId("dataset-row-search"), {
       target: { value: "escalation" },
     });
-    await user.click(screen.getByTestId("add-rows-from-csv"));
-    await waitFor(() => expect(screen.getAllByRole("dialog").length).toBe(1));
 
-    await waitFor(() =>
-      expect(screen.queryByTestId("add-rows-from-csv")).not.toBeInTheDocument(),
-    );
     // Waited for, not asserted outright: the dialog's unmount is animated, so a
     // bare assertion here races the exit transition and fails intermittently.
     await waitFor(() =>
       expect(screen.queryAllByRole("dialog")).toHaveLength(0),
     );
+  });
+
+  /** @scenario An import withdrawn by a search does not reopen when I clear it */
+  it("leaves it closed when the search is cleared, rather than reopening it", async () => {
+    // Withdrawing the import unmounted the dialog without telling the
+    // disclosure it had closed, so the "open" flag outlived it. Clearing the
+    // search then remounted the dialog on its own — seconds after the user last
+    // touched it, and empty of whatever file they had chosen in it.
+    const user = userEvent.setup();
+    serveDataset(singlePageRecords);
+    render(<DatasetEditorTable datasetId="ds" />, { wrapper: Wrapper });
+
+    await screen.findByText("billing question");
+    await user.click(await screen.findByTestId("add-rows-from-csv"));
+    await waitFor(() => expect(screen.getAllByRole("dialog").length).toBe(1));
+
+    fireEvent.change(screen.getByTestId("dataset-row-search"), {
+      target: { value: "escalation" },
+    });
+    await waitFor(() =>
+      expect(screen.queryAllByRole("dialog")).toHaveLength(0),
+    );
+
+    fireEvent.change(screen.getByTestId("dataset-row-search"), {
+      target: { value: "" },
+    });
+
+    // The import button coming back is the witness that the search really has
+    // been cleared — without it this could pass on a search that never lifted.
+    await waitFor(() =>
+      expect(screen.getByTestId("add-rows-from-csv")).toBeInTheDocument(),
+    );
+    expect(screen.queryAllByRole("dialog")).toHaveLength(0);
   });
 });
 

--- a/platform/app/src/components/datasets/editor/__tests__/DatasetEditorTable.search.integration.test.tsx
+++ b/platform/app/src/components/datasets/editor/__tests__/DatasetEditorTable.search.integration.test.tsx
@@ -410,6 +410,35 @@ describe("given a saved dataset", () => {
     });
   });
 
+  describe("when I edit a matching row so it no longer matches", () => {
+    /** @scenario A row edited so it no longer matches is not pulled out from under me */
+    it("leaves the row on screen rather than removing it under the cursor", async () => {
+      // Deliberate, not an oversight. Re-running the search on every settled
+      // save would take the row out from under the person still working in it,
+      // and strand any further edit to the same row — its grid position now
+      // belongs to a different record, which is what `selectedRows` and
+      // `rowData` address rows by. The grid answers the search as it was run.
+      updateMutate.mockImplementation(
+        (_args: unknown, opts: { onSuccess: () => void }) => opts.onSuccess(),
+      );
+      const user = userEvent.setup();
+      const requests = serveDataset(singlePageRecords);
+      render(<DatasetEditorTable datasetId="ds" />, { wrapper: Wrapper });
+
+      await typeSearch(user, "escalation");
+      await waitFor(() => expect(requests.at(-1)?.search).toBe("escalation"));
+      await screen.findByText("needs escalation");
+
+      await user.dblClick(screen.getByTestId("cell-0-input_0"));
+      const editor = await screen.findByRole("textbox");
+      await user.clear(editor);
+      await user.type(editor, "resolved{Enter}");
+
+      await waitFor(() => expect(updateMutate).toHaveBeenCalled());
+      expect(screen.getByText("resolved")).toBeInTheDocument();
+    });
+  });
+
   describe("when I clear the search", () => {
     /** @scenario Clearing the search restores the whole dataset */
     it("restores the whole dataset and the ways to add a row", async () => {

--- a/platform/app/src/components/datasets/editor/__tests__/DatasetEditorTable.search.integration.test.tsx
+++ b/platform/app/src/components/datasets/editor/__tests__/DatasetEditorTable.search.integration.test.tsx
@@ -161,10 +161,13 @@ const singlePageRecords = [
  * Serves a different set of records per `datasetId`, so a switch between
  * datasets on a still-mounted editor can be observed.
  */
-const serveDatasetsById = (
-  byId: Record<string, { id: string; entry: Record<string, string> }[]>,
-  { pageSize = 50 }: { pageSize?: number } = {},
-) => {
+const serveDatasetsById = ({
+  byId,
+  pageSize = 50,
+}: {
+  byId: Record<string, { id: string; entry: Record<string, string> }[]>;
+  pageSize?: number;
+}) => {
   const requests: { datasetId?: string; page?: number; search?: string }[] = [];
   const cache = new Map<string, unknown>();
 
@@ -265,6 +268,7 @@ describe("given a saved dataset", () => {
       expect(requests.at(-1)?.page).toBe(1);
     });
 
+    /** @scenario Searching returns me to the first page of results */
     it("never asks for a page of matches the search has not been applied to", async () => {
       // The page must be reset BEFORE the search reaches the query, not after.
       // Resetting it afterwards fires a real request for (old page, new search)
@@ -520,337 +524,361 @@ describe("given a saved dataset", () => {
 });
 
 describe("given the dataset's own total is not known yet", () => {
-  /** @scenario The record count reports the matches, not the whole dataset */
-  it("does not pass the match count off as the dataset's total", async () => {
-    // The two-number chip remembers the total from the last UNSEARCHED read. If
-    // no unsearched read has settled — a slow whole-dataset read, or a remount
-    // while a search is active — there is no total to report, and reusing the
-    // match count for both halves would state "1 of 1 records" for a dataset of
-    // 120: precisely the "the dataset has shrunk" misreading the two numbers
-    // exist to prevent. Saying less is the only honest option.
-    const user = userEvent.setup();
-    // Stable refs per branch — a fresh object each render feeds the editor's
-    // data-keyed effects a new value every time and spins it into an update
-    // loop, as the note on `serveDataset` describes.
-    const pending = { data: undefined, isLoading: true };
-    const matched = {
-      data: {
-        id: "ds",
-        name: "ds",
-        columnTypes,
-        count: 1,
-        totalPages: 1,
-        page: 1,
-        datasetRecords: [{ id: "r119", entry: { input: "needs escalation" } }],
-      },
-      isLoading: false,
-      refetch: vi.fn(),
-    };
-    listPaginatedQuery.mockImplementation(
-      (input: { search?: string } | undefined) =>
-        input?.search ? matched : pending,
-    );
-    render(<DatasetEditorTable datasetId="ds" />, { wrapper: Wrapper });
+  describe("when a search takes effect", () => {
+    /** @scenario The record count reports the matches, not the whole dataset */
+    it("does not pass the match count off as the dataset's total", async () => {
+      // The two-number chip remembers the total from the last UNSEARCHED read. If
+      // no unsearched read has settled — a slow whole-dataset read, or a remount
+      // while a search is active — there is no total to report, and reusing the
+      // match count for both halves would state "1 of 1 records" for a dataset of
+      // 120: precisely the "the dataset has shrunk" misreading the two numbers
+      // exist to prevent. Saying less is the only honest option.
+      const user = userEvent.setup();
+      // Stable refs per branch — a fresh object each render feeds the editor's
+      // data-keyed effects a new value every time and spins it into an update
+      // loop, as the note on `serveDataset` describes.
+      const pending = { data: undefined, isLoading: true };
+      const matched = {
+        data: {
+          id: "ds",
+          name: "ds",
+          columnTypes,
+          count: 1,
+          totalPages: 1,
+          page: 1,
+          datasetRecords: [
+            { id: "r119", entry: { input: "needs escalation" } },
+          ],
+        },
+        isLoading: false,
+        refetch: vi.fn(),
+      };
+      listPaginatedQuery.mockImplementation(
+        (input: { search?: string } | undefined) =>
+          input?.search ? matched : pending,
+      );
+      render(<DatasetEditorTable datasetId="ds" />, { wrapper: Wrapper });
 
-    await typeSearch(user, "escalation");
+      await typeSearch(user, "escalation");
 
-    await waitFor(() =>
-      expect(screen.getByTestId("dataset-row-count")).toHaveTextContent(
-        /matching/,
-      ),
-    );
-    expect(screen.getByTestId("dataset-row-count")).not.toHaveTextContent(
-      "1 of 1",
-    );
+      await waitFor(() =>
+        expect(screen.getByTestId("dataset-row-count")).toHaveTextContent(
+          /matching/,
+        ),
+      );
+      expect(screen.getByTestId("dataset-row-count")).not.toHaveTextContent(
+        "1 of 1",
+      );
+    });
   });
 });
 
 describe("given the search's own read has not come back yet", () => {
-  /** @scenario The record count reports the matches, not the whole dataset */
-  it("does not report the held-over rows as the matches", async () => {
-    // While the search's read is in flight, `keepPreviousData` keeps serving
-    // the last unsearched page, and the `count` that comes with it is the
-    // DATASET's size, not a number of matches. Rendered through the two-number
-    // chip that becomes "120 of 120 records" — every row matched — over rows
-    // that were never searched at all. On a large dataset that read takes
-    // seconds, and a refused one used to hold this state for the whole retry
-    // backoff.
-    const user = userEvent.setup();
-    const unsearched = {
-      data: {
-        id: "ds",
-        name: "ds",
-        columnTypes,
-        count: 120,
-        totalPages: 3,
-        page: 1,
-        datasetRecords: manyRecords.slice(0, 50),
-      },
-      isLoading: false,
-      refetch: vi.fn(),
-    };
-    // What react-query serves during a key change: the previous key's result,
-    // flagged as a placeholder, with the new key's read still in flight.
-    const inFlight = { ...unsearched, isPlaceholderData: true };
-    listPaginatedQuery.mockImplementation(
-      (input: { search?: string } | undefined) =>
-        input?.search ? inFlight : unsearched,
-    );
-    render(<DatasetEditorTable datasetId="ds" />, { wrapper: Wrapper });
+  describe("when the count chip is rendered", () => {
+    /** @scenario The record count reports the matches, not the whole dataset */
+    it("does not report the held-over rows as the matches", async () => {
+      // While the search's read is in flight, `keepPreviousData` keeps serving
+      // the last unsearched page, and the `count` that comes with it is the
+      // DATASET's size, not a number of matches. Rendered through the two-number
+      // chip that becomes "120 of 120 records" — every row matched — over rows
+      // that were never searched at all. On a large dataset that read takes
+      // seconds, and a refused one used to hold this state for the whole retry
+      // backoff.
+      const user = userEvent.setup();
+      const unsearched = {
+        data: {
+          id: "ds",
+          name: "ds",
+          columnTypes,
+          count: 120,
+          totalPages: 3,
+          page: 1,
+          datasetRecords: manyRecords.slice(0, 50),
+        },
+        isLoading: false,
+        refetch: vi.fn(),
+      };
+      // What react-query serves during a key change: the previous key's result,
+      // flagged as a placeholder, with the new key's read still in flight.
+      const inFlight = { ...unsearched, isPlaceholderData: true };
+      listPaginatedQuery.mockImplementation(
+        (input: { search?: string } | undefined) =>
+          input?.search ? inFlight : unsearched,
+      );
+      render(<DatasetEditorTable datasetId="ds" />, { wrapper: Wrapper });
 
-    await screen.findByText("question 0");
-    await typeSearch(user, "escalation");
+      await screen.findByText("question 0");
+      await typeSearch(user, "escalation");
 
-    // The self-check: without it, an editor that never ran the search at all
-    // would satisfy the assertion below by simply never entering search mode.
-    await waitFor(() =>
-      expect(screen.queryByTestId("add-rows-from-csv")).not.toBeInTheDocument(),
-    );
-    expect(screen.getByTestId("dataset-row-count")).not.toHaveTextContent(
-      "120 of 120",
-    );
+      // The self-check: without it, an editor that never ran the search at all
+      // would satisfy the assertion below by simply never entering search mode.
+      await waitFor(() =>
+        expect(
+          screen.queryByTestId("add-rows-from-csv"),
+        ).not.toBeInTheDocument(),
+      );
+      expect(screen.getByTestId("dataset-row-count")).not.toHaveTextContent(
+        "120 of 120",
+      );
+    });
   });
 });
 
 describe("given I have typed a search term that has not run yet", () => {
-  /** @scenario The ways to add a row go the moment I start typing */
-  it("withdraws every way of adding a row on the keystroke, not on the debounce", async () => {
-    // The gate used to read the DEBOUNCED term, so for the 300ms between the
-    // keystroke and the search running, the add-row button, the trailing row
-    // and the CSV import were all still offered. A row added in that window is
-    // empty, so the search arriving a moment later removes it from the grid.
-    const requests = serveDataset(singlePageRecords);
-    render(<DatasetEditorTable datasetId="ds" />, { wrapper: Wrapper });
+  describe("when the toolbar and the grid are rendered", () => {
+    /** @scenario The ways to add a row go the moment I start typing */
+    it("withdraws every way of adding a row on the keystroke, not on the debounce", async () => {
+      // The gate used to read the DEBOUNCED term, so for the 300ms between the
+      // keystroke and the search running, the add-row button, the trailing row
+      // and the CSV import were all still offered. A row added in that window is
+      // empty, so the search arriving a moment later removes it from the grid.
+      const requests = serveDataset(singlePageRecords);
+      render(<DatasetEditorTable datasetId="ds" />, { wrapper: Wrapper });
 
-    expect(await screen.findByTestId("add-row")).toBeInTheDocument();
-    expect(screen.getByTestId("add-rows-from-csv")).toBeInTheDocument();
+      expect(await screen.findByTestId("add-row")).toBeInTheDocument();
+      expect(screen.getByTestId("add-rows-from-csv")).toBeInTheDocument();
 
-    fireEvent.change(screen.getByTestId("dataset-row-search"), {
-      target: { value: "escalation" },
+      fireEvent.change(screen.getByTestId("dataset-row-search"), {
+        target: { value: "escalation" },
+      });
+
+      // Asserted outright rather than waited for: waiting would let the debounce
+      // fire and the test would pass on the old behaviour too.
+      expect(screen.queryByTestId("add-row")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("add-rows-from-csv")).not.toBeInTheDocument();
+      // The self-check that keeps the two assertions above honest: if the search
+      // had already run, they would hold for the wrong reason. No searched read
+      // has gone out, so the debounce is still pending.
+      expect(requests.at(-1)?.search).toBeUndefined();
     });
-
-    // Asserted outright rather than waited for: waiting would let the debounce
-    // fire and the test would pass on the old behaviour too.
-    expect(screen.queryByTestId("add-row")).not.toBeInTheDocument();
-    expect(screen.queryByTestId("add-rows-from-csv")).not.toBeInTheDocument();
-    // The self-check that keeps the two assertions above honest: if the search
-    // had already run, they would hold for the wrong reason. No searched read
-    // has gone out, so the debounce is still pending.
-    expect(requests.at(-1)?.search).toBeUndefined();
   });
 });
 
-describe("given the CSV import was open when a search landed", () => {
-  /** @scenario An import already open when the search lands is withdrawn too */
-  it("withdraws the import dialog too, not just the button", async () => {
-    // Rows imported here land at the end of the dataset, outside the matches on
-    // screen. Withdrawing only the toolbar button leaves the door open behind
-    // it for an import the user started before they started searching.
-    const user = userEvent.setup();
-    serveDataset(singlePageRecords);
-    render(<DatasetEditorTable datasetId="ds" />, { wrapper: Wrapper });
+describe("given I had opened the CSV import", () => {
+  describe("when a search takes effect", () => {
+    /** @scenario An import already open when the search lands is withdrawn too */
+    it("withdraws the import dialog too, not just the button", async () => {
+      // Rows imported here land at the end of the dataset, outside the matches on
+      // screen. Withdrawing only the toolbar button leaves the door open behind
+      // it for an import the user started before they started searching.
+      const user = userEvent.setup();
+      serveDataset(singlePageRecords);
+      render(<DatasetEditorTable datasetId="ds" />, { wrapper: Wrapper });
 
-    await screen.findByText("billing question");
-    await user.click(await screen.findByTestId("add-rows-from-csv"));
-    await waitFor(() => expect(screen.getAllByRole("dialog").length).toBe(1));
+      await screen.findByText("billing question");
+      await user.click(await screen.findByTestId("add-rows-from-csv"));
+      await waitFor(() => expect(screen.getAllByRole("dialog").length).toBe(1));
 
-    // The dialog traps focus, so the search box cannot be typed into while it
-    // is open — a change event is how this ordering is reachable at all.
-    fireEvent.change(screen.getByTestId("dataset-row-search"), {
-      target: { value: "escalation" },
+      // The dialog traps focus, so the search box cannot be typed into while it
+      // is open — a change event is how this ordering is reachable at all.
+      fireEvent.change(screen.getByTestId("dataset-row-search"), {
+        target: { value: "escalation" },
+      });
+
+      // Waited for, not asserted outright: the dialog's unmount is animated, so a
+      // bare assertion here races the exit transition and fails intermittently.
+      await waitFor(() =>
+        expect(screen.queryAllByRole("dialog")).toHaveLength(0),
+      );
     });
-
-    // Waited for, not asserted outright: the dialog's unmount is animated, so a
-    // bare assertion here races the exit transition and fails intermittently.
-    await waitFor(() =>
-      expect(screen.queryAllByRole("dialog")).toHaveLength(0),
-    );
   });
 
-  /** @scenario An import withdrawn by a search does not reopen when I clear it */
-  it("leaves it closed when the search is cleared, rather than reopening it", async () => {
-    // Withdrawing the import unmounted the dialog without telling the
-    // disclosure it had closed, so the "open" flag outlived it. Clearing the
-    // search then remounted the dialog on its own — seconds after the user last
-    // touched it, and empty of whatever file they had chosen in it.
-    const user = userEvent.setup();
-    serveDataset(singlePageRecords);
-    render(<DatasetEditorTable datasetId="ds" />, { wrapper: Wrapper });
+  describe("when I then clear the search", () => {
+    /** @scenario An import withdrawn by a search does not reopen when I clear it */
+    it("leaves it closed when the search is cleared, rather than reopening it", async () => {
+      // Withdrawing the import unmounted the dialog without telling the
+      // disclosure it had closed, so the "open" flag outlived it. Clearing the
+      // search then remounted the dialog on its own — seconds after the user last
+      // touched it, and empty of whatever file they had chosen in it.
+      const user = userEvent.setup();
+      serveDataset(singlePageRecords);
+      render(<DatasetEditorTable datasetId="ds" />, { wrapper: Wrapper });
 
-    await screen.findByText("billing question");
-    await user.click(await screen.findByTestId("add-rows-from-csv"));
-    await waitFor(() => expect(screen.getAllByRole("dialog").length).toBe(1));
+      await screen.findByText("billing question");
+      await user.click(await screen.findByTestId("add-rows-from-csv"));
+      await waitFor(() => expect(screen.getAllByRole("dialog").length).toBe(1));
 
-    fireEvent.change(screen.getByTestId("dataset-row-search"), {
-      target: { value: "escalation" },
+      fireEvent.change(screen.getByTestId("dataset-row-search"), {
+        target: { value: "escalation" },
+      });
+      await waitFor(() =>
+        expect(screen.queryAllByRole("dialog")).toHaveLength(0),
+      );
+
+      fireEvent.change(screen.getByTestId("dataset-row-search"), {
+        target: { value: "" },
+      });
+
+      // The import button coming back is the witness that the search really has
+      // been cleared — without it this could pass on a search that never lifted.
+      await waitFor(() =>
+        expect(screen.getByTestId("add-rows-from-csv")).toBeInTheDocument(),
+      );
+      expect(screen.queryAllByRole("dialog")).toHaveLength(0);
     });
-    await waitFor(() =>
-      expect(screen.queryAllByRole("dialog")).toHaveLength(0),
-    );
-
-    fireEvent.change(screen.getByTestId("dataset-row-search"), {
-      target: { value: "" },
-    });
-
-    // The import button coming back is the witness that the search really has
-    // been cleared — without it this could pass on a search that never lifted.
-    await waitFor(() =>
-      expect(screen.getByTestId("add-rows-from-csv")).toBeInTheDocument(),
-    );
-    expect(screen.queryAllByRole("dialog")).toHaveLength(0);
   });
 });
 
 describe("given the server refuses the search", () => {
-  /** @scenario A refused search does not leave unsearched rows on screen as if they matched */
-  it("stops presenting the pre-search rows as the result", async () => {
-    // The rows on screen were read before the search and never matched against
-    // it. The store is only written from a settled `data`, so on error it keeps
-    // them — and the chip, fed by the same stale count, labels them as the
-    // matches. "50 of 60,000 records" under a search box containing
-    // "escalation" is a complete, confident, false answer; the toast that
-    // explains it dismisses after 12s and leaves only the falsehood.
-    const user = userEvent.setup();
-    const loaded = {
-      data: {
-        id: "ds",
-        name: "ds",
-        columnTypes,
-        count: 120,
-        totalPages: 3,
-        page: 1,
-        datasetRecords: manyRecords.slice(0, 50),
-      },
-      isLoading: false,
-      refetch: vi.fn(),
-    };
-    const refused = {
-      data: undefined,
-      error: { message: "This dataset is too large to search" },
-      isLoading: false,
-      refetch: vi.fn(),
-    };
-    listPaginatedQuery.mockImplementation(
-      (input: { search?: string } | undefined) =>
-        input?.search ? refused : loaded,
-    );
-    render(<DatasetEditorTable datasetId="ds" />, { wrapper: Wrapper });
+  describe("when the refusal comes back", () => {
+    /** @scenario A refused search does not leave unsearched rows on screen as if they matched */
+    it("stops presenting the pre-search rows as the result", async () => {
+      // The rows on screen were read before the search and never matched against
+      // it. The store is only written from a settled `data`, so on error it keeps
+      // them — and the chip, fed by the same stale count, labels them as the
+      // matches. "50 of 60,000 records" under a search box containing
+      // "escalation" is a complete, confident, false answer; the toast that
+      // explains it dismisses after 12s and leaves only the falsehood.
+      const user = userEvent.setup();
+      const loaded = {
+        data: {
+          id: "ds",
+          name: "ds",
+          columnTypes,
+          count: 120,
+          totalPages: 3,
+          page: 1,
+          datasetRecords: manyRecords.slice(0, 50),
+        },
+        isLoading: false,
+        refetch: vi.fn(),
+      };
+      const refused = {
+        data: undefined,
+        error: { message: "This dataset is too large to search" },
+        isLoading: false,
+        refetch: vi.fn(),
+      };
+      listPaginatedQuery.mockImplementation(
+        (input: { search?: string } | undefined) =>
+          input?.search ? refused : loaded,
+      );
+      render(<DatasetEditorTable datasetId="ds" />, { wrapper: Wrapper });
 
-    await screen.findByText("question 0");
-    await typeSearch(user, "escalation");
+      await screen.findByText("question 0");
+      await typeSearch(user, "escalation");
 
-    await waitFor(() =>
-      expect(screen.getByTestId("dataset-search-failed")).toBeInTheDocument(),
-    );
-    // No match claim: the chip must not report a count of matches it never got.
-    expect(screen.getByTestId("dataset-row-count")).not.toHaveTextContent(
-      /\bof\b|matching/,
-    );
-    expect(screen.queryByText("question 0")).not.toBeInTheDocument();
+      await waitFor(() =>
+        expect(screen.getByTestId("dataset-search-failed")).toBeInTheDocument(),
+      );
+      // No match claim: the chip must not report a count of matches it never got.
+      expect(screen.getByTestId("dataset-row-count")).not.toHaveTextContent(
+        /\bof\b|matching/,
+      );
+      expect(screen.queryByText("question 0")).not.toBeInTheDocument();
+    });
   });
 });
 
 describe("given I open another dataset without leaving the editor", () => {
-  /** @scenario Opening another dataset starts it unsearched */
-  it("drops the previous dataset's search rather than applying it to the new one", async () => {
-    // The editor stays mounted across a client-side move between datasets, so
-    // every piece of search state is carried over unless it is reset. Carried
-    // over, the new dataset is fetched already narrowed by a word the user
-    // typed against a different dataset — rows are missing and nothing on
-    // screen says why.
-    const user = userEvent.setup();
-    const requests = serveDatasetsById({
-      "ds-a": manyRecords,
-      "ds-b": singlePageRecords,
-    });
-    const { rerender } = render(<DatasetEditorTable datasetId="ds-a" />, {
-      wrapper: Wrapper,
-    });
+  describe("when the new dataset is read", () => {
+    /** @scenario Opening another dataset starts it unsearched */
+    it("drops the previous dataset's search rather than applying it to the new one", async () => {
+      // The editor stays mounted across a client-side move between datasets, so
+      // every piece of search state is carried over unless it is reset. Carried
+      // over, the new dataset is fetched already narrowed by a word the user
+      // typed against a different dataset — rows are missing and nothing on
+      // screen says why.
+      const user = userEvent.setup();
+      const requests = serveDatasetsById({
+        byId: { "ds-a": manyRecords, "ds-b": singlePageRecords },
+      });
+      const { rerender } = render(<DatasetEditorTable datasetId="ds-a" />, {
+        wrapper: Wrapper,
+      });
 
-    await typeSearch(user, "escalation");
-    await waitFor(() => expect(requests.at(-1)?.search).toBe("escalation"));
+      await typeSearch(user, "escalation");
+      await waitFor(() => expect(requests.at(-1)?.search).toBe("escalation"));
 
-    rerender(<DatasetEditorTable datasetId="ds-b" />);
+      rerender(<DatasetEditorTable datasetId="ds-b" />);
 
-    await waitFor(() => expect(requests.at(-1)?.datasetId).toBe("ds-b"));
-    expect(requests.filter((r) => r.datasetId === "ds-b" && r.search)).toEqual(
-      [],
-    );
-    expect(screen.getByTestId("dataset-row-search")).toHaveValue("");
-  });
-
-  /** @scenario Opening another dataset starts it unsearched */
-  it("does not report the new dataset's size as the previous one's", async () => {
-    // `unsearchedRecordCount` is remembered so a search can say "3 of 679". Kept
-    // across a dataset switch it says "3 of 679" about a dataset that holds 3
-    // rows in total — a number the user has no way to recognise as stale.
-    const user = userEvent.setup();
-    serveDatasetsById({ "ds-a": manyRecords, "ds-b": singlePageRecords });
-    const { rerender } = render(<DatasetEditorTable datasetId="ds-a" />, {
-      wrapper: Wrapper,
+      await waitFor(() => expect(requests.at(-1)?.datasetId).toBe("ds-b"));
+      expect(
+        requests.filter((r) => r.datasetId === "ds-b" && r.search),
+      ).toEqual([]);
+      expect(screen.getByTestId("dataset-row-search")).toHaveValue("");
     });
 
-    await typeSearch(user, "escalation");
-    await waitFor(() =>
-      expect(screen.getByTestId("dataset-row-count")).toHaveTextContent(
-        "1 of 120",
-      ),
-    );
+    /** @scenario Opening another dataset starts it unsearched */
+    it("does not report the new dataset's size as the previous one's", async () => {
+      // `unsearchedRecordCount` is remembered so a search can say "3 of 679". Kept
+      // across a dataset switch it says "3 of 679" about a dataset that holds 3
+      // rows in total — a number the user has no way to recognise as stale.
+      const user = userEvent.setup();
+      serveDatasetsById({
+        byId: { "ds-a": manyRecords, "ds-b": singlePageRecords },
+      });
+      const { rerender } = render(<DatasetEditorTable datasetId="ds-a" />, {
+        wrapper: Wrapper,
+      });
 
-    rerender(<DatasetEditorTable datasetId="ds-b" />);
+      await typeSearch(user, "escalation");
+      await waitFor(() =>
+        expect(screen.getByTestId("dataset-row-count")).toHaveTextContent(
+          "1 of 120",
+        ),
+      );
 
-    await waitFor(() =>
-      expect(screen.getByTestId("dataset-row-count")).toHaveTextContent(
-        "3 records",
-      ),
-    );
-    expect(screen.getByTestId("dataset-row-count")).not.toHaveTextContent(
-      "120",
-    );
-  });
+      rerender(<DatasetEditorTable datasetId="ds-b" />);
 
-  /** @scenario Opening another dataset starts it unsearched */
-  it("starts the new dataset at its first page", async () => {
-    // Page is per-dataset too: page 3 of a 120-row dataset is past the end of a
-    // 3-row one, and the clamp only corrects it after a request for a page that
-    // does not exist has already gone out.
-    const user = userEvent.setup();
-    const requests = serveDatasetsById({
-      "ds-a": manyRecords,
-      "ds-b": singlePageRecords,
+      await waitFor(() =>
+        expect(screen.getByTestId("dataset-row-count")).toHaveTextContent(
+          "3 records",
+        ),
+      );
+      expect(screen.getByTestId("dataset-row-count")).not.toHaveTextContent(
+        "120",
+      );
     });
-    const { rerender } = render(<DatasetEditorTable datasetId="ds-a" />, {
-      wrapper: Wrapper,
+
+    /** @scenario Opening another dataset starts it unsearched */
+    it("starts the new dataset at its first page", async () => {
+      // Page is per-dataset too: page 3 of a 120-row dataset is past the end of a
+      // 3-row one, and the clamp only corrects it after a request for a page that
+      // does not exist has already gone out.
+      const user = userEvent.setup();
+      const requests = serveDatasetsById({
+        byId: { "ds-a": manyRecords, "ds-b": singlePageRecords },
+      });
+      const { rerender } = render(<DatasetEditorTable datasetId="ds-a" />, {
+        wrapper: Wrapper,
+      });
+
+      await user.click(await screen.findByTestId("pagination-next"));
+      await waitFor(() => expect(requests.at(-1)?.page).toBe(2));
+
+      rerender(<DatasetEditorTable datasetId="ds-b" />);
+
+      await waitFor(() => expect(requests.at(-1)?.datasetId).toBe("ds-b"));
+      expect(
+        requests.filter((r) => r.datasetId === "ds-b" && (r.page ?? 1) > 1),
+      ).toEqual([]);
     });
-
-    await user.click(await screen.findByTestId("pagination-next"));
-    await waitFor(() => expect(requests.at(-1)?.page).toBe(2));
-
-    rerender(<DatasetEditorTable datasetId="ds-b" />);
-
-    await waitFor(() => expect(requests.at(-1)?.datasetId).toBe("ds-b"));
-    expect(
-      requests.filter((r) => r.datasetId === "ds-b" && (r.page ?? 1) > 1),
-    ).toEqual([]);
   });
 });
 
 describe("given a draft dataset that has not been saved", () => {
-  /** @scenario A draft dataset offers no search */
-  it("offers no search, and still offers the ways to add a row", () => {
-    render(
-      <DatasetEditorTable
-        inMemoryDataset={{
-          name: "My Draft",
-          columnTypes,
-          datasetRecords: [{ id: "r1", input: "hello", expected_output: "x" }],
-        }}
-        onUpdateDataset={vi.fn()}
-      />,
-      { wrapper: Wrapper },
-    );
+  describe("when the editor is rendered", () => {
+    /** @scenario A draft dataset offers no search */
+    it("offers no search, and still offers the ways to add a row", () => {
+      render(
+        <DatasetEditorTable
+          inMemoryDataset={{
+            name: "My Draft",
+            columnTypes,
+            datasetRecords: [
+              { id: "r1", input: "hello", expected_output: "x" },
+            ],
+          }}
+          onUpdateDataset={vi.fn()}
+        />,
+        { wrapper: Wrapper },
+      );
 
-    expect(screen.queryByTestId("dataset-row-search")).not.toBeInTheDocument();
-    expect(screen.getByTestId("add-row")).toBeInTheDocument();
+      expect(
+        screen.queryByTestId("dataset-row-search"),
+      ).not.toBeInTheDocument();
+      expect(screen.getByTestId("add-row")).toBeInTheDocument();
+    });
   });
 });

--- a/platform/app/src/components/datasets/editor/__tests__/datasetEditorCopy.unit.test.ts
+++ b/platform/app/src/components/datasets/editor/__tests__/datasetEditorCopy.unit.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { truncatedReadTooltip } from "../datasetEditorCopy";
+import {
+  formatSearchRecordCount,
+  noSearchMatchesMessage,
+  searchFailedMessage,
+  truncatedReadTooltip,
+} from "../datasetEditorCopy";
 
 describe("given a dataset whose editor read is truncated", () => {
   describe("when building the count tooltip", () => {
@@ -15,6 +20,55 @@ describe("given a dataset whose editor read is truncated", () => {
     it("formats both counts with a fixed en-US thousands separator (locale-independent)", () => {
       const copy = truncatedReadTooltip({ shown: 10, total: 1000000 });
       expect(copy).toContain("showing 10 out of 1,000,000 rows");
+    });
+  });
+});
+
+describe("given a search is in effect", () => {
+  describe("when building the count chip", () => {
+    it("reports the matches and the dataset total, so neither number misleads alone", () => {
+      // Pin the customer-facing message so it can't silently drift.
+      expect(formatSearchRecordCount({ matched: 3, total: 679 })).toBe(
+        "3 of 679 records",
+      );
+    });
+
+    it("says zero rather than going blank when nothing matched", () => {
+      expect(formatSearchRecordCount({ matched: 0, total: 679 })).toBe(
+        "0 of 679 records",
+      );
+    });
+
+    it("formats both counts with a fixed en-US thousands separator (locale-independent)", () => {
+      expect(formatSearchRecordCount({ matched: 1200, total: 1000000 })).toBe(
+        "1,200 of 1,000,000 records",
+      );
+    });
+
+    it("drops the total rather than inventing one when the dataset's size is unknown", () => {
+      // Reusing the match count for both halves would render "1 of 1 records"
+      // for a dataset of any size — the "it has shrunk" misreading the pair of
+      // numbers exists to prevent.
+      expect(formatSearchRecordCount({ matched: 1 })).toBe("1 matching record");
+      expect(formatSearchRecordCount({ matched: 1200 })).toBe(
+        "1,200 matching records",
+      );
+    });
+  });
+
+  describe("when the search could not be run", () => {
+    it("names the search that failed, so the message is tied to it", () => {
+      expect(searchFailedMessage("escalation")).toBe(
+        "Couldn’t run the search for “escalation”.",
+      );
+    });
+  });
+
+  describe("when nothing matched", () => {
+    it("repeats the searched text, so the message is tied to a search", () => {
+      expect(noSearchMatchesMessage("escalation")).toBe(
+        "No records match “escalation”.",
+      );
     });
   });
 });

--- a/platform/app/src/components/datasets/editor/datasetEditorCopy.ts
+++ b/platform/app/src/components/datasets/editor/datasetEditorCopy.ts
@@ -17,6 +17,53 @@ export const formatRecordCount = (count: number): string =>
   recordCountFormatter.format(count);
 
 /**
+ * The count chip while a search is in effect.
+ *
+ * Both numbers, because either alone misleads: the match count on its own reads
+ * as the dataset having shrunk, and the dataset total on its own hides the
+ * result of the search that was just run.
+ *
+ * `total` is omitted when no unsearched read has settled yet, so the dataset's
+ * own size genuinely is not known. Reusing the match count for both halves
+ * would render "1 of 1 records" for a dataset of 120 — the exact misreading the
+ * pair exists to prevent — so the chip says less instead of saying something
+ * false.
+ */
+export const formatSearchRecordCount = ({
+  matched,
+  total,
+}: {
+  matched: number;
+  total?: number;
+}): string =>
+  total === undefined
+    ? `${formatRecordCount(matched)} matching ${
+        matched === 1 ? "record" : "records"
+      }`
+    : `${formatRecordCount(matched)} of ${formatRecordCount(total)} records`;
+
+/**
+ * Shown in place of the grid when a search matched nothing. Repeats the text
+ * that was searched for: with a debounce between typing and results, the user
+ * needs to see which search this empty result belongs to.
+ */
+/** The count chip with no search in effect: "679 records", "1 record". */
+export const plainRecordCount = (count: number): string =>
+  `${formatRecordCount(count)} ${count === 1 ? "record" : "records"}`;
+
+/**
+ * Shown in the grid when the server refused or failed the search.
+ *
+ * The toast carries the reason and then dismisses; this stays, so the screen
+ * never settles into looking like a search that returned something.
+ */
+export const searchFailedMessage = (search: string): string =>
+  `Couldn’t run the search for “${search}”.`;
+
+export const noSearchMatchesMessage = (search: string): string =>
+  `No records match “${search}”.`;
+
+/**
  * Tooltip shown on the truncated-read count chip. A large dataset is loaded into
  * the editor up to a byte budget, so only the first rows are shown; this
  * explains that nothing is lost, that editing a visible row is safe, and how to

--- a/platform/app/src/features/errors/logic/__tests__/presentation.datasetSearch.unit.test.ts
+++ b/platform/app/src/features/errors/logic/__tests__/presentation.datasetSearch.unit.test.ts
@@ -1,0 +1,42 @@
+/**
+ * The search refusal has to read as being about SEARCH. The registry is keyed by
+ * code, so a search that reused the export refusal's code would answer the user
+ * with copy about exporting a dataset they were trying to search.
+ */
+import { describe, expect, it } from "vitest";
+
+import { explainHandledError } from "../presentation";
+import type { HandledErrorShape } from "../readHandledError";
+
+const SERVER_MESSAGE =
+  "Dataset has 120000 rows, more than the 50000 a single search will read";
+
+const refusal: HandledErrorShape = {
+  code: "dataset_too_large_to_search",
+  meta: { rowCount: 120_000, maxRows: 50_000 },
+  httpStatus: 413,
+  fault: "customer",
+  tips: [],
+  docsUrl: undefined,
+  traceId: undefined,
+  reasons: [],
+};
+
+describe("a search refused because the dataset is too large", () => {
+  /** @scenario The refusal has its own words, not the export refusal's */
+  it("says the dataset is too large to search, and says nothing about exporting", () => {
+    const copy = explainHandledError(refusal);
+    const shown = `${copy.title} ${copy.description ?? ""}`;
+
+    expect(copy.title).toMatch(/too large to search/i);
+    expect(shown).not.toMatch(/export/i);
+  });
+
+  it("never shows the code slug or the server's own message", () => {
+    const copy = explainHandledError(refusal);
+    const shown = `${copy.title} ${copy.description ?? ""}`;
+
+    expect(shown).not.toContain("dataset_too_large_to_search");
+    expect(shown).not.toContain(SERVER_MESSAGE);
+  });
+});

--- a/platform/app/src/features/errors/logic/codes.ts
+++ b/platform/app/src/features/errors/logic/codes.ts
@@ -88,6 +88,7 @@ export const APP_ERROR_CODES = [
   "dataset_name_taken",
   "dataset_not_ready",
   "dataset_stale_columns",
+  "dataset_too_large_to_search",
   "dspy_step_not_found",
   "duplicate_invite",
   "email_already_registered",

--- a/platform/app/src/features/errors/logic/presentation.ts
+++ b/platform/app/src/features/errors/logic/presentation.ts
@@ -2171,6 +2171,15 @@ const presentations = {
     describe: () =>
       "Reload to pick up the current columns, then make your change again.",
   },
+  dataset_too_large_to_search: {
+    // A limit, not a breakage: the search would have had to read more of the
+    // dataset than one search reads. Saying so beats returning the matches
+    // found before giving up, which reads as a complete answer and is not one.
+    // Paging still works, so the copy points at the way through.
+    title: "This dataset is too large to search",
+    describe: () =>
+      "Page through the rows, or split the dataset into smaller ones.",
+  },
   storage_not_writable: {
     // fault: platform. Storage for this deployment was never provisioned, so
     // retrying changes nothing and there is no customer-side setting to fix.

--- a/platform/app/src/features/errors/logic/retryability.ts
+++ b/platform/app/src/features/errors/logic/retryability.ts
@@ -35,6 +35,13 @@ const PERMANENT_ERROR_CODES = new Set<AppErrorCode>([
   // "Close this and open it again." A replay sends the same stale quote and
   // gets the same refusal — the fix is a new quote, not another attempt.
   "billing_quote_expired",
+  // "Page through the rows, or split the dataset into smaller ones." The
+  // dataset does not shrink between attempts, so the row count that produced
+  // the refusal is the same one every replay reads. Retrying also does active
+  // harm here: it holds the query in `pending`, and a caller serving
+  // placeholder data shows the pre-search rows as the search result for the
+  // whole backoff.
+  "dataset_too_large_to_search",
 ]);
 
 /**

--- a/platform/app/src/server/api/routers/datasetRecord.ts
+++ b/platform/app/src/server/api/routers/datasetRecord.ts
@@ -187,6 +187,10 @@ export const datasetRecordRouter = createTRPCRouter({
         datasetId: z.string(),
         page: z.number().int().positive().default(1),
         limit: z.number().int().positive().max(200).default(50),
+        // When set, the page is a page of the rows whose cell values contain
+        // this text, and `count` is the number of matches — so the editor's
+        // pager pages the matches rather than the whole dataset.
+        search: z.string().optional(),
       }),
     )
     .permission("datasets:view")
@@ -197,6 +201,7 @@ export const datasetRecordRouter = createTRPCRouter({
           projectId: input.projectId,
           page: input.page,
           limit: input.limit,
+          search: input.search,
         });
       } catch (error) {
         // Parity with getAll/getFullDataset: an archived/missing dataset reads

--- a/platform/app/src/server/datasets/__tests__/dataset-chunking.unit.test.ts
+++ b/platform/app/src/server/datasets/__tests__/dataset-chunking.unit.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { chunkedMeta, chunkKey, toJsonlChunks } from "../dataset-chunking";
+import {
+  chunkedMeta,
+  chunkKey,
+  readValidChunkOffsets,
+  toJsonlChunks,
+} from "../dataset-chunking";
 
 describe("toJsonlChunks", () => {
   describe("given records that fit under the cap", () => {
@@ -88,6 +93,53 @@ describe("chunkKey", () => {
       expect(chunkKey("proj1", "ds1", 42)).toBe(
         "datasets/proj1/ds1/chunk-00042.jsonl",
       );
+    });
+  });
+});
+
+describe("readValidChunkOffsets", () => {
+  const contiguous = [
+    { index: 0, startRow: 0, endRow: 2, byteSize: 10 },
+    { index: 1, startRow: 2, endRow: 4, byteSize: 10 },
+  ];
+
+  describe("given a well-formed index", () => {
+    it("returns it unchanged", () => {
+      expect(readValidChunkOffsets(contiguous)).toEqual(contiguous);
+    });
+  });
+
+  describe("given two entries naming the same chunk", () => {
+    it("rejects the whole index rather than let the readers disagree", () => {
+      // The two readers of this array key off different parts of it, so a
+      // duplicate index makes the same dataset answer two ways. Paging selects
+      // entries by row range and reads the `index` each one names, so it
+      // fetches chunk 0 twice — once as rows 0-1 and again as rows 2-3 — and
+      // never reads chunk 1 at all. A search deduplicates the indexes, so it
+      // reads chunk 0 once and finds no trace of the rows the grid is showing.
+      // Neither is right, and the disagreement is the part a user cannot
+      // explain: the row is on screen and the search says there is no match.
+      expect(
+        readValidChunkOffsets([
+          { index: 0, startRow: 0, endRow: 2, byteSize: 10 },
+          { index: 0, startRow: 2, endRow: 4, byteSize: 10 },
+        ]),
+      ).toEqual([]);
+    });
+  });
+
+  describe("given an entry naming a chunk that cannot exist", () => {
+    it("rejects the whole index rather than ask storage for it", () => {
+      // Chunk keys are built by zero-padding the index, so a negative one
+      // addresses no object. `Number.isInteger` lets it through, the read comes
+      // back empty, and the rows of that chunk go silently missing from a
+      // dataset that still reports having them.
+      expect(
+        readValidChunkOffsets([
+          { index: -1, startRow: 0, endRow: 2, byteSize: 10 },
+          { index: 1, startRow: 2, endRow: 4, byteSize: 10 },
+        ]),
+      ).toEqual([]);
     });
   });
 });

--- a/platform/app/src/server/datasets/__tests__/dataset-search.unit.test.ts
+++ b/platform/app/src/server/datasets/__tests__/dataset-search.unit.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   DATASET_SEARCH_MAX_ROWS,
   matchesDatasetSearch,
+  measureRowsBytes,
   normalizeDatasetSearch,
 } from "../dataset-search";
 
@@ -104,6 +105,45 @@ describe("matchesDatasetSearch()", () => {
     expect(matchesDatasetSearch({ entry: 42 as never, search: "4" })).toBe(
       false,
     );
+  });
+});
+
+describe("measureRowsBytes()", () => {
+  it("grows with the content of the rows, not their count", () => {
+    // The whole reason the byte limit exists next to the row limit: one wide
+    // row can cost more than many narrow ones, and a count cannot tell them
+    // apart.
+    const oneWideRow = [{ text: "x".repeat(10_000) }];
+    const manyNarrowRows = Array.from({ length: 20 }, () => ({ text: "x" }));
+
+    expect(measureRowsBytes(oneWideRow)).toBeGreaterThan(
+      measureRowsBytes(manyNarrowRows),
+    );
+  });
+
+  it("counts bytes rather than characters", () => {
+    // A running total compared against a byte ceiling has to be in bytes.
+    // `String.length` counts UTF-16 units, so a multi-byte character would be
+    // undercounted and a dataset of them could read past the limit.
+    const measured = measureRowsBytes([{ text: "é€𝄞" }]);
+
+    expect(measured).toBeGreaterThan(JSON.stringify([{ text: "é€𝄞" }]).length);
+  });
+
+  it("reports no rows as no bytes", () => {
+    // A chunk that came back empty cost nothing to hold, and must not push a
+    // scan any closer to a refusal.
+    expect(measureRowsBytes([])).toBe(2); // "[]"
+  });
+
+  it("still reports a cost for rows it cannot serialise", () => {
+    // Unreachable from the scan, which parses its rows out of JSONL. But zero
+    // would make an unmeasurable chunk free and buy passage for every chunk
+    // after it, so the floor is one byte a row rather than nothing.
+    const cyclic: Record<string, unknown> = {};
+    cyclic.self = cyclic;
+
+    expect(measureRowsBytes([cyclic, cyclic])).toBe(2);
   });
 });
 

--- a/platform/app/src/server/datasets/__tests__/dataset-search.unit.test.ts
+++ b/platform/app/src/server/datasets/__tests__/dataset-search.unit.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DATASET_SEARCH_MAX_ROWS,
+  matchesDatasetSearch,
+  normalizeDatasetSearch,
+} from "../dataset-search";
+
+describe("normalizeDatasetSearch()", () => {
+  it("treats a blank search as no search at all", () => {
+    expect(normalizeDatasetSearch(undefined)).toBeUndefined();
+    expect(normalizeDatasetSearch("")).toBeUndefined();
+    expect(normalizeDatasetSearch("   ")).toBeUndefined();
+  });
+
+  it("trims the search so stray whitespace does not change the matches", () => {
+    expect(normalizeDatasetSearch("  escalation  ")).toBe("escalation");
+  });
+});
+
+describe("matchesDatasetSearch()", () => {
+  const entry = {
+    conversation_id: "conv_0390",
+    input: "The customer asked for an Escalation to a manager",
+    expected_output: "Escalate to tier 2",
+    turns: 4,
+    resolved: false,
+    metadata: { channel: "email" },
+    unanswered: null,
+  };
+
+  it("matches a cell value", () => {
+    expect(matchesDatasetSearch(entry, "manager")).toBe(true);
+  });
+
+  /** @scenario Search matches regardless of letter case */
+  it("matches regardless of letter case", () => {
+    expect(matchesDatasetSearch(entry, "escalation")).toBe(true);
+    expect(matchesDatasetSearch(entry, "ESCALATION")).toBe(true);
+  });
+
+  /** @scenario A word that only appears in a column name matches nothing */
+  it("does not match a word that only appears in a column name", () => {
+    // Matching column names too would make "id" return every row of a dataset
+    // with a `conversation_id` column — a result the user cannot explain from
+    // what is on screen.
+    expect(matchesDatasetSearch({ escalation: "none" }, "escalation")).toBe(
+      false,
+    );
+  });
+
+  it("matches inside non-string values rather than skipping them", () => {
+    expect(matchesDatasetSearch(entry, "4")).toBe(true);
+    expect(matchesDatasetSearch(entry, "false")).toBe(true);
+    expect(matchesDatasetSearch(entry, "email")).toBe(true);
+  });
+
+  it("does not match null or missing values", () => {
+    expect(matchesDatasetSearch({ a: null, b: undefined }, "null")).toBe(false);
+  });
+
+  it("reports no match when nothing contains the text", () => {
+    expect(matchesDatasetSearch(entry, "refund")).toBe(false);
+  });
+
+  it("survives an entry that is not an object", () => {
+    // `adaptS3JsonlRecord` assigns `entry` straight from a JSONL line with no
+    // shape check (datasetRecord.utils.ts:248), so a line of `null` — or a bare
+    // scalar — reaches this predicate. Ordinary paging tolerates such a row and
+    // renders it blank; a search must not be the one path that throws on data
+    // the rest of the editor survives, because it fails the WHOLE search, not
+    // the one row.
+    expect(() =>
+      matchesDatasetSearch(null as never, "escalation"),
+    ).not.toThrow();
+    expect(matchesDatasetSearch(null as never, "escalation")).toBe(false);
+    expect(matchesDatasetSearch(undefined as never, "escalation")).toBe(false);
+    expect(matchesDatasetSearch("escalation" as never, "escalation")).toBe(
+      false,
+    );
+    expect(matchesDatasetSearch(42 as never, "4")).toBe(false);
+  });
+});
+
+describe("DATASET_SEARCH_MAX_ROWS", () => {
+  it("caps how many rows one search will read", () => {
+    // Rows rather than bytes: legacy postgres-backed datasets carry a null
+    // `sizeBytes`, so a byte cap would never fire for them, and the real cost
+    // of an s3_jsonl search is chunk reads, not heap.
+    expect(DATASET_SEARCH_MAX_ROWS).toBe(50_000);
+  });
+});

--- a/platform/app/src/server/datasets/__tests__/dataset-search.unit.test.ts
+++ b/platform/app/src/server/datasets/__tests__/dataset-search.unit.test.ts
@@ -30,13 +30,19 @@ describe("matchesDatasetSearch()", () => {
   };
 
   it("matches a cell value", () => {
-    expect(matchesDatasetSearch(entry, "manager")).toBe(true);
+    expect(matchesDatasetSearch({ entry: entry, search: "manager" })).toBe(
+      true,
+    );
   });
 
   /** @scenario Search matches regardless of letter case */
   it("matches regardless of letter case", () => {
-    expect(matchesDatasetSearch(entry, "escalation")).toBe(true);
-    expect(matchesDatasetSearch(entry, "ESCALATION")).toBe(true);
+    expect(matchesDatasetSearch({ entry: entry, search: "escalation" })).toBe(
+      true,
+    );
+    expect(matchesDatasetSearch({ entry: entry, search: "ESCALATION" })).toBe(
+      true,
+    );
   });
 
   /** @scenario A word that only appears in a column name matches nothing */
@@ -44,23 +50,33 @@ describe("matchesDatasetSearch()", () => {
     // Matching column names too would make "id" return every row of a dataset
     // with a `conversation_id` column — a result the user cannot explain from
     // what is on screen.
-    expect(matchesDatasetSearch({ escalation: "none" }, "escalation")).toBe(
-      false,
-    );
+    expect(
+      matchesDatasetSearch({
+        entry: { escalation: "none" },
+        search: "escalation",
+      }),
+    ).toBe(false);
   });
 
   it("matches inside non-string values rather than skipping them", () => {
-    expect(matchesDatasetSearch(entry, "4")).toBe(true);
-    expect(matchesDatasetSearch(entry, "false")).toBe(true);
-    expect(matchesDatasetSearch(entry, "email")).toBe(true);
+    expect(matchesDatasetSearch({ entry: entry, search: "4" })).toBe(true);
+    expect(matchesDatasetSearch({ entry: entry, search: "false" })).toBe(true);
+    expect(matchesDatasetSearch({ entry: entry, search: "email" })).toBe(true);
   });
 
   it("does not match null or missing values", () => {
-    expect(matchesDatasetSearch({ a: null, b: undefined }, "null")).toBe(false);
+    expect(
+      matchesDatasetSearch({
+        entry: { a: null, b: undefined },
+        search: "null",
+      }),
+    ).toBe(false);
   });
 
   it("reports no match when nothing contains the text", () => {
-    expect(matchesDatasetSearch(entry, "refund")).toBe(false);
+    expect(matchesDatasetSearch({ entry: entry, search: "refund" })).toBe(
+      false,
+    );
   });
 
   it("survives an entry that is not an object", () => {
@@ -71,14 +87,23 @@ describe("matchesDatasetSearch()", () => {
     // the rest of the editor survives, because it fails the WHOLE search, not
     // the one row.
     expect(() =>
-      matchesDatasetSearch(null as never, "escalation"),
+      matchesDatasetSearch({ entry: null as never, search: "escalation" }),
     ).not.toThrow();
-    expect(matchesDatasetSearch(null as never, "escalation")).toBe(false);
-    expect(matchesDatasetSearch(undefined as never, "escalation")).toBe(false);
-    expect(matchesDatasetSearch("escalation" as never, "escalation")).toBe(
+    expect(
+      matchesDatasetSearch({ entry: null as never, search: "escalation" }),
+    ).toBe(false);
+    expect(
+      matchesDatasetSearch({ entry: undefined as never, search: "escalation" }),
+    ).toBe(false);
+    expect(
+      matchesDatasetSearch({
+        entry: "escalation" as never,
+        search: "escalation",
+      }),
+    ).toBe(false);
+    expect(matchesDatasetSearch({ entry: 42 as never, search: "4" })).toBe(
       false,
     );
-    expect(matchesDatasetSearch(42 as never, "4")).toBe(false);
   });
 });
 

--- a/platform/app/src/server/datasets/__tests__/dataset-service.search.unit.test.ts
+++ b/platform/app/src/server/datasets/__tests__/dataset-service.search.unit.test.ts
@@ -100,390 +100,496 @@ const searchPage = ({
 beforeEach(() => vi.clearAllMocks());
 
 describe("dataset search (s3_jsonl)", () => {
-  it("finds matches in chunks the requested page window does not cover", async () => {
-    // The matches live in chunk 2; an unsearched page-1 read would only touch
-    // chunk 0. This is the whole point of the feature — the row the user is
-    // looking for is on a page they have not loaded.
-    mockChunks();
-    const service = makeService({});
+  describe("given a dataset whose matches lie outside the page being viewed", () => {
+    describe("when a search runs", () => {
+      it("finds matches in chunks the requested page window does not cover", async () => {
+        // The matches live in chunk 2; an unsearched page-1 read would only touch
+        // chunk 0. This is the whole point of the feature — the row the user is
+        // looking for is on a page they have not loaded.
+        mockChunks();
+        const service = makeService({});
 
-    const result = await searchPage({
-      service,
-      dataset: baseS3Dataset,
-      search: "escalation",
+        const result = await searchPage({
+          service,
+          dataset: baseS3Dataset,
+          search: "escalation",
+        });
+
+        expect(result.data.map((r) => r.entry.text)).toEqual([
+          "needs Escalation",
+          "escalation follow-up",
+        ]);
+      });
+
+      it("reports the match count as the total, so the pager pages the matches", async () => {
+        mockChunks();
+        const service = makeService({});
+
+        const result = await searchPage({
+          service,
+          dataset: baseS3Dataset,
+          search: "escalation",
+        });
+
+        expect(result.pagination.total).toBe(2);
+        expect(result.pagination.totalPages).toBe(1);
+      });
+
+      it("pages the matches rather than the underlying rows", async () => {
+        mockChunks();
+        const service = makeService({});
+
+        const second = await searchPage({
+          service,
+          dataset: baseS3Dataset,
+          search: "escalation",
+          page: 2,
+          limit: 1,
+        });
+
+        expect(second.data.map((r) => r.entry.text)).toEqual([
+          "escalation follow-up",
+        ]);
+        expect(second.pagination.total).toBe(2);
+        expect(second.pagination.totalPages).toBe(2);
+      });
+
+      it("reads one chunk at a time rather than loading the dataset at once", async () => {
+        // `readChunks` (plural) pulls every chunk into the heap. A search must not
+        // use it: heap stays at one chunk plus the matches kept for the window,
+        // whatever the dataset's size.
+        const { readChunks, readChunk } = mockChunks();
+        const service = makeService({});
+
+        await searchPage({
+          service,
+          dataset: baseS3Dataset,
+          search: "escalation",
+        });
+
+        expect(readChunks).not.toHaveBeenCalled();
+        expect(readChunk).toHaveBeenCalledTimes(3);
+      });
+
+      it("returns nothing when a word appears only in a column name", async () => {
+        mockChunks();
+        const service = makeService({});
+
+        const result = await searchPage({
+          service,
+          dataset: baseS3Dataset,
+          search: "text",
+        });
+
+        expect(result.data).toEqual([]);
+        expect(result.pagination.total).toBe(0);
+      });
     });
-
-    expect(result.data.map((r) => r.entry.text)).toEqual([
-      "needs Escalation",
-      "escalation follow-up",
-    ]);
   });
 
-  it("reports the match count as the total, so the pager pages the matches", async () => {
-    mockChunks();
-    const service = makeService({});
+  describe("given a dataset larger than one search will read", () => {
+    describe("when a search runs", () => {
+      /** @scenario A dataset over the row limit refuses the search */
+      it("refuses a dataset with more rows than one search will read", async () => {
+        mockChunks();
+        const service = makeService({});
 
-    const result = await searchPage({
-      service,
-      dataset: baseS3Dataset,
-      search: "escalation",
+        await expect(
+          searchPage({
+            service,
+            dataset: {
+              ...baseS3Dataset,
+              rowCount: DATASET_SEARCH_MAX_ROWS + 1,
+            },
+            search: "escalation",
+          }),
+        ).rejects.toBeInstanceOf(DatasetTooLargeToSearchError);
+      });
+
+      /** @scenario A dataset too large to search is refused before any of it is read */
+      it("refuses before reading any chunk, rather than part-way through", async () => {
+        const { readChunk } = mockChunks();
+        const service = makeService({});
+
+        await expect(
+          searchPage({
+            service,
+            dataset: {
+              ...baseS3Dataset,
+              rowCount: DATASET_SEARCH_MAX_ROWS + 1,
+            },
+            search: "escalation",
+          }),
+        ).rejects.toThrow();
+        expect(readChunk).not.toHaveBeenCalled();
+      });
+
+      /** @scenario A dataset within the row limit but over the byte limit refuses the search */
+      it("refuses a dataset whose rows occupy more bytes than one search will read", async () => {
+        // Well inside the row cap, and the most expensive scan the search could be
+        // asked to run: rows are as wide as the columns they were given, so a row
+        // count says nothing about how much has to be fetched and parsed to produce
+        // them.
+        //
+        // `sizeBytes` is a bigint here because it is a bigint on the row. Passing a
+        // number would typecheck against this fixture and exercise a comparison the
+        // service never performs.
+        mockChunks();
+        const service = makeService({});
+
+        await expect(
+          searchPage({
+            service,
+            dataset: {
+              ...baseS3Dataset,
+              rowCount: 6,
+              sizeBytes: BigInt(DATASET_SEARCH_MAX_BYTES) + 1n,
+            },
+            search: "escalation",
+          }),
+        ).rejects.toBeInstanceOf(DatasetTooLargeToSearchError);
+      });
+
+      it("refuses an over-sized dataset before reading any chunk", async () => {
+        const { readChunk } = mockChunks();
+        const service = makeService({});
+
+        await expect(
+          searchPage({
+            service,
+            dataset: {
+              ...baseS3Dataset,
+              rowCount: 6,
+              sizeBytes: BigInt(DATASET_SEARCH_MAX_BYTES) + 1n,
+            },
+            search: "escalation",
+          }),
+        ).rejects.toThrow();
+        expect(readChunk).not.toHaveBeenCalled();
+      });
+
+      it("searches a dataset sitting exactly on the byte limit", async () => {
+        // The limit is what a search will read, not what it refuses: an off-by-one
+        // here withdraws search from a dataset that is precisely allowed.
+        mockChunks();
+        const service = makeService({});
+
+        const result = await searchPage({
+          service,
+          dataset: {
+            ...baseS3Dataset,
+            rowCount: 6,
+            sizeBytes: BigInt(DATASET_SEARCH_MAX_BYTES),
+          },
+          search: "escalation",
+        });
+
+        expect(result.pagination.total).toBe(2);
+      });
     });
-
-    expect(result.pagination.total).toBe(2);
-    expect(result.pagination.totalPages).toBe(1);
   });
 
-  it("pages the matches rather than the underlying rows", async () => {
-    mockChunks();
-    const service = makeService({});
+  describe("given a dataset that outgrows its own recorded size mid-scan", () => {
+    describe("when the scan counts what it has really read", () => {
+      /** @scenario A scan that outgrows the limit while it runs is stopped part-way */
+      it("refuses when the chunks it reads outweigh the size the dataset recorded", async () => {
+        // `sizeBytes` is a field on the dataset row, not a measurement taken at
+        // read time. Appends land in new chunks and the field does not always move
+        // with them, so a stale one passes the up-front fence and the scan then
+        // fetches and parses however much is really there, with nothing bounding
+        // it. The row backstop immediately above still stops the scan eventually,
+        // which is why this is the smaller of the two holes — but it stops it on
+        // the wrong dimension: 50,000 rows of stored model responses is exactly the
+        // read the byte limit exists to refuse.
+        //
+        // Two of the three chunks are enough to pass the limit, so a scan that
+        // counts what it reads stops on reaching the second.
+        const halfTheLimitEach = Math.ceil(DATASET_SEARCH_MAX_BYTES / 2) + 1;
+        const { readChunk } = mockChunks();
+        const service = makeService({});
 
-    const second = await searchPage({
-      service,
-      dataset: baseS3Dataset,
-      search: "escalation",
-      page: 2,
-      limit: 1,
+        await expect(
+          searchPage({
+            service,
+            dataset: {
+              ...baseS3Dataset,
+              rowCount: 6,
+              // Stale by three orders of magnitude — the fence sees a tiny dataset.
+              sizeBytes: BigInt(1_000),
+              chunkOffsets: [
+                {
+                  index: 0,
+                  startRow: 0,
+                  endRow: 2,
+                  byteSize: halfTheLimitEach,
+                },
+                {
+                  index: 1,
+                  startRow: 2,
+                  endRow: 4,
+                  byteSize: halfTheLimitEach,
+                },
+                {
+                  index: 2,
+                  startRow: 4,
+                  endRow: 6,
+                  byteSize: halfTheLimitEach,
+                },
+              ],
+            },
+            search: "escalation",
+          }),
+        ).rejects.toBeInstanceOf(DatasetTooLargeToSearchError);
+        // One, not zero and not three: zero would mean the up-front fence fired and
+        // this test proved nothing about the scan, three would mean the whole
+        // dataset was read before anyone objected. One is the chunk that fit — the
+        // one that would have breached the limit is refused rather than fetched
+        // and then complained about.
+        expect(readChunk).toHaveBeenCalledTimes(1);
+      });
+
+      it("keeps counting bytes across a chunk whose size was never recorded", async () => {
+        // `readValidChunkOffsets` checks the row bounds and not `byteSize`, so a
+        // valid offsets array can carry an entry without one. Added to a running
+        // total that value poisons it — every later comparison against `NaN` is
+        // false — and the backstop silently stops existing for the whole dataset,
+        // with every other test in this file still green. An unrecorded size is one
+        // chunk this cannot measure, not permission to stop measuring.
+        const halfTheLimitEach = Math.ceil(DATASET_SEARCH_MAX_BYTES / 2) + 1;
+        mockChunks();
+        const service = makeService({});
+
+        await expect(
+          searchPage({
+            service,
+            dataset: {
+              ...baseS3Dataset,
+              rowCount: 6,
+              sizeBytes: null,
+              chunkOffsets: [
+                { index: 0, startRow: 0, endRow: 2 }, // byteSize never written
+                {
+                  index: 1,
+                  startRow: 2,
+                  endRow: 4,
+                  byteSize: halfTheLimitEach,
+                },
+                {
+                  index: 2,
+                  startRow: 4,
+                  endRow: 6,
+                  byteSize: halfTheLimitEach,
+                },
+              ],
+            },
+            search: "escalation",
+          }),
+        ).rejects.toBeInstanceOf(DatasetTooLargeToSearchError);
+      });
+
+      it("does not let a negative recorded size buy room for the chunks after it", async () => {
+        // A size below zero is not a small chunk, it is a broken record — and
+        // subtracted from a running total it does not merely fail to bound its own
+        // chunk, it hands back allowance for every chunk that follows. One entry
+        // reading -100 MB is enough to carry the whole scan past the limit while
+        // the total still looks well inside it. Normalised the same way a missing
+        // size is: one chunk this cannot measure, contributing nothing.
+        const halfTheLimitEach = Math.ceil(DATASET_SEARCH_MAX_BYTES / 2) + 1;
+        const { readChunk } = mockChunks();
+        const service = makeService({});
+
+        await expect(
+          searchPage({
+            service,
+            dataset: {
+              ...baseS3Dataset,
+              rowCount: 6,
+              sizeBytes: null,
+              chunkOffsets: [
+                {
+                  index: 0,
+                  startRow: 0,
+                  endRow: 2,
+                  byteSize: -halfTheLimitEach,
+                },
+                {
+                  index: 1,
+                  startRow: 2,
+                  endRow: 4,
+                  byteSize: halfTheLimitEach,
+                },
+                {
+                  index: 2,
+                  startRow: 4,
+                  endRow: 6,
+                  byteSize: halfTheLimitEach,
+                },
+              ],
+            },
+            search: "escalation",
+          }),
+        ).rejects.toBeInstanceOf(DatasetTooLargeToSearchError);
+        // Two: the unmeasurable chunk and the one that fit. Three would mean the
+        // negative had paid for the chunk that should have been refused.
+        expect(readChunk).toHaveBeenCalledTimes(2);
+      });
     });
-
-    expect(second.data.map((r) => r.entry.text)).toEqual([
-      "escalation follow-up",
-    ]);
-    expect(second.pagination.total).toBe(2);
-    expect(second.pagination.totalPages).toBe(2);
   });
 
-  it("reads one chunk at a time rather than loading the dataset at once", async () => {
-    // `readChunks` (plural) pulls every chunk into the heap. A search must not
-    // use it: heap stays at one chunk plus the matches kept for the window,
-    // whatever the dataset's size.
-    const { readChunks, readChunk } = mockChunks();
-    const service = makeService({});
+  describe("given a dataset that records no size at all", () => {
+    describe("when a search runs", () => {
+      /** @scenario A chunked dataset that records no size is bounded by the row limit alone */
+      it("still refuses on rows alone when the dataset records no size", async () => {
+        // A dataset written before its size was recorded has none. Read as zero it
+        // would be the smallest dataset in the platform and sail through the byte
+        // limit, so the row limit has to keep holding by itself.
+        mockChunks();
+        const service = makeService({});
 
-    await searchPage({ service, dataset: baseS3Dataset, search: "escalation" });
+        await expect(
+          searchPage({
+            service,
+            dataset: {
+              ...baseS3Dataset,
+              rowCount: DATASET_SEARCH_MAX_ROWS + 1,
+              sizeBytes: null,
+            },
+            search: "escalation",
+          }),
+        ).rejects.toBeInstanceOf(DatasetTooLargeToSearchError);
+      });
 
-    expect(readChunks).not.toHaveBeenCalled();
-    expect(readChunk).toHaveBeenCalledTimes(3);
-  });
+      it("searches a dataset that records no size and is within the row limit", async () => {
+        // The other half of the missing-size case: absent a size, the byte limit
+        // has nothing to judge and must not refuse on the absence itself.
+        mockChunks();
+        const service = makeService({});
 
-  it("returns nothing when a word appears only in a column name", async () => {
-    mockChunks();
-    const service = makeService({});
+        const result = await searchPage({
+          service,
+          dataset: { ...baseS3Dataset, rowCount: 6, sizeBytes: null },
+          search: "escalation",
+        });
 
-    const result = await searchPage({
-      service,
-      dataset: baseS3Dataset,
-      search: "text",
+        expect(result.pagination.total).toBe(2);
+      });
     });
-
-    expect(result.data).toEqual([]);
-    expect(result.pagination.total).toBe(0);
   });
 
-  /** @scenario A dataset over the row limit refuses the search */
-  it("refuses a dataset with more rows than one search will read", async () => {
-    mockChunks();
-    const service = makeService({});
+  describe("given a chunk offsets index of varying quality", () => {
+    describe("when the scan works out which chunks to read", () => {
+      it("finds matches in every chunk the offsets index describes", async () => {
+        // `chunkOffsets` is what ordinary paging trusts to locate rows, and here it
+        // describes three chunks while `chunkCount` says two. Enumerating chunks by
+        // the count would stop early and report "no matches" for a row that paging
+        // displays — a wrong answer wearing the clothes of a right one.
+        mockChunks();
+        const service = makeService({});
 
-    await expect(
-      searchPage({
-        service,
-        dataset: { ...baseS3Dataset, rowCount: DATASET_SEARCH_MAX_ROWS + 1 },
-        search: "escalation",
-      }),
-    ).rejects.toBeInstanceOf(DatasetTooLargeToSearchError);
-  });
+        const result = await searchPage({
+          service,
+          dataset: { ...baseS3Dataset, chunkCount: 2 },
+          search: "escalation",
+        });
 
-  /** @scenario A dataset too large to search is refused before any of it is read */
-  it("refuses before reading any chunk, rather than part-way through", async () => {
-    const { readChunk } = mockChunks();
-    const service = makeService({});
+        expect(result.pagination.total).toBe(2);
+      });
 
-    await expect(
-      searchPage({
-        service,
-        dataset: { ...baseS3Dataset, rowCount: DATASET_SEARCH_MAX_ROWS + 1 },
-        search: "escalation",
-      }),
-    ).rejects.toThrow();
-    expect(readChunk).not.toHaveBeenCalled();
-  });
+      it("scans every chunk when the offsets index is only partly written", async () => {
+        // A half-written offsets array (an interrupted migration) has entries that
+        // pass a per-entry check and entries that do not. Trusting the survivors
+        // silently drops the chunks the broken entries described — here chunk 2,
+        // where every match lives, so the search would answer "no matches" for rows
+        // ordinary paging still displays. Ordinary paging already rejects the whole
+        // array on one bad entry and falls back to `chunkCount`; the search has to
+        // agree with it, or the same dataset answers two ways.
+        const { readChunk } = mockChunks();
+        const service = makeService({});
 
-  /** @scenario A dataset within the row limit but over the byte limit refuses the search */
-  it("refuses a dataset whose rows occupy more bytes than one search will read", async () => {
-    // Well inside the row cap, and the most expensive scan the search could be
-    // asked to run: rows are as wide as the columns they were given, so a row
-    // count says nothing about how much has to be fetched and parsed to produce
-    // them.
-    //
-    // `sizeBytes` is a bigint here because it is a bigint on the row. Passing a
-    // number would typecheck against this fixture and exercise a comparison the
-    // service never performs.
-    mockChunks();
-    const service = makeService({});
+        const result = await searchPage({
+          service,
+          dataset: {
+            ...baseS3Dataset,
+            chunkOffsets: [
+              { index: 0, startRow: 0, endRow: 2 },
+              { index: 1 }, // startRow/endRow never written
+              null,
+            ],
+          },
+          search: "escalation",
+        });
 
-    await expect(
-      searchPage({
-        service,
-        dataset: {
-          ...baseS3Dataset,
-          rowCount: 6,
-          sizeBytes: BigInt(DATASET_SEARCH_MAX_BYTES) + 1n,
-        },
-        search: "escalation",
-      }),
-    ).rejects.toBeInstanceOf(DatasetTooLargeToSearchError);
-  });
+        expect(readChunk).toHaveBeenCalledTimes(3);
+        expect(result.pagination.total).toBe(2);
+      });
 
-  it("refuses an over-sized dataset before reading any chunk", async () => {
-    const { readChunk } = mockChunks();
-    const service = makeService({});
+      it("refuses a dataset whose offsets are malformed and whose chunkCount has gone null", async () => {
+        // The other end of the fallback above: rejecting the offsets leaves
+        // `chunkCount` to say how many chunks there are, and on a dataset where
+        // that has gone null too there is nothing left to ask. Reading it as zero
+        // would scan no chunks and answer "no matches" for a dataset that has them
+        // — a wrong answer the user cannot tell from a right one, which is why this
+        // throws instead.
+        const { readChunk } = mockChunks();
+        const service = makeService({});
 
-    await expect(
-      searchPage({
-        service,
-        dataset: {
-          ...baseS3Dataset,
-          rowCount: 6,
-          sizeBytes: BigInt(DATASET_SEARCH_MAX_BYTES) + 1n,
-        },
-        search: "escalation",
-      }),
-    ).rejects.toThrow();
-    expect(readChunk).not.toHaveBeenCalled();
-  });
-
-  it("searches a dataset sitting exactly on the byte limit", async () => {
-    // The limit is what a search will read, not what it refuses: an off-by-one
-    // here withdraws search from a dataset that is precisely allowed.
-    mockChunks();
-    const service = makeService({});
-
-    const result = await searchPage({
-      service,
-      dataset: {
-        ...baseS3Dataset,
-        rowCount: 6,
-        sizeBytes: BigInt(DATASET_SEARCH_MAX_BYTES),
-      },
-      search: "escalation",
+        await expect(
+          searchPage({
+            service,
+            dataset: {
+              ...baseS3Dataset,
+              chunkOffsets: [{ index: 0 }],
+              chunkCount: null,
+            },
+            search: "escalation",
+          }),
+        ).rejects.toBeInstanceOf(DatasetChunkCountMissingError);
+        expect(readChunk).not.toHaveBeenCalled();
+      });
     });
-
-    expect(result.pagination.total).toBe(2);
   });
 
-  /** @scenario A scan that outgrows the limit while it runs is stopped part-way */
-  it("refuses when the chunks it reads outweigh the size the dataset recorded", async () => {
-    // `sizeBytes` is a field on the dataset row, not a measurement taken at
-    // read time. Appends land in new chunks and the field does not always move
-    // with them, so a stale one passes the up-front fence and the scan then
-    // fetches and parses however much is really there, with nothing bounding
-    // it. The row backstop immediately above still stops the scan eventually,
-    // which is why this is the smaller of the two holes — but it stops it on
-    // the wrong dimension: 50,000 rows of stored model responses is exactly the
-    // read the byte limit exists to refuse.
-    //
-    // Two of the three chunks are enough to pass the limit, so a scan that
-    // counts what it reads stops on reaching the second.
-    const halfTheLimitEach = Math.ceil(DATASET_SEARCH_MAX_BYTES / 2) + 1;
-    const { readChunk } = mockChunks();
-    const service = makeService({});
+  describe("given a read with no search term in effect", () => {
+    describe("when the page is served", () => {
+      it("leaves the unsearched page read on its bounded windowed path", async () => {
+        // Regression guard: adding search must not turn an ordinary page request
+        // into a full scan. Page 1 of 2 rows overlaps chunk 0 only.
+        const { readChunk } = mockChunks();
+        const service = makeService({});
 
-    await expect(
-      searchPage({
-        service,
-        dataset: {
-          ...baseS3Dataset,
-          rowCount: 6,
-          // Stale by three orders of magnitude — the fence sees a tiny dataset.
-          sizeBytes: BigInt(1_000),
-          chunkOffsets: [
-            { index: 0, startRow: 0, endRow: 2, byteSize: halfTheLimitEach },
-            { index: 1, startRow: 2, endRow: 4, byteSize: halfTheLimitEach },
-            { index: 2, startRow: 4, endRow: 6, byteSize: halfTheLimitEach },
-          ],
-        },
-        search: "escalation",
-      }),
-    ).rejects.toBeInstanceOf(DatasetTooLargeToSearchError);
-    // One, not zero and not three: zero would mean the up-front fence fired and
-    // this test proved nothing about the scan, three would mean the whole
-    // dataset was read before anyone objected. One is the chunk that fit — the
-    // one that would have breached the limit is refused rather than fetched
-    // and then complained about.
-    expect(readChunk).toHaveBeenCalledTimes(1);
-  });
+        await (
+          service as unknown as {
+            paginateResolvedDataset: (
+              p: Record<string, unknown>,
+            ) => Promise<unknown>;
+          }
+        ).paginateResolvedDataset({
+          dataset: baseS3Dataset,
+          projectId: "p1",
+          page: 1,
+          limit: 2,
+        });
 
-  it("keeps counting bytes across a chunk whose size was never recorded", async () => {
-    // `readValidChunkOffsets` checks the row bounds and not `byteSize`, so a
-    // valid offsets array can carry an entry without one. Added to a running
-    // total that value poisons it — every later comparison against `NaN` is
-    // false — and the backstop silently stops existing for the whole dataset,
-    // with every other test in this file still green. An unrecorded size is one
-    // chunk this cannot measure, not permission to stop measuring.
-    const halfTheLimitEach = Math.ceil(DATASET_SEARCH_MAX_BYTES / 2) + 1;
-    mockChunks();
-    const service = makeService({});
+        expect(readChunk).toHaveBeenCalledTimes(1);
+      });
 
-    await expect(
-      searchPage({
-        service,
-        dataset: {
-          ...baseS3Dataset,
-          rowCount: 6,
-          sizeBytes: null,
-          chunkOffsets: [
-            { index: 0, startRow: 0, endRow: 2 }, // byteSize never written
-            { index: 1, startRow: 2, endRow: 4, byteSize: halfTheLimitEach },
-            { index: 2, startRow: 4, endRow: 6, byteSize: halfTheLimitEach },
-          ],
-        },
-        search: "escalation",
-      }),
-    ).rejects.toBeInstanceOf(DatasetTooLargeToSearchError);
-  });
+      it("treats a blank search as no search at all", async () => {
+        const { readChunk } = mockChunks();
+        const service = makeService({});
 
-  /** @scenario A chunked dataset that records no size is bounded by the row limit alone */
-  it("still refuses on rows alone when the dataset records no size", async () => {
-    // A dataset written before its size was recorded has none. Read as zero it
-    // would be the smallest dataset in the platform and sail through the byte
-    // limit, so the row limit has to keep holding by itself.
-    mockChunks();
-    const service = makeService({});
+        const result = await searchPage({
+          service,
+          dataset: baseS3Dataset,
+          search: "   ",
+          page: 1,
+          limit: 2,
+        });
 
-    await expect(
-      searchPage({
-        service,
-        dataset: {
-          ...baseS3Dataset,
-          rowCount: DATASET_SEARCH_MAX_ROWS + 1,
-          sizeBytes: null,
-        },
-        search: "escalation",
-      }),
-    ).rejects.toBeInstanceOf(DatasetTooLargeToSearchError);
-  });
-
-  it("searches a dataset that records no size and is within the row limit", async () => {
-    // The other half of the missing-size case: absent a size, the byte limit
-    // has nothing to judge and must not refuse on the absence itself.
-    mockChunks();
-    const service = makeService({});
-
-    const result = await searchPage({
-      service,
-      dataset: { ...baseS3Dataset, rowCount: 6, sizeBytes: null },
-      search: "escalation",
+        // Whole dataset, windowed read — not a scan for rows containing a space.
+        expect(result.pagination.total).toBe(6);
+        expect(readChunk).toHaveBeenCalledTimes(1);
+      });
     });
-
-    expect(result.pagination.total).toBe(2);
-  });
-
-  it("finds matches in every chunk the offsets index describes", async () => {
-    // `chunkOffsets` is what ordinary paging trusts to locate rows, and here it
-    // describes three chunks while `chunkCount` says two. Enumerating chunks by
-    // the count would stop early and report "no matches" for a row that paging
-    // displays — a wrong answer wearing the clothes of a right one.
-    mockChunks();
-    const service = makeService({});
-
-    const result = await searchPage({
-      service,
-      dataset: { ...baseS3Dataset, chunkCount: 2 },
-      search: "escalation",
-    });
-
-    expect(result.pagination.total).toBe(2);
-  });
-
-  it("scans every chunk when the offsets index is only partly written", async () => {
-    // A half-written offsets array (an interrupted migration) has entries that
-    // pass a per-entry check and entries that do not. Trusting the survivors
-    // silently drops the chunks the broken entries described — here chunk 2,
-    // where every match lives, so the search would answer "no matches" for rows
-    // ordinary paging still displays. Ordinary paging already rejects the whole
-    // array on one bad entry and falls back to `chunkCount`; the search has to
-    // agree with it, or the same dataset answers two ways.
-    const { readChunk } = mockChunks();
-    const service = makeService({});
-
-    const result = await searchPage({
-      service,
-      dataset: {
-        ...baseS3Dataset,
-        chunkOffsets: [
-          { index: 0, startRow: 0, endRow: 2 },
-          { index: 1 }, // startRow/endRow never written
-          null,
-        ],
-      },
-      search: "escalation",
-    });
-
-    expect(readChunk).toHaveBeenCalledTimes(3);
-    expect(result.pagination.total).toBe(2);
-  });
-
-  it("refuses a dataset whose offsets are malformed and whose chunkCount has gone null", async () => {
-    // The other end of the fallback above: rejecting the offsets leaves
-    // `chunkCount` to say how many chunks there are, and on a dataset where
-    // that has gone null too there is nothing left to ask. Reading it as zero
-    // would scan no chunks and answer "no matches" for a dataset that has them
-    // — a wrong answer the user cannot tell from a right one, which is why this
-    // throws instead.
-    const { readChunk } = mockChunks();
-    const service = makeService({});
-
-    await expect(
-      searchPage({
-        service,
-        dataset: {
-          ...baseS3Dataset,
-          chunkOffsets: [{ index: 0 }],
-          chunkCount: null,
-        },
-        search: "escalation",
-      }),
-    ).rejects.toBeInstanceOf(DatasetChunkCountMissingError);
-    expect(readChunk).not.toHaveBeenCalled();
-  });
-
-  it("leaves the unsearched page read on its bounded windowed path", async () => {
-    // Regression guard: adding search must not turn an ordinary page request
-    // into a full scan. Page 1 of 2 rows overlaps chunk 0 only.
-    const { readChunk } = mockChunks();
-    const service = makeService({});
-
-    await (
-      service as unknown as {
-        paginateResolvedDataset: (
-          p: Record<string, unknown>,
-        ) => Promise<unknown>;
-      }
-    ).paginateResolvedDataset({
-      dataset: baseS3Dataset,
-      projectId: "p1",
-      page: 1,
-      limit: 2,
-    });
-
-    expect(readChunk).toHaveBeenCalledTimes(1);
-  });
-
-  it("treats a blank search as no search at all", async () => {
-    const { readChunk } = mockChunks();
-    const service = makeService({});
-
-    const result = await searchPage({
-      service,
-      dataset: baseS3Dataset,
-      search: "   ",
-      page: 1,
-      limit: 2,
-    });
-
-    // Whole dataset, windowed read — not a scan for rows containing a space.
-    expect(result.pagination.total).toBe(6);
-    expect(readChunk).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -517,119 +623,133 @@ describe("dataset search (postgres-backed)", () => {
     };
   };
 
-  it("applies the same predicate as the s3_jsonl path", async () => {
-    // Identical semantics across layouts: the same search must not return
-    // different rows depending on where the dataset happens to be stored.
-    const recordRepository = makeRecordRepository([
-      { text: "billing question" },
-      { text: "needs Escalation" },
-      { text: "refund request" },
-    ]);
-    const service = makeService({ recordRepository });
+  describe("given a postgres-backed dataset", () => {
+    describe("when a search runs", () => {
+      it("applies the same predicate as the s3_jsonl path", async () => {
+        // Identical semantics across layouts: the same search must not return
+        // different rows depending on where the dataset happens to be stored.
+        const recordRepository = makeRecordRepository([
+          { text: "billing question" },
+          { text: "needs Escalation" },
+          { text: "refund request" },
+        ]);
+        const service = makeService({ recordRepository });
 
-    const result = await searchPage({
-      service,
-      dataset: pgDataset,
-      search: "escalation",
+        const result = await searchPage({
+          service,
+          dataset: pgDataset,
+          search: "escalation",
+        });
+
+        expect(result.data.map((r) => r.entry.text)).toEqual([
+          "needs Escalation",
+        ]);
+        expect(result.pagination.total).toBe(1);
+      });
     });
-
-    expect(result.data.map((r) => r.entry.text)).toEqual(["needs Escalation"]);
-    expect(result.pagination.total).toBe(1);
   });
 
-  it("refuses a dataset with more rows than one search will read", async () => {
-    // `sizeBytes` is null on postgres-backed datasets, so the export-time byte
-    // guard can never fire here — the row cap is what bounds this path.
-    const recordRepository = {
-      countAndMaxUpdatedAt: vi.fn().mockResolvedValue({
-        count: DATASET_SEARCH_MAX_ROWS + 1,
-        maxUpdatedAt: null,
-      }),
-      findDatasetRecordsPage: vi.fn(),
-    };
-    const service = makeService({ recordRepository });
+  describe("given a postgres-backed dataset larger than one search will read", () => {
+    describe("when a search runs", () => {
+      it("refuses a dataset with more rows than one search will read", async () => {
+        // `sizeBytes` is null on postgres-backed datasets, so the export-time byte
+        // guard can never fire here — the row cap is what bounds this path.
+        const recordRepository = {
+          countAndMaxUpdatedAt: vi.fn().mockResolvedValue({
+            count: DATASET_SEARCH_MAX_ROWS + 1,
+            maxUpdatedAt: null,
+          }),
+          findDatasetRecordsPage: vi.fn(),
+        };
+        const service = makeService({ recordRepository });
 
-    await expect(
-      searchPage({ service, dataset: pgDataset, search: "escalation" }),
-    ).rejects.toBeInstanceOf(DatasetTooLargeToSearchError);
-    // Refused before reading, not part-way through.
-    expect(recordRepository.findDatasetRecordsPage).not.toHaveBeenCalled();
-  });
+        await expect(
+          searchPage({ service, dataset: pgDataset, search: "escalation" }),
+        ).rejects.toBeInstanceOf(DatasetTooLargeToSearchError);
+        // Refused before reading, not part-way through.
+        expect(recordRepository.findDatasetRecordsPage).not.toHaveBeenCalled();
+      });
 
-  it("refuses when the walk reads past the cap the count said it would not", async () => {
-    // The up-front check reads a count taken before the walk starts. Records
-    // keep arriving during it, so a dataset sitting just under the cap can be
-    // carried past it by a busy writer — the case a count taken beforehand
-    // cannot see. With nothing bounding the rows actually read, the walk goes
-    // as far as the writer takes it: the unbounded scan the cap exists to
-    // prevent. The chunk branch already holds this backstop; this one did not.
-    //
-    // Twice the cap's worth of batches: enough that a walk bounded by the cap
-    // stops well inside it, and a walk bounded by nothing runs off the end.
-    const MAX_BATCHES_BEFORE_GIVING_UP =
-      (DATASET_SEARCH_MAX_ROWS / DATASET_SEARCH_SCAN_BATCH) * 2;
-    let batchesServed = 0;
-    const recordRepository = {
-      countAndMaxUpdatedAt: vi.fn().mockResolvedValue({
-        count: DATASET_SEARCH_MAX_ROWS - 1,
-        maxUpdatedAt: null,
-      }),
-      // A full batch every time the walk asks, for twice as many rows as the
-      // cap allows, and then a short one. Handing back full batches forever
-      // would be the truer fake, but a walk with no backstop never asks for the
-      // last one — it spins until the heap gives out and takes the whole runner
-      // with it, which reads as an infrastructure failure rather than as this
-      // assertion. Bounded, the same missing backstop shows up as this test
-      // failing and nothing else.
-      findDatasetRecordsPage: vi.fn(({ take }: { take: number }) => {
-        batchesServed += 1;
-        const exhausted = batchesServed > MAX_BATCHES_BEFORE_GIVING_UP;
-        return Promise.resolve(
-          Array.from({ length: exhausted ? 1 : take }, (_, i) => ({
-            // Ids continue across batches: a keyset walk resumes from the last
-            // id it saw, so repeating them would end the walk by accident and
-            // pass this test without the backstop it exists to require.
-            id: `rec_${(batchesServed - 1) * take + i}`,
-            entry: { text: "row" },
-          })),
-        );
-      }),
-    };
-    const service = makeService({ recordRepository });
+      it("refuses when the walk reads past the cap the count said it would not", async () => {
+        // The up-front check reads a count taken before the walk starts. Records
+        // keep arriving during it, so a dataset sitting just under the cap can be
+        // carried past it by a busy writer — the case a count taken beforehand
+        // cannot see. With nothing bounding the rows actually read, the walk goes
+        // as far as the writer takes it: the unbounded scan the cap exists to
+        // prevent. The chunk branch already holds this backstop; this one did not.
+        //
+        // Twice the cap's worth of batches: enough that a walk bounded by the cap
+        // stops well inside it, and a walk bounded by nothing runs off the end.
+        const MAX_BATCHES_BEFORE_GIVING_UP =
+          (DATASET_SEARCH_MAX_ROWS / DATASET_SEARCH_SCAN_BATCH) * 2;
+        let batchesServed = 0;
+        const recordRepository = {
+          countAndMaxUpdatedAt: vi.fn().mockResolvedValue({
+            count: DATASET_SEARCH_MAX_ROWS - 1,
+            maxUpdatedAt: null,
+          }),
+          // A full batch every time the walk asks, for twice as many rows as the
+          // cap allows, and then a short one. Handing back full batches forever
+          // would be the truer fake, but a walk with no backstop never asks for the
+          // last one — it spins until the heap gives out and takes the whole runner
+          // with it, which reads as an infrastructure failure rather than as this
+          // assertion. Bounded, the same missing backstop shows up as this test
+          // failing and nothing else.
+          findDatasetRecordsPage: vi.fn(({ take }: { take: number }) => {
+            batchesServed += 1;
+            const exhausted = batchesServed > MAX_BATCHES_BEFORE_GIVING_UP;
+            return Promise.resolve(
+              Array.from({ length: exhausted ? 1 : take }, (_, i) => ({
+                // Ids continue across batches: a keyset walk resumes from the last
+                // id it saw, so repeating them would end the walk by accident and
+                // pass this test without the backstop it exists to require.
+                id: `rec_${(batchesServed - 1) * take + i}`,
+                entry: { text: "row" },
+              })),
+            );
+          }),
+        };
+        const service = makeService({ recordRepository });
 
-    await expect(
-      searchPage({ service, dataset: pgDataset, search: "escalation" }),
-    ).rejects.toBeInstanceOf(DatasetTooLargeToSearchError);
-    // The point is where it stopped, not merely that it did. Reading every
-    // batch the fake will serve and refusing at the end is the unbounded scan
-    // wearing a refusal.
-    expect(
-      recordRepository.findDatasetRecordsPage.mock.calls.length,
-    ).toBeLessThan(MAX_BATCHES_BEFORE_GIVING_UP);
-  });
-
-  it("counts once for the whole scan, not once per page", async () => {
-    // `listPaginated` runs a count(*) alongside every page, so offset-paging a
-    // 50k-row scan issues ~50 redundant full counts. Keyset-paginating counts
-    // once and then walks by cursor.
-    const entries = Array.from({ length: 2_500 }, (_, i) => ({
-      text: i === 2_499 ? "needs Escalation" : `row ${i}`,
-    }));
-    const recordRepository = makeRecordRepository(entries);
-    const service = makeService({ recordRepository });
-
-    const result = await searchPage({
-      service,
-      dataset: pgDataset,
-      search: "escalation",
+        await expect(
+          searchPage({ service, dataset: pgDataset, search: "escalation" }),
+        ).rejects.toBeInstanceOf(DatasetTooLargeToSearchError);
+        // The point is where it stopped, not merely that it did. Reading every
+        // batch the fake will serve and refusing at the end is the unbounded scan
+        // wearing a refusal.
+        expect(
+          recordRepository.findDatasetRecordsPage.mock.calls.length,
+        ).toBeLessThan(MAX_BATCHES_BEFORE_GIVING_UP);
+      });
     });
+  });
 
-    expect(result.pagination.total).toBe(1);
-    expect(recordRepository.countAndMaxUpdatedAt).toHaveBeenCalledTimes(1);
-    expect(
-      recordRepository.findDatasetRecordsPage.mock.calls.every(
-        (c) => (c[0] as { skip?: number }).skip === undefined,
-      ),
-    ).toBe(true);
+  describe("given a search whose matches are paged more than once", () => {
+    describe("when the later page is served", () => {
+      it("counts once for the whole scan, not once per page", async () => {
+        // `listPaginated` runs a count(*) alongside every page, so offset-paging a
+        // 50k-row scan issues ~50 redundant full counts. Keyset-paginating counts
+        // once and then walks by cursor.
+        const entries = Array.from({ length: 2_500 }, (_, i) => ({
+          text: i === 2_499 ? "needs Escalation" : `row ${i}`,
+        }));
+        const recordRepository = makeRecordRepository(entries);
+        const service = makeService({ recordRepository });
+
+        const result = await searchPage({
+          service,
+          dataset: pgDataset,
+          search: "escalation",
+        });
+
+        expect(result.pagination.total).toBe(1);
+        expect(recordRepository.countAndMaxUpdatedAt).toHaveBeenCalledTimes(1);
+        expect(
+          recordRepository.findDatasetRecordsPage.mock.calls.every(
+            (c) => (c[0] as { skip?: number }).skip === undefined,
+          ),
+        ).toBe(true);
+      });
+    });
   });
 });

--- a/platform/app/src/server/datasets/__tests__/dataset-service.search.unit.test.ts
+++ b/platform/app/src/server/datasets/__tests__/dataset-service.search.unit.test.ts
@@ -473,6 +473,49 @@ describe("dataset search (s3_jsonl)", () => {
 
         expect(result.pagination.total).toBe(2);
       });
+
+      /** @scenario A dataset that records no size is still bounded by the bytes the scan reads */
+      it("refuses on the bytes it reads when nothing recorded a size to judge", async () => {
+        // The case every other byte test here leaves open. `sizeBytes` is null,
+        // no offset carries a `byteSize`, and the rows are few — so the up-front
+        // fence sees nothing to refuse, the row limit is nowhere near, and the
+        // recorded total stays at zero however many chunks are read. A bound
+        // built only from what the offsets claim is not a bound at all here: it
+        // is absent on exactly the legacy and half-migrated rows the fallback
+        // path below exists to serve, which is where an unbounded scan is
+        // reachable in the first place.
+        //
+        // Rows this wide are the point — 50,000 rows of stored model responses
+        // is the read the byte limit exists to refuse, and it is a small row
+        // count.
+        const wideRow = { text: `escalation ${"x".repeat(30 * 1024 * 1024)}` };
+        const { readChunk } = mockChunks({
+          0: [wideRow],
+          1: [wideRow],
+          2: [wideRow],
+          3: [wideRow],
+        });
+        const service = makeService({});
+
+        await expect(
+          searchPage({
+            service,
+            dataset: {
+              ...baseS3Dataset,
+              rowCount: 4,
+              sizeBytes: null,
+              chunkCount: 4,
+              chunkOffsets: null, // legacy row: no offsets, so no sizes either
+            },
+            search: "escalation",
+          }),
+        ).rejects.toBeInstanceOf(DatasetTooLargeToSearchError);
+        // Four chunks of 30 MB pass 100 MB on the fourth, and nothing could see
+        // that coming, so the fourth is read before it is refused. Overshooting
+        // by the one chunk that carried the total over is the cost of measuring;
+        // reading all four and returning a page would be the bug.
+        expect(readChunk).toHaveBeenCalledTimes(4);
+      });
     });
   });
 

--- a/platform/app/src/server/datasets/__tests__/dataset-service.search.unit.test.ts
+++ b/platform/app/src/server/datasets/__tests__/dataset-service.search.unit.test.ts
@@ -193,6 +193,34 @@ describe("dataset search (s3_jsonl)", () => {
     expect(result.pagination.total).toBe(2);
   });
 
+  it("scans every chunk when the offsets index is only partly written", async () => {
+    // A half-written offsets array (an interrupted migration) has entries that
+    // pass a per-entry check and entries that do not. Trusting the survivors
+    // silently drops the chunks the broken entries described — here chunk 2,
+    // where every match lives, so the search would answer "no matches" for rows
+    // ordinary paging still displays. Ordinary paging already rejects the whole
+    // array on one bad entry and falls back to `chunkCount`; the search has to
+    // agree with it, or the same dataset answers two ways.
+    const { readChunk } = mockChunks();
+    const service = makeService({});
+
+    const result = await searchPage(
+      service,
+      {
+        ...baseS3Dataset,
+        chunkOffsets: [
+          { index: 0, startRow: 0, endRow: 2 },
+          { index: 1 }, // startRow/endRow never written
+          null,
+        ],
+      },
+      "escalation",
+    );
+
+    expect(readChunk).toHaveBeenCalledTimes(3);
+    expect(result.pagination.total).toBe(2);
+  });
+
   it("leaves the unsearched page read on its bounded windowed path", async () => {
     // Regression guard: adding search must not turn an ordinary page request
     // into a full scan. Page 1 of 2 rows overlaps chunk 0 only.

--- a/platform/app/src/server/datasets/__tests__/dataset-service.search.unit.test.ts
+++ b/platform/app/src/server/datasets/__tests__/dataset-service.search.unit.test.ts
@@ -1,0 +1,315 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Same boundaries as dataset-service.s3-reads: mock the storage accessor only,
+// so the search scan (chunk routing + predicate + windowing) runs for real.
+vi.mock("../dataset-storage", () => ({ getDatasetStorage: vi.fn() }));
+vi.mock("../dataset-normalize.queue", () => ({
+  enqueueDatasetNormalize: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { DatasetService } from "../dataset.service";
+import { DATASET_SEARCH_MAX_ROWS } from "../dataset-search";
+import { getDatasetStorage } from "../dataset-storage";
+import { DatasetTooLargeToSearchError } from "../errors";
+
+const makeService = (overrides: {
+  repository?: Record<string, unknown>;
+  recordRepository?: Record<string, unknown>;
+}) =>
+  new DatasetService(
+    {} as never,
+    (overrides.repository ?? {}) as never,
+    (overrides.recordRepository ?? {}) as never,
+    {} as never,
+  );
+
+const baseS3Dataset = {
+  id: "dataset_1",
+  projectId: "p1",
+  name: "DS",
+  slug: "ds",
+  columnTypes: [{ name: "text", type: "string" }],
+  createdAt: new Date("2026-01-01T00:00:00Z"),
+  updatedAt: new Date("2026-01-02T00:00:00Z"),
+  contentLayout: "s3_jsonl",
+  status: "ready",
+  statusError: null,
+  rowCount: 6,
+  chunkCount: 3,
+  chunkOffsets: [
+    { index: 0, startRow: 0, endRow: 2 },
+    { index: 1, startRow: 2, endRow: 4 },
+    { index: 2, startRow: 4, endRow: 6 },
+  ],
+};
+
+/** Two rows per chunk; the word "escalation" lives only in the LAST chunk. */
+const chunks: Record<number, unknown[]> = {
+  0: [{ text: "billing question" }, { text: "password reset" }],
+  1: [{ text: "refund request" }, { text: "shipping delay" }],
+  2: [{ text: "needs Escalation" }, { text: "escalation follow-up" }],
+};
+
+const mockChunks = (byIndex: Record<number, unknown[]> = chunks) => {
+  const readChunks = vi.fn();
+  const readChunk = vi.fn(({ index }: { index: number }) =>
+    Promise.resolve(byIndex[index] ?? []),
+  );
+  vi.mocked(getDatasetStorage).mockResolvedValue({
+    readChunks,
+    readChunk,
+  } as never);
+  return { readChunks, readChunk };
+};
+
+const searchPage = (
+  service: DatasetService,
+  dataset: Record<string, unknown>,
+  search: string,
+  page = 1,
+  limit = 50,
+) =>
+  (
+    service as unknown as {
+      paginateResolvedDataset: (p: Record<string, unknown>) => Promise<{
+        data: { entry: Record<string, unknown> }[];
+        pagination: { total: number; totalPages: number };
+      }>;
+    }
+  ).paginateResolvedDataset({
+    dataset,
+    projectId: "p1",
+    page,
+    limit,
+    search,
+  });
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("dataset search (s3_jsonl)", () => {
+  it("finds matches in chunks the requested page window does not cover", async () => {
+    // The matches live in chunk 2; an unsearched page-1 read would only touch
+    // chunk 0. This is the whole point of the feature — the row the user is
+    // looking for is on a page they have not loaded.
+    mockChunks();
+    const service = makeService({});
+
+    const result = await searchPage(service, baseS3Dataset, "escalation");
+
+    expect(result.data.map((r) => r.entry.text)).toEqual([
+      "needs Escalation",
+      "escalation follow-up",
+    ]);
+  });
+
+  it("reports the match count as the total, so the pager pages the matches", async () => {
+    mockChunks();
+    const service = makeService({});
+
+    const result = await searchPage(service, baseS3Dataset, "escalation");
+
+    expect(result.pagination.total).toBe(2);
+    expect(result.pagination.totalPages).toBe(1);
+  });
+
+  it("pages the matches rather than the underlying rows", async () => {
+    mockChunks();
+    const service = makeService({});
+
+    const second = await searchPage(service, baseS3Dataset, "escalation", 2, 1);
+
+    expect(second.data.map((r) => r.entry.text)).toEqual([
+      "escalation follow-up",
+    ]);
+    expect(second.pagination.total).toBe(2);
+    expect(second.pagination.totalPages).toBe(2);
+  });
+
+  it("reads one chunk at a time rather than loading the dataset at once", async () => {
+    // `readChunks` (plural) pulls every chunk into the heap. A search must not
+    // use it: heap stays at one chunk plus the matches kept for the window,
+    // whatever the dataset's size.
+    const { readChunks, readChunk } = mockChunks();
+    const service = makeService({});
+
+    await searchPage(service, baseS3Dataset, "escalation");
+
+    expect(readChunks).not.toHaveBeenCalled();
+    expect(readChunk).toHaveBeenCalledTimes(3);
+  });
+
+  it("returns nothing when a word appears only in a column name", async () => {
+    mockChunks();
+    const service = makeService({});
+
+    const result = await searchPage(service, baseS3Dataset, "text");
+
+    expect(result.data).toEqual([]);
+    expect(result.pagination.total).toBe(0);
+  });
+
+  /** @scenario A dataset over the row limit refuses the search */
+  it("refuses a dataset with more rows than one search will read", async () => {
+    mockChunks();
+    const service = makeService({});
+
+    await expect(
+      searchPage(
+        service,
+        { ...baseS3Dataset, rowCount: DATASET_SEARCH_MAX_ROWS + 1 },
+        "escalation",
+      ),
+    ).rejects.toBeInstanceOf(DatasetTooLargeToSearchError);
+  });
+
+  it("refuses before reading any chunk, rather than part-way through", async () => {
+    const { readChunk } = mockChunks();
+    const service = makeService({});
+
+    await expect(
+      searchPage(
+        service,
+        { ...baseS3Dataset, rowCount: DATASET_SEARCH_MAX_ROWS + 1 },
+        "escalation",
+      ),
+    ).rejects.toThrow();
+    expect(readChunk).not.toHaveBeenCalled();
+  });
+
+  it("finds matches in every chunk the offsets index describes", async () => {
+    // `chunkOffsets` is what ordinary paging trusts to locate rows, and here it
+    // describes three chunks while `chunkCount` says two. Enumerating chunks by
+    // the count would stop early and report "no matches" for a row that paging
+    // displays — a wrong answer wearing the clothes of a right one.
+    mockChunks();
+    const service = makeService({});
+
+    const result = await searchPage(
+      service,
+      { ...baseS3Dataset, chunkCount: 2 },
+      "escalation",
+    );
+
+    expect(result.pagination.total).toBe(2);
+  });
+
+  it("leaves the unsearched page read on its bounded windowed path", async () => {
+    // Regression guard: adding search must not turn an ordinary page request
+    // into a full scan. Page 1 of 2 rows overlaps chunk 0 only.
+    const { readChunk } = mockChunks();
+    const service = makeService({});
+
+    await (
+      service as unknown as {
+        paginateResolvedDataset: (
+          p: Record<string, unknown>,
+        ) => Promise<unknown>;
+      }
+    ).paginateResolvedDataset({
+      dataset: baseS3Dataset,
+      projectId: "p1",
+      page: 1,
+      limit: 2,
+    });
+
+    expect(readChunk).toHaveBeenCalledTimes(1);
+  });
+
+  it("treats a blank search as no search at all", async () => {
+    const { readChunk } = mockChunks();
+    const service = makeService({});
+
+    const result = await searchPage(service, baseS3Dataset, "   ", 1, 2);
+
+    // Whole dataset, windowed read — not a scan for rows containing a space.
+    expect(result.pagination.total).toBe(6);
+    expect(readChunk).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("dataset search (postgres-backed)", () => {
+  const pgDataset = {
+    ...baseS3Dataset,
+    contentLayout: "postgres",
+    rowCount: null,
+    chunkCount: null,
+    chunkOffsets: null,
+  };
+
+  /**
+   * Keyset-paginated, like the backfill's streaming scan: the cursor is the
+   * previous page's last id, so the scan does not re-count or re-skip per page.
+   */
+  const makeRecordRepository = (entries: Record<string, unknown>[]) => {
+    const rows = entries.map((entry, i) => ({ id: `rec_${i}`, entry }));
+    return {
+      countAndMaxUpdatedAt: vi
+        .fn()
+        .mockResolvedValue({ count: rows.length, maxUpdatedAt: null }),
+      findDatasetRecordsPage: vi.fn(
+        ({ take, cursorId }: { take: number; cursorId?: string }) => {
+          const start = cursorId
+            ? rows.findIndex((r) => r.id === cursorId) + 1
+            : 0;
+          return Promise.resolve(rows.slice(start, start + take));
+        },
+      ),
+    };
+  };
+
+  it("applies the same predicate as the s3_jsonl path", async () => {
+    // Identical semantics across layouts: the same search must not return
+    // different rows depending on where the dataset happens to be stored.
+    const recordRepository = makeRecordRepository([
+      { text: "billing question" },
+      { text: "needs Escalation" },
+      { text: "refund request" },
+    ]);
+    const service = makeService({ recordRepository });
+
+    const result = await searchPage(service, pgDataset, "escalation");
+
+    expect(result.data.map((r) => r.entry.text)).toEqual(["needs Escalation"]);
+    expect(result.pagination.total).toBe(1);
+  });
+
+  it("refuses a dataset with more rows than one search will read", async () => {
+    // `sizeBytes` is null on postgres-backed datasets, so the export-time byte
+    // guard can never fire here — the row cap is what bounds this path.
+    const recordRepository = {
+      countAndMaxUpdatedAt: vi.fn().mockResolvedValue({
+        count: DATASET_SEARCH_MAX_ROWS + 1,
+        maxUpdatedAt: null,
+      }),
+      findDatasetRecordsPage: vi.fn(),
+    };
+    const service = makeService({ recordRepository });
+
+    await expect(
+      searchPage(service, pgDataset, "escalation"),
+    ).rejects.toBeInstanceOf(DatasetTooLargeToSearchError);
+    // Refused before reading, not part-way through.
+    expect(recordRepository.findDatasetRecordsPage).not.toHaveBeenCalled();
+  });
+
+  it("counts once for the whole scan, not once per page", async () => {
+    // `listPaginated` runs a count(*) alongside every page, so offset-paging a
+    // 50k-row scan issues ~50 redundant full counts. Keyset-paginating counts
+    // once and then walks by cursor.
+    const entries = Array.from({ length: 2_500 }, (_, i) => ({
+      text: i === 2_499 ? "needs Escalation" : `row ${i}`,
+    }));
+    const recordRepository = makeRecordRepository(entries);
+    const service = makeService({ recordRepository });
+
+    const result = await searchPage(service, pgDataset, "escalation");
+
+    expect(result.pagination.total).toBe(1);
+    expect(recordRepository.countAndMaxUpdatedAt).toHaveBeenCalledTimes(1);
+    expect(
+      recordRepository.findDatasetRecordsPage.mock.calls.every(
+        (c) => (c[0] as { skip?: number }).skip === undefined,
+      ),
+    ).toBe(true);
+  });
+});

--- a/platform/app/src/server/datasets/__tests__/dataset-service.search.unit.test.ts
+++ b/platform/app/src/server/datasets/__tests__/dataset-service.search.unit.test.ts
@@ -8,7 +8,11 @@ vi.mock("../dataset-normalize.queue", () => ({
 }));
 
 import { DatasetService } from "../dataset.service";
-import { DATASET_SEARCH_MAX_ROWS } from "../dataset-search";
+import {
+  DATASET_SEARCH_MAX_BYTES,
+  DATASET_SEARCH_MAX_ROWS,
+  DATASET_SEARCH_SCAN_BATCH,
+} from "../dataset-search";
 import { getDatasetStorage } from "../dataset-storage";
 import { DatasetTooLargeToSearchError } from "../errors";
 
@@ -200,6 +204,103 @@ describe("dataset search (s3_jsonl)", () => {
     expect(readChunk).not.toHaveBeenCalled();
   });
 
+  it("refuses a dataset whose rows occupy more bytes than one search will read", async () => {
+    // Well inside the row cap, and the most expensive scan the search could be
+    // asked to run: rows are as wide as the columns they were given, so a row
+    // count says nothing about how much has to be fetched and parsed to produce
+    // them.
+    //
+    // `sizeBytes` is a bigint here because it is a bigint on the row. Passing a
+    // number would typecheck against this fixture and exercise a comparison the
+    // service never performs.
+    mockChunks();
+    const service = makeService({});
+
+    await expect(
+      searchPage({
+        service,
+        dataset: {
+          ...baseS3Dataset,
+          rowCount: 6,
+          sizeBytes: BigInt(DATASET_SEARCH_MAX_BYTES) + 1n,
+        },
+        search: "escalation",
+      }),
+    ).rejects.toBeInstanceOf(DatasetTooLargeToSearchError);
+  });
+
+  it("refuses an over-sized dataset before reading any chunk", async () => {
+    const { readChunk } = mockChunks();
+    const service = makeService({});
+
+    await expect(
+      searchPage({
+        service,
+        dataset: {
+          ...baseS3Dataset,
+          rowCount: 6,
+          sizeBytes: BigInt(DATASET_SEARCH_MAX_BYTES) + 1n,
+        },
+        search: "escalation",
+      }),
+    ).rejects.toThrow();
+    expect(readChunk).not.toHaveBeenCalled();
+  });
+
+  it("searches a dataset sitting exactly on the byte limit", async () => {
+    // The limit is what a search will read, not what it refuses: an off-by-one
+    // here withdraws search from a dataset that is precisely allowed.
+    mockChunks();
+    const service = makeService({});
+
+    const result = await searchPage({
+      service,
+      dataset: {
+        ...baseS3Dataset,
+        rowCount: 6,
+        sizeBytes: BigInt(DATASET_SEARCH_MAX_BYTES),
+      },
+      search: "escalation",
+    });
+
+    expect(result.pagination.total).toBe(2);
+  });
+
+  it("still refuses on rows alone when the dataset records no size", async () => {
+    // A dataset written before its size was recorded has none. Read as zero it
+    // would be the smallest dataset in the platform and sail through the byte
+    // limit, so the row limit has to keep holding by itself.
+    mockChunks();
+    const service = makeService({});
+
+    await expect(
+      searchPage({
+        service,
+        dataset: {
+          ...baseS3Dataset,
+          rowCount: DATASET_SEARCH_MAX_ROWS + 1,
+          sizeBytes: null,
+        },
+        search: "escalation",
+      }),
+    ).rejects.toBeInstanceOf(DatasetTooLargeToSearchError);
+  });
+
+  it("searches a dataset that records no size and is within the row limit", async () => {
+    // The other half of the missing-size case: absent a size, the byte limit
+    // has nothing to judge and must not refuse on the absence itself.
+    mockChunks();
+    const service = makeService({});
+
+    const result = await searchPage({
+      service,
+      dataset: { ...baseS3Dataset, rowCount: 6, sizeBytes: null },
+      search: "escalation",
+    });
+
+    expect(result.pagination.total).toBe(2);
+  });
+
   it("finds matches in every chunk the offsets index describes", async () => {
     // `chunkOffsets` is what ordinary paging trusts to locate rows, and here it
     // describes three chunks while `chunkCount` says two. Enumerating chunks by
@@ -352,6 +453,58 @@ describe("dataset search (postgres-backed)", () => {
     ).rejects.toBeInstanceOf(DatasetTooLargeToSearchError);
     // Refused before reading, not part-way through.
     expect(recordRepository.findDatasetRecordsPage).not.toHaveBeenCalled();
+  });
+
+  it("refuses when the walk reads past the cap the count said it would not", async () => {
+    // The up-front check reads a count taken before the walk starts. Records
+    // keep arriving during it, so a dataset sitting just under the cap can be
+    // carried past it by a busy writer — the case a count taken beforehand
+    // cannot see. With nothing bounding the rows actually read, the walk goes
+    // as far as the writer takes it: the unbounded scan the cap exists to
+    // prevent. The chunk branch already holds this backstop; this one did not.
+    //
+    // Twice the cap's worth of batches: enough that a walk bounded by the cap
+    // stops well inside it, and a walk bounded by nothing runs off the end.
+    const MAX_BATCHES_BEFORE_GIVING_UP =
+      (DATASET_SEARCH_MAX_ROWS / DATASET_SEARCH_SCAN_BATCH) * 2;
+    let batchesServed = 0;
+    const recordRepository = {
+      countAndMaxUpdatedAt: vi.fn().mockResolvedValue({
+        count: DATASET_SEARCH_MAX_ROWS - 1,
+        maxUpdatedAt: null,
+      }),
+      // A full batch every time the walk asks, for twice as many rows as the
+      // cap allows, and then a short one. Handing back full batches forever
+      // would be the truer fake, but a walk with no backstop never asks for the
+      // last one — it spins until the heap gives out and takes the whole runner
+      // with it, which reads as an infrastructure failure rather than as this
+      // assertion. Bounded, the same missing backstop shows up as this test
+      // failing and nothing else.
+      findDatasetRecordsPage: vi.fn(({ take }: { take: number }) => {
+        batchesServed += 1;
+        const exhausted = batchesServed > MAX_BATCHES_BEFORE_GIVING_UP;
+        return Promise.resolve(
+          Array.from({ length: exhausted ? 1 : take }, (_, i) => ({
+            // Ids continue across batches: a keyset walk resumes from the last
+            // id it saw, so repeating them would end the walk by accident and
+            // pass this test without the backstop it exists to require.
+            id: `rec_${(batchesServed - 1) * take + i}`,
+            entry: { text: "row" },
+          })),
+        );
+      }),
+    };
+    const service = makeService({ recordRepository });
+
+    await expect(
+      searchPage({ service, dataset: pgDataset, search: "escalation" }),
+    ).rejects.toBeInstanceOf(DatasetTooLargeToSearchError);
+    // The point is where it stopped, not merely that it did. Reading every
+    // batch the fake will serve and refusing at the end is the unbounded scan
+    // wearing a refusal.
+    expect(
+      recordRepository.findDatasetRecordsPage.mock.calls.length,
+    ).toBeLessThan(MAX_BATCHES_BEFORE_GIVING_UP);
   });
 
   it("counts once for the whole scan, not once per page", async () => {

--- a/platform/app/src/server/datasets/__tests__/dataset-service.search.unit.test.ts
+++ b/platform/app/src/server/datasets/__tests__/dataset-service.search.unit.test.ts
@@ -62,13 +62,19 @@ const mockChunks = (byIndex: Record<number, unknown[]> = chunks) => {
   return { readChunks, readChunk };
 };
 
-const searchPage = (
-  service: DatasetService,
-  dataset: Record<string, unknown>,
-  search: string,
+const searchPage = ({
+  service,
+  dataset,
+  search,
   page = 1,
   limit = 50,
-) =>
+}: {
+  service: DatasetService;
+  dataset: Record<string, unknown>;
+  search: string;
+  page?: number;
+  limit?: number;
+}) =>
   (
     service as unknown as {
       paginateResolvedDataset: (p: Record<string, unknown>) => Promise<{
@@ -94,7 +100,11 @@ describe("dataset search (s3_jsonl)", () => {
     mockChunks();
     const service = makeService({});
 
-    const result = await searchPage(service, baseS3Dataset, "escalation");
+    const result = await searchPage({
+      service,
+      dataset: baseS3Dataset,
+      search: "escalation",
+    });
 
     expect(result.data.map((r) => r.entry.text)).toEqual([
       "needs Escalation",
@@ -106,7 +116,11 @@ describe("dataset search (s3_jsonl)", () => {
     mockChunks();
     const service = makeService({});
 
-    const result = await searchPage(service, baseS3Dataset, "escalation");
+    const result = await searchPage({
+      service,
+      dataset: baseS3Dataset,
+      search: "escalation",
+    });
 
     expect(result.pagination.total).toBe(2);
     expect(result.pagination.totalPages).toBe(1);
@@ -116,7 +130,13 @@ describe("dataset search (s3_jsonl)", () => {
     mockChunks();
     const service = makeService({});
 
-    const second = await searchPage(service, baseS3Dataset, "escalation", 2, 1);
+    const second = await searchPage({
+      service,
+      dataset: baseS3Dataset,
+      search: "escalation",
+      page: 2,
+      limit: 1,
+    });
 
     expect(second.data.map((r) => r.entry.text)).toEqual([
       "escalation follow-up",
@@ -132,7 +152,7 @@ describe("dataset search (s3_jsonl)", () => {
     const { readChunks, readChunk } = mockChunks();
     const service = makeService({});
 
-    await searchPage(service, baseS3Dataset, "escalation");
+    await searchPage({ service, dataset: baseS3Dataset, search: "escalation" });
 
     expect(readChunks).not.toHaveBeenCalled();
     expect(readChunk).toHaveBeenCalledTimes(3);
@@ -142,7 +162,11 @@ describe("dataset search (s3_jsonl)", () => {
     mockChunks();
     const service = makeService({});
 
-    const result = await searchPage(service, baseS3Dataset, "text");
+    const result = await searchPage({
+      service,
+      dataset: baseS3Dataset,
+      search: "text",
+    });
 
     expect(result.data).toEqual([]);
     expect(result.pagination.total).toBe(0);
@@ -154,11 +178,11 @@ describe("dataset search (s3_jsonl)", () => {
     const service = makeService({});
 
     await expect(
-      searchPage(
+      searchPage({
         service,
-        { ...baseS3Dataset, rowCount: DATASET_SEARCH_MAX_ROWS + 1 },
-        "escalation",
-      ),
+        dataset: { ...baseS3Dataset, rowCount: DATASET_SEARCH_MAX_ROWS + 1 },
+        search: "escalation",
+      }),
     ).rejects.toBeInstanceOf(DatasetTooLargeToSearchError);
   });
 
@@ -167,11 +191,11 @@ describe("dataset search (s3_jsonl)", () => {
     const service = makeService({});
 
     await expect(
-      searchPage(
+      searchPage({
         service,
-        { ...baseS3Dataset, rowCount: DATASET_SEARCH_MAX_ROWS + 1 },
-        "escalation",
-      ),
+        dataset: { ...baseS3Dataset, rowCount: DATASET_SEARCH_MAX_ROWS + 1 },
+        search: "escalation",
+      }),
     ).rejects.toThrow();
     expect(readChunk).not.toHaveBeenCalled();
   });
@@ -184,11 +208,11 @@ describe("dataset search (s3_jsonl)", () => {
     mockChunks();
     const service = makeService({});
 
-    const result = await searchPage(
+    const result = await searchPage({
       service,
-      { ...baseS3Dataset, chunkCount: 2 },
-      "escalation",
-    );
+      dataset: { ...baseS3Dataset, chunkCount: 2 },
+      search: "escalation",
+    });
 
     expect(result.pagination.total).toBe(2);
   });
@@ -204,9 +228,9 @@ describe("dataset search (s3_jsonl)", () => {
     const { readChunk } = mockChunks();
     const service = makeService({});
 
-    const result = await searchPage(
+    const result = await searchPage({
       service,
-      {
+      dataset: {
         ...baseS3Dataset,
         chunkOffsets: [
           { index: 0, startRow: 0, endRow: 2 },
@@ -214,8 +238,8 @@ describe("dataset search (s3_jsonl)", () => {
           null,
         ],
       },
-      "escalation",
-    );
+      search: "escalation",
+    });
 
     expect(readChunk).toHaveBeenCalledTimes(3);
     expect(result.pagination.total).toBe(2);
@@ -247,7 +271,13 @@ describe("dataset search (s3_jsonl)", () => {
     const { readChunk } = mockChunks();
     const service = makeService({});
 
-    const result = await searchPage(service, baseS3Dataset, "   ", 1, 2);
+    const result = await searchPage({
+      service,
+      dataset: baseS3Dataset,
+      search: "   ",
+      page: 1,
+      limit: 2,
+    });
 
     // Whole dataset, windowed read — not a scan for rows containing a space.
     expect(result.pagination.total).toBe(6);
@@ -295,7 +325,11 @@ describe("dataset search (postgres-backed)", () => {
     ]);
     const service = makeService({ recordRepository });
 
-    const result = await searchPage(service, pgDataset, "escalation");
+    const result = await searchPage({
+      service,
+      dataset: pgDataset,
+      search: "escalation",
+    });
 
     expect(result.data.map((r) => r.entry.text)).toEqual(["needs Escalation"]);
     expect(result.pagination.total).toBe(1);
@@ -314,7 +348,7 @@ describe("dataset search (postgres-backed)", () => {
     const service = makeService({ recordRepository });
 
     await expect(
-      searchPage(service, pgDataset, "escalation"),
+      searchPage({ service, dataset: pgDataset, search: "escalation" }),
     ).rejects.toBeInstanceOf(DatasetTooLargeToSearchError);
     // Refused before reading, not part-way through.
     expect(recordRepository.findDatasetRecordsPage).not.toHaveBeenCalled();
@@ -330,7 +364,11 @@ describe("dataset search (postgres-backed)", () => {
     const recordRepository = makeRecordRepository(entries);
     const service = makeService({ recordRepository });
 
-    const result = await searchPage(service, pgDataset, "escalation");
+    const result = await searchPage({
+      service,
+      dataset: pgDataset,
+      search: "escalation",
+    });
 
     expect(result.pagination.total).toBe(1);
     expect(recordRepository.countAndMaxUpdatedAt).toHaveBeenCalledTimes(1);

--- a/platform/app/src/server/datasets/__tests__/dataset-service.search.unit.test.ts
+++ b/platform/app/src/server/datasets/__tests__/dataset-service.search.unit.test.ts
@@ -190,6 +190,7 @@ describe("dataset search (s3_jsonl)", () => {
     ).rejects.toBeInstanceOf(DatasetTooLargeToSearchError);
   });
 
+  /** @scenario A dataset too large to search is refused before any of it is read */
   it("refuses before reading any chunk, rather than part-way through", async () => {
     const { readChunk } = mockChunks();
     const service = makeService({});
@@ -204,6 +205,7 @@ describe("dataset search (s3_jsonl)", () => {
     expect(readChunk).not.toHaveBeenCalled();
   });
 
+  /** @scenario A dataset within the row limit but over the byte limit refuses the search */
   it("refuses a dataset whose rows occupy more bytes than one search will read", async () => {
     // Well inside the row cap, and the most expensive scan the search could be
     // asked to run: rows are as wide as the columns they were given, so a row
@@ -266,6 +268,78 @@ describe("dataset search (s3_jsonl)", () => {
     expect(result.pagination.total).toBe(2);
   });
 
+  /** @scenario A scan that outgrows the limit while it runs is stopped part-way */
+  it("refuses when the chunks it reads outweigh the size the dataset recorded", async () => {
+    // `sizeBytes` is a field on the dataset row, not a measurement taken at
+    // read time. Appends land in new chunks and the field does not always move
+    // with them, so a stale one passes the up-front fence and the scan then
+    // fetches and parses however much is really there, with nothing bounding
+    // it. The row backstop immediately above still stops the scan eventually,
+    // which is why this is the smaller of the two holes — but it stops it on
+    // the wrong dimension: 50,000 rows of stored model responses is exactly the
+    // read the byte limit exists to refuse.
+    //
+    // Two of the three chunks are enough to pass the limit, so a scan that
+    // counts what it reads stops on reaching the second.
+    const halfTheLimitEach = Math.ceil(DATASET_SEARCH_MAX_BYTES / 2) + 1;
+    const { readChunk } = mockChunks();
+    const service = makeService({});
+
+    await expect(
+      searchPage({
+        service,
+        dataset: {
+          ...baseS3Dataset,
+          rowCount: 6,
+          // Stale by three orders of magnitude — the fence sees a tiny dataset.
+          sizeBytes: BigInt(1_000),
+          chunkOffsets: [
+            { index: 0, startRow: 0, endRow: 2, byteSize: halfTheLimitEach },
+            { index: 1, startRow: 2, endRow: 4, byteSize: halfTheLimitEach },
+            { index: 2, startRow: 4, endRow: 6, byteSize: halfTheLimitEach },
+          ],
+        },
+        search: "escalation",
+      }),
+    ).rejects.toBeInstanceOf(DatasetTooLargeToSearchError);
+    // One, not zero and not three: zero would mean the up-front fence fired and
+    // this test proved nothing about the scan, three would mean the whole
+    // dataset was read before anyone objected. One is the chunk that fit — the
+    // one that would have breached the limit is refused rather than fetched
+    // and then complained about.
+    expect(readChunk).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps counting bytes across a chunk whose size was never recorded", async () => {
+    // `readValidChunkOffsets` checks the row bounds and not `byteSize`, so a
+    // valid offsets array can carry an entry without one. Added to a running
+    // total that value poisons it — every later comparison against `NaN` is
+    // false — and the backstop silently stops existing for the whole dataset,
+    // with every other test in this file still green. An unrecorded size is one
+    // chunk this cannot measure, not permission to stop measuring.
+    const halfTheLimitEach = Math.ceil(DATASET_SEARCH_MAX_BYTES / 2) + 1;
+    mockChunks();
+    const service = makeService({});
+
+    await expect(
+      searchPage({
+        service,
+        dataset: {
+          ...baseS3Dataset,
+          rowCount: 6,
+          sizeBytes: null,
+          chunkOffsets: [
+            { index: 0, startRow: 0, endRow: 2 }, // byteSize never written
+            { index: 1, startRow: 2, endRow: 4, byteSize: halfTheLimitEach },
+            { index: 2, startRow: 4, endRow: 6, byteSize: halfTheLimitEach },
+          ],
+        },
+        search: "escalation",
+      }),
+    ).rejects.toBeInstanceOf(DatasetTooLargeToSearchError);
+  });
+
+  /** @scenario A chunked dataset that records no size is bounded by the row limit alone */
   it("still refuses on rows alone when the dataset records no size", async () => {
     // A dataset written before its size was recorded has none. Read as zero it
     // would be the smallest dataset in the platform and sail through the byte

--- a/platform/app/src/server/datasets/__tests__/dataset-service.search.unit.test.ts
+++ b/platform/app/src/server/datasets/__tests__/dataset-service.search.unit.test.ts
@@ -14,7 +14,10 @@ import {
   DATASET_SEARCH_SCAN_BATCH,
 } from "../dataset-search";
 import { getDatasetStorage } from "../dataset-storage";
-import { DatasetTooLargeToSearchError } from "../errors";
+import {
+  DatasetChunkCountMissingError,
+  DatasetTooLargeToSearchError,
+} from "../errors";
 
 const makeService = (overrides: {
   repository?: Record<string, unknown>;
@@ -418,6 +421,30 @@ describe("dataset search (s3_jsonl)", () => {
 
     expect(readChunk).toHaveBeenCalledTimes(3);
     expect(result.pagination.total).toBe(2);
+  });
+
+  it("refuses a dataset whose offsets are malformed and whose chunkCount has gone null", async () => {
+    // The other end of the fallback above: rejecting the offsets leaves
+    // `chunkCount` to say how many chunks there are, and on a dataset where
+    // that has gone null too there is nothing left to ask. Reading it as zero
+    // would scan no chunks and answer "no matches" for a dataset that has them
+    // — a wrong answer the user cannot tell from a right one, which is why this
+    // throws instead.
+    const { readChunk } = mockChunks();
+    const service = makeService({});
+
+    await expect(
+      searchPage({
+        service,
+        dataset: {
+          ...baseS3Dataset,
+          chunkOffsets: [{ index: 0 }],
+          chunkCount: null,
+        },
+        search: "escalation",
+      }),
+    ).rejects.toBeInstanceOf(DatasetChunkCountMissingError);
+    expect(readChunk).not.toHaveBeenCalled();
   });
 
   it("leaves the unsearched page read on its bounded windowed path", async () => {

--- a/platform/app/src/server/datasets/dataset-chunking.ts
+++ b/platform/app/src/server/datasets/dataset-chunking.ts
@@ -43,6 +43,36 @@ export type ChunkOffset = {
 };
 
 /**
+ * Read a persisted `chunkOffsets` JSON value back as a typed, VALIDATED offsets
+ * array — or an empty array, meaning "do not trust this index, fall back to
+ * `chunkCount`".
+ *
+ * All-or-nothing on purpose. A half-written array (an interrupted migration
+ * that somehow committed) has entries that pass a per-entry check and entries
+ * that do not, and keeping only the survivors is worse than keeping none: a
+ * paged read would serve an empty page against a positive `rowCount`, and a
+ * search would scan only the chunks the surviving entries describe and report
+ * "no matches" for rows the pager still displays. Both callers reject the whole
+ * array on one bad entry so the same dataset cannot answer two ways.
+ */
+export const readValidChunkOffsets = (chunkOffsets: unknown): ChunkOffset[] => {
+  const raw = Array.isArray(chunkOffsets)
+    ? (chunkOffsets as unknown as ChunkOffset[])
+    : [];
+  const valid =
+    raw.length > 0 &&
+    raw.every(
+      (o) =>
+        o != null &&
+        Number.isInteger(o.index) &&
+        Number.isFinite(o.startRow) &&
+        Number.isFinite(o.endRow) &&
+        o.endRow >= o.startRow,
+    );
+  return valid ? raw : [];
+};
+
+/**
  * Lightweight per-chunk metadata — everything `chunkedMeta` needs to build the
  * PG-authoritative addressing WITHOUT the chunk's `jsonl` payload (I-MEM). The
  * streaming normalize writer maps each freshly-written `DatasetChunk` to this

--- a/platform/app/src/server/datasets/dataset-chunking.ts
+++ b/platform/app/src/server/datasets/dataset-chunking.ts
@@ -65,10 +65,22 @@ export const readValidChunkOffsets = (chunkOffsets: unknown): ChunkOffset[] => {
       (o) =>
         o != null &&
         Number.isInteger(o.index) &&
+        // Chunk keys are built by zero-padding the index, so a negative one
+        // addresses no object: the read comes back empty and that chunk's rows
+        // go missing from a dataset that still reports having them.
+        o.index >= 0 &&
         Number.isFinite(o.startRow) &&
         Number.isFinite(o.endRow) &&
         o.endRow >= o.startRow,
-    );
+    ) &&
+    // Each chunk named once. The two readers of this array key off different
+    // parts of it, so a repeated index makes the dataset answer two ways: the
+    // paged read selects entries by row range and fetches whatever `index`
+    // each one names, so it reads the duplicated chunk twice and never reads
+    // the one no entry names; a search deduplicates the indexes and reads it
+    // once. The grid then shows a row that the search reports no match for,
+    // which is the failure a user cannot make sense of.
+    new Set(raw.map((o) => o.index)).size === raw.length;
   return valid ? raw : [];
 };
 

--- a/platform/app/src/server/datasets/dataset-search.ts
+++ b/platform/app/src/server/datasets/dataset-search.ts
@@ -41,8 +41,11 @@ export const DATASET_SEARCH_MAX_ROWS = 50_000;
  * in use beats inventing one. If they are ever meant to move together, the
  * export constant is the one to move down here.
  *
- * Both limits apply, and neither subsumes the other: this one cannot hold where
- * no size was recorded, and the row limit cannot see how wide a row is.
+ * Both limits apply, and neither subsumes the other: the row limit cannot see
+ * how wide a row is, and this one cannot see how many rows a budget buys. It is
+ * held against bytes the scan measures as it reads, not against the sizes
+ * recorded on the dataset — those only decide how early a doomed scan can be
+ * refused, and they are missing on the very rows most likely to need the bound.
  */
 export const DATASET_SEARCH_MAX_BYTES = 100 * 1024 * 1024;
 
@@ -54,6 +57,36 @@ export const DATASET_SEARCH_MAX_BYTES = 100 * 1024 * 1024;
  * batch plus the matches kept for the page, not the whole dataset.
  */
 export const DATASET_SEARCH_SCAN_BATCH = 1_000;
+
+/**
+ * How many bytes a chunk's rows occupied, measured from the rows themselves
+ * rather than read off a field.
+ *
+ * The sizes in `chunkOffsets` are numbers a writer wrote down. They are absent
+ * on rows written before sizes were recorded and on offsets an interrupted
+ * migration left half-written, and nothing keeps them true afterwards. A byte
+ * bound that trusts them therefore holds everywhere except on the datasets with
+ * damaged or missing metadata — the only datasets where an unbounded scan is
+ * reachable in the first place.
+ *
+ * Serialised once per chunk rather than once per row: the cost is proportional
+ * to a fetch and parse the scan has already paid for.
+ *
+ * The number is the JSON encoding's byte length, not the JSONL file's — array
+ * punctuation stands in for the newlines. That is a byte or two per row against
+ * a hundred-megabyte ceiling.
+ */
+export const measureRowsBytes = (rows: unknown[]): number => {
+  try {
+    return Buffer.byteLength(JSON.stringify(rows) ?? "");
+  } catch {
+    // Rows parsed from JSONL cannot hold a cycle, so this is unreachable by the
+    // scan that calls it — but a chunk that cannot be measured still cost
+    // something to fetch, and reporting zero would make it free and buy passage
+    // for every chunk after it. One byte per row is a floor, not a reading.
+    return rows.length;
+  }
+};
 
 /**
  * Reduce a raw search input to the text to match on, or `undefined` when there

--- a/platform/app/src/server/datasets/dataset-search.ts
+++ b/platform/app/src/server/datasets/dataset-search.ts
@@ -1,0 +1,96 @@
+/**
+ * Row search for the dataset editor.
+ *
+ * A dataset of a few hundred rows is ~14 pages at the editor's page size, and
+ * paging is a poor way to find one row. Search narrows the dataset to the rows
+ * whose cell VALUES contain the text, and the pager then pages the matches.
+ *
+ * The predicate lives here rather than in the service because both storage
+ * layouts have to agree on it: s3_jsonl content is scanned chunk-by-chunk in
+ * the app, and postgres-backed content is filtered from the record rows. If the
+ * two disagreed, the same search would return different rows depending on where
+ * the dataset happens to be stored — a difference the user cannot see or explain.
+ */
+
+/**
+ * How many rows one search will read.
+ *
+ * Rows, not bytes: legacy postgres-backed datasets carry a null `sizeBytes`
+ * (only the s3_jsonl chunking paths write it), so a byte cap would never fire
+ * for them. And the real cost of searching an s3_jsonl dataset is the chunk
+ * reads, which scale with rows, not with the heap held at any one moment — the
+ * scan keeps one chunk in memory at a time.
+ */
+export const DATASET_SEARCH_MAX_ROWS = 50_000;
+
+/**
+ * How many postgres-backed rows are read per round of a scan.
+ *
+ * The s3_jsonl scan is naturally batched by chunk; the postgres scan has no
+ * such unit, so it reads in slices to keep the same property — heap holds one
+ * batch plus the matches kept for the page, not the whole dataset.
+ */
+export const DATASET_SEARCH_SCAN_BATCH = 1_000;
+
+/**
+ * Reduce a raw search input to the text to match on, or `undefined` when there
+ * is nothing to search for. Whitespace-only input is "no search" rather than a
+ * search for a space, which would match almost every row.
+ */
+export const normalizeDatasetSearch = (
+  search: string | undefined | null,
+): string | undefined => {
+  const trimmed = search?.trim();
+  return trimmed ? trimmed : undefined;
+};
+
+/**
+ * True when one of the entry's values contains `search`, case-insensitively.
+ *
+ * Values only, never the column names: a dataset with a `conversation_id`
+ * column would otherwise return every one of its rows for the search "id", and
+ * nothing on screen would explain why. Non-string values are stringified so a
+ * search for "4" finds a numeric cell; null and undefined never match, so
+ * searching "null" does not select every row with an empty cell.
+ *
+ * `search` is expected to have been through `normalizeDatasetSearch`.
+ */
+export const matchesDatasetSearch = (
+  entry: Record<string, unknown>,
+  search: string,
+): boolean => {
+  // `entry` is whatever was stored: `adaptS3JsonlRecord` assigns it straight
+  // from a JSONL line with no shape check, so a line of `null` or a bare scalar
+  // reaches here. Ordinary paging tolerates such a row and renders it blank —
+  // a search must not be the one path that throws on it, because throwing here
+  // fails the WHOLE search rather than skipping the one unreadable row.
+  if (entry === null || typeof entry !== "object") return false;
+
+  const needle = search.toLowerCase();
+
+  return Object.values(entry).some((value) => {
+    if (value === null || value === undefined) return false;
+
+    const haystack =
+      typeof value === "string" ? value : safeStringifyValue(value);
+
+    return haystack.toLowerCase().includes(needle);
+  });
+};
+
+/**
+ * Objects and arrays are searched by their JSON text, which is what the editor
+ * renders in the cell. A value that cannot be serialised (a cycle, a BigInt)
+ * falls back to `String(...)` rather than throwing mid-scan and failing the
+ * whole search over one bad cell.
+ */
+const safeStringifyValue = (value: unknown): string => {
+  if (typeof value === "object") {
+    try {
+      return JSON.stringify(value) ?? "";
+    } catch {
+      return String(value);
+    }
+  }
+  return String(value);
+};

--- a/platform/app/src/server/datasets/dataset-search.ts
+++ b/platform/app/src/server/datasets/dataset-search.ts
@@ -15,13 +15,36 @@
 /**
  * How many rows one search will read.
  *
- * Rows, not bytes: legacy postgres-backed datasets carry a null `sizeBytes`
- * (only the s3_jsonl chunking paths write it), so a byte cap would never fire
- * for them. And the real cost of searching an s3_jsonl dataset is the chunk
- * reads, which scale with rows, not with the heap held at any one moment — the
- * scan keeps one chunk in memory at a time.
+ * Rows because every dataset has a count of them: legacy postgres-backed
+ * datasets carry a null `sizeBytes` (only the s3_jsonl chunking paths write
+ * it), so this is the only limit that can hold on that path at all.
  */
 export const DATASET_SEARCH_MAX_ROWS = 50_000;
+
+/**
+ * How many bytes of dataset content one search will fetch and parse.
+ *
+ * A row count is not a measure of what a scan costs. A row is whatever columns
+ * it was given: an id and a status is ~100 bytes, a stored model response is
+ * tens of kilobytes, and both count as one row. Bounding rows alone therefore
+ * refuses narrow datasets while waving through datasets far more expensive to
+ * read — a 54,000-row dataset of 5 MB is refused while a 9,800-row dataset of
+ * 18 MB is allowed, though the second is more than three times the fetching and
+ * parsing.
+ *
+ * The number matches `DATASET_FULL_EXPORT_MAX_BYTES`, the ceiling the platform
+ * already applies to reading a dataset in one request. It is written out rather
+ * than imported because that constant sits in the router layer and this is the
+ * domain. Search holds one chunk at a time so it is not bounded by heap the way
+ * an export is, but it fetches and parses the same bytes, and there was no
+ * measurement arguing for a second, different number — matching the one already
+ * in use beats inventing one. If they are ever meant to move together, the
+ * export constant is the one to move down here.
+ *
+ * Both limits apply, and neither subsumes the other: this one cannot hold where
+ * no size was recorded, and the row limit cannot see how wide a row is.
+ */
+export const DATASET_SEARCH_MAX_BYTES = 100 * 1024 * 1024;
 
 /**
  * How many postgres-backed rows are read per round of a scan.

--- a/platform/app/src/server/datasets/dataset-search.ts
+++ b/platform/app/src/server/datasets/dataset-search.ts
@@ -55,10 +55,13 @@ export const normalizeDatasetSearch = (
  *
  * `search` is expected to have been through `normalizeDatasetSearch`.
  */
-export const matchesDatasetSearch = (
-  entry: Record<string, unknown>,
-  search: string,
-): boolean => {
+export const matchesDatasetSearch = ({
+  entry,
+  search,
+}: {
+  entry: Record<string, unknown>;
+  search: string;
+}): boolean => {
   // `entry` is whatever was stored: `adaptS3JsonlRecord` assigns it straight
   // from a JSONL line with no shape check, so a line of `null` or a bare scalar
   // reaches here. Ordinary paging tolerates such a row and renders it blank —

--- a/platform/app/src/server/datasets/dataset-search.ts
+++ b/platform/app/src/server/datasets/dataset-search.ts
@@ -69,8 +69,14 @@ export const DATASET_SEARCH_SCAN_BATCH = 1_000;
  * damaged or missing metadata — the only datasets where an unbounded scan is
  * reachable in the first place.
  *
- * Serialised once per chunk rather than once per row: the cost is proportional
- * to a fetch and parse the scan has already paid for.
+ * Serialised once per chunk rather than once per row. That is not free: on a
+ * 16 MB chunk it measures at roughly the parse and match it rides along with
+ * put together, and it holds a second copy of the chunk as a string while it
+ * runs. Both are worth paying — tens of milliseconds and one chunk of heap,
+ * against fetching that chunk over the network — but the cheaper measure is a
+ * real one: `readChunk` already holds the raw JSONL it parsed, so returning its
+ * byte length would be exact and cost nothing. That is a change to the storage
+ * interface and all three of its implementations, so it is not made here.
  *
  * The number is the JSON encoding's byte length, not the JSONL file's — array
  * punctuation stands in for the newlines. That is a byte or two per row against

--- a/platform/app/src/server/datasets/dataset.service.ts
+++ b/platform/app/src/server/datasets/dataset.service.ts
@@ -952,7 +952,8 @@ export class DatasetService {
   }
 
   /**
-   * Which chunk indexes a scan of the whole dataset has to read.
+   * Which chunks a scan of the whole dataset has to read, and how many bytes
+   * each of them is recorded as occupying.
    *
    * `chunkOffsets` is what ordinary paging trusts to locate rows, so the search
    * has to agree with it: enumerating by `chunkCount` alone would, on a dataset
@@ -971,34 +972,55 @@ export class DatasetService {
    *   `chunkCount` has gone null (I-COUNT drift). `?? 0` would scan zero chunks
    *   and report "no matches" for a dataset that has them.
    */
-  private chunkIndexesToScan(dataset: Dataset): number[] {
+  private chunksToScan(
+    dataset: Dataset,
+  ): { index: number; byteSize: number | null }[] {
     const offsets = readValidChunkOffsets(dataset.chunkOffsets);
     if (offsets.length > 0) {
-      return [...new Set(offsets.map((o) => o.index))].sort((a, b) => a - b);
+      // `byteSize` rides along so the scan can bound what it actually fetches,
+      // not only what the dataset row claims it will. `readValidChunkOffsets`
+      // validates the row bounds and not this, so an otherwise-valid entry can
+      // carry no size; it becomes `null` — one chunk that cannot be measured —
+      // rather than a number, because arithmetic on `undefined` yields `NaN`
+      // and one such entry would silently disable the bound for the whole
+      // dataset.
+      const byIndex = new Map<number, number | null>();
+      for (const offset of offsets) {
+        if (byIndex.has(offset.index)) continue;
+        byIndex.set(
+          offset.index,
+          Number.isFinite(offset.byteSize) ? offset.byteSize : null,
+        );
+      }
+      return [...byIndex.entries()]
+        .sort(([a], [b]) => a - b)
+        .map(([index, byteSize]) => ({ index, byteSize }));
     }
     if (dataset.chunkCount == null) {
       throw new DatasetChunkCountMissingError(dataset.id);
     }
-    return Array.from({ length: dataset.chunkCount }, (_, i) => i);
+    // No offsets means no per-chunk sizes either, so this walk is bounded by
+    // rows alone — the same gap the missing-`sizeBytes` case has, for the same
+    // reason: nothing recorded the number.
+    return Array.from({ length: dataset.chunkCount }, (_, i) => ({
+      index: i,
+      byteSize: null,
+    }));
   }
 
   /**
-   * Reads every chunk of an `s3_jsonl` dataset once, offering each row to
-   * `collect`. One chunk is held in the heap at a time.
+   * Refuses, before a byte of the dataset is fetched, a search the limits will
+   * not allow — judged on what the dataset row records about itself.
+   *
+   * Both limits are known up front, so the refusal costs nothing. Discovering
+   * it partway through means the reading the limits exist to prevent has
+   * already happened.
    *
    * @throws {DatasetNotReadyError} if the dataset is still preparing
    * @throws {DatasetTooLargeToSearchError} past the row limit, or past the byte
    *   limit where a size was recorded
    */
-  private async scanChunksForMatches({
-    dataset,
-    projectId,
-    collect,
-  }: {
-    dataset: Dataset;
-    projectId: string;
-    collect: (record: DatasetRecord) => void;
-  }) {
+  private refuseSearchOverRecordedLimits(dataset: Dataset) {
     if (dataset.status !== "ready") {
       throw new DatasetNotReadyError({
         status: dataset.status,
@@ -1032,28 +1054,82 @@ export class DatasetService {
         maxBytes: DATASET_SEARCH_MAX_BYTES,
       });
     }
+  }
+
+  /**
+   * Refuses a scan that has outgrown, in what it has actually read, the limits
+   * the dataset's own numbers said it would stay inside.
+   *
+   * Those numbers are fields on a row, written when the dataset was last
+   * measured — not readings taken now. A writer appending during the scan
+   * carries the dataset past a fence that has already been passed, so the two
+   * totals the scan is accumulating have to be held to the same limits, or the
+   * scan runs for as long as the writer keeps writing.
+   *
+   * @throws {DatasetTooLargeToSearchError} past either limit
+   */
+  private refuseScanPastLimits({
+    rowsRead,
+    bytesRead,
+  }: {
+    rowsRead: number;
+    bytesRead: number;
+  }) {
+    if (rowsRead > DATASET_SEARCH_MAX_ROWS) {
+      throw new DatasetTooLargeToSearchError({
+        rowCount: rowsRead,
+        maxRows: DATASET_SEARCH_MAX_ROWS,
+      });
+    }
+    if (bytesRead > DATASET_SEARCH_MAX_BYTES) {
+      throw new DatasetTooLargeToSearchError({
+        sizeBytes: bytesRead,
+        maxBytes: DATASET_SEARCH_MAX_BYTES,
+      });
+    }
+  }
+
+  /**
+   * Reads every chunk of an `s3_jsonl` dataset once, offering each row to
+   * `collect`. One chunk is held in the heap at a time.
+   *
+   * @throws {DatasetNotReadyError} if the dataset is still preparing
+   * @throws {DatasetTooLargeToSearchError} up front past what the dataset
+   *   records, or mid-scan past what it has really read
+   */
+  private async scanChunksForMatches({
+    dataset,
+    projectId,
+    collect,
+  }: {
+    dataset: Dataset;
+    projectId: string;
+    collect: (record: DatasetRecord) => void;
+  }) {
+    this.refuseSearchOverRecordedLimits(dataset);
 
     const storage = await getDatasetStorage(projectId);
     // `readChunk` per index, never `readChunks`: the plural form pulls every
     // chunk into the heap at once, which is exactly what the row cap and the
     // one-at-a-time read are here to prevent.
     let rowsRead = 0;
-    for (const index of this.chunkIndexesToScan(dataset)) {
+    let bytesRead = 0;
+    for (const { index, byteSize } of this.chunksToScan(dataset)) {
+      // Bytes are counted before the fetch, rows only after it. A chunk's size
+      // is recorded, so a limit on what a search will read can refuse the chunk
+      // that would breach it rather than pull it down first and object
+      // afterwards; how many rows are in it is only learned by reading it.
+      bytesRead += byteSize ?? 0;
+      this.refuseScanPastLimits({ rowsRead, bytesRead });
+
       const rows = await storage.readChunk({
         projectId,
         datasetId: dataset.id,
         index,
       });
-      // Backstop for a `rowCount` that under-reports (or is null, which reads
-      // as 0 and would sail past the up-front check): the cap has to hold on
-      // what is actually read, not only on what the row claims.
       rowsRead += rows.length;
-      if (rowsRead > DATASET_SEARCH_MAX_ROWS) {
-        throw new DatasetTooLargeToSearchError({
-          rowCount: rowsRead,
-          maxRows: DATASET_SEARCH_MAX_ROWS,
-        });
-      }
+      this.refuseScanPastLimits({ rowsRead, bytesRead });
+
       for (const line of rows) {
         collect(adaptS3JsonlRecord(line, dataset));
       }

--- a/platform/app/src/server/datasets/dataset.service.ts
+++ b/platform/app/src/server/datasets/dataset.service.ts
@@ -908,7 +908,10 @@ export class DatasetService {
     const matches: DatasetRecord[] = [];
     const collect = (record: DatasetRecord) => {
       if (
-        !matchesDatasetSearch(record.entry as Record<string, unknown>, search)
+        !matchesDatasetSearch({
+          entry: record.entry as Record<string, unknown>,
+          search,
+        })
       )
         return;
       if (matchCount >= windowStart && matchCount < windowEnd) {

--- a/platform/app/src/server/datasets/dataset.service.ts
+++ b/platform/app/src/server/datasets/dataset.service.ts
@@ -38,6 +38,7 @@ import {
   DATASET_SEARCH_MAX_ROWS,
   DATASET_SEARCH_SCAN_BATCH,
   matchesDatasetSearch,
+  measureRowsBytes,
   normalizeDatasetSearch,
 } from "./dataset-search";
 import { getDatasetStorage } from "./dataset-storage";
@@ -887,10 +888,14 @@ export class DatasetService {
    * window. Heap holds one unit of input plus at most `limit` matched rows,
    * whatever the dataset's size.
    *
-   * Both branches refuse BEFORE reading anything, so a refused search costs no
-   * reads and never returns a partial result, and both keep counting what they
-   * actually read so a dataset growing during the scan cannot carry it past the
-   * limit it was admitted under.
+   * Both branches refuse BEFORE reading anything when the dataset's own numbers
+   * already breach a limit, so that refusal costs no reads; neither ever returns
+   * a partial result. Those numbers are fields written when the dataset was last
+   * measured, though, so both branches also count what they actually read — the
+   * s3_jsonl branch measuring each chunk it fetches rather than trusting its
+   * recorded size. A dataset growing during the scan, or one whose recorded
+   * sizes are missing or wrong, is therefore still bounded, at the cost of
+   * overshooting by the one unit of input that carried the total past the limit.
    *
    * @throws {DatasetNotReadyError} if an s3_jsonl dataset is still preparing
    * @throws {DatasetTooLargeToSearchError} past the row or byte limit
@@ -977,18 +982,21 @@ export class DatasetService {
   ): { index: number; byteSize: number | null }[] {
     const offsets = readValidChunkOffsets(dataset.chunkOffsets);
     if (offsets.length > 0) {
-      // `byteSize` rides along so the scan can bound what it actually fetches,
-      // not only what the dataset row claims it will. `readValidChunkOffsets`
-      // validates the index and the row bounds but not this, so an
-      // otherwise-valid entry can carry no size, or a nonsensical one; it
-      // becomes `null` — one chunk that cannot be measured — rather than a
-      // number, because arithmetic on `undefined` yields `NaN` and one such
-      // entry would silently disable the bound for the whole dataset.
+      // `byteSize` rides along so the scan can refuse a chunk it can already
+      // tell is too expensive without fetching it first. It is what the writer
+      // recorded, not a reading, so it only ever brings the refusal forward —
+      // the bound itself comes from measuring each chunk that is read.
       //
-      // Negative sizes are normalised for a sharper reason than tidiness: a
-      // running total is not merely uninformed by one, it is actively set back
-      // by it, so a single entry reading -100 MB buys passage for every chunk
-      // after it while the total still looks well inside the limit.
+      // `readValidChunkOffsets` validates the index and the row bounds but not
+      // this, so an otherwise-valid entry can carry no size, or a nonsensical
+      // one; it becomes `null` — one chunk whose cost cannot be guessed at —
+      // rather than a number, because arithmetic on `undefined` yields `NaN`,
+      // and a `NaN` estimate compares false against every limit.
+      //
+      // Negative sizes are normalised for a sharper reason than tidiness: an
+      // estimate is not merely uninformed by one, it is set back by it, so an
+      // entry reading -100 MB would hide the next 100 MB chunk from the
+      // early refusal that exists to catch it.
       //
       // No deduplication needed: a repeated index is rejected at validation, so
       // every entry here names a chunk no other entry names.
@@ -1005,9 +1013,10 @@ export class DatasetService {
     if (dataset.chunkCount == null) {
       throw new DatasetChunkCountMissingError(dataset.id);
     }
-    // No offsets means no per-chunk sizes either, so this walk is bounded by
-    // rows alone — the same gap the missing-`sizeBytes` case has, for the same
-    // reason: nothing recorded the number.
+    // No offsets means no per-chunk sizes either, so nothing here can estimate
+    // what a chunk will cost before it is fetched. The scan measures each chunk
+    // it reads, so the byte limit still holds on this path; what is lost is only
+    // the earlier refusal, not the bound.
     return Array.from({ length: dataset.chunkCount }, (_, i) => ({
       index: i,
       byteSize: null,
@@ -1068,9 +1077,10 @@ export class DatasetService {
    *
    * Those numbers are fields on a row, written when the dataset was last
    * measured — not readings taken now. A writer appending during the scan
-   * carries the dataset past a fence that has already been passed, so the two
-   * totals the scan is accumulating have to be held to the same limits, or the
-   * scan runs for as long as the writer keeps writing.
+   * carries the dataset past a fence that has already been passed, and a size
+   * that was never written, or written wrong, describes no fence at all. Either
+   * way the totals the scan accumulates as it reads have to be held to the same
+   * limits, or the scan runs for as long as the content lasts.
    *
    * @throws {DatasetTooLargeToSearchError} past either limit
    */
@@ -1118,23 +1128,42 @@ export class DatasetService {
     // `readChunk` per index, never `readChunks`: the plural form pulls every
     // chunk into the heap at once, which is exactly what the row cap and the
     // one-at-a-time read are here to prevent.
+    // Two byte totals over the same chunks, because each covers the other's
+    // blind spot and the scan is refused on whichever is larger.
+    //
+    // What the offsets RECORD can be read before a chunk is fetched, so it can
+    // refuse a doomed chunk rather than pull it down and object afterwards —
+    // but it is absent on legacy rows and on half-written offsets, and nothing
+    // re-checks it on the rest. What the scan MEASURES is always true, and
+    // covers exactly those cases, but only after the fetch it was meant to
+    // bound. Taking the larger keeps the earlier refusal where the metadata is
+    // good, and keeps the bound where it is not.
     let rowsRead = 0;
-    let bytesRead = 0;
+    let bytesRecorded = 0;
+    let bytesMeasured = 0;
     for (const { index, byteSize } of this.chunksToScan(dataset)) {
-      // Bytes are counted before the fetch, rows only after it. A chunk's size
-      // is recorded, so a limit on what a search will read can refuse the chunk
-      // that would breach it rather than pull it down first and object
-      // afterwards; how many rows are in it is only learned by reading it.
-      bytesRead += byteSize ?? 0;
-      this.refuseScanPastLimits({ rowsRead, bytesRead });
+      this.refuseScanPastLimits({
+        rowsRead,
+        bytesRead: Math.max(bytesMeasured, bytesRecorded + (byteSize ?? 0)),
+      });
 
       const rows = await storage.readChunk({
         projectId,
         datasetId: dataset.id,
         index,
       });
+
+      // Rows, like the measurement, are only knowable after the read. A chunk
+      // can therefore still be read past the ceiling when nothing recorded its
+      // size: the scan overshoots by the one chunk that carried it over, rather
+      // than by every chunk remaining.
       rowsRead += rows.length;
-      this.refuseScanPastLimits({ rowsRead, bytesRead });
+      bytesRecorded += byteSize ?? 0;
+      bytesMeasured += measureRowsBytes(rows);
+      this.refuseScanPastLimits({
+        rowsRead,
+        bytesRead: Math.max(bytesMeasured, bytesRecorded),
+      });
 
       for (const line of rows) {
         collect(adaptS3JsonlRecord(line, dataset));

--- a/platform/app/src/server/datasets/dataset.service.ts
+++ b/platform/app/src/server/datasets/dataset.service.ts
@@ -886,7 +886,9 @@ export class DatasetService {
    * rows. Both branches therefore read incrementally — one chunk, or one batch,
    * at a time — keeping only the matches that fall inside the requested page
    * window. Heap holds one unit of input plus at most `limit` matched rows,
-   * whatever the dataset's size.
+   * whatever the dataset's size — and, while a chunk is being measured, a
+   * second copy of that one chunk, because measuring re-serialises it. Peak is
+   * therefore twice a chunk, not twice the scan; see `measureRowsBytes`.
    *
    * Both branches refuse BEFORE reading anything when the dataset's own numbers
    * already breach a limit, so that refusal costs no reads; neither ever returns

--- a/platform/app/src/server/datasets/dataset.service.ts
+++ b/platform/app/src/server/datasets/dataset.service.ts
@@ -34,6 +34,7 @@ import {
 import { enqueueDatasetNormalize } from "./dataset-normalize.queue";
 import { DatasetRecordRepository } from "./dataset-record.repository";
 import {
+  DATASET_SEARCH_MAX_BYTES,
   DATASET_SEARCH_MAX_ROWS,
   DATASET_SEARCH_SCAN_BATCH,
   matchesDatasetSearch,
@@ -760,8 +761,9 @@ export class DatasetService {
     // text, and the pager then pages the MATCHES — so `total` becomes the match
     // count, not the row count. Neither storage layout can locate matches
     // cheaply (there is no index over `entry`), so both scan; both bound that
-    // scan by DATASET_SEARCH_MAX_ROWS and refuse past it rather than return the
-    // matches found so far, which would be a wrong answer that looks right.
+    // scan — by rows, and by bytes where a size was recorded — and refuse past
+    // it rather than return the matches found so far, which would be a wrong
+    // answer that looks right.
     const search = normalizeDatasetSearch(params.search);
     if (search) {
       return await this.searchResolvedDataset({ ...params, search });
@@ -885,11 +887,13 @@ export class DatasetService {
    * window. Heap holds one unit of input plus at most `limit` matched rows,
    * whatever the dataset's size.
    *
-   * Both branches refuse past DATASET_SEARCH_MAX_ROWS BEFORE reading anything,
-   * so a refused search costs no reads and never returns a partial result.
+   * Both branches refuse BEFORE reading anything, so a refused search costs no
+   * reads and never returns a partial result, and both keep counting what they
+   * actually read so a dataset growing during the scan cannot carry it past the
+   * limit it was admitted under.
    *
    * @throws {DatasetNotReadyError} if an s3_jsonl dataset is still preparing
-   * @throws {DatasetTooLargeToSearchError} past the row cap
+   * @throws {DatasetTooLargeToSearchError} past the row or byte limit
    */
   private async searchResolvedDataset(params: {
     dataset: Dataset;
@@ -983,7 +987,8 @@ export class DatasetService {
    * `collect`. One chunk is held in the heap at a time.
    *
    * @throws {DatasetNotReadyError} if the dataset is still preparing
-   * @throws {DatasetTooLargeToSearchError} past the row cap
+   * @throws {DatasetTooLargeToSearchError} past the row limit, or past the byte
+   *   limit where a size was recorded
    */
   private async scanChunksForMatches({
     dataset,
@@ -1006,6 +1011,25 @@ export class DatasetService {
       throw new DatasetTooLargeToSearchError({
         rowCount,
         maxRows: DATASET_SEARCH_MAX_ROWS,
+      });
+    }
+
+    // Rows say nothing about what the scan costs — every chunk is fetched whole
+    // and parsed whole, and how many rows that is depends only on how wide they
+    // happen to be. Checked separately from the row cap rather than folded into
+    // it because neither covers the other: a dataset written before its size was
+    // recorded has none, and reading a missing size as zero would make it the
+    // smallest dataset in the platform and wave it straight through.
+    //
+    // `sizeBytes` is a bigint on the row. Compared as one, then narrowed to a
+    // number only to report it: a byte count large enough to lose precision as
+    // a double is nine petabytes, and the comparison that decides the refusal
+    // has already happened by then.
+    const sizeBytes = dataset.sizeBytes ?? null;
+    if (sizeBytes !== null && sizeBytes > BigInt(DATASET_SEARCH_MAX_BYTES)) {
+      throw new DatasetTooLargeToSearchError({
+        sizeBytes: Number(sizeBytes),
+        maxBytes: DATASET_SEARCH_MAX_BYTES,
       });
     }
 
@@ -1040,10 +1064,11 @@ export class DatasetService {
    * Walks every record of a Postgres-backed (legacy) dataset once, offering
    * each to `collect`. One batch is held in the heap at a time.
    *
-   * `sizeBytes` is null on these rows, so the export-time byte guard can never
-   * fire here — the row cap is the only thing bounding this scan.
+   * `sizeBytes` is null on these rows, so the byte limit can never fire here —
+   * the row limit is the only thing bounding this scan, checked both against
+   * the count taken up front and against what the walk actually reads.
    *
-   * @throws {DatasetTooLargeToSearchError} past the row cap
+   * @throws {DatasetTooLargeToSearchError} past the row limit
    */
   private async scanPostgresRecordsForMatches({
     dataset,
@@ -1073,6 +1098,7 @@ export class DatasetService {
     // same canonical [createdAt asc, id asc] order the paged read uses — so
     // matches come back in the order the user sees them when not searching.
     let cursorId: string | undefined;
+    let rowsRead = 0;
     for (;;) {
       const records = await this.recordRepository.findDatasetRecordsPage({
         datasetId: dataset.id,
@@ -1080,6 +1106,19 @@ export class DatasetService {
         take: DATASET_SEARCH_SCAN_BATCH,
         cursorId,
       });
+      // The same backstop the chunk walk holds, and for the same reason: the
+      // count above was taken before the walk started, so a dataset sitting just
+      // under the cap can be carried past it by rows written while the walk
+      // runs. Without this the loop's only exits are a short batch and a missing
+      // cursor, neither of which a dataset still being written to ever offers —
+      // so the scan runs as long as the writer does.
+      rowsRead += records.length;
+      if (rowsRead > DATASET_SEARCH_MAX_ROWS) {
+        throw new DatasetTooLargeToSearchError({
+          rowCount: rowsRead,
+          maxRows: DATASET_SEARCH_MAX_ROWS,
+        });
+      }
       for (const record of records) collect(record);
       if (records.length < DATASET_SEARCH_SCAN_BATCH) break;
       cursorId = records[records.length - 1]?.id;

--- a/platform/app/src/server/datasets/dataset.service.ts
+++ b/platform/app/src/server/datasets/dataset.service.ts
@@ -33,6 +33,12 @@ import {
 } from "./dataset-mutations";
 import { enqueueDatasetNormalize } from "./dataset-normalize.queue";
 import { DatasetRecordRepository } from "./dataset-record.repository";
+import {
+  DATASET_SEARCH_MAX_ROWS,
+  DATASET_SEARCH_SCAN_BATCH,
+  matchesDatasetSearch,
+  normalizeDatasetSearch,
+} from "./dataset-search";
 import { getDatasetStorage } from "./dataset-storage";
 import {
   ColumnTypeChangeNotSupportedError,
@@ -41,6 +47,7 @@ import {
   DatasetNotFoundError,
   DatasetNotReadyError,
   DatasetNotRetryableError,
+  DatasetTooLargeToSearchError,
   DirectUploadUnavailableError,
   InvalidColumnError,
   MalformedColumnTypesError,
@@ -744,9 +751,21 @@ export class DatasetService {
     projectId: string;
     page: number;
     limit: number;
+    search?: string;
   }) {
     const { dataset } = params;
     const skip = (params.page - 1) * params.limit;
+
+    // A search narrows the dataset to the rows whose cell values contain the
+    // text, and the pager then pages the MATCHES — so `total` becomes the match
+    // count, not the row count. Neither storage layout can locate matches
+    // cheaply (there is no index over `entry`), so both scan; both bound that
+    // scan by DATASET_SEARCH_MAX_ROWS and refuse past it rather than return the
+    // matches found so far, which would be a wrong answer that looks right.
+    const search = normalizeDatasetSearch(params.search);
+    if (search) {
+      return await this.searchResolvedDataset({ ...params, search });
+    }
 
     // ADR-032: s3_jsonl content lives in chunk objects, not the PG
     // DatasetRecord table (I-PG → zero PG rows), so the PG-only paginator would
@@ -868,6 +887,166 @@ export class DatasetService {
   }
 
   /**
+   * One page of the rows MATCHING `search`, for either storage layout.
+   *
+   * There is no index over dataset content (`entry` is opaque JSON in PG,
+   * newline-delimited JSON in object storage), so finding matches means reading
+   * rows. Both branches therefore read incrementally — one chunk, or one batch,
+   * at a time — keeping only the matches that fall inside the requested page
+   * window. Heap holds one unit of input plus at most `limit` matched rows,
+   * whatever the dataset's size.
+   *
+   * Both branches refuse past DATASET_SEARCH_MAX_ROWS BEFORE reading anything,
+   * so a refused search costs no reads and never returns a partial result.
+   *
+   * @throws {DatasetNotReadyError} if an s3_jsonl dataset is still preparing
+   * @throws {DatasetTooLargeToSearchError} past the row cap
+   */
+  private async searchResolvedDataset(params: {
+    dataset: Dataset;
+    projectId: string;
+    page: number;
+    limit: number;
+    search: string;
+  }) {
+    const { dataset, search } = params;
+    const windowStart = (params.page - 1) * params.limit;
+    const windowEnd = windowStart + params.limit; // exclusive
+
+    // Matches are counted as they are found, but only those inside the window
+    // are retained — `matchCount` is the pager's total, `matches` is the page.
+    let matchCount = 0;
+    const matches: DatasetRecord[] = [];
+    const collect = (record: DatasetRecord) => {
+      if (
+        !matchesDatasetSearch(record.entry as Record<string, unknown>, search)
+      )
+        return;
+      if (matchCount >= windowStart && matchCount < windowEnd) {
+        matches.push(record);
+      }
+      matchCount++;
+    };
+
+    if (dataset.contentLayout === "s3_jsonl") {
+      if (dataset.status !== "ready") {
+        throw new DatasetNotReadyError({
+          status: dataset.status,
+          statusError: dataset.statusError,
+        });
+      }
+
+      const rowCount = dataset.rowCount ?? 0;
+      if (rowCount > DATASET_SEARCH_MAX_ROWS) {
+        throw new DatasetTooLargeToSearchError({
+          rowCount,
+          maxRows: DATASET_SEARCH_MAX_ROWS,
+        });
+      }
+
+      // Which chunks to read. `chunkOffsets` is what ordinary paging trusts to
+      // locate rows, so the search has to agree with it: enumerating by
+      // `chunkCount` alone would, on a dataset whose count has drifted below its
+      // offsets, stop early and report "no matches" for rows the user can page
+      // to — the silent-wrong-answer this path exists to avoid. Offsets first,
+      // `chunkCount` as the fallback for legacy rows that have none.
+      const rawOffsets = Array.isArray(dataset.chunkOffsets)
+        ? (dataset.chunkOffsets as unknown as ChunkOffset[])
+        : [];
+      const offsetIndexes = rawOffsets
+        .filter((o) => o != null && Number.isInteger(o.index))
+        .map((o) => o.index);
+
+      let chunkIndexes: number[];
+      if (offsetIndexes.length > 0) {
+        chunkIndexes = [...new Set(offsetIndexes)].sort((a, b) => a - b);
+      } else {
+        // I-COUNT: a `ready` s3_jsonl dataset with no offsets MUST have a
+        // chunkCount. `?? 0` would scan zero chunks and report "no matches" for
+        // a dataset that has them.
+        if (dataset.chunkCount == null) {
+          throw new DatasetChunkCountMissingError(dataset.id);
+        }
+        chunkIndexes = Array.from({ length: dataset.chunkCount }, (_, i) => i);
+      }
+
+      const storage = await getDatasetStorage(params.projectId);
+      // `readChunk` per index, never `readChunks`: the plural form pulls every
+      // chunk into the heap at once, which is exactly what the row cap and the
+      // one-at-a-time read are here to prevent.
+      let rowsRead = 0;
+      for (const index of chunkIndexes) {
+        const rows = await storage.readChunk({
+          projectId: params.projectId,
+          datasetId: dataset.id,
+          index,
+        });
+        // Backstop for a `rowCount` that under-reports (or is null, which reads
+        // as 0 and would sail past the up-front check): the cap has to hold on
+        // what is actually read, not only on what the row claims.
+        rowsRead += rows.length;
+        if (rowsRead > DATASET_SEARCH_MAX_ROWS) {
+          throw new DatasetTooLargeToSearchError({
+            rowCount: rowsRead,
+            maxRows: DATASET_SEARCH_MAX_ROWS,
+          });
+        }
+        for (const line of rows) {
+          collect(adaptS3JsonlRecord(line, dataset));
+        }
+      }
+    } else {
+      // Postgres-backed (legacy) content. `sizeBytes` is null on these rows, so
+      // the export-time byte guard can never fire here — the row cap is the only
+      // thing bounding this scan.
+      const { count: rowCount } =
+        await this.recordRepository.countAndMaxUpdatedAt({
+          datasetId: dataset.id,
+          projectId: params.projectId,
+        });
+      if (rowCount > DATASET_SEARCH_MAX_ROWS) {
+        throw new DatasetTooLargeToSearchError({
+          rowCount,
+          maxRows: DATASET_SEARCH_MAX_ROWS,
+        });
+      }
+
+      // Keyset-paginate, like the PG→S3 backfill's streaming scan: `skip`/`take`
+      // would re-run a count(*) alongside every page (listPaginated does), so a
+      // scan at the cap would issue ~50 redundant full counts, and OFFSET
+      // degrades as it walks. The cursor is the previous page's last id, in the
+      // same canonical [createdAt asc, id asc] order the paged read uses — so
+      // matches come back in the order the user sees them when not searching.
+      let cursorId: string | undefined;
+      for (;;) {
+        const records = await this.recordRepository.findDatasetRecordsPage({
+          datasetId: dataset.id,
+          projectId: params.projectId,
+          take: DATASET_SEARCH_SCAN_BATCH,
+          cursorId,
+        });
+        if (records.length === 0) break;
+        for (const record of records) collect(record);
+        if (records.length < DATASET_SEARCH_SCAN_BATCH) break;
+        cursorId = records[records.length - 1]?.id;
+        if (!cursorId) break;
+      }
+    }
+
+    return {
+      data: matches,
+      pagination: {
+        page: params.page,
+        limit: params.limit,
+        // The pager pages the MATCHES: a search that matched 3 rows of a
+        // 10,000-row dataset is one page, not two hundred.
+        total: matchCount,
+        totalPages: Math.ceil(matchCount / params.limit),
+      },
+    };
+  }
+
+  /**
    * One page of a dataset for the editor: the dataset's name + columnTypes plus
    * the page's records ({ id, entry }) and the PG-authoritative total. Replaces
    * the editor's whole-dataset `getFullDataset` read (which truncated past a
@@ -883,6 +1062,8 @@ export class DatasetService {
     projectId: string;
     page: number;
     limit: number;
+    /** When set, pages the rows MATCHING it instead of the whole dataset. */
+    search?: string;
   }) {
     const dataset = await this.getBySlugOrId({
       slugOrId: params.slugOrId,
@@ -893,6 +1074,7 @@ export class DatasetService {
       projectId: params.projectId,
       page: params.page,
       limit: params.limit,
+      search: params.search,
     });
     return {
       id: dataset.id,

--- a/platform/app/src/server/datasets/dataset.service.ts
+++ b/platform/app/src/server/datasets/dataset.service.ts
@@ -18,7 +18,7 @@ import {
   getFullDataset,
 } from "../api/routers/datasetRecord.utils";
 import { DatasetRepository } from "./dataset.repository";
-import type { ChunkOffset } from "./dataset-chunking";
+import { type ChunkOffset, readValidChunkOffsets } from "./dataset-chunking";
 import {
   DATASET_MUTATION_TXN_MAX_WAIT_MS,
   DATASET_MUTATION_TXN_TIMEOUT_MS,
@@ -795,20 +795,9 @@ export class DatasetService {
       // offsets-absent repair branch (read every chunk + slice) rather than
       // serve a wrong page. The offsets-absent branch already throws loudly on a
       // null chunkCount, so a genuinely-broken dataset surfaces, not silences.
-      const rawOffsets = Array.isArray(dataset.chunkOffsets)
-        ? (dataset.chunkOffsets as unknown as ChunkOffset[])
-        : [];
-      const offsetsValid =
-        rawOffsets.length > 0 &&
-        rawOffsets.every(
-          (o) =>
-            o != null &&
-            Number.isInteger(o.index) &&
-            Number.isFinite(o.startRow) &&
-            Number.isFinite(o.endRow) &&
-            o.endRow >= o.startRow,
-        );
-      const offsets: ChunkOffset[] = offsetsValid ? rawOffsets : [];
+      const offsets: ChunkOffset[] = readValidChunkOffsets(
+        dataset.chunkOffsets,
+      );
 
       // Read only the chunks overlapping [windowStart, windowEnd). With offsets
       // present this touches at most ⌈limit / rows-per-chunk⌉ + 1 chunks.
@@ -950,16 +939,18 @@ export class DatasetService {
       // offsets, stop early and report "no matches" for rows the user can page
       // to — the silent-wrong-answer this path exists to avoid. Offsets first,
       // `chunkCount` as the fallback for legacy rows that have none.
-      const rawOffsets = Array.isArray(dataset.chunkOffsets)
-        ? (dataset.chunkOffsets as unknown as ChunkOffset[])
-        : [];
-      const offsetIndexes = rawOffsets
-        .filter((o) => o != null && Number.isInteger(o.index))
-        .map((o) => o.index);
+      // Same all-or-nothing validation the paged read uses. Keeping the
+      // individually-valid entries of a half-written array would scan only the
+      // chunks those entries name and report "no matches" for rows the pager,
+      // which rejects the whole array and falls back to `chunkCount`, still
+      // displays — the same dataset answering two ways.
+      const offsets = readValidChunkOffsets(dataset.chunkOffsets);
 
       let chunkIndexes: number[];
-      if (offsetIndexes.length > 0) {
-        chunkIndexes = [...new Set(offsetIndexes)].sort((a, b) => a - b);
+      if (offsets.length > 0) {
+        chunkIndexes = [...new Set(offsets.map((o) => o.index))].sort(
+          (a, b) => a - b,
+        );
       } else {
         // I-COUNT: a `ready` s3_jsonl dataset with no offsets MUST have a
         // chunkCount. `?? 0` would scan zero chunks and report "no matches" for

--- a/platform/app/src/server/datasets/dataset.service.ts
+++ b/platform/app/src/server/datasets/dataset.service.ts
@@ -979,22 +979,20 @@ export class DatasetService {
     if (offsets.length > 0) {
       // `byteSize` rides along so the scan can bound what it actually fetches,
       // not only what the dataset row claims it will. `readValidChunkOffsets`
-      // validates the row bounds and not this, so an otherwise-valid entry can
-      // carry no size; it becomes `null` — one chunk that cannot be measured —
-      // rather than a number, because arithmetic on `undefined` yields `NaN`
-      // and one such entry would silently disable the bound for the whole
-      // dataset.
-      const byIndex = new Map<number, number | null>();
-      for (const offset of offsets) {
-        if (byIndex.has(offset.index)) continue;
-        byIndex.set(
-          offset.index,
-          Number.isFinite(offset.byteSize) ? offset.byteSize : null,
-        );
-      }
-      return [...byIndex.entries()]
-        .sort(([a], [b]) => a - b)
-        .map(([index, byteSize]) => ({ index, byteSize }));
+      // validates the index and the row bounds but not this, so an
+      // otherwise-valid entry can carry no size; it becomes `null` — one chunk
+      // that cannot be measured — rather than a number, because arithmetic on
+      // `undefined` yields `NaN` and one such entry would silently disable the
+      // bound for the whole dataset.
+      //
+      // No deduplication needed: a repeated index is rejected at validation, so
+      // every entry here names a chunk no other entry names.
+      return offsets
+        .map((offset) => ({
+          index: offset.index,
+          byteSize: Number.isFinite(offset.byteSize) ? offset.byteSize : null,
+        }))
+        .sort((a, b) => a.index - b.index);
     }
     if (dataset.chunkCount == null) {
       throw new DatasetChunkCountMissingError(dataset.id);

--- a/platform/app/src/server/datasets/dataset.service.ts
+++ b/platform/app/src/server/datasets/dataset.service.ts
@@ -980,17 +980,25 @@ export class DatasetService {
       // `byteSize` rides along so the scan can bound what it actually fetches,
       // not only what the dataset row claims it will. `readValidChunkOffsets`
       // validates the index and the row bounds but not this, so an
-      // otherwise-valid entry can carry no size; it becomes `null` — one chunk
-      // that cannot be measured — rather than a number, because arithmetic on
-      // `undefined` yields `NaN` and one such entry would silently disable the
-      // bound for the whole dataset.
+      // otherwise-valid entry can carry no size, or a nonsensical one; it
+      // becomes `null` — one chunk that cannot be measured — rather than a
+      // number, because arithmetic on `undefined` yields `NaN` and one such
+      // entry would silently disable the bound for the whole dataset.
+      //
+      // Negative sizes are normalised for a sharper reason than tidiness: a
+      // running total is not merely uninformed by one, it is actively set back
+      // by it, so a single entry reading -100 MB buys passage for every chunk
+      // after it while the total still looks well inside the limit.
       //
       // No deduplication needed: a repeated index is rejected at validation, so
       // every entry here names a chunk no other entry names.
       return offsets
         .map((offset) => ({
           index: offset.index,
-          byteSize: Number.isFinite(offset.byteSize) ? offset.byteSize : null,
+          byteSize:
+            Number.isFinite(offset.byteSize) && offset.byteSize >= 0
+              ? offset.byteSize
+              : null,
         }))
         .sort((a, b) => a.index - b.index);
     }

--- a/platform/app/src/server/datasets/dataset.service.ts
+++ b/platform/app/src/server/datasets/dataset.service.ts
@@ -918,110 +918,17 @@ export class DatasetService {
     };
 
     if (dataset.contentLayout === "s3_jsonl") {
-      if (dataset.status !== "ready") {
-        throw new DatasetNotReadyError({
-          status: dataset.status,
-          statusError: dataset.statusError,
-        });
-      }
-
-      const rowCount = dataset.rowCount ?? 0;
-      if (rowCount > DATASET_SEARCH_MAX_ROWS) {
-        throw new DatasetTooLargeToSearchError({
-          rowCount,
-          maxRows: DATASET_SEARCH_MAX_ROWS,
-        });
-      }
-
-      // Which chunks to read. `chunkOffsets` is what ordinary paging trusts to
-      // locate rows, so the search has to agree with it: enumerating by
-      // `chunkCount` alone would, on a dataset whose count has drifted below its
-      // offsets, stop early and report "no matches" for rows the user can page
-      // to — the silent-wrong-answer this path exists to avoid. Offsets first,
-      // `chunkCount` as the fallback for legacy rows that have none.
-      // Same all-or-nothing validation the paged read uses. Keeping the
-      // individually-valid entries of a half-written array would scan only the
-      // chunks those entries name and report "no matches" for rows the pager,
-      // which rejects the whole array and falls back to `chunkCount`, still
-      // displays — the same dataset answering two ways.
-      const offsets = readValidChunkOffsets(dataset.chunkOffsets);
-
-      let chunkIndexes: number[];
-      if (offsets.length > 0) {
-        chunkIndexes = [...new Set(offsets.map((o) => o.index))].sort(
-          (a, b) => a - b,
-        );
-      } else {
-        // I-COUNT: a `ready` s3_jsonl dataset with no offsets MUST have a
-        // chunkCount. `?? 0` would scan zero chunks and report "no matches" for
-        // a dataset that has them.
-        if (dataset.chunkCount == null) {
-          throw new DatasetChunkCountMissingError(dataset.id);
-        }
-        chunkIndexes = Array.from({ length: dataset.chunkCount }, (_, i) => i);
-      }
-
-      const storage = await getDatasetStorage(params.projectId);
-      // `readChunk` per index, never `readChunks`: the plural form pulls every
-      // chunk into the heap at once, which is exactly what the row cap and the
-      // one-at-a-time read are here to prevent.
-      let rowsRead = 0;
-      for (const index of chunkIndexes) {
-        const rows = await storage.readChunk({
-          projectId: params.projectId,
-          datasetId: dataset.id,
-          index,
-        });
-        // Backstop for a `rowCount` that under-reports (or is null, which reads
-        // as 0 and would sail past the up-front check): the cap has to hold on
-        // what is actually read, not only on what the row claims.
-        rowsRead += rows.length;
-        if (rowsRead > DATASET_SEARCH_MAX_ROWS) {
-          throw new DatasetTooLargeToSearchError({
-            rowCount: rowsRead,
-            maxRows: DATASET_SEARCH_MAX_ROWS,
-          });
-        }
-        for (const line of rows) {
-          collect(adaptS3JsonlRecord(line, dataset));
-        }
-      }
+      await this.scanChunksForMatches({
+        dataset,
+        projectId: params.projectId,
+        collect,
+      });
     } else {
-      // Postgres-backed (legacy) content. `sizeBytes` is null on these rows, so
-      // the export-time byte guard can never fire here — the row cap is the only
-      // thing bounding this scan.
-      const { count: rowCount } =
-        await this.recordRepository.countAndMaxUpdatedAt({
-          datasetId: dataset.id,
-          projectId: params.projectId,
-        });
-      if (rowCount > DATASET_SEARCH_MAX_ROWS) {
-        throw new DatasetTooLargeToSearchError({
-          rowCount,
-          maxRows: DATASET_SEARCH_MAX_ROWS,
-        });
-      }
-
-      // Keyset-paginate, like the PG→S3 backfill's streaming scan: `skip`/`take`
-      // would re-run a count(*) alongside every page (listPaginated does), so a
-      // scan at the cap would issue ~50 redundant full counts, and OFFSET
-      // degrades as it walks. The cursor is the previous page's last id, in the
-      // same canonical [createdAt asc, id asc] order the paged read uses — so
-      // matches come back in the order the user sees them when not searching.
-      let cursorId: string | undefined;
-      for (;;) {
-        const records = await this.recordRepository.findDatasetRecordsPage({
-          datasetId: dataset.id,
-          projectId: params.projectId,
-          take: DATASET_SEARCH_SCAN_BATCH,
-          cursorId,
-        });
-        if (records.length === 0) break;
-        for (const record of records) collect(record);
-        if (records.length < DATASET_SEARCH_SCAN_BATCH) break;
-        cursorId = records[records.length - 1]?.id;
-        if (!cursorId) break;
-      }
+      await this.scanPostgresRecordsForMatches({
+        dataset,
+        projectId: params.projectId,
+        collect,
+      });
     }
 
     return {
@@ -1035,6 +942,146 @@ export class DatasetService {
         totalPages: Math.ceil(matchCount / params.limit),
       },
     };
+  }
+
+  /**
+   * Which chunk indexes a scan of the whole dataset has to read.
+   *
+   * `chunkOffsets` is what ordinary paging trusts to locate rows, so the search
+   * has to agree with it: enumerating by `chunkCount` alone would, on a dataset
+   * whose count has drifted below its offsets, stop early and report "no
+   * matches" for rows the user can page to — the silent wrong answer this path
+   * exists to avoid. Offsets first, `chunkCount` as the fallback for legacy
+   * rows that have none.
+   *
+   * Offsets are validated all-or-nothing, the same way the paged read validates
+   * them. Keeping the individually-valid entries of a half-written array would
+   * scan only the chunks those entries name and report "no matches" for rows
+   * the pager — which rejects the whole array and falls back to `chunkCount` —
+   * still displays: the same dataset answering two ways.
+   *
+   * @throws {DatasetChunkCountMissingError} on an offsets-less dataset whose
+   *   `chunkCount` has gone null (I-COUNT drift). `?? 0` would scan zero chunks
+   *   and report "no matches" for a dataset that has them.
+   */
+  private chunkIndexesToScan(dataset: Dataset): number[] {
+    const offsets = readValidChunkOffsets(dataset.chunkOffsets);
+    if (offsets.length > 0) {
+      return [...new Set(offsets.map((o) => o.index))].sort((a, b) => a - b);
+    }
+    if (dataset.chunkCount == null) {
+      throw new DatasetChunkCountMissingError(dataset.id);
+    }
+    return Array.from({ length: dataset.chunkCount }, (_, i) => i);
+  }
+
+  /**
+   * Reads every chunk of an `s3_jsonl` dataset once, offering each row to
+   * `collect`. One chunk is held in the heap at a time.
+   *
+   * @throws {DatasetNotReadyError} if the dataset is still preparing
+   * @throws {DatasetTooLargeToSearchError} past the row cap
+   */
+  private async scanChunksForMatches({
+    dataset,
+    projectId,
+    collect,
+  }: {
+    dataset: Dataset;
+    projectId: string;
+    collect: (record: DatasetRecord) => void;
+  }) {
+    if (dataset.status !== "ready") {
+      throw new DatasetNotReadyError({
+        status: dataset.status,
+        statusError: dataset.statusError,
+      });
+    }
+
+    const rowCount = dataset.rowCount ?? 0;
+    if (rowCount > DATASET_SEARCH_MAX_ROWS) {
+      throw new DatasetTooLargeToSearchError({
+        rowCount,
+        maxRows: DATASET_SEARCH_MAX_ROWS,
+      });
+    }
+
+    const storage = await getDatasetStorage(projectId);
+    // `readChunk` per index, never `readChunks`: the plural form pulls every
+    // chunk into the heap at once, which is exactly what the row cap and the
+    // one-at-a-time read are here to prevent.
+    let rowsRead = 0;
+    for (const index of this.chunkIndexesToScan(dataset)) {
+      const rows = await storage.readChunk({
+        projectId,
+        datasetId: dataset.id,
+        index,
+      });
+      // Backstop for a `rowCount` that under-reports (or is null, which reads
+      // as 0 and would sail past the up-front check): the cap has to hold on
+      // what is actually read, not only on what the row claims.
+      rowsRead += rows.length;
+      if (rowsRead > DATASET_SEARCH_MAX_ROWS) {
+        throw new DatasetTooLargeToSearchError({
+          rowCount: rowsRead,
+          maxRows: DATASET_SEARCH_MAX_ROWS,
+        });
+      }
+      for (const line of rows) {
+        collect(adaptS3JsonlRecord(line, dataset));
+      }
+    }
+  }
+
+  /**
+   * Walks every record of a Postgres-backed (legacy) dataset once, offering
+   * each to `collect`. One batch is held in the heap at a time.
+   *
+   * `sizeBytes` is null on these rows, so the export-time byte guard can never
+   * fire here — the row cap is the only thing bounding this scan.
+   *
+   * @throws {DatasetTooLargeToSearchError} past the row cap
+   */
+  private async scanPostgresRecordsForMatches({
+    dataset,
+    projectId,
+    collect,
+  }: {
+    dataset: Dataset;
+    projectId: string;
+    collect: (record: DatasetRecord) => void;
+  }) {
+    const { count: rowCount } =
+      await this.recordRepository.countAndMaxUpdatedAt({
+        datasetId: dataset.id,
+        projectId,
+      });
+    if (rowCount > DATASET_SEARCH_MAX_ROWS) {
+      throw new DatasetTooLargeToSearchError({
+        rowCount,
+        maxRows: DATASET_SEARCH_MAX_ROWS,
+      });
+    }
+
+    // Keyset-paginate, like the PG→S3 backfill's streaming scan: `skip`/`take`
+    // would re-run a count(*) alongside every page (listPaginated does), so a
+    // scan at the cap would issue ~50 redundant full counts, and OFFSET
+    // degrades as it walks. The cursor is the previous page's last id, in the
+    // same canonical [createdAt asc, id asc] order the paged read uses — so
+    // matches come back in the order the user sees them when not searching.
+    let cursorId: string | undefined;
+    for (;;) {
+      const records = await this.recordRepository.findDatasetRecordsPage({
+        datasetId: dataset.id,
+        projectId,
+        take: DATASET_SEARCH_SCAN_BATCH,
+        cursorId,
+      });
+      for (const record of records) collect(record);
+      if (records.length < DATASET_SEARCH_SCAN_BATCH) break;
+      cursorId = records[records.length - 1]?.id;
+      if (!cursorId) break;
+    }
   }
 
   /**

--- a/platform/app/src/server/datasets/errors.ts
+++ b/platform/app/src/server/datasets/errors.ts
@@ -246,32 +246,49 @@ export class DatasetNotReadyError extends HandledError {
 }
 
 /**
- * A search was asked for over more rows than one search will read.
+ * A search was asked for over more of a dataset than one search will read —
+ * more rows, or more bytes of content.
+ *
+ * One error and one code for both limits, because they are one thing to the
+ * user: the dataset is past what a search reads, and the way through is the
+ * same either way. Which limit fired is carried in `meta` for the log, not
+ * shown — "too many bytes" is not a distinction a user can act on differently
+ * from "too many rows".
  *
  * Distinct from DatasetTooLargeToExportError on purpose: the presentation
  * registry is keyed by code, so reusing the export error would show the user a
- * message about exporting a dataset they were trying to search. The limits also
- * differ in kind — export is bounded by bytes held in heap, search by rows read.
+ * message about exporting a dataset they were trying to search.
  */
 export class DatasetTooLargeToSearchError extends HandledError {
   declare readonly code: "dataset_too_large_to_search";
 
-  readonly rowCount: number;
-  readonly maxRows: number;
+  readonly measured: number;
+  readonly limit: number;
+  readonly dimension: "rows" | "bytes";
 
-  constructor({ rowCount, maxRows }: { rowCount: number; maxRows: number }) {
+  constructor(
+    params:
+      | { rowCount: number; maxRows: number }
+      | { sizeBytes: number; maxBytes: number },
+  ) {
+    const isRows = "rowCount" in params;
+    const measured = isRows ? params.rowCount : params.sizeBytes;
+    const limit = isRows ? params.maxRows : params.maxBytes;
+    const dimension = isRows ? "rows" : "bytes";
+
     super(
       "dataset_too_large_to_search",
-      `Dataset has ${rowCount} rows, more than the ${maxRows} a single search will read`,
+      `Dataset holds ${measured} ${dimension}, more than the ${limit} a single search will read`,
       {
-        meta: { rowCount, maxRows },
+        meta: { measured, limit, dimension },
         httpStatus: 413,
         fault: "customer",
       },
     );
     this.name = "DatasetTooLargeToSearchError";
-    this.rowCount = rowCount;
-    this.maxRows = maxRows;
+    this.measured = measured;
+    this.limit = limit;
+    this.dimension = dimension;
   }
 }
 

--- a/platform/app/src/server/datasets/errors.ts
+++ b/platform/app/src/server/datasets/errors.ts
@@ -246,6 +246,36 @@ export class DatasetNotReadyError extends HandledError {
 }
 
 /**
+ * A search was asked for over more rows than one search will read.
+ *
+ * Distinct from DatasetTooLargeToExportError on purpose: the presentation
+ * registry is keyed by code, so reusing the export error would show the user a
+ * message about exporting a dataset they were trying to search. The limits also
+ * differ in kind — export is bounded by bytes held in heap, search by rows read.
+ */
+export class DatasetTooLargeToSearchError extends HandledError {
+  declare readonly code: "dataset_too_large_to_search";
+
+  readonly rowCount: number;
+  readonly maxRows: number;
+
+  constructor({ rowCount, maxRows }: { rowCount: number; maxRows: number }) {
+    super(
+      "dataset_too_large_to_search",
+      `Dataset has ${rowCount} rows, more than the ${maxRows} a single search will read`,
+      {
+        meta: { rowCount, maxRows },
+        httpStatus: 413,
+        fault: "customer",
+      },
+    );
+    this.name = "DatasetTooLargeToSearchError";
+    this.rowCount = rowCount;
+    this.maxRows = maxRows;
+  }
+}
+
+/**
  * Thrown when a manual normalize retry is requested on a dataset that can't be
  * re-run: it's not in a recoverable state (`failed`/`processing`) or it carries
  * no staging key to re-read (no source to normalize). The route maps it to 409

--- a/platform/app/src/utils/__tests__/queryRetryPolicy.unit.test.ts
+++ b/platform/app/src/utils/__tests__/queryRetryPolicy.unit.test.ts
@@ -54,6 +54,24 @@ describe("shouldRetryQuery", () => {
           shouldRetryQuery(0, handledTrpcError({ code, httpStatus: 409 })),
         ).toBe(false);
       });
+
+      it("does not retry a search refused for being over the row cap", () => {
+        // The dataset does not shrink between attempts, so every replay reads
+        // the same row count and gets the same refusal. Retrying it holds the
+        // query in `pending` through the whole backoff, and for that whole
+        // time `placeholderData: keepPreviousData` keeps serving the last
+        // UNSEARCHED page — rows that were never matched against the search,
+        // under a count chip that labels them as the matches.
+        expect(
+          shouldRetryQuery(
+            0,
+            handledTrpcError({
+              code: "dataset_too_large_to_search",
+              httpStatus: 413,
+            }),
+          ),
+        ).toBe(false);
+      });
     });
 
     describe("when the failure is a conflict that says it resolves itself", () => {

--- a/specs/datasets/dataset-editor.feature
+++ b/specs/datasets/dataset-editor.feature
@@ -259,6 +259,23 @@ Feature: Dataset editor
       # announced once in a toast that dismisses; what is left on screen has to
       # go on being true after it does.
 
+  Rule: Each dataset is opened unsearched
+
+    A search belongs to the dataset it was typed against. The editor is not torn
+    down when the user moves between datasets — the same grid stays on screen
+    and the dataset under it changes — so a search left in the box would narrow
+    the next dataset by a word nobody typed against it, at a page it may not
+    have, with the previous dataset's size still shown as the total. Rows would
+    be missing and nothing on screen would say why.
+
+    @integration
+    Scenario: Opening another dataset starts it unsearched
+      Given I have searched one dataset
+      When I open a different dataset without leaving the editor
+      Then the search box is empty and the whole dataset is shown
+      And I am on its first page
+      And the record count reports that dataset's own size
+
   Rule: Search is offered for saved datasets only
 
     Search narrows a dataset by asking the server for the matching rows. A

--- a/specs/datasets/dataset-editor.feature
+++ b/specs/datasets/dataset-editor.feature
@@ -276,6 +276,21 @@ Feature: Dataset editor
       And I am on its first page
       And the record count reports that dataset's own size
 
+  Rule: A row edited out of its matches stays on screen
+
+    Editing a matching row so that it no longer contains the searched text
+    leaves it in the grid until the next search. The alternative is to remove it
+    the moment the edit saves, which takes the row out from under the cursor of
+    the person who is still working in it — and strands any further edit to the
+    same row, whose position in the grid has just been taken by another. The
+    grid answers the search as it was run; running it again re-answers it.
+
+    @integration
+    Scenario: A row edited so it no longer matches is not pulled out from under me
+      Given I have searched for "escalation"
+      When I edit the matching row so it no longer contains "escalation"
+      Then the row is still there with what I typed in it
+
   Rule: Search is offered for saved datasets only
 
     Search narrows a dataset by asking the server for the matching rows. A

--- a/specs/datasets/dataset-editor.feature
+++ b/specs/datasets/dataset-editor.feature
@@ -243,11 +243,19 @@ Feature: Dataset editor
 
   Rule: A dataset too large to scan is refused, not half-searched
 
-    Finding matches means reading the dataset's rows. Past a number of rows the
-    platform will read for one search, returning the matches found so far would
-    be a wrong answer wearing the clothes of a right one — the user cannot tell
-    an empty result from an abandoned scan. The search is refused with its own
+    Finding matches means reading the dataset's rows. Past what the platform
+    will read for one search, returning the matches found so far would be a
+    wrong answer wearing the clothes of a right one — the user cannot tell an
+    empty result from an abandoned scan. The search is refused with its own
     reason, distinct from the one shown when a dataset is too large to export.
+
+    How much a search reads is two numbers, not one. A row count bounds how many
+    records are offered to the match test; the bytes those rows occupy bound how
+    much has to be pulled out of storage and parsed to produce them. Nothing
+    constrains the two to agree: a row is whatever columns it was given, and the
+    platform accepts rows from a handful of bytes up to a chunk's worth. A row
+    count alone therefore lets a narrow dataset be refused while a dataset many
+    times more expensive to scan is allowed through.
 
     @unit
     Scenario: A dataset over the row limit refuses the search
@@ -255,6 +263,48 @@ Feature: Dataset editor
       When a search is run against it
       Then the search is refused as too large to search
       And no partial set of matches is returned
+
+    @unit
+    Scenario: A dataset within the row limit but over the byte limit refuses the search
+      Given a dataset with few enough rows for one search to read
+      But whose rows occupy more bytes than one search will read
+      When a search is run against it
+      Then the search is refused as too large to search
+      And no partial set of matches is returned
+      # The dimension that costs a search is bytes pulled out of storage and
+      # parsed, not records counted. A dataset of wide rows is under the row
+      # limit and still the most expensive thing the search will be asked to
+      # read.
+
+    @unit
+    Scenario: A dataset too large to search is refused before any of it is read
+      Given a dataset too large for one search to read
+      When a search is run against it
+      Then no chunk of the dataset is read from storage
+      # Both limits are known from what the dataset records about itself, so the
+      # refusal costs nothing. Discovering it partway through means the work the
+      # limit exists to prevent has already been done.
+
+    @unit
+    Scenario: A scan that outgrows the limit while it runs is stopped part-way
+      Given a dataset just inside what one search will read
+      And rows are still being written to it while the search runs
+      When the search has read more than one search will read
+      Then the search is refused as too large to search
+      # The limits are checked against what the dataset said about itself before
+      # the scan started. A dataset filling up during the scan passes that check
+      # and then outgrows it, so what is actually read has to be counted too —
+      # otherwise the scan runs as long as the writer keeps writing.
+
+    @unit
+    Scenario: A chunked dataset that records no size is bounded by the row limit alone
+      Given a chunked dataset that records no size in bytes
+      And with more rows than one search will read
+      When a search is run against it
+      Then the search is refused as too large to search
+      # A dataset written before its size was recorded has none. A byte limit
+      # reading a missing size as zero would wave those through as the smallest
+      # datasets in the platform, so the row limit has to keep holding alone.
 
     @unit
     Scenario: The refusal has its own words, not the export refusal's

--- a/specs/datasets/dataset-editor.feature
+++ b/specs/datasets/dataset-editor.feature
@@ -77,6 +77,209 @@ Feature: Dataset editor
     And I am returned to the first page
 
   # ============================================================================
+  # Searching rows
+  # ============================================================================
+  # Paging is how you read a dataset in order; it is a poor way to find one row
+  # among hundreds. Search narrows the dataset to the rows whose cell values
+  # contain what was typed, and the pager then pages the matches.
+  #
+  # The narrowing happens over the whole dataset, not over the page already on
+  # screen: a search that could only find rows the user can already see would
+  # not be worth having. That is what the first scenario pins — the matched
+  # record starts on a page that was never loaded.
+
+  @integration
+  Scenario: Find a record that is not on the page I am looking at
+    Given the dataset has more records than fit on one page
+    And the only record containing "escalation" is on the last page
+    When I open the dataset in the editor
+    And I search for "escalation"
+    Then I see that record without leaving the first page
+    And I see only the records containing "escalation"
+
+  @unit
+  Scenario: Search matches regardless of letter case
+    Given a record contains "Escalation"
+    When I search for "escalation"
+    Then that record is shown
+
+  @integration
+  Scenario: The record count reports the matches, not the whole dataset
+    Given the dataset has more records than fit on one page
+    When I search for something matching fewer records than the whole dataset
+    Then the record count tells me how many records matched
+    And it tells me how many records the dataset holds in total
+    # Both numbers, because either alone is a trap: the match count alone reads
+    # as the dataset having shrunk, and the total alone hides the result of the
+    # search that was just run.
+
+  @integration
+  Scenario: The pager pages the matches
+    Given a search matches more records than fit on one page
+    Then the pager offers one page per page of matches
+    And moving to the next page shows the next page of matches
+
+  @integration
+  Scenario: Searching returns me to the first page of results
+    Given the dataset has more records than fit on one page
+    When I go to a later page
+    And I search for something that matches many records
+    Then I am shown the first page of the matches
+
+  @integration
+  Scenario: Clearing the search restores the whole dataset
+    Given I have searched for "escalation"
+    When I clear the search
+    Then I see the whole dataset again
+    And the record count reports the whole dataset again
+    # Deliberately says nothing about which page you land on. That is settled by
+    # "Clearing the search offers adding rows again", which requires the page you
+    # searched FROM. An unconditional "and I am on the first page" here
+    # contradicted that scenario, and was false about the editor as built.
+
+  @integration
+  Scenario: A search that matches nothing says so in the grid
+    When I search for something no record contains
+    Then the grid tells me no records match what I searched for
+    And it repeats what I searched for, so I can see what was actually run
+    And the row count reads zero matches
+
+  Rule: Search matches the cell values, not the column names
+
+    A row is a match when one of its values contains the text. Matching the
+    column names too would make searching "id" return every row of a dataset
+    with a "conversation_id" column — a result the user cannot explain from
+    what is on screen.
+
+    @unit
+    Scenario: A word that only appears in a column name matches nothing
+      Given the dataset has a column named "escalation"
+      And no record contains the word "escalation" in any of its values
+      When I search for "escalation"
+      Then no records match
+
+  Rule: A search never strands an unsaved edit
+
+    Changing the search reloads the grid from the server, which drops the rows
+    the previous search returned. An edit still on its way to being saved refers
+    to one of those rows, so it would be discarded with nothing shown to the
+    user — and the editor would go on believing a save was still pending. The
+    editor already blocks page navigation for this reason; searching moves the
+    same rows and gets the same gate.
+
+    @integration
+    Scenario: Searching waits for a pending save
+      Given I have edited a cell and the save has not finished
+      Then I cannot change the search until it has
+      And once it has saved I can search again
+
+  Rule: Changing the search clears the row selection
+
+    Rows are selected by their position in the grid. A search replaces which
+    records occupy those positions, so a selection made before it would, after
+    it, name different records — and deleting would delete rows the user never
+    picked. Paging already clears the selection for this reason.
+
+    @integration
+    Scenario: A selection made before a search does not survive it
+      Given I have selected a row
+      When I search for something that matches different records
+      Then nothing is selected
+      And I am not offered the delete action for rows I can no longer see
+
+  Rule: Rows cannot be added while a search is active
+
+    Every way of adding a row appends an empty or unrelated row to the end of
+    the dataset, which by construction does not match the search — so it would
+    be created and immediately vanish. All three ways are withdrawn together:
+    the add-row button, the trailing empty row at the end of the grid, and
+    adding rows from a CSV file. All three return once the search is cleared.
+
+    @integration
+    Scenario: No way to add a row is offered during a search
+      When I search for "escalation"
+      Then the add-row button is not offered
+      And the trailing empty row is not shown
+      And adding rows from a CSV file is not offered
+
+    @integration
+    Scenario: An import already open when the search lands is withdrawn too
+      Given I have opened the CSV import
+      When a search takes effect
+      Then the import is withdrawn
+      # Withdrawing only the button leaves the door open behind it: the search
+      # box waits for a pause in typing, so a click landing in that pause opens
+      # the import while no search is in effect yet. Rows imported through it
+      # land at the end of the dataset, outside the matches on screen.
+
+    @integration
+    Scenario: Clearing the search offers adding rows again
+      Given I have searched for "escalation"
+      When I clear the search
+      Then I am offered the ways to add a row that I had before searching
+      # "That I had" is the whole assertion: the add-row button and trailing row
+      # live on the LAST page, so returning the user to page 1 rather than the
+      # page they searched from withdraws them for the rest of the session. A
+      # search must not cost the user their place.
+
+  Rule: A dataset too large to scan is refused, not half-searched
+
+    Finding matches means reading the dataset's rows. Past a number of rows the
+    platform will read for one search, returning the matches found so far would
+    be a wrong answer wearing the clothes of a right one — the user cannot tell
+    an empty result from an abandoned scan. The search is refused with its own
+    reason, distinct from the one shown when a dataset is too large to export.
+
+    @unit
+    Scenario: A dataset over the row limit refuses the search
+      Given a dataset with more rows than one search will read
+      When a search is run against it
+      Then the search is refused as too large to search
+      And no partial set of matches is returned
+
+    @unit
+    Scenario: The refusal has its own words, not the export refusal's
+      Given a search was refused because the dataset is too large
+      Then the user is told the dataset is too large to search
+      And is not told something about exporting instead
+      # Separate codes because the message registry is keyed by code: reusing
+      # the export refusal would answer a search with export copy.
+
+    @integration
+    Scenario: A refused search does not leave unsearched rows on screen as if they matched
+      Given I am looking at a dataset
+      When I search it and the search is refused
+      Then the rows I was looking at before the search are withdrawn
+      And the record count does not report a number of matches
+      # The rows on screen were read BEFORE the search and never matched
+      # against it. Left in place under a search box, with a count chip
+      # reporting them, the screen reads as a finished search that found them —
+      # a wrong answer wearing the clothes of a right one, which is the same
+      # failure this Rule refuses a partial scan to avoid. The refusal is
+      # announced once in a toast that dismisses; what is left on screen has to
+      # go on being true after it does.
+
+  Rule: Search is offered for saved datasets only
+
+    Search narrows a dataset by asking the server for the matching rows. A
+    dataset being drafted in the editor has never been saved, so there is no
+    server to ask and every row is already on screen — the affordance would
+    promise something it could not do. The draft editor keeps its unfiltered
+    grid and its ways of adding rows.
+
+    KNOWN GAP: the workflow dataset modal opens saved datasets and drafts
+    through the same dialog, so the search box appears in one and not the other
+    with nothing on screen explaining the difference. Closing it means selecting
+    rows by identity rather than by grid position, which is a larger change than
+    this one.
+
+    @integration
+    Scenario: A draft dataset offers no search
+      Given I am editing a dataset that has not been saved
+      Then I am not offered a way to search it
+      And I am still offered the ways to add a row
+
+  # ============================================================================
   # Inline cell editing
   # ============================================================================
 

--- a/specs/datasets/dataset-editor.feature
+++ b/specs/datasets/dataset-editor.feature
@@ -304,7 +304,24 @@ Feature: Dataset editor
       Then the search is refused as too large to search
       # A dataset written before its size was recorded has none. A byte limit
       # reading a missing size as zero would wave those through as the smallest
-      # datasets in the platform, so the row limit has to keep holding alone.
+      # datasets in the platform, so the row limit has to keep holding on its
+      # own terms. It is not the only thing holding — see the scenario below.
+
+    @unit
+    Scenario: A dataset that records no size is still bounded by the bytes the scan reads
+      Given a chunked dataset that records no size in bytes
+      And with few enough rows for one search to read
+      But whose rows occupy more bytes than one search will read
+      When a search is run against it
+      Then the search is refused as too large to search
+      And no partial set of matches is returned
+      # Sizes recorded against a dataset are numbers a writer wrote down, absent
+      # on rows written before sizes were kept and on offsets a half-finished
+      # migration left behind. A byte limit judged only on those holds
+      # everywhere except on the damaged and legacy rows — which is where an
+      # unbounded read is reachable at all. So the scan measures the chunks it
+      # reads and is held to the limit on those, refusing once it has gone past
+      # rather than reading on to the end.
 
     @unit
     Scenario: The refusal has its own words, not the export refusal's

--- a/specs/datasets/dataset-editor.feature
+++ b/specs/datasets/dataset-editor.feature
@@ -203,14 +203,33 @@ Feature: Dataset editor
       And adding rows from a CSV file is not offered
 
     @integration
+    Scenario: The ways to add a row go the moment I start typing
+      When I type a search term but the search has not run yet
+      Then the add-row button is not offered
+      And adding rows from a CSV file is not offered
+      # The search box waits for a pause in typing before it runs. Leaving the
+      # add-row affordances up during that pause offers a row that the search
+      # arriving a moment later will remove from the grid — the user adds a row
+      # and watches it disappear, with nothing on screen connecting the two.
+
+    @integration
     Scenario: An import already open when the search lands is withdrawn too
       Given I have opened the CSV import
       When a search takes effect
       Then the import is withdrawn
-      # Withdrawing only the button leaves the door open behind it: the search
-      # box waits for a pause in typing, so a click landing in that pause opens
-      # the import while no search is in effect yet. Rows imported through it
-      # land at the end of the dataset, outside the matches on screen.
+      # Withdrawing only the button leaves the door open behind it. Rows
+      # imported through it land at the end of the dataset, outside the matches
+      # on screen.
+
+    @integration
+    Scenario: An import withdrawn by a search does not reopen when I clear it
+      Given the CSV import was withdrawn by a search
+      When I clear the search
+      Then the import stays closed until I ask for it again
+      # Withdrawing the import unmounts it without recording that it closed, so
+      # the flag saying it is open outlives the dialog. Clearing the search
+      # would then reopen it on its own, seconds after the user last touched
+      # it, and empty of whatever they had selected in it.
 
     @integration
     Scenario: Clearing the search offers adding rows again


### PR DESCRIPTION
Closes #7731.

A 679-row dataset is 14 pages, and the editor offered no way to find one row in it. This adds a search box.

## What it does

Typing narrows the whole dataset to the rows whose cell values contain the text, and the pager pages the matches. Matching is case-insensitive and looks at values only — matching column names too would make searching `id` return every row of a dataset with a `conversation_id` column.

The narrowing happens on the server. The issue proposed matching against the `entry` JSON of dataset records in Postgres; that would have found nothing, because datasets store their content as JSONL chunks in object storage (ADR-032) and have no Postgres rows at all. Searching means reading chunks.

## Scanning, and the refusal

Chunks are read one at a time, in the order the stored offsets give, stopping at 50,000 rows or 100 MB. Past either the search is refused with its own error rather than returning what it found so far — a user cannot tell an empty result from an abandoned scan, and a wrong answer wearing the clothes of a right one is worse than a refusal. The refusal has its own code and copy, separate from the too-large-to-export one, because the message registry is keyed by code and reusing it would answer a search with export copy.

Both limits are checked twice: once against what the dataset row records about itself, so an over-large dataset is refused before a byte is fetched, and again against what the scan has actually read. The second check is not redundant. Those fields are written when the dataset is measured, not read when the search runs, so a writer appending during the scan carries the dataset past a fence it has already cleared; without a running backstop the scan continues for as long as the writer keeps writing.

Legacy Postgres-backed datasets take the same predicate through a keyset walk, counting once for the whole scan rather than per page, and hold the same running row backstop.

A refusal is final, so it is not retried. The client's retry policy treats the code as permanent; without that the editor sent the same doomed request five times over fifteen seconds and, while they were in flight, went on showing the unsearched rows as if they were the matches.

## What is withheld during a search

All three ways of adding a row: the button, the trailing empty row, and the CSV import — including one already open when the search lands, since the search box waits for a pause in typing and a click can land in that pause. Each would append a row that by construction does not match, so it would be created and immediately vanish.

Clearing the search brings them back **on the page the search started from**. They live on the last page; searching from there and being returned to page one would withdraw them for the rest of the session.

Changing the search also waits for a pending save and clears the row selection. Rows are addressed by grid position, so a search that changes which records hold those positions would leave a selection naming rows the user never picked, and deleting would delete the wrong ones.

## Known gaps

These are real and deliberate. None is a regression.

- **Draft datasets get no search.** Closing this needs rows selected by identity rather than grid position — a larger change than this one.
- **The workflow dataset modal** opens saved datasets and drafts through the same dialog, so the box appears in one and not the other with nothing on screen explaining the difference.
- **The spec cannot distinguish "the page you searched from" from "the last page."** The bound test searches from page 3 of 3, and the add-row affordances live on the last page, so both behaviours pass it. The code restores the literal prior page; a scenario searching from a *middle* page would pin it, and needs a four-page fixture. Worth a follow-up.
- **The refusal's toast has no automated test.** Its copy is pinned at unit level; the toast path is not.
- **A failed save leaves the pager and the search disabled** until reload — `clearPendingChange` runs only on success. Inherited from `main`, not introduced here, and deserves its own issue.
- **The Postgres scan is bounded by rows only, not bytes.** Those records arrive as parsed objects with no recorded size, so bounding them by bytes means serializing every row to measure it — paying `JSON.stringify` on up to 50,000 rows of every search to enforce a limit the row cap already stops. That trade wants a measurement rather than a guess. Raised by review and answered there.
- **Every page of a search restarts the scan.** Each request is bounded; ten of them are not cheap. The fixes are a short-TTL cache keyed on `(datasetId, search)` or an opaque resume cursor, both of which are new architecture over mutable tenant data and want their own change and their own ADR — a cache without an invalidation plan is not an improvement. Debouncing and the click-driven pager keep the realistic rate to a handful of scans a minute per user.
- **`chunkOffsets` row ranges are not checked for gaps or overlaps.** Duplicate and negative indexes are now rejected, because those make paging and search answer differently about the same dataset. Contiguity is not, because rejecting an index sends the dataset onto the unbounded every-chunk read, and I have no evidence about how many live datasets carry gaps. Worth measuring before tightening.

## Checks

Feature parity 10887 enforced scenarios bound, 41/41 in `dataset-editor.feature`; 55 editor component tests; 266 dataset server unit tests; the CI Biome gate reports no new violations and one removed; typecheck clean.

## Reviewing

This branch has a habit of yielding defects after it looks finished — twelve so far, several of them found only after a review had passed and two rounds of refutation had run. Wrong chunk enumeration, a page-reset race, a crash on a null entry, an offset scan that should have been keyset, a lost page, a count chip reporting held-over rows as matches, a dialog left open, a refused search retried four times before it was believed, the add-row affordances lingering through the debounce window, a chunk index that could name the same chunk twice, a byte limit checked before the scan and never during it, and a negative recorded size that bought passage for every chunk after it.

Two of those are worth singling out for reviewers, because they are the kind that survive a green suite:

- The 413 refusal was retried four times before the error surfaced, so the editor spent 15 seconds showing the unsearched rows as though they were the matches. Every test passed throughout: the component suite mocks the transport wholesale, so it never exercised react-query's retry or placeholder behaviour. It took a real browser against a 54,000-row dataset to see it.
- A self-check inside one test asserted that the CSV button was gone, as proof that the search had run. That was true when written and stopped being true two commits later, when the add-row affordances were moved to withdraw on the keystroke. The test kept passing while checking nothing. Caught in review, not by the suite.

One piece of history to know before bisecting: `b66a397daf` does not typecheck. Two agents edited this branch concurrently for about two minutes, and that commit changed a call site while the commit that changed the signature to match landed after it. `HEAD` is correct and typecheck is clean; the branch is pushed and shared, so it has not been rewritten.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added case-insensitive row search for saved datasets with paginated results and match counts.
  * Clearing a search restores the previous page and dataset view.
  * Add-row and CSV import controls are hidden while searching.
  * Added messages for no matches, failed searches, and datasets too large to search.
  * Search is unavailable for unsaved draft datasets.

* **Bug Fixes**
  * Prevented stale rows from appearing during dataset and search transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
