### PR TITLE
refactor(automations): align filter display conventions

### DIFF
--- a/platform/app/src/components/analytics/reports/GraphFilterIndicator.tsx
+++ b/platform/app/src/components/analytics/reports/GraphFilterIndicator.tsx
@@ -19,7 +19,7 @@ export function GraphFilterIndicator({ filters }: GraphFilterIndicatorProps) {
           height="100%"
           textWrap="wrap"
         >
-          <FilterDisplay filters={filters} clampValues={false} />
+          <FilterDisplay filters={filters} shouldClampValues={false} />
         </VStack>
       }
       positioning={{ placement: "top" }}

--- a/platform/app/src/components/automations/FilterDisplay.tsx
+++ b/platform/app/src/components/automations/FilterDisplay.tsx
@@ -10,7 +10,7 @@ interface FilterDisplayProps {
    * off where the chip is already inside a tooltip: there is no room for a
    * second hover, so the value has to wrap instead.
    */
-  clampValues?: boolean;
+  shouldClampValues?: boolean;
 }
 
 const FilterContainer = ({
@@ -61,12 +61,12 @@ const FilterLabel = ({ children }: { children: React.ReactNode }) => {
 
 const FilterValue = ({
   children,
-  clamp = true,
+  shouldClamp = true,
 }: {
   children: React.ReactNode;
-  clamp?: boolean;
+  shouldClamp?: boolean;
 }) => {
-  if (!clamp) {
+  if (!shouldClamp) {
     // Already inside a tooltip: wrap instead, and break mid-token so an
     // unbreakable id cannot run past the tooltip edge.
     return (
@@ -91,7 +91,7 @@ const FilterValue = ({
 export const FilterDisplay = ({
   filters,
   hasBorder = false,
-  clampValues = true,
+  shouldClampValues = true,
 }: FilterDisplayProps) => {
   const applyFilters = (filters: string | Record<string, any>) => {
     const obj = typeof filters === "string" ? JSON.parse(filters) : filters;
@@ -102,7 +102,9 @@ export const FilterDisplay = ({
         result.push(
           <FilterContainer key={key} hasBorder={hasBorder}>
             <FilterLabel>{key}</FilterLabel>
-            <FilterValue clamp={clampValues}>{value.join(", ")}</FilterValue>
+            <FilterValue shouldClamp={shouldClampValues}>
+              {value.join(", ")}
+            </FilterValue>
           </FilterContainer>,
         );
       } else if (typeof value === "object" && value !== null) {
@@ -126,7 +128,7 @@ export const FilterDisplay = ({
         result.push(
           <FilterContainer key={key} hasBorder={hasBorder}>
             <FilterLabel>{key}</FilterLabel>
-            <FilterValue clamp={clampValues}>
+            <FilterValue shouldClamp={shouldClampValues}>
               {nestedResult.join("; ")}
             </FilterValue>
           </FilterContainer>,
@@ -135,7 +137,9 @@ export const FilterDisplay = ({
         result.push(
           <FilterContainer key={key} fontSize="xs" hasBorder={hasBorder}>
             <FilterLabel>{key}</FilterLabel>
-            <FilterValue clamp={clampValues}>{String(value)}</FilterValue>
+            <FilterValue shouldClamp={shouldClampValues}>
+              {String(value)}
+            </FilterValue>
           </FilterContainer>,
         );
       }

--- a/platform/app/src/components/automations/__tests__/FilterDisplay.integration.test.tsx
+++ b/platform/app/src/components/automations/__tests__/FilterDisplay.integration.test.tsx
@@ -6,10 +6,13 @@ import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 import { FilterDisplay } from "../FilterDisplay";
 
-const renderFilters = (
-  filters: Record<string, unknown>,
-  props: { clampValues?: boolean } = {},
-) =>
+const renderFilters = ({
+  filters,
+  props = {},
+}: {
+  filters: Record<string, unknown>;
+  props?: { shouldClampValues?: boolean };
+}) =>
   render(
     <ChakraProvider value={defaultSystem}>
       <FilterDisplay filters={filters} hasBorder={true} {...props} />
@@ -24,55 +27,59 @@ const LONG_VALUE = "monitor_0008KDW6ykSweqn6dwR0UukEOi2wAbCdEfGhIjKlMnOpQrSt";
 describe("FilterDisplay", () => {
   afterEach(() => cleanup());
 
-  describe("when a filter value is one long unbreakable token", () => {
-    it("lets the value's flex child shrink below its content width", () => {
-      renderFilters({ "trace_checks.check_id": [LONG_VALUE] });
+  describe("given a filter value is one long unbreakable token", () => {
+    describe("when clamping is enabled", () => {
+      it("lets the value's flex child shrink below its content width", () => {
+        renderFilters({
+          filters: { "trace_checks.check_id": [LONG_VALUE] },
+        });
 
-      const text = screen.getByText(LONG_VALUE);
-      // The clamped text box sits inside FilterValue's Box, the flex child of
-      // the chip's HStack. Flex children default to min-width: auto, which is
-      // the defect: the chip cannot shrink it, so it must opt out.
-      const flexChild = text.closest("div")?.parentElement;
-      expect(flexChild).toBeTruthy();
-      const style = getComputedStyle(flexChild!);
-      expect(style.minWidth).toBe("0px");
-      expect(style.overflow).toBe("hidden");
+        const text = screen.getByText(LONG_VALUE);
+        // The clamped text box sits inside FilterValue's Box, the flex child of
+        // the chip's HStack. Flex children default to min-width: auto, which is
+        // the defect: the chip cannot shrink it, so it must opt out.
+        const flexChild = text.closest("div")?.parentElement;
+        expect(flexChild).toBeTruthy();
+        const style = getComputedStyle(flexChild!);
+        expect(style.minWidth).toBe("0px");
+        expect(style.overflow).toBe("hidden");
+      });
+
+      it("keeps the value clamped to one line inside the chip", () => {
+        renderFilters({
+          filters: { "trace_checks.check_id": [LONG_VALUE] },
+        });
+
+        const text = screen.getByText(LONG_VALUE);
+        const clamped = getComputedStyle(text.closest("div")!);
+        expect(clamped.webkitLineClamp).toBe("1");
+      });
     });
 
-    it("keeps the value clamped to one line inside the chip", () => {
-      renderFilters({ "trace_checks.check_id": [LONG_VALUE] });
+    describe("when clamping is disabled", () => {
+      it("wraps the value instead of clamping it to one line", () => {
+        renderFilters({
+          filters: { "trace_checks.check_id": [LONG_VALUE] },
+          props: { shouldClampValues: false },
+        });
 
-      const text = screen.getByText(LONG_VALUE);
-      const clamped = getComputedStyle(text.closest("div")!);
-      expect(clamped.webkitLineClamp).toBe("1");
-    });
-  });
+        const style = getComputedStyle(screen.getByText(LONG_VALUE));
+        // Asserted as absent rather than "not 1": a negative assertion would
+        // also pass if the styles had never applied at all.
+        expect(style.webkitLineClamp).toBe("");
+        expect(style.overflow).toBe("");
+      });
 
-  // The graph filter indicator renders this inside a tooltip, where clamping
-  // hides the rest of the value behind a hover the user cannot perform.
-  describe("when clamping is turned off", () => {
-    it("wraps the value instead of clamping it to one line", () => {
-      renderFilters(
-        { "trace_checks.check_id": [LONG_VALUE] },
-        { clampValues: false },
-      );
+      it("breaks mid-token so an unbreakable id cannot run past its container", () => {
+        renderFilters({
+          filters: { "trace_checks.check_id": [LONG_VALUE] },
+          props: { shouldClampValues: false },
+        });
 
-      const style = getComputedStyle(screen.getByText(LONG_VALUE));
-      // Asserted as absent rather than "not 1": a negative assertion would
-      // also pass if the styles had never applied at all.
-      expect(style.webkitLineClamp).toBe("");
-      expect(style.overflow).toBe("");
-    });
-
-    it("breaks mid-token so an unbreakable id cannot run past its container", () => {
-      renderFilters(
-        { "trace_checks.check_id": [LONG_VALUE] },
-        { clampValues: false },
-      );
-
-      const style = getComputedStyle(screen.getByText(LONG_VALUE));
-      expect(style.overflowWrap).toBe("anywhere");
-      expect(style.minWidth).toBe("0px");
+        const style = getComputedStyle(screen.getByText(LONG_VALUE));
+        expect(style.overflowWrap).toBe("anywhere");
+        expect(style.minWidth).toBe("0px");
+      });
     });
   });
 });


### PR DESCRIPTION
## Why

The filter display changes from #7760 introduced three convention deviations: unprefixed boolean names, a multi-argument test helper, and a flat test structure. Aligning them keeps the component and its integration test consistent with the repository conventions without changing behavior.

Closes #7773

## What changed

- Renamed `clampValues` and `clamp` to the boolean-prefixed `shouldClampValues` and `shouldClamp`, including the graph filter indicator call site.
- Changed `renderFilters` to take a single named-parameter object.
- Grouped the long-token scenarios under nested `given` and `when` blocks.

## Test plan

- `pnpm test:component run src/components/automations/__tests__/FilterDisplay.integration.test.tsx` (4 tests passed)
- `pnpm typecheck:all`
- `pnpm exec biome check src/components/analytics/reports/GraphFilterIndicator.tsx src/components/automations/FilterDisplay.tsx src/components/automations/__tests__/FilterDisplay.integration.test.tsx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated filter display behavior to consistently respect the value-clamping setting across analytics and automation views.
  * Preserved unclamped filter values when clamping is disabled.
  * Maintained the default behavior of clamping filter values when no setting is specified.

* **Tests**
  * Expanded coverage for filter displays with clamping enabled and disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->