### PR TITLE
feat(evaluations): show a category evaluator's label distribution in the list

### DIFF
--- a/platform/app/src/components/evaluations/OnlineEvaluationPerformancePreview.tsx
+++ b/platform/app/src/components/evaluations/OnlineEvaluationPerformancePreview.tsx
@@ -1,17 +1,35 @@
 import { Box, HStack, Skeleton, Text, VStack } from "@chakra-ui/react";
 
-export type OnlineEvaluationPerformance = {
-  metric: "score" | "pass_rate";
-  points: number[];
-  current: number | null;
-  previous: number | null;
+import { getHexColorForString } from "~/utils/rotatingColors";
+
+export type LabelShare = {
+  label: string;
+  count: number;
+  share: number;
 };
+
+export type OnlineEvaluationPerformance =
+  | {
+      metric: "score" | "pass_rate";
+      points: number[];
+      current: number | null;
+      previous: number | null;
+    }
+  | {
+      metric: "label";
+      labels: LabelShare[];
+      current: number | null;
+      previous: number | null;
+    };
 
 type PerformanceRow = {
   name: string;
   performance?: OnlineEvaluationPerformance;
   hasPerformanceError?: boolean;
 };
+
+const CHART_WIDTH = 112;
+const CHART_HEIGHT = 38;
 
 export const PerformancePreview = ({ row }: { row: PerformanceRow }) => {
   const performance = row.performance;
@@ -27,7 +45,7 @@ export const PerformancePreview = ({ row }: { row: PerformanceRow }) => {
   if (!performance) {
     return (
       <HStack width="full" gap={4}>
-        <Skeleton width="112px" height="38px" />
+        <Skeleton width={`${CHART_WIDTH}px`} height={`${CHART_HEIGHT}px`} />
         <VStack align="start" gap={1}>
           <Skeleton width="48px" height="18px" />
           <Skeleton width="64px" height="14px" />
@@ -36,7 +54,7 @@ export const PerformancePreview = ({ row }: { row: PerformanceRow }) => {
     );
   }
 
-  const { current, previous, metric, points } = performance;
+  const { current, previous, metric } = performance;
   const delta =
     current !== null && previous !== null ? current - previous : null;
   const trend =
@@ -55,9 +73,29 @@ export const PerformancePreview = ({ row }: { row: PerformanceRow }) => {
     );
   }
 
+  // A classifier's period is a distribution, not an average: every result
+  // carries a label and neither a score nor a pass flag, so there is nothing
+  // to average and a single number would say less than the split does.
+  if (metric === "label") {
+    const leading = performance.labels[0];
+    return (
+      <HStack width="full" gap={4} justify="space-between">
+        <LabelDistribution labels={performance.labels} name={row.name} />
+        <VStack minWidth="82px" align="start" gap={0}>
+          <Text fontWeight="semibold" lineClamp={1} title={leading?.label}>
+            {leading?.label}
+          </Text>
+          <Text textStyle="xs" color={trendColor} data-trend={trend}>
+            {formatLabelShare(current, delta)}
+          </Text>
+        </VStack>
+      </HStack>
+    );
+  }
+
   return (
     <HStack width="full" gap={4} justify="space-between">
-      <Sparkline points={points} trend={trend} name={row.name} />
+      <Sparkline points={performance.points} trend={trend} name={row.name} />
       <VStack minWidth="82px" align="start" gap={0}>
         <Text fontWeight="semibold">
           {metric === "pass_rate"
@@ -72,10 +110,16 @@ export const PerformancePreview = ({ row }: { row: PerformanceRow }) => {
   );
 };
 
-const formatTrend = (
-  metric: OnlineEvaluationPerformance["metric"],
-  delta: number | null,
-) => {
+const percent = (share: number) => `${Math.round(share * 100)}%`;
+
+const formatLabelShare = (current: number, delta: number | null) => {
+  if (delta === null) return `${percent(current)} of results`;
+  if (delta === 0) return `${percent(current)}, no change`;
+  const arrow = delta > 0 ? "↑" : "↓";
+  return `${percent(current)}, ${arrow} ${Math.round(Math.abs(delta) * 100)} pp`;
+};
+
+const formatTrend = (metric: "score" | "pass_rate", delta: number | null) => {
   if (delta === null) return "No comparison";
   if (delta === 0) return "No change";
 
@@ -87,6 +131,66 @@ const formatTrend = (
     : `${arrow} ${difference.toFixed(2)}`;
 };
 
+/**
+ * The period's labels as one strip, each segment sized by its share.
+ *
+ * Every segment carries its own accessible name and hover title, so the split
+ * is readable without a legend the column has no room for.
+ */
+const LabelDistribution = ({
+  labels,
+  name,
+}: {
+  labels: LabelShare[];
+  name: string;
+}) => {
+  const height = 14;
+  const gap = 1;
+  const radius = 2;
+
+  let offset = 0;
+  const segments = labels.map((entry) => {
+    const width = Math.max(entry.share * CHART_WIDTH - gap, 1);
+    const segment = { ...entry, x: offset, width };
+    offset += entry.share * CHART_WIDTH;
+    return segment;
+  });
+
+  return (
+    <Box
+      width={`${CHART_WIDTH}px`}
+      height={`${CHART_HEIGHT}px`}
+      flexShrink={0}
+      display="flex"
+      alignItems="center"
+    >
+      <svg
+        role="group"
+        aria-label={`Label distribution for ${name}`}
+        viewBox={`0 0 ${CHART_WIDTH} ${height}`}
+        width="100%"
+        height={height}
+      >
+        {segments.map((segment) => (
+          <rect
+            key={segment.label}
+            role="img"
+            aria-label={`${segment.label}, ${percent(segment.share)}`}
+            x={segment.x}
+            y={0}
+            width={segment.width}
+            height={height}
+            rx={radius}
+            fill={getHexColorForString(segment.label)}
+          >
+            <title>{`${segment.label}: ${percent(segment.share)} (${segment.count})`}</title>
+          </rect>
+        ))}
+      </svg>
+    </Box>
+  );
+};
+
 const Sparkline = ({
   points,
   trend,
@@ -96,8 +200,8 @@ const Sparkline = ({
   trend: "up" | "down" | "neutral";
   name: string;
 }) => {
-  const width = 112;
-  const height = 38;
+  const width = CHART_WIDTH;
+  const height = CHART_HEIGHT;
   const padding = 3;
   const finitePoints = points.filter(Number.isFinite);
   const min = finitePoints.length > 0 ? Math.min(...finitePoints) : 0;

--- a/platform/app/src/components/evaluations/__tests__/OnlineEvaluationsTable.integration.test.tsx
+++ b/platform/app/src/components/evaluations/__tests__/OnlineEvaluationsTable.integration.test.tsx
@@ -2,6 +2,7 @@
  * @vitest-environment jsdom
  *
  * @see specs/evaluations/experiments-online-evaluations-separation.feature
+ * @see specs/evaluations/category-evaluator-performance.feature
  */
 import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
 import { cleanup, render, screen } from "@testing-library/react";
@@ -75,6 +76,24 @@ const rows: OnlineEvaluationRow[] = [
     },
   },
 ];
+
+const categoryRow: OnlineEvaluationRow = {
+  id: "monitor-category",
+  name: "Conversation outcome",
+  checkType: "langevals/llm_category",
+  enabled: true,
+  executionMode: "ON_MESSAGE",
+  performance: {
+    metric: "label",
+    labels: [
+      { label: "resolved", count: 60, share: 0.6 },
+      { label: "escalated", count: 25, share: 0.25 },
+      { label: "abandoned", count: 15, share: 0.15 },
+    ],
+    current: 0.6,
+    previous: 0.48,
+  },
+};
 
 const defaultProps = {
   projectSlug: "demo",
@@ -194,6 +213,112 @@ describe("<OnlineEvaluationsTable />", () => {
 
     expect(screen.getByText("Performance unavailable")).toBeInTheDocument();
     expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
+  });
+
+  describe("when a monitor classifies instead of scoring", () => {
+    /** @scenario "The row shows the labels instead of an empty state" */
+    it("shows the label distribution and the leading label", () => {
+      render(
+        <OnlineEvaluationsTable {...defaultProps} rows={[categoryRow]} />,
+        { wrapper: Wrapper },
+      );
+
+      expect(
+        screen.getByRole("group", {
+          name: "Label distribution for Conversation outcome",
+        }),
+      ).toBeInTheDocument();
+      expect(screen.getByText("resolved")).toBeInTheDocument();
+      expect(screen.getByText("60%, ↑ 12 pp")).toHaveAttribute(
+        "data-trend",
+        "up",
+      );
+      expect(screen.queryByText("No data yet")).not.toBeInTheDocument();
+    });
+
+    /** @scenario "The distribution names every label it drew" */
+    it("names every label with its share", () => {
+      render(
+        <OnlineEvaluationsTable {...defaultProps} rows={[categoryRow]} />,
+        { wrapper: Wrapper },
+      );
+
+      expect(
+        screen.getByRole("img", { name: "resolved, 60%" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("img", { name: "escalated, 25%" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("img", { name: "abandoned, 15%" }),
+      ).toBeInTheDocument();
+    });
+
+    it("says how much of the period the leading label held when there is nothing to compare", () => {
+      render(
+        <OnlineEvaluationsTable
+          {...defaultProps}
+          rows={[
+            {
+              ...categoryRow,
+              performance: {
+                metric: "label",
+                labels: [{ label: "resolved", count: 3, share: 1 }],
+                current: 1,
+                previous: null,
+              },
+            },
+          ]}
+        />,
+        { wrapper: Wrapper },
+      );
+
+      expect(screen.getByText("100% of results")).toBeInTheDocument();
+    });
+
+    /** @scenario "A row with no results still says there is no data" */
+    it("still says there is no data when the classifier produced none", () => {
+      render(
+        <OnlineEvaluationsTable
+          {...defaultProps}
+          rows={[
+            {
+              ...categoryRow,
+              performance: {
+                metric: "label",
+                labels: [],
+                current: null,
+                previous: null,
+              },
+            },
+          ]}
+        />,
+        { wrapper: Wrapper },
+      );
+
+      expect(screen.getByText("No data yet")).toHaveAttribute(
+        "data-trend",
+        "neutral",
+      );
+    });
+  });
+
+  /** @scenario "A scoring row is unchanged" */
+  it("keeps showing a scoring monitor as a sparkline and a score", () => {
+    render(<OnlineEvaluationsTable {...defaultProps} rows={[rows[0]!]} />, {
+      wrapper: Wrapper,
+    });
+
+    expect(
+      screen.getByRole("img", { name: "Performance trend for Answer quality" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("0.86")).toBeInTheDocument();
+    expect(screen.getByText("↑ 0.12")).toHaveAttribute("data-trend", "up");
+    expect(
+      screen.queryByRole("group", {
+        name: "Label distribution for Answer quality",
+      }),
+    ).not.toBeInTheDocument();
   });
 
   it("centers a flat performance trend", () => {

--- a/platform/app/src/server/app-layer/evaluations/__tests__/monitor-performance.fixtures.ts
+++ b/platform/app/src/server/app-layer/evaluations/__tests__/monitor-performance.fixtures.ts
@@ -22,6 +22,8 @@ export interface SeededEvaluation {
   evaluatorId: string;
   score: number | null;
   passed: number | null;
+  /** The category a classifying evaluator decided on, if it decided one. */
+  label?: string | null;
   status?: string;
   evaluationId?: string;
   updatedAtMs?: number;
@@ -79,6 +81,7 @@ export const evaluationRunRow = ({
     evaluatorId,
     score,
     passed,
+    label = null,
     status = "processed",
     evaluationId = `eval-${nanoid()}`,
     updatedAtMs = scheduledAtMs,
@@ -97,7 +100,7 @@ export const evaluationRunRow = ({
   Status: status,
   Score: score,
   Passed: passed,
-  Label: null,
+  Label: label,
   ScheduledAt: new Date(scheduledAtMs),
   UpdatedAt: new Date(updatedAtMs),
   LastProcessedEventId: `event-${nanoid()}`,

--- a/platform/app/src/server/app-layer/evaluations/__tests__/monitor-performance.integration.test.ts
+++ b/platform/app/src/server/app-layer/evaluations/__tests__/monitor-performance.integration.test.ts
@@ -1,5 +1,6 @@
 /**
  * @see specs/analytics/evaluation-pass-rate-consistency.feature
+ * @see specs/evaluations/category-evaluator-performance.feature
  *
  * The Online Evaluations table and the analytics page must publish the same
  * numbers. The analytics page reads evaluations through the trace-anchored
@@ -25,6 +26,7 @@ import { MonitorPerformanceClickHouseRepository } from "../repositories/monitor-
 import {
   buildSeedMatrix,
   readAnalyticsPageNumbers,
+  type SeededEvaluation,
   seedMonitorPerformance,
 } from "./monitor-performance.fixtures";
 
@@ -32,6 +34,7 @@ const DAY_MS = 24 * 60 * 60 * 1000;
 const tenantId = `test-monitor-performance-${nanoid()}`;
 const scoreEvaluatorId = `${tenantId}-score`;
 const guardrailEvaluatorId = `${tenantId}-guardrail`;
+const categoryEvaluatorId = `${tenantId}-category`;
 const endMs = Date.now();
 const currentStartMs = endMs - 7 * DAY_MS;
 // Derived through the same helper the router and the analytics page use, so
@@ -98,6 +101,36 @@ const expectSameNumbers = ({
   });
 };
 
+/**
+ * A classifier: every result carries a label and neither a score nor a pass
+ * flag, which is exactly the shape that used to read as no data at all.
+ */
+const categorySeeds = (): SeededEvaluation[] => {
+  const half = DAY_MS / 2;
+  const at = (startMs: number, dayOffset: number) =>
+    startMs + dayOffset * DAY_MS + half;
+  const run = (occurredAtMs: number, label: string): SeededEvaluation => ({
+    traceId: `${categoryEvaluatorId}-trace-${nanoid()}`,
+    traceOccurredAtMs: occurredAtMs,
+    scheduledAtMs: occurredAtMs,
+    evaluatorId: categoryEvaluatorId,
+    score: null,
+    passed: null,
+    label,
+  });
+
+  return [
+    run(at(currentStartMs, 1), "resolved"),
+    run(at(currentStartMs, 1), "resolved"),
+    run(at(currentStartMs, 2), "resolved"),
+    run(at(currentStartMs, 2), "escalated"),
+    run(at(previousStartMs, 1), "resolved"),
+    run(at(previousStartMs, 1), "escalated"),
+    run(at(previousStartMs, 2), "escalated"),
+    run(at(previousStartMs, 2), "escalated"),
+  ];
+};
+
 beforeAll(async () => {
   const containers = await startTestContainers();
   clickHouse = containers.clickHouseClient;
@@ -105,13 +138,16 @@ beforeAll(async () => {
   await seedMonitorPerformance({
     client: clickHouse,
     tenantId,
-    seeded: buildSeedMatrix({
-      tenantId,
-      scoreEvaluatorId,
-      guardrailEvaluatorId,
-      currentStartMs,
-      previousStartMs,
-    }),
+    seeded: [
+      ...buildSeedMatrix({
+        tenantId,
+        scoreEvaluatorId,
+        guardrailEvaluatorId,
+        currentStartMs,
+        previousStartMs,
+      }),
+      ...categorySeeds(),
+    ],
   });
 }, 180_000);
 
@@ -189,10 +225,64 @@ describe("online evaluation monitor performance", () => {
     ]);
   });
 
+  describe("when a monitor classifies its results instead of scoring them", () => {
+    /** @scenario "Label counts are read per day and period" */
+    it("carries the count of each label produced on each day", async () => {
+      const repository = new MonitorPerformanceClickHouseRepository(
+        async () => clickHouse,
+      );
+      const buckets = await repository.findBuckets({
+        tenantId,
+        evaluatorIds: [categoryEvaluatorId],
+        previousStartMs,
+        currentStartMs,
+        endMs,
+        timeZone: "UTC",
+      });
+
+      const current = buckets.filter((bucket) => bucket.period === "current");
+      expect(current.map((bucket) => bucket.labelCounts)).toEqual([
+        { resolved: 2 },
+        { resolved: 1, escalated: 1 },
+      ]);
+      // Nothing to average: this is the shape that used to read as no data.
+      expect(current.every((bucket) => bucket.scoreCount === 0)).toBe(true);
+      expect(current.every((bucket) => bucket.passCount === 0)).toBe(true);
+    });
+
+    it("summarizes the period as a label distribution with a real comparison", async () => {
+      const service = new MonitorPerformanceService(
+        new MonitorPerformanceClickHouseRepository(async () => clickHouse),
+      );
+      const [performance] = await service.getPerformance({
+        tenantId,
+        monitors: [{ id: categoryEvaluatorId, isGuardrail: false }],
+        previousStartMs,
+        currentStartMs,
+        endMs,
+        timeZone: "UTC",
+      });
+
+      expect(performance).toEqual({
+        monitorId: categoryEvaluatorId,
+        metric: "label",
+        labels: [
+          { label: "resolved", count: 3, share: 0.75 },
+          { label: "escalated", count: 1, share: 0.25 },
+        ],
+        current: 0.75,
+        previous: 0.25,
+      });
+    });
+  });
+
   describe("when the analytics page reads the same period", () => {
     /** @scenario The configuration table matches the analytics page numbers */
     it("reports the same score values as the analytics page", async () => {
       const [scorePerformance] = await readTablePerformance();
+      if (scorePerformance?.metric !== "score") {
+        throw new Error("expected a score metric");
+      }
       const analyticsPage = await readAnalyticsPageNumbers({
         client: clickHouse,
         tenantId,
@@ -202,12 +292,15 @@ describe("online evaluation monitor performance", () => {
         endMs,
       });
 
-      expectSameNumbers({ table: scorePerformance!, analyticsPage });
+      expectSameNumbers({ table: scorePerformance, analyticsPage });
     });
 
     /** @scenario The configuration table matches the analytics page numbers */
     it("reports the same pass rate as the analytics page", async () => {
       const [, guardrailPerformance] = await readTablePerformance();
+      if (guardrailPerformance?.metric !== "pass_rate") {
+        throw new Error("expected a pass rate metric");
+      }
       const analyticsPage = await readAnalyticsPageNumbers({
         client: clickHouse,
         tenantId,
@@ -217,7 +310,7 @@ describe("online evaluation monitor performance", () => {
         endMs,
       });
 
-      expectSameNumbers({ table: guardrailPerformance!, analyticsPage });
+      expectSameNumbers({ table: guardrailPerformance, analyticsPage });
     });
   });
 });

--- a/platform/app/src/server/app-layer/evaluations/__tests__/monitor-performance.unit.test.ts
+++ b/platform/app/src/server/app-layer/evaluations/__tests__/monitor-performance.unit.test.ts
@@ -1,0 +1,208 @@
+/**
+ * @see specs/evaluations/category-evaluator-performance.feature
+ *
+ * How a period of results is read into the one number, or the one
+ * distribution, the online evaluations list shows.
+ */
+
+import { describe, expect, it } from "vitest";
+import { summarizeMonitorPerformance } from "../monitor-performance.service";
+import type {
+  MonitorPerformanceBucket,
+  MonitorPerformancePeriod,
+} from "../repositories/monitor-performance.repository";
+
+const evaluatorId = "monitor-1";
+
+const bucket = (
+  overrides: Partial<MonitorPerformanceBucket> & {
+    period: MonitorPerformancePeriod;
+    day: string;
+  },
+): MonitorPerformanceBucket => ({
+  evaluatorId,
+  scoreSum: 0,
+  scoreCount: 0,
+  passSum: 0,
+  passCount: 0,
+  labelCounts: {},
+  ...overrides,
+});
+
+const summarize = (buckets: MonitorPerformanceBucket[], isGuardrail = false) =>
+  summarizeMonitorPerformance({
+    monitors: [{ id: evaluatorId, isGuardrail }],
+    buckets,
+  })[0]!;
+
+describe("summarizeMonitorPerformance", () => {
+  describe("given a monitor whose results carry only a label", () => {
+    /** @scenario "An evaluator that only writes labels is summarized by label share" */
+    it("reports a label distribution ordered by how often each label occurred", () => {
+      const result = summarize([
+        bucket({
+          period: "current",
+          day: "2026-09-01",
+          labelCounts: { negative: 1, positive: 3 },
+        }),
+        bucket({
+          period: "current",
+          day: "2026-09-02",
+          labelCounts: { neutral: 2, positive: 4 },
+        }),
+      ]);
+
+      expect(result.metric).toBe("label");
+      if (result.metric !== "label") throw new Error("expected a label metric");
+      expect(result.labels).toEqual([
+        { label: "positive", count: 7, share: 0.7 },
+        { label: "neutral", count: 2, share: 0.2 },
+        { label: "negative", count: 1, share: 0.1 },
+      ]);
+      expect(result.current).toBe(0.7);
+    });
+
+    /** @scenario "The leading label's movement is measured against the same label" */
+    it("compares the leading label against its own previous share", () => {
+      const result = summarize([
+        bucket({
+          period: "current",
+          day: "2026-09-02",
+          labelCounts: { positive: 6, negative: 4 },
+        }),
+        bucket({
+          period: "previous",
+          day: "2026-08-26",
+          labelCounts: { positive: 2, negative: 8 },
+        }),
+      ]);
+
+      if (result.metric !== "label") throw new Error("expected a label metric");
+      expect(result.current).toBe(0.6);
+      expect(result.previous).toBe(0.2);
+    });
+
+    /** @scenario "A leading label absent from the previous period counts as no share" */
+    it("reads an absent label as a share of zero when the period had results", () => {
+      const result = summarize([
+        bucket({
+          period: "current",
+          day: "2026-09-02",
+          labelCounts: { escalated: 5 },
+        }),
+        bucket({
+          period: "previous",
+          day: "2026-08-26",
+          labelCounts: { resolved: 5 },
+        }),
+      ]);
+
+      if (result.metric !== "label") throw new Error("expected a label metric");
+      expect(result.current).toBe(1);
+      expect(result.previous).toBe(0);
+    });
+
+    it("supports no comparison when the previous period had no results", () => {
+      const result = summarize([
+        bucket({
+          period: "current",
+          day: "2026-09-02",
+          labelCounts: { escalated: 5 },
+        }),
+      ]);
+
+      expect(result.previous).toBeNull();
+    });
+
+    /** @scenario "Only the most common labels are kept, the rest are grouped" */
+    it("keeps the most common labels and groups the rest", () => {
+      const result = summarize([
+        bucket({
+          period: "current",
+          day: "2026-09-02",
+          labelCounts: {
+            a: 30,
+            b: 25,
+            c: 20,
+            d: 10,
+            e: 8,
+            f: 4,
+            g: 2,
+            h: 1,
+          },
+        }),
+      ]);
+
+      if (result.metric !== "label") throw new Error("expected a label metric");
+      expect(result.labels.map((entry) => entry.label)).toEqual([
+        "a",
+        "b",
+        "c",
+        "d",
+        "e",
+        "Other",
+      ]);
+      expect(result.labels.at(-1)).toEqual({
+        label: "Other",
+        count: 7,
+        share: 0.07,
+      });
+      const total = result.labels.reduce((sum, e) => sum + e.share, 0);
+      expect(total).toBeCloseTo(1, 10);
+    });
+  });
+
+  describe("given a monitor whose results carry a score", () => {
+    /** @scenario "A scoring evaluator is still summarized by score" */
+    it("reports the score even when the results also carry labels", () => {
+      const result = summarize([
+        bucket({
+          period: "current",
+          day: "2026-09-02",
+          scoreSum: 1.5,
+          scoreCount: 2,
+          labelCounts: { positive: 2 },
+        }),
+      ]);
+
+      expect(result.metric).toBe("score");
+      expect(result.current).toBe(0.75);
+    });
+  });
+
+  describe("given a guardrail monitor", () => {
+    /** @scenario "A guardrail is still summarized by pass rate" */
+    it("reports the pass rate even when the results carry labels", () => {
+      const result = summarize(
+        [
+          bucket({
+            period: "current",
+            day: "2026-09-02",
+            passSum: 3,
+            passCount: 4,
+            labelCounts: { blocked: 1 },
+          }),
+        ],
+        true,
+      );
+
+      expect(result.metric).toBe("pass_rate");
+      expect(result.current).toBe(0.75);
+    });
+  });
+
+  describe("given a monitor with no results in either period", () => {
+    /** @scenario "A monitor with no results at all reports nothing to show" */
+    it("reports no value", () => {
+      const result = summarize([]);
+
+      expect(result).toEqual({
+        monitorId: evaluatorId,
+        metric: "score",
+        points: [],
+        current: null,
+        previous: null,
+      });
+    });
+  });
+});

--- a/platform/app/src/server/app-layer/evaluations/monitor-performance.service.ts
+++ b/platform/app/src/server/app-layer/evaluations/monitor-performance.service.ts
@@ -10,13 +10,48 @@ export interface PerformanceMonitor {
   isGuardrail: boolean;
 }
 
-export interface OnlineEvaluationPerformance {
+/** One label and how much of the period it accounted for. */
+export interface LabelShare {
+  label: string;
+  count: number;
+  /** Fraction of the period's labelled results, 0 to 1. */
+  share: number;
+}
+
+interface AveragedPerformance {
   monitorId: string;
   metric: "score" | "pass_rate";
   points: number[];
   current: number | null;
   previous: number | null;
 }
+
+interface LabelPerformance {
+  monitorId: string;
+  metric: "label";
+  /** Ordered by how often each label occurred, most common first. */
+  labels: LabelShare[];
+  /** The leading label's share of the current period. */
+  current: number | null;
+  /** That same label's share of the previous period, or null if it had none. */
+  previous: number | null;
+}
+
+export type OnlineEvaluationPerformance =
+  | AveragedPerformance
+  | LabelPerformance;
+
+/**
+ * How many labels the list's strip names before the tail is grouped.
+ *
+ * A strip 112 pixels wide stops being readable well before this, and a
+ * classifier with a long tail would otherwise turn the column into a row of
+ * slivers nobody can hit or read.
+ */
+const MAX_LABELS_SHOWN = 5;
+
+/** The name the grouped tail is given. */
+const OTHER_LABEL = "Other";
 
 interface MetricTotal {
   sum: number;
@@ -40,6 +75,15 @@ const average = (totals: MetricTotal[]): number | null => {
   return count > 0 ? sum / count : null;
 };
 
+const bucketsIn = ({
+  buckets,
+  period,
+}: {
+  buckets: MonitorPerformanceBucket[];
+  period: MonitorPerformancePeriod;
+}): MonitorPerformanceBucket[] =>
+  buckets.filter((bucket) => bucket.period === period);
+
 const periodTotals = ({
   buckets,
   period,
@@ -49,9 +93,106 @@ const periodTotals = ({
   period: MonitorPerformancePeriod;
   isGuardrail: boolean;
 }): MetricTotal[] =>
-  buckets
-    .filter((bucket) => bucket.period === period)
-    .map((bucket) => totalFor({ bucket, isGuardrail }));
+  bucketsIn({ buckets, period }).map((bucket) =>
+    totalFor({ bucket, isGuardrail }),
+  );
+
+/** Every label the period produced, and how often, across its days. */
+const countLabels = (buckets: MonitorPerformanceBucket[]) => {
+  const counts = new Map<string, number>();
+  for (const bucket of buckets) {
+    for (const [label, count] of Object.entries(bucket.labelCounts)) {
+      counts.set(label, (counts.get(label) ?? 0) + count);
+    }
+  }
+  return counts;
+};
+
+const sumOf = (counts: Map<string, number>): number =>
+  [...counts.values()].reduce((total, count) => total + count, 0);
+
+/**
+ * The period's labels as shares, most common first, with everything past the
+ * strip's capacity grouped so the shares still add up to the whole period.
+ */
+const toLabelShares = (counts: Map<string, number>): LabelShare[] => {
+  const total = sumOf(counts);
+  if (total === 0) return [];
+
+  const ordered = [...counts.entries()].sort(
+    ([leftLabel, leftCount], [rightLabel, rightCount]) =>
+      rightCount - leftCount || leftLabel.localeCompare(rightLabel),
+  );
+  const shown = ordered.slice(0, MAX_LABELS_SHOWN);
+  const remainder = ordered.slice(MAX_LABELS_SHOWN);
+
+  const shares: LabelShare[] = shown.map(([label, count]) => ({
+    label,
+    count,
+    share: count / total,
+  }));
+
+  if (remainder.length > 0) {
+    const count = remainder.reduce((sum, [, value]) => sum + value, 0);
+    shares.push({ label: OTHER_LABEL, count, share: count / total });
+  }
+
+  return shares;
+};
+
+/**
+ * Whether this monitor's results can only be read as labels.
+ *
+ * A guardrail is always its pass rate, and a scoring evaluator is always its
+ * score, even in a period where it happened to produce neither. Labels are
+ * the reading of last resort, which is exactly the case a classifier is in:
+ * every result carries one and nothing else.
+ */
+const readsAsLabels = ({
+  buckets,
+  isGuardrail,
+}: {
+  buckets: MonitorPerformanceBucket[];
+  isGuardrail: boolean;
+}): boolean => {
+  if (isGuardrail) return false;
+  const hasAverage = buckets.some((bucket) => bucket.scoreCount > 0);
+  if (hasAverage) return false;
+  return buckets.some((bucket) => Object.keys(bucket.labelCounts).length > 0);
+};
+
+const summarizeLabels = ({
+  monitorId,
+  buckets,
+}: {
+  monitorId: string;
+  buckets: MonitorPerformanceBucket[];
+}): LabelPerformance => {
+  const labels = toLabelShares(
+    countLabels(bucketsIn({ buckets, period: "current" })),
+  );
+  const leading = labels[0];
+
+  const previousCounts = countLabels(
+    bucketsIn({ buckets, period: "previous" }),
+  );
+  const previousTotal = sumOf(previousCounts);
+  // A label absent from a period that HAD results held none of it, which is a
+  // real reading of zero. A period with no results at all supports no
+  // comparison, so it stays null and the row says so.
+  const previous =
+    leading && previousTotal > 0
+      ? (previousCounts.get(leading.label) ?? 0) / previousTotal
+      : null;
+
+  return {
+    monitorId,
+    metric: "label",
+    labels,
+    current: leading?.share ?? null,
+    previous,
+  };
+};
 
 export const summarizeMonitorPerformance = ({
   monitors,
@@ -69,6 +210,19 @@ export const summarizeMonitorPerformance = ({
 
   return monitors.map((monitor) => {
     const monitorBuckets = bucketsByEvaluator.get(monitor.id) ?? [];
+
+    if (
+      readsAsLabels({
+        buckets: monitorBuckets,
+        isGuardrail: monitor.isGuardrail,
+      })
+    ) {
+      return summarizeLabels({
+        monitorId: monitor.id,
+        buckets: monitorBuckets,
+      });
+    }
+
     const currentTotals = periodTotals({
       buckets: monitorBuckets,
       period: "current",

--- a/platform/app/src/server/app-layer/evaluations/repositories/monitor-performance.clickhouse.repository.ts
+++ b/platform/app/src/server/app-layer/evaluations/repositories/monitor-performance.clickhouse.repository.ts
@@ -23,6 +23,8 @@ interface ClickHouseMonitorPerformanceRow {
   ScoreCount: string;
   PassSum: string;
   PassCount: string;
+  /** sumMap's tuple: the labels seen, and how often each one was seen. */
+  LabelCounts: [string[], Array<number | string>];
 }
 
 /**
@@ -48,13 +50,15 @@ const queryForTimeZone = (timeZone: string) => `
     sum(ifNull(Score, 0)) AS ScoreSum,
     count(Score) AS ScoreCount,
     sum(ifNull(Passed, 0)) AS PassSum,
-    count(Passed) AS PassCount
+    count(Passed) AS PassCount,
+    sumMap([ifNull(Label, '')], [toUInt64(1)]) AS LabelCounts
   FROM (
     SELECT
       evaluations.EvaluatorId AS EvaluatorId,
       evaluations.Status AS Status,
       evaluations.Score AS Score,
       evaluations.Passed AS Passed,
+      evaluations.Label AS Label,
       traces.TraceOccurredAt AS TraceOccurredAt
     FROM (
       SELECT
@@ -74,12 +78,13 @@ const queryForTimeZone = (timeZone: string) => `
         tupleElement(Latest, 2) AS EvaluatorId,
         tupleElement(Latest, 3) AS Status,
         tupleElement(Latest, 4) AS Score,
-        tupleElement(Latest, 5) AS Passed
+        tupleElement(Latest, 5) AS Passed,
+        tupleElement(Latest, 6) AS Label
       FROM (
         SELECT
           TenantId,
           EvaluationId,
-          argMax(tuple(TraceId, EvaluatorId, Status, Score, Passed), UpdatedAt) AS Latest
+          argMax(tuple(TraceId, EvaluatorId, Status, Score, Passed, Label), UpdatedAt) AS Latest
         FROM evaluation_runs
         WHERE TenantId = {tenantId:String}
           AND EvaluatorId IN {evaluatorIds:Array(String)}
@@ -157,4 +162,22 @@ const toPerformanceBucket = (
   scoreCount: Number(row.ScoreCount),
   passSum: Number(row.PassSum),
   passCount: Number(row.PassCount),
+  labelCounts: toLabelCounts(row.LabelCounts),
 });
+
+/**
+ * sumMap answers as a pair of parallel arrays. Results with no label land
+ * under the empty key, which is every result of a scoring evaluator, so that
+ * key is dropped rather than counted as a label of its own.
+ */
+const toLabelCounts = (
+  counts: ClickHouseMonitorPerformanceRow["LabelCounts"] | undefined,
+): Record<string, number> => {
+  const [labels, occurrences] = counts ?? [[], []];
+  const byLabel: Record<string, number> = {};
+  labels.forEach((label, index) => {
+    if (label === "") return;
+    byLabel[label] = Number(occurrences[index] ?? 0);
+  });
+  return byLabel;
+};

--- a/platform/app/src/server/app-layer/evaluations/repositories/monitor-performance.repository.ts
+++ b/platform/app/src/server/app-layer/evaluations/repositories/monitor-performance.repository.ts
@@ -8,6 +8,12 @@ export interface MonitorPerformanceBucket {
   scoreCount: number;
   passSum: number;
   passCount: number;
+  /**
+   * How many results carried each label that day. Empty for evaluators that
+   * score or pass rather than classify; the only reading a category
+   * evaluator produces, since it leaves score and pass empty.
+   */
+  labelCounts: Record<string, number>;
 }
 
 export interface FindMonitorPerformanceParams {

--- a/specs/evaluations/category-evaluator-performance.feature
+++ b/specs/evaluations/category-evaluator-performance.feature
@@ -1,0 +1,103 @@
+Feature: Category evaluators show their label distribution in the list
+  As someone running a category evaluator
+  I want the online evaluations list to show what the evaluator has been deciding
+  So that a month of results is not reported as "No data yet"
+
+  An online evaluation that classifies rather than scores writes a label on
+  every result and leaves both the score and the pass flag empty. The
+  performance column averaged the score, or the pass flag for guardrails, so a
+  category evaluator producing results every day averaged nothing and the row
+  read "No data yet". The results were there the whole time; the column had no
+  way to read them.
+
+  A category evaluator's result is a distribution, not an average, so the
+  column shows one: a strip of the labels it produced over the period, sized by
+  share, with the leading label and its movement named next to it.
+
+  Background:
+    Given a project with online evaluations
+
+  Rule: The column reads the metric the evaluator actually produces
+
+    @unit
+    Scenario: An evaluator that only writes labels is summarized by label share
+      Given a monitor whose results carry a label and no score or pass flag
+      When the performance for the list is summarized
+      Then the monitor is reported as a label distribution
+      And the labels are ordered by how often they occurred
+      And each label carries its share of the period's results
+
+    @unit
+    Scenario: The leading label's movement is measured against the same label
+      Given a monitor whose leading label was less common in the previous period
+      When the performance for the list is summarized
+      Then the reported change is the leading label's own change in share
+
+    @unit
+    Scenario: A leading label absent from the previous period counts as no share
+      Given a monitor whose leading label did not occur in the previous period
+      And the previous period has other results
+      When the performance for the list is summarized
+      Then the reported change is the full share of the leading label
+
+    @unit
+    Scenario: A scoring evaluator is still summarized by score
+      Given a monitor whose results carry a score
+      When the performance for the list is summarized
+      Then the monitor is reported as a score
+
+    @unit
+    Scenario: A guardrail is still summarized by pass rate
+      Given a guardrail monitor whose results carry a pass flag
+      When the performance for the list is summarized
+      Then the monitor is reported as a pass rate
+
+    @unit
+    Scenario: A monitor with no results at all reports nothing to show
+      Given a monitor with no results in either period
+      When the performance for the list is summarized
+      Then the monitor reports no value
+
+    @unit
+    Scenario: Only the most common labels are kept, the rest are grouped
+      Given a monitor that produced more distinct labels than the strip can show
+      When the performance for the list is summarized
+      Then the most common labels are kept
+      And the remainder are grouped into a single other entry
+      And the shares still add up to the whole period
+
+  Rule: The list renders a label distribution instead of an empty state
+
+    @integration
+    Scenario: The row shows the labels instead of an empty state
+      Given a row whose performance is a label distribution
+      When the online evaluations list is rendered
+      Then the row shows a strip of the labels with their shares
+      And the row names the leading label and its share
+      And the row does not say there is no data
+
+    @integration
+    Scenario: The distribution names every label it drew
+      Given a row whose performance is a label distribution
+      When the online evaluations list is rendered
+      Then every label in the distribution is named with its share
+
+    @integration
+    Scenario: A scoring row is unchanged
+      Given a row whose performance is a score
+      When the online evaluations list is rendered
+      Then the row shows the score and its trend
+
+    @integration
+    Scenario: A row with no results still says there is no data
+      Given a row whose performance has no value
+      When the online evaluations list is rendered
+      Then the row says there is no data yet
+
+  Rule: The label counts come from the evaluation results themselves
+
+    @integration
+    Scenario: Label counts are read per day and period
+      Given processed results carrying labels across both periods
+      When the performance buckets are read
+      Then each bucket carries the count of each label produced that day


### PR DESCRIPTION
## The report

A customer project runs a `langevals/llm_category` online evaluation. It has produced `processed` results every day for a month. The online evaluations list shows a flat sparkline and **"No data yet"** on that row.

## What was wrong

A classifier writes a `label` on every result and leaves `score` and `passed` empty. The performance column knew two readings and neither of them is a label:

```sql
sum(ifNull(Score, 0)) AS ScoreSum, count(Score) AS ScoreCount,
sum(ifNull(Passed, 0)) AS PassSum, count(Passed) AS PassCount
```

`Label` was never selected, so a month of results produced `ScoreCount = 0`, the average came back `null`, and the row fell into the explicit no-data state. The data was there the whole time; the column had no way to read it.

## The fix

The query carries a per-day count of each label alongside the existing sums, and the summary picks the reading the evaluator actually produces: a guardrail is still its pass rate, a scoring evaluator is still its score even in a period where it happened to produce none, and a monitor that is neither is summarized as a distribution.

A distribution, not an average, because that is what a classifier's period is. The row draws one strip sized by share and colored per label, and names the leading label with its share and its own change in share against the previous period:

```
[■■■■■■■■■■■■□□□□□□]  resolved
                      75%, ↑ 50 pp
```

Every segment carries its own accessible name and hover title (`resolved: 75% (3)`), so the split reads without a legend the column has no room for. Labels past the fifth are grouped under "Other" so a long-tailed classifier does not turn the column into slivers, and the shares still add up to the whole period.

A label absent from a previous period that HAD results counts as a share of zero, which is a real reading. A previous period with no results at all supports no comparison, so the row says "75% of results" instead of inventing a trend.

## Tests

- `specs/evaluations/category-evaluator-performance.feature`, 12 scenarios, all bound.
- Unit, over the summary: label ordering and shares, the leading label compared against itself, an absent label read as zero, the tail grouped with the shares still summing to one, and score and pass rate unchanged even when the results also carry labels.
- Integration against real ClickHouse: a classifier seeded across both periods with no score and no pass flag anywhere. The buckets come back carrying `{ resolved: 2 }` and `{ resolved: 1, escalated: 1 }` per day, and the summary is the distribution with a real previous-period comparison. This is the shape that used to read as no data at all.
- Component, over the rendered list: the strip, the leading label and its movement, every label named with its share, a scoring row unchanged, and a classifier with no results still saying there is no data yet.

`pnpm typecheck:all` clean.

## Plotting labels in custom analytics

Not needed, and not added: `evaluations.evaluation_label` is already a group-by dimension in the analytics registry, and the ClickHouse group-by builder already reads `evaluation_runs.Label`. Label share over time is available today by grouping an evaluation series by Evaluation Label in the chart builder.

https://claude.ai/code/session_01WKLMWcBwMSbzAL77N9i3sx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added label-based performance summaries for category evaluators.
  * Online evaluation results now display label distributions, shares, leading-label trends, and grouped “Other” labels.
  * Preserved sparkline views for score and pass-rate evaluations.
  * Added clear empty states when no evaluation results are available.

* **Tests**
  * Added coverage for label distributions, trends, daily counts, and existing score/pass-rate behavior.

* **Documentation**
  * Added feature specifications for category evaluator performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->