### PR TITLE
fix(traces): keep the chosen time range when opening a conversation

### DIFF
--- a/platform/app/src/hooks/__tests__/useDrawer.liveFragment.integration.test.tsx
+++ b/platform/app/src/hooks/__tests__/useDrawer.liveFragment.integration.test.tsx
@@ -134,4 +134,51 @@ describe("useDrawer URL fragment", () => {
       expect(pushed).not.toContain("#");
     });
   });
+
+  describe("given the router already knows about a fragment carrying bar state", () => {
+    beforeEach(() => {
+      // A full page load on a shared link: React Router sees the whole
+      // fragment, `preset` and all, so nothing is stale here.
+      staleRouterHash = "#all-traces?preset=24h";
+      window.history.replaceState({}, "", "/acme/traces#all-traces?preset=24h");
+    });
+
+    describe("when a drawer is opened", () => {
+      it("leaves the bar state in the fragment instead of copying it into the query", () => {
+        const { result } = renderHook(() => useDrawer());
+
+        act(() => {
+          result.current.openDrawer("traceV2Details", { traceId: "trace-1" });
+        });
+
+        const pushed = mockPush.mock.calls[0]?.[0] as string;
+        expect(pushed).toContain("#all-traces?preset=24h");
+        const [beforeHash] = pushed.split("#");
+        expect(beforeHash).not.toContain("preset");
+      });
+    });
+  });
+
+  describe("given drawer params were parked after the fragment", () => {
+    it("still lifts them back into the real query string", () => {
+      // The case the fragment/query split exists for: a malformed URL where
+      // `drawer.*` sits after the `#`, where `router.query` cannot see it.
+      staleRouterHash = "#conversations?drawer.open=traceV2Details";
+      window.history.replaceState(
+        {},
+        "",
+        "/acme/traces#conversations?drawer.open=traceV2Details",
+      );
+      const { result } = renderHook(() => useUpdateDrawerParams());
+
+      act(() => {
+        result.current({ mode: "conversation" });
+      });
+
+      const pushed = mockPush.mock.calls[0]?.[0] as string;
+      const [beforeHash] = pushed.split("#");
+      expect(beforeHash).toContain("drawer.open=traceV2Details");
+      expect(beforeHash).toContain("drawer.mode=conversation");
+    });
+  });
 });

--- a/platform/app/src/hooks/__tests__/useDrawer.liveFragment.integration.test.tsx
+++ b/platform/app/src/hooks/__tests__/useDrawer.liveFragment.integration.test.tsx
@@ -1,0 +1,137 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  clearDrawerStack,
+  clearFlowCallbacks,
+  useDrawer,
+  useUpdateDrawerParams,
+} from "../useDrawer";
+
+const mockPush = vi.fn();
+const mockReplace = vi.fn();
+
+/**
+ * The hash React Router still believes the page is on. The traces bar state
+ * moves the real fragment with a raw `history.replaceState`, which the router
+ * never observes, so its copy lags behind from the first filter edit onwards.
+ */
+let staleRouterHash = "";
+let routerQuery: Record<string, string> = {};
+
+vi.mock("~/utils/compat/next-router", () => ({
+  useRouter: () => ({
+    query: routerQuery,
+    pathname: "/acme/traces",
+    asPath:
+      "/acme/traces" +
+      (Object.keys(routerQuery).length > 0
+        ? "?" + new URLSearchParams(routerQuery).toString()
+        : "") +
+      staleRouterHash,
+    push: mockPush,
+    replace: mockReplace,
+  }),
+}));
+
+describe("useDrawer URL fragment", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    routerQuery = {};
+    staleRouterHash = "";
+    window.history.replaceState({}, "", "/acme/traces");
+    clearDrawerStack();
+    clearFlowCallbacks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  describe("given the traces page moved the fragment behind React Router's back", () => {
+    beforeEach(() => {
+      // What the user did: opened the Conversations lens (a router
+      // navigation, so the router saw it), then narrowed the window to 24
+      // hours (a raw replaceState, so it did not).
+      staleRouterHash = "#conversations";
+      window.history.replaceState(
+        {},
+        "",
+        "/acme/traces#conversations?preset=24h",
+      );
+    });
+
+    describe("when a drawer is opened", () => {
+      it("republishes the fragment the browser is actually on", () => {
+        const { result } = renderHook(() => useDrawer());
+
+        act(() => {
+          result.current.openDrawer("traceV2Details", { traceId: "trace-1" });
+        });
+
+        const pushed = mockPush.mock.calls[0]?.[0] as string;
+        expect(pushed).toContain("drawer.open=traceV2Details");
+        expect(pushed).toContain("#conversations?preset=24h");
+      });
+    });
+
+    describe("when the drawer is closed", () => {
+      it("republishes the fragment the browser is actually on", () => {
+        const { result } = renderHook(() => useDrawer());
+
+        act(() => {
+          result.current.closeDrawer();
+        });
+
+        const pushed = mockPush.mock.calls[0]?.[0] as string;
+        expect(pushed).toContain("#conversations?preset=24h");
+      });
+    });
+
+    describe("when drawer params are updated", () => {
+      it("republishes the fragment the browser is actually on", () => {
+        const { result } = renderHook(() => useUpdateDrawerParams());
+
+        act(() => {
+          result.current({ mode: "conversation" });
+        });
+
+        const pushed = mockPush.mock.calls[0]?.[0] as string;
+        expect(pushed).toContain("#conversations?preset=24h");
+      });
+    });
+  });
+
+  describe("given the browser and the router agree on the fragment", () => {
+    it("keeps that fragment", () => {
+      staleRouterHash = "#conversations";
+      window.history.replaceState({}, "", "/acme/traces#conversations");
+      const { result } = renderHook(() => useDrawer());
+
+      act(() => {
+        result.current.openDrawer("traceV2Details", { traceId: "trace-1" });
+      });
+
+      const pushed = mockPush.mock.calls[0]?.[0] as string;
+      expect(pushed).toContain("#conversations");
+      expect(pushed).not.toContain("preset");
+    });
+  });
+
+  describe("given no fragment at all", () => {
+    it("pushes a URL without one", () => {
+      const { result } = renderHook(() => useDrawer());
+
+      act(() => {
+        result.current.openDrawer("traceV2Details", { traceId: "trace-1" });
+      });
+
+      const pushed = mockPush.mock.calls[0]?.[0] as string;
+      expect(pushed).not.toContain("#");
+    });
+  });
+});

--- a/platform/app/src/hooks/__tests__/useDrawer.liveFragment.integration.test.tsx
+++ b/platform/app/src/hooks/__tests__/useDrawer.liveFragment.integration.test.tsx
@@ -160,7 +160,7 @@ describe("useDrawer URL fragment", () => {
   });
 
   describe("given drawer params were parked after the fragment", () => {
-    it("still lifts them back into the real query string", () => {
+    beforeEach(() => {
       // The case the fragment/query split exists for: a malformed URL where
       // `drawer.*` sits after the `#`, where `router.query` cannot see it.
       staleRouterHash = "#conversations?drawer.open=traceV2Details";
@@ -169,39 +169,38 @@ describe("useDrawer URL fragment", () => {
         "",
         "/acme/traces#conversations?drawer.open=traceV2Details",
       );
-      const { result } = renderHook(() => useUpdateDrawerParams());
-
-      act(() => {
-        result.current({ mode: "conversation" });
-      });
-
-      const pushed = mockPush.mock.calls[0]?.[0] as string;
-      const [beforeHash] = pushed.split("#");
-      expect(beforeHash).toContain("drawer.open=traceV2Details");
-      expect(beforeHash).toContain("drawer.mode=conversation");
     });
 
-    it("leaves no copy of them behind in the fragment", () => {
-      // Lifting a param out of the fragment has to remove it from there too.
-      // A leftover `drawer.open` in the fragment is a stale snapshot that the
-      // next drawer navigation lifts again — closing the drawer and then
-      // opening another one would resurrect the old one.
-      staleRouterHash = "#conversations?drawer.open=traceV2Details";
-      window.history.replaceState(
-        {},
-        "",
-        "/acme/traces#conversations?drawer.open=traceV2Details",
-      );
-      const { result } = renderHook(() => useUpdateDrawerParams());
+    describe("when drawer params are updated", () => {
+      it("still lifts them back into the real query string", () => {
+        const { result } = renderHook(() => useUpdateDrawerParams());
 
-      act(() => {
-        result.current({ mode: "conversation" });
+        act(() => {
+          result.current({ mode: "conversation" });
+        });
+
+        const pushed = mockPush.mock.calls[0]?.[0] as string;
+        const [beforeHash] = pushed.split("#");
+        expect(beforeHash).toContain("drawer.open=traceV2Details");
+        expect(beforeHash).toContain("drawer.mode=conversation");
       });
 
-      const pushed = mockPush.mock.calls[0]?.[0] as string;
-      expect(pushed).toContain("#conversations");
-      const afterHash = pushed.slice(pushed.indexOf("#"));
-      expect(afterHash).toBe("#conversations");
+      it("leaves no copy of them behind in the fragment", () => {
+        // Lifting a param out of the fragment has to remove it from there too.
+        // A leftover `drawer.open` in the fragment is a stale snapshot that the
+        // next drawer navigation lifts again — closing the drawer and then
+        // opening another one would resurrect the old one.
+        const { result } = renderHook(() => useUpdateDrawerParams());
+
+        act(() => {
+          result.current({ mode: "conversation" });
+        });
+
+        const pushed = mockPush.mock.calls[0]?.[0] as string;
+        expect(pushed).toContain("#conversations");
+        const afterHash = pushed.slice(pushed.indexOf("#"));
+        expect(afterHash).toBe("#conversations");
+      });
     });
   });
 });

--- a/platform/app/src/hooks/__tests__/useDrawer.liveFragment.integration.test.tsx
+++ b/platform/app/src/hooks/__tests__/useDrawer.liveFragment.integration.test.tsx
@@ -203,4 +203,59 @@ describe("useDrawer URL fragment", () => {
       });
     });
   });
+
+  describe("given drawer params were parked after the fragment of a URL that already had a query", () => {
+    beforeEach(() => {
+      // Same malformed shape, but with a real query string in front of the
+      // `#`. The two orderings used to be parsed by different branches, and
+      // only one of them rescued `drawer.` params — so a filter on the URL
+      // was enough to strand the drawer after the fragment.
+      routerQuery = { filter: "active" };
+      staleRouterHash = "#conversations?drawer.open=traceV2Details";
+      window.history.replaceState(
+        {},
+        "",
+        "/acme/traces?filter=active#conversations?drawer.open=traceV2Details",
+      );
+    });
+
+    describe("when drawer params are updated", () => {
+      it("lifts them back into the real query string", () => {
+        const { result } = renderHook(() => useUpdateDrawerParams());
+
+        act(() => {
+          result.current({ mode: "conversation" });
+        });
+
+        const pushed = mockPush.mock.calls[0]?.[0] as string;
+        const [beforeHash] = pushed.split("#");
+        expect(beforeHash).toContain("drawer.open=traceV2Details");
+        expect(beforeHash).toContain("drawer.mode=conversation");
+      });
+
+      it("keeps the query that was already there", () => {
+        const { result } = renderHook(() => useUpdateDrawerParams());
+
+        act(() => {
+          result.current({ mode: "conversation" });
+        });
+
+        const pushed = mockPush.mock.calls[0]?.[0] as string;
+        const [beforeHash] = pushed.split("#");
+        expect(beforeHash).toContain("filter=active");
+      });
+
+      it("leaves no copy of them behind in the fragment", () => {
+        const { result } = renderHook(() => useUpdateDrawerParams());
+
+        act(() => {
+          result.current({ mode: "conversation" });
+        });
+
+        const pushed = mockPush.mock.calls[0]?.[0] as string;
+        const afterHash = pushed.slice(pushed.indexOf("#"));
+        expect(afterHash).toBe("#conversations");
+      });
+    });
+  });
 });

--- a/platform/app/src/hooks/__tests__/useDrawer.liveFragment.integration.test.tsx
+++ b/platform/app/src/hooks/__tests__/useDrawer.liveFragment.integration.test.tsx
@@ -107,31 +107,38 @@ describe("useDrawer URL fragment", () => {
   });
 
   describe("given the browser and the router agree on the fragment", () => {
-    it("keeps that fragment", () => {
+    beforeEach(() => {
       staleRouterHash = "#conversations";
       window.history.replaceState({}, "", "/acme/traces#conversations");
-      const { result } = renderHook(() => useDrawer());
+    });
 
-      act(() => {
-        result.current.openDrawer("traceV2Details", { traceId: "trace-1" });
+    describe("when a drawer is opened", () => {
+      it("keeps that fragment", () => {
+        const { result } = renderHook(() => useDrawer());
+
+        act(() => {
+          result.current.openDrawer("traceV2Details", { traceId: "trace-1" });
+        });
+
+        const pushed = mockPush.mock.calls[0]?.[0] as string;
+        expect(pushed).toContain("#conversations");
+        expect(pushed).not.toContain("preset");
       });
-
-      const pushed = mockPush.mock.calls[0]?.[0] as string;
-      expect(pushed).toContain("#conversations");
-      expect(pushed).not.toContain("preset");
     });
   });
 
   describe("given no fragment at all", () => {
-    it("pushes a URL without one", () => {
-      const { result } = renderHook(() => useDrawer());
+    describe("when a drawer is opened", () => {
+      it("pushes a URL without one", () => {
+        const { result } = renderHook(() => useDrawer());
 
-      act(() => {
-        result.current.openDrawer("traceV2Details", { traceId: "trace-1" });
+        act(() => {
+          result.current.openDrawer("traceV2Details", { traceId: "trace-1" });
+        });
+
+        const pushed = mockPush.mock.calls[0]?.[0] as string;
+        expect(pushed).not.toContain("#");
       });
-
-      const pushed = mockPush.mock.calls[0]?.[0] as string;
-      expect(pushed).not.toContain("#");
     });
   });
 
@@ -200,6 +207,51 @@ describe("useDrawer URL fragment", () => {
         expect(pushed).toContain("#conversations");
         const afterHash = pushed.slice(pushed.indexOf("#"));
         expect(afterHash).toBe("#conversations");
+      });
+    });
+  });
+
+  describe("given the fragment carries both bar state and a parked drawer param", () => {
+    beforeEach(() => {
+      // The realistic version of the malformed shape: the user has already
+      // narrowed the window, so the bar's `preset` is sitting in the fragment
+      // when a `drawer.` param gets parked alongside it.
+      staleRouterHash = "#conversations?preset=24h&drawer.open=traceV2Details";
+      window.history.replaceState(
+        {},
+        "",
+        "/acme/traces#conversations?preset=24h&drawer.open=traceV2Details",
+      );
+    });
+
+    describe("when drawer params are updated", () => {
+      it("lifts only the drawer param into the real query string", () => {
+        const { result } = renderHook(() => useUpdateDrawerParams());
+
+        act(() => {
+          result.current({ mode: "conversation" });
+        });
+
+        const pushed = mockPush.mock.calls[0]?.[0] as string;
+        const [beforeHash] = pushed.split("#");
+        expect(beforeHash).toContain("drawer.open=traceV2Details");
+        expect(beforeHash).toContain("drawer.mode=conversation");
+        expect(beforeHash).not.toContain("preset");
+      });
+
+      it("leaves the bar state in the fragment", () => {
+        // Carrying `preset` out of the fragment is the bug this whole file
+        // exists to fix — the traces bar reads the time range from there, and
+        // loses it the moment something else takes it away.
+        const { result } = renderHook(() => useUpdateDrawerParams());
+
+        act(() => {
+          result.current({ mode: "conversation" });
+        });
+
+        const pushed = mockPush.mock.calls[0]?.[0] as string;
+        const afterHash = pushed.slice(pushed.indexOf("#"));
+        expect(afterHash).toBe("#conversations?preset=24h");
       });
     });
   });

--- a/platform/app/src/hooks/__tests__/useDrawer.liveFragment.integration.test.tsx
+++ b/platform/app/src/hooks/__tests__/useDrawer.liveFragment.integration.test.tsx
@@ -180,5 +180,28 @@ describe("useDrawer URL fragment", () => {
       expect(beforeHash).toContain("drawer.open=traceV2Details");
       expect(beforeHash).toContain("drawer.mode=conversation");
     });
+
+    it("leaves no copy of them behind in the fragment", () => {
+      // Lifting a param out of the fragment has to remove it from there too.
+      // A leftover `drawer.open` in the fragment is a stale snapshot that the
+      // next drawer navigation lifts again — closing the drawer and then
+      // opening another one would resurrect the old one.
+      staleRouterHash = "#conversations?drawer.open=traceV2Details";
+      window.history.replaceState(
+        {},
+        "",
+        "/acme/traces#conversations?drawer.open=traceV2Details",
+      );
+      const { result } = renderHook(() => useUpdateDrawerParams());
+
+      act(() => {
+        result.current({ mode: "conversation" });
+      });
+
+      const pushed = mockPush.mock.calls[0]?.[0] as string;
+      expect(pushed).toContain("#conversations");
+      const afterHash = pushed.slice(pushed.indexOf("#"));
+      expect(afterHash).toBe("#conversations");
+    });
   });
 });

--- a/platform/app/src/hooks/useDrawer.ts
+++ b/platform/app/src/hooks/useDrawer.ts
@@ -399,7 +399,22 @@ function rescueFragmentQuery(hash: string): {
   if (q === -1) return { queryString: "", hash };
   const fragmentQuery = hash.slice(q + 1);
   if (!/(^|&)drawer\./.test(fragmentQuery)) return { queryString: "", hash };
-  return { queryString: fragmentQuery, hash: hash.slice(0, q) };
+
+  // Only the `drawer.` pairs move. A fragment query can hold both — the bar
+  // sets `preset` and something then parks `drawer.open` alongside it — and
+  // lifting the whole thing would carry `preset` out of the fragment its owner
+  // reads, resetting the time range: the very bug this file is fixing.
+  const lifted: string[] = [];
+  const kept: string[] = [];
+  for (const pair of fragmentQuery.split("&")) {
+    if (!pair) continue;
+    (pair.startsWith("drawer.") ? lifted : kept).push(pair);
+  }
+  const fragment = hash.slice(0, q);
+  return {
+    queryString: lifted.join("&"),
+    hash: kept.length > 0 ? `${fragment}?${kept.join("&")}` : fragment,
+  };
 }
 
 /**

--- a/platform/app/src/hooks/useDrawer.ts
+++ b/platform/app/src/hooks/useDrawer.ts
@@ -344,6 +344,13 @@ export const useDrawerParams = () => {
  * `#h?q` orderings — important for lens routes like `/traces#conversations`
  * where naive concatenation can leave drawer query params parked after the
  * hash, which Next's `router.query` (backed by `location.search`) cannot see.
+ *
+ * A `?` inside the fragment is not automatically a misplaced query, though: the
+ * traces bar keeps its own state there (`#conversations?preset=24h`), and
+ * lifting that into the real query string would both duplicate it and leave a
+ * stale `preset` parked on the URL. So the rescue only fires for a fragment
+ * query that actually carries `drawer.` params — everything else stays in the
+ * fragment, where its owner reads it from.
  */
 function splitAsPath(asPath: string): {
   path: string;
@@ -365,7 +372,11 @@ function splitAsPath(asPath: string): {
   if (rest.startsWith("#")) {
     const q = rest.indexOf("?");
     if (q === -1) return { path, queryString: "", hash: rest.slice(1) };
-    return { path, queryString: rest.slice(q + 1), hash: rest.slice(1, q) };
+    const fragmentQuery = rest.slice(q + 1);
+    if (!/(^|&)drawer\./.test(fragmentQuery)) {
+      return { path, queryString: "", hash: rest.slice(1) };
+    }
+    return { path, queryString: fragmentQuery, hash: rest.slice(1, q) };
   }
   return { path, queryString: "", hash: "" };
 }

--- a/platform/app/src/hooks/useDrawer.ts
+++ b/platform/app/src/hooks/useDrawer.ts
@@ -260,7 +260,12 @@ export const useUpdateDrawerParams = () => {
       options: { push?: boolean } = {},
     ) => {
       const push = options.push ?? true;
-      const { path, queryString, hash } = splitAsPath(router.asPath);
+      const {
+        path,
+        queryString,
+        hash: routerHash,
+      } = splitAsPath(router.asPath);
+      const hash = liveHash() ?? routerHash;
       const parsed = qs.parse(queryString, URL_QS_PARSE_OPTIONS) as Record<
         string,
         unknown
@@ -365,6 +370,29 @@ function splitAsPath(asPath: string): {
   return { path, queryString: "", hash: "" };
 }
 
+/**
+ * The URL fragment as the browser holds it right now, rather than as React
+ * Router remembers it.
+ *
+ * The traces page keeps its bar state — active lens, query, time range — in
+ * the fragment, and writes it with a raw `history.replaceState`
+ * (`useURLSync`). React Router never observes that write, so the hash inside
+ * `router.asPath` is whatever the last router navigation left behind. Every
+ * drawer URL below is rebuilt from `asPath` and republished through
+ * `router.push`, which turned a stale hash into a real navigation: pick a
+ * 24-hour window, open a conversation, and the page re-applied the fragment
+ * from before the pick — snapping the table back to the 30-day default.
+ *
+ * Only the fragment is read live. Path and query move exclusively through the
+ * router, so `asPath` is authoritative for those; the fragment is the one axis
+ * something else writes behind its back (the traces bar state, and the
+ * onboarding spotlight marker).
+ */
+function liveHash(): string | null {
+  if (typeof window === "undefined") return null;
+  return window.location.hash.replace(/^#/, "");
+}
+
 function buildUrl(path: string, queryString: string, hash: string): string {
   let url = path;
   if (queryString) url += `?${queryString}`;
@@ -432,7 +460,12 @@ export const useDrawer = () => {
       // Build query from the actual browser URL (router.asPath), not
       // router.query which may be stale after (url, as) shallow pushes.
       // This preserves filter params that only exist in the asPath URL.
-      const { path, queryString, hash } = splitAsPath(router.asPath);
+      const {
+        path,
+        queryString,
+        hash: routerHash,
+      } = splitAsPath(router.asPath);
+      const hash = liveHash() ?? routerHash;
       const currentQueryOnly = Object.fromEntries(
         Object.entries(qs.parse(queryString, URL_QS_PARSE_OPTIONS)).filter(
           ([key]) => !key.startsWith("drawer"),
@@ -608,7 +641,12 @@ export const useDrawer = () => {
 
     // Build clean URL from asPath (not router.query which may be stale
     // after (url, as) shallow pushes and misses filter params).
-    const { path, queryString: currentQs, hash } = splitAsPath(router.asPath);
+    const {
+      path,
+      queryString: currentQs,
+      hash: routerHash,
+    } = splitAsPath(router.asPath);
+    const hash = liveHash() ?? routerHash;
     const parsedQuery = qs.parse(currentQs, URL_QS_PARSE_OPTIONS);
     const cleanQuery = Object.fromEntries(
       Object.entries(parsedQuery).filter(

--- a/platform/app/src/hooks/useDrawer.ts
+++ b/platform/app/src/hooks/useDrawer.ts
@@ -364,18 +364,42 @@ function splitAsPath(asPath: string): {
   if (rest.startsWith("?")) {
     const h = rest.indexOf("#");
     if (h === -1) return { path, queryString: rest.slice(1), hash: "" };
-    return { path, queryString: rest.slice(1, h), hash: rest.slice(h + 1) };
+    const query = rest.slice(1, h);
+    const rescued = rescueFragmentQuery(rest.slice(h + 1));
+    return {
+      path,
+      queryString: [query, rescued.queryString].filter(Boolean).join("&"),
+      hash: rescued.hash,
+    };
   }
   if (rest.startsWith("#")) {
-    const q = rest.indexOf("?");
-    if (q === -1) return { path, queryString: "", hash: rest.slice(1) };
-    const fragmentQuery = rest.slice(q + 1);
-    if (!/(^|&)drawer\./.test(fragmentQuery)) {
-      return { path, queryString: "", hash: rest.slice(1) };
-    }
-    return { path, queryString: fragmentQuery, hash: rest.slice(1, q) };
+    return { path, ...rescueFragmentQuery(rest.slice(1)) };
   }
   return { path, queryString: "", hash: "" };
+}
+
+/**
+ * Pull a fragment apart into the part that belongs in the real query string and
+ * the part that stays a fragment.
+ *
+ * Shared by both orderings on purpose. A URL can reach us as `#h?q` or as
+ * `?q#h`, and only the first used to rescue `drawer.` params — so
+ * `/traces?filter=active#conversations?drawer.open=x` left `drawer.open` parked
+ * after the `#`, where `router.query` cannot see it, purely because a real
+ * query happened to come first.
+ *
+ * The rescue still only fires for a fragment query carrying `drawer.` params;
+ * bar state like `#conversations?preset=24h` is left where its owner reads it.
+ */
+function rescueFragmentQuery(hash: string): {
+  queryString: string;
+  hash: string;
+} {
+  const q = hash.indexOf("?");
+  if (q === -1) return { queryString: "", hash };
+  const fragmentQuery = hash.slice(q + 1);
+  if (!/(^|&)drawer\./.test(fragmentQuery)) return { queryString: "", hash };
+  return { queryString: fragmentQuery, hash: hash.slice(0, q) };
 }
 
 /**

--- a/platform/app/src/hooks/useDrawer.ts
+++ b/platform/app/src/hooks/useDrawer.ts
@@ -260,12 +260,9 @@ export const useUpdateDrawerParams = () => {
       options: { push?: boolean } = {},
     ) => {
       const push = options.push ?? true;
-      const {
-        path,
-        queryString,
-        hash: routerHash,
-      } = splitAsPath(router.asPath);
-      const hash = liveHash() ?? routerHash;
+      const { path, queryString, hash } = splitAsPath(
+        liveAsPath(router.asPath),
+      );
       const parsed = qs.parse(queryString, URL_QS_PARSE_OPTIONS) as Record<
         string,
         unknown
@@ -382,8 +379,8 @@ function splitAsPath(asPath: string): {
 }
 
 /**
- * The URL fragment as the browser holds it right now, rather than as React
- * Router remembers it.
+ * `router.asPath` with its fragment replaced by the one the browser holds right
+ * now.
  *
  * The traces page keeps its bar state — active lens, query, time range — in
  * the fragment, and writes it with a raw `history.replaceState`
@@ -394,14 +391,22 @@ function splitAsPath(asPath: string): {
  * 24-hour window, open a conversation, and the page re-applied the fragment
  * from before the pick — snapping the table back to the 30-day default.
  *
- * Only the fragment is read live. Path and query move exclusively through the
+ * Only the fragment is swapped. Path and query move exclusively through the
  * router, so `asPath` is authoritative for those; the fragment is the one axis
  * something else writes behind its back (the traces bar state, and the
  * onboarding spotlight marker).
+ *
+ * The swap happens before `splitAsPath` rather than after it, so that the hash
+ * and the query it may need to give up are always read out of the same string —
+ * splitting the router's fragment and then overwriting the hash with the
+ * browser's would promote a `drawer.` param into the query while leaving a
+ * stale copy of it in the fragment.
  */
-function liveHash(): string | null {
-  if (typeof window === "undefined") return null;
-  return window.location.hash.replace(/^#/, "");
+function liveAsPath(asPath: string): string {
+  if (typeof window === "undefined") return asPath;
+  const hashIdx = asPath.indexOf("#");
+  const withoutHash = hashIdx === -1 ? asPath : asPath.slice(0, hashIdx);
+  return withoutHash + window.location.hash;
 }
 
 function buildUrl(path: string, queryString: string, hash: string): string {
@@ -471,12 +476,9 @@ export const useDrawer = () => {
       // Build query from the actual browser URL (router.asPath), not
       // router.query which may be stale after (url, as) shallow pushes.
       // This preserves filter params that only exist in the asPath URL.
-      const {
-        path,
-        queryString,
-        hash: routerHash,
-      } = splitAsPath(router.asPath);
-      const hash = liveHash() ?? routerHash;
+      const { path, queryString, hash } = splitAsPath(
+        liveAsPath(router.asPath),
+      );
       const currentQueryOnly = Object.fromEntries(
         Object.entries(qs.parse(queryString, URL_QS_PARSE_OPTIONS)).filter(
           ([key]) => !key.startsWith("drawer"),
@@ -655,9 +657,8 @@ export const useDrawer = () => {
     const {
       path,
       queryString: currentQs,
-      hash: routerHash,
-    } = splitAsPath(router.asPath);
-    const hash = liveHash() ?? routerHash;
+      hash,
+    } = splitAsPath(liveAsPath(router.asPath));
     const parsedQuery = qs.parse(currentQs, URL_QS_PARSE_OPTIONS);
     const cleanQuery = Object.fromEntries(
       Object.entries(parsedQuery).filter(


### PR DESCRIPTION
## For humans

A customer filtered the Conversations tab to the last 24 hours, opened one conversation, and the page jumped back to showing the last 30 days. The window they had chosen was gone.

This fixes that. The time range now survives opening a conversation, closing it, and switching panes inside it.

## What was going on

The traces page stores three things in the part of the URL after the `#` — which lens you are on, what you typed in the search box, and the time range. It writes that directly to the browser, in a way the app's router never notices. So from the first filter change onwards, the router's own copy of that part of the URL is out of date.

Opening a conversation rebuilds the URL from the router's copy and navigates to it. That republished the out-of-date fragment as a real navigation. The page then read it back, found it said nothing about time, and fell back to its 30-day default.

Same path for closing the drawer and for switching between Summary / Trace / Conversation panes, so all three could throw the filter away.

## The fix

Three changes, each one a thing the URL-splitting code got wrong.

**Read the fragment from the browser, not from the router.** At the moment the drawer URL is built, take the fragment straight from the browser. The rest of the URL still comes from the router — that part only ever changes through the router, so it is already correct there. The fragment is the one piece something else writes behind its back (the traces bar state, and the onboarding spotlight marker).

**Leave the bar's own state in the fragment.** The splitter used to move anything after a `?` in the fragment into the real query string. That is right for drawer parameters, which the router has to see, and wrong for the bar's own state — it both duplicated the time range and left a stale copy parked on the URL. The rescue now only fires for a fragment query that actually carries `drawer.` parameters.

**Read the live fragment before splitting, not after.** Swapping the browser's fragment in after the split meant the hash and the query it might have to give up were read out of two different strings, which could promote a parameter into the query while leaving a stale copy behind in the fragment.

## Also fixed in review

**The rescue only ran for one of the two URL orderings.** A URL could reach the splitter as `#fragment?query` or as `?query#fragment`, and the two were parsed by separate branches — only the first rescued stray `drawer.` parameters. So `/acme/traces?filter=active#conversations?drawer.open=…` left `drawer.open` after the `#`, where the router cannot see it: an active filter was enough to strand the drawer, purely because the real query happened to be parsed first. The rescue is now a single helper both orderings call, so which separator comes first no longer decides whether it fires.

**The rescue took the bar's state with it.** One `drawer.` key moved the *whole* fragment query into the real query string. For `#conversations?preset=24h&drawer.open=…` that carried `preset` out of the fragment the traces bar reads it from — losing the chosen time range, the very thing this branch is fixing. It is the realistic shape too: the bar has already written `preset` by the time anything parks a drawer parameter next to it. The fragment query is now split by key — `drawer.` pairs move to the real query, everything else is written back into the fragment.

## Tests

New `useDrawer.liveFragment.integration.test.tsx`, 13 tests. It sets up exactly the mismatch that caused the bug — the browser on `#conversations?preset=24h`, the router still remembering `#conversations` — and checks that opening a drawer, closing it, and updating drawer parameters all republish the live fragment. It also covers the bar state staying put, both malformed `drawer.`-after-`#` shapes (with and without a real query in front), a fragment holding bar state and a drawer parameter at once, and the no-fragment case.

Every test was confirmed to fail without its fix and pass with it.

Also run: the rest of the drawer suites (`useDrawer`, stacking, traceV2 routing, run callbacks, preload, trace details) — 59 tests, all green; the repo's Biome gate against the merge base — zero new violations; and `pnpm typecheck:all` — clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Drawer URL updates now preserve the browser’s current fragment when opening, closing, or changing drawer parameters.
  * Improved handling when the browser fragment differs from the router’s remembered URL.
  * Fragment-based drawer parameters are correctly restored to the URL query.
  * Unrelated fragment parameters remain in the fragment.
  * URL state remains consistent when fragments match, differ, or are missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->