### PR TITLE
feat(traces-v2): clicking a facet row opens its drilldown

### DIFF
--- a/platform/app/src/features/traces-v2/components/FilterSidebar/FacetSection.tsx
+++ b/platform/app/src/features/traces-v2/components/FilterSidebar/FacetSection.tsx
@@ -154,9 +154,35 @@ const FacetSectionInner: React.FC<FacetSectionProps> = ({
     if (!searchOpen) setSearchQuery("");
   }, [searchOpen]);
 
+  // Clicking a row that carries a drilldown ALSO opens it. Without this the
+  // sub-options are reachable only through the trailing chevron, which reads
+  // as decoration: operators clicked the evaluator, got a filter, and never
+  // learned that pass/fail (or an event's metric values) were one level down.
+  // The layout freeze keeps the clicked row where it was clicked, so the
+  // drilldown opens in place instead of appearing in the pinned block after
+  // the pointer leaves — the reason the click looked inert.
+  //
+  // We mirror the filter state rather than latch: activating opens, undoing
+  // the same click closes again, so a row never keeps an open drilldown it
+  // no longer contributes to. `getValueState` still reports the PRE-toggle
+  // state here, so "neutral" means the click is about to activate the row.
   const handleToggle = useCallback(
-    (value: string) => onToggle(field, value),
-    [onToggle, field],
+    (value: string) => {
+      if (renderInactiveRowExtras) {
+        const willActivate = getValueState(value) === "neutral";
+        setExpandedInactiveRows((prev) => {
+          const next = new Set(prev);
+          if (willActivate) {
+            next.add(value);
+          } else {
+            next.delete(value);
+          }
+          return next;
+        });
+      }
+      onToggle(field, value);
+    },
+    [onToggle, field, renderInactiveRowExtras, getValueState],
   );
   const handleExclude = useCallback(
     (value: string) => onExclude(field, value),

--- a/platform/app/src/features/traces-v2/components/FilterSidebar/FacetSection.tsx
+++ b/platform/app/src/features/traces-v2/components/FilterSidebar/FacetSection.tsx
@@ -80,9 +80,10 @@ interface FacetSectionProps {
    * than as a full-width row beneath — is why the contract is an object
    * rather than a single node.
    *
-   * FacetSection owns the `expandedInactiveRows` Set so the state is
-   * automatically reset whenever the section unmounts or the sidebar
-   * is closed — no external persistence needed.
+   * FacetSection decides `isExpanded` itself: a row that carries a filter
+   * is expanded, and the chevron records a short-lived override on top of
+   * that. Nothing to persist externally, and nothing survives the section
+   * unmounting or the sidebar closing.
    */
   renderInactiveRowExtras?: (
     item: FacetItem,
@@ -118,20 +119,44 @@ const FacetSectionInner: React.FC<FacetSectionProps> = ({
   modeToggleProps,
   serverValueSearch,
 }) => {
-  const [expandedInactiveRows, setExpandedInactiveRows] = useState<Set<string>>(
-    () => new Set(),
+  // A row's drilldown is OPEN whenever that row contributes a filter —
+  // included or excluded alike. Deriving it (rather than latching a Set on
+  // click) is what keeps the inactive row and the pinned row consistent: the
+  // pinned path renders extras unconditionally for any non-neutral row, so a
+  // stored flag could only ever drift out of sync with it. It also means a
+  // filter dropped from ANYWHERE — the query bar, the pinned row's own
+  // toggle, a saved-view switch — closes the drilldown, instead of leaving
+  // sub-options open for a filter the row no longer carries.
+  //
+  // The trailing chevron is the one way to disagree with that default, so it
+  // records an override AGAINST the state it was pressed on. The moment that
+  // row's filter state changes the override stops matching and silently
+  // expires — no effect, no cleanup pass, no stale flag surviving a filter
+  // the user already cleared.
+  const [expandOverrides, setExpandOverrides] = useState<
+    Map<string, { open: boolean; against: FacetValueState }>
+  >(() => new Map());
+  const isRowExpanded = useCallback(
+    (value: string) => {
+      const state = getValueState(value);
+      const override = expandOverrides.get(value);
+      if (override && override.against === state) return override.open;
+      return state !== "neutral";
+    },
+    [expandOverrides, getValueState],
   );
-  const toggleInactiveExpand = useCallback((value: string) => {
-    setExpandedInactiveRows((prev) => {
-      const next = new Set(prev);
-      if (next.has(value)) {
-        next.delete(value);
-      } else {
-        next.add(value);
-      }
-      return next;
-    });
-  }, []);
+  const toggleInactiveExpand = useCallback(
+    (value: string) => {
+      const state = getValueState(value);
+      const open = isRowExpanded(value);
+      setExpandOverrides((prev) => {
+        const next = new Map(prev);
+        next.set(value, { open: !open, against: state });
+        return next;
+      });
+    },
+    [getValueState, isRowExpanded],
+  );
   const lensOverride = useFacetLensStore((s) => s.lens.sectionOpen[field]);
   const setSectionOpen = useFacetLensStore((s) => s.setSectionOpen);
   const [showMore, setShowMore] = useState(false);
@@ -154,35 +179,18 @@ const FacetSectionInner: React.FC<FacetSectionProps> = ({
     if (!searchOpen) setSearchQuery("");
   }, [searchOpen]);
 
-  // Clicking a row that carries a drilldown ALSO opens it. Without this the
-  // sub-options are reachable only through the trailing chevron, which reads
-  // as decoration: operators clicked the evaluator, got a filter, and never
-  // learned that pass/fail (or an event's metric values) were one level down.
-  // The layout freeze keeps the clicked row where it was clicked, so the
-  // drilldown opens in place instead of appearing in the pinned block after
-  // the pointer leaves — the reason the click looked inert.
-  //
-  // We mirror the filter state rather than latch: activating opens, undoing
-  // the same click closes again, so a row never keeps an open drilldown it
-  // no longer contributes to. `getValueState` still reports the PRE-toggle
-  // state here, so "neutral" means the click is about to activate the row.
+  // Clicking a row that carries a drilldown ALSO opens it — see
+  // `isRowExpanded`, which derives that from the row's filter state so no
+  // bookkeeping is needed here. Without it the sub-options are reachable only
+  // through the trailing chevron, which reads as decoration: operators clicked
+  // the evaluator, got a filter, and never learned that pass/fail (or an
+  // event's metric values) were one level down. The layout freeze keeps the
+  // clicked row where it was clicked, so the drilldown opens in place instead
+  // of appearing in the pinned block after the pointer leaves — the reason the
+  // click looked inert.
   const handleToggle = useCallback(
-    (value: string) => {
-      if (renderInactiveRowExtras) {
-        const willActivate = getValueState(value) === "neutral";
-        setExpandedInactiveRows((prev) => {
-          const next = new Set(prev);
-          if (willActivate) {
-            next.add(value);
-          } else {
-            next.delete(value);
-          }
-          return next;
-        });
-      }
-      onToggle(field, value);
-    },
-    [onToggle, field, renderInactiveRowExtras, getValueState],
+    (value: string) => onToggle(field, value),
+    [onToggle, field],
   );
   const handleExclude = useCallback(
     (value: string) => onExclude(field, value),
@@ -418,7 +426,7 @@ const FacetSectionInner: React.FC<FacetSectionProps> = ({
           {layout.facetWindow.visible.map((item) => {
             const inactiveExtras = renderInactiveRowExtras?.(
               item,
-              expandedInactiveRows.has(item.value),
+              isRowExpanded(item.value),
               () => toggleInactiveExpand(item.value),
             );
             const row = (

--- a/platform/app/src/features/traces-v2/components/FilterSidebar/__tests__/FacetSection.clickExpandsDrilldown.integration.test.tsx
+++ b/platform/app/src/features/traces-v2/components/FilterSidebar/__tests__/FacetSection.clickExpandsDrilldown.integration.test.tsx
@@ -105,7 +105,9 @@ const Harness = ({
         getValueState={getValueState}
         onToggle={onToggle}
         onExclude={vi.fn()}
-        renderActiveRowExtras={withDrilldown ? renderActiveRowExtras : undefined}
+        renderActiveRowExtras={
+          withDrilldown ? renderActiveRowExtras : undefined
+        }
         renderInactiveRowExtras={
           withDrilldown ? renderInactiveRowExtras : undefined
         }

--- a/platform/app/src/features/traces-v2/components/FilterSidebar/__tests__/FacetSection.clickExpandsDrilldown.integration.test.tsx
+++ b/platform/app/src/features/traces-v2/components/FilterSidebar/__tests__/FacetSection.clickExpandsDrilldown.integration.test.tsx
@@ -127,74 +127,88 @@ afterEach(() => {
 
 describe("<FacetSection /> click-to-expand", () => {
   describe("given an inactive row carrying a drilldown", () => {
-    /** @scenario "Clicking an evaluator row opens its verdict drilldown" */
-    it("opens the drilldown and applies the filter on a single click", async () => {
-      const user = userEvent.setup();
-      const onToggleSpy = vi.fn();
-      render(<Harness onToggleSpy={onToggleSpy} />);
-      await openSection(user);
+    describe("when the user clicks the row itself", () => {
+      /** @scenario "Clicking an evaluator row opens its verdict drilldown" */
+      it("opens the drilldown and applies the filter on a single click", async () => {
+        const user = userEvent.setup();
+        const onToggleSpy = vi.fn();
+        render(<Harness onToggleSpy={onToggleSpy} />);
+        await openSection(user);
 
-      expect(screen.queryByTestId("drilldown-eval-a")).not.toBeInTheDocument();
+        expect(
+          screen.queryByTestId("drilldown-eval-a"),
+        ).not.toBeInTheDocument();
 
-      await user.click(screen.getByText("Faithfulness"));
+        await user.click(screen.getByText("Faithfulness"));
 
-      expect(screen.getByTestId("drilldown-eval-a")).toBeInTheDocument();
-      expect(onToggleSpy).toHaveBeenCalledWith("evaluator", "eval-a");
+        expect(screen.getByTestId("drilldown-eval-a")).toBeInTheDocument();
+        expect(onToggleSpy).toHaveBeenCalledWith("evaluator", "eval-a");
+      });
+
+      it("leaves the sibling rows closed", async () => {
+        const user = userEvent.setup();
+        render(<Harness />);
+        await openSection(user);
+
+        await user.click(screen.getByText("Faithfulness"));
+
+        expect(
+          screen.queryByTestId("drilldown-eval-b"),
+        ).not.toBeInTheDocument();
+      });
     });
 
-    it("leaves the sibling rows closed", async () => {
-      const user = userEvent.setup();
-      render(<Harness />);
-      await openSection(user);
+    describe("when the user clicks the trailing chevron instead of the row", () => {
+      it("opens the drilldown without applying the filter", async () => {
+        const user = userEvent.setup();
+        const onToggleSpy = vi.fn();
+        render(<Harness onToggleSpy={onToggleSpy} />);
+        await openSection(user);
 
-      await user.click(screen.getByText("Faithfulness"));
+        await user.click(screen.getByLabelText("expand eval-a"));
 
-      expect(screen.queryByTestId("drilldown-eval-b")).not.toBeInTheDocument();
+        expect(screen.getByTestId("drilldown-eval-a")).toBeInTheDocument();
+        expect(onToggleSpy).not.toHaveBeenCalled();
+      });
     });
   });
 
   describe("given a row whose drilldown the user opened by clicking it", () => {
-    /** @scenario "Clicking the same row again closes the drilldown it opened" */
-    it("collapses the drilldown when the filter is dropped", async () => {
-      const user = userEvent.setup();
-      render(<Harness />);
-      await openSection(user);
+    describe("when the user clicks the row a second time", () => {
+      /** @scenario "Clicking the same row again closes the drilldown it opened" */
+      it("collapses the drilldown along with the filter", async () => {
+        const user = userEvent.setup();
+        render(<Harness />);
+        await openSection(user);
 
-      await user.click(screen.getByText("Faithfulness"));
-      expect(screen.getByTestId("drilldown-eval-a")).toBeInTheDocument();
+        await user.click(screen.getByText("Faithfulness"));
+        expect(screen.getByTestId("drilldown-eval-a")).toBeInTheDocument();
 
-      await user.click(screen.getByText("Faithfulness"));
+        await user.click(screen.getByText("Faithfulness"));
 
-      expect(screen.queryByTestId("drilldown-eval-a")).not.toBeInTheDocument();
+        expect(
+          screen.queryByTestId("drilldown-eval-a"),
+        ).not.toBeInTheDocument();
+      });
     });
   });
 
   describe("given a section whose rows carry no drilldown", () => {
-    /** @scenario "A row carrying no drilldown filters exactly as before" */
-    it("applies the filter and renders nothing extra", async () => {
-      const user = userEvent.setup();
-      const onToggleSpy = vi.fn();
-      render(<Harness withDrilldown={false} onToggleSpy={onToggleSpy} />);
-      await openSection(user);
+    describe("when the user clicks a row", () => {
+      /** @scenario "A row carrying no drilldown filters exactly as before" */
+      it("applies the filter and renders nothing extra", async () => {
+        const user = userEvent.setup();
+        const onToggleSpy = vi.fn();
+        render(<Harness withDrilldown={false} onToggleSpy={onToggleSpy} />);
+        await openSection(user);
 
-      await user.click(screen.getByText("Faithfulness"));
+        await user.click(screen.getByText("Faithfulness"));
 
-      expect(onToggleSpy).toHaveBeenCalledWith("evaluator", "eval-a");
-      expect(screen.queryByTestId("drilldown-eval-a")).not.toBeInTheDocument();
-    });
-  });
-
-  describe("when the trailing chevron is used instead of the row", () => {
-    it("still opens the drilldown without applying the filter", async () => {
-      const user = userEvent.setup();
-      const onToggleSpy = vi.fn();
-      render(<Harness onToggleSpy={onToggleSpy} />);
-      await openSection(user);
-
-      await user.click(screen.getByLabelText("expand eval-a"));
-
-      expect(screen.getByTestId("drilldown-eval-a")).toBeInTheDocument();
-      expect(onToggleSpy).not.toHaveBeenCalled();
+        expect(onToggleSpy).toHaveBeenCalledWith("evaluator", "eval-a");
+        expect(
+          screen.queryByTestId("drilldown-eval-a"),
+        ).not.toBeInTheDocument();
+      });
     });
   });
 });

--- a/platform/app/src/features/traces-v2/components/FilterSidebar/__tests__/FacetSection.clickExpandsDrilldown.integration.test.tsx
+++ b/platform/app/src/features/traces-v2/components/FilterSidebar/__tests__/FacetSection.clickExpandsDrilldown.integration.test.tsx
@@ -1,0 +1,198 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Clicking a facet row that carries a drilldown opens that drilldown as well
+ * as applying the filter — see specs/traces-v2/evaluator-filter-label.feature,
+ * rule "Picking a row opens its drilldown". The trailing chevron stays, but it
+ * is no longer the only way in.
+ */
+
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Activity } from "lucide-react";
+import { useCallback, useState } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+
+// FacetSection calls useFacetSearch (server-side value search) at the top
+// level. This suite renders it without a tRPC provider, so stub the hook out —
+// server search has its own suite (FacetSection.serverSearch.integration.test.tsx).
+vi.mock("../../../hooks/useFacetSearch", () => ({
+  useFacetSearch: () => ({ values: [], totalDistinct: 0, isLoading: false }),
+}));
+
+import { FacetSection } from "../FacetSection";
+import type { FacetItem, FacetValueState } from "../types";
+
+const ITEMS: FacetItem[] = [
+  { value: "eval-a", label: "Faithfulness", count: 12, dimmed: false },
+  { value: "eval-b", label: "Answer relevancy", count: 5, dimmed: false },
+];
+
+/**
+ * Stands in for the evaluator drilldown: the real one is fed from
+ * `item.aggregates` and is exercised by EvaluatorDrilldown.integration.test.tsx.
+ * All this suite needs is a `below` present exactly when the section considers
+ * the row expanded, and a `trailing` chevron that expands without filtering.
+ */
+const renderInactiveRowExtras = (
+  item: FacetItem,
+  isExpanded: boolean,
+  onToggleExpand: () => void,
+) => ({
+  trailing: (
+    <button
+      type="button"
+      aria-label={`expand ${item.value}`}
+      onClick={(e) => {
+        e.stopPropagation();
+        onToggleExpand();
+      }}
+    />
+  ),
+  below: isExpanded ? <div data-testid={`drilldown-${item.value}`} /> : null,
+});
+
+/** The active row's own drilldown, rendered in the pinned block. */
+const renderActiveRowExtras = (item: FacetItem) => (
+  <div data-testid={`pinned-drilldown-${item.value}`} />
+);
+
+/**
+ * Holds the filter state the way the sidebar does, so a second click on the
+ * same row is a genuine undo rather than a no-op against a frozen prop.
+ */
+const Harness = ({
+  initiallyIncluded = [],
+  withDrilldown = true,
+  onToggleSpy,
+}: {
+  initiallyIncluded?: string[];
+  withDrilldown?: boolean;
+  onToggleSpy?: (field: string, value: string) => void;
+}) => {
+  const [included, setIncluded] = useState<ReadonlySet<string>>(
+    () => new Set(initiallyIncluded),
+  );
+  const getValueState = useCallback(
+    (value: string): FacetValueState =>
+      included.has(value) ? "include" : "neutral",
+    [included],
+  );
+  const onToggle = useCallback(
+    (field: string, value: string) => {
+      onToggleSpy?.(field, value);
+      setIncluded((prev) => {
+        const next = new Set(prev);
+        if (next.has(value)) {
+          next.delete(value);
+        } else {
+          next.add(value);
+        }
+        return next;
+      });
+    },
+    [onToggleSpy],
+  );
+  return (
+    <ChakraProvider value={defaultSystem}>
+      <FacetSection
+        title="EVALUATOR"
+        icon={Activity}
+        field="evaluator"
+        items={ITEMS}
+        getValueState={getValueState}
+        onToggle={onToggle}
+        onExclude={vi.fn()}
+        renderActiveRowExtras={withDrilldown ? renderActiveRowExtras : undefined}
+        renderInactiveRowExtras={
+          withDrilldown ? renderInactiveRowExtras : undefined
+        }
+      />
+    </ChakraProvider>
+  );
+};
+
+/** Sections start collapsed; open one so its value rows render. */
+const openSection = async (user: ReturnType<typeof userEvent.setup>) => {
+  await user.click(screen.getByText("EVALUATOR"));
+};
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("<FacetSection /> click-to-expand", () => {
+  describe("given an inactive row carrying a drilldown", () => {
+    /** @scenario "Clicking an evaluator row opens its verdict drilldown" */
+    it("opens the drilldown and applies the filter on a single click", async () => {
+      const user = userEvent.setup();
+      const onToggleSpy = vi.fn();
+      render(<Harness onToggleSpy={onToggleSpy} />);
+      await openSection(user);
+
+      expect(screen.queryByTestId("drilldown-eval-a")).not.toBeInTheDocument();
+
+      await user.click(screen.getByText("Faithfulness"));
+
+      expect(screen.getByTestId("drilldown-eval-a")).toBeInTheDocument();
+      expect(onToggleSpy).toHaveBeenCalledWith("evaluator", "eval-a");
+    });
+
+    it("leaves the sibling rows closed", async () => {
+      const user = userEvent.setup();
+      render(<Harness />);
+      await openSection(user);
+
+      await user.click(screen.getByText("Faithfulness"));
+
+      expect(screen.queryByTestId("drilldown-eval-b")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("given a row whose drilldown the user opened by clicking it", () => {
+    /** @scenario "Clicking the same row again closes the drilldown it opened" */
+    it("collapses the drilldown when the filter is dropped", async () => {
+      const user = userEvent.setup();
+      render(<Harness />);
+      await openSection(user);
+
+      await user.click(screen.getByText("Faithfulness"));
+      expect(screen.getByTestId("drilldown-eval-a")).toBeInTheDocument();
+
+      await user.click(screen.getByText("Faithfulness"));
+
+      expect(screen.queryByTestId("drilldown-eval-a")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("given a section whose rows carry no drilldown", () => {
+    /** @scenario "A row carrying no drilldown filters exactly as before" */
+    it("applies the filter and renders nothing extra", async () => {
+      const user = userEvent.setup();
+      const onToggleSpy = vi.fn();
+      render(<Harness withDrilldown={false} onToggleSpy={onToggleSpy} />);
+      await openSection(user);
+
+      await user.click(screen.getByText("Faithfulness"));
+
+      expect(onToggleSpy).toHaveBeenCalledWith("evaluator", "eval-a");
+      expect(screen.queryByTestId("drilldown-eval-a")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("when the trailing chevron is used instead of the row", () => {
+    it("still opens the drilldown without applying the filter", async () => {
+      const user = userEvent.setup();
+      const onToggleSpy = vi.fn();
+      render(<Harness onToggleSpy={onToggleSpy} />);
+      await openSection(user);
+
+      await user.click(screen.getByLabelText("expand eval-a"));
+
+      expect(screen.getByTestId("drilldown-eval-a")).toBeInTheDocument();
+      expect(onToggleSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/platform/app/src/features/traces-v2/components/FilterSidebar/__tests__/FacetSection.clickExpandsDrilldown.integration.test.tsx
+++ b/platform/app/src/features/traces-v2/components/FilterSidebar/__tests__/FacetSection.clickExpandsDrilldown.integration.test.tsx
@@ -60,36 +60,38 @@ const renderActiveRowExtras = (item: FacetItem) => (
 );
 
 /**
- * Holds the filter state the way the sidebar does, so a second click on the
- * same row is a genuine undo rather than a no-op against a frozen prop.
+ * Holds the filter state the way the real sidebar does, including the part
+ * that matters here: a row click cycles neutral → include → exclude → neutral,
+ * it is NOT a two-state on/off. Modelling it as on/off would let this suite
+ * pass while the second click actually lands on "exclude" — an assertion that
+ * the drilldown had closed would then be reading the wrong transition.
+ *
+ * The escape hatch mirrors reality too: the same filter can be dropped from
+ * the query bar or a saved view, without the row being touched at all.
  */
 const Harness = ({
-  initiallyIncluded = [],
   withDrilldown = true,
   onToggleSpy,
 }: {
-  initiallyIncluded?: string[];
   withDrilldown?: boolean;
   onToggleSpy?: (field: string, value: string) => void;
 }) => {
-  const [included, setIncluded] = useState<ReadonlySet<string>>(
-    () => new Set(initiallyIncluded),
+  const [states, setStates] = useState<ReadonlyMap<string, FacetValueState>>(
+    () => new Map(),
   );
   const getValueState = useCallback(
-    (value: string): FacetValueState =>
-      included.has(value) ? "include" : "neutral",
-    [included],
+    (value: string): FacetValueState => states.get(value) ?? "neutral",
+    [states],
   );
   const onToggle = useCallback(
     (field: string, value: string) => {
       onToggleSpy?.(field, value);
-      setIncluded((prev) => {
-        const next = new Set(prev);
-        if (next.has(value)) {
-          next.delete(value);
-        } else {
-          next.add(value);
-        }
+      setStates((prev) => {
+        const next = new Map(prev);
+        const current = prev.get(value) ?? "neutral";
+        if (current === "neutral") next.set(value, "include");
+        else if (current === "include") next.set(value, "exclude");
+        else next.delete(value);
         return next;
       });
     },
@@ -97,6 +99,11 @@ const Harness = ({
   );
   return (
     <ChakraProvider value={defaultSystem}>
+      {/* Stands in for the query bar: drops every filter without the sidebar
+          row being involved. */}
+      <button type="button" onClick={() => setStates(new Map())}>
+        clear all filters
+      </button>
       <FacetSection
         title="EVALUATOR"
         icon={Activity}
@@ -175,8 +182,8 @@ describe("<FacetSection /> click-to-expand", () => {
 
   describe("given a row whose drilldown the user opened by clicking it", () => {
     describe("when the user clicks the row a second time", () => {
-      /** @scenario "Clicking the same row again closes the drilldown it opened" */
-      it("collapses the drilldown along with the filter", async () => {
+      /** @scenario "The drilldown stays open while the row is excluded" */
+      it("keeps the drilldown open, because the row still carries a filter", async () => {
         const user = userEvent.setup();
         render(<Harness />);
         await openSection(user);
@@ -185,6 +192,42 @@ describe("<FacetSection /> click-to-expand", () => {
         expect(screen.getByTestId("drilldown-eval-a")).toBeInTheDocument();
 
         await user.click(screen.getByText("Faithfulness"));
+
+        expect(screen.getByTestId("drilldown-eval-a")).toBeInTheDocument();
+      });
+    });
+
+    describe("when the row's filter is cycled all the way off", () => {
+      /** @scenario "Dropping the filter closes the drilldown" */
+      it("collapses the drilldown along with the filter", async () => {
+        const user = userEvent.setup();
+        render(<Harness />);
+        await openSection(user);
+
+        // neutral → include → exclude → neutral
+        await user.click(screen.getByText("Faithfulness"));
+        await user.click(screen.getByText("Faithfulness"));
+        expect(screen.getByTestId("drilldown-eval-a")).toBeInTheDocument();
+
+        await user.click(screen.getByText("Faithfulness"));
+
+        expect(
+          screen.queryByTestId("drilldown-eval-a"),
+        ).not.toBeInTheDocument();
+      });
+    });
+
+    describe("when the filter is cleared from outside the sidebar", () => {
+      /** @scenario "Clearing the filter elsewhere closes the drilldown" */
+      it("collapses the drilldown even though the row was never clicked again", async () => {
+        const user = userEvent.setup();
+        render(<Harness />);
+        await openSection(user);
+
+        await user.click(screen.getByText("Faithfulness"));
+        expect(screen.getByTestId("drilldown-eval-a")).toBeInTheDocument();
+
+        await user.click(screen.getByText("clear all filters"));
 
         expect(
           screen.queryByTestId("drilldown-eval-a"),

--- a/platform/app/src/features/traces-v2/components/FilterSidebar/__tests__/evaluatorVerdictPresentation.unit.test.ts
+++ b/platform/app/src/features/traces-v2/components/FilterSidebar/__tests__/evaluatorVerdictPresentation.unit.test.ts
@@ -38,7 +38,7 @@ describe("evaluator verdict presentation", () => {
           { value: "fail", count: 24 },
           { value: "error", count: 3 },
         ]),
-        synthetic: false,
+        isSynthetic: false,
       });
 
       expect(
@@ -56,7 +56,7 @@ describe("evaluator verdict presentation", () => {
           { value: "skipped", count: 2 },
           { value: "unknown", count: 1 },
         ]),
-        synthetic: false,
+        isSynthetic: false,
       });
 
       expect(
@@ -67,7 +67,7 @@ describe("evaluator verdict presentation", () => {
     it("renders the curated palette at full strength rather than dimmed", () => {
       const rows = buildFacetItems({
         cat: verdictSection([{ value: "pass", count: 1 }]),
-        synthetic: false,
+        isSynthetic: false,
       });
 
       expect(rows.map((r) => r.dimmed)).toEqual([false]);
@@ -82,7 +82,7 @@ describe("evaluator verdict presentation", () => {
           { value: "error", count: 40 },
           { value: "pass", count: 2 },
         ]),
-        synthetic: false,
+        isSynthetic: false,
       });
 
       expect(rows.map((r) => r.value)).toEqual(["pass", "fail", "error"]);
@@ -95,7 +95,7 @@ describe("evaluator verdict presentation", () => {
           { value: "fail", count: 24 },
           { value: "pass", count: 72 },
         ]),
-        synthetic: false,
+        isSynthetic: false,
       });
 
       expect(rows.map((r) => r.value)).toEqual(["pass", "fail"]);
@@ -107,7 +107,7 @@ describe("evaluator verdict presentation", () => {
           ...verdictSection([{ value: "pass", count: 1 }]),
           key: "someUncuratedFacet",
         } as CategoricalSection,
-        synthetic: false,
+        isSynthetic: false,
       });
 
       expect(rows[0]?.dotColor).not.toBe("green.solid");

--- a/platform/app/src/features/traces-v2/components/FilterSidebar/__tests__/evaluatorVerdictPresentation.unit.test.ts
+++ b/platform/app/src/features/traces-v2/components/FilterSidebar/__tests__/evaluatorVerdictPresentation.unit.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from "vitest";
+import {
+  FACET_DEFAULTS,
+  FACET_VALUE_ORDER,
+  VIBRANT_FIELDS,
+} from "../constants";
+import { buildFacetItems, orderValues } from "../hooks/useFilterSidebarData";
+import type { CategoricalSection } from "../types";
+
+/** A verdict facet as discover hands it over: counts, no order, no colour. */
+const verdictSection = (
+  topValues: { value: string; count: number }[],
+): CategoricalSection =>
+  ({
+    kind: "categorical",
+    key: "evaluatorVerdict",
+    label: "Evaluator Verdict",
+    topValues: topValues.map((v) => ({ ...v, label: v.value })),
+    totalDistinct: topValues.length,
+  }) as unknown as CategoricalSection;
+
+/**
+ * The Evaluator Verdict facet and the evaluator drilldown render the same
+ * verdicts on the same screen, one directly above the other. They are wired
+ * through completely different code (a facet colour map vs `buildVerdictSpecs`
+ * in EvaluatorDrilldown), so nothing but a test stops them drifting back into
+ * disagreement — which is how they got there: with no entry in FACET_COLORS
+ * the facet fell through to `hashColor`, and the two surfaces showed the same
+ * words in different colours.
+ */
+describe("evaluator verdict presentation", () => {
+  describe("given verdict rows built for the section", () => {
+    /** @scenario "Verdicts carry the drilldown's traffic light" */
+    it("hands each row the drilldown's colour for its verdict", () => {
+      const rows = buildFacetItems(
+        verdictSection([
+          { value: "pass", count: 72 },
+          { value: "fail", count: 24 },
+          { value: "error", count: 3 },
+        ]),
+        false,
+      );
+
+      expect(
+        Object.fromEntries(rows.map((r) => [r.value, r.dotColor])),
+      ).toEqual({
+        pass: "green.solid",
+        fail: "red.solid",
+        error: "yellow.solid",
+      });
+    });
+
+    it("keeps the non-verdicts neutral so they do not compete", () => {
+      const rows = buildFacetItems(
+        verdictSection([
+          { value: "skipped", count: 2 },
+          { value: "unknown", count: 1 },
+        ]),
+        false,
+      );
+
+      expect(
+        Object.fromEntries(rows.map((r) => [r.value, r.dotColor])),
+      ).toEqual({ skipped: "gray.solid", unknown: "gray.solid" });
+    });
+
+    it("renders the curated palette at full strength rather than dimmed", () => {
+      const rows = buildFacetItems(
+        verdictSection([{ value: "pass", count: 1 }]),
+        false,
+      );
+
+      expect(rows.map((r) => r.dimmed)).toEqual([false]);
+      expect(VIBRANT_FIELDS.has("evaluatorVerdict")).toBe(true);
+    });
+
+    /** @scenario "Verdicts read pass, fail, error regardless of counts" */
+    it("lists pass, then fail, then error however the counts fall", () => {
+      const rows = buildFacetItems(
+        verdictSection([
+          { value: "fail", count: 90 },
+          { value: "error", count: 40 },
+          { value: "pass", count: 2 },
+        ]),
+        false,
+      );
+
+      expect(rows.map((r) => r.value)).toEqual(["pass", "fail", "error"]);
+    });
+
+    /** @scenario "Ordering the facet does not invent verdict rows" */
+    it("lists no row for a verdict the project never emitted", () => {
+      const rows = buildFacetItems(
+        verdictSection([
+          { value: "fail", count: 24 },
+          { value: "pass", count: 72 },
+        ]),
+        false,
+      );
+
+      expect(rows.map((r) => r.value)).toEqual(["pass", "fail"]);
+    });
+
+    it("leaves a facet with no colour rule on the generic hash", () => {
+      const rows = buildFacetItems(
+        {
+          ...verdictSection([{ value: "pass", count: 1 }]),
+          key: "someUncuratedFacet",
+        } as CategoricalSection,
+        false,
+      );
+
+      expect(rows[0]?.dotColor).not.toBe("green.solid");
+    });
+  });
+
+  describe("given the display order", () => {
+    it("reads pass, fail, error — the drilldown's own sequence", () => {
+      expect(FACET_VALUE_ORDER.evaluatorVerdict).toEqual([
+        "pass",
+        "fail",
+        "error",
+      ]);
+    });
+
+    /**
+     * The regression this guards: ordering the facet through FACET_DEFAULTS
+     * also SEEDS it. That map feeds `synthesizeDefaultDescriptors` and renders
+     * its entries as zero-count rows, so a verdict the project has never
+     * emitted would take up a permanent row in an already-dense section.
+     * Order ranks what is present; it must not conjure anything.
+     */
+    it("does not seed the facet with verdict rows", () => {
+      expect(FACET_DEFAULTS.evaluatorVerdict).toBeUndefined();
+    });
+  });
+
+  describe("given values arriving in count order", () => {
+    const verdictOrder = FACET_VALUE_ORDER.evaluatorVerdict;
+
+    it("lifts the ranked verdicts above the count sort", () => {
+      expect(
+        orderValues({
+          defaults: undefined,
+          order: verdictOrder,
+          fallback: ["fail", "pass", "error"],
+          keys: ["fail", "pass", "error"],
+        }),
+      ).toEqual(["pass", "fail", "error"]);
+    });
+
+    it("leaves out a verdict the project never emitted", () => {
+      expect(
+        orderValues({
+          defaults: undefined,
+          order: verdictOrder,
+          fallback: ["fail", "pass"],
+          keys: ["fail", "pass"],
+        }),
+      ).toEqual(["pass", "fail"]);
+    });
+
+    it("trails the unranked verdicts behind, in the order they arrived", () => {
+      expect(
+        orderValues({
+          defaults: undefined,
+          order: verdictOrder,
+          fallback: ["skipped", "unknown", "fail", "pass"],
+          keys: ["skipped", "unknown", "fail", "pass"],
+        }),
+      ).toEqual(["pass", "fail", "skipped", "unknown"]);
+    });
+  });
+
+  describe("given a facet with no order rule", () => {
+    it("hands back the count sort untouched", () => {
+      expect(
+        orderValues({
+          defaults: undefined,
+          order: undefined,
+          fallback: ["b", "a", "c"],
+          keys: ["b", "a", "c"],
+        }),
+      ).toEqual(["b", "a", "c"]);
+    });
+  });
+});

--- a/platform/app/src/features/traces-v2/components/FilterSidebar/__tests__/evaluatorVerdictPresentation.unit.test.ts
+++ b/platform/app/src/features/traces-v2/components/FilterSidebar/__tests__/evaluatorVerdictPresentation.unit.test.ts
@@ -32,14 +32,14 @@ describe("evaluator verdict presentation", () => {
   describe("given verdict rows built for the section", () => {
     /** @scenario "Verdicts carry the drilldown's traffic light" */
     it("hands each row the drilldown's colour for its verdict", () => {
-      const rows = buildFacetItems(
-        verdictSection([
+      const rows = buildFacetItems({
+        cat: verdictSection([
           { value: "pass", count: 72 },
           { value: "fail", count: 24 },
           { value: "error", count: 3 },
         ]),
-        false,
-      );
+        synthetic: false,
+      });
 
       expect(
         Object.fromEntries(rows.map((r) => [r.value, r.dotColor])),
@@ -51,13 +51,13 @@ describe("evaluator verdict presentation", () => {
     });
 
     it("keeps the non-verdicts neutral so they do not compete", () => {
-      const rows = buildFacetItems(
-        verdictSection([
+      const rows = buildFacetItems({
+        cat: verdictSection([
           { value: "skipped", count: 2 },
           { value: "unknown", count: 1 },
         ]),
-        false,
-      );
+        synthetic: false,
+      });
 
       expect(
         Object.fromEntries(rows.map((r) => [r.value, r.dotColor])),
@@ -65,10 +65,10 @@ describe("evaluator verdict presentation", () => {
     });
 
     it("renders the curated palette at full strength rather than dimmed", () => {
-      const rows = buildFacetItems(
-        verdictSection([{ value: "pass", count: 1 }]),
-        false,
-      );
+      const rows = buildFacetItems({
+        cat: verdictSection([{ value: "pass", count: 1 }]),
+        synthetic: false,
+      });
 
       expect(rows.map((r) => r.dimmed)).toEqual([false]);
       expect(VIBRANT_FIELDS.has("evaluatorVerdict")).toBe(true);
@@ -76,39 +76,39 @@ describe("evaluator verdict presentation", () => {
 
     /** @scenario "Verdicts read pass, fail, error regardless of counts" */
     it("lists pass, then fail, then error however the counts fall", () => {
-      const rows = buildFacetItems(
-        verdictSection([
+      const rows = buildFacetItems({
+        cat: verdictSection([
           { value: "fail", count: 90 },
           { value: "error", count: 40 },
           { value: "pass", count: 2 },
         ]),
-        false,
-      );
+        synthetic: false,
+      });
 
       expect(rows.map((r) => r.value)).toEqual(["pass", "fail", "error"]);
     });
 
     /** @scenario "Ordering the facet does not invent verdict rows" */
     it("lists no row for a verdict the project never emitted", () => {
-      const rows = buildFacetItems(
-        verdictSection([
+      const rows = buildFacetItems({
+        cat: verdictSection([
           { value: "fail", count: 24 },
           { value: "pass", count: 72 },
         ]),
-        false,
-      );
+        synthetic: false,
+      });
 
       expect(rows.map((r) => r.value)).toEqual(["pass", "fail"]);
     });
 
     it("leaves a facet with no colour rule on the generic hash", () => {
-      const rows = buildFacetItems(
-        {
+      const rows = buildFacetItems({
+        cat: {
           ...verdictSection([{ value: "pass", count: 1 }]),
           key: "someUncuratedFacet",
         } as CategoricalSection,
-        false,
-      );
+        synthetic: false,
+      });
 
       expect(rows[0]?.dotColor).not.toBe("green.solid");
     });

--- a/platform/app/src/features/traces-v2/components/FilterSidebar/constants.ts
+++ b/platform/app/src/features/traces-v2/components/FilterSidebar/constants.ts
@@ -149,12 +149,25 @@ export const FACET_DEFAULTS: Record<string, string[]> = {
   conversation: [],
   errorMessage: [],
   evaluator: [],
-  // Fixed traffic-light order, matching the evaluator drilldown's
-  // Passed / Failed / Errored rows. Left to the count-sorted fallback, the
-  // section listed Fail above Pass whenever failures happened to outnumber
-  // passes — the same two rows swapping places between projects, for no
-  // reason a reader could see. `skipped` / `unknown` trail behind and only
-  // appear once they have traces.
+};
+
+/**
+ * Display order for facets whose values have an inherent sequence, applied
+ * on top of the default count-sort. Deliberately NOT `FACET_DEFAULTS`: that
+ * map SEEDS values (it feeds `synthesizeDefaultDescriptors`, and its entries
+ * render as zero-count rows), so ordering a facet through it would also
+ * conjure rows for verdicts the project has never emitted — extra furniture
+ * in a section that is already dense. Ordering ranks what is present and
+ * introduces nothing.
+ *
+ * Evaluator Verdict is the only member today: left to count-sorting, Fail
+ * sat above Pass whenever failures outnumbered passes, so the same two rows
+ * swapped places between projects for no reason a reader could see. The
+ * order here is the drilldown's Passed / Failed / Errored, so the two
+ * surfaces read the same way down as well as in colour. Values outside the
+ * list (`skipped`, `unknown`) keep their count-sorted position behind these.
+ */
+export const FACET_VALUE_ORDER: Record<string, readonly string[]> = {
   evaluatorVerdict: ["pass", "fail", "error"],
 };
 

--- a/platform/app/src/features/traces-v2/components/FilterSidebar/constants.ts
+++ b/platform/app/src/features/traces-v2/components/FilterSidebar/constants.ts
@@ -83,6 +83,24 @@ export const NORMAL_CASE_FIELDS = new Set([
 ]);
 
 /**
+ * Evaluator Verdict is a traffic light like Status, and must read as the
+ * SAME traffic light the evaluator drilldown already paints — green Passed,
+ * red Failed, yellow Errored (see `buildVerdictSpecs` in EvaluatorDrilldown).
+ * Without an entry here the field fell through to `hashColor`, which hashes
+ * the literal strings "pass"/"fail" into arbitrary palette slots: the two
+ * sections ended up showing the same words in opposite colours on the same
+ * screen. `skipped` / `unknown` are non-verdicts and stay neutral grey so
+ * they don't compete with the three that carry meaning.
+ */
+const EVALUATOR_VERDICT_COLORS: Record<string, Tokens["colors"]> = {
+  pass: "green.solid",
+  fail: "red.solid",
+  error: "yellow.solid",
+  skipped: "gray.solid",
+  unknown: "gray.solid",
+};
+
+/**
  * Status keeps a fixed traffic-light mapping. Origin derives its dot
  * colours from the shared `ORIGIN_DISPLAY` table — the same one the
  * Origin column badge consumes — so "evaluation" is always green,
@@ -91,6 +109,7 @@ export const NORMAL_CASE_FIELDS = new Set([
  */
 export const FACET_COLORS: Record<string, Record<string, Tokens["colors"]>> = {
   status: STATUS_COLORS,
+  evaluatorVerdict: EVALUATOR_VERDICT_COLORS,
   origin: Object.fromEntries(
     Object.entries(ORIGIN_DISPLAY).map(([value, { colorPalette }]) => [
       value,
@@ -130,6 +149,13 @@ export const FACET_DEFAULTS: Record<string, string[]> = {
   conversation: [],
   errorMessage: [],
   evaluator: [],
+  // Fixed traffic-light order, matching the evaluator drilldown's
+  // Passed / Failed / Errored rows. Left to the count-sorted fallback, the
+  // section listed Fail above Pass whenever failures happened to outnumber
+  // passes — the same two rows swapping places between projects, for no
+  // reason a reader could see. `skipped` / `unknown` trail behind and only
+  // appear once they have traces.
+  evaluatorVerdict: ["pass", "fail", "error"],
 };
 
 /**
@@ -144,7 +170,15 @@ export const RANGE_DEFAULTS: readonly string[] = ["duration", "cost", "tokens"];
  * Fields whose colour palette is curated. Other categoricals get hashed
  * colours rendered at reduced opacity to keep the sidebar visually calm.
  */
-export const VIBRANT_FIELDS = new Set(["status", "origin", "spanType"]);
+export const VIBRANT_FIELDS = new Set([
+  "status",
+  "origin",
+  "spanType",
+  // Curated traffic light — dimming it would leave pass and fail as two
+  // washed-out dots a reader has to squint at to tell apart, while the
+  // drilldown right above paints the same verdicts at full strength.
+  "evaluatorVerdict",
+]);
 
 export const FACET_ICONS: Record<string, LucideIcon> = {
   origin: Compass,

--- a/platform/app/src/features/traces-v2/components/FilterSidebar/hooks/useFilterSidebarData.ts
+++ b/platform/app/src/features/traces-v2/components/FilterSidebar/hooks/useFilterSidebarData.ts
@@ -323,7 +323,7 @@ export function useFilterSidebarData() {
     for (const cat of categoricals) {
       const baseItems = buildFacetItems({
         cat,
-        synthetic: cat.synthetic ?? isSynthetic,
+        isSynthetic: cat.synthetic ?? isSynthetic,
       });
       // Surface values that the user typed in the search bar but that
       // discover didn't return (rare value, custom label, paste from
@@ -668,10 +668,10 @@ function buildDiscreteFacetItems(
  */
 export function buildFacetItems({
   cat,
-  synthetic,
+  isSynthetic,
 }: {
   cat: CategoricalSection;
-  synthetic: boolean;
+  isSynthetic: boolean;
 }): FacetItem[] {
   const curatedColors = FACET_COLORS[cat.key];
   const dimmed = !VIBRANT_FIELDS.has(cat.key);
@@ -710,7 +710,7 @@ export function buildFacetItems({
     count: counts.get(value) ?? 0,
     dotColor: dotColorFor(value),
     dimmed,
-    synthetic,
+    synthetic: isSynthetic,
     aggregates: aggregates.get(value),
     eventMetrics: eventMetrics.get(value),
   }));

--- a/platform/app/src/features/traces-v2/components/FilterSidebar/hooks/useFilterSidebarData.ts
+++ b/platform/app/src/features/traces-v2/components/FilterSidebar/hooks/useFilterSidebarData.ts
@@ -29,6 +29,7 @@ import {
   EVENT_ATTRIBUTES_SECTION_KEY,
   FACET_COLORS,
   FACET_DEFAULTS,
+  FACET_VALUE_ORDER,
   METADATA_DOCS_URL,
   METADATA_SECTION_KEY,
   RANGE_DEFAULTS,
@@ -656,7 +657,13 @@ function buildDiscreteFacetItems(
   }));
 }
 
-function buildFacetItems(
+/**
+ * Exported for direct unit coverage. This is where a facet's curated colour
+ * and order rules actually reach the rows — `FACET_COLORS` being correct
+ * proves nothing if `dotColorFor` stops consulting it, and that wiring is
+ * otherwise only observable through the whole sidebar.
+ */
+export function buildFacetItems(
   cat: CategoricalSection,
   synthetic: boolean,
 ): FacetItem[] {
@@ -683,6 +690,7 @@ function buildFacetItems(
   );
   const orderedValues = orderValues({
     defaults: FACET_DEFAULTS[cat.key],
+    order: FACET_VALUE_ORDER[cat.key],
     fallback: cat.topValues.map((v) => v.value),
     keys: [...counts.keys()],
   });
@@ -702,16 +710,34 @@ function buildFacetItems(
   }));
 }
 
-function orderValues({
+/**
+ * Exported for direct unit coverage: the ordering rule (rank what is present,
+ * seed nothing) is invisible from the rendered sidebar, which sorts by count
+ * often enough to look right by accident.
+ */
+export function orderValues({
   defaults,
+  order,
   fallback,
   keys,
 }: {
   defaults: string[] | undefined;
+  order: readonly string[] | undefined;
   fallback: string[];
   keys: string[];
 }): string[] {
-  if (!defaults) return fallback;
-  const defaultSet = new Set(defaults);
-  return [...defaults, ...keys.filter((v) => !defaultSet.has(v))];
+  const base = defaults
+    ? [...defaults, ...keys.filter((v) => !new Set(defaults).has(v))]
+    : fallback;
+  if (!order) return base;
+  // Rank-sort rather than prepend: `defaults` may introduce values, `order`
+  // must not — a facet can be given a reading order without also being given
+  // rows for values it has never seen. Sort is stable, so anything outside
+  // the ranked list keeps the count-sorted position it arrived with.
+  const rank = new Map(order.map((value, i) => [value, i]));
+  return [...base].sort(
+    (a, b) =>
+      (rank.get(a) ?? Number.POSITIVE_INFINITY) -
+      (rank.get(b) ?? Number.POSITIVE_INFINITY),
+  );
 }

--- a/platform/app/src/features/traces-v2/components/FilterSidebar/hooks/useFilterSidebarData.ts
+++ b/platform/app/src/features/traces-v2/components/FilterSidebar/hooks/useFilterSidebarData.ts
@@ -321,7 +321,10 @@ export function useFilterSidebarData() {
   const facetItems = useMemo(() => {
     const map = new Map<string, FacetItem[]>();
     for (const cat of categoricals) {
-      const baseItems = buildFacetItems(cat, cat.synthetic ?? isSynthetic);
+      const baseItems = buildFacetItems({
+        cat,
+        synthetic: cat.synthetic ?? isSynthetic,
+      });
       // Surface values that the user typed in the search bar but that
       // discover didn't return (rare value, custom label, paste from
       // another query). Without this, an active filter like
@@ -663,10 +666,13 @@ function buildDiscreteFacetItems(
  * proves nothing if `dotColorFor` stops consulting it, and that wiring is
  * otherwise only observable through the whole sidebar.
  */
-export function buildFacetItems(
-  cat: CategoricalSection,
-  synthetic: boolean,
-): FacetItem[] {
+export function buildFacetItems({
+  cat,
+  synthetic,
+}: {
+  cat: CategoricalSection;
+  synthetic: boolean;
+}): FacetItem[] {
   const curatedColors = FACET_COLORS[cat.key];
   const dimmed = !VIBRANT_FIELDS.has(cat.key);
   const counts = new Map(cat.topValues.map((v) => [v.value, v.count]));

--- a/specs/traces-v2/evaluator-filter-label.feature
+++ b/specs/traces-v2/evaluator-filter-label.feature
@@ -48,12 +48,29 @@ Rule: Picking a row opens its drilldown
     Then the verdict/score drilldown expands below the row
     And the evaluator is added to the filter
 
-  # Latching the open state would leave a row displaying verdict controls
-  # for a filter it no longer contributes to.
+  # Open-ness follows the filter rather than latching on click. A latch would
+  # leave a row displaying verdict controls for a filter it no longer carries,
+  # and it would disagree with the pinned copy of the same row, which shows its
+  # drilldown for as long as the filter stands.
   @integration
-  Scenario: Clicking the same row again closes the drilldown it opened
+  Scenario: The drilldown stays open while the row is excluded
     Given an evaluator row whose drilldown was opened by clicking the row
-    When the user clicks the row a second time to drop the filter
+    When the user clicks the row a second time to exclude the evaluator
+    Then the drilldown stays open
+    And the evaluator is excluded from the filter
+
+  @integration
+  Scenario: Dropping the filter closes the drilldown
+    Given an evaluator row whose drilldown was opened by clicking the row
+    When the evaluator stops contributing to the filter
+    Then the drilldown collapses with it
+
+  # The filter can be dropped from outside the row entirely — the query bar,
+  # the pinned copy of the row, a saved view. The drilldown must not outlive it.
+  @integration
+  Scenario: Clearing the filter elsewhere closes the drilldown
+    Given an evaluator row whose drilldown was opened by clicking the row
+    When the evaluator filter is cleared without touching the row
     Then the drilldown collapses with it
 
   @integration

--- a/specs/traces-v2/evaluator-filter-label.feature
+++ b/specs/traces-v2/evaluator-filter-label.feature
@@ -41,6 +41,7 @@ Rule: Picking a row opens its drilldown
   behaviour belongs to the section, so event rows and their metric values
   gain it on the same terms.
 
+  @integration
   Scenario: Clicking an evaluator row opens its verdict drilldown
     Given an inactive evaluator row with verdict/score aggregates
     When the user clicks the row itself
@@ -49,11 +50,13 @@ Rule: Picking a row opens its drilldown
 
   # Latching the open state would leave a row displaying verdict controls
   # for a filter it no longer contributes to.
+  @integration
   Scenario: Clicking the same row again closes the drilldown it opened
     Given an evaluator row whose drilldown was opened by clicking the row
     When the user clicks the row a second time to drop the filter
     Then the drilldown collapses with it
 
+  @integration
   Scenario: A row carrying no drilldown filters exactly as before
     Given a facet section whose rows have no sub-options
     When the user clicks a row

--- a/specs/traces-v2/evaluator-filter-label.feature
+++ b/specs/traces-v2/evaluator-filter-label.feature
@@ -110,3 +110,31 @@ Rule: Emitted label values are clickable filters
     Given an evaluator drilldown whose aggregates include emitted label values
     Then each label value renders as a clickable row with its count
     And picking a label adds an evaluatorLabel filter scoped to that evaluator
+
+Rule: The Evaluator Verdict facet reads like the drilldown
+  The standalone Evaluator Verdict section sits directly above the evaluator
+  drilldown, showing the same words — Pass, Fail, Error. It had no colour or
+  order rules of its own, so it fell through to the generic string hash and
+  the generic count sort: the verdicts drew arbitrary palette slots, and Fail
+  sat above Pass whenever failures happened to outnumber passes. Two rows
+  swapping places between projects, in colours that disagreed with the panel
+  underneath them.
+
+  @unit
+  Scenario: Verdicts carry the drilldown's traffic light
+    Given the Evaluator Verdict facet
+    Then pass renders green, fail renders red and error renders yellow
+    And skipped and unknown stay neutral grey
+    And the palette renders at full strength rather than dimmed
+
+  @unit
+  Scenario: Verdicts read pass, fail, error regardless of counts
+    Given evaluator verdict values arriving in count order with fail ahead of pass
+    Then the section lists pass, then fail, then error
+    And verdicts outside that order trail behind in the order they arrived
+
+  @unit
+  Scenario: Ordering the facet does not invent verdict rows
+    Given a project whose evaluators have only ever emitted pass and fail
+    Then the section lists only pass and fail
+    And no zero-count error row is added to an already dense section

--- a/specs/traces-v2/evaluator-filter-label.feature
+++ b/specs/traces-v2/evaluator-filter-label.feature
@@ -32,6 +32,33 @@ Rule: Inline drilldown toggle on inactive evaluator rows
     Then the verdict/score drilldown expands below the row
     And the evaluator is not added to the filter by the click itself
 
+Rule: Picking a row opens its drilldown
+  The trailing chevron was the only way in, and it reads as decoration:
+  operators clicked the evaluator itself, got the filter, and never learned
+  that pass/fail lived one level down. So the row's own click opens the
+  drilldown as well as applying the filter — the sub-options are visible the
+  moment the filter lands, without a second, unadvertised gesture. The
+  behaviour belongs to the section, so event rows and their metric values
+  gain it on the same terms.
+
+  Scenario: Clicking an evaluator row opens its verdict drilldown
+    Given an inactive evaluator row with verdict/score aggregates
+    When the user clicks the row itself
+    Then the verdict/score drilldown expands below the row
+    And the evaluator is added to the filter
+
+  # Latching the open state would leave a row displaying verdict controls
+  # for a filter it no longer contributes to.
+  Scenario: Clicking the same row again closes the drilldown it opened
+    Given an evaluator row whose drilldown was opened by clicking the row
+    When the user clicks the row a second time to drop the filter
+    Then the drilldown collapses with it
+
+  Scenario: A row carrying no drilldown filters exactly as before
+    Given a facet section whose rows have no sub-options
+    When the user clicks a row
+    Then only the filter is applied
+
 Rule: Score slider is suppressed when the score only mirrors the verdict
   An evaluator that emits a binary 0/1 score alongside its pass/fail
   verdict produced a confusing pairing: the verdict pill rows AND a score


### PR DESCRIPTION
## For humans

In the traces filter sidebar, an evaluator row has extra choices hidden under it — pass, fail, error, a score range. The only way to reach them was a small pale arrow at the far right of the row, which nobody found. People clicked the evaluator name instead, got the filter, and never learned the extra choices existed.

Now clicking the row does both: it applies the filter *and* opens the extra choices underneath. They stay open for as long as that row is filtering, and close when it stops — including when the filter is dropped from the search bar rather than the row.

Also in here: the standalone Evaluator Verdict box was drawing Pass and Fail in whatever colours fell out of a string hash, and listing Fail above Pass. It now uses the same green/red/yellow, in a fixed order, as the choices that open under an evaluator row.

## Why

The sub-options exist already — verdict pass/fail/error, score range, per-event metric values — but the only way in was a 12px pale chevron at the row's trailing edge. Reviewers filtering by an evaluator clicked the row, got the filter, and had no signal that "failed" was one level down.

The click also *looked* inert. `FacetSection` freezes its row layout while the pointer is inside the section (so a click doesn't yank the row up to the pinned block under the cursor). The active drilldown renders in that pinned block — which the frozen layout is not yet showing. So the clicked row lit up, nothing expanded, and the options only appeared after the pointer left the sidebar entirely.

## What changed

**A row's drilldown is open whenever that row carries a filter** — included or excluded alike. `isRowExpanded` derives it from `getValueState` rather than latching a Set on click.

The first version of this PR did latch, and the Set could not tell the truth in two cases:

- A row click cycles `neutral → include → exclude → neutral`, not on/off. The second click *excludes* the value, but the latch treated it as an undo and collapsed a drilldown whose filter was still standing.
- A filter dropped anywhere else — the query bar, the pinned copy of the row, a saved view — left the sub-options open for a filter the row no longer carried.

Deriving also puts the inactive row and its pinned twin on the same rule: the pinned path has always rendered `renderActiveRowExtras` unconditionally for any non-neutral row, so a stored flag could only ever drift away from it.

The trailing chevron keeps its override and still expands without filtering. It records the state it was pressed on, so the override expires the moment that row's filter state changes — no effect, no cleanup pass, no stale flag outliving a filter the user cleared.

**Evaluator Verdict colours.** The field had no entry in `FACET_COLORS`, so it fell through to `hashColor`: the literal strings `"pass"` / `"fail"` drew arbitrary palette slots, and the same words appeared in different colours in the facet and in the drilldown right above it. It now maps to green / red / yellow, matching `buildVerdictSpecs` in `EvaluatorDrilldown`, and joins `VIBRANT_FIELDS` so a curated traffic light isn't rendered dimmed. `skipped` and `unknown` are non-verdicts and stay neutral grey.

**Evaluator Verdict order, without seeding rows.** Count-sorting put Fail above Pass whenever failures outnumbered passes, so the same two rows swapped places between projects for no visible reason. The obvious fix — an entry in `FACET_DEFAULTS` — is the wrong one, and the first attempt here made that mistake: `FACET_DEFAULTS` does two jobs. It sets order, and it **seeds values** (it feeds `synthesizeDefaultDescriptors`, and its entries render as zero-count rows). Listing `["pass","fail","error"]` there bought the ordering and, unasked, a permanent `Error 0` row for projects whose evaluators have never errored, plus a whole synthetic Evaluator Verdict section in the empty-project sidebar.

Ordering now lives in its own `FACET_VALUE_ORDER`, and `orderValues` rank-sorts by it instead of prepending — it ranks what is present and introduces nothing. `Array.sort` is stable, so unranked values keep the count-sorted position they arrived with.

Everything here is still gated on `renderInactiveRowExtras` being supplied, so only the two drilldown-capable sections change behaviour.

## Test plan

`FacetSection.clickExpandsDrilldown.integration.test.tsx` (component lane) — the harness models the real three-state cycle rather than an on/off toggle, and carries a "clear all filters" button outside the section. The old harness is why the derivation bugs above did not surface: its second-click assertion was passing against a transition that does not exist.

7 cases: click opens + filters, siblings stay closed, chevron expands without filtering, drilldown stays open while excluded, cycling all the way off closes it, clearing from outside closes it, no-drilldown sections unaffected. 4 of the 7 fail with the derivation stubbed out.

`evaluatorVerdictPresentation.unit.test.ts` — 12 cases against `buildFacetItems` and `orderValues`, both newly exported for this. Asserting `FACET_COLORS` alone would prove the constant, not that a row ever receives its colour; the wiring that matters is `dotColorFor` inside `buildFacetItems`, so the tests assert the produced rows. Probed: stubbing the order to a no-op fails 3/12, stubbing `dotColorFor` to `hashColor` fails 2/12. Before this file existed, both stubs passed everything.

- `pnpm test:component src/features/traces-v2/components/FilterSidebar/` — 13 files, 79 passed
- `pnpm test:unit src/features/traces-v2/` — 110 files, 1128 passed
- `pnpm typecheck` and `pnpm typecheck:all` — no errors in the touched files
- The CI lint gate (`.github/scripts/biome-new-violations.sh` against `origin/main`) — base 3374, head 3374, no new Biome violations

Spec: `specs/traces-v2/evaluator-filter-label.feature` — rule "Picking a row opens its drilldown" (5 `@integration` scenarios) and rule "The Evaluator Verdict facet reads like the drilldown" (3 `@unit` scenarios), all tagged and bound so `check-feature-parity` enforces them.

## Anything surprising?

The second click on a row **excludes** the evaluator (`NOT evaluator:"…"`); the third clears it. An earlier description of this PR said the second click drops the filter, which was wrong. The drilldown deliberately stays open across the exclude — the row is still filtering, and the pinned copy would show it anyway.

Ordering a facet through `FACET_DEFAULTS` also creates rows in it. That coupling is not obvious from the name and cost this PR a round: see the `FACET_VALUE_ORDER` note above.

Not covered: keyboard activation of a row, clicking while the typed value-search is open, and sections with hundreds of rows. The layout freeze is pointer-driven, so keyboard activation likely still behaves the old way. The rule's closing line — event rows and their metric values gain the same behaviour — was verified in a browser but has no scenario holding it in CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Clicking an evaluator row now applies its filter and opens the related verdict or score drilldown.
  - Repeated clicks can exclude an evaluator while keeping its drilldown open.
  - Drilldowns close when filters are cleared or removed elsewhere.
  - Evaluator verdicts use consistent traffic-light colors and appear in pass, fail, and error order.
  - Verdicts with no results are omitted, while skipped and unknown verdicts use neutral styling.
  - Rows without sub-options continue to support filtering without displaying extra content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->