### PR TITLE
fix(suites): the return banner sits in the header row

### DIFF
--- a/platform/app/src/components/scenarios/LabelFilterDropdown.tsx
+++ b/platform/app/src/components/scenarios/LabelFilterDropdown.tsx
@@ -1,4 +1,4 @@
-import { Box, HStack, Text, VStack } from "@chakra-ui/react";
+import { Box, Button, HStack, Text, VStack } from "@chakra-ui/react";
 import { Tag } from "lucide-react";
 import { SmallButton } from "~/components/agent-testing/shared/SmallButton";
 import { Checkbox } from "~/components/ui/checkbox";
@@ -14,6 +14,12 @@ type LabelFilterDropdownProps = {
   allLabels: string[];
   activeLabels: string[];
   onToggle: (label: string) => void;
+  /**
+   * "header" draws the trigger at the page-header button size, matching the
+   * PageLayout.HeaderButton beside it. Unset keeps the Agent Testing small
+   * button, which is what the cases panel wants.
+   */
+  triggerSize?: "header";
 };
 
 /**
@@ -23,21 +29,32 @@ export function LabelFilterDropdown({
   allLabels,
   activeLabels,
   onToggle,
+  triggerSize,
 }: LabelFilterDropdownProps) {
   const hasActiveFilters = activeLabels.length > 0;
+
+  const triggerContent = (
+    <>
+      <Tag size={triggerSize === "header" ? 16 : 13} />
+      Labels
+      {hasActiveFilters && (
+        <Text as="span" fontSize="12px" ml={1}>
+          ({activeLabels.length})
+        </Text>
+      )}
+    </>
+  );
 
   return (
     <PopoverRoot positioning={{ placement: "bottom-start" }}>
       <PopoverTrigger asChild>
-        <SmallButton>
-          <Tag size={13} />
-          Labels
-          {hasActiveFilters && (
-            <Text as="span" fontSize="12px" ml={1}>
-              ({activeLabels.length})
-            </Text>
-          )}
-        </SmallButton>
+        {triggerSize === "header" ? (
+          <Button variant="outline" size="sm">
+            {triggerContent}
+          </Button>
+        ) : (
+          <SmallButton>{triggerContent}</SmallButton>
+        )}
       </PopoverTrigger>
       <PopoverContent width="220px">
         <PopoverBody>

--- a/platform/app/src/components/suites/ReturnToNewSimulationsBanner.tsx
+++ b/platform/app/src/components/suites/ReturnToNewSimulationsBanner.tsx
@@ -1,7 +1,7 @@
 import { HStack, Icon, Text } from "@chakra-ui/react";
 import posthog from "posthog-js";
 import { useEffect, useState } from "react";
-import { LuArrowRight, LuSparkles } from "react-icons/lu";
+import { LuSparkles } from "react-icons/lu";
 import { useFeatureFlag } from "~/hooks/useFeatureFlag";
 import {
   clearLegacySimulationsPreference,
@@ -122,10 +122,9 @@ function BannerWithFlag({
         <Text fontSize="sm" color="colorPalette.fg">
           You are on the previous simulations screens.
         </Text>
-        <HStack gap={1} color="colorPalette.fg" fontSize="sm" fontWeight="600">
-          <Text>Go to the new version</Text>
-          <Icon as={LuArrowRight} boxSize={3.5} />
-        </HStack>
+        <Text color="colorPalette.fg" fontSize="sm" fontWeight="600">
+          Go to the new version
+        </Text>
       </HStack>
     </Link>
   );

--- a/platform/app/src/components/suites/ReturnToNewSimulationsBanner.tsx
+++ b/platform/app/src/components/suites/ReturnToNewSimulationsBanner.tsx
@@ -93,17 +93,13 @@ function BannerWithFlag({
   };
 
   return (
-    // The banner carries its own page spacing. A wrapper on the page would
-    // hold that space open on every browser that never sees the banner.
+    // Content-sized: the banner sits inside the page header row beside the
+    // header's own controls, so it takes only the room its words need.
     <Link
       href={href}
       onClick={handleClick}
       aria-label="Go to the new simulations screen"
       textDecoration="none"
-      display="block"
-      width="full"
-      paddingX={6}
-      paddingBottom={2}
       _hover={{ textDecoration: "none" }}
     >
       <HStack
@@ -111,7 +107,8 @@ function BannerWithFlag({
         gap={2}
         borderRadius="lg"
         paddingX={3}
-        paddingY={2}
+        paddingY={1.5}
+        whiteSpace="nowrap"
         bg="colorPalette.subtle"
         borderWidth="1px"
         borderColor="colorPalette.muted"

--- a/platform/app/src/components/suites/SimulationsPage.tsx
+++ b/platform/app/src/components/suites/SimulationsPage.tsx
@@ -371,6 +371,7 @@ export default function SimulationsPage() {
             <HStack justify="space-between" align="center" w="full">
               <PageLayout.Heading>Simulations</PageLayout.Heading>
               <HStack>
+                <ReturnToNewSimulationsBanner target="runs" />
                 <PeriodSelector
                   period={period}
                   mode={mode}
@@ -383,8 +384,6 @@ export default function SimulationsPage() {
               </HStack>
             </HStack>
           </PageLayout.Header>
-
-          <ReturnToNewSimulationsBanner target="runs" />
 
           {/* Second row: sidebar + content box */}
           <HStack flex={1} width="full" gap={0} overflow="hidden" minHeight={0}>

--- a/platform/app/src/pages/[project]/simulations/scenarios/index.tsx
+++ b/platform/app/src/pages/[project]/simulations/scenarios/index.tsx
@@ -173,18 +173,18 @@ function ScenarioLibraryPage() {
         <HStack justify="space-between" align="center" w="full">
           <PageLayout.Heading>Scenario Library</PageLayout.Heading>
           <Spacer />
+          <ReturnToNewSimulationsBanner target="scenarios" />
           <LabelFilterDropdown
             allLabels={allLabels}
             activeLabels={activeLabels}
             onToggle={handleLabelToggle}
+            triggerSize="header"
           />
           <PageLayout.HeaderButton onClick={handleNewScenario}>
             <Plus size={16} /> New Scenario
           </PageLayout.HeaderButton>
         </HStack>
       </PageLayout.Header>
-
-      <ReturnToNewSimulationsBanner target="scenarios" />
 
       <PageLayout.Container padding={0}>
         {isLoading && (

--- a/specs/suites/new-simulations-callout.feature
+++ b/specs/suites/new-simulations-callout.feature
@@ -15,7 +15,7 @@ Feature: The new-simulations callout offers the way back
   retirement, the dismissal and the recorded preference, so the way back to
   the previous screens stays reachable.
 
-  The previous screens carry the way forward: a banner under their header
+  The previous screens carry the way forward: a banner in their header row
   shows on the browser that recorded the preference, while the release flag
   is on, and a click clears the preference and the dismissal so the person
   reads the new screens again with the offer intact.


### PR DESCRIPTION
## What this changes

Follow-up to #7725. The return banner on the previous simulations screens took the full page width under the header. It now sits in the header row beside the header's own controls, sized to its content:

- Previous Simulations runs page: in the header, left of the period selector.
- Previous Scenario Library: in the header, left of the Labels button.

The Labels button on the previous Scenario Library also takes the page-header button size, so it matches the New Scenario button beside it. The cases panel on the new Agent Testing screens keeps the small button, unchanged.

## Screenshots

![Banner in the Simulations header](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/connected-agents/banner-header-runs.png)

![Banner in the Scenario Library header](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/connected-agents/banner-header-scenarios.png)

## Verification

- Component lanes green: `src/components/suites` + `src/pages` + the banner integration test, 653/653
- `pnpm typecheck:all` clean, biome clean
- Browser QA on the local stack: banner renders in both header rows with the preference set, and both pages render with no reserved space without it


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Moved the return banner into the page header action area for a more compact, integrated layout.
  * Added a larger header-style label filter trigger for scenario pages.

* **UX Improvements**
  * Adjusted spacing and sizing for the return banner so it fits better in the header row.
  * Updated the label filter button appearance to better match header controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->