### PR TITLE
feat(coding-agent): split pull request cost by stamped working context

### DIFF
--- a/platform/app/src/app/api/coding-agent/__tests__/pullRequestUsageV1TestApp.ts
+++ b/platform/app/src/app/api/coding-agent/__tests__/pullRequestUsageV1TestApp.ts
@@ -43,6 +43,7 @@ function staticBranchSessions(
     findBySessionId: base.findBySessionId.bind(base),
     findBySessionIdWithApplied: base.findBySessionIdWithApplied.bind(base),
     findManyRecent: base.findManyRecent.bind(base),
+    listBySessionIds: base.listBySessionIds.bind(base),
     listByRepositoryBranch: async (params) =>
       tenantIds
         .filter((tenantId) => params.tenantIds.includes(tenantId))

--- a/platform/app/src/server/app-layer/coding-agent/__tests__/coding-agent-session.service.unit.test.ts
+++ b/platform/app/src/server/app-layer/coding-agent/__tests__/coding-agent-session.service.unit.test.ts
@@ -178,6 +178,7 @@ function makeService({
       row ? { row, appliedEventIds: [] } : null,
     findManyRecent: async () => listed,
     listByRepositoryBranch: async () => [],
+    listBySessionIds: async () => [],
   };
   const traceSessions: CodingAgentTraceSessionRepository = {
     ensure: async () => {},
@@ -198,6 +199,7 @@ function makeService({
           findBySessionId: async ({ occurredAt }) =>
             onEventsRead({ occurredAt }),
           sumTokensByModelPerSession: async () => [],
+          listSessionsByStampedBranch: async () => [],
         }
       : new NullCodingAgentSessionEventsRepository(),
   });
@@ -214,6 +216,7 @@ describe("CodingAgentSessionService", () => {
           findBySessionIdWithApplied: async () => null,
           findManyRecent: async () => [],
           listByRepositoryBranch: async () => [],
+          listBySessionIds: async () => [],
         },
         traceSessions: {
           ensure: async () => {},
@@ -230,6 +233,7 @@ describe("CodingAgentSessionService", () => {
             return { events: [], nextCursor: null };
           },
           sumTokensByModelPerSession: async () => [],
+          listSessionsByStampedBranch: async () => [],
         },
       });
 
@@ -405,6 +409,7 @@ describe("CodingAgentSessionService", () => {
           findBySessionIdWithApplied: async () => null,
           findManyRecent: async () => [],
           listByRepositoryBranch: async () => [],
+          listBySessionIds: async () => [],
         };
         const service = new CodingAgentSessionService({
           sessions,

--- a/platform/app/src/server/app-layer/coding-agent/__tests__/pull-request-assignment.unit.test.ts
+++ b/platform/app/src/server/app-layer/coding-agent/__tests__/pull-request-assignment.unit.test.ts
@@ -14,6 +14,7 @@ import {
   type AssignablePullRequest,
   type AssignableSession,
   assignDrivingSessionsToPullRequests,
+  assignDrivingSessionsToPullRequestsPerBranch,
   assignSessionsToPullRequests,
   branchesOf,
 } from "../pull-request-assignment";
@@ -287,7 +288,8 @@ describe("assignDrivingSessionsToPullRequests", () => {
   });
 
   describe("given a session driving two branches that each have a live pull request", () => {
-    /** @scenario "A session that drove two pull requests counts toward only one of them" */
+    // The single-winner rule now prices only what has no finer record: the
+    // unstamped bucket. Stamped tokens split through the per-branch rule below.
     it("counts it toward the one it opened first and toward the other not at all", () => {
       const assignments = assignDrivingSessionsToPullRequests({
         sessions: [
@@ -392,6 +394,73 @@ describe("assignDrivingSessionsToPullRequests", () => {
       });
 
       expect(assignments.size).toBe(0);
+    });
+  });
+});
+
+describe("assignDrivingSessionsToPullRequestsPerBranch", () => {
+  describe("given a session driving two branches that each have a live pull request", () => {
+    it("answers with each branch's own winner", () => {
+      const assignments = assignDrivingSessionsToPullRequestsPerBranch({
+        sessions: [
+          {
+            sessionId: "both",
+            startedAtMs: base,
+            headBranches: ["feat/first", "feat/second"],
+          },
+        ],
+        pullRequests: [
+          pullRequest({ prNumber: 9, headBranch: "feat/first" }),
+          pullRequest({ prNumber: 21, headBranch: "feat/second" }),
+        ],
+      });
+
+      const perBranch = assignments.get("both");
+      expect(perBranch?.get("feat/first")).toBe(9);
+      expect(perBranch?.get("feat/second")).toBe(21);
+    });
+  });
+
+  describe("given a recycled branch with an old and a new pull request", () => {
+    /** @scenario "Two pull requests on one branch split by era, not by double counting" */
+    it("answers with the branch's tenure winner alone", () => {
+      const assignments = assignDrivingSessionsToPullRequestsPerBranch({
+        sessions: [
+          {
+            sessionId: "later-era",
+            startedAtMs: base + 5 * HOUR,
+            headBranches: ["feat/linkage"],
+          },
+        ],
+        pullRequests: [
+          pullRequest({
+            prNumber: 9,
+            prCreatedAtMs: base,
+            prClosedAtMs: base + HOUR,
+            prMergedAtMs: base + HOUR,
+          }),
+          pullRequest({ prNumber: 21, prCreatedAtMs: base + 4 * HOUR }),
+        ],
+      });
+
+      expect(assignments.get("later-era")?.get("feat/linkage")).toBe(21);
+    });
+  });
+
+  describe("given a session whose branches map to no pull request", () => {
+    it("leaves the session out of the answer entirely", () => {
+      const assignments = assignDrivingSessionsToPullRequestsPerBranch({
+        sessions: [
+          {
+            sessionId: "unlinked",
+            startedAtMs: base,
+            headBranches: ["feat/nowhere"],
+          },
+        ],
+        pullRequests: [pullRequest({ prNumber: 7 })],
+      });
+
+      expect(assignments.has("unlinked")).toBe(false);
     });
   });
 });

--- a/platform/app/src/server/app-layer/coding-agent/__tests__/pull-request-usage.integration.test.ts
+++ b/platform/app/src/server/app-layer/coding-agent/__tests__/pull-request-usage.integration.test.ts
@@ -223,6 +223,10 @@ function modelCallEvent({
     toolResultBytes: 0,
     promptChars: 0,
     totalTokens: 0,
+    repositoryHost: "",
+    repositoryOwner: "",
+    repositoryName: "",
+    branch: "",
   };
 }
 

--- a/platform/app/src/server/app-layer/coding-agent/__tests__/pull-request-usage.service.unit.test.ts
+++ b/platform/app/src/server/app-layer/coding-agent/__tests__/pull-request-usage.service.unit.test.ts
@@ -1365,6 +1365,64 @@ describe("PullRequestUsageService", () => {
     });
   });
 
+  describe("given a session too small to divide between two pull requests", () => {
+    // One input token and nothing else, stamped half on each branch. Rounding
+    // each share on its own would report that token twice.
+    const oneTokenFixture = () => ({
+      pullRequests: [
+        pullRequestRow(),
+        pullRequestRow({
+          prNumber: 8,
+          headBranch: "feat/next",
+          htmlUrl: "https://github.com/acme/widgets/pull/8",
+          prCreatedAt: new Date(NOW - 8 * HOUR),
+        }),
+      ],
+      sessions: [
+        sessionRow({
+          gitBranches: ["feat/linkage", "feat/next"],
+          inputTokens: 1,
+          outputTokens: 0,
+          cacheReadTokens: 0,
+          cacheCreationTokens: 0,
+          costUsd: 0.02,
+        }),
+      ],
+      modelTotals: [
+        stampedTotalsRow({
+          inputTokens: 1,
+          outputTokens: 0,
+          cacheReadTokens: 0,
+          cacheCreationTokens: 0,
+          costUsd: 0.01,
+        }),
+        stampedTotalsRow({
+          branch: "feat/next",
+          inputTokens: 1,
+          outputTokens: 0,
+          cacheReadTokens: 0,
+          cacheCreationTokens: 0,
+          costUsd: 0.01,
+        }),
+      ],
+    });
+
+    /** @scenario "A session too small to divide is never counted twice" */
+    it("hands the one token to a single pull request, never to both", async () => {
+      const first = await serviceWith(
+        oneTokenFixture(),
+      ).service.getPullRequestUsage(QUERY);
+      const second = await serviceWith(
+        oneTokenFixture(),
+      ).service.getPullRequestUsage({ ...QUERY, prNumber: 8 });
+
+      expect(first.totals.totalTokens + second.totals.totalTokens).toBe(1);
+      // Cost is a currency amount, so it stays exact and splits evenly.
+      expect(first.totals.costUsd).toBeCloseTo(0.01, 10);
+      expect(second.totals.costUsd).toBeCloseTo(0.01, 10);
+    });
+  });
+
   describe("given a session whose fact rows report cost but no token counts", () => {
     // Some agents price a call without telling us its token counts. The
     // stamps still have to decide where the money lands, so the ratio falls

--- a/platform/app/src/server/app-layer/coding-agent/__tests__/pull-request-usage.service.unit.test.ts
+++ b/platform/app/src/server/app-layer/coding-agent/__tests__/pull-request-usage.service.unit.test.ts
@@ -96,7 +96,11 @@ function personalSessionRow(
   };
 }
 
-/** One (session, model) total, as the per-call fact table returns it. */
+/**
+ * One (session, model, context) total, as the per-call fact table returns it.
+ * Unstamped by default — the shape every row predating the stamp has, which
+ * the legacy whole-session rule prices.
+ */
 function modelTotalsRow(
   over: Partial<SessionModelTotalsRow> = {},
 ): SessionModelTotalsRow {
@@ -104,6 +108,10 @@ function modelTotalsRow(
     tenantId: "project-1",
     sessionId: "session-a",
     model: "claude-fable-5",
+    repositoryHost: "",
+    repositoryOwner: "",
+    repositoryName: "",
+    branch: "",
     inputTokens: 100,
     outputTokens: 50,
     cacheReadTokens: 20,
@@ -111,6 +119,19 @@ function modelTotalsRow(
     costUsd: 1.5,
     ...over,
   };
+}
+
+/** The same row stamped on the mapping's own repository. */
+function stampedTotalsRow(
+  over: Partial<SessionModelTotalsRow> = {},
+): SessionModelTotalsRow {
+  return modelTotalsRow({
+    repositoryHost: "github.com",
+    repositoryOwner: "acme",
+    repositoryName: "widgets",
+    branch: "feat/linkage",
+    ...over,
+  });
 }
 
 /** Nothing is bundled unless a case says so. */
@@ -148,32 +169,51 @@ function serviceWith({
   pullRequests,
   sessions,
   modelTotals = [],
+  stampedSessions = [],
+  sessionsById = [],
   isSourceNonBillable = allBilled,
 }: {
   pullRequests: GithubPullRequestRow[];
   sessions: CodingAgentBranchSessionRow[];
   modelTotals?: SessionModelTotalsRow[];
+  /** What the stamped-branch discovery read answers. */
+  stampedSessions?: Array<{ tenantId: string; sessionId: string }>;
+  /** What the by-id session read answers for the stamp-only discoveries. */
+  sessionsById?: CodingAgentBranchSessionRow[];
   isSourceNonBillable?: (params: {
     organizationId: string;
     sourceType: string;
   }) => Promise<boolean>;
 }) {
   const listByRepositoryBranch = vi.fn().mockResolvedValue(sessions);
+  const listBySessionIds = vi.fn().mockResolvedValue(sessionsById);
   const sumTokensByModelPerSession = vi.fn().mockResolvedValue(modelTotals);
+  const listSessionsByStampedBranch = vi
+    .fn()
+    .mockResolvedValue(stampedSessions);
   const service = new PullRequestUsageService({
     pullRequests: {
-      findByNumber: vi.fn().mockResolvedValue(pullRequests[0] ?? null),
+      findByNumber: vi.fn(
+        async ({ prNumber }: { prNumber: number }) =>
+          pullRequests.find((row) => row.prNumber === prNumber) ?? null,
+      ),
       findAllByBranches: vi.fn().mockResolvedValue(pullRequests),
     } as never,
-    sessions: { listByRepositoryBranch } as never,
+    sessions: { listByRepositoryBranch, listBySessionIds } as never,
     personalSessions: { listRecent: vi.fn().mockResolvedValue([]) },
-    sessionEvents: { sumTokensByModelPerSession },
+    sessionEvents: { sumTokensByModelPerSession, listSessionsByStampedBranch },
     installations: { coversRepository: vi.fn().mockResolvedValue(true) },
     resolveOrganizationId: async () => "org-1",
     isSourceNonBillable,
     now: () => NOW,
   });
-  return { service, listByRepositoryBranch, sumTokensByModelPerSession };
+  return {
+    service,
+    listByRepositoryBranch,
+    listBySessionIds,
+    sumTokensByModelPerSession,
+    listSessionsByStampedBranch,
+  };
 }
 
 /** A personal workspace: named by the person who owns it, never linked. */
@@ -242,12 +282,16 @@ function personalServiceWith({
     .mockResolvedValue(organizationSessions);
   const service = new PullRequestUsageService({
     pullRequests: { findByNumber: vi.fn(), findAllByBranches } as never,
-    sessions: { listByRepositoryBranch } as never,
+    sessions: {
+      listByRepositoryBranch,
+      listBySessionIds: vi.fn().mockResolvedValue([]),
+    } as never,
     personalSessions: {
       listRecent: vi.fn().mockResolvedValue(personalSessions),
     },
     sessionEvents: {
       sumTokensByModelPerSession: vi.fn().mockResolvedValue(modelTotals),
+      listSessionsByStampedBranch: vi.fn().mockResolvedValue([]),
     },
     installations: { coversRepository: vi.fn().mockResolvedValue(true) },
     resolveOrganizationId: async () => "org-1",
@@ -560,10 +604,14 @@ describe("PullRequestUsageService", () => {
             findByNumber: vi.fn(),
             findAllByBranches: vi.fn().mockResolvedValue([]),
           } as never,
-          sessions: { listByRepositoryBranch: vi.fn() } as never,
+          sessions: {
+            listByRepositoryBranch: vi.fn(),
+            listBySessionIds: vi.fn().mockResolvedValue([]),
+          } as never,
           personalSessions: { listRecent },
           sessionEvents: {
             sumTokensByModelPerSession: vi.fn().mockResolvedValue([]),
+            listSessionsByStampedBranch: vi.fn().mockResolvedValue([]),
           },
           installations: { coversRepository: vi.fn().mockResolvedValue(true) },
           resolveOrganizationId: async () => "org-1",
@@ -591,10 +639,14 @@ describe("PullRequestUsageService", () => {
             findByNumber: vi.fn().mockResolvedValue(pullRequestRow()),
             findAllByBranches: vi.fn().mockResolvedValue([pullRequestRow()]),
           } as never,
-          sessions: { listByRepositoryBranch } as never,
+          sessions: {
+            listByRepositoryBranch,
+            listBySessionIds: vi.fn().mockResolvedValue([]),
+          } as never,
           personalSessions: { listRecent: vi.fn().mockResolvedValue([]) },
           sessionEvents: {
             sumTokensByModelPerSession: vi.fn().mockResolvedValue([]),
+            listSessionsByStampedBranch: vi.fn().mockResolvedValue([]),
           },
           installations: { coversRepository: vi.fn().mockResolvedValue(true) },
           resolveOrganizationId: async () => "org-1",
@@ -701,9 +753,17 @@ describe("PullRequestUsageService", () => {
 
   describe("given a personal session that drove two branches", () => {
     /** @scenario "The personal page discovers pull requests from every branch a session drove" */
-    it("looks up the pull requests of both, not only the one it ended on", async () => {
+    it("lists a row for each branch's pull request, not only the last one", async () => {
       const { service, findAllByBranches } = personalServiceWith({
-        pullRequests: [pullRequestRow()],
+        pullRequests: [
+          pullRequestRow(),
+          pullRequestRow({
+            prNumber: 8,
+            headBranch: "feat/next",
+            htmlUrl: "https://github.com/acme/widgets/pull/8",
+            prCreatedAt: new Date(NOW - 8 * HOUR),
+          }),
+        ],
         personalSessions: [
           personalSessionRow({
             sessionId: "mine",
@@ -727,9 +787,16 @@ describe("PullRequestUsageService", () => {
           headBranches: ["feat/linkage", "feat/next"],
         }),
       );
-      // Discovered through the branch it left, and priced there too.
-      expect(usage.rows[0]?.prNumber).toBe(7);
-      expect(usage.rows[0]?.sessionsCount).toBe(1);
+      expect(usage.rows.map((row) => row.prNumber).sort()).toEqual([7, 8]);
+      // With no stamped facts, the whole session prices under the pull
+      // request it opened first; the other row is discovered but reports the
+      // work that was stamped on it, which is none.
+      expect(
+        usage.rows.find((row) => row.prNumber === 7)?.totalTokens,
+      ).toBe(180);
+      expect(
+        usage.rows.find((row) => row.prNumber === 8)?.totalTokens,
+      ).toBe(0);
     });
   });
 
@@ -1174,6 +1241,238 @@ describe("PullRequestUsageService", () => {
         "title",
         "totalTokens",
       ]);
+    });
+  });
+
+  describe("given a session whose fact rows stamp work on two pull requests", () => {
+    // One session, two branches, each with its own live pull request. The
+    // stamps put a fifth of the event tokens on the first branch and the rest
+    // on the second, so the cumulative totals split 20/80.
+    const splitFixture = () => ({
+      pullRequests: [
+        pullRequestRow(),
+        pullRequestRow({
+          prNumber: 8,
+          headBranch: "feat/next",
+          htmlUrl: "https://github.com/acme/widgets/pull/8",
+          prCreatedAt: new Date(NOW - 8 * HOUR),
+        }),
+      ],
+      sessions: [
+        sessionRow({ gitBranches: ["feat/linkage", "feat/next"] }),
+      ],
+      modelTotals: [
+        stampedTotalsRow({
+          inputTokens: 20,
+          outputTokens: 10,
+          cacheReadTokens: 4,
+          cacheCreationTokens: 2,
+          costUsd: 0.2,
+        }),
+        stampedTotalsRow({
+          branch: "feat/next",
+          inputTokens: 80,
+          outputTokens: 40,
+          cacheReadTokens: 16,
+          cacheCreationTokens: 8,
+          costUsd: 0.8,
+        }),
+      ],
+    });
+
+    /** @scenario "A session that drove two pull requests splits its cost between them" */
+    it("prices each pull request by the share of tokens stamped on it", async () => {
+      const first = await serviceWith(splitFixture()).service.getPullRequestUsage(
+        QUERY,
+      );
+      const second = await serviceWith(
+        splitFixture(),
+      ).service.getPullRequestUsage({ ...QUERY, prNumber: 8 });
+
+      expect(first.totals.inputTokens).toBe(20);
+      expect(first.totals.outputTokens).toBe(10);
+      expect(first.totals.cacheReadTokens).toBe(4);
+      expect(first.totals.cacheCreationTokens).toBe(2);
+      expect(first.totals.costUsd).toBeCloseTo(0.3, 10);
+
+      expect(second.totals.inputTokens).toBe(80);
+      expect(second.totals.outputTokens).toBe(40);
+      expect(second.totals.cacheReadTokens).toBe(16);
+      expect(second.totals.cacheCreationTokens).toBe(8);
+      expect(second.totals.costUsd).toBeCloseTo(1.2, 10);
+
+      // The two shares partition the session's own cumulative totals.
+      expect(first.totals.totalTokens + second.totals.totalTokens).toBe(180);
+    });
+
+    /** @scenario "The model breakdown reports only the pull request's own calls" */
+    it("keeps each pull request's model breakdown to its own stamped calls", async () => {
+      const fixture = splitFixture();
+      fixture.modelTotals[1] = {
+        ...fixture.modelTotals[1]!,
+        model: "claude-opus-5",
+      };
+
+      const first = await serviceWith(fixture).service.getPullRequestUsage(
+        QUERY,
+      );
+      const second = await serviceWith(fixture).service.getPullRequestUsage({
+        ...QUERY,
+        prNumber: 8,
+      });
+
+      expect(first.modelBreakdown.map((m) => m.model)).toEqual([
+        "claude-fable-5",
+      ]);
+      expect(second.modelBreakdown.map((m) => m.model)).toEqual([
+        "claude-opus-5",
+      ]);
+    });
+  });
+
+  describe("given a session whose fact rows carry no stamped context", () => {
+    const legacyFixture = () => ({
+      pullRequests: [
+        pullRequestRow(),
+        pullRequestRow({
+          prNumber: 8,
+          headBranch: "feat/next",
+          htmlUrl: "https://github.com/acme/widgets/pull/8",
+          prCreatedAt: new Date(NOW - 8 * HOUR),
+        }),
+      ],
+      sessions: [
+        sessionRow({ gitBranches: ["feat/linkage", "feat/next"] }),
+      ],
+    });
+
+    /** @scenario "Tokens stamped with no context follow the legacy whole-session rule" */
+    it("lands the whole total on the first-opened pull request alone", async () => {
+      const fixture = { ...legacyFixture(), modelTotals: [modelTotalsRow()] };
+
+      const first = await serviceWith(fixture).service.getPullRequestUsage(
+        QUERY,
+      );
+      const second = await serviceWith(fixture).service.getPullRequestUsage({
+        ...QUERY,
+        prNumber: 8,
+      });
+
+      expect(first.totals.totalTokens).toBe(180);
+      expect(second.totals.totalTokens).toBe(0);
+      expect(second.rows).toHaveLength(0);
+    });
+
+    /** @scenario "A session with no fact rows at all keeps the legacy rule whole" */
+    it("prices a session that logged no per-call facts under the legacy rule", async () => {
+      const fixture = { ...legacyFixture(), modelTotals: [] };
+
+      const first = await serviceWith(fixture).service.getPullRequestUsage(
+        QUERY,
+      );
+      const second = await serviceWith(fixture).service.getPullRequestUsage({
+        ...QUERY,
+        prNumber: 8,
+      });
+
+      expect(first.totals.totalTokens).toBe(180);
+      expect(second.totals.totalTokens).toBe(0);
+    });
+  });
+
+  describe("given a session whose stamps span two repositories", () => {
+    /** @scenario "Tokens stamped on another repository stay out of this one" */
+    it("counts only this repository's stamped share toward its pull request", async () => {
+      const { service } = serviceWith({
+        pullRequests: [pullRequestRow()],
+        sessions: [sessionRow()],
+        modelTotals: [
+          stampedTotalsRow({
+            inputTokens: 50,
+            outputTokens: 25,
+            cacheReadTokens: 10,
+            cacheCreationTokens: 5,
+          }),
+          stampedTotalsRow({
+            repositoryOwner: "other",
+            repositoryName: "gadgets",
+            branch: "feat/elsewhere",
+            inputTokens: 50,
+            outputTokens: 25,
+            cacheReadTokens: 10,
+            cacheCreationTokens: 5,
+          }),
+        ],
+      });
+
+      const usage = await service.getPullRequestUsage(QUERY);
+
+      expect(usage.totals.inputTokens).toBe(50);
+      expect(usage.totals.outputTokens).toBe(25);
+      expect(usage.totals.totalTokens).toBe(90);
+      expect(usage.totals.costUsd).toBeCloseTo(0.75, 10);
+    });
+  });
+
+  describe("given a session whose row moved on to another repository", () => {
+    /** @scenario "A session found only by its stamps still counts toward the pull request" */
+    it("finds the session through its stamps and counts its stamped share", async () => {
+      const movedOn = sessionRow({
+        sessionId: "moved-on",
+        gitBranch: "feat/elsewhere",
+        gitBranches: ["feat/linkage", "feat/elsewhere"],
+      });
+      const { service, listBySessionIds } = serviceWith({
+        pullRequests: [pullRequestRow()],
+        sessions: [],
+        stampedSessions: [{ tenantId: "project-1", sessionId: "moved-on" }],
+        sessionsById: [movedOn],
+        modelTotals: [stampedTotalsRow({ sessionId: "moved-on" })],
+      });
+
+      const usage = await service.getPullRequestUsage(QUERY);
+
+      expect(listBySessionIds).toHaveBeenCalledWith(
+        expect.objectContaining({ sessionIds: ["moved-on"] }),
+      );
+      expect(usage.totals.totalTokens).toBe(180);
+    });
+
+    /** @scenario "The unstamped bucket is priced only where the session's row lives" */
+    it("leaves a stamp-discovered session's unstamped tokens out of this repository", async () => {
+      const movedOn = sessionRow({
+        sessionId: "moved-on",
+        gitBranch: "feat/elsewhere",
+        gitBranches: ["feat/linkage", "feat/elsewhere"],
+      });
+      const { service } = serviceWith({
+        pullRequests: [pullRequestRow()],
+        sessions: [],
+        stampedSessions: [{ tenantId: "project-1", sessionId: "moved-on" }],
+        sessionsById: [movedOn],
+        modelTotals: [
+          // Half the event tokens stamped here, half unstamped: only the
+          // stamped half may be priced under this repository's pull request.
+          stampedTotalsRow({
+            sessionId: "moved-on",
+            inputTokens: 50,
+            outputTokens: 25,
+            cacheReadTokens: 10,
+            cacheCreationTokens: 5,
+          }),
+          modelTotalsRow({
+            sessionId: "moved-on",
+            inputTokens: 50,
+            outputTokens: 25,
+            cacheReadTokens: 10,
+            cacheCreationTokens: 5,
+          }),
+        ],
+      });
+
+      const usage = await service.getPullRequestUsage(QUERY);
+
+      expect(usage.totals.totalTokens).toBe(90);
     });
   });
 });

--- a/platform/app/src/server/app-layer/coding-agent/__tests__/pull-request-usage.service.unit.test.ts
+++ b/platform/app/src/server/app-layer/coding-agent/__tests__/pull-request-usage.service.unit.test.ts
@@ -791,12 +791,10 @@ describe("PullRequestUsageService", () => {
       // With no stamped facts, the whole session prices under the pull
       // request it opened first; the other row is discovered but reports the
       // work that was stamped on it, which is none.
-      expect(
-        usage.rows.find((row) => row.prNumber === 7)?.totalTokens,
-      ).toBe(180);
-      expect(
-        usage.rows.find((row) => row.prNumber === 8)?.totalTokens,
-      ).toBe(0);
+      expect(usage.rows.find((row) => row.prNumber === 7)?.totalTokens).toBe(
+        180,
+      );
+      expect(usage.rows.find((row) => row.prNumber === 8)?.totalTokens).toBe(0);
     });
   });
 
@@ -1258,9 +1256,7 @@ describe("PullRequestUsageService", () => {
           prCreatedAt: new Date(NOW - 8 * HOUR),
         }),
       ],
-      sessions: [
-        sessionRow({ gitBranches: ["feat/linkage", "feat/next"] }),
-      ],
+      sessions: [sessionRow({ gitBranches: ["feat/linkage", "feat/next"] })],
       modelTotals: [
         stampedTotalsRow({
           inputTokens: 20,
@@ -1282,9 +1278,9 @@ describe("PullRequestUsageService", () => {
 
     /** @scenario "A session that drove two pull requests splits its cost between them" */
     it("prices each pull request by the share of tokens stamped on it", async () => {
-      const first = await serviceWith(splitFixture()).service.getPullRequestUsage(
-        QUERY,
-      );
+      const first = await serviceWith(
+        splitFixture(),
+      ).service.getPullRequestUsage(QUERY);
       const second = await serviceWith(
         splitFixture(),
       ).service.getPullRequestUsage({ ...QUERY, prNumber: 8 });
@@ -1313,9 +1309,8 @@ describe("PullRequestUsageService", () => {
         model: "claude-opus-5",
       };
 
-      const first = await serviceWith(fixture).service.getPullRequestUsage(
-        QUERY,
-      );
+      const first =
+        await serviceWith(fixture).service.getPullRequestUsage(QUERY);
       const second = await serviceWith(fixture).service.getPullRequestUsage({
         ...QUERY,
         prNumber: 8,
@@ -1341,18 +1336,15 @@ describe("PullRequestUsageService", () => {
           prCreatedAt: new Date(NOW - 8 * HOUR),
         }),
       ],
-      sessions: [
-        sessionRow({ gitBranches: ["feat/linkage", "feat/next"] }),
-      ],
+      sessions: [sessionRow({ gitBranches: ["feat/linkage", "feat/next"] })],
     });
 
     /** @scenario "Tokens stamped with no context follow the legacy whole-session rule" */
     it("lands the whole total on the first-opened pull request alone", async () => {
       const fixture = { ...legacyFixture(), modelTotals: [modelTotalsRow()] };
 
-      const first = await serviceWith(fixture).service.getPullRequestUsage(
-        QUERY,
-      );
+      const first =
+        await serviceWith(fixture).service.getPullRequestUsage(QUERY);
       const second = await serviceWith(fixture).service.getPullRequestUsage({
         ...QUERY,
         prNumber: 8,
@@ -1367,9 +1359,8 @@ describe("PullRequestUsageService", () => {
     it("prices a session that logged no per-call facts under the legacy rule", async () => {
       const fixture = { ...legacyFixture(), modelTotals: [] };
 
-      const first = await serviceWith(fixture).service.getPullRequestUsage(
-        QUERY,
-      );
+      const first =
+        await serviceWith(fixture).service.getPullRequestUsage(QUERY);
       const second = await serviceWith(fixture).service.getPullRequestUsage({
         ...QUERY,
         prNumber: 8,

--- a/platform/app/src/server/app-layer/coding-agent/__tests__/pull-request-usage.service.unit.test.ts
+++ b/platform/app/src/server/app-layer/coding-agent/__tests__/pull-request-usage.service.unit.test.ts
@@ -796,6 +796,46 @@ describe("PullRequestUsageService", () => {
       );
       expect(usage.rows.find((row) => row.prNumber === 8)?.totalTokens).toBe(0);
     });
+
+    /** @scenario "A discovered pull request with no stamped work still dates itself" */
+    it("dates a row with no stamped work by the pull request, not the epoch", async () => {
+      const { service } = personalServiceWith({
+        pullRequests: [
+          pullRequestRow(),
+          pullRequestRow({
+            prNumber: 8,
+            headBranch: "feat/next",
+            htmlUrl: "https://github.com/acme/widgets/pull/8",
+            prCreatedAt: new Date(NOW - 8 * HOUR),
+            prUpdatedAt: new Date(NOW - 2 * HOUR),
+          }),
+        ],
+        personalSessions: [
+          personalSessionRow({
+            sessionId: "mine",
+            gitBranch: "feat/next",
+            gitBranches: ["feat/linkage", "feat/next"],
+          }),
+        ],
+        organizationSessions: [
+          sessionRow({
+            sessionId: "mine",
+            gitBranch: "feat/next",
+            gitBranches: ["feat/linkage", "feat/next"],
+          }),
+        ],
+        // Every stamped token lands on the first branch, so the second pull
+        // request is discovered with no share of its own.
+        modelTotals: [stampedTotalsRow({ sessionId: "mine" })],
+      });
+
+      const usage = await service.getForPersonalProject(PERSONAL_QUERY);
+
+      const empty = usage.rows.find((row) => row.prNumber === 8);
+      expect(empty?.totalTokens).toBe(0);
+      expect(empty?.costUsd).toBeNull();
+      expect(empty?.lastActivityAtMs).toBe(NOW - 2 * HOUR);
+    });
   });
 
   describe("given a pull request whose sessions ran in two projects", () => {
@@ -1322,6 +1362,99 @@ describe("PullRequestUsageService", () => {
       expect(second.modelBreakdown.map((m) => m.model)).toEqual([
         "claude-opus-5",
       ]);
+    });
+  });
+
+  describe("given a session whose fact rows report cost but no token counts", () => {
+    // Some agents price a call without telling us its token counts. The
+    // stamps still have to decide where the money lands, so the ratio falls
+    // back to cost rather than the whole session dropping to the legacy rule.
+    const costOnlyFixture = () => ({
+      pullRequests: [
+        pullRequestRow(),
+        pullRequestRow({
+          prNumber: 8,
+          headBranch: "feat/next",
+          htmlUrl: "https://github.com/acme/widgets/pull/8",
+          prCreatedAt: new Date(NOW - 8 * HOUR),
+        }),
+      ],
+      sessions: [sessionRow({ gitBranches: ["feat/linkage", "feat/next"] })],
+      modelTotals: [
+        stampedTotalsRow({
+          inputTokens: 0,
+          outputTokens: 0,
+          cacheReadTokens: 0,
+          cacheCreationTokens: 0,
+          costUsd: 0.2,
+        }),
+        stampedTotalsRow({
+          branch: "feat/next",
+          inputTokens: 0,
+          outputTokens: 0,
+          cacheReadTokens: 0,
+          cacheCreationTokens: 0,
+          costUsd: 0.8,
+        }),
+      ],
+    });
+
+    /** @scenario "A session that priced its calls without reporting tokens splits by cost" */
+    it("splits the session by the cost stamped on each branch", async () => {
+      const first = await serviceWith(
+        costOnlyFixture(),
+      ).service.getPullRequestUsage(QUERY);
+      const second = await serviceWith(
+        costOnlyFixture(),
+      ).service.getPullRequestUsage({ ...QUERY, prNumber: 8 });
+
+      expect(first.totals.costUsd).toBeCloseTo(0.3, 10);
+      expect(first.totals.inputTokens).toBe(20);
+      expect(second.totals.costUsd).toBeCloseTo(1.2, 10);
+      expect(second.totals.inputTokens).toBe(80);
+
+      // The two shares still partition the session's own cumulative totals.
+      expect(first.totals.totalTokens + second.totals.totalTokens).toBe(180);
+    });
+  });
+
+  describe("given a branch that hosted a merged pull request and later a new one", () => {
+    // One branch, two eras: the first pull request merged an hour before the
+    // session started, the second opened before it. The stamps name the
+    // branch, so the era decides which of the two they belong to.
+    const recycledFixture = () => ({
+      pullRequests: [
+        pullRequestRow({
+          state: "closed",
+          prClosedAt: new Date(NOW - 9 * HOUR),
+          prMergedAt: new Date(NOW - 9 * HOUR),
+        }),
+        pullRequestRow({
+          prNumber: 9,
+          htmlUrl: "https://github.com/acme/widgets/pull/9",
+          prCreatedAt: new Date(NOW - 8 * HOUR),
+        }),
+      ],
+      sessions: [sessionRow()],
+      modelTotals: [stampedTotalsRow()],
+    });
+
+    /** @scenario "Two pull requests on one branch split by era, not by double counting" */
+    it("counts the stamped tokens toward the branch's tenure winner only", async () => {
+      const merged = await serviceWith(
+        recycledFixture(),
+      ).service.getPullRequestUsage(QUERY);
+      const successor = await serviceWith(
+        recycledFixture(),
+      ).service.getPullRequestUsage({ ...QUERY, prNumber: 9 });
+
+      expect(merged.totals.sessionsCount).toBe(0);
+      expect(merged.totals.totalTokens).toBe(0);
+      expect(merged.totals.costUsd).toBeNull();
+
+      expect(successor.totals.sessionsCount).toBe(1);
+      expect(successor.totals.totalTokens).toBe(180);
+      expect(successor.totals.costUsd).toBeCloseTo(1.5, 10);
     });
   });
 

--- a/platform/app/src/server/app-layer/coding-agent/pull-request-assignment.ts
+++ b/platform/app/src/server/app-layer/coding-agent/pull-request-assignment.ts
@@ -110,14 +110,14 @@ export function assignSessionsToPullRequests({
  * you start the next. Reading the last branch alone charges the whole session
  * to the last pull request and leaves the one it opened first reading as free.
  *
- * Still at most one, and that is a limit of the data rather than of the rule.
- * A session reports one set of token and cost totals for its whole life, and
- * the per-call events carry no branch, so there is nothing to divide by. Giving
- * every pull request the session drove that same full total would make a
- * repository's pull requests sum to more than was ever spent, which on a page
- * about cost is the one error worth refusing. The trade is named rather than
- * hidden: a session that drove two pull requests counts toward one of them, and
- * the sessions list is where all of them are shown.
+ * At most one, because this rule prices what has no finer record: the tokens a
+ * session spent with NO stamped working context — history from before the
+ * stamp existed, and sessions that never declared where they were. Giving
+ * every pull request that same full total would make a repository's pull
+ * requests sum to more than was ever spent, which on a page about cost is the
+ * one error worth refusing. Stamped tokens split per branch through
+ * `assignDrivingSessionsToPullRequestsPerBranch` instead, and the sessions
+ * list is where all of a session's pull requests are shown.
  *
  * The winner is the earliest-created pull request the rule matched, tie-broken
  * by number. A session is anchored on where it STARTED, so the pull request it
@@ -144,6 +144,39 @@ export function assignDrivingSessionsToPullRequests({
       if (match && (!winner || isEarlier(match, winner))) winner = match;
     }
     if (winner) assignments.set(session.sessionId, winner.prNumber);
+  }
+
+  return assignments;
+}
+
+/**
+ * The tenure rule answered PER BRANCH: for each branch the session drove, the
+ * pull request its work on that branch belongs to. This is what stamped fact
+ * rows attribute through — tokens stamped with branch B go to B's winner — so
+ * one session's cost lands on every pull request it drove, each by the work it
+ * did there. A branch with no pull request alive in the session's era is
+ * simply absent from the map.
+ */
+export function assignDrivingSessionsToPullRequestsPerBranch({
+  sessions,
+  pullRequests,
+}: {
+  sessions: readonly AssignableDrivingSession[];
+  pullRequests: readonly AssignablePullRequest[];
+}): Map<string, ReadonlyMap<string, number>> {
+  const byBranch = groupPullRequestsByBranch(pullRequests);
+  const assignments = new Map<string, ReadonlyMap<string, number>>();
+
+  for (const session of sessions) {
+    const perBranch = new Map<string, number>();
+    for (const headBranch of session.headBranches) {
+      const match = firstAliveAt({
+        candidates: byBranch.get(headBranch),
+        startedAtMs: session.startedAtMs,
+      });
+      if (match) perBranch.set(headBranch, match.prNumber);
+    }
+    if (perBranch.size > 0) assignments.set(session.sessionId, perBranch);
   }
 
   return assignments;

--- a/platform/app/src/server/app-layer/coding-agent/pull-request-share.ts
+++ b/platform/app/src/server/app-layer/coding-agent/pull-request-share.ts
@@ -1,0 +1,253 @@
+/**
+ * The proportional rule: how much of one session's cost belongs to one pull
+ * request.
+ *
+ * A session's cumulative counters stay the source of truth for WHAT was spent;
+ * its stamped fact rows decide WHERE. Each `model_call` row carries the
+ * repository and branch that were active when the call happened, so per pull
+ * request the split is:
+ *
+ *   share      = (event tokens whose stamp lands on this pull request)
+ *              / (all of the session's event tokens)
+ *   PR portion = share x the session's cumulative counters
+ *
+ * Three buckets partition a session's event tokens, so its shares across pull
+ * requests can never sum past one and a repository's pull requests never sum
+ * to more than was spent:
+ *
+ *   - Stamped on this repository: goes to the branch's own tenure winner
+ *     (`assignDrivingSessionsToPullRequestsPerBranch`).
+ *   - Stamped on another repository: counted in the denominator only; that
+ *     repository's own read prices it.
+ *   - Unstamped (history from before the stamp, sessions that never declared):
+ *     follows the legacy whole-session rule, and ONLY in the repository the
+ *     session's own row points at — the same place the legacy read charged it.
+ *
+ * A session with no event rows at all keeps the legacy rule whole: its full
+ * total lands on its single winner, so nothing regresses to zero.
+ *
+ * Pure and synchronous, like `pull-request-assignment.ts`: it decides from the
+ * rows it is handed, so the same rule answers the same way in the rollup and
+ * in a test.
+ *
+ * Spec: specs/coding-agent/pull-request-linkage.feature.
+ */
+import {
+  type AssignablePullRequest,
+  assignDrivingSessionsToPullRequests,
+  assignDrivingSessionsToPullRequestsPerBranch,
+  branchesOf,
+} from "./pull-request-assignment";
+import type { CodingAgentBranchSessionRow } from "./repositories/coding-agent-session.repository";
+import type { SessionModelTotalsRow } from "./repositories/coding-agent-session-events.repository";
+
+export interface PullRequestAttribution {
+  /**
+   * The candidate sessions scaled to their share of THIS pull request, ready
+   * to be grouped and summed exactly like whole sessions were. A session with
+   * no share is absent.
+   */
+  sessions: CodingAgentBranchSessionRow[];
+  /**
+   * The per-model event totals that belong to THIS pull request: rows stamped
+   * onto its branch, plus each attached session's unstamped rows where this
+   * pull request is the legacy winner. Per-call facts, deliberately unscaled —
+   * they are measurements, not shares.
+   */
+  modelTotals: SessionModelTotalsRow[];
+}
+
+/**
+ * Attribute the candidate sessions' usage to one pull request.
+ *
+ * `rowMatchedSessionKeys` names the candidates whose own session row matches
+ * this repository (`tenantId\0sessionId`); only those may receive the
+ * unstamped bucket here. A session discovered through its stamps alone
+ * belongs to another repository's row now, and that repository's read is
+ * where its unstamped tokens are priced — charging them here too would count
+ * them twice across the organization.
+ */
+export function attributeSessionsToPullRequest({
+  sessions,
+  rowMatchedSessionKeys,
+  pullRequests,
+  prNumber,
+  repositoryHost,
+  repositoryFullName,
+  modelTotals,
+}: {
+  sessions: readonly CodingAgentBranchSessionRow[];
+  rowMatchedSessionKeys: ReadonlySet<string>;
+  pullRequests: readonly AssignablePullRequest[];
+  prNumber: number;
+  repositoryHost: string;
+  repositoryFullName: string;
+  modelTotals: readonly SessionModelTotalsRow[];
+}): PullRequestAttribution {
+  const totalsBySession = groupBySession(modelTotals);
+  const scaled: CodingAgentBranchSessionRow[] = [];
+  const attributedTotals: SessionModelTotalsRow[] = [];
+
+  for (const session of sessions) {
+    const key = sessionKey(session);
+    const rows = totalsBySession.get(key) ?? [];
+    const rowMatched = rowMatchedSessionKeys.has(key);
+    const { share, prRows } = shareOfPullRequest({
+      session,
+      rows,
+      rowMatched,
+      pullRequests,
+      prNumber,
+      repositoryHost,
+      repositoryFullName,
+    });
+    if (share <= 0) continue;
+    scaled.push(scaleSession(session, share));
+    attributedTotals.push(...prRows);
+  }
+
+  return { sessions: scaled, modelTotals: attributedTotals };
+}
+
+/** One session's share of the pull request, and the event rows behind it. */
+function shareOfPullRequest({
+  session,
+  rows,
+  rowMatched,
+  pullRequests,
+  prNumber,
+  repositoryHost,
+  repositoryFullName,
+}: {
+  session: CodingAgentBranchSessionRow;
+  rows: readonly SessionModelTotalsRow[];
+  rowMatched: boolean;
+  pullRequests: readonly AssignablePullRequest[];
+  prNumber: number;
+  repositoryHost: string;
+  repositoryFullName: string;
+}): { share: number; prRows: SessionModelTotalsRow[] } {
+  const totalWeight = rows.reduce((sum, row) => sum + weightOf(row), 0);
+
+  // The stamps may name branches the session row's bounded branch set no
+  // longer holds, so the tenure rule is asked about the union of both.
+  const stampedBranches = rows
+    .filter((row) => isStampedOnRepository(row, repositoryHost, repositoryFullName))
+    .map((row) => row.branch);
+  const headBranches = [
+    ...new Set([...branchesOf(session), ...stampedBranches]),
+  ];
+  const assignable = [
+    {
+      sessionId: session.sessionId,
+      startedAtMs: session.startedAtMs,
+      headBranches,
+    },
+  ];
+  const perBranch =
+    assignDrivingSessionsToPullRequestsPerBranch({
+      sessions: assignable,
+      pullRequests,
+    }).get(session.sessionId) ?? new Map<string, number>();
+  const legacyWinner = assignDrivingSessionsToPullRequests({
+    sessions: assignable,
+    pullRequests,
+  }).get(session.sessionId);
+
+  // No event rows: nothing to divide by, so the legacy whole-session rule
+  // stands — and only where the session's own row lives, like always.
+  if (totalWeight === 0) {
+    return {
+      share: rowMatched && legacyWinner === prNumber ? 1 : 0,
+      prRows: [],
+    };
+  }
+
+  const prRows = rows.filter((row) => {
+    if (isUnstamped(row)) {
+      return rowMatched && legacyWinner === prNumber;
+    }
+    return (
+      isStampedOnRepository(row, repositoryHost, repositoryFullName) &&
+      perBranch.get(row.branch) === prNumber
+    );
+  });
+  const prWeight = prRows.reduce((sum, row) => sum + weightOf(row), 0);
+
+  return { share: prWeight / totalWeight, prRows };
+}
+
+/** The session's counters and cost scaled to its share of the pull request. */
+function scaleSession(
+  session: CodingAgentBranchSessionRow,
+  share: number,
+): CodingAgentBranchSessionRow {
+  if (share >= 1) return session;
+  return {
+    ...session,
+    inputTokens: Math.round(session.inputTokens * share),
+    outputTokens: Math.round(session.outputTokens * share),
+    cacheReadTokens: Math.round(session.cacheReadTokens * share),
+    cacheCreationTokens: Math.round(session.cacheCreationTokens * share),
+    costUsd: session.costUsd * share,
+  };
+}
+
+/**
+ * A row written before its session declared a working context. Stamps are
+ * written all-or-nothing (`isStampableContext`), so any missing field means
+ * the whole stamp is absent; checking each guards a partially stamped row
+ * from ever matching a pull request by accident.
+ */
+function isUnstamped(row: SessionModelTotalsRow): boolean {
+  return (
+    row.repositoryOwner === "" || row.repositoryName === "" || row.branch === ""
+  );
+}
+
+/**
+ * Case-folded like every repository comparison on this path: a stamp carries
+ * the remote's casing verbatim, the mapping stores lower case. Branch names
+ * stay case sensitive and are compared by the caller.
+ */
+function isStampedOnRepository(
+  row: SessionModelTotalsRow,
+  repositoryHost: string,
+  repositoryFullName: string,
+): boolean {
+  if (isUnstamped(row)) return false;
+  return (
+    row.repositoryHost.toLowerCase() === repositoryHost.toLowerCase() &&
+    `${row.repositoryOwner}/${row.repositoryName}`.toLowerCase() ===
+      repositoryFullName.toLowerCase()
+  );
+}
+
+function weightOf(row: SessionModelTotalsRow): number {
+  return (
+    row.inputTokens +
+    row.outputTokens +
+    row.cacheReadTokens +
+    row.cacheCreationTokens
+  );
+}
+
+export function sessionKey(session: {
+  tenantId: string;
+  sessionId: string;
+}): string {
+  return `${session.tenantId}\0${session.sessionId}`;
+}
+
+function groupBySession(
+  rows: readonly SessionModelTotalsRow[],
+): Map<string, SessionModelTotalsRow[]> {
+  const grouped = new Map<string, SessionModelTotalsRow[]>();
+  for (const row of rows) {
+    const key = sessionKey(row);
+    const list = grouped.get(key) ?? [];
+    list.push(row);
+    grouped.set(key, list);
+  }
+  return grouped;
+}

--- a/platform/app/src/server/app-layer/coding-agent/pull-request-share.ts
+++ b/platform/app/src/server/app-layer/coding-agent/pull-request-share.ts
@@ -223,9 +223,9 @@ function shareOfPullRequest({
 }
 
 /** The bucket a row falls in, named without reference to any pull request. */
-const UNSTAMPED_BUCKET = " unstamped";
-const ELSEWHERE_BUCKET = " elsewhere";
-const BRANCH_BUCKET_PREFIX = "branch ";
+const UNSTAMPED_BUCKET = "\0unstamped";
+const ELSEWHERE_BUCKET = "\0elsewhere";
+const BRANCH_BUCKET_PREFIX = "branch\0";
 
 function bucketKeyOf({
   row,

--- a/platform/app/src/server/app-layer/coding-agent/pull-request-share.ts
+++ b/platform/app/src/server/app-layer/coding-agent/pull-request-share.ts
@@ -132,7 +132,9 @@ function shareOfPullRequest({
   // The stamps may name branches the session row's bounded branch set no
   // longer holds, so the tenure rule is asked about the union of both.
   const stampedBranches = rows
-    .filter((row) => isStampedOnRepository(row, repositoryHost, repositoryFullName))
+    .filter((row) =>
+      isStampedOnRepository(row, repositoryHost, repositoryFullName),
+    )
     .map((row) => row.branch);
   const headBranches = [
     ...new Set([...branchesOf(session), ...stampedBranches]),

--- a/platform/app/src/server/app-layer/coding-agent/pull-request-share.ts
+++ b/platform/app/src/server/app-layer/coding-agent/pull-request-share.ts
@@ -26,6 +26,13 @@
  * A session with no event rows at all keeps the legacy rule whole: its full
  * total lands on its single winner, so nothing regresses to zero.
  *
+ * The token counters are whole numbers, so the split hands out whole units by
+ * the largest-remainder method across all of a session's buckets at once,
+ * rather than rounding each pull request's share on its own. Rounding
+ * separately would let a one-token session split two ways report a token to
+ * each, and on a page about cost, understating is survivable where
+ * overstating is not. Cost is a currency amount and stays exact.
+ *
  * Pure and synchronous, like `pull-request-assignment.ts`: it decides from the
  * rows it is handed, so the same rule answers the same way in the rollup and
  * in a test.
@@ -92,7 +99,7 @@ export function attributeSessionsToPullRequest({
     const key = sessionKey(session);
     const rows = totalsBySession.get(key) ?? [];
     const rowMatched = rowMatchedSessionKeys.has(key);
-    const { share, prRows } = shareOfPullRequest({
+    const share = shareOfPullRequest({
       session,
       rows,
       rowMatched,
@@ -101,15 +108,18 @@ export function attributeSessionsToPullRequest({
       repositoryHost,
       repositoryFullName,
     });
-    if (share <= 0) continue;
-    scaled.push(scaleSession({ session, share }));
-    attributedTotals.push(...prRows);
+    if (share === null) continue;
+    scaled.push(share.session);
+    attributedTotals.push(...share.prRows);
   }
 
   return { sessions: scaled, modelTotals: attributedTotals };
 }
 
-/** One session's share of the pull request, and the event rows behind it. */
+/**
+ * One session's share of the pull request: the session scaled to it, and the
+ * event rows behind it. Null when this pull request gets none of the session.
+ */
 function shareOfPullRequest({
   session,
   rows,
@@ -126,7 +136,10 @@ function shareOfPullRequest({
   prNumber: number;
   repositoryHost: string;
   repositoryFullName: string;
-}): { share: number; prRows: SessionModelTotalsRow[] } {
+}): {
+  session: CodingAgentBranchSessionRow;
+  prRows: SessionModelTotalsRow[];
+} | null {
   const { weightOf, totalWeight } = weighing(rows);
 
   // The stamps may name branches the session row's bounded branch set no
@@ -160,43 +173,141 @@ function shareOfPullRequest({
   // divide by, so the legacy whole-session rule stands — and only where the
   // session's own row lives, like always.
   if (totalWeight === 0) {
-    return {
-      share: rowMatched && legacyWinner === prNumber ? 1 : 0,
-      prRows: [],
-    };
+    if (!rowMatched || legacyWinner !== prNumber) return null;
+    return { session, prRows: [] };
   }
 
-  const prRows = rows.filter((row) => {
-    if (isUnstamped(row)) {
+  // Bucket the rows by a key that depends on the SESSION alone, never on
+  // which pull request is being asked about. That is what makes the integer
+  // allocation below the same answer in every read: each pull request takes a
+  // disjoint set of whole buckets, so their counters cannot sum past the
+  // session's own however many reads ask.
+  const buckets = new Map<string, number>();
+  const bucketOf = new Map<SessionModelTotalsRow, string>();
+  for (const row of rows) {
+    const key = bucketKeyOf({ row, repositoryHost, repositoryFullName });
+    bucketOf.set(row, key);
+    buckets.set(key, (buckets.get(key) ?? 0) + weightOf(row));
+  }
+
+  const ownsBucket = (key: string): boolean => {
+    if (key === ELSEWHERE_BUCKET) return false;
+    if (key === UNSTAMPED_BUCKET) {
       return rowMatched && legacyWinner === prNumber;
     }
-    return (
-      isStampedOnRepository({ row, repositoryHost, repositoryFullName }) &&
-      perBranch.get(row.branch) === prNumber
-    );
-  });
-  const prWeight = sum(prRows, weightOf);
+    return perBranch.get(branchOfBucketKey(key)) === prNumber;
+  };
 
-  return { share: prWeight / totalWeight, prRows };
+  const ownKeys = [...buckets.keys()].filter(ownsBucket);
+  const prWeight = ownKeys.reduce((total, key) => total + buckets.get(key)!, 0);
+  if (prWeight <= 0) return null;
+
+  const prRows = rows.filter((row) => ownsBucket(bucketOf.get(row)!));
+  const allocated = allocateCounters({
+    session,
+    buckets,
+    totalWeight,
+    ownKeys,
+  });
+
+  return {
+    session: {
+      ...session,
+      ...allocated,
+      // Cost is never rounded: it is a currency amount, so the share stays
+      // exact and only the integer counters need whole units handed out.
+      costUsd: (session.costUsd * prWeight) / totalWeight,
+    },
+    prRows,
+  };
 }
 
-/** The session's counters and cost scaled to its share of the pull request. */
-function scaleSession({
+/** The bucket a row falls in, named without reference to any pull request. */
+const UNSTAMPED_BUCKET = " unstamped";
+const ELSEWHERE_BUCKET = " elsewhere";
+const BRANCH_BUCKET_PREFIX = "branch ";
+
+function bucketKeyOf({
+  row,
+  repositoryHost,
+  repositoryFullName,
+}: {
+  row: SessionModelTotalsRow;
+  repositoryHost: string;
+  repositoryFullName: string;
+}): string {
+  if (isUnstamped(row)) return UNSTAMPED_BUCKET;
+  if (!isStampedOnRepository({ row, repositoryHost, repositoryFullName })) {
+    return ELSEWHERE_BUCKET;
+  }
+  return `${BRANCH_BUCKET_PREFIX}${row.branch}`;
+}
+
+function branchOfBucketKey(key: string): string {
+  return key.slice(BRANCH_BUCKET_PREFIX.length);
+}
+
+const COUNTER_FIELDS = [
+  "inputTokens",
+  "outputTokens",
+  "cacheReadTokens",
+  "cacheCreationTokens",
+] as const;
+
+/**
+ * This pull request's whole-token share of each of the session's counters.
+ *
+ * Each counter is handed out across ALL of the session's buckets by the
+ * largest-remainder method, and this pull request keeps the buckets it owns.
+ * Rounding each share on its own instead would let a one-token session split
+ * two ways report a token to each, and a page about cost may understate but
+ * must never overstate.
+ */
+function allocateCounters({
   session,
-  share,
+  buckets,
+  totalWeight,
+  ownKeys,
 }: {
   session: CodingAgentBranchSessionRow;
-  share: number;
-}): CodingAgentBranchSessionRow {
-  if (share >= 1) return session;
-  return {
-    ...session,
-    inputTokens: Math.round(session.inputTokens * share),
-    outputTokens: Math.round(session.outputTokens * share),
-    cacheReadTokens: Math.round(session.cacheReadTokens * share),
-    cacheCreationTokens: Math.round(session.cacheCreationTokens * share),
-    costUsd: session.costUsd * share,
-  };
+  buckets: ReadonlyMap<string, number>;
+  totalWeight: number;
+  ownKeys: readonly string[];
+}): Pick<CodingAgentBranchSessionRow, (typeof COUNTER_FIELDS)[number]> {
+  // Sorted so the allocation never depends on the order rows arrived in.
+  const keys = [...buckets.keys()].sort();
+  const owned = new Set(ownKeys);
+  const allocated = {} as Record<(typeof COUNTER_FIELDS)[number], number>;
+
+  for (const field of COUNTER_FIELDS) {
+    const amount = Math.max(0, Math.floor(session[field]));
+    const floors = new Map<string, number>();
+    const remainders: Array<{ key: string; remainder: number }> = [];
+    let handedOut = 0;
+
+    for (const key of keys) {
+      const exact = (amount * buckets.get(key)!) / totalWeight;
+      const whole = Math.floor(exact);
+      floors.set(key, whole);
+      handedOut += whole;
+      remainders.push({ key, remainder: exact - whole });
+    }
+
+    // What rounding down left over goes to the largest remainders first, ties
+    // broken by key so two reads of the same session agree.
+    remainders.sort(
+      (a, b) => b.remainder - a.remainder || (a.key < b.key ? -1 : 1),
+    );
+    for (const { key } of remainders.slice(0, amount - handedOut)) {
+      floors.set(key, floors.get(key)! + 1);
+    }
+
+    allocated[field] = keys
+      .filter((key) => owned.has(key))
+      .reduce((total, key) => total + floors.get(key)!, 0);
+  }
+
+  return allocated;
 }
 
 /**

--- a/platform/app/src/server/app-layer/coding-agent/pull-request-share.ts
+++ b/platform/app/src/server/app-layer/coding-agent/pull-request-share.ts
@@ -102,7 +102,7 @@ export function attributeSessionsToPullRequest({
       repositoryFullName,
     });
     if (share <= 0) continue;
-    scaled.push(scaleSession(session, share));
+    scaled.push(scaleSession({ session, share }));
     attributedTotals.push(...prRows);
   }
 
@@ -127,13 +127,13 @@ function shareOfPullRequest({
   repositoryHost: string;
   repositoryFullName: string;
 }): { share: number; prRows: SessionModelTotalsRow[] } {
-  const totalWeight = rows.reduce((sum, row) => sum + weightOf(row), 0);
+  const { weightOf, totalWeight } = weighing(rows);
 
   // The stamps may name branches the session row's bounded branch set no
   // longer holds, so the tenure rule is asked about the union of both.
   const stampedBranches = rows
     .filter((row) =>
-      isStampedOnRepository(row, repositoryHost, repositoryFullName),
+      isStampedOnRepository({ row, repositoryHost, repositoryFullName }),
     )
     .map((row) => row.branch);
   const headBranches = [
@@ -156,8 +156,9 @@ function shareOfPullRequest({
     pullRequests,
   }).get(session.sessionId);
 
-  // No event rows: nothing to divide by, so the legacy whole-session rule
-  // stands — and only where the session's own row lives, like always.
+  // No event rows, or rows that report neither tokens nor cost: nothing to
+  // divide by, so the legacy whole-session rule stands — and only where the
+  // session's own row lives, like always.
   if (totalWeight === 0) {
     return {
       share: rowMatched && legacyWinner === prNumber ? 1 : 0,
@@ -170,20 +171,23 @@ function shareOfPullRequest({
       return rowMatched && legacyWinner === prNumber;
     }
     return (
-      isStampedOnRepository(row, repositoryHost, repositoryFullName) &&
+      isStampedOnRepository({ row, repositoryHost, repositoryFullName }) &&
       perBranch.get(row.branch) === prNumber
     );
   });
-  const prWeight = prRows.reduce((sum, row) => sum + weightOf(row), 0);
+  const prWeight = sum(prRows, weightOf);
 
   return { share: prWeight / totalWeight, prRows };
 }
 
 /** The session's counters and cost scaled to its share of the pull request. */
-function scaleSession(
-  session: CodingAgentBranchSessionRow,
-  share: number,
-): CodingAgentBranchSessionRow {
+function scaleSession({
+  session,
+  share,
+}: {
+  session: CodingAgentBranchSessionRow;
+  share: number;
+}): CodingAgentBranchSessionRow {
   if (share >= 1) return session;
   return {
     ...session,
@@ -212,11 +216,15 @@ function isUnstamped(row: SessionModelTotalsRow): boolean {
  * the remote's casing verbatim, the mapping stores lower case. Branch names
  * stay case sensitive and are compared by the caller.
  */
-function isStampedOnRepository(
-  row: SessionModelTotalsRow,
-  repositoryHost: string,
-  repositoryFullName: string,
-): boolean {
+function isStampedOnRepository({
+  row,
+  repositoryHost,
+  repositoryFullName,
+}: {
+  row: SessionModelTotalsRow;
+  repositoryHost: string;
+  repositoryFullName: string;
+}): boolean {
   if (isUnstamped(row)) return false;
   return (
     row.repositoryHost.toLowerCase() === repositoryHost.toLowerCase() &&
@@ -225,13 +233,44 @@ function isStampedOnRepository(
   );
 }
 
-function weightOf(row: SessionModelTotalsRow): number {
+/**
+ * The unit one session's rows are weighed in, and their total in that unit.
+ *
+ * Tokens whenever the session reports any: every agent reports them, and they
+ * are what the counters being split are made of. A session that priced its
+ * calls without reporting token counts is weighed by cost instead, so its
+ * stamps still decide where the money lands rather than the whole session
+ * falling back to the legacy rule. The unit is picked per session, so one
+ * ratio never mixes dollars with tokens.
+ */
+function weighing(rows: readonly SessionModelTotalsRow[]): {
+  weightOf: (row: SessionModelTotalsRow) => number;
+  totalWeight: number;
+} {
+  const tokenWeight = sum(rows, tokensOf);
+  if (tokenWeight > 0) return { weightOf: tokensOf, totalWeight: tokenWeight };
+  return { weightOf: costOf, totalWeight: sum(rows, costOf) };
+}
+
+function tokensOf(row: SessionModelTotalsRow): number {
   return (
     row.inputTokens +
     row.outputTokens +
     row.cacheReadTokens +
     row.cacheCreationTokens
   );
+}
+
+/** Never negative: a stray negative cost would eat another row's share. */
+function costOf(row: SessionModelTotalsRow): number {
+  return row.costUsd > 0 ? row.costUsd : 0;
+}
+
+function sum(
+  rows: readonly SessionModelTotalsRow[],
+  of: (row: SessionModelTotalsRow) => number,
+): number {
+  return rows.reduce((total, row) => total + of(row), 0);
 }
 
 export function sessionKey(session: {

--- a/platform/app/src/server/app-layer/coding-agent/pull-request-usage.service.ts
+++ b/platform/app/src/server/app-layer/coding-agent/pull-request-usage.service.ts
@@ -637,7 +637,14 @@ export class PullRequestUsageService {
       return {
         ...toIdentity(pullRequest),
         title: pullRequest.title,
-        lastActivityAtMs: latestActivityAtMs(attached),
+        // Discovery runs on this project's own sessions, the share runs on
+        // the stamps, so a discovered pull request can end up with no session
+        // attached: every stamp of the session that found it landed on a
+        // neighbour. The row stays, reporting no tokens and no cost, and
+        // dates itself by the pull request rather than by the epoch.
+        lastActivityAtMs:
+          latestActivityAtMs(attached) ||
+          (pullRequest.prUpdatedAt ?? pullRequest.prCreatedAt).getTime(),
         sessionsCount: totals.sessionsCount,
         inputTokens: totals.inputTokens,
         outputTokens: totals.outputTokens,
@@ -772,24 +779,28 @@ export class PullRequestUsageService {
     sessions: CodingAgentBranchSessionRow[];
     rowMatchedSessionKeys: ReadonlySet<string>;
   }> {
-    const rowMatched = await this.deps.sessions.listByRepositoryBranch({
-      tenantIds,
-      repositoryHost,
-      repositoryOwner,
-      repositoryName,
-      branches,
-      startedAtFromMs: fromMs,
-    });
+    // Independent reads, so they go together: the stamped one needs the
+    // row-matched keys only to subtract them, which happens after both land.
+    const [rowMatched, stamped] = await Promise.all([
+      this.deps.sessions.listByRepositoryBranch({
+        tenantIds,
+        repositoryHost,
+        repositoryOwner,
+        repositoryName,
+        branches,
+        startedAtFromMs: fromMs,
+      }),
+      this.deps.sessionEvents.listSessionsByStampedBranch({
+        tenantIds,
+        repositoryHost,
+        repositoryOwner,
+        repositoryName,
+        branches,
+        fromMs,
+      }),
+    ]);
     const rowMatchedSessionKeys = new Set(rowMatched.map(sessionKey));
 
-    const stamped = await this.deps.sessionEvents.listSessionsByStampedBranch({
-      tenantIds,
-      repositoryHost,
-      repositoryOwner,
-      repositoryName,
-      branches,
-      fromMs,
-    });
     const missing = stamped.filter(
       (pair) => !rowMatchedSessionKeys.has(sessionKey(pair)),
     );

--- a/platform/app/src/server/app-layer/coding-agent/pull-request-usage.service.ts
+++ b/platform/app/src/server/app-layer/coding-agent/pull-request-usage.service.ts
@@ -45,9 +45,13 @@ import type {
 } from "../github/repositories/github-pull-requests.repository";
 import { ingestSourceTypeOfAgent } from "./coding-agent-source-type";
 import {
-  assignDrivingSessionsToPullRequests,
+  assignDrivingSessionsToPullRequestsPerBranch,
   branchesOf,
 } from "./pull-request-assignment";
+import {
+  attributeSessionsToPullRequest,
+  sessionKey,
+} from "./pull-request-share";
 import type {
   CodingAgentBranchSessionRow,
   CodingAgentSessionRepository,
@@ -338,18 +342,34 @@ export interface PersonalSessionLookup {
   >;
 }
 
-/** What each model consumed, per session, across the permitted projects. */
+/**
+ * The per-call fact reads: what each model consumed per session and stamped
+ * working context, and which sessions ever stamped work onto a repository's
+ * branches (the discovery leg for sessions whose own row moved on).
+ */
 export interface SessionModelTotalsLookup {
   sumTokensByModelPerSession(params: {
     tenantIds: string[];
     sessionIds: string[];
     fromMs: number;
   }): Promise<SessionModelTotalsRow[]>;
+
+  listSessionsByStampedBranch(params: {
+    tenantIds: string[];
+    repositoryHost: string;
+    repositoryOwner: string;
+    repositoryName: string;
+    branches: string[];
+    fromMs: number;
+  }): Promise<Array<{ tenantId: string; sessionId: string }>>;
 }
 
 export interface PullRequestUsageServiceDeps {
   pullRequests: GithubPullRequestsRepository;
-  sessions: Pick<CodingAgentSessionRepository, "listByRepositoryBranch">;
+  sessions: Pick<
+    CodingAgentSessionRepository,
+    "listByRepositoryBranch" | "listBySessionIds"
+  >;
   personalSessions: PersonalSessionLookup;
   sessionEvents: SessionModelTotalsLookup;
   installations: RepositoryCoverageLookup;
@@ -491,7 +511,7 @@ export class PullRequestUsageService {
           ...new Set(group.sessions.flatMap((s) => s.headBranches)),
         ],
       });
-      const assignments = assignDrivingSessionsToPullRequests({
+      const assignments = assignDrivingSessionsToPullRequestsPerBranch({
         sessions: group.sessions,
         pullRequests: toAssignable(pullRequests),
       });
@@ -499,12 +519,15 @@ export class PullRequestUsageService {
       // Discovery is personal: only the pull requests this project's own work
       // touched become rows. Their NUMBERS then come from every project the
       // caller may read, which is what makes a row the pull request's price
-      // rather than one person's share of it.
+      // rather than one person's share of it. Per branch, so a session that
+      // drove two pull requests surfaces both — each row then prices only its
+      // own share of the session.
       const discovered = pullRequests.filter((pullRequest) =>
-        group.sessions.some(
-          (session) =>
-            assignments.get(session.sessionId) === pullRequest.prNumber,
-        ),
+        group.sessions.some((session) => {
+          const branchWinners = assignments.get(session.sessionId);
+          if (branchWinners === undefined) return false;
+          return [...branchWinners.values()].includes(pullRequest.prNumber);
+        }),
       );
       if (discovered.length > 0) {
         rows.push(
@@ -571,41 +594,39 @@ export class PullRequestUsageService {
     const [owner, name] = group.repositoryFullName.split("/");
     if (!owner || !name) return [];
 
-    const sessions = await this.deps.sessions.listByRepositoryBranch({
+    const candidates = await this.candidateSessionsFor({
       tenantIds: permittedProjectIds,
       repositoryHost: group.repositoryHost,
       repositoryOwner: owner,
       repositoryName: name,
       branches: [...new Set(discovered.map((row) => row.headBranch))],
-      startedAtFromMs: toMs - USAGE_SESSION_WINDOW_MS,
-    });
-    const assignments = assignDrivingSessionsToPullRequests({
-      sessions: sessions.map((session) => ({
-        sessionId: session.sessionId,
-        startedAtMs: session.startedAtMs,
-        headBranches: branchesOf(session),
-      })),
-      pullRequests: toAssignable(pullRequests),
+      fromMs: toMs - USAGE_SESSION_WINDOW_MS,
     });
 
     const nonBillableAgents = await resolveNonBillableAgents({
       deps: this.deps,
       organizationId,
-      agents: sessions.map((session) => session.agent),
+      agents: candidates.sessions.map((session) => session.agent),
     });
     const modelTotals =
       await this.deps.sessionEvents.sumTokensByModelPerSession({
         tenantIds: permittedProjectIds,
-        sessionIds: sessions.map((session) => session.sessionId),
+        sessionIds: candidates.sessions.map((session) => session.sessionId),
         fromMs: toMs - USAGE_SESSION_WINDOW_MS,
       });
     const costProjects = new Set(costProjectIds);
 
     return discovered.map((pullRequest) => {
-      const attached = sessions.filter(
-        (session) =>
-          assignments.get(session.sessionId) === pullRequest.prNumber,
-      );
+      const attribution = attributeSessionsToPullRequest({
+        sessions: candidates.sessions,
+        rowMatchedSessionKeys: candidates.rowMatchedSessionKeys,
+        pullRequests: toAssignable(pullRequests),
+        prNumber: pullRequest.prNumber,
+        repositoryHost: group.repositoryHost,
+        repositoryFullName: group.repositoryFullName,
+        modelTotals,
+      });
+      const attached = attribution.sessions;
       const rows = groupRows({
         sessions: attached,
         costProjects,
@@ -628,7 +649,7 @@ export class PullRequestUsageService {
         nonBilledCostUsd: totals.nonBilledCostUsd,
         modelBreakdown: modelsFor({
           sessions: attached,
-          modelTotals,
+          modelTotals: attribution.modelTotals,
           costProjects,
         }),
         contributorsSummary: contributorsSummaryFor({
@@ -675,32 +696,37 @@ export class PullRequestUsageService {
     if (!owner || !name) return empty;
 
     const toMs = nowMs(this.deps);
-    const sessions = await this.deps.sessions.listByRepositoryBranch({
+    const candidates = await this.candidateSessionsFor({
       tenantIds: query.permittedProjectIds,
       repositoryHost: target.repositoryHost,
       repositoryOwner: owner,
       repositoryName: name,
       branches: [target.headBranch],
-      startedAtFromMs: toMs - USAGE_SESSION_WINDOW_MS,
+      fromMs: toMs - USAGE_SESSION_WINDOW_MS,
     });
+    const modelTotals =
+      await this.deps.sessionEvents.sumTokensByModelPerSession({
+        tenantIds: query.permittedProjectIds,
+        sessionIds: candidates.sessions.map((session) => session.sessionId),
+        fromMs: toMs - USAGE_SESSION_WINDOW_MS,
+      });
 
-    const attached = attachedToPullRequest({
-      sessions,
-      pullRequests: siblings,
+    const attribution = attributeSessionsToPullRequest({
+      sessions: candidates.sessions,
+      rowMatchedSessionKeys: candidates.rowMatchedSessionKeys,
+      pullRequests: toAssignable(siblings),
       prNumber: target.prNumber,
+      repositoryHost: target.repositoryHost,
+      repositoryFullName: target.repositoryFullName,
+      modelTotals,
     });
+    const attached = attribution.sessions;
     const costProjects = new Set(query.costProjectIds);
     const nonBillableAgents = await resolveNonBillableAgents({
       deps: this.deps,
       organizationId: query.organizationId,
       agents: attached.map((session) => session.agent),
     });
-    const modelTotals =
-      await this.deps.sessionEvents.sumTokensByModelPerSession({
-        tenantIds: query.permittedProjectIds,
-        sessionIds: attached.map((session) => session.sessionId),
-        fromMs: toMs - USAGE_SESSION_WINDOW_MS,
-      });
 
     return {
       target,
@@ -713,9 +739,79 @@ export class PullRequestUsageService {
       }),
       modelBreakdown: modelsFor({
         sessions: attached,
-        modelTotals,
+        modelTotals: attribution.modelTotals,
         costProjects,
       }),
+    };
+  }
+
+  /**
+   * Every session that may have worked on one repository's branches, found two
+   * ways and merged: sessions whose own row matches (the legacy read), plus
+   * sessions whose STAMPED fact rows name the repository even though their row
+   * has since moved to another one — a resumed agent cycling between
+   * repositories is one session, and only its stamps remember everywhere it
+   * has been. The returned key set marks the row-matched ones, which are the
+   * only candidates the unstamped bucket may be priced under here.
+   */
+  private async candidateSessionsFor({
+    tenantIds,
+    repositoryHost,
+    repositoryOwner,
+    repositoryName,
+    branches,
+    fromMs,
+  }: {
+    tenantIds: string[];
+    repositoryHost: string;
+    repositoryOwner: string;
+    repositoryName: string;
+    branches: string[];
+    fromMs: number;
+  }): Promise<{
+    sessions: CodingAgentBranchSessionRow[];
+    rowMatchedSessionKeys: ReadonlySet<string>;
+  }> {
+    const rowMatched = await this.deps.sessions.listByRepositoryBranch({
+      tenantIds,
+      repositoryHost,
+      repositoryOwner,
+      repositoryName,
+      branches,
+      startedAtFromMs: fromMs,
+    });
+    const rowMatchedSessionKeys = new Set(rowMatched.map(sessionKey));
+
+    const stamped = await this.deps.sessionEvents.listSessionsByStampedBranch({
+      tenantIds,
+      repositoryHost,
+      repositoryOwner,
+      repositoryName,
+      branches,
+      fromMs,
+    });
+    const missing = stamped.filter(
+      (pair) => !rowMatchedSessionKeys.has(sessionKey(pair)),
+    );
+    if (missing.length === 0) {
+      return { sessions: rowMatched, rowMatchedSessionKeys };
+    }
+
+    const fetched = await this.deps.sessions.listBySessionIds({
+      tenantIds,
+      sessionIds: [...new Set(missing.map((pair) => pair.sessionId))],
+      startedAtFromMs: fromMs,
+    });
+    // The id read cannot scope per tenant, so a provider session id shared by
+    // two projects fetches both; keep only the (tenant, session) pairs the
+    // stamps actually named.
+    const missingKeys = new Set(missing.map(sessionKey));
+    const stampedOnly = fetched.filter((session) =>
+      missingKeys.has(sessionKey(session)),
+    );
+    return {
+      sessions: [...rowMatched, ...stampedOnly],
+      rowMatchedSessionKeys,
     };
   }
 }
@@ -748,29 +844,6 @@ async function resolveNonBillableAgents({
   );
   return new Set(
     answers.filter((answer) => answer.nonBillable).map((a) => a.agent),
-  );
-}
-
-/** Keep only the sessions the tenure rule attaches to THIS pull request. */
-function attachedToPullRequest({
-  sessions,
-  pullRequests,
-  prNumber,
-}: {
-  sessions: CodingAgentBranchSessionRow[];
-  pullRequests: GithubPullRequestRow[];
-  prNumber: number;
-}): CodingAgentBranchSessionRow[] {
-  const assignments = assignDrivingSessionsToPullRequests({
-    sessions: sessions.map((session) => ({
-      sessionId: session.sessionId,
-      startedAtMs: session.startedAtMs,
-      headBranches: branchesOf(session),
-    })),
-    pullRequests: toAssignable(pullRequests),
-  });
-  return sessions.filter(
-    (session) => assignments.get(session.sessionId) === prNumber,
   );
 }
 

--- a/platform/app/src/server/app-layer/coding-agent/repositories/__tests__/coding-agent-session-events.repository.integration.test.ts
+++ b/platform/app/src/server/app-layer/coding-agent/repositories/__tests__/coding-agent-session-events.repository.integration.test.ts
@@ -70,6 +70,10 @@ function eventRecord(
     toolResultBytes: 0,
     promptChars: 0,
     totalTokens: 0,
+    repositoryHost: "",
+    repositoryOwner: "",
+    repositoryName: "",
+    branch: "",
     ...over,
   };
 }
@@ -286,6 +290,94 @@ describe("CodingAgentSessionEventsClickHouseRepository", () => {
       expect(
         totals.every((row) => row.inputTokens < 999 && row.costUsd < 99),
       ).toBe(true);
+    });
+  });
+
+  describe("given events stamped with a working context", () => {
+    const stampedSession = `${tag}-stamped-session`;
+    const stamp = {
+      repositoryHost: "GitHub.com",
+      repositoryOwner: "Acme",
+      repositoryName: "Widgets",
+    };
+
+    beforeAll(async () => {
+      await repository.ensure([
+        eventRecord({
+          sessionId: stampedSession,
+          recordId: "1".repeat(64),
+          ...stamp,
+          branch: "feat/split",
+          inputTokens: 10,
+          outputTokens: 20,
+          cacheReadTokens: 0,
+          cacheCreationTokens: 0,
+          costUsd: 0.1,
+        }),
+        eventRecord({
+          sessionId: stampedSession,
+          recordId: "2".repeat(64),
+          timeUnixMs: baseMs + 1_000,
+          ...stamp,
+          branch: "feat/other",
+          inputTokens: 30,
+          outputTokens: 40,
+          cacheReadTokens: 0,
+          cacheCreationTokens: 0,
+          costUsd: 0.2,
+        }),
+        eventRecord({
+          sessionId: stampedSession,
+          recordId: "3".repeat(64),
+          timeUnixMs: baseMs + 2_000,
+          inputTokens: 50,
+          outputTokens: 60,
+          cacheReadTokens: 0,
+          cacheCreationTokens: 0,
+          costUsd: 0.3,
+        }),
+      ]);
+    });
+
+    it("round-trips the stamp and returns one total per context", async () => {
+      const totals = await repository.sumTokensByModelPerSession({
+        tenantIds: [tenantId],
+        sessionIds: [stampedSession],
+        fromMs: baseMs - 60_000,
+      });
+
+      const byBranch = new Map(totals.map((row) => [row.branch, row]));
+      expect(byBranch.get("feat/split")?.inputTokens).toBe(10);
+      expect(byBranch.get("feat/split")?.repositoryOwner).toBe("Acme");
+      expect(byBranch.get("feat/other")?.inputTokens).toBe(30);
+      expect(byBranch.get("")?.inputTokens).toBe(50);
+      expect(byBranch.get("")?.repositoryOwner).toBe("");
+    });
+
+    it("finds the session by its stamped branch, case-folding the repository", async () => {
+      const pairs = await repository.listSessionsByStampedBranch({
+        tenantIds: [tenantId],
+        repositoryHost: "github.com",
+        repositoryOwner: "acme",
+        repositoryName: "widgets",
+        branches: ["feat/split"],
+        fromMs: baseMs - 60_000,
+      });
+
+      expect(pairs).toEqual([{ tenantId, sessionId: stampedSession }]);
+    });
+
+    it("answers nothing for a branch nothing was stamped on", async () => {
+      const pairs = await repository.listSessionsByStampedBranch({
+        tenantIds: [tenantId],
+        repositoryHost: "github.com",
+        repositoryOwner: "acme",
+        repositoryName: "widgets",
+        branches: ["feat/never-stamped"],
+        fromMs: baseMs - 60_000,
+      });
+
+      expect(pairs).toEqual([]);
     });
   });
 });

--- a/platform/app/src/server/app-layer/coding-agent/repositories/__tests__/coding-agent-session-events.repository.integration.test.ts
+++ b/platform/app/src/server/app-layer/coding-agent/repositories/__tests__/coding-agent-session-events.repository.integration.test.ts
@@ -339,45 +339,51 @@ describe("CodingAgentSessionEventsClickHouseRepository", () => {
       ]);
     });
 
-    it("round-trips the stamp and returns one total per context", async () => {
-      const totals = await repository.sumTokensByModelPerSession({
-        tenantIds: [tenantId],
-        sessionIds: [stampedSession],
-        fromMs: baseMs - 60_000,
-      });
+    describe("when the per-model totals are read", () => {
+      it("round-trips the stamp and returns one total per context", async () => {
+        const totals = await repository.sumTokensByModelPerSession({
+          tenantIds: [tenantId],
+          sessionIds: [stampedSession],
+          fromMs: baseMs - 60_000,
+        });
 
-      const byBranch = new Map(totals.map((row) => [row.branch, row]));
-      expect(byBranch.get("feat/split")?.inputTokens).toBe(10);
-      expect(byBranch.get("feat/split")?.repositoryOwner).toBe("Acme");
-      expect(byBranch.get("feat/other")?.inputTokens).toBe(30);
-      expect(byBranch.get("")?.inputTokens).toBe(50);
-      expect(byBranch.get("")?.repositoryOwner).toBe("");
+        const byBranch = new Map(totals.map((row) => [row.branch, row]));
+        expect(byBranch.get("feat/split")?.inputTokens).toBe(10);
+        expect(byBranch.get("feat/split")?.repositoryOwner).toBe("Acme");
+        expect(byBranch.get("feat/other")?.inputTokens).toBe(30);
+        expect(byBranch.get("")?.inputTokens).toBe(50);
+        expect(byBranch.get("")?.repositoryOwner).toBe("");
+      });
     });
 
-    it("finds the session by its stamped branch, case-folding the repository", async () => {
-      const pairs = await repository.listSessionsByStampedBranch({
-        tenantIds: [tenantId],
-        repositoryHost: "github.com",
-        repositoryOwner: "acme",
-        repositoryName: "widgets",
-        branches: ["feat/split"],
-        fromMs: baseMs - 60_000,
-      });
+    describe("when a stamped branch is looked up", () => {
+      it("finds the session, case-folding the repository", async () => {
+        const pairs = await repository.listSessionsByStampedBranch({
+          tenantIds: [tenantId],
+          repositoryHost: "github.com",
+          repositoryOwner: "acme",
+          repositoryName: "widgets",
+          branches: ["feat/split"],
+          fromMs: baseMs - 60_000,
+        });
 
-      expect(pairs).toEqual([{ tenantId, sessionId: stampedSession }]);
+        expect(pairs).toEqual([{ tenantId, sessionId: stampedSession }]);
+      });
     });
 
-    it("answers nothing for a branch nothing was stamped on", async () => {
-      const pairs = await repository.listSessionsByStampedBranch({
-        tenantIds: [tenantId],
-        repositoryHost: "github.com",
-        repositoryOwner: "acme",
-        repositoryName: "widgets",
-        branches: ["feat/never-stamped"],
-        fromMs: baseMs - 60_000,
-      });
+    describe("when a branch nothing was stamped on is looked up", () => {
+      it("answers nothing", async () => {
+        const pairs = await repository.listSessionsByStampedBranch({
+          tenantIds: [tenantId],
+          repositoryHost: "github.com",
+          repositoryOwner: "acme",
+          repositoryName: "widgets",
+          branches: ["feat/never-stamped"],
+          fromMs: baseMs - 60_000,
+        });
 
-      expect(pairs).toEqual([]);
+        expect(pairs).toEqual([]);
+      });
     });
   });
 });

--- a/platform/app/src/server/app-layer/coding-agent/repositories/__tests__/coding-agent-session.clickhouse.repository.integration.test.ts
+++ b/platform/app/src/server/app-layer/coding-agent/repositories/__tests__/coding-agent-session.clickhouse.repository.integration.test.ts
@@ -615,6 +615,29 @@ describe("coding_agent_sessions by repository branch", () => {
       listed.map((row) => row.sessionId).includes(`${tag}-elsewhere`),
     ).toBe(false);
   });
+
+  it("fetches the same row shape by session id, whatever repository the row names", async () => {
+    const listed = await sessions.listBySessionIds({
+      tenantIds: [tenantId],
+      sessionIds: [`${tag}-moved`],
+      startedAtFromMs: baseMs - 60_000,
+    });
+
+    expect(listed).toHaveLength(1);
+    expect(listed[0]!.sessionId).toBe(`${tag}-moved`);
+    expect(listed[0]!.gitBranches).toEqual(["feat/first", "feat/second"]);
+    expect(listed[0]!.title).toBe("Ship both branches");
+  });
+
+  it("answers nothing for a session id never folded", async () => {
+    const listed = await sessions.listBySessionIds({
+      tenantIds: [tenantId],
+      sessionIds: [`${tag}-never-existed`],
+      startedAtFromMs: baseMs - 60_000,
+    });
+
+    expect(listed).toEqual([]);
+  });
 });
 
 describe("coding_agent_trace_sessions map (migration 00051)", () => {

--- a/platform/app/src/server/app-layer/coding-agent/repositories/coding-agent-session-events.repository.ts
+++ b/platform/app/src/server/app-layer/coding-agent/repositories/coding-agent-session-events.repository.ts
@@ -45,8 +45,10 @@ export interface CodingAgentSessionEventsRepository {
   }>;
 
   /**
-   * What each model consumed, per session, across several tenants: the read
-   * behind a pull request's per-model breakdown.
+   * What each model consumed, per session and per stamped working context,
+   * across several tenants: the read behind a pull request's per-model
+   * breakdown AND the ratio that splits a session's cumulative totals across
+   * the pull requests it drove.
    *
    * Restricted to `model_call` rows, the one event kind that carries tokens and
    * cost; every other kind would contribute zeros under a model name of `""`.
@@ -59,13 +61,37 @@ export interface CodingAgentSessionEventsRepository {
     sessionIds: string[];
     fromMs: number;
   }): Promise<SessionModelTotalsRow[]>;
+
+  /**
+   * The sessions whose stamped fact rows name one repository's branches: the
+   * discovery read that finds a session for a pull request even after the
+   * session's own row moved on to another repository. Returns distinct
+   * (tenantId, sessionId) pairs only; the caller fetches the session rows.
+   */
+  listSessionsByStampedBranch(params: {
+    tenantIds: string[];
+    repositoryHost: string;
+    repositoryOwner: string;
+    repositoryName: string;
+    branches: string[];
+    fromMs: number;
+  }): Promise<Array<{ tenantId: string; sessionId: string }>>;
 }
 
-/** One (session, model) pair's totals. */
+/**
+ * One (session, model, working context) group's totals. The context fields are
+ * '' for rows written before the session declared where it was working (or
+ * before the stamp existed); those unstamped totals are priced under the
+ * legacy whole-session rule.
+ */
 export interface SessionModelTotalsRow {
   tenantId: string;
   sessionId: string;
   model: string;
+  repositoryHost: string;
+  repositoryOwner: string;
+  repositoryName: string;
+  branch: string;
   inputTokens: number;
   outputTokens: number;
   cacheReadTokens: number;
@@ -107,6 +133,12 @@ export class NullCodingAgentSessionEventsRepository
   }
 
   async sumTokensByModelPerSession(): Promise<SessionModelTotalsRow[]> {
+    return [];
+  }
+
+  async listSessionsByStampedBranch(): Promise<
+    Array<{ tenantId: string; sessionId: string }>
+  > {
     return [];
   }
 }
@@ -153,6 +185,10 @@ interface ClickHouseWriteRecord {
   ToolResultBytes: number;
   PromptChars: number;
   TotalTokens: number;
+  RepositoryHost: string;
+  RepositoryOwner: string;
+  RepositoryName: string;
+  Branch: string;
   UpdatedAt: Date;
   _retention_days: number;
 }
@@ -164,7 +200,8 @@ const READ_COLUMNS = `
   CacheCreationTokens, CostUsd, DurationMs, TtftMs, Attempt, Speed, StopReason,
   PreTokens, PostTokens, CompactionTrigger, PrecomputeReuse, StatusCode,
   ErrorType, RateLimitCarrier, RetryDurationMs, ToolName, Success, Decision,
-  DecisionSource, ToolInputBytes, ToolResultBytes, PromptChars, TotalTokens
+  DecisionSource, ToolInputBytes, ToolResultBytes, PromptChars, TotalTokens,
+  RepositoryHost, RepositoryOwner, RepositoryName, Branch
 `;
 
 interface ClickHouseReadRow {
@@ -208,6 +245,10 @@ interface ClickHouseReadRow {
   ToolResultBytes: string;
   PromptChars: string;
   TotalTokens: string;
+  RepositoryHost: string;
+  RepositoryOwner: string;
+  RepositoryName: string;
+  Branch: string;
 }
 
 /** One row's columns, written verbatim: the table carries typed scalars only. */
@@ -258,6 +299,10 @@ function toWriteRecord(
     ToolResultBytes: record.toolResultBytes,
     PromptChars: record.promptChars,
     TotalTokens: record.totalTokens,
+    RepositoryHost: record.repositoryHost,
+    RepositoryOwner: record.repositoryOwner,
+    RepositoryName: record.repositoryName,
+    Branch: record.branch,
     UpdatedAt: writtenAt,
     _retention_days: retentionDays ?? PLATFORM_DEFAULT_RETENTION_DAYS,
   };
@@ -459,6 +504,10 @@ export class CodingAgentSessionEventsClickHouseRepository
           TenantId,
           SessionId,
           Model,
+          RepositoryHost,
+          RepositoryOwner,
+          RepositoryName,
+          Branch,
           sum(InputTokens) AS InputTokens,
           sum(OutputTokens) AS OutputTokens,
           sum(CacheReadTokens) AS CacheReadTokens,
@@ -469,6 +518,10 @@ export class CodingAgentSessionEventsClickHouseRepository
             TenantId,
             SessionId,
             Model,
+            RepositoryHost,
+            RepositoryOwner,
+            RepositoryName,
+            Branch,
             InputTokens,
             OutputTokens,
             CacheReadTokens,
@@ -482,7 +535,7 @@ export class CodingAgentSessionEventsClickHouseRepository
           ORDER BY TenantId, SessionId, TimeUnixMs, RecordId, UpdatedAt DESC
           LIMIT 1 BY TenantId, SessionId, TimeUnixMs, RecordId
         )
-        GROUP BY TenantId, SessionId, Model
+        GROUP BY TenantId, SessionId, Model, RepositoryHost, RepositoryOwner, RepositoryName, Branch
       `,
       query_params: {
         tenantIds,
@@ -498,6 +551,10 @@ export class CodingAgentSessionEventsClickHouseRepository
       tenantId: row.TenantId,
       sessionId: row.SessionId,
       model: row.Model,
+      repositoryHost: row.RepositoryHost,
+      repositoryOwner: row.RepositoryOwner,
+      repositoryName: row.RepositoryName,
+      branch: row.Branch,
       inputTokens: Number(row.InputTokens),
       outputTokens: Number(row.OutputTokens),
       cacheReadTokens: Number(row.CacheReadTokens),
@@ -505,12 +562,82 @@ export class CodingAgentSessionEventsClickHouseRepository
       costUsd: Number(row.CostUsd),
     }));
   }
+
+  async listSessionsByStampedBranch({
+    tenantIds,
+    repositoryHost,
+    repositoryOwner,
+    repositoryName,
+    branches,
+    fromMs,
+  }: {
+    tenantIds: string[];
+    repositoryHost: string;
+    repositoryOwner: string;
+    repositoryName: string;
+    branches: string[];
+    fromMs: number;
+  }): Promise<Array<{ tenantId: string; sessionId: string }>> {
+    if (tenantIds.length === 0 || branches.length === 0) return [];
+    for (const tenantId of tenantIds) {
+      EventUtils.validateTenantId(
+        { tenantId },
+        "CodingAgentSessionEventsClickHouseRepository.listSessionsByStampedBranch",
+      );
+    }
+
+    const groups = await groupTenantsByClient({
+      tenantIds,
+      resolveClient: this.resolveClient,
+    });
+    const pairs: Array<{ tenantId: string; sessionId: string }> = [];
+    for (const group of groups) {
+      // Distinct pairs only, so no dedup scope is needed: duplicate row
+      // versions collapse under the DISTINCT. Repository identity is
+      // case-folded on both sides for the same reason the session read folds
+      // it — a session stores the remote's casing verbatim while the mapping
+      // stores lower case. Branches stay case sensitive.
+      const result = await group.client.query({
+        query: `
+          SELECT DISTINCT TenantId, SessionId
+          FROM ${TABLE_NAME}
+          WHERE TenantId IN {tenantIds:Array(String)}
+            AND TimeUnixMs >= fromUnixTimestamp64Milli({fromMs:Int64})
+            AND lower(RepositoryHost) = {repositoryHost:String}
+            AND lower(RepositoryOwner) = {repositoryOwner:String}
+            AND lower(RepositoryName) = {repositoryName:String}
+            AND Branch IN {branches:Array(String)}
+        `,
+        query_params: {
+          tenantIds: group.tenantIds,
+          fromMs,
+          repositoryHost: repositoryHost.toLowerCase(),
+          repositoryOwner: repositoryOwner.toLowerCase(),
+          repositoryName: repositoryName.toLowerCase(),
+          branches,
+        },
+        format: "JSONEachRow",
+      });
+      const rows = await result.json<{ TenantId: string; SessionId: string }>();
+      pairs.push(
+        ...rows.map((row) => ({
+          tenantId: row.TenantId,
+          sessionId: row.SessionId,
+        })),
+      );
+    }
+    return pairs;
+  }
 }
 
 interface ClickHouseModelTotalsRow {
   TenantId: string;
   SessionId: string;
   Model: string;
+  RepositoryHost: string;
+  RepositoryOwner: string;
+  RepositoryName: string;
+  Branch: string;
   InputTokens: string;
   OutputTokens: string;
   CacheReadTokens: string;
@@ -560,5 +687,9 @@ function mapRow(row: ClickHouseReadRow): CodingAgentSessionEventRow {
     toolResultBytes: Number(row.ToolResultBytes),
     promptChars: Number(row.PromptChars),
     totalTokens: Number(row.TotalTokens),
+    repositoryHost: row.RepositoryHost,
+    repositoryOwner: row.RepositoryOwner,
+    repositoryName: row.RepositoryName,
+    branch: row.Branch,
   };
 }

--- a/platform/app/src/server/app-layer/coding-agent/repositories/coding-agent-session.clickhouse.repository.ts
+++ b/platform/app/src/server/app-layer/coding-agent/repositories/coding-agent-session.clickhouse.repository.ts
@@ -24,6 +24,33 @@ import type {
 const TABLE_NAME = "coding_agent_sessions" as const;
 
 /**
+ * The columns behind a `CodingAgentBranchSessionRow`: only what the
+ * pull-request rollup adds up, groups by and names, plus the scalar tie-break
+ * keys — never content. Shared by the branch read and the by-id read so the
+ * two can never answer with different shapes.
+ */
+const BRANCH_SESSION_COLUMNS = `
+  SessionId,
+  TenantId,
+  StartedAt,
+  InputTokens,
+  OutputTokens,
+  CacheReadTokens,
+  CacheCreationTokens,
+  CostUsd,
+  Agent,
+  Models,
+  UserId,
+  GitBranch,
+  GitBranches,
+  Title,
+  LastEventOccurredAt,
+  ModelCalls,
+  ToolCalls,
+  Prompts
+`;
+
+/**
  * How much `findManyRecent` over-reads so its TypeScript dedup cannot shorten
  * the page.
  *
@@ -794,25 +821,7 @@ export class CodingAgentSessionClickHouseRepository
   }): Promise<CodingAgentBranchSessionRow[]> {
     const result = await client.query({
       query: `
-        SELECT
-          SessionId,
-          TenantId,
-          StartedAt,
-          InputTokens,
-          OutputTokens,
-          CacheReadTokens,
-          CacheCreationTokens,
-          CostUsd,
-          Agent,
-          Models,
-          UserId,
-          GitBranch,
-          GitBranches,
-          Title,
-          LastEventOccurredAt,
-          ModelCalls,
-          ToolCalls,
-          Prompts
+        SELECT ${BRANCH_SESSION_COLUMNS}
         FROM ${TABLE_NAME}
         WHERE TenantId IN {tenantIds:Array(String)}
           AND lower(RepositoryHost) = {repositoryHost:String}
@@ -866,6 +875,75 @@ export class CodingAgentSessionClickHouseRepository
     return [...byTenant.values()].flatMap((tenantRows) =>
       dedupToLatestPerSession(tenantRows).map(toBranchSessionRow),
     );
+  }
+
+  /**
+   * The same row shape as `listByRepositoryBranch`, anchored on session ids:
+   * the second leg of fact-stamp discovery, fetching the session rows for
+   * sessions whose stamped events named a repository their own row has since
+   * moved away from. Same tenant grouping, same unwindowed dedup, same
+   * per-tenant collapse, for the reasons documented there.
+   */
+  async listBySessionIds({
+    tenantIds,
+    sessionIds,
+    startedAtFromMs,
+  }: {
+    tenantIds: string[];
+    sessionIds: string[];
+    startedAtFromMs: number;
+  }): Promise<CodingAgentBranchSessionRow[]> {
+    if (tenantIds.length === 0 || sessionIds.length === 0) return [];
+    for (const tenantId of tenantIds) {
+      EventUtils.validateTenantId(
+        { tenantId },
+        "CodingAgentSessionClickHouseRepository.listBySessionIds",
+      );
+    }
+
+    const groups = await groupTenantsByClient({
+      tenantIds,
+      resolveClient: this.resolveClient,
+    });
+    const collected: CodingAgentBranchSessionRow[] = [];
+    for (const group of groups) {
+      const result = await group.client.query({
+        query: `
+          SELECT ${BRANCH_SESSION_COLUMNS}
+          FROM ${TABLE_NAME}
+          WHERE TenantId IN {tenantIds:Array(String)}
+            AND SessionId IN {sessionIds:Array(String)}
+            AND StartedAt >= fromUnixTimestamp64Milli({from:Int64})
+            AND (TenantId, SessionId, UpdatedAt) IN (
+              SELECT TenantId, SessionId, max(UpdatedAt)
+              FROM ${TABLE_NAME}
+              WHERE TenantId IN {tenantIds:Array(String)}
+              GROUP BY TenantId, SessionId
+            )
+          ORDER BY StartedAt ASC
+        `,
+        query_params: {
+          tenantIds: group.tenantIds,
+          sessionIds,
+          from: startedAtFromMs,
+        },
+        format: "JSONEachRow",
+      });
+      const rows = await result.json<Record<string, unknown>>();
+      const byTenant = new Map<string, Record<string, unknown>[]>();
+      for (const row of rows) {
+        const tenantId = String(row.TenantId ?? "");
+        const list = byTenant.get(tenantId) ?? [];
+        list.push(row);
+        byTenant.set(tenantId, list);
+      }
+      collected.push(
+        ...[...byTenant.values()].flatMap((tenantRows) =>
+          dedupToLatestPerSession(tenantRows).map(toBranchSessionRow),
+        ),
+      );
+    }
+    return collected;
   }
 
   async upsertBatch(

--- a/platform/app/src/server/app-layer/coding-agent/repositories/coding-agent-session.repository.ts
+++ b/platform/app/src/server/app-layer/coding-agent/repositories/coding-agent-session.repository.ts
@@ -137,6 +137,18 @@ export interface CodingAgentSessionRepository {
     branches: string[];
     startedAtFromMs: number;
   }): Promise<CodingAgentBranchSessionRow[]>;
+
+  /**
+   * The same rows as `listByRepositoryBranch`, fetched by session id instead
+   * of by repository: the read behind fact-stamp discovery, where a session's
+   * stamped rows name a repository its own row has since moved away from.
+   * `startedAtFromMs` is required for the same partition-pruning reason.
+   */
+  listBySessionIds(params: {
+    tenantIds: string[];
+    sessionIds: string[];
+    startedAtFromMs: number;
+  }): Promise<CodingAgentBranchSessionRow[]>;
 }
 
 /** No-op store for deployments without ClickHouse. */
@@ -163,6 +175,10 @@ export class NullCodingAgentSessionRepository
   }
 
   async listByRepositoryBranch(): Promise<CodingAgentBranchSessionRow[]> {
+    return [];
+  }
+
+  async listBySessionIds(): Promise<CodingAgentBranchSessionRow[]> {
     return [];
   }
 }

--- a/platform/app/src/server/clickhouse/migrations/00087_coding_agent_session_events_working_context.sql
+++ b/platform/app/src/server/clickhouse/migrations/00087_coding_agent_session_events_working_context.sql
@@ -1,0 +1,40 @@
+-- +goose Up
+-- +goose ENVSUB ON
+
+-- The working context active when the event happened: repository and branch,
+-- stamped onto each fact row by the contribute command from the session's
+-- last `session_context` declaration. This is what lets one session's cost
+-- split across every pull request it drove, instead of the whole
+-- lifetime-cumulative total landing on the earliest one.
+--
+-- '' means the row predates the stamp or the session had not declared yet;
+-- the usage read prices those rows under the legacy whole-session rule, so
+-- history behaves exactly as before this migration. No backfill on purpose:
+-- there is nothing correct to backfill from.
+-- +goose StatementBegin
+ALTER TABLE ${CLICKHOUSE_DATABASE}.coding_agent_session_events
+    ADD COLUMN IF NOT EXISTS RepositoryHost LowCardinality(String) DEFAULT '' CODEC(ZSTD(1));
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+ALTER TABLE ${CLICKHOUSE_DATABASE}.coding_agent_session_events
+    ADD COLUMN IF NOT EXISTS RepositoryOwner LowCardinality(String) DEFAULT '' CODEC(ZSTD(1));
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+ALTER TABLE ${CLICKHOUSE_DATABASE}.coding_agent_session_events
+    ADD COLUMN IF NOT EXISTS RepositoryName LowCardinality(String) DEFAULT '' CODEC(ZSTD(1));
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+ALTER TABLE ${CLICKHOUSE_DATABASE}.coding_agent_session_events
+    ADD COLUMN IF NOT EXISTS Branch LowCardinality(String) DEFAULT '' CODEC(ZSTD(1));
+-- +goose StatementEnd
+
+-- +goose Down
+-- Rolling back drops the stamped context on every row, which cannot be
+-- rewritten afterwards. To roll back, uncomment and run manually:
+-- ALTER TABLE ${CLICKHOUSE_DATABASE}.coding_agent_session_events DROP COLUMN IF EXISTS RepositoryHost;
+-- ALTER TABLE ${CLICKHOUSE_DATABASE}.coding_agent_session_events DROP COLUMN IF EXISTS RepositoryOwner;
+-- ALTER TABLE ${CLICKHOUSE_DATABASE}.coding_agent_session_events DROP COLUMN IF EXISTS RepositoryName;
+-- ALTER TABLE ${CLICKHOUSE_DATABASE}.coding_agent_session_events DROP COLUMN IF EXISTS Branch;

--- a/platform/app/src/server/clickhouse/migrations/00087_coding_agent_session_events_working_context.sql
+++ b/platform/app/src/server/clickhouse/migrations/00087_coding_agent_session_events_working_context.sql
@@ -27,8 +27,12 @@ ALTER TABLE ${CLICKHOUSE_DATABASE}.coding_agent_session_events
 -- +goose StatementEnd
 
 -- +goose StatementBegin
+-- Plain String, never LowCardinality: branch names are high-cardinality (one
+-- per task, often per agent run), the same reasoning GitBranch carries in
+-- 00075. The three repository columns above stay LowCardinality, which is what
+-- coding_agent_sessions gives them.
 ALTER TABLE ${CLICKHOUSE_DATABASE}.coding_agent_session_events
-    ADD COLUMN IF NOT EXISTS Branch LowCardinality(String) DEFAULT '' CODEC(ZSTD(1));
+    ADD COLUMN IF NOT EXISTS Branch String DEFAULT '' CODEC(ZSTD(1));
 -- +goose StatementEnd
 
 -- +goose Down

--- a/platform/app/src/server/event-sourcing/pipelineRegistry.ts
+++ b/platform/app/src/server/event-sourcing/pipelineRegistry.ts
@@ -137,6 +137,7 @@ import {
   CodingAgentTraceSessionAppendStore,
   SessionMetricSeriesAppendStore,
 } from "./pipelines/coding-agent-processing/projections/stores";
+import { RedisSessionContextMemo } from "./pipelines/coding-agent-processing/services/session-context-memo";
 import { createCodingAgentLogFactsDispatchSubscriber } from "./pipelines/coding-agent-processing/subscribers/codingAgentLogFactsDispatch.subscriber";
 import { createCodingAgentMetricFactsDispatchSubscriber } from "./pipelines/coding-agent-processing/subscribers/codingAgentMetricFactsDispatch.subscriber";
 import { createCodingAgentSpanFactsDispatchSubscriber } from "./pipelines/coding-agent-processing/subscribers/codingAgentSpanFactsDispatch.subscriber";
@@ -1168,6 +1169,7 @@ export class PipelineRegistry {
           new CodingAgentSessionEventsAppendStore(
             this.deps.repositories.codingAgentSessionEvents,
           ),
+        sessionContextMemo: new RedisSessionContextMemo(this.deps.redis),
         ...(this.deps.codingAgent
           ? {
               pullRequestMappingHandler: createPullRequestMappingHandler(

--- a/platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/__tests__/contributionCoalescing.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/__tests__/contributionCoalescing.unit.test.ts
@@ -29,6 +29,7 @@ import {
   applyLogToCodingAgentSession,
   createInitCodingAgentSession,
 } from "../services/coding-agent-session.derivation";
+import { InMemorySessionContextMemo } from "../services/session-context-memo";
 
 vi.mock("../../../utils/killSwitch", () => ({
   isComponentDisabled: vi.fn().mockResolvedValue(false),
@@ -50,6 +51,7 @@ function buildPipeline() {
     codingAgentTraceSessionAppendStore: store,
     sessionMetricSeriesAppendStore: store,
     codingAgentSessionEventsAppendStore: store,
+    sessionContextMemo: new InMemorySessionContextMemo(),
   });
 }
 
@@ -101,7 +103,9 @@ function batchParamsFor({
     payloads: payloads as unknown as Record<string, unknown>[],
     commandType: CONTRIBUTE_LOG_FACTS_COMMAND_TYPE,
     commandSchema: ContributeLogFactsCommand.schema,
-    handler: new ContributeLogFactsCommand(),
+    handler: new ContributeLogFactsCommand({
+      contextMemo: new InMemorySessionContextMemo(),
+    }),
     getAggregateId: ContributeLogFactsCommand.getAggregateId,
     storeEventsFn: storeEventsFn as never,
     aggregateType: "coding_agent_session" as const,

--- a/platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/commands/__tests__/contributions.commands.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/commands/__tests__/contributions.commands.unit.test.ts
@@ -25,6 +25,10 @@ import {
   METRIC_FACTS_CONTRIBUTED_EVENT_TYPE,
   SPAN_FACTS_CONTRIBUTED_EVENT_TYPE,
 } from "../../schemas/constants";
+import {
+  InMemorySessionContextMemo,
+  type SessionContextMemo,
+} from "../../services/session-context-memo";
 import { ContributeLogFactsCommand } from "../contributeLogFactsCommand";
 import { ContributeMetricFactsCommand } from "../contributeMetricFactsCommand";
 import { ContributeSpanFactsCommand } from "../contributeSpanFactsCommand";
@@ -178,11 +182,47 @@ describe("ContributeSpanFactsCommand", () => {
   });
 });
 
+function logFactsHandler(memo?: SessionContextMemo) {
+  return new ContributeLogFactsCommand({
+    contextMemo: memo ?? new InMemorySessionContextMemo(),
+  });
+}
+
+/** A `session_context` declaration's contribution, as the dispatcher sends it. */
+function declarationData(overrides?: Record<string, string>) {
+  return logFactsData({
+    recordId: "rec-context",
+    facts: {
+      "event.name": "langwatch.session_context",
+      "vcs.repository.host": "github.com",
+      "vcs.repository.owner": "acme",
+      "vcs.repository.name": "widgets",
+      "vcs.ref.head.name": "main",
+      "vcs.worktree.name": "widgets",
+      ...overrides,
+    },
+  });
+}
+
+/** An `api_request` contribution: the row-bearing kind the stamp exists for. */
+function modelCallData(overrides?: Record<string, unknown>) {
+  return logFactsData({
+    recordId: "rec-call",
+    facts: {
+      "event.name": "claude_code.api_request",
+      model: "claude-fable-5",
+      input_tokens: 100,
+      output_tokens: 50,
+    },
+    ...overrides,
+  });
+}
+
 describe("ContributeLogFactsCommand", () => {
   describe("when a log with no correlation contributes", () => {
     /** @scenario a denied tool is part of the session story */
     it("carries the facts with a null trace id", async () => {
-      const handler = new ContributeLogFactsCommand();
+      const handler = logFactsHandler();
       const events = await handler.handle(
         makeCommand(CONTRIBUTE_LOG_FACTS_COMMAND_TYPE, logFactsData()),
       );
@@ -198,7 +238,7 @@ describe("ContributeLogFactsCommand", () => {
 
   describe("when the same record is delivered twice", () => {
     it("collapses on the tenant-scoped record id", async () => {
-      const handler = new ContributeLogFactsCommand();
+      const handler = logFactsHandler();
       const [a] = await handler.handle(
         makeCommand(CONTRIBUTE_LOG_FACTS_COMMAND_TYPE, logFactsData()),
       );
@@ -210,6 +250,122 @@ describe("ContributeLogFactsCommand", () => {
       );
       expect(a!.idempotencyKey).toBe(b!.idempotencyKey);
       expect(a!.idempotencyKey).toBe(`${TENANT}:rec-abc`);
+    });
+  });
+
+  describe("when the session declared its working context", () => {
+    /** @scenario A model call after a declaration carries the declared context */
+    it("stamps a later model call with the declared repository and branch", async () => {
+      const handler = logFactsHandler();
+      await handler.handle(
+        makeCommand(CONTRIBUTE_LOG_FACTS_COMMAND_TYPE, declarationData()),
+      );
+      const [event] = await handler.handle(
+        makeCommand(CONTRIBUTE_LOG_FACTS_COMMAND_TYPE, modelCallData()),
+      );
+
+      expect(event!.data.repositoryHost).toBe("github.com");
+      expect(event!.data.repositoryOwner).toBe("acme");
+      expect(event!.data.repositoryName).toBe("widgets");
+      expect(event!.data.branch).toBe("main");
+    });
+
+    /** @scenario A new declaration moves the stamp for the rows that follow */
+    it("moves the stamp when the session declares another branch", async () => {
+      const handler = logFactsHandler();
+      await handler.handle(
+        makeCommand(CONTRIBUTE_LOG_FACTS_COMMAND_TYPE, declarationData()),
+      );
+      const [first] = await handler.handle(
+        makeCommand(CONTRIBUTE_LOG_FACTS_COMMAND_TYPE, modelCallData()),
+      );
+      await handler.handle(
+        makeCommand(
+          CONTRIBUTE_LOG_FACTS_COMMAND_TYPE,
+          declarationData({ "vcs.ref.head.name": "feat/next" }),
+        ),
+      );
+      const [second] = await handler.handle(
+        makeCommand(
+          CONTRIBUTE_LOG_FACTS_COMMAND_TYPE,
+          modelCallData({ recordId: "rec-call-2" }),
+        ),
+      );
+
+      expect(first!.data.branch).toBe("main");
+      expect(second!.data.branch).toBe("feat/next");
+    });
+
+    it("leaves a non-row event unstamped", async () => {
+      const handler = logFactsHandler();
+      await handler.handle(
+        makeCommand(CONTRIBUTE_LOG_FACTS_COMMAND_TYPE, declarationData()),
+      );
+      const [event] = await handler.handle(
+        makeCommand(
+          CONTRIBUTE_LOG_FACTS_COMMAND_TYPE,
+          logFactsData({
+            facts: { "event.name": "claude_code.hook_executed" },
+          }),
+        ),
+      );
+
+      expect(event!.data.branch).toBeUndefined();
+      expect(event!.data.repositoryOwner).toBeUndefined();
+    });
+  });
+
+  describe("when the session has not declared a working context", () => {
+    /** @scenario A model call before any declaration is stored unstamped */
+    it("contributes the model call unstamped", async () => {
+      const handler = logFactsHandler();
+      const [event] = await handler.handle(
+        makeCommand(CONTRIBUTE_LOG_FACTS_COMMAND_TYPE, modelCallData()),
+      );
+
+      expect(event!.data.repositoryHost).toBeUndefined();
+      expect(event!.data.repositoryOwner).toBeUndefined();
+      expect(event!.data.repositoryName).toBeUndefined();
+      expect(event!.data.branch).toBeUndefined();
+    });
+  });
+
+  describe("when the declaration names a repository but no branch", () => {
+    /** @scenario A declaration with no branch stamps nothing */
+    it("stamps nothing until a branch is declared", async () => {
+      const handler = logFactsHandler();
+      await handler.handle(
+        makeCommand(
+          CONTRIBUTE_LOG_FACTS_COMMAND_TYPE,
+          declarationData({ "vcs.ref.head.name": "" }),
+        ),
+      );
+      const [event] = await handler.handle(
+        makeCommand(CONTRIBUTE_LOG_FACTS_COMMAND_TYPE, modelCallData()),
+      );
+
+      expect(event!.data.branch).toBeUndefined();
+      expect(event!.data.repositoryOwner).toBeUndefined();
+    });
+  });
+
+  describe("when the memo cannot be read", () => {
+    it("contributes the record unstamped rather than failing it", async () => {
+      const failing: SessionContextMemo = {
+        get: async () => {
+          throw new Error("redis away");
+        },
+        set: async () => {
+          throw new Error("redis away");
+        },
+      };
+      const handler = logFactsHandler(failing);
+      const [event] = await handler.handle(
+        makeCommand(CONTRIBUTE_LOG_FACTS_COMMAND_TYPE, modelCallData()),
+      );
+
+      expect(event!.type).toBe(LOG_FACTS_CONTRIBUTED_EVENT_TYPE);
+      expect(event!.data.branch).toBeUndefined();
     });
   });
 });

--- a/platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/commands/__tests__/contributions.commands.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/commands/__tests__/contributions.commands.unit.test.ts
@@ -350,6 +350,7 @@ describe("ContributeLogFactsCommand", () => {
   });
 
   describe("when the memo cannot be read", () => {
+    /** @scenario "A record whose memo cannot be read is contributed unstamped" */
     it("contributes the record unstamped rather than failing it", async () => {
       const failing: SessionContextMemo = {
         get: async () => {
@@ -366,6 +367,26 @@ describe("ContributeLogFactsCommand", () => {
 
       expect(event!.type).toBe(LOG_FACTS_CONTRIBUTED_EVENT_TYPE);
       expect(event!.data.branch).toBeUndefined();
+    });
+  });
+
+  describe("when the memo cannot be written", () => {
+    /** @scenario "A declaration whose memo cannot be written is still contributed" */
+    it("contributes the declaration itself rather than failing it", async () => {
+      const failing: SessionContextMemo = {
+        get: async () => null,
+        set: async () => {
+          throw new Error("redis away");
+        },
+      };
+      const handler = logFactsHandler(failing);
+
+      const [event] = await handler.handle(
+        makeCommand(CONTRIBUTE_LOG_FACTS_COMMAND_TYPE, declarationData()),
+      );
+
+      expect(event!.type).toBe(LOG_FACTS_CONTRIBUTED_EVENT_TYPE);
+      expect(event!.data.recordId).toBe("rec-context");
     });
   });
 });

--- a/platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/commands/contributeLogFactsCommand.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/commands/contributeLogFactsCommand.ts
@@ -16,6 +16,7 @@ import {
   isStampableContext,
   SESSION_CONTEXT_EVENT,
   type SessionContextMemo,
+  type SessionWorkingContext,
   workingContextOfFacts,
 } from "../services/session-context-memo";
 
@@ -81,8 +82,9 @@ export class ContributeLogFactsCommand
    * else (hooks, plugin loads, body events) passes through untouched.
    *
    * A memo write is idempotent, so a retried command re-writes the same value.
-   * A memo read failure degrades to an unstamped row rather than failing the
-   * contribution — attribution is a refinement of the record, not part of it.
+   * Neither a failed read nor a failed write fails the contribution: both
+   * degrade to an unstamped row, because attribution is a refinement of the
+   * record, not part of it.
    */
   private async stamped(
     data: ContributeLogFactsCommandData,
@@ -90,29 +92,14 @@ export class ContributeLogFactsCommand
     const rawName = String(data.facts["event.name"] ?? "");
 
     if (normalizeEventName(rawName) === SESSION_CONTEXT_EVENT) {
-      const context = workingContextOfFacts(data.facts);
-      if (context) {
-        await this.deps.contextMemo.set({
-          tenantId: data.tenantId,
-          sessionId: data.sessionId,
-          context,
-        });
-      }
+      await this.remember(data);
       return data;
     }
 
     if (!mapsToCodingAgentSessionEvent({ data })) return data;
 
-    let context;
-    try {
-      context = await this.deps.contextMemo.get({
-        tenantId: data.tenantId,
-        sessionId: data.sessionId,
-      });
-    } catch {
-      return data;
-    }
-    if (context === null || !isStampableContext(context)) return data;
+    const context = await this.stampableContext(data);
+    if (context === null) return data;
 
     return {
       ...data,
@@ -121,6 +108,45 @@ export class ContributeLogFactsCommand
       repositoryName: context.repositoryName,
       branch: context.branch,
     };
+  }
+
+  /**
+   * Put a declaration's context in the memo, for the rows that follow it. A
+   * declaration naming no repository says nothing to remember, and a memo
+   * outage leaves those later rows unstamped rather than failing this one.
+   */
+  private async remember(data: ContributeLogFactsCommandData): Promise<void> {
+    const context = workingContextOfFacts(data.facts);
+    if (context === null) return;
+    try {
+      await this.deps.contextMemo.set({
+        tenantId: data.tenantId,
+        sessionId: data.sessionId,
+        context,
+      });
+    } catch {
+      return;
+    }
+  }
+
+  /**
+   * The context this record should be stamped with, or null when there is
+   * none to stamp: nothing declared yet, a partial declaration, or a memo
+   * that cannot be read.
+   */
+  private async stampableContext(
+    data: ContributeLogFactsCommandData,
+  ): Promise<SessionWorkingContext | null> {
+    try {
+      const context = await this.deps.contextMemo.get({
+        tenantId: data.tenantId,
+        sessionId: data.sessionId,
+      });
+      if (context === null || !isStampableContext(context)) return null;
+      return context;
+    } catch {
+      return null;
+    }
   }
 
   static getAggregateId(payload: ContributeLogFactsCommandData): string {

--- a/platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/commands/contributeLogFactsCommand.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/commands/contributeLogFactsCommand.ts
@@ -1,5 +1,6 @@
 import { createTenantId, defineCommandSchema, EventUtils } from "../../..";
 import type { Command, CommandHandler } from "../../../commands/command";
+import { mapsToCodingAgentSessionEvent } from "../projections/codingAgentSessionEvents.mapProjection";
 import {
   type ContributeLogFactsCommandData,
   contributeLogFactsCommandDataSchema,
@@ -10,7 +11,31 @@ import {
   LOG_FACTS_CONTRIBUTED_EVENT_VERSION_LATEST,
 } from "../schemas/constants";
 import type { LogFactsContributedEvent } from "../schemas/events";
+import { normalizeEventName } from "../services/coding-agent-normalization";
+import {
+  isStampableContext,
+  SESSION_CONTEXT_EVENT,
+  type SessionContextMemo,
+  workingContextOfFacts,
+} from "../services/session-context-memo";
 
+/**
+ * Contributes one log record's facts to its session, stamping row-bearing
+ * records with the session's declared working context on the way through.
+ *
+ * The stamp happens HERE and nowhere later, because this is the one lane with
+ * both per-session ordering and the ability to hold state: contributions are
+ * keyed per session and drain in order (see pipeline.ts), while the map
+ * projection that writes the fact table runs per-event on an unordered queue
+ * and must stay pure. Stamping the event data before it is appended also makes
+ * replays deterministic — a projection rebuild re-reads the same stamped
+ * events.
+ *
+ * A `session_context` declaration updates the memo; every record that becomes
+ * a fact-table row reads it. A record processed before its session ever
+ * declared goes through unstamped, which the usage read prices under the
+ * legacy whole-session rule.
+ */
 export class ContributeLogFactsCommand
   implements
     CommandHandler<
@@ -24,10 +49,12 @@ export class ContributeLogFactsCommand
     "Contribute one log record's coding-agent facts to its session",
   );
 
+  constructor(private readonly deps: { contextMemo: SessionContextMemo }) {}
+
   async handle(
     command: Command<ContributeLogFactsCommandData>,
   ): Promise<LogFactsContributedEvent[]> {
-    const data = command.data;
+    const data = await this.stamped(command.data);
     return [
       EventUtils.createEvent<LogFactsContributedEvent>({
         aggregateType: "coding_agent_session",
@@ -46,6 +73,54 @@ export class ContributeLogFactsCommand
         idempotencyKey: `${command.tenantId}:${data.recordId}`,
       }),
     ];
+  }
+
+  /**
+   * The contribution with the working context applied: a declaration writes
+   * the memo, a row-bearing record reads it onto the event, and everything
+   * else (hooks, plugin loads, body events) passes through untouched.
+   *
+   * A memo write is idempotent, so a retried command re-writes the same value.
+   * A memo read failure degrades to an unstamped row rather than failing the
+   * contribution — attribution is a refinement of the record, not part of it.
+   */
+  private async stamped(
+    data: ContributeLogFactsCommandData,
+  ): Promise<ContributeLogFactsCommandData> {
+    const rawName = String(data.facts["event.name"] ?? "");
+
+    if (normalizeEventName(rawName) === SESSION_CONTEXT_EVENT) {
+      const context = workingContextOfFacts(data.facts);
+      if (context) {
+        await this.deps.contextMemo.set({
+          tenantId: data.tenantId,
+          sessionId: data.sessionId,
+          context,
+        });
+      }
+      return data;
+    }
+
+    if (!mapsToCodingAgentSessionEvent({ data })) return data;
+
+    let context;
+    try {
+      context = await this.deps.contextMemo.get({
+        tenantId: data.tenantId,
+        sessionId: data.sessionId,
+      });
+    } catch {
+      return data;
+    }
+    if (context === null || !isStampableContext(context)) return data;
+
+    return {
+      ...data,
+      repositoryHost: context.repositoryHost,
+      repositoryOwner: context.repositoryOwner,
+      repositoryName: context.repositoryName,
+      branch: context.branch,
+    };
   }
 
   static getAggregateId(payload: ContributeLogFactsCommandData): string {

--- a/platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/pipeline.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/pipeline.ts
@@ -24,6 +24,7 @@ import {
 } from "./projections/sessionMetricSeries.mapProjection";
 import { CODING_AGENT_CONTRIBUTION_COALESCE_MAX_BATCH } from "./schemas/constants";
 import type { CodingAgentProcessingEvent } from "./schemas/events";
+import type { SessionContextMemo } from "./services/session-context-memo";
 import {
   PULL_REQUEST_MAPPING_WINDOW_MS,
   pullRequestMappingGroupKey,
@@ -37,6 +38,12 @@ export interface CodingAgentProcessingPipelineDeps {
   codingAgentTraceSessionAppendStore: AppendStore<CodingAgentTraceSessionRecord>;
   sessionMetricSeriesAppendStore: AppendStore<SessionMetricSeriesRecord>;
   codingAgentSessionEventsAppendStore: AppendStore<CodingAgentSessionEventRecord>;
+  /**
+   * The "context the session last declared" store the log-facts command stamps
+   * fact rows from (see `services/session-context-memo.ts`). Redis-backed in
+   * the app; in-memory in tests.
+   */
+  sessionContextMemo: SessionContextMemo;
   /**
    * Asks the organization's GitHub connection which pull requests a folded
    * session's branch has hosted. Absent where there is no GitHub connection to
@@ -126,9 +133,16 @@ export function createCodingAgentProcessingPipeline(
     .withCommand("contributeSpanFacts", ContributeSpanFactsCommand, {
       coalesceMaxBatch: CODING_AGENT_CONTRIBUTION_COALESCE_MAX_BATCH,
     })
-    .withCommand("contributeLogFacts", ContributeLogFactsCommand, {
-      coalesceMaxBatch: CODING_AGENT_CONTRIBUTION_COALESCE_MAX_BATCH,
-    })
+    // An instance rather than a class: the log-facts command carries the
+    // session-context memo it stamps row-bearing contributions from.
+    .withCommandInstance(
+      "contributeLogFacts",
+      ContributeLogFactsCommand,
+      new ContributeLogFactsCommand({ contextMemo: deps.sessionContextMemo }),
+      {
+        coalesceMaxBatch: CODING_AGENT_CONTRIBUTION_COALESCE_MAX_BATCH,
+      },
+    )
     .withCommand("contributeMetricFacts", ContributeMetricFactsCommand, {
       coalesceMaxBatch: CODING_AGENT_CONTRIBUTION_COALESCE_MAX_BATCH,
     });

--- a/platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/projections/__tests__/codingAgentSession.foldProjection.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/projections/__tests__/codingAgentSession.foldProjection.unit.test.ts
@@ -534,8 +534,8 @@ describe("CodingAgentSessionFoldProjection", () => {
       ...overrides,
     });
 
-    /** @scenario Repository identity and worktree set once and do not move */
-    it("keeps the first repository and worktree when a later event names another", () => {
+    /** @scenario Repository identity and worktree follow the latest context event */
+    it("moves the repository and worktree to the latest event's answer", () => {
       const projection = makeProjection();
       let state = initStateOf(projection);
 
@@ -556,10 +556,37 @@ describe("CodingAgentSessionFoldProjection", () => {
         state,
       );
 
+      expect(state.repositoryHost).toBe("gitlab.com");
+      expect(state.repositoryOwner).toBe("other");
+      expect(state.repositoryName).toBe("gadgets");
+      expect(state.gitWorktree).toBe("gadgets-hotfix");
+    });
+
+    /** @scenario A context event that omits a field keeps the previous value */
+    it("keeps the declared repository and worktree when a later event omits them", () => {
+      const projection = makeProjection();
+      let state = initStateOf(projection);
+
+      state = projection.handleCodingAgentSessionLogFactsContributed(
+        logFactsEvent({ facts: contextFacts() }),
+        state,
+      );
+      state = projection.handleCodingAgentSessionLogFactsContributed(
+        logFactsEvent({
+          facts: {
+            "event.name": "langwatch.session_context",
+            "vcs.ref.head.name": "feat/only-a-branch",
+          },
+          timeMs: 2_500,
+        }),
+        state,
+      );
+
       expect(state.repositoryHost).toBe("github.com");
       expect(state.repositoryOwner).toBe("acme");
       expect(state.repositoryName).toBe("widgets");
       expect(state.gitWorktree).toBe("widgets");
+      expect(state.gitBranch).toBe("feat/only-a-branch");
     });
 
     /** @scenario The branch follows the latest session context event */

--- a/platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/projections/__tests__/codingAgentSession.store.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/projections/__tests__/codingAgentSession.store.unit.test.ts
@@ -116,6 +116,10 @@ class FakeRepo implements CodingAgentSessionRepository {
   async listByRepositoryBranch(): Promise<CodingAgentBranchSessionRow[]> {
     return [];
   }
+
+  async listBySessionIds(): Promise<CodingAgentBranchSessionRow[]> {
+    return [];
+  }
 }
 
 const context = (

--- a/platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/projections/__tests__/codingAgentSessionEvents.mapProjection.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/projections/__tests__/codingAgentSessionEvents.mapProjection.unit.test.ts
@@ -99,6 +99,35 @@ describe("CodingAgentSessionEventsMapProjection", () => {
     });
   });
 
+  describe("when the contribution carries a stamped working context", () => {
+    it("copies the stamp onto the row", () => {
+      const event = logFactsEvent({ "event.name": "api_request" });
+      event.data.repositoryHost = "github.com";
+      event.data.repositoryOwner = "acme";
+      event.data.repositoryName = "widgets";
+      event.data.branch = "feat/split";
+
+      const row =
+        makeProjection().mapCodingAgentSessionLogFactsContributed(event);
+
+      expect(row?.repositoryHost).toBe("github.com");
+      expect(row?.repositoryOwner).toBe("acme");
+      expect(row?.repositoryName).toBe("widgets");
+      expect(row?.branch).toBe("feat/split");
+    });
+
+    it("stores an unstamped contribution with empty context columns", () => {
+      const row = makeProjection().mapCodingAgentSessionLogFactsContributed(
+        logFactsEvent({ "event.name": "api_request" }),
+      );
+
+      expect(row?.repositoryHost).toBe("");
+      expect(row?.repositoryOwner).toBe("");
+      expect(row?.repositoryName).toBe("");
+      expect(row?.branch).toBe("");
+    });
+  });
+
   describe("when a compaction contribution arrives", () => {
     /** @scenario a compaction becomes one row with its before and after tokens */
     it("maps it to a compaction row with pre and post tokens and the trigger", () => {

--- a/platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/projections/codingAgentSessionEvents.mapProjection.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/projections/codingAgentSessionEvents.mapProjection.ts
@@ -1,4 +1,3 @@
-import type { Event } from "../../../domain/types";
 import {
   AbstractMapProjection,
   type MapEventHandlers,
@@ -72,6 +71,18 @@ export interface CodingAgentSessionEventRecord {
   toolResultBytes: number;
   promptChars: number;
   totalTokens: number;
+  /**
+   * The working context active when the event happened, stamped onto the
+   * event by the contribute command from the session's last `session_context`
+   * declaration. '' on rows from before a declaration (or before the stamp
+   * existed), which the usage read prices under the legacy whole-session
+   * rule. This is what lets one session's cost split across every pull
+   * request it drove.
+   */
+  repositoryHost: string;
+  repositoryOwner: string;
+  repositoryName: string;
+  branch: string;
 }
 
 /**
@@ -124,7 +135,9 @@ export const EVENT_KIND_BY_RAW_NAME: Record<string, string> = {
  * `""`, which resolves to `null` — declined the same way an unlisted name is,
  * because `map()` would also have written nothing for it.
  */
-export function mapsToCodingAgentSessionEvent(event: Event): boolean {
+export function mapsToCodingAgentSessionEvent(event: {
+  data?: unknown;
+}): boolean {
   return resolveEventKind(rawEventName(event)) !== null;
 }
 
@@ -203,6 +216,10 @@ export class CodingAgentSessionEventsMapProjection
       toolResultBytes: nat(facts.tool_result_size_bytes),
       promptChars: nat(facts.prompt_length),
       totalTokens: nat(facts.total_tokens),
+      repositoryHost: event.data.repositoryHost ?? "",
+      repositoryOwner: event.data.repositoryOwner ?? "",
+      repositoryName: event.data.repositoryName ?? "",
+      branch: event.data.branch ?? "",
     };
   }
 }

--- a/platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/schemas/contributions.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/schemas/contributions.ts
@@ -84,6 +84,18 @@ export const logFactsContributionSchema = contributionBaseSchema.extend({
   scopeName: z.string().nullable(),
   /** The lifted scalar vocabulary (`CODING_AGENT_CONTRIBUTION_KEYS`). */
   facts: contributionFactsSchema,
+  /**
+   * The working context active when the record happened, stamped onto the
+   * EVENT by the contribute command from the session's last `session_context`
+   * declaration (see `services/session-context-memo.ts`). Absent on the
+   * contribution the dispatcher enqueues and on events from before the stamp
+   * existed; the fact table stores absence as '' and the usage read prices
+   * those rows under the legacy whole-session rule.
+   */
+  repositoryHost: z.string().optional(),
+  repositoryOwner: z.string().optional(),
+  repositoryName: z.string().optional(),
+  branch: z.string().optional(),
 });
 export type LogFactsContribution = z.infer<typeof logFactsContributionSchema>;
 

--- a/platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/services/__tests__/session-context-memo.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/services/__tests__/session-context-memo.unit.test.ts
@@ -1,0 +1,94 @@
+/**
+ * @vitest-environment node
+ * @unit
+ *
+ * The no-Redis memo's own housekeeping. The Redis memo hands expiry to Redis;
+ * this one has to do it itself, or a process that never restarts keeps one
+ * entry per session it ever saw.
+ *
+ * @see specs/coding-agent/session-git-context.feature
+ */
+import { describe, expect, it } from "vitest";
+import {
+  InMemorySessionContextMemo,
+  type SessionWorkingContext,
+} from "../session-context-memo";
+
+const DAY = 24 * 60 * 60 * 1000;
+
+const context: SessionWorkingContext = {
+  repositoryHost: "github.com",
+  repositoryOwner: "acme",
+  repositoryName: "widgets",
+  branch: "feat/split",
+};
+
+describe("InMemorySessionContextMemo", () => {
+  describe("given a context written to the memo", () => {
+    describe("when it is read back inside its lifetime", () => {
+      it("answers the declared context", async () => {
+        const memo = new InMemorySessionContextMemo(() => 0);
+        await memo.set({ tenantId: "p1", sessionId: "s1", context });
+
+        expect(await memo.get({ tenantId: "p1", sessionId: "s1" })).toEqual(
+          context,
+        );
+      });
+    });
+
+    describe("when its lifetime has passed", () => {
+      /** @scenario "A memo entry is forgotten once its lifetime passes" */
+      it("answers nothing for that session", async () => {
+        let now = 0;
+        const memo = new InMemorySessionContextMemo(() => now);
+        await memo.set({ tenantId: "p1", sessionId: "s1", context });
+
+        now = 181 * DAY;
+
+        expect(await memo.get({ tenantId: "p1", sessionId: "s1" })).toBeNull();
+      });
+    });
+  });
+
+  describe("given more sessions than the memo holds", () => {
+    /** @scenario "The no-Redis memo stops growing at its bound" */
+    it("evicts the oldest and keeps the newest", async () => {
+      const memo = new InMemorySessionContextMemo(() => 0);
+      // One past the bound, so exactly the first write is evicted.
+      for (let index = 0; index <= 10_000; index++) {
+        await memo.set({
+          tenantId: "p1",
+          sessionId: `s${index}`,
+          context,
+        });
+      }
+
+      expect(await memo.get({ tenantId: "p1", sessionId: "s0" })).toBeNull();
+      expect(await memo.get({ tenantId: "p1", sessionId: "s1" })).toEqual(
+        context,
+      );
+      expect(await memo.get({ tenantId: "p1", sessionId: "s10000" })).toEqual(
+        context,
+      );
+    });
+  });
+
+  describe("given two tenants that share a session id", () => {
+    it("keeps their contexts apart", async () => {
+      const memo = new InMemorySessionContextMemo(() => 0);
+      await memo.set({ tenantId: "p1", sessionId: "shared", context });
+      await memo.set({
+        tenantId: "p2",
+        sessionId: "shared",
+        context: { ...context, branch: "feat/other" },
+      });
+
+      expect(
+        (await memo.get({ tenantId: "p1", sessionId: "shared" }))?.branch,
+      ).toBe("feat/split");
+      expect(
+        (await memo.get({ tenantId: "p2", sessionId: "shared" }))?.branch,
+      ).toBe("feat/other");
+    });
+  });
+});

--- a/platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/services/__tests__/session-context-memo.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/services/__tests__/session-context-memo.unit.test.ts
@@ -51,44 +51,48 @@ describe("InMemorySessionContextMemo", () => {
   });
 
   describe("given more sessions than the memo holds", () => {
-    /** @scenario "The no-Redis memo stops growing at its bound" */
-    it("evicts the oldest and keeps the newest", async () => {
-      const memo = new InMemorySessionContextMemo(() => 0);
-      // One past the bound, so exactly the first write is evicted.
-      for (let index = 0; index <= 10_000; index++) {
-        await memo.set({
-          tenantId: "p1",
-          sessionId: `s${index}`,
-          context,
-        });
-      }
+    describe("when the oldest session's context is read", () => {
+      /** @scenario "The no-Redis memo stops growing at its bound" */
+      it("evicts the oldest and keeps the newest", async () => {
+        const memo = new InMemorySessionContextMemo(() => 0);
+        // One past the bound, so exactly the first write is evicted.
+        for (let index = 0; index <= 10_000; index++) {
+          await memo.set({
+            tenantId: "p1",
+            sessionId: `s${index}`,
+            context,
+          });
+        }
 
-      expect(await memo.get({ tenantId: "p1", sessionId: "s0" })).toBeNull();
-      expect(await memo.get({ tenantId: "p1", sessionId: "s1" })).toEqual(
-        context,
-      );
-      expect(await memo.get({ tenantId: "p1", sessionId: "s10000" })).toEqual(
-        context,
-      );
+        expect(await memo.get({ tenantId: "p1", sessionId: "s0" })).toBeNull();
+        expect(await memo.get({ tenantId: "p1", sessionId: "s1" })).toEqual(
+          context,
+        );
+        expect(await memo.get({ tenantId: "p1", sessionId: "s10000" })).toEqual(
+          context,
+        );
+      });
     });
   });
 
   describe("given two tenants that share a session id", () => {
-    it("keeps their contexts apart", async () => {
-      const memo = new InMemorySessionContextMemo(() => 0);
-      await memo.set({ tenantId: "p1", sessionId: "shared", context });
-      await memo.set({
-        tenantId: "p2",
-        sessionId: "shared",
-        context: { ...context, branch: "feat/other" },
-      });
+    describe("when each tenant's context is read", () => {
+      it("keeps their contexts apart", async () => {
+        const memo = new InMemorySessionContextMemo(() => 0);
+        await memo.set({ tenantId: "p1", sessionId: "shared", context });
+        await memo.set({
+          tenantId: "p2",
+          sessionId: "shared",
+          context: { ...context, branch: "feat/other" },
+        });
 
-      expect(
-        (await memo.get({ tenantId: "p1", sessionId: "shared" }))?.branch,
-      ).toBe("feat/split");
-      expect(
-        (await memo.get({ tenantId: "p2", sessionId: "shared" }))?.branch,
-      ).toBe("feat/other");
+        expect(
+          (await memo.get({ tenantId: "p1", sessionId: "shared" }))?.branch,
+        ).toBe("feat/split");
+        expect(
+          (await memo.get({ tenantId: "p2", sessionId: "shared" }))?.branch,
+        ).toBe("feat/other");
+      });
     });
   });
 });

--- a/platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/services/coding-agent-session.derivation.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/services/coding-agent-session.derivation.ts
@@ -15,16 +15,16 @@ import {
   SESSION_TITLE_FACT_KEY,
   SESSION_TITLE_FALLBACK_FACT_KEY,
 } from "./coding-agent-normalization";
-import {
-  SESSION_CONTEXT_ATTR,
-  SESSION_CONTEXT_EVENT,
-} from "./session-context-memo";
 import type {
   CodingAgentSessionData,
   MetricSeriesFact,
   SessionStep,
   SessionTitleSource,
 } from "./coding-agent-session.types";
+import {
+  SESSION_CONTEXT_ATTR,
+  SESSION_CONTEXT_EVENT,
+} from "./session-context-memo";
 
 /**
  * Derive a coding-agent SESSION from its contributions (ADR-056,

--- a/platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/services/coding-agent-session.derivation.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/services/coding-agent-session.derivation.ts
@@ -15,6 +15,10 @@ import {
   SESSION_TITLE_FACT_KEY,
   SESSION_TITLE_FALLBACK_FACT_KEY,
 } from "./coding-agent-normalization";
+import {
+  SESSION_CONTEXT_ATTR,
+  SESSION_CONTEXT_EVENT,
+} from "./session-context-memo";
 import type {
   CodingAgentSessionData,
   MetricSeriesFact,
@@ -148,14 +152,10 @@ const CODEX = {
  */
 const LANGWATCH = {
   EVENT: {
-    SESSION_CONTEXT: "session_context",
+    SESSION_CONTEXT: SESSION_CONTEXT_EVENT,
   },
   ATTR: {
-    REPOSITORY_HOST: "vcs.repository.host",
-    REPOSITORY_OWNER: "vcs.repository.owner",
-    REPOSITORY_NAME: "vcs.repository.name",
-    BRANCH: "vcs.ref.head.name",
-    WORKTREE: "vcs.worktree.name",
+    ...SESSION_CONTEXT_ATTR,
     TITLE: SESSION_TITLE_FACT_KEY,
     TITLE_FALLBACK: SESSION_TITLE_FALLBACK_FACT_KEY,
     NAME: SESSION_NAME_FACT_KEY,
@@ -1001,12 +1001,14 @@ export function applyLogToCodingAgentSession({
       });
 
     case LANGWATCH.EVENT.SESSION_CONTEXT: {
-      // Repository identity and worktree are once-set: a session is one
-      // checkout, so the first answer stands. The branch is the exception:
-      // it moves during a session, and the branch a session ENDS on is the
-      // one its pull request comes from. Every branch it passed through joins
-      // the set as well, because a session that moves on has still driven the
-      // branch it left, and the pull request it opened there.
+      // Everything here is present tense, last write wins: a resumed session
+      // moves between branches, worktrees and even repositories, and the row
+      // answers where it is NOW. Per-branch history lives on the fact rows
+      // (the contribute command stamps each one with the context active when
+      // it happened), so nothing is lost by letting the scalars move. Every
+      // branch the session passed through also joins the set, because a
+      // session that moves on has still driven the branch it left, and the
+      // pull request it opened there.
       const branch = str(attrs[LANGWATCH.ATTR.BRANCH]);
       // Two titles can ride the record. The context title is the codex
       // harvest's prompt-derived name (codex withholds prompt text from its
@@ -1026,12 +1028,12 @@ export function applyLogToCodingAgentSession({
       return {
         ...named,
         repositoryHost:
-          base.repositoryHost ?? str(attrs[LANGWATCH.ATTR.REPOSITORY_HOST]),
+          str(attrs[LANGWATCH.ATTR.REPOSITORY_HOST]) ?? base.repositoryHost,
         repositoryOwner:
-          base.repositoryOwner ?? str(attrs[LANGWATCH.ATTR.REPOSITORY_OWNER]),
+          str(attrs[LANGWATCH.ATTR.REPOSITORY_OWNER]) ?? base.repositoryOwner,
         repositoryName:
-          base.repositoryName ?? str(attrs[LANGWATCH.ATTR.REPOSITORY_NAME]),
-        gitWorktree: base.gitWorktree ?? str(attrs[LANGWATCH.ATTR.WORKTREE]),
+          str(attrs[LANGWATCH.ATTR.REPOSITORY_NAME]) ?? base.repositoryName,
+        gitWorktree: str(attrs[LANGWATCH.ATTR.WORKTREE]) ?? base.gitWorktree,
         gitBranch: branch ?? base.gitBranch,
         gitBranches:
           branch !== null

--- a/platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/services/session-context-memo.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/services/session-context-memo.ts
@@ -1,0 +1,174 @@
+import type { Cluster, Redis } from "ioredis";
+import type { ContributionFacts } from "../schemas/contributions";
+
+/**
+ * The LangWatch session-context vocabulary: the companion event a `langwatch
+ * ingest context` declaration arrives as, and the keys its git identity rides
+ * on. Agent-generic by construction — every agent that installs the hook sends
+ * these exact spellings. Shared by the session fold (which keeps the session
+ * row's present-tense identity) and the contribute command (which stamps each
+ * fact row with the context active when it happened).
+ */
+export const SESSION_CONTEXT_EVENT = "session_context";
+
+export const SESSION_CONTEXT_ATTR = {
+  REPOSITORY_HOST: "vcs.repository.host",
+  REPOSITORY_OWNER: "vcs.repository.owner",
+  REPOSITORY_NAME: "vcs.repository.name",
+  BRANCH: "vcs.ref.head.name",
+  WORKTREE: "vcs.worktree.name",
+} as const;
+
+/**
+ * The working context a declaration names: which repository and branch the
+ * session is on right now. The worktree is deliberately absent — attribution
+ * matches pull requests on repository and branch, and the worktree names a
+ * checkout, not a destination.
+ */
+export interface SessionWorkingContext {
+  repositoryHost: string;
+  repositoryOwner: string;
+  repositoryName: string;
+  branch: string;
+}
+
+/**
+ * The declared context off a `session_context` contribution's facts, or null
+ * when the declaration names no repository. A partial answer (repository
+ * without a branch, as on a detached HEAD) still returns, with the missing
+ * field empty; the stamper decides whether that is enough to stamp with.
+ */
+export function workingContextOfFacts(
+  facts: ContributionFacts,
+): SessionWorkingContext | null {
+  const context = {
+    repositoryHost: str(facts[SESSION_CONTEXT_ATTR.REPOSITORY_HOST]),
+    repositoryOwner: str(facts[SESSION_CONTEXT_ATTR.REPOSITORY_OWNER]),
+    repositoryName: str(facts[SESSION_CONTEXT_ATTR.REPOSITORY_NAME]),
+    branch: str(facts[SESSION_CONTEXT_ATTR.BRANCH]),
+  };
+  if (context.repositoryOwner === "" || context.repositoryName === "") {
+    return null;
+  }
+  return context;
+}
+
+/** Whether a context is complete enough to stamp fact rows with. */
+export function isStampableContext(context: SessionWorkingContext): boolean {
+  return (
+    context.repositoryHost !== "" &&
+    context.repositoryOwner !== "" &&
+    context.repositoryName !== "" &&
+    context.branch !== ""
+  );
+}
+
+/**
+ * The durable "context the session last declared" the contribute command
+ * stamps fact rows from.
+ *
+ * Correctness leans on the pipeline's own ordering guarantee, not on this
+ * store: contributions are keyed per session, one session is one queue group,
+ * and coalescing preserves the group's order (see pipeline.ts). So within a
+ * session, every `set` happens-before the `get`s of the records that follow
+ * it, and the memo never races itself.
+ *
+ * A missing answer (expired key, flushed Redis, a session that never declared)
+ * produces an unstamped row, which the usage read prices under the legacy
+ * whole-session rule — degraded attribution, never lost tokens.
+ */
+export interface SessionContextMemo {
+  get(params: {
+    tenantId: string;
+    sessionId: string;
+  }): Promise<SessionWorkingContext | null>;
+  set(params: {
+    tenantId: string;
+    sessionId: string;
+    context: SessionWorkingContext;
+  }): Promise<void>;
+}
+
+/**
+ * Matches `USAGE_SESSION_WINDOW_MS`: a session older than the usage read's own
+ * window prices nothing, so its memo has nothing left to stamp for.
+ */
+const MEMO_TTL_SECONDS = 180 * 24 * 60 * 60;
+
+const memoKey = (tenantId: string, sessionId: string): string =>
+  `coding-agent:session-context:${tenantId}:${sessionId}`;
+
+export class RedisSessionContextMemo implements SessionContextMemo {
+  constructor(private readonly redis: Redis | Cluster) {}
+
+  async get({
+    tenantId,
+    sessionId,
+  }: {
+    tenantId: string;
+    sessionId: string;
+  }): Promise<SessionWorkingContext | null> {
+    const raw = await this.redis.get(memoKey(tenantId, sessionId));
+    if (raw === null) return null;
+    try {
+      const parsed = JSON.parse(raw) as Partial<SessionWorkingContext>;
+      return {
+        repositoryHost: str(parsed.repositoryHost),
+        repositoryOwner: str(parsed.repositoryOwner),
+        repositoryName: str(parsed.repositoryName),
+        branch: str(parsed.branch),
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  async set({
+    tenantId,
+    sessionId,
+    context,
+  }: {
+    tenantId: string;
+    sessionId: string;
+    context: SessionWorkingContext;
+  }): Promise<void> {
+    await this.redis.set(
+      memoKey(tenantId, sessionId),
+      JSON.stringify(context),
+      "EX",
+      MEMO_TTL_SECONDS,
+    );
+  }
+}
+
+/** Test double, and the fallback for a preset with no Redis. */
+export class InMemorySessionContextMemo implements SessionContextMemo {
+  private readonly entries = new Map<string, SessionWorkingContext>();
+
+  async get({
+    tenantId,
+    sessionId,
+  }: {
+    tenantId: string;
+    sessionId: string;
+  }): Promise<SessionWorkingContext | null> {
+    return this.entries.get(memoKey(tenantId, sessionId)) ?? null;
+  }
+
+  async set({
+    tenantId,
+    sessionId,
+    context,
+  }: {
+    tenantId: string;
+    sessionId: string;
+    context: SessionWorkingContext;
+  }): Promise<void> {
+    this.entries.set(memoKey(tenantId, sessionId), context);
+  }
+}
+
+function str(value: string | number | boolean | undefined): string {
+  if (value === undefined) return "";
+  return String(value);
+}

--- a/platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/services/session-context-memo.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/services/session-context-memo.ts
@@ -53,7 +53,6 @@ export function workingContextOfFacts(
   return context;
 }
 
-/** Whether a context is complete enough to stamp fact rows with. */
 export function isStampableContext(context: SessionWorkingContext): boolean {
   return (
     context.repositoryHost !== "" &&
@@ -95,8 +94,13 @@ export interface SessionContextMemo {
  */
 const MEMO_TTL_SECONDS = 180 * 24 * 60 * 60;
 
-const memoKey = (tenantId: string, sessionId: string): string =>
-  `coding-agent:session-context:${tenantId}:${sessionId}`;
+const memoKey = ({
+  tenantId,
+  sessionId,
+}: {
+  tenantId: string;
+  sessionId: string;
+}): string => `coding-agent:session-context:${tenantId}:${sessionId}`;
 
 export class RedisSessionContextMemo implements SessionContextMemo {
   constructor(private readonly redis: Redis | Cluster) {}
@@ -108,7 +112,7 @@ export class RedisSessionContextMemo implements SessionContextMemo {
     tenantId: string;
     sessionId: string;
   }): Promise<SessionWorkingContext | null> {
-    const raw = await this.redis.get(memoKey(tenantId, sessionId));
+    const raw = await this.redis.get(memoKey({ tenantId, sessionId }));
     if (raw === null) return null;
     try {
       const parsed = JSON.parse(raw) as Partial<SessionWorkingContext>;
@@ -133,7 +137,7 @@ export class RedisSessionContextMemo implements SessionContextMemo {
     context: SessionWorkingContext;
   }): Promise<void> {
     await this.redis.set(
-      memoKey(tenantId, sessionId),
+      memoKey({ tenantId, sessionId }),
       JSON.stringify(context),
       "EX",
       MEMO_TTL_SECONDS,
@@ -141,9 +145,29 @@ export class RedisSessionContextMemo implements SessionContextMemo {
   }
 }
 
-/** Test double, and the fallback for a preset with no Redis. */
+/**
+ * How many sessions the no-Redis fallback keeps. A worker holds one entry per
+ * session it is currently draining, and a few hundred bytes each, so this is
+ * far above any real concurrency while still being a ceiling: without one the
+ * map grows for the life of the process.
+ */
+const IN_MEMORY_MEMO_MAX_ENTRIES = 10_000;
+
+/**
+ * Test double, and the fallback for a preset with no Redis.
+ *
+ * Bounded two ways, because a process holding this map has no Redis to expire
+ * it: entries carry the same TTL the Redis memo writes, and the map evicts its
+ * oldest entry once it is full. An evicted session stamps nothing more, which
+ * degrades to the legacy whole-session rule exactly like an expired Redis key.
+ */
 export class InMemorySessionContextMemo implements SessionContextMemo {
-  private readonly entries = new Map<string, SessionWorkingContext>();
+  private readonly entries = new Map<
+    string,
+    { context: SessionWorkingContext; expiresAtMs: number }
+  >();
+
+  constructor(private readonly now: () => number = Date.now) {}
 
   async get({
     tenantId,
@@ -152,7 +176,14 @@ export class InMemorySessionContextMemo implements SessionContextMemo {
     tenantId: string;
     sessionId: string;
   }): Promise<SessionWorkingContext | null> {
-    return this.entries.get(memoKey(tenantId, sessionId)) ?? null;
+    const key = memoKey({ tenantId, sessionId });
+    const entry = this.entries.get(key);
+    if (entry === undefined) return null;
+    if (entry.expiresAtMs <= this.now()) {
+      this.entries.delete(key);
+      return null;
+    }
+    return entry.context;
   }
 
   async set({
@@ -164,7 +195,19 @@ export class InMemorySessionContextMemo implements SessionContextMemo {
     sessionId: string;
     context: SessionWorkingContext;
   }): Promise<void> {
-    this.entries.set(memoKey(tenantId, sessionId), context);
+    const key = memoKey({ tenantId, sessionId });
+    // Re-inserting moves the key to the end of the Map's insertion order, so
+    // the eviction below always drops the least recently written session.
+    this.entries.delete(key);
+    this.entries.set(key, {
+      context,
+      expiresAtMs: this.now() + MEMO_TTL_SECONDS * 1000,
+    });
+    while (this.entries.size > IN_MEMORY_MEMO_MAX_ENTRIES) {
+      const oldest = this.entries.keys().next();
+      if (oldest.done === true) break;
+      this.entries.delete(oldest.value);
+    }
   }
 }
 

--- a/specs/coding-agent/pull-request-linkage.feature
+++ b/specs/coding-agent/pull-request-linkage.feature
@@ -323,22 +323,72 @@ Rule: The Pull Requests page prices each pull request's lifetime
 
   @unit
   Scenario: The personal page discovers pull requests from every branch a session drove
-    Given a session that drove two branches
+    Given a session that drove two branches, each with a live pull request
     When the personal pull requests are read
-    Then the pull requests of both branches are looked up
+    Then both pull requests become rows
 
-  # A session records one set of token and cost totals for its whole life and
-  # the per-call facts carry no branch, so there is nothing to divide between
-  # two pull requests. Counting the whole session toward each one would make a
-  # repository's pull requests sum to more than was ever spent. The sessions
-  # screen is where all of a session's pull requests are shown.
+Rule: A session's cost splits across the pull requests it drove, by the work stamped on each
+
+  # A session records one set of cumulative token and cost totals for its
+  # whole life; its per-call fact rows each carry the repository and branch
+  # that were active when the call happened. The fact rows set the RATIO, the
+  # cumulative totals stay the amount, and the buckets partition — so one
+  # session's shares never sum past its own total, and a repository's pull
+  # requests never sum to more than was ever spent.
 
   @unit
-  Scenario: A session that drove two pull requests counts toward only one of them
+  Scenario: A session that drove two pull requests splits its cost between them
     Given a session that drove two branches, each with a live pull request
-    When the tenure rule is asked
-    Then the session counts toward the pull request it opened first
-    And it counts toward the other one not at all
+    And its fact rows stamp a quarter of its tokens on one branch and the rest on the other
+    When each pull request's usage is read
+    Then the first reports a quarter of the session's totals
+    And the second reports the remaining three quarters
+
+  @unit
+  Scenario: Tokens stamped with no context follow the legacy whole-session rule
+    Given a session whose fact rows carry no stamped context
+    When its pull requests' usage is read
+    Then its whole total lands on the pull request it opened first
+    And the other pull requests report none of it
+
+  @unit
+  Scenario: A session with no fact rows at all keeps the legacy rule whole
+    Given a session that recorded totals but logged no per-call facts
+    When its pull requests' usage is read
+    Then its whole total lands on the pull request it opened first
+
+  @unit
+  Scenario: Tokens stamped on another repository stay out of this one
+    Given a session whose fact rows stamp work on two repositories
+    When one repository's pull request usage is read
+    Then only the tokens stamped on that repository count toward its pull request
+    And the other repository's tokens reduce the session's share rather than joining it
+
+  @unit
+  Scenario: A session found only by its stamps still counts toward the pull request
+    Given a session whose row moved on to another repository
+    And fact rows stamped on the pull request's own branch
+    When the pull request's usage is read
+    Then the session's stamped share is counted toward it
+
+  @unit
+  Scenario: The unstamped bucket is priced only where the session's row lives
+    Given a session whose row points at one repository and whose stamps name another
+    When the other repository's pull request usage is read
+    Then the session's unstamped tokens are not priced there
+
+  @unit
+  Scenario: Two pull requests on one branch split by era, not by double counting
+    Given a branch that hosted a merged pull request and later a new one
+    And a session whose fact rows stamp that branch
+    When both pull requests' usage is read
+    Then the stamped tokens count toward the branch's tenure winner only
+
+  @unit
+  Scenario: The model breakdown reports only the pull request's own calls
+    Given a session that called two models, each stamped on a different pull request
+    When one pull request's usage is read
+    Then its model breakdown reports only the model stamped on it
 
   @unit
   Scenario: A viewer without a GitHub connection sees the connect invitation

--- a/specs/coding-agent/pull-request-linkage.feature
+++ b/specs/coding-agent/pull-request-linkage.feature
@@ -7,6 +7,7 @@
 #   platform/app/src/server/app-layer/github/github-pull-request-status.service.ts    (live status, Redis-cached, never the queue)
 #   platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/subscribers/pullRequestMapping.subscriber.ts (fold trigger)
 #   platform/app/src/server/app-layer/coding-agent/pull-request-assignment.ts          (session-to-PR tenure rule)
+#   platform/app/src/server/app-layer/coding-agent/pull-request-share.ts                (the proportional rule: one session's cost split across the PRs it drove)
 #   platform/app/src/server/app-layer/coding-agent/pull-request-usage.service.ts       (org-first usage rollup)
 #   platform/app/src/server/app-layer/coding-agent/coding-agent-source-type.ts         (agent id to ingestion source type)
 #   platform/app/src/server/app-layer/coding-agent/repositories/coding-agent-session-events.repository.ts (per-model totals)
@@ -383,6 +384,21 @@ Rule: A session's cost splits across the pull requests it drove, by the work sta
     And a session whose fact rows stamp that branch
     When both pull requests' usage is read
     Then the stamped tokens count toward the branch's tenure winner only
+
+  @unit
+  Scenario: A discovered pull request with no stamped work still dates itself
+    Given a session that drove two branches, each with a live pull request
+    And its fact rows stamp all of its tokens on one branch
+    When the personal pull requests are read
+    Then the other pull request is still a row, reporting no tokens and no cost
+    And that row is dated by the pull request itself rather than by the epoch
+
+  @unit
+  Scenario: A session that priced its calls without reporting tokens splits by cost
+    Given a session that drove two branches, each with a live pull request
+    And its fact rows report cost but no token counts
+    When each pull request's usage is read
+    Then each reports the share of the cost stamped on its branch
 
   @unit
   Scenario: The model breakdown reports only the pull request's own calls

--- a/specs/coding-agent/pull-request-linkage.feature
+++ b/specs/coding-agent/pull-request-linkage.feature
@@ -386,6 +386,12 @@ Rule: A session's cost splits across the pull requests it drove, by the work sta
     Then the stamped tokens count toward the branch's tenure winner only
 
   @unit
+  Scenario: A session too small to divide is never counted twice
+    Given a session that spent one token, split evenly across two pull requests
+    When each pull request's usage is read
+    Then the two together report the one token, not one each
+
+  @unit
   Scenario: A discovered pull request with no stamped work still dates itself
     Given a session that drove two branches, each with a live pull request
     And its fact rows stamp all of its tokens on one branch

--- a/specs/coding-agent/session-git-context.feature
+++ b/specs/coding-agent/session-git-context.feature
@@ -5,6 +5,9 @@
 #   platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/subscribers/codingAgentLogFactsDispatch.subscriber.ts (declared-agent labeling, title stamp)
 #   platform/app/src/server/app-layer/traces/canonicalisation/extractors/claudeCode.ts                                (title extraction from the response body)
 #   platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/services/coding-agent-session.derivation.ts (fold semantics)
+#   platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/services/session-context-memo.ts           (the declared context the stamp reads)
+#   platform/app/src/server/event-sourcing/pipelines/coding-agent-processing/commands/contributeLogFactsCommand.ts      (where the stamp is applied)
+#   platform/app/src/server/clickhouse/migrations/00087_coding_agent_session_events_working_context.sql                  (the stamped fact columns)
 #   platform/app/src/server/clickhouse/migrations/00075_coding_agent_sessions_git_context.sql                          (session columns)
 #   platform/app/src/server/clickhouse/migrations/00077_coding_agent_sessions_git_branches.sql                         (every branch the session drove)
 #
@@ -136,6 +139,40 @@ Rule: Fact rows are stamped with the context declared before them
     Given a session whose declaration names a repository but no branch
     When a model call is contributed after it
     Then the stored fact row carries no stamped context
+
+  # The stamp is a refinement of the record, never part of it, so a memo
+  # outage costs later rows their stamp and nothing else. Those rows fall
+  # back to the legacy whole-session rule.
+
+  @unit
+  Scenario: A record whose memo cannot be read is contributed unstamped
+    Given a memo that fails every read
+    When a model call is contributed
+    Then the record is still contributed, carrying no stamped context
+
+  @unit
+  Scenario: A declaration whose memo cannot be written is still contributed
+    Given a memo that fails every write
+    When a session declares its working context
+    Then the declaration is still contributed
+
+Rule: The memo that carries the stamp forgets on its own
+
+  # The memo holds one entry per live session. Redis expires them; the
+  # no-Redis fallback has to do it itself, or a long-running process grows
+  # one entry per session it ever saw.
+
+  @unit
+  Scenario: A memo entry is forgotten once its lifetime passes
+    Given a context written to the no-Redis memo
+    When its lifetime has passed
+    Then the memo answers nothing for that session
+
+  @unit
+  Scenario: The no-Redis memo stops growing at its bound
+    Given more sessions written to the no-Redis memo than it holds
+    When the oldest session's context is read
+    Then it has been evicted, and the newest sessions are still remembered
 
 Rule: A session remembers every branch it drove
 

--- a/specs/coding-agent/session-git-context.feature
+++ b/specs/coding-agent/session-git-context.feature
@@ -73,13 +73,25 @@ Rule: The session context event joins the fold honestly
     When the contribution is dispatched
     Then no contribution reaches the session fold
 
-Rule: Git identity folds with honest semantics
+Rule: Git identity folds as the present tense, last write wins
+
+  # The session row answers where the session is NOW. A resumed session moves
+  # between branches, worktrees and even repositories, and per-branch history
+  # lives on the fact rows, so nothing is lost by letting the scalars move —
+  # while a row frozen on its first repository can never be found by the
+  # repository the session works in today.
 
   @unit
-  Scenario: Repository identity and worktree set once and do not move
+  Scenario: Repository identity and worktree follow the latest context event
     Given a session whose first context event names a repository and worktree
-    When a later context event names a different repository
-    Then the session keeps the first repository identity and worktree
+    When a later context event names a different repository and worktree
+    Then the session carries the later repository identity and worktree
+
+  @unit
+  Scenario: A context event that omits a field keeps the previous value
+    Given a session that declared a repository and worktree
+    When a later context event names only a branch
+    Then the session keeps the repository identity and worktree it had
 
   @unit
   Scenario: The branch follows the latest session context event
@@ -92,6 +104,38 @@ Rule: Git identity folds with honest semantics
     Given an admitted session context event
     When the session events fact table is projected
     Then no row is written for the context event
+
+Rule: Fact rows are stamped with the context declared before them
+
+  # The declaration itself becomes no row; instead it becomes the stamp on
+  # every row that follows it, which is what lets a session's cost split
+  # across the pull requests it drove. The stamp is applied where the
+  # pipeline already guarantees per-session ordering (the contribution
+  # command lane), so there is no re-fold and no read-time time matching.
+
+  @unit
+  Scenario: A model call after a declaration carries the declared context
+    Given a session that declared a repository and branch
+    When a model call is contributed after it
+    Then the stored fact row carries that repository and branch
+
+  @unit
+  Scenario: A model call before any declaration is stored unstamped
+    Given a session that has not declared a working context
+    When a model call is contributed
+    Then the stored fact row carries no repository and no branch
+
+  @unit
+  Scenario: A new declaration moves the stamp for the rows that follow
+    Given a session that declared one branch and then declared another
+    When model calls are contributed after each declaration
+    Then each fact row carries the branch declared before it
+
+  @unit
+  Scenario: A declaration with no branch stamps nothing
+    Given a session whose declaration names a repository but no branch
+    When a model call is contributed after it
+    Then the stored fact row carries no stamped context
 
 Rule: A session remembers every branch it drove
 


### PR DESCRIPTION
## Problem

The pull request usage rollup assigns each coding-agent session to at most one pull request: the earliest one still alive at session start, charged with the session's whole lifetime-cumulative total. That rule was correct when the per-call facts carried no branch, because there was nothing to divide by.

The background agents broke this assumption. They run `claude --resume <same-id>` for weeks, across many branches and several repositories. One session accumulates hundreds of millions of tokens, all of which land on one pull request from weeks ago. Every other pull request the session drove reports zero. A second defect made it worse: the session fold set `RepositoryHost/Owner/Name` once, so a resumed session that moved to another repository could never be matched there at all.

## Design: stamped facts

Each per-call fact row in `coding_agent_session_events` now carries the repository and branch that were active when the call happened. The stamp comes from the session's own `langwatch ingest context` declarations (agent-plugin 1.1.0 makes sessions declare on every switch).

**Where the stamp is computed.** The contribution command lane is the one place with both per-session ordering (one session is one queue group, coalescing preserves order) and the ability to hold state. `ContributeLogFactsCommand` now carries a small Redis memo: a `session_context` contribution writes it, every row-bearing contribution reads it onto the event before the event is appended. The map projection stays pure and only copies the fields. Replays are deterministic because the stamp lives in the event data.

**How the read splits.** Per session, the fact rows set the ratio and the cumulative counters stay the amount:

```
share      = event tokens stamped on this pull request / all event tokens
PR portion = share x the session's cumulative counters
```

Three buckets partition a session's event tokens, so shares never sum past one and a repository's pull requests never sum to more than was spent:

- Stamped on this repository: goes to the branch's tenure winner (per-branch rule, new `assignDrivingSessionsToPullRequestsPerBranch`).
- Stamped on another repository: counts in the denominator only; that repository's own read prices it.
- Unstamped (history, sessions that never declared): follows the legacy whole-session rule, and only in the repository the session's row points at. A session with no fact rows keeps the legacy rule whole, so nothing regresses to zero.

**Discovery.** The stamps also discover sessions: `listSessionsByStampedBranch` finds a session for a pull request even after the session's row moved to another repository. The fold's repository fields are now last-write-wins (present tense), since per-branch history lives on the fact rows.

The model breakdown is filtered the same way, so a pull request reports only its own calls. The personal page discovers a row for every pull request a session drove, each priced by its own share.

## Migration

`00087` adds `RepositoryHost`, `RepositoryOwner`, `RepositoryName`, `Branch` (all `LowCardinality(String) DEFAULT ''`) to `coding_agent_session_events`. No backfill: an empty stamp means the row predates the stamp, and those rows behave exactly as today.

## Specs and tests

- `specs/coding-agent/pull-request-linkage.feature`: new rule "A session's cost splits across the pull requests it drove" with 8 bound scenarios; the all-or-nothing scenario is replaced.
- `specs/coding-agent/session-git-context.feature`: git identity folds last-write-wins; new rule "Fact rows are stamped with the context declared before them" with 4 bound scenarios.
- 367 unit tests and 52 integration tests pass on the touched areas; `check-feature-parity` reports all scenarios bound for both feature files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Coding-agent usage can now be attributed across multiple pull requests by repository branch.
  * Costs are proportionally allocated using per-call repository and branch context.
  * Sessions can be discovered from stamped working-context activity.
  * Git repository and branch context updates as sessions move between locations.
  * Pull-request usage includes per-model breakdowns and more accurate activity dates.

* **Bug Fixes**
  * Unstamped activity retains whole-session attribution.
  * Activity from unrelated repositories is excluded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->