### PR TITLE
feat(governance): group the Copilot Studio form and default to one app registration

### DIFF
--- a/dev/docs/adr/128-governance-cost-and-identity-two-waves.md
+++ b/dev/docs/adr/128-governance-cost-and-identity-two-waves.md
@@ -763,6 +763,21 @@ credentials are absent. A fallback silently re-creates the exact grant
 this section exists to break, and it does so in the one case nobody is
 watching — the customer who declined to give billing access.
 
+*Form default (v3.7).* The create form defaults to **one app
+registration for both reads**: the switch "Use one app registration for
+everything" starts on, and the builder copies the bot pair into the
+billing keys at save time. This is not a fallback — the billing keys are
+always present when a subscription is claimed, written deliberately, and
+the token paths stay separate. The split arrangement remains the
+*recommendation* for tenants whose finance approval is separate, one
+flip away; the guard never required the pairs to differ, so the default
+codifies what most admins were going to do anyway rather than weakening
+an enforced boundary. The choice is recorded as
+`azureBillingUsesSameApp` (a non-secret config key), because once the
+credentials are sealed, equal pairs cannot be told apart from a
+deliberate second app with equal values. Spec:
+`specs/governance/copilot-studio-form-controls.feature`.
+
 **21.2 No schema change, and no new secret-handling path.** Credentials
 are already `Record<string, string>`
 (`pullers/pullerAdapter.ts:164-168`), decrypted by the worker before an
@@ -903,6 +918,7 @@ the third lane.
 | Anthropic restatement window | 30 days back (#6978) | why overlap/dedup rules are read-time only |
 | Billing credential keys (§21.1) | `billingClientId`, `billingClientSecret` in the existing `credentials` map; tenant reused from `tenantId` | the Azure Resource Manager identity, separate from the bot's `clientId`/`clientSecret` |
 | Prepaid declaration (§21.4) | `azureBillingIsPrepaid: boolean`, customer-set on the connection, default `false` | the only thing that licenses the prepaid sentence; never inferred |
+| One-app choice (§21.1 form default, v3.7) | `azureBillingUsesSameApp: boolean`, written by the create form's builder beside a claimed subscription, default `true` | the only durable record of whether the billing pair is a copy of the bot's or a second app; nothing reads it at run time — the edit path (#7777) will |
 | Spend-lane reasons (§21.3) | `billing_read_failed`, `prepaid_declared`, `no_spend_recorded` | closed list bounded by what the system can know (v3.4: `awaiting_grant` withdrawn with §21.6; `billing_access_denied` folded into `billing_read_failed` — 403 and 429 die at the same line today; `no_billing_credentials` became a save-time refusal, `assertAzureBillHasItsOwnCredential`, so the state cannot be stored to need a sentence — true on every write path only since v3.5, which closed the create that still passed through); the screen maps each to a sentence, provider text never reaches the browser |
 | Azure cost read interval | 6 h (`AZURE_COST_READ_INTERVAL_MS`), max hold 7 d (`AZURE_COST_MAX_HOLD_MS`) | already shipped; the allowance is a few requests/minute **shared with the customer's own portal users** |
 
@@ -1172,6 +1188,20 @@ money tables, only the identity tables and read paths.
 | Key-to-bill mapping schema shape (§7) — column vs join table on `IngestionSource` | wave-2 implementation |
 
 ## Revisions
+
+- **v3.7 (2026-09-03, captain: Sergio Esteban).** The create form's
+  default flipped to one app registration for both reads (issue #7775).
+  §21.1 gains the *Form default* paragraph: the builder copies the bot
+  pair into the billing keys when the switch is on, the split
+  arrangement stays the recommendation one flip away, and the choice is
+  persisted as `azureBillingUsesSameApp` because sealed credentials
+  cannot answer it later. Without this note the ADR and
+  `copilot-studio-form-controls.feature` would assert opposite defaults.
+  Nothing §21 enforces changed: the guard never compared the pairs, the
+  no-fallback invariant holds (the copy is written at save, not
+  substituted at read), and no reason list or health rule moved. The
+  edit path deliberately ships separately (#7777) — today's form cannot
+  edit this source type at all.
 
 - **v3.6 (2026-09-02, captain: Sergio Esteban).** The subscription claim
   becomes fixed once the bill has been read. Review of the sealed-envelope

--- a/platform/app/ee/governance/dashboard/pages/__tests__/copilotStudioDataversePullConfig.unit.test.ts
+++ b/platform/app/ee/governance/dashboard/pages/__tests__/copilotStudioDataversePullConfig.unit.test.ts
@@ -390,9 +390,11 @@ describe("given the one-app registration switch", () => {
       // An untouched switch holds nothing in form state, so only an explicit
       // boolean written by the builder makes the default durable.
       expect(config.azureBillingUsesSameApp).toBe(true);
-      expect(() =>
-        copilotStudioDataversePullConfigSchema.parse(config),
-      ).not.toThrow();
+      // Through the adapter's own parser, not just present on the raw object:
+      // the schema is strip-mode, so an undeclared (or misspelled) key would
+      // vanish here silently — and the #7777 edit path reads the parsed side.
+      const parsed = copilotStudioDataversePullConfigSchema.parse(config);
+      expect(parsed.azureBillingUsesSameApp).toBe(true);
     });
 
     /** @scenario "Billing values typed before flipping back to one app are not saved" */

--- a/platform/app/ee/governance/dashboard/pages/__tests__/copilotStudioDataversePullConfig.unit.test.ts
+++ b/platform/app/ee/governance/dashboard/pages/__tests__/copilotStudioDataversePullConfig.unit.test.ts
@@ -189,9 +189,13 @@ describe("buildCopilotStudioDataversePullConfig", () => {
   });
 
   describe("when the admin gives the bill its own credential", () => {
+    // Typing a billing pair of its own IS the two-app choice, which the form
+    // records explicitly — with the switch on its one-app default the builder
+    // would copy the conversation pair over whatever is held here.
     const WITH_BILLING = {
       ...REQUIRED,
       azureSubscriptionId: SUBSCRIPTION_ID,
+      azureBillingUsesSameApp: "false",
       credentialsBillingClientId: "billing-client-id",
       credentialsBillingClientSecret: "billing-client-secret",
     };
@@ -226,7 +230,13 @@ describe("buildCopilotStudioDataversePullConfig", () => {
     /** @scenario "A subscription cannot be saved without its own billing credential" */
     it("omits absent billing keys instead of sending empty strings", () => {
       const config = buildCopilotStudioDataversePullConfig(
-        composer({ ...REQUIRED, azureSubscriptionId: SUBSCRIPTION_ID }),
+        composer({
+          ...REQUIRED,
+          azureSubscriptionId: SUBSCRIPTION_ID,
+          // Two apps chosen but the pair not yet typed — the one state where
+          // "absent" is still the honest thing to send.
+          azureBillingUsesSameApp: "false",
+        }),
       ) as Record<string, unknown>;
 
       // The server-side guard reads "key present but blank" and "key absent"
@@ -348,6 +358,107 @@ describe("buildCopilotStudioDataversePullConfig", () => {
           values,
         }),
       ).toBe(values);
+    });
+  });
+});
+
+describe("given the one-app registration switch", () => {
+  const ONE_APP_WITH_SUBSCRIPTION = {
+    ...REQUIRED,
+    azureSubscriptionId: SUBSCRIPTION_ID,
+  };
+
+  describe("when the admin leaves the switch on its default", () => {
+    /** @scenario "With one app chosen, the saved bill credential is the conversation one" */
+    it("copies the conversation credential into the billing slots", () => {
+      const config = buildCopilotStudioDataversePullConfig(
+        composer(ONE_APP_WITH_SUBSCRIPTION),
+      ) as Record<string, unknown>;
+
+      expect(config.credentials).toMatchObject({
+        billingClientId: REQUIRED.credentialsClientId,
+        billingClientSecret: REQUIRED.credentialsClientSecret,
+      });
+    });
+
+    /** @scenario "The one-app choice is saved alongside the configuration" */
+    it("records the choice as an explicit boolean the adapter accepts", () => {
+      const config = buildCopilotStudioDataversePullConfig(
+        composer(ONE_APP_WITH_SUBSCRIPTION),
+      ) as Record<string, unknown>;
+
+      // An untouched switch holds nothing in form state, so only an explicit
+      // boolean written by the builder makes the default durable.
+      expect(config.azureBillingUsesSameApp).toBe(true);
+      expect(() =>
+        copilotStudioDataversePullConfigSchema.parse(config),
+      ).not.toThrow();
+    });
+
+    /** @scenario "Billing values typed before flipping back to one app are not saved" */
+    it("overrides billing values left over from a two-app detour", () => {
+      const config = buildCopilotStudioDataversePullConfig(
+        composer({
+          ...ONE_APP_WITH_SUBSCRIPTION,
+          azureBillingUsesSameApp: "true",
+          credentialsBillingClientId: "leftover-billing-id",
+          credentialsBillingClientSecret: "leftover-billing-secret",
+        }),
+      ) as Record<string, unknown>;
+
+      expect(config.credentials).toMatchObject({
+        billingClientId: REQUIRED.credentialsClientId,
+        billingClientSecret: REQUIRED.credentialsClientSecret,
+      });
+    });
+
+    /** @scenario "A source claiming no subscription saves no billing credential" */
+    it("saves no billing credential and no record without a subscription", () => {
+      const config = buildCopilotStudioDataversePullConfig(
+        composer(REQUIRED),
+      ) as Record<string, unknown>;
+
+      expect(config.credentials).not.toHaveProperty("billingClientId");
+      expect(config.credentials).not.toHaveProperty("billingClientSecret");
+      // Like the prepaid flag, the choice rides only beside a subscription:
+      // without a bill to read there is no choice to record.
+      expect(config).not.toHaveProperty("azureBillingUsesSameApp");
+    });
+  });
+
+  describe("when the admin chooses a second app registration", () => {
+    /** @scenario "Choosing two apps is recorded too" */
+    it("saves the typed billing pair and records the choice", () => {
+      const config = buildCopilotStudioDataversePullConfig(
+        composer({
+          ...ONE_APP_WITH_SUBSCRIPTION,
+          azureBillingUsesSameApp: "false",
+          credentialsBillingClientId: "billing-client-id",
+          credentialsBillingClientSecret: "billing-client-secret",
+        }),
+      ) as Record<string, unknown>;
+
+      expect(config.credentials).toMatchObject({
+        billingClientId: "billing-client-id",
+        billingClientSecret: "billing-client-secret",
+      });
+      expect(config.azureBillingUsesSameApp).toBe(false);
+    });
+  });
+
+  describe("when the flag would clash with the stored parserConfig", () => {
+    /** @scenario "The one-app choice is saved alongside the configuration" */
+    it("keeps the raw form string out of parserConfig, like the other switches", () => {
+      const parserConfig = buildParserConfig(
+        composer({
+          ...ONE_APP_WITH_SUBSCRIPTION,
+          azureBillingUsesSameApp: "true",
+        }),
+      );
+
+      // parserConfig wins the server's merge, so the form's string "true"
+      // would silently shadow the builder's boolean.
+      expect(parserConfig).not.toHaveProperty("azureBillingUsesSameApp");
     });
   });
 });

--- a/platform/app/ee/governance/dashboard/pages/__tests__/parserConfigFields.integration.test.tsx
+++ b/platform/app/ee/governance/dashboard/pages/__tests__/parserConfigFields.integration.test.tsx
@@ -278,3 +278,54 @@ describe("given the Copilot Studio licence switch", () => {
     });
   });
 });
+
+describe("given the Copilot Studio create form", () => {
+  describe("when the form first renders", () => {
+    /** @scenario "Copilot Studio setup reads as three purposes, in the order admins care" */
+    it("stands in three labelled groups, connection then cost then conversation", () => {
+      renderFields("copilot_studio_dataverse");
+
+      const headings = screen
+        .getAllByText(/^(Connection|Cost|Conversation access)$/)
+        .map((el) => el.textContent);
+      expect(headings).toEqual(["Connection", "Cost", "Conversation access"]);
+    });
+
+    /** @scenario "A new source starts with one app registration for everything" */
+    it("starts with the one-app switch on and no billing fields in sight", () => {
+      renderFields("copilot_studio_dataverse");
+
+      const oneApp = screen.getByTestId(
+        "parser-switch-azureBillingUsesSameApp",
+      ) as HTMLInputElement;
+      expect(oneApp.checked).toBe(true);
+      expect(
+        screen.queryByText(/Billing app registration client ID/),
+      ).toBeNull();
+      expect(
+        screen.queryByText(/Billing app registration client secret/),
+      ).toBeNull();
+    });
+  });
+
+  describe("when the admin turns the one-app switch off", () => {
+    /** @scenario "Turning the switch off reveals the billing credential fields" */
+    it("reveals the billing credential fields", async () => {
+      renderFields("copilot_studio_dataverse");
+      const user = userEvent.setup();
+
+      await user.click(
+        screen.getByTestId("parser-switch-azureBillingUsesSameApp"),
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(/Billing app registration client ID/),
+        ).toBeTruthy();
+      });
+      expect(
+        screen.getByText(/Billing app registration client secret/),
+      ).toBeTruthy();
+    });
+  });
+});

--- a/platform/app/ee/governance/dashboard/pages/__tests__/parserConfigFields.integration.test.tsx
+++ b/platform/app/ee/governance/dashboard/pages/__tests__/parserConfigFields.integration.test.tsx
@@ -281,7 +281,7 @@ describe("given the Copilot Studio licence switch", () => {
 
 describe("given the Copilot Studio create form", () => {
   describe("when the form first renders", () => {
-    /** @scenario "Copilot Studio setup reads as three purposes, in the order admins care" */
+    /** @scenario "The fields stand in three labelled groups" */
     it("stands in three labelled groups, connection then cost then conversation", () => {
       renderFields("copilot_studio_dataverse");
 

--- a/platform/app/ee/governance/dashboard/pages/__tests__/parserConfigFields.integration.test.tsx
+++ b/platform/app/ee/governance/dashboard/pages/__tests__/parserConfigFields.integration.test.tsx
@@ -281,14 +281,32 @@ describe("given the Copilot Studio licence switch", () => {
 
 describe("given the Copilot Studio create form", () => {
   describe("when the form first renders", () => {
-    /** @scenario "The fields stand in three labelled groups" */
-    it("stands in three labelled groups, connection then cost then conversation", () => {
+    /** @scenario "The fields stand in labelled groups, choices last" */
+    it("stands in labelled groups with the billing choice last", () => {
       renderFields("copilot_studio_dataverse");
 
       const headings = screen
-        .getAllByText(/^(Connection|Cost|Conversation access)$/)
+        .getAllByText(/^(Connection|Cost|Conversation access|Billing)$/)
         .map((el) => el.textContent);
-      expect(headings).toEqual(["Connection", "Cost", "Conversation access"]);
+      expect(headings).toEqual([
+        "Connection",
+        "Cost",
+        "Conversation access",
+        "Billing",
+      ]);
+    });
+
+    /** @scenario "The fields stand in labelled groups, choices last" */
+    it("keeps the prepaid declaration folded away under Advanced", async () => {
+      renderFields("copilot_studio_dataverse");
+
+      expect(
+        screen.queryByText("This Copilot runs on prepaid message packs"),
+      ).toBeNull();
+      await expandAdvanced();
+      expect(
+        screen.getByText("This Copilot runs on prepaid message packs"),
+      ).toBeTruthy();
     });
 
     /** @scenario "A new source starts with one app registration for everything" */

--- a/platform/app/ee/governance/dashboard/pages/__tests__/sourceComposerAdvanced.integration.test.tsx
+++ b/platform/app/ee/governance/dashboard/pages/__tests__/sourceComposerAdvanced.integration.test.tsx
@@ -364,21 +364,19 @@ describe("given the create drawer for a push source, which offers neither settin
 
 describe("given the create drawer for a source that routes conversations", () => {
   describe("when it opens with Advanced still closed", () => {
-    /** @scenario "The drawer says where conversations will go without opening Advanced" */
-    it("says in plain sight that the conversations will land nowhere yet", () => {
+    /** @scenario "The drawer names the destination once one is picked" */
+    it("shows no destination line while nothing is picked", () => {
       renderComposer();
 
-      // The picker itself is still folded away — which is the whole reason
-      // the line has to exist outside the group.
+      // The field tooltips already explain the silent default; a standing
+      // warning here would repeat them.
       expect(screen.queryByTestId("ingestion-trace-destination")).toBeNull();
-      const hint = screen.getByTestId("composer-destination-hint");
-      expect(hint.textContent).toMatch(/will not land anywhere/i);
-      expect(hint.textContent).toMatch(/audit events/i);
+      expect(screen.queryByTestId("composer-destination-hint")).toBeNull();
     });
   });
 
   describe("when a destination has been picked", () => {
-    /** @scenario "The drawer says where conversations will go without opening Advanced" */
+    /** @scenario "The drawer names the destination once one is picked" */
     it("names the project the conversations will land in", async () => {
       const user = userEvent.setup();
       renderComposer();
@@ -398,7 +396,7 @@ describe("given the create drawer for a source that routes conversations", () =>
 
 describe("given the create drawer for a source that pulls counts", () => {
   describe("when it opens", () => {
-    /** @scenario "The drawer says where conversations will go without opening Advanced" */
+    /** @scenario "The drawer names the destination once one is picked" */
     it("offers no destination line, because it routes no conversations", () => {
       // A line about where conversations land, on a source that produces
       // none, describes a routing decision the adapter never makes.

--- a/platform/app/ee/governance/dashboard/pages/inventory.tsx
+++ b/platform/app/ee/governance/dashboard/pages/inventory.tsx
@@ -1082,6 +1082,10 @@ function ComposerDestinationHint({
   destinationCtx: DestinationContext;
 }) {
   if (!routesConversations(composer.sourceType)) return null;
+  // Silent until a destination is picked: the field tooltips already say
+  // what the silent default means, so the drawer only speaks when it has a
+  // choice to confirm.
+  if (!composer.traceProjectId) return null;
   // Named from the same list the picker offers, so the line and the control
   // cannot disagree about which project was chosen.
   const chosen = destinationCtx.availableProjects.find(
@@ -1093,9 +1097,7 @@ function ComposerDestinationHint({
       color="fg.muted"
       data-testid="composer-destination-hint"
     >
-      {composer.traceProjectId
-        ? `Conversations will land in ${chosen?.name ?? "the project picked under Advanced"}.`
-        : "Conversations will not land anywhere until you pick a destination project under Advanced. Audit events are recorded either way."}
+      {`Conversations will land in ${chosen?.name ?? "the project picked under Advanced"}.`}
     </Text>
   );
 }
@@ -2107,57 +2109,6 @@ export const PARSER_FIELDS: Record<SourceType, FieldDef[]> = {
       group: "Cost",
     },
     {
-      // One app for both reads is what most admins actually set up; the
-      // split-credential arrangement (ADR-128 §21.1) stays one flip away for
-      // tenants whose finance approval is separate. The choice itself is
-      // persisted by the builder (`azureBillingUsesSameApp`), because it
-      // cannot be reconstructed from the stored credentials once they are
-      // sealed.
-      key: "azureBillingUsesSameApp",
-      label: "Use one app registration for everything",
-      placeholder: "",
-      hint: "On, the app registration under Conversation access also reads the subscription's bill — grant it the Cost Management Reader role on the subscription. Turn it off to give the bill its own app registration, holding that role and nothing else, so the finance approval never hands out conversation access.",
-      control: "switch",
-      defaultOn: AZURE_ONE_APP_DEFAULT_ON,
-      group: "Cost",
-    },
-    {
-      // The bill's OWN app registration: it holds Cost Management Reader on
-      // the subscription and nothing else, so the person who approves the
-      // finance grant hands out a permission that reads money and cannot read
-      // a conversation. Only offered once the admin has turned the one-app
-      // switch off — hidden, the copy in `copilotAzureBillingFrom` answers
-      // instead.
-      key: "credentialsBillingClientId",
-      label: "Billing app registration client ID",
-      placeholder: "00000000-0000-0000-0000-000000000000",
-      hint: "A second app registration, used only to read the subscription's bill. Grant it the Cost Management Reader role on the subscription — it needs no Dataverse or directory permission. If the first read fails right after granting, wait a couple of minutes: the role takes a moment to spread.",
-      secret: true,
-      group: "Cost",
-      visibleWhen: (values) => !azureOneAppChosen(values),
-    },
-    {
-      key: "credentialsBillingClientSecret",
-      label: "Billing app registration client secret",
-      placeholder: "(value pasted from the Azure portal)",
-      secret: true,
-      group: "Cost",
-      visibleWhen: (values) => !azureOneAppChosen(values),
-    },
-    {
-      // Declared by the customer, never inferred (ADR-128 §21.4): prepaid
-      // credit packs create no Azure resource, so the cost feed returns
-      // nothing — byte-for-byte what a quiet pay-as-you-go month returns.
-      // Only this declaration licenses the panel's prepaid sentence.
-      key: "azureBillingIsPrepaid",
-      label: "This Copilot runs on prepaid message packs",
-      placeholder: "",
-      hint: "Prepaid message packs never appear on the Azure bill. Turn this on and the spend panel will say so instead of showing an empty bill as if nothing ran.",
-      control: "switch",
-      defaultOn: false,
-      group: "Cost",
-    },
-    {
       key: "credentialsClientId",
       label: "App registration client ID",
       placeholder: "00000000-0000-0000-0000-000000000000",
@@ -2173,6 +2124,60 @@ export const PARSER_FIELDS: Record<SourceType, FieldDef[]> = {
       required: true,
       secret: true,
       group: "Conversation access",
+    },
+    {
+      // One app for both reads is what most admins actually set up; the
+      // split-credential arrangement (ADR-128 §21.1) stays one flip away for
+      // tenants whose finance approval is separate. The choice itself is
+      // persisted by the builder (`azureBillingUsesSameApp`), because it
+      // cannot be reconstructed from the stored credentials once they are
+      // sealed. Last on the form: it refers back to the credential above it,
+      // and most admins never touch it.
+      key: "azureBillingUsesSameApp",
+      label: "Use one app registration for everything",
+      placeholder: "",
+      hint: "On, the app registration under Conversation access also reads the subscription's bill — grant it the Cost Management Reader role on the subscription. Turn it off to give the bill its own app registration, holding that role and nothing else, so the finance approval never hands out conversation access.",
+      control: "switch",
+      defaultOn: AZURE_ONE_APP_DEFAULT_ON,
+      group: "Billing",
+    },
+    {
+      // The bill's OWN app registration: it holds Cost Management Reader on
+      // the subscription and nothing else, so the person who approves the
+      // finance grant hands out a permission that reads money and cannot read
+      // a conversation. Only offered once the admin has turned the one-app
+      // switch off — hidden, the copy in `copilotAzureBillingFrom` answers
+      // instead.
+      key: "credentialsBillingClientId",
+      label: "Billing app registration client ID",
+      placeholder: "00000000-0000-0000-0000-000000000000",
+      hint: "A second app registration, used only to read the subscription's bill. Grant it the Cost Management Reader role on the subscription — it needs no Dataverse or directory permission. If the first read fails right after granting, wait a couple of minutes: the role takes a moment to spread.",
+      secret: true,
+      group: "Billing",
+      visibleWhen: (values) => !azureOneAppChosen(values),
+    },
+    {
+      key: "credentialsBillingClientSecret",
+      label: "Billing app registration client secret",
+      placeholder: "(value pasted from the Azure portal)",
+      secret: true,
+      group: "Billing",
+      visibleWhen: (values) => !azureOneAppChosen(values),
+    },
+    {
+      // Declared by the customer, never inferred (ADR-128 §21.4): prepaid
+      // credit packs create no Azure resource, so the cost feed returns
+      // nothing — byte-for-byte what a quiet pay-as-you-go month returns.
+      // Only this declaration licenses the panel's prepaid sentence.
+      // Advanced because almost nobody runs on packs: the declaration is
+      // where an admin goes to disagree with the pay-as-you-go default.
+      key: "azureBillingIsPrepaid",
+      label: "This Copilot runs on prepaid message packs",
+      placeholder: "",
+      hint: "Prepaid message packs never appear on the Azure bill. Turn this on and the spend panel will say so instead of showing an empty bill as if nothing ran.",
+      control: "switch",
+      defaultOn: false,
+      advanced: true,
     },
     {
       key: "readSeats",

--- a/platform/app/ee/governance/dashboard/pages/inventory.tsx
+++ b/platform/app/ee/governance/dashboard/pages/inventory.tsx
@@ -52,7 +52,7 @@ import {
   RotateCw,
   Trash2,
 } from "lucide-react";
-import { type ReactNode, useEffect, useMemo, useState } from "react";
+import { Fragment, type ReactNode, useEffect, useMemo, useState } from "react";
 import { useSearchParams } from "react-router";
 import GovernanceLayout from "~/components/governance/GovernanceLayout";
 import { ToolCatalogPanel } from "~/components/governance/ToolCatalogPanel";
@@ -1756,6 +1756,22 @@ interface FieldDef {
    */
   advanced?: boolean;
   /**
+   * The sub-heading this field renders under, for a source whose fields
+   * serve more than one purpose. Consecutive fields sharing a group get one
+   * heading; a field without one renders as before. Purely presentational —
+   * grouping never changes what is saved, only the order it is asked in.
+   */
+  group?: string;
+  /**
+   * Whether the field is shown at all, given the sibling values. Absent means
+   * always. A hidden field's HELD value is deliberately not cleared (see
+   * `reconcileParserValues` — clearing a switch's siblings would discard what
+   * the admin typed on a mis-flip), so a builder reading a conditionally
+   * hidden field must decide from the controlling field, never from whether
+   * the hidden one still holds something.
+   */
+  visibleWhen?: (values: Record<string, string>) => boolean;
+  /**
    * How the field is rendered. Absent means a text input.
    *
    * A field only earns a `select` when its domain is closed and small enough
@@ -1974,6 +1990,28 @@ function anthropicBucketWidthOptions(
  */
 const READ_SEATS_DEFAULT_ON = true;
 
+/**
+ * Whether a new Copilot Studio source uses one app registration for both the
+ * conversation read and the bill, when nobody has said either way.
+ *
+ * On, because most admins set up one app and stop there (issue #7775). The
+ * split-credential arrangement stays the recommendation for tenants whose
+ * finance approval is separate (ADR-128 §21.1) — it is one switch away, not
+ * the price of entry. Same one-constant rule as `READ_SEATS_DEFAULT_ON`:
+ * the switch renders from it, the billing fields hide from it, and the
+ * builder saves from it, so an untouched form cannot show one arrangement
+ * and store another.
+ */
+const AZURE_ONE_APP_DEFAULT_ON = true;
+
+/** Whether the form's held values choose one app registration for everything. */
+function azureOneAppChosen(values: Record<string, string>): boolean {
+  return switchFieldIsOn({
+    value: values.azureBillingUsesSameApp,
+    defaultOn: AZURE_ONE_APP_DEFAULT_ON,
+  });
+}
+
 export const PARSER_FIELDS: Record<SourceType, FieldDef[]> = {
   // No parser-config fields for generic OTel sources today - the
   // receiver accepts any well-formed OTLP/HTTP body. (Earlier copy
@@ -2031,6 +2069,10 @@ export const PARSER_FIELDS: Record<SourceType, FieldDef[]> = {
       hint: "How often to call Purview Audit. Default 300s.",
     },
   ],
+  // Three groups, in the order admins care (issue #7775): where the
+  // environment lives, what it costs, and who may read its conversations.
+  // Grouping is presentational only — every key, secret flag and builder
+  // below is unchanged by it.
   copilot_studio_dataverse: [
     {
       key: "environmentUrl",
@@ -2038,6 +2080,7 @@ export const PARSER_FIELDS: Record<SourceType, FieldDef[]> = {
       placeholder: "https://org12345.crm.dynamics.com",
       hint: "From Power Platform admin centre → your environment → Environment URL. Environments served from a custom domain are not supported yet.",
       required: true,
+      group: "Connection",
     },
     {
       // Named `credentials*` on purpose, like the Databricks fields: the
@@ -2049,49 +2092,57 @@ export const PARSER_FIELDS: Record<SourceType, FieldDef[]> = {
       placeholder: "00000000-0000-0000-0000-000000000000",
       required: true,
       secret: true,
+      group: "Connection",
     },
     {
-      key: "credentialsClientId",
-      label: "App registration client ID",
-      placeholder: "00000000-0000-0000-0000-000000000000",
-      required: true,
-      secret: true,
-    },
-    {
-      key: "credentialsClientSecret",
-      label: "App registration client secret",
-      placeholder: "(value pasted from the Azure portal)",
-      hint: "The app needs a Dataverse application user in this environment with read access to the conversation transcript and bot tables. No directory permission is required.",
-      required: true,
-      secret: true,
-    },
-    {
-      // NOT a `credentials*` field, unlike the three above. A subscription id
-      // is a coordinate rather than a secret, and the adapter reads it off the
-      // config itself; naming it `credentialsAzureSubscriptionId` would bury
-      // it in the encrypted subtree where the config schema never looks.
+      // NOT a `credentials*` field, unlike the tenant id above. A
+      // subscription id is a coordinate rather than a secret, and the adapter
+      // reads it off the config itself; naming it
+      // `credentialsAzureSubscriptionId` would bury it in the encrypted
+      // subtree where the config schema never looks.
       key: "azureSubscriptionId",
       label: "Azure subscription ID (optional)",
       placeholder: "00000000-0000-0000-0000-000000000000",
-      hint: "Add this to also record what the environment costs each day, and fill in the billing app registration below. Leave it empty to record conversations only.",
+      hint: "Add this to also record what the environment costs each day. Leave it empty to record conversations only.",
+      group: "Cost",
     },
     {
-      // The bill's OWN app registration (ADR-128 §21.1): it holds Cost
-      // Management Reader on the subscription and nothing else, so the person
-      // who approves the finance grant hands out a permission that reads money
-      // and cannot read a conversation. The conversation credential above is
-      // never used for the bill — there is no fallback.
+      // One app for both reads is what most admins actually set up; the
+      // split-credential arrangement (ADR-128 §21.1) stays one flip away for
+      // tenants whose finance approval is separate. The choice itself is
+      // persisted by the builder (`azureBillingUsesSameApp`), because it
+      // cannot be reconstructed from the stored credentials once they are
+      // sealed.
+      key: "azureBillingUsesSameApp",
+      label: "Use one app registration for everything",
+      placeholder: "",
+      hint: "On, the app registration under Conversation access also reads the subscription's bill — grant it the Cost Management Reader role on the subscription. Turn it off to give the bill its own app registration, holding that role and nothing else, so the finance approval never hands out conversation access.",
+      control: "switch",
+      defaultOn: AZURE_ONE_APP_DEFAULT_ON,
+      group: "Cost",
+    },
+    {
+      // The bill's OWN app registration: it holds Cost Management Reader on
+      // the subscription and nothing else, so the person who approves the
+      // finance grant hands out a permission that reads money and cannot read
+      // a conversation. Only offered once the admin has turned the one-app
+      // switch off — hidden, the copy in `copilotAzureBillingFrom` answers
+      // instead.
       key: "credentialsBillingClientId",
       label: "Billing app registration client ID",
       placeholder: "00000000-0000-0000-0000-000000000000",
       hint: "A second app registration, used only to read the subscription's bill. Grant it the Cost Management Reader role on the subscription — it needs no Dataverse or directory permission. If the first read fails right after granting, wait a couple of minutes: the role takes a moment to spread.",
       secret: true,
+      group: "Cost",
+      visibleWhen: (values) => !azureOneAppChosen(values),
     },
     {
       key: "credentialsBillingClientSecret",
       label: "Billing app registration client secret",
       placeholder: "(value pasted from the Azure portal)",
       secret: true,
+      group: "Cost",
+      visibleWhen: (values) => !azureOneAppChosen(values),
     },
     {
       // Declared by the customer, never inferred (ADR-128 §21.4): prepaid
@@ -2104,6 +2155,24 @@ export const PARSER_FIELDS: Record<SourceType, FieldDef[]> = {
       hint: "Prepaid message packs never appear on the Azure bill. Turn this on and the spend panel will say so instead of showing an empty bill as if nothing ran.",
       control: "switch",
       defaultOn: false,
+      group: "Cost",
+    },
+    {
+      key: "credentialsClientId",
+      label: "App registration client ID",
+      placeholder: "00000000-0000-0000-0000-000000000000",
+      required: true,
+      secret: true,
+      group: "Conversation access",
+    },
+    {
+      key: "credentialsClientSecret",
+      label: "App registration client secret",
+      placeholder: "(value pasted from the Azure portal)",
+      hint: "The app needs a Dataverse application user in this environment with read access to the conversation transcript and bot tables. No directory permission is required.",
+      required: true,
+      secret: true,
+      group: "Conversation access",
     },
     {
       key: "readSeats",
@@ -2692,14 +2761,22 @@ export function buildCopilotStudioDataversePullConfig(
  * COMPLETE is judged server-side (`assertAzureBillHasItsOwnCredential`),
  * whose refusal names what is missing; the builder's job is only to not
  * manufacture values.
+ *
+ * With one app chosen (the form's default), the billing slots are COPIES of
+ * the conversation pair, decided here at save time from the switch alone —
+ * never from leftover billing values the form may still hold from a two-app
+ * detour, which the form deliberately never clears. The choice itself is
+ * written as `azureBillingUsesSameApp`, and only beside a subscription (same
+ * rule as the prepaid flag): it is the only durable record — once the
+ * credentials are sealed, equal-looking pairs cannot be told apart from a
+ * deliberate second app with the same values.
  */
 function copilotAzureBillingFrom(p: Record<string, string>): {
   config: Record<string, unknown>;
   credentials: Record<string, string>;
 } {
   const azureSubscriptionId = (p.azureSubscriptionId ?? "").trim();
-  const billingClientId = (p.credentialsBillingClientId ?? "").trim();
-  const billingClientSecret = (p.credentialsBillingClientSecret ?? "").trim();
+  const oneApp = azureOneAppChosen(p);
 
   const config: Record<string, unknown> = {};
   if (azureSubscriptionId) {
@@ -2708,14 +2785,49 @@ function copilotAzureBillingFrom(p: Record<string, string>): {
       value: p.azureBillingIsPrepaid,
       defaultOn: false,
     });
+    config.azureBillingUsesSameApp = oneApp;
   }
 
+  return {
+    config,
+    credentials: copilotBillingCredentialsFrom({
+      p,
+      oneApp,
+      hasBillToRead: azureSubscriptionId.length > 0,
+    }),
+  };
+}
+
+/**
+ * Which values land in the billing credential slots, given the one-app
+ * choice. One app: the conversation pair, and only when there is a bill to
+ * read — never a speculative credential, and never the leftover billing
+ * values a two-app detour may have left in form state. Two apps: what the
+ * admin typed in the billing fields, exactly as before the switch existed.
+ */
+function copilotBillingCredentialsFrom({
+  p,
+  oneApp,
+  hasBillToRead,
+}: {
+  p: Record<string, string>;
+  oneApp: boolean;
+  hasBillToRead: boolean;
+}): Record<string, string> {
+  if (oneApp && !hasBillToRead) return {};
+  const source = oneApp
+    ? { id: p.credentialsClientId, secret: p.credentialsClientSecret }
+    : {
+        id: p.credentialsBillingClientId,
+        secret: p.credentialsBillingClientSecret,
+      };
+
+  const id = (source.id ?? "").trim();
+  const secret = (source.secret ?? "").trim();
   const credentials: Record<string, string> = {};
-  if (billingClientId) credentials.billingClientId = billingClientId;
-  if (billingClientSecret) {
-    credentials.billingClientSecret = billingClientSecret;
-  }
-  return { config, credentials };
+  if (id) credentials.billingClientId = id;
+  if (secret) credentials.billingClientSecret = secret;
+  return credentials;
 }
 
 /**
@@ -3126,8 +3238,9 @@ export function ParserConfigFields({
   }, [sourceType, values, onChange]);
 
   const fields = PARSER_FIELDS[sourceType];
-  const primaryFields = fields.filter((f) => !f.advanced);
-  const advancedFields = fields.filter((f) => f.advanced);
+  const isVisible = (f: FieldDef) => f.visibleWhen?.(values) ?? true;
+  const primaryFields = fields.filter((f) => !f.advanced && isVisible(f));
+  const advancedFields = fields.filter((f) => f.advanced && isVisible(f));
   // Extras alone are reason enough to render: a source type with no
   // parser fields of its own still has a cadence to offer.
   if (fields.length === 0 && !advancedExtras) return null;
@@ -3139,15 +3252,26 @@ export function ParserConfigFields({
           Source-specific configuration
         </Text>
       )}
-      {primaryFields.map((f) => (
-        <ParserConfigField
-          key={f.key}
-          field={f}
-          values={values}
-          onChange={onChange}
-          mode={mode}
-          readOnly={isReadOnly(f.key)}
-        />
+      {primaryFields.map((f, i) => (
+        <Fragment key={f.key}>
+          {f.group && f.group !== primaryFields[i - 1]?.group && (
+            <Text
+              fontSize="xs"
+              fontWeight="semibold"
+              color="fg.muted"
+              pt={i > 0 ? 2 : 0}
+            >
+              {f.group}
+            </Text>
+          )}
+          <ParserConfigField
+            field={f}
+            values={values}
+            onChange={onChange}
+            mode={mode}
+            readOnly={isReadOnly(f.key)}
+          />
+        </Fragment>
       ))}
       {(advancedFields.length > 0 || advancedExtras) && (
         <AdvancedSettingsGroup>
@@ -3216,11 +3340,16 @@ const PULL_CONFIG_OWNED_FIELDS: Partial<Record<SourceType, readonly string[]>> =
     // the builder converts the switch's string to the boolean the adapter's
     // schema demands, and it also OMITS the field when no subscription is
     // named — the raw form string winning the merge would undo both.
+    // `azureBillingUsesSameApp` is owned for both of those reasons AND
+    // because an untouched switch holds nothing at all: the flag is the only
+    // durable record of the one-app choice, so it must come from the builder,
+    // which writes the declared default explicitly.
     copilot_studio_dataverse: [
       "environmentUrl",
       "botIds",
       "azureSubscriptionId",
       "azureBillingIsPrepaid",
+      "azureBillingUsesSameApp",
       "readSeats",
     ],
   };

--- a/platform/app/ee/governance/services/pullers/copilotStudioDataverse.puller.ts
+++ b/platform/app/ee/governance/services/pullers/copilotStudioDataverse.puller.ts
@@ -164,6 +164,19 @@ export const copilotStudioDataversePullConfigSchema = z.object({
    */
   azureBillingIsPrepaid: z.boolean().optional(),
   /**
+   * Whether the billing credential pair is a copy of the bot's, made by the
+   * create form's one-app switch (ADR-128 §21.1 form default), or a second
+   * app registration of its own.
+   *
+   * The adapter never reads this field; the billing token is minted from
+   * `billingClientId`/`billingClientSecret` either way. It exists because it
+   * is the only durable record of the choice — sealed credentials cannot be
+   * compared later — and the edit path (#7777) will need it to render the
+   * switch as the admin left it. Optional because a source without a
+   * subscription records no choice, and sources predate the switch.
+   */
+  azureBillingUsesSameApp: z.boolean().optional(),
+  /**
    * Whether to read the tenant's seat licences beside the conversations.
    *
    * On unless switched off. Seats are the half of the money the conversations

--- a/specs/ai-gateway/governance/ingestion-sources.feature
+++ b/specs/ai-gateway/governance/ingestion-sources.feature
@@ -216,18 +216,16 @@ Feature: IngestionSource — admin configuration of cross-platform feeds
         not be readable in the explorer until a destination is set
 
     @integration
-    Scenario: The drawer says where conversations will go without opening Advanced
-      An admin who never opens the group never reads what the picker
-      says inside it, so the drawer states the outcome in plain sight
-      rather than leaving the silent default silent.
+    Scenario: The drawer names the destination once one is picked
+      The field tooltips already say what the silent default means, so
+      the drawer stays quiet until there is a choice to confirm — a
+      standing warning above the fold was noise beside them.
 
       Given the admin is composing a "Databricks AI/BI Genie" source and
         has not expanded "Advanced"
-      Then the drawer says that its conversations will not land anywhere
-        until a destination is picked, and that its audit events are
-        recorded either way
+      Then the drawer shows no destination line yet
       When they expand "Advanced" and pick a destination
-      Then that same line names the project the conversations will land in
+      Then a line names the project the conversations will land in
       And a source type that pulls counts rather than conversations shows
         no such line, because it routes none
 

--- a/specs/governance/copilot-studio-form-controls.feature
+++ b/specs/governance/copilot-studio-form-controls.feature
@@ -1,0 +1,105 @@
+# SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+Feature: The Copilot Studio create form reads by purpose, and one app registration is the default
+  As an organization admin adding a Copilot Studio source
+  I want the fields grouped by what they are for, with one credential unless I
+  choose two
+  So that the common setup is one app registration pasted once, and the
+  least-privilege setup with a separate billing app stays one switch away
+
+  What this file deliberately does NOT restate (already owned elsewhere):
+  a subscription claim demanding a billing credential at save time, the
+  bill never borrowing the conversation credential at run time, and the
+  prepaid declaration (azure-billing-identity.feature). Secrets never
+  echoing back to the browser is generic. Read seats stay in the Advanced
+  group by their own documented decision — the usage group here is the
+  conversation credential, not the seats switch.
+
+  Everything edit-mode is out of scope: this source type is not editable
+  today, and making it so is issue #7777 (the sealed-credential envelope
+  question). The one-app choice is persisted on create precisely so that
+  work can restore it later without guessing from sealed secrets.
+
+  Background:
+    Given an organization with the ingestionSources:manage permission
+    And the source composer is open on the copilot_studio_dataverse adapter
+
+  Rule: The form is three purposes, not one list
+
+    @unit
+    Scenario: The fields stand in three labelled groups
+      When the admin looks at the form
+      Then the connection fields stand first under their own heading
+      And the cost fields stand second under their own heading
+      And the conversation credential stands third under its own heading
+
+  Rule: One app registration is the default, a second one is a choice
+
+    @unit
+    Scenario: A new source starts with one app registration for everything
+      When the admin opens the form for a new source
+      Then the one-app switch is on
+      And no billing credential field is shown
+
+    @unit
+    Scenario: With one app chosen, the saved bill credential is the conversation one
+      Given the one-app switch is on
+      And the admin typed the conversation credential
+      And the admin named an Azure subscription
+      When the admin saves the source
+      Then the saved billing client ID equals the conversation client ID
+      And the saved billing secret equals the conversation secret
+      # The copy happens in the form, from values the admin just typed —
+      # never as a server fallback, which azure-billing-identity.feature
+      # forbids. On create nothing is sealed, so the copy is always whole.
+
+    @unit
+    Scenario: Turning the switch off reveals the billing credential fields
+      Given the one-app switch is on
+      When the admin turns the one-app switch off
+      Then the billing credential fields appear
+      And what the admin types there is what is saved for the bill
+
+    @unit
+    Scenario: A source claiming no subscription saves no billing credential
+      Given the one-app switch is on
+      And the admin typed the conversation credential
+      And no Azure subscription is named
+      When the admin saves the source
+      Then the saved configuration carries no billing credential
+      # The switch decides which credential reads the bill, never whether
+      # a bill is read. That is the subscription's job alone.
+
+  Rule: The choice is written down, not left to be reconstructed from secrets
+
+    @unit
+    Scenario: The one-app choice is saved alongside the configuration
+      Given the admin typed the conversation credential
+      And the admin named an Azure subscription
+      When the admin saves the source with the one-app switch on
+      Then the saved configuration records that one app was chosen
+      # Stored secrets are sealed on any future read — equality between
+      # the billing pair and the conversation pair can never be checked
+      # after the fact. The flag is the only durable record of the choice,
+      # and the edit work in #7777 will read it instead of guessing.
+
+    @unit
+    Scenario: Choosing two apps is recorded too
+      Given the admin typed the conversation credential
+      And the admin named an Azure subscription
+      And the admin typed a billing credential of its own
+      When the admin saves the source with the one-app switch off
+      Then the saved configuration records that two apps were chosen
+
+  Rule: The copy is made at save time, from what the form holds now
+
+    @unit
+    Scenario: Billing values typed before flipping back to one app are not saved
+      Given the one-app switch was turned off
+      And the admin typed a billing credential of its own
+      When the admin turns the one-app switch back on
+      And saves the source with a subscription named
+      Then the saved billing client ID equals the conversation client ID
+      And the saved billing secret equals the conversation secret
+      # The form deliberately never erases what an admin typed when a
+      # switch hides it — flipping back must not resurrect it either. The
+      # copy is decided at save time by the switch, not by leftover state.

--- a/specs/governance/copilot-studio-form-controls.feature
+++ b/specs/governance/copilot-studio-form-controls.feature
@@ -23,14 +23,20 @@ Feature: The Copilot Studio create form reads by purpose, and one app registrati
     Given an organization with the ingestionSources:manage permission
     And the source composer is open on the copilot_studio_dataverse adapter
 
-  Rule: The form is three purposes, not one list
+  Rule: The form reads by purpose, not as one list
 
     @unit
-    Scenario: The fields stand in three labelled groups
+    Scenario: The fields stand in labelled groups, choices last
       When the admin looks at the form
       Then the connection fields stand first under their own heading
-      And the cost fields stand second under their own heading
+      And the subscription claim stands second under the cost heading
       And the conversation credential stands third under its own heading
+      And the billing choice stands last under its own heading
+      And the prepaid declaration sits in the Advanced group
+      # Required paste-work first, choices whose default already answers
+      # last: the billing switch refers back to the conversation credential
+      # above it, and the prepaid declaration is a disagreement with the
+      # pay-as-you-go default, which is what Advanced is for.
 
   Rule: One app registration is the default, a second one is a choice
 


### PR DESCRIPTION
## Why

The Copilot Studio create form grew by accretion into one flat list where the two optional billing credential fields sit exposed beside the required ones, reading as mandatory homework. Setting up a second app registration is real Azure admin work; a customer who would happily reuse their bot's app for the bill sees two more credential fields and stalls. And the split-credential design (#7745) is a *recommendation*, not a requirement — the guard never demanded the pairs differ.

Closes #7775

## What changed

- **The form reads by purpose, not as one list.** Connection, Cost, Conversation access, then Billing, each under its own heading — required paste-work first, choices last. The prepaid declaration moves into Advanced (it's a disagreement with the pay-as-you-go default, which is what Advanced is for).
- **One app registration is the default.** A switch — "Use one app registration for everything", on by default, last on the form — hides the billing credential pair. Flipping it off reveals the pair for customers who want the finance grant on its own signature.
- **The standing destination warning is gone.** The create drawer's "conversations will not land anywhere…" line duplicated what the field tooltips already say; the drawer now only speaks once a destination is picked, to confirm the choice (`ingestion-sources.feature` scenario retitled accordingly).
- **The copy is made at save time, from what the form holds now.** With the switch on, the builder writes the conversation pair into the billing slots as an explicit copy — not a fallback at read time. Token paths stay separate; the no-borrow invariant from #7745 is untouched. Values typed into the billing fields before flipping the switch back are ignored, not resurrected.
- **The choice is recorded.** `azureBillingUsesSameApp` is written beside the claimed subscription as an explicit boolean (an untouched switch holds nothing in form state, so the builder owns the default) and declared in the pull config schema like every other stored key. Nothing reads it at run time; the edit path (#7777) will, because sealed credentials can't answer "same or different?" later.
- **Grouping is a field attribute, not new machinery.** `FieldDef` gained `group` (consecutive fields sharing one heading) and `visibleWhen` (a predicate on current form values); the renderer applies both generically, so other sources can adopt groups without touching the renderer again.

ADR-128 v3.7 records the default flip and why it doesn't weaken §21: the split stays the recommendation, one switch-flip away.

Spec: `specs/governance/copilot-studio-form-controls.feature` — 8 scenarios, all bound to tests by title.

## Test plan

- Unit (builder): untouched default copies the conversation pair into the billing slots; the flag survives the adapter's own strip-mode parser (asserted on the parsed value — `not.toThrow` on a strip-mode schema proves nothing); leftover billing values typed before flipping back are overridden; no subscription → no billing keys and no flag; switch off + typed pair → saved as typed with flag false; the raw switch string never leaks into the config.
- Component (screen): the four headings render in order exactly once; the prepaid switch sits behind Advanced; the one-app switch starts checked with the billing fields absent; flipping it reveals them; the destination line stays absent until a destination is picked.
- The scenarios survived two independent adversarial refutation rounds; round two's kills (builder-owned flag, toggle-dance ignore rule, ADR contradiction note) are absorbed as tests and the ADR entry.

## Deployment Impact

None operationally. Frontend form change plus one optional key declared in the pull config schema — the adapter never reads it, so no pull behavior changes. No migration, no env var, no flag. Existing sources are untouched: the flag is optional precisely because sources predate the switch.

## Anything surprising?

- **The edit path for this source is already broken** (encrypted-envelope hazard, predates this PR) and this PR doesn't fix it — the switch renders correctly on create only. #7777 owns the edit path and will read the recorded flag.
- **Not browser-verified.** No dev stack serves this worktree. The observable claims — three headings, switch default, reveal-on-flip — are covered by component tests through the real field-rendering path.
- Review's convention scan caught two things now fixed in-branch: a spec scenario left unbound by a mistitled annotation, and the flag missing from the schema (which also made one test assertion vacuous — strip-mode zod never throws on unknown keys).
- One pre-existing lint complexity warning on an untouched HTTP builder remains; the new-violations gate is clean.

