### PR TITLE
fix(agent-testing): the Results tab reads what the window holds

### DIFF
--- a/platform/app/src/components/agent-testing/AgentTestingPage.tsx
+++ b/platform/app/src/components/agent-testing/AgentTestingPage.tsx
@@ -18,13 +18,21 @@ import { AgentTestingHeader } from "./AgentTestingHeader";
 import { AgentTestingCaseEditor } from "./cases/AgentTestingCaseEditor";
 import { TestCasesTab } from "./cases/TestCasesTab";
 import { ResultsTab } from "./results/ResultsTab";
+import { toRunPlanSuites } from "./results/run-plans";
 import { RunPlanDialogHost } from "./run/RunPlanDialogHost";
 import { useAgentTestingLiveUpdates } from "./useAgentTestingLiveUpdates";
 import { useHydrateViewFromUrl } from "./useAgentTestingPageFlows";
 import { useAgentTestingRouting } from "./useAgentTestingRouting";
 import { useAgentTestingStore } from "./useAgentTestingStore";
 
-/** How many scenarios and how many run plans the tabs count. */
+/**
+ * How many scenarios and how many run plans the tabs count.
+ *
+ * Both kinds of suite are read, because the read is shared with the Results
+ * tab, but only the run plans are counted: a test suite is a group of
+ * scenarios and never a row of the Test Runs list, so counting it put a number
+ * beside "Results" that no row under it accounted for.
+ */
 function useTabCounts(projectId: string) {
   const { data: scenarios } = api.scenarios.getAll.useQuery(
     { projectId },
@@ -35,7 +43,10 @@ function useTabCounts(projectId: string) {
     { enabled: !!projectId },
   );
 
-  return { casesCount: scenarios?.length, plansCount: suites?.length };
+  return {
+    casesCount: scenarios?.length,
+    plansCount: suites ? toRunPlanSuites(suites).length : undefined,
+  };
 }
 
 export function AgentTestingPage() {

--- a/platform/app/src/components/agent-testing/__tests__/resultsTabLoadingGates.integration.test.tsx
+++ b/platform/app/src/components/agent-testing/__tests__/resultsTabLoadingGates.integration.test.tsx
@@ -238,4 +238,82 @@ describe("the Results tab loading gate", () => {
       });
     });
   });
+
+  describe("given a project with no run plan and runs inside the window", () => {
+    beforeEach(() => {
+      routerState.query = { project: "test-project", path: ["results"] };
+      routerState.asPath = "/test-project/agent-testing/results";
+      // One test suite, which is no run plan, so the plan list stays empty.
+      mockSuitesGetAll.mockReturnValue({
+        data: [
+          {
+            id: "test_suite_checkout",
+            name: "Checkout",
+            slug: "checkout",
+            scenarioIds: ["scen_1"],
+            labels: [],
+            kind: "test_suite",
+            scope: null,
+          },
+        ],
+        isLoading: false,
+      });
+      mockResultsOverview.mockReturnValue({
+        data: {
+          totals: {
+            executions: 5,
+            runCount: 5,
+            passRate: 80,
+            failingScenarios: 1,
+            cost: { totalUsd: 0, knownAtoms: 0, unknownAtoms: 5 },
+            series: [],
+          },
+          groups: [],
+        },
+        isLoading: false,
+      });
+    });
+
+    describe("when the Results tab is opened", () => {
+      /** @scenario "A window that holds runs of no plan still reads the whole tab" */
+      it("reads the filter row and the count, never the empty state", () => {
+        render(<ResultsTab isSseConnected />, { wrapper: Wrapper });
+
+        expect(screen.queryByText("No runs yet")).not.toBeInTheDocument();
+        expect(screen.getByText("5 executions")).toBeInTheDocument();
+        expect(
+          screen.getByTestId("agent-testing-run-plans-table"),
+        ).toBeInTheDocument();
+      });
+
+      /** @scenario "The plan table says when the runs of the window belong to no plan" */
+      it("says the runs were started outside a run plan", () => {
+        render(<ResultsTab isSseConnected />, { wrapper: Wrapper });
+
+        expect(
+          screen.getByText(
+            "These runs were started outside a run plan. Group by scenario or target to read them.",
+          ),
+        ).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("given a project with no run plan and no run inside the window", () => {
+    describe("when the Results tab is opened", () => {
+      /** @scenario "The empty state of the tab offers a wider period" */
+      it("offers the next wider period", () => {
+        routerState.query = { project: "test-project", path: ["results"] };
+        routerState.asPath = "/test-project/agent-testing/results";
+        mockSuitesGetAll.mockReturnValue({ data: [], isLoading: false });
+
+        render(<ResultsTab isSseConnected />, { wrapper: Wrapper });
+
+        expect(screen.getByText("No runs yet")).toBeInTheDocument();
+        expect(screen.getByTestId("widen-period-button")).toHaveTextContent(
+          "Show the last 90 days",
+        );
+      });
+    });
+  });
 });

--- a/platform/app/src/components/agent-testing/__tests__/resultsTabLoadingGates.integration.test.tsx
+++ b/platform/app/src/components/agent-testing/__tests__/resultsTabLoadingGates.integration.test.tsx
@@ -11,6 +11,7 @@
  */
 import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
 import { cleanup, render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import type React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ResultsTab } from "../results/ResultsTab";
@@ -102,11 +103,14 @@ vi.mock("~/hooks/useDrawer", () => ({
   useDrawer: () => ({ openDrawer: vi.fn(), setFlowCallbacks: vi.fn() }),
 }));
 
+/** The address the page writes, which is where the period is held. */
+const mockPush = vi.hoisted(() => vi.fn());
+
 vi.mock("~/utils/compat/next-router", () => ({
   useRouter: () => ({
     query: routerState.query,
     asPath: routerState.asPath,
-    push: vi.fn(),
+    push: mockPush,
     isReady: true,
   }),
 }));
@@ -302,7 +306,7 @@ describe("the Results tab loading gate", () => {
   describe("given a project with no run plan and no run inside the window", () => {
     describe("when the Results tab is opened", () => {
       /** @scenario "The empty state of the tab offers a wider period" */
-      it("offers the next wider period", () => {
+      it("widens the window to ninety days when the offer is taken", async () => {
         routerState.query = { project: "test-project", path: ["results"] };
         routerState.asPath = "/test-project/agent-testing/results";
         mockSuitesGetAll.mockReturnValue({ data: [], isLoading: false });
@@ -310,8 +314,17 @@ describe("the Results tab loading gate", () => {
         render(<ResultsTab isSseConnected />, { wrapper: Wrapper });
 
         expect(screen.getByText("No runs yet")).toBeInTheDocument();
-        expect(screen.getByTestId("widen-period-button")).toHaveTextContent(
-          "Show the last 90 days",
+        const widen = screen.getByTestId("widen-period-button");
+        expect(widen).toHaveTextContent("Show the last 90 days");
+
+        await userEvent.click(widen);
+
+        expect(mockPush).toHaveBeenCalledWith(
+          expect.objectContaining({
+            query: expect.objectContaining({ period: "90d" }),
+          }),
+          undefined,
+          { shallow: true },
         );
       });
     });

--- a/platform/app/src/components/agent-testing/__tests__/runPlanSuites.unit.test.ts
+++ b/platform/app/src/components/agent-testing/__tests__/runPlanSuites.unit.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Which suites of a project are run plans.
+ *
+ * One rule serves the number beside the Results tab and the rows of the Test
+ * Runs list, so the two can never disagree.
+ *
+ * @see specs/features/agent-testing/page-structure.feature
+ */
+
+import { describe, expect, it } from "vitest";
+import { CLI_EPHEMERAL_LABEL, toRunPlanSuites } from "../results/run-plans";
+
+const RUN_PLAN = { id: "suite_plan", kind: "run_plan", labels: [] };
+const TEST_SUITE = { id: "test_suite_refunds", kind: "test_suite", labels: [] };
+const CLI_SUITE = {
+  id: "suite_cli",
+  kind: "run_plan",
+  labels: [CLI_EPHEMERAL_LABEL],
+};
+
+describe("given the suites of a project", () => {
+  describe("when the run plans are worked out", () => {
+    /** @scenario "The number beside the Results tab counts what the Test Runs list holds" */
+    it("counts the run plan alone", () => {
+      expect(
+        toRunPlanSuites([RUN_PLAN, TEST_SUITE, CLI_SUITE]).map(
+          (suite) => suite.id,
+        ),
+      ).toEqual(["suite_plan"]);
+    });
+
+    it("keeps a suite that names no kind, which is a plan the wire did not label", () => {
+      expect(toRunPlanSuites([{ id: "suite_old", labels: [] }])).toHaveLength(
+        1,
+      );
+    });
+  });
+});

--- a/platform/app/src/components/agent-testing/results/PlanRowsTable.tsx
+++ b/platform/app/src/components/agent-testing/results/PlanRowsTable.tsx
@@ -269,6 +269,13 @@ export type PlanRowsTableProps = {
   rows: PlanRowModel[];
   /** The window, in days, for the row that says nothing ran inside it. */
   days: number;
+  /**
+   * True while the window holds runs that no row of this table accounts for:
+   * a single scenario or a test suite run from the platform belongs to no run
+   * plan. The table then says where those runs are read instead of reporting
+   * a filter that matched nothing.
+   */
+  hasRunsOutsidePlans?: boolean;
   resolveTargetName: (targetKey: string) => string;
   resolveTargetKind: (targetKey: string) => TargetKind;
   onSelectPlan: (planSlug: string) => void;
@@ -281,6 +288,7 @@ export type PlanRowsTableProps = {
 export function PlanRowsTable({
   rows,
   days,
+  hasRunsOutsidePlans = false,
   resolveTargetName,
   resolveTargetKind,
   onSelectPlan,
@@ -352,7 +360,13 @@ export function PlanRowsTable({
         ))}
 
         {rows.length === 0 ? (
-          <ResultsTableEmptyLine text="No run plans match these filters." />
+          <ResultsTableEmptyLine
+            text={
+              hasRunsOutsidePlans
+                ? "These runs were started outside a run plan. Group by scenario or target to read them."
+                : "No run plans match these filters."
+            }
+          />
         ) : null}
       </ResultsTableBody>
 

--- a/platform/app/src/components/agent-testing/results/ResultsList.tsx
+++ b/platform/app/src/components/agent-testing/results/ResultsList.tsx
@@ -39,6 +39,7 @@ import { FlatRowsTable, GroupedRowsTable } from "./GroupedRowsTable";
 import { PlanRowsTable } from "./PlanRowsTable";
 import { ResultsChartsBlock } from "./ResultsChartsBlock";
 import { ResultsFilterRow } from "./ResultsFilterRow";
+import { nextWiderWindow } from "./RunPlanResultsStates";
 import type { ResultGrouping, ResultRow } from "./result-atoms";
 import type { RunPlan } from "./run-plans";
 import { type UseResultGroupsResult, useResultGroups } from "./useResultGroups";
@@ -87,8 +88,22 @@ function LoadingRows() {
   );
 }
 
-/** What the tab says to a project that has never run anything. */
-function NoRunsYet() {
+/**
+ * What the tab says while the window holds nothing.
+ *
+ * It offers the next wider window as well. The period picker lives in the
+ * filter row, which this state stands in for, so without the button a person
+ * whose runs are older than the window has no way back to them.
+ */
+function NoRunsYet({
+  period,
+  setRelativePeriod,
+}: {
+  period: Period;
+  setRelativePeriod: (key: RelativePresetKey) => void;
+}) {
+  const wider = nextWiderWindow(period);
+
   return (
     <EmptyState.Root paddingY={12}>
       <EmptyState.Content>
@@ -99,6 +114,12 @@ function NoRunsYet() {
         <EmptyState.Description>
           Run a test suite or a single scenario and the results land here.
         </EmptyState.Description>
+        <SmallButton
+          onClick={() => setRelativePeriod(wider.key)}
+          data-testid="widen-period-button"
+        >
+          {wider.label}
+        </SmallButton>
       </EmptyState.Content>
     </EmptyState.Root>
   );
@@ -133,6 +154,7 @@ function ResultsTable({
       <PlanRowsTable
         rows={results.planRows}
         days={days}
+        hasRunsOutsidePlans={results.totals.executions > 0}
         resolveTargetName={results.resolveTargetName}
         resolveTargetKind={results.resolveTargetKind}
         onSelectPlan={onSelectPlan}
@@ -283,6 +305,14 @@ export function ResultsList({
 
   const isLoading = isPlansLoading || results.isLoading;
 
+  // The empty state is about the window, not about the plan list. Runs started
+  // outside a run plan, a single scenario or a test suite, are counted by the
+  // header and listed by the scenario, target and flat groupings, so a project
+  // holding those and no plan was told it had no runs while the same header
+  // counted them, and lost the grouping selector and the period picker with
+  // the filter row.
+  const isEmptyWindow = !hasAnyPlans && results.totals.executions === 0;
+
   const openRun = (row: ResultRow) => onSelectRun(row.planSlug, row.runId);
 
   return (
@@ -297,8 +327,8 @@ export function ResultsList({
 
       {isLoading ? (
         <LoadingRows />
-      ) : !hasAnyPlans ? (
-        <NoRunsYet />
+      ) : isEmptyWindow ? (
+        <NoRunsYet period={period} setRelativePeriod={setRelativePeriod} />
       ) : (
         <ResultsBody
           view={view}

--- a/platform/app/src/components/agent-testing/results/RunPlanResultsStates.tsx
+++ b/platform/app/src/components/agent-testing/results/RunPlanResultsStates.tsx
@@ -24,7 +24,7 @@ import type { PeriodControls } from "./period-controls";
 const DAY_MS = 86_400_000;
 
 /** The next window to offer when nothing ran inside the one on screen. */
-function nextWiderWindow(period: Period): {
+export function nextWiderWindow(period: Period): {
   key: RelativePresetKey;
   label: string;
 } {

--- a/platform/app/src/components/agent-testing/results/run-plans.ts
+++ b/platform/app/src/components/agent-testing/results/run-plans.ts
@@ -35,6 +35,25 @@ import { RESULTS_SEGMENT } from "../useAgentTestingRouting";
  */
 export const CLI_EPHEMERAL_LABEL = "cli-ephemeral";
 
+/** The suite fields the run plan rule reads. */
+export type StoredSuite = { kind?: string | null; labels: string[] };
+
+/**
+ * The suites of a project that are run plans.
+ *
+ * A test suite is a group of scenarios and never a row of the Test Runs list,
+ * and the throwaway suites `scenario run` makes are deleted again. Every
+ * surface that counts or lists run plans reads this one rule, so the number
+ * beside the Results tab can never disagree with the rows under it.
+ */
+export function toRunPlanSuites<T extends StoredSuite>(suites: T[]): T[] {
+  return suites.filter(
+    (suite) =>
+      suite.kind !== "test_suite" &&
+      !suite.labels.includes(CLI_EPHEMERAL_LABEL),
+  );
+}
+
 export type RunPlanKind = "suite" | "external";
 
 /**
@@ -235,22 +254,20 @@ export function buildRunPlans({
   suiteSummaries: Record<string, SuiteRunSummary>;
   externalSets: ExternalSetSummary[];
 }): RunPlan[] {
-  const suitePlans: RunPlan[] = plans
-    .filter((suite) => !suite.labels.includes(CLI_EPHEMERAL_LABEL))
-    .map((suite) => {
-      const summary = suiteSummaries[suite.id];
-      return {
-        slug: suite.slug,
-        name: suite.name,
-        kind: "suite" as const,
-        scenarioSetId: getSuiteSetId(suite.id),
-        suiteId: suite.id,
-        caseCount: suite.scenarioIds.length,
-        lastRun: summary ? toLastRun(summary) : null,
-        scopeLabel: suiteScopeLabel({ suite, suiteNames }),
-        scopeKind: suiteScopeKind(suite),
-      };
-    });
+  const suitePlans: RunPlan[] = toRunPlanSuites(plans).map((suite) => {
+    const summary = suiteSummaries[suite.id];
+    return {
+      slug: suite.slug,
+      name: suite.name,
+      kind: "suite" as const,
+      scenarioSetId: getSuiteSetId(suite.id),
+      suiteId: suite.id,
+      caseCount: suite.scenarioIds.length,
+      lastRun: summary ? toLastRun(summary) : null,
+      scopeLabel: suiteScopeLabel({ suite, suiteNames }),
+      scopeKind: suiteScopeKind(suite),
+    };
+  });
 
   const externalPlans: RunPlan[] = externalSets.map((set) => ({
     slug: toExternalPlanSlug(set.scenarioSetId),

--- a/platform/app/src/components/agent-testing/results/useRunPlans.ts
+++ b/platform/app/src/components/agent-testing/results/useRunPlans.ts
@@ -13,7 +13,7 @@ import { useMemo } from "react";
 import type { Period } from "~/components/PeriodSelector";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 import { api } from "~/utils/api";
-import { buildRunPlans, type RunPlan } from "./run-plans";
+import { buildRunPlans, type RunPlan, toRunPlanSuites } from "./run-plans";
 
 export type UseRunPlansResult = {
   plans: RunPlan[];
@@ -51,10 +51,7 @@ export function useRunPlans({ period }: { period: Period }): UseRunPlansResult {
       { enabled: !!project },
     );
 
-  const storedPlans = useMemo(
-    () => (suites ?? []).filter((suite) => suite.kind !== "test_suite"),
-    [suites],
-  );
+  const storedPlans = useMemo(() => toRunPlanSuites(suites ?? []), [suites]);
 
   const plans = useMemo(
     () =>

--- a/specs/features/agent-testing/page-structure.feature
+++ b/specs/features/agent-testing/page-structure.feature
@@ -111,6 +111,13 @@ Feature: The Agent Testing page
     Then "Scenarios" carries the number of scenarios
     And "Results" carries the number of run plans
 
+  @unit
+  Scenario: The number beside the Results tab counts what the Test Runs list holds
+    Given a project with one test suite, one run plan and one throwaway suite of the command line
+    When the number beside "Results" is worked out
+    Then only the run plan is counted
+    And the Test Runs list holds the same rule, so the two can never disagree
+
   @integration
   Scenario: The selected tab is underlined on the header's own border
     Given the Agent Testing page is open

--- a/specs/features/agent-testing/results-tabs.feature
+++ b/specs/features/agent-testing/results-tabs.feature
@@ -51,6 +51,21 @@ Feature: The Results tab
     When the Test Runs list is read
     Then its row carries the pass rate of that last run
 
+  @integration
+  Scenario: A window that holds runs of no plan still reads the whole tab
+    Given a project with no run plan and runs inside the window
+    When the Results tab is opened
+    Then the filter row and the period picker read
+    And the "No runs yet" state does not read
+    And the count in the header of the list matches the runs the window holds
+
+  @integration
+  Scenario: The plan table says when the runs of the window belong to no plan
+    Given a project with no run plan and runs inside the window
+    When the Test Runs list is read
+    Then the table says those runs were started outside a run plan
+    And it points at the scenario and target groupings, which list them
+
   # --- The columns of the plan table ---
 
   @integration
@@ -774,6 +789,13 @@ Feature: The Results tab
     When the Results tab loads
     Then the skeleton reads no more
     And the empty "no runs yet" state reads on the tab
+
+  @integration
+  Scenario: The empty state of the tab offers a wider period
+    Given a project with no run plan and no run inside the window
+    When the Results tab is opened
+    Then the "No runs yet" state offers the next wider period
+    And choosing it widens the window
 
   # --- Stalled runs ---
 


### PR DESCRIPTION
## The report

A customer opened Agent Testing and read this: the tab said `Results 1`, the
list header said `5 executions`, and the body said **No runs yet**. A second
project read `Results 1` over `0 executions` and the same empty state. Their
words: "seems broken".

They are right, and the follow-up question was the sharper one: with the empty
state up, the period picker is gone, so there is no way to widen the window and
look for the runs.

## What was wrong

Three separate reads disagreed about the same page.

**1. The empty state came from the plan list, not from the window.**
`ResultsList` showed "No runs yet" whenever the project held no run plan. But a
run does not need a run plan. A single scenario run from the Scenarios page, and
a test suite run, both write to the `__internal__` set namespace, so they are
neither a stored run plan nor an external set. `getResultsOverview` counts them,
which is where `5 executions` came from, and the scenario, target and flat
groupings list them. The empty state hid the whole body, which took the grouping
selector and the period picker with it, from the one person who needed them.

**2. The number beside the Results tab counted test suites.**
`useTabCounts` counted `run_plan` and `test_suite` rows together, while the Test
Runs list is run plans only. A project with one test suite and no run plan read
`Results 1` over an empty list. That is the second screenshot exactly.

**3. The empty state was a dead end.**
The period picker lives in the filter row, which the empty state stands in for,
so a person whose runs are older than 30 days had no way back to them.

## The fix

- The empty state follows the window. It reads only when the project holds no
  run plan **and** the window holds no execution.
- It offers the next wider period, the same button the plan detail already uses,
  so an old run is still reachable.
- When the plan table has no row and the window holds runs, the table says those
  runs were started outside a run plan and points at the groupings that list
  them, instead of reporting a filter that matched nothing.
- One rule, `toRunPlanSuites`, now serves both the number beside the tab and the
  rows under it, so the two cannot disagree again.

No server change, no new query.

## Dogfooded

A local project put into the shape of the report: no run plan, three test
suites, runs inside the window.

The whole tab reads, and the table says where those runs are:

![runs outside a run plan](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/agent-testing-results-count/runs-outside-a-run-plan.png)

The pointer is true. Grouping by scenario lists them:

![grouped by scenario](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/agent-testing-results-count/grouped-by-scenario.png)

A window that really holds nothing keeps the way out:

![empty window offers a wider period](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/agent-testing-results-count/empty-window-offers-a-wider-period.png)

And taking the offer finds the runs:

![widened to ninety days](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/agent-testing-results-count/widened-to-ninety-days.png)

## Tests

- `runPlanSuites.unit.test.ts`: the count rule keeps the run plan and drops the
  test suite and the throwaway suites of the command line.
- `resultsTabLoadingGates.integration.test.tsx`: three new cases, one of them
  the exact shape of the report (one test suite, no run plan, five executions in
  the window). The widen case clicks the button and reads the address it writes.

Specs: `results-tabs.feature` and `page-structure.feature`.

Verified locally: `pnpm typecheck:all` clean, `check:feature-parity` OK, biome
clean at error level, agent-testing unit 114 passed and component 427 passed.

https://claude.ai/code/session_0124pVPYQNvQW4nrU4MNUVrp
