### PR TITLE
fix(analytics): refuse a filter value the query cannot apply

### DIFF
--- a/docs/features/embedded-analytics.mdx
+++ b/docs/features/embedded-analytics.mdx
@@ -29,6 +29,7 @@ curl -X POST "$ENDPOINT" \
     {
      "startDate": 1708434000000,
      "endDate": 1710939600000,
+     "timeZone": "UTC",
      "filters": {},
      "series": [
        {
@@ -42,6 +43,26 @@ EOF
 ```
 
     4. Execute the `curl` command. If successful, LangWatch will return the custom analytics data in the response.
+
+## Filters
+
+`filters` narrows the query the same way the filter sidebar narrows the dashboard. Each key is a filter field and each value is the list of options to keep:
+
+```json
+{
+  "filters": {
+    "traces.error": ["true"],
+    "metadata.user_id": ["user-123"],
+    "metadata.value": { "environment": ["production"] }
+  }
+}
+```
+
+Send the option's **value**, not the label shown in the interface. `traces.error` accepts `"true"` and `"false"`, and so do `annotations.hasAnnotation` and `evaluations.passed`. Sending `"Traces with error"` is rejected with a `validation_error` naming the field and listing the values it accepts.
+
+Filters that need a key, such as `metadata.value`, take an object whose key is the metadata key to filter on. Sending a plain list for those is rejected as well.
+
+An unknown filter field is rejected too, with the full list of fields in the response.
 
 ## Screenshots on how to get the JSON data.
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -37907,6 +37907,7 @@ curl -X POST "$ENDPOINT" \
     {
      "startDate": 1708434000000,
      "endDate": 1710939600000,
+     "timeZone": "UTC",
      "filters": {},
      "series": [
        {
@@ -37920,6 +37921,26 @@ EOF
 ```
 
     4. Execute the `curl` command. If successful, LangWatch will return the custom analytics data in the response.
+
+## Filters
+
+`filters` narrows the query the same way the filter sidebar narrows the dashboard. Each key is a filter field and each value is the list of options to keep:
+
+```json
+{
+  "filters": {
+    "traces.error": ["true"],
+    "metadata.user_id": ["user-123"],
+    "metadata.value": { "environment": ["production"] }
+  }
+}
+```
+
+Send the option's **value**, not the label shown in the interface. `traces.error` accepts `"true"` and `"false"`, and so do `annotations.hasAnnotation` and `evaluations.passed`. Sending `"Traces with error"` is rejected with a `validation_error` naming the field and listing the values it accepts.
+
+Filters that need a key, such as `metadata.value`, take an object whose key is the metadata key to filter on. Sending a plain list for those is rejected as well.
+
+An unknown filter field is rejected too, with the full list of fields in the response.
 
 ## Screenshots on how to get the JSON data.
 

--- a/platform/app/src/app/api/analytics/__tests__/filter-values.integration.test.ts
+++ b/platform/app/src/app/api/analytics/__tests__/filter-values.integration.test.ts
@@ -1,0 +1,130 @@
+/**
+ * @vitest-environment node
+ *
+ * @see specs/analytics/filter-value-validation.feature
+ *
+ * Drives both REST analytics paths the way the customer report did: a project
+ * API key in `X-Auth-Token`, and a `traces.error` filter carrying the option's
+ * LABEL instead of its value. Both used to answer 200 with the unfiltered
+ * numbers.
+ */
+
+import { nanoid } from "nanoid";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { app as analyticsApp } from "~/app/api/analytics/[...route]/app";
+import type { Organization, Project, Team } from "~/generated/prisma/client";
+import { prisma } from "~/server/db";
+import { app as miscApp } from "~/server/routes/misc";
+import { wireDefaultTestApp } from "~/test-utils/wireDefaultTestApp";
+
+wireDefaultTestApp();
+
+const ns = `analytics-filters-${nanoid(8)}`;
+
+let organization: Organization;
+let team: Team;
+let project: Project;
+
+beforeAll(async () => {
+  organization = await prisma.organization.create({
+    data: { name: `Org ${ns}`, slug: `--test-org-${ns}` },
+  });
+  team = await prisma.team.create({
+    data: {
+      name: `Team ${ns}`,
+      slug: `--test-team-${ns}`,
+      organizationId: organization.id,
+    },
+  });
+  project = await prisma.project.create({
+    data: {
+      name: `Project ${ns}`,
+      slug: `--test-project-${ns}`,
+      teamId: team.id,
+      language: "python",
+      framework: "openai",
+      apiKey: `test-pkey-${ns}`,
+    },
+  });
+}, 120_000);
+
+afterAll(async () => {
+  await prisma.project
+    .deleteMany({ where: { slug: { contains: ns } } })
+    .catch(() => {});
+  await prisma.team
+    .deleteMany({ where: { slug: { contains: ns } } })
+    .catch(() => {});
+  await prisma.organization
+    .deleteMany({ where: { slug: { contains: ns } } })
+    .catch(() => {});
+});
+
+const now = Date.now();
+
+function body(filters: Record<string, string[]>) {
+  return JSON.stringify({
+    startDate: now - 24 * 60 * 60 * 1000,
+    endDate: now,
+    timeZone: "UTC",
+    filters,
+    series: [{ metric: "metadata.trace_id", aggregation: "cardinality" }],
+    timeScale: 1,
+  });
+}
+
+function headers() {
+  return {
+    "X-Auth-Token": project.apiKey,
+    "Content-Type": "application/json",
+  };
+}
+
+describe("Feature: analytics rejects filter values it cannot apply", () => {
+  describe("given a project API key that may read analytics", () => {
+    /** @scenario "The REST endpoint refuses a filter value it cannot apply" */
+    it("refuses an option label on POST /api/analytics/timeseries", async () => {
+      const res = await analyticsApp.request("/api/analytics/timeseries", {
+        method: "POST",
+        headers: headers(),
+        body: body({ "traces.error": ["Traces with error"] }),
+      });
+
+      expect(res.status).toBe(422);
+      const payload = (await res.json()) as {
+        error: string;
+        reasons?: Array<{ code: string; meta?: Record<string, unknown> }>;
+      };
+      expect(payload.error).toBe("validation_error");
+      expect(payload.reasons?.[0]?.meta).toMatchObject({
+        field: "filters.traces.error",
+        type: "unsupported_filter_value",
+        expected: ["true", "false"],
+        received: "Traces with error",
+      });
+    });
+
+    /** @scenario "The legacy REST analytics path refuses the same value" */
+    it("refuses an option label on the legacy POST /api/analytics", async () => {
+      const res = await miscApp.request("/api/analytics", {
+        method: "POST",
+        headers: headers(),
+        body: body({ "traces.error": ["Traces without error"] }),
+      });
+
+      expect(res.status).toBe(422);
+      const payload = (await res.json()) as { error: string };
+      expect(payload.error).toBe("validation_error");
+    });
+
+    it("still refuses a filter field that is not a filter field at all", async () => {
+      const res = await analyticsApp.request("/api/analytics/timeseries", {
+        method: "POST",
+        headers: headers(),
+        body: body({ "traces.not_a_field": ["true"] }),
+      });
+
+      expect(res.status).toBe(422);
+    });
+  });
+});

--- a/platform/app/src/server/analytics/clickhouse/__tests__/error-filter.integration.test.ts
+++ b/platform/app/src/server/analytics/clickhouse/__tests__/error-filter.integration.test.ts
@@ -1,0 +1,175 @@
+/**
+ * @see specs/analytics/filter-value-validation.feature
+ *
+ * The reported symptom was numbers, not SQL: a timeseries asked for "traces
+ * with an error" came back identical to the unfiltered one. Asserting on the
+ * generated WHERE clause would not have caught that, because the clause the
+ * old code generated (`1=1`) was valid SQL that ran fine. So this test seeds
+ * real traces into `trace_summaries`, runs the real timeseries query against
+ * a real ClickHouse, and compares the three counts a caller would compare.
+ */
+
+import type { ClickHouseClient } from "@clickhouse/client";
+import { nanoid } from "nanoid";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { buildTimeseriesQuery } from "~/server/analytics/clickhouse/aggregation-builder";
+import { TraceSummaryClickHouseRepository } from "~/server/app-layer/traces/repositories/trace-summary.clickhouse.repository";
+import type { TraceSummaryData } from "~/server/app-layer/traces/types";
+import {
+  startTestContainers,
+  stopTestContainers,
+} from "~/server/event-sourcing/__tests__/integration/testContainers";
+
+const tenantId = `test-error-filter-${nanoid()}`;
+
+// Minute-aligned "yesterday", never a fixed calendar date: rows are stamped
+// with the platform's default retention and TTL-deleted that many days after
+// OccurredAt, so a fixed date eventually ages out and the fixtures vanish.
+const baseMs = Math.floor((Date.now() - 24 * 60 * 60 * 1000) / 60_000) * 60_000;
+
+let ch: ClickHouseClient;
+let summaryRepo: TraceSummaryClickHouseRepository;
+
+function makeSummary(overrides: Partial<TraceSummaryData>): TraceSummaryData {
+  return {
+    traceId: `trace-${nanoid()}`,
+    spanCount: 1,
+    totalDurationMs: 100,
+    computedIOSchemaVersion: "2026-04-28",
+    computedInput: null,
+    computedOutput: null,
+    timeToFirstTokenMs: null,
+    timeToLastTokenMs: null,
+    tokensPerSecond: null,
+    containsErrorStatus: false,
+    containsOKStatus: true,
+    errorMessage: null,
+    models: [],
+    totalCost: 0,
+    nonBilledCost: 0,
+    tokensEstimated: false,
+    totalPromptTokenCount: 0,
+    totalCompletionTokenCount: 0,
+    outputFromRootSpan: false,
+    outputSpanEndTimeMs: 0,
+    blockedByGuardrail: false,
+    rootSpanType: "llm",
+    containsAi: true,
+    containsPrompt: false,
+    selectedPromptId: null,
+    selectedPromptSpanId: null,
+    selectedPromptStartTimeMs: null,
+    lastUsedPromptId: null,
+    lastUsedPromptVersionNumber: null,
+    lastUsedPromptVersionId: null,
+    lastUsedPromptSpanId: null,
+    lastUsedPromptStartTimeMs: null,
+    topicId: null,
+    subTopicId: null,
+    annotationIds: [],
+    traceName: "filter fixture",
+    attributes: {},
+    traceNameUserOverridden: false,
+    traceNameFromFallback: false,
+    rootMetadataFromFallback: false,
+    occurredAt: baseMs,
+    createdAt: baseMs,
+    updatedAt: baseMs,
+    LastEventOccurredAt: baseMs,
+    ...overrides,
+  };
+}
+
+const window = {
+  startDate: new Date(baseMs - 60 * 60 * 1000),
+  endDate: new Date(baseMs + 60 * 60 * 1000),
+  previousPeriodStartDate: new Date(baseMs - 26 * 60 * 60 * 1000),
+  timeScale: 1440 as const,
+  timeZone: "UTC",
+};
+
+/** The trace count a caller would read off the chart, for these filters. */
+async function traceCount(
+  filters?: Parameters<typeof buildTimeseriesQuery>[0]["filters"],
+): Promise<number> {
+  const { sql, params } = buildTimeseriesQuery({
+    projectId: tenantId,
+    startDate: window.startDate,
+    endDate: window.endDate,
+    previousPeriodStartDate: window.previousPeriodStartDate,
+    series: [
+      { metric: "metadata.trace_id", aggregation: "cardinality" as const },
+    ],
+    filters,
+    timeScale: window.timeScale,
+    timeZone: window.timeZone,
+  });
+  const result = await ch.query({
+    query: sql,
+    query_params: params,
+    format: "JSONEachRow",
+  });
+  const rows = (await result.json()) as Array<Record<string, unknown>>;
+  return rows
+    .filter((row) => row.period === "current")
+    .reduce(
+      (total, row) =>
+        total + Number(row["0__metadata_trace_id__cardinality"] ?? 0),
+      0,
+    );
+}
+
+beforeAll(async () => {
+  const containers = await startTestContainers();
+  ch = containers.clickHouseClient;
+  summaryRepo = new TraceSummaryClickHouseRepository(async () => ch);
+
+  await summaryRepo.upsertBatch([
+    { data: makeSummary({ containsErrorStatus: true }), tenantId },
+    { data: makeSummary({ containsErrorStatus: true }), tenantId },
+    { data: makeSummary({ containsErrorStatus: false }), tenantId },
+    { data: makeSummary({ containsErrorStatus: false }), tenantId },
+    { data: makeSummary({ containsErrorStatus: false }), tenantId },
+  ]);
+  await ch.exec({ query: "SYSTEM FLUSH ASYNC INSERT QUEUE" });
+  await ch.exec({ query: "SYSTEM FLUSH LOGS" });
+}, 180_000);
+
+afterAll(async () => {
+  if (ch) {
+    await ch.exec({
+      query:
+        "ALTER TABLE trace_summaries DELETE WHERE TenantId = {tenantId:String}",
+      query_params: { tenantId },
+    });
+  }
+  await stopTestContainers();
+});
+
+describe("Feature: analytics rejects filter values it cannot apply", () => {
+  describe("given two traces that contain an error and three that do not", () => {
+    /** @scenario "A filtered timeseries query returns fewer traces than an unfiltered one" */
+    it("counts only the traces that contain an error when filtered", async () => {
+      const unfiltered = await traceCount();
+      const withError = await traceCount({ "traces.error": ["true"] });
+      const withoutError = await traceCount({ "traces.error": ["false"] });
+
+      expect(unfiltered).toBe(5);
+      expect(withError).toBe(2);
+      expect(withoutError).toBe(3);
+      // The regression itself: these three used to be the same number.
+      expect(withError).not.toBe(unfiltered);
+      expect(withError).not.toBe(withoutError);
+    });
+
+    it("counts every trace when both error states are asked for", async () => {
+      expect(await traceCount({ "traces.error": ["true", "false"] })).toBe(5);
+    });
+
+    it("refuses an option label before running any query", async () => {
+      await expect(
+        traceCount({ "traces.error": ["Traces with error"] }),
+      ).rejects.toMatchObject({ code: "validation_error" });
+    });
+  });
+});

--- a/platform/app/src/server/analytics/clickhouse/__tests__/filter-translator.test.ts
+++ b/platform/app/src/server/analytics/clickhouse/__tests__/filter-translator.test.ts
@@ -167,6 +167,7 @@ describe("filter-translator", () => {
         });
       });
 
+      /** @scenario "Filtering to traces that contain an error narrows the query" */
       it("translates traces.error filter for true using ContainsErrorStatus", () => {
         const result = translateFilter("traces.error", ["true"]);
         expect(result.whereClause).toContain("ts.ContainsErrorStatus = 1");
@@ -174,6 +175,7 @@ describe("filter-translator", () => {
         expect(result.requiredJoins).toHaveLength(0);
       });
 
+      /** @scenario "Filtering to traces without an error narrows the query" */
       it("translates traces.error filter for false using ContainsErrorStatus", () => {
         const result = translateFilter("traces.error", ["false"]);
         expect(result.whereClause).toContain("ts.ContainsErrorStatus = 0");
@@ -182,10 +184,82 @@ describe("filter-translator", () => {
         expect(result.requiredJoins).toHaveLength(0);
       });
 
+      /** @scenario "Asking for both error states filters nothing" */
       it("returns no-op when both true and false are specified", () => {
         const result = translateFilter("traces.error", ["true", "false"]);
         expect(result.whereClause).toBe("1=1");
         expect(result.params).toEqual({});
+      });
+    });
+
+    describe("when a filter value is not one the field can apply", () => {
+      /** @scenario "A filter value the field does not accept is refused" */
+      it("refuses an option label sent in place of the traces.error value", () => {
+        expect(() =>
+          translateFilter("traces.error", ["Traces with error"]),
+        ).toThrow(
+          expect.objectContaining({ code: "validation_error" }) as Error,
+        );
+      });
+
+      it("names the field and the values it accepts", () => {
+        let thrown: any;
+        try {
+          translateFilter("traces.error", ["Traces with error"]);
+        } catch (error) {
+          thrown = error;
+        }
+        expect(thrown.meta.fields).toEqual(["filters.traces.error"]);
+        expect(thrown.reasons[0].meta).toMatchObject({
+          field: "filters.traces.error",
+          type: "unsupported_filter_value",
+          expected: ["true", "false"],
+          received: "Traces with error",
+        });
+      });
+
+      /** @scenario "The annotation filter refuses a value it cannot apply" */
+      it("refuses an option label sent in place of the annotations.hasAnnotation value", () => {
+        expect(() =>
+          translateFilter("annotations.hasAnnotation", ["Has Annotation"]),
+        ).toThrow(
+          expect.objectContaining({ code: "validation_error" }) as Error,
+        );
+      });
+
+      /** @scenario "The evaluation pass filter refuses a value it cannot apply" */
+      it("refuses an option label sent in place of the evaluations.passed value", () => {
+        expect(() =>
+          translateFilter("evaluations.passed", ["Passed"], "evaluator-1"),
+        ).toThrow(
+          expect.objectContaining({ code: "validation_error" }) as Error,
+        );
+      });
+
+      /** @scenario "A metadata value filter sent without its metadata key is refused" */
+      it("refuses metadata.value with no metadata key", () => {
+        expect(() => translateFilter("metadata.value", ["prod"])).toThrow(
+          expect.objectContaining({ code: "validation_error" }) as Error,
+        );
+      });
+
+      /** @scenario "An event metric value filter sent without its metric key is refused" */
+      it("refuses events.metrics.value with no metric key", () => {
+        expect(() =>
+          translateFilter("events.metrics.value", ["0", "1"], "thumbs_up"),
+        ).toThrow(
+          expect.objectContaining({ code: "validation_error" }) as Error,
+        );
+      });
+
+      it("still accepts the values the options endpoint returns", () => {
+        expect(() => translateFilter("traces.error", ["true"])).not.toThrow();
+        expect(() =>
+          translateFilter("annotations.hasAnnotation", ["false"]),
+        ).not.toThrow();
+        expect(() =>
+          translateFilter("metadata.value", ["prod"], "env"),
+        ).not.toThrow();
       });
     });
 

--- a/platform/app/src/server/analytics/clickhouse/filter-translator.ts
+++ b/platform/app/src/server/analytics/clickhouse/filter-translator.ts
@@ -16,6 +16,7 @@
  * are semantically equivalent to EXISTS.
  */
 
+import { assertFilterValuesAreSupported } from "../../filters/supported-values";
 import type { FilterField } from "../../filters/types";
 import { type CHTable, tableAliases } from "./field-mappings";
 
@@ -162,6 +163,11 @@ export function translateFilter(
     return noOpFilter;
   }
 
+  // Before any SQL: a value this field cannot translate is refused, never
+  // widened. Several handlers below fall back to "1=1" when they recognise
+  // nothing, which returns the unfiltered answer under a filtered request.
+  assertFilterValuesAreSupported({ field, values, key, subkey });
+
   const handler = filterHandlers[field];
   return handler ? handler(values, key, subkey, spanTimePredicate) : noOpFilter;
 }
@@ -249,6 +255,8 @@ function translateMetadataValueFilter(
   key?: string,
 ): FilterTranslation {
   const ts = tableAliases.trace_summaries;
+  // `translateFilter` refuses this field without a key, so this only guards
+  // a direct call.
   if (!key) {
     return { whereClause: "1=1", requiredJoins: [], params: {} };
   }
@@ -346,7 +354,8 @@ function translateErrorFilter(values: string[]): FilterTranslation {
     };
   }
 
-  // Both or neither - no filtering
+  // Both states selected: every row, which is what was asked for. Values
+  // outside {true, false} never reach here; `translateFilter` refuses them.
   return { whereClause: "1=1", requiredJoins: [], params: {} };
 }
 
@@ -665,6 +674,8 @@ function translateEventMetricValueFilter(
 ): FilterTranslation {
   const ts = tableAliases.trace_summaries;
 
+  // `translateFilter` refuses this field without a metric key, so this only
+  // guards a direct call.
   if (!metricKey) {
     return { whereClause: "1=1", requiredJoins: [], params: {} };
   }
@@ -752,7 +763,8 @@ function translateAnnotationFilter(values: string[]): FilterTranslation {
     };
   }
 
-  // Both or neither - no filtering
+  // Both states selected: every row, which is what was asked for. Values
+  // outside {true, false} never reach here; `translateFilter` refuses them.
   return { whereClause: "1=1", requiredJoins: [], params: {} };
 }
 

--- a/platform/app/src/server/app-layer/analytics/analytics.service.ts
+++ b/platform/app/src/server/app-layer/analytics/analytics.service.ts
@@ -35,6 +35,7 @@ import { currentVsPreviousDates } from "~/server/api/routers/analytics/common";
 import type { ClickHouseClientResolver } from "~/server/clickhouse/clickhouseClient";
 import { featureFlagService } from "~/server/featureFlag";
 import { NOT_TARGETED } from "~/server/featureFlag/targeting";
+import { assertFiltersAreSupported } from "~/server/filters/supported-values";
 import type { FilterField } from "~/server/filters/types";
 import { TtlCache } from "~/server/utils/ttlCache";
 import { adjustTimeScaleForBucketCap } from "./query-builders/_shared";
@@ -110,6 +111,12 @@ export class AnalyticsService {
       "AnalyticsService.getTimeseries",
       { attributes: { "tenant.id": input.projectId } },
       async () => {
+        // Before the cache and before routing: every table has its own filter
+        // translator, and each one used to widen rather than fail on a value
+        // it could not apply. Refusing here is the one place that covers all
+        // of them, so a dropped filter can never reach a result.
+        assertFiltersAreSupported(input.filters);
+
         const hash = createHash("sha256")
           // `options` is part of the cache identity, not a side channel: a
           // bounded read and an unbounded one are different questions, and a

--- a/platform/app/src/server/app-layer/analytics/query-builders/slim-timeseries-query.ts
+++ b/platform/app/src/server/app-layer/analytics/query-builders/slim-timeseries-query.ts
@@ -25,6 +25,7 @@
 import { buildMetricAlias } from "~/server/analytics/clickhouse/metric-translator";
 import type { AggregationTypes } from "~/server/analytics/types";
 import { TRACE_ANALYTICS_HAS_SIGNAL_SQL } from "~/server/event-sourcing/pipelines/trace-processing/projections/traceAnalytics.foldProjection";
+import { assertFilterValuesAreSupported } from "~/server/filters/supported-values";
 import type { FilterField } from "~/server/filters/types";
 import {
   isSlimEligibleTraceMetricKey,
@@ -314,9 +315,12 @@ function buildSlimFilterClauses(
         break;
       }
       case "traces.error": {
-        // ES sends "true"/"false"; map to HasError boolean.
+        // The options endpoint returns "true"/"false"; map to HasError. A
+        // value outside that pair is refused rather than dropped, which would
+        // answer the unfiltered numbers under a filtered request.
         const vals = collectStringValues(rawValue);
         if (vals.length === 0) break;
+        assertFilterValuesAreSupported({ field, values: vals });
         if (vals.includes("true") && !vals.includes("false")) {
           clauses.push(`${ta}.HasError = true`);
         } else if (vals.includes("false") && !vals.includes("true")) {

--- a/platform/app/src/server/filters/__tests__/supported-values.unit.test.ts
+++ b/platform/app/src/server/filters/__tests__/supported-values.unit.test.ts
@@ -1,0 +1,58 @@
+/**
+ * @see specs/analytics/filter-value-validation.feature
+ *
+ * The whole-set walk, which is what the analytics service calls before it
+ * decides which table serves a request. Each table has its own filter
+ * translator, so a check inside any one of them would leave the others free
+ * to keep dropping values.
+ */
+
+import { describe, expect, it } from "vitest";
+import { assertFiltersAreSupported } from "../supported-values";
+
+describe("assertFiltersAreSupported", () => {
+  describe("when a filter set carries only values the fields accept", () => {
+    it("passes a flat, a keyed and a key-and-subkey filter together", () => {
+      expect(() =>
+        assertFiltersAreSupported({
+          "traces.error": ["true"],
+          "metadata.value": { env: ["prod"] },
+          "events.metrics.value": { thumbs_up: { vote: ["0", "1"] } },
+        }),
+      ).not.toThrow();
+    });
+
+    it("passes an empty set and an empty value list", () => {
+      expect(() => assertFiltersAreSupported({})).not.toThrow();
+      expect(() => assertFiltersAreSupported(undefined)).not.toThrow();
+      expect(() =>
+        assertFiltersAreSupported({ "traces.error": [] }),
+      ).not.toThrow();
+    });
+  });
+
+  describe("when a filter set carries a value the field cannot apply", () => {
+    it("refuses it at the top level", () => {
+      expect(() =>
+        assertFiltersAreSupported({
+          "metadata.user_id": ["someone"],
+          "traces.error": ["Traces with error"],
+        }),
+      ).toThrow(expect.objectContaining({ code: "validation_error" }) as Error);
+    });
+
+    it("refuses a keyed filter missing its key", () => {
+      expect(() =>
+        assertFiltersAreSupported({ "metadata.value": ["prod"] }),
+      ).toThrow(expect.objectContaining({ code: "validation_error" }) as Error);
+    });
+
+    it("refuses a key-and-subkey filter given only a key", () => {
+      expect(() =>
+        assertFiltersAreSupported({
+          "events.metrics.value": { thumbs_up: ["0", "1"] },
+        }),
+      ).toThrow(expect.objectContaining({ code: "validation_error" }) as Error);
+    });
+  });
+});

--- a/platform/app/src/server/filters/supported-values.ts
+++ b/platform/app/src/server/filters/supported-values.ts
@@ -1,0 +1,193 @@
+/**
+ * What each analytics filter field is able to filter by, and the refusal for
+ * anything else.
+ *
+ * ── WHY THIS EXISTS ────────────────────────────────────────────────────────
+ *
+ * A filter the platform cannot apply used to widen instead of failing. The
+ * boolean fields translate their values by looking for the strings "true" and
+ * "false" and fall back to "no filtering" when they find neither, so
+ * `{"traces.error": ["Traces with error"]}` returned the same numbers as
+ * `{}` and the same numbers as `["Traces without error"]`. Nothing in the
+ * response said a filter had been dropped.
+ *
+ * That value is not invented: the filter-options endpoint returns each option
+ * as a `field` (what to send) and a `label` (what to show), and "Traces with
+ * error" is the label of the option whose field is "true". The UI sends the
+ * field, so the UI never hit this. Anyone writing against the REST API by
+ * reading the option list did.
+ *
+ * The same shape of silence exists for the two fields whose translation needs
+ * a key: without one they match every row rather than saying the key is
+ * missing.
+ *
+ * Refusing is the point. A 422 naming the field and listing what it accepts
+ * costs one retry; numbers that look filtered and are not cost whatever gets
+ * decided on them.
+ */
+
+import type { FieldViolation } from "~/server/api/validation";
+import { RequestValidationError } from "~/server/api/validation";
+import { availableFilters } from "./registry";
+import type { FilterField } from "./types";
+
+/** The only two values a boolean filter's options endpoint ever returns. */
+const BOOLEAN_FILTER_VALUES = ["true", "false"] as const;
+
+/**
+ * Fields whose option list is exactly {true, false}.
+ *
+ * Kept as an explicit set rather than derived: the shared truth is the SQL in
+ * `clickhouse/filter-definitions.ts`, which projects a boolean column to those
+ * two strings, and there is no runtime handle on that.
+ */
+const BOOLEAN_VALUE_FIELDS = new Set<FilterField>([
+  "traces.error",
+  "annotations.hasAnnotation",
+  "evaluations.passed",
+]);
+
+/**
+ * Fields whose translation covers every row when the key is absent.
+ *
+ * Not every field carrying `requiresKey` belongs here. `evaluations.passed`,
+ * `.score`, `.label` and `.state` all translate without one, filtering across
+ * every evaluator instead of a named one: broader than the caller may have
+ * meant, but honestly narrower than no filter, so it stays allowed.
+ */
+const FIELDS_REQUIRING_KEY = new Set<FilterField>(["metadata.value"]);
+
+/** Fields whose translation covers every row when the subkey is absent. */
+const FIELDS_REQUIRING_SUBKEY = new Set<FilterField>(["events.metrics.value"]);
+
+/** How a field reads in a sentence written for a customer. */
+function nameOf(field: FilterField): string {
+  return availableFilters[field].name;
+}
+
+/** The name of the filter supplying `field`'s key, as the customer sees it. */
+function keyNameOf(field: FilterField): string | undefined {
+  const required =
+    availableFilters[field].requiresSubkey ??
+    availableFilters[field].requiresKey;
+  return required ? nameOf(required.filter) : undefined;
+}
+
+function unsupportedValue(
+  field: FilterField,
+  received: string,
+): FieldViolation {
+  return {
+    field: `filters.${field}`,
+    type: "unsupported_filter_value",
+    message: `The "${nameOf(field)}" filter accepts only "true" or "false". Send an option's value, not the label shown next to it.`,
+    expected: [...BOOLEAN_FILTER_VALUES],
+    received,
+  };
+}
+
+function missingKey(field: FilterField): FieldViolation {
+  const keyName = keyNameOf(field);
+  return {
+    field: `filters.${field}`,
+    type: "missing_filter_key",
+    message: keyName
+      ? `The "${nameOf(field)}" filter needs a "${keyName}" to filter by, given as the object key next to the values.`
+      : `The "${nameOf(field)}" filter needs a key to filter by, given as the object key next to the values.`,
+  };
+}
+
+/** The first thing wrong with one field's filter, if anything is. */
+function violationOf(args: {
+  field: FilterField;
+  values: string[];
+  key?: string;
+  subkey?: string;
+}): FieldViolation | undefined {
+  const { field, values, key, subkey } = args;
+
+  if (BOOLEAN_VALUE_FIELDS.has(field)) {
+    const bad = values.find(
+      (value) => !(BOOLEAN_FILTER_VALUES as readonly string[]).includes(value),
+    );
+    if (bad !== undefined) return unsupportedValue(field, bad);
+  }
+
+  if (FIELDS_REQUIRING_KEY.has(field) && !key) return missingKey(field);
+  if (FIELDS_REQUIRING_SUBKEY.has(field) && !subkey) return missingKey(field);
+
+  return undefined;
+}
+
+/**
+ * Refuse a filter this platform would otherwise drop.
+ *
+ * Called for every field of every analytics filter set, before any SQL is
+ * built, so REST and tRPC callers get the identical refusal.
+ */
+export function assertFilterValuesAreSupported(args: {
+  field: FilterField;
+  values: string[];
+  key?: string;
+  subkey?: string;
+}): void {
+  const violation = violationOf(args);
+  if (!violation) return;
+
+  throw new RequestValidationError({
+    target: "json",
+    violations: [violation],
+  });
+}
+
+/** One filter field's values, in any of the three shapes a filter set allows. */
+type FilterValue =
+  | string[]
+  | Record<string, string[]>
+  | Record<string, Record<string, string[]>>;
+
+/**
+ * Refuse an entire filter set, before anything decides how to serve it.
+ *
+ * Analytics has more than one query builder, and each one translates the
+ * handful of fields its table can serve. Validating inside any single builder
+ * would leave the others free to keep dropping values, so the whole set is
+ * checked once at the service boundary instead. Walks the same nesting the
+ * builders walk: a flat array, an object keyed by the filter's key, or one
+ * keyed by key then subkey.
+ */
+export function assertFiltersAreSupported(
+  filters: Partial<Record<FilterField, FilterValue>> | undefined,
+): void {
+  if (!filters) return;
+
+  for (const [rawField, value] of Object.entries(filters)) {
+    assertOneFieldIsSupported({ field: rawField as FilterField, value });
+  }
+}
+
+/** One field's value, at whichever nesting depth it was found. */
+function assertOneFieldIsSupported(args: {
+  field: FilterField;
+  value: unknown;
+  key?: string;
+  subkey?: string;
+}): void {
+  const { field, value, key, subkey } = args;
+  if (!value || typeof value !== "object") return;
+
+  if (Array.isArray(value)) {
+    if (value.length === 0) return;
+    assertFilterValuesAreSupported({ field, values: value, key, subkey });
+    return;
+  }
+
+  for (const [nestedKey, nested] of Object.entries(value)) {
+    assertOneFieldIsSupported({
+      field,
+      value: nested,
+      key: key ?? nestedKey,
+      subkey: key ? nestedKey : undefined,
+    });
+  }
+}

--- a/specs/analytics/filter-value-validation.feature
+++ b/specs/analytics/filter-value-validation.feature
@@ -1,0 +1,92 @@
+Feature: Analytics rejects filter values it cannot apply
+  As someone querying analytics over the REST API
+  I want a filter value the platform cannot apply to be refused
+  So that I never read numbers that look filtered and are not
+
+  Every analytics filter field has a closed set of values it accepts. The
+  boolean ones ("does the trace contain an error", "does the trace have an
+  annotation", "did the evaluation pass") accept only "true" and "false".
+  The list-options endpoint returns each option twice over: a `field` (the
+  value to send) and a `label` (the words to show). Sending the label instead
+  of the field used to leave the filter matching every row, so the answer came
+  back identical to the unfiltered one with nothing to say it had been
+  dropped. Wrong numbers that look right are worse than an error.
+
+  Selecting both "true" and "false" is not the same mistake: it is every row
+  on purpose, which is what the user asked for, so it stays a no-op.
+
+  Background:
+    Given a project with analytics data
+
+  Rule: A boolean filter accepts only the values the options endpoint returns
+
+    @unit
+    Scenario: Filtering to traces that contain an error narrows the query
+      Given a timeseries request filtering traces with an error
+      When the query is built
+      Then the query only counts traces that contain an error
+
+    @unit
+    Scenario: Filtering to traces without an error narrows the query
+      Given a timeseries request filtering traces without an error
+      When the query is built
+      Then the query only counts traces that contain no error
+
+    @unit
+    Scenario: Asking for both error states filters nothing
+      Given a timeseries request asking for traces with and without an error
+      When the query is built
+      Then the query counts every trace
+
+    @unit
+    Scenario: A filter value the field does not accept is refused
+      Given a timeseries request whose error filter carries an option label instead of its value
+      When the query is built
+      Then the request is refused as a validation error naming the filter and the values it accepts
+
+    @unit
+    Scenario: The annotation filter refuses a value it cannot apply
+      Given a timeseries request whose annotation filter carries an option label instead of its value
+      When the query is built
+      Then the request is refused as a validation error naming the filter and the values it accepts
+
+    @unit
+    Scenario: The evaluation pass filter refuses a value it cannot apply
+      Given a timeseries request whose evaluation pass filter carries an option label instead of its value
+      When the query is built
+      Then the request is refused as a validation error naming the filter and the values it accepts
+
+  Rule: A filter that needs a key is refused without one
+
+    @unit
+    Scenario: A metadata value filter sent without its metadata key is refused
+      Given a timeseries request filtering on a metadata value with no metadata key
+      When the query is built
+      Then the request is refused as a validation error naming the filter and the key it needs
+
+    @unit
+    Scenario: An event metric value filter sent without its metric key is refused
+      Given a timeseries request filtering on an event metric value with no metric key
+      When the query is built
+      Then the request is refused as a validation error naming the filter and the key it needs
+
+  Rule: The REST analytics endpoints apply the filters they are given
+
+    @integration
+    Scenario: A filtered timeseries query returns fewer traces than an unfiltered one
+      Given traces that contain an error and traces that do not
+      When a timeseries query is run with no filters
+      And the same query is run filtered to traces that contain an error
+      Then the filtered query counts only the traces that contain an error
+
+    @integration
+    Scenario: The REST endpoint refuses a filter value it cannot apply
+      Given a project API key that may read analytics
+      When a timeseries is requested with an error filter carrying an option label
+      Then the response is a validation error naming the filter
+
+    @integration
+    Scenario: The legacy REST analytics path refuses the same value
+      Given a project API key that may read analytics
+      When a timeseries is requested on the legacy path with an error filter carrying an option label
+      Then the response is a validation error naming the filter


### PR DESCRIPTION
## The report

Dogfooding a customer project against production: `POST /api/analytics` with

```json
{ "filters": { "traces.error": ["Traces with error"] }, "series": [{ "metric": "metadata.trace_id", "aggregation": "cardinality" }] }
```

returned numbers identical to the same query with `["Traces without error"]` and identical to `filters: {}`. Three ways of asking, one answer.

## What was actually wrong

Not the schema. `filters` has been wired through both REST analytics paths and the tRPC router the whole time, and the body is validated (an unknown filter field is already rejected with the full list of accepted fields).

The value was the problem. The filter-options endpoint returns every option twice over: a `field`, which is what you send, and a `label`, which is what the interface shows. For `traces.error` those are `"true"` / `"false"` and `"Traces with error"` / `"Traces without error"`. Every translator for the boolean fields looked for the strings `"true"` and `"false"` and fell back to "no filtering" when it found neither:

```ts
// Both or neither - no filtering
return { whereClause: "1=1", requiredJoins: [], params: {} };
```

So a label produced a query with no predicate at all, which is why the filtered and unfiltered answers matched exactly. The UI sends the field, so this only ever hit callers writing against the REST API from the option list.

**It never worked.** The fallback goes back to the original Elasticsearch filter registry in May 2024 (`8249894cfd`), was carried verbatim into the ClickHouse translator when the ClickHouse analytics backend landed in February 2026 (#1203), and then again into the routed slim builder that ADR-034 added. Three implementations, the same silent widening in all three. Not a regression.

The same silence covered two more fields: `metadata.value` and `events.metrics.value` matched every row when sent without the key they filter on.

## The fix

Filter values are checked once at the analytics service boundary, before the cache and before the table router picks a builder, so every backend path answers identically:

```
HTTP 422
{ "error": "validation_error",
  "reasons": [{ "code": "schema_failure",
    "meta": { "field": "filters.traces.error",
              "type": "unsupported_filter_value",
              "message": "The \"Contains Error\" filter accepts only \"true\" or \"false\". Send an option's value, not the label shown next to it.",
              "expected": ["true", "false"],
              "received": "Traces with error" } }] }
```

Asking for both `"true"` and `"false"` is still every row, because that is what was asked for. The ClickHouse translator and the slim builder call the same check themselves, so a direct caller cannot reintroduce the drop.

`docs/features/embedded-analytics.mdx` gains a Filters section covering the shape, the value-not-label rule, and the required `timeZone` the example was missing.

## Tests

- `specs/analytics/filter-value-validation.feature`, 11 scenarios, all bound.
- Unit: the translator refuses an option label for `traces.error`, `annotations.hasAnnotation` and `evaluations.passed`, refuses `metadata.value` and `events.metrics.value` without their key, and still accepts what the options endpoint returns.
- Integration against real ClickHouse: five seeded traces, two with an error. Unfiltered counts 5, `["true"]` counts 2, `["false"]` counts 3, and the label is refused before any query runs. Asserting on the generated SQL would not have caught this, since `1=1` is valid SQL that runs fine, so the test compares the numbers a caller compares.
- Integration against both REST paths with a project API key in `X-Auth-Token`, the way the report was made: `POST /api/analytics/timeseries` and the legacy `POST /api/analytics` both answer 422 naming the field.

`pnpm typecheck:all` clean.

## Not in scope

The endpoint still strips unknown top-level body keys rather than rejecting them. Marking the body schema `.strict()` would catch a misspelled top-level field the same way, but the documented payload is copy-pasted out of the chart builder and may legitimately carry extra keys, so that is a separate change with its own compatibility question.

https://claude.ai/code/session_01WKLMWcBwMSbzAL77N9i3sx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Analytics filters now reject unsupported values and missing keys with clear validation errors instead of silently broadening results.
  - Validation applies consistently across current and legacy analytics API endpoints.
  - Boolean filter values must use supported option values, while keyed filters require the appropriate key or subkey.

- **Documentation**
  - Added guidance on analytics filters, accepted values, keyed filters, and validation behavior.
  - Updated examples to explicitly use the UTC time zone.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->