### PR TITLE
fix(python-sdk): only fall back on a missing scenario package

### DIFF
--- a/sdks/python/src/langwatch/agent/decorator.py
+++ b/sdks/python/src/langwatch/agent/decorator.py
@@ -160,14 +160,18 @@ class ConnectedAgent:
         `ScenarioExecutor._next_agent_for_role` compares enum members, so
         this returns the member itself; the string value would never match.
         The scenario package is an optional dependency, so it is imported here
-        rather than at module load, and its value stands in without it. An
-        import that fails for any other reason is raised, since returning the
-        value there would leave the executor silently unable to match the role.
+        rather than at module load, and its value stands in without it.
+
+        Only an absent package falls back. Python names the top-level package
+        when it is the missing one, so any other name, `scenario.types`
+        included, means the package is installed and broken, and that is
+        raised: standing in for it would leave the executor unable to match
+        the role and fail somewhere far from the cause.
         """
         try:
             from scenario.types import AgentRole
         except ModuleNotFoundError as missing:
-            if (missing.name or "").split(".")[0] != "scenario":
+            if missing.name != "scenario":
                 raise
             return "Agent"
         return AgentRole.AGENT

--- a/sdks/python/src/langwatch/agent/decorator.py
+++ b/sdks/python/src/langwatch/agent/decorator.py
@@ -160,11 +160,15 @@ class ConnectedAgent:
         `ScenarioExecutor._next_agent_for_role` compares enum members, so
         this returns the member itself; the string value would never match.
         The scenario package is an optional dependency, so it is imported here
-        rather than at module load, and its value stands in without it.
+        rather than at module load, and its value stands in without it. An
+        import that fails for any other reason is raised, since returning the
+        value there would leave the executor silently unable to match the role.
         """
         try:
             from scenario.types import AgentRole
-        except ImportError:
+        except ModuleNotFoundError as missing:
+            if (missing.name or "").split(".")[0] != "scenario":
+                raise
             return "Agent"
         return AgentRole.AGENT
 

--- a/sdks/python/tests/agent/test_agent_decorator.py
+++ b/sdks/python/tests/agent/test_agent_decorator.py
@@ -4,6 +4,7 @@
 # See specs/python-sdk/agent-decorator.feature
 
 import asyncio
+import builtins
 import logging
 import subprocess
 import sys
@@ -254,28 +255,29 @@ def test_call_reads_the_scenario_input_shape():
 
 
 # @scenario "The decorated function is accepted as the agent under test"
-def test_scenario_executor_picks_the_connected_agent_for_the_agent_role():
-    from scenario.scenario_executor import ScenarioExecutor
-    from scenario.types import AgentRole
+def test_scenario_run_accepts_the_connected_agent_as_the_agent_under_test():
+    import scenario
 
     @connect_agent(name="under-test")
     def agent(messages) -> str:
-        return "reply"
+        return f"answered {messages[-1]['content']}"
 
-    executor = ScenarioExecutor(
-        name="connected agent under test",
-        description="the decorated function answers the user simulator",
-        agents=[agent],
+    result = run(
+        scenario.run(
+            name="connected agent under test",
+            description="the decorated function answers the user",
+            # The simulator is there to own the user role. Every message is
+            # scripted, so its model is declared but never called.
+            agents=[agent, scenario.UserSimulatorAgent(model="openai/gpt-5-mini")],
+            script=[scenario.user("hello"), scenario.agent(), scenario.succeed()],
+        )
     )
-    executor._pending_agents_on_turn = set(executor.agents)
-    executor._pending_roles_on_turn = [
-        AgentRole.USER,
-        AgentRole.AGENT,
-        AgentRole.JUDGE,
-    ]
 
-    assert executor._next_agent_for_role(AgentRole.AGENT) == (0, agent)
-    assert executor._next_agent_for_role(AgentRole.USER) == (-1, None)
+    assert result.success
+    assert [(m["role"], m["content"]) for m in result.messages] == [
+        ("user", "hello"),
+        ("assistant", "answered hello"),
+    ]
 
 
 def test_role_is_the_scenario_enum_member():
@@ -290,10 +292,10 @@ def test_role_is_the_scenario_enum_member():
     assert agent.role != AgentRole.AGENT.value
 
 
-def test_importing_the_sdk_never_imports_the_scenario_package():
+def test_importing_the_decorator_never_imports_the_scenario_package():
     """The scenario package is optional, so the role resolves it lazily."""
     probe = (
-        "import sys, langwatch;"
+        "import sys;"
         " from langwatch.agent import decorator;"
         " assert 'scenario' not in sys.modules, sorted("
         "     m for m in sys.modules if m.startswith('scenario'))"
@@ -301,6 +303,49 @@ def test_importing_the_sdk_never_imports_the_scenario_package():
     done = subprocess.run([sys.executable, "-c", probe], capture_output=True, text=True)
 
     assert done.returncode == 0, done.stderr
+
+
+def break_the_scenario_import(monkeypatch, *, missing: str) -> None:
+    """Fail every scenario import, reporting `missing` as the absent module."""
+    real_import = builtins.__import__
+
+    def fake_import(module, *args, **kwargs):
+        if module.split(".")[0] == "scenario":
+            raise ModuleNotFoundError(f"No module named '{missing}'", name=missing)
+        return real_import(module, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+
+def test_role_falls_back_when_the_scenario_package_is_not_installed(monkeypatch):
+    @connect_agent(name="no-scenario")
+    def agent(messages) -> str:
+        return "reply"
+
+    break_the_scenario_import(monkeypatch, missing="scenario")
+
+    assert agent.role == "Agent"
+
+
+def test_role_raises_when_scenario_is_installed_but_one_of_its_imports_fails(
+    monkeypatch,
+):
+    """Only an absent scenario package falls back; a broken install is raised.
+
+    Swallowing this would hand the executor the string value, which never
+    matches AgentRole.AGENT, and the run would fail somewhere else entirely.
+    """
+
+    @connect_agent(name="broken-scenario")
+    def agent(messages) -> str:
+        return "reply"
+
+    break_the_scenario_import(monkeypatch, missing="litellm")
+
+    with pytest.raises(ModuleNotFoundError) as raised:
+        agent.role
+
+    assert raised.value.name == "litellm"
 
 
 def test_call_accepts_a_dict_input():

--- a/sdks/python/tests/agent/test_agent_decorator.py
+++ b/sdks/python/tests/agent/test_agent_decorator.py
@@ -327,8 +327,9 @@ def test_role_falls_back_when_the_scenario_package_is_not_installed(monkeypatch)
     assert agent.role == "Agent"
 
 
-def test_role_raises_when_scenario_is_installed_but_one_of_its_imports_fails(
-    monkeypatch,
+@pytest.mark.parametrize("missing", ["scenario.types", "litellm"])
+def test_role_raises_when_the_scenario_package_is_installed_but_broken(
+    monkeypatch, missing
 ):
     """Only an absent scenario package falls back; a broken install is raised.
 
@@ -336,16 +337,33 @@ def test_role_raises_when_scenario_is_installed_but_one_of_its_imports_fails(
     matches AgentRole.AGENT, and the run would fail somewhere else entirely.
     """
 
-    @connect_agent(name="broken-scenario")
+    @connect_agent(name=f"broken-{missing}")
     def agent(messages) -> str:
         return "reply"
 
-    break_the_scenario_import(monkeypatch, missing="litellm")
+    break_the_scenario_import(monkeypatch, missing=missing)
 
     with pytest.raises(ModuleNotFoundError) as raised:
         agent.role
 
-    assert raised.value.name == "litellm"
+    assert raised.value.name == missing
+
+
+def test_an_absent_package_is_named_by_its_top_level_module():
+    """What the role guard tells a missing package from a broken one by.
+
+    Python reports the top-level name when the package itself is absent, and
+    the dotted name when only the submodule is, so an exact match on
+    "scenario" is what separates the two.
+    """
+    with pytest.raises(ModuleNotFoundError) as absent:
+        from langwatch_no_such_package.types import AgentRole  # noqa: F401
+
+    with pytest.raises(ModuleNotFoundError) as broken:
+        from scenario.no_such_module import AgentRole  # noqa: F401
+
+    assert absent.value.name == "langwatch_no_such_package"
+    assert broken.value.name == "scenario.no_such_module"
 
 
 def test_call_accepts_a_dict_input():


### PR DESCRIPTION
Follow-up to #7871, which merged while CodeRabbit's review was still landing. It raised two findings; both are valid and both are addressed here.

## 1. The fallback caught too much

`ConnectedAgent.role` imports `scenario.types` lazily, because the scenario package is optional, and fell back to the role's string value on `ImportError`. That also swallowed an import failing *inside* `scenario.types`, for example a scenario install whose own dependency is missing. The executor compares enum members, so the string value never matches `AgentRole.AGENT`, and the run would have failed somewhere further along with no sign of the real cause.

The fallback now applies only when the absent module is `scenario` itself:

```python
try:
    from scenario.types import AgentRole
except ModuleNotFoundError as missing:
    if (missing.name or "").split(".")[0] != "scenario":
        raise
    return "Agent"
return AgentRole.AGENT
```

Two tests pin it, both driving the real property through a patched import: an absent `scenario` returns the fallback, and a `ModuleNotFoundError` naming any other module propagates with its name intact. The second fails against the previous `except ImportError`, verified by reverting the guard.

## 2. The spec binding used private executor state

The scenario reads "Given a decorated function passed to scenario.run as the agent under test", and the test mutated `_pending_agents_on_turn` / `_pending_roles_on_turn` and called `_next_agent_for_role` directly. It now calls the public `scenario.run` and asserts on the resulting conversation:

```python
result = run(
    scenario.run(
        name="connected agent under test",
        description="the decorated function answers the user",
        agents=[agent, scenario.UserSimulatorAgent(model="openai/gpt-5-mini")],
        script=[scenario.user("hello"), scenario.agent(), scenario.succeed()],
    )
)
assert result.success
assert [(m["role"], m["content"]) for m in result.messages] == [
    ("user", "hello"),
    ("assistant", "answered hello"),
]
```

The run is fully scripted, so no model is called. The simulator is in the agents list only because the executor requires an agent to own the user role before it will accept a scripted user message. This still covers `_next_agent_for_role`, now by going through it rather than around it.

The lazy-import probe now imports only `langwatch.agent.decorator` rather than the whole SDK, which is the module the guarantee is about and roughly halves its cost.

`cd sdks/python && uv run pytest tests/agent -q` passes, 104 tests.

https://claude.ai/code/session_01DypX5YL4isKqq4Gj8DTCT4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved agent role detection when the optional scenario package is unavailable.
  * Import errors from incomplete or broken scenario installations are now surfaced instead of being treated as a generic agent role.
  * Preserved fallback behavior when the scenario package is not installed.

* **Tests**
  * Added coverage for missing and broken scenario installations.
  * Added end-to-end validation of connected agent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->