### PR TITLE
fix(aigateway): warn once per credential on the dropped Azure api-version, and say so in settings

### DIFF
--- a/platform/app/src/components/settings/__tests__/ModelProviderForm.azure-api-version-note.integration.test.tsx
+++ b/platform/app/src/components/settings/__tests__/ModelProviderForm.azure-api-version-note.integration.test.tsx
@@ -101,10 +101,10 @@ vi.mock("../../../hooks/useFeatureFlag", () => ({
 vi.mock("../../ui/toaster", () => ({ toaster: { create: vi.fn() } }));
 
 import { modelProviderRegistry } from "../../../features/onboarding/regions/model-providers/registry";
+import type { MaybeStoredModelProvider } from "../../../server/modelProviders/registry";
 import { MASKED_KEY_PLACEHOLDER } from "../../../utils/constants";
 import { EditModelProviderForm } from "../ModelProviderForm";
 import { makePrimeQueries, Wrapper } from "./modelProviderDrawerHarness";
-import type { MaybeStoredModelProvider } from "../../../server/modelProviders/registry";
 
 const primeQueries = makePrimeQueries({
   collapsedQuery: mockGetAllForProjectForFrontendQuery,
@@ -112,7 +112,7 @@ const primeQueries = makePrimeQueries({
   projectListQuery: mockListAllForProjectForFrontendQuery,
 });
 
-const renderDrawer = (providerKey: string) =>
+const renderDrawer = ({ providerKey }: { providerKey: string }) =>
   render(
     <Wrapper>
       <EditModelProviderForm
@@ -199,7 +199,7 @@ describe("Feature: the Azure drawer says the api-version override is ignored on 
       /** @scenario "The Azure provider drawer tells the customer the api-version is ignored on AI Gateway routing" */
       it("shows the direct-mode api-version note saying the value is ignored on Gateway routing", () => {
         primeQueries([azureDirectRow()]);
-        renderDrawer("azure");
+        renderDrawer({ providerKey: "azure" });
 
         const description =
           azureEntry?.fieldMetadata?.AZURE_OPENAI_API_VERSION?.description;
@@ -216,7 +216,7 @@ describe("Feature: the Azure drawer says the api-version override is ignored on 
       /** @scenario "The Azure provider drawer tells the customer the api-version is ignored on AI Gateway routing" */
       it("shows the gateway-mode api-version note saying the value is ignored on Gateway routing", () => {
         primeQueries([azureGatewayRow()]);
-        renderDrawer("azure");
+        renderDrawer({ providerKey: "azure" });
 
         const description =
           azureEntry?.fieldMetadata?.AZURE_API_GATEWAY_VERSION?.description;
@@ -233,7 +233,7 @@ describe("Feature: the Azure drawer says the api-version override is ignored on 
       /** @scenario "A non-Azure provider drawer shows no api-version note" */
       it("shows no ignored api-version note", () => {
         primeQueries([openaiRow()]);
-        renderDrawer("openai");
+        renderDrawer({ providerKey: "openai" });
 
         expect(screen.queryByText(/ignored/i)).toBeNull();
       });

--- a/platform/app/src/components/settings/__tests__/ModelProviderForm.azure-api-version-note.integration.test.tsx
+++ b/platform/app/src/components/settings/__tests__/ModelProviderForm.azure-api-version-note.integration.test.tsx
@@ -1,0 +1,242 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * #7892: bifrost v1.5 pins Azure's api-version itself, so a caller-supplied
+ * AZURE_OPENAI_API_VERSION / AZURE_API_GATEWAY_VERSION is silently dropped
+ * on the AI Gateway dispatch path (still honored on direct/Studio dispatch
+ * via prepareLitellmParams). The settings drawer offered both fields with no
+ * indication of that split. This pins the registry helper text the drawer
+ * renders for each field, in customer-facing language that never names an
+ * internal component (bifrost/aigateway), per CLAUDE.md copywriting rules.
+ *
+ * Covers @integration scenarios from
+ * specs/ai-gateway/azure-api-version-override.feature.
+ */
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockMutateAsync,
+  mockGetAllForProjectForFrontendQuery,
+  mockListAllForOrganizationForFrontendQuery,
+  mockListAllForProjectForFrontendQuery,
+} = vi.hoisted(() => ({
+  mockMutateAsync: vi.fn().mockResolvedValue({}),
+  mockGetAllForProjectForFrontendQuery: vi.fn(),
+  mockListAllForOrganizationForFrontendQuery: vi.fn(),
+  mockListAllForProjectForFrontendQuery: vi.fn(),
+}));
+
+vi.mock("../../../utils/api", () => ({
+  api: {
+    modelProvider: {
+      getAllForProjectForFrontend: {
+        useQuery: mockGetAllForProjectForFrontendQuery,
+      },
+      listAllForOrganizationForFrontend: {
+        useQuery: mockListAllForOrganizationForFrontendQuery,
+      },
+      listAllForProjectForFrontend: {
+        useQuery: mockListAllForProjectForFrontendQuery,
+      },
+      update: { useMutation: () => ({ mutateAsync: mockMutateAsync }) },
+      setRoleAssignmentForScope: {
+        useMutation: () => ({
+          mutateAsync: vi.fn().mockResolvedValue({ ok: true }),
+        }),
+      },
+      isManagedProvider: { useQuery: () => ({ data: { managed: false } }) },
+    },
+    useUtils: () => ({
+      organization: { getAll: { invalidate: vi.fn() } },
+      modelProvider: {
+        getAllForProject: { invalidate: vi.fn() },
+        getAllForProjectForFrontend: { invalidate: vi.fn() },
+        listAllForProjectForFrontend: { invalidate: vi.fn() },
+        listAllForOrganizationForFrontend: { invalidate: vi.fn() },
+        getResolvedDefault: { invalidate: vi.fn() },
+        getDefaultModelsForProject: { invalidate: vi.fn() },
+      },
+    }),
+  },
+}));
+
+vi.mock("../../../hooks/useDrawer", () => ({
+  useDrawer: () => ({ closeDrawer: vi.fn(), openDrawer: vi.fn() }),
+}));
+
+vi.mock("../../../hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({
+    project: { id: "proj-1", name: "Web App", slug: "web-app" },
+    team: { id: "team-1", name: "Platform" },
+    organization: {
+      id: "org-1",
+      name: "Acme",
+      teams: [
+        {
+          id: "team-1",
+          name: "Platform",
+          projects: [{ id: "proj-1", name: "Web App" }],
+        },
+      ],
+    },
+    hasPermission: () => true,
+  }),
+}));
+
+vi.mock("../../../hooks/useModelProviderApiKeyValidation", () => ({
+  useModelProviderApiKeyValidation: () => ({
+    validate: vi.fn().mockResolvedValue(true),
+    validateWithCustomUrl: vi.fn().mockResolvedValue(true),
+    isValidating: false,
+    validationError: undefined,
+    clearError: vi.fn(),
+  }),
+}));
+
+vi.mock("../../../hooks/useFeatureFlag", () => ({
+  useFeatureFlag: () => ({ enabled: false, isLoading: false }),
+}));
+
+vi.mock("../../ui/toaster", () => ({ toaster: { create: vi.fn() } }));
+
+import { modelProviderRegistry } from "../../../features/onboarding/regions/model-providers/registry";
+import { MASKED_KEY_PLACEHOLDER } from "../../../utils/constants";
+import { EditModelProviderForm } from "../ModelProviderForm";
+import { makePrimeQueries, Wrapper } from "./modelProviderDrawerHarness";
+import type { MaybeStoredModelProvider } from "../../../server/modelProviders/registry";
+
+const primeQueries = makePrimeQueries({
+  collapsedQuery: mockGetAllForProjectForFrontendQuery,
+  organizationListQuery: mockListAllForOrganizationForFrontendQuery,
+  projectListQuery: mockListAllForProjectForFrontendQuery,
+});
+
+const renderDrawer = (providerKey: string) =>
+  render(
+    <Wrapper>
+      <EditModelProviderForm
+        projectId="proj-1"
+        organizationId="org-1"
+        providerKey={providerKey}
+        modelProviderId={`row-${providerKey}`}
+      />
+    </Wrapper>,
+  );
+
+/** Direct mode: no AZURE_API_GATEWAY_BASE_URL, so the drawer shows the
+ * AZURE_OPENAI_* fields (see getDisplayKeysForProvider). */
+function azureDirectRow(): MaybeStoredModelProvider {
+  return {
+    id: "row-azure",
+    name: "azure",
+    provider: "azure",
+    enabled: true,
+    customKeys: {
+      AZURE_OPENAI_API_KEY: MASKED_KEY_PLACEHOLDER,
+      AZURE_OPENAI_ENDPOINT: "https://acme.openai.azure.com",
+    },
+    models: null,
+    embeddingsModels: null,
+    customModels: null,
+    customEmbeddingsModels: null,
+    disabledByDefault: false,
+    deploymentMapping: null,
+    extraHeaders: [],
+    scopes: [{ scopeType: "PROJECT", scopeId: "proj-1" }],
+    scopeType: "PROJECT",
+    scopeId: "proj-1",
+  };
+}
+
+/** Gateway (APIM) mode: AZURE_API_GATEWAY_BASE_URL set flips
+ * computeInitialUseApiGateway to true, so the drawer shows the
+ * AZURE_API_GATEWAY_* fields instead. */
+function azureGatewayRow(): MaybeStoredModelProvider {
+  return {
+    ...azureDirectRow(),
+    customKeys: {
+      AZURE_API_GATEWAY_BASE_URL: "https://gateway.example.com",
+    },
+  };
+}
+
+function openaiRow(): MaybeStoredModelProvider {
+  return {
+    id: "row-openai",
+    name: "openai",
+    provider: "openai",
+    enabled: true,
+    customKeys: { OPENAI_API_KEY: MASKED_KEY_PLACEHOLDER },
+    models: null,
+    embeddingsModels: null,
+    customModels: null,
+    customEmbeddingsModels: null,
+    disabledByDefault: false,
+    deploymentMapping: null,
+    extraHeaders: [],
+    scopes: [{ scopeType: "PROJECT", scopeId: "proj-1" }],
+    scopeType: "PROJECT",
+    scopeId: "proj-1",
+  };
+}
+
+const azureEntry = modelProviderRegistry.find(
+  (entry) => entry.backendModelProviderKey === "azure",
+);
+
+describe("Feature: the Azure drawer says the api-version override is ignored on AI Gateway routing", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  describe("given the Azure provider in direct-dispatch mode", () => {
+    describe("when the drawer is opened", () => {
+      /** @scenario "The Azure provider drawer tells the customer the api-version is ignored on AI Gateway routing" */
+      it("shows the direct-mode api-version note saying the value is ignored on Gateway routing", () => {
+        primeQueries([azureDirectRow()]);
+        renderDrawer("azure");
+
+        const description =
+          azureEntry?.fieldMetadata?.AZURE_OPENAI_API_VERSION?.description;
+        expect(description).toBeTruthy();
+        expect(description).toMatch(/ignored/i);
+        expect(description).not.toMatch(/bifrost|aigateway/i);
+        expect(screen.getByText(description!)).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("given the Azure provider in API Management gateway mode", () => {
+    describe("when the drawer is opened", () => {
+      /** @scenario "The Azure provider drawer tells the customer the api-version is ignored on AI Gateway routing" */
+      it("shows the gateway-mode api-version note saying the value is ignored on Gateway routing", () => {
+        primeQueries([azureGatewayRow()]);
+        renderDrawer("azure");
+
+        const description =
+          azureEntry?.fieldMetadata?.AZURE_API_GATEWAY_VERSION?.description;
+        expect(description).toBeTruthy();
+        expect(description).toMatch(/ignored/i);
+        expect(description).not.toMatch(/bifrost|aigateway/i);
+        expect(screen.getByText(description!)).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("given a non-Azure provider", () => {
+    describe("when the drawer is opened", () => {
+      /** @scenario "A non-Azure provider drawer shows no api-version note" */
+      it("shows no ignored api-version note", () => {
+        primeQueries([openaiRow()]);
+        renderDrawer("openai");
+
+        expect(screen.queryByText(/ignored/i)).toBeNull();
+      });
+    });
+  });
+});

--- a/platform/app/src/features/onboarding/regions/model-providers/registry.tsx
+++ b/platform/app/src/features/onboarding/regions/model-providers/registry.tsx
@@ -103,6 +103,11 @@ export const modelProviderRegistry: ModelProviderRegistry = [
         description:
           "Your Azure OpenAI resource endpoint URL (e.g., https://your-resource.openai.azure.com)",
       },
+      AZURE_OPENAI_API_VERSION: {
+        label: "API Version",
+        description:
+          "Optional: used when calling your Azure OpenAI resource directly. It is ignored when your traffic routes through the LangWatch AI Gateway, which sets its own version.",
+      },
       AZURE_API_GATEWAY_BASE_URL: {
         label: "Base URL",
         description:
@@ -110,7 +115,8 @@ export const modelProviderRegistry: ModelProviderRegistry = [
       },
       AZURE_API_GATEWAY_VERSION: {
         label: "Version",
-        description: "Optional: API version for Azure API Management gateway",
+        description:
+          "Optional: used when calling through your Azure API Management gateway. It is ignored when your traffic routes through the LangWatch AI Gateway, which sets its own version.",
       },
     },
   },

--- a/platform/app/src/server/api/routers/__tests__/modelProviders.utils.azure.unit.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/modelProviders.utils.azure.unit.test.ts
@@ -18,9 +18,11 @@ import { describe, expect, it } from "vitest";
 import type { MaybeStoredModelProvider } from "../../../modelProviders/registry";
 import { prepareLitellmParams } from "../modelProviders.utils";
 
-function azureProvider(
-  customKeys: Record<string, string>,
-): MaybeStoredModelProvider {
+function azureProvider({
+  customKeys,
+}: {
+  customKeys: Record<string, string>;
+}): MaybeStoredModelProvider {
   return {
     name: "azure",
     provider: "azure",
@@ -45,9 +47,11 @@ describe("Feature: Azure api-version is honored on the direct dispatch path", ()
       /** @scenario "Direct-mode Azure dispatch uses the customer's configured api-version" */
       it("uses the customer's configured AZURE_OPENAI_API_VERSION", async () => {
         const modelProvider = azureProvider({
-          AZURE_OPENAI_API_KEY: "az-key",
-          AZURE_OPENAI_ENDPOINT: "https://acme.openai.azure.com",
-          AZURE_OPENAI_API_VERSION: "2024-10-21",
+          customKeys: {
+            AZURE_OPENAI_API_KEY: "az-key",
+            AZURE_OPENAI_ENDPOINT: "https://acme.openai.azure.com",
+            AZURE_OPENAI_API_VERSION: "2024-10-21",
+          },
         });
 
         const params = await prepareLitellmParams({
@@ -66,8 +70,10 @@ describe("Feature: Azure api-version is honored on the direct dispatch path", ()
       /** @scenario "Azure API Management gateway mode defaults its own api-version" */
       it("falls back to the gateway-mode default api-version", async () => {
         const modelProvider = azureProvider({
-          AZURE_OPENAI_API_KEY: "az-key",
-          AZURE_API_GATEWAY_BASE_URL: "https://gateway.example.com",
+          customKeys: {
+            AZURE_OPENAI_API_KEY: "az-key",
+            AZURE_API_GATEWAY_BASE_URL: "https://gateway.example.com",
+          },
         });
 
         const params = await prepareLitellmParams({
@@ -82,8 +88,10 @@ describe("Feature: Azure api-version is honored on the direct dispatch path", ()
       /** @scenario "Azure API Management gateway mode defaults its own api-version" */
       it("marks the request as using the Azure gateway", async () => {
         const modelProvider = azureProvider({
-          AZURE_OPENAI_API_KEY: "az-key",
-          AZURE_API_GATEWAY_BASE_URL: "https://gateway.example.com",
+          customKeys: {
+            AZURE_OPENAI_API_KEY: "az-key",
+            AZURE_API_GATEWAY_BASE_URL: "https://gateway.example.com",
+          },
         });
 
         const params = await prepareLitellmParams({

--- a/platform/app/src/server/api/routers/__tests__/modelProviders.utils.azure.unit.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/modelProviders.utils.azure.unit.test.ts
@@ -1,0 +1,99 @@
+/**
+ * #7892: prepareLitellmParams is the direct/Studio dispatch path, and it
+ * still honors AZURE_OPENAI_API_VERSION / AZURE_API_GATEWAY_VERSION (unlike
+ * the AI Gateway/bifrost dispatch path, which drops a caller-supplied
+ * override — see azure_api_version_dedup_test.go). These pin that the
+ * direct-mode value and the API Management gateway-mode default are both
+ * unaffected by the #7892 change, since regressing either would make the
+ * two dispatch paths agree for the wrong reason.
+ *
+ * Covers @unit scenarios from specs/ai-gateway/azure-api-version-override.feature.
+ *
+ * `id` is left unset on every fixture so `prepareLitellmParams` never
+ * reaches `resolveServingRow`'s Prisma lookup (it short-circuits on a
+ * falsy `modelProvider.id`) — this is a pure-logic unit test, not an
+ * integration test against a real database.
+ */
+import { describe, expect, it } from "vitest";
+import type { MaybeStoredModelProvider } from "../../../modelProviders/registry";
+import { prepareLitellmParams } from "../modelProviders.utils";
+
+function azureProvider(
+  customKeys: Record<string, string>,
+): MaybeStoredModelProvider {
+  return {
+    name: "azure",
+    provider: "azure",
+    enabled: true,
+    customKeys,
+    models: null,
+    embeddingsModels: null,
+    customModels: null,
+    customEmbeddingsModels: null,
+    disabledByDefault: false,
+    deploymentMapping: null,
+    extraHeaders: [],
+    scopes: [{ scopeType: "PROJECT", scopeId: "proj-1" }],
+    scopeType: "PROJECT",
+    scopeId: "proj-1",
+  } as MaybeStoredModelProvider;
+}
+
+describe("Feature: Azure api-version is honored on the direct dispatch path", () => {
+  describe("given an Azure provider configured for direct dispatch", () => {
+    describe("when litellm dispatch parameters are prepared", () => {
+      /** @scenario "Direct-mode Azure dispatch uses the customer's configured api-version" */
+      it("uses the customer's configured AZURE_OPENAI_API_VERSION", async () => {
+        const modelProvider = azureProvider({
+          AZURE_OPENAI_API_KEY: "az-key",
+          AZURE_OPENAI_ENDPOINT: "https://acme.openai.azure.com",
+          AZURE_OPENAI_API_VERSION: "2024-10-21",
+        });
+
+        const params = await prepareLitellmParams({
+          model: "azure/gpt-5",
+          modelProvider,
+          projectId: "proj-1",
+        });
+
+        expect(params.api_version).toBe("2024-10-21");
+      });
+    });
+  });
+
+  describe("given an Azure provider configured for API Management gateway mode with no explicit version", () => {
+    describe("when litellm dispatch parameters are prepared", () => {
+      /** @scenario "Azure API Management gateway mode defaults its own api-version" */
+      it("falls back to the gateway-mode default api-version", async () => {
+        const modelProvider = azureProvider({
+          AZURE_OPENAI_API_KEY: "az-key",
+          AZURE_API_GATEWAY_BASE_URL: "https://gateway.example.com",
+        });
+
+        const params = await prepareLitellmParams({
+          model: "azure/gpt-5",
+          modelProvider,
+          projectId: "proj-1",
+        });
+
+        expect(params.api_version).toBe("2024-05-01-preview");
+      });
+
+      /** @scenario "Azure API Management gateway mode defaults its own api-version" */
+      it("marks the request as using the Azure gateway", async () => {
+        const modelProvider = azureProvider({
+          AZURE_OPENAI_API_KEY: "az-key",
+          AZURE_API_GATEWAY_BASE_URL: "https://gateway.example.com",
+        });
+
+        const params = await prepareLitellmParams({
+          model: "azure/gpt-5",
+          modelProvider,
+          projectId: "proj-1",
+        });
+
+        expect(params.use_azure_gateway).toBe("true");
+      });
+    });
+  });
+});

--- a/services/aigateway/adapters/providers/azure_api_version_dedup_test.go
+++ b/services/aigateway/adapters/providers/azure_api_version_dedup_test.go
@@ -1,0 +1,161 @@
+package providers
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	bfschemas "github.com/maximhq/bifrost/core/schemas"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/langwatch/langwatch/services/aigateway/domain"
+)
+
+// These tests pin the dedup behavior added for #7892: the
+// "azure api_version override is ignored" warning must fire once per
+// credential ID on the shared, long-lived `account` (bifrost's per-request
+// key-selection entry point, GetKeysForProvider, runs concurrently under a
+// 1000-worker pool) rather than once per dispatch.
+//
+// Spec: specs/ai-gateway/azure-api-version-override.feature
+
+func azureCredWithVersion(id, apiVersion string) domain.Credential {
+	extra := map[string]string{"api_base": "https://acme.openai.azure.com"}
+	if apiVersion != "" {
+		extra["api_version"] = apiVersion
+	}
+	return domain.Credential{
+		ID:         id,
+		ProviderID: domain.ProviderAzure,
+		APIKey:     "az-key",
+		Extra:      extra,
+	}
+}
+
+// @scenario "Repeated dispatches for one Azure credential warn only once"
+func TestAccountGetKeysForProvider_Azure_WarnsOnceAcrossRepeatedDispatches(t *testing.T) {
+	core, logs := observer.New(zapcore.WarnLevel)
+	logger := zap.New(core)
+	acc := &account{logger: logger}
+
+	cred := azureCredWithVersion("mp-azure-1", "2023-05-15")
+	ctx := withCredential(context.Background(), cred)
+
+	for i := 0; i < 3; i++ {
+		if _, err := acc.GetKeysForProvider(ctx, bfschemas.Azure); err != nil {
+			t.Fatalf("GetKeysForProvider call %d: unexpected error: %v", i, err)
+		}
+	}
+
+	entries := logs.FilterMessageSnippet("api_version override is ignored").All()
+	if len(entries) != 1 {
+		t.Fatalf("want exactly 1 warning across 3 dispatches for the same credential, got %d", len(entries))
+	}
+	if got := entries[0].ContextMap()["api_version"]; got != "2023-05-15" {
+		t.Fatalf("warning api_version field = %v, want 2023-05-15", got)
+	}
+}
+
+// @scenario "A credential sourced from the /go/proxy header path still warns on first sight"
+func TestAccountGetKeysForProvider_Azure_ProxyStyleCredentialIDStillWarns(t *testing.T) {
+	core, logs := observer.New(zapcore.WarnLevel)
+	logger := zap.New(core)
+	acc := &account{logger: logger}
+
+	// gatewayproxy.ParseCredentialFromHeaders (services/nlpgo/adapters/gatewayproxy)
+	// mints IDs of the shape "playground-inline-<provider>" for the /go/proxy
+	// header-credential path, distinct from the control-plane virtual-key ID
+	// shape. Dedup keys on cred.ID regardless of which path produced it.
+	cred := azureCredWithVersion("playground-inline-azure", "2023-05-15")
+	ctx := withCredential(context.Background(), cred)
+
+	if _, err := acc.GetKeysForProvider(ctx, bfschemas.Azure); err != nil {
+		t.Fatalf("GetKeysForProvider: unexpected error: %v", err)
+	}
+
+	entries := logs.FilterMessageSnippet("api_version override is ignored").All()
+	if len(entries) != 1 {
+		t.Fatalf("want exactly 1 warning on first sight of a proxy-style credential id, got %d", len(entries))
+	}
+}
+
+// @scenario "Two Azure credentials each warn once"
+func TestAccountGetKeysForProvider_Azure_TwoDistinctCredentialsWarnTwice(t *testing.T) {
+	core, logs := observer.New(zapcore.WarnLevel)
+	logger := zap.New(core)
+	acc := &account{logger: logger}
+
+	credA := azureCredWithVersion("mp-azure-a", "2023-05-15")
+	credB := azureCredWithVersion("mp-azure-b", "2024-02-01")
+
+	for i := 0; i < 2; i++ {
+		ctxA := withCredential(context.Background(), credA)
+		if _, err := acc.GetKeysForProvider(ctxA, bfschemas.Azure); err != nil {
+			t.Fatalf("GetKeysForProvider(credA) call %d: unexpected error: %v", i, err)
+		}
+		ctxB := withCredential(context.Background(), credB)
+		if _, err := acc.GetKeysForProvider(ctxB, bfschemas.Azure); err != nil {
+			t.Fatalf("GetKeysForProvider(credB) call %d: unexpected error: %v", i, err)
+		}
+	}
+
+	entries := logs.FilterMessageSnippet("api_version override is ignored").All()
+	if len(entries) != 2 {
+		t.Fatalf("want exactly 2 warnings for 2 distinct credential ids (dedup must be per-ID, not global), got %d", len(entries))
+	}
+}
+
+// @scenario "A credential with no api-version override never warns"
+func TestAccountGetKeysForProvider_Azure_NoOverrideNeverWarns(t *testing.T) {
+	core, logs := observer.New(zapcore.WarnLevel)
+	logger := zap.New(core)
+	acc := &account{logger: logger}
+
+	cred := azureCredWithVersion("mp-azure-no-version", "")
+	ctx := withCredential(context.Background(), cred)
+
+	for i := 0; i < 3; i++ {
+		if _, err := acc.GetKeysForProvider(ctx, bfschemas.Azure); err != nil {
+			t.Fatalf("GetKeysForProvider call %d: unexpected error: %v", i, err)
+		}
+	}
+
+	entries := logs.FilterMessageSnippet("api_version override is ignored").All()
+	if len(entries) != 0 {
+		t.Fatalf("want 0 warnings for a credential with no api_version override, got %d", len(entries))
+	}
+}
+
+// @scenario "Concurrent dispatches for one credential warn exactly once"
+func TestAccountGetKeysForProvider_Azure_ConcurrentDispatchesWarnOnce(t *testing.T) {
+	core, logs := observer.New(zapcore.WarnLevel)
+	logger := zap.New(core)
+	// One shared, long-lived account instance — the same struct literal
+	// NewBifrostRouter builds and hands to bifrost.Init, dispatched to
+	// concurrently by bifrost's worker pool in production. AC10 fails if the
+	// warned-set turns out to be scoped per-call instead of per-account.
+	acc := &account{logger: logger}
+
+	cred := azureCredWithVersion("mp-azure-concurrent", "2023-05-15")
+
+	const n = 50
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			ctx := withCredential(context.Background(), cred)
+			if _, err := acc.GetKeysForProvider(ctx, bfschemas.Azure); err != nil {
+				t.Errorf("GetKeysForProvider: unexpected error: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	entries := logs.FilterMessageSnippet("api_version override is ignored").All()
+	if len(entries) != 1 {
+		t.Fatalf("want exactly 1 warning across %d concurrent dispatches for the same credential, got %d", n, len(entries))
+	}
+}

--- a/services/aigateway/adapters/providers/bifrost.go
+++ b/services/aigateway/adapters/providers/bifrost.go
@@ -1207,6 +1207,12 @@ type account struct {
 	// logger is passed to credentialToBifrostKey for the dropped
 	// api_version warning. May be nil.
 	logger *zap.Logger
+	// warnedAzureAPIVersionIDs tracks credential IDs that have already
+	// logged the dropped-api_version warning, so a long-lived account
+	// (dispatched to concurrently by bifrost's worker pool) warns at most
+	// once per credential rather than once per dispatch. Bounded by the
+	// number of configured Azure credentials, not by request volume.
+	warnedAzureAPIVersionIDs sync.Map
 }
 
 func (a *account) GetConfiguredProviders() ([]bfschemas.ModelProvider, error) {
@@ -1218,7 +1224,16 @@ func (a *account) GetKeysForProvider(ctx context.Context, provider bfschemas.Mod
 	if cred.ID == "" {
 		return nil, fmt.Errorf("no credential on context for provider %s", provider)
 	}
-	key := credentialToBifrostKey(cred, provider, a.logger)
+	logger := a.logger
+	if cred.Extra["api_version"] != "" {
+		// LoadOrStore is the atomic check-and-set: only the dispatch that
+		// wins the race to store the ID keeps its logger, so concurrent
+		// dispatches for the same credential still warn exactly once.
+		if _, alreadyWarned := a.warnedAzureAPIVersionIDs.LoadOrStore(cred.ID, struct{}{}); alreadyWarned {
+			logger = nil
+		}
+	}
+	key := credentialToBifrostKey(cred, provider, logger)
 	return []bfschemas.Key{key}, nil
 }
 

--- a/services/aigateway/adapters/providers/bifrost.go
+++ b/services/aigateway/adapters/providers/bifrost.go
@@ -1211,7 +1211,8 @@ type account struct {
 	// logged the dropped-api_version warning, so a long-lived account
 	// (dispatched to concurrently by bifrost's worker pool) warns at most
 	// once per credential rather than once per dispatch. Bounded by the
-	// number of configured Azure credentials, not by request volume.
+	// number of distinct Azure credential IDs seen over this process's
+	// lifetime, not by request volume.
 	warnedAzureAPIVersionIDs sync.Map
 }
 
@@ -1224,17 +1225,27 @@ func (a *account) GetKeysForProvider(ctx context.Context, provider bfschemas.Mod
 	if cred.ID == "" {
 		return nil, fmt.Errorf("no credential on context for provider %s", provider)
 	}
-	logger := a.logger
-	if cred.Extra["api_version"] != "" {
-		// LoadOrStore is the atomic check-and-set: only the dispatch that
-		// wins the race to store the ID keeps its logger, so concurrent
-		// dispatches for the same credential still warn exactly once.
-		if _, alreadyWarned := a.warnedAzureAPIVersionIDs.LoadOrStore(cred.ID, struct{}{}); alreadyWarned {
-			logger = nil
-		}
-	}
-	key := credentialToBifrostKey(cred, provider, logger)
+	key := credentialToBifrostKey(cred, provider, a.azureAPIVersionWarnLogger(cred))
 	return []bfschemas.Key{key}, nil
+}
+
+// azureAPIVersionWarnLogger returns the account's logger only on the first
+// sight of a credential that carries an api-version override, and nil
+// thereafter. GetKeysForProvider sits on bifrost's per-request key-selection
+// path, so without this a static configuration fact would be logged on every
+// dispatch. LoadOrStore is the atomic check-and-set: exactly one of a set of
+// concurrent first dispatches keeps the logger. Suppressing by nil-ing the
+// logger is only sound while credentialToBifrostKey uses it for that one
+// warning — if it ever logs anything else, move this dedup into
+// warnIgnoredAzureAPIVersion instead.
+func (a *account) azureAPIVersionWarnLogger(cred domain.Credential) *zap.Logger {
+	if cred.Extra["api_version"] == "" {
+		return a.logger
+	}
+	if _, alreadyWarned := a.warnedAzureAPIVersionIDs.LoadOrStore(cred.ID, struct{}{}); alreadyWarned {
+		return nil
+	}
+	return a.logger
 }
 
 // ProviderRequestTimeoutSeconds is the gateway-wide upstream request timeout,
@@ -1320,9 +1331,6 @@ func (a *account) GetConfigForProvider(provider bfschemas.ModelProvider) (*bfsch
 	return cfg, nil
 }
 
-// credentialToBifrostKey converts a domain.Credential into bifrost's Key
-// format. logger may be nil (e.g. bare tests); used only to warn on a
-// dropped api_version override.
 // warnIgnoredAzureAPIVersion logs when a caller supplied an Azure api_version
 // override that bifrost v1.5 no longer forwards. logger may be nil.
 func warnIgnoredAzureAPIVersion(cred domain.Credential, logger *zap.Logger) {
@@ -1332,6 +1340,9 @@ func warnIgnoredAzureAPIVersion(cred domain.Credential, logger *zap.Logger) {
 	}
 }
 
+// credentialToBifrostKey converts a domain.Credential into bifrost's Key
+// format. logger may be nil (e.g. bare tests); used only to warn on a
+// dropped api_version override.
 func credentialToBifrostKey(cred domain.Credential, provider bfschemas.ModelProvider, logger *zap.Logger) bfschemas.Key {
 	k := bfschemas.Key{
 		ID:     cred.ID,

--- a/specs/ai-gateway/azure-api-version-override.feature
+++ b/specs/ai-gateway/azure-api-version-override.feature
@@ -1,0 +1,85 @@
+Feature: Azure api-version override — dedup the drop warning, tell the customer
+  Bifrost v1.5 pins Azure's api-version itself, so a caller-supplied
+  AZURE_OPENAI_API_VERSION / AZURE_API_GATEWAY_VERSION override is silently
+  dropped on the AI Gateway dispatch path (see #7877). Two follow-up gaps
+  from #7892:
+
+  1. The drop warning (`warnIgnoredAzureAPIVersion`, bifrost.go) fires on
+     every single dispatch for a credential instead of once — a busy Azure
+     provider floods the gateway logs with a static configuration fact.
+  2. The settings form offers the api-version fields with no indication
+     that they do nothing on Gateway-routed traffic, while the same fields
+     are still honored on the direct/Studio dispatch path
+     (prepareLitellmParams). A customer cannot tell which mode is in
+     force for their own provider.
+
+  Background:
+    Given an Azure OpenAI provider whose credential carries a caller-supplied
+      api-version override
+
+  @unit
+  Scenario: Repeated dispatches for one Azure credential warn only once
+    When the gateway resolves the Azure credential's bifrost key 3 times for
+      the same credential id
+    Then exactly one "azure api_version override is ignored" warning is logged
+    And that warning still carries the api_version value in its structured
+      fields
+
+  @unit
+  Scenario: A credential sourced from the /go/proxy header path still warns on first sight
+    Given the Azure credential's id was produced by the /go/proxy header
+      parsing path rather than the control-plane virtual-key path
+    When the gateway resolves that credential's bifrost key for the first time
+    Then the "azure api_version override is ignored" warning is logged
+
+  @unit
+  Scenario: Two Azure credentials each warn once
+    Given a second, distinct Azure credential that also carries an
+      api-version override
+    When the gateway resolves each credential's bifrost key at least twice
+    Then exactly two "azure api_version override is ignored" warnings are
+      logged in total, one per credential id
+
+  @unit
+  Scenario: A credential with no api-version override never warns
+    Given an Azure credential whose api-version field is empty
+    When the gateway resolves that credential's bifrost key 3 times
+    Then no "azure api_version override is ignored" warning is logged
+
+  @unit
+  Scenario: Concurrent dispatches for one credential warn exactly once
+    Given 50 or more concurrent goroutines resolving the same Azure
+      credential's bifrost key against one shared, long-lived account
+    When all of them complete
+    Then exactly one "azure api_version override is ignored" warning is
+      logged
+    And the race detector reports no data race
+
+  @integration
+  Scenario: The Azure provider drawer tells the customer the api-version is ignored on AI Gateway routing
+    When a customer opens the Azure OpenAI provider settings drawer
+    Then the direct-mode api-version field explains, without naming any
+      internal service, that the value is ignored when traffic routes
+      through the AI Gateway
+    And the API Management gateway-mode api-version field explains the same
+      thing
+
+  @integration
+  Scenario: A non-Azure provider drawer shows no api-version note
+    When a customer opens a non-Azure provider's settings drawer
+    Then no "ignored" api-version note appears
+
+  @unit
+  Scenario: Direct-mode Azure dispatch uses the customer's configured api-version
+    Given an Azure provider configured for direct dispatch with an explicit
+      AZURE_OPENAI_API_VERSION
+    When the litellm dispatch parameters are prepared for that provider
+    Then the resolved api_version equals the customer's configured value
+
+  @unit
+  Scenario: Azure API Management gateway mode defaults its own api-version
+    Given an Azure provider configured with an API Management gateway base
+      URL and no explicit gateway api-version
+    When the litellm dispatch parameters are prepared for that provider
+    Then the resolved api_version falls back to the gateway-mode default
+    And use_azure_gateway is set


### PR DESCRIPTION
**Low risk** — two independent, additive changes: a warned-set on a process-singleton struct, and two strings of settings copy. No schema change, no field removal, no behaviour change on any dispatch path.

- **Scariest thing** — the dedup suppresses by handing `credentialToBifrostKey` a `nil` logger. That is sound only while that function logs one thing. If it ever logs anything else, repeat dispatches would silently swallow the new line too. The tripwire is written into the method's doc comment; the alternative (threading the warned-set into `warnIgnoredAzureAPIVersion`) would have changed a signature three existing tests call directly.
- **Start here** — `services/aigateway/adapters/providers/bifrost.go`, `account.azureAPIVersionWarnLogger`. It is the whole gateway-side change.

## Why

Closes #7892. Follow-up to #7877.

Bifrost v1.5 pins Azure's `api-version` itself, so a customer's override is dropped on the AI Gateway dispatch path. #7877 added a warning for that drop and left two gaps: the field was still offered in settings **with no feedback a customer could see**, and the warning sat on the **per-request** key-selection path, so a busy Azure provider logged a static configuration fact on every single dispatch.

The field is **not** dead everywhere — `prepareLitellmParams` still honours it on the direct/Studio and Azure API Management paths. So removing it would be wrong, and gateway mode and direct mode genuinely disagree about which version is in force. The fix is to say so, not to delete.

## What changed

- **Warn once per credential ID, not per request** → alternative: a time-based rate limiter, or dropping the warning entirely. A limiter re-fires on a fact that never changes; dropping it loses the only signal an operator has. Blast radius if the keying is wrong: a misconfigured credential's warning is swallowed and the operator never learns the override is inert.
- **Dedup keyed on the process-singleton `account` via `sync.Map`** → alternative: a plain map with a mutex, or a per-dispatch cache. `GetKeysForProvider` runs under Bifrost's 1000-worker pool, so a non-atomic check-then-set both races and can emit several warnings on simultaneous first sight; `LoadOrStore` makes it exactly one. Cost: the set grows with distinct Azure credential IDs seen over the process lifetime — a string key and an empty struct each, never freed.
- **Say it in the settings form, using the mechanism already there** → alternative: a new alert component, or disabling the field. The drawer already renders per-credential helper text from `fieldMetadata`, so this is two strings rather than new UI, and the fields stay editable because the direct path still consumes them.
- **The two notes differ per field** → the direct-mode field and the Azure API Management field are honoured on different paths; one shared sentence would have told half the customers something false.

## How it works

```
services/aigateway/adapters/providers/bifrost.go
  account.warnedAzureAPIVersionIDs (sync.Map)   set of credential IDs already warned
  account.azureAPIVersionWarnLogger(cred)       owns the once-per-ID decision; returns the
                                                real logger on first sight, nil thereafter
  account.GetKeysForProvider                    per-request entry point; now asks the method
                                                above instead of always passing a.logger
  credentialToBifrostKey / warnIgnoredAzure...  unchanged — same message, same api_version field

platform/app/src/features/onboarding/regions/model-providers/registry.tsx
  open_ai_azure.fieldMetadata                   adds AZURE_OPENAI_API_VERSION, rewrites
                                                AZURE_API_GATEWAY_VERSION; rendered as
                                                Field.HelperText by ModelProviderCredentialsSection
```

## Human verification

Gateway half:
1. `go test ./services/aigateway/adapters/providers/ -race` — passes.
2. Boot nlpgo (`go run ./cmd/service nlpgo`) with any Azure endpoint reachable, and POST five times to `/go/proxy/v1/chat/completions` with `x-litellm-custom_llm_provider: azure` and `x-litellm-api_version: 2023-05-15`.
3. `grep -c "azure api_version override is ignored"` the log. Expect **1**, not 5.

Settings half:
1. `pnpm dev`, open **Settings → Model Providers → Azure OpenAI**.
2. Confirm the note under `AZURE_OPENAI_API_VERSION`; flip **Use API Gateway** and confirm the different note under `AZURE_API_GATEWAY_VERSION`.
3. Type `2024-10-21` into the direct-mode field, save, reopen. The value must still be there and the field still editable — that is the regression this PR must not cause.

## How I can prove I was successful

Every AC and every `.feature` scenario, exercised this session.

| AC / Scenario | Verdict | Evidence |
|---|---|---|
| **AC1** warn once per credential, `api_version` field intact | **proven** | Live: 5 real dispatches, 1 warning, field present (transcript below) |
| **AC2** two distinct IDs warn twice | **proven** | `go test -race` green; `TestAzureAPIVersion_TwoDistinctCredentialsWarnTwice` |
| **AC3** no override, no warning | **proven** | `go test -race` green; `..._NoOverrideNeverWarns` |
| **AC4** Azure key unchanged (endpoint, aliases, models) | **proven** | Pre-existing `TestCredentialToBifrostKey_Azure_*` untouched and green |
| **AC10** concurrency-safe, one shared account | **proven** | 50-goroutine fan-out, 1 warning, clean under `-race` |
| **AC5** visible customer-safe note, both fields | **proven** | Screenshots 1-3, driven in the running app |
| **AC5b** no note on non-Azure providers | **proven** | RTL: `queryByText(/ignored/i)` null on the openai drawer |
| **AC6** field still editable and persists | **proven** | Screenshot 4 — `2024-10-21` survives save + reopen, `disabled=false` |
| **AC7** API Management default preserved | **proven** | `modelProviders.utils.azure.unit.test.ts` — `2024-05-01-preview`, `use_azure_gateway=true` |
| **AC8** /go/proxy path still warns on first sight | **proven** | The live run above IS the proxy path (`playground-inline-azure`) |

### Gateway: 5 real dispatches, 1 warning

Five Azure chat-completions through the running gateway, credential carrying `api_version: 2023-05-15`, Azure resource stubbed locally. All five reached the provider and returned 200.

```console
$ for i in 1 2 3 4 5; do curl -s -o /dev/null -w "req$i=%{http_code} " \
    -X POST http://localhost:5562/go/proxy/v1/chat/completions \
    -H 'x-litellm-model: azure/gpt-4o' -H 'x-litellm-custom_llm_provider: azure' \
    -H 'x-litellm-api_key: stub-key' -H 'x-litellm-api_base: http://127.0.0.1:5599' \
    -H 'x-litellm-api_version: 2023-05-15' \
    -d '{"model":"azure/gpt-4o","messages":[{"role":"user","content":"ping"}]}'; done
req1=200 req2=200 req3=200 req4=200 req5=200

$ grep -c "azure api_version override is ignored" nlpgo.log
1

$ grep "azure api_version override is ignored" nlpgo.log
{"level":"warn","caller":"providers/bifrost.go:1338",
 "msg":"azure api_version override is ignored: bifrost v1.5 sets api-version itself",
 "service":"langwatch-service-nlp","api_version":"2023-05-15"}
```

**Before this change the same battery logged one line per dispatch** — the new tests measured exactly that on unfixed code (3 dispatches → 3 warnings; 50 concurrent → 50).

### Settings: the note a customer actually sees

Direct-mode field, light:

![Azure direct-mode api-version note, light mode](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-7900/notes/01-direct-apiversion-note-light.png)

**Use API Gateway** on — the API Management field carries its own, different sentence:

![Azure gateway-mode api-version note, light mode](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-7900/notes/02-gateway-apiversion-note-light.png)

Dark mode:

![Azure direct-mode api-version note, dark mode](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-7900/notes/03-direct-apiversion-note-dark.png)

Regression: `2024-10-21` typed, saved, drawer reopened — value persisted, field still editable:

![api-version value persisted after save](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-7900/notes/04-apiversion-persisted-after-save-dark.png)

## Deployment Impact

**No new configuration and no new deployment surface.** Nothing here needs an operator to do anything at rollout.

- **Environment variables** — none added, removed or changed. The two Azure api-version keys (`AZURE_OPENAI_API_VERSION`, `AZURE_API_GATEWAY_VERSION`) are per-provider credential fields stored on the `ModelProvider` row, not process env, and neither the schema nor the `optionalKeys` list is touched.
- **Helm values** — none added or changed. No chart under `charts/` is modified.
- **Default `helm install` with no overrides** — unchanged. The gateway gains an in-memory `sync.Map` on a struct it already allocates once per process; it holds one string key per distinct Azure credential that carries an api-version override, so on an install with no such credential it stays empty. No new listener, dependency, migration or startup step.
- **BYOC dataplane** — no impact. The gateway's dispatch behaviour, the Azure key it builds, and the requests it sends are byte-for-byte identical; only how often one warning line is written changes. A dataplane that never dispatches Azure sees no difference at all.
- **Rollback** — revert the commits. There is no persisted state to unwind: the warned-set lives only in process memory, and the settings copy is read from code, not stored.
- **Observability note for operators** — the `azure api_version override is ignored` warning now appears **once per credential per process lifetime** instead of once per request. An alert or dashboard that counted those lines as a rate will go quiet; that is the intended fix, not a regression.

## Anything surprising?

- The note says "the LangWatch AI Gateway" but the **Use API Gateway** toggle it relates to sits at the top of the drawer, far above the field. Legible, but the two ideas are physically separated. Flagged by QA as a rough edge, not a blocker.
- The Azure API Management field's note and the toggle both use the word "gateway" for **different** gateways — the customer's APIM instance versus ours. The copy names each one explicitly to keep them apart.
- The duplicated `vi.mock` block across the nine `ModelProviderForm.*` test files is filed as https://github.com/langwatch/langwatch/issues/7901 rather than fixed here — it touches 8+ files for zero behaviour change.
- `ParseCredentialFromHeaders` lives in `services/nlpgo/adapters/gatewayproxy`, not in the aigateway, despite what #7892's investigation implies. The proxy-path test uses that path's real ID shape (`playground-inline-azure`) rather than importing across services.
