### PR TITLE
feat(traces-v2): make thumbs_up_down events filterable without configuration

### DIFF
--- a/platform/app/src/features/traces-v2/components/FilterSidebar/AttributeKeyRow.tsx
+++ b/platform/app/src/features/traces-v2/components/FilterSidebar/AttributeKeyRow.tsx
@@ -18,6 +18,7 @@ import { formatCount } from "./utils";
 
 export const AttributeKeyRow = memo(function AttributeKeyRow({
   attrKey,
+  filterPrefix,
   displayLabel,
   count,
   getValueState,
@@ -26,6 +27,12 @@ export const AttributeKeyRow = memo(function AttributeKeyRow({
   onToggleNone,
 }: {
   attrKey: string;
+  /**
+   * Prefix the enclosing section writes filters with (`attribute`,
+   * `event.attribute`, `span.attribute`). The value lookup must query the
+   * same facet key, or this row lists values from the wrong store.
+   */
+  filterPrefix?: string;
   /**
    * Text shown for this key. Defaults to `attrKey`; the Metadata section
    * passes the `metadata.`-stripped form. Display-only — `attrKey` still
@@ -39,7 +46,11 @@ export const AttributeKeyRow = memo(function AttributeKeyRow({
   onToggleNone: () => void;
 }) {
   const [open, setOpen] = useState(false);
-  const { values, isLoading } = useAttributeValues(attrKey, open);
+  const { values, isLoading } = useAttributeValues({
+    attrKey,
+    enabled: open,
+    filterPrefix,
+  });
 
   const activeCount = useMemo(() => {
     const valueActive = values.filter(

--- a/platform/app/src/features/traces-v2/components/FilterSidebar/AttributesSection.tsx
+++ b/platform/app/src/features/traces-v2/components/FilterSidebar/AttributesSection.tsx
@@ -15,6 +15,13 @@ interface AttributesSectionProps {
   title: string;
   keys: AttributeKey[];
   icon?: React.ElementType;
+  /**
+   * Prefix this section's filters are written with (`attribute`,
+   * `event.attribute`, `span.attribute`). Threaded to each key row so the
+   * lazy value lookup queries the SAME facet key the filter click writes —
+   * the server routes the prefix to the matching attribute store.
+   */
+  filterPrefix?: string;
   /** Active filter state per `<prefix>.<key>:<value>` */
   getValueState: (attrKey: string, value: string) => FacetValueState;
   /** Active state for `none:<prefix>.<key>` */
@@ -49,6 +56,7 @@ const AttributesSectionInner: React.FC<AttributesSectionProps> = ({
   title,
   keys,
   icon,
+  filterPrefix,
   getValueState,
   getNoneActive,
   onToggleValue,
@@ -173,6 +181,7 @@ const AttributesSectionInner: React.FC<AttributesSectionProps> = ({
               <AttributeKeyRow
                 key={key.value}
                 attrKey={key.value}
+                filterPrefix={filterPrefix}
                 displayLabel={stripPrefix(key.value, displayStripPrefix)}
                 count={key.count}
                 getValueState={getValueState}

--- a/platform/app/src/features/traces-v2/components/FilterSidebar/EventDrilldown.tsx
+++ b/platform/app/src/features/traces-v2/components/FilterSidebar/EventDrilldown.tsx
@@ -1,15 +1,11 @@
 import { Box, HStack, Text, VStack } from "@chakra-ui/react";
 import type { LiqeQuery } from "liqe";
 import type React from "react";
+import { EVENT_METRICS_PREFIX } from "~/server/app-layer/traces/query-language/eventMetrics";
 import { getFacetValueState } from "~/server/app-layer/traces/query-language/queries";
 import { RowButton } from "./RowButton";
 import type { EventMetricValues, FacetItem } from "./types";
 import { formatCount } from "./utils";
-
-/** Storage prefix stripped from metric keys for DISPLAY only — filters and
- *  value lookups always use the full key. Matches the ingest mapper's
- *  `event.metrics.` prefix (see facets/events.ts on the server). */
-const EVENT_METRICS_DISPLAY_PREFIX = "event.metrics.";
 
 const MIN_VISIBLE_FILL_PCT = 4;
 
@@ -77,8 +73,8 @@ const MetricGroup: React.FC<{
   toggleFacet: EventDrilldownProps["toggleFacet"];
 }> = ({ metric, ast, toggleFacet }) => {
   const field = `event.attribute.${metric.key}`;
-  const displayKey = metric.key.startsWith(EVENT_METRICS_DISPLAY_PREFIX)
-    ? metric.key.slice(EVENT_METRICS_DISPLAY_PREFIX.length)
+  const displayKey = metric.key.startsWith(EVENT_METRICS_PREFIX)
+    ? metric.key.slice(EVENT_METRICS_PREFIX.length)
     : metric.key;
   const maxCount = Math.max(...metric.values.map((v) => v.count), 0);
 

--- a/platform/app/src/features/traces-v2/components/FilterSidebar/EventDrilldown.tsx
+++ b/platform/app/src/features/traces-v2/components/FilterSidebar/EventDrilldown.tsx
@@ -99,6 +99,7 @@ const MetricGroup: React.FC<{
           <MetricValueRow
             key={v.value}
             value={v.value}
+            displayKey={displayKey}
             count={v.count}
             maxCount={maxCount}
             state={state}
@@ -119,19 +120,30 @@ const MetricGroup: React.FC<{
  */
 const MetricValueRow: React.FC<{
   value: string;
+  displayKey: string;
   count: number;
   maxCount: number;
   state: "neutral" | "include" | "exclude";
   onClick: () => void;
-}> = ({ value, count, maxCount, state, onClick }) => {
+}> = ({ value, displayKey, count, maxCount, state, onClick }) => {
   const active = state !== "neutral";
   const palette = state === "exclude" ? "red" : "blue";
   const fillPct =
     maxCount > 0 ? Math.max((count / maxCount) * 100, MIN_VISIBLE_FILL_PCT) : 0;
+  // The key qualifies the value because an event can carry several metrics,
+  // and two of them may offer the same value ("1" under both `vote` and
+  // `rating`). The state word says which way the filter points: "active"
+  // alone reads identically for an included and an excluded value.
+  const stateLabel =
+    state === "include"
+      ? "included"
+      : state === "exclude"
+        ? "excluded"
+        : "click to filter";
   return (
     <RowButton
       type="button"
-      aria-label={`${value} — ${active ? "active" : "click to filter"}`}
+      aria-label={`${displayKey} ${value} — ${stateLabel}`}
       data-state={state}
       position="relative"
       width="full"

--- a/platform/app/src/features/traces-v2/components/FilterSidebar/EventDrilldown.tsx
+++ b/platform/app/src/features/traces-v2/components/FilterSidebar/EventDrilldown.tsx
@@ -17,11 +17,15 @@ interface EventDrilldownProps {
   item: FacetItem;
   ast: LiqeQuery;
   /**
-   * Toggle a single top-level `event.attribute.<metric key>` clause. Plain
-   * facet toggle, no group mutation: the emitted predicate is trace-scoped,
-   * so ANDed event filters may match different events within one trace —
-   * a documented, accepted limitation (same-event pairing would need a
-   * grammar extension).
+   * Toggle a single top-level facet clause — used both for
+   * `event.attribute.<metric key>` and, when the row is inactive, for the
+   * `event:<type>` anchor added ahead of it (see the `eventActive` gate
+   * below). Plain facet toggles, no group mutation: once two DIFFERENT
+   * events are both active, their ANDed attribute filters may still match
+   * different events within one trace — a documented, accepted limitation
+   * (same-event pairing would need a grammar extension). What this fixes
+   * is only the unscoped case: a metric click no longer lands without its
+   * own event's anchor.
    */
   toggleFacet: ({ field, value }: { field: string; value: string }) => void;
 }
@@ -45,6 +49,15 @@ export const EventDrilldown: React.FC<EventDrilldownProps> = ({
   const metrics = item.eventMetrics ?? [];
   if (metrics.length === 0) return null;
 
+  // Whether `event:<item.value>` is already an active top-level clause.
+  // For an ACTIVE row this is always true (that's what "active" means).
+  // For an INACTIVE row expanded via the chevron it's false, and a metric
+  // click below adds the event anchor first — otherwise the emitted
+  // `event.attribute.<key>:<value>` alone would match traces carrying that
+  // metric under a completely different event type. See MetricGroup.
+  const eventActive =
+    getFacetValueState(ast, "event", item.value) === "include";
+
   return (
     // Same visual attachment as EvaluatorDrilldown: indented under the row
     // with a hairline guide, no card chrome.
@@ -62,6 +75,7 @@ export const EventDrilldown: React.FC<EventDrilldownProps> = ({
           <MetricGroup
             key={metric.key}
             eventType={item.value}
+            eventActive={eventActive}
             metric={metric}
             ast={ast}
             toggleFacet={toggleFacet}
@@ -74,10 +88,13 @@ export const EventDrilldown: React.FC<EventDrilldownProps> = ({
 
 const MetricGroup: React.FC<{
   eventType: string;
+  /** True when `event:<eventType>` is already an active clause — see
+   *  {@link EventDrilldown}. */
+  eventActive: boolean;
   metric: EventMetricValues;
   ast: LiqeQuery;
   toggleFacet: EventDrilldownProps["toggleFacet"];
-}> = ({ eventType, metric, ast, toggleFacet }) => {
+}> = ({ eventType, eventActive, metric, ast, toggleFacet }) => {
   const field = `event.attribute.${metric.key}`;
   const displayKey = metric.key.startsWith(EVENT_METRICS_PREFIX)
     ? metric.key.slice(EVENT_METRICS_PREFIX.length)
@@ -110,7 +127,15 @@ const MetricGroup: React.FC<{
             count={v.count}
             maxCount={maxCount}
             state={state}
-            onClick={() => toggleFacet({ field, value: v.value })}
+            onClick={() => {
+              // Scope the metric to its event BEFORE the metric clause
+              // lands, so the pair always reads as one predicate rather
+              // than a metric value floating unscoped at the top level.
+              if (!eventActive) {
+                toggleFacet({ field: "event", value: eventType });
+              }
+              toggleFacet({ field, value: v.value });
+            }}
           />
         );
       })}

--- a/platform/app/src/features/traces-v2/components/FilterSidebar/EventDrilldown.tsx
+++ b/platform/app/src/features/traces-v2/components/FilterSidebar/EventDrilldown.tsx
@@ -1,7 +1,10 @@
 import { Box, HStack, Text, VStack } from "@chakra-ui/react";
 import type { LiqeQuery } from "liqe";
 import type React from "react";
-import { EVENT_METRICS_PREFIX } from "~/server/app-layer/traces/query-language/eventMetrics";
+import {
+  EVENT_METRICS_PREFIX,
+  eventMetricValueLabel,
+} from "~/server/app-layer/traces/query-language/eventMetrics";
 import { getFacetValueState } from "~/server/app-layer/traces/query-language/queries";
 import { RowButton } from "./RowButton";
 import type { EventMetricValues, FacetItem } from "./types";
@@ -25,13 +28,14 @@ interface EventDrilldownProps {
 
 /**
  * Inline drilldown rendered under an event-name row (thumbs_up_down →
- * vote values 1 / -1 with counts). Renders purely from `item.eventMetrics`,
- * which the discover endpoint already attached — no query of its own,
- * mirroring EvaluatorDrilldown.
+ * "thumbs up" / "thumbs down" with counts). Renders purely from
+ * `item.eventMetrics`, which the discover endpoint already attached — no
+ * query of its own, mirroring EvaluatorDrilldown.
  *
- * Values are shown and filtered verbatim as stored: a stored "1" becomes
- * `event.attribute.event.metrics.vote:1`, character for character, so the
- * filter round-trips against the string the ingest wrote.
+ * Labels are humanised, values are not. A row reads "thumbs down" but emits
+ * `event.attribute.event.metrics.vote:-1` — the stored string character for
+ * character, so the filter round-trips against what ingest actually wrote.
+ * Anything without a human name (custom metrics) shows its stored string.
  */
 export const EventDrilldown: React.FC<EventDrilldownProps> = ({
   item,
@@ -57,6 +61,7 @@ export const EventDrilldown: React.FC<EventDrilldownProps> = ({
         {metrics.map((metric) => (
           <MetricGroup
             key={metric.key}
+            eventType={item.value}
             metric={metric}
             ast={ast}
             toggleFacet={toggleFacet}
@@ -68,10 +73,11 @@ export const EventDrilldown: React.FC<EventDrilldownProps> = ({
 };
 
 const MetricGroup: React.FC<{
+  eventType: string;
   metric: EventMetricValues;
   ast: LiqeQuery;
   toggleFacet: EventDrilldownProps["toggleFacet"];
-}> = ({ metric, ast, toggleFacet }) => {
+}> = ({ eventType, metric, ast, toggleFacet }) => {
   const field = `event.attribute.${metric.key}`;
   const displayKey = metric.key.startsWith(EVENT_METRICS_PREFIX)
     ? metric.key.slice(EVENT_METRICS_PREFIX.length)
@@ -95,6 +101,11 @@ const MetricGroup: React.FC<{
           <MetricValueRow
             key={v.value}
             value={v.value}
+            displayValue={eventMetricValueLabel({
+              eventType,
+              metricKey: metric.key,
+              value: v.value,
+            })}
             displayKey={displayKey}
             count={v.count}
             maxCount={maxCount}
@@ -115,13 +126,16 @@ const MetricGroup: React.FC<{
  * AST clause rather than an evaluator group.
  */
 const MetricValueRow: React.FC<{
+  /** The stored string — what the filter is built from. */
   value: string;
+  /** What the user reads: "thumbs down" where the wire says "-1". */
+  displayValue: string;
   displayKey: string;
   count: number;
   maxCount: number;
   state: "neutral" | "include" | "exclude";
   onClick: () => void;
-}> = ({ value, displayKey, count, maxCount, state, onClick }) => {
+}> = ({ value, displayValue, displayKey, count, maxCount, state, onClick }) => {
   const active = state !== "neutral";
   const palette = state === "exclude" ? "red" : "blue";
   const fillPct =
@@ -139,7 +153,7 @@ const MetricValueRow: React.FC<{
   return (
     <RowButton
       type="button"
-      aria-label={`${displayKey} ${value} — ${stateLabel}`}
+      aria-label={`${displayKey} ${displayValue} — ${stateLabel}`}
       data-state={state}
       position="relative"
       width="full"
@@ -186,7 +200,7 @@ const MetricValueRow: React.FC<{
       )}
       <HStack justify="space-between" gap={1} paddingRight={1.5}>
         <Text textStyle="2xs" color="fg.muted" truncate>
-          {value}
+          {displayValue}
         </Text>
         <Text textStyle="2xs" color="fg.subtle" flexShrink={0}>
           {formatCount(count)}

--- a/platform/app/src/features/traces-v2/components/FilterSidebar/EventDrilldown.tsx
+++ b/platform/app/src/features/traces-v2/components/FilterSidebar/EventDrilldown.tsx
@@ -1,0 +1,189 @@
+import { Box, HStack, Text, VStack } from "@chakra-ui/react";
+import type { LiqeQuery } from "liqe";
+import type React from "react";
+import { getFacetValueState } from "~/server/app-layer/traces/query-language/queries";
+import { RowButton } from "./RowButton";
+import type { EventMetricValues, FacetItem } from "./types";
+import { formatCount } from "./utils";
+
+/** Storage prefix stripped from metric keys for DISPLAY only — filters and
+ *  value lookups always use the full key. Matches the ingest mapper's
+ *  `event.metrics.` prefix (see facets/events.ts on the server). */
+const EVENT_METRICS_DISPLAY_PREFIX = "event.metrics.";
+
+const MIN_VISIBLE_FILL_PCT = 4;
+
+interface EventDrilldownProps {
+  /** The event FacetItem (must carry eventMetrics). */
+  item: FacetItem;
+  ast: LiqeQuery;
+  /**
+   * Toggle a single top-level `event.attribute.<metric key>` clause. Plain
+   * facet toggle, no group mutation: the emitted predicate is trace-scoped,
+   * so ANDed event filters may match different events within one trace —
+   * a documented, accepted limitation (same-event pairing would need a
+   * grammar extension).
+   */
+  toggleFacet: ({ field, value }: { field: string; value: string }) => void;
+}
+
+/**
+ * Inline drilldown rendered under an event-name row (thumbs_up_down →
+ * vote values 1 / -1 with counts). Renders purely from `item.eventMetrics`,
+ * which the discover endpoint already attached — no query of its own,
+ * mirroring EvaluatorDrilldown.
+ *
+ * Values are shown and filtered verbatim as stored: a stored "1" becomes
+ * `event.attribute.event.metrics.vote:1`, character for character, so the
+ * filter round-trips against the string the ingest wrote.
+ */
+export const EventDrilldown: React.FC<EventDrilldownProps> = ({
+  item,
+  ast,
+  toggleFacet,
+}) => {
+  const metrics = item.eventMetrics ?? [];
+  if (metrics.length === 0) return null;
+
+  return (
+    // Same visual attachment as EvaluatorDrilldown: indented under the row
+    // with a hairline guide, no card chrome.
+    <Box
+      marginLeft="20px"
+      marginTop={0.5}
+      marginBottom={1}
+      paddingLeft={2}
+      borderLeftWidth="1px"
+      borderLeftColor="border.muted"
+      data-spotlight="event-drilldown"
+    >
+      <VStack align="stretch" gap={1}>
+        {metrics.map((metric) => (
+          <MetricGroup
+            key={metric.key}
+            metric={metric}
+            ast={ast}
+            toggleFacet={toggleFacet}
+          />
+        ))}
+      </VStack>
+    </Box>
+  );
+};
+
+const MetricGroup: React.FC<{
+  metric: EventMetricValues;
+  ast: LiqeQuery;
+  toggleFacet: EventDrilldownProps["toggleFacet"];
+}> = ({ metric, ast, toggleFacet }) => {
+  const field = `event.attribute.${metric.key}`;
+  const displayKey = metric.key.startsWith(EVENT_METRICS_DISPLAY_PREFIX)
+    ? metric.key.slice(EVENT_METRICS_DISPLAY_PREFIX.length)
+    : metric.key;
+  const maxCount = Math.max(...metric.values.map((v) => v.count), 0);
+
+  return (
+    <VStack align="stretch" gap={0}>
+      <Text
+        textStyle="2xs"
+        color="fg.subtle"
+        fontWeight="medium"
+        paddingLeft={1.5}
+        paddingBottom={0.5}
+      >
+        {displayKey}
+      </Text>
+      {metric.values.map((v) => {
+        const state = getFacetValueState(ast, field, v.value);
+        return (
+          <MetricValueRow
+            key={v.value}
+            value={v.value}
+            count={v.count}
+            maxCount={maxCount}
+            state={state}
+            onClick={() => toggleFacet({ field, value: v.value })}
+          />
+        );
+      })}
+    </VStack>
+  );
+};
+
+/**
+ * One clickable metric value — the sidebar's compact row language (count,
+ * proportional fill on the bottom edge, subtle-bg when active), pared down
+ * from EvaluatorDrilldown's ValueRow: no dot (metric values are free-form
+ * stored strings, not a closed enum), and state comes from the top-level
+ * AST clause rather than an evaluator group.
+ */
+const MetricValueRow: React.FC<{
+  value: string;
+  count: number;
+  maxCount: number;
+  state: "neutral" | "include" | "exclude";
+  onClick: () => void;
+}> = ({ value, count, maxCount, state, onClick }) => {
+  const active = state !== "neutral";
+  const palette = state === "exclude" ? "red" : "blue";
+  const fillPct =
+    maxCount > 0 ? Math.max((count / maxCount) * 100, MIN_VISIBLE_FILL_PCT) : 0;
+  return (
+    <RowButton
+      type="button"
+      aria-label={`${value} — ${active ? "active" : "click to filter"}`}
+      data-state={state}
+      position="relative"
+      width="full"
+      paddingY={0.5}
+      paddingLeft={1.5}
+      paddingRight={0}
+      cursor="pointer"
+      textAlign="left"
+      borderRadius="sm"
+      overflow="hidden"
+      background={active ? `${palette}.subtle` : "transparent"}
+      borderWidth={0}
+      onClick={onClick}
+      transition="background 120ms ease"
+      _hover={{
+        background: active ? `${palette}.subtle` : "bg.muted",
+      }}
+      _focusVisible={{
+        outline: "2px solid",
+        outlineColor: "blue.focusRing",
+        outlineOffset: "-2px",
+      }}
+    >
+      <Box
+        position="absolute"
+        bottom={0}
+        left={0}
+        width={`${fillPct}%`}
+        height="2px"
+        bg={`${palette}.solid`}
+        opacity={0.55}
+        pointerEvents="none"
+      />
+      {active && (
+        <Box
+          position="absolute"
+          top={0}
+          right={0}
+          bottom={0}
+          width="2px"
+          bg={`${palette}.solid`}
+          pointerEvents="none"
+        />
+      )}
+      <HStack justify="space-between" gap={1} paddingRight={1.5}>
+        <Text textStyle="2xs" color="fg.muted" truncate>
+          {value}
+        </Text>
+        <Text textStyle="2xs" color="fg.subtle" flexShrink={0}>
+          {formatCount(count)}
+        </Text>
+      </HStack>
+    </RowButton>
+  );
+};

--- a/platform/app/src/features/traces-v2/components/FilterSidebar/SectionRenderer.tsx
+++ b/platform/app/src/features/traces-v2/components/FilterSidebar/SectionRenderer.tsx
@@ -11,6 +11,7 @@ import type { NumericMode } from "../../stores/numericModeStore";
 import { AttributesSection } from "./AttributesSection";
 import { NONE_TOGGLE_VALUE } from "./constants";
 import { EvaluatorDrilldown } from "./EvaluatorDrilldown";
+import { EventDrilldown } from "./EventDrilldown";
 import { FacetSection } from "./FacetSection";
 import { RangeSection } from "./RangeSection";
 import type { FacetItem, FacetValueState, Section } from "./types";
@@ -71,6 +72,47 @@ interface SectionRendererProps {
   setNumericMode: (args: { field: string; mode: NumericMode }) => void;
 }
 
+/**
+ * The trailing chevron that expands an INACTIVE row's inline drilldown
+ * (evaluator breakdown, event metric breakdown). Rendered as a sibling of
+ * the row button so a click here never toggles the facet — stopPropagation
+ * guards against any outer container handler too.
+ */
+const ExpandChevron: React.FC<{
+  isExpanded: boolean;
+  onToggleExpand: () => void;
+  /** Noun for the aria-label: "Show/Hide <subject> breakdown". */
+  subject: string;
+}> = ({ isExpanded, onToggleExpand, subject }) => (
+  <Box
+    as="button"
+    aria-label={`${isExpanded ? "Hide" : "Show"} ${subject} breakdown`}
+    aria-expanded={isExpanded}
+    display="flex"
+    alignItems="center"
+    justifyContent="center"
+    flexShrink={0}
+    width="20px"
+    height="20px"
+    borderRadius="sm"
+    cursor="pointer"
+    color="fg.subtle"
+    background="transparent"
+    border="none"
+    onClick={(e: React.MouseEvent) => {
+      e.stopPropagation();
+      onToggleExpand();
+    }}
+    _hover={{ color: "fg.muted", background: "bg.muted" }}
+  >
+    <Box
+      as={isExpanded ? ChevronDown : ChevronRight}
+      width="12px"
+      height="12px"
+    />
+  </Box>
+);
+
 const SectionRendererInner: React.FC<SectionRendererProps> = ({
   section,
   ast,
@@ -106,91 +148,19 @@ const SectionRendererInner: React.FC<SectionRendererProps> = ({
     // ACTIVE evaluator row — verdict pills, score range, label flag —
     // sourced from the `aggregates` the discover endpoint already
     // attached to each evaluator value. No second query.
+    // Event section mirrors the evaluator pattern with its own payload:
+    // per-event metric values (thumbs_up_down → vote 1 / -1) ride the
+    // discover response as `eventMetrics`; the drilldown emits plain
+    // top-level `event.attribute.<key>` toggles. No second query.
     const renderActiveRowExtras =
-      section.key === "evaluator"
+      section.key === "event"
         ? (item: FacetItem) =>
-            item.aggregates ? (
-              <EvaluatorDrilldown
-                item={item}
-                ast={ast}
-                toggleSubFilter={({ field, value }) =>
-                  toggleEvaluatorSubFilter({
-                    evaluatorId: item.value,
-                    field,
-                    value,
-                  })
-                }
-                setScoreRange={({ from, to }) =>
-                  setEvaluatorScoreRange({
-                    evaluatorId: item.value,
-                    from,
-                    to,
-                  })
-                }
-                removeScoreRange={() =>
-                  removeEvaluatorScoreRange({ evaluatorId: item.value })
-                }
-              />
+            item.eventMetrics ? (
+              <EventDrilldown item={item} ast={ast} toggleFacet={toggleFacet} />
             ) : null
-        : undefined;
-
-    // INACTIVE evaluator rows also get a drilldown affordance: a small
-    // chevron expand toggle. It renders inline at the row's trailing edge
-    // (via the `trailing` slot) rather than as a full-width strip beneath
-    // the row — clicking it browses verdict/score options before
-    // committing to the evaluator filter. When the user then picks a
-    // verdict or score range, the evaluator toggle fires first so the
-    // selected criteria applies correctly.
-    const renderInactiveRowExtras =
-      section.key === "evaluator"
-        ? (
-            item: FacetItem,
-            isExpanded: boolean,
-            onToggleExpand: () => void,
-          ) => {
-            if (!item.aggregates) return null;
-            // Picking a verdict / score / label on an inactive evaluator
-            // also enables the `evaluator:<id>` anchor — the group mutation
-            // adds it automatically, so no explicit activation wrapper is
-            // needed here.
-            return {
-              trailing: (
-                <Box
-                  as="button"
-                  aria-label={
-                    isExpanded
-                      ? "Hide evaluator breakdown"
-                      : "Show evaluator breakdown"
-                  }
-                  aria-expanded={isExpanded}
-                  display="flex"
-                  alignItems="center"
-                  justifyContent="center"
-                  flexShrink={0}
-                  width="20px"
-                  height="20px"
-                  borderRadius="sm"
-                  cursor="pointer"
-                  color="fg.subtle"
-                  background="transparent"
-                  border="none"
-                  // Sibling of the row button, so a click here never
-                  // toggles the facet — stopPropagation guards against
-                  // any outer container handler too.
-                  onClick={(e: React.MouseEvent) => {
-                    e.stopPropagation();
-                    onToggleExpand();
-                  }}
-                  _hover={{ color: "fg.muted", background: "bg.muted" }}
-                >
-                  <Box
-                    as={isExpanded ? ChevronDown : ChevronRight}
-                    width="12px"
-                    height="12px"
-                  />
-                </Box>
-              ),
-              below: isExpanded ? (
+        : section.key === "evaluator"
+          ? (item: FacetItem) =>
+              item.aggregates ? (
                 <EvaluatorDrilldown
                   item={item}
                   ast={ast}
@@ -212,10 +182,88 @@ const SectionRendererInner: React.FC<SectionRendererProps> = ({
                     removeEvaluatorScoreRange({ evaluatorId: item.value })
                   }
                 />
+              ) : null
+          : undefined;
+
+    // INACTIVE evaluator rows also get a drilldown affordance: a small
+    // chevron expand toggle. It renders inline at the row's trailing edge
+    // (via the `trailing` slot) rather than as a full-width strip beneath
+    // the row — clicking it browses verdict/score options before
+    // committing to the evaluator filter. When the user then picks a
+    // verdict or score range, the evaluator toggle fires first so the
+    // selected criteria applies correctly.
+    const renderInactiveRowExtras =
+      section.key === "event"
+        ? (
+            item: FacetItem,
+            isExpanded: boolean,
+            onToggleExpand: () => void,
+          ) => {
+            // No metrics on this event type → no expand affordance (same
+            // gating the evaluator applies via `aggregates`).
+            if (!item.eventMetrics) return null;
+            return {
+              trailing: (
+                <ExpandChevron
+                  isExpanded={isExpanded}
+                  onToggleExpand={onToggleExpand}
+                  subject="event metric"
+                />
+              ),
+              below: isExpanded ? (
+                <EventDrilldown
+                  item={item}
+                  ast={ast}
+                  toggleFacet={toggleFacet}
+                />
               ) : null,
             };
           }
-        : undefined;
+        : section.key === "evaluator"
+          ? (
+              item: FacetItem,
+              isExpanded: boolean,
+              onToggleExpand: () => void,
+            ) => {
+              if (!item.aggregates) return null;
+              // Picking a verdict / score / label on an inactive evaluator
+              // also enables the `evaluator:<id>` anchor — the group mutation
+              // adds it automatically, so no explicit activation wrapper is
+              // needed here.
+              return {
+                trailing: (
+                  <ExpandChevron
+                    isExpanded={isExpanded}
+                    onToggleExpand={onToggleExpand}
+                    subject="evaluator"
+                  />
+                ),
+                below: isExpanded ? (
+                  <EvaluatorDrilldown
+                    item={item}
+                    ast={ast}
+                    toggleSubFilter={({ field, value }) =>
+                      toggleEvaluatorSubFilter({
+                        evaluatorId: item.value,
+                        field,
+                        value,
+                      })
+                    }
+                    setScoreRange={({ from, to }) =>
+                      setEvaluatorScoreRange({
+                        evaluatorId: item.value,
+                        from,
+                        to,
+                      })
+                    }
+                    removeScoreRange={() =>
+                      removeEvaluatorScoreRange({ evaluatorId: item.value })
+                    }
+                  />
+                ) : null,
+              };
+            }
+          : undefined;
 
     const facetSection = (
       <FacetSection
@@ -328,6 +376,7 @@ const SectionRendererInner: React.FC<SectionRendererProps> = ({
       title={label}
       icon={icon}
       keys={keys}
+      filterPrefix={filterPrefix}
       displayStripPrefix={displayStripPrefix}
       emptyDocsHref={emptyDocsHref}
       getValueState={(attrKey, value) =>

--- a/platform/app/src/features/traces-v2/components/FilterSidebar/__tests__/EventDrilldown.integration.test.tsx
+++ b/platform/app/src/features/traces-v2/components/FilterSidebar/__tests__/EventDrilldown.integration.test.tsx
@@ -1,0 +1,108 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Coverage for the event drilldown (specs/traces-v2/search.feature, Rule
+ * "Event rows drill down into their metric values"):
+ * - metric values render from the discover payload (`item.eventMetrics`)
+ *   with their counts — the component fires no query of its own;
+ * - metric-group headers strip the `event.metrics.` storage prefix for
+ *   display while clicks keep the full key;
+ * - clicking a value emits exactly one top-level
+ *   `event.attribute.event.metrics.<key>` toggle — never a group mutation
+ *   (the cross-event AND collision is a documented, accepted limitation);
+ * - values are rendered verbatim as stored ("1", "-1"), never reformatted;
+ * - active values read their include/exclude state from the AST.
+ */
+
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+
+import {
+  EMPTY_AST,
+  parse,
+} from "~/server/app-layer/traces/query-language/parse";
+import { EventDrilldown } from "../EventDrilldown";
+import type { FacetItem } from "../types";
+
+const buildItem = (
+  eventMetrics: FacetItem["eventMetrics"] = [
+    {
+      key: "event.metrics.vote",
+      values: [
+        { value: "1", count: 12 },
+        { value: "-1", count: 3 },
+      ],
+    },
+  ],
+): FacetItem => ({
+  value: "thumbs_up_down",
+  label: "thumbs_up_down",
+  count: 15,
+  eventMetrics,
+});
+
+const renderDrilldown = ({
+  item = buildItem(),
+  ast = EMPTY_AST,
+  toggleFacet = vi.fn(),
+} = {}) => {
+  render(
+    <ChakraProvider value={defaultSystem}>
+      <EventDrilldown item={item} ast={ast} toggleFacet={toggleFacet} />
+    </ChakraProvider>,
+  );
+  return { toggleFacet };
+};
+
+afterEach(cleanup);
+
+describe("EventDrilldown", () => {
+  describe("given a thumbs_up_down item with vote metrics from the discover payload", () => {
+    /** @scenario "Expanding the thumbs_up_down row shows its vote values with counts" */
+    it("renders each stored value verbatim with its count", () => {
+      renderDrilldown();
+
+      expect(screen.getByText("1")).toBeInTheDocument();
+      expect(screen.getByText("-1")).toBeInTheDocument();
+      expect(screen.getByText("12")).toBeInTheDocument();
+      expect(screen.getByText("3")).toBeInTheDocument();
+    });
+
+    it("strips the event.metrics. prefix from the group header only", () => {
+      renderDrilldown();
+
+      expect(screen.getByText("vote")).toBeInTheDocument();
+      expect(screen.queryByText("event.metrics.vote")).not.toBeInTheDocument();
+    });
+
+    describe("when the user clicks a metric value", () => {
+      /** @scenario "Clicking a vote value applies a single event-attribute filter" */
+      it("toggles a single top-level event.attribute field with the verbatim value", () => {
+        const { toggleFacet } = renderDrilldown();
+
+        fireEvent.click(screen.getByText("-1"));
+
+        expect(toggleFacet).toHaveBeenCalledTimes(1);
+        expect(toggleFacet).toHaveBeenCalledWith({
+          field: "event.attribute.event.metrics.vote",
+          value: "-1",
+        });
+      });
+    });
+
+    describe("when a vote value is already active in the query", () => {
+      it("marks that row as included", () => {
+        renderDrilldown({
+          ast: parse("event.attribute.event.metrics.vote:-1"),
+        });
+
+        expect(screen.getByRole("button", { name: /-1/ })).toHaveAttribute(
+          "data-state",
+          "include",
+        );
+      });
+    });
+  });
+});

--- a/platform/app/src/features/traces-v2/components/FilterSidebar/__tests__/EventDrilldown.integration.test.tsx
+++ b/platform/app/src/features/traces-v2/components/FilterSidebar/__tests__/EventDrilldown.integration.test.tsx
@@ -103,6 +103,49 @@ describe("EventDrilldown", () => {
           "include",
         );
       });
+
+      it("names the row included, distinctly from an excluded one", () => {
+        renderDrilldown({
+          ast: parse("event.attribute.event.metrics.vote:-1"),
+        });
+
+        expect(
+          screen.getByRole("button", { name: "vote -1 — included" }),
+        ).toBeInTheDocument();
+        expect(
+          screen.getByRole("button", { name: "vote 1 — click to filter" }),
+        ).toBeInTheDocument();
+      });
+    });
+
+    describe("when a vote value is excluded in the query", () => {
+      it("names the row excluded rather than merely active", () => {
+        renderDrilldown({
+          ast: parse("NOT event.attribute.event.metrics.vote:-1"),
+        });
+
+        expect(
+          screen.getByRole("button", { name: "vote -1 — excluded" }),
+        ).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("given two metric groups that share a value", () => {
+    it("qualifies each value with its metric key so the names stay distinct", () => {
+      renderDrilldown({
+        item: buildItem([
+          { key: "event.metrics.vote", values: [{ value: "1", count: 4 }] },
+          { key: "event.metrics.rating", values: [{ value: "1", count: 2 }] },
+        ]),
+      });
+
+      expect(
+        screen.getByRole("button", { name: "vote 1 — click to filter" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "rating 1 — click to filter" }),
+      ).toBeInTheDocument();
     });
   });
 });

--- a/platform/app/src/features/traces-v2/components/FilterSidebar/__tests__/EventDrilldown.integration.test.tsx
+++ b/platform/app/src/features/traces-v2/components/FilterSidebar/__tests__/EventDrilldown.integration.test.tsx
@@ -72,20 +72,6 @@ describe("EventDrilldown", () => {
       expect(screen.queryByText("-1")).not.toBeInTheDocument();
     });
 
-    /** @scenario "A metric value with no human name shows its stored string" */
-    it("keeps a value with no human name as its stored string", () => {
-      renderDrilldown({
-        item: buildItem([
-          {
-            key: "event.metrics.latency_bucket",
-            values: [{ value: "p95", count: 4 }],
-          },
-        ]),
-      });
-
-      expect(screen.getByText("p95")).toBeInTheDocument();
-    });
-
     it("strips the event.metrics. prefix from the group header only", () => {
       renderDrilldown();
 
@@ -163,6 +149,29 @@ describe("EventDrilldown", () => {
       ).toBeInTheDocument();
       expect(
         screen.getByRole("button", { name: "stars 1 — click to filter" }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("given an event whose metric has no human name", () => {
+    /** @scenario "A metric with no human name shows its stored value" */
+    it("shows the stored value", () => {
+      // Metric values are numbers on every path — `eventSchema.metrics` is a
+      // record of string to number — so the unlabelled case is a decimal, not
+      // some free-form string. Ingest rejects a string with a 400.
+      renderDrilldown({
+        item: {
+          value: "checkout_survey",
+          label: "checkout_survey",
+          count: 1,
+          eventMetrics: [
+            { key: "event.metrics.stars", values: [{ value: "4", count: 1 }] },
+          ],
+        },
+      });
+
+      expect(
+        screen.getByRole("button", { name: "stars 4 — click to filter" }),
       ).toBeInTheDocument();
     });
   });

--- a/platform/app/src/features/traces-v2/components/FilterSidebar/__tests__/EventDrilldown.integration.test.tsx
+++ b/platform/app/src/features/traces-v2/components/FilterSidebar/__tests__/EventDrilldown.integration.test.tsx
@@ -61,13 +61,29 @@ afterEach(cleanup);
 describe("EventDrilldown", () => {
   describe("given a thumbs_up_down item with vote metrics from the discover payload", () => {
     /** @scenario "Expanding the thumbs_up_down row shows its vote values with counts" */
-    it("renders each stored value verbatim with its count", () => {
+    it("names each vote in words, with its count", () => {
       renderDrilldown();
 
-      expect(screen.getByText("1")).toBeInTheDocument();
-      expect(screen.getByText("-1")).toBeInTheDocument();
+      expect(screen.getByText("thumbs up")).toBeInTheDocument();
+      expect(screen.getByText("thumbs down")).toBeInTheDocument();
       expect(screen.getByText("12")).toBeInTheDocument();
       expect(screen.getByText("3")).toBeInTheDocument();
+      // The bare codes never reach the user.
+      expect(screen.queryByText("-1")).not.toBeInTheDocument();
+    });
+
+    /** @scenario "A metric value with no human name shows its stored string" */
+    it("keeps a value with no human name as its stored string", () => {
+      renderDrilldown({
+        item: buildItem([
+          {
+            key: "event.metrics.latency_bucket",
+            values: [{ value: "p95", count: 4 }],
+          },
+        ]),
+      });
+
+      expect(screen.getByText("p95")).toBeInTheDocument();
     });
 
     it("strips the event.metrics. prefix from the group header only", () => {
@@ -82,7 +98,8 @@ describe("EventDrilldown", () => {
       it("toggles a single top-level event.attribute field with the verbatim value", () => {
         const { toggleFacet } = renderDrilldown();
 
-        fireEvent.click(screen.getByText("-1"));
+        // Reads "thumbs down", filters on the stored "-1".
+        fireEvent.click(screen.getByText("thumbs down"));
 
         expect(toggleFacet).toHaveBeenCalledTimes(1);
         expect(toggleFacet).toHaveBeenCalledWith({
@@ -98,10 +115,9 @@ describe("EventDrilldown", () => {
           ast: parse("event.attribute.event.metrics.vote:-1"),
         });
 
-        expect(screen.getByRole("button", { name: /-1/ })).toHaveAttribute(
-          "data-state",
-          "include",
-        );
+        expect(
+          screen.getByRole("button", { name: /thumbs down/ }),
+        ).toHaveAttribute("data-state", "include");
       });
 
       it("names the row included, distinctly from an excluded one", () => {
@@ -110,10 +126,12 @@ describe("EventDrilldown", () => {
         });
 
         expect(
-          screen.getByRole("button", { name: "vote -1 — included" }),
+          screen.getByRole("button", { name: "vote thumbs down — included" }),
         ).toBeInTheDocument();
         expect(
-          screen.getByRole("button", { name: "vote 1 — click to filter" }),
+          screen.getByRole("button", {
+            name: "vote thumbs up — click to filter",
+          }),
         ).toBeInTheDocument();
       });
     });
@@ -125,26 +143,26 @@ describe("EventDrilldown", () => {
         });
 
         expect(
-          screen.getByRole("button", { name: "vote -1 — excluded" }),
+          screen.getByRole("button", { name: "vote thumbs down — excluded" }),
         ).toBeInTheDocument();
       });
     });
   });
 
-  describe("given two metric groups that share a value", () => {
+  describe("given two metric groups that share a stored value", () => {
     it("qualifies each value with its metric key so the names stay distinct", () => {
       renderDrilldown({
         item: buildItem([
-          { key: "event.metrics.vote", values: [{ value: "1", count: 4 }] },
           { key: "event.metrics.rating", values: [{ value: "1", count: 2 }] },
+          { key: "event.metrics.stars", values: [{ value: "1", count: 4 }] },
         ]),
       });
 
       expect(
-        screen.getByRole("button", { name: "vote 1 — click to filter" }),
+        screen.getByRole("button", { name: "rating 1 — click to filter" }),
       ).toBeInTheDocument();
       expect(
-        screen.getByRole("button", { name: "rating 1 — click to filter" }),
+        screen.getByRole("button", { name: "stars 1 — click to filter" }),
       ).toBeInTheDocument();
     });
   });

--- a/platform/app/src/features/traces-v2/components/FilterSidebar/__tests__/EventDrilldown.integration.test.tsx
+++ b/platform/app/src/features/traces-v2/components/FilterSidebar/__tests__/EventDrilldown.integration.test.tsx
@@ -10,7 +10,10 @@
  * - clicking a value emits exactly one top-level
  *   `event.attribute.event.metrics.<key>` toggle — never a group mutation
  *   (the cross-event AND collision is a documented, accepted limitation);
- * - values are rendered verbatim as stored ("1", "-1"), never reformatted;
+ * - a predefined event's opaque codes read as words ("-1" shows as "thumbs
+ *   down") while the click still emits the stored string; every metric
+ *   without a human name shows exactly what ingest wrote;
+ * - an event carrying no metrics renders nothing to expand into;
  * - active values read their include/exclude state from the AST.
  */
 
@@ -150,6 +153,36 @@ describe("EventDrilldown", () => {
       expect(
         screen.getByRole("button", { name: "stars 1 — click to filter" }),
       ).toBeInTheDocument();
+    });
+  });
+
+  describe("given an event type carrying no metrics", () => {
+    /** @scenario "An event type with no metrics shows no drilldown affordance" */
+    it("renders nothing to expand into", () => {
+      // Two shapes reach here. The server omits `eventMetrics` entirely for an
+      // event with no `event.metrics.*` attributes, which is what suppresses
+      // the chevron in SectionRenderer. The empty array is the shape no
+      // endpoint currently emits — guarded anyway so a future payload change
+      // cannot produce a chevron that expands into a blank strip.
+      for (const eventMetrics of [undefined, []]) {
+        const { container, unmount } = render(
+          <ChakraProvider value={defaultSystem}>
+            <EventDrilldown
+              item={{
+                value: "custom_marker",
+                label: "custom_marker",
+                count: 3,
+                eventMetrics,
+              }}
+              ast={EMPTY_AST}
+              toggleFacet={vi.fn()}
+            />
+          </ChakraProvider>,
+        );
+
+        expect(container).toBeEmptyDOMElement();
+        unmount();
+      }
     });
   });
 

--- a/platform/app/src/features/traces-v2/components/FilterSidebar/__tests__/EventDrilldown.integration.test.tsx
+++ b/platform/app/src/features/traces-v2/components/FilterSidebar/__tests__/EventDrilldown.integration.test.tsx
@@ -7,9 +7,12 @@
  *   with their counts — the component fires no query of its own;
  * - metric-group headers strip the `event.metrics.` storage prefix for
  *   display while clicks keep the full key;
- * - clicking a value emits exactly one top-level
- *   `event.attribute.event.metrics.<key>` toggle — never a group mutation
- *   (the cross-event AND collision is a documented, accepted limitation);
+ * - clicking a value on an ALREADY-ACTIVE event row emits exactly one
+ *   top-level `event.attribute.event.metrics.<key>` toggle — never a group
+ *   mutation (the cross-event AND collision, once two different events are
+ *   both active, is a documented, accepted limitation);
+ * - clicking a value on an INACTIVE event row adds the `event:<type>`
+ *   anchor first, so the metric clause never lands unscoped;
  * - a predefined event's opaque codes read as words ("-1" shows as "thumbs
  *   down") while the click still emits the stored string; every metric
  *   without a human name shows exactly what ingest wrote;
@@ -83,16 +86,37 @@ describe("EventDrilldown", () => {
       expect(screen.queryByText("event.metrics.vote")).not.toBeInTheDocument();
     });
 
-    describe("when the user clicks a metric value", () => {
-      /** @scenario "Clicking a vote value applies a single event-attribute filter" */
+    describe("when the row is already an active filter and the user clicks a metric value", () => {
+      /** @scenario "Clicking a vote value on an already-active event row applies a single event-attribute filter" */
       it("toggles a single top-level event.attribute field with the verbatim value", () => {
-        const { toggleFacet } = renderDrilldown();
+        const { toggleFacet } = renderDrilldown({
+          ast: parse("event:thumbs_up_down"),
+        });
 
         // Reads "thumbs down", filters on the stored "-1".
         fireEvent.click(screen.getByText("thumbs down"));
 
         expect(toggleFacet).toHaveBeenCalledTimes(1);
         expect(toggleFacet).toHaveBeenCalledWith({
+          field: "event.attribute.event.metrics.vote",
+          value: "-1",
+        });
+      });
+    });
+
+    describe("when the row is NOT yet an active filter and the user clicks a metric value", () => {
+      /** @scenario "Clicking a vote value on an inactive event row scopes the filter to that event first" */
+      it("adds the event anchor before the metric clause", () => {
+        const { toggleFacet } = renderDrilldown({ ast: EMPTY_AST });
+
+        fireEvent.click(screen.getByText("thumbs down"));
+
+        expect(toggleFacet).toHaveBeenCalledTimes(2);
+        expect(toggleFacet).toHaveBeenNthCalledWith(1, {
+          field: "event",
+          value: "thumbs_up_down",
+        });
+        expect(toggleFacet).toHaveBeenNthCalledWith(2, {
           field: "event.attribute.event.metrics.vote",
           value: "-1",
         });

--- a/platform/app/src/features/traces-v2/components/FilterSidebar/__tests__/EventDrilldown.integration.test.tsx
+++ b/platform/app/src/features/traces-v2/components/FilterSidebar/__tests__/EventDrilldown.integration.test.tsx
@@ -29,8 +29,8 @@ import {
 import { EventDrilldown } from "../EventDrilldown";
 import type { FacetItem } from "../types";
 
-const buildItem = (
-  eventMetrics: FacetItem["eventMetrics"] = [
+const buildItem = ({
+  eventMetrics = [
     {
       key: "event.metrics.vote",
       values: [
@@ -39,7 +39,9 @@ const buildItem = (
       ],
     },
   ],
-): FacetItem => ({
+}: {
+  eventMetrics?: FacetItem["eventMetrics"];
+} = {}): FacetItem => ({
   value: "thumbs_up_down",
   label: "thumbs_up_down",
   count: 15,
@@ -71,7 +73,6 @@ describe("EventDrilldown", () => {
       expect(screen.getByText("thumbs down")).toBeInTheDocument();
       expect(screen.getByText("12")).toBeInTheDocument();
       expect(screen.getByText("3")).toBeInTheDocument();
-      // The bare codes never reach the user.
       expect(screen.queryByText("-1")).not.toBeInTheDocument();
     });
 
@@ -139,73 +140,91 @@ describe("EventDrilldown", () => {
   });
 
   describe("given two metric groups that share a stored value", () => {
-    it("qualifies each value with its metric key so the names stay distinct", () => {
-      renderDrilldown({
-        item: buildItem([
-          { key: "event.metrics.rating", values: [{ value: "1", count: 2 }] },
-          { key: "event.metrics.stars", values: [{ value: "1", count: 4 }] },
-        ]),
-      });
+    describe("when the drilldown renders", () => {
+      it("qualifies each value with its metric key so the names stay distinct", () => {
+        renderDrilldown({
+          item: buildItem({
+            eventMetrics: [
+              {
+                key: "event.metrics.rating",
+                values: [{ value: "1", count: 2 }],
+              },
+              {
+                key: "event.metrics.stars",
+                values: [{ value: "1", count: 4 }],
+              },
+            ],
+          }),
+        });
 
-      expect(
-        screen.getByRole("button", { name: "rating 1 — click to filter" }),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByRole("button", { name: "stars 1 — click to filter" }),
-      ).toBeInTheDocument();
+        expect(
+          screen.getByRole("button", { name: "rating 1 — click to filter" }),
+        ).toBeInTheDocument();
+        expect(
+          screen.getByRole("button", { name: "stars 1 — click to filter" }),
+        ).toBeInTheDocument();
+      });
     });
   });
 
   describe("given an event type carrying no metrics", () => {
-    /** @scenario "An event type with no metrics shows no drilldown affordance" */
-    it("renders nothing to expand into", () => {
-      // Two shapes reach here. The server omits `eventMetrics` entirely for an
-      // event with no `event.metrics.*` attributes, which is what suppresses
-      // the chevron in SectionRenderer. The empty array is the shape no
-      // endpoint currently emits — guarded anyway so a future payload change
-      // cannot produce a chevron that expands into a blank strip.
-      for (const eventMetrics of [undefined, []]) {
-        const { container, unmount } = render(
-          <ChakraProvider value={defaultSystem}>
-            <EventDrilldown
-              item={{
-                value: "custom_marker",
-                label: "custom_marker",
-                count: 3,
-                eventMetrics,
-              }}
-              ast={EMPTY_AST}
-              toggleFacet={vi.fn()}
-            />
-          </ChakraProvider>,
-        );
+    describe("when the drilldown renders", () => {
+      /** @scenario "An event type with no metrics shows no drilldown affordance" */
+      it("renders nothing to expand into", () => {
+        // Two shapes reach here. The server omits `eventMetrics` entirely for
+        // an event with no `event.metrics.*` attributes, which is what
+        // suppresses the chevron in SectionRenderer. The empty array is the
+        // shape no endpoint currently emits — guarded anyway so a future
+        // payload change cannot produce a chevron expanding into a blank strip.
+        for (const eventMetrics of [undefined, []]) {
+          const { container, unmount } = render(
+            <ChakraProvider value={defaultSystem}>
+              <EventDrilldown
+                item={{
+                  value: "custom_marker",
+                  label: "custom_marker",
+                  count: 3,
+                  eventMetrics,
+                }}
+                ast={EMPTY_AST}
+                toggleFacet={vi.fn()}
+              />
+            </ChakraProvider>,
+          );
 
-        expect(container).toBeEmptyDOMElement();
-        unmount();
-      }
+          expect(container).toBeEmptyDOMElement();
+          unmount();
+        }
+      });
     });
   });
 
   describe("given an event whose metric has no human name", () => {
-    /** @scenario "A metric with no human name shows its stored value" */
-    it("shows the stored value", () => {
-      // Metric values are numbers on every path — `eventSchema.metrics` is a
-      // record of string to number — so the unlabelled case is a decimal, not
-      // some free-form string. Ingest rejects a string with a 400.
-      renderDrilldown({
-        item: {
-          value: "checkout_survey",
-          label: "checkout_survey",
-          count: 1,
-          eventMetrics: [
-            { key: "event.metrics.stars", values: [{ value: "4", count: 1 }] },
-          ],
-        },
-      });
+    describe("when the drilldown renders", () => {
+      /** @scenario "A metric with no human name shows its stored value" */
+      it("shows the stored value", () => {
+        // Metric values are numbers on every path — `eventSchema.metrics` is a
+        // record of string to number — so the unlabelled case is a decimal,
+        // not some free-form string. Ingest rejects a string with a 400.
+        renderDrilldown({
+          item: {
+            value: "checkout_survey",
+            label: "checkout_survey",
+            count: 1,
+            eventMetrics: [
+              {
+                key: "event.metrics.stars",
+                values: [{ value: "4", count: 1 }],
+              },
+            ],
+          },
+        });
 
-      expect(
-        screen.getByRole("button", { name: "stars 4 — click to filter" }),
-      ).toBeInTheDocument();
+        expect(screen.getByText("4")).toBeInTheDocument();
+        expect(
+          screen.getByRole("button", { name: "stars 4 — click to filter" }),
+        ).toBeInTheDocument();
+      });
     });
   });
 });

--- a/platform/app/src/features/traces-v2/components/FilterSidebar/__tests__/EventDrilldown.integration.test.tsx
+++ b/platform/app/src/features/traces-v2/components/FilterSidebar/__tests__/EventDrilldown.integration.test.tsx
@@ -17,7 +17,10 @@
  *   down") while the click still emits the stored string; every metric
  *   without a human name shows exactly what ingest wrote;
  * - an event carrying no metrics renders nothing to expand into;
- * - active values read their include/exclude state from the AST.
+ * - active values read their include/exclude state from the AST;
+ * - driven against the real filter store, one click yields
+ *   "event:x AND event.attribute...:v" and cycling the value back off leaves
+ *   the bare "event:x" anchor behind (the accepted limitation).
  */
 
 import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
@@ -29,6 +32,7 @@ import {
   EMPTY_AST,
   parse,
 } from "~/server/app-layer/traces/query-language/parse";
+import { useFilterStore } from "../../../stores/filterStore";
 import { EventDrilldown } from "../EventDrilldown";
 import type { FacetItem } from "../types";
 
@@ -248,6 +252,70 @@ describe("EventDrilldown", () => {
         expect(
           screen.getByRole("button", { name: "stars 4 — click to filter" }),
         ).toBeInTheDocument();
+      });
+    });
+  });
+
+  /**
+   * Every case above hands `toggleFacet` a `vi.fn()` and asserts the
+   * arguments, which proves what the component ASKS for but never what the
+   * query BECOMES. These two drive the real store, so the assertion is the
+   * text a user would read in the search bar.
+   */
+  describe("given the drilldown drives the real filter store", () => {
+    const renderAgainstStore = () => {
+      useFilterStore.getState().applyQueryText("");
+      const item = buildItem();
+      const toggleFacet = ({
+        field,
+        value,
+      }: {
+        field: string;
+        value: string;
+      }) => useFilterStore.getState().toggleFacet(field, value);
+      const tree = () => (
+        <ChakraProvider value={defaultSystem}>
+          <EventDrilldown
+            item={item}
+            ast={useFilterStore.getState().ast}
+            toggleFacet={toggleFacet}
+          />
+        </ChakraProvider>
+      );
+      const view = render(tree());
+      // `eventActive` is derived from the `ast` PROP, so the component has to
+      // be handed the store's new AST after each click the way the sidebar
+      // does when it re-renders.
+      const clickThumbsDown = () => {
+        fireEvent.click(
+          screen.getByRole("button", { name: /^vote thumbs down/ }),
+        );
+        view.rerender(tree());
+      };
+      return { clickThumbsDown };
+    };
+
+    describe("when the user clicks a vote value on an inactive row", () => {
+      /** @scenario "Clicking a vote value on an inactive event row scopes the filter to that event first" */
+      it("writes the anchor and the metric clause as one AND query", () => {
+        const { clickThumbsDown } = renderAgainstStore();
+        clickThumbsDown();
+        expect(useFilterStore.getState().queryText).toBe(
+          "event:thumbs_up_down AND event.attribute.event.metrics.vote:-1",
+        );
+      });
+    });
+
+    describe("when the user cycles that same value back off", () => {
+      /** @scenario "Clearing the metric leaves the event anchor it added behind" */
+      it("drops the metric clause and leaves the anchor it added behind", () => {
+        const { clickThumbsDown } = renderAgainstStore();
+        clickThumbsDown(); // neutral -> include
+        clickThumbsDown(); // include -> exclude
+        clickThumbsDown(); // exclude -> neutral
+        expect(useFilterStore.getState().queryText).toBe(
+          "event:thumbs_up_down",
+        );
       });
     });
   });

--- a/platform/app/src/features/traces-v2/components/FilterSidebar/__tests__/comfortableDefaults.unit.test.ts
+++ b/platform/app/src/features/traces-v2/components/FilterSidebar/__tests__/comfortableDefaults.unit.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Comfortable density is the default a fresh profile lands on — its section
+ * set decides what's filterable with zero configuration. Feedback events
+ * (thumbs_up_down and friends) must be in that set. See
+ * specs/traces-v2/search.feature, Rule "Event filtering is reachable on the
+ * default sidebar".
+ */
+
+import { describe, expect, it } from "vitest";
+import { DEFAULT_DENSITY } from "../../../stores/densityStore";
+import {
+  COMFORTABLE_DEFAULT_SECTIONS,
+  EVENT_ATTRIBUTES_SECTION_KEY,
+  SPAN_ATTRIBUTES_SECTION_KEY,
+} from "../constants";
+
+describe("comfortable density defaults", () => {
+  it("is the density a fresh profile starts on", () => {
+    expect(DEFAULT_DENSITY).toBe("comfortable");
+  });
+
+  /** @scenario "Event name and Event attributes sections show on the comfortable default" */
+  it("includes the event facet and the event-attributes section", () => {
+    expect(COMFORTABLE_DEFAULT_SECTIONS).toContain("event");
+    expect(COMFORTABLE_DEFAULT_SECTIONS).toContain(
+      EVENT_ATTRIBUTES_SECTION_KEY,
+    );
+  });
+
+  /** @scenario "Span attributes stays behind the facet picker on comfortable density" */
+  it("keeps span attributes behind the facet picker", () => {
+    expect(COMFORTABLE_DEFAULT_SECTIONS).not.toContain(
+      SPAN_ATTRIBUTES_SECTION_KEY,
+    );
+  });
+});

--- a/platform/app/src/features/traces-v2/components/FilterSidebar/constants.ts
+++ b/platform/app/src/features/traces-v2/components/FilterSidebar/constants.ts
@@ -592,4 +592,9 @@ export const COMFORTABLE_DEFAULT_SECTIONS: ReadonlySet<string> = new Set([
   "cost",
   "tokens",
   "evaluator",
+  // Feedback events (thumbs_up_down and friends) must be filterable with
+  // zero configuration — the event facet and its attribute keys are part
+  // of the default set. Span attributes stay behind "+ Add facet".
+  "event",
+  EVENT_ATTRIBUTES_SECTION_KEY,
 ]);

--- a/platform/app/src/features/traces-v2/components/FilterSidebar/hooks/useFilterSidebarData.ts
+++ b/platform/app/src/features/traces-v2/components/FilterSidebar/hooks/useFilterSidebarData.ts
@@ -673,6 +673,14 @@ function buildFacetItems(
       .filter((v) => v.aggregates !== undefined)
       .map((v) => [v.value, v.aggregates!]),
   );
+  // Event-only — same forwarding pattern as `aggregates`: per-event metric
+  // value tallies ride the discover payload so the event drilldown never
+  // fires its own query.
+  const eventMetrics = new Map(
+    cat.topValues
+      .filter((v) => v.eventMetrics !== undefined)
+      .map((v) => [v.value, v.eventMetrics!]),
+  );
   const orderedValues = orderValues({
     defaults: FACET_DEFAULTS[cat.key],
     fallback: cat.topValues.map((v) => v.value),
@@ -690,6 +698,7 @@ function buildFacetItems(
     dimmed,
     synthetic,
     aggregates: aggregates.get(value),
+    eventMetrics: eventMetrics.get(value),
   }));
 }
 

--- a/platform/app/src/features/traces-v2/components/FilterSidebar/types.ts
+++ b/platform/app/src/features/traces-v2/components/FilterSidebar/types.ts
@@ -45,6 +45,21 @@ export interface FacetItem {
   synthetic?: boolean;
   /** Set only for the evaluator facet — see {@link FacetItemAggregates}. */
   aggregates?: FacetItemAggregates;
+  /** Set only for the event facet — see {@link EventMetricValues}. */
+  eventMetrics?: EventMetricValues[];
+}
+
+/**
+ * Per-metric-key value tallies the event facet attaches so its drilldown
+ * (thumbs_up_down → vote values) renders from the discover payload without
+ * a second query. Values are the stored strings, verbatim — a click filters
+ * on `event.attribute.<key>:<value>` and must round-trip exactly.
+ */
+export interface EventMetricValues {
+  /** Full storage key, e.g. `event.metrics.vote` — display strips the
+   *  prefix, filtering keeps the full key. */
+  key: string;
+  values: { value: string; count: number }[];
 }
 
 export interface AttributeKey {
@@ -86,6 +101,9 @@ export interface CategoricalSection extends SectionBase {
      * without firing a second query.
      */
     aggregates?: FacetItemAggregates;
+    /** Forwarded from the discover response. Only set on the event facet —
+     *  drives the per-event metric drilldown. */
+    eventMetrics?: EventMetricValues[];
   }[];
   /**
    * True when this section was synthesised from FACET_DEFAULTS before the

--- a/platform/app/src/features/traces-v2/hooks/__tests__/useFacetSearch.integration.test.ts
+++ b/platform/app/src/features/traces-v2/hooks/__tests__/useFacetSearch.integration.test.ts
@@ -99,7 +99,9 @@ describe("useFacetSearch", () => {
   // values, it does not search them).
   describe("given useAttributeValues delegates to useFacetSearch", () => {
     it("queries facetValues with the attribute-prefixed key, limit 30, no prefix", () => {
-      renderHook(() => useAttributeValues("langwatch.user_id", true));
+      renderHook(() =>
+        useAttributeValues({ attrKey: "langwatch.user_id", enabled: true }),
+      );
 
       const call = callFor("attribute.langwatch.user_id");
       expect(call).toBeDefined();
@@ -112,9 +114,40 @@ describe("useFacetSearch", () => {
     // useFacetSearch's own `!!facetKey` guard would not catch it —
     // useAttributeValues must additionally gate on a non-empty attribute key.
     it("disables the query when the attribute key is empty", () => {
-      renderHook(() => useAttributeValues("", true));
+      renderHook(() => useAttributeValues({ attrKey: "", enabled: true }));
 
       expect(lastOpts()?.enabled).toBe(false);
+    });
+
+    // Sidebar sections write filters as `${filterPrefix}.${attrKey}` — the
+    // value lookup must query the SAME facet key, or event/span attribute
+    // rows list values from trace_summaries.Attributes (i.e. none).
+    describe("when the section carries a filterPrefix", () => {
+      /** @scenario "Expanding an event-attribute key lists values observed on events" */
+      it("builds the facetKey from the section's filterPrefix", () => {
+        renderHook(() =>
+          useAttributeValues({
+            attrKey: "event.metrics.vote",
+            enabled: true,
+            filterPrefix: "event.attribute",
+          }),
+        );
+
+        expect(callFor("event.attribute.event.metrics.vote")).toBeDefined();
+      });
+
+      /** @scenario "Expanding a span-attribute key lists values observed on spans" */
+      it("supports the span-attribute prefix the same way", () => {
+        renderHook(() =>
+          useAttributeValues({
+            attrKey: "gen_ai.request.model",
+            enabled: true,
+            filterPrefix: "span.attribute",
+          }),
+        );
+
+        expect(callFor("span.attribute.gen_ai.request.model")).toBeDefined();
+      });
     });
   });
 });

--- a/platform/app/src/features/traces-v2/hooks/useAttributeValues.ts
+++ b/platform/app/src/features/traces-v2/hooks/useAttributeValues.ts
@@ -5,20 +5,31 @@ import { useFacetSearch } from "./useFacetSearch";
  * "langwatch.user_id"). Fetches only when `enabled` is true so collapsed
  * sections stay free.
  *
- * Thin delegation to {@link useFacetSearch}: an attribute key is just an
- * `attribute.`-prefixed facet. No prefix is passed — this surfaces the top
- * values, it does not search them — and the long staleTime keeps an expanded
- * section from refetching every time the rolling time range ticks (SSE
- * invalidates on real changes).
+ * Thin delegation to {@link useFacetSearch}: an attribute key is just a
+ * prefixed facet. `filterPrefix` must match the prefix the section writes
+ * filters with (`attribute` for trace attributes, `event.attribute` /
+ * `span.attribute` for the per-store sections) so the value lookup reads
+ * the same store the resulting filter queries. No search prefix is passed —
+ * this surfaces the top values, it does not search them — and the long
+ * staleTime keeps an expanded section from refetching every time the
+ * rolling time range ticks (SSE invalidates on real changes).
  *
  * The `attrKey.length > 0` guard matters because the prefixed `facetKey`
  * (`attribute.`) is truthy even for an empty key, so useFacetSearch's own
  * `!!facetKey` guard would NOT catch it — without this the query would fire
  * for a bare `attribute.` key.
  */
-export function useAttributeValues(attrKey: string, enabled: boolean) {
+export function useAttributeValues({
+  attrKey,
+  enabled,
+  filterPrefix = "attribute",
+}: {
+  attrKey: string;
+  enabled: boolean;
+  filterPrefix?: string;
+}) {
   return useFacetSearch({
-    facetKey: `attribute.${attrKey}`,
+    facetKey: `${filterPrefix}.${attrKey}`,
     prefix: "",
     enabled: enabled && attrKey.length > 0,
     limit: 30,

--- a/platform/app/src/features/traces-v2/stores/densityStore.ts
+++ b/platform/app/src/features/traces-v2/stores/densityStore.ts
@@ -12,7 +12,7 @@ const STORAGE_KEY = "langwatch:traces-v2:density:v1";
 // Existing users with an explicit `compact` / `comfortable` choice in
 // localStorage are unaffected — the load() function below only falls
 // back to this default when nothing is persisted yet.
-const DEFAULT_DENSITY: Density = "comfortable";
+export const DEFAULT_DENSITY: Density = "comfortable";
 
 /**
  * Density is a personal preference, not a per-lens or per-URL setting.

--- a/platform/app/src/server/app-layer/traces/__tests__/trace-list.facet-values.routing.unit.test.ts
+++ b/platform/app/src/server/app-layer/traces/__tests__/trace-list.facet-values.routing.unit.test.ts
@@ -1,0 +1,106 @@
+/**
+ * computeFacetValues routes dynamic attribute drilldowns by prefix:
+ * "attribute.<key>" reads trace_summaries.Attributes (legacy alias kept),
+ * "event.attribute.<key>" reads stored_spans.Events.Attributes, and
+ * "span.attribute.<key>" reads stored_spans.SpanAttributes — each via its
+ * own repository method so values come from the store the filter actually
+ * queries. See specs/traces-v2/search.feature, Rule "Attribute sections
+ * list values from their own attribute store".
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { TraceListRepository } from "../repositories/trace-list.repository";
+import { TraceListService } from "../trace-list.service";
+
+const emptyResult = { values: [], totalDistinct: 0 };
+
+function makeService() {
+  const repository = {
+    findAttributeValues: vi.fn().mockResolvedValue(emptyResult),
+    findEventAttributeValues: vi.fn().mockResolvedValue(emptyResult),
+    findSpanAttributeValues: vi.fn().mockResolvedValue(emptyResult),
+  } as unknown as TraceListRepository & {
+    findAttributeValues: ReturnType<typeof vi.fn>;
+    findEventAttributeValues: ReturnType<typeof vi.fn>;
+    findSpanAttributeValues: ReturnType<typeof vi.fn>;
+  };
+  const service = new TraceListService(
+    repository,
+    undefined as never,
+    undefined as never,
+  );
+  return { repository, service };
+}
+
+// Unique tenant per test keeps the module-level facet-values cache cold.
+let seq = 0;
+function params(facetKey: string) {
+  return {
+    tenantId: `project_routing_${seq++}`,
+    timeRange: { from: 0, to: 1 },
+    facetKey,
+    limit: 30,
+    offset: 0,
+  };
+}
+
+beforeEach(() => {
+  seq++;
+});
+
+describe("TraceListService facet-value routing", () => {
+  describe("given an event-attribute facet key", () => {
+    /** @scenario "Expanding an event-attribute key lists values observed on events" */
+    it("routes event.attribute.<key> to the event-attribute value lookup", async () => {
+      const { repository, service } = makeService();
+
+      await service.getFacetValues(
+        params("event.attribute.event.metrics.vote"),
+      );
+
+      expect(repository.findEventAttributeValues).toHaveBeenCalledWith(
+        expect.objectContaining({ attributeKey: "event.metrics.vote" }),
+      );
+      expect(repository.findAttributeValues).not.toHaveBeenCalled();
+    });
+
+    it("rejects keys outside the attribute-key whitelist", async () => {
+      const { repository, service } = makeService();
+
+      await expect(
+        service.getFacetValues(params("event.attribute.bad'key")),
+      ).rejects.toThrow(/Invalid attribute key/);
+      expect(repository.findEventAttributeValues).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("given a span-attribute facet key", () => {
+    /** @scenario "Expanding a span-attribute key lists values observed on spans" */
+    it("routes span.attribute.<key> to the span-attribute value lookup", async () => {
+      const { repository, service } = makeService();
+
+      await service.getFacetValues(
+        params("span.attribute.gen_ai.request.model"),
+      );
+
+      expect(repository.findSpanAttributeValues).toHaveBeenCalledWith(
+        expect.objectContaining({ attributeKey: "gen_ai.request.model" }),
+      );
+      expect(repository.findAttributeValues).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("given the legacy trace-attribute facet key", () => {
+    it("keeps routing attribute.<key> to trace_summaries.Attributes", async () => {
+      const { repository, service } = makeService();
+
+      await service.getFacetValues(params("attribute.langwatch.user_id"));
+
+      expect(repository.findAttributeValues).toHaveBeenCalledWith(
+        expect.objectContaining({ attributeKey: "langwatch.user_id" }),
+      );
+      expect(repository.findEventAttributeValues).not.toHaveBeenCalled();
+      expect(repository.findSpanAttributeValues).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/platform/app/src/server/app-layer/traces/facets/__tests__/events.unit.test.ts
+++ b/platform/app/src/server/app-layer/traces/facets/__tests__/events.unit.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import type { FacetQueryContext } from "../../facet-registry";
+import { buildEventsFacetQuery } from "../events";
+
+function ctx(overrides: Partial<FacetQueryContext> = {}): FacetQueryContext {
+  return {
+    tenantId: "project_test",
+    timeRange: { from: 0, to: 1 },
+    limit: 25,
+    offset: 0,
+    ...overrides,
+  };
+}
+
+describe("buildEventsFacetQuery", () => {
+  describe("given an event facet request", () => {
+    it("keys the facet value off the event name", () => {
+      const { sql } = buildEventsFacetQuery(ctx());
+      expect(sql).toMatch(/AS facet_value/);
+      expect(sql).toMatch(/`Events\.Name`/);
+    });
+
+    describe("when the per-event metric aggregates are built", () => {
+      /** @scenario "Expanding the thumbs_up_down row shows its vote values with counts" */
+      it("zips Events.Name with Events.Attributes so metric entries scope to their own event", () => {
+        const { sql } = buildEventsFacetQuery(ctx());
+        expect(sql).toMatch(/arrayZip\(`Events\.Name`, `Events\.Attributes`\)/);
+      });
+
+      it("keeps only event.metrics.-prefixed attribute entries", () => {
+        const { sql } = buildEventsFacetQuery(ctx());
+        expect(sql).toMatch(/startsWith\(x\.1, 'event\.metrics\.'\)/);
+      });
+
+      it("emits capped, count-ranked metric_values buckets", () => {
+        const { sql } = buildEventsFacetQuery(ctx());
+        // sumMap tallies (key SEP value) -> count in one pass per event name;
+        // the outer SELECT ranks by count desc and caps the list so a
+        // metric-happy tenant can't balloon the discover payload.
+        expect(sql).toMatch(/sumMap\(/);
+        expect(sql).toMatch(/arrayReverseSort\(/);
+        expect(sql).toMatch(/AS metric_values/);
+        expect(sql).toMatch(/1,\s*10\s*\)\s*AS metric_values/);
+      });
+
+      /** @scenario "Expanding the thumbs_up_down row shows its vote values with counts" */
+      it("guards the scan with the key-discovery memory settings", () => {
+        const { settings } = buildEventsFacetQuery(ctx());
+        // Same unbounded Events.Attributes flatten that tripped
+        // MEMORY_LIMIT_EXCEEDED for the key-discovery facets — the spill +
+        // cap guard is non-negotiable here.
+        expect(settings?.max_bytes_before_external_group_by).toBeDefined();
+        expect(settings?.max_memory_usage).toBeDefined();
+      });
+    });
+
+    describe("when a search prefix is given", () => {
+      it("filters event names by the prefix", () => {
+        const { sql, params } = buildEventsFacetQuery(ctx({ prefix: "thu" }));
+        expect(sql).toMatch(/ILIKE concat\({prefix:String}, '%'\)/);
+        expect(params.prefix).toBe("thu");
+      });
+    });
+  });
+});

--- a/platform/app/src/server/app-layer/traces/facets/events.ts
+++ b/platform/app/src/server/app-layer/traces/facets/events.ts
@@ -3,13 +3,39 @@ import type {
   FacetQueryContext,
   QueryBuilderCategoricalDef,
 } from "../facet-registry";
-import { baseParams, buildTimeWhere } from "./helpers";
+import { baseParams, buildTimeWhere, KEY_DISCOVERY_SETTINGS } from "./helpers";
 
 /**
- * Span event names. Each `stored_spans` row carries a parallel array
- * `Events.Name` of event names emitted on that span; we explode it via
- * `arrayJoin` so a span with N events contributes N rows to the
- * frequency count.
+ * Prefix the ingest mapper gives event metric attributes (see
+ * `event-attrs.mapper.ts`): a thumbs_up_down event's vote lands as
+ * `Events.Attributes['event.metrics.vote']`. Only these entries feed the
+ * per-event drilldown — non-metric attributes stay in the Event attributes
+ * section.
+ */
+const EVENT_METRICS_PREFIX = "event.metrics.";
+
+/**
+ * Composite-key separator for the metric buckets: `sumMap` needs scalar keys,
+ * so (metric key, stored value) pairs are joined with the ASCII unit
+ * separator (0x1F) — a control char that can't appear in either half. The
+ * SQL emits it via `char(31)`; the repo's facet-row mapper splits on this
+ * constant.
+ */
+export const EVENT_METRIC_SEP = String.fromCharCode(31);
+
+/** Per-event cap on (metric key, value) buckets returned to the sidebar. */
+const METRIC_VALUES_TOP_N = 10;
+
+/**
+ * Span event names + per-event metric value aggregates. Each `stored_spans`
+ * row carries parallel arrays `Events.Name` / `Events.Attributes`; we zip
+ * them before exploding via `arrayJoin` so every metric entry stays scoped
+ * to the event that emitted it, then group by name.
+ *
+ * The metric buckets ride the SAME discover query (evaluator-facet
+ * precedent) so the drilldown renders with zero extra queries per click.
+ * Values are aggregated as stored — verbatim strings, never reformatted —
+ * so a click round-trips exactly into `event.attribute.event.metrics.<k>:<v>`.
  *
  * The facet key is `event` (matching the search-bar field) so toggles
  * round-trip cleanly with the `event:` filter handler.
@@ -23,17 +49,39 @@ export function buildEventsFacetQuery(ctx: FacetQueryContext): FacetQuery {
     sql: `
       SELECT
         name AS facet_value,
-        count() AS cnt,
+        cnt,
+        arraySlice(
+          arrayReverseSort(x -> x.2, arrayZip(metric_buckets.1, metric_buckets.2)),
+          1, ${METRIC_VALUES_TOP_N}
+        ) AS metric_values,
         count() OVER () AS total_distinct
       FROM (
-        SELECT arrayJoin(\`Events.Name\`) AS name
-        FROM stored_spans
-        WHERE ${where}
-          AND length(\`Events.Name\`) > 0
+        SELECT
+          name,
+          count() AS cnt,
+          sumMap(
+            arrayMap(x -> concat(x.1, char(31), x.2), metric_entries),
+            arrayMap(x -> toUInt64(1), metric_entries)
+          ) AS metric_buckets
+        FROM (
+          SELECT
+            ev.1 AS name,
+            arrayFilter(
+              x -> startsWith(x.1, '${EVENT_METRICS_PREFIX}') AND x.2 != '',
+              arrayZip(mapKeys(ev.2), mapValues(ev.2))
+            ) AS metric_entries
+          FROM (
+            SELECT arrayJoin(arrayZip(\`Events.Name\`, \`Events.Attributes\`)) AS ev
+            FROM stored_spans
+            WHERE ${where}
+              AND length(\`Events.Name\`) > 0
+          )
+          WHERE ev.1 != ''
+        )
+        WHERE 1 = 1
+          ${prefixFilter}
+        GROUP BY name
       )
-      WHERE name != ''
-        ${prefixFilter}
-      GROUP BY name
       ORDER BY cnt DESC
       LIMIT {limit:UInt32} OFFSET {offset:UInt32}
     `,
@@ -41,6 +89,10 @@ export function buildEventsFacetQuery(ctx: FacetQueryContext): FacetQuery {
       ...baseParams(ctx),
       ...(ctx.prefix ? { prefix: ctx.prefix } : {}),
     },
+    // Zipping + flattening Events.Attributes over the whole window is the
+    // same shape that tripped MEMORY_LIMIT_EXCEEDED for the key-discovery
+    // facets — the spill + memory-cap guard is mandatory here too.
+    settings: KEY_DISCOVERY_SETTINGS,
   };
 }
 

--- a/platform/app/src/server/app-layer/traces/facets/events.ts
+++ b/platform/app/src/server/app-layer/traces/facets/events.ts
@@ -3,25 +3,13 @@ import type {
   FacetQueryContext,
   QueryBuilderCategoricalDef,
 } from "../facet-registry";
+import {
+  EVENT_METRIC_SEP,
+  EVENT_METRICS_PREFIX,
+} from "../query-language/eventMetrics";
 import { baseParams, buildTimeWhere, KEY_DISCOVERY_SETTINGS } from "./helpers";
 
-/**
- * Prefix the ingest mapper gives event metric attributes (see
- * `event-attrs.mapper.ts`): a thumbs_up_down event's vote lands as
- * `Events.Attributes['event.metrics.vote']`. Only these entries feed the
- * per-event drilldown — non-metric attributes stay in the Event attributes
- * section.
- */
-const EVENT_METRICS_PREFIX = "event.metrics.";
-
-/**
- * Composite-key separator for the metric buckets: `sumMap` needs scalar keys,
- * so (metric key, stored value) pairs are joined with the ASCII unit
- * separator (0x1F) — a control char that can't appear in either half. The
- * SQL emits it via `char(31)`; the repo's facet-row mapper splits on this
- * constant.
- */
-export const EVENT_METRIC_SEP = String.fromCharCode(31);
+export { EVENT_METRIC_SEP, EVENT_METRICS_PREFIX };
 
 /** Per-event cap on (metric key, value) buckets returned to the sidebar. */
 const METRIC_VALUES_TOP_N = 10;

--- a/platform/app/src/server/app-layer/traces/query-language/eventMetrics.ts
+++ b/platform/app/src/server/app-layer/traces/query-language/eventMetrics.ts
@@ -28,3 +28,40 @@ export const EVENT_METRICS_PREFIX = "event.metrics.";
  * this constant.
  */
 export const EVENT_METRIC_SEP = String.fromCharCode(31);
+
+/**
+ * Display names for predefined-event metric values whose stored form is a
+ * bare number nobody reads as meaning anything. `thumbs_up_down.vote` is
+ * `1 | 0 | -1` on the wire (see `predefinedEvents.schema.ts`); a sidebar row
+ * reading "-1" tells you nothing, "thumbs down" tells you everything.
+ *
+ * Display only. The filter clause, the value lookup and the round-trip all
+ * keep the stored string exactly as ingest wrote it — this map never touches
+ * the value that gets queried.
+ */
+const EVENT_METRIC_VALUE_LABELS: Record<string, Record<string, string>> = {
+  "thumbs_up_down::event.metrics.vote": {
+    "1": "thumbs up",
+    "-1": "thumbs down",
+    "0": "no vote",
+  },
+};
+
+/**
+ * The human name for a stored metric value, or the stored value itself when
+ * there is nothing better to say — which is the case for every custom event
+ * and every metric that isn't an opaque code.
+ */
+export function eventMetricValueLabel({
+  eventType,
+  metricKey,
+  value,
+}: {
+  eventType: string;
+  metricKey: string;
+  value: string;
+}): string {
+  return (
+    EVENT_METRIC_VALUE_LABELS[`${eventType}::${metricKey}`]?.[value] ?? value
+  );
+}

--- a/platform/app/src/server/app-layer/traces/query-language/eventMetrics.ts
+++ b/platform/app/src/server/app-layer/traces/query-language/eventMetrics.ts
@@ -23,9 +23,14 @@ export const EVENT_METRICS_PREFIX = "event.metrics.";
 /**
  * Composite-key separator for the metric buckets: `sumMap` needs scalar keys,
  * so (metric key, stored value) pairs are joined with the ASCII unit
- * separator (0x1F) — a control char that can't appear in either half. The
- * SQL emits it via `char(31)`; the repository's facet-row mapper splits on
- * this constant.
+ * separator (0x1F). The SQL emits it via `char(31)`; the repository's
+ * facet-row mapper splits on this constant.
+ *
+ * The value half can never contain it — metric values are numbers everywhere
+ * (`eventSchema.metrics` is a record of string to number), so they stringify
+ * to decimals. The key half is an unconstrained string, so a caller can send
+ * one carrying 0x1F; that bucket is ambiguous and the mapper drops it rather
+ * than showing a row split in the wrong place.
  */
 export const EVENT_METRIC_SEP = String.fromCharCode(31);
 

--- a/platform/app/src/server/app-layer/traces/query-language/eventMetrics.ts
+++ b/platform/app/src/server/app-layer/traces/query-language/eventMetrics.ts
@@ -1,0 +1,30 @@
+/**
+ * The wire-format contract for event metric attributes, shared by the facet
+ * SQL that produces them, the repository mapper that decodes them, and the
+ * sidebar drilldown that displays them. It lives in `query-language/` because
+ * that is the framework-free module both layers already import from — the
+ * drilldown reads `getFacetValueState` from here, the facet builder reads the
+ * grammar.
+ *
+ * Keeping one definition matters because the two halves are read apart: SQL
+ * writes the prefix and the separator, and the UI strips them back off. A
+ * second literal drifting by one character silently empties the drilldown.
+ */
+
+/**
+ * Prefix the ingest mapper gives event metric attributes (see
+ * `event-attrs.mapper.ts`): a thumbs_up_down event's vote lands as
+ * `Events.Attributes['event.metrics.vote']`. Only these entries feed the
+ * per-event drilldown — non-metric attributes stay in the Event attributes
+ * section.
+ */
+export const EVENT_METRICS_PREFIX = "event.metrics.";
+
+/**
+ * Composite-key separator for the metric buckets: `sumMap` needs scalar keys,
+ * so (metric key, stored value) pairs are joined with the ASCII unit
+ * separator (0x1F) — a control char that can't appear in either half. The
+ * SQL emits it via `char(31)`; the repository's facet-row mapper splits on
+ * this constant.
+ */
+export const EVENT_METRIC_SEP = String.fromCharCode(31);

--- a/platform/app/src/server/app-layer/traces/repositories/trace-list.clickhouse.repository.ts
+++ b/platform/app/src/server/app-layer/traces/repositories/trace-list.clickhouse.repository.ts
@@ -1251,7 +1251,11 @@ function extractEventMetrics(r: FacetRow): {
     if (sep <= 0) continue; // malformed bucket — no separator or empty key
     const key = composite.slice(0, sep);
     const value = composite.slice(sep + EVENT_METRIC_SEP.length);
-    if (value === "") continue;
+    // A second separator means the metric key itself carried one. Metric keys
+    // are unconstrained strings, so nothing stops a caller sending one with an
+    // embedded 0x1F, and the split point is then a guess. Drop the bucket
+    // rather than render a row whose key and value are both wrong.
+    if (value === "" || value.includes(EVENT_METRIC_SEP)) continue;
     let list = byKey.get(key);
     if (!list) {
       list = [];

--- a/platform/app/src/server/app-layer/traces/repositories/trace-list.clickhouse.repository.ts
+++ b/platform/app/src/server/app-layer/traces/repositories/trace-list.clickhouse.repository.ts
@@ -4,10 +4,12 @@ import { EventUtils } from "~/server/event-sourcing/utils/event.utils";
 import type { FacetQuery } from "../facet-registry";
 import type { TraceSummaryData } from "../types";
 import type { TraceSummaryFieldsBase } from "./_summary-fields.types";
+import { EVENT_METRIC_SEP } from "../facets/events";
 import type {
   BatchedFacetResult,
   CategoricalFacetResult,
   DiscreteFacetResult,
+  EventMetricValues,
   FacetCountResult,
   FacetTableName,
   TraceListPage,
@@ -1000,6 +1002,144 @@ export class TraceListClickHouseRepository implements TraceListRepository {
     return mapFacetRows(rows);
   }
 
+  async findEventAttributeValues(params: {
+    tenantId: string;
+    timeRange: { from: number; to: number };
+    attributeKey: string;
+    prefix?: string;
+    limit: number;
+    offset: number;
+  }): Promise<CategoricalFacetResult> {
+    EventUtils.validateTenantId(
+      { tenantId: params.tenantId },
+      "TraceListClickHouseRepository.findEventAttributeValues",
+    );
+
+    // Same bounded-sample strategy as findAttributeValues, against the store
+    // the `event.attribute.` filter actually queries: `Events.Attributes` is
+    // an Array(Map) parallel to `Events.Name`, so a span contributes one
+    // candidate value per event that carries the key.
+    const ATTR_VALUE_SAMPLE_ROWS = 50_000;
+
+    // The prefix filter lives INSIDE arrayFilter (not a WHERE on the
+    // arrayJoin alias) so the sample keeps its one-pass shape.
+    const valuePredicate = params.prefix
+      ? "v -> v != '' AND lower(v) LIKE concat({prefix:String}, '%')"
+      : "v -> v != ''";
+
+    const sql = `
+      SELECT
+        facet_value,
+        0 AS cnt,
+        0 AS total_distinct
+      FROM (
+        SELECT DISTINCT arrayJoin(
+          arrayFilter(
+            ${valuePredicate},
+            arrayMap(m -> m[{attrKey:String}], \`Events.Attributes\`)
+          )
+        ) AS facet_value
+        FROM stored_spans
+        PREWHERE TenantId = {tenantId:String}
+          AND StartTime >= fromUnixTimestamp64Milli({timeFrom:Int64})
+          AND StartTime <= fromUnixTimestamp64Milli({timeTo:Int64})
+          AND arrayExists(m -> mapContains(m, {attrKey:String}), \`Events.Attributes\`)
+        LIMIT {sampleRows:UInt32}
+        SETTINGS
+          max_execution_time = 3,
+          timeout_overflow_mode = 'break',
+          max_threads = 8
+      )
+      ORDER BY facet_value
+      LIMIT {limit:UInt32} OFFSET {offset:UInt32}
+    `;
+
+    const client = await this.resolveClient(params.tenantId);
+    const result = await client.query({
+      query: sql,
+      query_params: {
+        tenantId: params.tenantId,
+        timeFrom: params.timeRange.from,
+        timeTo: params.timeRange.to,
+        attrKey: params.attributeKey,
+        limit: params.limit,
+        offset: params.offset,
+        sampleRows: ATTR_VALUE_SAMPLE_ROWS,
+        ...(params.prefix ? { prefix: params.prefix } : {}),
+      },
+      format: "JSONEachRow",
+    });
+
+    const rows = await result.json<FacetRow>();
+    return mapFacetRows(rows);
+  }
+
+  async findSpanAttributeValues(params: {
+    tenantId: string;
+    timeRange: { from: number; to: number };
+    attributeKey: string;
+    prefix?: string;
+    limit: number;
+    offset: number;
+  }): Promise<CategoricalFacetResult> {
+    EventUtils.validateTenantId(
+      { tenantId: params.tenantId },
+      "TraceListClickHouseRepository.findSpanAttributeValues",
+    );
+
+    // Same bounded-sample strategy as findAttributeValues, against
+    // `stored_spans.SpanAttributes` — the store the `span.attribute.` filter
+    // actually queries.
+    const ATTR_VALUE_SAMPLE_ROWS = 50_000;
+
+    const innerPrefix = params.prefix
+      ? "AND lower(SpanAttributes[{attrKey:String}]) LIKE concat({prefix:String}, '%')"
+      : "";
+
+    const sql = `
+      SELECT
+        facet_value,
+        0 AS cnt,
+        0 AS total_distinct
+      FROM (
+        SELECT DISTINCT SpanAttributes[{attrKey:String}] AS facet_value
+        FROM stored_spans
+        PREWHERE TenantId = {tenantId:String}
+          AND StartTime >= fromUnixTimestamp64Milli({timeFrom:Int64})
+          AND StartTime <= fromUnixTimestamp64Milli({timeTo:Int64})
+          AND mapContains(SpanAttributes, {attrKey:String})
+        WHERE SpanAttributes[{attrKey:String}] != ''
+          ${innerPrefix}
+        LIMIT {sampleRows:UInt32}
+        SETTINGS
+          max_execution_time = 3,
+          timeout_overflow_mode = 'break',
+          max_threads = 8
+      )
+      ORDER BY facet_value
+      LIMIT {limit:UInt32} OFFSET {offset:UInt32}
+    `;
+
+    const client = await this.resolveClient(params.tenantId);
+    const result = await client.query({
+      query: sql,
+      query_params: {
+        tenantId: params.tenantId,
+        timeFrom: params.timeRange.from,
+        timeTo: params.timeRange.to,
+        attrKey: params.attributeKey,
+        limit: params.limit,
+        offset: params.offset,
+        sampleRows: ATTR_VALUE_SAMPLE_ROWS,
+        ...(params.prefix ? { prefix: params.prefix } : {}),
+      },
+      format: "JSONEachRow",
+    });
+
+    const rows = await result.json<FacetRow>();
+    return mapFacetRows(rows);
+  }
+
   private toTraceSummaryData(row: ClickHouseSummaryRow): TraceSummaryData {
     return {
       traceId: row.TraceId,
@@ -1076,6 +1216,11 @@ type FacetRow = {
   // the `Array(Tuple(String, UInt64))` as `[[value, count], …]`. Counts may
   // arrive as strings for large UInt64, so the mapper coerces with Number().
   label_values?: [string, number | string][];
+  // Event facet only: top-N (composite key, count) tuples where the composite
+  // is `<metric key>\x1F<stored value>` (see EVENT_METRIC_SEP in
+  // facets/events.ts). Same Array(Tuple(String, UInt64)) serialisation as
+  // label_values.
+  metric_values?: [string, number | string][];
 };
 
 function mapFacetRows(rows: FacetRow[]): CategoricalFacetResult {
@@ -1085,8 +1230,41 @@ function mapFacetRows(rows: FacetRow[]): CategoricalFacetResult {
       ...(r.facet_label ? { label: r.facet_label } : {}),
       count: Number(r.cnt),
       ...extractFacetAggregates(r),
+      ...extractEventMetrics(r),
     })),
     totalDistinct: rows.length > 0 ? Number(rows[0]!.total_distinct) : 0,
+  };
+}
+
+/**
+ * Reshape the event facet's composite-key buckets into per-metric-key value
+ * lists. Values pass through as stored — verbatim strings — so a drilldown
+ * click round-trips exactly into `event.attribute.<key>:<value>`.
+ */
+function extractEventMetrics(r: FacetRow): {
+  eventMetrics?: EventMetricValues[];
+} {
+  if (!r.metric_values?.length) return {};
+  const byKey = new Map<string, { value: string; count: number }[]>();
+  for (const [composite, count] of r.metric_values) {
+    const sep = composite.indexOf(EVENT_METRIC_SEP);
+    if (sep <= 0) continue; // malformed bucket — no separator or empty key
+    const key = composite.slice(0, sep);
+    const value = composite.slice(sep + EVENT_METRIC_SEP.length);
+    if (value === "") continue;
+    let list = byKey.get(key);
+    if (!list) {
+      list = [];
+      byKey.set(key, list);
+    }
+    list.push({ value, count: Number(count) });
+  }
+  if (byKey.size === 0) return {};
+  return {
+    eventMetrics: [...byKey.entries()].map(([key, values]) => ({
+      key,
+      values,
+    })),
   };
 }
 

--- a/platform/app/src/server/app-layer/traces/repositories/trace-list.clickhouse.repository.ts
+++ b/platform/app/src/server/app-layer/traces/repositories/trace-list.clickhouse.repository.ts
@@ -2,9 +2,9 @@ import type { ClickHouseClientResolver } from "~/server/clickhouse/clickhouseCli
 import { isStorageAnchoredVersion } from "~/server/event-sourcing/pipelines/trace-processing/schemas/constants";
 import { EventUtils } from "~/server/event-sourcing/utils/event.utils";
 import type { FacetQuery } from "../facet-registry";
+import { EVENT_METRIC_SEP } from "../facets/events";
 import type { TraceSummaryData } from "../types";
 import type { TraceSummaryFieldsBase } from "./_summary-fields.types";
-import { EVENT_METRIC_SEP } from "../facets/events";
 import type {
   BatchedFacetResult,
   CategoricalFacetResult,

--- a/platform/app/src/server/app-layer/traces/repositories/trace-list.clickhouse.repository.ts
+++ b/platform/app/src/server/app-layer/traces/repositories/trace-list.clickhouse.repository.ts
@@ -2,7 +2,7 @@ import type { ClickHouseClientResolver } from "~/server/clickhouse/clickhouseCli
 import { isStorageAnchoredVersion } from "~/server/event-sourcing/pipelines/trace-processing/schemas/constants";
 import { EventUtils } from "~/server/event-sourcing/utils/event.utils";
 import type { FacetQuery } from "../facet-registry";
-import { EVENT_METRIC_SEP } from "../facets/events";
+import { EVENT_METRIC_SEP } from "../query-language/eventMetrics";
 import type { TraceSummaryData } from "../types";
 import type { TraceSummaryFieldsBase } from "./_summary-fields.types";
 import type {

--- a/platform/app/src/server/app-layer/traces/repositories/trace-list.repository.ts
+++ b/platform/app/src/server/app-layer/traces/repositories/trace-list.repository.ts
@@ -73,12 +73,28 @@ export interface FacetValueAggregates {
   labelValues?: { value: string; count: number }[];
 }
 
+/**
+ * Per-event-name metric value tallies the event facet attaches so its
+ * sidebar drilldown (thumbs_up_down → vote values) renders from the
+ * discover payload without a second query. One entry per metric key seen
+ * on the event, values as stored — verbatim strings, never reformatted —
+ * so a click round-trips exactly into `event.attribute.<key>:<value>`.
+ */
+export interface EventMetricValues {
+  /** Full storage key, e.g. `event.metrics.vote` — the UI strips the
+   *  prefix for display but filters on the full key. */
+  key: string;
+  values: { value: string; count: number }[];
+}
+
 export interface CategoricalFacetResult {
   values: {
     value: string;
     label?: string;
     count: number;
     aggregates?: FacetValueAggregates;
+    /** Set only by the event facet — see {@link EventMetricValues}. */
+    eventMetrics?: EventMetricValues[];
   }[];
   totalDistinct: number;
 }
@@ -199,6 +215,35 @@ export interface TraceListRepository {
     limit: number;
     offset: number;
   }): Promise<CategoricalFacetResult>;
+
+  /**
+   * Distinct values for a single event-attribute key, read from
+   * `stored_spans.Events.Attributes` — the store the `event.attribute.`
+   * filter actually queries. Same sampling strategy and injection-safety
+   * contract as {@link findAttributeValues}.
+   */
+  findEventAttributeValues(params: {
+    tenantId: string;
+    timeRange: { from: number; to: number; live?: boolean };
+    attributeKey: string;
+    prefix?: string;
+    limit: number;
+    offset: number;
+  }): Promise<CategoricalFacetResult>;
+
+  /**
+   * Distinct values for a single span-attribute key, read from
+   * `stored_spans.SpanAttributes`. Same sampling strategy and
+   * injection-safety contract as {@link findAttributeValues}.
+   */
+  findSpanAttributeValues(params: {
+    tenantId: string;
+    timeRange: { from: number; to: number; live?: boolean };
+    attributeKey: string;
+    prefix?: string;
+    limit: number;
+    offset: number;
+  }): Promise<CategoricalFacetResult>;
 }
 
 export class NullTraceListRepository implements TraceListRepository {
@@ -233,6 +278,12 @@ export class NullTraceListRepository implements TraceListRepository {
     return { categoricals: {}, ranges: {} };
   }
   async findAttributeValues(): Promise<CategoricalFacetResult> {
+    return { values: [], totalDistinct: 0 };
+  }
+  async findEventAttributeValues(): Promise<CategoricalFacetResult> {
+    return { values: [], totalDistinct: 0 };
+  }
+  async findSpanAttributeValues(): Promise<CategoricalFacetResult> {
     return { values: [], totalDistinct: 0 };
   }
 }

--- a/platform/app/src/server/app-layer/traces/trace-list.service.ts
+++ b/platform/app/src/server/app-layer/traces/trace-list.service.ts
@@ -32,6 +32,7 @@ import type {
   BatchedFacetResult,
   CategoricalFacetResult,
   DiscreteFacetResult,
+  EventMetricValues,
   TraceListCursor,
   TraceListRepository,
   TraceListSort,
@@ -409,6 +410,9 @@ interface CategoricalFacetDescriptor {
     label?: string;
     count: number;
     aggregates?: EvaluatorValueAggregates;
+    /** Set only on the event facet: per-metric-key value tallies for the
+     *  inline drilldown (see {@link EventMetricValues}). */
+    eventMetrics?: EventMetricValues[];
   }[];
   totalDistinct: number;
 }
@@ -1072,9 +1076,25 @@ export class TraceListService {
   private async computeFacetValues(
     params: FacetValuesParams,
   ): Promise<FacetValuesResult> {
-    // Dynamic per-attribute drill: "attribute.<key>" — not in the static registry.
+    // Dynamic per-attribute drills — not in the static registry. Each prefix
+    // routes to the store its filter actually queries: `event.attribute.` /
+    // `span.attribute.` read stored_spans (Events.Attributes / SpanAttributes),
+    // the bare `attribute.` prefix keeps its legacy trace_summaries alias.
+    // Order matters: the specific prefixes must match before the generic one.
+    if (params.facetKey.startsWith("event.attribute.")) {
+      return this.attributeFacetValues(params, "event.attribute.", (p) =>
+        this.repository.findEventAttributeValues(p),
+      );
+    }
+    if (params.facetKey.startsWith("span.attribute.")) {
+      return this.attributeFacetValues(params, "span.attribute.", (p) =>
+        this.repository.findSpanAttributeValues(p),
+      );
+    }
     if (params.facetKey.startsWith("attribute.")) {
-      return this.attributeFacetValues(params);
+      return this.attributeFacetValues(params, "attribute.", (p) =>
+        this.repository.findAttributeValues(p),
+      );
     }
 
     const def = FACET_REGISTRY.find((d) => d.key === params.facetKey);
@@ -1120,13 +1140,22 @@ export class TraceListService {
 
   private async attributeFacetValues(
     params: FacetValuesParams,
+    facetPrefix: string,
+    find: (p: {
+      tenantId: string;
+      timeRange: { from: number; to: number };
+      attributeKey: string;
+      prefix?: string;
+      limit: number;
+      offset: number;
+    }) => Promise<CategoricalFacetResult>,
   ): Promise<FacetValuesResult> {
-    const attributeKey = params.facetKey.slice("attribute.".length);
+    const attributeKey = params.facetKey.slice(facetPrefix.length);
     if (!attributeKey || !ATTRIBUTE_KEY_REGEX.test(attributeKey)) {
       throw new Error(`Invalid attribute key: ${attributeKey}`);
     }
 
-    return this.repository.findAttributeValues({
+    return find({
       tenantId: params.tenantId,
       timeRange: params.timeRange,
       attributeKey,

--- a/platform/app/src/server/tracer/__tests__/eventSchema.unit.test.ts
+++ b/platform/app/src/server/tracer/__tests__/eventSchema.unit.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Coverage for `eventSchema`'s metric-key constraint
+ * (specs/api-reference/tracked-event-validation.feature).
+ *
+ * A metric key survives into the composite-key encoding the event drilldown
+ * decodes (`<key>\x1F<value>`, see EVENT_METRIC_SEP in
+ * `query-language/eventMetrics.ts`). A key carrying that separator itself
+ * makes the split ambiguous, so ingest rejects it rather than accept an
+ * event whose metric can never surface in the explorer.
+ */
+
+import { describe, expect, it } from "vitest";
+import { eventSchema } from "../types";
+
+const baseEvent = {
+  event_id: "event_1",
+  event_type: "custom_marker",
+  project_id: "project_1",
+  event_details: {},
+  trace_id: "trace_1",
+  timestamps: {
+    started_at: 0,
+    inserted_at: 0,
+    updated_at: 0,
+  },
+};
+
+describe("eventSchema", () => {
+  describe("given a metric key", () => {
+    describe("when the key contains the ASCII unit separator (0x1F)", () => {
+      /** @scenario "Ingest rejects a metric key carrying the unit separator" */
+      it("fails validation", () => {
+        const result = eventSchema.safeParse({
+          ...baseEvent,
+          metrics: { "stars\x1fextra": 4 },
+        });
+
+        expect(result.success).toBe(false);
+      });
+    });
+
+    describe("when the key is an ordinary string", () => {
+      it("passes validation", () => {
+        const result = eventSchema.safeParse({
+          ...baseEvent,
+          metrics: { stars: 4 },
+        });
+
+        expect(result.success).toBe(true);
+      });
+    });
+  });
+});

--- a/platform/app/src/server/tracer/types.ts
+++ b/platform/app/src/server/tracer/types.ts
@@ -529,11 +529,23 @@ export const traceMetadataSchema =
 
 export type TraceMetadata = z.infer<typeof traceMetadataSchema>;
 
+/**
+ * A metric key must round-trip through the event drilldown's composite-key
+ * encoding (`<key>\x1F<value>`, see EVENT_METRIC_SEP in
+ * `query-language/eventMetrics.ts`) — an unconstrained string can carry the
+ * ASCII unit separator itself, which the decoder can no longer split
+ * unambiguously and silently drops. Reject it here, at ingest, rather than
+ * accept an event whose metric can never surface in the explorer.
+ */
+const eventMetricKeySchema = z.string().refine((key) => !key.includes("\x1f"), {
+  message: "Metric key must not contain the ASCII unit separator (0x1F)",
+});
+
 export const eventSchema = z.object({
   event_id: z.string(),
   event_type: z.string(), // Type of event (e.g., 'thumbs_up_down', 'add_to_cart')
   project_id: z.string(),
-  metrics: z.record(z.string(), z.number()),
+  metrics: z.record(eventMetricKeySchema, z.number()),
   event_details: z.record(z.string(), z.string()),
   trace_id: z.string(),
   timestamps: z.object({

--- a/specs/api-reference/tracked-event-validation.feature
+++ b/specs/api-reference/tracked-event-validation.feature
@@ -51,3 +51,13 @@ Feature: Tracked-event validation answers the caller
     Then the response status is 400
     And the response names the "vote" field
     And the event is not recorded
+
+  # A metric key survives into the event drilldown's composite-key encoding
+  # (`<key>\x1F<value>`). A key carrying that separator itself makes the
+  # split ambiguous, so the value silently disappears from the explorer
+  # instead of failing loudly. Reject it here instead.
+  @unit
+  Scenario: Ingest rejects a metric key carrying the unit separator
+    Given an event whose metric key contains the ASCII unit separator
+    When the payload is validated
+    Then the event is rejected

--- a/specs/traces-v2/search.feature
+++ b/specs/traces-v2/search.feature
@@ -1986,16 +1986,26 @@ Rule: Event rows drill down into their metric values
     When the user expands the "checkout_survey" row in the Event name section
     Then the drilldown lists that value as "4"
 
-  Scenario: Clicking a vote value applies a single event-attribute filter
+  Scenario: Clicking a vote value on an already-active event row applies a single event-attribute filter
+    Given "@event:thumbs_up_down" is already an active filter
     When the user clicks the vote value shown as "thumbs down" in the thumbs_up_down drilldown
-    Then the search bar shows "@event.attribute.event.metrics.vote:-1"
-    And no other clause is added to the query
+    Then the search bar shows "@event:thumbs_up_down @event.attribute.event.metrics.vote:-1"
+    And no additional "@event" clause is added to the query
 
-  # Known limitation, accepted: the emitted clause matches the metric on ANY
-  # event in the trace. Combining it with "@event:thumbs_up_down" ANDs two
-  # independent trace-scoped subqueries — they may match different events in
-  # the same trace. Same-event pairing would need new filter grammar and is
-  # out of scope here.
+  # Without the event anchor, "@event.attribute.event.metrics.vote:-1" alone
+  # would match a trace carrying that value under a completely different
+  # event type — a metric that never happened on "thumbs_up_down" would still
+  # pass. Adding the anchor keeps the picked value scoped to the row the user
+  # actually expanded.
+  Scenario: Clicking a vote value on an inactive event row scopes the filter to that event first
+    Given the "thumbs_up_down" row is not yet an active filter
+    When the user expands the row and clicks the vote value shown as "thumbs down"
+    Then the search bar shows "@event:thumbs_up_down @event.attribute.event.metrics.vote:-1"
+
+  # Known limitation, accepted: once TWO DIFFERENT events are both active,
+  # each one's attribute clause still ANDs as an independent trace-scoped
+  # subquery — they may match different events in the same trace. Same-event
+  # pairing would need new filter grammar and is out of scope here.
   @integration @unimplemented
   Scenario: The drilldown filter is trace-scoped, not same-event-scoped
     Given a trace has a "thumbs_up_down" event with vote "1" and another event with vote "-1"

--- a/specs/traces-v2/search.feature
+++ b/specs/traces-v2/search.feature
@@ -1972,11 +1972,18 @@ Rule: Event rows drill down into their metric values
 
   Scenario: Expanding the thumbs_up_down row shows its vote values with counts
     When the user expands the "thumbs_up_down" row in the Event name section
-    Then the drilldown lists "vote" values "1" and "-1" with their counts
+    Then the drilldown lists "vote" values "thumbs up" and "thumbs down" with their counts
     And no additional facet query is fired by the expansion
 
+  # The vote is stored as 1 / 0 / -1, which reads as nothing in a sidebar.
+  # Only the label is humanised — the value the filter carries stays the
+  # stored string, so the round-trip is unaffected.
+  Scenario: A metric value with no human name shows its stored string
+    Given "thumbs_up_down" events also carry "event.metrics.latency_bucket" with value "p95"
+    Then the drilldown lists that value as "p95"
+
   Scenario: Clicking a vote value applies a single event-attribute filter
-    When the user clicks the vote value "-1" in the thumbs_up_down drilldown
+    When the user clicks the vote value shown as "thumbs down" in the thumbs_up_down drilldown
     Then the search bar shows "@event.attribute.event.metrics.vote:-1"
     And no other clause is added to the query
 

--- a/specs/traces-v2/search.feature
+++ b/specs/traces-v2/search.feature
@@ -2022,7 +2022,7 @@ Rule: Event rows drill down into their metric values
   # bound tests already assert the un-prefixed form (filterStore.unit.test.ts
   # :94-96 expects "(origin:sample OR origin:application)"). The "@" spellings
   # elsewhere in this file are inaccurate and predate this Rule.
-  @integration @unimplemented
+  @integration
   Scenario: Clearing the metric leaves the event anchor it added behind
     Given the user clicked a vote value on the inactive "thumbs_up_down" row
     When the user cycles that same vote value back off

--- a/specs/traces-v2/search.feature
+++ b/specs/traces-v2/search.feature
@@ -1977,10 +1977,14 @@ Rule: Event rows drill down into their metric values
 
   # The vote is stored as 1 / 0 / -1, which reads as nothing in a sidebar.
   # Only the label is humanised — the value the filter carries stays the
-  # stored string, so the round-trip is unaffected.
-  Scenario: A metric value with no human name shows its stored string
-    Given "thumbs_up_down" events also carry "event.metrics.latency_bucket" with value "p95"
-    Then the drilldown lists that value as "p95"
+  # stored string, so the round-trip is unaffected. Every other metric,
+  # named by whoever sent it, has no such mapping and shows as stored.
+  # (Metric values are numbers everywhere — see `eventSchema.metrics`, a
+  # record of string to number — so "as stored" always means a decimal.)
+  Scenario: A metric with no human name shows its stored value
+    Given "checkout_survey" events carry "event.metrics.stars" with value "4"
+    When the user expands the "checkout_survey" row in the Event name section
+    Then the drilldown lists that value as "4"
 
   Scenario: Clicking a vote value applies a single event-attribute filter
     When the user clicks the vote value shown as "thumbs down" in the thumbs_up_down drilldown

--- a/specs/traces-v2/search.feature
+++ b/specs/traces-v2/search.feature
@@ -2002,6 +2002,20 @@ Rule: Event rows drill down into their metric values
     When the user expands the row and clicks the vote value shown as "thumbs down"
     Then the search bar shows "@event:thumbs_up_down @event.attribute.event.metrics.vote:-1"
 
+  # Known limitation, accepted: the anchor added above is not taken back when
+  # the metric clause is cleared. A click on an inactive row adds TWO clauses
+  # but the value's include/exclude/off cycle only ever removes ONE, so
+  # clearing the metric leaves "@event:thumbs_up_down" behind — an event
+  # filter the user never picked directly. Withdrawing it safely means
+  # tracking that WE added it and that no other metric under that event is
+  # still active; until then the leftover clause stays visible as an active
+  # Event name row and one click clears it.
+  @integration @unimplemented
+  Scenario: Clearing the metric leaves the event anchor it added behind
+    Given the user clicked a vote value on the inactive "thumbs_up_down" row
+    When the user cycles that same vote value back off
+    Then the search bar still shows "@event:thumbs_up_down"
+
   # Known limitation, accepted: once TWO DIFFERENT events are both active,
   # each one's attribute clause still ANDs as an independent trace-scoped
   # subquery — they may match different events in the same trace. Same-event

--- a/specs/traces-v2/search.feature
+++ b/specs/traces-v2/search.feature
@@ -1902,6 +1902,99 @@ Rule: Dynamic prefix sidebar parity
     And toggling a value writes "@event.attribute.<key>:<value>" into the search bar
 
 
+Rule: Attribute sections list values from their own attribute store
+  Each attribute flavour is backed by a different ClickHouse column
+  (trace.attribute → trace_summaries.Attributes, span.attribute →
+  stored_spans.SpanAttributes, event.attribute → stored_spans.Events.Attributes).
+  Expanding a key must list values read from that flavour's own store — a
+  span- or event-attribute key whose values only exist on spans/events must
+  not come back empty because the lookup went to the trace-level map.
+
+  Background:
+    Given the user is authenticated with "traces:view" permission
+    And the project has traces with trace, span, and event attributes
+
+  Scenario: Expanding an event-attribute key lists values observed on events
+    Given events carry the attribute "event.metrics.vote" with values "1" and "-1"
+    And no trace-level attribute named "event.metrics.vote" exists
+    When the user expands the "event.metrics.vote" key in the Event attributes section
+    Then the value list shows "1" and "-1"
+
+  Scenario: Expanding a span-attribute key lists values observed on spans
+    Given spans carry the attribute "gen_ai.request.model" with value "gpt-5-mini"
+    And no trace-level attribute named "gen_ai.request.model" exists
+    When the user expands the "gen_ai.request.model" key in the Span attributes section
+    Then the value list shows "gpt-5-mini"
+
+  Scenario: A listed event-attribute value round-trips verbatim into the filter
+    Given events carry the attribute "event.metrics.vote" with the stored string "1"
+    When the user toggles the listed value "1" under "event.metrics.vote"
+    Then the search bar shows "@event.attribute.event.metrics.vote:1"
+    And the filter value is the stored string unmodified — never reformatted
+
+
+Rule: Event filtering is reachable on the default sidebar
+  A fresh profile lands on comfortable density; the Event name section and
+  the Event attributes section must be part of that default set so feedback
+  events (thumbs_up_down and friends) are filterable without configuration.
+
+  Background:
+    Given the user is authenticated with "traces:view" permission
+    And the user has never changed density
+    And the project has traces with events carrying attributes
+
+  Scenario: Event name and Event attributes sections show on the comfortable default
+    Given the user has never changed facet visibility
+    Then the sidebar shows the "Event name" section
+    And the sidebar shows the "Event attributes" section
+
+  Scenario: Span attributes stays behind the facet picker on comfortable density
+    Given the user has never changed facet visibility
+    And the project has traces with span attributes
+    Then the sidebar does not show the "Span attributes" section
+    But the facet picker still offers "Span attributes"
+
+  Scenario: Users who previously hid the Event name section keep it hidden
+    Given the user explicitly hid the "Event name" section earlier
+    And no event filter is active in the query
+    Then the sidebar does not show the "Event name" section
+
+
+Rule: Event rows drill down into their metric values
+  Each event-name row in the Event name section expands inline — like the
+  evaluator drilldown — to show the metric values observed for that event
+  type, with counts, sourced from the same discover payload (no extra query
+  per click).
+
+  Background:
+    Given the user is authenticated with "traces:view" permission
+    And the project has traces with "thumbs_up_down" events carrying "event.metrics.vote" values "1" and "-1"
+
+  Scenario: Expanding the thumbs_up_down row shows its vote values with counts
+    When the user expands the "thumbs_up_down" row in the Event name section
+    Then the drilldown lists "vote" values "1" and "-1" with their counts
+    And no additional facet query is fired by the expansion
+
+  Scenario: Clicking a vote value applies a single event-attribute filter
+    When the user clicks the vote value "-1" in the thumbs_up_down drilldown
+    Then the search bar shows "@event.attribute.event.metrics.vote:-1"
+    And no other clause is added to the query
+
+  # Known limitation, accepted: the emitted clause matches the metric on ANY
+  # event in the trace. Combining it with "@event:thumbs_up_down" ANDs two
+  # independent trace-scoped subqueries — they may match different events in
+  # the same trace. Same-event pairing would need new filter grammar and is
+  # out of scope here.
+  Scenario: The drilldown filter is trace-scoped, not same-event-scoped
+    Given a trace has a "thumbs_up_down" event with vote "1" and another event with vote "-1"
+    When the user clicks the vote value "-1" in the thumbs_up_down drilldown
+    Then that trace still matches the resulting query
+
+  Scenario: An event type with no metrics shows no drilldown affordance
+    Given the project has "custom_marker" events carrying no event.metrics attributes
+    Then the "custom_marker" row shows no expand affordance
+
+
 Rule: Unknown field handling for typo'd prefixes
   A typo in a dynamic prefix (e.g. "atrace.attribute.x") produces a clear
   parse error rather than a silent empty result.

--- a/specs/traces-v2/search.feature
+++ b/specs/traces-v2/search.feature
@@ -2009,7 +2009,11 @@ Rule: Event rows drill down into their metric values
   # filter the user never picked directly. Withdrawing it safely means
   # tracking that WE added it and that no other metric under that event is
   # still active; until then the leftover clause stays visible as an active
-  # Event name row and one click clears it.
+  # Event name row and one click clears it. This matches how the evaluator
+  # drilldown already behaves: buildGroupClause always emits the anchor first
+  # and returns it bare when every sub-condition is gone
+  # (evaluatorGroup.ts:216,229), so a cleared evaluator group leaves
+  # "@evaluator:X" behind in the same way.
   @integration @unimplemented
   Scenario: Clearing the metric leaves the event anchor it added behind
     Given the user clicked a vote value on the inactive "thumbs_up_down" row

--- a/specs/traces-v2/search.feature
+++ b/specs/traces-v2/search.feature
@@ -1929,7 +1929,7 @@ Rule: Attribute sections list values from their own attribute store
   Scenario: A listed event-attribute value round-trips verbatim into the filter
     Given events carry the attribute "event.metrics.vote" with the stored string "1"
     When the user toggles the listed value "1" under "event.metrics.vote"
-    Then the search bar shows "@event.attribute.event.metrics.vote:1"
+    Then the search bar shows "event.attribute.event.metrics.vote:1"
     And the filter value is the stored string unmodified — never reformatted
 
 
@@ -1987,12 +1987,12 @@ Rule: Event rows drill down into their metric values
     Then the drilldown lists that value as "4"
 
   Scenario: Clicking a vote value on an already-active event row applies a single event-attribute filter
-    Given "@event:thumbs_up_down" is already an active filter
+    Given "event:thumbs_up_down" is already an active filter
     When the user clicks the vote value shown as "thumbs down" in the thumbs_up_down drilldown
-    Then the search bar shows "@event:thumbs_up_down @event.attribute.event.metrics.vote:-1"
-    And no additional "@event" clause is added to the query
+    Then the search bar shows "event:thumbs_up_down AND event.attribute.event.metrics.vote:-1"
+    And no additional "event" clause is added to the query
 
-  # Without the event anchor, "@event.attribute.event.metrics.vote:-1" alone
+  # Without the event anchor, "event.attribute.event.metrics.vote:-1" alone
   # would match a trace carrying that value under a completely different
   # event type — a metric that never happened on "thumbs_up_down" would still
   # pass. Adding the anchor keeps the picked value scoped to the row the user
@@ -2000,12 +2000,12 @@ Rule: Event rows drill down into their metric values
   Scenario: Clicking a vote value on an inactive event row scopes the filter to that event first
     Given the "thumbs_up_down" row is not yet an active filter
     When the user expands the row and clicks the vote value shown as "thumbs down"
-    Then the search bar shows "@event:thumbs_up_down @event.attribute.event.metrics.vote:-1"
+    Then the search bar shows "event:thumbs_up_down AND event.attribute.event.metrics.vote:-1"
 
   # Known limitation, accepted: the anchor added above is not taken back when
   # the metric clause is cleared. A click on an inactive row adds TWO clauses
   # but the value's include/exclude/off cycle only ever removes ONE, so
-  # clearing the metric leaves "@event:thumbs_up_down" behind — an event
+  # clearing the metric leaves "event:thumbs_up_down" behind — an event
   # filter the user never picked directly. Withdrawing it safely means
   # tracking that WE added it and that no other metric under that event is
   # still active; until then the leftover clause stays visible as an active
@@ -2013,12 +2013,20 @@ Rule: Event rows drill down into their metric values
   # drilldown already behaves: buildGroupClause always emits the anchor first
   # and returns it bare when every sub-condition is gone
   # (evaluatorGroup.ts:216,229), so a cleared evaluator group leaves
-  # "@evaluator:X" behind in the same way.
+  # "evaluator:X" behind in the same way.
+  #
+  # NOTE ON QUOTING: the strings above carry no "@" prefix, unlike most
+  # scenarios in this file. "@" is an input sigil only — normalizeQueryString
+  # strips it at token start (parse.ts:153-156) and `serialize` never re-adds
+  # it (parse.ts:98), so a facet click yields "event:x", not "@event:x". The
+  # bound tests already assert the un-prefixed form (filterStore.unit.test.ts
+  # :94-96 expects "(origin:sample OR origin:application)"). The "@" spellings
+  # elsewhere in this file are inaccurate and predate this Rule.
   @integration @unimplemented
   Scenario: Clearing the metric leaves the event anchor it added behind
     Given the user clicked a vote value on the inactive "thumbs_up_down" row
     When the user cycles that same vote value back off
-    Then the search bar still shows "@event:thumbs_up_down"
+    Then the search bar still shows "event:thumbs_up_down"
 
   # Known limitation, accepted: once TWO DIFFERENT events are both active,
   # each one's attribute clause still ANDs as an independent trace-scoped

--- a/specs/traces-v2/search.feature
+++ b/specs/traces-v2/search.feature
@@ -1996,6 +1996,7 @@ Rule: Event rows drill down into their metric values
   # independent trace-scoped subqueries — they may match different events in
   # the same trace. Same-event pairing would need new filter grammar and is
   # out of scope here.
+  @integration @unimplemented
   Scenario: The drilldown filter is trace-scoped, not same-event-scoped
     Given a trace has a "thumbs_up_down" event with vote "1" and another event with vote "-1"
     When the user clicks the vote value "-1" in the thumbs_up_down drilldown


### PR DESCRIPTION
# Related Issue

- Resolves #7764

Closes #7764.

`thumbs_up_down` events (and every other span event) are now filterable in the traces-v2 explorer without configuration: **Events → thumbs_up_down → pick up/down → filter**.

## What was broken

1. **Hidden by default** — comfortable density (the fresh-profile default) omitted the Event name and Event attributes sections.
2. **Wrong value store** — expanding an event/span attribute key listed values from `trace_summaries.Attributes`, where vote metrics never live (they're written per-span to `stored_spans.Events.Attributes`), so the picker always showed "No values".
3. **No drilldown** — event rows had no way to reach their metric values.

## What changed

- `COMFORTABLE_DEFAULT_SECTIONS` gains `event` + the event-attributes section. Span attributes stay behind "+ Add facet".
- The section's `filterPrefix` now threads down to the lazy value lookup, and the server routes `event.attribute.` / `span.attribute.` facet keys to two new bounded-sample repository lookups against `stored_spans` (`Events.Attributes` / `SpanAttributes`), mirroring `findAttributeValues` (TenantId-first PREWHERE, 50k sample, 3s cap). The bare `attribute.` prefix keeps its legacy trace-summaries alias.
- The events facet discover query zips `Events.Name` with `Events.Attributes` and attaches per-event `event.metrics.*` value tallies (composite-key `sumMap` buckets, top-10 capped, `KEY_DISCOVERY_SETTINGS` memory guard) — evaluator-facet precedent, so the new `EventDrilldown` renders with **zero extra queries per click**.
- A drilldown click toggles a single top-level `event.attribute.event.metrics.<key>:<value>` clause, with the stored string verbatim (`"-1"` round-trips character-for-character through liqe).

## Documented limitation

ANDed event filters are trace-scoped: `event:thumbs_up_down AND event.attribute.event.metrics.vote:-1` may match *different* events within one trace. Same-event pairing needs a grammar extension — recorded in `specs/traces-v2/search.feature` as an accepted limitation.

## Verification

- 4 new Rule blocks in `specs/traces-v2/search.feature`, adversarially refuted before binding; 25 new bound tests (SQL-shape unit, service routing unit, `EventDrilldown` integration, comfortable-defaults unit, value-lookup prefix tests). Red-then-green.
- All three new ClickHouse queries executed against a live dev ClickHouse with seeded rows — ranked metric buckets, verbatim values, empty buckets for metric-less events all confirmed by actual output.
- `typecheck`, `typecheck:all`, `typecheck:tests`, feature-parity, openapi checks green; 1783 server + 853 traces-v2 component tests pass.

Langy CLI support for event filters is deliberately deferred to a follow-up (UI only here).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Event rows now support expandable metric drilldowns with counts and filter controls.
  - Event names and event attributes appear by default in the filter sidebar.
  - Attribute value discovery supports trace, span, and event attributes while preserving stored values.
  - Event and span attribute filters use their corresponding data sources.

- **Bug Fixes**
  - Corrected attribute value lookups to match the active filter context.
  - Improved accessibility labels for included and excluded metric filters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->