### PR TITLE
fix(cli-auth): the permission ceiling mirrors what an org MEMBER binding really grants

### DIFF
--- a/platform/app/src/pages/cli/__tests__/cliKeyScopeDefaults.unit.test.ts
+++ b/platform/app/src/pages/cli/__tests__/cliKeyScopeDefaults.unit.test.ts
@@ -1,7 +1,7 @@
 import { builtinRolePermissions } from "@langwatch/authz";
 import { describe, expect, it } from "vitest";
-import { isOrgExclusivePermission } from "~/server/api/rbac";
 import type { Permission } from "~/server/api/rbac";
+import { isOrgExclusivePermission } from "~/server/api/rbac";
 import { defaultCliKeyPermissions } from "~/server/api-key/cli-key-defaults";
 import { defaultCliKeyScopes } from "../cliKeyScopeDefaults";
 
@@ -197,7 +197,7 @@ describe("defaultCliKeyScopes()", () => {
     });
   });
 
-  describe("mintability of the organization-chip fallback", () => {
+  describe("when the organization-chip fallback is offered", () => {
     // The cross-layer pin for the fallback: the screen's permission list is
     // `defaultCliKeyPermissions()` intersected with the chip's ceiling, and
     // the mint (`filterToGrantable`) keeps org-exclusive permissions only

--- a/platform/app/src/pages/cli/__tests__/cliKeyScopeDefaults.unit.test.ts
+++ b/platform/app/src/pages/cli/__tests__/cliKeyScopeDefaults.unit.test.ts
@@ -1,4 +1,8 @@
+import { builtinRolePermissions } from "@langwatch/authz";
 import { describe, expect, it } from "vitest";
+import { isOrgExclusivePermission } from "~/server/api/rbac";
+import type { Permission } from "~/server/api/rbac";
+import { defaultCliKeyPermissions } from "~/server/api-key/cli-key-defaults";
 import { defaultCliKeyScopes } from "../cliKeyScopeDefaults";
 
 describe("defaultCliKeyScopes()", () => {
@@ -190,6 +194,33 @@ describe("defaultCliKeyScopes()", () => {
         { scopeType: "TEAM", scopeId: "team-1" },
         { scopeType: "PROJECT", scopeId: "proj-personal" },
       ]);
+    });
+  });
+
+  describe("mintability of the organization-chip fallback", () => {
+    // The cross-layer pin for the fallback: the screen's permission list is
+    // `defaultCliKeyPermissions()` intersected with the chip's ceiling, and
+    // the mint (`filterToGrantable`) keeps org-exclusive permissions only
+    // when an ORGANIZATION binding is selected. If either fact drifts, the
+    // fallback chip renders an approve button that can never be enabled, or
+    // the approval 422s server-side — both are the dead end this exists to
+    // prevent.
+    it("keeps the org-member bag inside the CLI defaults, so the chip's approval carries permissions", () => {
+      const defaults = new Set<string>(defaultCliKeyPermissions());
+      const bag = [...builtinRolePermissions("org-member")];
+      expect(bag.length).toBeGreaterThan(0);
+      expect(bag.filter((p) => defaults.has(p))).toEqual(bag);
+    });
+
+    it("holds a bag that is entirely org-exclusive, so a TEAM or PROJECT chip could never mint it", () => {
+      // This is why the fallback offers the ORGANIZATION chip and why a
+      // personal project without its TEAM binding row is skipped: the mint
+      // strips org-exclusive permissions from selections with no
+      // ORGANIZATION binding, and this bag has nothing else to give.
+      const bag = [...builtinRolePermissions("org-member")];
+      expect(
+        bag.filter((p) => isOrgExclusivePermission(p as Permission)),
+      ).toEqual(bag);
     });
   });
 

--- a/platform/app/src/pages/cli/__tests__/cliKeyScopeDefaults.unit.test.ts
+++ b/platform/app/src/pages/cli/__tests__/cliKeyScopeDefaults.unit.test.ts
@@ -4,6 +4,12 @@ import { defaultCliKeyScopes } from "../cliKeyScopeDefaults";
 describe("defaultCliKeyScopes()", () => {
   const organizationId = "org-1";
   const sharedTeamIds = ["team-1", "team-2"];
+  const personalProject = { id: "proj-personal", teamId: "team-personal" };
+  const personalTeamBinding = {
+    scopeType: "TEAM",
+    scopeId: "team-personal",
+    role: "ADMIN",
+  };
 
   describe("when the caller holds an ORGANIZATION-scoped ADMIN binding", () => {
     it("collapses to a single organization scope", () => {
@@ -14,7 +20,7 @@ describe("defaultCliKeyScopes()", () => {
           { scopeType: "TEAM", scopeId: "team-1", role: "MEMBER" },
         ],
         sharedTeamIds,
-        personalProjectId: "proj-personal",
+        personalProject,
       });
       expect(scopes).toEqual([
         { scopeType: "ORGANIZATION", scopeId: organizationId },
@@ -34,7 +40,7 @@ describe("defaultCliKeyScopes()", () => {
           },
         ],
         sharedTeamIds,
-        personalProjectId: null,
+        personalProject: null,
       });
       expect(scopes).toEqual([
         { scopeType: "ORGANIZATION", scopeId: organizationId },
@@ -57,9 +63,10 @@ describe("defaultCliKeyScopes()", () => {
             role: "MEMBER",
           },
           { scopeType: "TEAM", scopeId: "team-2", role: "MEMBER" },
+          personalTeamBinding,
         ],
         sharedTeamIds,
-        personalProjectId: "proj-personal",
+        personalProject,
       });
       expect(scopes).toEqual([
         { scopeType: "TEAM", scopeId: "team-2" },
@@ -67,7 +74,33 @@ describe("defaultCliKeyScopes()", () => {
       ]);
     });
 
-    it("offers the personal project when no team bindings exist", () => {
+    it("offers the personal project when its team binding is held", () => {
+      const scopes = defaultCliKeyScopes({
+        organizationId,
+        bindings: [
+          {
+            scopeType: "ORGANIZATION",
+            scopeId: organizationId,
+            role: "MEMBER",
+          },
+          personalTeamBinding,
+        ],
+        sharedTeamIds,
+        personalProject,
+      });
+      expect(scopes).toEqual([
+        { scopeType: "PROJECT", scopeId: "proj-personal" },
+      ]);
+    });
+
+    it("skips a personal project whose team binding is missing and offers the organization instead", () => {
+      // The personal-workspace owner grant is appended to the grants ledger
+      // asynchronously and is skipped outright on a ledger outage, so the
+      // personal project can be visible while its TEAM binding row is not.
+      // A PROJECT chip whose ceiling resolves to the org-member bag can
+      // never mint (both permissions are org-exclusive and the mint strips
+      // them from selections with no ORGANIZATION binding) — the org chip
+      // mints a view-only key instead of dead-ending the login.
       const scopes = defaultCliKeyScopes({
         organizationId,
         bindings: [
@@ -78,10 +111,28 @@ describe("defaultCliKeyScopes()", () => {
           },
         ],
         sharedTeamIds,
-        personalProjectId: "proj-personal",
+        personalProject,
       });
       expect(scopes).toEqual([
-        { scopeType: "PROJECT", scopeId: "proj-personal" },
+        { scopeType: "ORGANIZATION", scopeId: organizationId },
+      ]);
+    });
+
+    it("offers the organization when there is nothing else to offer", () => {
+      const scopes = defaultCliKeyScopes({
+        organizationId,
+        bindings: [
+          {
+            scopeType: "ORGANIZATION",
+            scopeId: organizationId,
+            role: "MEMBER",
+          },
+        ],
+        sharedTeamIds,
+        personalProject: null,
+      });
+      expect(scopes).toEqual([
+        { scopeType: "ORGANIZATION", scopeId: organizationId },
       ]);
     });
   });
@@ -99,9 +150,27 @@ describe("defaultCliKeyScopes()", () => {
           { scopeType: "TEAM", scopeId: "team-1", role: "VIEWER" },
         ],
         sharedTeamIds,
-        personalProjectId: null,
+        personalProject: null,
       });
       expect(scopes).toEqual([{ scopeType: "TEAM", scopeId: "team-1" }]);
+    });
+
+    it("offers the organization when there is nothing else to offer", () => {
+      const scopes = defaultCliKeyScopes({
+        organizationId,
+        bindings: [
+          {
+            scopeType: "ORGANIZATION",
+            scopeId: organizationId,
+            role: "VIEWER",
+          },
+        ],
+        sharedTeamIds,
+        personalProject: null,
+      });
+      expect(scopes).toEqual([
+        { scopeType: "ORGANIZATION", scopeId: organizationId },
+      ]);
     });
   });
 
@@ -112,9 +181,10 @@ describe("defaultCliKeyScopes()", () => {
         bindings: [
           { scopeType: "TEAM", scopeId: "team-1", role: "MEMBER" },
           { scopeType: "TEAM", scopeId: "team-other-org", role: "MEMBER" },
+          personalTeamBinding,
         ],
         sharedTeamIds,
-        personalProjectId: "proj-personal",
+        personalProject,
       });
       expect(scopes).toEqual([
         { scopeType: "TEAM", scopeId: "team-1" },
@@ -123,17 +193,19 @@ describe("defaultCliKeyScopes()", () => {
     });
   });
 
-  describe("when the caller holds no bindings", () => {
-    it("offers only the personal project", () => {
+  describe("when the caller holds no bindings at all", () => {
+    it("offers nothing: there is no ceiling to mint from", () => {
+      // With no RoleBinding rows the client ceiling is empty for every
+      // possible chip, so any offered scope would render an approve button
+      // that can never be enabled. The screen's "nothing here for you"
+      // state is the honest rendering of that.
       const scopes = defaultCliKeyScopes({
         organizationId,
         bindings: [],
         sharedTeamIds,
-        personalProjectId: "proj-personal",
+        personalProject,
       });
-      expect(scopes).toEqual([
-        { scopeType: "PROJECT", scopeId: "proj-personal" },
-      ]);
+      expect(scopes).toEqual([]);
     });
   });
 });

--- a/platform/app/src/pages/cli/__tests__/cliKeyScopeDefaults.unit.test.ts
+++ b/platform/app/src/pages/cli/__tests__/cliKeyScopeDefaults.unit.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { defaultCliKeyScopes } from "./cliKeyScopeDefaults";
+import { defaultCliKeyScopes } from "../cliKeyScopeDefaults";
 
 describe("defaultCliKeyScopes()", () => {
   const organizationId = "org-1";

--- a/platform/app/src/pages/cli/auth.tsx
+++ b/platform/app/src/pages/cli/auth.tsx
@@ -432,7 +432,9 @@ export default function CliAuthPage() {
         organizationId: selectedOrgId,
         bindings: myBindings.data,
         sharedTeamIds: sharedTeams.map((team) => team.id),
-        personalProjectId: personalProject?.id ?? null,
+        personalProject: personalProject
+          ? { id: personalProject.id, teamId: personalProject.teamId }
+          : null,
       }),
     );
     setScopeDefaultsOrgId(selectedOrgId);
@@ -474,7 +476,9 @@ export default function CliAuthPage() {
         organizationId: selectedOrgId,
         bindings: myBindings.data,
         sharedTeamIds: sharedTeams.map((team) => team.id),
-        personalProjectId: personalProject?.id ?? null,
+        personalProject: personalProject
+          ? { id: personalProject.id, teamId: personalProject.teamId }
+          : null,
       }).length > 0
     );
   }, [selectedOrgId, myBindings.data, sharedTeams, personalProject]);

--- a/platform/app/src/pages/cli/cliKeyScopeDefaults.ts
+++ b/platform/app/src/pages/cli/cliKeyScopeDefaults.ts
@@ -5,11 +5,13 @@
  * The key a `langwatch login` mints should reach everything the user works
  * with, so the preselected scopes mirror the widest access they hold:
  *
- *   - An ORGANIZATION-scoped binding of any role collapses to a single
- *     organization chip: one binding already covers every project, at
- *     whatever level the role allows. A MEMBER or VIEWER org binding is
- *     org-wide access too, so narrowing it to the personal project would
- *     hand the key less than the user holds.
+ *   - An ORGANIZATION-scoped ADMIN or CUSTOM binding collapses to a single
+ *     organization chip: the resolver answers org-scope checks from it (ADMIN
+ *     grants everything; CUSTOM resolves its own permission list). A MEMBER
+ *     or VIEWER org binding does NOT qualify — the resolver grants it the
+ *     org-member bag only (organization:view, aiTools:view), so an org-scoped
+ *     selection built from it can never carry traces or any other everyday
+ *     permission and the approve endpoint refuses it wholesale.
  *   - Everyone else starts from the shared teams they hold a TEAM-scoped
  *     binding on, plus their own personal workspace project. The team list
  *     keeps the organization's team order so the chips render stably.
@@ -33,10 +35,13 @@ export function defaultCliKeyScopes(args: {
 }): ScopeTriadEntry[] {
   const bindings = args.bindings ?? [];
 
-  const hasOrgBinding = bindings.some(
-    (b) => b.scopeType === "ORGANIZATION" && b.scopeId === args.organizationId,
+  const hasOrgWideBinding = bindings.some(
+    (b) =>
+      b.scopeType === "ORGANIZATION" &&
+      b.scopeId === args.organizationId &&
+      (b.role === "ADMIN" || b.role === "CUSTOM"),
   );
-  if (hasOrgBinding) {
+  if (hasOrgWideBinding) {
     return [{ scopeType: "ORGANIZATION", scopeId: args.organizationId }];
   }
 

--- a/platform/app/src/pages/cli/cliKeyScopeDefaults.ts
+++ b/platform/app/src/pages/cli/cliKeyScopeDefaults.ts
@@ -13,8 +13,19 @@
  *     selection built from it can never carry traces or any other everyday
  *     permission and the approve endpoint refuses it wholesale.
  *   - Everyone else starts from the shared teams they hold a TEAM-scoped
- *     binding on, plus their own personal workspace project. The team list
- *     keeps the organization's team order so the chips render stably.
+ *     binding on, plus their personal workspace project — the latter only
+ *     when the TEAM binding on the personal team is actually held: the
+ *     owner grant is appended to the grants ledger asynchronously and is
+ *     skipped outright on a ledger outage, so the project can be visible
+ *     while the binding row is not, and a PROJECT chip without it resolves
+ *     a ceiling of org-exclusive permissions the mint then strips
+ *     (`filterToGrantable`), failing the approval. The team list keeps the
+ *     organization's team order so the chips render stably.
+ *   - When that leaves nothing, any ORGANIZATION binding still yields the
+ *     organization chip: it mints a view-only key (organization:view,
+ *     aiTools:view), and a working login beats a dead-ended screen. Only a
+ *     caller with no bindings at all gets an empty list — no chip could
+ *     ever enable approve for them.
  *
  * Bindings come from `api.apiKey.myBindings` (the same source the API key
  * drawers mirror the user's ceiling from), so the defaults can never offer
@@ -31,7 +42,7 @@ export function defaultCliKeyScopes(args: {
   /** Non-personal team ids of the organization, in display order. */
   sharedTeamIds: string[];
   /** The caller's own personal workspace project, when one exists. */
-  personalProjectId: string | null;
+  personalProject: { id: string; teamId: string } | null;
 }): ScopeTriadEntry[] {
   const bindings = args.bindings ?? [];
 
@@ -52,8 +63,16 @@ export function defaultCliKeyScopes(args: {
     .filter((teamId) => boundTeamIds.has(teamId))
     .map((teamId) => ({ scopeType: "TEAM", scopeId: teamId }));
 
-  if (args.personalProjectId) {
-    scopes.push({ scopeType: "PROJECT", scopeId: args.personalProjectId });
+  if (args.personalProject && boundTeamIds.has(args.personalProject.teamId)) {
+    scopes.push({ scopeType: "PROJECT", scopeId: args.personalProject.id });
   }
-  return scopes;
+  if (scopes.length > 0) return scopes;
+
+  const hasAnyOrgBinding = bindings.some(
+    (b) => b.scopeType === "ORGANIZATION" && b.scopeId === args.organizationId,
+  );
+  if (hasAnyOrgBinding) {
+    return [{ scopeType: "ORGANIZATION", scopeId: args.organizationId }];
+  }
+  return [];
 }

--- a/platform/app/src/pages/cli/cliKeyScopeDefaults.unit.test.ts
+++ b/platform/app/src/pages/cli/cliKeyScopeDefaults.unit.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+import { defaultCliKeyScopes } from "./cliKeyScopeDefaults";
+
+describe("defaultCliKeyScopes()", () => {
+  const organizationId = "org-1";
+  const sharedTeamIds = ["team-1", "team-2"];
+
+  describe("when the caller holds an ORGANIZATION-scoped ADMIN binding", () => {
+    it("collapses to a single organization scope", () => {
+      const scopes = defaultCliKeyScopes({
+        organizationId,
+        bindings: [
+          { scopeType: "ORGANIZATION", scopeId: organizationId, role: "ADMIN" },
+          { scopeType: "TEAM", scopeId: "team-1", role: "MEMBER" },
+        ],
+        sharedTeamIds,
+        personalProjectId: "proj-personal",
+      });
+      expect(scopes).toEqual([
+        { scopeType: "ORGANIZATION", scopeId: organizationId },
+      ]);
+    });
+  });
+
+  describe("when the caller holds an ORGANIZATION-scoped CUSTOM binding", () => {
+    it("collapses to a single organization scope", () => {
+      const scopes = defaultCliKeyScopes({
+        organizationId,
+        bindings: [
+          {
+            scopeType: "ORGANIZATION",
+            scopeId: organizationId,
+            role: "CUSTOM",
+          },
+        ],
+        sharedTeamIds,
+        personalProjectId: null,
+      });
+      expect(scopes).toEqual([
+        { scopeType: "ORGANIZATION", scopeId: organizationId },
+      ]);
+    });
+  });
+
+  describe("when the caller holds an ORGANIZATION-scoped MEMBER binding", () => {
+    it("falls back to team scopes instead of the organization", () => {
+      // An org MEMBER binding grants the org-member bag only
+      // (organization:view, aiTools:view) — an org-scoped key selection
+      // built from it can never carry traces or any other everyday
+      // permission, so approve would refuse it wholesale.
+      const scopes = defaultCliKeyScopes({
+        organizationId,
+        bindings: [
+          {
+            scopeType: "ORGANIZATION",
+            scopeId: organizationId,
+            role: "MEMBER",
+          },
+          { scopeType: "TEAM", scopeId: "team-2", role: "MEMBER" },
+        ],
+        sharedTeamIds,
+        personalProjectId: "proj-personal",
+      });
+      expect(scopes).toEqual([
+        { scopeType: "TEAM", scopeId: "team-2" },
+        { scopeType: "PROJECT", scopeId: "proj-personal" },
+      ]);
+    });
+
+    it("offers the personal project when no team bindings exist", () => {
+      const scopes = defaultCliKeyScopes({
+        organizationId,
+        bindings: [
+          {
+            scopeType: "ORGANIZATION",
+            scopeId: organizationId,
+            role: "MEMBER",
+          },
+        ],
+        sharedTeamIds,
+        personalProjectId: "proj-personal",
+      });
+      expect(scopes).toEqual([
+        { scopeType: "PROJECT", scopeId: "proj-personal" },
+      ]);
+    });
+  });
+
+  describe("when the caller holds an ORGANIZATION-scoped VIEWER binding", () => {
+    it("falls back to team scopes instead of the organization", () => {
+      const scopes = defaultCliKeyScopes({
+        organizationId,
+        bindings: [
+          {
+            scopeType: "ORGANIZATION",
+            scopeId: organizationId,
+            role: "VIEWER",
+          },
+          { scopeType: "TEAM", scopeId: "team-1", role: "VIEWER" },
+        ],
+        sharedTeamIds,
+        personalProjectId: null,
+      });
+      expect(scopes).toEqual([{ scopeType: "TEAM", scopeId: "team-1" }]);
+    });
+  });
+
+  describe("when the caller holds only TEAM bindings", () => {
+    it("offers the bound shared teams plus the personal project", () => {
+      const scopes = defaultCliKeyScopes({
+        organizationId,
+        bindings: [
+          { scopeType: "TEAM", scopeId: "team-1", role: "MEMBER" },
+          { scopeType: "TEAM", scopeId: "team-other-org", role: "MEMBER" },
+        ],
+        sharedTeamIds,
+        personalProjectId: "proj-personal",
+      });
+      expect(scopes).toEqual([
+        { scopeType: "TEAM", scopeId: "team-1" },
+        { scopeType: "PROJECT", scopeId: "proj-personal" },
+      ]);
+    });
+  });
+
+  describe("when the caller holds no bindings", () => {
+    it("offers only the personal project", () => {
+      const scopes = defaultCliKeyScopes({
+        organizationId,
+        bindings: [],
+        sharedTeamIds,
+        personalProjectId: "proj-personal",
+      });
+      expect(scopes).toEqual([
+        { scopeType: "PROJECT", scopeId: "proj-personal" },
+      ]);
+    });
+  });
+});

--- a/platform/app/src/pages/settings/api-keys/utils.ts
+++ b/platform/app/src/pages/settings/api-keys/utils.ts
@@ -1,4 +1,5 @@
 import { createListCollection } from "@chakra-ui/react";
+import { builtinRolePermissions } from "@langwatch/authz";
 import { hasPermissionWithHierarchy } from "../../../server/api/rbac";
 import {
   type AccessLevel,
@@ -411,6 +412,16 @@ export function getUserPermissionsAtScope({
   if (!binding) return [];
   if (binding.scopeType === "ORGANIZATION" && binding.role === "ADMIN") {
     return categorizablePermissions();
+  }
+  // A non-ADMIN ORGANIZATION-scoped builtin binding grants the org-member bag
+  // only (organization:view, aiTools:view) — the resolver's non-ADMIN branch
+  // never consults the team-role bags for it. Offering the team bag here made
+  // the ceiling overstate what the approve/save endpoints would accept, so a
+  // selection built from it was refused wholesale with "exceeds your own
+  // access". CUSTOM org bindings resolve their own permission list and keep
+  // the injected bag.
+  if (binding.scopeType === "ORGANIZATION" && binding.role !== "CUSTOM") {
+    return [...builtinRolePermissions("org-member")];
   }
   return getRolePerms(binding.role);
 }

--- a/platform/app/src/pages/settings/api-keys/utils.ts
+++ b/platform/app/src/pages/settings/api-keys/utils.ts
@@ -1,5 +1,8 @@
 import { createListCollection } from "@chakra-ui/react";
-import { builtinRolePermissions } from "@langwatch/authz";
+import {
+  bindingScopeCanGrantPermission,
+  builtinRolePermissions,
+} from "@langwatch/authz";
 import { hasPermissionWithHierarchy } from "../../../server/api/rbac";
 import {
   type AccessLevel,
@@ -418,10 +421,20 @@ export function getUserPermissionsAtScope({
   // never consults the team-role bags for it. Offering the team bag here made
   // the ceiling overstate what the approve/save endpoints would accept, so a
   // selection built from it was refused wholesale with "exceeds your own
-  // access". CUSTOM org bindings resolve their own permission list and keep
-  // the injected bag.
+  // access". The bag is further narrowed to what a binding at the REQUESTED
+  // scope may carry: both bag permissions are org-exclusive, and the CLI mint
+  // strips org-exclusive permissions from any selection with no ORGANIZATION
+  // binding (`filterToGrantable`) — a TEAM or PROJECT chip covered only by
+  // this fallback therefore has an empty ceiling, not a view-only one that
+  // 422s at approval. CUSTOM org bindings resolve their own permission list
+  // and keep the injected bag.
   if (binding.scopeType === "ORGANIZATION" && binding.role !== "CUSTOM") {
-    return [...builtinRolePermissions("org-member")];
+    return [...builtinRolePermissions("org-member")].filter((permission) =>
+      bindingScopeCanGrantPermission({
+        scopeType: scopeType as "ORGANIZATION" | "TEAM" | "PROJECT",
+        permission,
+      }),
+    );
   }
   return getRolePerms(binding.role);
 }

--- a/platform/app/src/pages/settings/api-keys/utils.unit.test.ts
+++ b/platform/app/src/pages/settings/api-keys/utils.unit.test.ts
@@ -667,7 +667,7 @@ describe("getUserPermissionsAtScope()", () => {
   });
 
   describe("when an org-level MEMBER binding covers a project scope", () => {
-    it("returns the org-member bag, not the team-role bag", () => {
+    it("returns nothing: the whole org-member bag is org-exclusive", () => {
       const result = getUserPermissionsAtScope({
         myBindings: [
           { scopeType: "ORGANIZATION", scopeId: "org-1", role: "MEMBER" },
@@ -679,11 +679,30 @@ describe("getUserPermissionsAtScope()", () => {
         isServiceKey: false,
         getTeamRolePermissions: mockGetPerms,
       });
-      // The resolver grants an ORGANIZATION-scoped non-ADMIN binding the
-      // org-member bag only — offering the team bag here made the authorize
-      // screen send permissions the approve endpoint then refused with
-      // "exceeds your own access".
-      expect(result).toEqual([...builtinRolePermissions("org-member")]);
+      // The org-member bag (organization:view, aiTools:view) targets
+      // org-tier-only resources, and the mint strips org-exclusive
+      // permissions from any selection with no ORGANIZATION binding
+      // (`filterToGrantable`). Offering them on a PROJECT chip made the
+      // approve request carry only permissions the server then dropped,
+      // failing with "Select at least one permission".
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("when an org-level MEMBER binding covers a team scope", () => {
+    it("returns nothing: no org-exclusive permission is grantable there", () => {
+      const result = getUserPermissionsAtScope({
+        myBindings: [
+          { scopeType: "ORGANIZATION", scopeId: "org-1", role: "MEMBER" },
+        ],
+        scopeType: "TEAM",
+        scopeId: "team-1",
+        organizationId: "org-1",
+        orgProjects,
+        isServiceKey: false,
+        getTeamRolePermissions: mockGetPerms,
+      });
+      expect(result).toEqual([]);
     });
   });
 

--- a/platform/app/src/pages/settings/api-keys/utils.unit.test.ts
+++ b/platform/app/src/pages/settings/api-keys/utils.unit.test.ts
@@ -1,3 +1,4 @@
+import { builtinRolePermissions } from "@langwatch/authz";
 import { describe, expect, it } from "vitest";
 import {
   categorizablePermissions,
@@ -665,8 +666,8 @@ describe("getUserPermissionsAtScope()", () => {
     });
   });
 
-  describe("when an org-level non-ADMIN binding covers a project scope", () => {
-    it("returns the team-role bag", () => {
+  describe("when an org-level MEMBER binding covers a project scope", () => {
+    it("returns the org-member bag, not the team-role bag", () => {
       const result = getUserPermissionsAtScope({
         myBindings: [
           { scopeType: "ORGANIZATION", scopeId: "org-1", role: "MEMBER" },
@@ -678,7 +679,62 @@ describe("getUserPermissionsAtScope()", () => {
         isServiceKey: false,
         getTeamRolePermissions: mockGetPerms,
       });
-      expect(result).toEqual(["project:view", "project:update"]);
+      // The resolver grants an ORGANIZATION-scoped non-ADMIN binding the
+      // org-member bag only — offering the team bag here made the authorize
+      // screen send permissions the approve endpoint then refused with
+      // "exceeds your own access".
+      expect(result).toEqual([...builtinRolePermissions("org-member")]);
+    });
+  });
+
+  describe("when an org-level MEMBER binding is checked at org scope", () => {
+    it("returns the org-member bag", () => {
+      const result = getUserPermissionsAtScope({
+        myBindings: [
+          { scopeType: "ORGANIZATION", scopeId: "org-1", role: "MEMBER" },
+        ],
+        scopeType: "ORGANIZATION",
+        scopeId: "org-1",
+        organizationId: "org-1",
+        orgProjects,
+        isServiceKey: false,
+        getTeamRolePermissions: mockGetPerms,
+      });
+      expect(result).toEqual([...builtinRolePermissions("org-member")]);
+    });
+  });
+
+  describe("when an org-level VIEWER binding is checked at org scope", () => {
+    it("returns the org-member bag, mirroring the resolver's non-ADMIN branch", () => {
+      const result = getUserPermissionsAtScope({
+        myBindings: [
+          { scopeType: "ORGANIZATION", scopeId: "org-1", role: "VIEWER" },
+        ],
+        scopeType: "ORGANIZATION",
+        scopeId: "org-1",
+        organizationId: "org-1",
+        orgProjects,
+        isServiceKey: false,
+        getTeamRolePermissions: mockGetPerms,
+      });
+      expect(result).toEqual([...builtinRolePermissions("org-member")]);
+    });
+  });
+
+  describe("when an org-level CUSTOM binding is checked at org scope", () => {
+    it("keeps the injected role bag (custom roles resolve their own permissions)", () => {
+      const result = getUserPermissionsAtScope({
+        myBindings: [
+          { scopeType: "ORGANIZATION", scopeId: "org-1", role: "CUSTOM" },
+        ],
+        scopeType: "ORGANIZATION",
+        scopeId: "org-1",
+        organizationId: "org-1",
+        orgProjects,
+        isServiceKey: false,
+        getTeamRolePermissions: mockGetPerms,
+      });
+      expect(result).toEqual(["project:view"]);
     });
   });
 });


### PR DESCRIPTION
## For humans

Some users have their access set at the organization level with a "Member" role. For them, logging in with the LangWatch CLI was impossible: the authorize screen offered permissions they don't actually hold, and the server rejected the whole approval with "Cannot grant permission — exceeds your own access". After this fix, the screen only offers what the server will accept, and it points these users at their teams and personal workspace — the places where their access actually works — so login succeeds. When none of those exist, the screen falls back to a view-only organization key rather than a dead end.

## Why

The client and the server disagreed about what an ORGANIZATION-scoped MEMBER binding grants. The server (both the authz engine and the legacy resolver) answers: the org-member bag only — `organization:view` and `aiTools:view`. The client's ceiling helper answered: the full team-member bag (traces, datasets, prompts, `agentCache:manage`, …). The CLI authorize screen built its default selection from the client's answer, preselected the whole organization as scope, and every Approve was refused on the first permission the server checked. A customer report surfaced it; there was no working selection at org scope for these users.

Closes #7818

## What changed

- `getUserPermissionsAtScope` (shared by the CLI authorize screen and the Create/Edit API key drawers): a non-ADMIN builtin ORGANIZATION-scoped binding now resolves to `builtinRolePermissions("org-member")`, exactly what the server resolver grants (`role-binding-resolver.ts:449-459`), further narrowed by `bindingScopeCanGrantPermission` to what a binding at the requested scope may carry — mirroring the mint's `filterToGrantable`, so a TEAM/PROJECT chip covered only by the org fallback shows an empty ceiling instead of one that fails at approval. ORG+ADMIN still means everything; ORG+CUSTOM keeps the injected bag since custom roles resolve their own permission list.
- `defaultCliKeyScopes`: only ADMIN and CUSTOM org bindings collapse the scope selection to the single organization chip. MEMBER/VIEWER org bindings fall back to the user's team scopes plus their personal workspace project — offered only when the TEAM binding on the personal team is actually held (the owner grant is appended to the grants ledger asynchronously and skipped on a ledger outage, so the project can be visible while the binding row is not). When nothing else is offerable, any ORGANIZATION binding yields the organization chip, which mints a view-only key — a working login instead of a dead-ended screen. Only a caller with no bindings at all gets the empty "nothing to offer" state.

The doc comments on both functions state the resolver semantics they mirror. Follow-up #7824 tracks retiring the whole hand-mirrored ceiling class by computing it server-side.

## Test plan

- `cliKeyScopeDefaults.unit.test.ts` (12 tests): ADMIN/CUSTOM collapse, MEMBER/VIEWER fall back to teams + personal project, personal chip skipped without its team binding, org-chip fallback for MEMBER and VIEWER, team-only and no-binding cases, plus the cross-layer mintability pin (the org-member bag stays inside `defaultCliKeyPermissions()` and is entirely org-exclusive — either drifting recreates the dead end).
- `utils.unit.test.ts`: the org-level non-ADMIN cases assert the org-member bag at org scope and an empty ceiling at team/project scope (they previously codified the wrong team-bag behavior), plus VIEWER and CUSTOM org-binding cases. All new/changed assertions fail without the fix.
- Full `src/pages/cli` + `src/pages/settings/api-keys` unit and component suites green (128 tests). `pnpm typecheck`, `pnpm typecheck:all`, and the CI biome new-violations gate (run locally against the merge base) clean.

## Anything surprising?

- The approve endpoint refusing the whole selection on the first unheld permission is by design (a silent narrowing would mint a key weaker than the user reviewed) — untouched.
- The fallback organization key is view-only (`organization:view`, `aiTools:view`): the CLI logs in, but commands needing trace or prompt permissions are refused per-request until an admin grants a team role. Deliberate — a passable screen that can be upgraded beats a locked one.
- Client/server predicate parity (`bindingScopeCanGrantPermission` vs the mint's legacy `isOrgExclusivePermission`) is already pinned by `roles-parity.unit.test.ts`.
- ORG+CUSTOM bindings still show the generic CUSTOM baseline in the client ceiling rather than the custom role's real permission list; pre-existing gap, tracked in #7824.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected CLI key scope selection for organization bindings.
  * Organization `ADMIN` and `CUSTOM` bindings now use organization-level scopes.
  * `MEMBER` and `VIEWER` bindings correctly fall back to eligible team or personal project scopes.
  * Personal project scopes now require the appropriate team access.
  * Added a view-only organization fallback when no narrower scope is available.
  * Improved permission filtering for organization-level access.
* **Tests**
  * Added coverage for roles, team-only access, personal projects, and users without bindings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->