### PR TITLE
test(langevals): pin the ragas litellm shim against the langchain-openai client contract

### DIFF
--- a/services/langevals/tests/deterministic/test_ragas_litellm_client_shim.py
+++ b/services/langevals/tests/deterministic/test_ragas_litellm_client_shim.py
@@ -1,0 +1,179 @@
+"""The ragas litellm client shim, against the langchain-openai client contract.
+
+`model_to_langchain` hands `ChatOpenAI` a `LitellmCompletion` /
+`AsyncLitellmCompletion` pair instead of real OpenAI clients, so every ragas
+evaluator call routes through litellm. That only works while the shim serves
+the surface langchain-openai actually calls: since langchain-openai 0.3 the
+chat path is `client.with_raw_response.create(**payload)` followed by
+`raw_response.parse()`, unconditionally. A shim exposing only `.create()`
+crashes with AttributeError before a single provider call is made, taking
+down every ragas evaluator on every provider.
+
+These tests pin the contract at both levels: the langchain entry points the
+shim must survive (`invoke` for the sync client, `ainvoke` for the async one),
+and one ragas evaluator end to end, provider stubbed at
+`litellm_patch.originals` exactly like the sibling credential-isolation tests,
+so the whole real stack above litellm is exercised.
+"""
+
+import asyncio
+import json
+import os
+import sys
+
+import pytest
+
+# Same import guard as the other files in this directory (they must agree,
+# since the first file pytest collects is the one that actually imports the
+# module): `langevals.server` reads sys.argv and DISABLE_EVALUATORS_PRELOAD at
+# import time, and both are restored right after.
+_original_argv = sys.argv
+_original_preload = os.environ.get("DISABLE_EVALUATORS_PRELOAD")
+sys.argv = ["server.py", "--only", "langevals,ragas"]
+os.environ["DISABLE_EVALUATORS_PRELOAD"] = "1"
+try:
+    from langevals import server  # noqa: F401  (imports and patches litellm)
+finally:
+    sys.argv = _original_argv
+    if _original_preload is None:
+        os.environ.pop("DISABLE_EVALUATORS_PRELOAD", None)
+    else:
+        os.environ["DISABLE_EVALUATORS_PRELOAD"] = _original_preload
+
+# The server captured its baseline while the temporary preload flag was set.
+# Rebase it on the clean environment, so the drift tripwire compares against
+# what the process actually holds.
+server.original_env = os.environ.copy()
+
+from langevals_core import litellm_patch
+from langevals_core.request_env import request_env
+from langevals_ragas.faithfulness import (
+    RagasFaithfulnessEntry,
+    RagasFaithfulnessEvaluator,
+)
+from langevals_ragas.lib.model_to_langchain import model_to_langchain
+
+
+def canned_text_response(model: str, content: str):
+    from litellm.files.main import ModelResponse
+
+    return ModelResponse(
+        model=model,
+        choices=[
+            {
+                "index": 0,
+                "finish_reason": "stop",
+                "message": {"role": "assistant", "content": content},
+            }
+        ],
+        usage={"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+    )
+
+
+@pytest.fixture
+def stubbed_provider(monkeypatch):
+    """Stub `litellm_patch.originals` with per-call canned contents.
+
+    Returns (calls, respond_with): `respond_with` queues the content of each
+    successive provider response. A call past the end of the queue is served
+    the last content again, so an unexpected extra call still gets a
+    well-formed response and fails on the call-count assertion rather than on
+    an IndexError deep inside ragas.
+    """
+    calls: list[dict] = []
+    contents: list[str] = ["hello from litellm"]
+
+    def recording_completion(*args, **kwargs):
+        calls.append(
+            {
+                "model": kwargs.get("model"),
+                "api_key": kwargs.get("api_key"),
+                "api_base": kwargs.get("api_base"),
+                "api_version": kwargs.get("api_version"),
+            }
+        )
+        content = contents[min(len(calls) - 1, len(contents) - 1)]
+        return canned_text_response(kwargs.get("model", "gpt-5-mini"), content)
+
+    monkeypatch.setitem(litellm_patch.originals, "completion", recording_completion)
+
+    def respond_with(*queued: str):
+        contents[:] = list(queued)
+
+    return calls, respond_with
+
+
+def test_the_sync_shim_client_answers_a_langchain_invoke(stubbed_provider):
+    calls, _ = stubbed_provider
+    llm = model_to_langchain("openai/gpt-5-mini")
+
+    with request_env({"OPENAI_API_KEY": "sentinel-openai-key"}):
+        message = llm.invoke("Say hi")
+
+    assert message.content == "hello from litellm"
+    assert len(calls) == 1
+    assert calls[0]["model"] == "openai/gpt-5-mini"
+    assert calls[0]["api_key"] == "sentinel-openai-key"
+
+
+def test_the_async_shim_client_answers_a_langchain_ainvoke(stubbed_provider):
+    calls, _ = stubbed_provider
+    llm = model_to_langchain("openai/gpt-5-mini")
+
+    with request_env({"OPENAI_API_KEY": "sentinel-openai-key"}):
+        message = asyncio.run(llm.ainvoke("Say hi"))
+
+    assert message.content == "hello from litellm"
+    assert len(calls) == 1
+    assert calls[0]["model"] == "openai/gpt-5-mini"
+    assert calls[0]["api_key"] == "sentinel-openai-key"
+
+
+def test_a_ragas_evaluation_on_azure_reaches_litellm_and_scores(stubbed_provider):
+    calls, respond_with = stubbed_provider
+    # Faithfulness makes two provider calls in data-dependency order: first
+    # statement generation, then the NLI verdict over those statements. Each
+    # gets the JSON its ragas output schema expects, so the evaluation runs
+    # the same path a real provider response would.
+    respond_with(
+        json.dumps({"statements": ["The answer is 42."]}),
+        json.dumps(
+            {
+                "statements": [
+                    {
+                        "statement": "The answer is 42.",
+                        "reason": "Supported by the context.",
+                        "verdict": 1,
+                    }
+                ]
+            }
+        ),
+    )
+
+    evaluator = RagasFaithfulnessEvaluator(
+        settings={"model": "azure/gpt-5-mini"},
+        env={
+            "AZURE_OPENAI_API_KEY": "sentinel-azure-key",
+            "AZURE_OPENAI_ENDPOINT": "https://sentinel.openai.azure.com",
+        },
+    )
+    results = evaluator.evaluate_batch(
+        [
+            RagasFaithfulnessEntry(
+                input="What is the answer?",
+                output="The answer is 42.",
+                contexts=["The answer to everything is 42."],
+            )
+        ]
+    )
+
+    assert len(results) == 1
+    assert results[0].status == "processed", getattr(results[0], "details", None)
+    assert results[0].score == 1.0
+
+    assert len(calls) == 2
+    for call in calls:
+        assert call["model"] == "azure/gpt-5-mini"
+        assert call["api_key"] == "sentinel-azure-key"
+        assert call["api_base"] == "https://sentinel.openai.azure.com"
+        assert call["api_version"] is not None


### PR DESCRIPTION
## For humans

Every ragas-based evaluator (Faithfulness, Context Precision/Recall, Factual Correctness, Response Relevancy, Rubrics, SQL Equivalence, Summarization) was crashing on every provider — OpenAI, Azure, all of them — before making a single LLM call. A dependency upgrade changed how langchain talks to its LLM client, and our internal adapter didn't speak the new dialect.

**The adapter fix has since landed on `main` on its own** (it rode in with #7867 while this PR was open), so this PR no longer changes any production code. What it still carries is the part that was missing and is the reason the break went unnoticed for weeks: a deterministic test that drives a real ragas evaluation through the adapter, so the next dependency bump can't silently kill the evaluators again.

Relates to #7785.

## What happened

`langchain-openai >= 0.3` calls `client.with_raw_response.create(**payload)` unconditionally (`langchain_openai/chat_models/base.py:1208` sync, `:1449` async), and the litellm client shim in `services/langevals/evaluators/ragas/langevals_ragas/lib/model_to_langchain.py` only implemented `.create()`. The bump from langchain-openai 0.2.14 → 0.3.35 landed in #7195; from then on every ragas evaluation died with `AttributeError` above the litellm layer, so no credential handling was ever reached — the failure was provider-independent, not Azure-specific.

## Scope change while this PR was open

This PR originally added both the `with_raw_response` facade and the tests. `main` picked up an equivalent facade independently (`RawResponse` / `RawResponses` / `AsyncRawResponses` in the same file, via #7867), so on rebase the production hunk was dropped in favour of main's — no duplicate implementation, no behavioural difference. The PR is now **test-only**, and the tests pass unchanged against main's facade.

## What the tests do

`services/langevals/tests/deterministic/test_ragas_litellm_client_shim.py`, three cases:

- **sync** — `ChatOpenAI.invoke` through the shim reaches litellm carrying the request's credentials.
- **async** — the same for `ainvoke`, which is the path more likely to be tested less.
- **end to end** — a real `RagasFaithfulnessEvaluator` run, provider stubbed at `litellm_patch.originals` (the same seam the sibling credential-isolation tests use), so langchain, ragas and the shim all execute for real. Asserts the evaluation scores and that both provider calls arrive with the request's credentials.

The distinction that matters: a test asserting only that `with_raw_response` exists would pass against a future langchain that reaches for something else. This one drives the whole stack, so it fails on the class of break, not just this instance.

Against the current tree:

```
3 passed in 1.92s
```

CI's no-provider suite (`evaluators/langevals/tests/test_llm_answer_match_threading.py tests/deterministic/ langevals_core/tests/`): `215 passed in 89.22s`.

## Why CI never caught the original break

`tests/test_azure_evaluation.py` needs live credentials and skips without them, and the deterministic credential-isolation suite covered every `langevals_langevals` evaluator family but no ragas one. These tests are deterministic, need no key, and run on forks.

## Sweep

Looked for the same shape — our classes duck-typing a third-party client surface:

- `LitellmEmbeddings` / `LitellmEmbeddingsWrapper` (same file): safe — langchain-openai's embeddings path has zero `with_raw_response` call sites, and our wrapper overrides `embed_query` anyway.
- Streaming (`_stream` / `_astream`): langchain calls plain `client.create()` there unless `include_response_headers` is set (it never is for us), so the facade isn't involved.
- `root_client` structured-output paths in langchain: unreachable for ragas payloads (they trigger only on responses-API args or builtin tools).
- dspy-based evaluators: patch litellm directly, no OpenAI-client duck-typing; their deterministic suite is green.

## Deployment Impact

None. No production code changes, no environment variables, no chart or config changes, no migrations, no dependency version changes.

## Deliberately not covered here

- The evaluator deployment-name gaps tracked in #7766 (X_LITELLM `deployment` passthrough, embeddings default) — real but unrelated.
- No live-Azure verification: the deterministic tests prove the code path; a run against real Azure credentials still only exists in the skipped `tests/test_azure_evaluation.py`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage for the Ragas LiteLLM client integration.
  - Verified synchronous and asynchronous evaluation entry points.
  - Added an end-to-end faithfulness evaluation check using a stubbed Azure provider.
  - Confirmed evaluation scores and required provider configuration are forwarded correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->