### PR TITLE
fix(sdk-js): the langy control calls use the shared transport, and the tunnel probe allowance follows its file

### DIFF
--- a/sdks/typescript/src/cli/commands/langy/requests.ts
+++ b/sdks/typescript/src/cli/commands/langy/requests.ts
@@ -19,6 +19,7 @@ import prompts from "prompts";
 import type { WorkspaceInfo } from "../../../agent/local-control-protocol";
 import { buildAuthHeaders } from "../../../internal/api/auth";
 import { LANGWATCH_SDK_VERSION } from "../../../internal/constants";
+import { langwatchFetch } from "../../../internal/http/langwatchFetch";
 import { resolveCredentials } from "../../utils/apiKey";
 import { isLoggedIn, loadConfig } from "../../utils/governance/config";
 import {
@@ -186,7 +187,7 @@ export function createControlApi({
   endpoint,
   apiKey,
   projectId,
-  fetchImpl = fetch,
+  fetchImpl = langwatchFetch,
 }: {
   endpoint: string;
   apiKey: string;

--- a/sdks/typescript/src/internal/http/__tests__/raw-fetch-guard.unit.test.ts
+++ b/sdks/typescript/src/internal/http/__tests__/raw-fetch-guard.unit.test.ts
@@ -17,7 +17,7 @@ const SRC_ROOT = resolve(__dirname, "..", "..", "..");
  * added call fails even here.
  */
 const NOT_LANGWATCH = new Map([
-  ["cli/commands/agents/dev.ts", 1],
+  ["cli/commands/agents/tunnel.ts", 1],
   ["cli/commands/agents/run.ts", 1],
 ]);
 


### PR DESCRIPTION
## What broke

`typescript-sdk@v1.13.0` was tagged and released, but never reached npm. The `sdk-javascript-cd` publish job failed on its **Run tests** step, so **Publish to npm** was skipped. npm still serves 1.12.1.

main itself is red for the same reason.

## Why

Two pull requests that were each green on their own:

- **#7906** added `raw-fetch-guard.unit.test.ts`, which walks the SDK source and fails on any raw `fetch` outside a short allowlist.
- **#7879** added `cli/commands/agents/tunnel.ts` and `cli/commands/langy/requests.ts`, and moved `cli/commands/agents/dev.ts`.

Neither branch was rebased on the other before merging, so the guard first ran against the moved files on main. It reported both problems correctly:

```
+ "cli/commands/agents/tunnel.ts (1 calls)",
+ "cli/commands/langy/requests.ts (1 calls)",
```

## The fix

Both findings are real, and the fix follows what `specs/typescript-sdk/http-client-redirects.feature` already says.

- **`langy/requests.ts` posts to `/api/v1/langy/control/requests` with LangWatch auth headers**, so it is a platform call and belongs on the shared transport. Its `fetchImpl` now defaults to `langwatchFetch`, which is what applies the redirect rule. Before this it was the one platform call that would silently lose its body on an http to https redirect.
- **The tunnel health probe moved files.** It probes the public tunnel URL, not LangWatch, so it keeps its direct `fetch`; the allowance moves from `agents/dev.ts` to `agents/tunnel.ts`. The stale `dev.ts` entry is what the guard's second assertion caught.

No spec change: the scenario "every hand written request uses the shared transport" already describes this, including the tunnel as an allowed direct caller.

## Release recovery

`sdk-javascript-cd` accepts `workflow_dispatch` on main, and its version step reads `.release-please-manifest.json` when it is not a tag run. main already carries `"version": "1.13.0"`. So once this merges, dispatching that workflow on main publishes 1.13.0 from a green tree. Re-running the original failed run would check out the tag, which does not have this fix, and would fail the same way.

## Verification

- `raw-fetch-guard.unit.test.ts` and `langy/__tests__/requests.unit.test.ts`: 21 passing.
- Full SDK unit suite: 273 files, 3820 tests passing.
- `tsc --noEmit` and eslint clean on the changed files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated CLI API requests to use the application’s configured network handling by default.
  * Corrected the allowed raw network request for the agent command that communicates with an external server.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->