### PR TITLE
fix(governance): coverage holds its rule in plain Postgres

### DIFF
--- a/platform/app/ee/governance/__tests__/governanceCostCoverage.integration.test.ts
+++ b/platform/app/ee/governance/__tests__/governanceCostCoverage.integration.test.ts
@@ -8,7 +8,8 @@
  * would pass this file while leaving the constraint absent, which is the
  * failure this exists to catch.
  *
- * Requires the `btree_gist` extension and the triggers the migration installs.
+ * Requires the triggers and the one-open-bill index the migration installs.
+ * Plain Postgres - deliberately no extension is needed.
  *
  * Spec: specs/governance/governance-cost-coverage.feature
  * Decision: ADR-128 §7
@@ -24,13 +25,22 @@ import {
   GatewayKeyAlreadyCoveredError,
 } from "../services/costCoverage.errors";
 import { CostCoverageService } from "../services/costCoverage.service";
+import { isUniqueViolation } from "../services/logic/postgresConstraintErrors";
 
 const ns = `gov-coverage-${nanoid(8)}`;
 const organizationId = `org_${ns}`;
 const otherOrganizationId = `org_other_${ns}`;
 
-/** Postgres' exclusion-constraint violation. Asserted by code, never by prose. */
-const EXCLUSION_VIOLATION = "23P01";
+/**
+ * How Prisma reports the one-open-bill index refusing a second open row.
+ *
+ * Like the foreign-key case below, Prisma has a mapping of its own for a
+ * unique violation and replaces the raw 23505 entirely, so the Prisma code is
+ * the thing there is to assert on.
+ */
+const PRISMA_UNIQUE_VIOLATION = "P2002";
+/** Postgres' own unique-violation code, seen when a write bypasses Prisma. */
+const UNIQUE_VIOLATION = "23505";
 /** Postgres' check-constraint violation. */
 const CHECK_VIOLATION = "23514";
 /**
@@ -74,7 +84,7 @@ const sqlState = (error: unknown): string | undefined => {
       record.cause ?? (meta as Record<string, unknown> | undefined)?.cause;
   }
   const message = String((error as { message?: string })?.message ?? "");
-  return /\b(23P01|23514|23503)\b/.exec(message)?.[1];
+  return /\b(23505|23514|23503)\b/.exec(message)?.[1];
 };
 
 const makeKey = async (params: { id: string; organizationId: string }) => {
@@ -134,7 +144,11 @@ describe("Feature: every dollar has one home", () => {
         })
         .catch((error: unknown) => error);
 
-      expect(sqlState(refused)).toBe(EXCLUSION_VIOLATION);
+      // Prisma wraps the 23505 as P2002 and keeps the SQLSTATE to itself, so
+      // the second assertion is the application's own predicate — the exact
+      // contract the service's catch site relies on.
+      expect((refused as { code?: string }).code).toBe(PRISMA_UNIQUE_VIOLATION);
+      expect(isUniqueViolation(refused)).toBe(true);
     });
 
     /** @scenario "A bill may cover a key another bill has finished covering" */
@@ -174,6 +188,87 @@ describe("Feature: every dollar has one home", () => {
     });
   });
 
+  describe("when a second open bill is written straight to the database", () => {
+    it("is refused by the database itself, not by application code", async () => {
+      const rawKey = `vk_${ns}_raw`;
+      await makeKey({ id: rawKey, organizationId });
+      await repo.open(prisma, {
+        organizationId,
+        ingestionSourceId: `bill_1_${ns}`,
+        virtualKeyId: rawKey,
+        validFrom: utc("2026-03-01"),
+      });
+
+      let caught: unknown;
+      try {
+        // Raw SQL on purpose: this proves the rule holds for a writer that
+        // skips Prisma and the service layer entirely.
+        await prisma.$executeRawUnsafe(
+          `
+          -- @tenancy: single fixed test row; the rule under test is per-key,
+          -- not per-tenant.
+          INSERT INTO "IngestionSourceKeyCoverage"
+            ("id", "organizationId", "ingestionSourceId", "virtualKeyId", "validFrom", "validTo")
+          VALUES ($1, $2, $3, $4, '2026-04-01T00:00:00Z', NULL)
+          `,
+          `cov_raw_${ns}`,
+          organizationId,
+          `bill_2_${ns}`,
+          rawKey,
+        );
+      } catch (error) {
+        caught = error;
+      }
+
+      expect(sqlState(caught)).toBe(UNIQUE_VIOLATION);
+
+      // And the invariant itself: no key holds two open bills.
+      const doubled = await prisma.$queryRawUnsafe<unknown[]>(`
+        -- @tenancy: invariant sweep across the whole test database; a second
+        -- open bill anywhere is a failure regardless of tenant.
+        SELECT "virtualKeyId", count(*)
+        FROM "IngestionSourceKeyCoverage"
+        WHERE "validTo" IS NULL
+        GROUP BY 1
+        HAVING count(*) > 1
+      `);
+      expect(doubled).toHaveLength(0);
+    });
+  });
+
+  describe("when a closed period overlapping an open one is written", () => {
+    it("is accepted: the rule only counts open bills", async () => {
+      // Boundary made explicit: this is the guarantee traded away with the
+      // gist exclusion constraint. Closed history stays non-overlapping only
+      // because every closed row is written by the service transaction that
+      // holds the open row FOR UPDATE — a writer bypassing the service, like
+      // this one, is not refused. The trade and its reasoning live in the
+      // migration's header comment.
+      const tradedKey = `vk_${ns}_traded`;
+      await makeKey({ id: tradedKey, organizationId });
+      await repo.open(prisma, {
+        organizationId,
+        ingestionSourceId: `bill_1_${ns}`,
+        virtualKeyId: tradedKey,
+        validFrom: utc("2026-01-01"),
+      });
+
+      await prisma.ingestionSourceKeyCoverage.create({
+        data: {
+          id: `cov_traded_${ns}`,
+          organizationId,
+          ingestionSourceId: `bill_2_${ns}`,
+          virtualKeyId: tradedKey,
+          validFrom: utc("2025-12-01"),
+          validTo: utc("2026-02-01"),
+        },
+      });
+
+      const rows = await repo.findAllByOrganization(prisma, { organizationId });
+      expect(rows.map((row) => row.id)).toContain(`cov_traded_${ns}`);
+    });
+  });
+
   describe("when coverage describes no time at all", () => {
     /** @scenario "Coverage that starts and ends at the same moment is refused" */
     it("refuses a period that ends the instant it begins", async () => {
@@ -192,8 +287,9 @@ describe("Feature: every dollar has one home", () => {
         })
         .catch((error: unknown) => error);
 
-      // An empty range overlaps nothing, not even itself, so the exclusion
-      // constraint never sees it — the CHECK is the only thing that does.
+      // A zero-width period is closed the instant it begins, so the
+      // one-open-bill index never sees it — the CHECK is the only thing that
+      // does.
       expect(sqlState(refused)).toBe(CHECK_VIOLATION);
     });
 
@@ -360,7 +456,7 @@ describe("Feature: every dollar has one home", () => {
       });
 
       // The service's own read would find the open row and close it, so the
-      // constraint is reached by a writer that never saw it — which is what a
+      // index is reached by a writer that never saw it — which is what a
       // racing second administrator is.
       const refused = await repo
         .open(prisma, {
@@ -371,7 +467,8 @@ describe("Feature: every dollar has one home", () => {
         })
         .catch((error: unknown) => error);
 
-      expect(sqlState(refused)).toBe(EXCLUSION_VIOLATION);
+      expect((refused as { code?: string }).code).toBe(PRISMA_UNIQUE_VIOLATION);
+      expect(isUniqueViolation(refused)).toBe(true);
     });
 
     /**
@@ -443,9 +540,8 @@ describe("Feature: every dollar has one home", () => {
       // Here the winner moved the key to a period beginning at the very instant
       // this transaction is moving it from. The stale read is of the row as it
       // was BEFORE that, so the service's own "after the current start" check
-      // passes; the close it then makes leaves a period covering no time, and an
-      // empty range overlaps nothing, so the CHECK is the only thing that sees
-      // it.
+      // passes; the close it then makes leaves a period covering no time, and
+      // the CHECK is the only thing that sees it.
       const readsStale = Object.create(
         repo,
       ) as IngestionSourceKeyCoverageRepository;

--- a/platform/app/ee/governance/__tests__/governanceIdentityConstraints.integration.test.ts
+++ b/platform/app/ee/governance/__tests__/governanceIdentityConstraints.integration.test.ts
@@ -22,7 +22,7 @@ import {
   resolveGovOrganizationId,
   resolveGovTenantIds,
 } from "../services/governanceTenantHistory.service";
-import { isOpenLinkViolation } from "../services/logic/postgresConstraintErrors";
+import { isUniqueViolation } from "../services/logic/postgresConstraintErrors";
 
 const ns = `gov-identity-${nanoid(8)}`;
 const organizationId = `org_${ns}`;
@@ -144,7 +144,7 @@ describe("Feature: the identity tables hold their own rules", () => {
         // SQLSTATE to itself, so the assertion is the application's own
         // predicate — the exact contract the service's catch sites rely on.
         expect((caught as { code?: string }).code).toBe("P2002");
-        expect(isOpenLinkViolation(caught)).toBe(true);
+        expect(isUniqueViolation(caught)).toBe(true);
       });
     });
 

--- a/platform/app/ee/governance/repositories/ingestionSourceKeyCoverage.repository.ts
+++ b/platform/app/ee/governance/repositories/ingestionSourceKeyCoverage.repository.ts
@@ -67,9 +67,9 @@ export class IngestionSourceKeyCoverageRepository {
    * lets a second administrator interleave between the two writes — closing the
    * open row and opening a successor an hour later, leaving an hour of that
    * key's spend covered by no bill, with nothing raised and nothing to find it
-   * afterwards. The exclusion constraint cannot see that gap; it can only see
-   * an overlap. Holding the row for the length of the transaction is what makes
-   * the gap unrepresentable.
+   * afterwards. No database rule sees that gap — the one-open-bill index only
+   * counts open rows. Holding the row for the length of the transaction is
+   * what makes the gap unrepresentable.
    *
    * Must be called inside a transaction. Outside one the lock is released the
    * instant the statement returns, which is a lock that proves nothing.

--- a/platform/app/ee/governance/services/__tests__/costCoverage.service.unit.test.ts
+++ b/platform/app/ee/governance/services/__tests__/costCoverage.service.unit.test.ts
@@ -117,6 +117,33 @@ describe("Feature: a bill takes over a key on a date", () => {
     });
   });
 
+  describe("when two administrators claim an uncovered key at once", () => {
+    // Both find no open row to lock, so the one-open-bill unique index is the
+    // only thing that sees them collide. Prisma reports it as P2002 with the
+    // SQLSTATE underneath; the loser must be told in words, not a trace id.
+    it("tells the loser another bill already covers the key", async () => {
+      const { service, repo } = serviceWith(null);
+      (repo.open as ReturnType<typeof vi.fn>).mockRejectedValue(
+        Object.assign(new Error("Unique constraint failed"), {
+          code: "P2002",
+          meta: { code: "23505" },
+        }),
+      );
+
+      await expect(
+        service.pointKeyAtSource({
+          organizationId,
+          virtualKeyId,
+          ingestionSourceId: "bill_2",
+          effectiveFrom: new Date("2026-06-01T00:00:00.000Z"),
+        }),
+      ).rejects.toMatchObject({
+        code: "ingestion_source_key_already_covered",
+        meta: { virtualKeyId },
+      });
+    });
+  });
+
   describe("when no bill covers the key yet", () => {
     it("opens coverage without closing anything", async () => {
       const { service, repo } = serviceWith(null);

--- a/platform/app/ee/governance/services/costCoverage.errors.ts
+++ b/platform/app/ee/governance/services/costCoverage.errors.ts
@@ -15,13 +15,13 @@
 import { HandledError } from "@langwatch/handled-error";
 
 /**
- * Another bill already covers this key over the period being claimed.
+ * Another bill already covers this key.
  *
- * Raised from SQLSTATE 23P01, which is where the rule actually lives — the
- * exclusion constraint on `IngestionSourceKeyCoverage`. There is deliberately
- * no read-then-write check in front of it that could report this sooner: two
- * administrators saving in the same instant both pass such a read, and only the
- * database sees the collision.
+ * Raised from the one-open-bill unique index on `IngestionSourceKeyCoverage`
+ * (SQLSTATE 23505, wrapped by Prisma as `P2002`), which is where the rule
+ * actually lives. There is deliberately no read-then-write check in front of
+ * it that could report this sooner: two administrators saving in the same
+ * instant both pass such a read, and only the database sees the collision.
  */
 export class GatewayKeyAlreadyCoveredError extends HandledError {
   declare readonly code: "ingestion_source_key_already_covered";
@@ -70,8 +70,8 @@ export class CoverageStartNotMidnightError extends HandledError {
  * began.
  *
  * Closing the current row at that instant would leave a range covering no time
- * at all, which an exclusion constraint cannot see — so this is refused before
- * the write, and by the `CHECK` behind it if a race gets past.
+ * at all — refused before the write, and by the `CHECK` behind it if a race
+ * gets past.
  */
 export class CoverageStartNotAfterCurrentError extends HandledError {
   declare readonly code: "ingestion_source_coverage_not_after_start";

--- a/platform/app/ee/governance/services/costCoverage.service.ts
+++ b/platform/app/ee/governance/services/costCoverage.service.ts
@@ -4,13 +4,15 @@
  * Which gateway keys a connected provider bill pays for, and moving one key
  * from one bill to another without leaving a moment uncovered (ADR-128 §7).
  *
- * The database holds the rule that a key belongs to one bill at a time. What it
- * cannot hold is CONTINUITY: a non-overlap constraint structurally cannot see a
- * gap. Two administrators editing through independent updates could close a
- * key's coverage and open its successor an hour later, leaving an hour of that
+ * The database holds the rule that a key has at most one OPEN bill at a time.
+ * What it cannot hold is CONTINUITY: no uniqueness rule can see a gap. Two
+ * administrators editing through independent updates could close a key's
+ * coverage and open its successor an hour later, leaving an hour of that
  * key's spend covered by no bill, with nothing raised and nothing to find it
  * afterwards. So re-pointing is never two writes — it is one transaction that
  * locks the open row, closes it and opens the successor at the same instant.
+ * That same shape is what keeps CLOSED history non-overlapping: a closed row
+ * is only ever written by closing the open row, never inserted directly.
  * Continuity is the transaction's job; the constraints cover only the errors a
  * correct transaction can still make.
  *
@@ -30,7 +32,7 @@ import {
 import { coverageOnDay, isUtcMidnight } from "./logic/costCoverage";
 import {
   isCheckViolation,
-  isExclusionViolation,
+  isUniqueViolation,
 } from "./logic/postgresConstraintErrors";
 
 export class CostCoverageService {
@@ -169,10 +171,8 @@ export class CostCoverageService {
   /**
    * Refuses a change that would close the open period at or before it began.
    *
-   * At the same instant the period covers no time at all, which an exclusion
-   * constraint cannot see — an empty range overlaps nothing, not even itself —
-   * so this is checked before the write and the `CHECK` behind it catches a
-   * race.
+   * At the same instant the period covers no time at all — checked here before
+   * the write, and by the `CHECK` behind it if a race gets past.
    */
   private assertAfter(params: {
     open: CoveragePeriod;
@@ -193,10 +193,10 @@ export class CostCoverageService {
    * neither is caught by the checks above: those run against the state this
    * transaction read, and a racing writer moves it afterwards.
    *
-   * The exclusion violation is the ordinary one. The `FOR UPDATE` serialises
+   * The unique violation is the ordinary one. The `FOR UPDATE` serialises
    * re-points of the SAME key, but two administrators claiming a so-far
    * uncovered key from two different bills each find no open row to lock, so
-   * the constraint is the only thing that sees them collide.
+   * the one-open-bill index is the only thing that sees them collide.
    *
    * The check violation is narrower: the winner of such a race opened its
    * period at the very instant this one is closing at, so the close leaves a
@@ -211,7 +211,7 @@ export class CostCoverageService {
     try {
       return await write();
     } catch (error) {
-      if (isExclusionViolation(error)) {
+      if (isUniqueViolation(error)) {
         throw new GatewayKeyAlreadyCoveredError(context.virtualKeyId);
       }
       if (isCheckViolation(error)) {

--- a/platform/app/ee/governance/services/identityMatch.service.ts
+++ b/platform/app/ee/governance/services/identityMatch.service.ts
@@ -44,7 +44,7 @@ import {
   normalizeEmail,
   type OrganizationAccountIndex,
 } from "./logic/identityEvidence";
-import { isOpenLinkViolation } from "./logic/postgresConstraintErrors";
+import { isUniqueViolation } from "./logic/postgresConstraintErrors";
 
 const logger = createLogger("langwatch:governance:identity-match");
 
@@ -295,7 +295,7 @@ export class IdentityMatchService {
       });
       return 1;
     } catch (error) {
-      if (!isOpenLinkViolation(error)) throw error;
+      if (!isUniqueViolation(error)) throw error;
       logger.info(
         { organizationId, discoveredPersonId },
         "A concurrent pass had already opened this link; leaving it as it is",
@@ -382,7 +382,7 @@ export class IdentityMatchService {
       // Two reviewers confirming at once: the read above passed for both and
       // the one-open-link index refused the second. Same sentence either way —
       // the check and the index hold one rule between them.
-      if (isOpenLinkViolation(error)) {
+      if (isUniqueViolation(error)) {
         throw new IdentityAlreadyLinkedError(suggestion.discoveredPersonId);
       }
       throw error;

--- a/platform/app/ee/governance/services/logic/postgresConstraintErrors.ts
+++ b/platform/app/ee/governance/services/logic/postgresConstraintErrors.ts
@@ -11,20 +11,18 @@
  * their rules as database constraints, so both need to read the code back.
  */
 
-/** Postgres' unique-violation code, raised by the one-open-link index. */
+/** Postgres' unique-violation code, raised by the one-open-row indexes. */
 const UNIQUE_VIOLATION = "23505";
 
 /**
  * Prisma's own code for the same refusal: the client wraps a unique violation
  * as a `PrismaClientKnownRequestError` with `code: "P2002"` and buries the
- * SQLSTATE underneath. `IdentityMatch` has no other unique rule a write could
- * trip (the primary key is a fresh nanoid), so `P2002` on these writes means
- * the one-open-link index and nothing else.
+ * SQLSTATE underneath. Neither `IdentityMatch` nor
+ * `IngestionSourceKeyCoverage` has another unique rule a write could trip
+ * (their primary keys are fresh nanoids), so `P2002` on these writes means
+ * that table's one-open-row index and nothing else.
  */
 const PRISMA_UNIQUE_VIOLATION = "P2002";
-
-/** Postgres' exclusion-violation code: two rows overlap where none may. */
-const EXCLUSION_VIOLATION = "23P01";
 
 /** Postgres' check-violation code: a row a named CHECK refuses. */
 const CHECK_VIOLATION = "23514";
@@ -51,22 +49,18 @@ function hasSqlState(error: unknown, sqlState: string): boolean {
 }
 
 /**
- * Whether a thrown value is the one-open-link index refusing a second open
- * link.
+ * Whether a thrown value is a unique index refusing a duplicate.
  *
  * Prisma's `P2002` wrapper is checked alongside the raw SQLSTATE because the
- * client catches this one itself before the driver's code can surface.
+ * client catches this one itself before the driver's code can surface. Each
+ * caller's table holds exactly one unique rule a write can trip, which is what
+ * lets a callsite read this as its own index and nothing else.
  */
-export function isOpenLinkViolation(error: unknown): boolean {
+export function isUniqueViolation(error: unknown): boolean {
   if (typeof error !== "object" || error === null) return false;
   if ((error as { code?: unknown }).code === PRISMA_UNIQUE_VIOLATION)
     return true;
   return hasSqlState(error, UNIQUE_VIOLATION);
-}
-
-/** Whether a thrown value is an exclusion constraint refusing an overlap. */
-export function isExclusionViolation(error: unknown): boolean {
-  return hasSqlState(error, EXCLUSION_VIOLATION);
 }
 
 /**

--- a/platform/app/prisma/migrations/20260904120000_ingestion_source_key_coverage/migration.sql
+++ b/platform/app/prisma/migrations/20260904120000_ingestion_source_key_coverage/migration.sql
@@ -13,28 +13,17 @@
 -- drawn - history edited by a present-tense edit.
 --
 -- A SEPARATE TABLE, because that is what lets the database hold the rule. The
--- exclusion constraint below refuses a second bill claiming an already-covered
+-- one-open-bill index below refuses a second bill claiming an already-covered
 -- key, rather than letting the last administrator to hit Save win.
 --
--- Uses btree_gist, installed by 20260902120000_governance_identity_and_erasure.
--- The availability guard is repeated rather than assumed: this migration must
--- fail with an actionable message on a server where the extension is missing,
--- not half-apply and leave the overlap rule off. A missing overlap guard is
--- invisible until two bills claim one key and the read picks one.
-
--- +-------------------------------------------------------------------------+
--- | btree_gist availability guard                                            |
--- +-------------------------------------------------------------------------+
-DO $$
-BEGIN
-  IF NOT EXISTS (SELECT 1 FROM pg_available_extensions WHERE name = 'btree_gist') THEN
-    RAISE EXCEPTION
-      'btree_gist is not available on this PostgreSQL server, so the gateway-key coverage table cannot be created. It ships with the standard contrib package. Install the server''s contrib/extension package (postgresql-contrib on Debian/Ubuntu, postgresqlNN-contrib on RHEL), or enable btree_gist in your managed provider''s allowed-extensions list, then re-run the migration.';
-  END IF;
-END
-$$;
-
-CREATE EXTENSION IF NOT EXISTS btree_gist;
+-- PLAIN POSTGRES ONLY, deliberately. An exclusion constraint over the validity
+-- range would also refuse an overlap against closed history, but it needs the
+-- btree_gist extension - a contrib package a self-hosted server or a managed
+-- provider's allow-list may not have. The identity tables made the same trade
+-- (see 20260902120000_governance_identity_and_erasure): a partial unique index
+-- on the open row catches the race that actually happens, and closed history is
+-- kept non-overlapping by the service, which only ever writes a closed row by
+-- closing the open one inside a transaction that holds it FOR UPDATE.
 
 -- +-------------------------------------------------------------------------+
 -- | IngestionSourceKeyCoverage - the key-to-bill mapping                     |
@@ -63,25 +52,24 @@ CREATE INDEX "IngestionSourceKeyCoverage_organizationId_sourceId_idx" ON "Ingest
 -- Resolving which bill covered a key on the day being drawn.
 CREATE INDEX "IngestionSourceKeyCoverage_organizationId_key_validFrom_idx" ON "IngestionSourceKeyCoverage"("organizationId", "virtualKeyId", "validFrom");
 
--- A zero-width range (validFrom = validTo) is EMPTY, and an empty range
--- overlaps nothing - not even itself - so it slips past the exclusion
--- constraint below entirely and files a bill against no time at all. An
--- inverted range raises a raw type error (SQLSTATE 22000) that no layer maps.
--- One named CHECK rejects both, in the database.
+-- A zero-width range (validFrom = validTo) is closed the instant it begins, so
+-- the one-open-bill index below never sees it - and it would still be read
+-- back as history, filing a bill against no time at all. An inverted range is
+-- the same mistake with a sign error. One named CHECK rejects both, in the
+-- database.
 ALTER TABLE "IngestionSourceKeyCoverage" ADD CONSTRAINT "IngestionSourceKeyCoverage_valid_range_check"
     CHECK ("validTo" IS NULL OR "validTo" > "validFrom");
 
--- At most one bill may cover a key at any given instant. Two OPEN rows both
--- range to infinity, so this rejects the second with SQLSTATE 23P01; a closed
--- row overlapping an open one is rejected the same way. NO partial unique index
--- is added on top: it would be strictly redundant, and would make the common
--- race surface as 23505 instead - two error codes for one rule, and the
--- application would have to handle both to say one sentence.
-ALTER TABLE "IngestionSourceKeyCoverage" ADD CONSTRAINT "IngestionSourceKeyCoverage_no_overlap"
-    EXCLUDE USING gist (
-        "virtualKeyId" WITH =,
-        tsrange("validFrom", COALESCE("validTo", 'infinity')) WITH &&
-    );
+-- At most one OPEN bill per key. The race this exists for: two administrators
+-- claim a so-far uncovered key at once, each finds no open row to lock, and
+-- this index is the only thing that sees them collide - SQLSTATE 23505,
+-- surfaced by Prisma as P2002. It deliberately says nothing about CLOSED
+-- history: rows are only ever closed, never inserted closed, by a service
+-- transaction that holds the open row FOR UPDATE (see the header above for why
+-- that trade is taken over an exclusion constraint).
+CREATE UNIQUE INDEX "IngestionSourceKeyCoverage_one_open_bill_key"
+    ON "IngestionSourceKeyCoverage"("virtualKeyId")
+    WHERE "validTo" IS NULL;
 
 -- +-------------------------------------------------------------------------+
 -- | The row's organization must be its key's organization                    |
@@ -153,4 +141,3 @@ CREATE TRIGGER "VirtualKey_drop_coverage_on_delete"
 --   DROP TRIGGER "IngestionSourceKeyCoverage_key_org_check" ON "IngestionSourceKeyCoverage";
 --   DROP FUNCTION "ingestion_source_key_coverage_key_org_check"();
 --   DROP TABLE "IngestionSourceKeyCoverage";
---   -- btree_gist is left installed: the identity tables depend on it.

--- a/platform/app/prisma/schema.prisma
+++ b/platform/app/prisma/schema.prisma
@@ -5248,12 +5248,12 @@ model IdentityMatchSuggestion {
 /// chart was drawn.
 ///
 /// A separate table rather than a list column on `IngestionSource`, because
-/// that is what lets the DATABASE hold "every dollar has one home" - an
-/// exclusion constraint refuses a second bill claiming an already-covered key
+/// that is what lets the DATABASE hold "every dollar has one home" - a partial
+/// unique index refuses a second OPEN bill claiming an already-covered key
 /// instead of letting the last administrator to hit Save win.
 ///
 /// None of its rules are expressible here, so all of them live in the
-/// migration: an exclusion constraint over the validity range, a CHECK that the
+/// migration: a one-open-bill partial unique index, a CHECK that the validity
 /// range is non-empty, and a trigger tying the row to its key's own
 /// organization (`relationMode = "prisma"` means there are no real foreign keys
 /// to do it).


### PR DESCRIPTION
## Why

Part of #7746 (ADR-128 wave 2). The key-to-bill coverage table was the last place in the repo that needed the `btree_gist` Postgres extension: its overlap rule was held by an `EXCLUDE USING gist` constraint, with an availability guard that failed the migration on any server without the contrib package. The identity tables already walked away from that trade earlier in this wave; self-hosted installs and managed databases should never need an extra add-on for LangWatch to migrate. After this PR, zero `btree_gist` anywhere.

## What changed

- The migration no longer installs or guards `btree_gist`. The exclusion constraint is replaced by a partial unique index, `IngestionSourceKeyCoverage_one_open_bill_key`: at most one OPEN bill per gateway key — the same shape as identity's `IdentityMatch_one_open_link_key`.
- The service's error mapping moves from SQLSTATE 23P01 to the unique violation (23505, Prisma `P2002`). The recogniser generalises: `isOpenLinkViolation` becomes `isUniqueViolation`, shared by identity and coverage, and the 23P01 reader is deleted with the constraint.
- Comments across the migration, schema, service, repository and errors module now tell the one-open-bill story; the two stale claims that the identity migration installs `btree_gist` die with it.

## How it works

The exclusion constraint guarded two things. The common race — two administrators claiming a so-far uncovered key at once, where each finds no open row to lock — is fully caught by the new index, and that is the only refusal the product can actually produce. The rare guarantee — a closed row overlapping other history — is traded away at the database level: closed rows are only ever written by the service transaction that holds the open row `FOR UPDATE`, never inserted closed, so history stays non-overlapping by construction. The trade and its reasoning are written into the migration's header comment, and the boundary now has an explicit test.

## Test plan

- Red-then-green unit test: a `P2002`-shaped refusal from the repository maps to `GatewayKeyAlreadyCoveredError` (failed before the service change, passes after).
- Full coverage integration suite against real Postgres on a database created from scratch with the rewritten migration — `pg_extension` shows nothing beyond `plpgsql`. Two new tests mirror the identity suite: a raw-SQL writer bypassing Prisma and the service is refused with 23505 plus an invariant sweep, and a closed period overlapping an open one is accepted (the traded boundary, made explicit so a reversal of the trade fails a named test).
- Identity constraint integration suite (shares the recogniser): green.
- Governance unit suites (108 files, 1234 tests) and `typecheck:all`: green.

## Anything surprising?

- This PR edits a migration that #7823 introduced, so it stacks on #7823 and must merge after it. Any dev database that already applied the old version of `20260904120000_ingestion_source_key_coverage` keeps the gist constraint and will report a checksum mismatch — reset or re-create dev databases after this merges.
- Deliberately NOT database-enforced anymore: an overlap written against closed history by something that bypasses the service. No such writer exists (the repository is the only one), and the boundary test documents the behaviour.
- A known, inherited limitation stays as-is: `isUniqueViolation` treats any `P2002` on these writes as the one-open-row rule rather than matching the index name. Both tables have exactly one unique rule a write can trip (primary keys are fresh nanoids), which is the argument the identity code already relies on.
- One related stale comment could not ride along: ClickHouse migration `00091` still says "00087" in a comment, but that file lives on the retention-TTL branch (#7822), so the fix belongs there.

