### PR TITLE
feat(experiments-v3): a connected agent is a column in the workbench

### DIFF
--- a/platform/app/src/components/agents/AgentCard.tsx
+++ b/platform/app/src/components/agents/AgentCard.tsx
@@ -10,6 +10,7 @@ import {
 import {
   ArrowUp,
   Bot,
+  Cable,
   Code,
   Copy,
   ExternalLink,
@@ -35,6 +36,7 @@ const agentTypeIcons: Record<string, LucideIcon> = {
   code: Code,
   http: Globe,
   workflow: Workflow,
+  connected: Cable,
 };
 
 const agentTypeLabels: Record<string, string> = {
@@ -42,6 +44,7 @@ const agentTypeLabels: Record<string, string> = {
   code: "Code",
   http: "HTTP",
   workflow: "Workflow",
+  connected: "Connected",
 };
 
 /** The class that keeps a click inside the card menu out of the card click. */

--- a/platform/app/src/components/agents/AgentCard.tsx
+++ b/platform/app/src/components/agents/AgentCard.tsx
@@ -10,7 +10,6 @@ import {
 import {
   ArrowUp,
   Bot,
-  Cable,
   Code,
   Copy,
   ExternalLink,
@@ -26,20 +25,25 @@ import type { ReactNode } from "react";
 import { LuClock, LuPencil, LuTrash2 } from "react-icons/lu";
 import { LangyContextTarget } from "~/features/langy/components/LangyContextTarget";
 import { agentContextChip } from "~/features/langy/logic/langyContextChips";
-import type { TypedAgent } from "~/server/agents/agent.repository";
+import type { AgentType, TypedAgent } from "~/server/agents/agent.repository";
 import { formatTimeAgo } from "~/utils/formatTimeAgo";
 import { Menu } from "../ui/menu";
 import { agentHasDevTunnel, LocalTunnelBadge } from "./LocalTunnelBadge";
 
-const agentTypeIcons: Record<string, LucideIcon> = {
+/**
+ * The icon and the label per agent type. Both maps are keyed by the whole
+ * enum, so a new agent type does not compile until it names its icon and its
+ * word here, and no fallback stands in for it in silence.
+ */
+const agentTypeIcons: Record<AgentType, LucideIcon> = {
   signature: MessageSquare,
   code: Code,
   http: Globe,
   workflow: Workflow,
-  connected: Cable,
+  connected: Bot,
 };
 
-const agentTypeLabels: Record<string, string> = {
+const agentTypeLabels: Record<AgentType, string> = {
   signature: "Prompt",
   code: "Code",
   http: "HTTP",
@@ -155,8 +159,8 @@ export function AgentCardIcon({ icon: Icon }: { icon: LucideIcon }) {
   );
 }
 
-function AgentTypeIcon({ type }: { type: string }) {
-  return <AgentCardIcon icon={agentTypeIcons[type] ?? Bot} />;
+function AgentTypeIcon({ type }: { type: AgentType }) {
+  return <AgentCardIcon icon={agentTypeIcons[type]} />;
 }
 
 export type AgentCardProps = {
@@ -185,7 +189,7 @@ export function AgentCard({
   onViewHistory,
   onTest,
 }: AgentCardProps) {
-  const typeLabel = agentTypeLabels[agent.type] ?? agent.type;
+  const typeLabel = agentTypeLabels[agent.type];
 
   const isCopiedAgent = !!agent.copiedFromAgentId;
   const hasCopies = (agent._count?.copiedAgents ?? 0) > 0;

--- a/platform/app/src/components/agents/AgentListDrawer.tsx
+++ b/platform/app/src/components/agents/AgentListDrawer.tsx
@@ -10,6 +10,7 @@ import {
 import { formatDistanceToNow } from "date-fns";
 import {
   Bot,
+  Cable,
   Code,
   Globe,
   MessageSquare,
@@ -306,6 +307,7 @@ const agentTypeIcons: Record<string, typeof MessageSquare> = {
   code: Code,
   workflow: Workflow,
   http: Globe,
+  connected: Cable,
 };
 
 const agentTypeLabels: Record<string, string> = {
@@ -313,6 +315,7 @@ const agentTypeLabels: Record<string, string> = {
   code: "Code",
   workflow: "Workflow",
   http: "HTTP",
+  connected: "Connected",
 };
 
 type AgentCardProps = {

--- a/platform/app/src/components/agents/AgentListDrawer.tsx
+++ b/platform/app/src/components/agents/AgentListDrawer.tsx
@@ -10,7 +10,6 @@ import {
 import { formatDistanceToNow } from "date-fns";
 import {
   Bot,
-  Cable,
   Code,
   Globe,
   MessageSquare,
@@ -32,7 +31,7 @@ import {
   useDrawer,
 } from "~/hooks/useDrawer";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
-import type { TypedAgent } from "~/server/agents/agent.repository";
+import type { AgentType, TypedAgent } from "~/server/agents/agent.repository";
 import type { AgentWithFields } from "~/server/agents/agent-fields";
 import { api } from "~/utils/api";
 
@@ -302,15 +301,20 @@ function EmptyState({ onCreateNew }: { onCreateNew: () => void }) {
 // Agent Card Component
 // ============================================================================
 
-const agentTypeIcons: Record<string, typeof MessageSquare> = {
+/**
+ * The icon and the label per agent type. Both maps are keyed by the whole
+ * enum, so a new agent type does not compile until it names its icon and its
+ * word here, and no fallback stands in for it in silence.
+ */
+const agentTypeIcons: Record<AgentType, typeof MessageSquare> = {
   signature: MessageSquare,
   code: Code,
   workflow: Workflow,
   http: Globe,
-  connected: Cable,
+  connected: Bot,
 };
 
-const agentTypeLabels: Record<string, string> = {
+const agentTypeLabels: Record<AgentType, string> = {
   signature: "Prompt",
   code: "Code",
   workflow: "Workflow",
@@ -326,8 +330,8 @@ type AgentCardProps = {
 };
 
 function AgentCard({ agent, onClick, onEdit, onDelete }: AgentCardProps) {
-  const Icon = agentTypeIcons[agent.type] ?? Bot;
-  const typeLabel = agentTypeLabels[agent.type] ?? agent.type;
+  const Icon = agentTypeIcons[agent.type];
+  const typeLabel = agentTypeLabels[agent.type];
   const [menuOpen, setMenuOpen] = useState(false);
 
   return (

--- a/platform/app/src/components/agents/connected/ConnectedAgentDrawer.tsx
+++ b/platform/app/src/components/agents/connected/ConnectedAgentDrawer.tsx
@@ -176,14 +176,16 @@ function AgentBody({
           variables={connectedTargetFields(agent).inputs}
           onChange={() => {
             // The list is the agent's own contract: the turn to send, and the
-            // parameters the function declares. Mappable, not editable.
+            // parameters the function declares. Mappable, not editable, so
+            // the section stays read-only and only the mapping selector
+            // answers.
           }}
           showMappings={true}
           availableSources={availableSources}
           mappings={inputMappings}
           onMappingChange={onInputMappingsChange}
           canAddRemove={false}
-          readOnly={false}
+          readOnly={true}
         />
       ) : null}
       <ParametersTable agent={agent} />

--- a/platform/app/src/components/agents/connected/ConnectedAgentDrawer.tsx
+++ b/platform/app/src/components/agents/connected/ConnectedAgentDrawer.tsx
@@ -22,7 +22,18 @@ import {
 import { formatDistanceToNow } from "date-fns";
 import { AgentTestPanel } from "~/components/agents/AgentTestPanel";
 import { Drawer } from "~/components/ui/drawer";
-import { useDrawer, useDrawerParams } from "~/hooks/useDrawer";
+import {
+  type AvailableSource,
+  type FieldMapping,
+  VariablesSection,
+} from "~/components/variables";
+import { connectedTargetFields } from "~/experiments-v3/utils/connectedAgentTarget";
+import {
+  getComplexProps,
+  getFlowCallbacks,
+  useDrawer,
+  useDrawerParams,
+} from "~/hooks/useDrawer";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 import { api } from "~/utils/api";
 import {
@@ -34,14 +45,38 @@ import {
 
 export type ConnectedAgentDrawerProps = {
   agentId?: string;
+  /**
+   * The columns a workbench row can map from. Present only when the drawer is
+   * opened from a workbench column, which is the one place an agent's inputs
+   * are mapped to something.
+   */
+  availableSources?: AvailableSource[];
+  /** What the column maps today. */
+  inputMappings?: Record<string, FieldMapping>;
+  /** Records a mapping the moment it changes; the workbench has no Save. */
+  onInputMappingsChange?: (
+    identifier: string,
+    mapping: FieldMapping | undefined,
+  ) => void;
 };
 
 export function ConnectedAgentDrawer(props: ConnectedAgentDrawerProps) {
   const { closeDrawer } = useDrawer();
   const drawerParams = useDrawerParams();
+  const complexProps = getComplexProps();
+  const flowCallbacks = getFlowCallbacks("agentConnectedDetail");
   const { project } = useOrganizationTeamProject();
   const agentId = props.agentId ?? drawerParams.agentId;
   const projectId = project?.id ?? "";
+
+  const availableSources =
+    props.availableSources ??
+    (complexProps.availableSources as AvailableSource[] | undefined);
+  const inputMappings =
+    props.inputMappings ??
+    (complexProps.inputMappings as Record<string, FieldMapping> | undefined);
+  const onInputMappingsChange =
+    props.onInputMappingsChange ?? flowCallbacks?.onInputMappingsChange;
 
   const agentQuery = api.agents.getById.useQuery(
     { id: agentId ?? "", projectId },
@@ -64,6 +99,9 @@ export function ConnectedAgentDrawer(props: ConnectedAgentDrawerProps) {
             agent={agent}
             isLoading={agentQuery.isLoading}
             projectId={projectId}
+            availableSources={availableSources}
+            inputMappings={inputMappings}
+            onInputMappingsChange={onInputMappingsChange}
           />
         </Drawer.Body>
         <Drawer.Footer>
@@ -102,10 +140,19 @@ function AgentBody({
   agent,
   isLoading,
   projectId,
+  availableSources,
+  inputMappings,
+  onInputMappingsChange,
 }: {
   agent: ConnectedAgentView | null | undefined;
   isLoading: boolean;
   projectId: string;
+  availableSources?: AvailableSource[];
+  inputMappings?: Record<string, FieldMapping>;
+  onInputMappingsChange?: (
+    identifier: string,
+    mapping: FieldMapping | undefined,
+  ) => void;
 }) {
   if (isLoading) {
     return (
@@ -123,6 +170,22 @@ function AgentBody({
 
   return (
     <VStack align="stretch" gap={6} paddingBottom={6}>
+      {onInputMappingsChange ? (
+        <VariablesSection
+          title="Input Variables"
+          variables={connectedTargetFields(agent).inputs}
+          onChange={() => {
+            // The list is the agent's own contract: the turn to send, and the
+            // parameters the function declares. Mappable, not editable.
+          }}
+          showMappings={true}
+          availableSources={availableSources}
+          mappings={inputMappings}
+          onMappingChange={onInputMappingsChange}
+          canAddRemove={false}
+          readOnly={false}
+        />
+      ) : null}
       <ParametersTable agent={agent} />
       <InstancesTable agent={agent} />
       <AgentTestPanel

--- a/platform/app/src/experiments-v3/__tests__/connectedAgentTarget.unit.test.ts
+++ b/platform/app/src/experiments-v3/__tests__/connectedAgentTarget.unit.test.ts
@@ -22,8 +22,8 @@ const agent = {
 };
 
 describe("given a connected agent is added as a target", () => {
-  /** @scenario "The declared parameters are column inputs" */
   describe("when the column is built", () => {
+    /** @scenario "The declared parameters are column inputs" */
     it("reads the turn to send and every declared parameter", () => {
       const { inputs } = connectedTargetFields(agent);
 

--- a/platform/app/src/experiments-v3/__tests__/connectedAgentTarget.unit.test.ts
+++ b/platform/app/src/experiments-v3/__tests__/connectedAgentTarget.unit.test.ts
@@ -1,0 +1,81 @@
+/**
+ * What a connected agent reads as a workbench column.
+ *
+ * @see specs/experiments-v3/connected-agent-target.feature
+ */
+import { describe, expect, it } from "vitest";
+import { connectedTargetFields } from "../utils/connectedAgentTarget";
+
+const agent = {
+  parameters: [
+    {
+      name: "model",
+      type: "string",
+      options: ["gpt-5", "gpt-5-mini"],
+      defaultValue: "gpt-5-mini",
+    },
+    { name: "plan", type: "string", description: "Customer plan" },
+    { name: "max_tools", type: "number" },
+    { name: "verbose", type: "boolean" },
+    { name: "api_token", type: "string", secret: true },
+  ],
+};
+
+describe("given a connected agent is added as a target", () => {
+  /** @scenario "The declared parameters are column inputs" */
+  describe("when the column is built", () => {
+    it("reads the turn to send and every declared parameter", () => {
+      const { inputs } = connectedTargetFields(agent);
+
+      expect(inputs.map((input) => input.identifier)).toEqual([
+        "input",
+        "model",
+        "plan",
+        "max_tools",
+        "verbose",
+      ]);
+    });
+
+    it("keeps the parameters optional, so a column that maps none still runs", () => {
+      const { inputs } = connectedTargetFields(agent);
+
+      expect(inputs[0]).toEqual({ identifier: "input", type: "str" });
+      expect(inputs.slice(1).every((input) => input.optional)).toBe(true);
+    });
+
+    it("edits each parameter as the type it declares", () => {
+      const byName = new Map(
+        connectedTargetFields(agent).inputs.map((input) => [
+          input.identifier,
+          input.type,
+        ]),
+      );
+
+      expect(byName.get("model")).toBe("str");
+      expect(byName.get("max_tools")).toBe("float");
+      expect(byName.get("verbose")).toBe("bool");
+    });
+
+    it("leaves a secret out: a column mapping is not where a credential goes", () => {
+      const { inputs } = connectedTargetFields(agent);
+
+      expect(inputs.some((input) => input.identifier === "api_token")).toBe(
+        false,
+      );
+    });
+
+    it("writes the answer to one output", () => {
+      expect(connectedTargetFields(agent).outputs).toEqual([
+        { identifier: "output", type: "str" },
+      ]);
+    });
+  });
+
+  describe("when the agent declares no parameters", () => {
+    it("reads the turn alone", () => {
+      expect(connectedTargetFields({}).inputs).toEqual([
+        { identifier: "input", type: "str" },
+      ]);
+    });
+  });
+});

--- a/platform/app/src/experiments-v3/components/EvaluationsV3Table.tsx
+++ b/platform/app/src/experiments-v3/components/EvaluationsV3Table.tsx
@@ -68,6 +68,7 @@ import {
   isGoldenFieldSatisfied,
   LEGACY_PAIRWISE_EVALUATOR_TYPE,
 } from "../types";
+import { connectedTargetFields } from "../utils/connectedAgentTarget";
 import { convertInlineToRowRecords } from "../utils/datasetConversion";
 import { isRowEmpty } from "../utils/emptyRowDetection";
 import { createEvaluatorEditorCallbacks } from "../utils/evaluatorEditorCallbacks";
@@ -437,6 +438,24 @@ export function EvaluationsV3Table({
   const handleSelectSavedAgent = useCallback(
     (savedAgent: AgentWithFields) => {
       const config = savedAgent.config as Record<string, unknown>;
+
+      // A connected agent runs in the customer's own process, so the column
+      // reads the turn to send and the parameters the function declares
+      // rather than the fields of a node.
+      if (savedAgent.type === "connected") {
+        const { inputs, outputs } = connectedTargetFields(savedAgent.config);
+        addOrReplaceTarget({
+          id: newTargetId(),
+          type: "agent",
+          agentType: "connected",
+          dbAgentId: savedAgent.id,
+          inputs,
+          outputs,
+          mappings: {},
+        });
+        closeDrawer();
+        return;
+      }
 
       // Check if this is an HTTP agent by looking at savedAgent.type or config structure
       const isHttpAgent =

--- a/platform/app/src/experiments-v3/components/TargetSection/TargetHeader.tsx
+++ b/platform/app/src/experiments-v3/components/TargetSection/TargetHeader.tsx
@@ -9,7 +9,7 @@ import {
   Text,
 } from "@chakra-ui/react";
 import { keyframes } from "@emotion/react";
-import { Swords, Trophy } from "lucide-react";
+import { Bot, Swords, Trophy } from "lucide-react";
 import { memo, useMemo, useState } from "react";
 import {
   LuArrowLeftRight,
@@ -38,7 +38,7 @@ import { TARGET_MISSING_MAPPING_TOOLTIP } from "../../constants";
 import { useEvaluationsV3Store } from "../../hooks/useEvaluationsV3Store";
 import { usePromptTemplateFields } from "../../hooks/usePromptTemplateFields";
 import { useTargetName, useTargetNames } from "../../hooks/useTargetName";
-import type { TargetConfig } from "../../types";
+import type { AgentTypeEnum, TargetConfig } from "../../types";
 import { isComparisonEvaluator } from "../../types";
 import {
   computeComparisonColumnTargetAggregate,
@@ -52,6 +52,24 @@ import { toComparisonConfig } from "../../utils/normalizeComparison";
 import { disambiguateNames } from "../../utils/variantDisambiguation";
 import { ComparisonScoreboard } from "./ComparisonScoreboard";
 import { TargetSummary } from "./TargetSummary";
+
+/**
+ * The icon a column header shows per agent type.
+ *
+ * The map is keyed by the whole enum, so a new agent type does not compile
+ * until it names its icon here. A fallback would take its place in silence,
+ * which is how a connected agent first read as code.
+ */
+const AGENT_TYPE_ICONS: Record<
+  AgentTypeEnum,
+  { testId: string; icon: React.ComponentType<{ size?: number }> }
+> = {
+  code: { testId: "icon-code", icon: LuCode },
+  signature: { testId: "icon-code", icon: LuCode },
+  http: { testId: "icon-globe", icon: LuGlobe },
+  workflow: { testId: "icon-workflow", icon: LuWorkflow },
+  connected: { testId: "icon-connected", icon: Bot },
+};
 
 // Pulsing animation for missing mapping alert
 const pulseAnimation = keyframes`
@@ -354,29 +372,24 @@ export const TargetHeader = memo(function TargetHeader({
         </span>
       );
     }
-    // HTTP agents get a Globe icon
-    if (target.type === "agent" && target.agentType === "http") {
-      return (
-        <span data-testid="icon-globe">
-          <LuGlobe size={12} />
-        </span>
-      );
-    }
-    // A workflow-type agent (built in Studio, saved as an agent) or a
-    // directly-attached workflow target both run a whole Studio workflow, not
-    // a single code/signature node — give them their own icon so they don't
-    // read as raw code.
-    if (
-      target.type === "workflow" ||
-      (target.type === "agent" && target.agentType === "workflow")
-    ) {
+    // A workflow target runs a whole Studio workflow, not a single node, so
+    // it gets the workflow icon rather than reading as raw code.
+    if (target.type === "workflow") {
       return (
         <span data-testid="icon-workflow">
           <LuWorkflow size={12} />
         </span>
       );
     }
-    // Other agents (code, signature) get Code icon
+    if (target.type === "agent" && target.agentType) {
+      const { testId, icon: AgentIcon } = AGENT_TYPE_ICONS[target.agentType];
+      return (
+        <span data-testid={testId}>
+          <AgentIcon size={12} />
+        </span>
+      );
+    }
+    // An agent target that names no type is code, the oldest agent shape.
     return (
       <span data-testid="icon-code">
         <LuCode size={12} />

--- a/platform/app/src/experiments-v3/components/TargetSection/__tests__/TargetHeader.integration.test.tsx
+++ b/platform/app/src/experiments-v3/components/TargetSection/__tests__/TargetHeader.integration.test.tsx
@@ -105,7 +105,17 @@ describe("TargetHeader", () => {
     });
 
     describe("when a new agent type is added", () => {
-      it("gives every declared agent type its own icon", () => {
+      // Restated here rather than read off the component, so a type that
+      // silently takes another type's icon fails instead of passing.
+      const EXPECTED_ICON: Record<AgentTypeEnum, string> = {
+        code: "icon-code",
+        signature: "icon-code",
+        http: "icon-globe",
+        workflow: "icon-workflow",
+        connected: "icon-connected",
+      };
+
+      it("gives every declared agent type the icon it is meant to carry", () => {
         for (const agentType of agentTypeEnum.options) {
           const { unmount } = renderWithProviders(
             <TargetHeader
@@ -116,8 +126,8 @@ describe("TargetHeader", () => {
           );
 
           expect(
-            screen.getByTestId(/^icon-/),
-            `no icon for the ${agentType} agent type`,
+            screen.getByTestId(EXPECTED_ICON[agentType]),
+            `the ${agentType} agent type carries the wrong icon`,
           ).toBeInTheDocument();
           unmount();
         }

--- a/platform/app/src/experiments-v3/components/TargetSection/__tests__/TargetHeader.test.tsx
+++ b/platform/app/src/experiments-v3/components/TargetSection/__tests__/TargetHeader.test.tsx
@@ -7,6 +7,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useEvaluationsV3Store } from "../../../hooks/useEvaluationsV3Store";
 import { useTargetName } from "../../../hooks/useTargetName";
 import {
+  type AgentTypeEnum,
+  agentTypeEnum,
   createInitialResults,
   createInitialUIState,
   type TargetConfig,
@@ -70,6 +72,53 @@ describe("TargetHeader", () => {
 
   afterEach(() => {
     cleanup();
+  });
+
+  describe("Agent target", () => {
+    const agentTarget = (agentType: AgentTypeEnum): TargetConfig => ({
+      id: "support-agent",
+      type: "agent",
+      agentType,
+      dbAgentId: "agent_1",
+      inputs: [],
+      outputs: [],
+      mappings: {},
+    });
+
+    describe("when the agent runs in the customer's own process", () => {
+      it("marks the column with the agent icon, not the code icon", () => {
+        renderWithProviders(
+          <TargetHeader
+            target={agentTarget("connected")}
+            onEdit={mockOnEdit}
+            onRemove={mockOnRemove}
+          />,
+        );
+
+        expect(screen.getByTestId("icon-connected")).toBeInTheDocument();
+        expect(screen.queryByTestId("icon-code")).not.toBeInTheDocument();
+      });
+    });
+
+    describe("when a new agent type is added", () => {
+      it("gives every declared agent type its own icon", () => {
+        for (const agentType of agentTypeEnum.options) {
+          const { unmount } = renderWithProviders(
+            <TargetHeader
+              target={agentTarget(agentType)}
+              onEdit={mockOnEdit}
+              onRemove={mockOnRemove}
+            />,
+          );
+
+          expect(
+            screen.getByTestId(/^icon-/),
+            `no icon for the ${agentType} agent type`,
+          ).toBeInTheDocument();
+          unmount();
+        }
+      });
+    });
   });
 
   describe("Prompt target", () => {

--- a/platform/app/src/experiments-v3/components/TargetSection/__tests__/TargetHeader.test.tsx
+++ b/platform/app/src/experiments-v3/components/TargetSection/__tests__/TargetHeader.test.tsx
@@ -74,8 +74,12 @@ describe("TargetHeader", () => {
     cleanup();
   });
 
-  describe("Agent target", () => {
-    const agentTarget = (agentType: AgentTypeEnum): TargetConfig => ({
+  describe("given an agent target", () => {
+    const agentTarget = ({
+      agentType,
+    }: {
+      agentType: AgentTypeEnum;
+    }): TargetConfig => ({
       id: "support-agent",
       type: "agent",
       agentType,
@@ -89,7 +93,7 @@ describe("TargetHeader", () => {
       it("marks the column with the agent icon, not the code icon", () => {
         renderWithProviders(
           <TargetHeader
-            target={agentTarget("connected")}
+            target={agentTarget({ agentType: "connected" })}
             onEdit={mockOnEdit}
             onRemove={mockOnRemove}
           />,
@@ -105,7 +109,7 @@ describe("TargetHeader", () => {
         for (const agentType of agentTypeEnum.options) {
           const { unmount } = renderWithProviders(
             <TargetHeader
-              target={agentTarget(agentType)}
+              target={agentTarget({ agentType })}
               onEdit={mockOnEdit}
               onRemove={mockOnRemove}
             />,

--- a/platform/app/src/experiments-v3/hooks/useOpenTargetEditor.ts
+++ b/platform/app/src/experiments-v3/hooks/useOpenTargetEditor.ts
@@ -254,6 +254,47 @@ export const useOpenTargetEditor = () => {
             requestAnimationFrame(() => {
               scrollToTargetColumn(target.id);
             });
+          } else if (agent?.type === "connected") {
+            // A connected agent is registered from the customer's own code,
+            // so there is nothing here to edit: the drawer reads what the
+            // function declares, and the column maps its inputs to the
+            // dataset the same way every other target does.
+            const availableSources = buildAvailableSources();
+            const uiMappings = buildUIMappings(target, activeDatasetId);
+
+            setFlowCallbacks("agentConnectedDetail", {
+              // See the workflow-agent branch above for why this captures
+              // activeDatasetId/isDatasetSource instead of reading the store
+              // live: this drawer isn't modal either.
+              onInputMappingsChange: (
+                identifier: string,
+                mapping: UIFieldMapping | undefined,
+              ) => {
+                if (mapping) {
+                  setTargetMapping(
+                    target.id,
+                    activeDatasetId,
+                    identifier,
+                    convertFromUIMapping(mapping, isDatasetSource),
+                  );
+                } else {
+                  removeTargetMapping(target.id, activeDatasetId, identifier);
+                }
+              },
+            });
+
+            openDrawer("agentConnectedDetail", {
+              availableSources,
+              inputMappings: uiMappings,
+              urlParams: {
+                targetId: target.id,
+                agentId: target.dbAgentId ?? "",
+              },
+            });
+
+            requestAnimationFrame(() => {
+              scrollToTargetColumn(target.id);
+            });
           } else if (agent?.type === "http") {
             // HTTP agent - open HTTP editor drawer
             const availableSources = buildAvailableSources();

--- a/platform/app/src/experiments-v3/types.ts
+++ b/platform/app/src/experiments-v3/types.ts
@@ -363,9 +363,18 @@ export type EvaluatorConfig = Omit<
 
 /**
  * Agent types for targets (matches database agent types).
- * Used to determine which type of DSL node to generate.
+ *
+ * Says how the column runs the agent: which DSL node the row becomes, or, for
+ * a connected agent, that the row is one turn through the relay rather than a
+ * node at all.
  */
-export const agentTypeEnum = z.enum(["code", "signature", "workflow", "http"]);
+export const agentTypeEnum = z.enum([
+  "code",
+  "signature",
+  "workflow",
+  "http",
+  "connected",
+]);
 export type AgentTypeEnum = z.infer<typeof agentTypeEnum>;
 
 /**

--- a/platform/app/src/experiments-v3/utils/connectedAgentTarget.ts
+++ b/platform/app/src/experiments-v3/utils/connectedAgentTarget.ts
@@ -1,0 +1,80 @@
+/**
+ * What a connected agent reads as a workbench column.
+ *
+ * A connected agent runs in the customer's own process and answers one turn
+ * at a time (ADR-128). A workbench row is one such turn, so the column reads
+ * a single input, the message to send, and writes a single output, the answer.
+ *
+ * The parameters the function declares become optional inputs beside it. That
+ * is what makes "the same agent on two models" two columns rather than two
+ * agents: each column maps its own value, from the dataset or as a fixed
+ * value, and the rest keep whatever default the function declares.
+ *
+ * @see specs/experiments-v3/connected-agent-target.feature
+ */
+
+import type { Field } from "~/optimization_studio/types/dsl";
+import type { ScenarioParameterDefinition } from "~/server/scenarios/parameters";
+
+/** The input field a connected agent column reads the turn from. */
+export const CONNECTED_INPUT_FIELD = "input";
+
+/** The output field a connected agent column writes the answer to. */
+export const CONNECTED_OUTPUT_FIELD = "output";
+
+/**
+ * The parameters the agent declared, as a column reads them.
+ *
+ * Secrets are left out: a column mapping is stored in the experiment and read
+ * back by everyone who opens it, which is not where a credential goes. A run
+ * that needs one is a simulation, where secret values are supplied per run
+ * and encrypted.
+ */
+export const connectedParameterDefinitions = (
+  source: unknown,
+): ScenarioParameterDefinition[] => {
+  const declared = (
+    source as { parameters?: ScenarioParameterDefinition[] } | undefined
+  )?.parameters;
+  if (!Array.isArray(declared)) return [];
+  return declared.filter((definition) => !definition.secret);
+};
+
+/** The field type a declared parameter is edited and mapped as. */
+const fieldTypeOf = (
+  definition: ScenarioParameterDefinition,
+): Field["type"] => {
+  switch (definition.type) {
+    case "number":
+      return "float";
+    case "boolean":
+      return "bool";
+    default:
+      return "str";
+  }
+};
+
+/**
+ * The inputs and outputs of a connected agent column.
+ *
+ * Every parameter is optional, whatever the function declares: a column that
+ * maps none of them still runs, and the function applies its own defaults. A
+ * parameter the function requires is refused by the SDK with the name in the
+ * message, which is a clearer answer than a mapping the workbench invented.
+ */
+export const connectedTargetFields = (
+  source: unknown,
+): { inputs: Field[]; outputs: Field[] } => ({
+  inputs: [
+    { identifier: CONNECTED_INPUT_FIELD, type: "str" },
+    ...connectedParameterDefinitions(source).map(
+      (definition): Field => ({
+        identifier: definition.name,
+        type: fieldTypeOf(definition),
+        optional: true,
+        ...(definition.description ? { desc: definition.description } : {}),
+      }),
+    ),
+  ],
+  outputs: [{ identifier: CONNECTED_OUTPUT_FIELD, type: "str" }],
+});

--- a/platform/app/src/experiments-v3/utils/mappingValidation.ts
+++ b/platform/app/src/experiments-v3/utils/mappingValidation.ts
@@ -247,6 +247,19 @@ export const getTargetMissingMappings = (
     "agentType" in target &&
     target.agentType === "http";
 
+  // A connected agent declares the turn it reads plus the parameters of its
+  // own function. Every parameter carries the function's default, so only the
+  // turn has to be mapped for the column to run.
+  const isConnectedAgent =
+    target.type === "agent" &&
+    "agentType" in target &&
+    target.agentType === "connected";
+  const optionalInputIds = new Set(
+    inputs
+      .filter((input) => "optional" in input && input.optional)
+      .map((input) => input.identifier),
+  );
+
   // Evaluator targets use requiredFields/optionalFields from AVAILABLE_EVALUATORS
   const isEvaluatorTarget = target.type === "evaluator";
 
@@ -370,6 +383,10 @@ export const getTargetMissingMappings = (
   for (const fieldId of usedFields) {
     // Skip if not in inputs list - user hasn't defined this variable
     if (!inputIds.has(fieldId)) continue;
+
+    // An unmapped parameter of a connected agent is not a gap: the function
+    // applies its own default for it.
+    if (isConnectedAgent && optionalInputIds.has(fieldId)) continue;
 
     const hasMapping = datasetMappings[fieldId] !== undefined;
 

--- a/platform/app/src/server/connected-agents/__tests__/call.dispatcher.unit.test.ts
+++ b/platform/app/src/server/connected-agents/__tests__/call.dispatcher.unit.test.ts
@@ -635,6 +635,31 @@ describe("CallDispatcher", () => {
       });
     });
   });
+
+  describe("when the instance already runs its declared number of calls", () => {
+    /** @scenario "An instance that refuses a call as busy keeps the busy code" */
+    it("refuses with agent_busy, the code a caller retries", async () => {
+      await connectInstance({
+        instanceId: "inst_1",
+        behavior: async (_, reply) => {
+          await reply.result({
+            error: {
+              code: "agent_busy",
+              message: "support-agent already runs 4 call(s)",
+            },
+          });
+        },
+      });
+
+      await expect(
+        runtime.dispatcher.dispatch({
+          projectId,
+          agent: agent(),
+          call: call(),
+        }),
+      ).rejects.toMatchObject({ code: "agent_busy" });
+    });
+  });
 });
 
 describe("buildCallEnvelope", () => {

--- a/platform/app/src/server/connected-agents/call.dispatcher.ts
+++ b/platform/app/src/server/connected-agents/call.dispatcher.ts
@@ -570,11 +570,17 @@ export class CallDispatcher {
  * The error a result carries, as the handled error the caller reads.
  *
  * A gateway refusing an oversized payload writes what it measured, and that
- * keeps its own class; anything else is the function's own error.
+ * keeps its own class. An instance that already runs its declared number of
+ * calls answers `agent_busy`, which is the same refusal the dispatcher raises
+ * when every instance is full, so it keeps that class too and the caller can
+ * wait and send the turn again. Anything else is the function's own error.
  */
 function remoteError(error: StoredResultError): Error {
   if (error.payload) {
     return new AgentPayloadTooLargeError(error.payload);
+  }
+  if (error.code === "agent_busy") {
+    return new AgentBusyError({ retryAfterMs: BUSY_RETRY_AFTER_MS });
   }
   return new AgentCallFailedError({
     remoteCode: error.code,

--- a/platform/app/src/server/experiments-v3/execution/__tests__/connectedCell.integration.test.ts
+++ b/platform/app/src/server/experiments-v3/execution/__tests__/connectedCell.integration.test.ts
@@ -137,9 +137,12 @@ const gradingEvaluator: EvaluatorConfig = {
 const run = async ({
   cell,
   dispatch,
+  now,
 }: {
   cell: ExecutionCell;
   dispatch: ConnectedDispatch;
+  /** A clock the test moves by hand, so a cell duration is exact. */
+  now?: () => number;
 }): Promise<EvaluationV3Event[]> => {
   const events: EvaluationV3Event[] = [];
   for await (const event of executeConnectedCell({
@@ -149,6 +152,7 @@ const run = async ({
     datasetColumns: [{ id: "col_1", name: "question", type: "string" }],
     dispatch,
     sleep: async () => undefined,
+    ...(now ? { now } : {}),
   })) {
     events.push(event);
   }
@@ -168,7 +172,14 @@ describe("given a connected agent column", () => {
         answered("Open a return request."),
       );
 
-      const events = await run({ cell: makeCell(), dispatch });
+      // Every read of the clock is 1200ms later, so the duration the row
+      // reports is exact.
+      let clock = 0;
+      const events = await run({
+        cell: makeCell(),
+        dispatch,
+        now: () => (clock += 1200),
+      });
 
       const call = dispatch.mock.calls[0]![0];
       expect(call.call.messages).toEqual([

--- a/platform/app/src/server/experiments-v3/execution/__tests__/connectedCell.integration.test.ts
+++ b/platform/app/src/server/experiments-v3/execution/__tests__/connectedCell.integration.test.ts
@@ -1,0 +1,445 @@
+/**
+ * Tests executeConnectedCell: running a connected agent as a workbench column.
+ *
+ * The relay dispatcher is injected, so the turn is scripted rather than sent
+ * to a real process, and the nlpgo dispatch boundary is mocked the way the
+ * workflow-cell test mocks it, so the grading evaluators run their mapping
+ * logic without a live NLP service.
+ *
+ * @see specs/experiments-v3/connected-agent-target.feature
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { EvaluatorConfig } from "~/experiments-v3/types";
+import type { StudioServerEvent } from "~/optimization_studio/types/events";
+
+const scripted = vi.hoisted(() => ({
+  component: [] as StudioServerEvent[],
+  dispatched: [] as Array<{ type: string; payload: Record<string, any> }>,
+}));
+
+vi.mock("~/app/api/workflows/post_event/post-event", () => ({
+  studioBackendPostEvent: vi.fn(
+    async ({
+      message,
+      onEvent,
+    }: {
+      message: { type: string; payload: Record<string, any> };
+      onEvent: (event: StudioServerEvent) => void;
+    }) => {
+      scripted.dispatched.push(message);
+      for (const event of scripted.component) onEvent(event);
+    },
+  ),
+}));
+vi.mock("~/optimization_studio/server/addEnvs", () => ({
+  addEnvs: vi.fn(async (event: unknown) => event),
+}));
+vi.mock("~/optimization_studio/server/loadDatasets", () => ({
+  loadDatasets: vi.fn(async (event: unknown) => event),
+}));
+
+import { HandledError } from "@langwatch/handled-error";
+import type { EvaluationsV3State, TargetConfig } from "~/experiments-v3/types";
+import {
+  createInitialResults,
+  createInitialUIState,
+} from "~/experiments-v3/types";
+import type { TypedAgent } from "~/server/agents/agent.repository";
+import type { CallOutcome } from "~/server/connected-agents/call-envelope";
+import { AgentBusyError } from "~/server/connected-agents/errors";
+import {
+  type ConnectedDispatch,
+  executeConnectedCell,
+  type OrchestratorInput,
+  runOrchestrator,
+} from "../orchestrator";
+import type { EvaluationV3Event, ExecutionCell } from "../types";
+
+const agent = {
+  id: "agent_1",
+  name: "support-agent",
+  type: "connected",
+  environment: "production",
+  config: {
+    parameters: [
+      { name: "model", type: "string", options: ["gpt-5", "gpt-5-mini"] },
+      { name: "plan", type: "string" },
+    ],
+    sdk: { name: "langwatch", version: "1.0.0", language: "python" },
+  },
+} as unknown as TypedAgent;
+
+const answered = (output: string): CallOutcome => ({
+  output,
+  instance: {
+    instanceId: "inst_1",
+    hostname: "laptop",
+    label: null,
+  },
+  durationMs: 1200,
+});
+
+const makeCell = (overrides?: Partial<ExecutionCell>): ExecutionCell => ({
+  rowIndex: 0,
+  targetId: "connected-target",
+  targetConfig: {
+    id: "connected-target",
+    type: "agent",
+    agentType: "connected",
+    dbAgentId: "agent_1",
+    inputs: [
+      { identifier: "input", type: "str" },
+      { identifier: "model", type: "str", optional: true },
+    ],
+    outputs: [{ identifier: "output", type: "str" }],
+    mappings: {
+      "dataset-1": {
+        input: { type: "source", source: "dataset", sourceField: "question" },
+        model: { type: "value", value: "gpt-5" },
+      },
+    },
+  },
+  evaluatorConfigs: [],
+  datasetEntry: {
+    _datasetId: "dataset-1",
+    question: "How do I return a broken item?",
+  },
+  ...overrides,
+});
+
+/** A grading evaluator attached to the column, reading its output. */
+const gradingEvaluator: EvaluatorConfig = {
+  id: "eval-grading",
+  evaluatorType: "langevals/exact_match",
+  dbEvaluatorId: "db-eval-1",
+  inputs: [{ identifier: "output", type: "str" }],
+  mappings: {
+    "dataset-1": {
+      "connected-target": {
+        output: {
+          type: "source",
+          source: "target",
+          sourceId: "connected-target",
+          sourceField: "output",
+        },
+      },
+    },
+  },
+};
+
+const run = async ({
+  cell,
+  dispatch,
+}: {
+  cell: ExecutionCell;
+  dispatch: ConnectedDispatch;
+}): Promise<EvaluationV3Event[]> => {
+  const events: EvaluationV3Event[] = [];
+  for await (const event of executeConnectedCell({
+    cell,
+    projectId: "p1",
+    agent,
+    datasetColumns: [{ id: "col_1", name: "question", type: "string" }],
+    dispatch,
+    sleep: async () => undefined,
+  })) {
+    events.push(event);
+  }
+  return events;
+};
+
+beforeEach(() => {
+  scripted.component = [];
+  scripted.dispatched = [];
+});
+
+describe("given a connected agent column", () => {
+  describe("when the row runs", () => {
+    /** @scenario "The column reads the dataset row and answers" */
+    it("sends the mapped row and writes the answer in the cell", async () => {
+      const dispatch = vi.fn(async () => answered("Open a return request."));
+
+      const events = await run({ cell: makeCell(), dispatch });
+
+      const call = dispatch.mock
+        .calls[0]![0] as Parameters<ConnectedDispatch>[0];
+      expect(call.call.messages).toEqual([
+        { role: "user", content: "How do I return a broken item?" },
+      ]);
+      expect(call.call.params).toEqual({ model: "gpt-5" });
+      expect(call.agent.id).toBe("agent_1");
+
+      expect(events.map((event) => event.type)).toEqual([
+        "cell_started",
+        "target_result",
+      ]);
+      const result = events[1] as Extract<
+        EvaluationV3Event,
+        { type: "target_result" }
+      >;
+      expect(result.output).toBe("Open a return request.");
+      expect(result.duration).toBe(1200);
+      expect(result.error).toBeUndefined();
+    });
+
+    /** @scenario "The agent's own spans join the cell's trace" */
+    it("carries the cell's trace context", async () => {
+      const dispatch = vi.fn(async () => answered("ok"));
+
+      const events = await run({
+        cell: makeCell({ traceId: "a".repeat(32) }),
+        dispatch,
+      });
+
+      const call = dispatch.mock
+        .calls[0]![0] as Parameters<ConnectedDispatch>[0];
+      expect(call.call.traceparent).toMatch(/^00-a{32}-[0-9a-f]{16}-01$/);
+      const result = events[1] as Extract<
+        EvaluationV3Event,
+        { type: "target_result" }
+      >;
+      expect(result.traceId).toBe("a".repeat(32));
+    });
+
+    /** @scenario "Every row is a separate conversation" */
+    it("gives every row its own conversation and no session", async () => {
+      const dispatch = vi.fn(async () => answered("ok"));
+
+      await run({ cell: makeCell({ rowIndex: 0 }), dispatch });
+      await run({ cell: makeCell({ rowIndex: 1 }), dispatch });
+
+      const threads = dispatch.mock.calls.map(
+        (call) => (call[0] as Parameters<ConnectedDispatch>[0]).call.threadId,
+      );
+      expect(threads[0]).not.toBe(threads[1]);
+      for (const call of dispatch.mock.calls) {
+        expect(
+          (call[0] as Parameters<ConnectedDispatch>[0]).call.session,
+        ).toBeUndefined();
+      }
+    });
+  });
+
+  describe("when the column carries an evaluator", () => {
+    /** @scenario "The evaluators grade the agent's answer" */
+    it("grades the answer the agent gave", async () => {
+      scripted.component = [
+        {
+          type: "component_state_change",
+          payload: {
+            component_id: "connected-target.eval-grading",
+            execution_state: {
+              status: "success",
+              outputs: { score: 1, passed: true },
+            },
+          },
+        },
+      ] as unknown as StudioServerEvent[];
+
+      const events = await run({
+        cell: makeCell({ evaluatorConfigs: [gradingEvaluator] }),
+        dispatch: vi.fn(async () => answered("Open a return request.")),
+      });
+
+      const evaluatorInputs = scripted.dispatched[0]?.payload?.inputs as
+        | Record<string, unknown>
+        | undefined;
+      expect(evaluatorInputs?.output).toBe("Open a return request.");
+
+      const evaluatorResult = events.find(
+        (event) => event.type === "evaluator_result",
+      ) as Extract<EvaluationV3Event, { type: "evaluator_result" }> | undefined;
+      expect(evaluatorResult?.result).toMatchObject({
+        status: "processed",
+        score: 1,
+        passed: true,
+      });
+    });
+
+    it("does not grade a row the agent never answered", async () => {
+      const events = await run({
+        cell: makeCell({ evaluatorConfigs: [gradingEvaluator] }),
+        dispatch: vi.fn(async () => {
+          throw new HandledError("agent_offline", "No instance is connected", {
+            httpStatus: 503,
+            fault: "customer",
+          });
+        }),
+      });
+
+      expect(events.some((event) => event.type === "evaluator_result")).toBe(
+        false,
+      );
+      expect(scripted.dispatched).toHaveLength(0);
+    });
+  });
+
+  describe("when no process of the agent is connected", () => {
+    /** @scenario "An offline agent names itself in the failure" */
+    it("fails the cell with the offline code, not an unknown error", async () => {
+      const events = await run({
+        cell: makeCell(),
+        dispatch: vi.fn(async () => {
+          throw new HandledError("agent_offline", "No instance is connected", {
+            httpStatus: 503,
+            fault: "customer",
+          });
+        }),
+      });
+
+      const result = events[1] as Extract<
+        EvaluationV3Event,
+        { type: "target_result" }
+      >;
+      expect(result.error).toBe("agent_offline");
+      expect(result.domainError?.code).toBe("agent_offline");
+    });
+  });
+
+  describe("when every instance is busy", () => {
+    /** @scenario "A busy agent is retried before the row fails" */
+    it("tries again inside the budget", async () => {
+      let attempts = 0;
+      const dispatch = vi.fn(async () => {
+        attempts += 1;
+        if (attempts < 3) throw new AgentBusyError({ retryAfterMs: 10 });
+        return answered("Open a return request.");
+      });
+
+      const events = await run({ cell: makeCell(), dispatch });
+
+      expect(attempts).toBe(3);
+      const result = events[1] as Extract<
+        EvaluationV3Event,
+        { type: "target_result" }
+      >;
+      expect(result.output).toBe("Open a return request.");
+    });
+
+    /** @scenario "A busy agent is retried before the row fails" */
+    it("fails the row with the busy code once the budget ends", async () => {
+      const events: EvaluationV3Event[] = [];
+      let clock = 0;
+      for await (const event of executeConnectedCell({
+        cell: makeCell(),
+        projectId: "p1",
+        agent,
+        dispatch: async () => {
+          throw new AgentBusyError({ retryAfterMs: 10 });
+        },
+        sleep: async () => undefined,
+        // Every read of the clock is a minute later, so the budget is spent
+        // on the first retry rather than in real time.
+        now: () => (clock += 60_000),
+      })) {
+        events.push(event);
+      }
+
+      const result = events[1] as Extract<
+        EvaluationV3Event,
+        { type: "target_result" }
+      >;
+      expect(result.error).toBe("agent_busy");
+      expect(result.domainError?.code).toBe("agent_busy");
+    });
+  });
+});
+
+describe("given two columns of the same agent", () => {
+  describe("when each column sets its own parameter value", () => {
+    /** @scenario "Two parameter values compare side by side" */
+    it("sends each column's own value", async () => {
+      const dispatch = vi.fn(async () => answered("ok"));
+
+      const columnWith = (model: string): ExecutionCell => {
+        const cell = makeCell();
+        return {
+          ...cell,
+          targetId: `connected-${model}`,
+          targetConfig: {
+            ...cell.targetConfig,
+            id: `connected-${model}`,
+            mappings: {
+              "dataset-1": {
+                input: {
+                  type: "source",
+                  source: "dataset",
+                  sourceField: "question",
+                },
+                model: { type: "value", value: model },
+              },
+            },
+          },
+        };
+      };
+
+      await run({ cell: columnWith("gpt-5-mini"), dispatch });
+      await run({ cell: columnWith("gpt-5"), dispatch });
+
+      const models = dispatch.mock.calls.map(
+        (call) =>
+          (call[0] as Parameters<ConnectedDispatch>[0]).call.params.model,
+      );
+      expect(models).toEqual(["gpt-5-mini", "gpt-5"]);
+    });
+  });
+});
+
+describe("given a personal development agent of another person", () => {
+  const personalAgent = {
+    ...agent,
+    environment: "development",
+    ownerUserId: "user_someone_else",
+  } as unknown as typeof agent;
+
+  const stateWithConnectedTarget = (): EvaluationsV3State => ({
+    name: "Evaluation",
+    datasets: [
+      { id: "dataset-1", name: "Dataset" } as EvaluationsV3State["datasets"][0],
+    ],
+    activeDatasetId: "dataset-1",
+    targets: [makeCell().targetConfig as TargetConfig],
+    evaluators: [],
+    results: createInitialResults(),
+    pendingSavedChanges: {},
+    ui: createInitialUIState(),
+  });
+
+  const inputFor = (actor: OrchestratorInput["actor"]): OrchestratorInput => ({
+    projectId: "p1",
+    scope: { type: "full" },
+    state: stateWithConnectedTarget(),
+    datasetRows: [{ question: "How do I return a broken item?" }],
+    datasetColumns: [{ id: "col_1", name: "question", type: "string" }],
+    loadedPrompts: new Map(),
+    loadedAgents: new Map([["agent_1", personalAgent]]),
+    ...(actor ? { actor } : {}),
+  });
+
+  describe("when someone else starts the run", () => {
+    /** @scenario "Another person's development agent is refused" */
+    it("refuses the run with the owner-only code", async () => {
+      const events: EvaluationV3Event[] = [];
+      await expect(async () => {
+        for await (const event of runOrchestrator(
+          inputFor({ id: "user_me", label: "user" }),
+        )) {
+          events.push(event);
+        }
+      }).rejects.toMatchObject({ code: "agent_owner_only" });
+
+      expect(events).toEqual([]);
+    });
+  });
+
+  describe("when the run names no person at all", () => {
+    /** @scenario "Another person's development agent is refused" */
+    it("refuses it too", async () => {
+      await expect(async () => {
+        for await (const event of runOrchestrator(inputFor(undefined))) {
+          void event;
+        }
+      }).rejects.toMatchObject({ code: "agent_owner_only" });
+    });
+  });
+});

--- a/platform/app/src/server/experiments-v3/execution/__tests__/connectedCell.integration.test.ts
+++ b/platform/app/src/server/experiments-v3/execution/__tests__/connectedCell.integration.test.ts
@@ -38,7 +38,6 @@ vi.mock("~/optimization_studio/server/loadDatasets", () => ({
   loadDatasets: vi.fn(async (event: unknown) => event),
 }));
 
-import { HandledError } from "@langwatch/handled-error";
 import type { EvaluationsV3State, TargetConfig } from "~/experiments-v3/types";
 import {
   createInitialResults,
@@ -46,7 +45,10 @@ import {
 } from "~/experiments-v3/types";
 import type { TypedAgent } from "~/server/agents/agent.repository";
 import type { CallOutcome } from "~/server/connected-agents/call-envelope";
-import { AgentBusyError } from "~/server/connected-agents/errors";
+import {
+  AgentBusyError,
+  AgentOfflineError,
+} from "~/server/connected-agents/errors";
 import {
   type ConnectedDispatch,
   executeConnectedCell,
@@ -94,7 +96,12 @@ const makeCell = (overrides?: Partial<ExecutionCell>): ExecutionCell => ({
     outputs: [{ identifier: "output", type: "str" }],
     mappings: {
       "dataset-1": {
-        input: { type: "source", source: "dataset", sourceField: "question" },
+        input: {
+          type: "source",
+          source: "dataset",
+          sourceId: "dataset-1",
+          sourceField: "question",
+        },
         model: { type: "value", value: "gpt-5" },
       },
     },
@@ -157,12 +164,13 @@ describe("given a connected agent column", () => {
   describe("when the row runs", () => {
     /** @scenario "The column reads the dataset row and answers" */
     it("sends the mapped row and writes the answer in the cell", async () => {
-      const dispatch = vi.fn(async () => answered("Open a return request."));
+      const dispatch = vi.fn<ConnectedDispatch>(async () =>
+        answered("Open a return request."),
+      );
 
       const events = await run({ cell: makeCell(), dispatch });
 
-      const call = dispatch.mock
-        .calls[0]![0] as Parameters<ConnectedDispatch>[0];
+      const call = dispatch.mock.calls[0]![0];
       expect(call.call.messages).toEqual([
         { role: "user", content: "How do I return a broken item?" },
       ]);
@@ -184,15 +192,14 @@ describe("given a connected agent column", () => {
 
     /** @scenario "The agent's own spans join the cell's trace" */
     it("carries the cell's trace context", async () => {
-      const dispatch = vi.fn(async () => answered("ok"));
+      const dispatch = vi.fn<ConnectedDispatch>(async () => answered("ok"));
 
       const events = await run({
         cell: makeCell({ traceId: "a".repeat(32) }),
         dispatch,
       });
 
-      const call = dispatch.mock
-        .calls[0]![0] as Parameters<ConnectedDispatch>[0];
+      const call = dispatch.mock.calls[0]![0];
       expect(call.call.traceparent).toMatch(/^00-a{32}-[0-9a-f]{16}-01$/);
       const result = events[1] as Extract<
         EvaluationV3Event,
@@ -203,19 +210,15 @@ describe("given a connected agent column", () => {
 
     /** @scenario "Every row is a separate conversation" */
     it("gives every row its own conversation and no session", async () => {
-      const dispatch = vi.fn(async () => answered("ok"));
+      const dispatch = vi.fn<ConnectedDispatch>(async () => answered("ok"));
 
       await run({ cell: makeCell({ rowIndex: 0 }), dispatch });
       await run({ cell: makeCell({ rowIndex: 1 }), dispatch });
 
-      const threads = dispatch.mock.calls.map(
-        (call) => (call[0] as Parameters<ConnectedDispatch>[0]).call.threadId,
-      );
+      const threads = dispatch.mock.calls.map((call) => call[0].call.threadId);
       expect(threads[0]).not.toBe(threads[1]);
       for (const call of dispatch.mock.calls) {
-        expect(
-          (call[0] as Parameters<ConnectedDispatch>[0]).call.session,
-        ).toBeUndefined();
+        expect(call[0].call.session).toBeUndefined();
       }
     });
   });
@@ -238,7 +241,9 @@ describe("given a connected agent column", () => {
 
       const events = await run({
         cell: makeCell({ evaluatorConfigs: [gradingEvaluator] }),
-        dispatch: vi.fn(async () => answered("Open a return request.")),
+        dispatch: vi.fn<ConnectedDispatch>(async () =>
+          answered("Open a return request."),
+        ),
       });
 
       const evaluatorInputs = scripted.dispatched[0]?.payload?.inputs as
@@ -259,10 +264,10 @@ describe("given a connected agent column", () => {
     it("does not grade a row the agent never answered", async () => {
       const events = await run({
         cell: makeCell({ evaluatorConfigs: [gradingEvaluator] }),
-        dispatch: vi.fn(async () => {
-          throw new HandledError("agent_offline", "No instance is connected", {
-            httpStatus: 503,
-            fault: "customer",
+        dispatch: vi.fn<ConnectedDispatch>(async () => {
+          throw new AgentOfflineError({
+            agentName: "Support agent",
+            environment: "production",
           });
         }),
       });
@@ -279,10 +284,10 @@ describe("given a connected agent column", () => {
     it("fails the cell with the offline code, not an unknown error", async () => {
       const events = await run({
         cell: makeCell(),
-        dispatch: vi.fn(async () => {
-          throw new HandledError("agent_offline", "No instance is connected", {
-            httpStatus: 503,
-            fault: "customer",
+        dispatch: vi.fn<ConnectedDispatch>(async () => {
+          throw new AgentOfflineError({
+            agentName: "Support agent",
+            environment: "production",
           });
         }),
       });
@@ -300,7 +305,7 @@ describe("given a connected agent column", () => {
     /** @scenario "A busy agent is retried before the row fails" */
     it("tries again inside the budget", async () => {
       let attempts = 0;
-      const dispatch = vi.fn(async () => {
+      const dispatch = vi.fn<ConnectedDispatch>(async () => {
         attempts += 1;
         if (attempts < 3) throw new AgentBusyError({ retryAfterMs: 10 });
         return answered("Open a return request.");
@@ -349,7 +354,7 @@ describe("given two columns of the same agent", () => {
   describe("when each column sets its own parameter value", () => {
     /** @scenario "Two parameter values compare side by side" */
     it("sends each column's own value", async () => {
-      const dispatch = vi.fn(async () => answered("ok"));
+      const dispatch = vi.fn<ConnectedDispatch>(async () => answered("ok"));
 
       const columnWith = (model: string): ExecutionCell => {
         const cell = makeCell();
@@ -364,6 +369,7 @@ describe("given two columns of the same agent", () => {
                 input: {
                   type: "source",
                   source: "dataset",
+                  sourceId: "dataset-1",
                   sourceField: "question",
                 },
                 model: { type: "value", value: model },
@@ -377,8 +383,7 @@ describe("given two columns of the same agent", () => {
       await run({ cell: columnWith("gpt-5"), dispatch });
 
       const models = dispatch.mock.calls.map(
-        (call) =>
-          (call[0] as Parameters<ConnectedDispatch>[0]).call.params.model,
+        (call) => call[0].call.params.model,
       );
       expect(models).toEqual(["gpt-5-mini", "gpt-5"]);
     });

--- a/platform/app/src/server/experiments-v3/execution/__tests__/connectedTarget.unit.test.ts
+++ b/platform/app/src/server/experiments-v3/execution/__tests__/connectedTarget.unit.test.ts
@@ -1,0 +1,152 @@
+/**
+ * What a workbench column sends to a connected agent, and what it reads back.
+ *
+ * @see specs/experiments-v3/connected-agent-target.feature
+ */
+import { HandledError } from "@langwatch/handled-error";
+import { describe, expect, it } from "vitest";
+import type { ScenarioParameterDefinition } from "~/server/scenarios/parameters";
+import {
+  buildConnectedCall,
+  connectedCallFailure,
+  connectedOutputText,
+} from "../connectedTarget";
+import { UNNAMED_FAILURE } from "../types";
+
+const definitions: ScenarioParameterDefinition[] = [
+  { name: "model", type: "string", options: ["gpt-5", "gpt-5-mini"] },
+  { name: "plan", type: "string", defaultValue: "free" },
+  { name: "max_tools", type: "number" },
+  { name: "verbose", type: "boolean" },
+];
+
+describe("given a connected agent column", () => {
+  describe("when the row carries the mapped input", () => {
+    /** @scenario "The column reads the dataset row and answers" */
+    it("sends the row's input as one user message", () => {
+      const { messages } = buildConnectedCall({
+        inputs: { input: "How do I return a broken item?" },
+        definitions,
+      });
+
+      expect(messages).toEqual([
+        { role: "user", content: "How do I return a broken item?" },
+      ]);
+    });
+
+    it("keeps a conversation the dataset already holds", () => {
+      const conversation = [
+        { role: "user", content: "hi" },
+        { role: "assistant", content: "hello" },
+        { role: "user", content: "my order is late" },
+      ];
+
+      const { messages } = buildConnectedCall({
+        inputs: { input: conversation },
+        definitions,
+      });
+
+      expect(messages).toEqual(conversation);
+    });
+  });
+
+  describe("when parameter values are mapped", () => {
+    /** @scenario "A parameter value reaches the agent as its declared type" */
+    it("sends each value as the type the agent declared", () => {
+      const { params } = buildConnectedCall({
+        inputs: {
+          input: "hi",
+          model: "gpt-5",
+          max_tools: "3",
+          verbose: "true",
+        },
+        definitions,
+      });
+
+      expect(params).toEqual({ model: "gpt-5", max_tools: 3, verbose: true });
+    });
+
+    /** @scenario "A parameter value reaches the agent as its declared type" */
+    it("drops a name the agent does not declare", () => {
+      const { params } = buildConnectedCall({
+        inputs: { input: "hi", temperature: "0.7" },
+        definitions,
+      });
+
+      expect(params).not.toHaveProperty("temperature");
+    });
+
+    /** @scenario "The declared parameters are column inputs" */
+    it("sends nothing for a parameter with no value, so the default applies", () => {
+      const { params } = buildConnectedCall({
+        inputs: { input: "hi", model: "" },
+        definitions,
+      });
+
+      expect(params).toEqual({});
+    });
+  });
+});
+
+describe("given the agent answered", () => {
+  describe("when the function returned a message rather than a string", () => {
+    /** @scenario "The answer is text, whatever shape the function returned" */
+    it("reads the message content", () => {
+      expect(
+        connectedOutputText({ role: "assistant", content: "two days" }),
+      ).toBe("two days");
+    });
+
+    it("reads the last message of a list", () => {
+      expect(
+        connectedOutputText([
+          { role: "assistant", content: "let me check" },
+          { role: "assistant", content: "two days" },
+        ]),
+      ).toBe("two days");
+    });
+
+    it("joins the text parts of a multimodal message", () => {
+      expect(
+        connectedOutputText({
+          role: "assistant",
+          content: [
+            { type: "text", text: "two " },
+            { type: "text", text: "days" },
+          ],
+        }),
+      ).toBe("two days");
+    });
+  });
+
+  describe("when the function returned text", () => {
+    it("reads it as it is", () => {
+      expect(connectedOutputText("two days")).toBe("two days");
+    });
+  });
+});
+
+describe("given the call failed", () => {
+  /** @scenario "An offline agent names itself in the failure" */
+  describe("when the platform named the failure", () => {
+    it("records the code, so the cell renders the copy of that code", () => {
+      const failure = connectedCallFailure(
+        new HandledError("agent_offline", "No instance is connected", {
+          httpStatus: 503,
+          fault: "customer",
+        }),
+      );
+
+      expect(failure.message).toBe("agent_offline");
+      expect(failure.domainError?.code).toBe("agent_offline");
+    });
+  });
+
+  describe("when nothing named the failure", () => {
+    it("stays unnamed rather than showing a stack message", () => {
+      const failure = connectedCallFailure(new Error("socket hang up"));
+
+      expect(failure).toEqual({ message: UNNAMED_FAILURE });
+    });
+  });
+});

--- a/platform/app/src/server/experiments-v3/execution/__tests__/connectedTarget.unit.test.ts
+++ b/platform/app/src/server/experiments-v3/execution/__tests__/connectedTarget.unit.test.ts
@@ -3,8 +3,8 @@
  *
  * @see specs/experiments-v3/connected-agent-target.feature
  */
-import { HandledError } from "@langwatch/handled-error";
 import { describe, expect, it } from "vitest";
+import { AgentOfflineError } from "~/server/connected-agents/errors";
 import type { ScenarioParameterDefinition } from "~/server/scenarios/parameters";
 import {
   buildConnectedCall,
@@ -131,9 +131,9 @@ describe("given the call failed", () => {
   describe("when the platform named the failure", () => {
     it("records the code, so the cell renders the copy of that code", () => {
       const failure = connectedCallFailure(
-        new HandledError("agent_offline", "No instance is connected", {
-          httpStatus: 503,
-          fault: "customer",
+        new AgentOfflineError({
+          agentName: "Support agent",
+          environment: "production",
         }),
       );
 

--- a/platform/app/src/server/experiments-v3/execution/__tests__/connectedTarget.unit.test.ts
+++ b/platform/app/src/server/experiments-v3/execution/__tests__/connectedTarget.unit.test.ts
@@ -127,8 +127,8 @@ describe("given the agent answered", () => {
 });
 
 describe("given the call failed", () => {
-  /** @scenario "An offline agent names itself in the failure" */
   describe("when the platform named the failure", () => {
+    /** @scenario "An offline agent names itself in the failure" */
     it("records the code, so the cell renders the copy of that code", () => {
       const failure = connectedCallFailure(
         new AgentOfflineError({

--- a/platform/app/src/server/experiments-v3/execution/connectedTarget.ts
+++ b/platform/app/src/server/experiments-v3/execution/connectedTarget.ts
@@ -1,0 +1,183 @@
+/**
+ * What a workbench column sends to a connected agent, and what it reads back.
+ *
+ * A connected agent runs in the customer's own process and is reached through
+ * the relay (ADR-128). A workbench row is one turn: the column sends the
+ * mapped input as a single user message, carries the parameter values the
+ * agent declares, and writes the answer in the cell.
+ *
+ * The call itself is dispatched by the orchestrator. This module holds the
+ * parts that need no runtime: what to send, what the answer reads as, and
+ * what a failure is called.
+ *
+ * @see specs/experiments-v3/connected-agent-target.feature
+ */
+
+import type { SerializedHandledError } from "@langwatch/handled-error";
+import { HandledError } from "@langwatch/handled-error";
+import { CONNECTED_INPUT_FIELD } from "~/experiments-v3/utils/connectedAgentTarget";
+import type {
+  CallOutput,
+  ProtocolMessage,
+} from "~/server/connected-agents/protocol";
+import type { ScenarioParameterDefinition } from "~/server/scenarios/parameters";
+import { UNNAMED_FAILURE } from "./types";
+
+/**
+ * How long a row keeps waiting for a busy agent before it fails.
+ *
+ * The same budget a simulation turn gives it, so a customer whose agent takes
+ * one call at a time reads one behavior on both screens.
+ */
+export const CONNECTED_BUSY_RETRY_BUDGET_MS = 60_000;
+
+/** Slack over the agent's own budget before the row abandons the call. */
+export const CONNECTED_REQUEST_SLACK_MS = 15_000;
+
+/** What the column sends for one row. */
+export type ConnectedTargetCall = {
+  messages: ProtocolMessage[];
+  params: Record<string, string | number | boolean>;
+};
+
+/**
+ * The conversation for one row.
+ *
+ * A string input is the customer's own question and becomes one user message.
+ * A dataset column of chat messages is already a conversation and travels as
+ * it is, so a multi-turn dataset can be replayed against the agent.
+ */
+const messagesOf = (value: unknown): ProtocolMessage[] => {
+  if (Array.isArray(value)) {
+    const messages = value.filter(
+      (entry): entry is ProtocolMessage =>
+        typeof entry === "object" &&
+        entry !== null &&
+        typeof (entry as { role?: unknown }).role === "string",
+    );
+    if (messages.length > 0) return messages;
+  }
+  const content =
+    typeof value === "string"
+      ? value
+      : value === undefined
+        ? ""
+        : String(value);
+  return [{ role: "user", content }];
+};
+
+/** A mapped cell that holds a number, or nothing when it holds no number. */
+const numberValueOf = (value: unknown): number | undefined => {
+  const parsed = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+};
+
+/** A mapped cell that holds a truth value, written either way round. */
+const booleanValueOf = (value: unknown): boolean | undefined => {
+  if (typeof value === "boolean") return value;
+  const text = String(value).trim().toLowerCase();
+  if (text === "true") return true;
+  if (text === "false") return false;
+  return undefined;
+};
+
+/**
+ * A value read as the type the parameter declares, or nothing.
+ *
+ * A cell that holds nothing, and a value the declared type cannot read, both
+ * read as nothing: the parameter is left out of the call and the function
+ * applies its own default, rather than the agent receiving `NaN` or the text
+ * "undefined".
+ */
+const parameterValueOf = ({
+  value,
+  definition,
+}: {
+  value: unknown;
+  definition: ScenarioParameterDefinition;
+}): string | number | boolean | undefined => {
+  if (value === undefined || value === null || value === "") return undefined;
+  if (definition.type === "number") return numberValueOf(value);
+  if (definition.type === "boolean") return booleanValueOf(value);
+  return typeof value === "string" ? value : String(value);
+};
+
+/**
+ * The turn for one row: the conversation, and the parameter values the agent
+ * declared.
+ *
+ * Only declared names are sent. A column input that names nothing the agent
+ * declares is dropped rather than passed through, because the SDK refuses a
+ * parameter the function has no argument for.
+ */
+export const buildConnectedCall = ({
+  inputs,
+  definitions,
+}: {
+  inputs: Record<string, unknown>;
+  definitions: ScenarioParameterDefinition[];
+}): ConnectedTargetCall => {
+  const params: Record<string, string | number | boolean> = {};
+  for (const definition of definitions) {
+    const value = parameterValueOf({
+      value: inputs[definition.name],
+      definition,
+    });
+    // A parameter with no value keeps the default the function declares, so
+    // nothing is sent for it.
+    if (value !== undefined) params[definition.name] = value;
+  }
+  return { messages: messagesOf(inputs[CONNECTED_INPUT_FIELD]), params };
+};
+
+/** The text of one message, whatever shape its content has. */
+const contentText = (message: ProtocolMessage): string => {
+  const content = (message as { content?: unknown }).content;
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content
+      .map((part) =>
+        typeof part === "string"
+          ? part
+          : typeof (part as { text?: unknown })?.text === "string"
+            ? (part as { text: string }).text
+            : "",
+      )
+      .join("");
+  }
+  return content === undefined ? "" : JSON.stringify(content);
+};
+
+/**
+ * What the cell shows.
+ *
+ * The function may answer with text, one message or a list of them (the
+ * relay's output contract), and an evaluator mapped to the column reads one
+ * text either way. A list is read as its last message, which is the agent's
+ * answer to this turn.
+ */
+export const connectedOutputText = (output: CallOutput): string => {
+  if (typeof output === "string") return output;
+  if (Array.isArray(output)) {
+    const last = output[output.length - 1];
+    return last ? contentText(last) : "";
+  }
+  return contentText(output);
+};
+
+/**
+ * A failed call as the cell records it.
+ *
+ * A handled error travels by its code, so the cell renders the copy that code
+ * is registered with (ADR-045): "no process of this agent is connected", not
+ * a stack message. Anything else is unnamed and reads as the generic failure,
+ * which is what an unanticipated fault should look like.
+ */
+export const connectedCallFailure = (
+  error: unknown,
+): { message: string; domainError?: SerializedHandledError } => {
+  if (HandledError.isHandled(error)) {
+    return { message: error.code, domainError: error.serialize() };
+  }
+  return { message: UNNAMED_FAILURE };
+};

--- a/platform/app/src/server/experiments-v3/execution/orchestrator.ts
+++ b/platform/app/src/server/experiments-v3/execution/orchestrator.ts
@@ -28,12 +28,20 @@ import {
   isGoldenFieldSatisfied,
   LEGACY_PAIRWISE_EVALUATOR_TYPE,
 } from "~/experiments-v3/types";
+import {
+  CONNECTED_OUTPUT_FIELD,
+  connectedParameterDefinitions,
+} from "~/experiments-v3/utils/connectedAgentTarget";
 import { isRowEmpty } from "~/experiments-v3/utils/emptyRowDetection";
 import { toComparisonConfig } from "~/experiments-v3/utils/normalizeComparison";
 import { disambiguateNames } from "~/experiments-v3/utils/variantDisambiguation";
 import { addEnvs } from "~/optimization_studio/server/addEnvs";
 import { loadDatasets } from "~/optimization_studio/server/loadDatasets";
-import type { ExecutionState, Workflow } from "~/optimization_studio/types/dsl";
+import type {
+  ConnectedComponentConfig,
+  ExecutionState,
+  Workflow,
+} from "~/optimization_studio/types/dsl";
 import type {
   StudioClientEvent,
   StudioServerEvent,
@@ -42,6 +50,18 @@ import { nodeErrorToDomainError } from "~/optimization_studio/utils/nodeErrorDom
 import type { TypedAgent } from "~/server/agents/agent.repository";
 import { tryGetAgentSandboxApiKey } from "~/server/api-key/agent-sandbox-key";
 import { getApp } from "~/server/app-layer/app";
+import type {
+  DispatchAgent,
+  DispatchCall,
+} from "~/server/connected-agents/call.dispatcher";
+import type { CallOutcome } from "~/server/connected-agents/call-envelope";
+import {
+  BUSY_RETRY_AFTER_MS,
+  DEFAULT_CALL_TIMEOUT_MS,
+  MAX_CALL_TIMEOUT_MS,
+} from "~/server/connected-agents/constants";
+import { AgentBusyError } from "~/server/connected-agents/errors";
+import { getConnectedAgentRuntime } from "~/server/connected-agents/runtime";
 import { prisma } from "~/server/db";
 import type {
   EvaluatorTypes,
@@ -54,14 +74,23 @@ import type {
 } from "~/server/event-sourcing/pipelines/experiment-run-processing/schemas/commands";
 import type { ESBatchEvaluationTarget } from "~/server/experiments/types";
 import type { VersionedPrompt } from "~/server/prompt-config/prompt.service";
+import type { RunActor } from "~/server/scenarios/run-actor";
+import { assertConnectedAgentsRunnable } from "~/server/suites/connected-targets";
 import {
   estimateCost,
   getMatchingLLMModelCost,
 } from "~/server/tracer/collector/cost";
 import { KSUID_RESOURCES } from "~/utils/constants";
 import { generateHumanReadableId } from "~/utils/humanReadableId";
-import { generateOtelTraceId } from "~/utils/trace";
+import { generateOtelSpanId, generateOtelTraceId } from "~/utils/trace";
 import { abortManager } from "./abortManager";
+import {
+  buildConnectedCall,
+  CONNECTED_BUSY_RETRY_BUDGET_MS,
+  CONNECTED_REQUEST_SLACK_MS,
+  connectedCallFailure,
+  connectedOutputText,
+} from "./connectedTarget";
 import {
   type LoadedWorkflow,
   promptLoadKey,
@@ -133,6 +162,15 @@ export type OrchestratorInput = {
    * whole board and not only the column that was clicked.
    */
   carriedOverCells?: CarriedOverCell[];
+  /**
+   * Who started the run, when a person did.
+   *
+   * Read for one decision: a personal development agent belongs to the person
+   * whose key registered it, and only that person may send a turn to the
+   * process on their machine. A run that names no person is refused by the
+   * same rule, exactly as a simulation is.
+   */
+  actor?: RunActor;
 };
 
 /**
@@ -1942,6 +1980,222 @@ export async function* executeWorkflowCell({
   }
 }
 
+/** One turn to a connected agent, as the cell executor asks for it. */
+export type ConnectedDispatch = (params: {
+  projectId: string;
+  agent: DispatchAgent;
+  call: DispatchCall;
+  signal: AbortSignal;
+}) => Promise<CallOutcome>;
+
+/** The runtime's own dispatcher, which is what a real run uses. */
+const relayDispatch: ConnectedDispatch = (params) =>
+  getConnectedAgentRuntime().dispatcher.dispatch(params);
+
+/**
+ * The agent as the dispatcher reads it, with the per-call budget capped the
+ * same way the relay route caps it. One agent, one contract: a column may not
+ * ask for a longer call than a REST caller can.
+ */
+const dispatchAgentOf = (agent: TypedAgent): DispatchAgent => {
+  const config = agent.config as ConnectedComponentConfig;
+  return {
+    id: agent.id,
+    name: agent.name,
+    environment: agent.environment ?? null,
+    timeoutMs: Math.min(
+      config.timeoutMs ?? DEFAULT_CALL_TIMEOUT_MS,
+      MAX_CALL_TIMEOUT_MS,
+    ),
+    // A workbench row is a conversation of one turn, so there is nothing to
+    // pin: every row picks whichever instance is free.
+    isSticky: false,
+  };
+};
+
+/**
+ * Executes a single cell whose target is a connected agent.
+ *
+ * The agent runs in the customer's own process, so the engine has no node for
+ * it: the row is one turn through the relay dispatcher (ADR-128), sent from
+ * here and answered in place. The evaluators attached to the column then run
+ * exactly as they do for a workflow target, over the text the agent answered.
+ *
+ * Each row is its own conversation. A workbench row has no history to carry,
+ * so it sends one user message under its own thread id and keeps no session:
+ * what one row said can never reach another.
+ */
+export async function* executeConnectedCell({
+  cell,
+  projectId,
+  agent,
+  datasetColumns = [],
+  loadedEvaluators,
+  resultMapperConfig,
+  isAborted,
+  dispatch = relayDispatch,
+  sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms)),
+  now = () => Date.now(),
+}: {
+  cell: ExecutionCell;
+  projectId: string;
+  agent: TypedAgent;
+  datasetColumns?: Array<{ id: string; name: string; type: string }>;
+  loadedEvaluators?: Map<string, { id: string; name: string; config: unknown }>;
+  resultMapperConfig?: ResultMapperConfig;
+  isAborted?: () => Promise<boolean>;
+  /** The dispatcher the turn goes through, replaceable in tests. */
+  dispatch?: ConnectedDispatch;
+  /** The wait between busy retries, replaceable in tests. */
+  sleep?: (ms: number) => Promise<void>;
+  /** The clock the retry budget reads, replaceable in tests. */
+  now?: () => number;
+}): AsyncGenerator<EvaluationV3Event> {
+  yield {
+    type: "cell_started",
+    rowIndex: cell.rowIndex,
+    targetId: cell.targetId,
+  };
+
+  const traceId = cell.traceId ?? generateOtelTraceId();
+  const dispatchAgent = dispatchAgentOf(agent);
+  const startedAt = now();
+
+  let outcome: CallOutcome;
+  try {
+    const { messages, params } = buildConnectedCall({
+      inputs: buildTargetInputs(cell),
+      definitions: connectedParameterDefinitions(agent.config),
+    });
+    outcome = await dispatchWithBusyRetry({
+      dispatch,
+      sleep,
+      now,
+      budgetEndsAt: startedAt + CONNECTED_BUSY_RETRY_BUDGET_MS,
+      params: {
+        projectId,
+        agent: dispatchAgent,
+        call: {
+          // One row, one conversation. The cell's own trace id keeps it
+          // unique and ties the conversation to the row that started it.
+          threadId: `eval_v3_${cell.rowIndex}_${traceId}`,
+          messages,
+          newMessages: messages.slice(-1),
+          params,
+          session: undefined,
+          // The agent adopts this context, so the spans it records land in
+          // the cell's own trace and the row links straight to them.
+          traceparent: `00-${traceId}-${generateOtelSpanId()}-01`,
+          run: {},
+        },
+        signal: AbortSignal.timeout(
+          dispatchAgent.timeoutMs + CONNECTED_REQUEST_SLACK_MS,
+        ),
+      },
+    });
+  } catch (error) {
+    logger.info(
+      {
+        error,
+        projectId,
+        agentId: agent.id,
+        rowIndex: cell.rowIndex,
+        targetId: cell.targetId,
+      },
+      "Connected agent cell failed",
+    );
+    const failure = connectedCallFailure(error);
+    yield {
+      type: "target_result",
+      rowIndex: cell.rowIndex,
+      targetId: cell.targetId,
+      output: undefined,
+      duration: now() - startedAt,
+      traceId,
+      error: failure.message,
+      ...(failure.domainError ? { domainError: failure.domainError } : {}),
+    };
+    return;
+  }
+
+  const output = connectedOutputText(outcome.output);
+
+  yield {
+    type: "target_result",
+    rowIndex: cell.rowIndex,
+    targetId: cell.targetId,
+    output,
+    duration: outcome.durationMs,
+    traceId,
+  };
+
+  if (cell.evaluatorConfigs.length === 0) return;
+
+  const { workflow, evaluatorNodeIds } = buildEvaluatorCellWorkflow({
+    projectId,
+    cell,
+    datasetColumns,
+    loadedEvaluators,
+  });
+  yield* runCellEvaluators({
+    cell,
+    projectId,
+    workflow,
+    evaluatorNodeIds,
+    targetOutput: { [CONNECTED_OUTPUT_FIELD]: output },
+    traceId,
+    targetNodes: new Set([cell.targetId]),
+    config: resultMapperConfig ?? {},
+    isAborted,
+  });
+}
+
+/**
+ * One turn, waiting out a busy agent.
+ *
+ * Every instance being full is a queue, not a failure: the platform says when
+ * to try again and the row waits, the same way a simulation turn does. The
+ * budget bounds it so a permanently full agent still fails the row rather
+ * than holding a slot of the run forever.
+ */
+const dispatchWithBusyRetry = async ({
+  dispatch,
+  params,
+  sleep,
+  now,
+  budgetEndsAt,
+}: {
+  dispatch: ConnectedDispatch;
+  params: Parameters<ConnectedDispatch>[0];
+  sleep: (ms: number) => Promise<void>;
+  now: () => number;
+  budgetEndsAt: number;
+}): Promise<CallOutcome> => {
+  for (;;) {
+    try {
+      return await dispatch(params);
+    } catch (error) {
+      const retryAfterMs = busyRetryAfterMs(error);
+      if (retryAfterMs === undefined || now() >= budgetEndsAt) throw error;
+      // Jitter spreads the retries of the rows that hit a full agent at once.
+      const waitMs = Math.min(
+        retryAfterMs + Math.floor(Math.random() * retryAfterMs),
+        budgetEndsAt - now(),
+      );
+      await sleep(Math.max(0, waitMs));
+    }
+  }
+};
+
+/** How long a busy agent asked to be left alone, or nothing if it is not busy. */
+const busyRetryAfterMs = (error: unknown): number | undefined => {
+  if (!(error instanceof AgentBusyError)) return undefined;
+  const declared = error.meta?.retryAfterMs;
+  return typeof declared === "number" && declared > 0
+    ? declared
+    : BUSY_RETRY_AFTER_MS;
+};
+
 // Shared by the pairwise (#5100) and select-best (#5101) branches:
 // resolve `inputs.input` from the variant's dataset mapping, or fall back
 // to the dataset's `input` column. Kept as a mutating helper (rather than
@@ -2827,7 +3081,17 @@ export async function* runOrchestrator(
     concurrency: requestedConcurrency,
     seedTargetOutputs,
     carriedOverCells,
+    actor,
   } = input;
+
+  // A personal development agent runs on one person's own machine, so only
+  // that person may send it a turn. Refused before any cell exists, the way a
+  // simulation refuses it when the run is scheduled.
+  await assertConnectedAgentsRunnable({
+    agents: [...loadedAgents.values()],
+    actor,
+    users: prisma,
+  });
 
   // Use requested concurrency, environment variable, or default
   const concurrency = requestedConcurrency ?? DEFAULT_CONCURRENCY;
@@ -3243,25 +3507,43 @@ export async function* runOrchestrator(
                   loadedData.agent?.type === "workflow")) &&
               !!loadedData.workflow;
 
-            const cellEvents = runsAsWorkflow
-              ? executeWorkflowCell({
+            // A connected agent has no node in the engine: it runs in the
+            // customer's own process and is reached through the relay.
+            const connectedAgent =
+              cell.targetConfig.type === "agent" &&
+              loadedData.agent?.type === "connected"
+                ? loadedData.agent
+                : undefined;
+
+            const cellEvents = connectedAgent
+              ? executeConnectedCell({
                   cell,
                   projectId,
-                  workflowDsl: loadedData.workflow!.dsl,
+                  agent: connectedAgent,
                   datasetColumns,
                   loadedEvaluators,
                   resultMapperConfig,
                   isAborted: checkAbort,
-                  sandboxApiKey,
                 })
-              : executeCell(
-                  cell,
-                  projectId,
-                  datasetColumns,
-                  loadedData,
-                  resultMapperConfig,
-                  checkAbort,
-                );
+              : runsAsWorkflow
+                ? executeWorkflowCell({
+                    cell,
+                    projectId,
+                    workflowDsl: loadedData.workflow!.dsl,
+                    datasetColumns,
+                    loadedEvaluators,
+                    resultMapperConfig,
+                    isAborted: checkAbort,
+                    sandboxApiKey,
+                  })
+                : executeCell(
+                    cell,
+                    projectId,
+                    datasetColumns,
+                    loadedData,
+                    resultMapperConfig,
+                    checkAbort,
+                  );
 
             // Execute cell and collect events
             let cellFailed = false;

--- a/platform/app/src/server/experiments-v3/execution/orchestrator.ts
+++ b/platform/app/src/server/experiments-v3/execution/orchestrator.ts
@@ -2126,31 +2126,79 @@ interface ConnectedCellInput {
  * so it sends one user message under its own thread id and keeps no session:
  * what one row said can never reach another.
  */
-export async function* executeConnectedCell({
-  cell,
-  projectId,
-  agent,
-  datasetColumns = [],
-  loadedEvaluators,
-  resultMapperConfig,
-  isAborted,
-  dispatch = relayDispatch,
-  sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms)),
-  now = () => Date.now(),
-}: ConnectedCellInput): AsyncGenerator<EvaluationV3Event> {
+export async function* executeConnectedCell(
+  input: ConnectedCellInput,
+): AsyncGenerator<EvaluationV3Event> {
+  const { cell, projectId, agent } = input;
+  const now = input.now ?? (() => Date.now());
+  const traceId = cell.traceId ?? generateOtelTraceId();
+  const startedAt = now();
+
   yield {
     type: "cell_started",
     rowIndex: cell.rowIndex,
     targetId: cell.targetId,
   };
 
-  const traceId = cell.traceId ?? generateOtelTraceId();
-  const dispatchAgent = dispatchAgentOf(agent);
-  const startedAt = now();
+  const turn = await connectedTurn({ input: { ...input, now }, traceId, startedAt });
 
-  let outcome: CallOutcome;
+  if (!turn.ok) {
+    yield connectedFailureEvent({
+      cell,
+      projectId,
+      agentId: agent.id,
+      error: turn.error,
+      traceId,
+      duration: now() - startedAt,
+    });
+    return;
+  }
+
+  const output = connectedOutputText(turn.outcome.output);
+
+  yield {
+    type: "target_result",
+    rowIndex: cell.rowIndex,
+    targetId: cell.targetId,
+    output,
+    // The whole cell, not only the call that answered: a row that waited out
+    // a busy agent took that time too, and a run comparison reads it.
+    duration: now() - startedAt,
+    traceId,
+  };
+
+  yield* gradeConnectedAnswer({ input, output, traceId });
+}
+
+/**
+ * The one turn the row sends, retried while the agent is busy.
+ *
+ * The refusal comes back rather than being thrown, so the caller renders it
+ * as the cell's own failure instead of ending the run.
+ */
+const connectedTurn = async ({
+  input,
+  traceId,
+  startedAt,
+}: {
+  input: ConnectedCellInput;
+  traceId: string;
+  startedAt: number;
+}): Promise<
+  { ok: true; outcome: CallOutcome } | { ok: false; error: unknown }
+> => {
+  const {
+    cell,
+    projectId,
+    agent,
+    isAborted,
+    dispatch = relayDispatch,
+    sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms)),
+    now = () => Date.now(),
+  } = input;
+  const dispatchAgent = dispatchAgentOf(agent);
   try {
-    outcome = await dispatchWithBusyRetry({
+    const outcome = await dispatchWithBusyRetry({
       dispatch,
       sleep,
       now,
@@ -2165,31 +2213,35 @@ export async function* executeConnectedCell({
         traceId,
       }),
     });
+    return { ok: true, outcome };
   } catch (error) {
-    yield connectedFailureEvent({
-      cell,
-      projectId,
-      agentId: agent.id,
-      error,
-      traceId,
-      duration: now() - startedAt,
-    });
-    return;
+    return { ok: false, error };
   }
+};
 
-  const output = connectedOutputText(outcome.output);
-
-  yield {
-    type: "target_result",
-    rowIndex: cell.rowIndex,
-    targetId: cell.targetId,
-    output,
-    // The whole cell, not only the call that answered: a row that waited out
-    // a busy agent took that time too, and a run comparison reads it.
-    duration: now() - startedAt,
-    traceId,
-  };
-
+/**
+ * The evaluators of the column, over the answer the turn gave.
+ *
+ * They run through the same path a workflow target uses, so a connected
+ * column scores, costs and traces the way every other column does.
+ */
+async function* gradeConnectedAnswer({
+  input,
+  output,
+  traceId,
+}: {
+  input: ConnectedCellInput;
+  output: string;
+  traceId: string;
+}): AsyncGenerator<EvaluationV3Event> {
+  const {
+    cell,
+    projectId,
+    datasetColumns = [],
+    loadedEvaluators,
+    resultMapperConfig,
+    isAborted,
+  } = input;
   if (cell.evaluatorConfigs.length === 0) return;
 
   const { workflow, evaluatorNodeIds } = buildEvaluatorCellWorkflow({

--- a/platform/app/src/server/experiments-v3/execution/orchestrator.ts
+++ b/platform/app/src/server/experiments-v3/execution/orchestrator.ts
@@ -2303,20 +2303,41 @@ const dispatchWithBusyRetry = async ({
         signal: AbortSignal.timeout(callTimeoutMs),
       });
     } catch (error) {
-      const retryAfterMs = busyRetryAfterMs(error);
-      if (retryAfterMs === undefined || now() >= budgetEndsAt) throw error;
-      // A stopped run waits for nothing: the row fails now rather than
-      // holding a slot of the run for the rest of the budget.
-      if (isAborted && (await isAborted())) throw error;
-      // Jitter spreads the retries of the rows that hit a full agent at once.
-      const waitMs = Math.min(
-        retryAfterMs + Math.floor(Math.random() * retryAfterMs),
-        budgetEndsAt - now(),
-      );
-      await sleep(Math.max(0, waitMs));
+      const waitMs = await busyWaitMs({ error, now, budgetEndsAt, isAborted });
+      if (waitMs === undefined) throw error;
+      await sleep(waitMs);
     }
   }
 };
+
+/**
+ * How long to wait before the next attempt, or nothing when the turn must
+ * fail now.
+ *
+ * It fails now for three reasons: the agent refused for a reason other than
+ * being busy, the retry budget is spent, or the run was stopped. A stopped run
+ * waits for nothing, so the row fails rather than holding a slot of the run
+ * for the rest of the budget.
+ */
+async function busyWaitMs({
+  error,
+  now,
+  budgetEndsAt,
+  isAborted,
+}: {
+  error: unknown;
+  now: () => number;
+  budgetEndsAt: number;
+  isAborted?: () => Promise<boolean>;
+}): Promise<number | undefined> {
+  const retryAfterMs = busyRetryAfterMs(error);
+  if (retryAfterMs === undefined || now() >= budgetEndsAt) return undefined;
+  if (isAborted && (await isAborted())) return undefined;
+
+  // Jitter spreads the retries of the rows that hit a full agent at once.
+  const jittered = retryAfterMs + Math.floor(Math.random() * retryAfterMs);
+  return Math.max(0, Math.min(jittered, budgetEndsAt - now()));
+}
 
 /** How long a busy agent asked to be left alone, or nothing if it is not busy. */
 const busyRetryAfterMs = (error: unknown): number | undefined => {

--- a/platform/app/src/server/experiments-v3/execution/orchestrator.ts
+++ b/platform/app/src/server/experiments-v3/execution/orchestrator.ts
@@ -2014,6 +2014,110 @@ const dispatchAgentOf = (agent: TypedAgent): DispatchAgent => {
 };
 
 /**
+ * The one turn a row sends: the mapped row as a single user message, in its
+ * own conversation and inside the trace of the cell.
+ */
+const connectedTurnParams = ({
+  cell,
+  projectId,
+  agent,
+  dispatchAgent,
+  traceId,
+}: {
+  cell: ExecutionCell;
+  projectId: string;
+  agent: TypedAgent;
+  dispatchAgent: ReturnType<typeof dispatchAgentOf>;
+  traceId: string;
+}): Parameters<ConnectedDispatch>[0] => {
+  const { messages, params } = buildConnectedCall({
+    inputs: buildTargetInputs(cell),
+    definitions: connectedParameterDefinitions(agent.config),
+  });
+  return {
+    projectId,
+    agent: dispatchAgent,
+    call: {
+      // One row, one conversation. The cell's own trace id keeps it unique
+      // and ties the conversation to the row that started it.
+      threadId: `eval_v3_${cell.rowIndex}_${traceId}`,
+      messages,
+      newMessages: messages.slice(-1),
+      params,
+      session: undefined,
+      // The agent adopts this context, so the spans it records land in the
+      // cell's own trace and the row links straight to them.
+      traceparent: `00-${traceId}-${generateOtelSpanId()}-01`,
+      run: {},
+    },
+    signal: AbortSignal.timeout(
+      dispatchAgent.timeoutMs + CONNECTED_REQUEST_SLACK_MS,
+    ),
+  };
+};
+
+/**
+ * What the cell shows when the turn did not answer.
+ *
+ * A named failure keeps its code, so the cell renders the copy of that code
+ * instead of a generic unknown error.
+ */
+const connectedFailureEvent = ({
+  cell,
+  projectId,
+  agentId,
+  error,
+  traceId,
+  duration,
+}: {
+  cell: ExecutionCell;
+  projectId: string;
+  agentId: string;
+  error: unknown;
+  traceId: string;
+  duration: number;
+}): EvaluationV3Event => {
+  logger.info(
+    {
+      error,
+      projectId,
+      agentId,
+      rowIndex: cell.rowIndex,
+      targetId: cell.targetId,
+    },
+    "Connected agent cell failed",
+  );
+  const failure = connectedCallFailure(error);
+  return {
+    type: "target_result",
+    rowIndex: cell.rowIndex,
+    targetId: cell.targetId,
+    output: undefined,
+    duration,
+    traceId,
+    error: failure.message,
+    ...(failure.domainError ? { domainError: failure.domainError } : {}),
+  };
+};
+
+/** What one connected agent cell needs to run. */
+interface ConnectedCellInput {
+  cell: ExecutionCell;
+  projectId: string;
+  agent: TypedAgent;
+  datasetColumns?: Array<{ id: string; name: string; type: string }>;
+  loadedEvaluators?: Map<string, { id: string; name: string; config: unknown }>;
+  resultMapperConfig?: ResultMapperConfig;
+  isAborted?: () => Promise<boolean>;
+  /** The dispatcher the turn goes through, replaceable in tests. */
+  dispatch?: ConnectedDispatch;
+  /** The wait between busy retries, replaceable in tests. */
+  sleep?: (ms: number) => Promise<void>;
+  /** The clock the retry budget reads, replaceable in tests. */
+  now?: () => number;
+}
+
+/**
  * Executes a single cell whose target is a connected agent.
  *
  * The agent runs in the customer's own process, so the engine has no node for
@@ -2036,21 +2140,7 @@ export async function* executeConnectedCell({
   dispatch = relayDispatch,
   sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms)),
   now = () => Date.now(),
-}: {
-  cell: ExecutionCell;
-  projectId: string;
-  agent: TypedAgent;
-  datasetColumns?: Array<{ id: string; name: string; type: string }>;
-  loadedEvaluators?: Map<string, { id: string; name: string; config: unknown }>;
-  resultMapperConfig?: ResultMapperConfig;
-  isAborted?: () => Promise<boolean>;
-  /** The dispatcher the turn goes through, replaceable in tests. */
-  dispatch?: ConnectedDispatch;
-  /** The wait between busy retries, replaceable in tests. */
-  sleep?: (ms: number) => Promise<void>;
-  /** The clock the retry budget reads, replaceable in tests. */
-  now?: () => number;
-}): AsyncGenerator<EvaluationV3Event> {
+}: ConnectedCellInput): AsyncGenerator<EvaluationV3Event> {
   yield {
     type: "cell_started",
     rowIndex: cell.rowIndex,
@@ -2063,58 +2153,28 @@ export async function* executeConnectedCell({
 
   let outcome: CallOutcome;
   try {
-    const { messages, params } = buildConnectedCall({
-      inputs: buildTargetInputs(cell),
-      definitions: connectedParameterDefinitions(agent.config),
-    });
     outcome = await dispatchWithBusyRetry({
       dispatch,
       sleep,
       now,
       budgetEndsAt: startedAt + CONNECTED_BUSY_RETRY_BUDGET_MS,
-      params: {
+      params: connectedTurnParams({
+        cell,
         projectId,
-        agent: dispatchAgent,
-        call: {
-          // One row, one conversation. The cell's own trace id keeps it
-          // unique and ties the conversation to the row that started it.
-          threadId: `eval_v3_${cell.rowIndex}_${traceId}`,
-          messages,
-          newMessages: messages.slice(-1),
-          params,
-          session: undefined,
-          // The agent adopts this context, so the spans it records land in
-          // the cell's own trace and the row links straight to them.
-          traceparent: `00-${traceId}-${generateOtelSpanId()}-01`,
-          run: {},
-        },
-        signal: AbortSignal.timeout(
-          dispatchAgent.timeoutMs + CONNECTED_REQUEST_SLACK_MS,
-        ),
-      },
+        agent,
+        dispatchAgent,
+        traceId,
+      }),
     });
   } catch (error) {
-    logger.info(
-      {
-        error,
-        projectId,
-        agentId: agent.id,
-        rowIndex: cell.rowIndex,
-        targetId: cell.targetId,
-      },
-      "Connected agent cell failed",
-    );
-    const failure = connectedCallFailure(error);
-    yield {
-      type: "target_result",
-      rowIndex: cell.rowIndex,
-      targetId: cell.targetId,
-      output: undefined,
-      duration: now() - startedAt,
+    yield connectedFailureEvent({
+      cell,
+      projectId,
+      agentId: agent.id,
+      error,
       traceId,
-      error: failure.message,
-      ...(failure.domainError ? { domainError: failure.domainError } : {}),
-    };
+      duration: now() - startedAt,
+    });
     return;
   }
 

--- a/platform/app/src/server/experiments-v3/execution/orchestrator.ts
+++ b/platform/app/src/server/experiments-v3/execution/orchestrator.ts
@@ -2140,7 +2140,11 @@ export async function* executeConnectedCell(
     targetId: cell.targetId,
   };
 
-  const turn = await connectedTurn({ input: { ...input, now }, traceId, startedAt });
+  const turn = await connectedTurn({
+    input: { ...input, now },
+    traceId,
+    startedAt,
+  });
 
   if (!turn.ok) {
     yield connectedFailureEvent({

--- a/platform/app/src/server/experiments-v3/execution/orchestrator.ts
+++ b/platform/app/src/server/experiments-v3/execution/orchestrator.ts
@@ -2029,7 +2029,7 @@ const connectedTurnParams = ({
   agent: TypedAgent;
   dispatchAgent: ReturnType<typeof dispatchAgentOf>;
   traceId: string;
-}): Parameters<ConnectedDispatch>[0] => {
+}): Omit<Parameters<ConnectedDispatch>[0], "signal"> => {
   const { messages, params } = buildConnectedCall({
     inputs: buildTargetInputs(cell),
     definitions: connectedParameterDefinitions(agent.config),
@@ -2050,9 +2050,6 @@ const connectedTurnParams = ({
       traceparent: `00-${traceId}-${generateOtelSpanId()}-01`,
       run: {},
     },
-    signal: AbortSignal.timeout(
-      dispatchAgent.timeoutMs + CONNECTED_REQUEST_SLACK_MS,
-    ),
   };
 };
 
@@ -2157,7 +2154,9 @@ export async function* executeConnectedCell({
       dispatch,
       sleep,
       now,
+      isAborted,
       budgetEndsAt: startedAt + CONNECTED_BUSY_RETRY_BUDGET_MS,
+      callTimeoutMs: dispatchAgent.timeoutMs + CONNECTED_REQUEST_SLACK_MS,
       params: connectedTurnParams({
         cell,
         projectId,
@@ -2185,7 +2184,9 @@ export async function* executeConnectedCell({
     rowIndex: cell.rowIndex,
     targetId: cell.targetId,
     output,
-    duration: outcome.durationMs,
+    // The whole cell, not only the call that answered: a row that waited out
+    // a busy agent took that time too, and a run comparison reads it.
+    duration: now() - startedAt,
     traceId,
   };
 
@@ -2223,20 +2224,34 @@ const dispatchWithBusyRetry = async ({
   params,
   sleep,
   now,
+  isAborted,
   budgetEndsAt,
+  callTimeoutMs,
 }: {
   dispatch: ConnectedDispatch;
-  params: Parameters<ConnectedDispatch>[0];
+  params: Omit<Parameters<ConnectedDispatch>[0], "signal">;
   sleep: (ms: number) => Promise<void>;
   now: () => number;
+  isAborted?: () => Promise<boolean>;
   budgetEndsAt: number;
+  callTimeoutMs: number;
 }): Promise<CallOutcome> => {
   for (;;) {
     try {
-      return await dispatch(params);
+      // Every attempt gets its own deadline. One shared signal would carry
+      // the time the earlier attempts and their waits already spent, so an
+      // agent that declares a timeout shorter than the retry budget would
+      // abort a later attempt the moment it starts.
+      return await dispatch({
+        ...params,
+        signal: AbortSignal.timeout(callTimeoutMs),
+      });
     } catch (error) {
       const retryAfterMs = busyRetryAfterMs(error);
       if (retryAfterMs === undefined || now() >= budgetEndsAt) throw error;
+      // A stopped run waits for nothing: the row fails now rather than
+      // holding a slot of the run for the rest of the budget.
+      if (isAborted && (await isAborted())) throw error;
       // Jitter spreads the retries of the rows that hit a full agent at once.
       const waitMs = Math.min(
         retryAfterMs + Math.floor(Math.random() * retryAfterMs),

--- a/platform/app/src/server/routes/experiments-v3.ts
+++ b/platform/app/src/server/routes/experiments-v3.ts
@@ -726,6 +726,16 @@ secured.access(apiKeyAuthRun).post(
     const acceptHeader = c.req.header("Accept") ?? "";
     const isSSE = acceptHeader.includes("text/event-stream");
 
+    // The person behind the key, when the key names one. A personal
+    // development agent is reachable only by its owner, and a key that names
+    // no person is refused by that rule rather than passed through. Both the
+    // streaming and the polling variant of this route run the same agents, so
+    // both carry the same actor.
+    const keyActor =
+      resolved.type === "apiKey" && resolved.userId
+        ? { actor: { id: resolved.userId, label: "api" as const } }
+        : {};
+
     logger.info(
       { projectId: project.id, slug, isSSE, rowCount: datasetRows.length },
       "Starting CI/CD experiment execution",
@@ -748,6 +758,7 @@ secured.access(apiKeyAuthRun).post(
             loadedEvaluators,
             loadedWorkflows,
             ...(carriedOverCells.length > 0 ? { carriedOverCells } : {}),
+            ...keyActor,
           });
 
           for await (const event of orchestrator) {
@@ -798,12 +809,7 @@ secured.access(apiKeyAuthRun).post(
       loadedEvaluators,
       loadedWorkflows,
       ...(carriedOverCells.length > 0 ? { carriedOverCells } : {}),
-      // The person behind the key, when the key names one. A personal
-      // development agent is reachable only by its owner, and a key that
-      // names nobody is refused by that rule rather than passed through.
-      ...(resolved.type === "apiKey" && resolved.userId
-        ? { actor: { id: resolved.userId, label: "api" as const } }
-        : {}),
+      ...keyActor,
       // A run of the saved dataset fills the cells the workbench shows. The
       // app-layer service is the one that tells the tenant the experiment
       // moved, which is what makes an open page pick the cells up.

--- a/platform/app/src/server/routes/experiments-v3.ts
+++ b/platform/app/src/server/routes/experiments-v3.ts
@@ -411,6 +411,11 @@ secured.access(sessionAuth).post(
           loadedWorkflows,
           concurrency: request.concurrency,
           seedTargetOutputs: request.seedTargetOutputs,
+          // Who is running it, which decides whether a personal development
+          // agent among the targets may be reached at all.
+          ...(session.user?.id
+            ? { actor: { id: session.user.id, label: "user" as const } }
+            : {}),
           // The board as the page had it, minus what this run produces. The
           // page sends it rather than the server reading the saved state,
           // because the page can be ahead of its own autosave and the run has
@@ -793,6 +798,12 @@ secured.access(apiKeyAuthRun).post(
       loadedEvaluators,
       loadedWorkflows,
       ...(carriedOverCells.length > 0 ? { carriedOverCells } : {}),
+      // The person behind the key, when the key names one. A personal
+      // development agent is reachable only by its owner, and a key that
+      // names nobody is refused by that rule rather than passed through.
+      ...(resolved.type === "apiKey" && resolved.userId
+        ? { actor: { id: resolved.userId, label: "api" as const } }
+        : {}),
       // A run of the saved dataset fills the cells the workbench shows. The
       // app-layer service is the one that tells the tenant the experiment
       // moved, which is what makes an open page pick the cells up.

--- a/specs/agents/connected-agents.feature
+++ b/specs/agents/connected-agents.feature
@@ -250,6 +250,12 @@ Feature: Connected agents
     And the refusal carries a retry delay
 
   @unit
+  Scenario: An instance that refuses a call as busy keeps the busy code
+    Given one live instance that answers with the busy code
+    When a call is dispatched to it
+    Then the call fails with "agent_busy"
+
+  @unit
   Scenario: The instance with the most free slots is picked
     Given two live instances, one with a call in flight and one idle
     When a call is dispatched

--- a/specs/experiments-v3/connected-agent-target.feature
+++ b/specs/experiments-v3/connected-agent-target.feature
@@ -1,0 +1,98 @@
+Feature: A connected agent is a column in the workbench
+
+  A connected agent runs in the customer's own process: the SDK decorator
+  registers the function and the platform reaches it through the relay
+  (ADR-128). Agent Testing could already run simulations against it. The
+  workbench could not, so the same function that a customer simulates could
+  not be measured against a dataset.
+
+  A connected agent is now a target column like any other. The column sends
+  one turn per dataset row, writes the answer in the cell, and the evaluators
+  of the workbench grade that answer. Two columns of the same agent with
+  different parameter values compare side by side.
+
+  Each row is its own conversation: the column sends one user message and
+  keeps no session between rows, so a row never reads what another row said.
+
+  Background:
+    Given a project with a connected agent "support-agent" that is online
+    And the agent declares the parameters "model" and "plan"
+
+  @unit
+  Scenario: The column reads the dataset row and answers
+    Given a dataset with an "input" column
+    And a connected agent column with "input" mapped to that column
+    When the row runs
+    Then the agent receives one user message with the row's input
+    And the cell shows what the agent answered
+
+  @unit
+  Scenario: Every row is a separate conversation
+    Given a connected agent column over a dataset with three rows
+    When the rows run
+    Then each row sends its own conversation id
+    And no row carries the session of another row
+
+  @unit
+  Scenario: The declared parameters are column inputs
+    Given the person adds "support-agent" as a target
+    Then the column reads "input"
+    And the column offers "model" and "plan" as optional inputs
+    And a parameter with no value keeps the agent's own default
+
+  @unit
+  Scenario: A parameter value reaches the agent as its declared type
+    Given a connected agent column with "model" set to the value "gpt-5"
+    When the row runs
+    Then the call carries the parameter "model" with the value "gpt-5"
+    And a name the agent does not declare is not sent
+
+  @unit
+  Scenario: The answer is text, whatever shape the function returned
+    Given the function answers with a message object rather than a string
+    When the row runs
+    Then the cell shows the message content
+    And an evaluator mapped to the column output reads the same text
+
+  @integration
+  Scenario: The evaluators grade the agent's answer
+    Given a connected agent column and an exact match evaluator
+    When the row runs
+    Then the evaluator reads the agent's answer as the column output
+    And the evaluator score shows under the column
+
+  @integration
+  Scenario: Two parameter values compare side by side
+    Given a connected agent column with "model" set to "gpt-5-mini"
+    And a second column of the same agent with "model" set to "gpt-5"
+    When the rows run
+    Then each column shows the answer of its own parameter value
+    And the evaluators score the two columns separately
+
+  @integration
+  Scenario: An offline agent names itself in the failure
+    Given no process of "support-agent" is connected
+    When the row runs
+    Then the cell fails with the offline error code
+    And the copy names the agent, not an unknown error
+
+  @integration
+  Scenario: A busy agent is retried before the row fails
+    Given every instance of "support-agent" is busy
+    When the row runs
+    Then the call is tried again inside the retry budget
+    And the row fails with the busy error code when the budget ends
+
+  @integration
+  Scenario: The agent's own spans join the cell's trace
+    Given a connected agent column
+    When the row runs
+    Then the call carries the cell's trace context
+    And the trace of the cell holds the spans the agent recorded
+
+  @integration
+  Scenario: Another person's development agent is refused
+    Given "support-agent" is a personal development agent of another person
+    When the run starts
+    Then the run is refused with the owner-only error code
+    And no call is sent to the agent


### PR DESCRIPTION
## What

A connected agent is now a target column in the Experiments workbench. You add
the agent the same way you add a prompt, map the turn to a dataset column, set
the run parameters the function declares, and run the evaluation. Evaluators
grade the answer, and a second column of the same agent with a different
parameter value gives you a side by side comparison.

Before this change the workbench refused it: the workflow builder threw
"Connected agent target cannot run inside an experiment workflow", and the
target type list had no `connected` type. A customer asked for this.

## How it works

Each cell sends one turn to the agent through
`getConnectedAgentRuntime().dispatcher.dispatch`, in the app process. There is
no engine node and no HTTP hop, so a local or self hosted install needs no
network path back to itself and no project API key inside a workflow payload.
The cell then grades the answer with the column evaluators through the path the
workflow target already uses, so results, cost, duration, traces and comparison
columns work with no new plumbing.

- `executeConnectedCell` in `src/server/experiments-v3/execution/orchestrator.ts`
  runs the cell, yields the answer and then the evaluator results.
- `src/server/experiments-v3/execution/connectedTarget.ts` builds the call,
  reads the answer text out of whatever shape the function returned, and names
  the failure.
- `src/experiments-v3/utils/connectedAgentTarget.ts` owns the column fields:
  one `input` field for the turn, plus one optional field for every parameter
  the function declares, typed from the declaration.
- The column inputs are mapped in the connected agent drawer, which now shows
  the Input Variables section when the workbench opened it.
- Each row is a separate conversation. The thread id carries the row index and
  the cell trace id, and the call carries a `traceparent`, so the agent's own
  spans join the cell's trace.
- `runOrchestrator` takes the actor and calls `assertConnectedAgentsRunnable`,
  so a run that names another person's development agent is refused with
  `agent_owner_only`.

It also fixes a defect the feature exposed: an instance that already runs its
declared number of calls answers with the busy code, and the dispatcher read
that as the function's own error, so the row failed at once. The dispatcher now
raises the busy error, and the cell waits and sends the turn again.

## Dogfood

Local stack, one Python agent connected with `@langwatch.connect_agent`, a four
row dataset, two columns of the same agent (`model` fixed to `gpt-5-mini` and to
`gpt-5`) and one LLM as judge evaluator.

Choose the agent. A connected agent is in the list with its own type:

![Choose agent](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/connected-agents/experiments-choose-connected-agent.png)

The column reads the agent's contract: the turn, the declared parameters with
their options and defaults, and the processes that hold the agent:

![Column setup](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/connected-agents/experiments-connected-agent-column.png)

The run. Every row is answered by the customer's own function, and the
evaluator grades the answer:

![Run](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/connected-agents/experiments-connected-agent-run.png)

The comparison. Same agent, two models, one dataset: cost, latency and pass
rate side by side:

![Comparison](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/connected-agents/experiments-connected-agent-comparison.png)

## Tests

- `specs/experiments-v3/connected-agent-target.feature`, 11 scenarios, all bound.
- One scenario added to `specs/agents/connected-agents.feature` for the busy code.
- Unit: `connectedTarget.unit.test.ts`, `connectedAgentTarget.unit.test.ts`,
  `call.dispatcher.unit.test.ts`.
- Integration: `connectedCell.integration.test.ts` covers the answer, the
  traceparent, one conversation per row, the evaluator grading, the offline
  code, the busy retry, the two column comparison and the owner only refusal.
- `pnpm typecheck`, `pnpm test:unit`, `pnpm test:component` and
  `pnpm check:feature-parity` pass.

## Deployment impact

None. No new environment variable, no schema change, no helm change.

https://claude.ai/code/session_0124pVPYQNvQW4nrU4MNUVrp


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for using connected agents as experiment target columns.
  * Connected agents can receive mapped dataset inputs and parameters, process one turn per row, and return answers for evaluation.
  * Added connected-agent status, labeling, and icons throughout the interface.
  * Added retry handling for busy agents and clear offline or access-related run failures.

* **Bug Fixes**
  * Busy-agent responses are now reported consistently as retryable busy errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->