### PR TITLE
fix(governance): hold one open link per person without an extension

### DIFF
--- a/charts/langwatch/README.md
+++ b/charts/langwatch/README.md
@@ -6,7 +6,6 @@ Deploy LangWatch to Kubernetes. Includes the web app, workers, NLP service, Lang
 
 - Kubernetes 1.24+, Helm 3.12+
 - A default StorageClass for persistent components if chart-managed
-- An external PostgreSQL must allow `CREATE EXTENSION btree_gist`; migrations create it and fail loudly if it is unavailable. The chart-managed PostgreSQL already has it.
 
 ### Install
 

--- a/charts/langwatch/values.yaml
+++ b/charts/langwatch/values.yaml
@@ -1812,11 +1812,8 @@ postgresql:
 
   # Connection string to use for PostgreSQL when running in `chartManaged: false` mode
   #
-  # The instance must allow `CREATE EXTENSION btree_gist` and the migration user
-  # must be allowed to run it. It comes with postgresql-contrib, so the
-  # chart-managed instance above already has it; on a managed provider, check the
-  # extension allow-list before pointing this at it. Migrations fail with an
-  # explicit message rather than half-applying when it is missing.
+  # No extensions are required: any plain PostgreSQL the migration user can
+  # run DDL on will do, managed providers included.
   external:
     connectionString:
       ## @param postgresql.external.connectionString.value [string] External PostgreSQL connection string.

--- a/dev/docs/adr/128-governance-cost-and-identity-two-waves.md
+++ b/dev/docs/adr/128-governance-cost-and-identity-two-waves.md
@@ -512,15 +512,18 @@ Making midnight the only legal effective time is what keeps "May stays
 under Bill 1" true on the one day people actually check it. Admin UI
 therefore offers a date, not a timestamp.
 
-**Deployment: `btree_gist` is the repo's first extension.** No
-`CREATE EXTENSION` exists in the 297 migrations shipped so far. The
-migration must check the extension is available and fail with an
-actionable message rather than half-applying; the self-host
-documentation and the Helm chart must state the requirement; and
-availability must be verified per managed-Postgres provider before the
-migration ships (Azure Database for PostgreSQL in particular is
-unverified). This applies equally to `IdentityMatch` and `SeatPrice`,
-which use the same guard.
+**Deployment: no extensions.** An earlier revision made `btree_gist`
+the repo's first `CREATE EXTENSION`, for `IdentityMatch`'s overlap
+constraint — with an availability guard in the migration, a stated
+requirement in the self-host documentation and the Helm chart, and
+per-provider verification before shipping. That was reversed before
+anything shipped: nothing in wave 2 ever closes a link (no writer sets
+`validTo`), so the overlap rule degenerates to "at most one OPEN link
+per person", which a plain partial unique index holds with no extension
+at all. `SeatPrice` must make its own call when it ships — its dated
+price ranges do close, so if it wants the general overlap rule held in
+the database it re-opens this deployment question, guard and docs and
+provider verification included.
 
 The mapping is edited beside the source config (small admin list,
 audited, read at query time like every overlap rule). The exclusion filter
@@ -1435,7 +1438,7 @@ drift apart).
 | Path | Reversible? | Blast radius | Gate |
 |---|---|---|---|
 | ClickHouse migration `ALTER`ing `governance_cost_rollup_1d` (the table itself shipped in wave 1 as 00087; wave 2 adds exactly two columns, `RevisedAt` and `LastObservedAt` — the prior-amount column `PreviousAmountNanoUsd` is already there) | no (schema) | large | human review + a written manual rollback (`DROP COLUMN` per added column — the down path is narrower than wave 1's `DROP TABLE` precisely because the table is not ours to drop any more) — repo convention keeps data-touching down paths commented out, and no down-testing harness exists, so "tested down path" would be a false promise |
-| Prisma migration adding the identity tables, seat price list, coverage, tenant history, suppression list and suggestion index | no (schema) | large | human review + reversibility reviewed in PR (Prisma migrations here have no down files; rollback is a follow-up migration); the migration is also the repo's first `CREATE EXTENSION` (`btree_gist`, §7) — it must check availability and fail actionably, and the self-host docs and Helm chart must state the requirement |
+| Prisma migration adding the identity tables, seat price list, coverage, tenant history, suppression list and suggestion index | no (schema) | large | human review + reversibility reviewed in PR (Prisma migrations here have no down files; rollback is a follow-up migration); the identity migration needs no extensions (§7 — the one-open-link rule is a plain partial unique index); if `SeatPrice` re-opens the `btree_gist` question, that PR re-inherits the availability-guard, docs and Helm gates |
 | Rollup fold projection | yes (replayable) | large | automated: replay-equality test; feature flags gate the screens (no §7 dependency in wave 1 — lanes never summed) |
 | Exclusion filter + key-to-bill mapping (wave 2) | yes | large (money correctness) | automated: one-dollar-one-home test suite is a merge blocker for the first lane-merging screen |
 | Auto-link on deterministic evidence | yes (links are dated; closing reverses) | medium | automated: conflict-rule tests (two candidates → suspend + flag); fuzzy scoring runs **only** in §12's background suggestion job, never inline in a request — test: no request path computes an edit distance |
@@ -1598,15 +1601,14 @@ model IdentityMatch {
   validTo            DateTime? // open link = null; offboarding/correction closes, never rewrites
   createdAt          DateTime  @default(now())
   // at most one OPEN link per discovered person — enforced with a partial unique index
-  // (raw SQL in the migration: UNIQUE (discoveredPersonId) WHERE validTo IS NULL)
-  // Overlap guard: no two rows for the same discoveredPersonId may have overlapping
-  // validity ranges. Enforced by an exclusion constraint (raw SQL in the migration:
-  // CREATE EXTENSION IF NOT EXISTS btree_gist;
-  // EXCLUDE USING gist ("discoveredPersonId" WITH =,
-  //   tsrange("validFrom", COALESCE("validTo", 'infinity')) WITH &&)).
-  // tsrange treats NULL validTo as unbounded via COALESCE, so both open and closed
-  // rows participate. Without it, a read-time join on validFrom <= spendDate < validTo
-  // could match multiple rows.
+  // (raw SQL in the migration: UNIQUE (discoveredPersonId) WHERE validTo IS NULL,
+  // SQLSTATE 23505; Prisma wraps it as P2002 and the app maps both to one sentence).
+  // An earlier revision held the general overlap rule instead (btree_gist EXCLUDE,
+  // both open and closed rows participating) so a read-time join on
+  // validFrom <= spendDate < validTo could never match two rows. Reversed before
+  // shipping: nothing in wave 2 writes validTo, so closed rows cannot exist and the
+  // general rule guarded an unreachable case at the price of an extension
+  // requirement on every Postgres. Revisit when closing links ships.
 }
 
 model SeatPrice {
@@ -1634,10 +1636,13 @@ model IngestionSourceKeyCoverage {
   virtualKeyId      String              // the gateway key that bill pays for
   validFrom         DateTime            // §7: UTC midnight only — a day is the finest grain a bill can own
   validTo           DateTime?           // open coverage = null; re-pointing closes, never rewrites
-  // Overlap guard, and the ONLY uniqueness rule here: same btree_gist
-  // exclusion pattern as IdentityMatch —
+  // Overlap guard, and the ONLY uniqueness rule here — unlike IdentityMatch,
+  // coverage rows really do close (re-pointing writes validTo), so this table
+  // still needs the general overlap rule, which is a btree_gist exclusion:
   // EXCLUDE USING gist ("virtualKeyId" WITH =,
   //   tsrange("validFrom", COALESCE("validTo", 'infinity')) WITH &&).
+  // That makes this table (with SeatPrice) the one that re-opens the
+  // CREATE EXTENSION deployment question §7's identity reversal closed.
   // It already rejects a second open row for a key (SQLSTATE 23P01), so
   // NO partial unique index is added on top: the redundant index would only
   // make the common race surface as 23505 instead, two codes for one rule
@@ -1810,12 +1815,29 @@ money tables, only the identity tables and read paths.
 | Two sources may claim two DIFFERENT subscriptions (the ownership guard refuses only a duplicate), and the spend panel carries one note — the oldest claim speaks (`createdAt` order, deterministic). One note for two bills is unresolved | before a second claiming source is a real shape |
 | Azure and Databricks restatement windows are unmeasured; `SETTLING_WINDOW_DAYS` stays provisional for those sources until probed (§15) | Sergio / puller implementer |
 | Payload-level redaction for `governance_ocsf_events` — the raw OCSF JSON holds names and email addresses that a single-column pseudonym cannot reach; wave 2 answers with delete-and-suppress (§16), a redacting read path or structured columns is owed | identity implementer |
-| `btree_gist` availability per managed-Postgres provider (Azure Database for PostgreSQL unverified) — the repo's first `CREATE EXTENSION` (§7) | Sergio |
+| `btree_gist` availability per managed-Postgres provider (Azure Database for PostgreSQL unverified) — no longer needed by the identity tables (§7 reversal), but still ahead of `SeatPrice` and `IngestionSourceKeyCoverage` if their overlap rules stay database-held | Sergio |
 | LWQL org-wide cost surface (§17) — own design pass, wave 2+ | deferred |
 | Registry-final permission verb names (§18) | implementation PR |
 
 ## Revisions
 
+- **v3.10 (2026-09-03, captain: Sergio Esteban).** `IdentityMatch`'s
+  overlap rule is narrowed to "at most one OPEN link per person", held by
+  a plain partial unique index (`UNIQUE (discoveredPersonId) WHERE
+  "validTo" IS NULL`, SQLSTATE 23505 / Prisma P2002) — the `btree_gist`
+  exclusion constraint, and with it the repo's first `CREATE EXTENSION`,
+  is dropped before shipping (§7 deployment note, Schema, Gates, open
+  questions). The general rule guarded a case wave 2 cannot produce:
+  nothing writes `validTo`, so no closed row exists to overlap anything —
+  at the price of an extension requirement on every self-hosted and
+  managed Postgres, with per-provider availability unverified. Consequences
+  folded in: the app maps 23505/P2002 (not 23P01) to the same
+  already-linked sentence; a closed link overlapping an open one is no
+  longer database-refused (unreachable today, revisit when closing
+  ships); Helm chart and self-host docs drop the extension requirement.
+  `SeatPrice` and `IngestionSourceKeyCoverage` are untouched — their rows
+  really close, so their exclusion constraints stand and re-open the
+  extension question when they ship. Status unchanged (Proposed).
 - **v3.9 (2026-09-02, captain: Sergio Esteban).** Red-team panel on the
   wave-2 lock: five independent refuters attacked the claim that the six
   v3.8 lock decisions could be implemented without violating a hard

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -64071,7 +64071,6 @@ Deploy LangWatch on any Kubernetes cluster using the official Helm chart. The ch
 - `kubectl` configured for your cluster
 - A StorageClass that supports dynamic provisioning (for persistent volumes)
 - A domain name (for Ingress with TLS)
-- If you bring your own PostgreSQL: the `btree_gist` extension must be installable, and the migration user must be allowed to run `CREATE EXTENSION`. It ships with the standard `postgresql-contrib` package, so the chart-managed PostgreSQL already has it; on a managed provider, confirm it is on the allow-list before upgrading. Migrations fail with an explicit message rather than half-applying if it is missing.
 - **Default resource requirements:** ~5 CPU and ~17 Gi RAM (requests). See [Size Overlays](#size-overlays) for smaller or larger configurations.
 
 ## Quick Start

--- a/docs/self-hosting/deployment/kubernetes-helm.mdx
+++ b/docs/self-hosting/deployment/kubernetes-helm.mdx
@@ -12,7 +12,6 @@ Deploy LangWatch on any Kubernetes cluster using the official Helm chart. The ch
 - `kubectl` configured for your cluster
 - A StorageClass that supports dynamic provisioning (for persistent volumes)
 - A domain name (for Ingress with TLS)
-- If you bring your own PostgreSQL: the `btree_gist` extension must be installable, and the migration user must be allowed to run `CREATE EXTENSION`. It ships with the standard `postgresql-contrib` package, so the chart-managed PostgreSQL already has it; on a managed provider, confirm it is on the allow-list before upgrading. Migrations fail with an explicit message rather than half-applying if it is missing.
 - **Default resource requirements:** ~5 CPU and ~17 Gi RAM (requests). See [Size Overlays](#size-overlays) for smaller or larger configurations.
 
 ## Quick Start

--- a/platform/app/ee/governance/__tests__/governanceIdentityConstraints.integration.test.ts
+++ b/platform/app/ee/governance/__tests__/governanceIdentityConstraints.integration.test.ts
@@ -8,8 +8,6 @@
  * pass this file while leaving the constraint absent, which is the failure this
  * exists to catch.
  *
- * Requires the `btree_gist` extension the migration installs.
- *
  * Spec: specs/governance/governance-identity-and-erasure.feature
  * Decision: ADR-128 §11
  */
@@ -24,14 +22,15 @@ import {
   resolveGovOrganizationId,
   resolveGovTenantIds,
 } from "../services/governanceTenantHistory.service";
+import { isOpenLinkViolation } from "../services/identityMatch.errors";
 
 const ns = `gov-identity-${nanoid(8)}`;
 const organizationId = `org_${ns}`;
 const otherOrganizationId = `org_other_${ns}`;
 const discoveredPersonId = `dp_${ns}`;
 
-/** Postgres's exclusion-constraint violation. Asserted by code, never by prose. */
-const EXCLUSION_VIOLATION = "23P01";
+/** Postgres's unique-constraint violation. Asserted by code, never by prose. */
+const UNIQUE_VIOLATION = "23505";
 /** Postgres's check-constraint violation. */
 const CHECK_VIOLATION = "23514";
 
@@ -68,7 +67,7 @@ const sqlState = (error: unknown): string | undefined => {
   }
   // Last resort: the message carries the SQLSTATE when the chain does not.
   const message = String((error as { message?: string })?.message ?? "");
-  return /\b(23P01|23514)\b/.exec(message)?.[1];
+  return /\b(23505|23514)\b/.exec(message)?.[1];
 };
 
 const link = (overrides: {
@@ -123,8 +122,8 @@ describe("Feature: the identity tables hold their own rules", () => {
     });
 
     describe("when a second link is opened while the first is open", () => {
-      /** @scenario "A person can only be linked to one account at a time" */
-      it("is refused by the overlap rule rather than by a duplicate-row rule", async () => {
+      /** @scenario "A person can only have one open link at a time" */
+      it("is refused as a duplicate open link", async () => {
         let caught: unknown;
         try {
           await prisma.identityMatch.create({
@@ -138,36 +137,80 @@ describe("Feature: the identity tables hold their own rules", () => {
         }
 
         expect(caught).toBeDefined();
-        // 23P01 and not 23505: one rule, one error code. A partial unique index
-        // on top of the exclusion constraint would make the common race report
-        // the other one, and the application would have to handle both to say
-        // one sentence (ADR-128 §7).
-        expect(sqlState(caught)).toBe(EXCLUSION_VIOLATION);
+        // The partial unique index on open links is the only uniqueness rule
+        // left after ADR-128 dropped the gist exclusion constraint (nothing
+        // ever writes validTo, so overlap degenerated to "at most one open
+        // link per person"). Prisma wraps its 23505 as P2002 and keeps the
+        // SQLSTATE to itself, so the assertion is the application's own
+        // predicate — the exact contract the service's catch sites rely on.
+        expect((caught as { code?: string }).code).toBe("P2002");
+        expect(isOpenLinkViolation(caught)).toBe(true);
       });
     });
 
-    describe("when a closed link overlapping the open one is opened", () => {
-      it("is refused too, because a read on a spend date could match both", async () => {
+    describe("when a second open link is written straight to the database", () => {
+      /** @scenario "A second open link is refused even when written straight to the database" */
+      it("is refused by the database itself, not by application code", async () => {
         let caught: unknown;
         try {
-          await prisma.identityMatch.create({
-            data: link({
-              id: `im_overlap_${ns}`,
-              validFrom: new Date("2026-04-01T00:00:00.000Z"),
-              validTo: new Date("2026-04-30T00:00:00.000Z"),
-            }),
-          });
+          // Raw SQL on purpose: this proves the rule holds for a writer that
+          // skips Prisma and the service layer entirely.
+          await prisma.$executeRawUnsafe(
+            `
+            -- @tenancy: single fixed test row; the rule under test is per-person,
+            -- not per-tenant.
+            INSERT INTO "IdentityMatch"
+              ("id", "organizationId", "discoveredPersonId", "userId", "evidenceKind", "validFrom", "validTo")
+            VALUES ($1, $2, $3, $4, 'verified_email', '2026-05-02T00:00:00Z', NULL)
+            `,
+            `im_raw_${ns}`,
+            organizationId,
+            discoveredPersonId,
+            `user_${ns}`,
+          );
         } catch (error) {
           caught = error;
         }
 
-        expect(sqlState(caught)).toBe(EXCLUSION_VIOLATION);
+        expect(sqlState(caught)).toBe(UNIQUE_VIOLATION);
+
+        // And the invariant itself: no person holds two open links.
+        const doubled = await prisma.$queryRawUnsafe<unknown[]>(`
+          -- @tenancy: invariant sweep across the whole test database; a second
+          -- open link anywhere is a failure regardless of tenant.
+          SELECT "discoveredPersonId", count(*)
+          FROM "IdentityMatch"
+          WHERE "validTo" IS NULL
+          GROUP BY 1
+          HAVING count(*) > 1
+        `);
+        expect(doubled).toHaveLength(0);
+      });
+    });
+
+    describe("when a closed link overlapping the open one is written", () => {
+      it("is accepted: the rule only counts open links", async () => {
+        // Boundary made explicit by the spec: nothing in the product closes
+        // links yet, so an overlapping closed row cannot occur outside a test.
+        // Revisit when closing links ships.
+        await prisma.identityMatch.create({
+          data: link({
+            id: `im_overlap_${ns}`,
+            validFrom: new Date("2026-04-01T00:00:00.000Z"),
+            validTo: new Date("2026-04-30T00:00:00.000Z"),
+          }),
+        });
+
+        const rows = await prisma.identityMatch.findMany({
+          where: { organizationId, discoveredPersonId },
+        });
+        expect(rows.map((row) => row.id)).toContain(`im_overlap_${ns}`);
       });
     });
 
     describe("when a link whose start and end are the same instant is saved", () => {
       /** @scenario "A link that covers no time at all is refused" */
-      it("is refused, rather than slipping past the overlap rule as an empty span", async () => {
+      it("is refused, rather than slipping past the open-link rule as a closed row", async () => {
         let caught: unknown;
         try {
           await prisma.identityMatch.create({

--- a/platform/app/ee/governance/repositories/governanceIdentity.repository.ts
+++ b/platform/app/ee/governance/repositories/governanceIdentity.repository.ts
@@ -320,8 +320,8 @@ export class IdentityMatchRepository {
   /**
    * Opens a link, recording what proved it and from when.
    *
-   * No upsert and no catch: the exclusion constraint refuses a second link
-   * overlapping an open one with SQLSTATE 23P01, and that refusal is the
+   * No upsert and no catch: the one-open-link index refuses a second open
+   * link for the same person with SQLSTATE 23505, and that refusal is the
    * database holding a rule the application would otherwise have to remember.
    * The caller maps it; swallowing it here would let a race quietly re-point
    * somebody's spend.

--- a/platform/app/ee/governance/services/__tests__/identityErasure.service.unit.test.ts
+++ b/platform/app/ee/governance/services/__tests__/identityErasure.service.unit.test.ts
@@ -322,8 +322,9 @@ describe("given a provider-named person an organization has asked us to erase", 
       });
 
       // Two blanked in the first sweep, one more that appeared after it. The
-      // exclusion constraint would not have stopped this one: the person's own
-      // rows were blanked, so a fresh link on them overlaps nothing.
+      // one-open-link index is no guarantee against that one — a person whose
+      // links were all closed, or who had none, holds no open slot to refuse
+      // it — so the second sweep is what actually catches it.
       expect(outcome.identityMatchesBlanked).toBe(3);
       expect(calls.filter((call) => call === "matches.blank")).toHaveLength(2);
     });

--- a/platform/app/ee/governance/services/__tests__/identityMatch.service.unit.test.ts
+++ b/platform/app/ee/governance/services/__tests__/identityMatch.service.unit.test.ts
@@ -9,7 +9,7 @@
  * The repositories are doubles rather than a database, because what is under
  * test is the orchestration: which read filters which population, and which
  * write follows which decision. The database's half of the rules
- * (`IdentityMatch`'s overlap constraint) has its own integration test, and the
+ * (`IdentityMatch`'s one-open-link index) has its own integration test, and the
  * evidence rules have their own unit test — this is the seam between them.
  *
  * Spec: specs/governance/governance-identity-match-engine.feature
@@ -68,8 +68,8 @@ const build = ({
    * People the pass read as live and who were erased before it got to writing
    * them: `findMatchable` hands them over, `findById` reports them erased.
    *
-   * The one shape the exclusion constraint cannot catch, because a person who
-   * never held a link has no row for a new one to overlap.
+   * The one shape the one-open-link index cannot catch, because a person who
+   * never held a link has no open row for a new one to collide with.
    */
   erasedMidPass?: Person[];
   openLinks?: { discoveredPersonId: string; userId: string | null }[];
@@ -319,14 +319,16 @@ describe("Feature: linking provider-named people to accounts on proof", () => {
 
   describe("given a concurrent pass that opened the same link first", () => {
     it("carries on with the rest of the organization rather than ending the pass", async () => {
-      // The exclusion constraint refusing the second write is the rule holding.
+      // The one-open-link index refusing the second write is the rule holding.
       // Ending the pass there would leave everybody after this person unmatched
-      // until the next night.
+      // until the next night. Prisma reports the index as P2002 with the
+      // SQLSTATE underneath, which is the shape faked here.
       const { service } = build({
         people: [person()],
         emails: [{ userId: "user_42", email: "m.silva@acme.test" }],
-        openThrows: Object.assign(new Error("conflicting key value"), {
-          code: "23P01",
+        openThrows: Object.assign(new Error("Unique constraint failed"), {
+          code: "P2002",
+          meta: { code: "23505" },
         }),
       });
 
@@ -335,7 +337,7 @@ describe("Feature: linking provider-named people to accounts on proof", () => {
       ).resolves.toEqual({ linked: 0, suspended: 0, unproven: 0 });
     });
 
-    it("still raises anything that is not the overlap rule", async () => {
+    it("still raises anything that is not the open-link rule", async () => {
       const { service } = build({
         people: [person()],
         emails: [{ userId: "user_42", email: "m.silva@acme.test" }],
@@ -394,14 +396,15 @@ describe("Feature: turning a suggestion into a link", () => {
 
   describe("given two reviewers confirming at the same instant", () => {
     it("tells the loser the person is already linked, not that something unknown happened", async () => {
-      // Both reads pass; the exclusion constraint refuses the second write. The
-      // check and the constraint hold one rule between them, so they say one
-      // sentence.
+      // Both reads pass; the one-open-link index refuses the second write. The
+      // check and the index hold one rule between them, so they say one
+      // sentence. Faked here as the bare SQLSTATE, the shape a raw driver
+      // error carries when Prisma's wrapper is absent.
       const { service } = build({
         people: [person()],
         suggestions: [suggestion],
-        openThrows: Object.assign(new Error("conflicting key value"), {
-          code: "23P01",
+        openThrows: Object.assign(new Error("duplicate key value"), {
+          code: "23505",
         }),
       });
 

--- a/platform/app/ee/governance/services/__tests__/identityMatchEngine.integration.test.ts
+++ b/platform/app/ee/governance/services/__tests__/identityMatchEngine.integration.test.ts
@@ -539,9 +539,9 @@ describe("Feature: the match engine, against the database that holds its rules",
         discoveredPeople: racing,
       }).linkProvenMatches({ organizationId });
 
-      // The exclusion constraint is no help here and this is why: the person
-      // held no link before the erasure, so there is no overlapping row for a
-      // new one to collide with. The re-read is the whole of the defence.
+      // The one-open-link index is no help here and this is why: the person
+      // held no link before the erasure, so there is no open row for a new
+      // one to collide with. The re-read is the whole of the defence.
       expect(outcome.linked).toBe(0);
       await expect(linksFor(person.id)).resolves.toHaveLength(0);
     });

--- a/platform/app/ee/governance/services/identityMatch.errors.ts
+++ b/platform/app/ee/governance/services/identityMatch.errors.ts
@@ -33,12 +33,12 @@ export class IdentityMatchSuggestionNotFoundError extends NotFoundError {
 /**
  * The person already holds an open link.
  *
- * Raised on the read that finds the link, and again from SQLSTATE 23P01 when
- * two confirmations race past that read — the exclusion constraint on
- * `IdentityMatch` is what actually holds the rule, and it deserves the same
- * sentence as the check that usually gets there first. `fault` stays customer:
- * clicking a stale queue entry is an ordinary thing for a person to do, not an
- * incident.
+ * Raised on the read that finds the link, and again from SQLSTATE 23505 when
+ * two confirmations race past that read — the partial unique index on
+ * `IdentityMatch` (one open link per person) is what actually holds the rule,
+ * and it deserves the same sentence as the check that usually gets there
+ * first. `fault` stays customer: clicking a stale queue entry is an ordinary
+ * thing for a person to do, not an incident.
  */
 export class IdentityAlreadyLinkedError extends HandledError {
   declare readonly code: "identity_already_linked";
@@ -85,33 +85,38 @@ export class IdentityErasedError extends HandledError {
   }
 }
 
-/**
- * Postgres' exclusion-violation code.
- *
- * The repo maps Prisma's `P2002` and, before this, no exclusion violation
- * anywhere — so an overlap raised by the database arrived as a generic unknown
- * error with a trace id, for a situation the customer can act on in one click.
- */
-const EXCLUSION_VIOLATION = "23P01";
+/** Postgres' unique-violation code, raised by the one-open-link index. */
+const UNIQUE_VIOLATION = "23505";
 
 /**
- * Whether a thrown value is the overlap constraint refusing a second open link.
- *
- * Reads the driver's own code off whichever shape carried it: Prisma surfaces a
- * raw constraint violation as a `PrismaClientUnknownRequestError` whose SQLSTATE
- * lives in the message rather than in a field, so a structural check alone
- * misses it. Both are checked, and neither is a `String(err).includes` over the
- * whole message — that would also match an error whose *payload* happened to
- * contain the digits.
+ * Prisma's own code for the same refusal: the client wraps a unique violation
+ * as a `PrismaClientKnownRequestError` with `code: "P2002"` and buries the
+ * SQLSTATE underneath. `IdentityMatch` has no other unique rule a write could
+ * trip (the primary key is a fresh nanoid), so `P2002` on these writes means
+ * the one-open-link index and nothing else.
  */
-export function isExclusionViolation(error: unknown): boolean {
+const PRISMA_UNIQUE_VIOLATION = "P2002";
+
+/**
+ * Whether a thrown value is the one-open-link index refusing a second open
+ * link.
+ *
+ * Reads the code off whichever shape carried it: Prisma's `P2002` wrapper, a
+ * raw driver error's SQLSTATE in `code` or `meta.code`, or — for the wrapper
+ * shapes whose SQLSTATE lives only in the message — a word-bounded match on
+ * the message. Never a `String(err).includes` over the whole message: that
+ * would also match an error whose *payload* happened to contain the digits.
+ */
+export function isOpenLinkViolation(error: unknown): boolean {
   if (typeof error !== "object" || error === null) return false;
-  if ((error as { code?: unknown }).code === EXCLUSION_VIOLATION) return true;
+  const code = (error as { code?: unknown }).code;
+  if (code === UNIQUE_VIOLATION || code === PRISMA_UNIQUE_VIOLATION)
+    return true;
   const meta = (error as { meta?: { code?: unknown } }).meta;
-  if (meta?.code === EXCLUSION_VIOLATION) return true;
+  if (meta?.code === UNIQUE_VIOLATION) return true;
   const message = (error as { message?: unknown }).message;
   return (
     typeof message === "string" &&
-    new RegExp(`\\b${EXCLUSION_VIOLATION}\\b`).test(message)
+    new RegExp(`\\b${UNIQUE_VIOLATION}\\b`).test(message)
   );
 }

--- a/platform/app/ee/governance/services/identityMatch.service.ts
+++ b/platform/app/ee/governance/services/identityMatch.service.ts
@@ -37,7 +37,7 @@ import {
   IdentityAlreadyLinkedError,
   IdentityErasedError,
   IdentityMatchSuggestionNotFoundError,
-  isExclusionViolation,
+  isOpenLinkViolation,
 } from "./identityMatch.errors";
 import {
   decideMatch,
@@ -240,8 +240,8 @@ export class IdentityMatchService {
    * Opens one proven link, reporting 1 or 0 rather than throwing on the single
    * failure that is not one.
    *
-   * A concurrent pass beating this one to the same link raises the exclusion
-   * violation, which is the rule holding rather than breaking. Ending the whole
+   * A concurrent pass beating this one to the same link trips the one-open-
+   * link index, which is the rule holding rather than breaking. Ending the whole
    * pass there would leave everybody after this person unmatched until the next
    * night.
    */
@@ -263,11 +263,11 @@ export class IdentityMatchService {
     // `findMatchable` already excludes erased people, so this asks the same
     // question again at the last possible moment rather than a new one.
     //
-    // It matters more here than anywhere else in the pass: the exclusion
-    // constraint catches a re-link only for somebody who already had a link,
-    // because the erasure leaves that row open and overlapping. A person who
-    // never had one — most of them — has nothing in the database that would
-    // refuse the row, so this read is the only thing standing between an
+    // It matters more here than anywhere else in the pass: the one-open-link
+    // index catches a re-link only for somebody who already had a link,
+    // because the erasure leaves that row open and holding the slot. A person
+    // who never had one — most of them — has nothing in the database that
+    // would refuse the row, so this read is the only thing standing between an
     // erasure and a fresh link naming the account it just removed.
     const person = await this.discoveredPeople.findById(this.prisma, {
       id: discoveredPersonId,
@@ -295,7 +295,7 @@ export class IdentityMatchService {
       });
       return 1;
     } catch (error) {
-      if (!isExclusionViolation(error)) throw error;
+      if (!isOpenLinkViolation(error)) throw error;
       logger.info(
         { organizationId, discoveredPersonId },
         "A concurrent pass had already opened this link; leaving it as it is",
@@ -380,9 +380,9 @@ export class IdentityMatchService {
       });
     } catch (error) {
       // Two reviewers confirming at once: the read above passed for both and
-      // the exclusion constraint refused the second. Same sentence either way —
-      // the check and the constraint hold one rule between them.
-      if (isExclusionViolation(error)) {
+      // the one-open-link index refused the second. Same sentence either way —
+      // the check and the index hold one rule between them.
+      if (isOpenLinkViolation(error)) {
         throw new IdentityAlreadyLinkedError(suggestion.discoveredPersonId);
       }
       throw error;

--- a/platform/app/prisma/migrations/20260902120000_governance_identity_and_erasure/migration.sql
+++ b/platform/app/prisma/migrations/20260902120000_governance_identity_and_erasure/migration.sql
@@ -11,30 +11,12 @@
 -- that key would miss an erased person's data entirely.
 -- "GovernanceTenantHistory" is the durable translation instead.
 --
--- FIRST EXTENSION IN THIS REPO. None of the 297 migrations before this one ran
--- a CREATE EXTENSION. "IdentityMatch" needs btree_gist to hold "no two links
--- for one person may overlap in time" as a database guarantee rather than an
--- application convention. The guard below fails the whole migration with an
--- actionable message when the extension is unavailable, rather than
--- half-applying and leaving the constraint off - a missing overlap guard is
--- invisible until two links match one spend date and the read picks one.
--- Self-host documentation and the Helm chart state the requirement.
--- Availability must be confirmed per managed-Postgres provider; Azure Database
--- for PostgreSQL in particular is unverified.
-
--- +-------------------------------------------------------------------------+
--- | btree_gist availability guard                                            |
--- +-------------------------------------------------------------------------+
-DO $$
-BEGIN
-  IF NOT EXISTS (SELECT 1 FROM pg_available_extensions WHERE name = 'btree_gist') THEN
-    RAISE EXCEPTION
-      'btree_gist is not available on this PostgreSQL server, so the governance identity tables cannot be created. It ships with the standard contrib package. Install the server''s contrib/extension package (postgresql-contrib on Debian/Ubuntu, postgresqlNN-contrib on RHEL), or enable btree_gist in your managed provider''s allowed-extensions list, then re-run the migration.';
-  END IF;
-END
-$$;
-
-CREATE EXTENSION IF NOT EXISTS btree_gist;
+-- NO EXTENSIONS. An earlier draft held "no two links for one person may
+-- overlap in time" with a btree_gist exclusion constraint - the first
+-- CREATE EXTENSION in this repo, and a new requirement on every self-hosted
+-- and managed Postgres. Nothing here ever writes "validTo", so the only
+-- overlap that can occur is a second OPEN link, and a plain partial unique
+-- index holds that rule with no extension at all (ADR-128 §7).
 
 -- +-------------------------------------------------------------------------+
 -- | DiscoveredPerson - the unit of erasure                                   |
@@ -118,25 +100,24 @@ CREATE INDEX "IdentityMatch_organizationId_discoveredPersonId_idx" ON "IdentityM
 -- Offboarding and the erasure walk both ask "which links does this user hold".
 CREATE INDEX "IdentityMatch_organizationId_userId_idx" ON "IdentityMatch"("organizationId", "userId");
 
--- A zero-width range (validFrom = validTo) is EMPTY, and an empty range
--- overlaps nothing - not even itself - so it slips past the exclusion
--- constraint below entirely and files a link against no time at all. An
--- inverted range raises a raw type error (SQLSTATE 22000) that no layer maps.
--- One named CHECK rejects both, in the database.
+-- A zero-width "link" (validFrom = validTo) has "validTo" set, so the
+-- one-open-link index below cannot see it: it would file a person against no
+-- time at all and read as if the link had never been made. An inverted range
+-- raises a raw type error (SQLSTATE 22000) that no layer maps. One named
+-- CHECK rejects both, in the database.
 ALTER TABLE "IdentityMatch" ADD CONSTRAINT "IdentityMatch_valid_range_check"
     CHECK ("validTo" IS NULL OR "validTo" > "validFrom");
 
--- At most one link per discovered person may cover any given instant. Two OPEN
--- rows both range to infinity, so this rejects the second with SQLSTATE 23P01;
--- a closed row overlapping an open one is rejected the same way. NO partial
--- unique index is added on top: it would be strictly redundant, and would make
--- the common race surface as 23505 instead - two error codes for one rule, and
--- the application would have to handle both to say one sentence.
-ALTER TABLE "IdentityMatch" ADD CONSTRAINT "IdentityMatch_no_overlap"
-    EXCLUDE USING gist (
-        "discoveredPersonId" WITH =,
-        tsrange("validFrom", COALESCE("validTo", 'infinity')) WITH &&
-    );
+-- At most one OPEN link ("validTo" IS NULL) per discovered person; a second
+-- one is rejected with SQLSTATE 23505. This deliberately says nothing about
+-- CLOSED links overlapping in time: nothing in the product writes "validTo"
+-- yet, so no closed row can exist, and the general overlap rule it replaces
+-- (an EXCLUDE USING gist constraint) bought that unreachable guarantee at the
+-- price of a btree_gist extension requirement on every Postgres. Revisit when
+-- closing links ships (ADR-128 §7).
+CREATE UNIQUE INDEX "IdentityMatch_one_open_link_key"
+    ON "IdentityMatch"("discoveredPersonId")
+    WHERE "validTo" IS NULL;
 
 -- +-------------------------------------------------------------------------+
 -- | GovernanceTenantHistory - org to every tenant it ever wrote under         |
@@ -217,5 +198,3 @@ CREATE INDEX "ErasedIdentifierSuppression_organizationId_idx" ON "ErasedIdentifi
 --   DROP TABLE "IdentityMatch";
 --   DROP TABLE "DiscoveredAgent";
 --   DROP TABLE "DiscoveredPerson";
---   -- btree_gist is left installed: other schema objects may come to depend
---   -- on it, and DROP EXTENSION would take them with it.

--- a/platform/app/prisma/schema.prisma
+++ b/platform/app/prisma/schema.prisma
@@ -5133,18 +5133,18 @@ model IdentityMatch {
   validTo            DateTime?
   createdAt          DateTime  @default(now())
 
-  // Overlap guard, and the ONLY uniqueness rule here: no two rows for the same
-  // discoveredPersonId may have overlapping validity ranges. Raw SQL in the
-  // migration, because Prisma cannot express an exclusion constraint:
-  //   EXCLUDE USING gist ("discoveredPersonId" WITH =,
-  //     tsrange("validFrom", COALESCE("validTo", 'infinity')) WITH &&)
-  // Two OPEN rows both range to infinity, so they overlap and the constraint
-  // rejects the second - which is why NO partial unique index is added on top
-  // (ADR-128 §7's ruling, applied here for the same reason: a redundant index
-  // would make the common race surface as 23505 instead of 23P01, two error
-  // codes for one rule). Proved on Postgres 16.14.
-  // A CHECK rejects zero-width and inverted ranges, which an exclusion
-  // constraint cannot see: an empty range overlaps nothing, not even itself.
+  // One-open-link guard, and the ONLY uniqueness rule here: at most one row
+  // per discoveredPersonId may be open (validTo IS NULL). Raw SQL in the
+  // migration, because Prisma cannot express a partial unique index:
+  //   CREATE UNIQUE INDEX "IdentityMatch_one_open_link_key"
+  //     ON "IdentityMatch"("discoveredPersonId") WHERE "validTo" IS NULL
+  // A second open row is rejected with SQLSTATE 23505. Closed rows are outside
+  // the index on purpose: nothing writes validTo yet, so the general overlap
+  // rule this replaces (a btree_gist EXCLUDE constraint) guarded a case that
+  // cannot occur, at the price of an extension requirement on every Postgres
+  // (ADR-128 §7). Revisit when closing links ships.
+  // A CHECK rejects zero-width and inverted ranges, which the partial index
+  // cannot see: a zero-width row has validTo set and so counts as closed.
   @@index([organizationId, discoveredPersonId])
   // Offboarding and the erasure walk both ask "which links does this user hold".
   @@index([organizationId, userId])

--- a/sdks/typescript/src/internal/generated/openapi/api-client.ts
+++ b/sdks/typescript/src/internal/generated/openapi/api-client.ts
@@ -764,14 +764,14 @@ export interface paths {
         };
         /** @description Read one agent with its presence, its owner and the run parameters it declares. An id the project does not hold answers 404 agent_not_found. */
         get: operations["getAgent"];
-        /** @description Update an agent: any of name, type, configuration and workflow. The update is partial under PATCH and PUT alike. A connected agent takes no edit and answers 422 agent_register_only. */
+        /** @description Update an agent: any of name, type, configuration and workflow. The update is partial under PATCH and PUT alike. A connected agent takes only a new description; anything else answers 422 agent_register_only. */
         put: operations["replaceAgent"];
         post?: never;
         /** @description Archive an agent. It leaves the list and its runs stay. A connected agent that registers again restores its row. */
         delete: operations["archiveAgent"];
         options?: never;
         head?: never;
-        /** @description Update an agent: any of name, type, configuration and workflow. The update is partial under PATCH and PUT alike. A connected agent takes no edit and answers 422 agent_register_only. */
+        /** @description Update an agent: any of name, type, configuration and workflow. The update is partial under PATCH and PUT alike. A connected agent takes only a new description; anything else answers 422 agent_register_only. */
         patch: operations["updateAgent"];
         trace?: never;
     };
@@ -1031,29 +1031,9 @@ export interface paths {
         };
         /**
          * Get pull request coding agent usage
-         * @description Assistant usage for one pull request: sessions, tokens and cost, grouped by contributor and agent, plus per-model totals, over the pull request's whole lifetime rather than a time window. Every row and the totals split cost three ways: the part priced per token, the part a bundled subscription already covers, and the list-price total of both. Per-model totals carry the list price only. Cost is calculated from the tokens the agent reported and LangWatch's model prices, so it estimates spend rather than restating a provider invoice. Requires a personal-project API key; rows appear only for projects the calling user may view, and cost only for those they may price. Prefer `GET /api/v1/coding-agent/pull-request-usage`, which answers the same question with an organization API key alone and needs no X-Project-Id header.
+         * @description Assistant usage for one pull request: sessions, tokens and cost, grouped by contributor and agent, plus per-model totals, over the pull request's whole lifetime rather than a time window. Every row and the totals split cost three ways: the part priced per token, the part a bundled subscription already covers, and the list-price total of both. Per-model totals carry the list price only. Cost is calculated from the tokens the agent reported and LangWatch's model prices, so it estimates spend rather than restating a provider invoice. Requires a personal-project API key; rows appear only for projects the calling user may view, and cost only for those they may price.
          */
         get: operations["getApiCodingAgentPullRequestUsage"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/v1/coding-agent/pull-request-usage": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get pull request usage
-         * @description Assistant usage for one pull request: sessions, tokens and cost, grouped by contributor and agent, plus per-model totals, over the pull request's whole lifetime rather than a time window. Every row and the totals split cost three ways: the part priced per token, the part a bundled subscription already covers, and the list-price total of both. Per-model totals carry the list price only. Cost is calculated from the tokens the agent reported and LangWatch's model prices, so it estimates spend rather than restating a provider invoice. Authenticate with an organization API key and nothing else: no project id is sent anywhere. A key created for you reads with your own access; an organization service key, such as one a continuous integration job holds, reads with the access its bindings grant. Rows appear only for projects the key may view, and cost only for those it may price.
-         */
-        get: operations["getPullRequestUsage"];
         put?: never;
         post?: never;
         delete?: never;
@@ -5073,6 +5053,7 @@ export interface operations {
                     agents: {
                         name: string;
                         environment: string;
+                        description?: string;
                         /** @default {} */
                         parameters?: {
                             [key: string]: unknown;
@@ -8302,85 +8283,6 @@ export interface operations {
                     "application/json": {
                         error: string;
                         message?: string;
-                    };
-                };
-            };
-        };
-    };
-    getPullRequestUsage: {
-        parameters: {
-            query: {
-                /** @description The repository as "owner/name". */
-                repository: string;
-                /** @description The pull request number. */
-                pullRequest: number;
-                /** @description The GitHub host. Defaults to this instance's configured GitHub host, which is github.com unless an operator named a GitHub Enterprise Server. */
-                host?: string;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Success */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        pullRequest: {
-                            repositoryHost: string;
-                            repositoryFullName: string;
-                            prNumber: number;
-                            headBranch: string;
-                            htmlUrl: string;
-                            state: string;
-                            isDraft: boolean;
-                            authorLogin: string | null;
-                            prCreatedAtMs: number;
-                            prClosedAtMs: number | null;
-                            prMergedAtMs: number | null;
-                        };
-                        rows: {
-                            projectId: string;
-                            projectSlug: string;
-                            contributorLabel: string;
-                            contributorIsProject: boolean;
-                            agent: string;
-                            models: string[];
-                            sessionsCount: number;
-                            inputTokens: number;
-                            outputTokens: number;
-                            cacheReadTokens: number;
-                            cacheCreationTokens: number;
-                            totalTokens: number;
-                            costUsd: number | null;
-                            billedCostUsd: number | null;
-                            nonBilledCostUsd: number | null;
-                        }[];
-                        totals: {
-                            sessionsCount: number;
-                            inputTokens: number;
-                            outputTokens: number;
-                            cacheReadTokens: number;
-                            cacheCreationTokens: number;
-                            totalTokens: number;
-                            costUsd: number | null;
-                            billedCostUsd: number | null;
-                            nonBilledCostUsd: number | null;
-                        };
-                        modelBreakdown: {
-                            model: string;
-                            inputTokens: number;
-                            outputTokens: number;
-                            cacheReadTokens: number;
-                            cacheCreationTokens: number;
-                            totalTokens: number;
-                            costUsd: number | null;
-                            tokensKnown: boolean;
-                        }[];
                     };
                 };
             };

--- a/sdks/typescript/src/internal/generated/openapi/api-client.ts
+++ b/sdks/typescript/src/internal/generated/openapi/api-client.ts
@@ -764,14 +764,14 @@ export interface paths {
         };
         /** @description Read one agent with its presence, its owner and the run parameters it declares. An id the project does not hold answers 404 agent_not_found. */
         get: operations["getAgent"];
-        /** @description Update an agent: any of name, type, configuration and workflow. The update is partial under PATCH and PUT alike. A connected agent takes only a new description; anything else answers 422 agent_register_only. */
+        /** @description Update an agent: any of name, type, configuration and workflow. The update is partial under PATCH and PUT alike. A connected agent takes no edit and answers 422 agent_register_only. */
         put: operations["replaceAgent"];
         post?: never;
         /** @description Archive an agent. It leaves the list and its runs stay. A connected agent that registers again restores its row. */
         delete: operations["archiveAgent"];
         options?: never;
         head?: never;
-        /** @description Update an agent: any of name, type, configuration and workflow. The update is partial under PATCH and PUT alike. A connected agent takes only a new description; anything else answers 422 agent_register_only. */
+        /** @description Update an agent: any of name, type, configuration and workflow. The update is partial under PATCH and PUT alike. A connected agent takes no edit and answers 422 agent_register_only. */
         patch: operations["updateAgent"];
         trace?: never;
     };
@@ -1031,9 +1031,29 @@ export interface paths {
         };
         /**
          * Get pull request coding agent usage
-         * @description Assistant usage for one pull request: sessions, tokens and cost, grouped by contributor and agent, plus per-model totals, over the pull request's whole lifetime rather than a time window. Every row and the totals split cost three ways: the part priced per token, the part a bundled subscription already covers, and the list-price total of both. Per-model totals carry the list price only. Cost is calculated from the tokens the agent reported and LangWatch's model prices, so it estimates spend rather than restating a provider invoice. Requires a personal-project API key; rows appear only for projects the calling user may view, and cost only for those they may price.
+         * @description Assistant usage for one pull request: sessions, tokens and cost, grouped by contributor and agent, plus per-model totals, over the pull request's whole lifetime rather than a time window. Every row and the totals split cost three ways: the part priced per token, the part a bundled subscription already covers, and the list-price total of both. Per-model totals carry the list price only. Cost is calculated from the tokens the agent reported and LangWatch's model prices, so it estimates spend rather than restating a provider invoice. Requires a personal-project API key; rows appear only for projects the calling user may view, and cost only for those they may price. Prefer `GET /api/v1/coding-agent/pull-request-usage`, which answers the same question with an organization API key alone and needs no X-Project-Id header.
          */
         get: operations["getApiCodingAgentPullRequestUsage"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/coding-agent/pull-request-usage": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get pull request usage
+         * @description Assistant usage for one pull request: sessions, tokens and cost, grouped by contributor and agent, plus per-model totals, over the pull request's whole lifetime rather than a time window. Every row and the totals split cost three ways: the part priced per token, the part a bundled subscription already covers, and the list-price total of both. Per-model totals carry the list price only. Cost is calculated from the tokens the agent reported and LangWatch's model prices, so it estimates spend rather than restating a provider invoice. Authenticate with an organization API key and nothing else: no project id is sent anywhere. A key created for you reads with your own access; an organization service key, such as one a continuous integration job holds, reads with the access its bindings grant. Rows appear only for projects the key may view, and cost only for those it may price.
+         */
+        get: operations["getPullRequestUsage"];
         put?: never;
         post?: never;
         delete?: never;
@@ -5053,7 +5073,6 @@ export interface operations {
                     agents: {
                         name: string;
                         environment: string;
-                        description?: string;
                         /** @default {} */
                         parameters?: {
                             [key: string]: unknown;
@@ -8283,6 +8302,85 @@ export interface operations {
                     "application/json": {
                         error: string;
                         message?: string;
+                    };
+                };
+            };
+        };
+    };
+    getPullRequestUsage: {
+        parameters: {
+            query: {
+                /** @description The repository as "owner/name". */
+                repository: string;
+                /** @description The pull request number. */
+                pullRequest: number;
+                /** @description The GitHub host. Defaults to this instance's configured GitHub host, which is github.com unless an operator named a GitHub Enterprise Server. */
+                host?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Success */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        pullRequest: {
+                            repositoryHost: string;
+                            repositoryFullName: string;
+                            prNumber: number;
+                            headBranch: string;
+                            htmlUrl: string;
+                            state: string;
+                            isDraft: boolean;
+                            authorLogin: string | null;
+                            prCreatedAtMs: number;
+                            prClosedAtMs: number | null;
+                            prMergedAtMs: number | null;
+                        };
+                        rows: {
+                            projectId: string;
+                            projectSlug: string;
+                            contributorLabel: string;
+                            contributorIsProject: boolean;
+                            agent: string;
+                            models: string[];
+                            sessionsCount: number;
+                            inputTokens: number;
+                            outputTokens: number;
+                            cacheReadTokens: number;
+                            cacheCreationTokens: number;
+                            totalTokens: number;
+                            costUsd: number | null;
+                            billedCostUsd: number | null;
+                            nonBilledCostUsd: number | null;
+                        }[];
+                        totals: {
+                            sessionsCount: number;
+                            inputTokens: number;
+                            outputTokens: number;
+                            cacheReadTokens: number;
+                            cacheCreationTokens: number;
+                            totalTokens: number;
+                            costUsd: number | null;
+                            billedCostUsd: number | null;
+                            nonBilledCostUsd: number | null;
+                        };
+                        modelBreakdown: {
+                            model: string;
+                            inputTokens: number;
+                            outputTokens: number;
+                            cacheReadTokens: number;
+                            cacheCreationTokens: number;
+                            totalTokens: number;
+                            costUsd: number | null;
+                            tokensKnown: boolean;
+                        }[];
                     };
                 };
             };

--- a/specs/governance/governance-identity-and-erasure.feature
+++ b/specs/governance/governance-identity-and-erasure.feature
@@ -14,20 +14,20 @@ Feature: Erasing a person from the governance data, and making it stick
   # ── The identity records themselves ───────────────────────────────────────
 
   @integration
-  Scenario: A person can only be linked to one account at a time
+  Scenario: A person can only have one open link at a time
     Given a provider-named person already linked to an account
     When a second link is opened for that same person while the first is open
     Then the second link is refused
-    And the refusal names the overlap rather than a duplicate row
+    And the refusal says the person is already linked
 
   @integration
   Scenario: A link that covers no time at all is refused
     Given a link whose start and end are the same instant
     When it is saved
     Then it is refused
-    # An empty span overlaps nothing — not even itself — so the overlap rule
-    # cannot see it. It would file a person against no time at all and read as
-    # if the link had never been made.
+    # The one-open-link rule only counts links, not time, so it cannot see an
+    # empty span. A separate check refuses any link that covers no time at
+    # all, which would otherwise read as if the link had never been made.
 
   @integration
   Scenario: A link that ends before it starts is refused
@@ -42,6 +42,18 @@ Feature: Erasing a person from the governance data, and making it stick
     Then both links are kept
     # This is what makes a re-issued email address survivable: last year's
     # spend stays with last year's person.
+    # Boundary: the one-open-link rule only counts open links. A closed link
+    # that overlaps another in time is no longer refused by the database.
+    # Nothing in the product closes links yet, so no such row can exist;
+    # revisit when closing links ships.
+
+  @integration
+  Scenario: A second open link is refused even when written straight to the database
+    Given a provider-named person already linked to an account
+    When a second open link is written to the database directly, skipping the application
+    Then the database itself refuses it
+    # The one-open-link rule lives in the database, not in application code, so
+    # a script or a future writer that skips the service cannot break it.
 
   # ── Which tenants an organization's data lives in ─────────────────────────
 

--- a/specs/governance/governance-identity-match-engine.feature
+++ b/specs/governance/governance-identity-match-engine.feature
@@ -211,9 +211,12 @@ Feature: Deciding which provider-named person is which LangWatch account
 
   # The automatic half of the same rule. The pass reads the whole organization
   # once and then writes its way through it, so an erasure that finishes in the
-  # middle leaves a pass holding a list that says the person is still live. The
-  # database will not refuse the row either: erasure blanks the person's links
-  # rather than removing them, so a fresh link overlaps nothing.
+  # middle leaves a pass holding a list that says the person is still live.
+  # The database only half-helps: erasure blanks a person's links rather than
+  # removing them, so someone who HAD a link still holds their one-open-link
+  # slot and a fresh link is refused — but a person who never had a link has
+  # nothing in the database to refuse the row. The re-check below is the only
+  # guard that covers everyone.
 
   @unit
   Scenario: A person erased while a match pass is running is not linked


### PR DESCRIPTION
Drops the `btree_gist` extension from the governance identity migration — the repo's first and only `CREATE EXTENSION` — and replaces the overlap exclusion constraint with a plain partial unique index. Stacked on #7820.

## What changed

- **Migration** (edited in place — never shipped, dev DBs reset): the availability guard, `CREATE EXTENSION btree_gist`, and the `IdentityMatch_no_overlap` EXCLUDE constraint are gone. In their place: `CREATE UNIQUE INDEX "IdentityMatch_one_open_link_key" ON "IdentityMatch"("discoveredPersonId") WHERE "validTo" IS NULL`. The `validTo > validFrom` CHECK stays.
- **Error mapping**: the refusal now arrives as SQLSTATE `23505`, wrapped by Prisma as `P2002`. `isExclusionViolation` (hard-keyed to `23P01`) became `isOpenLinkViolation`, matching both shapes. Both catch sites keep their behaviour: the nightly pass's race loser logs and carries on; the losing reviewer of a concurrent confirm still gets "This person is already linked to an account" (409), not a 500.
- **Spec**: scenario retitled to "one open link at a time"; a new `@integration` scenario pins that the rule lives in the database (raw-SQL bypass write is refused); the narrowing is written down where it happens.
- **Helm chart + self-host docs**: the `btree_gist` prerequisite lines are removed — any plain Postgres works now.
- **ADR-128**: v3.10 revision entry; §7 deployment note, schema sketches, gates and open questions updated.

## Why

Nothing in wave 2 ever writes `validTo` — there is no `close()` anywhere. So the general "no two links overlap in time" rule degenerates to "at most one open link per person", which a partial unique index holds on any Postgres with no extension, no availability guard, and no per-provider verification burden.

## What is deliberately given up

A closed link overlapping an open one is **no longer refused by the database**. That row is unproducible today (nothing writes `validTo`), and the spec + schema comments say so explicitly, with "revisit when closing links ships." One pre-existing test asserting that refusal was flipped to assert the new boundary.

**Heads-up for the seat-coverage work**: `SeatPrice` and `IngestionSourceKeyCoverage` rows really do close, so the ADR keeps their gist-exclusion design. If those tables ship as designed, the extension question re-opens and the Helm/docs requirement lines this PR removes come back in that PR.

## Verification

- Red first: unit fakes and the constraints integration test flipped to the new codes and run red against the old schema (`23P01` observed), then green after the rewrite.
- `governanceIdentityConstraints.integration.test.ts` 11/11, `identityMatchEngine.integration.test.ts` 16/16 against real Postgres migrated from scratch.
- All governance unit tests: 104 files, 1207 passed.
- `check:feature-parity`, `lint`, `typecheck`, `typecheck:tests` all green.
- Governance integration sweep: 389 passed, 7 failed — all 7 are ClickHouse-side (cost rollup restatement + spendOverTime chart), reproduced identically on the base commit under the same local-services test mode, so pre-existing and unrelated.

## Refusal overridden

I initially declined to rewrite the shipped-shape migration in place and proposed a follow-up migration instead, on the grounds that editing an applied migration desyncs any database that already ran it. Overridden by: the requester — the migration has never shipped (this PR stack is unmerged), and the only affected databases are local dev ones, which are reset. Carried over from the heavy path: /challenge (two-refuter gate ran on the spec scenarios; both findings folded in).
