### PR TITLE
perf(cli-login): the login wait is the round trip, not the poll interval

### DIFF
--- a/platform/app/src/server/routes/__tests__/auth-cli-device-approval.integration.test.ts
+++ b/platform/app/src/server/routes/__tests__/auth-cli-device-approval.integration.test.ts
@@ -214,6 +214,31 @@ describe("CLI device-approval stream", () => {
         expect(heard).toBe("nothing");
       });
 
+      /** @scenario "A publication is lost if the stream has not subscribed yet" */
+      it("is closed by `subscribed`, which resolves only once the channel is live", async () => {
+        const deviceCode = await mintDeviceCode();
+        const abort = new AbortController();
+
+        // The other half of the boundary, and the reason re-reading after
+        // `subscribed` is enough on its own: from that point on, every
+        // publication is heard. So the gap the re-read has to cover is exactly
+        // [the route's first read, `subscribed`], with nothing after it.
+        const watch = waitForDeviceCodeSettled({
+          redis: redisConnection!,
+          deviceCode,
+          signal: abort.signal,
+        });
+        await watch.subscribed;
+        await publishDeviceCodeSettled({
+          redis: redisConnection!,
+          deviceCode,
+          status: "approved",
+        });
+
+        expect(await watch.settled).toBe("approved");
+        abort.abort();
+      });
+
       /** @scenario "The approval stream tells the CLI to poll the moment the browser settles the code" */
       it("emits anyway, because the stream re-reads once its channel is live", async () => {
         const deviceCode = await mintDeviceCode();

--- a/platform/app/src/server/routes/__tests__/auth-cli-device-approval.integration.test.ts
+++ b/platform/app/src/server/routes/__tests__/auth-cli-device-approval.integration.test.ts
@@ -146,6 +146,28 @@ describe("CLI device-approval stream", () => {
       });
     });
 
+    describe("when the code settles while the stream is still subscribing", () => {
+      /** @scenario "The approval stream tells the CLI to poll the moment the browser settles the code" */
+      it("emits anyway, because the stream re-reads once its channel is live", async () => {
+        const deviceCode = await mintDeviceCode();
+
+        // Redis pub/sub keeps nothing for a late subscriber. Approving in the
+        // same tick as the request lands the publication in the window where
+        // the route has read `pending` but has not subscribed yet, which is
+        // the window the re-read exists to cover.
+        const [stream] = await Promise.all([
+          openApprovalStream(deviceCode),
+          approveDeviceCode({
+            deviceCode,
+            userId: USER_ID,
+            organizationId: ORG_ID,
+          }),
+        ]);
+
+        expect(await readFirstFrame(stream)).toBe('{"status":"approved"}');
+      });
+    });
+
     describe("when the code settled before the CLI opened the stream", () => {
       /** @scenario "The approval stream tells the CLI to poll the moment the browser settles the code" */
       it("emits at once rather than holding the connection open", async () => {

--- a/platform/app/src/server/routes/__tests__/auth-cli-device-approval.integration.test.ts
+++ b/platform/app/src/server/routes/__tests__/auth-cli-device-approval.integration.test.ts
@@ -10,7 +10,9 @@
  *     settles the code, and emits one right away for a code already settled.
  *   - `POST /api/auth/cli/exchange` skips its per-device poll window once the
  *     code has settled, so the poll the stream just asked for is answered
- *     instead of being told to slow down.
+ *     instead of being told to slow down, and takes an exclusive redemption
+ *     claim instead, so two polls arriving together still redeem the approval
+ *     once.
  *
  * Spec: specs/ai-gateway/governance/cli-login.feature
  */
@@ -19,6 +21,7 @@ import { nanoid } from "nanoid";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { globalForApp, resetApp } from "~/server/app-layer/app";
 import { createTestApp } from "~/server/app-layer/presets";
+import { prisma } from "~/server/db";
 import {
   startTestContainers,
   stopTestContainers,
@@ -34,12 +37,16 @@ import { app, approveDeviceCode, denyDeviceCode } from "../auth-cli";
 const suffix = nanoid(8);
 const USER_ID = `usr-approval-${suffix}`;
 const ORG_ID = `org-approval-${suffix}`;
+const PROJECT_ID = `proj-approval-${suffix}`;
+const PROJECT_API_KEY = `sk-lw-approval-${suffix}-${"a".repeat(36)}`;
 
-async function mintDeviceCode(): Promise<string> {
+async function mintDeviceCode(
+  request: Record<string, unknown> = {},
+): Promise<string> {
   const res = await app.request("/api/auth/cli/device-code", {
     method: "POST",
     headers: { "content-type": "application/json" },
-    body: JSON.stringify({}),
+    body: JSON.stringify(request),
   });
   if (res.status !== 200) {
     throw new Error(`/device-code answered ${res.status}`);
@@ -107,11 +114,38 @@ describe("CLI device-approval stream", () => {
     ({ redisConnection } = await startTestContainers());
     await resetApp();
     globalForApp.__langwatch_app = createTestApp({ redis: redisConnection });
+
+    // The redemption path re-derives membership from Postgres, so the user and
+    // org the approvals below name have to exist for an exchange to reach 200.
+    await prisma.organization.create({
+      data: {
+        id: ORG_ID,
+        name: `Approval Org ${suffix}`,
+        slug: `approval-${suffix}`,
+      },
+    });
+    await prisma.user.create({
+      data: {
+        id: USER_ID,
+        email: `approval-${suffix}@example.com`,
+        name: `Approval ${suffix}`,
+      },
+    });
+    await prisma.organizationUser.create({
+      data: { userId: USER_ID, organizationId: ORG_ID, role: "ADMIN" },
+    });
   });
 
   afterAll(async () => {
     await resetDeviceApprovalSubscriber().catch(() => {});
     await resetApp();
+    await prisma.organizationUser
+      .deleteMany({ where: { userId: USER_ID, organizationId: ORG_ID } })
+      .catch(() => {});
+    await prisma.user.deleteMany({ where: { id: USER_ID } }).catch(() => {});
+    await prisma.organization
+      .deleteMany({ where: { id: ORG_ID } })
+      .catch(() => {});
     await stopTestContainers().catch(() => {});
   });
 
@@ -151,7 +185,7 @@ describe("CLI device-approval stream", () => {
     });
 
     describe("when the code settles while the stream is still subscribing", () => {
-      /** @scenario "A publication reaches nobody if the stream has not subscribed yet" */
+      /** @scenario "A publication is lost if the stream has not subscribed yet" */
       it("is a window a publication falls into, since pub/sub keeps nothing for a late subscriber", async () => {
         const deviceCode = await mintDeviceCode();
         const abort = new AbortController();
@@ -234,6 +268,44 @@ describe("CLI device-approval stream", () => {
         // Inside the same window, but the code has settled: this is the poll
         // the stream just asked for, and it gets its answer.
         expect((await callExchange(deviceCode)).status).toBe(410);
+      });
+    });
+
+    describe("when two polls for the same approval arrive together", () => {
+      /** @scenario "Two exchanges racing the same approval redeem it once" */
+      it("hands the credential to one of them and tells the other to slow down", async () => {
+        const deviceCode = await mintDeviceCode({
+          credential_type: "project_api_key",
+        });
+        await approveDeviceCode({
+          deviceCode,
+          userId: USER_ID,
+          organizationId: ORG_ID,
+          projectApiKey: {
+            project_id: PROJECT_ID,
+            project_slug: `approval-proj-${suffix}`,
+            project_name: `Approval Project ${suffix}`,
+            api_key: PROJECT_API_KEY,
+          },
+        });
+
+        // A settled code skips the poll window, so nothing else stands between
+        // these two: without the redemption claim both reach the credential.
+        const [first, second] = await Promise.all([
+          callExchange(deviceCode),
+          callExchange(deviceCode),
+        ]);
+
+        expect([first.status, second.status].sort()).toEqual([200, 429]);
+
+        const winner = first.status === 200 ? first : second;
+        const loser = first.status === 200 ? second : first;
+        expect(((await winner.json()) as { api_key: string }).api_key).toBe(
+          PROJECT_API_KEY,
+        );
+        expect(((await loser.json()) as { error: string }).error).toBe(
+          "slow_down",
+        );
       });
     });
   });

--- a/platform/app/src/server/routes/__tests__/auth-cli-device-approval.integration.test.ts
+++ b/platform/app/src/server/routes/__tests__/auth-cli-device-approval.integration.test.ts
@@ -24,7 +24,11 @@ import {
   stopTestContainers,
 } from "~/server/event-sourcing/__tests__/integration/testContainers";
 
-import { resetDeviceApprovalSubscriber } from "../_lib/device-approval-signal";
+import {
+  publishDeviceCodeSettled,
+  resetDeviceApprovalSubscriber,
+  waitForDeviceCodeSettled,
+} from "../_lib/device-approval-signal";
 import { app, approveDeviceCode, denyDeviceCode } from "../auth-cli";
 
 const suffix = nanoid(8);
@@ -147,14 +151,47 @@ describe("CLI device-approval stream", () => {
     });
 
     describe("when the code settles while the stream is still subscribing", () => {
+      /** @scenario "A publication reaches nobody if the stream has not subscribed yet" */
+      it("is a window a publication falls into, since pub/sub keeps nothing for a late subscriber", async () => {
+        const deviceCode = await mintDeviceCode();
+        const abort = new AbortController();
+
+        // The premise the re-read exists for, pinned on its own so it cannot
+        // rot silently: publish first, subscribe after, and the subscriber
+        // hears nothing. Redis has no replay for a channel.
+        await publishDeviceCodeSettled({
+          redis: redisConnection!,
+          deviceCode,
+          status: "approved",
+        });
+        const watch = waitForDeviceCodeSettled({
+          redis: redisConnection!,
+          deviceCode,
+          signal: abort.signal,
+        });
+        await watch.subscribed;
+
+        const heard = await Promise.race([
+          watch.settled,
+          new Promise((resolve) => setTimeout(() => resolve("nothing"), 250)),
+        ]);
+        abort.abort();
+
+        expect(heard).toBe("nothing");
+      });
+
       /** @scenario "The approval stream tells the CLI to poll the moment the browser settles the code" */
       it("emits anyway, because the stream re-reads once its channel is live", async () => {
         const deviceCode = await mintDeviceCode();
 
-        // Redis pub/sub keeps nothing for a late subscriber. Approving in the
-        // same tick as the request lands the publication in the window where
-        // the route has read `pending` but has not subscribed yet, which is
-        // the window the re-read exists to cover.
+        // Dropping the pod's subscriber makes the route open a fresh one, so
+        // its subscribe costs a connection handshake while the approval below
+        // runs on a connection that is already up. That is what puts the
+        // publication in the window between the route's first read and its
+        // subscribe, the window the re-read covers. Losing the race would only
+        // make this test less sensitive, never wrong: the frame is the claim.
+        await resetDeviceApprovalSubscriber();
+
         const [stream] = await Promise.all([
           openApprovalStream(deviceCode),
           approveDeviceCode({

--- a/platform/app/src/server/routes/__tests__/auth-cli-device-approval.integration.test.ts
+++ b/platform/app/src/server/routes/__tests__/auth-cli-device-approval.integration.test.ts
@@ -80,10 +80,13 @@ async function readFirstFrame(res: Response): Promise<string | null> {
 }
 
 /** Wait until the stream handler has actually subscribed to its channel. */
-async function waitForSubscriber(
-  redis: Redis,
-  deviceCode: string,
-): Promise<void> {
+async function waitForSubscriber({
+  redis,
+  deviceCode,
+}: {
+  redis: Redis;
+  deviceCode: string;
+}): Promise<void> {
   const channel = `lwcli:device-settled:${deviceCode}`;
   for (let attempt = 0; attempt < 100; attempt++) {
     const channels = (await redis.pubsub("CHANNELS", channel)) as string[];
@@ -108,69 +111,90 @@ describe("CLI device-approval stream", () => {
     await stopTestContainers().catch(() => {});
   });
 
-  describe("when the browser approves while the CLI is on the stream", () => {
-    /** @scenario "The approval stream tells the CLI to poll the moment the browser settles the code" */
-    it("emits the settled status without waiting for a poll", async () => {
-      const deviceCode = await mintDeviceCode();
-      const stream = await openApprovalStream(deviceCode);
-      expect(stream.status).toBe(200);
-      expect(stream.headers.get("content-type")).toContain("text/event-stream");
+  describe("given a device code the CLI is waiting on", () => {
+    describe("when the browser approves while the CLI is on the stream", () => {
+      /** @scenario "The approval stream tells the CLI to poll the moment the browser settles the code" */
+      it("emits the settled status without waiting for a poll", async () => {
+        const deviceCode = await mintDeviceCode();
+        const stream = await openApprovalStream(deviceCode);
+        expect(stream.status).toBe(200);
+        expect(stream.headers.get("content-type")).toContain(
+          "text/event-stream",
+        );
 
-      await waitForSubscriber(redisConnection!, deviceCode);
-      await approveDeviceCode({
-        deviceCode,
-        userId: USER_ID,
-        organizationId: ORG_ID,
+        await waitForSubscriber({ redis: redisConnection!, deviceCode });
+        await approveDeviceCode({
+          deviceCode,
+          userId: USER_ID,
+          organizationId: ORG_ID,
+        });
+
+        expect(await readFirstFrame(stream)).toBe('{"status":"approved"}');
       });
+    });
 
-      expect(await readFirstFrame(stream)).toBe('{"status":"approved"}');
+    describe("when the browser denies while the CLI is on the stream", () => {
+      /** @scenario "The approval stream tells the CLI to poll the moment the browser settles the code" */
+      it("emits denied, so the CLI stops instead of waiting the code out", async () => {
+        const deviceCode = await mintDeviceCode();
+        const stream = await openApprovalStream(deviceCode);
+
+        await waitForSubscriber({ redis: redisConnection!, deviceCode });
+        await denyDeviceCode(deviceCode);
+
+        expect(await readFirstFrame(stream)).toBe('{"status":"denied"}');
+      });
+    });
+
+    describe("when the code settled before the CLI opened the stream", () => {
+      /** @scenario "The approval stream tells the CLI to poll the moment the browser settles the code" */
+      it("emits at once rather than holding the connection open", async () => {
+        const deviceCode = await mintDeviceCode();
+        await approveDeviceCode({
+          deviceCode,
+          userId: USER_ID,
+          organizationId: ORG_ID,
+        });
+
+        const stream = await openApprovalStream(deviceCode);
+        expect(await readFirstFrame(stream)).toBe('{"status":"approved"}');
+      });
+    });
+
+    describe("when the CLI polls straight after the stream told it to", () => {
+      /** @scenario "A poll on a settled device code is answered, not rate limited" */
+      it("answers the settled code instead of asking it to slow down", async () => {
+        const deviceCode = await mintDeviceCode();
+
+        expect((await callExchange(deviceCode)).status).toBe(428);
+        // Still pending, so the poll window is what a second poll gets.
+        expect((await callExchange(deviceCode)).status).toBe(429);
+
+        await denyDeviceCode(deviceCode);
+
+        // Inside the same window, but the code has settled: this is the poll
+        // the stream just asked for, and it gets its answer.
+        expect((await callExchange(deviceCode)).status).toBe(410);
+      });
     });
   });
 
-  describe("when the code settled before the CLI opened the stream", () => {
-    /** @scenario "The approval stream tells the CLI to poll the moment the browser settles the code" */
-    it("emits at once rather than holding the connection open", async () => {
-      const deviceCode = await mintDeviceCode();
-      await approveDeviceCode({
-        deviceCode,
-        userId: USER_ID,
-        organizationId: ORG_ID,
+  describe("given a request the stream can do nothing for", () => {
+    describe("when the device code is unknown", () => {
+      /** @scenario "The approval stream tells the CLI to poll the moment the browser settles the code" */
+      it("says expired instead of holding a stream nothing will ever settle", async () => {
+        const stream = await openApprovalStream(`missing-${suffix}`);
+        expect(await readFirstFrame(stream)).toBe('{"status":"expired"}');
       });
-
-      const stream = await openApprovalStream(deviceCode);
-      expect(await readFirstFrame(stream)).toBe('{"status":"approved"}');
-    });
-  });
-
-  describe("when the device code is unknown", () => {
-    /** @scenario "The approval stream tells the CLI to poll the moment the browser settles the code" */
-    it("says expired instead of holding a stream nothing will ever settle", async () => {
-      const stream = await openApprovalStream(`missing-${suffix}`);
-      expect(await readFirstFrame(stream)).toBe('{"status":"expired"}');
     });
 
-    it("refuses a request with no device_code", async () => {
-      const res = await app.request("/api/auth/cli/device-approval", {
-        headers: { accept: "text/event-stream" },
+    describe("when no device_code is given", () => {
+      it("refuses the request", async () => {
+        const res = await app.request("/api/auth/cli/device-approval", {
+          headers: { accept: "text/event-stream" },
+        });
+        expect(res.status).toBe(400);
       });
-      expect(res.status).toBe(400);
-    });
-  });
-
-  describe("when the CLI polls straight after the stream told it to", () => {
-    /** @scenario "A poll on a settled device code is answered, not rate limited" */
-    it("answers the settled code instead of asking it to slow down", async () => {
-      const deviceCode = await mintDeviceCode();
-
-      expect((await callExchange(deviceCode)).status).toBe(428);
-      // Still pending, so the poll window is what a second poll gets.
-      expect((await callExchange(deviceCode)).status).toBe(429);
-
-      await denyDeviceCode(deviceCode);
-
-      // Inside the same window, but the code has settled: this is the poll
-      // the stream just asked for, and it gets its answer.
-      expect((await callExchange(deviceCode)).status).toBe(410);
     });
   });
 });

--- a/platform/app/src/server/routes/__tests__/auth-cli-device-approval.integration.test.ts
+++ b/platform/app/src/server/routes/__tests__/auth-cli-device-approval.integration.test.ts
@@ -1,0 +1,176 @@
+/**
+ * @vitest-environment node
+ *
+ * Integration coverage for the device-login latency fix: the CLI used to hear
+ * about an approval only on its next `/exchange` poll, so a login approved in
+ * two seconds still sat on the spinner for the rest of the interval.
+ *
+ * Two server-side halves are exercised here against real Redis:
+ *   - `GET /api/auth/cli/device-approval` emits a frame the moment the browser
+ *     settles the code, and emits one right away for a code already settled.
+ *   - `POST /api/auth/cli/exchange` skips its per-device poll window once the
+ *     code has settled, so the poll the stream just asked for is answered
+ *     instead of being told to slow down.
+ *
+ * Spec: specs/ai-gateway/governance/cli-login.feature
+ */
+import type { Redis } from "ioredis";
+import { nanoid } from "nanoid";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { globalForApp, resetApp } from "~/server/app-layer/app";
+import { createTestApp } from "~/server/app-layer/presets";
+import {
+  startTestContainers,
+  stopTestContainers,
+} from "~/server/event-sourcing/__tests__/integration/testContainers";
+
+import { resetDeviceApprovalSubscriber } from "../_lib/device-approval-signal";
+import { app, approveDeviceCode, denyDeviceCode } from "../auth-cli";
+
+const suffix = nanoid(8);
+const USER_ID = `usr-approval-${suffix}`;
+const ORG_ID = `org-approval-${suffix}`;
+
+async function mintDeviceCode(): Promise<string> {
+  const res = await app.request("/api/auth/cli/device-code", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({}),
+  });
+  if (res.status !== 200) {
+    throw new Error(`/device-code answered ${res.status}`);
+  }
+  const body = (await res.json()) as { device_code: string };
+  return body.device_code;
+}
+
+function callExchange(deviceCode: string) {
+  return app.request("/api/auth/cli/exchange", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ device_code: deviceCode }),
+  });
+}
+
+function openApprovalStream(deviceCode: string) {
+  return app.request(
+    `/api/auth/cli/device-approval?device_code=${encodeURIComponent(deviceCode)}`,
+    { headers: { accept: "text/event-stream" } },
+  );
+}
+
+/** The first frame carrying a payload, or null if the stream ends without one. */
+async function readFirstFrame(res: Response): Promise<string | null> {
+  const reader = (res.body as ReadableStream<Uint8Array>).getReader();
+  const decoder = new TextDecoder();
+  let buffered = "";
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) return null;
+      buffered += decoder.decode(value, { stream: true });
+      const frame = /^data: *(\{.*\})/m.exec(buffered);
+      if (frame) return frame[1] ?? null;
+    }
+  } finally {
+    await reader.cancel().catch(() => {
+      // The stream is already going away.
+    });
+  }
+}
+
+/** Wait until the stream handler has actually subscribed to its channel. */
+async function waitForSubscriber(
+  redis: Redis,
+  deviceCode: string,
+): Promise<void> {
+  const channel = `lwcli:device-settled:${deviceCode}`;
+  for (let attempt = 0; attempt < 100; attempt++) {
+    const channels = (await redis.pubsub("CHANNELS", channel)) as string[];
+    if (channels.includes(channel)) return;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  throw new Error(`the approval stream never subscribed to ${channel}`);
+}
+
+describe("CLI device-approval stream", () => {
+  let redisConnection: Redis | null = null;
+
+  beforeAll(async () => {
+    ({ redisConnection } = await startTestContainers());
+    await resetApp();
+    globalForApp.__langwatch_app = createTestApp({ redis: redisConnection });
+  });
+
+  afterAll(async () => {
+    await resetDeviceApprovalSubscriber().catch(() => {});
+    await resetApp();
+    await stopTestContainers().catch(() => {});
+  });
+
+  describe("when the browser approves while the CLI is on the stream", () => {
+    /** @scenario "The approval stream tells the CLI to poll the moment the browser settles the code" */
+    it("emits the settled status without waiting for a poll", async () => {
+      const deviceCode = await mintDeviceCode();
+      const stream = await openApprovalStream(deviceCode);
+      expect(stream.status).toBe(200);
+      expect(stream.headers.get("content-type")).toContain("text/event-stream");
+
+      await waitForSubscriber(redisConnection!, deviceCode);
+      await approveDeviceCode({
+        deviceCode,
+        userId: USER_ID,
+        organizationId: ORG_ID,
+      });
+
+      expect(await readFirstFrame(stream)).toBe('{"status":"approved"}');
+    });
+  });
+
+  describe("when the code settled before the CLI opened the stream", () => {
+    /** @scenario "The approval stream tells the CLI to poll the moment the browser settles the code" */
+    it("emits at once rather than holding the connection open", async () => {
+      const deviceCode = await mintDeviceCode();
+      await approveDeviceCode({
+        deviceCode,
+        userId: USER_ID,
+        organizationId: ORG_ID,
+      });
+
+      const stream = await openApprovalStream(deviceCode);
+      expect(await readFirstFrame(stream)).toBe('{"status":"approved"}');
+    });
+  });
+
+  describe("when the device code is unknown", () => {
+    /** @scenario "The approval stream tells the CLI to poll the moment the browser settles the code" */
+    it("says expired instead of holding a stream nothing will ever settle", async () => {
+      const stream = await openApprovalStream(`missing-${suffix}`);
+      expect(await readFirstFrame(stream)).toBe('{"status":"expired"}');
+    });
+
+    it("refuses a request with no device_code", async () => {
+      const res = await app.request("/api/auth/cli/device-approval", {
+        headers: { accept: "text/event-stream" },
+      });
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe("when the CLI polls straight after the stream told it to", () => {
+    /** @scenario "A poll on a settled device code is answered, not rate limited" */
+    it("answers the settled code instead of asking it to slow down", async () => {
+      const deviceCode = await mintDeviceCode();
+
+      expect((await callExchange(deviceCode)).status).toBe(428);
+      // Still pending, so the poll window is what a second poll gets.
+      expect((await callExchange(deviceCode)).status).toBe(429);
+
+      await denyDeviceCode(deviceCode);
+
+      // Inside the same window, but the code has settled: this is the poll
+      // the stream just asked for, and it gets its answer.
+      expect((await callExchange(deviceCode)).status).toBe(410);
+    });
+  });
+});

--- a/platform/app/src/server/routes/_lib/device-approval-signal.ts
+++ b/platform/app/src/server/routes/_lib/device-approval-signal.ts
@@ -86,8 +86,8 @@ export async function publishDeviceCodeSettled({
  * `subscribed` resolves once the channel is live, or once it is known that it
  * never will be. It is what lets the caller re-read the record before it
  * commits to waiting: a code settled between the caller's own read and this
- * subscribe published to nobody, and Redis pub/sub keeps nothing for a late
- * subscriber.
+ * subscribe published while the channel had no listener, and Redis pub/sub
+ * keeps nothing for a late subscriber.
  *
  * `settled` resolves with the published status, or with null when the signal
  * aborts first or the subscribe failed.

--- a/platform/app/src/server/routes/_lib/device-approval-signal.ts
+++ b/platform/app/src/server/routes/_lib/device-approval-signal.ts
@@ -1,0 +1,154 @@
+/**
+ * Cross-pod signal that a device-code login has settled.
+ *
+ * `langwatch login --device` learned about an approval only on its next
+ * `/exchange` poll, so a login the user approved in two seconds still sat on
+ * the spinner for the rest of the poll interval. The request that approves or
+ * denies the code publishes here, `GET /api/auth/cli/device-approval` waits on
+ * it, and the CLI polls the moment the frame lands.
+ *
+ * Everything here is best effort. Polling stays the correctness floor, so a
+ * Redis without pub/sub, a proxy that buffers the stream, or a CLI that
+ * predates the route all fall back to it, and no failure in this file may
+ * fail an approval.
+ */
+
+import { createLogger } from "@langwatch/observability";
+import type { Cluster, Redis } from "ioredis";
+
+const logger = createLogger("langwatch:auth-cli");
+
+type RedisConnection = Redis | Cluster;
+
+const CHANNEL_PREFIX = "lwcli:device-settled:";
+
+function channelFor(deviceCode: string): string {
+  return `${CHANNEL_PREFIX}${deviceCode}`;
+}
+
+type Listener = (status: string) => void;
+
+/**
+ * One subscriber shared by every open stream on this pod. Subscriber mode
+ * blocks a connection, so it cannot be the app's own, and a connection per
+ * waiting CLI would scale with logins rather than with pods.
+ */
+let subscriber: RedisConnection | null = null;
+const listeners = new Map<string, Set<Listener>>();
+
+function ensureSubscriber(redis: RedisConnection): RedisConnection | null {
+  if (subscriber) return subscriber;
+  try {
+    const connection = redis.duplicate();
+    connection.on("message", (channel: string, message: string) => {
+      for (const listener of listeners.get(channel) ?? []) listener(message);
+    });
+    connection.on("error", (error: Error) => {
+      logger.debug(
+        { error: error.message },
+        "[auth-cli] device-approval subscriber error; the CLI's own poll still settles the login",
+      );
+    });
+    subscriber = connection;
+    return connection;
+  } catch (error) {
+    logger.debug(
+      { error },
+      "[auth-cli] could not open the device-approval subscriber; the CLI's own poll still settles the login",
+    );
+    return null;
+  }
+}
+
+/** Announce that a device code reached `approved` or `denied`. */
+export async function publishDeviceCodeSettled(
+  redis: RedisConnection,
+  deviceCode: string,
+  status: string,
+): Promise<void> {
+  try {
+    await redis.publish(channelFor(deviceCode), status);
+  } catch (error) {
+    logger.debug(
+      { error },
+      "[auth-cli] could not publish the device-code settlement; the CLI's own poll still settles the login",
+    );
+  }
+}
+
+/**
+ * Resolve with the status the browser published for this device code, or with
+ * null when `signal` aborts first. A subscribe that fails resolves null too,
+ * which drops the stream and leaves the CLI polling.
+ */
+export function waitForDeviceCodeSettled(
+  redis: RedisConnection,
+  deviceCode: string,
+  signal: AbortSignal,
+): Promise<string | null> {
+  const connection = ensureSubscriber(redis);
+  if (!connection) return Promise.resolve(null);
+
+  const channel = channelFor(deviceCode);
+  return new Promise<string | null>((resolve) => {
+    let settled = false;
+    const finish = (status: string | null) => {
+      if (settled) return;
+      settled = true;
+      signal.removeEventListener("abort", onAbort);
+      release(connection, channel, listener);
+      resolve(status);
+    };
+    const listener: Listener = (status) => finish(status);
+    const onAbort = () => finish(null);
+
+    signal.addEventListener("abort", onAbort, { once: true });
+    if (signal.aborted) {
+      finish(null);
+      return;
+    }
+
+    let channelListeners = listeners.get(channel);
+    if (!channelListeners) {
+      channelListeners = new Set();
+      listeners.set(channel, channelListeners);
+    }
+    channelListeners.add(listener);
+
+    void connection.subscribe(channel).catch((error: unknown) => {
+      logger.debug(
+        { error },
+        "[auth-cli] could not subscribe to the device-code settlement; the CLI's own poll still settles the login",
+      );
+      finish(null);
+    });
+  });
+}
+
+function release(
+  connection: RedisConnection,
+  channel: string,
+  listener: Listener,
+): void {
+  const channelListeners = listeners.get(channel);
+  if (!channelListeners) return;
+  channelListeners.delete(listener);
+  if (channelListeners.size > 0) return;
+  listeners.delete(channel);
+  void connection.unsubscribe(channel).catch(() => {
+    // An unsubscribe that fails leaves a channel nothing listens on.
+  });
+}
+
+/** Drop the shared subscriber. Tests use it to release the connection. */
+export async function resetDeviceApprovalSubscriber(): Promise<void> {
+  const connection = subscriber;
+  subscriber = null;
+  listeners.clear();
+  if (!connection) return;
+  try {
+    await connection.quit();
+  } catch {
+    connection.disconnect();
+  }
+}

--- a/platform/app/src/server/routes/_lib/device-approval-signal.ts
+++ b/platform/app/src/server/routes/_lib/device-approval-signal.ts
@@ -81,9 +81,16 @@ export async function publishDeviceCodeSettled({
 }
 
 /**
- * Resolve with the status the browser published for this device code, or with
- * null when `signal` aborts first. A subscribe that fails resolves null too,
- * which drops the stream and leaves the CLI polling.
+ * Watch for the status the browser publishes for this device code.
+ *
+ * `subscribed` resolves once the channel is live, or once it is known that it
+ * never will be. It is what lets the caller re-read the record before it
+ * commits to waiting: a code settled between the caller's own read and this
+ * subscribe published to nobody, and Redis pub/sub keeps nothing for a late
+ * subscriber.
+ *
+ * `settled` resolves with the published status, or with null when the signal
+ * aborts first or the subscribe failed.
  */
 export function waitForDeviceCodeSettled({
   redis,
@@ -94,18 +101,28 @@ export function waitForDeviceCodeSettled({
   deviceCode: string;
   /** Aborts the wait: the stream closed, or the device code ran out of time. */
   signal: AbortSignal;
-}): Promise<string | null> {
+}): { subscribed: Promise<void>; settled: Promise<string | null> } {
   const connection = ensureSubscriber(redis);
-  if (!connection) return Promise.resolve(null);
+  if (!connection) {
+    return { subscribed: Promise.resolve(), settled: Promise.resolve(null) };
+  }
 
   const channel = channelFor(deviceCode);
-  return new Promise<string | null>((resolve) => {
-    let settled = false;
+  let markSubscribed: () => void = () => {
+    // Replaced below, before anything can call it.
+  };
+  const subscribed = new Promise<void>((resolve) => {
+    markSubscribed = resolve;
+  });
+
+  const settled = new Promise<string | null>((resolve) => {
+    let done = false;
     const finish = (status: string | null) => {
-      if (settled) return;
-      settled = true;
+      if (done) return;
+      done = true;
       signal.removeEventListener("abort", onAbort);
       release({ connection, channel, listener });
+      markSubscribed();
       resolve(status);
     };
     const listener: Listener = (status) => finish(status);
@@ -124,14 +141,19 @@ export function waitForDeviceCodeSettled({
     }
     channelListeners.add(listener);
 
-    void connection.subscribe(channel).catch((error: unknown) => {
-      logger.debug(
-        { error },
-        "[auth-cli] could not subscribe to the device-code settlement; the CLI's own poll still settles the login",
-      );
-      finish(null);
-    });
+    connection.subscribe(channel).then(
+      () => markSubscribed(),
+      (error: unknown) => {
+        logger.debug(
+          { error },
+          "[auth-cli] could not subscribe to the device-code settlement; the CLI's own poll still settles the login",
+        );
+        finish(null);
+      },
+    );
   });
+
+  return { subscribed, settled };
 }
 
 function release({

--- a/platform/app/src/server/routes/_lib/device-approval-signal.ts
+++ b/platform/app/src/server/routes/_lib/device-approval-signal.ts
@@ -61,11 +61,15 @@ function ensureSubscriber(redis: RedisConnection): RedisConnection | null {
 }
 
 /** Announce that a device code reached `approved` or `denied`. */
-export async function publishDeviceCodeSettled(
-  redis: RedisConnection,
-  deviceCode: string,
-  status: string,
-): Promise<void> {
+export async function publishDeviceCodeSettled({
+  redis,
+  deviceCode,
+  status,
+}: {
+  redis: RedisConnection;
+  deviceCode: string;
+  status: string;
+}): Promise<void> {
   try {
     await redis.publish(channelFor(deviceCode), status);
   } catch (error) {
@@ -81,11 +85,16 @@ export async function publishDeviceCodeSettled(
  * null when `signal` aborts first. A subscribe that fails resolves null too,
  * which drops the stream and leaves the CLI polling.
  */
-export function waitForDeviceCodeSettled(
-  redis: RedisConnection,
-  deviceCode: string,
-  signal: AbortSignal,
-): Promise<string | null> {
+export function waitForDeviceCodeSettled({
+  redis,
+  deviceCode,
+  signal,
+}: {
+  redis: RedisConnection;
+  deviceCode: string;
+  /** Aborts the wait: the stream closed, or the device code ran out of time. */
+  signal: AbortSignal;
+}): Promise<string | null> {
   const connection = ensureSubscriber(redis);
   if (!connection) return Promise.resolve(null);
 
@@ -96,7 +105,7 @@ export function waitForDeviceCodeSettled(
       if (settled) return;
       settled = true;
       signal.removeEventListener("abort", onAbort);
-      release(connection, channel, listener);
+      release({ connection, channel, listener });
       resolve(status);
     };
     const listener: Listener = (status) => finish(status);
@@ -125,11 +134,15 @@ export function waitForDeviceCodeSettled(
   });
 }
 
-function release(
-  connection: RedisConnection,
-  channel: string,
-  listener: Listener,
-): void {
+function release({
+  connection,
+  channel,
+  listener,
+}: {
+  connection: RedisConnection;
+  channel: string;
+  listener: Listener;
+}): void {
   const channelListeners = listeners.get(channel);
   if (!channelListeners) return;
   channelListeners.delete(listener);

--- a/platform/app/src/server/routes/auth-cli.ts
+++ b/platform/app/src/server/routes/auth-cli.ts
@@ -1098,6 +1098,17 @@ const APPROVAL_KEEPALIVE_MS = 15_000;
 const MAX_OPEN_APPROVAL_STREAMS = 512;
 let openApprovalStreams = 0;
 
+/** The device code's status once it has settled, or null while it is pending. */
+async function readDeviceCodeStatus(
+  redis: ReturnType<typeof getRedis>,
+  deviceCode: string,
+): Promise<string | null> {
+  const raw = await redis.get(deviceCodeKey(deviceCode));
+  if (!raw) return "expired";
+  const status = (JSON.parse(raw) as DeviceCodeRecord).status;
+  return status === "pending" ? null : status;
+}
+
 /**
  * Tell the CLI the moment its device code settles, so `langwatch login` does
  * not sit on the spinner until its next scheduled poll.
@@ -1165,11 +1176,20 @@ secured.access(CLI_POLICY).get("/device-approval", async (c: Context) => {
     }, APPROVAL_KEEPALIVE_MS);
 
     try {
-      const status = await waitForDeviceCodeSettled({
+      const watch = waitForDeviceCodeSettled({
         redis,
         deviceCode,
         signal: controller.signal,
       });
+      await watch.subscribed;
+
+      // Redis pub/sub keeps nothing for a late subscriber, so a code settled
+      // between the read above and that subscribe published to no one. Read it
+      // once more now that the channel is live: from here on, either the
+      // record already says so or the publication reaches us.
+      const status =
+        (await readDeviceCodeStatus(redis, deviceCode)) ??
+        (await watch.settled);
       if (status) {
         await stream.writeSSE({ data: JSON.stringify({ status }) });
       }

--- a/platform/app/src/server/routes/auth-cli.ts
+++ b/platform/app/src/server/routes/auth-cli.ts
@@ -1090,6 +1090,15 @@ secured.access(CLI_POLICY).post("/exchange", async (c: Context) => {
 const APPROVAL_KEEPALIVE_MS = 15_000;
 
 /**
+ * How many approval streams one pod holds open at once. Minting a device code
+ * takes no credential, so without a ceiling anyone could park a connection, a
+ * pair of timers and a Redis subscription per code they mint. Past the ceiling
+ * the route refuses, and a CLI that gets nothing polls the way it always did.
+ */
+const MAX_OPEN_APPROVAL_STREAMS = 512;
+let openApprovalStreams = 0;
+
+/**
  * Tell the CLI the moment its device code settles, so `langwatch login` does
  * not sit on the spinner until its next scheduled poll.
  *
@@ -1118,6 +1127,18 @@ secured.access(CLI_POLICY).get("/device-approval", async (c: Context) => {
   const raw = await redis.get(deviceCodeKey(deviceCode));
   const record = raw ? (JSON.parse(raw) as DeviceCodeRecord) : null;
   const deadline = record?.expires_at ?? Date.now();
+  const wouldWait = record?.status === "pending" && Date.now() <= deadline;
+
+  if (wouldWait && openApprovalStreams >= MAX_OPEN_APPROVAL_STREAMS) {
+    return c.json(
+      {
+        error: "temporarily_unavailable",
+        error_description:
+          "Too many approval streams are open. Poll /exchange at the interval you were given.",
+      },
+      503,
+    );
+  }
 
   return streamSSE(c, async (stream) => {
     // An already-settled code (or one Redis no longer holds) needs no wait:
@@ -1129,6 +1150,7 @@ secured.access(CLI_POLICY).get("/device-approval", async (c: Context) => {
       return;
     }
 
+    openApprovalStreams++;
     const controller = new AbortController();
     const closeOnDeadline = setTimeout(
       () => controller.abort(),
@@ -1143,11 +1165,11 @@ secured.access(CLI_POLICY).get("/device-approval", async (c: Context) => {
     }, APPROVAL_KEEPALIVE_MS);
 
     try {
-      const status = await waitForDeviceCodeSettled(
+      const status = await waitForDeviceCodeSettled({
         redis,
         deviceCode,
-        controller.signal,
-      );
+        signal: controller.signal,
+      });
       if (status) {
         await stream.writeSSE({ data: JSON.stringify({ status }) });
       }
@@ -1160,6 +1182,7 @@ secured.access(CLI_POLICY).get("/device-approval", async (c: Context) => {
       clearInterval(keepalive);
       clearTimeout(closeOnDeadline);
       controller.abort();
+      openApprovalStreams--;
     }
   });
 });
@@ -3216,7 +3239,7 @@ export async function approveDeviceCode({
     "EX",
     remainingSeconds,
   );
-  await publishDeviceCodeSettled(redis, deviceCode, "approved");
+  await publishDeviceCodeSettled({ redis, deviceCode, status: "approved" });
   return { approved: true };
 }
 
@@ -3237,5 +3260,5 @@ export async function denyDeviceCode(deviceCode: string): Promise<void> {
     "EX",
     Math.ceil(remainingMs / 1000),
   );
-  await publishDeviceCodeSettled(redis, deviceCode, "denied");
+  await publishDeviceCodeSettled({ redis, deviceCode, status: "denied" });
 }

--- a/platform/app/src/server/routes/auth-cli.ts
+++ b/platform/app/src/server/routes/auth-cli.ts
@@ -163,6 +163,13 @@ const REFRESH_TOKEN_TTL_SECONDS = positiveIntFromEnv(
 );
 /** Min seconds between successive /exchange polls per device_code. */
 const POLL_RATE_LIMIT_SECONDS = 4;
+/**
+ * How long one /exchange holds the exclusive redemption claim on an approved
+ * device code. Long enough to cover the Prisma reads, the personal-workspace
+ * ensure and the login-key mint the redemption does; short enough that an
+ * unexpected throw before the release frees the code well inside its TTL.
+ */
+const EXCHANGE_CLAIM_SECONDS = 30;
 
 const DEVICE_CODE_PREFIX = "lwcli:device:"; // Redis key prefix for device-code records
 const REFRESH_TOKEN_PREFIX = "lwcli:refresh:"; // Redis key prefix for refresh-token records
@@ -368,6 +375,16 @@ async function validateAccessToken(
 
 function pollRateKey(deviceCode: string): string {
   return `${POLL_RATE_PREFIX}${deviceCode}`;
+}
+
+/**
+ * Redemption claim for an approved device code. A settled code skips the
+ * poll-rate window, so this claim is what serialises concurrent /exchange
+ * calls on the approved branch: one request redeems the code, the rest get
+ * the same slow_down the window would have given them.
+ */
+function deviceExchangeClaimKey(deviceCode: string): string {
+  return `${DEVICE_CODE_PREFIX}claim:${deviceCode}`;
 }
 
 function getRedis() {
@@ -762,6 +779,35 @@ secured.access(CLI_POLICY).post("/exchange", async (c: Context) => {
       );
     }
 
+    // Exclusive redemption. Everything below hands out a credential the
+    // device code is only supposed to buy once: the project-key branch
+    // returns the project apiKey, the device-session branch mints an ApiKey
+    // and a token pair, and the mint revokes the previous login key for the
+    // same device label. Two concurrent exchanges both reaching that would
+    // hand out two sets and let the second revoke the first's key, so the
+    // approved branch is entered by one request at a time. The loser gets
+    // the same slow_down a too-fast poll gets, which the CLI already
+    // retries, and the winner deletes the device code on every path that
+    // consumes it.
+    const claimKey = deviceExchangeClaimKey(device_code);
+    const claimed = await redis.set(
+      claimKey,
+      "1",
+      "EX",
+      EXCHANGE_CLAIM_SECONDS,
+      "NX",
+    );
+    if (claimed !== "OK") {
+      return c.json(
+        {
+          error: "slow_down",
+          error_description:
+            "Polling too fast. Increase your interval before retrying.",
+        },
+        429,
+      );
+    }
+
     // Look up user + org details for the response payload. We only fetch
     // the fields the CLI actually needs to print on success.
     const user = await prisma.user.findUnique({
@@ -776,6 +822,9 @@ secured.access(CLI_POLICY).post("/exchange", async (c: Context) => {
       logger.error(
         `[auth-cli] approved device_code refers to missing user (${record.user_id}) or org (${record.organization_id})`,
       );
+      // Nothing was consumed, so the code stays redeemable for whatever
+      // retry the CLI makes next.
+      await redis.del(claimKey);
       return c.json(
         {
           error: "server_error",
@@ -827,6 +876,7 @@ secured.access(CLI_POLICY).post("/exchange", async (c: Context) => {
         logger.warn(
           `[auth-cli] approved project_api_key device_code ${device_code} missing project payload — returning pending`,
         );
+        await redis.del(claimKey);
         return c.json(
           {
             error: "authorization_pending",
@@ -960,6 +1010,7 @@ secured.access(CLI_POLICY).post("/exchange", async (c: Context) => {
             410,
           );
         }
+        await redis.del(claimKey);
         throw err;
       }
       cliApiKey = minted.token;

--- a/platform/app/src/server/routes/auth-cli.ts
+++ b/platform/app/src/server/routes/auth-cli.ts
@@ -1099,10 +1099,13 @@ const MAX_OPEN_APPROVAL_STREAMS = 512;
 let openApprovalStreams = 0;
 
 /** The device code's status once it has settled, or null while it is pending. */
-async function readDeviceCodeStatus(
-  redis: ReturnType<typeof getRedis>,
-  deviceCode: string,
-): Promise<string | null> {
+async function readDeviceCodeStatus({
+  redis,
+  deviceCode,
+}: {
+  redis: ReturnType<typeof getRedis>;
+  deviceCode: string;
+}): Promise<string | null> {
   const raw = await redis.get(deviceCodeKey(deviceCode));
   if (!raw) return "expired";
   const status = (JSON.parse(raw) as DeviceCodeRecord).status;
@@ -1188,7 +1191,7 @@ secured.access(CLI_POLICY).get("/device-approval", async (c: Context) => {
       // once more now that the channel is live: from here on, either the
       // record already says so or the publication reaches us.
       const status =
-        (await readDeviceCodeStatus(redis, deviceCode)) ??
+        (await readDeviceCodeStatus({ redis, deviceCode })) ??
         (await watch.settled);
       if (status) {
         await stream.writeSSE({ data: JSON.stringify({ status }) });

--- a/platform/app/src/server/routes/auth-cli.ts
+++ b/platform/app/src/server/routes/auth-cli.ts
@@ -48,6 +48,7 @@ import { PLATFORM_TOOL_SLUG_BY_SOURCE_TYPE } from "@ee/governance/services/platf
 import { GovernanceSetupStateService } from "@ee/governance/services/setupState.service";
 import { createLogger } from "@langwatch/observability";
 import type { Context } from "hono";
+import { streamSSE } from "hono/streaming";
 import { z } from "zod";
 import { env } from "~/env.mjs";
 import {
@@ -74,6 +75,10 @@ import { NOT_TARGETED } from "~/server/featureFlag/targeting";
 import { GatewayBudgetService } from "~/server/gateway/budget.service";
 import { BudgetOverviewService } from "~/server/gateway/budgetOverview.service";
 import { resolveSupportContact } from "~/server/organizations/resolveSupportContact";
+import {
+  publishDeviceCodeSettled,
+  waitForDeviceCodeSettled,
+} from "./_lib/device-approval-signal";
 
 const logger = createLogger("langwatch:auth-cli");
 
@@ -659,29 +664,37 @@ secured.access(CLI_POLICY).post("/exchange", async (c: Context) => {
 
   const { device_code } = parsed.data;
 
+  const raw = await redis.get(deviceCodeKey(device_code));
+  const settledEarly =
+    raw !== null && (JSON.parse(raw) as DeviceCodeRecord).status !== "pending";
+
   // Per-device polling rate-limit. RFC 8628 says clients respect the
   // server-issued interval but defensive servers must enforce it too.
   // We use SET NX EX — first call writes the key with TTL, subsequent
-  // calls within window see existing key and get rejected.
-  const setResult = await redis.set(
-    pollRateKey(device_code),
-    "1",
-    "EX",
-    POLL_RATE_LIMIT_SECONDS,
-    "NX",
-  );
-  if (setResult !== "OK") {
-    return c.json(
-      {
-        error: "slow_down",
-        error_description:
-          "Polling too fast. Increase your interval before retrying.",
-      },
-      429,
+  // calls within window see existing key and get rejected. A code that has
+  // already been approved or denied skips the window: that poll is the one
+  // `/device-approval` just told the CLI to make, and answering it with
+  // slow_down would put back the wait the stream exists to remove.
+  if (!settledEarly) {
+    const setResult = await redis.set(
+      pollRateKey(device_code),
+      "1",
+      "EX",
+      POLL_RATE_LIMIT_SECONDS,
+      "NX",
     );
+    if (setResult !== "OK") {
+      return c.json(
+        {
+          error: "slow_down",
+          error_description:
+            "Polling too fast. Increase your interval before retrying.",
+        },
+        429,
+      );
+    }
   }
 
-  const raw = await redis.get(deviceCodeKey(device_code));
   if (!raw) {
     // Either the device_code never existed or it expired and Redis evicted it.
     // RFC 8628 recommends `expired_token` here.
@@ -1067,6 +1080,88 @@ secured.access(CLI_POLICY).post("/exchange", async (c: Context) => {
     { error: "server_error", error_description: "Unknown device code state" },
     500,
   );
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/auth/cli/device-approval
+// ---------------------------------------------------------------------------
+
+/** How often the stream writes a comment so proxies keep it open. */
+const APPROVAL_KEEPALIVE_MS = 15_000;
+
+/**
+ * Tell the CLI the moment its device code settles, so `langwatch login` does
+ * not sit on the spinner until its next scheduled poll.
+ *
+ * The device_code is the credential, exactly as it is on `/exchange`, and the
+ * stream carries no session material: the CLI still has to POST `/exchange` to
+ * get its tokens. That keeps this route a latency fix rather than a second way
+ * to authenticate.
+ *
+ * The stream is an accelerator, never the contract. It ends on the first
+ * settle, on the device code's own deadline, or when the client disconnects,
+ * and a CLI that never reaches it just polls at the interval it was given.
+ */
+secured.access(CLI_POLICY).get("/device-approval", async (c: Context) => {
+  const redis = getRedis();
+  const deviceCode = c.req.query("device_code");
+  if (!deviceCode) {
+    return c.json(
+      {
+        error: "invalid_request",
+        error_description: "device_code is required",
+      },
+      400,
+    );
+  }
+
+  const raw = await redis.get(deviceCodeKey(deviceCode));
+  const record = raw ? (JSON.parse(raw) as DeviceCodeRecord) : null;
+  const deadline = record?.expires_at ?? Date.now();
+
+  return streamSSE(c, async (stream) => {
+    // An already-settled code (or one Redis no longer holds) needs no wait:
+    // the CLI's next poll is the one that matters and it can make it now.
+    if (record?.status !== "pending" || Date.now() > deadline) {
+      await stream.writeSSE({
+        data: JSON.stringify({ status: record?.status ?? "expired" }),
+      });
+      return;
+    }
+
+    const controller = new AbortController();
+    const closeOnDeadline = setTimeout(
+      () => controller.abort(),
+      Math.max(1000, deadline - Date.now()),
+    );
+    stream.onAbort(() => controller.abort());
+
+    const keepalive = setInterval(() => {
+      void stream.writeSSE({ data: "", event: "ping" }).catch(() => {
+        controller.abort();
+      });
+    }, APPROVAL_KEEPALIVE_MS);
+
+    try {
+      const status = await waitForDeviceCodeSettled(
+        redis,
+        deviceCode,
+        controller.signal,
+      );
+      if (status) {
+        await stream.writeSSE({ data: JSON.stringify({ status }) });
+      }
+    } catch (error) {
+      logger.debug(
+        { error },
+        "[auth-cli] device-approval stream ended early; the CLI's own poll still settles the login",
+      );
+    } finally {
+      clearInterval(keepalive);
+      clearTimeout(closeOnDeadline);
+      controller.abort();
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -3121,6 +3216,7 @@ export async function approveDeviceCode({
     "EX",
     remainingSeconds,
   );
+  await publishDeviceCodeSettled(redis, deviceCode, "approved");
   return { approved: true };
 }
 
@@ -3141,4 +3237,5 @@ export async function denyDeviceCode(deviceCode: string): Promise<void> {
     "EX",
     Math.ceil(remainingMs / 1000),
   );
+  await publishDeviceCodeSettled(redis, deviceCode, "denied");
 }

--- a/sdks/typescript/src/cli/utils/governance/__tests__/device-flow.unit.test.ts
+++ b/sdks/typescript/src/cli/utils/governance/__tests__/device-flow.unit.test.ts
@@ -167,38 +167,140 @@ describe("exchange", () => {
 });
 
 describe("pollUntilDone", () => {
+  const deviceCode = {
+    device_code: "DC",
+    user_code: "u",
+    verification_uri: "http://x/cli/auth",
+    expires_in: 60,
+    interval: 0.05,
+  } as any;
+
+  const sessionBody = {
+    access_token: "at",
+    refresh_token: "rt",
+    expires_in: 3600,
+    user: { id: "u", email: "j@x", name: "J" },
+    organization: { id: "o", slug: "x", name: "X" },
+  };
+
+  /** An approval stream that emits one settle frame and stays open. */
+  const approvalFrame = () =>
+    new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(
+            new TextEncoder().encode('data: {"status":"approved"}\n\n'),
+          );
+        },
+      }),
+      { status: 200, headers: { "Content-Type": "text/event-stream" } },
+    );
+
+  /**
+   * A fetch that answers /exchange from `exchanges` in order and gives the
+   * approval stream whatever `approval` returns. Counts only the polls: the
+   * stream is an accelerator, not part of the poll contract.
+   */
+  function routedFetch({
+    exchanges,
+    approval = () => emptyResponse(404),
+  }: {
+    exchanges: Array<() => Response>;
+    approval?: () => Response;
+  }) {
+    const polls: string[] = [];
+    const fetchImpl = vi.fn().mockImplementation((url: string) => {
+      if (String(url).includes("/device-approval")) {
+        return Promise.resolve(approval());
+      }
+      polls.push(String(url));
+      const next =
+        exchanges[polls.length - 1] ?? exchanges[exchanges.length - 1];
+      return Promise.resolve(next!());
+    });
+    return { fetchImpl, polls };
+  }
+
   it("retries on pending, returns on success", async () => {
-    let calls = 0;
-    const fetchImpl = vi.fn().mockImplementation(() => {
-      calls++;
-      if (calls < 2) return Promise.resolve(emptyResponse(428));
-      return Promise.resolve(
-        jsonResponse(200, {
-          access_token: "at",
-          refresh_token: "rt",
-          expires_in: 3600,
-          user: { id: "u", email: "j@x", name: "J" },
-          organization: { id: "o", slug: "x", name: "X" },
-        }),
-      );
+    const { fetchImpl, polls } = routedFetch({
+      exchanges: [
+        () => emptyResponse(428),
+        () => jsonResponse(200, sessionBody),
+      ],
     });
     const r = await pollUntilDone(
       { baseUrl: "http://x", fetchImpl },
-      { device_code: "DC", user_code: "u", verification_uri: "http://x/cli/auth", expires_in: 60, interval: 0.05 } as any,
+      deviceCode,
     );
     expect(r.kind).toBe("device_session");
     if (r.kind !== "device_session") throw new Error("unreachable");
     expect(r.access_token).toBe("at");
-    expect(calls).toBe(2);
+    expect(polls).toHaveLength(2);
+  });
+
+  /** @scenario "The CLI asks once before it starts waiting" */
+  it("polls before the first wait", async () => {
+    const { fetchImpl, polls } = routedFetch({
+      exchanges: [() => jsonResponse(200, sessionBody)],
+    });
+
+    const started = Date.now();
+    await pollUntilDone(
+      { baseUrl: "http://x", fetchImpl },
+      { ...deviceCode, interval: 30 },
+    );
+
+    expect(polls).toHaveLength(1);
+    expect(Date.now() - started).toBeLessThan(1000);
+  });
+
+  /** @scenario "The approval stream cuts the wait short" */
+  it("polls as soon as the approval stream emits", async () => {
+    const { fetchImpl, polls } = routedFetch({
+      exchanges: [
+        () => emptyResponse(428),
+        () => jsonResponse(200, sessionBody),
+      ],
+      approval: approvalFrame,
+    });
+
+    const started = Date.now();
+    const r = await pollUntilDone(
+      { baseUrl: "http://x", fetchImpl },
+      { ...deviceCode, interval: 30 },
+    );
+
+    expect(r.kind).toBe("device_session");
+    expect(polls).toHaveLength(2);
+    // Two polls at a 30s interval, finished in a fraction of one of them.
+    expect(Date.now() - started).toBeLessThan(5000);
+  });
+
+  /** @scenario "A server without the approval stream still logs in" */
+  it("falls back to the interval when the stream is unavailable", async () => {
+    const { fetchImpl, polls } = routedFetch({
+      exchanges: [
+        () => emptyResponse(428),
+        () => jsonResponse(200, sessionBody),
+      ],
+      approval: () => emptyResponse(404),
+    });
+
+    const started = Date.now();
+    await pollUntilDone(
+      { baseUrl: "http://x", fetchImpl },
+      { ...deviceCode, interval: 0.2 },
+    );
+
+    expect(polls).toHaveLength(2);
+    // The second poll waited the interval out rather than firing at once.
+    expect(Date.now() - started).toBeGreaterThanOrEqual(150);
   });
 
   it("propagates denied without retrying further", async () => {
     const fetchImpl = vi.fn().mockResolvedValue(emptyResponse(410));
     await expect(
-      pollUntilDone(
-        { baseUrl: "http://x", fetchImpl },
-        { device_code: "DC", user_code: "u", verification_uri: "http://x/cli/auth", expires_in: 60, interval: 0.05 } as any,
-      ),
+      pollUntilDone({ baseUrl: "http://x", fetchImpl }, deviceCode),
     ).rejects.toMatchObject({ kind: "denied" });
   });
 });

--- a/sdks/typescript/src/cli/utils/governance/__tests__/device-flow.unit.test.ts
+++ b/sdks/typescript/src/cli/utils/governance/__tests__/device-flow.unit.test.ts
@@ -297,6 +297,54 @@ describe("pollUntilDone", () => {
     expect(Date.now() - started).toBeGreaterThanOrEqual(150);
   });
 
+  /** @scenario "An approval that lands during a poll still cuts the next wait short" */
+  it("polls at once when the frame landed while the previous poll was in flight", async () => {
+    const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
+    // Held in an object so the stream's `start` can hand the emitter back out.
+    const frame: { emit: (() => void) | null } = { emit: null };
+    const approval = () =>
+      new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            frame.emit = () =>
+              controller.enqueue(
+                new TextEncoder().encode('data: {"status":"approved"}\n\n'),
+              );
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "text/event-stream" } },
+      );
+
+    const pollTimes: number[] = [];
+    let firstPollReturnedAt = 0;
+    const fetchImpl = vi.fn().mockImplementation(async (url: string) => {
+      if (String(url).includes("/device-approval")) return approval();
+      pollTimes.push(Date.now());
+      if (pollTimes.length > 2) return jsonResponse(200, sessionBody);
+      if (pollTimes.length === 1) {
+        // The browser settles the code while this poll is still in flight,
+        // the window in which the wakeup has no wait to cut short yet.
+        for (let i = 0; i < 50 && !frame.emit; i++) await tick();
+        frame.emit?.();
+        for (let i = 0; i < 50; i++) await tick();
+        firstPollReturnedAt = Date.now();
+      }
+      return emptyResponse(428);
+    });
+
+    const r = await pollUntilDone(
+      { baseUrl: "http://x", fetchImpl },
+      { ...deviceCode, interval: 0.2 },
+    );
+
+    expect(r.kind).toBe("device_session");
+    expect(pollTimes).toHaveLength(3);
+    // The frame is what sends the second poll out, so it does not wait.
+    expect(pollTimes[1]! - firstPollReturnedAt).toBeLessThan(150);
+    // And it is spent by that poll: the third one waits the interval again.
+    expect(pollTimes[2]! - pollTimes[1]!).toBeGreaterThanOrEqual(150);
+  });
+
   it("propagates denied without retrying further", async () => {
     const fetchImpl = vi.fn().mockResolvedValue(emptyResponse(410));
     await expect(

--- a/sdks/typescript/src/cli/utils/governance/device-flow.ts
+++ b/sdks/typescript/src/cli/utils/governance/device-flow.ts
@@ -243,9 +243,104 @@ export async function exchange(
 }
 
 /**
- * Poll `exchange` at the cadence the server requested until the user
- * approves, denies, or the device-code expires. Honours RFC 8628 §3.5
- * by doubling the polling interval on `slow_down` responses.
+ * `GET /api/auth/cli/device-approval` — a stream that emits one frame the
+ * moment the browser approves or denies the code. It carries no credential;
+ * it only says "poll now", which is what turns the wait from "up to the poll
+ * interval" into "as fast as the round trip".
+ *
+ * Resolves when a frame arrives, and never otherwise: a server that predates
+ * the route, a proxy that buffers the body, or a dropped connection all leave
+ * the poll timer in charge rather than making it fire early.
+ */
+function watchDeviceApproval(
+  opts: DeviceFlowOptions,
+  deviceCode: string,
+): { settled: Promise<void>; close: () => void } {
+  const controller = new AbortController();
+  const settled = new Promise<void>((resolve) => {
+    readApprovalStream(opts, deviceCode, controller.signal).then(
+      (sawFrame) => {
+        if (sawFrame) resolve();
+      },
+      () => {
+        // Never settles: polling stays in charge.
+      },
+    );
+  });
+  return { settled, close: () => controller.abort() };
+}
+
+/** Whether the approval stream delivered a frame before it ended. */
+async function readApprovalStream(
+  opts: DeviceFlowOptions,
+  deviceCode: string,
+  signal: AbortSignal,
+): Promise<boolean> {
+  const base = normalizeEndpoint(opts.baseUrl);
+  const f = opts.fetchImpl ?? fetch;
+  const res = await f(
+    `${base}/api/auth/cli/device-approval?device_code=${encodeURIComponent(deviceCode)}`,
+    {
+      headers: { Accept: "text/event-stream", Origin: base },
+      signal,
+    },
+  );
+  if (!res.ok || !res.body) return false;
+
+  const reader = (
+    res.body as ReadableStream<Uint8Array>
+  ).getReader();
+  const decoder = new TextDecoder();
+  let buffered = "";
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) return false;
+      buffered += decoder.decode(value, { stream: true });
+      // Any data frame means "the code settled, poll now". The payload does
+      // not decide anything: /exchange is what says approved or denied.
+      if (/^data:.*\S/m.test(buffered)) return true;
+    }
+  } finally {
+    void reader.cancel().catch(() => {
+      // The stream is already going away.
+    });
+  }
+}
+
+/** Sleep, cut short by the approval signal when one is still worth racing. */
+async function waitForNextPoll(
+  ms: number,
+  approval: Promise<void> | null,
+): Promise<void> {
+  if (!approval) {
+    await wait(ms);
+    return;
+  }
+  const timer = new AbortController();
+  try {
+    await Promise.race([
+      wait(ms, undefined, { signal: timer.signal }).catch(() => {
+        // Aborted because the approval landed first.
+      }),
+      approval,
+    ]);
+  } finally {
+    timer.abort();
+  }
+}
+
+/**
+ * Poll `exchange` until the user approves, denies, or the device-code
+ * expires. Honours RFC 8628 §3.5 by doubling the polling interval on
+ * `slow_down` responses.
+ *
+ * Two things keep the wait short. The first poll goes out immediately, since
+ * a login approved while the browser was still opening should not cost a
+ * whole interval; and the approval stream cuts every later wait short the
+ * moment the browser settles the code. Both are accelerators over the same
+ * timer, so a server or network that supports neither still logs in at the
+ * cadence the server asked for.
  */
 export async function pollUntilDone(
   opts: DeviceFlowOptions,
@@ -255,22 +350,39 @@ export async function pollUntilDone(
   const ceiling = 60_000;
   const deadline = Date.now() + dc.expires_in * 1000;
 
-  for (;;) {
-    if (Date.now() > deadline) {
-      throw new DeviceFlowError("expired", "authorization request expired");
-    }
-    await wait(interval);
-    try {
-      return await exchange(opts, dc.device_code);
-    } catch (err) {
-      if (!(err instanceof DeviceFlowError)) throw err;
-      if (err.kind === "pending") continue;
-      if (err.kind === "slow_down") {
-        interval = Math.min(interval * 2, ceiling);
-        continue;
+  const watch = watchDeviceApproval(opts, dc.device_code);
+  let approval: Promise<void> | null = watch.settled;
+  // A signal fires once. Racing a resolved promise every round would turn the
+  // loop into a hot poll if /exchange somehow still answered `pending`.
+  void watch.settled.then(() => {
+    approval = null;
+  });
+
+  try {
+    let firstPoll = true;
+    for (;;) {
+      if (Date.now() > deadline) {
+        throw new DeviceFlowError("expired", "authorization request expired");
       }
-      throw err;
+      if (firstPoll) {
+        firstPoll = false;
+      } else {
+        await waitForNextPoll(interval, approval);
+      }
+      try {
+        return await exchange(opts, dc.device_code);
+      } catch (err) {
+        if (!(err instanceof DeviceFlowError)) throw err;
+        if (err.kind === "pending") continue;
+        if (err.kind === "slow_down") {
+          interval = Math.min(interval * 2, ceiling);
+          continue;
+        }
+        throw err;
+      }
     }
+  } finally {
+    watch.close();
   }
 }
 

--- a/sdks/typescript/src/cli/utils/governance/device-flow.ts
+++ b/sdks/typescript/src/cli/utils/governance/device-flow.ts
@@ -252,13 +252,16 @@ export async function exchange(
  * the route, a proxy that buffers the body, or a dropped connection all leave
  * the poll timer in charge rather than making it fire early.
  */
-function watchDeviceApproval(
-  opts: DeviceFlowOptions,
-  deviceCode: string,
-): { settled: Promise<void>; close: () => void } {
+function watchDeviceApproval({
+  opts,
+  deviceCode,
+}: {
+  opts: DeviceFlowOptions;
+  deviceCode: string;
+}): { settled: Promise<void>; close: () => void } {
   const controller = new AbortController();
   const settled = new Promise<void>((resolve) => {
-    readApprovalStream(opts, deviceCode, controller.signal).then(
+    readApprovalStream({ opts, deviceCode, signal: controller.signal }).then(
       (sawFrame) => {
         if (sawFrame) resolve();
       },
@@ -271,11 +274,16 @@ function watchDeviceApproval(
 }
 
 /** Whether the approval stream delivered a frame before it ended. */
-async function readApprovalStream(
-  opts: DeviceFlowOptions,
-  deviceCode: string,
-  signal: AbortSignal,
-): Promise<boolean> {
+async function readApprovalStream({
+  opts,
+  deviceCode,
+  signal,
+}: {
+  opts: DeviceFlowOptions;
+  deviceCode: string;
+  /** Aborts the read once the login is over, so the socket is not left open. */
+  signal: AbortSignal;
+}): Promise<boolean> {
   const base = normalizeEndpoint(opts.baseUrl);
   const f = opts.fetchImpl ?? fetch;
   const res = await f(
@@ -309,10 +317,13 @@ async function readApprovalStream(
 }
 
 /** Sleep, cut short by the approval signal when one is still worth racing. */
-async function waitForNextPoll(
-  ms: number,
-  approval: Promise<void> | null,
-): Promise<void> {
+async function waitForNextPoll({
+  ms,
+  approval,
+}: {
+  ms: number;
+  approval: Promise<void> | null;
+}): Promise<void> {
   if (!approval) {
     await wait(ms);
     return;
@@ -350,7 +361,7 @@ export async function pollUntilDone(
   const ceiling = 60_000;
   const deadline = Date.now() + dc.expires_in * 1000;
 
-  const watch = watchDeviceApproval(opts, dc.device_code);
+  const watch = watchDeviceApproval({ opts, deviceCode: dc.device_code });
   let approval: Promise<void> | null = watch.settled;
   // A signal fires once. Racing a resolved promise every round would turn the
   // loop into a hot poll if /exchange somehow still answered `pending`.
@@ -367,7 +378,7 @@ export async function pollUntilDone(
       if (firstPoll) {
         firstPoll = false;
       } else {
-        await waitForNextPoll(interval, approval);
+        await waitForNextPoll({ ms: interval, approval });
       }
       try {
         return await exchange(opts, dc.device_code);

--- a/sdks/typescript/src/cli/utils/governance/device-flow.ts
+++ b/sdks/typescript/src/cli/utils/governance/device-flow.ts
@@ -362,11 +362,17 @@ export async function pollUntilDone(
   const deadline = Date.now() + dc.expires_in * 1000;
 
   const watch = watchDeviceApproval({ opts, deviceCode: dc.device_code });
-  let approval: Promise<void> | null = watch.settled;
-  // A signal fires once. Racing a resolved promise every round would turn the
-  // loop into a hot poll if /exchange somehow still answered `pending`.
-  void watch.settled.then(() => {
-    approval = null;
+  const approval = watch.settled;
+  // A signal fires once, so it is tracked in two parts. `signalled` says the
+  // frame arrived, `spent` says a poll has already been let through because
+  // of it. A frame that lands while an /exchange is in flight therefore still
+  // shortens the next wait instead of being dropped, and once it is spent the
+  // loop stops racing an already-resolved promise, which would otherwise turn
+  // into a hot poll if /exchange somehow still answered `pending`.
+  let signalled = false;
+  let spent = false;
+  void approval.then(() => {
+    signalled = true;
   });
 
   try {
@@ -377,8 +383,14 @@ export async function pollUntilDone(
       }
       if (firstPoll) {
         firstPoll = false;
+      } else if (signalled && !spent) {
+        // The browser settled the code while the previous poll was in
+        // flight. Poll again straight away rather than sleeping out an
+        // interval the signal exists to skip.
+        spent = true;
       } else {
-        await waitForNextPoll({ ms: interval, approval });
+        await waitForNextPoll({ ms: interval, approval: spent ? null : approval });
+        if (signalled) spent = true;
       }
       try {
         return await exchange(opts, dc.device_code);

--- a/specs/ai-gateway/governance/cli-login.feature
+++ b/specs/ai-gateway/governance/cli-login.feature
@@ -108,6 +108,52 @@ Feature: AI Gateway Governance — CLI login (RFC 8628 device-code flow)
     And the response body suggests the safe `interval` value
 
   # ---------------------------------------------------------------------------
+  # Approval latency — the wait is the round trip, not the poll interval
+  #
+  # Polling alone made the CLI wait out its whole interval after an approval
+  # the user had already given. The first poll now goes out immediately, and a
+  # stream tells the CLI to poll the moment the browser settles the code. Both
+  # are accelerators over the same timer: a server or network that supports
+  # neither still logs in at the interval it was given.
+  # ---------------------------------------------------------------------------
+
+  @unit @cli @device-flow @login-latency
+  Scenario: The CLI asks once before it starts waiting
+    Given the CLI has a device_code and the user approves in the browser at once
+    When the CLI starts waiting for the approval
+    Then it polls "/api/auth/cli/exchange" before its first wait
+    And the login finishes without costing a whole poll interval
+
+  @unit @cli @device-flow @login-latency
+  Scenario: The approval stream cuts the wait short
+    Given the CLI is waiting between polls
+    When the approval stream emits a frame for its device_code
+    Then the CLI polls "/api/auth/cli/exchange" straight away
+    And it does not treat the frame as the approval itself
+
+  @unit @cli @device-flow @login-latency
+  Scenario: A server without the approval stream still logs in
+    Given the control plane has no "/api/auth/cli/device-approval" route
+    When the CLI waits for the approval
+    Then it keeps polling at the interval the server asked for
+    And the missing stream changes nothing about the outcome
+
+  @integration @cli @device-flow @login-latency
+  Scenario: The approval stream tells the CLI to poll the moment the browser settles the code
+    Given the CLI is on "/api/auth/cli/device-approval" for its device_code
+    When the browser approves or denies that code
+    Then the stream emits the settled status
+    And a code that settled before the stream opened emits at once
+    And an unknown code is reported as expired rather than held open
+
+  @integration @cli @device-flow @login-latency @rate-limit
+  Scenario: A poll on a settled device code is answered, not rate limited
+    Given the CLI polled once and is inside the per-device poll window
+    When the code is approved or denied and the CLI polls again straight away
+    Then the response carries the settled outcome instead of 429
+    And a code still pending inside that window is told to slow down
+
+  # ---------------------------------------------------------------------------
   # Token persistence and refresh
   # ---------------------------------------------------------------------------
 

--- a/specs/ai-gateway/governance/cli-login.feature
+++ b/specs/ai-gateway/governance/cli-login.feature
@@ -147,6 +147,13 @@ Feature: AI Gateway Governance — CLI login (RFC 8628 device-code flow)
     And an unknown code is reported as expired rather than held open
     And the pod refuses a new stream once it holds too many, so the CLI polls
 
+  @integration @cli @device-flow @login-latency
+  Scenario: A publication reaches nobody if the stream has not subscribed yet
+    Given a device code settles before the stream subscribes to its channel
+    When the stream subscribes afterwards
+    Then it hears nothing, because the channel keeps no history
+    And this is why the stream re-reads the code once its channel is live
+
   @integration @cli @device-flow @login-latency @rate-limit
   Scenario: A poll on a settled device code is answered, not rate limited
     Given the CLI polled once and is inside the per-device poll window

--- a/specs/ai-gateway/governance/cli-login.feature
+++ b/specs/ai-gateway/governance/cli-login.feature
@@ -153,6 +153,8 @@ Feature: AI Gateway Governance — CLI login (RFC 8628 device-code flow)
     When the stream subscribes afterwards
     Then it hears nothing, because the channel keeps no history
     And this is why the stream re-reads the code once its channel is live
+    And a settlement published after that point is always heard, so the re-read
+      covers the whole gap
 
   @integration @cli @device-flow @login-latency @rate-limit
   Scenario: A poll on a settled device code is answered, not rate limited

--- a/specs/ai-gateway/governance/cli-login.feature
+++ b/specs/ai-gateway/governance/cli-login.feature
@@ -142,9 +142,10 @@ Feature: AI Gateway Governance — CLI login (RFC 8628 device-code flow)
   Scenario: The approval stream tells the CLI to poll the moment the browser settles the code
     Given the CLI is on "/api/auth/cli/device-approval" for its device_code
     When the browser approves or denies that code
-    Then the stream emits the settled status
+    Then the stream emits the settled status, approved or denied
     And a code that settled before the stream opened emits at once
     And an unknown code is reported as expired rather than held open
+    And the pod refuses a new stream once it holds too many, so the CLI polls
 
   @integration @cli @device-flow @login-latency @rate-limit
   Scenario: A poll on a settled device code is answered, not rate limited

--- a/specs/ai-gateway/governance/cli-login.feature
+++ b/specs/ai-gateway/governance/cli-login.feature
@@ -148,7 +148,7 @@ Feature: AI Gateway Governance — CLI login (RFC 8628 device-code flow)
     And the pod refuses a new stream once it holds too many, so the CLI polls
 
   @integration @cli @device-flow @login-latency
-  Scenario: A publication reaches nobody if the stream has not subscribed yet
+  Scenario: A publication is lost if the stream has not subscribed yet
     Given a device code settles before the stream subscribes to its channel
     When the stream subscribes afterwards
     Then it hears nothing, because the channel keeps no history
@@ -160,6 +160,20 @@ Feature: AI Gateway Governance — CLI login (RFC 8628 device-code flow)
     When the code is approved or denied and the CLI polls again straight away
     Then the response carries the settled outcome instead of 429
     And a code still pending inside that window is told to slow down
+
+  @integration @cli @device-flow @login-latency
+  Scenario: Two exchanges racing the same approval redeem it once
+    Given a device code has been approved
+    When two exchange calls for that code arrive at the same time
+    Then exactly one of them receives the credential
+    And the other is told to slow down instead of receiving a second one
+
+  @unit @cli @device-flow @login-latency
+  Scenario: An approval that lands during a poll still cuts the next wait short
+    Given the CLI has a poll in flight
+    When the approval stream emits a frame before that poll answers
+    Then the next poll goes out without waiting the interval
+    And the frame is spent by that poll, so the loop keeps its interval afterwards
 
   # ---------------------------------------------------------------------------
   # Token persistence and refresh


### PR DESCRIPTION
`langwatch login --device` sat on "Waiting for you to approve in the browser" long after the user had approved. Nothing told the CLI that anything had happened, so it found out on its next scheduled poll.

## What made it slow

Three things, all in the poll loop:

1. `pollUntilDone` slept **before** its first poll, so the floor was a whole interval even when the approval landed while the browser was still opening.
2. The interval is 5 seconds (`MIN_POLL_INTERVAL_SECONDS`).
3. `/exchange` rate-limits a device code to one poll every 4 seconds. A `slow_down` doubled the CLI's interval with no way back down, up to a 60 second ceiling, so a CLI that ever tripped the window stayed slow for the rest of the login.

## What this does

- **Poll once before waiting.** An approval that is already in costs a round trip, not an interval.
- **New `GET /api/auth/cli/device-approval`.** The browser's approve or deny publishes on a small Redis channel; the stream emits one frame and ends. The CLI races that frame against its own timer and polls the moment it lands. A frame that arrives is dropped from the race, so a stream and a poll that disagree cannot turn the loop into a hot poll.
- **`/exchange` skips its poll window for a settled code.** A code that has been approved or denied has nothing left to rate limit, and answering that poll with `slow_down` would put back the wait the stream exists to remove. A code still pending inside the window is still told to slow down.

The stream carries no credential and grants nothing. The device code is still the only thing it accepts, exactly as on `/exchange`, and the CLI still has to POST `/exchange` to get its tokens. It is a latency fix, not a second way to authenticate.

## Failure behaviour

Polling stays the correctness floor. A server without the route, a proxy that buffers the body, a Redis without pub/sub, a dropped connection and an older CLI all fall back to the interval they already used, and nothing in the signal path can fail an approval: the publish is best effort, the subscribe is best effort, and a stream that never emits just leaves the timer in charge.

One subscriber connection is shared per pod rather than one per waiting CLI, and each stream keeps a keepalive comment going so proxies do not close it, ending at the device code's own deadline.

## One exchange per approval

Skipping the poll window for a settled code removed the only thing that serialised concurrent `/exchange` calls, so two polls arriving together could both hold the same approved record and both reach a 200: the credential handed back twice, or two token pairs minted with the second mint revoking the login key the first had just returned. The approved branch now takes an atomic `SET NX EX 30` claim on the device code before it reads anything, released on every return that consumes nothing. The loser gets the same `429 slow_down` a too-fast poll gets, which the CLI already retries, so the client contract does not change.

On the CLI side the approval wakeup used to be cleared the moment the frame arrived, even while an `/exchange` was in flight, so a frame landing mid-poll was dropped and that iteration slept out a whole interval, the exact wait this PR removes. Arrival and spend are tracked separately now: a mid-poll frame sends the next poll out at once and is spent by it, so the loop still cannot become a hot poll.

## Tests

- `sdks/typescript/src/cli/utils/governance/__tests__/device-flow.unit.test.ts`: the first poll fires before any wait; a stream frame produces a poll well inside a 30 second interval; a 404 on the stream falls back to the interval; a frame that lands while a poll is in flight still sends the next poll out without waiting, and is spent by it so the poll after that waits the interval again; the existing pending/denied paths keep their behaviour, now routed by URL so the stream is not counted as a poll.
- `platform/app/src/server/routes/__tests__/auth-cli-device-approval.integration.test.ts` (real Redis): the stream emits on approval, emits at once for a code that settled first, reports an unknown code as expired instead of holding the connection, refuses a request with no `device_code`, a poll on a settled code inside the rate-limit window gets its answer rather than a 429, and two concurrent `/exchange` calls on one approved code produce exactly one 200 and one 429.
- `specs/ai-gateway/governance/cli-login.feature`: seven new scenarios, all with binding tags and `@scenario` annotations. The file reports 14/14 bound.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI login now receives near-immediate updates when device approval or denial is completed.
  * Device-code exchanges return settled outcomes promptly instead of applying polling delays.
  * Login falls back to regular polling when live updates are unavailable.
  * Live approval updates handle approved, denied, expired, and invalid device-code states.
  * Approval streams provide keepalive updates and limit concurrent connections.
  * Approved device codes can only be redeemed once.

* **Documentation**
  * Added specifications covering approval latency, fallback polling, and settled device-code outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

https://claude.ai/code/session_01GC6muSpK1eyEHfEVMNZLMo