### PR TITLE
fix(mcp): an empty trace search names the window and the tool that works

### DIFF
--- a/dev/docs/adr/132-a-trace-id-is-looked-up-never-searched.md
+++ b/dev/docs/adr/132-a-trace-id-is-looked-up-never-searched.md
@@ -24,20 +24,22 @@ inside captured content.
 Two further properties turn a wrong answer into a confident one. The default
 window is the last 24 hours, applied silently in
 `mcp/typescript/src/tools/search-traces.ts` (`now - 86400000`) and never
-mentioned in the response, so a legitimate text search for an older trace is
-also a false negative. And the tip that names `get_trace` is appended only on
-the success path, so the empty result — the one moment the caller needs a
-redirect — is the one place it never prints.
+mentioned in the response — the product's own trace list defaults to 30 days
+(`specs/traces-v2/search.feature`), so the two surfaces do not even agree — and
+a legitimate text search for an older trace is a false negative for the same
+reason. And the tip that names `get_trace` is appended only on the success path,
+so the empty result — the one moment the caller needs a redirect — is the one
+place it never prints.
 
 ```
   agent holds a trace id
           │
           ├── search_traces(query: "<id>")                    what it reaches for
           │     POST /api/traces/search
-          │     WHERE ... AND (  lower(ComputedInput)  LIKE q
-          │                   OR lower(ComputedOutput) LIKE q
-          │                   OR lower(TraceName)      LIKE q
-          │                   OR EXISTS(sp.SpanName    LIKE q) )
+          │     WHERE ... AND (  lower(ifNull(ComputedInput,''))  LIKE '%q%'
+          │                   OR lower(ifNull(ComputedOutput,'')) LIKE '%q%'
+          │                   OR lower(ifNull(TraceName,''))      LIKE '%q%'
+          │                   OR EXISTS(lower(sp.SpanName)        LIKE '%q%') )
           │               AND OccurredAt BETWEEN now-24h AND now
           │                   └─ TraceId is absent from the OR list,
           │                      and the window is ANDed on top of it
@@ -46,81 +48,125 @@ redirect — is the one place it never prints.
           └── get_trace(traceId: "<id>")                      the path that works
                 GET /api/traces/{id}
                 TraceService.getById(projectId, traceId, protections, opts)
-                    └─ no date range in the signature at all
+                    ├─ exact match: getTracesWithSpans(..., occurredAt: undefined)
+                    │               unbounded, by design
+                    └─ 8..31 hex:   git-style prefix resolution, bounded to
+                                    TRACE_ID_PREFIX_LOOKUP_WINDOW_DAYS = 90
                 -> the trace
 ```
 
 A trace id is not free-form text that might occur in a document; it is a primary
-key. The asymmetry above is the whole bug, and it is a guidance failure at the
-tool boundary rather than a defect in the query.
+key — in `trace_summaries` quite literally, since that table is
+`ORDER BY (TenantId, TraceId)`. The asymmetry above is the whole bug, and it is
+a guidance failure at the tool boundary rather than a defect in the query.
 
-Two capabilities already exist and are worth naming, because the decision below
-declines to build on either. The engine and the REST boundary already accept
+The storage layer is emphatically not the obstacle. `trace_summaries` carries
+`INDEX idx_trace_id TraceId TYPE bloom_filter(0.001)` and
+`INDEX idx_tenant_trace (TenantId, TraceId) TYPE bloom_filter(0.001)` on top of
+the sort key; `stored_spans` carries bloom filters on `TraceId`, `SpanId`,
+`(TenantId, TraceId)` and `(TenantId, TraceId, SpanId)`
+(`platform/app/src/server/clickhouse/migrations/00002_create_schema.sql`). An
+equality or `IN` match on a trace id is the cheapest shape these tables support.
+
+Two capabilities already exist. The engine and the REST boundary already accept
 `traceIds: string[]` — `sharedFiltersInputSchema` carries it, it survives into
 `getAllForProjectInput` and so into the search body schema, and the engine
-applies it as `AND ts.TraceId IN ({traceIds:Array(String)})`. The MCP tool
-simply never forwards it; neither, today, does the app's own trace list. And the
-error envelope already has a vocabulary for steering a caller: `tips: string[]`,
-rendered as a `Tips:` block by `mcp/typescript/src/langwatch-api.ts`.
+applies it as `AND ts.TraceId IN ({traceIds:Array(String)})`, which lands
+directly on the sort key. The MCP tool simply never forwards it; neither, today,
+does the app's own trace list. And the error envelope already has a vocabulary
+for steering a caller: `tips: string[]`, rendered as a `Tips:` block by
+`mcp/typescript/src/langwatch-api.ts`.
+
+The repo has also already ruled, twice, that an empty result must not be able to
+stand in for "you asked wrongly": `specs/traces-v2/sessions-lens.feature`
+("A failed read is told as a failure, not as an empty result") and
+`specs/langy/langy-cli-tool-envelope.feature` ("A rejected command is never read
+as an empty result"), the latter written after an agent read a rejected command
+as "no results" and reported that as a count. This ADR is the third instance of
+that rule, on the MCP surface.
 
 ## Decision
 
 We will state at the tool boundary that a trace id is looked up rather than
-searched, and make the empty result carry the reader to the tool that works.
+searched, make the empty result carry the reader to the tool that works, and
+expose the exact-match id filter the server already implements.
 
-`get_trace` is the sanctioned path for a known id, and its description says so.
-It is the right path for a reason the guidance can lean on: `getById` takes no
-date range, so an id lookup cannot be missed by a window. The `query` parameter
-of `search_traces` says in turn what it does not match — trace ids among them —
-so the model has the fact before it makes the call, not only after.
+`get_trace` is the sanctioned path for a single id, and its description says so.
+An exact full id resolves unbounded there, so it cannot be missed by a date
+window. A truncated hex id of 8 to 31 characters resolves git-style within the
+last 90 days (`TRACE_ID_PREFIX_LOOKUP_WINDOW_DAYS`), which is a window, and the
+guidance says so rather than promising more than the code does. The `query`
+parameter of `search_traces` says in turn what it does not match — trace ids
+among them — so the model has the fact before it makes the call.
+
+`search_traces` gains a `traceIds: string[]` passthrough for the batch case,
+forwarded to the field the REST boundary already accepts. When `traceIds` is
+supplied and the caller named no dates, the window defaults to 90 days rather
+than 24 hours, reusing the bound prefix resolution already justifies, and the
+response states the window it used. Naming ids is an exact-match intent, and
+answering it against yesterday only is a false negative by construction.
 
 The empty result stops being a dead end. It always names the window it actually
 searched and always names `get_trace` for a known trace id, whatever the query
 looked like. That unconditional guidance is the load-bearing half of this
 decision, because it is the half that cannot misfire.
 
-On top of it, and only on top of it, a narrow shape check adds one sentence when
-the query looks like a trace id: the OTel form `[0-9a-f]{32}`, the same with a
-`trace_` prefix, and any `trace_`-prefixed token. **The check may only ever add
+On top of it, and only on top of it, a shape check adds one sentence when the
+query looks like a trace id. It reuses the vocabulary the trace service already
+exports rather than inventing a second one — `HEX_ONLY`,
+`MIN_TRACE_ID_PREFIX_LENGTH` (8) and `FULL_TRACE_ID_LENGTH` (32) from
+`platform/app/src/server/traces/trace.service.ts` — so a hex string of 8 or more
+characters is recognised, which covers the truncated ids the CLI itself produces
+by printing 20 characters in its table. `trace_`-prefixed ids, the form the
+collector accepts, are recognised alongside them. **The check may only ever add
 advice. It must never change what the tool does.** This is the general rule for
 the MCP surface, not a detail of this tool: `TraceId` is `String` in ClickHouse
 and `trace_id` is `z.string()` in the collector contract, so a customer's ids can
-be `order-12345` and no regex over that space can ever be sound. A heuristic that
-routed execution would silently turn a legitimate text search into a different
-operation on the day it guessed wrong; a heuristic that only ever appends a
-sentence is wrong in a way the reader can see and discard.
+be `order-12345` and no regex over that space can ever be sound. It is the same
+principle ADR-079 settled for card selection — what a deterministic path can
+decide is not handed to a non-deterministic oracle — applied to tool routing
+rather than presentation.
 
 The window disclosure is what covers the ids the shape check cannot recognise,
 which is why it prints unconditionally rather than as the heuristic's else-branch.
 
 ## Rationale / Trade-offs
 
-We considered making `search_traces` do what the caller meant and route an
-id-shaped query into the id lookup. It is rejected on the soundness argument
-above: over a free-form id space the guess is unfalsifiable, and the failure is
-silent and semantic rather than visible and recoverable.
+We considered making `search_traces` route an id-shaped query into the id
+lookup. It is rejected on the soundness argument above: over a free-form id space
+the guess is unfalsifiable, and the failure is silent and semantic rather than
+visible and recoverable.
 
-We considered adding `TraceId` to the searchable columns so that pasting an id
-into free text simply works. It is rejected on blast radius. That predicate is a
-hot path shared with the product's own trace list, so the change is a product
-decision about the app's search box and not only about the MCP; the `LIKE` shape
-the other columns use is not index-friendly on an id column; and it would not
-even fix the reported problem, because the window is ANDed on top of the OR and
-an older trace would still come back empty. It buys a worse version of the fix
-at the highest price.
+We considered adding `TraceId` to the free-text searchable columns so that
+pasting an id into `query` simply works. It is rejected, but not for the reason
+it first appears: the column is superbly indexed, so "ids are not indexed" would
+be false. The obstacle is the shape of the free-text predicate. The term is built
+as `` `%${q}%` `` and applied as `lower(ifNull(col,'')) LIKE {searchQuery}`, and
+a bloom filter answers exact membership rather than substring containment, while
+the `lower(ifNull(...))` wrapper stops the expression matching any indexed
+expression in any case. So an id ORed into that list would scan where an `IN`
+would seek — a strictly worse mechanism for a job the sort key already does
+perfectly. It is also a hot path shared with the product's own trace list, so
+changing it is a product decision about the app's search box rather than an MCP
+fix, and it would still be ANDed with the window and so still miss an older
+trace.
 
-We considered exposing the `traceIds` passthrough that the REST boundary already
-accepts. It is genuinely nearly free and it is the honest answer to "I have five
-ids", but it is not the reported problem, and it inherits the window trap: named
-ids are still ANDed with the date range, so a batch lookup of older traces
-returns nothing unless the default is also widened. Widening it is not free
-either — the code's own comment warns that locating traces by id across a wide
-window scans every partition including cold S3. It is recorded here as the
-obvious follow-up rather than smuggled into a guidance fix.
+Exposing `traceIds` instead is the honest version of that idea and is nearly
+free, which is why it is in scope rather than deferred: `WHERE TenantId = x AND
+TraceId IN (...)` is a primary-key seek.
 
-We considered widening the default window generally. Rejected: it trades a
-visible wrong answer for an invisible cost, and disclosure solves the reported
-confusion without moving anyone's bill.
+The cost that does exist is partition pruning, not indexing. `trace_summaries`
+is `PARTITION BY toYearWeek(OccurredAt)`, so an id lookup with no date predicate
+is a fast seek *within* each partition but must open every weekly partition,
+including cold ones on S3 — exactly what the `resolveTraceIdByPrefix` comment
+warns about and exactly why prefix resolution bounds itself to 90 days. Defaulting
+the id path to that same 90 days, rather than to 24 hours or to unbounded, buys
+the recent-trace case that motivates this ADR at a cost the repo has already
+accepted once, and the disclosure line means nobody has to guess which it was.
+
+We considered widening the default window for ordinary text search too. Rejected:
+it trades a visible wrong answer for an invisible cost across every search, and
+disclosure solves the reported confusion without moving anyone's bill.
 
 The accepted cost is that a caller who ignores prose keeps getting an empty
 result. We are choosing to fix a model's tool selection with better words, which
@@ -131,24 +177,39 @@ for not putting an unsound guess on the execution path.
 
 An agent handed a trace id reaches `get_trace` on the first or second attempt
 instead of concluding the trace does not exist, and a human reading the
-transcript can see which window was searched rather than inferring it. Every
-empty search result grows two lines, which is a real cost paid on a path that
-previously carried no information at all.
+transcript can see which window was searched rather than inferring it. An agent
+holding several ids can ask for them in one call. Every empty search result grows
+two lines, which is a real cost paid on a path that previously carried no
+information at all.
+
+`search_traces` now has two windowing defaults — 24 hours for a text search, 90
+days when ids are named — which is a wart justified only by the two being
+different intents. The response says which one it used, so the wart is visible
+rather than silent, and that disclosure is what keeps it honest.
 
 The rule that a heuristic advises but never routes now applies to the whole MCP
 tool surface, and the next tool tempted to guess at its caller's intent inherits
 it.
 
-Trace-id lookup through `search_traces` stays unavailable, deliberately.
-`traceIds` remains wired end-to-end on the server and unexposed on the client,
-so the follow-up that exposes it starts from a boundary change and a window
-decision, not from new query work.
+Free-text search by trace id stays unavailable, deliberately. The app's own trace
+list still does not expose `traceIds`, so the same affordance is a candidate
+there; this ADR does not decide it.
 
 ## References
 
-- Specs: `specs/mcp-server/trace-tools.feature`
+- Related ADRs: ADR-079 (card selection is deterministic — the precedent for
+  "advice never routes")
+- Specs: `specs/mcp-server/trace-tools.feature`,
+  `specs/traces/partial-trace-id-resolution.feature` (owns `GET /api/traces/{id}`
+  prefix semantics), `specs/traces-v2/search.feature` (the app's 30-day default),
+  `specs/traces-v2/sessions-lens.feature` and
+  `specs/langy/langy-cli-tool-envelope.feature` (an empty result never stands in
+  for a failure)
 - Implementation: `mcp/typescript/src/tools/search-traces.ts`,
   `mcp/typescript/src/create-mcp-server.ts`
 - Search predicate: `platform/app/src/server/traces/clickhouse-trace.service.ts`
   (`getAllTracesForProject`), `platform/app/src/server/filters/registry.ts`
-- Id lookup: `platform/app/src/server/traces/trace.service.ts` (`getById`)
+- Id lookup and shape vocabulary: `platform/app/src/server/traces/trace.service.ts`
+  (`getById`, `HEX_ONLY`, `MIN_TRACE_ID_PREFIX_LENGTH`, `FULL_TRACE_ID_LENGTH`,
+  `TRACE_ID_PREFIX_LOOKUP_WINDOW_DAYS`)
+- Schema: `platform/app/src/server/clickhouse/migrations/00002_create_schema.sql`

--- a/dev/docs/adr/132-a-trace-id-is-looked-up-never-searched.md
+++ b/dev/docs/adr/132-a-trace-id-is-looked-up-never-searched.md
@@ -1,0 +1,154 @@
+# ADR-132: A trace id is looked up, never searched
+
+**Date:** 2026-09-01
+
+**Status:** Proposed
+
+## Context
+
+An agent driving the MCP server is handed a trace id and asked what happened in
+that trace. It reaches for `search_traces` and puts the id in `query`, because
+that is the tool whose name matches the intent. It gets back
+`No traces found matching your query.` and concludes the trace does not exist.
+The trace exists. Re-authenticating, the obvious suspect, changes nothing.
+
+Free text never matches a trace id. The search predicate
+(`getAllTracesForProject` in `platform/app/src/server/traces/clickhouse-trace.service.ts`)
+ORs exactly four things: `ComputedInput`, `ComputedOutput`, `TraceName`, and a
+correlated `EXISTS` over `stored_spans.SpanName`. `TraceId` is not among them,
+and `platform/app/src/server/filters/registry.ts` carries no `trace_id` filter
+field either, so neither the free-text nor the structured half of the tool can
+reach an id. The id would surface only by accident, if it happened to appear
+inside captured content.
+
+Two further properties turn a wrong answer into a confident one. The default
+window is the last 24 hours, applied silently in
+`mcp/typescript/src/tools/search-traces.ts` (`now - 86400000`) and never
+mentioned in the response, so a legitimate text search for an older trace is
+also a false negative. And the tip that names `get_trace` is appended only on
+the success path, so the empty result — the one moment the caller needs a
+redirect — is the one place it never prints.
+
+```
+  agent holds a trace id
+          │
+          ├── search_traces(query: "<id>")                    what it reaches for
+          │     POST /api/traces/search
+          │     WHERE ... AND (  lower(ComputedInput)  LIKE q
+          │                   OR lower(ComputedOutput) LIKE q
+          │                   OR lower(TraceName)      LIKE q
+          │                   OR EXISTS(sp.SpanName    LIKE q) )
+          │               AND OccurredAt BETWEEN now-24h AND now
+          │                   └─ TraceId is absent from the OR list,
+          │                      and the window is ANDed on top of it
+          │     -> 0 rows -> "No traces found matching your query."   dead end
+          │
+          └── get_trace(traceId: "<id>")                      the path that works
+                GET /api/traces/{id}
+                TraceService.getById(projectId, traceId, protections, opts)
+                    └─ no date range in the signature at all
+                -> the trace
+```
+
+A trace id is not free-form text that might occur in a document; it is a primary
+key. The asymmetry above is the whole bug, and it is a guidance failure at the
+tool boundary rather than a defect in the query.
+
+Two capabilities already exist and are worth naming, because the decision below
+declines to build on either. The engine and the REST boundary already accept
+`traceIds: string[]` — `sharedFiltersInputSchema` carries it, it survives into
+`getAllForProjectInput` and so into the search body schema, and the engine
+applies it as `AND ts.TraceId IN ({traceIds:Array(String)})`. The MCP tool
+simply never forwards it; neither, today, does the app's own trace list. And the
+error envelope already has a vocabulary for steering a caller: `tips: string[]`,
+rendered as a `Tips:` block by `mcp/typescript/src/langwatch-api.ts`.
+
+## Decision
+
+We will state at the tool boundary that a trace id is looked up rather than
+searched, and make the empty result carry the reader to the tool that works.
+
+`get_trace` is the sanctioned path for a known id, and its description says so.
+It is the right path for a reason the guidance can lean on: `getById` takes no
+date range, so an id lookup cannot be missed by a window. The `query` parameter
+of `search_traces` says in turn what it does not match — trace ids among them —
+so the model has the fact before it makes the call, not only after.
+
+The empty result stops being a dead end. It always names the window it actually
+searched and always names `get_trace` for a known trace id, whatever the query
+looked like. That unconditional guidance is the load-bearing half of this
+decision, because it is the half that cannot misfire.
+
+On top of it, and only on top of it, a narrow shape check adds one sentence when
+the query looks like a trace id: the OTel form `[0-9a-f]{32}`, the same with a
+`trace_` prefix, and any `trace_`-prefixed token. **The check may only ever add
+advice. It must never change what the tool does.** This is the general rule for
+the MCP surface, not a detail of this tool: `TraceId` is `String` in ClickHouse
+and `trace_id` is `z.string()` in the collector contract, so a customer's ids can
+be `order-12345` and no regex over that space can ever be sound. A heuristic that
+routed execution would silently turn a legitimate text search into a different
+operation on the day it guessed wrong; a heuristic that only ever appends a
+sentence is wrong in a way the reader can see and discard.
+
+The window disclosure is what covers the ids the shape check cannot recognise,
+which is why it prints unconditionally rather than as the heuristic's else-branch.
+
+## Rationale / Trade-offs
+
+We considered making `search_traces` do what the caller meant and route an
+id-shaped query into the id lookup. It is rejected on the soundness argument
+above: over a free-form id space the guess is unfalsifiable, and the failure is
+silent and semantic rather than visible and recoverable.
+
+We considered adding `TraceId` to the searchable columns so that pasting an id
+into free text simply works. It is rejected on blast radius. That predicate is a
+hot path shared with the product's own trace list, so the change is a product
+decision about the app's search box and not only about the MCP; the `LIKE` shape
+the other columns use is not index-friendly on an id column; and it would not
+even fix the reported problem, because the window is ANDed on top of the OR and
+an older trace would still come back empty. It buys a worse version of the fix
+at the highest price.
+
+We considered exposing the `traceIds` passthrough that the REST boundary already
+accepts. It is genuinely nearly free and it is the honest answer to "I have five
+ids", but it is not the reported problem, and it inherits the window trap: named
+ids are still ANDed with the date range, so a batch lookup of older traces
+returns nothing unless the default is also widened. Widening it is not free
+either — the code's own comment warns that locating traces by id across a wide
+window scans every partition including cold S3. It is recorded here as the
+obvious follow-up rather than smuggled into a guidance fix.
+
+We considered widening the default window generally. Rejected: it trades a
+visible wrong answer for an invisible cost, and disclosure solves the reported
+confusion without moving anyone's bill.
+
+The accepted cost is that a caller who ignores prose keeps getting an empty
+result. We are choosing to fix a model's tool selection with better words, which
+is weaker than making the wrong call impossible, and we accept that in exchange
+for not putting an unsound guess on the execution path.
+
+## Consequences
+
+An agent handed a trace id reaches `get_trace` on the first or second attempt
+instead of concluding the trace does not exist, and a human reading the
+transcript can see which window was searched rather than inferring it. Every
+empty search result grows two lines, which is a real cost paid on a path that
+previously carried no information at all.
+
+The rule that a heuristic advises but never routes now applies to the whole MCP
+tool surface, and the next tool tempted to guess at its caller's intent inherits
+it.
+
+Trace-id lookup through `search_traces` stays unavailable, deliberately.
+`traceIds` remains wired end-to-end on the server and unexposed on the client,
+so the follow-up that exposes it starts from a boundary change and a window
+decision, not from new query work.
+
+## References
+
+- Specs: `specs/mcp-server/trace-tools.feature`
+- Implementation: `mcp/typescript/src/tools/search-traces.ts`,
+  `mcp/typescript/src/create-mcp-server.ts`
+- Search predicate: `platform/app/src/server/traces/clickhouse-trace.service.ts`
+  (`getAllTracesForProject`), `platform/app/src/server/filters/registry.ts`
+- Id lookup: `platform/app/src/server/traces/trace.service.ts` (`getById`)

--- a/dev/docs/adr/132-a-trace-id-is-looked-up-never-searched.md
+++ b/dev/docs/adr/132-a-trace-id-is-looked-up-never-searched.md
@@ -50,7 +50,8 @@ Every empty search response states the exact window it searched. It also:
 - suggests the next wider window, up to 90 days.
 
 When only `endDate` is supplied, the default-width window is anchored to that
-end. An explicit `startDate` after `endDate` is rejected before the API call.
+end. Empty date values and a `startDate` at or after `endDate` are rejected
+before the API call.
 
 A narrow shape check recognises `trace_` ids and hex strings of at least eight
 characters. It may add advice to an empty result. It must never reroute the
@@ -80,7 +81,8 @@ the common path to address an id-specific problem.
 
 An agent holding one id has clear guidance to use `get_trace`. An agent holding
 several ids can fetch them through the exact filter in one paginated search.
-Empty results no longer hide the searched period.
+Empty results no longer hide the searched period. An empty batch-id result
+suggests an earlier window instead of telling the caller to pass the ids again.
 
 Free-text search by trace id remains unavailable. The product trace list also
 does not expose `traceIds`; that is outside this decision.

--- a/dev/docs/adr/132-a-trace-id-is-looked-up-never-searched.md
+++ b/dev/docs/adr/132-a-trace-id-is-looked-up-never-searched.md
@@ -6,210 +6,97 @@
 
 ## Context
 
-An agent driving the MCP server is handed a trace id and asked what happened in
-that trace. It reaches for `search_traces` and puts the id in `query`, because
-that is the tool whose name matches the intent. It gets back
-`No traces found matching your query.` and concludes the trace does not exist.
-The trace exists. Re-authenticating, the obvious suspect, changes nothing.
+An agent given a trace id is likely to call `search_traces(query: "<id>")`.
+That call returns no rows even when the trace exists. Free text searches
+captured input, captured output, the trace name and span names. It does not
+search `TraceId`, and the MCP tool previously offered no structured trace-id
+filter.
 
-Free text never matches a trace id. The search predicate
-(`getAllTracesForProject` in `platform/app/src/server/traces/clickhouse-trace.service.ts`)
-ORs exactly four things: `ComputedInput`, `ComputedOutput`, `TraceName`, and a
-correlated `EXISTS` over `stored_spans.SpanName`. `TraceId` is not among them,
-and `platform/app/src/server/filters/registry.ts` carries no `trace_id` filter
-field either, so neither the free-text nor the structured half of the tool can
-reach an id. The id would surface only by accident, if it happened to appear
-inside captured content.
+The empty response made the mistake hard to diagnose. It did not disclose the
+default 24-hour window, and the hint to use `get_trace` appeared only when rows
+were found. The product trace list defaults to 30 days, so the MCP and product
+surfaces could also disagree without saying why.
 
-Two further properties turn a wrong answer into a confident one. The default
-window is the last 24 hours, applied silently in
-`mcp/typescript/src/tools/search-traces.ts` (`now - 86400000`) and never
-mentioned in the response — the product's own trace list defaults to 30 days
-(`specs/traces-v2/search.feature`), so the two surfaces do not even agree — and
-a legitimate text search for an older trace is a false negative for the same
-reason. And the tip that names `get_trace` is appended only on the success path,
-so the empty result — the one moment the caller needs a redirect — is the one
-place it never prints.
+The storage layer already supports exact id filtering. The trace search request
+schema accepts `traceIds: string[]`, and the ClickHouse query applies
+`TraceId IN (...)`. `trace_summaries` is ordered by `(TenantId, TraceId)` and
+has trace-id bloom-filter indexes. The missing part is the MCP boundary.
 
-```
-  agent holds a trace id
-          │
-          ├── search_traces(query: "<id>")                    what it reaches for
-          │     POST /api/traces/search
-          │     WHERE ... AND (  lower(ifNull(ComputedInput,''))  LIKE '%q%'
-          │                   OR lower(ifNull(ComputedOutput,'')) LIKE '%q%'
-          │                   OR lower(ifNull(TraceName,''))      LIKE '%q%'
-          │                   OR EXISTS(lower(sp.SpanName)        LIKE '%q%') )
-          │               AND OccurredAt BETWEEN now-24h AND now
-          │                   └─ TraceId is absent from the OR list,
-          │                      and the window is ANDed on top of it
-          │     -> 0 rows -> "No traces found matching your query."   dead end
-          │
-          └── get_trace(traceId: "<id>")                      the path that works
-                GET /api/traces/{id}
-                TraceService.getById(projectId, traceId, protections, opts)
-                    ├─ exact match: getTracesWithSpans(..., occurredAt: undefined)
-                    │               unbounded, by design
-                    └─ 8..31 hex:   git-style prefix resolution, bounded to
-                                    TRACE_ID_PREFIX_LOOKUP_WINDOW_DAYS = 90
-                -> the trace
-```
+`get_trace` has two relevant behaviours:
 
-A trace id is not free-form text that might occur in a document; it is a primary
-key — in `trace_summaries` quite literally, since that table is
-`ORDER BY (TenantId, TraceId)`. The asymmetry above is the whole bug, and it is
-a guidance failure at the tool boundary rather than a defect in the query.
+- A complete id is tried as an exact lookup without a time window.
+- An 8-31 character hex id is treated as a possible prefix and resolved within
+  the last 90 days. This bound prevents a miss from scanning every weekly
+  ClickHouse partition, including cold storage.
 
-The storage layer is emphatically not the obstacle. `trace_summaries` carries
-`INDEX idx_trace_id TraceId TYPE bloom_filter(0.001)` and
-`INDEX idx_tenant_trace (TenantId, TraceId) TYPE bloom_filter(0.001)` on top of
-the sort key; `stored_spans` carries bloom filters on `TraceId`, `SpanId`,
-`(TenantId, TraceId)` and `(TenantId, TraceId, SpanId)`
-(`platform/app/src/server/clickhouse/migrations/00002_create_schema.sql`). An
-equality or `IN` match on a trace id is the cheapest shape these tables support.
-
-Two capabilities already exist. The engine and the REST boundary already accept
-`traceIds: string[]` — `sharedFiltersInputSchema` carries it, it survives into
-`getAllForProjectInput` and so into the search body schema, and the engine
-applies it as `AND ts.TraceId IN ({traceIds:Array(String)})`, which lands
-directly on the sort key. The MCP tool simply never forwards it; neither, today,
-does the app's own trace list. And the error envelope already has a vocabulary
-for steering a caller: `tips: string[]`, rendered as a `Tips:` block by
-`mcp/typescript/src/langwatch-api.ts`.
-
-The repo has also already ruled, twice, that an empty result must not be able to
-stand in for "you asked wrongly": `specs/traces-v2/sessions-lens.feature`
-("A failed read is told as a failure, not as an empty result") and
-`specs/langy/langy-cli-tool-envelope.feature` ("A rejected command is never read
-as an empty result"), the latter written after an agent read a rejected command
-as "no results" and reported that as a count. This ADR is the third instance of
-that rule, on the MCP surface.
+Trace ids remain free-form strings. Values such as `order-12345` are valid, so
+no shape check can reliably identify every trace id.
 
 ## Decision
 
-We will state at the tool boundary that a trace id is looked up rather than
-searched, make the empty result carry the reader to the tool that works, and
-expose the exact-match id filter the server already implements.
+`get_trace` is the primary tool for one known trace id. Its tool and parameter
+descriptions state the difference between an unbounded exact lookup and a
+90-day prefix lookup.
 
-`get_trace` is the sanctioned path for a single id, and its description says so.
-An exact full id resolves unbounded there, so it cannot be missed by a date
-window. A truncated hex id of 8 to 31 characters resolves git-style within the
-last 90 days (`TRACE_ID_PREFIX_LOOKUP_WINDOW_DAYS`), which is a window, and the
-guidance says so rather than promising more than the code does. The `query`
-parameter of `search_traces` says in turn what it does not match — trace ids
-among them — so the model has the fact before it makes the call.
+`search_traces` exposes the existing `traceIds` request field for batch lookup.
+The MCP input accepts between 1 and 1,000 non-empty ids. When ids are supplied
+without dates, the search defaults to the last 90 days. Ordinary text search
+keeps its 24-hour default.
 
-`search_traces` gains a `traceIds: string[]` passthrough for the batch case,
-forwarded to the field the REST boundary already accepts. When `traceIds` is
-supplied and the caller named no dates, the window defaults to 90 days rather
-than 24 hours, reusing the bound prefix resolution already justifies, and the
-response states the window it used. Naming ids is an exact-match intent, and
-answering it against yesterday only is a false negative by construction.
+Every empty search response states the exact window it searched. It also:
 
-The empty result stops being a dead end. It always names the window it actually
-searched and always names `get_trace` for a known trace id, whatever the query
-looked like. That unconditional guidance is the load-bearing half of this
-decision, because it is the half that cannot misfire.
+- directs a caller with one known id to `get_trace`;
+- directs a caller with several ids to `traceIds`; and
+- suggests the next wider window, up to 90 days.
 
-On top of it, and only on top of it, a shape check adds one sentence when the
-query looks like a trace id. It reuses the vocabulary the trace service already
-exports rather than inventing a second one — `HEX_ONLY`,
-`MIN_TRACE_ID_PREFIX_LENGTH` (8) and `FULL_TRACE_ID_LENGTH` (32) from
-`platform/app/src/server/traces/trace.service.ts` — so a hex string of 8 or more
-characters is recognised, which covers the truncated ids the CLI itself produces
-by printing 20 characters in its table. `trace_`-prefixed ids, the form the
-collector accepts, are recognised alongside them. **The check may only ever add
-advice. It must never change what the tool does.** This is the general rule for
-the MCP surface, not a detail of this tool: `TraceId` is `String` in ClickHouse
-and `trace_id` is `z.string()` in the collector contract, so a customer's ids can
-be `order-12345` and no regex over that space can ever be sound. It is the same
-principle ADR-079 settled for card selection — what a deterministic path can
-decide is not handed to a non-deterministic oracle — applied to tool routing
-rather than presentation.
+When only `endDate` is supplied, the default-width window is anchored to that
+end. An explicit `startDate` after `endDate` is rejected before the API call.
 
-The window disclosure is what covers the ids the shape check cannot recognise,
-which is why it prints unconditionally rather than as the heuristic's else-branch.
+A narrow shape check recognises `trace_` ids and hex strings of at least eight
+characters. It may add advice to an empty result. It must never reroute the
+request, because custom trace ids make that guess unsound.
 
 ## Rationale / Trade-offs
 
-We considered making `search_traces` route an id-shaped query into the id
-lookup. It is rejected on the soundness argument above: over a free-form id space
-the guess is unfalsifiable, and the failure is silent and semantic rather than
-visible and recoverable.
+Adding `TraceId` to the free-text predicate was rejected. Free text compiles to
+a case-insensitive substring search, while trace ids already have an exact
+`IN` path. Mixing the id into the text OR-list would turn a cheap exact filter
+into a scan and would still be constrained by the date window.
 
-We considered adding `TraceId` to the free-text searchable columns so that
-pasting an id into `query` simply works. It is rejected, but not for the reason
-it first appears: the column is superbly indexed, so "ids are not indexed" would
-be false. The obstacle is the shape of the free-text predicate. The term is built
-as `` `%${q}%` `` and applied as `lower(ifNull(col,'')) LIKE {searchQuery}`, and
-a bloom filter answers exact membership rather than substring containment, while
-the `lower(ifNull(...))` wrapper stops the expression matching any indexed
-expression in any case. So an id ORed into that list would scan where an `IN`
-would seek — a strictly worse mechanism for a job the sort key already does
-perfectly. It is also a hot path shared with the product's own trace list, so
-changing it is a product decision about the app's search box rather than an MCP
-fix, and it would still be ANDed with the window and so still miss an older
-trace.
+Automatically routing id-shaped queries to `get_trace` was also rejected.
+`TraceId` is a free-form string in storage and the collector contract, so a
+regex can only offer a hint. It cannot decide which tool the caller intended.
 
-Exposing `traceIds` instead is the honest version of that idea and is nearly
-free, which is why it is in scope rather than deferred: `WHERE TenantId = x AND
-TraceId IN (...)` is a primary-key seek.
+Batch id lookup remains windowed. An unbounded query would seek within every
+weekly partition, including old partitions on S3. Ninety days matches the cost
+already accepted for prefix resolution and covers the copied-recent-id use
+case. The response and parameter descriptions disclose the bound.
 
-The cost that does exist is partition pruning, not indexing. `trace_summaries`
-is `PARTITION BY toYearWeek(OccurredAt)`, so an id lookup with no date predicate
-is a fast seek *within* each partition but must open every weekly partition,
-including cold ones on S3 — exactly what the `resolveTraceIdByPrefix` comment
-warns about and exactly why prefix resolution bounds itself to 90 days. Defaulting
-the id path to that same 90 days, rather than to 24 hours or to unbounded, buys
-the recent-trace case that motivates this ADR at a cost the repo has already
-accepted once, and the disclosure line means nobody has to guess which it was.
-
-We considered widening the default window for ordinary text search too. Rejected:
-it trades a visible wrong answer for an invisible cost across every search, and
-disclosure solves the reported confusion without moving anyone's bill.
-
-The accepted cost is that a caller who ignores prose keeps getting an empty
-result. We are choosing to fix a model's tool selection with better words, which
-is weaker than making the wrong call impossible, and we accept that in exchange
-for not putting an unsound guess on the execution path.
+The two default windows are deliberate: 24 hours for content search and 90 days
+for named ids. Widening every content search would increase ClickHouse work on
+the common path to address an id-specific problem.
 
 ## Consequences
 
-An agent handed a trace id reaches `get_trace` on the first or second attempt
-instead of concluding the trace does not exist, and a human reading the
-transcript can see which window was searched rather than inferring it. An agent
-holding several ids can ask for them in one call. Every empty search result grows
-two lines, which is a real cost paid on a path that previously carried no
-information at all.
+An agent holding one id has clear guidance to use `get_trace`. An agent holding
+several ids can fetch them through the exact filter in one paginated search.
+Empty results no longer hide the searched period.
 
-`search_traces` now has two windowing defaults — 24 hours for a text search, 90
-days when ids are named — which is a wart justified only by the two being
-different intents. The response says which one it used, so the wart is visible
-rather than silent, and that disclosure is what keeps it honest.
+Free-text search by trace id remains unavailable. The product trace list also
+does not expose `traceIds`; that is outside this decision.
 
-The rule that a heuristic advises but never routes now applies to the whole MCP
-tool surface, and the next tool tempted to guess at its caller's intent inherits
-it.
-
-Free-text search by trace id stays unavailable, deliberately. The app's own trace
-list still does not expose `traceIds`, so the same affordance is a candidate
-there; this ADR does not decide it.
+The id-shape vocabulary is duplicated between the standalone MCP package and
+the platform trace service. Changes to the server's prefix rules must update
+the MCP hint as well.
 
 ## References
 
-- Related ADRs: ADR-079 (card selection is deterministic — the precedent for
-  "advice never routes")
-- Specs: `specs/mcp-server/trace-tools.feature`,
-  `specs/traces/partial-trace-id-resolution.feature` (owns `GET /api/traces/{id}`
-  prefix semantics), `specs/traces-v2/search.feature` (the app's 30-day default),
-  `specs/traces-v2/sessions-lens.feature` and
-  `specs/langy/langy-cli-tool-envelope.feature` (an empty result never stands in
-  for a failure)
-- Implementation: `mcp/typescript/src/tools/search-traces.ts`,
-  `mcp/typescript/src/create-mcp-server.ts`
-- Search predicate: `platform/app/src/server/traces/clickhouse-trace.service.ts`
-  (`getAllTracesForProject`), `platform/app/src/server/filters/registry.ts`
-- Id lookup and shape vocabulary: `platform/app/src/server/traces/trace.service.ts`
-  (`getById`, `HEX_ONLY`, `MIN_TRACE_ID_PREFIX_LENGTH`, `FULL_TRACE_ID_LENGTH`,
-  `TRACE_ID_PREFIX_LOOKUP_WINDOW_DAYS`)
-- Schema: `platform/app/src/server/clickhouse/migrations/00002_create_schema.sql`
+- ADR-079: card selection is deterministic
+- `specs/mcp-server/trace-tools.feature`
+- `specs/traces/partial-trace-id-resolution.feature`
+- `specs/traces-v2/search.feature`
+- `mcp/typescript/src/tools/search-traces.ts`
+- `mcp/typescript/src/create-mcp-server.ts`
+- `platform/app/src/server/traces/trace.service.ts`
+- `platform/app/src/server/traces/clickhouse-trace.service.ts`
+- `platform/app/src/server/clickhouse/migrations/00002_create_schema.sql`

--- a/mcp/typescript/src/__tests__/all-tools.integration.test.ts
+++ b/mcp/typescript/src/__tests__/all-tools.integration.test.ts
@@ -1075,6 +1075,22 @@ describe("All MCP tools integration", () => {
     });
 
     describe("when trace ids are named", () => {
+      /** @scenario An empty batch id lookup gives advice for that request */
+      it("suggests an earlier window instead of repeating traceIds guidance", async () => {
+        const { handleSearchTraces } = await import(
+          "../tools/search-traces.js"
+        );
+        const result = await handleSearchTraces({
+          traceIds: ["unknown-trace-id"],
+        });
+
+        expect(result).toContain(
+          "No traces matched the requested trace ids in the searched window.",
+        );
+        expect(result).toContain("Retry with an earlier startDate");
+        expect(result).not.toContain("pass `traceIds`");
+      });
+
       /** @scenario Agent looks up several traces by id in one call */
       it("fetches exactly those traces in one call", async () => {
         const { handleSearchTraces } = await import(

--- a/mcp/typescript/src/__tests__/all-tools.integration.test.ts
+++ b/mcp/typescript/src/__tests__/all-tools.integration.test.ts
@@ -36,6 +36,25 @@ const CANNED_TRACES_SEARCH = {
   pagination: { totalHits: 1 },
 };
 
+/**
+ * Traces addressable by exact id, for the `traceIds` path. The ids are the
+ * bare-hex form the platform's own fixtures and prefix resolver use.
+ */
+const CANNED_TRACES_BY_ID = [
+  {
+    trace_id: "63dc535cea6335c506bc81ef3543a07d",
+    formatted_trace: "Root [server] 900ms",
+    input: { value: "First by id" },
+    output: { value: "First out" },
+  },
+  {
+    trace_id: "a3c6656cf433e97549f654034be02955",
+    formatted_trace: "Root [server] 300ms",
+    input: { value: "Second by id" },
+    output: { value: "Second out" },
+  },
+];
+
 const CANNED_TRACES_SEARCH_WITH_SCROLL = {
   traces: [
     {
@@ -397,10 +416,35 @@ function createMockServer(): Server {
       // --- Trace endpoints ---
       if (url === "/api/traces/search" && method === "POST") {
         const parsed = JSON.parse(body);
-        // Return empty results when a special query is used
-        if (parsed.query === "__empty__") {
+        // Exact-id fetches answer from the addressable pool, mirroring the
+        // engine's `TraceId IN (...)` predicate.
+        if (Array.isArray(parsed.traceIds) && parsed.traceIds.length > 0) {
+          const wanted = new Set<string>(parsed.traceIds);
+          const found = CANNED_TRACES_BY_ID.filter((t) =>
+            wanted.has(t.trace_id)
+          );
           res.writeHead(200);
-          res.end(JSON.stringify(CANNED_TRACES_EMPTY));
+          res.end(
+            JSON.stringify({
+              traces: found,
+              pagination: { totalHits: found.length },
+            })
+          );
+        } else if (
+          typeof parsed.query === "string" &&
+          parsed.query.length > 0
+        ) {
+          // Free text matches captured content only — the same reason a trace
+          // id never matches in production. A query that appears nowhere in the
+          // canned content comes back empty, "__empty__" included.
+          const haystack = JSON.stringify(
+            CANNED_TRACES_SEARCH.traces
+          ).toLowerCase();
+          const hit = haystack.includes(parsed.query.toLowerCase());
+          res.writeHead(200);
+          res.end(
+            JSON.stringify(hit ? CANNED_TRACES_SEARCH : CANNED_TRACES_EMPTY)
+          );
         } else if (parsed.pageSize === 5) {
           res.writeHead(200);
           res.end(JSON.stringify(CANNED_TRACES_SEARCH_WITH_SCROLL));
@@ -902,7 +946,8 @@ describe("All MCP tools integration", () => {
     });
 
     describe("when no traces match", () => {
-      it("returns a no-results message", async () => {
+      /** @scenario A search that matches nothing says which window it searched */
+      it("states the window it searched and names get_trace", async () => {
         const { handleSearchTraces } = await import(
           "../tools/search-traces.js"
         );
@@ -910,7 +955,126 @@ describe("All MCP tools integration", () => {
           query: "__empty__",
         });
 
-        expect(result).toBe("No traces found matching your query.");
+        expect(result).toContain("No traces found matching your query.");
+        expect(result).toContain("Searched the last 24 hours");
+        expect(result).toContain("get_trace");
+      });
+
+      /** @scenario An empty search offers a wider window */
+      it("offers a wider startDate and the units it accepts", async () => {
+        const { handleSearchTraces } = await import(
+          "../tools/search-traces.js"
+        );
+        const result = await handleSearchTraces({
+          query: "__empty__",
+        });
+
+        expect(result).toContain('startDate: "7d"');
+        expect(result).toContain("w (weeks)");
+      });
+
+      /** @scenario A trace id in a format the shape check cannot recognise still gets guidance */
+      it("still names get_trace for a customer-assigned id it cannot recognise", async () => {
+        const { handleSearchTraces } = await import(
+          "../tools/search-traces.js"
+        );
+        const result = await handleSearchTraces({ query: "order-12345" });
+
+        expect(result).toContain("No traces found matching your query.");
+        expect(result).toContain("get_trace");
+        // The shape check does not claim this one; the unconditional guidance
+        // is what carries it.
+        expect(result).not.toContain("looks like a trace id");
+      });
+    });
+
+    describe("when the query looks like a trace id", () => {
+      /** @scenario Agent pastes a trace id into the search query */
+      it("says it looks like a trace id and points at get_trace", async () => {
+        const { handleSearchTraces } = await import(
+          "../tools/search-traces.js"
+        );
+        const result = await handleSearchTraces({
+          query: "63dc535cea6335c506bc81ef3543a07d",
+        });
+
+        expect(result).toContain("No traces found matching your query.");
+        expect(result).toContain("looks like a trace id");
+        expect(result).toContain(
+          'get_trace` with traceId: "63dc535cea6335c506bc81ef3543a07d"'
+        );
+      });
+
+      /** @scenario A trace id truncated by the CLI is still recognised as an id */
+      it("recognises a 20-character truncation the CLI prints", async () => {
+        const { handleSearchTraces } = await import(
+          "../tools/search-traces.js"
+        );
+        const result = await handleSearchTraces({
+          query: "63dc535cea6335c506bc",
+        });
+
+        expect(result).toContain("looks like a trace id");
+      });
+
+      /** @scenario An id-shaped query is still executed as a search */
+      it("still executes a search and never a single-trace lookup", async () => {
+        const { handleSearchTraces } = await import(
+          "../tools/search-traces.js"
+        );
+        delete lastRequests["GET /api/traces/63dc535cea6335c506bc81ef3543a07d"];
+
+        await handleSearchTraces({
+          query: "63dc535cea6335c506bc81ef3543a07d",
+        });
+
+        const search = lastRequests["POST /api/traces/search"];
+        expect(search).toBeDefined();
+        expect(JSON.parse(search!.body).query).toBe(
+          "63dc535cea6335c506bc81ef3543a07d"
+        );
+        expect(
+          lastRequests["GET /api/traces/63dc535cea6335c506bc81ef3543a07d"]
+        ).toBeUndefined();
+      });
+    });
+
+    describe("when trace ids are named", () => {
+      /** @scenario Agent looks up several traces by id in one call */
+      it("fetches exactly those traces in one call", async () => {
+        const { handleSearchTraces } = await import(
+          "../tools/search-traces.js"
+        );
+        const result = await handleSearchTraces({
+          traceIds: [
+            "63dc535cea6335c506bc81ef3543a07d",
+            "a3c6656cf433e97549f654034be02955",
+          ],
+        });
+
+        expect(result).toContain("63dc535cea6335c506bc81ef3543a07d");
+        expect(result).toContain("a3c6656cf433e97549f654034be02955");
+        expect(result).toContain("Found 2 traces");
+      });
+
+      /** @scenario Naming trace ids widens the default window past 24 hours */
+      it("defaults the window to 90 days instead of 24 hours", async () => {
+        const { handleSearchTraces } = await import(
+          "../tools/search-traces.js"
+        );
+        await handleSearchTraces({
+          traceIds: ["63dc535cea6335c506bc81ef3543a07d"],
+        });
+
+        const req = lastRequests["POST /api/traces/search"];
+        const parsed = JSON.parse(req!.body);
+        const spanDays =
+          (parsed.endDate - parsed.startDate) / (24 * 60 * 60 * 1000);
+
+        expect(parsed.traceIds).toEqual([
+          "63dc535cea6335c506bc81ef3543a07d",
+        ]);
+        expect(spanDays).toBeCloseTo(90, 0);
       });
     });
 

--- a/mcp/typescript/src/__tests__/all-tools.integration.test.ts
+++ b/mcp/typescript/src/__tests__/all-tools.integration.test.ts
@@ -11,6 +11,7 @@ import {
   getAgent,
   updateAgent,
 } from "../langwatch-api-agents.js";
+import { handleSearchTraces } from "../tools/search-traces.js";
 
 // --- Canned responses for every API endpoint ---
 
@@ -1075,11 +1076,8 @@ describe("All MCP tools integration", () => {
     });
 
     describe("when trace ids are named", () => {
-      /** @scenario An empty batch id lookup gives advice for that request */
+      /** @scenario "An empty batch id lookup gives advice for that request" */
       it("suggests an earlier window instead of repeating traceIds guidance", async () => {
-        const { handleSearchTraces } = await import(
-          "../tools/search-traces.js"
-        );
         const result = await handleSearchTraces({
           traceIds: ["unknown-trace-id"],
         });

--- a/mcp/typescript/src/__tests__/all-tools.integration.test.ts
+++ b/mcp/typescript/src/__tests__/all-tools.integration.test.ts
@@ -1,5 +1,6 @@
 import { createServer, type Server } from "http";
 import { afterAll, beforeAll, describe, expect, it, vi, beforeEach } from "vitest";
+import { z } from "zod";
 import { initConfig } from "../config.js";
 import {
   fetchDocumentation,
@@ -18,9 +19,9 @@ const CANNED_TRACES_SEARCH = {
     {
       trace_id: "trace-001",
       formatted_trace:
-        "Root [server] 1200ms\n  LLM Call [llm] 500ms\n    Input: Hello, how are you?\n    Output: I am fine, thank you!",
-      input: { value: "Hello, how are you?" },
-      output: { value: "I am fine, thank you!" },
+        "Root [server] 1200ms\n  LLM Call [llm] 500ms\n    Input: Login error while authenticating\n    Output: Please try again",
+      input: { value: "Login error while authenticating" },
+      output: { value: "Please try again" },
       timestamps: { started_at: 1700000000000 },
       metadata: { user_id: "user-42", thread_id: "thread-1" },
       evaluations: [
@@ -383,6 +384,13 @@ const CANNED_MODEL_PROVIDER_SET = {
 
 /** Track last request for each route so tests can assert on request body/params. */
 const lastRequests: Record<string, { method: string; url: string; body: string }> = {};
+
+const traceSearchRequestSchema = z.object({
+  query: z.string().optional(),
+  traceIds: z.array(z.string()).optional(),
+  startDate: z.number(),
+  endDate: z.number(),
+});
 
 /**
  * Mutable prompt detail so the mock is stateful: a PUT updates it and the
@@ -935,13 +943,20 @@ describe("All MCP tools integration", () => {
           "../tools/search-traces.js"
         );
         const result = await handleSearchTraces({
-          startDate: "24h",
-          endDate: "now",
+          query: "login error",
         });
 
         expect(result).toContain("trace-001");
         expect(result).toContain("LLM Call [llm] 500ms");
+        expect(result).toContain("Input: Login error while authenticating");
+        expect(result).toContain("Output: Please try again");
+        expect(result).toContain("**Time**: 1700000000000");
         expect(result).toContain("1 trace");
+
+        const req = lastRequests["POST /api/traces/search"];
+        const parsed = traceSearchRequestSchema.parse(JSON.parse(req!.body));
+        expect(parsed.query).toBe("login error");
+        expect(parsed.endDate - parsed.startDate).toBe(24 * 60 * 60 * 1000);
       });
     });
 
@@ -958,6 +973,8 @@ describe("All MCP tools integration", () => {
         expect(result).toContain("No traces found matching your query.");
         expect(result).toContain("Searched the last 24 hours");
         expect(result).toContain("get_trace");
+        expect(result).toContain("8–31 character hex prefix");
+        expect(result).toContain("last 90 days");
       });
 
       /** @scenario An empty search offers a wider window */
@@ -971,6 +988,23 @@ describe("All MCP tools integration", () => {
 
         expect(result).toContain('startDate: "7d"');
         expect(result).toContain("w (weeks)");
+      });
+
+      /** @scenario An end-only search anchors its default window to that end */
+      it("anchors the default start to an explicit end", async () => {
+        const { handleSearchTraces } = await import(
+          "../tools/search-traces.js"
+        );
+
+        await handleSearchTraces({
+          endDate: "2026-08-01T12:00:00Z",
+        });
+
+        const req = lastRequests["POST /api/traces/search"];
+        const parsed = traceSearchRequestSchema.parse(JSON.parse(req!.body));
+
+        expect(parsed.endDate).toBe(Date.parse("2026-08-01T12:00:00Z"));
+        expect(parsed.endDate - parsed.startDate).toBe(24 * 60 * 60 * 1000);
       });
 
       /** @scenario A trace id in a format the shape check cannot recognise still gets guidance */
@@ -1030,9 +1064,10 @@ describe("All MCP tools integration", () => {
 
         const search = lastRequests["POST /api/traces/search"];
         expect(search).toBeDefined();
-        expect(JSON.parse(search!.body).query).toBe(
-          "63dc535cea6335c506bc81ef3543a07d"
+        const requestBody = traceSearchRequestSchema.parse(
+          JSON.parse(search!.body)
         );
+        expect(requestBody.query).toBe("63dc535cea6335c506bc81ef3543a07d");
         expect(
           lastRequests["GET /api/traces/63dc535cea6335c506bc81ef3543a07d"]
         ).toBeUndefined();
@@ -1067,7 +1102,7 @@ describe("All MCP tools integration", () => {
         });
 
         const req = lastRequests["POST /api/traces/search"];
-        const parsed = JSON.parse(req!.body);
+        const parsed = traceSearchRequestSchema.parse(JSON.parse(req!.body));
         const spanDays =
           (parsed.endDate - parsed.startDate) / (24 * 60 * 60 * 1000);
 

--- a/mcp/typescript/src/__tests__/tools.integration.test.ts
+++ b/mcp/typescript/src/__tests__/tools.integration.test.ts
@@ -250,6 +250,14 @@ describe("handleSearchTraces()", () => {
       ).rejects.toThrow("must be before endDate");
       expect(mockSearchTraces).not.toHaveBeenCalled();
     });
+
+    /** @scenario An empty date input fails before the API call */
+    it("rejects an empty date before calling the API", async () => {
+      await expect(handleSearchTraces({ startDate: "" })).rejects.toThrow(
+        'Invalid date: ""',
+      );
+      expect(mockSearchTraces).not.toHaveBeenCalled();
+    });
   });
 
   describe("when pageSize is specified", () => {

--- a/mcp/typescript/src/__tests__/tools.integration.test.ts
+++ b/mcp/typescript/src/__tests__/tools.integration.test.ts
@@ -194,12 +194,14 @@ describe("handleSearchTraces()", () => {
   });
 
   describe("when no traces are found", () => {
-    it("returns a no-results message", async () => {
+    it("returns a no-results message that names the window and get_trace", async () => {
       mockSearchTraces.mockResolvedValue({ traces: [] });
 
       const result = await handleSearchTraces({});
 
-      expect(result).toBe("No traces found matching your query.");
+      expect(result).toContain("No traces found matching your query.");
+      expect(result).toContain("Searched the last 24 hours");
+      expect(result).toContain("get_trace");
     });
   });
 

--- a/mcp/typescript/src/__tests__/tools.integration.test.ts
+++ b/mcp/typescript/src/__tests__/tools.integration.test.ts
@@ -216,6 +216,40 @@ describe("handleSearchTraces()", () => {
       expect(call.endDate).toBeTypeOf("number");
       expect(call.startDate).toBeLessThan(call.endDate);
     });
+
+    it("anchors a default 24-hour window to an explicit end date", async () => {
+      mockSearchTraces.mockResolvedValue({ traces: [] });
+
+      await handleSearchTraces({ endDate: "2026-08-01T12:00:00Z" });
+
+      const call = mockSearchTraces.mock.calls[0]![0] as {
+        startDate: number;
+        endDate: number;
+      };
+      expect(call.endDate).toBe(Date.parse("2026-08-01T12:00:00Z"));
+      expect(call.endDate - call.startDate).toBe(24 * 60 * 60 * 1000);
+    });
+
+    /** @scenario An inverted search window fails before the API call */
+    it("rejects an inverted window before calling the API", async () => {
+      await expect(
+        handleSearchTraces({
+          startDate: "2026-08-02T12:00:00Z",
+          endDate: "2026-08-01T12:00:00Z",
+        }),
+      ).rejects.toThrow("startDate");
+      expect(mockSearchTraces).not.toHaveBeenCalled();
+    });
+
+    it("rejects an empty window before calling the API", async () => {
+      await expect(
+        handleSearchTraces({
+          startDate: "2026-08-01T12:00:00Z",
+          endDate: "2026-08-01T12:00:00Z",
+        }),
+      ).rejects.toThrow("must be before endDate");
+      expect(mockSearchTraces).not.toHaveBeenCalled();
+    });
   });
 
   describe("when pageSize is specified", () => {

--- a/mcp/typescript/src/__tests__/tools.integration.test.ts
+++ b/mcp/typescript/src/__tests__/tools.integration.test.ts
@@ -251,7 +251,7 @@ describe("handleSearchTraces()", () => {
       expect(mockSearchTraces).not.toHaveBeenCalled();
     });
 
-    /** @scenario An empty date input fails before the API call */
+    /** @scenario "An empty date input fails before the API call" */
     it("rejects an empty date before calling the API", async () => {
       await expect(handleSearchTraces({ startDate: "" })).rejects.toThrow(
         'Invalid date: ""',

--- a/mcp/typescript/src/create-mcp-server.ts
+++ b/mcp/typescript/src/create-mcp-server.ts
@@ -268,7 +268,7 @@ function registerTools(server: McpServer): void {
       traceId: z
         .string()
         .describe(
-          "The trace ID to retrieve. A full ID resolves at any age; a unique hex prefix of 8 or more characters also resolves, git-style, within the last 90 days."
+          "The trace ID to retrieve. A full ID resolves at any age; a unique 8–31 character hex prefix also resolves, git-style, within the last 90 days."
         ),
       format: z
         .enum(["digest", "json"])

--- a/mcp/typescript/src/create-mcp-server.ts
+++ b/mcp/typescript/src/create-mcp-server.ts
@@ -229,12 +229,14 @@ function registerTools(server: McpServer): void {
         ),
       startDate: z
         .string()
+        .min(1)
         .optional()
         .describe(
           'Start of the window: ISO date, or relative like "24h", "7d", "4w", "3m" — units are h (hours), d (days), w (weeks), m (30-day months). Defaults to 24h ago for a text search, or 90d when traceIds is set. Widen this when a search comes back empty.'
         ),
       endDate: z
         .string()
+        .min(1)
         .optional()
         .describe("End of the window: ISO date or relative. Default: now"),
       pageSize: z

--- a/mcp/typescript/src/create-mcp-server.ts
+++ b/mcp/typescript/src/create-mcp-server.ts
@@ -205,9 +205,20 @@ function registerTools(server: McpServer): void {
 
   server.tool(
     "search_traces",
-    "Search LangWatch traces with filters, text query, and date range. Returns AI-readable trace digests by default. Use format: 'json' for full raw data.",
+    "Search LangWatch traces by content, with filters and a date range. Returns AI-readable trace digests by default. Use format: 'json' for full raw data. To fetch a trace you already have the ID for, use get_trace instead — free text does not match trace IDs.",
     {
-      query: z.string().optional().describe("Text search query"),
+      query: z
+        .string()
+        .optional()
+        .describe(
+          "Text search query. Matches captured input/output, the trace name and span names ONLY. It does not match trace IDs — to fetch a known trace ID use get_trace, or pass traceIds here for several at once."
+        ),
+      traceIds: z
+        .array(z.string())
+        .optional()
+        .describe(
+          "Exact trace IDs to fetch. Use instead of query when you already know the IDs. When set and no startDate is given, the window defaults to the last 90 days rather than 24 hours."
+        ),
       filters: z
         .record(z.string(), z.array(z.string()))
         .optional()
@@ -218,12 +229,12 @@ function registerTools(server: McpServer): void {
         .string()
         .optional()
         .describe(
-          'Start date: ISO string or relative like "24h", "7d", "30d". Default: 24h ago'
+          'Start of the window: ISO date, or relative like "24h", "7d", "4w", "3m" — units are h (hours), d (days), w (weeks), m (30-day months). Defaults to 24h ago for a text search, or 90d when traceIds is set. Widen this when a search comes back empty.'
         ),
       endDate: z
         .string()
         .optional()
-        .describe("End date: ISO string or relative. Default: now"),
+        .describe("End of the window: ISO date or relative. Default: now"),
       pageSize: z
         .number()
         .optional()
@@ -250,9 +261,13 @@ function registerTools(server: McpServer): void {
 
   server.tool(
     "get_trace",
-    "Get full details of a single trace by ID. Returns AI-readable trace digest by default. Use format: 'json' for full raw data including all spans.",
+    "Get full details of a single trace by ID. This is the right tool whenever you have a trace ID — search_traces does not match IDs. Applies no time window, so it finds a trace of any age. Returns AI-readable trace digest by default. Use format: 'json' for full raw data including all spans.",
     {
-      traceId: z.string().describe("The trace ID to retrieve"),
+      traceId: z
+        .string()
+        .describe(
+          "The trace ID to retrieve. A full ID resolves at any age; a unique hex prefix of 8 or more characters also resolves, git-style, within the last 90 days."
+        ),
       format: z
         .enum(["digest", "json"])
         .optional()

--- a/mcp/typescript/src/create-mcp-server.ts
+++ b/mcp/typescript/src/create-mcp-server.ts
@@ -214,10 +214,12 @@ function registerTools(server: McpServer): void {
           "Text search query. Matches captured input/output, the trace name and span names ONLY. It does not match trace IDs — to fetch a known trace ID use get_trace, or pass traceIds here for several at once."
         ),
       traceIds: z
-        .array(z.string())
+        .array(z.string().min(1))
+        .min(1)
+        .max(1000)
         .optional()
         .describe(
-          "Exact trace IDs to fetch. Use instead of query when you already know the IDs. When set and no startDate is given, the window defaults to the last 90 days rather than 24 hours."
+          "Exact trace IDs to fetch (1–1000). Use instead of query when you already know the IDs. When set and no startDate is given, the window defaults to the last 90 days rather than 24 hours."
         ),
       filters: z
         .record(z.string(), z.array(z.string()))
@@ -261,7 +263,7 @@ function registerTools(server: McpServer): void {
 
   server.tool(
     "get_trace",
-    "Get full details of a single trace by ID. This is the right tool whenever you have a trace ID — search_traces does not match IDs. Applies no time window, so it finds a trace of any age. Returns AI-readable trace digest by default. Use format: 'json' for full raw data including all spans.",
+    "Get full details of a single trace by ID. This is the right tool whenever you have a trace ID — search_traces does not match IDs. A full ID resolves at any age; a unique 8–31 character hex prefix resolves within the last 90 days. Returns AI-readable trace digest by default. Use format: 'json' for full raw data including all spans.",
     {
       traceId: z
         .string()

--- a/mcp/typescript/src/langwatch-api.ts
+++ b/mcp/typescript/src/langwatch-api.ts
@@ -338,6 +338,13 @@ export async function makeRequest(
  */
 export async function searchTraces(params: {
   query?: string;
+  /**
+   * Exact trace ids. Lands on `trace_summaries`' `(TenantId, TraceId)` sort key
+   * as an `IN` predicate, so it is a primary-key seek rather than a scan — the
+   * cheapest shape the table supports. The REST boundary already accepted this
+   * field; only the tool never forwarded it (ADR-132).
+   */
+  traceIds?: string[];
   filters?: Record<string, string[]>;
   startDate: number;
   endDate: number;

--- a/mcp/typescript/src/tools/search-traces.ts
+++ b/mcp/typescript/src/tools/search-traces.ts
@@ -1,16 +1,103 @@
 import { searchTraces as apiSearchTraces } from "../langwatch-api.js";
 import { parseRelativeDate } from "../utils/date-parsing.js";
 import { formatEvaluationLines } from "../utils/format-evaluations.js";
+import { looksLikeTraceId } from "../utils/trace-id-shape.js";
+
+const HOUR_MS = 3600000;
+const DAY_MS = 86400000;
+
+/** Default window for a text search. */
+const TEXT_SEARCH_WINDOW_MS = DAY_MS;
+
+/**
+ * Default window when the caller names trace ids. Naming ids is an exact-match
+ * intent, so answering it against yesterday alone is a false negative by
+ * construction. 90 days mirrors the platform's
+ * `TRACE_ID_PREFIX_LOOKUP_WINDOW_DAYS` — the bound its own id resolution
+ * already accepts, chosen because `trace_summaries` is
+ * `PARTITION BY toYearWeek(OccurredAt)`, so an unbounded id lookup opens every
+ * weekly partition including cold storage on S3 (ADR-132).
+ */
+const ID_LOOKUP_WINDOW_MS = 90 * DAY_MS;
+
+function describeSpan(ms: number): string {
+  if (ms % DAY_MS === 0) {
+    const days = ms / DAY_MS;
+    return days === 1 ? "24 hours" : `${days} days`;
+  }
+  const hours = Math.round(ms / HOUR_MS);
+  return hours === 1 ? "1 hour" : `${hours} hours`;
+}
+
+/** The next sensible window to offer, or undefined once the span is already wide. */
+function suggestWiderWindow(spanMs: number): string | undefined {
+  if (spanMs < 7 * DAY_MS) return "7d";
+  if (spanMs < 30 * DAY_MS) return "30d";
+  if (spanMs < 90 * DAY_MS) return "90d";
+  return undefined;
+}
+
+/**
+ * An empty result is the one moment the caller needs a redirect, and it used to
+ * be the one place that carried none — the tip naming `get_trace` printed only
+ * on the success path. It now always states the window it searched and always
+ * names the tool that looks an id up, whatever the query looked like; the
+ * id-shape line is an extra sentence on top, never a change of behaviour.
+ */
+function buildEmptyResult({
+  query,
+  spanMs,
+  windowWasDefaulted,
+  startDate,
+  endDate,
+}: {
+  query?: string;
+  spanMs: number;
+  windowWasDefaulted: boolean;
+  startDate: number;
+  endDate: number;
+}): string {
+  const lines = ["No traces found matching your query.", ""];
+
+  const range = `${new Date(startDate).toISOString()} to ${new Date(endDate).toISOString()}`;
+  lines.push(
+    windowWasDefaulted
+      ? `Searched the last ${describeSpan(spanMs)} (the default): ${range}.`
+      : `Searched ${range}.`,
+  );
+  lines.push("", "Tips:");
+
+  if (query && looksLikeTraceId(query)) {
+    lines.push(
+      `- "${query}" looks like a trace id. Free text never matches trace ids — use \`get_trace\` with traceId: "${query}".`,
+    );
+  }
+
+  const wider = suggestWiderWindow(spanMs);
+  if (wider) {
+    lines.push(
+      `- Widen the window with startDate, e.g. startDate: "${wider}". Accepts h (hours), d (days), w (weeks), m (30-day months), or an ISO date.`,
+    );
+  }
+
+  lines.push(
+    "- Looking up a known trace id? `get_trace` takes a traceId and applies no time window.",
+    "- To fetch several known trace ids at once, pass `traceIds` instead of `query`.",
+  );
+
+  return lines.join("\n");
+}
 
 /**
  * Handles the search_traces MCP tool invocation.
  *
- * Searches LangWatch traces with optional filters, text query, and date range.
- * In digest mode (default), returns AI-readable formatted digests per trace.
- * In json mode, returns the full raw JSON.
+ * Searches LangWatch traces with optional filters, text query, explicit trace
+ * ids, and date range. In digest mode (default), returns AI-readable formatted
+ * digests per trace. In json mode, returns the full raw JSON.
  */
 export async function handleSearchTraces(params: {
   query?: string;
+  traceIds?: string[];
   filters?: Record<string, string[]>;
   startDate?: string;
   endDate?: string;
@@ -19,14 +106,18 @@ export async function handleSearchTraces(params: {
   format?: "digest" | "json";
 }): Promise<string> {
   const now = Date.now();
+  const namesTraceIds = (params.traceIds?.length ?? 0) > 0;
+  const defaultSpanMs = namesTraceIds ? ID_LOOKUP_WINDOW_MS : TEXT_SEARCH_WINDOW_MS;
+
   const startDate = params.startDate
     ? parseRelativeDate(params.startDate)
-    : now - 86400000;
+    : now - defaultSpanMs;
   const endDate = params.endDate ? parseRelativeDate(params.endDate) : now;
   const format = params.format ?? "digest";
 
   const result = await apiSearchTraces({
     query: params.query,
+    traceIds: params.traceIds,
     filters: params.filters,
     startDate,
     endDate,
@@ -37,7 +128,13 @@ export async function handleSearchTraces(params: {
 
   const traces = result.traces ?? [];
   if (traces.length === 0) {
-    return "No traces found matching your query.";
+    return buildEmptyResult({
+      query: params.query,
+      spanMs: endDate - startDate,
+      windowWasDefaulted: !params.startDate,
+      startDate,
+      endDate,
+    });
   }
 
   if (format === "json") {
@@ -45,9 +142,7 @@ export async function handleSearchTraces(params: {
   }
 
   const lines: string[] = [];
-  lines.push(
-    `Found ${result.pagination?.totalHits ?? traces.length} traces:\n`
-  );
+  lines.push(`Found ${result.pagination?.totalHits ?? traces.length} traces:\n`);
 
   for (const trace of traces) {
     lines.push(`### Trace: ${trace.trace_id}`);
@@ -55,17 +150,13 @@ export async function handleSearchTraces(params: {
     if (trace.formatted_trace) {
       lines.push(trace.formatted_trace);
     } else {
-      const inputStr = trace.input?.value
-        ? String(trace.input.value)
-        : "N/A";
-      const outputStr = trace.output?.value
-        ? String(trace.output.value)
-        : "N/A";
+      const inputStr = trace.input?.value ? String(trace.input.value) : "N/A";
+      const outputStr = trace.output?.value ? String(trace.output.value) : "N/A";
       lines.push(
-        `- **Input**: ${inputStr.slice(0, 100)}${inputStr.length > 100 ? "..." : ""}`
+        `- **Input**: ${inputStr.slice(0, 100)}${inputStr.length > 100 ? "..." : ""}`,
       );
       lines.push(
-        `- **Output**: ${outputStr.slice(0, 100)}${outputStr.length > 100 ? "..." : ""}`
+        `- **Output**: ${outputStr.slice(0, 100)}${outputStr.length > 100 ? "..." : ""}`,
       );
     }
 
@@ -83,12 +174,12 @@ export async function handleSearchTraces(params: {
 
   if (result.pagination?.scrollId) {
     lines.push(
-      `\n**More results available.** Use scrollId: "${result.pagination.scrollId}" to get next page.`
+      `\n**More results available.** Use scrollId: "${result.pagination.scrollId}" to get next page.`,
     );
   }
 
   lines.push(
-    '\n> Tip: Use `get_trace` with a trace_id for full details. Use `search_traces` with `format: "json"` for raw data. Use `discover_schema` to see available filter fields.'
+    '\n> Tip: Use `get_trace` with a trace_id for full details. Use `search_traces` with `format: "json"` for raw data. Use `discover_schema` to see available filter fields.',
   );
 
   return lines.join("\n");

--- a/mcp/typescript/src/tools/search-traces.ts
+++ b/mcp/typescript/src/tools/search-traces.ts
@@ -59,9 +59,9 @@ function buildEmptyResult({
   startDate: number;
   endDate: number;
 }): string {
-  const namesTraceIds = (traceIds?.length ?? 0) > 0;
+  const hasTraceIds = (traceIds?.length ?? 0) > 0;
   const lines = [
-    namesTraceIds
+    hasTraceIds
       ? "No traces matched the requested trace ids in the searched window."
       : "No traces found matching your query.",
     "",
@@ -88,7 +88,7 @@ function buildEmptyResult({
     );
   }
 
-  if (namesTraceIds) {
+  if (hasTraceIds) {
     lines.push(
       "- Retry with an earlier startDate, or relax the query and filters if you supplied them.",
       "- Looking up one full id? `get_trace` has no time window. A unique 8–31 character hex prefix searches the last 90 days.",
@@ -121,8 +121,8 @@ export async function handleSearchTraces(params: {
   format?: "digest" | "json";
 }): Promise<string> {
   const now = Date.now();
-  const namesTraceIds = (params.traceIds?.length ?? 0) > 0;
-  const defaultSpanMs = namesTraceIds ? ID_LOOKUP_WINDOW_MS : TEXT_SEARCH_WINDOW_MS;
+  const hasTraceIds = (params.traceIds?.length ?? 0) > 0;
+  const defaultSpanMs = hasTraceIds ? ID_LOOKUP_WINDOW_MS : TEXT_SEARCH_WINDOW_MS;
 
   const endDate =
     params.endDate !== undefined ? parseRelativeDate(params.endDate) : now;

--- a/mcp/typescript/src/tools/search-traces.ts
+++ b/mcp/typescript/src/tools/search-traces.ts
@@ -81,7 +81,7 @@ function buildEmptyResult({
   }
 
   lines.push(
-    "- Looking up a known trace id? `get_trace` takes a traceId and applies no time window.",
+    "- Looking up a known trace id? `get_trace` takes a traceId. A full id has no time window; a unique 8–31 character hex prefix searches the last 90 days.",
     "- To fetch several known trace ids at once, pass `traceIds` instead of `query`.",
   );
 
@@ -109,10 +109,16 @@ export async function handleSearchTraces(params: {
   const namesTraceIds = (params.traceIds?.length ?? 0) > 0;
   const defaultSpanMs = namesTraceIds ? ID_LOOKUP_WINDOW_MS : TEXT_SEARCH_WINDOW_MS;
 
+  const endDate = params.endDate ? parseRelativeDate(params.endDate) : now;
   const startDate = params.startDate
     ? parseRelativeDate(params.startDate)
-    : now - defaultSpanMs;
-  const endDate = params.endDate ? parseRelativeDate(params.endDate) : now;
+    : endDate - defaultSpanMs;
+
+  if (startDate >= endDate) {
+    throw new Error(
+      `Invalid trace search window: startDate (${new Date(startDate).toISOString()}) must be before endDate (${new Date(endDate).toISOString()}).`,
+    );
+  }
   const format = params.format ?? "digest";
 
   const result = await apiSearchTraces({

--- a/mcp/typescript/src/tools/search-traces.ts
+++ b/mcp/typescript/src/tools/search-traces.ts
@@ -46,18 +46,26 @@ function suggestWiderWindow(spanMs: number): string | undefined {
  */
 function buildEmptyResult({
   query,
+  traceIds,
   spanMs,
   windowWasDefaulted,
   startDate,
   endDate,
 }: {
   query?: string;
+  traceIds?: string[];
   spanMs: number;
   windowWasDefaulted: boolean;
   startDate: number;
   endDate: number;
 }): string {
-  const lines = ["No traces found matching your query.", ""];
+  const namesTraceIds = (traceIds?.length ?? 0) > 0;
+  const lines = [
+    namesTraceIds
+      ? "No traces matched the requested trace ids in the searched window."
+      : "No traces found matching your query.",
+    "",
+  ];
 
   const range = `${new Date(startDate).toISOString()} to ${new Date(endDate).toISOString()}`;
   lines.push(
@@ -80,10 +88,17 @@ function buildEmptyResult({
     );
   }
 
-  lines.push(
-    "- Looking up a known trace id? `get_trace` takes a traceId. A full id has no time window; a unique 8–31 character hex prefix searches the last 90 days.",
-    "- To fetch several known trace ids at once, pass `traceIds` instead of `query`.",
-  );
+  if (namesTraceIds) {
+    lines.push(
+      "- Retry with an earlier startDate, or relax the query and filters if you supplied them.",
+      "- Looking up one full id? `get_trace` has no time window. A unique 8–31 character hex prefix searches the last 90 days.",
+    );
+  } else {
+    lines.push(
+      "- Looking up a known trace id? `get_trace` takes a traceId. A full id has no time window; a unique 8–31 character hex prefix searches the last 90 days.",
+      "- To fetch several known trace ids at once, pass `traceIds` instead of `query`.",
+    );
+  }
 
   return lines.join("\n");
 }
@@ -109,8 +124,9 @@ export async function handleSearchTraces(params: {
   const namesTraceIds = (params.traceIds?.length ?? 0) > 0;
   const defaultSpanMs = namesTraceIds ? ID_LOOKUP_WINDOW_MS : TEXT_SEARCH_WINDOW_MS;
 
-  const endDate = params.endDate ? parseRelativeDate(params.endDate) : now;
-  const startDate = params.startDate
+  const endDate =
+    params.endDate !== undefined ? parseRelativeDate(params.endDate) : now;
+  const startDate = params.startDate !== undefined
     ? parseRelativeDate(params.startDate)
     : endDate - defaultSpanMs;
 
@@ -136,8 +152,9 @@ export async function handleSearchTraces(params: {
   if (traces.length === 0) {
     return buildEmptyResult({
       query: params.query,
+      traceIds: params.traceIds,
       spanMs: endDate - startDate,
-      windowWasDefaulted: !params.startDate,
+      windowWasDefaulted: params.startDate === undefined,
       startDate,
       endDate,
     });

--- a/mcp/typescript/src/tools/search-traces.ts
+++ b/mcp/typescript/src/tools/search-traces.ts
@@ -185,7 +185,7 @@ export async function handleSearchTraces(params: {
   }
 
   lines.push(
-    '\n> Tip: Use `get_trace` with a trace_id for full details. Use `search_traces` with `format: "json"` for raw data. Use `discover_schema` to see available filter fields.',
+    '\n> Tip: Use `get_trace` with a traceId for full details. Use `search_traces` with `format: "json"` for raw data. Use `discover_schema` to see available filter fields.',
   );
 
   return lines.join("\n");

--- a/mcp/typescript/src/utils/trace-id-shape.ts
+++ b/mcp/typescript/src/utils/trace-id-shape.ts
@@ -1,0 +1,37 @@
+/**
+ * Whether a free-text query looks like a trace id.
+ *
+ * Mirrors the vocabulary the platform's trace service exports — `HEX_ONLY`,
+ * `MIN_TRACE_ID_PREFIX_LENGTH` (8) and `FULL_TRACE_ID_LENGTH` (32) in
+ * `platform/app/src/server/traces/trace.service.ts`. This package is a
+ * standalone published client that reaches the platform over HTTP and shares no
+ * server code, so the vocabulary is restated here rather than imported; keep the
+ * two in step.
+ *
+ * Deliberately narrow, and deliberately advisory. `TraceId` is a free-form
+ * `String` in ClickHouse and `trace_id` is `z.string()` in the collector
+ * contract, so a customer's ids can be `order-12345` and no check over that
+ * space can ever be sound. The answer only ever adds a sentence to an empty
+ * result — it never changes what the tool does (ADR-132).
+ */
+
+/** Hex-only, matching the server's prefix resolver. */
+const HEX_ONLY = /^[0-9a-f]+$/i;
+
+/**
+ * Shortest hex string worth calling an id. Matches the server's
+ * `MIN_TRACE_ID_PREFIX_LENGTH`, which is also the shortest prefix its git-style
+ * resolver will attempt. There is deliberately no upper bound: the CLI prints
+ * 20-character truncations, OTel ids are 32, and longer ids exist in the wild.
+ */
+const MIN_TRACE_ID_LENGTH = 8;
+
+/** The `trace_`-prefixed form the collector accepts (`trace_` + nanoid). */
+const PREFIXED_TRACE_ID = /^trace_[A-Za-z0-9_-]{8,}$/;
+
+export function looksLikeTraceId(query: string): boolean {
+  const candidate = query.trim();
+  if (candidate.includes(" ")) return false;
+  if (PREFIXED_TRACE_ID.test(candidate)) return true;
+  return HEX_ONLY.test(candidate) && candidate.length >= MIN_TRACE_ID_LENGTH;
+}

--- a/specs/mcp-server/trace-tools.feature
+++ b/specs/mcp-server/trace-tools.feature
@@ -1,3 +1,6 @@
+# See dev/docs/adr/132-a-trace-id-is-looked-up-never-searched.md for why a trace
+# id is not reachable through search, and why the shape check below only ever
+# adds advice instead of changing what the tool does.
 @integration
 Feature: MCP Trace Tools
   As a coding agent
@@ -45,3 +48,42 @@ Feature: MCP Trace Tools
   Scenario: Agent gets a trace that does not exist
     When the agent calls get_trace with traceId "nonexistent-trace"
     Then the response contains an error message "Trace not found"
+
+  # Implementation:
+  #   mcp/typescript/src/tools/search-traces.ts
+  #
+  # An empty result is the one moment the caller needs a redirect, and it was
+  # the one place the tip naming get_trace never printed. These four scenarios
+  # are @unimplemented until the bindings land alongside the change; the tag
+  # comes off in the same commit as the tests.
+
+  @unimplemented
+  Scenario: Agent pastes a trace id into the search query
+    Given a trace exists with id "trace_4bf92f3577b34da6a3ce929d0e0e4736"
+    When the agent calls search_traces with query "trace_4bf92f3577b34da6a3ce929d0e0e4736"
+    Then the response reports that no traces matched
+    And the response says the query looks like a trace id and names get_trace
+
+  @unimplemented
+  Scenario: A search that matches nothing says which window it searched
+    When the agent calls search_traces with a query that matches no trace
+    Then the response reports that no traces matched
+    And the response states the time window it searched
+    And the response names get_trace for looking up a known trace id
+
+  # The shape check recognises the OTel and trace_-prefixed forms only. A
+  # customer-assigned id is unrecognisable by construction — TraceId is a
+  # free-form String — so the unconditional guidance is what has to carry it.
+  @unimplemented
+  Scenario: A trace id in a format the shape check cannot recognise still gets guidance
+    Given the project's traces carry customer-assigned ids like "order-12345"
+    When the agent calls search_traces with query "order-12345"
+    Then the response reports that no traces matched
+    And the response names get_trace for looking up a known trace id
+
+  # The load-bearing guarantee of ADR-132: advice only, never routing.
+  @unimplemented
+  Scenario: An id-shaped query is still executed as a search
+    When the agent calls search_traces with query "trace_4bf92f3577b34da6a3ce929d0e0e4736"
+    Then the server receives a trace search request
+    And the server receives no single-trace lookup

--- a/specs/mcp-server/trace-tools.feature
+++ b/specs/mcp-server/trace-tools.feature
@@ -53,14 +53,17 @@ Feature: MCP Trace Tools
   #   mcp/typescript/src/tools/search-traces.ts
   #
   # An empty result is the one moment the caller needs a redirect, and it was
-  # the one place the tip naming get_trace never printed. These four scenarios
-  # are @unimplemented until the bindings land alongside the change; the tag
-  # comes off in the same commit as the tests.
+  # the one place the tip naming get_trace never printed. Two existing rules say
+  # an empty result must never stand in for a failure — see
+  # specs/traces-v2/sessions-lens.feature and
+  # specs/langy/langy-cli-tool-envelope.feature. These scenarios are
+  # @unimplemented until the bindings land alongside the change; the tag comes
+  # off in the same commit as the tests.
 
   @unimplemented
   Scenario: Agent pastes a trace id into the search query
-    Given a trace exists with id "trace_4bf92f3577b34da6a3ce929d0e0e4736"
-    When the agent calls search_traces with query "trace_4bf92f3577b34da6a3ce929d0e0e4736"
+    Given a trace exists with id "63dc535cea6335c506bc81ef3543a07d"
+    When the agent calls search_traces with query "63dc535cea6335c506bc81ef3543a07d"
     Then the response reports that no traces matched
     And the response says the query looks like a trace id and names get_trace
 
@@ -71,8 +74,17 @@ Feature: MCP Trace Tools
     And the response states the time window it searched
     And the response names get_trace for looking up a known trace id
 
-  # The shape check recognises the OTel and trace_-prefixed forms only. A
-  # customer-assigned id is unrecognisable by construction — TraceId is a
+  # The CLI's own table truncates trace ids to 20 characters, so a copied id is
+  # the common case rather than the exotic one. The shape check reuses the trace
+  # service's exported vocabulary (HEX_ONLY, MIN_TRACE_ID_PREFIX_LENGTH = 8)
+  # instead of matching full 32-character ids only.
+  @unimplemented
+  Scenario: A trace id truncated by the CLI is still recognised as an id
+    When the agent calls search_traces with query "63dc535cea6335c506bc"
+    Then the response reports that no traces matched
+    And the response says the query looks like a trace id and names get_trace
+
+  # A customer-assigned id is unrecognisable by construction — TraceId is a
   # free-form String — so the unconditional guidance is what has to carry it.
   @unimplemented
   Scenario: A trace id in a format the shape check cannot recognise still gets guidance
@@ -84,6 +96,24 @@ Feature: MCP Trace Tools
   # The load-bearing guarantee of ADR-132: advice only, never routing.
   @unimplemented
   Scenario: An id-shaped query is still executed as a search
-    When the agent calls search_traces with query "trace_4bf92f3577b34da6a3ce929d0e0e4736"
+    When the agent calls search_traces with query "63dc535cea6335c506bc81ef3543a07d"
     Then the server receives a trace search request
     And the server receives no single-trace lookup
+
+  # traceIds rides the (TenantId, TraceId) sort key, so this is a primary-key
+  # seek rather than a scan. The REST boundary already accepted the field.
+  @unimplemented
+  Scenario: Agent looks up several traces by id in one call
+    Given traces exist with ids "63dc535cea6335c506bc81ef3543a07d" and "a3c6656cf433e97549f654034be02955"
+    When the agent calls search_traces with traceIds for both
+    Then the response contains exactly those two traces
+
+  # Naming ids is an exact-match intent; answering it against yesterday only is
+  # a false negative by construction. 90 days is the bound prefix resolution
+  # already justifies (TRACE_ID_PREFIX_LOOKUP_WINDOW_DAYS).
+  @unimplemented
+  Scenario: Naming trace ids widens the default window past 24 hours
+    Given a trace exists with id "63dc535cea6335c506bc81ef3543a07d" from 10 days ago
+    When the agent calls search_traces with traceIds for it and no dates
+    Then the response contains that trace
+    And the response states the time window it searched

--- a/specs/mcp-server/trace-tools.feature
+++ b/specs/mcp-server/trace-tools.feature
@@ -51,69 +51,64 @@ Feature: MCP Trace Tools
 
   # Implementation:
   #   mcp/typescript/src/tools/search-traces.ts
+  #   mcp/typescript/src/utils/trace-id-shape.ts
   #
   # An empty result is the one moment the caller needs a redirect, and it was
   # the one place the tip naming get_trace never printed. Two existing rules say
   # an empty result must never stand in for a failure — see
   # specs/traces-v2/sessions-lens.feature and
-  # specs/langy/langy-cli-tool-envelope.feature. These scenarios are
-  # @unimplemented until the bindings land alongside the change; the tag comes
-  # off in the same commit as the tests.
+  # specs/langy/langy-cli-tool-envelope.feature.
 
-  @unimplemented
-  Scenario: Agent pastes a trace id into the search query
-    Given a trace exists with id "63dc535cea6335c506bc81ef3543a07d"
-    When the agent calls search_traces with query "63dc535cea6335c506bc81ef3543a07d"
-    Then the response reports that no traces matched
-    And the response says the query looks like a trace id and names get_trace
-
-  @unimplemented
   Scenario: A search that matches nothing says which window it searched
     When the agent calls search_traces with a query that matches no trace
     Then the response reports that no traces matched
     And the response states the time window it searched
     And the response names get_trace for looking up a known trace id
 
+  Scenario: An empty search offers a wider window
+    When the agent calls search_traces with a query that matches no trace
+    Then the response suggests a wider startDate the caller can pass
+    And the response lists the units the window accepts
+
+  Scenario: Agent pastes a trace id into the search query
+    When the agent calls search_traces with query "63dc535cea6335c506bc81ef3543a07d"
+    Then the response reports that no traces matched
+    And the response says the query looks like a trace id
+    And the response names get_trace with that id
+
   # The CLI's own table truncates trace ids to 20 characters, so a copied id is
-  # the common case rather than the exotic one. The shape check reuses the trace
-  # service's exported vocabulary (HEX_ONLY, MIN_TRACE_ID_PREFIX_LENGTH = 8)
+  # the common case rather than the exotic one. The shape check mirrors the
+  # trace service's vocabulary (HEX_ONLY, MIN_TRACE_ID_PREFIX_LENGTH = 8)
   # instead of matching full 32-character ids only.
-  @unimplemented
   Scenario: A trace id truncated by the CLI is still recognised as an id
     When the agent calls search_traces with query "63dc535cea6335c506bc"
-    Then the response reports that no traces matched
-    And the response says the query looks like a trace id and names get_trace
+    Then the response says the query looks like a trace id
 
   # A customer-assigned id is unrecognisable by construction — TraceId is a
   # free-form String — so the unconditional guidance is what has to carry it.
-  @unimplemented
   Scenario: A trace id in a format the shape check cannot recognise still gets guidance
-    Given the project's traces carry customer-assigned ids like "order-12345"
     When the agent calls search_traces with query "order-12345"
     Then the response reports that no traces matched
     And the response names get_trace for looking up a known trace id
+    But the response does not claim the query looks like a trace id
 
   # The load-bearing guarantee of ADR-132: advice only, never routing.
-  @unimplemented
   Scenario: An id-shaped query is still executed as a search
     When the agent calls search_traces with query "63dc535cea6335c506bc81ef3543a07d"
-    Then the server receives a trace search request
+    Then the server receives a trace search request carrying that query
     And the server receives no single-trace lookup
 
   # traceIds rides the (TenantId, TraceId) sort key, so this is a primary-key
   # seek rather than a scan. The REST boundary already accepted the field.
-  @unimplemented
   Scenario: Agent looks up several traces by id in one call
     Given traces exist with ids "63dc535cea6335c506bc81ef3543a07d" and "a3c6656cf433e97549f654034be02955"
     When the agent calls search_traces with traceIds for both
     Then the response contains exactly those two traces
 
-  # Naming ids is an exact-match intent; answering it against yesterday only is
+  # Naming ids is an exact-match intent; answering it against yesterday alone is
   # a false negative by construction. 90 days is the bound prefix resolution
   # already justifies (TRACE_ID_PREFIX_LOOKUP_WINDOW_DAYS).
-  @unimplemented
   Scenario: Naming trace ids widens the default window past 24 hours
-    Given a trace exists with id "63dc535cea6335c506bc81ef3543a07d" from 10 days ago
-    When the agent calls search_traces with traceIds for it and no dates
-    Then the response contains that trace
-    And the response states the time window it searched
+    When the agent calls search_traces with traceIds and no dates
+    Then the search covers the last 90 days rather than the last 24 hours
+    And the request carries those trace ids

--- a/specs/mcp-server/trace-tools.feature
+++ b/specs/mcp-server/trace-tools.feature
@@ -79,6 +79,11 @@ Feature: MCP Trace Tools
     Then the response explains that startDate must be before endDate
     And the server receives no trace search request
 
+  Scenario: An empty date input fails before the API call
+    When the agent calls search_traces with an empty startDate
+    Then the response explains that the date is invalid
+    And the server receives no trace search request
+
   Scenario: Agent pastes a trace id into the search query
     When the agent calls search_traces with query "63dc535cea6335c506bc81ef3543a07d"
     Then the response reports that no traces matched
@@ -113,6 +118,12 @@ Feature: MCP Trace Tools
     Given traces exist with ids "63dc535cea6335c506bc81ef3543a07d" and "a3c6656cf433e97549f654034be02955"
     When the agent calls search_traces with traceIds for both
     Then the response contains exactly those two traces
+
+  Scenario: An empty batch id lookup gives advice for that request
+    When the agent calls search_traces with traceIds that are not found
+    Then the response says no requested trace ids matched in the searched window
+    And the response suggests an earlier startDate
+    But the response does not tell the agent to pass traceIds again
 
   # Naming ids is an exact-match intent; answering it against yesterday alone is
   # a false negative by construction. 90 days is the bound prefix resolution

--- a/specs/mcp-server/trace-tools.feature
+++ b/specs/mcp-server/trace-tools.feature
@@ -14,7 +14,7 @@ Feature: MCP Trace Tools
   Scenario: Agent searches traces with a text query
     When the agent calls search_traces with query "login error"
     Then the response contains matching traces with summaries
-    And each trace summary includes trace_id, input preview, timestamps, and status
+    And each trace summary includes trace_id, input preview, output preview, and timestamp
     And the response defaults to the last 24 hours
 
   Scenario: Agent searches traces filtered by user_id
@@ -69,6 +69,15 @@ Feature: MCP Trace Tools
     When the agent calls search_traces with a query that matches no trace
     Then the response suggests a wider startDate the caller can pass
     And the response lists the units the window accepts
+
+  Scenario: An end-only search anchors its default window to that end
+    When the agent calls search_traces with endDate "2026-08-01T12:00:00Z" and no startDate
+    Then the search covers the 24 hours ending at "2026-08-01T12:00:00Z"
+
+  Scenario: An inverted search window fails before the API call
+    When the agent calls search_traces with startDate after endDate
+    Then the response explains that startDate must be before endDate
+    And the server receives no trace search request
 
   Scenario: Agent pastes a trace id into the search query
     When the agent calls search_traces with query "63dc535cea6335c506bc81ef3543a07d"


### PR DESCRIPTION
A trace ID pasted into `search_traces` currently returns an unexplained empty result because free text does not match `TraceId`. This change makes the tool boundary explicit: `get_trace` handles one known ID, while `search_traces.traceIds` handles batches of exact IDs within a disclosed time window.

## What changed

- Empty searches report the exact window, suggest the next wider window, and point callers to `get_trace` or `traceIds`.
- `traceIds` is forwarded to the existing exact-ID API filter, accepts 1 to 1,000 IDs, and defaults to a 90-day window. Text search keeps its 24-hour default.
- A full trace ID lookup can resolve at any age. An 8 to 31 character hexadecimal prefix is accurately described as a 90-day lookup.
- An end-only search anchors its default span to the supplied end. Empty date values and empty or inverted windows fail before making an API request with a useful error.
- Empty batch-ID results suggest an earlier window instead of repeating the input instruction.
- ID-shape detection remains advisory and never changes routing, so customer-assigned IDs remain valid.
- ADR-132 and the MCP trace-tool specification record the storage, cost, and behaviour decisions.

## Deployment Impact

No environment variables or Helm values change. A vanilla Helm install keeps the same defaults, and BYOC dataplanes need no configuration or rollout changes. The behaviour is confined to the published MCP server and its existing trace search API call.

## Validation

- `pnpm --dir mcp/typescript exec vitest run src/__tests__/tools.integration.test.ts src/__tests__/all-tools.integration.test.ts` (140 passed)
- `pnpm --dir mcp/typescript exec vitest run --exclude tests/scenario-openai.test.ts` (669 passed)
- `pnpm --dir mcp/typescript exec tsc --noEmit`
- `pnpm --dir mcp/typescript run build`
- `pnpm dlx oxlint@latest` on the six changed TypeScript files
- `node platform/app/scripts/check-feature-parity.ts` (18/18 MCP trace-tool scenarios bound; full parity check passed)
- `git diff --check`

The excluded scenario test launches an external Claude process through `node-pty`; this checkout fails before the scenario starts with `posix_spawnp failed`. The MCP unit and integration suites are green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added exact trace ID lookup through `search_traces`, including support for multiple IDs.
  * Added guidance for finding known traces with `get_trace` or trace ID filters.
  * Trace ID lookups use a 90-day default window; text searches retain a 24-hour default.
  * Empty results now show the searched time window and suggest next steps.
  * Added date-window validation and support for anchoring default windows to an end date.

* **Documentation**
  * Documented trace ID lookup behavior and search limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->