### PR TITLE
feat(governance): discovered people get a producer, a directory feed, and a screen

### DIFF
--- a/platform/app/ee/event-sourcing/pipelineSet.ts
+++ b/platform/app/ee/event-sourcing/pipelineSet.ts
@@ -5,6 +5,7 @@ import type { PulledUsageLedgerProcessDeps } from "@ee/governance/process-manage
 import type { GovernanceCostRollupState } from "@ee/governance/projections/governanceCostRollup.foldProjection";
 import { reconcileIngestionPullProcesses } from "@ee/governance/services/pullers/ingestionPullLifecycle";
 import {
+  type DiscoveredPeopleMatcher,
   type PulledUsageDispatcher,
   runIngestionPull,
 } from "@ee/governance/services/pullers/pullerWorker";
@@ -31,6 +32,15 @@ export interface EnterprisePipelineSetConfig {
    * pipeline still records every observation, only the summary is skipped.
    */
   governanceCostRollupStore?: FoldProjectionStore<GovernanceCostRollupState>;
+  /**
+   * ADR-128 §12's identity-match engine, composed by the root on the worker
+   * role only. A type, never an import: this module is statically reachable
+   * from request routers, and the scorer behind the engine is gated off every
+   * request path by the engine's import-graph guard. Absent on request-serving
+   * roles — discovery still records people, the review queue just waits for a
+   * process that composes the engine.
+   */
+  identityMatch?: DiscoveredPeopleMatcher;
 }
 
 type EnterprisePipelineRuntimeDeps = EnterprisePipelineSetConfig & {
@@ -54,7 +64,11 @@ function registerIngestionPullPipeline(
       dispatch: {
         runPort: {
           run: (params) =>
-            runIngestionPull({ ...params, pulledUsage: deps.pulledUsage }),
+            runIngestionPull({
+              ...params,
+              pulledUsage: deps.pulledUsage,
+              identityMatch: deps.identityMatch,
+            }),
         },
         commands: () => {
           if (!outcomeCommands) {

--- a/platform/app/ee/governance/repositories/governanceIdentity.repository.ts
+++ b/platform/app/ee/governance/repositories/governanceIdentity.repository.ts
@@ -15,6 +15,8 @@
  */
 import type { Prisma, PrismaClient } from "~/generated/prisma/client";
 
+import { isUniqueViolation } from "../services/identityMatch.errors";
+
 type Client = Prisma.TransactionClient | PrismaClient;
 
 /** Every `TenantId` an organization has ever written governance rows under. */
@@ -176,6 +178,130 @@ export class DiscoveredPersonRepository {
     });
   }
 
+  /** The identity screen's read: an organization's people, newest-seen first. */
+  listByOrganization(client: Client, params: { organizationId: string }) {
+    return client.discoveredPerson.findMany({
+      where: { organizationId: params.organizationId },
+      orderBy: { lastSeenAt: "desc" },
+    });
+  }
+
+  /**
+   * Records that a provider row named this identity at `seenAt` — creating the
+   * person on first sight, and only ever widening the seen range after that.
+   *
+   * Widening, not stamping: a September run backfilling July must move
+   * `firstSeenAt` back without dragging `lastSeenAt` forward, and the
+   * conditional WHEREs are what make replaying a window a no-op rather than a
+   * rewrite. Nothing else on an existing row is touched — display text belongs
+   * to the first sighting (or the directory), and `kind` to the rule that
+   * classified it.
+   *
+   * An erased person cannot be resurrected through here by accident — their
+   * plaintext identifier no longer matches any row's `rawActorId` — but the
+   * caller must still never offer one: that is the suppression list's job,
+   * upstream, on the whole event.
+   */
+  async recordActivitySighting(
+    client: Client,
+    params: {
+      organizationId: string;
+      provider: string;
+      rawActorId: string;
+      displayText: string;
+      kind: string;
+      /** The batch's earliest and latest event times for this actor. */
+      earliestAt: Date;
+      latestAt: Date;
+    },
+  ): Promise<void> {
+    const key = {
+      organizationId: params.organizationId,
+      provider: params.provider,
+      rawActorId: params.rawActorId,
+    };
+    try {
+      await client.discoveredPerson.create({
+        data: {
+          ...key,
+          displayText: params.displayText,
+          kind: params.kind,
+          firstSeenAt: params.earliestAt,
+          lastSeenAt: params.latestAt,
+        },
+      });
+      return;
+    } catch (error) {
+      // The row already exists — from an earlier run, or from a concurrent
+      // source racing this one to the same actor. Both fall through to the
+      // widen below.
+      if (!isUniqueViolation(error)) throw error;
+    }
+    await client.discoveredPerson.updateMany({
+      where: { ...key, lastSeenAt: { lt: params.latestAt } },
+      data: { lastSeenAt: params.latestAt },
+    });
+    await client.discoveredPerson.updateMany({
+      where: { ...key, firstSeenAt: { gt: params.earliestAt } },
+      data: { firstSeenAt: params.earliestAt },
+    });
+  }
+
+  /**
+   * Records that the directory listed this identity — creating the person on
+   * first sight, and upgrading the display text of one already known.
+   *
+   * Deliberately narrower than an activity sighting: a directory lists
+   * presence, not activity, so it never widens the seen range — a person
+   * refreshed daily by the directory must not read as "active today" on a
+   * screen whose seen dates otherwise mean spend. The display text upgrade is
+   * the read direction: a transcript knows people only as directory ids, and
+   * the directory is the one source that knows what the id is called.
+   *
+   * `erasedAt: null` on the update is belt and braces — an erased row's key is
+   * a pseudonym and cannot match — kept because "never rewrite an erased
+   * row's text" should not depend on a hashing detail two files away.
+   */
+  async recordDirectorySighting(
+    client: Client,
+    params: {
+      organizationId: string;
+      provider: string;
+      rawActorId: string;
+      displayText: string;
+      seenAt: Date;
+    },
+  ): Promise<void> {
+    const key = {
+      organizationId: params.organizationId,
+      provider: params.provider,
+      rawActorId: params.rawActorId,
+    };
+    try {
+      await client.discoveredPerson.create({
+        data: {
+          ...key,
+          displayText: params.displayText,
+          kind: DISCOVERED_PERSON_KIND.PERSON,
+          firstSeenAt: params.seenAt,
+          lastSeenAt: params.seenAt,
+        },
+      });
+      return;
+    } catch (error) {
+      if (!isUniqueViolation(error)) throw error;
+    }
+    if (params.displayText === "") return;
+    await client.discoveredPerson.updateMany({
+      where: {
+        ...key,
+        erasedAt: null,
+        displayText: { not: params.displayText },
+      },
+      data: { displayText: params.displayText },
+    });
+  }
+
   /**
    * Stops automatic linking for one person, and says why.
    *
@@ -313,7 +439,9 @@ export class IdentityMatchRepository {
         validTo: null,
         userId: { not: null },
       },
-      select: { discoveredPersonId: true, userId: true },
+      // `evidenceKind` rides along for the People screen's "by what proof"
+      // column; the match engine reads only the first two.
+      select: { discoveredPersonId: true, userId: true, evidenceKind: true },
     });
   }
 

--- a/platform/app/ee/governance/routers/__tests__/governancePeople.rbac.integration.test.ts
+++ b/platform/app/ee/governance/routers/__tests__/governancePeople.rbac.integration.test.ts
@@ -206,16 +206,18 @@ describe("governancePeople router — RBAC enforcement", () => {
   });
 
   describe("given an org ADMIN", () => {
-    /** @scenario "The match button runs the proven pass and the suggestion pass" */
-    it("runs both passes and answers with the counts", async () => {
+    /** @scenario "The match button runs the proof pass" */
+    it("runs the proof pass and answers with its counts", async () => {
       const caller = callerFor(adminUserId);
+      // No suggestion count in the answer, and that is the point: the
+      // suggestion pass scores names, which ADR-128 §12 gates off every
+      // request path. It rides the discovery feed on the worker role.
       await expect(
         caller.governancePeople.runMatch({ organizationId }),
       ).resolves.toEqual({
         linked: 0,
         suspended: 0,
         unproven: 0,
-        suggestionsWritten: 0,
       });
     });
 

--- a/platform/app/ee/governance/routers/__tests__/governancePeople.rbac.integration.test.ts
+++ b/platform/app/ee/governance/routers/__tests__/governancePeople.rbac.integration.test.ts
@@ -1,0 +1,235 @@
+// SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+
+/**
+ * @vitest-environment node
+ *
+ * The People router's grants, enforced at the tRPC boundary rather than only
+ * by the page: reads open on `governance:view`, and the two writes — running
+ * the engine, confirming a suggestion — ask for `governance:manage`. The
+ * page-level guard is a courtesy; a caller talking to tRPC directly is who
+ * these tests speak for.
+ *
+ * Three principals, from the same production shapes governance.rbac uses:
+ * an org ADMIN (holds both grants), an org MEMBER (holds neither — before
+ * the RBAC drift fix this bag could read everything), and a delegated
+ * VIEWER (a custom role carrying `governance:view` and nothing that manages
+ * anything — the shape the delegated-governance-viewer feature ships).
+ *
+ * Spec: specs/governance/governance-people-screen.feature
+ */
+
+import { FREE_PLAN } from "@ee/licensing/constants";
+import type { PlanInfo } from "@ee/licensing/planInfo";
+import { nanoid } from "nanoid";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  OrganizationUserRole,
+  RoleBindingScopeType,
+  TeamUserRole,
+} from "~/generated/prisma/client";
+import { appRouter } from "~/server/api/root";
+import { createInnerTRPCContext } from "~/server/api/trpc";
+import { globalForApp, resetApp } from "~/server/app-layer/app";
+import { createTestApp } from "~/server/app-layer/presets";
+import { PlanProviderService } from "~/server/app-layer/subscription/plan-provider";
+import { prisma } from "~/server/db";
+import { cleanupTestRows } from "~/test-utils/cleanupTestRows";
+
+// RBAC is what this file pins, not licensing — same override, same reason,
+// as governance.rbac.integration.test.ts.
+const enterprisePlan: PlanInfo = { ...FREE_PLAN, type: "ENTERPRISE" };
+
+describe("governancePeople router — RBAC enforcement", () => {
+  const ns = `gov-people-rbac-${nanoid(8)}`;
+
+  let organizationId: string;
+  let adminUserId: string;
+  let memberUserId: string;
+  let viewerUserId: string;
+
+  beforeAll(async () => {
+    await resetApp();
+    globalForApp.__langwatch_app = createTestApp({
+      planProvider: PlanProviderService.create({
+        getActivePlan: async () => enterprisePlan,
+      }),
+    });
+
+    const organization = await prisma.organization.create({
+      data: { name: `People RBAC Org ${ns}`, slug: `--gp-${ns}` },
+    });
+    organizationId = organization.id;
+
+    const team = await prisma.team.create({
+      data: {
+        name: `People RBAC Team ${ns}`,
+        slug: `--gp-team-${ns}`,
+        organizationId,
+      },
+    });
+
+    const principal = async (
+      name: string,
+      email: string,
+      orgRole: OrganizationUserRole,
+      teamRole: TeamUserRole,
+      customRoleId?: string,
+    ) => {
+      const user = await prisma.user.create({ data: { name, email } });
+      await prisma.organizationUser.create({
+        data: { userId: user.id, organizationId, role: orgRole },
+      });
+      await prisma.teamUser.create({
+        data: { userId: user.id, teamId: team.id, role: teamRole },
+      });
+      // One binding per principal and scope. The table's check constraint
+      // ties the two columns together: a customRoleId demands role CUSTOM,
+      // and the custom role's permission bag then resolves instead of the
+      // built-in role's.
+      await prisma.roleBinding.create({
+        data: {
+          organizationId,
+          userId: user.id,
+          role: customRoleId ? TeamUserRole.CUSTOM : teamRole,
+          customRoleId: customRoleId ?? null,
+          scopeType: RoleBindingScopeType.ORGANIZATION,
+          scopeId: organizationId,
+        },
+      });
+      return user.id;
+    };
+
+    adminUserId = await principal(
+      "People Admin",
+      `gp-admin-${ns}@example.com`,
+      OrganizationUserRole.ADMIN,
+      TeamUserRole.ADMIN,
+    );
+    memberUserId = await principal(
+      "People Member",
+      `gp-member-${ns}@example.com`,
+      OrganizationUserRole.MEMBER,
+      TeamUserRole.MEMBER,
+    );
+
+    // The delegated viewer: a MEMBER whose custom role carries the one read
+    // grant the Governance product is offered on, and nothing that manages.
+    const viewerRole = await prisma.customRole.create({
+      data: {
+        organizationId,
+        name: `Governance viewer ${ns}`,
+        permissions: ["organization:view", "governance:view"],
+      },
+    });
+    viewerUserId = await principal(
+      "People Viewer",
+      `gp-viewer-${ns}@example.com`,
+      OrganizationUserRole.MEMBER,
+      TeamUserRole.MEMBER,
+      viewerRole.id,
+    );
+  });
+
+  afterAll(async () => {
+    await cleanupTestRows(prisma, [
+      ["roleBinding", { organizationId }],
+      ["customRole", { organizationId }],
+      ["teamUser", { team: { organizationId } }],
+      ["organizationUser", { organizationId }],
+      ["team", { organizationId }],
+      ["organization", { slug: `--gp-${ns}` }],
+      [
+        "user",
+        {
+          email: {
+            in: [
+              `gp-admin-${ns}@example.com`,
+              `gp-member-${ns}@example.com`,
+              `gp-viewer-${ns}@example.com`,
+            ],
+          },
+        },
+      ],
+    ]);
+    await resetApp();
+  });
+
+  function callerFor(userId: string) {
+    const ctx = createInnerTRPCContext({
+      session: { user: { id: userId }, expires: "1" } as never,
+    });
+    return appRouter.createCaller(ctx);
+  }
+
+  describe("given a caller without governance view", () => {
+    /** @scenario "Reading the list requires the governance view grant" */
+    it("refuses the list and the suggestions to an org MEMBER", async () => {
+      const caller = callerFor(memberUserId);
+      await expect(
+        caller.governancePeople.list({ organizationId }),
+      ).rejects.toMatchObject({ code: "FORBIDDEN" });
+      await expect(
+        caller.governancePeople.suggestions({ organizationId }),
+      ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    });
+  });
+
+  describe("given a caller with only governance view", () => {
+    it("serves the list and the suggestions", async () => {
+      const caller = callerFor(viewerUserId);
+      await expect(
+        caller.governancePeople.list({ organizationId }),
+      ).resolves.toEqual([]);
+      await expect(
+        caller.governancePeople.suggestions({ organizationId }),
+      ).resolves.toEqual([]);
+    });
+
+    /** @scenario "Running the engine requires the governance manage grant" */
+    it("refuses to run the match pass", async () => {
+      const caller = callerFor(viewerUserId);
+      await expect(
+        caller.governancePeople.runMatch({ organizationId }),
+      ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    });
+
+    /** @scenario "Confirming requires the governance manage grant" */
+    it("refuses to confirm a suggestion", async () => {
+      const caller = callerFor(viewerUserId);
+      await expect(
+        caller.governancePeople.confirmSuggestion({
+          organizationId,
+          suggestionId: "sugg_nonexistent",
+        }),
+      ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    });
+  });
+
+  describe("given an org ADMIN", () => {
+    /** @scenario "The match button runs the proven pass and the suggestion pass" */
+    it("runs both passes and answers with the counts", async () => {
+      const caller = callerFor(adminUserId);
+      await expect(
+        caller.governancePeople.runMatch({ organizationId }),
+      ).resolves.toEqual({
+        linked: 0,
+        suspended: 0,
+        unproven: 0,
+        suggestionsWritten: 0,
+      });
+    });
+
+    it("reaches the service on confirm, where a vanished suggestion is its own refusal", async () => {
+      const caller = callerFor(adminUserId);
+      // Past the grant, the engine speaks: this suggestion does not exist.
+      // The refusal carrying the engine's message rather than FORBIDDEN is
+      // what proves the permission gate opened.
+      await expect(
+        caller.governancePeople.confirmSuggestion({
+          organizationId,
+          suggestionId: "sugg_nonexistent",
+        }),
+      ).rejects.toThrow(/suggestion/i);
+    });
+  });
+});

--- a/platform/app/ee/governance/routers/governancePeople.ts
+++ b/platform/app/ee/governance/routers/governancePeople.ts
@@ -6,18 +6,18 @@
  * Reads gate on `governance:view`, the two writes on `governance:manage` —
  * the viewer grant reads, linking writes identity rows.
  *
- * The engine keeps no standing appointment of its own
- * (governance-identity-match-engine.feature); `runMatch` is the trigger the
- * engine spec left to the screen. One button runs both passes — proof, then
- * suggestions — because splitting them asks the user to know the engine's
- * internal seam between proof and guess.
+ * `runMatch` runs the PROOF pass only. The suggestion half scores names —
+ * quadratic, and gated off every request path by the engine's import-graph
+ * guard (ADR-128 §12) — so it rides the discovery feed on the worker role
+ * instead; the composition root is its one caller. The button still gives a
+ * reviewer fresh proof links on demand, and the suggestions list fills as
+ * pulls deliver people.
  *
  * Spec: specs/governance/governance-people-screen.feature
  */
 
 import { GovernancePeopleScreenService } from "@ee/governance/services/governancePeopleScreen.service";
 import { IdentityMatchService } from "@ee/governance/services/identityMatch.service";
-import { IdentityMatchSuggestionService } from "@ee/governance/services/identityMatchSuggestion.service";
 import { z } from "zod";
 
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
@@ -48,14 +48,10 @@ export const governancePeopleRouter = createTRPCRouter({
       const linked = await IdentityMatchService.create(
         ctx.prisma,
       ).linkProvenMatches({ organizationId: input.organizationId });
-      const suggested = await IdentityMatchSuggestionService.create(
-        ctx.prisma,
-      ).recompute({ organizationId: input.organizationId });
       return {
         linked: linked.linked,
         suspended: linked.suspended,
         unproven: linked.unproven,
-        suggestionsWritten: suggested.suggestionsWritten,
       };
     }),
 

--- a/platform/app/ee/governance/routers/governancePeople.ts
+++ b/platform/app/ee/governance/routers/governancePeople.ts
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+
+/**
+ * tRPC router for the People screen's identity half: the discovered-people
+ * list, the review queue, the match button, and confirming a suggestion.
+ * Reads gate on `governance:view`, the two writes on `governance:manage` —
+ * the viewer grant reads, linking writes identity rows.
+ *
+ * The engine keeps no standing appointment of its own
+ * (governance-identity-match-engine.feature); `runMatch` is the trigger the
+ * engine spec left to the screen. One button runs both passes — proof, then
+ * suggestions — because splitting them asks the user to know the engine's
+ * internal seam between proof and guess.
+ *
+ * Spec: specs/governance/governance-people-screen.feature
+ */
+
+import { GovernancePeopleScreenService } from "@ee/governance/services/governancePeopleScreen.service";
+import {
+  IdentityAlreadyLinkedError,
+  IdentityErasedError,
+  IdentityMatchSuggestionNotFoundError,
+} from "@ee/governance/services/identityMatch.errors";
+import { IdentityMatchService } from "@ee/governance/services/identityMatch.service";
+import { IdentityMatchSuggestionService } from "@ee/governance/services/identityMatchSuggestion.service";
+import { HandledError } from "@langwatch/handled-error";
+import { TRPCError } from "@trpc/server";
+import { z } from "zod";
+
+import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
+
+export const governancePeopleRouter = createTRPCRouter({
+  list: protectedProcedure
+    .input(z.object({ organizationId: z.string() }))
+    .permission("governance:view")
+    .query(async ({ ctx, input }) => {
+      return await GovernancePeopleScreenService.create(ctx.prisma).listPeople({
+        organizationId: input.organizationId,
+      });
+    }),
+
+  suggestions: protectedProcedure
+    .input(z.object({ organizationId: z.string() }))
+    .permission("governance:view")
+    .query(async ({ ctx, input }) => {
+      return await GovernancePeopleScreenService.create(
+        ctx.prisma,
+      ).listSuggestions({ organizationId: input.organizationId });
+    }),
+
+  runMatch: protectedProcedure
+    .input(z.object({ organizationId: z.string() }))
+    .permission("governance:manage")
+    .mutation(async ({ ctx, input }) => {
+      const linked = await IdentityMatchService.create(
+        ctx.prisma,
+      ).linkProvenMatches({ organizationId: input.organizationId });
+      const suggested = await IdentityMatchSuggestionService.create(
+        ctx.prisma,
+      ).recompute({ organizationId: input.organizationId });
+      return {
+        linked: linked.linked,
+        suspended: linked.suspended,
+        unproven: linked.unproven,
+        suggestionsWritten: suggested.suggestionsWritten,
+      };
+    }),
+
+  confirmSuggestion: protectedProcedure
+    .input(z.object({ organizationId: z.string(), suggestionId: z.string() }))
+    .permission("governance:manage")
+    .mutation(async ({ ctx, input }) => {
+      try {
+        return await IdentityMatchService.create(ctx.prisma).confirmSuggestion({
+          organizationId: input.organizationId,
+          suggestionId: input.suggestionId,
+        });
+      } catch (err) {
+        throw mapError(err);
+      }
+    }),
+});
+
+/**
+ * The engine's refusals shaped for the boundary, each with the code a client
+ * can act on: a queue read before somebody else confirmed is a CONFLICT to
+ * refresh past, a vanished suggestion is NOT_FOUND, and everything else keeps
+ * its `cause` on the way to the logs.
+ */
+function mapError(err: unknown): Error {
+  if (HandledError.isHandled(err)) {
+    return err;
+  }
+  if (
+    err instanceof IdentityAlreadyLinkedError ||
+    err instanceof IdentityErasedError
+  ) {
+    return new TRPCError({
+      code: "CONFLICT",
+      message: err.message,
+      cause: err,
+    });
+  }
+  if (err instanceof IdentityMatchSuggestionNotFoundError) {
+    return new TRPCError({
+      code: "NOT_FOUND",
+      message: err.message,
+      cause: err,
+    });
+  }
+  return err instanceof TRPCError
+    ? err
+    : new TRPCError({ code: "INTERNAL_SERVER_ERROR", cause: err });
+}

--- a/platform/app/ee/governance/routers/governancePeople.ts
+++ b/platform/app/ee/governance/routers/governancePeople.ts
@@ -16,15 +16,8 @@
  */
 
 import { GovernancePeopleScreenService } from "@ee/governance/services/governancePeopleScreen.service";
-import {
-  IdentityAlreadyLinkedError,
-  IdentityErasedError,
-  IdentityMatchSuggestionNotFoundError,
-} from "@ee/governance/services/identityMatch.errors";
 import { IdentityMatchService } from "@ee/governance/services/identityMatch.service";
 import { IdentityMatchSuggestionService } from "@ee/governance/services/identityMatchSuggestion.service";
-import { HandledError } from "@langwatch/handled-error";
-import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
@@ -70,45 +63,14 @@ export const governancePeopleRouter = createTRPCRouter({
     .input(z.object({ organizationId: z.string(), suggestionId: z.string() }))
     .permission("governance:manage")
     .mutation(async ({ ctx, input }) => {
-      try {
-        return await IdentityMatchService.create(ctx.prisma).confirmSuggestion({
-          organizationId: input.organizationId,
-          suggestionId: input.suggestionId,
-        });
-      } catch (err) {
-        throw mapError(err);
-      }
+      // No error mapping here, unlike departments.ts: the engine's refusals
+      // (already linked, erased, suggestion gone) all extend HandledError,
+      // which the boundary formatter already serialises with its registered
+      // code and remediation. A local instanceof map would be dead code the
+      // HandledError check shadows.
+      return await IdentityMatchService.create(ctx.prisma).confirmSuggestion({
+        organizationId: input.organizationId,
+        suggestionId: input.suggestionId,
+      });
     }),
 });
-
-/**
- * The engine's refusals shaped for the boundary, each with the code a client
- * can act on: a queue read before somebody else confirmed is a CONFLICT to
- * refresh past, a vanished suggestion is NOT_FOUND, and everything else keeps
- * its `cause` on the way to the logs.
- */
-function mapError(err: unknown): Error {
-  if (HandledError.isHandled(err)) {
-    return err;
-  }
-  if (
-    err instanceof IdentityAlreadyLinkedError ||
-    err instanceof IdentityErasedError
-  ) {
-    return new TRPCError({
-      code: "CONFLICT",
-      message: err.message,
-      cause: err,
-    });
-  }
-  if (err instanceof IdentityMatchSuggestionNotFoundError) {
-    return new TRPCError({
-      code: "NOT_FOUND",
-      message: err.message,
-      cause: err,
-    });
-  }
-  return err instanceof TRPCError
-    ? err
-    : new TRPCError({ code: "INTERNAL_SERVER_ERROR", cause: err });
-}

--- a/platform/app/ee/governance/services/__tests__/directoryDepartmentSync.integration.test.ts
+++ b/platform/app/ee/governance/services/__tests__/directoryDepartmentSync.integration.test.ts
@@ -1,0 +1,263 @@
+// SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+
+/**
+ * @vitest-environment node
+ *
+ * The directory's department field landing on real rows: real members, real
+ * `Department` rows through `resolveByNameOrCreate`, real assignments on the
+ * membership. What lives here is the proof rule against actual join paths —
+ * a confirmed address, an unconfirmed one, the SSO connection's directory id
+ * — and the idempotence of a read that runs every day.
+ *
+ * Spec: specs/governance/governance-people-discovery.feature
+ * Decision: ADR-128 §10–12
+ */
+import { nanoid } from "nanoid";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+import { prisma } from "~/server/db";
+import { cleanupTestRows } from "~/test-utils/cleanupTestRows";
+
+import { DirectoryDepartmentSyncService } from "../directoryDepartmentSync.service";
+import { DIRECTORY_REPORT_ACTION } from "../pullers/microsoftGraphDirectory";
+import type { NormalizedPullEvent } from "../pullers/pullerAdapter";
+
+const ns = nanoid(8);
+const organizationId = `org_dirdept_${ns}`;
+const mariaUserId = `user_dd_maria_${ns}`;
+const jonasUserId = `user_dd_jonas_${ns}`;
+const connectionId = `sso_dd_${ns}`;
+
+const MARIA_OID = "f6481ec4-0000-4000-8000-000000000001";
+const JONAS_OID = "f6481ec4-0000-4000-8000-000000000002";
+const STRANGER_OID = "f6481ec4-0000-4000-8000-000000000003";
+
+const service = () => DirectoryDepartmentSyncService.create(prisma);
+
+const directoryEvent = (over: {
+  actor: string;
+  mail?: string;
+  department?: string;
+}): NormalizedPullEvent => ({
+  source_event_id: `dir_${nanoid(6)}`,
+  event_timestamp: "2026-09-03T00:00:00.000Z",
+  actor: over.actor,
+  action: DIRECTORY_REPORT_ACTION,
+  target: over.department ?? "",
+  cost_usd: "0",
+  tokens_input: 0,
+  tokens_output: 0,
+  raw_payload: "{}",
+  extra: {
+    directoryId: over.actor,
+    displayName: "",
+    mail: over.mail ?? "",
+    userPrincipalName: "",
+    department: over.department ?? "",
+    accountEnabled: true,
+  },
+});
+
+const membership = (userId: string) =>
+  prisma.organizationUser.findFirstOrThrow({
+    where: { organizationId, userId },
+    select: { departmentId: true },
+  });
+
+const departments = () =>
+  prisma.department.findMany({
+    where: { organizationId },
+    orderBy: { name: "asc" },
+  });
+
+describe("Feature: directory departments land on the entities we already have", () => {
+  beforeAll(async () => {
+    await prisma.organization.create({
+      data: {
+        id: organizationId,
+        name: "Directory Dept Org",
+        slug: `--test-dirdept-${ns}`,
+      },
+    });
+
+    const member = async (
+      id: string,
+      name: string,
+      email: string,
+      verified: boolean,
+    ) => {
+      await prisma.user.create({
+        data: { id, name, email, emailVerified: verified },
+      });
+      await prisma.organizationUser.create({
+        data: { organizationId, userId: id, role: "MEMBER" },
+      });
+    };
+    await member(mariaUserId, "Maria Silva", `m.silva-${ns}@acme.test`, true);
+    // Jonas never confirmed his address; his proof, if any, is the directory id.
+    await member(
+      jonasUserId,
+      "Jonas Bakker",
+      `j.bakker-${ns}@acme.test`,
+      false,
+    );
+
+    const at = new Date("2026-09-01T00:00:00.000Z");
+    await prisma.ssoConnection.create({
+      data: {
+        id: connectionId,
+        organizationId,
+        type: "oidc",
+        state: "ACTIVE",
+        idpMetadata: {},
+        source: "self-serve",
+        occurredAt: at,
+        lastEventId: `evt_${ns}`,
+        acceptedAt: at,
+        projectionVersion: "1",
+        createdAt: at,
+        updatedAt: at,
+      },
+    });
+    await prisma.scimExternalId.create({
+      data: { connectionId, externalId: JONAS_OID, userId: jonasUserId },
+    });
+  });
+
+  beforeEach(async () => {
+    await prisma.organizationUser.updateMany({
+      where: { organizationId },
+      data: { departmentId: null },
+    });
+    await cleanupTestRows(prisma, [["department", { organizationId }]]);
+  });
+
+  afterAll(() =>
+    cleanupTestRows(prisma, [
+      ["department", { organizationId }],
+      ["scimExternalId", { connectionId }],
+      ["ssoConnection", { id: connectionId }],
+      ["organizationUser", { organizationId }],
+      ["user", { id: { in: [mariaUserId, jonasUserId] } }],
+      ["organization", { id: organizationId }],
+    ]),
+  );
+
+  it("assigns a member their directory department through a confirmed address", async () => {
+    await prisma.department.create({
+      data: { organizationId, name: "Engineering" },
+    });
+
+    const outcome = await service().applyDirectoryEvents({
+      organizationId,
+      events: [
+        directoryEvent({
+          actor: MARIA_OID,
+          mail: `m.silva-${ns}@acme.test`,
+          department: "Engineering",
+        }),
+      ],
+    });
+
+    expect(outcome.assigned).toBe(1);
+    const rows = await departments();
+    expect(rows).toHaveLength(1);
+    expect((await membership(mariaUserId)).departmentId).toBe(rows[0]?.id);
+  });
+
+  it("creates a department the organization has not created yet — the SCIM costCenter call", async () => {
+    await service().applyDirectoryEvents({
+      organizationId,
+      events: [
+        directoryEvent({
+          actor: MARIA_OID,
+          mail: `m.silva-${ns}@acme.test`,
+          department: "Field Research",
+        }),
+      ],
+    });
+
+    const rows = await departments();
+    expect(rows.map((d) => d.name)).toEqual(["Field Research"]);
+    expect((await membership(mariaUserId)).departmentId).toBe(rows[0]?.id);
+  });
+
+  it("assigns through the SSO connection's directory id when no address is confirmed", async () => {
+    const outcome = await service().applyDirectoryEvents({
+      organizationId,
+      events: [
+        directoryEvent({
+          actor: JONAS_OID,
+          // The unconfirmed address alone would prove nothing; the id does.
+          mail: `j.bakker-${ns}@acme.test`,
+          department: "Operations",
+        }),
+      ],
+    });
+
+    expect(outcome.assigned).toBe(1);
+    expect((await membership(jonasUserId)).departmentId).not.toBeNull();
+  });
+
+  it("assigns nobody from a row that proves nobody, and creates no department for it", async () => {
+    const outcome = await service().applyDirectoryEvents({
+      organizationId,
+      events: [
+        directoryEvent({
+          actor: STRANGER_OID,
+          mail: `nobody-${ns}@acme.test`,
+          department: "Marketing",
+        }),
+      ],
+    });
+
+    expect(outcome.assigned).toBe(0);
+    expect(await departments()).toHaveLength(0);
+  });
+
+  it("leaves a hand-assigned member alone when their directory department is blank", async () => {
+    const dept = await prisma.department.create({
+      data: { organizationId, name: "Platform" },
+    });
+    await prisma.organizationUser.updateMany({
+      where: { organizationId, userId: mariaUserId },
+      data: { departmentId: dept.id },
+    });
+
+    await service().applyDirectoryEvents({
+      organizationId,
+      events: [
+        directoryEvent({
+          actor: MARIA_OID,
+          mail: `m.silva-${ns}@acme.test`,
+          department: "",
+        }),
+      ],
+    });
+
+    expect((await membership(mariaUserId)).departmentId).toBe(dept.id);
+  });
+
+  it("costs nothing to run twice — one department, same assignment, no write reported", async () => {
+    const events = [
+      directoryEvent({
+        actor: MARIA_OID,
+        mail: `m.silva-${ns}@acme.test`,
+        department: "Engineering",
+      }),
+    ];
+
+    const first = await service().applyDirectoryEvents({
+      organizationId,
+      events,
+    });
+    const second = await service().applyDirectoryEvents({
+      organizationId,
+      events,
+    });
+
+    expect(first.assigned).toBe(1);
+    expect(second.assigned).toBe(0);
+    expect(await departments()).toHaveLength(1);
+  });
+});

--- a/platform/app/ee/governance/services/__tests__/directoryDepartmentSync.integration.test.ts
+++ b/platform/app/ee/governance/services/__tests__/directoryDepartmentSync.integration.test.ts
@@ -143,6 +143,7 @@ describe("Feature: directory departments land on the entities we already have", 
     ]),
   );
 
+  /** @scenario "A directory department lands on the member it proves" */
   it("assigns a member their directory department through a confirmed address", async () => {
     await prisma.department.create({
       data: { organizationId, name: "Engineering" },
@@ -165,6 +166,7 @@ describe("Feature: directory departments land on the entities we already have", 
     expect((await membership(mariaUserId)).departmentId).toBe(rows[0]?.id);
   });
 
+  /** @scenario "A department the organization has not created yet is created" */
   it("creates a department the organization has not created yet — the SCIM costCenter call", async () => {
     await service().applyDirectoryEvents({
       organizationId,
@@ -199,6 +201,7 @@ describe("Feature: directory departments land on the entities we already have", 
     expect((await membership(jonasUserId)).departmentId).not.toBeNull();
   });
 
+  /** @scenario "A directory row proving no member assigns nobody" */
   it("assigns nobody from a row that proves nobody, and creates no department for it", async () => {
     const outcome = await service().applyDirectoryEvents({
       organizationId,
@@ -215,6 +218,7 @@ describe("Feature: directory departments land on the entities we already have", 
     expect(await departments()).toHaveLength(0);
   });
 
+  /** @scenario "A blank directory department leaves the member's assignment alone" */
   it("leaves a hand-assigned member alone when their directory department is blank", async () => {
     const dept = await prisma.department.create({
       data: { organizationId, name: "Platform" },

--- a/platform/app/ee/governance/services/__tests__/governancePeopleScreen.service.integration.test.ts
+++ b/platform/app/ee/governance/services/__tests__/governancePeopleScreen.service.integration.test.ts
@@ -16,6 +16,7 @@ import { prisma } from "~/server/db";
 import { cleanupTestRows } from "~/test-utils/cleanupTestRows";
 
 import { GovernancePeopleScreenService } from "../governancePeopleScreen.service";
+import { IdentityMatchService } from "../identityMatch.service";
 
 const ns = nanoid(8);
 const organizationId = `org_pscreen_${ns}`;
@@ -89,6 +90,7 @@ describe("Feature: the People screen shows who the providers named", () => {
 
   afterAll(() =>
     cleanupTestRows(prisma, [
+      ["identityMatchSuggestion", { organizationId }],
       ["identityMatch", { organizationId }],
       ["discoveredPerson", { organizationId }],
       ["department", { organizationId }],
@@ -98,31 +100,89 @@ describe("Feature: the People screen shows who the providers named", () => {
     ]),
   );
 
-  it("shows the link, its proof, and the member's department on a linked person", async () => {
-    const people = await service().listPeople({ organizationId });
+  describe("when the list is read", () => {
+    /** @scenario "The list shows what a provider said and what the engine decided" */
+    it("shows each person's identifier, provider, kind, seen range, and link state", async () => {
+      const people = await service().listPeople({ organizationId });
 
-    const linked = people.find((p) => p.id === `linked_${ns}`);
-    expect(linked?.link).toMatchObject({
-      userId: mariaUserId,
-      evidenceKind: "verified_email",
-      memberName: "Maria Silva",
-      departmentName: "Engineering",
+      const stranger = people.find((p) => p.id === `stranger_${ns}`);
+      expect(stranger).toMatchObject({
+        displayText: `stranger@acme.test`,
+        provider: "openai_admin",
+        kind: "person",
+        link: null,
+      });
+      expect(stranger?.firstSeenAt).toEqual(
+        new Date("2026-08-01T00:00:00.000Z"),
+      );
+      expect(stranger?.lastSeenAt).toEqual(
+        new Date("2026-08-01T00:00:00.000Z"),
+      );
+    });
+
+    /** @scenario "A linked person shows their member's department" */
+    it("shows the link, its proof, and the member's department on a linked person", async () => {
+      const people = await service().listPeople({ organizationId });
+
+      const linked = people.find((p) => p.id === `linked_${ns}`);
+      expect(linked?.link).toMatchObject({
+        userId: mariaUserId,
+        evidenceKind: "verified_email",
+        memberName: "Maria Silva",
+        departmentName: "Engineering",
+      });
+    });
+
+    /** @scenario "An erased person shows a stand-in, never the identifier" */
+    it("shows an erased person as erased, wearing the stand-in text", async () => {
+      const people = await service().listPeople({ organizationId });
+
+      const gone = people.find((p) => p.id === `gone_${ns}`);
+      expect(gone?.erasedAt).not.toBeNull();
+      expect(gone?.displayText).toBe("pseudonym_xyz");
+      expect(gone?.rawActorId).toBe("pseudonym_xyz");
     });
   });
 
-  it("shows an unlinked person with no link and no department", async () => {
-    const people = await service().listPeople({ organizationId });
+  describe("given a stored suggestion pairing the stranger with Maria", () => {
+    beforeAll(async () => {
+      await prisma.identityMatchSuggestion.create({
+        data: {
+          id: `sugg_${ns}`,
+          organizationId,
+          discoveredPersonId: `stranger_${ns}`,
+          userId: mariaUserId,
+          score: 0.91,
+          computedAt: new Date("2026-09-01T00:00:00.000Z"),
+        },
+      });
+    });
 
-    const stranger = people.find((p) => p.id === `stranger_${ns}`);
-    expect(stranger?.link).toBeNull();
-  });
+    /** @scenario "A suggestion shows both halves and a confirm action" */
+    it("shows both halves, and confirming links them and clears the queue", async () => {
+      const before = await service().listSuggestions({ organizationId });
+      expect(before).toMatchObject([
+        {
+          id: `sugg_${ns}`,
+          personDisplayText: "stranger@acme.test",
+          personProvider: "openai_admin",
+          memberName: "Maria Silva",
+        },
+      ]);
 
-  it("shows an erased person as erased, wearing the stand-in text", async () => {
-    const people = await service().listPeople({ organizationId });
+      await IdentityMatchService.create(prisma).confirmSuggestion({
+        organizationId,
+        suggestionId: `sugg_${ns}`,
+      });
 
-    const gone = people.find((p) => p.id === `gone_${ns}`);
-    expect(gone?.erasedAt).not.toBeNull();
-    expect(gone?.displayText).toBe("pseudonym_xyz");
-    expect(gone?.rawActorId).toBe("pseudonym_xyz");
+      const after = await service().listSuggestions({ organizationId });
+      expect(after).toEqual([]);
+      const people = await service().listPeople({ organizationId });
+      const stranger = people.find((p) => p.id === `stranger_${ns}`);
+      expect(stranger?.link).toMatchObject({
+        userId: mariaUserId,
+        evidenceKind: "human_confirmed",
+      });
+    });
   });
 });

--- a/platform/app/ee/governance/services/__tests__/governancePeopleScreen.service.integration.test.ts
+++ b/platform/app/ee/governance/services/__tests__/governancePeopleScreen.service.integration.test.ts
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+
+/**
+ * @vitest-environment node
+ *
+ * The People screen's server-side joins against real rows: the open link and
+ * its evidence beside the person, the linked member's department read
+ * through the membership, and the erased row showing its stand-in.
+ *
+ * Spec: specs/governance/governance-people-screen.feature
+ */
+import { nanoid } from "nanoid";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { prisma } from "~/server/db";
+import { cleanupTestRows } from "~/test-utils/cleanupTestRows";
+
+import { GovernancePeopleScreenService } from "../governancePeopleScreen.service";
+
+const ns = nanoid(8);
+const organizationId = `org_pscreen_${ns}`;
+const mariaUserId = `user_ps_maria_${ns}`;
+
+const service = () => GovernancePeopleScreenService.create(prisma);
+
+describe("Feature: the People screen shows who the providers named", () => {
+  beforeAll(async () => {
+    await prisma.organization.create({
+      data: {
+        id: organizationId,
+        name: "People Screen Org",
+        slug: `--test-pscreen-${ns}`,
+      },
+    });
+    await prisma.user.create({
+      data: {
+        id: mariaUserId,
+        name: "Maria Silva",
+        email: `m.silva-${ns}@acme.test`,
+        emailVerified: true,
+      },
+    });
+    const department = await prisma.department.create({
+      data: { organizationId, name: "Engineering" },
+    });
+    await prisma.organizationUser.create({
+      data: {
+        organizationId,
+        userId: mariaUserId,
+        role: "MEMBER",
+        departmentId: department.id,
+      },
+    });
+
+    const seenAt = new Date("2026-08-01T00:00:00.000Z");
+    const person = (id: string, over: Record<string, unknown>) =>
+      prisma.discoveredPerson.create({
+        data: {
+          id: `${id}_${ns}`,
+          organizationId,
+          provider: "openai_admin",
+          rawActorId: `${id}@acme.test`,
+          displayText: `${id}@acme.test`,
+          kind: "person",
+          firstSeenAt: seenAt,
+          lastSeenAt: seenAt,
+          ...over,
+        },
+      });
+
+    await person("linked", {});
+    await person("stranger", {});
+    await person("gone", {
+      rawActorId: "pseudonym_xyz",
+      displayText: "pseudonym_xyz",
+      erasedAt: new Date("2026-09-01T00:00:00.000Z"),
+    });
+
+    await prisma.identityMatch.create({
+      data: {
+        organizationId,
+        discoveredPersonId: `linked_${ns}`,
+        userId: mariaUserId,
+        evidenceKind: "verified_email",
+        validFrom: seenAt,
+      },
+    });
+  });
+
+  afterAll(() =>
+    cleanupTestRows(prisma, [
+      ["identityMatch", { organizationId }],
+      ["discoveredPerson", { organizationId }],
+      ["department", { organizationId }],
+      ["organizationUser", { organizationId }],
+      ["user", { id: mariaUserId }],
+      ["organization", { id: organizationId }],
+    ]),
+  );
+
+  it("shows the link, its proof, and the member's department on a linked person", async () => {
+    const people = await service().listPeople({ organizationId });
+
+    const linked = people.find((p) => p.id === `linked_${ns}`);
+    expect(linked?.link).toMatchObject({
+      userId: mariaUserId,
+      evidenceKind: "verified_email",
+      memberName: "Maria Silva",
+      departmentName: "Engineering",
+    });
+  });
+
+  it("shows an unlinked person with no link and no department", async () => {
+    const people = await service().listPeople({ organizationId });
+
+    const stranger = people.find((p) => p.id === `stranger_${ns}`);
+    expect(stranger?.link).toBeNull();
+  });
+
+  it("shows an erased person as erased, wearing the stand-in text", async () => {
+    const people = await service().listPeople({ organizationId });
+
+    const gone = people.find((p) => p.id === `gone_${ns}`);
+    expect(gone?.erasedAt).not.toBeNull();
+    expect(gone?.displayText).toBe("pseudonym_xyz");
+    expect(gone?.rawActorId).toBe("pseudonym_xyz");
+  });
+});

--- a/platform/app/ee/governance/services/__tests__/identityScorerRequestBoundary.unit.test.ts
+++ b/platform/app/ee/governance/services/__tests__/identityScorerRequestBoundary.unit.test.ts
@@ -14,15 +14,16 @@
  * Three claims, weakest to strongest:
  *
  *  1. exactly one module imports the scorer, and it is the background job;
- *  2. nothing imports that job at all, now the nightly pass is gone;
+ *  2. exactly one module imports that job, and it is the composition root;
  *  3. walking out from the request surfaces never arrives at the scorer.
  *
- * Claim 2 used to name the composition root, which booked the job nightly. The
- * appointment is gone (nothing writes `DiscoveredPerson` yet, so every pass
- * read an empty table) and the job is left with no caller. Asserting the empty
- * list rather than deleting the claim is the point: the next caller written is
- * the one that has to be a background job, and this line is what makes adding
- * it visible in review instead of silent.
+ * Claim 2 has named the composition root before, back when the root booked
+ * the job nightly. The appointment went (every nightly pass read an empty
+ * table), the list was asserted empty so the next caller would be visible in
+ * review — and this is that caller: the feed that discovers people has
+ * landed, and the root now composes the job behind its worker-role gate as
+ * the pull run's `identityMatch` port. The router that offers the match
+ * button runs the proof pass only; it must never appear in this list.
  *
  * The third treats the composition root as a leaf, and that exclusion is stated
  * rather than hidden: `presets.ts` composes every service in the process and is
@@ -193,8 +194,10 @@ describe("Feature: where the name scorer can be reached from", () => {
   });
 
   describe("given the modules that import the background job", () => {
-    it("finds none, because nothing calls the job yet", () => {
-      expect(directImportersOf(SUGGESTION_JOB)).toEqual([]);
+    it("finds exactly the composition root, which runs it on the worker role", () => {
+      expect(directImportersOf(SUGGESTION_JOB)).toEqual([
+        relative(APP_DIR, COMPOSITION_ROOT),
+      ]);
     });
   });
 

--- a/platform/app/ee/governance/services/__tests__/personDiscovery.service.integration.test.ts
+++ b/platform/app/ee/governance/services/__tests__/personDiscovery.service.integration.test.ts
@@ -86,7 +86,8 @@ afterAll(() =>
   cleanupTestRows(prisma, [["discoveredPerson", { organizationId }]]),
 );
 
-describe("an actor on a pulled row", () => {
+describe("given a provider's pulled rows naming an actor", () => {
+  /** @scenario "An actor on a pulled row becomes a discovered person" */
   it("becomes a discovered person with the event's own time as both seen dates", async () => {
     await service().recordFromPulledEvents({
       organizationId,
@@ -106,6 +107,7 @@ describe("an actor on a pulled row", () => {
     });
   });
 
+  /** @scenario "Seeing the same actor again moves last-seen forward only" */
   it("only ever widens the seen range on later sightings, in either direction", async () => {
     const at = (iso: string) => activityEvent({ event_timestamp: iso });
     await service().recordFromPulledEvents({
@@ -135,6 +137,7 @@ describe("an actor on a pulled row", () => {
     expect(await personRows()).toEqual(rows);
   });
 
+  /** @scenario "The same identifier on two providers is two discovered people" */
   it("is two discovered people when two providers name the same email", async () => {
     await service().recordFromPulledEvents({
       organizationId,
@@ -155,7 +158,8 @@ describe("an actor on a pulled row", () => {
   });
 });
 
-describe("rows that must not become people", () => {
+describe("given rows that must not become people", () => {
+  /** @scenario "A row naming nobody discovers nobody" */
   it("discovers nobody from an empty actor", async () => {
     await service().recordFromPulledEvents({
       organizationId,
@@ -165,6 +169,7 @@ describe("rows that must not become people", () => {
     expect(await personRows()).toHaveLength(0);
   });
 
+  /** @scenario "A bare-UUID Databricks actor is recorded as a machine login" */
   it("records a bare-UUID Databricks actor as a machine login", async () => {
     const uuid = "2f6b6a10-9f21-4d3a-8f01-6f2f1a9c1b2d";
     await service().recordFromPulledEvents({
@@ -190,7 +195,7 @@ describe("rows that must not become people", () => {
   });
 });
 
-describe("a directory sighting", () => {
+describe("given a directory listing of the tenant's people", () => {
   const oid = "f6481ec4-0000-4000-8000-2a8f29bb1c4a";
 
   it("creates the person under their best name", async () => {
@@ -207,6 +212,7 @@ describe("a directory sighting", () => {
     });
   });
 
+  /** @scenario "A directory row enriches a discovered person's display text" */
   it("upgrades the display text of a person activity discovered as a bare id", async () => {
     // Activity saw the id first — a transcript knows people only as GUIDs.
     await service().recordFromPulledEvents({

--- a/platform/app/ee/governance/services/__tests__/personDiscovery.service.integration.test.ts
+++ b/platform/app/ee/governance/services/__tests__/personDiscovery.service.integration.test.ts
@@ -1,0 +1,282 @@
+// SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+
+/**
+ * @vitest-environment node
+ *
+ * The discovery feed against real Postgres.
+ *
+ * What lives here is everything that is a constraint or a conditional WHERE:
+ * that a replayed window is a no-op, that the seen range only ever widens,
+ * that two providers naming one email are two rows under the unique key, and
+ * that a directory sighting upgrades text without touching the range. An
+ * application-level double would pass all of it with the WHEREs absent.
+ *
+ * Spec: specs/governance/governance-people-discovery.feature
+ * Decision: ADR-128 §10–11
+ */
+import { nanoid } from "nanoid";
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+
+import { prisma } from "~/server/db";
+import { cleanupTestRows } from "~/test-utils/cleanupTestRows";
+
+import { DISCOVERED_PERSON_KIND } from "../../repositories/governanceIdentity.repository";
+import { PersonDiscoveryService } from "../personDiscovery.service";
+import { DIRECTORY_REPORT_ACTION } from "../pullers/microsoftGraphDirectory";
+import type { NormalizedPullEvent } from "../pullers/pullerAdapter";
+
+const ns = nanoid(8);
+const organizationId = `org_discovery_${ns}`;
+
+const service = () => PersonDiscoveryService.create(prisma);
+
+/** An activity event, with only what a test varies spelled out. */
+const activityEvent = (
+  over: Partial<NormalizedPullEvent>,
+): NormalizedPullEvent => ({
+  source_event_id: `evt_${nanoid(6)}`,
+  event_timestamp: "2026-08-10T12:00:00.000Z",
+  actor: "m.silva@acme.test",
+  action: "cost_report",
+  target: "gpt-5",
+  cost_usd: "1.25",
+  tokens_input: 0,
+  tokens_output: 0,
+  raw_payload: "{}",
+  ...over,
+});
+
+const directoryEvent = (over: {
+  actor: string;
+  displayName?: string;
+  mail?: string;
+  department?: string;
+  timestamp?: string;
+}): NormalizedPullEvent => ({
+  source_event_id: `dir_${nanoid(6)}`,
+  event_timestamp: over.timestamp ?? "2026-09-01T00:00:00.000Z",
+  actor: over.actor,
+  action: DIRECTORY_REPORT_ACTION,
+  target: over.department ?? "",
+  cost_usd: "0",
+  tokens_input: 0,
+  tokens_output: 0,
+  raw_payload: "{}",
+  extra: {
+    directoryId: over.actor,
+    displayName: over.displayName ?? "",
+    mail: over.mail ?? "",
+    userPrincipalName: "",
+    department: over.department ?? "",
+    accountEnabled: true,
+  },
+});
+
+const personRows = () =>
+  prisma.discoveredPerson.findMany({
+    where: { organizationId },
+    orderBy: [{ provider: "asc" }, { rawActorId: "asc" }],
+  });
+
+beforeEach(() =>
+  cleanupTestRows(prisma, [["discoveredPerson", { organizationId }]]),
+);
+
+afterAll(() =>
+  cleanupTestRows(prisma, [["discoveredPerson", { organizationId }]]),
+);
+
+describe("an actor on a pulled row", () => {
+  it("becomes a discovered person with the event's own time as both seen dates", async () => {
+    await service().recordFromPulledEvents({
+      organizationId,
+      provider: "openai_admin",
+      events: [activityEvent({})],
+    });
+
+    const rows = await personRows();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      provider: "openai_admin",
+      rawActorId: "m.silva@acme.test",
+      displayText: "m.silva@acme.test",
+      kind: DISCOVERED_PERSON_KIND.PERSON,
+      firstSeenAt: new Date("2026-08-10T12:00:00.000Z"),
+      lastSeenAt: new Date("2026-08-10T12:00:00.000Z"),
+    });
+  });
+
+  it("only ever widens the seen range on later sightings, in either direction", async () => {
+    const at = (iso: string) => activityEvent({ event_timestamp: iso });
+    await service().recordFromPulledEvents({
+      organizationId,
+      provider: "openai_admin",
+      events: [at("2026-08-10T12:00:00.000Z")],
+    });
+    // A later event moves last-seen forward and leaves first-seen alone; an
+    // earlier one — a September run backfilling July — does the opposite.
+    await service().recordFromPulledEvents({
+      organizationId,
+      provider: "openai_admin",
+      events: [at("2026-08-20T09:00:00.000Z"), at("2026-07-01T00:00:00.000Z")],
+    });
+
+    const rows = await personRows();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.firstSeenAt).toEqual(new Date("2026-07-01T00:00:00.000Z"));
+    expect(rows[0]?.lastSeenAt).toEqual(new Date("2026-08-20T09:00:00.000Z"));
+
+    // Replaying the whole window again changes nothing.
+    await service().recordFromPulledEvents({
+      organizationId,
+      provider: "openai_admin",
+      events: [at("2026-08-10T12:00:00.000Z"), at("2026-07-01T00:00:00.000Z")],
+    });
+    expect(await personRows()).toEqual(rows);
+  });
+
+  it("is two discovered people when two providers name the same email", async () => {
+    await service().recordFromPulledEvents({
+      organizationId,
+      provider: "openai_admin",
+      events: [activityEvent({})],
+    });
+    await service().recordFromPulledEvents({
+      organizationId,
+      provider: "anthropic_admin",
+      events: [activityEvent({})],
+    });
+
+    const rows = await personRows();
+    expect(rows.map((r) => r.provider)).toEqual([
+      "anthropic_admin",
+      "openai_admin",
+    ]);
+  });
+});
+
+describe("rows that must not become people", () => {
+  it("discovers nobody from an empty actor", async () => {
+    await service().recordFromPulledEvents({
+      organizationId,
+      provider: "copilot_studio_dataverse",
+      events: [activityEvent({ actor: "" })],
+    });
+    expect(await personRows()).toHaveLength(0);
+  });
+
+  it("records a bare-UUID Databricks actor as a machine login", async () => {
+    const uuid = "2f6b6a10-9f21-4d3a-8f01-6f2f1a9c1b2d";
+    await service().recordFromPulledEvents({
+      organizationId,
+      provider: "databricks_genie",
+      events: [activityEvent({ actor: uuid })],
+    });
+
+    const rows = await personRows();
+    expect(rows[0]?.kind).toBe(DISCOVERED_PERSON_KIND.SERVICE_ACCOUNT);
+  });
+
+  it("keeps a UUID-shaped directory id a person — the rule is Databricks', not a shape rule", async () => {
+    const oid = "f6481ec4-0000-4000-8000-2a8f29bb1c4a";
+    await service().recordFromPulledEvents({
+      organizationId,
+      provider: "copilot_studio_dataverse",
+      events: [directoryEvent({ actor: oid, displayName: "Maria Silva" })],
+    });
+
+    const rows = await personRows();
+    expect(rows[0]?.kind).toBe(DISCOVERED_PERSON_KIND.PERSON);
+  });
+});
+
+describe("a directory sighting", () => {
+  const oid = "f6481ec4-0000-4000-8000-2a8f29bb1c4a";
+
+  it("creates the person under their best name", async () => {
+    await service().recordFromPulledEvents({
+      organizationId,
+      provider: "copilot_studio_dataverse",
+      events: [directoryEvent({ actor: oid, displayName: "Maria Silva" })],
+    });
+
+    const rows = await personRows();
+    expect(rows[0]).toMatchObject({
+      rawActorId: oid,
+      displayText: "Maria Silva",
+    });
+  });
+
+  it("upgrades the display text of a person activity discovered as a bare id", async () => {
+    // Activity saw the id first — a transcript knows people only as GUIDs.
+    await service().recordFromPulledEvents({
+      organizationId,
+      provider: "copilot_studio_dataverse",
+      events: [activityEvent({ actor: oid, action: "conversation" })],
+    });
+    await service().recordFromPulledEvents({
+      organizationId,
+      provider: "copilot_studio_dataverse",
+      events: [directoryEvent({ actor: oid, displayName: "Maria Silva" })],
+    });
+
+    const rows = await personRows();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.displayText).toBe("Maria Silva");
+  });
+
+  it("never widens the seen range — a directory lists presence, not activity", async () => {
+    await service().recordFromPulledEvents({
+      organizationId,
+      provider: "copilot_studio_dataverse",
+      events: [
+        activityEvent({
+          actor: oid,
+          action: "conversation",
+          event_timestamp: "2026-08-10T12:00:00.000Z",
+        }),
+      ],
+    });
+    await service().recordFromPulledEvents({
+      organizationId,
+      provider: "copilot_studio_dataverse",
+      events: [
+        directoryEvent({
+          actor: oid,
+          displayName: "Maria Silva",
+          timestamp: "2026-09-02T00:00:00.000Z",
+        }),
+      ],
+    });
+
+    const rows = await personRows();
+    expect(rows[0]?.lastSeenAt).toEqual(new Date("2026-08-10T12:00:00.000Z"));
+  });
+
+  it("never rewrites an erased row's text", async () => {
+    // An erased person's key is a pseudonym, so a directory row's plaintext id
+    // cannot address it — this pins the belt-and-braces WHERE for the day a
+    // pseudonym ever collides with a real identifier.
+    await prisma.discoveredPerson.create({
+      data: {
+        organizationId,
+        provider: "copilot_studio_dataverse",
+        rawActorId: oid,
+        displayText: "pseudonym_abc",
+        kind: DISCOVERED_PERSON_KIND.PERSON,
+        firstSeenAt: new Date("2026-08-01T00:00:00.000Z"),
+        lastSeenAt: new Date("2026-08-01T00:00:00.000Z"),
+        erasedAt: new Date("2026-09-01T00:00:00.000Z"),
+      },
+    });
+
+    await service().recordFromPulledEvents({
+      organizationId,
+      provider: "copilot_studio_dataverse",
+      events: [directoryEvent({ actor: oid, displayName: "Maria Silva" })],
+    });
+
+    const rows = await personRows();
+    expect(rows[0]?.displayText).toBe("pseudonym_abc");
+  });
+});

--- a/platform/app/ee/governance/services/directoryDepartmentSync.service.ts
+++ b/platform/app/ee/governance/services/directoryDepartmentSync.service.ts
@@ -103,6 +103,25 @@ export class DirectoryDepartmentSyncService {
     }
     if (desired.size === 0) return { assigned: 0 };
 
+    const assigned = await this.assignWhereChanged({ organizationId, desired });
+
+    if (assigned > 0) {
+      logger.info(
+        { organizationId, assigned },
+        "directory departments assigned to proven members",
+      );
+    }
+    return { assigned };
+  }
+
+  /** Writes each changed assignment, resolving each department name once. */
+  private async assignWhereChanged({
+    organizationId,
+    desired,
+  }: {
+    organizationId: string;
+    desired: Map<string, string>;
+  }): Promise<number> {
     const memberships = await this.prisma.organizationUser.findMany({
       where: { organizationId, userId: { in: [...desired.keys()] } },
       select: { userId: true, departmentId: true },
@@ -134,14 +153,7 @@ export class DirectoryDepartmentSyncService {
       });
       assigned += 1;
     }
-
-    if (assigned > 0) {
-      logger.info(
-        { organizationId, assigned },
-        "directory departments assigned to proven members",
-      );
-    }
-    return { assigned };
+    return assigned;
   }
 }
 

--- a/platform/app/ee/governance/services/directoryDepartmentSync.service.ts
+++ b/platform/app/ee/governance/services/directoryDepartmentSync.service.ts
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+
+/**
+ * The directory's department field, landed on the entities we already have.
+ *
+ * SCIM provisioning has mapped directory-asserted department text onto
+ * `Department` rows for a while (costCenter → `resolveByNameOrCreate` +
+ * `assignUser`, `scim.service.ts`). This service is the same mapping for
+ * organizations whose directory we READ rather than are pushed by: a pulled
+ * directory row carries the tenant's own department string, and it lands
+ * through the identical two calls — no parallel department shape, no free
+ * text on the person row.
+ *
+ * Who a row may assign is decided by the match engine's own proof standard,
+ * through the same account index (`loadAccountIndex`): the directory id the
+ * org's SSO connection recorded, or an address a member has CONFIRMED. An
+ * unconfirmed address is a claim anyone can type in, and two candidates are
+ * a contradiction, not a coin toss — both assign nobody.
+ *
+ * Two deliberate divergences from the SCIM push:
+ *
+ *  - a BLANK department leaves the member's assignment alone, where SCIM
+ *    clears it. A pull is an observation, not a provisioning command; Entra
+ *    tenants routinely leave the field blank, and blank must not erase an
+ *    admin's hand-work once a day;
+ *  - rows proving no member do nothing here at all. They still become
+ *    discovered people (personDiscovery.service.ts), and the day one is
+ *    linked, the next directory read assigns their department unasked.
+ *
+ * Fed with KEPT events only, like every consumer downstream of the erasure
+ * partition — a directory row naming an erased identifier never reaches
+ * here.
+ *
+ * Spec: specs/governance/governance-people-discovery.feature
+ */
+
+import { createLogger } from "@langwatch/observability";
+import type { PrismaClient } from "~/generated/prisma/client";
+
+import { DepartmentService } from "./department/department.service";
+import { IdentityMatchService } from "./identityMatch.service";
+import {
+  normalizeEmail,
+  type OrganizationAccountIndex,
+} from "./logic/identityEvidence";
+import { DIRECTORY_REPORT_ACTION } from "./pullers/microsoftGraphDirectory";
+import type { NormalizedPullEvent } from "./pullers/pullerAdapter";
+
+const logger = createLogger("langwatch:governance:directory-departments");
+
+/** A string field off an event's `extra`, or "" for anything else. */
+function extraString(event: NormalizedPullEvent, field: string): string {
+  const value = event.extra?.[field];
+  return typeof value === "string" ? value : "";
+}
+
+export class DirectoryDepartmentSyncService {
+  private readonly prisma: PrismaClient;
+  private readonly departments: DepartmentService;
+  private readonly matcher: IdentityMatchService;
+
+  constructor({ prisma }: { prisma: PrismaClient }) {
+    this.prisma = prisma;
+    this.departments = DepartmentService.create(prisma);
+    this.matcher = IdentityMatchService.create(prisma);
+  }
+
+  static create(prisma: PrismaClient): DirectoryDepartmentSyncService {
+    return new DirectoryDepartmentSyncService({ prisma });
+  }
+
+  /**
+   * Applies whatever department facts a batch of directory events carries.
+   *
+   * One account-index load per batch, one department resolve per distinct
+   * name, and no write at all for a member already where the directory says
+   * they belong — the read runs daily, and an idempotent day must cost
+   * nothing.
+   */
+  async applyDirectoryEvents({
+    organizationId,
+    events,
+  }: {
+    organizationId: string;
+    events: NormalizedPullEvent[];
+  }): Promise<{ assigned: number }> {
+    const rows = events.filter(
+      (event) =>
+        event.action === DIRECTORY_REPORT_ACTION &&
+        extraString(event, "department").trim() !== "",
+    );
+    if (rows.length === 0) return { assigned: 0 };
+
+    const accounts = await this.matcher.loadAccountIndex({ organizationId });
+
+    // userId → department name, resolved through the proof rule. Built first
+    // so the current-assignment read below is one query for the whole batch.
+    const desired = new Map<string, string>();
+    for (const row of rows) {
+      const department = extraString(row, "department").trim();
+      const userId = provenUserId({ row, accounts });
+      if (userId !== null) desired.set(userId, department);
+    }
+    if (desired.size === 0) return { assigned: 0 };
+
+    const memberships = await this.prisma.organizationUser.findMany({
+      where: { organizationId, userId: { in: [...desired.keys()] } },
+      select: { userId: true, departmentId: true },
+    });
+    const currentByUser = new Map(
+      memberships.map((m) => [m.userId, m.departmentId]),
+    );
+
+    const departmentByName = new Map<string, string>();
+    let assigned = 0;
+    for (const [userId, name] of desired) {
+      // Proof can point at a user who is not a member of THIS organization
+      // (a verified address is global). No membership row, nothing to assign.
+      if (!currentByUser.has(userId)) continue;
+
+      let departmentId = departmentByName.get(name);
+      if (departmentId === undefined) {
+        departmentId = (
+          await this.departments.resolveByNameOrCreate({ organizationId, name })
+        ).id;
+        departmentByName.set(name, departmentId);
+      }
+
+      if (currentByUser.get(userId) === departmentId) continue;
+      await this.departments.assignUser({
+        organizationId,
+        userId,
+        departmentId,
+      });
+      assigned += 1;
+    }
+
+    if (assigned > 0) {
+      logger.info(
+        { organizationId, assigned },
+        "directory departments assigned to proven members",
+      );
+    }
+    return { assigned };
+  }
+}
+
+/**
+ * The one member a directory row proves, or null.
+ *
+ * The directory id is checked first — it is the identifier the row IS keyed
+ * by — and the confirmed address second. Either way, exactly one candidate
+ * or nobody: the engine suspends automatic linking on a contradiction, and
+ * an assignment must not out-run the engine's own caution.
+ */
+function provenUserId({
+  row,
+  accounts,
+}: {
+  row: NormalizedPullEvent;
+  accounts: OrganizationAccountIndex;
+}): string | null {
+  const byDirectory = accounts.usersByDirectoryId.get(row.actor) ?? [];
+  if (byDirectory.length === 1) return byDirectory[0] ?? null;
+  if (byDirectory.length > 1) return null;
+
+  const mailKey = normalizeEmail(extraString(row, "mail"));
+  if (mailKey === null) return null;
+  const byMail = accounts.usersByVerifiedEmail.get(mailKey) ?? [];
+  return byMail.length === 1 ? (byMail[0] ?? null) : null;
+}

--- a/platform/app/ee/governance/services/governancePeopleScreen.service.ts
+++ b/platform/app/ee/governance/services/governancePeopleScreen.service.ts
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+
+/**
+ * The People screen's reads, composed once on the server.
+ *
+ * The screen shows three things no single table holds: what a provider said
+ * (the discovered person), what the engine decided (the open link and its
+ * evidence), and where the linked member sits (name and department). Joining
+ * them here rather than in the page keeps the page on one query and keeps
+ * the join rules — an erased person shows a stand-in, a link with a blanked
+ * user shows as unlinked — in code a test can hold down.
+ *
+ * Spec: specs/governance/governance-people-screen.feature
+ */
+
+import type { PrismaClient } from "~/generated/prisma/client";
+
+import {
+  DiscoveredPersonRepository,
+  IdentityMatchRepository,
+  IdentityMatchSuggestionRepository,
+  OrganizationAccountDirectoryRepository,
+} from "../repositories/governanceIdentity.repository";
+import { DepartmentService } from "./department/department.service";
+
+export interface PeopleScreenPerson {
+  id: string;
+  provider: string;
+  kind: string;
+  /** The pseudonym when erased — the identifier column IS this text then. */
+  displayText: string;
+  rawActorId: string;
+  firstSeenAt: Date;
+  lastSeenAt: Date;
+  erasedAt: Date | null;
+  suspendedAt: Date | null;
+  suspendedReason: string | null;
+  link: {
+    userId: string;
+    evidenceKind: string;
+    memberName: string | null;
+    departmentName: string | null;
+  } | null;
+}
+
+export interface PeopleScreenSuggestion {
+  id: string;
+  discoveredPersonId: string;
+  personDisplayText: string;
+  personProvider: string;
+  userId: string;
+  memberName: string | null;
+  score: number;
+}
+
+export class GovernancePeopleScreenService {
+  private readonly prisma: PrismaClient;
+  private readonly people = new DiscoveredPersonRepository();
+  private readonly matches = new IdentityMatchRepository();
+  private readonly suggestions = new IdentityMatchSuggestionRepository();
+  private readonly accounts = new OrganizationAccountDirectoryRepository();
+  private readonly departments: DepartmentService;
+
+  constructor({ prisma }: { prisma: PrismaClient }) {
+    this.prisma = prisma;
+    this.departments = DepartmentService.create(prisma);
+  }
+
+  static create(prisma: PrismaClient): GovernancePeopleScreenService {
+    return new GovernancePeopleScreenService({ prisma });
+  }
+
+  /** Everyone the providers named, newest-seen first, with the engine's verdicts. */
+  async listPeople({
+    organizationId,
+  }: {
+    organizationId: string;
+  }): Promise<PeopleScreenPerson[]> {
+    const [people, openLinks, memberNames, departmentRows, assignments] =
+      await Promise.all([
+        this.people.listByOrganization(this.prisma, { organizationId }),
+        this.matches.findOpenByOrganization(this.prisma, { organizationId }),
+        this.accounts.findMemberNames(this.prisma, { organizationId }),
+        this.departments.getAll({ organizationId }),
+        this.departments.getAssignments({ organizationId }),
+      ]);
+
+    const linkByPerson = new Map(
+      openLinks.map((link) => [link.discoveredPersonId, link]),
+    );
+    const nameByUser = new Map(memberNames.map((m) => [m.userId, m.name]));
+    const departmentNameById = new Map(
+      departmentRows.map((d) => [d.id, d.name]),
+    );
+    const departmentIdByUser = new Map(
+      assignments.users.map((u) => [u.id, u.departmentId]),
+    );
+
+    return people.map((person) => {
+      const open = linkByPerson.get(person.id);
+      // `findOpenByOrganization` already excludes blanked links, so a link
+      // here always names a user; the null check keeps the type honest.
+      const link =
+        open?.userId == null
+          ? null
+          : {
+              userId: open.userId,
+              evidenceKind: open.evidenceKind,
+              memberName: nameByUser.get(open.userId) ?? null,
+              departmentName: (() => {
+                const departmentId = departmentIdByUser.get(open.userId);
+                return departmentId
+                  ? (departmentNameById.get(departmentId) ?? null)
+                  : null;
+              })(),
+            };
+      return {
+        id: person.id,
+        provider: person.provider,
+        kind: person.kind,
+        displayText: person.displayText,
+        rawActorId: person.rawActorId,
+        firstSeenAt: person.firstSeenAt,
+        lastSeenAt: person.lastSeenAt,
+        erasedAt: person.erasedAt,
+        suspendedAt: person.suspendedAt,
+        suspendedReason: person.suspendedReason,
+        link,
+      };
+    });
+  }
+
+  /** The review queue with both halves named, strongest candidate first. */
+  async listSuggestions({
+    organizationId,
+  }: {
+    organizationId: string;
+  }): Promise<PeopleScreenSuggestion[]> {
+    const [rows, people, memberNames] = await Promise.all([
+      this.suggestions.findAllByOrganization(this.prisma, { organizationId }),
+      this.people.listByOrganization(this.prisma, { organizationId }),
+      this.accounts.findMemberNames(this.prisma, { organizationId }),
+    ]);
+
+    const personById = new Map(people.map((p) => [p.id, p]));
+    const nameByUser = new Map(memberNames.map((m) => [m.userId, m.name]));
+
+    return rows.flatMap((row) => {
+      const person = personById.get(row.discoveredPersonId);
+      // A suggestion whose person is gone is a row the next recompute drops;
+      // showing a half it cannot name helps nobody meanwhile.
+      if (!person) return [];
+      return [
+        {
+          id: row.id,
+          discoveredPersonId: row.discoveredPersonId,
+          personDisplayText: person.displayText,
+          personProvider: person.provider,
+          userId: row.userId,
+          memberName: nameByUser.get(row.userId) ?? null,
+          score: row.score,
+        },
+      ];
+    });
+  }
+}

--- a/platform/app/ee/governance/services/identityMatch.errors.ts
+++ b/platform/app/ee/governance/services/identityMatch.errors.ts
@@ -85,7 +85,7 @@ export class IdentityErasedError extends HandledError {
   }
 }
 
-/** Postgres' unique-violation code, raised by the one-open-link index. */
+/** Postgres' unique-violation code. */
 const UNIQUE_VIOLATION = "23505";
 
 /**
@@ -98,8 +98,8 @@ const UNIQUE_VIOLATION = "23505";
 const PRISMA_UNIQUE_VIOLATION = "P2002";
 
 /**
- * Whether a thrown value is the one-open-link index refusing a second open
- * link.
+ * Whether a thrown value is Postgres refusing a duplicate under any unique
+ * rule.
  *
  * Reads the code off whichever shape carried it: Prisma's `P2002` wrapper, a
  * raw driver error's SQLSTATE in `code` or `meta.code`, or — for the wrapper
@@ -107,7 +107,7 @@ const PRISMA_UNIQUE_VIOLATION = "P2002";
  * the message. Never a `String(err).includes` over the whole message: that
  * would also match an error whose *payload* happened to contain the digits.
  */
-export function isOpenLinkViolation(error: unknown): boolean {
+export function isUniqueViolation(error: unknown): boolean {
   if (typeof error !== "object" || error === null) return false;
   const code = (error as { code?: unknown }).code;
   if (code === UNIQUE_VIOLATION || code === PRISMA_UNIQUE_VIOLATION)
@@ -119,4 +119,13 @@ export function isOpenLinkViolation(error: unknown): boolean {
     typeof message === "string" &&
     new RegExp(`\\b${UNIQUE_VIOLATION}\\b`).test(message)
   );
+}
+
+/**
+ * Whether a thrown value is the one-open-link index refusing a second open
+ * link. The same refusal shape as any unique violation; the name records
+ * which rule the caller believes it tripped (`IdentityMatch` has no other).
+ */
+export function isOpenLinkViolation(error: unknown): boolean {
+  return isUniqueViolation(error);
 }

--- a/platform/app/ee/governance/services/identityMatch.errors.ts
+++ b/platform/app/ee/governance/services/identityMatch.errors.ts
@@ -2,9 +2,10 @@
 
 /**
  * What the match engine refuses to do, said in words the reviewer can act on
- * (ADR-128 §12).
+ * (ADR-128 §12) — plus the domain's shared reading of Postgres refusing a
+ * duplicate, which the discovery repository leans on too.
  *
- * Both of these are races rather than mistakes: a review queue is read by
+ * The error classes are races rather than mistakes: a review queue is read by
  * people, and between reading it and clicking, the world moves. The whole point
  * of naming them is that the loser of such a race should be told what happened,
  * not handed a trace id.
@@ -91,9 +92,9 @@ const UNIQUE_VIOLATION = "23505";
 /**
  * Prisma's own code for the same refusal: the client wraps a unique violation
  * as a `PrismaClientKnownRequestError` with `code: "P2002"` and buries the
- * SQLSTATE underneath. `IdentityMatch` has no other unique rule a write could
- * trip (the primary key is a fresh nanoid), so `P2002` on these writes means
- * the one-open-link index and nothing else.
+ * SQLSTATE underneath. Which unique rule tripped is the caller's knowledge —
+ * the one-open-link index for `IdentityMatch` writes, the (organization,
+ * provider, actor) key for discovered-person writes.
  */
 const PRISMA_UNIQUE_VIOLATION = "P2002";
 

--- a/platform/app/ee/governance/services/personDiscovery.service.ts
+++ b/platform/app/ee/governance/services/personDiscovery.service.ts
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+
+/**
+ * The feed that discovers people (ADR-128 §10–11).
+ *
+ * Every pulled row already names who did the thing; until this service,
+ * those names were read for money and audit and then forgotten — nothing
+ * wrote them down as people, the match engine swept an empty list, and the
+ * People screen had nobody to show. This is the producer the engine spec
+ * promised ("the trigger arrives with the feed that discovers people"),
+ * minus the trigger, which stays a button a person presses.
+ *
+ * Fed exclusively with events that already passed the erasure suppression
+ * check — the worker hands it the KEPT half of the partition. That ordering
+ * is load-bearing: the pullers re-read a thirty-day window, so discovery
+ * running before that check would re-create a plaintext person row the day
+ * after every erasure.
+ *
+ * Two sighting kinds, deliberately unequal:
+ *
+ *  - an ACTIVITY row (a cost line, a query, a conversation) creates the
+ *    person and widens their seen range — those dates mean "was active";
+ *  - a DIRECTORY row creates the person and upgrades their display text,
+ *    but never touches the seen range — a directory lists presence, and a
+ *    person refreshed daily by it must not read as "active today".
+ *
+ * Spec: specs/governance/governance-people-discovery.feature
+ */
+
+import type { PrismaClient } from "~/generated/prisma/client";
+
+import {
+  DISCOVERED_PERSON_KIND,
+  DiscoveredPersonRepository,
+} from "../repositories/governanceIdentity.repository";
+import { DIRECTORY_REPORT_ACTION } from "./pullers/microsoftGraphDirectory";
+import type { NormalizedPullEvent } from "./pullers/pullerAdapter";
+
+/**
+ * ADR-128 §10's deterministic service-account rule, and nothing looser: in
+ * Databricks query history humans surface as emails and service principals
+ * as bare UUIDs (proven under app-only auth). Provider-specific on purpose —
+ * a directory id is UUID-shaped everywhere Microsoft touches, and those are
+ * people.
+ */
+const DATABRICKS_PROVIDER = "databricks_genie";
+const BARE_UUID =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function kindOf({
+  provider,
+  rawActorId,
+}: {
+  provider: string;
+  rawActorId: string;
+}): string {
+  return provider === DATABRICKS_PROVIDER && BARE_UUID.test(rawActorId)
+    ? DISCOVERED_PERSON_KIND.SERVICE_ACCOUNT
+    : DISCOVERED_PERSON_KIND.PERSON;
+}
+
+/** A string field off an event's `extra`, or "" for anything else. */
+function extraString(event: NormalizedPullEvent, field: string): string {
+  const value = event.extra?.[field];
+  return typeof value === "string" ? value : "";
+}
+
+export class PersonDiscoveryService {
+  private readonly prisma: PrismaClient;
+  private readonly people: DiscoveredPersonRepository;
+
+  constructor({ prisma }: { prisma: PrismaClient }) {
+    this.prisma = prisma;
+    this.people = new DiscoveredPersonRepository();
+  }
+
+  static create(prisma: PrismaClient): PersonDiscoveryService {
+    return new PersonDiscoveryService({ prisma });
+  }
+
+  /**
+   * Records everyone a batch of pulled events names.
+   *
+   * One write per distinct actor, not per event: a batch is routinely
+   * thousands of rows naming a handful of people, and the repository's
+   * widen-only writes make replaying the same window a no-op.
+   *
+   * Rows naming nobody (`actor === ""`) discover nobody — seat reports
+   * deliberately name no person, and inventing one would attribute the
+   * tenant's procurement to a blank string.
+   */
+  async recordFromPulledEvents({
+    organizationId,
+    provider,
+    events,
+  }: {
+    organizationId: string;
+    /** The source type, which is what `DiscoveredPerson.provider` holds. */
+    provider: string;
+    events: NormalizedPullEvent[];
+  }): Promise<{ discovered: number }> {
+    const activityByActor = new Map<
+      string,
+      { earliestAt: Date; latestAt: Date }
+    >();
+    const directoryByActor = new Map<
+      string,
+      { displayText: string; seenAt: Date }
+    >();
+
+    for (const event of events) {
+      if (event.actor === "") continue;
+      const seenAt = new Date(event.event_timestamp);
+      // An adapter that emitted an unparseable timestamp gets its event
+      // recorded elsewhere; a seen-date of `Invalid Date` would poison the
+      // widen comparisons for everyone sharing the row.
+      if (Number.isNaN(seenAt.getTime())) continue;
+
+      if (event.action === DIRECTORY_REPORT_ACTION) {
+        // The best name the row offers, falling back to the address and
+        // finally the id itself — a person must never render as "".
+        const displayText =
+          extraString(event, "displayName") ||
+          extraString(event, "mail") ||
+          extraString(event, "userPrincipalName") ||
+          event.actor;
+        directoryByActor.set(event.actor, { displayText, seenAt });
+        continue;
+      }
+
+      const range = activityByActor.get(event.actor);
+      if (!range) {
+        activityByActor.set(event.actor, {
+          earliestAt: seenAt,
+          latestAt: seenAt,
+        });
+      } else {
+        if (seenAt < range.earliestAt) range.earliestAt = seenAt;
+        if (seenAt > range.latestAt) range.latestAt = seenAt;
+      }
+    }
+
+    for (const [rawActorId, range] of activityByActor) {
+      await this.people.recordActivitySighting(this.prisma, {
+        organizationId,
+        provider,
+        rawActorId,
+        displayText: rawActorId,
+        kind: kindOf({ provider, rawActorId }),
+        earliestAt: range.earliestAt,
+        latestAt: range.latestAt,
+      });
+    }
+    for (const [rawActorId, sighting] of directoryByActor) {
+      await this.people.recordDirectorySighting(this.prisma, {
+        organizationId,
+        provider,
+        rawActorId,
+        displayText: sighting.displayText,
+        seenAt: sighting.seenAt,
+      });
+    }
+
+    return { discovered: activityByActor.size + directoryByActor.size };
+  }
+}

--- a/platform/app/ee/governance/services/personDiscovery.service.ts
+++ b/platform/app/ee/governance/services/personDiscovery.service.ts
@@ -99,46 +99,7 @@ export class PersonDiscoveryService {
     provider: string;
     events: NormalizedPullEvent[];
   }): Promise<{ discovered: number }> {
-    const activityByActor = new Map<
-      string,
-      { earliestAt: Date; latestAt: Date }
-    >();
-    const directoryByActor = new Map<
-      string,
-      { displayText: string; seenAt: Date }
-    >();
-
-    for (const event of events) {
-      if (event.actor === "") continue;
-      const seenAt = new Date(event.event_timestamp);
-      // An adapter that emitted an unparseable timestamp gets its event
-      // recorded elsewhere; a seen-date of `Invalid Date` would poison the
-      // widen comparisons for everyone sharing the row.
-      if (Number.isNaN(seenAt.getTime())) continue;
-
-      if (event.action === DIRECTORY_REPORT_ACTION) {
-        // The best name the row offers, falling back to the address and
-        // finally the id itself — a person must never render as "".
-        const displayText =
-          extraString(event, "displayName") ||
-          extraString(event, "mail") ||
-          extraString(event, "userPrincipalName") ||
-          event.actor;
-        directoryByActor.set(event.actor, { displayText, seenAt });
-        continue;
-      }
-
-      const range = activityByActor.get(event.actor);
-      if (!range) {
-        activityByActor.set(event.actor, {
-          earliestAt: seenAt,
-          latestAt: seenAt,
-        });
-      } else {
-        if (seenAt < range.earliestAt) range.earliestAt = seenAt;
-        if (seenAt > range.latestAt) range.latestAt = seenAt;
-      }
-    }
+    const { activityByActor, directoryByActor } = bucketByActor(events);
 
     for (const [rawActorId, range] of activityByActor) {
       await this.people.recordActivitySighting(this.prisma, {
@@ -163,4 +124,68 @@ export class PersonDiscoveryService {
 
     return { discovered: activityByActor.size + directoryByActor.size };
   }
+}
+
+/** One entry per distinct actor: activity as a seen range, directory as the freshest name. */
+function bucketByActor(events: NormalizedPullEvent[]): {
+  activityByActor: Map<string, { earliestAt: Date; latestAt: Date }>;
+  directoryByActor: Map<string, { displayText: string; seenAt: Date }>;
+} {
+  const activityByActor = new Map<
+    string,
+    { earliestAt: Date; latestAt: Date }
+  >();
+  const directoryByActor = new Map<
+    string,
+    { displayText: string; seenAt: Date }
+  >();
+
+  for (const event of events) {
+    if (event.actor === "") continue;
+    const seenAt = new Date(event.event_timestamp);
+    // An adapter that emitted an unparseable timestamp gets its event
+    // recorded elsewhere; a seen-date of `Invalid Date` would poison the
+    // widen comparisons for everyone sharing the row.
+    if (Number.isNaN(seenAt.getTime())) continue;
+
+    if (event.action === DIRECTORY_REPORT_ACTION) {
+      directoryByActor.set(event.actor, {
+        displayText: directoryDisplayText(event),
+        seenAt,
+      });
+      continue;
+    }
+
+    widenRange(activityByActor, event.actor, seenAt);
+  }
+
+  return { activityByActor, directoryByActor };
+}
+
+/**
+ * The best name a directory row offers, falling back to the address and
+ * finally the id itself — a person must never render as "".
+ */
+function directoryDisplayText(event: NormalizedPullEvent): string {
+  return (
+    extraString(event, "displayName") ||
+    extraString(event, "mail") ||
+    extraString(event, "userPrincipalName") ||
+    event.actor
+  );
+}
+
+/** Stretches the actor's seen range to include this sighting. */
+function widenRange(
+  activityByActor: Map<string, { earliestAt: Date; latestAt: Date }>,
+  actor: string,
+  seenAt: Date,
+): void {
+  const range = activityByActor.get(actor);
+  if (!range) {
+    activityByActor.set(actor, { earliestAt: seenAt, latestAt: seenAt });
+    return;
+  }
+  if (seenAt < range.earliestAt) range.earliestAt = seenAt;
+  if (seenAt > range.latestAt) range.latestAt = seenAt;
 }

--- a/platform/app/ee/governance/services/pullers/__tests__/copilotStudioDataverseCost.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/copilotStudioDataverseCost.unit.test.ts
@@ -170,6 +170,7 @@ async function runPull({
       botIds: [],
       // Off throughout this file: the licence read has its own, next door.
       readSeats: false,
+      readDirectory: false,
       ...(azureSubscriptionId === undefined ? {} : { azureSubscriptionId }),
     },
   );

--- a/platform/app/ee/governance/services/pullers/__tests__/copilotStudioDataverseDirectory.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/copilotStudioDataverseDirectory.unit.test.ts
@@ -144,7 +144,7 @@ async function runPull({
       botIds: [],
       // Licences off so every Graph call in these tests is the directory's.
       readSeats: false,
-      ...(readDirectory === undefined ? {} : { readDirectory }),
+      readDirectory: readDirectory ?? false,
     },
   );
 }

--- a/platform/app/ee/governance/services/pullers/__tests__/copilotStudioDataverseDirectory.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/copilotStudioDataverseDirectory.unit.test.ts
@@ -1,0 +1,276 @@
+// SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+
+/**
+ * The directory read living inside the Dataverse source.
+ *
+ * The same two rules the seat read is held to: it degrades rather than
+ * throwing (an error count against an unmoved cursor discards the run whole,
+ * conversations included), and it neither holds nor is held by the other
+ * reads. Plus its own two: it is OFF unless switched on — the User.Read.All
+ * consent hands this source every name in the tenant, and an admin should
+ * turn that on deliberately — and its page walk is all or nothing, because a
+ * directory reported from half its pages would list half the tenant with
+ * nothing marking the rest missing.
+ *
+ * Spec: specs/governance/governance-people-discovery.feature
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { RedirectRefusedError } from "~/utils/ssrfProtection";
+
+interface FetchCall {
+  url: string;
+  init: (RequestInit & { followRedirects?: boolean }) | undefined;
+}
+
+const ENVIRONMENT_URL = "https://org12345.crm.dynamics.com";
+const CREDENTIALS = {
+  tenantId: "aaaaaaaa-0000-4000-8000-000000000001",
+  clientId: "app-client-id",
+  clientSecret: "app-client-secret",
+};
+const BOT_ID = "bbbbbbbb-0000-4000-8000-000000000002";
+const USER_ID = "f6481ec4-e30f-4bf3-954f-2a8f29bb1c4a";
+const SECOND_USER_ID = "0a2b3c4d-0000-4000-8000-000000000009";
+
+const today = () => new Date().toISOString().slice(0, 10);
+
+let capturedCalls: FetchCall[] = [];
+let warnings: string[] = [];
+let errors: string[] = [];
+/** What Graph answers each successive /users call with. */
+let usersReplies: Array<{ status: number; body: unknown }> = [];
+
+function captured(args: unknown[]): string {
+  return args
+    .map((arg) => (typeof arg === "string" ? arg : JSON.stringify(arg)))
+    .join(" ");
+}
+
+const graphUser = (over: Record<string, unknown> = {}) => ({
+  id: USER_ID,
+  displayName: "Maria Silva",
+  mail: "m.silva@acme.test",
+  userPrincipalName: "m.silva@acme.test",
+  department: "Engineering",
+  accountEnabled: true,
+  ...over,
+});
+
+function transcriptRow() {
+  return {
+    conversationtranscriptid: "11111111-1111-4111-8111-111111111111",
+    name: "cccccccc-0000-4000-8000-000000000003_agent-one",
+    conversationstarttime: "2026-08-25T19:14:34Z",
+    createdon: "2026-08-25T19:44:43Z",
+    metadata: JSON.stringify({ BotId: "agent-one", BatchId: 0 }),
+    content: JSON.stringify({ activities: [] }),
+    _bot_conversationtranscriptid_value: BOT_ID,
+  };
+}
+
+beforeEach(() => {
+  capturedCalls = [];
+  warnings = [];
+  errors = [];
+  usersReplies = [];
+
+  vi.doMock("@langwatch/observability", async (importOriginal) => ({
+    ...(await importOriginal<Record<string, unknown>>()),
+    createLogger: () => ({
+      warn: (...args: unknown[]) => warnings.push(captured(args)),
+      error: (...args: unknown[]) => errors.push(captured(args)),
+      info: () => undefined,
+      debug: () => undefined,
+    }),
+  }));
+
+  vi.doMock("~/utils/ssrfProtection", () => ({
+    RedirectRefusedError,
+    ssrfSafeFetch: async (url: string, init?: RequestInit) => {
+      capturedCalls.push({ url, init });
+
+      if (url.includes("login.microsoftonline.com")) {
+        return new Response(JSON.stringify({ access_token: "a-token" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (url.includes("graph.microsoft.com")) {
+        const next = usersReplies.shift() ?? {
+          status: 200,
+          body: { value: [graphUser()] },
+        };
+        return new Response(JSON.stringify(next.body), {
+          status: next.status,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (url.includes("/bots")) {
+        return new Response(
+          JSON.stringify({ value: [{ botid: BOT_ID, name: "eng-agent" }] }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      return new Response(JSON.stringify({ value: [transcriptRow()] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    },
+  }));
+});
+
+afterEach(() => {
+  vi.resetModules();
+  vi.clearAllMocks();
+});
+
+async function runPull({
+  readDirectory,
+  cursor = null,
+}: {
+  readDirectory?: boolean;
+  cursor?: string | null;
+}) {
+  const { CopilotStudioDataversePuller } = await import(
+    "../copilotStudioDataverse.puller"
+  );
+  const adapter = new CopilotStudioDataversePuller();
+  return adapter.runOnce(
+    { cursor, credentials: CREDENTIALS },
+    {
+      adapter: "copilot_studio_dataverse" as const,
+      environmentUrl: ENVIRONMENT_URL,
+      botIds: [],
+      // Licences off so every Graph call in these tests is the directory's.
+      readSeats: false,
+      ...(readDirectory === undefined ? {} : { readDirectory }),
+    },
+  );
+}
+
+const usersCalls = () =>
+  capturedCalls.filter((call) => call.url.includes("/v1.0/users"));
+const directoryEvents = <T extends { action: string }>(events: T[]) =>
+  events.filter((event) => event.action === "directory_report");
+const conversationEvents = <T extends { action: string }>(events: T[]) =>
+  events.filter((event) => event.action !== "directory_report");
+const storedDirectoryDay = (cursor: string | null): string | null =>
+  cursor ? (JSON.parse(cursor).directoryReportedThroughDay ?? null) : null;
+
+describe("the directory read inside the Dataverse source", () => {
+  describe("when nobody has switched it on", () => {
+    /** @scenario "The directory is not read unless switched on" */
+    it("asks Graph nothing, by default and when off explicitly", async () => {
+      await runPull({});
+      expect(usersCalls()).toHaveLength(0);
+
+      await runPull({ readDirectory: false });
+      expect(usersCalls()).toHaveLength(0);
+    });
+  });
+
+  describe("when the source reads the directory", () => {
+    it("records a directory event per user beside the conversations", async () => {
+      const result = await runPull({ readDirectory: true });
+
+      const directory = directoryEvents(result.events);
+      expect(directory).toHaveLength(1);
+      expect(directory[0]).toMatchObject({
+        actor: USER_ID,
+        target: "Engineering",
+      });
+      expect(conversationEvents(result.events)).toHaveLength(1);
+      expect(result.errorCount).toBe(0);
+      expect(storedDirectoryDay(result.cursor)).toBe(today());
+    });
+
+    it("selects only the fields it records, and keeps the token off redirects", async () => {
+      await runPull({ readDirectory: true });
+      const [call] = usersCalls();
+
+      expect(call?.url).toContain(
+        "$select=id,displayName,mail,userPrincipalName,department,accountEnabled",
+      );
+      expect(call?.init?.followRedirects).toBe(false);
+    });
+
+    /** @scenario "The directory is read once a day, not once a tick" */
+    it("asks nothing on a day already reported", async () => {
+      const first = await runPull({ readDirectory: true });
+      expect(usersCalls()).toHaveLength(1);
+
+      await runPull({ readDirectory: true, cursor: first.cursor });
+      expect(usersCalls()).toHaveLength(1);
+    });
+
+    it("follows Graph's own next link and records both pages as one day", async () => {
+      usersReplies = [
+        {
+          status: 200,
+          body: {
+            value: [graphUser()],
+            "@odata.nextLink":
+              "https://graph.microsoft.com/v1.0/users?$skiptoken=page2",
+          },
+        },
+        { status: 200, body: { value: [graphUser({ id: SECOND_USER_ID })] } },
+      ];
+
+      const result = await runPull({ readDirectory: true });
+
+      expect(usersCalls()).toHaveLength(2);
+      expect(directoryEvents(result.events)).toHaveLength(2);
+      expect(storedDirectoryDay(result.cursor)).toBe(today());
+    });
+
+    it("refuses a next link that is not Microsoft Graph, and holds the day", async () => {
+      usersReplies = [
+        {
+          status: 200,
+          body: {
+            value: [graphUser()],
+            "@odata.nextLink": "https://evil.test/v1.0/users?$skiptoken=x",
+          },
+        },
+      ];
+
+      const result = await runPull({ readDirectory: true });
+
+      expect(usersCalls()).toHaveLength(1);
+      expect(directoryEvents(result.events)).toHaveLength(0);
+      expect(conversationEvents(result.events)).toHaveLength(1);
+      expect(storedDirectoryDay(result.cursor)).toBeNull();
+      expect(errors.some((line) => line.includes("not Microsoft Graph"))).toBe(
+        true,
+      );
+    });
+  });
+
+  describe("when the tenant refuses or garbles the read", () => {
+    /** @scenario "A directory read that fails holds the day and delivers the rest" */
+    it("names an HTTP 403 for what it is and still delivers the conversations", async () => {
+      usersReplies = [{ status: 403, body: {} }];
+
+      const result = await runPull({ readDirectory: true });
+
+      expect(
+        warnings.some((line) =>
+          line.includes("has not consented to the directory read"),
+        ),
+      ).toBe(true);
+      expect(conversationEvents(result.events)).toHaveLength(1);
+      expect(result.errorCount).toBe(0);
+      expect(storedDirectoryDay(result.cursor)).toBeNull();
+    });
+
+    it("holds a body that is not a page rather than recording an empty tenant", async () => {
+      usersReplies = [{ status: 200, body: { error: "oops" } }];
+
+      const result = await runPull({ readDirectory: true });
+
+      expect(directoryEvents(result.events)).toHaveLength(0);
+      expect(storedDirectoryDay(result.cursor)).toBeNull();
+    });
+  });
+});

--- a/platform/app/ee/governance/services/pullers/__tests__/copilotStudioDataverseSeats.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/copilotStudioDataverseSeats.unit.test.ts
@@ -220,6 +220,7 @@ async function runPull({
       environmentUrl: ENVIRONMENT_URL,
       botIds: [],
       readSeats,
+      readDirectory: false,
       ...(azureSubscriptionId === undefined ? {} : { azureSubscriptionId }),
     },
   );

--- a/platform/app/ee/governance/services/pullers/__tests__/microsoftGraphDirectory.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/microsoftGraphDirectory.unit.test.ts
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+
+/**
+ * The pure half of the directory read: row reading, event shaping, and the
+ * host gate a next-page link passes before it is followed with a token.
+ *
+ * Spec: specs/governance/governance-people-discovery.feature
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  DIRECTORY_REPORT_ACTION,
+  isMicrosoftGraphUrl,
+  microsoftDirectoryEvents,
+  readDirectoryUserRows,
+} from "../microsoftGraphDirectory";
+
+const USER_ID = "f6481ec4-e30f-4bf3-954f-2a8f29bb1c4a";
+
+const graphUser = (over: Record<string, unknown> = {}) => ({
+  id: USER_ID,
+  displayName: "Maria Silva",
+  mail: "m.silva@acme.test",
+  userPrincipalName: "m.silva@acme.test",
+  department: "Engineering",
+  accountEnabled: true,
+  ...over,
+});
+
+describe("reading a directory page", () => {
+  it("reads the rows and hands back the next link beside them", () => {
+    const read = readDirectoryUserRows({
+      response: {
+        value: [graphUser()],
+        "@odata.nextLink":
+          "https://graph.microsoft.com/v1.0/users?$skiptoken=x",
+      },
+    });
+
+    expect(read.malformed).toBe(false);
+    expect(read.users).toHaveLength(1);
+    expect(read.nextLink).toContain("$skiptoken");
+  });
+
+  it("counts an unreadable row rather than dropping the page", () => {
+    const read = readDirectoryUserRows({
+      response: { value: [graphUser(), { id: "not-a-guid" }] },
+    });
+
+    expect(read.users).toHaveLength(1);
+    expect(read.unreadableRows).toBe(1);
+  });
+
+  it("keeps a row that carries nothing but its id — Graph omits absent fields", () => {
+    const read = readDirectoryUserRows({
+      response: { value: [{ id: USER_ID }] },
+    });
+
+    expect(read.users).toHaveLength(1);
+    expect(read.unreadableRows).toBe(0);
+  });
+
+  it("calls a body that is not a page malformed, not an empty tenant", () => {
+    const read = readDirectoryUserRows({ response: { error: "oops" } });
+
+    expect(read.malformed).toBe(true);
+    expect(read.users).toHaveLength(0);
+  });
+});
+
+describe("shaping directory events", () => {
+  it("keys the event on the person and the day, with the directory id as actor", () => {
+    const [event] = microsoftDirectoryEvents({
+      users: [graphUser()],
+      day: "2026-09-03",
+    });
+
+    expect(event).toMatchObject({
+      source_event_id: `msgraph_directory:${USER_ID}:2026-09-03`,
+      event_timestamp: "2026-09-03T00:00:00.000Z",
+      // The id, never the address: it is what the tenant's other rows call
+      // the same human, and what an erasure of this provider suppresses.
+      actor: USER_ID,
+      action: DIRECTORY_REPORT_ACTION,
+      cost_usd: "0",
+    });
+    expect(event?.extra).toMatchObject({
+      displayName: "Maria Silva",
+      mail: "m.silva@acme.test",
+      department: "Engineering",
+      accountEnabled: true,
+    });
+  });
+
+  it("shapes absent fields as empty strings, never as the word undefined", () => {
+    const [event] = microsoftDirectoryEvents({
+      users: [
+        {
+          id: USER_ID,
+          displayName: null,
+          mail: null,
+          userPrincipalName: null,
+          department: null,
+          accountEnabled: null,
+        },
+      ],
+      day: "2026-09-03",
+    });
+
+    expect(event?.extra).toMatchObject({
+      displayName: "",
+      mail: "",
+      department: "",
+    });
+  });
+});
+
+describe("the next-page host gate", () => {
+  it("accepts only https Microsoft Graph with a clean authority", () => {
+    expect(
+      isMicrosoftGraphUrl(
+        "https://graph.microsoft.com/v1.0/users?$skiptoken=x",
+      ),
+    ).toBe(true);
+    expect(isMicrosoftGraphUrl("http://graph.microsoft.com/v1.0/users")).toBe(
+      false,
+    );
+    expect(isMicrosoftGraphUrl("https://evil.test/v1.0/users")).toBe(false);
+    expect(
+      isMicrosoftGraphUrl("https://graph.microsoft.com.evil.test/users"),
+    ).toBe(false);
+    expect(
+      isMicrosoftGraphUrl("https://user:pass@graph.microsoft.com/users"),
+    ).toBe(false);
+    expect(isMicrosoftGraphUrl("https://graph.microsoft.com:8443/users")).toBe(
+      false,
+    );
+    expect(isMicrosoftGraphUrl("not a url")).toBe(false);
+  });
+});

--- a/platform/app/ee/governance/services/pullers/__tests__/pullerWorkerErasureSuppression.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/pullerWorkerErasureSuppression.unit.test.ts
@@ -11,9 +11,15 @@
  * export re-publishes the erased person's conversation on every daily pull,
  * with the thirty-day lookback guaranteeing it happens again tomorrow.
  *
+ * Suppression also stands in front of person discovery: the discovery and
+ * directory passes are fed the kept half of the batch, so an erased
+ * identifier can neither be re-discovered from activity nor slip back in
+ * through a directory listing (governance-people-discovery.feature).
+ *
  * Same mocking boundary as pullerWorkerPulledUsage.unit.test.ts.
  *
  * Spec: specs/governance/governance-identity-and-erasure.feature
+ * Spec: specs/governance/governance-people-discovery.feature
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -21,6 +27,7 @@ const {
   findUnique,
   projectFindFirst,
   suppressionFindMany,
+  personCreate,
   insertEvent,
   handleOtlpTraceRequest,
   runOnce,
@@ -29,6 +36,7 @@ const {
   findUnique: vi.fn(),
   projectFindFirst: vi.fn(),
   suppressionFindMany: vi.fn(),
+  personCreate: vi.fn(),
   insertEvent: vi.fn(),
   handleOtlpTraceRequest: vi.fn(),
   runOnce: vi.fn(),
@@ -45,6 +53,7 @@ vi.mock("~/server/db", () => ({
     erasedIdentifierSuppression: {
       findMany: (...a: unknown[]) => suppressionFindMany(...a),
     },
+    discoveredPerson: { create: (...a: unknown[]) => personCreate(...a) },
   },
 }));
 vi.mock("~/server/app-layer/app", () => ({
@@ -129,6 +138,7 @@ beforeEach(() => {
   vi.stubEnv(ERASURE_SECRET_ENV, SECRET);
   findUnique.mockReset().mockResolvedValue(SOURCE_ROW);
   projectFindFirst.mockReset().mockResolvedValue({ id: "proj_dest" });
+  personCreate.mockReset().mockResolvedValue({ id: "person_1" });
   insertEvent.mockReset().mockResolvedValue(undefined);
   handleOtlpTraceRequest.mockReset().mockResolvedValue({});
   runOnce.mockReset();
@@ -186,6 +196,73 @@ describe("given a pull carrying an event that names an erased person", () => {
       expect(exportedPayload()).toContain(STAYS);
       expect(exportedPayload()).not.toContain(ERASED);
     });
+
+    /** @scenario "An erased identifier is never re-discovered" */
+    it("discovers the other person and never the erased identifier", async () => {
+      runOnce.mockResolvedValue({
+        events: [
+          genieEvent(ERASED, "msg-erased"),
+          genieEvent(STAYS, "msg-stays"),
+        ],
+        cursor: null,
+        errorCount: 0,
+      });
+
+      await runIngestionPull({ sourceId: "src_1", cursor: null });
+
+      expect(personCreate).toHaveBeenCalledTimes(1);
+      expect(JSON.stringify(personCreate.mock.calls)).toContain(STAYS);
+      expect(JSON.stringify(personCreate.mock.calls)).not.toContain(ERASED);
+    });
+  });
+
+  describe("when the event is a directory listing of the erased person", () => {
+    /** @scenario "An erased identifier in the directory is skipped entirely" */
+    it("neither discovers them nor lets their department row through", async () => {
+      runOnce.mockResolvedValue({
+        events: [
+          {
+            source_event_id: "msgraph_directory:erased:2026-08-20",
+            event_timestamp: "2026-08-20T10:00:00.000Z",
+            actor: ERASED,
+            action: "directory_report",
+            target: "Finance",
+            cost_usd: "0",
+            tokens_input: 0,
+            tokens_output: 0,
+            raw_payload: JSON.stringify({ id: ERASED, department: "Finance" }),
+            extra: { department: "Finance", displayName: "Leaver" },
+          },
+        ],
+        cursor: null,
+        errorCount: 0,
+      });
+
+      await runIngestionPull({ sourceId: "src_1", cursor: null });
+
+      // Suppression empties the batch before discovery and the department
+      // sync run; the sync's own empty-batch early return means neither pass
+      // touches a table this harness would have had to mock.
+      expect(personCreate).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe("given a pull where person discovery itself breaks", () => {
+  /** @scenario "Discovery failing does not cost the run its events" */
+  it("still writes the audit row and exports the conversation", async () => {
+    suppressionFindMany.mockResolvedValue([]);
+    personCreate.mockRejectedValue(new Error("relation does not exist"));
+    runOnce.mockResolvedValue({
+      events: [genieEvent(STAYS, "msg-stays")],
+      cursor: null,
+      errorCount: 0,
+    });
+
+    await runIngestionPull({ sourceId: "src_1", cursor: null });
+
+    expect(insertEvent).toHaveBeenCalled();
+    expect(handleOtlpTraceRequest).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/platform/app/ee/governance/services/pullers/__tests__/pullerWorkerIdentityMatch.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/pullerWorkerIdentityMatch.unit.test.ts
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+
+/**
+ * The match seam: a pull that discovers people hands the organization to the
+ * injected identity-match port, after the run's own writes. The port is how
+ * ADR-128 §12's gate is honoured — this worker never imports the engine's
+ * suggestion half; the composition root does, on the worker role, and passes
+ * it in (see `DiscoveredPeopleMatcher` in pullerWorker.ts).
+ *
+ * Spec: specs/governance/governance-people-screen.feature
+ * Decision: ADR-128 §12.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { findUnique, insertEvent, runOnce, isEnabled, recordFromPulledEvents } =
+  vi.hoisted(() => ({
+    findUnique: vi.fn(),
+    insertEvent: vi.fn(),
+    runOnce: vi.fn(),
+    isEnabled: vi.fn(),
+    recordFromPulledEvents: vi.fn(),
+  }));
+
+vi.mock("~/server/featureFlag", () => ({
+  featureFlagService: { isEnabled: (...a: unknown[]) => isEnabled(...a) },
+}));
+vi.mock("~/server/db", () => ({
+  prisma: {
+    ingestionSource: { findUnique: (...a: unknown[]) => findUnique(...a) },
+  },
+}));
+vi.mock("~/server/app-layer/app", () => ({
+  getApp: () => ({
+    governance: {
+      ocsfEvents: { insertEvent: (...a: unknown[]) => insertEvent(...a) },
+    },
+  }),
+}));
+vi.mock("../../governanceOcsfEvents.clickhouse.repository", () => ({
+  OCSF_ACTIVITY: { INVOKE: 1 },
+  OCSF_SEVERITY: { INFO: 1 },
+}));
+vi.mock("../../governanceProject.service", () => ({
+  ensureHiddenGovernanceProject: async () => ({ id: "proj_governance" }),
+}));
+vi.mock("../../activity-monitor/ingestionCredentials", () => ({
+  decryptCredentials: () => ({ token: "sk-admin" }),
+}));
+// The discovery service is the seam under test's trigger, so its answer is
+// controlled directly. The department sync gets its own no-op double beside
+// it: both services would otherwise reach for prisma models this harness
+// never builds.
+vi.mock("../../personDiscovery.service", () => ({
+  PersonDiscoveryService: {
+    create: () => ({
+      recordFromPulledEvents: (...a: unknown[]) => recordFromPulledEvents(...a),
+    }),
+  },
+}));
+vi.mock("../../directoryDepartmentSync.service", () => ({
+  DirectoryDepartmentSyncService: {
+    create: () => ({ applyDirectoryEvents: async () => undefined }),
+  },
+}));
+vi.mock("../index", async (importOriginal) => {
+  const original = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...original,
+    registerBuiltInPullers: () => undefined,
+    pullerAdapterRegistry: {
+      get: () => ({
+        id: "test_adapter",
+        validateConfig: (c: unknown) => c,
+        runOnce: (...a: unknown[]) => runOnce(...a),
+      }),
+    },
+  };
+});
+
+import { runIngestionPull } from "../pullerWorker";
+
+const SOURCE_ROW = {
+  id: "src_1",
+  organizationId: "org_acme",
+  teamId: "team_platform",
+  sourceType: "anthropic_admin",
+  status: "active",
+  parserConfig: { adapter: "test_adapter" },
+} as const;
+
+const pulledEvent = {
+  source_event_id: "evt_1",
+  event_timestamp: "2026-08-01T00:00:00.000Z",
+  actor: "casey@example-provider.test",
+  action: "invoke",
+  target: "anthropic/claude-sonnet-5",
+  cost_usd: 0,
+  tokens_input: 1,
+  tokens_output: 1,
+  raw_payload: "{}",
+  extra: {},
+} as const;
+
+beforeEach(() => {
+  findUnique.mockReset().mockResolvedValue(SOURCE_ROW);
+  insertEvent.mockReset().mockResolvedValue(undefined);
+  runOnce
+    .mockReset()
+    .mockResolvedValue({ events: [pulledEvent], cursor: null, errorCount: 0 });
+  isEnabled.mockReset().mockResolvedValue(false);
+  recordFromPulledEvents.mockReset().mockResolvedValue({ discovered: 1 });
+});
+
+describe("the pull run's identity-match seam", () => {
+  describe("when a delivery discovers at least one person", () => {
+    /** @scenario "Suggestions are recomputed when the feed discovers people" */
+    it("hands the organization to the injected matcher, once, after the delivery's own writes", async () => {
+      const runFor = vi.fn().mockResolvedValue(undefined);
+
+      await runIngestionPull({
+        sourceId: "src_1",
+        cursor: null,
+        identityMatch: { runFor },
+      });
+
+      expect(runFor).toHaveBeenCalledExactlyOnceWith({
+        organizationId: "org_acme",
+      });
+      // "After the delivery's own writes" is a claim about order, so order is
+      // what gets asserted: the OCSF audit row is the delivery's write, and
+      // the matcher must not run until the events it would score are stored.
+      expect(insertEvent.mock.invocationCallOrder[0]).toBeLessThan(
+        runFor.mock.invocationCallOrder[0]!,
+      );
+    });
+
+    it("still delivers the run when the matcher throws", async () => {
+      const runFor = vi.fn().mockRejectedValue(new Error("scorer fell over"));
+
+      await expect(
+        runIngestionPull({
+          sourceId: "src_1",
+          cursor: null,
+          identityMatch: { runFor },
+        }),
+      ).resolves.toMatchObject({ eventCount: 1, errorCount: 0 });
+    });
+  });
+
+  describe("when the delivery discovers nobody", () => {
+    it("never invokes the matcher — an empty feed is not a trigger", async () => {
+      recordFromPulledEvents.mockResolvedValue({ discovered: 0 });
+      const runFor = vi.fn();
+
+      await runIngestionPull({
+        sourceId: "src_1",
+        cursor: null,
+        identityMatch: { runFor },
+      });
+
+      expect(runFor).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when no matcher is composed", () => {
+    it("the run completes as it always did — the port is optional", async () => {
+      await expect(
+        runIngestionPull({ sourceId: "src_1", cursor: null }),
+      ).resolves.toMatchObject({ eventCount: 1 });
+    });
+  });
+});

--- a/platform/app/ee/governance/services/pullers/copilotStudioDataverse.puller.ts
+++ b/platform/app/ee/governance/services/pullers/copilotStudioDataverse.puller.ts
@@ -382,6 +382,29 @@ const NO_CURSOR: StoredCursor = {
   directory: { reportedThroughDay: null, heldSinceMs: null },
 };
 
+/** The per-read sections of a stored position; absent and null read the same. */
+function sectionsOf(
+  data: z.infer<typeof storedCursorSchema>,
+): Pick<StoredCursor, "cost" | "seats" | "directory"> {
+  return {
+    cost: {
+      pricedThroughDay: data.costPricedThroughDay ?? null,
+      heldSinceMs: data.costHeldSinceMs ?? null,
+      // Absent on every position written before the ask was recorded, which
+      // reads as never asked and so asks at once.
+      readAtMs: data.costReadAtMs ?? null,
+    },
+    seats: {
+      reportedThroughDay: data.seatsReportedThroughDay ?? null,
+      heldSinceMs: data.seatsHeldSinceMs ?? null,
+    },
+    directory: {
+      reportedThroughDay: data.directoryReportedThroughDay ?? null,
+      heldSinceMs: data.directoryHeldSinceMs ?? null,
+    },
+  };
+}
+
 function parseCursor(raw: string | null): StoredCursor {
   if (!raw) return NO_CURSOR;
   try {
@@ -395,21 +418,7 @@ function parseCursor(raw: string | null): StoredCursor {
         createdon && conversationtranscriptid
           ? { createdon, conversationtranscriptid }
           : null,
-      cost: {
-        pricedThroughDay: parsed.data.costPricedThroughDay ?? null,
-        heldSinceMs: parsed.data.costHeldSinceMs ?? null,
-        // Absent on every position written before the ask was recorded, which
-        // reads as never asked and so asks at once.
-        readAtMs: parsed.data.costReadAtMs ?? null,
-      },
-      seats: {
-        reportedThroughDay: parsed.data.seatsReportedThroughDay ?? null,
-        heldSinceMs: parsed.data.seatsHeldSinceMs ?? null,
-      },
-      directory: {
-        reportedThroughDay: parsed.data.directoryReportedThroughDay ?? null,
-        heldSinceMs: parsed.data.directoryHeldSinceMs ?? null,
-      },
+      ...sectionsOf(parsed.data),
     };
   } catch {
     // A cursor we cannot read is treated as no cursor: re-reading a window is
@@ -448,6 +457,133 @@ export function readStoredCostCursor(pollerCursor: unknown): {
     costPricedThroughDay: cursor.cost.pricedThroughDay,
     costHeldSinceMs: cursor.cost.heldSinceMs,
   };
+}
+
+/**
+ * One directory page: fetched, refusal-checked, parsed — or null when the
+ * whole day must hold.
+ */
+async function readDirectoryPage({
+  url,
+  token,
+  options,
+}: {
+  url: string;
+  token: string;
+  options: PullRunOptions;
+}): Promise<ReturnType<typeof readDirectoryUserRows> | null> {
+  const timeout = AbortSignal.timeout(REQUEST_TIMEOUT_MS);
+  const response = await ssrfSafeFetch(url, {
+    method: "GET",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/json",
+    },
+    signal: options.signal
+      ? AbortSignal.any([options.signal, timeout])
+      : timeout,
+    // Carries a token minted from the customer's secret, so a redirect
+    // must not hand it to whoever answers.
+    followRedirects: false,
+  });
+
+  if (!response.ok) {
+    logger.warn(
+      { status: response.status },
+      response.status === 403
+        ? "copilot studio dataverse: the tenant has not consented to the directory read (HTTP 403); holding the day"
+        : "copilot studio dataverse: Microsoft Graph refused the directory read; holding the day",
+    );
+    return null;
+  }
+
+  const read = readDirectoryUserRows({ response: await response.json() });
+  if (read.malformed) {
+    logger.warn(
+      "copilot studio dataverse: Microsoft Graph answered the directory read with an unrecognised body; holding the day",
+    );
+    return null;
+  }
+  return read;
+}
+
+/** The finished list — unless nothing in it survived parsing. */
+function completeDirectoryList({
+  users,
+  unreadableRows,
+}: {
+  users: DirectoryUser[];
+  unreadableRows: number;
+}): DirectoryUser[] | null {
+  if (users.length === 0 && unreadableRows > 0) {
+    // Nothing survived. Recording the day would publish "this tenant
+    // lists nobody" for "nobody could be read" — permanently.
+    logger.warn(
+      { unreadableRows },
+      "copilot studio dataverse: no directory row in Microsoft Graph's reply could be read; holding the day",
+    );
+    return null;
+  }
+  if (unreadableRows > 0) {
+    // Counted here and nowhere else, exactly as the licence read does:
+    // reaching the run's own error count would cost it its
+    // conversations.
+    logger.warn(
+      { unreadableRows },
+      "copilot studio dataverse: some directory rows could not be read; the rest of the list is recorded",
+    );
+  }
+  return users;
+}
+
+/**
+ * Whether the run's outgoing position differs from the one it started with.
+ *
+ * Any of the four reads counts, on a clean run and on a failing one alike. A
+ * run whose conversations broke but whose bill was read is a partial success:
+ * the worker persists the advance, keeps the figures, and warns. What such a
+ * run does to the source's recorded health is the fold projection's decision
+ * to make, not this gate's — refusing the advance here would buy that
+ * visibility by throwing away figures already in hand.
+ *
+ * What stops a dead environment reading as steady progress is that the seat
+ * and directory marks only move on the day roll, and the cost mark only on
+ * the few runs a day that are due to ask about the bill at all. On a
+ * five-minute schedule that is four runs out of two hundred and eighty-eight;
+ * the rest hand back the incoming cursor string verbatim, which the worker
+ * reads as no progress and fails. The signal is weaker than it was when
+ * nothing but the day roll moved these marks, and it still holds.
+ * `refusesNextLink` still fails or warns exactly as it did, because there the
+ * transcript cursor is what moved.
+ */
+function positionMoved({
+  previous,
+  next,
+}: {
+  previous: StoredCursor;
+  next: StoredCursor;
+}): boolean {
+  const transcriptMoved =
+    next.transcript !== null &&
+    (next.transcript.createdon !== previous.transcript?.createdon ||
+      next.transcript.conversationtranscriptid !==
+        previous.transcript?.conversationtranscriptid);
+  const costMoved =
+    next.cost.pricedThroughDay !== previous.cost.pricedThroughDay ||
+    next.cost.heldSinceMs !== previous.cost.heldSinceMs ||
+    // The instant of the ask counts as movement in its own right. A run that
+    // asked and found the same figure moves neither of the two above, and
+    // dropping the record of the ask would leave the source due again on the
+    // very next run.
+    next.cost.readAtMs !== previous.cost.readAtMs;
+  const seatsMoved =
+    next.seats.reportedThroughDay !== previous.seats.reportedThroughDay ||
+    next.seats.heldSinceMs !== previous.seats.heldSinceMs;
+  const directoryMoved =
+    next.directory.reportedThroughDay !==
+      previous.directory.reportedThroughDay ||
+    next.directory.heldSinceMs !== previous.directory.heldSinceMs;
+  return transcriptMoved || costMoved || seatsMoved || directoryMoved;
 }
 
 /** The position a run hands back, as the string that is stored. */
@@ -991,43 +1127,7 @@ export class CopilotStudioDataversePuller
     // environment with no new conversations never price its bill, or a bill
     // that cannot be read stall the transcripts.
     const advanced = walk.last?.createdon ? walk.last : previous.transcript;
-    const transcriptMoved =
-      advanced !== null &&
-      (advanced.createdon !== previous.transcript?.createdon ||
-        advanced.conversationtranscriptid !==
-          previous.transcript?.conversationtranscriptid);
-    const costMoved =
-      cost.pricedThroughDay !== previous.cost.pricedThroughDay ||
-      cost.heldSinceMs !== previous.cost.heldSinceMs ||
-      // The instant of the ask counts as movement in its own right. A run that
-      // asked and found the same figure moves neither of the two above, and
-      // dropping the record of the ask would leave the source due again on the
-      // very next run.
-      cost.readAtMs !== previous.cost.readAtMs;
-    const seatsMoved =
-      seats.reportedThroughDay !== previous.seats.reportedThroughDay ||
-      seats.heldSinceMs !== previous.seats.heldSinceMs;
-    const directoryMoved =
-      directory.reportedThroughDay !== previous.directory.reportedThroughDay ||
-      directory.heldSinceMs !== previous.directory.heldSinceMs;
-
-    // Any of the three reads counts, on a clean run and on a failing one
-    // alike. A run whose conversations broke but whose bill was read is a
-    // partial success: the worker persists the advance, keeps the figures, and
-    // warns. What such a run does to the source's recorded health is the fold
-    // projection's decision to make, not this gate's — refusing the advance
-    // here bought that visibility by throwing away figures already in hand.
-    //
-    // What stops a dead environment reading as steady progress is that the
-    // seat mark only moves on the day roll, and the cost mark only on the few
-    // runs a day that are due to ask about the bill at all. On a five-minute
-    // schedule that is four runs out of two hundred and eighty-eight; the rest
-    // hand back the incoming cursor string verbatim, which the worker reads as
-    // no progress and fails. The signal is weaker than it was when nothing but
-    // the day roll moved these marks, and it still holds. `refusesNextLink`
-    // still fails or warns exactly as it did, because there the transcript
-    // cursor is what moved.
-    const moved = transcriptMoved || costMoved || seatsMoved || directoryMoved;
+    const next: StoredCursor = { transcript: advanced, cost, seats, directory };
 
     return {
       events: walk.events,
@@ -1037,8 +1137,8 @@ export class CopilotStudioDataversePuller
       // position yields a different string — the cost fields now spelled out
       // — which it would read as an advance and persist. That is the whole
       // reason this is a string comparison and not a deep one.
-      cursor: moved
-        ? encodeCursor({ transcript: advanced, cost, seats, directory })
+      cursor: positionMoved({ previous, next })
+        ? encodeCursor(next)
         : options.cursor,
       errorCount: walk.errorCount,
     };
@@ -1567,61 +1667,13 @@ export class CopilotStudioDataversePuller
     let url: string = DIRECTORY_USERS_FIRST_PAGE;
 
     for (let page = 0; page < MAX_DIRECTORY_PAGES; page += 1) {
-      const timeout = AbortSignal.timeout(REQUEST_TIMEOUT_MS);
-      const response = await ssrfSafeFetch(url, {
-        method: "GET",
-        headers: {
-          Authorization: `Bearer ${token}`,
-          Accept: "application/json",
-        },
-        signal: options.signal
-          ? AbortSignal.any([options.signal, timeout])
-          : timeout,
-        // Carries a token minted from the customer's secret, so a redirect
-        // must not hand it to whoever answers.
-        followRedirects: false,
-      });
-
-      if (!response.ok) {
-        logger.warn(
-          { status: response.status },
-          response.status === 403
-            ? "copilot studio dataverse: the tenant has not consented to the directory read (HTTP 403); holding the day"
-            : "copilot studio dataverse: Microsoft Graph refused the directory read; holding the day",
-        );
-        return null;
-      }
-
-      const read = readDirectoryUserRows({ response: await response.json() });
-      if (read.malformed) {
-        logger.warn(
-          "copilot studio dataverse: Microsoft Graph answered the directory read with an unrecognised body; holding the day",
-        );
-        return null;
-      }
+      const read = await readDirectoryPage({ url, token, options });
+      if (read === null) return null;
       users.push(...read.users);
       unreadableRows += read.unreadableRows;
 
       if (read.nextLink === null) {
-        if (users.length === 0 && unreadableRows > 0) {
-          // Nothing survived. Recording the day would publish "this tenant
-          // lists nobody" for "nobody could be read" — permanently.
-          logger.warn(
-            { unreadableRows },
-            "copilot studio dataverse: no directory row in Microsoft Graph's reply could be read; holding the day",
-          );
-          return null;
-        }
-        if (unreadableRows > 0) {
-          // Counted here and nowhere else, exactly as the licence read does:
-          // reaching the run's own error count would cost it its
-          // conversations.
-          logger.warn(
-            { unreadableRows },
-            "copilot studio dataverse: some directory rows could not be read; the rest of the list is recorded",
-          );
-        }
-        return users;
+        return completeDirectoryList({ users, unreadableRows });
       }
       if (!isMicrosoftGraphUrl(read.nextLink)) {
         logger.error(

--- a/platform/app/ee/governance/services/pullers/copilotStudioDataverse.puller.ts
+++ b/platform/app/ee/governance/services/pullers/copilotStudioDataverse.puller.ts
@@ -60,6 +60,15 @@ import {
   isSameDataverseEnvironment,
 } from "./dataverseEnvironment";
 import {
+  DIRECTORY_USERS_FIRST_PAGE,
+  type DirectoryUser,
+  directoryReadIsDue,
+  isMicrosoftGraphUrl,
+  microsoftDirectoryEvents,
+  nextDirectoryCursor,
+  readDirectoryUserRows,
+} from "./microsoftGraphDirectory";
+import {
   MICROSOFT_GRAPH_SCOPE,
   microsoftSeatEvents,
   nextSeatsCursor,
@@ -80,6 +89,14 @@ const TOKEN_TIMEOUT_MS = 15_000;
 const REQUEST_TIMEOUT_MS = 30_000;
 /** Dataverse's own page ceiling for this kind of read. */
 const PAGE_SIZE = 50;
+
+/**
+ * How many Graph pages a directory read may follow — at 999 rows a page,
+ * about fifty thousand users. A tenant bigger than that holds its day and
+ * says so in the log (see `fetchDirectoryUsers`), rather than being listed
+ * in part.
+ */
+const MAX_DIRECTORY_PAGES = 50;
 
 /**
  * The order every transcript read asks for, and the order the continuation
@@ -193,6 +210,18 @@ export const copilotStudioDataversePullConfigSchema = z.object({
    * switch off, not a source that breaks.
    */
   readSeats: z.boolean().default(true),
+  /**
+   * Whether to read the tenant's user directory beside the conversations.
+   *
+   * Off unless switched on — the opposite default from `readSeats`, because
+   * the consent is heavier: `/users` needs `User.Read.All`, which hands this
+   * source every name, address, and department in the tenant rather than a
+   * list of licence pools. That is exactly what the identity screens need
+   * (a transcript knows people only as directory ids, and the directory is
+   * what knows their names and departments) — and exactly what an admin
+   * should turn on deliberately rather than discover was on.
+   */
+  readDirectory: z.boolean().default(false),
 });
 
 export type CopilotStudioDataverseConfig = z.infer<
@@ -325,6 +354,13 @@ const storedCursorSchema = z.object({
     .nullish(),
   /** When the current unreported day started being held. */
   seatsHeldSinceMs: z.number().int().nonnegative().nullish(),
+  /** The last day the user directory was reported for, `YYYY-MM-DD`. */
+  directoryReportedThroughDay: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/)
+    .nullish(),
+  /** When the current unreported directory day started being held. */
+  directoryHeldSinceMs: z.number().int().nonnegative().nullish(),
 });
 
 interface StoredCursor {
@@ -336,12 +372,14 @@ interface StoredCursor {
     readAtMs: number | null;
   };
   seats: { reportedThroughDay: string | null; heldSinceMs: number | null };
+  directory: { reportedThroughDay: string | null; heldSinceMs: number | null };
 }
 
 const NO_CURSOR: StoredCursor = {
   transcript: null,
   cost: { pricedThroughDay: null, heldSinceMs: null, readAtMs: null },
   seats: { reportedThroughDay: null, heldSinceMs: null },
+  directory: { reportedThroughDay: null, heldSinceMs: null },
 };
 
 function parseCursor(raw: string | null): StoredCursor {
@@ -367,6 +405,10 @@ function parseCursor(raw: string | null): StoredCursor {
       seats: {
         reportedThroughDay: parsed.data.seatsReportedThroughDay ?? null,
         heldSinceMs: parsed.data.seatsHeldSinceMs ?? null,
+      },
+      directory: {
+        reportedThroughDay: parsed.data.directoryReportedThroughDay ?? null,
+        heldSinceMs: parsed.data.directoryHeldSinceMs ?? null,
       },
     };
   } catch {
@@ -417,6 +459,8 @@ function encodeCursor(cursor: StoredCursor): string {
     costReadAtMs: cursor.cost.readAtMs,
     seatsReportedThroughDay: cursor.seats.reportedThroughDay,
     seatsHeldSinceMs: cursor.seats.heldSinceMs,
+    directoryReportedThroughDay: cursor.directory.reportedThroughDay,
+    directoryHeldSinceMs: cursor.directory.heldSinceMs,
   });
 }
 
@@ -899,6 +943,14 @@ export class CopilotStudioDataversePuller
     walk.events.push(...seatsRead.events);
     const seats = seatsRead.seats;
 
+    const directoryRead = await this.readMicrosoftDirectory({
+      config,
+      options,
+      previous: previous.directory,
+    });
+    walk.events.push(...directoryRead.events);
+    const directory = directoryRead.directory;
+
     try {
       const token = await resolveEnvironmentToken({
         credentials: options.credentials,
@@ -955,6 +1007,9 @@ export class CopilotStudioDataversePuller
     const seatsMoved =
       seats.reportedThroughDay !== previous.seats.reportedThroughDay ||
       seats.heldSinceMs !== previous.seats.heldSinceMs;
+    const directoryMoved =
+      directory.reportedThroughDay !== previous.directory.reportedThroughDay ||
+      directory.heldSinceMs !== previous.directory.heldSinceMs;
 
     // Any of the three reads counts, on a clean run and on a failing one
     // alike. A run whose conversations broke but whose bill was read is a
@@ -972,7 +1027,7 @@ export class CopilotStudioDataversePuller
     // the day roll moved these marks, and it still holds. `refusesNextLink`
     // still fails or warns exactly as it did, because there the transcript
     // cursor is what moved.
-    const moved = transcriptMoved || costMoved || seatsMoved;
+    const moved = transcriptMoved || costMoved || seatsMoved || directoryMoved;
 
     return {
       events: walk.events,
@@ -983,7 +1038,7 @@ export class CopilotStudioDataversePuller
       // — which it would read as an advance and persist. That is the whole
       // reason this is a string comparison and not a deep one.
       cursor: moved
-        ? encodeCursor({ transcript: advanced, cost, seats })
+        ? encodeCursor({ transcript: advanced, cost, seats, directory })
         : options.cursor,
       errorCount: walk.errorCount,
     };
@@ -1417,6 +1472,176 @@ export class CopilotStudioDataversePuller
     }
 
     return read;
+  }
+
+  /**
+   * The tenant's user directory, as directory-report events, or none.
+   *
+   * The licence read's contract exactly — NEVER throws, NEVER counts an
+   * error, a failed or refused read HOLDS the day rather than reporting it —
+   * because the same `assertRunMadeProgress` economics apply: an error count
+   * against an unmoved cursor discards the run whole, conversations and all.
+   */
+  private async readMicrosoftDirectory(params: {
+    config: CopilotStudioDataverseConfig;
+    options: PullRunOptions;
+    previous: { reportedThroughDay: string | null; heldSinceMs: number | null };
+  }): Promise<{
+    events: NormalizedPullEvent[];
+    directory: {
+      reportedThroughDay: string | null;
+      heldSinceMs: number | null;
+    };
+  }> {
+    const { config, options, previous } = params;
+
+    // Neither skip is a hold — nothing was attempted, so the position is
+    // handed back untouched, and `directoryMoved` stays false.
+    if (!config.readDirectory) return { events: [], directory: previous };
+
+    const nowMs = Date.now();
+    const due = directoryReadIsDue({
+      nowMs,
+      reportedThroughDay: previous.reportedThroughDay,
+    });
+    if (!due) return { events: [], directory: previous };
+
+    const held = () => ({
+      events: [],
+      directory: nextDirectoryCursor({
+        nowMs,
+        previous,
+        outcome: "held" as const,
+      }),
+    });
+
+    try {
+      const token = await resolveEnvironmentToken({
+        credentials: options.credentials,
+        environmentUrl: config.environmentUrl,
+        scope: MICROSOFT_GRAPH_SCOPE,
+        signal: options.signal,
+      });
+
+      const users = await this.fetchDirectoryUsers({ token, options });
+      if (users === null) return held();
+
+      return {
+        events: microsoftDirectoryEvents({
+          users,
+          day: seatsReportDay({ nowMs }),
+        }),
+        directory: nextDirectoryCursor({
+          nowMs,
+          previous,
+          outcome: "reported",
+        }),
+      };
+    } catch (error) {
+      logger.warn(
+        { error: error instanceof Error ? error.message : String(error) },
+        "copilot studio dataverse: could not read the tenant's directory; holding the day and delivering the conversations",
+      );
+      return held();
+    }
+  }
+
+  /**
+   * The whole user list across however many pages Graph serves it in, or null
+   * when it could not all be read.
+   *
+   * All or nothing, where the licence read is one page by nature: a directory
+   * reported from half its pages would list half the tenant, and the day
+   * would be marked read with nothing marking the other half missing. Any
+   * page failing — or serving a next link that is not Microsoft Graph, which
+   * would otherwise be followed carrying the Graph bearer — holds the day.
+   */
+  private async fetchDirectoryUsers(params: {
+    token: string;
+    options: PullRunOptions;
+  }): Promise<DirectoryUser[] | null> {
+    const { token, options } = params;
+
+    const users: DirectoryUser[] = [];
+    let unreadableRows = 0;
+    let url: string = DIRECTORY_USERS_FIRST_PAGE;
+
+    for (let page = 0; page < MAX_DIRECTORY_PAGES; page += 1) {
+      const timeout = AbortSignal.timeout(REQUEST_TIMEOUT_MS);
+      const response = await ssrfSafeFetch(url, {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: "application/json",
+        },
+        signal: options.signal
+          ? AbortSignal.any([options.signal, timeout])
+          : timeout,
+        // Carries a token minted from the customer's secret, so a redirect
+        // must not hand it to whoever answers.
+        followRedirects: false,
+      });
+
+      if (!response.ok) {
+        logger.warn(
+          { status: response.status },
+          response.status === 403
+            ? "copilot studio dataverse: the tenant has not consented to the directory read (HTTP 403); holding the day"
+            : "copilot studio dataverse: Microsoft Graph refused the directory read; holding the day",
+        );
+        return null;
+      }
+
+      const read = readDirectoryUserRows({ response: await response.json() });
+      if (read.malformed) {
+        logger.warn(
+          "copilot studio dataverse: Microsoft Graph answered the directory read with an unrecognised body; holding the day",
+        );
+        return null;
+      }
+      users.push(...read.users);
+      unreadableRows += read.unreadableRows;
+
+      if (read.nextLink === null) {
+        if (users.length === 0 && unreadableRows > 0) {
+          // Nothing survived. Recording the day would publish "this tenant
+          // lists nobody" for "nobody could be read" — permanently.
+          logger.warn(
+            { unreadableRows },
+            "copilot studio dataverse: no directory row in Microsoft Graph's reply could be read; holding the day",
+          );
+          return null;
+        }
+        if (unreadableRows > 0) {
+          // Counted here and nowhere else, exactly as the licence read does:
+          // reaching the run's own error count would cost it its
+          // conversations.
+          logger.warn(
+            { unreadableRows },
+            "copilot studio dataverse: some directory rows could not be read; the rest of the list is recorded",
+          );
+        }
+        return users;
+      }
+      if (!isMicrosoftGraphUrl(read.nextLink)) {
+        logger.error(
+          { refusedHost: hostOf(read.nextLink) },
+          "copilot studio dataverse: refusing a directory next-page link that is not Microsoft Graph; holding the day",
+        );
+        return null;
+      }
+      url = read.nextLink;
+    }
+
+    // Ran out of page budget with a next link still standing. Held, not
+    // recorded — see the all-or-nothing note above — and said out loud with
+    // the cap in the line, so a tenant bigger than the budget reads as a
+    // limit to raise rather than a silent stall.
+    logger.error(
+      { pagesRead: MAX_DIRECTORY_PAGES, usersRead: users.length },
+      "copilot studio dataverse: the directory did not fit the page budget; holding the day",
+    );
+    return null;
   }
 
   /**

--- a/platform/app/ee/governance/services/pullers/microsoftGraphDirectory.ts
+++ b/platform/app/ee/governance/services/pullers/microsoftGraphDirectory.ts
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+
+/**
+ * Who exists in the tenant, read from its directory.
+ *
+ * Conversations know people only as directory ids, and the licence list knows
+ * only counts. The directory is the one source that knows what an id is
+ * called, what address it answers to, and which department the tenant filed
+ * it under — the three facts the identity tables and the department screen
+ * need and no activity row carries. Same Microsoft Graph audience as the
+ * licence read, one more consent (`User.Read.All`).
+ *
+ * Pure, exactly as `microsoftGraphSeats.ts` is pure: no I/O, no clock, no
+ * fetch. The caller does the talking and hands the reply here, so every rule
+ * below is decided against a captured reply in a unit test.
+ *
+ * Unlike `/subscribedSkus`, `/users` DOES page: the reply carries an
+ * `@odata.nextLink` until the list is done, and the caller follows it. The
+ * reader hands the link back beside the rows rather than hiding the loop
+ * here, keeping this module pure.
+ *
+ * The day-cursor contract — read once a day, hold a refused day, give up
+ * after a week so an unconsented tenant costs one request a day — is the
+ * licence read's contract verbatim, and it is imported from there rather than
+ * restated: two copies of "what does giving up do" is how the two reads drift
+ * into answering it differently.
+ *
+ * Spec: specs/governance/governance-people-discovery.feature
+ */
+
+import { z } from "zod";
+import { nextSeatsCursor, seatsReadIsDue } from "./microsoftGraphSeats";
+import type { NormalizedPullEvent } from "./pullerAdapter";
+
+/** The verb these events carry, so a reader can tell them from a conversation. */
+export const DIRECTORY_REPORT_ACTION = "directory_report" as const;
+
+const MICROSOFT_GRAPH_HOST = "graph.microsoft.com";
+
+/**
+ * Whether a URL is Microsoft Graph itself — the gate a next-page link passes
+ * before it is followed carrying the Graph bearer token. The same four
+ * comparisons `isAzureResourceManagerUrl` makes, for the same reasons: parsed
+ * rather than prefix-compared, https only, no credentials in the authority,
+ * no port games.
+ */
+export function isMicrosoftGraphUrl(value: string): boolean {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    return false;
+  }
+  if (url.protocol !== "https:") return false;
+  if (url.username !== "" || url.password !== "") return false;
+  if (url.port !== "") return false;
+  return url.hostname === MICROSOFT_GRAPH_HOST;
+}
+
+/**
+ * The first page of the tenant's user list. `$select` keeps the reply to the
+ * facts recorded below — Graph returns a much wider row unasked — and `$top`
+ * at its documented maximum keeps the page count down on large tenants.
+ */
+export const DIRECTORY_USERS_FIRST_PAGE =
+  "https://graph.microsoft.com/v1.0/users?$select=id,displayName,mail,userPrincipalName,department,accountEnabled&$top=999";
+
+/**
+ * One user row, by the facts this read records. Only the id is required:
+ * Graph omits any selected field the row does not carry (`mail` is routinely
+ * absent on unlicensed accounts), and a row missing everything but its id is
+ * still a person the tenant lists.
+ */
+const directoryUserSchema = z.object({
+  id: z.string().uuid(),
+  displayName: z.string().nullish(),
+  mail: z.string().nullish(),
+  userPrincipalName: z.string().nullish(),
+  department: z.string().nullish(),
+  accountEnabled: z.boolean().nullish(),
+});
+
+export type DirectoryUser = z.infer<typeof directoryUserSchema>;
+
+const directoryPageSchema = z.object({
+  value: z.array(z.unknown()),
+  "@odata.nextLink": z.string().optional(),
+});
+
+/**
+ * Reads one page of the user list, row by row.
+ *
+ * Same posture as `readSubscribedSkuRows`: a body that is not a page at all
+ * is `malformed` (the caller holds the day rather than recording an empty
+ * tenant), and a row that fails the row schema is counted rather than thrown
+ * — one unreadable guest account must not cost the tenant the rest of the
+ * directory.
+ */
+export function readDirectoryUserRows({ response }: { response: unknown }): {
+  users: DirectoryUser[];
+  unreadableRows: number;
+  nextLink: string | null;
+  malformed: boolean;
+} {
+  const page = directoryPageSchema.safeParse(response);
+  if (!page.success) {
+    return { users: [], unreadableRows: 0, nextLink: null, malformed: true };
+  }
+
+  const users: DirectoryUser[] = [];
+  let unreadableRows = 0;
+  for (const raw of page.data.value) {
+    const row = directoryUserSchema.safeParse(raw);
+    if (row.success) users.push(row.data);
+    else unreadableRows += 1;
+  }
+
+  return {
+    users,
+    unreadableRows,
+    nextLink: page.data["@odata.nextLink"] ?? null,
+    malformed: false,
+  };
+}
+
+/**
+ * The users a read found, as the events the run hands back.
+ *
+ * The identity is the person and the day, never the fields — two reads of the
+ * same day land ON each other, exactly as seat events do.
+ *
+ * `actor` is the directory id, not the address. It is the identifier the
+ * tenant's other rows use for the same human (a Dataverse transcript's author
+ * IS this id), it survives a rename and a re-issued address, and it is what
+ * an erasure of this provider's person suppresses — which is how a directory
+ * row naming an erased person is dropped by the same do-not-reimport check
+ * every pulled event passes through, with no directory-specific carve-out to
+ * maintain.
+ *
+ * The address and the department travel in `extra`: they are facts ABOUT the
+ * actor, and putting the address in `actor` would key suppression on the one
+ * field the tenant re-issues.
+ */
+export function microsoftDirectoryEvents({
+  users,
+  day,
+}: {
+  users: DirectoryUser[];
+  /** The calendar day being reported on, `YYYY-MM-DD` in UTC. */
+  day: string;
+}): NormalizedPullEvent[] {
+  return users.map((user) => ({
+    source_event_id: `msgraph_directory:${user.id}:${day}`,
+    // The day the listing belongs to, not the instant it was read.
+    event_timestamp: `${day}T00:00:00.000Z`,
+    actor: user.id,
+    action: DIRECTORY_REPORT_ACTION,
+    target: user.department ?? "",
+    cost_usd: "0",
+    tokens_input: 0,
+    tokens_output: 0,
+    raw_payload: JSON.stringify(user),
+    extra: {
+      directoryId: user.id,
+      displayName: user.displayName ?? "",
+      mail: user.mail ?? "",
+      userPrincipalName: user.userPrincipalName ?? "",
+      department: user.department ?? "",
+      // A boolean, not a string, for the same reason seat facts are native
+      // types: the OCSF row serialises it as JSON and keeps it.
+      accountEnabled: user.accountEnabled ?? true,
+    },
+  }));
+}
+
+/**
+ * Whether this run should read the directory at all. The licence read's
+ * once-a-day rule, unchanged: a directory changes on people-time, and a
+ * two-minute cadence would ask Graph hundreds of times a day for the same
+ * answer.
+ */
+export function directoryReadIsDue(params: {
+  nowMs: number;
+  reportedThroughDay: string | null;
+}): boolean {
+  return seatsReadIsDue(params);
+}
+
+/**
+ * Where the directory read stands after a run — reported, held, or given up.
+ * The licence read's contract verbatim, including keeping the hold instant
+ * through a give-up so an unconsented tenant costs one request a day forever
+ * rather than a fresh week of asking.
+ */
+export function nextDirectoryCursor(params: {
+  nowMs: number;
+  previous: { reportedThroughDay: string | null; heldSinceMs: number | null };
+  outcome: "reported" | "held";
+}): { reportedThroughDay: string | null; heldSinceMs: number | null } {
+  return nextSeatsCursor(params);
+}

--- a/platform/app/ee/governance/services/pullers/pullerWorker.ts
+++ b/platform/app/ee/governance/services/pullers/pullerWorker.ts
@@ -145,6 +145,22 @@ export interface PulledUsageDispatcher {
 }
 
 /**
+ * The identity-match engine, as the pull run is allowed to know it (ADR-128
+ * §12). A port rather than an import: the suggestion half scores names —
+ * quadratic, gated off every request path by the import-graph guard next to
+ * the engine — and this worker is statically reachable from the ops router
+ * through the pipeline registry. The composition root builds the
+ * implementation on the worker role and hands it in; this file never names
+ * the scorer.
+ *
+ * Optional. Without it discovery still records people; the review queue just
+ * waits for a process that composes the engine.
+ */
+export interface DiscoveredPeopleMatcher {
+  runFor(args: { organizationId: string }): Promise<void>;
+}
+
+/**
  * Answers what a source's `pullConfig` says to run, and refuses the run when it
  * does not name a registered adapter or does not validate against one.
  *
@@ -298,6 +314,7 @@ export async function runIngestionPull(params: {
   sourceId: string;
   cursor: string | null;
   pulledUsage?: PulledUsageDispatcher;
+  identityMatch?: DiscoveredPeopleMatcher;
 }): Promise<{
   nextCursor: string | null;
   eventCount: number;
@@ -357,6 +374,7 @@ export async function runIngestionPull(params: {
       events: result.events,
       source,
       pulledUsage: params.pulledUsage,
+      identityMatch: params.identityMatch,
     });
     logger.info(
       {
@@ -416,10 +434,12 @@ async function writePulledEvents({
   events,
   source,
   pulledUsage,
+  identityMatch,
 }: {
   events: NormalizedPullEvent[];
   source: PullingSource;
   pulledUsage?: PulledUsageDispatcher;
+  identityMatch?: DiscoveredPeopleMatcher;
 }): Promise<void> {
   const govProject = await ensureHiddenGovernanceProject(
     prisma,
@@ -491,30 +511,67 @@ async function writePulledEvents({
       "skipped pulled events naming an erased identifier",
     );
   }
-  // `kept`, again deliberately: discovery running on the pre-partition list
-  // would re-create a plaintext person row for an erased identifier on the
-  // next thirty-day re-read (ADR-128 §9 step 1). And a discovery failure
-  // never costs the run its events — the next run sees the same actors
-  // again, while audit rows missed would be gone for good.
+  const { discovered } = await syncPeopleFactsFromPull({
+    source,
+    events: kept,
+  });
+  // `kept`, not `events`. This is the export that leaves our storage entirely
+  // — it writes the conversation into the customer's own trace project, with
+  // the provider's user id on it and the question and answer in the spans. A
+  // suppressed person is suppressed here most of all.
+  await routeConversationsToTraceDestination({ events: kept, source });
+  // ADR-128 §12: the feed that discovers people is the engine's trigger.
+  // After routing, so a slow or failing pass never delays the export above.
+  if (discovered > 0 && identityMatch) {
+    try {
+      await identityMatch.runFor({ organizationId: source.organizationId });
+    } catch (error) {
+      logger.error(
+        { error: toError(error), ingestionSourceId: source.id },
+        "identity match pass failed; the discovered people are kept and the next pull retries",
+      );
+    }
+  }
+}
+
+/**
+ * People and department facts, off one delivery's events.
+ *
+ * `events` must be the post-partition list — the caller's `kept`, never the
+ * raw pull: discovery running on the pre-partition list would re-create a
+ * plaintext person row for an erased identifier on the next thirty-day
+ * re-read (ADR-128 §9 step 1). And a discovery failure never costs the run
+ * its events — the next run sees the same actors again, while audit rows
+ * missed would be gone for good. Department facts ride the same directory
+ * events, behind the same partition, with the same isolation: the directory
+ * read runs again tomorrow, so a failed sync costs a day, never the run.
+ */
+async function syncPeopleFactsFromPull({
+  source,
+  events,
+}: {
+  source: PullingSource;
+  events: NormalizedPullEvent[];
+}): Promise<{ discovered: number }> {
+  let discovered = 0;
   try {
-    await PersonDiscoveryService.create(prisma).recordFromPulledEvents({
+    ({ discovered } = await PersonDiscoveryService.create(
+      prisma,
+    ).recordFromPulledEvents({
       organizationId: source.organizationId,
       provider: source.sourceType,
-      events: kept,
-    });
+      events,
+    }));
   } catch (error) {
     logger.error(
       { error: toError(error), ingestionSourceId: source.id },
       "could not record discovered people; the pulled events are still delivered",
     );
   }
-  // Department facts ride the same directory events, behind the same
-  // partition, with the same isolation: the directory read runs again
-  // tomorrow, so a failed sync costs a day, never the run.
   try {
     await DirectoryDepartmentSyncService.create(prisma).applyDirectoryEvents({
       organizationId: source.organizationId,
-      events: kept,
+      events,
     });
   } catch (error) {
     logger.error(
@@ -522,11 +579,7 @@ async function writePulledEvents({
       "could not apply directory departments; the pulled events are still delivered",
     );
   }
-  // `kept`, not `events`. This is the export that leaves our storage entirely
-  // — it writes the conversation into the customer's own trace project, with
-  // the provider's user id on it and the question and answer in the spans. A
-  // suppressed person is suppressed here most of all.
-  await routeConversationsToTraceDestination({ events: kept, source });
+  return { discovered };
 }
 
 /**

--- a/platform/app/ee/governance/services/pullers/pullerWorker.ts
+++ b/platform/app/ee/governance/services/pullers/pullerWorker.ts
@@ -45,7 +45,9 @@ import {
   OCSF_ACTIVITY,
   OCSF_SEVERITY,
 } from "../governanceOcsfEvents.clickhouse.repository";
+import { DirectoryDepartmentSyncService } from "../directoryDepartmentSync.service";
 import { ensureHiddenGovernanceProject } from "../governanceProject.service";
+import { PersonDiscoveryService } from "../personDiscovery.service";
 import type {
   ConversationRoutingProfile,
   RoutingOrigin,
@@ -487,6 +489,37 @@ async function writePulledEvents({
     logger.info(
       { ingestionSourceId: source.id, suppressedCount },
       "skipped pulled events naming an erased identifier",
+    );
+  }
+  // `kept`, again deliberately: discovery running on the pre-partition list
+  // would re-create a plaintext person row for an erased identifier on the
+  // next thirty-day re-read (ADR-128 §9 step 1). And a discovery failure
+  // never costs the run its events — the next run sees the same actors
+  // again, while audit rows missed would be gone for good.
+  try {
+    await PersonDiscoveryService.create(prisma).recordFromPulledEvents({
+      organizationId: source.organizationId,
+      provider: source.sourceType,
+      events: kept,
+    });
+  } catch (error) {
+    logger.error(
+      { error: toError(error), ingestionSourceId: source.id },
+      "could not record discovered people; the pulled events are still delivered",
+    );
+  }
+  // Department facts ride the same directory events, behind the same
+  // partition, with the same isolation: the directory read runs again
+  // tomorrow, so a failed sync costs a day, never the run.
+  try {
+    await DirectoryDepartmentSyncService.create(prisma).applyDirectoryEvents({
+      organizationId: source.organizationId,
+      events: kept,
+    });
+  } catch (error) {
+    logger.error(
+      { error: toError(error), ingestionSourceId: source.id },
+      "could not apply directory departments; the pulled events are still delivered",
     );
   }
   // `kept`, not `events`. This is the export that leaves our storage entirely

--- a/platform/app/ee/governance/services/pullers/pullerWorker.ts
+++ b/platform/app/ee/governance/services/pullers/pullerWorker.ts
@@ -36,6 +36,7 @@ import {
 } from "~/utils/posthogErrorCapture";
 import { decryptCredentials } from "../activity-monitor/ingestionCredentials";
 import type { SourceType } from "../activity-monitor/ingestionSource.service";
+import { DirectoryDepartmentSyncService } from "../directoryDepartmentSync.service";
 import {
   loadErasureSuppression,
   partitionSuppressedEvents,
@@ -45,7 +46,6 @@ import {
   OCSF_ACTIVITY,
   OCSF_SEVERITY,
 } from "../governanceOcsfEvents.clickhouse.repository";
-import { DirectoryDepartmentSyncService } from "../directoryDepartmentSync.service";
 import { ensureHiddenGovernanceProject } from "../governanceProject.service";
 import { PersonDiscoveryService } from "../personDiscovery.service";
 import type {

--- a/platform/app/src/components/settings/__tests__/departmentAssignment.integration.test.tsx
+++ b/platform/app/src/components/settings/__tests__/departmentAssignment.integration.test.tsx
@@ -73,6 +73,10 @@ vi.mock("~/utils/api", () => ({
         list: { invalidate: vi.fn() },
         assignments: { invalidate: vi.fn() },
       },
+      governancePeople: {
+        list: { invalidate: vi.fn() },
+        suggestions: { invalidate: vi.fn() },
+      },
     }),
     departments: {
       list: {
@@ -101,6 +105,18 @@ vi.mock("~/utils/api", () => ({
           mutateAsync: mutations.assignProject,
           isPending: false,
         }),
+      },
+    },
+    // The page now carries the discovered-people panel; an empty answer keeps
+    // these tests about what they were about — departments and their links.
+    governancePeople: {
+      list: { useQuery: () => ({ data: [], isLoading: false }) },
+      suggestions: { useQuery: () => ({ data: [], isLoading: false }) },
+      runMatch: {
+        useMutation: () => ({ mutate: vi.fn(), isPending: false }),
+      },
+      confirmSuggestion: {
+        useMutation: () => ({ mutate: vi.fn(), isPending: false }),
       },
     },
   },

--- a/platform/app/src/pages/governance/people.tsx
+++ b/platform/app/src/pages/governance/people.tsx
@@ -121,13 +121,7 @@ const fmtDay = (d: Date | string) => {
  *
  * Spec: specs/governance/governance-people-screen.feature
  */
-function DiscoveredPeoplePanel({
-  orgId,
-  canManage,
-}: {
-  orgId: string;
-  canManage: boolean;
-}) {
+function useDiscoveredPeople(orgId: string) {
   const utils = api.useUtils();
   const peopleQuery = api.governancePeople.list.useQuery(
     { organizationId: orgId },
@@ -161,6 +155,65 @@ function DiscoveredPeoplePanel({
       }),
   });
 
+  return { peopleQuery, suggestionsQuery, refreshIdentity, runMatch };
+}
+
+function DiscoveredPeopleHeader({
+  canManage,
+  running,
+  onRun,
+}: {
+  canManage: boolean;
+  running: boolean;
+  onRun: () => void;
+}) {
+  return (
+    <HStack
+      paddingY={2}
+      paddingX={3}
+      borderBottomWidth="1px"
+      borderColor="border.muted"
+      backgroundColor="bg.subtle"
+      justifyContent="space-between"
+    >
+      <VStack align="start" gap={0}>
+        <Text
+          fontSize="xs"
+          fontWeight="semibold"
+          color="fg.muted"
+          textTransform="uppercase"
+          letterSpacing="wider"
+        >
+          People the providers see
+        </Text>
+        <Text fontSize="xs" color="fg.subtle">
+          Everyone named on pulled rows, most of whom hold no LangWatch account.
+          Run the match pass to link the ones something proves.
+        </Text>
+      </VStack>
+      {canManage && (
+        <Button
+          size="xs"
+          colorPalette="orange"
+          loading={running}
+          onClick={onRun}
+        >
+          Run match pass
+        </Button>
+      )}
+    </HStack>
+  );
+}
+
+function DiscoveredPeoplePanel({
+  orgId,
+  canManage,
+}: {
+  orgId: string;
+  canManage: boolean;
+}) {
+  const { peopleQuery, suggestionsQuery, refreshIdentity, runMatch } =
+    useDiscoveredPeople(orgId);
   const people = peopleQuery.data ?? [];
   const suggestions = suggestionsQuery.data ?? [];
 
@@ -174,40 +227,11 @@ function DiscoveredPeoplePanel({
         borderRadius="md"
         overflow="hidden"
       >
-        <HStack
-          paddingY={2}
-          paddingX={3}
-          borderBottomWidth="1px"
-          borderColor="border.muted"
-          backgroundColor="bg.subtle"
-          justifyContent="space-between"
-        >
-          <VStack align="start" gap={0}>
-            <Text
-              fontSize="xs"
-              fontWeight="semibold"
-              color="fg.muted"
-              textTransform="uppercase"
-              letterSpacing="wider"
-            >
-              People the providers see
-            </Text>
-            <Text fontSize="xs" color="fg.subtle">
-              Everyone named on pulled rows, most of whom hold no LangWatch
-              account. Run the match pass to link the ones something proves.
-            </Text>
-          </VStack>
-          {canManage && (
-            <Button
-              size="xs"
-              colorPalette="orange"
-              loading={runMatch.isPending}
-              onClick={() => runMatch.mutate({ organizationId: orgId })}
-            >
-              Run match pass
-            </Button>
-          )}
-        </HStack>
+        <DiscoveredPeopleHeader
+          canManage={canManage}
+          running={runMatch.isPending}
+          onRun={() => runMatch.mutate({ organizationId: orgId })}
+        />
 
         <HandledErrorAlert
           error={peopleQuery.error}
@@ -272,28 +296,35 @@ function DiscoveredPersonRow({ person }: { person: DiscoveredPerson }) {
           {fmtDay(person.lastSeenAt)}
         </Text>
       </VStack>
-      <VStack align="end" gap={0} flexShrink={0}>
-        {person.link ? (
-          <>
-            <Text fontSize="sm">
-              {person.link.memberName ?? person.link.userId}
-              {person.link.departmentName
-                ? ` · ${person.link.departmentName}`
-                : ""}
-            </Text>
-            <Text fontSize="xs" color="fg.muted">
-              linked ·{" "}
-              {EVIDENCE_LABEL[person.link.evidenceKind] ??
-                person.link.evidenceKind}
-            </Text>
-          </>
-        ) : (
-          <Text fontSize="xs" color="fg.subtle">
-            {person.erasedAt ? "" : "not linked"}
-          </Text>
-        )}
-      </VStack>
+      <PersonLinkCell person={person} />
     </HStack>
+  );
+}
+
+/** The right-hand column: who the person is linked to, or that they are not. */
+function PersonLinkCell({ person }: { person: DiscoveredPerson }) {
+  return (
+    <VStack align="end" gap={0} flexShrink={0}>
+      {person.link ? (
+        <>
+          <Text fontSize="sm">
+            {person.link.memberName ?? person.link.userId}
+            {person.link.departmentName
+              ? ` · ${person.link.departmentName}`
+              : ""}
+          </Text>
+          <Text fontSize="xs" color="fg.muted">
+            linked ·{" "}
+            {EVIDENCE_LABEL[person.link.evidenceKind] ??
+              person.link.evidenceKind}
+          </Text>
+        </>
+      ) : (
+        <Text fontSize="xs" color="fg.subtle">
+          {person.erasedAt ? "" : "not linked"}
+        </Text>
+      )}
+    </VStack>
   );
 }
 

--- a/platform/app/src/pages/governance/people.tsx
+++ b/platform/app/src/pages/governance/people.tsx
@@ -1,4 +1,5 @@
 import {
+  Badge,
   Box,
   Button,
   Heading,
@@ -24,6 +25,8 @@ import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 import { api, type RouterOutputs } from "~/utils/api";
 
 type Department = RouterOutputs["departments"]["list"][number];
+type DiscoveredPerson = RouterOutputs["governancePeople"]["list"][number];
+type MatchSuggestion = RouterOutputs["governancePeople"]["suggestions"][number];
 
 /**
  * The People page (nee Departments — the page identity renamed, the
@@ -64,6 +67,8 @@ function PeoplePage() {
           fallbackTitle="Couldn't load departments"
         />
 
+        <DiscoveredPeoplePanel orgId={orgId} canManage={canManage} />
+
         {canManage && <CreateDepartmentBox orgId={orgId} onCreated={refresh} />}
 
         <DepartmentList
@@ -84,6 +89,302 @@ function PeoplePage() {
         {hasDepartments && <AssignmentGuide />}
       </VStack>
     </GovernanceLayout>
+  );
+}
+
+/** The proof column's words, for humans rather than for the enum. */
+const EVIDENCE_LABEL: Record<string, string> = {
+  verified_email: "confirmed address",
+  verified_email_and_directory_id: "confirmed address + directory",
+  human_confirmed: "confirmed by a person",
+};
+
+const fmtDay = (d: Date | string) => {
+  const date = typeof d === "string" ? new Date(d) : d;
+  return Number.isNaN(date.getTime()) ? "—" : date.toISOString().slice(0, 10);
+};
+
+/**
+ * Everyone the providers named, with the match engine's verdicts beside them
+ * and its button in front of them. The engine keeps no standing appointment
+ * of its own — this button is the trigger its spec left to the screen.
+ *
+ * Spec: specs/governance/governance-people-screen.feature
+ */
+function DiscoveredPeoplePanel({
+  orgId,
+  canManage,
+}: {
+  orgId: string;
+  canManage: boolean;
+}) {
+  const utils = api.useUtils();
+  const peopleQuery = api.governancePeople.list.useQuery(
+    { organizationId: orgId },
+    { enabled: !!orgId, refetchOnWindowFocus: false },
+  );
+  const suggestionsQuery = api.governancePeople.suggestions.useQuery(
+    { organizationId: orgId },
+    { enabled: !!orgId, refetchOnWindowFocus: false },
+  );
+
+  const refreshIdentity = async () => {
+    await Promise.all([
+      utils.governancePeople.list.invalidate({ organizationId: orgId }),
+      utils.governancePeople.suggestions.invalidate({ organizationId: orgId }),
+    ]);
+  };
+
+  const runMatch = api.governancePeople.runMatch.useMutation({
+    onSuccess: async (outcome) => {
+      toaster.create({
+        title: "Match pass finished",
+        description: `${outcome.linked} linked, ${outcome.suggestionsWritten} suggested, ${outcome.unproven} unproven.`,
+        type: "success",
+      });
+      await refreshIdentity();
+    },
+    onError: (e) =>
+      showErrorToast({
+        error: e,
+        fallbackTitle: "Couldn't run the match pass",
+      }),
+  });
+
+  const people = peopleQuery.data ?? [];
+  const suggestions = suggestionsQuery.data ?? [];
+
+  return (
+    <>
+      <VStack
+        align="stretch"
+        gap={0}
+        borderWidth="1px"
+        borderColor="border.muted"
+        borderRadius="md"
+        overflow="hidden"
+      >
+        <HStack
+          paddingY={2}
+          paddingX={3}
+          borderBottomWidth="1px"
+          borderColor="border.muted"
+          backgroundColor="bg.subtle"
+          justifyContent="space-between"
+        >
+          <VStack align="start" gap={0}>
+            <Text
+              fontSize="xs"
+              fontWeight="semibold"
+              color="fg.muted"
+              textTransform="uppercase"
+              letterSpacing="wider"
+            >
+              People the providers see
+            </Text>
+            <Text fontSize="xs" color="fg.subtle">
+              Everyone named on pulled rows, most of whom hold no LangWatch
+              account. Run the match pass to link the ones something proves.
+            </Text>
+          </VStack>
+          {canManage && (
+            <Button
+              size="xs"
+              colorPalette="orange"
+              loading={runMatch.isPending}
+              onClick={() => runMatch.mutate({ organizationId: orgId })}
+            >
+              Run match pass
+            </Button>
+          )}
+        </HStack>
+
+        <HandledErrorAlert
+          error={peopleQuery.error}
+          fallbackTitle="Couldn't load discovered people"
+        />
+
+        {peopleQuery.isLoading ? (
+          <Box padding={4}>
+            <Spinner />
+          </Box>
+        ) : people.length === 0 ? (
+          <Box padding={4} color="fg.muted" fontSize="sm">
+            Nobody discovered yet. People appear here as pull sources deliver
+            rows that name them.
+          </Box>
+        ) : (
+          people.map((person) => (
+            <DiscoveredPersonRow key={person.id} person={person} />
+          ))
+        )}
+      </VStack>
+
+      {suggestions.length > 0 && (
+        <SuggestionsPanel
+          orgId={orgId}
+          suggestions={suggestions}
+          canManage={canManage}
+          onChanged={refreshIdentity}
+        />
+      )}
+    </>
+  );
+}
+
+function DiscoveredPersonRow({ person }: { person: DiscoveredPerson }) {
+  const isMachine = person.kind !== "person";
+  return (
+    <HStack
+      paddingY={2}
+      paddingX={3}
+      borderBottomWidth="1px"
+      borderColor="border.muted"
+      fontSize="sm"
+      justifyContent="space-between"
+      gap={4}
+    >
+      <VStack align="start" gap={0} minW={0}>
+        <HStack gap={2}>
+          <Text fontWeight="medium" truncate>
+            {person.displayText}
+          </Text>
+          {person.erasedAt && <Badge colorPalette="purple">erased</Badge>}
+          {isMachine && <Badge colorPalette="gray">machine login</Badge>}
+          {person.suspendedAt && (
+            <Badge colorPalette="yellow" title={person.suspendedReason ?? ""}>
+              needs review
+            </Badge>
+          )}
+        </HStack>
+        <Text fontSize="xs" color="fg.muted">
+          {person.provider} · seen {fmtDay(person.firstSeenAt)} –{" "}
+          {fmtDay(person.lastSeenAt)}
+        </Text>
+      </VStack>
+      <VStack align="end" gap={0} flexShrink={0}>
+        {person.link ? (
+          <>
+            <Text fontSize="sm">
+              {person.link.memberName ?? person.link.userId}
+              {person.link.departmentName
+                ? ` · ${person.link.departmentName}`
+                : ""}
+            </Text>
+            <Text fontSize="xs" color="fg.muted">
+              linked ·{" "}
+              {EVIDENCE_LABEL[person.link.evidenceKind] ??
+                person.link.evidenceKind}
+            </Text>
+          </>
+        ) : (
+          <Text fontSize="xs" color="fg.subtle">
+            {person.erasedAt ? "" : "not linked"}
+          </Text>
+        )}
+      </VStack>
+    </HStack>
+  );
+}
+
+/**
+ * The review queue: what the engine would not decide on its own. Confirming
+ * is the engine spec's contract — the link it opens, the refusals for people
+ * since linked or erased — this panel only reaches it.
+ */
+function SuggestionsPanel({
+  orgId,
+  suggestions,
+  canManage,
+  onChanged,
+}: {
+  orgId: string;
+  suggestions: MatchSuggestion[];
+  canManage: boolean;
+  onChanged: () => Promise<void>;
+}) {
+  const confirmMutation = api.governancePeople.confirmSuggestion.useMutation({
+    onSuccess: async () => {
+      toaster.create({ title: "Link confirmed", type: "success" });
+      await onChanged();
+    },
+    onError: (e) =>
+      showErrorToast({ error: e, fallbackTitle: "Couldn't confirm the link" }),
+  });
+
+  return (
+    <VStack
+      align="stretch"
+      gap={0}
+      borderWidth="1px"
+      borderColor="border.muted"
+      borderRadius="md"
+      overflow="hidden"
+    >
+      <Box
+        paddingY={2}
+        paddingX={3}
+        borderBottomWidth="1px"
+        borderColor="border.muted"
+        backgroundColor="bg.subtle"
+      >
+        <Text
+          fontSize="xs"
+          fontWeight="semibold"
+          color="fg.muted"
+          textTransform="uppercase"
+          letterSpacing="wider"
+        >
+          Suggested matches
+        </Text>
+        <Text fontSize="xs" color="fg.subtle" marginTop={1}>
+          Names that merely resemble a member. Nothing links until a person
+          confirms it.
+        </Text>
+      </Box>
+      {suggestions.map((suggestion) => (
+        <HStack
+          key={suggestion.id}
+          paddingY={2}
+          paddingX={3}
+          borderBottomWidth="1px"
+          borderColor="border.muted"
+          fontSize="sm"
+          justifyContent="space-between"
+        >
+          <Text minW={0} truncate>
+            <Text as="span" fontWeight="medium">
+              {suggestion.personDisplayText}
+            </Text>{" "}
+            <Text as="span" color="fg.muted">
+              ({suggestion.personProvider})
+            </Text>{" "}
+            ≈{" "}
+            <Text as="span" fontWeight="medium">
+              {suggestion.memberName ?? suggestion.userId}
+            </Text>
+          </Text>
+          {canManage && (
+            <Button
+              size="xs"
+              variant="outline"
+              loading={
+                confirmMutation.isPending &&
+                confirmMutation.variables?.suggestionId === suggestion.id
+              }
+              onClick={() =>
+                confirmMutation.mutate({
+                  organizationId: orgId,
+                  suggestionId: suggestion.id,
+                })
+              }
+            >
+              Confirm
+            </Button>
+          )}
+        </HStack>
+      ))}
+    </VStack>
   );
 }
 

--- a/platform/app/src/pages/governance/people.tsx
+++ b/platform/app/src/pages/governance/people.tsx
@@ -9,6 +9,7 @@ import {
   Text,
   VStack,
 } from "@chakra-ui/react";
+import { MATCH_EVIDENCE_KIND } from "@ee/governance/services/logic/identityEvidence";
 import { Archive, ExternalLink, MoreVertical, Pencil } from "lucide-react";
 import { useState } from "react";
 import { ConfirmDialog } from "~/components/gateway/ConfirmDialog";
@@ -92,12 +93,21 @@ function PeoplePage() {
   );
 }
 
-/** The proof column's words, for humans rather than for the enum. */
+/**
+ * The proof column's words, for humans rather than for the enum — keyed off
+ * the engine's own vocabulary so a kind added there fails the build here
+ * instead of silently rendering its slug.
+ */
 const EVIDENCE_LABEL: Record<string, string> = {
-  verified_email: "confirmed address",
-  verified_email_and_directory_id: "confirmed address + directory",
-  human_confirmed: "confirmed by a person",
-};
+  [MATCH_EVIDENCE_KIND.VERIFIED_EMAIL]: "confirmed address",
+  [MATCH_EVIDENCE_KIND.VERIFIED_EMAIL_AND_DIRECTORY_ID]:
+    "confirmed address + directory",
+  [MATCH_EVIDENCE_KIND.DIRECTORY_ID]: "directory identifier",
+  [MATCH_EVIDENCE_KIND.HUMAN_CONFIRMED]: "confirmed by a person",
+} satisfies Record<
+  (typeof MATCH_EVIDENCE_KIND)[keyof typeof MATCH_EVIDENCE_KIND],
+  string
+>;
 
 const fmtDay = (d: Date | string) => {
   const date = typeof d === "string" ? new Date(d) : d;

--- a/platform/app/src/pages/governance/people.tsx
+++ b/platform/app/src/pages/governance/people.tsx
@@ -143,7 +143,7 @@ function useDiscoveredPeople(orgId: string) {
     onSuccess: async (outcome) => {
       toaster.create({
         title: "Match pass finished",
-        description: `${outcome.linked} linked, ${outcome.suggestionsWritten} suggested, ${outcome.unproven} unproven.`,
+        description: `${outcome.linked} linked, ${outcome.unproven} unproven. Suggestions refresh as pull sources deliver people.`,
         type: "success",
       });
       await refreshIdentity();

--- a/platform/app/src/server/api/root.ts
+++ b/platform/app/src/server/api/root.ts
@@ -4,6 +4,7 @@ import { anomalyRulesRouter } from "@ee/governance/routers/anomalyRules";
 import { departmentsRouter } from "@ee/governance/routers/departments";
 import { governanceRouter } from "@ee/governance/routers/governance";
 import { governanceCostRouter } from "@ee/governance/routers/governanceCost";
+import { governancePeopleRouter } from "@ee/governance/routers/governancePeople";
 import { ingestionKeyRouter } from "@ee/governance/routers/ingestionKey";
 import { ingestionSourcesRouter } from "@ee/governance/routers/ingestionSources";
 import { ingestionTemplatesRouter } from "@ee/governance/routers/ingestionTemplates";
@@ -176,6 +177,7 @@ const coreRouters = {
   ingestionKey: ingestionKeyRouter,
   governance: governanceRouter,
   governanceCost: governanceCostRouter,
+  governancePeople: governancePeopleRouter,
   personalSessions: personalSessionsRouter,
   sessionPolicy: sessionPolicyRouter,
   gatewayBudgets: gatewayBudgetsRouter,

--- a/platform/app/src/server/app-layer/presets.ts
+++ b/platform/app/src/server/app-layer/presets.ts
@@ -28,6 +28,7 @@ import { createGovernanceRollupReplayPort } from "@ee/governance/services/govern
 import { GovernanceTraceActivityClickHouseRepository } from "@ee/governance/services/governanceTraceActivity.clickhouse.repository";
 import { IdentityErasureService } from "@ee/governance/services/identityErasure.service";
 import { IdentityMatchService } from "@ee/governance/services/identityMatch.service";
+import { IdentityMatchSuggestionService } from "@ee/governance/services/identityMatchSuggestion.service";
 import { PersonalUsageClickHouseRepository } from "@ee/governance/services/personalUsage.clickhouse.repository";
 import { WebhookEndpointService } from "@ee/webhooks/webhookEndpoint.service";
 import { WebhookEventsClickHouseRepository } from "@ee/webhooks/webhookEvents.clickhouse.repository";
@@ -1119,8 +1120,8 @@ export function initializeDefaultApp(options?: {
   // still has people to match.
   //
   // NOT the suggestion half. That one scores names, and it is composed only
-  // inside the worker-role block below so no request path can reach the scorer
-  // through this bag.
+  // behind the worker-role gate in `enterprisePipelines.identityMatch` below,
+  // so no request path can reach the scorer through this bag.
   const governanceIdentityMatch = new IdentityMatchService({ prisma });
 
   // Governance's OCSF SIEM-export sink. One instance for the whole App: the
@@ -1292,13 +1293,6 @@ export function initializeDefaultApp(options?: {
         );
       });
   }
-
-  // ADR-128 §12: the match engine gets no calendar entry, deliberately —
-  // nothing writes `DiscoveredPerson` yet, so a standing appointment would read
-  // an empty table on every tenant for ever. Its trigger arrives with the feed
-  // that discovers people and is a call site, not a schedule. Compose that
-  // caller on the worker role: the name scorer measured 2.9 seconds of blocked
-  // event loop at the ADR's example size.
 
   // ADR-044 Phase 3c: register the report handler so a due report ScheduledJob
   // renders + dispatches on schedule (worker-only, same notify pipeline as
@@ -1498,6 +1492,25 @@ export function initializeDefaultApp(options?: {
           }
         : undefined,
       governanceCostRollupStore,
+      // ADR-128 §12: the suggestion half's ONLY runtime composition, and the
+      // engine's only trigger — the feed that discovers people, a call site
+      // rather than a calendar entry. Worker role only (the name scorer
+      // measured 2.9 seconds of blocked event loop at the ADR's example size)
+      // and proof before guesses, the order the engine spec fixes. This import
+      // is what the scorer's import-graph guard names as the one allowed
+      // caller.
+      identityMatch: roleRunsWorkers(config.processRole)
+        ? {
+            runFor: async ({ organizationId }) => {
+              await IdentityMatchService.create(prisma).linkProvenMatches({
+                organizationId,
+              });
+              await IdentityMatchSuggestionService.create(prisma).recompute({
+                organizationId,
+              });
+            },
+          }
+        : undefined,
     },
     projects,
     monitors,

--- a/platform/app/src/server/evaluations/evaluators.generated.ts
+++ b/platform/app/src/server/evaluations/evaluators.generated.ts
@@ -242,27 +242,25 @@ export const evaluatorsSchema = z.object({
           "The maximum number of tokens allowed for evaluation, a too high number can be costly. Entries above this amount will be skipped.",
         )
         .default(2048),
-      rubrics: z
-        .array(z.object({ description: z.string() }))
-        .default([
-          { description: "The response is incorrect, irrelevant." },
-          {
-            description:
-              "The response partially answers the question but includes significant errors, omissions, or irrelevant information.",
-          },
-          {
-            description:
-              "The response partially answers the question but includes minor errors, omissions, or irrelevant information.",
-          },
-          {
-            description:
-              "The response fully answers the question and includes minor errors, omissions, or irrelevant information.",
-          },
-          {
-            description:
-              "The response fully answers the question and includes no errors, omissions, or irrelevant information.",
-          },
-        ]),
+      rubrics: z.array(z.object({ description: z.string() })).default([
+        { description: "The response is incorrect, irrelevant." },
+        {
+          description:
+            "The response partially answers the question but includes significant errors, omissions, or irrelevant information.",
+        },
+        {
+          description:
+            "The response partially answers the question but includes minor errors, omissions, or irrelevant information.",
+        },
+        {
+          description:
+            "The response fully answers the question and includes minor errors, omissions, or irrelevant information.",
+        },
+        {
+          description:
+            "The response fully answers the question and includes no errors, omissions, or irrelevant information.",
+        },
+      ]),
     }),
   }),
   "ragas/sql_query_equivalence": z.object({
@@ -893,7 +891,13 @@ export type EvaluatorDefinition<T extends EvaluatorTypes> = {
   name: string;
   description: string;
   category:
-    "quality" | "rag" | "safety" | "policy" | "other" | "custom" | "similarity";
+    | "quality"
+    | "rag"
+    | "safety"
+    | "policy"
+    | "other"
+    | "custom"
+    | "similarity";
   docsUrl?: string;
   isGuardrail: boolean;
   requiredFields: string[];

--- a/platform/app/src/server/evaluations/evaluators.generated.ts
+++ b/platform/app/src/server/evaluations/evaluators.generated.ts
@@ -242,25 +242,27 @@ export const evaluatorsSchema = z.object({
           "The maximum number of tokens allowed for evaluation, a too high number can be costly. Entries above this amount will be skipped.",
         )
         .default(2048),
-      rubrics: z.array(z.object({ description: z.string() })).default([
-        { description: "The response is incorrect, irrelevant." },
-        {
-          description:
-            "The response partially answers the question but includes significant errors, omissions, or irrelevant information.",
-        },
-        {
-          description:
-            "The response partially answers the question but includes minor errors, omissions, or irrelevant information.",
-        },
-        {
-          description:
-            "The response fully answers the question and includes minor errors, omissions, or irrelevant information.",
-        },
-        {
-          description:
-            "The response fully answers the question and includes no errors, omissions, or irrelevant information.",
-        },
-      ]),
+      rubrics: z
+        .array(z.object({ description: z.string() }))
+        .default([
+          { description: "The response is incorrect, irrelevant." },
+          {
+            description:
+              "The response partially answers the question but includes significant errors, omissions, or irrelevant information.",
+          },
+          {
+            description:
+              "The response partially answers the question but includes minor errors, omissions, or irrelevant information.",
+          },
+          {
+            description:
+              "The response fully answers the question and includes minor errors, omissions, or irrelevant information.",
+          },
+          {
+            description:
+              "The response fully answers the question and includes no errors, omissions, or irrelevant information.",
+          },
+        ]),
     }),
   }),
   "ragas/sql_query_equivalence": z.object({
@@ -891,13 +893,7 @@ export type EvaluatorDefinition<T extends EvaluatorTypes> = {
   name: string;
   description: string;
   category:
-    | "quality"
-    | "rag"
-    | "safety"
-    | "policy"
-    | "other"
-    | "custom"
-    | "similarity";
+    "quality" | "rag" | "safety" | "policy" | "other" | "custom" | "similarity";
   docsUrl?: string;
   isGuardrail: boolean;
   requiredFields: string[];

--- a/platform/app/src/shared/langy/langySkills.generated.json
+++ b/platform/app/src/shared/langy/langySkills.generated.json
@@ -23,9 +23,9 @@
 	{
 		"id": "connect-agent",
 		"label": "Connect agent",
-		"description": "Connect the codebase's AI agent to LangWatch agent testing over HTTP, so test suites run against it from the platform. Finds or adds the agent's chat endpoint, wires authentication for scenario traffic, makes the server adopt the W3C traceparent header so the judge reads the agent's own traces, registers the agent with the `langwatch` CLI, and runs the first test suite. Use when the user wants platform scenarios to test their real, deployed agent.",
+		"description": "Connect the codebase's AI agent to LangWatch agent simulations, so test suites run against the real agent process. Adds a small connect function beside the service startup that calls the agent already in the codebase, which opens an outbound connection and registers the agent with its environment and its run parameters, confirms the agent is Online, and runs the first test suite. Falls back to an HTTP registration when the agent cannot import the SDK. Use when the user wants platform scenarios to test their real agent.",
 		"category": "skill",
-		"userPrompt": "Connect my agent to LangWatch agent testing"
+		"userPrompt": "Connect my agent to LangWatch simulations"
 	},
 	{
 		"id": "context-sweet-spot",
@@ -140,7 +140,7 @@
 	{
 		"id": "scenarios",
 		"label": "Scenarios",
-		"description": "Test your AI agent with simulation-based scenarios. Covers writing scenario test code (Scenario SDK), creating platform scenarios via the `langwatch` CLI, and red teaming for security vulnerabilities. Auto-detects whether to use code or platform approach based on context.",
+		"description": "Test your AI agent with simulation-based scenarios. Covers writing scenario test code (Scenario SDK), creating platform scenarios via the `langwatch` CLI against a connected agent, reading the run parameters that agent declares so the scenarios and comparison runs turn its real levers, and red teaming for security vulnerabilities. Auto-detects whether to use code or platform approach based on context.",
 		"category": "skill",
 		"userPrompt": "Add scenario tests for my agent"
 	},

--- a/sdks/typescript/src/internal/generated/openapi/api-client.ts
+++ b/sdks/typescript/src/internal/generated/openapi/api-client.ts
@@ -764,14 +764,14 @@ export interface paths {
         };
         /** @description Read one agent with its presence, its owner and the run parameters it declares. An id the project does not hold answers 404 agent_not_found. */
         get: operations["getAgent"];
-        /** @description Update an agent: any of name, type, configuration and workflow. The update is partial under PATCH and PUT alike. A connected agent takes only a new description; anything else answers 422 agent_register_only. */
+        /** @description Update an agent: any of name, type, configuration and workflow. The update is partial under PATCH and PUT alike. A connected agent takes no edit and answers 422 agent_register_only. */
         put: operations["replaceAgent"];
         post?: never;
         /** @description Archive an agent. It leaves the list and its runs stay. A connected agent that registers again restores its row. */
         delete: operations["archiveAgent"];
         options?: never;
         head?: never;
-        /** @description Update an agent: any of name, type, configuration and workflow. The update is partial under PATCH and PUT alike. A connected agent takes only a new description; anything else answers 422 agent_register_only. */
+        /** @description Update an agent: any of name, type, configuration and workflow. The update is partial under PATCH and PUT alike. A connected agent takes no edit and answers 422 agent_register_only. */
         patch: operations["updateAgent"];
         trace?: never;
     };
@@ -1031,9 +1031,29 @@ export interface paths {
         };
         /**
          * Get pull request coding agent usage
-         * @description Assistant usage for one pull request: sessions, tokens and cost, grouped by contributor and agent, plus per-model totals, over the pull request's whole lifetime rather than a time window. Every row and the totals split cost three ways: the part priced per token, the part a bundled subscription already covers, and the list-price total of both. Per-model totals carry the list price only. Cost is calculated from the tokens the agent reported and LangWatch's model prices, so it estimates spend rather than restating a provider invoice. Requires a personal-project API key; rows appear only for projects the calling user may view, and cost only for those they may price.
+         * @description Assistant usage for one pull request: sessions, tokens and cost, grouped by contributor and agent, plus per-model totals, over the pull request's whole lifetime rather than a time window. Every row and the totals split cost three ways: the part priced per token, the part a bundled subscription already covers, and the list-price total of both. Per-model totals carry the list price only. Cost is calculated from the tokens the agent reported and LangWatch's model prices, so it estimates spend rather than restating a provider invoice. Requires a personal-project API key; rows appear only for projects the calling user may view, and cost only for those they may price. Prefer `GET /api/v1/coding-agent/pull-request-usage`, which answers the same question with an organization API key alone and needs no X-Project-Id header.
          */
         get: operations["getApiCodingAgentPullRequestUsage"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/coding-agent/pull-request-usage": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get pull request usage
+         * @description Assistant usage for one pull request: sessions, tokens and cost, grouped by contributor and agent, plus per-model totals, over the pull request's whole lifetime rather than a time window. Every row and the totals split cost three ways: the part priced per token, the part a bundled subscription already covers, and the list-price total of both. Per-model totals carry the list price only. Cost is calculated from the tokens the agent reported and LangWatch's model prices, so it estimates spend rather than restating a provider invoice. Authenticate with an organization API key and nothing else: no project id is sent anywhere. A key created for you reads with your own access; an organization service key, such as one a continuous integration job holds, reads with the access its bindings grant. Rows appear only for projects the key may view, and cost only for those it may price.
+         */
+        get: operations["getPullRequestUsage"];
         put?: never;
         post?: never;
         delete?: never;
@@ -5053,7 +5073,6 @@ export interface operations {
                     agents: {
                         name: string;
                         environment: string;
-                        description?: string;
                         /** @default {} */
                         parameters?: {
                             [key: string]: unknown;
@@ -8283,6 +8302,85 @@ export interface operations {
                     "application/json": {
                         error: string;
                         message?: string;
+                    };
+                };
+            };
+        };
+    };
+    getPullRequestUsage: {
+        parameters: {
+            query: {
+                /** @description The repository as "owner/name". */
+                repository: string;
+                /** @description The pull request number. */
+                pullRequest: number;
+                /** @description The GitHub host. Defaults to this instance's configured GitHub host, which is github.com unless an operator named a GitHub Enterprise Server. */
+                host?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Success */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        pullRequest: {
+                            repositoryHost: string;
+                            repositoryFullName: string;
+                            prNumber: number;
+                            headBranch: string;
+                            htmlUrl: string;
+                            state: string;
+                            isDraft: boolean;
+                            authorLogin: string | null;
+                            prCreatedAtMs: number;
+                            prClosedAtMs: number | null;
+                            prMergedAtMs: number | null;
+                        };
+                        rows: {
+                            projectId: string;
+                            projectSlug: string;
+                            contributorLabel: string;
+                            contributorIsProject: boolean;
+                            agent: string;
+                            models: string[];
+                            sessionsCount: number;
+                            inputTokens: number;
+                            outputTokens: number;
+                            cacheReadTokens: number;
+                            cacheCreationTokens: number;
+                            totalTokens: number;
+                            costUsd: number | null;
+                            billedCostUsd: number | null;
+                            nonBilledCostUsd: number | null;
+                        }[];
+                        totals: {
+                            sessionsCount: number;
+                            inputTokens: number;
+                            outputTokens: number;
+                            cacheReadTokens: number;
+                            cacheCreationTokens: number;
+                            totalTokens: number;
+                            costUsd: number | null;
+                            billedCostUsd: number | null;
+                            nonBilledCostUsd: number | null;
+                        };
+                        modelBreakdown: {
+                            model: string;
+                            inputTokens: number;
+                            outputTokens: number;
+                            cacheReadTokens: number;
+                            cacheCreationTokens: number;
+                            totalTokens: number;
+                            costUsd: number | null;
+                            tokensKnown: boolean;
+                        }[];
                     };
                 };
             };

--- a/specs/governance/governance-identity-match-engine.feature
+++ b/specs/governance/governance-identity-match-engine.feature
@@ -17,10 +17,11 @@ Feature: Deciding which provider-named person is which LangWatch account
   Scenario: The matcher keeps no standing appointment of its own
     When the background workers start
     Then no recurring matcher run is booked for that organization
-    # Nothing fills the provider-named people table yet, so a pass on a timer
-    # would sweep an empty list every night forever, on every tenant. The
-    # engine itself stays and runs whenever something asks it to; the trigger
-    # arrives with the feed that discovers people.
+    # A pass on a timer would re-sweep every tenant nightly whether or not
+    # anything changed. The engine runs whenever something asks it to, and
+    # the feed that discovers people is that trigger: the pull run hands the
+    # organization to the worker-composed matcher when a delivery names
+    # someone (governance-people-screen.feature).
 
   # ── Proof links by itself ─────────────────────────────────────────────────
 

--- a/specs/governance/governance-people-discovery.feature
+++ b/specs/governance/governance-people-discovery.feature
@@ -1,0 +1,156 @@
+@governance @identity
+Feature: Provider rows become discovered people
+  Every pulled row already names who did the thing — an email on an OpenAI
+  cost line, a directory id on a Copilot transcript, whatever Databricks put
+  in executed_by. Until now those names were read for money and audit and
+  then forgotten: nothing wrote them down as people, so the match engine
+  swept an empty list and the People screen had nobody to show. This is the
+  feed the engine spec promised — "the trigger arrives with the feed that
+  discovers people" — minus the trigger, which stays a button a person
+  presses (governance-people-screen.feature).
+  Decision: ADR-128 sections 10 and 11.
+
+  Background:
+    Given an organization with a pull source delivering events
+
+  # ── Discovery ─────────────────────────────────────────────────────────────
+
+  @integration
+  Scenario: An actor on a pulled row becomes a discovered person
+    When a pulled event names an actor this organization has never seen
+    Then a discovered person exists for that provider and identifier
+    And their first-seen and last-seen are the event's own time
+    # The event's time, not the pull's. A backfill of July read in September
+    # discovers people who were active in July.
+
+  @integration
+  Scenario: Seeing the same actor again moves last-seen forward only
+    Given a discovered person seen before
+    When a later pulled event names the same actor
+    Then their last-seen moves to the later event's time
+    And their first-seen stays where it was
+
+  @integration
+  Scenario: The same identifier on two providers is two discovered people
+    When two different providers both name the same email
+    Then each provider gets its own discovered person
+    # "m.silva on Anthropic" and "m.silva on OpenAI" are two claims by two
+    # systems. The match engine is what may decide they are one human.
+
+  @integration
+  Scenario: A row naming nobody discovers nobody
+    When a pulled event carries an empty actor
+    Then no discovered person is written
+    # Seat reports deliberately name no person; inventing one would attribute
+    # the tenant's procurement to a blank string.
+
+  @unit
+  Scenario: A bare-UUID Databricks actor is recorded as a machine login
+    When a Databricks event's actor is a bare UUID
+    Then the discovered record's kind is machine login, not person
+    # Deterministic per ADR-128 §10: under app-only auth humans surface as
+    # emails and service principals as UUIDs. Never guessed from name shape,
+    # and never per-provider generalized — a Copilot directory id is a person.
+
+  @integration
+  Scenario: An erased identifier is never re-discovered
+    Given a person who has been erased
+    When the next pull reads a window that still contains their activity
+    Then no discovered person row carries their identifier in plain text
+    # The same do-not-reimport list that keeps their money rows out keeps
+    # their person row out. Discovery running before that check would undo
+    # every erasure on the next thirty-day re-read.
+
+  @integration
+  Scenario: Discovery failing does not cost the run its events
+    When writing a discovered person fails
+    Then the pulled events are still recorded
+    And the failure is logged
+    # Discovery is a side-channel of the pull, not its purpose. The next run
+    # sees the same actor again; audit rows missed are gone for good.
+
+  # ── The directory read ────────────────────────────────────────────────────
+  # The Copilot source's tenant app can also read the directory itself —
+  # who exists, their name, their department. Same credential, one more
+  # consent (User.Read.All), so it is off until switched on.
+
+  @unit
+  Scenario: The directory is not read unless switched on
+    Given a Copilot source with the directory read left off
+    When the source runs
+    Then no directory request is made
+
+  @unit
+  Scenario: The directory is read once a day, not once a tick
+    Given a Copilot source with the directory read switched on
+    And the directory was already read today
+    When the source runs again today
+    Then no directory request is made
+    # A directory changes on people-time. Reading it every two minutes asks
+    # Graph four hundred times for the same answer.
+
+  @unit
+  Scenario: A directory read that fails holds the day and delivers the rest
+    Given a Copilot source with the directory read switched on
+    When the directory request fails
+    Then the run still delivers its conversations
+    And the directory day is held to be retried, not marked read
+    # Same contract as the seat read, including naming HTTP 403 for what it
+    # is: consent never granted, not a role misassigned.
+
+  @integration
+  Scenario: A directory row enriches a discovered person's display text
+    Given a discovered person whose display text is a bare directory id
+    When the directory names that id with a person's name
+    Then the discovered person's display text becomes that name
+    # A Copilot transcript knows people only as GUIDs. The directory is the
+    # one source that knows what the GUID is called.
+
+  # ── Departments ride the directory row ────────────────────────────────────
+  # The directory's department field lands on the SAME entities the SCIM
+  # costCenter push writes: resolve the department by name (creating it if
+  # new), assign the member. No parallel department shape, no free text.
+
+  @integration
+  Scenario: A directory department lands on the member it proves
+    Given a directory row whose identity proves a platform member
+    And the row carries a department name that already exists
+    When the directory sync runs
+    Then that member is assigned to that department
+    # Proof is the same standard the match engine accepts: the directory id
+    # the org's own SSO connection recorded, or an address the member has
+    # confirmed. An unconfirmed address assigns nobody.
+
+  @integration
+  Scenario: A department the organization has not created yet is created
+    Given a directory row naming a department that does not exist
+    When the directory sync runs
+    Then an active department with that name exists
+    And the proven member is assigned to it
+    # resolveByNameOrCreate — the identical call SCIM costCenter provisioning
+    # makes, so an IdP-run org and a directory-pull org build the same shape.
+
+  @integration
+  Scenario: A blank directory department leaves the member's assignment alone
+    Given a member an admin assigned to a department by hand
+    And the directory row for that member carries no department
+    When the directory sync runs
+    Then the member's assignment is untouched
+    # Deliberately weaker than SCIM push, which clears on empty. A pull is an
+    # observation, not a provisioning command: Entra tenants routinely leave
+    # the field blank, and blank must not erase an admin's hand-work daily.
+
+  @integration
+  Scenario: A directory row proving no member assigns nobody
+    Given a directory row whose identity proves no platform member
+    When the directory sync runs
+    Then no department assignment is made
+    And the row's person is still discovered
+    # They appear on the People screen as discovered; the day they are linked,
+    # the next directory read assigns their department without anyone asking.
+
+  @integration
+  Scenario: An erased identifier in the directory is skipped entirely
+    Given a person who has been erased
+    When the directory read returns a row naming their identifier
+    Then no discovered person, display text, or assignment is written from it

--- a/specs/governance/governance-people-screen.feature
+++ b/specs/governance/governance-people-screen.feature
@@ -4,8 +4,8 @@ Feature: The People screen shows who the providers named
   everyone a provider has named, whether they hold a LangWatch account or
   not, with the match engine's verdicts beside them and its button in front
   of them. The engine keeps no standing appointment
-  (governance-identity-match-engine.feature) — this screen is where a person
-  asks it to run.
+  (governance-identity-match-engine.feature) — this screen asks for the proof
+  pass on demand, and the feed that discovers people triggers the rest.
   Decision: ADR-128 sections 11 and 12.
 
   Background:
@@ -45,13 +45,23 @@ Feature: The People screen shows who the providers named
   # ── Running the engine ────────────────────────────────────────────────────
 
   @integration
-  Scenario: The match button runs the proven pass and the suggestion pass
+  Scenario: The match button runs the proof pass
     When a governance manager presses the match button
     Then proven identities are linked
-    And suggestions are recomputed
-    And the answer says how many were linked and how many suggested
-    # One button, both passes. Splitting them asks the user to know the
-    # engine's internal seam between proof and guess.
+    And the answer says how many were linked and how many remain unproven
+    # Proof only, and the absence is the design: the suggestion pass scores
+    # names, which the engine's import-graph gate keeps off every request
+    # path (ADR-128 section 12). The button gives fresh proof links on
+    # demand; guesses arrive with the feed, below.
+
+  @unit
+  Scenario: Suggestions are recomputed when the feed discovers people
+    When a pull delivers rows that discover at least one person
+    Then the suggestion pass runs on the worker, after the delivery's own writes
+    # The trigger the engine spec promised: a call site on the feed, composed
+    # by the root on the worker role. A pull that discovers nobody is not a
+    # trigger — an empty feed re-scoring an unchanged queue is the nightly
+    # timer this design replaced.
 
   @integration
   Scenario: Running the engine requires the governance manage grant

--- a/specs/governance/governance-people-screen.feature
+++ b/specs/governance/governance-people-screen.feature
@@ -1,0 +1,77 @@
+@governance @identity
+Feature: The People screen shows who the providers named
+  Departments already live on this screen. This adds the people themselves:
+  everyone a provider has named, whether they hold a LangWatch account or
+  not, with the match engine's verdicts beside them and its button in front
+  of them. The engine keeps no standing appointment
+  (governance-identity-match-engine.feature) — this screen is where a person
+  asks it to run.
+  Decision: ADR-128 sections 11 and 12.
+
+  Background:
+    Given an organization with discovered people
+
+  # ── Reading ───────────────────────────────────────────────────────────────
+
+  @integration
+  Scenario: The list shows what a provider said and what the engine decided
+    When a governance viewer opens the People screen
+    Then each discovered person shows their identifier, provider, and kind
+    And when they were first and last seen
+    And whether they are linked to an account, and by what proof
+
+  @integration
+  Scenario: A linked person shows their member's department
+    Given a discovered person linked to a member assigned to a department
+    When the list is read
+    Then that person's row carries the department name
+    # The department lives on the membership, not on the discovered person.
+    # The row shows it through the link; an unlinked person shows none.
+
+  @integration
+  Scenario: An erased person shows a stand-in, never the identifier
+    Given a person who has been erased
+    When the list is read
+    Then their row is marked erased
+    And shows the pseudonym their identifier was replaced with
+    # The row survives erasure so spend stays attributable to someone; what
+    # it must never do is show who that someone was.
+
+  @integration
+  Scenario: Reading the list requires the governance view grant
+    When someone without governance view asks for the list
+    Then the request is refused
+
+  # ── Running the engine ────────────────────────────────────────────────────
+
+  @integration
+  Scenario: The match button runs the proven pass and the suggestion pass
+    When a governance manager presses the match button
+    Then proven identities are linked
+    And suggestions are recomputed
+    And the answer says how many were linked and how many suggested
+    # One button, both passes. Splitting them asks the user to know the
+    # engine's internal seam between proof and guess.
+
+  @integration
+  Scenario: Running the engine requires the governance manage grant
+    When someone with only governance view asks to run the engine
+    Then the request is refused
+    # The viewer grant reads; linking writes identity rows.
+
+  # ── Suggestions ───────────────────────────────────────────────────────────
+  # What confirming does — the link it opens, the refusals for people since
+  # linked or erased — is the engine spec's contract. This screen only has
+  # to reach it.
+
+  @integration
+  Scenario: A suggestion shows both halves and a confirm action
+    Given a stored suggestion
+    When a governance manager reads the screen
+    Then the suggestion shows the provider-named person and the account
+    And confirming it links them and removes the suggestion from the screen
+
+  @integration
+  Scenario: Confirming requires the governance manage grant
+    When someone with only governance view tries to confirm a suggestion
+    Then the request is refused


### PR DESCRIPTION
# Related Issue

- Resolves #7746

Wave-2 people UI (#7746, stacks directly on #7820): the identity tables the erasure PR created get their producer, their directory feed, and their screen. Zero schema changes, and no dependency on the seat-coverage (#7823) or retention (#7822) branches.

## What this adds

**Discovery producer** — every pull now records who the provider named. `PersonDiscoveryService.recordFromPulledEvents` runs on the post-suppression (`kept`) half of each batch inside `writePulledEvents`: an actor on a pulled row upserts a `DiscoveredPerson` (widen-only seen range), an empty actor discovers nobody, a bare-UUID Databricks actor is recorded as a machine login, and an erased identifier can never be re-discovered because suppression partitions the batch before discovery sees it. Discovery failure is caught and logged — it never costs the run its events (and `assertRunMadeProgress` runs before `writePulledEvents`, so a failed run never reaches discovery at all).

**Directory feed** — the Copilot source grows `readDirectory` (default **off**: `/v1.0/users` needs `User.Read.All`, a heavier consent than the seats read's `Organization.Read.All`). Once a day, same held-day cursor contract as seats, it lists the tenant's users: each row is a `directory_report` event whose actor is the Entra object id — the same id space Copilot transcripts use, so one person row serves both, and erasure suppression covers directory rows for free. Directory sightings enrich `displayText` and never widen the seen range (presence is not activity).

**Departments from the directory** — `DirectoryDepartmentSyncService` reuses the SCIM costCenter path (`DepartmentService.resolveByNameOrCreate` + `assignUser`): a directory row that *proves* a member (directory id exactly-one, else confirmed address exactly-one) lands their Entra `department` on the membership, creating the Department if the org hasn't yet. A blank department leaves hand-work alone (deliberate divergence from SCIM, where blank clears). A row proving nobody assigns nobody.

**People screen** — `/governance/people` (the departments page) gains the discovered-people panel: everyone the providers named, provider + seen range, link state with human-readable evidence, erased rows wearing their pseudonym, a **Run match pass** button (`governance:manage`) that runs the engine's proof pass, and a suggestions panel with per-row Confirm. Reads on `governance:view`, writes on `governance:manage`, enforced at the tRPC boundary (`governancePeople` router) and covered by an RBAC test with admin / member / delegated-viewer principals.

**Suggestion pass rides the feed, not the button** — the scorer's import-graph guard (ADR-128 §12) caught the first cut running the quadratic suggestion pass from the router. Now the button runs only the proof pass (cheap, exact-key), and the suggestion pass runs when a pull delivery discovers people: `pullerWorker` takes an injected `DiscoveredPeopleMatcher` port (a type, never an import — the worker is statically reachable from the ops router), and `presets.ts` composes the engine behind the worker-role gate as the guard's one allowed caller. A failed pass costs freshness only; the next pull retries.

## Specs

- `specs/governance/governance-people-discovery.feature` — 16 scenarios, all bound
- `specs/governance/governance-people-screen.feature` — 9 scenarios, all bound

## Proven against live providers

Ran on a fresh haven stack with real credentials (verdict comment below): the directory read pulled the real Entra tenant (8 people with display names), the department sync auto-created "Product" from a live Entra `department` field and assigned it through the directory-id proof, the match pass suggested a name-similarity pair and Confirm linked it, and the OpenAI cost pull attributed rows to a member's verified address.

## Notes for review

- No error mapping in the router's `confirmSuggestion`: the engine's refusals all extend `HandledError`, which the boundary already serialises with registered codes (the departments router's map is live only because its errors extend plain `Error`).
- `EVIDENCE_LABEL` on the page keys off `MATCH_EVIDENCE_KIND`, so a new evidence kind fails the build rather than rendering its slug.
- P2 (accepted): `listPeople`/`listSuggestions` are unpaginated; fine at current volumes, worth a cursor before orgs with thousands of discovered actors.
- P3 (by design): each directory user costs one OCSF audit row per day (PII in `raw_payload`, suppression-gated; the retention cap on those rows lands separately with #7822).


