### PR TITLE
fix(agents): a key waits for its grants, and a listing shows who holds each agent

### DIFF
--- a/docs/api-reference/openapiLangWatch.json
+++ b/docs/api-reference/openapiLangWatch.json
@@ -2590,8 +2590,7 @@
                       },
                       "maxConcurrency": {
                         "type": "integer",
-                        "exclusiveMinimum": true,
-                        "minimum": 0,
+                        "exclusiveMinimum": 0,
                         "maximum": 1000
                       }
                     },
@@ -2626,14 +2625,12 @@
                         },
                         "concurrency": {
                           "type": "integer",
-                          "exclusiveMinimum": true,
-                          "minimum": 0,
+                          "exclusiveMinimum": 0,
                           "maximum": 1000
                         },
                         "timeoutMs": {
                           "type": "integer",
-                          "exclusiveMinimum": true,
-                          "minimum": 0
+                          "exclusiveMinimum": 0
                         },
                         "sticky": {
                           "type": "boolean"
@@ -18430,13 +18427,11 @@
                 "properties": {
                   "startDate": {
                     "type": "number",
-                    "exclusiveMinimum": true,
-                    "minimum": 0
+                    "exclusiveMinimum": 0
                   },
                   "endDate": {
                     "type": "number",
-                    "exclusiveMinimum": true,
-                    "minimum": 0
+                    "exclusiveMinimum": 0
                   },
                   "query": {
                     "type": "string"
@@ -36022,8 +36017,7 @@
                                 },
                                 "pid": {
                                   "type": "integer",
-                                  "exclusiveMinimum": true,
-                                  "minimum": 0
+                                  "exclusiveMinimum": 0
                                 },
                                 "durationMs": {
                                   "type": "integer",
@@ -36136,8 +36130,7 @@
                             },
                             "timeoutSeconds": {
                               "type": "integer",
-                              "exclusiveMinimum": true,
-                              "minimum": 0,
+                              "exclusiveMinimum": 0,
                               "maximum": 3600
                             }
                           },

--- a/docs/api-reference/openapiLangWatch.json
+++ b/docs/api-reference/openapiLangWatch.json
@@ -3279,6 +3279,21 @@
                             },
                             "description": "The processes currently connected for a connected agent: hostname, user, pid, SDK and how many calls each has in flight. Empty for every other kind."
                           },
+                          "selectable": {
+                            "type": "boolean",
+                            "description": "Whether the credential making this request can run simulations against the agent. False for a personal development agent that belongs to somebody else, which is listed all the same so it can be told apart from the other agents of the same name."
+                          },
+                          "notSelectableReason": {
+                            "type": [
+                              "string",
+                              "null"
+                            ],
+                            "enum": [
+                              "owned_by_another_person",
+                              null
+                            ],
+                            "description": "Why the agent cannot be run by this credential. Null when it can."
+                          },
                           "createdAt": {
                             "type": "string"
                           },
@@ -3303,6 +3318,8 @@
                           "owner",
                           "status",
                           "instances",
+                          "selectable",
+                          "notSelectableReason",
                           "createdAt",
                           "updatedAt",
                           "platformUrl"
@@ -3599,6 +3616,21 @@
                       },
                       "description": "The processes currently connected for a connected agent: hostname, user, pid, SDK and how many calls each has in flight. Empty for every other kind."
                     },
+                    "selectable": {
+                      "type": "boolean",
+                      "description": "Whether the credential making this request can run simulations against the agent. False for a personal development agent that belongs to somebody else, which is listed all the same so it can be told apart from the other agents of the same name."
+                    },
+                    "notSelectableReason": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "enum": [
+                        "owned_by_another_person",
+                        null
+                      ],
+                      "description": "Why the agent cannot be run by this credential. Null when it can."
+                    },
                     "createdAt": {
                       "type": "string"
                     },
@@ -3623,6 +3655,8 @@
                     "owner",
                     "status",
                     "instances",
+                    "selectable",
+                    "notSelectableReason",
                     "createdAt",
                     "updatedAt",
                     "platformUrl"
@@ -3910,6 +3944,21 @@
                       },
                       "description": "The processes currently connected for a connected agent: hostname, user, pid, SDK and how many calls each has in flight. Empty for every other kind."
                     },
+                    "selectable": {
+                      "type": "boolean",
+                      "description": "Whether the credential making this request can run simulations against the agent. False for a personal development agent that belongs to somebody else, which is listed all the same so it can be told apart from the other agents of the same name."
+                    },
+                    "notSelectableReason": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "enum": [
+                        "owned_by_another_person",
+                        null
+                      ],
+                      "description": "Why the agent cannot be run by this credential. Null when it can."
+                    },
                     "createdAt": {
                       "type": "string"
                     },
@@ -3934,6 +3983,8 @@
                     "owner",
                     "status",
                     "instances",
+                    "selectable",
+                    "notSelectableReason",
                     "createdAt",
                     "updatedAt",
                     "platformUrl"
@@ -4191,6 +4242,21 @@
                       },
                       "description": "The processes currently connected for a connected agent: hostname, user, pid, SDK and how many calls each has in flight. Empty for every other kind."
                     },
+                    "selectable": {
+                      "type": "boolean",
+                      "description": "Whether the credential making this request can run simulations against the agent. False for a personal development agent that belongs to somebody else, which is listed all the same so it can be told apart from the other agents of the same name."
+                    },
+                    "notSelectableReason": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "enum": [
+                        "owned_by_another_person",
+                        null
+                      ],
+                      "description": "Why the agent cannot be run by this credential. Null when it can."
+                    },
                     "createdAt": {
                       "type": "string"
                     },
@@ -4215,6 +4281,8 @@
                     "owner",
                     "status",
                     "instances",
+                    "selectable",
+                    "notSelectableReason",
                     "createdAt",
                     "updatedAt",
                     "platformUrl"
@@ -4510,6 +4578,21 @@
                       },
                       "description": "The processes currently connected for a connected agent: hostname, user, pid, SDK and how many calls each has in flight. Empty for every other kind."
                     },
+                    "selectable": {
+                      "type": "boolean",
+                      "description": "Whether the credential making this request can run simulations against the agent. False for a personal development agent that belongs to somebody else, which is listed all the same so it can be told apart from the other agents of the same name."
+                    },
+                    "notSelectableReason": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "enum": [
+                        "owned_by_another_person",
+                        null
+                      ],
+                      "description": "Why the agent cannot be run by this credential. Null when it can."
+                    },
                     "createdAt": {
                       "type": "string"
                     },
@@ -4534,6 +4617,8 @@
                     "owner",
                     "status",
                     "instances",
+                    "selectable",
+                    "notSelectableReason",
                     "createdAt",
                     "updatedAt",
                     "platformUrl"
@@ -36022,6 +36107,38 @@
                             },
                             "skipOffered": {
                               "type": "boolean"
+                            },
+                            "segments": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "command": {
+                                    "type": "string",
+                                    "maxLength": 4000
+                                  },
+                                  "pattern": {
+                                    "type": "string",
+                                    "maxLength": 500
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "command",
+                                  "pattern",
+                                  "readOnly"
+                                ],
+                                "additionalProperties": false
+                              },
+                              "maxItems": 50
+                            },
+                            "timeoutSeconds": {
+                              "type": "integer",
+                              "exclusiveMinimum": true,
+                              "minimum": 0,
+                              "maximum": 3600
                             }
                           },
                           "required": [
@@ -36032,6 +36149,49 @@
                             "pattern",
                             "reason",
                             "skipOffered"
+                          ],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "protocol": {
+                              "type": "number",
+                              "enum": [
+                                1
+                              ]
+                            },
+                            "type": {
+                              "type": "string",
+                              "enum": [
+                                "permission_answered"
+                              ]
+                            },
+                            "callId": {
+                              "type": "string"
+                            },
+                            "decision": {
+                              "type": "string",
+                              "enum": [
+                                "allow_once",
+                                "allow_pattern",
+                                "deny"
+                              ]
+                            },
+                            "patterns": {
+                              "type": "array",
+                              "items": {
+                                "type": "string",
+                                "maxLength": 500
+                              },
+                              "maxItems": 50
+                            }
+                          },
+                          "required": [
+                            "protocol",
+                            "type",
+                            "callId",
+                            "decision"
                           ],
                           "additionalProperties": false
                         },

--- a/mcp/typescript/src/__tests__/agent-tools.unit.test.ts
+++ b/mcp/typescript/src/__tests__/agent-tools.unit.test.ts
@@ -80,6 +80,21 @@ describe("handleListAgents()", () => {
       expect(http).not.toContain("Status");
     });
   });
+
+  describe("when a listed agent belongs to another person", () => {
+    /** @scenario "A listed agent the key cannot choose says so" */
+    it("lists it with its owner and says only its owner can run it", async () => {
+      mockRequest.mockResolvedValueOnce({
+        data: [connectedAgent({ selectable: false, notSelectableReason: "owned_by_another_person" })],
+        pagination: { page: 1, limit: 100, total: 1, totalPages: 1 },
+      });
+
+      const output = await handleListAgents();
+
+      expect(output).toContain("**Owner**: Ada");
+      expect(output).toContain("**Run**: only its owner can run this agent");
+    });
+  });
 });
 
 describe("handleGetAgent()", () => {

--- a/mcp/typescript/src/langwatch-api-agents.ts
+++ b/mcp/typescript/src/langwatch-api-agents.ts
@@ -52,6 +52,10 @@ export interface AgentSummary {
   lastSeenAt?: string | null;
   owner?: { userId: string; name: string } | null;
   hostLabel?: string | null;
+  /** Whether this key can run the agent. */
+  selectable?: boolean;
+  /** Why the agent cannot be run with this key; null when it can. */
+  notSelectableReason?: "owned_by_another_person" | null;
   parameters?: AgentParameterSpec[];
 }
 

--- a/mcp/typescript/src/tools/get-agent.ts
+++ b/mcp/typescript/src/tools/get-agent.ts
@@ -32,6 +32,9 @@ export async function handleGetAgent({ id }: { id: string }): Promise<string> {
   if (agent.status) lines.push(`**Status**: ${agent.status}`);
   if (agent.owner?.name) lines.push(`**Owner**: ${agent.owner.name}`);
   else if (agent.hostLabel) lines.push(`**Host**: ${agent.hostLabel}`);
+  if (agent.selectable === false) {
+    lines.push("**Run**: only its owner can run this agent");
+  }
   if (agent.lastSeenAt) lines.push(`**Last seen**: ${agent.lastSeenAt}`);
   lines.push(`**Created**: ${agent.createdAt}`);
   lines.push(`**Updated**: ${agent.updatedAt}`);

--- a/mcp/typescript/src/tools/list-agents.ts
+++ b/mcp/typescript/src/tools/list-agents.ts
@@ -29,6 +29,9 @@ export async function handleListAgents(): Promise<string> {
     if (a.instances) lines.push(`**Instances**: ${a.instances.length}`);
     const owner = agentOwnerLabel(a);
     if (owner) lines.push(`**Owner**: ${owner}`);
+    if (a.selectable === false) {
+      lines.push("**Run**: only its owner can run this agent");
+    }
     lines.push(`**Updated**: ${a.updatedAt}`);
     lines.push("");
   }

--- a/platform/app/src/app/api/agents/[[...route]]/agents.v1.ts
+++ b/platform/app/src/app/api/agents/[[...route]]/agents.v1.ts
@@ -9,6 +9,7 @@
 
 import type { BaseApp, VersionBuilder } from "@langwatch/api";
 import type { AuthzPermission } from "@langwatch/authz";
+import type { Context } from "hono";
 import { nanoid } from "nanoid";
 import { z } from "zod";
 import type { Project } from "~/generated/prisma/client";
@@ -27,6 +28,7 @@ import {
   agentPresenceView,
   readAgentPresence,
 } from "~/server/connected-agents/presence.read";
+import { CONNECTED_AGENT_NOT_SELECTABLE_REASONS } from "~/server/connected-agents/selectable";
 import { scenarioParameterDefinitionSchema } from "~/server/scenarios/parameters";
 import { runActorOf } from "../../shared/run-actor";
 import { agentPlatformUrl } from "../agent-platform-url";
@@ -147,6 +149,17 @@ export const agentResponseSchema = z.object({
     .describe(
       "The processes currently connected for a connected agent: hostname, user, pid, SDK and how many calls each has in flight. Empty for every other kind.",
     ),
+  selectable: z
+    .boolean()
+    .describe(
+      "Whether the credential making this request can run simulations against the agent. False for a personal development agent that belongs to somebody else, which is listed all the same so it can be told apart from the other agents of the same name.",
+    ),
+  notSelectableReason: z
+    .enum(CONNECTED_AGENT_NOT_SELECTABLE_REASONS)
+    .nullable()
+    .describe(
+      "Why the agent cannot be run by this credential. Null when it can.",
+    ),
   createdAt: z.date(),
   updatedAt: z.date(),
   platformUrl: z.string().url(),
@@ -183,13 +196,25 @@ type AgentWire = z.infer<typeof agentResponseSchema>;
 
 type ReadableAgent = Parameters<typeof toAgentListRow>[0];
 
+/**
+ * The person the request's key belongs to, or nothing for a project or
+ * service key. It decides only what each row says about itself: a personal
+ * agent of somebody else is listed either way, marked as not selectable.
+ */
+function viewerUserIdOf(c: Context): string | null {
+  return c.get("apiKeyUserId") ?? null;
+}
+
 /** The rows as every read answers them: presence, owner and link added. */
 async function rowsWire({
   app,
   rows,
+  viewerUserId,
 }: {
   app: AgentsApp;
   rows: AgentListRow[];
+  /** The person the key belongs to; nothing for a project or service key. */
+  viewerUserId: string | null;
 }): Promise<AgentWire[]> {
   const [owners, presence] = await Promise.all([
     app.agents.ownersOf(rows),
@@ -198,7 +223,7 @@ async function rowsWire({
   return rows.map((row) => ({
     ...row,
     type: agentTypeSchema.parse(row.type),
-    ...agentPresenceView({ agent: row, owners, presence }),
+    ...agentPresenceView({ agent: row, owners, presence, viewerUserId }),
     platformUrl: agentPlatformUrl({
       projectSlug: app.project.slug,
       agentId: row.id,
@@ -210,11 +235,17 @@ async function rowsWire({
 async function agentWire({
   app,
   agent,
+  viewerUserId,
 }: {
   app: AgentsApp;
   agent: ReadableAgent;
+  viewerUserId: string | null;
 }): Promise<AgentWire> {
-  const [wire] = await rowsWire({ app, rows: [toAgentListRow(agent)] });
+  const [wire] = await rowsWire({
+    app,
+    rows: [toAgentListRow(agent)],
+    viewerUserId,
+  });
   return wire!;
 }
 
@@ -262,7 +293,7 @@ function registerCollectionEndpoints({ v, guard, docs }: RegisterAgents): void {
       docs: docsOf({ docs, operationId: "listAgents" }),
     },
     async (
-      _c,
+      c,
       {
         query,
         app,
@@ -278,7 +309,11 @@ function registerCollectionEndpoints({ v, guard, docs }: RegisterAgents): void {
       });
       return {
         pagination: result.pagination,
-        data: await rowsWire({ app, rows: result.data }),
+        data: await rowsWire({
+          app,
+          rows: result.data,
+          viewerUserId: viewerUserIdOf(c),
+        }),
       };
     },
   );
@@ -295,7 +330,7 @@ function registerCollectionEndpoints({ v, guard, docs }: RegisterAgents): void {
       docs: docsOf({ docs, operationId: "createAgent" }),
     },
     async (
-      _c,
+      c,
       {
         input,
         app,
@@ -313,7 +348,7 @@ function registerCollectionEndpoints({ v, guard, docs }: RegisterAgents): void {
         config: input.config as AgentComponentConfig,
         workflowId: input.workflowId,
       });
-      return agentWire({ app, agent });
+      return agentWire({ app, agent, viewerUserId: viewerUserIdOf(c) });
     },
   );
 }
@@ -329,12 +364,12 @@ function registerItemEndpoints({ v, guard, docs }: RegisterAgents): void {
         "Read one agent with its presence, its owner and the run parameters it declares. An id the project does not hold answers 404 agent_not_found.",
       docs: docsOf({ docs, operationId: "getAgent" }),
     },
-    async (_c, { params, app }: { params: { id: string }; app: AgentsApp }) => {
+    async (c, { params, app }: { params: { id: string }; app: AgentsApp }) => {
       const agent = await app.agents.getByIdOrThrow({
         id: params.id,
         projectId: app.project.id,
       });
-      return agentWire({ app, agent });
+      return agentWire({ app, agent, viewerUserId: viewerUserIdOf(c) });
     },
   );
 
@@ -356,7 +391,7 @@ function registerItemEndpoints({ v, guard, docs }: RegisterAgents): void {
         }),
       },
       async (
-        _c,
+        c,
         {
           params,
           input,
@@ -381,7 +416,7 @@ function registerItemEndpoints({ v, guard, docs }: RegisterAgents): void {
             }),
           },
         });
-        return agentWire({ app, agent });
+        return agentWire({ app, agent, viewerUserId: viewerUserIdOf(c) });
       },
     );
   }

--- a/platform/app/src/app/api/agents/__tests__/connected-agents-rest.integration.test.ts
+++ b/platform/app/src/app/api/agents/__tests__/connected-agents-rest.integration.test.ts
@@ -76,6 +76,67 @@ describe("Feature: connected agents on the REST agents API", () => {
     });
   }
 
+  describe("when one name and one environment hold a personal row and a host-scoped row", () => {
+    /** @scenario "A listed connected agent carries its owner and whether the caller can choose it" */
+    it("lists both rows, and marks the personal one as not selectable", async () => {
+      const owner = await prisma.user.create({
+        data: { name: "Ana", email: `owner-${nanoid(8)}@example.com` },
+      });
+      const name = `two-owners-${nanoid(6)}`;
+      const personal = await prisma.agent.create({
+        data: {
+          id: `agent_${nanoid()}`,
+          projectId: project.id,
+          name,
+          type: "connected",
+          config: connectedConfig,
+          environment: "development",
+          ownerUserId: owner.id,
+          identityKey: `${name}@development/user:${owner.id}`,
+          lastSeenAt: new Date(),
+        },
+      });
+      const hosted = await prisma.agent.create({
+        data: {
+          id: `agent_${nanoid()}`,
+          projectId: project.id,
+          name,
+          type: "connected",
+          config: connectedConfig,
+          environment: "development",
+          hostLabel: "acme-laptop",
+          identityKey: `${name}@development/host:acme-laptop`,
+          lastSeenAt: new Date(),
+        },
+      });
+
+      const response = await app.request("/api/v1/agents?limit=100", {
+        headers: headers(),
+      });
+
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as {
+        data: {
+          id: string;
+          owner: { name: string | null } | null;
+          selectable: boolean;
+          notSelectableReason: string | null;
+        }[];
+      };
+      const personalWire = body.data.find((row) => row.id === personal.id);
+      const hostedWire = body.data.find((row) => row.id === hosted.id);
+
+      expect(personalWire?.owner?.name).toBe("Ana");
+      expect(personalWire?.selectable).toBe(false);
+      expect(personalWire?.notSelectableReason).toBe("owned_by_another_person");
+      expect(hostedWire?.owner).toBeNull();
+      expect(hostedWire?.selectable).toBe(true);
+      expect(hostedWire?.notSelectableReason).toBeNull();
+
+      await prisma.user.delete({ where: { id: owner.id } }).catch(() => {});
+    });
+  });
+
   describe("when a caller creates a connected agent by hand", () => {
     /** @scenario "A connected agent cannot be created by hand" */
     it("refuses with agent_register_only", async () => {

--- a/platform/app/src/app/api/openapiLangWatch.json
+++ b/platform/app/src/app/api/openapiLangWatch.json
@@ -2590,8 +2590,7 @@
                       },
                       "maxConcurrency": {
                         "type": "integer",
-                        "exclusiveMinimum": true,
-                        "minimum": 0,
+                        "exclusiveMinimum": 0,
                         "maximum": 1000
                       }
                     },
@@ -2626,14 +2625,12 @@
                         },
                         "concurrency": {
                           "type": "integer",
-                          "exclusiveMinimum": true,
-                          "minimum": 0,
+                          "exclusiveMinimum": 0,
                           "maximum": 1000
                         },
                         "timeoutMs": {
                           "type": "integer",
-                          "exclusiveMinimum": true,
-                          "minimum": 0
+                          "exclusiveMinimum": 0
                         },
                         "sticky": {
                           "type": "boolean"
@@ -18430,13 +18427,11 @@
                 "properties": {
                   "startDate": {
                     "type": "number",
-                    "exclusiveMinimum": true,
-                    "minimum": 0
+                    "exclusiveMinimum": 0
                   },
                   "endDate": {
                     "type": "number",
-                    "exclusiveMinimum": true,
-                    "minimum": 0
+                    "exclusiveMinimum": 0
                   },
                   "query": {
                     "type": "string"
@@ -36022,8 +36017,7 @@
                                 },
                                 "pid": {
                                   "type": "integer",
-                                  "exclusiveMinimum": true,
-                                  "minimum": 0
+                                  "exclusiveMinimum": 0
                                 },
                                 "durationMs": {
                                   "type": "integer",
@@ -36136,8 +36130,7 @@
                             },
                             "timeoutSeconds": {
                               "type": "integer",
-                              "exclusiveMinimum": true,
-                              "minimum": 0,
+                              "exclusiveMinimum": 0,
                               "maximum": 3600
                             }
                           },

--- a/platform/app/src/app/api/openapiLangWatch.json
+++ b/platform/app/src/app/api/openapiLangWatch.json
@@ -3279,6 +3279,21 @@
                             },
                             "description": "The processes currently connected for a connected agent: hostname, user, pid, SDK and how many calls each has in flight. Empty for every other kind."
                           },
+                          "selectable": {
+                            "type": "boolean",
+                            "description": "Whether the credential making this request can run simulations against the agent. False for a personal development agent that belongs to somebody else, which is listed all the same so it can be told apart from the other agents of the same name."
+                          },
+                          "notSelectableReason": {
+                            "type": [
+                              "string",
+                              "null"
+                            ],
+                            "enum": [
+                              "owned_by_another_person",
+                              null
+                            ],
+                            "description": "Why the agent cannot be run by this credential. Null when it can."
+                          },
                           "createdAt": {
                             "type": "string"
                           },
@@ -3303,6 +3318,8 @@
                           "owner",
                           "status",
                           "instances",
+                          "selectable",
+                          "notSelectableReason",
                           "createdAt",
                           "updatedAt",
                           "platformUrl"
@@ -3599,6 +3616,21 @@
                       },
                       "description": "The processes currently connected for a connected agent: hostname, user, pid, SDK and how many calls each has in flight. Empty for every other kind."
                     },
+                    "selectable": {
+                      "type": "boolean",
+                      "description": "Whether the credential making this request can run simulations against the agent. False for a personal development agent that belongs to somebody else, which is listed all the same so it can be told apart from the other agents of the same name."
+                    },
+                    "notSelectableReason": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "enum": [
+                        "owned_by_another_person",
+                        null
+                      ],
+                      "description": "Why the agent cannot be run by this credential. Null when it can."
+                    },
                     "createdAt": {
                       "type": "string"
                     },
@@ -3623,6 +3655,8 @@
                     "owner",
                     "status",
                     "instances",
+                    "selectable",
+                    "notSelectableReason",
                     "createdAt",
                     "updatedAt",
                     "platformUrl"
@@ -3910,6 +3944,21 @@
                       },
                       "description": "The processes currently connected for a connected agent: hostname, user, pid, SDK and how many calls each has in flight. Empty for every other kind."
                     },
+                    "selectable": {
+                      "type": "boolean",
+                      "description": "Whether the credential making this request can run simulations against the agent. False for a personal development agent that belongs to somebody else, which is listed all the same so it can be told apart from the other agents of the same name."
+                    },
+                    "notSelectableReason": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "enum": [
+                        "owned_by_another_person",
+                        null
+                      ],
+                      "description": "Why the agent cannot be run by this credential. Null when it can."
+                    },
                     "createdAt": {
                       "type": "string"
                     },
@@ -3934,6 +3983,8 @@
                     "owner",
                     "status",
                     "instances",
+                    "selectable",
+                    "notSelectableReason",
                     "createdAt",
                     "updatedAt",
                     "platformUrl"
@@ -4191,6 +4242,21 @@
                       },
                       "description": "The processes currently connected for a connected agent: hostname, user, pid, SDK and how many calls each has in flight. Empty for every other kind."
                     },
+                    "selectable": {
+                      "type": "boolean",
+                      "description": "Whether the credential making this request can run simulations against the agent. False for a personal development agent that belongs to somebody else, which is listed all the same so it can be told apart from the other agents of the same name."
+                    },
+                    "notSelectableReason": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "enum": [
+                        "owned_by_another_person",
+                        null
+                      ],
+                      "description": "Why the agent cannot be run by this credential. Null when it can."
+                    },
                     "createdAt": {
                       "type": "string"
                     },
@@ -4215,6 +4281,8 @@
                     "owner",
                     "status",
                     "instances",
+                    "selectable",
+                    "notSelectableReason",
                     "createdAt",
                     "updatedAt",
                     "platformUrl"
@@ -4510,6 +4578,21 @@
                       },
                       "description": "The processes currently connected for a connected agent: hostname, user, pid, SDK and how many calls each has in flight. Empty for every other kind."
                     },
+                    "selectable": {
+                      "type": "boolean",
+                      "description": "Whether the credential making this request can run simulations against the agent. False for a personal development agent that belongs to somebody else, which is listed all the same so it can be told apart from the other agents of the same name."
+                    },
+                    "notSelectableReason": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "enum": [
+                        "owned_by_another_person",
+                        null
+                      ],
+                      "description": "Why the agent cannot be run by this credential. Null when it can."
+                    },
                     "createdAt": {
                       "type": "string"
                     },
@@ -4534,6 +4617,8 @@
                     "owner",
                     "status",
                     "instances",
+                    "selectable",
+                    "notSelectableReason",
                     "createdAt",
                     "updatedAt",
                     "platformUrl"
@@ -36022,6 +36107,38 @@
                             },
                             "skipOffered": {
                               "type": "boolean"
+                            },
+                            "segments": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "command": {
+                                    "type": "string",
+                                    "maxLength": 4000
+                                  },
+                                  "pattern": {
+                                    "type": "string",
+                                    "maxLength": 500
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "command",
+                                  "pattern",
+                                  "readOnly"
+                                ],
+                                "additionalProperties": false
+                              },
+                              "maxItems": 50
+                            },
+                            "timeoutSeconds": {
+                              "type": "integer",
+                              "exclusiveMinimum": true,
+                              "minimum": 0,
+                              "maximum": 3600
                             }
                           },
                           "required": [
@@ -36032,6 +36149,49 @@
                             "pattern",
                             "reason",
                             "skipOffered"
+                          ],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "protocol": {
+                              "type": "number",
+                              "enum": [
+                                1
+                              ]
+                            },
+                            "type": {
+                              "type": "string",
+                              "enum": [
+                                "permission_answered"
+                              ]
+                            },
+                            "callId": {
+                              "type": "string"
+                            },
+                            "decision": {
+                              "type": "string",
+                              "enum": [
+                                "allow_once",
+                                "allow_pattern",
+                                "deny"
+                              ]
+                            },
+                            "patterns": {
+                              "type": "array",
+                              "items": {
+                                "type": "string",
+                                "maxLength": 500
+                              },
+                              "maxItems": 50
+                            }
+                          },
+                          "required": [
+                            "protocol",
+                            "type",
+                            "callId",
+                            "decision"
                           ],
                           "additionalProperties": false
                         },

--- a/platform/app/src/components/agents/connected/ConnectedAgentsSection.tsx
+++ b/platform/app/src/components/agents/connected/ConnectedAgentsSection.tsx
@@ -144,6 +144,10 @@ function ScopeChip({ agent }: { agent: ConnectedAgentView }) {
         flexShrink={0}
         maxWidth="50%"
         data-testid="connected-agent-scope-chip"
+        // The chip is the only place a card says why it cannot be run, so on
+        // the cards that carry that reason it takes the tab order too: the
+        // tooltip opens on focus, not on hover alone.
+        tabIndex={agent.selectable ? undefined : 0}
         aria-label={
           agent.selectable ? undefined : ownerOnlyCopy(agent.owner?.name)
         }

--- a/platform/app/src/components/agents/connected/ConnectedAgentsSection.tsx
+++ b/platform/app/src/components/agents/connected/ConnectedAgentsSection.tsx
@@ -14,6 +14,7 @@
 import { Box, HStack, Text } from "@chakra-ui/react";
 import { Bot, ExternalLink, Laptop, Play, User } from "lucide-react";
 import { LuTrash2 } from "react-icons/lu";
+import { ownerOnlyCopy } from "~/components/scenarios/useFilteredScenarioTargets";
 import { Menu } from "~/components/ui/menu";
 import { Tooltip } from "~/components/ui/tooltip";
 import {
@@ -117,27 +118,42 @@ function EnvironmentLabel({ environment }: { environment: string }) {
   );
 }
 
-/** The chip that names the person or the machine a card belongs to. */
+/**
+ * The chip that names the person or the machine a card belongs to.
+ *
+ * Two cards of one name and one environment are told apart by this chip
+ * alone, so a card the reader cannot run carries it too and says why on
+ * hover, in the words the refused run itself uses.
+ */
 function ScopeChip({ agent }: { agent: ConnectedAgentView }) {
   const scope = scopeOf(agent);
   if (!scope) return null;
   return (
-    <HStack
-      gap={1}
-      display="inline-flex"
-      paddingX={1.5}
-      paddingY={0.5}
-      borderRadius="full"
-      background="bg.muted"
-      minWidth={0}
-      flexShrink={0}
-      maxWidth="50%"
+    <Tooltip
+      content={ownerOnlyCopy(agent.owner?.name)}
+      disabled={agent.selectable}
     >
-      {scope.kind === "owner" ? <User size={10} /> : <Laptop size={10} />}
-      <Text fontSize="11px" truncate>
-        {scope.label}
-      </Text>
-    </HStack>
+      <HStack
+        gap={1}
+        display="inline-flex"
+        paddingX={1.5}
+        paddingY={0.5}
+        borderRadius="full"
+        background="bg.muted"
+        minWidth={0}
+        flexShrink={0}
+        maxWidth="50%"
+        data-testid="connected-agent-scope-chip"
+        aria-label={
+          agent.selectable ? undefined : ownerOnlyCopy(agent.owner?.name)
+        }
+      >
+        {scope.kind === "owner" ? <User size={10} /> : <Laptop size={10} />}
+        <Text fontSize="11px" truncate>
+          {scope.label}
+        </Text>
+      </HStack>
+    </Tooltip>
   );
 }
 

--- a/platform/app/src/components/agents/connected/__tests__/ConnectedAgentsSection.integration.test.tsx
+++ b/platform/app/src/components/agents/connected/__tests__/ConnectedAgentsSection.integration.test.tsx
@@ -198,6 +198,7 @@ describe("<ConnectedAgentsSection />", () => {
       const chip = screen.getByTestId("connected-agent-scope-chip");
       expect(within(chip).getByText("Ana")).toBeInTheDocument();
       expect(chip.getAttribute("aria-label")).toContain("Ana");
+      expect(chip.getAttribute("tabindex")).toBe("0");
     });
   });
 
@@ -214,6 +215,7 @@ describe("<ConnectedAgentsSection />", () => {
       const chip = screen.getByTestId("connected-agent-scope-chip");
       expect(within(chip).getByText("Ana")).toBeInTheDocument();
       expect(chip.getAttribute("aria-label")).toBeNull();
+      expect(chip.getAttribute("tabindex")).toBeNull();
     });
   });
 

--- a/platform/app/src/components/agents/connected/__tests__/ConnectedAgentsSection.integration.test.tsx
+++ b/platform/app/src/components/agents/connected/__tests__/ConnectedAgentsSection.integration.test.tsx
@@ -50,6 +50,8 @@ function agent(
     status: "online",
     instances: [instance()],
     owner: null,
+    selectable: true,
+    notSelectableReason: null,
     parameters: [],
     config: {
       sdk: { name: "langwatch-python", version: "1.2.3", language: "python" },
@@ -178,6 +180,40 @@ describe("<ConnectedAgentsSection />", () => {
       ]);
 
       expect(screen.getByText("Ana")).toBeInTheDocument();
+    });
+  });
+
+  describe("given a development agent that belongs to another person", () => {
+    /** @scenario "A card the reader cannot choose says who holds it" */
+    it("carries the owner's name and says only that person can run it", () => {
+      renderSection([
+        agent({
+          environment: "development",
+          owner: { userId: "user_1", name: "Ana" },
+          selectable: false,
+          notSelectableReason: "owned_by_another_person",
+        }),
+      ]);
+
+      const chip = screen.getByTestId("connected-agent-scope-chip");
+      expect(within(chip).getByText("Ana")).toBeInTheDocument();
+      expect(chip.getAttribute("aria-label")).toContain("Ana");
+    });
+  });
+
+  describe("given a development agent that belongs to the reader", () => {
+    /** @scenario "A card the reader can choose carries no refusal" */
+    it("carries the owner's name and no refusal", () => {
+      renderSection([
+        agent({
+          environment: "development",
+          owner: { userId: "user_1", name: "Ana" },
+        }),
+      ]);
+
+      const chip = screen.getByTestId("connected-agent-scope-chip");
+      expect(within(chip).getByText("Ana")).toBeInTheDocument();
+      expect(chip.getAttribute("aria-label")).toBeNull();
     });
   });
 

--- a/platform/app/src/components/agents/connected/__tests__/connected-agent-rows.unit.test.ts
+++ b/platform/app/src/components/agents/connected/__tests__/connected-agent-rows.unit.test.ts
@@ -25,6 +25,8 @@ function agent(
     status: "online",
     instances: [],
     owner: null,
+    selectable: true,
+    notSelectableReason: null,
     parameters: [],
     config: {},
     ...overrides,

--- a/platform/app/src/components/agents/connected/connected-agent-rows.ts
+++ b/platform/app/src/components/agents/connected/connected-agent-rows.ts
@@ -13,6 +13,7 @@
  */
 
 import { formatDistanceStrict } from "date-fns";
+import type { ConnectedAgentNotSelectableReason } from "~/server/connected-agents/selectable";
 import type { ScenarioParameterDefinition } from "~/server/scenarios/parameters";
 
 /** The SDK that registered an agent, as the card prints it. */
@@ -45,6 +46,9 @@ export interface ConnectedAgentView {
   status: "online" | "offline";
   instances: ConnectedAgentInstance[];
   owner: { userId: string; name: string | null } | null;
+  /** Whether the reader can run this agent; false for another person's. */
+  selectable: boolean;
+  notSelectableReason: ConnectedAgentNotSelectableReason | null;
   parameters: ScenarioParameterDefinition[];
   config: { description?: string; sdk?: ConnectedAgentSdk } & Record<
     string,
@@ -131,6 +135,10 @@ export function instanceCountLabel(agent: ConnectedAgentView): string | null {
  * A development agent registered with a personal key belongs to that person,
  * and one registered with a project key belongs to the machine it runs on.
  * A shared environment belongs to the project and carries no chip.
+ *
+ * Two cards of one name and one environment differ only here, which is why
+ * the chip is drawn on every card that has an owner or a machine and not
+ * only on the ones the reader can run.
  */
 export function scopeOf(agent: ConnectedAgentView): ConnectedAgentScope {
   if (agent.owner) return { kind: "owner", label: agent.owner.name ?? "Owner" };

--- a/platform/app/src/components/scenarios/useFilteredScenarioTargets.ts
+++ b/platform/app/src/components/scenarios/useFilteredScenarioTargets.ts
@@ -11,6 +11,7 @@
 
 import { useMemo } from "react";
 import { explainHandledError } from "~/features/errors";
+import { connectedAgentSelectability } from "~/server/connected-agents/selectable";
 import { targetLabelOf } from "~/server/suites/target-key";
 import type { TargetValue } from "./TargetSelector";
 
@@ -60,7 +61,12 @@ export function agentTargetLabel(agent: AgentLike): string {
   });
 }
 
-/** True when this agent is a personal development agent of another person. */
+/**
+ * True when this agent is a personal development agent of another person.
+ *
+ * The same rule the listings mark their rows with and the run refuses on, so
+ * the picker never offers a target the run would refuse.
+ */
 export function isTeammateOwned({
   agent,
   viewerUserId,
@@ -68,9 +74,10 @@ export function isTeammateOwned({
   agent: AgentLike;
   viewerUserId?: string | null;
 }): boolean {
-  const ownerId = agent.owner?.userId;
-  if (!ownerId) return false;
-  return ownerId !== viewerUserId;
+  return !connectedAgentSelectability({
+    ownerUserId: agent.owner?.userId ?? null,
+    viewerUserId,
+  }).selectable;
 }
 
 /** The agents of the project as targets, newest first, filtered by the search. */

--- a/platform/app/src/features/errors/logic/codes.ts
+++ b/platform/app/src/features/errors/logic/codes.ts
@@ -48,6 +48,7 @@ export const APP_ERROR_CODES = [
   "api_key_permission_not_delegable",
   "api_key_reserved_name",
   "api_key_scope_violation",
+  "authz_grant_not_confirmed",
   "authz_ledger_unavailable",
   "avatar_image_processing_failed",
   "avatar_image_too_large",

--- a/platform/app/src/features/errors/logic/presentation.ts
+++ b/platform/app/src/features/errors/logic/presentation.ts
@@ -1568,6 +1568,11 @@ const presentations = {
     describe: () =>
       "It may have been removed already. Reload to see the current bindings.",
   },
+  authz_grant_not_confirmed: {
+    title: "Access could not be confirmed",
+    describe: () =>
+      "We could not confirm the access change in time, so nothing was granted. Try again in a moment.",
+  },
   authz_ledger_unavailable: {
     title: "Access changes are paused",
     describe: () =>

--- a/platform/app/src/server/agents/__tests__/connected-agent.service.integration.test.ts
+++ b/platform/app/src/server/agents/__tests__/connected-agent.service.integration.test.ts
@@ -347,4 +347,48 @@ describe("connected agent rows", () => {
       ).rejects.toMatchObject({ code: "agent_register_only" });
     });
   });
+  describe("when one name and one environment hold a personal row and a host-scoped row", () => {
+    /** @scenario "A listing carries every row of a name, whoever holds it" */
+    it("lists both rows, whoever the caller is", async () => {
+      const user = await getTestUser();
+      const name = `two-owners-${nanoid(6)}`;
+      const personal = await service.registerConnected({
+        id: `agent_${nanoid()}`,
+        projectId,
+        name,
+        config,
+        identity: {
+          environment: "development",
+          ownerUserId: user.id,
+          hostLabel: null,
+          identityKey: `${name}@development/user:${user.id}`,
+        },
+      });
+      const hosted = await service.registerConnected({
+        id: `agent_${nanoid()}`,
+        projectId,
+        name,
+        config,
+        identity: {
+          environment: "development",
+          ownerUserId: null,
+          hostLabel: "acme-laptop",
+          identityKey: `${name}@development/host:acme-laptop`,
+        },
+      });
+
+      const listed = await service.listAgents({
+        projectId,
+        page: 1,
+        limit: 100,
+      });
+      const ids = listed.data
+        .filter((row) => row.name === name)
+        .map((row) => row.id);
+
+      expect(ids).toHaveLength(2);
+      expect(ids).toContain(personal.id);
+      expect(ids).toContain(hosted.id);
+    });
+  });
 });

--- a/platform/app/src/server/api-key/__tests__/api-key.grant-confirmation.integration.test.ts
+++ b/platform/app/src/server/api-key/__tests__/api-key.grant-confirmation.integration.test.ts
@@ -1,0 +1,208 @@
+/**
+ * A key is handed out only once its grants are readable.
+ *
+ * Against a real database on purpose. The failure this pins was not a thrown
+ * error anywhere: the ledger append was durable, the projection had not landed
+ * the rows, the bounded wait timed out and said so only in a log line, and the
+ * mint went on to activate the key. The proof therefore has to be the stored
+ * row, which a mocked repository cannot give.
+ *
+ * The fold is not running here, so a command that is "sent" and never applied
+ * is exactly the degraded stack: the rows never appear. The other half of the
+ * test writes the rows from the sender, which is what a healthy fold does.
+ *
+ * @see specs/api-keys/unified-api-keys.feature
+ */
+
+import { HandledError } from "@langwatch/handled-error";
+import { generate } from "@langwatch/ksuid";
+import { nanoid } from "nanoid";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  OrganizationUserRole,
+  type PrismaClient,
+  RoleBindingScopeType,
+  TeamUserRole,
+} from "~/generated/prisma/client";
+import {
+  type AuthzGrantsCommandSenders,
+  GrantsLedgerWriter,
+} from "~/server/app-layer/authz/ledger";
+import { prisma } from "~/server/db";
+import { RoleRepository } from "~/server/role/repositories/role.repository";
+import { cleanupTestRows } from "~/test-utils/cleanupTestRows";
+import { KSUID_RESOURCES } from "~/utils/constants";
+import { ApiKeyRepository } from "../api-key.repository";
+import { ApiKeyService } from "../api-key.service";
+
+/** The commands of a stack whose fold never applies them. */
+function sendersThatNeverLand(): AuthzGrantsCommandSenders {
+  const noop = { send: async () => undefined };
+  return {
+    attachGrant: noop,
+    changeGrantRole: noop,
+    revokeGrant: noop,
+    defineRole: noop,
+    changeRolePermissions: noop,
+    deleteRole: noop,
+  } as unknown as AuthzGrantsCommandSenders;
+}
+
+/** The commands of a healthy stack: the fold writes the row the caller polls for. */
+function sendersThatLand({
+  organizationId,
+}: {
+  organizationId: string;
+}): AuthzGrantsCommandSenders {
+  const noop = { send: async () => undefined };
+  return {
+    ...sendersThatNeverLand(),
+    attachGrant: {
+      send: async (data: {
+        grant: {
+          grantId: string;
+          principal: { type: string; id: string };
+          scope: { type: string; id: string };
+        };
+      }) => {
+        await prisma.roleBinding.create({
+          data: {
+            id: data.grant.grantId,
+            organizationId,
+            apiKeyId: data.grant.principal.id,
+            role: TeamUserRole.ADMIN,
+            scopeType: data.grant.scope.type as RoleBindingScopeType,
+            scopeId: data.grant.scope.id,
+          },
+        });
+      },
+    },
+    revokeGrant: noop,
+  } as unknown as AuthzGrantsCommandSenders;
+}
+
+describe("Feature: a key is activated only once its grants are readable", () => {
+  const ns = `apikey-grants-${nanoid(8)}`;
+
+  let organizationId: string;
+  let userId: string;
+
+  /** The service over a writer whose projection either lands or does not. */
+  const serviceWith = (commands: AuthzGrantsCommandSenders) => {
+    const writer = new GrantsLedgerWriter(prisma as unknown as PrismaClient, {
+      onLedgerWrites: async () => true,
+      // Short on purpose: the point is the window closing, not how long a
+      // real one is.
+      poll: { intervalMs: 10, timeoutMs: 150 },
+      commands: async () => ({ commands }),
+    });
+    return new ApiKeyService({
+      prisma,
+      repo: new ApiKeyRepository(prisma, writer),
+      roleRepo: new RoleRepository(prisma),
+    });
+  };
+
+  const mint = (service: ApiKeyService) =>
+    service.create({
+      name: `grants-${nanoid(6)}`,
+      userId: null,
+      createdByUserId: userId,
+      organizationId,
+      permissionMode: "all",
+      bindings: [
+        {
+          role: TeamUserRole.ADMIN,
+          scopeType: RoleBindingScopeType.ORGANIZATION,
+          scopeId: organizationId,
+        },
+      ],
+    });
+
+  beforeAll(async () => {
+    const organization = await prisma.organization.create({
+      data: { name: "Grant Confirmation Org", slug: `--test-org-${ns}` },
+    });
+    organizationId = organization.id;
+
+    const user = await prisma.user.create({
+      data: {
+        name: "Grant Confirmation User",
+        email: `test-${ns}@example.com`,
+      },
+    });
+    userId = user.id;
+
+    await prisma.organizationUser.create({
+      data: { userId, organizationId, role: OrganizationUserRole.ADMIN },
+    });
+    await prisma.roleBinding.create({
+      data: {
+        id: generate(KSUID_RESOURCES.ROLE_BINDING).toString(),
+        organizationId,
+        userId,
+        role: TeamUserRole.ADMIN,
+        scopeType: RoleBindingScopeType.ORGANIZATION,
+        scopeId: organizationId,
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await cleanupTestRows(prisma, [
+      ["roleBinding", { organizationId }],
+      ["apiKey", { organizationId }],
+      ["organizationUser", { organizationId }],
+    ]);
+    await prisma.organization
+      .delete({ where: { id: organizationId } })
+      .catch(() => {});
+    await prisma.user.delete({ where: { id: userId } }).catch(() => {});
+  });
+
+  describe("given the grants land in the projection", () => {
+    /** @scenario "A key whose grants are readable is activated and returned" */
+    it("returns a token that authenticates", async () => {
+      const service = serviceWith(sendersThatLand({ organizationId }));
+
+      const { token, apiKey } = await mint(service);
+
+      expect(apiKey.revokedAt).toBeNull();
+      const verified = await service.verify({ token });
+      expect(verified?.id).toBe(apiKey.id);
+    });
+  });
+
+  describe("given the grants are durable but their projection has not landed", () => {
+    /** @scenario "A key whose grants did not become readable is never activated" */
+    it("refuses the mint and leaves no usable key behind", async () => {
+      const service = serviceWith(sendersThatNeverLand());
+      const before = await prisma.apiKey.count({
+        where: { organizationId, revokedAt: null },
+      });
+
+      const failure = await mint(service).then(
+        () => null,
+        (error: unknown) => error,
+      );
+
+      expect(HandledError.isHandled(failure)).toBe(true);
+      expect((failure as HandledError).code).toBe("authz_grant_not_confirmed");
+
+      // The row the failed mint left behind is revoked, so it authenticates
+      // nothing: the count of live keys did not move.
+      const after = await prisma.apiKey.count({
+        where: { organizationId, revokedAt: null },
+      });
+      expect(after).toBe(before);
+
+      const stranded = await prisma.apiKey.findFirst({
+        where: { organizationId, revokedAt: { not: null } },
+        orderBy: { createdAt: "desc" },
+        include: { roleBindings: true },
+      });
+      expect(stranded?.revokedAt).toBeInstanceOf(Date);
+      expect(stranded?.roleBindings).toHaveLength(0);
+    });
+  });
+});

--- a/platform/app/src/server/api-key/__tests__/api-key.service.crash-windows.unit.test.ts
+++ b/platform/app/src/server/api-key/__tests__/api-key.service.crash-windows.unit.test.ts
@@ -270,6 +270,29 @@ describe("ApiKeyService — the crash windows around a grant write", () => {
       expect((failure as HandledError).code).toBe("authz_grant_not_confirmed");
       expect(ledger.revokeBindingsWhere).not.toHaveBeenCalled();
     });
+
+    /** @scenario "Replacing a key's grants leaves its metadata alone when the new ones do not land" */
+    it("leaves the key's own row alone when a replace cannot confirm", async () => {
+      ledger.attachBindings.mockRejectedValueOnce(
+        new AuthzGrantNotConfirmedError(),
+      );
+
+      await service
+        .update({
+          id: "ak_existing",
+          callerUserId: USER_ID,
+          callerIsAdmin: true,
+          organizationId: ORG_ID,
+          permissionMode: "restricted",
+          permissions: ["langy:view"],
+          bindings: [
+            { role: "CUSTOM", scopeType: "ORGANIZATION", scopeId: ORG_ID },
+          ],
+        })
+        .catch(() => null);
+
+      expect(prisma.apiKey.update).not.toHaveBeenCalled();
+    });
   });
 
   describe("when the ledger refuses the new key's grants", () => {

--- a/platform/app/src/server/api-key/__tests__/api-key.service.crash-windows.unit.test.ts
+++ b/platform/app/src/server/api-key/__tests__/api-key.service.crash-windows.unit.test.ts
@@ -9,7 +9,9 @@
  * the grants the key already had — never a live credential holding nothing,
  * which is the shape the read-through mint used to read as "legacy".
  */
+import { HandledError } from "@langwatch/handled-error";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AuthzGrantNotConfirmedError } from "~/server/app-layer/authz/errors";
 import { ApiKeyService } from "../api-key.service";
 
 vi.mock("../api-key-token.utils", () => ({
@@ -167,6 +169,106 @@ describe("ApiKeyService — the crash windows around a grant write", () => {
       );
       expect(activationsOf(prisma)).toHaveLength(1);
       expect(apiKey.revokedAt).toBeNull();
+    });
+  });
+
+  describe("when the grants are written but not yet readable", () => {
+    /** @scenario "A key whose grants did not become readable is never activated" */
+    it("leaves the credential revoked and returns no token", async () => {
+      ledger.attachBindings.mockRejectedValueOnce(
+        new AuthzGrantNotConfirmedError(),
+      );
+
+      const failure = await service
+        .create({
+          name: "Automation Key",
+          userId: null,
+          organizationId: ORG_ID,
+          permissionMode: "all",
+          bindings: [
+            { role: "ADMIN", scopeType: "ORGANIZATION", scopeId: ORG_ID },
+          ],
+        })
+        .then(
+          () => null,
+          (error: unknown) => error,
+        );
+
+      expect(HandledError.isHandled(failure)).toBe(true);
+      expect((failure as HandledError).code).toBe("authz_grant_not_confirmed");
+      expect(
+        prisma.apiKey.create.mock.calls[0]![0].data.revokedAt,
+      ).toBeInstanceOf(Date);
+      expect(activationsOf(prisma)).toHaveLength(0);
+    });
+
+    /** @scenario "A key whose grants are readable is activated and returned" */
+    it("asks the ledger to confirm the grants before activating", async () => {
+      await service.create({
+        name: "Automation Key",
+        userId: null,
+        organizationId: ORG_ID,
+        permissionMode: "all",
+        bindings: [
+          { role: "ADMIN", scopeType: "ORGANIZATION", scopeId: ORG_ID },
+        ],
+      });
+
+      expect(ledger.attachBindings).toHaveBeenCalledWith(
+        expect.objectContaining({ requireProjection: true }),
+      );
+      expect(activationsOf(prisma)).toHaveLength(1);
+    });
+
+    /** @scenario "A key whose custom role did not become readable is never activated" */
+    it("leaves a restricted key revoked when its role does not become readable", async () => {
+      ledger.defineRole.mockRejectedValueOnce(
+        new AuthzGrantNotConfirmedError(),
+      );
+
+      const failure = await service
+        .create({
+          name: "Restricted Key",
+          userId: null,
+          organizationId: ORG_ID,
+          permissionMode: "restricted",
+          permissions: ["langy:view"],
+          bindings: [
+            { role: "CUSTOM", scopeType: "ORGANIZATION", scopeId: ORG_ID },
+          ],
+        })
+        .then(
+          () => null,
+          (error: unknown) => error,
+        );
+
+      expect((failure as HandledError).code).toBe("authz_grant_not_confirmed");
+      expect(activationsOf(prisma)).toHaveLength(0);
+    });
+
+    /** @scenario "Replacing a key's grants keeps the old ones when the new ones do not land" */
+    it("revokes nothing the key already held when a replace cannot confirm", async () => {
+      ledger.attachBindings.mockRejectedValueOnce(
+        new AuthzGrantNotConfirmedError(),
+      );
+
+      const failure = await service
+        .update({
+          id: "ak_existing",
+          callerUserId: USER_ID,
+          callerIsAdmin: true,
+          organizationId: ORG_ID,
+          bindings: [
+            { role: "MEMBER", scopeType: "ORGANIZATION", scopeId: ORG_ID },
+          ],
+        })
+        .then(
+          () => null,
+          (error: unknown) => error,
+        );
+
+      expect((failure as HandledError).code).toBe("authz_grant_not_confirmed");
+      expect(ledger.revokeBindingsWhere).not.toHaveBeenCalled();
     });
   });
 

--- a/platform/app/src/server/api-key/api-key.repository.ts
+++ b/platform/app/src/server/api-key/api-key.repository.ts
@@ -625,6 +625,12 @@ export class ApiKeyRepository {
    * The attach itself, with the outcome intact: which ids were written and
    * which identical rows were already there. `replaceRoleBindings` needs both
    * to know what its revoke must spare.
+   *
+   * `requireProjection` because both callers act on these rows next: a create
+   * activates the credential, and a replace revokes whatever the attach did
+   * not keep. An append that is durable but not yet readable is fine for a
+   * caller that only writes; here it would hand out a token the resolver
+   * refuses, or drop the grants the key already had.
    */
   private async attachRoleBindings({
     apiKeyId,
@@ -651,6 +657,7 @@ export class ApiKeyRepository {
       })),
       actor,
       onDuplicate: "skip",
+      requireProjection: true,
     });
   }
 }

--- a/platform/app/src/server/api-key/api-key.service.ts
+++ b/platform/app/src/server/api-key/api-key.service.ts
@@ -524,13 +524,12 @@ export class ApiKeyService {
       );
     }
 
-    await this.repo.update({
-      id,
-      name,
-      description,
-      permissionMode,
-    });
-
+    // The grants move first, the metadata after. `replaceRoleBindings` can
+    // refuse with AuthzGrantNotConfirmedError, and a metadata write that had
+    // already landed would leave the key describing permissions it does not
+    // hold — a key marked "restricted" while the old grants are still the
+    // live ones. Writing it last means a refused grant change leaves the key
+    // exactly as it was.
     if (effectiveBindings) {
       await this.repo.replaceRoleBindings({
         apiKeyId: id,
@@ -560,6 +559,13 @@ export class ApiKeyService {
         });
       }
     }
+
+    await this.repo.update({
+      id,
+      name,
+      description,
+      permissionMode,
+    });
 
     const updated = await this.repo.findById({ id });
     if (!updated) throw new ApiKeyNotFoundError(id);

--- a/platform/app/src/server/api-key/api-key.service.ts
+++ b/platform/app/src/server/api-key/api-key.service.ts
@@ -318,6 +318,11 @@ export class ApiKeyService {
     // is that a failed create leaves less-or-equal access, never a live token
     // with no grants (which is also the shape the read-through mint refuses
     // to widen, see ./legacy-grant-mint.ts).
+    //
+    // "Facts" means readable, not merely appended. The grant writes below
+    // require the projection, so a durable append that the fold has not
+    // landed yet throws AuthzGrantNotConfirmedError and the key is never
+    // activated: the row stays revoked and the token cannot authenticate.
     const apiKey = await this.repo.create({
       name,
       description,
@@ -343,6 +348,7 @@ export class ApiKeyService {
           kind: CUSTOM_ROLE_KIND.SYSTEM_API_KEY,
         },
         actor,
+        requireProjection: true,
       });
       effectiveBindings = effectiveBindings.map((b) =>
         b.role === TeamUserRole.CUSTOM
@@ -509,6 +515,7 @@ export class ApiKeyService {
           kind: CUSTOM_ROLE_KIND.SYSTEM_API_KEY,
         },
         actor,
+        requireProjection: true,
       });
       effectiveBindings = effectiveBindings.map((b) =>
         b.role === TeamUserRole.CUSTOM

--- a/platform/app/src/server/api/__tests__/openapi-exclusive-bounds.unit.test.ts
+++ b/platform/app/src/server/api/__tests__/openapi-exclusive-bounds.unit.test.ts
@@ -1,0 +1,113 @@
+/**
+ * The 3.1 spelling of an exclusive bound, and that the published document
+ * carries no 3.0 leftovers.
+ *
+ * @see specs/api-reference/exclusive-bounds-3-1.feature
+ */
+import { describe, expect, it } from "vitest";
+import spec from "../../../app/api/openapiLangWatch.json";
+import { normalizeExclusiveBounds } from "../openapi-exclusive-bounds";
+
+describe("normalizeExclusiveBounds", () => {
+  describe("given a lower bound written the 3.0 way", () => {
+    /** @scenario "A boolean exclusive bound is rewritten as the number it meant" */
+    it("rewrites the flag as the number it meant and drops the inclusive bound", () => {
+      const schema = {
+        type: "integer",
+        minimum: 0,
+        exclusiveMinimum: true,
+        maximum: 1000,
+      };
+
+      normalizeExclusiveBounds(schema);
+
+      expect(schema).toEqual({
+        type: "integer",
+        exclusiveMinimum: 0,
+        maximum: 1000,
+      });
+    });
+  });
+
+  describe("given an upper bound written the 3.0 way", () => {
+    /** @scenario "The same holds for an upper bound" */
+    it("rewrites the flag as the number it meant", () => {
+      const schema = { type: "number", maximum: 100, exclusiveMaximum: true };
+
+      normalizeExclusiveBounds(schema);
+
+      expect(schema).toEqual({ type: "number", exclusiveMaximum: 100 });
+    });
+  });
+
+  describe("given an inclusive bound", () => {
+    /** @scenario "An inclusive bound is left as it was" */
+    it("keeps the bound and drops the flag that said nothing", () => {
+      const schema = { type: "integer", minimum: 0, exclusiveMinimum: false };
+
+      normalizeExclusiveBounds(schema);
+
+      expect(schema).toEqual({ type: "integer", minimum: 0 });
+    });
+  });
+
+  describe("given a flag with no bound beside it", () => {
+    /** @scenario "A flag with no bound beside it is dropped" */
+    it("drops the flag", () => {
+      const schema = { type: "integer", exclusiveMinimum: true };
+
+      normalizeExclusiveBounds(schema);
+
+      expect(schema).toEqual({ type: "integer" });
+    });
+  });
+
+  describe("given a document with the bounds nested in arrays and objects", () => {
+    it("walks the whole document", () => {
+      const document = {
+        components: {
+          schemas: {
+            page: {
+              anyOf: [{ type: "integer", minimum: 0, exclusiveMinimum: true }],
+            },
+          },
+        },
+      };
+
+      normalizeExclusiveBounds(document);
+
+      expect(document.components.schemas.page.anyOf[0]).toEqual({
+        type: "integer",
+        exclusiveMinimum: 0,
+      });
+    });
+  });
+});
+
+describe("the published OpenAPI document", () => {
+  /** @scenario "The published document carries no boolean exclusive bound" */
+  it("spells every exclusive bound as a number", () => {
+    const booleanBounds: string[] = [];
+
+    const walk = (node: unknown, path: string): void => {
+      if (Array.isArray(node)) {
+        node.forEach((child, index) => walk(child, `${path}[${index}]`));
+        return;
+      }
+      if (typeof node !== "object" || node === null) return;
+      for (const [key, value] of Object.entries(node)) {
+        if (
+          (key === "exclusiveMinimum" || key === "exclusiveMaximum") &&
+          typeof value === "boolean"
+        ) {
+          booleanBounds.push(`${path}.${key}`);
+        }
+        walk(value, `${path}.${key}`);
+      }
+    };
+
+    walk(spec, "$");
+
+    expect(booleanBounds).toEqual([]);
+  });
+});

--- a/platform/app/src/server/api/openapi-exclusive-bounds.ts
+++ b/platform/app/src/server/api/openapi-exclusive-bounds.ts
@@ -1,0 +1,65 @@
+/**
+ * The 3.1 spelling of an exclusive bound.
+ *
+ * The document declares `openapi: 3.1.0`, where a schema is JSON Schema
+ * 2020-12 and `exclusiveMinimum` / `exclusiveMaximum` are numbers. The schema
+ * builders still emit the OpenAPI 3.0 spelling: a boolean flag next to a
+ * `minimum` or `maximum`. Strict validators reject it, and a client generator
+ * reading it either drops the bound or errors, so a `z.number().int().positive()`
+ * reached integrators as an unbounded integer.
+ *
+ * Applied to the merged document rather than fixed at each schema, because
+ * the spelling comes from the builder and not from anything a route wrote.
+ */
+
+/** Whether the value is a plain object worth walking into. */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Rewrite every `exclusiveMinimum: true` / `exclusiveMaximum: true` into the
+ * numeric 3.1 form, in place.
+ *
+ * `{ minimum: 0, exclusiveMinimum: true }` becomes `{ exclusiveMinimum: 0 }`.
+ * A boolean flag with no bound beside it says nothing and is dropped; `false`
+ * means "inclusive", which is what a bare `minimum` already says.
+ */
+export function normalizeExclusiveBounds<T>(document: T): T {
+  walk(document);
+  return document;
+}
+
+function walk(node: unknown): void {
+  if (Array.isArray(node)) {
+    for (const child of node) walk(child);
+    return;
+  }
+  if (!isRecord(node)) return;
+
+  normalizeBound({ node, flag: "exclusiveMinimum", bound: "minimum" });
+  normalizeBound({ node, flag: "exclusiveMaximum", bound: "maximum" });
+
+  for (const child of Object.values(node)) walk(child);
+}
+
+function normalizeBound({
+  node,
+  flag,
+  bound,
+}: {
+  node: Record<string, unknown>;
+  flag: "exclusiveMinimum" | "exclusiveMaximum";
+  bound: "minimum" | "maximum";
+}): void {
+  const value = node[flag];
+  if (typeof value !== "boolean") return;
+
+  const limit = node[bound];
+  if (value && typeof limit === "number") {
+    node[flag] = limit;
+    delete node[bound];
+    return;
+  }
+  delete node[flag];
+}

--- a/platform/app/src/server/api/routers/agents.ts
+++ b/platform/app/src/server/api/routers/agents.ts
@@ -9,6 +9,7 @@ import {
   agentPresenceView,
   readAgentPresence,
 } from "~/server/connected-agents/presence.read";
+import type { ConnectedAgentSelectability } from "~/server/connected-agents/selectable";
 import type { ScenarioParameterDefinition } from "~/server/scenarios/parameters";
 import {
   type AgentComponentConfig,
@@ -40,17 +41,20 @@ async function withConnectedAgentViews<T extends AgentWithFields>({
   agents,
   projectId,
   agentService,
+  viewerUserId,
 }: {
   agents: T[];
   projectId: string;
   agentService: AgentService;
+  /** The person reading, so each row says whether they can choose it. */
+  viewerUserId: string | null;
 }): Promise<
   (T & {
     parameters: ScenarioParameterDefinition[];
     owner: { userId: string; name: string | null } | null;
     status: AgentPresenceStatus;
     instances: AgentInstanceView[];
-  })[]
+  } & ConnectedAgentSelectability)[]
 > {
   const [owners, presence] = await Promise.all([
     agentService.ownersOf(agents),
@@ -59,7 +63,7 @@ async function withConnectedAgentViews<T extends AgentWithFields>({
   return agents.map((agent) => ({
     ...agent,
     parameters: declaredAgentParameters(agent),
-    ...agentPresenceView({ agent, owners, presence }),
+    ...agentPresenceView({ agent, owners, presence, viewerUserId }),
   }));
 }
 
@@ -89,6 +93,7 @@ export const agentsRouter = createTRPCRouter({
         agents,
         projectId: input.projectId,
         agentService,
+        viewerUserId: ctx.session.user.id,
       });
     }),
 
@@ -110,6 +115,7 @@ export const agentsRouter = createTRPCRouter({
         agents: [agent],
         projectId: input.projectId,
         agentService,
+        viewerUserId: ctx.session.user.id,
       });
       return view ?? null;
     }),

--- a/platform/app/src/server/app-layer/authz/__tests__/ledger-read-your-writes.unit.test.ts
+++ b/platform/app/src/server/app-layer/authz/__tests__/ledger-read-your-writes.unit.test.ts
@@ -1,0 +1,151 @@
+/**
+ * The bounded read-your-writes hold, and what a caller can ask it to do when
+ * the projection does not land inside the window.
+ *
+ * The append is durable either way, so most callers pass: the fold converges
+ * and the rows appear. A caller whose next step hands out access those rows
+ * decide asks for `requireProjection` and is refused instead.
+ *
+ * @see specs/rbac/authz-grants.feature
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../epoch", () => ({
+  bumpAuthzEpoch: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { HandledError } from "@langwatch/handled-error";
+import { ACTOR, binding, harness, ORG_ID } from "./ledger-write-fork.harness";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+/** The code of a handled failure, or the error itself when it is not one. */
+async function codeOf(run: () => Promise<unknown>): Promise<unknown> {
+  try {
+    await run();
+  } catch (error) {
+    return HandledError.isHandled(error) ? error.code : error;
+  }
+  return null;
+}
+
+describe("given an attach whose projection does not land inside the window", () => {
+  describe("when the caller does not require the projection", () => {
+    /** @scenario "A write that nobody reads next passes when the projection lags" */
+    it("reports the write as done", async () => {
+      const { writer } = harness({ onLedger: true });
+
+      const outcome = await writer.attachBindings({
+        organizationId: ORG_ID,
+        bindings: [binding],
+        actor: ACTOR,
+        onDuplicate: "skip",
+      });
+
+      expect(outcome.attached).toEqual(["rb_1"]);
+    });
+  });
+
+  describe("when the caller requires the projection", () => {
+    /** @scenario "A write whose caller requires the projection fails when it lags" */
+    it("refuses with authz_grant_not_confirmed", async () => {
+      const { writer } = harness({ onLedger: true });
+
+      expect(
+        await codeOf(() =>
+          writer.attachBindings({
+            organizationId: ORG_ID,
+            bindings: [binding],
+            actor: ACTOR,
+            onDuplicate: "skip",
+            requireProjection: true,
+          }),
+        ),
+      ).toBe("authz_grant_not_confirmed");
+    });
+
+    it("reports the failure as ours, not the caller's", async () => {
+      const { writer } = harness({ onLedger: true });
+
+      let caught: unknown;
+      try {
+        await writer.attachBindings({
+          organizationId: ORG_ID,
+          bindings: [binding],
+          actor: ACTOR,
+          onDuplicate: "skip",
+          requireProjection: true,
+        });
+      } catch (error) {
+        caught = error;
+      }
+
+      expect(HandledError.isHandled(caught)).toBe(true);
+      const handled = caught as HandledError;
+      expect(handled.fault).toBe("platform");
+      expect(handled.httpStatus).toBe(503);
+    });
+  });
+});
+
+describe("given an attach whose projection lands inside the window", () => {
+  describe("when the caller requires the projection", () => {
+    /** @scenario "A required write that lands inside the window passes" */
+    it("reports the write as done", async () => {
+      const { writer, db } = harness({ onLedger: true });
+      db.roleBinding.count.mockResolvedValue(1);
+
+      const outcome = await writer.attachBindings({
+        organizationId: ORG_ID,
+        bindings: [binding],
+        actor: ACTOR,
+        onDuplicate: "skip",
+        requireProjection: true,
+      });
+
+      expect(outcome.attached).toEqual(["rb_1"]);
+    });
+  });
+});
+
+describe("given a role definition whose projection does not land inside the window", () => {
+  describe("when the caller requires the projection", () => {
+    /** @scenario "A role definition whose caller requires the projection fails when it lags" */
+    it("refuses with authz_grant_not_confirmed", async () => {
+      const { writer } = harness({ onLedger: true });
+
+      expect(
+        await codeOf(() =>
+          writer.defineRole({
+            organizationId: ORG_ID,
+            roleId: "role_1",
+            name: "apikey:key_1",
+            permissions: ["langy:view"],
+            kind: "system_api_key",
+            actor: ACTOR,
+            requireProjection: true,
+          }),
+        ),
+      ).toBe("authz_grant_not_confirmed");
+    });
+  });
+
+  describe("when the caller does not require the projection", () => {
+    it("reports the write as done", async () => {
+      const { writer } = harness({ onLedger: true });
+
+      await expect(
+        writer.defineRole({
+          organizationId: ORG_ID,
+          roleId: "role_1",
+          name: "apikey:key_1",
+          permissions: ["langy:view"],
+          kind: "system_api_key",
+          actor: ACTOR,
+        }),
+      ).resolves.toBeUndefined();
+    });
+  });
+});

--- a/platform/app/src/server/app-layer/authz/__tests__/ledger-read-your-writes.unit.test.ts
+++ b/platform/app/src/server/app-layer/authz/__tests__/ledger-read-your-writes.unit.test.ts
@@ -66,6 +66,24 @@ describe("given an attach whose projection does not land inside the window", () 
       ).toBe("authz_grant_not_confirmed");
     });
 
+    /** @scenario "Requiring the projection waits for it even when the wait is switched off" */
+    it("waits and refuses even when the caller switched the wait off", async () => {
+      const { writer } = harness({ onLedger: true });
+
+      expect(
+        await codeOf(() =>
+          writer.attachBindings({
+            organizationId: ORG_ID,
+            bindings: [binding],
+            actor: ACTOR,
+            onDuplicate: "skip",
+            awaitProjection: false,
+            requireProjection: true,
+          }),
+        ),
+      ).toBe("authz_grant_not_confirmed");
+    });
+
     it("reports the failure as ours, not the caller's", async () => {
       const { writer } = harness({ onLedger: true });
 

--- a/platform/app/src/server/app-layer/authz/errors.ts
+++ b/platform/app/src/server/app-layer/authz/errors.ts
@@ -1,0 +1,39 @@
+/**
+ * The failures a grant write reports to its caller.
+ *
+ * Separate from `./ledger.ts` so a caller can catch one without importing the
+ * writer, and so a test of a caller can name the failure without standing the
+ * whole ledger up.
+ *
+ * @see dev/docs/best_practices/error-handling.md
+ */
+import { HandledError } from "@langwatch/handled-error";
+
+/**
+ * The append is durable, but the projection did not make the rows readable
+ * inside the read-your-writes window, and the caller asked to be told
+ * (`requireProjection`).
+ *
+ * Only a caller whose NEXT step hands out access that depends on those rows
+ * asks for this. Minting an API key is the case it exists for: the key row
+ * and its grants cannot share a transaction, so the key is born revoked and
+ * activated last, and activating it on an unconfirmed grant is what produced
+ * a live token that every route then refused.
+ *
+ * Handled and named because the caller can act on it (retry, once the fold
+ * has drained) and because it is not a validation failure. `fault: "platform"`
+ * — a lagging fold is ours. The detail (which write, which organization) goes
+ * to the log line; the message stays customer-safe.
+ */
+export class AuthzGrantNotConfirmedError extends HandledError {
+  declare readonly code: "authz_grant_not_confirmed";
+
+  constructor() {
+    super(
+      "authz_grant_not_confirmed",
+      "We could not confirm the access change in time. Nothing was granted. Try again in a moment.",
+      { httpStatus: 503, fault: "platform" },
+    );
+    this.name = "AuthzGrantNotConfirmedError";
+  }
+}

--- a/platform/app/src/server/app-layer/authz/ledger.ts
+++ b/platform/app/src/server/app-layer/authz/ledger.ts
@@ -78,6 +78,7 @@ import { RoleDuplicateNameError } from "../../role/errors/role-duplicate-name.er
 import { tryGetApp } from "../app";
 import { organizationOnAuthzEngine } from "./engine-gate";
 import { bumpAuthzEpoch } from "./epoch";
+import { AuthzGrantNotConfirmedError } from "./errors";
 import { PrismaAuthzRevocationRepository } from "./repositories/authz-revocation.prisma.repository";
 import { liveGrants } from "./repositories/live-rows";
 
@@ -377,6 +378,7 @@ export class GrantsLedgerWriter {
     commandId,
     occurredAtMs: occurredAtOverrideMs,
     awaitProjection = true,
+    requireProjection = false,
   }: {
     organizationId: string;
     bindings: LedgerBindingAttach[];
@@ -416,6 +418,15 @@ export class GrantsLedgerWriter {
      * only spend the request's time.
      */
     awaitProjection?: boolean;
+    /**
+     * Whether an unlanded projection is an error. Off by default, because for
+     * most callers the append is the write and the fold converging later is
+     * the normal, correct outcome. A caller that is about to hand out access
+     * these very rows decide — minting an API key — turns it on, and gets an
+     * {@link AuthzGrantNotConfirmedError} instead of a silent pass. Needs
+     * `awaitProjection`, since there is nothing to require without the wait.
+     */
+    requireProjection?: boolean;
   }): Promise<AttachOutcome> {
     if (bindings.length === 0) return { attached: [], duplicates: [] };
 
@@ -463,7 +474,7 @@ export class GrantsLedgerWriter {
 
     const wanted = fresh.map((binding) => binding.bindingId);
     if (awaitProjection) {
-      await this.awaitProjection({
+      const landed = await this.awaitProjection({
         what: `attach of ${wanted.length} binding(s)`,
         organizationId,
         check: async () => {
@@ -473,6 +484,7 @@ export class GrantsLedgerWriter {
           return present === wanted.length;
         },
       });
+      if (!landed && requireProjection) throw new AuthzGrantNotConfirmedError();
     }
     await bumpAuthzEpoch({ organizationId });
     return { attached: wanted, duplicates };
@@ -1299,6 +1311,7 @@ export class GrantsLedgerWriter {
     permissions,
     kind,
     actor,
+    requireProjection = false,
   }: {
     organizationId: string;
     roleId: string;
@@ -1307,6 +1320,14 @@ export class GrantsLedgerWriter {
     permissions: string[];
     kind: "custom" | "system_api_key";
     actor: LedgerActor;
+    /**
+     * Whether an unlanded projection is an error. Same contract as
+     * {@link GrantsLedgerWriter.attachBindings}: a caller about to bind a
+     * grant to this role and then hand the credential out turns it on, so a
+     * role definition that never became readable refuses the mint instead of
+     * leaving a binding pointing at a role that grants nothing.
+     */
+    requireProjection?: boolean;
   }): Promise<void> {
     const occurredAtMs = this.now();
     if (!(await this.onLedger(organizationId))) {
@@ -1340,7 +1361,7 @@ export class GrantsLedgerWriter {
     // that write fails if the role row is not there yet. Commands are queued
     // per command name, not per organization, so `attachGrants` can be picked
     // up before `defineRoles` and cannot stand in for this hold.
-    await this.awaitProjection({
+    const landed = await this.awaitProjection({
       what: `definition of role ${roleId}`,
       organizationId,
       // The COMPAT head, like every other read-your-writes check here: that
@@ -1360,6 +1381,7 @@ export class GrantsLedgerWriter {
         );
       },
     });
+    if (!landed && requireProjection) throw new AuthzGrantNotConfirmedError();
     await bumpAuthzEpoch({ organizationId });
   }
 
@@ -1502,8 +1524,12 @@ export class GrantsLedgerWriter {
 
   /**
    * Bounded read-your-writes: poll until the projection reflects the write.
-   * Timing out is NOT a failure — the append landed and the fold will drain
-   * (Redis-down doctrine); the caller's write is durable either way.
+   * Answers whether the rows landed inside the window.
+   *
+   * Timing out is not in itself a failure — the append landed and the fold
+   * will drain (Redis-down doctrine), so the caller's write is durable either
+   * way. It IS a failure for a caller whose next step only makes sense once
+   * the rows are readable, which is what `requireProjection` states.
    */
   private async awaitProjection({
     what,
@@ -1513,7 +1539,7 @@ export class GrantsLedgerWriter {
     what: string;
     organizationId: string;
     check: () => Promise<boolean>;
-  }): Promise<void> {
+  }): Promise<boolean> {
     const poll = this.deps.poll ?? {
       intervalMs: CONVERGENCE_POLL_MS,
       timeoutMs: CONVERGENCE_TIMEOUT_MS,
@@ -1524,13 +1550,13 @@ export class GrantsLedgerWriter {
     // ever time out.
     const deadline = Date.now() + poll.timeoutMs;
     for (;;) {
-      if (await check()) return;
+      if (await check()) return true;
       if (Date.now() >= deadline) {
         logger.warn(
           { organizationId, what },
           "grants projection did not land a write within the read-your-writes window; the append is durable and the fold will converge",
         );
-        return;
+        return false;
       }
       await new Promise((resolve) => setTimeout(resolve, poll.intervalMs));
     }

--- a/platform/app/src/server/app-layer/authz/ledger.ts
+++ b/platform/app/src/server/app-layer/authz/ledger.ts
@@ -423,8 +423,9 @@ export class GrantsLedgerWriter {
      * most callers the append is the write and the fold converging later is
      * the normal, correct outcome. A caller that is about to hand out access
      * these very rows decide — minting an API key — turns it on, and gets an
-     * {@link AuthzGrantNotConfirmedError} instead of a silent pass. Needs
-     * `awaitProjection`, since there is nothing to require without the wait.
+     * {@link AuthzGrantNotConfirmedError} instead of a silent pass. It implies
+     * the wait: there is nothing to require without one, so asking for the
+     * error with `awaitProjection: false` waits anyway rather than passing.
      */
     requireProjection?: boolean;
   }): Promise<AttachOutcome> {
@@ -473,7 +474,7 @@ export class GrantsLedgerWriter {
     );
 
     const wanted = fresh.map((binding) => binding.bindingId);
-    if (awaitProjection) {
+    if (awaitProjection || requireProjection) {
       const landed = await this.awaitProjection({
         what: `attach of ${wanted.length} binding(s)`,
         organizationId,

--- a/platform/app/src/server/connected-agents/__tests__/selectable.unit.test.ts
+++ b/platform/app/src/server/connected-agents/__tests__/selectable.unit.test.ts
@@ -1,0 +1,109 @@
+/**
+ * What a listing says about a connected agent row the caller may read but may
+ * not run, and that the run refuses exactly the rows the listing marks.
+ *
+ * @see specs/agents/connected-agents.feature
+ */
+import { describe, expect, it } from "vitest";
+import { assertConnectedAgentsRunnable } from "~/server/suites/connected-targets";
+import { agentPresenceView } from "../presence.read";
+import { connectedAgentSelectability } from "../selectable";
+
+const NO_OWNERS = new Map<string, { userId: string; name: string | null }>();
+const NO_PRESENCE_MAP = new Map<
+  string,
+  { status: "online" | "offline"; instances: [] }
+>();
+
+function view({
+  ownerUserId,
+  viewerUserId,
+}: {
+  ownerUserId: string | null;
+  viewerUserId: string | null;
+}) {
+  return agentPresenceView({
+    agent: { id: "agent_1", ownerUserId },
+    owners: NO_OWNERS,
+    presence: NO_PRESENCE_MAP,
+    viewerUserId,
+  });
+}
+
+describe("given a personal development agent", () => {
+  describe("when somebody else lists the project's agents", () => {
+    /** @scenario "A row the caller cannot choose is listed and marked" */
+    it("marks the row as not selectable and names the reason", () => {
+      const row = view({ ownerUserId: "u_1", viewerUserId: "u_2" });
+
+      expect(row.owner?.userId).toBe("u_1");
+      expect(row.selectable).toBe(false);
+      expect(row.notSelectableReason).toBe("owned_by_another_person");
+    });
+  });
+
+  describe("when its owner lists the project's agents", () => {
+    /** @scenario "A row the caller can choose is marked selectable" */
+    it("marks the row as selectable", () => {
+      const row = view({ ownerUserId: "u_1", viewerUserId: "u_1" });
+
+      expect(row.selectable).toBe(true);
+      expect(row.notSelectableReason).toBeNull();
+    });
+  });
+
+  describe("when a key that names no person lists the project's agents", () => {
+    /** @scenario "A personal row is not selectable by a key that names no person" */
+    it("marks the row as not selectable", () => {
+      const row = view({ ownerUserId: "u_1", viewerUserId: null });
+
+      expect(row.selectable).toBe(false);
+    });
+  });
+});
+
+describe("given a host-scoped development agent", () => {
+  describe("when a key that names no person lists the project's agents", () => {
+    /** @scenario "A host-scoped row is selectable by anybody in the project" */
+    it("marks the row as selectable", () => {
+      const row = view({ ownerUserId: null, viewerUserId: null });
+
+      expect(row.owner).toBeNull();
+      expect(row.selectable).toBe(true);
+      expect(row.notSelectableReason).toBeNull();
+    });
+  });
+});
+
+describe("given the listing mark and the run refusal read the same agents", () => {
+  /** @scenario "The listing mark and the run refusal read one rule" */
+  it("refuses exactly the agents the listing marks as not selectable", async () => {
+    const agents = [
+      { id: "a_1", name: "shared", type: "connected", ownerUserId: null },
+      { id: "a_2", name: "mine", type: "connected", ownerUserId: "u_1" },
+      { id: "a_3", name: "theirs", type: "connected", ownerUserId: "u_2" },
+    ];
+    const users = {
+      user: { findMany: async () => [{ id: "u_2", name: "Ana" }] },
+    } as unknown as Parameters<
+      typeof assertConnectedAgentsRunnable
+    >[0]["users"];
+
+    for (const agent of agents) {
+      const marked = connectedAgentSelectability({
+        ownerUserId: agent.ownerUserId,
+        viewerUserId: "u_1",
+      }).selectable;
+      const refused = await assertConnectedAgentsRunnable({
+        agents: [agent],
+        actor: { id: "u_1", label: "user" },
+        users,
+      }).then(
+        () => false,
+        () => true,
+      );
+
+      expect(refused).toBe(!marked);
+    }
+  });
+});

--- a/platform/app/src/server/connected-agents/__tests__/selectable.unit.test.ts
+++ b/platform/app/src/server/connected-agents/__tests__/selectable.unit.test.ts
@@ -5,6 +5,7 @@
  * @see specs/agents/connected-agents.feature
  */
 import { describe, expect, it } from "vitest";
+import type { AgentIdentityRow } from "~/server/agents/agent.repository";
 import { assertConnectedAgentsRunnable } from "~/server/suites/connected-targets";
 import { agentPresenceView } from "../presence.read";
 import { connectedAgentSelectability } from "../selectable";
@@ -78,7 +79,10 @@ describe("given a host-scoped development agent", () => {
 describe("given the listing mark and the run refusal read the same agents", () => {
   /** @scenario "The listing mark and the run refusal read one rule" */
   it("refuses exactly the agents the listing marks as not selectable", async () => {
-    const agents = [
+    const agents: Pick<
+      AgentIdentityRow,
+      "id" | "name" | "type" | "ownerUserId"
+    >[] = [
       { id: "a_1", name: "shared", type: "connected", ownerUserId: null },
       { id: "a_2", name: "mine", type: "connected", ownerUserId: "u_1" },
       { id: "a_3", name: "theirs", type: "connected", ownerUserId: "u_2" },

--- a/platform/app/src/server/connected-agents/presence.read.ts
+++ b/platform/app/src/server/connected-agents/presence.read.ts
@@ -9,6 +9,10 @@
 import { createLogger } from "@langwatch/observability";
 import type { LiveInstance } from "./instance.registry";
 import { getConnectedAgentRuntime } from "./runtime";
+import {
+  type ConnectedAgentSelectability,
+  connectedAgentSelectability,
+} from "./selectable";
 
 const logger = createLogger("langwatch:connected-agents:presence");
 
@@ -42,23 +46,30 @@ export interface AgentOwnerView {
 }
 
 /**
- * The owner and the presence of one agent, as the response schemas declare
- * them.
+ * The owner, the presence and the selectability of one agent, as the response
+ * schemas declare them.
  *
- * Both the REST routes and the tRPC router answer with these three fields, so
- * the fold lives here beside the presence it reads. An owner the name lookup
+ * Both the REST routes and the tRPC router answer with these fields, so the
+ * fold lives here beside the presence it reads. An owner the name lookup
  * missed still reports its id, because the row knows the agent belongs to
  * somebody even when the person cannot be named.
+ *
+ * A row a caller may read but may not choose is answered all the same, marked
+ * with the reason, so the client can show it and say why it is not on offer.
  */
 export function agentPresenceView({
   agent,
   owners,
   presence,
+  viewerUserId,
 }: {
   agent: { id: string; ownerUserId: string | null };
   owners: Map<string, AgentOwnerView>;
   presence: Map<string, AgentPresence>;
-}): { owner: AgentOwnerView | null } & AgentPresence {
+  /** The person behind the caller; nothing for a key that names none. */
+  viewerUserId?: string | null;
+}): { owner: AgentOwnerView | null } & AgentPresence &
+  ConnectedAgentSelectability {
   const { status, instances } = presence.get(agent.id) ?? NO_PRESENCE;
   return {
     owner: agent.ownerUserId
@@ -69,6 +80,10 @@ export function agentPresenceView({
       : null,
     status,
     instances,
+    ...connectedAgentSelectability({
+      ownerUserId: agent.ownerUserId,
+      viewerUserId,
+    }),
   };
 }
 

--- a/platform/app/src/server/connected-agents/selectable.ts
+++ b/platform/app/src/server/connected-agents/selectable.ts
@@ -1,0 +1,53 @@
+/**
+ * Whether the caller reading a connected agent can also choose it (ADR-128).
+ *
+ * A development agent registered with a personal key belongs to that person,
+ * and only that person can run it. Everybody in the project can still READ the
+ * row: one name and one environment can hold a personal row and a host-scoped
+ * row at once, and a listing that dropped the personal one would show two
+ * agents of one name with no way to tell them apart.
+ *
+ * So a listing carries every row the caller may read, and each row says
+ * whether the caller may choose it. The rule is here, in one framework-free
+ * module, because three readers have to agree on it: the listings that mark
+ * the rows, the run that refuses a target, and the browser that draws the
+ * picker. Two copies of it is how a row marked selectable becomes a run that
+ * refuses.
+ *
+ * @see specs/agents/connected-agents.feature
+ */
+
+/** Why a row is listed but cannot be chosen. */
+export const CONNECTED_AGENT_NOT_SELECTABLE_REASONS = [
+  "owned_by_another_person",
+] as const;
+
+export type ConnectedAgentNotSelectableReason =
+  (typeof CONNECTED_AGENT_NOT_SELECTABLE_REASONS)[number];
+
+/** What every listing says about a row beside its owner. */
+export interface ConnectedAgentSelectability {
+  selectable: boolean;
+  notSelectableReason: ConnectedAgentNotSelectableReason | null;
+}
+
+/**
+ * Whether this caller can choose this agent, and why not when they cannot.
+ *
+ * A row that belongs to nobody is everybody's to choose. A row that belongs to
+ * a person is theirs alone, so a caller who is somebody else, or a key that
+ * names no person at all, reads it but cannot choose it.
+ */
+export function connectedAgentSelectability({
+  ownerUserId,
+  viewerUserId,
+}: {
+  ownerUserId: string | null | undefined;
+  /** The person behind the caller; nothing for a key that names none. */
+  viewerUserId: string | null | undefined;
+}): ConnectedAgentSelectability {
+  if (!ownerUserId || ownerUserId === viewerUserId) {
+    return { selectable: true, notSelectableReason: null };
+  }
+  return { selectable: false, notSelectableReason: "owned_by_another_person" };
+}

--- a/platform/app/src/server/role/repositories/role.repository.ts
+++ b/platform/app/src/server/role/repositories/role.repository.ts
@@ -253,9 +253,18 @@ export class RoleRepository {
   async create({
     params,
     actor,
+    requireProjection = false,
   }: {
     params: CreateRoleParams;
     actor: LedgerActor;
+    /**
+     * Whether a definition that did not become readable inside the
+     * read-your-writes window is an error. The API-key mint turns it on: it
+     * binds a grant to this role and then activates the credential, so an
+     * unconfirmed definition would hand out a key whose permissions nothing
+     * can resolve.
+     */
+    requireProjection?: boolean;
   }): Promise<CustomRole> {
     const roleId = nanoid();
     await this.assertNameFree({
@@ -276,6 +285,7 @@ export class RoleRepository {
       permissions: params.permissions as string[],
       kind: kind as "custom" | "system_api_key",
       actor,
+      requireProjection,
     });
     const now = new Date();
     return {

--- a/platform/app/src/server/suites/connected-targets.ts
+++ b/platform/app/src/server/suites/connected-targets.ts
@@ -29,6 +29,7 @@ import {
   parseConnectedReference,
 } from "../connected-agents/identity";
 import { readAgentPresence } from "../connected-agents/presence.read";
+import { connectedAgentSelectability } from "../connected-agents/selectable";
 import {
   parseScenarioParameterDefinitions,
   type ScenarioParameterDefinition,
@@ -229,6 +230,10 @@ export function isAgentUnseen(
  * Refuses the run when one of its agents is a personal development agent of
  * someone other than the actor.
  *
+ * The same predicate the listings mark their rows with, so a row a client was
+ * told it could choose is never refused here, and one it was told it could
+ * not is never accepted.
+ *
  * A run with no actor at all, one started with a legacy project key, has no
  * person to match, so a personal agent refuses it too. The refusal names the
  * owner, so the customer reads who to ask.
@@ -248,8 +253,10 @@ export async function assertConnectedAgentsRunnable({
   const foreign = agents.find(
     (agent) =>
       agent.type === "connected" &&
-      agent.ownerUserId !== null &&
-      agent.ownerUserId !== actor?.id,
+      !connectedAgentSelectability({
+        ownerUserId: agent.ownerUserId,
+        viewerUserId: actor?.id ?? null,
+      }).selectable,
   );
   if (!foreign?.ownerUserId) return;
   const names = await ownerNamesOf({ agents: [foreign], users });

--- a/platform/app/src/tasks/generateOpenAPISpec.ts
+++ b/platform/app/src/tasks/generateOpenAPISpec.ts
@@ -36,6 +36,7 @@ import { app as roleBindingsApp } from "../app/api/role-bindings/[[...route]]/ap
 import { app as rolesApp } from "../app/api/roles/[[...route]]/app";
 import { app as runPlansApp } from "../app/api/run-plans/[[...route]]/app";
 import { app as scimTokensApp } from "../app/api/scim-tokens/[[...route]]/app";
+import { normalizeExclusiveBounds } from "../server/api/openapi-exclusive-bounds";
 import { requireDefaultedResponseFields } from "../server/api/openapi-response-required";
 import {
   allRegisteredRoutes,
@@ -366,6 +367,7 @@ export default async function execute() {
 
   console.log("Stamping per-operation security...");
   stampSecurityFromRegistry(mergedSpec as SpecShape);
+  normalizeExclusiveBounds(mergedSpec);
 
   fs.writeFileSync(
     path.join(__dirname, "../app/api/openapiLangWatch.json"),

--- a/sdks/typescript/src/cli/commands/agents/__tests__/agent-connected.unit.test.ts
+++ b/sdks/typescript/src/cli/commands/agents/__tests__/agent-connected.unit.test.ts
@@ -144,6 +144,22 @@ describe("listAgentsCommand()", () => {
       expect(agentOwnerLabel(connectedAgent({ hostLabel: "ada-laptop" }))).toBe("ada-laptop");
       expect(agentOwnerLabel(connectedAgent())).toBe("");
     });
+
+    /** @scenario "A row the key cannot choose reads as not selectable" */
+    it("marks the owner cell of a row this key cannot run", () => {
+      expect(
+        agentOwnerLabel(
+          connectedAgent({
+            owner: { userId: "u1", name: "Ada" },
+            selectable: false,
+            notSelectableReason: "owned_by_another_person",
+          }),
+        ),
+      ).toBe("Ada (owner only)");
+      expect(agentOwnerLabel(connectedAgent({ selectable: false }))).toBe(
+        "owner only",
+      );
+    });
   });
 });
 
@@ -193,6 +209,26 @@ describe("getAgentCommand()", () => {
 
     it("describes one parameter on one line", () => {
       expect(describeParameter({ name: "n", type: "number", default: 5 })).toBe("n: number, default 5");
+    });
+  });
+
+  describe("when the agent belongs to another person", () => {
+    /** @scenario "The detail says whether the key can choose the agent" */
+    it("names the owner and says only its owner can run it", async () => {
+      service.get.mockResolvedValue(
+        connectedAgent({
+          owner: { userId: "u1", name: "Ada" },
+          selectable: false,
+          notSelectableReason: "owned_by_another_person",
+        }),
+      );
+
+      const result = await getAgentCommand("agent_conn");
+      result?.table?.();
+
+      const output = printed();
+      expect(output).toContain("Ada");
+      expect(output).toContain("only its owner can run this agent");
     });
   });
 });

--- a/sdks/typescript/src/cli/commands/agents/get.ts
+++ b/sdks/typescript/src/cli/commands/agents/get.ts
@@ -55,6 +55,11 @@ export const getAgentCommand = async (id: string): Promise<CommandResult | void>
         } else if (agent.hostLabel) {
           console.log(`  ${chalk.gray("Host:")}        ${agent.hostLabel}`);
         }
+        if (agent.selectable === false) {
+          console.log(
+            `  ${chalk.gray("Run:")}         ${chalk.yellow("only its owner can run this agent")}`,
+          );
+        }
         if (agent.lastSeenAt) {
           console.log(`  ${chalk.gray("Last seen:")}   ${new Date(agent.lastSeenAt).toLocaleString()}`);
         }

--- a/sdks/typescript/src/cli/commands/agents/list.ts
+++ b/sdks/typescript/src/cli/commands/agents/list.ts
@@ -9,9 +9,21 @@ import { formatTable, formatRelativeTime } from "../../utils/formatting";
 import { failSpinner } from "../../utils/spinnerError";
 import type { CommandResult } from "../../utils/output";
 
-/** Who a personal or host-scoped agent belongs to, empty for a shared one. */
-export const agentOwnerLabel = (agent: AgentResponse): string =>
-  agent.owner?.name ?? agent.hostLabel ?? "";
+/**
+ * Who a personal or host-scoped agent belongs to, empty for a shared one.
+ *
+ * A personal agent of another person is listed like every other, because two
+ * agents of one name are told apart by this column alone. It reads "owner
+ * only" so the difference between "you can run this" and "you can see this"
+ * is on the row rather than in a later refusal.
+ */
+export const agentOwnerLabel = (agent: AgentResponse): string => {
+  const owner = agent.owner?.name ?? agent.hostLabel ?? "";
+  if (agent.selectable === false) {
+    return owner ? `${owner} (owner only)` : "owner only";
+  }
+  return owner;
+};
 
 /** The status column: online or offline for a connected agent, empty for the other types. */
 export const agentStatusLabel = (agent: AgentResponse): string => agent.status ?? "";

--- a/sdks/typescript/src/client-sdk/services/agents/agents-api.service.ts
+++ b/sdks/typescript/src/client-sdk/services/agents/agents-api.service.ts
@@ -46,6 +46,14 @@ export interface AgentResponse {
   owner?: { userId: string; name: string } | null;
   /** The machine a host-scoped development agent belongs to. */
   hostLabel?: string | null;
+  /**
+   * Whether this key can run the agent. A personal development agent of
+   * another person is listed all the same, so two agents of one name can be
+   * told apart, but it cannot be run with this key.
+   */
+  selectable?: boolean;
+  /** Why the agent cannot be run with this key; null when it can. */
+  notSelectableReason?: "owned_by_another_person" | null;
   parameters?: AgentParameterSpec[];
 }
 

--- a/sdks/typescript/src/internal/generated/openapi/api-client.ts
+++ b/sdks/typescript/src/internal/generated/openapi/api-client.ts
@@ -5492,6 +5492,13 @@ export interface operations {
                                 inflight: number;
                                 maxConcurrency: number;
                             }[];
+                            /** @description Whether the credential making this request can run simulations against the agent. False for a personal development agent that belongs to somebody else, which is listed all the same so it can be told apart from the other agents of the same name. */
+                            selectable: boolean;
+                            /**
+                             * @description Why the agent cannot be run by this credential. Null when it can.
+                             * @enum {string|null}
+                             */
+                            notSelectableReason: "owned_by_another_person" | null;
                             createdAt: string;
                             updatedAt: string;
                             /** Format: uri */
@@ -5594,6 +5601,13 @@ export interface operations {
                             inflight: number;
                             maxConcurrency: number;
                         }[];
+                        /** @description Whether the credential making this request can run simulations against the agent. False for a personal development agent that belongs to somebody else, which is listed all the same so it can be told apart from the other agents of the same name. */
+                        selectable: boolean;
+                        /**
+                         * @description Why the agent cannot be run by this credential. Null when it can.
+                         * @enum {string|null}
+                         */
+                        notSelectableReason: "owned_by_another_person" | null;
                         createdAt: string;
                         updatedAt: string;
                         /** Format: uri */
@@ -5677,6 +5691,13 @@ export interface operations {
                             inflight: number;
                             maxConcurrency: number;
                         }[];
+                        /** @description Whether the credential making this request can run simulations against the agent. False for a personal development agent that belongs to somebody else, which is listed all the same so it can be told apart from the other agents of the same name. */
+                        selectable: boolean;
+                        /**
+                         * @description Why the agent cannot be run by this credential. Null when it can.
+                         * @enum {string|null}
+                         */
+                        notSelectableReason: "owned_by_another_person" | null;
                         createdAt: string;
                         updatedAt: string;
                         /** Format: uri */
@@ -5775,6 +5796,13 @@ export interface operations {
                             inflight: number;
                             maxConcurrency: number;
                         }[];
+                        /** @description Whether the credential making this request can run simulations against the agent. False for a personal development agent that belongs to somebody else, which is listed all the same so it can be told apart from the other agents of the same name. */
+                        selectable: boolean;
+                        /**
+                         * @description Why the agent cannot be run by this credential. Null when it can.
+                         * @enum {string|null}
+                         */
+                        notSelectableReason: "owned_by_another_person" | null;
                         createdAt: string;
                         updatedAt: string;
                         /** Format: uri */
@@ -5902,6 +5930,13 @@ export interface operations {
                             inflight: number;
                             maxConcurrency: number;
                         }[];
+                        /** @description Whether the credential making this request can run simulations against the agent. False for a personal development agent that belongs to somebody else, which is listed all the same so it can be told apart from the other agents of the same name. */
+                        selectable: boolean;
+                        /**
+                         * @description Why the agent cannot be run by this credential. Null when it can.
+                         * @enum {string|null}
+                         */
+                        notSelectableReason: "owned_by_another_person" | null;
                         createdAt: string;
                         updatedAt: string;
                         /** Format: uri */
@@ -18127,6 +18162,21 @@ export interface operations {
                         pattern: string;
                         reason: string;
                         skipOffered: boolean;
+                        segments?: {
+                            command: string;
+                            pattern: string;
+                            readOnly: boolean;
+                        }[];
+                        timeoutSeconds?: number;
+                    } | {
+                        /** @enum {number} */
+                        protocol: 1;
+                        /** @enum {string} */
+                        type: "permission_answered";
+                        callId: string;
+                        /** @enum {string} */
+                        decision: "allow_once" | "allow_pattern" | "deny";
+                        patterns?: string[];
                     } | {
                         /** @enum {number} */
                         protocol: 1;

--- a/specs/agents/agents-rest-api.feature
+++ b/specs/agents/agents-rest-api.feature
@@ -32,6 +32,14 @@ Feature: Agent REST API
     When I call GET /api/v1/agents
     Then I receive a paginated response with 0 agents
 
+  @integration
+  Scenario: A listed connected agent carries its owner and whether the caller can choose it
+    Given "support-agent" in "development" has a row owned by a person and a row scoped to a host
+    When I call GET /api/v1/agents with a project key
+    Then both rows are in the answer
+    And the personal row carries its owner and reads as not selectable
+    And the host-scoped row reads as selectable
+
   # ── Create Agent ─────────────────────────────────────────────
 
   @integration

--- a/specs/agents/connected-agents.feature
+++ b/specs/agents/connected-agents.feature
@@ -158,6 +158,55 @@ Feature: Connected agents
     Then the reference is left as written
 
   # ---------------------------------------------------------------------------
+  # What a listing shows
+  # ---------------------------------------------------------------------------
+
+  # One name and one environment can hold more than one row: the person who
+  # ran it from their laptop with their own key, and the machine that ran it
+  # with the project key. A listing shows every row the caller is allowed to
+  # read, and says of each whether the caller can choose it. Hiding a row the
+  # caller may read leaves two agents of one name with no way to tell them
+  # apart.
+
+  @unit
+  Scenario: A listing carries every row of a name, whoever holds it
+    Given "support-agent" in "development" has a row owned by user "u_1" and a row scoped to a host
+    When a project key lists the project's agents
+    Then both rows are in the answer
+
+  @unit
+  Scenario: A row the caller cannot choose is listed and marked
+    Given a personal development agent owned by user "u_1"
+    When user "u_2" lists the project's agents
+    Then the row is in the answer
+    And it is marked as not selectable
+    And the mark reads "owned_by_another_person"
+
+  @unit
+  Scenario: A row the caller can choose is marked selectable
+    Given a personal development agent owned by user "u_1"
+    When user "u_1" lists the project's agents
+    Then the row is marked as selectable
+
+  @unit
+  Scenario: A host-scoped row is selectable by anybody in the project
+    Given a development agent scoped to a host and owned by no person
+    When a project key lists the project's agents
+    Then the row is marked as selectable
+
+  @unit
+  Scenario: A personal row is not selectable by a key that names no person
+    Given a personal development agent owned by user "u_1"
+    When a project key lists the project's agents
+    Then the row is marked as not selectable
+
+  @unit
+  Scenario: The listing mark and the run refusal read one rule
+    Given a set of connected agents and a caller
+    When each agent is read for the listing mark and for the run refusal
+    Then an agent marked not selectable is exactly one the run refuses with "agent_owner_only"
+
+  # ---------------------------------------------------------------------------
   # Presence
   # ---------------------------------------------------------------------------
 

--- a/specs/api-keys/unified-api-keys.feature
+++ b/specs/api-keys/unified-api-keys.feature
@@ -389,3 +389,41 @@ Feature: Unified API Keys
     Given a key id that is unknown, or belongs to another organization
     When I look it up against my own organization
     Then I get nothing back, so the two cases are indistinguishable
+
+  # ── The grants have to land before the key is handed out ───────
+
+  # A key row is a plain insert and its grants are ledger commands, so the two
+  # cannot share a transaction. The key is written revoked and un-revoked last,
+  # once its grants are readable. "Readable" is the part that was missing: a
+  # durable append whose projection had not landed yet counted as a grant, and
+  # the mutation answered with a live key that every route then refused.
+
+  @unit
+  Scenario: A key whose grants did not become readable is never activated
+    Given the grant write is durable but its projection has not landed
+    When I create an API key
+    Then the create fails with "authz_grant_not_confirmed"
+    And the key row is left revoked
+    And no token is returned
+
+  @unit
+  Scenario: A key whose custom role did not become readable is never activated
+    Given a restricted key whose role definition has not landed in the projection
+    When I create the API key
+    Then the create fails with "authz_grant_not_confirmed"
+    And the key row is left revoked
+
+  @unit
+  Scenario: A key whose grants are readable is activated and returned
+    Given the grant write lands in the projection
+    When I create an API key
+    Then the key row is activated
+    And the token is returned
+
+  @unit
+  Scenario: Replacing a key's grants keeps the old ones when the new ones do not land
+    Given an API key with grants
+    And the grant write is durable but its projection has not landed
+    When I replace its grants
+    Then the update fails with "authz_grant_not_confirmed"
+    And nothing the key already held is revoked

--- a/specs/api-keys/unified-api-keys.feature
+++ b/specs/api-keys/unified-api-keys.feature
@@ -427,3 +427,11 @@ Feature: Unified API Keys
     When I replace its grants
     Then the update fails with "authz_grant_not_confirmed"
     And nothing the key already held is revoked
+
+  @unit
+  Scenario: Replacing a key's grants leaves its metadata alone when the new ones do not land
+    Given an API key with grants
+    And the grant write is durable but its projection has not landed
+    When I replace its grants and its permission mode in one edit
+    Then the update fails with "authz_grant_not_confirmed"
+    And the key still reads with the name and permission mode it had

--- a/specs/api-reference/exclusive-bounds-3-1.feature
+++ b/specs/api-reference/exclusive-bounds-3-1.feature
@@ -1,0 +1,38 @@
+@unit
+Feature: Exclusive bounds are written the way OpenAPI 3.1 reads them
+  As an integrator generating a client from the API document
+  I want a bound like "greater than zero" to survive into my client
+  So that the generated types keep the constraint the route enforces
+
+  # The document declares openapi 3.1.0, where a schema is JSON Schema 2020-12
+  # and exclusiveMinimum / exclusiveMaximum are numbers. The schema builders
+  # still emit the 3.0 spelling: a boolean flag beside a minimum or maximum.
+  # A strict validator rejects it and a client generator drops the bound, so a
+  # positive integer reached integrators as an unbounded one.
+
+  Scenario: A boolean exclusive bound is rewritten as the number it meant
+    Given a schema with "minimum" 0 and "exclusiveMinimum" true
+    When the document is written
+    Then the schema reads "exclusiveMinimum" 0
+    And it carries no "minimum"
+
+  Scenario: The same holds for an upper bound
+    Given a schema with "maximum" 100 and "exclusiveMaximum" true
+    When the document is written
+    Then the schema reads "exclusiveMaximum" 100
+    And it carries no "maximum"
+
+  Scenario: An inclusive bound is left as it was
+    Given a schema with "minimum" 0 and "exclusiveMinimum" false
+    When the document is written
+    Then the schema reads "minimum" 0
+    And it carries no "exclusiveMinimum"
+
+  Scenario: A flag with no bound beside it is dropped
+    Given a schema with "exclusiveMinimum" true and no "minimum"
+    When the document is written
+    Then the schema carries no "exclusiveMinimum"
+
+  Scenario: The published document carries no boolean exclusive bound
+    When I read the generated OpenAPI document
+    Then no schema in it spells an exclusive bound as a boolean

--- a/specs/features/agents/connected-agents-ui.feature
+++ b/specs/features/agents/connected-agents-ui.feature
@@ -67,6 +67,20 @@ Feature: Connected agents in the product
     Then it carries a chip with the owner's name
 
   @integration
+  Scenario: A card the reader cannot choose says who holds it
+    Given "support-agent" in "development" belongs to another person
+    When the card is drawn
+    Then it carries a chip with the owner's name
+    And the chip says only that person can run the agent
+
+  @integration
+  Scenario: A card the reader can choose carries no refusal
+    Given "support-agent" in "development" belongs to the reader
+    When the card is drawn
+    Then it carries a chip with the owner's name
+    And the chip says nothing about who can run the agent
+
+  @integration
   Scenario: A shared development agent reads the machine that holds it
     Given "support-agent" in "development" belongs to no person and names a machine
     When the card is drawn

--- a/specs/features/agents/connected-agents-ui.feature
+++ b/specs/features/agents/connected-agents-ui.feature
@@ -72,6 +72,7 @@ Feature: Connected agents in the product
     When the card is drawn
     Then it carries a chip with the owner's name
     And the chip says only that person can run the agent
+    And the chip takes the tab order, so the reason is reachable by keyboard
 
   @integration
   Scenario: A card the reader can choose carries no refusal
@@ -79,6 +80,7 @@ Feature: Connected agents in the product
     When the card is drawn
     Then it carries a chip with the owner's name
     And the chip says nothing about who can run the agent
+    And the chip stays out of the tab order
 
   @integration
   Scenario: A shared development agent reads the machine that holds it

--- a/specs/mcp-server/agent-tools.feature
+++ b/specs/mcp-server/agent-tools.feature
@@ -23,6 +23,12 @@ Feature: Agent tools expose connected agents and run them through the relay
       Then the parameters read their type, options, default and required
       And each instance reads its hostname, label and connection time
 
+    Scenario: A listed agent the key cannot choose says so
+      Given a personal development agent owned by another person
+      When the agent calls platform_list_agents
+      Then the entry is listed with its owner
+      And it says only its owner can run it
+
     Scenario: The listing keeps the HTTP agent entry unchanged
       Given an HTTP agent
       When the agent calls platform_list_agents

--- a/specs/rbac/authz-grants.feature
+++ b/specs/rbac/authz-grants.feature
@@ -303,6 +303,40 @@ Feature: Authorization grants
     Then the orphaned binding's revocation is issued before the edit commits
     And a failure to revoke fails the edit
 
+
+  # ═══ Read-your-writes ═════════════════════════════════════════════════
+
+  # An attach and a role definition hold, bounded, for the projection to make
+  # their rows readable. Timing out is normally not a failure: the append is
+  # durable and the fold converges. It IS a failure for a caller whose next
+  # step hands out access these rows decide, which is what `requireProjection`
+  # states.
+
+  @unit
+  Scenario: A write that nobody reads next passes when the projection lags
+    Given an attach whose caller does not require the projection
+    When the read-your-writes window passes with the rows not readable
+    Then the write is reported as done
+    And the lag is logged
+
+  @unit
+  Scenario: A write whose caller requires the projection fails when it lags
+    Given an attach whose caller requires the projection
+    When the read-your-writes window passes with the rows not readable
+    Then the write fails with "authz_grant_not_confirmed"
+
+  @unit
+  Scenario: A role definition whose caller requires the projection fails when it lags
+    Given a role definition whose caller requires the projection
+    When the read-your-writes window passes with the row not readable
+    Then the write fails with "authz_grant_not_confirmed"
+
+  @unit
+  Scenario: A required write that lands inside the window passes
+    Given an attach whose caller requires the projection
+    When the rows become readable inside the window
+    Then the write is reported as done
+
   # ═══ The projection ═══════════════════════════════════════════════════
 
   @unit @unimplemented

--- a/specs/rbac/authz-grants.feature
+++ b/specs/rbac/authz-grants.feature
@@ -337,6 +337,12 @@ Feature: Authorization grants
     When the rows become readable inside the window
     Then the write is reported as done
 
+  @unit
+  Scenario: Requiring the projection waits for it even when the wait is switched off
+    Given an attach whose caller requires the projection and asks not to wait
+    When the read-your-writes window passes with the rows not readable
+    Then the write fails with "authz_grant_not_confirmed"
+
   # ═══ The projection ═══════════════════════════════════════════════════
 
   @unit @unimplemented

--- a/specs/typescript-sdk/cli-agents.feature
+++ b/specs/typescript-sdk/cli-agents.feature
@@ -30,6 +30,18 @@ Feature: The agent commands show connected agents and run them through the relay
       Then the first row names the user
       And the second row names the host label
 
+    Scenario: A row the key cannot choose reads as not selectable
+      Given a personal development agent owned by another person
+      When I run "langwatch agent list"
+      Then the row is listed
+      And its owner cell is marked "owner only"
+
+    Scenario: The detail says whether the key can choose the agent
+      Given a personal development agent owned by another person
+      When I run "langwatch agent get <id>"
+      Then the detail names the owner
+      And it says only its owner can run it
+
   Rule: The detail shows the parameters an agent declared and its instances
 
     Scenario: The detail lists parameters with type, options, default and required


### PR DESCRIPTION
Two connected agent and API key defects reported from a local stack on 2026-09-03.

Closes #7846
Closes #7847

## #7846: apiKey.create answered 200 with a key whose grant never landed

### What it was

On a degraded ClickHouse (`SELECT 1` took 7.8 s) the tRPC `apiKey.create` mutation returned a live key three times in a row while the grant it must record never became readable. Every route then refused the key with "does not grant langy:view".

The key row was already born revoked and activated last, so the ordering was right. The hole was one level down: `GrantsLedgerWriter.attachBindings` waits, bounded, for the projection to make the new rows readable, and a wait that ran out **logged a warning and returned normally**. The append was durable, so from the mint's point of view the grants were facts, and it went on to activate the key.

### The approach, and why

Both options in the issue, in the order that keeps them honest: **confirm the grant, and fail the mutation when the confirmation does not arrive.**

Confirming alone is not enough because the confirmation already existed and was being thrown away. Failing alone would refuse mints that are merely a fold cycle behind. So `awaitProjection` now answers whether the rows landed, and a caller states whether that answer matters:

- `attachBindings` and `defineRole` take `requireProjection`, off by default. For most callers a durable append plus a converging fold is the correct, normal outcome, and refusing them would turn a lagging fold into a broken product.
- The API-key writes turn it on, because their next step hands out access these very rows decide. A create activates the credential; a replace revokes whatever the attach did not keep.

An unconfirmed write now raises `AuthzGrantNotConfirmedError`: code `authz_grant_not_confirmed`, `fault: "platform"` (a lagging fold is ours, not the customer's), HTTP 503, a customer-safe message, an entry in `features/errors/logic/codes.ts` and its copy in the client presentation registry.

### What a failed create leaves behind

The key row, revoked, holding no bindings. It is written with `startsDisabled`, the refusal happens before `activate`, and nothing clears `revokedAt` afterwards, so the token that was never returned could not authenticate even if somebody held it. The ledger append may still converge later and attach grants to that row; they are inert, because the key stays revoked forever. The integration test asserts exactly this: the count of live keys in the organization does not move, and the stranded row is revoked with zero role bindings.

The same rule protects a replace: the attach is confirmed before anything is revoked, so a key keeps the grants it already had rather than losing them to an unconfirmed replacement.

### The Langy fixture probe

`platform/app/e2e/langy/local-control-fixture.ts` was left as it is. The mutation is now the guard for keys minted through this path, but the fixture probes a key it did not necessarily mint in that same process, and a fixture that proves its own preconditions before a long scenario run is cheap and still worth having. Nothing in it depends on the old behaviour.

## #7847: two rows of one name, and no way to tell which one you can use

### What it was

One agent name and one environment held two rows: `acme-support@development/user:<id>` and `acme-support@development/host:<machine>`. The listings did return both, but nothing on the wire said which of them the caller could actually run, and the difference only surfaced later as an `agent_owner_only` refusal or as a reference that silently resolved to the host row.

The owner picked the second option in the issue: an owner the user can see, and a listing that returns every row the caller may see, marked.

### What changed

- One rule, in `server/connected-agents/selectable.ts`: a row that belongs to nobody is everybody's to run; a row that belongs to a person is theirs alone. Three readers now share it instead of writing it out three times: the listings that mark rows, `assertConnectedAgentsRunnable` that refuses a run, and the scenario target picker in the browser. A unit test pins that a row marked not selectable is exactly a row the run refuses.
- Every agent read carries `selectable` and `notSelectableReason` beside `owner`, on tRPC and on `GET /api/v1/agents` (and `/:id`). The reason is a stable enum, `owned_by_another_person`, so a client can explain the refusal in its own words.
- Nothing anyone is permitted to see changed. The listing was already unfiltered by owner and stays so; the selection and tenancy rules are untouched. What is new is that a row you may read but may not choose says so.
- The agents page keeps the owner chip it already had and, for a row the reader cannot run, explains on hover why, in the same words the refused run uses.
- `langwatch agent list` marks the owner cell `owner only`, `langwatch agent get` prints a `Run:` line, and the MCP `platform_list_agents` and `platform_get_agent` entries say the same.
- The OpenAPI document and the docs copy were regenerated for the two new response fields.

![The agents page with three rows of one name: a machine, another person, and the reader](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/langy-local-dev/agents-owner-and-selectability.png)

## Verified

- `pnpm typecheck:all`, biome on the touched files (no new complexity violation against main), eslint on the touched SDK files, `check:feature-parity` green with every touched spec fully bound.
- New specs in `specs/rbac/authz-grants.feature`, `specs/api-keys/unified-api-keys.feature`, `specs/agents/connected-agents.feature`, `specs/agents/agents-rest-api.feature`, `specs/features/agents/connected-agents-ui.feature`, `specs/typescript-sdk/cli-agents.feature` and `specs/mcp-server/agent-tools.feature`, each bound by a test.
- #7846 reproduced against a real Postgres in `api-key.grant-confirmation.integration.test.ts`: with a command sender whose fold never applies the write, the mint refuses with `authz_grant_not_confirmed` and leaves a revoked, grantless row; with a sender that lands the row, the same mint returns a token that verifies.
- #7847 checked in a browser on the local stack with three rows of one name in one environment. A project key over `GET /api/v1/agents` returns all of them, with the personal row marked `selectable: false` and `notSelectableReason: owned_by_another_person`, and the two host-scoped rows selectable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Agent listings now show whether each agent can be run by the current user or key.
  - Agents owned by someone else remain visible but are clearly marked as owner-only across the web app, CLI, MCP tools, and APIs.
  - API responses include ownership and run-eligibility details.
  - API key creation and permission updates now confirm authorization changes before activation.
- **Bug Fixes**
  - Failed authorization confirmation now leaves keys inactive and provides a clear retry message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->