### PR TITLE
fix(traces): keep a reading of zero on ingest

### DIFF
--- a/platform/app/src/generated/generated
+++ b/platform/app/src/generated/generated
@@ -1,1 +1,0 @@
-/Users/sergioesteban/workspace/langwatch/langwatch/.claude/worktrees/evaluators-azure-and-zero-metric/platform/app/src/generated

--- a/platform/app/src/generated/generated
+++ b/platform/app/src/generated/generated
@@ -1,0 +1,1 @@
+/Users/sergioesteban/workspace/langwatch/langwatch/.claude/worktrees/evaluators-azure-and-zero-metric/platform/app/src/generated

--- a/platform/app/src/server/event-sourcing/pipelines/trace-processing/utils/__tests__/traceRequest.utils.test.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/trace-processing/utils/__tests__/traceRequest.utils.test.ts
@@ -443,8 +443,9 @@ describe("traceRequest.utils", () => {
       });
 
       it("preserves boolValue false via !== null check", () => {
-        // NOTE: The boolValue check uses `v.boolValue !== null` (not a truthy
-        // check), so false IS correctly returned -- unlike intValue/doubleValue.
+        // NOTE: The boolValue check asks whether the value is there, not
+        // whether it is truthy, so false is correctly returned. intValue and
+        // doubleValue now ask the same question.
         const result = TraceRequestUtils.normalizeOtlpAnyValue(
           { boolValue: false },
           "flag",
@@ -471,36 +472,34 @@ describe("traceRequest.utils", () => {
         expect(result).toEqual({ flag: false });
       });
 
-      it("drops intValue 0 due to falsy check", () => {
-        // BUG: scalar() checks `v.intValue` which is falsy for 0,
-        // so intValue: 0 is never captured and returns undefined.
+      /** @scenario "A neutral vote is stored as the value it was sent as" */
+      it("keeps intValue 0", () => {
         const result = TraceRequestUtils.normalizeOtlpAnyValue(
           { intValue: 0 },
           "count",
         );
 
-        expect(result).toEqual({});
+        expect(result).toEqual({ count: 0 });
       });
 
-      it("drops doubleValue 0 due to falsy check", () => {
-        // BUG: scalar() checks `v.doubleValue` which is falsy for 0,
-        // so doubleValue: 0 is never captured and returns undefined.
+      /** @scenario "A neutral vote is stored as the value it was sent as" */
+      it("keeps doubleValue 0", () => {
         const result = TraceRequestUtils.normalizeOtlpAnyValue(
           { doubleValue: 0 },
           "value",
         );
 
-        expect(result).toEqual({});
+        expect(result).toEqual({ value: 0 });
       });
 
-      it("drops doubleValue 0.0 due to falsy check", () => {
-        // BUG: 0.0 === 0 in JavaScript, still falsy.
+      /** @scenario "A neutral vote is stored as the value it was sent as" */
+      it("keeps doubleValue 0.0", () => {
         const result = TraceRequestUtils.normalizeOtlpAnyValue(
           { doubleValue: 0.0 },
           "value",
         );
 
-        expect(result).toEqual({});
+        expect(result).toEqual({ value: 0 });
       });
 
       it("returns empty object when scalar root has no rootKey", () => {
@@ -1009,6 +1008,81 @@ describe("traceRequest.utils", () => {
             },
           },
         ]);
+      });
+    });
+
+    /**
+     * Spec: specs/traces/zero-valued-attributes-survive-ingest.feature
+     *
+     * A tracked event's metrics arrive here as numeric attributes, so an
+     * attribute dropped for being zero is a vote, a count or a score that was
+     * accepted and then stored as absent.
+     */
+    describe("when a numeric attribute is zero", () => {
+      /** @scenario "A neutral vote is stored as the value it was sent as" */
+      it("keeps a whole-number zero", () => {
+        const result = TraceRequestUtils.normalizeOtlpAttributes([
+          { key: "event.metrics.vote", value: { intValue: 0 } },
+        ]);
+
+        expect(result["event.metrics.vote"]).toBe(0);
+      });
+
+      /** @scenario "A neutral vote is stored as the value it was sent as" */
+      it("keeps a fractional zero", () => {
+        const result = TraceRequestUtils.normalizeOtlpAttributes([
+          { key: "event.metrics.vote", value: { doubleValue: 0 } },
+        ]);
+
+        expect(result["event.metrics.vote"]).toBe(0);
+      });
+
+      /** @scenario "A zero sent over the wire as text is still a zero" */
+      it("keeps a zero that arrived as text", () => {
+        const result = TraceRequestUtils.normalizeOtlpAttributes([
+          { key: "event.metrics.count", value: { intValue: "0" } },
+          { key: "event.metrics.latency", value: { doubleValue: "0.0" } },
+        ]);
+
+        expect(result["event.metrics.count"]).toBe(0);
+        expect(result["event.metrics.latency"]).toBe(0);
+      });
+
+      /** @scenario "A list of readings keeps the zeroes in it" */
+      it("keeps zeroes inside a list", () => {
+        const result = TraceRequestUtils.normalizeOtlpAttributes([
+          {
+            key: "event.metrics.scores",
+            value: {
+              arrayValue: {
+                values: [
+                  { doubleValue: 0 },
+                  { doubleValue: 0.5 },
+                ] as OtlpAnyValue[],
+              },
+            },
+          },
+        ]);
+
+        expect(result["event.metrics.scores"]).toEqual([0, 0.5]);
+      });
+
+      /** @scenario "An attribute that carries no value at all is still absent" */
+      it("still drops an attribute that carries no value", () => {
+        const result = TraceRequestUtils.normalizeOtlpAttributes([
+          { key: "event.metrics.missing", value: {} as OtlpAnyValue },
+        ]);
+
+        expect(result).not.toHaveProperty("event.metrics.missing");
+      });
+
+      /** @scenario "A neutral vote is stored as the value it was sent as" */
+      it("keeps a non-zero reading untouched", () => {
+        const result = TraceRequestUtils.normalizeOtlpAttributes([
+          { key: "event.metrics.vote", value: { doubleValue: -1 } },
+        ]);
+
+        expect(result["event.metrics.vote"]).toBe(-1);
       });
     });
   });

--- a/platform/app/src/server/event-sourcing/pipelines/trace-processing/utils/__tests__/traceRequest.utils.test.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/trace-processing/utils/__tests__/traceRequest.utils.test.ts
@@ -472,7 +472,7 @@ describe("traceRequest.utils", () => {
         expect(result).toEqual({ flag: false });
       });
 
-      /** @scenario "A neutral vote is stored as the value it was sent as" */
+      /** @scenario "A neutral vote is kept as the value it was sent as" */
       it("keeps intValue 0", () => {
         const result = TraceRequestUtils.normalizeOtlpAnyValue(
           { intValue: 0 },
@@ -482,7 +482,7 @@ describe("traceRequest.utils", () => {
         expect(result).toEqual({ count: 0 });
       });
 
-      /** @scenario "A neutral vote is stored as the value it was sent as" */
+      /** @scenario "A neutral vote is kept as the value it was sent as" */
       it("keeps doubleValue 0", () => {
         const result = TraceRequestUtils.normalizeOtlpAnyValue(
           { doubleValue: 0 },
@@ -492,7 +492,7 @@ describe("traceRequest.utils", () => {
         expect(result).toEqual({ value: 0 });
       });
 
-      /** @scenario "A neutral vote is stored as the value it was sent as" */
+      /** @scenario "A neutral vote is kept as the value it was sent as" */
       it("keeps doubleValue 0.0", () => {
         const result = TraceRequestUtils.normalizeOtlpAnyValue(
           { doubleValue: 0.0 },
@@ -1019,7 +1019,7 @@ describe("traceRequest.utils", () => {
      * accepted and then stored as absent.
      */
     describe("when a numeric attribute is zero", () => {
-      /** @scenario "A neutral vote is stored as the value it was sent as" */
+      /** @scenario "A neutral vote is kept as the value it was sent as" */
       it("keeps a whole-number zero", () => {
         const result = TraceRequestUtils.normalizeOtlpAttributes([
           { key: "event.metrics.vote", value: { intValue: 0 } },
@@ -1028,7 +1028,7 @@ describe("traceRequest.utils", () => {
         expect(result["event.metrics.vote"]).toBe(0);
       });
 
-      /** @scenario "A neutral vote is stored as the value it was sent as" */
+      /** @scenario "A neutral vote is kept as the value it was sent as" */
       it("keeps a fractional zero", () => {
         const result = TraceRequestUtils.normalizeOtlpAttributes([
           { key: "event.metrics.vote", value: { doubleValue: 0 } },
@@ -1076,7 +1076,7 @@ describe("traceRequest.utils", () => {
         expect(result).not.toHaveProperty("event.metrics.missing");
       });
 
-      /** @scenario "A neutral vote is stored as the value it was sent as" */
+      /** @scenario "A neutral vote is kept as the value it was sent as" */
       it("keeps a non-zero reading untouched", () => {
         const result = TraceRequestUtils.normalizeOtlpAttributes([
           { key: "event.metrics.vote", value: { doubleValue: -1 } },

--- a/platform/app/src/server/event-sourcing/pipelines/trace-processing/utils/__tests__/traceRequest.utils.test.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/trace-processing/utils/__tests__/traceRequest.utils.test.ts
@@ -1075,9 +1075,16 @@ describe("traceRequest.utils", () => {
 
         expect(result).not.toHaveProperty("event.metrics.missing");
       });
+    });
 
-      /** @scenario "A neutral vote is kept as the value it was sent as" */
-      it("keeps a non-zero reading untouched", () => {
+    /**
+     * The control for the change above, deliberately unbound: no scenario in
+     * the spec claims it, because a reading that was never at risk is not a
+     * behaviour anyone asked for. It is here so that widening the check to
+     * presence is shown not to have moved anything else.
+     */
+    describe("when a numeric attribute is not zero", () => {
+      it("keeps the reading untouched", () => {
         const result = TraceRequestUtils.normalizeOtlpAttributes([
           { key: "event.metrics.vote", value: { doubleValue: -1 } },
         ]);

--- a/platform/app/src/server/event-sourcing/pipelines/trace-processing/utils/traceRequest.utils.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/trace-processing/utils/traceRequest.utils.ts
@@ -74,7 +74,12 @@ const scalar = (v: OtlpAnyValue): AttributeScalar | undefined => {
     }
     return v.boolValue;
   }
-  if ("intValue" in v && v.intValue) {
+  // `!= null` rather than a truthiness check: zero is a value, and the one a
+  // truthiness check cannot tell apart from an absent attribute. A tracked
+  // event with a vote of 0, a count of 0 or a score of 0 was accepted and then
+  // stored with the metric missing entirely, so downstream it read as an event
+  // carrying no vote rather than a neutral one.
+  if ("intValue" in v && v.intValue != null) {
     if (typeof v.intValue === "string") {
       return parseInt(v.intValue, 10);
     }
@@ -90,7 +95,7 @@ const scalar = (v: OtlpAnyValue): AttributeScalar | undefined => {
     }
     return v.intValue;
   }
-  if ("doubleValue" in v && v.doubleValue) {
+  if ("doubleValue" in v && v.doubleValue != null) {
     if (typeof v.doubleValue === "string") {
       return parseFloat(v.doubleValue);
     }

--- a/specs/traces/zero-valued-attributes-survive-ingest.feature
+++ b/specs/traces/zero-valued-attributes-survive-ingest.feature
@@ -1,0 +1,47 @@
+Feature: A reading of zero survives ingest
+  As someone recording a tracked event against a trace
+  I want a reading of zero to be stored as zero
+  So that a neutral answer is not read back as no answer at all
+
+  # A tracked event's metrics travel as numeric attributes on the span, and
+  # the step that turns an OTLP attribute into a value asked whether the
+  # number was truthy. Zero is not, so the attribute was built, accepted with
+  # a 200, and then dropped on the way to storage — while every other value on
+  # the same path stored fine.
+  #
+  # The vote on a thumbs-up/down event is allowed anywhere between -1 and 1, so
+  # 0 is a legal neutral vote and the only one that could not survive. The same
+  # went for any custom metric that happened to be zero: a count of 0, a
+  # latency of 0, a score of 0. Downstream — filters, the event drilldown,
+  # trigger matching — the event read as carrying nothing rather than carrying
+  # a neutral reading.
+  #
+  # Bindings:
+  #   platform/app/src/server/event-sourcing/pipelines/trace-processing/utils/traceRequest.utils.ts
+  #   platform/app/src/server/event-sourcing/pipelines/trace-processing/utils/__tests__/traceRequest.utils.test.ts
+
+  @unit
+  Scenario: A neutral vote is stored as the value it was sent as
+    Given a tracked event whose reading is zero
+    When the event is ingested
+    Then the stored event carries that reading
+
+  @unit
+  Scenario: A zero sent over the wire as text is still a zero
+    Given a tracked event whose reading arrives as text
+    When the event is ingested
+    Then the stored event carries that reading as a number
+
+  @unit
+  Scenario: A list of readings keeps the zeroes in it
+    Given a tracked event carrying a list of readings, one of them zero
+    When the event is ingested
+    Then the stored list carries every reading it was sent
+
+  # The distinction the truthiness check destroyed, stated the other way
+  # round: an attribute that genuinely carries nothing is still absent.
+  @unit
+  Scenario: An attribute that carries no value at all is still absent
+    Given a tracked event carrying an attribute with no value
+    When the event is ingested
+    Then the stored event does not carry that attribute

--- a/specs/traces/zero-valued-attributes-survive-ingest.feature
+++ b/specs/traces/zero-valued-attributes-survive-ingest.feature
@@ -16,32 +16,41 @@ Feature: A reading of zero survives ingest
   # trigger matching — the event read as carrying nothing rather than carrying
   # a neutral reading.
   #
+  # Scope of what these scenarios observe: the step that turns an incoming
+  # attribute into a value, which every span event's attributes pass through
+  # on the ingest path. They do not replay a write to storage and read it
+  # back, so they establish that the value survives normalization and not
+  # that no later step drops it. That is the whole of the reported loss as
+  # far as it was traced, and it is the step where the loss was found.
+  #
   # Bindings:
   #   platform/app/src/server/event-sourcing/pipelines/trace-processing/utils/traceRequest.utils.ts
   #   platform/app/src/server/event-sourcing/pipelines/trace-processing/utils/__tests__/traceRequest.utils.test.ts
 
   @unit
-  Scenario: A neutral vote is stored as the value it was sent as
-    Given a tracked event whose reading is zero
-    When the event is ingested
-    Then the stored event carries that reading
+  Scenario: A neutral vote is kept as the value it was sent as
+    Given an event attribute whose reading is zero
+    When the attribute is normalized on the way in
+    Then the normalized attributes carry that reading
 
   @unit
   Scenario: A zero sent over the wire as text is still a zero
-    Given a tracked event whose reading arrives as text
-    When the event is ingested
-    Then the stored event carries that reading as a number
+    Given an event attribute whose reading arrives as text
+    When the attribute is normalized on the way in
+    Then the normalized attributes carry that reading as a number
 
+  # Not reachable from the tracked-event endpoint, which sends one number per
+  # metric — this covers the same value arriving on an ordinary span.
   @unit
   Scenario: A list of readings keeps the zeroes in it
-    Given a tracked event carrying a list of readings, one of them zero
-    When the event is ingested
-    Then the stored list carries every reading it was sent
+    Given an attribute carrying a list of readings, one of them zero
+    When the attribute is normalized on the way in
+    Then the normalized list carries every reading it was sent
 
   # The distinction the truthiness check destroyed, stated the other way
   # round: an attribute that genuinely carries nothing is still absent.
   @unit
   Scenario: An attribute that carries no value at all is still absent
-    Given a tracked event carrying an attribute with no value
-    When the event is ingested
-    Then the stored event does not carry that attribute
+    Given an attribute with no value at all
+    When the attribute is normalized on the way in
+    Then the normalized attributes do not carry it


### PR DESCRIPTION
Closes #7869

## For humans

Someone gives a thumbs-up/down on a traced answer. A thumbs-up is `1`, a thumbs-down is `-1`, and sitting on the fence is `0`. The first two were saved. The third was accepted, answered "OK", and then quietly thrown away — so a neutral answer came back looking like no answer at all. The same went for any number that happened to be zero: a count of zero, a score of zero, a duration of zero.

The cause is one of the oldest mistakes there is. The code asked "is there a number here?" by asking "is this number interesting?", and zero is not interesting. It now asks whether the number is *there*.

## What was wrong

A tracked event whose metric value is exactly `0` was accepted with HTTP 200 and stored with that metric missing entirely. The same call with `0.5` or `-1` stored fine, so the loss was specific to zero.

The issue placed it "somewhere between the OTLP attribute construction and the ClickHouse write — most likely a truthiness check treating `0` as absent". It was exactly that, in `scalar()` in `traceRequest.utils.ts`: the whole-number and fractional branches asked whether the value was *truthy*, not whether it was *there*. `scalar()` returning undefined makes the attribute invisible to the flattener, so it never reaches the event's attribute map — and `span-normalization.service.ts` runs every span event's attributes through it.

The boolean branch alongside them already asked the right question (`!== null`), which is why `false` survived and `0` did not. Three existing tests pinned the old behaviour and called it a bug in their own comments.

## Why it matters

`thumbsUpDownSchema` allows a vote anywhere in `[-1, 1]`, so `0` is a legal neutral vote — and it was the one value that could not survive ingest. Downstream (filters, the trace-explorer event drilldown, trigger matching) the event read as carrying no vote at all rather than a neutral one. The same went for any custom metric that happened to be zero: a count of 0, a latency of 0, a score of 0.

## What changed

The two numeric branches ask `!= null` instead of truthiness. An attribute that genuinely carries no value is still dropped.

## Tests

`specs/traces/zero-valued-attributes-survive-ingest.feature`, bound to `traceRequest.utils.test.ts`: a whole-number zero, a fractional zero, a zero that arrived as text, zeroes inside a list, and an attribute with no value at all still absent. A sixth test, deliberately unbound to any scenario, holds a non-zero reading as the control that widening the check did not move anything else.

The three tests that pinned the drop now assert the value survives — the change is load-bearing in both directions: with the fix reverted they fail, and they failed on the first run before the pins were updated.

53 tests in the file, 113 in the utils folder and 2692 across `app-layer/traces` + `trace-processing` pass. `pnpm typecheck`, `pnpm typecheck:all` and the feature-parity check are clean — that spec reports 4/4 scenarios bound, not a vacuous 0/0.

## Is the fix enough on its own

Review asked whether a zero survives the rest of the journey, since the tests stop at the normalization step. The path was read hop by hop, looking for the same shape of mistake:

- the callers — `span-normalization.service.ts` (span, event and link attributes) and `canonicalLog.ts`
- the OTLP schemas — `intValue` is a nullable union with no falsy strip; `normalizedAttributesSchema` is `z.record(z.unknown())` and strips nothing
- canonicalisation and projection — `setAttr`, `attributeBag`, `eventBag` and the span-storage projection all guard on `null`/`undefined` only
- the write — `serializeAttributes` skips only `null`/`undefined`, then `String(0)` gives `"0"`
- the column — `Array(Map(LowCardinality(String), String))`, not Nullable, so `"0"` and an absent key stay different things
- the read-back and its consumers — `deserializeAttributes`, the event-attribute mapper's decimal gate, the trigger matcher and the trace-summary mapper all test `Number.isFinite`, and the query language gives `0` its own "no vote" label

Three truthiness tests do sit on this path, and all three are safe: two filter attribute *objects* rather than their values (`{intValue: 0}` is a truthy object), and the third, `parseFloat(value) || 0` on the event read, returns `0` for a zero anyway.

The same sweep across the other four places that read an OTLP numeric — the tracked-event and evaluation-trigger subscribers, token estimation, and metric canonicalisation — found all of them already presence-based. `scalar()` was the only truthiness one.

## Not covered

Still not replayed through a live ClickHouse write and read-back. The path above was read, not executed end to end.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Zero-valued numeric attributes are now preserved during trace ingestion instead of being treated as missing.
  * Zero values remain intact when sent as numbers, text, or elements within arrays.
  * Attributes without a value continue to remain absent.
* **Tests**
  * Added coverage for zero, negative, missing, and normalized attribute values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->