### PR TITLE
fix(api-keys): every door to a personal key stops revoking the other machines', and a signed-out device says so

### DIFF
--- a/platform/app/ee/governance/routers/ingestionKey.ts
+++ b/platform/app/ee/governance/routers/ingestionKey.ts
@@ -46,16 +46,20 @@ export const ingestionKeyRouter = createTRPCRouter({
     }),
 
   /**
-   * Mint (rotating in place) an ingestion key for the caller's personal
-   * project + sourceType. Returns the plaintext token ONCE; subsequent
-   * reads only see the source list.
+   * Connect a source: mint an ingestion key for the caller's personal project
+   * + sourceType. Returns the plaintext token ONCE; subsequent reads only see
+   * the source list.
+   *
+   * Create-only. Connecting a source says nothing about the machines already
+   * exporting for it, so their keys stay live; `rotate` is the verb that
+   * kills them.
    */
   install: protectedProcedure
     .input(mintInput)
     .permission("organization:view")
     .mutation(async ({ ctx, input }) => {
       const service = IngestionKeyService.create(ctx.prisma);
-      return await service.ensureForPersonalProject({
+      return await service.createForPersonalProject({
         userId: ctx.session.user.id,
         organizationId: input.organizationId,
         sourceType: input.sourceType,

--- a/platform/app/ee/governance/services/__tests__/ingestionKey.personalCap.unit.test.ts
+++ b/platform/app/ee/governance/services/__tests__/ingestionKey.personalCap.unit.test.ts
@@ -13,7 +13,6 @@ const apiKeys = vi.hoisted(() => ({
   revoke: vi.fn(),
 }));
 const apiKeyRepo = vi.hoisted(() => ({
-  findIngestKey: vi.fn(),
   findIngestKeysForProject: vi.fn(),
 }));
 const workspace = vi.hoisted(() => ({
@@ -91,6 +90,23 @@ describe("IngestionKeyService.issueForPersonalProject", () => {
     });
   });
 
+  describe("when the source type is one the product knows but no CLI wraps", () => {
+    it("mints through the create-only path the tile and MCP use", async () => {
+      apiKeyRepo.findIngestKeysForProject.mockResolvedValue([]);
+
+      const issued = await service.createForPersonalProject({
+        ...PARAMS,
+        sourceType: "claude_cowork",
+      });
+
+      // The wrapped-tool list bounds what a device session may mint. The
+      // tile and the MCP tool name source types from the product's own
+      // catalog, so they reach the same create-only mint without it.
+      expect(issued.apiKeyId).toBe("ak_new");
+      expect(apiKeys.revoke).not.toHaveBeenCalled();
+    });
+  });
+
   describe("when other devices already hold live keys under the cap", () => {
     it("mints a new key and revokes none of them", async () => {
       apiKeyRepo.findIngestKeysForProject.mockResolvedValue([
@@ -103,7 +119,6 @@ describe("IngestionKeyService.issueForPersonalProject", () => {
 
       expect(issued.apiKeyId).toBe("ak_new");
       expect(apiKeys.revoke).not.toHaveBeenCalled();
-      expect(apiKeyRepo.findIngestKey).not.toHaveBeenCalled();
     });
   });
 

--- a/platform/app/ee/governance/services/__tests__/ingestionKey.personalCap.unit.test.ts
+++ b/platform/app/ee/governance/services/__tests__/ingestionKey.personalCap.unit.test.ts
@@ -18,12 +18,20 @@ const apiKeyRepo = vi.hoisted(() => ({
 const workspace = vi.hoisted(() => ({
   findExisting: vi.fn(),
 }));
+const templates = vi.hoisted(() => ({
+  findByIdForOrg: vi.fn(),
+}));
 
 vi.mock("~/server/api-key/api-key.service", () => ({
   ApiKeyService: { create: () => apiKeys },
 }));
 vi.mock("~/server/api-key/api-key.repository", () => ({
   ApiKeyRepository: { create: () => apiKeyRepo },
+}));
+vi.mock("../../repositories/ingestionTemplate.repository", () => ({
+  IngestionTemplateRepository: class {
+    findByIdForOrg = templates.findByIdForOrg;
+  },
 }));
 vi.mock("../personalWorkspace.service", () => ({
   PersonalWorkspaceService: class {
@@ -71,6 +79,7 @@ describe("IngestionKeyService.issueForPersonalProject", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     service = IngestionKeyService.create({} as never);
+    templates.findByIdForOrg.mockResolvedValue(null);
     workspace.findExisting.mockResolvedValue({ project: { id: "project_1" } });
     apiKeys.create.mockResolvedValue({
       token: "ik-lw-fresh-token",
@@ -91,19 +100,41 @@ describe("IngestionKeyService.issueForPersonalProject", () => {
   });
 
   describe("when the source type is one the product knows but no CLI wraps", () => {
-    it("mints through the create-only path the tile and MCP use", async () => {
+    /** @scenario "A source type outside the wrapped tools needs its template" */
+    it("mints when a published template names it", async () => {
       apiKeyRepo.findIngestKeysForProject.mockResolvedValue([]);
+      templates.findByIdForOrg.mockResolvedValue({
+        id: "tmpl_cowork",
+        sourceType: "claude_cowork",
+      });
 
       const issued = await service.createForPersonalProject({
         ...PARAMS,
         sourceType: "claude_cowork",
+        ingestionTemplateId: "tmpl_cowork",
       });
 
-      // The wrapped-tool list bounds what a device session may mint. The
-      // tile and the MCP tool name source types from the product's own
-      // catalog, so they reach the same create-only mint without it.
       expect(issued.apiKeyId).toBe("ak_new");
       expect(apiKeys.revoke).not.toHaveBeenCalled();
+    });
+
+    /** @scenario "A source type outside the wrapped tools needs its template" */
+    it("refuses a source type no template names", async () => {
+      // The cap counts one source type at a time, so a caller free to invent
+      // them is a caller with an unbounded number of 32-key buckets.
+      await expect(
+        service.createForPersonalProject({
+          ...PARAMS,
+          sourceType: "made_up",
+          ingestionTemplateId: "tmpl_other",
+        }),
+      ).rejects.toThrow(/made_up/);
+
+      await expect(
+        service.createForPersonalProject({ ...PARAMS, sourceType: "made_up" }),
+      ).rejects.toThrow(/made_up/);
+
+      expect(apiKeys.create).not.toHaveBeenCalled();
     });
   });
 

--- a/platform/app/ee/governance/services/__tests__/ingestionKey.personalCreateOnly.integration.test.ts
+++ b/platform/app/ee/governance/services/__tests__/ingestionKey.personalCreateOnly.integration.test.ts
@@ -20,6 +20,7 @@ import {
 import { registerGovernanceMcpTools } from "~/mcp/governance-tools";
 import { appRouter } from "~/server/api/root";
 import { createInnerTRPCContext } from "~/server/api/trpc";
+import { TokenResolver } from "~/server/api-key/token-resolver";
 import { prisma } from "~/server/db";
 import { wireDefaultTestApp } from "~/test-utils/wireDefaultTestApp";
 
@@ -35,7 +36,7 @@ const PROJECT_ID = `prj-ikc-${suffix}`;
 const PROJECT_API_KEY = `sk-lw-ikc-${suffix}`;
 
 /** The one MCP surface under test, invoked the way the server would. */
-async function mintThroughMcp(sourceType: string): Promise<void> {
+async function mintThroughMcp(sourceType: string): Promise<string> {
   const tools = new Map<string, (args: any) => Promise<unknown>>();
   const server = {
     tool: (
@@ -56,7 +57,22 @@ async function mintThroughMcp(sourceType: string): Promise<void> {
   const mint = tools.get("governance_ingestion_keys_mint");
   if (!mint)
     throw new Error("governance_ingestion_keys_mint is not registered");
-  await mint({ source_type: sourceType });
+  const result = (await mint({ source_type: sourceType })) as {
+    content: Array<{ text: string }>;
+  };
+  const issued = JSON.parse(
+    result.content.map((part) => part.text).join(""),
+  ) as { token: string };
+  return issued.token;
+}
+
+/**
+ * Whether a token still gets through the resolver every trace-write endpoint
+ * authorizes with. A revoked key resolves to nothing, which is the 401.
+ */
+async function authorizesTraceWrites(token: string): Promise<boolean> {
+  const resolved = await TokenResolver.create(prisma).resolve({ token });
+  return resolved !== null;
 }
 
 function caller() {
@@ -82,6 +98,8 @@ async function liveKeyIds(): Promise<string[]> {
 
 describe("personal ingest keys minted outside the CLI", () => {
   const service = IngestionKeyService.create(prisma);
+  /** Every token handed out before the rotation, in the order it was minted. */
+  const priorTokens: string[] = [];
 
   beforeAll(async () => {
     await prisma.organization.create({
@@ -152,21 +170,24 @@ describe("personal ingest keys minted outside the CLI", () => {
 
   describe("when a device already holds a key and the tile connects the source", () => {
     /** @scenario "Connecting a source from the personal tile keeps the devices' keys" */
-    it("adds a key and revokes none", async () => {
+    it("adds a key and leaves the device's own authorizing", async () => {
       const laptop = await service.issueForPersonalProject({
         userId: USER_ID,
         organizationId: ORG_ID,
         sourceType: "claude_code",
       });
+      priorTokens.push(laptop.token);
 
-      await caller().ingestionKey.install({
+      const installed = await caller().ingestionKey.install({
         organizationId: ORG_ID,
         sourceType: "claude_code",
       });
+      priorTokens.push(installed.token);
 
       const live = await liveKeyIds();
       expect(live).toContain(laptop.apiKeyId);
       expect(live).toHaveLength(2);
+      expect(await authorizesTraceWrites(laptop.token)).toBe(true);
     });
   });
 
@@ -175,7 +196,7 @@ describe("personal ingest keys minted outside the CLI", () => {
     it("adds a key and revokes none", async () => {
       const before = await liveKeyIds();
 
-      await mintThroughMcp("claude_code");
+      priorTokens.push(await mintThroughMcp("claude_code"));
 
       const live = await liveKeyIds();
       // Every key that was live before an agent asked for one is still live:
@@ -187,17 +208,27 @@ describe("personal ingest keys minted outside the CLI", () => {
 
   describe("when the tile rotates the source", () => {
     /** @scenario "An explicit rotation from the personal tile revokes every prior key" */
-    it("leaves exactly the rotated key live", async () => {
-      expect((await liveKeyIds()).length).toBeGreaterThan(1);
+    it("leaves one new key authorizing and every prior token refused", async () => {
+      const before = await liveKeyIds();
+      expect(before.length).toBeGreaterThan(1);
+      expect(priorTokens).toHaveLength(before.length);
 
-      await caller().ingestionKey.rotate({
+      const rotated = await caller().ingestionKey.rotate({
         organizationId: ORG_ID,
         sourceType: "claude_code",
       });
 
       // Rotation is the verb that kills the other machines' keys, and it is
-      // the only one that still does.
-      expect(await liveKeyIds()).toHaveLength(1);
+      // the only one that still does. A row read is not the claim being
+      // made, so each prior token goes back through the resolver the
+      // trace-write endpoints authorize with.
+      const live = await liveKeyIds();
+      expect(live).toHaveLength(1);
+      expect(before).not.toContain(live[0]);
+      expect(await authorizesTraceWrites(rotated.token)).toBe(true);
+      for (const token of priorTokens) {
+        expect(await authorizesTraceWrites(token)).toBe(false);
+      }
     });
   });
 });

--- a/platform/app/ee/governance/services/__tests__/ingestionKey.personalCreateOnly.integration.test.ts
+++ b/platform/app/ee/governance/services/__tests__/ingestionKey.personalCreateOnly.integration.test.ts
@@ -17,10 +17,10 @@ import {
   RoleBindingScopeType,
   TeamUserRole,
 } from "~/generated/prisma/client";
+import { registerGovernanceMcpTools } from "~/mcp/governance-tools";
 import { appRouter } from "~/server/api/root";
 import { createInnerTRPCContext } from "~/server/api/trpc";
 import { prisma } from "~/server/db";
-import { registerGovernanceMcpTools } from "~/mcp/governance-tools";
 import { wireDefaultTestApp } from "~/test-utils/wireDefaultTestApp";
 
 import { IngestionKeyService } from "../ingestionKey.service";
@@ -38,7 +38,12 @@ const PROJECT_API_KEY = `sk-lw-ikc-${suffix}`;
 async function mintThroughMcp(sourceType: string): Promise<void> {
   const tools = new Map<string, (args: any) => Promise<unknown>>();
   const server = {
-    tool: (name: string, _d: unknown, _s: unknown, cb: (a: any) => Promise<unknown>) => {
+    tool: (
+      name: string,
+      _d: unknown,
+      _s: unknown,
+      cb: (a: any) => Promise<unknown>,
+    ) => {
       tools.set(name, cb);
       return null;
     },
@@ -49,7 +54,8 @@ async function mintThroughMcp(sourceType: string): Promise<void> {
     callerUserId: USER_ID,
   });
   const mint = tools.get("governance_ingestion_keys_mint");
-  if (!mint) throw new Error("governance_ingestion_keys_mint is not registered");
+  if (!mint)
+    throw new Error("governance_ingestion_keys_mint is not registered");
   await mint({ source_type: sourceType });
 }
 
@@ -127,13 +133,16 @@ describe("personal ingest keys minted outside the CLI", () => {
 
   afterAll(async () => {
     for (const del of [
-      () => prisma.roleBinding.deleteMany({ where: { organizationId: ORG_ID } }),
+      () =>
+        prisma.roleBinding.deleteMany({ where: { organizationId: ORG_ID } }),
       () => prisma.apiKey.deleteMany({ where: { organizationId: ORG_ID } }),
       () => prisma.customRole.deleteMany({ where: { organizationId: ORG_ID } }),
       () => prisma.project.deleteMany({ where: { teamId: TEAM_ID } }),
       () => prisma.team.deleteMany({ where: { organizationId: ORG_ID } }),
       () =>
-        prisma.organizationUser.deleteMany({ where: { organizationId: ORG_ID } }),
+        prisma.organizationUser.deleteMany({
+          where: { organizationId: ORG_ID },
+        }),
       () => prisma.user.deleteMany({ where: { id: USER_ID } }),
       () => prisma.organization.deleteMany({ where: { id: ORG_ID } }),
     ]) {

--- a/platform/app/ee/governance/services/__tests__/ingestionKey.personalCreateOnly.integration.test.ts
+++ b/platform/app/ee/governance/services/__tests__/ingestionKey.personalCreateOnly.integration.test.ts
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+/**
+ * @vitest-environment node
+ *
+ * The CLI is not the only door to a personal ingest key: the /me Trace Ingest
+ * tile connects a source, and an agent mints one through MCP. Both used to
+ * rotate in place, so either one revoked the key every machine under that
+ * login was exporting with, which is the failure the create-only CLI mint was
+ * built to end. They add a key now. The tile's explicit rotate still does not.
+ *
+ * Spec: specs/ai-gateway/governance/ingest-api-key-lifecycle.feature
+ */
+import { nanoid } from "nanoid";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  OrganizationUserRole,
+  RoleBindingScopeType,
+  TeamUserRole,
+} from "~/generated/prisma/client";
+import { appRouter } from "~/server/api/root";
+import { createInnerTRPCContext } from "~/server/api/trpc";
+import { prisma } from "~/server/db";
+import { registerGovernanceMcpTools } from "~/mcp/governance-tools";
+import { wireDefaultTestApp } from "~/test-utils/wireDefaultTestApp";
+
+import { IngestionKeyService } from "../ingestionKey.service";
+
+wireDefaultTestApp();
+
+const suffix = nanoid(8);
+const ORG_ID = `org-ikc-${suffix}`;
+const USER_ID = `usr-ikc-${suffix}`;
+const TEAM_ID = `team-ikc-${suffix}`;
+const PROJECT_ID = `prj-ikc-${suffix}`;
+const PROJECT_API_KEY = `sk-lw-ikc-${suffix}`;
+
+/** The one MCP surface under test, invoked the way the server would. */
+async function mintThroughMcp(sourceType: string): Promise<void> {
+  const tools = new Map<string, (args: any) => Promise<unknown>>();
+  const server = {
+    tool: (name: string, _d: unknown, _s: unknown, cb: (a: any) => Promise<unknown>) => {
+      tools.set(name, cb);
+      return null;
+    },
+  };
+  registerGovernanceMcpTools(server as never, {
+    prisma,
+    apiKey: PROJECT_API_KEY,
+    callerUserId: USER_ID,
+  });
+  const mint = tools.get("governance_ingestion_keys_mint");
+  if (!mint) throw new Error("governance_ingestion_keys_mint is not registered");
+  await mint({ source_type: sourceType });
+}
+
+function caller() {
+  return appRouter.createCaller(
+    createInnerTRPCContext({
+      session: { user: { id: USER_ID }, expires: "1" } as never,
+    }),
+  );
+}
+
+async function liveKeyIds(): Promise<string[]> {
+  const rows = await prisma.apiKey.findMany({
+    where: {
+      organizationId: ORG_ID,
+      ingestSourceType: "claude_code",
+      revokedAt: null,
+    },
+    select: { id: true },
+    orderBy: { createdAt: "asc" },
+  });
+  return rows.map((row) => row.id);
+}
+
+describe("personal ingest keys minted outside the CLI", () => {
+  const service = IngestionKeyService.create(prisma);
+
+  beforeAll(async () => {
+    await prisma.organization.create({
+      data: { id: ORG_ID, name: `IKC ${suffix}`, slug: ORG_ID },
+    });
+    await prisma.user.create({
+      data: { id: USER_ID, email: `${USER_ID}@example.com`, name: "Jane" },
+    });
+    await prisma.organizationUser.create({
+      data: {
+        organizationId: ORG_ID,
+        userId: USER_ID,
+        role: OrganizationUserRole.ADMIN,
+      },
+    });
+    await prisma.roleBinding.create({
+      data: {
+        organizationId: ORG_ID,
+        userId: USER_ID,
+        role: TeamUserRole.ADMIN,
+        scopeType: RoleBindingScopeType.ORGANIZATION,
+        scopeId: ORG_ID,
+      },
+    });
+    await prisma.team.create({
+      data: {
+        id: TEAM_ID,
+        organizationId: ORG_ID,
+        name: `team ${suffix}`,
+        slug: `team-ikc-${suffix}`,
+        ownerUserId: USER_ID,
+        isPersonal: true,
+      },
+    });
+    await prisma.project.create({
+      data: {
+        id: PROJECT_ID,
+        teamId: TEAM_ID,
+        name: `personal ${suffix}`,
+        slug: `prj-ikc-${suffix}`,
+        ownerUserId: USER_ID,
+        isPersonal: true,
+        apiKey: PROJECT_API_KEY,
+        language: "typescript",
+        framework: "other",
+      },
+    });
+  });
+
+  afterAll(async () => {
+    for (const del of [
+      () => prisma.roleBinding.deleteMany({ where: { organizationId: ORG_ID } }),
+      () => prisma.apiKey.deleteMany({ where: { organizationId: ORG_ID } }),
+      () => prisma.customRole.deleteMany({ where: { organizationId: ORG_ID } }),
+      () => prisma.project.deleteMany({ where: { teamId: TEAM_ID } }),
+      () => prisma.team.deleteMany({ where: { organizationId: ORG_ID } }),
+      () =>
+        prisma.organizationUser.deleteMany({ where: { organizationId: ORG_ID } }),
+      () => prisma.user.deleteMany({ where: { id: USER_ID } }),
+      () => prisma.organization.deleteMany({ where: { id: ORG_ID } }),
+    ]) {
+      await del().catch(() => undefined);
+    }
+  });
+
+  describe("when a device already holds a key and the tile connects the source", () => {
+    /** @scenario "Connecting a source from the personal tile keeps the devices' keys" */
+    it("adds a key and revokes none", async () => {
+      const laptop = await service.issueForPersonalProject({
+        userId: USER_ID,
+        organizationId: ORG_ID,
+        sourceType: "claude_code",
+      });
+
+      await caller().ingestionKey.install({
+        organizationId: ORG_ID,
+        sourceType: "claude_code",
+      });
+
+      const live = await liveKeyIds();
+      expect(live).toContain(laptop.apiKeyId);
+      expect(live).toHaveLength(2);
+    });
+  });
+
+  describe("when a device already holds a key and an agent mints through MCP", () => {
+    /** @scenario "An agent minting through MCP keeps the devices' keys" */
+    it("adds a key and revokes none", async () => {
+      const before = await liveKeyIds();
+
+      await mintThroughMcp("claude_code");
+
+      const live = await liveKeyIds();
+      // Every key that was live before an agent asked for one is still live:
+      // the machines exporting with them never learn about this call.
+      expect(live).toEqual(expect.arrayContaining(before));
+      expect(live).toHaveLength(before.length + 1);
+    });
+  });
+
+  describe("when the tile rotates the source", () => {
+    /** @scenario "An explicit rotation from the personal tile revokes every prior key" */
+    it("leaves exactly the rotated key live", async () => {
+      expect((await liveKeyIds()).length).toBeGreaterThan(1);
+
+      await caller().ingestionKey.rotate({
+        organizationId: ORG_ID,
+        sourceType: "claude_code",
+      });
+
+      // Rotation is the verb that kills the other machines' keys, and it is
+      // the only one that still does.
+      expect(await liveKeyIds()).toHaveLength(1);
+    });
+  });
+});

--- a/platform/app/ee/governance/services/__tests__/ingestionKey.rotation.unit.test.ts
+++ b/platform/app/ee/governance/services/__tests__/ingestionKey.rotation.unit.test.ts
@@ -14,7 +14,7 @@ const apiKeys = vi.hoisted(() => ({
   revoke: vi.fn(),
 }));
 const apiKeyRepo = vi.hoisted(() => ({
-  findIngestKey: vi.fn(),
+  findIngestKeysForProject: vi.fn(),
 }));
 
 vi.mock("~/server/api-key/api-key.service", () => ({
@@ -37,6 +37,12 @@ const MINT_PARAMS = {
   sourceType: "claude_code",
 } as const;
 
+const priorKey = (id: string, sourceType = "claude_code") => ({
+  id,
+  ingestSourceType: sourceType,
+  ingestionTemplateId: null,
+});
+
 describe("IngestionKeyService.ensureForProject", () => {
   let service: IngestionKeyService;
 
@@ -52,7 +58,9 @@ describe("IngestionKeyService.ensureForProject", () => {
   describe("when a prior key exists for the project and source type", () => {
     /** @scenario "Rotating a key answers without waiting on the old key's cleanup" */
     it("revokes it without a projection hold of its own", async () => {
-      apiKeyRepo.findIngestKey.mockResolvedValue({ id: "ak_prior" });
+      apiKeyRepo.findIngestKeysForProject.mockResolvedValue([
+        priorKey("ak_prior"),
+      ]);
 
       await service.ensureForProject(MINT_PARAMS);
 
@@ -66,7 +74,9 @@ describe("IngestionKeyService.ensureForProject", () => {
 
     /** @scenario "A hard-cut rotation names itself as the cause" */
     it("names the rotation as the cause of the revoke", async () => {
-      apiKeyRepo.findIngestKey.mockResolvedValue({ id: "ak_prior" });
+      apiKeyRepo.findIngestKeysForProject.mockResolvedValue([
+        priorKey("ak_prior"),
+      ]);
 
       await service.ensureForProject(MINT_PARAMS);
 
@@ -76,9 +86,30 @@ describe("IngestionKeyService.ensureForProject", () => {
     });
   });
 
+  describe("when several machines hold live keys for the same tool", () => {
+    /** @scenario "An explicit rotation from the personal tile revokes every prior key" */
+    it("revokes all of them, not just the first", async () => {
+      apiKeyRepo.findIngestKeysForProject.mockResolvedValue([
+        priorKey("ak_laptop"),
+        priorKey("ak_desktop"),
+        priorKey("ak_vm"),
+        // Another tool's key, which this rotation is not about.
+        priorKey("ak_codex", "codex"),
+      ]);
+
+      await service.ensureForProject(MINT_PARAMS);
+
+      expect(apiKeys.revoke.mock.calls.map(([args]) => args.id)).toEqual([
+        "ak_laptop",
+        "ak_desktop",
+        "ak_vm",
+      ]);
+    });
+  });
+
   describe("when no prior key exists", () => {
     it("mints without revoking anything", async () => {
-      apiKeyRepo.findIngestKey.mockResolvedValue(null);
+      apiKeyRepo.findIngestKeysForProject.mockResolvedValue([]);
 
       const issued = await service.ensureForProject(MINT_PARAMS);
 

--- a/platform/app/ee/governance/services/__tests__/ingestionKey.rotation.unit.test.ts
+++ b/platform/app/ee/governance/services/__tests__/ingestionKey.rotation.unit.test.ts
@@ -107,6 +107,34 @@ describe("IngestionKeyService.ensureForProject", () => {
     });
   });
 
+  describe("when one of the prior keys cannot be revoked", () => {
+    /** @scenario "A rotation that cannot kill every prior key mints nothing" */
+    it("still tries the rest, then fails without minting", async () => {
+      apiKeyRepo.findIngestKeysForProject.mockResolvedValue([
+        priorKey("ak_laptop"),
+        priorKey("ak_desktop"),
+        priorKey("ak_vm"),
+      ]);
+      apiKeys.revoke.mockImplementation(async ({ id }: { id: string }) => {
+        if (id === "ak_desktop") throw new Error("postgres is down");
+      });
+
+      await expect(service.ensureForProject(MINT_PARAMS)).rejects.toThrow(
+        /prior ingestion key/,
+      );
+
+      // Handing back a fresh token while a machine keeps writing with an old
+      // one is the outcome rotation exists to prevent. Every key still gets
+      // its attempt, so the retry has less left to do.
+      expect(apiKeys.revoke.mock.calls.map(([args]) => args.id)).toEqual([
+        "ak_laptop",
+        "ak_desktop",
+        "ak_vm",
+      ]);
+      expect(apiKeys.create).not.toHaveBeenCalled();
+    });
+  });
+
   describe("when no prior key exists", () => {
     it("mints without revoking anything", async () => {
       apiKeyRepo.findIngestKeysForProject.mockResolvedValue([]);

--- a/platform/app/ee/governance/services/ingestionKey.service.ts
+++ b/platform/app/ee/governance/services/ingestionKey.service.ts
@@ -5,11 +5,13 @@ import { createLogger } from "@langwatch/observability";
 import type { PrismaClient } from "~/generated/prisma/client";
 import { ApiKeyRepository } from "~/server/api-key/api-key.repository";
 import { ApiKeyService } from "~/server/api-key/api-key.service";
+import { ApiKeyAlreadyRevokedError } from "~/server/api-key/errors";
 import {
   type ApiKeyRevocationCause,
   isApiKeyRevocationCause,
 } from "~/server/api-key/revocation-cause";
 
+import { IngestionTemplateRepository } from "../repositories/ingestionTemplate.repository";
 import { PersonalWorkspaceService } from "./personalWorkspace.service";
 
 /** What every project-scoped mint needs to know. */
@@ -70,6 +72,23 @@ export class PersonalSourceTypeNotAllowedError extends Error {
   }
 }
 
+/**
+ * A rotation that could not kill every token it replaces, so it minted none.
+ *
+ * Rotation's whole promise is that no previous token survives it. Reporting
+ * success while one is still live would hand the caller a fresh key and a
+ * false statement about the old ones, so the mint is skipped and this is
+ * thrown instead. Retrying is safe: the keys already revoked stay revoked.
+ */
+export class IngestionKeyRotationIncompleteError extends Error {
+  constructor(public readonly survivingApiKeyIds: readonly string[]) {
+    super(
+      `Rotation left ${survivingApiKeyIds.length} prior ingestion key(s) live; no new key was minted.`,
+    );
+    this.name = "IngestionKeyRotationIncompleteError";
+  }
+}
+
 /** The plaintext token, returned exactly once, plus its identifiers. */
 export interface IssuedIngestionKey {
   token: string;
@@ -123,11 +142,13 @@ export class IngestionKeyService {
   private readonly apiKeys: ApiKeyService;
   private readonly apiKeyRepo: ApiKeyRepository;
   private readonly personalWorkspace: PersonalWorkspaceService;
+  private readonly templates: IngestionTemplateRepository;
 
   constructor(private readonly prisma: PrismaClient) {
     this.apiKeys = ApiKeyService.create(prisma);
     this.apiKeyRepo = ApiKeyRepository.create(prisma);
     this.personalWorkspace = new PersonalWorkspaceService(prisma);
+    this.templates = new IngestionTemplateRepository();
   }
 
   static create(prisma: PrismaClient): IngestionKeyService {
@@ -166,21 +187,40 @@ export class IngestionKeyService {
         key.ingestSourceType === sourceType &&
         (key.ingestionTemplateId ?? null) === ingestionTemplateId,
     );
+    const survivors: string[] = [];
     for (const key of prior) {
-      await this.apiKeys.revoke({
-        id: key.id,
-        callerUserId,
-        callerIsAdmin: true,
-        organizationId,
-        // The prior key is dead the moment its row is revoked, and its
-        // private role is named after that key id, so the mint below never
-        // waits for the name. Holding here for the role deletion to project
-        // only added a fold pickup cycle to a rotation that already waits
-        // for the new key's own writes: the CLI's first `langwatch claude`
-        // after a logout sat well over twenty seconds on this one request.
-        awaitProjection: false,
-        cause: "rotation",
-      });
+      try {
+        await this.apiKeys.revoke({
+          id: key.id,
+          callerUserId,
+          callerIsAdmin: true,
+          organizationId,
+          // The prior key is dead the moment its row is revoked, and its
+          // private role is named after that key id, so the mint below never
+          // waits for the name. Holding here for the role deletion to project
+          // only added a fold pickup cycle to a rotation that already waits
+          // for the new key's own writes: the CLI's first `langwatch claude`
+          // after a logout sat well over twenty seconds on this one request.
+          awaitProjection: false,
+          cause: "rotation",
+        });
+      } catch (error) {
+        // Someone else revoking it first is the outcome this loop wanted.
+        if (error instanceof ApiKeyAlreadyRevokedError) continue;
+        logger.warn(
+          { error, apiKeyId: key.id, projectId, sourceType },
+          "could not revoke a prior ingest key during rotation",
+        );
+        survivors.push(key.id);
+      }
+    }
+    // Every prior key gets its attempt before this throws, so a retry has
+    // less left to do. But a rotation that mints while one of them is still
+    // live is the thing rotation exists to prevent: the caller would be
+    // handed a fresh token and told the old ones are dead. Fail instead, and
+    // let the retry finish the job.
+    if (survivors.length > 0) {
+      throw new IngestionKeyRotationIncompleteError(survivors);
     }
 
     return await this.mint({
@@ -316,15 +356,20 @@ export class IngestionKeyService {
 
   /**
    * Add a key to the caller's personal project without touching the keys
-   * already there, for any source type the product knows.
+   * already there.
    *
-   * Same create-only shape as `issueForPersonalProject`, minus the
-   * wrapped-tool allowlist that bounds the CLI device mint. The callers are
-   * the ones whose source type comes from the product's own catalog rather
-   * than from a device: the /me Trace Ingest tile connecting a source, and
-   * the MCP mint tool. Connecting a source is not a decision about the
-   * machines already exporting, so it must not revoke their keys; the
-   * explicit rotate is `ensureForPersonalProject`.
+   * Same create-only shape as `issueForPersonalProject`, for the callers
+   * whose source type comes from the product's own catalog rather than from
+   * a device: the /me Trace Ingest tile connecting a source, and the MCP
+   * mint tool. Connecting a source is not a decision about the machines
+   * already exporting, so it must not revoke their keys; the explicit rotate
+   * is `ensureForPersonalProject`.
+   *
+   * The source type is still bounded, because the cap is per source type and
+   * an unbounded set of them is an unbounded set of keys. A tool the CLI
+   * wraps passes on its name; anything else passes by naming a published
+   * template, which is an admin-created row and is what decides the source
+   * type in the first place.
    */
   async createForPersonalProject({
     userId,
@@ -339,6 +384,15 @@ export class IngestionKeyService {
     ingestionTemplateId?: string | null;
     createdByDeviceLabel?: string | null;
   }): Promise<IssuedIngestionKey> {
+    if (
+      !(PERSONAL_INGEST_SOURCE_TYPES as readonly string[]).includes(sourceType)
+    ) {
+      await this.assertTemplateNamesSourceType({
+        organizationId,
+        ingestionTemplateId,
+        sourceType,
+      });
+    }
     const workspace = await this.personalWorkspace.findExisting({
       userId,
       organizationId,
@@ -368,6 +422,38 @@ export class IngestionKeyService {
     });
 
     return issued;
+  }
+
+  /**
+   * Hold a non-wrapped source type to a published template that names it.
+   *
+   * The template is an admin-created row, so the set of source types it can
+   * name is the set the product actually knows, and the per-source cap keeps
+   * meaning something. A caller inventing source types would otherwise get a
+   * fresh 32-key bucket for every string it made up.
+   *
+   * A platform template (`organizationId: null`) counts for every
+   * organization, which is what makes the shipped tiles installable.
+   */
+  private async assertTemplateNamesSourceType({
+    organizationId,
+    ingestionTemplateId,
+    sourceType,
+  }: {
+    organizationId: string;
+    ingestionTemplateId: string | null;
+    sourceType: string;
+  }): Promise<void> {
+    if (!ingestionTemplateId) {
+      throw new PersonalSourceTypeNotAllowedError(sourceType);
+    }
+    const template = await this.templates.findByIdForOrg(this.prisma, {
+      id: ingestionTemplateId,
+      organizationId,
+    });
+    if (template?.sourceType !== sourceType) {
+      throw new PersonalSourceTypeNotAllowedError(sourceType);
+    }
   }
 
   /**

--- a/platform/app/ee/governance/services/ingestionKey.service.ts
+++ b/platform/app/ee/governance/services/ingestionKey.service.ts
@@ -151,17 +151,24 @@ export class IngestionKeyService {
     ingestionTemplateId = null,
     createdByDeviceLabel = null,
   }: IngestionKeyMintParams): Promise<IssuedIngestionKey> {
-    // Hard-cut rotation: revoke any prior live ingest key for this
-    // (project, sourceType) so the previous token dies immediately and we
-    // never accumulate keys.
-    const prior = await this.apiKeyRepo.findIngestKey({
-      organizationId,
-      projectId,
-      sourceType,
-    });
-    if (prior) {
+    // Hard-cut rotation: revoke EVERY prior live ingest key for this
+    // (project, sourceType, template) so no previous token survives it.
+    // One key was enough while a project held one key per source; the
+    // create-only mints leave several, and a rotation that kills one of them
+    // hands the user a page saying rotated while two machines keep writing.
+    const prior = (
+      await this.apiKeyRepo.findIngestKeysForProject({
+        organizationId,
+        projectId,
+      })
+    ).filter(
+      (key) =>
+        key.ingestSourceType === sourceType &&
+        (key.ingestionTemplateId ?? null) === ingestionTemplateId,
+    );
+    for (const key of prior) {
       await this.apiKeys.revoke({
-        id: prior.id,
+        id: key.id,
         callerUserId,
         callerIsAdmin: true,
         organizationId,
@@ -298,6 +305,40 @@ export class IngestionKeyService {
     ) {
       throw new PersonalSourceTypeNotAllowedError(sourceType);
     }
+    return this.createForPersonalProject({
+      userId,
+      organizationId,
+      sourceType,
+      ingestionTemplateId,
+      createdByDeviceLabel,
+    });
+  }
+
+  /**
+   * Add a key to the caller's personal project without touching the keys
+   * already there, for any source type the product knows.
+   *
+   * Same create-only shape as `issueForPersonalProject`, minus the
+   * wrapped-tool allowlist that bounds the CLI device mint. The callers are
+   * the ones whose source type comes from the product's own catalog rather
+   * than from a device: the /me Trace Ingest tile connecting a source, and
+   * the MCP mint tool. Connecting a source is not a decision about the
+   * machines already exporting, so it must not revoke their keys; the
+   * explicit rotate is `ensureForPersonalProject`.
+   */
+  async createForPersonalProject({
+    userId,
+    organizationId,
+    sourceType,
+    ingestionTemplateId = null,
+    createdByDeviceLabel = null,
+  }: {
+    userId: string;
+    organizationId: string;
+    sourceType: string;
+    ingestionTemplateId?: string | null;
+    createdByDeviceLabel?: string | null;
+  }): Promise<IssuedIngestionKey> {
     const workspace = await this.personalWorkspace.findExisting({
       userId,
       organizationId,

--- a/platform/app/src/mcp/governance-tools.ts
+++ b/platform/app/src/mcp/governance-tools.ts
@@ -328,7 +328,7 @@ export function registerGovernanceMcpTools(
 
   server.tool(
     "governance_ingestion_keys_mint",
-    "Mint an ingestion key for the caller's personal project + source_type, returning the ik-lw-* token (shown ONCE). Adds a key: the keys other machines already export with are left alone. Requires OAuth-authenticated session + organization:view.",
+    "Mint an ingestion key for the caller's personal project + source_type, returning the ik-lw-* token (shown ONCE). Minting adds a key rather than replacing one, so the keys other machines already export with keep working; the only exception is the per-source cap, which retires the least recently used key once the workspace holds 32 of them. source_type must be a tool the LangWatch CLI wraps, or match a published ingestion template named by template_id. Requires OAuth-authenticated session + organization:view.",
     {
       source_type: z.string(),
       template_id: z.string().optional(),

--- a/platform/app/src/mcp/governance-tools.ts
+++ b/platform/app/src/mcp/governance-tools.ts
@@ -328,7 +328,7 @@ export function registerGovernanceMcpTools(
 
   server.tool(
     "governance_ingestion_keys_mint",
-    "Mint (rotating in place) an ingestion key for the caller's personal project + source_type, returning the ik-lw-* token (shown ONCE). Requires OAuth-authenticated session + organization:view.",
+    "Mint an ingestion key for the caller's personal project + source_type, returning the ik-lw-* token (shown ONCE). Adds a key: the keys other machines already export with are left alone. Requires OAuth-authenticated session + organization:view.",
     {
       source_type: z.string(),
       template_id: z.string().optional(),
@@ -337,7 +337,10 @@ export function registerGovernanceMcpTools(
       const r = await resolve();
       const denied = await requirePermission(r, "organization:view");
       if (denied) return text(denied);
-      const result = await ingestionKeyService.ensureForPersonalProject({
+      // Create-only: an agent asking for a key for the machine it runs on
+      // must not revoke the key every other machine under this login is
+      // exporting with. The explicit rotate lives on the /me tile.
+      const result = await ingestionKeyService.createForPersonalProject({
         userId: r.callerUserId!,
         organizationId: r.organizationId,
         sourceType: source_type,

--- a/platform/app/src/server/api-key/api-key.repository.ts
+++ b/platform/app/src/server/api-key/api-key.repository.ts
@@ -122,35 +122,6 @@ export class ApiKeyRepository {
   }
 
   /**
-   * Finds the live ingestion key for a (project, sourceType) pair: a non-revoked
-   * ApiKey carrying that ingestSourceType whose role binding is project-scoped to
-   * `projectId`. Used by the ingest-key service to rotate-in-place rather than
-   * accumulate keys.
-   */
-  async findIngestKey({
-    organizationId,
-    projectId,
-    sourceType,
-  }: {
-    organizationId: string;
-    projectId: string;
-    sourceType: string;
-  }): Promise<ApiKeyWithBindings | null> {
-    return this.prisma.apiKey.findFirst({
-      where: {
-        organizationId,
-        ingestSourceType: sourceType,
-        revokedAt: null,
-        roleBindings: {
-          some: { scopeType: RoleBindingScopeType.PROJECT, scopeId: projectId },
-        },
-      },
-      include: { roleBindings: true },
-      orderBy: { createdAt: "desc" },
-    });
-  }
-
-  /**
    * Lists every live ingestion key (`ingestSourceType IS NOT NULL`, not
    * revoked) whose role binding is project-scoped to `projectId`. Powers
    * the /me Trace Ingest installed-state lookup so a connected tile stays

--- a/sdks/typescript/src/cli/commands/__tests__/instrument.unit.test.ts
+++ b/sdks/typescript/src/cli/commands/__tests__/instrument.unit.test.ts
@@ -116,6 +116,26 @@ describe("instrumentCommand", () => {
     });
   });
 
+  describe("given a platform that refuses the device session", () => {
+    /** @scenario "A signed-out device is told its wiring was not confirmed" */
+    it("wires the cached key and says the machine is signed out", async () => {
+      asMock(telemetryRefreshMod.resolveIngestionCredential).mockResolvedValue({
+        ...personalCredential,
+        sessionExpired: true,
+      });
+
+      await instrumentCommand("claude", {});
+
+      // The wiring is worth writing: the cached key may still work. What is
+      // not acceptable is the success line alone, which reads as a confirmed
+      // setup on a machine that cannot confirm anything.
+      expect(installTelemetryWiring).toHaveBeenCalledTimes(1);
+      const err = writtenTo(stderrSpy);
+      expect(err).toContain("signed out");
+      expect(err).toContain("langwatch login --device");
+    });
+  });
+
   describe("given a tool with no ingestion path", () => {
     it("fails with the supported list", async () => {
       await expect(instrumentCommand("cursor", {})).rejects.toThrow(ExitError);

--- a/sdks/typescript/src/cli/commands/ingestion/__tests__/hook-heal.unit.test.ts
+++ b/sdks/typescript/src/cli/commands/ingestion/__tests__/hook-heal.unit.test.ts
@@ -37,6 +37,7 @@ const DECLINED = { status: "declined" } as const;
 const FAILED = { status: "failed" } as const;
 /** The platform said a person revoked the key on purpose. */
 const WITHHELD = { status: "withheld" } as const;
+const EXPIRED = { status: "expired" } as const;
 
 /** A collector that rejects the old bearer and accepts the fresh one. */
 const rotatedCollector: typeof fetch = ((
@@ -315,6 +316,23 @@ describe("the session context hook's self-heal", () => {
         fs.existsSync(path.join(hook.stateDir, "heal-claude_code.json")),
       ).toBe(true);
       expect(hook.stdout).toEqual([]);
+    });
+  });
+
+  describe("given a device the platform refuses to authenticate", () => {
+    /** @scenario "A signed-out device is told to sign in again" */
+    it("tells the user to sign the machine in again", async () => {
+      await hook.runHook({
+        env: OLD_KEY_ENV,
+        fetchImpl: rotatedCollector,
+        healRevokedKey: vi.fn().mockResolvedValue(EXPIRED),
+      });
+
+      expect(hook.stdout).toHaveLength(1);
+      const notice = JSON.parse(hook.stdout[0]!) as { systemMessage: string };
+      expect(notice.systemMessage).toContain("signed out");
+      expect(notice.systemMessage).toContain("langwatch login --device");
+      expect(hook.exits).toEqual([]);
     });
   });
 

--- a/sdks/typescript/src/cli/commands/ingestion/hook.ts
+++ b/sdks/typescript/src/cli/commands/ingestion/hook.ts
@@ -297,6 +297,12 @@ async function runHook({
       // repair is to say so.
       debug({ message: "ingest key was revoked by a person; not re-minted", env });
       if (agent === "claude_code") notifyClaude(REVOKED_NOTICE);
+    } else if (outcome.status === "expired") {
+      // The platform refused the device's session, so nothing here can mint.
+      // Without this line the session ends with telemetry silently going
+      // nowhere and no sign of why.
+      debug({ message: "device session is signed out; not re-minted", env });
+      if (agent === "claude_code") notifyClaude(SIGNED_OUT_NOTICE);
     }
   }
 
@@ -319,6 +325,10 @@ const HEAL_NOTICE =
 /** What the user reads when the key was revoked on purpose and stays dead. */
 const REVOKED_NOTICE =
   "LangWatch: the ingest key this machine exports with was revoked and was not replaced. Run `langwatch instrument claude` to set this machine up again.";
+
+/** What the user reads when the device is signed out of LangWatch. */
+const SIGNED_OUT_NOTICE =
+  "LangWatch: this machine is signed out, so its ingest key could not be checked or replaced and telemetry is not being recorded. Run `langwatch login --device` and then `langwatch instrument claude`.";
 
 /** How long one heal attempt stands before the hook tries again. */
 const HEAL_THROTTLE_MS = 10 * 60 * 1000;

--- a/sdks/typescript/src/cli/commands/instrument.ts
+++ b/sdks/typescript/src/cli/commands/instrument.ts
@@ -151,15 +151,6 @@ export async function instrumentCommand(
 		token: credential.token,
 	});
 
-	// The wiring landed, but nothing confirmed the key in it: this device is
-	// signed out, so the key could not be checked and could not be replaced.
-	// Reporting only the success line would tell the user telemetry is
-	// flowing when the key may have been revoked weeks ago.
-	if (credential.sessionExpired) {
-		process.stderr.write(
-			`${lwTag()} this device is signed out, so \`${tool}\` was wired with the ingest key it already had. If telemetry stops arriving, run \`langwatch login --device\` and then \`langwatch instrument ${tool}\` again.\n`,
-		);
-	}
 	for (const warning of result.warnings) {
 		process.stderr.write(`${lwTag()} ${warning}\n`);
 	}
@@ -177,6 +168,16 @@ export async function instrumentCommand(
 	}
 	for (const label of result.labels) {
 		process.stdout.write(`${lwTag()} wrote telemetry wiring to ${label}.\n`);
+	}
+	// The wiring landed, but nothing confirmed the key in it: this device is
+	// signed out, so the key could not be checked and could not be replaced.
+	// Said after the wiring is known to have been written, and before the
+	// success line, so it qualifies a setup that happened rather than one
+	// that may have failed for another reason entirely.
+	if (credential.sessionExpired) {
+		process.stderr.write(
+			`${lwTag()} this device is signed out, so \`${tool}\` was wired with the ingest key it already had. If telemetry stops arriving, run \`langwatch login --device\` and then \`langwatch instrument ${tool}\` again.\n`,
+		);
 	}
 	const destination =
 		credential.scope === "project"

--- a/sdks/typescript/src/cli/commands/instrument.ts
+++ b/sdks/typescript/src/cli/commands/instrument.ts
@@ -151,6 +151,15 @@ export async function instrumentCommand(
 		token: credential.token,
 	});
 
+	// The wiring landed, but nothing confirmed the key in it: this device is
+	// signed out, so the key could not be checked and could not be replaced.
+	// Reporting only the success line would tell the user telemetry is
+	// flowing when the key may have been revoked weeks ago.
+	if (credential.sessionExpired) {
+		process.stderr.write(
+			`${lwTag()} this device is signed out, so \`${tool}\` was wired with the ingest key it already had. If telemetry stops arriving, run \`langwatch login --device\` and then \`langwatch instrument ${tool}\` again.\n`,
+		);
+	}
 	for (const warning of result.warnings) {
 		process.stderr.write(`${lwTag()} ${warning}\n`);
 	}

--- a/sdks/typescript/src/cli/utils/governance/__tests__/ingest-key-heal.unit.test.ts
+++ b/sdks/typescript/src/cli/utils/governance/__tests__/ingest-key-heal.unit.test.ts
@@ -6,6 +6,7 @@
  */
 import { describe, expect, it, vi } from "vitest";
 
+import { GovernanceCliError } from "../cli-api";
 import type { GovernanceConfig } from "../config";
 import { type HealDeps, healRevokedIngestKey } from "../ingest-key-heal";
 
@@ -181,6 +182,30 @@ describe("healRevokedIngestKey", () => {
       // Minting here would replace a key a person may have revoked on
       // purpose, decided on a platform answer that never arrived.
       expect(healed).toEqual({ status: "failed" });
+      expect(d.resolveLiveIngestionKey).not.toHaveBeenCalled();
+      expect(d.saveConfig).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("given a platform that refuses the device's session", () => {
+    /** @scenario "A signed-out device is told to sign in again" */
+    it("reports the session rather than a failure, so the hook can name the repair", async () => {
+      const d = deps({
+        describeIngestionKey: vi
+          .fn()
+          .mockRejectedValue(new GovernanceCliError(401, "unauthorized", "signed out")),
+      });
+
+      const healed = await healRevokedIngestKey({
+        agent: "claude_code",
+        rejectedToken: CACHED,
+        deps: d,
+      });
+
+      // The mint after the status call would be refused the same way, so
+      // there is nothing to try; only a person signing the machine in again
+      // repairs this.
+      expect(healed).toEqual({ status: "expired" });
       expect(d.resolveLiveIngestionKey).not.toHaveBeenCalled();
       expect(d.saveConfig).not.toHaveBeenCalled();
     });

--- a/sdks/typescript/src/cli/utils/governance/__tests__/resolve-ingestion-credential.unit.test.ts
+++ b/sdks/typescript/src/cli/utils/governance/__tests__/resolve-ingestion-credential.unit.test.ts
@@ -82,6 +82,53 @@ describe("resolveLiveIngestionKey", () => {
 			expect(cliApi.mintIngestionKey).not.toHaveBeenCalled();
 		});
 	});
+
+	describe("when the platform refuses the device session", () => {
+		/** @scenario "A signed-out device is told its wiring was not confirmed" */
+		it("still reuses the cached key, and marks the resolution as unconfirmed", async () => {
+			const cfg = baseCfg({
+				default_personal_ingest_keys: {
+					claude_code: { secret: "ik-lw-cachedlookupid_secret" },
+				},
+			});
+			vi.mocked(cliApi.listIngestionKeys).mockRejectedValue(
+				new cliApi.GovernanceCliError(401, "unauthorized", "signed out"),
+			);
+
+			const resolved = await resolveLiveIngestionKey({
+				cfg,
+				sourceType: "claude_code",
+			});
+
+			// A mint would be refused the same way, so the cached key is all
+			// this device has. Marking it is what lets the caller say the
+			// setup was never confirmed instead of reporting success.
+			expect(resolved.token).toBe("ik-lw-cachedlookupid_secret");
+			expect(resolved.minted).toBe(false);
+			expect(resolved.sessionExpired).toBe(true);
+			expect(cliApi.mintIngestionKey).not.toHaveBeenCalled();
+		});
+
+		it("leaves an ordinary network failure unmarked", async () => {
+			const cfg = baseCfg({
+				default_personal_ingest_keys: {
+					claude_code: { secret: "ik-lw-cachedlookupid_secret" },
+				},
+			});
+			vi.mocked(cliApi.listIngestionKeys).mockRejectedValue(
+				new Error("fetch failed"),
+			);
+
+			const resolved = await resolveLiveIngestionKey({
+				cfg,
+				sourceType: "claude_code",
+			});
+
+			// An offline laptop has always kept exporting with its key, and
+			// nothing about that run is worth a warning.
+			expect(resolved.sessionExpired).toBeUndefined();
+		});
+	});
 });
 
 describe("resolveIngestionCredential", () => {

--- a/sdks/typescript/src/cli/utils/governance/cli-api.ts
+++ b/sdks/typescript/src/cli/utils/governance/cli-api.ts
@@ -109,6 +109,20 @@ export class GovernanceCliError extends Error {
 }
 
 /**
+ * Whether a governance call failed because this device's session is dead.
+ *
+ * `requestREST` refreshes a spent access token and retries on its own, so a
+ * 401 that reaches a caller is a refresh the server itself rejected: the
+ * device is signed out and every governance call it makes will fail the same
+ * way until someone runs `langwatch login --device` on it again. That is a
+ * different repair from an unreachable platform, and the paths that fall back
+ * to a cached ingest key have to tell the two apart.
+ */
+export function isExpiredSession(error: unknown): boolean {
+  return error instanceof GovernanceCliError && error.status === 401;
+}
+
+/**
  * The ADR-045 error path for a non-2xx governance response. Before throwing the
  * CLI's own {@link GovernanceCliError}, hand the parsed body to
  * `throwIfHandledError`: when the platform NAMED the failure (a domain-error

--- a/sdks/typescript/src/cli/utils/governance/ingest-key-heal.ts
+++ b/sdks/typescript/src/cli/utils/governance/ingest-key-heal.ts
@@ -14,7 +14,11 @@
  * session broke, so every failure is a null and a debug line.
  */
 import { installTelemetryWiring } from "./instrument-wiring";
-import { describeIngestionKey, extractLookupIdFromToken } from "./cli-api";
+import {
+  describeIngestionKey,
+  extractLookupIdFromToken,
+  isExpiredSession,
+} from "./cli-api";
 import {
   type GovernanceConfig,
   isLoggedIn,
@@ -39,17 +43,27 @@ export interface HealedTarget {
  * the platform. A `failed` heal may already have spent a mint, so it is the
  * one that must not be retried in a loop. A `withheld` heal found that a
  * person revoked the key on purpose: the device must not replace it, and the
- * person must be told to set the device up again. Throttling a decline would
- * spend a repair window on a rejection that never cost anything, and delay
- * the real repair.
+ * person must be told to set the device up again. An `expired` heal found
+ * that the device itself is signed out, which no mint can repair either.
+ * Throttling a decline would spend a repair window on a rejection that never
+ * cost anything, and delay the real repair.
  */
 export type HealOutcome =
   | { status: "declined" }
   | { status: "failed" }
   | { status: "withheld" }
+  | { status: "expired" }
   | { status: "healed"; target: HealedTarget };
 
 const DECLINED: HealOutcome = { status: "declined" };
+
+/**
+ * Stands in for a key status the platform never gave, because it refused the
+ * device's session instead of answering. Distinct from the `null` any other
+ * describe failure produces, so the heal can end on the repair the person can
+ * actually make rather than on a silent failure.
+ */
+const EXPIRED_SESSION = Symbol("expired-session");
 
 /** The seams the healer composes, injectable so a test needs no real config. */
 export interface HealDeps {
@@ -161,6 +175,11 @@ export async function healRevokedIngestKey({
  * one revocation the device must not mint past is a person's, so a status
  * call that times out or errors ends the heal rather than falling through to
  * the mint; the next session asks again once the window is up.
+ *
+ * A platform that refused the session is the same wall for a different
+ * reason: the mint after this check would be refused too, so the heal ends
+ * on `expired`, which is the one outcome that names a repair the person can
+ * make.
  */
 async function revocationBlocksHeal({
   cfg,
@@ -176,8 +195,11 @@ async function revocationBlocksHeal({
 
   const described = await deps
     .describeIngestionKey(cfg, lookupId, { timeoutMs: DESCRIBE_TIMEOUT_MS })
-    .catch(() => null);
+    .catch((error: unknown) =>
+      isExpiredSession(error) ? EXPIRED_SESSION : null,
+    );
   if (!described) return { status: "failed" };
+  if (described === EXPIRED_SESSION) return { status: "expired" };
   if (
     described.status === "revoked" &&
     !PLATFORM_REVOCATION_CAUSES.has(described.revocationCause)

--- a/sdks/typescript/src/cli/utils/governance/telemetry-refresh.ts
+++ b/sdks/typescript/src/cli/utils/governance/telemetry-refresh.ts
@@ -70,6 +70,7 @@ import {
 } from "./session-context-hooks";
 import {
 	extractLookupIdFromToken,
+	isExpiredSession,
 	listIngestionKeys,
 	mintIngestionKey,
 } from "./cli-api";
@@ -130,6 +131,17 @@ export interface IngestionKeyResolution {
 	endpoint: string;
 	/** True when a fresh key was minted (vs a cached one reused). */
 	minted: boolean;
+	/**
+	 * True when the platform rejected this device's session, so the cached
+	 * key was reused without anything confirming it is still live.
+	 *
+	 * A device that cannot authenticate can neither check its key nor mint a
+	 * replacement, and the key it holds may have been revoked weeks ago. The
+	 * resolution still carries that key, because wiring the tool with a key
+	 * that may work beats wiring it with nothing, but the caller must say so
+	 * instead of reporting a working setup.
+	 */
+	sessionExpired?: boolean;
 }
 
 /**
@@ -190,6 +202,7 @@ export async function resolveLiveIngestionKey({
 			};
 		}
 		let cacheIsLive = true; // assume live; falsified when server confirms otherwise
+		let sessionExpired = false;
 		try {
 			const liveKeys = await listIngestionKeys(cfg);
 			// Server resolved - verify the cached lookupId is still present
@@ -201,12 +214,17 @@ export async function resolveLiveIngestionKey({
 				// Key was revoked or rotated on the platform - treat as no cache.
 				cacheIsLive = false;
 			}
-		} catch {
+		} catch (error) {
 			// Network error / older server without the endpoint: reuse cache
-			// as-is (offline-first fallback - hard-cut rotation is a
-			// re-mint-kills-old invariant, so a genuinely revoked key will
-			// self-correct next time the device is online) - unless the
-			// caller disabled that fallback.
+			// as-is (offline-first fallback - a device that is merely offline
+			// keeps exporting with the key it has) - unless the caller
+			// disabled that fallback.
+			//
+			// A session the platform rejected is not that case. Nothing about
+			// the cached key was confirmed and nothing can replace it, so the
+			// fallback still hands the key back but marks the resolution: the
+			// key may have been dead for weeks and only the caller can say so.
+			sessionExpired = isExpiredSession(error);
 			cacheIsLive = allowOfflineFallback;
 		}
 		if (cacheIsLive) {
@@ -215,6 +233,7 @@ export async function resolveLiveIngestionKey({
 				prefix: cached.prefix,
 				endpoint: otlpEndpointFor(cfg.control_plane_url),
 				minted: false,
+				...(sessionExpired ? { sessionExpired: true } : {}),
 			};
 		}
 	}

--- a/specs/ai-gateway/governance/ingest-api-key-lifecycle.feature
+++ b/specs/ai-gateway/governance/ingest-api-key-lifecycle.feature
@@ -150,6 +150,39 @@ Feature: AI Gateway Governance — Ingest API Key Lifecycle
     When a device mints a personal key for "codex"
     Then no "claude_code" key is revoked
 
+  # The CLI is not the only door to a personal key. Connecting a source from
+  # the /me tile, and the MCP mint an agent calls, reach the same workspace,
+  # and both used to rotate in place: one click, or one agent, revoked the key
+  # every machine under that login was exporting with. Connecting a source is
+  # not a decision about those machines, so it adds a key like the CLI does.
+  # The tile's explicit rotate is still the verb that kills them.
+
+  @integration @ingest-api-key @issue @personal @create-only
+  Scenario: Connecting a source from the personal tile keeps the devices' keys
+    Given jane's laptop already minted a personal ingestion key for "claude_code"
+    When she connects "claude_code" from her personal ingest tile
+    Then both tokens authorize trace writes into her personal workspace
+    And neither key is revoked by the other
+
+  @integration @ingest-api-key @issue @personal @create-only
+  Scenario: An agent minting through MCP keeps the devices' keys
+    Given jane's laptop already minted a personal ingestion key for "claude_code"
+    When an agent mints a personal key for "claude_code" through the MCP tool
+    Then both tokens authorize trace writes into her personal workspace
+    And neither key is revoked by the other
+
+  # Rotation revoked one prior key, which was every key a project could have
+  # while the mint rotated. With several machines holding their own, a rotate
+  # that stops at the first leaves the rest writing under a page that says the
+  # key was rotated.
+
+  @integration @ingest-api-key @rotate @personal
+  Scenario: An explicit rotation from the personal tile revokes every prior key
+    Given jane's personal workspace holds several live "claude_code" keys
+    When she rotates "claude_code" from her personal ingest tile
+    Then the rotated key is the only live one
+    And none of the previous tokens authorize trace writes
+
   # The cap is per source type, so the set of source types must be finite or
   # a device session holds the cap again under every value it invents. The
   # personal mint accepts the tools the CLI wraps and nothing else.

--- a/specs/ai-gateway/governance/ingest-api-key-lifecycle.feature
+++ b/specs/ai-gateway/governance/ingest-api-key-lifecycle.feature
@@ -176,6 +176,13 @@ Feature: AI Gateway Governance — Ingest API Key Lifecycle
   # that stops at the first leaves the rest writing under a page that says the
   # key was rotated.
 
+  @unit @ingest-api-key @rotate
+  Scenario: A rotation that cannot kill every prior key mints nothing
+    Given a rotation over several live keys
+    When one of them cannot be revoked
+    Then every other prior key is still attempted
+    And no new key is minted
+
   @integration @ingest-api-key @rotate @personal
   Scenario: An explicit rotation from the personal tile revokes every prior key
     Given jane's personal workspace holds several live "claude_code" keys
@@ -186,6 +193,13 @@ Feature: AI Gateway Governance — Ingest API Key Lifecycle
   # The cap is per source type, so the set of source types must be finite or
   # a device session holds the cap again under every value it invents. The
   # personal mint accepts the tools the CLI wraps and nothing else.
+
+  @unit @ingest-api-key @issue @personal @create-only
+  Scenario: A source type outside the wrapped tools needs its template
+    Given a personal mint from the tile or the MCP tool
+    When it names a source type no wrapped tool stamps
+    Then it mints only if a published template names that source type
+    And no key is created for a source type nothing names
 
   @integration @ingest-api-key @issue @personal @create-only
   Scenario: A personal key is minted only for a tool the CLI wraps

--- a/specs/ai-governance/cli-wrappers/cli-mints-ingest-key.feature
+++ b/specs/ai-governance/cli-wrappers/cli-mints-ingest-key.feature
@@ -44,6 +44,19 @@ Feature: CLI Wrappers — `langwatch <tool>` mints and uses an ingestion key (Pa
     Then the wrapper reuses the cached `ik-lw-` token
     And it does NOT mint a new key
 
+  # A device that cannot reach the platform keeps exporting with the key it
+  # has, which is what an offline laptop needs. A device the platform refuses
+  # to authenticate looks the same from here and is not the same thing: its
+  # key may have been revoked weeks ago, and no mint can replace it while the
+  # session is dead. The key is still used, and the run says so.
+
+  @unit @cli-wrappers @ingest-key @reuse
+  Scenario: A signed-out device is told its wiring was not confirmed
+    Given a cached ingestion key and a platform that refuses the device session
+    When the user runs `langwatch instrument claude`
+    Then the tool is wired with the cached key
+    And the run says the machine is signed out and names how to sign it in
+
   @bdd @cli-wrappers @ingest-key @per-tool
   Scenario Outline: Each tool gets an ingest key for its own sourceType
     When the user runs `langwatch <tool>` in ingestion mode

--- a/specs/ai-governance/cli-wrappers/session-context-hook.feature
+++ b/specs/ai-governance/cli-wrappers/session-context-hook.feature
@@ -424,6 +424,18 @@ Rule: A revoked ingest key heals itself
     When the hook runs
     Then a new key is minted
 
+  # A device whose own session the platform refuses can neither check its key
+  # nor mint a replacement. Saying nothing leaves the session exporting into
+  # a 401 with no sign of why, so the one repair a person can make is named.
+
+  @unit
+  Scenario: A signed-out device is told to sign in again
+    Given a signed-in CLI whose cached personal key the collector answers 401 to
+    And a platform that refuses the device's session
+    When the hook runs
+    Then no new key is minted
+    And the user is told to sign this machine in again
+
   @unit
   Scenario: A withheld heal spends the throttle
     Given a hook that was told a person revoked its key minutes ago


### PR DESCRIPTION
Follow-up to #7859, from verifying instrumentation end to end across a laptop, a remote box and a snapshot fork.

#7859 made the CLI's personal ingest-key mint create-only, so one machine's setup stops killing another's telemetry. Three other paths still behaved as if a workspace held one key per source, and a machine whose LangWatch session had expired had no way to find out.

## What was wrong

**The MCP mint tool and the /me tile's connect action rotated in place.** Both called `ensureForPersonalProject`, so one agent calling `governance_ingestion_keys_mint`, or one click on a tile for a source already connected, revoked the key every machine under that login was exporting with. That is the exact failure #7859 set out to end, reached through a different door. Both create a key now. `rotate` on the tile still revokes, because that is what the user asked for.

**Rotation revoked one prior key.** That was every key a project could have while the mint rotated. Now that several machines hold their own, a rotate that stopped at the first left the rest writing under a page that said the key was rotated. It revokes every live key for the (project, source type, template) now.

**A signed-out device reported a working setup.** `resolveLiveIngestionKey` treated a rejected session exactly like an unreachable platform: reuse the cached key and say nothing. Offline is the case that behavior exists for, and a device that is merely offline should keep exporting. A device the platform refuses is different, because its key cannot be checked and cannot be replaced, and may have been dead for weeks. The resolution now carries that, and `langwatch instrument <tool>` says the machine is signed out and names the two commands that fix it.

**The hook's self-heal went silent on the same refusal.** `describeIngestionKey` throws a 401, the healer mapped it to `failed`, and `failed` prints nothing while holding the 10 minute window. A session ended with telemetry going nowhere and no sign of why. There is an `expired` outcome now, and Claude Code shows a notice pointing at `langwatch login --device`.

## How it was found

Running a `--model sonnet` session on each machine and reading the events back. A boxd VM had been exporting into a 401 since its key was revoked by the pre-#7859 rotation: `{"status":"revoked","revocation_cause":null}` from the describe endpoint, and `langwatch instrument claude` had rewritten that dead key into `settings.json` while reporting success. Its snapshot fork inherited all of it.

## Tests

- `ingestionKey.personalCreateOnly.integration.test.ts`: the tile's connect and the MCP tool each add a key with the devices' keys still live; the tile's rotate leaves exactly one.
- `ingestionKey.rotation.unit.test.ts`: rotation revokes all three prior keys and leaves another tool's alone.
- `ingest-key-heal`, `hook-heal`, `instrument` and `resolve-ingestion-credential` unit tests cover the expired-session path, including that an ordinary network failure stays unmarked.
- Specs updated in `ingest-api-key-lifecycle.feature`, `session-context-hook.feature` and `cli-mints-ingest-key.feature`; all three report all bound.

`pnpm typecheck:all`, the SDK unit suite (3825 tests) and the touched platform suites are green.

https://claude.ai/code/session_011aDTBqQqwrZrTVSzapDawv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Personal ingestion-key installs and MCP minting now preserve keys used on other machines.
  * Explicit rotation replaces all previous matching keys with a single active key.
  * CLI instrumentation and hook healing report signed-out sessions and provide re-login guidance.
  * Ingestion keys for supported source types require a published template.

* **Documentation**
  * Added scenarios covering key creation, rotation, cached-key reuse, and signed-out device behavior.

* **Tests**
  * Expanded coverage for multi-device preservation, rotation, template validation, and expired sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->