### PR TITLE
fix(gateway): re-read budget spend when its period ends

### DIFF
--- a/services/aigateway/adapters/authresolver/budget_period_test.go
+++ b/services/aigateway/adapters/authresolver/budget_period_test.go
@@ -138,7 +138,13 @@ func TestResolve_BudgetPeriodRunning_DoesNotForceRefresh(t *testing.T) {
 	svc := newBudgetService(t, fetcher)
 
 	rawKey := "vk-lw-budget-running"
-	seedBudgetEntry(t, svc, rawKey, time.Now().Add(1*time.Hour), "42")
+	e := seedBudgetEntry(t, svc, rawKey, time.Now().Add(1*time.Hour), "42")
+
+	// The claim is that the boundary alone triggers nothing, so the other half
+	// of the staleness check has to be out of the way: assert the config is
+	// inside its TTL rather than assume it.
+	require.False(t, e.configStale(60*time.Second),
+		"the entry must start fresh, or this proves nothing about the boundary")
 
 	got, err := svc.Resolve(context.Background(), rawKey)
 	require.NoError(t, err)

--- a/services/aigateway/adapters/authresolver/budget_period_test.go
+++ b/services/aigateway/adapters/authresolver/budget_period_test.go
@@ -1,0 +1,197 @@
+// Tests for the budget-period half of the config staleness refresh.
+// Spec: specs/ai-gateway/auth-cache.feature, Rule "A budget period that ends
+// invalidates the spend the gateway is holding".
+package authresolver
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/langwatch/langwatch/services/aigateway/domain"
+)
+
+// budgetConfigFetcher answers with a config whose one budget carries `spent`
+// and whose period ends at `validUntil`, recording the If-None-Match every
+// fetch offered. Unlike etagConfigFetcher it keeps a budget on the config it
+// returns, so a refresh does not silently clear the boundary under test.
+type budgetConfigFetcher struct {
+	fakeResolver
+
+	mu         sync.Mutex
+	etag       string
+	spent      int64
+	validUntil time.Time
+	conds      []string
+}
+
+func (f *budgetConfigFetcher) FetchConfig(_ context.Context, _, ifNoneMatch string) (domain.ConfigFetchResult, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.conds = append(f.conds, ifNoneMatch)
+	if ifNoneMatch != "" && ifNoneMatch == f.etag {
+		return domain.ConfigFetchResult{ETag: f.etag, NotModified: true}, nil
+	}
+	return domain.ConfigFetchResult{
+		ETag:   f.etag,
+		Config: budgetConfig(f.spent, f.validUntil),
+	}, nil
+}
+
+func (f *budgetConfigFetcher) conditionals() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.conds...)
+}
+
+// budgetConfig is a config carrying one blocking $5 budget.
+func budgetConfig(spentMicroUSD int64, validUntil time.Time) domain.BundleConfig {
+	return domain.BundleConfig{
+		Budget: domain.BudgetConfig{
+			Scopes: []domain.BudgetScope{{
+				ID:            "budget_day",
+				Scope:         "virtual_key",
+				Window:        "day",
+				LimitMicroUSD: 5_000_000,
+				SpentMicroUSD: spentMicroUSD,
+				OnBreach:      "block",
+			}},
+			ValidUntil: validUntil,
+		},
+	}
+}
+
+// seedBudgetEntry warms L1 with an exhausted budget whose period ends at
+// validUntil, fetched a minute inside that period — the state a real entry is
+// in when its period ends underneath it.
+//
+// The fetch instant matters: an entry already fetched past its boundary has
+// asked its question, and the whole point of the one-shot rule is that it does
+// not ask again. Stamping it here rather than leaving storeL1's `now` is what
+// separates "the period ended after we read it" from "the boundary was already
+// behind us". Never later than now, so a period still running does not leave
+// the entry claiming a fetch in the future.
+func seedBudgetEntry(t *testing.T, svc *Service, rawKey string, validUntil time.Time, etag string) *entry {
+	t.Helper()
+	bundle := freshBundle("vk_budget", time.Now().Add(1*time.Hour))
+	bundle.Config = budgetConfig(5_000_000, validUntil)
+	svc.storeL1(hashKey(rawKey), bundle, etag)
+	e, ok := svc.l1.Peek(hashKey(rawKey))
+	require.True(t, ok, "the seeded entry must be in L1")
+
+	fetchedAt := validUntil.Add(-time.Minute)
+	if now := time.Now(); fetchedAt.After(now) {
+		fetchedAt = now
+	}
+	e.mu.Lock()
+	e.configFetchedAt = fetchedAt
+	e.mu.Unlock()
+	return e
+}
+
+func newBudgetService(t *testing.T, fetcher *budgetConfigFetcher) *Service {
+	t.Helper()
+	svc, _ := newService(t, Options{
+		Resolver:         &fetcher.fakeResolver,
+		ConfigFetcher:    fetcher,
+		ConfigTTL:        60 * time.Second,
+		RefreshThreshold: time.Second, // keep the near-soft-expiry path out of the way
+	})
+	return svc
+}
+
+/** @scenario "the refresh at a period boundary asks for the config instead of confirming it" */
+func TestResolve_BudgetPeriodRolled_RefreshesUnconditionally(t *testing.T) {
+	tomorrow := time.Now().Add(24 * time.Hour)
+	fetcher := &budgetConfigFetcher{etag: "42", spent: 0, validUntil: tomorrow}
+	svc := newBudgetService(t, fetcher)
+
+	rawKey := "vk-lw-budget-rolled"
+	// Yesterday's period, spent up to the limit: the state a key is left in
+	// by the block that stopped its last request.
+	e := seedBudgetEntry(t, svc, rawKey, time.Now().Add(-time.Second), "42")
+
+	_, err := svc.Resolve(context.Background(), rawKey)
+	require.NoError(t, err)
+	awaitConfigRefresh(t, e)
+
+	assert.Equal(t, []string{""}, fetcher.conditionals(),
+		"the token is built from the key's revision and providers, so offering it here would be answered 304 and pin yesterday's spend")
+
+	live, ok := svc.l1.Peek(hashKey(rawKey))
+	require.True(t, ok)
+	assert.Equal(t, int64(0), live.bundle.Config.Budget.Scopes[0].SpentMicroUSD,
+		"the new period's spend has to replace the old period's, or the key stays blocked on money it did not spend today")
+	assert.Equal(t, tomorrow.Unix(), live.bundle.Config.Budget.ValidUntil.Unix(),
+		"and the boundary has to move with it")
+	assert.False(t, live.configStale(60*time.Second),
+		"a config read inside the current period is not stale")
+}
+
+/** @scenario "a period still running is revalidated the ordinary way" */
+func TestResolve_BudgetPeriodRunning_DoesNotForceRefresh(t *testing.T) {
+	fetcher := &budgetConfigFetcher{etag: "42", spent: 0, validUntil: time.Now().Add(24 * time.Hour)}
+	svc := newBudgetService(t, fetcher)
+
+	rawKey := "vk-lw-budget-running"
+	seedBudgetEntry(t, svc, rawKey, time.Now().Add(1*time.Hour), "42")
+
+	got, err := svc.Resolve(context.Background(), rawKey)
+	require.NoError(t, err)
+
+	assert.Empty(t, fetcher.conditionals(),
+		"an exhausted budget inside its own period is a correct block, not a stale one: nothing to re-read")
+	assert.Equal(t, int64(5_000_000), got.Config.Budget.Scopes[0].SpentMicroUSD)
+}
+
+/** @scenario "a boundary that is already behind the gateway is asked about once" */
+func TestResolve_BudgetBoundaryLongPast_RefreshesOnce(t *testing.T) {
+	// The refresh answers with the same past boundary, modelling a budget
+	// whose stored instant simply never moves (a MANUAL window, a skewed
+	// clock). Without the one-shot rule this is a fetch on every request for
+	// as long as the entry lives.
+	past := time.Now().Add(-72 * time.Hour)
+	fetcher := &budgetConfigFetcher{etag: "42", spent: 0, validUntil: past}
+	svc := newBudgetService(t, fetcher)
+
+	rawKey := "vk-lw-budget-frozen"
+	e := seedBudgetEntry(t, svc, rawKey, past, "42")
+
+	for range 3 {
+		_, err := svc.Resolve(context.Background(), rawKey)
+		require.NoError(t, err)
+		awaitConfigRefresh(t, e)
+		live, ok := svc.l1.Peek(hashKey(rawKey))
+		require.True(t, ok)
+		e = live
+	}
+
+	assert.Equal(t, []string{""}, fetcher.conditionals(),
+		"the first request re-reads the config; after that the entry has been fetched past the boundary and the ordinary clock takes over")
+}
+
+/** @scenario "a bundle with no budgets keeps the ordinary staleness clock" */
+func TestResolve_NoBudgetBoundary_KeepsConditionalRefresh(t *testing.T) {
+	fetcher := &budgetConfigFetcher{etag: "42", spent: 0}
+	svc := newBudgetService(t, fetcher)
+
+	rawKey := "vk-lw-budget-none"
+	bundle := freshBundle("vk_nobudget", time.Now().Add(1*time.Hour))
+	svc.storeL1(hashKey(rawKey), bundle, "42")
+
+	_, err := svc.Resolve(context.Background(), rawKey)
+	require.NoError(t, err)
+	assert.Empty(t, fetcher.conditionals(), "a fresh config with no boundary is not stale")
+
+	e := backdateConfig(t, svc, rawKey, 2*time.Minute)
+	_, err = svc.Resolve(context.Background(), rawKey)
+	require.NoError(t, err)
+	awaitConfigRefresh(t, e)
+
+	assert.Equal(t, []string{"42"}, fetcher.conditionals(),
+		"past the TTL it still revalidates, so a key with no budget costs no extra materialisation")
+}

--- a/services/aigateway/adapters/authresolver/budget_period_test.go
+++ b/services/aigateway/adapters/authresolver/budget_period_test.go
@@ -156,7 +156,7 @@ func TestResolve_BudgetPeriodRunning_DoesNotForceRefresh(t *testing.T) {
 
 /** @scenario "a boundary that is already behind the gateway is asked about once" */
 func TestResolve_BudgetBoundaryLongPast_RefreshesOnce(t *testing.T) {
-	// The refresh answers with the same past boundary, modelling a budget
+	// The refresh answers with the same past boundary, modeling a budget
 	// whose stored instant simply never moves (a MANUAL window, a skewed
 	// clock). Without the one-shot rule this is a fetch on every request for
 	// as long as the entry lives.
@@ -199,5 +199,5 @@ func TestResolve_NoBudgetBoundary_KeepsConditionalRefresh(t *testing.T) {
 	awaitConfigRefresh(t, e)
 
 	assert.Equal(t, []string{"42"}, fetcher.conditionals(),
-		"past the TTL it still revalidates, so a key with no budget costs no extra materialisation")
+		"past the TTL it still revalidates, so a key with no budget costs no extra materialization")
 }

--- a/services/aigateway/adapters/authresolver/budget_period_test.go
+++ b/services/aigateway/adapters/authresolver/budget_period_test.go
@@ -5,6 +5,7 @@ package authresolver
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -27,12 +28,20 @@ type budgetConfigFetcher struct {
 	spent      int64
 	validUntil time.Time
 	conds      []string
+	// failures is how many leading fetches answer with a transport error
+	// instead of a config, standing in for a control plane that cannot be
+	// reached at the moment the period rolls.
+	failures int
 }
 
 func (f *budgetConfigFetcher) FetchConfig(_ context.Context, _, ifNoneMatch string) (domain.ConfigFetchResult, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.conds = append(f.conds, ifNoneMatch)
+	if f.failures > 0 {
+		f.failures--
+		return domain.ConfigFetchResult{}, errors.New("control plane unreachable")
+	}
 	if ifNoneMatch != "" && ifNoneMatch == f.etag {
 		return domain.ConfigFetchResult{ETag: f.etag, NotModified: true}, nil
 	}
@@ -75,6 +84,11 @@ func budgetConfig(spentMicroUSD int64, validUntil time.Time) domain.BundleConfig
 // separates "the period ended after we read it" from "the boundary was already
 // behind us". Never later than now, so a period still running does not leave
 // the entry claiming a fetch in the future.
+//
+// budgetRollAckedFor is cleared for the same reason. storeL1 acks a boundary
+// that had already passed when it built the entry, which is right for a real
+// insert but wrong for the state being staged here: this entry stands for one
+// built while the period was still running, and such an entry starts unacked.
 func seedBudgetEntry(t *testing.T, svc *Service, rawKey string, validUntil time.Time, etag string) *entry {
 	t.Helper()
 	bundle := freshBundle("vk_budget", time.Now().Add(1*time.Hour))
@@ -89,6 +103,7 @@ func seedBudgetEntry(t *testing.T, svc *Service, rawKey string, validUntil time.
 	}
 	e.mu.Lock()
 	e.configFetchedAt = fetchedAt
+	e.budgetRollAckedFor = time.Time{}
 	e.mu.Unlock()
 	return e
 }
@@ -178,6 +193,48 @@ func TestResolve_BudgetBoundaryLongPast_RefreshesOnce(t *testing.T) {
 
 	assert.Equal(t, []string{""}, fetcher.conditionals(),
 		"the first request re-reads the config; after that the entry has been fetched past the boundary and the ordinary clock takes over")
+}
+
+/** @scenario "a refresh the control plane never answered leaves the period unresolved" */
+func TestResolve_BudgetRollFetchFails_StaysUnconditional(t *testing.T) {
+	// The refresh stamps configFetchedAt on every outcome, failures included.
+	// If that stamp were what closed out the roll, this entry would go back to
+	// offering its token, be answered 304, and enforce the dead period's spend
+	// for as long as it lived — the deadlock this Rule exists to break, reached
+	// through a transport error instead of the clock.
+	tomorrow := time.Now().Add(24 * time.Hour)
+	fetcher := &budgetConfigFetcher{etag: "42", spent: 0, validUntil: tomorrow, failures: 1}
+	svc := newBudgetService(t, fetcher)
+
+	rawKey := "vk-lw-budget-fetch-failed"
+	e := seedBudgetEntry(t, svc, rawKey, time.Now().Add(-time.Second), "42")
+
+	_, err := svc.Resolve(context.Background(), rawKey)
+	require.NoError(t, err, "a failed config refresh is a background concern; the request still serves from cache")
+	awaitConfigRefresh(t, e)
+
+	live, ok := svc.l1.Peek(hashKey(rawKey))
+	require.True(t, ok)
+	require.Same(t, e, live, "a failed refresh swaps nothing in, so the entry is the one we seeded")
+	assert.Equal(t, int64(5_000_000), live.bundle.Config.Budget.Scopes[0].SpentMicroUSD,
+		"nothing was fetched, so the dead period's spend is still what the entry holds")
+	assert.True(t, live.configStale(0),
+		"with no staleness clock an unanswered roll has to keep asking, or it never retries at all")
+
+	// The ordinary clock paces the retry rather than firing it on every
+	// request, so move past it the way a real entry would.
+	e = backdateConfig(t, svc, rawKey, 2*time.Minute)
+	_, err = svc.Resolve(context.Background(), rawKey)
+	require.NoError(t, err)
+	awaitConfigRefresh(t, e)
+
+	assert.Equal(t, []string{"", ""}, fetcher.conditionals(),
+		"the retry after a failure has to go out unconditional too; offering the token would be answered 304 and pin the dead period's spend")
+
+	live, ok = svc.l1.Peek(hashKey(rawKey))
+	require.True(t, ok)
+	assert.Equal(t, int64(0), live.bundle.Config.Budget.Scopes[0].SpentMicroUSD,
+		"once the control plane answers, the new period's spend replaces the old")
 }
 
 /** @scenario "a bundle with no budgets keeps the ordinary staleness clock" */

--- a/services/aigateway/adapters/authresolver/budget_period_test.go
+++ b/services/aigateway/adapters/authresolver/budget_period_test.go
@@ -237,6 +237,48 @@ func TestResolve_BudgetRollFetchFails_StaysUnconditional(t *testing.T) {
 		"once the control plane answers, the new period's spend replaces the old")
 }
 
+/** @scenario "a confirmation taken before the boundary does not count as reading past it" */
+func TestResolve_BudgetPeriodRolled_AfterEarlier304_StillRefreshes(t *testing.T) {
+	// The ordinary staleness refresh runs many times inside a period and is
+	// answered 304 every time — a daily budget on a 60s clock sees hundreds
+	// before its boundary. None of them may count as having read past that
+	// boundary: they carry no spend, and were taken while the period was still
+	// running. If one did, the roll would never fire for the entry that had it,
+	// which is nearly every entry.
+	boundary := time.Now().Add(300 * time.Millisecond)
+	fetcher := &budgetConfigFetcher{etag: "42", spent: 0, validUntil: time.Now().Add(24 * time.Hour)}
+	svc := newBudgetService(t, fetcher)
+
+	rawKey := "vk-lw-budget-304-then-roll"
+	seedBudgetEntry(t, svc, rawKey, boundary, "42")
+
+	// A staleness refresh inside the period: the token goes out and is
+	// confirmed, so nothing is swapped in.
+	e := backdateConfig(t, svc, rawKey, 2*time.Minute)
+	_, err := svc.Resolve(context.Background(), rawKey)
+	require.NoError(t, err)
+	awaitConfigRefresh(t, e)
+	require.Equal(t, []string{"42"}, fetcher.conditionals(),
+		"inside its period the entry revalidates normally")
+
+	// Now the period ends underneath it.
+	time.Sleep(400 * time.Millisecond)
+
+	live, ok := svc.l1.Peek(hashKey(rawKey))
+	require.True(t, ok)
+	_, err = svc.Resolve(context.Background(), rawKey)
+	require.NoError(t, err)
+	awaitConfigRefresh(t, live)
+
+	assert.Equal(t, []string{"42", ""}, fetcher.conditionals(),
+		"the boundary still has to force an unconditional re-read; the earlier 304 was taken inside the period and says nothing about the spend after it")
+
+	live, ok = svc.l1.Peek(hashKey(rawKey))
+	require.True(t, ok)
+	assert.Equal(t, int64(0), live.bundle.Config.Budget.Scopes[0].SpentMicroUSD,
+		"and the new period's spend replaces the old")
+}
+
 /** @scenario "a bundle with no budgets keeps the ordinary staleness clock" */
 func TestResolve_NoBudgetBoundary_KeepsConditionalRefresh(t *testing.T) {
 	fetcher := &budgetConfigFetcher{etag: "42", spent: 0}

--- a/services/aigateway/adapters/authresolver/service.go
+++ b/services/aigateway/adapters/authresolver/service.go
@@ -171,7 +171,7 @@ func (e *entry) currentConfigETag() string {
 // from the key's revision and its provider set, and a period ending moves
 // neither, so a conditional refresh of a bundle whose spend figures expired at
 // midnight comes back 304 and leaves those figures in place. Unconditional
-// costs one materialisation per key per period.
+// costs one materialization per key per period.
 func (e *entry) refreshConfigETag() string {
 	e.mu.Lock()
 	defer e.mu.Unlock()

--- a/services/aigateway/adapters/authresolver/service.go
+++ b/services/aigateway/adapters/authresolver/service.go
@@ -154,12 +154,19 @@ type entry struct {
 	// Empty means we have no token to revalidate with, and the next refresh
 	// goes out unconditional.
 	configETag string
-	// budgetRollAckedFor is the budget boundary the control plane has already
-	// answered for on this entry. It is deliberately not configFetchedAt: that
-	// one is stamped on every refresh outcome, failures included, so keying the
-	// roll on it would let a control plane that could not be reached count as
-	// the re-read and hand the entry back to conditional revalidation still
-	// holding the dead period's spend.
+	// budgetRollAckedFor is the budget boundary whose spend this entry already
+	// carries, set once at construction and never after. It is deliberately not
+	// configFetchedAt: that one is stamped on every refresh outcome, failures
+	// included, so keying the roll on it would let a control plane that could
+	// not be reached count as the re-read and hand the entry back to
+	// conditional revalidation still holding the dead period's spend.
+	//
+	// Only a config the gateway actually received clears a roll, and that
+	// arrives as a new entry through storeL1 rather than a mutation here — so
+	// there is no ack on the refresh path at all. A 304 must not clear one: it
+	// carries no spend, and a 304 taken while the period was still running
+	// would ack a boundary the entry has not reached yet and suppress the roll
+	// when it does.
 	budgetRollAckedFor time.Time
 }
 
@@ -216,10 +223,12 @@ func (e *entry) configStale(ttl time.Duration) bool {
 // budget period that has since ended and the control plane has not answered for
 // the new one yet. Caller holds e.mu.
 //
-// Only an answer clears it. A failed fetch leaves the roll standing, so the
-// retry goes out unconditional again instead of offering the token and being
-// closed out by a 304 — which would leave the entry enforcing the dead period's
-// spend, the exact deadlock this is here to break.
+// Only a config the gateway actually received clears it, which arrives as a new
+// entry. A failed fetch, and a 304 answering the unconditional refresh this
+// forces, both leave the roll standing so the next attempt goes out
+// unconditional too — offering the token instead would be answered 304 and
+// leave the entry enforcing the dead period's spend, the exact deadlock this is
+// here to break.
 //
 // The permanently-past boundary — a MANUAL budget carrying an old stored
 // instant, a clock skewed forward — is handled at construction rather than
@@ -234,15 +243,6 @@ func (e *entry) budgetPeriodRolled() bool {
 		return false
 	}
 	return !e.budgetRollAckedFor.Equal(validUntil)
-}
-
-// ackBudgetRoll records that the control plane answered for the boundary this
-// entry carries. Success and 304 both count: either is a live answer about this
-// key's config. A transport failure is not, and must not land here.
-func (e *entry) ackBudgetRoll() {
-	e.mu.Lock()
-	defer e.mu.Unlock()
-	e.budgetRollAckedFor = e.bundle.Config.Budget.ValidUntil
 }
 
 // ackedBoundaryAtBuild is the boundary a freshly built entry should count as
@@ -1092,12 +1092,6 @@ func (s *Service) refreshConfigBackground(h [64]byte, e *entry) {
 		)
 		return
 	}
-	// The control plane answered, so a rolled boundary has had its re-read and
-	// stops forcing unconditional refreshes. This is deliberately after the
-	// error return above: a fetch that never got an answer leaves the roll
-	// standing so the next attempt goes out unconditional too.
-	e.ackBudgetRoll()
-
 	if res.NotModified {
 		// The config this entry carries is still the current one, so there is
 		// nothing to swap in. The deferred endConfigRefresh restarts the

--- a/services/aigateway/adapters/authresolver/service.go
+++ b/services/aigateway/adapters/authresolver/service.go
@@ -163,15 +163,56 @@ func (e *entry) currentConfigETag() string {
 	return e.configETag
 }
 
-// configStale reports whether the entry's config is older than ttl.
-// ttl <= 0 disables staleness (never stale).
+// refreshConfigETag is the If-None-Match a staleness refresh of this entry
+// should send: the carried token normally, and none once the budget period has
+// rolled.
+//
+// Dropping the token there is the whole point of the roll. The token is built
+// from the key's revision and its provider set, and a period ending moves
+// neither, so a conditional refresh of a bundle whose spend figures expired at
+// midnight comes back 304 and leaves those figures in place. Unconditional
+// costs one materialisation per key per period.
+func (e *entry) refreshConfigETag() string {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.budgetPeriodRolled() {
+		return ""
+	}
+	return e.configETag
+}
+
+// configStale reports whether the entry's config needs refreshing: its budget
+// period has rolled, or it is older than ttl. ttl <= 0 disables the age half
+// only — a rolled period is stale whatever the ttl, because the figures it
+// leaves behind are not merely old, they belong to a period that has ended.
 func (e *entry) configStale(ttl time.Duration) bool {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.budgetPeriodRolled() {
+		return true
+	}
 	if ttl <= 0 {
 		return false
 	}
-	e.mu.Lock()
-	defer e.mu.Unlock()
 	return time.Since(e.configFetchedAt) > ttl
+}
+
+// budgetPeriodRolled reports whether this entry's spend figures were read in a
+// budget period that has since ended. Caller holds e.mu.
+//
+// The `configFetchedAt` comparison is what keeps this a one-shot: it asks
+// whether the config was fetched BEFORE the boundary, so the refresh it
+// triggers clears it whether or not the control plane could be reached
+// (endConfigRefresh stamps configFetchedAt on every outcome). Without it a
+// bundle whose boundary is permanently in the past — a MANUAL budget carrying
+// an old stored instant, a clock skewed forward — would ask for a fresh fetch
+// on every request for as long as it lived.
+func (e *entry) budgetPeriodRolled() bool {
+	validUntil := e.bundle.Config.Budget.ValidUntil
+	if validUntil.IsZero() {
+		return false
+	}
+	return !time.Now().Before(validUntil) && e.configFetchedAt.Before(validUntil)
 }
 
 // tryBeginConfigRefresh claims the per-entry config-refresh slot.
@@ -977,6 +1018,10 @@ func (s *Service) bumpEntryAfterTransportFailure(h [64]byte, cause error) {
 // changed, and the conditional request turns a full config materialization
 // into a 304 the control plane answers from the key's revision.
 //
+// The exception is a rolled budget period, where refreshConfigETag drops the
+// token so the fetch cannot come back 304 — nothing the token is built from
+// moves when a period ends, and the spend figures have to move.
+//
 // It bounds the staleness of the key's own expiration date by the same TTL. The
 // date arrives on the config response as well as on the token, so an admin who
 // shortens it is followed within one TTL even while the change feed is
@@ -991,7 +1036,7 @@ func (s *Service) refreshConfigBackground(h [64]byte, e *entry) {
 	defer cancel()
 
 	stale, _, _ := e.snapshot()
-	res, err := s.configFetcher.FetchConfig(ctx, stale.VirtualKeyID, e.currentConfigETag())
+	res, err := s.configFetcher.FetchConfig(ctx, stale.VirtualKeyID, e.refreshConfigETag())
 	if err != nil {
 		s.logger.Warn("config_ttl_refresh_failed",
 			zap.String("vk_id", stale.VirtualKeyID),

--- a/services/aigateway/adapters/authresolver/service.go
+++ b/services/aigateway/adapters/authresolver/service.go
@@ -154,6 +154,13 @@ type entry struct {
 	// Empty means we have no token to revalidate with, and the next refresh
 	// goes out unconditional.
 	configETag string
+	// budgetRollAckedFor is the budget boundary the control plane has already
+	// answered for on this entry. It is deliberately not configFetchedAt: that
+	// one is stamped on every refresh outcome, failures included, so keying the
+	// roll on it would let a control plane that could not be reached count as
+	// the re-read and hand the entry back to conditional revalidation still
+	// holding the dead period's spend.
+	budgetRollAckedFor time.Time
 }
 
 // currentConfigETag reports the ETag of the config this entry is carrying.
@@ -188,31 +195,70 @@ func (e *entry) refreshConfigETag() string {
 func (e *entry) configStale(ttl time.Duration) bool {
 	e.mu.Lock()
 	defer e.mu.Unlock()
-	if e.budgetPeriodRolled() {
+	rolled := e.budgetPeriodRolled()
+	if rolled && e.configFetchedAt.Before(e.bundle.Config.Budget.ValidUntil) {
+		// First look past the boundary: the figures are known dead, go now.
 		return true
 	}
 	if ttl <= 0 {
-		return false
+		// No staleness clock configured. A period that ended still has to keep
+		// asking, because with the roll unanswered nothing else will replace
+		// spend belonging to a period that is over.
+		return rolled
 	}
+	// A refresh that failed has stamped configFetchedAt, so the retries of an
+	// unanswered roll are paced by the ordinary clock rather than fired on
+	// every request. They stay unconditional until one of them is answered.
 	return time.Since(e.configFetchedAt) > ttl
 }
 
 // budgetPeriodRolled reports whether this entry's spend figures were read in a
-// budget period that has since ended. Caller holds e.mu.
+// budget period that has since ended and the control plane has not answered for
+// the new one yet. Caller holds e.mu.
 //
-// The `configFetchedAt` comparison is what keeps this a one-shot: it asks
-// whether the config was fetched BEFORE the boundary, so the refresh it
-// triggers clears it whether or not the control plane could be reached
-// (endConfigRefresh stamps configFetchedAt on every outcome). Without it a
-// bundle whose boundary is permanently in the past — a MANUAL budget carrying
-// an old stored instant, a clock skewed forward — would ask for a fresh fetch
-// on every request for as long as it lived.
+// Only an answer clears it. A failed fetch leaves the roll standing, so the
+// retry goes out unconditional again instead of offering the token and being
+// closed out by a 304 — which would leave the entry enforcing the dead period's
+// spend, the exact deadlock this is here to break.
+//
+// The permanently-past boundary — a MANUAL budget carrying an old stored
+// instant, a clock skewed forward — is handled at construction rather than
+// here: an entry built from a config read after the boundary starts already
+// acked, so it never asks. See ackedBoundaryAtBuild.
 func (e *entry) budgetPeriodRolled() bool {
 	validUntil := e.bundle.Config.Budget.ValidUntil
 	if validUntil.IsZero() {
 		return false
 	}
-	return !time.Now().Before(validUntil) && e.configFetchedAt.Before(validUntil)
+	if time.Now().Before(validUntil) {
+		return false
+	}
+	return !e.budgetRollAckedFor.Equal(validUntil)
+}
+
+// ackBudgetRoll records that the control plane answered for the boundary this
+// entry carries. Success and 304 both count: either is a live answer about this
+// key's config. A transport failure is not, and must not land here.
+func (e *entry) ackBudgetRoll() {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.budgetRollAckedFor = e.bundle.Config.Budget.ValidUntil
+}
+
+// ackedBoundaryAtBuild is the boundary a freshly built entry should count as
+// already answered: one that had passed by the time this config was read, so
+// the spend it carries was materialized after it. Zero otherwise, which leaves
+// the next roll to be detected normally.
+//
+// Without this a boundary that never moves would re-arm on every entry the
+// refresh creates, turning each staleness refresh into a full materialization
+// forever.
+func ackedBoundaryAtBuild(bundle *domain.Bundle, now time.Time) time.Time {
+	validUntil := bundle.Config.Budget.ValidUntil
+	if validUntil.IsZero() || now.Before(validUntil) {
+		return time.Time{}
+	}
+	return validUntil
 }
 
 // tryBeginConfigRefresh claims the per-entry config-refresh slot.
@@ -719,12 +765,14 @@ func (s *Service) Stop() {
 // config outright rather than revalidating against a token we do not have.
 func (s *Service) storeL1(h [64]byte, bundle *domain.Bundle, configETag string) {
 	softExpiresAt, hardExpiresAt := entryDeadlines(bundle, s.hardGrace)
+	now := time.Now()
 	s.l1.Add(h, &entry{
-		bundle:          bundle,
-		softExpiresAt:   softExpiresAt,
-		hardExpiresAt:   hardExpiresAt,
-		configFetchedAt: time.Now(),
-		configETag:      configETag,
+		bundle:             bundle,
+		softExpiresAt:      softExpiresAt,
+		hardExpiresAt:      hardExpiresAt,
+		configFetchedAt:    now,
+		configETag:         configETag,
+		budgetRollAckedFor: ackedBoundaryAtBuild(bundle, now),
 	})
 	// Record the bundle's org so the change-feed loop knows which orgs
 	// to subscribe to. LoadOrStore is the first-write-wins shape: if
@@ -1044,6 +1092,12 @@ func (s *Service) refreshConfigBackground(h [64]byte, e *entry) {
 		)
 		return
 	}
+	// The control plane answered, so a rolled boundary has had its re-read and
+	// stops forcing unconditional refreshes. This is deliberately after the
+	// error return above: a fetch that never got an answer leaves the roll
+	// standing so the next attempt goes out unconditional too.
+	e.ackBudgetRoll()
+
 	if res.NotModified {
 		// The config this entry carries is still the current one, so there is
 		// nothing to swap in. The deferred endConfigRefresh restarts the

--- a/services/aigateway/adapters/controlplane/config_wire.go
+++ b/services/aigateway/adapters/controlplane/config_wire.go
@@ -264,6 +264,7 @@ func (w *configWire) toDomain() domain.BundleConfig {
 	}
 
 	cfg.Budget.Scopes = toBudgetScopes(w.Budgets)
+	cfg.Budget.ValidUntil = budgetsValidUntil(w.Budgets)
 	cfg.PolicyRules = buildPolicyRules(w.PolicyRules)
 	cfg.CacheRules = buildCacheRules(w.CacheRules)
 
@@ -446,6 +447,32 @@ func toBudgetScopes(ws []budgetWire) []domain.BudgetScope {
 		}
 	}
 	return scopes
+}
+
+// budgetsValidUntil is the earliest boundary any enforceable budget on this
+// bundle is heading for: the instant its spend figures stop describing the
+// current period. See domain.BudgetConfig.ValidUntil for what the cache does
+// with it.
+//
+// Scopes without a limit are skipped because the checker skips them too, so
+// their boundary would shorten the config's life for a budget that can never
+// block. A non-positive resets_at is skipped as no answer rather than read as
+// 1970: TOTAL and MANUAL windows ship a far-future sentinel, and a control
+// plane older than the field ships nothing at all, neither of which is a
+// period that has ended.
+func budgetsValidUntil(ws []budgetWire) time.Time {
+	var earliest time.Time
+	for i := range ws {
+		b := &ws[i]
+		if b.LimitMicroUSD <= 0 || b.ResetsAt <= 0 {
+			continue
+		}
+		at := time.Unix(b.ResetsAt, 0)
+		if earliest.IsZero() || at.Before(earliest) {
+			earliest = at
+		}
+	}
+	return earliest
 }
 
 // toExcludedProviders maps the {id, type} exclusion wire entries onto domain

--- a/services/aigateway/adapters/controlplane/config_wire_test.go
+++ b/services/aigateway/adapters/controlplane/config_wire_test.go
@@ -470,3 +470,57 @@ func TestControlPlaneMaterialiserEmitsTheKeyExpiry(t *testing.T) {
 		t.Error("config.materialiser.ts no longer emits expires_at in unix SECONDS; milliseconds would push the date out of reach")
 	}
 }
+
+// The bundle's budget validity horizon: the earliest instant one of its
+// enforceable budgets leaves the period its spend figure was read in. The
+// auth cache re-reads rather than revalidates past it, because the config
+// version token does not move when a period ends.
+//
+// Spec: specs/ai-gateway/auth-cache.feature
+//
+//	(@unit — "A budget period that ends invalidates the spend the gateway
+//	 is holding").
+/** @scenario "a bundle knows when its spend figures stop describing the current period" */
+func TestConfigWire_BudgetsValidUntil(t *testing.T) {
+	day := int64(1788739200)  // the earlier boundary
+	week := int64(1789171200) // the later one
+
+	t.Run("takes the earliest boundary any enforceable budget is heading for", func(t *testing.T) {
+		w := configWire{Budgets: []budgetWire{
+			{ID: "b_week", Window: "week", LimitMicroUSD: 50_000_000, ResetsAt: week},
+			{ID: "b_day", Window: "day", LimitMicroUSD: 5_000_000, ResetsAt: day},
+		}}
+		assert.Equal(t, time.Unix(day, 0), w.toDomain().Budget.ValidUntil,
+			"the first period to end is the first that can leave a spend figure describing a period that is over")
+	})
+
+	t.Run("ignores a budget with no limit", func(t *testing.T) {
+		w := configWire{Budgets: []budgetWire{
+			{ID: "b_week", Window: "week", LimitMicroUSD: 50_000_000, ResetsAt: week},
+			{ID: "b_unset", Window: "day", LimitMicroUSD: 0, ResetsAt: day},
+		}}
+		assert.Equal(t, time.Unix(week, 0), w.toDomain().Budget.ValidUntil,
+			"a budget that can never block must not shorten the config's life")
+	})
+
+	t.Run("ignores a boundary the control plane did not send", func(t *testing.T) {
+		w := configWire{Budgets: []budgetWire{
+			{ID: "b_week", Window: "week", LimitMicroUSD: 50_000_000, ResetsAt: week},
+			{ID: "b_total", Window: "total", LimitMicroUSD: 5_000_000, ResetsAt: 0},
+		}}
+		assert.Equal(t, time.Unix(week, 0), w.toDomain().Budget.ValidUntil,
+			"an absent boundary is no answer, not a period that ended in 1970")
+	})
+
+	t.Run("is zero when nothing carries a boundary", func(t *testing.T) {
+		w := configWire{Budgets: []budgetWire{
+			{ID: "b_total", Window: "total", LimitMicroUSD: 5_000_000, ResetsAt: 0},
+		}}
+		assert.True(t, w.toDomain().Budget.ValidUntil.IsZero(),
+			"with nothing to expire, the ordinary staleness clock is the only schedule")
+	})
+
+	t.Run("is zero when the key has no budgets at all", func(t *testing.T) {
+		assert.True(t, (&configWire{}).toDomain().Budget.ValidUntil.IsZero())
+	})
+}

--- a/services/aigateway/domain/bundle.go
+++ b/services/aigateway/domain/bundle.go
@@ -552,10 +552,15 @@ type BudgetConfig struct {
 	// from the key's revision and its provider set, neither of which moves
 	// when a period rolls, so a conditional refresh comes back 304 and the
 	// figures never change. A budget that reached its limit in the old
-	// period would then keep rejecting every request in the new one, and
-	// the change event that would otherwise evict this entry is emitted by
-	// the debit of a request that got through — which, once the block is
-	// in force, no request ever does.
+	// period then keeps rejecting requests in the new one.
+	//
+	// The change feed does not close this. The BUDGET_UPDATED that evicts
+	// this entry is emitted by a debit — by a request that got through — and
+	// a blocked key cannot produce one. Eviction is project-wide, so a
+	// sibling key with traffic clears the block for the whole project; a
+	// project whose only traffic is the blocked key has no sibling, and stays
+	// blocked until an admin edits something or the process restarts. Hence a
+	// boundary the gateway keeps on its own schedule.
 	ValidUntil time.Time
 }
 

--- a/services/aigateway/domain/bundle.go
+++ b/services/aigateway/domain/bundle.go
@@ -540,6 +540,23 @@ type RateLimits struct {
 // BudgetConfig holds spending controls.
 type BudgetConfig struct {
 	Scopes []BudgetScope
+
+	// ValidUntil is the earliest instant at which one of Scopes leaves the
+	// period its SpentMicroUSD was read in — the earliest `resets_at` the
+	// control plane stamped on a scope that can block. Zero when no scope
+	// carries a usable boundary (no budgets, or none with a limit).
+	//
+	// Past this instant every spend figure here describes a period that has
+	// ended, so the cache holding this config must re-read it rather than
+	// revalidate it. Revalidating is not enough: the config ETag is built
+	// from the key's revision and its provider set, neither of which moves
+	// when a period rolls, so a conditional refresh comes back 304 and the
+	// figures never change. A budget that reached its limit in the old
+	// period would then keep rejecting every request in the new one, and
+	// the change event that would otherwise evict this entry is emitted by
+	// the debit of a request that got through — which, once the block is
+	// in force, no request ever does.
+	ValidUntil time.Time
 }
 
 // BudgetScope is a single budget limit with its current spend (microdollars).

--- a/specs/ai-gateway/auth-cache.feature
+++ b/specs/ai-gateway/auth-cache.feature
@@ -559,6 +559,13 @@ Feature: Gateway auth cache — hot path is zero RTT after first hit
       And the period counts as resolved only once an answer arrives
 
     @unit
+    Scenario: a confirmation taken before the boundary does not count as reading past it
+      Given a cached key whose config was confirmed unchanged inside its budget period
+      When that period ends and the next request arrives
+      Then the boundary still forces an unconditional re-read
+      And the new period's spend replaces the old
+
+    @unit
     Scenario: a bundle with no budgets keeps the ordinary staleness clock
       Given a cached key with no budgets
       When its config passes the staleness TTL

--- a/specs/ai-gateway/auth-cache.feature
+++ b/specs/ai-gateway/auth-cache.feature
@@ -550,6 +550,15 @@ Feature: Gateway auth cache — hot path is zero RTT after first hit
       And the rest fall back to the ordinary staleness clock
 
     @unit
+    Scenario: a refresh the control plane never answered leaves the period unresolved
+      Given a cached key whose budget period ended after its config was read
+      And a config refresh that fails to reach the control plane
+      When a later request arrives
+      Then the entry still holds the ended period's spend
+      And the next refresh is unconditional too, so it cannot be confirmed as unchanged
+      And the period counts as resolved only once an answer arrives
+
+    @unit
     Scenario: a bundle with no budgets keeps the ordinary staleness clock
       Given a cached key with no budgets
       When its config passes the staleness TTL

--- a/specs/ai-gateway/auth-cache.feature
+++ b/specs/ai-gateway/auth-cache.feature
@@ -504,11 +504,20 @@ Feature: Gateway auth cache — hot path is zero RTT after first hit
     # provider set. Neither of those moves when a period ends, so a conditional
     # revalidation confirms figures that describe a period that is over.
     #
-    # For a budget that reached its limit, that is a block with no way out. The
-    # change event that would evict the entry is emitted by the debit of a
-    # request that got through, and once the block is in force no request gets
-    # through. The key stays rejected on yesterday's money until someone edits
-    # it or the gateway restarts.
+    # For a budget that reached its limit, that leaves the key rejecting on
+    # money it did not spend this period. What clears it is a BUDGET_UPDATED
+    # event, and the only one that arrives without an admin touching something
+    # is emitted by a debit — by a request that got through. The blocked key
+    # cannot produce one itself.
+    #
+    # Eviction on that event is project-wide (org-wide when the event carries
+    # no project), so a sibling key with traffic in the same project clears the
+    # block for everyone within a poll cycle. The keys that stay stuck are the
+    # ones whose project has no other traffic — a CI key, a scheduled job, a
+    # single-key project — and they stay stuck until an admin edits something
+    # or the gateway restarts. That is the case this Rule closes; it is not
+    # closed by the change feed, which is why the boundary has to be a schedule
+    # the gateway keeps on its own.
 
     @unit
     Scenario: a bundle knows when its spend figures stop describing the current period
@@ -528,6 +537,7 @@ Feature: Gateway auth cache — hot path is zero RTT after first hit
     @unit
     Scenario: a period still running is revalidated the ordinary way
       Given a cached key whose budget is exhausted inside its own period
+      And a config read within the staleness TTL
       When the next request arrives
       Then no config refresh is triggered
       And the request is judged against the spend the gateway holds

--- a/specs/ai-gateway/auth-cache.feature
+++ b/specs/ai-gateway/auth-cache.feature
@@ -497,6 +497,54 @@ Feature: Gateway auth cache — hot path is zero RTT after first hit
       And an explicit null is a key that never expires
       And a missing field says nothing about expiry, so the caller keeps what it holds
 
+  Rule: A budget period that ends invalidates the spend the gateway is holding
+
+    # The bundle carries each budget's spend for the period it was read in, and
+    # the config version token is built from the key's revision and its
+    # provider set. Neither of those moves when a period ends, so a conditional
+    # revalidation confirms figures that describe a period that is over.
+    #
+    # For a budget that reached its limit, that is a block with no way out. The
+    # change event that would evict the entry is emitted by the debit of a
+    # request that got through, and once the block is in force no request gets
+    # through. The key stays rejected on yesterday's money until someone edits
+    # it or the gateway restarts.
+
+    @unit
+    Scenario: a bundle knows when its spend figures stop describing the current period
+      Given a config response carrying budgets that reset at different instants
+      When the gateway decodes it
+      Then the bundle is valid until the earliest of those instants
+      And a budget with no limit does not shorten that, because it can never block
+      And a budget the control plane sent no boundary for does not shorten it either
+
+    @unit
+    Scenario: the refresh at a period boundary asks for the config instead of confirming it
+      Given a cached key whose budget period ended after its config was read
+      When the next request arrives
+      Then the config refresh carries no version token
+      And the new period's spend replaces the old period's
+
+    @unit
+    Scenario: a period still running is revalidated the ordinary way
+      Given a cached key whose budget is exhausted inside its own period
+      When the next request arrives
+      Then no config refresh is triggered
+      And the request is judged against the spend the gateway holds
+
+    @unit
+    Scenario: a boundary that is already behind the gateway is asked about once
+      Given a cached key carrying a budget boundary that never moves
+      When request after request arrives
+      Then only the first triggers a config re-read
+      And the rest fall back to the ordinary staleness clock
+
+    @unit
+    Scenario: a bundle with no budgets keeps the ordinary staleness clock
+      Given a cached key with no budgets
+      When its config passes the staleness TTL
+      Then the refresh revalidates against the version token as before
+
   Rule: Bootstrap-pull enables gateway to serve when control plane is cold
 
     # The flag is named the way contract.md §6 and §9 name it. Nothing reads


### PR DESCRIPTION
## What is broken

A gateway-cached bundle carries each budget's `spent_micro_usd` for the period it was materialised in. The config version token is `revision.hash(providers)` (`platform/app/src/server/gateway/configETag.ts:75`), and neither half moves when a budget period ends. So the 60-second staleness refresh (`ConfigTTL`) sends `If-None-Match`, gets a 304, and the spend figures stay where they were — describing a period that is over.

For a budget at its limit that means the key keeps returning 402 `budget_exceeded` into the new period, on money it did not spend there.

## Why the change feed does not already cover it

`BUDGET_UPDATED` is what evicts the entry, and the only one that arrives without an admin action is emitted by a debit — by a request that got through (`platform/app/ee/governance/process-manager/gatewayDebits.process.ts:386`). A blocked key cannot produce one.

Eviction is project-wide, or org-wide when the event carries no project (`services/aigateway/adapters/authresolver/service.go`, `ChangeKindBudgetUpdated`), so a sibling key with traffic clears the block for the whole project within a poll cycle. The keys that stay stuck are the ones whose project has no other traffic — a CI key, a scheduled job, a single-key project. Those stay blocked until an admin edits something or the process restarts.

## The change

The wire already carries each budget's `resets_at` (`config.materialiser.ts`, `budgetToWire`); the gateway decoded it into `budgetWire.ResetsAt` and dropped it on the floor. No control-plane change is needed.

- `domain.BudgetConfig.ValidUntil` — the earliest `resets_at` belonging to a scope with a limit. Zero when nothing carries a usable boundary. A scope with no limit is skipped because the checker skips it too; a non-positive `resets_at` is skipped as "no answer" rather than read as 1970, which is what `TOTAL`/`MANUAL` sentinels and older control planes send.
- `configStale` refreshes at once on the first look past that instant, whatever the TTL, and keeps asking while the roll is unanswered even when `ttl <= 0`. Disabling the age-based safety net is not consent to enforce a dead period's spend indefinitely.
- `refreshConfigETag` drops the `If-None-Match` while the roll is unanswered, so none of those refreshes can come back 304.
- `entry.budgetRollAckedFor` is the boundary whose spend the entry already carries, set once at construction and never on the refresh path. It is deliberately not `configFetchedAt`: that stamp lands on every refresh outcome, failures included, so keying the roll on it would let a control plane that could not be reached count as the re-read — the entry would offer its token again, be answered 304, and go on enforcing the dead period's spend.
- Only a config the gateway actually received clears a roll, and that arrives as a new entry through `storeL1`, whose `ackedBoundaryAtBuild` marks a boundary that had already passed when the config was read. A boundary that never moves — a `MANUAL` window, a skewed clock — therefore costs one re-read rather than one per refresh.
- A 304 and a transport failure both leave the roll standing, so the next refresh goes out unconditional too, paced by the ordinary clock. A 304 carries no spend, and one taken while the period was still running says nothing about the period after it.

## Evidence

The fix was disabled in place (`budgetPeriodRolled` forced to `false`) and the suite re-run. Without it:

```
--- FAIL: TestResolve_BudgetPeriodRolled_RefreshesUnconditionally
    expected: []string{""}   actual: []string{"42"}    (the refresh offers the token and is answered 304)
    expected: 0              actual: 5000000           (the ended period's spend stays in force)
--- FAIL: TestResolve_BudgetBoundaryLongPast_RefreshesOnce
    expected: []string{""}   actual: []string{"42"}
```

The two ways a roll can be closed out without fresh spend were probed the same way:

- Reverting `budgetPeriodRolled` to the `configFetchedAt` comparison fails `TestResolve_BudgetRollFetchFails_StaysUnconditional` on the `ttl <= 0` assertion — a failed fetch would close out the roll and never retry.
- Acking the roll on any control-plane answer fails `TestResolve_BudgetPeriodRolled_AfterEarlier304_StillRefreshes` with conditionals `["42"]` instead of `["42", ""]` and spend `5000000` instead of `0`. That one is the sharper of the two: the ordinary in-period refresh is confirmed hundreds of times before a daily boundary, so acking on 304 would ack a boundary the entry had not reached and the roll would never fire at all.

Restored, the package passes. `gofmt`, `go vet`, `golangci-lint` and the full `services/aigateway` suite are clean.

## Spec

`specs/ai-gateway/auth-cache.feature` gains the Rule "A budget period that ends invalidates the spend the gateway is holding", seven `@unit` scenarios, all bound.

## Deployment Impact

**Env vars added or changed:** none. The boundary is read from the config the gateway already fetches (`resets_at`, decoded into `budgetWire.ResetsAt`), so there is no new setting, flag or toggle to roll out. `LW_GATEWAY_AUTH_CACHE_*` and the config TTL keep their current meanings.

**Helm values added or changed:** none. No chart, template or default was touched — the diff is six files under `services/aigateway/` and one spec file.

**Default behavior on a vanilla `helm install` with no overrides:** the fix is on, with no opt-in. The only operational change is that a cached key whose budget period has just ended does one full config read instead of a conditional one that returns 304. That is bounded at one extra read per cached key per budget period, because the entry the re-read produces is built with that boundary already accounted for. When the control plane cannot be reached the retry stays unconditional and is paced by the existing staleness clock, so an outage does not turn into a per-request fetch. Gateways whose keys carry no budget, or budgets with no limit or no usable `resets_at`, behave exactly as before and keep the conditional refresh.

**BYOC dataplane impact:** the gateway is the dataplane component here, and it keeps talking to the same control-plane config endpoint it already uses — no new destination, dependency, port or credential. Dataplane operators see a small rise in config-fetch volume at budget period boundaries and no change to request latency on the hot path, since the re-read happens on the existing background refresh, not inline with a request. Older control planes that send no `resets_at` are handled: the boundary reads as absent and the gateway keeps its current behaviour, so a dataplane can be upgraded ahead of its control plane.

Rollback is a plain revert; nothing persists state and no migration is involved.

## Not addressed

Every daily budget in a fleet rolls at the same instant, so at 00:00 UTC refreshes that were 304s all become full materialisations (provider resolution, budget resolution, a ClickHouse read) at once. There is no jitter. Spreading them is cheap to add, but not without a measurement of how many cached keys carry a cyclic budget and what a materialisation costs — a guess here would trade a correctness bug for a load one.

Separately: this was found while investigating a production report of 402s. Whether those particular rejections were caused by this bug or were correct enforcement was never established — the period's ClickHouse spend was not read. The defect above stands on its own evidence, not on that incident.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Budget-period rollovers now refresh cached spend data correctly, preventing stale budget information after a reset.
  * Budget boundaries trigger an unconditional configuration refresh when needed.
  * Failed refreshes continue retrying until the control plane responds.
  * Budgets without usable reset boundaries retain standard refresh behavior.

* **Tests**
  * Added coverage for active periods, rollover handling, delayed boundaries, failed refreshes, and configurations without budgets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


