### PR TITLE
test(model-providers): share drawer harness mocks

### DIFF
--- a/platform/app/src/components/settings/__tests__/ModelProviderForm.advanced-gateway.integration.test.tsx
+++ b/platform/app/src/components/settings/__tests__/ModelProviderForm.advanced-gateway.integration.test.tsx
@@ -15,9 +15,7 @@
  * second-"Save Advanced" button is gone: a single Save funnels basic +
  * advanced to one `api.modelProvider.update` mutation.
  */
-import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
 import { cleanup, render, screen } from "@testing-library/react";
-import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { z } from "zod";
 import type {
@@ -25,82 +23,20 @@ import type {
   UseModelProviderFormState,
 } from "../../../hooks/useModelProviderForm";
 import type { MaybeStoredModelProvider } from "../../../server/modelProviders/registry";
-
-const {
-  mockUseModelProviderForm,
-  mockUseModelProvidersSettings,
-  mockUseFeatureFlag,
-  mockListAllForOrgQuery,
-  mockListAllForProjectQuery,
-} = vi.hoisted(() => ({
-  mockUseModelProviderForm: vi.fn(),
-  mockUseModelProvidersSettings: vi.fn(),
-  mockUseFeatureFlag: vi.fn(),
-  mockListAllForOrgQuery: vi.fn(),
-  mockListAllForProjectQuery: vi.fn(),
-}));
-
-vi.mock("../../../hooks/useModelProviderForm", () => ({
-  useModelProviderForm: (...args: unknown[]) =>
-    mockUseModelProviderForm(...args),
-}));
-
-vi.mock("../../../hooks/useModelProvidersSettings", () => ({
-  useModelProvidersSettings: (...args: unknown[]) =>
-    mockUseModelProvidersSettings(...args),
-}));
-
-vi.mock("../../../hooks/useDrawer", () => ({
-  useDrawer: () => ({
-    closeDrawer: vi.fn(),
-    openDrawer: vi.fn(),
-  }),
-}));
-
-vi.mock("../../../hooks/useOrganizationTeamProject", () => ({
-  useOrganizationTeamProject: () => ({
-    project: { id: "proj-1", slug: "test-project", defaultModel: null },
-    organization: { id: "org-1" },
-    hasPermission: () => true,
-  }),
-}));
-
-vi.mock("../../../hooks/useModelProviderApiKeyValidation", () => ({
-  useModelProviderApiKeyValidation: () => ({
-    validate: vi.fn().mockResolvedValue(true),
-    validateWithCustomUrl: vi.fn().mockResolvedValue(true),
-    isValidating: false,
-    validationError: undefined,
-    clearError: vi.fn(),
-  }),
-}));
-
-vi.mock("../../../hooks/useFeatureFlag", () => ({
-  useFeatureFlag: (...args: unknown[]) => mockUseFeatureFlag(...args),
-}));
-
-vi.mock("../../../utils/api", () => ({
-  api: {
-    modelProvider: {
-      isManagedProvider: {
-        useQuery: () => ({ data: { managed: false } }),
-      },
-      // EditModelProviderForm resolves its edit target from the flat
-      // (uncollapsed) provider list via useAllModelProvidersList (#5380).
-      // primeHooks seeds both with the same mp_existing fixture the
-      // collapsed-record mock below uses, so the id lookup still finds
-      // the row this suite has always intended to render.
-      listAllForOrganizationForFrontend: { useQuery: mockListAllForOrgQuery },
-      listAllForProjectForFrontend: { useQuery: mockListAllForProjectQuery },
-    },
-  },
-}));
-
+import {
+  modelProviderDrawerMocks,
+  resetModelProviderDrawerMocks,
+  Wrapper,
+} from "./modelProviderDrawerHarness";
 import { EditModelProviderForm } from "../ModelProviderForm";
 
-const Wrapper = ({ children }: { children: ReactNode }) => (
-  <ChakraProvider value={defaultSystem}>{children}</ChakraProvider>
-);
+const {
+  mockUseFeatureFlag,
+  mockListAllForOrganizationForFrontendQuery: mockListAllForOrgQuery,
+  mockListAllForProjectForFrontendQuery: mockListAllForProjectQuery,
+  mockUseModelProviderForm,
+  mockUseModelProvidersSettings,
+} = modelProviderDrawerMocks;
 
 function buildState(
   overrides: Partial<UseModelProviderFormState> = {},
@@ -203,7 +139,7 @@ function primeHooks({ gatewayEnabled }: { gatewayEnabled: boolean }) {
 
 describe("Feature: Advanced (Gateway) accordion on ModelProvider drawer", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    resetModelProviderDrawerMocks();
   });
 
   afterEach(() => {

--- a/platform/app/src/components/settings/__tests__/ModelProviderForm.azure-safety.integration.test.tsx
+++ b/platform/app/src/components/settings/__tests__/ModelProviderForm.azure-safety.integration.test.tsx
@@ -11,7 +11,6 @@
  * (CustomModelInputSection, DefaultProviderSection, Azure API Gateway toggle)
  * must be hidden when the provider's registry `type` is "safety".
  */
-import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { z } from "zod";
@@ -20,88 +19,20 @@ import type {
   UseModelProviderFormState,
 } from "../../../hooks/useModelProviderForm";
 import type { MaybeStoredModelProvider } from "../../../server/modelProviders/registry";
-
-// ---------------------------------------------------------------------------
-// Mocks
-// ---------------------------------------------------------------------------
-
-const {
-  mockUseModelProviderForm,
-  mockUseModelProvidersSettings,
-  mockListAllForOrgQuery,
-  mockListAllForProjectQuery,
-} = vi.hoisted(() => ({
-  mockUseModelProviderForm: vi.fn(),
-  mockUseModelProvidersSettings: vi.fn(),
-  mockListAllForOrgQuery: vi.fn(),
-  mockListAllForProjectQuery: vi.fn(),
-}));
-
-vi.mock("../../../hooks/useModelProviderForm", () => ({
-  useModelProviderForm: (...args: unknown[]) =>
-    mockUseModelProviderForm(...args),
-}));
-
-vi.mock("../../../hooks/useModelProvidersSettings", () => ({
-  useModelProvidersSettings: (...args: unknown[]) =>
-    mockUseModelProvidersSettings(...args),
-}));
-
-vi.mock("../../../hooks/useDrawer", () => ({
-  useDrawer: () => ({
-    closeDrawer: vi.fn(),
-    openDrawer: vi.fn(),
-  }),
-}));
-
-vi.mock("../../../hooks/useOrganizationTeamProject", () => ({
-  useOrganizationTeamProject: () => ({
-    project: { id: "proj-1", slug: "test-project", defaultModel: null },
-    organization: { id: "org-1" },
-    hasPermission: () => false,
-  }),
-}));
-
-vi.mock("../../../hooks/useModelProviderApiKeyValidation", () => ({
-  useModelProviderApiKeyValidation: () => ({
-    validate: vi.fn().mockResolvedValue(true),
-    validateWithCustomUrl: vi.fn().mockResolvedValue(true),
-    isValidating: false,
-    validationError: undefined,
-    clearError: vi.fn(),
-  }),
-}));
-
-vi.mock("../../../hooks/useFeatureFlag", () => ({
-  useFeatureFlag: () => ({ enabled: false, isLoading: false }),
-}));
-
-vi.mock("../../../utils/api", () => ({
-  api: {
-    modelProvider: {
-      isManagedProvider: {
-        useQuery: () => ({ data: { managed: false } }),
-      },
-      // EditModelProviderForm resolves its edit target from the flat
-      // (uncollapsed) provider list via useAllModelProvidersList (#5380).
-      // primeHooksForProvider seeds both with the same fixture the
-      // collapsed-record mock below uses.
-      listAllForOrganizationForFrontend: { useQuery: mockListAllForOrgQuery },
-      listAllForProjectForFrontend: { useQuery: mockListAllForProjectQuery },
-    },
-  },
-}));
-
-// Import after mocks
+import {
+  modelProviderDrawerMocks,
+  resetModelProviderDrawerMocks,
+  Wrapper,
+} from "./modelProviderDrawerHarness";
 import { EditModelProviderForm } from "../ModelProviderForm";
 
-// ---------------------------------------------------------------------------
-// Test helpers
-// ---------------------------------------------------------------------------
-
-const Wrapper = ({ children }: { children: React.ReactNode }) => (
-  <ChakraProvider value={defaultSystem}>{children}</ChakraProvider>
-);
+const {
+  mockListAllForOrganizationForFrontendQuery: mockListAllForOrgQuery,
+  mockListAllForProjectForFrontendQuery: mockListAllForProjectQuery,
+  mockUseModelProviderForm,
+  mockUseModelProvidersSettings,
+  mockUseOrganizationTeamProject,
+} = modelProviderDrawerMocks;
 
 function buildState(
   overrides: Partial<UseModelProviderFormState> = {},
@@ -183,6 +114,27 @@ function primeHooksForProvider({
   providerKey: string;
   displayKeys: Record<string, z.ZodTypeAny>;
 }) {
+  mockUseOrganizationTeamProject.mockReturnValue({
+    project: {
+      id: "proj-1",
+      name: "Web App",
+      slug: "test-project",
+      defaultModel: null,
+    },
+    team: { id: "team-1", name: "Platform" },
+    organization: {
+      id: "org-1",
+      name: "Acme",
+      teams: [
+        {
+          id: "team-1",
+          name: "Platform",
+          projects: [{ id: "proj-1", name: "Web App" }],
+        },
+      ],
+    },
+    hasPermission: () => false,
+  });
   const provider = buildProvider({ provider: providerKey });
   mockUseModelProvidersSettings.mockReturnValue({
     providers: { [providerKey]: provider },
@@ -214,7 +166,7 @@ function primeHooksForProvider({
 
 describe("Feature: Azure Safety model provider form rendering", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    resetModelProviderDrawerMocks();
   });
 
   afterEach(() => {

--- a/platform/app/src/components/settings/__tests__/ModelProviderForm.codex-signin.integration.test.tsx
+++ b/platform/app/src/components/settings/__tests__/ModelProviderForm.codex-signin.integration.test.tsx
@@ -14,11 +14,9 @@
  *   Save has nothing left to do) and queues the coding-defaults ask to the
  *   page-level host instead of mounting a dialog inside the drawer.
  *
- * Mirrors ModelProviderForm.azure-safety.integration.test.tsx's mock
- * setup; the api mock additionally feeds CodexSignIn's status/sign-in
- * endpoints so the real component renders.
+ * Uses the shared model-provider drawer harness; the api mock also feeds
+ * CodexSignIn's status/sign-in endpoints so the real component renders.
  */
-import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
 import {
   cleanup,
   fireEvent,
@@ -33,113 +31,24 @@ import type {
   UseModelProviderFormState,
 } from "../../../hooks/useModelProviderForm";
 import type { MaybeStoredModelProvider } from "../../../server/modelProviders/registry";
-
-// ---------------------------------------------------------------------------
-// Mocks
-// ---------------------------------------------------------------------------
-
-const {
-  mockUseModelProviderForm,
-  mockUseModelProvidersSettings,
-  mockListAllForOrgQuery,
-  mockListAllForProjectQuery,
-  mockCloseDrawer,
-  mockCodexSignInStart,
-  mockCodexSignInPoll,
-} = vi.hoisted(() => ({
-  mockUseModelProviderForm: vi.fn(),
-  mockUseModelProvidersSettings: vi.fn(),
-  mockListAllForOrgQuery: vi.fn(),
-  mockListAllForProjectQuery: vi.fn(),
-  mockCloseDrawer: vi.fn(),
-  mockCodexSignInStart: vi.fn(),
-  mockCodexSignInPoll: vi.fn(),
-}));
-
-vi.mock("../../../hooks/useModelProviderForm", () => ({
-  useModelProviderForm: (...args: unknown[]) =>
-    mockUseModelProviderForm(...args),
-}));
-
-vi.mock("../../../hooks/useModelProvidersSettings", () => ({
-  useModelProvidersSettings: (...args: unknown[]) =>
-    mockUseModelProvidersSettings(...args),
-}));
-
-vi.mock("../../../hooks/useDrawer", () => ({
-  useDrawer: () => ({
-    closeDrawer: mockCloseDrawer,
-    openDrawer: vi.fn(),
-  }),
-}));
-
-vi.mock("../../../hooks/useOrganizationTeamProject", () => ({
-  useOrganizationTeamProject: () => ({
-    project: { id: "proj-1", slug: "test-project", defaultModel: null },
-    organization: { id: "org-1" },
-    hasPermission: () => false,
-  }),
-}));
-
-vi.mock("../../../hooks/useModelProviderApiKeyValidation", () => ({
-  useModelProviderApiKeyValidation: () => ({
-    validate: vi.fn().mockResolvedValue(true),
-    validateWithCustomUrl: vi.fn().mockResolvedValue(true),
-    isValidating: false,
-    validationError: undefined,
-    clearError: vi.fn(),
-  }),
-}));
-
-vi.mock("../../../hooks/useFeatureFlag", () => ({
-  useFeatureFlag: () => ({ enabled: false, isLoading: false }),
-}));
-
-vi.mock("../../../utils/api", () => ({
-  api: {
-    useUtils: () => ({
-      modelProvider: { invalidate: vi.fn() },
-    }),
-    modelProvider: {
-      isManagedProvider: {
-        useQuery: () => ({ data: { managed: false } }),
-      },
-      listAllForOrganizationForFrontend: { useQuery: mockListAllForOrgQuery },
-      listAllForProjectForFrontend: { useQuery: mockListAllForProjectQuery },
-      // CodexSignIn's own endpoints: idle, not yet connected.
-      codexStatus: {
-        useQuery: () => ({ data: { connected: false }, isLoading: false }),
-      },
-      codexSignInStart: {
-        useMutation: () => ({
-          mutateAsync: mockCodexSignInStart,
-          isLoading: false,
-        }),
-      },
-      codexSignInPoll: {
-        useMutation: () => ({
-          mutateAsync: mockCodexSignInPoll,
-          isLoading: false,
-        }),
-      },
-      delete: {
-        useMutation: () => ({ mutateAsync: vi.fn(), isLoading: false }),
-      },
-    },
-  },
-}));
-
-// Import after mocks
+import {
+  modelProviderDrawerMocks,
+  resetModelProviderDrawerMocks,
+  Wrapper,
+} from "./modelProviderDrawerHarness";
 import { useCodexCodingDefaultsAskStore } from "../CodexCodingDefaultsAsk";
 import { EditModelProviderForm } from "../ModelProviderForm";
 
-// ---------------------------------------------------------------------------
-// Test helpers
-// ---------------------------------------------------------------------------
-
-const Wrapper = ({ children }: { children: React.ReactNode }) => (
-  <ChakraProvider value={defaultSystem}>{children}</ChakraProvider>
-);
+const {
+  mockListAllForOrganizationForFrontendQuery: mockListAllForOrgQuery,
+  mockListAllForProjectForFrontendQuery: mockListAllForProjectQuery,
+  mockCloseDrawer,
+  mockCodexSignInStart,
+  mockCodexSignInPoll,
+  mockUseModelProviderForm,
+  mockUseModelProvidersSettings,
+  mockUseOrganizationTeamProject,
+} = modelProviderDrawerMocks;
 
 function buildState(
   overrides: Partial<UseModelProviderFormState> = {},
@@ -224,6 +133,27 @@ function primeHooksForProvider({
   state?: Partial<UseModelProviderFormState>;
   actions?: Partial<UseModelProviderFormActions>;
 }) {
+  mockUseOrganizationTeamProject.mockReturnValue({
+    project: {
+      id: "proj-1",
+      name: "Web App",
+      slug: "test-project",
+      defaultModel: null,
+    },
+    team: { id: "team-1", name: "Platform" },
+    organization: {
+      id: "org-1",
+      name: "Acme",
+      teams: [
+        {
+          id: "team-1",
+          name: "Platform",
+          projects: [{ id: "proj-1", name: "Web App" }],
+        },
+      ],
+    },
+    hasPermission: () => false,
+  });
   const provider = buildProvider({ provider: providerKey });
   mockUseModelProvidersSettings.mockReturnValue({
     providers: { [providerKey]: provider },
@@ -268,7 +198,7 @@ function renderForm(providerKey: string) {
 
 describe("Feature: Codex model provider form rendering", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    resetModelProviderDrawerMocks();
     useCodexCodingDefaultsAskStore.setState({ pending: null });
   });
 

--- a/platform/app/src/components/settings/__tests__/ModelProviderForm.credential-preservation.integration.test.tsx
+++ b/platform/app/src/components/settings/__tests__/ModelProviderForm.credential-preservation.integration.test.tsx
@@ -15,7 +15,21 @@
  */
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { MASKED_KEY_PLACEHOLDER } from "../../../utils/constants";
+import {
+  eitherOrProviders,
+  inputFor,
+  isMarkedRequired,
+  keyedRow,
+  makePrimeQueries,
+  modelProviderDrawerMocks,
+  resetModelProviderDrawerMocks,
+  SELF_HOSTED_URL,
+  Wrapper,
+} from "./modelProviderDrawerHarness";
+import { EditModelProviderForm } from "../ModelProviderForm";
 
 const {
   mockMutateAsync,
@@ -23,98 +37,7 @@ const {
   mockListAllForOrganizationForFrontendQuery,
   mockListAllForProjectForFrontendQuery,
   mockValidateApiKey,
-} = vi.hoisted(() => ({
-  mockMutateAsync: vi.fn().mockResolvedValue({}),
-  mockGetAllForProjectForFrontendQuery: vi.fn(),
-  mockListAllForOrganizationForFrontendQuery: vi.fn(),
-  mockListAllForProjectForFrontendQuery: vi.fn(),
-  mockValidateApiKey: vi.fn().mockResolvedValue(true),
-}));
-
-vi.mock("../../../utils/api", () => ({
-  api: {
-    modelProvider: {
-      getAllForProjectForFrontend: {
-        useQuery: mockGetAllForProjectForFrontendQuery,
-      },
-      listAllForOrganizationForFrontend: {
-        useQuery: mockListAllForOrganizationForFrontendQuery,
-      },
-      listAllForProjectForFrontend: {
-        useQuery: mockListAllForProjectForFrontendQuery,
-      },
-      update: { useMutation: () => ({ mutateAsync: mockMutateAsync }) },
-      setRoleAssignmentForScope: {
-        useMutation: () => ({
-          mutateAsync: vi.fn().mockResolvedValue({ ok: true }),
-        }),
-      },
-      isManagedProvider: { useQuery: () => ({ data: { managed: false } }) },
-    },
-    useUtils: () => ({
-      organization: { getAll: { invalidate: vi.fn() } },
-      modelProvider: {
-        getAllForProject: { invalidate: vi.fn() },
-        getAllForProjectForFrontend: { invalidate: vi.fn() },
-        listAllForProjectForFrontend: { invalidate: vi.fn() },
-        listAllForOrganizationForFrontend: { invalidate: vi.fn() },
-        getResolvedDefault: { invalidate: vi.fn() },
-        getDefaultModelsForProject: { invalidate: vi.fn() },
-      },
-    }),
-  },
-}));
-
-vi.mock("../../../hooks/useDrawer", () => ({
-  useDrawer: () => ({ closeDrawer: vi.fn(), openDrawer: vi.fn() }),
-}));
-
-vi.mock("../../../hooks/useOrganizationTeamProject", () => ({
-  useOrganizationTeamProject: () => ({
-    project: { id: "proj-1", name: "Web App", slug: "web-app" },
-    team: { id: "team-1", name: "Platform" },
-    organization: {
-      id: "org-1",
-      name: "Acme",
-      teams: [
-        {
-          id: "team-1",
-          name: "Platform",
-          projects: [{ id: "proj-1", name: "Web App" }],
-        },
-      ],
-    },
-    hasPermission: () => true,
-  }),
-}));
-
-vi.mock("../../../hooks/useModelProviderApiKeyValidation", () => ({
-  useModelProviderApiKeyValidation: () => ({
-    validate: mockValidateApiKey,
-    validateWithCustomUrl: vi.fn().mockResolvedValue(true),
-    isValidating: false,
-    validationError: undefined,
-    clearError: vi.fn(),
-  }),
-}));
-
-vi.mock("../../../hooks/useFeatureFlag", () => ({
-  useFeatureFlag: () => ({ enabled: false, isLoading: false }),
-}));
-
-vi.mock("../../ui/toaster", () => ({ toaster: { create: vi.fn() } }));
-
-import { MASKED_KEY_PLACEHOLDER } from "../../../utils/constants";
-import { EditModelProviderForm } from "../ModelProviderForm";
-import {
-  eitherOrProviders,
-  inputFor,
-  isMarkedRequired,
-  keyedRow,
-  makePrimeQueries,
-  SELF_HOSTED_URL,
-  Wrapper,
-} from "./modelProviderDrawerHarness";
+} = modelProviderDrawerMocks;
 
 const primeQueries = makePrimeQueries({
   collapsedQuery: mockGetAllForProjectForFrontendQuery,
@@ -137,9 +60,7 @@ const renderDrawer = (
   );
 
 const resetMocks = () => {
-  vi.clearAllMocks();
-  mockMutateAsync.mockResolvedValue({});
-  mockValidateApiKey.mockResolvedValue(true);
+  resetModelProviderDrawerMocks();
 };
 
 describe("Feature: edits beside a saved credential leave that credential intact", () => {

--- a/platform/app/src/components/settings/__tests__/ModelProviderForm.credential-requiredness.integration.test.tsx
+++ b/platform/app/src/components/settings/__tests__/ModelProviderForm.credential-requiredness.integration.test.tsx
@@ -23,7 +23,20 @@ import {
   within,
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  eitherOrProviders,
+  fieldWrapper,
+  inputFor,
+  isMarkedRequired,
+  makePrimeQueries,
+  modelProviderDrawerMocks,
+  resetModelProviderDrawerMocks,
+  SELF_HOSTED_URL,
+  Wrapper,
+} from "./modelProviderDrawerHarness";
+import { EditModelProviderForm } from "../ModelProviderForm";
 
 const {
   mockMutateAsync,
@@ -31,97 +44,7 @@ const {
   mockListAllForOrganizationForFrontendQuery,
   mockListAllForProjectForFrontendQuery,
   mockValidateApiKey,
-} = vi.hoisted(() => ({
-  mockMutateAsync: vi.fn().mockResolvedValue({}),
-  mockGetAllForProjectForFrontendQuery: vi.fn(),
-  mockListAllForOrganizationForFrontendQuery: vi.fn(),
-  mockListAllForProjectForFrontendQuery: vi.fn(),
-  mockValidateApiKey: vi.fn().mockResolvedValue(true),
-}));
-
-vi.mock("../../../utils/api", () => ({
-  api: {
-    modelProvider: {
-      getAllForProjectForFrontend: {
-        useQuery: mockGetAllForProjectForFrontendQuery,
-      },
-      listAllForOrganizationForFrontend: {
-        useQuery: mockListAllForOrganizationForFrontendQuery,
-      },
-      listAllForProjectForFrontend: {
-        useQuery: mockListAllForProjectForFrontendQuery,
-      },
-      update: { useMutation: () => ({ mutateAsync: mockMutateAsync }) },
-      setRoleAssignmentForScope: {
-        useMutation: () => ({
-          mutateAsync: vi.fn().mockResolvedValue({ ok: true }),
-        }),
-      },
-      isManagedProvider: { useQuery: () => ({ data: { managed: false } }) },
-    },
-    useUtils: () => ({
-      organization: { getAll: { invalidate: vi.fn() } },
-      modelProvider: {
-        getAllForProject: { invalidate: vi.fn() },
-        getAllForProjectForFrontend: { invalidate: vi.fn() },
-        listAllForProjectForFrontend: { invalidate: vi.fn() },
-        listAllForOrganizationForFrontend: { invalidate: vi.fn() },
-        getResolvedDefault: { invalidate: vi.fn() },
-        getDefaultModelsForProject: { invalidate: vi.fn() },
-      },
-    }),
-  },
-}));
-
-vi.mock("../../../hooks/useDrawer", () => ({
-  useDrawer: () => ({ closeDrawer: vi.fn(), openDrawer: vi.fn() }),
-}));
-
-vi.mock("../../../hooks/useOrganizationTeamProject", () => ({
-  useOrganizationTeamProject: () => ({
-    project: { id: "proj-1", name: "Web App", slug: "web-app" },
-    team: { id: "team-1", name: "Platform" },
-    organization: {
-      id: "org-1",
-      name: "Acme",
-      teams: [
-        {
-          id: "team-1",
-          name: "Platform",
-          projects: [{ id: "proj-1", name: "Web App" }],
-        },
-      ],
-    },
-    hasPermission: () => true,
-  }),
-}));
-
-vi.mock("../../../hooks/useModelProviderApiKeyValidation", () => ({
-  useModelProviderApiKeyValidation: () => ({
-    validate: mockValidateApiKey,
-    validateWithCustomUrl: vi.fn().mockResolvedValue(true),
-    isValidating: false,
-    validationError: undefined,
-    clearError: vi.fn(),
-  }),
-}));
-
-vi.mock("../../../hooks/useFeatureFlag", () => ({
-  useFeatureFlag: () => ({ enabled: false, isLoading: false }),
-}));
-
-vi.mock("../../ui/toaster", () => ({ toaster: { create: vi.fn() } }));
-
-import { EditModelProviderForm } from "../ModelProviderForm";
-import {
-  eitherOrProviders,
-  fieldWrapper,
-  inputFor,
-  isMarkedRequired,
-  makePrimeQueries,
-  SELF_HOSTED_URL,
-  Wrapper,
-} from "./modelProviderDrawerHarness";
+} = modelProviderDrawerMocks;
 
 const primeQueries = makePrimeQueries({
   collapsedQuery: mockGetAllForProjectForFrontendQuery,
@@ -144,9 +67,7 @@ const renderDrawer = (
   );
 
 const resetMocks = () => {
-  vi.clearAllMocks();
-  mockMutateAsync.mockResolvedValue({});
-  mockValidateApiKey.mockResolvedValue(true);
+  resetModelProviderDrawerMocks();
 };
 
 describe("Feature: the drawer asks for the credentials the provider actually needs", () => {

--- a/platform/app/src/components/settings/__tests__/ModelProviderForm.edit-row-resolution.integration.test.tsx
+++ b/platform/app/src/components/settings/__tests__/ModelProviderForm.edit-row-resolution.integration.test.tsx
@@ -23,128 +23,32 @@
  * — producing a duplicate row instead of an update.
  *
  * `useModelProviderForm` and `useModelProvidersSettings` are deliberately
- * NOT mocked below — the row-resolution memo and the real submit payload
- * must actually execute for this test to exercise the bug.
+ * left on the shared harness's real-implementation fallback — the
+ * row-resolution memo and the real submit payload must actually execute for
+ * this test to exercise the bug.
  */
-import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import type { ReactNode } from "react";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { MaybeStoredModelProvider } from "../../../server/modelProviders/registry";
+import { MASKED_KEY_PLACEHOLDER } from "../../../utils/constants";
+import {
+  inputFor,
+  modelProviderDrawerMocks,
+  notReadyQueryResult,
+  readyQueryResult,
+  resetModelProviderDrawerMocks,
+  Wrapper,
+} from "./modelProviderDrawerHarness";
+import { EditModelProviderForm } from "../ModelProviderForm";
 
 const {
   mockMutateAsync,
   mockGetAllForProjectForFrontendQuery,
   mockListAllForOrganizationForFrontendQuery,
   mockListAllForProjectForFrontendQuery,
-} = vi.hoisted(() => ({
-  mockMutateAsync: vi.fn().mockResolvedValue({}),
-  mockGetAllForProjectForFrontendQuery: vi.fn(),
-  mockListAllForOrganizationForFrontendQuery: vi.fn(),
-  mockListAllForProjectForFrontendQuery: vi.fn(),
-}));
-
-// `useModelProviderForm` / `useModelProvidersSettings` are NOT mocked here
-// (see file header) — only their external boundaries are:
-//   - the tRPC client (`utils/api`)
-//   - peripheral hooks that reach outside this component's own logic
-//     (router-backed drawer state, feature flags, org/team/project context,
-//     the async API-key validation round-trip, and the toaster).
-vi.mock("../../../utils/api", () => ({
-  api: {
-    modelProvider: {
-      getAllForProjectForFrontend: {
-        useQuery: mockGetAllForProjectForFrontendQuery,
-      },
-      listAllForOrganizationForFrontend: {
-        useQuery: mockListAllForOrganizationForFrontendQuery,
-      },
-      listAllForProjectForFrontend: {
-        useQuery: mockListAllForProjectForFrontendQuery,
-      },
-      update: {
-        useMutation: () => ({ mutateAsync: mockMutateAsync }),
-      },
-      setRoleAssignmentForScope: {
-        useMutation: () => ({
-          mutateAsync: vi.fn().mockResolvedValue({ ok: true }),
-        }),
-      },
-      isManagedProvider: {
-        useQuery: () => ({ data: { managed: false } }),
-      },
-    },
-    useUtils: () => ({
-      organization: {
-        getAll: { invalidate: vi.fn() },
-      },
-      modelProvider: {
-        getAllForProject: { invalidate: vi.fn() },
-        getAllForProjectForFrontend: { invalidate: vi.fn() },
-        listAllForProjectForFrontend: { invalidate: vi.fn() },
-        // Not read by any query above on current (buggy) code — included
-        // up front so this file is byte-identical across the fail-on-main
-        // run and the pass-after-fix run once the fix adds this
-        // invalidation to useProviderFormSubmit's awaited Promise.all.
-        listAllForOrganizationForFrontend: { invalidate: vi.fn() },
-        getResolvedDefault: { invalidate: vi.fn() },
-        getDefaultModelsForProject: { invalidate: vi.fn() },
-      },
-    }),
-  },
-}));
-
-vi.mock("../../../hooks/useDrawer", () => ({
-  useDrawer: () => ({
-    closeDrawer: vi.fn(),
-    openDrawer: vi.fn(),
-  }),
-}));
-
-vi.mock("../../../hooks/useOrganizationTeamProject", () => ({
-  useOrganizationTeamProject: () => ({
-    project: { id: "proj-1", name: "Web App", slug: "web-app" },
-    team: { id: "team-1", name: "Platform" },
-    organization: {
-      id: "org-1",
-      name: "Acme",
-      teams: [
-        {
-          id: "team-1",
-          name: "Platform",
-          projects: [{ id: "proj-1", name: "Web App" }],
-        },
-      ],
-    },
-    hasPermission: () => true,
-  }),
-}));
-
-vi.mock("../../../hooks/useModelProviderApiKeyValidation", () => ({
-  useModelProviderApiKeyValidation: () => ({
-    validate: vi.fn().mockResolvedValue(true),
-    validateWithCustomUrl: vi.fn().mockResolvedValue(true),
-    isValidating: false,
-    validationError: undefined,
-    clearError: vi.fn(),
-  }),
-}));
-
-vi.mock("../../../hooks/useFeatureFlag", () => ({
-  useFeatureFlag: () => ({ enabled: false, isLoading: false }),
-}));
-
-vi.mock("../../ui/toaster", () => ({
-  toaster: { create: vi.fn() },
-}));
-
-import type { MaybeStoredModelProvider } from "../../../server/modelProviders/registry";
-import { MASKED_KEY_PLACEHOLDER } from "../../../utils/constants";
-import { EditModelProviderForm } from "../ModelProviderForm";
-
-const Wrapper = ({ children }: { children: ReactNode }) => (
-  <ChakraProvider value={defaultSystem}>{children}</ChakraProvider>
-);
+} = modelProviderDrawerMocks;
 
 // rowA is the edit TARGET: the wider (organization) scope, absent from the
 // collapsed record because rowB (narrower scope) wins the provider-type
@@ -176,36 +80,6 @@ const rowB: MaybeStoredModelProvider = {
 };
 
 /**
- * Minimal but *realistic* TanStack Query v4 result. `useAllModelProvidersList`
- * gates on `isSuccess`/`isError` (not just `isLoading`) to tell "the list
- * definitively arrived" apart from "not loaded yet". A mock that returns only
- * `{ data, isLoading }` leaves those gates `undefined` — silently falsy — so
- * every `isReady`-derived branch would be untested by accident. These helpers
- * set the full status triplet so the gates actually run.
- */
-function readyQueryResult<T>(data: T) {
-  return {
-    data,
-    isSuccess: true,
-    isError: false,
-    isLoading: false,
-    status: "success" as const,
-    refetch: vi.fn(),
-  };
-}
-
-function notReadyQueryResult() {
-  return {
-    data: undefined,
-    isSuccess: false,
-    isError: false,
-    isLoading: true,
-    status: "loading" as const,
-    refetch: vi.fn(),
-  };
-}
-
-/**
  * Primes the collapsed-record query and BOTH flat-list queries (org and
  * project variants). `flatList` drives the uncollapsed list the row-by-id
  * resolution reads: an explicit row array (ready), `[]` (ready but empty),
@@ -229,38 +103,9 @@ function primeQueries({
   mockListAllForProjectForFrontendQuery.mockReturnValue(flatResult);
 }
 
-/**
- * `CredentialsSection` labels each credential input with a plain `Text`
- * (no `htmlFor`/`id` association — see ModelProviderCredentialsSection.tsx
- * lines ~99-136), so `getByLabelText` can't find it. Instead, walk up from
- * the label text node to the first ancestor that contains an `<input>`
- * descendant (the field's own wrapper) and return that input.
- */
-function getInputNearLabel(labelText: string): HTMLInputElement {
-  const label = screen.getByText(labelText);
-  let node: HTMLElement | null = label;
-  while (node && !node.querySelector("input")) {
-    node = node.parentElement;
-  }
-  if (!node) {
-    throw new Error(`no input found near label "${labelText}"`);
-  }
-  // Exactly one input, not just "at least one" — if a future Field.Root
-  // flattening merges this field's wrapper with a sibling field's, a
-  // loose `querySelector` would silently return whichever input happens
-  // to come first in DOM order instead of failing loudly.
-  const inputs = node.querySelectorAll("input");
-  if (inputs.length !== 1) {
-    throw new Error(
-      `expected exactly one input near label "${labelText}", found ${inputs.length}`,
-    );
-  }
-  return inputs[0] as HTMLInputElement;
-}
-
 describe("Feature: editing a model-provider row resolves the correct row by id", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    resetModelProviderDrawerMocks();
   });
 
   afterEach(() => {
@@ -369,7 +214,7 @@ describe("Feature: editing a model-provider row resolves the correct row by id",
       });
 
       it("renders a blank credential field and no stale-miss error", () => {
-        expect(getInputNearLabel("OPENAI_API_KEY").value).toBe("");
+        expect(inputFor("OPENAI_API_KEY").value).toBe("");
         expect(screen.queryByText(/no longer exists/i)).toBeNull();
       });
     });
@@ -379,7 +224,7 @@ describe("Feature: editing a model-provider row resolves the correct row by id",
         primeQueries();
         renderNew();
         const user = userEvent.setup();
-        const input = getInputNearLabel("OPENAI_API_KEY");
+        const input = inputFor("OPENAI_API_KEY");
         await user.clear(input);
         await user.type(input, "sk-brand-new-key");
         await user.click(screen.getByRole("button", { name: /^save$/i }));
@@ -412,12 +257,10 @@ describe("Feature: editing a model-provider row resolves the correct row by id",
         const user = userEvent.setup();
         const { rerender } = renderNew();
 
-        const input = getInputNearLabel("OPENAI_API_KEY");
+        const input = inputFor("OPENAI_API_KEY");
         await user.clear(input);
         await user.type(input, "sk-survives-rerender");
-        expect(getInputNearLabel("OPENAI_API_KEY").value).toBe(
-          "sk-survives-rerender",
-        );
+        expect(inputFor("OPENAI_API_KEY").value).toBe("sk-survives-rerender");
 
         rerender(
           <Wrapper>
@@ -430,9 +273,7 @@ describe("Feature: editing a model-provider row resolves the correct row by id",
           </Wrapper>,
         );
 
-        expect(getInputNearLabel("OPENAI_API_KEY").value).toBe(
-          "sk-survives-rerender",
-        );
+        expect(inputFor("OPENAI_API_KEY").value).toBe("sk-survives-rerender");
       });
     });
   });
@@ -455,7 +296,7 @@ describe("Feature: editing a model-provider row resolves the correct row by id",
 
       /** @scenario Editing a row shows its own saved credential, not another row's */
       it("shows the targeted row's saved API key, masked", () => {
-        const input = getInputNearLabel("OPENAI_API_KEY");
+        const input = inputFor("OPENAI_API_KEY");
         expect(input.value).toBe(MASKED_KEY_PLACEHOLDER);
       });
     });
@@ -474,7 +315,7 @@ describe("Feature: editing a model-provider row resolves the correct row by id",
           </Wrapper>,
         );
         const user = userEvent.setup();
-        const input = getInputNearLabel("OPENAI_API_KEY");
+        const input = inputFor("OPENAI_API_KEY");
         await user.clear(input);
         await user.type(input, "sk-reentered-key");
         await user.click(screen.getByRole("button", { name: /^save$/i }));

--- a/platform/app/src/components/settings/__tests__/ModelProviderForm.field-guidance.integration.test.tsx
+++ b/platform/app/src/components/settings/__tests__/ModelProviderForm.field-guidance.integration.test.tsx
@@ -11,100 +11,23 @@
  * specs/model-providers/credential-validation.feature.
  */
 import { cleanup, render, screen } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-
-const {
-  mockMutateAsync,
-  mockGetAllForProjectForFrontendQuery,
-  mockListAllForOrganizationForFrontendQuery,
-  mockListAllForProjectForFrontendQuery,
-} = vi.hoisted(() => ({
-  mockMutateAsync: vi.fn().mockResolvedValue({}),
-  mockGetAllForProjectForFrontendQuery: vi.fn(),
-  mockListAllForOrganizationForFrontendQuery: vi.fn(),
-  mockListAllForProjectForFrontendQuery: vi.fn(),
-}));
-
-vi.mock("../../../utils/api", () => ({
-  api: {
-    modelProvider: {
-      getAllForProjectForFrontend: {
-        useQuery: mockGetAllForProjectForFrontendQuery,
-      },
-      listAllForOrganizationForFrontend: {
-        useQuery: mockListAllForOrganizationForFrontendQuery,
-      },
-      listAllForProjectForFrontend: {
-        useQuery: mockListAllForProjectForFrontendQuery,
-      },
-      update: { useMutation: () => ({ mutateAsync: mockMutateAsync }) },
-      setRoleAssignmentForScope: {
-        useMutation: () => ({
-          mutateAsync: vi.fn().mockResolvedValue({ ok: true }),
-        }),
-      },
-      isManagedProvider: { useQuery: () => ({ data: { managed: false } }) },
-    },
-    useUtils: () => ({
-      organization: { getAll: { invalidate: vi.fn() } },
-      modelProvider: {
-        getAllForProject: { invalidate: vi.fn() },
-        getAllForProjectForFrontend: { invalidate: vi.fn() },
-        listAllForProjectForFrontend: { invalidate: vi.fn() },
-        listAllForOrganizationForFrontend: { invalidate: vi.fn() },
-        getResolvedDefault: { invalidate: vi.fn() },
-        getDefaultModelsForProject: { invalidate: vi.fn() },
-      },
-    }),
-  },
-}));
-
-vi.mock("../../../hooks/useDrawer", () => ({
-  useDrawer: () => ({ closeDrawer: vi.fn(), openDrawer: vi.fn() }),
-}));
-
-vi.mock("../../../hooks/useOrganizationTeamProject", () => ({
-  useOrganizationTeamProject: () => ({
-    project: { id: "proj-1", name: "Web App", slug: "web-app" },
-    team: { id: "team-1", name: "Platform" },
-    organization: {
-      id: "org-1",
-      name: "Acme",
-      teams: [
-        {
-          id: "team-1",
-          name: "Platform",
-          projects: [{ id: "proj-1", name: "Web App" }],
-        },
-      ],
-    },
-    hasPermission: () => true,
-  }),
-}));
-
-vi.mock("../../../hooks/useModelProviderApiKeyValidation", () => ({
-  useModelProviderApiKeyValidation: () => ({
-    validate: vi.fn().mockResolvedValue(true),
-    validateWithCustomUrl: vi.fn().mockResolvedValue(true),
-    isValidating: false,
-    validationError: undefined,
-    clearError: vi.fn(),
-  }),
-}));
-
-vi.mock("../../../hooks/useFeatureFlag", () => ({
-  useFeatureFlag: () => ({ enabled: false, isLoading: false }),
-}));
-
-vi.mock("../../ui/toaster", () => ({ toaster: { create: vi.fn() } }));
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { modelProviderRegistry } from "../../../features/onboarding/regions/model-providers/registry";
-import { EditModelProviderForm } from "../ModelProviderForm";
 import {
   keyedRow,
   makePrimeQueries,
+  modelProviderDrawerMocks,
+  resetModelProviderDrawerMocks,
   Wrapper,
 } from "./modelProviderDrawerHarness";
+import { EditModelProviderForm } from "../ModelProviderForm";
+
+const {
+  mockGetAllForProjectForFrontendQuery,
+  mockListAllForOrganizationForFrontendQuery,
+  mockListAllForProjectForFrontendQuery,
+} = modelProviderDrawerMocks;
 
 const primeQueries = makePrimeQueries({
   collapsedQuery: mockGetAllForProjectForFrontendQuery,
@@ -130,7 +53,7 @@ const geminiEntry = modelProviderRegistry.find(
 
 describe("Feature: the drawer says where each credential comes from", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    resetModelProviderDrawerMocks();
   });
 
   afterEach(() => {

--- a/platform/app/src/components/settings/__tests__/ModelProviderForm.validation-escape-hatch.integration.test.tsx
+++ b/platform/app/src/components/settings/__tests__/ModelProviderForm.validation-escape-hatch.integration.test.tsx
@@ -15,7 +15,17 @@
  */
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  inputFor,
+  keyedRow,
+  makePrimeQueries,
+  modelProviderDrawerMocks,
+  resetModelProviderDrawerMocks,
+  Wrapper,
+} from "./modelProviderDrawerHarness";
+import { EditModelProviderForm } from "../ModelProviderForm";
 
 const {
   mockMutateAsync,
@@ -23,94 +33,7 @@ const {
   mockListAllForOrganizationForFrontendQuery,
   mockListAllForProjectForFrontendQuery,
   mockValidateApiKey,
-} = vi.hoisted(() => ({
-  mockMutateAsync: vi.fn().mockResolvedValue({}),
-  mockGetAllForProjectForFrontendQuery: vi.fn(),
-  mockListAllForOrganizationForFrontendQuery: vi.fn(),
-  mockListAllForProjectForFrontendQuery: vi.fn(),
-  mockValidateApiKey: vi.fn().mockResolvedValue(true),
-}));
-
-vi.mock("../../../utils/api", () => ({
-  api: {
-    modelProvider: {
-      getAllForProjectForFrontend: {
-        useQuery: mockGetAllForProjectForFrontendQuery,
-      },
-      listAllForOrganizationForFrontend: {
-        useQuery: mockListAllForOrganizationForFrontendQuery,
-      },
-      listAllForProjectForFrontend: {
-        useQuery: mockListAllForProjectForFrontendQuery,
-      },
-      update: { useMutation: () => ({ mutateAsync: mockMutateAsync }) },
-      setRoleAssignmentForScope: {
-        useMutation: () => ({
-          mutateAsync: vi.fn().mockResolvedValue({ ok: true }),
-        }),
-      },
-      isManagedProvider: { useQuery: () => ({ data: { managed: false } }) },
-    },
-    useUtils: () => ({
-      organization: { getAll: { invalidate: vi.fn() } },
-      modelProvider: {
-        getAllForProject: { invalidate: vi.fn() },
-        getAllForProjectForFrontend: { invalidate: vi.fn() },
-        listAllForProjectForFrontend: { invalidate: vi.fn() },
-        listAllForOrganizationForFrontend: { invalidate: vi.fn() },
-        getResolvedDefault: { invalidate: vi.fn() },
-        getDefaultModelsForProject: { invalidate: vi.fn() },
-      },
-    }),
-  },
-}));
-
-vi.mock("../../../hooks/useDrawer", () => ({
-  useDrawer: () => ({ closeDrawer: vi.fn(), openDrawer: vi.fn() }),
-}));
-
-vi.mock("../../../hooks/useOrganizationTeamProject", () => ({
-  useOrganizationTeamProject: () => ({
-    project: { id: "proj-1", name: "Web App", slug: "web-app" },
-    team: { id: "team-1", name: "Platform" },
-    organization: {
-      id: "org-1",
-      name: "Acme",
-      teams: [
-        {
-          id: "team-1",
-          name: "Platform",
-          projects: [{ id: "proj-1", name: "Web App" }],
-        },
-      ],
-    },
-    hasPermission: () => true,
-  }),
-}));
-
-vi.mock("../../../hooks/useModelProviderApiKeyValidation", () => ({
-  useModelProviderApiKeyValidation: () => ({
-    validate: mockValidateApiKey,
-    validateWithCustomUrl: vi.fn().mockResolvedValue(true),
-    isValidating: false,
-    validationError: undefined,
-    clearError: vi.fn(),
-  }),
-}));
-
-vi.mock("../../../hooks/useFeatureFlag", () => ({
-  useFeatureFlag: () => ({ enabled: false, isLoading: false }),
-}));
-
-vi.mock("../../ui/toaster", () => ({ toaster: { create: vi.fn() } }));
-
-import { EditModelProviderForm } from "../ModelProviderForm";
-import {
-  inputFor,
-  keyedRow,
-  makePrimeQueries,
-  Wrapper,
-} from "./modelProviderDrawerHarness";
+} = modelProviderDrawerMocks;
 
 const primeQueries = makePrimeQueries({
   collapsedQuery: mockGetAllForProjectForFrontendQuery,
@@ -150,9 +73,7 @@ const enterKey = async (
 
 describe("Feature: a refused API key is not a dead end", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
-    mockMutateAsync.mockResolvedValue({});
-    mockValidateApiKey.mockResolvedValue(true);
+    resetModelProviderDrawerMocks();
     primeQueries([
       keyedRow({
         providerKey: PROVIDER_KEY,

--- a/platform/app/src/components/settings/__tests__/modelProviderDrawerHarness.tsx
+++ b/platform/app/src/components/settings/__tests__/modelProviderDrawerHarness.tsx
@@ -1,10 +1,10 @@
 /**
  * Shared harness for the model-provider drawer integration tests.
  *
- * Holds everything that is not a behaviour assertion: the Chakra wrapper,
- * the provider-row fixture, the query priming, and the DOM readers for a
- * credential field. The `vi.mock` calls stay in each test file, since they
- * have to hoist above that file's own imports.
+ * Holds everything that is not a behaviour assertion: the shared module
+ * mocks, Chakra wrapper, provider-row fixture, query priming, and the DOM
+ * readers for a credential field. Import this before `ModelProviderForm` so
+ * the mocks register before the component module evaluates.
  */
 import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
 import { screen } from "@testing-library/react";
@@ -13,6 +13,244 @@ import { vi } from "vitest";
 
 import type { MaybeStoredModelProvider } from "../../../server/modelProviders/registry";
 import { MASKED_KEY_PLACEHOLDER } from "../../../utils/constants";
+
+const modelProviderDrawerMocks = vi.hoisted(() => ({
+  mockMutateAsync: vi.fn().mockResolvedValue({}),
+  mockSetRoleAssignmentForScope: vi.fn().mockResolvedValue({ ok: true }),
+  mockGetAllForProjectForFrontendQuery: vi.fn(),
+  mockListAllForOrganizationForFrontendQuery: vi.fn(),
+  mockListAllForProjectForFrontendQuery: vi.fn(),
+  mockIsManagedProviderQuery: vi.fn(() => ({ data: { managed: false } })),
+  mockValidateApiKey: vi.fn().mockResolvedValue(true),
+  mockValidateWithCustomUrl: vi.fn().mockResolvedValue(true),
+  mockUseFeatureFlag: vi.fn((_: string) => ({
+    enabled: false,
+    isLoading: false,
+  })),
+  mockCloseDrawer: vi.fn(),
+  mockOpenDrawer: vi.fn(),
+  mockUseOrganizationTeamProject: vi.fn(() => ({
+    project: {
+      id: "proj-1",
+      name: "Web App",
+      slug: "web-app",
+      defaultModel: null,
+    },
+    team: { id: "team-1", name: "Platform" },
+    organization: {
+      id: "org-1",
+      name: "Acme",
+      teams: [
+        {
+          id: "team-1",
+          name: "Platform",
+          projects: [{ id: "proj-1", name: "Web App" }],
+        },
+      ],
+    },
+    hasPermission: () => true,
+  })),
+  mockUseModelProviderForm: vi.fn(),
+  mockUseModelProvidersSettings: vi.fn(),
+  mockCodexSignInStart: vi.fn(),
+  mockCodexSignInPoll: vi.fn(),
+  mockDeleteModelProvider: vi.fn(),
+}));
+
+export { modelProviderDrawerMocks };
+
+vi.mock("../../../utils/api", () => ({
+  api: {
+    modelProvider: {
+      getAllForProjectForFrontend: {
+        useQuery: modelProviderDrawerMocks.mockGetAllForProjectForFrontendQuery,
+      },
+      listAllForOrganizationForFrontend: {
+        useQuery:
+          modelProviderDrawerMocks.mockListAllForOrganizationForFrontendQuery,
+      },
+      listAllForProjectForFrontend: {
+        useQuery: modelProviderDrawerMocks.mockListAllForProjectForFrontendQuery,
+      },
+      update: {
+        useMutation: () => ({
+          mutateAsync: modelProviderDrawerMocks.mockMutateAsync,
+        }),
+      },
+      setRoleAssignmentForScope: {
+        useMutation: () => ({
+          mutateAsync: modelProviderDrawerMocks.mockSetRoleAssignmentForScope,
+        }),
+      },
+      isManagedProvider: {
+        useQuery: modelProviderDrawerMocks.mockIsManagedProviderQuery,
+      },
+      codexStatus: {
+        useQuery: () => ({ data: { connected: false }, isLoading: false }),
+      },
+      codexSignInStart: {
+        useMutation: () => ({
+          mutateAsync: modelProviderDrawerMocks.mockCodexSignInStart,
+          isLoading: false,
+        }),
+      },
+      codexSignInPoll: {
+        useMutation: () => ({
+          mutateAsync: modelProviderDrawerMocks.mockCodexSignInPoll,
+          isLoading: false,
+        }),
+      },
+      delete: {
+        useMutation: () => ({
+          mutateAsync: modelProviderDrawerMocks.mockDeleteModelProvider,
+          isLoading: false,
+        }),
+      },
+    },
+    useUtils: () => ({
+      organization: {
+        getAll: { invalidate: vi.fn() },
+      },
+      modelProvider: {
+        invalidate: vi.fn(),
+        getAllForProject: { invalidate: vi.fn() },
+        getAllForProjectForFrontend: { invalidate: vi.fn() },
+        listAllForProjectForFrontend: { invalidate: vi.fn() },
+        listAllForOrganizationForFrontend: { invalidate: vi.fn() },
+        getResolvedDefault: { invalidate: vi.fn() },
+        getDefaultModelsForProject: { invalidate: vi.fn() },
+      },
+    }),
+  },
+}));
+
+vi.mock("../../../hooks/useDrawer", () => ({
+  useDrawer: () => ({
+    closeDrawer: modelProviderDrawerMocks.mockCloseDrawer,
+    openDrawer: modelProviderDrawerMocks.mockOpenDrawer,
+  }),
+}));
+
+vi.mock("../../../hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject:
+    modelProviderDrawerMocks.mockUseOrganizationTeamProject,
+}));
+
+vi.mock("../../../hooks/useModelProviderApiKeyValidation", () => ({
+  useModelProviderApiKeyValidation: () => ({
+    validate: modelProviderDrawerMocks.mockValidateApiKey,
+    validateWithCustomUrl: modelProviderDrawerMocks.mockValidateWithCustomUrl,
+    isValidating: false,
+    validationError: undefined,
+    clearError: vi.fn(),
+  }),
+}));
+
+vi.mock("../../../hooks/useFeatureFlag", () => ({
+  useFeatureFlag: modelProviderDrawerMocks.mockUseFeatureFlag,
+}));
+
+vi.mock("../../ui/toaster", () => ({ toaster: { create: vi.fn() } }));
+
+vi.mock("../../../hooks/useModelProviderForm", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../../hooks/useModelProviderForm")>();
+
+  return {
+    ...actual,
+    useModelProviderForm: (
+      ...args: Parameters<typeof actual.useModelProviderForm>
+    ) => {
+      if (
+        modelProviderDrawerMocks.mockUseModelProviderForm.getMockImplementation()
+      ) {
+        return modelProviderDrawerMocks.mockUseModelProviderForm(
+          ...args,
+        ) as ReturnType<typeof actual.useModelProviderForm>;
+      }
+
+      return actual.useModelProviderForm(...args);
+    },
+  };
+});
+
+vi.mock("../../../hooks/useModelProvidersSettings", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("../../../hooks/useModelProvidersSettings")
+    >();
+
+  return {
+    ...actual,
+    useModelProvidersSettings: (
+      ...args: Parameters<typeof actual.useModelProvidersSettings>
+    ) => {
+      if (
+        modelProviderDrawerMocks.mockUseModelProvidersSettings.getMockImplementation()
+      ) {
+        return modelProviderDrawerMocks.mockUseModelProvidersSettings(
+          ...args,
+        ) as ReturnType<typeof actual.useModelProvidersSettings>;
+      }
+
+      return actual.useModelProvidersSettings(...args);
+    },
+  };
+});
+
+export function resetModelProviderDrawerMocks() {
+  modelProviderDrawerMocks.mockMutateAsync.mockReset();
+  modelProviderDrawerMocks.mockMutateAsync.mockResolvedValue({});
+  modelProviderDrawerMocks.mockSetRoleAssignmentForScope.mockReset();
+  modelProviderDrawerMocks.mockSetRoleAssignmentForScope.mockResolvedValue({
+    ok: true,
+  });
+  modelProviderDrawerMocks.mockGetAllForProjectForFrontendQuery.mockReset();
+  modelProviderDrawerMocks.mockListAllForOrganizationForFrontendQuery.mockReset();
+  modelProviderDrawerMocks.mockListAllForProjectForFrontendQuery.mockReset();
+  modelProviderDrawerMocks.mockIsManagedProviderQuery.mockReset();
+  modelProviderDrawerMocks.mockIsManagedProviderQuery.mockReturnValue({
+    data: { managed: false },
+  });
+  modelProviderDrawerMocks.mockValidateApiKey.mockReset();
+  modelProviderDrawerMocks.mockValidateApiKey.mockResolvedValue(true);
+  modelProviderDrawerMocks.mockValidateWithCustomUrl.mockReset();
+  modelProviderDrawerMocks.mockValidateWithCustomUrl.mockResolvedValue(true);
+  modelProviderDrawerMocks.mockUseFeatureFlag.mockReset();
+  modelProviderDrawerMocks.mockUseFeatureFlag.mockReturnValue({
+    enabled: false,
+    isLoading: false,
+  });
+  modelProviderDrawerMocks.mockCloseDrawer.mockReset();
+  modelProviderDrawerMocks.mockOpenDrawer.mockReset();
+  modelProviderDrawerMocks.mockUseOrganizationTeamProject.mockReset();
+  modelProviderDrawerMocks.mockUseOrganizationTeamProject.mockReturnValue({
+    project: {
+      id: "proj-1",
+      name: "Web App",
+      slug: "web-app",
+      defaultModel: null,
+    },
+    team: { id: "team-1", name: "Platform" },
+    organization: {
+      id: "org-1",
+      name: "Acme",
+      teams: [
+        {
+          id: "team-1",
+          name: "Platform",
+          projects: [{ id: "proj-1", name: "Web App" }],
+        },
+      ],
+    },
+    hasPermission: () => true,
+  });
+  modelProviderDrawerMocks.mockUseModelProviderForm.mockReset();
+  modelProviderDrawerMocks.mockUseModelProvidersSettings.mockReset();
+  modelProviderDrawerMocks.mockCodexSignInStart.mockReset();
+  modelProviderDrawerMocks.mockCodexSignInPoll.mockReset();
+  modelProviderDrawerMocks.mockDeleteModelProvider.mockReset();
+}
 
 export const Wrapper = ({ children }: { children: ReactNode }) => (
   <ChakraProvider value={defaultSystem}>{children}</ChakraProvider>
@@ -73,13 +311,24 @@ export function keyedRow({
   };
 }
 
-function readyQueryResult<T>(data: T) {
+export function readyQueryResult<T>(data: T) {
   return {
     data,
     isSuccess: true,
     isError: false,
     isLoading: false,
     status: "success" as const,
+    refetch: vi.fn(),
+  };
+}
+
+export function notReadyQueryResult() {
+  return {
+    data: undefined,
+    isSuccess: false,
+    isError: false,
+    isLoading: true,
+    status: "loading" as const,
     refetch: vi.fn(),
   };
 }


### PR DESCRIPTION
## Why

Closes #7901.

The `ModelProviderForm.*.integration.test.tsx` suites repeated the same drawer boundary mocks, so any mock shape change had to be copied across each file.

## What changed

Moved the shared `vi.mock` setup into `modelProviderDrawerHarness.tsx`. The harness defaults to the real `useModelProviderForm` and `useModelProvidersSettings` implementations, while suites that need those hooks mocked still override them through shared mock handles.

## How it works

Each suite imports the harness before `ModelProviderForm`, so the mock registrations happen before the component module evaluates. `resetModelProviderDrawerMocks` restores the default mock behavior before each test.

## Test plan

- `pnpm --dir platform/app exec vitest -c vitest.component.config.ts run src/components/settings/__tests__/ModelProviderForm.credential-requiredness.integration.test.tsx src/components/settings/__tests__/ModelProviderForm.credential-preservation.integration.test.tsx src/components/settings/__tests__/ModelProviderForm.validation-escape-hatch.integration.test.tsx src/components/settings/__tests__/ModelProviderForm.field-guidance.integration.test.tsx src/components/settings/__tests__/ModelProviderForm.edit-row-resolution.integration.test.tsx src/components/settings/__tests__/ModelProviderForm.advanced-gateway.integration.test.tsx src/components/settings/__tests__/ModelProviderForm.azure-safety.integration.test.tsx src/components/settings/__tests__/ModelProviderForm.codex-signin.integration.test.tsx`
- `pnpm --dir platform/app exec vitest -c vitest.component.config.ts run src/components/settings/__tests__`
- `pnpm typecheck`
- `pnpm lint` could not run locally: the installed Biome binary requires GLIBC_2.29/2.30 on this host.

## Anything surprising?

Local install needed `--registry=https://registry.npmjs.org` because the configured registry returned 404 for `monacopilot@1.2.12`.
