### PR TITLE
fix(skills): skill tests drive Claude Code through the Scenario SDK adapter, which leaves no orphan process

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1626,8 +1626,8 @@ importers:
         specifier: ^3.0.41
         version: 3.0.79(zod@4.4.3)
       '@langwatch/scenario':
-        specifier: ^1.5.0
-        version: 1.5.0(cf0443684fd47d811d4e643afd142fce)
+        specifier: ^1.6.0
+        version: 1.6.0(cf0443684fd47d811d4e643afd142fce)
       '@types/mdast':
         specifier: ^4.0.4
         version: 4.0.4
@@ -3488,8 +3488,8 @@ packages:
       '@google/genai':
         optional: true
 
-  '@langwatch/scenario@1.5.0':
-    resolution: {integrity: sha512-guj7WVmAQobNnLbxOfRAlRg8c2T7vPrHNl+6Csguq7VoWXRKz41GVZPmBpbS+psfH1/v3nSJVz5dr8YcTDiPyA==}
+  '@langwatch/scenario@1.6.0':
+    resolution: {integrity: sha512-1P3ULHh4RYDg3HYX0qfYdCko8ZVLv1GtGyJq8XOPCMMcdl3Z7xXequ1W25uD5KY4z2TljlG7bq+gz8iuk7qZAQ==}
     engines: {node: '>=20', pnpm: '>=8'}
     peerDependencies:
       '@elevenlabs/elevenlabs-js': '>=2.51.0'
@@ -14461,7 +14461,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@langwatch/scenario@1.5.0(cf0443684fd47d811d4e643afd142fce)':
+  '@langwatch/scenario@1.6.0(cf0443684fd47d811d4e643afd142fce)':
     dependencies:
       '@ag-ui/core': 0.0.58
       '@ai-sdk/openai': 3.0.79(zod@3.25.76)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1626,8 +1626,8 @@ importers:
         specifier: ^3.0.41
         version: 3.0.79(zod@4.4.3)
       '@langwatch/scenario':
-        specifier: ^0.4.12
-        version: 0.4.15(ae74f9bd2279f6be9dff095a962075a7)
+        specifier: ^1.5.0
+        version: 1.5.0(cf0443684fd47d811d4e643afd142fce)
       '@types/mdast':
         specifier: ^4.0.4
         version: 4.0.4
@@ -1683,6 +1683,9 @@ packages:
 
   '@ag-ui/core@0.0.57':
     resolution: {integrity: sha512-gho1OWjNE6E3Rl7ZEZ1wr2CEpUHjLFU0FqzCZZk439TicLu+BfLCMkMokB07bMGlRmbJ60hM6LW60iOVauCx+Q==}
+
+  '@ag-ui/core@0.0.58':
+    resolution: {integrity: sha512-XgGb7YmhV+yMBaEmlrpsd5S+nUxq0JgSegss2t4gIFR1j7w3w0ibtKfRgcQHWeMvwZxcT5S28VEEarqtgxYYHw==}
 
   '@ag-ui/encoder@0.0.47':
     resolution: {integrity: sha512-AgKTM/DEHtaNrcbMa0z1UQ7lKiKtalbFAjBTTP0vCh+lJ6JWIu9LrpCJQ4EjON1IRoAZtJBORlCj1KY+F14HXQ==}
@@ -3485,6 +3488,20 @@ packages:
       '@google/genai':
         optional: true
 
+  '@langwatch/scenario@1.5.0':
+    resolution: {integrity: sha512-guj7WVmAQobNnLbxOfRAlRg8c2T7vPrHNl+6Csguq7VoWXRKz41GVZPmBpbS+psfH1/v3nSJVz5dr8YcTDiPyA==}
+    engines: {node: '>=20', pnpm: '>=8'}
+    peerDependencies:
+      '@elevenlabs/elevenlabs-js': '>=2.51.0'
+      '@google/genai': '>=2.0.0'
+      ai: ^6.0.161
+      vitest: '>=4.1.0'
+    peerDependenciesMeta:
+      '@elevenlabs/elevenlabs-js':
+        optional: true
+      '@google/genai':
+        optional: true
+
   '@langwatch/scenario@file:platform/app/vendor/langwatch-scenario-1.3.0.tgz':
     resolution: {integrity: sha512-g9Uv5vEeXAVqJzTsDbBaEJvJkQYzlOkDDN3WbkXBshHcIXLhOD0/V4wm0rUJLd0phHWt+vfb+0EEJviyzIpW9Q==, tarball: file:platform/app/vendor/langwatch-scenario-1.3.0.tgz}
     version: 1.3.0
@@ -3589,6 +3606,14 @@ packages:
   '@microsoft/fetch-event-source@2.0.1':
     resolution: {integrity: sha512-W6CLUJ2eBMw3Rec70qrsEW0jOm/3twwJv21mrmj2yORiaVmVYGS4sSS5yUwvQc1ZlDLYGPnClVWmUUMagKNsfA==}
 
+  '@modelcontextprotocol/client@2.0.0':
+    resolution: {integrity: sha512-8f1OghQ2rjzIOfqgUCP+8GiUWqRs89njoWLNqAe8kWmDePv3s1fZXseej+QXemssEuuOvLLmLO/kqM3IQHtISw==}
+    engines: {node: '>=20'}
+
+  '@modelcontextprotocol/core@2.0.0':
+    resolution: {integrity: sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA==}
+    engines: {node: '>=20'}
+
   '@modelcontextprotocol/sdk@1.29.0':
     resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
     engines: {node: '>=18'}
@@ -3683,6 +3708,14 @@ packages:
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
 
+  '@openai/agents-core@0.16.1':
+    resolution: {integrity: sha512-h6X7P95NP/uLwGvWTRg2gHYZ5peB4662s+yDn894gIyC1XUH+B9olJyZy6+pdTVJNq4V9Thi7A43PeYFe8S4LA==}
+    peerDependencies:
+      zod: ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
   '@openai/agents-core@0.3.9':
     resolution: {integrity: sha512-6Fr/VkA3lMaTT9EV2+OsmkMX9Yx+/PeWtlmaWNKDRG8D15IWuK13NOC9eFklTsa7otbuwbw/Xmjes+h4Z+CwSQ==}
     peerDependencies:
@@ -3691,15 +3724,30 @@ packages:
       zod:
         optional: true
 
+  '@openai/agents-openai@0.16.1':
+    resolution: {integrity: sha512-1Ma6Md3eIQMZSGKJPMiCKu6pVsVQu4HdYnw/M/kLlO5OAWbHEEBqnDsDr597qJ83+LSHm08oUWHllkx+LQ/UAA==}
+    peerDependencies:
+      zod: ^4.0.0
+
   '@openai/agents-openai@0.3.9':
     resolution: {integrity: sha512-duXUt0xU6K/+c7ae4m8BrJIUzZal6Pzln8V0frnJfNyfYO4SvHMV4qwPRzVDvv/ANj4DQXWI2L1JdPxKJeSHkw==}
     peerDependencies:
       zod: ^3.25.40 || ^4.0
 
+  '@openai/agents-realtime@0.16.1':
+    resolution: {integrity: sha512-q9E4eQf5FtzTMx/XQE5RA3HAvjl01lKz2BKvNJYdHCuQ6h9T/Pa/LDK7nV5e1dxsJCw+7aaKwCZVbhmtFeguIw==}
+    peerDependencies:
+      zod: ^4.0.0
+
   '@openai/agents-realtime@0.3.9':
     resolution: {integrity: sha512-51zHO/zao/LHv70gseU1otTvXyS81tuVaewHlUBiNMXvqSZNkYViiO69hpXMoTYn5c3gCjUrXPxxI+NlHUtaHg==}
     peerDependencies:
       zod: ^3.25.40 || ^4.0
+
+  '@openai/agents@0.16.1':
+    resolution: {integrity: sha512-L1ROwfXhoqiLCwtOp1E2tEluK2GRmq/LsQyoRGGFN/BjYYbyNMtLn6afuaULEIOdFC6treHdNtiEQaCt5I6rdg==}
+    peerDependencies:
+      zod: ^4.0.0
 
   '@openai/agents@0.3.9':
     resolution: {integrity: sha512-YaKnqv0M6bCVvn47pThkFfyHz8xWJ+0Ll9ZnhvwJZ5gyPX0UxHIUeUs9SMG9BSvNuJNJHlc5uvfUDGYAmKJClw==}
@@ -7752,6 +7800,7 @@ packages:
   eslint@9.39.5:
     resolution: {integrity: sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -9750,6 +9799,10 @@ packages:
     resolution: {integrity: sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==}
     engines: {node: '>=20'}
 
+  open@11.0.1:
+    resolution: {integrity: sha512-NzwMUB6C1D0+Kd+9iMS/H4k+Ck3cTX6Ckyfr/gAGlmvSE1LUQZnEZvWBi4PYmMwH/S5SMeTXnE+9uAz8uF+pWw==}
+    engines: {node: '>=20'}
+
   openai@4.104.0:
     resolution: {integrity: sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==}
     hasBin: true
@@ -10193,6 +10246,10 @@ packages:
     resolution: {integrity: sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==}
     engines: {node: '>=20'}
 
+  powershell-utils@0.2.1:
+    resolution: {integrity: sha512-C+y9x90UElAddDZmV4qOx9W53B61PO7cIqWz2dQsWlwswuq4mr8NEwytdGKboYbQlGZ3awrkTeNvcZiZNHnQ8A==}
+    engines: {node: '>=20'}
+
   pprof-format@2.3.1:
     resolution: {integrity: sha512-y51Z83qG2vEQBACPu6lkGFREVkHwQaCaNDdSFEMLIqSo3bmpADsbP6J3F2SSk7tYB741oTQ9Kt5YAdQsmiCRkA==}
 
@@ -10260,6 +10317,7 @@ packages:
   prom-client@15.1.3:
     resolution: {integrity: sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==}
     engines: {node: ^16 || ^18 || >=20}
+    deprecated: prom-client has been replaced by @prometheus-io/client
 
   prompts@2.4.2:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
@@ -11987,6 +12045,10 @@ packages:
     resolution: {integrity: sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==}
     engines: {node: '>=20'}
 
+  wsl-utils@1.0.0:
+    resolution: {integrity: sha512-Hl0ZOAs672vg+06kfujwRhoS6/jehvULrlFkuF2dRu6pHgA8U06h3xqNIqNNU1LTXPcedxByAR4GS6pwQK0mgA==}
+    engines: {node: '>=20'}
+
   xksuid@0.0.4:
     resolution: {integrity: sha512-uVWuWtTLV0c5glVnRUFVtAT0At/a438v4KCqhmKpkGiU1JXMzmrigEtKzNaQ3D4yHgDbEFl7C5EG688b2FARqA==}
 
@@ -12160,6 +12222,10 @@ snapshots:
     dependencies:
       zod: 3.25.76
 
+  '@ag-ui/core@0.0.58':
+    dependencies:
+      zod: 3.25.76
+
   '@ag-ui/encoder@0.0.47':
     dependencies:
       '@ag-ui/core': 0.0.47
@@ -12212,7 +12278,7 @@ snapshots:
   '@ai-sdk/openai@3.0.79(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 3.0.13
-      '@ai-sdk/provider-utils': 4.0.34(zod@3.25.76)
+      '@ai-sdk/provider-utils': 4.0.34(zod@4.4.3)
       zod: 4.4.3
 
   '@ai-sdk/provider-utils@3.0.30(zod@4.4.3)':
@@ -14395,39 +14461,40 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@langwatch/scenario@0.4.15(ae74f9bd2279f6be9dff095a962075a7)':
+  '@langwatch/scenario@1.5.0(cf0443684fd47d811d4e643afd142fce)':
     dependencies:
-      '@ag-ui/core': 0.0.28
+      '@ag-ui/core': 0.0.58
       '@ai-sdk/openai': 3.0.79(zod@3.25.76)
-      '@elevenlabs/elevenlabs-js': 2.58.0(bufferutil@4.1.0)(encoding@0.1.13)
-      '@openai/agents': 0.3.9(@aws-sdk/credential-provider-node@3.972.79)(@cfworker/json-schema@4.1.1)(@smithy/signature-v4@5.7.0)(bufferutil@4.1.0)(ws@8.21.1(bufferutil@4.1.0))(zod@3.25.76)
+      '@openai/agents': 0.16.1(@aws-sdk/credential-provider-node@3.972.79)(@smithy/signature-v4@5.7.0)(bufferutil@4.1.0)(ws@8.21.3(bufferutil@4.1.0))(zod@3.25.76)
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/context-async-hooks': 2.10.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-node': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-node': 2.10.0(@opentelemetry/api@1.9.1)
       ai: 6.0.217(zod@4.4.3)
       chalk: 5.6.2
       ffmpeg-static: 5.3.0
       fft.js: 4.0.4
       langwatch: 0.16.1(0d0c2ccf4d0b984d761a8d4ddb875cf0)
-      open: 11.0.0
-      openai: 6.45.0(@aws-sdk/credential-provider-node@3.972.79)(@smithy/signature-v4@5.7.0)(ws@8.21.1(bufferutil@4.1.0))(zod@3.25.76)
+      open: 11.0.1
+      openai: 6.49.0(@aws-sdk/credential-provider-node@3.972.79)(@smithy/signature-v4@5.7.0)(ws@8.21.3(bufferutil@4.1.0))(zod@3.25.76)
       rxjs: 7.8.2
       vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.2.0)(typescript@7.0.2))(vite@8.1.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
-      ws: 8.21.1(bufferutil@4.1.0)
+      ws: 8.21.3(bufferutil@4.1.0)
       xksuid: 0.0.4
       zod: 3.25.76
+    optionalDependencies:
+      '@elevenlabs/elevenlabs-js': 2.58.0(bufferutil@4.1.0)(encoding@0.1.13)
     transitivePeerDependencies:
       - '@aws-sdk/credential-provider-node'
-      - '@cfworker/json-schema'
       - '@langchain/core'
       - '@langchain/langgraph'
       - '@langchain/openai'
-      - '@opentelemetry/api'
-      - '@opentelemetry/context-async-hooks'
       - '@opentelemetry/context-zone'
       - '@opentelemetry/sdk-trace-web'
       - '@smithy/hash-node'
       - '@smithy/signature-v4'
       - bufferutil
-      - encoding
       - langchain
       - supports-color
       - utf-8-validate
@@ -14532,6 +14599,22 @@ snapshots:
       - '@types/react'
 
   '@microsoft/fetch-event-source@2.0.1': {}
+
+  '@modelcontextprotocol/client@2.0.0':
+    dependencies:
+      '@modelcontextprotocol/core': 2.0.0
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.0
+      jose: 6.2.3
+      pkce-challenge: 5.0.1
+      zod: 4.4.3
+    optional: true
+
+  '@modelcontextprotocol/core@2.0.0':
+    dependencies:
+      zod: 4.4.3
+    optional: true
 
   '@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)':
     dependencies:
@@ -14652,6 +14735,21 @@ snapshots:
 
   '@open-draft/until@2.1.0': {}
 
+  '@openai/agents-core@0.16.1(@aws-sdk/credential-provider-node@3.972.79)(@smithy/signature-v4@5.7.0)(ws@8.21.3(bufferutil@4.1.0))(zod@3.25.76)':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      debug: 4.4.3(supports-color@10.2.2)
+      openai: 7.4.0(@aws-sdk/credential-provider-node@3.972.79)(@smithy/signature-v4@5.7.0)(ws@8.21.3(bufferutil@4.1.0))(zod@3.25.76)
+    optionalDependencies:
+      '@modelcontextprotocol/client': 2.0.0
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - '@aws-sdk/credential-provider-node'
+      - '@smithy/hash-node'
+      - '@smithy/signature-v4'
+      - supports-color
+      - ws
+
   '@openai/agents-core@0.3.9(@aws-sdk/credential-provider-node@3.972.79)(@cfworker/json-schema@4.1.1)(@smithy/signature-v4@5.7.0)(ws@8.21.1(bufferutil@4.1.0))(zod@3.25.76)':
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
@@ -14677,6 +14775,19 @@ snapshots:
     transitivePeerDependencies:
       - '@aws-sdk/credential-provider-node'
       - '@cfworker/json-schema'
+      - '@smithy/hash-node'
+      - '@smithy/signature-v4'
+      - supports-color
+      - ws
+
+  '@openai/agents-openai@0.16.1(@aws-sdk/credential-provider-node@3.972.79)(@smithy/signature-v4@5.7.0)(ws@8.21.3(bufferutil@4.1.0))(zod@3.25.76)':
+    dependencies:
+      '@openai/agents-core': 0.16.1(@aws-sdk/credential-provider-node@3.972.79)(@smithy/signature-v4@5.7.0)(ws@8.21.3(bufferutil@4.1.0))(zod@3.25.76)
+      debug: 4.4.3(supports-color@10.2.2)
+      openai: 7.4.0(@aws-sdk/credential-provider-node@3.972.79)(@smithy/signature-v4@5.7.0)(ws@8.21.3(bufferutil@4.1.0))(zod@3.25.76)
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - '@aws-sdk/credential-provider-node'
       - '@smithy/hash-node'
       - '@smithy/signature-v4'
       - supports-color
@@ -14710,6 +14821,21 @@ snapshots:
       - supports-color
       - ws
 
+  '@openai/agents-realtime@0.16.1(@aws-sdk/credential-provider-node@3.972.79)(@smithy/signature-v4@5.7.0)(bufferutil@4.1.0)(zod@3.25.76)':
+    dependencies:
+      '@openai/agents-core': 0.16.1(@aws-sdk/credential-provider-node@3.972.79)(@smithy/signature-v4@5.7.0)(ws@8.21.3(bufferutil@4.1.0))(zod@3.25.76)
+      '@types/ws': 8.18.1
+      debug: 4.4.3(supports-color@10.2.2)
+      ws: 8.21.3(bufferutil@4.1.0)
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - '@aws-sdk/credential-provider-node'
+      - '@smithy/hash-node'
+      - '@smithy/signature-v4'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   '@openai/agents-realtime@0.3.9(@aws-sdk/credential-provider-node@3.972.79)(@cfworker/json-schema@4.1.1)(@smithy/signature-v4@5.7.0)(bufferutil@4.1.0)(zod@3.25.76)':
     dependencies:
       '@openai/agents-core': 0.3.9(@aws-sdk/credential-provider-node@3.972.79)(@cfworker/json-schema@4.1.1)(@smithy/signature-v4@5.7.0)(ws@8.21.3(bufferutil@4.1.0))(zod@3.25.76)
@@ -14725,6 +14851,23 @@ snapshots:
       - bufferutil
       - supports-color
       - utf-8-validate
+
+  '@openai/agents@0.16.1(@aws-sdk/credential-provider-node@3.972.79)(@smithy/signature-v4@5.7.0)(bufferutil@4.1.0)(ws@8.21.3(bufferutil@4.1.0))(zod@3.25.76)':
+    dependencies:
+      '@openai/agents-core': 0.16.1(@aws-sdk/credential-provider-node@3.972.79)(@smithy/signature-v4@5.7.0)(ws@8.21.3(bufferutil@4.1.0))(zod@3.25.76)
+      '@openai/agents-openai': 0.16.1(@aws-sdk/credential-provider-node@3.972.79)(@smithy/signature-v4@5.7.0)(ws@8.21.3(bufferutil@4.1.0))(zod@3.25.76)
+      '@openai/agents-realtime': 0.16.1(@aws-sdk/credential-provider-node@3.972.79)(@smithy/signature-v4@5.7.0)(bufferutil@4.1.0)(zod@3.25.76)
+      debug: 4.4.3(supports-color@10.2.2)
+      openai: 7.4.0(@aws-sdk/credential-provider-node@3.972.79)(@smithy/signature-v4@5.7.0)(ws@8.21.3(bufferutil@4.1.0))(zod@3.25.76)
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - '@aws-sdk/credential-provider-node'
+      - '@smithy/hash-node'
+      - '@smithy/signature-v4'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
 
   '@openai/agents@0.3.9(@aws-sdk/credential-provider-node@3.972.79)(@cfworker/json-schema@4.1.1)(@smithy/signature-v4@5.7.0)(bufferutil@4.1.0)(ws@8.21.1(bufferutil@4.1.0))(zod@3.25.76)':
     dependencies:
@@ -17471,9 +17614,9 @@ snapshots:
       obug: 2.1.4
       std-env: 4.2.0
       tinyrainbow: 3.1.1
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.2.0)(typescript@6.0.3))(vite@8.1.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.2.0)(typescript@7.0.2))(vite@8.1.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
     optionalDependencies:
-      '@vitest/browser': 4.1.10(bufferutil@4.1.0)(msw@2.15.0(@types/node@26.2.0)(typescript@6.0.3))(vite@8.1.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.10)
+      '@vitest/browser': 4.1.10(bufferutil@4.1.0)(msw@2.15.0(@types/node@26.2.0)(typescript@7.0.2))(vite@8.1.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.10)
 
   '@vitest/expect@4.1.10':
     dependencies:
@@ -17529,7 +17672,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.1
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.2.0)(typescript@6.0.3))(vite@8.1.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.2.0)(typescript@7.0.2))(vite@8.1.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   '@vitest/utils@4.1.10':
     dependencies:
@@ -18187,14 +18330,17 @@ snapshots:
     dependencies:
       acorn: 8.17.0
 
+  acorn-import-attributes@1.9.5(acorn@8.18.0):
+    dependencies:
+      acorn: 8.18.0
+
   acorn-jsx@5.3.2(acorn@8.17.0):
     dependencies:
       acorn: 8.17.0
 
   acorn@8.17.0: {}
 
-  acorn@8.18.0:
-    optional: true
+  acorn@8.18.0: {}
 
   agent-base@6.0.2:
     dependencies:
@@ -20440,8 +20586,8 @@ snapshots:
 
   import-in-the-middle@2.0.6:
     dependencies:
-      acorn: 8.17.0
-      acorn-import-attributes: 1.9.5(acorn@8.17.0)
+      acorn: 8.18.0
+      acorn-import-attributes: 1.9.5(acorn@8.18.0)
       cjs-module-lexer: 2.2.0
       module-details-from-path: 1.0.4
 
@@ -20880,7 +21026,7 @@ snapshots:
       js-yaml: 4.3.1
       langchain: 0.3.37(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@7.4.0(@aws-sdk/credential-provider-node@3.972.79)(@smithy/signature-v4@5.7.0)(ws@8.21.3(bufferutil@4.1.0))(zod@4.4.3))(ws@8.21.3(bufferutil@4.1.0)))(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(axios@1.19.0)(handlebars@4.7.9)(openai@7.4.0(@aws-sdk/credential-provider-node@3.972.79)(@smithy/signature-v4@5.7.0)(ws@8.21.3(bufferutil@4.1.0))(zod@4.4.3))(ws@8.21.3(bufferutil@4.1.0))
       liquidjs: 10.27.1
-      open: 11.0.0
+      open: 11.0.1
       openapi-fetch: 0.16.0
       ora: 5.4.1
       prompts: 2.4.2
@@ -20917,7 +21063,7 @@ snapshots:
       js-yaml: 4.3.1
       langchain: 0.3.37(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@7.4.0(@aws-sdk/credential-provider-node@3.972.79)(@smithy/signature-v4@5.7.0)(ws@8.21.1(bufferutil@4.1.0))(zod@4.4.3))(ws@8.21.1(bufferutil@4.1.0)))(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(axios@1.19.0)(handlebars@4.7.9)(openai@7.4.0(@aws-sdk/credential-provider-node@3.972.79)(@smithy/signature-v4@5.7.0)(ws@8.21.1(bufferutil@4.1.0))(zod@4.4.3))(ws@8.21.1(bufferutil@4.1.0))
       liquidjs: 10.27.1
-      open: 11.0.0
+      open: 11.0.1
       openapi-fetch: 0.16.0
       ora: 5.4.1
       prompts: 2.4.2
@@ -22180,6 +22326,15 @@ snapshots:
       powershell-utils: 0.1.0
       wsl-utils: 0.3.1
 
+  open@11.0.1:
+    dependencies:
+      default-browser: 5.5.0
+      define-lazy-prop: 3.0.0
+      is-in-ssh: 1.0.0
+      is-inside-container: 1.0.0
+      powershell-utils: 0.2.1
+      wsl-utils: 1.0.0
+
   openai@4.104.0(encoding@0.1.13)(ws@8.21.1(bufferutil@4.1.0))(zod@3.25.76):
     dependencies:
       '@types/node': 18.19.130
@@ -22252,6 +22407,13 @@ snapshots:
       ws: 8.21.1(bufferutil@4.1.0)
       zod: 4.4.3
     optional: true
+
+  openai@7.4.0(@aws-sdk/credential-provider-node@3.972.79)(@smithy/signature-v4@5.7.0)(ws@8.21.3(bufferutil@4.1.0))(zod@3.25.76):
+    optionalDependencies:
+      '@aws-sdk/credential-provider-node': 3.972.79
+      '@smithy/signature-v4': 5.7.0
+      ws: 8.21.3(bufferutil@4.1.0)
+      zod: 3.25.76
 
   openai@7.4.0(@aws-sdk/credential-provider-node@3.972.79)(@smithy/signature-v4@5.7.0)(ws@8.21.3(bufferutil@4.1.0))(zod@4.4.3):
     optionalDependencies:
@@ -22646,6 +22808,8 @@ snapshots:
       rxjs: 7.8.2
 
   powershell-utils@0.1.0: {}
+
+  powershell-utils@0.2.1: {}
 
   pprof-format@2.3.1: {}
 
@@ -24891,6 +25055,11 @@ snapshots:
       is-wsl: 3.1.1
 
   wsl-utils@0.3.1:
+    dependencies:
+      is-wsl: 3.1.1
+      powershell-utils: 0.1.0
+
+  wsl-utils@1.0.0:
     dependencies:
       is-wsl: 3.1.1
       powershell-utils: 0.1.0

--- a/skills/_tests/agent-best-practices.scenario.test.ts
+++ b/skills/_tests/agent-best-practices.scenario.test.ts
@@ -1,4 +1,4 @@
-import scenario from "@langwatch/scenario";
+import scenario, { assertSkillWasRead } from "@langwatch/scenario";
 import fs from "fs";
 import { describe, it, expect } from "vitest";
 import dotenv from "dotenv";
@@ -8,8 +8,6 @@ import { fileURLToPath } from "url";
 import { openai } from "@ai-sdk/openai";
 import {
   createClaudeCodeAgent,
-  toolCallFix,
-  assertSkillWasRead,
   installSkillToWorkDir,
   SKILL_TESTS_SET_ID,
 } from "./helpers/claude-code-adapter";
@@ -65,7 +63,6 @@ describe("Agent Best Practices Skill", () => {
           ),
           scenario.agent(),
           (state) => {
-            toolCallFix(state);
             assertSkillWasRead(state, "agent-best-practices");
           },
           scenario.judge(),

--- a/skills/_tests/agent-improve.scenario.test.ts
+++ b/skills/_tests/agent-improve.scenario.test.ts
@@ -1,4 +1,4 @@
-import scenario from "@langwatch/scenario";
+import scenario, { assertSkillWasRead } from "@langwatch/scenario";
 import fs from "fs";
 import { describe, it, expect } from "vitest";
 import dotenv from "dotenv";
@@ -8,8 +8,6 @@ import { fileURLToPath } from "url";
 import { openai } from "@ai-sdk/openai";
 import {
   createClaudeCodeAgent,
-  toolCallFix,
-  assertSkillWasRead,
   installSkillToWorkDir,
   SKILL_TESTS_SET_ID,
 } from "./helpers/claude-code-adapter";
@@ -67,7 +65,6 @@ describe("Agent Improvement Skill", () => {
           scenario.user("what should I do next to improve my agent?"),
           scenario.agent(),
           (state) => {
-            toolCallFix(state);
             assertSkillWasRead(state, "agent-improve");
           },
           scenario.user(
@@ -75,7 +72,6 @@ describe("Agent Improvement Skill", () => {
           ),
           scenario.agent(),
           (state) => {
-            toolCallFix(state);
           },
           scenario.judge(),
         ],

--- a/skills/_tests/agent-performance.scenario.test.ts
+++ b/skills/_tests/agent-performance.scenario.test.ts
@@ -1,4 +1,4 @@
-import scenario from "@langwatch/scenario";
+import scenario, { assertSkillWasRead } from "@langwatch/scenario";
 import fs from "fs";
 import { describe, it, expect } from "vitest";
 import dotenv from "dotenv";
@@ -8,8 +8,6 @@ import { fileURLToPath } from "url";
 import { openai } from "@ai-sdk/openai";
 import {
   createClaudeCodeAgent,
-  toolCallFix,
-  assertSkillWasRead,
   installSkillToWorkDir,
   SKILL_TESTS_SET_ID,
 } from "./helpers/claude-code-adapter";
@@ -73,7 +71,6 @@ describe("Agent Performance Skill", () => {
           ),
           scenario.agent(),
           (state) => {
-            toolCallFix(state);
             assertSkillWasRead(state, "agent-performance");
 
             const report = findReport(tempFolder);

--- a/skills/_tests/claude-code-adapter.test.ts
+++ b/skills/_tests/claude-code-adapter.test.ts
@@ -1,237 +1,16 @@
+import { pointClaudeMdAtSkills } from "@langwatch/scenario";
 import fs from "node:fs";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 
 import {
-	bashCommands,
-	claudeCodeTranscriptToModelMessages,
 	createSkillTestWorkDir,
-	ensureClaudeSkillInstructions,
 	installSkillToWorkDir,
 	removeSkillTestWorkDir,
 } from "./helpers/claude-code-adapter";
 
-describe("Claude Code transcript conversion", () => {
-	const transcript = [
-		{
-			role: "assistant",
-			content: [
-				{ type: "thinking", thinking: "Read the skill first.", signature: "s" },
-				{ type: "text", text: "I'll start by reading the skill instructions." },
-				{
-					type: "tool_use",
-					id: "toolu_01",
-					name: "Bash",
-					input: { command: "cat .skills/scenarios/SKILL.md" },
-				},
-			],
-		},
-		{
-			role: "user",
-			content: [
-				{
-					type: "tool_result",
-					tool_use_id: "toolu_01",
-					content: [{ type: "text", text: "# Scenarios skill" }],
-				},
-			],
-		},
-		{
-			role: "assistant",
-			content: [{ type: "text", text: "Done." }],
-		},
-	];
-
-	describe("when the transcript holds thinking, text, tool_use and tool_result blocks", () => {
-		/** @scenario "The Claude Code adapter of the skill tests reports tool calls as AI SDK parts" */
-		it("emits AI SDK model messages with tool-call and tool-result parts", () => {
-			const messages = claudeCodeTranscriptToModelMessages(transcript);
-
-			expect(messages).toEqual([
-				{
-					role: "assistant",
-					content: [
-						{
-							type: "text",
-							text: "I'll start by reading the skill instructions.",
-						},
-						{
-							type: "tool-call",
-							toolCallId: "toolu_01",
-							toolName: "Bash",
-							input: { command: "cat .skills/scenarios/SKILL.md" },
-						},
-					],
-				},
-				{
-					role: "tool",
-					content: [
-						{
-							type: "tool-result",
-							toolCallId: "toolu_01",
-							toolName: "Bash",
-							output: { type: "text", value: "# Scenarios skill" },
-						},
-					],
-				},
-				{ role: "assistant", content: [{ type: "text", text: "Done." }] },
-			]);
-			expect(JSON.stringify(messages)).not.toContain("Read the skill first.");
-		});
-
-		it("reads the Bash commands from the converted transcript", () => {
-			const messages = claudeCodeTranscriptToModelMessages(transcript);
-			expect(bashCommands({ messages } as never)).toEqual([
-				"cat .skills/scenarios/SKILL.md",
-			]);
-		});
-	});
-
-	describe("when a turn holds a block the conversation has no part for", () => {
-		/** @scenario "A block the transcript cannot carry leaves a line naming it" */
-		it("keeps the turn and names the block instead of dropping it", () => {
-			const messages = claudeCodeTranscriptToModelMessages([
-				{
-					role: "assistant",
-					content: [
-						{ type: "text", text: "Here is the screenshot." },
-						{ type: "image", source: { type: "base64", data: "iVBORw0KGgo=" } },
-					],
-				},
-			]);
-
-			expect(messages[0]?.content).toEqual([
-				{
-					type: "text",
-					text: "Here is the screenshot.\n[image block, not shown in the transcript]",
-				},
-			]);
-		});
-
-		/** @scenario "A block the transcript cannot carry leaves a line naming it" */
-		it("names the block on a user turn as well", () => {
-			const messages = claudeCodeTranscriptToModelMessages([
-				{
-					role: "user",
-					content: [{ type: "document", source: { type: "text", data: "x" } }],
-				},
-			]);
-
-			expect(messages).toEqual([
-				{
-					role: "user",
-					content: "[document block, not shown in the transcript]",
-				},
-			]);
-		});
-	});
-
-	describe("when an assistant turn only calls tools", () => {
-		it("keeps an empty text part so the tool calls stay next to a string content", () => {
-			const messages = claudeCodeTranscriptToModelMessages([
-				{
-					role: "assistant",
-					content: [
-						{ type: "tool_use", id: "toolu_02", name: "Read", input: { file: "x" } },
-					],
-				},
-			]);
-			expect(messages[0]?.content).toEqual([
-				{ type: "text", text: "" },
-				{
-					type: "tool-call",
-					toolCallId: "toolu_02",
-					toolName: "Read",
-					input: { file: "x" },
-				},
-			]);
-		});
-	});
-	describe("when a tool call carries far more text than a judge can read", () => {
-		const huge = "x".repeat(60_000);
-		const messages = claudeCodeTranscriptToModelMessages([
-			{
-				role: "assistant",
-				content: [
-					{
-						type: "tool_use",
-						id: "toolu_big",
-						name: "Bash",
-						input: { command: `cat > report.html <<EOF\n${huge}` },
-					},
-				],
-			},
-			{
-				role: "user",
-				content: [
-					{
-						type: "tool_result",
-						tool_use_id: "toolu_big",
-						content: [{ type: "text", text: huge }],
-					},
-				],
-			},
-		]);
-
-		it("caps the call input and says how much it dropped", () => {
-			const call = (messages[0]!.content as any[])[1];
-			expect(call.type).toBe("tool-call");
-			expect(call.input.command.length).toBeLessThan(31_000);
-			expect(call.input.command).toContain("cat > report.html");
-			expect(call.input.command).toMatch(/more characters/);
-		});
-
-		it("caps the result the same way", () => {
-			const result = (messages[1]!.content as any[])[0];
-			expect(result.type).toBe("tool-result");
-			expect(result.output.value.length).toBeLessThan(9000);
-			expect(result.output.value).toMatch(/more characters/);
-		});
-		
-		it("caps a string nested inside the input too", () => {
-			const nested = claudeCodeTranscriptToModelMessages([
-				{
-					role: "assistant",
-					content: [
-						{
-							type: "tool_use",
-							id: "toolu_nested",
-							name: "Write",
-							input: { payload: { html: huge }, files: [huge] },
-						},
-					],
-				},
-			]);
-
-			const call = (nested[0]!.content as any[])[1];
-			expect(call.input.payload.html.length).toBeLessThan(31_000);
-			expect(call.input.payload.html).toMatch(/more characters/);
-			expect(call.input.files[0].length).toBeLessThan(31_000);
-		});
-
-		it("leaves a small tool call alone", () => {
-			const small = claudeCodeTranscriptToModelMessages([
-				{
-					role: "assistant",
-					content: [
-						{
-							type: "tool_use",
-							id: "toolu_small",
-							name: "Bash",
-							input: { command: "langwatch virtual-keys list" },
-						},
-					],
-				},
-			]);
-			expect(bashCommands({ messages: small } as any)).toEqual([
-				"langwatch virtual-keys list",
-			]);
-		});
-	});
-});
-
 describe("Claude Code skill discovery", () => {
-	it("preserves existing instructions and appends each missing skill once", () => {
+	it("points an existing CLAUDE.md at each installed skill once", () => {
 		const workingDirectory = createSkillTestWorkDir(
 			"claude-skill-discovery-",
 		);
@@ -249,8 +28,8 @@ describe("Claude Code skill discovery", () => {
 				skillSubpath: "online-evaluations",
 			});
 
-			ensureClaudeSkillInstructions(workingDirectory);
-			ensureClaudeSkillInstructions(workingDirectory);
+			pointClaudeMdAtSkills(workingDirectory);
+			pointClaudeMdAtSkills(workingDirectory);
 
 			const contents = fs.readFileSync(
 				path.join(workingDirectory, "CLAUDE.md"),

--- a/skills/_tests/cli-auth.scenario.test.ts
+++ b/skills/_tests/cli-auth.scenario.test.ts
@@ -1,17 +1,15 @@
 import { createGoogleGenerativeAI } from "@ai-sdk/google";
-import scenario from "@langwatch/scenario";
+import scenario, { assertSkillWasRead } from "@langwatch/scenario";
 import dotenv from "dotenv";
 import fs from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
 import { describe, expect, it } from "vitest";
 import {
-	assertSkillWasRead,
-	createClaudeCodeAgent,
-	createSkillTestWorkDir,
-	installSkillToWorkDir,
-	SKILL_TESTS_SET_ID,
-	toolCallFix,
+  createClaudeCodeAgent,
+  createSkillTestWorkDir,
+  installSkillToWorkDir,
+  SKILL_TESTS_SET_ID,
 } from "./helpers/claude-code-adapter";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -69,7 +67,6 @@ describe("LangWatch CLI Auth Discovery: bare CLI, no skill", () => {
 					scenario.user("use langwatch to list my prompts"),
 					scenario.agent(),
 					(state) => {
-						toolCallFix(state);
 					},
 					scenario.judge(),
 				],
@@ -143,7 +140,6 @@ describe("given the experiments skill installed with a project key in .env", () 
 						),
 						scenario.agent(),
 						(state) => {
-							toolCallFix(state);
 							assertSkillWasRead(state, "experiments");
 							// Hard guardrail: the agent must never EXECUTE the AI-tools / device
 							// login (that is what routes evaluations to a personal project). We

--- a/skills/_tests/cli-comprehensive.scenario.test.ts
+++ b/skills/_tests/cli-comprehensive.scenario.test.ts
@@ -9,7 +9,6 @@ import { openai } from "@ai-sdk/openai";
 import {
   createClaudeCodeAgent,
   setupLocalCli,
-  toolCallFix,
   SKILL_TESTS_SET_ID,
 } from "./helpers/claude-code-adapter";
 
@@ -75,7 +74,6 @@ Then run CLI commands:
           ),
           scenario.agent(),
           (state) => {
-            toolCallFix(state);
 
             const allText = state.messages
               .map((m) =>
@@ -148,7 +146,6 @@ Prompt management commands:
           ),
           scenario.agent(),
           (state) => {
-            toolCallFix(state);
 
             const allText = state.messages
               .map((m) =>

--- a/skills/_tests/cli-crud.scenario.test.ts
+++ b/skills/_tests/cli-crud.scenario.test.ts
@@ -9,7 +9,6 @@ import { openai } from "@ai-sdk/openai";
 import {
   createClaudeCodeAgent,
   setupLocalCli,
-  toolCallFix,
   SKILL_TESTS_SET_ID,
 } from "./helpers/claude-code-adapter";
 
@@ -77,7 +76,6 @@ Then run CLI commands directly:
           ),
           scenario.agent(),
           (state) => {
-            toolCallFix(state);
 
             const allText = state.messages
               .map((m) =>
@@ -150,7 +148,6 @@ Then: \`langwatch dataset records list qa-test-set\`
           ),
           scenario.agent(),
           (state) => {
-            toolCallFix(state);
 
             const allText = state.messages
               .map((m) =>
@@ -217,7 +214,6 @@ Then: \`langwatch trace search --limit 5\`
           ),
           scenario.agent(),
           (state) => {
-            toolCallFix(state);
 
             const allText = state.messages
               .map((m) =>

--- a/skills/_tests/cli-gateway.scenario.test.ts
+++ b/skills/_tests/cli-gateway.scenario.test.ts
@@ -9,7 +9,6 @@ import { openai } from "@ai-sdk/openai";
 import {
   createClaudeCodeAgent,
   setupLocalCli,
-  toolCallFix,
   SKILL_TESTS_SET_ID,
 } from "./helpers/claude-code-adapter";
 
@@ -80,7 +79,6 @@ Workflow to exercise (in order):
           ),
           scenario.agent(),
           (state) => {
-            toolCallFix(state);
 
             const allText = state.messages
               .map((m) =>
@@ -155,7 +153,6 @@ Workflow:
           ),
           scenario.agent(),
           (state) => {
-            toolCallFix(state);
 
             const allText = state.messages
               .map((m) =>
@@ -227,7 +224,6 @@ Your goal: report back which top-level command groups are available and what the
           ),
           scenario.agent(),
           (state) => {
-            toolCallFix(state);
 
             const allText = state.messages
               .map((m) =>

--- a/skills/_tests/cli-projects-api-keys.scenario.test.ts
+++ b/skills/_tests/cli-projects-api-keys.scenario.test.ts
@@ -10,7 +10,6 @@ import { openai } from "@ai-sdk/openai";
 import {
   createClaudeCodeAgent,
   setupLocalCli,
-  toolCallFix,
   SKILL_TESTS_SET_ID,
 } from "./helpers/claude-code-adapter";
 
@@ -169,7 +168,6 @@ describe("LangWatch CLI Projects & API Keys — Agent Usability", () => {
               ),
               scenario.agent(),
               (state) => {
-                toolCallFix(state);
 
                 const allText = state.messages
                   .map((m) =>
@@ -254,7 +252,6 @@ describe("LangWatch CLI Projects & API Keys — Agent Usability", () => {
               ),
               scenario.agent(),
               (state) => {
-                toolCallFix(state);
 
                 const allText = state.messages
                   .map((m) =>

--- a/skills/_tests/cli-suites.scenario.test.ts
+++ b/skills/_tests/cli-suites.scenario.test.ts
@@ -9,7 +9,6 @@ import { openai } from "@ai-sdk/openai";
 import {
   createClaudeCodeAgent,
   setupLocalCli,
-  toolCallFix,
   SKILL_TESTS_SET_ID,
 } from "./helpers/claude-code-adapter";
 
@@ -76,7 +75,6 @@ Then run these commands:
           ),
           scenario.agent(),
           (state) => {
-            toolCallFix(state);
 
             const allText = state.messages
               .map((m) =>
@@ -143,7 +141,6 @@ If runs exist, get details: \`langwatch simulation-run get <runId>\`
           ),
           scenario.agent(),
           (state) => {
-            toolCallFix(state);
 
             const allText = state.messages
               .map((m) =>
@@ -212,7 +209,6 @@ Then: \`langwatch trigger list --format json\`
           ),
           scenario.agent(),
           (state) => {
-            toolCallFix(state);
 
             const allText = state.messages
               .map((m) =>

--- a/skills/_tests/connect-agent.scenario.test.ts
+++ b/skills/_tests/connect-agent.scenario.test.ts
@@ -1,4 +1,4 @@
-import scenario, { type ScenarioExecutionStateLike } from "@langwatch/scenario";
+import scenario, { type ScenarioExecutionStateLike, assertSkillWasRead, bashCommands } from "@langwatch/scenario";
 import fs from "fs";
 import { describe, it, expect } from "vitest";
 import dotenv from "dotenv";
@@ -6,15 +6,12 @@ import path from "path";
 import { fileURLToPath } from "url";
 import { openai } from "@ai-sdk/openai";
 import {
-  assertSkillWasRead,
-  bashCommands,
   copyFixtureToWorkDir,
   createClaudeCodeAgent,
   createSkillTestWorkDir,
   installSkillToWorkDir,
   removeSkillTestWorkDir,
   SKILL_TESTS_SET_ID,
-  toolCallFix,
 } from "./helpers/claude-code-adapter";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -123,7 +120,6 @@ describe("Connect Agent Skill", () => {
             ),
             scenario.agent(),
             (state) => {
-              toolCallFix(state);
               assertSkillWasRead(state, "connect-agent");
 
               const pythonFiles = findFiles(tempFolder, /\.py$/);
@@ -236,7 +232,6 @@ describe("Connect Agent Skill", () => {
             ),
             scenario.agent(),
             (state) => {
-              toolCallFix(state);
               assertSkillWasRead(state, "connect-agent");
 
               const pythonContent = readAll(findFiles(tempFolder, /\.py$/));

--- a/skills/_tests/datasets.scenario.test.ts
+++ b/skills/_tests/datasets.scenario.test.ts
@@ -1,12 +1,11 @@
 import { openai } from "@ai-sdk/openai";
-import scenario from "@langwatch/scenario";
+import scenario, { assertSkillWasRead } from "@langwatch/scenario";
 import dotenv from "dotenv";
 import fs from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
 import { describe, expect, it } from "vitest";
 import {
-	assertSkillWasRead,
 	copyFixtureToWorkDir,
 	createClaudeCodeAgent,
 	createSkillTestWorkDir,
@@ -14,7 +13,6 @@ import {
 	removeSkillTestWorkDir,
 	SKILL_TESTS_SET_ID,
 	setupLocalCli,
-	toolCallFix,
 } from "./helpers/claude-code-adapter";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -139,17 +137,14 @@ describe("Dataset Generation Skill", () => {
 							),
 							scenario.agent(),
 							(state) => {
-								toolCallFix(state);
 							},
 							scenario.user(),
 							scenario.agent(),
 							(state) => {
-								toolCallFix(state);
 							},
 							scenario.user(),
 							scenario.agent(),
 							(state) => {
-								toolCallFix(state);
 								assertSkillWasRead(state, "datasets");
 
 								// Check a CSV file was created
@@ -252,17 +247,14 @@ describe("Dataset Generation Skill", () => {
 							),
 							scenario.agent(),
 							(state) => {
-								toolCallFix(state);
 							},
 							scenario.user(),
 							scenario.agent(),
 							(state) => {
-								toolCallFix(state);
 							},
 							scenario.user(),
 							scenario.agent(),
 							(state) => {
-								toolCallFix(state);
 								assertSkillWasRead(state, "datasets");
 
 								const csvFiles = findGeneratedFiles({
@@ -355,17 +347,14 @@ describe("Dataset Generation Skill", () => {
 							scenario.user("create an evaluation dataset for my project"),
 							scenario.agent(),
 							(state) => {
-								toolCallFix(state);
 							},
 							scenario.user(),
 							scenario.agent(),
 							(state) => {
-								toolCallFix(state);
 							},
 							scenario.user(),
 							scenario.agent(),
 							(state) => {
-								toolCallFix(state);
 								assertSkillWasRead(state, "datasets");
 							},
 							scenario.judge(),
@@ -435,17 +424,14 @@ describe("Dataset Generation Skill", () => {
 							),
 							scenario.agent(),
 							(state) => {
-								toolCallFix(state);
 							},
 							scenario.user(),
 							scenario.agent(),
 							(state) => {
-								toolCallFix(state);
 							},
 							scenario.user(),
 							scenario.agent(),
 							(state) => {
-								toolCallFix(state);
 								assertSkillWasRead(state, "datasets");
 
 								const csvFiles = findGeneratedFiles({
@@ -535,17 +521,14 @@ describe("Dataset Generation Skill", () => {
 							),
 							scenario.agent(),
 							(state) => {
-								toolCallFix(state);
 							},
 							scenario.user(),
 							scenario.agent(),
 							(state) => {
-								toolCallFix(state);
 							},
 							scenario.user(),
 							scenario.agent(),
 							(state) => {
-								toolCallFix(state);
 								assertSkillWasRead(state, "datasets");
 
 								const csvFiles = findGeneratedFiles({

--- a/skills/_tests/experiments-faithfulness.scenario.test.ts
+++ b/skills/_tests/experiments-faithfulness.scenario.test.ts
@@ -1,11 +1,9 @@
-import scenario from "@langwatch/scenario";
+import scenario, { assertSkillWasRead } from "@langwatch/scenario";
 import { describe, expect, it } from "vitest";
 
 import {
-	assertSkillWasRead,
 	createClaudeCodeAgent,
 	SKILL_TESTS_SET_ID,
-	toolCallFix,
 } from "./helpers/claude-code-adapter";
 import {
 	experimentsJudgeModel,
@@ -53,7 +51,6 @@ describe("Experiments Skill for targeted faithfulness", () => {
 							),
 							scenario.agent(),
 							(state) => {
-								toolCallFix(state);
 								assertSkillWasRead(state, "experiments");
 								const createdFiles = findFilesCreatedSince({
 									directory: workingDirectory,

--- a/skills/_tests/experiments-python-langgraph.scenario.test.ts
+++ b/skills/_tests/experiments-python-langgraph.scenario.test.ts
@@ -1,11 +1,9 @@
-import scenario from "@langwatch/scenario";
+import scenario, { assertSkillWasRead } from "@langwatch/scenario";
 import { describe, expect, it } from "vitest";
 
 import {
-	assertSkillWasRead,
 	createClaudeCodeAgent,
 	SKILL_TESTS_SET_ID,
-	toolCallFix,
 } from "./helpers/claude-code-adapter";
 import {
 	experimentsJudgeModel,
@@ -53,7 +51,6 @@ describe("Experiments Skill for a Python LangGraph agent", () => {
 							),
 							scenario.agent(),
 							(state) => {
-								toolCallFix(state);
 								assertSkillWasRead(state, "experiments");
 								const createdFiles = findFilesCreatedSince({
 									directory: workingDirectory,

--- a/skills/_tests/experiments-python-openai.scenario.test.ts
+++ b/skills/_tests/experiments-python-openai.scenario.test.ts
@@ -1,11 +1,9 @@
-import scenario from "@langwatch/scenario";
+import scenario, { assertSkillWasRead } from "@langwatch/scenario";
 import { describe, expect, it } from "vitest";
 
 import {
-	assertSkillWasRead,
 	createClaudeCodeAgent,
 	SKILL_TESTS_SET_ID,
-	toolCallFix,
 } from "./helpers/claude-code-adapter";
 import {
 	executedCommandTranscript,
@@ -78,7 +76,6 @@ describe("Experiments Skill for a Python OpenAI bot", () => {
 									),
 									"Expected a single `langwatch experiment list --format json` command",
 								).toBe(true);
-								toolCallFix(state);
 								assertSkillWasRead(state, "experiments");
 
 								const createdFiles = findFilesCreatedSince({

--- a/skills/_tests/experiments-rag.scenario.test.ts
+++ b/skills/_tests/experiments-rag.scenario.test.ts
@@ -1,11 +1,9 @@
-import scenario from "@langwatch/scenario";
+import scenario, { assertSkillWasRead } from "@langwatch/scenario";
 import { describe, expect, it } from "vitest";
 
 import {
-	assertSkillWasRead,
 	createClaudeCodeAgent,
 	SKILL_TESTS_SET_ID,
-	toolCallFix,
 } from "./helpers/claude-code-adapter";
 import {
 	experimentsJudgeModel,
@@ -53,7 +51,6 @@ describe("Experiments Skill for a domain-specific RAG agent", () => {
 							),
 							scenario.agent(),
 							(state) => {
-								toolCallFix(state);
 								assertSkillWasRead(state, "experiments");
 								const createdFiles = findFilesCreatedSince({
 									directory: workingDirectory,

--- a/skills/_tests/experiments-typescript-vercel.scenario.test.ts
+++ b/skills/_tests/experiments-typescript-vercel.scenario.test.ts
@@ -1,11 +1,9 @@
-import scenario from "@langwatch/scenario";
+import scenario, { assertSkillWasRead } from "@langwatch/scenario";
 import { describe, expect, it } from "vitest";
 
 import {
-	assertSkillWasRead,
 	createClaudeCodeAgent,
 	SKILL_TESTS_SET_ID,
-	toolCallFix,
 } from "./helpers/claude-code-adapter";
 import {
 	experimentsJudgeModel,
@@ -53,7 +51,6 @@ describe("Experiments Skill for a TypeScript Vercel AI bot", () => {
 							),
 							scenario.agent(),
 							(state) => {
-								toolCallFix(state);
 								assertSkillWasRead(state, "experiments");
 								const createdFiles = findFilesCreatedSince({
 									directory: workingDirectory,

--- a/skills/_tests/helpers/claude-code-adapter.ts
+++ b/skills/_tests/helpers/claude-code-adapter.ts
@@ -1,10 +1,9 @@
 import {
 	type AgentAdapter,
-	AgentRole,
-	type ScenarioExecutionStateLike,
+	claudeCodeAgent,
+	pointClaudeMdAtSkills,
 } from "@langwatch/scenario";
 import chalk from "chalk";
-import { execSync, spawn } from "child_process";
 import fs from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
@@ -19,6 +18,13 @@ const __dirname = path.dirname(__filename);
  * the skills themselves create at runtime end up.
  */
 export const SKILL_TESTS_SET_ID = "skill-tests";
+
+/**
+ * How long one Claude Code turn may take. A skill run installs dependencies,
+ * writes tests and runs them, so a turn is measured in minutes, not the two
+ * the SDK defaults to. Matches the vitest test timeout.
+ */
+const CLAUDE_TURN_TIMEOUT_MS = 60 * 60 * 1000;
 
 const skillTestWorkRoot = path.resolve(
 	__dirname,
@@ -120,48 +126,18 @@ exec node "${cliDistPath}" "$@"
 	fs.writeFileSync(wrapperPath, wrapperScript, { mode: 0o755 });
 }
 
-export function ensureClaudeSkillInstructions(workingDirectory: string): void {
-	const skillsDir = path.join(workingDirectory, ".skills");
-	if (!fs.existsSync(skillsDir)) return;
-
-	const skillPaths = fs
-		.readdirSync(skillsDir, { withFileTypes: true })
-		.filter(
-			(entry) =>
-				entry.isDirectory() &&
-				fs.existsSync(path.join(skillsDir, entry.name, "SKILL.md")),
-		)
-		.map((entry) => `.skills/${entry.name}/SKILL.md`);
-	if (skillPaths.length === 0) return;
-
-	const claudeMdPath = path.join(workingDirectory, "CLAUDE.md");
-	const existingInstructions = fs.existsSync(claudeMdPath)
-		? fs.readFileSync(claudeMdPath, "utf8")
-		: "";
-	const missingSkillPaths = skillPaths.filter(
-		(skillPath) => !existingInstructions.includes(skillPath),
-	);
-	if (missingSkillPaths.length === 0) return;
-
-	const separator =
-		existingInstructions.length > 0 && !existingInstructions.endsWith("\n")
-			? "\n"
-			: "";
-	fs.appendFileSync(
-		claudeMdPath,
-		`${separator}Read and follow the instructions in ${missingSkillPaths.join(
-			" and ",
-		)} before doing anything else.\n`,
-	);
-}
-
 /**
- * Creates a Claude Code agent adapter for use with @langwatch/scenario.
+ * Creates the Claude Code agent under test, the `claudeCodeAgent` of
+ * `@langwatch/scenario` configured for skill testing.
  *
- * Spawns Claude Code via child_process.spawn. Skills are CLI-only, and the locally
- * built `langwatch` CLI is always wired onto PATH so the agent can use
- * `langwatch docs`, `langwatch scenario-docs`, and every platform command.
- * No MCP server is configured; skills must work end-to-end through the CLI.
+ * Skills are CLI-only, and the locally built `langwatch` CLI is always wired
+ * onto PATH so the agent can use `langwatch docs`, `langwatch scenario-docs`,
+ * and every platform command. No MCP server is configured; skills must work
+ * end-to-end through the CLI. The turn comes back as AI SDK messages with
+ * `tool-call` and `tool-result` parts, so the judge reads what the agent ran
+ * and the run view renders it as tool calls. The SDK keeps the spawned Claude
+ * in its own process group and kills it, with everything it started, when
+ * the test process dies, so an interrupted run leaves no Claude behind.
  *
  * @param workingDirectory - The directory to run Claude Code in
  * @param skillPath - Optional path to a SKILL.md to copy into the working directory
@@ -189,538 +165,41 @@ export function createClaudeCodeAgent({
 	extraEnv?: Record<string, string>;
 }): AgentAdapter {
 	setupLocalCli(workingDirectory);
-	if (skillPath) {
-		const skillName = path.basename(path.dirname(skillPath));
-		const skillDir = path.join(workingDirectory, ".skills", skillName);
-		fs.mkdirSync(skillDir, { recursive: true });
-		fs.copyFileSync(skillPath, path.join(skillDir, "SKILL.md"));
+
+	// The batch of the harness is not the batch of the agent. Several skills
+	// tell the agent to write scenario tests and run them, and those runs would
+	// otherwise join the batch this suite reports under and read as results of
+	// the suite itself.
+	const removedKeys = ["SCENARIO_BATCH_RUN_ID", ...omitEnvKeys];
+	if (cleanEnv) {
+		removedKeys.push("LANGWATCH_API_KEY", "OPENAI_API_KEY", "ANTHROPIC_API_KEY");
 	}
 
-	// Claude Code does not auto-discover .skills/ in arbitrary directories.
-	// Preserve any existing CLAUDE.md and append only missing skill references.
-	ensureClaudeSkillInstructions(workingDirectory);
-
-	return {
-		role: AgentRole.AGENT,
-		call: async (state) => {
-			// Render each turn as plain text. Anthropic-format messages can have
-			// `content` as an array of blocks (text, tool_use, tool_result, image,
-			// …). String-interpolating that array yields `[object Object]`, which
-			// the next Claude Code session then sees as the previous turn, making
-			// multi-turn scenarios appear garbled to the agent. Flatten content
-			// blocks down to readable text instead.
-			const renderContent = (content: unknown): string => {
-				if (typeof content === "string") return content;
-				if (!Array.isArray(content)) {
-					try {
-						return JSON.stringify(content);
-					} catch {
-						return String(content);
-					}
-				}
-				return content
-					.map((block: any) => {
-						if (block == null) return "";
-						if (typeof block === "string") return block;
-						switch (block.type) {
-							case "text":
-								return block.text ?? "";
-							case "tool-call":
-							case "tool_use": {
-								const input =
-									block.input != null ? JSON.stringify(block.input) : "";
-								const name = block.toolName ?? block.name ?? "?";
-								return `[tool_use ${name}(${input})]`;
-							}
-							case "tool-result": {
-								const value = block.output?.value ?? block.output;
-								const inner =
-									typeof value === "string" ? value : JSON.stringify(value);
-								return `[tool_result] ${inner}`;
-							}
-							case "tool_result": {
-								const inner =
-									typeof block.content === "string"
-										? block.content
-										: Array.isArray(block.content)
-											? renderContent(block.content)
-											: JSON.stringify(block.content ?? "");
-								return `[tool_result] ${inner}`;
-							}
-							case "image":
-								return "[image omitted]";
-							default:
-								try {
-									return JSON.stringify(block);
-								} catch {
-									return String(block);
-								}
-						}
-					})
-					.filter(Boolean)
-					.join("\n");
-			};
-
-			const formattedMessages = state.messages
-				.map((message) => `${message.role}: ${renderContent(message.content)}`)
-				.join("\n\n");
-
-			return new Promise<string>((resolve, reject) => {
-				const claudeBin =
-					process.env.CLAUDE_BIN ||
-					execSync("which claude", { encoding: "utf8" }).trim();
-
-				// Pin the model. The user's default in ~/.claude/settings.json can be
-				// a more expensive tier, and these tests run many sub Claudes.
-				const args = [
-					"--model",
-					"opus",
-					"--output-format",
-					"stream-json",
-					"-p",
-					"--dangerously-skip-permissions",
-					"--verbose",
-					formattedMessages,
-				];
-
-				console.log(chalk.blue("Starting claude in:"), workingDirectory);
-
-				const omittedKeys = new Set(omitEnvKeys);
-				// The batch of the harness is not the batch of the agent. Several
-				// skills tell the agent to write scenario tests and run them, and
-				// those runs would otherwise join the batch this suite reports
-				// under and read as results of the suite itself.
-				omittedKeys.add("SCENARIO_BATCH_RUN_ID");
-				if (cleanEnv) {
-					omittedKeys.add("LANGWATCH_API_KEY");
-					omittedKeys.add("OPENAI_API_KEY");
-					omittedKeys.add("ANTHROPIC_API_KEY");
-				}
-				const envVars =
-					omittedKeys.size > 0
-						? Object.fromEntries(
-								Object.entries(process.env).filter(
-									([key]) => !omittedKeys.has(key),
-								),
-							)
-						: process.env;
-
-				// Prepend the local bin/ wrapper (created by setupLocalCli) so Claude
-				// uses the locally-built `langwatch` CLI with the latest commands.
-				const localBinDir = path.join(workingDirectory, "bin");
-				const pathPrefix = `${localBinDir}:${envVars.PATH ?? ""}`;
-
-				const child = spawn(claudeBin, args, {
-					cwd: workingDirectory,
-					env: {
-						...envVars,
-						...extraEnv,
-						FORCE_COLOR: "0",
-						PATH: pathPrefix,
-					},
-					stdio: ["ignore", "pipe", "pipe"],
-				});
-
-				let output = "";
-
-				child.stdout.on("data", (data: Buffer) => {
-					const text = data.toString();
-					console.log(chalk.cyan("Claude Code:"), text);
-					output += text;
-				});
-
-				child.stderr.on("data", (data: Buffer) => {
-					console.log(chalk.yellow("Claude Code stderr:"), data.toString());
-				});
-
-				child.on("close", (exitCode) => {
-					if (exitCode === 0) {
-						const rawMessages: any[] = output
-							.split("\n")
-							.map((line) => {
-								try {
-									return JSON.parse(line.trim());
-								} catch {
-									return null;
-								}
-							})
-							.filter((message) => message !== null && "message" in message)
-							.map((message) => message.message);
-						const messages = claudeCodeTranscriptToModelMessages(rawMessages);
-						// Roles and counts only. The messages carry tool results,
-						// which can hold file contents and keys, and this runs on
-						// a shared stdout.
-						console.log(
-							`[claude-code adapter] ${messages.length} message(s): ` +
-								messages.map((message) => message.role).join(", "),
-						);
-
-						resolve(messages as any);
-					} else {
-						reject(
-							new Error(
-								`Claude Code failed with exit code ${exitCode}` +
-									`${describeFailure(output)}`,
-							),
-						);
-					}
-				});
-
-				child.on("error", (err) => {
-					reject(err);
-				});
-			});
+	const agent = claudeCodeAgent({
+		workingDirectory,
+		skillPath,
+		// Pin the model. The user's default in ~/.claude/settings.json can be
+		// a more expensive tier, and these tests run many sub Claudes.
+		model: "opus",
+		skipPermissions: true,
+		output: "messages",
+		timeout: CLAUDE_TURN_TIMEOUT_MS,
+		env: {
+			...Object.fromEntries(removedKeys.map((key) => [key, undefined])),
+			...extraEnv,
+			// The local bin/ wrapper first, so Claude uses the locally-built
+			// `langwatch` CLI with the latest commands.
+			PATH: `${path.join(workingDirectory, "bin")}:${process.env.PATH ?? ""}`,
 		},
-	};
-}
-
-/**
- * What the last line of the stream says about a failed run.
- *
- * Claude Code closes its stream with a result object that carries the reason
- * it stopped. Without it the test reports only "exit code 1", which reads as a
- * crash and sends the reader to the wrong place. The two that matter here are
- * a refusal, which a red team scenario can meet because of the content it
- * writes, and a rate limit, which means rerun the file later.
- */
-function describeFailure(output: string): string {
-	for (const line of output.split("\n").reverse()) {
-		const text = line.trim();
-		if (!text.startsWith("{")) continue;
-		try {
-			const parsed = JSON.parse(text) as {
-				is_error?: boolean;
-				stop_reason?: string;
-				terminal_reason?: string;
-				result?: unknown;
-			};
-			if (!parsed.is_error) continue;
-			const reasons = [parsed.stop_reason, parsed.terminal_reason]
-				.filter(Boolean)
-				.join(", ");
-			const detail =
-				typeof parsed.result === "string" ? `: ${parsed.result.slice(0, 300)}` : "";
-			return reasons ? ` (${reasons})${detail}` : detail;
-		} catch {
-			continue;
-		}
-	}
-	return "";
-}
-
-type ModelMessage = {
-	role: "user" | "assistant" | "tool";
-	content: string | Record<string, unknown>[];
-};
-
-/**
- * How much of one tool result may reach the conversation.
- *
- * The judge and the user simulator read the whole conversation on every
- * step. A skill that exports traces puts hundreds of kilobytes into a
- * single result, and a long run then goes past the context window of the
- * judge model. The test then fails for a reason that has nothing to do
- * with the skill. A result is the evidence the agent gathered, and what
- * these tests read of it is short: command names, URLs and ids, which
- * stand at the start of the output.
- */
-const MAX_TOOL_RESULT_CHARS = 8000;
-
-/**
- * How much of one tool call may reach the conversation.
- *
- * A call carries what the agent wrote: the dataset, the report, the test
- * file. That is the work under judgement, so it keeps far more room than
- * a result, and there are few such calls in a run.
- */
-const MAX_TOOL_INPUT_CHARS = 30000;
-
-function truncateText({ text, limit }: { text: string; limit: number }): string {
-	if (text.length <= limit) return text;
-	const dropped = text.length - limit;
-	return `${text.slice(0, limit)}\n… [${dropped} more characters]`;
-}
-
-/**
- * The call cap over the string fields of a tool call, structure kept.
- *
- * Nested objects and arrays are walked, not only the top level: a payload such
- * as `{ body: { html } }` carries the same unbounded text a top-level field
- * would, and it reaches every judge prompt the same way.
- */
-function truncateToolInput(input: unknown): unknown {
-	if (typeof input === "string") {
-		return truncateText({ text: input, limit: MAX_TOOL_INPUT_CHARS });
-	}
-	if (Array.isArray(input)) return input.map((item) => truncateToolInput(item));
-	if (input == null || typeof input !== "object") return input;
-	return Object.fromEntries(
-		Object.entries(input as Record<string, unknown>).map(([key, value]) => [
-			key,
-			truncateToolInput(value),
-		]),
-	);
-}
-
-function toolResultText(content: unknown): string {
-	if (typeof content === "string") return content;
-	if (!Array.isArray(content)) return JSON.stringify(content ?? "");
-	return content
-		.map((block: any) =>
-			block?.type === "text" && typeof block.text === "string"
-				? block.text
-				: JSON.stringify(block),
-		)
-		.join("\n");
-}
-
-/**
- * The blocks this converter reads. Anything else is a block Claude Code can
- * write that the conversation has no part for, most often an `image` or a
- * `document` a tool returned.
- */
-const KNOWN_BLOCK_TYPES = new Set([
-	"text",
-	"thinking",
-	"redacted_thinking",
-	"tool_use",
-	"tool_result",
-]);
-
-/**
- * What a block of any other type leaves in the conversation.
- *
- * The judge reads this transcript, so a block that silently disappeared would
- * read as a turn the agent never took. A line naming the type keeps the turn
- * whole and says what is not shown, which is the honest answer for a block the
- * AI SDK message format cannot carry.
- */
-function unsupportedBlockText(block: any): string {
-	return `[${String(block?.type ?? "unknown")} block, not shown in the transcript]`;
-}
-
-/** One assistant turn: the text it wrote, then the tool calls it made. */
-function assistantMessageFromBlocks({
-	content,
-	toolNamesByCallId,
-}: {
-	content: any[];
-	toolNamesByCallId: Map<string, string>;
-}): ModelMessage | null {
-	const texts: string[] = [];
-	const toolCalls: Record<string, unknown>[] = [];
-
-	for (const block of content) {
-		if (block?.type === "text" && typeof block.text === "string") {
-			texts.push(block.text);
-		} else if (block?.type === "tool_use") {
-			toolNamesByCallId.set(block.id, block.name);
-			toolCalls.push({
-				type: "tool-call",
-				toolCallId: block.id,
-				toolName: block.name,
-				input: truncateToolInput(block.input ?? {}),
-			});
-		} else if (!KNOWN_BLOCK_TYPES.has(block?.type)) {
-			texts.push(unsupportedBlockText(block));
-		}
-		// Thinking blocks are dropped: they are not part of the conversation.
-	}
-
-	if (texts.length === 0 && toolCalls.length === 0) return null;
-	return {
-		role: "assistant",
-		content: [{ type: "text", text: texts.join("\n") }, ...toolCalls],
-	};
-}
-
-/**
- * One user turn: the tool results it answers with become a `tool` message, and
- * whatever text it carries becomes a `user` message after it.
- */
-function userMessagesFromBlocks({
-	content,
-	toolNamesByCallId,
-}: {
-	content: any[];
-	toolNamesByCallId: Map<string, string>;
-}): ModelMessage[] {
-	const messages: ModelMessage[] = [];
-
-	const toolResults = content
-		.filter((block: any) => block?.type === "tool_result")
-		.map((block: any) => ({
-			type: "tool-result",
-			toolCallId: block.tool_use_id,
-			toolName: toolNamesByCallId.get(block.tool_use_id) ?? "tool",
-			output: {
-				type: block.is_error ? "error-text" : "text",
-				value: truncateText({
-					text: toolResultText(block.content),
-					limit: MAX_TOOL_RESULT_CHARS,
-				}),
-			},
-		}));
-	if (toolResults.length > 0) {
-		messages.push({ role: "tool", content: toolResults });
-	}
-
-	const texts = content
-		.filter(
-			(block: any) =>
-				(block?.type === "text" && typeof block.text === "string") ||
-				!KNOWN_BLOCK_TYPES.has(block?.type),
-		)
-		.map((block: any) =>
-			block?.type === "text" ? block.text : unsupportedBlockText(block),
-		);
-	if (texts.length > 0) {
-		messages.push({ role: "user", content: texts.join("\n") });
-	}
-
-	return messages;
-}
-
-/**
- * Converts the `claude -p --output-format stream-json` transcript into AI SDK
- * model messages, the format `@langwatch/scenario` works with.
- *
- * Claude Code writes Anthropic-format messages: an assistant turn is an array
- * of `thinking`, `text` and `tool_use` blocks, and each tool result comes back
- * as a `user` message holding `tool_result` blocks. The scenario SDK passes an
- * adapter's array return through as is, so those blocks reached the platform
- * unchanged, where the scenario-events validator refused every snapshot that
- * carried one. The run then kept only the last snapshot that validated: the
- * user message and the first assistant text. The user simulator of the SDK
- * also only summarizes `tool-call` and `tool-result` parts, not the Anthropic
- * blocks.
- *
- * Each assistant turn becomes one text part (the text blocks joined, an empty
- * string when the turn only called tools, so the AG-UI conversion keeps the
- * `toolCalls` next to a string content) followed by one `tool-call` part per
- * `tool_use` block. Each `tool_result` block becomes a `tool-result` part of a
- * `tool` message, with the tool name looked up from the call it answers.
- * Thinking blocks are dropped: they are not part of the conversation. A block
- * of any other type, such as an `image` a tool returned, leaves a line naming
- * its type rather than disappearing from the turn.
- */
-export function claudeCodeTranscriptToModelMessages(
-	rawMessages: any[],
-): ModelMessage[] {
-	const toolNamesByCallId = new Map<string, string>();
-	const messages: ModelMessage[] = [];
-
-	for (const raw of rawMessages) {
-		if (!raw || typeof raw !== "object") continue;
-		const { role, content } = raw;
-
-		if (role !== "assistant" && role !== "user") continue;
-		if (typeof content === "string") {
-			messages.push({ role, content });
-			continue;
-		}
-		if (!Array.isArray(content)) continue;
-
-		if (role === "assistant") {
-			const message = assistantMessageFromBlocks({
-				content,
-				toolNamesByCallId,
-			});
-			if (message) messages.push(message);
-			continue;
-		}
-
-		messages.push(...userMessagesFromBlocks({ content, toolNamesByCallId }));
-	}
-
-	return messages;
-}
-
-/**
- * Asserts that the agent actually read the SKILL.md file during execution.
- * Checks the conversation messages for evidence of a Read tool call on
- * a .skills/ directory file or explicit SKILL.md content references.
- */
-export function assertSkillWasRead(
-	state: ScenarioExecutionStateLike,
-	skillName: string,
-): void {
-	const allContent = state.messages
-		.map((m) =>
-			typeof m.content === "string" ? m.content : JSON.stringify(m.content),
-		)
-		.join("\n");
-
-	const hasSkillRead =
-		allContent.includes("SKILL.md") ||
-		allContent.includes(`.skills/${skillName}`) ||
-		allContent.includes(`skills/${skillName}`);
-
-	if (!hasSkillRead) {
-		throw new Error(
-			`Expected agent to read the ${skillName} SKILL.md file, but found no evidence ` +
-				`of reading .skills/${skillName}/SKILL.md in the conversation. ` +
-				`The agent may have ignored the skill and hallucinated instructions.`,
-		);
-	}
-}
-
-/**
- * The shell commands the agent ran, read from its Bash tool calls.
- *
- * A phrase in the transcript is not a command that ran: the skill text the
- * agent read and its own explanation of what it did not do both quote
- * commands. Reads the AI SDK `tool-call` parts the adapter emits, the
- * Anthropic `tool_use` blocks of an unconverted transcript, and the JSON text
- * `toolCallFix` leaves behind for either.
- */
-export function bashCommands(state: ScenarioExecutionStateLike): string[] {
-	const commands: string[] = [];
-	for (const message of state.messages) {
-		if (!Array.isArray(message.content)) continue;
-		for (const block of message.content as any[]) {
-			let candidate: any = block;
-			if (
-				block?.type === "text" &&
-				typeof block.text === "string" &&
-				block.text.startsWith("{")
-			) {
-				try {
-					candidate = JSON.parse(block.text);
-				} catch {
-					continue;
-				}
-			}
-			const isBashCall =
-				(candidate?.type === "tool-call" && candidate.toolName === "Bash") ||
-				(candidate?.type === "tool_use" && candidate.name === "Bash");
-			if (isBashCall && typeof candidate.input?.command === "string") {
-				commands.push(candidate.input.command);
-			}
-		}
-	}
-	return commands;
-}
-
-/**
- * Turns content parts the scenario SDK does not know into text parts holding
- * their JSON, so a model call over the conversation never receives a part it
- * cannot read. The AI SDK `tool-call` and `tool-result` parts stay as they
- * are: the SDK summarizes them for the user simulator and the platform stores
- * and renders them.
- */
-export function toolCallFix(state: ScenarioExecutionStateLike): void {
-	const knownPartTypes = new Set(["text", "tool-call", "tool-result"]);
-	state.messages.forEach((message) => {
-		if (Array.isArray(message.content)) {
-			message.content.forEach((content, index) => {
-				if (!knownPartTypes.has(content.type)) {
-					(message.content as any)[index] = {
-						type: "text",
-						text: JSON.stringify(content),
-					};
-				}
-			});
-		}
+		logger: {
+			log: (message) => console.log(chalk.cyan("Claude Code:"), message),
+			warn: (message) => console.log(chalk.yellow("Claude Code:"), message),
+		},
 	});
+
+	// The skills a test installed with installSkillToWorkDir are not the one
+	// skillPath injects, and Claude Code does not discover .skills/ on its own.
+	pointClaudeMdAtSkills(workingDirectory);
+
+	return agent;
 }

--- a/skills/_tests/helpers/claude-code-adapter.ts
+++ b/skills/_tests/helpers/claude-code-adapter.ts
@@ -189,7 +189,7 @@ export function createClaudeCodeAgent({
 			...extraEnv,
 			// The local bin/ wrapper first, so Claude uses the locally-built
 			// `langwatch` CLI with the latest commands.
-			PATH: `${path.join(workingDirectory, "bin")}:${process.env.PATH ?? ""}`,
+			PATH: `${path.join(workingDirectory, "bin")}:${extraEnv.PATH ?? process.env.PATH ?? ""}`,
 		},
 		logger: {
 			log: (message) => console.log(chalk.cyan("Claude Code:"), message),

--- a/skills/_tests/helpers/experiments-scenario.ts
+++ b/skills/_tests/helpers/experiments-scenario.ts
@@ -1,10 +1,10 @@
+import { bashCommands } from "@langwatch/scenario";
 import dotenv from "dotenv";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import {
-	bashCommands,
 	copyFixtureToWorkDir,
 	createSkillTestWorkDir,
 	installSkillToWorkDir,

--- a/skills/_tests/helpers/no-orphan-harness.ts
+++ b/skills/_tests/helpers/no-orphan-harness.ts
@@ -1,0 +1,30 @@
+/**
+ * Stands in for a vitest worker that is running Claude Code, for
+ * `no-orphan-process.test.ts`. It builds the same agent the skill scenario
+ * tests build and starts one turn, which never returns: the test puts a fake
+ * `claude` on the agent's PATH that keeps running until something kills it.
+ *
+ * The test kills this process without warning and then checks that the fake
+ * `claude`, and the child that fake started, are gone too.
+ */
+import { type AgentInput, AgentRole } from "@langwatch/scenario";
+
+import { createClaudeCodeAgent } from "./claude-code-adapter.js";
+
+const workingDirectory = process.argv[2];
+if (!workingDirectory) {
+	throw new Error("usage: no-orphan-harness <workingDirectory>");
+}
+
+const agent = createClaudeCodeAgent({ workingDirectory });
+
+// The Claude Code adapter reads the thread id and the messages, so the rest of
+// AgentInput, which only a real scenario run can build, stays out of the turn.
+const input = {
+	threadId: "no-orphan",
+	messages: [{ role: "user" as const, content: "hang" }],
+	newMessages: [{ role: "user" as const, content: "hang" }],
+	requestedRole: AgentRole.AGENT,
+} satisfies Partial<AgentInput>;
+
+await agent.call(input as AgentInput);

--- a/skills/_tests/level-up.scenario.test.ts
+++ b/skills/_tests/level-up.scenario.test.ts
@@ -1,4 +1,4 @@
-import scenario from "@langwatch/scenario";
+import scenario, { assertSkillWasRead } from "@langwatch/scenario";
 import fs from "fs";
 import { describe, it, expect } from "vitest";
 import dotenv from "dotenv";
@@ -9,8 +9,6 @@ import { openai } from "@ai-sdk/openai";
 import {
   copyFixtureToWorkDir,
   createClaudeCodeAgent,
-  toolCallFix,
-  assertSkillWasRead,
   installSkillToWorkDir,
   SKILL_TESTS_SET_ID,
 } from "./helpers/claude-code-adapter";
@@ -101,7 +99,6 @@ describe("Level-up Skill", () => {
           ),
           scenario.agent(),
           (state) => {
-            toolCallFix(state);
             assertSkillWasRead(state, "level-up");
             // Verify tracing was added
             expectTracingInSource({ tempFolder, extension: ".py" });
@@ -150,7 +147,6 @@ describe("Level-up Skill", () => {
           ),
           scenario.agent(),
           (state) => {
-            toolCallFix(state);
             assertSkillWasRead(state, "level-up");
             expectTracingInSource({ tempFolder, extension: ".ts" });
           },
@@ -196,7 +192,6 @@ describe("Level-up Skill", () => {
           ),
           scenario.agent(),
           (state) => {
-            toolCallFix(state);
             assertSkillWasRead(state, "level-up");
             expectTracingInSource({ tempFolder, extension: ".py" });
           },
@@ -242,7 +237,6 @@ describe("Level-up Skill", () => {
           ),
           scenario.agent(),
           (state) => {
-            toolCallFix(state);
             assertSkillWasRead(state, "level-up");
             expectTracingInSource({ tempFolder, extension: ".ts" });
           },

--- a/skills/_tests/no-orphan-process.test.ts
+++ b/skills/_tests/no-orphan-process.test.ts
@@ -43,10 +43,15 @@ function readPid(pidPath: string): number | undefined {
 	return Number.isInteger(pid) && pid > 0 ? pid : undefined;
 }
 
-async function waitUntil(
-	condition: () => boolean,
-	{ timeoutMs, what }: { timeoutMs: number; what: string },
-): Promise<void> {
+async function waitUntil({
+	condition,
+	timeoutMs,
+	what,
+}: {
+	condition: () => boolean;
+	timeoutMs: number;
+	what: string;
+}): Promise<void> {
 	const deadline = Date.now() + timeoutMs;
 	while (Date.now() < deadline) {
 		if (condition()) return;
@@ -64,62 +69,63 @@ function killIfRunning(pid: number | undefined): void {
 	}
 }
 
-describe("given a killed test worker that was running Claude Code", () => {
-	// The lifecycle guard uses process groups, which Windows does not have.
-	/** @scenario "No Claude Code process outlives the test harness" */
-	it.skipIf(process.platform === "win32")(
-		"stops Claude Code and everything it started",
-		async () => {
-			const workingDirectory = createSkillTestWorkDir("no-orphan-");
-			const binDir = path.join(workingDirectory, "bin");
-			fs.mkdirSync(binDir, { recursive: true });
-			fs.writeFileSync(
-				path.join(binDir, "claude"),
-				fakeClaudeScript(workingDirectory),
-				{ mode: 0o755 },
-			);
-
-			const harness = spawn(
-				process.execPath,
-				["--import", "tsx", harnessPath, workingDirectory],
-				{ cwd: skillsRoot, stdio: "ignore" },
-			);
-
-			let claudePid: number | undefined;
-			let claudeChildPid: number | undefined;
-			try {
-				await waitUntil(
-					() => {
-						claudePid = readPid(path.join(workingDirectory, "claude.pid"));
-						claudeChildPid = readPid(
-							path.join(workingDirectory, "claude-child.pid"),
-						);
-						return claudePid !== undefined && claudeChildPid !== undefined;
-					},
-					{ timeoutMs: 120_000, what: "the agent to spawn Claude Code" },
+describe("given a test worker is running Claude Code", () => {
+	describe("when the worker is killed", () => {
+		// The lifecycle guard uses process groups, which Windows does not have.
+		/** @scenario "No Claude Code process outlives the test harness" */
+		it.skipIf(process.platform === "win32")(
+			"stops Claude Code and everything it started",
+			async () => {
+				const workingDirectory = createSkillTestWorkDir("no-orphan-");
+				const binDir = path.join(workingDirectory, "bin");
+				fs.mkdirSync(binDir, { recursive: true });
+				fs.writeFileSync(
+					path.join(binDir, "claude"),
+					fakeClaudeScript(workingDirectory),
+					{ mode: 0o755 },
 				);
 
-				expect(isRunning(claudePid as number)).toBe(true);
-				expect(isRunning(claudeChildPid as number)).toBe(true);
+				const harness = spawn(
+					process.execPath,
+					["--import", "tsx", harnessPath, workingDirectory],
+					{ cwd: skillsRoot, stdio: "ignore" },
+				);
 
-				harness.kill("SIGKILL");
+				let claudePid: number | undefined;
+				let claudeChildPid: number | undefined;
+				try {
+					await waitUntil({
+						condition: () => {
+							claudePid = readPid(path.join(workingDirectory, "claude.pid"));
+							claudeChildPid = readPid(
+								path.join(workingDirectory, "claude-child.pid"),
+							);
+							return claudePid !== undefined && claudeChildPid !== undefined;
+						},
+						timeoutMs: 120_000,
+						what: "the agent to spawn Claude Code",
+					});
 
-				await waitUntil(
-					() =>
-						!isRunning(claudePid as number) &&
-						!isRunning(claudeChildPid as number),
-					{
+					expect(isRunning(claudePid as number)).toBe(true);
+					expect(isRunning(claudeChildPid as number)).toBe(true);
+
+					harness.kill("SIGKILL");
+
+					await waitUntil({
+						condition: () =>
+							!isRunning(claudePid as number) &&
+							!isRunning(claudeChildPid as number),
 						timeoutMs: 30_000,
 						what: "Claude Code and its child to stop after the worker was killed",
-					},
-				);
-			} finally {
-				harness.kill("SIGKILL");
-				killIfRunning(claudeChildPid);
-				killIfRunning(claudePid);
-				removeSkillTestWorkDir(workingDirectory);
-			}
-		},
-		180_000,
-	);
+					});
+				} finally {
+					harness.kill("SIGKILL");
+					killIfRunning(claudeChildPid);
+					killIfRunning(claudePid);
+					removeSkillTestWorkDir(workingDirectory);
+				}
+			},
+			180_000,
+		);
+	});
 });

--- a/skills/_tests/no-orphan-process.test.ts
+++ b/skills/_tests/no-orphan-process.test.ts
@@ -1,0 +1,125 @@
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+import {
+	createSkillTestWorkDir,
+	removeSkillTestWorkDir,
+} from "./helpers/claude-code-adapter";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const skillsRoot = path.resolve(__dirname, "..");
+const harnessPath = path.join(__dirname, "helpers", "no-orphan-harness.ts");
+
+/**
+ * A stand-in for the Claude Code CLI: it starts a child of its own, writes both
+ * pids where the test can read them, and then runs until killed. Nothing here
+ * reacts to the harness dying, so the only thing that can stop these two
+ * processes is the lifecycle guard the Scenario SDK adapter installs.
+ */
+function fakeClaudeScript(workingDirectory: string): string {
+	return `#!/bin/sh
+sleep 600 &
+printf '%s\\n' "$!" > "${workingDirectory}/claude-child.pid"
+printf '%s\\n' "$$" > "${workingDirectory}/claude.pid"
+while :; do sleep 1; done
+`;
+}
+
+function isRunning(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+function readPid(pidPath: string): number | undefined {
+	if (!fs.existsSync(pidPath)) return undefined;
+	const pid = Number.parseInt(fs.readFileSync(pidPath, "utf8").trim(), 10);
+	return Number.isInteger(pid) && pid > 0 ? pid : undefined;
+}
+
+async function waitUntil(
+	condition: () => boolean,
+	{ timeoutMs, what }: { timeoutMs: number; what: string },
+): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (condition()) return;
+		await new Promise((resolve) => setTimeout(resolve, 250));
+	}
+	throw new Error(`Timed out after ${timeoutMs}ms waiting for ${what}`);
+}
+
+function killIfRunning(pid: number | undefined): void {
+	if (pid === undefined || !isRunning(pid)) return;
+	try {
+		process.kill(pid, "SIGKILL");
+	} catch {
+		// Already gone between the check and the signal.
+	}
+}
+
+describe("given a killed test worker that was running Claude Code", () => {
+	// The lifecycle guard uses process groups, which Windows does not have.
+	/** @scenario "No Claude Code process outlives the test harness" */
+	it.skipIf(process.platform === "win32")(
+		"stops Claude Code and everything it started",
+		async () => {
+			const workingDirectory = createSkillTestWorkDir("no-orphan-");
+			const binDir = path.join(workingDirectory, "bin");
+			fs.mkdirSync(binDir, { recursive: true });
+			fs.writeFileSync(
+				path.join(binDir, "claude"),
+				fakeClaudeScript(workingDirectory),
+				{ mode: 0o755 },
+			);
+
+			const harness = spawn(
+				process.execPath,
+				["--import", "tsx", harnessPath, workingDirectory],
+				{ cwd: skillsRoot, stdio: "ignore" },
+			);
+
+			let claudePid: number | undefined;
+			let claudeChildPid: number | undefined;
+			try {
+				await waitUntil(
+					() => {
+						claudePid = readPid(path.join(workingDirectory, "claude.pid"));
+						claudeChildPid = readPid(
+							path.join(workingDirectory, "claude-child.pid"),
+						);
+						return claudePid !== undefined && claudeChildPid !== undefined;
+					},
+					{ timeoutMs: 120_000, what: "the agent to spawn Claude Code" },
+				);
+
+				expect(isRunning(claudePid as number)).toBe(true);
+				expect(isRunning(claudeChildPid as number)).toBe(true);
+
+				harness.kill("SIGKILL");
+
+				await waitUntil(
+					() =>
+						!isRunning(claudePid as number) &&
+						!isRunning(claudeChildPid as number),
+					{
+						timeoutMs: 30_000,
+						what: "Claude Code and its child to stop after the worker was killed",
+					},
+				);
+			} finally {
+				harness.kill("SIGKILL");
+				killIfRunning(claudeChildPid);
+				killIfRunning(claudePid);
+				removeSkillTestWorkDir(workingDirectory);
+			}
+		},
+		180_000,
+	);
+});

--- a/skills/_tests/online-evaluations.scenario.test.ts
+++ b/skills/_tests/online-evaluations.scenario.test.ts
@@ -1,17 +1,14 @@
-import scenario, { type ScenarioExecutionStateLike } from "@langwatch/scenario";
+import scenario, { type ScenarioExecutionStateLike, assertSkillWasRead, bashCommands } from "@langwatch/scenario";
 import dotenv from "dotenv";
 import path from "path";
 import { fileURLToPath } from "url";
 import { describe, expect, it } from "vitest";
 import {
-	assertSkillWasRead,
-	bashCommands,
 	createClaudeCodeAgent,
 	createSkillTestWorkDir,
 	installSkillToWorkDir,
 	removeSkillTestWorkDir,
 	SKILL_TESTS_SET_ID,
-	toolCallFix,
 } from "./helpers/claude-code-adapter";
 import { createSkillJudgeModel } from "./helpers/judge-model";
 
@@ -158,7 +155,6 @@ describe("Online Evaluations Skill", () => {
 								const commands = executedCommands(state);
 							expect(commands).toMatch(/langwatch monitor create/);
 							expect(commands).toMatch(/langwatch monitor (get|list)/);
-							toolCallFix(state);
 							assertSkillWasRead(state, "online-evaluations");
 						},
 						scenario.judge(),
@@ -237,7 +233,6 @@ describe("Online Evaluations Skill", () => {
 					(state) => {
 						const commands = executedCommands(state);
 						expect(commands).not.toMatch(/langwatch monitor create/);
-						toolCallFix(state);
 						assertSkillWasRead(state, "online-evaluations");
 					},
 					scenario.judge(),

--- a/skills/_tests/prompts-cli.scenario.test.ts
+++ b/skills/_tests/prompts-cli.scenario.test.ts
@@ -9,7 +9,6 @@ import { openai } from "@ai-sdk/openai";
 import {
   copyFixtureToWorkDir,
   createClaudeCodeAgent,
-  toolCallFix,
   SKILL_TESTS_SET_ID,
 } from "./helpers/claude-code-adapter";
 
@@ -77,7 +76,6 @@ describe("LangWatch Prompts CLI — Agent Usability", () => {
           ),
           scenario.agent(),
           (state) => {
-            toolCallFix(state);
 
             expect(
               fs.existsSync(path.join(tempFolder, "prompts.json")),
@@ -152,7 +150,6 @@ describe("LangWatch Prompts CLI — Agent Usability", () => {
           ),
           scenario.agent(),
           (state) => {
-            toolCallFix(state);
 
             const promptsDir = path.join(tempFolder, "prompts");
             const yamlFiles = fs.existsSync(promptsDir)
@@ -228,7 +225,6 @@ describe("LangWatch Prompts CLI — Agent Usability", () => {
           ),
           scenario.agent(),
           (state) => {
-            toolCallFix(state);
 
             // Verify prompt was created
             const promptsDir = path.join(tempFolder, "prompts");
@@ -294,7 +290,6 @@ describe("LangWatch Prompts CLI — Agent Usability", () => {
           ),
           scenario.agent(),
           (state) => {
-            toolCallFix(state);
 
             const promptsDir = path.join(tempFolder, "prompts");
             const yamlFiles = fs.existsSync(promptsDir)

--- a/skills/_tests/prompts.scenario.test.ts
+++ b/skills/_tests/prompts.scenario.test.ts
@@ -1,4 +1,4 @@
-import scenario from "@langwatch/scenario";
+import scenario, { assertSkillWasRead } from "@langwatch/scenario";
 import fs from "fs";
 import { describe, it, expect } from "vitest";
 import dotenv from "dotenv";
@@ -9,8 +9,6 @@ import { openai } from "@ai-sdk/openai";
 import {
   copyFixtureToWorkDir,
   createClaudeCodeAgent,
-  toolCallFix,
-  assertSkillWasRead,
   installSkillToWorkDir,
   SKILL_TESTS_SET_ID,
 } from "./helpers/claude-code-adapter";
@@ -83,7 +81,6 @@ describe("Prompts Skill", () => {
           ),
           scenario.agent(),
           (state) => {
-            toolCallFix(state);
             assertSkillWasRead(state, "prompts");
 
             // Verify the agent modified main.py to use langwatch prompts
@@ -149,7 +146,6 @@ describe("Prompts Skill", () => {
           ),
           scenario.agent(),
           (state) => {
-            toolCallFix(state);
             assertSkillWasRead(state, "prompts");
             const indexTs = fs.readFileSync(
               `${tempFolder}/index.ts`,
@@ -212,7 +208,6 @@ describe("Prompts Skill", () => {
           ),
           scenario.agent(),
           (state) => {
-            toolCallFix(state);
             assertSkillWasRead(state, "prompts");
 
             const mainPy = fs.readFileSync(
@@ -278,7 +273,6 @@ describe("Prompts Skill", () => {
           ),
           scenario.agent(),
           (state) => {
-            toolCallFix(state);
             assertSkillWasRead(state, "prompts");
 
             const indexTs = fs.readFileSync(
@@ -343,7 +337,6 @@ describe("Prompts Skill", () => {
           ),
           scenario.agent(),
           (state) => {
-            toolCallFix(state);
             assertSkillWasRead(state, "prompts");
             const mainPy = fs.readFileSync(`${tempFolder}/main.py`, "utf8");
             // Either the code was updated to use langwatch prompts, or prompt files were created
@@ -407,7 +400,6 @@ describe("Prompts Skill", () => {
           ),
           scenario.agent(),
           (state) => {
-            toolCallFix(state);
             assertSkillWasRead(state, "prompts");
 
             const mainPy = fs.readFileSync(

--- a/skills/_tests/recipes.scenario.test.ts
+++ b/skills/_tests/recipes.scenario.test.ts
@@ -1,4 +1,4 @@
-import scenario from "@langwatch/scenario";
+import scenario, { assertSkillWasRead } from "@langwatch/scenario";
 import fs from "fs";
 import { describe, it, expect } from "vitest";
 import dotenv from "dotenv";
@@ -9,8 +9,6 @@ import { openai } from "@ai-sdk/openai";
 import {
   copyFixtureToWorkDir,
   createClaudeCodeAgent,
-  toolCallFix,
-  assertSkillWasRead,
   installSkillToWorkDir,
   SKILL_TESTS_SET_ID,
 } from "./helpers/claude-code-adapter";
@@ -115,7 +113,6 @@ describe("Recipes", () => {
           ),
           scenario.agent(),
           (state) => {
-            toolCallFix(state);
             assertSkillWasRead(state, "generate-rag-dataset");
 
             // Find CSV or Python dataset files
@@ -215,7 +212,6 @@ describe("Recipes", () => {
           ),
           scenario.agent(),
           (state) => {
-            toolCallFix(state);
             assertSkillWasRead(state, "test-compliance");
 
             // Find test files (Python or TypeScript)
@@ -314,7 +310,6 @@ describe("Recipes", () => {
           ),
           scenario.agent(),
           (state) => {
-            toolCallFix(state);
             assertSkillWasRead(state, "debug-instrumentation");
 
             // Verify the agent used the langwatch CLI for trace inspection

--- a/skills/_tests/scenarios.scenario.test.ts
+++ b/skills/_tests/scenarios.scenario.test.ts
@@ -1,4 +1,4 @@
-import scenario from "@langwatch/scenario";
+import scenario, { assertSkillWasRead, bashCommands } from "@langwatch/scenario";
 import fs from "fs";
 import { describe, it, expect } from "vitest";
 import dotenv from "dotenv";
@@ -7,15 +7,12 @@ import path from "path";
 import { fileURLToPath } from "url";
 import { openai } from "@ai-sdk/openai";
 import {
-  copyFixtureToWorkDir,
-  createClaudeCodeAgent,
-  createSkillTestWorkDir,
-  toolCallFix,
-  assertSkillWasRead,
-  bashCommands,
-  installSkillToWorkDir,
-  removeSkillTestWorkDir,
-  SKILL_TESTS_SET_ID,
+	copyFixtureToWorkDir,
+	createClaudeCodeAgent,
+	createSkillTestWorkDir,
+	installSkillToWorkDir,
+	removeSkillTestWorkDir,
+	SKILL_TESTS_SET_ID,
 } from "./helpers/claude-code-adapter";
 import {
 	type RunningConnectedAgent,
@@ -87,7 +84,6 @@ describe("Scenarios Skill", () => {
           ),
           scenario.agent(),
           (state) => {
-            toolCallFix(state);
             assertSkillWasRead(state, "scenarios");
 
             const testFiles = findTestFiles(tempFolder, /^test_.*\.py$/);
@@ -170,7 +166,6 @@ describe("Scenarios Skill", () => {
           ),
           scenario.agent(),
           (state) => {
-            toolCallFix(state);
             assertSkillWasRead(state, "scenarios");
 
             const testFiles = findTestFiles(tempFolder, /\.test\.ts$/);
@@ -236,7 +231,6 @@ describe("Scenarios Skill", () => {
           ),
           scenario.agent(),
           (state) => {
-            toolCallFix(state);
             assertSkillWasRead(state, "scenarios");
             const testFiles = findTestFiles(tempFolder, /^test_.*\.py$/);
             expect(testFiles.length).toBeGreaterThan(0);
@@ -288,7 +282,6 @@ describe("Scenarios Skill", () => {
           ),
           scenario.agent(),
           (state) => {
-            toolCallFix(state);
             assertSkillWasRead(state, "scenarios");
 
             const testFiles = findTestFiles(tempFolder, /^test_.*\.py$/);
@@ -353,7 +346,6 @@ describe("Scenarios Skill", () => {
           ),
           scenario.agent(),
           (state) => {
-            toolCallFix(state);
             assertSkillWasRead(state, "scenarios");
 
             const testFiles = findTestFiles(tempFolder, /\.(test|spec)\.ts$/);
@@ -421,7 +413,6 @@ describe("Scenarios Skill", () => {
           ),
           scenario.agent(),
           (state) => {
-            toolCallFix(state);
             assertSkillWasRead(state, "scenarios");
             const testFiles = findTestFiles(tempFolder, /^test_.*\.py$/);
             expect(testFiles.length).toBeGreaterThan(0);
@@ -483,7 +474,6 @@ describe("Scenarios Skill", () => {
           ),
           scenario.agent(),
           (state) => {
-            toolCallFix(state);
             assertSkillWasRead(state, "scenarios");
             // In platform mode, no test files should be created.
             // The agent should use the langwatch CLI instead.
@@ -545,7 +535,6 @@ describe("Scenarios Skill", () => {
           ),
           scenario.agent(),
           (state) => {
-            toolCallFix(state);
             assertSkillWasRead(state, "scenarios");
             const testFiles = findTestFiles(tempFolder, /\.(test|spec)\.ts$/);
             expect(testFiles.length).toBeGreaterThan(0);
@@ -597,7 +586,6 @@ describe("Scenarios Skill", () => {
           ),
           scenario.agent(),
           (state) => {
-            toolCallFix(state);
             assertSkillWasRead(state, "scenarios");
             const testFiles = findTestFiles(tempFolder, /^test_.*\.py$/);
             expect(testFiles.length).toBeGreaterThan(0);
@@ -667,7 +655,6 @@ describe("Scenarios Skill", () => {
           ),
           scenario.agent(),
           (state) => {
-            toolCallFix(state);
             assertSkillWasRead(state, "scenarios");
 
             // Verify test files were created
@@ -747,7 +734,6 @@ describe("Scenarios Skill", () => {
           ),
           scenario.agent(),
           (state) => {
-            toolCallFix(state);
             assertSkillWasRead(state, "scenarios");
 
             const testFiles = findTestFiles(tempFolder, /^test_.*\.py$/);
@@ -847,7 +833,6 @@ describe("Scenarios Skill", () => {
           ),
           scenario.agent(),
           (state) => {
-            toolCallFix(state);
             assertSkillWasRead(state, "scenarios");
 
             const testFiles = findTestFiles(tempFolder, /\.(test|spec)\.ts$/);
@@ -964,7 +949,6 @@ describe("Scenarios Skill", () => {
               ),
               scenario.agent(),
               (state) => {
-                toolCallFix(state);
                 assertSkillWasRead(state, "scenarios");
 
                 // Read from the commands that ran, not from the transcript, so a

--- a/skills/_tests/tracing.scenario.test.ts
+++ b/skills/_tests/tracing.scenario.test.ts
@@ -1,4 +1,4 @@
-import scenario from "@langwatch/scenario";
+import scenario, { assertSkillWasRead } from "@langwatch/scenario";
 import fs from "fs";
 import { describe, it, expect } from "vitest";
 import dotenv from "dotenv";
@@ -9,8 +9,6 @@ import { openai } from "@ai-sdk/openai";
 import {
   copyFixtureToWorkDir,
   createClaudeCodeAgent,
-  toolCallFix,
-  assertSkillWasRead,
   installSkillToWorkDir,
   SKILL_TESTS_SET_ID,
 } from "./helpers/claude-code-adapter";
@@ -64,7 +62,6 @@ describe("Tracing Skill", () => {
           ),
           scenario.agent(),
           (state) => {
-            toolCallFix(state);
             assertSkillWasRead(state, "tracing");
             const resultFile = fs.readFileSync(
               `${tempFolder}/main.py`,
@@ -117,7 +114,6 @@ describe("Tracing Skill", () => {
           ),
           scenario.agent(),
           (state) => {
-            toolCallFix(state);
             assertSkillWasRead(state, "tracing");
             const resultFile = fs.readFileSync(
               `${tempFolder}/index.ts`,
@@ -169,7 +165,6 @@ describe("Tracing Skill", () => {
           ),
           scenario.agent(),
           (state) => {
-            toolCallFix(state);
             assertSkillWasRead(state, "tracing");
             const resultFile = fs.readFileSync(
               `${tempFolder}/main.py`,
@@ -221,7 +216,6 @@ describe("Tracing Skill", () => {
           ),
           scenario.agent(),
           (state) => {
-            toolCallFix(state);
             assertSkillWasRead(state, "tracing");
             const resultFile = fs.readFileSync(
               `${tempFolder}/index.ts`,
@@ -273,7 +267,6 @@ describe("Tracing Skill", () => {
           ),
           scenario.agent(),
           (state) => {
-            toolCallFix(state);
             assertSkillWasRead(state, "tracing");
             const resultFile = fs.readFileSync(
               `${tempFolder}/main.py`,
@@ -334,7 +327,6 @@ describe("Tracing Skill", () => {
           ),
           scenario.agent(),
           (state) => {
-            toolCallFix(state);
             assertSkillWasRead(state, "tracing");
             const mainPy = fs.readFileSync(
               `${tempFolder}/main.py`,
@@ -392,7 +384,6 @@ describe("Tracing Skill", () => {
           ),
           scenario.agent(),
           (state) => {
-            toolCallFix(state);
             assertSkillWasRead(state, "tracing");
             const mainPy = fs.readFileSync(`${tempFolder}/main.py`, "utf8");
             expect(mainPy).toContain("langwatch");
@@ -450,7 +441,6 @@ describe("Tracing Skill", () => {
           ),
           scenario.agent(),
           (state) => {
-            toolCallFix(state);
             assertSkillWasRead(state, "tracing");
             const mainPy = fs.readFileSync(`${tempFolder}/main.py`, "utf8");
             expect(mainPy).toContain("langwatch");

--- a/skills/package.json
+++ b/skills/package.json
@@ -21,7 +21,7 @@
     "@ai-sdk/anthropic": "^3.0.44",
     "@ai-sdk/google": "^2.0.78",
     "@ai-sdk/openai": "^3.0.41",
-    "@langwatch/scenario": "^0.4.12",
+    "@langwatch/scenario": "^1.5.0",
     "@types/mdast": "^4.0.4",
     "@types/node": "^26.2.0",
     "chalk": "^6.0.0",

--- a/skills/package.json
+++ b/skills/package.json
@@ -21,7 +21,7 @@
     "@ai-sdk/anthropic": "^3.0.44",
     "@ai-sdk/google": "^2.0.78",
     "@ai-sdk/openai": "^3.0.41",
-    "@langwatch/scenario": "^1.5.0",
+    "@langwatch/scenario": "^1.6.0",
     "@types/mdast": "^4.0.4",
     "@types/node": "^26.2.0",
     "chalk": "^6.0.0",

--- a/specs/scenarios/anthropic-transcript-on-the-wire.feature
+++ b/specs/scenarios/anthropic-transcript-on-the-wire.feature
@@ -51,18 +51,3 @@ Feature: Anthropic-format transcripts reach the run conversation
     When the wire validator parses the event
     Then the parse succeeds
     And the message keeps its top-level tool_calls when it declares them
-
-  @unit
-  Scenario: A block the transcript cannot carry leaves a line naming it
-    Given a Claude Code transcript whose turn holds an image or a document block
-    When the adapter converts the transcript
-    Then the turn stays in the conversation
-    And a line names the type of the block that is not shown
-
-  @unit
-  Scenario: The Claude Code adapter of the skill tests reports tool calls as AI SDK parts
-    Given a Claude Code stream-json transcript with a thinking block, a text block, a tool_use block and its tool_result
-    When the adapter converts the transcript
-    Then the assistant message holds one text part followed by a tool-call part with the tool name and input
-    And the tool result becomes a tool message with a tool-result part that names the tool it answers
-    And the thinking block is not part of the conversation

--- a/specs/skills/skills-testing.feature
+++ b/specs/skills/skills-testing.feature
@@ -38,6 +38,7 @@ Feature: Scenario tests for skills quality assurance
     And it returns each turn as messages with tool-call and tool-result parts, so the judge and the run view see what the agent ran
     And it keeps the batch id of the suite and the keys a test withholds out of the agent's environment
 
+  @integration
   Scenario: No Claude Code process outlives the test harness
     Given a scenario test is running Claude Code
     When the vitest worker that spawned it is killed

--- a/specs/skills/skills-testing.feature
+++ b/specs/skills/skills-testing.feature
@@ -30,12 +30,19 @@ Feature: Scenario tests for skills quality assurance
   # Test infrastructure
   # ──────────────────────────────────────────────────
 
-  Scenario: Claude Code agent adapter exists for skill testing
-    Given a reusable Claude Code agent adapter exists in skills/_tests/
-    Then it spawns Claude Code with the skill loaded
+  Scenario: The skill tests drive Claude Code through the Scenario SDK adapter
+    Given the tests build their agent with claudeCodeAgent from @langwatch/scenario
+    Then it spawns Claude Code with the installed skills pointed at from CLAUDE.md
     And it makes the locally-built `langwatch` CLI available on PATH (so new commands like `docs` and `scenario-docs` are exercised)
     And it runs in a temporary directory with the fixture codebase
-    And it captures Claude Code's output for assertion
+    And it returns each turn as messages with tool-call and tool-result parts, so the judge and the run view see what the agent ran
+    And it keeps the batch id of the suite and the keys a test withholds out of the agent's environment
+
+  Scenario: No Claude Code process outlives the test harness
+    Given a scenario test is running Claude Code
+    When the vitest worker that spawned it is killed
+    Then Claude Code and every process it started are stopped
+    And nothing is left running under pid 1 from that test
 
   Scenario: Fixture codebases cover the framework matrix
     Given fixture codebases exist for the key combinations:


### PR DESCRIPTION
## Why

The skill scenario tests drove Claude Code through a hand-rolled adapter in `skills/_tests/helpers/claude-code-adapter.ts`: 900 lines of spawn, stream-json parsing, transcript conversion and caps that duplicated what `claudeCodeAgent` in `@langwatch/scenario` does, minus the parts the SDK lacked. And neither adapter cleaned up after itself: when a vitest worker died with a turn running (memory pressure, a Ctrl-C, a session restart), the `claude -p` and everything it had started (a dev server, a pytest run, a `langwatch` CLI daemon) reparented to pid 1 and kept running. On one machine that was 17 claude processes and 13 GB of swap.

The missing parts moved into the SDK in [scenario#972](https://github.com/langwatch/scenario/pull/972): `env` (with `undefined` removing a key), `output: "messages"` (tool-call and tool-result parts), the tool result and tool input caps, `toModelMessages`, `bashCommands`, `pointClaudeMdAtSkills`, and a process lifecycle that leaves no orphan. This PR adopts it.

## What

- `skills/_tests/helpers/claude-code-adapter.ts` keeps the parts that are ours (`SKILL_TESTS_SET_ID`, the work dir helpers, `installSkillToWorkDir`, `setupLocalCli`) and `createClaudeCodeAgent` becomes a thin wrapper: `claudeCodeAgent` with `model: "opus"`, `skipPermissions`, `output: "messages"`, a one hour turn timeout, the local `bin/` first on `PATH`, `SCENARIO_BATCH_RUN_ID` and the keys a test withholds removed through `env`, a chalk logger, and `pointClaudeMdAtSkills` after the skills are installed. The same options as before, without the spawn code.
- `toolCallFix` is gone from all 24 test files (it turned unknown parts into text; the SDK adapter emits only parts the SDK knows). `assertSkillWasRead` and `bashCommands` are imported from `@langwatch/scenario`. The SDK's `assertSkillWasRead` is stricter: it looks for `.skills/<name>/SKILL.md`, not any `SKILL.md`. Every call site names the directory the skill was installed as.
- `claudeCodeTranscriptToModelMessages`, `describeFailure` and `ensureClaudeSkillInstructions` are deleted, along with their tests; the behavior is specified and tested in the SDK (`specs/claude-code-adapter.feature` there). The two scenarios in `specs/scenarios/anthropic-transcript-on-the-wire.feature` that bound those tests are removed, and `specs/skills/skills-testing.feature` describes the SDK adapter and adds "No Claude Code process outlives the test harness".
- `skills/package.json` moves `@langwatch/scenario` to the SDK release that carries the new adapter.

## Verification

Kill test, with the SDK build from scenario#972: started `tracing.scenario.test.ts -t "Python OpenAI"`, waited for Claude to be running, then `kill -9` on the vitest worker that spawned it.

```
claude pid 8050 pgid 8050, spawned by pid 7739 (vitest worker)
watchdog pid 8051
kill -9 worker 7739
after 9s:
  claude 8050 alive: no
  watchdog 8051 alive: no
  members of group 8050 still alive: 0
  headless claude processes with ppid 1: 0
reaper dry run: (nothing)
```

Before this change the same kill left `claude -p` running under pid 1 until something killed it by hand.

End-to-end dogfood: `tracing.scenario.test.ts -t "Python OpenAI"` against the SDK build passes (judge verdict pass, 247 s). The generated `main.py` calls `langwatch.setup()`, decorates the handler with `@langwatch.trace` and enables `autotrack_openai_calls`. A first run with a stale judge key showed the turn reaching the judge as 58 Bash tool-call parts. After the run no `claude` and no `claude-code-watchdog` process is left.

Also: `tsc --noEmit` in `skills/` is clean, `skills/_tests/claude-code-adapter.test.ts` passes.

## Out of scope

`mcp/typescript/tests/scenario-openai.test.ts` has a hand-rolled Claude adapter of its own with the same orphan problem. Separate PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Claude Code skill-test reliability with standardized skill discovery and tool-call result handling.
  - Ensured Claude Code and its child processes stop when a test worker is terminated.

- **Tests**
  - Added coverage to prevent orphaned processes.
  - Updated skill and scenario tests to use standardized SDK assertions.
  - Added scenarios covering skill setup, message parts, environment handling, and process cleanup.
  - Removed obsolete transcript-conversion test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->