### PR TITLE
fix(python-sdk): annotations reads return the annotations, and create requires what the server requires

### DIFF
--- a/sdks/python/src/langwatch/annotations.py
+++ b/sdks/python/src/langwatch/annotations.py
@@ -7,7 +7,7 @@ Uses httpx via the generated REST API client for HTTP transport.
 """
 
 import urllib.parse
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 import httpx
 
@@ -82,16 +82,16 @@ class AnnotationsFacade:
     def _http(self) -> httpx.Client:
         return self._client.get_httpx_client()
 
-    def list(self) -> Dict[str, Any]:
+    def list(self) -> List[Dict[str, Any]]:
         """
         List all annotations for the project.
 
         Returns:
-            Dictionary with annotation data.
+            List of annotations, empty when the project has none.
         """
         response = self._http().get("/api/annotations")
         _raise_for_status(response, operation="list")
-        return response.json()
+        return response.json()["data"]
 
     def get(self, annotation_id: str) -> Dict[str, Any]:
         """
@@ -101,13 +101,13 @@ class AnnotationsFacade:
             annotation_id: The annotation ID.
 
         Returns:
-            Dictionary containing the annotation data.
+            The annotation.
         """
         response = self._http().get(f"/api/annotations/{_quote(annotation_id)}")
         _raise_for_status(response, operation="get")
-        return response.json()
+        return response.json()["data"]
 
-    def get_by_trace(self, trace_id: str) -> Dict[str, Any]:
+    def get_by_trace(self, trace_id: str) -> List[Dict[str, Any]]:
         """
         Retrieve annotations for a specific trace.
 
@@ -115,36 +115,60 @@ class AnnotationsFacade:
             trace_id: The trace ID to look up annotations for.
 
         Returns:
-            Dictionary containing the annotation data for the trace.
+            List of the trace's annotations, empty when it has none.
         """
         response = self._http().get(
             f"/api/annotations/trace/{_quote(trace_id)}"
         )
         _raise_for_status(response, operation="get_by_trace")
-        return response.json()
+        return response.json()["data"]
 
     def create(
         self,
         trace_id: str,
         *,
+        comment: Optional[str] = None,
+        is_thumbs_up: Optional[bool] = None,
         params: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """
         Create a new annotation on a trace.
 
+        Both ``comment`` and ``is_thumbs_up`` are mandatory: the route refuses
+        a body missing either. They are checked here so a caller learns which
+        field is missing without spending a round trip on a 400, and they are
+        keyword arguments rather than dictionary keys so the requirement is
+        visible at the call site. Either may still arrive through ``params``
+        under its wire name, which is how callers supplied them before this
+        signature existed.
+
         Args:
             trace_id: The trace ID to annotate.
-            params: Dictionary of annotation fields (comment, isThumbsUp, etc.).
+            comment: What the reviewer said about the trace.
+            is_thumbs_up: The reviewer's verdict on the trace.
+            params: Any further annotation fields, under their wire names.
 
         Returns:
-            Dictionary containing the created annotation data.
+            The created annotation.
         """
-        body = params or {}
+        body: Dict[str, Any] = dict(params or {})
+        if comment is not None:
+            body["comment"] = comment
+        if is_thumbs_up is not None:
+            body["isThumbsUp"] = is_thumbs_up
+
+        if not body.get("comment") or not isinstance(body["comment"], str):
+            raise ValueError(
+                "comment is required and must be a non-empty string."
+            )
+        if not isinstance(body.get("isThumbsUp"), bool):
+            raise ValueError("is_thumbs_up is required and must be a boolean.")
+
         response = self._http().post(
             f"/api/annotations/trace/{_quote(trace_id)}", json=body
         )
         _raise_for_status(response, operation="create")
-        return response.json()
+        return response.json()["data"]
 
     def delete(self, annotation_id: str) -> Dict[str, Any]:
         """
@@ -154,7 +178,9 @@ class AnnotationsFacade:
             annotation_id: The annotation ID to delete.
 
         Returns:
-            Dictionary with deletion result.
+            The route's ``{status, message}`` acknowledgement. Alone among
+            these methods the delete carries no ``data`` key, so there is
+            nothing here to unwrap.
         """
         response = self._http().delete(
             f"/api/annotations/{_quote(annotation_id)}"

--- a/sdks/python/src/langwatch/dashboards.py
+++ b/sdks/python/src/langwatch/dashboards.py
@@ -7,7 +7,7 @@ Uses httpx via the generated REST API client for HTTP transport.
 """
 
 import urllib.parse
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 import httpx
 
@@ -82,16 +82,18 @@ class DashboardsFacade:
     def _http(self) -> httpx.Client:
         return self._client.get_httpx_client()
 
-    def list(self) -> Dict[str, Any]:
+    def list(self) -> List[Dict[str, Any]]:
         """
         List all dashboards for the project.
 
         Returns:
-            Dictionary with dashboard data.
+            List of dashboards, empty when the project has none. Alone among
+            the dashboard routes this one wraps its body in a ``data`` key,
+            which is why it is the only one that unwraps.
         """
         response = self._http().get("/api/dashboards")
         _raise_for_status(response, operation="list")
-        return response.json()
+        return response.json()["data"]
 
     def get(self, dashboard_id: str) -> Dict[str, Any]:
         """

--- a/sdks/python/tests/test_annotations_facade.py
+++ b/sdks/python/tests/test_annotations_facade.py
@@ -1,0 +1,178 @@
+"""Unit coverage for the annotations facade: every read hands back the
+annotation rows themselves rather than the ``{"data": ...}`` wrapper the REST
+app serves them in, a create refuses locally when it is missing a field the
+server requires, and a delete keeps the status body it actually returns.
+
+Transport is a mounted httpx.MockTransport; no network, no generated-client
+coupling beyond get_httpx_client().
+"""
+
+import json
+from typing import Any, Dict, List, Optional, Tuple
+
+import httpx
+import pytest
+
+from langwatch.annotations import AnnotationsFacade
+
+
+class FakeRestClient:
+    """The one method the facade uses from the generated client."""
+
+    def __init__(self, handler) -> None:
+        self._http = httpx.Client(
+            base_url="http://langwatch.test",
+            transport=httpx.MockTransport(handler),
+        )
+
+    def get_httpx_client(self) -> httpx.Client:
+        return self._http
+
+
+def recorder(responses: Dict[Tuple[str, str], Any], status: int = 200):
+    calls: List[Tuple[str, str, Optional[Any]]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        key = (request.method, request.url.path)
+        body = None
+        if request.content:
+            body = json.loads(request.content)
+        calls.append((request.method, str(request.url), body))
+        payload = responses.get(key)
+        assert payload is not None, f"unexpected call {key}"
+        return httpx.Response(status, json=payload)
+
+    return handler, calls
+
+
+ANNOTATION = {
+    "id": "annotation_1",
+    "traceId": "trace_1",
+    "comment": "The answer cited the wrong document.",
+    "isThumbsUp": False,
+}
+
+
+def facade_for(responses: Dict[Tuple[str, str], Any]) -> AnnotationsFacade:
+    handler, _ = recorder(responses)
+    return AnnotationsFacade(FakeRestClient(handler))
+
+
+class TestGivenTheServerWrapsAnnotationsInADataEnvelope:
+    """Every annotation 200 body is ``{"data": ...}``; the caller asked for
+    the annotations, not the envelope."""
+
+    def test_list_returns_the_annotation_rows(self):
+        facade = facade_for({("GET", "/api/annotations"): {"data": [ANNOTATION]}})
+
+        assert facade.list() == [ANNOTATION]
+
+    def test_list_returns_an_empty_list_when_the_project_has_none(self):
+        facade = facade_for({("GET", "/api/annotations"): {"data": []}})
+
+        assert facade.list() == []
+
+    def test_get_returns_the_annotation(self):
+        facade = facade_for(
+            {("GET", "/api/annotations/annotation_1"): {"data": ANNOTATION}}
+        )
+
+        assert facade.get("annotation_1") == ANNOTATION
+
+    def test_get_by_trace_returns_the_annotation_rows(self):
+        facade = facade_for(
+            {("GET", "/api/annotations/trace/trace_1"): {"data": [ANNOTATION]}}
+        )
+
+        assert facade.get_by_trace("trace_1") == [ANNOTATION]
+
+    def test_create_returns_the_created_annotation(self):
+        facade = facade_for(
+            {("POST", "/api/annotations/trace/trace_1"): {"data": ANNOTATION}}
+        )
+
+        created = facade.create(
+            "trace_1",
+            comment="The answer cited the wrong document.",
+            is_thumbs_up=False,
+        )
+
+        assert created == ANNOTATION
+
+
+class TestGivenADeleteWhoseBodyCarriesNoDataKey:
+    """The delete route answers ``{status, message}`` and nothing else, so
+    unwrapping it would raise on a call that succeeded."""
+
+    def test_delete_returns_the_status_body(self):
+        facade = facade_for(
+            {
+                ("DELETE", "/api/annotations/annotation_1"): {
+                    "status": "success",
+                    "message": "Annotation deleted.",
+                }
+            }
+        )
+
+        assert facade.delete("annotation_1") == {
+            "status": "success",
+            "message": "Annotation deleted.",
+        }
+
+
+class TestGivenTheServerRequiresACommentAndAVerdict:
+    """Both fields are mandatory on the create route. Sending neither costs a
+    round trip to learn what the signature could have said."""
+
+    def test_create_without_a_comment_is_refused_before_the_request(self):
+        handler, calls = recorder({})
+        facade = AnnotationsFacade(FakeRestClient(handler))
+
+        with pytest.raises(ValueError, match="comment"):
+            facade.create("trace_1", is_thumbs_up=True)
+
+        assert calls == []
+
+    def test_create_without_a_verdict_is_refused_before_the_request(self):
+        handler, calls = recorder({})
+        facade = AnnotationsFacade(FakeRestClient(handler))
+
+        with pytest.raises(ValueError, match="is_thumbs_up"):
+            facade.create("trace_1", comment="Looks right.")
+
+        assert calls == []
+
+    def test_create_sends_the_wire_names_the_route_reads(self):
+        handler, calls = recorder(
+            {("POST", "/api/annotations/trace/trace_1"): {"data": ANNOTATION}}
+        )
+        facade = AnnotationsFacade(FakeRestClient(handler))
+
+        facade.create(
+            "trace_1",
+            comment="Looks right.",
+            is_thumbs_up=True,
+            params={"email": "reviewer@example.test"},
+        )
+
+        _, _, body = calls[0]
+        assert body == {
+            "comment": "Looks right.",
+            "isThumbsUp": True,
+            "email": "reviewer@example.test",
+        }
+
+    def test_create_accepts_the_required_fields_supplied_through_params(self):
+        """The pre-fix signature had no dedicated arguments, so a caller who
+        already worked around it by putting both in ``params`` keeps working."""
+        handler, calls = recorder(
+            {("POST", "/api/annotations/trace/trace_1"): {"data": ANNOTATION}}
+        )
+        facade = AnnotationsFacade(FakeRestClient(handler))
+
+        created = facade.create(
+            "trace_1", params={"comment": "Looks right.", "isThumbsUp": True}
+        )
+
+        assert created == ANNOTATION
+        assert calls[0][2] == {"comment": "Looks right.", "isThumbsUp": True}

--- a/sdks/python/tests/test_dashboards_facade.py
+++ b/sdks/python/tests/test_dashboards_facade.py
@@ -1,0 +1,48 @@
+"""Unit coverage for the dashboards facade's list, the one dashboards route
+whose 200 body is wrapped in a ``{"data": ...}`` envelope. Transport is a
+mounted httpx.MockTransport; no network.
+"""
+
+from typing import Any, Dict
+
+import httpx
+
+from langwatch.dashboards import DashboardsFacade
+
+
+class FakeRestClient:
+    """The one method the facade uses from the generated client."""
+
+    def __init__(self, payload: Dict[str, Any]) -> None:
+        self._http = httpx.Client(
+            base_url="http://langwatch.test",
+            transport=httpx.MockTransport(
+                lambda _: httpx.Response(200, json=payload)
+            ),
+        )
+
+    def get_httpx_client(self) -> httpx.Client:
+        return self._http
+
+
+DASHBOARD = {"id": "dashboard_1", "name": "Latency", "graphCount": 3}
+
+
+class TestGivenTheListRouteWrapsDashboardsInADataEnvelope:
+    """The detail, create, rename and delete routes answer bare bodies; only
+    the list is wrapped, which is why it is the only one to unwrap."""
+
+    def test_list_returns_the_dashboard_rows(self):
+        facade = DashboardsFacade(FakeRestClient({"data": [DASHBOARD]}))
+
+        assert facade.list() == [DASHBOARD]
+
+    def test_list_returns_an_empty_list_when_the_project_has_none(self):
+        facade = DashboardsFacade(FakeRestClient({"data": []}))
+
+        assert facade.list() == []
+
+    def test_get_returns_the_bare_dashboard_it_is_served(self):
+        facade = DashboardsFacade(FakeRestClient(DASHBOARD))
+
+        assert facade.get("dashboard_1") == DASHBOARD


### PR DESCRIPTION
## Why

The annotations facade in the Python SDK returns the transport envelope instead of the annotations, and its `create` method makes no field mandatory although the server requires two.

Every annotation route that answers with a payload nests it under a `data` key — the project listing at `platform/app/src/server/routes/annotations.ts:140`, the single read at `:173`, the update at `:263`, the per-trace listing at `:299`, the create at `:378`. The facade returned `response.json()` unchanged, so a caller asking for the annotations on a trace received `{"data": [...]}`.

That is not merely inconvenient. Iterating the returned dictionary walks its key names rather than the rows, so the obvious next line raises:

```
AttributeError: 'str' object has no attribute 'get'
```

On the write path `create` returns the envelope, so `created["id"]` is `None` rather than an id.

Separately, `create` accepted an optional `params` dictionary and nothing else, while the route returns HTTP 400 with `[comment] is required in the request body and must be a string.` and HTTP 400 with `[isThumbsUp] is required in the request body and must be a boolean.` A caller had to read the route source to learn which fields exist, and otherwise found out by round trip.

This is the same defect class as #7863, fixed for the TypeScript SDK in #7865.

## What changed

`sdks/python/src/langwatch/annotations.py` — `list`, `get`, `get_by_trace` and `create` now return `response.json()["data"]`. The two listing methods are retyped from `Dict[str, Any]` to `List[Dict[str, Any]]`, which is what they now hand back. `create` gains explicit `comment` and `is_thumbs_up` keyword arguments and raises `ValueError` locally when either is missing, before the request leaves the process; both are still accepted through `params` for callers already passing them that way.

`delete` is deliberately left as it was. Its handler at `platform/app/src/server/routes/annotations.ts:202` answers `{"status": "success", "message": "Annotation deleted."}` with no `data` key, so unwrapping it would raise on a call that succeeded. A docstring records why.

`sdks/python/src/langwatch/dashboards.py` — `list` unwraps for the same reason. It is the only dashboards route that wraps; the handler at `platform/app/src/app/api/dashboards/[[...route]]/app.ts:69` nests under `data` while the reorder, get-by-id, rename and delete routes at `:138`, `:159`, `:193` and `:225` all answer bare. The docstring records that too, so nobody "fixes" the siblings to match.

## Test plan

`tests/test_annotations_facade.py` and `tests/test_dashboards_facade.py` drive the facades over a mock transport serving exactly the bodies the routes serve. Thirteen tests pass.

They fail without the fix. Reverting only the two source files to their `main` state and rerunning gives eleven failures and two passes — the two survivors are the `delete` tests, whose behaviour this PR does not change.

The defect and the fix were also confirmed against a live deployment, on a scratch project, over the real HTTP path. The published SDK reproduces all of it: the per-trace read returns a dictionary keyed `data`, the natural filter line over that result raises `AttributeError`, the project listing does the same, a create without a comment fails only on the server's 400, and a successful create yields an envelope whose `id` reads as `None`. Running the identical script against this branch returns a list from both reads, filters without raising, refuses the comment-less create locally before any request is sent, and produces real ids on create and read.

Raw HTTP capture against the same deployment confirms the server side independently: both 400 messages arrive as quoted above, and both the create response and the per-trace read arrive `data`-keyed.

## Breaking change — needs a decision before merge

This changes the return type of five public methods, and existing callers break on it.

A caller using annotations against the published SDK today is necessarily unwrapping by hand, because that was the only thing that worked. That line now raises. Driving both builds over the same mock transport:

```
published 1.3.1
  list         : returns dict
  result["data"] -> ok, 1 rows
  get_by_trace : returns dict
  result["data"] -> ok, 1 rows

this branch
  list         : returns list
  result["data"] -> TypeError: list indices must be integers or slices, not str
  get_by_trace : returns list
  result["data"] -> TypeError: list indices must be integers or slices, not str
```

Both commits are typed `fix(python-sdk):`, so Release Please will cut this as a patch — 1.3.1 to 1.3.2 — and every working caller breaks on a patch upgrade. The same applies to `create`, `get` and `dashboards.list`, which now return the payload rather than the envelope.

Two defensible ways to go, and the choice is not mine:

- **Ship as a patch**, matching what the TypeScript SDK did for the identical defect one week ago in #7865, released as 1.12.1. Consistent with the sibling SDK; breaks callers quietly.
- **Mark it breaking** so Release Please cuts a major. Correct under semver; a heavier release than a bug fix usually earns.

Retitle the commits and this PR to `feat(python-sdk)!:` with a `BREAKING CHANGE:` footer if the second is the call. As it stands the PR takes the first.

## Anything surprising?

`delete` is unverified against a live server in every run above, on both the published build and this branch. Its behaviour is unchanged here, but nothing in this PR proves the route answers what the docstring now claims.

Six further facades were not checked and may carry the same defect: `agents.py`, `graphs.py`, `scenarios.py`, `suites.py`, `model_providers.py`, `analytics.py`. They are leads, not findings.

There is still no update method on the Python facade, so the PATCH route at `platform/app/src/server/routes/annotations.ts:218` — which enforces the same two fields at `:232-251` — remains unreachable from the SDK. Out of scope here.
