### PR TITLE
Dashboard widgets 3/4: reserved param rows + {param:Type} SQL highlighting

### DIFF
--- a/platform/app/src/features/custom-chart-playground/DashboardWidgetCodeEditor.tsx
+++ b/platform/app/src/features/custom-chart-playground/DashboardWidgetCodeEditor.tsx
@@ -8,10 +8,12 @@
  */
 
 import { Box } from "@chakra-ui/react";
-import type { BeforeMount } from "@monaco-editor/react";
+import type { BeforeMount, OnMount } from "@monaco-editor/react";
 import type { editor } from "monaco-editor";
+import { useEffect, useRef } from "react";
 
 import { useColorMode } from "~/components/ui/color-mode";
+import { RESERVED_PARAMETERS } from "~/server/analytics/dashboardWidgetDefinition";
 import dynamic from "~/utils/compat/next-dynamic";
 
 const MonacoEditor = dynamic(() => import("@monaco-editor/react"), {
@@ -57,19 +59,108 @@ const configureTypeScriptDefaults: BeforeMount = (monaco) => {
   });
 };
 
+/** Matches ClickHouse bound-param tokens like `{period_start:DateTime}`. */
+const BOUND_PARAM_PATTERN = /\{([A-Za-z_][A-Za-z0-9_]*):[A-Za-z0-9_]+\}/g;
+
+const RESERVED_PARAM_NAMES = new Set(RESERVED_PARAMETERS.map((p) => p.name));
+
+const PARAM_TOKEN_CLASS_RESERVED = "lw-sql-param-reserved";
+const PARAM_TOKEN_CLASS_DECLARED = "lw-sql-param-declared";
+const PARAM_TOKEN_CLASS_UNDECLARED = "lw-sql-param-undeclared";
+
+/**
+ * One shared stylesheet for the three token classes below — injected once,
+ * since decorations only carry a className, not inline colors. Colors are
+ * fixed (not theme-derived) because they must read clearly on both the
+ * `vs` and `vs-dark` Monaco themes this editor switches between.
+ */
+function ensureParamTokenStyles() {
+  const id = "lw-sql-param-token-styles";
+  if (document.getElementById(id)) return;
+  const style = document.createElement("style");
+  style.id = id;
+  style.textContent = `
+    .${PARAM_TOKEN_CLASS_RESERVED} { color: #3182CE; font-weight: 600; }
+    .${PARAM_TOKEN_CLASS_DECLARED} { color: #805AD5; font-weight: 600; }
+    .${PARAM_TOKEN_CLASS_UNDECLARED} { color: #DD6B20; font-weight: 600; text-decoration: underline wavy; }
+  `;
+  document.head.appendChild(style);
+}
+
 interface DashboardWidgetCodeEditorProps {
   /** Monaco's "typescript" language id highlights JSX/TSX too. */
   language: "typescript" | "sql";
   value: string;
   onChange: (value: string) => void;
+  /**
+   * Names of this query's user-declared parameters — only used for `sql` to
+   * color `{name:Type}` tokens as reserved / declared / undeclared. Reserved
+   * names always come from `RESERVED_PARAMETERS`, not this list.
+   */
+  declaredParamNames?: string[];
 }
 
 export function DashboardWidgetCodeEditor({
   language,
   value,
   onChange,
+  declaredParamNames,
 }: DashboardWidgetCodeEditorProps) {
   const { colorMode } = useColorMode();
+  const editorRef = useRef<editor.IStandaloneCodeEditor | null>(null);
+  const decorationsRef = useRef<editor.IEditorDecorationsCollection | null>(
+    null,
+  );
+
+  const updateDecorations = useRef(() => {});
+  updateDecorations.current = () => {
+    const ed = editorRef.current;
+    if (!ed || language !== "sql") return;
+    const model = ed.getModel();
+    if (!model) return;
+
+    const declared = new Set(declaredParamNames ?? []);
+    const text = model.getValue();
+    const newDecorations: editor.IModelDeltaDecoration[] = [];
+    for (const match of text.matchAll(BOUND_PARAM_PATTERN)) {
+      const name = match[1];
+      if (!name || match.index === undefined) continue;
+      const startPos = model.getPositionAt(match.index);
+      const endPos = model.getPositionAt(match.index + match[0].length);
+      const className = RESERVED_PARAM_NAMES.has(name)
+        ? PARAM_TOKEN_CLASS_RESERVED
+        : declared.has(name)
+          ? PARAM_TOKEN_CLASS_DECLARED
+          : PARAM_TOKEN_CLASS_UNDECLARED;
+      newDecorations.push({
+        range: {
+          startLineNumber: startPos.lineNumber,
+          startColumn: startPos.column,
+          endLineNumber: endPos.lineNumber,
+          endColumn: endPos.column,
+        },
+        options: { inlineClassName: className },
+      });
+    }
+
+    if (!decorationsRef.current) {
+      decorationsRef.current = ed.createDecorationsCollection(newDecorations);
+    } else {
+      decorationsRef.current.set(newDecorations);
+    }
+  };
+
+  // Re-run whenever the value or the declared-param list changes (typing a
+  // param name in the params editor should recolor tokens without an edit).
+  useEffect(() => {
+    updateDecorations.current();
+  }, [value, declaredParamNames, language]);
+
+  const handleMount: OnMount = (mountedEditor) => {
+    ensureParamTokenStyles();
+    editorRef.current = mountedEditor;
+    updateDecorations.current();
+  };
 
   return (
     <MonacoEditor
@@ -78,6 +169,7 @@ export function DashboardWidgetCodeEditor({
       value={value}
       theme={colorMode === "dark" ? "vs-dark" : "vs"}
       onChange={(v: string | undefined) => onChange(v ?? "")}
+      onMount={handleMount}
       options={EDITOR_OPTIONS}
       beforeMount={
         language === "typescript" ? configureTypeScriptDefaults : undefined

--- a/platform/app/src/features/custom-chart-playground/DashboardWidgetQueryParamsEditor.tsx
+++ b/platform/app/src/features/custom-chart-playground/DashboardWidgetQueryParamsEditor.tsx
@@ -6,6 +6,7 @@
  */
 
 import {
+  Badge,
   Box,
   Button,
   HStack,
@@ -16,7 +17,10 @@ import {
 } from "@chakra-ui/react";
 import { Plus, Trash2 } from "lucide-react";
 
-import type { DashboardWidgetQueryParameterDeclaration } from "~/server/analytics/dashboardWidgetDefinition";
+import {
+  RESERVED_PARAMETERS,
+  type DashboardWidgetQueryParameterDeclaration,
+} from "~/server/analytics/dashboardWidgetDefinition";
 
 const PARAM_TYPES: DashboardWidgetQueryParameterDeclaration["type"][] = [
   "string",
@@ -42,6 +46,37 @@ function defaultInputValue(
   value: DashboardWidgetQueryParameterDeclaration["default"],
 ): string {
   return value === undefined ? "" : String(value);
+}
+
+/** One reserved param, shown read-only above user-declared params. */
+function ReservedParamRow({
+  reserved,
+}: {
+  reserved: (typeof RESERVED_PARAMETERS)[number];
+}) {
+  return (
+    <HStack gap={2} title={reserved.description}>
+      <Text
+        fontSize="12px"
+        fontFamily="mono"
+        flex={1}
+        minWidth={0}
+        truncate
+        color="fg.muted"
+      >
+        {reserved.name}
+      </Text>
+      <Text fontSize="12px" color="fg.muted" width="90px" flexShrink={0}>
+        {reserved.type}
+      </Text>
+      <Badge size="sm" colorPalette="gray" flexShrink={0}>
+        built-in
+      </Badge>
+      {/* Spacer matching the remove IconButton's width so name/type columns
+          still line up with the editable rows below. */}
+      <Box width="26px" flexShrink={0} />
+    </HStack>
+  );
 }
 
 interface ParamRowProps {
@@ -137,9 +172,15 @@ export function DashboardWidgetQueryParamsEditor({
       <Text fontSize="11px" fontWeight="600" color="fg.muted" marginBottom={1}>
         Parameters
       </Text>
+      {RESERVED_PARAMETERS.map((reserved) => (
+        <Box key={reserved.name} marginBottom={1}>
+          <ReservedParamRow reserved={reserved} />
+        </Box>
+      ))}
       {params.length === 0 && (
         <Text fontSize="12px" color="fg.muted" marginBottom={1}>
-          None declared — LW.query calls for this query may pass no params.
+          No custom parameters declared — LW.query calls for this query may
+          omit them.
         </Text>
       )}
       {params.map((param, index) => (

--- a/platform/app/src/features/custom-chart-playground/DashboardWidgetQueryRow.tsx
+++ b/platform/app/src/features/custom-chart-playground/DashboardWidgetQueryRow.tsx
@@ -135,6 +135,9 @@ export function DashboardWidgetQueryRow({
                   language="sql"
                   value={query.sql}
                   onChange={(sql) => onChange({ ...query, sql })}
+                  declaredParamNames={(query.parameters ?? []).map(
+                    (p) => p.name,
+                  )}
                 />
               </Box>
 

--- a/platform/app/src/server/analytics/dashboardWidgetDefinition.ts
+++ b/platform/app/src/server/analytics/dashboardWidgetDefinition.ts
@@ -46,12 +46,35 @@ const MAX_CODE_LENGTH = 200_000;
  * the `lwql-charts` skill's SQL does; declaring a parameter under one of
  * these names would silently never receive the value a caller passes, since
  * the executor's own binding always wins.
+ *
+ * Exported (not just the name set below) so the client-side parameters editor
+ * can list these as built-in rows without hand-duplicating the names, types,
+ * or ClickHouse binding, and without importing anything server-only — this
+ * module is already safe for the client (zod + constants only).
  */
-const RESERVED_PARAMETER_NAMES = new Set([
-  "period_start",
-  "period_end",
-  "period_granularity_seconds",
-]);
+export const RESERVED_PARAMETERS = [
+  {
+    name: "period_start",
+    type: "DateTime",
+    description:
+      "Start of the dashboard's selected time range — bound automatically.",
+  },
+  {
+    name: "period_end",
+    type: "DateTime",
+    description: "End of the selected time range (exclusive).",
+  },
+  {
+    name: "period_granularity_seconds",
+    type: "UInt32",
+    description:
+      "Suggested bucket size in seconds for the selected range.",
+  },
+] as const;
+
+const RESERVED_PARAMETER_NAMES = new Set(
+  RESERVED_PARAMETERS.map((p) => p.name),
+);
 
 /**
  * The JS types a bound parameter's value may take. Scalars only, matching


### PR DESCRIPTION
Reserved params (period_start/period_end/period_granularity_seconds) shown as built-in read-only rows; Monaco decorations for bound-param tokens (reserved/declared/undeclared).

🤖 Generated with [Claude Code](https://claude.com/claude-code)