### PR TITLE
fix(ci): unbreak lint and feature parity on the wave-1 governance cost branch

### DIFF
--- a/platform/app/scripts/check-feature-parity.ts
+++ b/platform/app/scripts/check-feature-parity.ts
@@ -693,6 +693,12 @@ const LEGACY_PARTIAL: string[] = [
   "specs/automations/authoring-drawer.feature",
   "specs/automations/process-manager-dispatch.feature",
   "specs/ci/path-filters.feature",
+  // Reason: reached this branch from main already partially tagged, and its
+  // eight untagged scenarios describe the CI comment bot, which this branch
+  // does not own. Tagging them @unimplemented would claim the behaviour is
+  // unbuilt when it ships today; the honest statement is that it is untagged
+  // and unmeasured. For the CI owners to bind or park.
+  "specs/ci/pr-token-usage.feature",
   "specs/clickhouse/windowed-read-fallback.feature",
   "specs/coding-agent/cache-write-ttl-pricing.feature",
   "specs/coding-agent/terminal-view.feature",
@@ -736,6 +742,10 @@ const LEGACY_PARTIAL: string[] = [
   "specs/prompts/locked-input-variable.feature",
   "specs/queue-pausing/queue-pausing.feature",
   "specs/rbac/scoped-role-bindings.feature",
+  // Reason: same as specs/ci/pr-token-usage.feature — arrived from main
+  // already partially tagged. Its two untagged scenarios describe the skill
+  // testing harness, which this branch does not own.
+  "specs/skills/skills-testing.feature",
   "specs/suites/suite-model-selection.feature",
   "specs/topic-clustering/event-sourced-scheduling.feature",
   "specs/traces-v2/annotations.feature",

--- a/platform/app/src/server/__tests__/projectFilter.invariant.integration.test.ts
+++ b/platform/app/src/server/__tests__/projectFilter.invariant.integration.test.ts
@@ -25,10 +25,10 @@
  * Decision: ADR-128.
  */
 
-import { DepartmentService } from "@ee/governance/services/department/department.service";
-import { nanoid } from "nanoid";
 import fs from "node:fs";
 import path from "node:path";
+import { DepartmentService } from "@ee/governance/services/department/department.service";
+import { nanoid } from "nanoid";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
   CostReferenceType,
@@ -96,7 +96,8 @@ interface ListingSurface {
 const surfaces: ListingSurface[] = [
   {
     name: "the projects REST list",
-    module: "src/server/app-layer/projects/repositories/project.prisma.repository.ts",
+    module:
+      "src/server/app-layer/projects/repositories/project.prisma.repository.ts",
     ids: async () => {
       const page = await new PrismaProjectRepository(
         prisma,

--- a/platform/app/src/server/app-layer/teams/repositories/team.repository.ts
+++ b/platform/app/src/server/app-layer/teams/repositories/team.repository.ts
@@ -36,9 +36,7 @@ export interface TeamRepository {
    * (`src/server/__tests__/projectFilter.invariant.integration.test.ts`) can
    * drive this listing the way it drives every other one.
    */
-  findProjectsInTeam(params: {
-    teamId: string;
-  }): Promise<TeamProjectListing[]>;
+  findProjectsInTeam(params: { teamId: string }): Promise<TeamProjectListing[]>;
   findAllByOrganization(params: {
     organizationId: string;
     page: number;

--- a/specs/governance/pulled-rows-home-and-leak-gate.feature
+++ b/specs/governance/pulled-rows-home-and-leak-gate.feature
@@ -53,6 +53,17 @@ Feature: Pulled provider cost has a home and never leaks
     And the same listing without the safeguard would have contained it
 
   @integration
+  Scenario: Every filtered project listing is a surface the leak gate drives
+    # The scenario above only proves the surfaces it names. A listing added
+    # later would filter the home on the day it lands and could quietly stop
+    # filtering it a year on with nothing failing, because no surface drives
+    # it. This closes that gap in both directions.
+    Given the sweep finds the project repository among the modules that filter the home
+    When every filtering module is matched against the surfaces this gate drives
+    Then no filtering module is left without a surface that proves it keeps filtering
+    And no surface names a module that no longer filters
+
+  @integration
   Scenario: A homed pulled row still never counts against spending limits
     Given a team whose spending is at its limit
     When a pulled usage record is stored under the governance home

--- a/specs/nlp-go/studio-lambda-cache.feature
+++ b/specs/nlp-go/studio-lambda-cache.feature
@@ -87,12 +87,14 @@ Feature: getProjectLambdaArn — per-project ARN cache + single-flight
     And a fresh Lambda resolution flow runs so reconcileProjectLambdaConfig applies the new timeout
     And the stale ceiling is not served for the remainder of the cache TTL
 
+  @integration @unit
   Scenario: An unchanged desired configuration keeps serving from cache, no spurious invalidation
     Given getProjectLambdaArn("projectA") resolved and cached
     When getProjectLambdaArn("projectA") is called again with an identical desired configuration
     Then the configFingerprint matches and the cached ARN is returned
     And no additional AWS calls are made
 
+  @integration @unit
   Scenario: Different projects do not share cache slots
     When getProjectLambdaArn("projectA") and getProjectLambdaArn("projectB") both resolve
     Then the cache holds two independent entries


### PR DESCRIPTION
Both CI failures on this branch are here, not in anything stacked on top of it. Fixing them at the root so everything downstream inherits green.

## Lint — 3 errors, 2 files

`projectFilter.invariant.integration.test.ts` needed its node builtins hoisted above the aliased imports and one long string wrapped; `team.repository.ts` had a method signature the formatter collapses to one line. All three came in with the commit that added the leak-gate sweep and were never formatted. Pure formatter output, no logic touched.

## Feature parity — one dangling annotation, three untagged files

**The dangling annotation.** The leak gate's last test says: every module that filters the governance home must be driven by one of the surfaces this gate exercises, and every surface must name a module that still filters. Its `@scenario` annotation pointed at a title the rewritten feature file no longer holds.

The scenario is worth having, so it is written rather than the annotation deleted. Without that test a listing added later filters the home on the day it lands and can quietly stop a release on, because nothing drives it — and the scenario above it only proves the surfaces it names.

**The untagged files.** This branch's parity check newly refuses a feature file that enforces some scenarios while others carry no tag at all. That is a real hole: `15/15 bound` printed beside a dozen invisible scenarios reads exactly like full coverage. Three files arrived from main already in that state.

- `specs/nlp-go/studio-lambda-cache.feature` — its two untagged scenarios are already bound, in the same test file and the same style as their tagged siblings. They just missed the tag, so they get it.
- `specs/ci/pr-token-usage.feature` and `specs/skills/skills-testing.feature` — not this branch's to tag. Marking their scenarios `@unimplemented` would claim the behaviour is unbuilt when it ships today. They join `LEGACY_PARTIAL` with a reason recorded inline: untagged and unmeasured, for their owners to bind or park.

## Verification

- `check-feature-parity.ts` → exit 0
- biome over `src ee scripts e2e prisma vite` → **0 errors** (warning count unchanged)
- `typecheck` → exit 0
- `check-feature-parity.unit.test.ts` → 48 passed
- `getProjectLambdaArn.test.ts` → 20 passed

Not run: `projectFilter.invariant.integration.test.ts` itself, which needs a container runtime that was not available locally. Its only change is formatter output — no mock, no side-effect import, no ordering the runtime depends on — and it typechecks. CI covers it.
