### PR TITLE
feat(governance): give the cost screen its breakdowns and filters

### DIFF
--- a/platform/app/ee/governance/dashboard/logic/sourceHealthDisplay.ts
+++ b/platform/app/ee/governance/dashboard/logic/sourceHealthDisplay.ts
@@ -62,34 +62,8 @@ export function sourceBadge({
 }
 
 /**
- * The line under a broken source: how far back the numbers can be trusted.
- *
- * Returns null while the source is healthy, and null when it has never
- * pulled successfully -- there is no "since" to name in either case, and the
- * awaiting-first-event badge already covers the second.
- *
- * Disabled is checked first, for the reason the badge checks it first: a
- * source nobody asked to run has not "stopped pulling". Retained failures
- * from before it was switched off would otherwise put an outage notice under
- * a source whose badge, correctly, reads Disabled.
+ * Re-exported from the health rule it belongs with. The badge and the cost
+ * screen ask the same question, and the cost service cannot import this
+ * module — it brings icons with it.
  */
-export function noDataSinceNotice({
-  status,
-  errorCount,
-  lastSuccessAt,
-}: {
-  status: string;
-  errorCount: number;
-  lastSuccessAt: Date | string | null;
-}): { lastSuccessIso: string } | null {
-  if (status === "disabled") return null;
-  if (deriveSourceHealth({ consecutiveFailures: errorCount }) === "healthy") {
-    return null;
-  }
-  if (lastSuccessAt === null) return null;
-  const iso =
-    typeof lastSuccessAt === "string"
-      ? lastSuccessAt
-      : lastSuccessAt.toISOString();
-  return { lastSuccessIso: iso };
-}
+export { noDataSinceNotice } from "@ee/governance/services/pullers/sourceHealth";

--- a/platform/app/ee/governance/dashboard/pages/ingestion-source-detail.tsx
+++ b/platform/app/ee/governance/dashboard/pages/ingestion-source-detail.tsx
@@ -229,8 +229,8 @@ function NoDataSinceCallout({ source }: { source: Source }) {
       padding={3}
     >
       <Text fontSize="sm" color="red.700">
-        No data since {fmtRelative(notice.lastSuccessIso)}. This source has
-        stopped pulling, so spend after that point is unknown rather than zero.
+        No data since {fmtRelative(notice.lastSuccessIso)}. This source is
+        failing to pull, so spend after that point is unknown rather than zero.
       </Text>
     </Box>
   );

--- a/platform/app/ee/governance/services/__tests__/governanceCost.service.unit.test.ts
+++ b/platform/app/ee/governance/services/__tests__/governanceCost.service.unit.test.ts
@@ -20,10 +20,23 @@ type LaneRow = Awaited<
   ReturnType<GovernanceCostRollupClickHouseRepository["sumDaysByLane"]>
 >[number];
 
-/** A prisma double that answers the governance-project lookup and nothing else. */
-function prismaWithGovProject(id: string | null) {
+/** One ingestion source, as the stale-source read selects it. */
+type SourceRow = {
+  name: string;
+  status: string;
+  errorCount: number;
+  lastSuccessAt: Date | null;
+};
+
+/**
+ * A prisma double that answers the governance-project lookup and the source
+ * read behind the stale-data notice. `sources` defaults to none, which is the
+ * healthy answer: no source has stopped, so there is nothing to caveat.
+ */
+function prismaWithGovProject(id: string | null, sources: SourceRow[] = []) {
   return {
     project: { findFirst: vi.fn().mockResolvedValue(id ? { id } : null) },
+    ingestionSource: { findMany: vi.fn().mockResolvedValue(sources) },
   } as unknown as Parameters<typeof GovernanceCostService.create>[0]["prisma"];
 }
 
@@ -440,6 +453,105 @@ describe("GovernanceCostService.summary", () => {
         });
 
         expect(result.seats).toEqual({ status: "awaiting_data" });
+      });
+    });
+  });
+
+  // ADR-128 §4a. A source that has stopped pulling reports no spend, so the
+  // lanes fall and the screen looks like a cheap month. These say where the
+  // numbers stop being complete.
+  describe("given a source has stopped pulling", () => {
+    const brokenSince = (iso: string, name: string): SourceRow => ({
+      name,
+      status: "active",
+      errorCount: 5,
+      lastSuccessAt: new Date(iso),
+    });
+
+    describe("when requesting the summary", () => {
+      it("names the source and the day its data stops", async () => {
+        const service = createService({
+          prisma: prismaWithGovProject("gov-1", [
+            brokenSince("2026-08-20T09:00:00.000Z", "Azure Billing"),
+          ]),
+          costRollup: rollupReturning([]),
+        });
+
+        const result = await service.summary({
+          organizationId: "org-1",
+          windowDays: 30,
+        });
+
+        expect(result.staleSources).toEqual({
+          oldestLastSuccessIso: "2026-08-20T09:00:00.000Z",
+          sourceNames: ["Azure Billing"],
+        });
+      });
+
+      /** @scenario "The gap is dated from the first source that fell over" */
+      it("dates the gap from the first source that fell over, not the last", async () => {
+        const service = createService({
+          prisma: prismaWithGovProject("gov-1", [
+            brokenSince("2026-08-25T09:00:00.000Z", "OpenAI Compliance"),
+            brokenSince("2026-08-20T09:00:00.000Z", "Azure Billing"),
+          ]),
+          costRollup: rollupReturning([]),
+        });
+
+        const result = await service.summary({
+          organizationId: "org-1",
+          windowDays: 30,
+        });
+
+        // The totals stopped being whole when the earlier one broke.
+        expect(result.staleSources?.oldestLastSuccessIso).toBe(
+          "2026-08-20T09:00:00.000Z",
+        );
+        expect(result.staleSources?.sourceNames).toEqual([
+          "Azure Billing",
+          "OpenAI Compliance",
+        ]);
+      });
+    });
+  });
+
+  describe("given every source is still pulling", () => {
+    describe("when requesting the summary", () => {
+      /** @scenario "A source nobody asked to run is not reported as an outage" */
+      it("says nothing, rather than caveating figures that are whole", async () => {
+        const service = createService({
+          prisma: prismaWithGovProject("gov-1", [
+            {
+              name: "Azure Billing",
+              status: "active",
+              errorCount: 0,
+              lastSuccessAt: new Date("2026-09-01T09:00:00.000Z"),
+            },
+            // Switched off on purpose. A source nobody asked to run has not
+            // stopped pulling, and an outage notice here would be a lie.
+            {
+              name: "Retired Source",
+              status: "disabled",
+              errorCount: 9,
+              lastSuccessAt: new Date("2026-01-01T09:00:00.000Z"),
+            },
+            // Never succeeded, so there is no "since" to name.
+            {
+              name: "Brand New",
+              status: "active",
+              errorCount: 5,
+              lastSuccessAt: null,
+            },
+          ]),
+          costRollup: rollupReturning([]),
+        });
+
+        const result = await service.summary({
+          organizationId: "org-1",
+          windowDays: 30,
+        });
+
+        expect(result.staleSources).toBeNull();
       });
     });
   });

--- a/platform/app/ee/governance/services/__tests__/governanceCost.service.unit.test.ts
+++ b/platform/app/ee/governance/services/__tests__/governanceCost.service.unit.test.ts
@@ -488,8 +488,8 @@ describe("GovernanceCostService.summary", () => {
         });
       });
 
-      /** @scenario "The gap is dated from the first source that fell over" */
-      it("dates the gap from the first source that fell over, not the last", async () => {
+      /** @scenario "The gap is dated from the first source that started failing" */
+      it("dates the gap from the first source that started failing, not the last", async () => {
         const service = createService({
           prisma: prismaWithGovProject("gov-1", [
             brokenSince("2026-08-25T09:00:00.000Z", "OpenAI Compliance"),
@@ -517,25 +517,44 @@ describe("GovernanceCostService.summary", () => {
 
   describe("given every source is still pulling", () => {
     describe("when requesting the summary", () => {
-      /** @scenario "A source nobody asked to run is not reported as an outage" */
-      it("says nothing, rather than caveating figures that are whole", async () => {
+      const healthy = {
+        name: "Azure Billing",
+        status: "active",
+        errorCount: 0,
+        lastSuccessAt: new Date("2026-09-01T09:00:00.000Z"),
+      } as const;
+
+      /** @scenario "A source nobody asked to run is not reported as having stopped" */
+      it("ignores a source that was switched off while failing", async () => {
         const service = createService({
           prisma: prismaWithGovProject("gov-1", [
-            {
-              name: "Azure Billing",
-              status: "active",
-              errorCount: 0,
-              lastSuccessAt: new Date("2026-09-01T09:00:00.000Z"),
-            },
+            healthy,
             // Switched off on purpose. A source nobody asked to run has not
-            // stopped pulling, and an outage notice here would be a lie.
+            // stopped pulling, and a warning here would be a lie.
             {
               name: "Retired Source",
               status: "disabled",
               errorCount: 9,
               lastSuccessAt: new Date("2026-01-01T09:00:00.000Z"),
             },
-            // Never succeeded, so there is no "since" to name.
+          ]),
+          costRollup: rollupReturning([]),
+        });
+
+        const result = await service.summary({
+          organizationId: "org-1",
+          windowDays: 30,
+        });
+
+        expect(result.staleSources).toBeNull();
+      });
+
+      /** @scenario "A source that has never pulled has no day to report" */
+      it("ignores a failing source that has never once succeeded", async () => {
+        const service = createService({
+          prisma: prismaWithGovProject("gov-1", [
+            healthy,
+            // Failing hard, but there is no last success to date the gap from.
             {
               name: "Brand New",
               status: "active",

--- a/platform/app/ee/governance/services/governanceCost.service.ts
+++ b/platform/app/ee/governance/services/governanceCost.service.ts
@@ -31,6 +31,7 @@ import type {
   GovernanceSeatReportRow,
 } from "@ee/governance/services/governanceOcsfEvents.clickhouse.repository";
 import { resolveGovProjectId } from "@ee/governance/services/govProject";
+import { noDataSinceNotice } from "@ee/governance/services/pullers/sourceHealth";
 import { createLogger } from "@langwatch/observability";
 import type { PrismaClient } from "~/generated/prisma/client";
 import { GOVERNANCE_COST_SOURCE } from "../projections/governanceCostRollup.constants";
@@ -105,6 +106,25 @@ export interface GovernanceCostDayDto {
   gatewayUsd: number | null;
 }
 
+/**
+ * The point after which the lanes are missing at least one source (ADR-128 §4a).
+ *
+ * A source that has stopped pulling is not asked about anything, so it reports
+ * no spend, so the lanes quietly fall. That is indistinguishable on screen
+ * from a cheap month, and it is the difference between "we spent nothing" and
+ * "we do not know" — which is why this is surfaced rather than left to the
+ * source pages, where only someone already suspicious would look.
+ *
+ * The date is the OLDEST last-success among the stopped sources, because the
+ * totals stop being complete at the first one that fell over, not the last.
+ */
+export interface GovernanceCostStaleSourcesDto {
+  /** Oldest successful pull among the sources that have stopped. */
+  oldestLastSuccessIso: string;
+  /** Names of the stopped sources, alphabetical, so the notice can say which. */
+  sourceNames: string[];
+}
+
 export interface GovernanceCostSummaryDto {
   /**
    * Null when the screen has figures to show. Non-null means every lane is
@@ -120,6 +140,8 @@ export interface GovernanceCostSummaryDto {
   /** Oldest day first. Empty while unavailable. */
   series: GovernanceCostDayDto[];
   windowDays: number;
+  /** Null when every source is still pulling. */
+  staleSources: GovernanceCostStaleSourcesDto | null;
 }
 
 /** A lane nobody has a figure for. Null, never zero — see the file header. */
@@ -141,6 +163,9 @@ function unavailable({
     seats: { status: "awaiting_data" },
     series: [],
     windowDays,
+    // An unavailable screen has no lanes to caveat. The reason it prints
+    // already outranks "a source stopped pulling".
+    staleSources: null,
   };
 }
 
@@ -225,9 +250,10 @@ export class GovernanceCostService {
     // still fails the whole summary: this screen is about money, and a money
     // lane that swallowed its own failure would render an absence as a
     // measurement.
-    const [rows, seats] = await Promise.all([
+    const [rows, seats, staleSources] = await Promise.all([
       costRollup.sumDaysByLane({ tenantId, fromDay, toDay }),
       this.readSeats({ tenantId }),
+      this.readStaleSources({ organizationId }),
     ]);
 
     return {
@@ -237,6 +263,54 @@ export class GovernanceCostService {
       seats,
       series: seriesFrom(rows),
       windowDays,
+      staleSources,
+    };
+  }
+
+  /**
+   * Which sources have stopped pulling, and how far back the lanes are whole.
+   *
+   * Every non-archived source counts, not only the ones that produced rows in
+   * this window. A source broken for longer than the window produces nothing
+   * at all, and that is precisely the case where the screen most needs to say
+   * so — filtering on "contributed recently" would hide the worst outages.
+   */
+  private async readStaleSources({
+    organizationId,
+  }: {
+    organizationId: string;
+  }): Promise<GovernanceCostStaleSourcesDto | null> {
+    const sources = await this.deps.prisma.ingestionSource.findMany({
+      where: { organizationId, archivedAt: null },
+      select: {
+        name: true,
+        status: true,
+        errorCount: true,
+        lastSuccessAt: true,
+      },
+    });
+
+    const stopped = sources.flatMap((source) => {
+      const notice = noDataSinceNotice({
+        status: source.status,
+        errorCount: source.errorCount,
+        lastSuccessAt: source.lastSuccessAt,
+      });
+      return notice
+        ? [{ name: source.name, lastSuccessIso: notice.lastSuccessIso }]
+        : [];
+    });
+    if (stopped.length === 0) return null;
+
+    // Both ISO strings are UTC and fixed-width, so ordering them as text
+    // orders them as instants.
+    const oldest = stopped.reduce((earliest, candidate) =>
+      candidate.lastSuccessIso < earliest.lastSuccessIso ? candidate : earliest,
+    );
+
+    return {
+      oldestLastSuccessIso: oldest.lastSuccessIso,
+      sourceNames: stopped.map((source) => source.name).sort(),
     };
   }
 

--- a/platform/app/ee/governance/services/pullers/sourceHealth.ts
+++ b/platform/app/ee/governance/services/pullers/sourceHealth.ts
@@ -48,3 +48,40 @@ export function isDayCoveredByPull({
 }): boolean {
   return lastSuccessfulPullMs !== null && dayStartMs <= lastSuccessfulPullMs;
 }
+
+/**
+ * The line under a broken source: how far back the numbers can be trusted.
+ *
+ * Returns null while the source is healthy, and null when it has never
+ * pulled successfully -- there is no "since" to name in either case, and the
+ * awaiting-first-event badge already covers the second.
+ *
+ * Disabled is checked first, for the reason the badge checks it first: a
+ * source nobody asked to run has not "stopped pulling". Retained failures
+ * from before it was switched off would otherwise put an outage notice under
+ * a source whose badge, correctly, reads Disabled.
+ *
+ * This lives beside the health rule rather than with the badge that first
+ * needed it, because the cost screen asks the same question about the same
+ * sources (ADR-128 s4a) and must not import a module that pulls in icons.
+ */
+export function noDataSinceNotice({
+  status,
+  errorCount,
+  lastSuccessAt,
+}: {
+  status: string;
+  errorCount: number;
+  lastSuccessAt: Date | string | null;
+}): { lastSuccessIso: string } | null {
+  if (status === "disabled") return null;
+  if (deriveSourceHealth({ consecutiveFailures: errorCount }) === "healthy") {
+    return null;
+  }
+  if (lastSuccessAt === null) return null;
+  const iso =
+    typeof lastSuccessAt === "string"
+      ? lastSuccessAt
+      : lastSuccessAt.toISOString();
+  return { lastSuccessIso: iso };
+}

--- a/platform/app/src/components/governance/CostLanesChart.tsx
+++ b/platform/app/src/components/governance/CostLanesChart.tsx
@@ -11,7 +11,12 @@ import {
   YAxis,
 } from "recharts";
 
-import { CHART_TOOLTIP_CONTENT, CHART_TOOLTIP_LABEL } from "./chartTheme";
+import {
+  CHART_AXIS_TICK,
+  CHART_GRID_STROKE,
+  CHART_TOOLTIP_CONTENT,
+  CHART_TOOLTIP_LABEL,
+} from "./chartTheme";
 import { formatLaneUsd } from "./costLaneFormat";
 
 /** The two lanes' colors. Fixed, so a lane keeps its color between renders. */
@@ -45,10 +50,14 @@ function LaneAreas({ series }: { series: readonly GovernanceCostDayDto[] }) {
   return (
     <ResponsiveContainer width="100%" height="100%">
       <AreaChart data={[...series]}>
-        <CartesianGrid strokeDasharray="3 3" vertical={false} />
-        <XAxis dataKey="day" tick={{ fontSize: 11 }} minTickGap={24} />
+        <CartesianGrid
+          strokeDasharray="3 3"
+          vertical={false}
+          stroke={CHART_GRID_STROKE}
+        />
+        <XAxis dataKey="day" tick={CHART_AXIS_TICK} minTickGap={24} />
         <YAxis
-          tick={{ fontSize: 11 }}
+          tick={CHART_AXIS_TICK}
           width={70}
           tickFormatter={(value: number) => formatLaneUsd(value)}
         />

--- a/platform/app/src/components/governance/CostLanesChart.tsx
+++ b/platform/app/src/components/governance/CostLanesChart.tsx
@@ -11,6 +11,7 @@ import {
   YAxis,
 } from "recharts";
 
+import { CHART_TOOLTIP_CONTENT, CHART_TOOLTIP_LABEL } from "./chartTheme";
 import { formatLaneUsd } from "./costLaneFormat";
 
 /** The two lanes' colors. Fixed, so a lane keeps its color between renders. */
@@ -55,7 +56,8 @@ function LaneAreas({ series }: { series: readonly GovernanceCostDayDto[] }) {
           formatter={(value) =>
             formatLaneUsd(value === null ? null : Number(value))
           }
-          contentStyle={{ fontSize: 12 }}
+          contentStyle={CHART_TOOLTIP_CONTENT}
+          labelStyle={CHART_TOOLTIP_LABEL}
         />
         <Legend wrapperStyle={{ fontSize: 11 }} iconType="circle" />
         <Area

--- a/platform/app/src/components/governance/chartTheme.ts
+++ b/platform/app/src/components/governance/chartTheme.ts
@@ -31,3 +31,18 @@ export const CHART_TOOLTIP_LABEL = {
 export const CHART_TOOLTIP_CURSOR = {
   fill: "var(--chakra-colors-bg-muted)",
 } as const;
+
+/**
+ * Axis labels. Recharts defaults tick text to a fixed `#666`, which is dim
+ * against a dark panel and out of step with every other label on the page.
+ */
+export const CHART_AXIS_TICK = {
+  fontSize: 11,
+  fill: "var(--chakra-colors-fg-muted)",
+} as const;
+
+/**
+ * Grid lines. Left unset, recharts draws them in `#ccc` — on a dark panel that
+ * reads as bright dashes across the data.
+ */
+export const CHART_GRID_STROKE = "var(--chakra-colors-border)";

--- a/platform/app/src/components/governance/chartTheme.ts
+++ b/platform/app/src/components/governance/chartTheme.ts
@@ -1,0 +1,33 @@
+/**
+ * Shared recharts styling for the governance charts.
+ *
+ * Recharts draws its tooltip on a hard-coded white background with a hard-coded
+ * light border. Passing only `fontSize` leaves both in place, so in dark mode
+ * every chart on the page opened a white card, and the date heading inside it —
+ * also hard-coded dark — vanished into it. These map the tooltip onto the same
+ * Chakra tokens as the panel around it, so it follows the theme like everything
+ * else on the screen.
+ */
+
+/** The tooltip card: panel background, real border, readable at either theme. */
+export const CHART_TOOLTIP_CONTENT = {
+  background: "var(--chakra-colors-bg-panel)",
+  border: "1px solid var(--chakra-colors-border)",
+  borderRadius: 6,
+  fontSize: 12,
+} as const;
+
+/**
+ * The heading inside the card — the day, or the series name. Recharts defaults
+ * it to near-black, which is the half of the tooltip that disappeared.
+ */
+export const CHART_TOOLTIP_LABEL = {
+  color: "var(--chakra-colors-fg)",
+  fontWeight: 600,
+  marginBottom: 4,
+} as const;
+
+/** The band drawn behind the hovered category. Chakra's muted, not grey #ccc. */
+export const CHART_TOOLTIP_CURSOR = {
+  fill: "var(--chakra-colors-bg-muted)",
+} as const;

--- a/platform/app/src/components/governance/costs/CostCharts.tsx
+++ b/platform/app/src/components/governance/costs/CostCharts.tsx
@@ -22,6 +22,8 @@ import {
 import { getHexColorForString } from "~/utils/rotatingColors";
 
 import {
+  CHART_AXIS_TICK,
+  CHART_GRID_STROKE,
   CHART_TOOLTIP_CONTENT,
   CHART_TOOLTIP_CURSOR,
   CHART_TOOLTIP_LABEL,
@@ -29,14 +31,8 @@ import {
 
 import type { DailyBucket, RankRow } from "./sampleSeries";
 
-// Chakra tokens rather than fixed greys: a light grid stroke reads as bright
-// white dashes across a dark panel, and the axis labels drift out of step with
-// every other label on the page.
-const AXIS_TICK = {
-  fontSize: 11,
-  fill: "var(--chakra-colors-fg-muted)",
-} as const;
-const GRID_STROKE = "var(--chakra-colors-border)";
+const AXIS_TICK = CHART_AXIS_TICK;
+const GRID_STROKE = CHART_GRID_STROKE;
 
 /** Compact above a thousand, exact below it. Money is read, not audited, here. */
 function fmtMoney(value: number): string {

--- a/platform/app/src/components/governance/costs/CostCharts.tsx
+++ b/platform/app/src/components/governance/costs/CostCharts.tsx
@@ -27,7 +27,7 @@ const AXIS_TICK = { fontSize: 11, fill: "#64748b" } as const;
 const GRID_STROKE = "#e2e8f0";
 
 /** Compact above a thousand, exact below it. Money is read, not audited, here. */
-export function fmtMoney(value: number): string {
+function fmtMoney(value: number): string {
   if (value === 0) return "$0";
   if (Math.abs(value) >= 1000) return numeral(value).format("$0.[0]a");
   return numeral(value).format("$0,0.[00]");

--- a/platform/app/src/components/governance/costs/CostCharts.tsx
+++ b/platform/app/src/components/governance/costs/CostCharts.tsx
@@ -1,0 +1,428 @@
+import { Box, HStack, Text, VStack } from "@chakra-ui/react";
+import numeral from "numeral";
+import { useMemo } from "react";
+import {
+  Area,
+  AreaChart,
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  Legend,
+  Pie,
+  PieChart,
+  ReferenceArea,
+  ReferenceLine,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+import { getHexColorForString } from "~/utils/rotatingColors";
+
+import type { DailyBucket, RankRow } from "./sampleSeries";
+
+const AXIS_TICK = { fontSize: 11, fill: "#64748b" } as const;
+const GRID_STROKE = "#e2e8f0";
+
+/** Compact above a thousand, exact below it. Money is read, not audited, here. */
+export function fmtMoney(value: number): string {
+  if (value === 0) return "$0";
+  if (Math.abs(value) >= 1000) return numeral(value).format("$0.[0]a");
+  return numeral(value).format("$0,0.[00]");
+}
+
+export function fmtCount(value: number): string {
+  return numeral(value).format("0.[0]a");
+}
+
+/** ISO day (or full ISO timestamp) to a short `Jul 5` tick. */
+export function formatDayTick(day: string | number): string {
+  const iso = String(day).slice(0, 10);
+  const parsed = new Date(`${iso}T00:00:00Z`);
+  if (Number.isNaN(parsed.getTime())) return String(day);
+  return parsed.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    timeZone: "UTC",
+  });
+}
+
+function EmptyPanel({ height }: { height: string }) {
+  return (
+    <VStack align="center" justify="center" height={height} color="fg.muted">
+      <Text fontSize="sm">Nothing in this window yet.</Text>
+    </VStack>
+  );
+}
+
+/**
+ * Ranked horizontal bars — label, a bar proportional to the leader, and the
+ * figure. The bar is scaled against the largest row rather than the total, so
+ * a long tail stays legible instead of collapsing into slivers.
+ */
+export function CostRankList({
+  rows,
+  format = fmtMoney,
+  maxRows = 8,
+}: {
+  rows: RankRow[];
+  format?: (value: number) => string;
+  maxRows?: number;
+}) {
+  const shown = useMemo(
+    () => [...rows].sort((a, b) => b.value - a.value).slice(0, maxRows),
+    [rows, maxRows],
+  );
+  const leader = shown[0]?.value ?? 0;
+
+  if (shown.length === 0) return <EmptyPanel height="220px" />;
+
+  return (
+    <VStack align="stretch" gap={2}>
+      {shown.map((row) => (
+        <HStack key={row.key} gap={3} fontSize="sm">
+          <Text flex="0 0 34%" truncate title={row.label}>
+            {row.label}
+          </Text>
+          <Box
+            flex="1"
+            height="14px"
+            borderRadius="sm"
+            backgroundColor="bg.muted"
+            overflow="hidden"
+          >
+            <Box
+              height="100%"
+              borderRadius="sm"
+              width={leader > 0 ? `${(row.value / leader) * 100}%` : "0%"}
+              backgroundColor={getHexColorForString(row.label)}
+            />
+          </Box>
+          <Text
+            flex="0 0 18%"
+            textAlign="right"
+            fontVariantNumeric="tabular-nums"
+          >
+            {format(row.value)}
+          </Text>
+        </HStack>
+      ))}
+    </VStack>
+  );
+}
+
+/**
+ * Donut with the breakdown listed beside it. The list carries the figures, so
+ * the ring itself needs no labels.
+ */
+export function CostDonut({ rows }: { rows: RankRow[] }) {
+  const shown = useMemo(
+    () => [...rows].sort((a, b) => b.value - a.value).slice(0, 8),
+    [rows],
+  );
+  const total = shown.reduce((sum, row) => sum + row.value, 0);
+
+  if (total === 0) return <EmptyPanel height="220px" />;
+
+  return (
+    <HStack align="center" gap={4}>
+      <Box width="150px" height="180px" flexShrink={0}>
+        <ResponsiveContainer width="100%" height="100%">
+          <PieChart>
+            <Pie
+              data={shown}
+              dataKey="value"
+              nameKey="label"
+              innerRadius="58%"
+              outerRadius="88%"
+              paddingAngle={1}
+              isAnimationActive={false}
+              stroke="none"
+            >
+              {shown.map((row) => (
+                <Cell key={row.key} fill={getHexColorForString(row.label)} />
+              ))}
+            </Pie>
+            <Tooltip
+              formatter={(value) => fmtMoney(Number(value))}
+              contentStyle={{ fontSize: 12 }}
+            />
+          </PieChart>
+        </ResponsiveContainer>
+      </Box>
+      <VStack align="stretch" gap={1.5} flex="1" fontSize="xs">
+        {shown.map((row) => (
+          <HStack key={row.key} gap={2}>
+            <Box
+              width="8px"
+              height="8px"
+              borderRadius="full"
+              flexShrink={0}
+              backgroundColor={getHexColorForString(row.label)}
+            />
+            <Text truncate title={row.label} flex="1">
+              {row.label}
+            </Text>
+            <Text fontVariantNumeric="tabular-nums">{fmtMoney(row.value)}</Text>
+            <Text color="fg.muted" flex="0 0 32px" textAlign="right">
+              {Math.round((row.value / total) * 100)}%
+            </Text>
+          </HStack>
+        ))}
+      </VStack>
+    </HStack>
+  );
+}
+
+function seriesKeysOf(buckets: DailyBucket[]): Array<{
+  key: string;
+  label: string;
+}> {
+  const labelByKey = new Map<string, string>();
+  for (const bucket of buckets) {
+    for (const point of bucket.points) {
+      if (!labelByKey.has(point.key)) labelByKey.set(point.key, point.label);
+    }
+  }
+  return [...labelByKey.entries()].map(([key, label]) => ({ key, label }));
+}
+
+function widenBuckets(
+  buckets: DailyBucket[],
+  keys: Array<{ key: string; label: string }>,
+): Array<Record<string, number | string>> {
+  return buckets.map((bucket) => {
+    const row: Record<string, number | string> = { day: bucket.day };
+    for (const k of keys) row[k.key] = 0;
+    for (const point of bucket.points) row[point.key] = point.value;
+    return row;
+  });
+}
+
+/**
+ * Called as a plain function at the call sites below, not rendered as
+ * `<ChartLegend />`. Recharts inspects the *type* of each direct child to
+ * decide what it is, and a custom wrapper component is not a `Legend` as far
+ * as that inspection is concerned — wrapping this in JSX makes the legend
+ * silently disappear. Calling it returns the `Legend` element itself, which is
+ * what Recharts needs to see.
+ */
+function ChartLegend({
+  keys,
+}: {
+  keys: Array<{ key: string; label: string }>;
+}) {
+  return (
+    <Legend
+      wrapperStyle={{ fontSize: 11 }}
+      iconType="circle"
+      formatter={(value: string) =>
+        keys.find((k) => k.key === value)?.label ?? value
+      }
+    />
+  );
+}
+
+/** Daily stacked bars — the shape the cost-evolution panels want. */
+export function CostStackedBars({
+  buckets,
+  height = "220px",
+  format = fmtMoney,
+  showLegend = true,
+}: {
+  buckets: DailyBucket[];
+  height?: string;
+  format?: (value: number) => string;
+  showLegend?: boolean;
+}) {
+  const keys = useMemo(() => seriesKeysOf(buckets), [buckets]);
+  const rows = useMemo(() => widenBuckets(buckets, keys), [buckets, keys]);
+
+  if (rows.length === 0) return <EmptyPanel height={height} />;
+
+  return (
+    <Box height={height}>
+      <ResponsiveContainer width="100%" height="100%">
+        <BarChart data={rows} margin={{ top: 8, right: 8, bottom: 0, left: 0 }}>
+          <CartesianGrid
+            strokeDasharray="3 3"
+            stroke={GRID_STROKE}
+            vertical={false}
+          />
+          <XAxis
+            dataKey="day"
+            tick={AXIS_TICK}
+            tickFormatter={formatDayTick}
+            minTickGap={24}
+          />
+          <YAxis tick={AXIS_TICK} tickFormatter={format} width={58} />
+          <Tooltip
+            formatter={(value, name) => [
+              format(Number(value)),
+              keys.find((k) => k.key === String(name))?.label ?? String(name),
+            ]}
+            labelFormatter={(label) => formatDayTick(label as string)}
+            contentStyle={{ fontSize: 12 }}
+          />
+          {showLegend && ChartLegend({ keys })}
+          {keys.map((k) => (
+            <Bar
+              key={k.key}
+              dataKey={k.key}
+              stackId="cost"
+              fill={getHexColorForString(k.label)}
+              isAnimationActive={false}
+            />
+          ))}
+        </BarChart>
+      </ResponsiveContainer>
+    </Box>
+  );
+}
+
+/**
+ * Stacked area with the tail of the window shaded as a projection. The
+ * projected span is drawn from the same series — it is a run-rate carried
+ * forward, not a separate measurement — and marked so it cannot be read as
+ * something already spent.
+ */
+export function CostForecastArea({
+  buckets,
+  projectedFromDay,
+  height = "220px",
+}: {
+  buckets: DailyBucket[];
+  projectedFromDay: string | null;
+  height?: string;
+}) {
+  const keys = useMemo(() => seriesKeysOf(buckets), [buckets]);
+  const rows = useMemo(() => widenBuckets(buckets, keys), [buckets, keys]);
+  const lastDay = rows[rows.length - 1]?.day;
+
+  if (rows.length === 0) return <EmptyPanel height={height} />;
+
+  return (
+    <Box height={height}>
+      <ResponsiveContainer width="100%" height="100%">
+        <AreaChart
+          data={rows}
+          margin={{ top: 8, right: 8, bottom: 0, left: 0 }}
+        >
+          <CartesianGrid
+            strokeDasharray="3 3"
+            stroke={GRID_STROKE}
+            vertical={false}
+          />
+          <XAxis
+            dataKey="day"
+            tick={AXIS_TICK}
+            tickFormatter={formatDayTick}
+            minTickGap={24}
+          />
+          <YAxis tick={AXIS_TICK} tickFormatter={fmtMoney} width={58} />
+          <Tooltip
+            formatter={(value, name) => [
+              fmtMoney(Number(value)),
+              keys.find((k) => k.key === String(name))?.label ?? String(name),
+            ]}
+            labelFormatter={(label) => formatDayTick(label as string)}
+            contentStyle={{ fontSize: 12 }}
+          />
+          {ChartLegend({ keys })}
+          {projectedFromDay && lastDay && (
+            <ReferenceArea
+              x1={projectedFromDay}
+              x2={String(lastDay)}
+              fill="#94a3b8"
+              fillOpacity={0.12}
+            />
+          )}
+          {projectedFromDay && (
+            <ReferenceLine
+              x={projectedFromDay}
+              stroke="#94a3b8"
+              strokeDasharray="4 4"
+              label={{
+                value: "projected",
+                position: "insideTopRight",
+                fontSize: 10,
+                fill: "#94a3b8",
+              }}
+            />
+          )}
+          {keys.map((k) => (
+            <Area
+              key={k.key}
+              type="monotone"
+              dataKey={k.key}
+              stackId="cost"
+              stroke={getHexColorForString(k.label)}
+              strokeWidth={1.5}
+              fill={getHexColorForString(k.label)}
+              fillOpacity={0.35}
+              isAnimationActive={false}
+            />
+          ))}
+        </AreaChart>
+      </ResponsiveContainer>
+    </Box>
+  );
+}
+
+/** One spiky line, for counts rather than money. */
+export function CostLine({
+  points,
+  height = "220px",
+  format = fmtCount,
+}: {
+  points: Array<{ day: string; value: number }>;
+  height?: string;
+  format?: (value: number) => string;
+}) {
+  if (points.length === 0) return <EmptyPanel height={height} />;
+
+  return (
+    <Box height={height}>
+      <ResponsiveContainer width="100%" height="100%">
+        <AreaChart
+          data={points}
+          margin={{ top: 8, right: 8, bottom: 0, left: 0 }}
+        >
+          <defs>
+            <linearGradient id="cost-line-fill" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stopColor="#3182ce" stopOpacity={0.35} />
+              <stop offset="100%" stopColor="#3182ce" stopOpacity={0.03} />
+            </linearGradient>
+          </defs>
+          <CartesianGrid
+            strokeDasharray="3 3"
+            stroke={GRID_STROKE}
+            vertical={false}
+          />
+          <XAxis
+            dataKey="day"
+            tick={AXIS_TICK}
+            tickFormatter={formatDayTick}
+            minTickGap={24}
+          />
+          <YAxis tick={AXIS_TICK} tickFormatter={format} width={58} />
+          <Tooltip
+            formatter={(value) => format(Number(value))}
+            labelFormatter={(label) => formatDayTick(label as string)}
+            contentStyle={{ fontSize: 12 }}
+          />
+          <Area
+            type="monotone"
+            dataKey="value"
+            stroke="#3182ce"
+            strokeWidth={1.5}
+            fill="url(#cost-line-fill)"
+            isAnimationActive={false}
+          />
+        </AreaChart>
+      </ResponsiveContainer>
+    </Box>
+  );
+}

--- a/platform/app/src/components/governance/costs/CostCharts.tsx
+++ b/platform/app/src/components/governance/costs/CostCharts.tsx
@@ -274,7 +274,10 @@ export function CostStackedBars({
   );
 
   if (buckets === null) return <EmptyPanel height={height} unanswered />;
-  if (rows.length === 0)
+  // A window can come back full of days and empty of series — every day
+  // present, nothing spent on any of them. That has rows but nothing to draw,
+  // and drawing it anyway leaves bare axes that read as a broken chart.
+  if (rows.length === 0 || keys.length === 0)
     return <EmptyPanel height={height} unanswered={false} />;
 
   return (
@@ -338,7 +341,7 @@ export function CostForecastArea({
   const rows = useMemo(() => widenBuckets(buckets, keys), [buckets, keys]);
   const lastDay = rows[rows.length - 1]?.day;
 
-  if (rows.length === 0)
+  if (rows.length === 0 || keys.length === 0)
     return <EmptyPanel height={height} unanswered={false} />;
 
   return (

--- a/platform/app/src/components/governance/costs/CostCharts.tsx
+++ b/platform/app/src/components/governance/costs/CostCharts.tsx
@@ -49,10 +49,27 @@ export function formatDayTick(day: string | number): string {
   });
 }
 
-function EmptyPanel({ height }: { height: string }) {
+/**
+ * The two reasons a panel has nothing to draw, kept apart on purpose.
+ *
+ * A read that answered with no rows measured the window and found it empty.
+ * A read that never answered — still in flight, or never allowed to run —
+ * measured nothing at all. "Nothing in this window yet" is a result, so
+ * showing it for the second case reports a finding the screen does not have.
+ * `null` rows mean unanswered; an empty array means measured-and-empty.
+ */
+function EmptyPanel({
+  height,
+  unanswered,
+}: {
+  height: string;
+  unanswered: boolean;
+}) {
   return (
     <VStack align="center" justify="center" height={height} color="fg.muted">
-      <Text fontSize="sm">Nothing in this window yet.</Text>
+      <Text fontSize="sm">
+        {unanswered ? "Not available." : "Nothing in this window yet."}
+      </Text>
     </VStack>
   );
 }
@@ -67,17 +84,21 @@ export function CostRankList({
   format = fmtMoney,
   maxRows = 8,
 }: {
-  rows: RankRow[];
+  rows: RankRow[] | null;
   format?: (value: number) => string;
   maxRows?: number;
 }) {
   const shown = useMemo(
-    () => [...rows].sort((a, b) => b.value - a.value).slice(0, maxRows),
+    // Copied before sorting: these rows can be a query cache, and sorting in
+    // place would reorder what every other reader of that cache sees.
+    () => [...(rows ?? [])].sort((a, b) => b.value - a.value).slice(0, maxRows),
     [rows, maxRows],
   );
   const leader = shown[0]?.value ?? 0;
 
-  if (shown.length === 0) return <EmptyPanel height="220px" />;
+  if (rows === null) return <EmptyPanel height="220px" unanswered />;
+  if (shown.length === 0)
+    return <EmptyPanel height="220px" unanswered={false} />;
 
   return (
     <VStack align="stretch" gap={2}>
@@ -124,7 +145,7 @@ export function CostDonut({ rows }: { rows: RankRow[] }) {
   );
   const total = shown.reduce((sum, row) => sum + row.value, 0);
 
-  if (total === 0) return <EmptyPanel height="220px" />;
+  if (total === 0) return <EmptyPanel height="220px" unanswered={false} />;
 
   return (
     <HStack align="center" gap={4}>
@@ -232,15 +253,20 @@ export function CostStackedBars({
   format = fmtMoney,
   showLegend = true,
 }: {
-  buckets: DailyBucket[];
+  buckets: DailyBucket[] | null;
   height?: string;
   format?: (value: number) => string;
   showLegend?: boolean;
 }) {
-  const keys = useMemo(() => seriesKeysOf(buckets), [buckets]);
-  const rows = useMemo(() => widenBuckets(buckets, keys), [buckets, keys]);
+  const keys = useMemo(() => seriesKeysOf(buckets ?? []), [buckets]);
+  const rows = useMemo(
+    () => widenBuckets(buckets ?? [], keys),
+    [buckets, keys],
+  );
 
-  if (rows.length === 0) return <EmptyPanel height={height} />;
+  if (buckets === null) return <EmptyPanel height={height} unanswered />;
+  if (rows.length === 0)
+    return <EmptyPanel height={height} unanswered={false} />;
 
   return (
     <Box height={height}>
@@ -301,7 +327,8 @@ export function CostForecastArea({
   const rows = useMemo(() => widenBuckets(buckets, keys), [buckets, keys]);
   const lastDay = rows[rows.length - 1]?.day;
 
-  if (rows.length === 0) return <EmptyPanel height={height} />;
+  if (rows.length === 0)
+    return <EmptyPanel height={height} unanswered={false} />;
 
   return (
     <Box height={height}>
@@ -381,7 +408,8 @@ export function CostLine({
   height?: string;
   format?: (value: number) => string;
 }) {
-  if (points.length === 0) return <EmptyPanel height={height} />;
+  if (points.length === 0)
+    return <EmptyPanel height={height} unanswered={false} />;
 
   return (
     <Box height={height}>

--- a/platform/app/src/components/governance/costs/CostCharts.tsx
+++ b/platform/app/src/components/governance/costs/CostCharts.tsx
@@ -21,10 +21,22 @@ import {
 
 import { getHexColorForString } from "~/utils/rotatingColors";
 
+import {
+  CHART_TOOLTIP_CONTENT,
+  CHART_TOOLTIP_CURSOR,
+  CHART_TOOLTIP_LABEL,
+} from "../chartTheme";
+
 import type { DailyBucket, RankRow } from "./sampleSeries";
 
-const AXIS_TICK = { fontSize: 11, fill: "#64748b" } as const;
-const GRID_STROKE = "#e2e8f0";
+// Chakra tokens rather than fixed greys: a light grid stroke reads as bright
+// white dashes across a dark panel, and the axis labels drift out of step with
+// every other label on the page.
+const AXIS_TICK = {
+  fontSize: 11,
+  fill: "var(--chakra-colors-fg-muted)",
+} as const;
+const GRID_STROKE = "var(--chakra-colors-border)";
 
 /** Compact above a thousand, exact below it. Money is read, not audited, here. */
 function fmtMoney(value: number): string {
@@ -168,7 +180,8 @@ export function CostDonut({ rows }: { rows: RankRow[] }) {
             </Pie>
             <Tooltip
               formatter={(value) => fmtMoney(Number(value))}
-              contentStyle={{ fontSize: 12 }}
+              contentStyle={CHART_TOOLTIP_CONTENT}
+              labelStyle={CHART_TOOLTIP_LABEL}
             />
           </PieChart>
         </ResponsiveContainer>
@@ -290,7 +303,9 @@ export function CostStackedBars({
               keys.find((k) => k.key === String(name))?.label ?? String(name),
             ]}
             labelFormatter={(label) => formatDayTick(label as string)}
-            contentStyle={{ fontSize: 12 }}
+            contentStyle={CHART_TOOLTIP_CONTENT}
+            labelStyle={CHART_TOOLTIP_LABEL}
+            cursor={CHART_TOOLTIP_CURSOR}
           />
           {showLegend && ChartLegend({ keys })}
           {keys.map((k) => (
@@ -355,7 +370,8 @@ export function CostForecastArea({
               keys.find((k) => k.key === String(name))?.label ?? String(name),
             ]}
             labelFormatter={(label) => formatDayTick(label as string)}
-            contentStyle={{ fontSize: 12 }}
+            contentStyle={CHART_TOOLTIP_CONTENT}
+            labelStyle={CHART_TOOLTIP_LABEL}
           />
           {ChartLegend({ keys })}
           {projectedFromDay && lastDay && (
@@ -439,7 +455,8 @@ export function CostLine({
           <Tooltip
             formatter={(value) => format(Number(value))}
             labelFormatter={(label) => formatDayTick(label as string)}
-            contentStyle={{ fontSize: 12 }}
+            contentStyle={CHART_TOOLTIP_CONTENT}
+            labelStyle={CHART_TOOLTIP_LABEL}
           />
           <Area
             type="monotone"

--- a/platform/app/src/components/governance/costs/CostFilterBar.tsx
+++ b/platform/app/src/components/governance/costs/CostFilterBar.tsx
@@ -1,0 +1,175 @@
+import { Button, HStack, Text } from "@chakra-ui/react";
+import {
+  Building2,
+  CalendarDays,
+  ChevronDown,
+  Clock,
+  Layers,
+} from "lucide-react";
+import type { ReactNode } from "react";
+
+import {
+  MenuContent,
+  MenuItem,
+  MenuRoot,
+  MenuTrigger,
+} from "~/components/ui/menu";
+
+import {
+  ALL_DEPARTMENTS,
+  GROUP_BYS,
+  type GroupBy,
+  TIME_FRAMES,
+  TIME_INTERVALS,
+  type TimeInterval,
+} from "./costsWindow";
+
+/**
+ * The filter row: one pill per choice, each showing its own name and the value
+ * currently picked. Every chip here changes what the page renders — a chip
+ * that only looked like a filter would be worse than no chip at all.
+ */
+function FilterChip({
+  icon,
+  label,
+  value,
+  children,
+}: {
+  icon: ReactNode;
+  label: string;
+  value: string;
+  children: ReactNode;
+}) {
+  return (
+    <MenuRoot>
+      <MenuTrigger asChild>
+        <Button
+          size="xs"
+          variant="outline"
+          borderRadius="full"
+          paddingX={3}
+          fontWeight="normal"
+          colorPalette="purple"
+        >
+          <HStack gap={1.5}>
+            {icon}
+            <Text color="fg.muted">{label}</Text>
+            <Text color="fg.muted">·</Text>
+            <Text fontWeight="medium">{value}</Text>
+            <ChevronDown size={12} />
+          </HStack>
+        </Button>
+      </MenuTrigger>
+      <MenuContent minWidth="180px">{children}</MenuContent>
+    </MenuRoot>
+  );
+}
+
+export function CostFilterBar({
+  department,
+  departments,
+  onDepartmentChange,
+  windowDays,
+  onWindowDaysChange,
+  interval,
+  onIntervalChange,
+  groupBy,
+  onGroupByChange,
+}: {
+  department: string;
+  departments: Array<{ id: string; name: string }>;
+  onDepartmentChange: (value: string) => void;
+  windowDays: number;
+  onWindowDaysChange: (value: number) => void;
+  interval: TimeInterval;
+  onIntervalChange: (value: TimeInterval) => void;
+  groupBy: GroupBy;
+  onGroupByChange: (value: GroupBy) => void;
+}) {
+  const departmentLabel =
+    department === ALL_DEPARTMENTS
+      ? "All departments"
+      : (departments.find((d) => d.id === department)?.name ??
+        "All departments");
+  const timeFrameLabel =
+    TIME_FRAMES.find((f) => f.value === windowDays)?.label ??
+    `Last ${windowDays} days`;
+  const intervalLabel =
+    TIME_INTERVALS.find((i) => i.value === interval)?.label ?? "Day";
+  const groupByLabel =
+    GROUP_BYS.find((g) => g.value === groupBy)?.label ?? "Team";
+
+  return (
+    <HStack gap={2} wrap="wrap">
+      <FilterChip
+        icon={<Building2 size={12} />}
+        label="Department"
+        value={departmentLabel}
+      >
+        <MenuItem
+          value={ALL_DEPARTMENTS}
+          onClick={() => onDepartmentChange(ALL_DEPARTMENTS)}
+        >
+          All departments
+        </MenuItem>
+        {departments.map((d) => (
+          <MenuItem
+            key={d.id}
+            value={d.id}
+            onClick={() => onDepartmentChange(d.id)}
+          >
+            {d.name}
+          </MenuItem>
+        ))}
+      </FilterChip>
+
+      <FilterChip
+        icon={<CalendarDays size={12} />}
+        label="Time Frame"
+        value={timeFrameLabel}
+      >
+        {TIME_FRAMES.map((frame) => (
+          <MenuItem
+            key={frame.value}
+            value={String(frame.value)}
+            onClick={() => onWindowDaysChange(frame.value)}
+          >
+            {frame.label}
+          </MenuItem>
+        ))}
+      </FilterChip>
+
+      <FilterChip
+        icon={<Clock size={12} />}
+        label="Time Interval"
+        value={intervalLabel}
+      >
+        {TIME_INTERVALS.map((option) => (
+          <MenuItem
+            key={option.value}
+            value={option.value}
+            onClick={() => onIntervalChange(option.value)}
+          >
+            {option.label}
+          </MenuItem>
+        ))}
+      </FilterChip>
+
+      <FilterChip
+        icon={<Layers size={12} />}
+        label="Group By"
+        value={groupByLabel}
+      >
+        {GROUP_BYS.map((option) => (
+          <MenuItem
+            key={option.value}
+            value={option.value}
+            onClick={() => onGroupByChange(option.value)}
+          >
+            {option.label}
+          </MenuItem>
+        ))}
+      </FilterChip>
+    </HStack>
+  );
+}

--- a/platform/app/src/components/governance/costs/CostPanel.tsx
+++ b/platform/app/src/components/governance/costs/CostPanel.tsx
@@ -1,0 +1,48 @@
+import { Badge, Box, Heading, HStack, Spacer, VStack } from "@chakra-ui/react";
+import type { ReactNode } from "react";
+
+/**
+ * Card shell for every panel on the Costs page: a title, the panel, and
+ * nothing else. The page deliberately carries no explanatory prose — a
+ * heading and the figures beneath it have to do the work.
+ *
+ * `sample` marks a panel drawn from `sampleSeries` rather than from a real
+ * read. It is a badge rather than a sentence so it stays out of the way, but
+ * it is never optional on a placeholder panel: unlabelled invented money is
+ * indistinguishable from the organization's own.
+ */
+export function CostPanel({
+  title,
+  sample = false,
+  action,
+  children,
+}: {
+  title: string;
+  sample?: boolean;
+  action?: ReactNode;
+  children: ReactNode;
+}) {
+  return (
+    <VStack
+      align="stretch"
+      gap={3}
+      borderWidth="1px"
+      borderColor="border.subtle"
+      borderRadius="lg"
+      backgroundColor="bg.panel"
+      padding={4}
+    >
+      <HStack gap={2}>
+        <Heading size="sm">{title}</Heading>
+        {sample && (
+          <Badge size="xs" variant="subtle" colorPalette="gray">
+            sample
+          </Badge>
+        )}
+        <Spacer />
+        {action}
+      </HStack>
+      <Box>{children}</Box>
+    </VStack>
+  );
+}

--- a/platform/app/src/components/governance/costs/CostPanel.tsx
+++ b/platform/app/src/components/governance/costs/CostPanel.tsx
@@ -24,6 +24,7 @@ export function CostPanel({
 }) {
   return (
     <VStack
+      data-testid="cost-panel"
       align="stretch"
       gap={3}
       borderWidth="1px"

--- a/platform/app/src/components/governance/costs/CostSampleControls.tsx
+++ b/platform/app/src/components/governance/costs/CostSampleControls.tsx
@@ -1,0 +1,84 @@
+import { Button, Flex, Icon, Text } from "@chakra-ui/react";
+import { Compass, Sparkles, Tent } from "lucide-react";
+import type React from "react";
+
+/**
+ * The two affordances that come with the Costs page's sample panels: the
+ * toggle that turns them on and off, and the banner that says what they are.
+ *
+ * Both are modelled on the trace explorer's sample-data pair
+ * (`Toolbar.tsx`, `SampleDataBanner.tsx`) — same words, same orange, same
+ * single exit — because a reader who has learned what "sample data" means on
+ * one screen should not have to learn it again on another.
+ */
+
+/**
+ * Toggle for the sample panels.
+ *
+ * Unlike the trace explorer's, this one stays on screen after real data
+ * arrives. There it is onboarding furniture: sample traces stand in for real
+ * traces, so once real ones exist the button has nothing left to offer and is
+ * hidden. Here the sample panels show measurements the platform does not take
+ * at all, so an organization with a full cost screen still has a reason to
+ * look at them — they are the only picture of what the screen will hold once
+ * those measurements exist.
+ */
+export const CostSampleToggle: React.FC<{
+  active: boolean;
+  onToggle: () => void;
+}> = ({ active, onToggle }) => {
+  const label = active ? "Hide sample data" : "See sample data";
+  return (
+    <Button
+      size="xs"
+      variant={active ? "subtle" : "ghost"}
+      colorPalette={active ? "orange" : undefined}
+      onClick={onToggle}
+      aria-label={label}
+      aria-pressed={active}
+    >
+      <Icon boxSize={3.5} color={{ base: "orange.500", _dark: "orange.fg" }}>
+        {active ? <Tent /> : <Compass />}
+      </Icon>
+      {label}
+    </Button>
+  );
+};
+
+/**
+ * The honesty affordance, rendered above the panels whenever any of them are
+ * invented.
+ *
+ * Each sample panel already carries its own badge, but a badge is a label on
+ * one panel and this is a claim about the screen. The failure it guards
+ * against is a reader who arrives at a filled-in dashboard, reads a figure off
+ * it, and never looks at the corner of the card it came from — money in the
+ * house typeface reads as measured whether or not it was.
+ *
+ * `role="status"` rather than an alert: this is a standing condition of the
+ * screen, not an event, and it should not interrupt a screen reader mid-
+ * sentence to announce it.
+ */
+export const CostSampleBanner: React.FC = () => (
+  <Flex
+    role="status"
+    align="center"
+    gap={2}
+    paddingX={3.5}
+    paddingY={2.5}
+    background="orange.subtle"
+    borderWidth="1px"
+    borderColor="orange.muted"
+    borderRadius="md"
+    color="orange.fg"
+    flexShrink={0}
+  >
+    <Icon boxSize={4}>
+      <Sparkles />
+    </Icon>
+    <Text textStyle="sm" fontWeight={600}>
+      Panels marked sample are illustrations of measurements we do not take yet
+      — nothing here is real.
+    </Text>
+  </Flex>
+);

--- a/platform/app/src/components/governance/costs/__tests__/costSampleMode.unit.test.ts
+++ b/platform/app/src/components/governance/costs/__tests__/costSampleMode.unit.test.ts
@@ -10,7 +10,11 @@
  */
 import { describe, expect, it } from "vitest";
 
-import { resolveRealDataState, sampleModeActive } from "../costSampleMode";
+import {
+  resolveRealDataState,
+  sampleModeActive,
+  settleRealDataState,
+} from "../costSampleMode";
 
 describe("reading the real cost reads", () => {
   describe("given every read has answered with rows", () => {
@@ -66,6 +70,31 @@ describe("deciding whether the sample panels render", () => {
       expect(sampleModeActive({ optIn: false, realData: "absent" })).toBe(
         false,
       );
+    });
+  });
+});
+
+describe("holding the answer across a gap in the reads", () => {
+  describe("given the reads go unanswered again", () => {
+    it("keeps the empty screen empty instead of forgetting it", () => {
+      expect(settleRealDataState("absent", "unknown")).toBe("absent");
+    });
+
+    it("keeps real figures real instead of forgetting them", () => {
+      expect(settleRealDataState("present", "unknown")).toBe("present");
+    });
+  });
+
+  describe("given a later window answers", () => {
+    it("takes the new answer over the held one", () => {
+      expect(settleRealDataState("absent", "present")).toBe("present");
+      expect(settleRealDataState("present", "absent")).toBe("absent");
+    });
+  });
+
+  describe("given nothing has answered yet", () => {
+    it("has nothing to hold", () => {
+      expect(settleRealDataState("unknown", "unknown")).toBe("unknown");
     });
   });
 });

--- a/platform/app/src/components/governance/costs/__tests__/costSampleMode.unit.test.ts
+++ b/platform/app/src/components/governance/costs/__tests__/costSampleMode.unit.test.ts
@@ -1,0 +1,71 @@
+/**
+ * The two rules behind the sample panels' visibility, tested directly because
+ * the interesting case is one the page cannot easily be put into: reads that
+ * land at different times.
+ *
+ * Four reads answer independently, so mid-load the page holds a mix of rows
+ * and nulls. Reading that mix as "nothing measured" would flash the sample
+ * panels onto a screen that is about to fill with real figures — the exact
+ * flicker the `unknown` state exists to prevent.
+ */
+import { describe, expect, it } from "vitest";
+
+import { resolveRealDataState, sampleModeActive } from "../costSampleMode";
+
+describe("reading the real cost reads", () => {
+  describe("given every read has answered with rows", () => {
+    it("reports the organization has real figures", () => {
+      expect(resolveRealDataState([[1], [1]])).toBe("present");
+    });
+  });
+
+  describe("given one read holds rows and another has not answered", () => {
+    it("reports figures rather than waiting on the slower read", () => {
+      expect(resolveRealDataState([[1], null])).toBe("present");
+    });
+  });
+
+  describe("given one read answered empty and another has not answered", () => {
+    it("withholds a verdict, since the pending read may hold the figures", () => {
+      expect(resolveRealDataState([[], null])).toBe("unknown");
+    });
+  });
+
+  describe("given every read answered and all are empty", () => {
+    it("reports the screen as measured and empty", () => {
+      expect(resolveRealDataState([[], []])).toBe("absent");
+    });
+  });
+});
+
+describe("deciding whether the sample panels render", () => {
+  describe("given the reader has not touched the toggle", () => {
+    it("fills an empty screen", () => {
+      expect(sampleModeActive({ optIn: null, realData: "absent" })).toBe(true);
+    });
+
+    it("stays out of the way of real figures", () => {
+      expect(sampleModeActive({ optIn: null, realData: "present" })).toBe(
+        false,
+      );
+    });
+
+    it("waits rather than guessing while a read is in flight", () => {
+      expect(sampleModeActive({ optIn: null, realData: "unknown" })).toBe(
+        false,
+      );
+    });
+  });
+
+  describe("given the reader has chosen", () => {
+    it("shows the panels over real figures when they asked for them", () => {
+      expect(sampleModeActive({ optIn: true, realData: "present" })).toBe(true);
+    });
+
+    it("leaves an empty screen empty when they turned them off", () => {
+      expect(sampleModeActive({ optIn: false, realData: "absent" })).toBe(
+        false,
+      );
+    });
+  });
+});

--- a/platform/app/src/components/governance/costs/costSampleMode.ts
+++ b/platform/app/src/components/governance/costs/costSampleMode.ts
@@ -13,6 +13,7 @@
  * removes those panels rather than emptying them: a permanently blank panel
  * would imply we looked and found nothing.
  */
+import { useRef } from "react";
 
 /**
  * What the real reads have told us so far. `unknown` is a distinct answer
@@ -41,6 +42,39 @@ export function resolveRealDataState(
 }
 
 /**
+ * Hold the last real answer across a gap in the reads.
+ *
+ * Changing a filter chip re-keys every activity query, and until the new
+ * window lands they all read as unanswered again. Recomputing the default from
+ * that gap would take an organization that we already know is empty, decide we
+ * no longer know, and pull the sample panels off the screen until the new
+ * reads arrive — a flicker on every filter change. An answer we have already
+ * had stands until a later one replaces it.
+ */
+export function settleRealDataState(
+  previous: RealDataState,
+  current: RealDataState,
+): RealDataState {
+  return current === "unknown" ? previous : current;
+}
+
+/**
+ * `settleRealDataState` applied across renders. Writing the ref during render
+ * is safe because the result depends only on the arguments, so a repeated
+ * render reaches the same answer.
+ */
+export function useSettledRealDataState(
+  reads: ReadonlyArray<{ length: number } | null>,
+): RealDataState {
+  const settled = useRef<RealDataState>("unknown");
+  settled.current = settleRealDataState(
+    settled.current,
+    resolveRealDataState(reads),
+  );
+  return settled.current;
+}
+
+/**
  * Whether the sample panels render.
  *
  * `optIn` is the reader's own choice — `null` until they touch the toggle,
@@ -58,4 +92,3 @@ export function sampleModeActive({
   if (optIn !== null) return optIn;
   return realData === "absent";
 }
-

--- a/platform/app/src/components/governance/costs/costSampleMode.ts
+++ b/platform/app/src/components/governance/costs/costSampleMode.ts
@@ -1,0 +1,61 @@
+/**
+ * Whether the Costs page is currently showing its sample panels.
+ *
+ * The rule is the one the trace explorer already uses for sample traces
+ * (`usePreviewTracesActive`): sample data fills an empty screen, and gets out
+ * of the way once the screen has something real on it. An explicit choice by
+ * the reader always wins over both.
+ *
+ * The difference from traces is what "off" means. A sample trace stands in for
+ * a real trace that has not arrived yet, so traces swap one for the other. Half
+ * the Costs panels have no backing read at all — nothing measures agents, seats
+ * or forecasts today — so there is nothing to swap in. Turning samples off
+ * removes those panels rather than emptying them: a permanently blank panel
+ * would imply we looked and found nothing.
+ */
+
+/**
+ * What the real reads have told us so far. `unknown` is a distinct answer
+ * rather than a pessimistic `absent`, because defaulting to sample-on while a
+ * read is still in flight would flash the sample panels up and then pull them
+ * away the moment the data landed.
+ */
+export type RealDataState = "unknown" | "present" | "absent";
+
+/**
+ * Resolve the three states from the real reads. A read that has not answered
+ * is `null`; one that answered with no rows is an empty array.
+ *
+ * Any read holding a row means the organization has real cost data, so the
+ * page has something to show and samples stay out of the way. Only once
+ * *every* read has answered, and all of them are empty, is the screen known to
+ * be empty — a single unanswered read is enough to keep the answer `unknown`,
+ * since it might be the one holding the data.
+ */
+export function resolveRealDataState(
+  reads: ReadonlyArray<{ length: number } | null>,
+): RealDataState {
+  if (reads.some((read) => read !== null && read.length > 0)) return "present";
+  if (reads.some((read) => read === null)) return "unknown";
+  return "absent";
+}
+
+/**
+ * Whether the sample panels render.
+ *
+ * `optIn` is the reader's own choice — `null` until they touch the toggle,
+ * which is what lets the default follow the data underneath them. Once they
+ * have chosen, the data no longer overrides it: a reader who turned samples
+ * off does not want them back when a read comes back empty.
+ */
+export function sampleModeActive({
+  optIn,
+  realData,
+}: {
+  optIn: boolean | null;
+  realData: RealDataState;
+}): boolean {
+  if (optIn !== null) return optIn;
+  return realData === "absent";
+}
+

--- a/platform/app/src/components/governance/costs/costsWindow.ts
+++ b/platform/app/src/components/governance/costs/costsWindow.ts
@@ -1,0 +1,116 @@
+/**
+ * The choices the Costs filter bar offers, and the one transformation they
+ * imply that the API does not already do for us.
+ *
+ * Time frame and group-by are passed straight to `api.activityMonitor.*`.
+ * Time interval is applied here instead: the spend endpoints return daily
+ * buckets and nothing else, so weekly and monthly views are folded from those
+ * days on the client rather than re-queried.
+ */
+
+import type { DailyBucket } from "./sampleSeries";
+
+export const TIME_FRAMES = [
+  { value: 7, label: "Last 7 days" },
+  { value: 30, label: "Last 30 days" },
+  { value: 90, label: "Last 90 days" },
+] as const;
+
+export type TimeInterval = "day" | "week" | "month";
+
+export const TIME_INTERVALS: Array<{ value: TimeInterval; label: string }> = [
+  { value: "day", label: "Day" },
+  { value: "week", label: "Week" },
+  { value: "month", label: "Month" },
+];
+
+export type GroupBy = "team" | "user" | "model";
+
+export const GROUP_BYS: Array<{ value: GroupBy; label: string }> = [
+  { value: "team", label: "Team" },
+  { value: "user", label: "User" },
+  { value: "model", label: "Model" },
+];
+
+export const ALL_DEPARTMENTS = "__all__";
+
+/**
+ * The ISO day that starts the bucket `day` falls into. Weeks start Monday;
+ * months start on the first. Days are returned unchanged, which is what makes
+ * the day case free rather than a no-op pass over the data.
+ */
+function bucketStartOf(day: string, interval: TimeInterval): string {
+  if (interval === "day") return day;
+  const date = new Date(`${day.slice(0, 10)}T00:00:00Z`);
+  if (Number.isNaN(date.getTime())) return day;
+  if (interval === "month") {
+    date.setUTCDate(1);
+    return date.toISOString().slice(0, 10);
+  }
+  // Monday-start weeks: getUTCDay() is 0 on Sunday, which is 6 days in.
+  const dayOfWeek = date.getUTCDay();
+  const backToMonday = (dayOfWeek + 6) % 7;
+  date.setUTCDate(date.getUTCDate() - backToMonday);
+  return date.toISOString().slice(0, 10);
+}
+
+/**
+ * Fold daily buckets into weekly or monthly ones, summing each series across
+ * the days it covers. Series absent from some days simply contribute nothing
+ * on those days rather than dropping out of the fold.
+ */
+export function aggregateBuckets(
+  buckets: DailyBucket[],
+  interval: TimeInterval,
+): DailyBucket[] {
+  if (interval === "day") return buckets;
+
+  const byBucket = new Map<
+    string,
+    Map<string, { label: string; value: number }>
+  >();
+  for (const bucket of buckets) {
+    const start = bucketStartOf(bucket.day, interval);
+    let series = byBucket.get(start);
+    if (!series) {
+      series = new Map();
+      byBucket.set(start, series);
+    }
+    for (const point of bucket.points) {
+      const existing = series.get(point.key);
+      if (existing) {
+        existing.value += point.value;
+      } else {
+        series.set(point.key, { label: point.label, value: point.value });
+      }
+    }
+  }
+
+  return [...byBucket.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([day, series]) => ({
+      day,
+      points: [...series.entries()].map(([key, { label, value }]) => ({
+        key,
+        label,
+        value,
+      })),
+    }));
+}
+
+/** The same fold for a single unstacked line. */
+export function aggregateLine(
+  points: Array<{ day: string; value: number }>,
+  interval: TimeInterval,
+): Array<{ day: string; value: number }> {
+  if (interval === "day") return points;
+
+  const totals = new Map<string, number>();
+  for (const point of points) {
+    const start = bucketStartOf(point.day, interval);
+    totals.set(start, (totals.get(start) ?? 0) + point.value);
+  }
+  return [...totals.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([day, value]) => ({ day, value }));
+}

--- a/platform/app/src/components/governance/costs/sampleSeries.ts
+++ b/platform/app/src/components/governance/costs/sampleSeries.ts
@@ -1,0 +1,168 @@
+/**
+ * Placeholder series for the Costs panels whose backing data does not exist
+ * yet — agents, prepaid seats, forecasts, token counts and Genie questions.
+ * Nothing here reads the database, and every panel drawn from this module is
+ * badged `sample` in the UI so a reader never mistakes these figures for the
+ * organization's own money.
+ *
+ * The numbers are generated from a seeded pseudo-random sequence rather than
+ * `Math.random`, so a given label always paints the same shape. That keeps the
+ * server-rendered markup identical to the client's first paint, and keeps the
+ * page from reshuffling itself on every re-render.
+ *
+ * Panels backed by real reads — total spend, cost by department, cost by user,
+ * cost by model, cost over time — do not come through here.
+ *
+ * Spec: specs/ai-gateway/governance/governance-home-routing.feature
+ * (the billed-cost flag section).
+ */
+
+export interface RankRow {
+  key: string;
+  label: string;
+  value: number;
+}
+
+export interface DailyPoint {
+  key: string;
+  label: string;
+  value: number;
+}
+
+export interface DailyBucket {
+  day: string;
+  points: DailyPoint[];
+}
+
+/**
+ * Mulberry32. Small, fast, and — the only property we actually need —
+ * completely determined by its seed.
+ */
+function seededRandom(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/** Stable 32-bit hash of a label, so each series seeds itself. */
+function hashLabel(label: string): number {
+  let hash = 2166136261;
+  for (let i = 0; i < label.length; i++) {
+    hash ^= label.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}
+
+export const SAMPLE_AGENTS = [
+  "support-copilot-prod",
+  "checkout-agent-prod",
+  "fraud-triage-prod",
+  "churn-predictor",
+  "docs-rag-prod",
+  "revenue-forecaster",
+  "etl-doctor",
+  "hr-helpdesk",
+] as const;
+
+export const SAMPLE_DEPARTMENTS = [
+  "Engineering",
+  "Data & AI",
+  "Unallocated",
+  "Customer Support",
+  "Marketing",
+] as const;
+
+/**
+ * The last `days` calendar days ending today, as ISO day strings. Callers hold
+ * this in a `useMemo` so the window is read from the clock once per render
+ * pass rather than once per series.
+ */
+export function recentDays(days: number): string[] {
+  const out: string[] = [];
+  const today = new Date();
+  for (let i = days - 1; i >= 0; i--) {
+    const d = new Date(today);
+    d.setDate(today.getDate() - i);
+    out.push(d.toISOString().slice(0, 10));
+  }
+  return out;
+}
+
+/**
+ * A ranked list that falls away steeply from its leader, the way real spend
+ * does — one agent carrying most of the bill and a long tail beneath it.
+ */
+export function sampleRanked(
+  labels: readonly string[],
+  topValue: number,
+): RankRow[] {
+  return labels.map((label, index) => {
+    const random = seededRandom(hashLabel(label));
+    const decay = 0.42 ** index;
+    const jitter = 0.75 + random() * 0.5;
+    return {
+      key: label,
+      label,
+      value: Math.round(topValue * decay * jitter),
+    };
+  });
+}
+
+/** Daily buckets with one stacked segment per label. */
+export function sampleDaily(
+  days: string[],
+  labels: readonly string[],
+  dailyTopValue: number,
+): DailyBucket[] {
+  const randomByLabel = new Map(
+    labels.map((label) => [label, seededRandom(hashLabel(label))]),
+  );
+  return days.map((day) => ({
+    day,
+    points: labels.map((label, index) => {
+      const random = randomByLabel.get(label)!;
+      const decay = 0.5 ** index;
+      return {
+        key: label,
+        label,
+        value: Math.round(dailyTopValue * decay * (0.35 + random() * 1.3)),
+      };
+    }),
+  }));
+}
+
+/** A single spiky line — token counts rather than money. */
+export function sampleLine(
+  days: string[],
+  seed: string,
+  midpoint: number,
+): Array<{ day: string; value: number }> {
+  const random = seededRandom(hashLabel(seed));
+  return days.map((day) => ({
+    day,
+    value: Math.round(midpoint * (0.3 + random() * 1.7)),
+  }));
+}
+
+/**
+ * Consumption split into the part already spent and the part still projected,
+ * so the forecast panel can paint the run-rate tail in a lighter shade. The
+ * last quarter of the window is the projection.
+ */
+export function sampleForecast(
+  days: string[],
+  labels: readonly string[],
+  dailyTopValue: number,
+): { buckets: DailyBucket[]; projectedFromDay: string | null } {
+  const splitIndex = Math.floor(days.length * 0.75);
+  return {
+    buckets: sampleDaily(days, labels, dailyTopValue),
+    projectedFromDay: days[splitIndex] ?? null,
+  };
+}

--- a/platform/app/src/pages/governance/__tests__/costBreakdowns.integration.test.tsx
+++ b/platform/app/src/pages/governance/__tests__/costBreakdowns.integration.test.tsx
@@ -1,0 +1,207 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The breakdown panels under the cost lanes, mounted through the real page.
+ *
+ * Two things are under test, and both are about what the screen is allowed to
+ * claim. First, the panels have to survive a real answer: the activity reads
+ * hand back a wrapper object, not a list, and a panel that maps over the
+ * wrapper throws the instant real data arrives — which no test caught, because
+ * every existing mock answers `undefined`. Second, a panel that has not heard
+ * back must not print a figure: "0 users" and "nothing in this window" are both
+ * measurements, and neither has been made while a read is still in flight or
+ * was never permitted to run.
+ *
+ * Spec: specs/governance/governance-cost-screen.feature
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import type React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const harness = vi.hoisted(() => ({
+  /** What each activity read answers. `undefined` means it has not answered. */
+  activity: {
+    summary: undefined as unknown,
+    spendByDepartment: undefined as unknown,
+    spendByUser: undefined as unknown,
+    spendOverTime: undefined as unknown,
+  },
+}));
+
+vi.mock("~/hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({
+    isLoading: false,
+    organization: { id: "org-1", slug: "acme", name: "ACME", teams: [] },
+    organizations: [],
+    project: undefined,
+    hasPermission: () => true,
+    hasOrgPermission: () => true,
+    hasAnyPermission: () => true,
+  }),
+}));
+
+vi.mock("~/hooks/useFeatureFlag", () => ({
+  useFeatureFlag: () => ({ enabled: true, isLoading: false }),
+}));
+vi.mock("~/hooks/useActivePlan", () => ({
+  useActivePlan: () => ({ isEnterprise: true, activePlan: undefined }),
+}));
+vi.mock("~/components/governance/GovernanceLayout", () => ({
+  default: ({ children }: { children: React.ReactNode }) => children,
+}));
+vi.mock("~/components/NotFoundScene", () => ({
+  NotFoundScene: () => <div>this page does not exist</div>,
+}));
+vi.mock("~/components/LoadingScreen", () => ({
+  LoadingScreen: () => <div>loading</div>,
+}));
+
+vi.mock("~/utils/api", () => ({
+  api: {
+    governanceCost: {
+      summary: {
+        useQuery: () => ({
+          data: {
+            unavailableReason: null,
+            billed: { amountUsd: 123.45, cellsWithoutAmount: 0 },
+            gateway: { amountUsd: 67.89, cellsWithoutAmount: 0 },
+            seats: { status: "awaiting_data" },
+            series: [
+              { day: "2026-08-01", billedUsd: 123.45, gatewayUsd: 67.89 },
+            ],
+            windowDays: 30,
+          },
+          isLoading: false,
+          isError: false,
+        }),
+      },
+    },
+    activityMonitor: {
+      summary: { useQuery: () => ({ data: harness.activity.summary }) },
+      spendByDepartment: {
+        useQuery: () => ({ data: harness.activity.spendByDepartment }),
+      },
+      spendByUser: {
+        useQuery: () => ({ data: harness.activity.spendByUser }),
+      },
+      spendOverTime: {
+        useQuery: () => ({ data: harness.activity.spendOverTime }),
+      },
+    },
+  },
+}));
+
+import CostsPage from "../costs";
+
+const renderScreen = () =>
+  render(
+    <ChakraProvider value={defaultSystem}>
+      <CostsPage />
+    </ChakraProvider>,
+  );
+
+beforeEach(() => {
+  harness.activity = {
+    summary: undefined,
+    spendByDepartment: undefined,
+    spendByUser: undefined,
+    spendOverTime: undefined,
+  };
+});
+
+afterEach(() => cleanup());
+
+describe("the cost breakdown panels", () => {
+  describe("given the activity reads answer with real figures", () => {
+    beforeEach(() => {
+      harness.activity.summary = {
+        activeUsersThisWindow: 42,
+        newUsersThisWindow: 3,
+        spentThisWindowUsd: "500.00",
+      };
+      harness.activity.spendByDepartment = [
+        {
+          departmentId: "dep-1",
+          departmentName: "Engineering",
+          spendUsd: "310.50",
+        },
+        {
+          departmentId: "dep-2",
+          departmentName: "Support",
+          spendUsd: "120.25",
+        },
+      ];
+      harness.activity.spendByUser = [
+        { actor: "ada@acme.test", spendUsd: "200.00", requests: 90 },
+      ];
+      // The read answers a wrapper around the buckets, not the buckets. A
+      // panel that treats this as a list throws here rather than rendering.
+      harness.activity.spendOverTime = {
+        buckets: [
+          {
+            bucketIso: "2026-08-01",
+            points: [
+              { key: "team-a", label: "Team A", spendUsd: "310.50" },
+              { key: "team-b", label: "Team B", spendUsd: "120.25" },
+            ],
+          },
+        ],
+      };
+    });
+
+    it("renders the real breakdowns instead of throwing on the wrapper", () => {
+      renderScreen();
+
+      expect(screen.getByText("Engineering")).toBeInTheDocument();
+      expect(screen.getByText("Support")).toBeInTheDocument();
+      expect(screen.getByText("ada@acme.test")).toBeInTheDocument();
+    });
+
+    it("reports the measured user count", () => {
+      renderScreen();
+
+      expect(screen.getByText("42")).toBeInTheDocument();
+    });
+
+    it("never claims a real panel is empty while it holds figures", () => {
+      renderScreen();
+
+      expect(screen.queryByText("Not available.")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("given an activity read has not answered", () => {
+    it("says so rather than printing a zero nobody measured", () => {
+      renderScreen();
+
+      // The adoption card and every real panel are unanswered here, so the
+      // screen may not show "0" or claim the window held nothing.
+      expect(screen.queryByText("0")).not.toBeInTheDocument();
+      expect(
+        screen.queryByText("Nothing in this window yet."),
+      ).not.toBeInTheDocument();
+      expect(screen.getAllByText("Not available.").length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("given an activity read answers with no rows", () => {
+    it("reports the window as empty, which it measured", () => {
+      harness.activity.summary = {
+        activeUsersThisWindow: 0,
+        newUsersThisWindow: 0,
+        spentThisWindowUsd: "0",
+      };
+      harness.activity.spendByDepartment = [];
+      harness.activity.spendByUser = [];
+      harness.activity.spendOverTime = { buckets: [] };
+
+      renderScreen();
+
+      expect(
+        screen.getAllByText("Nothing in this window yet.").length,
+      ).toBeGreaterThan(0);
+    });
+  });
+});

--- a/platform/app/src/pages/governance/__tests__/costBreakdowns.integration.test.tsx
+++ b/platform/app/src/pages/governance/__tests__/costBreakdowns.integration.test.tsx
@@ -15,7 +15,7 @@
  * Spec: specs/governance/governance-cost-screen.feature
  */
 import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, render, screen, within } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
 import type React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -202,6 +202,50 @@ describe("the cost breakdown panels", () => {
       expect(
         screen.getAllByText("Nothing in this window yet.").length,
       ).toBeGreaterThan(0);
+    });
+  });
+
+  describe("given the window answers with days but nothing spent on any of them", () => {
+    it("says the window is empty rather than drawing bare axes", () => {
+      // The read answered, and it answered with a full window — one bucket per
+      // day, no spend on any. There is a row per day and no series to plot, so
+      // a length check on the rows alone lets this through and the panel draws
+      // an axis with nothing above it, which reads as a chart that broke.
+      harness.activity.summary = {
+        activeUsersThisWindow: 4,
+        newUsersThisWindow: 1,
+        spentThisWindowUsd: "0",
+      };
+      harness.activity.spendByDepartment = [
+        {
+          departmentId: "dep-1",
+          departmentName: "Engineering",
+          spendUsd: "410.00",
+        },
+      ];
+      harness.activity.spendByUser = [
+        { actor: "ada@acme.test", spendUsd: "200.00", requests: 90 },
+      ];
+      harness.activity.spendOverTime = {
+        buckets: [
+          { bucketIso: "2026-08-01", points: [] },
+          { bucketIso: "2026-08-02", points: [] },
+        ],
+      };
+
+      renderScreen();
+
+      // Scoped to this panel on purpose. Other panels are empty for their own
+      // reasons and print the same sentence, so a page-wide search for it
+      // passes whether or not this panel drew bare axes.
+      const panel = screen
+        .getByText("Cost evolution by team")
+        .closest('[data-testid="cost-panel"]');
+
+      expect(panel).not.toBeNull();
+      expect(
+        within(panel as HTMLElement).getByText("Nothing in this window yet."),
+      ).toBeInTheDocument();
     });
   });
 });

--- a/platform/app/src/pages/governance/__tests__/costSampleMode.integration.test.tsx
+++ b/platform/app/src/pages/governance/__tests__/costSampleMode.integration.test.tsx
@@ -101,12 +101,28 @@ import CostsPage from "../costs";
 /** One of the seven invented panels. If this is on screen, samples are on. */
 const A_SAMPLE_PANEL = "Tokens over time";
 
-const renderScreen = () =>
-  render(
-    <ChakraProvider value={defaultSystem}>
-      <CostsPage />
-    </ChakraProvider>,
-  );
+const screenTree = () => (
+  <ChakraProvider value={defaultSystem}>
+    <CostsPage />
+  </ChakraProvider>
+);
+
+const renderScreen = () => render(screenTree());
+
+/**
+ * Every activity read goes back to unanswered, which is what react-query hands
+ * the page the instant a filter chip re-keys the queries. A fresh element each
+ * time, so React cannot bail out of reconciliation on reference equality.
+ */
+const withReadsBackInFlight = (rerender: (ui: React.ReactElement) => void) => {
+  harness.activity = {
+    summary: undefined,
+    spendByDepartment: undefined,
+    spendByUser: undefined,
+    spendOverTime: undefined,
+  };
+  rerender(screenTree());
+};
 
 /** Every real read answers, and one of them holds a row. */
 const withRealFigures = () => {
@@ -172,6 +188,14 @@ describe("the sample panels on the cost screen", () => {
         screen.getByRole("button", { name: "See sample data" }),
       ).toBeInTheDocument();
     });
+
+    it("does not let a filter change put the invented panels back", () => {
+      const { rerender } = renderScreen();
+
+      withReadsBackInFlight(rerender);
+
+      expect(screen.queryByText(A_SAMPLE_PANEL)).not.toBeInTheDocument();
+    });
   });
 
   describe("given the reads answered and measured nothing", () => {
@@ -189,6 +213,14 @@ describe("the sample panels on the cost screen", () => {
       expect(screen.getByRole("status")).toHaveTextContent(
         /nothing here is real/i,
       );
+    });
+
+    it("does not pull the invented panels away on a filter change", () => {
+      const { rerender } = renderScreen();
+
+      withReadsBackInFlight(rerender);
+
+      expect(screen.getByText(A_SAMPLE_PANEL)).toBeInTheDocument();
     });
   });
 

--- a/platform/app/src/pages/governance/__tests__/costSampleMode.integration.test.tsx
+++ b/platform/app/src/pages/governance/__tests__/costSampleMode.integration.test.tsx
@@ -1,0 +1,236 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The sample panels' visibility, mounted through the real page.
+ *
+ * Seven of the panels on this screen are invented — nothing in the platform
+ * measures agents, seats, forecasts, tokens or questions yet. They exist to
+ * show the shape of the screen to an organization that has nothing on it. The
+ * moment that organization has real cost figures, invented ones sitting beside
+ * them stop being an illustration and start being a hazard: two panels, same
+ * typography, same money format, and only a small badge separating what was
+ * measured from what was made up.
+ *
+ * So the rule under test is the one the trace explorer already applies to
+ * sample traces — samples fill an empty screen and get out of the way once
+ * there is something real to look at, and an explicit choice by the reader
+ * beats both.
+ *
+ * Spec: specs/governance/governance-cost-screen.feature
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import type React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const harness = vi.hoisted(() => ({
+  activity: {
+    summary: undefined as unknown,
+    spendByDepartment: undefined as unknown,
+    spendByUser: undefined as unknown,
+    spendOverTime: undefined as unknown,
+  },
+}));
+
+vi.mock("~/hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({
+    isLoading: false,
+    organization: { id: "org-1", slug: "acme", name: "ACME", teams: [] },
+    organizations: [],
+    project: undefined,
+    hasPermission: () => true,
+    hasOrgPermission: () => true,
+    hasAnyPermission: () => true,
+  }),
+}));
+
+vi.mock("~/hooks/useFeatureFlag", () => ({
+  useFeatureFlag: () => ({ enabled: true, isLoading: false }),
+}));
+vi.mock("~/hooks/useActivePlan", () => ({
+  useActivePlan: () => ({ isEnterprise: true, activePlan: undefined }),
+}));
+vi.mock("~/components/governance/GovernanceLayout", () => ({
+  default: ({ children }: { children: React.ReactNode }) => children,
+}));
+vi.mock("~/components/NotFoundScene", () => ({
+  NotFoundScene: () => <div>this page does not exist</div>,
+}));
+vi.mock("~/components/LoadingScreen", () => ({
+  LoadingScreen: () => <div>loading</div>,
+}));
+
+vi.mock("~/utils/api", () => ({
+  api: {
+    governanceCost: {
+      summary: {
+        useQuery: () => ({
+          data: {
+            unavailableReason: null,
+            billed: { amountUsd: 123.45, cellsWithoutAmount: 0 },
+            gateway: { amountUsd: 67.89, cellsWithoutAmount: 0 },
+            seats: { status: "awaiting_data" },
+            series: [
+              { day: "2026-08-01", billedUsd: 123.45, gatewayUsd: 67.89 },
+            ],
+            windowDays: 30,
+          },
+          isLoading: false,
+          isError: false,
+        }),
+      },
+    },
+    activityMonitor: {
+      summary: { useQuery: () => ({ data: harness.activity.summary }) },
+      spendByDepartment: {
+        useQuery: () => ({ data: harness.activity.spendByDepartment }),
+      },
+      spendByUser: {
+        useQuery: () => ({ data: harness.activity.spendByUser }),
+      },
+      spendOverTime: {
+        useQuery: () => ({ data: harness.activity.spendOverTime }),
+      },
+    },
+  },
+}));
+
+import CostsPage from "../costs";
+
+/** One of the seven invented panels. If this is on screen, samples are on. */
+const A_SAMPLE_PANEL = "Tokens over time";
+
+const renderScreen = () =>
+  render(
+    <ChakraProvider value={defaultSystem}>
+      <CostsPage />
+    </ChakraProvider>,
+  );
+
+/** Every real read answers, and one of them holds a row. */
+const withRealFigures = () => {
+  harness.activity.summary = {
+    activeUsersThisWindow: 42,
+    newUsersThisWindow: 3,
+    spentThisWindowUsd: "500.00",
+  };
+  harness.activity.spendByDepartment = [
+    {
+      departmentId: "dep-1",
+      departmentName: "Engineering",
+      spendUsd: "310.50",
+    },
+  ];
+  harness.activity.spendByUser = [];
+  harness.activity.spendOverTime = { buckets: [] };
+};
+
+/** Every real read answers, and all of them are empty. */
+const withNothingMeasured = () => {
+  harness.activity.summary = {
+    activeUsersThisWindow: 0,
+    newUsersThisWindow: 0,
+    spentThisWindowUsd: "0",
+  };
+  harness.activity.spendByDepartment = [];
+  harness.activity.spendByUser = [];
+  harness.activity.spendOverTime = { buckets: [] };
+};
+
+beforeEach(() => {
+  harness.activity = {
+    summary: undefined,
+    spendByDepartment: undefined,
+    spendByUser: undefined,
+    spendOverTime: undefined,
+  };
+});
+
+afterEach(() => cleanup());
+
+describe("the sample panels on the cost screen", () => {
+  describe("given the organization has real cost figures", () => {
+    beforeEach(withRealFigures);
+
+    it("keeps the invented panels off the screen", () => {
+      renderScreen();
+
+      expect(screen.queryByText(A_SAMPLE_PANEL)).not.toBeInTheDocument();
+    });
+
+    it("still shows the real breakdowns", () => {
+      renderScreen();
+
+      expect(screen.getByText("Engineering")).toBeInTheDocument();
+    });
+
+    it("offers to show the sample panels rather than hiding the option", () => {
+      renderScreen();
+
+      expect(
+        screen.getByRole("button", { name: "See sample data" }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("given the reads answered and measured nothing", () => {
+    beforeEach(withNothingMeasured);
+
+    it("fills the empty screen with the sample panels", () => {
+      renderScreen();
+
+      expect(screen.getByText(A_SAMPLE_PANEL)).toBeInTheDocument();
+    });
+
+    it("says on the screen that the figures are not real", () => {
+      renderScreen();
+
+      expect(screen.getByRole("status")).toHaveTextContent(
+        /nothing here is real/i,
+      );
+    });
+  });
+
+  describe("given a read has not answered yet", () => {
+    it("shows no sample panels rather than flashing them up and pulling them away", () => {
+      renderScreen();
+
+      expect(screen.queryByText(A_SAMPLE_PANEL)).not.toBeInTheDocument();
+    });
+  });
+
+  describe("given the reader turns the sample panels on", () => {
+    beforeEach(withRealFigures);
+
+    it("shows them alongside the real ones", () => {
+      renderScreen();
+
+      fireEvent.click(screen.getByRole("button", { name: "See sample data" }));
+
+      expect(screen.getByText(A_SAMPLE_PANEL)).toBeInTheDocument();
+      expect(screen.getByText("Engineering")).toBeInTheDocument();
+    });
+
+    it("lets them turn the panels back off", () => {
+      renderScreen();
+
+      fireEvent.click(screen.getByRole("button", { name: "See sample data" }));
+      fireEvent.click(screen.getByRole("button", { name: "Hide sample data" }));
+
+      expect(screen.queryByText(A_SAMPLE_PANEL)).not.toBeInTheDocument();
+    });
+  });
+
+  describe("given the reader turns the sample panels off on an empty screen", () => {
+    beforeEach(withNothingMeasured);
+
+    it("does not put them back", () => {
+      renderScreen();
+
+      fireEvent.click(screen.getByRole("button", { name: "Hide sample data" }));
+
+      expect(screen.queryByText(A_SAMPLE_PANEL)).not.toBeInTheDocument();
+    });
+  });
+});

--- a/platform/app/src/pages/governance/__tests__/costScreen.integration.test.tsx
+++ b/platform/app/src/pages/governance/__tests__/costScreen.integration.test.tsx
@@ -150,6 +150,8 @@ function summaryFixture(overrides: Record<string, unknown> = {}) {
     seats: { status: "awaiting_data" },
     series: [{ day: "2026-08-01", billedUsd: 123.45, gatewayUsd: 67.89 }],
     windowDays: 30,
+    // Every source still pulling, so the figures need no caveat.
+    staleSources: null,
     ...overrides,
   };
 }
@@ -372,6 +374,68 @@ describe("the governance cost screen", () => {
       renderScreen();
 
       expect(screen.queryByTestId("cost-lane-billed")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("given the per-day lane chart", () => {
+    // Both testids shipped unasserted, so nothing caught the chart swapping
+    // its populated and empty states.
+    it("draws the chart when the window holds days", () => {
+      renderScreen();
+
+      expect(screen.getByTestId("cost-lanes-chart")).toBeInTheDocument();
+      expect(
+        screen.queryByTestId("cost-lanes-chart-empty"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("says the window is empty rather than drawing an empty chart", () => {
+      harness.query = {
+        data: summaryFixture({ series: [] }),
+        isLoading: false,
+        isError: false,
+      };
+
+      renderScreen();
+
+      expect(screen.getByTestId("cost-lanes-chart-empty")).toBeInTheDocument();
+      expect(screen.queryByTestId("cost-lanes-chart")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("given a contributing source has stopped pulling", () => {
+    /** @scenario "The cost screen says where its numbers stop being complete" */
+    it("names the source and the day, next to the lanes it undercounts", () => {
+      harness.query = {
+        data: summaryFixture({
+          staleSources: {
+            oldestLastSuccessIso: "2026-08-20T09:00:00.000Z",
+            sourceNames: ["Azure Billing"],
+          },
+        }),
+        isLoading: false,
+        isError: false,
+      };
+
+      renderScreen();
+
+      const notice = screen.getByTestId("cost-stale-sources");
+      expect(within(notice).getByText(/Azure Billing/)).toBeInTheDocument();
+      expect(
+        within(notice).getByText(/unknown rather than zero/i),
+      ).toBeInTheDocument();
+      // The lanes still render. A stalled pull caveats the figures; it does
+      // not withdraw them.
+      expect(screen.getByTestId("cost-lane-billed")).toBeInTheDocument();
+    });
+
+    /** @scenario "A screen whose sources are all pulling carries no outage notice" */
+    it("stays silent while every source is still pulling", () => {
+      renderScreen();
+
+      expect(
+        screen.queryByTestId("cost-stale-sources"),
+      ).not.toBeInTheDocument();
     });
   });
 });

--- a/platform/app/src/pages/governance/__tests__/costScreen.integration.test.tsx
+++ b/platform/app/src/pages/governance/__tests__/costScreen.integration.test.tsx
@@ -90,15 +90,28 @@ vi.mock("~/components/LoadingScreen", () => ({
   LoadingScreen: () => <div>loading</div>,
 }));
 
-vi.mock("~/utils/api", () => ({
-  api: {
-    governanceCost: {
-      summary: {
-        useQuery: () => harness.query,
+vi.mock("~/utils/api", () => {
+  // The breakdown panels below the lanes read the activity monitor. They are
+  // not what these tests are about, so they answer with nothing — which is
+  // also the shape a viewer without `activityMonitor:view` sees. Leaving them
+  // out entirely would crash the render before a single lane assertion ran.
+  const empty = { useQuery: () => ({ data: undefined }) };
+  return {
+    api: {
+      governanceCost: {
+        summary: {
+          useQuery: () => harness.query,
+        },
+      },
+      activityMonitor: {
+        summary: empty,
+        spendByDepartment: empty,
+        spendByUser: empty,
+        spendOverTime: empty,
       },
     },
-  },
-}));
+  };
+});
 
 import CostsPage from "../costs";
 

--- a/platform/app/src/pages/governance/__tests__/costScreen.integration.test.tsx
+++ b/platform/app/src/pages/governance/__tests__/costScreen.integration.test.tsx
@@ -403,7 +403,7 @@ describe("the governance cost screen", () => {
     });
   });
 
-  describe("given a contributing source has stopped pulling", () => {
+  describe("given a source whose pulls have been failing", () => {
     /** @scenario "The cost screen says where its numbers stop being complete" */
     it("names the source and the day, next to the lanes it undercounts", () => {
       harness.query = {
@@ -424,12 +424,19 @@ describe("the governance cost screen", () => {
       expect(
         within(notice).getByText(/unknown rather than zero/i),
       ).toBeInTheDocument();
+      // The day itself, not merely the words around it. Asserting only the
+      // phrase let a title that had lost its date pass. Matching the digits
+      // rather than a formatted string keeps this locale-independent: every
+      // locale renders a numeric day and year as those numerals.
+      const since = within(notice).getByText(/^No data since /);
+      expect(since.textContent).toMatch(/\b20\b/);
+      expect(since.textContent).toMatch(/\b2026\b/);
       // The lanes still render. A stalled pull caveats the figures; it does
       // not withdraw them.
       expect(screen.getByTestId("cost-lane-billed")).toBeInTheDocument();
     });
 
-    /** @scenario "A screen whose sources are all pulling carries no outage notice" */
+    /** @scenario "A screen whose sources are all pulling carries no warning" */
     it("stays silent while every source is still pulling", () => {
       renderScreen();
 

--- a/platform/app/src/pages/governance/costs.tsx
+++ b/platform/app/src/pages/governance/costs.tsx
@@ -31,8 +31,8 @@ import {
   CostSampleToggle,
 } from "~/components/governance/costs/CostSampleControls";
 import {
-  resolveRealDataState,
   sampleModeActive,
+  useSettledRealDataState,
 } from "~/components/governance/costs/costSampleMode";
 import {
   ALL_DEPARTMENTS,
@@ -128,13 +128,19 @@ function CostsPage() {
   // explorer applies to its sample traces — opting in is a decision about this
   // sitting, not a preference that follows you back tomorrow.
   const [sampleOptIn, setSampleOptIn] = useState<boolean | null>(null);
+  // Adoption counts as real data even with no spend behind it yet: showing a
+  // measured headcount beside invented money is the confusion this toggle
+  // exists to prevent.
   const showSample = sampleModeActive({
     optIn: sampleOptIn,
-    realData: resolveRealDataState([
+    realData: useSettledRealDataState([
       breakdowns.departmentRows,
       breakdowns.userRows,
       breakdowns.overTime,
       breakdowns.modelOverTime,
+      breakdowns.activeUsers === null
+        ? null
+        : { length: breakdowns.activeUsers },
     ]),
   });
 

--- a/platform/app/src/pages/governance/costs.tsx
+++ b/platform/app/src/pages/governance/costs.tsx
@@ -215,17 +215,29 @@ function CostsBody({
   );
 }
 
+/**
+ * What the activity reads have answered so far.
+ *
+ * Every field is nullable and `null` means the read has not answered — still in
+ * flight, or never allowed to run because the viewer lacks the grant. It is
+ * deliberately NOT collapsed to `0`/`[]`: this screen does not show a figure it
+ * did not measure, and a zero is a measurement.
+ */
 interface Breakdowns {
   departments: Array<{ id: string; name: string }>;
   departmentRows: Array<{
     departmentId: string | null;
     departmentName: string;
     spendUsd: string;
-  }>;
-  userRows: Array<{ actor: string; spendUsd: string; requests: number }>;
-  activeUsers: number;
-  overTime: DailyBucket[];
-  modelOverTime: DailyBucket[];
+  }> | null;
+  userRows: Array<{
+    actor: string;
+    spendUsd: string;
+    requests: number;
+  }> | null;
+  activeUsers: number | null;
+  overTime: DailyBucket[] | null;
+  modelOverTime: DailyBucket[] | null;
 }
 
 /** Wire buckets carry money as strings; the charts want numbers. */
@@ -280,17 +292,22 @@ function useBreakdownQueries({
     options,
   );
 
-  const departmentRows = byDepartment.data ?? [];
+  const departmentRows = byDepartment.data ?? null;
   return {
     departmentRows,
-    departments: departmentRows.map((row) => ({
+    // The picker is the one place an unanswered read may fall back to empty:
+    // it offers choices, it does not report a measurement.
+    departments: (departmentRows ?? []).map((row) => ({
       id: row.departmentId ?? "unassigned",
       name: row.departmentName,
     })),
-    userRows: byUser.data ?? [],
-    activeUsers: summary.data?.activeUsersThisWindow ?? 0,
-    overTime: toDailyBuckets(overTime.data),
-    modelOverTime: toDailyBuckets(byModel.data),
+    userRows: byUser.data ?? null,
+    activeUsers: summary.data?.activeUsersThisWindow ?? null,
+    // `.buckets`, not the result object: the read answers a wrapper, and
+    // handing the wrapper to a function that maps over an array throws the
+    // moment a real answer arrives.
+    overTime: overTime.data ? toDailyBuckets(overTime.data.buckets) : null,
+    modelOverTime: byModel.data ? toDailyBuckets(byModel.data.buckets) : null,
   };
 }
 
@@ -323,17 +340,30 @@ function CostBreakdowns({
   );
   const sample = useSampleSeries(days, filters.interval);
 
-  const departmentRows = breakdowns.departmentRows
-    .filter(
-      (row) =>
-        filters.department === ALL_DEPARTMENTS ||
-        (row.departmentId ?? "unassigned") === filters.department,
-    )
-    .map((row) => ({
-      key: row.departmentId ?? "unassigned",
-      label: row.departmentName,
-      value: Number(row.spendUsd),
-    }));
+  // Null in, null out — an unanswered read stays unanswered all the way to the
+  // panel rather than turning into an empty list that reads as a measurement.
+  const departmentRows =
+    breakdowns.departmentRows === null
+      ? null
+      : breakdowns.departmentRows
+          .filter(
+            (row) =>
+              filters.department === ALL_DEPARTMENTS ||
+              (row.departmentId ?? "unassigned") === filters.department,
+          )
+          .map((row) => ({
+            key: row.departmentId ?? "unassigned",
+            label: row.departmentName,
+            value: Number(row.spendUsd),
+          }));
+  const userRows =
+    breakdowns.userRows === null
+      ? null
+      : breakdowns.userRows.map((row) => ({
+          key: row.actor,
+          label: row.actor,
+          value: Number(row.spendUsd),
+        }));
 
   return (
     <VStack align="stretch" gap={4}>
@@ -360,7 +390,11 @@ function CostBreakdowns({
         </CostPanel>
         <CostPanel title={`Cost evolution by ${filters.groupBy}`}>
           <CostStackedBars
-            buckets={aggregateBuckets(breakdowns.overTime, filters.interval)}
+            buckets={
+              breakdowns.overTime === null
+                ? null
+                : aggregateBuckets(breakdowns.overTime, filters.interval)
+            }
           />
         </CostPanel>
         <CostPanel title="Cost by department">
@@ -371,16 +405,16 @@ function CostBreakdowns({
           <CostRankList rows={sample.agents} />
         </CostPanel>
         <CostPanel title="Cost by model">
-          <CostRankList rows={totalPerSeries(breakdowns.modelOverTime)} />
+          <CostRankList
+            rows={
+              breakdowns.modelOverTime === null
+                ? null
+                : totalPerSeries(breakdowns.modelOverTime)
+            }
+          />
         </CostPanel>
         <CostPanel title="Cost by user">
-          <CostRankList
-            rows={breakdowns.userRows.map((row) => ({
-              key: row.actor,
-              label: row.actor,
-              value: Number(row.spendUsd),
-            }))}
-          />
+          <CostRankList rows={userRows} />
         </CostPanel>
 
         <CostPanel title="Genie questions over time" sample>
@@ -401,20 +435,30 @@ function CostBreakdowns({
   );
 }
 
+/**
+ * Active users for the window, and only that.
+ *
+ * An interaction count used to sit beside it, summed from the ranked user
+ * rows — but that read is a top-8, so the sum was the leaders' share wearing
+ * the name of an organization-wide total. There is no whole-window
+ * interaction count to put there instead, so the figure is gone rather than
+ * quietly wrong.
+ */
 function AdoptionRow({ breakdowns }: { breakdowns: Breakdowns }) {
-  const interactions = breakdowns.userRows.reduce(
-    (sum, row) => sum + row.requests,
-    0,
-  );
   return (
     <CostPanel title="Adoption">
-      <HStack gap={10} align="flex-end">
-        <Stat
-          label="Users"
-          value={numeral(breakdowns.activeUsers).format("0,0")}
-        />
-        <Stat label="Interactions" value={fmtCount(interactions)} />
-      </HStack>
+      {breakdowns.activeUsers === null ? (
+        <Text fontSize="sm" color="fg.muted">
+          Not available.
+        </Text>
+      ) : (
+        <HStack gap={10} align="flex-end">
+          <Stat
+            label="Users"
+            value={numeral(breakdowns.activeUsers).format("0,0")}
+          />
+        </HStack>
+      )}
     </CostPanel>
   );
 }

--- a/platform/app/src/pages/governance/costs.tsx
+++ b/platform/app/src/pages/governance/costs.tsx
@@ -269,13 +269,21 @@ function CostsBody({
 /**
  * Where the numbers below stop being complete (ADR-128 §4a).
  *
- * A source that has stopped pulling still has a lane on this screen; it just
+ * A source that is failing to pull still has a lane on this screen; it just
  * contributes nothing to it, so the totals fall and nothing says why. Without
  * this line a broken credential reads as a cheap month, which is the one
  * reading of a cost screen that is worse than no cost screen.
  *
- * The sources are named because "something stopped" is not actionable and
- * "Azure Billing stopped" is.
+ * The wording says "failing to pull" rather than "stopped pulling" because
+ * that is the whole of what the check behind it detects: a run of consecutive
+ * pull failures. A source whose worker is never scheduled keeps a zero failure
+ * count and is never named here, though its figures are just as incomplete —
+ * see the known gap recorded on the Rule in
+ * `specs/governance/governance-cost-screen.feature`. Claiming "stopped" would
+ * promise a guarantee this line cannot keep.
+ *
+ * The sources are named because "something is failing" is not actionable and
+ * "Azure Billing is failing" is.
  */
 function StaleSourcesNotice({
   staleSources,
@@ -296,8 +304,8 @@ function StaleSourcesNotice({
         <Alert.Title>No data since {since}</Alert.Title>
         <Alert.Description>
           {staleSources.sourceNames.join(", ")}{" "}
-          {staleSources.sourceNames.length === 1 ? "has" : "have"} stopped
-          pulling, so spend after that point is unknown rather than zero.
+          {staleSources.sourceNames.length === 1 ? "is" : "are"} failing to
+          pull, so spend after that point is unknown rather than zero.
         </Alert.Description>
       </Alert.Content>
     </Alert.Root>

--- a/platform/app/src/pages/governance/costs.tsx
+++ b/platform/app/src/pages/governance/costs.tsx
@@ -350,11 +350,15 @@ function CostBreakdowns({
         </CostPanel>
       </SimpleGrid>
 
+      {/* One grid of nine, in the prototype's order. */}
       <SimpleGrid columns={{ base: 1, xl: 3 }} gap={4}>
+        {/* The placeholder series is agents whatever Group By says, so this
+            title does not follow it — a chart labelled by model showing agent
+            names would be worse than a fixed label. */}
         <CostPanel title="% cost by agent" sample>
           <CostDonut rows={sample.agents} />
         </CostPanel>
-        <CostPanel title={`Cost over time · by ${filters.groupBy}`}>
+        <CostPanel title={`Cost evolution by ${filters.groupBy}`}>
           <CostStackedBars
             buckets={aggregateBuckets(breakdowns.overTime, filters.interval)}
           />
@@ -362,9 +366,7 @@ function CostBreakdowns({
         <CostPanel title="Cost by department">
           <CostRankList rows={departmentRows} />
         </CostPanel>
-      </SimpleGrid>
 
-      <SimpleGrid columns={{ base: 1, xl: 3 }} gap={4}>
         <CostPanel title="Cost by agent" sample>
           <CostRankList rows={sample.agents} />
         </CostPanel>
@@ -380,9 +382,7 @@ function CostBreakdowns({
             }))}
           />
         </CostPanel>
-      </SimpleGrid>
 
-      <SimpleGrid columns={{ base: 1, xl: 3 }} gap={4}>
         <CostPanel title="Genie questions over time" sample>
           <CostStackedBars
             buckets={sample.genie}

--- a/platform/app/src/pages/governance/costs.tsx
+++ b/platform/app/src/pages/governance/costs.tsx
@@ -2,69 +2,135 @@ import {
   Alert,
   Heading,
   HStack,
+  SimpleGrid,
   Skeleton,
   Text,
   VStack,
 } from "@chakra-ui/react";
-
 import type { GovernanceCostSummaryDto } from "@ee/governance/services/governanceCost.service";
+import numeral from "numeral";
+import { useMemo, useState } from "react";
 
 import {
   CostLanePanel,
   SeatLanePanel,
 } from "~/components/governance/CostLanePanel";
 import { CostLanesChart } from "~/components/governance/CostLanesChart";
+import {
+  CostDonut,
+  CostForecastArea,
+  CostLine,
+  CostRankList,
+  CostStackedBars,
+  fmtCount,
+} from "~/components/governance/costs/CostCharts";
+import { CostFilterBar } from "~/components/governance/costs/CostFilterBar";
+import { CostPanel } from "~/components/governance/costs/CostPanel";
+import {
+  ALL_DEPARTMENTS,
+  aggregateBuckets,
+  aggregateLine,
+  type GroupBy,
+  type TimeInterval,
+} from "~/components/governance/costs/costsWindow";
+import {
+  type DailyBucket,
+  type RankRow,
+  recentDays,
+  SAMPLE_AGENTS,
+  SAMPLE_DEPARTMENTS,
+  sampleDaily,
+  sampleForecast,
+  sampleLine,
+  sampleRanked,
+} from "~/components/governance/costs/sampleSeries";
 import GovernanceLayout from "~/components/governance/GovernanceLayout";
 import { withFeatureFlagGuard } from "~/components/WithFeatureFlagGuard";
 import { withPermissionGuard } from "~/components/WithPermissionGuard";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 import { api } from "~/utils/api";
 
-const WINDOW_DAYS = 30;
-
 /**
- * The cost screen: three lanes, side by side, each labeled for what it is.
+ * The cost screen: three lanes, side by side, each labeled for what it is,
+ * and the breakdowns underneath them.
  *
  * The lanes are never added together. What a provider invoices and what the
  * gateway metered are two different measurements of overlapping traffic, and
  * the gap between them is the thing worth looking at — a combined figure would
- * hide exactly what the screen exists to show.
+ * hide exactly what the screen exists to show. That is why nothing on this page
+ * shows a single "total AI cost".
  *
  * Nothing here ever renders a zero it did not measure. A failed read, a
  * deployment without a cost store, and a lane with no figure all render as
  * such; `$0.00` is reserved for a lane that really did report no spend.
  *
+ * The breakdowns below the lanes are a mix. Cost over time, cost by
+ * department, cost by model and cost by user are real reads. Agents, prepaid
+ * seats, forecasts, token counts and Genie questions have no backing read yet
+ * and are drawn from `sampleSeries`, each badged `sample`.
+ *
  * Spec: specs/governance/governance-cost-screen.feature (ADR-128)
  */
+
+interface CostFilters {
+  department: string;
+  windowDays: number;
+  interval: TimeInterval;
+  groupBy: GroupBy;
+}
+
 function CostsPage() {
-  const { organization } = useOrganizationTeamProject({
+  const { organization, hasAnyPermission } = useOrganizationTeamProject({
     redirectToOnboarding: false,
     redirectToProjectOnboarding: false,
   });
   const organizationId = organization?.id ?? "";
+  const [filters, setFilters] = useState<CostFilters>({
+    department: ALL_DEPARTMENTS,
+    windowDays: 30,
+    interval: "day",
+    groupBy: "team",
+  });
+  const patch = (next: Partial<CostFilters>) =>
+    setFilters((current) => ({ ...current, ...next }));
 
   const summary = api.governanceCost.summary.useQuery(
-    { organizationId, windowDays: WINDOW_DAYS },
+    { organizationId, windowDays: filters.windowDays },
     { enabled: !!organizationId },
   );
+  const breakdowns = useBreakdownQueries({
+    organizationId,
+    windowDays: filters.windowDays,
+    groupBy: filters.groupBy,
+    // The page opens on `governanceCost:view`, but the breakdowns read the
+    // activity monitor, which is its own grant. A viewer holding one and not
+    // the other gets the lanes and no failed queries underneath them.
+    enabled: !!organizationId && hasAnyPermission("activityMonitor:view"),
+  });
 
   return (
     <GovernanceLayout pageTitle="Costs · AI Governance · LangWatch">
-      <VStack align="stretch" gap={6} width="full">
-        <VStack align="start" gap={1}>
-          <Heading size="md">Costs</Heading>
-          <Text color="fg.muted">
-            What your providers billed and what the gateway metered, side by
-            side. They measure different things, so they are shown separately
-            and never added together.
-          </Text>
-        </VStack>
+      <VStack align="stretch" gap={5} width="full">
+        <Heading size="md">Costs</Heading>
+        <CostFilterBar
+          department={filters.department}
+          departments={breakdowns.departments}
+          onDepartmentChange={(department) => patch({ department })}
+          windowDays={filters.windowDays}
+          onWindowDaysChange={(windowDays) => patch({ windowDays })}
+          interval={filters.interval}
+          onIntervalChange={(interval) => patch({ interval })}
+          groupBy={filters.groupBy}
+          onGroupByChange={(groupBy) => patch({ groupBy })}
+        />
 
         <CostsBody
           isLoading={summary.isLoading && !!organizationId}
           isError={summary.isError}
           data={summary.data}
         />
+
+        <CostBreakdowns filters={filters} breakdowns={breakdowns} />
       </VStack>
     </GovernanceLayout>
   );
@@ -145,6 +211,256 @@ function CostsBody({
         <SeatLanePanel testId="cost-lane-seats" seats={data.seats} />
       </HStack>
       <CostLanesChart series={data.series} />
+    </VStack>
+  );
+}
+
+interface Breakdowns {
+  departments: Array<{ id: string; name: string }>;
+  departmentRows: Array<{
+    departmentId: string | null;
+    departmentName: string;
+    spendUsd: string;
+  }>;
+  userRows: Array<{ actor: string; spendUsd: string; requests: number }>;
+  activeUsers: number;
+  overTime: DailyBucket[];
+  modelOverTime: DailyBucket[];
+}
+
+/** Wire buckets carry money as strings; the charts want numbers. */
+function toDailyBuckets(
+  buckets:
+    | Array<{
+        bucketIso: string;
+        points: Array<{ key: string; label: string; spendUsd: string }>;
+      }>
+    | undefined,
+): DailyBucket[] {
+  if (!buckets) return [];
+  return buckets.map((bucket) => ({
+    day: bucket.bucketIso,
+    points: bucket.points.map((point) => ({
+      key: point.key,
+      label: point.label,
+      value: Number(point.spendUsd),
+    })),
+  }));
+}
+
+function useBreakdownQueries({
+  organizationId,
+  windowDays,
+  groupBy,
+  enabled,
+}: {
+  organizationId: string;
+  windowDays: number;
+  groupBy: GroupBy;
+  enabled: boolean;
+}): Breakdowns {
+  const args = { organizationId, windowDays };
+  const options = { enabled, refetchOnWindowFocus: false };
+
+  const summary = api.activityMonitor.summary.useQuery(args, options);
+  const byDepartment = api.activityMonitor.spendByDepartment.useQuery(
+    args,
+    options,
+  );
+  const byUser = api.activityMonitor.spendByUser.useQuery(
+    { ...args, limit: 8 },
+    options,
+  );
+  const overTime = api.activityMonitor.spendOverTime.useQuery(
+    { ...args, groupBy },
+    options,
+  );
+  const byModel = api.activityMonitor.spendOverTime.useQuery(
+    { ...args, groupBy: "model" as const },
+    options,
+  );
+
+  const departmentRows = byDepartment.data ?? [];
+  return {
+    departmentRows,
+    departments: departmentRows.map((row) => ({
+      id: row.departmentId ?? "unassigned",
+      name: row.departmentName,
+    })),
+    userRows: byUser.data ?? [],
+    activeUsers: summary.data?.activeUsersThisWindow ?? 0,
+    overTime: toDailyBuckets(overTime.data),
+    modelOverTime: toDailyBuckets(byModel.data),
+  };
+}
+
+/** Total each series across the window, for the ranked and donut panels. */
+function totalPerSeries(buckets: DailyBucket[]): RankRow[] {
+  const totals = new Map<string, RankRow>();
+  for (const bucket of buckets) {
+    for (const point of bucket.points) {
+      const existing = totals.get(point.key);
+      if (existing) {
+        existing.value += point.value;
+      } else {
+        totals.set(point.key, { ...point });
+      }
+    }
+  }
+  return [...totals.values()];
+}
+
+function CostBreakdowns({
+  filters,
+  breakdowns,
+}: {
+  filters: CostFilters;
+  breakdowns: Breakdowns;
+}) {
+  const days = useMemo(
+    () => recentDays(filters.windowDays),
+    [filters.windowDays],
+  );
+  const sample = useSampleSeries(days, filters.interval);
+
+  const departmentRows = breakdowns.departmentRows
+    .filter(
+      (row) =>
+        filters.department === ALL_DEPARTMENTS ||
+        (row.departmentId ?? "unassigned") === filters.department,
+    )
+    .map((row) => ({
+      key: row.departmentId ?? "unassigned",
+      label: row.departmentName,
+      value: Number(row.spendUsd),
+    }));
+
+  return (
+    <VStack align="stretch" gap={4}>
+      <AdoptionRow breakdowns={breakdowns} />
+      <SimpleGrid columns={{ base: 1, lg: 2 }} gap={4}>
+        <CostPanel title="Consumption forecast · by agent" sample>
+          <CostForecastArea
+            buckets={sample.forecast.buckets}
+            projectedFromDay={sample.forecast.projectedFromDay}
+          />
+        </CostPanel>
+        <CostPanel title="Subscriptions · by department" sample>
+          <CostStackedBars buckets={sample.subscriptions} />
+        </CostPanel>
+      </SimpleGrid>
+
+      <SimpleGrid columns={{ base: 1, xl: 3 }} gap={4}>
+        <CostPanel title="% cost by agent" sample>
+          <CostDonut rows={sample.agents} />
+        </CostPanel>
+        <CostPanel title={`Cost over time · by ${filters.groupBy}`}>
+          <CostStackedBars
+            buckets={aggregateBuckets(breakdowns.overTime, filters.interval)}
+          />
+        </CostPanel>
+        <CostPanel title="Cost by department">
+          <CostRankList rows={departmentRows} />
+        </CostPanel>
+      </SimpleGrid>
+
+      <SimpleGrid columns={{ base: 1, xl: 3 }} gap={4}>
+        <CostPanel title="Cost by agent" sample>
+          <CostRankList rows={sample.agents} />
+        </CostPanel>
+        <CostPanel title="Cost by model">
+          <CostRankList rows={totalPerSeries(breakdowns.modelOverTime)} />
+        </CostPanel>
+        <CostPanel title="Cost by user">
+          <CostRankList
+            rows={breakdowns.userRows.map((row) => ({
+              key: row.actor,
+              label: row.actor,
+              value: Number(row.spendUsd),
+            }))}
+          />
+        </CostPanel>
+      </SimpleGrid>
+
+      <SimpleGrid columns={{ base: 1, xl: 3 }} gap={4}>
+        <CostPanel title="Genie questions over time" sample>
+          <CostStackedBars
+            buckets={sample.genie}
+            format={fmtCount}
+            showLegend={false}
+          />
+        </CostPanel>
+        <CostPanel title="Tokens over time" sample>
+          <CostLine points={sample.tokens} />
+        </CostPanel>
+        <CostPanel title="Subscriptions vs consumption" sample>
+          <CostStackedBars buckets={sample.seatsVsUsage} showLegend={false} />
+        </CostPanel>
+      </SimpleGrid>
+    </VStack>
+  );
+}
+
+function AdoptionRow({ breakdowns }: { breakdowns: Breakdowns }) {
+  const interactions = breakdowns.userRows.reduce(
+    (sum, row) => sum + row.requests,
+    0,
+  );
+  return (
+    <CostPanel title="Adoption">
+      <HStack gap={10} align="flex-end">
+        <Stat
+          label="Users"
+          value={numeral(breakdowns.activeUsers).format("0,0")}
+        />
+        <Stat label="Interactions" value={fmtCount(interactions)} />
+      </HStack>
+    </CostPanel>
+  );
+}
+
+/** Every placeholder series the page needs, folded to the chosen interval. */
+function useSampleSeries(days: string[], interval: TimeInterval) {
+  return useMemo(() => {
+    const forecast = sampleForecast(days, SAMPLE_AGENTS.slice(0, 5), 2200);
+    return {
+      agents: sampleRanked(SAMPLE_AGENTS, 2296),
+      forecast: {
+        buckets: aggregateBuckets(forecast.buckets, interval),
+        // The projection marker sits on a specific day, so it only lines up
+        // with the axis while the axis is days. Weekly and monthly folds drop
+        // it rather than point it at a bucket boundary it does not fall on.
+        projectedFromDay: interval === "day" ? forecast.projectedFromDay : null,
+      },
+      subscriptions: aggregateBuckets(
+        sampleDaily(days, SAMPLE_DEPARTMENTS, 3600),
+        interval,
+      ),
+      genie: aggregateBuckets(
+        sampleDaily(days, SAMPLE_AGENTS.slice(0, 6), 26),
+        interval,
+      ),
+      tokens: aggregateLine(
+        sampleLine(days, "tokens", 3_000_000_000),
+        interval,
+      ),
+      seatsVsUsage: aggregateBuckets(
+        sampleDaily(days, ["Usage", "Seat", "Cloud", "Activity"], 2400),
+        interval,
+      ),
+    };
+  }, [days, interval]);
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <VStack align="flex-start" gap={0}>
+      <Text fontSize="xs" color="fg.muted">
+        {label}
+      </Text>
+      <Text fontSize="2xl" fontWeight="semibold" lineHeight="1.1">
+        {value}
+      </Text>
     </VStack>
   );
 }

--- a/platform/app/src/pages/governance/costs.tsx
+++ b/platform/app/src/pages/governance/costs.tsx
@@ -7,7 +7,10 @@ import {
   Text,
   VStack,
 } from "@chakra-ui/react";
-import type { GovernanceCostSummaryDto } from "@ee/governance/services/governanceCost.service";
+import type {
+  GovernanceCostStaleSourcesDto,
+  GovernanceCostSummaryDto,
+} from "@ee/governance/services/governanceCost.service";
 import numeral from "numeral";
 import { useMemo, useState } from "react";
 
@@ -240,6 +243,7 @@ function CostsBody({
 
   return (
     <VStack align="stretch" gap={6}>
+      <StaleSourcesNotice staleSources={data.staleSources} />
       <HStack align="stretch" gap={4} flexWrap="wrap">
         <CostLanePanel
           testId="cost-lane-billed"
@@ -259,6 +263,44 @@ function CostsBody({
       </HStack>
       <CostLanesChart series={data.series} />
     </VStack>
+  );
+}
+
+/**
+ * Where the numbers below stop being complete (ADR-128 §4a).
+ *
+ * A source that has stopped pulling still has a lane on this screen; it just
+ * contributes nothing to it, so the totals fall and nothing says why. Without
+ * this line a broken credential reads as a cheap month, which is the one
+ * reading of a cost screen that is worse than no cost screen.
+ *
+ * The sources are named because "something stopped" is not actionable and
+ * "Azure Billing stopped" is.
+ */
+function StaleSourcesNotice({
+  staleSources,
+}: {
+  staleSources: GovernanceCostStaleSourcesDto | null;
+}) {
+  if (!staleSources) return null;
+
+  const since = new Date(staleSources.oldestLastSuccessIso).toLocaleDateString(
+    undefined,
+    { year: "numeric", month: "short", day: "numeric" },
+  );
+
+  return (
+    <Alert.Root status="warning" data-testid="cost-stale-sources">
+      <Alert.Indicator />
+      <Alert.Content>
+        <Alert.Title>No data since {since}</Alert.Title>
+        <Alert.Description>
+          {staleSources.sourceNames.join(", ")}{" "}
+          {staleSources.sourceNames.length === 1 ? "has" : "have"} stopped
+          pulling, so spend after that point is unknown rather than zero.
+        </Alert.Description>
+      </Alert.Content>
+    </Alert.Root>
   );
 }
 

--- a/platform/app/src/pages/governance/costs.tsx
+++ b/platform/app/src/pages/governance/costs.tsx
@@ -27,6 +27,14 @@ import {
 import { CostFilterBar } from "~/components/governance/costs/CostFilterBar";
 import { CostPanel } from "~/components/governance/costs/CostPanel";
 import {
+  CostSampleBanner,
+  CostSampleToggle,
+} from "~/components/governance/costs/CostSampleControls";
+import {
+  resolveRealDataState,
+  sampleModeActive,
+} from "~/components/governance/costs/costSampleMode";
+import {
   ALL_DEPARTMENTS,
   aggregateBuckets,
   aggregateLine,
@@ -69,6 +77,13 @@ import { api } from "~/utils/api";
  * seats, forecasts, token counts and Genie questions have no backing read yet
  * and are drawn from `sampleSeries`, each badged `sample`.
  *
+ * Those invented panels do not render unconditionally. They fill a screen with
+ * nothing measured on it, step aside once real figures arrive, and the reader
+ * can overrule either default from the toggle in the header — the same
+ * arrangement the trace explorer uses for its sample traces. See
+ * `costSampleMode.ts` for why an unanswered read is not treated as an empty
+ * one.
+ *
  * Spec: specs/governance/governance-cost-screen.feature (ADR-128)
  */
 
@@ -108,10 +123,32 @@ function CostsPage() {
     enabled: !!organizationId && hasAnyPermission("activityMonitor:view"),
   });
 
+  // `null` until the reader picks a side, which is what lets the default below
+  // follow the data. Deliberately not persisted: the same rule the trace
+  // explorer applies to its sample traces — opting in is a decision about this
+  // sitting, not a preference that follows you back tomorrow.
+  const [sampleOptIn, setSampleOptIn] = useState<boolean | null>(null);
+  const showSample = sampleModeActive({
+    optIn: sampleOptIn,
+    realData: resolveRealDataState([
+      breakdowns.departmentRows,
+      breakdowns.userRows,
+      breakdowns.overTime,
+      breakdowns.modelOverTime,
+    ]),
+  });
+
   return (
     <GovernanceLayout pageTitle="Costs · AI Governance · LangWatch">
       <VStack align="stretch" gap={5} width="full">
-        <Heading size="md">Costs</Heading>
+        <HStack justify="space-between" align="center">
+          <Heading size="md">Costs</Heading>
+          <CostSampleToggle
+            active={showSample}
+            onToggle={() => setSampleOptIn(!showSample)}
+          />
+        </HStack>
+        {showSample && <CostSampleBanner />}
         <CostFilterBar
           department={filters.department}
           departments={breakdowns.departments}
@@ -130,7 +167,11 @@ function CostsPage() {
           data={summary.data}
         />
 
-        <CostBreakdowns filters={filters} breakdowns={breakdowns} />
+        <CostBreakdowns
+          filters={filters}
+          breakdowns={breakdowns}
+          showSample={showSample}
+        />
       </VStack>
     </GovernanceLayout>
   );
@@ -330,9 +371,11 @@ function totalPerSeries(buckets: DailyBucket[]): RankRow[] {
 function CostBreakdowns({
   filters,
   breakdowns,
+  showSample,
 }: {
   filters: CostFilters;
   breakdowns: Breakdowns;
+  showSample: boolean;
 }) {
   const days = useMemo(
     () => recentDays(filters.windowDays),
@@ -368,26 +411,31 @@ function CostBreakdowns({
   return (
     <VStack align="stretch" gap={4}>
       <AdoptionRow breakdowns={breakdowns} />
-      <SimpleGrid columns={{ base: 1, lg: 2 }} gap={4}>
-        <CostPanel title="Consumption forecast · by agent" sample>
-          <CostForecastArea
-            buckets={sample.forecast.buckets}
-            projectedFromDay={sample.forecast.projectedFromDay}
-          />
-        </CostPanel>
-        <CostPanel title="Subscriptions · by department" sample>
-          <CostStackedBars buckets={sample.subscriptions} />
-        </CostPanel>
-      </SimpleGrid>
+      {showSample && (
+        <SimpleGrid columns={{ base: 1, lg: 2 }} gap={4}>
+          <CostPanel title="Consumption forecast · by agent" sample>
+            <CostForecastArea
+              buckets={sample.forecast.buckets}
+              projectedFromDay={sample.forecast.projectedFromDay}
+            />
+          </CostPanel>
+          <CostPanel title="Subscriptions · by department" sample>
+            <CostStackedBars buckets={sample.subscriptions} />
+          </CostPanel>
+        </SimpleGrid>
+      )}
 
-      {/* One grid of nine, in the prototype's order. */}
+      {/* One grid, in the prototype's order. With samples off the four
+          measured panels close ranks and the grid reflows around them. */}
       <SimpleGrid columns={{ base: 1, xl: 3 }} gap={4}>
         {/* The placeholder series is agents whatever Group By says, so this
             title does not follow it — a chart labelled by model showing agent
             names would be worse than a fixed label. */}
-        <CostPanel title="% cost by agent" sample>
-          <CostDonut rows={sample.agents} />
-        </CostPanel>
+        {showSample && (
+          <CostPanel title="% cost by agent" sample>
+            <CostDonut rows={sample.agents} />
+          </CostPanel>
+        )}
         <CostPanel title={`Cost evolution by ${filters.groupBy}`}>
           <CostStackedBars
             buckets={
@@ -401,9 +449,11 @@ function CostBreakdowns({
           <CostRankList rows={departmentRows} />
         </CostPanel>
 
-        <CostPanel title="Cost by agent" sample>
-          <CostRankList rows={sample.agents} />
-        </CostPanel>
+        {showSample && (
+          <CostPanel title="Cost by agent" sample>
+            <CostRankList rows={sample.agents} />
+          </CostPanel>
+        )}
         <CostPanel title="Cost by model">
           <CostRankList
             rows={
@@ -417,19 +467,26 @@ function CostBreakdowns({
           <CostRankList rows={userRows} />
         </CostPanel>
 
-        <CostPanel title="Genie questions over time" sample>
-          <CostStackedBars
-            buckets={sample.genie}
-            format={fmtCount}
-            showLegend={false}
-          />
-        </CostPanel>
-        <CostPanel title="Tokens over time" sample>
-          <CostLine points={sample.tokens} />
-        </CostPanel>
-        <CostPanel title="Subscriptions vs consumption" sample>
-          <CostStackedBars buckets={sample.seatsVsUsage} showLegend={false} />
-        </CostPanel>
+        {showSample && (
+          <>
+            <CostPanel title="Genie questions over time" sample>
+              <CostStackedBars
+                buckets={sample.genie}
+                format={fmtCount}
+                showLegend={false}
+              />
+            </CostPanel>
+            <CostPanel title="Tokens over time" sample>
+              <CostLine points={sample.tokens} />
+            </CostPanel>
+            <CostPanel title="Subscriptions vs consumption" sample>
+              <CostStackedBars
+                buckets={sample.seatsVsUsage}
+                showLegend={false}
+              />
+            </CostPanel>
+          </>
+        )}
       </SimpleGrid>
     </VStack>
   );

--- a/specs/governance/governance-cost-screen.feature
+++ b/specs/governance/governance-cost-screen.feature
@@ -201,6 +201,47 @@ Feature: One cost screen, three honest lanes
     When a permitted viewer opens the cost screen
     Then the billed lane shows the negative amount as reported
 
+  Rule: The screen says where its numbers stop being complete
+    # ADR-128 4a. A source that has stopped pulling is not asked about
+    # anything, so it reports no spend, so the lanes fall. On screen that is
+    # indistinguishable from a cheap month, and a reader who takes an outage
+    # for a saving is worse off than one with no cost screen at all. The
+    # source pages already carry this line; only someone already suspicious
+    # goes there.
+
+    @integration
+    Scenario: The cost screen says where its numbers stop being complete
+      Given a contributing source that has stopped pulling
+      When a permitted viewer opens the cost screen
+      Then the screen names that source and the day its data stops
+      And the lanes are still shown
+      # The figures are caveated, not withdrawn. What was pulled before the
+      # outage is still the truth about those days.
+
+    @integration
+    Scenario: A screen whose sources are all pulling carries no outage notice
+      Given every contributing source pulling successfully
+      When a permitted viewer opens the cost screen
+      Then the screen carries no outage notice
+      # A caveat on whole figures teaches the reader to ignore caveats.
+
+    @unit
+    Scenario: The gap is dated from the first source that fell over
+      Given two contributing sources that stopped pulling on different days
+      When the cost summary is read
+      Then the gap is dated from the earlier of the two
+      # The totals stopped being whole when the first one broke, not the last.
+
+    @unit
+    Scenario: A source nobody asked to run is not reported as an outage
+      Given a disabled source whose last runs failed before it was switched off
+      And a source that has never pulled successfully
+      When the cost summary is read
+      Then neither is reported as having stopped pulling
+      # A disabled source is not failing to run, it is doing what an admin
+      # chose. One that never succeeded has no "since" to name, and its
+      # awaiting-first-event badge already says so.
+
   Rule: The seat lane reads the newest report of each pool, and nobody else's
 
     A licence count is a standing fact, not a running total. Each read of a

--- a/specs/governance/governance-cost-screen.feature
+++ b/specs/governance/governance-cost-screen.feature
@@ -202,45 +202,67 @@ Feature: One cost screen, three honest lanes
     Then the billed lane shows the negative amount as reported
 
   Rule: The screen says where its numbers stop being complete
-    # ADR-128 4a. A source that has stopped pulling is not asked about
-    # anything, so it reports no spend, so the lanes fall. On screen that is
-    # indistinguishable from a cheap month, and a reader who takes an outage
-    # for a saving is worse off than one with no cost screen at all. The
-    # source pages already carry this line; only someone already suspicious
-    # goes there.
+    # ADR-128 4a. A source whose pulls keep failing brings nothing back, so it
+    # reports no spend, so the lanes fall. On screen that is indistinguishable
+    # from a cheap month, and a reader who takes a stalled pull for a saving is
+    # worse off than one with no cost screen at all. The source pages already
+    # carry this line; only someone already suspicious goes there.
+    #
+    # These scenarios say "failing to pull", not "stopped pulling", and the
+    # difference is a known gap rather than pedantry. What is detected is a run
+    # of consecutive pull FAILURES. A source whose worker is never scheduled at
+    # all keeps a zero failure count and is never named here, though its
+    # figures are exactly as incomplete. Closing that needs a staleness rule
+    # measured against each source's expected pull interval, which nothing
+    # records yet. Until it exists, this Rule covers the loud failure and not
+    # the quiet one.
+    #
+    # "Every source" below means every source the organization has that is not
+    # archived. The read does not distinguish sources that feed cost from
+    # sources that do not, so a failing non-cost puller is named here too.
+    # Deliberate: the alternative to a slightly wide caveat is silence, which
+    # is the harm this Rule exists to stop.
 
     @integration
     Scenario: The cost screen says where its numbers stop being complete
-      Given a contributing source that has stopped pulling
+      Given a source whose pulls have been failing
       When a permitted viewer opens the cost screen
-      Then the screen names that source and the day its data stops
+      Then the screen names that source and the day of its last successful pull
       And the lanes are still shown
       # The figures are caveated, not withdrawn. What was pulled before the
-      # outage is still the truth about those days.
+      # failures is still the truth about those days.
 
     @integration
-    Scenario: A screen whose sources are all pulling carries no outage notice
-      Given every contributing source pulling successfully
+    Scenario: A screen whose sources are all pulling carries no warning
+      Given every source pulling successfully
       When a permitted viewer opens the cost screen
-      Then the screen carries no outage notice
+      Then the screen carries no stopped-pulling warning
       # A caveat on whole figures teaches the reader to ignore caveats.
 
     @unit
-    Scenario: The gap is dated from the first source that fell over
-      Given two contributing sources that stopped pulling on different days
+    Scenario: The gap is dated from the first source that started failing
+      Given two sources whose pulls started failing on different days
       When the cost summary is read
       Then the gap is dated from the earlier of the two
       # The totals stopped being whole when the first one broke, not the last.
 
     @unit
-    Scenario: A source nobody asked to run is not reported as an outage
+    Scenario: A source nobody asked to run is not reported as having stopped
       Given a disabled source whose last runs failed before it was switched off
-      And a source that has never pulled successfully
       When the cost summary is read
-      Then neither is reported as having stopped pulling
+      Then it is not reported as having stopped pulling
       # A disabled source is not failing to run, it is doing what an admin
-      # chose. One that never succeeded has no "since" to name, and its
-      # awaiting-first-event badge already says so.
+      # chose. Split from the never-pulled case below on purpose: they are two
+      # independent exclusions, and one regressing must not hide behind the
+      # other holding.
+
+    @unit
+    Scenario: A source that has never pulled has no day to report
+      Given a source that has never pulled successfully
+      When the cost summary is read
+      Then it is not reported as having stopped pulling
+      # There is no "since" to name, and its awaiting-first-event badge
+      # already says so.
 
   Rule: The seat lane reads the newest report of each pool, and nobody else's
 


### PR DESCRIPTION
## What this does

The governance cost screen showed three lanes and nothing else. This gives it the breakdowns and filters the screen was always meant to carry, laid out the way the design prototype does.

The three existing lanes, the `governanceCost:view` guard, both feature flags, and every existing testid are untouched. Everything new sits below them.

### Filters

Four chips across the top: Department, Time Frame (7 / 30 / 90 days), Time Interval, Group By (team / user / model). They drive the panels that read real data.

The prototype also has a generic "Filters" chip. It is not here, because it has nothing to put in it yet.

### Panels

Nine panels in one grid, in the prototype's order.

Five read real data through `activityMonitor`:

- Cost evolution, grouped by the Group By chip
- Cost by department
- Cost by model
- Cost by user
- Adoption

Seven are seeded sample data and carry a visible **sample** badge, because the platform does not measure them yet: consumption forecast, subscriptions by department, % cost by agent, cost by agent, questions over time, tokens over time, subscriptions vs consumption.

The sample series are generated from a seeded PRNG rather than `Math.random`, so server and client render the same markup and hydration stays quiet.

### Sample panels are not always on

They follow the rule the trace explorer already uses for sample traces (`usePreviewTracesActive`): fill a screen with nothing measured on it, step aside once real figures arrive, and let an explicit choice by the reader beat both defaults. The header toggle uses the same words, colour and single-exit shape as the one in the trace toolbar.

Two things differ from traces, both because these panels are not standing in for data that is on its way:

- **Off removes them rather than emptying them.** A permanently blank panel would imply we looked and found nothing.
- **The toggle stays after real data arrives.** Traces hides it, because sample traces have nothing left to offer once real ones exist. Here the sample panels remain the only picture of what the screen will hold once those measurements are built.

An unanswered read is not treated as an empty one. The four real reads land independently, so mid-load the page holds a mix of rows and nulls; reading that as "nothing measured" would flash the sample panels onto a screen about to fill with real figures. `resolveRealDataState` stays `unknown` until either a row appears or every read has answered.

A banner sits above the panels whenever any are showing. Each panel already carries a badge, but a badge labels one card and this is a claim about the screen — the reader who takes a figure off a filled-in dashboard without checking the corner of the card is exactly the one the badge does not reach.

### Deliberate omissions

- **No "AI cost" total card.** ADR-128 says the lanes must not be summed — billed cost and gateway cost measure overlapping things, and adding them produces a number that means nothing. The prototype's big figure has no honest equivalent here.
- **No "the bill behind these numbers" link.** This is one page.
- **No "Interactions" figure in Adoption.** `spendByUser` is called with `limit: 8`, so any sum over its rows is the top eight users, not the organization. A headline figure that is quietly a slice is worse than no figure. Users is shown alone.

## Two defects found and fixed before review

Both were in the first commit of this branch, and both were caught by executing the page rather than reading it.

**The screen crashed on the first real answer.** `spendOverTime` resolves to a wrapper, `{ buckets: [...] }`, not to an array — see `SpendOverTimeResult` at `platform/app/ee/governance/services/activity-monitor/activityMonitor.service.ts:169`. The page handed that wrapper to a function that maps over an array. The wrapper is truthy, so the guard passed and `buckets.map is not a function` took the whole screen down. It never showed up in the tests because every existing mock answered `undefined`.

**Five panels reported measurements that were never taken.** Absent reads were collapsed with `?? 0` and `?? []`, so a screen with no data rendered `Users 0` and *Nothing in this window yet* — while the seats lane, on the same screen, correctly said *Seat data is not yet available*. Two contradictory claims about the same absence, side by side.

The fix separates the two states everywhere. `null` means the read has not answered and renders *Not available.*; `[]` means it answered and found nothing, and renders *Nothing in this window yet.* A zero is a measurement, and the page no longer invents one.

Both guarantees are covered by `costBreakdowns.integration.test.tsx` and were mutation-tested: reinstating the wrapper bug fails 4 of 5 tests, reinstating the `?? 0` collapse fails 1.

## Verification

- `src/pages/governance/` — 46 passed (component config), 2 passed (default)
- `src/components/governance/` — 9 passed
- biome clean on every changed file
- `pnpm run typecheck` exits 0. Confirmed it actually covers the new files by breaking one deliberately and watching it fail. Note that a direct `tsc --noEmit` invocation is useless in this repo — it aborts on a `baseUrl` config error and reports success having compiled nothing.

**Not verified: this page has never been rendered in a browser.** Everything above is from tests and from a probe that dumped the rendered text. Layout, spacing, colour and the charts' visual behaviour are unreviewed.

## Follow-ups, not fixed here

- `formatDayTick` now exists three times: `SpendOverTimeChart.tsx:200`, `gateway/usage.tsx:502`, and `CostCharts.tsx`. Two copies predate this branch; this adds a third. They can drift, and the same day could render as different dates on adjacent screens. Consolidating touches files this change does not own.
- Money arrives as a string and is converted with `Number()` for display. Correct for reading, wrong for anything that later sums or reconciles.
- No Gherkin scenarios were added for the nine new panels.
