### PR TITLE
fix(evaluators): send the Azure deployment where langevals reads it

### DIFF
--- a/platform/app/src/server/api/routers/modelProviders.utils.ts
+++ b/platform/app/src/server/api/routers/modelProviders.utils.ts
@@ -252,7 +252,10 @@ export const prepareEnvKeys = (modelProvider: MaybeStoredModelProvider) => {
     return {};
   }
 
-  // TODO: add AZURE_DEPLOYMENT_NAME and AZURE_EMBEDDINGS_DEPLOYMENT_NAME for deployment name mapping
+  // AZURE_DEPLOYMENT_NAME / AZURE_EMBEDDINGS_DEPLOYMENT_NAME are not emitted
+  // here: the deployment is a per-model mapping and this function only sees
+  // the provider. `setupModelEnv` derives them from the resolved litellm
+  // params, where the model is known.
 
   return Object.fromEntries(
     Object.keys(getSchemaShape(providerDefinition.keysSchema))

--- a/platform/app/src/server/app-layer/evaluations/__tests__/evaluation-execution.factories.unit.test.ts
+++ b/platform/app/src/server/app-layer/evaluations/__tests__/evaluation-execution.factories.unit.test.ts
@@ -59,9 +59,11 @@ function buildProvider(
  * skipped-evaluation details both build on. Resolving instead of throwing
  * yields a bare object, so the caller's `code` assertion fails on it too.
  */
-async function refusalFrom(
-  promise: Promise<unknown>,
-): Promise<EvaluatorConfigError> {
+async function refusalFrom({
+  promise,
+}: {
+  promise: Promise<unknown>;
+}): Promise<EvaluatorConfigError> {
   return (await promise.then(
     () => ({}),
     (reason: unknown) => reason,
@@ -302,9 +304,9 @@ describe("setupModelEnv", () => {
         azureOnlyProject();
         vi.mocked(getResolvedDefaultForFeature).mockResolvedValueOnce(null);
 
-        const error = await refusalFrom(
-          setupModelEnv("openai/text-embedding-ada-002", true, "proj-1"),
-        );
+        const error = await refusalFrom({
+          promise: setupModelEnv("openai/text-embedding-ada-002", true, "proj-1"),
+        });
 
         expect(error.code).toBe("evaluator_config_error");
         // The message is what the customer reads: a refused evaluation
@@ -321,9 +323,9 @@ describe("setupModelEnv", () => {
           scope: "project" as never,
         });
 
-        const error = await refusalFrom(
-          setupModelEnv("openai/text-embedding-ada-002", true, "proj-1"),
-        );
+        const error = await refusalFrom({
+          promise: setupModelEnv("openai/text-embedding-ada-002", true, "proj-1"),
+        });
 
         expect(error.code).toBe("evaluator_config_error");
         expect(error.message).toContain('"openai/text-embedding-ada-002"');
@@ -335,9 +337,9 @@ describe("setupModelEnv", () => {
       it("refuses the judge model rather than swapping it", async () => {
         azureOnlyProject();
 
-        const error = await refusalFrom(
-          setupModelEnv("openai/gpt-4o", false, "proj-1"),
-        );
+        const error = await refusalFrom({
+          promise: setupModelEnv("openai/gpt-4o", false, "proj-1"),
+        });
 
         expect(error.code).toBe("evaluator_config_error");
         expect(getResolvedDefaultForFeature).not.toHaveBeenCalled();

--- a/platform/app/src/server/app-layer/evaluations/__tests__/evaluation-execution.factories.unit.test.ts
+++ b/platform/app/src/server/app-layer/evaluations/__tests__/evaluation-execution.factories.unit.test.ts
@@ -305,7 +305,11 @@ describe("setupModelEnv", () => {
         vi.mocked(getResolvedDefaultForFeature).mockResolvedValueOnce(null);
 
         const error = await refusalFrom({
-          promise: setupModelEnv("openai/text-embedding-ada-002", true, "proj-1"),
+          promise: setupModelEnv(
+            "openai/text-embedding-ada-002",
+            true,
+            "proj-1",
+          ),
         });
 
         expect(error.code).toBe("evaluator_config_error");
@@ -324,7 +328,11 @@ describe("setupModelEnv", () => {
         });
 
         const error = await refusalFrom({
-          promise: setupModelEnv("openai/text-embedding-ada-002", true, "proj-1"),
+          promise: setupModelEnv(
+            "openai/text-embedding-ada-002",
+            true,
+            "proj-1",
+          ),
         });
 
         expect(error.code).toBe("evaluator_config_error");

--- a/platform/app/src/server/app-layer/evaluations/__tests__/evaluation-execution.factories.unit.test.ts
+++ b/platform/app/src/server/app-layer/evaluations/__tests__/evaluation-execution.factories.unit.test.ts
@@ -7,7 +7,7 @@
  * test validation logic in isolation without DB or external calls.
  */
 
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { MaybeStoredModelProvider } from "~/server/modelProviders/registry";
 
 vi.mock("~/server/api/routers/modelProviders.utils", () => ({
@@ -22,7 +22,15 @@ vi.mock("~/server/modelProviders/resolveMaxTokensCeiling", () => ({
   resolveMaxTokensCeiling: vi.fn().mockReturnValue(null),
 }));
 
-import { getProjectModelProviders } from "~/server/api/routers/modelProviders.utils";
+vi.mock("~/server/modelProviders/modelDefaults.read", () => ({
+  getResolvedDefaultForFeature: vi.fn().mockResolvedValue(null),
+}));
+
+import {
+  getProjectModelProviders,
+  prepareLitellmParams,
+} from "~/server/api/routers/modelProviders.utils";
+import { getResolvedDefaultForFeature } from "~/server/modelProviders/modelDefaults.read";
 import { EvaluatorConfigError } from "../errors";
 import { setupModelEnv } from "../evaluation-execution.factories";
 
@@ -44,6 +52,13 @@ function buildProvider(
 }
 
 describe("setupModelEnv", () => {
+  // A queued one-shot the test under it never consumes would otherwise be
+  // waiting for the next test that does.
+  beforeEach(() => {
+    vi.mocked(getResolvedDefaultForFeature).mockReset();
+    vi.mocked(getResolvedDefaultForFeature).mockResolvedValue(null);
+  });
+
   describe("when model is in the registry list", () => {
     it("resolves without error", async () => {
       vi.mocked(getProjectModelProviders).mockResolvedValue({
@@ -137,6 +152,138 @@ describe("setupModelEnv", () => {
       await expect(
         setupModelEnv("gemini/gemini-2.5-pro", false, "proj-1"),
       ).rejects.toThrow("Provider gemini is not enabled");
+    });
+  });
+
+  describe("when the provider maps the model to an Azure deployment", () => {
+    function azureProject() {
+      vi.mocked(getProjectModelProviders).mockResolvedValue({
+        azure: buildProvider({
+          provider: "azure",
+          models: ["gpt-4o"],
+          embeddingsModels: ["text-embedding-ada-002"],
+          deploymentMapping: { "gpt-4o": "prod-judge" },
+        }),
+      });
+    }
+
+    /** @scenario "A judge on an Azure deployment named something other than the model reaches that deployment" */
+    it("sends the deployment under the name langevals reads", async () => {
+      azureProject();
+      vi.mocked(prepareLitellmParams).mockResolvedValueOnce({
+        model: "azure/gpt-4o",
+        api_key: "test-key",
+        deployment: "prod-judge",
+      });
+
+      const env = await setupModelEnv("azure/gpt-4o", false, "proj-1");
+
+      expect(env.AZURE_DEPLOYMENT_NAME).toBe("prod-judge");
+    });
+
+    /** @scenario "The deployment name is never sent as a call argument" */
+    it("does not send the deployment as a call argument", async () => {
+      azureProject();
+      vi.mocked(prepareLitellmParams).mockResolvedValueOnce({
+        model: "azure/gpt-4o",
+        api_key: "test-key",
+        deployment: "prod-judge",
+      });
+
+      const env = await setupModelEnv("azure/gpt-4o", false, "proj-1");
+
+      expect(env).not.toHaveProperty("X_LITELLM_deployment");
+    });
+
+    it("names the embeddings deployment separately from the judge one", async () => {
+      azureProject();
+      vi.mocked(prepareLitellmParams).mockResolvedValueOnce({
+        model: "azure/text-embedding-ada-002",
+        api_key: "test-key",
+        deployment: "prod-embeddings",
+      });
+
+      const env = await setupModelEnv(
+        "azure/text-embedding-ada-002",
+        true,
+        "proj-1",
+      );
+
+      expect(env.AZURE_EMBEDDINGS_DEPLOYMENT_NAME).toBe("prod-embeddings");
+      expect(env).not.toHaveProperty("X_LITELLM_EMBEDDINGS_deployment");
+    });
+
+    it("leaves a provider with no deployment mapping untouched", async () => {
+      vi.mocked(getProjectModelProviders).mockResolvedValue({
+        gemini: buildProvider(),
+      });
+
+      const env = await setupModelEnv("gemini/gemini-2.5-pro", false, "proj-1");
+
+      expect(env).not.toHaveProperty("AZURE_DEPLOYMENT_NAME");
+    });
+  });
+
+  describe("when the evaluator's embeddings model names a provider the project does not have", () => {
+    function azureOnlyProject() {
+      vi.mocked(getProjectModelProviders).mockResolvedValue({
+        azure: buildProvider({
+          provider: "azure",
+          models: ["gpt-4o"],
+          embeddingsModels: ["text-embedding-ada-002"],
+        }),
+      });
+    }
+
+    /** @scenario "An evaluator embeds with the provider the project actually configured" */
+    it("embeds with the model the project resolves to", async () => {
+      azureOnlyProject();
+      vi.mocked(getResolvedDefaultForFeature).mockResolvedValueOnce({
+        model: "azure/text-embedding-ada-002",
+        source: "project" as never,
+        scope: "project" as never,
+      });
+
+      const env = await setupModelEnv(
+        "openai/text-embedding-ada-002",
+        true,
+        "proj-1",
+      );
+
+      expect(env.X_LITELLM_EMBEDDINGS_model).toBeDefined();
+    });
+
+    /** @scenario "A judge model is never swapped for the project's default" */
+    it("refuses a judge model rather than swapping it", async () => {
+      azureOnlyProject();
+
+      await expect(
+        setupModelEnv("openai/gpt-4o", false, "proj-1"),
+      ).rejects.toThrow("Provider openai is not configured");
+      expect(getResolvedDefaultForFeature).not.toHaveBeenCalled();
+    });
+
+    /** @scenario "With nothing to fall back to, the refusal names the embeddings setting" */
+    it("names the embeddings model when there is nothing to fall back to", async () => {
+      azureOnlyProject();
+      vi.mocked(getResolvedDefaultForFeature).mockResolvedValueOnce(null);
+
+      await expect(
+        setupModelEnv("openai/text-embedding-ada-002", true, "proj-1"),
+      ).rejects.toThrow(/embeddings model .* "openai\/text-embedding-ada-002"/);
+    });
+
+    it("does not fall back to a default whose own provider is missing", async () => {
+      azureOnlyProject();
+      vi.mocked(getResolvedDefaultForFeature).mockResolvedValueOnce({
+        model: "cohere/embed-v4",
+        source: "project" as never,
+        scope: "project" as never,
+      });
+
+      await expect(
+        setupModelEnv("openai/text-embedding-ada-002", true, "proj-1"),
+      ).rejects.toThrow(/"openai\/text-embedding-ada-002"/);
     });
   });
 });

--- a/platform/app/src/server/app-layer/evaluations/__tests__/evaluation-execution.factories.unit.test.ts
+++ b/platform/app/src/server/app-layer/evaluations/__tests__/evaluation-execution.factories.unit.test.ts
@@ -57,6 +57,9 @@ describe("setupModelEnv", () => {
   beforeEach(() => {
     vi.mocked(getResolvedDefaultForFeature).mockReset();
     vi.mocked(getResolvedDefaultForFeature).mockResolvedValue(null);
+    // Which model the env was built for is read off this call, so a call from
+    // the test before must not answer for the one under it.
+    vi.mocked(prepareLitellmParams).mockClear();
   });
 
   describe("when model is in the registry list", () => {
@@ -244,13 +247,11 @@ describe("setupModelEnv", () => {
         scope: "project" as never,
       });
 
-      const env = await setupModelEnv(
-        "openai/text-embedding-ada-002",
-        true,
-        "proj-1",
-      );
+      await setupModelEnv("openai/text-embedding-ada-002", true, "proj-1");
 
-      expect(env.X_LITELLM_EMBEDDINGS_model).toBeDefined();
+      expect(prepareLitellmParams).toHaveBeenCalledWith(
+        expect.objectContaining({ model: "azure/text-embedding-ada-002" }),
+      );
     });
 
     /** @scenario "A judge model is never swapped for the project's default" */

--- a/platform/app/src/server/app-layer/evaluations/__tests__/evaluation-execution.factories.unit.test.ts
+++ b/platform/app/src/server/app-layer/evaluations/__tests__/evaluation-execution.factories.unit.test.ts
@@ -51,6 +51,23 @@ function buildProvider(
   };
 }
 
+/**
+ * The refusal `setupModelEnv` threw, for the caller to assert on.
+ *
+ * `rejects.toThrow` cannot reach `code`, and `code` is the stable identity —
+ * the message is copy, which the presentation registry and the
+ * skipped-evaluation details both build on. Resolving instead of throwing
+ * yields a bare object, so the caller's `code` assertion fails on it too.
+ */
+async function refusalFrom(
+  promise: Promise<unknown>,
+): Promise<EvaluatorConfigError> {
+  return (await promise.then(
+    () => ({}),
+    (reason: unknown) => reason,
+  )) as EvaluatorConfigError;
+}
+
 describe("setupModelEnv", () => {
   // A queued one-shot the test under it never consumes would otherwise be
   // waiting for the next test that does.
@@ -158,7 +175,7 @@ describe("setupModelEnv", () => {
     });
   });
 
-  describe("when the provider maps the model to an Azure deployment", () => {
+  describe("given a project whose Azure provider maps a model to a deployment of another name", () => {
     function azureProject() {
       vi.mocked(getProjectModelProviders).mockResolvedValue({
         azure: buildProvider({
@@ -170,64 +187,76 @@ describe("setupModelEnv", () => {
       });
     }
 
-    /** @scenario "A judge on an Azure deployment named something other than the model reaches that deployment" */
-    it("sends the deployment under the name langevals reads", async () => {
-      azureProject();
-      vi.mocked(prepareLitellmParams).mockResolvedValueOnce({
-        model: "azure/gpt-4o",
-        api_key: "test-key",
-        deployment: "prod-judge",
+    describe("when the platform prepares a judge evaluator's environment", () => {
+      /** @scenario "A judge on an Azure deployment named something other than the model reaches that deployment" */
+      it("sends the deployment under the name langevals reads", async () => {
+        azureProject();
+        vi.mocked(prepareLitellmParams).mockResolvedValueOnce({
+          model: "azure/gpt-4o",
+          api_key: "test-key",
+          deployment: "prod-judge",
+        });
+
+        const env = await setupModelEnv("azure/gpt-4o", false, "proj-1");
+
+        expect(env.AZURE_DEPLOYMENT_NAME).toBe("prod-judge");
       });
 
-      const env = await setupModelEnv("azure/gpt-4o", false, "proj-1");
+      /** @scenario "The deployment name is never sent as a call argument" */
+      it("does not send the deployment as a call argument", async () => {
+        azureProject();
+        vi.mocked(prepareLitellmParams).mockResolvedValueOnce({
+          model: "azure/gpt-4o",
+          api_key: "test-key",
+          deployment: "prod-judge",
+        });
 
-      expect(env.AZURE_DEPLOYMENT_NAME).toBe("prod-judge");
+        const env = await setupModelEnv("azure/gpt-4o", false, "proj-1");
+
+        expect(env).not.toHaveProperty("X_LITELLM_deployment");
+      });
     });
 
-    /** @scenario "The deployment name is never sent as a call argument" */
-    it("does not send the deployment as a call argument", async () => {
-      azureProject();
-      vi.mocked(prepareLitellmParams).mockResolvedValueOnce({
-        model: "azure/gpt-4o",
-        api_key: "test-key",
-        deployment: "prod-judge",
+    describe("when the platform prepares an embedding evaluator's environment", () => {
+      it("names the embeddings deployment separately from the judge one", async () => {
+        azureProject();
+        vi.mocked(prepareLitellmParams).mockResolvedValueOnce({
+          model: "azure/text-embedding-ada-002",
+          api_key: "test-key",
+          deployment: "prod-embeddings",
+        });
+
+        const env = await setupModelEnv(
+          "azure/text-embedding-ada-002",
+          true,
+          "proj-1",
+        );
+
+        expect(env.AZURE_EMBEDDINGS_DEPLOYMENT_NAME).toBe("prod-embeddings");
+        expect(env).not.toHaveProperty("X_LITELLM_EMBEDDINGS_deployment");
       });
-
-      const env = await setupModelEnv("azure/gpt-4o", false, "proj-1");
-
-      expect(env).not.toHaveProperty("X_LITELLM_deployment");
-    });
-
-    it("names the embeddings deployment separately from the judge one", async () => {
-      azureProject();
-      vi.mocked(prepareLitellmParams).mockResolvedValueOnce({
-        model: "azure/text-embedding-ada-002",
-        api_key: "test-key",
-        deployment: "prod-embeddings",
-      });
-
-      const env = await setupModelEnv(
-        "azure/text-embedding-ada-002",
-        true,
-        "proj-1",
-      );
-
-      expect(env.AZURE_EMBEDDINGS_DEPLOYMENT_NAME).toBe("prod-embeddings");
-      expect(env).not.toHaveProperty("X_LITELLM_EMBEDDINGS_deployment");
-    });
-
-    it("leaves a provider with no deployment mapping untouched", async () => {
-      vi.mocked(getProjectModelProviders).mockResolvedValue({
-        gemini: buildProvider(),
-      });
-
-      const env = await setupModelEnv("gemini/gemini-2.5-pro", false, "proj-1");
-
-      expect(env).not.toHaveProperty("AZURE_DEPLOYMENT_NAME");
     });
   });
 
-  describe("when the evaluator's embeddings model names a provider the project does not have", () => {
+  describe("given a provider that maps no deployment at all", () => {
+    describe("when the platform prepares the evaluator's environment", () => {
+      it("names no deployment", async () => {
+        vi.mocked(getProjectModelProviders).mockResolvedValue({
+          gemini: buildProvider(),
+        });
+
+        const env = await setupModelEnv(
+          "gemini/gemini-2.5-pro",
+          false,
+          "proj-1",
+        );
+
+        expect(env).not.toHaveProperty("AZURE_DEPLOYMENT_NAME");
+      });
+    });
+  });
+
+  describe("given a project that configured no OpenAI provider", () => {
     function azureOnlyProject() {
       vi.mocked(getProjectModelProviders).mockResolvedValue({
         azure: buildProvider({
@@ -238,53 +267,81 @@ describe("setupModelEnv", () => {
       });
     }
 
-    /** @scenario "An evaluator embeds with the provider the project actually configured" */
-    it("embeds with the model the project resolves to", async () => {
-      azureOnlyProject();
-      vi.mocked(getResolvedDefaultForFeature).mockResolvedValueOnce({
-        model: "azure/text-embedding-ada-002",
-        source: "project" as never,
-        scope: "project" as never,
+    describe("when the evaluator carries the baked-in OpenAI embeddings default", () => {
+      /** @scenario "An evaluator embeds with the provider the project actually configured" */
+      it("embeds with the model the project resolves to", async () => {
+        azureOnlyProject();
+        vi.mocked(getResolvedDefaultForFeature).mockResolvedValueOnce({
+          model: "azure/text-embedding-ada-002",
+          source: "project" as never,
+          scope: "project" as never,
+        });
+        // Echoes the model back so the emitted env, and not only the call
+        // into the params builder, shows which model was chosen.
+        vi.mocked(prepareLitellmParams).mockResolvedValueOnce({
+          model: "azure/text-embedding-ada-002",
+          api_key: "test-key",
+        });
+
+        const env = await setupModelEnv(
+          "openai/text-embedding-ada-002",
+          true,
+          "proj-1",
+        );
+
+        expect(prepareLitellmParams).toHaveBeenCalledWith(
+          expect.objectContaining({ model: "azure/text-embedding-ada-002" }),
+        );
+        expect(env.X_LITELLM_EMBEDDINGS_model).toBe(
+          "azure/text-embedding-ada-002",
+        );
       });
 
-      await setupModelEnv("openai/text-embedding-ada-002", true, "proj-1");
+      /** @scenario "With nothing to fall back to, the refusal names the embeddings setting" */
+      it("names the embeddings model when there is nothing to fall back to", async () => {
+        azureOnlyProject();
+        vi.mocked(getResolvedDefaultForFeature).mockResolvedValueOnce(null);
 
-      expect(prepareLitellmParams).toHaveBeenCalledWith(
-        expect.objectContaining({ model: "azure/text-embedding-ada-002" }),
-      );
-    });
+        const error = await refusalFrom(
+          setupModelEnv("openai/text-embedding-ada-002", true, "proj-1"),
+        );
 
-    /** @scenario "A judge model is never swapped for the project's default" */
-    it("refuses a judge model rather than swapping it", async () => {
-      azureOnlyProject();
-
-      await expect(
-        setupModelEnv("openai/gpt-4o", false, "proj-1"),
-      ).rejects.toThrow("Provider openai is not configured");
-      expect(getResolvedDefaultForFeature).not.toHaveBeenCalled();
-    });
-
-    /** @scenario "With nothing to fall back to, the refusal names the embeddings setting" */
-    it("names the embeddings model when there is nothing to fall back to", async () => {
-      azureOnlyProject();
-      vi.mocked(getResolvedDefaultForFeature).mockResolvedValueOnce(null);
-
-      await expect(
-        setupModelEnv("openai/text-embedding-ada-002", true, "proj-1"),
-      ).rejects.toThrow(/embeddings model .* "openai\/text-embedding-ada-002"/);
-    });
-
-    it("does not fall back to a default whose own provider is missing", async () => {
-      azureOnlyProject();
-      vi.mocked(getResolvedDefaultForFeature).mockResolvedValueOnce({
-        model: "cohere/embed-v4",
-        source: "project" as never,
-        scope: "project" as never,
+        expect(error.code).toBe("evaluator_config_error");
+        // The message is what the customer reads: a refused evaluation
+        // reports `skipped` with this text as its details, so which model it
+        // names is the behaviour under test, not incidental copy.
+        expect(error.message).toContain('"openai/text-embedding-ada-002"');
       });
 
-      await expect(
-        setupModelEnv("openai/text-embedding-ada-002", true, "proj-1"),
-      ).rejects.toThrow(/"openai\/text-embedding-ada-002"/);
+      it("does not fall back to a default whose own provider is missing", async () => {
+        azureOnlyProject();
+        vi.mocked(getResolvedDefaultForFeature).mockResolvedValueOnce({
+          model: "cohere/embed-v4",
+          source: "project" as never,
+          scope: "project" as never,
+        });
+
+        const error = await refusalFrom(
+          setupModelEnv("openai/text-embedding-ada-002", true, "proj-1"),
+        );
+
+        expect(error.code).toBe("evaluator_config_error");
+        expect(error.message).toContain('"openai/text-embedding-ada-002"');
+      });
+    });
+
+    describe("when the evaluator's judge is an OpenAI model", () => {
+      /** @scenario "A judge model is never swapped for the project's default" */
+      it("refuses the judge model rather than swapping it", async () => {
+        azureOnlyProject();
+
+        const error = await refusalFrom(
+          setupModelEnv("openai/gpt-4o", false, "proj-1"),
+        );
+
+        expect(error.code).toBe("evaluator_config_error");
+        expect(getResolvedDefaultForFeature).not.toHaveBeenCalled();
+      });
     });
   });
 });

--- a/platform/app/src/server/app-layer/evaluations/evaluation-execution.factories.ts
+++ b/platform/app/src/server/app-layer/evaluations/evaluation-execution.factories.ts
@@ -4,6 +4,7 @@ import {
   prepareLitellmParams,
 } from "~/server/api/routers/modelProviders.utils";
 import { prisma } from "~/server/db";
+import { getResolvedDefaultForFeature } from "~/server/modelProviders/modelDefaults.read";
 import { ModelProviderService } from "~/server/modelProviders/modelProvider.service";
 import { resolveMaxTokensCeiling } from "~/server/modelProviders/resolveMaxTokensCeiling";
 import { clampMaxTokens } from "~/utils/clampMaxTokens";
@@ -72,6 +73,47 @@ export function createDefaultModelEnvResolver(): ModelEnvResolver {
 }
 
 /**
+ * The feature key whose cascade answer says what a project embeds with. Shared
+ * with the evaluator create path, so an evaluator created today and one
+ * created before the cascade existed resolve to the same model.
+ */
+const EMBEDDINGS_FEATURE_KEY = "analytics.topic_clustering_embeddings";
+
+/**
+ * The embeddings model an evaluation should actually use on this project.
+ *
+ * Returns the requested model whenever its provider is configured and enabled.
+ * Otherwise falls back to the project's cascade-resolved embeddings default,
+ * and only when that default is itself usable. Nothing here reaches for a
+ * hardcoded provider: when the cascade has nothing to say the requested model
+ * comes back unchanged, so the caller reports the real gap rather than a
+ * fabricated one.
+ */
+async function resolveEmbeddingsModel({
+  requested,
+  projectId,
+  modelProviders,
+}: {
+  requested: string;
+  projectId: string;
+  modelProviders: Awaited<ReturnType<typeof getProjectModelProviders>>;
+}): Promise<string> {
+  const isUsable = (model: string): boolean =>
+    modelProviders[model.split("/")[0]!]?.enabled === true;
+
+  if (isUsable(requested)) return requested;
+
+  const resolved = await getResolvedDefaultForFeature(
+    { prisma, session: null },
+    { projectId, featureKey: EMBEDDINGS_FEATURE_KEY },
+  );
+
+  return resolved?.model && isUsable(resolved.model)
+    ? resolved.model
+    : requested;
+}
+
+/**
  * Builds the X_LITELLM_* env block for an evaluator that needs to call a
  * specific model. Validates the provider is configured + enabled, projects
  * litellm params, and overlays whitelisted generation params (temperature,
@@ -81,20 +123,43 @@ export function createDefaultModelEnvResolver(): ModelEnvResolver {
  * need a per-worker error class should catch and rewrap.
  */
 export async function setupModelEnv(
-  model: string,
+  requestedModel: string,
   embeddings: boolean,
   projectId: string,
   settings?: Record<string, unknown>,
 ): Promise<Record<string, string>> {
   const modelProviders = await getProjectModelProviders(projectId);
+
+  // The embeddings model is rarely a deliberate choice: an evaluator that
+  // carries one gets it from a literal baked into the evaluator definition
+  // (`openai/text-embedding-ada-002`), so a project that never configured
+  // OpenAI failed here on a provider it does not use and never picked. Ask
+  // the cascade what this project actually embeds with before refusing. The
+  // judge `model` is chosen per evaluator and is left exactly as configured.
+  const model = embeddings
+    ? await resolveEmbeddingsModel({
+        requested: requestedModel,
+        projectId,
+        modelProviders,
+      })
+    : requestedModel;
+
   const provider = model.split("/")[0]!;
   const modelProvider = modelProviders[provider];
 
   if (!modelProvider) {
-    throw new EvaluatorConfigError(`Provider ${provider} is not configured`);
+    throw new EvaluatorConfigError(
+      embeddings
+        ? `The embeddings model for this evaluation is "${model}", and ${provider} is not configured for this project. Point the evaluator's embeddings model at a configured provider, or configure ${provider}.`
+        : `Provider ${provider} is not configured`,
+    );
   }
   if (!modelProvider.enabled) {
-    throw new EvaluatorConfigError(`Provider ${provider} is not enabled`);
+    throw new EvaluatorConfigError(
+      embeddings
+        ? `The embeddings model for this evaluation is "${model}", and ${provider} is not enabled for this project. Point the evaluator's embeddings model at an enabled provider, or enable ${provider}.`
+        : `Provider ${provider} is not enabled`,
+    );
   }
 
   const modelName = model.split("/").slice(1).join("/");
@@ -147,12 +212,27 @@ export async function setupModelEnv(
     projectId,
   });
 
-  let envResult = Object.fromEntries(
-    Object.entries(litellmParams).map(([key, value]) => [
+  // The Azure deployment name is not a litellm call argument — litellm reads
+  // the deployment out of the model string (`azure/<deployment>`). Sent as
+  // `X_LITELLM_deployment` it landed in the call kwargs, where nothing
+  // consumed it, and the request kept targeting `azure/<model-id>`: on a
+  // provider whose deployment is named anything else, a deployment that does
+  // not exist. `AZURE_DEPLOYMENT_NAME` / `AZURE_EMBEDDINGS_DEPLOYMENT_NAME`
+  // are the names langevals already reads to rewrite the model string.
+  const { deployment, ...callParams } = litellmParams;
+
+  let envResult: Record<string, string> = Object.fromEntries(
+    Object.entries(callParams).map(([key, value]) => [
       embeddings ? `X_LITELLM_EMBEDDINGS_${key}` : `X_LITELLM_${key}`,
       value,
     ]),
   );
+
+  if (deployment) {
+    envResult[
+      embeddings ? "AZURE_EMBEDDINGS_DEPLOYMENT_NAME" : "AZURE_DEPLOYMENT_NAME"
+    ] = deployment;
+  }
 
   // Generation params (temperature, max_tokens, etc.)
   const generationParams = [

--- a/services/langevals/langevals_core/langevals_core/litellm_patch.py
+++ b/services/langevals/langevals_core/langevals_core/litellm_patch.py
@@ -303,20 +303,6 @@ def patch_litellm_params(kwargs):
 
     request_env = current_request_env()
 
-    request_credentials(kwargs)
-
-    # The server environment is the fallback for vertex, after the request env
-    # had its turn through the table above and only when the caller named
-    # nothing. Reading it for any other provider would attach credentials that
-    # the call has no use for.
-    if (
-        kwargs.get("vertex_credentials") is None
-        and _model_provider(kwargs.get("model") or "") == "vertex_ai"
-    ):
-        google_credentials = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
-        if google_credentials is not None:
-            kwargs["vertex_credentials"] = google_credentials
-
     # X_LITELLM_* variables are litellm call arguments by name. The server's
     # own environment provides the baseline and the request env overrides it,
     # the same precedence get_env gives every other variable.
@@ -354,6 +340,28 @@ def patch_litellm_params(kwargs):
         and kwargs["model"].startswith("azure/")
     ):
         kwargs["model"] = "azure/" + deployment_name
+
+    # Credentials are resolved for the model the request actually names, so
+    # this runs after the model is final rather than before. `X_LITELLM_model`
+    # can name a different provider than the caller's own argument did — that
+    # is how an evaluator's baked-in embeddings default is redirected to the
+    # provider a project configured — and credentials chosen from the model on
+    # the way in would then belong to a provider the call no longer addresses.
+    # Precedence is unchanged: the loop above assigns, and this only fills
+    # arguments still unset.
+    request_credentials(kwargs)
+
+    # The server environment is the fallback for vertex, after the request env
+    # had its turn through the table above and only when the caller named
+    # nothing. Reading it for any other provider would attach credentials that
+    # the call has no use for.
+    if (
+        kwargs.get("vertex_credentials") is None
+        and _model_provider(kwargs.get("model") or "") == "vertex_ai"
+    ):
+        google_credentials = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
+        if google_credentials is not None:
+            kwargs["vertex_credentials"] = google_credentials
 
     if "use_azure_gateway" in kwargs:
         kwargs["model"] = kwargs["model"].replace("azure/", "")
@@ -394,8 +402,6 @@ def patch_litellm_embedding_params(kwargs):
 
     request_env = current_request_env()
 
-    request_credentials(kwargs)
-
     for key, value in {**os.environ, **request_env}.items():
         if key.startswith("X_LITELLM_EMBEDDINGS_"):
             replaced_key = key.replace("X_LITELLM_EMBEDDINGS_", "")
@@ -421,6 +427,12 @@ def patch_litellm_embedding_params(kwargs):
         kwargs.get("model") or ""
     ).startswith("azure/"):
         kwargs["model"] = "azure/" + embeddings_deployment
+
+    # After the model is final, for the reason given on the completion path:
+    # an evaluator carrying a baked-in embeddings default is redirected here
+    # by X_LITELLM_EMBEDDINGS_model, so the provider whose credentials the
+    # call needs is only known once that override has landed.
+    request_credentials(kwargs)
 
     if "extra_headers" in kwargs and isinstance(kwargs["extra_headers"], str):
         kwargs["extra_headers"] = json.loads(kwargs["extra_headers"])

--- a/services/langevals/langevals_core/langevals_core/litellm_patch.py
+++ b/services/langevals/langevals_core/langevals_core/litellm_patch.py
@@ -333,12 +333,20 @@ def patch_litellm_params(kwargs):
     if "extra_headers" in kwargs and isinstance(kwargs["extra_headers"], str):
         kwargs["extra_headers"] = json.loads(kwargs["extra_headers"])
 
+    # A caller may name the deployment the litellm-shaped way, as a
+    # `deployment` argument. litellm has no such argument — it takes the
+    # deployment from the model string — so it is read here and dropped
+    # before the call rather than travelling on as dead weight.
+    deployment_argument = kwargs.pop("deployment", None)
+
     # Azure patches. Kept before the rewrite: a deployment name is arbitrary
     # ("prod-judge"), so after this block there is nothing left in the model
     # string to recognise a family by.
     requested_model = kwargs.get("model")
-    deployment_name = request_env.get("AZURE_DEPLOYMENT_NAME") or os.environ.get(
-        "AZURE_DEPLOYMENT_NAME"
+    deployment_name = (
+        request_env.get("AZURE_DEPLOYMENT_NAME")
+        or os.environ.get("AZURE_DEPLOYMENT_NAME")
+        or deployment_argument
     )
     if (
         deployment_name is not None
@@ -386,12 +394,6 @@ def patch_litellm_embedding_params(kwargs):
 
     request_env = current_request_env()
 
-    embeddings_deployment = request_env.get(
-        "AZURE_EMBEDDINGS_DEPLOYMENT_NAME"
-    ) or os.environ.get("AZURE_EMBEDDINGS_DEPLOYMENT_NAME")
-    if embeddings_deployment is not None:
-        kwargs["model"] = "azure/" + embeddings_deployment
-
     request_credentials(kwargs)
 
     for key, value in {**os.environ, **request_env}.items():
@@ -401,6 +403,24 @@ def patch_litellm_embedding_params(kwargs):
             if replaced_key.isupper():
                 continue
             kwargs[replaced_key] = convert_param_type(replaced_key, value)
+
+    deployment_argument = kwargs.pop("deployment", None)
+
+    # After the loop, not before it, and the same way round as the completion
+    # path: X_LITELLM_EMBEDDINGS_model carries the caller's model and used to
+    # land on top of the rewrite, putting the model id back where the
+    # deployment name belonged. Only an azure model is rewritten — an
+    # embeddings deployment left in the server environment has nothing to say
+    # about a call to any other provider.
+    embeddings_deployment = (
+        request_env.get("AZURE_EMBEDDINGS_DEPLOYMENT_NAME")
+        or os.environ.get("AZURE_EMBEDDINGS_DEPLOYMENT_NAME")
+        or deployment_argument
+    )
+    if embeddings_deployment is not None and str(
+        kwargs.get("model") or ""
+    ).startswith("azure/"):
+        kwargs["model"] = "azure/" + embeddings_deployment
 
     if "extra_headers" in kwargs and isinstance(kwargs["extra_headers"], str):
         kwargs["extra_headers"] = json.loads(kwargs["extra_headers"])

--- a/services/langevals/langevals_core/tests/test_azure_deployment_resolution.py
+++ b/services/langevals/langevals_core/tests/test_azure_deployment_resolution.py
@@ -17,6 +17,7 @@ from langevals_core.litellm_patch import (
     patch_litellm_embedding_params,
     patch_litellm_params,
 )
+from langevals_core.request_env import request_env
 
 
 @pytest.fixture(autouse=True)
@@ -97,3 +98,52 @@ def test_an_embedding_deployment_does_not_divert_another_provider(monkeypatch):
     kwargs = patch_litellm_embedding_params({"model": "openai/text-embedding-3-small"})
 
     assert kwargs["model"] == "openai/text-embedding-3-small"
+
+
+# @scenario "Credentials follow the model the request ends up naming"
+def test_embedding_credentials_follow_the_resolved_model():
+    """The credentials belong to the provider the call finally addresses.
+
+    An evaluator carrying a baked-in OpenAI embeddings default is redirected
+    to the provider the project configured, and the redirect arrives as
+    X_LITELLM_EMBEDDINGS_model. Resolving credentials from the model on the
+    way in picks the provider the call no longer addresses.
+
+    The request env here deliberately carries no X_LITELLM_EMBEDDINGS_api_key:
+    the platform does send one, and it would mask the ordering. What is under
+    test is which provider's table the resolution reads.
+    """
+    env = {
+        "X_LITELLM_EMBEDDINGS_model": "azure/text-embedding-ada-002",
+        "AZURE_OPENAI_API_KEY": "azure-key",
+        "AZURE_OPENAI_ENDPOINT": "https://example-resource.openai.azure.test",
+        "OPENAI_API_KEY": "openai-key",
+    }
+
+    with request_env(env):
+        kwargs = patch_litellm_embedding_params(
+            {"model": "openai/text-embedding-ada-002"}
+        )
+
+    assert kwargs["model"] == "azure/text-embedding-ada-002"
+    assert kwargs["api_key"] == "azure-key"
+    assert kwargs["api_base"] == "https://example-resource.openai.azure.test"
+
+
+# @scenario "Credentials follow the model the request ends up naming"
+def test_completion_credentials_follow_the_resolved_model():
+    """The same ordering on the completion path, where X_LITELLM_model can
+    equally name a provider the caller's own argument did not."""
+    env = {
+        "X_LITELLM_model": "azure/gpt-4o",
+        "AZURE_OPENAI_API_KEY": "azure-key",
+        "AZURE_OPENAI_ENDPOINT": "https://example-resource.openai.azure.test",
+        "OPENAI_API_KEY": "openai-key",
+    }
+
+    with request_env(env):
+        kwargs = patch_litellm_params({"model": "openai/gpt-4o"})
+
+    assert kwargs["model"] == "azure/gpt-4o"
+    assert kwargs["api_key"] == "azure-key"
+    assert kwargs["api_base"] == "https://example-resource.openai.azure.test"

--- a/services/langevals/langevals_core/tests/test_azure_deployment_resolution.py
+++ b/services/langevals/langevals_core/tests/test_azure_deployment_resolution.py
@@ -1,0 +1,99 @@
+"""
+Unit tests for how langevals settles which Azure deployment a call names.
+
+Exercised at the patch seam (`patch_litellm_params`,
+`patch_litellm_embedding_params`), which every litellm call in langevals
+flows through, so what is asserted is the request that actually leaves
+langevals. No API keys and no network.
+
+Spec: specs/evaluators/evaluator-azure-deployment-and-embeddings-provider.feature
+"""
+
+import os
+
+import pytest
+
+from langevals_core.litellm_patch import (
+    patch_litellm_embedding_params,
+    patch_litellm_params,
+)
+
+
+@pytest.fixture(autouse=True)
+def scrubbed_litellm_env(monkeypatch):
+    """A developer's own variables must not steer these assertions."""
+    for key in list(os.environ):
+        if key.startswith("X_LITELLM_") or key in (
+            "AZURE_DEPLOYMENT_NAME",
+            "AZURE_EMBEDDINGS_DEPLOYMENT_NAME",
+        ):
+            monkeypatch.delenv(key)
+
+
+# @scenario "A deployment named as a call argument still selects the deployment"
+def test_a_deployment_argument_selects_the_deployment():
+    kwargs = patch_litellm_params(
+        {"model": "azure/gpt-4o", "deployment": "prod-judge"}
+    )
+
+    assert kwargs["model"] == "azure/prod-judge"
+
+
+# @scenario "The deployment name is never sent as a call argument"
+def test_the_deployment_argument_does_not_survive_into_the_request():
+    kwargs = patch_litellm_params(
+        {"model": "azure/gpt-4o", "deployment": "prod-judge"}
+    )
+
+    assert "deployment" not in kwargs
+
+
+# The environment is how the platform sends it, and it is the older of the
+# two spellings — it stays the one that wins.
+def test_the_environment_name_wins_over_a_call_argument(monkeypatch):
+    monkeypatch.setenv("AZURE_DEPLOYMENT_NAME", "from-environment")
+
+    kwargs = patch_litellm_params(
+        {"model": "azure/gpt-4o", "deployment": "from-argument"}
+    )
+
+    assert kwargs["model"] == "azure/from-environment"
+
+
+def test_a_deployment_name_does_not_divert_a_call_to_another_provider(monkeypatch):
+    monkeypatch.setenv("AZURE_DEPLOYMENT_NAME", "prod-judge")
+
+    kwargs = patch_litellm_params({"model": "openai/gpt-4o"})
+
+    assert kwargs["model"] == "openai/gpt-4o"
+
+
+# @scenario "An embedding call reaches the mapped deployment rather than the model id"
+def test_an_embedding_call_names_the_deployment_over_the_callers_model(monkeypatch):
+    monkeypatch.setenv("AZURE_EMBEDDINGS_DEPLOYMENT_NAME", "prod-embeddings")
+    # How the platform sends the embeddings model: as a request setting merged
+    # into the call arguments. It used to land after the rewrite and undo it.
+    monkeypatch.setenv("X_LITELLM_EMBEDDINGS_model", "azure/text-embedding-ada-002")
+
+    kwargs = patch_litellm_embedding_params({"model": "azure/text-embedding-ada-002"})
+
+    assert kwargs["model"] == "azure/prod-embeddings"
+
+
+# @scenario "The deployment name is never sent as a call argument"
+def test_an_embedding_deployment_argument_does_not_survive_into_the_request():
+    kwargs = patch_litellm_embedding_params(
+        {"model": "azure/text-embedding-ada-002", "deployment": "prod-embeddings"}
+    )
+
+    assert "deployment" not in kwargs
+    assert kwargs["model"] == "azure/prod-embeddings"
+
+
+# @scenario "A deployment name left in the environment does not divert a call to another provider"
+def test_an_embedding_deployment_does_not_divert_another_provider(monkeypatch):
+    monkeypatch.setenv("AZURE_EMBEDDINGS_DEPLOYMENT_NAME", "prod-embeddings")
+
+    kwargs = patch_litellm_embedding_params({"model": "openai/text-embedding-3-small"})
+
+    assert kwargs["model"] == "openai/text-embedding-3-small"

--- a/specs/evaluators/evaluator-azure-deployment-and-embeddings-provider.feature
+++ b/specs/evaluators/evaluator-azure-deployment-and-embeddings-provider.feature
@@ -72,6 +72,15 @@ Feature: Evaluators reach the Azure deployment and the embeddings provider a pro
     When langevals prepares the call
     Then the request still names the provider the caller chose
 
+  # The redirect below arrives as a request setting, so the provider the call
+  # addresses is only settled once that setting has landed. Credentials picked
+  # from the model on the way in belong to the provider it no longer names.
+  @unit
+  Scenario: Credentials follow the model the request ends up naming
+    Given a call whose model is redirected to another provider by a request setting
+    When langevals prepares the call
+    Then the call carries the credentials of the provider it ends up naming
+
   @unit
   Scenario: An evaluator embeds with the provider the project actually configured
     Given a project that configured no OpenAI provider

--- a/specs/evaluators/evaluator-azure-deployment-and-embeddings-provider.feature
+++ b/specs/evaluators/evaluator-azure-deployment-and-embeddings-provider.feature
@@ -1,0 +1,87 @@
+Feature: Evaluators reach the Azure deployment and the embeddings provider a project actually has
+  As someone running evaluators on a project whose only model provider is Azure
+  I want the evaluator to reach the deployment I mapped and embed with a provider I configured
+  So that the evaluation returns a verdict instead of a provider rejection
+
+  # Two gaps on the boundary between the platform and langevals, both of
+  # which stop an Azure-only project from running a model-backed evaluator.
+  #
+  # 1. An Azure deployment may be named anything ("prod-judge"), and the
+  #    provider carries a mapping from model id to deployment name. The
+  #    platform resolved that mapping and then sent it under `deployment` —
+  #    a name nothing reads. litellm has no `deployment` argument: it takes
+  #    the deployment out of the model string, and langevals rewrites that
+  #    string from AZURE_DEPLOYMENT_NAME. So the mapping was resolved
+  #    correctly and then discarded, and every call went to a deployment
+  #    named after the model id, which on such a provider does not exist.
+  #
+  # 2. An evaluator that embeds carries an embeddings model, and the default
+  #    baked into the evaluator definition names OpenAI. A project that never
+  #    configured OpenAI was refused over a provider it does not use and
+  #    never picked, with an error naming that provider rather than the
+  #    setting that carried it.
+  #
+  # Bindings:
+  #   platform/app/src/server/app-layer/evaluations/evaluation-execution.factories.ts
+  #   platform/app/src/server/app-layer/evaluations/__tests__/evaluation-execution.factories.unit.test.ts
+  #   services/langevals/langevals_core/langevals_core/litellm_patch.py
+  #   services/langevals/langevals_core/tests/test_azure_deployment_resolution.py
+
+  @unit
+  Scenario: A judge on an Azure deployment named something other than the model reaches that deployment
+    Given a project whose Azure provider maps a model to a deployment of another name
+    And an evaluator whose judge is that model
+    When the platform prepares the evaluator's environment
+    Then the deployment name travels under the name langevals reads
+
+  # The same name, sent the way it used to be, still has to work: an
+  # evaluator env built by a platform that has not been deployed yet reaches
+  # a langevals that has.
+  @unit
+  Scenario: A deployment named as a call argument still selects the deployment
+    Given a call that names its Azure deployment as an argument
+    When langevals prepares the call
+    Then the request names the deployment rather than the model id
+
+  @unit
+  Scenario: The deployment name is never sent as a call argument
+    Given a call that names its Azure deployment as an argument
+    When langevals prepares the call
+    Then no deployment argument survives into the request
+
+  # The embeddings branch merged the caller's own model on top of the
+  # rewrite, putting the model id back where the deployment name belonged.
+  @unit
+  Scenario: An embedding call reaches the mapped deployment rather than the model id
+    Given an embedding call on an Azure model whose deployment has another name
+    And the caller's own model arrives as a request setting
+    When langevals prepares the call
+    Then the request names the deployment rather than the model id
+
+  @unit
+  Scenario: A deployment name left in the environment does not divert a call to another provider
+    Given an Azure embeddings deployment named in the environment
+    And an embedding call on a provider that is not Azure
+    When langevals prepares the call
+    Then the request still names the provider the caller chose
+
+  @unit
+  Scenario: An evaluator embeds with the provider the project actually configured
+    Given a project that configured no OpenAI provider
+    And an evaluator carrying the baked-in OpenAI embeddings default
+    When the platform prepares the evaluator's environment
+    Then the evaluation embeds with the model the project resolves to
+
+  @unit
+  Scenario: A judge model is never swapped for the project's default
+    Given a project that configured no OpenAI provider
+    And an evaluator whose judge is an OpenAI model
+    When the platform prepares the evaluator's environment
+    Then the evaluation is refused rather than judged by another model
+
+  @unit
+  Scenario: With nothing to fall back to, the refusal names the embeddings setting
+    Given a project that configured no OpenAI provider and resolves no embeddings default
+    And an evaluator carrying the baked-in OpenAI embeddings default
+    When the platform prepares the evaluator's environment
+    Then the refusal names the evaluator's embeddings model

--- a/specs/evaluators/evaluator-azure-deployment-and-embeddings-provider.feature
+++ b/specs/evaluators/evaluator-azure-deployment-and-embeddings-provider.feature
@@ -21,6 +21,13 @@ Feature: Evaluators reach the Azure deployment and the embeddings provider a pro
   #    never picked, with an error naming that provider rather than the
   #    setting that carried it.
   #
+  # Scope of what these scenarios observe: the seam either side of the handoff
+  # between the platform and the evaluator service. On the platform side they
+  # watch what the environment is built to say, taking the model-to-deployment
+  # mapping itself as given — it is resolved and covered a layer below. On the
+  # service side they watch what the call ends up addressed to. Nothing here
+  # calls a real provider.
+  #
   # Bindings:
   #   platform/app/src/server/app-layer/evaluations/evaluation-execution.factories.ts
   #   platform/app/src/server/app-layer/evaluations/__tests__/evaluation-execution.factories.unit.test.ts


### PR DESCRIPTION
Closes #7766

## What was wrong

Two gaps on the boundary between the platform and langevals, both of which stop an Azure-only project from running a model-backed evaluator.

**1. The Azure deployment name was resolved and then dropped.**

An Azure deployment can be named anything, and a provider carries a mapping from model id to deployment name. `prepareLitellmParams` resolves that mapping and sets `params.deployment`; `setupModelEnv` prefixed every param into the evaluator env, so it arrived as `X_LITELLM_deployment`.

Nothing on the other side reads that name. litellm has no `deployment` argument — it takes the deployment out of the model string (`azure/<deployment>`) — and langevals rewrites that string from `AZURE_DEPLOYMENT_NAME`, which the completion branch had no way to set. So the mapping was resolved correctly and then discarded, and every call went to a deployment named after the model id, which on such a provider does not exist.

`modelProviders.utils.ts` carried the matching TODO.

**2. An evaluator that embeds required OpenAI.**

The embeddings model default baked into an evaluator definition names OpenAI. On a project that configured only Azure, `setupModelEnv` refused with `Provider openai is not configured` — a provider the project does not use and never picked, named instead of the setting that carried it.

## What changed

**Platform** — `setupModelEnv`:

- The Azure deployment leaves as `AZURE_DEPLOYMENT_NAME`, or `AZURE_EMBEDDINGS_DEPLOYMENT_NAME` on the embeddings branch — the names langevals already reads. It no longer leaves as `X_LITELLM_deployment`.
- An embeddings model whose provider is not configured or not enabled falls back to the project's cascade-resolved embeddings default, and only when that default is itself usable. Nothing reaches for a hardcoded provider: with nothing to fall back to, the refusal names the evaluator's embeddings model. A judge `model` is a deliberate per-evaluator choice and is still taken exactly as configured.

**langevals** — `litellm_patch`:

- A `deployment` argument is honoured as the deployment name and dropped before the call, so an evaluator env built by a platform that has not rolled yet still lands on the right deployment.
- On the embeddings branch the rewrite ran *before* the caller's own settings were merged in, so `X_LITELLM_EMBEDDINGS_model` landed on top of it and put the model id back where the deployment name belonged. It now runs after the merge, the same way round as the completion branch.
- The embeddings rewrite only ever touches an `azure/` model. It used to fire unconditionally, so a deployment name left in the server environment would have diverted a call to any other provider — latent before, live as soon as the platform starts sending the variable.

## A third fix, found in review

`request_credentials` resolved its provider table from the model the caller passed in, before the `X_LITELLM_*` override loop could redirect the call. Since gap 2 redirects an evaluator's embeddings default to the provider a project actually configured, that attached the wrong provider's key first.

It now runs after the override loop and the Azure deployment rewrite on both paths, and still before the gateway block that needs `api_base` and `api_version`. The vertex server-env fallback moved with it, for the same reason. Precedence is unchanged: the loop assigns, and `request_credentials` only fills arguments still unset.

This was a latent hazard rather than the reported outage — `prepareLitellmParams` always emits `api_key`, so the loop supplied the right one afterwards. With the old ordering restored, the two new tests fail on the wrong key.

## Tests

`specs/evaluators/evaluator-azure-deployment-and-embeddings-provider.feature`, bound both sides:

- platform: the deployment travels under the name langevals reads, never as a call argument, separately for judge and embeddings; a provider with no mapping is untouched; the embeddings model falls back to what the project resolves to; a judge model is refused rather than swapped; with nothing to fall back to the refusal names the embeddings model; a fallback whose own provider is missing is not taken.
- langevals: a `deployment` argument selects the deployment and does not survive into the request, on both the completion and embedding paths; the environment name still wins over the argument; a deployment name does not divert a call to another provider; an embedding call reaches the deployment even with the caller's model arriving as a request setting; and a call redirected to another provider by a request setting carries that provider's credentials rather than the ones the caller's own model named.

15 platform unit tests and 53 langevals tests pass. `pnpm typecheck`, `pnpm typecheck:all` and the feature-parity check are clean.

## Deployment Impact

No deployment impact. No environment variable is added, removed or renamed, no Helm value or chart template changes, and nothing in `.env.example` or the self-hosting docs moves.

`AZURE_DEPLOYMENT_NAME` and `AZURE_EMBEDDINGS_DEPLOYMENT_NAME` are not operator configuration: the platform puts them in the per-request evaluator environment, and the evaluator service already read both. An operator who has set either in the server environment keeps the behaviour they had, narrowed — the embeddings rewrite now fires only for an `azure/` model, so a name left there can no longer divert a call to another provider.

A vanilla `helm install` with no overrides behaves exactly as before, and BYOC dataplanes are unaffected: no new dataplane-side variable, no new egress, no new dependency between the control plane and the dataplane. The two sides roll independently in either order — a deployment name sent the old way is still honoured by the evaluator service, and the new names are ignored by a service that has not rolled yet.

## Not covered

Neither gap was validated against a real Azure resource — no Azure account was available here. Both are read from the code and asserted at the seam the request actually leaves through.

Gap 1 only bites providers that define a deployment mapping; gap 2 only bites evaluators carrying an embeddings model. An evaluator with neither is not explained by either finding.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Azure deployment mapping for evaluation and embedding requests.
  * Added fallback selection for configured embedding models when the requested provider is unavailable.
  * Improved model-specific errors for missing or disabled embedding providers.

* **Bug Fixes**
  * Prevented deployment settings from affecting non-Azure providers.
  * Preserved explicitly configured embedding and judge models.
  * Ensured credentials match the final resolved model and provider.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

