### PR TITLE
fix(gateway): self-map Azure deployments on the dispatch path

### DIFF
--- a/platform/app/scripts/check-feature-parity.ts
+++ b/platform/app/scripts/check-feature-parity.ts
@@ -267,7 +267,6 @@ const LEGACY_UNBOUND: string[] = [
 const LEGACY_INERT: string[] = [
   "specs/agents/create-workflow-agent.feature",
   "specs/agents/workflow-agent-editor.feature",
-  "specs/ai-gateway/azure-endpoint-from-api-base.feature",
   "specs/ai-gateway/budgets-principal-cascade.feature",
   "specs/ai-gateway/cache-control-rules.feature",
   "specs/ai-gateway/caching-passthrough.feature",

--- a/services/aigateway/adapters/providers/azure_deployment_selfmap_test.go
+++ b/services/aigateway/adapters/providers/azure_deployment_selfmap_test.go
@@ -33,12 +33,11 @@ import (
 // in for the customer's Azure resource, so what they observe is the URL
 // Bifrost actually builds, not a restatement of the mapping helper.
 
-// azureUpstream records the path of every request it receives and answers
-// with an OpenAI-shaped chat completion (Azure's wire format).
+// azureUpstream answers with an OpenAI-shaped chat completion (Azure's wire
+// format) and keeps the path of every request it received, in arrival order.
 type azureUpstream struct {
-	srv *httptest.Server
-	mu  sync.Mutex
-	// paths holds each received request path, in arrival order.
+	srv   *httptest.Server
+	mu    sync.Mutex
 	paths []string
 }
 
@@ -102,9 +101,9 @@ func azureCredNoDeploymentMap(endpoint string) domain.Credential {
 	}
 }
 
-func azureChatRequest(stream bool) *domain.Request {
+func azureChatRequest(isStream bool) *domain.Request {
 	body := `{"model":"gpt-5-mini","messages":[{"role":"user","content":"hi"}]}`
-	if stream {
+	if isStream {
 		body = `{"model":"gpt-5-mini","messages":[{"role":"user","content":"hi"}],"stream":true}`
 	}
 	return &domain.Request{

--- a/services/aigateway/adapters/providers/azure_deployment_selfmap_test.go
+++ b/services/aigateway/adapters/providers/azure_deployment_selfmap_test.go
@@ -152,6 +152,9 @@ func TestDispatchStream_Azure_NoDeploymentMap_SelfMapsToModelID(t *testing.T) {
 			"on Azure providers the non-streaming lane serves fine")
 	for iter.Next(context.Background()) {
 	}
+	require.NoError(t, iter.Err(),
+		"the stream must drain cleanly; a mid-stream failure would leave the URL "+
+			"assertion below passing on a request that never produced a usable answer")
 
 	paths := upstream.received()
 	require.NotEmpty(t, paths, "the stream must actually reach the customer's Azure resource")

--- a/services/aigateway/adapters/providers/azure_deployment_selfmap_test.go
+++ b/services/aigateway/adapters/providers/azure_deployment_selfmap_test.go
@@ -1,0 +1,180 @@
+package providers
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/langwatch/langwatch/services/aigateway/domain"
+)
+
+// Azure addresses a model by deployment name, so Bifrost's Azure provider
+// refuses to build a URL for a key whose AzureKeyConfig.Deployments is empty
+// ("deployments not set") — the request never leaves the gateway, and the
+// caller sees an opaque provider error instead of a completion.
+//
+// The control plane only emits `deployment_map` when the provider row carries
+// an explicit deployment mapping (config.materialiser.ts), which most Azure
+// rows do not: by default the model id IS the deployment name. Every other
+// dispatch path already closes that gap with domain.WithDeploymentSelfMap
+// (nlpgo's dispatcheradapter and gatewayproxy, #5760); the gateway did not,
+// so the same Azure provider that worked in the playground failed through the
+// gateway.
+//
+// These tests drive the real dispatch path against a local upstream standing
+// in for the customer's Azure resource, so what they observe is the URL
+// Bifrost actually builds, not a restatement of the mapping helper.
+
+// azureUpstream records the path of every request it receives and answers
+// with an OpenAI-shaped chat completion (Azure's wire format).
+type azureUpstream struct {
+	srv *httptest.Server
+	mu  sync.Mutex
+	// paths holds each received request path, in arrival order.
+	paths []string
+}
+
+func (u *azureUpstream) received() []string {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	return append([]string(nil), u.paths...)
+}
+
+func newAzureUpstream(t *testing.T) *azureUpstream {
+	t.Helper()
+	u := &azureUpstream{}
+	u.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		u.mu.Lock()
+		u.paths = append(u.paths, r.URL.Path)
+		u.mu.Unlock()
+		body, _ := io.ReadAll(r.Body)
+		if bytes.Contains(body, []byte(`"stream":true`)) {
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`data: {"id":"chatcmpl-azure1","object":"chat.completion.chunk",` +
+				`"created":1730000000,"model":"gpt-5-mini","choices":[{"index":0,` +
+				`"delta":{"role":"assistant","content":"ok"},"finish_reason":null}]}` + "\n\n" +
+				"data: [DONE]\n\n"))
+			if f, ok := w.(http.Flusher); ok {
+				f.Flush()
+			}
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"chatcmpl-azure1","object":"chat.completion",` +
+			`"created":1730000000,"model":"gpt-5-mini","choices":[{"index":0,` +
+			`"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],` +
+			`"usage":{"prompt_tokens":9,"completion_tokens":1,"total_tokens":10}}`))
+	}))
+	t.Cleanup(u.srv.Close)
+	return u
+}
+
+func azureRouter(t *testing.T) *BifrostRouter {
+	t.Helper()
+	router, err := NewBifrostRouter(context.Background(), BifrostOptions{Logger: zap.NewNop()})
+	require.NoError(t, err)
+	t.Cleanup(router.Close)
+	return router
+}
+
+// azureCredNoDeploymentMap is the shape the control plane sends for an Azure
+// provider row with no explicit deployment mapping: api key, endpoint, api
+// version, and nothing that says which deployment serves the model.
+func azureCredNoDeploymentMap(endpoint string) domain.Credential {
+	return domain.Credential{
+		ID:         "mp-azure",
+		ProviderID: domain.ProviderAzure,
+		APIKey:     "az-test",
+		Extra: map[string]string{
+			"endpoint":    endpoint,
+			"api_version": "2025-04-01-preview",
+		},
+	}
+}
+
+func azureChatRequest(stream bool) *domain.Request {
+	body := `{"model":"gpt-5-mini","messages":[{"role":"user","content":"hi"}]}`
+	if stream {
+		body = `{"model":"gpt-5-mini","messages":[{"role":"user","content":"hi"}],"stream":true}`
+	}
+	return &domain.Request{
+		Type:     domain.RequestTypeChat,
+		Model:    "azure/gpt-5-mini",
+		Resolved: &domain.ResolvedModel{ModelID: "gpt-5-mini", ProviderID: domain.ProviderAzure},
+		Body:     []byte(body),
+	}
+}
+
+// Spec: specs/ai-gateway/azure-endpoint-from-api-base.feature
+//
+// @scenario "Gateway chat completion for an Azure model reaches the deployment named by the model id"
+func TestDispatch_Azure_NoDeploymentMap_SelfMapsToModelID(t *testing.T) {
+	upstream := newAzureUpstream(t)
+	router := azureRouter(t)
+
+	resp, err := router.Dispatch(context.Background(), azureChatRequest(false),
+		azureCredNoDeploymentMap(upstream.srv.URL))
+	require.NoError(t, err,
+		"an Azure credential without an explicit deployment mapping must still dispatch; "+
+			"without the self-map Bifrost refuses with \"deployments not set\" and nothing leaves the gateway")
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	paths := upstream.received()
+	require.Len(t, paths, 1, "the request must actually reach the customer's Azure resource")
+	assert.Contains(t, paths[0], "/openai/deployments/gpt-5-mini/",
+		"the deployment defaults to the model id, so the URL must address deployment gpt-5-mini")
+}
+
+// The streaming lane resolves its credential separately from Dispatch, so it
+// needs its own self-map or /v1/chat/completions with stream:true keeps
+// failing on Azure while the non-streaming call succeeds.
+//
+// @scenario "Gateway streaming chat completion for an Azure model reaches the deployment named by the model id"
+func TestDispatchStream_Azure_NoDeploymentMap_SelfMapsToModelID(t *testing.T) {
+	upstream := newAzureUpstream(t)
+	router := azureRouter(t)
+
+	iter, err := router.DispatchStream(context.Background(), azureChatRequest(true),
+		azureCredNoDeploymentMap(upstream.srv.URL))
+	require.NoError(t, err,
+		"the streaming lane must self-map the deployment too, or stream:true fails "+
+			"on Azure providers the non-streaming lane serves fine")
+	for iter.Next(context.Background()) {
+	}
+
+	paths := upstream.received()
+	require.NotEmpty(t, paths, "the stream must actually reach the customer's Azure resource")
+	assert.Contains(t, paths[0], "/openai/deployments/gpt-5-mini/",
+		"the deployment defaults to the model id, so the URL must address deployment gpt-5-mini")
+}
+
+// An explicit mapping is the provider saying the model id is NOT the
+// deployment name. The self-map must never overwrite it.
+//
+// @scenario "An explicit deployment mapping still decides the deployment on the gateway lane"
+func TestDispatch_Azure_ExplicitDeploymentMap_Wins(t *testing.T) {
+	upstream := newAzureUpstream(t)
+	router := azureRouter(t)
+
+	cred := azureCredNoDeploymentMap(upstream.srv.URL)
+	cred.DeploymentMap = map[string]string{"gpt-5-mini": "prod-mini-eastus"}
+
+	_, err := router.Dispatch(context.Background(), azureChatRequest(false), cred)
+	require.NoError(t, err)
+
+	paths := upstream.received()
+	require.Len(t, paths, 1)
+	assert.Contains(t, paths[0], "/openai/deployments/prod-mini-eastus/",
+		"the provider's own mapping decides the deployment; the self-map only fills a gap")
+}

--- a/services/aigateway/adapters/providers/azure_deployment_selfmap_test.go
+++ b/services/aigateway/adapters/providers/azure_deployment_selfmap_test.go
@@ -191,6 +191,71 @@ func TestDispatch_Azure_ExplicitDeploymentMap_Wins(t *testing.T) {
 		"the provider's own mapping decides the deployment; the default only fills a gap")
 }
 
+// app.dispatch walks the credential chain with retry.Walk and hands the SAME
+// *domain.Request to Dispatch on every attempt, so resolving the deployment
+// must not write back into it. If it did, the first credential's deployment
+// would still be in the body on the second attempt: the guard early-returns
+// when deployment == model, so nothing rewrites it back, and the next Azure
+// resource is asked for a deployment it does not have.
+//
+// @scenario "A deployment resolved for one credential does not leak into the next attempt"
+func TestDispatch_Azure_DeploymentDoesNotLeakAcrossCredentials(t *testing.T) {
+	upstream := newAzureUpstream(t)
+	router := azureRouter(t)
+
+	req := azureChatRequest(false)
+	sent := append([]byte(nil), req.Body...)
+
+	mapped := azureCredNoDeploymentMap(upstream.srv.URL)
+	mapped.DeploymentMap = map[string]string{"gpt-5-mini": "prod-mini-eastus"}
+	_, err := router.Dispatch(context.Background(), req, mapped)
+	require.NoError(t, err)
+
+	// Second attempt, as a failover would run it: same request pointer, a
+	// credential whose resource serves the model under its own name.
+	_, err = router.Dispatch(context.Background(), req, azureCredNoDeploymentMap(upstream.srv.URL))
+	require.NoError(t, err)
+
+	assert.Equal(t, "prod-mini-eastus", upstream.deploymentAddressed(t, 0))
+	assert.Equal(t, "gpt-5-mini", upstream.deploymentAddressed(t, 1),
+		"the second credential names no deployment, so its resource must be asked "+
+			"for gpt-5-mini and not the first credential's prod-mini-eastus")
+	assert.Equal(t, string(sent), string(req.Body),
+		"the caller's request is shared across retry attempts, so resolving the "+
+			"deployment must leave it untouched")
+}
+
+// The other side of the same leak, and the worse one: the non-Azure guard
+// returns before the deployment comparison, so an in-place rewrite would hand
+// a plain OpenAI provider an Azure deployment name as its model.
+func TestDispatch_Azure_DeploymentDoesNotLeakIntoANonAzureFallback(t *testing.T) {
+	upstream := newAzureUpstream(t)
+	router := azureRouter(t)
+
+	req := azureChatRequest(false)
+
+	mapped := azureCredNoDeploymentMap(upstream.srv.URL)
+	mapped.DeploymentMap = map[string]string{"gpt-5-mini": "prod-mini-eastus"}
+	_, err := router.Dispatch(context.Background(), req, mapped)
+	require.NoError(t, err)
+
+	// Failover off Azure entirely, onto a provider that has never heard of
+	// deployments and serves the model under its own name.
+	fallback := domain.Credential{
+		ID:         "mp-openai",
+		ProviderID: domain.ProviderOpenAI,
+		APIKey:     "sk-test",
+		Extra:      map[string]string{"base_url": upstream.srv.URL},
+	}
+	_, err = router.Dispatch(context.Background(), req, fallback)
+	require.NoError(t, err)
+
+	assert.Equal(t, "prod-mini-eastus", upstream.deploymentAddressed(t, 0))
+	assert.Equal(t, "gpt-5-mini", upstream.deploymentAddressed(t, 1),
+		"a non-Azure credential must be sent the model id, never the Azure "+
+			"deployment name left over from the previous attempt")
+}
+
 // The two lanes read the deployment from the same place, so this covers the
 // streaming seam and the other credential shape at once: a deployment named
 // alongside the credential rather than in a mapping, which is what

--- a/services/aigateway/adapters/providers/azure_deployment_selfmap_test.go
+++ b/services/aigateway/adapters/providers/azure_deployment_selfmap_test.go
@@ -11,50 +11,61 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
 	"go.uber.org/zap"
 
 	"github.com/langwatch/langwatch/services/aigateway/domain"
 )
 
-// Azure addresses a model by deployment name, so Bifrost's Azure provider
-// refuses to build a URL for a key whose AzureKeyConfig.Deployments is empty
-// ("deployments not set") — the request never leaves the gateway, and the
-// caller sees an opaque provider error instead of a completion.
+// Azure addresses a model by deployment name, and its v1 API carries that name
+// in the request body's `model` field. Azure is raw-forwarded
+// (isOpenAICompatibleProvider), so the client's own bytes are what reach the
+// wire: whatever the gateway resolves has to land in that field, or it never
+// leaves the box.
 //
 // The control plane only emits `deployment_map` when the provider row carries
 // an explicit deployment mapping (config.materialiser.ts), which most Azure
 // rows do not: by default the model id IS the deployment name. Every other
 // dispatch path already closes that gap with domain.WithDeploymentSelfMap
-// (nlpgo's dispatcheradapter and gatewayproxy, #5760); the gateway did not,
-// so the same Azure provider that worked in the playground failed through the
-// gateway.
+// (nlpgo's dispatcheradapter and gatewayproxy, #5760); the gateway did not, so
+// the same Azure provider that worked in the playground missed its deployment
+// through the gateway.
 //
 // These tests drive the real dispatch path against a local upstream standing
-// in for the customer's Azure resource, so what they observe is the URL
-// Bifrost actually builds, not a restatement of the mapping helper.
+// in for the customer's Azure resource, so what they observe is the request
+// Bifrost actually sends, not a restatement of the mapping helper.
 
 // azureUpstream answers with an OpenAI-shaped chat completion (Azure's wire
-// format) and keeps the path of every request it received, in arrival order.
+// format) and keeps every request it received, in arrival order.
 type azureUpstream struct {
-	srv   *httptest.Server
-	mu    sync.Mutex
-	paths []string
+	srv    *httptest.Server
+	mu     sync.Mutex
+	bodies [][]byte
 }
 
-func (u *azureUpstream) received() []string {
+func (u *azureUpstream) received() [][]byte {
 	u.mu.Lock()
 	defer u.mu.Unlock()
-	return append([]string(nil), u.paths...)
+	return append([][]byte(nil), u.bodies...)
+}
+
+// deploymentAddressed reports the deployment the nth upstream request names.
+func (u *azureUpstream) deploymentAddressed(t *testing.T, n int) string {
+	t.Helper()
+	bodies := u.received()
+	require.Greater(t, len(bodies), n,
+		"the request must actually reach the customer's Azure resource")
+	return gjson.GetBytes(bodies[n], "model").String()
 }
 
 func newAzureUpstream(t *testing.T) *azureUpstream {
 	t.Helper()
 	u := &azureUpstream{}
 	u.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		u.mu.Lock()
-		u.paths = append(u.paths, r.URL.Path)
-		u.mu.Unlock()
 		body, _ := io.ReadAll(r.Body)
+		u.mu.Lock()
+		u.bodies = append(u.bodies, body)
+		u.mu.Unlock()
 		if bytes.Contains(body, []byte(`"stream":true`)) {
 			w.Header().Set("Content-Type", "text/event-stream")
 			w.WriteHeader(http.StatusOK)
@@ -121,23 +132,27 @@ func TestDispatch_Azure_NoDeploymentMap_SelfMapsToModelID(t *testing.T) {
 	upstream := newAzureUpstream(t)
 	router := azureRouter(t)
 
-	resp, err := router.Dispatch(context.Background(), azureChatRequest(false),
+	req := azureChatRequest(false)
+	sent := append([]byte(nil), req.Body...)
+
+	resp, err := router.Dispatch(context.Background(), req,
 		azureCredNoDeploymentMap(upstream.srv.URL))
 	require.NoError(t, err,
-		"an Azure credential without an explicit deployment mapping must still dispatch; "+
-			"without the self-map Bifrost refuses with \"deployments not set\" and nothing leaves the gateway")
+		"an Azure credential without an explicit deployment mapping must still dispatch")
 	require.NotNil(t, resp)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-	paths := upstream.received()
-	require.Len(t, paths, 1, "the request must actually reach the customer's Azure resource")
-	assert.Contains(t, paths[0], "/openai/deployments/gpt-5-mini/",
-		"the deployment defaults to the model id, so the URL must address deployment gpt-5-mini")
+	assert.Equal(t, "gpt-5-mini", upstream.deploymentAddressed(t, 0),
+		"the deployment defaults to the model id, so the request must address deployment gpt-5-mini")
+	// Azure is raw-forwarded to keep OpenAI's prompt-prefix auto-cache hitting.
+	// With nothing to remap, the customer's bytes must go out untouched.
+	assert.Equal(t, string(sent), string(upstream.received()[0]),
+		"with no deployment to remap the body must be forwarded byte-for-byte")
 }
 
 // The streaming lane resolves its credential separately from Dispatch, so it
-// needs its own self-map or /v1/chat/completions with stream:true keeps
-// failing on Azure while the non-streaming call succeeds.
+// needs its own resolution or stream:true keeps missing the deployment on
+// Azure while the non-streaming call gets it right.
 //
 // @scenario "Gateway streaming chat completion for an Azure model reaches the deployment named by the model id"
 func TestDispatchStream_Azure_NoDeploymentMap_SelfMapsToModelID(t *testing.T) {
@@ -147,22 +162,20 @@ func TestDispatchStream_Azure_NoDeploymentMap_SelfMapsToModelID(t *testing.T) {
 	iter, err := router.DispatchStream(context.Background(), azureChatRequest(true),
 		azureCredNoDeploymentMap(upstream.srv.URL))
 	require.NoError(t, err,
-		"the streaming lane must self-map the deployment too, or stream:true fails "+
+		"the streaming lane must resolve the deployment too, or stream:true fails "+
 			"on Azure providers the non-streaming lane serves fine")
 	for iter.Next(context.Background()) {
 	}
 	require.NoError(t, iter.Err(),
-		"the stream must drain cleanly; a mid-stream failure would leave the URL "+
-			"assertion below passing on a request that never produced a usable answer")
+		"the stream must drain cleanly; a mid-stream failure would leave the assertion "+
+			"below passing on a request that never produced a usable answer")
 
-	paths := upstream.received()
-	require.NotEmpty(t, paths, "the stream must actually reach the customer's Azure resource")
-	assert.Contains(t, paths[0], "/openai/deployments/gpt-5-mini/",
-		"the deployment defaults to the model id, so the URL must address deployment gpt-5-mini")
+	assert.Equal(t, "gpt-5-mini", upstream.deploymentAddressed(t, 0),
+		"the deployment defaults to the model id, so the request must address deployment gpt-5-mini")
 }
 
 // An explicit mapping is the provider saying the model id is NOT the
-// deployment name. The self-map must never overwrite it.
+// deployment name. Dropping it sends Azure a deployment it does not have.
 //
 // @scenario "An explicit deployment mapping still decides the deployment on the gateway lane"
 func TestDispatch_Azure_ExplicitDeploymentMap_Wins(t *testing.T) {
@@ -175,8 +188,29 @@ func TestDispatch_Azure_ExplicitDeploymentMap_Wins(t *testing.T) {
 	_, err := router.Dispatch(context.Background(), azureChatRequest(false), cred)
 	require.NoError(t, err)
 
-	paths := upstream.received()
-	require.Len(t, paths, 1)
-	assert.Contains(t, paths[0], "/openai/deployments/prod-mini-eastus/",
-		"the provider's own mapping decides the deployment; the self-map only fills a gap")
+	assert.Equal(t, "prod-mini-eastus", upstream.deploymentAddressed(t, 0),
+		"the provider's own mapping decides the deployment; the default only fills a gap")
+}
+
+// The two lanes read the deployment from the same place, so this covers the
+// streaming seam and the other credential shape at once: a deployment named
+// alongside the credential rather than in a mapping, which is what
+// WithDeploymentSelfMap folds into DeploymentMap for both lanes to read.
+//
+// @scenario "The streaming lane honors an explicit deployment name too"
+func TestDispatchStream_Azure_ExplicitDeployment_Wins(t *testing.T) {
+	upstream := newAzureUpstream(t)
+	router := azureRouter(t)
+
+	cred := azureCredNoDeploymentMap(upstream.srv.URL)
+	cred.Extra["deployment"] = "prod-mini-eastus"
+
+	iter, err := router.DispatchStream(context.Background(), azureChatRequest(true), cred)
+	require.NoError(t, err)
+	for iter.Next(context.Background()) {
+	}
+	require.NoError(t, iter.Err(), "the stream must drain cleanly")
+
+	assert.Equal(t, "prod-mini-eastus", upstream.deploymentAddressed(t, 0),
+		"the provider's own deployment name decides the deployment on the streaming lane too")
 }

--- a/services/aigateway/adapters/providers/azure_deployment_selfmap_test.go
+++ b/services/aigateway/adapters/providers/azure_deployment_selfmap_test.go
@@ -228,6 +228,8 @@ func TestDispatch_Azure_DeploymentDoesNotLeakAcrossCredentials(t *testing.T) {
 // The other side of the same leak, and the worse one: the non-Azure guard
 // returns before the deployment comparison, so an in-place rewrite would hand
 // a plain OpenAI provider an Azure deployment name as its model.
+//
+// @scenario "An Azure deployment does not leak into a non-Azure fallback"
 func TestDispatch_Azure_DeploymentDoesNotLeakIntoANonAzureFallback(t *testing.T) {
 	upstream := newAzureUpstream(t)
 	router := azureRouter(t)

--- a/services/aigateway/adapters/providers/azure_deployment_selfmap_test.go
+++ b/services/aigateway/adapters/providers/azure_deployment_selfmap_test.go
@@ -49,7 +49,6 @@ func (u *azureUpstream) received() [][]byte {
 	return append([][]byte(nil), u.bodies...)
 }
 
-// deploymentAddressed reports the deployment the nth upstream request names.
 func (u *azureUpstream) deploymentAddressed(t *testing.T, n int) string {
 	t.Helper()
 	bodies := u.received()

--- a/services/aigateway/adapters/providers/bifrost.go
+++ b/services/aigateway/adapters/providers/bifrost.go
@@ -234,6 +234,7 @@ func (r *BifrostRouter) Dispatch(ctx context.Context, req *domain.Request, cred 
 	if req.Resolved != nil {
 		model = req.Resolved.ModelID
 	}
+	cred = domain.WithDeploymentSelfMap(cred, model)
 
 	// Voyage is not a Bifrost ModelProvider (its enum doesn't include
 	// Voyage). The gateway proxies directly to api.voyageai.com — wire
@@ -621,6 +622,7 @@ func (r *BifrostRouter) DispatchStream(ctx context.Context, req *domain.Request,
 	if req.Resolved != nil {
 		model = req.Resolved.ModelID
 	}
+	cred = domain.WithDeploymentSelfMap(cred, model)
 
 	// The image routes answer with one JSON body, so no credential and no
 	// provider lane streams them. This sits above every provider-specific

--- a/services/aigateway/adapters/providers/bifrost.go
+++ b/services/aigateway/adapters/providers/bifrost.go
@@ -235,6 +235,7 @@ func (r *BifrostRouter) Dispatch(ctx context.Context, req *domain.Request, cred 
 		model = req.Resolved.ModelID
 	}
 	cred = domain.WithDeploymentSelfMap(cred, model)
+	req.Body = withResolvedDeployment(req.Body, cred, model)
 
 	// Voyage is not a Bifrost ModelProvider (its enum doesn't include
 	// Voyage). The gateway proxies directly to api.voyageai.com — wire
@@ -623,6 +624,7 @@ func (r *BifrostRouter) DispatchStream(ctx context.Context, req *domain.Request,
 		model = req.Resolved.ModelID
 	}
 	cred = domain.WithDeploymentSelfMap(cred, model)
+	req.Body = withResolvedDeployment(req.Body, cred, model)
 
 	// The image routes answer with one JSON body, so no credential and no
 	// provider lane streams them. This sits above every provider-specific

--- a/services/aigateway/adapters/providers/bifrost.go
+++ b/services/aigateway/adapters/providers/bifrost.go
@@ -235,7 +235,7 @@ func (r *BifrostRouter) Dispatch(ctx context.Context, req *domain.Request, cred 
 		model = req.Resolved.ModelID
 	}
 	cred = domain.WithDeploymentSelfMap(cred, model)
-	req.Body = withResolvedDeployment(req.Body, cred, model)
+	req = requestWithResolvedDeployment(req, cred, model)
 
 	// Voyage is not a Bifrost ModelProvider (its enum doesn't include
 	// Voyage). The gateway proxies directly to api.voyageai.com — wire
@@ -624,7 +624,7 @@ func (r *BifrostRouter) DispatchStream(ctx context.Context, req *domain.Request,
 		model = req.Resolved.ModelID
 	}
 	cred = domain.WithDeploymentSelfMap(cred, model)
-	req.Body = withResolvedDeployment(req.Body, cred, model)
+	req = requestWithResolvedDeployment(req, cred, model)
 
 	// The image routes answer with one JSON body, so no credential and no
 	// provider lane streams them. This sits above every provider-specific

--- a/services/aigateway/adapters/providers/bifrost_parser.go
+++ b/services/aigateway/adapters/providers/bifrost_parser.go
@@ -217,6 +217,38 @@ func stripDropTuningParams(body []byte) []byte {
 	return out
 }
 
+// withResolvedDeployment points a raw-forwarded Azure body at the deployment
+// the credential names for this model.
+//
+// Azure addresses a model by deployment name, and its v1 API carries that name
+// in the request body's `model` field rather than in the URL. Bifrost resolves
+// model -> deployment through Key.Aliases, but Azure is raw-forwarded
+// (isOpenAICompatibleProvider), so the client's own bytes are what reach the
+// wire and Bifrost's resolved model never lands in them. A provider whose
+// deployment name differs from the model id would therefore be sent a name its
+// resource does not have, and Azure answers "deployment not found".
+//
+// Mutates only when the deployment actually differs from the model, so the
+// common case (deployment == model id) stays byte-identical and OpenAI's
+// prompt-prefix auto-cache keeps hitting — the same conditional-mutation rule
+// stripDropTuningParams follows. Callers apply WithDeploymentSelfMap first, so
+// DeploymentMap already carries both the provider's explicit mapping and the
+// self-mapped default.
+func withResolvedDeployment(body []byte, cred domain.Credential, model string) []byte {
+	if cred.ProviderID != domain.ProviderAzure {
+		return body
+	}
+	deployment := cred.DeploymentMap[model]
+	if deployment == "" || deployment == model {
+		return body
+	}
+	out, err := sjson.SetBytes(body, "model", deployment)
+	if err != nil {
+		return body
+	}
+	return out
+}
+
 // isOpenAICompatibleProvider reports whether the destination provider
 // natively speaks OpenAI chat-completions wire format. When true, the
 // gateway raw-forwards the inbound body rather than parse+re-marshal,

--- a/services/aigateway/adapters/providers/bifrost_parser.go
+++ b/services/aigateway/adapters/providers/bifrost_parser.go
@@ -217,8 +217,35 @@ func stripDropTuningParams(body []byte) []byte {
 	return out
 }
 
+// requestWithResolvedDeployment returns a request whose body addresses the
+// deployment this credential names, without touching the caller's request.
+//
+// The copy is the point: app.dispatch walks the credential chain with
+// retry.Walk and hands the same *domain.Request to Dispatch on every attempt
+// (app/dispatch.go). Writing the rewritten body back into that shared request
+// would outlive the credential that caused it — the next Azure key would be
+// sent the previous key's deployment (the guard below early-returns when
+// deployment == model, so nothing rewrites it back), and a non-Azure fallback
+// returns earlier still. Either way the next resource is asked for a
+// deployment it does not have. ensureStreamIncludeUsage may write through the
+// shared request precisely because it is idempotent and reads nothing off the
+// credential; this is neither.
+//
+// Only the rewriting case allocates. With the body unchanged the original
+// pointer comes straight back, so the common path shares the request exactly
+// as it did before.
+func requestWithResolvedDeployment(req *domain.Request, cred domain.Credential, model string) *domain.Request {
+	body, rewritten := withResolvedDeployment(req.Body, cred, model)
+	if !rewritten {
+		return req
+	}
+	clone := *req
+	clone.Body = body
+	return &clone
+}
+
 // withResolvedDeployment points a raw-forwarded Azure body at the deployment
-// the credential names for this model.
+// the credential names for this model, reporting whether it changed anything.
 //
 // Azure addresses a model by deployment name, and its v1 API carries that name
 // in the request body's `model` field rather than in the URL. Bifrost resolves
@@ -228,25 +255,25 @@ func stripDropTuningParams(body []byte) []byte {
 // deployment name differs from the model id would therefore be sent a name its
 // resource does not have, and Azure answers "deployment not found".
 //
-// Mutates only when the deployment actually differs from the model, so the
+// Rewrites only when the deployment actually differs from the model, so the
 // common case (deployment == model id) stays byte-identical and OpenAI's
-// prompt-prefix auto-cache keeps hitting — the same conditional-mutation rule
+// prompt-prefix auto-cache keeps hitting — the same conditional rule
 // stripDropTuningParams follows. Callers apply WithDeploymentSelfMap first, so
 // DeploymentMap already carries both the provider's explicit mapping and the
 // self-mapped default.
-func withResolvedDeployment(body []byte, cred domain.Credential, model string) []byte {
+func withResolvedDeployment(body []byte, cred domain.Credential, model string) ([]byte, bool) {
 	if cred.ProviderID != domain.ProviderAzure {
-		return body
+		return body, false
 	}
 	deployment := cred.DeploymentMap[model]
 	if deployment == "" || deployment == model {
-		return body
+		return body, false
 	}
 	out, err := sjson.SetBytes(body, "model", deployment)
 	if err != nil {
-		return body
+		return body, false
 	}
-	return out
+	return out, true
 }
 
 // isOpenAICompatibleProvider reports whether the destination provider

--- a/services/aigateway/domain/provider.go
+++ b/services/aigateway/domain/provider.go
@@ -205,9 +205,9 @@ func (c Credential) DeclaresCatalog() bool {
 }
 
 // WithDeploymentSelfMap ensures Azure / Bedrock / Vertex credentials carry a
-// deployment entry for bareModel so Bifrost's per-key readers resolve a
-// deployment ("deployment not found for model X" / "deployments not set"
-// otherwise). By default the model id IS the deployment name
+// deployment entry for bareModel, so every dispatch lane can read the
+// deployment for a model out of one place instead of each rediscovering the
+// provider's own naming. By default the model id IS the deployment name
 // (azure/gpt-5-mini → deployment "gpt-5-mini"), so a {bareModel: bareModel}
 // self-map suffices; when the provider defines an explicit deployment (the
 // model id need not equal the deployment name), the control plane / gateway
@@ -216,9 +216,11 @@ func (c Credential) DeclaresCatalog() bool {
 //
 // Every dispatch path shares this so Azure resolves its deployment identically
 // regardless of entry point: dispatcheradapter (Studio / workflows /
-// runSignature) and the gatewayproxy /go/proxy path (scenario User Simulator,
-// playground). The /go/proxy path previously skipped it, so Azure calls that
-// got past the endpoint check then failed deployment resolution (#5760).
+// runSignature), the gatewayproxy /go/proxy path (scenario User Simulator,
+// playground), and the gateway's own dispatch lanes. The /go/proxy path
+// previously skipped it, so Azure calls that got past the endpoint check then
+// failed deployment resolution (#5760); the gateway skipped it too, and sent
+// Azure the model id where the provider had named a deployment (#7765).
 func WithDeploymentSelfMap(cred Credential, bareModel string) Credential {
 	if bareModel == "" {
 		return cred

--- a/specs/ai-gateway/azure-endpoint-from-api-base.feature
+++ b/specs/ai-gateway/azure-endpoint-from-api-base.feature
@@ -58,23 +58,23 @@ Feature: Azure OpenAI provider routing through in-app dispatch paths
     anything left the box.
 
     Background:
-      Given an Azure provider slot on a virtual key with a correct endpoint and API key
-      And the provider row defines no explicit deployment mapping
+      Given an Azure provider credential with a correct endpoint and API key reaches dispatch
+      And the credential carries no explicit deployment mapping
 
     @integration
     Scenario: Gateway chat completion for an Azure model reaches the deployment named by the model id
-      When a chat completion for that model is sent through the gateway
+      When a chat completion for that model is dispatched
       Then the upstream request targets the deployment named by the model id
-      And the dispatch does not fail with "deployments not set"
+      And the dispatch is not refused as a provider-configuration error
 
     @integration
     Scenario: Gateway streaming chat completion for an Azure model reaches the deployment named by the model id
-      When a streaming chat completion for that model is sent through the gateway
+      When a streaming chat completion for that model is dispatched
       Then the upstream request targets the deployment named by the model id
-      And the dispatch does not fail with "deployments not set"
+      And the stream drains without error
 
     @integration
     Scenario: An explicit deployment mapping still decides the deployment on the gateway lane
-      Given the provider row maps the model to a deployment name that differs from the model id
-      When a chat completion for that model is sent through the gateway
+      Given the credential maps the model to a deployment name that differs from the model id
+      When a chat completion for that model is dispatched
       Then the upstream request targets the mapped deployment name

--- a/specs/ai-gateway/azure-endpoint-from-api-base.feature
+++ b/specs/ai-gateway/azure-endpoint-from-api-base.feature
@@ -47,3 +47,34 @@ Feature: Azure OpenAI provider routing through in-app dispatch paths
     Given an Azure provider slot on a virtual key whose endpoint arrives under "endpoint"
     When a chat completion is sent through the gateway
     Then the upstream request is sent to the configured Azure resource endpoint
+
+  Rule: The gateway resolves the Azure deployment the same way the in-app paths do
+
+    An Azure provider row carries an explicit deployment mapping only when the
+    deployment name differs from the model id, which is the exception rather
+    than the rule. The in-app dispatch paths fill the gap by defaulting the
+    deployment to the model id; the gateway did not, so the same provider that
+    served the playground failed through a virtual key on every request, before
+    anything left the box.
+
+    Background:
+      Given an Azure provider slot on a virtual key with a correct endpoint and API key
+      And the provider row defines no explicit deployment mapping
+
+    @integration
+    Scenario: Gateway chat completion for an Azure model reaches the deployment named by the model id
+      When a chat completion for that model is sent through the gateway
+      Then the upstream request targets the deployment named by the model id
+      And the dispatch does not fail with "deployments not set"
+
+    @integration
+    Scenario: Gateway streaming chat completion for an Azure model reaches the deployment named by the model id
+      When a streaming chat completion for that model is sent through the gateway
+      Then the upstream request targets the deployment named by the model id
+      And the dispatch does not fail with "deployments not set"
+
+    @integration
+    Scenario: An explicit deployment mapping still decides the deployment on the gateway lane
+      Given the provider row maps the model to a deployment name that differs from the model id
+      When a chat completion for that model is sent through the gateway
+      Then the upstream request targets the mapped deployment name

--- a/specs/ai-gateway/azure-endpoint-from-api-base.feature
+++ b/specs/ai-gateway/azure-endpoint-from-api-base.feature
@@ -58,6 +58,12 @@ Feature: Azure OpenAI provider routing through in-app dispatch paths
     named differently from the model must not have that name dropped on the way
     out: Azure has no such deployment and refuses the call.
 
+    A deployment belongs to the credential that named it. Dispatch retries walk
+    a chain of credentials over one request, so a deployment resolved for one
+    attempt must not decide what a later attempt sends: the next resource, or a
+    provider that is not Azure at all, would be asked for a deployment it does
+    not have.
+
     Background:
       Given an Azure provider credential with a correct endpoint and API key reaches dispatch
 
@@ -86,3 +92,18 @@ Feature: Azure OpenAI provider routing through in-app dispatch paths
       Given the provider names a deployment that differs from the model id
       When a streaming chat completion for that model is dispatched
       Then the upstream request targets that deployment name
+
+    @integration
+    Scenario: A deployment resolved for one credential does not leak into the next attempt
+      Given the provider maps the model to a deployment name that differs from the model id
+      And a second Azure credential that names no deployment of its own follows it in the chain
+      When the request fails over to that second credential
+      Then the second resource is asked for the deployment named by the model id
+      And the request the customer sent is left unaltered for the next attempt
+
+    @integration
+    Scenario: An Azure deployment does not leak into a non-Azure fallback
+      Given the provider maps the model to a deployment name that differs from the model id
+      And a credential for a provider that is not Azure follows it in the chain
+      When the request fails over to that credential
+      Then that provider is asked for the model id and not the Azure deployment name

--- a/specs/ai-gateway/azure-endpoint-from-api-base.feature
+++ b/specs/ai-gateway/azure-endpoint-from-api-base.feature
@@ -50,31 +50,39 @@ Feature: Azure OpenAI provider routing through in-app dispatch paths
 
   Rule: The gateway resolves the Azure deployment the same way the in-app paths do
 
-    An Azure provider row carries an explicit deployment mapping only when the
-    deployment name differs from the model id, which is the exception rather
-    than the rule. The in-app dispatch paths fill the gap by defaulting the
-    deployment to the model id; the gateway did not, so the same provider that
-    served the playground failed through a virtual key on every request, before
-    anything left the box.
+    An Azure provider row names a deployment explicitly only when that name
+    differs from the model id, which is the exception rather than the rule; by
+    default the model id is the deployment name. The in-app dispatch paths fill
+    that gap, and gateway traffic must resolve the deployment identically, on
+    the streaming lane as well as the plain one. A customer whose deployment is
+    named differently from the model must not have that name dropped on the way
+    out: Azure has no such deployment and refuses the call.
 
     Background:
       Given an Azure provider credential with a correct endpoint and API key reaches dispatch
-      And the credential carries no explicit deployment mapping
 
     @integration
     Scenario: Gateway chat completion for an Azure model reaches the deployment named by the model id
+      Given the provider names no deployment of its own
       When a chat completion for that model is dispatched
       Then the upstream request targets the deployment named by the model id
-      And the dispatch is not refused as a provider-configuration error
+      And the request the customer sent is forwarded unaltered
 
     @integration
     Scenario: Gateway streaming chat completion for an Azure model reaches the deployment named by the model id
+      Given the provider names no deployment of its own
       When a streaming chat completion for that model is dispatched
       Then the upstream request targets the deployment named by the model id
       And the stream drains without error
 
     @integration
     Scenario: An explicit deployment mapping still decides the deployment on the gateway lane
-      Given the credential maps the model to a deployment name that differs from the model id
+      Given the provider maps the model to a deployment name that differs from the model id
       When a chat completion for that model is dispatched
       Then the upstream request targets the mapped deployment name
+
+    @integration
+    Scenario: The streaming lane honors an explicit deployment name too
+      Given the provider names a deployment that differs from the model id
+      When a streaming chat completion for that model is dispatched
+      Then the upstream request targets that deployment name


### PR DESCRIPTION
Closes #7765.

## For humans

Azure doesn't let you ask for a model by its name. You have to ask for a *deployment* — the label you gave that model when you set it up in your own Azure resource. Most people give the deployment the same name as the model, so the two look identical and nobody thinks about it. Some don't: you might call yours `prod-mini-eastus`.

When you told LangWatch that name, the gateway was throwing it away. Your request went to Azure asking for the model name instead, Azure had no deployment by that name, and the call failed — while the exact same provider worked fine in the playground, because that path fills the name in.

This makes the gateway send the deployment name you actually configured, on both normal and streaming requests. If you never set one, it keeps assuming the deployment is named after the model, which is the common case and is what already happened.

## What broke it

Bifrost v1.5 (bumped on `main` in #7877) changed how Azure is addressed:

- `AzureKeyConfig.Deployments` is gone. Model → deployment is now `Key.Aliases`, and `main` already rewired `cred.DeploymentMap` onto it (`bifrost.go:1378`).
- The deployment left the URL. The Azure chat endpoint is now a flat `/openai/v1/chat/completions` (`azure.go:640`), and the deployment is named by the request body's `model` field.

Azure is **raw-forwarded** — `isOpenAICompatibleProvider` includes it (`bifrost_parser.go:234`), so the gateway hands Bifrost the client's bytes verbatim to keep OpenAI's prompt-prefix auto-cache hitting. Bifrost resolves the alias into its own request object, but that object is not what goes on the wire, so the resolved deployment never reaches the body.

Net effect: **the deployment a provider names is dropped**. Measured on the real dispatch path against a local upstream, all three credential shapes sent the identical request:

| credential | request sent |
|---|---|
| no deployment mapping | `/openai/v1/chat/completions` `{"model":"gpt-5-mini"}` |
| explicit map `gpt-5-mini` → `prod-mini-eastus` | *identical* |
| deployment named alongside the credential | *identical* |

## The fix

Four production lines plus a helper in `bifrost_parser.go`.

`withResolvedDeployment` writes the resolved deployment into the raw-forwarded body's `model` field. `requestWithResolvedDeployment` wraps it, and `Dispatch` / `DispatchStream` call that right after the model is resolved — the same seam that already applies `WithDeploymentSelfMap`, so the two lanes cannot drift apart.

It rewrites **only** when the deployment differs from the model id. In the common case (deployment == model id) the body goes out byte-identical and the auto-cache is untouched — the same conditional rule `stripDropTuningParams` follows.

**The rewrite is attempt-scoped, not written through.** `retry.Walk` hands the *same* `*domain.Request` to `Dispatch` on every attempt in the credential chain (`app/dispatch.go:35`, `:73`), so rewriting the body in place would outlive the credential that caused it. Both leak directions were real and are now covered by tests:

- next Azure key: its own deployment equals the model id, so the guard early-returns and never rewrites the previous key's `prod-mini-eastus` back out — that resource gets asked for a deployment it does not have.
- non-Azure fallback: the provider guard returns even earlier, handing a plain OpenAI provider an Azure deployment name as its model.

So the helper returns a shallow copy carrying the new body, and only when it actually rewrites — the unchanged path returns the original pointer and shares the request exactly as before. This is what separates it from `ensureStreamIncludeUsage`, which may write through the shared request because it is idempotent and reads nothing off the credential.

The two `WithDeploymentSelfMap` calls stay and are load-bearing: they fold a deployment named alongside the credential into `DeploymentMap`, which is the single place both lanes read.

`WithDeploymentSelfMap` also covers Bedrock and Vertex, so those now carry a `{model: model}` self-map on this path. Both consumers collapse to the identity — `KeyAliases.Resolve` returns the model unchanged for a self-alias exactly as it does for a nil map (`account.go:170`), and `bedrockModelID` (`bedrock_vpce.go:137`) returns the model either way. Vertex has no dispatch-path consumer at all. Verified by reading those call sites, not by an observed Bedrock or Vertex request.

## Tests

`azure_deployment_selfmap_test.go` drives the real router against a local upstream standing in for the customer's Azure resource, and observes the deployment the request actually names:

- no mapping → addresses `gpt-5-mini`, **and** the body is forwarded byte-for-byte
- streaming, no mapping → addresses `gpt-5-mini`, stream drains clean
- explicit map → addresses `prod-mini-eastus`
- streaming, deployment named alongside the credential → addresses `prod-mini-eastus`
- two Azure credentials in sequence on one request pointer, as failover runs it → the second resource is addressed as `gpt-5-mini`, not the first's `prod-mini-eastus`, and the caller's body is unchanged
- Azure then a non-Azure fallback on one request pointer → the OpenAI provider is addressed as `gpt-5-mini`

Every half was verified load-bearing rather than assumed:

- with `withResolvedDeployment` neutralised, both explicit-deployment tests fail (`expected prod-mini-eastus, actual gpt-5-mini`)
- with the two `WithDeploymentSelfMap` lines removed, the streaming explicit-deployment test fails
- with the copy replaced by a write-through, both leak tests fail — the second Azure resource and the OpenAI provider are each sent `prod-mini-eastus`

Green locally: `go build`, `go vet` and the full `go test ./services/aigateway/...`, plus both lint gates CI runs (the package-list run and `make go-lint-changed`).

## Spec

Six scenarios under a rule for the gateway lane in `specs/ai-gateway/azure-endpoint-from-api-base.feature`, tagged `@integration` and bound by the tests above. The rule also states the retry-safety property in prose: a resolved deployment belongs to the credential that named it and must not decide what a later attempt sends. That makes the file enforce scenarios for the first time, so it comes off `LEGACY_INERT` in `check-feature-parity.ts` — the ratchet clicking, as that list's own comment describes. Parity reports `6/6 scenarios bound`.

## Deployment Impact

No environment variables, Helm chart values, config keys, migrations or dependencies change.

**Dataplane effect.** Azure requests dispatched through the gateway now carry the deployment the provider names:

- A provider **without** an explicit deployment keeps sending the model id as the deployment — byte-identical to today, so no cache or latency change.
- A provider **with** a deployment name different from the model id previously had that name dropped and got a deployment-not-found from Azure; it now reaches the intended deployment. That is the fix.
- Non-Azure providers are untouched: `withResolvedDeployment` returns the body unchanged for every other provider id, including when a failover reaches them mid-chain after an Azure attempt (covered by a test).

**Upgrade behavior.** Default on deploy, no operator action, no rollout ordering constraint. Web and worker can roll in either order.

**Rollback.** Revert the commit; nothing is persisted and no state migrates.

## Note for reviewers

The `deployment_map` regression above landed on `main` with the Bifrost bump and is not caused by this branch — this PR is where it gets caught and fixed, because these are the tests that look at what Azure actually receives. Worth a tracked issue on its own if you want the history recorded separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Azure chat completions now automatically target the requested model ID as the deployment when no explicit deployment mapping is configured.
  * Explicit deployment mappings and names continue to take precedence.
  * Deployment resolution now works consistently for streaming and non-streaming requests.

* **Tests**
  * Added coverage for automatic deployment selection and explicit mapping behavior across both request modes.
  * Added integration validation that requests reach the intended Azure deployment without provider-configuration errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
