### PR TITLE
fix(automations): keep long filter values clamped inside their chip

### DIFF
--- a/platform/app/src/components/analytics/reports/GraphFilterIndicator.tsx
+++ b/platform/app/src/components/analytics/reports/GraphFilterIndicator.tsx
@@ -19,7 +19,7 @@ export function GraphFilterIndicator({ filters }: GraphFilterIndicatorProps) {
           height="100%"
           textWrap="wrap"
         >
-          <FilterDisplay filters={filters} />
+          <FilterDisplay filters={filters} clampValues={false} />
         </VStack>
       }
       positioning={{ placement: "top" }}

--- a/platform/app/src/components/automations/FilterDisplay.tsx
+++ b/platform/app/src/components/automations/FilterDisplay.tsx
@@ -54,7 +54,10 @@ const FilterLabel = ({ children }: { children: React.ReactNode }) => {
 
 const FilterValue = ({ children }: { children: React.ReactNode }) => {
   return (
-    <Box padding={1} borderRightRadius="md">
+    // minWidth 0 opts out of the flex child's min-width: auto, so a long
+    // unbreakable value (a monitor id) clamps inside the chip instead of
+    // widening it past its border.
+    <Box padding={1} borderRightRadius="md" minWidth={0} overflow="hidden">
       <HoverableBigText lineClamp={1} expandable={false}>
         {children}
       </HoverableBigText>

--- a/platform/app/src/components/automations/FilterDisplay.tsx
+++ b/platform/app/src/components/automations/FilterDisplay.tsx
@@ -28,7 +28,8 @@ const FilterContainer = ({
     gap={2}
     paddingX={2}
     paddingY={1}
-    border={hasBorder ? "1px solid lightgray" : "none"}
+    border={hasBorder ? "1px solid" : "none"}
+    borderColor={hasBorder ? "border.muted" : undefined}
     borderRadius="md"
   >
     <Box color="fg.subtle">

--- a/platform/app/src/components/automations/FilterDisplay.tsx
+++ b/platform/app/src/components/automations/FilterDisplay.tsx
@@ -5,6 +5,12 @@ import { HoverableBigText } from "../HoverableBigText";
 interface FilterDisplayProps {
   filters: string | Record<string, any>;
   hasBorder?: boolean;
+  /**
+   * Clamp each value to a single line, revealing the rest on hover. Turn this
+   * off where the chip is already inside a tooltip: there is no room for a
+   * second hover, so the value has to wrap instead.
+   */
+  clampValues?: boolean;
 }
 
 const FilterContainer = ({
@@ -52,7 +58,23 @@ const FilterLabel = ({ children }: { children: React.ReactNode }) => {
   );
 };
 
-const FilterValue = ({ children }: { children: React.ReactNode }) => {
+const FilterValue = ({
+  children,
+  clamp = true,
+}: {
+  children: React.ReactNode;
+  clamp?: boolean;
+}) => {
+  if (!clamp) {
+    // Already inside a tooltip: wrap instead, and break mid-token so an
+    // unbreakable id cannot run past the tooltip edge.
+    return (
+      <Box padding={1} minWidth={0} overflowWrap="anywhere">
+        {children}
+      </Box>
+    );
+  }
+
   return (
     // minWidth 0 opts out of the flex child's min-width: auto, so a long
     // unbreakable value (a monitor id) clamps inside the chip instead of
@@ -68,6 +90,7 @@ const FilterValue = ({ children }: { children: React.ReactNode }) => {
 export const FilterDisplay = ({
   filters,
   hasBorder = false,
+  clampValues = true,
 }: FilterDisplayProps) => {
   const applyFilters = (filters: string | Record<string, any>) => {
     const obj = typeof filters === "string" ? JSON.parse(filters) : filters;
@@ -78,7 +101,7 @@ export const FilterDisplay = ({
         result.push(
           <FilterContainer key={key} hasBorder={hasBorder}>
             <FilterLabel>{key}</FilterLabel>
-            <FilterValue>{value.join(", ")}</FilterValue>
+            <FilterValue clamp={clampValues}>{value.join(", ")}</FilterValue>
           </FilterContainer>,
         );
       } else if (typeof value === "object" && value !== null) {
@@ -102,14 +125,16 @@ export const FilterDisplay = ({
         result.push(
           <FilterContainer key={key} hasBorder={hasBorder}>
             <FilterLabel>{key}</FilterLabel>
-            <FilterValue>{nestedResult.join("; ")}</FilterValue>
+            <FilterValue clamp={clampValues}>
+              {nestedResult.join("; ")}
+            </FilterValue>
           </FilterContainer>,
         );
       } else {
         result.push(
           <FilterContainer key={key} fontSize="xs" hasBorder={hasBorder}>
             <FilterLabel>{key}</FilterLabel>
-            <FilterValue>{String(value)}</FilterValue>
+            <FilterValue clamp={clampValues}>{String(value)}</FilterValue>
           </FilterContainer>,
         );
       }

--- a/platform/app/src/components/automations/__tests__/FilterDisplay.integration.test.tsx
+++ b/platform/app/src/components/automations/__tests__/FilterDisplay.integration.test.tsx
@@ -6,10 +6,13 @@ import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 import { FilterDisplay } from "../FilterDisplay";
 
-const renderFilters = (filters: Record<string, unknown>) =>
+const renderFilters = (
+  filters: Record<string, unknown>,
+  props: { clampValues?: boolean } = {},
+) =>
   render(
     <ChakraProvider value={defaultSystem}>
-      <FilterDisplay filters={filters} hasBorder={true} />
+      <FilterDisplay filters={filters} hasBorder={true} {...props} />
     </ChakraProvider>,
   );
 
@@ -42,6 +45,32 @@ describe("FilterDisplay", () => {
       const text = screen.getByText(LONG_VALUE);
       const clamped = getComputedStyle(text.closest("div")!);
       expect(clamped.webkitLineClamp).toBe("1");
+    });
+  });
+
+  // The graph filter indicator renders this inside a tooltip, where clamping
+  // hides the rest of the value behind a hover the user cannot perform.
+  describe("when clamping is turned off", () => {
+    it("wraps the value instead of clamping it to one line", () => {
+      renderFilters(
+        { "trace_checks.check_id": [LONG_VALUE] },
+        { clampValues: false },
+      );
+
+      const style = getComputedStyle(screen.getByText(LONG_VALUE));
+      expect(style.webkitLineClamp).not.toBe("1");
+      expect(style.overflow).not.toBe("hidden");
+    });
+
+    it("breaks mid-token so an unbreakable id cannot run past its container", () => {
+      renderFilters(
+        { "trace_checks.check_id": [LONG_VALUE] },
+        { clampValues: false },
+      );
+
+      const style = getComputedStyle(screen.getByText(LONG_VALUE));
+      expect(style.overflowWrap).toBe("anywhere");
+      expect(style.minWidth).toBe("0px");
     });
   });
 });

--- a/platform/app/src/components/automations/__tests__/FilterDisplay.integration.test.tsx
+++ b/platform/app/src/components/automations/__tests__/FilterDisplay.integration.test.tsx
@@ -58,8 +58,10 @@ describe("FilterDisplay", () => {
       );
 
       const style = getComputedStyle(screen.getByText(LONG_VALUE));
-      expect(style.webkitLineClamp).not.toBe("1");
-      expect(style.overflow).not.toBe("hidden");
+      // Asserted as absent rather than "not 1": a negative assertion would
+      // also pass if the styles had never applied at all.
+      expect(style.webkitLineClamp).toBe("");
+      expect(style.overflow).toBe("");
     });
 
     it("breaks mid-token so an unbreakable id cannot run past its container", () => {

--- a/platform/app/src/components/automations/__tests__/FilterDisplay.integration.test.tsx
+++ b/platform/app/src/components/automations/__tests__/FilterDisplay.integration.test.tsx
@@ -1,0 +1,47 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { FilterDisplay } from "../FilterDisplay";
+
+const renderFilters = (filters: Record<string, unknown>) =>
+  render(
+    <ChakraProvider value={defaultSystem}>
+      <FilterDisplay filters={filters} hasBorder={true} />
+    </ChakraProvider>,
+  );
+
+// One unbreakable token, the shape of a monitor id. Without min-width: 0 on
+// the flex child, its min-content width beats the chip's border and the text
+// bleeds into the next table column.
+const LONG_VALUE = "monitor_0008KDW6ykSweqn6dwR0UukEOi2wAbCdEfGhIjKlMnOpQrSt";
+
+describe("FilterDisplay", () => {
+  afterEach(() => cleanup());
+
+  describe("when a filter value is one long unbreakable token", () => {
+    it("lets the value's flex child shrink below its content width", () => {
+      renderFilters({ "trace_checks.check_id": [LONG_VALUE] });
+
+      const text = screen.getByText(LONG_VALUE);
+      // The clamped text box sits inside FilterValue's Box, the flex child of
+      // the chip's HStack. Flex children default to min-width: auto, which is
+      // the defect: the chip cannot shrink it, so it must opt out.
+      const flexChild = text.closest("div")?.parentElement;
+      expect(flexChild).toBeTruthy();
+      const style = getComputedStyle(flexChild!);
+      expect(style.minWidth).toBe("0px");
+      expect(style.overflow).toBe("hidden");
+    });
+
+    it("keeps the value clamped to one line inside the chip", () => {
+      renderFilters({ "trace_checks.check_id": [LONG_VALUE] });
+
+      const text = screen.getByText(LONG_VALUE);
+      const clamped = getComputedStyle(text.closest("div")!);
+      expect(clamped.webkitLineClamp).toBe("1");
+    });
+  });
+});

--- a/platform/app/src/features/automations/components/page/AutomationTableCells.tsx
+++ b/platform/app/src/features/automations/components/page/AutomationTableCells.tsx
@@ -258,6 +258,13 @@ export function ReportRunCells({
  *  automation tables get their shared polish — a quiet uppercase header on a
  *  tinted strip, generous row height, and a soft hover — so no per-page table
  *  markup has to repeat it. */
+/**
+ * Width below which these tables scroll instead of shrinking. Without a floor,
+ * `width="full"` makes the table fit the shell at any cost, and the cost is the
+ * Name column collapsing to its longest single word.
+ */
+export const TABLE_MIN_WIDTH = "1000px";
+
 export function TableShell({ children }: { children: React.ReactNode }) {
   return (
     <Box

--- a/platform/app/src/features/automations/components/page/AutomationTableCells.tsx
+++ b/platform/app/src/features/automations/components/page/AutomationTableCells.tsx
@@ -258,13 +258,6 @@ export function ReportRunCells({
  *  automation tables get their shared polish — a quiet uppercase header on a
  *  tinted strip, generous row height, and a soft hover — so no per-page table
  *  markup has to repeat it. */
-/**
- * Width below which these tables scroll instead of shrinking. Without a floor,
- * `width="full"` makes the table fit the shell at any cost, and the cost is the
- * Name column collapsing to its longest single word.
- */
-export const TABLE_MIN_WIDTH = "1000px";
-
 export function TableShell({ children }: { children: React.ReactNode }) {
   return (
     <Box
@@ -277,6 +270,12 @@ export function TableShell({ children }: { children: React.ReactNode }) {
       <Box
         overflowX="auto"
         css={{
+          // Percentage column widths only bind under a fixed layout, and they
+          // only mean anything above a floor: without one, `width="full"`
+          // shrinks the table to the shell at any cost, and the cost is the
+          // Name column collapsing to its longest single word. Below this the
+          // shell scrolls instead.
+          "& table": { tableLayout: "fixed", minWidth: "1000px" },
           "& thead th": {
             backgroundColor: "var(--chakra-colors-bg-subtle)",
             fontSize: "11px",

--- a/platform/app/src/pages/[project]/automations.tsx
+++ b/platform/app/src/pages/[project]/automations.tsx
@@ -977,17 +977,20 @@ function AutomationsPage() {
                                       {trigger.filterQuery ? (
                                         // ADR-043: a trace-subject automation shows
                                         // its search query.
-                                        <Code
-                                          size="sm"
-                                          variant="surface"
-                                          display="block"
-                                          minWidth={0}
+                                        <HoverableBigText
                                           lineClamp={2}
-                                          wordBreak="break-word"
-                                          title={trigger.filterQuery}
+                                          expandedVersion={trigger.filterQuery}
                                         >
-                                          {trigger.filterQuery}
-                                        </Code>
+                                          <Code
+                                            size="sm"
+                                            variant="surface"
+                                            display="block"
+                                            minWidth={0}
+                                            wordBreak="break-word"
+                                          >
+                                            {trigger.filterQuery}
+                                          </Code>
+                                        </HoverableBigText>
                                       ) : trigger.filters &&
                                         typeof trigger.filters === "string" &&
                                         trigger.filters !== "{}" ? (
@@ -1003,18 +1006,24 @@ function AutomationsPage() {
                                       <Text textStyle="sm" fontWeight="medium">
                                         {triggerActionName(trigger.action)}
                                       </Text>
-                                      <Box
+                                      {/* Clamped, so it needs a reveal: the
+                                          destination (a long email, a webhook
+                                          URL) is the whole point of the cell.
+                                          Not expandable — the dialog wants a
+                                          string and these are nodes. */}
+                                      <HoverableBigText
                                         textStyle="xs"
                                         color="fg.muted"
                                         width="full"
                                         lineClamp={2}
                                         overflowWrap="anywhere"
+                                        expandable={false}
                                       >
                                         {actionItems(
                                           trigger.action,
                                           actionParams,
                                         )}
-                                      </Box>
+                                      </HoverableBigText>
                                     </VStack>
                                   </Table.Cell>
                                   <Table.Cell whiteSpace="nowrap">

--- a/platform/app/src/pages/[project]/automations.tsx
+++ b/platform/app/src/pages/[project]/automations.tsx
@@ -44,7 +44,6 @@ import {
   ReportRunCells,
   ReportSubjectCell,
   SectionHeader,
-  TABLE_MIN_WIDTH,
   TableShell,
 } from "~/features/automations/components/page/AutomationTableCells";
 import { RUNAWAY_PAUSE_REASON } from "~/features/automations/logic/pauseReasons";
@@ -572,12 +571,7 @@ function AutomationsPage() {
                     />
                   ) : (
                     <TableShell>
-                      <Table.Root
-                        variant="line"
-                        width="full"
-                        minWidth={TABLE_MIN_WIDTH}
-                        style={{ tableLayout: "fixed" }}
-                      >
+                      <Table.Root variant="line" width="full">
                         <Table.Header>
                           <Table.Row>
                             <Table.ColumnHeader width="20%">
@@ -780,21 +774,16 @@ function AutomationsPage() {
                     </EmptyHint>
                   ) : (
                     <TableShell>
-                      <Table.Root
-                        variant="line"
-                        width="full"
-                        minWidth={TABLE_MIN_WIDTH}
-                        style={{ tableLayout: "fixed" }}
-                      >
+                      <Table.Root variant="line" width="full">
                         <Table.Header>
                           <Table.Row>
-                            <Table.ColumnHeader width="22%">
+                            <Table.ColumnHeader width="20%">
                               Name
                             </Table.ColumnHeader>
-                            <Table.ColumnHeader width="20%">
+                            <Table.ColumnHeader width="18%">
                               Sends
                             </Table.ColumnHeader>
-                            <Table.ColumnHeader width="14%" whiteSpace="nowrap">
+                            <Table.ColumnHeader width="18%" whiteSpace="nowrap">
                               Schedule
                             </Table.ColumnHeader>
                             <Table.ColumnHeader width="12%" whiteSpace="nowrap">
@@ -861,7 +850,13 @@ function AutomationsPage() {
                                       graphNameById={graphNameById}
                                     />
                                   </Table.Cell>
-                                  <Table.Cell whiteSpace="nowrap">
+                                  {/* No nowrap here: a cadence plus an IANA
+                                      zone ("Weekly · Monday 09:00
+                                      Europe/Amsterdam") is far wider than this
+                                      column, and under a fixed layout a
+                                      nowrap cell prints straight over its
+                                      neighbour instead of widening. */}
+                                  <Table.Cell>
                                     <Text textStyle="sm">
                                       {schedule?.cron
                                         ? describeSchedule(
@@ -916,12 +911,7 @@ function AutomationsPage() {
                     />
                   ) : (
                     <TableShell>
-                      <Table.Root
-                        variant="line"
-                        width="full"
-                        minWidth={TABLE_MIN_WIDTH}
-                        style={{ tableLayout: "fixed" }}
-                      >
+                      <Table.Root variant="line" width="full">
                         <Table.Header>
                           <Table.Row>
                             <Table.ColumnHeader width="24%">

--- a/platform/app/src/pages/[project]/automations.tsx
+++ b/platform/app/src/pages/[project]/automations.tsx
@@ -348,7 +348,10 @@ function AutomationsPage() {
 
   const FilterValue = ({ children }: { children: React.ReactNode }) => {
     return (
-      <Box padding={1} borderRightRadius="md">
+      // minWidth 0 opts out of the flex child's min-width: auto, so a long
+      // unbreakable value (a monitor id) clamps inside the chip instead of
+      // widening it past its border.
+      <Box padding={1} borderRightRadius="md" minWidth={0} overflow="hidden">
         <HoverableBigText lineClamp={1} expandable={false}>
           {children}
         </HoverableBigText>

--- a/platform/app/src/pages/[project]/automations.tsx
+++ b/platform/app/src/pages/[project]/automations.tsx
@@ -44,6 +44,7 @@ import {
   ReportRunCells,
   ReportSubjectCell,
   SectionHeader,
+  TABLE_MIN_WIDTH,
   TableShell,
 } from "~/features/automations/components/page/AutomationTableCells";
 import { RUNAWAY_PAUSE_REASON } from "~/features/automations/logic/pauseReasons";
@@ -571,29 +572,42 @@ function AutomationsPage() {
                     />
                   ) : (
                     <TableShell>
-                      <Table.Root variant="line" width="full">
+                      <Table.Root
+                        variant="line"
+                        width="full"
+                        minWidth={TABLE_MIN_WIDTH}
+                        style={{ tableLayout: "fixed" }}
+                      >
                         <Table.Header>
                           <Table.Row>
-                            <Table.ColumnHeader>Name</Table.ColumnHeader>
-                            <Table.ColumnHeader>Watches</Table.ColumnHeader>
-                            <Table.ColumnHeader whiteSpace="nowrap">
+                            <Table.ColumnHeader width="20%">
+                              Name
+                            </Table.ColumnHeader>
+                            <Table.ColumnHeader width="20%">
+                              Watches
+                            </Table.ColumnHeader>
+                            <Table.ColumnHeader width="14%" whiteSpace="nowrap">
                               Fires when
                             </Table.ColumnHeader>
-                            <Table.ColumnHeader>Notifies</Table.ColumnHeader>
-                            <Table.ColumnHeader whiteSpace="nowrap">
+                            <Table.ColumnHeader width="14%">
+                              Notifies
+                            </Table.ColumnHeader>
+                            <Table.ColumnHeader width="12%" whiteSpace="nowrap">
                               <MetricHeader
                                 label="Last fired"
                                 help="When this alert last crossed its threshold and notified you."
                               />
                             </Table.ColumnHeader>
-                            <Table.ColumnHeader whiteSpace="nowrap">
+                            <Table.ColumnHeader width="9%" whiteSpace="nowrap">
                               <MetricHeader
                                 label="Status"
                                 help="Firing while the metric is past its threshold, back to OK when it recovers."
                               />
                             </Table.ColumnHeader>
-                            <Table.ColumnHeader>Active</Table.ColumnHeader>
-                            <Table.ColumnHeader />
+                            <Table.ColumnHeader width="6%">
+                              Active
+                            </Table.ColumnHeader>
+                            <Table.ColumnHeader width="5%" />
                           </Table.Row>
                         </Table.Header>
                         <Table.Body>
@@ -766,29 +780,42 @@ function AutomationsPage() {
                     </EmptyHint>
                   ) : (
                     <TableShell>
-                      <Table.Root variant="line" width="full">
+                      <Table.Root
+                        variant="line"
+                        width="full"
+                        minWidth={TABLE_MIN_WIDTH}
+                        style={{ tableLayout: "fixed" }}
+                      >
                         <Table.Header>
                           <Table.Row>
-                            <Table.ColumnHeader>Name</Table.ColumnHeader>
-                            <Table.ColumnHeader>Sends</Table.ColumnHeader>
-                            <Table.ColumnHeader whiteSpace="nowrap">
+                            <Table.ColumnHeader width="22%">
+                              Name
+                            </Table.ColumnHeader>
+                            <Table.ColumnHeader width="20%">
+                              Sends
+                            </Table.ColumnHeader>
+                            <Table.ColumnHeader width="14%" whiteSpace="nowrap">
                               Schedule
                             </Table.ColumnHeader>
-                            <Table.ColumnHeader whiteSpace="nowrap">
+                            <Table.ColumnHeader width="12%" whiteSpace="nowrap">
                               <MetricHeader
                                 label="Next run"
                                 help="When this next goes out, straight from the scheduler. A paused schedule has no next run."
                               />
                             </Table.ColumnHeader>
-                            <Table.ColumnHeader whiteSpace="nowrap">
+                            <Table.ColumnHeader width="12%" whiteSpace="nowrap">
                               <MetricHeader
                                 label="Last run"
                                 help="The last time this was sent."
                               />
                             </Table.ColumnHeader>
-                            <Table.ColumnHeader>Delivery</Table.ColumnHeader>
-                            <Table.ColumnHeader>Active</Table.ColumnHeader>
-                            <Table.ColumnHeader />
+                            <Table.ColumnHeader width="9%">
+                              Delivery
+                            </Table.ColumnHeader>
+                            <Table.ColumnHeader width="6%">
+                              Active
+                            </Table.ColumnHeader>
+                            <Table.ColumnHeader width="5%" />
                           </Table.Row>
                         </Table.Header>
                         <Table.Body>
@@ -889,26 +916,39 @@ function AutomationsPage() {
                     />
                   ) : (
                     <TableShell>
-                      <Table.Root variant="line" width="full">
+                      <Table.Root
+                        variant="line"
+                        width="full"
+                        minWidth={TABLE_MIN_WIDTH}
+                        style={{ tableLayout: "fixed" }}
+                      >
                         <Table.Header>
                           <Table.Row>
-                            <Table.ColumnHeader>Name</Table.ColumnHeader>
-                            <Table.ColumnHeader>Acts on</Table.ColumnHeader>
-                            <Table.ColumnHeader>Then</Table.ColumnHeader>
-                            <Table.ColumnHeader whiteSpace="nowrap">
+                            <Table.ColumnHeader width="24%">
+                              Name
+                            </Table.ColumnHeader>
+                            <Table.ColumnHeader width="25%">
+                              Acts on
+                            </Table.ColumnHeader>
+                            <Table.ColumnHeader width="17%">
+                              Then
+                            </Table.ColumnHeader>
+                            <Table.ColumnHeader width="13%" whiteSpace="nowrap">
                               <MetricHeader
                                 label="Last fired"
                                 help="When this automation last matched a trace and ran its action. Automations on a digest schedule also show when the next bundled send is due."
                               />
                             </Table.ColumnHeader>
-                            <Table.ColumnHeader whiteSpace="nowrap">
+                            <Table.ColumnHeader width="10%" whiteSpace="nowrap">
                               <MetricHeader
                                 label="Fires (30d)"
                                 help="Times this automation fired in the last 30 days."
                               />
                             </Table.ColumnHeader>
-                            <Table.ColumnHeader>Active</Table.ColumnHeader>
-                            <Table.ColumnHeader />
+                            <Table.ColumnHeader width="6%">
+                              Active
+                            </Table.ColumnHeader>
+                            <Table.ColumnHeader width="5%" />
                           </Table.Row>
                         </Table.Header>
                         <Table.Body>
@@ -932,8 +972,12 @@ function AutomationsPage() {
                                   <Table.Cell fontWeight="medium">
                                     {trigger.name}
                                   </Table.Cell>
-                                  <Table.Cell maxWidth="360px">
-                                    <VStack gap={2} align="stretch">
+                                  <Table.Cell>
+                                    <VStack
+                                      gap={2}
+                                      align="stretch"
+                                      minWidth={0}
+                                    >
                                       {applyChecks(
                                         trigger.checks?.filter(
                                           (check): check is Monitor => !!check,
@@ -946,8 +990,11 @@ function AutomationsPage() {
                                         <Code
                                           size="sm"
                                           variant="surface"
-                                          whiteSpace="pre-wrap"
+                                          display="block"
+                                          minWidth={0}
+                                          lineClamp={2}
                                           wordBreak="break-word"
+                                          title={trigger.filterQuery}
                                         >
                                           {trigger.filterQuery}
                                         </Code>
@@ -962,11 +1009,17 @@ function AutomationsPage() {
                                     </VStack>
                                   </Table.Cell>
                                   <Table.Cell>
-                                    <VStack align="start" gap={0}>
+                                    <VStack align="start" gap={0} minWidth={0}>
                                       <Text textStyle="sm" fontWeight="medium">
                                         {triggerActionName(trigger.action)}
                                       </Text>
-                                      <Box textStyle="xs" color="fg.muted">
+                                      <Box
+                                        textStyle="xs"
+                                        color="fg.muted"
+                                        width="full"
+                                        lineClamp={2}
+                                        overflowWrap="anywhere"
+                                      >
                                         {actionItems(
                                           trigger.action,
                                           actionParams,


### PR DESCRIPTION
## For humans

In the automations list, a filter chip showing a long value with no spaces (like a monitor id) stretched past its own border and overlapped the next column. The value now stays on one line inside the chip, cut off with the full text still available on hover.

## Cause

`FilterValue`'s box is a flex child of the chip's `HStack`. Flex children default to `min-width: auto`, so one unbreakable token set the box's minimum width to the full text width — wider than the chip — and the one-line clamp never engaged. Short values fit, which is why only long names overflowed.

- `platform/app/src/components/automations/FilterDisplay.tsx:55` (shared component, used for `trigger.filters`)
- `platform/app/src/pages/[project]/automations.tsx` inline duplicate (`applyChecks` evaluations chip)

Fix: `minWidth={0}` + `overflow="hidden"` on the flex child, both copies.

## Evidence

Regression test written first and failed on the defect:

```
FAIL  FilterDisplay.integration.test.tsx > lets the value's flex child shrink below its content width
AssertionError: expected 'auto' to be '0px'
```

After the fix: 2 passed. Full automations component suites: 17 files, 159 tests passed. `pnpm typecheck:all` green, biome 0 errors on touched files.

## Sweep

Same shape checked across every `HoverableBigText` consumer:

- Safe: `TryItOut.tsx` (table cell, not a flex child), `EvaluationStatusItem.tsx` (values use `wordBreak: break-word`), `BatchEvaluationV2EvaluationResult.tsx` (`maxWidth` caps the minimum).
- Same shape, unverified, deliberately not touched (no report, partial guards of their own): `StudioDrawerWrapper.tsx:136`, `BasePropertiesPanel.tsx:616`, `BatchEvaluationSummary.tsx:81`, `NodeDraggable.tsx:130`.

## Not fixed on purpose

The page keeps its inline duplicate of `FilterDisplay`'s internals — merging them means reconciling diverged styles (`fg.muted` vs `fg.subtle`, border tokens), a visual decision beyond this bug.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Long, unbroken filter values in Automations now stay within their chips instead of expanding beyond the border.
  - Oversized values are constrained and truncated to improve readability.
  - Analytics report tooltips can wrap long filter values to keep the full value visible.
  - Automation, alert, and schedule tables now maintain readable column layouts, wrapping content or enabling horizontal scrolling when needed.
  - Filter containers now use the theme’s muted border color for visual consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Browser proof

Verified in the running app (Playwright, real data): a long monitor id clamps to one line with an ellipsis inside the chip, the hover tooltip shows the full value, and a short chip is unchanged. Measured in the live DOM: value right edge 926px ≤ chip 939px ≤ cell 947px, and the flex child computes `min-width: 0`.

![after fix: long value clamped in chip with tooltip](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-7760/automations-chip-fix.png)
