### PR TITLE
fix(sdks): one HTTP client per SDK, redirects followed only for an http to https upgrade

### DIFF
--- a/docs/integration/python/guide.mdx
+++ b/docs/integration/python/guide.mdx
@@ -206,7 +206,10 @@ langwatch.setup(
 
 <ParamField path="endpoint_url" type="str | None">
   The LangWatch endpoint URL. Defaults to the `LANGWATCH_ENDPOINT` environment
-  variable or `https://app.langwatch.ai`.
+  variable or `https://app.langwatch.ai`. An `http://` endpoint that answers
+  with a redirect to the same `https://` URL is upgraded automatically, with one
+  warning per process. Any other redirect raises
+  `langwatch.http_client.RedirectRefusedError`: set the endpoint to the final URL.
 </ParamField>
 
 <ParamField path="base_attributes" type="dict[str, Any] | None">

--- a/docs/integration/python/guide.mdx
+++ b/docs/integration/python/guide.mdx
@@ -206,10 +206,11 @@ langwatch.setup(
 
 <ParamField path="endpoint_url" type="str | None">
   The LangWatch endpoint URL. Defaults to the `LANGWATCH_ENDPOINT` environment
-  variable or `https://app.langwatch.ai`. An `http://` endpoint that answers
-  with a redirect to the same `https://` URL is upgraded automatically, with one
-  warning per process. Any other redirect raises
-  `langwatch.http_client.RedirectRefusedError`: set the endpoint to the final URL.
+  variable or `https://app.langwatch.ai`. GET requests follow redirects, up to
+  five hops. Every other request only follows an `http://` endpoint's redirect
+  to the same `https://` URL, once, with one warning per process. A refused
+  redirect raises `langwatch.http_client.RedirectRefusedError`: set the
+  endpoint to the final URL.
 </ParamField>
 
 <ParamField path="base_attributes" type="dict[str, Any] | None">

--- a/docs/integration/python/guide.mdx
+++ b/docs/integration/python/guide.mdx
@@ -206,7 +206,7 @@ langwatch.setup(
 
 <ParamField path="endpoint_url" type="str | None">
   The LangWatch endpoint URL. Defaults to the `LANGWATCH_ENDPOINT` environment
-  variable or `https://app.langwatch.ai`. GET requests follow redirects, up to
+  variable or `https://app.langwatch.ai`. GET and HEAD requests follow redirects, up to
   five hops. Every other request only follows an `http://` endpoint's redirect
   to the same `https://` URL, once, with one warning per process. A refused
   redirect raises `langwatch.http_client.RedirectRefusedError`: set the

--- a/docs/integration/typescript/reference.mdx
+++ b/docs/integration/typescript/reference.mdx
@@ -317,7 +317,7 @@ const langwatch = new LangWatch({
   Configuration options for the LangWatch client.
 </ParamField>
 
-An endpoint written with `http://` that answers with a redirect to the same URL over `https://` is followed once, with a warning asking you to configure the https URL directly. Any other redirect, such as a different host or path, a downgrade to http, or a 303, is refused with a `LangWatchRedirectError` that names the request URL, the `Location` and the status. Set the endpoint to the final URL to fix it.
+GET requests follow redirects, up to five hops, and drop credential headers when the target is another origin. Every other request only follows an `http://` endpoint's redirect to the same URL over `https://`, once, with a warning asking you to configure the https URL directly. A refused redirect throws a `LangWatchRedirectError` that names the request URL, the `Location` and the status. Set the endpoint to the final URL to fix it.
 
 #### Properties
 

--- a/docs/integration/typescript/reference.mdx
+++ b/docs/integration/typescript/reference.mdx
@@ -317,6 +317,8 @@ const langwatch = new LangWatch({
   Configuration options for the LangWatch client.
 </ParamField>
 
+An endpoint written with `http://` that answers with a redirect to the same URL over `https://` is followed once, with a warning asking you to configure the https URL directly. Any other redirect, such as a different host or path, a downgrade to http, or a 303, is refused with a `LangWatchRedirectError` that names the request URL, the `Location` and the status. Set the endpoint to the final URL to fix it.
+
 #### Properties
 
 <ResponseField name="prompts" type="PromptsFacade">

--- a/docs/integration/typescript/reference.mdx
+++ b/docs/integration/typescript/reference.mdx
@@ -317,7 +317,7 @@ const langwatch = new LangWatch({
   Configuration options for the LangWatch client.
 </ParamField>
 
-GET requests follow redirects, up to five hops, and drop credential headers when the target is another origin. Every other request only follows an `http://` endpoint's redirect to the same URL over `https://`, once, with a warning asking you to configure the https URL directly. A refused redirect throws a `LangWatchRedirectError` that names the request URL, the `Location` and the status. Set the endpoint to the final URL to fix it.
+GET and HEAD requests follow redirects, up to five hops, and drop credential headers when the target is another origin. Every other request only follows an `http://` endpoint's redirect to the same URL over `https://`, once, with a warning asking you to configure the https URL directly. A refused redirect throws a `LangWatchRedirectError` that names the request URL, the `Location` and the status. Set the endpoint to the final URL to fix it.
 
 #### Properties
 

--- a/sdks/python/src/langwatch/agent/client.py
+++ b/sdks/python/src/langwatch/agent/client.py
@@ -40,6 +40,7 @@ except ImportError:  # pragma: no cover
     websockets = None  # type: ignore[assignment]
 
 from langwatch.__version__ import __version__
+from langwatch.http_client import create_async_client
 from langwatch.state import get_api_key, get_endpoint, get_instance
 from langwatch.utils.initialization import ensure_setup
 
@@ -696,7 +697,7 @@ class AgentClient:
         """
         base = http_url(self.resolved_endpoint)
         timeout = httpx.Timeout(POLL_TIMEOUT_SECONDS, connect=OPEN_TIMEOUT_SECONDS)
-        async with httpx.AsyncClient(timeout=timeout) as http:
+        async with create_async_client(timeout=timeout) as http:
             self._http = http
             self._instance_token = None
             self._session_lost = False

--- a/sdks/python/src/langwatch/batch_evaluation.py
+++ b/sdks/python/src/langwatch/batch_evaluation.py
@@ -23,6 +23,7 @@ import httpx
 from tqdm import tqdm
 import pandas as pd
 
+from langwatch.http_client import create_async_client, create_client
 from langwatch.types import Money
 from langwatch.utils.auth import build_auth_headers
 from langwatch.utils.exceptions import better_raise_for_status
@@ -137,7 +138,7 @@ class BatchEvaluation:
         dataset = get_dataset(self.dataset)
 
         print("Starting batch evaluation...")
-        with httpx.Client(timeout=60) as client:
+        with create_client(timeout=60) as client:
             response = client.post(
                 f"{langwatch.get_endpoint()}/api/experiment/init",
                 headers=build_auth_headers(langwatch.get_api_key() or ""),
@@ -364,12 +365,12 @@ class BatchEvaluation:
         reraise=True,
     )
     def post_results(cls, api_key: str, body: dict):
-        response = httpx.post(
-            f"{langwatch.get_endpoint()}/api/evaluations/batch/log_results",
-            headers=build_auth_headers(api_key),
-            json=body,
-            timeout=60,
-        )
+        with create_client(timeout=60) as client:
+            response = client.post(
+                f"{langwatch.get_endpoint()}/api/evaluations/batch/log_results",
+                headers=build_auth_headers(api_key),
+                json=body,
+            )
         better_raise_for_status(response)
 
     def wait_for_completion(self):
@@ -414,7 +415,7 @@ async def run_evaluation(
 
         start_time = time.time()
 
-        async with httpx.AsyncClient(timeout=900) as client:
+        async with create_async_client(timeout=900) as client:
             response = await client.post(**request_params)
             better_raise_for_status(response)
 
@@ -462,7 +463,7 @@ def get_dataset(
         "headers": build_auth_headers(str(langwatch.get_api_key() or "")),
     }
 
-    with httpx.Client(timeout=300) as client:
+    with create_client(timeout=300) as client:
         response = client.get(**request_params)
         better_raise_for_status(response)
 

--- a/sdks/python/src/langwatch/client.py
+++ b/sdks/python/src/langwatch/client.py
@@ -7,6 +7,7 @@ from typing import List, Optional, Sequence, ClassVar
 from langwatch.__version__ import __version__
 from langwatch.attributes import AttributeKey
 from langwatch.domain import BaseAttributes, SpanProcessingExcludeRule
+from langwatch.http_client import create_async_client, create_client
 from langwatch.state import DEFAULT_ENDPOINT, get_instance, normalize_endpoint
 from opentelemetry import trace
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
@@ -772,14 +773,27 @@ class Client(LangWatchClientProtocol):
         """
         Sets up the REST API client for the client.
         """
-        Client._rest_api_client = LangWatchApiClient(
+        headers = build_auth_headers(
+            api_key=Client._api_key,
+            project_id=Client._project_id,
+        )
+        rest_api_client = LangWatchApiClient(
             base_url=Client._endpoint_url,
-            headers=build_auth_headers(
-                api_key=Client._api_key,
-                project_id=Client._project_id,
-            ),
+            headers=headers,
             raise_on_unexpected_status=True,
         )
+        # The generated client would build plain httpx clients on first use;
+        # these carry the shared redirect rule instead. Timeout stays unset,
+        # the way the generated client leaves it.
+        rest_api_client.set_httpx_client(
+            create_client(base_url=Client._endpoint_url, headers=headers, timeout=None)
+        )
+        rest_api_client.set_async_httpx_client(
+            create_async_client(
+                base_url=Client._endpoint_url, headers=headers, timeout=None
+            )
+        )
+        Client._rest_api_client = rest_api_client
 
         return Client._rest_api_client
 

--- a/sdks/python/src/langwatch/client.py
+++ b/sdks/python/src/langwatch/client.py
@@ -1,4 +1,3 @@
-import asyncio
 import atexit
 import os
 import logging
@@ -8,8 +7,6 @@ from typing import List, Optional, Sequence, ClassVar
 from langwatch.__version__ import __version__
 from langwatch.attributes import AttributeKey
 from langwatch.domain import BaseAttributes, SpanProcessingExcludeRule
-import httpx
-
 from langwatch.http_client import create_async_client, create_client
 from langwatch.state import DEFAULT_ENDPOINT, get_instance, normalize_endpoint
 from opentelemetry import trace
@@ -81,9 +78,6 @@ class Client(LangWatchClientProtocol):
     _exporter_attached_providers: ClassVar[set[int]] = set()
     _langwatch_processor: ClassVar[Optional["FilterableBatchSpanProcessor"]] = None
     _rest_api_client: ClassVar[Optional[LangWatchApiClient]] = None
-    # Held so a reconfiguration can release the pools before replacing them.
-    _rest_httpx_client: ClassVar[Optional[httpx.Client]] = None
-    _rest_async_httpx_client: ClassVar[Optional[httpx.AsyncClient]] = None
     _registered_instrumentors: ClassVar[
         dict[opentelemetry.trace.TracerProvider, set[BaseInstrumentor]]
     ] = {}
@@ -430,7 +424,6 @@ class Client(LangWatchClientProtocol):
         cls._is_dedicated_provider = False
         cls._exporter_attached_providers.clear()
         cls._langwatch_processor = None
-        cls._close_rest_httpx_clients()
         cls._rest_api_client = None
         cls._prompts_path = None
         cls._registered_instrumentors.clear()
@@ -789,46 +782,20 @@ class Client(LangWatchClientProtocol):
             headers=headers,
             raise_on_unexpected_status=True,
         )
-        Client._close_rest_httpx_clients()
         # The generated client would build plain httpx clients on first use;
         # these carry the shared redirect rule instead. Timeout stays unset,
         # the way the generated client leaves it.
-        sync_client = create_client(
-            base_url=Client._endpoint_url, headers=headers, timeout=None
+        rest_api_client.set_httpx_client(
+            create_client(base_url=Client._endpoint_url, headers=headers, timeout=None)
         )
-        async_client = create_async_client(
-            base_url=Client._endpoint_url, headers=headers, timeout=None
+        rest_api_client.set_async_httpx_client(
+            create_async_client(
+                base_url=Client._endpoint_url, headers=headers, timeout=None
+            )
         )
-        rest_api_client.set_httpx_client(sync_client)
-        rest_api_client.set_async_httpx_client(async_client)
-        Client._rest_httpx_client = sync_client
-        Client._rest_async_httpx_client = async_client
         Client._rest_api_client = rest_api_client
 
         return Client._rest_api_client
-
-    @staticmethod
-    def _close_rest_httpx_clients() -> None:
-        """Release the connection pools the previous REST clients held.
-
-        The sync client closes here. The async one needs an await, which this
-        synchronous method cannot give it, so it closes on a loop of its own
-        when none is running and is left to the caller's loop otherwise:
-        firing the coroutine at a running loop would leave it unobserved.
-        """
-        sync_client = Client._rest_httpx_client
-        Client._rest_httpx_client = None
-        if sync_client is not None and not sync_client.is_closed:
-            sync_client.close()
-
-        async_client = Client._rest_async_httpx_client
-        Client._rest_async_httpx_client = None
-        if async_client is None or async_client.is_closed:
-            return
-        try:
-            asyncio.get_running_loop()
-        except RuntimeError:
-            asyncio.run(async_client.aclose())
 
 
 class ConditionalSpanExporter(SpanExporter):

--- a/sdks/python/src/langwatch/client.py
+++ b/sdks/python/src/langwatch/client.py
@@ -1,3 +1,4 @@
+import asyncio
 import atexit
 import os
 import logging
@@ -7,6 +8,8 @@ from typing import List, Optional, Sequence, ClassVar
 from langwatch.__version__ import __version__
 from langwatch.attributes import AttributeKey
 from langwatch.domain import BaseAttributes, SpanProcessingExcludeRule
+import httpx
+
 from langwatch.http_client import create_async_client, create_client
 from langwatch.state import DEFAULT_ENDPOINT, get_instance, normalize_endpoint
 from opentelemetry import trace
@@ -78,6 +81,9 @@ class Client(LangWatchClientProtocol):
     _exporter_attached_providers: ClassVar[set[int]] = set()
     _langwatch_processor: ClassVar[Optional["FilterableBatchSpanProcessor"]] = None
     _rest_api_client: ClassVar[Optional[LangWatchApiClient]] = None
+    # Held so a reconfiguration can release the pools before replacing them.
+    _rest_httpx_client: ClassVar[Optional[httpx.Client]] = None
+    _rest_async_httpx_client: ClassVar[Optional[httpx.AsyncClient]] = None
     _registered_instrumentors: ClassVar[
         dict[opentelemetry.trace.TracerProvider, set[BaseInstrumentor]]
     ] = {}
@@ -424,6 +430,7 @@ class Client(LangWatchClientProtocol):
         cls._is_dedicated_provider = False
         cls._exporter_attached_providers.clear()
         cls._langwatch_processor = None
+        cls._close_rest_httpx_clients()
         cls._rest_api_client = None
         cls._prompts_path = None
         cls._registered_instrumentors.clear()
@@ -782,20 +789,46 @@ class Client(LangWatchClientProtocol):
             headers=headers,
             raise_on_unexpected_status=True,
         )
+        Client._close_rest_httpx_clients()
         # The generated client would build plain httpx clients on first use;
         # these carry the shared redirect rule instead. Timeout stays unset,
         # the way the generated client leaves it.
-        rest_api_client.set_httpx_client(
-            create_client(base_url=Client._endpoint_url, headers=headers, timeout=None)
+        sync_client = create_client(
+            base_url=Client._endpoint_url, headers=headers, timeout=None
         )
-        rest_api_client.set_async_httpx_client(
-            create_async_client(
-                base_url=Client._endpoint_url, headers=headers, timeout=None
-            )
+        async_client = create_async_client(
+            base_url=Client._endpoint_url, headers=headers, timeout=None
         )
+        rest_api_client.set_httpx_client(sync_client)
+        rest_api_client.set_async_httpx_client(async_client)
+        Client._rest_httpx_client = sync_client
+        Client._rest_async_httpx_client = async_client
         Client._rest_api_client = rest_api_client
 
         return Client._rest_api_client
+
+    @staticmethod
+    def _close_rest_httpx_clients() -> None:
+        """Release the connection pools the previous REST clients held.
+
+        The sync client closes here. The async one needs an await, which this
+        synchronous method cannot give it, so it closes on a loop of its own
+        when none is running and is left to the caller's loop otherwise:
+        firing the coroutine at a running loop would leave it unobserved.
+        """
+        sync_client = Client._rest_httpx_client
+        Client._rest_httpx_client = None
+        if sync_client is not None and not sync_client.is_closed:
+            sync_client.close()
+
+        async_client = Client._rest_async_httpx_client
+        Client._rest_async_httpx_client = None
+        if async_client is None or async_client.is_closed:
+            return
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            asyncio.run(async_client.aclose())
 
 
 class ConditionalSpanExporter(SpanExporter):

--- a/sdks/python/src/langwatch/dspy/__init__.py
+++ b/sdks/python/src/langwatch/dspy/__init__.py
@@ -12,7 +12,7 @@ from langwatch.utils.utils import safe_get
 from langwatch.telemetry.tracing import LangWatchTrace
 from typing_extensions import TypedDict
 import langwatch
-import httpx
+from langwatch.http_client import create_client
 import json
 from pydantic import BaseModel
 from dspy.predict import Predict
@@ -197,17 +197,17 @@ class LangWatchDSPy:
             return
 
         try:
-            response = httpx.post(
-                f"{langwatch.get_endpoint()}/api/experiment/init",
-                headers=build_auth_headers(langwatch.get_api_key() or ""),
-                json={
-                    "experiment_slug": slug or experiment,
-                    "experiment_type": "DSPY",
-                    "experiment_name": experiment,
-                    "workflow_id": workflow_id,
-                },
-                timeout=60,
-            )
+            with create_client(timeout=60) as client:
+                response = client.post(
+                    f"{langwatch.get_endpoint()}/api/experiment/init",
+                    headers=build_auth_headers(langwatch.get_api_key() or ""),
+                    json={
+                        "experiment_slug": slug or experiment,
+                        "experiment_type": "DSPY",
+                        "experiment_name": experiment,
+                        "workflow_id": workflow_id,
+                    },
+                )
         except Exception as e:
             raise Exception(f"Error initializing LangWatch experiment: {e}")
         if response.status_code == 401:
@@ -407,15 +407,15 @@ class LangWatchDSPy:
             )
             for item in data_list
         ]
-        response = httpx.post(
-            f"{langwatch.get_endpoint()}/api/dspy/log_steps",
-            headers={
-                **build_auth_headers(langwatch.get_api_key() or ""),
-                "Content-Type": "application/json",
-            },
-            data=json.dumps(data),  # type: ignore
-            timeout=60,
-        )
+        with create_client(timeout=60) as client:
+            response = client.post(
+                f"{langwatch.get_endpoint()}/api/dspy/log_steps",
+                headers={
+                    **build_auth_headers(langwatch.get_api_key() or ""),
+                    "Content-Type": "application/json",
+                },
+                content=json.dumps(data),
+            )
         better_raise_for_status(response)
         self.steps_buffer = []
 

--- a/sdks/python/src/langwatch/evaluation/__init__.py
+++ b/sdks/python/src/langwatch/evaluation/__init__.py
@@ -38,6 +38,7 @@ from tenacity import (
 )
 import langwatch
 from langwatch.domain import SpanTimestamps
+from langwatch.http_client import create_async_client, create_client
 from pksuid import PKSUID
 from langwatch.telemetry.span import LangWatchSpan
 from langwatch.telemetry.context import get_current_span
@@ -190,7 +191,7 @@ def evaluate(
         )
         @_retry_evaluator_call
         def _post() -> httpx.Response:
-            with httpx.Client(timeout=900) as client:
+            with create_client(timeout=900) as client:
                 response = client.post(**request_params)
                 better_raise_for_status(response)
                 return response
@@ -255,7 +256,7 @@ async def async_evaluate(
         )
         @_retry_evaluator_call
         async def _post() -> httpx.Response:
-            async with httpx.AsyncClient(timeout=900) as client:
+            async with create_async_client(timeout=900) as client:
                 response = await client.post(**request_params)
                 better_raise_for_status(response)
                 return response

--- a/sdks/python/src/langwatch/experiment/experiment.py
+++ b/sdks/python/src/langwatch/experiment/experiment.py
@@ -9,7 +9,6 @@ import sys
 import threading
 import time
 import traceback
-import httpx
 from opentelemetry import trace, context as otel_context
 from opentelemetry.trace import Span
 from pydantic import BaseModel, Field
@@ -44,6 +43,7 @@ import langwatch
 from langwatch.attributes import AttributeKey
 from langwatch.domain import Money, TypedValueJson
 from langwatch.experiment._results_df import build_results_df
+from langwatch.http_client import create_client
 from langwatch.experiment.platform_run import (
     EvaluatorStats,
     ExperimentRunResult,
@@ -365,7 +365,7 @@ class Experiment:
             )
         langwatch.ensure_setup()
 
-        with httpx.Client(timeout=60) as client:
+        with create_client(timeout=60) as client:
             response = client.post(
                 f"{langwatch.get_endpoint()}/api/experiment/init",
                 headers=build_auth_headers(langwatch.get_api_key() or ""),
@@ -433,7 +433,7 @@ class Experiment:
 
         for attempt in range(retries):
             try:
-                with httpx.Client(timeout=30) as client:
+                with create_client(timeout=30) as client:
                     response = client.get(url, headers=build_auth_headers(api_key))
 
                 if response.status_code == 404:
@@ -794,7 +794,7 @@ class Experiment:
                 f"concurrency must be >= 1, got {concurrency!r}"
             )
         if not self.initialized:
-            # init() does a blocking httpx.post — run it off-loop.
+            # init() does a blocking HTTP call, run it off-loop.
             await asyncio.to_thread(self.init)
 
         progress_bar: Optional[tqdm] = None
@@ -1131,15 +1131,15 @@ class Experiment:
         reraise=True,
     )
     def _log_results(cls, api_key: str, body: Dict[str, Any]):
-        response = httpx.post(
-            f"{langwatch.get_endpoint()}/api/evaluations/batch/log_results",
-            headers={
-                **build_auth_headers(api_key),
-                "Content-Type": "application/json",
-            },
-            data=json.dumps(body, cls=SerializableWithStringFallback),  # type: ignore
-            timeout=60,
-        )
+        with create_client(timeout=60) as client:
+            response = client.post(
+                f"{langwatch.get_endpoint()}/api/evaluations/batch/log_results",
+                headers={
+                    **build_auth_headers(api_key),
+                    "Content-Type": "application/json",
+                },
+                content=json.dumps(body, cls=SerializableWithStringFallback),
+            )
         better_raise_for_status(response)
 
     def _wait_for_completion(self):

--- a/sdks/python/src/langwatch/experiment/platform_run.py
+++ b/sdks/python/src/langwatch/experiment/platform_run.py
@@ -10,10 +10,10 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Literal, Optional, 
 from urllib.parse import quote, urlparse, urlunparse
 import sys
 import time
-import httpx
 
 import langwatch
 from langwatch.experiment._results_df import build_results_df
+from langwatch.http_client import create_client
 from langwatch.state import get_api_key, get_endpoint
 from langwatch.utils.auth import build_auth_headers
 
@@ -185,7 +185,7 @@ class ExperimentRunResult:
 
         for attempt in range(retries):
             try:
-                with httpx.Client(timeout=30) as client:
+                with create_client(timeout=30) as client:
                     response = client.get(url, headers=build_auth_headers(api_key))
 
                 if response.status_code == 404:
@@ -505,7 +505,7 @@ def _start_run(
     ``body`` carries the optional inline data / dataset_id / parameters / row_indices.
     When empty we send ``json=None`` so the historical no-body request is preserved.
     """
-    with httpx.Client(timeout=60) as client:
+    with create_client(timeout=60) as client:
         response = client.post(
             f"{endpoint}/api/evaluations/v3/{slug}/run",
             headers=build_auth_headers(api_key),
@@ -528,7 +528,7 @@ def _start_run(
 
 def _get_run_status(run_id: str, endpoint: str, api_key: str) -> dict:
     """Get the status of a run."""
-    with httpx.Client(timeout=60) as client:
+    with create_client(timeout=60) as client:
         response = client.get(
             f"{endpoint}/api/evaluations/v3/runs/{run_id}",
             headers=build_auth_headers(api_key),

--- a/sdks/python/src/langwatch/http_client.py
+++ b/sdks/python/src/langwatch/http_client.py
@@ -1,0 +1,250 @@
+"""The one HTTP client for every request the SDK sends to the LangWatch API.
+
+httpx never follows a redirect on its own here. The transports in this module
+follow exactly one kind: a 301, 302, 307 or 308 whose Location is the same
+URL with the scheme changed from http to https. That is what an endpoint set
+to `http://app.langwatch.ai` answers with, and following it with the default
+client would turn a POST into a GET and drop the body. The replay keeps the
+method, the headers and the body bytes. Every other redirect is refused with
+`RedirectRefusedError`, so a misconfigured endpoint fails where the caller can
+read it instead of losing the request.
+
+Use `create_client` and `create_async_client` instead of `httpx.Client` and
+`httpx.AsyncClient` anywhere the SDK talks to LangWatch.
+"""
+
+import logging
+import threading
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+# Every status the rule inspects. A 303 is in the set so it is refused with
+# the typed error instead of reaching the caller as a bare response.
+REDIRECT_STATUSES = frozenset({301, 302, 303, 307, 308})
+UPGRADE_STATUSES = frozenset({301, 302, 307, 308})
+
+_SCHEME_DEFAULT_PORTS = {"http": 80, "https": 443}
+
+# Keyword arguments that httpx only honours on the transport it builds itself.
+# Passing them to a client that already carries a transport does nothing, so
+# the factories move them onto the inner transport.
+_TRANSPORT_KWARGS = ("verify", "cert", "http1", "http2", "limits", "proxy")
+
+
+class RedirectRefusedError(Exception):
+    """A LangWatch request answered with a redirect the SDK will not follow."""
+
+    def __init__(self, *, url: str, location: str | None, status: int) -> None:
+        self.url = url
+        self.location = location
+        self.status = status
+        shown_location = location if location is not None else "<no Location header>"
+        super().__init__(
+            f"LangWatch refused to follow a redirect from {url} to {shown_location} "
+            f"(HTTP {status}). Set the endpoint to the final URL."
+        )
+
+
+_warning_lock = threading.Lock()
+_upgrade_warned = False
+
+
+def _reset_upgrade_warning() -> None:
+    """Allow the next upgrade to warn again. For tests."""
+    global _upgrade_warned
+    with _warning_lock:
+        _upgrade_warned = False
+
+
+def _warn_once(request_url: httpx.URL) -> None:
+    global _upgrade_warned
+    with _warning_lock:
+        if _upgrade_warned:
+            return
+        _upgrade_warned = True
+    netloc = request_url.netloc.decode("ascii")
+    logger.warning(
+        "LangWatch endpoint %s://%s redirected to https. Set the endpoint to "
+        "https://%s to skip the extra round trip.",
+        request_url.scheme,
+        netloc,
+        netloc,
+    )
+
+
+def _effective_port(url: httpx.URL) -> int | None:
+    """The port, with the scheme default read as absent so http://host and
+    https://host compare equal and http://host:80 equals http://host."""
+    if url.port is None or url.port == _SCHEME_DEFAULT_PORTS.get(url.scheme):
+        return None
+    return url.port
+
+
+def scheme_upgrade_target(request_url: httpx.URL, location: str) -> httpx.URL | None:
+    """The https URL to replay against when `location` is the request URL with
+    only its scheme upgraded from http to https, otherwise None."""
+    try:
+        target = request_url.join(location)
+    except httpx.InvalidURL:
+        return None
+    if request_url.scheme != "http" or target.scheme != "https":
+        return None
+    if request_url.host != target.host:
+        return None
+    if _effective_port(request_url) != _effective_port(target):
+        return None
+    if request_url.raw_path != target.raw_path:
+        return None
+    return target.copy_with(fragment=None)
+
+
+def _replayable_body(request: httpx.Request) -> bytes | None:
+    try:
+        return request.content
+    except httpx.RequestNotRead:
+        return None
+
+
+def _refusal(request: httpx.Request, response: httpx.Response) -> RedirectRefusedError:
+    return RedirectRefusedError(
+        url=str(request.url),
+        location=response.headers.get("location"),
+        status=response.status_code,
+    )
+
+
+def _plan_replay(
+    request: httpx.Request, response: httpx.Response
+) -> httpx.Request | None:
+    """The request to send once more, or None when the response is not a
+    redirect. Raises RedirectRefusedError for every redirect that is not an
+    http to https upgrade of the same URL with a replayable body."""
+    if response.status_code not in REDIRECT_STATUSES:
+        return None
+    location = response.headers.get("location")
+    if location is None or response.status_code not in UPGRADE_STATUSES:
+        raise _refusal(request, response)
+    target = scheme_upgrade_target(request.url, location)
+    if target is None:
+        raise _refusal(request, response)
+    body = _replayable_body(request)
+    if body is None:
+        raise _refusal(request, response)
+    return httpx.Request(
+        request.method,
+        target,
+        headers=request.headers,
+        content=body,
+        extensions=request.extensions,
+    )
+
+
+class SchemeUpgradeTransport(httpx.BaseTransport):
+    """Wraps a sync transport and applies the redirect rule to its answers."""
+
+    def __init__(self, transport: httpx.BaseTransport | None = None) -> None:
+        self.transport: httpx.BaseTransport = transport or httpx.HTTPTransport()
+
+    def handle_request(self, request: httpx.Request) -> httpx.Response:
+        response = self.transport.handle_request(request)
+        try:
+            replay = _plan_replay(request, response)
+        finally:
+            if response.status_code in REDIRECT_STATUSES:
+                response.close()
+        if replay is None:
+            return response
+        _warn_once(request.url)
+        upgraded = self.transport.handle_request(replay)
+        if upgraded.status_code in REDIRECT_STATUSES:
+            upgraded.close()
+            raise _refusal(replay, upgraded)
+        return upgraded
+
+    def close(self) -> None:
+        self.transport.close()
+
+
+class AsyncSchemeUpgradeTransport(httpx.AsyncBaseTransport):
+    """Wraps an async transport and applies the redirect rule to its answers."""
+
+    def __init__(self, transport: httpx.AsyncBaseTransport | None = None) -> None:
+        self.transport: httpx.AsyncBaseTransport = (
+            transport or httpx.AsyncHTTPTransport()
+        )
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        response = await self.transport.handle_async_request(request)
+        try:
+            replay = _plan_replay(request, response)
+        finally:
+            if response.status_code in REDIRECT_STATUSES:
+                await response.aclose()
+        if replay is None:
+            return response
+        _warn_once(request.url)
+        upgraded = await self.transport.handle_async_request(replay)
+        if upgraded.status_code in REDIRECT_STATUSES:
+            await upgraded.aclose()
+            raise _refusal(replay, upgraded)
+        return upgraded
+
+    async def aclose(self) -> None:
+        await self.transport.aclose()
+
+
+def _split_transport_kwargs(httpx_kwargs: dict[str, Any]) -> dict[str, Any]:
+    transport_kwargs = {
+        key: httpx_kwargs.pop(key) for key in _TRANSPORT_KWARGS if key in httpx_kwargs
+    }
+    if "trust_env" in httpx_kwargs:
+        transport_kwargs["trust_env"] = httpx_kwargs["trust_env"]
+    return transport_kwargs
+
+
+def _wrap_mounts(client: Any, wrapper: type) -> None:
+    """Proxy settings read from the environment become extra transports on the
+    client. Those must apply the rule too, so they are wrapped in place."""
+    mounts = getattr(client, "_mounts", None)
+    if not isinstance(mounts, dict):
+        return
+    for pattern, transport in list(mounts.items()):
+        if transport is not None and not isinstance(transport, wrapper):
+            mounts[pattern] = wrapper(transport)
+
+
+def create_client(**httpx_kwargs: Any) -> httpx.Client:
+    """An `httpx.Client` for the LangWatch API. Accepts the `httpx.Client`
+    keyword arguments (timeout, headers, base_url, and so on); a `transport`
+    argument becomes the inner transport."""
+    inner = httpx_kwargs.pop("transport", None)
+    transport_kwargs = _split_transport_kwargs(httpx_kwargs)
+    if inner is None:
+        inner = httpx.HTTPTransport(**transport_kwargs)
+    client = httpx.Client(
+        follow_redirects=False,
+        transport=SchemeUpgradeTransport(inner),
+        **httpx_kwargs,
+    )
+    _wrap_mounts(client, SchemeUpgradeTransport)
+    return client
+
+
+def create_async_client(**httpx_kwargs: Any) -> httpx.AsyncClient:
+    """An `httpx.AsyncClient` for the LangWatch API. Accepts the
+    `httpx.AsyncClient` keyword arguments; a `transport` argument becomes the
+    inner transport."""
+    inner = httpx_kwargs.pop("transport", None)
+    transport_kwargs = _split_transport_kwargs(httpx_kwargs)
+    if inner is None:
+        inner = httpx.AsyncHTTPTransport(**transport_kwargs)
+    client = httpx.AsyncClient(
+        follow_redirects=False,
+        transport=AsyncSchemeUpgradeTransport(inner),
+        **httpx_kwargs,
+    )
+    _wrap_mounts(client, AsyncSchemeUpgradeTransport)
+    return client

--- a/sdks/python/src/langwatch/http_client.py
+++ b/sdks/python/src/langwatch/http_client.py
@@ -51,11 +51,6 @@ CREDENTIAL_HEADERS = (
 
 _SCHEME_DEFAULT_PORTS = {"http": 80, "https": 443}
 
-# Keyword arguments that httpx only honours on the transport it builds itself.
-# Passing them to a client that already carries a transport does nothing, so
-# the factories move them onto the inner transport.
-_TRANSPORT_KWARGS = ("verify", "cert", "http1", "http2", "limits", "proxy")
-
 
 class RedirectRefusedError(Exception):
     """A LangWatch request answered with a redirect the SDK will not follow."""
@@ -292,40 +287,34 @@ class AsyncSchemeUpgradeTransport(httpx.AsyncBaseTransport):
         await self.transport.aclose()
 
 
-def _split_transport_kwargs(httpx_kwargs: dict[str, Any]) -> dict[str, Any]:
-    transport_kwargs = {
-        key: httpx_kwargs.pop(key) for key in _TRANSPORT_KWARGS if key in httpx_kwargs
-    }
-    if "trust_env" in httpx_kwargs:
-        transport_kwargs["trust_env"] = httpx_kwargs["trust_env"]
-    return transport_kwargs
+def _wrap_transports(client: Any, wrapper: type) -> None:
+    """Wrap the client's own transports in place, after httpx has built them.
 
+    httpx enables environment proxy discovery only when it builds the transport
+    itself (`allow_env_proxies = trust_env and transport is None`), so handing
+    it a ready-made transport would silently drop HTTP_PROXY, HTTPS_PROXY,
+    ALL_PROXY and the NO_PROXY routing that goes with them. The client is built
+    the stock way and its transport and every proxy mount are wrapped here, so
+    the rule applies to direct and proxied requests alike.
+    """
+    transport = getattr(client, "_transport", None)
+    if transport is not None and not isinstance(transport, wrapper):
+        client._transport = wrapper(transport)
 
-def _wrap_mounts(client: Any, wrapper: type) -> None:
-    """Proxy settings read from the environment become extra transports on the
-    client. Those must apply the rule too, so they are wrapped in place."""
     mounts = getattr(client, "_mounts", None)
     if not isinstance(mounts, dict):
         return
-    for pattern, transport in list(mounts.items()):
-        if transport is not None and not isinstance(transport, wrapper):
-            mounts[pattern] = wrapper(transport)
+    for pattern, mounted in list(mounts.items()):
+        if mounted is not None and not isinstance(mounted, wrapper):
+            mounts[pattern] = wrapper(mounted)
 
 
 def create_client(**httpx_kwargs: Any) -> httpx.Client:
     """An `httpx.Client` for the LangWatch API. Accepts the `httpx.Client`
     keyword arguments (timeout, headers, base_url, and so on); a `transport`
     argument becomes the inner transport."""
-    inner = httpx_kwargs.pop("transport", None)
-    transport_kwargs = _split_transport_kwargs(httpx_kwargs)
-    if inner is None:
-        inner = httpx.HTTPTransport(**transport_kwargs)
-    client = httpx.Client(
-        follow_redirects=False,
-        transport=SchemeUpgradeTransport(inner),
-        **httpx_kwargs,
-    )
-    _wrap_mounts(client, SchemeUpgradeTransport)
+    client = httpx.Client(follow_redirects=False, **httpx_kwargs)
+    _wrap_transports(client, SchemeUpgradeTransport)
     return client
 
 
@@ -333,14 +322,6 @@ def create_async_client(**httpx_kwargs: Any) -> httpx.AsyncClient:
     """An `httpx.AsyncClient` for the LangWatch API. Accepts the
     `httpx.AsyncClient` keyword arguments; a `transport` argument becomes the
     inner transport."""
-    inner = httpx_kwargs.pop("transport", None)
-    transport_kwargs = _split_transport_kwargs(httpx_kwargs)
-    if inner is None:
-        inner = httpx.AsyncHTTPTransport(**transport_kwargs)
-    client = httpx.AsyncClient(
-        follow_redirects=False,
-        transport=AsyncSchemeUpgradeTransport(inner),
-        **httpx_kwargs,
-    )
-    _wrap_mounts(client, AsyncSchemeUpgradeTransport)
+    client = httpx.AsyncClient(follow_redirects=False, **httpx_kwargs)
+    _wrap_transports(client, AsyncSchemeUpgradeTransport)
     return client

--- a/sdks/python/src/langwatch/http_client.py
+++ b/sdks/python/src/langwatch/http_client.py
@@ -7,7 +7,8 @@ transport the caller mounted) from the URL of every hop.
 
 GET and HEAD follow the redirect with the same method, up to five hops. A hop
 that keeps the origin, or only upgrades http to https on the same host and
-port, keeps every header; any other hop drops the credential headers first.
+port, keeps every header; any other hop drops the credential headers and the
+auth the client was built with, so httpx does not sign the hop back in.
 A hop from https to http and a hop without a Location are refused.
 
 Every other method follows exactly one redirect, and only when the Location is
@@ -167,13 +168,19 @@ def _refusal(request: httpx.Request, response: httpx.Response) -> RedirectRefuse
     )
 
 
+def _keeps_credentials(request_url: httpx.URL, target: httpx.URL) -> bool:
+    """Whether a hop may carry the caller's credentials: the same origin, or an
+    https upgrade of the same host and port."""
+    return _same_origin(request_url, target) or _is_scheme_upgrade(request_url, target)
+
+
 def _follow_headers(request: httpx.Request, target: httpx.URL) -> httpx.Headers:
     """The headers a GET or HEAD hop sends. Credentials survive the same origin
     and an https upgrade of the same host; the Host header follows the target."""
     headers = httpx.Headers(request.headers)
     if _same_origin(request.url, target):
         return headers
-    if not _is_scheme_upgrade(request.url, target):
+    if not _keeps_credentials(request.url, target):
         for name in CREDENTIAL_HEADERS:
             headers.pop(name, None)
     headers["Host"] = target.netloc.decode("ascii")
@@ -257,8 +264,9 @@ class LangWatchClient(httpx.Client):
         auth: Any = httpx.USE_CLIENT_DEFAULT,
         follow_redirects: Any = httpx.USE_CLIENT_DEFAULT,
     ) -> httpx.Response:
+        hop_auth = auth
         response = super().send(
-            request, stream=stream, auth=auth, follow_redirects=False
+            request, stream=stream, auth=hop_auth, follow_redirects=False
         )
         hops = 0
         while response.status_code in REDIRECT_STATUSES:
@@ -266,12 +274,14 @@ class LangWatchClient(httpx.Client):
                 next_request = _plan_next(request, response, hops)
             finally:
                 response.close()
+            if not _keeps_credentials(request.url, next_request.url):
+                hop_auth = None
             if _is_scheme_upgrade(request.url, next_request.url):
                 _warn_once(request.url)
             request = next_request
             hops += 1
             response = super().send(
-                request, stream=stream, auth=auth, follow_redirects=False
+                request, stream=stream, auth=hop_auth, follow_redirects=False
             )
         return response
 
@@ -292,8 +302,9 @@ class LangWatchAsyncClient(httpx.AsyncClient):
         auth: Any = httpx.USE_CLIENT_DEFAULT,
         follow_redirects: Any = httpx.USE_CLIENT_DEFAULT,
     ) -> httpx.Response:
+        hop_auth = auth
         response = await super().send(
-            request, stream=stream, auth=auth, follow_redirects=False
+            request, stream=stream, auth=hop_auth, follow_redirects=False
         )
         hops = 0
         while response.status_code in REDIRECT_STATUSES:
@@ -301,12 +312,14 @@ class LangWatchAsyncClient(httpx.AsyncClient):
                 next_request = _plan_next(request, response, hops)
             finally:
                 await response.aclose()
+            if not _keeps_credentials(request.url, next_request.url):
+                hop_auth = None
             if _is_scheme_upgrade(request.url, next_request.url):
                 _warn_once(request.url)
             request = next_request
             hops += 1
             response = await super().send(
-                request, stream=stream, auth=auth, follow_redirects=False
+                request, stream=stream, auth=hop_auth, follow_redirects=False
             )
         return response
 

--- a/sdks/python/src/langwatch/http_client.py
+++ b/sdks/python/src/langwatch/http_client.py
@@ -1,13 +1,21 @@
 """The one HTTP client for every request the SDK sends to the LangWatch API.
 
 httpx never follows a redirect on its own here. The transports in this module
-follow exactly one kind: a 301, 302, 307 or 308 whose Location is the same
-URL with the scheme changed from http to https. That is what an endpoint set
-to `http://app.langwatch.ai` answers with, and following it with the default
-client would turn a POST into a GET and drop the body. The replay keeps the
-method, the headers and the body bytes. Every other redirect is refused with
-`RedirectRefusedError`, so a misconfigured endpoint fails where the caller can
-read it instead of losing the request.
+apply a rule per method to a 301, 302, 303, 307 or 308.
+
+GET and HEAD follow the redirect with the same method, up to five hops. A hop
+that keeps the origin, or only upgrades http to https on the same host and
+port, keeps every header; any other hop drops the credential headers first.
+A hop from https to http and a hop without a Location are refused.
+
+Every other method follows exactly one redirect, and only when the Location is
+the same URL with the scheme changed from http to https. That is what an
+endpoint set to `http://app.langwatch.ai` answers with, and following it with
+the default client would turn a POST into a GET and drop the body. The replay
+keeps the method, the headers and the body bytes.
+
+Every refused redirect raises `RedirectRefusedError`, so a misconfigured
+endpoint fails where the caller can read it instead of losing the request.
 
 Use `create_client` and `create_async_client` instead of `httpx.Client` and
 `httpx.AsyncClient` anywhere the SDK talks to LangWatch.
@@ -21,10 +29,17 @@ import httpx
 
 logger = logging.getLogger(__name__)
 
-# Every status the rule inspects. A 303 is in the set so it is refused with
-# the typed error instead of reaching the caller as a bare response.
+# Every status the rule inspects.
 REDIRECT_STATUSES = frozenset({301, 302, 303, 307, 308})
+# The statuses a method other than GET or HEAD may follow for the upgrade.
 UPGRADE_STATUSES = frozenset({301, 302, 307, 308})
+
+# Methods that follow a redirect to any http or https URL.
+FOLLOWING_METHODS = frozenset({"GET", "HEAD"})
+# The most redirects a GET or HEAD follows before the next one is refused.
+MAX_FOLLOW_HOPS = 5
+# Headers dropped when a GET or HEAD hop leaves the origin.
+CREDENTIAL_HEADERS = ("authorization", "x-auth-token", "x-project-id")
 
 _SCHEME_DEFAULT_PORTS = {"http": 80, "https": 443}
 
@@ -83,6 +98,27 @@ def _effective_port(url: httpx.URL) -> int | None:
     return url.port
 
 
+def _same_host_and_port(request_url: httpx.URL, target: httpx.URL) -> bool:
+    return request_url.host == target.host and _effective_port(
+        request_url
+    ) == _effective_port(target)
+
+
+def _is_scheme_upgrade(request_url: httpx.URL, target: httpx.URL) -> bool:
+    """Same host and port, with the scheme changed from http to https."""
+    return (
+        request_url.scheme == "http"
+        and target.scheme == "https"
+        and _same_host_and_port(request_url, target)
+    )
+
+
+def _same_origin(request_url: httpx.URL, target: httpx.URL) -> bool:
+    return request_url.scheme == target.scheme and _same_host_and_port(
+        request_url, target
+    )
+
+
 def scheme_upgrade_target(request_url: httpx.URL, location: str) -> httpx.URL | None:
     """The https URL to replay against when `location` is the request URL with
     only its scheme upgraded from http to https, otherwise None."""
@@ -90,13 +126,23 @@ def scheme_upgrade_target(request_url: httpx.URL, location: str) -> httpx.URL | 
         target = request_url.join(location)
     except httpx.InvalidURL:
         return None
-    if request_url.scheme != "http" or target.scheme != "https":
-        return None
-    if request_url.host != target.host:
-        return None
-    if _effective_port(request_url) != _effective_port(target):
+    if not _is_scheme_upgrade(request_url, target):
         return None
     if request_url.raw_path != target.raw_path:
+        return None
+    return target.copy_with(fragment=None)
+
+
+def follow_target(request_url: httpx.URL, location: str) -> httpx.URL | None:
+    """The URL a GET or HEAD follows to, or None when the hop is refused: a
+    target that is not http or https, or a downgrade from https to http."""
+    try:
+        target = request_url.join(location)
+    except httpx.InvalidURL:
+        return None
+    if target.scheme not in _SCHEME_DEFAULT_PORTS:
+        return None
+    if request_url.scheme == "https" and target.scheme == "http":
         return None
     return target.copy_with(fragment=None)
 
@@ -116,14 +162,49 @@ def _refusal(request: httpx.Request, response: httpx.Response) -> RedirectRefuse
     )
 
 
-def _plan_replay(
-    request: httpx.Request, response: httpx.Response
-) -> httpx.Request | None:
-    """The request to send once more, or None when the response is not a
-    redirect. Raises RedirectRefusedError for every redirect that is not an
-    http to https upgrade of the same URL with a replayable body."""
-    if response.status_code not in REDIRECT_STATUSES:
-        return None
+def _follow_headers(request: httpx.Request, target: httpx.URL) -> httpx.Headers:
+    """The headers a GET or HEAD hop sends. Credentials survive the same origin
+    and an https upgrade of the same host; the Host header follows the target."""
+    headers = httpx.Headers(request.headers)
+    if _same_origin(request.url, target):
+        return headers
+    if not _is_scheme_upgrade(request.url, target):
+        for name in CREDENTIAL_HEADERS:
+            headers.pop(name, None)
+    headers["Host"] = target.netloc.decode("ascii")
+    return headers
+
+
+def _plan_follow(
+    request: httpx.Request, response: httpx.Response, hops: int
+) -> httpx.Request:
+    """The next GET or HEAD hop. Raises RedirectRefusedError past the hop
+    limit, without a Location, for a downgrade or a target that is not http
+    or https."""
+    if hops >= MAX_FOLLOW_HOPS:
+        raise _refusal(request, response)
+    location = response.headers.get("location")
+    if location is None:
+        raise _refusal(request, response)
+    target = follow_target(request.url, location)
+    if target is None:
+        raise _refusal(request, response)
+    return httpx.Request(
+        request.method,
+        target,
+        headers=_follow_headers(request, target),
+        extensions=request.extensions,
+    )
+
+
+def _plan_upgrade(
+    request: httpx.Request, response: httpx.Response, hops: int
+) -> httpx.Request:
+    """The one replay for a method other than GET or HEAD. Raises
+    RedirectRefusedError for every redirect that is not an http to https
+    upgrade of the same URL with a replayable body, and for a second hop."""
+    if hops >= 1:
+        raise _refusal(request, response)
     location = response.headers.get("location")
     if location is None or response.status_code not in UPGRADE_STATUSES:
         raise _refusal(request, response)
@@ -142,6 +223,15 @@ def _plan_replay(
     )
 
 
+def _plan_next(
+    request: httpx.Request, response: httpx.Response, hops: int
+) -> httpx.Request:
+    """The request to send after a redirect, per the method's rule."""
+    if request.method in FOLLOWING_METHODS:
+        return _plan_follow(request, response, hops)
+    return _plan_upgrade(request, response, hops)
+
+
 class SchemeUpgradeTransport(httpx.BaseTransport):
     """Wraps a sync transport and applies the redirect rule to its answers."""
 
@@ -150,19 +240,18 @@ class SchemeUpgradeTransport(httpx.BaseTransport):
 
     def handle_request(self, request: httpx.Request) -> httpx.Response:
         response = self.transport.handle_request(request)
-        try:
-            replay = _plan_replay(request, response)
-        finally:
-            if response.status_code in REDIRECT_STATUSES:
+        hops = 0
+        while response.status_code in REDIRECT_STATUSES:
+            try:
+                next_request = _plan_next(request, response, hops)
+            finally:
                 response.close()
-        if replay is None:
-            return response
-        _warn_once(request.url)
-        upgraded = self.transport.handle_request(replay)
-        if upgraded.status_code in REDIRECT_STATUSES:
-            upgraded.close()
-            raise _refusal(replay, upgraded)
-        return upgraded
+            if _is_scheme_upgrade(request.url, next_request.url):
+                _warn_once(request.url)
+            request = next_request
+            hops += 1
+            response = self.transport.handle_request(request)
+        return response
 
     def close(self) -> None:
         self.transport.close()
@@ -178,19 +267,18 @@ class AsyncSchemeUpgradeTransport(httpx.AsyncBaseTransport):
 
     async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
         response = await self.transport.handle_async_request(request)
-        try:
-            replay = _plan_replay(request, response)
-        finally:
-            if response.status_code in REDIRECT_STATUSES:
+        hops = 0
+        while response.status_code in REDIRECT_STATUSES:
+            try:
+                next_request = _plan_next(request, response, hops)
+            finally:
                 await response.aclose()
-        if replay is None:
-            return response
-        _warn_once(request.url)
-        upgraded = await self.transport.handle_async_request(replay)
-        if upgraded.status_code in REDIRECT_STATUSES:
-            await upgraded.aclose()
-            raise _refusal(replay, upgraded)
-        return upgraded
+            if _is_scheme_upgrade(request.url, next_request.url):
+                _warn_once(request.url)
+            request = next_request
+            hops += 1
+            response = await self.transport.handle_async_request(request)
+        return response
 
     async def aclose(self) -> None:
         await self.transport.aclose()

--- a/sdks/python/src/langwatch/http_client.py
+++ b/sdks/python/src/langwatch/http_client.py
@@ -38,8 +38,16 @@ UPGRADE_STATUSES = frozenset({301, 302, 307, 308})
 FOLLOWING_METHODS = frozenset({"GET", "HEAD"})
 # The most redirects a GET or HEAD follows before the next one is refused.
 MAX_FOLLOW_HOPS = 5
-# Headers dropped when a GET or HEAD hop leaves the origin.
-CREDENTIAL_HEADERS = ("authorization", "x-auth-token", "x-project-id")
+# Headers dropped when a GET or HEAD hop leaves the origin: the three the Fetch
+# standard strips on a cross-origin redirect, plus the names LangWatch keys on.
+CREDENTIAL_HEADERS = (
+    "authorization",
+    "cookie",
+    "proxy-authorization",
+    "x-api-key",
+    "x-auth-token",
+    "x-project-id",
+)
 
 _SCHEME_DEFAULT_PORTS = {"http": 80, "https": 443}
 

--- a/sdks/python/src/langwatch/http_client.py
+++ b/sdks/python/src/langwatch/http_client.py
@@ -1,7 +1,9 @@
 """The one HTTP client for every request the SDK sends to the LangWatch API.
 
-httpx never follows a redirect on its own here. The transports in this module
-apply a rule per method to a 301, 302, 303, 307 or 308.
+httpx never follows a redirect on its own here. The clients in this module
+apply a rule per method to a 301, 302, 303, 307 or 308, one hop at a time,
+so httpx picks the transport (a proxy mount, a NO_PROXY exemption, or a
+transport the caller mounted) from the URL of every hop.
 
 GET and HEAD follow the redirect with the same method, up to five hops. A hop
 that keeps the origin, or only upgrades http to https on the same host and
@@ -235,14 +237,29 @@ def _plan_next(
     return _plan_upgrade(request, response, hops)
 
 
-class SchemeUpgradeTransport(httpx.BaseTransport):
-    """Wraps a sync transport and applies the redirect rule to its answers."""
+class LangWatchClient(httpx.Client):
+    """An `httpx.Client` that applies the redirect rule to every request.
 
-    def __init__(self, transport: httpx.BaseTransport | None = None) -> None:
-        self.transport: httpx.BaseTransport = transport or httpx.HTTPTransport()
+    Redirects are never followed by httpx itself. Each hop goes through
+    `httpx.Client.send`, which selects the transport for the hop's own URL, so
+    an https replay leaves through the https mount and a hop to another host
+    leaves through that host's mount.
+    """
 
-    def handle_request(self, request: httpx.Request) -> httpx.Response:
-        response = self.transport.handle_request(request)
+    def __init__(self, **httpx_kwargs: Any) -> None:
+        super().__init__(**{**httpx_kwargs, "follow_redirects": False})
+
+    def send(
+        self,
+        request: httpx.Request,
+        *,
+        stream: bool = False,
+        auth: Any = httpx.USE_CLIENT_DEFAULT,
+        follow_redirects: Any = httpx.USE_CLIENT_DEFAULT,
+    ) -> httpx.Response:
+        response = super().send(
+            request, stream=stream, auth=auth, follow_redirects=False
+        )
         hops = 0
         while response.status_code in REDIRECT_STATUSES:
             try:
@@ -253,23 +270,31 @@ class SchemeUpgradeTransport(httpx.BaseTransport):
                 _warn_once(request.url)
             request = next_request
             hops += 1
-            response = self.transport.handle_request(request)
+            response = super().send(
+                request, stream=stream, auth=auth, follow_redirects=False
+            )
         return response
 
-    def close(self) -> None:
-        self.transport.close()
 
+class LangWatchAsyncClient(httpx.AsyncClient):
+    """An `httpx.AsyncClient` that applies the redirect rule to every request,
+    one hop at a time through `httpx.AsyncClient.send`, the same way
+    `LangWatchClient` does."""
 
-class AsyncSchemeUpgradeTransport(httpx.AsyncBaseTransport):
-    """Wraps an async transport and applies the redirect rule to its answers."""
+    def __init__(self, **httpx_kwargs: Any) -> None:
+        super().__init__(**{**httpx_kwargs, "follow_redirects": False})
 
-    def __init__(self, transport: httpx.AsyncBaseTransport | None = None) -> None:
-        self.transport: httpx.AsyncBaseTransport = (
-            transport or httpx.AsyncHTTPTransport()
+    async def send(
+        self,
+        request: httpx.Request,
+        *,
+        stream: bool = False,
+        auth: Any = httpx.USE_CLIENT_DEFAULT,
+        follow_redirects: Any = httpx.USE_CLIENT_DEFAULT,
+    ) -> httpx.Response:
+        response = await super().send(
+            request, stream=stream, auth=auth, follow_redirects=False
         )
-
-    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
-        response = await self.transport.handle_async_request(request)
         hops = 0
         while response.status_code in REDIRECT_STATUSES:
             try:
@@ -280,48 +305,21 @@ class AsyncSchemeUpgradeTransport(httpx.AsyncBaseTransport):
                 _warn_once(request.url)
             request = next_request
             hops += 1
-            response = await self.transport.handle_async_request(request)
+            response = await super().send(
+                request, stream=stream, auth=auth, follow_redirects=False
+            )
         return response
-
-    async def aclose(self) -> None:
-        await self.transport.aclose()
-
-
-def _wrap_transports(client: Any, wrapper: type) -> None:
-    """Wrap the client's own transports in place, after httpx has built them.
-
-    httpx enables environment proxy discovery only when it builds the transport
-    itself (`allow_env_proxies = trust_env and transport is None`), so handing
-    it a ready-made transport would silently drop HTTP_PROXY, HTTPS_PROXY,
-    ALL_PROXY and the NO_PROXY routing that goes with them. The client is built
-    the stock way and its transport and every proxy mount are wrapped here, so
-    the rule applies to direct and proxied requests alike.
-    """
-    transport = getattr(client, "_transport", None)
-    if transport is not None and not isinstance(transport, wrapper):
-        client._transport = wrapper(transport)
-
-    mounts = getattr(client, "_mounts", None)
-    if not isinstance(mounts, dict):
-        return
-    for pattern, mounted in list(mounts.items()):
-        if mounted is not None and not isinstance(mounted, wrapper):
-            mounts[pattern] = wrapper(mounted)
 
 
 def create_client(**httpx_kwargs: Any) -> httpx.Client:
-    """An `httpx.Client` for the LangWatch API. Accepts the `httpx.Client`
-    keyword arguments (timeout, headers, base_url, and so on); a `transport`
-    argument becomes the inner transport."""
-    client = httpx.Client(follow_redirects=False, **httpx_kwargs)
-    _wrap_transports(client, SchemeUpgradeTransport)
-    return client
+    """A `LangWatchClient` for the LangWatch API. Accepts the `httpx.Client`
+    keyword arguments (timeout, headers, base_url, transport, mounts, and so
+    on) and passes them to httpx unchanged, so environment proxy discovery
+    works the stock way."""
+    return LangWatchClient(**httpx_kwargs)
 
 
 def create_async_client(**httpx_kwargs: Any) -> httpx.AsyncClient:
-    """An `httpx.AsyncClient` for the LangWatch API. Accepts the
-    `httpx.AsyncClient` keyword arguments; a `transport` argument becomes the
-    inner transport."""
-    client = httpx.AsyncClient(follow_redirects=False, **httpx_kwargs)
-    _wrap_transports(client, AsyncSchemeUpgradeTransport)
-    return client
+    """A `LangWatchAsyncClient` for the LangWatch API. Accepts the
+    `httpx.AsyncClient` keyword arguments and passes them to httpx unchanged."""
+    return LangWatchAsyncClient(**httpx_kwargs)

--- a/sdks/python/src/langwatch/login.py
+++ b/sdks/python/src/langwatch/login.py
@@ -1,6 +1,5 @@
-import httpx
-
 import langwatch
+from langwatch.http_client import create_client
 from langwatch.utils.exceptions import better_raise_for_status
 from .state import get_api_key, get_endpoint
 from getpass import getpass
@@ -19,11 +18,12 @@ def login(relogin=False):
     if not api_key:
         raise ValueError("API key was not set")
 
-    response = httpx.post(
-        f"{get_endpoint()}/api/auth/validate",
-        headers={"X-Auth-Token": api_key or ""},
-        json={},
-    )
+    with create_client() as client:
+        response = client.post(
+            f"{get_endpoint()}/api/auth/validate",
+            headers={"X-Auth-Token": api_key or ""},
+            json={},
+        )
     if response.status_code == 401:
         raise ValueError("API key is not valid, please try to login again")
     better_raise_for_status(response)

--- a/sdks/python/src/langwatch/telemetry/tracing.py
+++ b/sdks/python/src/langwatch/telemetry/tracing.py
@@ -7,6 +7,7 @@ import threading
 from deprecated import deprecated
 from tenacity import retry, retry_if_exception, stop_after_attempt, wait_exponential
 from langwatch.attributes import AttributeKey
+from langwatch.http_client import create_client
 from langwatch.utils.auth import build_auth_headers
 from langwatch.utils.exceptions import better_raise_for_status
 from langwatch.utils.transformation import (
@@ -365,7 +366,7 @@ class LangWatchTrace:
 
         @_retry_on_transient
         def _do_share() -> str:
-            with httpx.Client() as client:
+            with create_client() as client:
                 response = client.post(
                     f"{endpoint}/api/trace/{trace_id}/share",
                     headers=build_auth_headers(get_api_key()),
@@ -387,7 +388,7 @@ class LangWatchTrace:
 
         @_retry_on_transient
         def _do_unshare() -> None:
-            with httpx.Client() as client:
+            with create_client() as client:
                 response = client.post(
                     f"{endpoint}/api/trace/{trace_id}/unshare",
                     headers=build_auth_headers(get_api_key()),

--- a/sdks/python/src/langwatch/workflow/__init__.py
+++ b/sdks/python/src/langwatch/workflow/__init__.py
@@ -17,8 +17,6 @@ result.results  # per-row DataFrame, same shape as experiment.run(...).results
 from typing import Any, Callable, Dict, List, Optional, Union
 from urllib.parse import urlparse
 
-import httpx
-
 import langwatch
 from langwatch.experiment.platform_run import (
     ExperimentRunResult,
@@ -27,6 +25,7 @@ from langwatch.experiment.platform_run import (
     _poll_until_complete,
     _replace_url_domain,
 )
+from langwatch.http_client import create_client
 from langwatch.state import get_api_key, get_endpoint
 from langwatch.utils.auth import build_auth_headers
 
@@ -152,7 +151,7 @@ def _evaluate_workflow(
     workflow_id: str, endpoint: str, api_key: str, body: Dict[str, Any]
 ) -> dict:
     """Kick off a workflow evaluation run."""
-    with httpx.Client(timeout=60) as client:
+    with create_client(timeout=60) as client:
         response = client.post(
             f"{endpoint}/api/workflows/{workflow_id}/evaluate",
             headers=build_auth_headers(api_key),

--- a/sdks/python/tests/dspy_tracking/test_gepa_tracking.py
+++ b/sdks/python/tests/dspy_tracking/test_gepa_tracking.py
@@ -11,6 +11,8 @@ import pytest
 from dspy.teleprompt import GEPA
 
 import langwatch
+import httpx
+from langwatch.http_client import create_client
 import langwatch.dspy
 from langwatch.dspy import (
     DSPyExample,
@@ -51,17 +53,17 @@ def sent_steps(monkeypatch) -> list[DSPyStep]:
 class TestWhenInitReceivesAGepaOptimizer:
     # @scenario "init recognises a GEPA optimizer"
     def test_patches_the_optimizer_for_tracking(self, monkeypatch, capsys):
-        class Response:
-            status_code = 200
-
-            def json(self):
-                return {"path": "/project/experiments/experiment"}
-
-            def raise_for_status(self):
-                return None
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200, json={"path": "/project/experiments/experiment"}
+            )
 
         monkeypatch.setattr(langwatch, "get_api_key", lambda: "key")
-        monkeypatch.setattr(langwatch.dspy.httpx, "post", lambda *a, **k: Response())
+        monkeypatch.setattr(
+            langwatch.dspy,
+            "create_client",
+            lambda **kwargs: create_client(transport=httpx.MockTransport(handler)),
+        )
         optimizer = build_optimizer()
 
         langwatch.dspy.init(experiment="experiment", optimizer=optimizer, run_id="run")

--- a/sdks/python/tests/dspy_tracking/test_step_delivery.py
+++ b/sdks/python/tests/dspy_tracking/test_step_delivery.py
@@ -10,6 +10,7 @@ import pytest
 
 import langwatch
 import langwatch.dspy
+from langwatch.http_client import create_client
 from langwatch.dspy import (
     DSPyOptimizer,
     LangWatchGEPACallback,
@@ -26,12 +27,12 @@ class Posts:
         self.statuses: list[int] = []
         self.bodies: list[list[dict]] = []
 
-    def post(self, url, **kwargs):
-        self.bodies.append(json.loads(kwargs["data"]))
-        return httpx.Response(
-            self.statuses.pop(0) if self.statuses else 200,
-            request=httpx.Request("POST", url),
-        )
+    def handle(self, request: httpx.Request) -> httpx.Response:
+        self.bodies.append(json.loads(request.content))
+        return httpx.Response(self.statuses.pop(0) if self.statuses else 200)
+
+    def client(self, **kwargs) -> httpx.Client:
+        return create_client(transport=httpx.MockTransport(self.handle))
 
 
 @pytest.fixture
@@ -44,7 +45,7 @@ def posts(monkeypatch) -> Posts:
     langwatch_dspy.workflow_version_id = None
     langwatch_dspy.reset()
     monkeypatch.setattr(langwatch, "get_api_key", lambda: "key")
-    monkeypatch.setattr(langwatch.dspy.httpx, "post", posts.post)
+    monkeypatch.setattr(langwatch.dspy, "create_client", posts.client)
     monkeypatch.setattr(langwatch.dspy.time, "sleep", lambda seconds: None)
     return posts
 

--- a/sdks/python/tests/evaluation/test_evaluate.py
+++ b/sdks/python/tests/evaluation/test_evaluate.py
@@ -85,7 +85,7 @@ class TestEvaluationResultModel:
 class TestEvaluate:
     """Tests for evaluate() function."""
 
-    @patch("langwatch.evaluation.httpx.Client")
+    @patch("langwatch.evaluation.create_client")
     @patch("langwatch.evaluation.langwatch.span")
     @patch("langwatch.evaluation.get_current_span")
     @patch("langwatch.evaluation.get_endpoint")
@@ -150,7 +150,7 @@ class TestEvaluate:
             call_args
         )
 
-    @patch("langwatch.evaluation.httpx.Client")
+    @patch("langwatch.evaluation.create_client")
     @patch("langwatch.evaluation.langwatch.span")
     @patch("langwatch.evaluation.get_current_span")
     @patch("langwatch.evaluation.get_endpoint")
@@ -208,7 +208,7 @@ class TestEvaluate:
             name="presidio/pii_detection", type="guardrail"
         )
 
-    @patch("langwatch.evaluation.httpx.Client")
+    @patch("langwatch.evaluation.create_client")
     @patch("langwatch.evaluation.langwatch.span")
     @patch("langwatch.evaluation.get_current_span")
     @patch("langwatch.evaluation.get_endpoint")
@@ -257,7 +257,7 @@ class TestEvaluate:
         assert result.passed is True
         assert "Network error" in result.details
 
-    @patch("langwatch.evaluation.httpx.Client")
+    @patch("langwatch.evaluation.create_client")
     @patch("langwatch.evaluation.langwatch.span")
     @patch("langwatch.evaluation.get_current_span")
     @patch("langwatch.evaluation.get_endpoint")
@@ -312,7 +312,7 @@ class TestAsyncEvaluate:
     """Tests for async_evaluate() function."""
 
     @pytest.mark.asyncio
-    @patch("langwatch.evaluation.httpx.AsyncClient")
+    @patch("langwatch.evaluation.create_async_client")
     @patch("langwatch.evaluation.langwatch.span")
     @patch("langwatch.evaluation.get_current_span")
     @patch("langwatch.evaluation.get_endpoint")

--- a/sdks/python/tests/experiment/test_async_trace_isolation.py
+++ b/sdks/python/tests/experiment/test_async_trace_isolation.py
@@ -15,11 +15,13 @@ import threading
 import time
 from unittest.mock import MagicMock, patch
 
+import httpx
 import pandas as pd
 import pytest
 
 import langwatch
 from langwatch.experiment.experiment import Experiment
+from langwatch.http_client import create_client
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -59,17 +61,18 @@ def experiment(monkeypatch):
 
 
 def _mock_http_capture():
+    """A create_client stand-in whose transport records every JSON body sent
+    and answers 200, plus the list it records into."""
     captured = []
 
-    def mock_post(*args, **kwargs):
-        body = json.loads(kwargs.get("data", "{}"))
-        captured.append(body)
-        response = MagicMock()
-        response.status_code = 200
-        response.raise_for_status = MagicMock()
-        return response
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(json.loads(request.content))
+        return httpx.Response(200)
 
-    return captured, mock_post
+    def client_factory(**kwargs):
+        return create_client(transport=httpx.MockTransport(handler))
+
+    return captured, client_factory
 
 
 @pytest.mark.unit
@@ -345,7 +348,7 @@ class TestAsyncHttpPayload:
 
     @pytest.mark.asyncio
     async def test_batch_payload_contains_unique_trace_ids(self):
-        captured, mock_post = _mock_http_capture()
+        captured, client_factory = _mock_http_capture()
 
         experiment = Experiment("test-async-batch")
         experiment.initialized = True
@@ -355,7 +358,7 @@ class TestAsyncHttpPayload:
         async def task(row):
             await asyncio.sleep(0.005)
 
-        with patch("httpx.post", side_effect=mock_post):
+        with patch("langwatch.experiment.experiment.create_client", client_factory):
             async for _index, row in experiment.aloop(df.iterrows(), concurrency=3, total=6):
                 experiment.asubmit(task, row)
 
@@ -371,7 +374,7 @@ class TestAsyncHttpPayload:
 
     @pytest.mark.asyncio
     async def test_final_batch_includes_finished_at(self):
-        captured, mock_post = _mock_http_capture()
+        captured, client_factory = _mock_http_capture()
 
         experiment = Experiment("test-async-finished")
         experiment.initialized = True
@@ -379,7 +382,7 @@ class TestAsyncHttpPayload:
         async def task(item):
             await asyncio.sleep(0.005)
 
-        with patch("httpx.post", side_effect=mock_post):
+        with patch("langwatch.experiment.experiment.create_client", client_factory):
             async for item in experiment.aloop([1, 2, 3], concurrency=2):
                 experiment.asubmit(task, item)
 

--- a/sdks/python/tests/experiment/test_async_trace_parentage.py
+++ b/sdks/python/tests/experiment/test_async_trace_parentage.py
@@ -15,6 +15,10 @@ import time
 from typing import Sequence
 from unittest.mock import MagicMock, patch
 
+import httpx
+
+from langwatch.http_client import create_client
+
 import pandas as pd
 import pytest
 from opentelemetry import trace as trace_api
@@ -178,6 +182,17 @@ class TestTraceParentage:
         )
 
 
+def _capturing_client_factory(bucket):
+    """A create_client stand-in whose transport records every JSON body sent
+    and answers 200."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        bucket.append(json.loads(request.content))
+        return httpx.Response(200)
+
+    return lambda **kwargs: create_client(transport=httpx.MockTransport(handler))
+
+
 class TestThreadingAsyncParity:
     """Running the same workload through `loop`/`submit` and `aloop`/`asubmit`
     must produce equivalent batch output. No drift, no regression."""
@@ -186,21 +201,15 @@ class TestThreadingAsyncParity:
         captured_threading = []
         captured_async = []
 
-        def mock_post_factory(bucket):
-            def mock_post(*args, **kwargs):
-                bucket.append(json.loads(kwargs.get("data", "{}")))
-                response = MagicMock()
-                response.status_code = 200
-                response.raise_for_status = MagicMock()
-                return response
-            return mock_post
-
         df = pd.DataFrame([{"q": f"Q{i}"} for i in range(6)])
 
         # Threading path
         ev_t = Experiment("parity-threading")
         ev_t.initialized = True
-        with patch("httpx.post", side_effect=mock_post_factory(captured_threading)):
+        with patch(
+            "langwatch.experiment.experiment.create_client",
+            _capturing_client_factory(captured_threading),
+        ):
             for index, row in ev_t.loop(df.iterrows(), threads=3):
                 def task_t(index, row):
                     time.sleep(0.005)
@@ -214,7 +223,10 @@ class TestThreadingAsyncParity:
             async def task_a(row):
                 await asyncio.sleep(0.005)
 
-            with patch("httpx.post", side_effect=mock_post_factory(captured_async)):
+            with patch(
+                "langwatch.experiment.experiment.create_client",
+                _capturing_client_factory(captured_async),
+            ):
                 async for _index, row in ev_a.aloop(df.iterrows(), concurrency=3, total=6):
                     ev_a.asubmit(task_a, row)
 

--- a/sdks/python/tests/experiment/test_comparison.py
+++ b/sdks/python/tests/experiment/test_comparison.py
@@ -131,8 +131,8 @@ def judge(monkeypatch) -> _Judge:
         def get_span_context(self) -> _FakeSpanContext:
             return _FakeSpanContext()
 
-    monkeypatch.setattr(langwatch.evaluation.httpx, "Client", _FakeClient)
-    monkeypatch.setattr(langwatch.evaluation.httpx, "AsyncClient", _FakeAsyncClient)
+    monkeypatch.setattr(langwatch.evaluation, "create_client", _FakeClient)
+    monkeypatch.setattr(langwatch.evaluation, "create_async_client", _FakeAsyncClient)
     monkeypatch.setattr(
         langwatch.evaluation, "get_endpoint", lambda: "https://app.langwatch.test"
     )

--- a/sdks/python/tests/experiment/test_server_run_results.py
+++ b/sdks/python/tests/experiment/test_server_run_results.py
@@ -1,6 +1,6 @@
 """Unit tests for server-side ``langwatch.experiment.run`` with per-row results.
 
-These mock the HTTP boundary (``httpx.Client``) so we assert exactly what JSON body
+These mock the HTTP boundary (``create_client``) so we assert exactly what JSON body
 the SDK posts to ``/api/evaluations/v3/{slug}/run`` and that ``result.results``
 materializes the expected per-row DataFrame from the ``/results`` response.
 
@@ -158,7 +158,7 @@ class TestExperimentRunWithInlineData:
         _script_full_run()
         rows = [{"question": "what is AI?"}, {"question": "what is ML?"}]
 
-        with patch.object(platform_run.httpx, "Client", _FakeClient):
+        with patch.object(platform_run, "create_client", _FakeClient):
             result = experiment_run("rag-eval", data=rows, poll_interval=0)
 
             # Body carries inline data and no dataset id.
@@ -184,7 +184,7 @@ class TestExperimentRunWithInlineData:
 
     def test_results_request_includes_experiment_slug(self):
         _script_full_run()
-        with patch.object(platform_run.httpx, "Client", _FakeClient):
+        with patch.object(platform_run, "create_client", _FakeClient):
             result = experiment_run("rag-eval", data=[{"q": "x"}], poll_interval=0)
             _ = result.results
             results_get = next(
@@ -194,7 +194,7 @@ class TestExperimentRunWithInlineData:
 
     def test_results_are_cached_after_first_access(self):
         _script_full_run()
-        with patch.object(platform_run.httpx, "Client", _FakeClient):
+        with patch.object(platform_run, "create_client", _FakeClient):
             result = experiment_run("rag-eval", data=[{"q": "x"}], poll_interval=0)
             _ = result.results
             _ = result.results
@@ -211,7 +211,7 @@ class TestExperimentRunWithDataFrame:
         _script_full_run()
         frame = pd.DataFrame([{"question": "a"}, {"question": "b"}])
 
-        with patch.object(platform_run.httpx, "Client", _FakeClient):
+        with patch.object(platform_run, "create_client", _FakeClient):
             experiment_run("rag-eval", data=frame, poll_interval=0)
 
         run_post = next(p for p in _FakeClient.captured_posts if "/run" in p["url"])
@@ -223,7 +223,7 @@ class TestExperimentRunWithDatasetId:
 
     def test_posts_dataset_id_and_no_inline_data(self):
         _script_full_run()
-        with patch.object(platform_run.httpx, "Client", _FakeClient):
+        with patch.object(platform_run, "create_client", _FakeClient):
             experiment_run("rag-eval", dataset_id="ds_abc", poll_interval=0)
 
         run_post = next(p for p in _FakeClient.captured_posts if "/run" in p["url"])
@@ -236,7 +236,7 @@ class TestExperimentRunWithParameters:
 
     def test_parameters_are_sent_in_body(self):
         _script_full_run()
-        with patch.object(platform_run.httpx, "Client", _FakeClient):
+        with patch.object(platform_run, "create_client", _FakeClient):
             experiment_run(
                 "rag-eval", parameters={"model": "gpt-5-mini"}, poll_interval=0
             )
@@ -250,7 +250,7 @@ class TestExperimentRunWithNoBody:
 
     def test_sends_json_none_to_preserve_no_body_behavior(self):
         _script_full_run()
-        with patch.object(platform_run.httpx, "Client", _FakeClient):
+        with patch.object(platform_run, "create_client", _FakeClient):
             experiment_run("rag-eval", poll_interval=0)
 
         run_post = next(p for p in _FakeClient.captured_posts if "/run" in p["url"])
@@ -261,7 +261,7 @@ class TestExperimentRunValidation:
     """when both inline data and a dataset id are provided"""
 
     def test_raises_value_error_before_any_http_call(self):
-        with patch.object(platform_run.httpx, "Client", _FakeClient):
+        with patch.object(platform_run, "create_client", _FakeClient):
             with pytest.raises(ValueError):
                 experiment_run("rag-eval", data=[{"q": "x"}], dataset_id="ds_abc")
 
@@ -313,7 +313,7 @@ class TestExperimentRunResultsRetry:
                     return _FakeResponse(200, _results_payload())
                 return _FakeResponse(200, status_payload)
 
-        with patch.object(platform_run.httpx, "Client", _LaggyClient):
+        with patch.object(platform_run, "create_client", _LaggyClient):
             result = experiment_run("rag-eval", data=[{"q": "x"}], poll_interval=0)
             df = result.results
             assert len(df) == 2

--- a/sdks/python/tests/experiment/test_target_trace_isolation.py
+++ b/sdks/python/tests/experiment/test_target_trace_isolation.py
@@ -11,9 +11,12 @@ import time
 import pandas as pd
 import pytest
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
+
+import httpx
 
 import langwatch
+from langwatch.http_client import create_client
 from langwatch.experiment.experiment import (
     Experiment,
     _iteration_context,
@@ -111,20 +114,23 @@ class TestTraceIdUniqueness:
             f"Expected 6 unique trace_ids, got {len(set(all_ids))}: {all_ids}"
 
 
+def _capturing_client_factory(bucket):
+    """A create_client stand-in whose transport records every JSON body sent
+    and answers 200."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        bucket.append(json.loads(request.content))
+        return httpx.Response(200)
+
+    return lambda **kwargs: create_client(transport=httpx.MockTransport(handler))
+
+
 class TestTraceIdInHttpPayload:
     """Integration tests that verify trace_ids in the actual HTTP payload."""
 
     def test_http_payload_has_unique_trace_ids_per_target(self):
         """Mock HTTP and verify the payload has unique trace_ids."""
         captured_bodies = []
-
-        def mock_post(*args, **kwargs):
-            body = json.loads(kwargs.get("data", "{}"))
-            captured_bodies.append(body)
-            response = MagicMock()
-            response.status_code = 200
-            response.raise_for_status = MagicMock()
-            return response
 
         evaluation = Experiment("test-trace-payload")
         evaluation.initialized = True
@@ -134,7 +140,10 @@ class TestTraceIdInHttpPayload:
             {"question": "Question B"},
         ])
 
-        with patch("httpx.post", side_effect=mock_post):
+        with patch(
+            "langwatch.experiment.experiment.create_client",
+            _capturing_client_factory(captured_bodies),
+        ):
             for index, row in evaluation.loop(df.iterrows(), threads=2):
                 def run(index, row):
                     with evaluation.target("gpt-4"):

--- a/sdks/python/tests/experiment/test_with_target_integration.py
+++ b/sdks/python/tests/experiment/test_with_target_integration.py
@@ -334,21 +334,24 @@ class TestRaceConditionPrevention:
         iteration context, but multiple target() calls within the same submitted
         function should all use that same iteration context.
         """
-        import pandas as pd
         import json
-        from unittest.mock import patch, MagicMock
-        import langwatch
 
-        # Mock HTTP to capture what gets sent
+        import httpx
+        import pandas as pd
+        from unittest.mock import patch
+
+        import langwatch
+        from langwatch.http_client import create_client
+
+        # Record every batch body the experiment sends.
         captured_bodies = []
 
-        def mock_post(*args, **kwargs):
-            body = json.loads(kwargs.get("data", "{}"))
-            captured_bodies.append(body)
-            response = MagicMock()
-            response.status_code = 200
-            response.raise_for_status = MagicMock()
-            return response
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured_bodies.append(json.loads(request.content))
+            return httpx.Response(200)
+
+        def client_factory(**kwargs):
+            return create_client(transport=httpx.MockTransport(handler))
 
         # Setup langwatch
         langwatch._api_key = "test-key"
@@ -365,7 +368,7 @@ class TestRaceConditionPrevention:
             {"question": "Question C"},
         ])
 
-        with patch("httpx.post", side_effect=mock_post):
+        with patch("langwatch.experiment.experiment.create_client", client_factory):
             for index, row in evaluation.loop(df.iterrows(), threads=3):
                 def task(index, row):
                     # First target

--- a/sdks/python/tests/telemetry/test_tracing.py
+++ b/sdks/python/tests/telemetry/test_tracing.py
@@ -119,7 +119,7 @@ def test_share_retries_on_transient_timeout(monkeypatch):
                 request=httpx.Request("POST", url),
             )
 
-    monkeypatch.setattr(httpx, "Client", lambda: _FakeClient())
+    monkeypatch.setattr("langwatch.telemetry.tracing.create_client", lambda **kwargs: _FakeClient())
     # Collapse tenacity's exponential backoff so the test is fast.
     import time as time_module
 
@@ -149,7 +149,7 @@ def test_share_gives_up_after_max_attempts(monkeypatch):
             call_count["n"] += 1
             raise httpx.ReadTimeout("read operation timed out")
 
-    monkeypatch.setattr(httpx, "Client", lambda: _FakeClient())
+    monkeypatch.setattr("langwatch.telemetry.tracing.create_client", lambda **kwargs: _FakeClient())
     import time as time_module
 
     monkeypatch.setattr(time_module, "sleep", lambda *a, **kw: None)

--- a/sdks/python/tests/test_http_client.py
+++ b/sdks/python/tests/test_http_client.py
@@ -342,6 +342,28 @@ def test_get_drops_credentials_on_another_host(caplog: pytest.LogCaptureFixture)
 
 
 # @scenario "a GET drops credential headers on a cross origin redirect"
+def test_get_drops_cookie_proxy_auth_and_api_key_on_another_host():
+    handler, seen = scripted(redirect(302, OTHER_HOST), httpx.Response(200))
+
+    with sync_client(handler) as client:
+        client.get(
+            HTTPS_URL,
+            headers={
+                **CREDENTIALS,
+                "Cookie": "session=secret",
+                "Proxy-Authorization": "Basic c2VjcmV0",
+                "X-Api-Key": "sk-lw-test",
+            },
+        )
+
+    second = seen[1]
+    assert "cookie" not in second.headers
+    assert "proxy-authorization" not in second.headers
+    assert "x-api-key" not in second.headers
+    assert second.headers["x-trace"] == "abc"
+
+
+# @scenario "a GET drops credential headers on a cross origin redirect"
 def test_get_drops_credentials_on_another_port():
     handler, seen = scripted(
         redirect(302, "https://langwatch.test:8443/api/v1/things?page=2"),

--- a/sdks/python/tests/test_http_client.py
+++ b/sdks/python/tests/test_http_client.py
@@ -1,0 +1,326 @@
+"""Unit coverage for the shared HTTP client: an http to https upgrade of the
+same URL is followed once with the same method, headers and body, every other
+redirect raises RedirectRefusedError, the generated REST client carries the
+transport, and no hand written call builds its own httpx client. The inner
+transport is httpx.MockTransport, so the assertions are on the requests that
+leave the process.
+
+Spec: specs/python-sdk/http-client-redirects.feature
+"""
+
+import json
+import logging
+import re
+from collections.abc import Callable
+from pathlib import Path
+
+import httpx
+import pytest
+
+from langwatch.client import Client
+from langwatch.http_client import (
+    AsyncSchemeUpgradeTransport,
+    RedirectRefusedError,
+    SchemeUpgradeTransport,
+    _reset_upgrade_warning,
+    create_async_client,
+    create_client,
+    scheme_upgrade_target,
+)
+
+HTTP_URL = "http://langwatch.test/api/v1/things?page=2"
+HTTPS_URL = "https://langwatch.test/api/v1/things?page=2"
+
+
+@pytest.fixture(autouse=True)
+def fresh_warning():
+    _reset_upgrade_warning()
+    yield
+    _reset_upgrade_warning()
+
+
+def redirecting(
+    status: int = 301,
+    location: str | None = HTTPS_URL,
+    after_upgrade: Callable[[httpx.Request], httpx.Response] | None = None,
+):
+    """A handler that redirects every http request and answers every https
+    request with 200 (or `after_upgrade`), plus the requests it saw."""
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        if request.url.scheme == "http":
+            headers = {} if location is None else {"location": location}
+            return httpx.Response(status, headers=headers)
+        if after_upgrade is not None:
+            return after_upgrade(request)
+        return httpx.Response(200, json={"ok": True})
+
+    return handler, seen
+
+
+def sync_client(handler) -> httpx.Client:
+    return create_client(transport=httpx.MockTransport(handler))
+
+
+def async_client(handler) -> httpx.AsyncClient:
+    return create_async_client(transport=httpx.MockTransport(handler))
+
+
+# @scenario "follows a redirect that only upgrades http to https"
+@pytest.mark.parametrize("status", [301, 302, 307, 308])
+def test_follows_the_scheme_upgrade_once(status: int):
+    handler, seen = redirecting(status=status)
+
+    with sync_client(handler) as client:
+        response = client.get(HTTP_URL)
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+    assert [str(r.url) for r in seen] == [HTTP_URL, HTTPS_URL]
+
+
+# @scenario "follows a redirect that only upgrades http to https"
+@pytest.mark.asyncio
+async def test_follows_the_scheme_upgrade_once_async():
+    handler, seen = redirecting()
+
+    async with async_client(handler) as client:
+        response = await client.get(HTTP_URL)
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+    assert [str(r.url) for r in seen] == [HTTP_URL, HTTPS_URL]
+
+
+# @scenario "follows a redirect that only upgrades http to https"
+def test_fragment_and_default_port_do_not_block_the_upgrade():
+    request_url = httpx.URL("http://langwatch.test:80/api/v1/things?page=2")
+
+    assert scheme_upgrade_target(request_url, HTTPS_URL + "#top") == httpx.URL(
+        HTTPS_URL
+    )
+    assert scheme_upgrade_target(
+        httpx.URL("http://langwatch.test:8080/api"), "https://langwatch.test:8080/api"
+    ) == httpx.URL("https://langwatch.test:8080/api")
+    assert (
+        scheme_upgrade_target(
+            httpx.URL("http://langwatch.test:8080/api"), "https://langwatch.test/api"
+        )
+        is None
+    )
+
+
+# @scenario "replays the same method, headers and body on the upgrade"
+def test_replays_method_headers_and_body():
+    handler, seen = redirecting(status=307)
+    body = {"name": "ACME", "rows": [1, 2, 3]}
+
+    with sync_client(handler) as client:
+        response = client.post(
+            HTTP_URL,
+            headers={"Authorization": "Bearer sk-lw-test", "X-Trace": "abc"},
+            json=body,
+        )
+
+    assert response.status_code == 200
+    first, second = seen
+    assert second.method == "POST"
+    assert str(second.url) == HTTPS_URL
+    assert second.headers["authorization"] == "Bearer sk-lw-test"
+    assert second.headers["x-trace"] == "abc"
+    assert second.headers["content-type"] == first.headers["content-type"]
+    assert second.content == first.content
+    assert json.loads(second.content) == body
+
+
+# @scenario "replays the same method, headers and body on the upgrade"
+@pytest.mark.asyncio
+async def test_replays_method_headers_and_body_async():
+    handler, seen = redirecting(status=308)
+
+    async with async_client(handler) as client:
+        await client.put(
+            HTTP_URL, headers={"Authorization": "Bearer k"}, content=b"raw"
+        )
+
+    first, second = seen
+    assert second.method == "PUT"
+    assert second.headers["authorization"] == "Bearer k"
+    assert second.content == first.content == b"raw"
+
+
+# @scenario "warns once per process about an http endpoint"
+def test_warns_once_per_process(caplog: pytest.LogCaptureFixture):
+    handler, _ = redirecting()
+
+    with (
+        caplog.at_level(logging.WARNING, logger="langwatch.http_client"),
+        sync_client(handler) as client,
+    ):
+        client.get(HTTP_URL)
+        client.get(HTTP_URL)
+
+    warnings = [r for r in caplog.records if r.name == "langwatch.http_client"]
+    assert len(warnings) == 1
+    assert warnings[0].getMessage() == (
+        "LangWatch endpoint http://langwatch.test redirected to https. "
+        "Set the endpoint to https://langwatch.test to skip the extra round trip."
+    )
+
+
+# @scenario "refuses a redirect to another host"
+def test_refuses_another_host():
+    other = "https://other.test/api/v1/things?page=2"
+    handler, seen = redirecting(location=other)
+
+    with sync_client(handler) as client, pytest.raises(RedirectRefusedError) as raised:
+        client.get(HTTP_URL)
+
+    error = raised.value
+    assert error.url == HTTP_URL
+    assert error.location == other
+    assert error.status == 301
+    assert str(error) == (
+        f"LangWatch refused to follow a redirect from {HTTP_URL} to {other} "
+        "(HTTP 301). Set the endpoint to the final URL."
+    )
+    assert len(seen) == 1
+
+
+# @scenario "refuses a redirect to another host"
+@pytest.mark.asyncio
+async def test_refuses_another_host_async():
+    handler, seen = redirecting(location="https://other.test/api/v1/things?page=2")
+
+    async with async_client(handler) as client:
+        with pytest.raises(RedirectRefusedError) as raised:
+            await client.post(HTTP_URL, json={})
+
+    assert raised.value.status == 301
+    assert len(seen) == 1
+
+
+# @scenario "refuses a redirect that changes the path or query"
+@pytest.mark.parametrize(
+    "location",
+    [
+        "https://langwatch.test/api/v2/things?page=2",
+        "https://langwatch.test/api/v1/things?page=3",
+        "https://langwatch.test/api/v1/things",
+    ],
+)
+def test_refuses_a_changed_path_or_query(location: str):
+    handler, _ = redirecting(status=308, location=location)
+
+    with sync_client(handler) as client, pytest.raises(RedirectRefusedError) as raised:
+        client.get(HTTP_URL)
+
+    assert raised.value.location == location
+    assert raised.value.status == 308
+
+
+# @scenario "refuses a downgrade from https to http"
+def test_refuses_a_downgrade():
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(301, headers={"location": HTTP_URL})
+
+    with sync_client(handler) as client, pytest.raises(RedirectRefusedError) as raised:
+        client.get(HTTPS_URL)
+
+    assert raised.value.url == HTTPS_URL
+    assert raised.value.location == HTTP_URL
+    assert len(seen) == 1
+
+
+# @scenario "refuses a 303"
+def test_refuses_a_303():
+    handler, seen = redirecting(status=303)
+
+    with sync_client(handler) as client, pytest.raises(RedirectRefusedError) as raised:
+        client.post(HTTP_URL, json={"a": 1})
+
+    assert raised.value.status == 303
+    assert raised.value.location == HTTPS_URL
+    assert len(seen) == 1
+
+
+# @scenario "refuses a second redirect after the upgrade"
+def test_refuses_a_second_redirect():
+    second_hop = "https://langwatch.test/api/v2/things?page=2"
+    handler, seen = redirecting(
+        status=307,
+        after_upgrade=lambda request: httpx.Response(
+            307, headers={"location": second_hop}
+        ),
+    )
+
+    with sync_client(handler) as client, pytest.raises(RedirectRefusedError) as raised:
+        client.get(HTTP_URL)
+
+    assert raised.value.url == HTTPS_URL
+    assert raised.value.location == second_hop
+    assert raised.value.status == 307
+    assert len(seen) == 2
+
+
+# @scenario "refuses a redirect without a location"
+def test_refuses_a_redirect_without_a_location():
+    handler, _ = redirecting(location=None)
+
+    with sync_client(handler) as client, pytest.raises(RedirectRefusedError) as raised:
+        client.get(HTTP_URL)
+
+    assert raised.value.location is None
+    assert raised.value.status == 301
+    assert "<no Location header>" in str(raised.value)
+
+
+# @scenario "the generated API client uses the shared transport"
+def test_generated_client_carries_the_transport():
+    Client.reset_for_testing()
+    try:
+        sdk = Client(
+            api_key="sk-lw-test",
+            endpoint_url="http://langwatch.test",
+            skip_open_telemetry_setup=True,
+        )
+        rest = sdk.rest_api_client
+        sync_http = rest.get_httpx_client()
+        async_http = rest.get_async_httpx_client()
+
+        assert isinstance(sync_http._transport, SchemeUpgradeTransport)
+        assert isinstance(async_http._transport, AsyncSchemeUpgradeTransport)
+        assert sync_http.follow_redirects is False
+        assert async_http.follow_redirects is False
+        assert str(sync_http.base_url) == "http://langwatch.test"
+        assert str(async_http.base_url) == "http://langwatch.test"
+        assert sync_http.headers["x-auth-token"] == "sk-lw-test"
+        assert async_http.headers["x-auth-token"] == "sk-lw-test"
+    finally:
+        Client.reset_for_testing()
+
+
+RAW_HTTPX_CALL = re.compile(
+    r"\bhttpx\.(Client|AsyncClient|HTTPTransport|AsyncHTTPTransport"
+    r"|get|post|put|patch|delete|head|options|request|stream)\("
+)
+
+
+# @scenario "every hand written request uses the shared transport"
+def test_no_hand_written_request_builds_its_own_client():
+    source_root = Path(__file__).resolve().parents[1] / "src" / "langwatch"
+    offenders: list[str] = []
+    for path in source_root.rglob("*.py"):
+        relative = path.relative_to(source_root).as_posix()
+        if relative.startswith("generated/") or relative == "http_client.py":
+            continue
+        for number, line in enumerate(path.read_text().splitlines(), start=1):
+            if RAW_HTTPX_CALL.search(line):
+                offenders.append(f"{relative}:{number}: {line.strip()}")
+
+    assert offenders == []

--- a/sdks/python/tests/test_http_client.py
+++ b/sdks/python/tests/test_http_client.py
@@ -1,9 +1,11 @@
-"""Unit coverage for the shared HTTP client: an http to https upgrade of the
-same URL is followed once with the same method, headers and body, every other
-redirect raises RedirectRefusedError, the generated REST client carries the
-transport, and no hand written call builds its own httpx client. The inner
-transport is httpx.MockTransport, so the assertions are on the requests that
-leave the process.
+"""Unit coverage for the shared HTTP client: a GET or HEAD follows redirects
+with the same method up to five hops and drops credentials when it leaves the
+origin, every other method follows only an http to https upgrade of the same
+URL with the same method, headers and body, every refused redirect raises
+RedirectRefusedError, the generated REST client carries the transport, and no
+hand written call builds its own httpx client. The inner transport is
+httpx.MockTransport, so the assertions are on the requests that leave the
+process.
 
 Spec: specs/python-sdk/http-client-redirects.feature
 """
@@ -30,6 +32,15 @@ from langwatch.http_client import (
 
 HTTP_URL = "http://langwatch.test/api/v1/things?page=2"
 HTTPS_URL = "https://langwatch.test/api/v1/things?page=2"
+OTHER_PATH = "https://langwatch.test/api/v2/things?page=2"
+OTHER_HOST = "https://other.test/api/v1/things?page=2"
+
+CREDENTIALS = {
+    "Authorization": "Bearer sk-lw-test",
+    "X-Auth-Token": "sk-lw-test",
+    "X-Project-Id": "project_1",
+    "X-Trace": "abc",
+}
 
 
 @pytest.fixture(autouse=True)
@@ -60,6 +71,23 @@ def redirecting(
     return handler, seen
 
 
+def scripted(*responses: httpx.Response):
+    """A handler answering each request from the script, in order, plus the
+    requests it saw."""
+    seen: list[httpx.Request] = []
+    queue = list(responses)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return queue.pop(0)
+
+    return handler, seen
+
+
+def redirect(status: int, location: str) -> httpx.Response:
+    return httpx.Response(status, headers={"location": location})
+
+
 def sync_client(handler) -> httpx.Client:
     return create_client(transport=httpx.MockTransport(handler))
 
@@ -68,17 +96,22 @@ def async_client(handler) -> httpx.AsyncClient:
     return create_async_client(transport=httpx.MockTransport(handler))
 
 
+# --- The upgrade every method follows ---
+
+
 # @scenario "follows a redirect that only upgrades http to https"
 @pytest.mark.parametrize("status", [301, 302, 307, 308])
-def test_follows_the_scheme_upgrade_once(status: int):
+@pytest.mark.parametrize("method", ["GET", "POST"])
+def test_follows_the_scheme_upgrade_once(status: int, method: str):
     handler, seen = redirecting(status=status)
 
     with sync_client(handler) as client:
-        response = client.get(HTTP_URL)
+        response = client.request(method, HTTP_URL)
 
     assert response.status_code == 200
     assert response.json() == {"ok": True}
     assert [str(r.url) for r in seen] == [HTTP_URL, HTTPS_URL]
+    assert [r.method for r in seen] == [method, method]
 
 
 # @scenario "follows a redirect that only upgrades http to https"
@@ -160,7 +193,7 @@ def test_warns_once_per_process(caplog: pytest.LogCaptureFixture):
         sync_client(handler) as client,
     ):
         client.get(HTTP_URL)
-        client.get(HTTP_URL)
+        client.post(HTTP_URL, json={})
 
     warnings = [r for r in caplog.records if r.name == "langwatch.http_client"]
     assert len(warnings) == 1
@@ -170,64 +203,162 @@ def test_warns_once_per_process(caplog: pytest.LogCaptureFixture):
     )
 
 
-# @scenario "refuses a redirect to another host"
-def test_refuses_another_host():
-    other = "https://other.test/api/v1/things?page=2"
-    handler, seen = redirecting(location=other)
+# --- What a GET or HEAD follows ---
+
+
+# @scenario "a GET follows a redirect to another path"
+def test_get_follows_another_path():
+    handler, seen = scripted(
+        redirect(301, OTHER_PATH), httpx.Response(200, json={"moved": True})
+    )
+
+    with sync_client(handler) as client:
+        response = client.get(HTTPS_URL)
+
+    assert response.json() == {"moved": True}
+    assert [str(r.url) for r in seen] == [HTTPS_URL, OTHER_PATH]
+    assert [r.method for r in seen] == ["GET", "GET"]
+
+
+# @scenario "a GET follows a redirect to another path"
+def test_get_follows_a_relative_location():
+    handler, seen = scripted(redirect(302, "/api/other"), httpx.Response(200))
+
+    with sync_client(handler) as client:
+        client.get(HTTPS_URL)
+
+    assert str(seen[1].url) == "https://langwatch.test/api/other"
+
+
+# @scenario "a GET follows a redirect to another path"
+@pytest.mark.asyncio
+async def test_get_follows_another_path_async():
+    handler, seen = scripted(redirect(301, OTHER_PATH), httpx.Response(200))
+
+    async with async_client(handler) as client:
+        response = await client.get(HTTPS_URL)
+
+    assert response.status_code == 200
+    assert [str(r.url) for r in seen] == [HTTPS_URL, OTHER_PATH]
+
+
+# @scenario "a GET follows a chain of redirects up to five hops"
+def test_get_follows_five_hops():
+    hops = [f"https://langwatch.test/hop/{n}" for n in range(1, 6)]
+    handler, seen = scripted(
+        *(redirect(301 if i % 2 == 0 else 307, hop) for i, hop in enumerate(hops)),
+        httpx.Response(200, text="final"),
+    )
+
+    with sync_client(handler) as client:
+        response = client.get(HTTPS_URL)
+
+    assert response.text == "final"
+    assert [str(r.url) for r in seen] == [HTTPS_URL, *hops]
+    assert {r.method for r in seen} == {"GET"}
+
+
+# @scenario "a GET refuses a sixth hop"
+def test_get_refuses_a_sixth_hop():
+    hops = [f"https://langwatch.test/hop/{n}" for n in range(1, 7)]
+    handler, seen = scripted(
+        *(redirect(302 if i == 5 else 301, hop) for i, hop in enumerate(hops)),
+        httpx.Response(200),
+    )
 
     with sync_client(handler) as client, pytest.raises(RedirectRefusedError) as raised:
-        client.get(HTTP_URL)
+        client.get(HTTPS_URL)
 
-    error = raised.value
-    assert error.url == HTTP_URL
-    assert error.location == other
-    assert error.status == 301
-    assert str(error) == (
-        f"LangWatch refused to follow a redirect from {HTTP_URL} to {other} "
-        "(HTTP 301). Set the endpoint to the final URL."
-    )
-    assert len(seen) == 1
+    assert len(seen) == 6
+    assert raised.value.url == hops[4]
+    assert raised.value.location == hops[5]
+    assert raised.value.status == 302
 
 
-# @scenario "refuses a redirect to another host"
+# @scenario "a GET refuses a sixth hop"
 @pytest.mark.asyncio
-async def test_refuses_another_host_async():
-    handler, seen = redirecting(location="https://other.test/api/v1/things?page=2")
+async def test_get_refuses_a_sixth_hop_async():
+    hops = [f"https://langwatch.test/hop/{n}" for n in range(1, 7)]
+    handler, seen = scripted(*(redirect(301, hop) for hop in hops), httpx.Response(200))
 
     async with async_client(handler) as client:
         with pytest.raises(RedirectRefusedError) as raised:
-            await client.post(HTTP_URL, json={})
+            await client.get(HTTPS_URL)
 
-    assert raised.value.status == 301
-    assert len(seen) == 1
-
-
-# @scenario "refuses a redirect that changes the path or query"
-@pytest.mark.parametrize(
-    "location",
-    [
-        "https://langwatch.test/api/v2/things?page=2",
-        "https://langwatch.test/api/v1/things?page=3",
-        "https://langwatch.test/api/v1/things",
-    ],
-)
-def test_refuses_a_changed_path_or_query(location: str):
-    handler, _ = redirecting(status=308, location=location)
-
-    with sync_client(handler) as client, pytest.raises(RedirectRefusedError) as raised:
-        client.get(HTTP_URL)
-
-    assert raised.value.location == location
-    assert raised.value.status == 308
+    assert len(seen) == 6
+    assert raised.value.url == hops[4]
 
 
-# @scenario "refuses a downgrade from https to http"
-def test_refuses_a_downgrade():
-    seen: list[httpx.Request] = []
+# @scenario "a GET keeps its headers on a same origin redirect"
+def test_get_keeps_headers_on_the_same_origin():
+    handler, seen = scripted(redirect(302, OTHER_PATH), httpx.Response(200))
 
-    def handler(request: httpx.Request) -> httpx.Response:
-        seen.append(request)
-        return httpx.Response(301, headers={"location": HTTP_URL})
+    with sync_client(handler) as client:
+        client.get(HTTPS_URL, headers=CREDENTIALS)
+
+    first, second = seen
+    for name in CREDENTIALS:
+        assert second.headers[name] == first.headers[name]
+    assert second.headers["host"] == "langwatch.test"
+
+
+# @scenario "a GET keeps its headers on a same origin redirect"
+def test_get_keeps_headers_on_the_scheme_upgrade_of_the_same_host(
+    caplog: pytest.LogCaptureFixture,
+):
+    handler, seen = scripted(redirect(301, OTHER_PATH), httpx.Response(200))
+
+    with (
+        caplog.at_level(logging.WARNING, logger="langwatch.http_client"),
+        sync_client(handler) as client,
+    ):
+        client.get(HTTP_URL, headers=CREDENTIALS)
+
+    second = seen[1]
+    assert second.headers["authorization"] == "Bearer sk-lw-test"
+    assert second.headers["x-auth-token"] == "sk-lw-test"
+    assert second.headers["x-project-id"] == "project_1"
+    assert len([r for r in caplog.records if r.name == "langwatch.http_client"]) == 1
+
+
+# @scenario "a GET drops credential headers on a cross origin redirect"
+def test_get_drops_credentials_on_another_host(caplog: pytest.LogCaptureFixture):
+    handler, seen = scripted(redirect(302, OTHER_HOST), httpx.Response(200))
+
+    with (
+        caplog.at_level(logging.WARNING, logger="langwatch.http_client"),
+        sync_client(handler) as client,
+    ):
+        client.get(HTTPS_URL, headers=CREDENTIALS)
+
+    second = seen[1]
+    assert str(second.url) == OTHER_HOST
+    assert "authorization" not in second.headers
+    assert "x-auth-token" not in second.headers
+    assert "x-project-id" not in second.headers
+    assert second.headers["x-trace"] == "abc"
+    assert second.headers["host"] == "other.test"
+    assert [r for r in caplog.records if r.name == "langwatch.http_client"] == []
+
+
+# @scenario "a GET drops credential headers on a cross origin redirect"
+def test_get_drops_credentials_on_another_port():
+    handler, seen = scripted(
+        redirect(302, "https://langwatch.test:8443/api/v1/things?page=2"),
+        httpx.Response(200),
+    )
+
+    with sync_client(handler) as client:
+        client.get(HTTPS_URL, headers=CREDENTIALS)
+
+    second = seen[1]
+    assert "authorization" not in second.headers
+    assert second.headers["host"] == "langwatch.test:8443"
+
+
+# @scenario "a GET refuses a downgrade from https to http"
+def test_get_refuses_a_downgrade():
+    handler, seen = scripted(redirect(301, HTTP_URL), httpx.Response(200))
 
     with sync_client(handler) as client, pytest.raises(RedirectRefusedError) as raised:
         client.get(HTTPS_URL)
@@ -237,8 +368,125 @@ def test_refuses_a_downgrade():
     assert len(seen) == 1
 
 
-# @scenario "refuses a 303"
-def test_refuses_a_303():
+# @scenario "a GET refuses a downgrade from https to http"
+def test_get_refuses_a_downgrade_in_the_middle_of_a_chain():
+    plain = "http://langwatch.test/api/plain"
+    handler, seen = scripted(
+        redirect(301, OTHER_PATH), redirect(301, plain), httpx.Response(200)
+    )
+
+    with sync_client(handler) as client, pytest.raises(RedirectRefusedError) as raised:
+        client.get(HTTPS_URL)
+
+    assert raised.value.url == OTHER_PATH
+    assert raised.value.location == plain
+    assert len(seen) == 2
+
+
+# @scenario "a GET follows a 303"
+def test_get_follows_a_303():
+    handler, seen = scripted(redirect(303, OTHER_PATH), httpx.Response(200))
+
+    with sync_client(handler) as client:
+        client.get(HTTPS_URL)
+
+    assert [str(r.url) for r in seen] == [HTTPS_URL, OTHER_PATH]
+    assert seen[1].method == "GET"
+
+
+# @scenario "a HEAD follows a redirect like a GET"
+def test_head_follows_like_a_get():
+    handler, seen = scripted(redirect(301, OTHER_PATH), httpx.Response(200))
+
+    with sync_client(handler) as client:
+        response = client.head(HTTPS_URL, headers=CREDENTIALS)
+
+    assert response.status_code == 200
+    assert [str(r.url) for r in seen] == [HTTPS_URL, OTHER_PATH]
+    assert seen[1].method == "HEAD"
+    assert seen[1].headers["authorization"] == "Bearer sk-lw-test"
+
+
+# --- What every other method refuses ---
+
+
+# @scenario "a POST refuses a redirect to another host"
+def test_post_refuses_another_host():
+    handler, seen = redirecting(location=OTHER_HOST)
+
+    with sync_client(handler) as client, pytest.raises(RedirectRefusedError) as raised:
+        client.post(HTTP_URL, json={})
+
+    error = raised.value
+    assert error.url == HTTP_URL
+    assert error.location == OTHER_HOST
+    assert error.status == 301
+    assert str(error) == (
+        f"LangWatch refused to follow a redirect from {HTTP_URL} to {OTHER_HOST} "
+        "(HTTP 301). Set the endpoint to the final URL."
+    )
+    assert len(seen) == 1
+
+
+# @scenario "a POST refuses a redirect to another host"
+@pytest.mark.asyncio
+async def test_post_refuses_another_host_async():
+    handler, seen = redirecting(location=OTHER_HOST)
+
+    async with async_client(handler) as client:
+        with pytest.raises(RedirectRefusedError) as raised:
+            await client.post(HTTP_URL, json={})
+
+    assert raised.value.status == 301
+    assert len(seen) == 1
+
+
+# @scenario "a POST still refuses a redirect to another path"
+@pytest.mark.parametrize(
+    "location",
+    [
+        OTHER_PATH,
+        "https://langwatch.test/api/v1/things?page=3",
+        "https://langwatch.test/api/v1/things",
+    ],
+)
+def test_post_refuses_a_changed_path_or_query(location: str):
+    handler, seen = redirecting(status=308, location=location)
+
+    with sync_client(handler) as client, pytest.raises(RedirectRefusedError) as raised:
+        client.post(HTTP_URL, json={})
+
+    assert raised.value.location == location
+    assert raised.value.status == 308
+    assert len(seen) == 1
+
+
+# @scenario "a POST still refuses a redirect to another path"
+@pytest.mark.parametrize("method", ["PUT", "PATCH", "DELETE"])
+def test_other_methods_refuse_another_path(method: str):
+    handler, seen = scripted(redirect(301, OTHER_PATH), httpx.Response(200))
+
+    with sync_client(handler) as client, pytest.raises(RedirectRefusedError) as raised:
+        client.request(method, HTTPS_URL)
+
+    assert raised.value.location == OTHER_PATH
+    assert len(seen) == 1
+
+
+# @scenario "a POST refuses a downgrade from https to http"
+def test_post_refuses_a_downgrade():
+    handler, seen = scripted(redirect(301, HTTP_URL), httpx.Response(200))
+
+    with sync_client(handler) as client, pytest.raises(RedirectRefusedError) as raised:
+        client.post(HTTPS_URL, json={})
+
+    assert raised.value.url == HTTPS_URL
+    assert raised.value.location == HTTP_URL
+    assert len(seen) == 1
+
+
+# @scenario "a POST refuses a 303"
+def test_post_refuses_a_303():
     handler, seen = redirecting(status=303)
 
     with sync_client(handler) as client, pytest.raises(RedirectRefusedError) as raised:
@@ -249,35 +497,37 @@ def test_refuses_a_303():
     assert len(seen) == 1
 
 
-# @scenario "refuses a second redirect after the upgrade"
-def test_refuses_a_second_redirect():
-    second_hop = "https://langwatch.test/api/v2/things?page=2"
+# @scenario "a POST refuses a second redirect after the upgrade"
+def test_post_refuses_a_second_redirect():
     handler, seen = redirecting(
         status=307,
-        after_upgrade=lambda request: httpx.Response(
-            307, headers={"location": second_hop}
-        ),
+        after_upgrade=lambda request: redirect(307, OTHER_PATH),
     )
 
     with sync_client(handler) as client, pytest.raises(RedirectRefusedError) as raised:
-        client.get(HTTP_URL)
+        client.post(HTTP_URL, json={})
 
     assert raised.value.url == HTTPS_URL
-    assert raised.value.location == second_hop
+    assert raised.value.location == OTHER_PATH
     assert raised.value.status == 307
     assert len(seen) == 2
 
 
 # @scenario "refuses a redirect without a location"
-def test_refuses_a_redirect_without_a_location():
-    handler, _ = redirecting(location=None)
+@pytest.mark.parametrize("method", ["GET", "POST"])
+def test_refuses_a_redirect_without_a_location(method: str):
+    handler, seen = redirecting(location=None)
 
     with sync_client(handler) as client, pytest.raises(RedirectRefusedError) as raised:
-        client.get(HTTP_URL)
+        client.request(method, HTTP_URL)
 
     assert raised.value.location is None
     assert raised.value.status == 301
     assert "<no Location header>" in str(raised.value)
+    assert len(seen) == 1
+
+
+# --- Every request goes through the shared client ---
 
 
 # @scenario "the generated API client uses the shared transport"

--- a/sdks/python/tests/test_http_client.py
+++ b/sdks/python/tests/test_http_client.py
@@ -10,9 +10,13 @@ process.
 Spec: specs/python-sdk/http-client-redirects.feature
 """
 
+import asyncio
+import http.server
 import json
 import logging
 import re
+import socketserver
+import threading
 from collections.abc import Callable
 from pathlib import Path
 
@@ -575,6 +579,88 @@ def test_generated_client_carries_the_transport():
         assert async_http.headers["x-auth-token"] == "sk-lw-test"
     finally:
         Client.reset_for_testing()
+
+
+# --- Environment proxy discovery ---
+#
+# httpx builds its environment proxy mounts only when it builds the transport
+# itself, so the factories must let it construct the client and wrap the
+# transports afterwards. These run against real loopback servers: a stub origin
+# and a stub proxy, each answering with its own name, so the assertion is on
+# which one actually received the request.
+
+
+def _serve(body: bytes) -> "tuple[socketserver.TCPServer, int]":
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):  # noqa: N802 - the BaseHTTPRequestHandler contract
+            self.send_response(200)
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, *args):  # the stub keeps the test output quiet
+            pass
+
+    server = socketserver.TCPServer(("127.0.0.1", 0), Handler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    return server, server.server_address[1]
+
+
+@pytest.fixture
+def origin_and_proxy(monkeypatch: pytest.MonkeyPatch):
+    """A loopback origin and a loopback proxy, with HTTP_PROXY pointing at the
+    proxy. Yields the origin's URL; the response body names who answered."""
+    origin, origin_port = _serve(b"ORIGIN")
+    proxy, proxy_port = _serve(b"PROXY")
+    monkeypatch.setenv("HTTP_PROXY", f"http://127.0.0.1:{proxy_port}")
+    monkeypatch.delenv("NO_PROXY", raising=False)
+    monkeypatch.delenv("no_proxy", raising=False)
+    try:
+        yield f"http://127.0.0.1:{origin_port}/api/v1/things"
+    finally:
+        origin.shutdown()
+        proxy.shutdown()
+
+
+# @scenario "the client keeps httpx's environment proxy discovery"
+def test_create_client_routes_through_the_environment_proxy(origin_and_proxy: str):
+    with create_client() as client:
+        assert client.get(origin_and_proxy).text == "PROXY"
+
+
+# @scenario "the client keeps httpx's environment proxy discovery"
+def test_create_async_client_routes_through_the_environment_proxy(
+    origin_and_proxy: str,
+):
+    async def call() -> str:
+        async with create_async_client() as client:
+            return (await client.get(origin_and_proxy)).text
+
+    assert asyncio.run(call()) == "PROXY"
+
+
+# @scenario "the client keeps httpx's environment proxy discovery"
+def test_the_proxy_transport_carries_the_redirect_rule(origin_and_proxy: str):
+    with create_client() as client:
+        assert client._mounts
+        for mounted in client._mounts.values():
+            assert isinstance(mounted, SchemeUpgradeTransport)
+
+
+# @scenario "the client keeps httpx's environment proxy discovery"
+def test_no_proxy_sends_the_request_straight_to_the_origin(
+    origin_and_proxy: str, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setenv("NO_PROXY", "127.0.0.1")
+
+    with create_client() as client:
+        assert client.get(origin_and_proxy).text == "ORIGIN"
+
+
+# @scenario "the client keeps httpx's environment proxy discovery"
+def test_trust_env_false_ignores_the_environment_proxy(origin_and_proxy: str):
+    with create_client(trust_env=False) as client:
+        assert client.get(origin_and_proxy).text == "ORIGIN"
 
 
 RAW_HTTPX_CALL = re.compile(

--- a/sdks/python/tests/test_http_client.py
+++ b/sdks/python/tests/test_http_client.py
@@ -40,6 +40,9 @@ HTTPS_URL = "https://langwatch.test/api/v1/things?page=2"
 OTHER_PATH = "https://langwatch.test/api/v2/things?page=2"
 OTHER_HOST = "https://other.test/api/v1/things?page=2"
 
+# What httpx.BasicAuth("user", "secret") signs a request with.
+BASIC_AUTH = "Basic dXNlcjpzZWNyZXQ="
+
 CREDENTIALS = {
     "Authorization": "Bearer sk-lw-test",
     "X-Auth-Token": "sk-lw-test",
@@ -381,6 +384,66 @@ def test_get_drops_credentials_on_another_port():
     second = seen[1]
     assert "authorization" not in second.headers
     assert second.headers["host"] == "langwatch.test:8443"
+
+
+# @scenario "a GET drops the client's auth on a cross origin redirect"
+def test_get_drops_the_client_auth_on_another_host():
+    handler, seen = scripted(redirect(302, OTHER_HOST), httpx.Response(200))
+
+    with create_client(
+        transport=httpx.MockTransport(handler), auth=httpx.BasicAuth("user", "secret")
+    ) as client:
+        client.get(HTTPS_URL)
+
+    assert seen[0].headers["authorization"] == BASIC_AUTH
+    assert "authorization" not in seen[1].headers
+
+
+# @scenario "a GET drops the client's auth on a cross origin redirect"
+def test_async_get_drops_the_client_auth_on_another_host():
+    handler, seen = scripted(redirect(302, OTHER_HOST), httpx.Response(200))
+
+    async def run():
+        async with create_async_client(
+            transport=httpx.MockTransport(handler),
+            auth=httpx.BasicAuth("user", "secret"),
+        ) as client:
+            await client.get(HTTPS_URL)
+
+    asyncio.run(run())
+
+    assert seen[0].headers["authorization"] == BASIC_AUTH
+    assert "authorization" not in seen[1].headers
+
+
+# @scenario "a GET keeps the client's auth on an https upgrade"
+def test_get_keeps_the_client_auth_on_an_https_upgrade():
+    handler, seen = scripted(redirect(301, HTTPS_URL), httpx.Response(200))
+
+    with create_client(
+        transport=httpx.MockTransport(handler), auth=httpx.BasicAuth("user", "secret")
+    ) as client:
+        client.get(HTTP_URL)
+
+    assert str(seen[1].url) == HTTPS_URL
+    assert seen[1].headers["authorization"] == BASIC_AUTH
+
+
+# @scenario "a GET keeps the client's auth on an https upgrade"
+def test_async_get_keeps_the_client_auth_on_an_https_upgrade():
+    handler, seen = scripted(redirect(301, HTTPS_URL), httpx.Response(200))
+
+    async def run():
+        async with create_async_client(
+            transport=httpx.MockTransport(handler),
+            auth=httpx.BasicAuth("user", "secret"),
+        ) as client:
+            await client.get(HTTP_URL)
+
+    asyncio.run(run())
+
+    assert str(seen[1].url) == HTTPS_URL
+    assert seen[1].headers["authorization"] == BASIC_AUTH
 
 
 # @scenario "a GET refuses a downgrade from https to http"

--- a/sdks/python/tests/test_http_client.py
+++ b/sdks/python/tests/test_http_client.py
@@ -2,9 +2,10 @@
 with the same method up to five hops and drops credentials when it leaves the
 origin, every other method follows only an http to https upgrade of the same
 URL with the same method, headers and body, every refused redirect raises
-RedirectRefusedError, the generated REST client carries the transport, and no
-hand written call builds its own httpx client. The inner transport is
-httpx.MockTransport, so the assertions are on the requests that leave the
+RedirectRefusedError, every hop leaves through the transport httpx mounts for
+the hop's own URL, the generated REST client is built from the shared client
+classes, and no hand written call builds its own httpx client. The transports
+are httpx.MockTransport, so the assertions are on the requests that leave the
 process.
 
 Spec: specs/python-sdk/http-client-redirects.feature
@@ -25,9 +26,9 @@ import pytest
 
 from langwatch.client import Client
 from langwatch.http_client import (
-    AsyncSchemeUpgradeTransport,
+    LangWatchAsyncClient,
+    LangWatchClient,
     RedirectRefusedError,
-    SchemeUpgradeTransport,
     _reset_upgrade_warning,
     create_async_client,
     create_client,
@@ -553,11 +554,105 @@ def test_refuses_a_redirect_without_a_location(method: str):
     assert len(seen) == 1
 
 
+# --- The transport is chosen per hop ---
+
+
+def recording(handler):
+    """A MockTransport around `handler`, plus the requests it saw."""
+    seen: list[httpx.Request] = []
+
+    def record(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return handler(request)
+
+    return httpx.MockTransport(record), seen
+
+
+def scheme_mounts():
+    """An http mount answering 301 to the https URL and an https mount
+    answering 200, each with the requests it received."""
+    http_mount, http_seen = recording(lambda request: redirect(301, HTTPS_URL))
+    https_mount, https_seen = recording(
+        lambda request: httpx.Response(200, json={"ok": True})
+    )
+    return {"http://": http_mount, "https://": https_mount}, http_seen, https_seen
+
+
+def no_proxy_mounts():
+    """What HTTP_PROXY plus NO_PROXY=other.test produce: a catch-all proxy
+    mount and a direct mount for other.test. The proxy answers every request
+    with a 302 to other.test, the direct mount answers 200."""
+    proxy_mount, proxy_seen = recording(lambda request: redirect(302, OTHER_HOST))
+    direct_mount, direct_seen = recording(
+        lambda request: httpx.Response(200, text="direct")
+    )
+    return (
+        {"all://": proxy_mount, "all://other.test": direct_mount},
+        proxy_seen,
+        direct_seen,
+    )
+
+
+# @scenario "the https replay uses the mount of the https URL"
+def test_https_replay_uses_the_https_mount():
+    mounts, http_seen, https_seen = scheme_mounts()
+
+    with create_client(mounts=mounts) as client:
+        response = client.post(HTTP_URL, json={"a": 1})
+
+    assert response.json() == {"ok": True}
+    assert [str(r.url) for r in http_seen] == [HTTP_URL]
+    assert [str(r.url) for r in https_seen] == [HTTPS_URL]
+    assert https_seen[0].method == "POST"
+    assert https_seen[0].content == http_seen[0].content
+
+
+# @scenario "the https replay uses the mount of the https URL"
+@pytest.mark.asyncio
+async def test_https_replay_uses_the_https_mount_async():
+    mounts, http_seen, https_seen = scheme_mounts()
+
+    async with create_async_client(mounts=mounts) as client:
+        response = await client.post(HTTP_URL, json={"a": 1})
+
+    assert response.json() == {"ok": True}
+    assert [str(r.url) for r in http_seen] == [HTTP_URL]
+    assert [str(r.url) for r in https_seen] == [HTTPS_URL]
+    assert https_seen[0].method == "POST"
+
+
+# @scenario "a GET hop across a NO_PROXY boundary uses the mount of the new host"
+def test_get_hop_across_a_no_proxy_boundary_uses_the_mount_of_the_new_host():
+    mounts, proxy_seen, direct_seen = no_proxy_mounts()
+
+    with create_client(mounts=mounts) as client:
+        response = client.get(HTTPS_URL, headers=CREDENTIALS)
+
+    assert response.text == "direct"
+    assert [str(r.url) for r in proxy_seen] == [HTTPS_URL]
+    assert [str(r.url) for r in direct_seen] == [OTHER_HOST]
+    assert "authorization" not in direct_seen[0].headers
+    assert direct_seen[0].headers["host"] == "other.test"
+
+
+# @scenario "a GET hop across a NO_PROXY boundary uses the mount of the new host"
+@pytest.mark.asyncio
+async def test_get_hop_across_a_no_proxy_boundary_uses_the_mount_of_the_new_host_async():
+    mounts, proxy_seen, direct_seen = no_proxy_mounts()
+
+    async with create_async_client(mounts=mounts) as client:
+        response = await client.get(HTTPS_URL)
+
+    assert response.text == "direct"
+    assert [str(r.url) for r in proxy_seen] == [HTTPS_URL]
+    assert [str(r.url) for r in direct_seen] == [OTHER_HOST]
+
+
 # --- Every request goes through the shared client ---
 
 
-# @scenario "the generated API client uses the shared transport"
-def test_generated_client_carries_the_transport():
+# @scenario "the generated API client uses the shared client"
+def test_generated_client_is_built_from_the_shared_classes():
     Client.reset_for_testing()
     try:
         sdk = Client(
@@ -569,8 +664,8 @@ def test_generated_client_carries_the_transport():
         sync_http = rest.get_httpx_client()
         async_http = rest.get_async_httpx_client()
 
-        assert isinstance(sync_http._transport, SchemeUpgradeTransport)
-        assert isinstance(async_http._transport, AsyncSchemeUpgradeTransport)
+        assert isinstance(sync_http, LangWatchClient)
+        assert isinstance(async_http, LangWatchAsyncClient)
         assert sync_http.follow_redirects is False
         assert async_http.follow_redirects is False
         assert str(sync_http.base_url) == "http://langwatch.test"
@@ -584,15 +679,21 @@ def test_generated_client_carries_the_transport():
 # --- Environment proxy discovery ---
 #
 # httpx builds its environment proxy mounts only when it builds the transport
-# itself, so the factories must let it construct the client and wrap the
-# transports afterwards. These run against real loopback servers: a stub origin
-# and a stub proxy, each answering with its own name, so the assertion is on
-# which one actually received the request.
+# itself, so the factories pass every argument to httpx unchanged. These run
+# against real loopback servers: a stub origin and a stub proxy, each answering
+# with its own name, so the assertion is on which one actually received the
+# request. Both answer the path /redirect with a 301 to /api/v1/things.
 
 
 def _serve(body: bytes) -> "tuple[socketserver.TCPServer, int]":
     class Handler(http.server.BaseHTTPRequestHandler):
-        def do_GET(self):  # noqa: N802 - the BaseHTTPRequestHandler contract
+        def do_GET(self):  # the BaseHTTPRequestHandler contract names it so
+            if self.path.endswith("/redirect"):
+                self.send_response(301)
+                self.send_header("Location", "/api/v1/things")
+                self.send_header("Content-Length", "0")
+                self.end_headers()
+                return
             self.send_response(200)
             self.send_header("Content-Length", str(len(body)))
             self.end_headers()
@@ -640,11 +741,12 @@ def test_create_async_client_routes_through_the_environment_proxy(
 
 
 # @scenario "the client keeps httpx's environment proxy discovery"
-def test_the_proxy_transport_carries_the_redirect_rule(origin_and_proxy: str):
+def test_a_redirect_answered_by_the_proxy_follows_the_rule(origin_and_proxy: str):
     with create_client() as client:
-        assert client._mounts
-        for mounted in client._mounts.values():
-            assert isinstance(mounted, SchemeUpgradeTransport)
+        response = client.get(origin_and_proxy.replace("/api/v1/things", "/redirect"))
+
+    assert response.text == "PROXY"
+    assert str(response.url) == origin_and_proxy
 
 
 # @scenario "the client keeps httpx's environment proxy discovery"
@@ -669,7 +771,7 @@ RAW_HTTPX_CALL = re.compile(
 )
 
 
-# @scenario "every hand written request uses the shared transport"
+# @scenario "every hand written request uses the shared client"
 def test_no_hand_written_request_builds_its_own_client():
     source_root = Path(__file__).resolve().parents[1] / "src" / "langwatch"
     offenders: list[str] = []

--- a/sdks/python/tests/test_login.py
+++ b/sdks/python/tests/test_login.py
@@ -17,7 +17,8 @@ def test_login_already_logged_in_no_relogin(capsys):
     with patch("langwatch.login.get_api_key", return_value="fake_api_key"), \
          patch("langwatch.login.langwatch.setup") as mock_setup, \
          patch("langwatch.login.getpass") as mock_getpass, \
-         patch("langwatch.login.httpx.post") as mock_post:
+         patch("langwatch.login.create_client") as mock_create_client:
+        mock_post = mock_create_client.return_value.__enter__.return_value.post
 
         login(relogin=False)
 
@@ -32,7 +33,8 @@ def test_login_successful(capsys):
          patch("langwatch.login.langwatch.setup") as mock_setup, \
          patch("langwatch.login.get_endpoint", return_value="http://fake-endpoint.internal") as mock_get_endpoint, \
          patch("langwatch.login.getpass", return_value="new_valid_key") as mock_getpass, \
-         patch("langwatch.login.httpx.post") as mock_post:
+         patch("langwatch.login.create_client") as mock_create_client:
+        mock_post = mock_create_client.return_value.__enter__.return_value.post
 
         mock_response = MagicMock()
         mock_response.status_code = 200
@@ -58,7 +60,8 @@ def test_login_successful_with_relogin(capsys):
          patch("langwatch.login.langwatch.setup") as mock_setup, \
          patch("langwatch.login.get_endpoint", return_value="http://fake-endpoint.internal") as mock_get_endpoint, \
          patch("langwatch.login.getpass", return_value="new_valid_key_relogin") as mock_getpass, \
-         patch("langwatch.login.httpx.post") as mock_post:
+         patch("langwatch.login.create_client") as mock_create_client:
+        mock_post = mock_create_client.return_value.__enter__.return_value.post
 
         mock_response = MagicMock()
         mock_response.status_code = 200
@@ -84,7 +87,8 @@ def test_login_empty_api_key_entered(capsys):
     with patch("langwatch.login.get_api_key", return_value=""), \
          patch("langwatch.login.get_endpoint", return_value="http://fake-endpoint.internal") as mock_get_endpoint, \
          patch("langwatch.login.getpass", return_value="") as mock_getpass, \
-         patch("langwatch.login.httpx.post") as mock_post:
+         patch("langwatch.login.create_client") as mock_create_client:
+        mock_post = mock_create_client.return_value.__enter__.return_value.post
 
         with pytest.raises(ValueError) as excinfo:
             login()
@@ -102,7 +106,8 @@ def test_login_invalid_api_key(capsys):
          patch("langwatch.login.langwatch.setup") as mock_setup, \
          patch("langwatch.login.get_endpoint", return_value="http://fake-endpoint.internal") as mock_get_endpoint, \
          patch("langwatch.login.getpass", return_value="invalid_key") as mock_getpass, \
-         patch("langwatch.login.httpx.post") as mock_post:
+         patch("langwatch.login.create_client") as mock_create_client:
+        mock_post = mock_create_client.return_value.__enter__.return_value.post
 
         mock_response = MagicMock()
         mock_response.status_code = 401
@@ -129,7 +134,8 @@ def test_login_api_call_fails_non_401(capsys):
          patch("langwatch.login.langwatch.setup") as mock_setup, \
          patch("langwatch.login.get_endpoint", return_value="http://fake-endpoint.internal") as mock_get_endpoint, \
          patch("langwatch.login.getpass", return_value="some_key") as mock_getpass, \
-         patch("langwatch.login.httpx.post") as mock_post:
+         patch("langwatch.login.create_client") as mock_create_client:
+        mock_post = mock_create_client.return_value.__enter__.return_value.post
 
         mock_response = MagicMock()
         mock_response.status_code = 500

--- a/sdks/python/tests/workflow/test_server_run_results.py
+++ b/sdks/python/tests/workflow/test_server_run_results.py
@@ -1,6 +1,6 @@
 """Unit tests for server-side ``langwatch.workflow.run`` with per-row results.
 
-These mock the HTTP boundary (``httpx.Client``) so we assert the SDK posts to
+These mock the HTTP boundary (``create_client``) so we assert the SDK posts to
 ``/api/workflows/{workflow_id}/evaluate`` and that ``result.results`` builds the
 SAME per-row DataFrame shape an experiment run returns.
 
@@ -158,8 +158,8 @@ class TestWorkflowRunWithInlineData:
         _script_full_run()
         rows = [{"input": "hi"}, {"input": "bye"}]
 
-        with patch.object(platform_run.httpx, "Client", _FakeClient), patch.object(
-            workflow_module.httpx, "Client", _FakeClient
+        with patch.object(platform_run, "create_client", _FakeClient), patch.object(
+            workflow_module, "create_client", _FakeClient
         ):
             result = workflow_run("workflow_abc", data=rows, poll_interval=0)
 
@@ -191,8 +191,8 @@ class TestWorkflowRunWithDatasetId:
 
     def test_posts_dataset_id_and_no_inline_data(self):
         _script_full_run()
-        with patch.object(platform_run.httpx, "Client", _FakeClient), patch.object(
-            workflow_module.httpx, "Client", _FakeClient
+        with patch.object(platform_run, "create_client", _FakeClient), patch.object(
+            workflow_module, "create_client", _FakeClient
         ):
             workflow_run("workflow_abc", dataset_id="ds_xyz", poll_interval=0)
 
@@ -207,8 +207,8 @@ class TestWorkflowRunWithParameters:
 
     def test_parameters_and_version_in_body(self):
         _script_full_run()
-        with patch.object(platform_run.httpx, "Client", _FakeClient), patch.object(
-            workflow_module.httpx, "Client", _FakeClient
+        with patch.object(platform_run, "create_client", _FakeClient), patch.object(
+            workflow_module, "create_client", _FakeClient
         ):
             workflow_run(
                 "workflow_abc",
@@ -230,7 +230,7 @@ class TestWorkflowRunValidation:
     """when both inline data and a dataset id are provided"""
 
     def test_raises_value_error_before_any_http_call(self):
-        with patch.object(workflow_module.httpx, "Client", _FakeClient):
+        with patch.object(workflow_module, "create_client", _FakeClient):
             with pytest.raises(ValueError):
                 workflow_run("workflow_abc", data=[{"q": "x"}], dataset_id="ds_xyz")
 
@@ -242,7 +242,7 @@ class TestWorkflowRunErrors:
 
     def test_404_maps_to_workflow_not_found(self):
         _FakeClient.post_responses = {"/evaluate": _FakeResponse(404)}
-        with patch.object(workflow_module.httpx, "Client", _FakeClient):
+        with patch.object(workflow_module, "create_client", _FakeClient):
             with pytest.raises(ValueError) as exc:
                 workflow_run("missing_wf", data=[{"q": "x"}], poll_interval=0)
         assert "missing_wf" in str(exc.value)
@@ -253,7 +253,7 @@ class TestWorkflowRunErrors:
                 400, {"error": "Workflow has no committed version"}
             )
         }
-        with patch.object(workflow_module.httpx, "Client", _FakeClient):
+        with patch.object(workflow_module, "create_client", _FakeClient):
             with pytest.raises(ValueError) as exc:
                 workflow_run("wf_uncommitted", data=[{"q": "x"}], poll_interval=0)
         assert "committed version" in str(exc.value)

--- a/sdks/typescript/src/agent/transport.ts
+++ b/sdks/typescript/src/agent/transport.ts
@@ -12,6 +12,7 @@
 
 import { createRequire } from "node:module";
 import type { WebSocket as WsWebSocket } from "ws";
+import { langwatchFetch } from "../internal/http/langwatchFetch";
 
 export const AGENT_TRANSPORTS = ["websocket", "http"] as const;
 export type AgentTransport = (typeof AGENT_TRANSPORTS)[number];
@@ -203,7 +204,7 @@ export class HttpLongPollSocket implements SocketLike {
   constructor(options: HttpLongPollOptions) {
     this.url = options.url;
     this.headers = options.headers;
-    const fetchImpl = options.fetch ?? globalThis.fetch;
+    const fetchImpl = options.fetch ?? (typeof globalThis.fetch === "function" ? langwatchFetch : undefined);
     if (typeof fetchImpl !== "function") {
       throw new Error("the HTTP transport needs a global fetch; run on Node 20 or later");
     }

--- a/sdks/typescript/src/cli/commands/agents/run.ts
+++ b/sdks/typescript/src/cli/commands/agents/run.ts
@@ -15,6 +15,7 @@ import { parseRunParameterFlags } from "../../utils/keyValueFlags";
 import type { CommandResult } from "../../utils/output";
 
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
+import { langwatchFetch } from "@/internal/http/langwatchFetch";
 
 export interface RunAgentOptions {
   input?: string;
@@ -209,7 +210,7 @@ export const runAgentCommand = async (
 
     const runSpinner = createSpinner(`Running agent via workflow ${workflowId}...`).start();
     try {
-      const response = await fetch(
+      const response = await langwatchFetch(
         `${endpoint}/api/workflows/${encodeURIComponent(workflowId)}/run`,
         {
           method: "POST",

--- a/sdks/typescript/src/cli/commands/docs.ts
+++ b/sdks/typescript/src/cli/commands/docs.ts
@@ -1,4 +1,5 @@
 import chalk from "chalk";
+import { langwatchFetch } from "../../internal/http/langwatchFetch";
 
 const LANGWATCH_DOCS_BASE = "https://langwatch.ai/docs";
 const LANGWATCH_DOCS_INDEX = "https://langwatch.ai/docs/llms.txt";
@@ -52,7 +53,7 @@ export function normalizeDocsUrl(input: string | undefined, kind: DocsKind): str
 async function fetchAndPrint(url: string): Promise<void> {
   let response: Response;
   try {
-    response = await fetch(url, {
+    response = await langwatchFetch(url, {
       headers: { Accept: "text/markdown, text/plain;q=0.9, */*;q=0.5" },
     });
   } catch (error) {

--- a/sdks/typescript/src/cli/commands/graphs/create.ts
+++ b/sdks/typescript/src/cli/commands/graphs/create.ts
@@ -9,6 +9,7 @@ import { buildAuthHeaders } from "@/internal/api/auth";
 import type { CommandResult } from "../../utils/output";
 
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
+import { langwatchFetch } from "@/internal/http/langwatchFetch";
 /**
  * Returns the created graph rather than printing it: the output port renders it
  * in whatever format the caller asked for (utils/output.ts).
@@ -36,7 +37,7 @@ export const createGraphCommand = async (
       graphDef = JSON.parse(options.graph) as Record<string, unknown>;
     }
 
-    const response = await fetch(`${endpoint}/api/graphs`, {
+    const response = await langwatchFetch(`${endpoint}/api/graphs`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/sdks/typescript/src/cli/commands/graphs/delete.ts
+++ b/sdks/typescript/src/cli/commands/graphs/delete.ts
@@ -7,6 +7,7 @@ import { buildAuthHeaders } from "@/internal/api/auth";
 import type { CommandResult } from "../../utils/output";
 
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
+import { langwatchFetch } from "@/internal/http/langwatchFetch";
 /**
  * Returns the deletion outcome rather than printing it: the output port renders
  * it in whatever format the caller asked for (utils/output.ts).
@@ -22,7 +23,7 @@ export const deleteGraphCommand = async (
   const spinner = createSpinner(`Deleting graph "${id}"...`).start();
 
   try {
-    const response = await fetch(`${endpoint}/api/graphs/${encodeURIComponent(id)}`, {
+    const response = await langwatchFetch(`${endpoint}/api/graphs/${encodeURIComponent(id)}`, {
       method: "DELETE",
       headers: buildAuthHeaders({ apiKey }),
     });

--- a/sdks/typescript/src/cli/commands/graphs/get.ts
+++ b/sdks/typescript/src/cli/commands/graphs/get.ts
@@ -8,6 +8,7 @@ import { buildAuthHeaders } from "@/internal/api/auth";
 import type { CommandResult } from "../../utils/output";
 
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
+import { langwatchFetch } from "@/internal/http/langwatchFetch";
 /**
  * Returns the graph rather than printing it: the output port renders it in
  * whatever format the caller asked for (utils/output.ts).
@@ -24,7 +25,7 @@ export const getGraphCommand = async (
   const spinner = createSpinner(`Fetching graph "${id}"...`).start();
 
   try {
-    const response = await fetch(`${endpoint}/api/graphs/${id}`, {
+    const response = await langwatchFetch(`${endpoint}/api/graphs/${id}`, {
       headers: buildAuthHeaders({ apiKey }),
     });
 

--- a/sdks/typescript/src/cli/commands/graphs/list.ts
+++ b/sdks/typescript/src/cli/commands/graphs/list.ts
@@ -9,6 +9,7 @@ import { buildAuthHeaders } from "@/internal/api/auth";
 import type { CommandResult } from "../../utils/output";
 
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
+import { langwatchFetch } from "@/internal/http/langwatchFetch";
 /**
  * Returns the listing rather than printing it: the output port renders it in
  * whatever format the caller asked for (utils/output.ts). The `table` closure
@@ -29,7 +30,7 @@ export const listGraphsCommand = async (options: {
     if (options.dashboardId) params.set("dashboardId", options.dashboardId);
     const qs = params.toString() ? `?${params}` : "";
 
-    const response = await fetch(`${endpoint}/api/graphs${qs}`, {
+    const response = await langwatchFetch(`${endpoint}/api/graphs${qs}`, {
       headers: buildAuthHeaders({ apiKey }),
     });
 

--- a/sdks/typescript/src/cli/commands/graphs/update.ts
+++ b/sdks/typescript/src/cli/commands/graphs/update.ts
@@ -9,6 +9,7 @@ import { buildAuthHeaders } from "@/internal/api/auth";
 import type { CommandResult } from "../../utils/output";
 
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
+import { langwatchFetch } from "@/internal/http/langwatchFetch";
 /**
  * Returns the updated graph rather than printing it: the output port renders it
  * in whatever format the caller asked for (utils/output.ts).
@@ -48,7 +49,7 @@ export const updateGraphCommand = async (
       body.filters = JSON.parse(options.filters) as Record<string, unknown>;
     }
 
-    const response = await fetch(`${endpoint}/api/graphs/${id}`, {
+    const response = await langwatchFetch(`${endpoint}/api/graphs/${id}`, {
       method: "PATCH",
       headers: {
         "Content-Type": "application/json",

--- a/sdks/typescript/src/cli/commands/ingestion/context.ts
+++ b/sdks/typescript/src/cli/commands/ingestion/context.ts
@@ -73,6 +73,7 @@ import {
   type ResolvedSession,
   resolveSession,
 } from "./context-session";
+import { langwatchFetch } from "@/internal/http/langwatchFetch";
 
 export interface ContextCommandOptions {
   /** Declare for this session instead of resolving the live one. */
@@ -107,7 +108,7 @@ export async function contextCommand({
   env = process.env,
   cwd = process.cwd(),
   runGit = runGitCommand,
-  fetchImpl = fetch,
+  fetchImpl = langwatchFetch,
   now = Date.now,
   stateDir = defaultStateDir(),
   claudeRegistryDir,

--- a/sdks/typescript/src/cli/commands/ingestion/hook.ts
+++ b/sdks/typescript/src/cli/commands/ingestion/hook.ts
@@ -80,6 +80,7 @@ import {
   parseTraceparent,
   sessionContextFingerprint,
 } from "@/cli/utils/governance/session-context";
+import { langwatchFetch } from "@/internal/http/langwatchFetch";
 
 /**
  * What each accepted tool argument means: the agent the record declares, plus
@@ -169,7 +170,7 @@ export async function hookCommand({
   env = process.env,
   readInput = readStdin,
   runGit = runGitCommand,
-  fetchImpl = fetch,
+  fetchImpl = langwatchFetch,
   now = Date.now,
   stateDir = defaultStateDir(),
   claudeRegistryDir,

--- a/sdks/typescript/src/cli/commands/monitors/create.ts
+++ b/sdks/typescript/src/cli/commands/monitors/create.ts
@@ -9,6 +9,7 @@ import type { CommandResult } from "../../utils/output";
 import { buildAuthHeaders } from "@/internal/api/auth";
 
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
+import { langwatchFetch } from "@/internal/http/langwatchFetch";
 /**
  * Returns the created monitor rather than printing it: the output port renders
  * it in whatever format the caller asked for (utils/output.ts).
@@ -68,7 +69,7 @@ export const createMonitorCommand = async (
       parameters = JSON.parse(options.parameters) as Record<string, unknown>;
     }
 
-    const response = await fetch(`${endpoint}/api/monitors`, {
+    const response = await langwatchFetch(`${endpoint}/api/monitors`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/sdks/typescript/src/cli/commands/monitors/delete.ts
+++ b/sdks/typescript/src/cli/commands/monitors/delete.ts
@@ -7,6 +7,7 @@ import type { CommandResult } from "../../utils/output";
 import { buildAuthHeaders } from "@/internal/api/auth";
 
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
+import { langwatchFetch } from "@/internal/http/langwatchFetch";
 /**
  * Returns the deletion outcome rather than printing it: the output port renders
  * it in whatever format the caller asked for (utils/output.ts).
@@ -27,7 +28,7 @@ export const deleteMonitorCommand = async (
     deleted: boolean;
   };
   try {
-    const response = await fetch(`${endpoint}/api/monitors/${id}`, {
+    const response = await langwatchFetch(`${endpoint}/api/monitors/${id}`, {
       method: "DELETE",
       headers: buildAuthHeaders({ apiKey }),
     });

--- a/sdks/typescript/src/cli/commands/monitors/get.ts
+++ b/sdks/typescript/src/cli/commands/monitors/get.ts
@@ -8,6 +8,7 @@ import type { CommandResult } from "../../utils/output";
 import { buildAuthHeaders } from "@/internal/api/auth";
 
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
+import { langwatchFetch } from "@/internal/http/langwatchFetch";
 /**
  * Returns the monitor rather than printing it: the output port renders it in
  * whatever format the caller asked for (utils/output.ts).
@@ -38,7 +39,7 @@ export const getMonitorCommand = async (
     platformUrl?: string;
   };
   try {
-    const response = await fetch(`${endpoint}/api/monitors/${id}`, {
+    const response = await langwatchFetch(`${endpoint}/api/monitors/${id}`, {
       headers: buildAuthHeaders({ apiKey }),
     });
 

--- a/sdks/typescript/src/cli/commands/monitors/list.ts
+++ b/sdks/typescript/src/cli/commands/monitors/list.ts
@@ -9,6 +9,7 @@ import type { CommandResult } from "../../utils/output";
 import { buildAuthHeaders } from "@/internal/api/auth";
 
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
+import { langwatchFetch } from "@/internal/http/langwatchFetch";
 /**
  * Returns the listing rather than printing it: the output port renders it in
  * whatever format the caller asked for (utils/output.ts). The `table` closure
@@ -32,7 +33,7 @@ export const listMonitorsCommand = async (): Promise<CommandResult | void> => {
     sample: number;
   }>;
   try {
-    const response = await fetch(`${endpoint}/api/monitors`, {
+    const response = await langwatchFetch(`${endpoint}/api/monitors`, {
       headers: buildAuthHeaders({ apiKey }),
     });
 

--- a/sdks/typescript/src/cli/commands/monitors/update.ts
+++ b/sdks/typescript/src/cli/commands/monitors/update.ts
@@ -9,6 +9,7 @@ import type { CommandResult } from "../../utils/output";
 import { buildAuthHeaders } from "@/internal/api/auth";
 
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
+import { langwatchFetch } from "@/internal/http/langwatchFetch";
 /**
  * Returns the updated monitor rather than printing it: the output port renders
  * it in whatever format the caller asked for (utils/output.ts).
@@ -50,7 +51,7 @@ export const updateMonitorCommand = async (
       >;
     }
 
-    const response = await fetch(`${endpoint}/api/monitors/${id}`, {
+    const response = await langwatchFetch(`${endpoint}/api/monitors/${id}`, {
       method: "PATCH",
       headers: {
         "Content-Type": "application/json",

--- a/sdks/typescript/src/cli/commands/prompt/restore.ts
+++ b/sdks/typescript/src/cli/commands/prompt/restore.ts
@@ -8,6 +8,7 @@ import { buildAuthHeaders } from "@/internal/api/auth";
 
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
 import type { CommandResult } from "../../utils/output";
+import { langwatchFetch } from "@/internal/http/langwatchFetch";
 
 /**
  * Returns the restored version rather than printing it: the output port renders
@@ -28,7 +29,7 @@ export const promptRestoreCommand = async (
   ).start();
 
   try {
-    const response = await fetch(
+    const response = await langwatchFetch(
       `${endpoint}/api/prompts/${encodeURIComponent(handle)}/versions/${encodeURIComponent(versionId)}/restore`,
       {
         method: "POST",

--- a/sdks/typescript/src/cli/commands/report.ts
+++ b/sdks/typescript/src/cli/commands/report.ts
@@ -11,6 +11,7 @@ import {
   truncateJsonlToByteBudget,
 } from "../../internal/generated/redaction/sessionReport";
 import { normalizeEndpoint } from "../../internal/endpoint";
+import { langwatchFetch } from "@/internal/http/langwatchFetch";
 
 declare const __CLI_VERSION__: string;
 
@@ -186,7 +187,7 @@ export const reportCommand = async (
 
   let response: Response;
   try {
-    response = await fetch(`${endpoint}/api/bug-reports`, {
+    response = await langwatchFetch(`${endpoint}/api/bug-reports`, {
       method: "POST",
       headers: {
         "content-type": "application/json",

--- a/sdks/typescript/src/cli/commands/secrets/create.ts
+++ b/sdks/typescript/src/cli/commands/secrets/create.ts
@@ -9,6 +9,7 @@ import { buildAuthHeaders } from "@/internal/api/auth";
 
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
 import type { CommandResult } from "../../utils/output";
+import { langwatchFetch } from "@/internal/http/langwatchFetch";
 
 /**
  * Returns the created secret's metadata rather than printing it: the output
@@ -42,7 +43,7 @@ export const createSecretCommand = async (
   const spinner = createSpinner(`Creating secret "${name}"...`).start();
 
   try {
-    const response = await fetch(`${endpoint}/api/secrets`, {
+    const response = await langwatchFetch(`${endpoint}/api/secrets`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/sdks/typescript/src/cli/commands/secrets/delete.ts
+++ b/sdks/typescript/src/cli/commands/secrets/delete.ts
@@ -7,6 +7,7 @@ import { buildAuthHeaders } from "@/internal/api/auth";
 
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
 import type { CommandResult } from "../../utils/output";
+import { langwatchFetch } from "@/internal/http/langwatchFetch";
 
 /**
  * Returns the deletion result rather than printing it: the output port renders
@@ -24,7 +25,7 @@ export const deleteSecretCommand = async (
   const spinner = createSpinner(`Deleting secret "${id}"...`).start();
 
   try {
-    const response = await fetch(`${endpoint}/api/secrets/${id}`, {
+    const response = await langwatchFetch(`${endpoint}/api/secrets/${id}`, {
       method: "DELETE",
       headers: buildAuthHeaders({ apiKey }),
     });

--- a/sdks/typescript/src/cli/commands/secrets/get.ts
+++ b/sdks/typescript/src/cli/commands/secrets/get.ts
@@ -8,6 +8,7 @@ import { buildAuthHeaders } from "@/internal/api/auth";
 
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
 import type { CommandResult } from "../../utils/output";
+import { langwatchFetch } from "@/internal/http/langwatchFetch";
 
 /**
  * Returns the secret's metadata rather than printing it: the output port
@@ -27,7 +28,7 @@ export const getSecretCommand = async (
   const spinner = createSpinner(`Fetching secret "${id}"...`).start();
 
   try {
-    const response = await fetch(`${endpoint}/api/secrets/${id}`, {
+    const response = await langwatchFetch(`${endpoint}/api/secrets/${id}`, {
       headers: buildAuthHeaders({ apiKey }),
     });
 

--- a/sdks/typescript/src/cli/commands/secrets/list.ts
+++ b/sdks/typescript/src/cli/commands/secrets/list.ts
@@ -9,6 +9,7 @@ import { buildAuthHeaders } from "@/internal/api/auth";
 
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
 import type { CommandResult } from "../../utils/output";
+import { langwatchFetch } from "@/internal/http/langwatchFetch";
 
 /**
  * Returns the listing rather than printing it: the output port renders it in
@@ -25,7 +26,7 @@ export const listSecretsCommand = async (): Promise<CommandResult | void> => {
   const spinner = createSpinner("Fetching secrets...").start();
 
   try {
-    const response = await fetch(`${endpoint}/api/secrets`, {
+    const response = await langwatchFetch(`${endpoint}/api/secrets`, {
       headers: buildAuthHeaders({ apiKey }),
     });
 

--- a/sdks/typescript/src/cli/commands/secrets/update.ts
+++ b/sdks/typescript/src/cli/commands/secrets/update.ts
@@ -8,6 +8,7 @@ import { buildAuthHeaders } from "@/internal/api/auth";
 
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
 import type { CommandResult } from "../../utils/output";
+import { langwatchFetch } from "@/internal/http/langwatchFetch";
 
 /**
  * Returns the updated secret's metadata rather than printing it: the output
@@ -29,7 +30,7 @@ export const updateSecretCommand = async (
   const spinner = createSpinner(`Updating secret "${id}"...`).start();
 
   try {
-    const response = await fetch(`${endpoint}/api/secrets/${id}`, {
+    const response = await langwatchFetch(`${endpoint}/api/secrets/${id}`, {
       method: "PUT",
       headers: {
         "Content-Type": "application/json",

--- a/sdks/typescript/src/cli/commands/sessions/events.ts
+++ b/sdks/typescript/src/cli/commands/sessions/events.ts
@@ -11,6 +11,7 @@ import {
 } from "../../utils/output";
 import { createCommandEvents } from "../../telemetry/events";
 import { cliAuthHeaders } from "../../utils/authHeaders";
+import { langwatchFetch } from "@/internal/http/langwatchFetch";
 
 /** Bound each page request so a quiet socket cannot hold the CLI open forever. */
 const REQUEST_TIMEOUT_MS = 60_000;
@@ -124,7 +125,7 @@ const fetchAllSessionEvents = async ({
     if (toMs !== undefined) params.set("to", String(toMs));
     if (cursor) params.set("cursor", cursor);
 
-    const response = await fetch(
+    const response = await langwatchFetch(
       `${endpoint}/api/coding-agent/sessions/${encodeURIComponent(sessionId)}/events?${params}`,
       {
         headers: cliAuthHeaders({ apiKey }),

--- a/sdks/typescript/src/cli/commands/simulation-runs/get.ts
+++ b/sdks/typescript/src/cli/commands/simulation-runs/get.ts
@@ -8,6 +8,7 @@ import type { CommandResult } from "../../utils/output";
 import { buildAuthHeaders } from "@/internal/api/auth";
 
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
+import { langwatchFetch } from "@/internal/http/langwatchFetch";
 /**
  * Flattens Anthropic-style content (string OR array of {type:text|tool_use|tool_result|thinking})
  * into a readable single-line string. Thinking blocks are dropped; tool_use shows the tool name;
@@ -67,7 +68,7 @@ export const getSimulationRunCommand = async (
   const spinner = createSpinner(`Fetching simulation run "${runId}"...`).start();
 
   try {
-    const response = await fetch(
+    const response = await langwatchFetch(
       `${endpoint}/api/simulation-runs/${encodeURIComponent(runId)}`,
       {
         method: "GET",

--- a/sdks/typescript/src/cli/commands/simulation-runs/list.ts
+++ b/sdks/typescript/src/cli/commands/simulation-runs/list.ts
@@ -9,6 +9,7 @@ import type { CommandResult } from "../../utils/output";
 import { buildAuthHeaders } from "@/internal/api/auth";
 
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
+import { langwatchFetch } from "@/internal/http/langwatchFetch";
 
 type SimulationRunListItem = {
   scenarioRunId: string;
@@ -69,7 +70,7 @@ export const listSimulationRunsCommand = async (options: {
       if (limit) params.set("limit", limit);
       if (cursor) params.set("cursor", cursor);
 
-      const response = await fetch(
+      const response = await langwatchFetch(
         `${endpoint}/api/simulation-runs?${params.toString()}`,
         {
           method: "GET",

--- a/sdks/typescript/src/cli/commands/status.ts
+++ b/sdks/typescript/src/cli/commands/status.ts
@@ -14,6 +14,7 @@ import { buildCatalog, renderStatusSummary } from "../utils/commandCatalog";
 import { TracesApiService } from "@/client-sdk/services/traces/traces-api.service";
 import { ExperimentsApiService } from "@/client-sdk/services/experiments/experiments-api.service";
 import { GatewayBudgetsApiService } from "@/client-sdk/services/gateway-budgets/gateway-budgets-api.service";
+import { langwatchFetch } from "@/internal/http/langwatchFetch";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 /** Budgets at or above this utilization are worth a human's attention. */
@@ -164,7 +165,7 @@ export const statusCommand = async (options?: RawOutputFlags): Promise<void> => 
   };
 
   async function fetchCount(url: string): Promise<{ data: unknown; error?: unknown; status?: number }> {
-    const response = await fetch(`${endpoint}${url}`, {
+    const response = await langwatchFetch(`${endpoint}${url}`, {
       headers: buildAuthHeaders({ apiKey }),
     });
     if (!response.ok) {

--- a/sdks/typescript/src/cli/commands/traces/export.ts
+++ b/sdks/typescript/src/cli/commands/traces/export.ts
@@ -10,6 +10,7 @@ import { cliAuthHeaders } from "../../utils/authHeaders";
 
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
 import { parseOriginOption } from "./origin-filter";
+import { langwatchFetch } from "@/internal/http/langwatchFetch";
 
 /** Rows are serialised in chunks so the progress bar moves as the file is built. */
 const PROGRESS_CHUNK = 25;
@@ -122,7 +123,7 @@ export const exportTracesCommand = async (options: {
         options.includeSpans ? SPANS_PAGE_CAP : SERVER_PAGE_CAP,
       );
 
-      const response = await fetch(`${endpoint}/api/traces/search`, {
+      const response = await langwatchFetch(`${endpoint}/api/traces/search`, {
         method: "POST",
         signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
         headers: {

--- a/sdks/typescript/src/cli/commands/traces/transcript.ts
+++ b/sdks/typescript/src/cli/commands/traces/transcript.ts
@@ -14,6 +14,7 @@ import { createCommandEvents } from "../../telemetry/events";
 import { cliAuthHeaders } from "../../utils/authHeaders";
 
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
+import { langwatchFetch } from "@/internal/http/langwatchFetch";
 
 /** Bound the request so a quiet socket cannot hold the CLI open forever. */
 const REQUEST_TIMEOUT_MS = 60_000;
@@ -62,7 +63,7 @@ export const transcriptTraceCommand = async (
   try {
     events.started("Fetching transcript…");
 
-    const response = await fetch(
+    const response = await langwatchFetch(
       `${endpoint}/api/traces/${encodeURIComponent(traceId)}/transcript`,
       {
         headers: cliAuthHeaders({ apiKey }),

--- a/sdks/typescript/src/cli/commands/triggers/create.ts
+++ b/sdks/typescript/src/cli/commands/triggers/create.ts
@@ -10,6 +10,7 @@ import { buildAuthHeaders } from "@/internal/api/auth";
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
 import type { CommandResult } from "../../utils/output";
 import { redactTriggerSecrets } from "./redact";
+import { langwatchFetch } from "@/internal/http/langwatchFetch";
 
 /**
  * Returns the created trigger rather than printing it: the output port renders
@@ -51,7 +52,7 @@ export const createTriggerCommand = async (
     const actionParams: Record<string, unknown> = {};
     if (options.slackWebhook) actionParams.slackWebhook = options.slackWebhook;
 
-    const response = await fetch(`${endpoint}/api/triggers`, {
+    const response = await langwatchFetch(`${endpoint}/api/triggers`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/sdks/typescript/src/cli/commands/triggers/delete.ts
+++ b/sdks/typescript/src/cli/commands/triggers/delete.ts
@@ -7,6 +7,7 @@ import { buildAuthHeaders } from "@/internal/api/auth";
 
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
 import type { CommandResult } from "../../utils/output";
+import { langwatchFetch } from "@/internal/http/langwatchFetch";
 
 /**
  * Returns the deletion result rather than printing it: the output port renders
@@ -23,7 +24,7 @@ export const deleteTriggerCommand = async (
   const spinner = createSpinner(`Deleting trigger "${id}"...`).start();
 
   try {
-    const response = await fetch(`${endpoint}/api/triggers/${encodeURIComponent(id)}`, {
+    const response = await langwatchFetch(`${endpoint}/api/triggers/${encodeURIComponent(id)}`, {
       method: "DELETE",
       headers: buildAuthHeaders({ apiKey }),
     });

--- a/sdks/typescript/src/cli/commands/triggers/get.ts
+++ b/sdks/typescript/src/cli/commands/triggers/get.ts
@@ -9,6 +9,7 @@ import { buildAuthHeaders } from "@/internal/api/auth";
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
 import type { CommandResult } from "../../utils/output";
 import { redactTriggerSecrets } from "./redact";
+import { langwatchFetch } from "@/internal/http/langwatchFetch";
 
 /**
  * Returns the trigger rather than printing it: the output port renders it in
@@ -27,7 +28,7 @@ export const getTriggerCommand = async (
   const spinner = createSpinner(`Fetching trigger "${id}"...`).start();
 
   try {
-    const response = await fetch(`${endpoint}/api/triggers/${encodeURIComponent(id)}`, {
+    const response = await langwatchFetch(`${endpoint}/api/triggers/${encodeURIComponent(id)}`, {
       headers: buildAuthHeaders({ apiKey }),
     });
 

--- a/sdks/typescript/src/cli/commands/triggers/list.ts
+++ b/sdks/typescript/src/cli/commands/triggers/list.ts
@@ -10,6 +10,7 @@ import { buildAuthHeaders } from "@/internal/api/auth";
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
 import type { CommandResult } from "../../utils/output";
 import { redactTriggerListSecrets } from "./redact";
+import { langwatchFetch } from "@/internal/http/langwatchFetch";
 
 /**
  * Returns the listing rather than printing it: the output port renders it in
@@ -24,7 +25,7 @@ export const listTriggersCommand = async (): Promise<CommandResult | void> => {
   const spinner = createSpinner("Fetching triggers...").start();
 
   try {
-    const response = await fetch(`${endpoint}/api/triggers`, {
+    const response = await langwatchFetch(`${endpoint}/api/triggers`, {
       headers: buildAuthHeaders({ apiKey }),
     });
 

--- a/sdks/typescript/src/cli/commands/triggers/update.ts
+++ b/sdks/typescript/src/cli/commands/triggers/update.ts
@@ -8,6 +8,7 @@ import { buildAuthHeaders } from "@/internal/api/auth";
 
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
 import type { CommandResult } from "../../utils/output";
+import { langwatchFetch } from "@/internal/http/langwatchFetch";
 
 /**
  * Returns the updated trigger rather than printing it: the output port renders
@@ -47,7 +48,7 @@ export const updateTriggerCommand = async (
       process.exit(1);
     }
 
-    const response = await fetch(`${endpoint}/api/triggers/${encodeURIComponent(id)}`, {
+    const response = await langwatchFetch(`${endpoint}/api/triggers/${encodeURIComponent(id)}`, {
       method: "PATCH",
       headers: {
         "Content-Type": "application/json",

--- a/sdks/typescript/src/cli/commands/ui/actions.ts
+++ b/sdks/typescript/src/cli/commands/ui/actions.ts
@@ -1,6 +1,7 @@
 import { resolveCredentials } from "../../utils/apiKey";
 import type { CommandResult } from "../../utils/output";
 import { asCommandResult } from "./call";
+import { langwatchFetch } from "@/internal/http/langwatchFetch";
 
 /**
  * Bound the request so a quiet socket cannot hold the CLI open forever. This
@@ -20,7 +21,7 @@ export const uiActionsCommand = async (): Promise<CommandResult | void> => {
 
   let response: Response;
   try {
-    response = await fetch(`${endpoint}/api/langy/ui/actions`, {
+    response = await langwatchFetch(`${endpoint}/api/langy/ui/actions`, {
       method: "GET",
       headers: { "X-Auth-Token": apiKey },
       signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),

--- a/sdks/typescript/src/cli/commands/ui/actions.ts
+++ b/sdks/typescript/src/cli/commands/ui/actions.ts
@@ -20,17 +20,23 @@ export const uiActionsCommand = async (): Promise<CommandResult | void> => {
   const { apiKey, endpoint } = await resolveCredentials();
 
   let response: Response;
+  let text: string;
   try {
     response = await langwatchFetch(`${endpoint}/api/langy/ui/actions`, {
       method: "GET",
       headers: { "X-Auth-Token": apiKey },
       signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
     });
+    // The deadline covers the body too: a socket that goes quiet after the
+    // headers aborts this read, not the send.
+    text = await response.text();
   } catch (error) {
     // A tripped deadline rejects with a bare TimeoutError, which reads as a
     // crash rather than as the limit this command set. Name it, and leave every
-    // other failure to the caller's error path.
-    if ((error as { name?: string } | null)?.name !== "TimeoutError") throw error;
+    // other failure to the caller's error path. An aborted body read arrives as
+    // an AbortError instead.
+    const name = (error as { name?: string } | null)?.name;
+    if (name !== "TimeoutError" && name !== "AbortError") throw error;
     process.stderr.write(
       `${endpoint} did not answer with the UI actions within ${REQUEST_TIMEOUT_MS / 1000}s.\n`,
     );
@@ -38,7 +44,6 @@ export const uiActionsCommand = async (): Promise<CommandResult | void> => {
     return;
   }
 
-  const text = await response.text();
   if (!response.ok) {
     process.stderr.write(`${text}\n`);
     process.exitCode = 1;

--- a/sdks/typescript/src/cli/commands/ui/call.ts
+++ b/sdks/typescript/src/cli/commands/ui/call.ts
@@ -137,6 +137,7 @@ export const uiCallCommand = async (
   }
 
   let response: Response;
+  let text: string;
   try {
     response = await langwatchFetch(`${endpoint}/api/langy/ui/actions`, {
       method: "POST",
@@ -154,11 +155,16 @@ export const uiCallCommand = async (
       }),
       signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
     });
+    // The deadline covers the body too: a socket that goes quiet after the
+    // headers aborts this read, not the send.
+    text = await response.text();
   } catch (error) {
     // A tripped deadline rejects with a bare TimeoutError, which reads as a
     // crash rather than as the limit this command set. Name it. Every other
-    // failure is left to the caller's error path.
-    if ((error as { name?: string } | null)?.name !== "TimeoutError") throw error;
+    // failure is left to the caller's error path. An aborted body read arrives
+    // as an AbortError instead.
+    const name = (error as { name?: string } | null)?.name;
+    if (name !== "TimeoutError" && name !== "AbortError") throw error;
     process.stderr.write(
       `${endpoint} did not answer "${kind}" within ${REQUEST_TIMEOUT_MS / 1000}s. ` +
         `${MAY_HAVE_APPLIED}\n`,
@@ -167,7 +173,6 @@ export const uiCallCommand = async (
     return;
   }
 
-  const text = await response.text();
   if (!response.ok) {
     // Through the shared reporter, not straight to stderr. The body is the
     // platform's REST envelope (`{error: {...}}`), and the reader on the other

--- a/sdks/typescript/src/cli/commands/ui/call.ts
+++ b/sdks/typescript/src/cli/commands/ui/call.ts
@@ -3,6 +3,7 @@ import { handledErrorFrom } from "@/internal/api/errors";
 import { resolveCredentials } from "../../utils/apiKey";
 import { reportCommandError } from "../../utils/errorOutput";
 import type { CommandResult } from "../../utils/output";
+import { langwatchFetch } from "@/internal/http/langwatchFetch";
 
 /**
  * Bound the request so a wedged control plane cannot hold the whole turn.
@@ -137,7 +138,7 @@ export const uiCallCommand = async (
 
   let response: Response;
   try {
-    response = await fetch(`${endpoint}/api/langy/ui/actions`, {
+    response = await langwatchFetch(`${endpoint}/api/langy/ui/actions`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/sdks/typescript/src/cli/commands/workflows/run.ts
+++ b/sdks/typescript/src/cli/commands/workflows/run.ts
@@ -10,6 +10,7 @@ import type { CommandResult } from "../../utils/output";
 
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
 import { parseRunParameterFlags } from "../../utils/keyValueFlags";
+import { langwatchFetch } from "@/internal/http/langwatchFetch";
 
 export const runWorkflowCommand = async ({
   id,
@@ -47,7 +48,7 @@ export const runWorkflowCommand = async ({
     const apiKey = scopedApiKey() ?? process.env.LANGWATCH_API_KEY ?? "";
     const endpoint = resolveControlPlaneUrl();
 
-    const response = await fetch(`${endpoint}/api/workflows/${encodeURIComponent(id)}/run`, {
+    const response = await langwatchFetch(`${endpoint}/api/workflows/${encodeURIComponent(id)}/run`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/sdks/typescript/src/cli/commands/workflows/update.ts
+++ b/sdks/typescript/src/cli/commands/workflows/update.ts
@@ -9,6 +9,7 @@ import { buildAuthHeaders } from "@/internal/api/auth";
 import type { CommandResult } from "../../utils/output";
 
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
+import { langwatchFetch } from "@/internal/http/langwatchFetch";
 export const updateWorkflowCommand = async (
   id: string,
   options: { name?: string; icon?: string; description?: string },
@@ -37,7 +38,7 @@ export const updateWorkflowCommand = async (
       process.exit(1);
     }
 
-    const response = await fetch(
+    const response = await langwatchFetch(
       `${endpoint}/api/workflows/${encodeURIComponent(id)}`,
       {
         method: "PATCH",

--- a/sdks/typescript/src/cli/utils/batchRunProgress.ts
+++ b/sdks/typescript/src/cli/utils/batchRunProgress.ts
@@ -1,3 +1,5 @@
+import { langwatchFetch } from "@/internal/http/langwatchFetch";
+
 /**
  * How far along a batch of simulation runs is.
  *
@@ -91,7 +93,7 @@ export async function fetchBatchRuns({
 		url.searchParams.set("limit", "100");
 		if (cursor) url.searchParams.set("cursor", cursor);
 
-		const response = await fetch(url, { method: "GET", headers });
+		const response = await langwatchFetch(url, { method: "GET", headers });
 		if (!response.ok) {
 			throw new Error(`status endpoint answered ${response.status}`);
 		}

--- a/sdks/typescript/src/cli/utils/identityNotice.ts
+++ b/sdks/typescript/src/cli/utils/identityNotice.ts
@@ -42,6 +42,7 @@ import * as path from "node:path";
 import chalk from "chalk";
 import { normalizeEndpoint } from "../../internal/endpoint";
 import { configPath } from "./governance/config";
+import { langwatchFetch } from "@/internal/http/langwatchFetch";
 
 /** How long one showing of the notice keeps later ones quiet. */
 export const NOTICE_SUPPRESSION_MS = 30 * 60 * 1000;
@@ -167,7 +168,7 @@ export async function maybePrintIdentityNotice({
   mode,
   apiKey,
   endpoint,
-  fetchImpl = fetch,
+  fetchImpl = langwatchFetch,
 }: {
   mode: NoticeMode;
   apiKey: string;

--- a/sdks/typescript/src/client-sdk/services/_shared/management-request.ts
+++ b/sdks/typescript/src/client-sdk/services/_shared/management-request.ts
@@ -17,6 +17,7 @@
 import { scopedApiKey } from "@/internal/credentialContext";
 import { formatApiErrorForOperation } from "./format-api-error";
 import { throwIfHandledError } from "./throw-handled-error";
+import { langwatchFetch } from "@/internal/http/langwatchFetch";
 
 /** Builds the family's own error for a failure the platform did not name. */
 export type ManagementErrorFactory = (params: {
@@ -105,7 +106,7 @@ export const createManagementRequest = ({
     query,
     signal,
   }: ManagementRequestParams): Promise<T> => {
-    const response = await fetch(
+    const response = await langwatchFetch(
       `${endpoint}${path}${buildQueryString(query)}`,
       {
         ...(method ? { method } : {}),

--- a/sdks/typescript/src/client-sdk/services/api-keys/api-keys-api.service.ts
+++ b/sdks/typescript/src/client-sdk/services/api-keys/api-keys-api.service.ts
@@ -6,6 +6,7 @@ import type {
 } from "@/client-sdk/services/_shared/management-types";
 import { throwIfHandledError } from "@/client-sdk/services/_shared/throw-handled-error";
 import { resolveEndpoint } from "@/internal/endpoint";
+import { langwatchFetch } from "@/internal/http/langwatchFetch";
 
 export interface RoleBinding {
   id: string;
@@ -120,7 +121,7 @@ export class ApiKeysApiService {
   }
 
   private async request<T>(operation: string, path: string, init?: RequestInit): Promise<T> {
-    const response = await fetch(`${this.endpoint}${path}`, {
+    const response = await langwatchFetch(`${this.endpoint}${path}`, {
       ...init,
       headers: { ...this.headers(), ...(init?.headers ?? {}) },
     });

--- a/sdks/typescript/src/client-sdk/services/datasets/dataset.service.ts
+++ b/sdks/typescript/src/client-sdk/services/datasets/dataset.service.ts
@@ -26,6 +26,7 @@ import { tracer } from "./tracing";
 import { formatApiErrorMessage } from "@/client-sdk/services/_shared/format-api-error";
 import { buildAuthHeaders } from "@/internal/api/auth";
 import { resolveEndpoint } from "@/internal/endpoint";
+import { langwatchFetch } from "@/internal/http/langwatchFetch";
 
 type DatasetServiceConfig = {
   langwatchApiClient: LangwatchApiClient;
@@ -414,7 +415,7 @@ export class DatasetService {
     const { endpoint, apiKey } = this.config;
     const url = `${endpoint}${path}`;
 
-    const response = await fetch(url, {
+    const response = await langwatchFetch(url, {
       method: "POST",
       headers: buildAuthHeaders({ apiKey }),
       body: formData,

--- a/sdks/typescript/src/client-sdk/services/evaluations/evaluations.facade.ts
+++ b/sdks/typescript/src/client-sdk/services/evaluations/evaluations.facade.ts
@@ -36,6 +36,7 @@ import {
 } from "./errors";
 import type { Logger } from "@/logger";
 import { buildAuthHeaders } from "@/internal/api/auth";
+import { langwatchFetch } from "@/internal/http/langwatchFetch";
 
 type EvaluationsFacadeConfig = {
   endpoint: string;
@@ -148,7 +149,7 @@ export class EvaluationsFacade {
 
       this.#logger.debug(`Calling evaluation API: ${url}`);
 
-      const response = await fetch(url, {
+      const response = await langwatchFetch(url, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/sdks/typescript/src/client-sdk/services/experiments/experiment.ts
+++ b/sdks/typescript/src/client-sdk/services/experiments/experiment.ts
@@ -61,6 +61,7 @@ import {
 } from "./comparison";
 import { printSummary } from "./printSummary";
 import { buildAuthHeaders } from "@/internal/api/auth";
+import { langwatchFetch } from "@/internal/http/langwatchFetch";
 
 const DEFAULT_CONCURRENCY = 4;
 const DEBOUNCE_INTERVAL_MS = 1000;
@@ -226,7 +227,7 @@ export class Experiment {
     }
 
     try {
-      const response = await fetch(`${this.endpoint}/api/experiment/init`, {
+      const response = await langwatchFetch(`${this.endpoint}/api/experiment/init`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -670,7 +671,7 @@ export class Experiment {
     spanId?: string | null;
     asGuardrail?: boolean;
   }): Promise<RunEvaluatorResponse> {
-    const response = await fetch(
+    const response = await langwatchFetch(
       `${this.endpoint}/api/evaluations/${evaluatorSlug}/evaluate`,
       {
         method: "POST",
@@ -1382,7 +1383,7 @@ export class Experiment {
     };
 
     // Fire and forget (with error logging)
-    this.pendingFlush = fetch(`${this.endpoint}/api/evaluations/batch/log_results`, {
+    this.pendingFlush = langwatchFetch(`${this.endpoint}/api/evaluations/batch/log_results`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/sdks/typescript/src/client-sdk/services/gateway-budgets/gateway-budgets-api.service.ts
+++ b/sdks/typescript/src/client-sdk/services/gateway-budgets/gateway-budgets-api.service.ts
@@ -14,6 +14,7 @@ import {
 import { formatApiErrorForOperation } from "@/client-sdk/services/_shared/format-api-error";
 import { throwIfHandledError } from "@/client-sdk/services/_shared/throw-handled-error";
 import { resolveEndpoint } from "@/internal/endpoint";
+import { langwatchFetch } from "@/internal/http/langwatchFetch";
 
 export type BudgetScopeKind =
   | "organization"
@@ -191,7 +192,7 @@ export class GatewayBudgetsApiService {
     path: string,
     init?: ObservedRequestInit,
   ): Promise<T> {
-    const response = await fetch(`${this.endpoint}${path}`, {
+    const response = await langwatchFetch(`${this.endpoint}${path}`, {
       ...init,
       // A hung control plane must fail the command, not freeze it.
       signal: init?.signal ?? AbortSignal.timeout(30_000),

--- a/sdks/typescript/src/client-sdk/services/model-defaults/model-defaults-api.service.ts
+++ b/sdks/typescript/src/client-sdk/services/model-defaults/model-defaults-api.service.ts
@@ -3,6 +3,7 @@ import { resolveEndpoint } from "@/internal/endpoint";
 import { buildAuthHeaders } from "@/internal/api/auth";
 import { formatApiErrorMessage } from "@/client-sdk/services/_shared/format-api-error";
 import { throwIfHandledError } from "@/client-sdk/services/_shared/throw-handled-error";
+import { langwatchFetch } from "@/internal/http/langwatchFetch";
 
 export type ModelDefaultScopeType = "ORGANIZATION" | "TEAM" | "PROJECT";
 
@@ -74,7 +75,7 @@ export class ModelDefaultsApiService {
     path: string,
     options?: RequestInit & { allowNoContent?: boolean },
   ): Promise<T> {
-    const response = await fetch(`${this.endpoint}${path}`, {
+    const response = await langwatchFetch(`${this.endpoint}${path}`, {
       ...options,
       headers: {
         ...buildAuthHeaders({ apiKey: this.apiKey }),

--- a/sdks/typescript/src/client-sdk/services/monitors/monitors-api.service.ts
+++ b/sdks/typescript/src/client-sdk/services/monitors/monitors-api.service.ts
@@ -3,6 +3,7 @@ import { resolveEndpoint } from "@/internal/endpoint";
 import { buildAuthHeaders } from "@/internal/api/auth";
 import { formatApiErrorMessage } from "@/client-sdk/services/_shared/format-api-error";
 import { throwIfHandledError } from "@/client-sdk/services/_shared/throw-handled-error";
+import { langwatchFetch } from "@/internal/http/langwatchFetch";
 
 export interface MonitorResponse {
   id: string;
@@ -69,7 +70,7 @@ export class MonitorsApiService {
   }
 
   private async request<T>(path: string, options?: RequestInit): Promise<T> {
-    const response = await fetch(`${this.endpoint}${path}`, {
+    const response = await langwatchFetch(`${this.endpoint}${path}`, {
       ...options,
       headers: {
         ...buildAuthHeaders({ apiKey: this.apiKey }),

--- a/sdks/typescript/src/client-sdk/services/projects/projects-api.service.ts
+++ b/sdks/typescript/src/client-sdk/services/projects/projects-api.service.ts
@@ -2,6 +2,7 @@ import { scopedApiKey } from "@/internal/credentialContext";
 import { formatApiErrorForOperation } from "@/client-sdk/services/_shared/format-api-error";
 import { throwIfHandledError } from "@/client-sdk/services/_shared/throw-handled-error";
 import { resolveEndpoint } from "@/internal/endpoint";
+import { langwatchFetch } from "@/internal/http/langwatchFetch";
 
 export interface Project {
   id: string;
@@ -93,7 +94,7 @@ export class ProjectsApiService {
   }
 
   private async request<T>(operation: string, path: string, init?: RequestInit): Promise<T> {
-    const response = await fetch(`${this.endpoint}${path}`, {
+    const response = await langwatchFetch(`${this.endpoint}${path}`, {
       ...init,
       headers: { ...this.headers(), ...(init?.headers ?? {}) },
     });

--- a/sdks/typescript/src/client-sdk/services/secrets/secrets-api.service.ts
+++ b/sdks/typescript/src/client-sdk/services/secrets/secrets-api.service.ts
@@ -3,6 +3,7 @@ import { resolveEndpoint } from "@/internal/endpoint";
 import { buildAuthHeaders } from "@/internal/api/auth";
 import { formatApiErrorMessage } from "@/client-sdk/services/_shared/format-api-error";
 import { throwIfHandledError } from "@/client-sdk/services/_shared/throw-handled-error";
+import { langwatchFetch } from "@/internal/http/langwatchFetch";
 
 export interface SecretResponse {
   id: string;
@@ -38,7 +39,7 @@ export class SecretsApiService {
   }
 
   private async request<T>(path: string, options?: RequestInit): Promise<T> {
-    const response = await fetch(`${this.endpoint}${path}`, {
+    const response = await langwatchFetch(`${this.endpoint}${path}`, {
       ...options,
       headers: {
         ...buildAuthHeaders({ apiKey: this.apiKey }),

--- a/sdks/typescript/src/client-sdk/services/spend-events/spend-events-api.service.ts
+++ b/sdks/typescript/src/client-sdk/services/spend-events/spend-events-api.service.ts
@@ -10,6 +10,7 @@ import {
 import { formatApiErrorForOperation } from "@/client-sdk/services/_shared/format-api-error";
 import { throwIfHandledError } from "@/client-sdk/services/_shared/throw-handled-error";
 import { resolveEndpoint } from "@/internal/endpoint";
+import { langwatchFetch } from "@/internal/http/langwatchFetch";
 
 export interface SpendEvent {
   id: string;
@@ -331,7 +332,7 @@ export class SpendEventsApiService {
     path: string,
     init?: RequestInit,
   ): Promise<T> {
-    const response = await fetch(`${this.endpoint}${path}`, {
+    const response = await langwatchFetch(`${this.endpoint}${path}`, {
       ...init,
       // A hung control plane must fail the command, not freeze it.
       signal: init?.signal ?? AbortSignal.timeout(30_000),

--- a/sdks/typescript/src/client-sdk/services/virtual-keys/virtual-keys-api.service.ts
+++ b/sdks/typescript/src/client-sdk/services/virtual-keys/virtual-keys-api.service.ts
@@ -14,6 +14,7 @@ import {
 import { formatApiErrorForOperation } from "@/client-sdk/services/_shared/format-api-error";
 import { throwIfHandledError } from "@/client-sdk/services/_shared/throw-handled-error";
 import { resolveEndpoint } from "@/internal/endpoint";
+import { langwatchFetch } from "@/internal/http/langwatchFetch";
 
 export type VirtualKeyScopeType = "organization" | "team" | "project";
 
@@ -221,7 +222,7 @@ export class VirtualKeysApiService {
     path: string,
     init?: ObservedRequestInit,
   ): Promise<T> {
-    const response = await fetch(`${this.endpoint}${path}`, {
+    const response = await langwatchFetch(`${this.endpoint}${path}`, {
       ...init,
       // A hung control plane must fail the command, not freeze it.
       signal: init?.signal ?? AbortSignal.timeout(30_000),

--- a/sdks/typescript/src/client-sdk/services/webhooks/webhooks-api.service.ts
+++ b/sdks/typescript/src/client-sdk/services/webhooks/webhooks-api.service.ts
@@ -13,6 +13,7 @@ import {
 import { formatApiErrorForOperation } from "@/client-sdk/services/_shared/format-api-error";
 import { throwIfHandledError } from "@/client-sdk/services/_shared/throw-handled-error";
 import { resolveEndpoint } from "@/internal/endpoint";
+import { langwatchFetch } from "@/internal/http/langwatchFetch";
 
 /** Where an endpoint delivers. */
 export type WebhookDestinationKind = "http" | "sqs";
@@ -230,7 +231,7 @@ export class WebhooksApiService {
     path: string,
     init?: ObservedRequestInit,
   ): Promise<T> {
-    const response = await fetch(`${this.endpoint}${path}`, {
+    const response = await langwatchFetch(`${this.endpoint}${path}`, {
       ...init,
       // A hung control plane must fail the command, not freeze it.
       signal: init?.signal ?? AbortSignal.timeout(30_000),

--- a/sdks/typescript/src/index.ts
+++ b/sdks/typescript/src/index.ts
@@ -244,3 +244,17 @@ export const logger = {
   ConsoleLogger,
   NoOpLogger,
 };
+
+/**
+ * The HTTP client every SDK request to the LangWatch API goes through. It
+ * follows a redirect only when it upgrades http to https on the same URL and
+ * refuses every other one with `LangWatchRedirectError`. `createLangWatchFetch`
+ * builds one over another transport or logger.
+ */
+export {
+  langwatchFetch,
+  createLangWatchFetch,
+  LangWatchRedirectError,
+  type LangWatchFetch,
+  type CreateLangWatchFetchOptions,
+} from "./internal/http/langwatchFetch";

--- a/sdks/typescript/src/internal/api/client.ts
+++ b/sdks/typescript/src/internal/api/client.ts
@@ -11,6 +11,7 @@ import { resolveEndpoint } from "@/internal/endpoint";
 import { scopedApiKey, scopedProjectId } from "@/internal/credentialContext";
 import { buildAuthHeaders } from "./auth";
 import { handledErrorFrom } from "./errors";
+import { langwatchFetch } from "../http/langwatchFetch";
 
 /**
  * Turns a NAMED failure into a typed throw, once, for every call that goes
@@ -89,6 +90,7 @@ export const createLangWatchApiClient = (
 ) => {
   const client = openApiCreateClient<paths>({
     baseUrl: resolveEndpoint(endpoint),
+    fetch: langwatchFetch,
     headers: {
       ...buildAuthHeaders({ apiKey, projectId }),
       "content-type": "application/json",

--- a/sdks/typescript/src/internal/http/__tests__/langwatchFetch.unit.test.ts
+++ b/sdks/typescript/src/internal/http/__tests__/langwatchFetch.unit.test.ts
@@ -240,6 +240,34 @@ describe("langwatchFetch", () => {
         expect(error.status).toBe(307);
         expect(calls).toHaveLength(1);
       });
+
+      /** @scenario refuses to replay a streaming body */
+      it("settles when the caller aborts while a Request's streamed body is replayed", async () => {
+        const { fetchImpl, calls } = scripted(redirect({ status: 307, location: HTTPS_URL }), ok());
+        const fetchLangWatch = createLangWatchFetch({ fetch: fetchImpl, logger: silentLogger() });
+        const controller = new AbortController();
+        // One chunk, then silence: reading it to the end never finishes, so
+        // only the abort can settle the call.
+        const stream = new ReadableStream<Uint8Array>({
+          start(streamController) {
+            streamController.enqueue(new TextEncoder().encode("{"));
+          },
+        });
+        const request = new Request(HTTP_URL, {
+          method: "POST",
+          body: stream,
+          signal: controller.signal,
+          // @ts-expect-error duplex is required for streamed bodies in Node
+          duplex: "half",
+        });
+
+        const call = fetchLangWatch(request);
+        await Promise.resolve();
+        controller.abort();
+
+        await expect(call).rejects.toMatchObject({ name: "AbortError" });
+        expect(calls).toHaveLength(1);
+      });
     });
   });
 

--- a/sdks/typescript/src/internal/http/__tests__/langwatchFetch.unit.test.ts
+++ b/sdks/typescript/src/internal/http/__tests__/langwatchFetch.unit.test.ts
@@ -241,7 +241,18 @@ describe("langwatchFetch", () => {
         expect(calls).toHaveLength(1);
       });
 
-      /** @scenario refuses to replay a streaming body */
+      /** @scenario a body that is never replayed is released without waiting */
+      it("returns the answer to a Request with a body that is not a redirect", async () => {
+        const { fetchImpl } = scripted(ok("done"));
+        const fetchLangWatch = createLangWatchFetch({ fetch: fetchImpl, logger: silentLogger() });
+        const request = new Request(HTTPS_URL, { method: "POST", body: "{}" });
+
+        const response = await fetchLangWatch(request);
+
+        expect(await response.text()).toBe("done");
+      });
+
+      /** @scenario an aborted call settles while a streamed body is replayed */
       it("settles when the caller aborts while a Request's streamed body is replayed", async () => {
         const { fetchImpl, calls } = scripted(redirect({ status: 307, location: HTTPS_URL }), ok());
         const fetchLangWatch = createLangWatchFetch({ fetch: fetchImpl, logger: silentLogger() });

--- a/sdks/typescript/src/internal/http/__tests__/langwatchFetch.unit.test.ts
+++ b/sdks/typescript/src/internal/http/__tests__/langwatchFetch.unit.test.ts
@@ -350,6 +350,27 @@ describe("langwatchFetch", () => {
     });
 
     /** @scenario a GET drops credential headers on a cross origin redirect */
+    it("drops Cookie, Proxy-Authorization and X-Api-Key on a hop to another host too", async () => {
+      const { fetchImpl, calls } = scripted(redirect({ status: 302, location: OTHER_HOST }), ok());
+      const fetchLangWatch = createLangWatchFetch({ fetch: fetchImpl, logger: silentLogger() });
+
+      await fetchLangWatch(HTTPS_URL, {
+        headers: {
+          ...CREDENTIALS,
+          Cookie: "session=secret",
+          "Proxy-Authorization": "Basic c2VjcmV0",
+          "X-Api-Key": "sk-lw-secret",
+        },
+      });
+
+      const hop = headersOf(calls[1]!);
+      expect(hop.get("cookie")).toBeNull();
+      expect(hop.get("proxy-authorization")).toBeNull();
+      expect(hop.get("x-api-key")).toBeNull();
+      expect(hop.get("accept")).toBe("application/json");
+    });
+
+    /** @scenario a GET drops credential headers on a cross origin redirect */
     it("drops credential headers on a hop to another port of the same host", async () => {
       const { fetchImpl, calls } = scripted(
         redirect({ status: 302, location: "https://app.langwatch.ai:8443/api/traces/search?limit=1" }),

--- a/sdks/typescript/src/internal/http/__tests__/langwatchFetch.unit.test.ts
+++ b/sdks/typescript/src/internal/http/__tests__/langwatchFetch.unit.test.ts
@@ -12,7 +12,13 @@ const HTTPS_URL = "https://app.langwatch.ai/api/traces/search?limit=1";
 const OTHER_PATH = "https://app.langwatch.ai/api/traces/search/?limit=1";
 const OTHER_HOST = "https://other.example.com/api/traces/search?limit=1";
 
-const redirect = (status: number, location?: string): Response =>
+const redirect = ({
+  status,
+  location,
+}: {
+  status: number;
+  location?: string;
+}): Response =>
   new Response(null, {
     status,
     headers: location ? { location } : {},
@@ -81,7 +87,7 @@ describe("langwatchFetch", () => {
       /** @scenario follows a redirect that only upgrades http to https */
       it("follows the redirect once and returns the https response", async () => {
         for (const method of ["GET", "POST"]) {
-          const { fetchImpl, calls } = scripted(redirect(301, HTTPS_URL), ok("https answer"));
+          const { fetchImpl, calls } = scripted(redirect({ status: 301, location: HTTPS_URL }), ok("https answer"));
           const fetchLangWatch = createLangWatchFetch({ fetch: fetchImpl, logger: silentLogger() });
 
           const response = await fetchLangWatch(HTTP_URL, { method });
@@ -100,7 +106,7 @@ describe("langwatchFetch", () => {
           "https://app.langwatch.ai:443/api/traces/search?limit=1",
           "https://app.langwatch.ai/api/traces/search?limit=1#section",
         ]) {
-          const { fetchImpl, calls } = scripted(redirect(308, location), ok());
+          const { fetchImpl, calls } = scripted(redirect({ status: 308, location }), ok());
           const fetchLangWatch = createLangWatchFetch({ fetch: fetchImpl, logger: silentLogger() });
 
           await fetchLangWatch(HTTP_URL, { method: "POST", body: "{}" });
@@ -111,7 +117,7 @@ describe("langwatchFetch", () => {
 
       /** @scenario replays the same method, headers and body on the upgrade */
       it("replays the method, the headers and the body bytes", async () => {
-        const { fetchImpl, calls } = scripted(redirect(307, HTTPS_URL), ok());
+        const { fetchImpl, calls } = scripted(redirect({ status: 307, location: HTTPS_URL }), ok());
         const fetchLangWatch = createLangWatchFetch({ fetch: fetchImpl, logger: silentLogger() });
         const body = JSON.stringify({ trace_id: "trace_1" });
 
@@ -132,7 +138,7 @@ describe("langwatchFetch", () => {
 
       /** @scenario replays the same method, headers and body on the upgrade */
       it("replays a Request object with its method, headers and body bytes", async () => {
-        const { fetchImpl, calls } = scripted(redirect(301, HTTPS_URL), ok());
+        const { fetchImpl, calls } = scripted(redirect({ status: 301, location: HTTPS_URL }), ok());
         const fetchLangWatch = createLangWatchFetch({ fetch: fetchImpl, logger: silentLogger() });
         const body = JSON.stringify({ trace_id: "trace_1" });
         const request = new Request(HTTP_URL, {
@@ -152,13 +158,52 @@ describe("langwatchFetch", () => {
         expect(await replay.text()).toBe(body);
       });
 
+      /** @scenario replays the same method, headers and body on the upgrade */
+      it("replays what init overrode on the Request, not the Request's own fields", async () => {
+        const { fetchImpl, calls } = scripted(redirect({ status: 301, location: HTTPS_URL }), ok());
+        const fetchLangWatch = createLangWatchFetch({ fetch: fetchImpl, logger: silentLogger() });
+        const request = new Request(HTTP_URL, {
+          method: "PATCH",
+          headers: { Authorization: "Bearer stale", "X-Project-Id": "project_stale" },
+          body: "stale",
+        });
+
+        await fetchLangWatch(request, {
+          method: "PUT",
+          headers: { Authorization: "Bearer sk-lw-secret" },
+          body: "fresh",
+        });
+
+        const first = calls[0]!.input as Request;
+        const replay = calls[1]!.input as Request;
+        expect(first.method).toBe("PUT");
+        expect(await first.text()).toBe("fresh");
+        expect(replay.url).toBe(HTTPS_URL);
+        expect(replay.method).toBe("PUT");
+        expect(replay.headers.get("authorization")).toBe("Bearer sk-lw-secret");
+        expect(replay.headers.get("x-project-id")).toBeNull();
+        expect(await replay.text()).toBe("fresh");
+      });
+
+      /** @scenario follows a redirect that only upgrades http to https */
+      it("takes the method from init when it overrides a GET Request", async () => {
+        const { fetchImpl, calls } = scripted(redirect({ status: 308, location: HTTPS_URL }), ok());
+        const fetchLangWatch = createLangWatchFetch({ fetch: fetchImpl, logger: silentLogger() });
+
+        await fetchLangWatch(new Request(HTTP_URL), { method: "POST", body: "{}" });
+
+        expect(calls.map((call) => urlOf(call.input))).toEqual([HTTP_URL, HTTPS_URL]);
+        expect((calls[1]!.input as Request).method).toBe("POST");
+        expect(await (calls[1]!.input as Request).text()).toBe("{}");
+      });
+
       /** @scenario warns once per process about an http endpoint */
       it("warns once, naming the https endpoint to configure", async () => {
         const logger = silentLogger();
         const { fetchImpl } = scripted(
-          redirect(301, HTTPS_URL),
+          redirect({ status: 301, location: HTTPS_URL }),
           ok(),
-          redirect(301, HTTPS_URL),
+          redirect({ status: 301, location: HTTPS_URL }),
           ok(),
         );
         const fetchLangWatch = createLangWatchFetch({ fetch: fetchImpl, logger });
@@ -174,7 +219,7 @@ describe("langwatchFetch", () => {
 
       /** @scenario refuses to replay a streaming body */
       it("refuses to replay a ReadableStream body", async () => {
-        const { fetchImpl, calls } = scripted(redirect(307, HTTPS_URL), ok());
+        const { fetchImpl, calls } = scripted(redirect({ status: 307, location: HTTPS_URL }), ok());
         const fetchLangWatch = createLangWatchFetch({ fetch: fetchImpl, logger: silentLogger() });
         const stream = new ReadableStream<Uint8Array>({
           start(controller) {
@@ -201,7 +246,7 @@ describe("langwatchFetch", () => {
   describe("given a GET or HEAD answered with a redirect", () => {
     /** @scenario a GET follows a redirect to another path */
     it("follows a GET to another path on the same host", async () => {
-      const { fetchImpl, calls } = scripted(redirect(301, OTHER_PATH), ok("moved"));
+      const { fetchImpl, calls } = scripted(redirect({ status: 301, location: OTHER_PATH }), ok("moved"));
       const fetchLangWatch = createLangWatchFetch({ fetch: fetchImpl, logger: silentLogger() });
 
       const response = await fetchLangWatch(HTTPS_URL, { method: "GET" });
@@ -214,7 +259,7 @@ describe("langwatchFetch", () => {
 
     /** @scenario a GET follows a redirect to another path */
     it("follows a GET given as a Request object and keeps the Request shape", async () => {
-      const { fetchImpl, calls } = scripted(redirect(302, "/api/other"), ok());
+      const { fetchImpl, calls } = scripted(redirect({ status: 302, location: "/api/other" }), ok());
       const fetchLangWatch = createLangWatchFetch({ fetch: fetchImpl, logger: silentLogger() });
 
       await fetchLangWatch(new Request(HTTPS_URL, { headers: CREDENTIALS }));
@@ -230,7 +275,7 @@ describe("langwatchFetch", () => {
     it("follows five redirects in a row and returns the final response", async () => {
       const hops = [1, 2, 3, 4, 5].map((n) => `https://app.langwatch.ai/hop/${n}`);
       const { fetchImpl, calls } = scripted(
-        ...hops.map((location, index) => redirect(index % 2 === 0 ? 301 : 307, location)),
+        ...hops.map((location, index) => redirect({ status: index % 2 === 0 ? 301 : 307, location })),
         ok("final"),
       );
       const fetchLangWatch = createLangWatchFetch({ fetch: fetchImpl, logger: silentLogger() });
@@ -246,7 +291,7 @@ describe("langwatchFetch", () => {
     it("refuses the sixth redirect with the fifth target as the URL", async () => {
       const hops = [1, 2, 3, 4, 5, 6].map((n) => `https://app.langwatch.ai/hop/${n}`);
       const { fetchImpl, calls } = scripted(
-        ...hops.map((location, index) => redirect(index === 5 ? 302 : 301, location)),
+        ...hops.map((location, index) => redirect({ status: index === 5 ? 302 : 301, location })),
         ok(),
       );
       const fetchLangWatch = createLangWatchFetch({ fetch: fetchImpl, logger: silentLogger() });
@@ -261,7 +306,7 @@ describe("langwatchFetch", () => {
 
     /** @scenario a GET keeps its headers on a same origin redirect */
     it("keeps every header on a same origin hop", async () => {
-      const { fetchImpl, calls } = scripted(redirect(302, OTHER_PATH), ok());
+      const { fetchImpl, calls } = scripted(redirect({ status: 302, location: OTHER_PATH }), ok());
       const fetchLangWatch = createLangWatchFetch({ fetch: fetchImpl, logger: silentLogger() });
 
       await fetchLangWatch(HTTPS_URL, { headers: CREDENTIALS });
@@ -276,7 +321,7 @@ describe("langwatchFetch", () => {
     /** @scenario a GET keeps its headers on a same origin redirect */
     it("keeps every header on an http to https upgrade of the same host and warns once", async () => {
       const logger = silentLogger();
-      const { fetchImpl, calls } = scripted(redirect(301, OTHER_PATH), ok());
+      const { fetchImpl, calls } = scripted(redirect({ status: 301, location: OTHER_PATH }), ok());
       const fetchLangWatch = createLangWatchFetch({ fetch: fetchImpl, logger });
 
       await fetchLangWatch(HTTP_URL, { headers: CREDENTIALS });
@@ -290,7 +335,7 @@ describe("langwatchFetch", () => {
     /** @scenario a GET drops credential headers on a cross origin redirect */
     it("drops Authorization, X-Auth-Token and X-Project-Id on a hop to another host", async () => {
       const logger = silentLogger();
-      const { fetchImpl, calls } = scripted(redirect(302, OTHER_HOST), ok());
+      const { fetchImpl, calls } = scripted(redirect({ status: 302, location: OTHER_HOST }), ok());
       const fetchLangWatch = createLangWatchFetch({ fetch: fetchImpl, logger });
 
       await fetchLangWatch(HTTPS_URL, { headers: CREDENTIALS });
@@ -307,7 +352,7 @@ describe("langwatchFetch", () => {
     /** @scenario a GET drops credential headers on a cross origin redirect */
     it("drops credential headers on a hop to another port of the same host", async () => {
       const { fetchImpl, calls } = scripted(
-        redirect(302, "https://app.langwatch.ai:8443/api/traces/search?limit=1"),
+        redirect({ status: 302, location: "https://app.langwatch.ai:8443/api/traces/search?limit=1" }),
         ok(),
       );
       const fetchLangWatch = createLangWatchFetch({ fetch: fetchImpl, logger: silentLogger() });
@@ -319,7 +364,7 @@ describe("langwatchFetch", () => {
 
     /** @scenario a GET refuses a downgrade from https to http */
     it("refuses a GET downgrade from https to http", async () => {
-      const { fetchImpl, calls } = scripted(redirect(301, HTTP_URL), ok());
+      const { fetchImpl, calls } = scripted(redirect({ status: 301, location: HTTP_URL }), ok());
       const fetchLangWatch = createLangWatchFetch({ fetch: fetchImpl, logger: silentLogger() });
 
       const error = await refusal(() => fetchLangWatch(HTTPS_URL));
@@ -333,8 +378,8 @@ describe("langwatchFetch", () => {
     /** @scenario a GET refuses a downgrade from https to http */
     it("refuses a GET downgrade in the middle of a chain", async () => {
       const { fetchImpl, calls } = scripted(
-        redirect(301, OTHER_PATH),
-        redirect(301, "http://app.langwatch.ai/api/plain"),
+        redirect({ status: 301, location: OTHER_PATH }),
+        redirect({ status: 301, location: "http://app.langwatch.ai/api/plain" }),
         ok(),
       );
       const fetchLangWatch = createLangWatchFetch({ fetch: fetchImpl, logger: silentLogger() });
@@ -348,7 +393,7 @@ describe("langwatchFetch", () => {
 
     /** @scenario a GET follows a 303 */
     it("follows a 303 as a GET", async () => {
-      const { fetchImpl, calls } = scripted(redirect(303, OTHER_PATH), ok());
+      const { fetchImpl, calls } = scripted(redirect({ status: 303, location: OTHER_PATH }), ok());
       const fetchLangWatch = createLangWatchFetch({ fetch: fetchImpl, logger: silentLogger() });
 
       await fetchLangWatch(HTTPS_URL);
@@ -359,7 +404,7 @@ describe("langwatchFetch", () => {
 
     /** @scenario a HEAD follows a redirect like a GET */
     it("follows a HEAD with the same method", async () => {
-      const { fetchImpl, calls } = scripted(redirect(301, OTHER_PATH), new Response(null, { status: 200 }));
+      const { fetchImpl, calls } = scripted(redirect({ status: 301, location: OTHER_PATH }), new Response(null, { status: 200 }));
       const fetchLangWatch = createLangWatchFetch({ fetch: fetchImpl, logger: silentLogger() });
 
       const response = await fetchLangWatch(HTTPS_URL, { method: "head", headers: CREDENTIALS });
@@ -372,7 +417,7 @@ describe("langwatchFetch", () => {
 
     /** @scenario refuses a redirect without a location */
     it("refuses a GET redirect without a Location header", async () => {
-      const { fetchImpl, calls } = scripted(redirect(302), ok());
+      const { fetchImpl, calls } = scripted(redirect({ status: 302 }), ok());
       const fetchLangWatch = createLangWatchFetch({ fetch: fetchImpl, logger: silentLogger() });
 
       const error = await refusal(() => fetchLangWatch(HTTPS_URL));
@@ -393,7 +438,7 @@ describe("langwatchFetch", () => {
       status: number;
       location?: string;
     }) => {
-      const { fetchImpl, calls } = scripted(redirect(status, location), ok());
+      const { fetchImpl, calls } = scripted(redirect({ status, location }), ok());
       const fetchLangWatch = createLangWatchFetch({ fetch: fetchImpl, logger: silentLogger() });
 
       const error = await refusal(() => fetchLangWatch(url, { method: "POST", body: "{}" }));
@@ -433,7 +478,7 @@ describe("langwatchFetch", () => {
     /** @scenario a POST still refuses a redirect to another path */
     it("refuses a PUT, PATCH and DELETE redirect to another path as well", async () => {
       for (const method of ["PUT", "PATCH", "DELETE"]) {
-        const { fetchImpl, calls } = scripted(redirect(301, OTHER_PATH), ok());
+        const { fetchImpl, calls } = scripted(redirect({ status: 301, location: OTHER_PATH }), ok());
         const fetchLangWatch = createLangWatchFetch({ fetch: fetchImpl, logger: silentLogger() });
 
         const error = await refusal(() => fetchLangWatch(HTTPS_URL, { method }));
@@ -477,8 +522,8 @@ describe("langwatchFetch", () => {
     /** @scenario a POST refuses a second redirect after the upgrade */
     it("refuses a second redirect after the upgrade", async () => {
       const { fetchImpl, calls } = scripted(
-        redirect(301, HTTPS_URL),
-        redirect(302, OTHER_PATH),
+        redirect({ status: 301, location: HTTPS_URL }),
+        redirect({ status: 302, location: OTHER_PATH }),
         ok(),
       );
       const fetchLangWatch = createLangWatchFetch({ fetch: fetchImpl, logger: silentLogger() });
@@ -516,7 +561,7 @@ describe("langwatchFetch", () => {
     /** @scenario the generated API client uses the shared transport */
     it("sends through the shared transport and replays the upgrade with its headers", async () => {
       const { fetchImpl, calls } = scripted(
-        redirect(301, "https://app.langwatch.ai/api/annotations"),
+        redirect({ status: 301, location: "https://app.langwatch.ai/api/annotations" }),
         new Response("[]", { status: 200, headers: { "content-type": "application/json" } }),
       );
       globalThis.fetch = fetchImpl;

--- a/sdks/typescript/src/internal/http/__tests__/langwatchFetch.unit.test.ts
+++ b/sdks/typescript/src/internal/http/__tests__/langwatchFetch.unit.test.ts
@@ -9,6 +9,8 @@ import {
 
 const HTTP_URL = "http://app.langwatch.ai/api/traces/search?limit=1";
 const HTTPS_URL = "https://app.langwatch.ai/api/traces/search?limit=1";
+const OTHER_PATH = "https://app.langwatch.ai/api/traces/search/?limit=1";
+const OTHER_HOST = "https://other.example.com/api/traces/search?limit=1";
 
 const redirect = (status: number, location?: string): Response =>
   new Response(null, {
@@ -35,6 +37,19 @@ const scripted = (...responses: Response[]) => {
 
 const urlOf = (input: RequestInfo | URL): string =>
   typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+
+const headersOf = (call: { input: RequestInfo | URL; init?: RequestInit }): Headers =>
+  call.input instanceof Request ? call.input.headers : new Headers(call.init?.headers);
+
+const methodOf = (call: { input: RequestInfo | URL; init?: RequestInit }): string =>
+  call.input instanceof Request ? call.input.method : (call.init?.method ?? "GET");
+
+const CREDENTIALS = {
+  Authorization: "Bearer sk-lw-secret",
+  "X-Auth-Token": "sk-lw-secret",
+  "X-Project-Id": "project_1",
+  Accept: "application/json",
+};
 
 const silentLogger = () => {
   const logger = {
@@ -65,16 +80,18 @@ describe("langwatchFetch", () => {
     describe("when a request is sent", () => {
       /** @scenario follows a redirect that only upgrades http to https */
       it("follows the redirect once and returns the https response", async () => {
-        const { fetchImpl, calls } = scripted(redirect(301, HTTPS_URL), ok("https answer"));
-        const fetchLangWatch = createLangWatchFetch({ fetch: fetchImpl, logger: silentLogger() });
+        for (const method of ["GET", "POST"]) {
+          const { fetchImpl, calls } = scripted(redirect(301, HTTPS_URL), ok("https answer"));
+          const fetchLangWatch = createLangWatchFetch({ fetch: fetchImpl, logger: silentLogger() });
 
-        const response = await fetchLangWatch(HTTP_URL, { method: "GET" });
+          const response = await fetchLangWatch(HTTP_URL, { method });
 
-        expect(response.status).toBe(200);
-        expect(await response.text()).toBe("https answer");
-        expect(calls.map((call) => urlOf(call.input))).toEqual([HTTP_URL, HTTPS_URL]);
-        expect(calls[0]!.init?.redirect).toBe("manual");
-        expect(calls[1]!.init?.redirect).toBe("manual");
+          expect(response.status).toBe(200);
+          expect(await response.text()).toBe("https answer");
+          expect(calls.map((call) => urlOf(call.input))).toEqual([HTTP_URL, HTTPS_URL]);
+          expect(calls[0]!.init?.redirect).toBe("manual");
+          expect(calls[1]!.init?.redirect).toBe("manual");
+        }
       });
 
       /** @scenario follows a redirect that only upgrades http to https */
@@ -86,7 +103,7 @@ describe("langwatchFetch", () => {
           const { fetchImpl, calls } = scripted(redirect(308, location), ok());
           const fetchLangWatch = createLangWatchFetch({ fetch: fetchImpl, logger: silentLogger() });
 
-          await fetchLangWatch(HTTP_URL);
+          await fetchLangWatch(HTTP_URL, { method: "POST", body: "{}" });
 
           expect(calls[1] && urlOf(calls[1].input)).toBe(HTTPS_URL);
         }
@@ -147,7 +164,7 @@ describe("langwatchFetch", () => {
         const fetchLangWatch = createLangWatchFetch({ fetch: fetchImpl, logger });
 
         await fetchLangWatch(HTTP_URL);
-        await fetchLangWatch(HTTP_URL);
+        await fetchLangWatch(HTTP_URL, { method: "POST", body: "{}" });
 
         expect(logger.warn).toHaveBeenCalledTimes(1);
         expect(logger.warn).toHaveBeenCalledWith(
@@ -181,7 +198,192 @@ describe("langwatchFetch", () => {
     });
   });
 
-  describe("given a redirect that is not an http to https upgrade", () => {
+  describe("given a GET or HEAD answered with a redirect", () => {
+    /** @scenario a GET follows a redirect to another path */
+    it("follows a GET to another path on the same host", async () => {
+      const { fetchImpl, calls } = scripted(redirect(301, OTHER_PATH), ok("moved"));
+      const fetchLangWatch = createLangWatchFetch({ fetch: fetchImpl, logger: silentLogger() });
+
+      const response = await fetchLangWatch(HTTPS_URL, { method: "GET" });
+
+      expect(await response.text()).toBe("moved");
+      expect(calls.map((call) => urlOf(call.input))).toEqual([HTTPS_URL, OTHER_PATH]);
+      expect(calls.map(methodOf)).toEqual(["GET", "GET"]);
+      expect(calls[1]!.init?.redirect).toBe("manual");
+    });
+
+    /** @scenario a GET follows a redirect to another path */
+    it("follows a GET given as a Request object and keeps the Request shape", async () => {
+      const { fetchImpl, calls } = scripted(redirect(302, "/api/other"), ok());
+      const fetchLangWatch = createLangWatchFetch({ fetch: fetchImpl, logger: silentLogger() });
+
+      await fetchLangWatch(new Request(HTTPS_URL, { headers: CREDENTIALS }));
+
+      const hop = calls[1]!.input as Request;
+      expect(hop.url).toBe("https://app.langwatch.ai/api/other");
+      expect(hop.method).toBe("GET");
+      expect(hop.redirect).toBe("manual");
+      expect(hop.headers.get("x-auth-token")).toBe("sk-lw-secret");
+    });
+
+    /** @scenario a GET follows a chain of redirects up to five hops */
+    it("follows five redirects in a row and returns the final response", async () => {
+      const hops = [1, 2, 3, 4, 5].map((n) => `https://app.langwatch.ai/hop/${n}`);
+      const { fetchImpl, calls } = scripted(
+        ...hops.map((location, index) => redirect(index % 2 === 0 ? 301 : 307, location)),
+        ok("final"),
+      );
+      const fetchLangWatch = createLangWatchFetch({ fetch: fetchImpl, logger: silentLogger() });
+
+      const response = await fetchLangWatch(HTTPS_URL);
+
+      expect(await response.text()).toBe("final");
+      expect(calls.map((call) => urlOf(call.input))).toEqual([HTTPS_URL, ...hops]);
+      expect(calls.map(methodOf)).toEqual(Array(6).fill("GET"));
+    });
+
+    /** @scenario a GET refuses a sixth hop */
+    it("refuses the sixth redirect with the fifth target as the URL", async () => {
+      const hops = [1, 2, 3, 4, 5, 6].map((n) => `https://app.langwatch.ai/hop/${n}`);
+      const { fetchImpl, calls } = scripted(
+        ...hops.map((location, index) => redirect(index === 5 ? 302 : 301, location)),
+        ok(),
+      );
+      const fetchLangWatch = createLangWatchFetch({ fetch: fetchImpl, logger: silentLogger() });
+
+      const error = await refusal(() => fetchLangWatch(HTTPS_URL));
+
+      expect(calls).toHaveLength(6);
+      expect(error.url).toBe(hops[4]);
+      expect(error.location).toBe(hops[5]);
+      expect(error.status).toBe(302);
+    });
+
+    /** @scenario a GET keeps its headers on a same origin redirect */
+    it("keeps every header on a same origin hop", async () => {
+      const { fetchImpl, calls } = scripted(redirect(302, OTHER_PATH), ok());
+      const fetchLangWatch = createLangWatchFetch({ fetch: fetchImpl, logger: silentLogger() });
+
+      await fetchLangWatch(HTTPS_URL, { headers: CREDENTIALS });
+
+      const hop = headersOf(calls[1]!);
+      expect(hop.get("authorization")).toBe("Bearer sk-lw-secret");
+      expect(hop.get("x-auth-token")).toBe("sk-lw-secret");
+      expect(hop.get("x-project-id")).toBe("project_1");
+      expect(hop.get("accept")).toBe("application/json");
+    });
+
+    /** @scenario a GET keeps its headers on a same origin redirect */
+    it("keeps every header on an http to https upgrade of the same host and warns once", async () => {
+      const logger = silentLogger();
+      const { fetchImpl, calls } = scripted(redirect(301, OTHER_PATH), ok());
+      const fetchLangWatch = createLangWatchFetch({ fetch: fetchImpl, logger });
+
+      await fetchLangWatch(HTTP_URL, { headers: CREDENTIALS });
+
+      const hop = headersOf(calls[1]!);
+      expect(hop.get("authorization")).toBe("Bearer sk-lw-secret");
+      expect(hop.get("x-auth-token")).toBe("sk-lw-secret");
+      expect(logger.warn).toHaveBeenCalledTimes(1);
+    });
+
+    /** @scenario a GET drops credential headers on a cross origin redirect */
+    it("drops Authorization, X-Auth-Token and X-Project-Id on a hop to another host", async () => {
+      const logger = silentLogger();
+      const { fetchImpl, calls } = scripted(redirect(302, OTHER_HOST), ok());
+      const fetchLangWatch = createLangWatchFetch({ fetch: fetchImpl, logger });
+
+      await fetchLangWatch(HTTPS_URL, { headers: CREDENTIALS });
+
+      expect(urlOf(calls[1]!.input)).toBe(OTHER_HOST);
+      const hop = headersOf(calls[1]!);
+      expect(hop.get("authorization")).toBeNull();
+      expect(hop.get("x-auth-token")).toBeNull();
+      expect(hop.get("x-project-id")).toBeNull();
+      expect(hop.get("accept")).toBe("application/json");
+      expect(logger.warn).not.toHaveBeenCalled();
+    });
+
+    /** @scenario a GET drops credential headers on a cross origin redirect */
+    it("drops credential headers on a hop to another port of the same host", async () => {
+      const { fetchImpl, calls } = scripted(
+        redirect(302, "https://app.langwatch.ai:8443/api/traces/search?limit=1"),
+        ok(),
+      );
+      const fetchLangWatch = createLangWatchFetch({ fetch: fetchImpl, logger: silentLogger() });
+
+      await fetchLangWatch(HTTPS_URL, { headers: CREDENTIALS });
+
+      expect(headersOf(calls[1]!).get("authorization")).toBeNull();
+    });
+
+    /** @scenario a GET refuses a downgrade from https to http */
+    it("refuses a GET downgrade from https to http", async () => {
+      const { fetchImpl, calls } = scripted(redirect(301, HTTP_URL), ok());
+      const fetchLangWatch = createLangWatchFetch({ fetch: fetchImpl, logger: silentLogger() });
+
+      const error = await refusal(() => fetchLangWatch(HTTPS_URL));
+
+      expect(calls).toHaveLength(1);
+      expect(error.url).toBe(HTTPS_URL);
+      expect(error.location).toBe(HTTP_URL);
+      expect(error.status).toBe(301);
+    });
+
+    /** @scenario a GET refuses a downgrade from https to http */
+    it("refuses a GET downgrade in the middle of a chain", async () => {
+      const { fetchImpl, calls } = scripted(
+        redirect(301, OTHER_PATH),
+        redirect(301, "http://app.langwatch.ai/api/plain"),
+        ok(),
+      );
+      const fetchLangWatch = createLangWatchFetch({ fetch: fetchImpl, logger: silentLogger() });
+
+      const error = await refusal(() => fetchLangWatch(HTTPS_URL));
+
+      expect(calls).toHaveLength(2);
+      expect(error.url).toBe(OTHER_PATH);
+      expect(error.location).toBe("http://app.langwatch.ai/api/plain");
+    });
+
+    /** @scenario a GET follows a 303 */
+    it("follows a 303 as a GET", async () => {
+      const { fetchImpl, calls } = scripted(redirect(303, OTHER_PATH), ok());
+      const fetchLangWatch = createLangWatchFetch({ fetch: fetchImpl, logger: silentLogger() });
+
+      await fetchLangWatch(HTTPS_URL);
+
+      expect(calls.map((call) => urlOf(call.input))).toEqual([HTTPS_URL, OTHER_PATH]);
+      expect(methodOf(calls[1]!)).toBe("GET");
+    });
+
+    /** @scenario a HEAD follows a redirect like a GET */
+    it("follows a HEAD with the same method", async () => {
+      const { fetchImpl, calls } = scripted(redirect(301, OTHER_PATH), new Response(null, { status: 200 }));
+      const fetchLangWatch = createLangWatchFetch({ fetch: fetchImpl, logger: silentLogger() });
+
+      const response = await fetchLangWatch(HTTPS_URL, { method: "head", headers: CREDENTIALS });
+
+      expect(response.status).toBe(200);
+      expect(calls.map((call) => urlOf(call.input))).toEqual([HTTPS_URL, OTHER_PATH]);
+      expect(methodOf(calls[1]!)).toBe("HEAD");
+      expect(headersOf(calls[1]!).get("authorization")).toBe("Bearer sk-lw-secret");
+    });
+
+    /** @scenario refuses a redirect without a location */
+    it("refuses a GET redirect without a Location header", async () => {
+      const { fetchImpl, calls } = scripted(redirect(302), ok());
+      const fetchLangWatch = createLangWatchFetch({ fetch: fetchImpl, logger: silentLogger() });
+
+      const error = await refusal(() => fetchLangWatch(HTTPS_URL));
+
+      expect(calls).toHaveLength(1);
+      expect(error.location).toBeNull();
+      expect(error.status).toBe(302);
+    });
+  });
+
+  describe("given a POST answered with a redirect that is not an http to https upgrade", () => {
     const refuses = async ({
       url = HTTP_URL,
       status,
@@ -204,39 +406,49 @@ describe("langwatchFetch", () => {
       return error;
     };
 
-    /** @scenario refuses a redirect to another host */
+    /** @scenario a POST refuses a redirect to another host */
     it("refuses a redirect to another host", async () => {
-      const error = await refuses({
-        status: 301,
-        location: "https://other.example.com/api/traces/search?limit=1",
-      });
+      const error = await refuses({ status: 301, location: OTHER_HOST });
 
       expect(error.message).toBe(
         "LangWatch refused to follow a redirect from http://app.langwatch.ai/api/traces/search?limit=1 to https://other.example.com/api/traces/search?limit=1 (HTTP 301). Set the endpoint to the final URL.",
       );
     });
 
-    /** @scenario refuses a redirect to another host */
+    /** @scenario a POST refuses a redirect to another host */
     it("refuses a redirect to another port on the same host", async () => {
       await refuses({ status: 301, location: "https://app.langwatch.ai:8443/api/traces/search?limit=1" });
     });
 
-    /** @scenario refuses a redirect that changes the path or query */
+    /** @scenario a POST still refuses a redirect to another path */
     it("refuses a redirect that changes the path", async () => {
-      await refuses({ status: 308, location: "https://app.langwatch.ai/api/traces/search/?limit=1" });
+      await refuses({ status: 308, location: OTHER_PATH });
     });
 
-    /** @scenario refuses a redirect that changes the path or query */
+    /** @scenario a POST still refuses a redirect to another path */
     it("refuses a redirect that changes the query", async () => {
       await refuses({ status: 308, location: "https://app.langwatch.ai/api/traces/search?limit=2" });
     });
 
-    /** @scenario refuses a downgrade from https to http */
+    /** @scenario a POST still refuses a redirect to another path */
+    it("refuses a PUT, PATCH and DELETE redirect to another path as well", async () => {
+      for (const method of ["PUT", "PATCH", "DELETE"]) {
+        const { fetchImpl, calls } = scripted(redirect(301, OTHER_PATH), ok());
+        const fetchLangWatch = createLangWatchFetch({ fetch: fetchImpl, logger: silentLogger() });
+
+        const error = await refusal(() => fetchLangWatch(HTTPS_URL, { method }));
+
+        expect(calls).toHaveLength(1);
+        expect(error.location).toBe(OTHER_PATH);
+      }
+    });
+
+    /** @scenario a POST refuses a downgrade from https to http */
     it("refuses a downgrade from https to http", async () => {
       await refuses({ url: HTTPS_URL, status: 301, location: HTTP_URL });
     });
 
-    /** @scenario refuses a 303 */
+    /** @scenario a POST refuses a 303 */
     it("refuses a 303 even when it only upgrades the scheme", async () => {
       await refuses({ status: 303, location: HTTPS_URL });
     });
@@ -250,30 +462,32 @@ describe("langwatchFetch", () => {
 
     /** @scenario refuses an opaque redirect */
     it("refuses an opaque redirect with status 0", async () => {
-      const { fetchImpl, calls } = scripted(opaqueRedirect(), ok());
-      const fetchLangWatch = createLangWatchFetch({ fetch: fetchImpl, logger: silentLogger() });
+      for (const method of ["GET", "POST"]) {
+        const { fetchImpl, calls } = scripted(opaqueRedirect(), ok());
+        const fetchLangWatch = createLangWatchFetch({ fetch: fetchImpl, logger: silentLogger() });
 
-      const error = await refusal(() => fetchLangWatch(HTTP_URL));
+        const error = await refusal(() => fetchLangWatch(HTTP_URL, { method }));
 
-      expect(error.status).toBe(0);
-      expect(error.location).toBeNull();
-      expect(calls).toHaveLength(1);
+        expect(error.status).toBe(0);
+        expect(error.location).toBeNull();
+        expect(calls).toHaveLength(1);
+      }
     });
 
-    /** @scenario refuses a second redirect after the upgrade */
+    /** @scenario a POST refuses a second redirect after the upgrade */
     it("refuses a second redirect after the upgrade", async () => {
       const { fetchImpl, calls } = scripted(
         redirect(301, HTTPS_URL),
-        redirect(302, "https://app.langwatch.ai/api/traces/search/?limit=1"),
+        redirect(302, OTHER_PATH),
         ok(),
       );
       const fetchLangWatch = createLangWatchFetch({ fetch: fetchImpl, logger: silentLogger() });
 
-      const error = await refusal(() => fetchLangWatch(HTTP_URL));
+      const error = await refusal(() => fetchLangWatch(HTTP_URL, { method: "POST", body: "{}" }));
 
       expect(calls).toHaveLength(2);
       expect(error.url).toBe(HTTPS_URL);
-      expect(error.location).toBe("https://app.langwatch.ai/api/traces/search/?limit=1");
+      expect(error.location).toBe(OTHER_PATH);
       expect(error.status).toBe(302);
     });
   });

--- a/sdks/typescript/src/internal/http/__tests__/langwatchFetch.unit.test.ts
+++ b/sdks/typescript/src/internal/http/__tests__/langwatchFetch.unit.test.ts
@@ -1,0 +1,324 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Logger } from "../../../logger";
+import { createLangWatchApiClient } from "../../api/client";
+import {
+  createLangWatchFetch,
+  LangWatchRedirectError,
+  resetSchemeUpgradeWarnings,
+} from "../langwatchFetch";
+
+const HTTP_URL = "http://app.langwatch.ai/api/traces/search?limit=1";
+const HTTPS_URL = "https://app.langwatch.ai/api/traces/search?limit=1";
+
+const redirect = (status: number, location?: string): Response =>
+  new Response(null, {
+    status,
+    headers: location ? { location } : {},
+  });
+
+const ok = (body = "done"): Response => new Response(body, { status: 200 });
+
+const opaqueRedirect = (): Response =>
+  ({ type: "opaqueredirect", status: 0, headers: new Headers() }) as Response;
+
+/** A transport answering each call from the script, in order. */
+const scripted = (...responses: Response[]) => {
+  const calls: Array<{ input: RequestInfo | URL; init?: RequestInit }> = [];
+  const fetchImpl = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    calls.push({ input, init });
+    const next = responses.shift();
+    if (!next) throw new Error("the script ran out of responses");
+    return next;
+  }) as unknown as typeof fetch;
+  return { fetchImpl, calls };
+};
+
+const urlOf = (input: RequestInfo | URL): string =>
+  typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+
+const silentLogger = () => {
+  const logger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+  return logger satisfies Logger;
+};
+
+const refusal = async (run: () => Promise<unknown>): Promise<LangWatchRedirectError> => {
+  try {
+    await run();
+  } catch (error) {
+    if (error instanceof LangWatchRedirectError) return error;
+    throw error;
+  }
+  throw new Error("expected the redirect to be refused");
+};
+
+describe("langwatchFetch", () => {
+  beforeEach(() => {
+    resetSchemeUpgradeWarnings();
+  });
+
+  describe("given an http endpoint that redirects to the same URL over https", () => {
+    describe("when a request is sent", () => {
+      /** @scenario follows a redirect that only upgrades http to https */
+      it("follows the redirect once and returns the https response", async () => {
+        const { fetchImpl, calls } = scripted(redirect(301, HTTPS_URL), ok("https answer"));
+        const fetchLangWatch = createLangWatchFetch({ fetch: fetchImpl, logger: silentLogger() });
+
+        const response = await fetchLangWatch(HTTP_URL, { method: "GET" });
+
+        expect(response.status).toBe(200);
+        expect(await response.text()).toBe("https answer");
+        expect(calls.map((call) => urlOf(call.input))).toEqual([HTTP_URL, HTTPS_URL]);
+        expect(calls[0]!.init?.redirect).toBe("manual");
+        expect(calls[1]!.init?.redirect).toBe("manual");
+      });
+
+      /** @scenario follows a redirect that only upgrades http to https */
+      it("accepts a relative Location, an explicit default port and a fragment", async () => {
+        for (const location of [
+          "https://app.langwatch.ai:443/api/traces/search?limit=1",
+          "https://app.langwatch.ai/api/traces/search?limit=1#section",
+        ]) {
+          const { fetchImpl, calls } = scripted(redirect(308, location), ok());
+          const fetchLangWatch = createLangWatchFetch({ fetch: fetchImpl, logger: silentLogger() });
+
+          await fetchLangWatch(HTTP_URL);
+
+          expect(calls[1] && urlOf(calls[1].input)).toBe(HTTPS_URL);
+        }
+      });
+
+      /** @scenario replays the same method, headers and body on the upgrade */
+      it("replays the method, the headers and the body bytes", async () => {
+        const { fetchImpl, calls } = scripted(redirect(307, HTTPS_URL), ok());
+        const fetchLangWatch = createLangWatchFetch({ fetch: fetchImpl, logger: silentLogger() });
+        const body = JSON.stringify({ trace_id: "trace_1" });
+
+        await fetchLangWatch(HTTP_URL, {
+          method: "POST",
+          headers: { Authorization: "Bearer sk-lw-secret", "Content-Type": "application/json" },
+          body,
+        });
+
+        const replay = calls[1]!.init!;
+        expect(replay.method).toBe("POST");
+        expect(replay.headers).toEqual({
+          Authorization: "Bearer sk-lw-secret",
+          "Content-Type": "application/json",
+        });
+        expect(replay.body).toBe(body);
+      });
+
+      /** @scenario replays the same method, headers and body on the upgrade */
+      it("replays a Request object with its method, headers and body bytes", async () => {
+        const { fetchImpl, calls } = scripted(redirect(301, HTTPS_URL), ok());
+        const fetchLangWatch = createLangWatchFetch({ fetch: fetchImpl, logger: silentLogger() });
+        const body = JSON.stringify({ trace_id: "trace_1" });
+        const request = new Request(HTTP_URL, {
+          method: "POST",
+          headers: { Authorization: "Bearer sk-lw-secret" },
+          body,
+        });
+
+        await fetchLangWatch(request);
+
+        const first = calls[0]!.input as Request;
+        const replay = calls[1]!.input as Request;
+        expect(first.redirect).toBe("manual");
+        expect(replay.url).toBe(HTTPS_URL);
+        expect(replay.method).toBe("POST");
+        expect(replay.headers.get("authorization")).toBe("Bearer sk-lw-secret");
+        expect(await replay.text()).toBe(body);
+      });
+
+      /** @scenario warns once per process about an http endpoint */
+      it("warns once, naming the https endpoint to configure", async () => {
+        const logger = silentLogger();
+        const { fetchImpl } = scripted(
+          redirect(301, HTTPS_URL),
+          ok(),
+          redirect(301, HTTPS_URL),
+          ok(),
+        );
+        const fetchLangWatch = createLangWatchFetch({ fetch: fetchImpl, logger });
+
+        await fetchLangWatch(HTTP_URL);
+        await fetchLangWatch(HTTP_URL);
+
+        expect(logger.warn).toHaveBeenCalledTimes(1);
+        expect(logger.warn).toHaveBeenCalledWith(
+          "LangWatch endpoint http://app.langwatch.ai redirected to https. Set the endpoint to https://app.langwatch.ai to skip the extra round trip.",
+        );
+      });
+
+      /** @scenario refuses to replay a streaming body */
+      it("refuses to replay a ReadableStream body", async () => {
+        const { fetchImpl, calls } = scripted(redirect(307, HTTPS_URL), ok());
+        const fetchLangWatch = createLangWatchFetch({ fetch: fetchImpl, logger: silentLogger() });
+        const stream = new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode("{}"));
+            controller.close();
+          },
+        });
+
+        const error = await refusal(() =>
+          fetchLangWatch(HTTP_URL, {
+            method: "POST",
+            body: stream,
+            // @ts-expect-error duplex is required for streamed bodies in Node
+            duplex: "half",
+          }),
+        );
+
+        expect(error.status).toBe(307);
+        expect(calls).toHaveLength(1);
+      });
+    });
+  });
+
+  describe("given a redirect that is not an http to https upgrade", () => {
+    const refuses = async ({
+      url = HTTP_URL,
+      status,
+      location,
+    }: {
+      url?: string;
+      status: number;
+      location?: string;
+    }) => {
+      const { fetchImpl, calls } = scripted(redirect(status, location), ok());
+      const fetchLangWatch = createLangWatchFetch({ fetch: fetchImpl, logger: silentLogger() });
+
+      const error = await refusal(() => fetchLangWatch(url, { method: "POST", body: "{}" }));
+
+      expect(calls).toHaveLength(1);
+      expect(error.name).toBe("LangWatchRedirectError");
+      expect(error.url).toBe(url);
+      expect(error.location).toBe(location ?? null);
+      expect(error.status).toBe(status);
+      return error;
+    };
+
+    /** @scenario refuses a redirect to another host */
+    it("refuses a redirect to another host", async () => {
+      const error = await refuses({
+        status: 301,
+        location: "https://other.example.com/api/traces/search?limit=1",
+      });
+
+      expect(error.message).toBe(
+        "LangWatch refused to follow a redirect from http://app.langwatch.ai/api/traces/search?limit=1 to https://other.example.com/api/traces/search?limit=1 (HTTP 301). Set the endpoint to the final URL.",
+      );
+    });
+
+    /** @scenario refuses a redirect to another host */
+    it("refuses a redirect to another port on the same host", async () => {
+      await refuses({ status: 301, location: "https://app.langwatch.ai:8443/api/traces/search?limit=1" });
+    });
+
+    /** @scenario refuses a redirect that changes the path or query */
+    it("refuses a redirect that changes the path", async () => {
+      await refuses({ status: 308, location: "https://app.langwatch.ai/api/traces/search/?limit=1" });
+    });
+
+    /** @scenario refuses a redirect that changes the path or query */
+    it("refuses a redirect that changes the query", async () => {
+      await refuses({ status: 308, location: "https://app.langwatch.ai/api/traces/search?limit=2" });
+    });
+
+    /** @scenario refuses a downgrade from https to http */
+    it("refuses a downgrade from https to http", async () => {
+      await refuses({ url: HTTPS_URL, status: 301, location: HTTP_URL });
+    });
+
+    /** @scenario refuses a 303 */
+    it("refuses a 303 even when it only upgrades the scheme", async () => {
+      await refuses({ status: 303, location: HTTPS_URL });
+    });
+
+    /** @scenario refuses a redirect without a location */
+    it("refuses a redirect without a Location header", async () => {
+      const error = await refuses({ status: 302 });
+
+      expect(error.message).toContain("to an unknown location (HTTP 302)");
+    });
+
+    /** @scenario refuses an opaque redirect */
+    it("refuses an opaque redirect with status 0", async () => {
+      const { fetchImpl, calls } = scripted(opaqueRedirect(), ok());
+      const fetchLangWatch = createLangWatchFetch({ fetch: fetchImpl, logger: silentLogger() });
+
+      const error = await refusal(() => fetchLangWatch(HTTP_URL));
+
+      expect(error.status).toBe(0);
+      expect(error.location).toBeNull();
+      expect(calls).toHaveLength(1);
+    });
+
+    /** @scenario refuses a second redirect after the upgrade */
+    it("refuses a second redirect after the upgrade", async () => {
+      const { fetchImpl, calls } = scripted(
+        redirect(301, HTTPS_URL),
+        redirect(302, "https://app.langwatch.ai/api/traces/search/?limit=1"),
+        ok(),
+      );
+      const fetchLangWatch = createLangWatchFetch({ fetch: fetchImpl, logger: silentLogger() });
+
+      const error = await refusal(() => fetchLangWatch(HTTP_URL));
+
+      expect(calls).toHaveLength(2);
+      expect(error.url).toBe(HTTPS_URL);
+      expect(error.location).toBe("https://app.langwatch.ai/api/traces/search/?limit=1");
+      expect(error.status).toBe(302);
+    });
+  });
+
+  describe("given a response that is not a redirect", () => {
+    it("returns it untouched, a 304 included", async () => {
+      for (const status of [200, 204, 304, 404, 500]) {
+        const { fetchImpl, calls } = scripted(new Response(null, { status }));
+        const fetchLangWatch = createLangWatchFetch({ fetch: fetchImpl, logger: silentLogger() });
+
+        const response = await fetchLangWatch(HTTP_URL);
+
+        expect(response.status).toBe(status);
+        expect(calls).toHaveLength(1);
+      }
+    });
+  });
+
+  describe("given the generated API client", () => {
+    const originalFetch = globalThis.fetch;
+
+    afterEach(() => {
+      globalThis.fetch = originalFetch;
+    });
+
+    /** @scenario the generated API client uses the shared transport */
+    it("sends through the shared transport and replays the upgrade with its headers", async () => {
+      const { fetchImpl, calls } = scripted(
+        redirect(301, "https://app.langwatch.ai/api/annotations"),
+        new Response("[]", { status: 200, headers: { "content-type": "application/json" } }),
+      );
+      globalThis.fetch = fetchImpl;
+      const client = createLangWatchApiClient("sk-lw-secret", "http://app.langwatch.ai");
+
+      const { data, error } = await client.GET("/api/annotations");
+
+      expect(error).toBeUndefined();
+      expect(data).toEqual([]);
+      expect(calls.map((call) => urlOf(call.input))).toEqual([
+        "http://app.langwatch.ai/api/annotations",
+        "https://app.langwatch.ai/api/annotations",
+      ]);
+      const replay = calls[1]!.input as Request;
+      expect(replay.headers.get("x-auth-token")).toBe("sk-lw-secret");
+      expect(replay.redirect).toBe("manual");
+    });
+  });
+});

--- a/sdks/typescript/src/internal/http/__tests__/raw-fetch-guard.unit.test.ts
+++ b/sdks/typescript/src/internal/http/__tests__/raw-fetch-guard.unit.test.ts
@@ -11,11 +11,10 @@ import { join, relative, resolve } from "node:path";
 
 const SRC_ROOT = resolve(__dirname, "..", "..", "..");
 
-/** Files that call another server: a tunnel, a user's own HTTP agent, the docs site. */
+/** Files that call another server: a tunnel, a user's own HTTP agent. */
 const NOT_LANGWATCH = new Set([
   "cli/commands/agents/dev.ts",
   "cli/commands/agents/run.ts",
-  "cli/commands/docs.ts",
 ]);
 
 /** Test folders, the generated OpenAPI types, and the shared client itself. */

--- a/sdks/typescript/src/internal/http/__tests__/raw-fetch-guard.unit.test.ts
+++ b/sdks/typescript/src/internal/http/__tests__/raw-fetch-guard.unit.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Every request the SDK sends to the LangWatch API goes through
+ * `langwatchFetch`, which is what applies the redirect rule. A raw `fetch(`
+ * call, or a `fetchImpl = fetch` default, anywhere else in `src` bypasses
+ * that rule, so this test walks the source and fails on any it finds outside
+ * the short list of calls that talk to something other than LangWatch.
+ */
+import { describe, expect, it } from "vitest";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative, resolve } from "node:path";
+
+const SRC_ROOT = resolve(__dirname, "..", "..", "..");
+
+/** Files that call another server: a tunnel, a user's own HTTP agent, the docs site. */
+const NOT_LANGWATCH = new Set([
+  "cli/commands/agents/dev.ts",
+  "cli/commands/agents/run.ts",
+  "cli/commands/docs.ts",
+]);
+
+/** Test folders, the generated OpenAPI types, and the shared client itself. */
+const SKIPPED = new Set(["internal/generated", "internal/http"]);
+
+/** A call, a parameter default, or a fallback to the global. */
+const RAW_FETCH = /(?<![\w.$])fetch\(|(?<![\w.$])=\s*fetch\s*[,;)]|\?\?\s*globalThis\.fetch\b|globalThis\.fetch\(/;
+
+const isComment = (line: string): boolean => /^\s*(\*|\/\/|\/\*)/.test(line);
+
+const isSource = (file: string): boolean =>
+  file.endsWith(".ts") && !file.endsWith(".test.ts") && !file.endsWith(".d.ts");
+
+const walk = (dir: string, out: string[] = []): string[] => {
+  for (const entry of readdirSync(dir)) {
+    const path = join(dir, entry);
+    if (statSync(path).isDirectory()) {
+      if (entry !== "__tests__" && !SKIPPED.has(relative(SRC_ROOT, path))) walk(path, out);
+    } else if (isSource(path)) {
+      out.push(path);
+    }
+  }
+  return out;
+};
+
+const filesWithRawFetch = (): string[] =>
+  walk(SRC_ROOT)
+    .filter((file) => {
+      const source = readFileSync(file, "utf8");
+      return source
+        .split("\n")
+        .some((line) => !isComment(line) && RAW_FETCH.test(line));
+    })
+    .map((file) => relative(SRC_ROOT, file))
+    .sort();
+
+describe("the SDK source", () => {
+  describe("given every file under src outside tests and generated code", () => {
+    /** @scenario every hand written request uses the shared transport */
+    it("sends every LangWatch request through langwatchFetch", () => {
+      const offenders = filesWithRawFetch().filter((file) => !NOT_LANGWATCH.has(file));
+
+      expect(
+        offenders,
+        "These files call fetch directly. Import langwatchFetch from @/internal/http/langwatchFetch instead, or add the file to NOT_LANGWATCH if it talks to another server.",
+      ).toEqual([]);
+    });
+
+    it("keeps the list of non-LangWatch callers current", () => {
+      const raw = new Set(filesWithRawFetch());
+      const stale = [...NOT_LANGWATCH].filter((file) => !raw.has(file));
+
+      expect(stale, "These files no longer call fetch directly. Remove them from NOT_LANGWATCH.").toEqual([]);
+    });
+  });
+});

--- a/sdks/typescript/src/internal/http/__tests__/raw-fetch-guard.unit.test.ts
+++ b/sdks/typescript/src/internal/http/__tests__/raw-fetch-guard.unit.test.ts
@@ -11,14 +11,21 @@ import { join, relative, resolve } from "node:path";
 
 const SRC_ROOT = resolve(__dirname, "..", "..", "..");
 
-/** Files that call another server: a tunnel, a user's own HTTP agent. */
-const NOT_LANGWATCH = new Set([
-  "cli/commands/agents/dev.ts",
-  "cli/commands/agents/run.ts",
+/**
+ * Files that call another server, and how many raw calls each is allowed: a
+ * tunnel probe, a user's own HTTP agent. A file is not exempt as a whole, so an
+ * added call fails even here.
+ */
+const NOT_LANGWATCH = new Map([
+  ["cli/commands/agents/dev.ts", 1],
+  ["cli/commands/agents/run.ts", 1],
 ]);
 
-/** Test folders, the generated OpenAPI types, and the shared client itself. */
-const SKIPPED = new Set(["internal/generated", "internal/http"]);
+/** The shared transport itself: the one file that reaches the global fetch. */
+const TRANSPORT = "internal/http/langwatchFetch.ts";
+
+/** Generated OpenAPI code, not hand written. */
+const SKIPPED_DIRS = new Set(["internal/generated"]);
 
 /** A call, a parameter default, or a fallback to the global. */
 const RAW_FETCH = /(?<![\w.$])fetch\(|(?<![\w.$])=\s*fetch\s*[,;)]|\?\?\s*globalThis\.fetch\b|globalThis\.fetch\(/;
@@ -28,11 +35,13 @@ const isComment = (line: string): boolean => /^\s*(\*|\/\/|\/\*)/.test(line);
 const isSource = (file: string): boolean =>
   file.endsWith(".ts") && !file.endsWith(".test.ts") && !file.endsWith(".d.ts");
 
-const walk = (dir: string, out: string[] = []): string[] => {
+const walk = ({ dir, out = [] }: { dir: string; out?: string[] }): string[] => {
   for (const entry of readdirSync(dir)) {
     const path = join(dir, entry);
     if (statSync(path).isDirectory()) {
-      if (entry !== "__tests__" && !SKIPPED.has(relative(SRC_ROOT, path))) walk(path, out);
+      if (entry !== "__tests__" && !SKIPPED_DIRS.has(relative(SRC_ROOT, path))) {
+        walk({ dir: path, out });
+      }
     } else if (isSource(path)) {
       out.push(path);
     }
@@ -40,34 +49,49 @@ const walk = (dir: string, out: string[] = []): string[] => {
   return out;
 };
 
-const filesWithRawFetch = (): string[] =>
-  walk(SRC_ROOT)
-    .filter((file) => {
-      const source = readFileSync(file, "utf8");
-      return source
-        .split("\n")
-        .some((line) => !isComment(line) && RAW_FETCH.test(line));
-    })
-    .map((file) => relative(SRC_ROOT, file))
-    .sort();
+/** Every file that calls fetch directly, with how many such lines it has. */
+const rawFetchCounts = (): Map<string, number> => {
+  const counts = new Map<string, number>();
+  for (const file of walk({ dir: SRC_ROOT }).sort()) {
+    const calls = readFileSync(file, "utf8")
+      .split("\n")
+      .filter((line) => !isComment(line) && RAW_FETCH.test(line)).length;
+    if (calls > 0) counts.set(relative(SRC_ROOT, file), calls);
+  }
+  return counts;
+};
 
 describe("the SDK source", () => {
   describe("given every file under src outside tests and generated code", () => {
     /** @scenario every hand written request uses the shared transport */
     it("sends every LangWatch request through langwatchFetch", () => {
-      const offenders = filesWithRawFetch().filter((file) => !NOT_LANGWATCH.has(file));
+      const offenders = [...rawFetchCounts()]
+        .filter(([file, calls]) => {
+          if (file === TRANSPORT) return false;
+          return calls > (NOT_LANGWATCH.get(file) ?? 0);
+        })
+        .map(([file, calls]) => `${file} (${calls} calls)`);
 
       expect(
         offenders,
-        "These files call fetch directly. Import langwatchFetch from @/internal/http/langwatchFetch instead, or add the file to NOT_LANGWATCH if it talks to another server.",
+        "These files call fetch directly. Import langwatchFetch from @/internal/http/langwatchFetch instead, or raise the file's allowance in NOT_LANGWATCH if the new call talks to another server.",
       ).toEqual([]);
     });
 
     it("keeps the list of non-LangWatch callers current", () => {
-      const raw = new Set(filesWithRawFetch());
-      const stale = [...NOT_LANGWATCH].filter((file) => !raw.has(file));
+      const counts = rawFetchCounts();
+      const stale = [...NOT_LANGWATCH]
+        .filter(([file, allowed]) => (counts.get(file) ?? 0) < allowed)
+        .map(([file]) => file);
 
-      expect(stale, "These files no longer call fetch directly. Remove them from NOT_LANGWATCH.").toEqual([]);
+      expect(
+        stale,
+        "These files call fetch fewer times than NOT_LANGWATCH allows. Lower the allowance, or drop the entry.",
+      ).toEqual([]);
+    });
+
+    it("keeps the shared transport as the only file reaching the global fetch", () => {
+      expect(rawFetchCounts().has(TRANSPORT)).toBe(true);
     });
   });
 });

--- a/sdks/typescript/src/internal/http/langwatchFetch.ts
+++ b/sdks/typescript/src/internal/http/langwatchFetch.ts
@@ -92,11 +92,14 @@ const isRedirect = (response: Response): boolean =>
 const isStream = (body: unknown): boolean =>
   typeof ReadableStream !== "undefined" && body instanceof ReadableStream;
 
-const abortError = (signal: AbortSignal): unknown =>
-  signal.reason ??
-  (typeof DOMException !== "undefined"
-    ? new DOMException("This operation was aborted", "AbortError")
-    : Object.assign(new Error("This operation was aborted"), { name: "AbortError" }));
+const abortError = (signal: AbortSignal): Error => {
+  const reason: unknown = signal.reason;
+  if (reason instanceof Error) return reason;
+  if (typeof DOMException !== "undefined") {
+    return new DOMException("This operation was aborted", "AbortError");
+  }
+  return Object.assign(new Error("This operation was aborted"), { name: "AbortError" });
+};
 
 /**
  * The body bytes to replay, read under the caller's signal.

--- a/sdks/typescript/src/internal/http/langwatchFetch.ts
+++ b/sdks/typescript/src/internal/http/langwatchFetch.ts
@@ -32,8 +32,18 @@ const FOLLOWING_METHODS = new Set(["GET", "HEAD"]);
 /** The most redirects a GET or HEAD follows before the next one is refused. */
 export const MAX_FOLLOW_HOPS = 5;
 
-/** Headers dropped when a GET or HEAD hop leaves the origin. */
-const CREDENTIAL_HEADERS = ["authorization", "x-auth-token", "x-project-id"];
+/**
+ * Headers dropped when a GET or HEAD hop leaves the origin: the three the Fetch
+ * standard strips on a cross-origin redirect, plus the names LangWatch keys on.
+ */
+const CREDENTIAL_HEADERS = [
+  "authorization",
+  "cookie",
+  "proxy-authorization",
+  "x-api-key",
+  "x-auth-token",
+  "x-project-id",
+];
 
 export class LangWatchRedirectError extends Error {
   readonly url: string;
@@ -184,6 +194,102 @@ const refusalOf = ({
   });
 
 /**
+ * What `fetch(input, init)` would send, as one request both sends read from.
+ * `init` wins over a `Request` input field by field, so reading the raw input
+ * for the replay would resend a method, headers or body the caller overrode.
+ * A plain URL input stays null: the non-Request path keeps `init` as it is, so
+ * a stream body reaches the transport untouched.
+ */
+const effectiveRequest = ({
+  input,
+  init,
+}: {
+  input: RequestInfo | URL;
+  init: RequestInit | undefined;
+}): Request | null =>
+  typeof Request !== "undefined" && input instanceof Request
+    ? new Request(input, { ...init, redirect: "manual" })
+    : null;
+
+interface Hop {
+  send: LangWatchFetch;
+  log: Logger;
+  effective: Request | null;
+  init: RequestInit | undefined;
+  url: string;
+  first: Response;
+}
+
+/** The GET and HEAD rule: follow with the same method, up to MAX_FOLLOW_HOPS. */
+const follow = async ({
+  send,
+  log,
+  effective,
+  init,
+  url,
+  method,
+  first,
+}: Hop & { method: string }): Promise<Response> => {
+  let headers = new Headers(effective?.headers ?? init?.headers);
+  const signal = effective?.signal ?? init?.signal;
+  let current = url;
+  let response = first;
+
+  for (let hop = 0; hop < MAX_FOLLOW_HOPS; hop++) {
+    const location = response.headers.get("location");
+    const target = location === null ? null : followTarget({ url: current, location });
+    if (target === null) throw refusalOf({ url: current, response });
+
+    const from = new URL(current);
+    const to = new URL(target);
+    if (!keepsCredentials({ from, to })) headers = withoutCredentials(headers);
+    if (isSchemeUpgrade({ from, to })) warnOnce({ url: current, logger: log });
+
+    current = target;
+    response = effective
+      ? await send(new Request(target, { method, headers, signal, redirect: "manual" }))
+      : await send(target, { ...init, method, headers, body: undefined, redirect: "manual" });
+    if (!isRedirect(response)) return response;
+  }
+
+  throw refusalOf({ url: current, response });
+};
+
+/** The rule for every other method: one hop, and only an https upgrade of the same URL. */
+const upgrade = async ({
+  send,
+  log,
+  effective,
+  init,
+  url,
+  first,
+  spare,
+}: Hop & { spare: Request | null }): Promise<Response> => {
+  const location = first.headers.get("location");
+  const refused = refusalOf({ url, response: first });
+  if (location === null || first.status === 303) throw refused;
+  const target = schemeUpgradeTarget({ url, location });
+  if (target === null || isStream(init?.body)) throw refused;
+
+  warnOnce({ url, logger: log });
+
+  const second = effective
+    ? await send(
+        new Request(target, {
+          method: effective.method,
+          headers: effective.headers,
+          body: spare ? await spare.arrayBuffer() : null,
+          signal: effective.signal,
+          redirect: "manual",
+        }),
+      )
+    : await send(target, { ...init, redirect: "manual" });
+  if (!isRedirect(second)) return second;
+
+  throw refusalOf({ url: target, response: second });
+};
+
+/**
  * Builds a `fetch` that applies the redirect rule. Pass `fetch` to send through
  * another transport (a test double, a proxying client) and `logger` to route
  * the http endpoint warning.
@@ -196,91 +302,9 @@ export const createLangWatchFetch = ({
     fetchImpl ?? ((input, init) => globalThis.fetch(input, init));
   const log = logger ?? new ConsoleLogger({ level: "warn", prefix: "LangWatch" });
 
-  /** The GET and HEAD rule: follow with the same method, up to MAX_FOLLOW_HOPS. */
-  const follow = async ({
-    effective,
-    init,
-    url,
-    method,
-    first,
-  }: {
-    effective: Request | null;
-    init: RequestInit | undefined;
-    url: string;
-    method: string;
-    first: Response;
-  }): Promise<Response> => {
-    let headers = new Headers(effective?.headers ?? init?.headers);
-    const signal = effective?.signal ?? init?.signal;
-    let current = url;
-    let response = first;
-
-    for (let hop = 0; hop < MAX_FOLLOW_HOPS; hop++) {
-      const location = response.headers.get("location");
-      const target = location === null ? null : followTarget({ url: current, location });
-      if (target === null) throw refusalOf({ url: current, response });
-
-      const from = new URL(current);
-      const to = new URL(target);
-      if (!keepsCredentials({ from, to })) headers = withoutCredentials(headers);
-      if (isSchemeUpgrade({ from, to })) warnOnce({ url: current, logger: log });
-
-      current = target;
-      response = effective
-        ? await send(new Request(target, { method, headers, signal, redirect: "manual" }))
-        : await send(target, { ...init, method, headers, body: undefined, redirect: "manual" });
-      if (!isRedirect(response)) return response;
-    }
-
-    throw refusalOf({ url: current, response });
-  };
-
-  /** The rule for every other method: one hop, and only an https upgrade of the same URL. */
-  const upgrade = async ({
-    effective,
-    init,
-    url,
-    first,
-    spare,
-  }: {
-    effective: Request | null;
-    init: RequestInit | undefined;
-    url: string;
-    first: Response;
-    spare: Request | null;
-  }): Promise<Response> => {
-    const location = first.headers.get("location");
-    const refused = refusalOf({ url, response: first });
-    if (location === null || first.status === 303) throw refused;
-    const target = schemeUpgradeTarget({ url, location });
-    if (target === null || isStream(init?.body)) throw refused;
-
-    warnOnce({ url, logger: log });
-
-    const second = effective
-      ? await send(
-          new Request(target, {
-            method: effective.method,
-            headers: effective.headers,
-            body: spare ? await spare.arrayBuffer() : null,
-            signal: effective.signal,
-            redirect: "manual",
-          }),
-        )
-      : await send(target, { ...init, redirect: "manual" });
-    if (!isRedirect(second)) return second;
-
-    throw refusalOf({ url: target, response: second });
-  };
-
   return async (input, init) => {
-    const isRequest = typeof Request !== "undefined" && input instanceof Request;
     const url = requestUrl(input);
-    // What `fetch(input, init)` would send: `init` wins over the Request field
-    // by field, so both sends read the same method, headers and body.
-    const effective = isRequest
-      ? new Request(input, { ...init, redirect: "manual" })
-      : null;
+    const effective = effectiveRequest({ input, init });
     const method = (effective?.method ?? init?.method ?? "GET").toUpperCase();
     // A Request carries its body as a stream that one send consumes, so a copy
     // is taken before the first send and read only if the replay happens.
@@ -291,10 +315,10 @@ export const createLangWatchFetch = ({
       : await send(input, { ...init, redirect: "manual" });
     if (!isRedirect(first)) return first;
 
-    if (FOLLOWING_METHODS.has(method)) {
-      return follow({ effective, init, url, method, first });
-    }
-    return upgrade({ effective, init, url, first, spare });
+    const hop = { send, log, effective, init, url, first };
+    return FOLLOWING_METHODS.has(method)
+      ? follow({ ...hop, method })
+      : upgrade({ ...hop, spare });
   };
 };
 

--- a/sdks/typescript/src/internal/http/langwatchFetch.ts
+++ b/sdks/typescript/src/internal/http/langwatchFetch.ts
@@ -102,6 +102,21 @@ const abortError = (signal: AbortSignal): Error => {
 };
 
 /**
+ * Releases the unread copy of a request body.
+ *
+ * `Request.clone` tees the body stream, and a branch nobody reads holds every
+ * chunk the other branch consumes in memory. Cancelling the copy the replay
+ * never needs keeps a streamed upload from being buffered whole.
+ *
+ * The cancellation is never awaited: a tee only settles the promise its
+ * `cancel` returns once both branches are cancelled, so waiting on the copy
+ * while the sent branch is still live would never return.
+ */
+const discard = (spare: Request | null): void => {
+  void spare?.body?.cancel().catch(() => undefined);
+};
+
+/**
  * The body bytes to replay, read under the caller's signal.
  *
  * A `Request` built from a stream hands its copy over as a stream too, and
@@ -128,7 +143,7 @@ const replayBody = async ({
   try {
     return await Promise.race([spare.arrayBuffer(), aborted]);
   } catch (error) {
-    await spare.body?.cancel().catch(() => undefined);
+    discard(spare);
     throw error;
   }
 };
@@ -308,9 +323,11 @@ const upgrade = async ({
 }: Hop & { spare: Request | null }): Promise<Response> => {
   const location = first.headers.get("location");
   const refused = refusalOf({ url, response: first });
-  if (location === null || first.status === 303) throw refused;
-  const target = schemeUpgradeTarget({ url, location });
-  if (target === null || isStream(init?.body)) throw refused;
+  const target = location === null ? null : schemeUpgradeTarget({ url, location });
+  if (location === null || first.status === 303 || target === null || isStream(init?.body)) {
+    discard(spare);
+    throw refused;
+  }
 
   warnOnce({ url, logger: log });
 
@@ -354,12 +371,16 @@ export const createLangWatchFetch = ({
     const first = effective
       ? await send(effective)
       : await send(input, { ...init, redirect: "manual" });
-    if (!isRedirect(first)) return first;
+    if (!isRedirect(first)) {
+      discard(spare);
+      return first;
+    }
 
     const hop = { send, log, effective, init, url, first };
-    return FOLLOWING_METHODS.has(method)
-      ? follow({ ...hop, method })
-      : upgrade({ ...hop, spare });
+    if (!FOLLOWING_METHODS.has(method)) return upgrade({ ...hop, spare });
+
+    discard(spare);
+    return follow({ ...hop, method });
   };
 };
 

--- a/sdks/typescript/src/internal/http/langwatchFetch.ts
+++ b/sdks/typescript/src/internal/http/langwatchFetch.ts
@@ -198,21 +198,20 @@ export const createLangWatchFetch = ({
 
   /** The GET and HEAD rule: follow with the same method, up to MAX_FOLLOW_HOPS. */
   const follow = async ({
-    input,
+    effective,
     init,
     url,
     method,
     first,
   }: {
-    input: RequestInfo | URL;
+    effective: Request | null;
     init: RequestInit | undefined;
     url: string;
     method: string;
     first: Response;
   }): Promise<Response> => {
-    const isRequest = typeof Request !== "undefined" && input instanceof Request;
-    let headers = new Headers(init?.headers ?? (isRequest ? input.headers : undefined));
-    const signal = init?.signal ?? (isRequest ? input.signal : undefined);
+    let headers = new Headers(effective?.headers ?? init?.headers);
+    const signal = effective?.signal ?? init?.signal;
     let current = url;
     let response = first;
 
@@ -227,7 +226,7 @@ export const createLangWatchFetch = ({
       if (isSchemeUpgrade({ from, to })) warnOnce({ url: current, logger: log });
 
       current = target;
-      response = isRequest
+      response = effective
         ? await send(new Request(target, { method, headers, signal, redirect: "manual" }))
         : await send(target, { ...init, method, headers, body: undefined, redirect: "manual" });
       if (!isRedirect(response)) return response;
@@ -238,19 +237,18 @@ export const createLangWatchFetch = ({
 
   /** The rule for every other method: one hop, and only an https upgrade of the same URL. */
   const upgrade = async ({
-    input,
+    effective,
     init,
     url,
     first,
     spare,
   }: {
-    input: RequestInfo | URL;
+    effective: Request | null;
     init: RequestInit | undefined;
     url: string;
     first: Response;
     spare: Request | null;
   }): Promise<Response> => {
-    const isRequest = typeof Request !== "undefined" && input instanceof Request;
     const location = first.headers.get("location");
     const refused = refusalOf({ url, response: first });
     if (location === null || first.status === 303) throw refused;
@@ -259,13 +257,13 @@ export const createLangWatchFetch = ({
 
     warnOnce({ url, logger: log });
 
-    const second = isRequest
+    const second = effective
       ? await send(
           new Request(target, {
-            method: input.method,
-            headers: input.headers,
+            method: effective.method,
+            headers: effective.headers,
             body: spare ? await spare.arrayBuffer() : null,
-            signal: input.signal,
+            signal: effective.signal,
             redirect: "manual",
           }),
         )
@@ -278,23 +276,25 @@ export const createLangWatchFetch = ({
   return async (input, init) => {
     const isRequest = typeof Request !== "undefined" && input instanceof Request;
     const url = requestUrl(input);
-    const method = (init?.method ?? (isRequest ? input.method : "GET")).toUpperCase();
+    // What `fetch(input, init)` would send: `init` wins over the Request field
+    // by field, so both sends read the same method, headers and body.
+    const effective = isRequest
+      ? new Request(input, { ...init, redirect: "manual" })
+      : null;
+    const method = (effective?.method ?? init?.method ?? "GET").toUpperCase();
     // A Request carries its body as a stream that one send consumes, so a copy
     // is taken before the first send and read only if the replay happens.
-    const spare =
-      isRequest && init?.body === undefined && input.body !== null
-        ? input.clone()
-        : null;
+    const spare = effective !== null && effective.body !== null ? effective.clone() : null;
 
-    const first = isRequest
-      ? await send(new Request(input, { ...init, redirect: "manual" }))
+    const first = effective
+      ? await send(effective)
       : await send(input, { ...init, redirect: "manual" });
     if (!isRedirect(first)) return first;
 
     if (FOLLOWING_METHODS.has(method)) {
-      return follow({ input, init, url, method, first });
+      return follow({ effective, init, url, method, first });
     }
-    return upgrade({ input, init, url, first, spare });
+    return upgrade({ effective, init, url, first, spare });
   };
 };
 

--- a/sdks/typescript/src/internal/http/langwatchFetch.ts
+++ b/sdks/typescript/src/internal/http/langwatchFetch.ts
@@ -92,6 +92,44 @@ const isRedirect = (response: Response): boolean =>
 const isStream = (body: unknown): boolean =>
   typeof ReadableStream !== "undefined" && body instanceof ReadableStream;
 
+const abortError = (signal: AbortSignal): unknown =>
+  signal.reason ??
+  (typeof DOMException !== "undefined"
+    ? new DOMException("This operation was aborted", "AbortError")
+    : Object.assign(new Error("This operation was aborted"), { name: "AbortError" }));
+
+/**
+ * The body bytes to replay, read under the caller's signal.
+ *
+ * A `Request` built from a stream hands its copy over as a stream too, and
+ * reading one that never ends would leave the call pending for good, past an
+ * abort the caller already made. The read races the signal and cancels the
+ * copy it loses to, so an aborted call settles.
+ */
+const replayBody = async ({
+  spare,
+  signal,
+}: {
+  spare: Request;
+  signal: AbortSignal | null | undefined;
+}): Promise<ArrayBuffer> => {
+  if (!signal) return spare.arrayBuffer();
+  if (signal.aborted) throw abortError(signal);
+
+  const aborted = new Promise<never>((_, reject) => {
+    signal.addEventListener("abort", () => reject(abortError(signal)), { once: true });
+  });
+  // An abort that arrives after the read already won still rejects this one,
+  // and nothing would be waiting on it by then.
+  void aborted.catch(() => undefined);
+  try {
+    return await Promise.race([spare.arrayBuffer(), aborted]);
+  } catch (error) {
+    await spare.body?.cancel().catch(() => undefined);
+    throw error;
+  }
+};
+
 const requestUrl = (input: RequestInfo | URL): string => {
   if (typeof input === "string") return input;
   if (input instanceof URL) return input.href;
@@ -278,7 +316,7 @@ const upgrade = async ({
         new Request(target, {
           method: effective.method,
           headers: effective.headers,
-          body: spare ? await spare.arrayBuffer() : null,
+          body: spare ? await replayBody({ spare, signal: effective.signal }) : null,
           signal: effective.signal,
           redirect: "manual",
         }),

--- a/sdks/typescript/src/internal/http/langwatchFetch.ts
+++ b/sdks/typescript/src/internal/http/langwatchFetch.ts
@@ -5,10 +5,19 @@
  * redirect to https. The global `fetch` follows it on its own and, for a 301
  * or 302, turns the POST into a GET and drops the body, so the event is lost
  * without an error. This client sends with `redirect: "manual"` and applies a
- * single rule to the 3xx it gets back: a redirect is followed once, and only
- * when the target is the same URL with the scheme changed from http to https
- * (same host, port, path and query). The replay uses the same method, headers
- * and body bytes. Every other redirect is refused with `LangWatchRedirectError`.
+ * rule per method to the 3xx it gets back.
+ *
+ * GET and HEAD follow a 301, 302, 303, 307 or 308 with the same method, up to
+ * five hops. A hop that keeps the origin, or only upgrades http to https on
+ * the same host and port, keeps every header; any other hop drops the
+ * credential headers first. A hop from https to http and a hop without a
+ * Location are refused.
+ *
+ * Every other method follows exactly one redirect, and only when the target is
+ * the same URL with the scheme changed from http to https (same host, port,
+ * path and query). The replay uses the same method, headers and body bytes.
+ *
+ * Every refused redirect throws `LangWatchRedirectError`.
  *
  * This module depends on the SDK logger only, so the CLI boot graph and the
  * `agent` entry can import it without pulling anything else in.
@@ -16,6 +25,15 @@
 import { ConsoleLogger, type Logger } from "../../logger";
 
 const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+
+/** Methods that follow a redirect to any http or https URL. */
+const FOLLOWING_METHODS = new Set(["GET", "HEAD"]);
+
+/** The most redirects a GET or HEAD follows before the next one is refused. */
+export const MAX_FOLLOW_HOPS = 5;
+
+/** Headers dropped when a GET or HEAD hop leaves the origin. */
+const CREDENTIAL_HEADERS = ["authorization", "x-auth-token", "x-project-id"];
 
 export class LangWatchRedirectError extends Error {
   readonly url: string;
@@ -70,6 +88,28 @@ const requestUrl = (input: RequestInfo | URL): string => {
   return input.url;
 };
 
+const parseHop = ({
+  url,
+  location,
+}: {
+  url: string;
+  location: string;
+}): { from: URL; to: URL } | null => {
+  try {
+    const from = new URL(url);
+    return { from, to: new URL(location, from) };
+  } catch {
+    return null;
+  }
+};
+
+/** Same host and port, with the scheme changed from http to https. */
+const isSchemeUpgrade = ({ from, to }: { from: URL; to: URL }): boolean =>
+  from.protocol === "http:" &&
+  to.protocol === "https:" &&
+  from.hostname === to.hostname &&
+  from.port === to.port;
+
 /**
  * The https URL to replay against when `location` only upgrades the scheme of
  * `url`, and null for any other target. The URL parser drops a default port,
@@ -82,21 +122,43 @@ export const schemeUpgradeTarget = ({
   url: string;
   location: string;
 }): string | null => {
-  let from: URL;
-  let to: URL;
-  try {
-    from = new URL(url);
-    to = new URL(location, from);
-  } catch {
-    return null;
-  }
-  if (from.protocol !== "http:" || to.protocol !== "https:") return null;
-  if (from.hostname !== to.hostname) return null;
-  if (from.port !== to.port) return null;
+  const hop = parseHop({ url, location });
+  if (hop === null || !isSchemeUpgrade(hop)) return null;
+  const { from, to } = hop;
   if (from.pathname !== to.pathname) return null;
   if (from.search !== to.search) return null;
   to.hash = "";
   return to.href;
+};
+
+/**
+ * The URL a GET or HEAD follows to, and null when the hop is refused: a
+ * target that is not http or https, or a downgrade from https to http.
+ */
+export const followTarget = ({
+  url,
+  location,
+}: {
+  url: string;
+  location: string;
+}): string | null => {
+  const hop = parseHop({ url, location });
+  if (hop === null) return null;
+  const { from, to } = hop;
+  if (to.protocol !== "http:" && to.protocol !== "https:") return null;
+  if (from.protocol === "https:" && to.protocol === "http:") return null;
+  to.hash = "";
+  return to.href;
+};
+
+/** A hop keeps its credential headers on the same origin and on an https upgrade of the same host. */
+const keepsCredentials = ({ from, to }: { from: URL; to: URL }): boolean =>
+  from.origin === to.origin || isSchemeUpgrade({ from, to });
+
+const withoutCredentials = (headers: Headers): Headers => {
+  const stripped = new Headers(headers);
+  for (const name of CREDENTIAL_HEADERS) stripped.delete(name);
+  return stripped;
 };
 
 const warnOnce = ({ url, logger }: { url: string; logger: Logger }): void => {
@@ -107,6 +169,19 @@ const warnOnce = ({ url, logger }: { url: string; logger: Logger }): void => {
     `LangWatch endpoint ${origin} redirected to https. Set the endpoint to https://${host} to skip the extra round trip.`,
   );
 };
+
+const refusalOf = ({
+  url,
+  response,
+}: {
+  url: string;
+  response: Response;
+}): LangWatchRedirectError =>
+  new LangWatchRedirectError({
+    url,
+    location: response.headers.get("location"),
+    status: response.status,
+  });
 
 /**
  * Builds a `fetch` that applies the redirect rule. Pass `fetch` to send through
@@ -121,31 +196,66 @@ export const createLangWatchFetch = ({
     fetchImpl ?? ((input, init) => globalThis.fetch(input, init));
   const log = logger ?? new ConsoleLogger({ level: "warn", prefix: "LangWatch" });
 
-  return async (input, init) => {
+  /** The GET and HEAD rule: follow with the same method, up to MAX_FOLLOW_HOPS. */
+  const follow = async ({
+    input,
+    init,
+    url,
+    method,
+    first,
+  }: {
+    input: RequestInfo | URL;
+    init: RequestInit | undefined;
+    url: string;
+    method: string;
+    first: Response;
+  }): Promise<Response> => {
     const isRequest = typeof Request !== "undefined" && input instanceof Request;
-    const url = requestUrl(input);
-    const streamed = isStream(init?.body);
-    // A Request carries its body as a stream that one send consumes, so a copy
-    // is taken before the first send and read only if the replay happens.
-    const spare =
-      isRequest && init?.body === undefined && input.body !== null
-        ? input.clone()
-        : null;
+    let headers = new Headers(init?.headers ?? (isRequest ? input.headers : undefined));
+    const signal = init?.signal ?? (isRequest ? input.signal : undefined);
+    let current = url;
+    let response = first;
 
-    const first = isRequest
-      ? await send(new Request(input, { ...init, redirect: "manual" }))
-      : await send(input, { ...init, redirect: "manual" });
-    if (!isRedirect(first)) return first;
+    for (let hop = 0; hop < MAX_FOLLOW_HOPS; hop++) {
+      const location = response.headers.get("location");
+      const target = location === null ? null : followTarget({ url: current, location });
+      if (target === null) throw refusalOf({ url: current, response });
 
+      const from = new URL(current);
+      const to = new URL(target);
+      if (!keepsCredentials({ from, to })) headers = withoutCredentials(headers);
+      if (isSchemeUpgrade({ from, to })) warnOnce({ url: current, logger: log });
+
+      current = target;
+      response = isRequest
+        ? await send(new Request(target, { method, headers, signal, redirect: "manual" }))
+        : await send(target, { ...init, method, headers, body: undefined, redirect: "manual" });
+      if (!isRedirect(response)) return response;
+    }
+
+    throw refusalOf({ url: current, response });
+  };
+
+  /** The rule for every other method: one hop, and only an https upgrade of the same URL. */
+  const upgrade = async ({
+    input,
+    init,
+    url,
+    first,
+    spare,
+  }: {
+    input: RequestInfo | URL;
+    init: RequestInit | undefined;
+    url: string;
+    first: Response;
+    spare: Request | null;
+  }): Promise<Response> => {
+    const isRequest = typeof Request !== "undefined" && input instanceof Request;
     const location = first.headers.get("location");
-    const refused = new LangWatchRedirectError({
-      url,
-      location,
-      status: first.status,
-    });
+    const refused = refusalOf({ url, response: first });
     if (location === null || first.status === 303) throw refused;
     const target = schemeUpgradeTarget({ url, location });
-    if (target === null || streamed) throw refused;
+    if (target === null || isStream(init?.body)) throw refused;
 
     warnOnce({ url, logger: log });
 
@@ -162,11 +272,29 @@ export const createLangWatchFetch = ({
       : await send(target, { ...init, redirect: "manual" });
     if (!isRedirect(second)) return second;
 
-    throw new LangWatchRedirectError({
-      url: target,
-      location: second.headers.get("location"),
-      status: second.status,
-    });
+    throw refusalOf({ url: target, response: second });
+  };
+
+  return async (input, init) => {
+    const isRequest = typeof Request !== "undefined" && input instanceof Request;
+    const url = requestUrl(input);
+    const method = (init?.method ?? (isRequest ? input.method : "GET")).toUpperCase();
+    // A Request carries its body as a stream that one send consumes, so a copy
+    // is taken before the first send and read only if the replay happens.
+    const spare =
+      isRequest && init?.body === undefined && input.body !== null
+        ? input.clone()
+        : null;
+
+    const first = isRequest
+      ? await send(new Request(input, { ...init, redirect: "manual" }))
+      : await send(input, { ...init, redirect: "manual" });
+    if (!isRedirect(first)) return first;
+
+    if (FOLLOWING_METHODS.has(method)) {
+      return follow({ input, init, url, method, first });
+    }
+    return upgrade({ input, init, url, first, spare });
   };
 };
 

--- a/sdks/typescript/src/internal/http/langwatchFetch.ts
+++ b/sdks/typescript/src/internal/http/langwatchFetch.ts
@@ -1,0 +1,174 @@
+/**
+ * The one HTTP client every request to the LangWatch API goes through.
+ *
+ * A LangWatch endpoint configured as `http://app.langwatch.ai` answers with a
+ * redirect to https. The global `fetch` follows it on its own and, for a 301
+ * or 302, turns the POST into a GET and drops the body, so the event is lost
+ * without an error. This client sends with `redirect: "manual"` and applies a
+ * single rule to the 3xx it gets back: a redirect is followed once, and only
+ * when the target is the same URL with the scheme changed from http to https
+ * (same host, port, path and query). The replay uses the same method, headers
+ * and body bytes. Every other redirect is refused with `LangWatchRedirectError`.
+ *
+ * This module depends on the SDK logger only, so the CLI boot graph and the
+ * `agent` entry can import it without pulling anything else in.
+ */
+import { ConsoleLogger, type Logger } from "../../logger";
+
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+
+export class LangWatchRedirectError extends Error {
+  readonly url: string;
+  readonly location: string | null;
+  readonly status: number;
+
+  constructor({
+    url,
+    location,
+    status,
+  }: {
+    url: string;
+    location: string | null;
+    status: number;
+  }) {
+    super(
+      `LangWatch refused to follow a redirect from ${url} to ${location ?? "an unknown location"} (HTTP ${status}). Set the endpoint to the final URL.`,
+    );
+    this.name = "LangWatchRedirectError";
+    this.url = url;
+    this.location = location;
+    this.status = status;
+  }
+}
+
+export type LangWatchFetch = typeof globalThis.fetch;
+
+export interface CreateLangWatchFetchOptions {
+  /** The transport to send with. Defaults to the global `fetch` at call time. */
+  fetch?: LangWatchFetch;
+  /** Receives the one warning per process about an http endpoint. */
+  logger?: Logger;
+}
+
+/** Origins that already produced the http-to-https warning in this process. */
+const warnedOrigins = new Set<string>();
+
+/** Forgets which origins were warned about. For tests only. */
+export const resetSchemeUpgradeWarnings = (): void => {
+  warnedOrigins.clear();
+};
+
+const isRedirect = (response: Response): boolean =>
+  response.type === "opaqueredirect" || REDIRECT_STATUSES.has(response.status);
+
+const isStream = (body: unknown): boolean =>
+  typeof ReadableStream !== "undefined" && body instanceof ReadableStream;
+
+const requestUrl = (input: RequestInfo | URL): string => {
+  if (typeof input === "string") return input;
+  if (input instanceof URL) return input.href;
+  return input.url;
+};
+
+/**
+ * The https URL to replay against when `location` only upgrades the scheme of
+ * `url`, and null for any other target. The URL parser drops a default port,
+ * so `http://host:80` and `https://host:443` both read as no port.
+ */
+export const schemeUpgradeTarget = ({
+  url,
+  location,
+}: {
+  url: string;
+  location: string;
+}): string | null => {
+  let from: URL;
+  let to: URL;
+  try {
+    from = new URL(url);
+    to = new URL(location, from);
+  } catch {
+    return null;
+  }
+  if (from.protocol !== "http:" || to.protocol !== "https:") return null;
+  if (from.hostname !== to.hostname) return null;
+  if (from.port !== to.port) return null;
+  if (from.pathname !== to.pathname) return null;
+  if (from.search !== to.search) return null;
+  to.hash = "";
+  return to.href;
+};
+
+const warnOnce = ({ url, logger }: { url: string; logger: Logger }): void => {
+  const { origin, host } = new URL(url);
+  if (warnedOrigins.has(origin)) return;
+  warnedOrigins.add(origin);
+  logger.warn(
+    `LangWatch endpoint ${origin} redirected to https. Set the endpoint to https://${host} to skip the extra round trip.`,
+  );
+};
+
+/**
+ * Builds a `fetch` that applies the redirect rule. Pass `fetch` to send through
+ * another transport (a test double, a proxying client) and `logger` to route
+ * the http endpoint warning.
+ */
+export const createLangWatchFetch = ({
+  fetch: fetchImpl,
+  logger,
+}: CreateLangWatchFetchOptions = {}): LangWatchFetch => {
+  const send: LangWatchFetch =
+    fetchImpl ?? ((input, init) => globalThis.fetch(input, init));
+  const log = logger ?? new ConsoleLogger({ level: "warn", prefix: "LangWatch" });
+
+  return async (input, init) => {
+    const isRequest = typeof Request !== "undefined" && input instanceof Request;
+    const url = requestUrl(input);
+    const streamed = isStream(init?.body);
+    // A Request carries its body as a stream that one send consumes, so a copy
+    // is taken before the first send and read only if the replay happens.
+    const spare =
+      isRequest && init?.body === undefined && input.body !== null
+        ? input.clone()
+        : null;
+
+    const first = isRequest
+      ? await send(new Request(input, { ...init, redirect: "manual" }))
+      : await send(input, { ...init, redirect: "manual" });
+    if (!isRedirect(first)) return first;
+
+    const location = first.headers.get("location");
+    const refused = new LangWatchRedirectError({
+      url,
+      location,
+      status: first.status,
+    });
+    if (location === null || first.status === 303) throw refused;
+    const target = schemeUpgradeTarget({ url, location });
+    if (target === null || streamed) throw refused;
+
+    warnOnce({ url, logger: log });
+
+    const second = isRequest
+      ? await send(
+          new Request(target, {
+            method: input.method,
+            headers: input.headers,
+            body: spare ? await spare.arrayBuffer() : null,
+            signal: input.signal,
+            redirect: "manual",
+          }),
+        )
+      : await send(target, { ...init, redirect: "manual" });
+    if (!isRedirect(second)) return second;
+
+    throw new LangWatchRedirectError({
+      url: target,
+      location: second.headers.get("location"),
+      status: second.status,
+    });
+  };
+};
+
+/** The shared client, bound to the global `fetch` and the SDK console logger. */
+export const langwatchFetch: LangWatchFetch = createLangWatchFetch();

--- a/specs/python-sdk/http-client-redirects.feature
+++ b/specs/python-sdk/http-client-redirects.feature
@@ -3,20 +3,24 @@ Feature: Python SDK HTTP client redirects
   I want every request the SDK sends to LangWatch to go through one HTTP client
   So that an http endpoint still works and any other redirect fails where I can read it
 
-  Background: one client, one rule.
+  Background: one client, one rule per method.
     Every request the SDK sends to the LangWatch API, from the generated
     OpenAPI client and from every hand written call, goes through
     `langwatch.http_client`. httpx never follows a redirect on its own there.
-    The SDK follows exactly one kind of redirect: a 301, 302, 307 or 308
-    whose Location is the same URL with the scheme changed from http to
-    https. Same host, same port (an absent port is the scheme default), same
-    path, same query; the fragment is ignored. The replay keeps the method,
-    the headers and the body bytes. Every other redirect raises
-    `RedirectRefusedError`, which carries the request URL, the Location value
-    and the status. OpenTelemetry's own exporter keeps its own HTTP stack and
-    is outside this rule.
+    A GET or HEAD follows a 301, 302, 303, 307 or 308 with the same method,
+    up to five hops. A hop that keeps the origin, or only upgrades http to
+    https on the same host and port, keeps every header; any other hop drops
+    Authorization, X-Auth-Token and X-Project-Id first. A hop from https to
+    http is refused. Every other method follows exactly one redirect: a 301,
+    302, 307 or 308 whose Location is the same URL with the scheme changed
+    from http to https. Same host, same port (an absent port is the scheme
+    default), same path, same query; the fragment is ignored. The replay
+    keeps the method, the headers and the body bytes. Every refused redirect
+    raises `RedirectRefusedError`, which carries the request URL, the
+    Location value and the status. OpenTelemetry's own exporter keeps its own
+    HTTP stack and is outside this rule.
 
-  # --- The upgrade that is followed ---
+  # --- The upgrade every method follows ---
 
   @unit
   Scenario: follows a redirect that only upgrades http to https
@@ -38,38 +42,92 @@ Feature: Python SDK HTTP client redirects
     Then one warning names the http endpoint and the https endpoint to set
     And the second upgrade logs no warning
 
-  # --- Redirects that are refused ---
+  # --- What a GET or HEAD follows ---
 
   @unit
-  Scenario: refuses a redirect to another host
-    Given a client whose endpoint answers with a 301 to a different host
-    When the SDK sends a request
+  Scenario: a GET follows a redirect to another path
+    Given a client whose endpoint answers a GET with a 301 to another path on the same host
+    When the SDK sends the GET
+    Then the transport sent a second GET to the new path
+    And the caller receives the response of the new path
+
+  @unit
+  Scenario: a GET follows a chain of redirects up to five hops
+    Given a client whose endpoint answers a GET with five redirects in a row and then a 200
+    When the SDK sends the GET
+    Then the transport sent six requests, each one a GET
+    And the caller receives the final 200
+
+  @unit
+  Scenario: a GET refuses a sixth hop
+    Given a client whose endpoint answers a GET with six redirects in a row
+    When the SDK sends the GET
+    Then the call raises RedirectRefusedError naming the fifth target, the sixth Location and its status
+    And the transport sent six requests
+
+  @unit
+  Scenario: a GET keeps its headers on a same origin redirect
+    Given a client whose endpoint answers a GET with a 302 to another path on the same origin
+    When the SDK sends the GET with Authorization, X-Auth-Token, X-Project-Id and X-Trace headers
+    Then the second request carries every header of the first
+
+  @unit
+  Scenario: a GET drops credential headers on a cross origin redirect
+    Given a client whose endpoint answers a GET with a 302 to another host
+    When the SDK sends the GET with Authorization, X-Auth-Token, X-Project-Id and X-Trace headers
+    Then the second request carries X-Trace and the new Host and none of the credential headers
+
+  @unit
+  Scenario: a GET refuses a downgrade from https to http
+    Given a client whose endpoint answers a https GET with a 301 to the same http URL
+    When the SDK sends the GET to the https URL
+    Then the call raises RedirectRefusedError
+    And the transport sent one request
+
+  @unit
+  Scenario: a GET follows a 303
+    Given a client whose endpoint answers a GET with a 303 to another path
+    When the SDK sends the GET
+    Then the transport sent a second GET to the new path
+
+  @unit
+  Scenario: a HEAD follows a redirect like a GET
+    Given a client whose endpoint answers a HEAD with a 301 to another path
+    When the SDK sends the HEAD
+    Then the transport sent a second HEAD to the new path
+
+  # --- What every other method refuses ---
+
+  @unit
+  Scenario: a POST refuses a redirect to another host
+    Given a client whose endpoint answers a POST with a 301 to a different host
+    When the SDK sends the POST
     Then the call raises RedirectRefusedError with the request URL, the Location and the status
     And the error message tells the caller to set the endpoint to the final URL
 
   @unit
-  Scenario: refuses a redirect that changes the path or query
-    Given a client whose endpoint answers with a 308 to the https URL with another path
-    And a client whose endpoint answers with a 308 to the https URL with another query
-    When the SDK sends a request to each
+  Scenario: a POST still refuses a redirect to another path
+    Given a client whose endpoint answers a POST with a 308 to the https URL with another path
+    And a client whose endpoint answers a POST with a 308 to the https URL with another query
+    When the SDK sends a POST to each
     Then each call raises RedirectRefusedError
 
   @unit
-  Scenario: refuses a downgrade from https to http
-    Given a client whose endpoint answers https with a 301 to the same http URL
-    When the SDK sends a request to the https URL
+  Scenario: a POST refuses a downgrade from https to http
+    Given a client whose endpoint answers a https POST with a 301 to the same http URL
+    When the SDK sends the POST to the https URL
     Then the call raises RedirectRefusedError
 
   @unit
-  Scenario: refuses a 303
-    Given a client whose endpoint answers http with a 303 to the same https URL
-    When the SDK sends a request
+  Scenario: a POST refuses a 303
+    Given a client whose endpoint answers a http POST with a 303 to the same https URL
+    When the SDK sends the POST
     Then the call raises RedirectRefusedError with status 303
 
   @unit
-  Scenario: refuses a second redirect after the upgrade
-    Given a client whose endpoint upgrades http to https and then redirects again
-    When the SDK sends a request to the http URL
+  Scenario: a POST refuses a second redirect after the upgrade
+    Given a client whose endpoint upgrades a POST from http to https and then redirects again
+    When the SDK sends the POST to the http URL
     Then the call raises RedirectRefusedError naming the https URL as the request URL
 
   @unit

--- a/specs/python-sdk/http-client-redirects.feature
+++ b/specs/python-sdk/http-client-redirects.feature
@@ -10,10 +10,11 @@ Feature: Python SDK HTTP client redirects
     A GET or HEAD follows a 301, 302, 303, 307 or 308 with the same method,
     up to five hops. A hop that keeps the origin, or only upgrades http to
     https on the same host and port, keeps every header; any other hop drops
-    Authorization, X-Auth-Token and X-Project-Id first. A hop from https to
-    http is refused. Every other method follows exactly one redirect: a 301,
-    302, 307 or 308 whose Location is the same URL with the scheme changed
-    from http to https. Same host, same port (an absent port is the scheme
+    Authorization, Cookie, Proxy-Authorization, X-Api-Key, X-Auth-Token and
+    X-Project-Id first. A hop from https to http is refused. Every other
+    method follows exactly one redirect: a 301, 302, 307 or 308 whose
+    Location is the same URL with the scheme changed from http to https.
+    Same host, same port (an absent port is the scheme
     default), same path, same query; the fragment is ignored. The replay
     keeps the method, the headers and the body bytes. Every refused redirect
     raises `RedirectRefusedError`, which carries the request URL, the

--- a/specs/python-sdk/http-client-redirects.feature
+++ b/specs/python-sdk/http-client-redirects.feature
@@ -82,6 +82,18 @@ Feature: Python SDK HTTP client redirects
     Then the second request carries X-Trace and the new Host and none of the credential headers
 
   @unit
+  Scenario: a GET drops the client's auth on a cross origin redirect
+    Given a client built with httpx auth whose endpoint answers a GET with a 302 to another host
+    When the SDK sends the GET
+    Then the second request carries no Authorization header
+
+  @unit
+  Scenario: a GET keeps the client's auth on an https upgrade
+    Given a client built with httpx auth whose endpoint answers a GET with a 301 to the same https URL
+    When the SDK sends the GET
+    Then the second request carries the Authorization header httpx signs
+
+  @unit
   Scenario: a GET refuses a downgrade from https to http
     Given a client whose endpoint answers a https GET with a 301 to the same http URL
     When the SDK sends the GET to the https URL

--- a/specs/python-sdk/http-client-redirects.feature
+++ b/specs/python-sdk/http-client-redirects.feature
@@ -6,7 +6,10 @@ Feature: Python SDK HTTP client redirects
   Background: one client, one rule per method.
     Every request the SDK sends to the LangWatch API, from the generated
     OpenAPI client and from every hand written call, goes through
-    `langwatch.http_client`. httpx never follows a redirect on its own there.
+    `langwatch.http_client`. httpx never follows a redirect on its own there;
+    the shared client sends one hop at a time, so httpx picks the transport
+    (a proxy mount, a NO_PROXY exemption, or a mount the caller passed) from
+    the URL of every hop.
     A GET or HEAD follows a 301, 302, 303, 307 or 308 with the same method,
     up to five hops. A hop that keeps the origin, or only upgrades http to
     https on the same host and port, keeps every header; any other hop drops
@@ -137,16 +140,34 @@ Feature: Python SDK HTTP client redirects
     When the SDK sends a request
     Then the call raises RedirectRefusedError with no location
 
+  # --- The transport is chosen per hop ---
+
+  @unit
+  Scenario: the https replay uses the mount of the https URL
+    Given a client with one transport mounted for http and another for https
+    And the http transport answers a POST with a 301 to the same https URL
+    When the SDK sends the POST to the http URL
+    Then the http transport received the first request only
+    And the https transport received the replay with the same method and body
+
+  @unit
+  Scenario: a GET hop across a NO_PROXY boundary uses the mount of the new host
+    Given a client with a proxy transport mounted for every URL and a direct transport mounted for one host
+    And the proxy transport answers a GET with a 302 to that host
+    When the SDK sends the GET
+    Then the proxy transport received the first request only
+    And the direct transport received the hop without the credential headers
+
   # --- Every request goes through the shared client ---
 
   @unit
-  Scenario: the generated API client uses the shared transport
+  Scenario: the generated API client uses the shared client
     Given the SDK client is set up with an api key and an endpoint
     When the generated REST client builds its sync and async httpx clients
-    Then both carry the scheme upgrade transport and never follow redirects on their own
+    Then both are the shared client classes and never follow redirects on their own
 
   @unit
-  Scenario: every hand written request uses the shared transport
+  Scenario: every hand written request uses the shared client
     Given the SDK source tree outside the generated client and the shared module
     When the source is scanned for raw httpx client constructions and module level httpx calls
     Then none are found
@@ -155,6 +176,6 @@ Feature: Python SDK HTTP client redirects
   Scenario: the client keeps httpx's environment proxy discovery
     Given HTTP_PROXY names a proxy and the SDK sends a request to an http origin
     When the shared sync or async client sends it
-    Then the proxy receives the request and its transport applies the redirect rule
+    Then the proxy receives the request and a redirect it answers follows the rule
     And NO_PROXY sends the request straight to the origin instead
     And trust_env set to false ignores the environment proxy

--- a/specs/python-sdk/http-client-redirects.feature
+++ b/specs/python-sdk/http-client-redirects.feature
@@ -150,3 +150,11 @@ Feature: Python SDK HTTP client redirects
     Given the SDK source tree outside the generated client and the shared module
     When the source is scanned for raw httpx client constructions and module level httpx calls
     Then none are found
+
+  @unit
+  Scenario: the client keeps httpx's environment proxy discovery
+    Given HTTP_PROXY names a proxy and the SDK sends a request to an http origin
+    When the shared sync or async client sends it
+    Then the proxy receives the request and its transport applies the redirect rule
+    And NO_PROXY sends the request straight to the origin instead
+    And trust_env set to false ignores the environment proxy

--- a/specs/python-sdk/http-client-redirects.feature
+++ b/specs/python-sdk/http-client-redirects.feature
@@ -1,0 +1,93 @@
+Feature: Python SDK HTTP client redirects
+  As a Python SDK user who sets LANGWATCH_ENDPOINT
+  I want every request the SDK sends to LangWatch to go through one HTTP client
+  So that an http endpoint still works and any other redirect fails where I can read it
+
+  Background: one client, one rule.
+    Every request the SDK sends to the LangWatch API, from the generated
+    OpenAPI client and from every hand written call, goes through
+    `langwatch.http_client`. httpx never follows a redirect on its own there.
+    The SDK follows exactly one kind of redirect: a 301, 302, 307 or 308
+    whose Location is the same URL with the scheme changed from http to
+    https. Same host, same port (an absent port is the scheme default), same
+    path, same query; the fragment is ignored. The replay keeps the method,
+    the headers and the body bytes. Every other redirect raises
+    `RedirectRefusedError`, which carries the request URL, the Location value
+    and the status. OpenTelemetry's own exporter keeps its own HTTP stack and
+    is outside this rule.
+
+  # --- The upgrade that is followed ---
+
+  @unit
+  Scenario: follows a redirect that only upgrades http to https
+    Given a client whose endpoint answers http with a 301 to the same https URL
+    When the SDK sends a request to the http URL
+    Then the caller receives the https response
+    And the transport sent exactly two requests
+
+  @unit
+  Scenario: replays the same method, headers and body on the upgrade
+    Given a client whose endpoint answers http with a 307 to the same https URL
+    When the SDK sends a POST with an Authorization header and a JSON body
+    Then the https request carries the same method, the same headers and the same body bytes
+
+  @unit
+  Scenario: warns once per process about an http endpoint
+    Given a client whose endpoint upgrades http to https
+    When the SDK sends two requests to the http URL
+    Then one warning names the http endpoint and the https endpoint to set
+    And the second upgrade logs no warning
+
+  # --- Redirects that are refused ---
+
+  @unit
+  Scenario: refuses a redirect to another host
+    Given a client whose endpoint answers with a 301 to a different host
+    When the SDK sends a request
+    Then the call raises RedirectRefusedError with the request URL, the Location and the status
+    And the error message tells the caller to set the endpoint to the final URL
+
+  @unit
+  Scenario: refuses a redirect that changes the path or query
+    Given a client whose endpoint answers with a 308 to the https URL with another path
+    And a client whose endpoint answers with a 308 to the https URL with another query
+    When the SDK sends a request to each
+    Then each call raises RedirectRefusedError
+
+  @unit
+  Scenario: refuses a downgrade from https to http
+    Given a client whose endpoint answers https with a 301 to the same http URL
+    When the SDK sends a request to the https URL
+    Then the call raises RedirectRefusedError
+
+  @unit
+  Scenario: refuses a 303
+    Given a client whose endpoint answers http with a 303 to the same https URL
+    When the SDK sends a request
+    Then the call raises RedirectRefusedError with status 303
+
+  @unit
+  Scenario: refuses a second redirect after the upgrade
+    Given a client whose endpoint upgrades http to https and then redirects again
+    When the SDK sends a request to the http URL
+    Then the call raises RedirectRefusedError naming the https URL as the request URL
+
+  @unit
+  Scenario: refuses a redirect without a location
+    Given a client whose endpoint answers with a 301 and no Location header
+    When the SDK sends a request
+    Then the call raises RedirectRefusedError with no location
+
+  # --- Every request goes through the shared client ---
+
+  @unit
+  Scenario: the generated API client uses the shared transport
+    Given the SDK client is set up with an api key and an endpoint
+    When the generated REST client builds its sync and async httpx clients
+    Then both carry the scheme upgrade transport and never follow redirects on their own
+
+  @unit
+  Scenario: every hand written request uses the shared transport
+    Given the SDK source tree outside the generated client and the shared module
+    When the source is scanned for raw httpx client constructions and module level httpx calls
+    Then none are found

--- a/specs/typescript-sdk/http-client-redirects.feature
+++ b/specs/typescript-sdk/http-client-redirects.feature
@@ -148,6 +148,21 @@ Feature: TypeScript SDK HTTP client redirects
     Then the request fails with a LangWatchRedirectError
     And no second request is sent
 
+  @unit
+  Scenario: a body that is never replayed is released without waiting
+    Given a POST Request carrying a body
+    And the platform answers it without a redirect
+    When the SDK sends the request
+    Then the caller receives the answer
+
+  @unit
+  Scenario: an aborted call settles while a streamed body is replayed
+    Given a POST Request whose streamed body never ends
+    And the platform answers with a 307 to the same URL over https
+    When the caller aborts the request while the body is replayed
+    Then the request fails with an AbortError
+    And no second request is sent
+
   # --- Every request goes through the shared client ---
 
   @unit

--- a/specs/typescript-sdk/http-client-redirects.feature
+++ b/specs/typescript-sdk/http-client-redirects.feature
@@ -6,6 +6,10 @@ Feature: TypeScript SDK HTTP client redirects
   Background:
     Given every request the SDK sends to the LangWatch API goes through the shared langwatchFetch
     And langwatchFetch sends with redirects disabled and inspects the response itself
+    And a GET or HEAD follows a 301, 302, 303, 307 or 308 with the same method, up to five hops
+    And every other method follows one redirect only, and only an http to https upgrade of the same URL
+
+  # --- The upgrade every method follows ---
 
   @unit
   Scenario: follows a redirect that only upgrades http to https
@@ -29,37 +33,96 @@ Feature: TypeScript SDK HTTP client redirects
     Then the SDK logger warns exactly once
     And the warning names "https://app.langwatch.ai" as the endpoint to configure
 
+  # --- What a GET or HEAD follows ---
+
   @unit
-  Scenario: refuses a redirect to another host
-    Given the platform answers with a 301 to "https://other.example.com" on the same path
+  Scenario: a GET follows a redirect to another path
+    Given the platform answers a GET with a 301 to another path on the same host
+    When the SDK sends the request
+    Then the request is sent again as a GET to the new path
+    And the caller receives the response of the new path
+
+  @unit
+  Scenario: a GET follows a chain of redirects up to five hops
+    Given the platform answers a GET with five redirects in a row and then a 200
+    When the SDK sends the request
+    Then six requests are sent, each one as a GET
+    And the caller receives the final 200
+
+  @unit
+  Scenario: a GET refuses a sixth hop
+    Given the platform answers a GET with six redirects in a row
+    When the SDK sends the request
+    Then the request fails with a LangWatchRedirectError carrying the fifth target as the URL and the sixth Location and status
+    And no seventh request is sent
+
+  @unit
+  Scenario: a GET keeps its headers on a same origin redirect
+    Given a GET with Authorization, X-Auth-Token, X-Project-Id and Accept headers
+    And the platform answers with a 302 to another path on the same origin
+    When the SDK sends the request
+    Then the second request carries every header of the first
+
+  @unit
+  Scenario: a GET drops credential headers on a cross origin redirect
+    Given a GET with Authorization, X-Auth-Token, X-Project-Id and Accept headers
+    And the platform answers with a 302 to another host
+    When the SDK sends the request
+    Then the second request carries the Accept header and none of the credential headers
+
+  @unit
+  Scenario: a GET refuses a downgrade from https to http
+    Given the endpoint is "https://app.langwatch.ai"
+    And the platform answers a GET with a 301 to the same URL over http
+    When the SDK sends the request
+    Then the request fails with a LangWatchRedirectError
+    And no second request is sent
+
+  @unit
+  Scenario: a GET follows a 303
+    Given the platform answers a GET with a 303 to another path
+    When the SDK sends the request
+    Then the request is sent again as a GET to the new path
+
+  @unit
+  Scenario: a HEAD follows a redirect like a GET
+    Given the platform answers a HEAD with a 301 to another path
+    When the SDK sends the request
+    Then the request is sent again as a HEAD to the new path
+
+  # --- What every other method refuses ---
+
+  @unit
+  Scenario: a POST refuses a redirect to another host
+    Given the platform answers a POST with a 301 to "https://other.example.com" on the same path
     When the SDK sends the request
     Then the request fails with a LangWatchRedirectError carrying the request URL, the Location and the status
     And the error message asks to set the endpoint to the final URL
     And no second request is sent
 
   @unit
-  Scenario: refuses a redirect that changes the path or query
-    Given the platform answers with a 308 to the same host over https on a different path or query
+  Scenario: a POST still refuses a redirect to another path
+    Given the platform answers a POST with a 308 to the same host over https on a different path or query
     When the SDK sends the request
     Then the request fails with a LangWatchRedirectError
     And no second request is sent
 
   @unit
-  Scenario: refuses a downgrade from https to http
+  Scenario: a POST refuses a downgrade from https to http
     Given the endpoint is "https://app.langwatch.ai"
-    And the platform answers with a 301 to the same URL over http
+    And the platform answers a POST with a 301 to the same URL over http
     When the SDK sends the request
     Then the request fails with a LangWatchRedirectError
 
   @unit
-  Scenario: refuses a 303
-    Given the platform answers with a 303 to the same URL over https
+  Scenario: a POST refuses a 303
+    Given the platform answers a POST with a 303 to the same URL over https
     When the SDK sends the request
     Then the request fails with a LangWatchRedirectError
 
   @unit
-  Scenario: refuses a second redirect after the upgrade
-    Given the platform answers the http request with a 301 to the same URL over https
+  Scenario: a POST refuses a second redirect after the upgrade
+    Given the platform answers the http POST with a 301 to the same URL over https
     And the https request is answered with another redirect
     When the SDK sends the request
     Then the request fails with a LangWatchRedirectError carrying the https URL and the second Location
@@ -85,6 +148,8 @@ Feature: TypeScript SDK HTTP client redirects
     Then the request fails with a LangWatchRedirectError
     And no second request is sent
 
+  # --- Every request goes through the shared client ---
+
   @unit
   Scenario: the generated API client uses the shared transport
     Given the OpenAPI client is created for "http://app.langwatch.ai"
@@ -97,5 +162,5 @@ Feature: TypeScript SDK HTTP client redirects
   Scenario: every hand written request uses the shared transport
     Given the SDK source outside tests and generated code
     When it is scanned for direct fetch calls and fetch defaults
-    Then every file that talks to the LangWatch API uses langwatchFetch
-    And only calls to other servers, a tunnel, a user's own agent or the docs site, use fetch directly
+    Then every file that talks to the LangWatch API or the docs site uses langwatchFetch
+    And only calls to other servers, a tunnel or a user's own agent, use fetch directly

--- a/specs/typescript-sdk/http-client-redirects.feature
+++ b/specs/typescript-sdk/http-client-redirects.feature
@@ -1,0 +1,101 @@
+Feature: TypeScript SDK HTTP client redirects
+  As a developer pointing the SDK at LangWatch with an http endpoint
+  I want every request to reach the API over https without losing its body
+  So that an endpoint written as http://app.langwatch.ai still records events and any other redirect is an error I can read
+
+  Background:
+    Given every request the SDK sends to the LangWatch API goes through the shared langwatchFetch
+    And langwatchFetch sends with redirects disabled and inspects the response itself
+
+  @unit
+  Scenario: follows a redirect that only upgrades http to https
+    Given the endpoint is "http://app.langwatch.ai"
+    And the platform answers a request with a 301 whose Location is the same URL over https
+    When the SDK sends the request
+    Then the request is sent again to the https URL
+    And the caller receives the https response
+
+  @unit
+  Scenario: replays the same method, headers and body on the upgrade
+    Given a POST with an Authorization header and a JSON body
+    And the platform answers with a 307 to the same URL over https
+    When the SDK sends the request
+    Then the https request carries the same method, the same headers and the same body bytes
+
+  @unit
+  Scenario: warns once per process about an http endpoint
+    Given two requests to "http://app.langwatch.ai" that are both upgraded
+    When both complete
+    Then the SDK logger warns exactly once
+    And the warning names "https://app.langwatch.ai" as the endpoint to configure
+
+  @unit
+  Scenario: refuses a redirect to another host
+    Given the platform answers with a 301 to "https://other.example.com" on the same path
+    When the SDK sends the request
+    Then the request fails with a LangWatchRedirectError carrying the request URL, the Location and the status
+    And the error message asks to set the endpoint to the final URL
+    And no second request is sent
+
+  @unit
+  Scenario: refuses a redirect that changes the path or query
+    Given the platform answers with a 308 to the same host over https on a different path or query
+    When the SDK sends the request
+    Then the request fails with a LangWatchRedirectError
+    And no second request is sent
+
+  @unit
+  Scenario: refuses a downgrade from https to http
+    Given the endpoint is "https://app.langwatch.ai"
+    And the platform answers with a 301 to the same URL over http
+    When the SDK sends the request
+    Then the request fails with a LangWatchRedirectError
+
+  @unit
+  Scenario: refuses a 303
+    Given the platform answers with a 303 to the same URL over https
+    When the SDK sends the request
+    Then the request fails with a LangWatchRedirectError
+
+  @unit
+  Scenario: refuses a second redirect after the upgrade
+    Given the platform answers the http request with a 301 to the same URL over https
+    And the https request is answered with another redirect
+    When the SDK sends the request
+    Then the request fails with a LangWatchRedirectError carrying the https URL and the second Location
+    And no third request is sent
+
+  @unit
+  Scenario: refuses a redirect without a location
+    Given the platform answers with a 302 and no Location header
+    When the SDK sends the request
+    Then the request fails with a LangWatchRedirectError whose location is empty
+
+  @unit
+  Scenario: refuses an opaque redirect
+    Given the runtime hides the redirect target behind an opaque redirect response
+    When the SDK sends the request
+    Then the request fails with a LangWatchRedirectError with status 0
+
+  @unit
+  Scenario: refuses to replay a streaming body
+    Given a POST whose body is a ReadableStream
+    And the platform answers with a 307 to the same URL over https
+    When the SDK sends the request
+    Then the request fails with a LangWatchRedirectError
+    And no second request is sent
+
+  @unit
+  Scenario: the generated API client uses the shared transport
+    Given the OpenAPI client is created for "http://app.langwatch.ai"
+    And the platform answers with a 301 to the same URL over https
+    When a request is made through the client
+    Then the https request carries the client's authentication headers
+    And the caller receives the https response body
+
+  @unit
+  Scenario: every hand written request uses the shared transport
+    Given the SDK source outside tests and generated code
+    When it is scanned for direct fetch calls and fetch defaults
+    Then every file that talks to the LangWatch API uses langwatchFetch
+    And only calls to other servers, a tunnel, a user's own agent or the docs site, use fetch directly


### PR DESCRIPTION
## Why

Every SDK talked to the LangWatch API through many ad hoc HTTP calls with different redirect behaviour. When the endpoint is set to `http://app.langwatch.ai`, the platform answers with a 301 to https. A default HTTP client follows it by turning the POST into a GET and dropping the body, so the event is lost without an error. Refusing every redirect breaks those users instead.

## The rule

The Python and TypeScript SDKs each get one shared HTTP client, and every request to the LangWatch API goes through it (the generated OpenAPI client and every hand written call). The client sends with redirects disabled and applies a rule per method to a 301, 302, 303, 307 or 308:

- **GET and HEAD follow redirects**, up to 5 hops, each hop with the same method. When the hop stays on the same origin (scheme, host, port), or only upgrades http to https on the same host and port, every header is kept. When the origin changes otherwise, `Authorization`, `X-Auth-Token` and `X-Project-Id` are removed before sending and every other header is kept. A hop from https to http, a hop without `Location`, and a sixth hop are refused with the typed error (URL of the last request, `Location` and status of the last response).
- **Every other method** (POST, PUT, PATCH, DELETE and the rest) follows one redirect only, and only when the target is the same URL with the scheme changed from http to https: same host, same port (an absent port equals the scheme default), same path, same query, fragment ignored. The replay uses the same method, headers and body bytes. Every other redirect is refused: another host, another path or query, https to http, a 303, a second redirect after the upgrade, a redirect without `Location`, or a body that cannot be replayed (a stream).
- On an http to https upgrade hop the SDK logs one warning per process: `LangWatch endpoint http://host redirected to https. Set the endpoint to https://host to skip the extra round trip.`
- The error message is `LangWatch refused to follow a redirect from <url> to <location> (HTTP <status>). Set the endpoint to the final URL.` and the error carries `url`, `location` and `status`.

OTLP exporters use OpenTelemetry's own HTTP stack and are out of scope.

## TypeScript SDK (`sdks/typescript`)

- New `src/internal/http/langwatchFetch.ts`: `createLangWatchFetch({ fetch?, logger? })`, the default `langwatchFetch` bound to the global fetch, and `LangWatchRedirectError` (`url`, `location`, `status`). Same signature as `fetch`. An opaque redirect (browsers) is refused with status 0. `schemeUpgradeTarget` decides the upgrade for the non GET methods, `followTarget` decides a GET or HEAD hop, and `MAX_FOLLOW_HOPS` is 5.
- `createLangWatchApiClient` passes `fetch: langwatchFetch` to `openapi-fetch`; `createManagementRequest`, every raw `fetch(` in `src/client-sdk/services/**` and `src/cli/**` that targets the LangWatch endpoint, the ingestion hook and context defaults, the identity notice, the agent long-poll transport and the `docs` command use it. The tunnel probe and the user's own HTTP agent call stay on the plain fetch because they do not target LangWatch.
- `langwatchFetch`, `createLangWatchFetch` and `LangWatchRedirectError` are exported from the package main entry so `@langwatch/scenario` can import them.
- A unit test walks `src` and fails on any raw `fetch(` or `= fetch` default outside the shared module and the two non-LangWatch callers, so a new call site cannot bypass the rule.
- The CLI boot graph is unchanged (`src/cli/__tests__/index-boot.unit.test.ts`).
- Spec: `specs/typescript-sdk/http-client-redirects.feature` (21 scenarios, all bound). Docs: one paragraph in `docs/integration/typescript/reference.mdx`.

## Python SDK (`sdks/python`)

`langwatch.http_client` ships `LangWatchClient(httpx.Client)` and `LangWatchAsyncClient(httpx.AsyncClient)`, plus `create_client(**httpx_kwargs)` and `create_async_client(**httpx_kwargs)`, which build them and pass every keyword argument to httpx unchanged. The classes force `follow_redirects=False` and override `send`: each hop goes through `httpx.Client.send`, which selects the transport from the hop's own URL, so the https replay of an http request leaves through the https mount and a GET hop to a host exempted by NO_PROXY leaves through that host's direct transport. Environment proxy discovery (HTTP_PROXY, HTTPS_PROXY, ALL_PROXY, NO_PROXY) stays httpx's own. A GET or HEAD hop that leaves the origin also rewrites the `Host` header for the new target. A refused redirect raises `RedirectRefusedError` with `url`, `location` and `status`. One warning per process goes through the `langwatch.http_client` logger.

The generated `Client` receives both clients through `set_httpx_client` and `set_async_httpx_client`, so every facade and generated call uses the rule. The hand written httpx calls in batch evaluation, the agent client, evaluation, workflow, experiment, tracing, login and dspy use the factories. Tests: `sdks/python/tests/test_http_client.py` (52 tests, spec `specs/python-sdk/http-client-redirects.feature`, 22 of 22 scenarios bound), including two mounts per client that record which transport received each hop, and loopback proxy servers for the environment proxy scenarios; `make test-unit` passes.

## How to verify

```bash
cd sdks/typescript && pnpm test:unit src/internal/http src/cli/__tests__/index-boot.unit.test.ts
cd sdks/typescript && pnpm typecheck
cd sdks/python && make test-unit
cd platform/app && pnpm check:feature-parity
```

Point either SDK at `http://app.langwatch.ai` (or a local server that answers 301 to https) and send a request: it is delivered over https with one warning. Send a GET to a server that redirects to another path or host: the SDK follows it, without the credential headers when the host changes. Send a POST to a server that redirects elsewhere: the request fails with the redirect error naming the URL, the `Location` and the status.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added consistent HTTP handling across the TypeScript and Python SDKs.
  - GET and HEAD requests can follow redirects for up to five hops; other requests support one same-URL HTTP-to-HTTPS upgrade.
  - Cross-origin credentials are removed during supported redirects.
  - Unsupported redirects now provide clear request and redirect details.
  - Added warnings when HTTP endpoints are upgraded to HTTPS.
  - Improved operation when no global fetch implementation is available.
  - Exported HTTP client utilities for SDK integrations.

- **Documentation**
  - Documented redirect behavior and recommended configuring final HTTPS endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

