### PR TITLE
fix(observability): expose collection health and ingestion outcomes

### DIFF
--- a/.github/workflows/langwatch-app-ci.yml
+++ b/.github/workflows/langwatch-app-ci.yml
@@ -97,8 +97,10 @@ jobs:
       # It also fixes the draft case, which was silently wrong: a draft got
       # `shards: [1]` and still ran `--shard=1/4`, so it executed a quarter of
       # its files while reporting a pass over all of them.
-      unit-shards: ${{ (github.event_name != 'pull_request' || github.event.pull_request.draft == false) && '[1,2,3,4]' || '[1]' }}
-      unit-shard-count: ${{ (github.event_name != 'pull_request' || github.event.pull_request.draft == false) && '4' || '1' }}
+      # At 602 files per shard, healthy runs hit the four-minute hard floor.
+      # Five shards give the full suite headroom without weakening that floor.
+      unit-shards: ${{ (github.event_name != 'pull_request' || github.event.pull_request.draft == false) && '[1,2,3,4,5]' || '[1]' }}
+      unit-shard-count: ${{ (github.event_name != 'pull_request' || github.event.pull_request.draft == false) && '5' || '1' }}
       # Six became four when the component lane took the files that never
       # needed a datastore. 540 of the 1017 integration files declare jsdom and
       # name no database, queue or cache; they now run on `test-component`
@@ -466,7 +468,7 @@ jobs:
         if: matrix.shard == 1
         run: pnpm --filter @langwatch/langyworker run typecheck
 
-      - name: Run unit tests (shard ${{ matrix.shard }}/4)
+      - name: Run unit tests (shard ${{ matrix.shard }}/${{ needs.changes.outputs.unit-shard-count }})
         id: unit-tests
         working-directory: platform/app
         run: |

--- a/dev/docs/adr/054-observability-as-code-for-the-process-substrate.md
+++ b/dev/docs/adr/054-observability-as-code-for-the-process-substrate.md
@@ -84,6 +84,26 @@ outcomes exist only as events and log lines).
    knows no cheap low-cardinality source label) from the pull intent
    executor.
 
+5. **Scrape freshness and event visibility are explicit.**
+   `pm_fleet_collection_success` and
+   `pm_fleet_last_success_timestamp_seconds` distinguish a fresh global count
+   from the retained value after a database read failure. Consumers aggregate
+   process counts with `max`, gate recovery on healthy collection and detect
+   missing targets independently. `gq_jobs_last_dropped_timestamp_seconds`
+   preserves queue, pipeline, job type, job name and reason so one discard is
+   visible without a prior counter baseline. It complements the counter; a pod
+   exit before any scrape can still lose this observation. Reoffered unroutable
+   work never updates this loss signal.
+
+6. **OTLP outcomes describe acceptance semantics.**
+   `trace_ingestion_spans_total{operation="otlp_traces",outcome}` records
+   collected, failed, dropped, deduped and filtered spans. Collected means
+   dispatched; failed means dispatch infrastructure failure; dropped means
+   invalid or aged input. Filtering and deduplication remain intentional
+   outcomes. Counters initialize all five outcomes at zero. Neither this
+   counter nor an HTTP 200 proves queryability; the SaaS functional probe owns
+   that check. Tenant IDs are deliberately absent from these metric labels.
+
 ## Consequences
 
 - An outbox dead-letter, a >30-minute wake delay, a sustained

--- a/platform/app/scripts/check-feature-parity.ts
+++ b/platform/app/scripts/check-feature-parity.ts
@@ -525,7 +525,6 @@ const LEGACY_INERT: string[] = [
   "specs/npx-installer/05-publish.feature",
   "specs/npx-installer/06-langy.feature",
   "specs/observability/browser-rum-trace-correlation.feature",
-  "specs/observability/process-substrate-alerting.feature",
   "specs/ops/clickhouse-backup-metrics.feature",
   "specs/ops/dashboard-latency.feature",
   "specs/ops/dejaview-impersonation-access.feature",

--- a/platform/app/src/server/app-layer/traces/__tests__/span-ingestion-tally.unit.test.ts
+++ b/platform/app/src/server/app-layer/traces/__tests__/span-ingestion-tally.unit.test.ts
@@ -2,17 +2,21 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { SpanIngestionTally } from "../span-ingestion-tally";
 import { traceIngestionSpansTotal } from "../trace-ingestion.metrics";
 
-it("initializes each bounded outcome at zero before any OTLP span", async () => {
-  const metric = await traceIngestionSpansTotal.get();
-  expect(
-    metric.values.map((sample) => [sample.labels.outcome, sample.value]),
-  ).toEqual([
-    ["collected", 0],
-    ["failed", 0],
-    ["dropped", 0],
-    ["deduped", 0],
-    ["filtered", 0],
-  ]);
+describe("given no OTLP span has been ingested", () => {
+  describe("when the initialized outcome metric is read", () => {
+    it("initializes each bounded outcome at zero before any OTLP span", async () => {
+      const metric = await traceIngestionSpansTotal.get();
+      expect(
+        metric.values.map((sample) => [sample.labels.outcome, sample.value]),
+      ).toEqual([
+        ["collected", 0],
+        ["failed", 0],
+        ["dropped", 0],
+        ["deduped", 0],
+        ["filtered", 0],
+      ]);
+    });
+  });
 });
 
 describe("OTLP ingestion outcomes", () => {
@@ -20,52 +24,62 @@ describe("OTLP ingestion outcomes", () => {
     traceIngestionSpansTotal.reset();
   });
 
-  it("keeps intentional skips out of partial rejection and infrastructure failures distinct", async () => {
-    const tally = SpanIngestionTally.create();
-    tally.record({ status: "collected" });
-    tally.record({ status: "filtered" });
-    tally.record({ status: "deduped" });
-    tally.record({ status: "dropped", error: "invalid timestamp" });
-    tally.record({ status: "failed", error: "Redis unavailable" });
-    tally.record({ status: "failed", error: "queue unavailable" });
+  describe("given collected, skipped and rejected spans", () => {
+    describe("when the tally records their outcomes", () => {
+      /** @scenario "OTLP partial rejection exposes its cause independently of HTTP status" */
+      it("keeps intentional skips out of partial rejection and infrastructure failures distinct", async () => {
+        const tally = SpanIngestionTally.create();
+        tally.record({ status: "collected" });
+        tally.record({ status: "filtered" });
+        tally.record({ status: "deduped" });
+        tally.record({ status: "dropped", error: "invalid timestamp" });
+        tally.record({ status: "failed", error: "Redis unavailable" });
+        tally.record({ status: "failed", error: "queue unavailable" });
 
-    expect(tally.toResult()).toEqual({
-      rejectedSpans: 3,
-      ingestionFailures: 2,
-      ingestionFailureMessage: "Redis unavailable; queue unavailable",
-      errorMessage: "invalid timestamp; Redis unavailable; queue unavailable",
+        expect(tally.toResult()).toEqual({
+          rejectedSpans: 3,
+          ingestionFailures: 2,
+          ingestionFailureMessage: "Redis unavailable; queue unavailable",
+          errorMessage:
+            "invalid timestamp; Redis unavailable; queue unavailable",
+        });
+        const metric = await traceIngestionSpansTotal.get();
+        expect(metric.values).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              labels: { operation: "otlp_traces", outcome: "collected" },
+              value: 1,
+            }),
+            expect.objectContaining({
+              labels: { operation: "otlp_traces", outcome: "failed" },
+              value: 2,
+            }),
+            expect.objectContaining({
+              labels: { operation: "otlp_traces", outcome: "dropped" },
+              value: 1,
+            }),
+            expect.objectContaining({
+              labels: { operation: "otlp_traces", outcome: "deduped" },
+              value: 1,
+            }),
+            expect.objectContaining({
+              labels: { operation: "otlp_traces", outcome: "filtered" },
+              value: 1,
+            }),
+          ]),
+        );
+        expect(metric.values).toHaveLength(5);
+      });
     });
-    const metric = await traceIngestionSpansTotal.get();
-    expect(metric.values).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          labels: { operation: "otlp_traces", outcome: "collected" },
-          value: 1,
-        }),
-        expect.objectContaining({
-          labels: { operation: "otlp_traces", outcome: "failed" },
-          value: 2,
-        }),
-        expect.objectContaining({
-          labels: { operation: "otlp_traces", outcome: "dropped" },
-          value: 1,
-        }),
-        expect.objectContaining({
-          labels: { operation: "otlp_traces", outcome: "deduped" },
-          value: 1,
-        }),
-        expect.objectContaining({
-          labels: { operation: "otlp_traces", outcome: "filtered" },
-          value: 1,
-        }),
-      ]),
-    );
-    expect(metric.values).toHaveLength(5);
   });
 
-  it("does not count an empty request as accepted work", async () => {
-    expect(SpanIngestionTally.create().toResult().rejectedSpans).toBe(0);
-    const metric = await traceIngestionSpansTotal.get();
-    expect(metric.values).toHaveLength(0);
+  describe("given an empty OTLP request", () => {
+    describe("when its collection tally is read", () => {
+      it("does not count an empty request as accepted work", async () => {
+        expect(SpanIngestionTally.create().toResult().rejectedSpans).toBe(0);
+        const metric = await traceIngestionSpansTotal.get();
+        expect(metric.values).toHaveLength(0);
+      });
+    });
   });
 });

--- a/platform/app/src/server/app-layer/traces/__tests__/span-ingestion-tally.unit.test.ts
+++ b/platform/app/src/server/app-layer/traces/__tests__/span-ingestion-tally.unit.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { SpanIngestionTally } from "../span-ingestion-tally";
+import { traceIngestionSpansTotal } from "../trace-ingestion.metrics";
+
+it("initializes each bounded outcome at zero before any OTLP span", async () => {
+  const metric = await traceIngestionSpansTotal.get();
+  expect(
+    metric.values.map((sample) => [sample.labels.outcome, sample.value]),
+  ).toEqual([
+    ["collected", 0],
+    ["failed", 0],
+    ["dropped", 0],
+    ["deduped", 0],
+    ["filtered", 0],
+  ]);
+});
+
+describe("OTLP ingestion outcomes", () => {
+  beforeEach(() => {
+    traceIngestionSpansTotal.reset();
+  });
+
+  it("keeps intentional skips out of partial rejection and infrastructure failures distinct", async () => {
+    const tally = SpanIngestionTally.create();
+    tally.record({ status: "collected" });
+    tally.record({ status: "filtered" });
+    tally.record({ status: "deduped" });
+    tally.record({ status: "dropped", error: "invalid timestamp" });
+    tally.record({ status: "failed", error: "Redis unavailable" });
+    tally.record({ status: "failed", error: "queue unavailable" });
+
+    expect(tally.toResult()).toEqual({
+      rejectedSpans: 3,
+      ingestionFailures: 2,
+      ingestionFailureMessage: "Redis unavailable; queue unavailable",
+      errorMessage: "invalid timestamp; Redis unavailable; queue unavailable",
+    });
+    const metric = await traceIngestionSpansTotal.get();
+    expect(metric.values).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          labels: { operation: "otlp_traces", outcome: "collected" },
+          value: 1,
+        }),
+        expect.objectContaining({
+          labels: { operation: "otlp_traces", outcome: "failed" },
+          value: 2,
+        }),
+        expect.objectContaining({
+          labels: { operation: "otlp_traces", outcome: "dropped" },
+          value: 1,
+        }),
+        expect.objectContaining({
+          labels: { operation: "otlp_traces", outcome: "deduped" },
+          value: 1,
+        }),
+        expect.objectContaining({
+          labels: { operation: "otlp_traces", outcome: "filtered" },
+          value: 1,
+        }),
+      ]),
+    );
+    expect(metric.values).toHaveLength(5);
+  });
+
+  it("does not count an empty request as accepted work", async () => {
+    expect(SpanIngestionTally.create().toResult().rejectedSpans).toBe(0);
+    const metric = await traceIngestionSpansTotal.get();
+    expect(metric.values).toHaveLength(0);
+  });
+});

--- a/platform/app/src/server/app-layer/traces/span-ingestion-tally.ts
+++ b/platform/app/src/server/app-layer/traces/span-ingestion-tally.ts
@@ -1,0 +1,75 @@
+import type { Span as OtelSpan } from "@opentelemetry/api";
+import { traceIngestionSpansTotal } from "./trace-ingestion.metrics";
+import type {
+  SpanIngestionResult,
+  TraceRequestCollectionResult,
+} from "./trace-request-collection.service";
+
+/**
+ * Intentional filtering is not rejection. Validation drops and infrastructure
+ * dispatch failures are both rejected spans, but have opposite retry answers.
+ */
+export class SpanIngestionTally {
+  private constructor() {}
+
+  static create(): SpanIngestionTally {
+    return new SpanIngestionTally();
+  }
+
+  private collected = 0;
+  private dropped = 0;
+  private deduped = 0;
+  private filtered = 0;
+  private failed = 0;
+  private readonly errors: string[] = [];
+  private readonly failureErrors: string[] = [];
+
+  record(result: SpanIngestionResult): void {
+    traceIngestionSpansTotal.inc({
+      operation: "otlp_traces",
+      outcome: result.status,
+    });
+    switch (result.status) {
+      case "collected":
+        this.collected++;
+        break;
+      case "dropped":
+        this.dropped++;
+        break;
+      case "deduped":
+        this.deduped++;
+        break;
+      case "filtered":
+        this.filtered++;
+        break;
+      case "failed":
+        this.failed++;
+        if (result.error) {
+          this.failureErrors.push(result.error);
+        }
+        break;
+    }
+    if (result.error) {
+      this.errors.push(result.error);
+    }
+  }
+
+  annotate(span: OtelSpan): void {
+    span.setAttribute("spans.ingestion.successes", this.collected);
+    span.setAttribute("spans.ingestion.failures", this.failed);
+    span.setAttribute("spans.ingestion.drops", this.dropped);
+    span.setAttribute("spans.ingestion.deduped", this.deduped);
+    span.setAttribute("spans.ingestion.filtered", this.filtered);
+  }
+
+  toResult(): TraceRequestCollectionResult {
+    return {
+      // Filtered spans are intentionally not stored (coding-agent infra
+      // noise), so they are NOT rejections.
+      rejectedSpans: this.dropped + this.failed,
+      ingestionFailures: this.failed,
+      ingestionFailureMessage: this.failureErrors.join("; "),
+      errorMessage: this.errors.join("; "),
+    };
+  }
+}

--- a/platform/app/src/server/app-layer/traces/trace-ingestion.metrics.ts
+++ b/platform/app/src/server/app-layer/traces/trace-ingestion.metrics.ts
@@ -1,0 +1,22 @@
+import { Counter, register } from "prom-client";
+import type { SpanIngestionStatus } from "./trace-request-collection.service";
+
+register.removeSingleMetric("trace_ingestion_spans_total");
+
+export const traceIngestionSpansTotal = new Counter({
+  name: "trace_ingestion_spans_total",
+  help: "OTLP collection span outcomes: collected means dispatched, failed means dispatch infrastructure failure, dropped means invalid or aged, deduped and filtered are intentional. Dispatch does not prove queryability.",
+  labelNames: ["operation", "outcome"] as const,
+});
+
+const outcomes: readonly SpanIngestionStatus[] = [
+  "collected",
+  "failed",
+  "dropped",
+  "deduped",
+  "filtered",
+];
+
+for (const outcome of outcomes) {
+  traceIngestionSpansTotal.inc({ operation: "otlp_traces", outcome }, 0);
+}

--- a/platform/app/src/server/app-layer/traces/trace-request-collection.service.ts
+++ b/platform/app/src/server/app-layer/traces/trace-request-collection.service.ts
@@ -18,6 +18,7 @@ import {
   spanSchema,
 } from "../../event-sourcing/pipelines/trace-processing/schemas/otlp";
 import { TraceRequestUtils } from "../../event-sourcing/pipelines/trace-processing/utils/traceRequest.utils";
+import { SpanIngestionTally } from "./span-ingestion-tally";
 import { shouldFilterCodingAgentSpan } from "./coding-agent-span-filter";
 import type { SpanDedupService } from "./span-dedupe.service";
 
@@ -119,66 +120,6 @@ export interface TraceRequestCollectionDeps {
 }
 
 /**
- * Per-request tally of span outcomes, and the one place that decides what each
- * outcome means to a caller.
- *
- * It exists as its own unit because two of those decisions are load-bearing and
- * were previously inline: filtered spans are NOT rejections, and drops and
- * dispatch failures are rejections with opposite retry answers (see
- * `TraceRequestCollectionResult`).
- */
-class SpanIngestionTally {
-  private collected = 0;
-  private dropped = 0;
-  private deduped = 0;
-  private filtered = 0;
-  private failed = 0;
-  private readonly errors: string[] = [];
-  private readonly failureErrors: string[] = [];
-
-  record(result: SpanIngestionResult): void {
-    switch (result.status) {
-      case "collected":
-        this.collected++;
-        break;
-      case "dropped":
-        this.dropped++;
-        break;
-      case "deduped":
-        this.deduped++;
-        break;
-      case "filtered":
-        this.filtered++;
-        break;
-      case "failed":
-        this.failed++;
-        if (result.error) this.failureErrors.push(result.error);
-        break;
-    }
-    if (result.error) this.errors.push(result.error);
-  }
-
-  annotate(span: OtelSpan): void {
-    span.setAttribute("spans.ingestion.successes", this.collected);
-    span.setAttribute("spans.ingestion.failures", this.failed);
-    span.setAttribute("spans.ingestion.drops", this.dropped);
-    span.setAttribute("spans.ingestion.deduped", this.deduped);
-    span.setAttribute("spans.ingestion.filtered", this.filtered);
-  }
-
-  toResult(): TraceRequestCollectionResult {
-    return {
-      // Filtered spans are intentionally not stored (coding-agent infra
-      // noise), so they are NOT rejections.
-      rejectedSpans: this.dropped + this.failed,
-      ingestionFailures: this.failed,
-      ingestionFailureMessage: this.failureErrors.join("; "),
-      errorMessage: this.errors.join("; "),
-    };
-  }
-}
-
-/**
  * Service for collecting trace requests into the trace processing pipeline.
  *
  * Normalizes OTLP trace requests and sends each span as a span-received event
@@ -214,7 +155,7 @@ export class TraceRequestCollectionService {
         },
       },
       async (span) => {
-        const tally = new SpanIngestionTally();
+        const tally = SpanIngestionTally.create();
 
         for (const resourceSpan of traceRequest.resourceSpans ?? []) {
           const resource = resourceSpan?.resource;

--- a/platform/app/src/server/app-layer/traces/trace-request-collection.service.ts
+++ b/platform/app/src/server/app-layer/traces/trace-request-collection.service.ts
@@ -18,9 +18,9 @@ import {
   spanSchema,
 } from "../../event-sourcing/pipelines/trace-processing/schemas/otlp";
 import { TraceRequestUtils } from "../../event-sourcing/pipelines/trace-processing/utils/traceRequest.utils";
-import { SpanIngestionTally } from "./span-ingestion-tally";
 import { shouldFilterCodingAgentSpan } from "./coding-agent-span-filter";
 import type { SpanDedupService } from "./span-dedupe.service";
+import { SpanIngestionTally } from "./span-ingestion-tally";
 
 const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 /**

--- a/platform/app/src/server/event-sourcing/process-manager/__tests__/metrics.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/process-manager/__tests__/metrics.unit.test.ts
@@ -1,8 +1,16 @@
 import { register } from "prom-client";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { bindProcessFleetMetricsSource } from "../metrics";
 
 describe("process-manager fleet gauges", () => {
+  it("does not report an unbound process as a failed collector", async () => {
+    const scraped = await register.metrics();
+    expect(scraped).not.toMatch(/^pm_fleet_collection_success [0-9]/m);
+    expect(scraped).not.toMatch(
+      /^pm_fleet_last_success_timestamp_seconds [0-9]/m,
+    );
+  });
+
   describe("given dead messages and overdue wakes exist", () => {
     /** @scenario "The fleet's trouble counts reach Prometheus" */
     it("reports them per process name on scrape, with the max() aggregation warning", async () => {
@@ -36,5 +44,71 @@ describe("process-manager fleet gauges", () => {
     bindProcessFleetMetricsSource(async () => []);
     const scraped = await register.metrics();
     expect(scraped).not.toContain('process_name="automations"');
+  });
+});
+
+describe("process fleet collection freshness", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("retains unresolved dead work without refreshing its timestamp after a failed read", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-09-07T10:00:00Z"));
+    const read = vi
+      .fn()
+      .mockResolvedValueOnce([
+        {
+          processName: "triggerSettlement",
+          instances: 1,
+          overdueWakes: 0,
+          pendingMessages: 0,
+          overduePending: 0,
+          lapsedLeases: 0,
+          deadMessages: 1,
+        },
+      ])
+      .mockRejectedValueOnce(new Error("database unavailable"))
+      .mockResolvedValueOnce([]);
+    bindProcessFleetMetricsSource(read);
+
+    const healthy = await register.metrics();
+    expect(read).toHaveBeenCalledTimes(1);
+    expect(healthy).toContain("pm_fleet_collection_success 1");
+    expect(healthy).toContain(
+      "pm_fleet_last_success_timestamp_seconds 1788775200",
+    );
+
+    vi.advanceTimersByTime(11_000);
+    const failed = await register.metrics();
+    expect(read).toHaveBeenCalledTimes(2);
+    expect(failed).toContain(
+      'pm_outbox_dead{process_name="triggerSettlement"} 1',
+    );
+    expect(failed).toContain("pm_fleet_collection_success 0");
+    expect(failed).toContain(
+      "pm_fleet_last_success_timestamp_seconds 1788775200",
+    );
+
+    await register.metrics();
+    expect(read).toHaveBeenCalledTimes(2);
+    vi.advanceTimersByTime(11_000);
+    const recovered = await register.metrics();
+    expect(read).toHaveBeenCalledTimes(3);
+    expect(recovered).toContain("pm_fleet_collection_success 1");
+    expect(recovered).toContain(
+      "pm_fleet_last_success_timestamp_seconds 1788775222",
+    );
+    expect(recovered).not.toContain('process_name="triggerSettlement"');
+  });
+
+  it("reports unknown counts and zero freshness when its first read fails", async () => {
+    bindProcessFleetMetricsSource(async () => {
+      throw new Error("offline");
+    });
+    const failed = await register.metrics();
+    expect(failed).toContain("pm_fleet_collection_success 0");
+    expect(failed).toContain("pm_fleet_last_success_timestamp_seconds 0");
+    expect(failed).not.toMatch(/pm_outbox_dead\{/);
   });
 });

--- a/platform/app/src/server/event-sourcing/process-manager/__tests__/metrics.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/process-manager/__tests__/metrics.unit.test.ts
@@ -3,12 +3,16 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { bindProcessFleetMetricsSource } from "../metrics";
 
 describe("process-manager fleet gauges", () => {
-  it("does not report an unbound process as a failed collector", async () => {
-    const scraped = await register.metrics();
-    expect(scraped).not.toMatch(/^pm_fleet_collection_success [0-9]/m);
-    expect(scraped).not.toMatch(
-      /^pm_fleet_last_success_timestamp_seconds [0-9]/m,
-    );
+  describe("given no fleet metrics source is bound", () => {
+    describe("when metrics are scraped", () => {
+      it("does not report an unbound process as a failed collector", async () => {
+        const scraped = await register.metrics();
+        expect(scraped).not.toMatch(/^pm_fleet_collection_success [0-9]/m);
+        expect(scraped).not.toMatch(
+          /^pm_fleet_last_success_timestamp_seconds [0-9]/m,
+        );
+      });
+    });
   });
 
   describe("given dead messages and overdue wakes exist", () => {
@@ -52,63 +56,72 @@ describe("process fleet collection freshness", () => {
     vi.useRealTimers();
   });
 
-  it("retains unresolved dead work without refreshing its timestamp after a failed read", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-09-07T10:00:00Z"));
-    const read = vi
-      .fn()
-      .mockResolvedValueOnce([
-        {
-          processName: "triggerSettlement",
-          instances: 1,
-          overdueWakes: 0,
-          pendingMessages: 0,
-          overduePending: 0,
-          lapsedLeases: 0,
-          deadMessages: 1,
-        },
-      ])
-      .mockRejectedValueOnce(new Error("database unavailable"))
-      .mockResolvedValueOnce([]);
-    bindProcessFleetMetricsSource(read);
+  describe("given the last successful collection found dead work", () => {
+    describe("when collection fails and then recovers", () => {
+      /** @scenario "A failed fleet collection cannot clear unresolved work" */
+      it("retains unresolved dead work without refreshing its timestamp after a failed read", async () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date("2026-09-07T10:00:00Z"));
+        const read = vi
+          .fn()
+          .mockResolvedValueOnce([
+            {
+              processName: "triggerSettlement",
+              instances: 1,
+              overdueWakes: 0,
+              pendingMessages: 0,
+              overduePending: 0,
+              lapsedLeases: 0,
+              deadMessages: 1,
+            },
+          ])
+          .mockRejectedValueOnce(new Error("database unavailable"))
+          .mockResolvedValueOnce([]);
+        bindProcessFleetMetricsSource(read);
 
-    const healthy = await register.metrics();
-    expect(read).toHaveBeenCalledTimes(1);
-    expect(healthy).toContain("pm_fleet_collection_success 1");
-    expect(healthy).toContain(
-      "pm_fleet_last_success_timestamp_seconds 1788775200",
-    );
+        const healthy = await register.metrics();
+        expect(read).toHaveBeenCalledTimes(1);
+        expect(healthy).toContain("pm_fleet_collection_success 1");
+        expect(healthy).toContain(
+          "pm_fleet_last_success_timestamp_seconds 1788775200",
+        );
 
-    vi.advanceTimersByTime(11_000);
-    const failed = await register.metrics();
-    expect(read).toHaveBeenCalledTimes(2);
-    expect(failed).toContain(
-      'pm_outbox_dead{process_name="triggerSettlement"} 1',
-    );
-    expect(failed).toContain("pm_fleet_collection_success 0");
-    expect(failed).toContain(
-      "pm_fleet_last_success_timestamp_seconds 1788775200",
-    );
+        vi.advanceTimersByTime(11_000);
+        const failed = await register.metrics();
+        expect(read).toHaveBeenCalledTimes(2);
+        expect(failed).toContain(
+          'pm_outbox_dead{process_name="triggerSettlement"} 1',
+        );
+        expect(failed).toContain("pm_fleet_collection_success 0");
+        expect(failed).toContain(
+          "pm_fleet_last_success_timestamp_seconds 1788775200",
+        );
 
-    await register.metrics();
-    expect(read).toHaveBeenCalledTimes(2);
-    vi.advanceTimersByTime(11_000);
-    const recovered = await register.metrics();
-    expect(read).toHaveBeenCalledTimes(3);
-    expect(recovered).toContain("pm_fleet_collection_success 1");
-    expect(recovered).toContain(
-      "pm_fleet_last_success_timestamp_seconds 1788775222",
-    );
-    expect(recovered).not.toContain('process_name="triggerSettlement"');
+        await register.metrics();
+        expect(read).toHaveBeenCalledTimes(2);
+        vi.advanceTimersByTime(11_000);
+        const recovered = await register.metrics();
+        expect(read).toHaveBeenCalledTimes(3);
+        expect(recovered).toContain("pm_fleet_collection_success 1");
+        expect(recovered).toContain(
+          "pm_fleet_last_success_timestamp_seconds 1788775222",
+        );
+        expect(recovered).not.toContain('process_name="triggerSettlement"');
+      });
+    });
   });
 
-  it("reports unknown counts and zero freshness when its first read fails", async () => {
-    bindProcessFleetMetricsSource(async () => {
-      throw new Error("offline");
+  describe("given a newly bound fleet metrics source", () => {
+    describe("when its first collection fails", () => {
+      it("reports unknown counts and zero freshness when its first read fails", async () => {
+        bindProcessFleetMetricsSource(async () => {
+          throw new Error("offline");
+        });
+        const failed = await register.metrics();
+        expect(failed).toContain("pm_fleet_collection_success 0");
+        expect(failed).toContain("pm_fleet_last_success_timestamp_seconds 0");
+        expect(failed).not.toMatch(/pm_outbox_dead\{/);
+      });
     });
-    const failed = await register.metrics();
-    expect(failed).toContain("pm_fleet_collection_success 0");
-    expect(failed).toContain("pm_fleet_last_success_timestamp_seconds 0");
-    expect(failed).not.toMatch(/pm_outbox_dead\{/);
   });
 });

--- a/platform/app/src/server/event-sourcing/process-manager/metrics.ts
+++ b/platform/app/src/server/event-sourcing/process-manager/metrics.ts
@@ -17,6 +17,8 @@ const metricNames = [
   "pm_outbox_overdue_pending",
   "pm_outbox_lapsed_leases",
   "pm_outbox_dead",
+  "pm_fleet_collection_success",
+  "pm_fleet_last_success_timestamp_seconds",
 ] as const;
 
 for (const name of metricNames) {
@@ -38,27 +40,41 @@ type FleetReader = () => Promise<ProcessFleetMetricsRow[]>;
 let readFleet: FleetReader | null = null;
 
 /**
- * Scrape-time cache: six gauges collect on every scrape, and each must see
- * the same read rather than issuing six aggregate queries per scrape.
- * In-flight reads are shared; a settled read serves ten seconds.
+ * All fleet gauges share one database read per ten seconds, including failed
+ * attempts. Freshness advances only after a successful database read.
  */
-let cached: { at: number; rows: ProcessFleetMetricsRow[] } | null = null;
+let cached: {
+  at: number;
+  rows: ProcessFleetMetricsRow[];
+  success: boolean;
+} | null = null;
+let lastSuccessAt = 0;
 let inFlight: Promise<ProcessFleetMetricsRow[]> | null = null;
 const CACHE_TTL_MS = 10_000;
 
 async function readCounts(): Promise<ProcessFleetMetricsRow[]> {
-  if (!readFleet) return [];
-  if (cached && Date.now() - cached.at < CACHE_TTL_MS) return cached.rows;
-  if (inFlight !== null) return inFlight;
-  inFlight = readFleet()
+  const read = readFleet;
+  if (!read) {
+    return [];
+  }
+  if (cached && Date.now() - cached.at < CACHE_TTL_MS) {
+    return cached.rows;
+  }
+  if (inFlight !== null) {
+    return inFlight;
+  }
+  inFlight = Promise.resolve()
+    .then(read)
     .then((rows) => {
-      cached = { at: Date.now(), rows };
+      lastSuccessAt = Date.now();
+      cached = { at: lastSuccessAt, rows, success: true };
       return rows;
     })
     .catch(() => {
-      // A failed read reports nothing rather than stale numbers presented
-      // as fresh; the scrape itself still succeeds.
-      return cached?.rows ?? [];
+      // Retain unresolved work, but never advance its freshness on failure.
+      const rows = cached?.rows ?? [];
+      cached = { at: Date.now(), rows, success: false };
+      return rows;
     })
     .finally(() => {
       inFlight = null;
@@ -74,6 +90,7 @@ async function readCounts(): Promise<ProcessFleetMetricsRow[]> {
 export function bindProcessFleetMetricsSource(read: FleetReader): void {
   readFleet = read;
   cached = null;
+  lastSuccessAt = 0;
 }
 
 function fleetGauge(
@@ -125,3 +142,31 @@ export const pmOutboxDead = fleetGauge(
   "Dead outbox messages per process name — intents that will not happen until redriven.",
   (r) => r.deadMessages,
 );
+
+export const pmFleetCollectionSuccess = new Gauge({
+  name: "pm_fleet_collection_success",
+  help: "Whether the latest process fleet database collection succeeded. Absent when this process has no source bound.",
+  async collect() {
+    await readCounts();
+    this.reset();
+    if (readFleet) {
+      this.set(cached?.success ? 1 : 0);
+    } else {
+      this.remove();
+    }
+  },
+});
+
+export const pmFleetLastSuccessTimestampSeconds = new Gauge({
+  name: "pm_fleet_last_success_timestamp_seconds",
+  help: "Unix timestamp of the last successful process fleet database collection, or zero before the first success.",
+  async collect() {
+    await readCounts();
+    this.reset();
+    if (readFleet) {
+      this.set(lastSuccessAt / 1000);
+    } else {
+      this.remove();
+    }
+  },
+});

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/metrics.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/metrics.unit.test.ts
@@ -1,9 +1,11 @@
 import { register } from "prom-client";
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // Import to trigger metric registration
 import {
   gqBlockedGroups,
+  gqJobsUnroutableTotal,
+  recordDroppedJob,
   gqGroupsBlockedTotal,
   gqJobDelayMilliseconds,
   gqJobDurationMilliseconds,
@@ -214,5 +216,57 @@ describe("GroupQueue metrics", () => {
         gqBlockedGroups.set({ queue_name: "test-queue" }, 0),
       ).not.toThrow();
     });
+  });
+});
+
+describe("first discarded job visibility", () => {
+  beforeEach(() => {
+    register.resetMetrics();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-09-07T10:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("exposes the first discard on the first scrape and again after a counter reset", async () => {
+    const labels = {
+      ...routingLabels,
+      job_type: "subscriber",
+      reason: "missing_blob",
+    };
+    recordDroppedJob(labels);
+    const first = await register.getSingleMetricAsString(
+      "gq_jobs_last_dropped_timestamp_seconds",
+    );
+    expect(first).toContain('pipeline_name="test-pipeline"');
+    expect(first).toContain('job_type="subscriber"');
+    expect(first).toContain('reason="missing_blob"');
+    expect(first).toContain("1788775200");
+    const counter = await register.getSingleMetricAsString(
+      "gq_jobs_dropped_total",
+    );
+    expect(counter).toMatch(/reason="missing_blob"} 1/);
+
+    register.resetMetrics();
+    vi.advanceTimersByTime(20_000);
+    recordDroppedJob(labels);
+    const restarted = await register.getSingleMetricAsString(
+      "gq_jobs_last_dropped_timestamp_seconds",
+    );
+    expect(restarted).toContain("1788775220");
+  });
+
+  it("does not record reoffered unroutable work as a discard", async () => {
+    gqJobsUnroutableTotal.inc(routingLabels);
+    const dropped = await register.getSingleMetricAsString(
+      "gq_jobs_last_dropped_timestamp_seconds",
+    );
+    expect(dropped).not.toContain('queue_name="test-queue"');
+    const unroutable = await register.getSingleMetricAsString(
+      "gq_jobs_unroutable_total",
+    );
+    expect(unroutable).toMatch(/job_name="traceSummary"} 1/);
   });
 });

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/metrics.unit.test.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/__tests__/metrics.unit.test.ts
@@ -4,8 +4,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 // Import to trigger metric registration
 import {
   gqBlockedGroups,
-  gqJobsUnroutableTotal,
-  recordDroppedJob,
   gqGroupsBlockedTotal,
   gqJobDelayMilliseconds,
   gqJobDurationMilliseconds,
@@ -14,9 +12,11 @@ import {
   gqJobsExhaustedTotal,
   gqJobsNonRetryableTotal,
   gqJobsRetriedTotal,
+  gqJobsUnroutableTotal,
   gqOldestPendingAgeMilliseconds,
   gqRetryAttempt,
   gqRetryBackoffMilliseconds,
+  recordDroppedJob,
 } from "../metrics";
 
 const routingLabels = {
@@ -230,43 +230,53 @@ describe("first discarded job visibility", () => {
     vi.useRealTimers();
   });
 
-  it("exposes the first discard on the first scrape and again after a counter reset", async () => {
-    const labels = {
-      ...routingLabels,
-      job_type: "subscriber",
-      reason: "missing_blob",
-    };
-    recordDroppedJob(labels);
-    const first = await register.getSingleMetricAsString(
-      "gq_jobs_last_dropped_timestamp_seconds",
-    );
-    expect(first).toContain('pipeline_name="test-pipeline"');
-    expect(first).toContain('job_type="subscriber"');
-    expect(first).toContain('reason="missing_blob"');
-    expect(first).toContain("1788775200");
-    const counter = await register.getSingleMetricAsString(
-      "gq_jobs_dropped_total",
-    );
-    expect(counter).toMatch(/reason="missing_blob"} 1/);
+  describe("given a worker with no previous discard series", () => {
+    describe("when a job is discarded before and after a counter reset", () => {
+      /** @scenario "The first discarded queue job is visible without a counter baseline" */
+      it("exposes the first discard on the first scrape and again after a counter reset", async () => {
+        const labels = {
+          ...routingLabels,
+          job_type: "subscriber",
+          reason: "missing_blob",
+        };
+        recordDroppedJob(labels);
+        const first = await register.getSingleMetricAsString(
+          "gq_jobs_last_dropped_timestamp_seconds",
+        );
+        expect(first).toContain('pipeline_name="test-pipeline"');
+        expect(first).toContain('job_type="subscriber"');
+        expect(first).toContain('reason="missing_blob"');
+        expect(first).toContain("1788775200");
+        const counter = await register.getSingleMetricAsString(
+          "gq_jobs_dropped_total",
+        );
+        expect(counter).toMatch(/reason="missing_blob"} 1/);
 
-    register.resetMetrics();
-    vi.advanceTimersByTime(20_000);
-    recordDroppedJob(labels);
-    const restarted = await register.getSingleMetricAsString(
-      "gq_jobs_last_dropped_timestamp_seconds",
-    );
-    expect(restarted).toContain("1788775220");
+        register.resetMetrics();
+        vi.advanceTimersByTime(20_000);
+        recordDroppedJob(labels);
+        const restarted = await register.getSingleMetricAsString(
+          "gq_jobs_last_dropped_timestamp_seconds",
+        );
+        expect(restarted).toContain("1788775220");
+      });
+    });
   });
 
-  it("does not record reoffered unroutable work as a discard", async () => {
-    gqJobsUnroutableTotal.inc(routingLabels);
-    const dropped = await register.getSingleMetricAsString(
-      "gq_jobs_last_dropped_timestamp_seconds",
-    );
-    expect(dropped).not.toContain('queue_name="test-queue"');
-    const unroutable = await register.getSingleMetricAsString(
-      "gq_jobs_unroutable_total",
-    );
-    expect(unroutable).toMatch(/job_name="traceSummary"} 1/);
+  describe("given unroutable work that will be reoffered", () => {
+    describe("when its routing failure is recorded", () => {
+      /** @scenario "The first discarded queue job is visible without a counter baseline" */
+      it("does not record reoffered unroutable work as a discard", async () => {
+        gqJobsUnroutableTotal.inc(routingLabels);
+        const dropped = await register.getSingleMetricAsString(
+          "gq_jobs_last_dropped_timestamp_seconds",
+        );
+        expect(dropped).not.toContain('queue_name="test-queue"');
+        const unroutable = await register.getSingleMetricAsString(
+          "gq_jobs_unroutable_total",
+        );
+        expect(unroutable).toMatch(/job_name="traceSummary"} 1/);
+      });
+    });
   });
 });

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
@@ -90,7 +90,6 @@ import {
   gqJobsCompletedTotal,
   gqJobsDedupedTotal,
   gqJobsDelayedTotal,
-  recordDroppedJob,
   gqJobsExhaustedTotal,
   gqJobsNonRetryableTotal,
   gqJobsRetriedTotal,
@@ -99,6 +98,7 @@ import {
   gqRetryAttempt,
   gqRetryBackoffMilliseconds,
   gqRetryEncodeFailuresTotal,
+  recordDroppedJob,
 } from "./metrics";
 import { GroupQueueMetricsCollector } from "./metricsCollector";
 import {
@@ -300,9 +300,9 @@ const dropReasonOf = (err: unknown): DecodeFailureReason | "unknown" =>
  * - Weighted round-robin (sqrt(pendingCount)) provides fair scheduling across groups
  * - fastq provides concurrency-limited async task execution with backpressure
  */
-export class GroupQueueProcessor<
-  Payload extends Record<string, unknown>,
-> implements EventSourcedQueueProcessor<Payload> {
+export class GroupQueueProcessor<Payload extends Record<string, unknown>>
+  implements EventSourcedQueueProcessor<Payload>
+{
   private readonly logger = createLogger(
     "langwatch:event-sourcing:group-queue",
   );
@@ -390,7 +390,8 @@ export class GroupQueueProcessor<
    * a restarted pod must never inherit the identity of the one it replaced, or
    * its predecessor's death would resolve to "that's me, still running".
    */
-  private readonly workerId = `${hostname()}-${pid}-${randomUUID().slice(0, 8)}`;
+  private readonly workerId =
+    `${hostname()}-${pid}-${randomUUID().slice(0, 8)}`;
 
   /** Beacon refresh timer; stopped before the retirement write in {@link close}. */
   private livenessTimer: ReturnType<typeof setInterval> | undefined;

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
@@ -90,7 +90,7 @@ import {
   gqJobsCompletedTotal,
   gqJobsDedupedTotal,
   gqJobsDelayedTotal,
-  gqJobsDroppedTotal,
+  recordDroppedJob,
   gqJobsExhaustedTotal,
   gqJobsNonRetryableTotal,
   gqJobsRetriedTotal,
@@ -300,9 +300,9 @@ const dropReasonOf = (err: unknown): DecodeFailureReason | "unknown" =>
  * - Weighted round-robin (sqrt(pendingCount)) provides fair scheduling across groups
  * - fastq provides concurrency-limited async task execution with backpressure
  */
-export class GroupQueueProcessor<Payload extends Record<string, unknown>>
-  implements EventSourcedQueueProcessor<Payload>
-{
+export class GroupQueueProcessor<
+  Payload extends Record<string, unknown>,
+> implements EventSourcedQueueProcessor<Payload> {
   private readonly logger = createLogger(
     "langwatch:event-sourcing:group-queue",
   );
@@ -390,8 +390,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
    * a restarted pod must never inherit the identity of the one it replaced, or
    * its predecessor's death would resolve to "that's me, still running".
    */
-  private readonly workerId =
-    `${hostname()}-${pid}-${randomUUID().slice(0, 8)}`;
+  private readonly workerId = `${hostname()}-${pid}-${randomUUID().slice(0, 8)}`;
 
   /** Beacon refresh timer; stopped before the retirement write in {@link close}. */
   private livenessTimer: ReturnType<typeof setInterval> | undefined;
@@ -2471,7 +2470,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
     const { pipelineName, jobType, jobName } = readJobRoutingMeta(jobDataJson);
     const descriptor = readEnvelopeDescriptor(jobDataJson);
 
-    gqJobsDroppedTotal.inc({
+    recordDroppedJob({
       queue_name: this.queueName,
       pipeline_name: pipelineName ?? "unknown",
       job_type: jobType ?? "unknown",

--- a/platform/app/src/server/event-sourcing/queues/groupQueue/metrics.ts
+++ b/platform/app/src/server/event-sourcing/queues/groupQueue/metrics.ts
@@ -33,6 +33,7 @@ const metricNames = [
   "gq_retry_encode_failures_total",
   // #5538
   "gq_jobs_dropped_total",
+  "gq_jobs_last_dropped_timestamp_seconds",
   "gq_group_attempt_read_failures_total",
   // 2026-07-22 blob-retention fix
   "gq_blob_release_grace_total",
@@ -400,6 +401,29 @@ export const gqJobsDroppedTotal = new Counter({
     "reason",
   ] as const,
 });
+
+export const gqJobsLastDroppedTimestampSeconds = new Gauge({
+  name: "gq_jobs_last_dropped_timestamp_seconds",
+  help: "Unix timestamp of the latest discarded job in this process. Detects the first discard without a previous counter sample; not durable across an unscraped process exit.",
+  labelNames: [
+    "queue_name",
+    "pipeline_name",
+    "job_type",
+    "job_name",
+    "reason",
+  ] as const,
+});
+
+export function recordDroppedJob(labels: {
+  queue_name: string;
+  pipeline_name: string;
+  job_type: string;
+  job_name: string;
+  reason: string;
+}): void {
+  gqJobsDroppedTotal.inc(labels);
+  gqJobsLastDroppedTimestampSeconds.set(labels, Date.now() / 1000);
+}
 
 /**
  * A dispatched job whose routing metadata names a pipeline this worker does

--- a/specs/observability/process-substrate-alerting.feature
+++ b/specs/observability/process-substrate-alerting.feature
@@ -53,3 +53,26 @@ Feature: The process substrate tells operators when it is in trouble
     Given the substrate and topic clustering dashboards are tracked in the infra repository
     Then production Grafana serves them from reviewed, versioned JSON
     And a metric rename in this repository is caught by its alert rules referencing the old name
+
+  Scenario: A failed fleet collection cannot clear unresolved work
+    Given the last successful database read found a dead outbox intent
+    When the next fleet metrics collection fails
+    Then the dead count remains visible
+    And collection success is zero
+    And the last successful collection timestamp does not advance
+    And concurrent gauges share the same collection attempt
+
+  Scenario: The first discarded queue job is visible without a counter baseline
+    Given a worker has never emitted a discard metric series
+    When a job is discarded
+    Then the first scrape exposes its last-discard timestamp
+    And the metric identifies queue, pipeline, job type, job name and reason
+    And reoffered unroutable work does not set that timestamp
+    And a subsequent discard after a worker restart is visible on its first scrape
+
+  Scenario: OTLP partial rejection exposes its cause independently of HTTP status
+    Given an OTLP request contains collected, filtered, duplicate and rejected spans
+    When the collection tally records their outcomes
+    Then metrics distinguish dispatch failure from invalid or aged spans
+    And intentional filtering and deduplication are not counted as rejected
+    And dispatched spans are not described as already queryable

--- a/specs/observability/process-substrate-alerting.feature
+++ b/specs/observability/process-substrate-alerting.feature
@@ -54,6 +54,7 @@ Feature: The process substrate tells operators when it is in trouble
     Then production Grafana serves them from reviewed, versioned JSON
     And a metric rename in this repository is caught by its alert rules referencing the old name
 
+  @unit
   Scenario: A failed fleet collection cannot clear unresolved work
     Given the last successful database read found a dead outbox intent
     When the next fleet metrics collection fails
@@ -62,6 +63,7 @@ Feature: The process substrate tells operators when it is in trouble
     And the last successful collection timestamp does not advance
     And concurrent gauges share the same collection attempt
 
+  @unit
   Scenario: The first discarded queue job is visible without a counter baseline
     Given a worker has never emitted a discard metric series
     When a job is discarded
@@ -70,6 +72,7 @@ Feature: The process substrate tells operators when it is in trouble
     And reoffered unroutable work does not set that timestamp
     And a subsequent discard after a worker restart is visible on its first scrape
 
+  @unit
   Scenario: OTLP partial rejection exposes its cause independently of HTTP status
     Given an OTLP request contains collected, filtered, duplicate and rejected spans
     When the collection tally records their outcomes


### PR DESCRIPTION
## Why

Production detectors need to distinguish a failed metrics collection from an empty queue and separate ingestion failures from intentional filtering. This supplies the application signals consumed by langwatch/langwatch-saas#1214.

## What changed

- Expose process-fleet collection success and the last successful collection timestamp, retaining prior counts when a read fails.
- Record the latest discarded queue job timestamp so a first event is visible without a counter baseline.
- Classify span ingestion outcomes with bounded metric labels.
- Extract the existing ingestion tally while preserving rejection and retry semantics.
- Extend ADR-054 and the process-substrate alerting spec, with enforced test bindings.
- Split ready-PR unit CI across five shards after two runs hit the four-minute limit while still processing tests. The timeout and test selection stay unchanged.

## How it works

Fleet gauges share a cached database read, including failed attempts. A failed read does not advance freshness. Ingestion counters distinguish collected, dropped, deduplicated, filtered and failed spans.

Incident processing and Slack delivery live in the SaaS repository's `functions/alerting` service.

## Test plan

- [x] 32 focused tests across ingestion tally, process-fleet metrics and group-queue metrics.
- [x] Oxfmt on reviewed tests, Oxc on changed TypeScript and `git diff --check`.
- [x] Pinned Biome app lint (9,325 files) and feature-parity check after review fixes.
- [x] Strict process-manager/queue TypeScript slice checked during implementation.
- [x] Initial core CI: full app typecheck, build, unit, component and integration suites.
- Local full app typecheck remains unavailable because the isolated checkout lacks its TypeScript installation.

## Deployment Impact

Deploy the app and workers before activating the corresponding SaaS detectors so their scrape targets expose the new metrics. No environment variables, schema migrations or Helm values are added. Rollback removes these signals, so deactivate the dependent detectors before rolling back the instrumentation. This PR does not enable production alert routing.

## Anything surprising?

These metrics are detector inputs as well as diagnostic context. Deploying this instrumentation is part of making the corresponding SaaS detectors operational.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added observability metrics for fleet collection success, collection freshness, discarded queue jobs, and OTLP trace-ingestion outcomes.
  - Added timestamps for the latest successful fleet collection and discarded queue jobs.
  - Improved trace-ingestion reporting by distinguishing collected, failed, dropped, deduplicated, and filtered spans.

- **Bug Fixes**
  - Preserved the latest successful collection data when subsequent metric reads fail.
  - Improved visibility into initial and recovered collection states.
  - Clarified partial-rejection reporting by separating processing failures from intentionally filtered or deduplicated spans.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


