### PR TITLE
fix(cli): suggest restarting active code launchers after telemetry changes

### DIFF
--- a/sdks/typescript/src/cli/commands/__tests__/instrument.unit.test.ts
+++ b/sdks/typescript/src/cli/commands/__tests__/instrument.unit.test.ts
@@ -97,6 +97,19 @@ afterEach(() => {
 });
 
 describe("instrumentCommand", () => {
+
+  describe("given changed wiring and a running langwatch code launcher", () => {
+    it("prints the restart advice returned by the installer", async () => {
+      const notice = "Restart `langwatch code` to apply the updated telemetry settings.";
+      asMock(installTelemetryWiring).mockReturnValue({
+        labels: ["~/.zshrc"], warnings: [notice], requiredFailures: [],
+      });
+
+      await instrumentCommand("code", {});
+
+      expect(writtenTo(stderrSpy)).toContain(notice);
+    });
+  });
   describe("given a companion write the wiring depends on failed", () => {
     it("fails instead of reporting a wired tool", async () => {
       asMock(installTelemetryWiring).mockReturnValue({

--- a/sdks/typescript/src/cli/utils/governance/__tests__/instrument-wiring.unit.test.ts
+++ b/sdks/typescript/src/cli/utils/governance/__tests__/instrument-wiring.unit.test.ts
@@ -51,6 +51,7 @@ describe("installTelemetryWiring", () => {
 			vi.mocked(runningCodeRestartNotice).mockReturnValue(notice);
 		});
 
+		/** @scenario "A running langwatch code command needs a restart after reconfiguration" */
 		it("reports restart advice after changing the ingest key", () => {
 			install();
 			expect(install("ik-lw-replacement_secret").warnings).toContain(notice);
@@ -73,6 +74,7 @@ describe("installTelemetryWiring", () => {
 			expect(install("ik-lw-replacement_secret").warnings).toEqual([]);
 		});
 
+		/** @scenario "Unchanged wiring needs no restart notice" */
 		it("does not inspect processes or advise restarting unchanged wiring", () => {
 			install();
 			vi.mocked(runningCodeRestartNotice).mockClear();

--- a/sdks/typescript/src/cli/utils/governance/__tests__/instrument-wiring.unit.test.ts
+++ b/sdks/typescript/src/cli/utils/governance/__tests__/instrument-wiring.unit.test.ts
@@ -6,13 +6,19 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { appSettingsTargetFor } from "../app-settings";
 import { installTelemetryWiring } from "../instrument-wiring";
-import { baseCfg, installTempHomeAndCwd } from "./telemetry-refresh-test-helpers";
+import { runningCodeRestartNotice } from "../running-code";
+import {
+	baseCfg,
+	installTempHomeAndCwd,
+} from "./telemetry-refresh-test-helpers";
 
 const temp = installTempHomeAndCwd();
+
+vi.mock("../running-code", () => ({ runningCodeRestartNotice: vi.fn() }));
 
 const ENDPOINT = "http://app.example.com/api/otel";
 const TOKEN = "ik-lw-wiring0000000000_secret";
@@ -30,6 +36,77 @@ afterEach(() => {
 });
 
 describe("installTelemetryWiring", () => {
+	describe("when langwatch code is running", () => {
+		const notice =
+			"Restart `langwatch code` to apply the updated telemetry settings.";
+		const install = (token = TOKEN) =>
+			installTelemetryWiring({
+				cfg: baseCfg(),
+				tool: "code",
+				endpoint: ENDPOINT,
+				token,
+			});
+
+		beforeEach(() => {
+			vi.mocked(runningCodeRestartNotice).mockReturnValue(notice);
+		});
+
+		it("reports restart advice after changing the ingest key", () => {
+			install();
+			expect(install("ik-lw-replacement_secret").warnings).toContain(notice);
+		});
+
+		it("reports restart advice after changing the endpoint", () => {
+			install();
+			const result = installTelemetryWiring({
+				cfg: baseCfg(),
+				tool: "code",
+				endpoint: "https://new.example.com/api/otel",
+				token: TOKEN,
+			});
+			expect(result.warnings).toContain(notice);
+		});
+
+		it("stays quiet when no LangWatch code launcher is detected", () => {
+			install();
+			vi.mocked(runningCodeRestartNotice).mockReturnValue(undefined);
+			expect(install("ik-lw-replacement_secret").warnings).toEqual([]);
+		});
+
+		it("does not inspect processes or advise restarting unchanged wiring", () => {
+			install();
+			vi.mocked(runningCodeRestartNotice).mockClear();
+			expect(install().warnings).toEqual([]);
+			expect(runningCodeRestartNotice).not.toHaveBeenCalled();
+		});
+
+		it("does not report a restart when the wiring write fails", () => {
+			fs.mkdirSync(path.join(temp.home, ".zshrc"));
+			expect(install().warnings).not.toContain(notice);
+		});
+
+		it.skipIf(process.platform === "win32")(
+			"does not report a restart when VS Code's companion write fails",
+			() => {
+				const settingsParent =
+					process.platform === "darwin"
+						? path.join(
+								temp.home,
+								"Library",
+								"Application Support",
+								"Code",
+								"User",
+							)
+						: path.join(temp.home, ".config", "Code", "User");
+				fs.mkdirSync(path.join(settingsParent, "settings.json"), {
+					recursive: true,
+				});
+				const result = install();
+				expect(result.requiredFailures).not.toEqual([]);
+				expect(result.warnings).not.toContain(notice);
+			},
+		);
+	});
 	describe("when the tool is claude", () => {
 		/** @scenario "The wiring targets are the same files a wrapped run manages" */
 		it("writes the OTel env into the user settings.json on a fresh machine", () => {

--- a/sdks/typescript/src/cli/utils/governance/__tests__/login-flow-personal-project.unit.test.ts
+++ b/sdks/typescript/src/cli/utils/governance/__tests__/login-flow-personal-project.unit.test.ts
@@ -65,6 +65,7 @@ vi.mock("../../identityNotice", () => ({
 
 import { loadConfig } from "../config";
 import { runUnifiedLoginFlow } from "../login-flow";
+import { refreshTelemetryWiringForLogin } from "../telemetry-refresh";
 
 const exchangeResult = (extra: Record<string, unknown> = {}) => ({
   kind: "device_session" as const,
@@ -86,6 +87,19 @@ describe("runUnifiedLoginFlow (device session) personal-project persistence", ()
   afterEach(() => {
     delete process.env.LANGWATCH_BROWSER;
     vi.restoreAllMocks();
+  });
+
+  it("prints restart advice when login refreshed a running code launcher's wiring", async () => {
+    pollUntilDone.mockResolvedValue(exchangeResult());
+    const notice = "Restart `langwatch code` to apply the updated telemetry settings.";
+    vi.mocked(refreshTelemetryWiringForLogin).mockResolvedValueOnce({
+      mintedAny: false, labels: ["code shell function (~/.zshrc)"], warnings: [notice],
+    });
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    await runUnifiedLoginFlow({ kind: "device_session" });
+
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining(notice));
   });
 
   /** @scenario device-login exchange delivers the personal project key and the CLI stores it */

--- a/sdks/typescript/src/cli/utils/governance/__tests__/refresh-telemetry-wiring-for-login.unit.test.ts
+++ b/sdks/typescript/src/cli/utils/governance/__tests__/refresh-telemetry-wiring-for-login.unit.test.ts
@@ -49,6 +49,7 @@ const temp = installTempHomeAndCwd();
 
 describe("refreshTelemetryWiringForLogin", () => {
 	describe("when login changes the instance used by an active langwatch code launcher", () => {
+		/** @scenario "Login refresh reports the same restart advice" */
 		it("returns restart advice with the successful wiring refresh", async () => {
 			const notice =
 				"Restart `langwatch code` to apply the updated telemetry settings.";

--- a/sdks/typescript/src/cli/utils/governance/__tests__/refresh-telemetry-wiring-for-login.unit.test.ts
+++ b/sdks/typescript/src/cli/utils/governance/__tests__/refresh-telemetry-wiring-for-login.unit.test.ts
@@ -23,6 +23,9 @@ import {
 	toolMarkers,
 } from "../shell-rc";
 import { refreshTelemetryWiringForLogin } from "../telemetry-refresh";
+import { runningCodeRestartNotice } from "../running-code";
+
+vi.mock("../running-code", () => ({ runningCodeRestartNotice: vi.fn() }));
 import {
 	baseCfg,
 	CURRENT_ENDPOINT,
@@ -45,6 +48,31 @@ vi.mock("../cli-api", async () => {
 const temp = installTempHomeAndCwd();
 
 describe("refreshTelemetryWiringForLogin", () => {
+	describe("when login changes the instance used by an active langwatch code launcher", () => {
+		it("returns restart advice with the successful wiring refresh", async () => {
+			const notice =
+				"Restart `langwatch code` to apply the updated telemetry settings.";
+			vi.mocked(runningCodeRestartNotice).mockReturnValue(notice);
+			persistBlockToRc(
+				"zsh",
+				buildScopedToolFunction(
+					"code",
+					buildOtelEnvBlock("code", STALE_ENDPOINT, STALE_TOKEN),
+					"zsh",
+				),
+				toolMarkers("code"),
+			);
+			vi.mocked(cliApi.mintIngestionKey).mockResolvedValue({
+				token: CURRENT_TOKEN,
+				prefix: "ik-lw-test",
+				endpoint: CURRENT_ENDPOINT,
+			});
+
+			const result = await refreshTelemetryWiringForLogin(baseCfg());
+
+			expect(result).toMatchObject({ warnings: [notice] });
+		});
+	});
 	describe("given persisted wiring pointing at a previous instance", () => {
 		beforeEach(() => {
 			// claude → user-level settings env at the stale instance

--- a/sdks/typescript/src/cli/utils/governance/__tests__/running-code.integration.test.ts
+++ b/sdks/typescript/src/cli/utils/governance/__tests__/running-code.integration.test.ts
@@ -21,26 +21,39 @@ afterEach(async () => {
 
 describe("runningCodeRestartNotice()", () => {
 	describe("when an npm-style LangWatch code process is alive", () => {
+		/** @scenario "Launch detection handles install paths with spaces and Node runtime flags" */
 		it.each([
-			{ name: "ordinary launch", folder: "plain", flags: [] },
+			{ name: "ordinary launch", folder: "plain", flags: [], preload: false },
 			{
 				name: "installation path containing spaces",
 				folder: "space path",
 				flags: [],
+				preload: false,
 			},
 			{
 				name: "Node runtime flag",
 				folder: "plain",
 				flags: ["--enable-source-maps"],
+				preload: false,
 			},
 			{
 				name: "spaces and a runtime flag",
 				folder: "space path",
 				flags: ["--enable-source-maps"],
+				preload: false,
+			},
+			{
+				// ps splits `--require /tmp/pre load.js` into two tokens, so a
+				// naive two-token skip would mistake `load.js` for the entrypoint.
+				name: "a preload path containing spaces",
+				folder: "space path",
+				flags: [],
+				preload: true,
 			},
 		])("detects $name through the operating system", async ({
 			folder,
 			flags,
+			preload,
 		}) => {
 			directory = mkdtempSync(join(tmpdir(), "lw-code-process-"));
 			const cliDir = join(directory, folder, "langwatch", "dist", "cli");
@@ -50,7 +63,13 @@ describe("runningCodeRestartNotice()", () => {
 				entry,
 				'setInterval(() => {}, 1000); process.stdout.write("ready");',
 			);
-			child = spawn(process.execPath, [...flags, entry, "code"], {
+			const runtimeArgs = [...flags];
+			if (preload) {
+				const preloadPath = join(directory, folder, "pre load.js");
+				writeFileSync(preloadPath, "");
+				runtimeArgs.push("--require", preloadPath);
+			}
+			child = spawn(process.execPath, [...runtimeArgs, entry, "code"], {
 				stdio: ["ignore", "pipe", "pipe"],
 			});
 			await once(child.stdout!, "data");

--- a/sdks/typescript/src/cli/utils/governance/__tests__/running-code.integration.test.ts
+++ b/sdks/typescript/src/cli/utils/governance/__tests__/running-code.integration.test.ts
@@ -1,0 +1,61 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { once } from "node:events";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { runningCodeRestartNotice } from "../running-code";
+
+let child: ChildProcess | undefined;
+let directory: string | undefined;
+
+afterEach(async () => {
+	if (child?.exitCode === null && child.signalCode === null) {
+		const closed = once(child, "close");
+		child.kill();
+		await closed;
+	}
+	if (directory) rmSync(directory, { recursive: true, force: true });
+});
+
+describe("runningCodeRestartNotice()", () => {
+	describe("when an npm-style LangWatch code process is alive", () => {
+		it.each([
+			{ name: "ordinary launch", folder: "plain", flags: [] },
+			{
+				name: "installation path containing spaces",
+				folder: "space path",
+				flags: [],
+			},
+			{
+				name: "Node runtime flag",
+				folder: "plain",
+				flags: ["--enable-source-maps"],
+			},
+			{
+				name: "spaces and a runtime flag",
+				folder: "space path",
+				flags: ["--enable-source-maps"],
+			},
+		])("detects $name through the operating system", async ({
+			folder,
+			flags,
+		}) => {
+			directory = mkdtempSync(join(tmpdir(), "lw-code-process-"));
+			const cliDir = join(directory, folder, "langwatch", "dist", "cli");
+			mkdirSync(cliDir, { recursive: true });
+			const entry = join(cliDir, "index.js");
+			writeFileSync(
+				entry,
+				'setInterval(() => {}, 1000); process.stdout.write("ready");',
+			);
+			child = spawn(process.execPath, [...flags, entry, "code"], {
+				stdio: ["ignore", "pipe", "pipe"],
+			});
+			await once(child.stdout!, "data");
+
+			expect(runningCodeRestartNotice()).toContain("Restart `langwatch code`");
+		});
+	});
+});

--- a/sdks/typescript/src/cli/utils/governance/__tests__/running-code.unit.test.ts
+++ b/sdks/typescript/src/cli/utils/governance/__tests__/running-code.unit.test.ts
@@ -11,7 +11,13 @@ afterEach(() => {
 	vi.restoreAllMocks();
 });
 
-function processes(command: string, pid = process.pid + 1): void {
+function processes({
+	command,
+	pid = process.pid + 1,
+}: {
+	command: string;
+	pid?: number;
+}): void {
 	vi.mocked(execFileSync).mockReturnValue(
 		process.platform === "win32"
 			? JSON.stringify([{ ProcessId: pid, CommandLine: command }])
@@ -23,9 +29,10 @@ describe("runningCodeRestartNotice()", () => {
 	describe("when Windows reports running processes", () => {
 		it("detects an npm launcher from CIM output", () => {
 			Object.defineProperty(process, "platform", { value: "win32" });
-			processes(
-				'"C:\\nodejs\\node.exe" "C:\\npm\\langwatch\\dist\\cli\\index.js" code',
-			);
+			processes({
+				command:
+					'"C:\\nodejs\\node.exe" "C:\\npm\\langwatch\\dist\\cli\\index.js" code',
+			});
 			expect(runningCodeRestartNotice()).toContain("Restart `langwatch code`");
 		});
 
@@ -50,12 +57,13 @@ describe("runningCodeRestartNotice()", () => {
 			"/usr/local/bin/lw code .",
 			'"C:\\Program Files\\nodejs\\node.exe" "C:\\npm\\node_modules\\langwatch\\dist\\cli\\index.js" code .',
 		])("suggests a restart for %s", (command) => {
-			processes(command);
+			processes({ command });
 			expect(runningCodeRestartNotice()).toContain("Restart `langwatch code`");
 		});
 	});
 
 	describe("when no other LangWatch code launcher is running", () => {
+		/** @scenario "Other applications do not trigger the notice" */
 		it.each([
 			"claude",
 			"code .",
@@ -73,17 +81,18 @@ describe("runningCodeRestartNotice()", () => {
 			"node /another/script.js /usr/local/bin/langwatch code",
 			"node /another/script /usr/local/bin/langwatch code",
 		])("ignores %s", (command) => {
-			processes(command);
+			processes({ command });
 			expect(runningCodeRestartNotice()).toBeUndefined();
 		});
 
 		it("excludes the current command", () => {
-			processes("langwatch code", process.pid);
+			processes({ command: "langwatch code", pid: process.pid });
 			expect(runningCodeRestartNotice()).toBeUndefined();
 		});
 	});
 
 	describe("when process inspection fails", () => {
+		/** @scenario "Process inspection failure does not fail configuration" */
 		it("does not fail configuration or claim a running launcher", () => {
 			vi.mocked(execFileSync).mockImplementation(() => {
 				throw new Error("process inspection timed out");

--- a/sdks/typescript/src/cli/utils/governance/__tests__/running-code.unit.test.ts
+++ b/sdks/typescript/src/cli/utils/governance/__tests__/running-code.unit.test.ts
@@ -1,0 +1,94 @@
+import { execFileSync } from "node:child_process";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { runningCodeRestartNotice } from "../running-code";
+
+vi.mock("node:child_process", () => ({ execFileSync: vi.fn() }));
+
+const originalPlatform = process.platform;
+afterEach(() => {
+	Object.defineProperty(process, "platform", { value: originalPlatform });
+	vi.restoreAllMocks();
+});
+
+function processes(command: string, pid = process.pid + 1): void {
+	vi.mocked(execFileSync).mockReturnValue(
+		process.platform === "win32"
+			? JSON.stringify([{ ProcessId: pid, CommandLine: command }])
+			: `${pid} ${command}\n`,
+	);
+}
+
+describe("runningCodeRestartNotice()", () => {
+	describe("when Windows reports running processes", () => {
+		it("detects an npm launcher from CIM output", () => {
+			Object.defineProperty(process, "platform", { value: "win32" });
+			processes(
+				'"C:\\nodejs\\node.exe" "C:\\npm\\langwatch\\dist\\cli\\index.js" code',
+			);
+			expect(runningCodeRestartNotice()).toContain("Restart `langwatch code`");
+		});
+
+		it("ignores missing command lines and malformed records", () => {
+			Object.defineProperty(process, "platform", { value: "win32" });
+			vi.mocked(execFileSync).mockReturnValue(
+				'[null, {}, {"ProcessId": 1, "CommandLine": null}]',
+			);
+			expect(runningCodeRestartNotice()).toBeUndefined();
+		});
+	});
+	describe("when a LangWatch code launcher is running", () => {
+		it.each([
+			"langwatch code .",
+			"/usr/local/bin/langwatch code --wait .",
+			"node /usr/local/bin/langwatch code .",
+			"node /usr/lib/node_modules/langwatch/dist/cli/index.js code .",
+			"node /repo/sdks/typescript/dist/cli/index.js code .",
+			"node --enable-source-maps /usr/local/bin/langwatch code .",
+			"node --require /tmp/preload.js --trace-warnings /usr/local/bin/langwatch code .",
+			"node --max-old-space-size=4096 -- /usr/local/bin/langwatch code .",
+			"/usr/local/bin/lw code .",
+			'"C:\\Program Files\\nodejs\\node.exe" "C:\\npm\\node_modules\\langwatch\\dist\\cli\\index.js" code .',
+		])("suggests a restart for %s", (command) => {
+			processes(command);
+			expect(runningCodeRestartNotice()).toContain("Restart `langwatch code`");
+		});
+	});
+
+	describe("when no other LangWatch code launcher is running", () => {
+		it.each([
+			"claude",
+			"code .",
+			"langwatch claude",
+			"langwatch codex",
+			"langwatch instrument code --project example",
+			"langwatch code-server",
+			"node /another/cli/index.js code",
+			"sh -c 'langwatch code'",
+			"rg langwatch code",
+			"node -e 'langwatch code'",
+			"node --eval /usr/local/bin/langwatch code",
+			"node --print /usr/local/bin/langwatch code",
+			"node --require /usr/local/bin/langwatch code",
+			"node /another/script.js /usr/local/bin/langwatch code",
+			"node /another/script /usr/local/bin/langwatch code",
+		])("ignores %s", (command) => {
+			processes(command);
+			expect(runningCodeRestartNotice()).toBeUndefined();
+		});
+
+		it("excludes the current command", () => {
+			processes("langwatch code", process.pid);
+			expect(runningCodeRestartNotice()).toBeUndefined();
+		});
+	});
+
+	describe("when process inspection fails", () => {
+		it("does not fail configuration or claim a running launcher", () => {
+			vi.mocked(execFileSync).mockImplementation(() => {
+				throw new Error("process inspection timed out");
+			});
+			expect(runningCodeRestartNotice()).toBeUndefined();
+		});
+	});
+});

--- a/sdks/typescript/src/cli/utils/governance/__tests__/wrapper-mode.unit.test.ts
+++ b/sdks/typescript/src/cli/utils/governance/__tests__/wrapper-mode.unit.test.ts
@@ -14,6 +14,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as cliApi from "../cli-api";
 import * as configMod from "../config";
 import type { GovernanceConfig } from "../config";
+import { runningCodeRestartNotice } from "../running-code";
+import { buildOtelEnvBlock } from "../otel-env-block";
+import { buildScopedToolFunction, persistBlockToRc, toolMarkers } from "../shell-rc";
+
+vi.mock("../running-code", () => ({ runningCodeRestartNotice: vi.fn() }));
 
 vi.mock("../cli-api", async () => {
 	const actual = await vi.importActual<typeof cliApi>("../cli-api");
@@ -41,6 +46,7 @@ let originalUserprofile: string | undefined;
 let originalCodexHome: string | undefined;
 
 beforeEach(() => {
+	vi.mocked(runningCodeRestartNotice).mockReset();
 	tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "lw-wrapper-mode-"));
 	originalHome = process.env.HOME;
 	originalUserprofile = process.env.USERPROFILE;
@@ -91,6 +97,44 @@ function baseCfg(overrides: Partial<GovernanceConfig> = {}): GovernanceConfig {
 }
 
 describe("resolveWrapperMode", () => {
+	describe("when a project switch changes code telemetry while another launcher is running", () => {
+		const restartNotice =
+			"Restart `langwatch code` to apply the updated telemetry settings.";
+		const endpoint = "http://app.example.com/api/otel";
+		const replacementKey = "ik-lw-projectb_secret";
+		const persistCode = (token: string) =>
+			persistBlockToRc(
+				"zsh",
+				buildScopedToolFunction("code", buildOtelEnvBlock("code", endpoint, token), "zsh"),
+				toolMarkers("code"),
+			);
+		const pinnedConfig = () =>
+			baseCfg({
+				tool_project_keys: {
+					code: { secret: replacementKey, project_slug: "project-b" },
+				},
+			});
+
+		beforeEach(() => {
+			vi.mocked(runningCodeRestartNotice).mockReturnValue(restartNotice);
+		});
+
+		it("returns restart advice alongside the refreshed wiring", async () => {
+			const { resolveWrapperMode } = await import("../wrapper-mode.js");
+			persistCode("ik-lw-projecta_secret");
+			const result = await resolveWrapperMode(pinnedConfig(), "code", {});
+			expect(result.refreshedWiring).toContain("code shell function (~/.zshrc)");
+			expect(result.notice).toContain(restartNotice);
+		});
+
+		it("does not inspect processes when the wiring already matches", async () => {
+			const { resolveWrapperMode } = await import("../wrapper-mode.js");
+			persistCode(replacementKey);
+			const result = await resolveWrapperMode(pinnedConfig(), "code", {});
+			expect(result.notice ?? "").not.toContain(restartNotice);
+			expect(runningCodeRestartNotice).not.toHaveBeenCalled();
+		});
+	});
 	describe("when a personal VK is configured", () => {
 		it("returns gateway mode with the gateway env vars unchanged", async () => {
 			const { resolveWrapperMode } = await import("../wrapper-mode.js");

--- a/sdks/typescript/src/cli/utils/governance/__tests__/wrapper-mode.unit.test.ts
+++ b/sdks/typescript/src/cli/utils/governance/__tests__/wrapper-mode.unit.test.ts
@@ -119,6 +119,7 @@ describe("resolveWrapperMode", () => {
 			vi.mocked(runningCodeRestartNotice).mockReturnValue(restartNotice);
 		});
 
+		/** @scenario "Switching projects through the wrapper reports restart advice" */
 		it("returns restart advice alongside the refreshed wiring", async () => {
 			const { resolveWrapperMode } = await import("../wrapper-mode.js");
 			persistCode("ik-lw-projecta_secret");

--- a/sdks/typescript/src/cli/utils/governance/instrument-wiring.ts
+++ b/sdks/typescript/src/cli/utils/governance/instrument-wiring.ts
@@ -27,6 +27,7 @@ import { appSettingsTargetFor, installAppEnv } from "./app-settings";
 import { readClaudePluginState } from "./claude-plugin";
 import type { GovernanceConfig } from "./config";
 import { buildOtelEnvBlock } from "./otel-env-block";
+import { runningCodeRestartNotice } from "./running-code";
 import {
 	installSessionContextHooks,
 	removeSessionContextHooks,
@@ -40,6 +41,7 @@ import {
 	removeBlockFromRc,
 	tildify,
 	rcPath,
+	rcHasLangwatchBlock,
 	toolMarkers,
 } from "./shell-rc";
 
@@ -136,6 +138,13 @@ export function installTelemetryWiring({
 		);
 		return { labels, warnings, requiredFailures };
 	}
+	const codeWiringChanged =
+		tool === "code" &&
+		!rcHasLangwatchBlock({
+			shell,
+			markers: toolMarkers(tool),
+			requiredKeys: [buildScopedToolFunction(tool, vars, shell)],
+		});
 	try {
 		persistBlockToRc(
 			shell,
@@ -193,6 +202,10 @@ export function installTelemetryWiring({
 				);
 			}
 		}
+	}
+	if (codeWiringChanged && labels.length > 0 && requiredFailures.length === 0) {
+		const notice = runningCodeRestartNotice();
+		if (notice) warnings.push(notice);
 	}
 	return { labels, warnings, requiredFailures };
 }

--- a/sdks/typescript/src/cli/utils/governance/login-flow.ts
+++ b/sdks/typescript/src/cli/utils/governance/login-flow.ts
@@ -200,6 +200,9 @@ export async function runUnifiedLoginFlow(
 						console.log(chalk.gray(`  • ${label}`));
 					}
 				}
+				for (const warning of refresh.warnings ?? []) {
+					console.warn(chalk.yellow(`  ${warning}`));
+				}
 			} catch {
 				// Wiring refresh is best-effort; the session itself is already saved.
 			}

--- a/sdks/typescript/src/cli/utils/governance/running-code.ts
+++ b/sdks/typescript/src/cli/utils/governance/running-code.ts
@@ -1,0 +1,155 @@
+import { execFileSync } from "node:child_process";
+import { statSync } from "node:fs";
+
+interface RunningProcess {
+	pid: number;
+	command: string;
+}
+
+/**
+ * Inspect launchers already running, including ones started by an older CLI.
+ * Never print process arguments: they can contain credentials or user content.
+ * This cannot see a detached editor after its LangWatch launcher has exited.
+ */
+export function runningCodeRestartNotice(): string | undefined {
+	try {
+		const running = listProcesses().some(
+			({ pid, command }) => pid !== process.pid && isLangwatchCode(command),
+		);
+		if (!running) return undefined;
+		return "`langwatch code` is already running. Restart `langwatch code` to apply the updated telemetry credentials and destination; fully quit VS Code before relaunching.";
+	} catch {
+		// Missing utilities, permissions and timeouts must never break setup.
+		return undefined;
+	}
+}
+
+function listProcesses(): RunningProcess[] {
+	const options = {
+		encoding: "utf8" as const,
+		timeout: 1_000,
+		maxBuffer: 2 * 1024 * 1024,
+		stdio: ["ignore", "pipe", "ignore"] as ["ignore", "pipe", "ignore"],
+		windowsHide: true,
+	};
+	if (process.platform === "win32") {
+		const output = execFileSync(
+			"powershell.exe",
+			[
+				"-NoProfile",
+				"-NonInteractive",
+				"-Command",
+				"Get-CimInstance Win32_Process | Select-Object ProcessId,CommandLine | ConvertTo-Json -Compress",
+			],
+			options,
+		);
+		const parsed: unknown = JSON.parse(output);
+		const records: unknown[] = Array.isArray(parsed) ? parsed : [parsed];
+		return records.flatMap((record) => {
+			if (!record || typeof record !== "object") return [];
+			const entry = record as Record<string, unknown>;
+			return typeof entry.ProcessId === "number" &&
+				typeof entry.CommandLine === "string"
+				? [{ pid: entry.ProcessId, command: entry.CommandLine }]
+				: [];
+		});
+	}
+	if (!process.getuid) return [];
+	const output = execFileSync(
+		"ps",
+		["-ww", "-U", String(process.getuid()), "-o", "pid=,args="],
+		options,
+	);
+	return output.split("\n").flatMap((line) => {
+		const match = /^\s*(\d+)\s+(.+)$/.exec(line);
+		return match ? [{ pid: Number(match[1]), command: match[2]! }] : [];
+	});
+}
+
+function isLangwatchCode(command: string): boolean {
+	// Match executable + subcommand, not a substring inside a shell, grep,
+	// another LangWatch command, or a user's prompt. Quotes cover Windows paths.
+	const args = (command.match(/"[^"]*"|'[^']*'|\S+/g) ?? []).map((arg) =>
+		arg.replace(/^(?:"(.*)"|'(.*)')$/, "$1$2").replace(/\\/g, "/"),
+	);
+	const executable = readCommandPath(
+		args,
+		0,
+		(value) => isRuntime(value) || isLauncher(value),
+	);
+	if (!isRuntime(executable.value)) {
+		return isLauncher(executable.value) && args[executable.next] === "code";
+	}
+	const entryIndex = skipRuntimeOptions(args, executable.next);
+	if (entryIndex === undefined) return false;
+	const entry = readCommandPath(args, entryIndex, isEntrypoint);
+	return isEntrypoint(entry.value) && args[entry.next] === "code";
+}
+
+const basename = (value: string): string => value.split("/").pop() ?? "";
+const isRuntime = (value: string): boolean =>
+	/^(?:node|bun)(?:\.exe)?$/.test(basename(value));
+const isLauncher = (value: string): boolean =>
+	/^(?:langwatch|lw)(?:\.exe)?$/.test(basename(value));
+const isEntrypoint = (value: string): boolean =>
+	isLauncher(value) ||
+	/\/(?:langwatch|sdks\/typescript)\/dist\/cli\/index\.js$/.test(value);
+
+/**
+ * POSIX ps discards argv boundaries, including quotes around paths with spaces.
+ * Recover a split absolute path only when it names a real file. Stop at the
+ * first file so an unrelated script's arguments cannot become our entrypoint.
+ * Keep the ordinary/quoted-path case independent of filesystem permissions.
+ */
+function readCommandPath(
+	args: string[],
+	index: number,
+	recognizes: (value: string) => boolean,
+): { value: string; next: number } {
+	const first = args[index] ?? "";
+	if (recognizes(first) || !/^(?:\/|[A-Za-z]:\/)/.test(first)) {
+		return { value: first, next: index + 1 };
+	}
+	let candidate = "";
+	for (let end = index; end < Math.min(args.length, index + 16); end++) {
+		candidate += `${end === index ? "" : " "}${args[end]!}`;
+		try {
+			if (statSync(candidate).isFile())
+				return { value: candidate, next: end + 1 };
+		} catch {
+			// A prefix of a space-containing path normally does not exist.
+		}
+	}
+	return { value: first, next: index + 1 };
+}
+
+// Consume option arguments before looking for the script: a preload module is
+// not the entrypoint. Unknown options fail closed rather than matching a prompt.
+const RUNTIME_VALUE_OPTIONS = new Set([
+	"--require",
+	"-r",
+	"--import",
+	"--loader",
+	"--experimental-loader",
+	"--conditions",
+	"-C",
+	"--icu-data-dir",
+	"--openssl-config",
+	"--redirect-warnings",
+	"--diagnostic-dir",
+	"--max-old-space-size",
+	"--stack-trace-limit",
+	"--unhandled-rejections",
+]);
+
+function skipRuntimeOptions(args: string[], start: number): number | undefined {
+	let index = start;
+	while (args[index]?.startsWith("-")) {
+		const option = args[index]!;
+		if (option === "--") return index + 1;
+		const name = option.split("=")[0]!;
+		if (!process.allowedNodeEnvironmentFlags.has(name)) return undefined;
+		index += RUNTIME_VALUE_OPTIONS.has(name) && !option.includes("=") ? 2 : 1;
+	}
+	return index;
+}

--- a/sdks/typescript/src/cli/utils/governance/running-code.ts
+++ b/sdks/typescript/src/cli/utils/governance/running-code.ts
@@ -72,17 +72,21 @@ function isLangwatchCode(command: string): boolean {
 	const args = (command.match(/"[^"]*"|'[^']*'|\S+/g) ?? []).map((arg) =>
 		arg.replace(/^(?:"(.*)"|'(.*)')$/, "$1$2").replace(/\\/g, "/"),
 	);
-	const executable = readCommandPath(
+	const executable = readCommandPath({
 		args,
-		0,
-		(value) => isRuntime(value) || isLauncher(value),
-	);
+		index: 0,
+		recognizes: (value) => isRuntime(value) || isLauncher(value),
+	});
 	if (!isRuntime(executable.value)) {
 		return isLauncher(executable.value) && args[executable.next] === "code";
 	}
-	const entryIndex = skipRuntimeOptions(args, executable.next);
+	const entryIndex = skipRuntimeOptions({ args, start: executable.next });
 	if (entryIndex === undefined) return false;
-	const entry = readCommandPath(args, entryIndex, isEntrypoint);
+	const entry = readCommandPath({
+		args,
+		index: entryIndex,
+		recognizes: isEntrypoint,
+	});
 	return isEntrypoint(entry.value) && args[entry.next] === "code";
 }
 
@@ -101,11 +105,15 @@ const isEntrypoint = (value: string): boolean =>
  * first file so an unrelated script's arguments cannot become our entrypoint.
  * Keep the ordinary/quoted-path case independent of filesystem permissions.
  */
-function readCommandPath(
-	args: string[],
-	index: number,
-	recognizes: (value: string) => boolean,
-): { value: string; next: number } {
+function readCommandPath({
+	args,
+	index,
+	recognizes,
+}: {
+	args: string[];
+	index: number;
+	recognizes: (value: string) => boolean;
+}): { value: string; next: number } {
 	const first = args[index] ?? "";
 	if (recognizes(first) || !/^(?:\/|[A-Za-z]:\/)/.test(first)) {
 		return { value: first, next: index + 1 };
@@ -142,14 +150,31 @@ const RUNTIME_VALUE_OPTIONS = new Set([
 	"--unhandled-rejections",
 ]);
 
-function skipRuntimeOptions(args: string[], start: number): number | undefined {
+function skipRuntimeOptions({
+	args,
+	start,
+}: {
+	args: string[];
+	start: number;
+}): number | undefined {
 	let index = start;
 	while (args[index]?.startsWith("-")) {
 		const option = args[index]!;
 		if (option === "--") return index + 1;
 		const name = option.split("=")[0]!;
 		if (!process.allowedNodeEnvironmentFlags.has(name)) return undefined;
-		index += RUNTIME_VALUE_OPTIONS.has(name) && !option.includes("=") ? 2 : 1;
+		if (!RUNTIME_VALUE_OPTIONS.has(name) || option.includes("=")) {
+			index += 1;
+			continue;
+		}
+		// The value is a path in its own right, so ps may have split it across
+		// tokens too. Recognizing nothing keeps this to the join-until-a-real-file
+		// recovery, which falls back to a single token exactly as before.
+		index = readCommandPath({
+			args,
+			index: index + 1,
+			recognizes: () => false,
+		}).next;
 	}
 	return index;
 }

--- a/sdks/typescript/src/cli/utils/governance/telemetry-refresh.ts
+++ b/sdks/typescript/src/cli/utils/governance/telemetry-refresh.ts
@@ -80,6 +80,7 @@ import {
 	telemetryEnvVarNames,
 } from "./otel-env-block";
 import { resolvePlatformToolPolicy } from "./platform-tool-policy";
+import { runningCodeRestartNotice } from "./running-code";
 import { assertCodexAgentGuidance } from "./codex-agents-md";
 import {
 	buildScopedToolFunction,
@@ -547,6 +548,8 @@ export interface LoginTelemetryRefreshResult {
 	 * cfg.default_personal_ingest_keys) - the caller should saveConfig.
 	 */
 	mintedAny: boolean;
+	/** Restart advice when a live launcher predates successfully changed wiring. */
+	warnings?: string[];
 }
 
 /**
@@ -567,6 +570,7 @@ export async function refreshTelemetryWiringForLogin(
 ): Promise<LoginTelemetryRefreshResult> {
 	const labels: string[] = [];
 	let mintedAny = false;
+	const warnings: string[] = [];
 	const expectedEndpoint = otlpEndpointFor(cfg.control_plane_url);
 
 	for (const [tool, sourceType] of Object.entries(SOURCE_TYPE_BY_TOOL)) {
@@ -619,7 +623,12 @@ export async function refreshTelemetryWiringForLogin(
 				});
 				if (label) labels.push(label);
 			} else {
-				labels.push(...refreshScopedShellFunctions({ tool, vars }));
+				const refreshed = refreshScopedShellFunctions({ tool, vars });
+				labels.push(...refreshed);
+				if (tool === "code" && refreshed.length > 0) {
+					const notice = runningCodeRestartNotice();
+					if (notice) warnings.push(notice);
+				}
 			}
 		} catch {
 			// Best-effort per tool: one failed mint must not block the login
@@ -641,5 +650,5 @@ export async function refreshTelemetryWiringForLogin(
 		// Best-effort, same as above.
 	}
 
-	return { labels, mintedAny };
+	return { labels, mintedAny, ...(warnings.length > 0 ? { warnings } : {}) };
 }

--- a/sdks/typescript/src/cli/utils/governance/wrapper-mode.ts
+++ b/sdks/typescript/src/cli/utils/governance/wrapper-mode.ts
@@ -42,6 +42,7 @@ import { deviceLabelForThisMachine } from "./device-label";
 import { warnIfGeminiOAuthSelected } from "./gemini-settings-preflight";
 import { buildOtelEnvBlock, SOURCE_TYPE_BY_TOOL } from "./otel-env-block";
 import { resolvePlatformToolPolicy } from "./platform-tool-policy";
+import { runningCodeRestartNotice } from "./running-code";
 import { SHELL_FUNCTION_TOOLS, assertCodexTurnHarvest } from "./shell-rc";
 import { assertCodexAgentGuidance } from "./codex-agents-md";
 import {
@@ -483,6 +484,12 @@ export async function resolveWrapperMode(
 				[] as string[],
 			),
 		);
+	}
+	if (tool === "code" && refreshedWiring.length > 0) {
+		const restartNotice = runningCodeRestartNotice();
+		if (restartNotice) {
+			notice = notice ? `${notice}\n${restartNotice}` : restartNotice;
+		}
 	}
 
 	// VS Code hardening, coupled to the env INJECTION (not to the shell-rc

--- a/specs/ai-governance/cli-wrappers/instrument-command.feature
+++ b/specs/ai-governance/cli-wrappers/instrument-command.feature
@@ -31,6 +31,55 @@ Feature: `langwatch instrument <tool>` writes telemetry wiring without launching
   Background:
     Given the langwatch CLI is installed
 
+  Rule: changed code telemetry warns about an active LangWatch launcher
+
+    Detection targets the `langwatch code` command, including npm and native
+    binary launches. A detached VS Code editor whose launcher has exited is
+    outside this detection. Process inspection is bounded and best-effort.
+
+    @unit @cli-wrappers @instrument
+    Scenario: A running langwatch code command needs a restart after reconfiguration
+      Given code telemetry is configured and another `langwatch code` command is running
+      When instrumentation successfully changes code's ingest key or endpoint
+      Then the CLI suggests restarting `langwatch code` to apply the change
+
+    @unit @cli-wrappers @instrument
+    Scenario: Login refresh reports the same restart advice
+      Given code telemetry points at an earlier instance and `langwatch code` is running
+      When login successfully refreshes code's telemetry wiring
+      Then the CLI suggests restarting `langwatch code` to apply the change
+
+    @unit @cli-wrappers @instrument
+    Scenario: Switching projects through the wrapper reports restart advice
+      Given code telemetry points at project A and another `langwatch code` command is running
+      When `langwatch code --project B` successfully refreshes the persisted wiring
+      Then the CLI suggests restarting the existing launcher to apply the change
+
+    @integration @cli-wrappers @instrument
+    Scenario: Launch detection handles install paths with spaces and Node runtime flags
+      Given a running npm-style `langwatch code` launcher
+      And its install path contains spaces or Node was started with runtime flags
+      When the CLI checks for running launchers
+      Then it detects that launcher
+
+    @unit @cli-wrappers @instrument
+    Scenario: Unchanged wiring needs no restart notice
+      Given code telemetry already matches the requested settings
+      When instrumentation runs again
+      Then there is no restart notice
+
+    @unit @cli-wrappers @instrument
+    Scenario: Other applications do not trigger the notice
+      Given only plain Claude, plain VS Code, or other LangWatch commands are running
+      When code telemetry changes
+      Then there is no restart notice
+
+    @unit @cli-wrappers @instrument
+    Scenario: Process inspection failure does not fail configuration
+      Given running processes cannot be inspected
+      When code telemetry changes
+      Then configuration succeeds without claiming a running session was detected
+
   Rule: scope flags pick where the telemetry goes
 
     @unit @cli-wrappers @instrument


### PR DESCRIPTION
## Why

Changing code telemetry credentials or its destination project can leave an existing `langwatch code` launcher using its previously loaded environment. Setup reported success without telling the user to restart that launcher.

Closes #7945

## What changed

- Suggest restarting a detected `langwatch code` launcher after successful telemetry wiring changes during instrumentation, login refresh, or a wrapper project switch.
- Keep unchanged settings quiet and ignore unrelated commands, including plain Claude and VS Code launches.
- Handle npm installation paths containing spaces and Node runtime options such as `--enable-source-maps`, including a runtime option whose own value is a path containing spaces (`--require "/opt/pre load.js"`).

## How it works

Process inspection uses `ps` on Unix and PowerShell/CIM on Windows, with bounded output and a timeout. Matching checks the launcher and its subcommand; process arguments and credentials are never printed. On Unix, a split absolute path is reconstructed only when it names a real file - for the entrypoint and for the value of a runtime option such as `--require`, since `ps` discards argv boundaries in both. Inspection failures do not fail configuration.

## Test plan

- Added regression tests first and observed the missing restart advice, space-containing paths, and runtime-flag cases fail before the fixes.
- Passed 864 tests across the CLI governance suite and the instrument/login command tests.
- Passed five real-process tests on macOS: ordinary launch, a path containing spaces, a Node runtime flag, both together, and a `--require` preload path containing spaces. These use temporary fixture processes without launching an editor. The last case was observed failing against the previous two-token option skip before the fix landed.
- Passed `pnpm typecheck` and targeted ESLint checks for the final changes. The full SDK lint run reported zero errors and existing warnings.
- Covered failed writes, unavailable process inspection, unrelated commands, current-process exclusion, unchanged settings, and login/wrapper notice output. Windows process-list parsing has mocked coverage.

## Anything surprising?

- Detection covers a live `langwatch code` launcher. It cannot detect a detached VS Code editor after its launcher exits. The notice tells users to fully quit VS Code before relaunching.
- Login advice appears only when login actually refreshes persisted wiring; this does not change project-pin or same-endpoint login refresh behavior.
- Windows detection has not been exercised on a live Windows host.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added detection of running `langwatch code` processes across supported launch methods and platforms.
  - Added restart guidance when telemetry settings change while `langwatch code` is running.
  - Restart warnings are now surfaced during instrumentation, login, and project-switch flows.

- **Tests**
  - Added unit, integration, and behavior coverage for launcher detection, telemetry updates, unchanged wiring, and process-inspection failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->