### PR TITLE
fix(export): route every CSV writer through the formula guard

### DIFF
--- a/platform/app/src/components/batch-evaluation-results/__tests__/csvExport.test.ts
+++ b/platform/app/src/components/batch-evaluation-results/__tests__/csvExport.test.ts
@@ -1350,3 +1350,57 @@ describe("given two targets stored under the same name", () => {
     });
   });
 });
+
+/**
+ * A batch evaluation exports the dataset a person uploaded and the reasoning a
+ * model wrote, into a file whose whole purpose is to be opened in a
+ * spreadsheet. A cell opening with `=` is a formula Excel and Sheets execute,
+ * and RFC 4180 quoting does not prevent that — quoting protects the CSV
+ * grammar, not the reader. The guard belongs where the string is serialized,
+ * not in every builder above it.
+ *
+ * `buildCsvData` is deliberately left uncovered here: it returns the values as
+ * they are, and its callers assert on content. The apostrophe appears when the
+ * file is written.
+ *
+ * @see src/utils/csvFormulaGuard.ts
+ */
+describe("spreadsheet formula injection", () => {
+  const FORMULA = "=cmd|' /c calc'!A1";
+
+  it("defuses a formula in a dataset cell", () => {
+    const csv = generateCsvContent(
+      createMinimalData({
+        datasetColumns: [{ name: "input", hasImages: false }],
+        rows: [{ index: 0, datasetEntry: { input: FORMULA }, targets: {} }],
+      }),
+    );
+
+    expect(csv).toContain(`'${FORMULA}`);
+  });
+
+  it("defuses a formula in a column heading someone named", () => {
+    const csv = generateCsvContent(
+      createMinimalData({
+        datasetColumns: [{ name: FORMULA, hasImages: false }],
+        rows: [],
+      }),
+    );
+
+    // The heading is slugified on the way in, so the assertion is on the
+    // leading apostrophe rather than on the name as it was typed.
+    expect(csv.split("\r\n")[0]).toContain("'=cmd");
+  });
+
+  it("leaves a negative number alone so a number column stays numeric", () => {
+    const csv = generateCsvContent(
+      createMinimalData({
+        datasetColumns: [{ name: "score", hasImages: false }],
+        rows: [{ index: 0, datasetEntry: { score: "-5" }, targets: {} }],
+      }),
+    );
+
+    expect(csv).not.toContain("'-5");
+    expect(csv).toContain("-5");
+  });
+});

--- a/platform/app/src/components/batch-evaluation-results/csvExport.ts
+++ b/platform/app/src/components/batch-evaluation-results/csvExport.ts
@@ -12,6 +12,7 @@
 import numeral from "numeral";
 import Parse from "papaparse";
 
+import { neutralizeFormula, neutralizeRows } from "~/utils/csvFormulaGuard";
 import type {
   BatchComparisonColumn,
   BatchComparisonVerdict,
@@ -338,13 +339,19 @@ export const buildCsvData = (
 };
 
 /**
- * Generate CSV content string from BatchEvaluationData
+ * Generate CSV content string from BatchEvaluationData.
+ *
+ * The formula guard is applied here rather than in `buildCsvData`: the builders
+ * return the values as they are so callers can assert on content, and the
+ * apostrophe belongs to the file, not to the data. Both halves need it — the
+ * dataset columns and the evaluator names in the header row are named by
+ * whoever set the experiment up.
  */
 export const generateCsvContent = (data: BatchEvaluationData): string => {
   const { headers, rows } = buildCsvData(data);
   return Parse.unparse({
-    fields: headers,
-    data: rows,
+    fields: headers.map(neutralizeFormula),
+    data: neutralizeRows(rows),
   });
 };
 

--- a/platform/app/src/components/datasets/editor/DatasetEditorTable.tsx
+++ b/platform/app/src/components/datasets/editor/DatasetEditorTable.tsx
@@ -33,7 +33,6 @@ import {
   getCoreRowModel,
   useReactTable,
 } from "@tanstack/react-table";
-import Parse from "papaparse";
 import {
   type ReactNode,
   useCallback,
@@ -57,6 +56,7 @@ import type {
   DatasetRecordEntry,
 } from "~/server/datasets/types";
 import { api } from "~/utils/api";
+import { downloadCsv } from "~/utils/downloadCsv";
 import { AddRowsFromCSVModal } from "../AddRowsFromCSVModal";
 import {
   type AutosaveState,
@@ -617,24 +617,15 @@ export function DatasetEditorTable({
       }
     }
 
-    const csv = Parse.unparse({
+    downloadCsv({
       fields: exportColumns.map((col) => col.name),
-      data: exportRecords.map((record) =>
+      rows: exportRecords.map((record) =>
         exportColumns.map((col) => record[col.name] ?? ""),
       ),
+      fileName: `${
+        datasetName?.toLowerCase().replace(/ /g, "_") ?? "draft_dataset"
+      }.csv`,
     });
-
-    const url = window.URL.createObjectURL(new Blob([csv]));
-    const link = document.createElement("a");
-    link.href = url;
-    const fileName = `${
-      datasetName?.toLowerCase().replace(/ /g, "_") ?? "draft_dataset"
-    }.csv`;
-    link.setAttribute("download", fileName);
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-    window.URL.revokeObjectURL(url);
   }, [columns, datasetId, datasetName, downloadDataset, project?.id, store]);
 
   // "Add row" only appends an empty row at the bottom. It must not steal focus

--- a/platform/app/src/components/experiments/BatchEvaluation.tsx
+++ b/platform/app/src/components/experiments/BatchEvaluation.tsx
@@ -14,7 +14,6 @@ import {
 } from "@chakra-ui/react";
 import type { JsonObject } from "@prisma/client/runtime/client";
 import numeral from "numeral";
-import Parse from "papaparse";
 import { Download } from "react-feather";
 import type {
   BatchEvaluation,
@@ -22,6 +21,7 @@ import type {
   Project,
 } from "~/generated/prisma/client";
 import { api } from "~/utils/api";
+import { downloadCsv } from "~/utils/downloadCsv";
 import { Tooltip } from "../../components/ui/tooltip";
 import { formatMoney } from "../../utils/formatMoney";
 
@@ -91,20 +91,11 @@ export default function BatchEvaluation({
       ]);
     });
 
-    const csv = Parse.unparse({
-      fields: fields,
-      data: csvData,
+    downloadCsv({
+      fields,
+      rows: csvData,
+      fileName: `${experiment?.slug}.csv`,
     });
-
-    const url = window.URL.createObjectURL(new Blob([csv]));
-
-    const link = document.createElement("a");
-    link.href = url;
-    const fileName = `${experiment?.slug}.csv`;
-    link.setAttribute("download", fileName);
-    document.body.appendChild(link);
-    link.click();
-    link.remove();
   };
 
   const totalCost = evaluations.data?.reduce((acc, curr) => acc + curr.cost, 0);

--- a/platform/app/src/components/experiments/BatchEvaluationV2/BatchEvaluationV2EvaluationResults.tsx
+++ b/platform/app/src/components/experiments/BatchEvaluationV2/BatchEvaluationV2EvaluationResults.tsx
@@ -9,11 +9,11 @@ import {
   VStack,
 } from "@chakra-ui/react";
 import numeral from "numeral";
-import Parse from "papaparse";
 import React, { useEffect, useRef, useState } from "react";
 import { Download, ExternalLink, MoreVertical } from "react-feather";
 import { showErrorToast } from "~/features/errors";
 import type { Experiment, Project } from "~/generated/prisma/client";
+import { downloadCsv } from "~/utils/downloadCsv";
 import { Menu } from "../../../components/ui/menu";
 import type { ExperimentRunWithItems } from "../../../server/experiments-v3/services/types";
 import { api } from "../../../utils/api";
@@ -309,15 +309,6 @@ export const useBatchEvaluationDownloadCSV = ({
       },
     );
 
-    const csvBlob = Parse.unparse({
-      fields: csvHeaders,
-      data: csvData,
-    });
-
-    const url = window.URL.createObjectURL(new Blob([csvBlob]));
-
-    const link = document.createElement("a");
-    link.href = url;
     // Non-null per the `isDownloadCSVEnabled` guard above (the early
     // throw on line 208 ensures `run.data` is populated by the time we
     // get here). `getRun` returns `ExperimentRunWithItems | null` since
@@ -326,11 +317,12 @@ export const useBatchEvaluationDownloadCSV = ({
     const formattedDate = new Date(run.data!.timestamps.createdAt)
       .toISOString()
       .split("T")[0];
-    const fileName = `${formattedDate}_${experiment.name}_${runId}.csv`;
-    link.setAttribute("download", fileName);
-    document.body.appendChild(link);
-    link.click();
-    link.remove();
+
+    downloadCsv({
+      fields: csvHeaders,
+      rows: csvData,
+      fileName: `${formattedDate}_${experiment.name}_${runId}.csv`,
+    });
   };
 
   return { downloadCSV, isDownloadCSVEnabled };

--- a/platform/app/src/pages/gateway/usage.tsx
+++ b/platform/app/src/pages/gateway/usage.tsx
@@ -41,6 +41,7 @@ import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 import { useRollingWindow } from "~/hooks/useRollingWindow";
 import { api } from "~/utils/api";
 import { useRouter } from "~/utils/compat/next-router";
+import { neutralizeRows } from "~/utils/csvFormulaGuard";
 
 const PRESETS: Array<{ label: string; days: number | "mtd" }> = [
   { label: "Last 24h", days: 1 },
@@ -209,7 +210,10 @@ function GatewayUsagePage() {
         m.requests,
       ]);
     }
-    const csv = Parse.unparse(rows);
+    // Sectioned: the file carries several header rows and blank separators, so
+    // there is no single `fields` list to pass and every row is guarded in
+    // place. Virtual key and model names are typed by whoever created them.
+    const csv = Parse.unparse(neutralizeRows(rows));
     const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
     const url = window.URL.createObjectURL(blob);
     const link = document.createElement("a");

--- a/platform/app/src/pages/settings/audit-log.tsx
+++ b/platform/app/src/pages/settings/audit-log.tsx
@@ -14,12 +14,12 @@ import {
 } from "@chakra-ui/react";
 import { formatDistanceToNow } from "date-fns";
 import { ArrowLeft, Download, Search } from "lucide-react";
-import Parse from "papaparse";
 import { useState } from "react";
 import { PageLayout } from "~/components/ui/layouts/PageLayout";
 import { Link } from "~/components/ui/link";
 import type { EnrichedAuditLog } from "~/server/app-layer/organizations/repositories/organization.repository";
 import { useRouter } from "~/utils/compat/next-router";
+import { downloadCsv } from "~/utils/downloadCsv";
 import { NavigationFooter } from "../../components/NavigationFooter";
 import {
   PeriodSelector,
@@ -341,24 +341,12 @@ function AuditLogPage() {
         truncateJsonForCsv(log.after),
       ]);
 
-      // Generate CSV
-      const csvBlob = Parse.unparse({
+      const formattedDate = new Date().toISOString().split("T")[0];
+      downloadCsv({
         fields,
-        data: csvData,
+        rows: csvData,
+        fileName: `audit_logs_${formattedDate}.csv`,
       });
-
-      // Create download link
-      const url = window.URL.createObjectURL(new Blob([csvBlob]));
-      const link = document.createElement("a");
-      link.href = url;
-      const today = new Date();
-      const formattedDate = today.toISOString().split("T")[0];
-      const fileName = `audit_logs_${formattedDate}.csv`;
-      link.setAttribute("download", fileName);
-      document.body.appendChild(link);
-      link.click();
-      link.remove();
-      window.URL.revokeObjectURL(url);
     } catch (error) {
       console.error("Failed to export audit logs:", error);
     } finally {

--- a/platform/app/src/server/export/__tests__/csv-serializer.unit.test.ts
+++ b/platform/app/src/server/export/__tests__/csv-serializer.unit.test.ts
@@ -643,3 +643,67 @@ describe("when an export spans several batches", () => {
     expect(csv.endsWith("\r\n")).toBe(true);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Spreadsheet formula injection
+// ---------------------------------------------------------------------------
+
+/**
+ * These files exist to be opened in a spreadsheet, and a cell opening with `=`
+ * is a formula Excel and Sheets run on the reader's machine. RFC 4180 quoting
+ * does not stop it — quoting protects the CSV grammar, not the reader — so the
+ * cell has to carry a leading apostrophe, which both tools strip on display.
+ *
+ * Everything asserted here is a value somebody typed: a trace's input and
+ * output arrive from the instrumented application, labels are set on the trace,
+ * and an evaluator's display name is chosen in the project and reaches the
+ * header row.
+ *
+ * @see src/utils/csvFormulaGuard.ts
+ */
+describe("spreadsheet formula injection", () => {
+  const FORMULA = "=cmd|' /c calc'!A1";
+
+  it("defuses a formula in a trace input cell", () => {
+    const csv = serializeTracesToSummaryCsv({
+      traces: [buildTrace({ input: { value: FORMULA } })],
+      evaluatorNames: [],
+    });
+
+    const rows = parseCsv(csv).data as Record<string, string>[];
+    expect(rows[0]?.input).toBe(`'${FORMULA}`);
+  });
+
+  it("defuses a formula in a column heading the project named", () => {
+    const csv = serializeTracesToSummaryCsv({
+      traces: [buildTrace()],
+      evaluatorNames: [FORMULA],
+    });
+
+    expect(csv.split("\r\n")[0]).toContain(`'${FORMULA}_score`);
+  });
+
+  it("leaves a negative number alone so a number column stays numeric", () => {
+    const csv = serializeTracesToSummaryCsv({
+      traces: [buildTrace({ output: { value: "-5" } })],
+      evaluatorNames: [],
+    });
+
+    const rows = parseCsv(csv).data as Record<string, string>[];
+    expect(rows[0]?.output).toBe("-5");
+  });
+
+  it("defuses a formula in a span cell in full mode", () => {
+    const csv = serializeTracesToFullCsv({
+      traces: [
+        buildTrace({
+          spans: [buildLLMSpan({ output: { type: "text", value: FORMULA } })],
+        }),
+      ],
+      evaluatorNames: [],
+    });
+
+    const rows = parseCsv(csv).data as Record<string, string>[];
+    expect(rows[0]?.span_output).toBe(`'${FORMULA}`);
+  });
+});

--- a/platform/app/src/server/export/__tests__/csv-serializer.unit.test.ts
+++ b/platform/app/src/server/export/__tests__/csv-serializer.unit.test.ts
@@ -644,10 +644,6 @@ describe("when an export spans several batches", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// Spreadsheet formula injection
-// ---------------------------------------------------------------------------
-
 /**
  * These files exist to be opened in a spreadsheet, and a cell opening with `=`
  * is a formula Excel and Sheets run on the reader's machine. RFC 4180 quoting
@@ -664,46 +660,50 @@ describe("when an export spans several batches", () => {
 describe("spreadsheet formula injection", () => {
   const FORMULA = "=cmd|' /c calc'!A1";
 
-  it("defuses a formula in a trace input cell", () => {
-    const csv = serializeTracesToSummaryCsv({
-      traces: [buildTrace({ input: { value: FORMULA } })],
-      evaluatorNames: [],
+  describe("when a typed value opens like a formula", () => {
+    it("defuses it in a trace input cell", () => {
+      const csv = serializeTracesToSummaryCsv({
+        traces: [buildTrace({ input: { value: FORMULA } })],
+        evaluatorNames: [],
+      });
+
+      const rows = parseCsv(csv).data as Record<string, string>[];
+      expect(rows[0]?.input).toBe(`'${FORMULA}`);
     });
 
-    const rows = parseCsv(csv).data as Record<string, string>[];
-    expect(rows[0]?.input).toBe(`'${FORMULA}`);
+    it("defuses it in a column heading the project named", () => {
+      const csv = serializeTracesToSummaryCsv({
+        traces: [buildTrace()],
+        evaluatorNames: [FORMULA],
+      });
+
+      expect(csv.split("\r\n")[0]).toContain(`'${FORMULA}_score`);
+    });
+
+    it("defuses it in a span cell in full mode", () => {
+      const csv = serializeTracesToFullCsv({
+        traces: [
+          buildTrace({
+            spans: [buildLLMSpan({ output: { type: "text", value: FORMULA } })],
+          }),
+        ],
+        evaluatorNames: [],
+      });
+
+      const rows = parseCsv(csv).data as Record<string, string>[];
+      expect(rows[0]?.span_output).toBe(`'${FORMULA}`);
+    });
   });
 
-  it("defuses a formula in a column heading the project named", () => {
-    const csv = serializeTracesToSummaryCsv({
-      traces: [buildTrace()],
-      evaluatorNames: [FORMULA],
+  describe("when a cell is a negative number", () => {
+    it("leaves it alone so a number column stays numeric", () => {
+      const csv = serializeTracesToSummaryCsv({
+        traces: [buildTrace({ output: { value: "-5" } })],
+        evaluatorNames: [],
+      });
+
+      const rows = parseCsv(csv).data as Record<string, string>[];
+      expect(rows[0]?.output).toBe("-5");
     });
-
-    expect(csv.split("\r\n")[0]).toContain(`'${FORMULA}_score`);
-  });
-
-  it("leaves a negative number alone so a number column stays numeric", () => {
-    const csv = serializeTracesToSummaryCsv({
-      traces: [buildTrace({ output: { value: "-5" } })],
-      evaluatorNames: [],
-    });
-
-    const rows = parseCsv(csv).data as Record<string, string>[];
-    expect(rows[0]?.output).toBe("-5");
-  });
-
-  it("defuses a formula in a span cell in full mode", () => {
-    const csv = serializeTracesToFullCsv({
-      traces: [
-        buildTrace({
-          spans: [buildLLMSpan({ output: { type: "text", value: FORMULA } })],
-        }),
-      ],
-      evaluatorNames: [],
-    });
-
-    const rows = parseCsv(csv).data as Record<string, string>[];
-    expect(rows[0]?.span_output).toBe(`'${FORMULA}`);
   });
 });

--- a/platform/app/src/server/export/scenario-runs/csv-serializer.ts
+++ b/platform/app/src/server/export/scenario-runs/csv-serializer.ts
@@ -21,6 +21,7 @@
 import Parse from "papaparse";
 import type { ExportableRun } from "~/server/app-layer/simulations/repositories/simulation.repository";
 import { categorizeRunStatus } from "~/server/scenarios/scenario-run-category";
+import { neutralizeFormula } from "~/utils/csvFormulaGuard";
 
 /**
  * The columns a person reads, shortest and highest-signal first so the useful
@@ -333,19 +334,20 @@ function stringOrEmpty(value: unknown): string {
 /**
  * Neutralize a free-text cell against spreadsheet formula injection.
  *
- * A cell whose first character is `=`, `+`, `-`, `@`, TAB or CR is evaluated
- * as a formula by Excel and Sheets. RFC 4180 quoting does not prevent this —
- * quoting protects the CSV grammar, not the spreadsheet that reads it. Since
- * scenario names, judge reasoning, criteria and message content are all
- * user- or model-controlled, and the entire point of this file is to be
- * opened in a spreadsheet, every free-text cell is prefixed with an
- * apostrophe, which those tools strip on display and treat as literal text.
+ * Scenario names, judge reasoning, criteria and message content are all user-
+ * or model-controlled, and the entire point of this file is to be opened in a
+ * spreadsheet, so every free-text cell goes through the guard.
  *
- * Deliberately applied only to text: numbers and timestamps are generated
- * here, and prefixing a negative number would corrupt it.
+ * The rule itself lives in `~/utils/csvFormulaGuard`; this file used to carry
+ * its own copy, written independently of the browser-side one. Delegating also
+ * picks up the guard's number exemption, so a text cell that happens to read
+ * `-5` stays a number to the reader rather than becoming quoted text.
+ *
+ * Still applied only to text: numbers and timestamps are generated here and
+ * never need it.
  */
 function text(value: string): string {
-  return /^[=+\-@\t\r]/.test(value) ? `'${value}` : value;
+  return neutralizeFormula(value);
 }
 
 /**

--- a/platform/app/src/server/export/serializers/csv-serializer.ts
+++ b/platform/app/src/server/export/serializers/csv-serializer.ts
@@ -5,6 +5,11 @@
  * Full mode: one row per span with trace fields denormalized (repeated per row).
  *
  * Uses PapaParse for RFC 4180-compliant CSV generation.
+ *
+ * Every heading and every cell goes through the shared formula guard on the way
+ * out. Trace input and output are whatever the instrumented application sent,
+ * and an evaluator's display name is chosen in the project and lands in the
+ * header row — so both halves of the file are somebody's typing.
  */
 
 import Parse from "papaparse";
@@ -17,6 +22,7 @@ import type {
   SpanInputOutput,
   Trace,
 } from "~/server/tracer/types";
+import { neutralizeFormula, neutralizeRows } from "~/utils/csvFormulaGuard";
 import { RESERVED_METADATA_KEYS } from "./constants";
 
 /**
@@ -75,8 +81,10 @@ export function serializeTracesToSummaryCsv({
   );
 
   return (
-    Parse.unparse({ fields: headers, data: rows }, { newline: CSV_NEWLINE }) +
-    CSV_NEWLINE
+    Parse.unparse(
+      { fields: headers.map(neutralizeFormula), data: neutralizeRows(rows) },
+      { newline: CSV_NEWLINE },
+    ) + CSV_NEWLINE
   );
 }
 
@@ -198,8 +206,10 @@ export function serializeTracesToFullCsv({
   }
 
   return (
-    Parse.unparse({ fields: headers, data: rows }, { newline: CSV_NEWLINE }) +
-    CSV_NEWLINE
+    Parse.unparse(
+      { fields: headers.map(neutralizeFormula), data: neutralizeRows(rows) },
+      { newline: CSV_NEWLINE },
+    ) + CSV_NEWLINE
   );
 }
 

--- a/platform/app/src/utils/__tests__/csvWritersUseTheGuard.unit.test.ts
+++ b/platform/app/src/utils/__tests__/csvWritersUseTheGuard.unit.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Stops CSV writers from growing back outside the formula guard.
+ *
+ * A cell opening with `=`, `+`, `-`, `@`, TAB or CR is executed as a formula by
+ * Excel and Sheets. RFC 4180 quoting does not stop that — quoting protects the
+ * CSV grammar, not the spreadsheet reading it — so the only defence is a
+ * leading apostrophe, and papaparse does not add one.
+ *
+ * The guard was written once and then bypassed seven times, because
+ * `Parse.unparse` is the obvious call to reach for and nothing objected. Each
+ * bypass was individually reasonable and collectively meant the property was
+ * true of one export surface rather than of the product.
+ *
+ * A type cannot catch this: `unparse` takes strings and every offender passed
+ * perfectly good strings. So it is caught structurally, the same way
+ * `noRawErrorToasts.unit.test.ts` catches a raw-message toast — by reading the
+ * tree and asking which files call the raw serializer at all.
+ *
+ * Adding a file to {@link GUARDED_WRITERS} is a claim that it applies
+ * {@link neutralizeFormula} (or delegates to something that does) to both the
+ * header row and every data cell. Nothing here verifies that claim; the
+ * per-writer tests do. What this file guarantees is that the list of places
+ * where the claim has to hold stays short and deliberate.
+ */
+import { readdirSync, readFileSync } from "node:fs";
+import { join, relative, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const PACKAGE_ROOT = fileURLToPath(new URL("../../../", import.meta.url));
+
+/** Both trees that ship code able to produce a file a person opens. */
+const ROOTS = ["src", "ee"];
+
+/**
+ * A call to papaparse's serializer, in any of its spellings.
+ *
+ * Anchored on the dot so the word alone does not match: "unparseable" appears
+ * in dozens of comments and error codes, and `urlunparse(parts)` is a Python
+ * stdlib signature quoted inside the Monaco autocomplete table.
+ */
+const UNPARSE_CALL = /\.unparse\s*\(/;
+
+/**
+ * The writers allowed to call the raw serializer, and what each one does about
+ * the guard. Everything else must route through one of them.
+ */
+const GUARDED_WRITERS: Record<string, string> = {
+  "src/utils/downloadCsv.ts":
+    "the browser-side writer; maps neutralizeFormula over fields and rows",
+  "src/server/export/scenario-runs/csv-serializer.ts":
+    "server-side; every free-text cell goes through text() -> neutralizeFormula",
+  "src/server/export/serializers/csv-serializer.ts":
+    "server-side; headers and rows both go through neutralizeFormula",
+  "src/components/batch-evaluation-results/csvExport.ts":
+    "generateCsvContent applies neutralizeFormula before serializing",
+  "src/pages/gateway/usage.tsx":
+    "sectioned rows with no separate header row, so it guards each row in place",
+};
+
+/**
+ * Below this many scanned files, assume the walk broke rather than that the
+ * codebase shrank. Without it, a bad root or a thrown readdir reports "no
+ * offenders" and the guard is green forever. Roughly 6,000 files match today.
+ */
+const SCANNED_FILE_FLOOR = 2000;
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === "node_modules" || entry.name === "dist") continue;
+      walk(path, out);
+    } else if (/\.tsx?$/.test(entry.name)) {
+      out.push(path);
+    }
+  }
+  return out;
+}
+
+/** Tests may serialize freely — they assert on output, they do not ship it. */
+const isTest = (relativePath: string): boolean =>
+  /\.(test|spec)\.tsx?$/.test(relativePath) ||
+  relativePath.split("/").includes("__tests__");
+
+function sourceFiles(): string[] {
+  return ROOTS.flatMap((root) => {
+    try {
+      return walk(join(PACKAGE_ROOT, root));
+    } catch {
+      return [];
+    }
+  });
+}
+
+function callSites(): string[] {
+  return sourceFiles()
+    .map((path) => relative(PACKAGE_ROOT, path).split(sep).join("/"))
+    .filter((path) => !isTest(path))
+    .filter((path) =>
+      UNPARSE_CALL.test(readFileSync(join(PACKAGE_ROOT, path), "utf8")),
+    )
+    .sort();
+}
+
+describe("every CSV the product writes goes through the formula guard", () => {
+  it("finds enough files to be scanning the tree at all", () => {
+    expect(sourceFiles().length).toBeGreaterThan(SCANNED_FILE_FLOOR);
+  });
+
+  it("has no writer calling the raw serializer outside the guarded set", () => {
+    const unguarded = callSites().filter((path) => !(path in GUARDED_WRITERS));
+
+    expect(unguarded).toEqual([]);
+  });
+
+  it("keeps the guarded set honest about which files still exist", () => {
+    const present = new Set(callSites());
+    const stale = Object.keys(GUARDED_WRITERS).filter(
+      (path) => !present.has(path),
+    );
+
+    expect(stale).toEqual([]);
+  });
+});
+
+/**
+ * The detector's own test. Without it, "no offenders" and "matches nothing"
+ * look identical, and this shape of guard has shipped in the second state
+ * before.
+ */
+describe("the unparse detector", () => {
+  it.each([
+    ["a namespaced call", `const csv = Parse.unparse({ fields, data });`],
+    ["a bare method call", `writer.unparse(rows)`],
+    ["spaced", `Parse.unparse ({ fields, data })`],
+  ])("matches %s", (_label, source) => {
+    expect(UNPARSE_CALL.test(source)).toBe(true);
+  });
+
+  it.each([
+    ["the adjective", `// an unparseable cursor is treated as absent`],
+    [
+      "an error code",
+      `export const LWQL_UNPARSEABLE_CODE = "lwql_unparseable";`,
+    ],
+    ["a quoted foreign signature", `fn("urlunparse", "urlunparse(parts)")`],
+  ])("does not match %s", (_label, source) => {
+    expect(UNPARSE_CALL.test(source)).toBe(false);
+  });
+});

--- a/platform/app/src/utils/__tests__/csvWritersUseTheGuard.unit.test.ts
+++ b/platform/app/src/utils/__tests__/csvWritersUseTheGuard.unit.test.ts
@@ -74,8 +74,9 @@ const GUARDED_WRITERS: Record<string, string> = {
 
 /**
  * Below this many scanned files, assume the walk broke rather than that the
- * codebase shrank. Without it, a bad root or a thrown readdir reports "no
- * offenders" and the guard is green forever. Roughly 6,000 files match today.
+ * codebase shrank. A missing root throws on its own; this catches the quieter
+ * failure where the walk runs but matches almost nothing. Roughly 6,000 files
+ * match today.
  */
 const SCANNED_FILE_FLOOR = 2000;
 
@@ -98,13 +99,7 @@ const isTest = (relativePath: string): boolean =>
   relativePath.split("/").includes("__tests__");
 
 function sourceFiles(): string[] {
-  return ROOTS.flatMap((root) => {
-    try {
-      return walk(join(PACKAGE_ROOT, root));
-    } catch {
-      return [];
-    }
-  });
+  return ROOTS.flatMap((root) => walk(join(PACKAGE_ROOT, root)));
 }
 
 function callSites(): string[] {

--- a/platform/app/src/utils/__tests__/csvWritersUseTheGuard.unit.test.ts
+++ b/platform/app/src/utils/__tests__/csvWritersUseTheGuard.unit.test.ts
@@ -35,13 +35,16 @@ const PACKAGE_ROOT = fileURLToPath(new URL("../../../", import.meta.url));
 const ROOTS = ["src", "ee"];
 
 /**
- * A call to papaparse's serializer, in any of its spellings.
- *
- * Anchored on the dot so the word alone does not match: "unparseable" appears
- * in dozens of comments and error codes, and `urlunparse(parts)` is a Python
- * stdlib signature quoted inside the Monaco autocomplete table.
+ * Any reference to papaparse's serializer by name — a direct `Parse.unparse(`,
+ * a destructured `import { unparse }`, or an alias like
+ * `const serialize = Parse.unparse`. All of them have to write the word
+ * somewhere, so matching the bare word catches the alias shapes a
+ * call-site-only regex misses. The word boundaries keep "unparseable" (comments
+ * and error codes) and `urlunparse(parts)` (a Python signature quoted in the
+ * Monaco autocomplete table) from matching: both bury the word inside a longer
+ * one, so the boundary fails.
  */
-const UNPARSE_CALL = /\.unparse\s*\(/;
+const UNPARSE_CALL = /\bunparse\b/;
 
 /**
  * An import of the guard module, by either path shape the codebase uses.
@@ -152,6 +155,8 @@ describe("the unparse detector", () => {
     ["a namespaced call", `const csv = Parse.unparse({ fields, data });`],
     ["a bare method call", `writer.unparse(rows)`],
     ["spaced", `Parse.unparse ({ fields, data })`],
+    ["a destructured import", `import { unparse } from "papaparse";`],
+    ["an alias assignment", `const serialize = Parse.unparse;`],
   ])("matches %s", (_label, source) => {
     expect(UNPARSE_CALL.test(source)).toBe(true);
   });

--- a/platform/app/src/utils/__tests__/csvWritersUseTheGuard.unit.test.ts
+++ b/platform/app/src/utils/__tests__/csvWritersUseTheGuard.unit.test.ts
@@ -16,11 +16,13 @@
  * `noRawErrorToasts.unit.test.ts` catches a raw-message toast — by reading the
  * tree and asking which files call the raw serializer at all.
  *
- * Adding a file to {@link GUARDED_WRITERS} is a claim that it applies
- * {@link neutralizeFormula} (or delegates to something that does) to both the
- * header row and every data cell. Nothing here verifies that claim; the
- * per-writer tests do. What this file guarantees is that the list of places
- * where the claim has to hold stays short and deliberate.
+ * Adding a file to {@link GUARDED_WRITERS} is a claim that it applies the guard
+ * to both the header row and every data cell. This file checks the weak half of
+ * that claim — the file does reach for the guard at all — and the per-writer
+ * tests check the strong half, that the apostrophe reaches the bytes. The weak
+ * half is here because it is the failure this guard was built for: deleting the
+ * `neutralizeRows` call while leaving the file on the list would otherwise pass
+ * both.
  */
 import { readdirSync, readFileSync } from "node:fs";
 import { join, relative, sep } from "node:path";
@@ -40,6 +42,18 @@ const ROOTS = ["src", "ee"];
  * stdlib signature quoted inside the Monaco autocomplete table.
  */
 const UNPARSE_CALL = /\.unparse\s*\(/;
+
+/**
+ * An import of the guard module, by either path shape the codebase uses.
+ *
+ * Deliberately weaker than "the guard is applied to the right arguments": a
+ * regex cannot tell those apart, and pretending otherwise would make this file
+ * look like it verifies more than it does. It catches the one regression a
+ * reader would otherwise miss entirely — the guard call deleted while the file
+ * stays on the allow-list.
+ */
+const GUARD_IMPORT =
+  /from\s+["'](?:~\/utils|\.{1,2}(?:\/[^"']*)?)\/csvFormulaGuard["']/;
 
 /**
  * The writers allowed to call the raw serializer, and what each one does about
@@ -121,6 +135,15 @@ describe("every CSV the product writes goes through the formula guard", () => {
     );
 
     expect(stale).toEqual([]);
+  });
+
+  it("has every listed writer actually reaching for the guard", () => {
+    const notReaching = Object.keys(GUARDED_WRITERS).filter(
+      (path) =>
+        !GUARD_IMPORT.test(readFileSync(join(PACKAGE_ROOT, path), "utf8")),
+    );
+
+    expect(notReaching).toEqual([]);
   });
 });
 

--- a/platform/app/src/utils/csvFormulaGuard.ts
+++ b/platform/app/src/utils/csvFormulaGuard.ts
@@ -1,0 +1,48 @@
+/**
+ * The one rule every CSV this product writes has to apply.
+ *
+ * A spreadsheet treats a cell opening with one of {@link FORMULA_LEADERS} as a
+ * formula to run, not text to show. RFC 4180 quoting does not stop it —
+ * quoting protects the CSV grammar, not the spreadsheet reading the file — so
+ * the only defence is a leading apostrophe, which Excel and Sheets both read as
+ * "this is text" and drop on display.
+ *
+ * It lives here, apart from any writer, because the rule had been written twice
+ * independently and bypassed seven times. Server-side serializers import it as
+ * readily as browser-side ones; nothing in this file touches the DOM.
+ *
+ * @see src/utils/downloadCsv.ts — the browser-side writer
+ * @see src/utils/__tests__/csvWritersUseTheGuard.unit.test.ts — stops writers
+ *      growing back outside it
+ */
+
+/**
+ * `-` is here alongside `=` and `+` because `-1+1` is arithmetic to a
+ * spreadsheet, and `@` because it opens a legacy Lotus function that Excel
+ * still honours. TAB and CR lead because a leading control character is
+ * stripped before the parse and can expose whatever follows it.
+ */
+export const FORMULA_LEADERS = ["=", "+", "-", "@", "\t", "\r"];
+
+/**
+ * Neutralises a cell a spreadsheet would otherwise run, and returns everything
+ * else untouched.
+ *
+ * A value that is simply a number is left alone: "-5" is not a formula, and
+ * quoting it would turn a number column into a text one — which breaks sorting
+ * and every SUM written against the file. Non-strings pass through, so a caller
+ * holding `(string | number)[]` can map this over the row without narrowing.
+ */
+export const neutralizeFormula = <T extends string | number>(
+  cell: T,
+): T | string => {
+  if (typeof cell !== "string" || cell.length === 0) return cell;
+  if (!FORMULA_LEADERS.includes(cell[0]!)) return cell;
+  if (Number.isFinite(Number(cell))) return cell;
+  return `'${cell}`;
+};
+
+/** Convenience for the common `{ fields, data }` shape papaparse takes. */
+export const neutralizeRows = <T extends string | number>(
+  rows: T[][],
+): (T | string)[][] => rows.map((row) => row.map(neutralizeFormula));

--- a/platform/app/src/utils/downloadCsv.ts
+++ b/platform/app/src/utils/downloadCsv.ts
@@ -1,27 +1,5 @@
 import Parse from "papaparse";
-
-/**
- * A spreadsheet treats a cell opening with one of these as a formula to run,
- * not text to show. Every value in these files is typed by somebody — a
- * comment, a suggestion, the reason given for a score — so a cell opening with
- * `=` is a formula the reader's spreadsheet would execute on their machine.
- */
-const FORMULA_LEADERS = ["=", "+", "-", "@", "\t", "\r"];
-
-/**
- * Neutralises a cell a spreadsheet would otherwise run. The leading quote is
- * what Excel and Sheets both read as "this is text"; it is dropped again on
- * display, so the reader still sees what was written.
- *
- * A value that is simply a number is left alone: "-5" is not a formula, and
- * quoting it would turn a number column into a text one.
- */
-const neutralizeFormula = <T extends string | number>(cell: T): T | string => {
-  if (typeof cell !== "string" || cell.length === 0) return cell;
-  if (!FORMULA_LEADERS.includes(cell[0]!)) return cell;
-  if (Number.isFinite(Number(cell))) return cell;
-  return `'${cell}`;
-};
+import { neutralizeFormula, neutralizeRows } from "./csvFormulaGuard";
 
 /**
  * Turns a header row plus its data rows into a CSV file and hands it to the
@@ -45,7 +23,7 @@ export function downloadCsv({
 }): void {
   const csv = Parse.unparse({
     fields: fields.map(neutralizeFormula),
-    data: rows.map((row) => row.map(neutralizeFormula)),
+    data: neutralizeRows(rows),
   });
   const url = window.URL.createObjectURL(new Blob([csv], { type: "text/csv" }));
 


### PR DESCRIPTION
Closes #7783.

## Cause

`platform/app/src/utils/downloadCsv.ts:47` defuses a cell a spreadsheet would run as a formula. Seven other writers never reached it — they called papaparse directly and built their own blob or response:

| Writer | Line |
| --- | --- |
| `components/experiments/BatchEvaluation.tsx` | 94 |
| `components/experiments/BatchEvaluationV2/BatchEvaluationV2EvaluationResults.tsx` | 312 |
| `components/batch-evaluation-results/csvExport.ts` | 345 |
| `components/datasets/editor/DatasetEditorTable.tsx` | 620 |
| `pages/settings/audit-log.tsx` | 345 |
| `pages/gateway/usage.tsx` | 212 |
| `server/export/serializers/csv-serializer.ts` | 78, 201 |

The issue named six. `csvExport.ts` is the seventh — it exports its own `downloadCsv` built on `generateCsvContent`, which is why a search for the shared helper's importers missed it.

A cell opening with `=`, `+`, `-`, `@`, TAB or CR is executed as a formula by Excel and Sheets. RFC 4180 quoting does not stop that: quoting protects the CSV grammar, not the spreadsheet reading the file.

## Failing test, before the fix

```
FAIL  src/utils/__tests__/csvWritersUseTheGuard.unit.test.ts
  > has no writer calling the raw serializer outside the guarded set

  - Expected
  + Received
  - []
  + [
  +   "src/components/datasets/editor/DatasetEditorTable.tsx",
  +   "src/components/experiments/BatchEvaluation.tsx",
  +   "src/components/experiments/BatchEvaluationV2/BatchEvaluationV2EvaluationResults.tsx",
  +   "src/pages/settings/audit-log.tsx",
  + ]

FAIL  src/server/export/__tests__/csv-serializer.unit.test.ts
  > defuses a formula in a trace input cell
  AssertionError: expected '=cmd|\' /c calc\'!A1' to be '\'=cmd|\' /c calc\'!A1'
  > defuses a formula in a column heading the project named
  > defuses a formula in a span cell in full mode

FAIL  src/components/batch-evaluation-results/__tests__/csvExport.test.ts
  > defuses a formula in a dataset cell
  AssertionError: expected 'index,input\r\n0,=cmd|\' /c calc\'!A1' to contain '\'=cmd|…'
  > defuses a formula in a column heading someone named

 Tests  5 failed | 63 passed (68)
```

Plus the two class-level failures above: **7 failing.**

## The change

The rule moves to `utils/csvFormulaGuard.ts` — pure, no DOM — so the server serializers import it as readily as the browser ones.

- `server/export/scenario-runs/csv-serializer.ts` had written the same rule independently. Its `text()` now delegates instead of keeping a second copy, which also picks up the number exemption: a text cell reading `-5` stays a number to the reader rather than becoming quoted text. Its headers are static const arrays, so they need no guard.
- Four client writers move onto `downloadCsv`, deleting the blob-and-anchor dance each repeated. Two of them gained a `revokeObjectURL` they were missing.
- The two that cannot move apply the guard in place: `pages/gateway/usage.tsx` writes a sectioned file with several header rows and blank separators, so there is no single `fields` list to pass; the server trace serializer has no DOM.

## Passing, after

```
Test Files  10 passed (10)
     Tests  158 passed (158)
```

`pnpm typecheck:all` exit 0. `biome-new-violations.sh` against `origin/main`: *no new Biome violations* — head 26, base 28, **2 removed**. Feature parity `OK: 10905 enforced scenario(s) bound`.

Broader suites on this base: `src/utils`, `src/server/export`, `frontend-boundary` → 974 passed. Component suites for datasets editor, experiments and annotations → 105 passed.

## Sweep

Swept for the same defect written differently, not just for the same call:

- **Other CSV mechanisms** — no hand-rolled comma joins building a file, no XLSX or Excel writer anywhere in `src` or `ee`. The only `text/csv` producers are the ones above plus the two export API routes, whose bodies come from the serializers now fixed.
- **The class itself** — `csvWritersUseTheGuard.unit.test.ts` walks both trees and fails on any writer calling the raw serializer outside a five-entry allow-list, so this cannot grow back silently. It carries a scanned-file floor and its own detector tests, because "no offenders" and "matches nothing" otherwise look identical.

## Reviewed, and what changed because of it

One P2 in my own diff: the allow-list made a per-file claim nothing verified. Deleting a `neutralizeRows` call while leaving the file listed would have passed every assertion. Closed in `9ab7399671` with a fourth check that each listed writer still imports the guard — verified by removing the import from `pages/gateway/usage.tsx` and watching the run go red.

Review then found a second, larger version of the same mistake — a check that could not fail. `sourceFiles()` wrapped each root's walk in a `try/catch` that turned an unreadable root into an empty list. `src` alone clears the 2,000-file floor, so a broken `ee` walk would have reported "no offenders" while never looking at enterprise code at all. Fixed in `72182b2f82`: the catch is gone, so a missing root now fails the suite instead of quietly shrinking its coverage. The same commit drops a banner comment that restated the suite title verbatim and folds the formula-injection cases into nested `when` blocks, matching the rest of the file.

One suggestion from that round was declined: converting the local `walk` and `isTest` helpers to object parameters. The named-parameter rule as configured covers exported functions taking 2+ positional parameters of the same primitive type, and explicitly exempts two-parameter functions whose types differ obviously. `walk` is module-local and takes `(string, string[])`; `isTest` takes one parameter. Neither is in scope.

## Noticed and deliberately not fixed

- **`pages/gateway/usage.tsx` has no behavioural test of its guard.** It is the one allow-list entry covered only by the structural check above. A page-render test asserting one apostrophe was more machinery than this earns; stating the gap is the honest alternative.
- **`\t` or `\r` followed by a bare number passes through unguarded** — `Number("\t5")` is 5, so the number exemption swallows it. Not a formula, so harmless, and this is a property of the guard as it already shipped, not something introduced here.
- **A pre-existing unhandled rejection** in `AnnotationsTable.selection.integration.test.tsx`: the tRPC utils mock does not stub `annotation.getQueues`, so `getQueues.invalidate()` throws inside `onSuccess`. Reproduces on `origin/main` untouched by this branch. The suite passes, which is the problem — an unhandled rejection can mask a real failure.

## Severity

Low, and worth saying plainly: exploiting this needs a person to open the file in a spreadsheet and accept the prompt their spreadsheet shows. It is not remote execution. It is worth closing because the cost is small and these exports carry text one person wrote and another downloads.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CSV exports now protect headers and cell values against spreadsheet formula injection.
  * Negative numbers and other valid numeric values remain unchanged.
  * Protection covers dataset, evaluation, usage, audit-log, trace, and scenario-run exports.

* **Improvements**
  * CSV downloads now use a consistent shared export process across supported areas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
