### PR TITLE
feat(governance): adr-128 wave 2 — retention + SIEM TTL (#7746)

### DIFF
--- a/platform/app/ee/governance/__tests__/governanceCostCoverage.integration.test.ts
+++ b/platform/app/ee/governance/__tests__/governanceCostCoverage.integration.test.ts
@@ -1,0 +1,373 @@
+// SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+
+/**
+ * @vitest-environment node
+ *
+ * The key-to-bill mapping's rules, against real Postgres — because every one of
+ * them is a database guarantee and nothing else. An application-level check
+ * would pass this file while leaving the constraint absent, which is the
+ * failure this exists to catch.
+ *
+ * Requires the `btree_gist` extension and the triggers the migration installs.
+ *
+ * Spec: specs/governance/governance-cost-coverage.feature
+ * Decision: ADR-128 §7
+ */
+import { nanoid } from "nanoid";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { prisma } from "~/server/db";
+import { cleanupTestRows } from "~/test-utils/cleanupTestRows";
+import { IngestionSourceKeyCoverageRepository } from "../repositories/ingestionSourceKeyCoverage.repository";
+import { CostCoverageService } from "../services/costCoverage.service";
+
+const ns = `gov-coverage-${nanoid(8)}`;
+const organizationId = `org_${ns}`;
+const otherOrganizationId = `org_other_${ns}`;
+
+/** Postgres' exclusion-constraint violation. Asserted by code, never by prose. */
+const EXCLUSION_VIOLATION = "23P01";
+/** Postgres' check-constraint violation. */
+const CHECK_VIOLATION = "23514";
+/**
+ * How Prisma reports what the organization-mismatch trigger raises.
+ *
+ * The trigger raises SQLSTATE 23503, and this is the one case where asserting
+ * on a Prisma code rather than the driver's is right: Prisma has a specific
+ * mapping for it (`P2003`, foreign key constraint violated) and replaces the
+ * raw code entirely, so the SQLSTATE is not in the error at all to be read.
+ */
+const PRISMA_FOREIGN_KEY_VIOLATION = "P2003";
+
+/**
+ * The Postgres SQLSTATE behind a Prisma failure.
+ *
+ * Prisma reports a constraint it has no code of its own for as `P2039` and puts
+ * the driver's error underneath, so reading `error.code` alone would assert on
+ * Prisma's "something happened" wrapper and pass whether the constraint exists
+ * or not. This walks the cause chain to the code the database actually raised.
+ */
+const sqlState = (error: unknown): string | undefined => {
+  const seen = new Set<unknown>();
+  let current: unknown = error;
+  while (current && typeof current === "object" && !seen.has(current)) {
+    seen.add(current);
+    const record = current as Record<string, unknown>;
+    const code = record.code;
+    if (
+      typeof code === "string" &&
+      /^[0-9A-Z]{5}$/.test(code) &&
+      code[0] !== "P"
+    ) {
+      return code;
+    }
+    const meta = record.meta;
+    if (meta && typeof meta === "object") {
+      const metaCode = (meta as Record<string, unknown>).code;
+      if (typeof metaCode === "string" && metaCode[0] !== "P") return metaCode;
+    }
+    current =
+      record.cause ?? (meta as Record<string, unknown> | undefined)?.cause;
+  }
+  const message = String((error as { message?: string })?.message ?? "");
+  return /\b(23P01|23514|23503)\b/.exec(message)?.[1];
+};
+
+const makeKey = async (params: { id: string; organizationId: string }) => {
+  await prisma.virtualKey.create({
+    data: {
+      id: params.id,
+      organizationId: params.organizationId,
+      name: `--test-${params.id}`,
+      hashedSecret: `hash_${params.id}`,
+      displayPrefix: `vk-test-${params.id.slice(-6)}`,
+      createdById: `user_${ns}`,
+    },
+  });
+};
+
+const utc = (day: string) => new Date(`${day}T00:00:00.000Z`);
+
+const repo = new IngestionSourceKeyCoverageRepository();
+const service = new CostCoverageService(prisma, repo);
+
+describe("Feature: every dollar has one home", () => {
+  const ownKeyId = `vk_${ns}_own`;
+  const foreignKeyId = `vk_${ns}_foreign`;
+
+  beforeAll(async () => {
+    await makeKey({ id: ownKeyId, organizationId });
+    await makeKey({ id: foreignKeyId, organizationId: otherOrganizationId });
+  });
+
+  afterAll(() =>
+    cleanupTestRows(prisma, [
+      ["ingestionSourceKeyCoverage", { organizationId }],
+      ["ingestionSourceKeyCoverage", { organizationId: otherOrganizationId }],
+      ["virtualKey", { organizationId }],
+      ["virtualKey", { organizationId: otherOrganizationId }],
+    ]),
+  );
+
+  describe("given a bill covering a gateway key from the first of the month", () => {
+    const keyId = `${ownKeyId}`;
+
+    /** @scenario "A second bill cannot claim a key another bill already covers" */
+    it("refuses a second bill claiming the same key over the same period", async () => {
+      await repo.open(prisma, {
+        organizationId,
+        ingestionSourceId: `bill_1_${ns}`,
+        virtualKeyId: keyId,
+        validFrom: utc("2026-03-01"),
+      });
+
+      const refused = await repo
+        .open(prisma, {
+          organizationId,
+          ingestionSourceId: `bill_2_${ns}`,
+          virtualKeyId: keyId,
+          validFrom: utc("2026-03-01"),
+        })
+        .catch((error: unknown) => error);
+
+      expect(sqlState(refused)).toBe(EXCLUSION_VIOLATION);
+    });
+
+    /** @scenario "A bill may cover a key another bill has finished covering" */
+    it("accepts a bill taking over where the previous one ended", async () => {
+      const takeoverKey = `vk_${ns}_takeover`;
+      await makeKey({ id: takeoverKey, organizationId });
+
+      const first = await repo.open(prisma, {
+        organizationId,
+        ingestionSourceId: `bill_1_${ns}`,
+        virtualKeyId: takeoverKey,
+        validFrom: utc("2026-01-01"),
+      });
+      await repo.close(prisma, {
+        organizationId,
+        id: first.id,
+        validTo: utc("2026-06-01"),
+      });
+      await repo.open(prisma, {
+        organizationId,
+        ingestionSourceId: `bill_2_${ns}`,
+        virtualKeyId: takeoverKey,
+        validFrom: utc("2026-06-01"),
+      });
+
+      const may = await service.getCoverageOnDay({
+        organizationId,
+        day: "2026-05-31",
+      });
+      const june = await service.getCoverageOnDay({
+        organizationId,
+        day: "2026-06-01",
+      });
+
+      expect(may.get(takeoverKey)).toBe(`bill_1_${ns}`);
+      expect(june.get(takeoverKey)).toBe(`bill_2_${ns}`);
+    });
+  });
+
+  describe("when coverage describes no time at all", () => {
+    /** @scenario "Coverage that starts and ends at the same moment is refused" */
+    it("refuses a period that ends the instant it begins", async () => {
+      const zeroWidthKey = `vk_${ns}_zero`;
+      await makeKey({ id: zeroWidthKey, organizationId });
+
+      const refused = await prisma.ingestionSourceKeyCoverage
+        .create({
+          data: {
+            organizationId,
+            ingestionSourceId: `bill_1_${ns}`,
+            virtualKeyId: zeroWidthKey,
+            validFrom: utc("2026-03-01"),
+            validTo: utc("2026-03-01"),
+          },
+        })
+        .catch((error: unknown) => error);
+
+      // An empty range overlaps nothing, not even itself, so the exclusion
+      // constraint never sees it — the CHECK is the only thing that does.
+      expect(sqlState(refused)).toBe(CHECK_VIOLATION);
+    });
+
+    /** @scenario "Coverage that ends before it begins is refused" */
+    it("refuses a period that ends before it begins", async () => {
+      const invertedKey = `vk_${ns}_inverted`;
+      await makeKey({ id: invertedKey, organizationId });
+
+      const refused = await prisma.ingestionSourceKeyCoverage
+        .create({
+          data: {
+            organizationId,
+            ingestionSourceId: `bill_1_${ns}`,
+            virtualKeyId: invertedKey,
+            validFrom: utc("2026-06-01"),
+            validTo: utc("2026-03-01"),
+          },
+        })
+        .catch((error: unknown) => error);
+
+      expect(sqlState(refused)).toBe(CHECK_VIOLATION);
+    });
+  });
+
+  describe("given a gateway key belonging to one organization", () => {
+    /** @scenario "Coverage cannot name a different organization than its key" */
+    it("refuses coverage recorded under another organization", async () => {
+      const refused = await repo
+        .open(prisma, {
+          organizationId,
+          ingestionSourceId: `bill_1_${ns}`,
+          virtualKeyId: foreignKeyId,
+          validFrom: utc("2026-03-01"),
+        })
+        .catch((error: unknown) => error);
+
+      expect((refused as { code?: string }).code).toBe(
+        PRISMA_FOREIGN_KEY_VIOLATION,
+      );
+    });
+
+    it("refuses coverage of a key that does not exist", async () => {
+      const refused = await repo
+        .open(prisma, {
+          organizationId,
+          ingestionSourceId: `bill_1_${ns}`,
+          virtualKeyId: `vk_${ns}_missing`,
+          validFrom: utc("2026-03-01"),
+        })
+        .catch((error: unknown) => error);
+
+      expect((refused as { code?: string }).code).toBe(
+        PRISMA_FOREIGN_KEY_VIOLATION,
+      );
+    });
+  });
+
+  describe("given a bill covering a gateway key", () => {
+    /** @scenario "Moving a key to another bill closes the old coverage and opens the new together" */
+    it("closes the old coverage and opens the new one at the same instant", async () => {
+      const movedKey = `vk_${ns}_moved`;
+      await makeKey({ id: movedKey, organizationId });
+      await service.pointKeyAtSource({
+        organizationId,
+        virtualKeyId: movedKey,
+        ingestionSourceId: `bill_1_${ns}`,
+        effectiveFrom: utc("2026-01-01"),
+      });
+
+      await service.pointKeyAtSource({
+        organizationId,
+        virtualKeyId: movedKey,
+        ingestionSourceId: `bill_2_${ns}`,
+        effectiveFrom: utc("2026-06-01"),
+      });
+
+      const periods = (
+        await repo.findAllByOrganization(prisma, { organizationId })
+      ).filter((row) => row.virtualKeyId === movedKey);
+      expect(periods).toHaveLength(2);
+      expect(periods[0]?.validTo).toEqual(utc("2026-06-01"));
+      expect(periods[1]?.validFrom).toEqual(utc("2026-06-01"));
+
+      // No day between the two belongs to nobody, and none belongs to both.
+      for (const day of ["2026-05-31", "2026-06-01"]) {
+        const covering = await service.getCoverageOnDay({
+          organizationId,
+          day,
+        });
+        expect(covering.has(movedKey)).toBe(true);
+      }
+    });
+
+    /** @scenario "A failed move leaves the original coverage intact" */
+    it("leaves the original coverage intact when the move fails partway", async () => {
+      const stuckKey = `vk_${ns}_stuck`;
+      await makeKey({ id: stuckKey, organizationId });
+      await service.pointKeyAtSource({
+        organizationId,
+        virtualKeyId: stuckKey,
+        ingestionSourceId: `bill_1_${ns}`,
+        effectiveFrom: utc("2026-01-01"),
+      });
+
+      // The successor's write fails AFTER the predecessor has already been
+      // closed inside the same transaction. If the two writes were independent,
+      // this is exactly the interleave that would leave the key covered by no
+      // bill from June onward, with nothing raised and nothing to find it
+      // later. Real Postgres, so what is proved is the rollback, not a double.
+      const failsToOpen = Object.create(
+        repo,
+      ) as IngestionSourceKeyCoverageRepository;
+      failsToOpen.open = () => Promise.reject(new Error("write lost"));
+      const refused = await new CostCoverageService(prisma, failsToOpen)
+        .pointKeyAtSource({
+          organizationId,
+          virtualKeyId: stuckKey,
+          ingestionSourceId: `bill_2_${ns}`,
+          effectiveFrom: utc("2026-06-01"),
+        })
+        .catch((error: unknown) => error);
+      expect(refused).toBeInstanceOf(Error);
+
+      const periods = (
+        await repo.findAllByOrganization(prisma, { organizationId })
+      ).filter((row) => row.virtualKeyId === stuckKey);
+      expect(periods).toHaveLength(1);
+      expect(periods[0]?.validTo).toBeNull();
+      expect(periods[0]?.ingestionSourceId).toBe(`bill_1_${ns}`);
+    });
+  });
+
+  describe("when a gateway key is deleted", () => {
+    it("takes its coverage with it, so the key's slot is not held forever", async () => {
+      const doomedKey = `vk_${ns}_doomed`;
+      await makeKey({ id: doomedKey, organizationId });
+      await repo.open(prisma, {
+        organizationId,
+        ingestionSourceId: `bill_1_${ns}`,
+        virtualKeyId: doomedKey,
+        validFrom: utc("2026-01-01"),
+      });
+
+      await prisma.virtualKey.deleteMany({
+        where: { organizationId, id: doomedKey },
+      });
+
+      const left = (
+        await repo.findAllByOrganization(prisma, { organizationId })
+      ).filter((row) => row.virtualKeyId === doomedKey);
+      expect(left).toHaveLength(0);
+    });
+  });
+
+  describe("when two administrators claim the same key at once", () => {
+    it("tells the loser another bill already covers it", async () => {
+      const racedKey = `vk_${ns}_raced`;
+      await makeKey({ id: racedKey, organizationId });
+      await repo.open(prisma, {
+        organizationId,
+        ingestionSourceId: `bill_1_${ns}`,
+        virtualKeyId: racedKey,
+        validFrom: utc("2026-01-01"),
+      });
+
+      // The service's own read would find the open row and close it, so the
+      // constraint is reached by a writer that never saw it — which is what a
+      // racing second administrator is.
+      const refused = await repo
+        .open(prisma, {
+          organizationId,
+          ingestionSourceId: `bill_2_${ns}`,
+          virtualKeyId: racedKey,
+          validFrom: utc("2026-02-01"),
+        })
+        .catch((error: unknown) => error);
+
+      expect(sqlState(refused)).toBe(EXCLUSION_VIOLATION);
+    });
+  });
+});

--- a/platform/app/ee/governance/__tests__/governanceCostCoverage.integration.test.ts
+++ b/platform/app/ee/governance/__tests__/governanceCostCoverage.integration.test.ts
@@ -19,6 +19,10 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { prisma } from "~/server/db";
 import { cleanupTestRows } from "~/test-utils/cleanupTestRows";
 import { IngestionSourceKeyCoverageRepository } from "../repositories/ingestionSourceKeyCoverage.repository";
+import {
+  CoverageStartNotAfterCurrentError,
+  GatewayKeyAlreadyCoveredError,
+} from "../services/costCoverage.errors";
 import { CostCoverageService } from "../services/costCoverage.service";
 
 const ns = `gov-coverage-${nanoid(8)}`;
@@ -368,6 +372,105 @@ describe("Feature: every dollar has one home", () => {
         .catch((error: unknown) => error);
 
       expect(sqlState(refused)).toBe(EXCLUSION_VIOLATION);
+    });
+
+    /**
+     * The two tests below are the only ones that reach the service's translation
+     * of a database refusal into words. Everything else here drives the
+     * repository, where the assertion is a SQLSTATE — which proves the
+     * constraint holds but proves nothing about what the losing administrator is
+     * shown. Without these, that translation could be deleted whole and every
+     * other test would still pass.
+     *
+     * Both simulate exactly one thing: what the losing transaction READ. The
+     * stale read is what makes a race a race, and it is not reproducible on
+     * demand from two real connections. The write it then makes, the constraint
+     * that refuses it and the error that comes back are all real.
+     */
+    /** @scenario "A second bill cannot claim a key another bill already covers" */
+    it("tells the losing administrator, in words, that another bill covers it", async () => {
+      const contestedKey = `vk_${ns}_contested`;
+      await makeKey({ id: contestedKey, organizationId });
+      await repo.open(prisma, {
+        organizationId,
+        ingestionSourceId: `bill_1_${ns}`,
+        virtualKeyId: contestedKey,
+        validFrom: utc("2026-01-01"),
+      });
+
+      // The loser's transaction read the key before the winner committed, so it
+      // finds no open row to close and goes straight to opening its own.
+      const readsNothing = Object.create(
+        repo,
+      ) as IngestionSourceKeyCoverageRepository;
+      readsNothing.findOpenForUpdate = () => Promise.resolve(null);
+
+      const refused = await new CostCoverageService(prisma, readsNothing)
+        .pointKeyAtSource({
+          organizationId,
+          virtualKeyId: contestedKey,
+          ingestionSourceId: `bill_2_${ns}`,
+          effectiveFrom: utc("2026-02-01"),
+        })
+        .catch((error: unknown) => error);
+
+      expect(refused).toBeInstanceOf(GatewayKeyAlreadyCoveredError);
+      expect((refused as GatewayKeyAlreadyCoveredError).code).toBe(
+        "ingestion_source_key_already_covered",
+      );
+      expect((refused as GatewayKeyAlreadyCoveredError).meta).toMatchObject({
+        virtualKeyId: contestedKey,
+      });
+
+      // The winner's coverage is untouched, and no second row was left behind.
+      const periods = (
+        await repo.findAllByOrganization(prisma, { organizationId })
+      ).filter((row) => row.virtualKeyId === contestedKey);
+      expect(periods).toHaveLength(1);
+      expect(periods[0]?.ingestionSourceId).toBe(`bill_1_${ns}`);
+    });
+
+    it("tells the losing administrator when the coverage it is closing already starts then", async () => {
+      const seamKey = `vk_${ns}_seam`;
+      await makeKey({ id: seamKey, organizationId });
+      const current = await repo.open(prisma, {
+        organizationId,
+        ingestionSourceId: `bill_1_${ns}`,
+        virtualKeyId: seamKey,
+        validFrom: utc("2026-06-01"),
+      });
+
+      // Here the winner moved the key to a period beginning at the very instant
+      // this transaction is moving it from. The stale read is of the row as it
+      // was BEFORE that, so the service's own "after the current start" check
+      // passes; the close it then makes leaves a period covering no time, and an
+      // empty range overlaps nothing, so the CHECK is the only thing that sees
+      // it.
+      const readsStale = Object.create(
+        repo,
+      ) as IngestionSourceKeyCoverageRepository;
+      readsStale.findOpenForUpdate = () =>
+        Promise.resolve({ ...current, validFrom: utc("2026-01-01") });
+
+      const refused = await new CostCoverageService(prisma, readsStale)
+        .pointKeyAtSource({
+          organizationId,
+          virtualKeyId: seamKey,
+          ingestionSourceId: `bill_2_${ns}`,
+          effectiveFrom: utc("2026-06-01"),
+        })
+        .catch((error: unknown) => error);
+
+      expect(refused).toBeInstanceOf(CoverageStartNotAfterCurrentError);
+      expect((refused as CoverageStartNotAfterCurrentError).code).toBe(
+        "ingestion_source_coverage_not_after_start",
+      );
+
+      const periods = (
+        await repo.findAllByOrganization(prisma, { organizationId })
+      ).filter((row) => row.virtualKeyId === seamKey);
+      expect(periods).toHaveLength(1);
+      expect(periods[0]?.validTo).toBeNull();
     });
   });
 });

--- a/platform/app/ee/governance/__tests__/governanceEventLogHorizon.integration.test.ts
+++ b/platform/app/ee/governance/__tests__/governanceEventLogHorizon.integration.test.ts
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+
+/**
+ * @vitest-environment node
+ *
+ * How far back the event log reaches, read against the ClickHouse we deploy.
+ *
+ * The point of the query is that it is an OBSERVATION. A boundary computed
+ * from the retention policy would be a prediction, and wrong in both
+ * directions — `_retention_days` is stamped from the policy in force when a row
+ * was written, and ClickHouse applies a DELETE TTL lazily on merge. So this
+ * suite asserts against rows actually sitting in the table.
+ *
+ * Spec: specs/governance/governance-data-retention.feature
+ * Decision: ADR-128 §9 step 4, ADR-022
+ */
+import type { ClickHouseClient } from "@clickhouse/client";
+import { nanoid } from "nanoid";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { getTestClickHouseClient } from "~/server/event-sourcing/__tests__/integration/testContainers";
+import { GovernanceEventLogHorizonClickHouseRepository } from "../services/governanceEventLogHorizon.clickhouse.repository";
+
+const ns = nanoid(8);
+const RECENT_TENANT = `project_gov_recent_${ns}`;
+const DEEP_TENANT = `project_gov_deep_${ns}`;
+const UNKNOWN_TIME_TENANT = `project_gov_untimed_${ns}`;
+const EMPTY_TENANT = `project_gov_empty_${ns}`;
+
+const ALL_TENANTS = [
+  RECENT_TENANT,
+  DEEP_TENANT,
+  UNKNOWN_TIME_TENANT,
+  EMPTY_TENANT,
+];
+
+const ms = (iso: string) => new Date(iso).getTime();
+
+/**
+ * One event-log record. Only the columns this file reasons about carry meaning;
+ * the rest take the table's defaults.
+ */
+const event = (overrides: {
+  tenantId: string;
+  occurredAtMs: number;
+  eventId: string;
+}) => ({
+  TenantId: overrides.tenantId,
+  IdempotencyKey: overrides.eventId,
+  AggregateType: "governance_cost",
+  AggregateId: `agg-${ns}`,
+  EventId: overrides.eventId,
+  EventType: "PulledUsageRecorded",
+  EventVersion: "1",
+  EventTimestamp: overrides.occurredAtMs,
+  EventPayload: "{}",
+  EventOccurredAt: overrides.occurredAtMs,
+});
+
+describe("Feature: how far back the event log still reaches", () => {
+  let client: ClickHouseClient;
+  let repository: GovernanceEventLogHorizonClickHouseRepository;
+
+  beforeAll(async () => {
+    const testClient = getTestClickHouseClient();
+    if (!testClient) {
+      throw new Error(
+        "No test ClickHouse client — this suite reads a real event_log and proves nothing without one",
+      );
+    }
+    client = testClient;
+    repository = new GovernanceEventLogHorizonClickHouseRepository(
+      async () => client,
+    );
+
+    await client.insert({
+      table: "event_log",
+      values: [
+        event({
+          tenantId: RECENT_TENANT,
+          occurredAtMs: ms("2026-08-01T00:00:00.000Z"),
+          eventId: `recent-oldest-${ns}`,
+        }),
+        event({
+          tenantId: RECENT_TENANT,
+          occurredAtMs: ms("2026-08-25T00:00:00.000Z"),
+          eventId: `recent-newest-${ns}`,
+        }),
+        event({
+          tenantId: DEEP_TENANT,
+          occurredAtMs: ms("2025-02-14T00:00:00.000Z"),
+          eventId: `deep-oldest-${ns}`,
+        }),
+        event({
+          tenantId: DEEP_TENANT,
+          occurredAtMs: ms("2026-08-25T00:00:00.000Z"),
+          eventId: `deep-newest-${ns}`,
+        }),
+        // EventOccurredAt defaults to 0 when the producer knew no event time.
+        // One of these must not drag the horizon back to 1970.
+        event({
+          tenantId: UNKNOWN_TIME_TENANT,
+          occurredAtMs: 0,
+          eventId: `untimed-${ns}`,
+        }),
+        event({
+          tenantId: UNKNOWN_TIME_TENANT,
+          occurredAtMs: ms("2026-07-04T00:00:00.000Z"),
+          eventId: `untimed-dated-${ns}`,
+        }),
+      ],
+      format: "JSONEachRow",
+      clickhouse_settings: { async_insert: 0, wait_for_async_insert: 0 },
+    });
+  });
+
+  afterAll(async () => {
+    await client.exec({
+      query: `
+        ALTER TABLE event_log
+        DELETE WHERE TenantId IN ({tenantIds:Array(String)})
+      `,
+      query_params: { tenantIds: ALL_TENANTS },
+      clickhouse_settings: { mutations_sync: "1" },
+    });
+  });
+
+  describe("when two areas' logs reach back to different days", () => {
+    /** @scenario "Each area is judged against how far its own log reaches" */
+    it("reports each area's own oldest event", async () => {
+      const horizons = await repository.oldestEventByTenant({
+        tenantIds: [RECENT_TENANT, DEEP_TENANT],
+      });
+
+      expect(horizons.get(RECENT_TENANT)?.toISOString()).toBe(
+        "2026-08-01T00:00:00.000Z",
+      );
+      expect(horizons.get(DEEP_TENANT)?.toISOString()).toBe(
+        "2025-02-14T00:00:00.000Z",
+      );
+    });
+  });
+
+  describe("when an area's log holds nothing", () => {
+    /** @scenario "An area whose log cannot be read is retried, not written off" */
+    it("names no horizon for it rather than reporting today", async () => {
+      const horizons = await repository.oldestEventByTenant({
+        tenantIds: [EMPTY_TENANT],
+      });
+
+      // The population is real — the same call answers for a tenant that has
+      // events — so "absent" here means absent, not "the query found nothing
+      // anywhere".
+      expect(horizons.has(EMPTY_TENANT)).toBe(false);
+      const populated = await repository.oldestEventByTenant({
+        tenantIds: [RECENT_TENANT],
+      });
+      expect(populated.has(RECENT_TENANT)).toBe(true);
+    });
+  });
+
+  describe("when an area holds an event whose time was never known", () => {
+    /** @scenario "Each area is judged against how far its own log reaches" */
+    it("ignores it rather than reporting a 1970 horizon", async () => {
+      const horizons = await repository.oldestEventByTenant({
+        tenantIds: [UNKNOWN_TIME_TENANT],
+      });
+
+      // Without the `EventOccurredAt > 0` predicate this reads 1970-01-01, and
+      // every affected day then looks replayable.
+      expect(horizons.get(UNKNOWN_TIME_TENANT)?.toISOString()).toBe(
+        "2026-07-04T00:00:00.000Z",
+      );
+    });
+  });
+});

--- a/platform/app/ee/governance/__tests__/governanceIdentityConstraints.integration.test.ts
+++ b/platform/app/ee/governance/__tests__/governanceIdentityConstraints.integration.test.ts
@@ -22,7 +22,7 @@ import {
   resolveGovOrganizationId,
   resolveGovTenantIds,
 } from "../services/governanceTenantHistory.service";
-import { isOpenLinkViolation } from "../services/identityMatch.errors";
+import { isOpenLinkViolation } from "../services/logic/postgresConstraintErrors";
 
 const ns = `gov-identity-${nanoid(8)}`;
 const organizationId = `org_${ns}`;

--- a/platform/app/ee/governance/projections/__tests__/governanceSettlingRetention.unit.test.ts
+++ b/platform/app/ee/governance/projections/__tests__/governanceSettlingRetention.unit.test.ts
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+
+/**
+ * The settling window and the retention floor are set in two different
+ * modules, and only one of them knows the other exists.
+ *
+ * A day inside its settling window is rendered to the customer as "this can
+ * still move". If retention could expire that day's events while the screen is
+ * still saying so, we would be promising a figure can change on a day we can
+ * no longer act on — the restatement is unfoldable and an erasure of it is
+ * unrebuildable. Today the floor clears the window by five days, entirely by
+ * accident of two unrelated decisions. This is what notices if one of them
+ * moves.
+ *
+ * Spec: specs/governance/governance-data-retention.feature
+ * Decision: ADR-128 §15 (the settling window), ADR-022 (retention is the ceiling)
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  MIN_RETENTION_DAYS,
+  PAID_RETENTION_PRESET_DAYS,
+  retentionDaysSchema,
+} from "~/server/data-retention/retentionPolicy.schema";
+import { GOVERNANCE_SETTLING_WINDOW_DAYS } from "../governanceCostRollup.constants";
+
+describe("given a cost day the screen calls provisional", () => {
+  describe("when the shortest retention a customer can set is applied to it", () => {
+    /** @scenario "A day the screen says can still change is a day we can still act on" */
+    it("still holds the day's events for longer than the day stays provisional", () => {
+      // The floor the schema enforces, and the shortest value on the paid menu,
+      // are two separate ways to reach the same low number. Check both.
+      const shortestSettable = Math.min(
+        MIN_RETENTION_DAYS,
+        ...PAID_RETENTION_PRESET_DAYS,
+      );
+
+      expect(shortestSettable).toBeGreaterThan(GOVERNANCE_SETTLING_WINDOW_DAYS);
+    });
+
+    /** @scenario "A day the screen says can still change is a day we can still act on" */
+    it("rejects a retention shorter than the settling window", () => {
+      // Without this the assertion above could pass against a schema that has
+      // stopped enforcing anything: it names a constant, not a behaviour.
+      const insideTheWindow = 28;
+      expect(insideTheWindow).toBeLessThan(GOVERNANCE_SETTLING_WINDOW_DAYS);
+      expect(retentionDaysSchema.safeParse(insideTheWindow).success).toBe(
+        false,
+      );
+
+      // And it does accept the shortest value we claim is settable, so the
+      // rejection above is about the length rather than about the schema
+      // refusing everything.
+      expect(
+        retentionDaysSchema.safeParse(Math.min(...PAID_RETENTION_PRESET_DAYS))
+          .success,
+      ).toBe(true);
+    });
+  });
+});

--- a/platform/app/ee/governance/repositories/ingestionSourceKeyCoverage.repository.ts
+++ b/platform/app/ee/governance/repositories/ingestionSourceKeyCoverage.repository.ts
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+
+/**
+ * Row access for the key-to-bill coverage mapping (ADR-128 §7). Every
+ * `prisma.ingestionSourceKeyCoverage.*` call lives here; the service owns the
+ * guards and the words an administrator reads.
+ *
+ * Scoped by `organizationId`, like every other governance table — the hidden
+ * governance project's id can be archived out from under a row, and this
+ * mapping outlives any one of them.
+ *
+ * Spec: specs/governance/governance-cost-coverage.feature
+ */
+import type { Prisma, PrismaClient } from "~/generated/prisma/client";
+
+type Client = Prisma.TransactionClient | PrismaClient;
+
+/** One period during which one bill paid for one gateway key. */
+export interface CoveragePeriod {
+  id: string;
+  ingestionSourceId: string;
+  virtualKeyId: string;
+  validFrom: Date;
+  validTo: Date | null;
+}
+
+export class IngestionSourceKeyCoverageRepository {
+  /**
+   * Every period an organization has recorded, oldest first.
+   *
+   * The whole history, not just the open rows: a chart of last March has to
+   * resolve the bill that covered March, and that period may have been closed
+   * since.
+   */
+  findAllByOrganization(
+    client: Client,
+    params: { organizationId: string },
+  ): Promise<CoveragePeriod[]> {
+    return client.ingestionSourceKeyCoverage.findMany({
+      where: { organizationId: params.organizationId },
+      select: COVERAGE_FIELDS,
+      orderBy: [{ virtualKeyId: "asc" }, { validFrom: "asc" }],
+    });
+  }
+
+  /** One bill's periods, for the list shown beside its configuration. */
+  findAllBySource(
+    client: Client,
+    params: { organizationId: string; ingestionSourceId: string },
+  ): Promise<CoveragePeriod[]> {
+    return client.ingestionSourceKeyCoverage.findMany({
+      where: {
+        organizationId: params.organizationId,
+        ingestionSourceId: params.ingestionSourceId,
+      },
+      select: COVERAGE_FIELDS,
+      orderBy: [{ virtualKeyId: "asc" }, { validFrom: "asc" }],
+    });
+  }
+
+  /**
+   * The key's currently-open period, locked for update, or null when no bill
+   * covers it.
+   *
+   * `FOR UPDATE` is the whole point and it is why this is raw SQL: closing one
+   * period and opening its successor has to be one movement, and a plain read
+   * lets a second administrator interleave between the two writes — closing the
+   * open row and opening a successor an hour later, leaving an hour of that
+   * key's spend covered by no bill, with nothing raised and nothing to find it
+   * afterwards. The exclusion constraint cannot see that gap; it can only see
+   * an overlap. Holding the row for the length of the transaction is what makes
+   * the gap unrepresentable.
+   *
+   * Must be called inside a transaction. Outside one the lock is released the
+   * instant the statement returns, which is a lock that proves nothing.
+   */
+  async findOpenForUpdate(
+    tx: Prisma.TransactionClient,
+    params: { organizationId: string; virtualKeyId: string },
+  ): Promise<CoveragePeriod | null> {
+    const rows = await tx.$queryRaw<
+      Array<{
+        id: string;
+        ingestionSourceId: string;
+        virtualKeyId: string;
+        validFrom: Date;
+        validTo: Date | null;
+      }>
+    >`
+      SELECT "id", "ingestionSourceId", "virtualKeyId", "validFrom", "validTo"
+      FROM "IngestionSourceKeyCoverage"
+      WHERE "organizationId" = ${params.organizationId}
+        AND "virtualKeyId" = ${params.virtualKeyId}
+        AND "validTo" IS NULL
+      FOR UPDATE
+    `;
+    return rows[0] ?? null;
+  }
+
+  /** Records a bill as covering a key from an instant onward. */
+  async open(
+    client: Client,
+    params: {
+      organizationId: string;
+      ingestionSourceId: string;
+      virtualKeyId: string;
+      validFrom: Date;
+    },
+  ): Promise<CoveragePeriod> {
+    return await client.ingestionSourceKeyCoverage.create({
+      data: {
+        organizationId: params.organizationId,
+        ingestionSourceId: params.ingestionSourceId,
+        virtualKeyId: params.virtualKeyId,
+        validFrom: params.validFrom,
+      },
+      select: COVERAGE_FIELDS,
+    });
+  }
+
+  /**
+   * Ends a period at an instant.
+   *
+   * Addressed by id and still bounded by organization: the id came from a read
+   * this organization made, and naming the organization again is what keeps a
+   * stale id from reaching across tenants.
+   */
+  async close(
+    client: Client,
+    params: { organizationId: string; id: string; validTo: Date },
+  ): Promise<void> {
+    await client.ingestionSourceKeyCoverage.updateMany({
+      where: { organizationId: params.organizationId, id: params.id },
+      data: { validTo: params.validTo },
+    });
+  }
+}
+
+const COVERAGE_FIELDS = {
+  id: true,
+  ingestionSourceId: true,
+  virtualKeyId: true,
+  validFrom: true,
+  validTo: true,
+} as const;

--- a/platform/app/ee/governance/services/__tests__/costCoverage.service.unit.test.ts
+++ b/platform/app/ee/governance/services/__tests__/costCoverage.service.unit.test.ts
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+
+/**
+ * What the key-to-bill mapping refuses before it writes anything (ADR-128 §7).
+ *
+ * The rules the DATABASE holds are proved against real Postgres in
+ * `governanceCostCoverage.integration.test.ts`; an application-level double
+ * would pass while the constraint was absent. What is proved here is the half
+ * the database cannot: the guards that run first, and that a refusal writes
+ * nothing.
+ *
+ * Spec: specs/governance/governance-cost-coverage.feature
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import type { PrismaClient } from "~/generated/prisma/client";
+import type {
+  CoveragePeriod,
+  IngestionSourceKeyCoverageRepository,
+} from "../../repositories/ingestionSourceKeyCoverage.repository";
+import { CostCoverageService } from "../costCoverage.service";
+
+const organizationId = "org_1";
+const virtualKeyId = "vk_1";
+
+const openPeriod = (validFrom: string): CoveragePeriod => ({
+  id: "cov_1",
+  ingestionSourceId: "bill_1",
+  virtualKeyId,
+  validFrom: new Date(validFrom),
+  validTo: null,
+});
+
+/**
+ * A repository whose transaction really runs the callback, so a guard that
+ * throws inside it is observed exactly where it would be in production.
+ */
+const serviceWith = (open: CoveragePeriod | null) => {
+  const repo = {
+    findAllByOrganization: vi.fn(),
+    findAllBySource: vi.fn(),
+    findOpenForUpdate: vi.fn().mockResolvedValue(open),
+    open: vi.fn(async (_client, params) => ({
+      id: "cov_new",
+      ingestionSourceId: params.ingestionSourceId,
+      virtualKeyId: params.virtualKeyId,
+      validFrom: params.validFrom,
+      validTo: null,
+    })),
+    close: vi.fn().mockResolvedValue(undefined),
+  } as unknown as IngestionSourceKeyCoverageRepository;
+  const prisma = {
+    $transaction: (run: (tx: unknown) => unknown) => run({}),
+  } as unknown as PrismaClient;
+  return { service: new CostCoverageService(prisma, repo), repo };
+};
+
+describe("Feature: a bill takes over a key on a date", () => {
+  describe("when an administrator records coverage starting partway through a day", () => {
+    /** @scenario "Coverage may only start at midnight" */
+    it("refuses it and asks for a date", async () => {
+      const { service, repo } = serviceWith(null);
+
+      await expect(
+        service.pointKeyAtSource({
+          organizationId,
+          virtualKeyId,
+          ingestionSourceId: "bill_2",
+          effectiveFrom: new Date("2026-06-01T09:30:00.000Z"),
+        }),
+      ).rejects.toMatchObject({
+        code: "ingestion_source_coverage_not_midnight",
+      });
+      expect(repo.open).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("given a bill that began covering a key today", () => {
+    /** @scenario "Coverage cannot be moved to the day it already started" */
+    it("refuses a move effective that same day and asks for a later one", async () => {
+      const { service, repo } = serviceWith(
+        openPeriod("2026-06-01T00:00:00.000Z"),
+      );
+
+      await expect(
+        service.pointKeyAtSource({
+          organizationId,
+          virtualKeyId,
+          ingestionSourceId: "bill_2",
+          effectiveFrom: new Date("2026-06-01T00:00:00.000Z"),
+        }),
+      ).rejects.toMatchObject({
+        code: "ingestion_source_coverage_not_after_start",
+      });
+      // The refusal happens before either write: closing at the instant the
+      // period began would leave a period covering no time at all.
+      expect(repo.close).not.toHaveBeenCalled();
+      expect(repo.open).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when the key already points at that same bill", () => {
+    it("leaves the existing coverage alone rather than putting a seam in it", async () => {
+      const current = openPeriod("2026-01-01T00:00:00.000Z");
+      const { service, repo } = serviceWith(current);
+
+      const result = await service.pointKeyAtSource({
+        organizationId,
+        virtualKeyId,
+        ingestionSourceId: "bill_1",
+        effectiveFrom: new Date("2026-06-01T00:00:00.000Z"),
+      });
+
+      expect(result).toBe(current);
+      expect(repo.close).not.toHaveBeenCalled();
+      expect(repo.open).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when no bill covers the key yet", () => {
+    it("opens coverage without closing anything", async () => {
+      const { service, repo } = serviceWith(null);
+
+      const result = await service.pointKeyAtSource({
+        organizationId,
+        virtualKeyId,
+        ingestionSourceId: "bill_2",
+        effectiveFrom: new Date("2026-06-01T00:00:00.000Z"),
+      });
+
+      expect(result.ingestionSourceId).toBe("bill_2");
+      expect(repo.close).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe("Feature: a bill stops covering a key", () => {
+  describe("when nothing covers the key", () => {
+    it("does nothing rather than failing", async () => {
+      const { service, repo } = serviceWith(null);
+
+      await service.stopCoveringKey({
+        organizationId,
+        virtualKeyId,
+        effectiveFrom: new Date("2026-06-01T00:00:00.000Z"),
+      });
+
+      expect(repo.close).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when the key is covered", () => {
+    it("closes the period rather than deleting it, so past months keep their bill", async () => {
+      const { service, repo } = serviceWith(
+        openPeriod("2026-01-01T00:00:00.000Z"),
+      );
+
+      await service.stopCoveringKey({
+        organizationId,
+        virtualKeyId,
+        effectiveFrom: new Date("2026-06-01T00:00:00.000Z"),
+      });
+
+      expect(repo.close).toHaveBeenCalledWith(expect.anything(), {
+        organizationId,
+        id: "cov_1",
+        validTo: new Date("2026-06-01T00:00:00.000Z"),
+      });
+    });
+
+    it("refuses a mid-day end", async () => {
+      const { service, repo } = serviceWith(
+        openPeriod("2026-01-01T00:00:00.000Z"),
+      );
+
+      await expect(
+        service.stopCoveringKey({
+          organizationId,
+          virtualKeyId,
+          effectiveFrom: new Date("2026-06-01T13:00:00.000Z"),
+        }),
+      ).rejects.toMatchObject({
+        code: "ingestion_source_coverage_not_midnight",
+      });
+      expect(repo.close).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/platform/app/ee/governance/services/__tests__/erasureFoldSubstitution.unit.test.ts
+++ b/platform/app/ee/governance/services/__tests__/erasureFoldSubstitution.unit.test.ts
@@ -181,7 +181,7 @@ function buildErasure(prisma: PrismaClient) {
         replayObserved = actorTheFoldWouldWrite(ERASED);
       },
     },
-    replayHorizon: () => null,
+    replayHorizon: async () => new Map(),
   });
 }
 

--- a/platform/app/ee/governance/services/__tests__/identityErasure.service.unit.test.ts
+++ b/platform/app/ee/governance/services/__tests__/identityErasure.service.unit.test.ts
@@ -41,7 +41,8 @@ function buildService(
     person?: FakePerson | null;
     days?: { tenantId: string; day: string }[];
     tenants?: string[];
-    replayHorizon?: Date | null;
+    /** The oldest event the log still holds, per tenant. Absent = unknown. */
+    replayHorizon?: Record<string, Date>;
     /** How many times the ClickHouse delete throws before it starts working. */
     failDeleteTimes?: number;
     /** How many times the rebuild request throws before it starts working. */
@@ -80,6 +81,7 @@ function buildService(
     replayedSince?: string;
     replayedTenants?: string[];
     markedRebuildSince?: string | null;
+    horizonTenants?: string[];
   } = { suppressionHashes: [] };
 
   // Installed rather than injected: the service reaches the process's one
@@ -191,7 +193,16 @@ function buildService(
         }
       }),
     },
-    replayHorizon: () => overrides.replayHorizon ?? null,
+    replayHorizon: vi.fn(async ({ tenantIds }: { tenantIds: string[] }) => {
+      recorded.horizonTenants = tenantIds;
+      const horizons = new Map<string, Date>();
+      for (const [tenantId, oldest] of Object.entries(
+        overrides.replayHorizon ?? {},
+      )) {
+        if (tenantIds.includes(tenantId)) horizons.set(tenantId, oldest);
+      }
+      return horizons;
+    }),
     now: () => new Date("2026-09-02T00:00:00.000Z"),
   };
 
@@ -393,7 +404,9 @@ describe("given a provider-named person an organization has asked us to erase", 
           { tenantId: "project_gov_new", day: "2025-01-05" },
           { tenantId: "project_gov_new", day: "2026-08-20" },
         ],
-        replayHorizon: new Date("2026-06-01T00:00:00.000Z"),
+        replayHorizon: {
+          project_gov_new: new Date("2026-06-01T00:00:00.000Z"),
+        },
       });
 
       const outcome = await service.erase({
@@ -416,7 +429,9 @@ describe("given a provider-named person an organization has asked us to erase", 
     it("deletes the rows and does not ask for a replay that has nothing to read", async () => {
       const { service, deps } = buildService({
         days: [{ tenantId: "project_gov_new", day: "2025-01-05" }],
-        replayHorizon: new Date("2026-06-01T00:00:00.000Z"),
+        replayHorizon: {
+          project_gov_new: new Date("2026-06-01T00:00:00.000Z"),
+        },
       });
 
       const outcome = await service.erase({
@@ -427,6 +442,61 @@ describe("given a provider-named person an organization has asked us to erase", 
       expect(outcome.daysNotRebuilt).toHaveLength(1);
       expect(deps.replay.replaySince).not.toHaveBeenCalled();
       expect(deps.rollupErasure.deleteRowsCarryingActor).toHaveBeenCalled();
+    });
+  });
+
+  describe("when two areas' logs reach back to different days", () => {
+    /** @scenario "Each area is judged against how far its own log reaches" */
+    it("judges each area against its own log", async () => {
+      const { service, recorded } = buildService({
+        tenants: ["project_gov_new", "project_gov_old"],
+        days: [
+          { tenantId: "project_gov_new", day: "2026-03-10" },
+          { tenantId: "project_gov_old", day: "2026-03-10" },
+        ],
+        replayHorizon: {
+          // The same day is inside one area's log and gone from the other's.
+          project_gov_new: new Date("2026-01-01T00:00:00.000Z"),
+          project_gov_old: new Date("2026-06-01T00:00:00.000Z"),
+        },
+      });
+
+      const outcome = await service.erase({
+        organizationId: ORG,
+        discoveredPersonId: PERSON,
+      });
+
+      expect(outcome.daysNotRebuilt).toEqual([
+        { tenantId: "project_gov_old", day: "2026-03-10" },
+      ]);
+      // Asked about every area the organization has ever written under, not
+      // only the current one.
+      expect(recorded.horizonTenants).toEqual([
+        "project_gov_new",
+        "project_gov_old",
+      ]);
+    });
+  });
+
+  describe("when an area's log says nothing about how far back it reaches", () => {
+    /** @scenario "An area whose log cannot be read is retried, not written off" */
+    it("attempts every day rather than writing any off", async () => {
+      const { service, recorded } = buildService({
+        days: [
+          { tenantId: "project_gov_new", day: "2019-01-05" },
+          { tenantId: "project_gov_new", day: "2026-08-20" },
+        ],
+        // No entry for the tenant: the log holds nothing, or could not say.
+        replayHorizon: {},
+      });
+
+      const outcome = await service.erase({
+        organizationId: ORG,
+        discoveredPersonId: PERSON,
+      });
+
+      expect(outcome.daysNotRebuilt).toEqual([]);
+      expect(recorded.replayedSince).toBe("2019-01-05");
     });
   });
 

--- a/platform/app/ee/governance/services/__tests__/identityMatchEngine.integration.test.ts
+++ b/platform/app/ee/governance/services/__tests__/identityMatchEngine.integration.test.ts
@@ -88,7 +88,7 @@ const eraser = () =>
       deleteRowsCarryingActor: async () => {},
     } as never,
     replay: { replaySince: async () => {} },
-    replayHorizon: () => null,
+    replayHorizon: async () => new Map(),
     now: () => at,
   });
 
@@ -581,7 +581,7 @@ describe("Feature: the match engine, against the database that holds its rules",
           },
         } as never,
         replay: { replaySince: async () => {} },
-        replayHorizon: () => null,
+        replayHorizon: async () => new Map(),
         now: () => at,
       });
 

--- a/platform/app/ee/governance/services/costCoverage.errors.ts
+++ b/platform/app/ee/governance/services/costCoverage.errors.ts
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+
+/**
+ * What the key-to-bill mapping refuses, said in words an administrator can act
+ * on (ADR-128 §7).
+ *
+ * All three are ordinary things for a person editing a small list to do — claim
+ * a key somebody else just claimed, pick today when today is already the start,
+ * hand an API a timestamp where the screen offers a date. None is an incident,
+ * so all three are `fault: "customer"`, and none of them may reach the
+ * administrator as a trace id.
+ *
+ * Spec: specs/governance/governance-cost-coverage.feature
+ */
+import { HandledError } from "@langwatch/handled-error";
+
+/**
+ * Another bill already covers this key over the period being claimed.
+ *
+ * Raised from SQLSTATE 23P01, which is where the rule actually lives — the
+ * exclusion constraint on `IngestionSourceKeyCoverage`. There is deliberately
+ * no read-then-write check in front of it that could report this sooner: two
+ * administrators saving in the same instant both pass such a read, and only the
+ * database sees the collision.
+ */
+export class GatewayKeyAlreadyCoveredError extends HandledError {
+  declare readonly code: "ingestion_source_key_already_covered";
+
+  constructor(virtualKeyId: string) {
+    super(
+      "ingestion_source_key_already_covered",
+      "Another bill already covers this gateway key",
+      {
+        httpStatus: 409,
+        fault: "customer",
+        meta: { virtualKeyId },
+      },
+    );
+    this.name = "GatewayKeyAlreadyCoveredError";
+  }
+}
+
+/**
+ * Coverage was asked to start partway through a day.
+ *
+ * The rollup buckets spend by UTC day, so a day is the finest thing a bill can
+ * own; a mid-day start would file the whole day under whichever bill the read
+ * happened to resolve. The screen offers a date rather than a timestamp, so
+ * this is reachable only through the API.
+ */
+export class CoverageStartNotMidnightError extends HandledError {
+  declare readonly code: "ingestion_source_coverage_not_midnight";
+
+  constructor(startedAt: Date) {
+    super(
+      "ingestion_source_coverage_not_midnight",
+      "Coverage can only start at the beginning of a UTC day",
+      {
+        httpStatus: 400,
+        fault: "customer",
+        meta: { startedAt: startedAt.toISOString() },
+      },
+    );
+    this.name = "CoverageStartNotMidnightError";
+  }
+}
+
+/**
+ * A re-point was asked to take effect no later than the coverage it replaces
+ * began.
+ *
+ * Closing the current row at that instant would leave a range covering no time
+ * at all, which an exclusion constraint cannot see — so this is refused before
+ * the write, and by the `CHECK` behind it if a race gets past.
+ */
+export class CoverageStartNotAfterCurrentError extends HandledError {
+  declare readonly code: "ingestion_source_coverage_not_after_start";
+
+  constructor(params: { virtualKeyId: string; currentStartedAt: Date }) {
+    super(
+      "ingestion_source_coverage_not_after_start",
+      "Coverage must move to a day after the day the current coverage started",
+      {
+        httpStatus: 409,
+        fault: "customer",
+        meta: {
+          virtualKeyId: params.virtualKeyId,
+          currentStartedAt: params.currentStartedAt.toISOString(),
+        },
+      },
+    );
+    this.name = "CoverageStartNotAfterCurrentError";
+  }
+}

--- a/platform/app/ee/governance/services/costCoverage.service.ts
+++ b/platform/app/ee/governance/services/costCoverage.service.ts
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+
+/**
+ * Which gateway keys a connected provider bill pays for, and moving one key
+ * from one bill to another without leaving a moment uncovered (ADR-128 §7).
+ *
+ * The database holds the rule that a key belongs to one bill at a time. What it
+ * cannot hold is CONTINUITY: a non-overlap constraint structurally cannot see a
+ * gap. Two administrators editing through independent updates could close a
+ * key's coverage and open its successor an hour later, leaving an hour of that
+ * key's spend covered by no bill, with nothing raised and nothing to find it
+ * afterwards. So re-pointing is never two writes — it is one transaction that
+ * locks the open row, closes it and opens the successor at the same instant.
+ * Continuity is the transaction's job; the constraints cover only the errors a
+ * correct transaction can still make.
+ *
+ * Spec: specs/governance/governance-cost-coverage.feature
+ */
+import type { PrismaClient } from "~/generated/prisma/client";
+
+import {
+  type CoveragePeriod,
+  IngestionSourceKeyCoverageRepository,
+} from "../repositories/ingestionSourceKeyCoverage.repository";
+import {
+  CoverageStartNotAfterCurrentError,
+  CoverageStartNotMidnightError,
+  GatewayKeyAlreadyCoveredError,
+} from "./costCoverage.errors";
+import { coverageOnDay, isUtcMidnight } from "./logic/costCoverage";
+import {
+  isCheckViolation,
+  isExclusionViolation,
+} from "./logic/postgresConstraintErrors";
+
+export class CostCoverageService {
+  constructor(
+    private readonly prisma: PrismaClient,
+    private readonly repo: IngestionSourceKeyCoverageRepository = new IngestionSourceKeyCoverageRepository(),
+  ) {}
+
+  static create(prisma: PrismaClient): CostCoverageService {
+    return new CostCoverageService(prisma);
+  }
+
+  /** Every period this organization has recorded, closed ones included. */
+  getAll(params: { organizationId: string }): Promise<CoveragePeriod[]> {
+    return this.repo.findAllByOrganization(this.prisma, params);
+  }
+
+  /** One bill's periods, for the list shown beside its configuration. */
+  getAllBySource(params: {
+    organizationId: string;
+    ingestionSourceId: string;
+  }): Promise<CoveragePeriod[]> {
+    return this.repo.findAllBySource(this.prisma, params);
+  }
+
+  /**
+   * Which bill covered each of the organization's keys on one UTC day: key id
+   * to ingestion source id. A key absent from the map is unmapped that day, and
+   * its gateway spend stands alone as metered.
+   *
+   * Reads the whole history and resolves in memory rather than filtering the
+   * day in SQL. The mapping is a small administrator-curated list — tens of rows
+   * for an organization with a lot of keys — and the caller draws a window of
+   * days, so one read serves all of them where a per-day query would repeat.
+   */
+  async getCoverageOnDay(params: {
+    organizationId: string;
+    day: string;
+  }): Promise<Map<string, string>> {
+    const periods = await this.repo.findAllByOrganization(this.prisma, {
+      organizationId: params.organizationId,
+    });
+    return coverageOnDay({ periods, day: params.day });
+  }
+
+  /**
+   * Records a bill as covering a key from a UTC midnight onward, moving the key
+   * off whatever bill covered it before.
+   *
+   * One transaction, and the ordering inside it is what makes a gap
+   * unrepresentable: the open row is taken `FOR UPDATE` first, so a second
+   * administrator's re-point of the same key waits rather than interleaving.
+   * Both writes land or neither does.
+   *
+   * Re-pointing a key to the bill already covering it is a no-op rather than an
+   * error: an administrator confirming what is already true has not made a
+   * mistake, and closing and reopening the same coverage would put a seam in
+   * the history for nothing.
+   */
+  async pointKeyAtSource(params: {
+    organizationId: string;
+    virtualKeyId: string;
+    ingestionSourceId: string;
+    effectiveFrom: Date;
+  }): Promise<CoveragePeriod> {
+    this.assertMidnight(params.effectiveFrom);
+    return await this.mappingConstraints(params, () =>
+      this.prisma.$transaction(async (tx) => {
+        const open = await this.repo.findOpenForUpdate(tx, {
+          organizationId: params.organizationId,
+          virtualKeyId: params.virtualKeyId,
+        });
+        if (open?.ingestionSourceId === params.ingestionSourceId) return open;
+        if (open) {
+          this.assertAfter({
+            open,
+            effectiveFrom: params.effectiveFrom,
+            virtualKeyId: params.virtualKeyId,
+          });
+          await this.repo.close(tx, {
+            organizationId: params.organizationId,
+            id: open.id,
+            validTo: params.effectiveFrom,
+          });
+        }
+        return await this.repo.open(tx, {
+          organizationId: params.organizationId,
+          ingestionSourceId: params.ingestionSourceId,
+          virtualKeyId: params.virtualKeyId,
+          validFrom: params.effectiveFrom,
+        });
+      }),
+    );
+  }
+
+  /**
+   * Ends a key's coverage from a UTC midnight, leaving its spend to stand alone
+   * as metered from that day on.
+   *
+   * Deliberately not a delete: the closed row is what keeps last May reading
+   * under the bill that covered May.
+   */
+  async stopCoveringKey(params: {
+    organizationId: string;
+    virtualKeyId: string;
+    effectiveFrom: Date;
+  }): Promise<void> {
+    this.assertMidnight(params.effectiveFrom);
+    await this.mappingConstraints(params, () =>
+      this.prisma.$transaction(async (tx) => {
+        const open = await this.repo.findOpenForUpdate(tx, {
+          organizationId: params.organizationId,
+          virtualKeyId: params.virtualKeyId,
+        });
+        if (!open) return;
+        this.assertAfter({
+          open,
+          effectiveFrom: params.effectiveFrom,
+          virtualKeyId: params.virtualKeyId,
+        });
+        await this.repo.close(tx, {
+          organizationId: params.organizationId,
+          id: open.id,
+          validTo: params.effectiveFrom,
+        });
+      }),
+    );
+  }
+
+  private assertMidnight(effectiveFrom: Date): void {
+    if (!isUtcMidnight(effectiveFrom)) {
+      throw new CoverageStartNotMidnightError(effectiveFrom);
+    }
+  }
+
+  /**
+   * Refuses a change that would close the open period at or before it began.
+   *
+   * At the same instant the period covers no time at all, which an exclusion
+   * constraint cannot see — an empty range overlaps nothing, not even itself —
+   * so this is checked before the write and the `CHECK` behind it catches a
+   * race.
+   */
+  private assertAfter(params: {
+    open: CoveragePeriod;
+    effectiveFrom: Date;
+    virtualKeyId: string;
+  }): void {
+    if (params.effectiveFrom.getTime() > params.open.validFrom.getTime())
+      return;
+    throw new CoverageStartNotAfterCurrentError({
+      virtualKeyId: params.virtualKeyId,
+      currentStartedAt: params.open.validFrom,
+    });
+  }
+
+  /**
+   * Turns the two constraint violations this mapping can raise into words an
+   * administrator can act on. Both are losing sides of a race, which is why
+   * neither is caught by the checks above: those run against the state this
+   * transaction read, and a racing writer moves it afterwards.
+   *
+   * The exclusion violation is the ordinary one. The `FOR UPDATE` serialises
+   * re-points of the SAME key, but two administrators claiming a so-far
+   * uncovered key from two different bills each find no open row to lock, so
+   * the constraint is the only thing that sees them collide.
+   *
+   * The check violation is narrower: the winner of such a race opened its
+   * period at the very instant this one is closing at, so the close leaves a
+   * period covering no time. The instant this transaction was given is
+   * therefore also the instant the coverage it lost to begins, which is what
+   * the reported date names.
+   */
+  private async mappingConstraints<T>(
+    context: { virtualKeyId: string; effectiveFrom: Date },
+    write: () => Promise<T>,
+  ): Promise<T> {
+    try {
+      return await write();
+    } catch (error) {
+      if (isExclusionViolation(error)) {
+        throw new GatewayKeyAlreadyCoveredError(context.virtualKeyId);
+      }
+      if (isCheckViolation(error)) {
+        throw new CoverageStartNotAfterCurrentError({
+          virtualKeyId: context.virtualKeyId,
+          currentStartedAt: context.effectiveFrom,
+        });
+      }
+      throw error;
+    }
+  }
+}

--- a/platform/app/ee/governance/services/governanceEventLogHorizon.clickhouse.repository.ts
+++ b/platform/app/ee/governance/services/governanceEventLogHorizon.clickhouse.repository.ts
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+
+/**
+ * How far back the event log still reaches, per tenant (ADR-128 §9 step 4).
+ *
+ * A governance erasure deletes the money rows carrying an identifier and then
+ * asks for those days to be rebuilt by replaying the events they were folded
+ * from. ADR-022 makes the log's retention the ceiling on that: for a day whose
+ * events have expired there is nothing left to replay, the delete is the whole
+ * operation, and the day's total is permanently lower by the erased amount.
+ * The erasure reports those days rather than pretending the totals are
+ * unchanged, and this repository is what tells it which ones they are.
+ *
+ * It ASKS THE LOG rather than computing the boundary from the retention
+ * policy, and the difference is not cosmetic. `_retention_days` is stamped on
+ * each row from the policy in force when it was written, so a policy that has
+ * since changed does not describe the rows already in the table; ClickHouse
+ * applies a DELETE TTL lazily on merge, so rows past their nominal expiry
+ * routinely survive; and the platform default is itself environment-dependent.
+ * Every one of those makes a policy-derived boundary a prediction. The oldest
+ * surviving event is an observation, and it is the only number that is true
+ * about the table this replay will actually read.
+ *
+ * Spec: specs/governance/governance-data-retention.feature
+ */
+import type { ClickHouseClient } from "@clickhouse/client";
+import { createLogger } from "@langwatch/observability";
+
+const logger = createLogger("langwatch:governance:event-log-horizon");
+
+export class GovernanceEventLogHorizonClickHouseRepository {
+  constructor(
+    private readonly resolveClient: (
+      tenantId: string,
+    ) => Promise<ClickHouseClient>,
+  ) {}
+
+  /**
+   * The oldest event still in the log for each tenant, as an instant.
+   *
+   * A tenant whose log holds nothing is absent from the result rather than
+   * mapped to "now". An empty log alongside money rows that need rebuilding is
+   * an anomaly, and the safe reading of an anomaly is that we cannot state a
+   * horizon — so every day gets attempted, and a day that genuinely cannot be
+   * replayed surfaces as a rebuild that changed nothing rather than as a day
+   * written off unasked.
+   *
+   * Tenants are queried one at a time rather than through a single `IN` list,
+   * for the reason `GovernanceRollupErasureClickHouseRepository` gives: the
+   * resolver maps a tenant to its organization's ClickHouse instance, and an
+   * organization on a dedicated instance would otherwise have one query aimed
+   * at the wrong one.
+   *
+   * `EventOccurredAt` is epoch milliseconds and the table's partition key
+   * (`toYearWeek`), so this is a min over the tenant's granules — `TenantId`
+   * leads the sort key, which is what keeps the scan to them. Rows carrying
+   * the unknown-time default of 0 are excluded: one of those would report the
+   * horizon as 1970 and quietly make every day look replayable.
+   */
+  async oldestEventByTenant({
+    tenantIds,
+  }: {
+    tenantIds: string[];
+  }): Promise<Map<string, Date>> {
+    const horizons = new Map<string, Date>();
+    for (const tenantId of tenantIds) {
+      try {
+        const client = await this.resolveClient(tenantId);
+        const result = await client.query({
+          query: `
+            SELECT min(EventOccurredAt) AS OldestOccurredAt
+            FROM event_log
+            WHERE TenantId = {tenantId:String}
+              AND EventOccurredAt > 0
+          `,
+          query_params: { tenantId },
+          format: "JSONEachRow",
+        });
+        const rows = (await result.json()) as Record<string, unknown>[];
+        // ClickHouse renders UInt64 as a string in JSONEachRow, and min() over
+        // an empty set returns 0 rather than no row at all.
+        const oldest = Number(rows[0]?.OldestOccurredAt ?? 0);
+        if (!Number.isFinite(oldest) || oldest <= 0) continue;
+        horizons.set(tenantId, new Date(oldest));
+      } catch (error) {
+        // Swallowed on purpose, and only here. This query decides which days an
+        // erasure REPORTS as unrebuildable; the deletion and the rebuild happen
+        // either way. Leaving the tenant out of the result means every one of
+        // its days is attempted, which is the same answer the caller reaches
+        // when the log is empty — so a failed read costs a wider replay and a
+        // warning, never a refused erasure.
+        logger.warn(
+          { error, tenantId },
+          "Could not read how far back the event log reaches; every affected day will be attempted rather than written off",
+        );
+      }
+    }
+    return horizons;
+  }
+}

--- a/platform/app/ee/governance/services/identityErasure.service.ts
+++ b/platform/app/ee/governance/services/identityErasure.service.ts
@@ -166,12 +166,22 @@ export interface IdentityErasureDeps {
   rollupErasure: GovernanceRollupErasureClickHouseRepository;
   replay: RollupReplayPort;
   /**
-   * How far back the event log still holds events. Days older than this cannot
-   * be replayed, so they are reported as not rebuilt instead of being retried
-   * forever. Null means the caller cannot state a horizon, in which case every
-   * day is attempted and none is pre-emptively declared unreachable.
+   * How far back the event log still holds events, for each area asked about.
+   * Days older than an area's horizon cannot be replayed, so they are reported
+   * as not rebuilt instead of being retried forever.
+   *
+   * Per area rather than one number for the organization, because retention is
+   * resolved per project and an organization that has been re-tenanted can hold
+   * two logs reaching back to two different days.
+   *
+   * An area missing from the result is one whose horizon could not be stated,
+   * and the safe reading of that is to attempt every one of its days: a day
+   * that genuinely cannot be replayed then surfaces as a rebuild that changed
+   * nothing, which is a far better failure than a day written off unasked.
    */
-  replayHorizon: () => Date | null;
+  replayHorizon: (params: {
+    tenantIds: string[];
+  }) => Promise<Map<string, Date>>;
   now?: () => Date;
 }
 
@@ -479,7 +489,7 @@ export class IdentityErasureService {
       rawActorId,
     });
 
-    const daysNotRebuilt = this.daysBeyondReplayHorizon(affectedDays);
+    const daysNotRebuilt = await this.daysBeyondReplayHorizon(affectedDays);
     const replayable = affectedDays.filter(
       (candidate) =>
         !daysNotRebuilt.some(
@@ -627,13 +637,27 @@ export class IdentityErasureService {
    * ADR-022 makes the event log's retention the durability ceiling: for a day
    * older than it there is nothing left to replay from, so the delete is the
    * whole operation.
+   *
+   * Each day is judged against its own area's horizon. An area with no horizon
+   * loses no days — see the dep's own note on why silence means "attempt".
    */
-  private daysBeyondReplayHorizon(
+  private async daysBeyondReplayHorizon(
     days: { tenantId: string; day: string }[],
-  ): { tenantId: string; day: string }[] {
-    const horizon = this.deps.replayHorizon();
-    if (!horizon) return [];
-    const horizonDay = horizon.toISOString().slice(0, 10);
-    return days.filter((entry) => entry.day < horizonDay);
+  ): Promise<{ tenantId: string; day: string }[]> {
+    const tenantIds = [...new Set(days.map((entry) => entry.tenantId))];
+    if (tenantIds.length === 0) return [];
+
+    const horizons = await this.deps.replayHorizon({ tenantIds });
+    const horizonDays = new Map(
+      [...horizons].map(([tenantId, oldest]) => [
+        tenantId,
+        oldest.toISOString().slice(0, 10),
+      ]),
+    );
+
+    return days.filter((entry) => {
+      const horizonDay = horizonDays.get(entry.tenantId);
+      return horizonDay !== undefined && entry.day < horizonDay;
+    });
   }
 }

--- a/platform/app/ee/governance/services/identityMatch.errors.ts
+++ b/platform/app/ee/governance/services/identityMatch.errors.ts
@@ -84,39 +84,3 @@ export class IdentityErasedError extends HandledError {
     this.name = "IdentityErasedError";
   }
 }
-
-/** Postgres' unique-violation code, raised by the one-open-link index. */
-const UNIQUE_VIOLATION = "23505";
-
-/**
- * Prisma's own code for the same refusal: the client wraps a unique violation
- * as a `PrismaClientKnownRequestError` with `code: "P2002"` and buries the
- * SQLSTATE underneath. `IdentityMatch` has no other unique rule a write could
- * trip (the primary key is a fresh nanoid), so `P2002` on these writes means
- * the one-open-link index and nothing else.
- */
-const PRISMA_UNIQUE_VIOLATION = "P2002";
-
-/**
- * Whether a thrown value is the one-open-link index refusing a second open
- * link.
- *
- * Reads the code off whichever shape carried it: Prisma's `P2002` wrapper, a
- * raw driver error's SQLSTATE in `code` or `meta.code`, or — for the wrapper
- * shapes whose SQLSTATE lives only in the message — a word-bounded match on
- * the message. Never a `String(err).includes` over the whole message: that
- * would also match an error whose *payload* happened to contain the digits.
- */
-export function isOpenLinkViolation(error: unknown): boolean {
-  if (typeof error !== "object" || error === null) return false;
-  const code = (error as { code?: unknown }).code;
-  if (code === UNIQUE_VIOLATION || code === PRISMA_UNIQUE_VIOLATION)
-    return true;
-  const meta = (error as { meta?: { code?: unknown } }).meta;
-  if (meta?.code === UNIQUE_VIOLATION) return true;
-  const message = (error as { message?: unknown }).message;
-  return (
-    typeof message === "string" &&
-    new RegExp(`\\b${UNIQUE_VIOLATION}\\b`).test(message)
-  );
-}

--- a/platform/app/ee/governance/services/identityMatch.service.ts
+++ b/platform/app/ee/governance/services/identityMatch.service.ts
@@ -37,7 +37,6 @@ import {
   IdentityAlreadyLinkedError,
   IdentityErasedError,
   IdentityMatchSuggestionNotFoundError,
-  isOpenLinkViolation,
 } from "./identityMatch.errors";
 import {
   decideMatch,
@@ -45,6 +44,7 @@ import {
   normalizeEmail,
   type OrganizationAccountIndex,
 } from "./logic/identityEvidence";
+import { isOpenLinkViolation } from "./logic/postgresConstraintErrors";
 
 const logger = createLogger("langwatch:governance:identity-match");
 

--- a/platform/app/ee/governance/services/logic/__tests__/combinedCostLanes.unit.test.ts
+++ b/platform/app/ee/governance/services/logic/__tests__/combinedCostLanes.unit.test.ts
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+
+/**
+ * The connected view's arithmetic (ADR-128 §2, §7).
+ *
+ * Spec: specs/governance/governance-cost-coverage.feature
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  COVERAGE_INELIGIBLE,
+  type CurrencyAmount,
+  combineProviderDay,
+} from "../combinedCostLanes";
+
+/** One dollar in nano-units. */
+const DOLLAR = 1_000_000_000n;
+const usd = (dollars: number): CurrencyAmount => ({
+  amountNano: (BigInt(Math.round(dollars * 100)) * DOLLAR) / 100n,
+  currencyCode: "USD",
+});
+const eur = (dollars: number): CurrencyAmount => ({
+  ...usd(dollars),
+  currencyCode: "EUR",
+});
+
+const lanes = (overrides: {
+  bill?: CurrencyAmount | null;
+  coveredGateway?: CurrencyAmount | null;
+  unmappedGateway?: CurrencyAmount | null;
+}) => ({
+  day: "2026-06-01",
+  provider: "anthropic",
+  bill: overrides.bill ?? null,
+  coveredGateway: overrides.coveredGateway ?? null,
+  unmappedGateway: overrides.unmappedGateway ?? null,
+});
+
+describe("Feature: the total shown is the bill, and gateway detail splits it", () => {
+  describe("given a bill and gateway spend on the keys it covers", () => {
+    /** @scenario "Gateway detail splits the bill and the remainder is its own line" */
+    it("shows the bill as the total and names the part nothing explains", () => {
+      const combined = combineProviderDay(
+        lanes({ bill: usd(6), coveredGateway: usd(4.2) }),
+      );
+
+      expect(combined.total).toEqual({ ...usd(6), basis: "billed" });
+      expect(combined.split?.attributedNano).toBe(usd(4.2).amountNano);
+      expect(combined.split?.unallocatedNano).toBe(usd(1.8).amountNano);
+      expect(combined.split?.overMeteredNano).toBe(0n);
+    });
+  });
+
+  describe("when metering ran above the bill", () => {
+    /** @scenario "Gateway spend above the bill is shown as a variance, never subtracted" */
+    it("keeps the bill as the total and reports the overrun beside it", () => {
+      const combined = combineProviderDay(
+        lanes({ bill: usd(6), coveredGateway: usd(6.5) }),
+      );
+
+      expect(combined.total?.amountNano).toBe(usd(6).amountNano);
+      expect(combined.split?.overMeteredNano).toBe(usd(0.5).amountNano);
+      // Nothing is taken off the total, and the attributed part cannot exceed
+      // it: the overrun is a comparison, not a component.
+      expect(combined.split?.attributedNano).toBe(usd(6).amountNano);
+      expect(combined.split?.unallocatedNano).toBe(0n);
+    });
+  });
+
+  describe("given a provider day whose bill is a refund", () => {
+    /** @scenario "A refunded day stays negative" */
+    it("renders the negative figure as it is", () => {
+      const refund = { amountNano: -3n * DOLLAR, currencyCode: "USD" };
+
+      const combined = combineProviderDay(
+        lanes({ bill: refund, coveredGateway: usd(5) }),
+      );
+
+      expect(combined.total?.amountNano).toBe(-3n * DOLLAR);
+      // Metering cannot account for a refund, so none of it is attributed and
+      // the whole negative figure is the unallocated line.
+      expect(combined.split?.attributedNano).toBe(0n);
+      expect(combined.split?.unallocatedNano).toBe(-3n * DOLLAR);
+      expect(combined.split?.overMeteredNano).toBe(8n * DOLLAR);
+    });
+  });
+
+  describe("given a day no bill has reported yet", () => {
+    /** @scenario "A day the bill has not reached yet is marked estimated" */
+    it("stands the gateway figure in and says it is an estimate", () => {
+      const combined = combineProviderDay(
+        lanes({ bill: null, coveredGateway: usd(4.2) }),
+      );
+
+      expect(combined.total).toEqual({ ...usd(4.2), basis: "estimated" });
+      expect(combined.split?.attributedNano).toBe(usd(4.2).amountNano);
+      expect(combined.split?.unallocatedNano).toBe(0n);
+    });
+
+    /** @scenario "The estimate becomes the bill when the bill lands" */
+    it("flips to the bill and drops the estimate mark once the bill arrives", () => {
+      const before = combineProviderDay(
+        lanes({ bill: null, coveredGateway: usd(4.2) }),
+      );
+      const after = combineProviderDay(
+        lanes({ bill: usd(6), coveredGateway: usd(4.2) }),
+      );
+
+      expect(before.total?.basis).toBe("estimated");
+      expect(after.total?.basis).toBe("billed");
+      expect(after.total?.amountNano).toBe(usd(6).amountNano);
+    });
+  });
+
+  describe("given gateway spend on a key no bill covers", () => {
+    /** @scenario "Gateway spend no bill covers stands alone" */
+    it("reports it on its own and counts it against no bill", () => {
+      const combined = combineProviderDay(
+        lanes({ bill: usd(6), coveredGateway: null, unmappedGateway: usd(2) }),
+      );
+
+      expect(combined.metered).toEqual(usd(2));
+      expect(combined.split?.attributedNano).toBe(0n);
+      expect(combined.split?.unallocatedNano).toBe(usd(6).amountNano);
+    });
+  });
+
+  describe("when the bill and its keys are priced in different currencies", () => {
+    /** @scenario "A bill and its keys in different currencies are not combined" */
+    it("reports both lanes in their own currency and shows no split", () => {
+      const combined = combineProviderDay(
+        lanes({
+          bill: eur(6),
+          coveredGateway: usd(4.2),
+          unmappedGateway: usd(1),
+        }),
+      );
+
+      expect(combined.total).toEqual({ ...eur(6), basis: "billed" });
+      expect(combined.split).toBeNull();
+      expect(combined.ineligibleReason).toBe(
+        COVERAGE_INELIGIBLE.CROSS_CURRENCY,
+      );
+      // The covered metering does not vanish because it could not be matched:
+      // its dollars are real, so it joins the lane that stands alone.
+      expect(combined.metered).toEqual(usd(5.2));
+    });
+  });
+
+  describe("given any provider day with a bill", () => {
+    /** @scenario "The parts of a day always add up to its total" */
+    it("keeps the attributed part and the unallocated part summing to the total", () => {
+      const bills = [usd(6), usd(0), { amountNano: -3n, currencyCode: "USD" }];
+      const metering = [null, usd(0), usd(4.2), usd(6.5), usd(100)];
+
+      for (const bill of bills) {
+        for (const coveredGateway of metering) {
+          const combined = combineProviderDay(lanes({ bill, coveredGateway }));
+
+          expect(combined.split).not.toBeNull();
+          expect(
+            combined.split!.attributedNano + combined.split!.unallocatedNano,
+          ).toBe(bill.amountNano);
+          expect(combined.split!.attributedNano >= 0n).toBe(true);
+          expect(combined.split!.overMeteredNano >= 0n).toBe(true);
+        }
+      }
+    });
+  });
+
+  describe("given a day neither lane said anything about", () => {
+    it("states no total rather than zero", () => {
+      const combined = combineProviderDay(lanes({}));
+
+      expect(combined.total).toBeNull();
+      expect(combined.split).toBeNull();
+      expect(combined.metered).toBeNull();
+    });
+  });
+});

--- a/platform/app/ee/governance/services/logic/__tests__/combinedCostLanes.unit.test.ts
+++ b/platform/app/ee/governance/services/logic/__tests__/combinedCostLanes.unit.test.ts
@@ -3,6 +3,13 @@
 /**
  * The connected view's arithmetic (ADR-128 §2, §7).
  *
+ * The scenarios these bind to are parked `@unimplemented`, so the parity gate
+ * does not count them, and that is deliberate rather than an oversight: each one
+ * describes what a reader is SHOWN, and nothing draws these numbers yet. The
+ * arithmetic is real and this file proves it; the view is the part that is
+ * missing. Binding without parking would report a screen as delivered on the
+ * strength of tests that render nothing.
+ *
  * Spec: specs/governance/governance-cost-coverage.feature
  */
 import { describe, expect, it } from "vitest";

--- a/platform/app/ee/governance/services/logic/__tests__/costCoverage.unit.test.ts
+++ b/platform/app/ee/governance/services/logic/__tests__/costCoverage.unit.test.ts
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+
+/**
+ * Reading the key-to-bill mapping as of a day (ADR-128 §7).
+ *
+ * Spec: specs/governance/governance-cost-coverage.feature
+ */
+import { describe, expect, it } from "vitest";
+
+import type { CoveragePeriod } from "../../../repositories/ingestionSourceKeyCoverage.repository";
+import { coverageOnDay, isUtcMidnight } from "../costCoverage";
+
+const period = (overrides: {
+  ingestionSourceId: string;
+  validFrom: string;
+  validTo?: string;
+  virtualKeyId?: string;
+}): CoveragePeriod => ({
+  id: `cov_${overrides.ingestionSourceId}_${overrides.validFrom}`,
+  ingestionSourceId: overrides.ingestionSourceId,
+  virtualKeyId: overrides.virtualKeyId ?? "vk_1",
+  validFrom: new Date(overrides.validFrom),
+  validTo: overrides.validTo ? new Date(overrides.validTo) : null,
+});
+
+describe("Feature: which bill covered a key is read as of the day being drawn", () => {
+  describe("given a key covered by one bill until June and another from June", () => {
+    const periods = [
+      period({
+        ingestionSourceId: "bill_1",
+        validFrom: "2026-01-01T00:00:00.000Z",
+        validTo: "2026-06-01T00:00:00.000Z",
+      }),
+      period({
+        ingestionSourceId: "bill_2",
+        validFrom: "2026-06-01T00:00:00.000Z",
+      }),
+    ];
+
+    /** @scenario "A past month keeps the bill that covered it at the time" */
+    it("files each month under the bill that covered it at the time", () => {
+      expect(coverageOnDay({ periods, day: "2026-05-31" }).get("vk_1")).toBe(
+        "bill_1",
+      );
+      expect(coverageOnDay({ periods, day: "2026-06-01" }).get("vk_1")).toBe(
+        "bill_2",
+      );
+    });
+
+    it("leaves the changeover day to the successor alone", () => {
+      // The predecessor ends at the same instant the successor begins, so the
+      // half-open ranges give the first of June to the successor and to nobody
+      // else. Asserted by the ambiguity check below rather than by counting the
+      // map, whose keys would hide a second claim by overwriting the first.
+      expect(() => coverageOnDay({ periods, day: "2026-06-01" })).not.toThrow();
+      expect(coverageOnDay({ periods, day: "2026-06-01" }).get("vk_1")).toBe(
+        "bill_2",
+      );
+    });
+  });
+
+  describe("given two bills that both somehow claim a key on one day", () => {
+    it("refuses to pick one rather than attributing the money at random", () => {
+      // Unreachable while the exclusion constraint stands. Reaching it means the
+      // constraint is gone, and quietly keeping the last row read is the
+      // last-writer-wins attribution that constraint exists to prevent.
+      const overlapping = [
+        period({
+          ingestionSourceId: "bill_1",
+          validFrom: "2026-01-01T00:00:00.000Z",
+          validTo: "2026-07-01T00:00:00.000Z",
+        }),
+        period({
+          ingestionSourceId: "bill_2",
+          validFrom: "2026-06-01T00:00:00.000Z",
+        }),
+      ];
+
+      expect(() =>
+        coverageOnDay({ periods: overlapping, day: "2026-06-15" }),
+      ).toThrow(/Two ingestion sources cover gateway key vk_1/);
+    });
+  });
+
+  describe("given a key whose coverage began in June", () => {
+    const periods = [
+      period({
+        ingestionSourceId: "bill_2",
+        validFrom: "2026-06-01T00:00:00.000Z",
+      }),
+    ];
+
+    /** @scenario "A key covered by nobody on that day belongs to no bill" */
+    it("leaves the key out of the mapping for earlier days", () => {
+      expect(coverageOnDay({ periods, day: "2026-05-31" }).has("vk_1")).toBe(
+        false,
+      );
+    });
+  });
+
+  describe("given several keys with different coverage", () => {
+    it("answers for each key independently", () => {
+      const periods = [
+        period({
+          ingestionSourceId: "bill_1",
+          virtualKeyId: "vk_1",
+          validFrom: "2026-01-01T00:00:00.000Z",
+        }),
+        period({
+          ingestionSourceId: "bill_2",
+          virtualKeyId: "vk_2",
+          validFrom: "2026-05-01T00:00:00.000Z",
+        }),
+      ];
+
+      const may = coverageOnDay({ periods, day: "2026-05-15" });
+      expect(may.get("vk_1")).toBe("bill_1");
+      expect(may.get("vk_2")).toBe("bill_2");
+
+      const april = coverageOnDay({ periods, day: "2026-04-15" });
+      expect(april.get("vk_1")).toBe("bill_1");
+      expect(april.has("vk_2")).toBe(false);
+    });
+  });
+});
+
+describe("Feature: coverage starts on a date", () => {
+  it("accepts a UTC midnight", () => {
+    expect(isUtcMidnight(new Date("2026-06-01T00:00:00.000Z"))).toBe(true);
+  });
+
+  it("refuses any instant inside a day", () => {
+    expect(isUtcMidnight(new Date("2026-06-01T12:00:00.000Z"))).toBe(false);
+    expect(isUtcMidnight(new Date("2026-06-01T00:00:00.001Z"))).toBe(false);
+  });
+});

--- a/platform/app/ee/governance/services/logic/combinedCostLanes.ts
+++ b/platform/app/ee/governance/services/logic/combinedCostLanes.ts
@@ -116,18 +116,8 @@ export function combineProviderDay(
     // reported as itself.
     return {
       ...base,
-      total:
-        coveredGateway === null
-          ? null
-          : { ...coveredGateway, basis: "estimated" },
-      split:
-        coveredGateway === null
-          ? null
-          : {
-              attributedNano: coveredGateway.amountNano,
-              unallocatedNano: 0n,
-              overMeteredNano: 0n,
-            },
+      total: coveredGateway && { ...coveredGateway, basis: "estimated" },
+      split: coveredGateway && splitOf(coveredGateway.amountNano, null),
       metered: unmappedGateway,
       ineligibleReason: null,
     };
@@ -135,23 +125,7 @@ export function combineProviderDay(
 
   const total = { ...bill, basis: "billed" as const };
 
-  if (coveredGateway === null) {
-    // A bill nothing is mapped to. The whole of it is unexplained by metering,
-    // which is the honest reading of a bill whose keys nobody has named yet.
-    return {
-      ...base,
-      total,
-      split: {
-        attributedNano: 0n,
-        unallocatedNano: bill.amountNano,
-        overMeteredNano: 0n,
-      },
-      metered: unmappedGateway,
-      ineligibleReason: null,
-    };
-  }
-
-  if (coveredGateway.currencyCode !== bill.currencyCode) {
+  if (coveredGateway && coveredGateway.currencyCode !== bill.currencyCode) {
     // Splitting would mean converting, and nobody here has a rate that is not
     // invented. Both lanes render, each in its own currency, and the covered
     // metering joins the metered line rather than disappearing: its dollars are
@@ -165,24 +139,43 @@ export function combineProviderDay(
     };
   }
 
-  const billNano = bill.amountNano;
-  const meteredNano = coveredGateway.amountNano;
-  // Clamped at zero because metering cannot account for a refund: on a negative
-  // day the whole (negative) figure is unallocated, and the metering that ran
-  // anyway shows up as the variance below.
-  const attributedNano =
-    billNano <= 0n ? 0n : meteredNano < billNano ? meteredNano : billNano;
-
+  // A bill nothing is mapped to still gets a split: the whole of it is then
+  // unexplained by metering, which is the honest reading of a bill whose keys
+  // nobody has named yet.
   return {
     ...base,
     total,
-    split: {
-      attributedNano,
-      unallocatedNano: billNano - attributedNano,
-      overMeteredNano: meteredNano > billNano ? meteredNano - billNano : 0n,
-    },
+    split: splitOf(coveredGateway?.amountNano ?? 0n, bill.amountNano),
     metered: unmappedGateway,
     ineligibleReason: null,
+  };
+}
+
+/**
+ * How metering divides a total.
+ *
+ * `billNano` is null when metering IS the total — the estimated case, where
+ * every metered unit accounts for itself and there is nothing left over.
+ *
+ * The attributed part is clamped to `[0, max(bill, 0)]` because metering cannot
+ * account for a refund: on a negative day the whole negative figure is
+ * unallocated, and the metering that ran anyway shows up as the variance. That
+ * is what keeps `attributed + unallocated` equal to the total in every branch.
+ */
+function splitOf(meteredNano: bigint, billNano: bigint | null): BillSplit {
+  if (billNano === null) {
+    return {
+      attributedNano: meteredNano,
+      unallocatedNano: 0n,
+      overMeteredNano: 0n,
+    };
+  }
+  const attributedNano =
+    billNano <= 0n ? 0n : meteredNano < billNano ? meteredNano : billNano;
+  return {
+    attributedNano,
+    unallocatedNano: billNano - attributedNano,
+    overMeteredNano: meteredNano > billNano ? meteredNano - billNano : 0n,
   };
 }
 

--- a/platform/app/ee/governance/services/logic/combinedCostLanes.ts
+++ b/platform/app/ee/governance/services/logic/combinedCostLanes.ts
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+
+/**
+ * The connected view's arithmetic: the bill is the total, and gateway metering
+ * splits it (ADR-128 §2, §7).
+ *
+ * Four rules, and all four are about not inventing money.
+ *
+ *   1. The total shown is the BILL, so the screen's number can be held against
+ *      the invoice. Gateway metering never replaces it and is never added to
+ *      it.
+ *   2. Metering splits that total. The part no gateway row explains is its own
+ *      line, never silently netted away.
+ *   3. Metering above the bill is a variance line, never a subtraction, and
+ *      never a negative number we invented. A provider's own refund CAN make a
+ *      day genuinely negative, and that renders as-is — clamping it to zero
+ *      silently eats money.
+ *   4. A day the bill has not reached yet shows the gateway figure marked
+ *      *estimated*, because gateway rows arrive instantly and bills land days
+ *      later. Derived here at read time from whether a bill row exists, stored
+ *      nowhere — the same pattern the big cloud cost pages use, so Tuesday's
+ *      $4.20 becoming Thursday's $6.00 never looks like a silent change.
+ *
+ * Integer nano-units throughout (§3): every figure is a `bigint`, and nothing
+ * here divides. Amounts in different currency codes are never added — where the
+ * bill and its keys disagree on currency and the biller published no conversion
+ * of its own, the mapping is ineligible and the two lanes are reported side by
+ * side instead of split.
+ *
+ * Pure. No clock, no database, no rounding.
+ *
+ * Spec: specs/governance/governance-cost-coverage.feature
+ */
+
+/** Why a bill and the keys mapped to it could not be combined. */
+export const COVERAGE_INELIGIBLE = {
+  /** §3: the bill and its keys are priced in different currencies, and the
+   *  biller published no conversion, so no split can be computed without
+   *  inventing an exchange rate. */
+  CROSS_CURRENCY: "cross_currency",
+} as const;
+export type CoverageIneligibleReason =
+  (typeof COVERAGE_INELIGIBLE)[keyof typeof COVERAGE_INELIGIBLE];
+
+/** An amount and the currency it is denominated in. Never added across codes. */
+export interface CurrencyAmount {
+  amountNano: bigint;
+  currencyCode: string;
+}
+
+/** One provider-day's two lanes, as the read side hands them over. */
+export interface ProviderDayLanes {
+  day: string;
+  provider: string;
+  /**
+   * The provider's own figure for this day, or null when no bill row has landed
+   * for it yet. Null is what makes a day read as *estimated*; a bill of zero is
+   * a bill and reads as billed.
+   */
+  bill: CurrencyAmount | null;
+  /**
+   * Gateway metering on keys this bill covered on this day, or null when the
+   * bill covers no key that spent anything. Its currency is the gateway's, not
+   * necessarily the bill's.
+   */
+  coveredGateway: CurrencyAmount | null;
+  /** Gateway metering on keys no bill covered on this day. */
+  unmappedGateway: CurrencyAmount | null;
+}
+
+/** How gateway metering divides up the total. */
+export interface BillSplit {
+  /** The part of the total gateway metering accounts for. Never negative. */
+  attributedNano: bigint;
+  /** The rest of the total. Negative on a refund day, and rendered as-is. */
+  unallocatedNano: bigint;
+  /** How far metering ran OVER the total. Never negative, never subtracted. */
+  overMeteredNano: bigint;
+}
+
+/** One provider-day, ready to render. */
+export interface CombinedProviderDay {
+  day: string;
+  provider: string;
+  /**
+   * The figure the screen shows, and what it is. `billed` reconciles to the
+   * provider's cost feed; `estimated` is gateway metering standing in until the
+   * bill lands. Null when neither lane said anything.
+   */
+  total: (CurrencyAmount & { basis: "billed" | "estimated" }) | null;
+  /** How the total divides, or null when no mapping could be applied to it. */
+  split: BillSplit | null;
+  /** Gateway dollars no bill claims, in their own currency. Real money. */
+  metered: CurrencyAmount | null;
+  /** Why `split` is null despite there being both a bill and covered metering. */
+  ineligibleReason: CoverageIneligibleReason | null;
+}
+
+/**
+ * Combines one provider-day's lanes into the figure and the lines beneath it.
+ *
+ * The one arithmetic invariant, which holds in every branch including refunds:
+ * `attributedNano + unallocatedNano` equals the total exactly. `overMeteredNano`
+ * sits outside that sum on purpose — it is a comparison, not a component, and
+ * folding it in would be the subtraction rule 3 forbids.
+ */
+export function combineProviderDay(
+  lanes: ProviderDayLanes,
+): CombinedProviderDay {
+  const { bill, coveredGateway, unmappedGateway } = lanes;
+  const base = { day: lanes.day, provider: lanes.provider };
+
+  if (bill === null) {
+    // No bill has reached this day. Covered metering stands in for one and says
+    // so; metering on unmapped keys was never going to be part of a bill and is
+    // reported as itself.
+    return {
+      ...base,
+      total:
+        coveredGateway === null
+          ? null
+          : { ...coveredGateway, basis: "estimated" },
+      split:
+        coveredGateway === null
+          ? null
+          : {
+              attributedNano: coveredGateway.amountNano,
+              unallocatedNano: 0n,
+              overMeteredNano: 0n,
+            },
+      metered: unmappedGateway,
+      ineligibleReason: null,
+    };
+  }
+
+  const total = { ...bill, basis: "billed" as const };
+
+  if (coveredGateway === null) {
+    // A bill nothing is mapped to. The whole of it is unexplained by metering,
+    // which is the honest reading of a bill whose keys nobody has named yet.
+    return {
+      ...base,
+      total,
+      split: {
+        attributedNano: 0n,
+        unallocatedNano: bill.amountNano,
+        overMeteredNano: 0n,
+      },
+      metered: unmappedGateway,
+      ineligibleReason: null,
+    };
+  }
+
+  if (coveredGateway.currencyCode !== bill.currencyCode) {
+    // Splitting would mean converting, and nobody here has a rate that is not
+    // invented. Both lanes render, each in its own currency, and the covered
+    // metering joins the metered line rather than disappearing: its dollars are
+    // real whether or not they can be matched against this bill.
+    return {
+      ...base,
+      total,
+      split: null,
+      metered: addSameCurrency(coveredGateway, unmappedGateway),
+      ineligibleReason: COVERAGE_INELIGIBLE.CROSS_CURRENCY,
+    };
+  }
+
+  const billNano = bill.amountNano;
+  const meteredNano = coveredGateway.amountNano;
+  // Clamped at zero because metering cannot account for a refund: on a negative
+  // day the whole (negative) figure is unallocated, and the metering that ran
+  // anyway shows up as the variance below.
+  const attributedNano =
+    billNano <= 0n ? 0n : meteredNano < billNano ? meteredNano : billNano;
+
+  return {
+    ...base,
+    total,
+    split: {
+      attributedNano,
+      unallocatedNano: billNano - attributedNano,
+      overMeteredNano: meteredNano > billNano ? meteredNano - billNano : 0n,
+    },
+    metered: unmappedGateway,
+    ineligibleReason: null,
+  };
+}
+
+/**
+ * Adds two amounts that may or may not be present, refusing to add across
+ * currencies.
+ *
+ * Where they disagree the second is dropped rather than converted, and the
+ * caller is expected to have already established that this cannot happen: the
+ * gateway prices its whole lane in one currency, so both arguments here are
+ * always the gateway's. The check is the guard that keeps that assumption from
+ * quietly becoming a wrong sum if the gateway ever prices in two.
+ */
+function addSameCurrency(
+  first: CurrencyAmount,
+  second: CurrencyAmount | null,
+): CurrencyAmount {
+  if (second === null || second.currencyCode !== first.currencyCode) {
+    return first;
+  }
+  return {
+    amountNano: first.amountNano + second.amountNano,
+    currencyCode: first.currencyCode,
+  };
+}

--- a/platform/app/ee/governance/services/logic/costCoverage.ts
+++ b/platform/app/ee/governance/services/logic/costCoverage.ts
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+
+/**
+ * Reading the key-to-bill mapping as of a day (ADR-128 §7).
+ *
+ * The mapping is dated, and this is what makes that worth anything: a chart of
+ * last May resolves the bill that covered May, not the bill covering the key
+ * today. Everything here is a pure function of periods and a day — no clock, no
+ * database — so the same answer comes back however many times May is drawn.
+ *
+ * Spec: specs/governance/governance-cost-coverage.feature
+ */
+import type { CoveragePeriod } from "../../repositories/ingestionSourceKeyCoverage.repository";
+
+const MS_PER_DAY = 86_400_000;
+
+/**
+ * Whether an instant is the start of a UTC day.
+ *
+ * A day is the finest grain a bill can own — the rollup buckets spend with
+ * `toStartOfDay` — so a mid-day effective instant is not representable, and a
+ * noon re-point would file the whole day under whichever bill the read happened
+ * to resolve.
+ */
+export function isUtcMidnight(at: Date): boolean {
+  return at.getTime() % MS_PER_DAY === 0;
+}
+
+/** The UTC midnight that begins a `YYYY-MM-DD` day. */
+export function startOfUtcDay(day: string): Date {
+  return new Date(`${day}T00:00:00.000Z`);
+}
+
+/**
+ * Which bill covered each key on one day: key id to ingestion source id.
+ *
+ * A period covers a day when it began no later than that day's midnight and had
+ * not yet ended by it — half-open, so a period ending on the first of June
+ * covers May the 31st and not June the 1st, and its successor beginning at the
+ * same instant covers June the 1st with no day claimed twice and none left out.
+ *
+ * A key absent from the returned map is *unmapped* on that day: its gateway
+ * spend stands alone as metered, which is a different statement from zero.
+ *
+ * Throws when two bills both claim a key on one day. The exclusion constraint
+ * makes that unreachable, so reaching it means the constraint is missing or
+ * something wrote around it — and the alternative, keeping whichever period was
+ * read last, is exactly the silent last-writer-wins attribution the constraint
+ * exists to prevent. A plain error rather than a named one: nobody reading a
+ * chart can act on it.
+ */
+export function coverageOnDay(params: {
+  periods: readonly CoveragePeriod[];
+  day: string;
+}): Map<string, string> {
+  const at = startOfUtcDay(params.day).getTime();
+  const covering = new Map<string, string>();
+  for (const period of params.periods) {
+    if (period.validFrom.getTime() > at) continue;
+    if (period.validTo !== null && period.validTo.getTime() <= at) continue;
+    const claimed = covering.get(period.virtualKeyId);
+    if (claimed !== undefined && claimed !== period.ingestionSourceId) {
+      throw new Error(
+        `Two ingestion sources cover gateway key ${period.virtualKeyId} on ${params.day}`,
+      );
+    }
+    covering.set(period.virtualKeyId, period.ingestionSourceId);
+  }
+  return covering;
+}

--- a/platform/app/ee/governance/services/logic/postgresConstraintErrors.ts
+++ b/platform/app/ee/governance/services/logic/postgresConstraintErrors.ts
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+
+/**
+ * Recognising the Postgres constraint violations governance holds its rules
+ * with, through whichever shape Prisma wrapped them in.
+ *
+ * The repo maps Prisma's own `P2002` and, before ADR-128, no raw SQLSTATE
+ * anywhere — so a violation raised by the database arrived as a generic unknown
+ * error with a trace id, for situations the customer can act on in one click.
+ * Both the identity links (§11) and the key-to-bill coverage mapping (§7) hold
+ * their rules as database constraints, so both need to read the code back.
+ */
+
+/** Postgres' unique-violation code, raised by the one-open-link index. */
+const UNIQUE_VIOLATION = "23505";
+
+/**
+ * Prisma's own code for the same refusal: the client wraps a unique violation
+ * as a `PrismaClientKnownRequestError` with `code: "P2002"` and buries the
+ * SQLSTATE underneath. `IdentityMatch` has no other unique rule a write could
+ * trip (the primary key is a fresh nanoid), so `P2002` on these writes means
+ * the one-open-link index and nothing else.
+ */
+const PRISMA_UNIQUE_VIOLATION = "P2002";
+
+/** Postgres' exclusion-violation code: two rows overlap where none may. */
+const EXCLUSION_VIOLATION = "23P01";
+
+/** Postgres' check-violation code: a row a named CHECK refuses. */
+const CHECK_VIOLATION = "23514";
+
+/**
+ * The driver's SQLSTATE, read off whichever shape carried it.
+ *
+ * Prisma surfaces a raw constraint violation as a `PrismaClientUnknownRequestError`
+ * whose SQLSTATE lives in the message rather than in a field, so a structural
+ * check alone misses it. All three places are checked, and the message check is
+ * a word-boundary match rather than a `String(err).includes` over the whole
+ * text — that would also match an error whose *payload* happened to contain the
+ * digits.
+ */
+function hasSqlState(error: unknown, sqlState: string): boolean {
+  if (typeof error !== "object" || error === null) return false;
+  if ((error as { code?: unknown }).code === sqlState) return true;
+  const meta = (error as { meta?: { code?: unknown } }).meta;
+  if (meta?.code === sqlState) return true;
+  const message = (error as { message?: unknown }).message;
+  return (
+    typeof message === "string" && new RegExp(`\\b${sqlState}\\b`).test(message)
+  );
+}
+
+/**
+ * Whether a thrown value is the one-open-link index refusing a second open
+ * link.
+ *
+ * Prisma's `P2002` wrapper is checked alongside the raw SQLSTATE because the
+ * client catches this one itself before the driver's code can surface.
+ */
+export function isOpenLinkViolation(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) return false;
+  if ((error as { code?: unknown }).code === PRISMA_UNIQUE_VIOLATION)
+    return true;
+  return hasSqlState(error, UNIQUE_VIOLATION);
+}
+
+/** Whether a thrown value is an exclusion constraint refusing an overlap. */
+export function isExclusionViolation(error: unknown): boolean {
+  return hasSqlState(error, EXCLUSION_VIOLATION);
+}
+
+/**
+ * Whether a thrown value is a CHECK constraint refusing a row.
+ *
+ * In governance that is always a validity range that covers no time — a
+ * zero-width or inverted `[validFrom, validTo)`.
+ */
+export function isCheckViolation(error: unknown): boolean {
+  return hasSqlState(error, CHECK_VIOLATION);
+}

--- a/platform/app/prisma/migrations/20260904120000_ingestion_source_key_coverage/migration.sql
+++ b/platform/app/prisma/migrations/20260904120000_ingestion_source_key_coverage/migration.sql
@@ -95,7 +95,16 @@ RETURNS TRIGGER AS $$
 DECLARE
     key_org TEXT;
 BEGIN
-    SELECT "organizationId" INTO key_org FROM "VirtualKey" WHERE "id" = NEW."virtualKeyId";
+    -- FOR KEY SHARE, and it is the whole difference between this check holding
+    -- and merely appearing to. A plain SELECT reads a key that a concurrent
+    -- session is about to delete, finds it, and lets the insert through; that
+    -- session's delete then fires the orphan-drop trigger below and finds
+    -- nothing, because this row is not committed yet. Both transactions commit,
+    -- and the coverage row outlives its key. The share lock makes the deleting
+    -- session wait for this insert instead, so the orphan-drop trigger runs
+    -- after the row exists and does see it. (Reproduced and the fix verified on
+    -- PostgreSQL 16.14.)
+    SELECT "organizationId" INTO key_org FROM "VirtualKey" WHERE "id" = NEW."virtualKeyId" FOR KEY SHARE;
     IF key_org IS NULL THEN
         RAISE EXCEPTION 'Gateway key % does not exist, so no bill can be recorded as covering it.', NEW."virtualKeyId"
             USING ERRCODE = 'foreign_key_violation';
@@ -115,6 +124,11 @@ CREATE TRIGGER "IngestionSourceKeyCoverage_key_org_check"
 -- The same absence of real foreign keys means nothing removes coverage when its
 -- key is deleted. An orphaned open row holds that key's one open slot forever,
 -- so a key later created with the same id could never be covered by anything.
+--
+-- This trigger only reaches rows that exist when the delete runs, which is why
+-- the check above takes FOR KEY SHARE: without that lock an insert racing this
+-- delete commits a row neither statement ever sees, and the pair of triggers
+-- covers every ordering except the one that matters.
 CREATE OR REPLACE FUNCTION "ingestion_source_key_coverage_drop_orphans"()
 RETURNS TRIGGER AS $$
 BEGIN

--- a/platform/app/prisma/migrations/20260904120000_ingestion_source_key_coverage/migration.sql
+++ b/platform/app/prisma/migrations/20260904120000_ingestion_source_key_coverage/migration.sql
@@ -1,0 +1,142 @@
+-- Which gateway keys a connected provider bill pays for (ADR-128 wave 2, section 7).
+--
+-- The screens show a provider bill and the gateway's own metering as separate
+-- lanes today. The moment they are merged into one figure, "every dollar has
+-- one home" stops being structural and starts needing an answer to: does a
+-- bill already claim this key's spend? That answer is an administrator's
+-- explicit mapping, and this is where it lives.
+--
+-- DATED, and that is the whole design. Coverage is read as of the day being
+-- drawn, so re-pointing a key from Bill 1 to Bill 2 in June leaves May filed
+-- under Bill 1. A list column on "IngestionSource" would be rewritten wholesale
+-- on every edit, silently re-filing every past month the next time a chart was
+-- drawn - history edited by a present-tense edit.
+--
+-- A SEPARATE TABLE, because that is what lets the database hold the rule. The
+-- exclusion constraint below refuses a second bill claiming an already-covered
+-- key, rather than letting the last administrator to hit Save win.
+--
+-- Uses btree_gist, installed by 20260902120000_governance_identity_and_erasure.
+-- The availability guard is repeated rather than assumed: this migration must
+-- fail with an actionable message on a server where the extension is missing,
+-- not half-apply and leave the overlap rule off. A missing overlap guard is
+-- invisible until two bills claim one key and the read picks one.
+
+-- +-------------------------------------------------------------------------+
+-- | btree_gist availability guard                                            |
+-- +-------------------------------------------------------------------------+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_available_extensions WHERE name = 'btree_gist') THEN
+    RAISE EXCEPTION
+      'btree_gist is not available on this PostgreSQL server, so the gateway-key coverage table cannot be created. It ships with the standard contrib package. Install the server''s contrib/extension package (postgresql-contrib on Debian/Ubuntu, postgresqlNN-contrib on RHEL), or enable btree_gist in your managed provider''s allowed-extensions list, then re-run the migration.';
+  END IF;
+END
+$$;
+
+CREATE EXTENSION IF NOT EXISTS btree_gist;
+
+-- +-------------------------------------------------------------------------+
+-- | IngestionSourceKeyCoverage - the key-to-bill mapping                     |
+-- +-------------------------------------------------------------------------+
+CREATE TABLE "IngestionSourceKeyCoverage" (
+    "id" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "ingestionSourceId" TEXT NOT NULL,
+    "virtualKeyId" TEXT NOT NULL,
+    -- UTC midnight only, enforced by the service: the rollup buckets spend with
+    -- toStartOfDay, so a day is the finest thing a bill can own. Not a database
+    -- constraint, because the column is a naive TIMESTAMP(3) and "midnight" is
+    -- a statement about the caller's calendar - a CHECK here would read the
+    -- session's own time zone and reject a legitimate write from another one.
+    "validFrom" TIMESTAMP(3) NOT NULL,
+    "validTo" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "IngestionSourceKeyCoverage_pkey" PRIMARY KEY ("id")
+);
+
+-- One organization's mapping, and the per-source list shown beside the source's
+-- own configuration.
+CREATE INDEX "IngestionSourceKeyCoverage_organizationId_sourceId_idx" ON "IngestionSourceKeyCoverage"("organizationId", "ingestionSourceId");
+
+-- Resolving which bill covered a key on the day being drawn.
+CREATE INDEX "IngestionSourceKeyCoverage_organizationId_key_validFrom_idx" ON "IngestionSourceKeyCoverage"("organizationId", "virtualKeyId", "validFrom");
+
+-- A zero-width range (validFrom = validTo) is EMPTY, and an empty range
+-- overlaps nothing - not even itself - so it slips past the exclusion
+-- constraint below entirely and files a bill against no time at all. An
+-- inverted range raises a raw type error (SQLSTATE 22000) that no layer maps.
+-- One named CHECK rejects both, in the database.
+ALTER TABLE "IngestionSourceKeyCoverage" ADD CONSTRAINT "IngestionSourceKeyCoverage_valid_range_check"
+    CHECK ("validTo" IS NULL OR "validTo" > "validFrom");
+
+-- At most one bill may cover a key at any given instant. Two OPEN rows both
+-- range to infinity, so this rejects the second with SQLSTATE 23P01; a closed
+-- row overlapping an open one is rejected the same way. NO partial unique index
+-- is added on top: it would be strictly redundant, and would make the common
+-- race surface as 23505 instead - two error codes for one rule, and the
+-- application would have to handle both to say one sentence.
+ALTER TABLE "IngestionSourceKeyCoverage" ADD CONSTRAINT "IngestionSourceKeyCoverage_no_overlap"
+    EXCLUDE USING gist (
+        "virtualKeyId" WITH =,
+        tsrange("validFrom", COALESCE("validTo", 'infinity')) WITH &&
+    );
+
+-- +-------------------------------------------------------------------------+
+-- | The row's organization must be its key's organization                    |
+-- +-------------------------------------------------------------------------+
+-- relationMode = "prisma" means "virtualKeyId" is not a real foreign key, so
+-- nothing here would otherwise stop a coverage row naming one organization
+-- while the key it points at belongs to another - which is one organization's
+-- bill claiming another's spend.
+CREATE OR REPLACE FUNCTION "ingestion_source_key_coverage_key_org_check"()
+RETURNS TRIGGER AS $$
+DECLARE
+    key_org TEXT;
+BEGIN
+    SELECT "organizationId" INTO key_org FROM "VirtualKey" WHERE "id" = NEW."virtualKeyId";
+    IF key_org IS NULL THEN
+        RAISE EXCEPTION 'Gateway key % does not exist, so no bill can be recorded as covering it.', NEW."virtualKeyId"
+            USING ERRCODE = 'foreign_key_violation';
+    END IF;
+    IF key_org <> NEW."organizationId" THEN
+        RAISE EXCEPTION 'Gateway key % belongs to a different organization than the coverage row naming it.', NEW."virtualKeyId"
+            USING ERRCODE = 'foreign_key_violation';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER "IngestionSourceKeyCoverage_key_org_check"
+    BEFORE INSERT OR UPDATE OF "virtualKeyId", "organizationId" ON "IngestionSourceKeyCoverage"
+    FOR EACH ROW EXECUTE FUNCTION "ingestion_source_key_coverage_key_org_check"();
+
+-- The same absence of real foreign keys means nothing removes coverage when its
+-- key is deleted. An orphaned open row holds that key's one open slot forever,
+-- so a key later created with the same id could never be covered by anything.
+CREATE OR REPLACE FUNCTION "ingestion_source_key_coverage_drop_orphans"()
+RETURNS TRIGGER AS $$
+BEGIN
+    DELETE FROM "IngestionSourceKeyCoverage" WHERE "virtualKeyId" = OLD."id";
+    RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER "VirtualKey_drop_coverage_on_delete"
+    AFTER DELETE ON "VirtualKey"
+    FOR EACH ROW EXECUTE FUNCTION "ingestion_source_key_coverage_drop_orphans"();
+
+-- IRREVERSIBLE: dropping "IngestionSourceKeyCoverage" discards which bill paid
+-- for which gateway key, and when. That mapping is an administrator's stated
+-- knowledge, not something any pull can rediscover - the re-pointing history
+-- goes with it, so even re-entering today's mapping would re-file every past
+-- month under today's answer.
+--
+-- Repair goes forward, in a new migration.
+--   DROP TRIGGER "VirtualKey_drop_coverage_on_delete" ON "VirtualKey";
+--   DROP FUNCTION "ingestion_source_key_coverage_drop_orphans"();
+--   DROP TRIGGER "IngestionSourceKeyCoverage_key_org_check" ON "IngestionSourceKeyCoverage";
+--   DROP FUNCTION "ingestion_source_key_coverage_key_org_check"();
+--   DROP TABLE "IngestionSourceKeyCoverage";
+--   -- btree_gist is left installed: the identity tables depend on it.

--- a/platform/app/prisma/schema.prisma
+++ b/platform/app/prisma/schema.prisma
@@ -5239,3 +5239,43 @@ model IdentityMatchSuggestion {
   // The review surface reads one organization's candidates, strongest first.
   @@index([organizationId, score])
 }
+
+/// Which gateway keys a connected provider bill pays for (ADR-128 §7).
+///
+/// Dated, because coverage is read as of the day being drawn: re-pointing a key
+/// from one bill to another in June must leave May filed under the first bill.
+/// An undated column would silently re-file every past month the next time a
+/// chart was drawn.
+///
+/// A separate table rather than a list column on `IngestionSource`, because
+/// that is what lets the DATABASE hold "every dollar has one home" - an
+/// exclusion constraint refuses a second bill claiming an already-covered key
+/// instead of letting the last administrator to hit Save win.
+///
+/// None of its rules are expressible here, so all of them live in the
+/// migration: an exclusion constraint over the validity range, a CHECK that the
+/// range is non-empty, and a trigger tying the row to its key's own
+/// organization (`relationMode = "prisma"` means there are no real foreign keys
+/// to do it).
+model IngestionSourceKeyCoverage {
+  id                String    @id @default(nanoid())
+  organizationId    String
+  /// The connected bill.
+  ingestionSourceId String
+  /// The gateway key that bill pays for.
+  virtualKeyId      String
+  /// UTC midnight only. A day is the finest grain a bill can own, so a mid-day
+  /// instant is not representable and would file a whole day under whichever
+  /// bill the read happened to resolve.
+  validFrom         DateTime
+  /// Open coverage is null. Re-pointing closes this row and opens a successor
+  /// at the same instant, in one transaction - it never rewrites this one.
+  validTo           DateTime?
+  createdAt         DateTime  @default(now())
+
+  // One organization's mapping, and the per-source list shown beside the
+  // source's own configuration.
+  @@index([organizationId, ingestionSourceId])
+  // Resolving which bill covered a key on the day being drawn.
+  @@index([organizationId, virtualKeyId, validFrom])
+}

--- a/platform/app/src/features/errors/logic/codes.ts
+++ b/platform/app/src/features/errors/logic/codes.ts
@@ -156,6 +156,9 @@ export const APP_ERROR_CODES = [
   "identity_verification_expired",
   "identity_verification_invalid",
   "ingestion_source_cap_reached",
+  "ingestion_source_coverage_not_after_start",
+  "ingestion_source_coverage_not_midnight",
+  "ingestion_source_key_already_covered",
   "ingestion_source_not_found",
   "insufficient_permissions",
   // Also a Go code, with copy already written under the shared/transport

--- a/platform/app/src/features/errors/logic/presentation.ts
+++ b/platform/app/src/features/errors/logic/presentation.ts
@@ -2164,6 +2164,24 @@ const presentations = {
     describe: () =>
       "Archive one you no longer use, or upgrade your plan to raise the limit.",
   },
+  // ADR-128 §7. A key belongs to one bill at a time, so that a dollar is never
+  // counted twice. All three of these are ordinary edits, not mistakes worth a
+  // trace id.
+  ingestion_source_key_already_covered: {
+    title: "Another bill already covers this key",
+    describe: () =>
+      "A key's spend can only be paid for by one bill at a time. Stop the other bill covering it first, or move the key across in one step.",
+  },
+  ingestion_source_coverage_not_midnight: {
+    title: "Coverage starts on a date, not at a time",
+    describe: () =>
+      "A bill can only take over a key from the start of a day. Pick a date.",
+  },
+  ingestion_source_coverage_not_after_start: {
+    title: "Pick a later date",
+    describe: () =>
+      "This key's current bill already starts on that date, so there is no day for it to have covered. Choose a date after it.",
+  },
 
   // ---- datasets ----
   dataset_name_taken: {

--- a/platform/app/src/server/app-layer/presets.ts
+++ b/platform/app/src/server/app-layer/presets.ts
@@ -21,6 +21,7 @@ import {
 } from "@ee/governance/services/costRollupComparatorSchedule";
 import { installGovernanceSuppressionSnapshot } from "@ee/governance/services/erasureSuppression.service";
 import { GovernanceCostRollupClickHouseRepository } from "@ee/governance/services/governanceCostRollup.clickhouse.repository";
+import { GovernanceEventLogHorizonClickHouseRepository } from "@ee/governance/services/governanceEventLogHorizon.clickhouse.repository";
 import { GovernanceKpisClickHouseRepository } from "@ee/governance/services/governanceKpis.clickhouse.repository";
 import { GovernanceOcsfEventsClickHouseRepository } from "@ee/governance/services/governanceOcsfEvents.clickhouse.repository";
 import { GovernanceRollupErasureClickHouseRepository } from "@ee/governance/services/governanceRollupErasure.clickhouse.repository";
@@ -1081,6 +1082,13 @@ export function initializeDefaultApp(options?: {
   const governanceRollupErasureRepository = clickhouseEnabled
     ? new GovernanceRollupErasureClickHouseRepository(resolveClickHouseClient)
     : undefined;
+  // ADR-022 makes the event log's retention the ceiling on what an erasure can
+  // rebuild, and this is what reads that ceiling off the log itself rather than
+  // predicting it from the retention policy — see the repository for why the
+  // policy is the wrong source.
+  const governanceEventLogHorizonRepository = clickhouseEnabled
+    ? new GovernanceEventLogHorizonClickHouseRepository(resolveClickHouseClient)
+    : undefined;
   const governanceIdentityErasure = governanceRollupErasureRepository
     ? new IdentityErasureService({
         prisma,
@@ -1103,12 +1111,13 @@ export function initializeDefaultApp(options?: {
           }
           return ops.replay;
         }),
-        // ADR-022 makes the event log's retention the ceiling on what can be
-        // rebuilt. Stated as null until PR-D wires the configured retention
-        // through: every affected day is then attempted rather than being
-        // pre-emptively written off, and a day that genuinely cannot be
-        // replayed surfaces as a rebuild that changed nothing.
-        replayHorizon: () => null,
+        // Asked per erasure, never cached: a horizon read at boot would be
+        // months stale by the time an erasure uses it, and stale in the one
+        // direction that writes days off unasked.
+        replayHorizon: async ({ tenantIds }) =>
+          (await governanceEventLogHorizonRepository?.oldestEventByTenant({
+            tenantIds,
+          })) ?? new Map(),
       })
     : undefined;
 

--- a/platform/app/src/server/clickhouse/__tests__/retentionTtl.unit.test.ts
+++ b/platform/app/src/server/clickhouse/__tests__/retentionTtl.unit.test.ts
@@ -186,3 +186,42 @@ describe("governance_cost_rollup_1d retention exemption", () => {
     expect(migration).not.toContain("_retention_days");
   });
 });
+
+describe("governance_ocsf_events retention exemption", () => {
+  // ADR-128 §16. Four shipped pullers write provider display names and email
+  // addresses into this table, and it declared no TTL at all — rows kept
+  // forever. The holding period for personal data has to be a fixed bound, not
+  // a customer setting, which is why the answer is a 13-month TTL in a
+  // migration and NOT enrolment in the retention map: `MODIFY TTL` replaces the
+  // whole clause atomically (ttlReconciler.ts), so enrolling the table would
+  // overwrite the fixed bound with the tenant's own retention value — and a
+  // tenant who sets a longer one would then hold names and addresses past 13
+  // months.
+  /** @scenario "The SIEM event table holds personal data for a fixed period, not a customer-set one" */
+  it("is absent from tenant retention and from the TTL reconciler config", () => {
+    // The absence assertions below are only worth anything if the populations
+    // they search are the real ones, so name a member of each first.
+    expect(RETENTION_MANAGED_TABLES).toContain("event_log");
+    expect(TABLE_TTL_CONFIG.find((c) => c.table === "event_log")).toBeDefined();
+
+    expect(RETENTION_MANAGED_TABLES).not.toContain("governance_ocsf_events");
+    expect(
+      TABLE_TTL_CONFIG.find((c) => c.table === "governance_ocsf_events"),
+    ).toBeUndefined();
+  });
+
+  /** @scenario "The SIEM event table holds personal data for a fixed period, not a customer-set one" */
+  it("declares its fixed 13-month delete in the migration itself", () => {
+    const migration = readFileSync(
+      join(
+        process.cwd(),
+        "src/server/clickhouse/migrations/00091_governance_ocsf_events_fixed_ttl.sql",
+      ),
+      "utf8",
+    );
+    expect(migration).toContain(
+      "MODIFY TTL toDateTime(EventTime) + INTERVAL 13 MONTH DELETE",
+    );
+    expect(migration).not.toContain("_retention_days");
+  });
+});

--- a/platform/app/src/server/clickhouse/migrations/00091_governance_ocsf_events_fixed_ttl.sql
+++ b/platform/app/src/server/clickhouse/migrations/00091_governance_ocsf_events_fixed_ttl.sql
@@ -1,0 +1,51 @@
+-- +goose Up
+-- +goose ENVSUB ON
+
+-- ============================================================================
+-- governance_ocsf_events: a fixed thirteen-month holding period (ADR-128 §16).
+--
+-- The table shipped in 00026 declaring no TTL at all, so its rows are kept
+-- forever. Four shipped pullers write provider display names, user principal
+-- names and email addresses into `ActorEmail` and into the `RawOcsfJson`
+-- payload, which makes "forever" the wrong answer for this table specifically.
+--
+-- Thirteen months, and FIXED, deliberately. The table stays absent from
+-- `RETENTION_TABLE_CATEGORY_MAP` and `TABLE_TTL_CONFIG` — the same shape
+-- 00067 (gateway_spend) and 00087 (governance_cost_rollup_1d) already use.
+-- Enrolling it in the retention map is ruled out rather than merely skipped:
+-- the reconciler's `MODIFY TTL` replaces the whole TTL expression atomically
+-- (`ttlReconciler.ts`), so enrolment would overwrite this bound with the
+-- tenant's own retention value, and a tenant who sets a longer one would then
+-- hold names and email addresses past thirteen months. A holding period for
+-- personal data is not a customer setting.
+--
+-- `toDateTime(EventTime)` because EventTime is DateTime64(3) and ClickHouse
+-- rejects DateTime64 directly in TTL arithmetic. It is also the partition key
+-- (`toYYYYMM(EventTime)`), so expiry drops whole monthly partitions at the part
+-- level rather than mutating rows.
+--
+-- `materialize_ttl_after_modify = 0` — metadata only, matching what the
+-- reconciler issues for every other retention TTL in this schema. The
+-- alternative rewrites every existing part in one pass, and this table carries
+-- six skip indices whose backing data a retroactive TTL mutation has wedged
+-- before. Consequence, stated rather than glossed: the bound binds on each
+-- part's next merge instead of immediately. Nothing in the table is near
+-- thirteen months old (00026 is weeks old), so there is nothing for an
+-- immediate pass to delete anyway.
+-- ============================================================================
+
+-- +goose StatementBegin
+ALTER TABLE ${CLICKHOUSE_DATABASE}.governance_ocsf_events
+  MODIFY TTL toDateTime(EventTime) + INTERVAL 13 MONTH DELETE
+  SETTINGS materialize_ttl_after_modify = 0;
+-- +goose StatementEnd
+
+-- +goose Down
+-- IRREVERSIBLE in the direction that matters: removing the TTL puts the table
+-- back to keeping personal data forever, which is the defect this migration
+-- exists to close. `up` is idempotent (MODIFY TTL is a whole-clause replace),
+-- so `down` is deliberately a no-op.
+--
+-- To roll back, uncomment and run manually.
+--
+-- ALTER TABLE ${CLICKHOUSE_DATABASE}.governance_ocsf_events REMOVE TTL;

--- a/platform/app/src/utils/dbOrganizationIdProtection.ts
+++ b/platform/app/src/utils/dbOrganizationIdProtection.ts
@@ -338,6 +338,12 @@ const ORG_SCOPED_MODELS: Record<string, OrgScopedModelConfig> = {
   ErasedIdentifierSuppression: {
     platformScopeActions: ["findMany"],
   },
+  // Which gateway keys a connected provider bill pays for (ADR-128 §7). Every
+  // access names the organization: an administrator edits their own mapping,
+  // and the combined view resolves it for the organization whose chart is being
+  // drawn. A bare read across tenants would be one organization's bill claiming
+  // another's spend, which is exactly what the row-level trigger also refuses.
+  IngestionSourceKeyCoverage: {},
   // The grants ledger's projection tables (ADR-092 §13). Written only by
   // the authz_grants fold (plus revocation enforcement); read by the engine
   // per organization. Row id / organizationId cover every access pattern.

--- a/specs/governance/governance-cost-coverage.feature
+++ b/specs/governance/governance-cost-coverage.feature
@@ -93,7 +93,16 @@ Feature: Every dollar has one home
 
   Rule: The total shown is the bill; gateway detail splits it
 
-    @unit
+    # Every scenario under this rule says what a reader is SHOWN, and nothing
+    # shows it yet: there is no connected view, and no caller of the arithmetic
+    # behind it. What does exist and is proved is `combineProviderDay` — the
+    # split, the variance line, the unclamped refund, the estimated day and the
+    # add-up-exactly invariant are all unit-tested against it. So these are
+    # parked rather than bound: counting them would report a view as delivered
+    # on the strength of tests that draw nothing. They become @unit the day a
+    # reader can see the numbers.
+
+    @unimplemented
     Scenario: Gateway detail splits the bill and the remainder is its own line
       Given a bill of six dollars for a provider day
       And four dollars twenty of gateway spend on keys that bill covers
@@ -102,7 +111,7 @@ Feature: Every dollar has one home
       And four dollars twenty is shown as attributed
       And one dollar eighty is shown as not seen by the gateway
 
-    @unit
+    @unimplemented
     Scenario: Gateway spend above the bill is shown as a variance, never subtracted
       Given a bill of six dollars for a provider day
       And six dollars fifty of gateway spend on keys that bill covers
@@ -111,34 +120,34 @@ Feature: Every dollar has one home
       And fifty cents is shown as metering running over the bill
       And nothing is subtracted from the total
 
-    @unit
+    @unimplemented
     Scenario: A refunded day stays negative
       Given a provider day whose bill is a refund
       When the connected view is drawn
       Then the total shown is negative
       # Clamping it to zero would silently eat money.
 
-    @unit
+    @unimplemented
     Scenario: A day the bill has not reached yet is marked estimated
       Given a key covered by a bill
       And gateway spend on a day no bill has reported yet
       When the connected view is drawn
       Then the day shows the gateway figure marked as estimated
 
-    @unit
+    @unimplemented
     Scenario: The estimate becomes the bill when the bill lands
       Given a day shown as estimated from gateway spend
       When the provider's bill for that day arrives
       Then the day shows the bill and is no longer marked estimated
 
-    @unit
+    @unimplemented
     Scenario: Gateway spend no bill covers stands alone
       Given gateway spend on a key no bill covers
       When the connected view is drawn
       Then that spend is shown on its own as metered
       And it is not counted against any bill
 
-    @unit
+    @unimplemented
     Scenario: A bill and its keys in different currencies are not combined
       Given a bill in euros covering keys metered in dollars
       And the provider published no dollar figure of its own
@@ -146,7 +155,7 @@ Feature: Every dollar has one home
       Then the bill and the gateway spend are shown separately in their own currencies
       And no split is shown for that day
 
-    @unit
+    @unimplemented
     Scenario: The parts of a day always add up to its total
       Given any provider day with a bill
       When the connected view is drawn

--- a/specs/governance/governance-cost-coverage.feature
+++ b/specs/governance/governance-cost-coverage.feature
@@ -1,0 +1,153 @@
+@governance @cost
+Feature: Every dollar has one home
+  A connected provider bill and the gateway's own metering can describe the
+  same spend. Which gateway keys a bill pays for is something an administrator
+  says, never something we assume, and what they said last May has to keep
+  being true when May is drawn again next year. So the answer is a dated
+  record, the database itself refuses a second bill claiming a key somebody
+  already claimed, and the screen's number is always the bill.
+  Decision: ADR-128 sections 2 and 7.
+
+  Rule: A key belongs to one bill at a time, and the database is what says so
+
+    @integration
+    Scenario: A second bill cannot claim a key another bill already covers
+      Given a bill covering a gateway key from the first of the month
+      When another bill is recorded as covering that same key from the same day
+      Then the second record is refused
+      And the administrator is told another bill already covers that key
+      # Refused by the database, not by a read-then-write in the application:
+      # two administrators saving at the same instant both pass the read.
+
+    @integration
+    Scenario: A bill may cover a key another bill has finished covering
+      Given a bill that covered a gateway key until the first of June
+      When another bill is recorded as covering that key from the first of June
+      Then both records are kept
+      And each month reads under the bill that covered it at the time
+
+    @integration
+    Scenario: Coverage that starts and ends at the same moment is refused
+      When coverage is recorded that ends the instant it begins
+      Then the record is refused
+      # It describes no time at all, so nothing would ever notice it overlapping
+      # anything, and the key would read as covered by a bill it never was.
+
+    @integration
+    Scenario: Coverage that ends before it begins is refused
+      When coverage is recorded that ends before it begins
+      Then the record is refused
+
+    @integration
+    Scenario: Coverage cannot name a different organization than its key
+      Given a gateway key belonging to one organization
+      When coverage for that key is recorded under another organization
+      Then the record is refused
+      # Nothing else would stop it: these are not real foreign keys.
+
+  Rule: Re-pointing a key is one movement, so no day is left uncovered
+
+    @integration
+    Scenario: Moving a key to another bill closes the old coverage and opens the new together
+      Given a bill covering a gateway key
+      When an administrator moves that key to another bill from the first of next month
+      Then the old coverage ends at that moment and the new coverage begins at it
+      And no moment in between belongs to no bill
+
+    @integration
+    Scenario: A failed move leaves the original coverage intact
+      Given a bill covering a gateway key
+      When moving that key to another bill fails partway
+      Then the key is still covered by the original bill
+
+    @unit
+    Scenario: Coverage may only start at midnight
+      When an administrator records coverage starting partway through a day
+      Then the record is refused
+      And the administrator is told to pick a date
+      # A day is the finest grain a bill can own, so a mid-day start would file
+      # the whole day under whichever bill the reader happened to resolve.
+
+    @unit
+    Scenario: Coverage cannot be moved to the day it already started
+      Given a bill that began covering a gateway key today
+      When an administrator moves that key to another bill from today
+      Then the move is refused
+      And the administrator is told to pick a later date
+
+  Rule: Which bill covered a key is read as of the day being drawn
+
+    @unit
+    Scenario: A past month keeps the bill that covered it at the time
+      Given a key covered by one bill until June and by another from June
+      When May is drawn
+      Then May reads under the first bill
+      When June is drawn
+      Then June reads under the second bill
+
+    @unit
+    Scenario: A key covered by nobody on that day belongs to no bill
+      Given a key whose coverage began in June
+      When May is drawn
+      Then May's gateway spend belongs to no bill
+
+  Rule: The total shown is the bill; gateway detail splits it
+
+    @unit
+    Scenario: Gateway detail splits the bill and the remainder is its own line
+      Given a bill of six dollars for a provider day
+      And four dollars twenty of gateway spend on keys that bill covers
+      When the connected view is drawn
+      Then the total shown is six dollars
+      And four dollars twenty is shown as attributed
+      And one dollar eighty is shown as not seen by the gateway
+
+    @unit
+    Scenario: Gateway spend above the bill is shown as a variance, never subtracted
+      Given a bill of six dollars for a provider day
+      And six dollars fifty of gateway spend on keys that bill covers
+      When the connected view is drawn
+      Then the total shown is still six dollars
+      And fifty cents is shown as metering running over the bill
+      And nothing is subtracted from the total
+
+    @unit
+    Scenario: A refunded day stays negative
+      Given a provider day whose bill is a refund
+      When the connected view is drawn
+      Then the total shown is negative
+      # Clamping it to zero would silently eat money.
+
+    @unit
+    Scenario: A day the bill has not reached yet is marked estimated
+      Given a key covered by a bill
+      And gateway spend on a day no bill has reported yet
+      When the connected view is drawn
+      Then the day shows the gateway figure marked as estimated
+
+    @unit
+    Scenario: The estimate becomes the bill when the bill lands
+      Given a day shown as estimated from gateway spend
+      When the provider's bill for that day arrives
+      Then the day shows the bill and is no longer marked estimated
+
+    @unit
+    Scenario: Gateway spend no bill covers stands alone
+      Given gateway spend on a key no bill covers
+      When the connected view is drawn
+      Then that spend is shown on its own as metered
+      And it is not counted against any bill
+
+    @unit
+    Scenario: A bill and its keys in different currencies are not combined
+      Given a bill in euros covering keys metered in dollars
+      And the provider published no dollar figure of its own
+      When the connected view is drawn
+      Then the bill and the gateway spend are shown separately in their own currencies
+      And no split is shown for that day
+
+    @unit
+    Scenario: The parts of a day always add up to its total
+      Given any provider day with a bill
+      When the connected view is drawn
+      Then the attributed part and the part not seen by the gateway add up to the total exactly

--- a/specs/governance/governance-data-retention.feature
+++ b/specs/governance/governance-data-retention.feature
@@ -19,6 +19,17 @@ Feature: How long governance data lives, and what that costs when it goes
     # fixed bound. A holding period for personal data is not a customer
     # setting.
 
+  @unit
+  Scenario: A day the screen says can still change is a day we can still act on
+    Given a cost day the screen shows as still able to change
+    When the shortest retention a customer can set is applied to it
+    Then that day's history outlives the period the screen calls it changeable
+    # Otherwise we tell the customer a figure can still move on a day whose
+    # history has already gone, so the restatement that arrives cannot be
+    # folded and an erasure on that day cannot be rebuilt. The two periods are
+    # set in unrelated places and clear each other by five days entirely by
+    # accident, which is the reason to pin it.
+
   @unit @integration
   Scenario: Each area is judged against how far its own log reaches
     Given an organization whose spend was recorded in two areas

--- a/specs/governance/governance-data-retention.feature
+++ b/specs/governance/governance-data-retention.feature
@@ -1,0 +1,20 @@
+@governance @retention
+Feature: How long governance data lives, and what that costs when it goes
+  Governance keeps two very different kinds of record, and they expire under
+  two different rules. Security events name real people, so they are held for
+  a fixed period nobody can extend. Money days are rebuilt from the event log,
+  so once the log has aged out there is nothing left to rebuild them from and
+  an erasure has to say so.
+  Decision: ADR-128 sections 9 and 16.
+
+  @unit
+  Scenario: The SIEM event table holds personal data for a fixed period, not a customer-set one
+    Given the security event table carries provider display names and email addresses
+    Then it expires those rows after a fixed period
+    And no customer retention setting can lengthen or shorten that period
+    # The table shipped keeping rows forever. Enrolling it in the customer
+    # retention machinery would not fix that: applying a retention setting
+    # replaces the whole expiry rule in one go, so a customer who asked for a
+    # longer window would then be holding names and email addresses past the
+    # fixed bound. A holding period for personal data is not a customer
+    # setting.

--- a/specs/governance/governance-data-retention.feature
+++ b/specs/governance/governance-data-retention.feature
@@ -18,3 +18,28 @@ Feature: How long governance data lives, and what that costs when it goes
     # longer window would then be holding names and email addresses past the
     # fixed bound. A holding period for personal data is not a customer
     # setting.
+
+  @unit @integration
+  Scenario: Each area is judged against how far its own log reaches
+    Given an organization whose spend was recorded in two areas
+    And one area's history reaches further back than the other's
+    When somebody is erased from both
+    Then a day is only reported as unrebuildable when its own area's history
+      has aged past it
+    # How far back the history reaches is read from the history itself, not
+    # worked out from the retention setting. The setting describes what will
+    # happen to rows written from now on; it says nothing reliable about the
+    # rows already there, which were written under whatever setting was in
+    # force then and are removed lazily rather than on the stroke of the
+    # deadline.
+
+  @unit @integration
+  Scenario: An area whose log cannot be read is retried, not written off
+    Given an area whose history cannot be read
+    When somebody is erased
+    Then every affected day is attempted
+    And no day is reported as unrebuildable
+    # The two ways of being wrong here are not equal. Attempting a day that
+    # cannot be rebuilt costs a wider replay that changes nothing. Writing off
+    # a day that could have been rebuilt permanently lowers that day's total
+    # and tells the customer it was unavoidable.


### PR DESCRIPTION
# Related Issue

- Resolves #7746

Part of #7746 (ADR-128 wave 2). Stacked on the match engine PR — review only the commits above `issue7746/adr128-wave2-match-engine`.

## What this delivers

- 13-month TTL on the governance SIEM event table (migration 00089), so exported names stop being kept forever.
- Replay-horizon accounting: an erasure asks the event log how far back it can actually rebuild, and reports days it cannot (`daysBeyondReplayHorizon`).
- A pinned guarantee that the settling window stays inside the retention floor.

## Known scope limits

- The TTL bounds the ClickHouse store only; `DiscoveredPerson.rawActorId` / `.displayText` in Postgres have no expiry and are removed only by erasure. Recorded as a review finding.
- The TTL is fixed — no per-customer lengthening. Deliberate, but a ceiling for orgs under multi-year audit obligations.

Remaining P2/P3 review findings are recorded as PR comments rather than fixed here.
