### PR TITLE
ci: the MCP publish workflow runs its install through the setup action

### DIFF
--- a/.github/actions/setup-pnpm-node/action.yml
+++ b/.github/actions/setup-pnpm-node/action.yml
@@ -12,6 +12,9 @@
 #     with:
 #       # optional: what to install. Omit to skip installing entirely.
 #       install: "@langwatch/web..."
+#       # optional: npm registry for a publish job. Writes the .npmrc that
+#       # `pnpm publish` authenticates through. Omit everywhere else.
+#       registry-url: "https://registry.npmjs.org"
 name: setup-pnpm-node
 description: Set up pnpm + Node 24 with pnpm-store caching.
 inputs:
@@ -37,6 +40,14 @@ inputs:
       or `@langwatch/web... @langwatch/langyworker...` for two roots).
     required: false
     default: ""
+  registry-url:
+    description: >
+      npm registry to authenticate against, for publish jobs only. Passed
+      through to actions/setup-node, which writes a project .npmrc pointing at
+      it with an auth token read from NODE_AUTH_TOKEN. Empty (the default)
+      leaves .npmrc untouched.
+    required: false
+    default: ""
 
 runs:
   using: composite
@@ -59,6 +70,7 @@ runs:
         node-version: 24
         cache: "pnpm"
         cache-dependency-path: ${{ inputs.cache-dependency-path }}
+        registry-url: ${{ inputs.registry-url }}
 
     # node-gyp is no longer bundled on PATH under Node-24 + npm-11, so any
     # native-module install lifecycle script (e.g. node-pty's prebuild fallback

--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -195,27 +195,16 @@ jobs:
 
       # Shared pnpm + Node setup with pnpm-store caching, so this job stops
       # re-downloading the full langwatch + skills dependency trees on every run.
+      # skills/ pulls node-pty, whose postinstall falls back to `node-gyp
+      # rebuild` on linux, so the install runs through the action too: it puts
+      # node-gyp on PATH and makes pnpm's bundled gyp_main.py executable.
+      # skills/ used to need `--ignore-workspace` to escape the root workspace
+      # it sat inside without being a member of; it is a member now. See ADR-076.
       - name: Setup pnpm + Node
         uses: ./.github/actions/setup-pnpm-node
         with:
           cache-dependency-path: pnpm-lock.yaml
-
-      # skills/ pulls node-pty, whose postinstall falls back to `node-gyp
-      # rebuild` on linux. The composite action above installs node-gyp only
-      # when it does the install itself, and here it does not, so it has to be
-      # installed explicitly before the install below reaches that lifecycle
-      # script — otherwise it ELIFECYCLEs with "node-gyp: not found".
-      - name: Install node-gyp (for node-pty postinstall)
-        run: npm install -g node-gyp@12.3.0
-
-      # One install for the app and the skills compiler. skills/ used to need
-      # `--ignore-workspace` to escape the root workspace it sat inside without
-      # being a member of; it is a member now. See ADR-076.
-      - name: Install dependencies
-        run: >
-          pnpm install --frozen-lockfile
-          --filter "@langwatch/web..."
-          --filter "@langwatch/skills..."
+          install: "@langwatch/web... @langwatch/skills..."
 
       - name: Regenerate docs/skills pages
         run: bash docs/scripts/sync-prompts.sh

--- a/.github/workflows/gateway-matrix.yaml
+++ b/.github/workflows/gateway-matrix.yaml
@@ -196,21 +196,14 @@ jobs:
           go-version-file: go.mod
           cache-dependency-path: go.sum
 
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v4
+      # node-pty is in the app's closure via mcp-server and falls back to
+      # `node-gyp rebuild` on linux, so the install runs through the shared
+      # action: it puts node-gyp on PATH and makes pnpm's bundled gyp_main.py
+      # executable.
+      - name: Setup pnpm + Node
+        uses: ./.github/actions/setup-pnpm-node
         with:
-          node-version: '24'
-          cache: 'pnpm'
-          cache-dependency-path: pnpm-lock.yaml
-
-      - name: Install langwatch deps
-        # node-pty (in the app's closure via mcp-server) falls back to
-        # `node-gyp rebuild` on linux, and this job bypasses the shared setup
-        # action that puts node-gyp on PATH.
-        run: |
-          npm install -g node-gyp@12.3.0
-          pnpm install --frozen-lockfile --filter "@langwatch/web..."
+          install: "@langwatch/web..."
 
       - name: Apply DB migrations
         working-directory: platform/app

--- a/.github/workflows/mcp-javascript-cd.yml
+++ b/.github/workflows/mcp-javascript-cd.yml
@@ -25,19 +25,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
 
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+      # The install runs through the shared action because mcp-server pulls
+      # node-pty, whose rebuild needs node-gyp on PATH and an executable
+      # gyp_main.py in pnpm's bundled copy; the action sets both up.
+      - name: Setup pnpm + Node
+        uses: ./.github/actions/setup-pnpm-node
         with:
-          version: 10.24.0
-
-      - name: Setup Node
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
-        with:
-          node-version: 24
-          cache: pnpm
+          install: "@langwatch/mcp-server..."
           registry-url: "https://registry.npmjs.org"
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile --filter "@langwatch/mcp-server..."
 
       - name: Build and publish
         working-directory: mcp/typescript

--- a/.github/workflows/npx-server-publish.yml
+++ b/.github/workflows/npx-server-publish.yml
@@ -61,14 +61,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
 
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v4
+      # The workspace install pulls node-pty through mcp-server, so it runs
+      # through the shared action: it puts node-gyp on PATH and makes pnpm's
+      # bundled gyp_main.py executable. The version check below still gates the
+      # publish, it just runs after a frozen-lockfile install rather than before.
+      - name: Setup pnpm + Node
+        uses: ./.github/actions/setup-pnpm-node
         with:
-          node-version: "24"
+          install: all
           registry-url: "https://registry.npmjs.org"
-
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-        with:
-          run_install: false
 
       - name: Resolve and verify versions
         id: versions
@@ -111,9 +112,6 @@ jobs:
 
           echo "version=$pkg_version" >> "$GITHUB_OUTPUT"
           echo "npm_tag=$npm_tag" >> "$GITHUB_OUTPUT"
-
-      - name: Install pnpm dependencies (workspace)
-        run: pnpm install --frozen-lockfile
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:

--- a/platform/app/src/components/datasets/editor/__tests__/DatasetEditorTable.integration.test.tsx
+++ b/platform/app/src/components/datasets/editor/__tests__/DatasetEditorTable.integration.test.tsx
@@ -854,11 +854,17 @@ describe("given rows are deleted from a paginated dataset", () => {
       // too, or a committed delete leaves the pager count stale. (Settling the
       // delete synchronously would hide the bug, since ops would hit zero on the
       // delete's own success.)
-      let resolveDelete: (() => void) | undefined;
-      let rejectUpdate: ((e: { message: string }) => void) | undefined;
+      //
+      // Every dispatched callback is collected, not just the most recent one. A
+      // stall longer than the 500ms sync debounce splits the typing across two
+      // flushes, so the edit can reach the server as two updates. Keeping only
+      // the last one leaves a pending op outstanding, the batch never drains,
+      // and the assertion below fails for a reason this test is not about.
+      const resolveDeletes: (() => void)[] = [];
+      const rejectUpdates: ((e: { message: string }) => void)[] = [];
       deleteManyMutate.mockImplementation(
         (_args: unknown, opts?: { onSuccess?: () => void }) => {
-          resolveDelete = opts?.onSuccess;
+          if (opts?.onSuccess) resolveDeletes.push(opts.onSuccess);
         },
       );
       updateMutate.mockImplementation(
@@ -866,7 +872,7 @@ describe("given rows are deleted from a paginated dataset", () => {
           _args: unknown,
           opts?: { onError?: (e: { message: string }) => void },
         ) => {
-          rejectUpdate = opts?.onError;
+          if (opts?.onError) rejectUpdates.push(opts.onError);
         },
       );
       const refetchSpy = vi.fn();
@@ -893,8 +899,8 @@ describe("given rows are deleted from a paginated dataset", () => {
       render(<DatasetEditorTable datasetId="dp" />, { wrapper: Wrapper });
       await screen.findByText("a");
 
-      // Queue a delete (row 1) and an edit (row 2, now at index 0) into the same
-      // debounce batch.
+      // Queue a delete (row 1) and an edit (row 2, now at index 0). The debounce
+      // normally carries them in one batch.
       await user.click(screen.getByLabelText("Select row 1"));
       await user.click(await screen.findByTestId("delete-selected-rows"));
       await user.dblClick(screen.getByTestId("cell-0-input_0"));
@@ -905,12 +911,16 @@ describe("given rows are deleted from a paginated dataset", () => {
       // Both mutations dispatched; settle them delete-then-update so ops reaches
       // zero through the error path.
       await waitFor(() => {
-        expect(resolveDelete).toBeDefined();
-        expect(rejectUpdate).toBeDefined();
+        expect(resolveDeletes.length).toBeGreaterThan(0);
+        expect(rejectUpdates.length).toBeGreaterThan(0);
       });
+      // Deletes first, updates after, so the batch can only reach zero pending
+      // ops through the error path however many flushes the debounce produced.
       await act(async () => {
-        resolveDelete?.();
-        rejectUpdate?.({ message: "boom" });
+        for (const resolveDelete of resolveDeletes) resolveDelete();
+        for (const rejectUpdate of rejectUpdates) {
+          rejectUpdate({ message: "boom" });
+        }
       });
 
       expect(refetchSpy).toHaveBeenCalled();


### PR DESCRIPTION
# Related Issue

- Resolves #7903

## What was failing

`@langwatch/mcp-server` depends on `node-pty`, which ships prebuilds only for darwin and win32, so on linux its postinstall falls back to `node-gyp rebuild`. pnpm builds native modules with the node-gyp bundled in its own dist, and that copy reaches the runner without an executable bit. The generated Makefile invokes `gyp_main.py` by path, `sh` answers `Permission denied`, and make stops with error 126. It only shows up when the pnpm store cache misses, which is why it reads as a flake rather than a broken workflow.

`.github/actions/setup-pnpm-node` already fixes both halves of this: it installs `node-gyp@12.3.0` globally so scripts can resolve it via PATH, and it restores the executable bit on pnpm's bundled `gyp_main.py`. Both are gated on its `install` input, so a workflow that only uses the action for pnpm and Node setup gets neither.

## What changed

**`.github/actions/setup-pnpm-node/action.yml`** gains an optional `registry-url` input, passed through to its `actions/setup-node` step. `setup-node` only writes an `.npmrc` when `registry-url` is non-empty, so the empty default leaves every existing caller unchanged. This is what lets a publish job use the one setup path instead of keeping a separate `setup-node` step alongside it, which would have left two places pinning the Node version and the cache strategy.

**`.github/workflows/mcp-javascript-cd.yml`** replaces its hand-rolled `pnpm/action-setup` + `actions/setup-node` + `pnpm install` trio with one call to the action, carrying `install: "@langwatch/mcp-server..."` and the registry url. The publish step, `--provenance`, `permissions: id-token: write` and the concurrency block are untouched.

Three more workflows had the same gap and are fixed the same way:

- **`.github/workflows/gateway-matrix.yaml`**: installed node-gyp globally but never restored the executable bit, so it was exposed to the same error 126. Its pnpm setup, Node setup and install collapse into one action call with `install: "@langwatch/web..."`. Same pnpm version (10.24.0 is what the bare `pnpm/action-setup` already resolved to from the root `packageManager`), same Node 24, same cache path, same filter.
- **`.github/workflows/docs-ci.yml`** `check_generated_files`: called the action for caching only, then installed node-gyp itself and ran its own two-filter install. The filters move onto the action as `install: "@langwatch/web... @langwatch/skills..."`, which it splits on whitespace into one `--filter` each.
- **`.github/workflows/npx-server-publish.yml`**: a full workspace install with lifecycle scripts and no node-gyp handling at all. Now one action call with `install: all` and the registry url. This moves the install ahead of `Resolve and verify versions`, which is fine: the install is `--frozen-lockfile` and deterministic, and a failed version check still fails the job well before anything publishes. The workflow also picks up pnpm-store caching it did not have.

## Survey of the remaining workflows

`node-pty` is declared by exactly two packages, `mcp/typescript` and `skills`. Ten workflows mention node-pty, mcp-server or skills. The rest were already safe and are untouched:

| Workflow | Why it was already safe |
|---|---|
| `skills-publish.yml` | installs with `--ignore-scripts` |
| `mcp-javascript-ci.yml` | both jobs already go through the action with `install:` |
| `sdk-javascript-ci.yml`, `e2e-ci.yml`, `npx-server-smoke.yml`, `langwatch-app-ci.yml` e2e job | install node-gyp globally and set `npm_config_node_gyp`, which overrides pnpm's bundled copy |
| `langwatch-app-ci.yml` server-cli job | the action already ran the install in that job, so node-gyp and the executable bit are in place before the second `pnpm install` |
| `sdk-javascript-cd.yml` | the `langwatch...` closure is the SDK plus `@langwatch/langy`, neither pulls node-pty |

## How it was verified

- All five touched files parse as YAML.
- `actionlint` over the four workflows reports 11 shellcheck findings, and running it over the same four files at `origin/main` reports the same 11. Every one sits on a `run:` step this PR does not touch, so the change introduces none.
- `specs/ci/` has no feature file covering the setup action, node-gyp or node-pty, so there is no spec to extend.

Closes #7903


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized Node.js and pnpm setup across documentation checks, gateway builds, and publishing workflows.
  * Centralized dependency installation and native module build preparation in the shared setup process.
  * Added optional npm registry configuration for publishing workflows.
  * Preserved existing build, publishing, version detection, and notification behavior.

* **Tests**
  * Improved dataset editor integration test coverage for delete and update operations that span multiple synchronization cycles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->