### PR TITLE
fix(sdk-ts): annotations methods return what their signatures promise

### DIFF
--- a/docs/api-reference/openapiLangWatch.json
+++ b/docs/api-reference/openapiLangWatch.json
@@ -544,9 +544,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/Annotation"
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Annotation"
+                      }
+                    }
                   }
                 }
               }
@@ -598,9 +606,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/Annotation"
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Annotation"
+                      }
+                    }
                   }
                 }
               }
@@ -648,7 +664,11 @@
                   "email": {
                     "type": "string"
                   }
-                }
+                },
+                "required": [
+                  "comment",
+                  "isThumbsUp"
+                ]
               }
             }
           }
@@ -659,7 +679,15 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Annotation"
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/Annotation"
+                    }
+                  }
                 }
               }
             }
@@ -697,7 +725,15 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Annotation"
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/Annotation"
+                    }
+                  }
                 }
               }
             }
@@ -787,7 +823,11 @@
                   "email": {
                     "type": "string"
                   }
-                }
+                },
+                "required": [
+                  "comment",
+                  "isThumbsUp"
+                ]
               }
             }
           }
@@ -799,12 +839,12 @@
               "application/json": {
                 "schema": {
                   "type": "object",
+                  "required": [
+                    "data"
+                  ],
                   "properties": {
-                    "status": {
-                      "type": "string"
-                    },
-                    "message": {
-                      "type": "string"
+                    "data": {
+                      "$ref": "#/components/schemas/Annotation"
                     }
                   }
                 }
@@ -71797,7 +71837,15 @@
     "schemas": {
       "Annotation": {
         "required": [
-          "name"
+          "id",
+          "projectId",
+          "traceId",
+          "createdAt",
+          "updatedAt",
+          "comment",
+          "isThumbsUp",
+          "userId",
+          "email"
         ],
         "type": "object",
         "properties": {
@@ -71815,15 +71863,24 @@
           },
           "comment": {
             "description": "The comment of the annotation",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "isThumbsUp": {
             "description": "The thumbs up status of the annotation",
-            "type": "boolean"
+            "type": [
+              "boolean",
+              "null"
+            ]
           },
           "userId": {
             "description": "The ID of the user",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "createdAt": {
             "description": "The created at of the annotation",
@@ -71835,7 +71892,10 @@
           },
           "email": {
             "description": "The email of the user",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           }
         }
       },

--- a/platform/app/src/app/api/openapiLangWatch.json
+++ b/platform/app/src/app/api/openapiLangWatch.json
@@ -544,9 +544,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/Annotation"
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Annotation"
+                      }
+                    }
                   }
                 }
               }
@@ -598,9 +606,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/Annotation"
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Annotation"
+                      }
+                    }
                   }
                 }
               }
@@ -648,7 +664,11 @@
                   "email": {
                     "type": "string"
                   }
-                }
+                },
+                "required": [
+                  "comment",
+                  "isThumbsUp"
+                ]
               }
             }
           }
@@ -659,7 +679,15 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Annotation"
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/Annotation"
+                    }
+                  }
                 }
               }
             }
@@ -697,7 +725,15 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Annotation"
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/Annotation"
+                    }
+                  }
                 }
               }
             }
@@ -787,7 +823,11 @@
                   "email": {
                     "type": "string"
                   }
-                }
+                },
+                "required": [
+                  "comment",
+                  "isThumbsUp"
+                ]
               }
             }
           }
@@ -799,12 +839,12 @@
               "application/json": {
                 "schema": {
                   "type": "object",
+                  "required": [
+                    "data"
+                  ],
                   "properties": {
-                    "status": {
-                      "type": "string"
-                    },
-                    "message": {
-                      "type": "string"
+                    "data": {
+                      "$ref": "#/components/schemas/Annotation"
                     }
                   }
                 }
@@ -71797,7 +71837,15 @@
     "schemas": {
       "Annotation": {
         "required": [
-          "name"
+          "id",
+          "projectId",
+          "traceId",
+          "createdAt",
+          "updatedAt",
+          "comment",
+          "isThumbsUp",
+          "userId",
+          "email"
         ],
         "type": "object",
         "properties": {
@@ -71815,15 +71863,24 @@
           },
           "comment": {
             "description": "The comment of the annotation",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "isThumbsUp": {
             "description": "The thumbs up status of the annotation",
-            "type": "boolean"
+            "type": [
+              "boolean",
+              "null"
+            ]
           },
           "userId": {
             "description": "The ID of the user",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "createdAt": {
             "description": "The created at of the annotation",
@@ -71835,7 +71892,10 @@
           },
           "email": {
             "description": "The email of the user",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           }
         }
       },

--- a/sdks/typescript/src/cli/commands/annotations/__tests__/annotation-commands.unit.test.ts
+++ b/sdks/typescript/src/cli/commands/annotations/__tests__/annotation-commands.unit.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { AnnotationsApiError } from "@/client-sdk/services/annotations/annotations-api.service";
+import { setOutputFormat } from "../../../utils/errorOutput";
 
 vi.mock("@/client-sdk/services/annotations/annotations-api.service", async (importOriginal) => {
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
@@ -195,6 +196,52 @@ describe("createAnnotationCommand()", () => {
         isThumbsUp: false,
         email: undefined,
       });
+    });
+  });
+
+  // The server rejects either omission with a 400 (routes/annotations.ts), so
+  // the command refuses before spending a round trip — through the shared
+  // error port, so `--format json` still gets a document on stdout rather
+  // than a bare exit code and an ANSI sentence on stderr.
+  describe("when a required flag is missing under --format json", () => {
+    const stdoutDocument = () =>
+      JSON.parse(
+        vi
+          .mocked(console.log)
+          .mock.calls.map((call) => String(call[0]))
+          .join("\n"),
+      ) as { ok: boolean; error: { kind: string; message: string } };
+
+    beforeEach(() => {
+      setOutputFormat("json");
+    });
+
+    afterEach(() => {
+      setOutputFormat("text");
+    });
+
+    it("refuses --comment omission without calling the API", async () => {
+      await expect(
+        createAnnotationCommand("trace_abc", { thumbsUp: true }),
+      ).rejects.toThrow(ProcessExitError);
+
+      expect(mockCreate).not.toHaveBeenCalled();
+      const document = stdoutDocument();
+      expect(document.ok).toBe(false);
+      expect(document.error.kind).toBe("validation_error");
+      expect(document.error.message).toContain("--comment is required");
+    });
+
+    it("refuses a missing rating without calling the API", async () => {
+      await expect(
+        createAnnotationCommand("trace_abc", { comment: "No rating" }),
+      ).rejects.toThrow(ProcessExitError);
+
+      expect(mockCreate).not.toHaveBeenCalled();
+      const document = stdoutDocument();
+      expect(document.ok).toBe(false);
+      expect(document.error.kind).toBe("validation_error");
+      expect(document.error.message).toContain("--thumbs-up");
     });
   });
 });

--- a/sdks/typescript/src/cli/commands/annotations/__tests__/annotation-commands.unit.test.ts
+++ b/sdks/typescript/src/cli/commands/annotations/__tests__/annotation-commands.unit.test.ts
@@ -210,7 +210,7 @@ describe("createAnnotationCommand()", () => {
           .mocked(console.log)
           .mock.calls.map((call) => String(call[0]))
           .join("\n"),
-      ) as { ok: boolean; error: { kind: string; message: string } };
+      ) as { ok: boolean; error: { code: string; message: string } };
 
     beforeEach(() => {
       setOutputFormat("json");
@@ -228,7 +228,7 @@ describe("createAnnotationCommand()", () => {
       expect(mockCreate).not.toHaveBeenCalled();
       const document = stdoutDocument();
       expect(document.ok).toBe(false);
-      expect(document.error.kind).toBe("validation_error");
+      expect(document.error.code).toBe("validation_error");
       expect(document.error.message).toContain("--comment is required");
     });
 
@@ -240,7 +240,7 @@ describe("createAnnotationCommand()", () => {
       expect(mockCreate).not.toHaveBeenCalled();
       const document = stdoutDocument();
       expect(document.ok).toBe(false);
-      expect(document.error.kind).toBe("validation_error");
+      expect(document.error.code).toBe("validation_error");
       expect(document.error.message).toContain("--thumbs-up");
     });
   });

--- a/sdks/typescript/src/cli/commands/annotations/__tests__/annotation-commands.unit.test.ts
+++ b/sdks/typescript/src/cli/commands/annotations/__tests__/annotation-commands.unit.test.ts
@@ -243,6 +243,21 @@ describe("createAnnotationCommand()", () => {
       expect(document.error.code).toBe("validation_error");
       expect(document.error.message).toContain("--thumbs-up");
     });
+
+    it("refuses both rating flags rather than silently picking one", async () => {
+      await expect(
+        createAnnotationCommand("trace_abc", {
+          comment: "Cannot be both",
+          thumbsUp: true,
+          thumbsDown: true,
+        }),
+      ).rejects.toThrow(ProcessExitError);
+
+      expect(mockCreate).not.toHaveBeenCalled();
+      const document = stdoutDocument();
+      expect(document.error.code).toBe("validation_error");
+      expect(document.error.message).toContain("cannot be combined");
+    });
   });
 });
 

--- a/sdks/typescript/src/cli/commands/annotations/__tests__/annotation-commands.unit.test.ts
+++ b/sdks/typescript/src/cli/commands/annotations/__tests__/annotation-commands.unit.test.ts
@@ -199,11 +199,13 @@ describe("createAnnotationCommand()", () => {
     });
   });
 
-  // The server rejects either omission with a 400 (routes/annotations.ts), so
-  // the command refuses before spending a round trip — through the shared
-  // error port, so `--format json` still gets a document on stdout rather
+  // The server answers the two omissions with a 400 (routes/annotations.ts),
+  // so the command refuses before spending a round trip. The flag conflict
+  // never reaches it — `CreateAnnotationBody` carries a single `isThumbsUp`,
+  // so the pair cannot be expressed on the wire. All three refuse through the
+  // shared error port, so `--format json` gets a document on stdout rather
   // than a bare exit code and an ANSI sentence on stderr.
-  describe("when a required flag is missing under --format json", () => {
+  describe("given --format json is active", () => {
     const stdoutDocument = () =>
       JSON.parse(
         vi
@@ -220,43 +222,50 @@ describe("createAnnotationCommand()", () => {
       setOutputFormat("text");
     });
 
-    it("refuses --comment omission without calling the API", async () => {
-      await expect(
-        createAnnotationCommand("trace_abc", { thumbsUp: true }),
-      ).rejects.toThrow(ProcessExitError);
+    describe("when --comment is omitted", () => {
+      it("refuses without calling the API", async () => {
+        await expect(
+          createAnnotationCommand("trace_abc", { thumbsUp: true }),
+        ).rejects.toThrow(ProcessExitError);
 
-      expect(mockCreate).not.toHaveBeenCalled();
-      const document = stdoutDocument();
-      expect(document.ok).toBe(false);
-      expect(document.error.code).toBe("validation_error");
-      expect(document.error.message).toContain("--comment is required");
+        expect(mockCreate).not.toHaveBeenCalled();
+        const document = stdoutDocument();
+        expect(document.ok).toBe(false);
+        expect(document.error.code).toBe("validation_error");
+        expect(document.error.message).toContain("--comment is required");
+      });
     });
 
-    it("refuses a missing rating without calling the API", async () => {
-      await expect(
-        createAnnotationCommand("trace_abc", { comment: "No rating" }),
-      ).rejects.toThrow(ProcessExitError);
+    describe("when neither rating flag is given", () => {
+      it("refuses without calling the API", async () => {
+        await expect(
+          createAnnotationCommand("trace_abc", { comment: "No rating" }),
+        ).rejects.toThrow(ProcessExitError);
 
-      expect(mockCreate).not.toHaveBeenCalled();
-      const document = stdoutDocument();
-      expect(document.ok).toBe(false);
-      expect(document.error.code).toBe("validation_error");
-      expect(document.error.message).toContain("--thumbs-up");
+        expect(mockCreate).not.toHaveBeenCalled();
+        const document = stdoutDocument();
+        expect(document.ok).toBe(false);
+        expect(document.error.code).toBe("validation_error");
+        expect(document.error.message).toContain("--thumbs-up");
+      });
     });
 
-    it("refuses both rating flags rather than silently picking one", async () => {
-      await expect(
-        createAnnotationCommand("trace_abc", {
-          comment: "Cannot be both",
-          thumbsUp: true,
-          thumbsDown: true,
-        }),
-      ).rejects.toThrow(ProcessExitError);
+    describe("when both rating flags are given", () => {
+      it("refuses rather than silently picking one", async () => {
+        await expect(
+          createAnnotationCommand("trace_abc", {
+            comment: "Cannot be both",
+            thumbsUp: true,
+            thumbsDown: true,
+          }),
+        ).rejects.toThrow(ProcessExitError);
 
-      expect(mockCreate).not.toHaveBeenCalled();
-      const document = stdoutDocument();
-      expect(document.error.code).toBe("validation_error");
-      expect(document.error.message).toContain("cannot be combined");
+        expect(mockCreate).not.toHaveBeenCalled();
+        const document = stdoutDocument();
+        expect(document.ok).toBe(false);
+        expect(document.error.code).toBe("validation_error");
+        expect(document.error.message).toContain("cannot be combined");
+      });
     });
   });
 });

--- a/sdks/typescript/src/cli/commands/annotations/create.ts
+++ b/sdks/typescript/src/cli/commands/annotations/create.ts
@@ -33,9 +33,9 @@ export const createAnnotationCommand = async (
     });
     process.exit(1);
   }
-  // An annotation carries one rating, so asking for both is a mistake worth
-  // naming rather than resolving silently in favour of whichever is checked
-  // first.
+  // Unlike the two above, this is not a server rule: `CreateAnnotationBody`
+  // carries a single `isThumbsUp`, so the contradiction is inexpressible on
+  // the wire and the CLI is the only layer that can still see it.
   if (options.thumbsUp === true && options.thumbsDown === true) {
     reportCommandError({
       error: commandValidationError(

--- a/sdks/typescript/src/cli/commands/annotations/create.ts
+++ b/sdks/typescript/src/cli/commands/annotations/create.ts
@@ -33,6 +33,17 @@ export const createAnnotationCommand = async (
     });
     process.exit(1);
   }
+  // An annotation carries one rating, so asking for both is a mistake worth
+  // naming rather than resolving silently in favour of whichever is checked
+  // first.
+  if (options.thumbsUp === true && options.thumbsDown === true) {
+    reportCommandError({
+      error: commandValidationError(
+        "--thumbs-up and --thumbs-down cannot be combined: an annotation carries one rating.",
+      ),
+    });
+    process.exit(1);
+  }
 
   await resolveCredentials();
 

--- a/sdks/typescript/src/cli/commands/annotations/create.ts
+++ b/sdks/typescript/src/cli/commands/annotations/create.ts
@@ -3,6 +3,7 @@ import { createSpinner } from "../../utils/spinner";
 import { AnnotationsApiService } from "@/client-sdk/services/annotations/annotations-api.service";
 import { resolveCredentials } from "../../utils/apiKey";
 import { failSpinner } from "../../utils/spinnerError";
+import { commandValidationError, reportCommandError } from "../../utils/errorOutput";
 import type { CommandResult } from "../../utils/output";
 
 /**
@@ -13,18 +14,33 @@ export const createAnnotationCommand = async (
   traceId: string,
   options: { comment?: string; thumbsUp?: boolean; thumbsDown?: boolean; email?: string },
 ): Promise<CommandResult | void> => {
+  // Both are hard server requirements (routes/annotations.ts), so refuse
+  // before credential resolution rather than after a network round trip.
+  if (!options.comment) {
+    reportCommandError({
+      error: commandValidationError(
+        "--comment is required: an annotation without a comment is rejected by the API.\n" +
+          '  langwatch annotation create <traceId> --comment "Great response!" --thumbs-up',
+      ),
+    });
+    process.exit(1);
+  }
+  if (options.thumbsUp !== true && options.thumbsDown !== true) {
+    reportCommandError({
+      error: commandValidationError(
+        "One of --thumbs-up or --thumbs-down is required: the API stores a rating with every annotation.",
+      ),
+    });
+    process.exit(1);
+  }
+
   await resolveCredentials();
 
   const service = new AnnotationsApiService();
   const spinner = createSpinner(`Creating annotation for trace "${traceId}"...`).start();
 
   try {
-    const isThumbsUp =
-      options.thumbsUp === true
-        ? true
-        : options.thumbsDown === true
-          ? false
-          : undefined;
+    const isThumbsUp = options.thumbsUp === true;
 
     const annotation = await service.create(traceId, {
       comment: options.comment,
@@ -32,8 +48,7 @@ export const createAnnotationCommand = async (
       email: options.email,
     });
 
-    const ratingStr =
-      isThumbsUp === true ? " 👍" : isThumbsUp === false ? " 👎" : "";
+    const ratingStr = isThumbsUp ? " 👍" : " 👎";
 
     spinner.succeed(
       `Created annotation${ratingStr} ${chalk.gray(`(id: ${annotation.id ?? "—"})`)}`,

--- a/sdks/typescript/src/cli/commands/annotations/list.ts
+++ b/sdks/typescript/src/cli/commands/annotations/list.ts
@@ -40,7 +40,7 @@ export const listAnnotationsCommand = async (options: {
           console.log(chalk.gray("Create one with:"));
           console.log(
             chalk.cyan(
-              '  langwatch annotation create <traceId> --comment "Great response!"',
+              '  langwatch annotation create <traceId> --comment "Great response!" --thumbs-up',
             ),
           );
           return;

--- a/sdks/typescript/src/cli/commands/annotations/list.ts
+++ b/sdks/typescript/src/cli/commands/annotations/list.ts
@@ -23,14 +23,9 @@ export const listAnnotationsCommand = async (options: {
   const spinner = createSpinner(label).start();
 
   try {
-    const result = options.traceId
+    const annotations = options.traceId
       ? await service.getByTrace(options.traceId)
       : await service.getAll();
-
-    // Handle both array and {data: [...]} response shapes
-    const annotations = Array.isArray(result)
-      ? result
-      : (result as unknown as { data: typeof result }).data ?? [];
 
     spinner.succeed(
       `Found ${annotations.length} annotation${annotations.length !== 1 ? "s" : ""}`,

--- a/sdks/typescript/src/cli/program.ts
+++ b/sdks/typescript/src/cli/program.ts
@@ -2660,9 +2660,9 @@ export function buildProgram({ bin }: { bin?: string } = {}): Command {
     annotationCmd
       .command("create <traceId>")
       .description("Create an annotation for a trace")
-      .option("--comment <comment>", "Annotation comment")
-      .option("--thumbs-up", "Mark as thumbs up")
-      .option("--thumbs-down", "Mark as thumbs down")
+      .option("--comment <comment>", "Annotation comment (required)")
+      .option("--thumbs-up", "Mark as thumbs up (one of --thumbs-up/--thumbs-down required)")
+      .option("--thumbs-down", "Mark as thumbs down (one of --thumbs-up/--thumbs-down required)")
       .option("--email <email>", "Email of the annotator")
       .option("-f, --format <format>", "Output format: table (default) or json", "table"),
     async (traceId: string, options: { comment?: string; thumbsUp?: boolean; thumbsDown?: boolean; email?: string }) => {

--- a/sdks/typescript/src/cli/program.ts
+++ b/sdks/typescript/src/cli/program.ts
@@ -2661,8 +2661,8 @@ export function buildProgram({ bin }: { bin?: string } = {}): Command {
       .command("create <traceId>")
       .description("Create an annotation for a trace")
       .option("--comment <comment>", "Annotation comment (required)")
-      .option("--thumbs-up", "Mark as thumbs up (one of --thumbs-up/--thumbs-down required)")
-      .option("--thumbs-down", "Mark as thumbs down (one of --thumbs-up/--thumbs-down required)")
+      .option("--thumbs-up", "Mark as thumbs up (exactly one of --thumbs-up/--thumbs-down)")
+      .option("--thumbs-down", "Mark as thumbs down (exactly one of --thumbs-up/--thumbs-down)")
       .option("--email <email>", "Email of the annotator")
       .option("-f, --format <format>", "Output format: table (default) or json", "table"),
     async (traceId: string, options: { comment?: string; thumbsUp?: boolean; thumbsDown?: boolean; email?: string }) => {

--- a/sdks/typescript/src/client-sdk/services/annotations/__tests__/annotations-api.service.unit.test.ts
+++ b/sdks/typescript/src/client-sdk/services/annotations/__tests__/annotations-api.service.unit.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  AnnotationsApiService,
+  type AnnotationResponse,
+  type CreateAnnotationBody,
+} from "../annotations-api.service";
+import type { LangwatchApiClient } from "@/internal/api/client";
+
+/**
+ * The server wraps every annotation read and write in `{ data: ... }`
+ * (`platform/app/src/server/routes/annotations.ts` — trace GET :299,
+ * list GET :140, single GET :173, POST :378, PATCH :263), and has done so
+ * since before the Hono migration. The published SDK returned that envelope
+ * unwrapped, so `getByTrace(...).filter(...)` crashed with
+ * "res.filter is not a function" (issue #7863).
+ */
+const annotation: AnnotationResponse = {
+  id: "annotation_1",
+  projectId: "project_1",
+  traceId: "trace_1",
+  comment: "helpful answer",
+  isThumbsUp: true,
+  // Nullable columns in `model Annotation` — the row always carries the key,
+  // with JSON null when unset, which is why they are required-and-nullable
+  // rather than optional.
+  userId: null,
+  email: "reviewer@example.com",
+  createdAt: "2026-09-01T00:00:00.000Z",
+  updatedAt: "2026-09-01T00:00:00.000Z",
+};
+
+const clientWith = (body: unknown): LangwatchApiClient => {
+  const result = {
+    data: body,
+    error: undefined,
+    response: new Response(null, { status: 200 }),
+  };
+  return {
+    GET: vi.fn(async () => result),
+    POST: vi.fn(async () => result),
+    PATCH: vi.fn(async () => result),
+    PUT: vi.fn(async () => result),
+    DELETE: vi.fn(async () => result),
+  } as unknown as LangwatchApiClient;
+};
+
+const serviceWith = (body: unknown) =>
+  new AnnotationsApiService({ langwatchApiClient: clientWith(body) });
+
+describe("given an AnnotationsApiService against the server's envelope", () => {
+  describe("when getByTrace() answers `{ data: [...] }`", () => {
+    it("returns the array itself, so callers can .filter it", async () => {
+      const service = serviceWith({ data: [annotation] });
+
+      const result = await service.getByTrace("trace_1");
+
+      expect(Array.isArray(result)).toBe(true);
+      expect(result.filter((a) => a.isThumbsUp)).toHaveLength(1);
+      expect(result[0]).toMatchObject({ id: "annotation_1" });
+    });
+  });
+
+  describe("when getAll() answers `{ data: [...] }`", () => {
+    it("returns the array itself", async () => {
+      const service = serviceWith({ data: [annotation] });
+
+      const result = await service.getAll();
+
+      expect(Array.isArray(result)).toBe(true);
+      expect(result).toHaveLength(1);
+    });
+  });
+
+  describe("when get() answers `{ data: {...} }`", () => {
+    it("returns the annotation itself", async () => {
+      const service = serviceWith({ data: annotation });
+
+      const result = await service.get("annotation_1");
+
+      expect(result.id).toBe("annotation_1");
+      expect(result.comment).toBe("helpful answer");
+    });
+  });
+
+  describe("when create() answers `{ data: {...} }`", () => {
+    it("returns the created annotation itself", async () => {
+      const service = serviceWith({ data: annotation });
+
+      const result = await service.create("trace_1", {
+        comment: "helpful answer",
+        isThumbsUp: true,
+      });
+
+      expect(result.id).toBe("annotation_1");
+    });
+  });
+
+  describe("the create body's compile-time contract", () => {
+    it("requires comment and isThumbsUp, as the server enforces at runtime", () => {
+      // The server 400s without them (routes/annotations.ts:336-355), so the
+      // generated type must refuse the same bodies at compile time.
+      // @ts-expect-error — comment is required
+      const missingComment: CreateAnnotationBody = { isThumbsUp: true };
+      // @ts-expect-error — isThumbsUp is required
+      const missingThumb: CreateAnnotationBody = { comment: "hi" };
+      const complete: CreateAnnotationBody = {
+        comment: "hi",
+        isThumbsUp: true,
+      };
+      expect([missingComment, missingThumb, complete]).toBeDefined();
+    });
+  });
+});

--- a/sdks/typescript/src/client-sdk/services/annotations/__tests__/annotations-api.service.unit.test.ts
+++ b/sdks/typescript/src/client-sdk/services/annotations/__tests__/annotations-api.service.unit.test.ts
@@ -95,7 +95,7 @@ describe("given an AnnotationsApiService against the server's envelope", () => {
     });
   });
 
-  describe("the create body's compile-time contract", () => {
+  describe("when a caller builds the create body", () => {
     it("requires comment and isThumbsUp, as the server enforces at runtime", () => {
       // The server 400s without them (routes/annotations.ts:336-355), so the
       // generated type must refuse the same bodies at compile time.

--- a/sdks/typescript/src/client-sdk/services/annotations/annotations-api.service.ts
+++ b/sdks/typescript/src/client-sdk/services/annotations/annotations-api.service.ts
@@ -43,7 +43,7 @@ export class AnnotationsApiService {
   async getAll(): Promise<AnnotationResponse[]> {
     const { data, error } = await this.apiClient.GET("/api/annotations");
     if (error) this.handleApiError("fetch all annotations", error);
-    return data;
+    return data.data;
   }
 
   async get(id: string): Promise<AnnotationResponse> {
@@ -52,7 +52,7 @@ export class AnnotationsApiService {
     });
     if (error)
       this.handleApiError(`fetch annotation with ID "${id}"`, error);
-    return data;
+    return data.data;
   }
 
   async getByTrace(traceId: string): Promise<AnnotationResponse[]> {
@@ -64,7 +64,7 @@ export class AnnotationsApiService {
     );
     if (error)
       this.handleApiError(`fetch annotations for trace "${traceId}"`, error);
-    return data;
+    return data.data;
   }
 
   async create(traceId: string, params: CreateAnnotationBody): Promise<AnnotationResponse> {
@@ -76,7 +76,7 @@ export class AnnotationsApiService {
       },
     );
     if (error) this.handleApiError("create annotation", error);
-    return data;
+    return data.data;
   }
 
   async delete(id: string): Promise<{ status?: string; message?: string }> {

--- a/sdks/typescript/src/internal/generated/openapi/api-client.ts
+++ b/sdks/typescript/src/internal/generated/openapi/api-client.ts
@@ -48,7 +48,9 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["Annotation"][];
+                        "application/json": {
+                            data: components["schemas"]["Annotation"][];
+                        };
                     };
                 };
                 /** @description Unexpected error */
@@ -99,7 +101,9 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["Annotation"][];
+                        "application/json": {
+                            data: components["schemas"]["Annotation"][];
+                        };
                     };
                 };
                 /** @description Unexpected error */
@@ -129,8 +133,8 @@ export interface paths {
             requestBody: {
                 content: {
                     "application/json": {
-                        comment?: string;
-                        isThumbsUp?: boolean;
+                        comment: string;
+                        isThumbsUp: boolean;
                         email?: string;
                     };
                 };
@@ -142,7 +146,9 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["Annotation"];
+                        "application/json": {
+                            data: components["schemas"]["Annotation"];
+                        };
                     };
                 };
                 /** @description Invalid input */
@@ -188,7 +194,9 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["Annotation"];
+                        "application/json": {
+                            data: components["schemas"]["Annotation"];
+                        };
                     };
                 };
                 /** @description Unexpected error */
@@ -256,8 +264,8 @@ export interface paths {
             requestBody: {
                 content: {
                     "application/json": {
-                        comment?: string;
-                        isThumbsUp?: boolean;
+                        comment: string;
+                        isThumbsUp: boolean;
                         email?: string;
                     };
                 };
@@ -270,8 +278,7 @@ export interface paths {
                     };
                     content: {
                         "application/json": {
-                            status?: string;
-                            message?: string;
+                            data: components["schemas"]["Annotation"];
                         };
                     };
                 };
@@ -764,14 +771,14 @@ export interface paths {
         };
         /** @description Read one agent with its presence, its owner and the run parameters it declares. An id the project does not hold answers 404 agent_not_found. */
         get: operations["getAgent"];
-        /** @description Update an agent: any of name, type, configuration and workflow. The update is partial under PATCH and PUT alike. A connected agent takes only a new description; anything else answers 422 agent_register_only. */
+        /** @description Update an agent: any of name, type, configuration and workflow. The update is partial under PATCH and PUT alike. A connected agent takes no edit and answers 422 agent_register_only. */
         put: operations["replaceAgent"];
         post?: never;
         /** @description Archive an agent. It leaves the list and its runs stay. A connected agent that registers again restores its row. */
         delete: operations["archiveAgent"];
         options?: never;
         head?: never;
-        /** @description Update an agent: any of name, type, configuration and workflow. The update is partial under PATCH and PUT alike. A connected agent takes only a new description; anything else answers 422 agent_register_only. */
+        /** @description Update an agent: any of name, type, configuration and workflow. The update is partial under PATCH and PUT alike. A connected agent takes no edit and answers 422 agent_register_only. */
         patch: operations["updateAgent"];
         trace?: never;
     };
@@ -1031,9 +1038,29 @@ export interface paths {
         };
         /**
          * Get pull request coding agent usage
-         * @description Assistant usage for one pull request: sessions, tokens and cost, grouped by contributor and agent, plus per-model totals, over the pull request's whole lifetime rather than a time window. Every row and the totals split cost three ways: the part priced per token, the part a bundled subscription already covers, and the list-price total of both. Per-model totals carry the list price only. Cost is calculated from the tokens the agent reported and LangWatch's model prices, so it estimates spend rather than restating a provider invoice. Requires a personal-project API key; rows appear only for projects the calling user may view, and cost only for those they may price.
+         * @description Assistant usage for one pull request: sessions, tokens and cost, grouped by contributor and agent, plus per-model totals, over the pull request's whole lifetime rather than a time window. Every row and the totals split cost three ways: the part priced per token, the part a bundled subscription already covers, and the list-price total of both. Per-model totals carry the list price only. Cost is calculated from the tokens the agent reported and LangWatch's model prices, so it estimates spend rather than restating a provider invoice. Requires a personal-project API key; rows appear only for projects the calling user may view, and cost only for those they may price. Prefer `GET /api/v1/coding-agent/pull-request-usage`, which answers the same question with an organization API key alone and needs no X-Project-Id header.
          */
         get: operations["getApiCodingAgentPullRequestUsage"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/coding-agent/pull-request-usage": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get pull request usage
+         * @description Assistant usage for one pull request: sessions, tokens and cost, grouped by contributor and agent, plus per-model totals, over the pull request's whole lifetime rather than a time window. Every row and the totals split cost three ways: the part priced per token, the part a bundled subscription already covers, and the list-price total of both. Per-model totals carry the list price only. Cost is calculated from the tokens the agent reported and LangWatch's model prices, so it estimates spend rather than restating a provider invoice. Authenticate with an organization API key and nothing else: no project id is sent anywhere. A key created for you reads with your own access; an organization service key, such as one a continuous integration job holds, reads with the access its bindings grant. Rows appear only for projects the key may view, and cost only for those it may price.
+         */
+        get: operations["getPullRequestUsage"];
         put?: never;
         post?: never;
         delete?: never;
@@ -4214,23 +4241,23 @@ export interface components {
     schemas: {
         Annotation: {
             /** @description The ID of the annotation */
-            id?: string;
+            id: string;
             /** @description The ID of the project */
-            projectId?: string;
+            projectId: string;
             /** @description The ID of the trace */
-            traceId?: string;
+            traceId: string;
             /** @description The comment of the annotation */
-            comment?: string;
+            comment: string | null;
             /** @description The thumbs up status of the annotation */
-            isThumbsUp?: boolean;
+            isThumbsUp: boolean | null;
             /** @description The ID of the user */
-            userId?: string;
+            userId: string | null;
             /** @description The created at of the annotation */
-            createdAt?: string;
+            createdAt: string;
             /** @description The updated at of the annotation */
-            updatedAt?: string;
+            updatedAt: string;
             /** @description The email of the user */
-            email?: string;
+            email: string | null;
         };
         Error: {
             /** Format: int32 */
@@ -5053,7 +5080,6 @@ export interface operations {
                     agents: {
                         name: string;
                         environment: string;
-                        description?: string;
                         /** @default {} */
                         parameters?: {
                             [key: string]: unknown;
@@ -8283,6 +8309,85 @@ export interface operations {
                     "application/json": {
                         error: string;
                         message?: string;
+                    };
+                };
+            };
+        };
+    };
+    getPullRequestUsage: {
+        parameters: {
+            query: {
+                /** @description The repository as "owner/name". */
+                repository: string;
+                /** @description The pull request number. */
+                pullRequest: number;
+                /** @description The GitHub host. Defaults to this instance's configured GitHub host, which is github.com unless an operator named a GitHub Enterprise Server. */
+                host?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Success */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        pullRequest: {
+                            repositoryHost: string;
+                            repositoryFullName: string;
+                            prNumber: number;
+                            headBranch: string;
+                            htmlUrl: string;
+                            state: string;
+                            isDraft: boolean;
+                            authorLogin: string | null;
+                            prCreatedAtMs: number;
+                            prClosedAtMs: number | null;
+                            prMergedAtMs: number | null;
+                        };
+                        rows: {
+                            projectId: string;
+                            projectSlug: string;
+                            contributorLabel: string;
+                            contributorIsProject: boolean;
+                            agent: string;
+                            models: string[];
+                            sessionsCount: number;
+                            inputTokens: number;
+                            outputTokens: number;
+                            cacheReadTokens: number;
+                            cacheCreationTokens: number;
+                            totalTokens: number;
+                            costUsd: number | null;
+                            billedCostUsd: number | null;
+                            nonBilledCostUsd: number | null;
+                        }[];
+                        totals: {
+                            sessionsCount: number;
+                            inputTokens: number;
+                            outputTokens: number;
+                            cacheReadTokens: number;
+                            cacheCreationTokens: number;
+                            totalTokens: number;
+                            costUsd: number | null;
+                            billedCostUsd: number | null;
+                            nonBilledCostUsd: number | null;
+                        };
+                        modelBreakdown: {
+                            model: string;
+                            inputTokens: number;
+                            outputTokens: number;
+                            cacheReadTokens: number;
+                            cacheCreationTokens: number;
+                            totalTokens: number;
+                            costUsd: number | null;
+                            tokensKnown: boolean;
+                        }[];
                     };
                 };
             };

--- a/specs/features/annotation-cli.feature
+++ b/specs/features/annotation-cli.feature
@@ -32,6 +32,18 @@ Feature: Annotation CLI Commands
     When I run "langwatch annotation create trace_abc123 --comment 'Incorrect answer' --thumbs-down"
     Then a new annotation is created with negative feedback
 
+  Scenario: Create annotation without a comment
+    When I run "langwatch annotation create trace_abc123 --thumbs-up"
+    Then I see an error that --comment is required and no annotation is created
+
+  Scenario: Create annotation without a rating
+    When I run "langwatch annotation create trace_abc123 --comment 'No rating'"
+    Then I see an error that one rating flag is required and no annotation is created
+
+  Scenario: Create annotation with both rating flags
+    When I run "langwatch annotation create trace_abc123 --comment 'Cannot be both' --thumbs-up --thumbs-down"
+    Then I see an error that the rating flags cannot be combined and no annotation is created
+
   Scenario: Delete an annotation
     Given my project has an annotation with ID "ann_123"
     When I run "langwatch annotation delete ann_123"


### PR DESCRIPTION
Fixes #7863.

## Cause

`sdks/typescript/src/client-sdk/services/annotations/annotations-api.service.ts:58` returned the raw response body from a method typed `Promise<AnnotationResponse[]>`. The body is `{ data: [...] }`, so `.filter()` on the result threw.

The server is not the thing that changed. `platform/app/src/server/routes/annotations.ts` wraps every response in `{ data }` (`:140`, `:173`, `:263`, `:299`, `:378`) and rejects a missing `comment` with a 400 (`:232-241`, `:336-345`), and it has done so since before the Hono migration — `670b4fd8b0^` shows the same two shapes in the Next.js handler this route replaced. The defect is in `platform/app/src/app/api/openapiLangWatch.json`, the hand-maintained document the SDK client is generated from: it declared the GET 200 bodies as bare arrays and `comment`/`isThumbsUp` as optional. Omitting `comment` type-checked and then 400'd at runtime; the envelope was invisible to the type system, so the service handed it back untouched.

The issue reports the wrapper key as `annotations` and says `comment` is absent from `CreateAnnotationBody`. Both are slightly off: the key is always `data`, and `comment` is present in the published types — it is optional, which is what let the omission compile. Neither correction changes the fix.

## Reproduced first

Against a local instance with the published `langwatch@1.10.0`:

```
getByTrace returned: {"data":[]} | isArray: false
FILTER CRASH: res.filter is not a function
CREATE FAIL: Failed to create annotation: [comment] is required in the request body and must be a string.
```

And directly against the route, to confirm the server side:

```
GET  /api/annotations/trace/:id  →  {"data":[]}
POST /api/annotations/trace/:id  →  400 [comment] is required in the request body and must be a string.
PATCH /api/annotations/:id       →  400 [comment] is required in the request body and must be a string.
```

## The failing test

`sdks/typescript/src/client-sdk/services/annotations/__tests__/annotations-api.service.unit.test.ts` is new, and fails before the fix:

```
 FAIL  ... > when getByTrace() answers `{ data: [...] }` > returns the array itself, so callers can .filter it
AssertionError: expected false to be true // Object.is equality
- Expected: true
+ Received: false
 ❯ ...annotations-api.service.unit.test.ts:52:37
     52|       expect(Array.isArray(result)).toBe(true);

 FAIL  ... > when get() answers `{ data: {...} }` > returns the annotation itself
AssertionError: expected undefined to be 'annotation_1'

 Test Files  1 failed (1)
      Tests  4 failed | 1 passed (5)
```

This is the only level that could have caught it — the existing CLI test mocks `AnnotationsApiService` wholesale, so its mocks returned unwrapped arrays and it stayed green through the whole bug.

## Passing after

```
 Test Files  256 passed (256)
      Tests  3439 passed (3439)
```

Typecheck clean. End-to-end against a local instance with this build:

```
created id: NcsNf… | has data wrapper leaked: false
getByTrace isArray: true | count: 1
filter works: 1 thumbs up
get(id) returns annotation: true
```

## What changed

- Corrected the OpenAPI document (and its `docs/api-reference/` mirror) for the five annotation operations: `{ data }` on the 200 bodies, `comment` and `isThumbsUp` required on POST and PATCH.
- Corrected the `Annotation` schema, which declared `required: ["name"]` for a property it does not define. openapi-typescript drops an unresolvable entry silently, which is why every field was optional and callers read annotations through `?? "—"`. It now requires the columns the row always carries, with the nullable ones typed nullable.
- Regenerated the client and unwrapped `data` in the service. `getAll`, `get` and `create` had the same defect; `annotation get` in the CLI had been printing `Annotation undefined` with a dash for every field, with no workaround in place.
- `annotation create` now refuses a missing `--comment`, a missing rating, or both rating flags at once, through the shared error port, so `--format json` still gets a document on stdout instead of a bare exit code. `annotation list` loses the `Array.isArray` shim it carried for the envelope.

### Breaking-ish, worth knowing

Anyone who worked around this by reading `.data` off the result now gets `undefined` silently rather than a crash. The declared return type was always the array, so this repairs the published contract rather than changing it, and it stays a patch — but it is in the commit body so it reaches the changelog.

`annotation create --thumbs-up --thumbs-down` used to exit 0, having quietly stored a thumbs-up; it now exits 1 and stores nothing. The old behaviour was deterministic but arbitrary — whichever flag the ternary tested first won — so a script passing both was already storing a rating it never unambiguously asked for. This surfaces a latent bug rather than introducing one, but it is an exit-code change and scripts can see it.

The committed client was two commits stale, so regenerating it also picks up an unrelated `pull-request-usage` operation and drops a connected-agent `description` field. Nothing in the repo uses either typed operation. That drift is invisible to CI because `prebuild` and `pretest` regenerate `src/internal/generated` in place — a generate-and-diff step would close it, and belongs in its own change rather than buried here.

## Sweep

Checked every path in the document against its handler for the same wrapper drift. **No other endpoint has it** — roughly 27 `data`-wrapped and 14 bare-array paths all match their routes. Server sites that wrap but are undocumented (teams, groups, dashboards, dataset records POST) map to paths with no declared 200 schema at all: documentation gaps, not this defect.

The required-field half of the drift does appear elsewhere, and none of it currently breaks a caller, so it is not fixed here:

| Endpoint | Server requires | Document says |
| --- | --- | --- |
| `POST /api/evaluations/batch/log_results` | `experiment_id` or `experiment_slug` | neither required, no `anyOf` |
| `POST /api/dataset/upload` | `name`, `file` | no request body declared |
| `POST /api/dataset/{slugOrId}/upload` | `file` | no request body declared |
| `POST /api/dataset/direct-upload` | `projectId`, `name`, `filename` | no request body declared |
| `GET /api/dataset/{slugOrId}` | returns 7 keys beside `data` | only `data` declared |

## Noticed and deliberately not fixed

- The annotation routes can answer 401, 404 and 500, and the document declares none of them. Adding them means pointing at a correct error schema first, and the shared `Error` schema is `{ error: int32, message }` while these routes send `{ status: "error", message }` — it is also referenced by three trace paths that answer three different shapes again. That is its own change.
- The `Annotation` schema still under-declares the row: `scoreOptions`, `expectedOutput` and the anchor fields are returned and undocumented.
- The required-field drift in the table above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Annotation creation now requires a comment and either a thumbs-up or thumbs-down rating.
  * Annotation API responses consistently return data in a `data` envelope.

* **Bug Fixes**
  * Annotation results are handled consistently across listing, retrieval, and creation workflows.
  * JSON validation errors identify missing or conflicting annotation inputs and prevent invalid requests.
  * Annotation creation confirmations display the selected rating.

* **Documentation**
  * Updated API documentation to reflect annotation response formats, required fields, and nullable values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
