### PR TITLE
fix(automations): find a trigger's latest firing through an index, not a scan

### DIFF
--- a/platform/app/prisma/migrations/20260907120000_trigger_sent_latest_fire_index/migration.sql
+++ b/platform/app/prisma/migrations/20260907120000_trigger_sent_latest_fire_index/migration.sql
@@ -48,5 +48,5 @@
 --   prisma migrate deploy
 CREATE INDEX CONCURRENTLY "TriggerSent_projectId_triggerId_createdAt_idx" ON "TriggerSent"("projectId", "triggerId", "createdAt");
 
--- Down (manual rollback; uncomment and run):
+-- To roll back, uncomment and run manually.
 -- DROP INDEX CONCURRENTLY "TriggerSent_projectId_triggerId_createdAt_idx";

--- a/platform/app/prisma/migrations/20260907120000_trigger_sent_latest_fire_index/migration.sql
+++ b/platform/app/prisma/migrations/20260907120000_trigger_sent_latest_fire_index/migration.sql
@@ -48,5 +48,5 @@
 --   prisma migrate deploy
 CREATE INDEX CONCURRENTLY "TriggerSent_projectId_triggerId_createdAt_idx" ON "TriggerSent"("projectId", "triggerId", "createdAt");
 
--- To roll back, uncomment and run manually.
+-- Down step. To roll back, uncomment and run manually.
 -- DROP INDEX CONCURRENTLY "TriggerSent_projectId_triggerId_createdAt_idx";

--- a/platform/app/prisma/migrations/20260907120000_trigger_sent_latest_fire_index/migration.sql
+++ b/platform/app/prisma/migrations/20260907120000_trigger_sent_latest_fire_index/migration.sql
@@ -41,6 +41,12 @@
 -- went from a 68 ms parallel sequential scan to a 0.013 ms index scan on
 -- the same data. Read the build times as an order of magnitude: expect
 -- roughly ten seconds against production, not five.
+--
+-- ORDERING NOTE: the creates come before the drops on purpose. `prisma
+-- migrate diff` emits the drops first; in that order the ACCESS EXCLUSIVE
+-- lock the drops take is held through the whole build above, and reads
+-- block for those ten seconds too, not just writes. Keep this order if the
+-- file is ever regenerated.
 CREATE INDEX "TriggerSent_projectId_triggerId_createdAt_idx" ON "TriggerSent"("projectId", "triggerId", "createdAt");
 CREATE INDEX "TriggerSent_projectId_createdAt_idx" ON "TriggerSent"("projectId", "createdAt");
 

--- a/platform/app/prisma/migrations/20260907120000_trigger_sent_latest_fire_index/migration.sql
+++ b/platform/app/prisma/migrations/20260907120000_trigger_sent_latest_fire_index/migration.sql
@@ -15,52 +15,38 @@
 --
 -- A composite ending in createdAt lets the planner walk to the newest
 -- entry directly: an Index Scan Backward that reads a handful of pages no
--- matter how many rows the trigger has. The project-scoped twin serves the
--- automations activity feed (`findAllRecentForProject`), which has the same
--- shape without the triggerId.
+-- matter how many rows the trigger has. Measured on a local Postgres 16
+-- over a 2.1M-row reproduction of the production distribution (one
+-- project/trigger pair holding 1.385M rows, the rest spread over 229
+-- pairs): the probe went from a 68 ms parallel sequential scan to a
+-- 0.013 ms index scan. The build took 3.0 s and 97 MB there; expect
+-- roughly ten seconds against production.
 --
--- The single-column triggerId and projectId indexes are prefixes of the new
--- composites and go. So does the index on resolvedAt: every read that
--- filters on it also filters on customGraphId, which keeps its own index,
--- and production shows the resolvedAt index has never been scanned once.
--- Any lookup by triggerId alone is still served by the
--- "TriggerSent_triggerId_traceId_key" unique.
+-- This is the first of five one-statement migrations
+-- (20260907120000-20260907120004): two builds, then three drops of the
+-- indexes they replace. They are split because `CONCURRENTLY` needs a
+-- statement that is the only one in its file, and they run in this order
+-- so a replacement exists before the index it replaces goes.
 --
--- LOCKING NOTE: plain `CREATE INDEX` takes a SHARE lock on "TriggerSent" -
--- reads keep working, writes wait until the build finishes. Writes to this
--- table are the automations firing: each one queues behind the build and
--- lands when it lifts, none is lost. The two builds run back to back, so
--- plan for the sum. `CREATE INDEX CONCURRENTLY` would avoid the wait but
--- cannot run inside the transaction Prisma wraps a migration in - the same
--- trade 20260804120000_dataset_record_project_dataset_index made.
+-- LOCKING NOTE: `CONCURRENTLY` builds in the background - reads and writes
+-- (the automations firing) keep going the whole time. A plain `CREATE
+-- INDEX` would block writes for the build, and a plain `DROP INDEX` later
+-- would wait for every in-flight read on the table while queueing every
+-- new read and write behind it: with probe queries that have run for 171 s
+-- on this table, that is an unbounded stall. Verified against this
+-- repository's Prisma 7.9.1 that `migrate deploy` applies one-statement
+-- `CONCURRENTLY` migrations; the older note in
+-- 20260831120000_grant_role_key_live_index predates that.
 --
--- Measured on a local Postgres 16 on developer hardware, over a 2.1M-row
--- reproduction of the production distribution (one project/trigger pair
--- holding 1.385M rows, the rest spread over 229 pairs): 3.0 s and 97 MB for
--- the three-column index, 1.8 s and 76 MB for the two-column one. The probe
--- went from a 68 ms parallel sequential scan to a 0.013 ms index scan on
--- the same data. Read the build times as an order of magnitude: expect
--- roughly ten seconds against production, not five.
---
--- ORDERING NOTE: the creates come before the drops on purpose. `prisma
--- migrate diff` emits the drops first; in that order the ACCESS EXCLUSIVE
--- lock the drops take is held through the whole build above, and reads
--- block for those ten seconds too, not just writes. Keep this order if the
--- file is ever regenerated.
-CREATE INDEX "TriggerSent_projectId_triggerId_createdAt_idx" ON "TriggerSent"("projectId", "triggerId", "createdAt");
-CREATE INDEX "TriggerSent_projectId_createdAt_idx" ON "TriggerSent"("projectId", "createdAt");
+-- IF THE BUILD FAILS (timeout, connection drop, cancelled deploy): Postgres
+-- leaves an INVALID index of this name behind, and Prisma records the
+-- migration as failed. Deliberately no `IF NOT EXISTS`: it would skip over
+-- the invalid index and report success while the probe keeps scanning.
+-- Recover with, in order:
+--   DROP INDEX CONCURRENTLY "TriggerSent_projectId_triggerId_createdAt_idx";
+--   prisma migrate resolve --rolled-back 20260907120000_trigger_sent_latest_fire_index
+--   prisma migrate deploy
+CREATE INDEX CONCURRENTLY "TriggerSent_projectId_triggerId_createdAt_idx" ON "TriggerSent"("projectId", "triggerId", "createdAt");
 
--- Dropping takes an ACCESS EXCLUSIVE lock for the time it takes to unlink a
--- catalog entry: 1-21 ms each on the reproduction above.
-DROP INDEX "TriggerSent_triggerId_idx";
-DROP INDEX "TriggerSent_projectId_idx";
-DROP INDEX "TriggerSent_resolvedAt_idx";
-
--- Down (manual rollback; uncomment and run). Indexes carry no row data, so
--- nothing is lost either way - the probe just goes back to scanning every
--- row the trigger ever wrote.
--- CREATE INDEX "TriggerSent_triggerId_idx" ON "TriggerSent"("triggerId");
--- CREATE INDEX "TriggerSent_projectId_idx" ON "TriggerSent"("projectId");
--- CREATE INDEX "TriggerSent_resolvedAt_idx" ON "TriggerSent"("resolvedAt");
--- DROP INDEX "TriggerSent_projectId_triggerId_createdAt_idx";
--- DROP INDEX "TriggerSent_projectId_createdAt_idx";
+-- Down (manual rollback; uncomment and run):
+-- DROP INDEX CONCURRENTLY "TriggerSent_projectId_triggerId_createdAt_idx";

--- a/platform/app/prisma/migrations/20260907120000_trigger_sent_latest_fire_index/migration.sql
+++ b/platform/app/prisma/migrations/20260907120000_trigger_sent_latest_fire_index/migration.sql
@@ -1,0 +1,60 @@
+-- Fire history is read one way: the newest rows for one trigger, or the
+-- newest rows for one project. The health probe (`/api/health/triggers`)
+-- asks "when did this trigger last fire" with
+-- `WHERE "triggerId" = $1 AND "projectId" = $2 ORDER BY "createdAt" DESC LIMIT 1`.
+--
+-- Every index on "TriggerSent" led with a column that could find the rows
+-- but not order them: single-column triggerId, single-column projectId. One
+-- trigger holds 65% of the table in production, so for it "find the rows"
+-- is "find the table", and the planner correctly gave up on both indexes
+-- and sequentially scanned every row to sort out the newest one. Measured
+-- on production: 710 ms per probe on a warm cache, a mean of 1.1 s and a
+-- worst case of 171 s across six months of calls, eighth most expensive
+-- query in the database by total time - for an endpoint that returns one
+-- row and is polled by an external monitor.
+--
+-- A composite ending in createdAt lets the planner walk to the newest
+-- entry directly: an Index Scan Backward that reads a handful of pages no
+-- matter how many rows the trigger has. The project-scoped twin serves the
+-- automations activity feed (`findAllRecentForProject`), which has the same
+-- shape without the triggerId.
+--
+-- The single-column triggerId and projectId indexes are prefixes of the new
+-- composites and go. So does the index on resolvedAt: every read that
+-- filters on it also filters on customGraphId, which keeps its own index,
+-- and production shows the resolvedAt index has never been scanned once.
+-- Any lookup by triggerId alone is still served by the
+-- "TriggerSent_triggerId_traceId_key" unique.
+--
+-- LOCKING NOTE: plain `CREATE INDEX` takes a SHARE lock on "TriggerSent" -
+-- reads keep working, writes wait until the build finishes. Writes to this
+-- table are the automations firing: each one queues behind the build and
+-- lands when it lifts, none is lost. The two builds run back to back, so
+-- plan for the sum. `CREATE INDEX CONCURRENTLY` would avoid the wait but
+-- cannot run inside the transaction Prisma wraps a migration in - the same
+-- trade 20260804120000_dataset_record_project_dataset_index made.
+--
+-- Measured on a local Postgres 16 on developer hardware, over a 2.1M-row
+-- reproduction of the production distribution (one project/trigger pair
+-- holding 1.385M rows, the rest spread over 229 pairs): 3.0 s and 97 MB for
+-- the three-column index, 1.8 s and 76 MB for the two-column one. The probe
+-- went from a 68 ms parallel sequential scan to a 0.013 ms index scan on
+-- the same data. Read the build times as an order of magnitude: expect
+-- roughly ten seconds against production, not five.
+CREATE INDEX "TriggerSent_projectId_triggerId_createdAt_idx" ON "TriggerSent"("projectId", "triggerId", "createdAt");
+CREATE INDEX "TriggerSent_projectId_createdAt_idx" ON "TriggerSent"("projectId", "createdAt");
+
+-- Dropping takes an ACCESS EXCLUSIVE lock for the time it takes to unlink a
+-- catalog entry: 1-21 ms each on the reproduction above.
+DROP INDEX "TriggerSent_triggerId_idx";
+DROP INDEX "TriggerSent_projectId_idx";
+DROP INDEX "TriggerSent_resolvedAt_idx";
+
+-- Down (manual rollback; uncomment and run). Indexes carry no row data, so
+-- nothing is lost either way - the probe just goes back to scanning every
+-- row the trigger ever wrote.
+-- CREATE INDEX "TriggerSent_triggerId_idx" ON "TriggerSent"("triggerId");
+-- CREATE INDEX "TriggerSent_projectId_idx" ON "TriggerSent"("projectId");
+-- CREATE INDEX "TriggerSent_resolvedAt_idx" ON "TriggerSent"("resolvedAt");
+-- DROP INDEX "TriggerSent_projectId_triggerId_createdAt_idx";
+-- DROP INDEX "TriggerSent_projectId_createdAt_idx";

--- a/platform/app/prisma/migrations/20260907120001_trigger_sent_project_feed_index/migration.sql
+++ b/platform/app/prisma/migrations/20260907120001_trigger_sent_project_feed_index/migration.sql
@@ -1,0 +1,13 @@
+-- Second of five (see 20260907120000_trigger_sent_latest_fire_index).
+-- The project-scoped twin of the latest-fire index: the automations
+-- activity feed (`findAllRecentForProject`) reads the newest rows for one
+-- project, `WHERE "projectId" = $1 ORDER BY "createdAt" DESC LIMIT n`, and
+-- had the same sequential-scan-and-sort plan (582 ms in production).
+-- 1.8 s and 76 MB on the local reproduction.
+--
+-- Same failure recovery as the first file, with this index's name and
+-- migration name.
+CREATE INDEX CONCURRENTLY "TriggerSent_projectId_createdAt_idx" ON "TriggerSent"("projectId", "createdAt");
+
+-- Down (manual rollback; uncomment and run):
+-- DROP INDEX CONCURRENTLY "TriggerSent_projectId_createdAt_idx";

--- a/platform/app/prisma/migrations/20260907120001_trigger_sent_project_feed_index/migration.sql
+++ b/platform/app/prisma/migrations/20260907120001_trigger_sent_project_feed_index/migration.sql
@@ -9,5 +9,5 @@
 -- migration name.
 CREATE INDEX CONCURRENTLY "TriggerSent_projectId_createdAt_idx" ON "TriggerSent"("projectId", "createdAt");
 
--- Down (manual rollback; uncomment and run):
+-- To roll back, uncomment and run manually.
 -- DROP INDEX CONCURRENTLY "TriggerSent_projectId_createdAt_idx";

--- a/platform/app/prisma/migrations/20260907120001_trigger_sent_project_feed_index/migration.sql
+++ b/platform/app/prisma/migrations/20260907120001_trigger_sent_project_feed_index/migration.sql
@@ -9,5 +9,5 @@
 -- migration name.
 CREATE INDEX CONCURRENTLY "TriggerSent_projectId_createdAt_idx" ON "TriggerSent"("projectId", "createdAt");
 
--- To roll back, uncomment and run manually.
+-- Down step. To roll back, uncomment and run manually.
 -- DROP INDEX CONCURRENTLY "TriggerSent_projectId_createdAt_idx";

--- a/platform/app/prisma/migrations/20260907120002_trigger_sent_drop_trigger_id_index/migration.sql
+++ b/platform/app/prisma/migrations/20260907120002_trigger_sent_drop_trigger_id_index/migration.sql
@@ -9,5 +9,5 @@
 -- `IF EXISTS` so a re-run after a partial deploy is a no-op.
 DROP INDEX CONCURRENTLY IF EXISTS "TriggerSent_triggerId_idx";
 
--- To roll back, uncomment and run manually.
+-- Down step. To roll back, uncomment and run manually.
 -- CREATE INDEX CONCURRENTLY "TriggerSent_triggerId_idx" ON "TriggerSent"("triggerId");

--- a/platform/app/prisma/migrations/20260907120002_trigger_sent_drop_trigger_id_index/migration.sql
+++ b/platform/app/prisma/migrations/20260907120002_trigger_sent_drop_trigger_id_index/migration.sql
@@ -9,5 +9,5 @@
 -- `IF EXISTS` so a re-run after a partial deploy is a no-op.
 DROP INDEX CONCURRENTLY IF EXISTS "TriggerSent_triggerId_idx";
 
--- Down (manual rollback; uncomment and run):
+-- To roll back, uncomment and run manually.
 -- CREATE INDEX CONCURRENTLY "TriggerSent_triggerId_idx" ON "TriggerSent"("triggerId");

--- a/platform/app/prisma/migrations/20260907120002_trigger_sent_drop_trigger_id_index/migration.sql
+++ b/platform/app/prisma/migrations/20260907120002_trigger_sent_drop_trigger_id_index/migration.sql
@@ -1,0 +1,13 @@
+-- Third of five (see 20260907120000_trigger_sent_latest_fire_index).
+-- Every read that looks rows up by triggerId also has the projectId
+-- (served by the new "TriggerSent_projectId_triggerId_createdAt_idx") or
+-- the traceId (served by the "TriggerSent_triggerId_traceId_key" unique,
+-- which stays). Nothing is left for a single-column triggerId index to do.
+--
+-- `CONCURRENTLY` so the drop never queues reads and writes behind it; the
+-- index is gone once every transaction that could see it has finished.
+-- `IF EXISTS` so a re-run after a partial deploy is a no-op.
+DROP INDEX CONCURRENTLY IF EXISTS "TriggerSent_triggerId_idx";
+
+-- Down (manual rollback; uncomment and run):
+-- CREATE INDEX CONCURRENTLY "TriggerSent_triggerId_idx" ON "TriggerSent"("triggerId");

--- a/platform/app/prisma/migrations/20260907120003_trigger_sent_drop_project_id_index/migration.sql
+++ b/platform/app/prisma/migrations/20260907120003_trigger_sent_drop_project_id_index/migration.sql
@@ -1,0 +1,7 @@
+-- Fourth of five (see 20260907120000_trigger_sent_latest_fire_index).
+-- projectId leads both new composites, so any lookup by project alone
+-- (the stats rollup, the open-claims read) walks one of those instead.
+DROP INDEX CONCURRENTLY IF EXISTS "TriggerSent_projectId_idx";
+
+-- Down (manual rollback; uncomment and run):
+-- CREATE INDEX CONCURRENTLY "TriggerSent_projectId_idx" ON "TriggerSent"("projectId");

--- a/platform/app/prisma/migrations/20260907120003_trigger_sent_drop_project_id_index/migration.sql
+++ b/platform/app/prisma/migrations/20260907120003_trigger_sent_drop_project_id_index/migration.sql
@@ -3,5 +3,5 @@
 -- (the stats rollup, the open-claims read) walks one of those instead.
 DROP INDEX CONCURRENTLY IF EXISTS "TriggerSent_projectId_idx";
 
--- Down (manual rollback; uncomment and run):
+-- To roll back, uncomment and run manually.
 -- CREATE INDEX CONCURRENTLY "TriggerSent_projectId_idx" ON "TriggerSent"("projectId");

--- a/platform/app/prisma/migrations/20260907120003_trigger_sent_drop_project_id_index/migration.sql
+++ b/platform/app/prisma/migrations/20260907120003_trigger_sent_drop_project_id_index/migration.sql
@@ -3,5 +3,5 @@
 -- (the stats rollup, the open-claims read) walks one of those instead.
 DROP INDEX CONCURRENTLY IF EXISTS "TriggerSent_projectId_idx";
 
--- To roll back, uncomment and run manually.
+-- Down step. To roll back, uncomment and run manually.
 -- CREATE INDEX CONCURRENTLY "TriggerSent_projectId_idx" ON "TriggerSent"("projectId");

--- a/platform/app/prisma/migrations/20260907120004_trigger_sent_drop_resolved_at_index/migration.sql
+++ b/platform/app/prisma/migrations/20260907120004_trigger_sent_drop_resolved_at_index/migration.sql
@@ -1,0 +1,7 @@
+-- Fifth of five (see 20260907120000_trigger_sent_latest_fire_index).
+-- Every read that filters on resolvedAt also filters on customGraphId,
+-- which keeps its own index; production shows this one was never scanned.
+DROP INDEX CONCURRENTLY IF EXISTS "TriggerSent_resolvedAt_idx";
+
+-- Down (manual rollback; uncomment and run):
+-- CREATE INDEX CONCURRENTLY "TriggerSent_resolvedAt_idx" ON "TriggerSent"("resolvedAt");

--- a/platform/app/prisma/migrations/20260907120004_trigger_sent_drop_resolved_at_index/migration.sql
+++ b/platform/app/prisma/migrations/20260907120004_trigger_sent_drop_resolved_at_index/migration.sql
@@ -3,5 +3,5 @@
 -- which keeps its own index; production shows this one was never scanned.
 DROP INDEX CONCURRENTLY IF EXISTS "TriggerSent_resolvedAt_idx";
 
--- Down (manual rollback; uncomment and run):
+-- To roll back, uncomment and run manually.
 -- CREATE INDEX CONCURRENTLY "TriggerSent_resolvedAt_idx" ON "TriggerSent"("resolvedAt");

--- a/platform/app/prisma/migrations/20260907120004_trigger_sent_drop_resolved_at_index/migration.sql
+++ b/platform/app/prisma/migrations/20260907120004_trigger_sent_drop_resolved_at_index/migration.sql
@@ -3,5 +3,5 @@
 -- which keeps its own index; production shows this one was never scanned.
 DROP INDEX CONCURRENTLY IF EXISTS "TriggerSent_resolvedAt_idx";
 
--- To roll back, uncomment and run manually.
+-- Down step. To roll back, uncomment and run manually.
 -- CREATE INDEX CONCURRENTLY "TriggerSent_resolvedAt_idx" ON "TriggerSent"("resolvedAt");

--- a/platform/app/prisma/schema.prisma
+++ b/platform/app/prisma/schema.prisma
@@ -2224,10 +2224,15 @@ model TriggerSent {
   updatedAt       DateTime     @default(now()) @updatedAt
 
   @@unique([triggerId, traceId])
-  @@index([triggerId])
-  @@index([projectId])
+  // Every read of fire history asks for the newest rows of one trigger or of
+  // one project. Both composites end in createdAt so the planner walks
+  // straight to the newest entry instead of sorting the whole key range —
+  // one trigger holds 65% of the table in production, so an index that
+  // cannot order within the trigger is a sequential scan. Single-column
+  // triggerId and projectId indexes are prefixes of these and were dropped.
+  @@index([projectId, triggerId, createdAt])
+  @@index([projectId, createdAt])
   @@index([customGraphId])
-  @@index([resolvedAt])
 }
 
 // ADR-031: recipient unsubscribe / suppression list for trigger emails. A row

--- a/platform/app/src/server/app-layer/automations/__tests__/trigger-fire-history.prisma.repository.unit.test.ts
+++ b/platform/app/src/server/app-layer/automations/__tests__/trigger-fire-history.prisma.repository.unit.test.ts
@@ -16,7 +16,7 @@ function makeRepo() {
 }
 
 describe("PrismaTriggerFireHistoryRepository", () => {
-  describe("findAllRecentByTriggerId", () => {
+  describe("given a trigger with fire history", () => {
     describe("when reading a trigger's recent fires", () => {
       it("scopes the query to the project, trigger, and requested limit", async () => {
         const { repo, findMany } = makeRepo();
@@ -61,7 +61,7 @@ describe("PrismaTriggerFireHistoryRepository", () => {
     });
   });
 
-  describe("findLatestByTriggerId", () => {
+  describe("given a trigger that has fired more than once", () => {
     describe("when reading a trigger's newest fire", () => {
       /** @scenario "The newest fire is asked for by project and trigger, newest first, one row" */
       it("asks for exactly one row, newest first, scoped to project and trigger", async () => {

--- a/platform/app/src/server/app-layer/automations/__tests__/trigger-fire-history.prisma.repository.unit.test.ts
+++ b/platform/app/src/server/app-layer/automations/__tests__/trigger-fire-history.prisma.repository.unit.test.ts
@@ -63,6 +63,7 @@ describe("PrismaTriggerFireHistoryRepository", () => {
 
   describe("findLatestByTriggerId", () => {
     describe("when reading a trigger's newest fire", () => {
+      /** @scenario "The newest fire is asked for by project and trigger, newest first, one row" */
       it("asks for exactly one row, newest first, scoped to project and trigger", async () => {
         const { repo, findFirst } = makeRepo();
 
@@ -83,6 +84,7 @@ describe("PrismaTriggerFireHistoryRepository", () => {
         );
       });
 
+      /** @scenario "The newest fire carries metadata only" */
       it("selects fire metadata only, never traceId or captured trace content", async () => {
         const { repo, findFirst } = makeRepo();
 

--- a/platform/app/src/server/app-layer/automations/__tests__/trigger-fire-history.prisma.repository.unit.test.ts
+++ b/platform/app/src/server/app-layer/automations/__tests__/trigger-fire-history.prisma.repository.unit.test.ts
@@ -4,12 +4,14 @@ import { PrismaTriggerFireHistoryRepository } from "../repositories/trigger-fire
 
 function makeRepo() {
   const findMany = vi.fn().mockResolvedValue([]);
+  const findFirst = vi.fn().mockResolvedValue(null);
   const prisma = {
-    triggerSent: { findMany },
+    triggerSent: { findMany, findFirst },
   } as unknown as PrismaClient;
   return {
     repo: new PrismaTriggerFireHistoryRepository(prisma),
     findMany,
+    findFirst,
   };
 }
 
@@ -47,6 +49,49 @@ describe("PrismaTriggerFireHistoryRepository", () => {
         // must never widen into a side door around the trace protections
         // surface, so the projected columns are pinned exactly here.
         const selectArg = findMany.mock.calls[0]![0].select;
+        expect(Object.keys(selectArg).sort()).toEqual([
+          "createdAt",
+          "customGraphId",
+          "id",
+          "resolvedAt",
+          "triggerId",
+        ]);
+        expect(selectArg).not.toHaveProperty("traceId");
+      });
+    });
+  });
+
+  describe("findLatestByTriggerId", () => {
+    describe("when reading a trigger's newest fire", () => {
+      it("asks for exactly one row, newest first, scoped to project and trigger", async () => {
+        const { repo, findFirst } = makeRepo();
+
+        await repo.findLatestByTriggerId({
+          projectId: "proj_123",
+          triggerId: "trigger_1",
+        });
+
+        // This is the shape `TriggerSent_projectId_triggerId_createdAt_idx`
+        // exists for: equality on the leading two columns, ordered by the
+        // third. Changing the where or the orderBy here silently turns the
+        // health probe back into a scan of every row the trigger ever wrote.
+        expect(findFirst).toHaveBeenCalledWith(
+          expect.objectContaining({
+            where: { projectId: "proj_123", triggerId: "trigger_1" },
+            orderBy: { createdAt: "desc" },
+          }),
+        );
+      });
+
+      it("selects fire metadata only, never traceId or captured trace content", async () => {
+        const { repo, findFirst } = makeRepo();
+
+        await repo.findLatestByTriggerId({
+          projectId: "proj_123",
+          triggerId: "trigger_1",
+        });
+
+        const selectArg = findFirst.mock.calls[0]![0].select;
         expect(Object.keys(selectArg).sort()).toEqual([
           "createdAt",
           "customGraphId",

--- a/platform/app/src/server/app-layer/automations/__tests__/trigger-fire-history.service.unit.test.ts
+++ b/platform/app/src/server/app-layer/automations/__tests__/trigger-fire-history.service.unit.test.ts
@@ -125,6 +125,7 @@ describe("TriggerFireHistoryService", () => {
         expect(result).toEqual(fires[0]);
       });
 
+      /** @scenario "A trigger that never fired reads as nothing" */
       it("returns null when the trigger never fired", async () => {
         vi.mocked(repo.findLatestByTriggerId).mockResolvedValueOnce(null);
 

--- a/platform/app/src/server/app-layer/automations/__tests__/trigger-fire-history.service.unit.test.ts
+++ b/platform/app/src/server/app-layer/automations/__tests__/trigger-fire-history.service.unit.test.ts
@@ -36,6 +36,7 @@ describe("TriggerFireHistoryService", () => {
     repo = {
       findAllStatsForProject: vi.fn().mockResolvedValue(stats),
       findAllRecentByTriggerId: vi.fn().mockResolvedValue(fires),
+      findLatestByTriggerId: vi.fn().mockResolvedValue(fires[0]),
       findAllRecentForProject: vi.fn().mockResolvedValue(fires),
     };
     service = new TriggerFireHistoryService(repo);
@@ -99,6 +100,40 @@ describe("TriggerFireHistoryService", () => {
         // service is a passthrough, so asserting the shape here would only
         // test the fixture. That guard is asserted directly against the
         // prisma `select` in trigger-fire-history.prisma.repository.unit.test.ts.
+      });
+    });
+
+    describe("when fetching the latest fire for one trigger", () => {
+      it("scopes the lookup to the project and trigger", async () => {
+        await service.getLatestFireForTrigger({
+          projectId: "proj_123",
+          triggerId: "trigger_1",
+        });
+
+        expect(repo.findLatestByTriggerId).toHaveBeenCalledWith({
+          projectId: "proj_123",
+          triggerId: "trigger_1",
+        });
+      });
+
+      it("returns the repository's newest fire unchanged", async () => {
+        const result = await service.getLatestFireForTrigger({
+          projectId: "proj_123",
+          triggerId: "trigger_1",
+        });
+
+        expect(result).toEqual(fires[0]);
+      });
+
+      it("returns null when the trigger never fired", async () => {
+        vi.mocked(repo.findLatestByTriggerId).mockResolvedValueOnce(null);
+
+        const result = await service.getLatestFireForTrigger({
+          projectId: "proj_123",
+          triggerId: "trigger_never",
+        });
+
+        expect(result).toBeNull();
       });
     });
   });

--- a/platform/app/src/server/app-layer/automations/repositories/trigger-fire-history.prisma.repository.ts
+++ b/platform/app/src/server/app-layer/automations/repositories/trigger-fire-history.prisma.repository.ts
@@ -76,6 +76,27 @@ export class PrismaTriggerFireHistoryRepository
     });
   }
 
+  async findLatestByTriggerId({
+    projectId,
+    triggerId,
+  }: {
+    projectId: string;
+    triggerId: string;
+  }): Promise<TriggerFire | null> {
+    return this.prisma.triggerSent.findFirst({
+      where: { projectId, triggerId },
+      orderBy: { createdAt: "desc" },
+      // Metadata only, for the same reason as the list reads above.
+      select: {
+        id: true,
+        triggerId: true,
+        customGraphId: true,
+        createdAt: true,
+        resolvedAt: true,
+      },
+    });
+  }
+
   async findAllRecentForProject({
     projectId,
     limit,

--- a/platform/app/src/server/app-layer/automations/repositories/trigger-fire-history.repository.ts
+++ b/platform/app/src/server/app-layer/automations/repositories/trigger-fire-history.repository.ts
@@ -51,6 +51,15 @@ export interface TriggerFireHistoryRepository {
   }): Promise<TriggerFire[]>;
 
   /**
+   * The single newest fire for one trigger, or null when it never fired.
+   * Backs the `/api/health/triggers` probe. Same metadata-only contract.
+   */
+  findLatestByTriggerId(params: {
+    projectId: string;
+    triggerId: string;
+  }): Promise<TriggerFire | null>;
+
+  /**
    * Every trigger's recent fires across the project, newest first — the feed
    * behind "what have my automations actually been doing?". Same metadata-only
    * contract as `findAllRecentByTriggerId`: no trace ids, no trace content.

--- a/platform/app/src/server/app-layer/automations/trigger-fire-history.service.ts
+++ b/platform/app/src/server/app-layer/automations/trigger-fire-history.service.ts
@@ -54,6 +54,21 @@ export class TriggerFireHistoryService {
   }
 
   /**
+   * The newest fire for one trigger, or null when it never fired. This is
+   * what the `/api/health/triggers` probe asks: did this trigger fire
+   * recently enough to count as alive.
+   */
+  async getLatestFireForTrigger({
+    projectId,
+    triggerId,
+  }: {
+    projectId: string;
+    triggerId: string;
+  }): Promise<TriggerFire | null> {
+    return this.repo.findLatestByTriggerId({ projectId, triggerId });
+  }
+
+  /**
    * Latest fires across every trigger in the project, newest first — the
    * activity feed on the automations page. Metadata only.
    */

--- a/platform/app/src/server/routes/health-checks.ts
+++ b/platform/app/src/server/routes/health-checks.ts
@@ -24,6 +24,7 @@ import type { Context } from "hono";
 import { nanoid } from "nanoid";
 import { env } from "~/env.mjs";
 import { createServiceApp, publicEndpoint } from "~/server/api/security";
+import { TriggerFireHistoryService } from "~/server/app-layer/automations/trigger-fire-history.service";
 import { authorizeLangyApiKey } from "~/server/app-layer/langy/langyApiKeyAuthorization";
 import { prisma } from "~/server/db";
 import { sendCanary } from "~/server/health-probes/canary.service";
@@ -456,10 +457,9 @@ secured
       return c.json({ message: "Trigger not found." }, { status: 404 });
     }
 
-    const lastTriggerSent = await prisma.triggerSent.findFirst({
-      where: { triggerId, projectId: project.id },
-      orderBy: { createdAt: "desc" },
-    });
+    const lastTriggerSent = await TriggerFireHistoryService.create(
+      prisma,
+    ).getLatestFireForTrigger({ projectId: project.id, triggerId });
 
     if (!lastTriggerSent) {
       return c.json({ message: "No trigger sent found." }, { status: 404 });

--- a/specs/automations/fire-history-latest-read.feature
+++ b/specs/automations/fire-history-latest-read.feature
@@ -1,0 +1,35 @@
+Feature: Finding a trigger's newest fire reads one row, not its whole history
+
+  The /api/health/triggers probe answers "did this trigger fire in the last
+  hour" by looking at its newest TriggerSent row. One trigger can own most of
+  the table, so the read has to be shaped so the database walks straight to
+  the newest entry - equality on project and trigger, ordered by createdAt,
+  one row - and served through the fire-history service like every other
+  read of that table, rather than a hand-written query in the route.
+
+  # Bindings:
+  #   platform/app/src/server/app-layer/automations/trigger-fire-history.service.ts
+  #   platform/app/src/server/app-layer/automations/repositories/trigger-fire-history.prisma.repository.ts
+  #   platform/app/src/server/app-layer/automations/__tests__/trigger-fire-history.service.unit.test.ts
+  #   platform/app/src/server/app-layer/automations/__tests__/trigger-fire-history.prisma.repository.unit.test.ts
+  #   platform/app/prisma/migrations/20260907120000_trigger_sent_latest_fire_index/migration.sql
+
+  @unit
+  Scenario: The newest fire is asked for by project and trigger, newest first, one row
+    Given a trigger with fire history
+    When the newest fire is read
+    Then the query filters on exactly the project and the trigger
+    And orders by createdAt descending
+    And asks for a single row
+
+  @unit
+  Scenario: The newest fire carries metadata only
+    Given a trigger with fire history
+    When the newest fire is read
+    Then the row has no trace id and no captured trace content
+
+  @unit
+  Scenario: A trigger that never fired reads as nothing
+    Given a trigger with no fire history
+    When the newest fire is read
+    Then the result is null


### PR DESCRIPTION
Fixes langwatch/langwatch-saas#1217

## What

The `/api/health/triggers` probe asks "when did this trigger last fire" and Postgres answered by scanning every `TriggerSent` row and sorting, because no index on the table could both find one trigger's rows *and* order them by time. One trigger owns most of the table, so for it the scan was the whole table — on every poll from an external monitor.

- **Indexes**: add `TriggerSent(projectId, triggerId, createdAt)` and `TriggerSent(projectId, createdAt)`; drop the single-column `triggerId`, `projectId` and `resolvedAt` indexes (the first two are prefixes of the new ones; `resolvedAt` is never used on its own).
- **Route**: the probe reads through `TriggerFireHistoryService.getLatestFireForTrigger` instead of a hand-written Prisma query in the route file. Same 404 / one-hour / project-scoping behaviour.
- **Spec + tests**: `specs/automations/fire-history-latest-read.feature` pins the query shape (equality on project + trigger, order by `createdAt` desc, one row) and the metadata-only select.

## Measured

On a 2.1M-row local reproduction of the production distribution (Postgres 16):

| read | before | after |
|---|---|---|
| health probe, heaviest trigger | 68 ms parallel seq scan | 0.013 ms index scan |
| automations activity feed, heaviest project | seq scan | 0.011 ms index scan |

Production numbers (from the issue): the probe was averaging over a second, with a worst case of almost three minutes, and ranked among the top ten queries by total time.

## Deploy

Five one-statement migrations, all `CONCURRENTLY`: the two composite builds first, then the three drops. Reads and writes (automation firings) keep going throughout; a plain `DROP INDEX` would have queued every read and write behind any in-flight probe, and probes on this table have run for minutes. Verified against this repo's Prisma 7.9.1 that `migrate deploy` applies them. Expect roughly ten seconds of background build against production.

If a build is interrupted, Postgres leaves an invalid index behind and Prisma marks the migration failed; the creates deliberately have no `IF NOT EXISTS` so that cannot pass silently. The recovery steps (drop the invalid index, `migrate resolve --rolled-back`, redeploy) are in the first migration's header, with the rollback for each file.

Net index size goes up (roughly +100–130 MB): the composites are larger than the single-column ones they replace.

## Not in this PR

- `TriggerSent` retention — would also make the per-trigger stats rollup cheap for the heaviest project. Separate issue if wanted.
- Prompt / workflow version lookups with the same shape — langwatch/langwatch-saas#1218.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving the latest fire record for a specific trigger.
  * Latest-fire results include relevant metadata and return no result when the trigger has never fired.
  * Trigger health checks now use the latest-fire history lookup.

* **Performance**
  * Improved fire-history and project activity-feed lookup performance with optimized indexes.

* **Tests**
  * Added coverage for scoping, newest-first ordering, metadata-only results, and empty history.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
