### PR TITLE
fix(clickhouse): the rollup dimension migration takes the next free number

### DIFF
--- a/platform/app/src/server/clickhouse/__tests__/aggregatingDimensionGuard.unit.test.ts
+++ b/platform/app/src/server/clickhouse/__tests__/aggregatingDimensionGuard.unit.test.ts
@@ -33,19 +33,19 @@ const MIGRATIONS_DIR = resolve(
   "src/server/clickhouse/migrations",
 );
 
-const CONVERGE_MIGRATION = "00087_aggregating_rollup_dimension_columns.sql";
+const CONVERGE_MIGRATION = "00088_aggregating_rollup_dimension_columns.sql";
 
 /** Column names that never carry a merge rule of their own. */
 const NON_COLUMN_PREFIXES = ["INDEX", "CONSTRAINT", "PROJECTION", "PRIMARY"];
 
 /**
- * The columns that were declared without a merge rule before 00087, and the
+ * The columns that were declared without a merge rule before 00088, and the
  * merged migrations that still create them that way.
  *
  * These files have run somewhere, so they cannot change: `migration-order`
  * fails a branch that edits a migration already on main. A new install still
  * replays them, so on a server that enforces the check goose.ts runs them with
- * `allow_dimensions_outside_sorting_key` relaxed and 00087 converts the tables
+ * `allow_dimensions_outside_sorting_key` relaxed and 00088 converts the tables
  * immediately after. Every install therefore ends on the same schema.
  *
  * DO NOT add entries. A new migration runs without the compatibility setting,
@@ -104,7 +104,7 @@ const HISTORICAL_DIMENSIONS: {
   },
 ];
 
-/** The live tables 00087 converts, and the column each one converts. */
+/** The live tables 00088 converts, and the column each one converts. */
 const CONVERGED_COLUMNS = [
   { table: "gateway_budget_scope_totals", column: "UpdatedAt" },
   { table: "trace_analytics_rollup", column: "_retention_days" },

--- a/platform/app/src/server/clickhouse/__tests__/migrationReplay.ts
+++ b/platform/app/src/server/clickhouse/__tests__/migrationReplay.ts
@@ -31,20 +31,20 @@ const MIGRATIONS_DIR = join(__dirname, "..", "migrations");
  * restoring only some of it hands later suites a rollup the reader cannot
  * read. 00069 re-derives the rows and declares the sorting key; 00070 adds
  * the nano-USD aggregate every spend read now sums; 00082 stops the view
- * folding pulled provider cost into those totals (ADR-088); 00087 gives
+ * folding pulled provider cost into those totals (ADR-088); 00088 gives
  * UpdatedAt the merge rule the rollup carries from then on. Append to this
  * list whenever another lands.
  *
  * 00082 alters the view 00070 creates rather than creating its own, so it
  * only replays correctly after 00070 — which is the order this list is read
- * in, and the reason it is a list rather than a set. 00087 comes last for the
+ * in, and the reason it is a list rather than a set. 00088 comes last for the
  * same reason: 00069 recreates the table with the column it converts.
  */
 export const CURRENT_ROLLUP_REBUILD_MIGRATIONS = [
   "00069_gateway_budget_scope_totals_budget_grain.sql",
   "00070_gateway_budget_ledger_nano_usd.sql",
   "00082_gateway_budget_scope_totals_exclude_pulled.sql",
-  "00087_aggregating_rollup_dimension_columns.sql",
+  "00088_aggregating_rollup_dimension_columns.sql",
 ] as const;
 
 /** Replays `CURRENT_ROLLUP_REBUILD_MIGRATIONS` in order. */

--- a/platform/app/src/server/clickhouse/goose.ts
+++ b/platform/app/src/server/clickhouse/goose.ts
@@ -37,8 +37,8 @@ const VALID_DB_NAME = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
 const AGGREGATING_DIMENSION_SETTING = "allow_dimensions_outside_sorting_key";
 
 /**
- * The last migration that predates 00087, which is where those four rollup
- * columns gained their merge rule.
+ * The last migration that runs with the setting above relaxed. 00088 is where
+ * those four rollup columns gain their merge rule.
  *
  * Migrations up to here are merged history: they still create the tables the
  * old way on a new install, and on ClickHouse 26 they only run with the
@@ -358,7 +358,7 @@ async function bootstrapDatabase(
 
   // ClickHouse 26.0 refuses to create an AggregatingMergeTree table with a
   // column that is neither in the sorting key nor an aggregate state. Four
-  // rollups were created that way before 00087 converted them, and those
+  // rollups were created that way before 00088 converted them, and those
   // CREATE TABLE statements are merged history that a new install still
   // replays. The presence of the setting that relaxes the check is what says
   // the server enforces it — read rather than inferred from a version number,

--- a/platform/app/src/server/clickhouse/migrations/00088_aggregating_rollup_dimension_columns.sql
+++ b/platform/app/src/server/clickhouse/migrations/00088_aggregating_rollup_dimension_columns.sql
@@ -29,9 +29,9 @@
 -- and 00081) and cannot be edited, so a new install replays them exactly as
 -- they are. runMigrations in goose.ts therefore runs everything up to 00086
 -- with allow_dimensions_outside_sorting_key relaxed, but only on a server
--- that has that setting, and this migration converts the tables immediately
--- after. Both paths end here, so an install created on ClickHouse 25 and one
--- created on ClickHouse 26 carry the same schema.
+-- that has that setting, and this migration then converts the tables. Both
+-- paths end here, so an install created on ClickHouse 25 and one created on
+-- ClickHouse 26 carry the same schema.
 --
 -- Migrations after this one run with the check in force.
 --


### PR DESCRIPTION
Two pull requests merged to main on the same day and both added a ClickHouse migration numbered 00087: the coding agent working context columns and the aggregating rollup dimension columns. Goose refuses a migration set with a duplicate version, so no fresh stack completes its ClickHouse migrations from main. The unit test `clickhouseMigrations.unit.test.ts` reports the duplicate `00087`. This change renames the later merged file to `00088_aggregating_rollup_dimension_columns.sql` and updates the references to it in `goose.ts`, `migrationReplay.ts` and `aggregatingDimensionGuard.unit.test.ts`.

A development database that already recorded version 87 keeps that record and now sees 88 as pending, so it runs the rollup file again. Every statement in it is an `ALTER TABLE ... MODIFY COLUMN` to a fixed target type, which is metadata only and gives the same result on each run. This was verified against ClickHouse 25.8: the same statement applied three times to an `AggregatingMergeTree` column succeeds each time and leaves the column as `SimpleAggregateFunction(max, DateTime64(3))`. The `migration-order` workflow reports one finding on this branch, because the branch renames a file that is already on main. That is the intended repair for the duplicate, and the workflow is not a required check.
