### PR TITLE
feat(annotations): make the review inbox readable and its actions reachable

### DIFF
--- a/platform/app/src/components/HoverableBigText.tsx
+++ b/platform/app/src/components/HoverableBigText.tsx
@@ -1,5 +1,5 @@
 import { Box, type BoxProps, HStack, Text, VStack } from "@chakra-ui/react";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { isJson } from "../utils/isJson";
 import { Markdown } from "./Markdown";
 import { RenderInputOutput } from "./traces/RenderInputOutput";
@@ -81,14 +81,14 @@ export function HoverableBigText({
   );
   const expandedVersion_ = expandedVersion ?? children;
 
-  const checkOverflow = () => {
+  const checkOverflow = useCallback(() => {
     setIsOverflown(
       ref.current
         ? Math.abs(ref.current.offsetWidth - ref.current.scrollWidth) > 2 ||
             Math.abs(ref.current.offsetHeight - ref.current.scrollHeight) > 2
         : false,
     );
-  };
+  }, []);
 
   // Re-measure after every render, once the browser has laid the box out.
   // The handle is cleared on unmount and before the next render's probe, so a
@@ -97,6 +97,19 @@ export function HoverableBigText({
     const timeout = setTimeout(checkOverflow, 100);
     return () => clearTimeout(timeout);
   });
+
+  // A render is not the only way this box changes size: a window resize, a
+  // column drag or a sidebar opening all reflow it while the component sits
+  // still. Without this the last render's answer stands, so text that has
+  // since started clamping offers no tooltip and the hidden half is
+  // unreachable — and text that has stopped clamping still offers one.
+  useEffect(() => {
+    const element = ref.current;
+    if (!element || typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(checkOverflow);
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [checkOverflow]);
 
   return (
     <>

--- a/platform/app/src/components/__tests__/HoverableBigText.resize.integration.test.tsx
+++ b/platform/app/src/components/__tests__/HoverableBigText.resize.integration.test.tsx
@@ -10,7 +10,13 @@
  * Spec: specs/components/hoverable-big-text-overflow.feature
  */
 import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
-import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
 
@@ -84,8 +90,10 @@ const settleFirstMeasurement = async () => {
 
 const resizeBox = (box: HTMLElement) => {
   const watch = watches.find((candidate) => candidate.element === box);
-  expect(watch, "the box must be watched for this test to mean anything").toBeDefined();
-  act(() => watch!.fire());
+  // A box nobody watches would make every test here pass for the wrong reason,
+  // so say so rather than firing nothing.
+  if (!watch) throw new Error("the box is not watched for resizes");
+  act(() => watch.fire());
 };
 
 describe("HoverableBigText overflow measurement", () => {

--- a/platform/app/src/components/__tests__/HoverableBigText.resize.integration.test.tsx
+++ b/platform/app/src/components/__tests__/HoverableBigText.resize.integration.test.tsx
@@ -1,0 +1,128 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * HoverableBigText only offers its tooltip and its expand dialog once it has
+ * measured itself as clipped. The measurement runs after a render, and a
+ * browser window resize causes no render, so a box that narrows underneath the
+ * component keeps whatever answer the last render left behind: text clamps but
+ * the tooltip stays disabled, and the hidden half becomes unreachable.
+ *
+ * Spec: specs/components/hoverable-big-text-overflow.feature
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+
+import { HoverableBigText } from "../HoverableBigText";
+
+const TEXT = "a very long value nobody can read in one line";
+
+/** How long the component waits before measuring a freshly laid-out box. */
+const MEASURE_DELAY_MS = 100;
+
+type Watch = { element: Element; fire: () => void };
+
+let watches: Watch[] = [];
+
+/**
+ * A ResizeObserver whose callbacks the test fires by hand, standing in for the
+ * global no-op stub. Nothing else in jsdom reports a size change, so this is
+ * the only way to say "the box got narrower" to a component that listens.
+ */
+class TestResizeObserver implements ResizeObserver {
+  private readonly callback: ResizeObserverCallback;
+  private readonly own: Watch[] = [];
+
+  constructor(callback: ResizeObserverCallback) {
+    this.callback = callback;
+  }
+
+  observe(element: Element) {
+    const watch: Watch = { element, fire: () => this.callback([], this) };
+    this.own.push(watch);
+    watches.push(watch);
+  }
+
+  unobserve() {
+    // The component drops the whole observer on unmount, never one element.
+  }
+
+  disconnect() {
+    watches = watches.filter((watch) => !this.own.includes(watch));
+  }
+}
+
+/** Make the box report more content than it can show, as clamping does. */
+const clipContent = (element: HTMLElement) => {
+  Object.defineProperty(element, "offsetHeight", {
+    value: 40,
+    configurable: true,
+  });
+  Object.defineProperty(element, "scrollHeight", {
+    value: 400,
+    configurable: true,
+  });
+};
+
+const renderText = () =>
+  render(<HoverableBigText>{TEXT}</HoverableBigText>, {
+    wrapper: ({ children }) => (
+      <ChakraProvider value={defaultSystem}>{children}</ChakraProvider>
+    ),
+  });
+
+/** Let the post-render measurement land, so the box starts out un-clipped. */
+const settleFirstMeasurement = async () => {
+  await act(
+    () =>
+      new Promise<void>((resolve) =>
+        setTimeout(resolve, MEASURE_DELAY_MS + 50),
+      ),
+  );
+};
+
+const resizeBox = (box: HTMLElement) => {
+  const watch = watches.find((candidate) => candidate.element === box);
+  expect(watch, "the box must be watched for this test to mean anything").toBeDefined();
+  act(() => watch!.fire());
+};
+
+describe("HoverableBigText overflow measurement", () => {
+  const realResizeObserver = globalThis.ResizeObserver;
+
+  beforeEach(() => {
+    watches = [];
+    globalThis.ResizeObserver =
+      TestResizeObserver as unknown as typeof ResizeObserver;
+  });
+
+  afterEach(() => {
+    cleanup();
+    globalThis.ResizeObserver = realResizeObserver;
+    vi.restoreAllMocks();
+  });
+
+  describe("given the text fits its box when it is first laid out", () => {
+    describe("when the box narrows without anything re-rendering it", () => {
+      /** @scenario Text clipped by a resize becomes readable again */
+      it("measures again and offers the hidden text", async () => {
+        renderText();
+        const box = screen.getByText(TEXT);
+        await settleFirstMeasurement();
+
+        fireEvent.click(box);
+        expect(
+          screen.queryByText("Formatted"),
+          "text that fits offers nothing to expand",
+        ).not.toBeInTheDocument();
+
+        clipContent(box);
+        resizeBox(box);
+
+        fireEvent.click(screen.getByText(TEXT));
+        expect(await screen.findByText("Formatted")).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/platform/app/src/components/__tests__/HoverableBigText.resize.integration.test.tsx
+++ b/platform/app/src/components/__tests__/HoverableBigText.resize.integration.test.tsx
@@ -60,7 +60,7 @@ class TestResizeObserver implements ResizeObserver {
 }
 
 /** Make the box report more content than it can show, as clamping does. */
-const clipContent = (element: HTMLElement) => {
+const clipContent = ({ element }: { element: HTMLElement }) => {
   Object.defineProperty(element, "offsetHeight", {
     value: 40,
     configurable: true,
@@ -88,7 +88,7 @@ const settleFirstMeasurement = async () => {
   );
 };
 
-const resizeBox = (box: HTMLElement) => {
+const resizeBox = ({ box }: { box: HTMLElement }) => {
   const watch = watches.find((candidate) => candidate.element === box);
   // A box nobody watches would make every test here pass for the wrong reason,
   // so say so rather than firing nothing.
@@ -124,11 +124,26 @@ describe("HoverableBigText overflow measurement", () => {
           screen.queryByText("Formatted"),
           "text that fits offers nothing to expand",
         ).not.toBeInTheDocument();
+        expect(
+          box,
+          "text that fits is not a tooltip trigger either",
+        ).not.toHaveAttribute("data-scope", "tooltip");
 
-        clipContent(box);
-        resizeBox(box);
+        clipContent({ element: box });
+        resizeBox({ box });
 
-        fireEvent.click(screen.getByText(TEXT));
+        // The scenario asks for the full text on hover as well as on click.
+        // Hover is the tooltip, and the tooltip is disabled until the component
+        // measures itself as clipped — disabled means the wrapper renders the
+        // bare text with no trigger wiring at all, so becoming a trigger IS the
+        // affordance appearing. Asserted on the wiring rather than by hovering
+        // because the tooltip opens on a 420ms delay through a portal that
+        // jsdom cannot position.
+        const clipped = screen.getByText(TEXT);
+        expect(clipped).toHaveAttribute("data-scope", "tooltip");
+        expect(clipped).toHaveAttribute("data-part", "trigger");
+
+        fireEvent.click(clipped);
         expect(await screen.findByText("Formatted")).toBeInTheDocument();
       });
     });

--- a/platform/app/src/components/analytics/reports/GraphFilterIndicator.tsx
+++ b/platform/app/src/components/analytics/reports/GraphFilterIndicator.tsx
@@ -19,7 +19,7 @@ export function GraphFilterIndicator({ filters }: GraphFilterIndicatorProps) {
           height="100%"
           textWrap="wrap"
         >
-          <FilterDisplay filters={filters} clampValues={false} />
+          <FilterDisplay filters={filters} shouldClampValues={false} />
         </VStack>
       }
       positioning={{ placement: "top" }}

--- a/platform/app/src/components/annotations/AnnotationColumnsMenu.tsx
+++ b/platform/app/src/components/annotations/AnnotationColumnsMenu.tsx
@@ -1,0 +1,175 @@
+import { Button, HStack, Icon, Input, Stack, Text } from "@chakra-ui/react";
+import { ChevronDown, Columns3, Search } from "lucide-react";
+import { useMemo, useState } from "react";
+import { Checkbox } from "../ui/checkbox";
+import { Popover } from "../ui/popover";
+import { Tooltip } from "../ui/tooltip";
+import {
+  type AnnotationColumnChoices,
+  type AnnotationColumnOption,
+  isColumnVisible,
+} from "./annotationColumns";
+
+/**
+ * Show or hide the annotations list's columns, the way the trace explorer's
+ * column picker does: a search box over the whole set, grouped by section,
+ * with a count of what is showing.
+ *
+ * Order is the table's own and is not something the reviewer sets here — the
+ * list has one sensible reading order, and the complaint this answers was a
+ * wall of empty columns, not the order they sat in.
+ */
+export function AnnotationColumnsMenu({
+  columns,
+  choices,
+  onColumnVisibleChange,
+  onReset,
+  hasChoices,
+}: {
+  columns: AnnotationColumnOption[];
+  choices: AnnotationColumnChoices;
+  onColumnVisibleChange: (change: {
+    columnId: string;
+    isVisible: boolean;
+  }) => void;
+  onReset: () => void;
+  hasChoices: boolean;
+}) {
+  const [query, setQuery] = useState("");
+
+  const shownCount = useMemo(
+    () =>
+      columns.filter((column) => isColumnVisible({ column, choices })).length,
+    [columns, choices],
+  );
+
+  const sections = useMemo(() => {
+    const wanted = query.trim().toLowerCase();
+    const matching = wanted
+      ? columns.filter((column) => column.label.toLowerCase().includes(wanted))
+      : columns;
+    const bySection = new Map<string, AnnotationColumnOption[]>();
+    for (const column of matching) {
+      const bucket = bySection.get(column.section) ?? [];
+      bucket.push(column);
+      bySection.set(column.section, bucket);
+    }
+    return [...bySection.entries()].map(([title, sectionColumns]) => ({
+      title,
+      columns: sectionColumns,
+    }));
+  }, [columns, query]);
+
+  return (
+    <Popover.Root positioning={{ placement: "bottom-end" }}>
+      <Tooltip
+        content="Show or hide columns"
+        positioning={{ placement: "top" }}
+      >
+        <Popover.Trigger asChild>
+          <Button
+            variant="outline"
+            aria-label="Show or hide columns in the table"
+            gap={1}
+          >
+            <Columns3 size={16} />
+            Columns
+            <ChevronDown size={16} />
+          </Button>
+        </Popover.Trigger>
+      </Tooltip>
+      <Popover.Content width="auto" padding={0}>
+        <Stack
+          width="284px"
+          maxHeight="min(70vh, 520px)"
+          overflowY="auto"
+          gap={2.5}
+          padding={2.5}
+        >
+          <HStack justify="space-between" align="baseline">
+            <Text textStyle="sm" fontWeight="semibold" color="fg">
+              Columns
+            </Text>
+            <Text textStyle="2xs" color="fg.subtle">
+              {shownCount} shown
+            </Text>
+          </HStack>
+
+          <HStack
+            gap={1.5}
+            paddingX={2}
+            height="36px"
+            borderWidth="1px"
+            borderColor="border"
+            borderRadius="md"
+            bg="bg.subtle"
+            _focusWithin={{ borderColor: "border.emphasized" }}
+          >
+            <Icon color="fg.subtle" boxSize={3.5}>
+              <Search />
+            </Icon>
+            <Input
+              size="xs"
+              variant="flushed"
+              border="none"
+              height="full"
+              padding={0}
+              placeholder="Search columns…"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key !== "Escape") e.stopPropagation();
+              }}
+              _focusVisible={{ boxShadow: "none" }}
+            />
+          </HStack>
+
+          {sections.map(({ title, columns: sectionColumns }) => (
+            <Stack key={title} gap={1}>
+              <Text
+                textStyle="2xs"
+                fontWeight="semibold"
+                color="fg.muted"
+                textTransform="uppercase"
+                letterSpacing="0.06em"
+              >
+                {title}
+              </Text>
+              <Stack gap={0}>
+                {sectionColumns.map((column) => (
+                  <Checkbox
+                    key={column.id}
+                    size="sm"
+                    paddingY={1}
+                    checked={isColumnVisible({ column, choices })}
+                    onCheckedChange={({ checked }) =>
+                      onColumnVisibleChange({
+                        columnId: column.id,
+                        isVisible: checked === true,
+                      })
+                    }
+                  >
+                    <Text textStyle="xs" color="fg">
+                      {column.label}
+                    </Text>
+                  </Checkbox>
+                ))}
+              </Stack>
+            </Stack>
+          ))}
+
+          {hasChoices && (
+            <Button
+              size="xs"
+              variant="ghost"
+              alignSelf="start"
+              onClick={onReset}
+            >
+              Reset to default
+            </Button>
+          )}
+        </Stack>
+      </Popover.Content>
+    </Popover.Root>
+  );
+}

--- a/platform/app/src/components/annotations/AnnotationColumnsMenu.tsx
+++ b/platform/app/src/components/annotations/AnnotationColumnsMenu.tsx
@@ -95,67 +95,16 @@ export function AnnotationColumnsMenu({
             </Text>
           </HStack>
 
-          <HStack
-            gap={1.5}
-            paddingX={2}
-            height="36px"
-            borderWidth="1px"
-            borderColor="border"
-            borderRadius="md"
-            bg="bg.subtle"
-            _focusWithin={{ borderColor: "border.emphasized" }}
-          >
-            <Icon color="fg.subtle" boxSize={3.5}>
-              <Search />
-            </Icon>
-            <Input
-              size="xs"
-              variant="flushed"
-              border="none"
-              height="full"
-              padding={0}
-              placeholder="Search columns…"
-              value={query}
-              onChange={(e) => setQuery(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key !== "Escape") e.stopPropagation();
-              }}
-              _focusVisible={{ boxShadow: "none" }}
-            />
-          </HStack>
+          <SearchBox query={query} onQueryChange={setQuery} />
 
           {sections.map(({ title, columns: sectionColumns }) => (
-            <Stack key={title} gap={1}>
-              <Text
-                textStyle="2xs"
-                fontWeight="semibold"
-                color="fg.muted"
-                textTransform="uppercase"
-                letterSpacing="0.06em"
-              >
-                {title}
-              </Text>
-              <Stack gap={0}>
-                {sectionColumns.map((column) => (
-                  <Checkbox
-                    key={column.id}
-                    size="sm"
-                    paddingY={1}
-                    checked={isColumnVisible({ column, choices })}
-                    onCheckedChange={({ checked }) =>
-                      onColumnVisibleChange({
-                        columnId: column.id,
-                        isVisible: checked === true,
-                      })
-                    }
-                  >
-                    <Text textStyle="xs" color="fg">
-                      {column.label}
-                    </Text>
-                  </Checkbox>
-                ))}
-              </Stack>
-            </Stack>
+            <ColumnSection
+              key={title}
+              title={title}
+              columns={sectionColumns}
+              choices={choices}
+              onColumnVisibleChange={onColumnVisibleChange}
+            />
           ))}
 
           {hasChoices && (
@@ -171,5 +120,95 @@ export function AnnotationColumnsMenu({
         </Stack>
       </Popover.Content>
     </Popover.Root>
+  );
+}
+
+function SearchBox({
+  query,
+  onQueryChange,
+}: {
+  query: string;
+  onQueryChange: (query: string) => void;
+}) {
+  return (
+    <HStack
+      gap={1.5}
+      paddingX={2}
+      height="36px"
+      borderWidth="1px"
+      borderColor="border"
+      borderRadius="md"
+      bg="bg.subtle"
+      _focusWithin={{ borderColor: "border.emphasized" }}
+    >
+      <Icon color="fg.subtle" boxSize={3.5}>
+        <Search />
+      </Icon>
+      <Input
+        size="xs"
+        variant="flushed"
+        border="none"
+        height="full"
+        padding={0}
+        placeholder="Search columns…"
+        value={query}
+        onChange={(e) => onQueryChange(e.target.value)}
+        // Escape closes the popover; every other key belongs to the box, and
+        // without this the menu's own type-ahead would steal them.
+        onKeyDown={(e) => {
+          if (e.key !== "Escape") e.stopPropagation();
+        }}
+        _focusVisible={{ boxShadow: "none" }}
+      />
+    </HStack>
+  );
+}
+
+function ColumnSection({
+  title,
+  columns,
+  choices,
+  onColumnVisibleChange,
+}: {
+  title: string;
+  columns: AnnotationColumnOption[];
+  choices: AnnotationColumnChoices;
+  onColumnVisibleChange: (change: {
+    columnId: string;
+    isVisible: boolean;
+  }) => void;
+}) {
+  return (
+    <Stack gap={1}>
+      <Text
+        textStyle="2xs"
+        fontWeight="semibold"
+        color="fg.muted"
+        textTransform="uppercase"
+        letterSpacing="0.06em"
+      >
+        {title}
+      </Text>
+      <Stack gap={0}>
+        {columns.map((column) => (
+          <Checkbox
+            key={column.id}
+            size="sm"
+            paddingY={1}
+            checked={isColumnVisible({ column, choices })}
+            onCheckedChange={({ checked }) =>
+              onColumnVisibleChange({
+                columnId: column.id,
+                isVisible: checked === true,
+              })
+            }
+          >
+            <Text textStyle="xs" color="fg">
+              {column.label}
+            </Text>
+          </Checkbox>
+        ))}
+      </Stack>
+    </Stack>
   );
 }

--- a/platform/app/src/components/annotations/AnnotationColumnsMenu.tsx
+++ b/platform/app/src/components/annotations/AnnotationColumnsMenu.tsx
@@ -3,6 +3,7 @@ import { ChevronDown, Columns3, Search } from "lucide-react";
 import { useMemo, useState } from "react";
 import { Checkbox } from "../ui/checkbox";
 import { Popover } from "../ui/popover";
+import { TriggerAnchor } from "../ui/TriggerAnchor";
 import { Tooltip } from "../ui/tooltip";
 import {
   type AnnotationColumnChoices,
@@ -66,17 +67,22 @@ export function AnnotationColumnsMenu({
         content="Show or hide columns"
         positioning={{ placement: "top" }}
       >
-        <Popover.Trigger asChild>
-          <Button
-            variant="outline"
-            aria-label="Show or hide columns in the table"
-            gap={1}
-          >
-            <Columns3 size={16} />
-            Columns
-            <ChevronDown size={16} />
-          </Button>
-        </Popover.Trigger>
+        {/* Tooltip and Popover.Trigger both clone their id onto the child, so
+            the trigger needs its own node or the menu loses its anchor and
+            opens at the page's top-left corner. */}
+        <TriggerAnchor>
+          <Popover.Trigger asChild>
+            <Button
+              variant="outline"
+              aria-label="Show or hide columns in the table"
+              gap={1}
+            >
+              <Columns3 size={16} />
+              Columns
+              <ChevronDown size={16} />
+            </Button>
+          </Popover.Trigger>
+        </TriggerAnchor>
       </Tooltip>
       <Popover.Content width="auto" padding={0}>
         <Stack

--- a/platform/app/src/components/annotations/AnnotationQueueFilter.tsx
+++ b/platform/app/src/components/annotations/AnnotationQueueFilter.tsx
@@ -1,0 +1,82 @@
+import { Button, Text, VStack } from "@chakra-ui/react";
+import { ChevronDown } from "lucide-react";
+import { Checkbox } from "../ui/checkbox";
+import { Menu } from "../ui/menu";
+
+/** A queue the reviewer can narrow the list to. */
+export type FilterableQueue = { id: string; name: string };
+
+/**
+ * Which queues the inbox reads. The inbox pools every queue the reviewer
+ * belongs to, so on a project with several of them the list is a mix nobody
+ * asked for: this is how a reviewer gets down to the one they are working on
+ * without leaving the page that counts all their pending work.
+ *
+ * Picking nothing reads them all, which is what the label says rather than
+ * leaving the reviewer to infer it from an empty control.
+ */
+export function AnnotationQueueFilter({
+  queues,
+  selectedQueueIds,
+  onSelectedQueueIdsChange,
+}: {
+  queues: FilterableQueue[];
+  selectedQueueIds: string[];
+  onSelectedQueueIdsChange: (queueIds: string[]) => void;
+}) {
+  if (queues.length === 0) return null;
+
+  const selected = new Set(selectedQueueIds);
+  const label =
+    selected.size === 0
+      ? "All"
+      : selected.size === 1
+        ? (queues.find((queue) => selected.has(queue.id))?.name ?? "1 queue")
+        : `${selected.size} queues`;
+
+  const toggle = (queueId: string) => {
+    const next = new Set(selected);
+    if (next.has(queueId)) next.delete(queueId);
+    else next.add(queueId);
+    onSelectedQueueIdsChange([...next]);
+  };
+
+  return (
+    <Menu.Root closeOnSelect={false}>
+      <Menu.Trigger asChild>
+        <Button variant="outline">
+          Queues: {label} <ChevronDown size={16} />
+        </Button>
+      </Menu.Trigger>
+      <Menu.Content>
+        <VStack
+          align="start"
+          padding={3}
+          gap={3}
+          maxHeight="320px"
+          overflowY="auto"
+        >
+          {queues.map((queue) => (
+            <Checkbox
+              key={queue.id}
+              size="sm"
+              checked={selected.has(queue.id)}
+              onCheckedChange={() => toggle(queue.id)}
+            >
+              <Text textStyle="sm">{queue.name}</Text>
+            </Checkbox>
+          ))}
+          {selected.size > 0 && (
+            <Button
+              size="xs"
+              variant="ghost"
+              onClick={() => onSelectedQueueIdsChange([])}
+            >
+              Show all queues
+            </Button>
+          )}
+        </VStack>
+      </Menu.Content>
+    </Menu.Root>
+  );
+}

--- a/platform/app/src/components/annotations/AnnotationsTable.tsx
+++ b/platform/app/src/components/annotations/AnnotationsTable.tsx
@@ -18,8 +18,8 @@ import {
   flexRender,
   getCoreRowModel,
   type RowSelectionState,
-  type VisibilityState,
   useReactTable,
+  type VisibilityState,
 } from "@tanstack/react-table";
 import {
   ChevronDown,
@@ -59,8 +59,8 @@ import { RedactedField } from "../ui/RedactedField";
 import { SelectionActionBar } from "../ui/SelectionActionBar";
 import { toaster } from "../ui/toaster";
 import { AnnotationColumnsMenu } from "./AnnotationColumnsMenu";
-import { AnnotationQueueFilter } from "./AnnotationQueueFilter";
 import { AnnotationCommentsChip } from "./AnnotationCommentsChip";
+import { AnnotationQueueFilter } from "./AnnotationQueueFilter";
 import { AnnotationSuggestionsChip } from "./AnnotationSuggestionsChip";
 import UserAvatarGroup from "./AvatarGroup";
 import {

--- a/platform/app/src/components/annotations/AnnotationsTable.tsx
+++ b/platform/app/src/components/annotations/AnnotationsTable.tsx
@@ -18,6 +18,7 @@ import {
   flexRender,
   getCoreRowModel,
   type RowSelectionState,
+  type VisibilityState,
   useReactTable,
 } from "@tanstack/react-table";
 import {
@@ -49,6 +50,7 @@ import { Link } from "../../components/ui/link";
 import { Menu } from "../../components/ui/menu";
 import { Radio, RadioGroup } from "../../components/ui/radio";
 import { Tooltip } from "../../components/ui/tooltip";
+import { HoverableBigText } from "../HoverableBigText";
 import { NoDataInfoBlock } from "../NoDataInfoBlock";
 import { Checkbox } from "../ui/checkbox";
 import { ListTable } from "../ui/ListTable";
@@ -56,15 +58,22 @@ import { Pagination } from "../ui/Pagination";
 import { RedactedField } from "../ui/RedactedField";
 import { SelectionActionBar } from "../ui/SelectionActionBar";
 import { toaster } from "../ui/toaster";
+import { AnnotationColumnsMenu } from "./AnnotationColumnsMenu";
 import { AnnotationCommentsChip } from "./AnnotationCommentsChip";
 import { AnnotationSuggestionsChip } from "./AnnotationSuggestionsChip";
 import UserAvatarGroup from "./AvatarGroup";
+import {
+  annotationColumnOptions,
+  isColumnVisible,
+  scoreColumnId,
+} from "./annotationColumns";
 import {
   type AnnotationRow,
   type AnnotationWithUser,
   queueItemsToRows,
   suggestionExportLine,
 } from "./annotationRow";
+import { useAnnotationColumnChoices } from "./useAnnotationColumnChoices";
 
 const ChakraButton = chakra("button");
 
@@ -126,6 +135,22 @@ function SelectCheckbox({
   );
 }
 
+/**
+ * A trace's input or output as the list shows it: enough to judge the row at a
+ * glance, the rest one hover away and the whole thing one click away. These two
+ * are what the reviewer is being asked about, so they get the room — a cell
+ * clamped to a couple of ellipsised words is not something anyone can review.
+ */
+function ReviewedText({ value }: { value?: string | null }) {
+  return (
+    <Box minWidth="220px" maxWidth="420px">
+      <HoverableBigText lineClamp={3} wordBreak="break-word">
+        {value ?? "<empty>"}
+      </HoverableBigText>
+    </Box>
+  );
+}
+
 /** Page number and size, kept in the URL so a list survives a reload. */
 function useListPaging() {
   const router = useRouter();
@@ -173,8 +198,51 @@ function useListPaging() {
   };
 }
 
+/**
+ * The row's actions, pinned to the right edge of the table's own scroll.
+ *
+ * A project that collects many score types makes this table wider than the
+ * page, and the overflow menu is the last column: unpinned, "View trace" and
+ * "Remove from queue" sit off screen behind a sideways scroll nobody thinks to
+ * make. Pinned, the only way to act on one row is always where the eye is.
+ */
+const stickyActionsCell = {
+  position: "sticky" as const,
+  right: 0,
+  zIndex: 1,
+  borderLeftWidth: "1px",
+  borderLeftColor: "border.muted",
+};
+
+/** The status filter's choices, as the control names them. */
+const STATUS_LABELS: Record<string, string> = {
+  pending: "Pending",
+  completed: "Completed",
+  all: "All",
+};
+
 const formatRowDate = (date: Date | null): string =>
   date ? date.toLocaleDateString() : "-";
+
+/**
+ * Every score given on the row, named by its type. The folded "Scores" column
+ * renders this: one column that says what the reviewers answered, in place of
+ * one column per score type that a project with a dozen of them could not read.
+ */
+const givenScores = ({
+  annotations,
+  activeScoreTypes,
+}: {
+  annotations: AnnotationWithUser[];
+  activeScoreTypes: ActiveScoreType[];
+}) =>
+  activeScoreTypes.flatMap((scoreType) =>
+    scoreValuesFor(annotations, scoreType.id).map((score) => ({
+      ...score,
+      key: `${score.annotationId}-${scoreType.id}`,
+      name: scoreType.name,
+    })),
+  );
 
 const scoreValuesFor = (
   annotations: AnnotationWithUser[],
@@ -307,6 +375,27 @@ export const AnnotationsTable = ({
         .filter((scoreType) => scoreType.active)
         .map((scoreType) => ({ id: scoreType.id, name: scoreType.name })),
     [scoreTypes.data],
+  );
+
+  const columnOptions = useMemo(
+    () =>
+      annotationColumnOptions({
+        dateColumnLabel,
+        scoreTypes: activeScoreTypes,
+      }),
+    [dateColumnLabel, activeScoreTypes],
+  );
+  const { choices, setColumnVisible, resetColumns, hasChoices } =
+    useAnnotationColumnChoices({ projectId: project?.id });
+  const columnVisibility: VisibilityState = useMemo(
+    () =>
+      Object.fromEntries(
+        columnOptions.map((column) => [
+          column.id,
+          isColumnVisible({ column, choices }),
+        ]),
+      ),
+    [columnOptions, choices],
   );
 
   // A page that brings its own rows brings all of them, so the pager slices
@@ -480,16 +569,7 @@ export const AnnotationsTable = ({
         header: "Input",
         cell: ({ row }) => (
           <RedactedField field="input">
-            <Tooltip content={row.original.trace?.input?.value ?? "<empty>"}>
-              <Text
-                lineClamp={2}
-                maxWidth="320px"
-                textOverflow="ellipsis"
-                wordBreak="break-word"
-              >
-                {row.original.trace?.input?.value ?? "<empty>"}
-              </Text>
-            </Tooltip>
+            <ReviewedText value={row.original.trace?.input?.value} />
           </RedactedField>
         ),
       }),
@@ -498,17 +578,29 @@ export const AnnotationsTable = ({
         header: "Output",
         cell: ({ row }) => (
           <RedactedField field="output">
-            <Tooltip content={row.original.trace?.output?.value ?? "<empty>"}>
-              <Text
-                lineClamp={2}
-                maxWidth="320px"
-                textOverflow="ellipsis"
-                wordBreak="break-word"
-              >
-                {row.original.trace?.output?.value ?? "<empty>"}
-              </Text>
-            </Tooltip>
+            <ReviewedText value={row.original.trace?.output?.value} />
           </RedactedField>
+        ),
+      }),
+      columnHelper.display({
+        id: "scores",
+        header: "Scores",
+        cell: ({ row }) => (
+          <HStack gap={1} wrap="wrap" minWidth="140px">
+            {givenScores({
+              annotations: row.original.annotations,
+              activeScoreTypes,
+            }).map((score) => (
+              <Badge key={score.key} whiteSpace="normal">
+                {score.name}: {score.value.join(", ")}
+                {score.reason && (
+                  <Tooltip content={score.reason}>
+                    <MessageCircle size={14} />
+                  </Tooltip>
+                )}
+              </Badge>
+            ))}
+          </HStack>
         ),
       }),
       columnHelper.display({
@@ -533,7 +625,7 @@ export const AnnotationsTable = ({
       }),
       ...activeScoreTypes.map((scoreType) =>
         columnHelper.display({
-          id: `score-${scoreType.id}`,
+          id: scoreColumnId(scoreType.id),
           header: scoreType.name,
           cell: ({ row }) => (
             <VStack align="start" gap={2}>
@@ -619,7 +711,7 @@ export const AnnotationsTable = ({
   const table = useReactTable({
     data: pageRows,
     columns,
-    state: { rowSelection },
+    state: { rowSelection, columnVisibility },
     enableRowSelection: true,
     onRowSelectionChange: setRowSelection,
     getCoreRowModel: getCoreRowModel(),
@@ -711,8 +803,11 @@ export const AnnotationsTable = ({
         {showStatusFilter && (
           <Menu.Root>
             <Menu.Trigger asChild>
+              {/* The chosen status is on the trigger: a filter nobody can read
+                  off the page is one that quietly hides rows. */}
               <Button variant="outline">
-                Status <ChevronDown size={16} />
+                Status: {STATUS_LABELS[statusFilter] ?? statusFilter}{" "}
+                <ChevronDown size={16} />
               </Button>
             </Menu.Trigger>
             <Menu.Content>
@@ -729,6 +824,13 @@ export const AnnotationsTable = ({
             </Menu.Content>
           </Menu.Root>
         )}
+        <AnnotationColumnsMenu
+          columns={columnOptions}
+          choices={choices}
+          onColumnVisibleChange={setColumnVisible}
+          onReset={resetColumns}
+          hasChoices={hasChoices}
+        />
         <PeriodSelector
           period={{ startDate, endDate }}
           mode={periodMode}
@@ -797,6 +899,12 @@ export const AnnotationsTable = ({
                               : undefined
                         }
                         paddingX={header.id === "select" ? 0 : undefined}
+                        {...(header.id === "actions"
+                          ? {
+                              ...stickyActionsCell,
+                              backgroundColor: "bg.subtle",
+                            }
+                          : {})}
                       >
                         {flexRender(
                           header.column.columnDef.header,
@@ -829,6 +937,15 @@ export const AnnotationsTable = ({
                           key={cell.id}
                           paddingX={cell.column.id === "select" ? 0 : undefined}
                           verticalAlign="top"
+                          {...(cell.column.id === "actions"
+                            ? {
+                                ...stickyActionsCell,
+                                // Inherits the row's own background, so the
+                                // pinned cell keeps following the row through
+                                // its done and hover states.
+                                backgroundColor: "inherit",
+                              }
+                            : {})}
                         >
                           {flexRender(
                             cell.column.columnDef.cell,

--- a/platform/app/src/components/annotations/AnnotationsTable.tsx
+++ b/platform/app/src/components/annotations/AnnotationsTable.tsx
@@ -387,9 +387,11 @@ export const AnnotationsTable = ({
   );
 
   // Only the inbox pools several queues into one list, so only the inbox has
-  // anything to narrow.
+  // anything to narrow. It asks for the queues it can read rather than all of
+  // them: the read narrows to the reviewer's reach either way, so offering the
+  // rest would only hand them a pick that empties the list.
   const queues = api.annotation.getQueues.useQuery(
-    { projectId: project?.id ?? "" },
+    { projectId: project?.id ?? "", reachableOnly: true },
     { enabled: !!project?.id && !!showQueueAndUser },
   );
 

--- a/platform/app/src/components/annotations/AnnotationsTable.tsx
+++ b/platform/app/src/components/annotations/AnnotationsTable.tsx
@@ -526,6 +526,11 @@ export const AnnotationsTable = ({
       utils.annotation.getPendingItemsCount.invalidate(),
       utils.annotation.getAssignedItemsCount.invalidate(),
       utils.annotation.getQueueItemsCounts.invalidate(),
+      // The picker's list is a reach, not a name list: a reviewer who is not a
+      // member reaches a queue only through items assigned to them, so removing
+      // their last one takes the queue out of it. Left cached, the picker keeps
+      // offering a queue whose rows have all gone.
+      utils.annotation.getQueues.invalidate(),
     ]);
   }, [utils]);
 

--- a/platform/app/src/components/annotations/AnnotationsTable.tsx
+++ b/platform/app/src/components/annotations/AnnotationsTable.tsx
@@ -59,6 +59,7 @@ import { RedactedField } from "../ui/RedactedField";
 import { SelectionActionBar } from "../ui/SelectionActionBar";
 import { toaster } from "../ui/toaster";
 import { AnnotationColumnsMenu } from "./AnnotationColumnsMenu";
+import { AnnotationQueueFilter } from "./AnnotationQueueFilter";
 import { AnnotationCommentsChip } from "./AnnotationCommentsChip";
 import { AnnotationSuggestionsChip } from "./AnnotationSuggestionsChip";
 import UserAvatarGroup from "./AvatarGroup";
@@ -325,6 +326,7 @@ export const AnnotationsTable = ({
   } = usePeriodSelector();
 
   const [statusFilter, setStatusFilter] = useState<string>("pending");
+  const [selectedQueueIds, setSelectedQueueIds] = useState<string[]>([]);
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
 
   const isPageProvidedRows = providedRows !== undefined;
@@ -358,6 +360,7 @@ export const AnnotationsTable = ({
     {
       selectedAnnotations: statusFilter,
       queueId,
+      queueIds: selectedQueueIds,
       showQueueAndUser,
       ...queuedRange,
       enabled: !isPageProvidedRows,
@@ -367,6 +370,13 @@ export const AnnotationsTable = ({
   const scoreTypes = api.annotationScore.getAll.useQuery(
     { projectId: project?.id ?? "" },
     { enabled: !!project?.id },
+  );
+
+  // Only the inbox pools several queues into one list, so only the inbox has
+  // anything to narrow.
+  const queues = api.annotation.getQueues.useQuery(
+    { projectId: project?.id ?? "" },
+    { enabled: !!project?.id && !!showQueueAndUser },
   );
 
   const activeScoreTypes: ActiveScoreType[] = useMemo(
@@ -421,6 +431,7 @@ export const AnnotationsTable = ({
   }, [
     statusFilter,
     queueId,
+    selectedQueueIds,
     paging.pageOffset,
     paging.pageSize,
     queuedRangeKey,
@@ -800,6 +811,13 @@ export const AnnotationsTable = ({
           </Heading>
         )}
         <Spacer />
+        {showQueueAndUser && (
+          <AnnotationQueueFilter
+            queues={queues.data ?? []}
+            selectedQueueIds={selectedQueueIds}
+            onSelectedQueueIdsChange={setSelectedQueueIds}
+          />
+        )}
         {showStatusFilter && (
           <Menu.Root>
             <Menu.Trigger asChild>

--- a/platform/app/src/components/annotations/AnnotationsTable.tsx
+++ b/platform/app/src/components/annotations/AnnotationsTable.tsx
@@ -238,17 +238,20 @@ const givenScores = ({
   activeScoreTypes: ActiveScoreType[];
 }) =>
   activeScoreTypes.flatMap((scoreType) =>
-    scoreValuesFor(annotations, scoreType.id).map((score) => ({
+    scoreValuesFor({ annotations, scoreTypeId: scoreType.id }).map((score) => ({
       ...score,
       key: `${score.annotationId}-${scoreType.id}`,
       name: scoreType.name,
     })),
   );
 
-const scoreValuesFor = (
-  annotations: AnnotationWithUser[],
-  scoreTypeId: string,
-): { annotationId: string; value: string[]; reason?: string | null }[] =>
+const scoreValuesFor = ({
+  annotations,
+  scoreTypeId,
+}: {
+  annotations: AnnotationWithUser[];
+  scoreTypeId: string;
+}): { annotationId: string; value: string[]; reason?: string | null }[] =>
   annotations.flatMap((annotation) => {
     const scores = annotation.scoreOptions as Record<string, ScoreValue> | null;
     const score = scores?.[scoreTypeId];
@@ -328,6 +331,17 @@ export const AnnotationsTable = ({
   const [statusFilter, setStatusFilter] = useState<string>("pending");
   const [selectedQueueIds, setSelectedQueueIds] = useState<string[]>([]);
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
+
+  // Narrowing the queues narrows the rows, so the page the reviewer was on may
+  // no longer exist: picking a small queue from page three would otherwise show
+  // them the empty state for a queue that has items.
+  const changeSelectedQueueIds = useCallback(
+    (queueIds: string[]) => {
+      setSelectedQueueIds(queueIds);
+      paging.setPage(1);
+    },
+    [paging.setPage],
+  );
 
   const isPageProvidedRows = providedRows !== undefined;
 
@@ -640,20 +654,21 @@ export const AnnotationsTable = ({
           header: scoreType.name,
           cell: ({ row }) => (
             <VStack align="start" gap={2}>
-              {scoreValuesFor(row.original.annotations, scoreType.id).map(
-                (score) => (
-                  <HStack key={score.annotationId} gap={1} wrap="wrap">
-                    {score.value.map((value) => (
-                      <Badge key={value}>{value}</Badge>
-                    ))}
-                    {score.reason && (
-                      <Tooltip content={score.reason}>
-                        <MessageCircle size={14} />
-                      </Tooltip>
-                    )}
-                  </HStack>
-                ),
-              )}
+              {scoreValuesFor({
+                annotations: row.original.annotations,
+                scoreTypeId: scoreType.id,
+              }).map((score) => (
+                <HStack key={score.annotationId} gap={1} wrap="wrap">
+                  {score.value.map((value) => (
+                    <Badge key={value}>{value}</Badge>
+                  ))}
+                  {score.reason && (
+                    <Tooltip content={score.reason}>
+                      <MessageCircle size={14} />
+                    </Tooltip>
+                  )}
+                </HStack>
+              ))}
             </VStack>
           ),
         }),
@@ -778,7 +793,10 @@ export const AnnotationsTable = ({
         .filter(Boolean)
         .join("\n"),
       ...activeScoreTypes.map((scoreType) =>
-        scoreValuesFor(row.annotations, scoreType.id)
+        scoreValuesFor({
+          annotations: row.annotations,
+          scoreTypeId: scoreType.id,
+        })
           .map((score) =>
             score.reason
               ? `${score.value.join(", ")} (${score.reason})`
@@ -815,7 +833,7 @@ export const AnnotationsTable = ({
           <AnnotationQueueFilter
             queues={queues.data ?? []}
             selectedQueueIds={selectedQueueIds}
-            onSelectedQueueIdsChange={setSelectedQueueIds}
+            onSelectedQueueIdsChange={changeSelectedQueueIds}
           />
         )}
         {showStatusFilter && (

--- a/platform/app/src/components/annotations/AnnotationsTable.tsx
+++ b/platform/app/src/components/annotations/AnnotationsTable.tsx
@@ -66,6 +66,7 @@ import UserAvatarGroup from "./AvatarGroup";
 import {
   annotationColumnOptions,
   isColumnVisible,
+  SCORE_COLUMN_PREFIX,
   scoreColumnId,
 } from "./annotationColumns";
 import {
@@ -244,6 +245,70 @@ const givenScores = ({
       name: scoreType.name,
     })),
   );
+
+/**
+ * One column's value for one row, as the CSV writes it. Keyed by the same
+ * column ids the table lays out, so the export follows what the reviewer chose
+ * to see instead of keeping a second list that drifts from it.
+ */
+const exportedCell = ({
+  row,
+  columnId,
+  activeScoreTypes,
+}: {
+  row: AnnotationRow;
+  columnId: string;
+  activeScoreTypes: ActiveScoreType[];
+}): string => {
+  if (columnId.startsWith(SCORE_COLUMN_PREFIX)) {
+    return scoreValuesFor({
+      annotations: row.annotations,
+      scoreTypeId: columnId.slice(SCORE_COLUMN_PREFIX.length),
+    })
+      .map(scoreExportLine)
+      .join("\n");
+  }
+
+  switch (columnId) {
+    case "queuedBy":
+      return row.createdByUser?.name ?? "";
+    case "date":
+      return row.date ? row.date.toISOString() : "";
+    case "input":
+      return row.trace?.input?.value ?? "";
+    case "output":
+      return row.trace?.output?.value ?? "";
+    case "scores":
+      // The folded column names each type, the way its badges do — otherwise
+      // the file would hold a column of bare answers nobody can attribute.
+      return givenScores({ annotations: row.annotations, activeScoreTypes })
+        .map((score) => `${score.name}: ${scoreExportLine(score)}`)
+        .join("\n");
+    case "comments":
+      return row.annotations
+        .map((annotation) => annotation.comment)
+        .filter(Boolean)
+        .join("\n");
+    case "suggestions":
+      return row.annotations
+        .map((annotation) =>
+          suggestionExportLine({ annotation, traceId: row.traceId }),
+        )
+        .filter(Boolean)
+        .join("\n");
+    default:
+      return "";
+  }
+};
+
+/** One score as the file writes it: the answer, and why it was given. */
+const scoreExportLine = (score: {
+  value: string[];
+  reason?: string | null;
+}): string =>
+  score.reason
+    ? `${score.value.join(", ")} (${score.reason})`
+    : score.value.join(", ");
 
 const scoreValuesFor = ({
   annotations,
@@ -765,52 +830,33 @@ export const AnnotationsTable = ({
   );
 
   const exportPage = useCallback(() => {
+    // The file is the rows on screen, so it carries the columns on screen: a
+    // score type the reviewer folded away is not in it either, and the folded
+    // Scores column exports what its cell shows. Trace id, status and
+    // annotators ride along whatever the reviewer picked — they say which row
+    // this is and what became of it, rather than being something chosen to
+    // read.
+    const visibleColumns = columnOptions.filter((column) =>
+      isColumnVisible({ column, choices }),
+    );
+
     const fields = [
-      dateColumnLabel,
-      "Status",
-      "Queued by",
       "Trace ID",
-      "Input",
-      "Output",
-      "Comments",
-      "Suggestions",
-      ...activeScoreTypes.map((scoreType) => scoreType.name),
+      "Status",
+      ...visibleColumns.map((column) => column.label),
       "Annotators",
     ];
     const data = pageRows.map((row) => [
-      row.date ? row.date.toISOString() : "",
-      row.doneAt ? "Completed" : "Pending",
-      row.createdByUser?.name ?? "",
       row.traceId,
-      row.trace?.input?.value ?? "",
-      row.trace?.output?.value ?? "",
-      row.annotations
-        .map((annotation) => annotation.comment)
-        .filter(Boolean)
-        .join("\n"),
-      row.annotations
-        .map((annotation) =>
-          suggestionExportLine({ annotation, traceId: row.traceId }),
-        )
-        .filter(Boolean)
-        .join("\n"),
-      ...activeScoreTypes.map((scoreType) =>
-        scoreValuesFor({
-          annotations: row.annotations,
-          scoreTypeId: scoreType.id,
-        })
-          .map((score) =>
-            score.reason
-              ? `${score.value.join(", ")} (${score.reason})`
-              : score.value.join(", "),
-          )
-          .join("\n"),
+      row.doneAt ? "Completed" : "Pending",
+      ...visibleColumns.map((column) =>
+        exportedCell({ row, columnId: column.id, activeScoreTypes }),
       ),
       annotatorNames(row.annotations).join(", "),
     ]);
 
     downloadCsv({ fields, rows: data, fileName: csvFileName("Annotations") });
-  }, [activeScoreTypes, dateColumnLabel, pageRows]);
+  }, [activeScoreTypes, choices, columnOptions, pageRows]);
 
   const selectedCount = selectedRows.length;
 

--- a/platform/app/src/components/annotations/__tests__/AnnotationsTable.columns.integration.test.tsx
+++ b/platform/app/src/components/annotations/__tests__/AnnotationsTable.columns.integration.test.tsx
@@ -770,6 +770,23 @@ describe("AnnotationsTable columns and row actions", () => {
       expect(columnHeaders()).toContain("Input");
       expect(columnHeaders()).toContain("Output");
     });
+
+    /** @scenario "A column added after the reviewer chose still appears" */
+    it("shows a column the stored choice never mentioned", () => {
+      // What an older build wrote: the reviewer hid one column, back when
+      // Suggestions did not exist yet. A store of the visible set would now
+      // read as "Suggestions off"; storing the choice per column instead lets
+      // the new column's own default decide.
+      window.localStorage.setItem(
+        "annotations:columns:project-1",
+        JSON.stringify({ comments: false }),
+      );
+
+      renderQueuePage();
+
+      expect(columnHeaders()).toContain("Suggestions");
+      expect(columnHeaders()).not.toContain("Comments");
+    });
   });
 
   describe("given a row carries suggestions", () => {

--- a/platform/app/src/components/annotations/__tests__/AnnotationsTable.columns.integration.test.tsx
+++ b/platform/app/src/components/annotations/__tests__/AnnotationsTable.columns.integration.test.tsx
@@ -239,6 +239,9 @@ beforeEach(() => {
   mocks.scoreTypes = [];
   mocks.periodIsDefault = true;
   mocks.queueReadArgs = null;
+  // Column choices live in the browser, so one test's picks must not decide
+  // what the next one starts from.
+  window.localStorage.clear();
   setItems([{ id: "item-1", traceId: "trace-1" }]);
 });
 afterEach(cleanup);
@@ -349,6 +352,28 @@ describe("AnnotationsTable columns and row actions", () => {
 
       expect(columnHeaders()).toContain("Date queued");
       expect(columnHeaders()).not.toContain("Date annotated");
+    });
+
+    /** @scenario "The row's actions stay reachable however wide the table is" */
+    it("pins the actions column to the edge of the table's own scroll", () => {
+      renderQueuePage();
+
+      const actionsHeader = screen.getAllByRole("columnheader").at(-1)!;
+      const actionsCell = screen.getAllByRole("row")[1]!.lastElementChild!;
+      for (const cell of [actionsHeader, actionsCell]) {
+        const style = getComputedStyle(cell);
+        expect(style.position).toBe("sticky");
+        expect(style.right).toBe("0px");
+      }
+    });
+
+    /** @scenario "A queue page filters by status" */
+    it("names the status it is filtering by", () => {
+      renderQueuePage();
+
+      expect(
+        screen.getByRole("button", { name: /Status: Pending/ }),
+      ).toBeInTheDocument();
     });
 
     /** @scenario "A queue page filters by status" */
@@ -591,26 +616,69 @@ describe("AnnotationsTable columns and row actions", () => {
   });
 
   describe("given the project collects scores", () => {
-    /** @scenario "One column per active score type" */
-    it("adds one column per active score type and one cell per row", () => {
+    const twoActiveScoreTypes = () => {
       mocks.scoreTypes = [
         { id: "score-1", name: "Helpfulness", active: true },
         { id: "score-2", name: "Tone", active: true },
         { id: "score-3", name: "Retired", active: false },
       ];
+      setItems([
+        {
+          id: "item-1",
+          traceId: "trace-1",
+          annotations: [
+            annotation({
+              scoreOptions: {
+                "score-1": { value: "good", reason: "on point" },
+              },
+            }),
+          ],
+        },
+      ]);
+    };
+
+    /** @scenario "Every score is folded into one Scores column" */
+    it("folds the scores into one column instead of one column per type", () => {
+      twoActiveScoreTypes();
       renderQueuePage();
 
       const headers = columnHeaders();
-      expect(headers).toContain("Helpfulness");
-      expect(headers).toContain("Tone");
+      expect(headers).toContain("Scores");
+      // One column per type is what made a project with a dozen of them
+      // unreadable; they are on offer in the columns menu, not on by default.
+      expect(headers).not.toContain("Helpfulness");
+      expect(headers).not.toContain("Tone");
       expect(headers).not.toContain("Retired");
+      expect(screen.getByText("Helpfulness: good")).toBeInTheDocument();
       expect(screen.getAllByRole("row")[1]!.children).toHaveLength(
         headers.length,
       );
     });
 
+    /** @scenario "A score type can be given its own column" */
+    it("adds a column for a score type the reviewer picks", async () => {
+      const user = userEvent.setup({ pointerEventsCheck: 0 });
+      twoActiveScoreTypes();
+      renderQueuePage();
+
+      await user.click(
+        screen.getByRole("button", {
+          name: "Show or hide columns in the table",
+        }),
+      );
+      await user.click(
+        await screen.findByRole("checkbox", { name: "Helpfulness" }),
+      );
+
+      expect(columnHeaders()).toContain("Helpfulness");
+      expect(columnHeaders()).not.toContain("Tone");
+      expect(screen.getAllByRole("row")[1]!.children).toHaveLength(
+        columnHeaders().length,
+      );
+    });
+
     /** @scenario "Score types that are all inactive add no columns" */
-    it("adds no score column when none is active", () => {
+    it("offers no score type when none is active", () => {
       mocks.scoreTypes = [
         { id: "score-1", name: "Retired", active: false },
         { id: "score-2", name: "Also retired", active: false },
@@ -622,6 +690,35 @@ describe("AnnotationsTable columns and row actions", () => {
       expect(screen.getAllByRole("row")[1]!.children).toHaveLength(
         headers.length,
       );
+    });
+  });
+
+  describe("given the reviewer wants fewer columns", () => {
+    /** @scenario "A column the reviewer hides stays hidden" */
+    it("hides a column it is told to hide and remembers the choice", async () => {
+      const user = userEvent.setup({ pointerEventsCheck: 0 });
+      const view = renderQueuePage();
+      expect(columnHeaders()).toContain("Suggestions");
+
+      await user.click(
+        screen.getByRole("button", {
+          name: "Show or hide columns in the table",
+        }),
+      );
+      await user.click(
+        await screen.findByRole("checkbox", { name: "Suggestions" }),
+      );
+
+      expect(columnHeaders()).not.toContain("Suggestions");
+
+      view.unmount();
+      renderQueuePage();
+
+      expect(columnHeaders()).not.toContain("Suggestions");
+      // Input and output are what the reviewer is judging, so they are never
+      // the thing a stored choice quietly drops.
+      expect(columnHeaders()).toContain("Input");
+      expect(columnHeaders()).toContain("Output");
     });
   });
 

--- a/platform/app/src/components/annotations/__tests__/AnnotationsTable.columns.integration.test.tsx
+++ b/platform/app/src/components/annotations/__tests__/AnnotationsTable.columns.integration.test.tsx
@@ -773,64 +773,72 @@ describe("AnnotationsTable columns and row actions", () => {
   });
 
   describe("given the reviewer wants fewer columns", () => {
-    /** @scenario "A column the reviewer hides stays hidden" */
-    it("hides a column it is told to hide and remembers the choice", async () => {
-      const user = userEvent.setup({ pointerEventsCheck: 0 });
-      const view = renderQueuePage();
-      expect(columnHeaders()).toContain("Suggestions");
+    describe("when the reviewer turns one off in the menu", () => {
+      /** @scenario "A column the reviewer hides stays hidden" */
+      it("hides it and remembers the choice", async () => {
+        const user = userEvent.setup({ pointerEventsCheck: 0 });
+        const view = renderQueuePage();
+        expect(columnHeaders()).toContain("Suggestions");
 
-      await user.click(
-        screen.getByRole("button", {
-          name: "Show or hide columns in the table",
-        }),
-      );
-      await user.click(
-        await screen.findByRole("checkbox", { name: "Suggestions" }),
-      );
+        await user.click(
+          screen.getByRole("button", {
+            name: "Show or hide columns in the table",
+          }),
+        );
+        await user.click(
+          await screen.findByRole("checkbox", { name: "Suggestions" }),
+        );
 
-      expect(columnHeaders()).not.toContain("Suggestions");
+        expect(columnHeaders()).not.toContain("Suggestions");
 
-      view.unmount();
-      renderQueuePage();
+        view.unmount();
+        renderQueuePage();
 
-      expect(columnHeaders()).not.toContain("Suggestions");
-      // Input and output are what the reviewer is judging, so they are never
-      // the thing a stored choice quietly drops.
-      expect(columnHeaders()).toContain("Input");
-      expect(columnHeaders()).toContain("Output");
-    });
-
-    /** @scenario "A column added after the reviewer chose still appears" */
-    it("shows a column the stored choice never mentioned", () => {
-      // What an older build wrote: the reviewer hid one column, back when
-      // Suggestions did not exist yet. A store of the visible set would now
-      // read as "Suggestions off"; storing the choice per column instead lets
-      // the new column's own default decide.
-      window.localStorage.setItem(
-        "annotations:columns:project-1",
-        JSON.stringify({ comments: false }),
-      );
-
-      renderQueuePage();
-
-      expect(columnHeaders()).toContain("Suggestions");
-      expect(columnHeaders()).not.toContain("Comments");
-    });
-
-    /** @scenario "The columns menu keeps the button as its own trigger" */
-    it("leaves the button to the menu rather than to its tooltip", () => {
-      renderQueuePage();
-
-      const trigger = screen.getByRole("button", {
-        name: "Show or hide columns in the table",
+        expect(columnHeaders()).not.toContain("Suggestions");
+        // Input and output are what the reviewer is judging, so they are never
+        // the thing a stored choice quietly drops.
+        expect(columnHeaders()).toContain("Input");
+        expect(columnHeaders()).toContain("Output");
       });
+    });
 
-      // The tooltip and the menu trigger both clone themselves onto their
-      // child. Let the tooltip win and the menu has no anchor left to measure
-      // against, and it opens in the corner of the page instead of under the
-      // button. Where it lands needs a browser to see; whose button this is
-      // does not, and it is the half that goes wrong.
-      expect(trigger).toHaveAttribute("data-scope", "popover");
+    describe("when the project gains a column their choice never mentioned", () => {
+      /** @scenario "A column added after the reviewer chose still appears" */
+      it("shows the new column", () => {
+        // What an older build wrote: the reviewer hid one column, back when
+        // Suggestions did not exist yet. A store of the visible set would now
+        // read as "Suggestions off"; storing the choice per column instead lets
+        // the new column's own default decide.
+        window.localStorage.setItem(
+          "annotations:columns:project-1",
+          JSON.stringify({ comments: false }),
+        );
+
+        renderQueuePage();
+
+        expect(columnHeaders()).toContain("Suggestions");
+        expect(columnHeaders()).not.toContain("Comments");
+      });
+    });
+  });
+
+  describe("given the columns menu sits behind a tooltip", () => {
+    describe("when the list renders", () => {
+      /** @scenario "The columns menu keeps the button as its own trigger" */
+      it("leaves the button to the menu rather than to its tooltip", () => {
+        renderQueuePage();
+
+        const trigger = screen.getByRole("button", {
+          name: "Show or hide columns in the table",
+        });
+
+        // The tooltip and the menu trigger both clone themselves onto their
+        // child. Let the tooltip win and the menu has no anchor left to measure
+        // against, and it opens in the corner of the page instead of under the
+        // button. Where it lands needs a browser to see; whose button this is
+        // does not, and it is the half that goes wrong.
+        expect(trigger).toHaveAttribute("data-scope", "popover");
+      });
     });
   });
 

--- a/platform/app/src/components/annotations/__tests__/AnnotationsTable.columns.integration.test.tsx
+++ b/platform/app/src/components/annotations/__tests__/AnnotationsTable.columns.integration.test.tsx
@@ -482,23 +482,51 @@ describe("AnnotationsTable columns and row actions", () => {
       fireEvent.click(screen.getByRole("button", { name: /Export/ }));
 
       const call = mocks.downloadCsv.mock.calls[0]?.[0];
+      // The columns the table shows, in table order. "Helpfulness" is a score
+      // type of its own and off by default, so it is not here; the folded
+      // Scores column is what carries the answers, and it names the type.
       expect(call.fields).toEqual([
-        "Date queued",
-        "Status",
-        "Queued by",
         "Trace ID",
+        "Status",
+        "People",
+        "Date queued",
         "Input",
         "Output",
+        "Scores",
         "Comments",
         "Suggestions",
-        "Helpfulness",
         "Annotators",
       ]);
       expect(call.rows).toHaveLength(2);
       expect(call.rows[0]).toContain("trace-1");
       expect(call.rows[0]).toContain("Pending");
-      expect(call.rows[0]).toContain("good (on point)");
+      expect(call.rows[0]).toContain("Helpfulness: good (on point)");
       expect(call.fileName).toBe("Annotations - 2026-08-08.csv");
+    });
+
+    /** @scenario "A queue page exports the rows on screen" */
+    it("drops a column from the file when the reviewer hides it", async () => {
+      const user = userEvent.setup({ pointerEventsCheck: 0 });
+      mocks.scoreTypes = [{ id: "score-1", name: "Helpfulness", active: true }];
+      renderQueuePage();
+
+      await user.click(
+        screen.getByRole("button", {
+          name: "Show or hide columns in the table",
+        }),
+      );
+      await user.click(
+        await screen.findByRole("checkbox", { name: "Suggestions" }),
+      );
+      // ...and take a score type's own column, which is off by default, on.
+      await user.click(
+        await screen.findByRole("checkbox", { name: "Helpfulness" }),
+      );
+      await user.click(screen.getByRole("button", { name: /Export/ }));
+
+      const call = mocks.downloadCsv.mock.calls[0]?.[0];
+      expect(call.fields).not.toContain("Suggestions");
+      expect(call.fields).toContain("Helpfulness");
     });
   });
 

--- a/platform/app/src/components/annotations/__tests__/AnnotationsTable.columns.integration.test.tsx
+++ b/platform/app/src/components/annotations/__tests__/AnnotationsTable.columns.integration.test.tsx
@@ -7,6 +7,7 @@ import {
   fireEvent,
   render,
   screen,
+  waitFor,
   within,
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -38,6 +39,12 @@ const mocks = vi.hoisted(() => ({
   downloadCsv: vi.fn(),
   periodIsDefault: true,
   queueReadArgs: null as Record<string, unknown> | null,
+  // Stable across renders, unlike the invalidators built inside useUtils, so a
+  // test can say whether the picker's list was refreshed.
+  invalidateQueues: vi.fn(),
+  // What the component wants done once a removal lands. Held so a test can run
+  // it, which is the only way the refresh is reachable from here.
+  deleteOnSuccess: null as ((result: { deleted: number }) => void) | null,
 }));
 
 vi.mock("~/hooks/useAnnotationQueues", () => ({
@@ -73,6 +80,7 @@ vi.mock("~/utils/api", () => ({
         getPendingItemsCount: { invalidate: vi.fn() },
         getAssignedItemsCount: { invalidate: vi.fn() },
         getQueueItemsCounts: { invalidate: vi.fn() },
+        getQueues: { invalidate: mocks.invalidateQueues },
       },
     }),
     annotationScore: {
@@ -80,7 +88,12 @@ vi.mock("~/utils/api", () => ({
     },
     annotation: {
       deleteQueueItems: {
-        useMutation: () => ({ mutate: mocks.deleteMutate, isLoading: false }),
+        useMutation: (options?: {
+          onSuccess?: (result: { deleted: number }) => void;
+        }) => {
+          mocks.deleteOnSuccess = options?.onSuccess ?? null;
+          return { mutate: mocks.deleteMutate, isLoading: false };
+        },
       },
       getQueues: { useQuery: () => ({ data: mocks.queues }) },
     },
@@ -242,6 +255,8 @@ beforeEach(() => {
   mocks.queues = [];
   mocks.periodIsDefault = true;
   mocks.queueReadArgs = null;
+  mocks.invalidateQueues.mockClear();
+  mocks.deleteOnSuccess = null;
   // Column choices live in the browser, so one test's picks must not decide
   // what the next one starts from.
   window.localStorage.clear();
@@ -783,6 +798,23 @@ describe("AnnotationsTable columns and row actions", () => {
           { pathname: "/[project]/annotations", query: {} },
           undefined,
           { shallow: true },
+        );
+      });
+    });
+
+    describe("when items are removed from a queue", () => {
+      /** @scenario "The queue filter is refreshed when items leave a queue" */
+      it("reads the filter's list again", async () => {
+        twoQueues();
+        renderQueuePage({ showQueueAndUser: true });
+        expect(mocks.invalidateQueues).not.toHaveBeenCalled();
+
+        // A non-member reaches a queue only through items assigned to them, so
+        // the removal that empties that set is the one that changes the list.
+        mocks.deleteOnSuccess?.({ deleted: 1 });
+
+        await waitFor(() =>
+          expect(mocks.invalidateQueues).toHaveBeenCalledTimes(1),
         );
       });
     });

--- a/platform/app/src/components/annotations/__tests__/AnnotationsTable.columns.integration.test.tsx
+++ b/platform/app/src/components/annotations/__tests__/AnnotationsTable.columns.integration.test.tsx
@@ -29,6 +29,7 @@ const mocks = vi.hoisted(() => ({
   },
   items: [] as unknown[],
   scoreTypes: [] as { id: string; name: string; active: boolean }[],
+  queues: [] as { id: string; name: string }[],
   query: {} as Record<string, string>,
   openDrawer: vi.fn(),
   push: vi.fn(),
@@ -81,6 +82,7 @@ vi.mock("~/utils/api", () => ({
       deleteQueueItems: {
         useMutation: () => ({ mutate: mocks.deleteMutate, isLoading: false }),
       },
+      getQueues: { useQuery: () => ({ data: mocks.queues }) },
     },
   },
 }));
@@ -237,6 +239,7 @@ beforeEach(() => {
   mocks.requestEnable.mockResolvedValue(true);
   mocks.query = {};
   mocks.scoreTypes = [];
+  mocks.queues = [];
   mocks.periodIsDefault = true;
   mocks.queueReadArgs = null;
   // Column choices live in the browser, so one test's picks must not decide
@@ -690,6 +693,53 @@ describe("AnnotationsTable columns and row actions", () => {
       expect(screen.getAllByRole("row")[1]!.children).toHaveLength(
         headers.length,
       );
+    });
+  });
+
+  describe("given the inbox pools several queues", () => {
+    const twoQueues = () => {
+      mocks.queues = [
+        { id: "queue-1", name: "Tone review" },
+        { id: "queue-2", name: "Safety review" },
+      ];
+    };
+
+    /** @scenario "The inbox reads every queue until one is picked" */
+    it("reads them all and says so", () => {
+      twoQueues();
+      renderQueuePage({ showQueueAndUser: true });
+
+      expect(
+        screen.getByRole("button", { name: /Queues: All/ }),
+      ).toBeInTheDocument();
+      expect(mocks.queueReadArgs?.queueIds).toEqual([]);
+    });
+
+    /** @scenario "The inbox narrows to the queues the reviewer picks" */
+    it("narrows the read to a picked queue and names it", async () => {
+      const user = userEvent.setup({ pointerEventsCheck: 0 });
+      twoQueues();
+      renderQueuePage({ showQueueAndUser: true });
+
+      await user.click(screen.getByRole("button", { name: /Queues:/ }));
+      await user.click(
+        await screen.findByRole("checkbox", { name: "Safety review" }),
+      );
+
+      expect(mocks.queueReadArgs?.queueIds).toEqual(["queue-2"]);
+      expect(
+        screen.getByRole("button", { name: /Queues: Safety review/ }),
+      ).toBeInTheDocument();
+    });
+
+    /** @scenario "A page that is one queue offers no queue filter" */
+    it("offers no queue filter where the page is already one queue", () => {
+      twoQueues();
+      renderQueuePage({ queueId: "queue-1" });
+
+      expect(
+        screen.queryByRole("button", { name: /Queues:/ }),
+      ).not.toBeInTheDocument();
     });
   });
 

--- a/platform/app/src/components/annotations/__tests__/AnnotationsTable.columns.integration.test.tsx
+++ b/platform/app/src/components/annotations/__tests__/AnnotationsTable.columns.integration.test.tsx
@@ -787,6 +787,22 @@ describe("AnnotationsTable columns and row actions", () => {
       expect(columnHeaders()).toContain("Suggestions");
       expect(columnHeaders()).not.toContain("Comments");
     });
+
+    /** @scenario "The columns menu opens against its own button" */
+    it("keeps the menu's own identity on the button its tooltip wraps", () => {
+      renderQueuePage();
+
+      const trigger = screen.getByRole("button", {
+        name: "Show or hide columns in the table",
+      });
+
+      // The tooltip and the menu trigger both clone an id onto their child. Let
+      // the tooltip win and the menu has no anchor left to measure against, so
+      // it opens in the page's top-left corner instead of under the button —
+      // which no layout-free test can see, but this attribute can.
+      expect(trigger).toHaveAttribute("data-scope", "popover");
+      expect(trigger.id).toMatch(/^popover:/);
+    });
   });
 
   describe("given a row carries suggestions", () => {

--- a/platform/app/src/components/annotations/__tests__/AnnotationsTable.columns.integration.test.tsx
+++ b/platform/app/src/components/annotations/__tests__/AnnotationsTable.columns.integration.test.tsx
@@ -704,42 +704,71 @@ describe("AnnotationsTable columns and row actions", () => {
       ];
     };
 
-    /** @scenario "The inbox reads every queue until one is picked" */
-    it("reads them all and says so", () => {
-      twoQueues();
-      renderQueuePage({ showQueueAndUser: true });
+    describe("when no queue has been picked", () => {
+      /** @scenario "The inbox reads every queue until one is picked" */
+      it("reads them all and says so", () => {
+        twoQueues();
+        renderQueuePage({ showQueueAndUser: true });
 
-      expect(
-        screen.getByRole("button", { name: /Queues: All/ }),
-      ).toBeInTheDocument();
-      expect(mocks.queueReadArgs?.queueIds).toEqual([]);
+        expect(
+          screen.getByRole("button", { name: /Queues: All/ }),
+        ).toBeInTheDocument();
+        expect(mocks.queueReadArgs?.queueIds).toEqual([]);
+      });
     });
 
-    /** @scenario "The inbox narrows to the queues the reviewer picks" */
-    it("narrows the read to a picked queue and names it", async () => {
-      const user = userEvent.setup({ pointerEventsCheck: 0 });
-      twoQueues();
-      renderQueuePage({ showQueueAndUser: true });
+    describe("when the reviewer picks one of them", () => {
+      /** @scenario "The inbox narrows to the queues the reviewer picks" */
+      it("narrows the read to a picked queue and names it", async () => {
+        const user = userEvent.setup({ pointerEventsCheck: 0 });
+        twoQueues();
+        renderQueuePage({ showQueueAndUser: true });
 
-      await user.click(screen.getByRole("button", { name: /Queues:/ }));
-      await user.click(
-        await screen.findByRole("checkbox", { name: "Safety review" }),
-      );
+        await user.click(screen.getByRole("button", { name: /Queues:/ }));
+        await user.click(
+          await screen.findByRole("checkbox", { name: "Safety review" }),
+        );
 
-      expect(mocks.queueReadArgs?.queueIds).toEqual(["queue-2"]);
-      expect(
-        screen.getByRole("button", { name: /Queues: Safety review/ }),
-      ).toBeInTheDocument();
+        expect(mocks.queueReadArgs?.queueIds).toEqual(["queue-2"]);
+        expect(
+          screen.getByRole("button", { name: /Queues: Safety review/ }),
+        ).toBeInTheDocument();
+      });
     });
 
-    /** @scenario "A page that is one queue offers no queue filter" */
-    it("offers no queue filter where the page is already one queue", () => {
-      twoQueues();
-      renderQueuePage({ queueId: "queue-1" });
+    describe("when the reviewer picks one of them from a later page", () => {
+      /** @scenario "Picking a queue takes the reviewer back to the first page" */
+      it("goes back to the first page", async () => {
+        const user = userEvent.setup({ pointerEventsCheck: 0 });
+        twoQueues();
+        mocks.query = { pageOffset: "25" };
+        renderQueuePage({ showQueueAndUser: true });
 
-      expect(
-        screen.queryByRole("button", { name: /Queues:/ }),
-      ).not.toBeInTheDocument();
+        await user.click(screen.getByRole("button", { name: /Queues:/ }));
+        await user.click(
+          await screen.findByRole("checkbox", { name: "Safety review" }),
+        );
+
+        // pageOffset drops out of the query entirely at offset zero, so an
+        // empty query IS page one.
+        expect(mocks.push).toHaveBeenCalledWith(
+          { pathname: "/[project]/annotations", query: {} },
+          undefined,
+          { shallow: true },
+        );
+      });
+    });
+
+    describe("when the page is already one queue", () => {
+      /** @scenario "A page that is one queue offers no queue filter" */
+      it("offers no queue filter", () => {
+        twoQueues();
+        renderQueuePage({ queueId: "queue-1" });
+
+        expect(
+          screen.queryByRole("button", { name: /Queues:/ }),
+        ).not.toBeInTheDocument();
+      });
     });
   });
 
@@ -788,20 +817,20 @@ describe("AnnotationsTable columns and row actions", () => {
       expect(columnHeaders()).not.toContain("Comments");
     });
 
-    /** @scenario "The columns menu opens against its own button" */
-    it("keeps the menu's own identity on the button its tooltip wraps", () => {
+    /** @scenario "The columns menu keeps the button as its own trigger" */
+    it("leaves the button to the menu rather than to its tooltip", () => {
       renderQueuePage();
 
       const trigger = screen.getByRole("button", {
         name: "Show or hide columns in the table",
       });
 
-      // The tooltip and the menu trigger both clone an id onto their child. Let
-      // the tooltip win and the menu has no anchor left to measure against, so
-      // it opens in the page's top-left corner instead of under the button —
-      // which no layout-free test can see, but this attribute can.
+      // The tooltip and the menu trigger both clone themselves onto their
+      // child. Let the tooltip win and the menu has no anchor left to measure
+      // against, and it opens in the corner of the page instead of under the
+      // button. Where it lands needs a browser to see; whose button this is
+      // does not, and it is the half that goes wrong.
       expect(trigger).toHaveAttribute("data-scope", "popover");
-      expect(trigger.id).toMatch(/^popover:/);
     });
   });
 

--- a/platform/app/src/components/annotations/annotationColumns.ts
+++ b/platform/app/src/components/annotations/annotationColumns.ts
@@ -1,0 +1,140 @@
+/**
+ * Which columns the annotations list can show, and which of them a reviewer
+ * sees before they have said anything.
+ *
+ * A project that collects a dozen score types used to get a dozen columns,
+ * nearly all of them empty on any given row, pushing input and output — the
+ * two things a reviewer actually judges — into a narrow strip and the row's
+ * actions off the right edge. So the score types now arrive folded into one
+ * "Scores" column, and each type is still available on its own for anyone who
+ * wants the matrix.
+ */
+
+/** One column the list can show, as the column picker names it. */
+export interface AnnotationColumnOption {
+  id: string;
+  label: string;
+  /** Grouping label inside the picker. */
+  section: string;
+  /** Whether it shows before the reviewer has chosen anything. */
+  isVisibleByDefault: boolean;
+}
+
+/**
+ * The columns the table always carries: picking rows, and the row's own
+ * actions. Neither is content, so neither is offered in the picker — hiding
+ * them would only ever cost the reviewer a way to act.
+ */
+export const FIXED_COLUMN_IDS = ["select", "actions"] as const;
+
+/** What a per-score-type column's id starts with. */
+export const SCORE_COLUMN_PREFIX = "score-";
+
+export const scoreColumnId = (scoreTypeId: string) =>
+  `${SCORE_COLUMN_PREFIX}${scoreTypeId}`;
+
+/** What the reviewer has chosen to show or hide, by column id. */
+export type AnnotationColumnChoices = Record<string, boolean>;
+
+const STANDARD = "Standard";
+const SCORE_TYPES = "Score types";
+
+/**
+ * Every column on offer, in the order the table lays them out. The date
+ * column is named by the page, because a queue dates a row by when it was
+ * queued and the all annotations page by when it was last judged.
+ */
+export function annotationColumnOptions({
+  dateColumnLabel,
+  scoreTypes,
+}: {
+  dateColumnLabel: string;
+  scoreTypes: { id: string; name: string }[];
+}): AnnotationColumnOption[] {
+  return [
+    {
+      id: "queuedBy",
+      label: "People",
+      section: STANDARD,
+      isVisibleByDefault: true,
+    },
+    {
+      id: "date",
+      label: dateColumnLabel,
+      section: STANDARD,
+      isVisibleByDefault: true,
+    },
+    {
+      id: "input",
+      label: "Input",
+      section: STANDARD,
+      isVisibleByDefault: true,
+    },
+    {
+      id: "output",
+      label: "Output",
+      section: STANDARD,
+      isVisibleByDefault: true,
+    },
+    {
+      id: "scores",
+      label: "Scores",
+      section: STANDARD,
+      isVisibleByDefault: true,
+    },
+    {
+      id: "comments",
+      label: "Comments",
+      section: STANDARD,
+      isVisibleByDefault: true,
+    },
+    {
+      id: "suggestions",
+      label: "Suggestions",
+      section: STANDARD,
+      isVisibleByDefault: true,
+    },
+    // Off by default: the folded "Scores" column already says what every
+    // reviewer answered, and one column per type is what made the list
+    // unreadable for the projects that collect many.
+    ...scoreTypes.map((scoreType) => ({
+      id: scoreColumnId(scoreType.id),
+      label: scoreType.name,
+      section: SCORE_TYPES,
+      isVisibleByDefault: false,
+    })),
+  ];
+}
+
+/**
+ * Whether a column shows: what the reviewer chose for it, and its own default
+ * where they have chosen nothing. Reading the default per column rather than
+ * storing the visible set is what lets a column added later — a new score type
+ * among them — arrive as its author intended instead of silently hidden.
+ */
+export function isColumnVisible({
+  column,
+  choices,
+}: {
+  column: AnnotationColumnOption;
+  choices: AnnotationColumnChoices;
+}): boolean {
+  return choices[column.id] ?? column.isVisibleByDefault;
+}
+
+/** The ids the table renders, fixed columns included, in table order. */
+export function visibleColumnIds({
+  columns,
+  choices,
+}: {
+  columns: AnnotationColumnOption[];
+  choices: AnnotationColumnChoices;
+}): string[] {
+  return [
+    "select",
+    ...columns
+      .filter((column) => isColumnVisible({ column, choices }))
+      .map((column) => column.id),
+    "actions",
+  ];
+}

--- a/platform/app/src/components/annotations/useAnnotationColumnChoices.ts
+++ b/platform/app/src/components/annotations/useAnnotationColumnChoices.ts
@@ -1,0 +1,77 @@
+import { useCallback, useEffect, useState } from "react";
+import type { AnnotationColumnChoices } from "./annotationColumns";
+
+/**
+ * The reviewer's column choices, kept per project so a wide review project and
+ * a narrow one do not fight over one layout. Local to the browser on purpose:
+ * this is how one person likes to read the list, not something the project
+ * agrees on, and nothing is lost if it does not follow them to another machine.
+ */
+const storageKey = (projectId: string) => `annotations:columns:${projectId}`;
+
+const readChoices = (projectId: string): AnnotationColumnChoices => {
+  if (typeof window === "undefined" || !projectId) return {};
+  try {
+    const stored = window.localStorage.getItem(storageKey(projectId));
+    if (!stored) return {};
+    const parsed: unknown = JSON.parse(stored);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed))
+      return {};
+    // Anything that is not a plain on/off is not a choice this build wrote, so
+    // it is dropped rather than trusted: a bad entry would otherwise hide a
+    // column with no way to work out why.
+    return Object.fromEntries(
+      Object.entries(parsed as Record<string, unknown>).filter(
+        (entry): entry is [string, boolean] => typeof entry[1] === "boolean",
+      ),
+    );
+  } catch {
+    return {};
+  }
+};
+
+export function useAnnotationColumnChoices({
+  projectId,
+}: {
+  projectId: string | undefined;
+}) {
+  const [choices, setChoices] = useState<AnnotationColumnChoices>({});
+
+  // Read after mount rather than in the initial state, so the server and the
+  // first client render agree and the table does not flash a different set.
+  useEffect(() => {
+    setChoices(readChoices(projectId ?? ""));
+  }, [projectId]);
+
+  const persist = useCallback(
+    (next: AnnotationColumnChoices) => {
+      setChoices(next);
+      if (typeof window === "undefined" || !projectId) return;
+      try {
+        window.localStorage.setItem(
+          storageKey(projectId),
+          JSON.stringify(next),
+        );
+      } catch {
+        // A full or blocked store costs the reviewer their choice next visit,
+        // never this one: the table already has it in state.
+      }
+    },
+    [projectId],
+  );
+
+  const setColumnVisible = useCallback(
+    ({ columnId, isVisible }: { columnId: string; isVisible: boolean }) =>
+      persist({ ...choices, [columnId]: isVisible }),
+    [choices, persist],
+  );
+
+  const resetColumns = useCallback(() => persist({}), [persist]);
+
+  return {
+    choices,
+    setColumnVisible,
+    resetColumns,
+    hasChoices: Object.keys(choices).length > 0,
+  };
+}

--- a/platform/app/src/components/automations/FilterDisplay.tsx
+++ b/platform/app/src/components/automations/FilterDisplay.tsx
@@ -10,7 +10,7 @@ interface FilterDisplayProps {
    * off where the chip is already inside a tooltip: there is no room for a
    * second hover, so the value has to wrap instead.
    */
-  clampValues?: boolean;
+  shouldClampValues?: boolean;
 }
 
 const FilterContainer = ({
@@ -61,12 +61,12 @@ const FilterLabel = ({ children }: { children: React.ReactNode }) => {
 
 const FilterValue = ({
   children,
-  clamp = true,
+  shouldClamp = true,
 }: {
   children: React.ReactNode;
-  clamp?: boolean;
+  shouldClamp?: boolean;
 }) => {
-  if (!clamp) {
+  if (!shouldClamp) {
     // Already inside a tooltip: wrap instead, and break mid-token so an
     // unbreakable id cannot run past the tooltip edge.
     return (
@@ -91,7 +91,7 @@ const FilterValue = ({
 export const FilterDisplay = ({
   filters,
   hasBorder = false,
-  clampValues = true,
+  shouldClampValues = true,
 }: FilterDisplayProps) => {
   const applyFilters = (filters: string | Record<string, any>) => {
     const obj = typeof filters === "string" ? JSON.parse(filters) : filters;
@@ -102,7 +102,9 @@ export const FilterDisplay = ({
         result.push(
           <FilterContainer key={key} hasBorder={hasBorder}>
             <FilterLabel>{key}</FilterLabel>
-            <FilterValue clamp={clampValues}>{value.join(", ")}</FilterValue>
+            <FilterValue shouldClamp={shouldClampValues}>
+              {value.join(", ")}
+            </FilterValue>
           </FilterContainer>,
         );
       } else if (typeof value === "object" && value !== null) {
@@ -126,7 +128,7 @@ export const FilterDisplay = ({
         result.push(
           <FilterContainer key={key} hasBorder={hasBorder}>
             <FilterLabel>{key}</FilterLabel>
-            <FilterValue clamp={clampValues}>
+            <FilterValue shouldClamp={shouldClampValues}>
               {nestedResult.join("; ")}
             </FilterValue>
           </FilterContainer>,
@@ -135,7 +137,9 @@ export const FilterDisplay = ({
         result.push(
           <FilterContainer key={key} fontSize="xs" hasBorder={hasBorder}>
             <FilterLabel>{key}</FilterLabel>
-            <FilterValue clamp={clampValues}>{String(value)}</FilterValue>
+            <FilterValue shouldClamp={shouldClampValues}>
+              {String(value)}
+            </FilterValue>
           </FilterContainer>,
         );
       }

--- a/platform/app/src/components/automations/__tests__/FilterDisplay.integration.test.tsx
+++ b/platform/app/src/components/automations/__tests__/FilterDisplay.integration.test.tsx
@@ -6,13 +6,20 @@ import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 import { FilterDisplay } from "../FilterDisplay";
 
-const renderFilters = (
-  filters: Record<string, unknown>,
-  props: { clampValues?: boolean } = {},
-) =>
+const renderFilters = ({
+  filters,
+  shouldClampValues,
+}: {
+  filters: Record<string, unknown>;
+  shouldClampValues?: boolean;
+}) =>
   render(
     <ChakraProvider value={defaultSystem}>
-      <FilterDisplay filters={filters} hasBorder={true} {...props} />
+      <FilterDisplay
+        filters={filters}
+        hasBorder={true}
+        {...(shouldClampValues === undefined ? {} : { shouldClampValues })}
+      />
     </ChakraProvider>,
   );
 
@@ -21,58 +28,56 @@ const renderFilters = (
 // bleeds into the next table column.
 const LONG_VALUE = "monitor_0008KDW6ykSweqn6dwR0UukEOi2wAbCdEfGhIjKlMnOpQrSt";
 
+const LONG_FILTER = { "trace_checks.check_id": [LONG_VALUE] };
+
 describe("FilterDisplay", () => {
   afterEach(() => cleanup());
 
-  describe("when a filter value is one long unbreakable token", () => {
-    it("lets the value's flex child shrink below its content width", () => {
-      renderFilters({ "trace_checks.check_id": [LONG_VALUE] });
+  describe("given a filter value is one long unbreakable token", () => {
+    describe("when the chip clamps its values", () => {
+      it("lets the value's flex child shrink below its content width", () => {
+        renderFilters({ filters: LONG_FILTER });
 
-      const text = screen.getByText(LONG_VALUE);
-      // The clamped text box sits inside FilterValue's Box, the flex child of
-      // the chip's HStack. Flex children default to min-width: auto, which is
-      // the defect: the chip cannot shrink it, so it must opt out.
-      const flexChild = text.closest("div")?.parentElement;
-      expect(flexChild).toBeTruthy();
-      const style = getComputedStyle(flexChild!);
-      expect(style.minWidth).toBe("0px");
-      expect(style.overflow).toBe("hidden");
+        const text = screen.getByText(LONG_VALUE);
+        // The clamped text box sits inside FilterValue's Box, the flex child of
+        // the chip's HStack. Flex children default to min-width: auto, which is
+        // the defect: the chip cannot shrink it, so it must opt out.
+        const flexChild = text.closest("div")?.parentElement;
+        expect(flexChild).toBeTruthy();
+        const style = getComputedStyle(flexChild!);
+        expect(style.minWidth).toBe("0px");
+        expect(style.overflow).toBe("hidden");
+      });
+
+      it("keeps the value clamped to one line inside the chip", () => {
+        renderFilters({ filters: LONG_FILTER });
+
+        const text = screen.getByText(LONG_VALUE);
+        const clamped = getComputedStyle(text.closest("div")!);
+        expect(clamped.webkitLineClamp).toBe("1");
+      });
     });
 
-    it("keeps the value clamped to one line inside the chip", () => {
-      renderFilters({ "trace_checks.check_id": [LONG_VALUE] });
+    // The graph filter indicator renders this inside a tooltip, where clamping
+    // hides the rest of the value behind a hover the user cannot perform.
+    describe("when clamping is turned off", () => {
+      it("wraps the value instead of clamping it to one line", () => {
+        renderFilters({ filters: LONG_FILTER, shouldClampValues: false });
 
-      const text = screen.getByText(LONG_VALUE);
-      const clamped = getComputedStyle(text.closest("div")!);
-      expect(clamped.webkitLineClamp).toBe("1");
-    });
-  });
+        const style = getComputedStyle(screen.getByText(LONG_VALUE));
+        // Asserted as absent rather than "not 1": a negative assertion would
+        // also pass if the styles had never applied at all.
+        expect(style.webkitLineClamp).toBe("");
+        expect(style.overflow).toBe("");
+      });
 
-  // The graph filter indicator renders this inside a tooltip, where clamping
-  // hides the rest of the value behind a hover the user cannot perform.
-  describe("when clamping is turned off", () => {
-    it("wraps the value instead of clamping it to one line", () => {
-      renderFilters(
-        { "trace_checks.check_id": [LONG_VALUE] },
-        { clampValues: false },
-      );
+      it("breaks mid-token so an unbreakable id cannot run past its container", () => {
+        renderFilters({ filters: LONG_FILTER, shouldClampValues: false });
 
-      const style = getComputedStyle(screen.getByText(LONG_VALUE));
-      // Asserted as absent rather than "not 1": a negative assertion would
-      // also pass if the styles had never applied at all.
-      expect(style.webkitLineClamp).toBe("");
-      expect(style.overflow).toBe("");
-    });
-
-    it("breaks mid-token so an unbreakable id cannot run past its container", () => {
-      renderFilters(
-        { "trace_checks.check_id": [LONG_VALUE] },
-        { clampValues: false },
-      );
-
-      const style = getComputedStyle(screen.getByText(LONG_VALUE));
-      expect(style.overflowWrap).toBe("anywhere");
-      expect(style.minWidth).toBe("0px");
+        const style = getComputedStyle(screen.getByText(LONG_VALUE));
+        expect(style.overflowWrap).toBe("anywhere");
+        expect(style.minWidth).toBe("0px");
+      });
     });
   });
 });

--- a/platform/app/src/hooks/useAnnotationQueues.tsx
+++ b/platform/app/src/hooks/useAnnotationQueues.tsx
@@ -17,34 +17,59 @@ const dateRangeInput = ({
   return range;
 };
 
+/**
+ * The read the list asks for: every default applied here rather than in the
+ * hook, so the hook stays about wiring the query to the page and this stays
+ * the one place that says what an unset option means.
+ */
+const queueReadInput = ({
+  projectId,
+  pageSize,
+  pageOffset,
+  options,
+}: {
+  projectId: string;
+  pageSize: number;
+  pageOffset: number;
+  options: UseAnnotationQueuesOptions;
+}) => ({
+  projectId,
+  selectedAnnotations: options.selectedAnnotations ?? "pending",
+  pageSize,
+  pageOffset,
+  queueId: options.queueId ?? "",
+  // Absent rather than empty: an empty pick means "every queue", and an empty
+  // list would narrow the read to nothing.
+  ...(options.queueIds && options.queueIds.length > 0
+    ? { queueIds: options.queueIds }
+    : {}),
+  showQueueAndUser: options.showQueueAndUser ?? false,
+  allQueueItems: options.allQueueItems ?? false,
+  ...dateRangeInput(options),
+});
+
+interface UseAnnotationQueuesOptions {
+  selectedAnnotations?: string;
+  queueId?: string;
+  /** The reviewer's pick of queues to read. Empty or absent reads them all. */
+  queueIds?: string[];
+  showQueueAndUser?: boolean;
+  allQueueItems?: boolean;
+  /** Narrows the read to items queued inside this range. */
+  startDate?: Date;
+  endDate?: Date;
+  /** Off where the caller already has its rows and only needs the shape. */
+  enabled?: boolean;
+}
+
 export function useAnnotationQueues(
-  {
-    selectedAnnotations,
-    queueId,
-    queueIds,
-    showQueueAndUser,
-    allQueueItems,
-    startDate,
-    endDate,
-    enabled = true,
-  }: {
-    selectedAnnotations?: string;
-    queueId?: string;
-    /** The reviewer's pick of queues to read. Empty or absent reads them all. */
-    queueIds?: string[];
-    showQueueAndUser?: boolean;
-    allQueueItems?: boolean;
-    /** Narrows the read to items queued inside this range. */
-    startDate?: Date;
-    endDate?: Date;
-    /** Off where the caller already has its rows and only needs the shape. */
-    enabled?: boolean;
-  } = {
+  options: UseAnnotationQueuesOptions = {
     selectedAnnotations: "pending",
     showQueueAndUser: false,
     allQueueItems: false,
   },
 ) {
+  const { enabled = true } = options;
   const { project } = useOrganizationTeamProject();
 
   const router = useRouter();
@@ -52,17 +77,12 @@ export function useAnnotationQueues(
   const pageSize = parseInt(router.query.pageSize as string) || 25;
 
   const optimizedData = api.annotation.getOptimizedAnnotationQueues.useQuery(
-    {
+    queueReadInput({
       projectId: project?.id ?? "",
-      selectedAnnotations: selectedAnnotations ?? "pending",
       pageSize,
       pageOffset,
-      queueId: queueId ?? "",
-      ...(queueIds && queueIds.length > 0 ? { queueIds } : {}),
-      showQueueAndUser: showQueueAndUser ?? false,
-      allQueueItems: allQueueItems ?? false,
-      ...dateRangeInput({ startDate, endDate }),
-    },
+      options,
+    }),
     {
       enabled: !!project && enabled,
       refetchOnWindowFocus: false,

--- a/platform/app/src/hooks/useAnnotationQueues.tsx
+++ b/platform/app/src/hooks/useAnnotationQueues.tsx
@@ -21,6 +21,7 @@ export function useAnnotationQueues(
   {
     selectedAnnotations,
     queueId,
+    queueIds,
     showQueueAndUser,
     allQueueItems,
     startDate,
@@ -29,6 +30,8 @@ export function useAnnotationQueues(
   }: {
     selectedAnnotations?: string;
     queueId?: string;
+    /** The reviewer's pick of queues to read. Empty or absent reads them all. */
+    queueIds?: string[];
     showQueueAndUser?: boolean;
     allQueueItems?: boolean;
     /** Narrows the read to items queued inside this range. */
@@ -55,6 +58,7 @@ export function useAnnotationQueues(
       pageSize,
       pageOffset,
       queueId: queueId ?? "",
+      ...(queueIds && queueIds.length > 0 ? { queueIds } : {}),
       showQueueAndUser: showQueueAndUser ?? false,
       allQueueItems: allQueueItems ?? false,
       ...dateRangeInput({ startDate, endDate }),

--- a/platform/app/src/server/api/routers/__tests__/annotation.4991-full-resolution.unit.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/annotation.4991-full-resolution.unit.test.ts
@@ -31,6 +31,7 @@ const { mockCreate, mockGetTracesWithSpans, mockBuildDeps, BLOB_DEPS } =
 const mockAnnotationFindMany = vi.fn().mockResolvedValue([]);
 const mockQueueItemFindMany = vi.fn();
 const mockQueueItemCount = vi.fn().mockResolvedValue(1);
+const mockQueueFindMany = vi.fn().mockResolvedValue([]);
 
 // The declared permission seam resolves its service from the App.
 vi.mock("~/server/app-layer/app", async () => {
@@ -90,7 +91,7 @@ function makePrismaStub(): PrismaClient {
       findMany: mockAnnotationFindMany,
     },
     annotationQueue: {
-      findMany: vi.fn().mockResolvedValue([]),
+      findMany: mockQueueFindMany,
     },
     project: {
       findUnique: vi.fn().mockResolvedValue({
@@ -219,6 +220,44 @@ describe("annotation router — #4991 AC3 annotation-queue reads", () => {
           ]),
         }),
       });
+    });
+  });
+
+  describe("when the caller asks which queues it can narrow to", () => {
+    /** @scenario "The queue filter only offers queues the reviewer can read" */
+    it("offers only the queues whose items this caller may already read", async () => {
+      await caller.getQueues({
+        projectId: "project_123",
+        reachableOnly: true,
+      });
+
+      // The same reach the item read applies, so every queue on offer has
+      // rows behind it: picking one can never empty the list on its own.
+      expect(mockQueueFindMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            projectId: "project_123",
+            OR: [
+              { members: { some: { userId: "test-user-id" } } },
+              { AnnotationQueueItems: { some: { userId: "test-user-id" } } },
+            ],
+          },
+        }),
+      );
+    });
+
+    /** @scenario "Choosing a queue for a trace still offers every queue" */
+    it("leaves every project queue on offer for callers that do not ask", async () => {
+      // The dialogs that add a trace to a queue, or invite people to one,
+      // target any queue in the project: narrowing those would hide choices
+      // the reviewer is entitled to make.
+      await caller.getQueues({ projectId: "project_123" });
+
+      expect(mockQueueFindMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { projectId: "project_123" },
+        }),
+      );
     });
   });
 });

--- a/platform/app/src/server/api/routers/__tests__/annotation.4991-full-resolution.unit.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/annotation.4991-full-resolution.unit.test.ts
@@ -231,8 +231,11 @@ describe("annotation router — #4991 AC3 annotation-queue reads", () => {
         reachableOnly: true,
       });
 
-      // The same reach the item read applies, so every queue on offer has
-      // rows behind it: picking one can never empty the list on its own.
+      // The same reach the item read applies, so nothing on offer is a queue
+      // the read would narrow straight back out. It is reach, not row count:
+      // a queue the reviewer belongs to that holds nothing pending is still
+      // offered, and picking it still shows an empty list. That empty is the
+      // status filter answering honestly, not the page failing.
       expect(mockQueueFindMany).toHaveBeenCalledWith(
         expect.objectContaining({
           where: {
@@ -246,11 +249,12 @@ describe("annotation router — #4991 AC3 annotation-queue reads", () => {
       );
     });
 
-    /** @scenario "Choosing a queue for a trace still offers every queue" */
+    /** @scenario "A caller that does not ask to be narrowed is not narrowed" */
     it("leaves every project queue on offer for callers that do not ask", async () => {
-      // The dialogs that add a trace to a queue, or invite people to one,
-      // target any queue in the project: narrowing those would hide choices
-      // the reviewer is entitled to make.
+      // Narrowing is opt-in because the other callers genuinely target any
+      // queue in the project — putting a trace into one, inviting people to
+      // one. This proves the default only; that those two callers leave the
+      // flag off is a fact about their own call sites, not about this read.
       await caller.getQueues({ projectId: "project_123" });
 
       expect(mockQueueFindMany).toHaveBeenCalledWith(

--- a/platform/app/src/server/api/routers/__tests__/annotation.4991-full-resolution.unit.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/annotation.4991-full-resolution.unit.test.ts
@@ -198,6 +198,27 @@ describe("annotation router — #4991 AC3 annotation-queue reads", () => {
         }),
       });
     });
+
+    it("narrows to the picked queues without widening the caller's reach", async () => {
+      await caller.getOptimizedAnnotationQueues({
+        projectId: "project_123",
+        selectedAnnotations: "pending",
+        pageSize: 10,
+        pageOffset: 0,
+        queueIds: ["queue_a", "queue_b"],
+      });
+
+      expect(mockQueueItemCount).toHaveBeenCalledWith({
+        where: expect.objectContaining({
+          // Still only this caller's items: the pick is an extra AND clause,
+          // so a queue id from anywhere else can subtract rows, never add one.
+          userId: "test-user-id",
+          AND: expect.arrayContaining([
+            { annotationQueueId: { in: ["queue_a", "queue_b"] } },
+          ]),
+        }),
+      });
+    });
   });
 });
 

--- a/platform/app/src/server/api/routers/__tests__/annotation.4991-full-resolution.unit.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/annotation.4991-full-resolution.unit.test.ts
@@ -199,6 +199,7 @@ describe("annotation router — #4991 AC3 annotation-queue reads", () => {
       });
     });
 
+    /** @scenario "A picked queue cannot widen what the reviewer may read" */
     it("narrows to the picked queues without widening the caller's reach", async () => {
       await caller.getOptimizedAnnotationQueues({
         projectId: "project_123",

--- a/platform/app/src/server/api/routers/annotation.ts
+++ b/platform/app/src/server/api/routers/annotation.ts
@@ -1006,6 +1006,12 @@ export const annotationRouter = createTRPCRouter({
         pageSize: z.number(),
         pageOffset: z.number(),
         queueId: z.string().optional(),
+        /**
+         * Narrows the read to these queues. Only ever narrows: it is applied
+         * on top of the reach the caller already has, so a queue id from
+         * anywhere else can subtract rows but never add one.
+         */
+        queueIds: z.array(z.string()).optional(),
         showQueueAndUser: z.boolean().optional(),
         allQueueItems: z.boolean().optional(),
         // The list's date range. A queue item is dated by when it was queued,
@@ -1085,6 +1091,14 @@ export const annotationRouter = createTRPCRouter({
       } else {
         // Default case - just user's items
         whereCondition.userId = userId;
+      }
+
+      // The reviewer's own pick of which queues to read, applied last so it can
+      // only cut into what the clauses above already allow.
+      if (input.queueIds && input.queueIds.length > 0) {
+        whereCondition.AND.push({
+          annotationQueueId: { in: input.queueIds },
+        });
       }
 
       // Get total count for pagination

--- a/platform/app/src/server/api/routers/annotation.ts
+++ b/platform/app/src/server/api/routers/annotation.ts
@@ -288,6 +288,78 @@ const queuedAtRangeFilter = ({
 };
 
 /**
+ * Which queue items the optimized list reads. The clauses stack rather than
+ * replace: the caller's reach is settled first, and the reviewer's own pick of
+ * queues is applied last, so a queue id from anywhere else can subtract rows
+ * but never add one.
+ */
+const optimizedQueueItemsWhere = ({
+  input,
+  userId,
+  organizationId,
+  userQueueIds,
+}: {
+  input: {
+    projectId: string;
+    selectedAnnotations: string;
+    queueId?: string;
+    queueIds?: string[];
+    startDate?: Date;
+    endDate?: Date;
+  };
+  userId: string;
+  organizationId: string;
+  /** The queues the caller belongs to, where those were looked up. */
+  userQueueIds: string[];
+}) => {
+  const whereCondition: any = {
+    ...queueItemReferenceFilter({
+      projectId: input.projectId,
+      organizationId,
+    }),
+    doneAt: doneAtFilter(input.selectedAnnotations),
+    ...queuedAtRangeFilter(input),
+  };
+
+  if (input.queueId) {
+    // Pin the requested queue to the caller's project so a queue id from
+    // another tenant cannot surface its items here.
+    whereCondition.AND.push({
+      annotationQueue: {
+        id: input.queueId,
+        projectId: input.projectId,
+      },
+    });
+  } else if (userQueueIds.length > 0) {
+    // No specific queue requested: include items from the queues the caller
+    // belongs to, plus items assigned directly to them.
+    whereCondition.AND.push({
+      OR: [{ annotationQueueId: { in: userQueueIds } }, { userId }],
+    });
+  } else {
+    // Default case - just user's items
+    whereCondition.userId = userId;
+  }
+
+  // The reviewer's own pick of which queues to read, applied last so it can
+  // only cut into what the clauses above already allow.
+  if (input.queueIds && input.queueIds.length > 0) {
+    whereCondition.AND.push({
+      annotationQueueId: { in: input.queueIds },
+    });
+  }
+
+  return whereCondition;
+};
+
+/** Pending items have no `doneAt`, completed ones have one, "all" reads both. */
+const doneAtFilter = (selectedAnnotations: string) => {
+  if (selectedAnnotations === "pending") return null;
+  if (selectedAnnotations === "completed") return { not: null };
+  return undefined;
+};
+
+/**
  * The queue items a reviewer is responsible for: assigned to them directly, or
  * sitting in a queue they belong to. Same reach as the pending and assigned
  * counts, so what the queue page walks and what it hands to a dataset agree.
@@ -1049,57 +1121,12 @@ export const annotationRouter = createTRPCRouter({
         projectId: input.projectId,
       });
 
-      // Build the where condition based on the scenario
-      const whereCondition: any = {
-        ...queueItemReferenceFilter({
-          projectId: input.projectId,
-          organizationId,
-        }),
-        doneAt:
-          input.selectedAnnotations === "pending"
-            ? null
-            : input.selectedAnnotations === "completed"
-              ? { not: null }
-              : undefined,
-        ...queuedAtRangeFilter(input),
-      };
-
-      if (input.queueId) {
-        // Pin the requested queue to the caller's project so a queue id from
-        // another tenant cannot surface its items here.
-        whereCondition.AND.push({
-          annotationQueue: {
-            id: input.queueId,
-            projectId: input.projectId,
-          },
-        });
-      } else if (userQueueIds.length > 0) {
-        // No specific queue requested: include items from the queues the caller
-        // belongs to, plus items assigned directly to them.
-        whereCondition.AND.push({
-          OR: [
-            {
-              annotationQueueId: {
-                in: userQueueIds,
-              },
-            },
-            {
-              userId: userId,
-            },
-          ],
-        });
-      } else {
-        // Default case - just user's items
-        whereCondition.userId = userId;
-      }
-
-      // The reviewer's own pick of which queues to read, applied last so it can
-      // only cut into what the clauses above already allow.
-      if (input.queueIds && input.queueIds.length > 0) {
-        whereCondition.AND.push({
-          annotationQueueId: { in: input.queueIds },
-        });
-      }
+      const whereCondition = optimizedQueueItemsWhere({
+        input,
+        userId,
+        organizationId,
+        userQueueIds,
+      });
 
       // Get total count for pagination
       const totalCount = await ctx.prisma.annotationQueueItem.count({

--- a/platform/app/src/server/api/routers/annotation.ts
+++ b/platform/app/src/server/api/routers/annotation.ts
@@ -778,11 +778,39 @@ export const annotationRouter = createTRPCRouter({
       }
     }),
   getQueues: protectedProcedure
-    .input(z.object({ projectId: z.string() }))
+    .input(
+      z.object({
+        projectId: z.string(),
+        /**
+         * Ask for only the queues whose items this caller can already read.
+         * A picker built from every queue in the project offers ones the
+         * optimized read narrows straight back out, so choosing them empties
+         * the list and looks broken. Callers that genuinely target any queue
+         * — adding a trace to one, inviting people to one — leave this off.
+         */
+        reachableOnly: z.boolean().optional(),
+      }),
+    )
     .permission("annotations:view")
     .query(async ({ ctx, input }) => {
       return ctx.prisma.annotationQueue.findMany({
-        where: { projectId: input.projectId },
+        where: {
+          projectId: input.projectId,
+          // The same reach the optimized queue-item read applies: the queues
+          // this caller belongs to, plus any holding an item assigned to them.
+          ...(input.reachableOnly
+            ? {
+                OR: [
+                  { members: { some: { userId: ctx.session.user.id } } },
+                  {
+                    AnnotationQueueItems: {
+                      some: { userId: ctx.session.user.id },
+                    },
+                  },
+                ],
+              }
+            : {}),
+        },
         select: {
           id: true,
           name: true,

--- a/platform/app/src/server/api/routers/annotation.ts
+++ b/platform/app/src/server/api/routers/annotation.ts
@@ -4,6 +4,7 @@ import { nanoid } from "nanoid";
 import { z } from "zod";
 import type {
   AnnotationQueueItem,
+  Prisma,
   PrismaClient,
 } from "~/generated/prisma/client";
 import { AnnotationService } from "~/server/annotations/annotation.service";
@@ -288,6 +289,15 @@ const queuedAtRangeFilter = ({
 };
 
 /**
+ * A queue-item `where` whose `AND` is always a list, so clauses can be stacked
+ * onto it. Prisma allows a single object there too, which would make every
+ * push a type error for a shape this code never builds.
+ */
+type QueueItemWhere = Prisma.AnnotationQueueItemWhereInput & {
+  AND: Prisma.AnnotationQueueItemWhereInput[];
+};
+
+/**
  * Which queue items the optimized list reads. The clauses stack rather than
  * replace: the caller's reach is settled first, and the reviewer's own pick of
  * queues is applied last, so a queue id from anywhere else can subtract rows
@@ -311,8 +321,8 @@ const optimizedQueueItemsWhere = ({
   organizationId: string;
   /** The queues the caller belongs to, where those were looked up. */
   userQueueIds: string[];
-}) => {
-  const whereCondition: any = {
+}): QueueItemWhere => {
+  const whereCondition: QueueItemWhere = {
     ...queueItemReferenceFilter({
       projectId: input.projectId,
       organizationId,
@@ -337,7 +347,9 @@ const optimizedQueueItemsWhere = ({
       OR: [{ annotationQueueId: { in: userQueueIds } }, { userId }],
     });
   } else {
-    // Default case - just user's items
+    // Nothing else has narrowed the read, so it is the caller's own items or
+    // nothing: without this the reference filter alone would return the
+    // project's whole queue.
     whereCondition.userId = userId;
   }
 

--- a/platform/app/src/utils/__tests__/downloadCsv.bytes.unit.test.ts
+++ b/platform/app/src/utils/__tests__/downloadCsv.bytes.unit.test.ts
@@ -1,0 +1,49 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The sibling suite mocks papaparse, so it can only show what downloadCsv
+ * hands the writer. That is one step short of the thing being promised: what
+ * matters is the text that lands in the file somebody opens.
+ *
+ * This file runs the real writer and reads the bytes back, so the guarantee is
+ * held by the artifact rather than by an argument.
+ */
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+import { downloadCsv } from "../downloadCsv";
+
+let lastBlob: Blob | undefined;
+
+beforeAll(() => {
+  window.URL.createObjectURL = vi.fn((blob: Blob) => {
+    lastBlob = blob;
+    return "blob:test";
+  });
+  window.URL.revokeObjectURL = vi.fn();
+});
+
+/** The text actually written to the file, read back out of the blob. */
+const writtenFile = async (args: {
+  fields: string[];
+  rows: (string | number)[][];
+}) => {
+  lastBlob = undefined;
+  downloadCsv({ ...args, fileName: "f.csv" });
+  return await lastBlob!.text();
+};
+
+describe("the file downloadCsv actually writes", () => {
+  describe("given a heading and a cell a spreadsheet would run", () => {
+    it("shows them as text and leaves a number a number", async () => {
+      const file = await writtenFile({
+        fields: ["Trace ID", "=cmd|' /c calc'!A1", "-5", "@handle"],
+        rows: [["ok", "=1+1", "-5", "plain"]],
+      });
+
+      expect(file.split("\r\n")).toEqual([
+        "Trace ID,'=cmd|' /c calc'!A1,-5,'@handle",
+        "ok,'=1+1,-5,plain",
+      ]);
+    });
+  });
+});

--- a/platform/app/src/utils/__tests__/downloadCsv.unit.test.ts
+++ b/platform/app/src/utils/__tests__/downloadCsv.unit.test.ts
@@ -31,6 +31,13 @@ const exportedRows = (rows: (string | number)[][]) => {
   return unparse.mock.calls[0]![0].data;
 };
 
+/** The header row papaparse was actually handed, after the sink had its say. */
+const exportedFields = (fields: string[]) => {
+  unparse.mockClear();
+  downloadCsv({ fields, rows: [["a"]], fileName: "f.csv" });
+  return unparse.mock.calls[0]![0].fields;
+};
+
 describe("downloadCsv", () => {
   describe("given a cell a spreadsheet would run as a formula", () => {
     describe("when the file is written", () => {
@@ -42,6 +49,19 @@ describe("downloadCsv", () => {
         expect(
           exportedRows([["=cmd"], ["+cmd"], ["@cmd"], ["\tcmd"], ["\rcmd"]]),
         ).toEqual([["'=cmd"], ["'+cmd"], ["'@cmd"], ["'\tcmd"], ["'\rcmd"]]);
+      });
+    });
+  });
+
+  describe("given a column heading a spreadsheet would run as a formula", () => {
+    describe("when the file is written", () => {
+      it("marks the heading as text so it is shown, not executed", () => {
+        // A heading is not always fixed text: a score type column is headed
+        // with the name its project gave it, so it is somebody's typing too.
+        expect(exportedFields(["Trace ID", "=cmd|' /c calc'!A1"])).toEqual([
+          "Trace ID",
+          "'=cmd|' /c calc'!A1",
+        ]);
       });
     });
   });

--- a/platform/app/src/utils/__tests__/downloadCsv.unit.test.ts
+++ b/platform/app/src/utils/__tests__/downloadCsv.unit.test.ts
@@ -1,0 +1,78 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Every value in an exported CSV was typed by somebody — a comment, a
+ * suggestion, the reason given for a score. A spreadsheet runs a cell opening
+ * with `=` as a formula, so the export is the last place that can stop one
+ * person's text becoming code on another person's machine.
+ *
+ * jsdom only for the download itself, which needs a document to hang the link
+ * on; nothing here renders a component.
+ */
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+const { unparse } = vi.hoisted(() => ({
+  unparse: vi.fn((_input: { fields: string[]; data: unknown[][] }) => "csv"),
+}));
+vi.mock("papaparse", () => ({ default: { unparse } }));
+
+import { csvFileName, downloadCsv } from "../downloadCsv";
+
+// jsdom implements neither, and the file only needs them not to throw.
+beforeAll(() => {
+  window.URL.createObjectURL = vi.fn(() => "blob:test");
+  window.URL.revokeObjectURL = vi.fn();
+});
+
+/** The rows papaparse was actually handed, after the sink had its say. */
+const exportedRows = (rows: (string | number)[][]) => {
+  unparse.mockClear();
+  downloadCsv({ fields: ["A"], rows, fileName: "f.csv" });
+  return unparse.mock.calls[0]![0].data;
+};
+
+describe("downloadCsv", () => {
+  describe("given a cell a spreadsheet would run as a formula", () => {
+    describe("when the file is written", () => {
+      it("marks the cell as text so it is shown, not executed", () => {
+        expect(exportedRows([["=1+1"]])[0]).toEqual(["'=1+1"]);
+      });
+
+      it("covers every leader a spreadsheet acts on", () => {
+        expect(
+          exportedRows([["=cmd"], ["+cmd"], ["@cmd"], ["\tcmd"], ["\rcmd"]]),
+        ).toEqual([["'=cmd"], ["'+cmd"], ["'@cmd"], ["'\tcmd"], ["'\rcmd"]]);
+      });
+    });
+  });
+
+  describe("given ordinary content", () => {
+    describe("when the file is written", () => {
+      it("leaves it exactly as it was written", () => {
+        expect(
+          exportedRows([["clear enough", "good (on point)", 4]])[0],
+        ).toEqual(["clear enough", "good (on point)", 4]);
+      });
+
+      it("leaves a negative number a number", () => {
+        // "-5" opens with a leader but is not a formula, and quoting it would
+        // turn a column of numbers into a column of text.
+        expect(exportedRows([["-5", "-1.5", ""]])[0]).toEqual([
+          "-5",
+          "-1.5",
+          "",
+        ]);
+      });
+    });
+  });
+});
+
+describe("csvFileName", () => {
+  describe("given a name and a day", () => {
+    it("dates the file so two exports do not collide", () => {
+      expect(csvFileName("Annotations", new Date("2026-08-08T10:00:00Z"))).toBe(
+        "Annotations - 2026-08-08.csv",
+      );
+    });
+  });
+});

--- a/platform/app/src/utils/downloadCsv.ts
+++ b/platform/app/src/utils/downloadCsv.ts
@@ -16,7 +16,7 @@ const FORMULA_LEADERS = ["=", "+", "-", "@", "\t", "\r"];
  * A value that is simply a number is left alone: "-5" is not a formula, and
  * quoting it would turn a number column into a text one.
  */
-const neutralizeFormula = (cell: string | number): string | number => {
+const neutralizeFormula = <T extends string | number>(cell: T): T | string => {
   if (typeof cell !== "string" || cell.length === 0) return cell;
   if (!FORMULA_LEADERS.includes(cell[0]!)) return cell;
   if (Number.isFinite(Number(cell))) return cell;
@@ -29,6 +29,10 @@ const neutralizeFormula = (cell: string | number): string | number => {
  * that exports a table produces the same file and the same failure surface —
  * and one place where a cell that would run as a formula is defused, rather
  * than every caller having to remember.
+ *
+ * The header row is defused with the rest. A column heading is not always
+ * fixed text: a score type carries the name its project gave it, so a heading
+ * can be just as much somebody's typing as the cells beneath it.
  */
 export function downloadCsv({
   fields,
@@ -40,7 +44,7 @@ export function downloadCsv({
   fileName: string;
 }): void {
   const csv = Parse.unparse({
-    fields,
+    fields: fields.map(neutralizeFormula),
     data: rows.map((row) => row.map(neutralizeFormula)),
   });
   const url = window.URL.createObjectURL(new Blob([csv], { type: "text/csv" }));

--- a/platform/app/src/utils/downloadCsv.ts
+++ b/platform/app/src/utils/downloadCsv.ts
@@ -1,9 +1,34 @@
 import Parse from "papaparse";
 
 /**
+ * A spreadsheet treats a cell opening with one of these as a formula to run,
+ * not text to show. Every value in these files is typed by somebody — a
+ * comment, a suggestion, the reason given for a score — so a cell opening with
+ * `=` is a formula the reader's spreadsheet would execute on their machine.
+ */
+const FORMULA_LEADERS = ["=", "+", "-", "@", "\t", "\r"];
+
+/**
+ * Neutralises a cell a spreadsheet would otherwise run. The leading quote is
+ * what Excel and Sheets both read as "this is text"; it is dropped again on
+ * display, so the reader still sees what was written.
+ *
+ * A value that is simply a number is left alone: "-5" is not a formula, and
+ * quoting it would turn a number column into a text one.
+ */
+const neutralizeFormula = (cell: string | number): string | number => {
+  if (typeof cell !== "string" || cell.length === 0) return cell;
+  if (!FORMULA_LEADERS.includes(cell[0]!)) return cell;
+  if (Number.isFinite(Number(cell))) return cell;
+  return `'${cell}`;
+};
+
+/**
  * Turns a header row plus its data rows into a CSV file and hands it to the
  * browser as a download. One place for the blob/anchor dance so every surface
- * that exports a table produces the same file and the same failure surface.
+ * that exports a table produces the same file and the same failure surface —
+ * and one place where a cell that would run as a formula is defused, rather
+ * than every caller having to remember.
  */
 export function downloadCsv({
   fields,
@@ -14,7 +39,10 @@ export function downloadCsv({
   rows: (string | number)[][];
   fileName: string;
 }): void {
-  const csv = Parse.unparse({ fields, data: rows });
+  const csv = Parse.unparse({
+    fields,
+    data: rows.map((row) => row.map(neutralizeFormula)),
+  });
   const url = window.URL.createObjectURL(new Blob([csv], { type: "text/csv" }));
 
   const link = document.createElement("a");

--- a/specs/annotations/annotations-list-selection.feature
+++ b/specs/annotations/annotations-list-selection.feature
@@ -342,6 +342,20 @@ Rule: The inbox can be narrowed to the queues being worked on
     When they pick a queue they do not belong to
     Then the read still asks only for their own items
 
+  # The read narrows to the reviewer's reach whatever the filter asks for, so a
+  # queue they cannot read is a pick that empties the list and reads as broken.
+  @unit
+  Scenario: The queue filter only offers queues the reviewer can read
+    Given the project holds a queue the reviewer is not in
+    When the filter asks which queues it may offer
+    Then it is told only the queues whose items the reviewer can read
+
+  @unit
+  Scenario: Choosing a queue for a trace still offers every queue
+    Given the reviewer is putting a trace into a queue
+    When that picker asks which queues it may offer
+    Then it is told every queue the project has
+
 Rule: The reviewer chooses which columns the list shows
 
   The list is read differently by different people, and one project's score

--- a/specs/annotations/annotations-list-selection.feature
+++ b/specs/annotations/annotations-list-selection.feature
@@ -327,6 +327,15 @@ Rule: The inbox can be narrowed to the queues being worked on
     When a single queue's page renders
     Then it carries no queue filter
 
+  # Narrowing the queues narrows the rows, so the page they were on may not
+  # exist any more: from page three, a queue with five items would show the
+  # empty state for a queue that plainly has work in it.
+  @integration
+  Scenario: Picking a queue takes the reviewer back to the first page
+    Given the reviewer is reading a later page of the inbox
+    When the reviewer picks one queue
+    Then the list goes back to the first page
+
   @unit
   Scenario: A picked queue cannot widen what the reviewer may read
     Given the reviewer may read only their own items
@@ -359,10 +368,21 @@ Rule: The reviewer chooses which columns the list shows
   # The button carries a tooltip as well as the menu. Both want to name the
   # button as their own, and if the tooltip wins the menu has nothing left to
   # measure against: it opens in the corner of the page, over the navigation.
+  #
+  # Where the menu lands is the behaviour that matters, and only a browser can
+  # see it — nothing about placement is observable without layout, so the
+  # scenario for it is parked rather than bound to a test that cannot look.
+  # What a test can hold is the cause: whether the button is still the menu's.
   @integration
-  Scenario: The columns menu opens against its own button
+  Scenario: The columns menu keeps the button as its own trigger
+    When the columns menu renders its button
+    Then the button belongs to the menu rather than to its tooltip
+
+  @e2e @unimplemented
+  Scenario: The columns menu opens under its button
     When the reviewer opens the columns menu
-    Then it is the menu's own button that it opens against
+    Then it appears against the button they pressed
+    And not in the corner of the page over the navigation
 
 Rule: The row's actions are always within reach
 

--- a/specs/annotations/annotations-list-selection.feature
+++ b/specs/annotations/annotations-list-selection.feature
@@ -275,17 +275,66 @@ Rule: The columns say what the reviewer needs to judge a row
     Given a row carries no comment
     Then its comments cell is empty
 
+  # A project that collects a dozen score types used to get a dozen columns,
+  # nearly all empty on any given row, which squeezed input and output into a
+  # strip and pushed the row's actions off the right edge.
   @integration
-  Scenario: One column per active score type
+  Scenario: Every score is folded into one Scores column
     Given the project has two active score types and one inactive one
-    Then the table carries a column for each active score type
+    Then the table carries one "Scores" column and no column per score type
+    And a score shows there as its type's name and the answer given
+    And every row has exactly one cell per column
+
+  @integration
+  Scenario: A score type can be given its own column
+    Given the project has two active score types
+    When the reviewer picks one of them in the columns menu
+    Then the table carries a column for that score type only
     And every row has exactly one cell per column
 
   @integration
   Scenario: Score types that are all inactive add no columns
     Given the project has score types and none of them is active
     Then the table carries no score column
+    And the columns menu offers none of them
     And every row has exactly as many cells as the header has columns
+
+Rule: The reviewer chooses which columns the list shows
+
+  The list is read differently by different people, and one project's score
+  types are another's noise. The choice is per project and kept in the browser:
+  it is how one person likes to read the list, not something the project agrees
+  on.
+
+  Background:
+    Given the user is authenticated with "annotations:view" permission
+    And the annotations list shows rows
+
+  @integration
+  Scenario: A column the reviewer hides stays hidden
+    When the reviewer turns a column off in the columns menu
+    Then the table stops carrying it
+    And it is still off when they come back to the list
+
+  @integration
+  Scenario: A column added after the reviewer chose still appears
+    Given the reviewer has hidden a column
+    When the project gains a column that shows by default
+    Then that new column shows
+
+Rule: The row's actions are always within reach
+
+  Background:
+    Given the user is authenticated with "annotations:update" permission
+    And the annotations list shows rows
+
+  # Unpinned, the overflow menu is the last column of a table that can be wider
+  # than the page, so "View trace" and "Remove from queue" sit off screen behind
+  # a sideways scroll nobody thinks to make.
+  @integration
+  Scenario: The row's actions stay reachable however wide the table is
+    When the annotations list renders
+    Then the actions column is pinned to the edge of the table's own scroll
 
   @integration
   Scenario: Input and output stay behind the redaction marker
@@ -302,6 +351,7 @@ Rule: Every page carries the same header controls
   Scenario: A queue page filters by status
     When a queue page renders
     Then the header offers Pending, Completed and All
+    And the control names the status it is filtering by
 
   @integration
   Scenario: The all annotations page has no status filter

--- a/specs/annotations/annotations-list-selection.feature
+++ b/specs/annotations/annotations-list-selection.feature
@@ -344,16 +344,21 @@ Rule: The inbox can be narrowed to the queues being worked on
 
   # The read narrows to the reviewer's reach whatever the filter asks for, so a
   # queue they cannot read is a pick that empties the list and reads as broken.
+  # Reach, not row count: a queue they are in that holds nothing pending is
+  # still offered, and picking it still shows an empty list. That empty is the
+  # status filter answering honestly.
   @unit
   Scenario: The queue filter only offers queues the reviewer can read
     Given the project holds a queue the reviewer is not in
     When the filter asks which queues it may offer
     Then it is told only the queues whose items the reviewer can read
 
+  # Narrowing is opt-in because the pickers that put a trace into a queue, or
+  # invite people to one, target any queue the project has.
   @unit
-  Scenario: Choosing a queue for a trace still offers every queue
-    Given the reviewer is putting a trace into a queue
-    When that picker asks which queues it may offer
+  Scenario: A caller that does not ask to be narrowed is not narrowed
+    Given a caller that has not asked for the reviewer's queues only
+    When it asks which queues it may offer
     Then it is told every queue the project has
 
 Rule: The reviewer chooses which columns the list shows

--- a/specs/annotations/annotations-list-selection.feature
+++ b/specs/annotations/annotations-list-selection.feature
@@ -356,6 +356,14 @@ Rule: The reviewer chooses which columns the list shows
     When the project gains a column that shows by default
     Then that new column shows
 
+  # The button carries a tooltip as well as the menu. Both want to name the
+  # button as their own, and if the tooltip wins the menu has nothing left to
+  # measure against: it opens in the corner of the page, over the navigation.
+  @integration
+  Scenario: The columns menu opens against its own button
+    When the reviewer opens the columns menu
+    Then it is the menu's own button that it opens against
+
 Rule: The row's actions are always within reach
 
   Background:

--- a/specs/annotations/annotations-list-selection.feature
+++ b/specs/annotations/annotations-list-selection.feature
@@ -299,6 +299,40 @@ Rule: The columns say what the reviewer needs to judge a row
     And the columns menu offers none of them
     And every row has exactly as many cells as the header has columns
 
+Rule: The inbox can be narrowed to the queues being worked on
+
+  The inbox pools every queue the reviewer belongs to, which is what makes its
+  pending count trustworthy and its list a mix nobody asked for. The pick only
+  ever narrows: it is applied on top of the reach the reviewer already has, so
+  a queue id from anywhere else can subtract rows but never add one.
+
+  Background:
+    Given the user is authenticated with "annotations:view" permission
+    And the reviewer belongs to two queues
+
+  @integration
+  Scenario: The inbox reads every queue until one is picked
+    When the inbox renders
+    Then the queue control reads "All"
+    And the read asks for no particular queue
+
+  @integration
+  Scenario: The inbox narrows to the queues the reviewer picks
+    When the reviewer picks one queue
+    Then the read asks for that queue only
+    And the queue control names it
+
+  @integration
+  Scenario: A page that is one queue offers no queue filter
+    When a single queue's page renders
+    Then it carries no queue filter
+
+  @unit
+  Scenario: A picked queue cannot widen what the reviewer may read
+    Given the reviewer may read only their own items
+    When they pick a queue they do not belong to
+    Then the read still asks only for their own items
+
 Rule: The reviewer chooses which columns the list shows
 
   The list is read differently by different people, and one project's score

--- a/specs/annotations/annotations-list-selection.feature
+++ b/specs/annotations/annotations-list-selection.feature
@@ -336,6 +336,15 @@ Rule: The inbox can be narrowed to the queues being worked on
     When the reviewer picks one queue
     Then the list goes back to the first page
 
+  # The filter lists the queues the reviewer can reach, and a non-member
+  # reaches one only through items assigned to them. Removing the last of those
+  # takes the queue out of their reach, so a cached list would keep offering a
+  # queue whose rows have all gone.
+  @integration
+  Scenario: The queue filter is refreshed when items leave a queue
+    When items are removed from a queue
+    Then the queue filter's list is read again
+
   @unit
   Scenario: A picked queue cannot widen what the reviewer may read
     Given the reviewer may read only their own items

--- a/specs/components/hoverable-big-text-overflow.feature
+++ b/specs/components/hoverable-big-text-overflow.feature
@@ -47,6 +47,21 @@ Feature: Expanded text dialog handles overflow for large content
     Then all content is accessible within the dialog
 
   # ============================================================================
+  # The measurement tracks the box, not only the render
+  # ============================================================================
+
+  # A window resize, a column drag or a sidebar opening reflows the box without
+  # rendering the component, so a measurement taken only after a render goes
+  # stale in both directions: hidden text with no way to reach it, or a tooltip
+  # offered on text that is no longer clipped.
+  @integration
+  Scenario: Text clipped by a resize becomes readable again
+    Given a HoverableBigText whose text fits its box
+    When the box narrows without anything re-rendering the component
+    Then the text is measured again
+    And the full text is offered on hover and on click
+
+  # ============================================================================
   # The overflow probe never outlives the component
   # ============================================================================
 


### PR DESCRIPTION
A reviewer opening the annotations inbox on a project that collects a dozen
score types saw a table that was mostly empty columns: input and output — the
two things they are being asked to judge — squeezed into a narrow strip clamped
to two ellipsised lines, and the row's actions off the right edge behind a
sideways scroll nobody thinks to make.

This makes that list readable, and picks up the two follow-ups filed off #7760
while the same components are open.

## The list

**Scores fold into one column.** One column per active score type became a dozen
near-empty columns on any given row. There is now a single "Scores" column that
names each type and the answer given; every type is still available as its own
column from the columns menu, for anyone who wants the matrix.

**A columns menu**, the way the trace explorer has one: search over the whole
set, grouped by section, with a count of what is showing and a reset. Choices
are kept per project in the browser — this is how one person likes to read the
list, not something the project agrees on. They are read per column rather than
stored as a visible set, so a column added later still arrives as its author
intended instead of silently hidden.

**Input and output get room**: real width, three lines, the full value on hover
and the whole thing one click away.

**The actions column is pinned** to the edge of the table's own scroll, so
"View trace", "Add to dataset" and "Remove from queue" are always where the eye
is however wide the table gets.

**The status control names the status it is filtering by** rather than reading
"Status" whatever it is hiding.

**The inbox can be narrowed to the queues being worked on.** The inbox pools
every queue the reviewer belongs to, which is what makes its pending count
trustworthy and its list a mix nobody asked for. The pick is applied as an extra
`AND` clause on top of the reach the caller already has, so a queue id from
anywhere else can subtract rows but never add one — there is a unit test on
exactly that. Only the inbox carries the filter: a single queue's page is
already one queue, and the all annotations page has no queue items.

## Follow-ups from #7760

Closes #7771 — `HoverableBigText` decided whether to offer its tooltip in an
effect with no dependency array, so it re-measured on every render but never on
a resize, which renders nothing. The last render's answer stood: text that had
started clamping offered no tooltip and its hidden half was unreachable. Now
measured with a `ResizeObserver`, following the pattern already used across
traces-v2. The regression test fails without the fix.

Closes #7773 — the three convention deviations CodeRabbit raised on #7760:
`clampValues` / `clamp` renamed to `shouldClampValues` / `shouldClamp`, the test
helper takes a single object, and the test file uses nested `given` / `when`
blocks.

## Deliberately not here

- **Column order** is the table's own and is not settable in the menu. The
  complaint was a wall of empty columns, not the order they sat in; the trace
  explorer's reorder strip is coupled to its lens store and would have to be
  lifted out to be shared.
- **Free-text search over input and output.** The queue read has no query
  support, and filtering only the page on screen would quietly lie about what
  matched.

Review raised three more that are real and deliberately not fixed here, each
tracked so it is not lost in a resolved thread:

- **#7779** — the annotation queue reads build their own query in the route
  while the writes go through `AnnotationService`. The file is mid-migration
  rather than unlayered: nine service calls, 25 direct Prisma calls left on the
  read side. Moving them is a backend change on a hot read path and does not
  belong in a branch about a table.
- **#7782** — the same rule across 33 router files.
- **#7783** — the six CSV writers that bypass the shared helper, and the two
  formula guards that should be one.

One known P2 with no issue: `getQueues` restates the read's reach in a
different shape from `optimizedQueueItemsWhere`, and nothing holds the two
together — both tests would stay green through a divergence. Left as
duplication on purpose; a forced shared helper would be a worse seam. It is a
UX risk, not an authorization one: the reach is enforced by the item read
regardless of what the picker offers.

## Found while reviewing this

> **A security fix rides in this UI branch.** One of the six below is a CSV
> formula-injection fix in a shared export helper. It predates this work and is
> not about annotations, so it is easy to skim past in a branch named for a
> review inbox. It is called out here so it gets read rather than scrolled.

Review and browser testing turned up six things that were wrong, not stylistic.
They are listed because each one shipped a wrong answer to somebody:

- **The CSV kept its own column list.** Folding the score types into one column
  changed the table and left the export behind: the file still wrote one column
  per score type — the wall of near-empty columns this branch exists to remove —
  the folded "Scores" column never appeared in it at all, and a column the
  reviewer hid was exported anyway. The export now walks the same visible column
  set the table lays out. The scenario had said "the columns are the ones the
  table shows" the whole time; the test asserted the hardcoded list instead, so
  it read green while encoding the wrong behaviour.
- **A spreadsheet would run an exported cell as a formula.** Every value in these
  files is typed by somebody — a comment, a suggestion, the reason given for a
  score — and a cell opening with `=` executes on whoever opens the file. Fixed
  in `downloadCsv`, which has exactly **two** call sites — `AnnotationsTable`
  and `annotations/all` — and those two are covered for their data rows. Not
  the product, and not four: `batch-evaluation-results/csvExport.ts` exports a
  same-named `downloadCsv` that does its own papaparse call and never touches
  this helper, so it counts among the unguarded writers rather than the covered
  ones. Six writers call papaparse directly and are still unguarded, and
  `server/export/scenario-runs/csv-serializer.ts:333` already had its own guard
  written independently, so this is the second implementation rather than the
  first. Both are tracked in #7783. The commit message for this change says
  "every export in the product", which is wrong. This one predates the branch.

  The first version of this fix was incomplete and I resolved the thread on it
  too early: it defused the data rows but handed `fields` to papaparse
  untouched, leaving the header row live. That was reachable — a score type is
  named in project settings, `annotationColumns.ts:100` makes that name a
  column label, and the labels are spread into `fields` — so a score type named
  `=…` exported as an executable header cell. Closed in `3cee2976f8`; the
  header now goes through the same guard, and the doc comment no longer claims
  more reach than the code has. papaparse's own `escapeFormulae` would have
  covered it, but its default regex escapes `-5` too and would turn negative
  numbers into text cells, so the helper stays hand-rolled with its finite-number
  exemption. Verified against the bytes actually written, not just what was
  handed to papaparse.
- **The queue picker offered queues that return nothing.** It listed every queue
  in the project while the read narrows to the reviewer's own reach, so picking
  one they are not in emptied the list and read as a broken page. `getQueues`
  now takes an opt-in `reachableOnly`; the dialogs that genuinely target any
  queue still see them all.
- **Picking a queue kept the page offset**, so choosing a five-item queue from
  page three showed the empty state for a queue that plainly has work in it.
- **The columns menu opened in the corner of the page.** The tooltip and the
  popover both cloned their id onto the same button, and the menu lost the
  anchor it measures against. Only a browser could see where it landed; whose
  button it is can be asserted, and that is the half that went wrong.
- **The queue picker's list went stale.** It lists queues the reviewer can
  reach, and a non-member reaches one only through items assigned to them — so
  removing the last of those takes the queue out of reach while the cache kept
  offering it.

## Checks

`platform/app`: `pnpm typecheck:all` clean, and the lint gate reports no new
Biome violations against the merge base. The annotations, automations,
`HoverableBigText` and annotations-page suites pass, along with the annotation
router unit tests and the new `downloadCsv` unit tests.

Every scenario this PR adds is bound and enforced — `check-feature-parity`
passes. That is worth saying because it did not at first: the queue-narrowing
scenario had its test but no `@scenario` annotation, so it read as unbound, and
the column-defaults scenario had no test at all.

Two of the tests here exist because the old ones could not have failed. The
column-defaults test asserts the hidden column stays hidden as well, so it
cannot pass without the stored choice actually being read. And the mutation mock
in the columns test was swallowing `onSuccess` entirely, so no test in that file
could observe a refresh, an invalidation or a toast after a removal; it now
hands it back, which is what made the stale-list regression testable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added annotation inbox filters for selecting specific queues.
  - Added searchable column controls with customizable visibility, consolidated score options, and reset-to-default support.
  - Added persistent per-project column preferences.
  - Kept table actions pinned while scrolling.
  - Status filters now display the selected status.
  - Improved annotation input, output, and CSV export based on visible columns.

- **Bug Fixes**
  - Text expansion remains accurate after window, column, or sidebar resizing.
  - Queue filtering now respects selected queues without widening results.
  - Pagination resets appropriately when queue filters change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->




