### PR TITLE
fix(health): authenticate /api/health/scenarios with the project API key like its siblings

### DIFF
--- a/platform/app/.env.example
+++ b/platform/app/.env.example
@@ -572,19 +572,17 @@ LANGY_INTERNAL_SECRET=
 
 # SCENARIO CANARY HEALTH PROBE
 # GET /api/health/scenarios fires a real scenario run and reports what broke.
-# Its scenario/target selection is NOT configured here: it is passed per request
-# as ?projectId=<project id>&runPlanId=<SimulationSuite id> query parameters,
-# naming a run plan (a SimulationSuite with kind "run_plan") that holds exactly
-# one scenario and one target. The plan is looked up scoped to projectId (the
-# multitenancy guard rejects an unscoped read), and the plan's own row supplies
-# the scenario and target; the run's model is pinned on the canary Scenario
-# record's simulatorModel/judgeModel columns (recommended gpt-5-mini). A
-# runPlanId that does not belong to projectId, or a plan that does not resolve to
-# exactly one scenario and one target, reports "run_failed" (never a hang)
-# rather than running the wrong thing.
+# It needs NO env var of its own: like every other /api/health/* probe it is
+# authenticated by a project API key (X-Auth-Token header), and the project
+# comes from that key. Its scenario/target selection is passed per request as
+# ?runPlanId=<SimulationSuite id or slug>, naming a run plan (a SimulationSuite
+# with kind "run_plan") in the key's project that holds exactly one scenario and
+# one target. The plan's own row supplies the scenario and target; the run's
+# model is pinned on the canary Scenario record's simulatorModel/judgeModel
+# columns (recommended gpt-5-mini). A runPlanId that belongs to another project,
+# or a plan that does not resolve to exactly one scenario and one target,
+# reports "run_failed" (never a hang) rather than running the wrong thing.
 # Failure reasons are exactly three: run_failed | judge_failed | timeout.
 # "timeout" means the 120s total budget ran out — including a wedged run plan
 # lookup, which shares that same single budget with the run phase rather than
 # getting a budget of its own.
-# CRON_API_KEY is the only env var this probe needs — the shared secret it is
-# authenticated by (see validateInternalSecret).

--- a/platform/app/src/server/health-probes/__tests__/scenario-canary.service.unit.test.ts
+++ b/platform/app/src/server/health-probes/__tests__/scenario-canary.service.unit.test.ts
@@ -21,7 +21,7 @@ import {
 import type { ScenarioResults } from "~/server/scenarios/schemas/event-schemas";
 
 const { logger } = vi.hoisted(() => ({
-  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }));
 
 vi.mock("@langwatch/observability", () => ({
@@ -639,8 +639,8 @@ describe("parseRunPlanConfig", () => {
 });
 
 /**
- * A `SimulationSuite` row as the canary's lookup reads it, plus the two columns
- * the `findFirst` `where` filters on (`kind`, `archivedAt`).
+ * A `SimulationSuite` row as the canary's lookup reads it, plus `archivedAt`
+ * (filtered in the repository `where`) and `kind` (checked after the read).
  */
 type FakeSuiteRow = {
   id: string;
@@ -653,33 +653,28 @@ type FakeSuiteRow = {
 };
 
 /**
- * Drives `prisma.simulationSuite.findFirst` off an in-memory table that HONOURS
- * the `where` (id-or-slug + `projectId` + `archivedAt: null` + `kind: "run_plan"`).
- * Returning `null` unconditionally would make an "archived plan is rejected"
- * test pass even if the filter were dropped; making the fake obey the filter is
- * what proves each clause is load-bearing — a row that would match without one
- * clause is filtered out by it, including a plan queried under the wrong
- * projectId.
+ * Drives `prisma.simulationSuite.findFirst` — which `SuiteRepository.findById`
+ * and `findBySlug` both sit on — off an in-memory table that HONOURS the
+ * `where` (`id` or `slug` + `projectId` + `archivedAt: null`). Returning `null`
+ * unconditionally would make an "archived plan is rejected" test pass even if
+ * the filter were dropped; making the fake obey the filter is what proves each
+ * clause is load-bearing — a row that would match without one clause is
+ * filtered out by it, including a plan queried under the wrong projectId.
+ * `kind` is deliberately NOT filtered here: the repository finders are
+ * kind-agnostic, so the service must reject a non-`run_plan` row itself and
+ * the "test_suite is rejected" test proves it does.
  */
 function fakeSuiteTable(rows: FakeSuiteRow[]) {
   vi.mocked(prisma.simulationSuite.findFirst).mockImplementation((async (
     args: { where?: Record<string, unknown> } | undefined,
   ) => {
     const where = args?.where ?? {};
-    const or = where.OR as Array<{ id?: string; slug?: string }> | undefined;
     const match = rows.find(
       (row) =>
         (where.id === undefined || row.id === where.id) &&
-        (or === undefined ||
-          or.some((clause) =>
-            clause.id !== undefined
-              ? row.id === clause.id
-              : row.slug === clause.slug,
-          )) &&
+        (where.slug === undefined || row.slug === where.slug) &&
         (where.projectId === undefined || row.projectId === where.projectId) &&
-        (where.archivedAt === undefined ||
-          row.archivedAt === where.archivedAt) &&
-        (where.kind === undefined || row.kind === where.kind),
+        (where.archivedAt === undefined || row.archivedAt === where.archivedAt),
     );
     return match ?? null;
   }) as typeof prisma.simulationSuite.findFirst);
@@ -712,7 +707,7 @@ describe("runScenarioHealthCanary", () => {
 
   describe("given a runPlanId that resolves to no active run plan", () => {
     /** @scenario "A misconfigured run plan reports unhealthy without launching a run" */
-    it("looks the plan up by id, project, unarchived and kind run_plan, then reports run_failed", async () => {
+    it("looks the plan up by id then by slug, each scoped to the project and unarchived, then reports run_failed", async () => {
       fakeSuiteTable([]);
 
       const result = await runScenarioHealthCanary({
@@ -720,12 +715,19 @@ describe("runScenarioHealthCanary", () => {
         runPlanId: "missing-plan",
       });
 
-      expect(prisma.simulationSuite.findFirst).toHaveBeenCalledWith({
+      expect(prisma.simulationSuite.findFirst).toHaveBeenCalledTimes(2);
+      expect(prisma.simulationSuite.findFirst).toHaveBeenNthCalledWith(1, {
         where: {
+          id: "missing-plan",
           projectId: "canary-project",
-          OR: [{ id: "missing-plan" }, { slug: "missing-plan" }],
           archivedAt: null,
-          kind: "run_plan",
+        },
+      });
+      expect(prisma.simulationSuite.findFirst).toHaveBeenNthCalledWith(2, {
+        where: {
+          slug: "missing-plan",
+          projectId: "canary-project",
+          archivedAt: null,
         },
       });
       expect(result).toMatchObject({ healthy: false, reason: "run_failed" });

--- a/platform/app/src/server/health-probes/__tests__/scenario-canary.service.unit.test.ts
+++ b/platform/app/src/server/health-probes/__tests__/scenario-canary.service.unit.test.ts
@@ -960,6 +960,59 @@ describe("runScenarioHealthCanary", () => {
     });
   });
 
+  describe("given a runPlanId that is both a test_suite's id and a run plan's slug", () => {
+    /** @scenario "A run plan may be named by its slug" */
+    it("falls through the wrong-kind id hit to the slug and launches the run plan", async () => {
+      fakeSuiteTable([
+        {
+          id: "shared-token",
+          slug: "some-test-suite",
+          projectId: "collide-project",
+          scenarioIds: ["suite-scenario"],
+          targets: [{ type: "prompt", referenceId: "suite-prompt" }],
+          kind: "test_suite",
+          archivedAt: null,
+        },
+        {
+          id: "real-plan-id",
+          slug: "shared-token",
+          projectId: "collide-project",
+          scenarioIds: ["plan-scenario"],
+          targets: [{ type: "prompt", referenceId: "plan-prompt" }],
+          kind: "run_plan",
+          archivedAt: null,
+        },
+      ]);
+      vi.mocked(launchScenarioRun).mockResolvedValue({
+        scenarioRunId: "canary-run-4",
+      } as Awaited<ReturnType<typeof launchScenarioRun>>);
+      vi.mocked(getApp).mockReturnValue({
+        simulations: {
+          runs: {
+            getScenarioRunData: async () => ({
+              status: ScenarioRunStatus.SUCCESS,
+              results: verdictResults(Verdict.SUCCESS),
+            }),
+          },
+        },
+      } as unknown as ReturnType<typeof getApp>);
+
+      const result = await runScenarioHealthCanary({
+        projectId: "collide-project",
+        runPlanId: "shared-token",
+      });
+
+      expect(result).toMatchObject({
+        healthy: true,
+        scenarioRunId: "canary-run-4",
+      });
+      expect(launchScenarioRun).toHaveBeenCalledTimes(1);
+      expect(vi.mocked(launchScenarioRun).mock.calls[0]![0]).toMatchObject({
+        scenarioId: "plan-scenario",
+      });
+    });
+  });
+
   describe("given concurrent requests naming the same plan by id and by slug", () => {
     /** @scenario "A concurrent canary while one is in flight starts no second run" */
     it("keys single flight by the resolved plan id, so the slug request sees busy and launches nothing", async () => {

--- a/platform/app/src/server/health-probes/__tests__/scenario-canary.service.unit.test.ts
+++ b/platform/app/src/server/health-probes/__tests__/scenario-canary.service.unit.test.ts
@@ -373,6 +373,7 @@ describe("runScenarioCanary", () => {
         } as Awaited<ReturnType<typeof launchScenarioRun>>);
         const config: CanaryConfig = {
           projectId: "canary-project",
+          runPlanId: "canary-plan",
           scenarioId: "canary-scenario",
           target: { type: "prompt", referenceId: "canary-prompt" },
         };
@@ -543,6 +544,7 @@ describe("runScenarioCanary with a wedged boundary await", () => {
 
 describe("parseRunPlanConfig", () => {
   const validSuite = {
+    id: "canary-plan",
     projectId: "canary-project",
     scenarioIds: ["canary-scenario"],
     targets: [{ type: "prompt", referenceId: "canary-prompt-id" }],
@@ -555,6 +557,7 @@ describe("parseRunPlanConfig", () => {
 
       expect(result).toEqual({
         projectId: "canary-project",
+        runPlanId: "canary-plan",
         scenarioId: "canary-scenario",
         target: { type: "prompt", referenceId: "canary-prompt-id" },
       });
@@ -574,6 +577,7 @@ describe("parseRunPlanConfig", () => {
 
       expect(result).toEqual({
         projectId: "canary-project",
+        runPlanId: "canary-plan",
         scenarioId: "canary-scenario",
         target: { type, referenceId: "ref" },
       });
@@ -953,6 +957,66 @@ describe("runScenarioHealthCanary", () => {
         scenarioRunId: "canary-run-2",
       });
       expect(launchScenarioRun).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("given concurrent requests naming the same plan by id and by slug", () => {
+    /** @scenario "A concurrent canary while one is in flight starts no second run" */
+    it("keys single flight by the resolved plan id, so the slug request sees busy and launches nothing", async () => {
+      fakeSuiteTable([
+        {
+          id: "flight-plan-id",
+          slug: "flight-plan-slug",
+          projectId: "flight-project",
+          scenarioIds: ["plan-scenario"],
+          targets: [{ type: "prompt", referenceId: "plan-prompt" }],
+          kind: "run_plan",
+          archivedAt: null,
+        },
+      ]);
+      // Hold the first launch open until the second request has been answered,
+      // so the first run is provably still in flight when the slug request lands.
+      type Launched = Awaited<ReturnType<typeof launchScenarioRun>>;
+      let releaseLaunch!: (value: Launched) => void;
+      vi.mocked(launchScenarioRun).mockReturnValue(
+        new Promise<Launched>((resolve) => {
+          releaseLaunch = resolve;
+        }),
+      );
+      vi.mocked(getApp).mockReturnValue({
+        simulations: {
+          runs: {
+            getScenarioRunData: async () => ({
+              status: ScenarioRunStatus.SUCCESS,
+              results: verdictResults(Verdict.SUCCESS),
+            }),
+          },
+        },
+      } as unknown as ReturnType<typeof getApp>);
+
+      const byId = runScenarioHealthCanary({
+        projectId: "flight-project",
+        runPlanId: "flight-plan-id",
+      });
+      // Let the id request resolve its plan and take the lock before the slug
+      // request resolves the same plan.
+      await vi.waitFor(() =>
+        expect(launchScenarioRun).toHaveBeenCalledTimes(1),
+      );
+
+      const bySlug = await runScenarioHealthCanary({
+        projectId: "flight-project",
+        runPlanId: "flight-plan-slug",
+      });
+
+      expect(bySlug).toEqual({ busy: true });
+      expect(launchScenarioRun).toHaveBeenCalledTimes(1);
+
+      releaseLaunch({ scenarioRunId: "canary-run-3" } as Launched);
+      expect(await byId).toMatchObject({
+        healthy: true,
+        scenarioRunId: "canary-run-3",
+      });
     });
   });
 

--- a/platform/app/src/server/health-probes/__tests__/scenario-canary.service.unit.test.ts
+++ b/platform/app/src/server/health-probes/__tests__/scenario-canary.service.unit.test.ts
@@ -644,6 +644,7 @@ describe("parseRunPlanConfig", () => {
  */
 type FakeSuiteRow = {
   id: string;
+  slug?: string;
   projectId: string;
   scenarioIds: string[];
   targets: unknown;
@@ -653,7 +654,7 @@ type FakeSuiteRow = {
 
 /**
  * Drives `prisma.simulationSuite.findFirst` off an in-memory table that HONOURS
- * the `where` (id + `projectId` + `archivedAt: null` + `kind: "run_plan"`).
+ * the `where` (id-or-slug + `projectId` + `archivedAt: null` + `kind: "run_plan"`).
  * Returning `null` unconditionally would make an "archived plan is rejected"
  * test pass even if the filter were dropped; making the fake obey the filter is
  * what proves each clause is load-bearing — a row that would match without one
@@ -665,9 +666,16 @@ function fakeSuiteTable(rows: FakeSuiteRow[]) {
     args: { where?: Record<string, unknown> } | undefined,
   ) => {
     const where = args?.where ?? {};
+    const or = where.OR as Array<{ id?: string; slug?: string }> | undefined;
     const match = rows.find(
       (row) =>
         (where.id === undefined || row.id === where.id) &&
+        (or === undefined ||
+          or.some((clause) =>
+            clause.id !== undefined
+              ? row.id === clause.id
+              : row.slug === clause.slug,
+          )) &&
         (where.projectId === undefined || row.projectId === where.projectId) &&
         (where.archivedAt === undefined ||
           row.archivedAt === where.archivedAt) &&
@@ -714,8 +722,8 @@ describe("runScenarioHealthCanary", () => {
 
       expect(prisma.simulationSuite.findFirst).toHaveBeenCalledWith({
         where: {
-          id: "missing-plan",
           projectId: "canary-project",
+          OR: [{ id: "missing-plan" }, { slug: "missing-plan" }],
           archivedAt: null,
           kind: "run_plan",
         },
@@ -902,6 +910,47 @@ describe("runScenarioHealthCanary", () => {
         scenarioId: "plan-scenario",
         target: { type: "prompt", referenceId: "plan-prompt" },
       });
+    });
+  });
+
+  describe("given a runPlanId that is the plan's slug rather than its id", () => {
+    /** @scenario "A run plan may be named by its slug" */
+    it("resolves the plan by slug within the caller's project and launches through it", async () => {
+      fakeSuiteTable([
+        {
+          id: "plan-nanoid",
+          slug: "canary-health-check",
+          projectId: "plan-project",
+          scenarioIds: ["plan-scenario"],
+          targets: [{ type: "prompt", referenceId: "plan-prompt" }],
+          kind: "run_plan",
+          archivedAt: null,
+        },
+      ]);
+      vi.mocked(launchScenarioRun).mockResolvedValue({
+        scenarioRunId: "canary-run-2",
+      } as Awaited<ReturnType<typeof launchScenarioRun>>);
+      vi.mocked(getApp).mockReturnValue({
+        simulations: {
+          runs: {
+            getScenarioRunData: async () => ({
+              status: ScenarioRunStatus.SUCCESS,
+              results: verdictResults(Verdict.SUCCESS),
+            }),
+          },
+        },
+      } as unknown as ReturnType<typeof getApp>);
+
+      const result = await runScenarioHealthCanary({
+        projectId: "plan-project",
+        runPlanId: "canary-health-check",
+      });
+
+      expect(result).toMatchObject({
+        healthy: true,
+        scenarioRunId: "canary-run-2",
+      });
+      expect(launchScenarioRun).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/platform/app/src/server/health-probes/scenario-canary.service.ts
+++ b/platform/app/src/server/health-probes/scenario-canary.service.ts
@@ -309,6 +309,12 @@ const CANARY_ACTOR: RunActor = { id: "scenario-canary", label: "api" };
 /** The validated server-side config a canary run needs to launch. */
 export interface CanaryConfig {
   projectId: string;
+  /**
+   * The resolved run plan's own `SimulationSuite.id`, whatever the caller
+   * named it by (id or slug), so the single-flight guard has one canonical key
+   * per plan.
+   */
+  runPlanId: string;
   scenarioId: string;
   target: SimulationTarget;
 }
@@ -327,7 +333,12 @@ export interface CanaryConfig {
  * type system, so an unknown target type is caught here.
  */
 export function parseRunPlanConfig(
-  suite: { projectId: string; scenarioIds: string[]; targets: unknown } | null,
+  suite: {
+    id: string;
+    projectId: string;
+    scenarioIds: string[];
+    targets: unknown;
+  } | null,
 ): CanaryConfig | { invalid: string } {
   if (!suite) {
     return { invalid: "run plan not found" };
@@ -351,6 +362,7 @@ export function parseRunPlanConfig(
   const target = targets[0]!;
   return {
     projectId: suite.projectId,
+    runPlanId: suite.id,
     scenarioId: suite.scenarioIds[0]!,
     target: { type: target.type, referenceId: target.referenceId },
   };
@@ -554,10 +566,12 @@ export async function runScenarioHealthCanary({
     );
     return { healthy: false, reason: "run_failed", durationMs: 0 };
   }
-  // Keyed per project AND plan: two projects may legitimately reuse a slug,
-  // and their monitors must never block each other.
+  // Keyed per project AND resolved plan id, never the caller's spelling: two
+  // projects may legitimately reuse a slug and must not block each other, and
+  // one plan named by its id in one request and its slug in another is still
+  // ONE plan — the second request must see busy, not launch a parallel run.
   return singleFlightCanary({
-    key: `${projectId}/${runPlanId}`,
+    key: `${projectId}/${resolved.runPlanId}`,
     deps: buildProductionDeps(resolved),
     hardDeadline,
   });

--- a/platform/app/src/server/health-probes/scenario-canary.service.ts
+++ b/platform/app/src/server/health-probes/scenario-canary.service.ts
@@ -19,9 +19,9 @@
  *    second call for the same run plan while one is in flight starts no second
  *    run — a different run plan is unaffected.
  *  - {@link runScenarioHealthCanary} is the production entrypoint the route
- *    crosses: it looks up the run plan named by `?runPlanId=`, scoped to
- *    `?projectId=`, validates it, builds the real deps and drives the
- *    single-flight guard.
+ *    crosses: it looks up the run plan named by `?runPlanId=` (id or slug),
+ *    scoped to the project the API key resolved to, validates it, builds the
+ *    real deps and drives the single-flight guard.
  *
  * Two failure modes the injected clock alone cannot bound are handled with a
  * real timer instead: a boundary await (`queueRun` / `getScenarioRunData`) that
@@ -404,13 +404,19 @@ async function resolveCanaryConfigFromRunPlan({
     const raced = await raceDeadline({
       ms: remainingMs,
       // `projectId` scopes the read to a plan the caller's project owns and
-      // satisfies the multitenancy guard. `kind: "run_plan"` and
+      // satisfies the multitenancy guard. `runPlanId` may be the plan's id or
+      // its slug (slugs are unique per project). `kind: "run_plan"` and
       // `archivedAt: null` are load-bearing too: a 1×1 `test_suite` or an
       // archived plan would otherwise launch a real run the operator meant to
       // retire. Filtering in the query keeps every one of those decisions in a
       // single place instead of re-checking them after the read.
       work: prisma.simulationSuite.findFirst({
-        where: { id: runPlanId, projectId, archivedAt: null, kind: "run_plan" },
+        where: {
+          projectId,
+          OR: [{ id: runPlanId }, { slug: runPlanId }],
+          archivedAt: null,
+          kind: "run_plan",
+        },
       }),
     });
     if ("timedOut" in raced) {
@@ -469,9 +475,9 @@ export function buildProductionDeps(config: CanaryConfig): ScenarioCanaryDeps {
 const singleFlightCanary = createSingleFlightScenarioCanary(runScenarioCanary);
 
 /**
- * The route's single entrypoint. Takes the id of the run plan (a
+ * The route's single entrypoint. Takes the id or slug of the run plan (a
  * `SimulationSuite` with `kind: "run_plan"`) the canary is pointed at and the
- * `projectId` that plan belongs to. The run plan is looked up scoped to that
+ * `projectId` the caller's API key resolved to. The run plan is looked up scoped to that
  * project (both to satisfy the multitenancy guard and to confine the canary to
  * a plan the project owns), and the canary's own scenario and target come from
  * that plan's row — so a runPlanId that does not belong to `projectId`, or a
@@ -533,8 +539,10 @@ export async function runScenarioHealthCanary({
     );
     return { healthy: false, reason: "run_failed", durationMs: 0 };
   }
+  // Keyed per project AND plan: two projects may legitimately reuse a slug,
+  // and their monitors must never block each other.
   return singleFlightCanary({
-    key: runPlanId,
+    key: `${projectId}/${runPlanId}`,
     deps: buildProductionDeps(resolved),
     hardDeadline,
   });

--- a/platform/app/src/server/health-probes/scenario-canary.service.ts
+++ b/platform/app/src/server/health-probes/scenario-canary.service.ts
@@ -371,7 +371,8 @@ export function parseRunPlanConfig(
 /**
  * Resolves `runPlanId` (id or slug) to a non-archived `run_plan` suite in
  * `projectId`, or `null`. Tries the id first: ids are globally unique, so a
- * hit needs no second read; a miss falls back to the per-project slug.
+ * `run_plan` hit needs no second read; a miss, or a hit of another kind, falls
+ * back to the per-project slug.
  */
 async function findRunPlan({
   projectId,
@@ -381,10 +382,13 @@ async function findRunPlan({
   runPlanId: string;
 }): Promise<SimulationSuite | null> {
   const suites = new SuiteRepository(prisma);
-  const suite =
-    (await suites.findById({ id: runPlanId, projectId })) ??
-    (await suites.findBySlug({ slug: runPlanId, projectId }));
-  return suite?.kind === "run_plan" ? suite : null;
+  const byId = await suites.findById({ id: runPlanId, projectId });
+  if (byId?.kind === "run_plan") return byId;
+  // An id hit of the wrong kind is not the plan: ids and per-project slugs are
+  // enforced unique separately, so a `test_suite` id may coincide with a real
+  // run plan's slug — fall through to the slug rather than stop here.
+  const bySlug = await suites.findBySlug({ slug: runPlanId, projectId });
+  return bySlug?.kind === "run_plan" ? bySlug : null;
 }
 
 /**

--- a/platform/app/src/server/health-probes/scenario-canary.service.ts
+++ b/platform/app/src/server/health-probes/scenario-canary.service.ts
@@ -39,6 +39,7 @@
  */
 
 import { createLogger } from "@langwatch/observability";
+import type { SimulationSuite } from "~/generated/prisma/client";
 import { getApp } from "~/server/app-layer/app";
 import { prisma } from "~/server/db";
 import { launchScenarioRun } from "~/server/scenarios/launch-scenario-run.service";
@@ -50,6 +51,7 @@ import {
 } from "~/server/scenarios/scenario-event.enums";
 import type { ScenarioResults } from "~/server/scenarios/schemas/event-schemas";
 import type { SimulationTarget } from "~/server/scenarios/simulation-target";
+import { SuiteRepository } from "~/server/suites/suite.repository";
 import { parseSuiteTargets } from "~/server/suites/types";
 
 const logger = createLogger("langwatch:scenario-canary");
@@ -355,6 +357,25 @@ export function parseRunPlanConfig(
 }
 
 /**
+ * Resolves `runPlanId` (id or slug) to a non-archived `run_plan` suite in
+ * `projectId`, or `null`. Tries the id first: ids are globally unique, so a
+ * hit needs no second read; a miss falls back to the per-project slug.
+ */
+async function findRunPlan({
+  projectId,
+  runPlanId,
+}: {
+  projectId: string;
+  runPlanId: string;
+}): Promise<SimulationSuite | null> {
+  const suites = new SuiteRepository(prisma);
+  const suite =
+    (await suites.findById({ id: runPlanId, projectId })) ??
+    (await suites.findBySlug({ slug: runPlanId, projectId }));
+  return suite?.kind === "run_plan" ? suite : null;
+}
+
+/**
  * Reads and validates the canary config off the named run plan's suite row,
  * scoped to `projectId`.
  *
@@ -372,7 +393,7 @@ export function parseRunPlanConfig(
  * documented 200/503/429 contract.
  *
  * The read is also raced against `raceDeadline` (defaulting to
- * {@link raceAgainstRealDeadline}) so a wedged `findFirst` cannot wedge the
+ * {@link raceAgainstRealDeadline}) so a wedged lookup cannot wedge the
  * endpoint forever. `remainingMs` is what is left of the ONE shared total
  * budget after the caller ({@link runScenarioHealthCanary}) computed its
  * `hardDeadline` — the lookup and the run phase that follows it share a single
@@ -403,21 +424,15 @@ async function resolveCanaryConfigFromRunPlan({
   try {
     const raced = await raceDeadline({
       ms: remainingMs,
-      // `projectId` scopes the read to a plan the caller's project owns and
-      // satisfies the multitenancy guard. `runPlanId` may be the plan's id or
-      // its slug (slugs are unique per project). `kind: "run_plan"` and
-      // `archivedAt: null` are load-bearing too: a 1×1 `test_suite` or an
-      // archived plan would otherwise launch a real run the operator meant to
-      // retire. Filtering in the query keeps every one of those decisions in a
-      // single place instead of re-checking them after the read.
-      work: prisma.simulationSuite.findFirst({
-        where: {
-          projectId,
-          OR: [{ id: runPlanId }, { slug: runPlanId }],
-          archivedAt: null,
-          kind: "run_plan",
-        },
-      }),
+      // `runPlanId` may be the plan's id or its slug (slugs are unique per
+      // project), resolved through the same repository every other suite read
+      // goes through: by id first, then by slug. Both lookups are scoped to
+      // `projectId` (satisfying the multitenancy guard and confining the canary
+      // to a plan the caller's project owns) and skip archived rows. `kind` is
+      // checked here because the repository has no kind-aware finder: a 1×1
+      // `test_suite` would otherwise launch a real run the operator never meant
+      // to schedule.
+      work: findRunPlan({ projectId, runPlanId }),
     });
     if ("timedOut" in raced) {
       logger.error(

--- a/platform/app/src/server/routes/__tests__/scenario-canary.integration.test.ts
+++ b/platform/app/src/server/routes/__tests__/scenario-canary.integration.test.ts
@@ -89,14 +89,20 @@ describe("GET /api/health/scenarios", () => {
   });
 
   describe("given the request carries a project API key that matches no project", () => {
-    /** @scenario "A request with an unknown project API key is refused before any run is queued" */
-    it.each<{ label: string; headers: Record<string, string> }>([
+    // Typed on the rows, not as `it.each<T>(`: the parity checker only binds
+    // `@scenario` to a bare `it.each(` call.
+    const wrongKeyRows: { label: string; headers: Record<string, string> }[] = [
       { label: "X-Auth-Token", headers: { "x-auth-token": "wrong-key" } },
       {
         label: "Authorization: Bearer",
         headers: { authorization: "Bearer wrong-key" },
       },
-    ])("responds 401 via $label and queues no scenario run", async ({
+    ];
+
+    /** @scenario "A request with an unknown project API key is refused before any run is queued" */
+    it.each(
+      wrongKeyRows,
+    )("responds 401 via $label and queues no scenario run", async ({
       headers,
     }) => {
       const app = await getApp();

--- a/platform/app/src/server/routes/__tests__/scenario-canary.integration.test.ts
+++ b/platform/app/src/server/routes/__tests__/scenario-canary.integration.test.ts
@@ -3,8 +3,9 @@
  *
  * @see specs/scenarios/scenario-canary-healthcheck.feature
  *
- * Route-level proof for `GET /api/health/scenarios`: auth runs and can reject
- * BEFORE any run is queued, a busy probe answers 429, and a healthy/unhealthy
+ * Route-level proof for `GET /api/health/scenarios`: project API key auth
+ * (identical to the sibling health probes) runs and can reject BEFORE any run
+ * is queued, a busy probe answers 429, and a healthy/unhealthy
  * outcome from the service maps onto the documented response shape. The
  * service's own retry/budget/single-flight logic is unit-tested against an
  * injected queue/poll boundary in
@@ -13,39 +14,44 @@
  * (`runScenarioHealthCanary`) as the one boundary this route crosses, so a
  * queued-run assertion here is "was the entrypoint invoked", never a real
  * queue call.
- *
- * This file is expected to fail until GET /api/health/scenarios exists on
- * src/server/routes/health-checks.ts and
- * src/server/health-probes/scenario-canary.service.ts exports
- * `runScenarioHealthCanary`.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { runScenarioHealthCanary } = vi.hoisted(() => ({
+const { runScenarioHealthCanary, projectFindUnique } = vi.hoisted(() => ({
   runScenarioHealthCanary: vi.fn(),
+  projectFindUnique: vi.fn(),
 }));
 
 vi.mock("~/server/health-probes/scenario-canary.service", () => ({
   runScenarioHealthCanary,
 }));
 
-const SECRET = "scenario-canary-integration-secret";
+// The route authenticates exactly like its siblings: the project API key in
+// `X-Auth-Token` is resolved through `prisma.project.findUnique`. That lookup
+// is the second (and only other) boundary this route crosses.
+vi.mock("~/server/db", () => ({
+  prisma: { project: { findUnique: projectFindUnique } },
+}));
+
+const API_KEY = "scenario-canary-project-api-key";
+const PROJECT = { id: "proj-1", apiKey: API_KEY, team: { id: "team-1" } };
+const AUTHED = { headers: { "x-auth-token": API_KEY } };
 
 describe("GET /api/health/scenarios", () => {
-  let original: string | undefined;
-
-  beforeEach(async () => {
-    original = process.env.CRON_API_KEY;
-    process.env.CRON_API_KEY = SECRET;
+  beforeEach(() => {
     runScenarioHealthCanary.mockReset();
+    projectFindUnique.mockReset();
+    projectFindUnique.mockImplementation(
+      async ({ where }: { where: { apiKey: string } }) =>
+        where.apiKey === API_KEY ? PROJECT : null,
+    );
     // Fresh module registry per test so the route's own module-scope state
     // (if any) does not leak between auth/busy/healthy cases.
     vi.resetModules();
   });
 
   afterEach(() => {
-    if (original === undefined) delete process.env.CRON_API_KEY;
-    else process.env.CRON_API_KEY = original;
+    vi.clearAllMocks();
   });
 
   async function getApp() {
@@ -54,69 +60,68 @@ describe("GET /api/health/scenarios", () => {
   }
 
   describe("given the route is registered", () => {
-    /** @scenario "The scenario canary route is declared internal-secret, never public" */
-    it("declares the scenario canary route as internalSecret so the OpenAPI spec never advertises this LLM-spend endpoint as unauthenticated", async () => {
-      // The handler gates in-handler on validateInternalSecret, so its declared
-      // access policy must be `internal`. A `public` declaration would document
-      // a real-run, LLM-spend endpoint as needing no auth. Registering the app
-      // populates the process-wide route registry as a side effect.
+    /** @scenario "The scenario canary route is declared public like its sibling health probes" */
+    it("declares the scenario canary route as a public endpoint that authenticates the project in-handler, like its siblings", async () => {
       await import("../health-checks");
       const { getRoutePolicy } = await import(
         "~/server/api/security/route-registry"
       );
 
       const registered = getRoutePolicy("GET", "/api/health/scenarios");
+      const sibling = getRoutePolicy("GET", "/api/health/triggers");
 
-      expect(registered?.policy.kind).toBe("internal");
-      expect(registered?.policy.kind).not.toBe("public");
+      expect(registered?.policy.kind).toBe("public");
+      expect(registered?.policy.kind).toBe(sibling?.policy.kind);
     });
   });
 
-  describe("given the request carries no Authorization header", () => {
-    /** @scenario "A request with no auth secret is refused before any run is queued" */
-    it("responds 401", async () => {
+  describe("given the request carries no project API key", () => {
+    /** @scenario "A request with no project API key is refused before any run is queued" */
+    it("responds 401 and queues no scenario run", async () => {
       const app = await getApp();
 
-      const res = await app.request("/api/health/scenarios");
+      const res = await app.request("/api/health/scenarios?runPlanId=plan-1");
 
       expect(res.status).toBe(401);
-    });
-
-    /** @scenario "A request with no auth secret is refused before any run is queued" */
-    it("queues no scenario run", async () => {
-      const app = await getApp();
-
-      await app.request("/api/health/scenarios");
-
       expect(runScenarioHealthCanary).not.toHaveBeenCalled();
+      expect(projectFindUnique).not.toHaveBeenCalled();
     });
   });
 
-  describe("given the request carries a bearer token that does not match the configured secret", () => {
-    /** @scenario "A request with the wrong auth secret is refused before any run is queued" */
-    it("responds 403", async () => {
+  describe("given the request carries a project API key that matches no project", () => {
+    /** @scenario "A request with an unknown project API key is refused before any run is queued" */
+    it.each([
+      ["X-Auth-Token", { "x-auth-token": "wrong-key" }],
+      ["Authorization: Bearer", { authorization: "Bearer wrong-key" }],
+    ])("responds 401 via %s and queues no scenario run", async (_label, headers) => {
       const app = await getApp();
 
-      const res = await app.request("/api/health/scenarios", {
-        headers: { authorization: "Bearer wrong-secret" },
+      const res = await app.request("/api/health/scenarios?runPlanId=plan-1", {
+        headers,
       });
 
-      expect(res.status).toBe(403);
+      expect(res.status).toBe(401);
+      expect(runScenarioHealthCanary).not.toHaveBeenCalled();
     });
 
-    /** @scenario "A request with the wrong auth secret is refused before any run is queued" */
-    it("queues no scenario run", async () => {
+    it("refuses with the same status and message a sibling health probe gives", async () => {
       const app = await getApp();
 
-      await app.request("/api/health/scenarios", {
-        headers: { authorization: "Bearer wrong-secret" },
-      });
+      const [canary, sibling] = await Promise.all([
+        app.request("/api/health/scenarios?runPlanId=plan-1", {
+          headers: { "x-auth-token": "wrong-key" },
+        }),
+        app.request("/api/health/triggers?triggerId=t-1", {
+          headers: { "x-auth-token": "wrong-key" },
+        }),
+      ]);
 
-      expect(runScenarioHealthCanary).not.toHaveBeenCalled();
+      expect(canary.status).toBe(sibling.status);
+      expect(await canary.json()).toEqual(await sibling.json());
     });
   });
 
-  describe("given a request carrying the correct internal secret", () => {
+  describe("given a request carrying a valid project API key", () => {
     /** @scenario "An authenticated request triggers a real run through the shared queue path" */
     it("returns 200 with the queued scenarioRunId when the run is healthy", async () => {
       runScenarioHealthCanary.mockResolvedValue({
@@ -127,8 +132,8 @@ describe("GET /api/health/scenarios", () => {
       const app = await getApp();
 
       const res = await app.request(
-        "/api/health/scenarios?projectId=proj-1&runPlanId=plan-1",
-        { headers: { authorization: `Bearer ${SECRET}` } },
+        "/api/health/scenarios?runPlanId=plan-1",
+        AUTHED,
       );
       const body = (await res.json()) as Record<string, unknown>;
 
@@ -158,8 +163,8 @@ describe("GET /api/health/scenarios", () => {
       const app = await getApp();
 
       const res = await app.request(
-        "/api/health/scenarios?projectId=proj-1&runPlanId=plan-1",
-        { headers: { authorization: `Bearer ${SECRET}` } },
+        "/api/health/scenarios?runPlanId=plan-1",
+        AUTHED,
       );
       const body = (await res.json()) as Record<string, unknown>;
 
@@ -173,8 +178,8 @@ describe("GET /api/health/scenarios", () => {
       const app = await getApp();
 
       const res = await app.request(
-        "/api/health/scenarios?projectId=proj-1&runPlanId=plan-1",
-        { headers: { authorization: `Bearer ${SECRET}` } },
+        "/api/health/scenarios?runPlanId=plan-1",
+        AUTHED,
       );
       const body = (await res.json()) as Record<string, unknown>;
 
@@ -186,9 +191,7 @@ describe("GET /api/health/scenarios", () => {
     it("responds 400 and queues no run when runPlanId is absent", async () => {
       const app = await getApp();
 
-      const res = await app.request("/api/health/scenarios?projectId=proj-1", {
-        headers: { authorization: `Bearer ${SECRET}` },
-      });
+      const res = await app.request("/api/health/scenarios", AUTHED);
 
       expect(res.status).toBe(400);
       // A missing pointer is a bad request, distinct from the 503 a plan that
@@ -198,60 +201,57 @@ describe("GET /api/health/scenarios", () => {
 
     /** @scenario "A blank runPlanId is a bad request" */
     it.each([
-      ["empty", "?projectId=proj-1&runPlanId="],
-      ["whitespace-only", "?projectId=proj-1&runPlanId=%20%20"],
+      ["empty", "?runPlanId="],
+      ["whitespace-only", "?runPlanId=%20%20"],
     ])("responds 400 and queues no run when runPlanId is %s", async (_label, query) => {
       const app = await getApp();
 
-      const res = await app.request(`/api/health/scenarios${query}`, {
-        headers: { authorization: `Bearer ${SECRET}` },
-      });
+      const res = await app.request(`/api/health/scenarios${query}`, AUTHED);
 
       expect(res.status).toBe(400);
-      // A blank/whitespace pointer never reaches the DB — it is rejected
-      // exactly like an absent one, not passed through to a run plan lookup.
       expect(runScenarioHealthCanary).not.toHaveBeenCalled();
     });
 
     /** @scenario "Canary responses are never cacheable" */
-    it("sets Cache-Control no-store on a healthy 200", async () => {
-      runScenarioHealthCanary.mockResolvedValue({
-        healthy: true,
-        scenarioRunId: "canary-run-abc",
-        durationMs: 1000,
-      });
+    it.each([
+      [
+        200,
+        { healthy: true, scenarioRunId: "canary-run-abc", durationMs: 1000 },
+      ],
+      [
+        503,
+        {
+          healthy: false,
+          reason: "run_failed",
+          scenarioRunId: "canary-run-abc",
+          durationMs: 9000,
+        },
+      ],
+    ])("sets Cache-Control no-store on a %s", async (status, result) => {
+      runScenarioHealthCanary.mockResolvedValue(result);
       const app = await getApp();
 
       const res = await app.request(
-        "/api/health/scenarios?projectId=proj-1&runPlanId=plan-1",
-        { headers: { authorization: `Bearer ${SECRET}` } },
+        "/api/health/scenarios?runPlanId=plan-1",
+        AUTHED,
       );
 
-      expect(res.status).toBe(200);
+      expect(res.status).toBe(status);
       expect(res.headers.get("cache-control")).toBe("no-store");
     });
 
     /** @scenario "Canary responses are never cacheable" */
-    it("sets Cache-Control no-store on an unhealthy 503", async () => {
-      runScenarioHealthCanary.mockResolvedValue({
-        healthy: false,
-        reason: "run_failed",
-        scenarioRunId: "canary-run-abc",
-        durationMs: 9000,
-      });
+    it("sets Cache-Control no-store on an auth refusal too", async () => {
       const app = await getApp();
 
-      const res = await app.request(
-        "/api/health/scenarios?projectId=proj-1&runPlanId=plan-1",
-        { headers: { authorization: `Bearer ${SECRET}` } },
-      );
+      const res = await app.request("/api/health/scenarios?runPlanId=plan-1");
 
-      expect(res.status).toBe(503);
+      expect(res.status).toBe(401);
       expect(res.headers.get("cache-control")).toBe("no-store");
     });
 
-    /** @scenario "Canary runs are confined to the run plan's own project regardless of caller input" */
-    it("passes the projectId and runPlanId query params through to the entrypoint", async () => {
+    /** @scenario "Canary runs are confined to the API key's own project regardless of caller input" */
+    it("scopes the run plan lookup to the key's project, ignoring any projectId on the query string", async () => {
       runScenarioHealthCanary.mockResolvedValue({
         healthy: true,
         scenarioRunId: "canary-run-abc",
@@ -260,32 +260,18 @@ describe("GET /api/health/scenarios", () => {
       const app = await getApp();
 
       await app.request(
-        "/api/health/scenarios?projectId=proj-1&runPlanId=plan-1",
-        { headers: { authorization: `Bearer ${SECRET}` } },
+        "/api/health/scenarios?runPlanId=plan-1&projectId=someone-elses-project",
+        AUTHED,
       );
 
-      // The route forwards exactly the two query params. Confinement is enforced
-      // one layer down: the run plan is looked up scoped to `projectId`, and the
-      // launched run's project comes from the resolved plan's own row — so a
-      // runPlanId that does not belong to `projectId` resolves to nothing and no
-      // run is launched (proven in the service unit test), and no request value
-      // can redirect a canary run into a project the plan does not own.
+      // The project is the one the API key resolved to. Confinement is enforced
+      // one layer down: the plan is looked up scoped to that project, so a
+      // runPlanId owned by another project resolves to nothing and no run is
+      // launched (proven in the service unit test).
       expect(runScenarioHealthCanary).toHaveBeenCalledWith({
         projectId: "proj-1",
         runPlanId: "plan-1",
       });
-    });
-
-    /** @scenario "A request with no projectId is a bad request" */
-    it("responds 400 and queues no run when projectId is absent", async () => {
-      const app = await getApp();
-
-      const res = await app.request("/api/health/scenarios?runPlanId=plan-1", {
-        headers: { authorization: `Bearer ${SECRET}` },
-      });
-
-      expect(res.status).toBe(400);
-      expect(runScenarioHealthCanary).not.toHaveBeenCalled();
     });
 
     /** @scenario "An implausibly long query parameter is a bad request" */
@@ -294,8 +280,8 @@ describe("GET /api/health/scenarios", () => {
       const tooLong = "p".repeat(129);
 
       const res = await app.request(
-        `/api/health/scenarios?projectId=proj-1&runPlanId=${tooLong}`,
-        { headers: { authorization: `Bearer ${SECRET}` } },
+        `/api/health/scenarios?runPlanId=${tooLong}`,
+        AUTHED,
       );
       const body = (await res.json()) as Record<string, unknown>;
 
@@ -303,7 +289,6 @@ describe("GET /api/health/scenarios", () => {
       expect(body).toMatchObject({
         message: "runPlanId query parameter is invalid.",
       });
-      // Rejected before any run plan lookup — the entrypoint is never called.
       expect(runScenarioHealthCanary).not.toHaveBeenCalled();
     });
   });

--- a/platform/app/src/server/routes/__tests__/scenario-canary.integration.test.ts
+++ b/platform/app/src/server/routes/__tests__/scenario-canary.integration.test.ts
@@ -90,10 +90,15 @@ describe("GET /api/health/scenarios", () => {
 
   describe("given the request carries a project API key that matches no project", () => {
     /** @scenario "A request with an unknown project API key is refused before any run is queued" */
-    it.each([
-      ["X-Auth-Token", { "x-auth-token": "wrong-key" }],
-      ["Authorization: Bearer", { authorization: "Bearer wrong-key" }],
-    ])("responds 401 via %s and queues no scenario run", async (_label, headers) => {
+    it.each<{ label: string; headers: Record<string, string> }>([
+      { label: "X-Auth-Token", headers: { "x-auth-token": "wrong-key" } },
+      {
+        label: "Authorization: Bearer",
+        headers: { authorization: "Bearer wrong-key" },
+      },
+    ])("responds 401 via $label and queues no scenario run", async ({
+      headers,
+    }) => {
       const app = await getApp();
 
       const res = await app.request("/api/health/scenarios?runPlanId=plan-1", {
@@ -201,9 +206,11 @@ describe("GET /api/health/scenarios", () => {
 
     /** @scenario "A blank runPlanId is a bad request" */
     it.each([
-      ["empty", "?runPlanId="],
-      ["whitespace-only", "?runPlanId=%20%20"],
-    ])("responds 400 and queues no run when runPlanId is %s", async (_label, query) => {
+      { label: "empty", query: "?runPlanId=" },
+      { label: "whitespace-only", query: "?runPlanId=%20%20" },
+    ])("responds 400 and queues no run when runPlanId is $label", async ({
+      query,
+    }) => {
       const app = await getApp();
 
       const res = await app.request(`/api/health/scenarios${query}`, AUTHED);
@@ -214,20 +221,27 @@ describe("GET /api/health/scenarios", () => {
 
     /** @scenario "Canary responses are never cacheable" */
     it.each([
-      [
-        200,
-        { healthy: true, scenarioRunId: "canary-run-abc", durationMs: 1000 },
-      ],
-      [
-        503,
-        {
+      {
+        status: 200,
+        result: {
+          healthy: true,
+          scenarioRunId: "canary-run-abc",
+          durationMs: 1000,
+        },
+      },
+      {
+        status: 503,
+        result: {
           healthy: false,
           reason: "run_failed",
           scenarioRunId: "canary-run-abc",
           durationMs: 9000,
         },
-      ],
-    ])("sets Cache-Control no-store on a %s", async (status, result) => {
+      },
+    ])("sets Cache-Control no-store on a $status", async ({
+      status,
+      result,
+    }) => {
       runScenarioHealthCanary.mockResolvedValue(result);
       const app = await getApp();
 

--- a/platform/app/src/server/routes/health-checks.ts
+++ b/platform/app/src/server/routes/health-checks.ts
@@ -20,17 +20,12 @@ import crypto from "crypto";
 import type { Context } from "hono";
 import { nanoid } from "nanoid";
 import { env } from "~/env.mjs";
-import {
-  createServiceApp,
-  internalSecret,
-  publicEndpoint,
-} from "~/server/api/security";
+import { createServiceApp, publicEndpoint } from "~/server/api/security";
 import { prisma } from "~/server/db";
 import { sendCanary } from "~/server/health-probes/canary.service";
 import { runScenarioHealthCanary } from "~/server/health-probes/scenario-canary.service";
 import type { CollectorRESTParams } from "~/server/tracer/types";
 import type { DeepPartial } from "~/utils/types";
-import { validateInternalSecret } from "./_lib/internal-secret";
 
 const logger = createLogger("langwatch:health-checks");
 
@@ -540,53 +535,39 @@ secured
 
 // ── GET /scenarios ───────────────────────────────────────────────────
 
-// The plan is looked up scoped to `projectId` (the multitenancy guard rejects
-// an unscoped read), and the plan's own row supplies the scenario and target —
-// a runPlanId that does not belong to `projectId` resolves to nothing and
-// reports `run_failed`. Authenticated by the shared internal secret (a
-// status-page poller has no user session and no project API key), checked
-// BEFORE the run plan is read or any run is queued.
+// Authenticated exactly like its siblings: a project API key in `X-Auth-Token`
+// (or `Authorization: Bearer`), resolved by `authenticateProject` BEFORE the
+// run plan is read or any run is queued. The project comes from the key, never
+// from the query string; the plan is looked up scoped to that project (the
+// multitenancy guard rejects an unscoped read) and the plan's own row supplies
+// the scenario and target — a runPlanId that belongs to another project
+// resolves to nothing and reports `run_failed` with no run launched.
 //
 // Every response carries `Cache-Control: no-store` — a monitor must see each
 // run's real result, never a cached one.
 //
 // @see specs/scenarios/scenario-canary-healthcheck.feature
 
-// Neither id is ever this long in practice (both are cuid/nanoid-shaped), so a
-// value past this length is a malformed or hostile request — reject it here,
-// before it ever reaches a DB query, rather than let an oversized param ride
-// all the way down to the multitenancy-scoped `findFirst`.
+// Neither an id nor a slug is ever this long in practice, so a value past this
+// length is a malformed or hostile request — reject it here, before it ever
+// reaches a DB query, rather than let an oversized param ride all the way down
+// to the multitenancy-scoped `findFirst`.
 const MAX_CANARY_QUERY_PARAM_LENGTH = 128;
 
-// Trims and validates the two required query params in one place so the
-// handler's cognitive complexity stays low; returns the 400 message text
-// unchanged when either is missing/blank, and a distinct one when either is
-// implausibly long.
+// Trims and validates the one required query param in one place so the
+// handler's cognitive complexity stays low; a missing/blank value and an
+// implausibly long one are distinct 400s.
 function readCanaryQuery(
   c: Context,
-):
-  | { projectId: string; runPlanId: string }
-  | { missing: string[] }
-  | { invalid: string } {
-  const projectId = c.req.query("projectId")?.trim();
+): { runPlanId: string } | { missing: true } | { invalid: true } {
   const runPlanId = c.req.query("runPlanId")?.trim();
-  for (const [name, value] of [
-    ["projectId", projectId],
-    ["runPlanId", runPlanId],
-  ] as const) {
-    if (value && value.length > MAX_CANARY_QUERY_PARAM_LENGTH) {
-      return { invalid: name };
-    }
+  if (runPlanId && runPlanId.length > MAX_CANARY_QUERY_PARAM_LENGTH) {
+    return { invalid: true };
   }
-  if (projectId && runPlanId) {
-    return { projectId, runPlanId };
+  if (runPlanId) {
+    return { runPlanId };
   }
-  return {
-    missing: [
-      ...(projectId ? [] : ["projectId"]),
-      ...(runPlanId ? [] : ["runPlanId"]),
-    ],
-  };
+  return { missing: true };
 }
 
 // Maps the canary's result union to its HTTP response so the handler itself
@@ -620,51 +601,41 @@ function canaryResultToResponse({
 }
 
 secured
-  .access(
-    internalSecret(
-      "scenario canary health probe — CRON_API_KEY shared secret checked " +
-        "in-handler via validateInternalSecret before any run is queued",
-    ),
-  )
+  .access(publicEndpoint("subsystem health probe"))
   .get("/scenarios", async (c) => {
     // A monitor may poll this on an interval; a cached 200/503 would hide the
     // next run's real result, so no response on any path is cacheable. Set once
     // before the branches so every return below inherits it.
     c.header("Cache-Control", "no-store");
 
-    if (!c.req.header("authorization")) {
-      return c.json(
-        { message: "Authentication token is required." },
-        { status: 401 },
-      );
+    const auth = await authenticateProject(c);
+    if ("error" in auth) {
+      return c.json({ message: auth.error }, { status: auth.status });
     }
-    if (!validateInternalSecret(c)) {
-      return c.json({ message: "Invalid auth token." }, { status: 403 });
-    }
+    const { project } = auth;
 
-    // Both are required and both come from the query string: `projectId` scopes
-    // the run plan lookup (the multitenancy guard rejects an unscoped read) and
-    // `runPlanId` names the plan. A missing/blank either is a bad request,
-    // distinct from the 503 a plan that does not resolve reports.
+    // `runPlanId` (the plan's id or its slug) is the only query param; the
+    // project scoping the lookup comes from the API key. A missing/blank value
+    // is a bad request, distinct from the 503 a plan that does not resolve
+    // reports.
     const query = readCanaryQuery(c);
     if ("invalid" in query) {
       return c.json(
-        { message: `${query.invalid} query parameter is invalid.` },
+        { message: "runPlanId query parameter is invalid." },
         { status: 400 },
       );
     }
     if ("missing" in query) {
       return c.json(
-        {
-          message: `${query.missing.join(" and ")} query parameter${
-            query.missing.length > 1 ? "s are" : " is"
-          } required.`,
-        },
+        { message: "runPlanId query parameter is required." },
         { status: 400 },
       );
     }
 
-    const result = await runScenarioHealthCanary(query);
+    const result = await runScenarioHealthCanary({
+      projectId: project.id,
+      runPlanId: query.runPlanId,
+    });
     return canaryResultToResponse({ c, result });
   });
 

--- a/specs/scenarios/scenario-canary-healthcheck.feature
+++ b/specs/scenarios/scenario-canary-healthcheck.feature
@@ -23,10 +23,11 @@ Feature: A scenario canary health check that fires a real run and says what brok
   orphaned by walking away from it.
 
   The scenario and target the canary runs are not server-side config: they are
-  named per request by a `?runPlanId=<SimulationSuite id>` query parameter,
-  pointing at a run plan (a suite with kind `run_plan`) that holds exactly one
-  scenario and exactly one target. The plan's own row supplies the project, so
-  nothing else on the request can redirect the run. A request with no runPlanId
+  named per request by a `?runPlanId=<SimulationSuite id or slug>` query
+  parameter, pointing at a run plan (a suite with kind `run_plan`) that holds
+  exactly one scenario and exactly one target. The plan is looked up inside the
+  project the API key belongs to, and the plan's own row supplies the scenario
+  and target, so nothing else on the request can redirect the run. A request with no runPlanId
   is a bad request (400) — distinct from a plan that does not resolve. A run
   that cannot even be launched — the launcher throws, or the named run plan is
   not found, or it does not hold exactly one scenario and one target — is
@@ -34,11 +35,14 @@ Feature: A scenario canary health check that fires a real run and says what brok
   escaping as a raw 500. The run plan is validated up front, before any run is
   queued.
 
-  Auth is the shared `CRON_API_KEY` secret (`validateInternalSecret`), checked
-  before any run is queued: a status-page poller has no user session and no
-  project API key, only this one shared secret. The route is declared as an
-  internal-secret endpoint, so the generated OpenAPI spec never advertises this
-  LLM-spend endpoint as needing no auth. A second request for the same run plan
+  Auth is the project API key (`X-Auth-Token`, or `Authorization: Bearer`),
+  exactly as on every sibling health probe (`/collector`, `/evaluations`,
+  `/processor`, `/triggers`, `/workflows`): a missing or unknown key is refused
+  with the same status and message the siblings give, before any run plan is
+  read or any run is queued. The project is taken from the key and never from
+  the request, so a run plan owned by another project does not resolve and
+  reports `run_failed` with no run launched. No new env var and no new auth
+  pattern is involved. A second request for the same run plan
   arriving while its canary is already running starts no second LLM run — it is
   told the probe is busy; the guard is keyed per run plan, so two monitors
   probing two different plans never block each other. Every response carries
@@ -116,32 +120,38 @@ Feature: A scenario canary health check that fires a real run and says what brok
     And the run inherits the model configured on the canary scenario record
 
   @integration
-  Scenario: A request with no auth secret is refused before any run is queued
-    Given the request carries no Authorization header
+  Scenario: A request with no project API key is refused before any run is queued
+    Given the request carries no X-Auth-Token and no Authorization header
     When the scenario canary endpoint is called
-    Then the response is 401
-    And no scenario run is queued
+    Then the response is 401, the same as a sibling health probe
+    And no project lookup and no scenario run is queued
 
   @integration
-  Scenario: A request with the wrong auth secret is refused before any run is queued
-    Given the request carries a bearer token that does not match the configured secret
+  Scenario: A request with an unknown project API key is refused before any run is queued
+    Given the request carries an X-Auth-Token or bearer token that matches no project
     When the scenario canary endpoint is called
-    Then the response is 403
+    Then the response is 401 with the same message a sibling health probe gives
     And no scenario run is queued
 
   @integration
   Scenario: An authenticated request triggers a real run through the shared queue path
-    Given a request carrying the correct internal secret
+    Given a request carrying a valid project API key and a runPlanId
     When the scenario canary endpoint is called
     Then the run is queued through the same queue path simulationRunnerRouter.run uses
     And the response is 200 with the queued scenarioRunId
 
   @integration
-  Scenario: Canary runs are confined to the run plan's own project regardless of caller input
-    Given a request carrying the correct internal secret and a runPlanId
+  Scenario: Canary runs are confined to the API key's own project regardless of caller input
+    Given a request carrying a valid project API key, a runPlanId, and a projectId query parameter naming another project
     When the scenario canary endpoint is called
-    Then the run is queued against the project id held on that run plan
-    And that project id is never taken from any other value on the caller's request
+    Then the run plan is looked up scoped to the project the API key resolved to
+    And the projectId on the query string is ignored
+
+  @unit
+  Scenario: A run plan may be named by its slug
+    Given a runPlanId equal to the slug of a valid run plan in the caller's project
+    When the probe runs the canary
+    Then the plan resolves by slug and the run is launched through it
 
   @unit
   Scenario: The probe abandons the retry once the total budget is spent
@@ -173,14 +183,7 @@ Feature: A scenario canary health check that fires a real run and says what brok
 
   @integration
   Scenario: A request with no runPlanId is a bad request
-    Given a request carrying the correct internal secret but no runPlanId
-    When the scenario canary endpoint is called
-    Then the response is 400
-    And no scenario run is queued
-
-  @integration
-  Scenario: A request with no projectId is a bad request
-    Given a request carrying the correct internal secret and a runPlanId but no projectId
+    Given a request carrying a valid project API key but no runPlanId
     When the scenario canary endpoint is called
     Then the response is 400
     And no scenario run is queued
@@ -202,10 +205,10 @@ Feature: A scenario canary health check that fires a real run and says what brok
     And no run is launched
 
   @integration
-  Scenario: The scenario canary route is declared internal-secret, never public
-    Given the scenario canary route gates in-handler on the internal secret
+  Scenario: The scenario canary route is declared public like its sibling health probes
+    Given the scenario canary route authenticates the project API key in-handler
     When its registered access policy is read
-    Then the policy is declared internal-secret, not a public endpoint
+    Then the policy is the same public-endpoint declaration its sibling health probes carry
 
   @unit
   Scenario: An archived run plan is rejected without launching a run
@@ -230,14 +233,14 @@ Feature: A scenario canary health check that fires a real run and says what brok
 
   @integration
   Scenario: A blank runPlanId is a bad request
-    Given a request carrying the correct internal secret and a blank or whitespace-only runPlanId
+    Given a request carrying a valid project API key and a blank or whitespace-only runPlanId
     When the scenario canary endpoint is called
     Then the response is 400
     And no scenario run is queued
 
   @integration
   Scenario: Canary responses are never cacheable
-    Given a request carrying the correct internal secret
+    Given any request, authenticated or not
     When the scenario canary endpoint returns any response
     Then the response carries Cache-Control no-store
 
@@ -258,7 +261,7 @@ Feature: A scenario canary health check that fires a real run and says what brok
 
   @integration
   Scenario: An implausibly long query parameter is a bad request
-    Given a request carrying the correct internal secret and a runPlanId longer than 128 characters
+    Given a request carrying a valid project API key and a runPlanId longer than 128 characters
     When the scenario canary endpoint is called
     Then the response is 400
     And no scenario run is queued


### PR DESCRIPTION
Closes #7939. Refs #7835, #7840.

## What changed

Review follow-up (8a22cb3f8f): the run plan is now resolved through `SuiteRepository.findById` then `findBySlug`, scoped to the project and non-archived, with the `run_plan` kind checked after the read. The ad-hoc prisma `OR` is gone.

Review follow-up (5121802727): the single-flight guard is keyed by project + the resolved plan id, so an id request and a slug request for the same plan share one lock (new unit test). The integration test `it.each` tables use object rows.

Review follow-up (af1de2c683): only a `run_plan` id hit short-circuits the lookup; a wrong-kind id hit (a `test_suite` id that coincides with a run plan slug) falls through to the slug lookup (new unit test).

`GET /api/health/scenarios` was the only health probe gated by the `CRON_API_KEY` internal secret. The external uptime monitor does not hold that secret, so the endpoint was uncallable in production.

- The route now uses `publicEndpoint` + `authenticateProject`, identical to `/collector`, `/evaluations`, `/processor`, `/triggers` and `/workflows`. The project comes from the `X-Auth-Token` (or `Authorization: Bearer`) API key.
- The `projectId` query param is removed. `runPlanId` is the single query param and accepts the run plan's **id or slug** (`SimulationSuite.slug` already exists, unique per project; nothing was invented).
- `internalSecret` / `validateInternalSecret` are removed for this route only. `cron.ts` is untouched.
- Unchanged semantics: single-flight per plan (429), 120s total budget with one retry, 200 ok / 503 `timeout|run_failed|judge_failed`, `Cache-Control: no-store` on every response. The single-flight key is now `project/plan` so two projects that share a slug never block each other.
- A run plan owned by another project does not resolve under the key's project and reports 503 `run_failed` with no run launched (existing service guard, now scoped by the key instead of a caller-supplied id).
- `.env.example`, the feature spec, the route integration test and the service unit test are updated. No docs page mentions this route.

No new env vars. No new auth pattern.

## Files

- `platform/app/src/server/routes/health-checks.ts`
- `platform/app/src/server/health-probes/scenario-canary.service.ts` (lookup by id-or-slug, single-flight key)
- `platform/app/src/server/health-probes/__tests__/scenario-canary.service.unit.test.ts`
- `platform/app/src/server/routes/__tests__/scenario-canary.integration.test.ts`
- `platform/app/.env.example`
- `specs/scenarios/scenario-canary-healthcheck.feature`

## Tests run

| Check | Result |
|---|---|
| `scenario-canary.service.unit.test.ts` | 46 passed |
| `scenario-canary.integration.test.ts` | 18 passed |
| `pnpm typecheck:all` | clean |
| `biome check` on touched files | no new diagnostics (3 pre-existing warnings on sibling routes) |
| `check-feature-parity` on the spec | 30/30 scenarios bound |

## Deployment Impact

- Env vars added: none.
- Env vars removed: `CRON_API_KEY` is no longer needed by this route (`/api/health/scenarios`). It is still read by `cron.ts` and other internal-secret routes, so the variable itself stays.
- Helm values: unchanged. Vanilla `helm install` behaviour: unchanged.
- BYOC dataplane impact: none.
- Operators: any monitor already calling `/api/health/scenarios` with the internal secret must switch to a project API key in `X-Auth-Token` and drop `projectId` from the query. That is the fix for #7939.

## Side-by-side vs `GET /api/health/workflows`

Same as the sibling, line for line: `.access(publicEndpoint("subsystem health probe"))`, `authenticateProject(c)` first, `401`/`403` via `c.json({ message: auth.error }, { status: auth.status })`, project taken only from the key, one query param read with `c.req.query(...)`, plan read scoped to `project.id`, no new headers, env vars, param names or auth helpers.

Divergences, all pre-existing from #7835/#7840 and kept on purpose:

| Aspect | `/workflows` | `/scenarios` | Why kept |
|---|---|---|---|
| Missing or blank param | `?? ""` then `404 Workflow not found.` | `400 runPlanId query parameter is required.` | The issue and the spec keep the 400 for a misconfigured monitor. A blank id is a caller bug, not a missing plan. |
| Over-long param (> 128 chars) | not checked | `400 runPlanId query parameter is invalid.` | Rejects a hostile or malformed value before it reaches the DB. Pre-existing guard. |
| Param value | id only | id or slug | Requested by the issue. `SimulationSuite` already has a per-project unique slug, and the lookup goes through the existing `SuiteRepository.findById` / `findBySlug`. |
| Plan does not resolve | `404` | `503 {"status":"unhealthy","reason":"run_failed"}` | Monitors treat any non-200 as down. The issue requires the 200/503/429 contract. |
| Success envelope | `{ status, body }` of a proxied call | `{ status: "ok", scenarioRunId, durationMs }` | Nothing is proxied. The spec fixes this shape. |
| Busy | none | `429 { status: "busy" }` | Single flight per project/plan, required by the issue. |
| `Cache-Control: no-store` | not set | set on every response | Required by the issue, so a monitor never reads a cached result. |
| Helpers | inline | `readCanaryQuery`, `canaryResultToResponse` | Module-local, pre-existing, keep the handler under the complexity lint. |

## UI surface

Backend-only. This PR changes one Hono health route, a service lookup, tests, a spec and `.env.example`. No page, component or client code changes, so there is no browser proof to take. <!-- no-ui-surface -->

## Human verification

Against prod, with the canary project's API key (`canary-H9pyui`, run plan `zeus-response-scenario-health-check-workflow`):

| Step | Expected | Status |
|---|---|---|
| `curl "$BASE/api/health/scenarios?runPlanId=zeus-response-scenario-health-check-workflow" -H "X-Auth-Token: <canary key>"` | 200 `{"status":"ok","scenarioRunId":...}` | UNVERIFIED |
| Same call with the run plan's nanoid instead of the slug | 200, same shape | UNVERIFIED |
| Same call with no header | 401, same body as `/api/health/triggers` with no header | UNVERIFIED |
| Same call with a wrong key | 401, same body as `/api/health/triggers` with a wrong key | UNVERIFIED |
| Same call with a valid key from a **different** project | 503 `{"status":"unhealthy","reason":"run_failed"}` and no new run in the canary project's Results tab | UNVERIFIED |
| Two overlapping calls for the same plan | second one 429 `{"status":"busy"}` | UNVERIFIED |
| Point BetterStack at the 200 call | monitor turns green | UNVERIFIED |

I did not run the app or hit prod, so every row above is unverified.

## How I can prove I was successful

- Route-level: the integration test asserts 401 with the **same status and body** a sibling probe returns for a missing/unknown key, that `runScenarioHealthCanary` is called with the key's project id and never with a `projectId` from the query string, that the registered access policy equals the sibling's (`public`), 400 on a missing/blank/oversized `runPlanId`, 200/503/429 mapping, and `no-store` on 200, 503 and 401.
- Service-level: the unit test's in-memory suite table honours `projectId` + `OR: [{id},{slug}]` + `archivedAt: null` + `kind: "run_plan"`, and proves a plan owned by another project reports `run_failed` with `launchScenarioRun` never called, plus a new test that a slug resolves and launches.
- Spec: `specs/scenarios/scenario-canary-healthcheck.feature` no longer mentions the internal secret; every scenario is tagged and bound.
- The live curl rows in the table above are the remaining proof, and they need a prod project key I do not have.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018wUbSgajTKarPpMt2ARvBx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scenario health checks now authenticate with a project API key using `X-Auth-Token` or Bearer authentication.
  * Run plans can be selected by ID or project-scoped slug.
  * Requests are automatically scoped to the project associated with the API key.
* **Changes**
  * The `projectId` query parameter and shared cron secret are no longer required.
* **Bug Fixes**
  * Equivalent ID and slug requests now share execution, while plans in different projects remain isolated.
  * Invalid or cross-project run plans return `run_failed`.
  * Improved validation and consistent unauthorized responses for invalid credentials.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->