### PR TITLE
fix(governance): keep the department chip honest and let a bar draw a credit

### DIFF
--- a/platform/app/src/components/governance/costs/CostCharts.tsx
+++ b/platform/app/src/components/governance/costs/CostCharts.tsx
@@ -82,10 +82,44 @@ function EmptyPanel({
   );
 }
 
+/** A ranked row with the bar it draws. */
+export interface RankBar extends RankRow {
+  /** Bar length as a percentage of the panel width. Never negative. */
+  widthPct: number;
+  isCredit: boolean;
+}
+
 /**
- * Ranked horizontal bars — label, a bar proportional to the leader, and the
- * figure. The bar is scaled against the largest row rather than the total, so
- * a long tail stays legible instead of collapsing into slivers.
+ * How long each ranked bar is drawn.
+ *
+ * Cost here is signed — a credited or refunded period arrives as a negative
+ * figure — so the bars are scaled against the largest magnitude rather than
+ * against the top row. Scaling against the top row divides by a negative
+ * whenever a credit leads, which draws bars pointing the wrong way, and the
+ * obvious guard against that collapses a panel of nothing but credits to
+ * nothing at all.
+ *
+ * Extracted from the panel because the width lands in a generated class name
+ * that jsdom cannot resolve, which leaves the arithmetic untestable through
+ * the rendered output.
+ */
+export function rankBarGeometry(rows: RankRow[]): RankBar[] {
+  const scale = rows.reduce(
+    (max, row) => Math.max(max, Math.abs(row.value)),
+    0,
+  );
+  return rows.map((row) => ({
+    ...row,
+    widthPct: scale > 0 ? (Math.abs(row.value) / scale) * 100 : 0,
+    isCredit: row.value < 0,
+  }));
+}
+
+/**
+ * Ranked horizontal bars — label, bar, figure. Rows are ordered by what was
+ * spent, and each bar is scaled against the largest figure rather than the
+ * total, so a long tail stays legible instead of collapsing into slivers.
+ * `rankBarGeometry` explains why "largest" means largest magnitude.
  */
 export function CostRankList({
   rows,
@@ -99,10 +133,12 @@ export function CostRankList({
   const shown = useMemo(
     // Copied before sorting: these rows can be a query cache, and sorting in
     // place would reorder what every other reader of that cache sees.
-    () => [...(rows ?? [])].sort((a, b) => b.value - a.value).slice(0, maxRows),
+    () =>
+      rankBarGeometry(
+        [...(rows ?? [])].sort((a, b) => b.value - a.value).slice(0, maxRows),
+      ),
     [rows, maxRows],
   );
-  const leader = shown[0]?.value ?? 0;
 
   if (rows === null) return <EmptyPanel height="220px" unanswered />;
   if (shown.length === 0)
@@ -125,8 +161,21 @@ export function CostRankList({
             <Box
               height="100%"
               borderRadius="sm"
-              width={leader > 0 ? `${(row.value / leader) * 100}%` : "0%"}
-              backgroundColor={getHexColorForString(row.label)}
+              width={`${row.widthPct}%`}
+              // The same number, readable without resolving styling — the
+              // width above lands in a generated class name. `MeterBar` does
+              // the same for the same reason.
+              data-width-pct={row.widthPct}
+              data-credit={row.isCredit ? "true" : undefined}
+              // A credit is drawn as an outline rather than a fill, so a
+              // refund and a charge of the same size do not read alike.
+              backgroundColor={
+                row.isCredit ? "transparent" : getHexColorForString(row.label)
+              }
+              borderWidth={row.isCredit ? "2px" : undefined}
+              borderColor={
+                row.isCredit ? getHexColorForString(row.label) : undefined
+              }
             />
           </Box>
           <Text

--- a/platform/app/src/components/governance/costs/CostFilterBar.tsx
+++ b/platform/app/src/components/governance/costs/CostFilterBar.tsx
@@ -66,7 +66,7 @@ function FilterChip({
 }
 
 export function CostFilterBar({
-  department,
+  departmentName,
   departments,
   onDepartmentChange,
   windowDays,
@@ -76,9 +76,10 @@ export function CostFilterBar({
   groupBy,
   onGroupByChange,
 }: {
-  department: string;
+  /** `null` when no single department is selected. */
+  departmentName: string | null;
   departments: Array<{ id: string; name: string }>;
-  onDepartmentChange: (value: string) => void;
+  onDepartmentChange: (value: string, name: string | null) => void;
   windowDays: number;
   onWindowDaysChange: (value: number) => void;
   interval: TimeInterval;
@@ -86,11 +87,11 @@ export function CostFilterBar({
   groupBy: GroupBy;
   onGroupByChange: (value: GroupBy) => void;
 }) {
-  const departmentLabel =
-    department === ALL_DEPARTMENTS
-      ? "All departments"
-      : (departments.find((d) => d.id === department)?.name ??
-        "All departments");
+  // The selected name, not a lookup against the current window's options. A
+  // department the reader picked can drop out of those options, and falling
+  // back to "All departments" there would label a filtered panel as the whole
+  // organisation's spend.
+  const departmentLabel = departmentName ?? "All departments";
   const timeFrameLabel =
     TIME_FRAMES.find((f) => f.value === windowDays)?.label ??
     `Last ${windowDays} days`;
@@ -108,7 +109,7 @@ export function CostFilterBar({
       >
         <MenuItem
           value={ALL_DEPARTMENTS}
-          onClick={() => onDepartmentChange(ALL_DEPARTMENTS)}
+          onClick={() => onDepartmentChange(ALL_DEPARTMENTS, null)}
         >
           All departments
         </MenuItem>
@@ -116,7 +117,7 @@ export function CostFilterBar({
           <MenuItem
             key={d.id}
             value={d.id}
-            onClick={() => onDepartmentChange(d.id)}
+            onClick={() => onDepartmentChange(d.id, d.name)}
           >
             {d.name}
           </MenuItem>

--- a/platform/app/src/components/governance/costs/__tests__/costRankBars.unit.test.ts
+++ b/platform/app/src/components/governance/costs/__tests__/costRankBars.unit.test.ts
@@ -1,0 +1,87 @@
+/**
+ * The geometry behind the ranked cost bars.
+ *
+ * Cost on this screen is signed: a provider that credits or refunds a period
+ * reports it as a negative figure, and the ledger keeps it that way so the
+ * charge it reverses does not stand alone. A ranked panel that scales every
+ * bar against the top row therefore has to survive a top row that is itself a
+ * credit — dividing by a negative leader produces a negative width, and
+ * guarding that with `leader > 0` collapses an entire panel of credits to
+ * nothing.
+ *
+ * Width is asserted here rather than in the DOM on purpose: the width lands in
+ * a generated class name that jsdom cannot resolve, so a rendered assertion
+ * would pass no matter what the arithmetic did.
+ *
+ * Issue: #7768
+ */
+import { describe, expect, it } from "vitest";
+
+import { rankBarGeometry } from "../CostCharts";
+
+describe("the ranked bar geometry", () => {
+  describe("given every row is a charge", () => {
+    it("gives the leader the full bar and scales the rest against it", () => {
+      const geometry = rankBarGeometry([
+        { key: "a", label: "Alpha", value: 100 },
+        { key: "b", label: "Beta", value: 25 },
+      ]);
+
+      expect(geometry.map((row) => row.widthPct)).toEqual([100, 25]);
+      expect(geometry.every((row) => !row.isCredit)).toBe(true);
+    });
+  });
+
+  describe("given every row is a credit", () => {
+    it("draws them against the largest credit rather than collapsing to nothing", () => {
+      const geometry = rankBarGeometry([
+        { key: "a", label: "Alpha", value: -20 },
+        { key: "b", label: "Beta", value: -80 },
+      ]);
+
+      // Sorted descending by value, so the smaller credit leads. It is the
+      // larger magnitude that sets the scale.
+      expect(geometry.map((row) => row.widthPct)).toEqual([25, 100]);
+      expect(geometry.every((row) => row.isCredit)).toBe(true);
+    });
+  });
+
+  describe("given charges and credits together", () => {
+    it("never produces a negative width", () => {
+      const geometry = rankBarGeometry([
+        { key: "a", label: "Alpha", value: 40 },
+        { key: "b", label: "Beta", value: -60 },
+      ]);
+
+      expect(geometry.every((row) => row.widthPct >= 0)).toBe(true);
+      expect(geometry.map((row) => row.widthPct)).toEqual([
+        (40 / 60) * 100,
+        100,
+      ]);
+    });
+
+    it("marks the credit so an equal magnitude does not read as an equal charge", () => {
+      const geometry = rankBarGeometry([
+        { key: "a", label: "Alpha", value: 50 },
+        { key: "b", label: "Beta", value: -50 },
+      ]);
+
+      expect(geometry.map((row) => [row.key, row.isCredit])).toEqual([
+        ["a", false],
+        ["b", true],
+      ]);
+    });
+  });
+
+  describe("given nothing was spent on any row", () => {
+    it("draws no bars rather than dividing by zero", () => {
+      const geometry = rankBarGeometry([
+        { key: "a", label: "Alpha", value: 0 },
+        { key: "b", label: "Beta", value: 0 },
+      ]);
+
+      expect(geometry.map((row) => row.widthPct)).toEqual([0, 0]);
+      expect(geometry.every((row) => Number.isFinite(row.widthPct))).toBe(true);
+    });
+  });
+});

--- a/platform/app/src/pages/governance/__tests__/costDepartmentFilter.integration.test.tsx
+++ b/platform/app/src/pages/governance/__tests__/costDepartmentFilter.integration.test.tsx
@@ -1,0 +1,228 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * What the department chip says, against what the screen actually filtered.
+ *
+ * The department options are built from the response, so changing the time
+ * frame can drop the department the reader picked. When that happens the chip
+ * has no name to show and falls back to "All departments" — and the selection
+ * itself is a separate piece of state that nothing resets. The two disagree,
+ * and the reader is shown an empty panel labelled as every department's spend.
+ *
+ * These tests hold the label and the filtered rows to the same story, whichever
+ * side the fix moves.
+ *
+ * Issue: #7767
+ * Spec: specs/governance/governance-cost-screen.feature
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom/vitest";
+import type React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const ENGINEERING = {
+  departmentId: "dep-1",
+  departmentName: "Engineering",
+  spendUsd: "310.50",
+};
+const SUPPORT = {
+  departmentId: "dep-2",
+  departmentName: "Support",
+  spendUsd: "120.25",
+};
+
+const harness = vi.hoisted(() => ({
+  /**
+   * Keyed by window, because that is the whole point: the shorter window has
+   * no Engineering rows in it, which is what removes the option the reader is
+   * standing on.
+   */
+  departmentsByWindow: {} as Record<number, unknown>,
+}));
+
+vi.mock("~/hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({
+    isLoading: false,
+    organization: { id: "org-1", slug: "acme", name: "ACME", teams: [] },
+    organizations: [],
+    project: undefined,
+    hasPermission: () => true,
+    hasOrgPermission: () => true,
+    hasAnyPermission: () => true,
+  }),
+}));
+
+vi.mock("~/hooks/useFeatureFlag", () => ({
+  useFeatureFlag: () => ({ enabled: true, isLoading: false }),
+}));
+vi.mock("~/hooks/useActivePlan", () => ({
+  useActivePlan: () => ({ isEnterprise: true, activePlan: undefined }),
+}));
+vi.mock("~/components/governance/GovernanceLayout", () => ({
+  default: ({ children }: { children: React.ReactNode }) => children,
+}));
+vi.mock("~/components/NotFoundScene", () => ({
+  NotFoundScene: () => <div>this page does not exist</div>,
+}));
+vi.mock("~/components/LoadingScreen", () => ({
+  LoadingScreen: () => <div>loading</div>,
+}));
+
+vi.mock("~/utils/api", () => ({
+  api: {
+    governanceCost: {
+      summary: {
+        useQuery: () => ({
+          data: {
+            unavailableReason: null,
+            billed: { amountUsd: 123.45, cellsWithoutAmount: 0 },
+            gateway: { amountUsd: 67.89, cellsWithoutAmount: 0 },
+            seats: { status: "awaiting_data" },
+            series: [
+              { day: "2026-08-01", billedUsd: 123.45, gatewayUsd: 67.89 },
+            ],
+            windowDays: 30,
+          },
+          isLoading: false,
+          isError: false,
+        }),
+      },
+    },
+    activityMonitor: {
+      summary: {
+        useQuery: () => ({
+          data: {
+            activeUsersThisWindow: 42,
+            newUsersThisWindow: 3,
+            spentThisWindowUsd: "500.00",
+          },
+        }),
+      },
+      spendByDepartment: {
+        // Answers per window, the way the real read does.
+        useQuery: (input: { windowDays: number }) => ({
+          data: harness.departmentsByWindow[input.windowDays],
+        }),
+      },
+      spendByUser: {
+        useQuery: () => ({
+          data: [{ actor: "ada@acme.test", spendUsd: "200.00", requests: 90 }],
+        }),
+      },
+      spendOverTime: {
+        useQuery: () => ({
+          data: {
+            buckets: [
+              {
+                bucketIso: "2026-08-01",
+                points: [
+                  { key: "team-a", label: "Team A", spendUsd: "310.50" },
+                ],
+              },
+            ],
+          },
+        }),
+      },
+    },
+  },
+}));
+
+import CostsPage from "../costs";
+
+const renderScreen = () =>
+  render(
+    <ChakraProvider value={defaultSystem}>
+      <CostsPage />
+    </ChakraProvider>,
+  );
+
+/** Opens a filter chip by its label and picks one of its options. */
+const pickFilter = async (chipLabel: string, option: string) => {
+  const user = userEvent.setup();
+  const chip = screen
+    .getByText(chipLabel)
+    .closest("button") as HTMLButtonElement;
+  await user.click(chip);
+  const item = await screen.findByRole("menuitem", { name: option });
+  await user.click(item);
+};
+
+beforeEach(() => {
+  harness.departmentsByWindow = {
+    30: [ENGINEERING, SUPPORT],
+    // Engineering spent nothing in the last seven days, so it is not here.
+    7: [SUPPORT],
+  };
+});
+
+afterEach(() => cleanup());
+
+describe("the department filter", () => {
+  describe("given a department is selected and the window then drops it", () => {
+    it("never labels the chip all departments while still filtering by one", async () => {
+      renderScreen();
+
+      await pickFilter("Department", "Engineering");
+      await waitFor(() =>
+        expect(screen.getAllByText("Engineering").length).toBeGreaterThan(0),
+      );
+
+      await pickFilter("Time Frame", "Last 7 days");
+
+      // Whatever the fix does, these two have to agree. Today the chip says
+      // "All departments" and the panel shows no department at all, because
+      // the dropped Engineering id is still filtering every row away.
+      await waitFor(() => {
+        const saysAllDepartments =
+          screen.queryAllByText("All departments").length > 0;
+        const showsEveryReturnedDepartment =
+          screen.queryAllByText("Support").length > 0;
+
+        expect({ saysAllDepartments, showsEveryReturnedDepartment }).toEqual({
+          saysAllDepartments: true,
+          showsEveryReturnedDepartment: true,
+        });
+      });
+    });
+  });
+
+  describe("given a department is selected and the window keeps it", () => {
+    it("keeps filtering to that department", async () => {
+      harness.departmentsByWindow[7] = [ENGINEERING, SUPPORT];
+
+      renderScreen();
+
+      await pickFilter("Department", "Engineering");
+      await pickFilter("Time Frame", "Last 7 days");
+
+      await waitFor(() =>
+        expect(screen.getAllByText("Engineering").length).toBeGreaterThan(0),
+      );
+      // The selection survives a window that still contains it: the panel is
+      // filtered, so Support is not among the rows.
+      const panel = screen
+        .getByText("Cost by department")
+        .closest('[data-testid="cost-panel"]') as HTMLElement;
+      expect(panel.textContent).not.toContain("Support");
+    });
+  });
+
+  describe("given a department is selected and the next read has not answered", () => {
+    it("keeps naming the selection instead of claiming all departments", async () => {
+      harness.departmentsByWindow[7] = undefined;
+
+      renderScreen();
+
+      await pickFilter("Department", "Engineering");
+      await pickFilter("Time Frame", "Last 7 days");
+
+      // An unanswered read is not evidence the department disappeared, so
+      // resetting here would throw away the reader's choice on every refetch.
+      await waitFor(() =>
+        expect(screen.getAllByText("Engineering").length).toBeGreaterThan(0),
+      );
+    });
+  });
+});

--- a/platform/app/src/pages/governance/costs.tsx
+++ b/platform/app/src/pages/governance/costs.tsx
@@ -12,7 +12,13 @@ import type {
   GovernanceCostSummaryDto,
 } from "@ee/governance/services/governanceCost.service";
 import numeral from "numeral";
-import { useMemo, useState } from "react";
+import {
+  type Dispatch,
+  type SetStateAction,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 
 import {
   CostLanePanel,
@@ -92,9 +98,52 @@ import { api } from "~/utils/api";
 
 interface CostFilters {
   department: string;
+  /**
+   * Carried alongside the id rather than looked up from the response. The
+   * options come from the window being viewed, so a lookup has nothing to find
+   * the moment the window changes, and the chip would name a department the
+   * screen is no longer filtering by — or worse, name all of them.
+   */
+  departmentName: string | null;
   windowDays: number;
   interval: TimeInterval;
   groupBy: GroupBy;
+}
+
+/**
+ * Drops a department selection the current window no longer contains.
+ *
+ * A window can answer without the department the reader is standing on: it
+ * spent nothing over the shorter span, so it has no row and no option in the
+ * picker. The selection would stay behind and filter every remaining row away,
+ * leaving an empty panel under a chip that no longer had a name to show.
+ * Clearing it is the only outcome where the label and the rows agree.
+ *
+ * Only an answered read counts. A read still in flight is not evidence that the
+ * department is gone, and resetting on one would throw the reader's choice away
+ * on every refetch.
+ */
+function useDepartmentSelectionReset({
+  filters,
+  breakdowns,
+  setFilters,
+}: {
+  filters: CostFilters;
+  breakdowns: Breakdowns;
+  setFilters: Dispatch<SetStateAction<CostFilters>>;
+}) {
+  const { departmentRows, departments } = breakdowns;
+  const selected = filters.department;
+  useEffect(() => {
+    if (selected === ALL_DEPARTMENTS) return;
+    if (departmentRows === null) return;
+    if (departments.some((d) => d.id === selected)) return;
+    setFilters((current) => ({
+      ...current,
+      department: ALL_DEPARTMENTS,
+      departmentName: null,
+    }));
+  }, [selected, departmentRows, departments, setFilters]);
 }
 
 function CostsPage() {
@@ -105,6 +154,7 @@ function CostsPage() {
   const organizationId = organization?.id ?? "";
   const [filters, setFilters] = useState<CostFilters>({
     department: ALL_DEPARTMENTS,
+    departmentName: null,
     windowDays: 30,
     interval: "day",
     groupBy: "team",
@@ -125,6 +175,8 @@ function CostsPage() {
     // the other gets the lanes and no failed queries underneath them.
     enabled: !!organizationId && hasAnyPermission("activityMonitor:view"),
   });
+
+  useDepartmentSelectionReset({ filters, breakdowns, setFilters });
 
   // `null` until the reader picks a side, which is what lets the default below
   // follow the data. Deliberately not persisted: the same rule the trace
@@ -159,9 +211,11 @@ function CostsPage() {
         </HStack>
         {showSample && <CostSampleBanner />}
         <CostFilterBar
-          department={filters.department}
+          departmentName={filters.departmentName}
           departments={breakdowns.departments}
-          onDepartmentChange={(department) => patch({ department })}
+          onDepartmentChange={(department, departmentName) =>
+            patch({ department, departmentName })
+          }
           windowDays={filters.windowDays}
           onWindowDaysChange={(windowDays) => patch({ windowDays })}
           interval={filters.interval}
@@ -392,14 +446,21 @@ function useBreakdownQueries({
   );
 
   const departmentRows = byDepartment.data ?? null;
+  // The picker is the one place an unanswered read may fall back to empty: it
+  // offers choices, it does not report a measurement. Memoised because the
+  // selection reset watches this list, and a fresh array every render would
+  // wake that effect on every render.
+  const departments = useMemo(
+    () =>
+      (departmentRows ?? []).map((row) => ({
+        id: row.departmentId ?? "unassigned",
+        name: row.departmentName,
+      })),
+    [departmentRows],
+  );
   return {
     departmentRows,
-    // The picker is the one place an unanswered read may fall back to empty:
-    // it offers choices, it does not report a measurement.
-    departments: (departmentRows ?? []).map((row) => ({
-      id: row.departmentId ?? "unassigned",
-      name: row.departmentName,
-    })),
+    departments,
     userRows: byUser.data ?? null,
     activeUsers: summary.data?.activeUsersThisWindow ?? null,
     // `.buckets`, not the result object: the read answers a wrapper, and


### PR DESCRIPTION
# Related Issue

- Resolves #7767

Fixes the two P2 findings raised in review of #7743 and filed as #7767 and #7768. Both shipped in that merge.

Stacked on `issue7649/adr128-wave1-governance-cost` (#7650).

## The causes

**#7767 — the chip says all departments while one is still filtering.** The department options are derived from the response for the window being viewed (`platform/app/src/pages/governance/costs.tsx:399`), and the selected id lives in separate state that nothing reconciled. Shortening the window can drop the selected department from the response. The rows kept being filtered by the vanished id (`costs.tsx:483`) while the label, a lookup against the now-absent option, fell through to its "All departments" default (`platform/app/src/components/governance/costs/CostFilterBar.tsx:89-93`). The reader saw an empty panel captioned as every department's spend.

**#7768 — a ranked bar cannot draw a credit.** Every bar was scaled against the top row's value: `width={leader > 0 ? \`${(row.value / leader) * 100}%\` : "0%"}` (`platform/app/src/components/governance/costs/CostCharts.tsx:128`), with `leader` taken from the first row after a descending sort. Cost on this screen is signed — a credited or refunded period arrives negative and the ledger keeps it that way (`platform/app/ee/governance/process-manager/pulledUsageLedger.process.ts:52-62`) — so a leading credit divided every bar by a negative number, and the `leader > 0` guard collapsed a panel of nothing but credits to no bars at all.

## The failing tests, before the fix

`src/components/governance/costs/__tests__/costRankBars.unit.test.ts`, run against the geometry extracted with the original arithmetic:

```
FAIL  given every row is a credit > draws them against the largest credit rather than collapsing to nothing
AssertionError: expected [ +0, +0 ] to deeply equal [ 25, 100 ]

FAIL  given charges and credits together > never produces a negative width
AssertionError: expected false to be true

FAIL  given charges and credits together > marks the credit so an equal magnitude does not read as an equal charge
AssertionError: expected [ [ 'a', false ], [ 'b', false ] ] to deeply equal [ [ 'a', false ], [ 'b', true ] ]

Tests  3 failed | 2 passed (5)
```

`src/pages/governance/__tests__/costDepartmentFilter.integration.test.tsx`, driving the real page through the real menus:

```
FAIL  given a department is selected and the window then drops it > never labels the chip all departments while still filtering by one
AssertionError: expected { saysAllDepartments: true, showsEveryReturnedDepartment: false }
                to deeply equal { saysAllDepartments: true, showsEveryReturnedDepartment: true }

FAIL  given a department is selected and the next read has not answered > keeps naming the selection instead of claiming all departments
TestingLibraryElementError: Unable to find an element with the text: Engineering

Tests  2 failed | 1 passed (3)
```

The one that passed in each file is the control: a window that keeps the selection, and a panel of ordinary charges.

## After the fix

```
Tests  57 passed (57)   # vitest.component.config.ts, src/pages/governance + src/components/governance
Tests  18 passed (18)   # unit, src/components/governance
```

`pnpm run typecheck` clean. `npx biome check` on all five files: no errors, no warnings. `pnpm run check:feature-parity` OK.

## What changed

- The selected department's name is carried in filter state beside its id, so the chip never depends on a lookup that can go missing.
- `useDepartmentSelectionReset` clears a selection an **answered** read no longer contains. An unanswered read clears nothing — a query in flight is not evidence the department is gone, and resetting on one would discard the reader's choice on every refetch.
- `rankBarGeometry` scales bars against the largest magnitude and flags credits. A credit renders as an outline rather than a fill, so a refund and a charge of the same size do not read alike.
- The geometry is a separate function because the width lands in a generated class name that jsdom cannot resolve — a rendered assertion would pass regardless of the arithmetic. The bar also carries `data-width-pct`, the same escape hatch `MeterBar` already uses.
- `departments` is memoised in `useBreakdownQueries`; a fresh array each render would wake the reset effect on every render.

## Sweep

Looked for both shapes across `src/components`, `src/pages` and `ee/governance`.

- The `ALL_*` sentinel-plus-derived-options pattern exists nowhere else — the department chip is the only one.
- Other proportional-width renderers found: `src/components/ui/MeterBar.tsx:47` (guarded by `fillRatio > 0`), `src/pages/me/index.tsx:182-183,262-263` (guarded by `d.usd > 0` / `d.billedUsd > 0`, and floored at 2%). None can produce a negative width. They do silently omit a credit rather than drawing one, which is a smaller and different problem than the one fixed here.
- `CostRankList` is the only signed-cost renderer on this screen without such a guard.

## Noticed and deliberately not fixed

- **`CostDonut` cannot draw a credit either** (`CostCharts.tsx:204`): it bails when the summed total is zero, which mixed signs can reach with rows present, and a pie cannot render a negative slice at all. Left alone because its only call site feeds it invented sample data (`costs.tsx:555`), so no real figure reaches it today.
- **`src/components/me/PeerComparisonCell.tsx:56`** computes `Math.min(ratio, 1) * 100` with no lower clamp. Different feature, no signed input known to reach it.
- **Not verified in a browser.** The department fix is exercised through the real page component with real menu clicks in jsdom, not through a rendered screen. Reproducing it live needs seeded `trace_summaries` rows carrying departments, which the local stack does not have. The credit fix has no UI path at all today: the breakdowns read trace spend computed from tokens (`ee/governance/services/activity-monitor/activityMonitor.spend.clickhouse.repository.ts:185-213`), and no current writer emits a negative `TotalCost` — which is why #7768 was filed as P3 rather than the reviewer's P2.

Closes #7767
Closes #7768
