### PR TITLE
feat(langy): an uptime monitor that proves Langy answers a greeting

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1023,7 +1023,8 @@
               "self-hosting/langy/setup",
               "self-hosting/langy/github-app",
               "self-hosting/langy/environment-variables",
-              "self-hosting/langy/networking-and-egress"
+              "self-hosting/langy/networking-and-egress",
+              "self-hosting/langy/uptime-monitoring"
             ]
           }
         ]

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -61353,6 +61353,137 @@ other part of your install is left as it was.
 
 ---
 
+# FILE: ./self-hosting/langy/uptime-monitoring.mdx
+
+---
+title: Langy Uptime Monitoring
+description: "Prove on a schedule that Langy still answers, with a Better Stack monitor that starts a real turn"
+sidebarTitle: Uptime monitoring
+---
+
+A pod being up does not mean the assistant answers. The check on this page
+starts a real Langy turn from outside the cluster every few minutes, waits for
+the reply, and pages when there is none. It runs on
+[Better Stack](https://betterstack.com/uptime) as a Playwright monitor and needs
+no platform code: it is a client of the same `POST /api/langy/conversations`
+route scripts and CI use.
+
+## What one check does
+
+```
+Better Stack (one region)
+   │  every 3 minutes
+   ▼
+mint a random idempotencyKey
+   │
+   ▼
+POST {LANGY_BASE_URL}/api/langy/conversations
+  X-Auth-Token: <Langy user API key>
+  Prefer: wait=30
+  { "messages": [{ "role": "user", "content": "Hi Langy." }],
+    "idempotencyKey": "<uuid>" }
+   │
+   ▼
+200 + reply.text  ──► healthy
+anything else     ──► unhealthy, with a reason (table below)
+```
+
+The turn is real: it shows up in the monitoring project's Langy history, it
+uses the project's configured model, and it costs one short completion per
+check.
+
+### Why it must be a scripted monitor
+
+Every turn request carries an `idempotencyKey`. The platform resolves a repeated
+key for the same project and user to the turn it already ran, and returns that
+turn's stored reply without running the assistant again. A plain HTTP monitor
+sends the same body every time, so from the second check on it would be reading
+a stored reply and stay green while Langy is down. The Playwright script mints a
+new key on every run.
+
+## Setup
+
+### 1. A project, a user, and a key
+
+Create these once, by hand, in the deployment you want to watch:
+
+1. **A dedicated project** for monitoring. Nothing else should live in it.
+2. **A dedicated user** who is a member of that project and has Langy access
+   (the Langy cohort). The check runs as this user; do not reuse a person's
+   account.
+3. **A project API key owned by that user** with the `langy:create`
+   permission. Keys are issued in the project's settings; the key must be
+   minted while signed in as the monitoring user, because the platform resolves
+   the key to its owner and judges access per user.
+4. **The feature flag** `release_langy_api_key_turns_enabled` on for the
+   monitoring project. While it is off the route answers 404 and the monitor
+   reports `surface_dark`.
+
+### 2. Provision the monitor
+
+The monitor is created and kept up to date by a script in the repository, so
+its definition lives in git rather than in a dashboard form.
+
+```bash
+cd platform/app
+BETTERSTACK_API_TOKEN=... \
+LANGY_BASE_URL=https://langwatch.example.com \
+LANGY_API_KEY=<the key from step 1> \
+npx tsx scripts/uptime/upsert-langy-greeting-monitor.ts --dry-run
+```
+
+The dry run prints the monitor definition with the key redacted and writes
+nothing. Drop `--dry-run` to create the monitor, or to update it in place if one
+with the same name already exists. Run it again after any change to the script
+in `scripts/uptime/langy-greeting.betterstack.js`.
+
+| Variable | Required | Default | Meaning |
+|---|---|---|---|
+| `BETTERSTACK_API_TOKEN` | yes | | Better Stack Uptime API token |
+| `LANGY_BASE_URL` | yes | | Deployment origin, no trailing path |
+| `LANGY_API_KEY` | yes | | The monitoring user's key. Stored as a monitor environment variable, never in the script |
+| `BETTERSTACK_MONITOR_NAME` | no | `Langy greeting` | Name the monitor is found by on later runs |
+| `BETTERSTACK_REGION` | no | `eu` | One of `us`, `eu`, `as`, `au`. One region only |
+| `BETTERSTACK_CHECK_FREQUENCY_SECONDS` | no | `180` | Must be at least 60, the monitor's timeout |
+| `BETTERSTACK_TEAM_NAME` | no | | Only with a global API token |
+
+The monitor runs from one region on purpose. Each check is a real turn, and a
+second region would double the load without adding signal.
+
+### 3. Wire the alert
+
+Attach the monitor to your escalation policy or status page in Better Stack as
+you would any other. The monitor's incident timeline carries one JSON line per
+check with the status, latency, idempotency key and turn ids, so a red check can
+be found in the platform's Langy history.
+
+## Reading a red check
+
+The script names why it failed. The reason appears in the failed assertion and
+in the logged line.
+
+| Reason | What happened | Where to look |
+|---|---|---|
+| `not_settled` | The turn was accepted but produced no reply within 30 seconds | Langy worker pod, model provider latency |
+| `turn_failed` | The turn ran and ended in an error; the error message is carried | Langy worker logs, model provider credentials and budget |
+| `empty_reply` | The turn ended with a reply that has no text | Model configuration for the monitoring project |
+| `surface_dark` | The route answered 404 | The `release_langy_api_key_turns_enabled` flag for the monitoring project, or the app not deployed |
+| `unauthorized` | The key was missing or invalid | The key was rotated or revoked; mint a new one and re-run the provisioning script |
+| `forbidden` | The key lacks `langy:create`, or its owner lost Langy access | The key's permissions, the monitoring user's cohort membership |
+| `unexpected_status` | Any other status, carried in the line (429, 5xx, redirects) | Ingress, app pods |
+| `malformed_body` | The response was not the turn envelope | A proxy or maintenance page answering in the app's place |
+| `unreachable` | The request never got an answer | DNS, ingress, network policy |
+
+## Limits
+
+- The check proves a reply exists. It does not judge whether the reply is a good
+  answer.
+- It exercises one turn with no tools, retrieval or session keys.
+- History and latency live in Better Stack. The platform keeps the turns
+  themselves in the monitoring project's Langy history.
+
+---
+
 # FILE: ./self-hosting/licensing.mdx
 
 ---

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -61480,8 +61480,10 @@ in the logged line.
   answer.
 - It exercises one turn with no tools, retrieval or session keys.
 - Each check opens a new conversation, which spawns a fresh Langy worker. At
-  the default frequency that is 480 worker boots a day on the monitoring
-  project; raise the frequency if that is too much.
+  the default interval of 180 seconds that is 480 worker boots a day on the
+  monitoring project. To check less often, raise
+  `BETTERSTACK_CHECK_FREQUENCY_SECONDS`: 300 gives 288 boots a day, 600 gives
+  144.
 - History and latency live in Better Stack. The platform keeps the turns
   themselves in the monitoring project's Langy history.
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -61379,7 +61379,7 @@ mint a random idempotencyKey
    ▼
 POST {LANGY_BASE_URL}/api/langy/conversations
   X-Auth-Token: <Langy user API key>
-  Prefer: wait=30
+  Prefer: wait=90
   { "messages": [{ "role": "user", "content": "Hi Langy." }],
     "idempotencyKey": "<uuid>" }
    │
@@ -61444,7 +61444,7 @@ in `scripts/uptime/langy-greeting.betterstack.js`.
 | `LANGY_API_KEY` | yes | | The monitoring user's key. Stored as a monitor environment variable, never in the script |
 | `BETTERSTACK_MONITOR_NAME` | no | `Langy greeting` | Name the monitor is found by on later runs |
 | `BETTERSTACK_REGION` | no | `eu` | One of `us`, `eu`, `as`, `au`. One region only |
-| `BETTERSTACK_CHECK_FREQUENCY_SECONDS` | no | `180` | Must be at least 60, the monitor's timeout |
+| `BETTERSTACK_CHECK_FREQUENCY_SECONDS` | no | `180` | Must be at least 120, the monitor's timeout |
 | `BETTERSTACK_TEAM_NAME` | no | | Only with a global API token |
 
 The monitor runs from one region on purpose. Each check is a real turn, and a
@@ -61464,7 +61464,7 @@ in the logged line.
 
 | Reason | What happened | Where to look |
 |---|---|---|
-| `not_settled` | The turn was accepted but produced no reply within 30 seconds | Langy worker pod, model provider latency |
+| `not_settled` | The turn was accepted but produced no reply within 90 seconds. Every check is a cold start, so a slow worker boot lands here first | Langy worker pod, model provider latency |
 | `turn_failed` | The turn ran and ended in an error; the error message is carried | Langy worker logs, model provider credentials and budget |
 | `empty_reply` | The turn ended with a reply that has no text | Model configuration for the monitoring project |
 | `surface_dark` | The route answered 404 | The `release_langy_api_key_turns_enabled` flag for the monitoring project, or the app not deployed |
@@ -61479,6 +61479,9 @@ in the logged line.
 - The check proves a reply exists. It does not judge whether the reply is a good
   answer.
 - It exercises one turn with no tools, retrieval or session keys.
+- Each check opens a new conversation, which spawns a fresh Langy worker. At
+  the default frequency that is 480 worker boots a day on the monitoring
+  project; raise the frequency if that is too much.
 - History and latency live in Better Stack. The platform keeps the turns
   themselves in the monitoring project's Langy history.
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -61407,7 +61407,7 @@ new key on every run.
 
 Create these once, by hand, in the deployment you want to watch:
 
-1. **A dedicated project** for monitoring. Nothing else should live in it.
+1. **A dedicated project** for monitoring, holding only the user and key below.
 2. **A dedicated user** who is a member of that project and has Langy access
    (the Langy cohort). The check runs as this user; do not reuse a person's
    account.
@@ -61432,10 +61432,10 @@ LANGY_API_KEY=<the key from step 1> \
 npx tsx scripts/uptime/upsert-langy-greeting-monitor.ts --dry-run
 ```
 
-The dry run prints the monitor definition with the key redacted and writes
-nothing. Drop `--dry-run` to create the monitor, or to update it in place if one
-with the same name already exists. Run it again after any change to the script
-in `scripts/uptime/langy-greeting.betterstack.js`.
+The dry run prints the monitor definition with the key redacted and leaves
+Better Stack unchanged. Drop `--dry-run` to create the monitor, or to update it
+in place if one with the same name already exists. Run it again after any
+change to the script in `scripts/uptime/langy-greeting.betterstack.js`.
 
 | Variable | Required | Default | Meaning |
 |---|---|---|---|

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -709,6 +709,7 @@ For agents: if anything in these docs is wrong, confusing, or fails when you try
 - [Register the GitHub App](https://langwatch.ai/docs/self-hosting/langy/github-app.md): Deployment-time guide for the GitHub App the organization connects, covering registration, permissions, the GITHUB_LANGY env vars, GitHub Enterprise Server, restricted networks, install, verify, and disconnect.
 - [Langy Environment Variables](https://langwatch.ai/docs/self-hosting/langy/environment-variables.md): The environment variable reference for the Langy agent pod and its control-plane integration, grouped by core, workers, egress, mirror lane, and GitHub.
 - [Langy Networking and Egress](https://langwatch.ai/docs/self-hosting/langy/networking-and-egress.md): The NetworkPolicy and L7 egress adapter that govern what the Langy agent pod can reach, the GitHub FQDN floor, and the cooperative-vs-mandatory enforcement limit.
+- [Langy Uptime Monitoring](https://langwatch.ai/docs/self-hosting/langy/uptime-monitoring.md): Prove on a schedule that Langy still answers, with a Better Stack monitor that starts a real turn
 
 # API Reference
 

--- a/docs/self-hosting/langy/uptime-monitoring.mdx
+++ b/docs/self-hosting/langy/uptime-monitoring.mdx
@@ -22,7 +22,7 @@ mint a random idempotencyKey
    ▼
 POST {LANGY_BASE_URL}/api/langy/conversations
   X-Auth-Token: <Langy user API key>
-  Prefer: wait=30
+  Prefer: wait=90
   { "messages": [{ "role": "user", "content": "Hi Langy." }],
     "idempotencyKey": "<uuid>" }
    │
@@ -87,7 +87,7 @@ in `scripts/uptime/langy-greeting.betterstack.js`.
 | `LANGY_API_KEY` | yes | | The monitoring user's key. Stored as a monitor environment variable, never in the script |
 | `BETTERSTACK_MONITOR_NAME` | no | `Langy greeting` | Name the monitor is found by on later runs |
 | `BETTERSTACK_REGION` | no | `eu` | One of `us`, `eu`, `as`, `au`. One region only |
-| `BETTERSTACK_CHECK_FREQUENCY_SECONDS` | no | `180` | Must be at least 60, the monitor's timeout |
+| `BETTERSTACK_CHECK_FREQUENCY_SECONDS` | no | `180` | Must be at least 120, the monitor's timeout |
 | `BETTERSTACK_TEAM_NAME` | no | | Only with a global API token |
 
 The monitor runs from one region on purpose. Each check is a real turn, and a
@@ -107,7 +107,7 @@ in the logged line.
 
 | Reason | What happened | Where to look |
 |---|---|---|
-| `not_settled` | The turn was accepted but produced no reply within 30 seconds | Langy worker pod, model provider latency |
+| `not_settled` | The turn was accepted but produced no reply within 90 seconds. Every check is a cold start, so a slow worker boot lands here first | Langy worker pod, model provider latency |
 | `turn_failed` | The turn ran and ended in an error; the error message is carried | Langy worker logs, model provider credentials and budget |
 | `empty_reply` | The turn ended with a reply that has no text | Model configuration for the monitoring project |
 | `surface_dark` | The route answered 404 | The `release_langy_api_key_turns_enabled` flag for the monitoring project, or the app not deployed |
@@ -122,5 +122,8 @@ in the logged line.
 - The check proves a reply exists. It does not judge whether the reply is a good
   answer.
 - It exercises one turn with no tools, retrieval or session keys.
+- Each check opens a new conversation, which spawns a fresh Langy worker. At
+  the default frequency that is 480 worker boots a day on the monitoring
+  project; raise the frequency if that is too much.
 - History and latency live in Better Stack. The platform keeps the turns
   themselves in the monitoring project's Langy history.

--- a/docs/self-hosting/langy/uptime-monitoring.mdx
+++ b/docs/self-hosting/langy/uptime-monitoring.mdx
@@ -1,0 +1,126 @@
+---
+title: Langy Uptime Monitoring
+description: "Prove on a schedule that Langy still answers, with a Better Stack monitor that starts a real turn"
+sidebarTitle: Uptime monitoring
+---
+
+A pod being up does not mean the assistant answers. The check on this page
+starts a real Langy turn from outside the cluster every few minutes, waits for
+the reply, and pages when there is none. It runs on
+[Better Stack](https://betterstack.com/uptime) as a Playwright monitor and needs
+no platform code: it is a client of the same `POST /api/langy/conversations`
+route scripts and CI use.
+
+## What one check does
+
+```
+Better Stack (one region)
+   │  every 3 minutes
+   ▼
+mint a random idempotencyKey
+   │
+   ▼
+POST {LANGY_BASE_URL}/api/langy/conversations
+  X-Auth-Token: <Langy user API key>
+  Prefer: wait=30
+  { "messages": [{ "role": "user", "content": "Hi Langy." }],
+    "idempotencyKey": "<uuid>" }
+   │
+   ▼
+200 + reply.text  ──► healthy
+anything else     ──► unhealthy, with a reason (table below)
+```
+
+The turn is real: it shows up in the monitoring project's Langy history, it
+uses the project's configured model, and it costs one short completion per
+check.
+
+### Why it must be a scripted monitor
+
+Every turn request carries an `idempotencyKey`. The platform resolves a repeated
+key for the same project and user to the turn it already ran, and returns that
+turn's stored reply without running the assistant again. A plain HTTP monitor
+sends the same body every time, so from the second check on it would be reading
+a stored reply and stay green while Langy is down. The Playwright script mints a
+new key on every run.
+
+## Setup
+
+### 1. A project, a user, and a key
+
+Create these once, by hand, in the deployment you want to watch:
+
+1. **A dedicated project** for monitoring. Nothing else should live in it.
+2. **A dedicated user** who is a member of that project and has Langy access
+   (the Langy cohort). The check runs as this user; do not reuse a person's
+   account.
+3. **A project API key owned by that user** with the `langy:create`
+   permission. Keys are issued in the project's settings; the key must be
+   minted while signed in as the monitoring user, because the platform resolves
+   the key to its owner and judges access per user.
+4. **The feature flag** `release_langy_api_key_turns_enabled` on for the
+   monitoring project. While it is off the route answers 404 and the monitor
+   reports `surface_dark`.
+
+### 2. Provision the monitor
+
+The monitor is created and kept up to date by a script in the repository, so
+its definition lives in git rather than in a dashboard form.
+
+```bash
+cd platform/app
+BETTERSTACK_API_TOKEN=... \
+LANGY_BASE_URL=https://langwatch.example.com \
+LANGY_API_KEY=<the key from step 1> \
+npx tsx scripts/uptime/upsert-langy-greeting-monitor.ts --dry-run
+```
+
+The dry run prints the monitor definition with the key redacted and writes
+nothing. Drop `--dry-run` to create the monitor, or to update it in place if one
+with the same name already exists. Run it again after any change to the script
+in `scripts/uptime/langy-greeting.betterstack.js`.
+
+| Variable | Required | Default | Meaning |
+|---|---|---|---|
+| `BETTERSTACK_API_TOKEN` | yes | | Better Stack Uptime API token |
+| `LANGY_BASE_URL` | yes | | Deployment origin, no trailing path |
+| `LANGY_API_KEY` | yes | | The monitoring user's key. Stored as a monitor environment variable, never in the script |
+| `BETTERSTACK_MONITOR_NAME` | no | `Langy greeting` | Name the monitor is found by on later runs |
+| `BETTERSTACK_REGION` | no | `eu` | One of `us`, `eu`, `as`, `au`. One region only |
+| `BETTERSTACK_CHECK_FREQUENCY_SECONDS` | no | `180` | Must be at least 60, the monitor's timeout |
+| `BETTERSTACK_TEAM_NAME` | no | | Only with a global API token |
+
+The monitor runs from one region on purpose. Each check is a real turn, and a
+second region would double the load without adding signal.
+
+### 3. Wire the alert
+
+Attach the monitor to your escalation policy or status page in Better Stack as
+you would any other. The monitor's incident timeline carries one JSON line per
+check with the status, latency, idempotency key and turn ids, so a red check can
+be found in the platform's Langy history.
+
+## Reading a red check
+
+The script names why it failed. The reason appears in the failed assertion and
+in the logged line.
+
+| Reason | What happened | Where to look |
+|---|---|---|
+| `not_settled` | The turn was accepted but produced no reply within 30 seconds | Langy worker pod, model provider latency |
+| `turn_failed` | The turn ran and ended in an error; the error message is carried | Langy worker logs, model provider credentials and budget |
+| `empty_reply` | The turn ended with a reply that has no text | Model configuration for the monitoring project |
+| `surface_dark` | The route answered 404 | The `release_langy_api_key_turns_enabled` flag for the monitoring project, or the app not deployed |
+| `unauthorized` | The key was missing or invalid | The key was rotated or revoked; mint a new one and re-run the provisioning script |
+| `forbidden` | The key lacks `langy:create`, or its owner lost Langy access | The key's permissions, the monitoring user's cohort membership |
+| `unexpected_status` | Any other status, carried in the line (429, 5xx, redirects) | Ingress, app pods |
+| `malformed_body` | The response was not the turn envelope | A proxy or maintenance page answering in the app's place |
+| `unreachable` | The request never got an answer | DNS, ingress, network policy |
+
+## Limits
+
+- The check proves a reply exists. It does not judge whether the reply is a good
+  answer.
+- It exercises one turn with no tools, retrieval or session keys.
+- History and latency live in Better Stack. The platform keeps the turns
+  themselves in the monitoring project's Langy history.

--- a/docs/self-hosting/langy/uptime-monitoring.mdx
+++ b/docs/self-hosting/langy/uptime-monitoring.mdx
@@ -123,7 +123,9 @@ in the logged line.
   answer.
 - It exercises one turn with no tools, retrieval or session keys.
 - Each check opens a new conversation, which spawns a fresh Langy worker. At
-  the default frequency that is 480 worker boots a day on the monitoring
-  project; raise the frequency if that is too much.
+  the default interval of 180 seconds that is 480 worker boots a day on the
+  monitoring project. To check less often, raise
+  `BETTERSTACK_CHECK_FREQUENCY_SECONDS`: 300 gives 288 boots a day, 600 gives
+  144.
 - History and latency live in Better Stack. The platform keeps the turns
   themselves in the monitoring project's Langy history.

--- a/docs/self-hosting/langy/uptime-monitoring.mdx
+++ b/docs/self-hosting/langy/uptime-monitoring.mdx
@@ -50,7 +50,7 @@ new key on every run.
 
 Create these once, by hand, in the deployment you want to watch:
 
-1. **A dedicated project** for monitoring. Nothing else should live in it.
+1. **A dedicated project** for monitoring, holding only the user and key below.
 2. **A dedicated user** who is a member of that project and has Langy access
    (the Langy cohort). The check runs as this user; do not reuse a person's
    account.
@@ -75,10 +75,10 @@ LANGY_API_KEY=<the key from step 1> \
 npx tsx scripts/uptime/upsert-langy-greeting-monitor.ts --dry-run
 ```
 
-The dry run prints the monitor definition with the key redacted and writes
-nothing. Drop `--dry-run` to create the monitor, or to update it in place if one
-with the same name already exists. Run it again after any change to the script
-in `scripts/uptime/langy-greeting.betterstack.js`.
+The dry run prints the monitor definition with the key redacted and leaves
+Better Stack unchanged. Drop `--dry-run` to create the monitor, or to update it
+in place if one with the same name already exists. Run it again after any
+change to the script in `scripts/uptime/langy-greeting.betterstack.js`.
 
 | Variable | Required | Default | Meaning |
 |---|---|---|---|

--- a/platform/app/scripts/uptime/__tests__/langy-greeting-check.unit.test.ts
+++ b/platform/app/scripts/uptime/__tests__/langy-greeting-check.unit.test.ts
@@ -97,6 +97,35 @@ describe("buildGreetingRequest", () => {
       expect(request.url).toBe(`${BASE_URL}${LANGY_CONVERSATIONS_PATH}`);
     });
   });
+
+  describe("when the base URL would put the API key on the wire in the clear", () => {
+    /** @scenario A plaintext base URL is refused before the key is attached */
+    it("refuses http and any scheme that is not https", () => {
+      for (const baseUrl of [
+        "http://app.example.com",
+        "ftp://app.example.com",
+      ]) {
+        expect(() =>
+          buildGreetingRequest({
+            baseUrl,
+            apiKey: API_KEY,
+            idempotencyKey: "k",
+          }),
+        ).toThrow(/must use https/);
+      }
+    });
+
+    /** @scenario A base URL that is not a URL at all is refused by name */
+    it("refuses a base URL that does not parse", () => {
+      expect(() =>
+        buildGreetingRequest({
+          baseUrl: "app.example.com",
+          apiKey: API_KEY,
+          idempotencyKey: "k",
+        }),
+      ).toThrow(/not a valid URL/);
+    });
+  });
 });
 
 describe("classifyGreetingResponse", () => {

--- a/platform/app/scripts/uptime/__tests__/langy-greeting-check.unit.test.ts
+++ b/platform/app/scripts/uptime/__tests__/langy-greeting-check.unit.test.ts
@@ -42,276 +42,298 @@ function fetchAnswering(status: number, body: unknown): FetchLike {
 }
 
 describe("buildGreetingRequest", () => {
-  /** @scenario Every check starts a turn no earlier check could have started */
-  it("carries whatever key the check minted, and two checks mint different ones", async () => {
-    const keys: string[] = [];
-    const fetch: FetchLike = async (_url, init) => {
-      keys.push(JSON.parse(init.body).idempotencyKey);
-      return { status: 200, text: async () => JSON.stringify(settled) };
-    };
-    await runLangyGreetingCheck({ baseUrl: BASE_URL, apiKey: API_KEY, fetch });
-    await runLangyGreetingCheck({ baseUrl: BASE_URL, apiKey: API_KEY, fetch });
-    expect(keys).toHaveLength(2);
-    expect(keys[0]).not.toBe(keys[1]);
-    expect(keys[0]).toMatch(/^[0-9a-f-]{36}$/);
-    expect(keys[0]).not.toContain(API_KEY);
-    expect(keys[0]).not.toContain(LANGY_GREETING_TEXT);
-  });
+  describe("when a check is built for a deployment", () => {
+    /** @scenario Every check starts a turn no earlier check could have started */
+    it("carries whatever key the check minted, and two checks mint different ones", async () => {
+      const keys: string[] = [];
+      const fetch: FetchLike = async (_url, init) => {
+        keys.push(JSON.parse(init.body).idempotencyKey);
+        return { status: 200, text: async () => JSON.stringify(settled) };
+      };
+      await runLangyGreetingCheck({
+        baseUrl: BASE_URL,
+        apiKey: API_KEY,
+        fetch,
+      });
+      await runLangyGreetingCheck({
+        baseUrl: BASE_URL,
+        apiKey: API_KEY,
+        fetch,
+      });
+      expect(keys).toHaveLength(2);
+      expect(keys[0]).not.toBe(keys[1]);
+      expect(keys[0]).toMatch(/^[0-9a-f-]{36}$/);
+      expect(keys[0]).not.toContain(API_KEY);
+      expect(keys[0]).not.toContain(LANGY_GREETING_TEXT);
+    });
 
-  /** @scenario The request is the plain-text turn shape with a bounded wait */
-  it("posts one plain-text user message with the key in X-Auth-Token and a bounded wait", () => {
-    const request = buildGreetingRequest({
-      baseUrl: BASE_URL,
-      apiKey: API_KEY,
-      idempotencyKey: "k-1",
+    /** @scenario The request is the plain-text turn shape with a bounded wait */
+    it("posts one plain-text user message with the key in X-Auth-Token and a bounded wait", () => {
+      const request = buildGreetingRequest({
+        baseUrl: BASE_URL,
+        apiKey: API_KEY,
+        idempotencyKey: "k-1",
+      });
+      expect(request.method).toBe("POST");
+      expect(request.url).toBe(`${BASE_URL}${LANGY_CONVERSATIONS_PATH}`);
+      expect(request.headers["X-Auth-Token"]).toBe(API_KEY);
+      expect(request.headers.Prefer).toBe(
+        `wait=${LANGY_GREETING_WAIT_SECONDS}`,
+      );
+      expect(LANGY_GREETING_WAIT_SECONDS).toBeLessThan(120);
+      expect(JSON.parse(request.body)).toEqual({
+        messages: [{ role: "user", content: LANGY_GREETING_TEXT }],
+        idempotencyKey: "k-1",
+      });
     });
-    expect(request.method).toBe("POST");
-    expect(request.url).toBe(`${BASE_URL}${LANGY_CONVERSATIONS_PATH}`);
-    expect(request.headers["X-Auth-Token"]).toBe(API_KEY);
-    expect(request.headers.Prefer).toBe(`wait=${LANGY_GREETING_WAIT_SECONDS}`);
-    expect(LANGY_GREETING_WAIT_SECONDS).toBeLessThan(120);
-    expect(JSON.parse(request.body)).toEqual({
-      messages: [{ role: "user", content: LANGY_GREETING_TEXT }],
-      idempotencyKey: "k-1",
-    });
-  });
 
-  /** @scenario A trailing slash on the base URL does not double the path */
-  it("strips trailing slashes from the base URL", () => {
-    const request = buildGreetingRequest({
-      baseUrl: `${BASE_URL}//`,
-      apiKey: API_KEY,
-      idempotencyKey: "k-1",
+    /** @scenario A trailing slash on the base URL does not double the path */
+    it("strips trailing slashes from the base URL", () => {
+      const request = buildGreetingRequest({
+        baseUrl: `${BASE_URL}//`,
+        apiKey: API_KEY,
+        idempotencyKey: "k-1",
+      });
+      expect(request.url).toBe(`${BASE_URL}${LANGY_CONVERSATIONS_PATH}`);
     });
-    expect(request.url).toBe(`${BASE_URL}${LANGY_CONVERSATIONS_PATH}`);
   });
 });
 
 describe("classifyGreetingResponse", () => {
-  /** @scenario A settled turn with reply text is healthy */
-  it("is healthy on 200 with a non-empty reply, carrying the ids and text", () => {
-    expect(classifyGreetingResponse({ status: 200, body: settled })).toEqual({
-      healthy: true,
-      status: 200,
-      conversationId: "conv_1",
-      turnId: "langyturn_abc",
-      replyText: "Hello! How can I help?",
-    });
-  });
-
-  /** @scenario A settled turn that failed is unhealthy even though the transport said 200 */
-  it("is turn_failed on 200 with a null reply, carrying the turn's error", () => {
-    const outcome = classifyGreetingResponse({
-      status: 200,
-      body: {
-        ...settled,
-        status: "failed",
-        error: { code: "model_unavailable", message: "provider timed out" },
-        reply: null,
-      },
-    });
-    expect(outcome).toMatchObject({
-      healthy: false,
-      reason: "turn_failed",
-      status: 200,
-      conversationId: "conv_1",
-      turnId: "langyturn_abc",
-    });
-    expect(outcome.healthy === false && outcome.detail).toContain(
-      "provider timed out",
-    );
-    expect(outcome.healthy === false && outcome.detail).toContain("failed");
-  });
-
-  /** @scenario A reply with no text is not a reply */
-  it.each(["", "   \n"])("is empty_reply when reply.text is %j", (text) => {
-    expect(
-      classifyGreetingResponse({
+  describe("given the response the route answered", () => {
+    /** @scenario A settled turn with reply text is healthy */
+    it("is healthy on 200 with a non-empty reply, carrying the ids and text", () => {
+      expect(classifyGreetingResponse({ status: 200, body: settled })).toEqual({
+        healthy: true,
         status: 200,
-        body: { ...settled, reply: { role: "assistant", text } },
-      }),
-    ).toMatchObject({ healthy: false, reason: "empty_reply", status: 200 });
-  });
+        conversationId: "conv_1",
+        turnId: "langyturn_abc",
+        replyText: "Hello! How can I help?",
+      });
+    });
 
-  /** @scenario An accepted turn that did not settle inside the wait is unhealthy */
-  it("is not_settled on 202, keeping the accepted ids", () => {
-    expect(
-      classifyGreetingResponse({
+    /** @scenario A settled turn that failed is unhealthy even though the transport said 200 */
+    it("is turn_failed on 200 with a null reply, carrying the turn's error", () => {
+      const outcome = classifyGreetingResponse({
+        status: 200,
+        body: {
+          ...settled,
+          status: "failed",
+          error: { code: "model_unavailable", message: "provider timed out" },
+          reply: null,
+        },
+      });
+      expect(outcome).toMatchObject({
+        healthy: false,
+        reason: "turn_failed",
+        status: 200,
+        conversationId: "conv_1",
+        turnId: "langyturn_abc",
+      });
+      expect(outcome.healthy === false && outcome.detail).toContain(
+        "provider timed out",
+      );
+      expect(outcome.healthy === false && outcome.detail).toContain("failed");
+    });
+
+    /** @scenario A reply with no text is not a reply */
+    it.each(["", "   \n"])("is empty_reply when reply.text is %j", (text) => {
+      expect(
+        classifyGreetingResponse({
+          status: 200,
+          body: { ...settled, reply: { role: "assistant", text } },
+        }),
+      ).toMatchObject({ healthy: false, reason: "empty_reply", status: 200 });
+    });
+
+    /** @scenario An accepted turn that did not settle inside the wait is unhealthy */
+    it("is not_settled on 202, keeping the accepted ids", () => {
+      expect(
+        classifyGreetingResponse({
+          status: 202,
+          body: { conversationId: "conv_2", turnId: "langyturn_def" },
+        }),
+      ).toMatchObject({
+        healthy: false,
+        reason: "not_settled",
         status: 202,
-        body: { conversationId: "conv_2", turnId: "langyturn_def" },
-      }),
-    ).toMatchObject({
-      healthy: false,
-      reason: "not_settled",
-      status: 202,
-      conversationId: "conv_2",
-      turnId: "langyturn_def",
+        conversationId: "conv_2",
+        turnId: "langyturn_def",
+      });
     });
-  });
 
-  /** @scenario A dark surface is named, not mistaken for an outage of the assistant */
-  it("is surface_dark on 404", () => {
-    expect(classifyGreetingResponse({ status: 404, body: {} })).toMatchObject({
-      healthy: false,
-      reason: "surface_dark",
-      status: 404,
+    /** @scenario A dark surface is named, not mistaken for an outage of the assistant */
+    it("is surface_dark on 404", () => {
+      expect(classifyGreetingResponse({ status: 404, body: {} })).toMatchObject(
+        {
+          healthy: false,
+          reason: "surface_dark",
+          status: 404,
+        },
+      );
     });
-  });
 
-  /** @scenario A refused credential is named by which gate refused it */
-  it("is unauthorized on 401 and forbidden on 403", () => {
-    expect(
-      classifyGreetingResponse({
+    /** @scenario A refused credential is named by which gate refused it */
+    it("is unauthorized on 401 and forbidden on 403", () => {
+      expect(
+        classifyGreetingResponse({
+          status: 401,
+          body: { error: { code: "credential_invalid", message: "bad key" } },
+        }),
+      ).toMatchObject({
+        reason: "unauthorized",
         status: 401,
-        body: { error: { code: "credential_invalid", message: "bad key" } },
-      }),
-    ).toMatchObject({
-      reason: "unauthorized",
-      status: 401,
-      detail: "credential_invalid: bad key",
+        detail: "credential_invalid: bad key",
+      });
+      expect(classifyGreetingResponse({ status: 403, body: {} })).toMatchObject(
+        {
+          reason: "forbidden",
+          status: 403,
+        },
+      );
     });
-    expect(classifyGreetingResponse({ status: 403, body: {} })).toMatchObject({
-      reason: "forbidden",
-      status: 403,
-    });
-  });
 
-  /** @scenario Any other status is unhealthy and keeps the status for the alert */
-  it.each([
-    500, 429, 502, 302,
-  ])("is unexpected_status carrying %d", (status) => {
-    expect(classifyGreetingResponse({ status, body: "gateway" })).toMatchObject(
-      {
+    /** @scenario Any other status is unhealthy and keeps the status for the alert */
+    it.each([
+      500, 429, 502, 302,
+    ])("is unexpected_status carrying %d", (status) => {
+      expect(
+        classifyGreetingResponse({ status, body: "gateway" }),
+      ).toMatchObject({
         healthy: false,
         reason: "unexpected_status",
         status,
-      },
-    );
-  });
+      });
+    });
 
-  /** @scenario A body that is not the turn envelope is unhealthy, whatever the status */
-  it.each([
-    null,
-    "ok",
-    [],
-    { reply: { text: "hi" } },
-    { conversationId: "c" },
-  ])("is malformed_body on 200 with body %j", (body) => {
-    expect(classifyGreetingResponse({ status: 200, body })).toMatchObject({
-      healthy: false,
-      reason: "malformed_body",
-      status: 200,
+    /** @scenario A body that is not the turn envelope is unhealthy, whatever the status */
+    it.each([
+      null,
+      "ok",
+      [],
+      { reply: { text: "hi" } },
+      { conversationId: "c" },
+    ])("is malformed_body on 200 with body %j", (body) => {
+      expect(classifyGreetingResponse({ status: 200, body })).toMatchObject({
+        healthy: false,
+        reason: "malformed_body",
+        status: 200,
+      });
     });
   });
 });
 
 describe("runLangyGreetingCheck", () => {
-  /** @scenario A network failure is unhealthy with the cause, not a crash */
-  it("is unreachable with the error message when fetch throws", async () => {
-    const result = await runLangyGreetingCheck({
-      baseUrl: BASE_URL,
-      apiKey: API_KEY,
-      fetch: async () => {
-        throw new Error("ECONNREFUSED 10.0.0.1:443");
-      },
+  describe("when the transport or body is not what the route promises", () => {
+    /** @scenario A network failure is unhealthy with the cause, not a crash */
+    it("is unreachable with the error message when fetch throws", async () => {
+      const result = await runLangyGreetingCheck({
+        baseUrl: BASE_URL,
+        apiKey: API_KEY,
+        fetch: async () => {
+          throw new Error("ECONNREFUSED 10.0.0.1:443");
+        },
+      });
+      expect(result).toMatchObject({
+        healthy: false,
+        reason: "unreachable",
+        status: null,
+        detail: "ECONNREFUSED 10.0.0.1:443",
+      });
     });
-    expect(result).toMatchObject({
-      healthy: false,
-      reason: "unreachable",
-      status: null,
-      detail: "ECONNREFUSED 10.0.0.1:443",
-    });
-  });
 
-  /** @scenario A non-JSON response body is unhealthy with reason malformed_body */
-  it("is malformed_body when the body does not parse", async () => {
-    const result = await runLangyGreetingCheck({
-      baseUrl: BASE_URL,
-      apiKey: API_KEY,
-      fetch: fetchAnswering(200, "<html>maintenance</html>"),
+    /** @scenario A non-JSON response body is unhealthy with reason malformed_body */
+    it("is malformed_body when the body does not parse", async () => {
+      const result = await runLangyGreetingCheck({
+        baseUrl: BASE_URL,
+        apiKey: API_KEY,
+        fetch: fetchAnswering(200, "<html>maintenance</html>"),
+      });
+      expect(result).toMatchObject({
+        healthy: false,
+        reason: "malformed_body",
+        status: 200,
+      });
     });
-    expect(result).toMatchObject({
-      healthy: false,
-      reason: "malformed_body",
-      status: 200,
-    });
-  });
 
-  /** @scenario The check reports how long the turn took and which key it used */
-  it("carries durationMs and the minted key", async () => {
-    let tick = 1_000;
-    const result = await runLangyGreetingCheck({
-      baseUrl: BASE_URL,
-      apiKey: API_KEY,
-      fetch: fetchAnswering(200, settled),
-      mintKey: () => "minted-key",
-      now: () => (tick += 1_250),
+    /** @scenario The check reports how long the turn took and which key it used */
+    it("carries durationMs and the minted key", async () => {
+      let tick = 1_000;
+      const result = await runLangyGreetingCheck({
+        baseUrl: BASE_URL,
+        apiKey: API_KEY,
+        fetch: fetchAnswering(200, settled),
+        mintKey: () => "minted-key",
+        now: () => (tick += 1_250),
+      });
+      expect(result).toMatchObject({
+        healthy: true,
+        idempotencyKey: "minted-key",
+        durationMs: 1_250,
+      });
     });
-    expect(result).toMatchObject({
-      healthy: true,
-      idempotencyKey: "minted-key",
-      durationMs: 1_250,
-    });
-  });
 
-  /** @scenario The credential never appears in the check's output */
-  it("formats a log line without the key", async () => {
-    const healthy = await runLangyGreetingCheck({
-      baseUrl: BASE_URL,
-      apiKey: API_KEY,
-      fetch: fetchAnswering(200, settled),
+    /** @scenario The credential never appears in the check's output */
+    it("formats a log line without the key", async () => {
+      const healthy = await runLangyGreetingCheck({
+        baseUrl: BASE_URL,
+        apiKey: API_KEY,
+        fetch: fetchAnswering(200, settled),
+      });
+      const refused = await runLangyGreetingCheck({
+        baseUrl: BASE_URL,
+        apiKey: API_KEY,
+        fetch: fetchAnswering(401, {
+          error: { message: `key ${API_KEY} rejected` },
+        }),
+      });
+      for (const line of [
+        formatGreetingCheckResult(healthy),
+        formatGreetingCheckResult(refused),
+      ]) {
+        expect(line).not.toContain(API_KEY);
+        expect(JSON.parse(line)).toHaveProperty("idempotencyKey");
+        expect(JSON.parse(line)).toHaveProperty("durationMs");
+      }
+      // Upstream echoing the key in an error message is not our line to repeat.
+      expect(formatGreetingCheckResult(refused)).toContain("unauthorized");
     });
-    const refused = await runLangyGreetingCheck({
-      baseUrl: BASE_URL,
-      apiKey: API_KEY,
-      fetch: fetchAnswering(401, {
-        error: { message: `key ${API_KEY} rejected` },
-      }),
-    });
-    for (const line of [
-      formatGreetingCheckResult(healthy),
-      formatGreetingCheckResult(refused),
-    ]) {
-      expect(line).not.toContain(API_KEY);
-      expect(JSON.parse(line)).toHaveProperty("idempotencyKey");
-      expect(JSON.parse(line)).toHaveProperty("durationMs");
-    }
-    // Upstream echoing the key in an error message is not our line to repeat.
-    expect(formatGreetingCheckResult(refused)).toContain("unauthorized");
   });
 });
 
 describe("the Better Stack script", () => {
-  const script = readFileSync(
-    join(
-      dirname(fileURLToPath(import.meta.url)),
-      "..",
-      "langy-greeting.betterstack.js",
-    ),
-    "utf8",
-  );
+  describe("given the pasted script next to the module", () => {
+    const script = readFileSync(
+      join(
+        dirname(fileURLToPath(import.meta.url)),
+        "..",
+        "langy-greeting.betterstack.js",
+      ),
+      "utf8",
+    );
 
-  /** @scenario The pasted script cannot drift from the check module */
-  it("uses the module's greeting, wait, path, header and reason names, and a random UUID per run", () => {
-    expect(script).toContain(
-      `const GREETING = ${JSON.stringify(LANGY_GREETING_TEXT)};`,
-    );
-    expect(script).toContain(
-      `const WAIT_SECONDS = ${LANGY_GREETING_WAIT_SECONDS};`,
-    );
-    expect(script).toContain(
-      `const PATH = ${JSON.stringify(LANGY_CONVERSATIONS_PATH)};`,
-    );
-    expect(script).toContain('"X-Auth-Token": apiKey');
-    expect(script).toContain("randomUUID()");
-    expect(script).toContain('import { randomUUID } from "node:crypto";');
-    for (const reason of GREETING_FAILURE_REASONS) {
-      expect(script, `script must name reason ${reason}`).toContain(
-        `"${reason}"`,
+    /** @scenario The pasted script cannot drift from the check module */
+    it("uses the module's greeting, wait, path, header and reason names, and a random UUID per run", () => {
+      expect(script).toContain(
+        `const GREETING = ${JSON.stringify(LANGY_GREETING_TEXT)};`,
       );
-    }
-    expect(script).toContain(
-      'import { expect, test } from "@playwright/test";',
-    );
+      expect(script).toContain(
+        `const WAIT_SECONDS = ${LANGY_GREETING_WAIT_SECONDS};`,
+      );
+      expect(script).toContain(
+        `const PATH = ${JSON.stringify(LANGY_CONVERSATIONS_PATH)};`,
+      );
+      expect(script).toContain('"X-Auth-Token": apiKey');
+      expect(script).toContain("randomUUID()");
+      expect(script).toContain('import { randomUUID } from "node:crypto";');
+      for (const reason of GREETING_FAILURE_REASONS) {
+        expect(script, `script must name reason ${reason}`).toContain(
+          `"${reason}"`,
+        );
+      }
+      expect(script).toContain(
+        'import { expect, test } from "@playwright/test";',
+      );
+    });
   });
 });

--- a/platform/app/scripts/uptime/__tests__/langy-greeting-check.unit.test.ts
+++ b/platform/app/scripts/uptime/__tests__/langy-greeting-check.unit.test.ts
@@ -1,0 +1,316 @@
+/**
+ * @vitest-environment node
+ *
+ * scripts/uptime/langy-greeting-check.ts — the request shape, the verdict
+ * table, and the drift guard on the pasted Better Stack script.
+ *
+ * Spec: specs/langy/langy-uptime-greeting-monitor.feature
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  buildGreetingRequest,
+  classifyGreetingResponse,
+  type FetchLike,
+  formatGreetingCheckResult,
+  GREETING_FAILURE_REASONS,
+  LANGY_CONVERSATIONS_PATH,
+  LANGY_GREETING_TEXT,
+  LANGY_GREETING_WAIT_SECONDS,
+  runLangyGreetingCheck,
+} from "../langy-greeting-check";
+
+const API_KEY = "sk-lw-test-key-DO-NOT-LOG";
+const BASE_URL = "https://langwatch.example";
+
+const settled = {
+  conversationId: "conv_1",
+  turnId: "langyturn_abc",
+  status: "completed",
+  error: null,
+  reply: { role: "assistant", text: "Hello! How can I help?" },
+};
+
+function fetchAnswering(status: number, body: unknown): FetchLike {
+  return async () => ({
+    status,
+    text: async () => (typeof body === "string" ? body : JSON.stringify(body)),
+  });
+}
+
+describe("buildGreetingRequest", () => {
+  /** @scenario Every check starts a turn no earlier check could have started */
+  it("carries whatever key the check minted, and two checks mint different ones", async () => {
+    const keys: string[] = [];
+    const fetch: FetchLike = async (_url, init) => {
+      keys.push(JSON.parse(init.body).idempotencyKey);
+      return { status: 200, text: async () => JSON.stringify(settled) };
+    };
+    await runLangyGreetingCheck({ baseUrl: BASE_URL, apiKey: API_KEY, fetch });
+    await runLangyGreetingCheck({ baseUrl: BASE_URL, apiKey: API_KEY, fetch });
+    expect(keys).toHaveLength(2);
+    expect(keys[0]).not.toBe(keys[1]);
+    expect(keys[0]).toMatch(/^[0-9a-f-]{36}$/);
+    expect(keys[0]).not.toContain(API_KEY);
+    expect(keys[0]).not.toContain(LANGY_GREETING_TEXT);
+  });
+
+  /** @scenario The request is the plain-text turn shape with a bounded wait */
+  it("posts one plain-text user message with the key in X-Auth-Token and a bounded wait", () => {
+    const request = buildGreetingRequest({
+      baseUrl: BASE_URL,
+      apiKey: API_KEY,
+      idempotencyKey: "k-1",
+    });
+    expect(request.method).toBe("POST");
+    expect(request.url).toBe(`${BASE_URL}${LANGY_CONVERSATIONS_PATH}`);
+    expect(request.headers["X-Auth-Token"]).toBe(API_KEY);
+    expect(request.headers.Prefer).toBe(`wait=${LANGY_GREETING_WAIT_SECONDS}`);
+    expect(LANGY_GREETING_WAIT_SECONDS).toBeLessThan(60);
+    expect(JSON.parse(request.body)).toEqual({
+      messages: [{ role: "user", content: LANGY_GREETING_TEXT }],
+      idempotencyKey: "k-1",
+    });
+  });
+
+  /** @scenario A trailing slash on the base URL does not double the path */
+  it("strips trailing slashes from the base URL", () => {
+    const request = buildGreetingRequest({
+      baseUrl: `${BASE_URL}//`,
+      apiKey: API_KEY,
+      idempotencyKey: "k-1",
+    });
+    expect(request.url).toBe(`${BASE_URL}${LANGY_CONVERSATIONS_PATH}`);
+  });
+});
+
+describe("classifyGreetingResponse", () => {
+  /** @scenario A settled turn with reply text is healthy */
+  it("is healthy on 200 with a non-empty reply, carrying the ids and text", () => {
+    expect(classifyGreetingResponse({ status: 200, body: settled })).toEqual({
+      healthy: true,
+      status: 200,
+      conversationId: "conv_1",
+      turnId: "langyturn_abc",
+      replyText: "Hello! How can I help?",
+    });
+  });
+
+  /** @scenario A settled turn that failed is unhealthy even though the transport said 200 */
+  it("is turn_failed on 200 with a null reply, carrying the turn's error", () => {
+    const outcome = classifyGreetingResponse({
+      status: 200,
+      body: {
+        ...settled,
+        status: "failed",
+        error: { code: "model_unavailable", message: "provider timed out" },
+        reply: null,
+      },
+    });
+    expect(outcome).toMatchObject({
+      healthy: false,
+      reason: "turn_failed",
+      status: 200,
+      conversationId: "conv_1",
+      turnId: "langyturn_abc",
+    });
+    expect(outcome.healthy === false && outcome.detail).toContain(
+      "provider timed out",
+    );
+    expect(outcome.healthy === false && outcome.detail).toContain("failed");
+  });
+
+  /** @scenario A reply with no text is not a reply */
+  it.each(["", "   \n"])("is empty_reply when reply.text is %j", (text) => {
+    expect(
+      classifyGreetingResponse({
+        status: 200,
+        body: { ...settled, reply: { role: "assistant", text } },
+      }),
+    ).toMatchObject({ healthy: false, reason: "empty_reply", status: 200 });
+  });
+
+  /** @scenario An accepted turn that did not settle inside the wait is unhealthy */
+  it("is not_settled on 202, keeping the accepted ids", () => {
+    expect(
+      classifyGreetingResponse({
+        status: 202,
+        body: { conversationId: "conv_2", turnId: "langyturn_def" },
+      }),
+    ).toMatchObject({
+      healthy: false,
+      reason: "not_settled",
+      status: 202,
+      conversationId: "conv_2",
+      turnId: "langyturn_def",
+    });
+  });
+
+  /** @scenario A dark surface is named, not mistaken for an outage of the assistant */
+  it("is surface_dark on 404", () => {
+    expect(classifyGreetingResponse({ status: 404, body: {} })).toMatchObject({
+      healthy: false,
+      reason: "surface_dark",
+      status: 404,
+    });
+  });
+
+  /** @scenario A refused credential is named by which gate refused it */
+  it("is unauthorized on 401 and forbidden on 403", () => {
+    expect(
+      classifyGreetingResponse({
+        status: 401,
+        body: { error: { code: "credential_invalid", message: "bad key" } },
+      }),
+    ).toMatchObject({
+      reason: "unauthorized",
+      status: 401,
+      detail: "credential_invalid: bad key",
+    });
+    expect(classifyGreetingResponse({ status: 403, body: {} })).toMatchObject({
+      reason: "forbidden",
+      status: 403,
+    });
+  });
+
+  /** @scenario Any other status is unhealthy and keeps the status for the alert */
+  it.each([
+    500, 429, 502, 302,
+  ])("is unexpected_status carrying %d", (status) => {
+    expect(classifyGreetingResponse({ status, body: "gateway" })).toMatchObject(
+      {
+        healthy: false,
+        reason: "unexpected_status",
+        status,
+      },
+    );
+  });
+
+  /** @scenario A body that is not the turn envelope is unhealthy, whatever the status */
+  it.each([
+    null,
+    "ok",
+    [],
+    { reply: { text: "hi" } },
+    { conversationId: "c" },
+  ])("is malformed_body on 200 with body %j", (body) => {
+    expect(classifyGreetingResponse({ status: 200, body })).toMatchObject({
+      healthy: false,
+      reason: "malformed_body",
+      status: 200,
+    });
+  });
+});
+
+describe("runLangyGreetingCheck", () => {
+  /** @scenario A network failure is unhealthy with the cause, not a crash */
+  it("is unreachable with the error message when fetch throws", async () => {
+    const result = await runLangyGreetingCheck({
+      baseUrl: BASE_URL,
+      apiKey: API_KEY,
+      fetch: async () => {
+        throw new Error("ECONNREFUSED 10.0.0.1:443");
+      },
+    });
+    expect(result).toMatchObject({
+      healthy: false,
+      reason: "unreachable",
+      status: null,
+      detail: "ECONNREFUSED 10.0.0.1:443",
+    });
+  });
+
+  /** @scenario A non-JSON response body is unhealthy with reason malformed_body */
+  it("is malformed_body when the body does not parse", async () => {
+    const result = await runLangyGreetingCheck({
+      baseUrl: BASE_URL,
+      apiKey: API_KEY,
+      fetch: fetchAnswering(200, "<html>maintenance</html>"),
+    });
+    expect(result).toMatchObject({
+      healthy: false,
+      reason: "malformed_body",
+      status: 200,
+    });
+  });
+
+  /** @scenario The check reports how long the turn took and which key it used */
+  it("carries durationMs and the minted key", async () => {
+    let tick = 1_000;
+    const result = await runLangyGreetingCheck({
+      baseUrl: BASE_URL,
+      apiKey: API_KEY,
+      fetch: fetchAnswering(200, settled),
+      mintKey: () => "minted-key",
+      now: () => (tick += 1_250),
+    });
+    expect(result).toMatchObject({
+      healthy: true,
+      idempotencyKey: "minted-key",
+      durationMs: 1_250,
+    });
+  });
+
+  /** @scenario The credential never appears in the check's output */
+  it("formats a log line without the key", async () => {
+    const healthy = await runLangyGreetingCheck({
+      baseUrl: BASE_URL,
+      apiKey: API_KEY,
+      fetch: fetchAnswering(200, settled),
+    });
+    const refused = await runLangyGreetingCheck({
+      baseUrl: BASE_URL,
+      apiKey: API_KEY,
+      fetch: fetchAnswering(401, {
+        error: { message: `key ${API_KEY} rejected` },
+      }),
+    });
+    for (const line of [
+      formatGreetingCheckResult(healthy),
+      formatGreetingCheckResult(refused),
+    ]) {
+      expect(line).not.toContain(API_KEY);
+      expect(JSON.parse(line)).toHaveProperty("idempotencyKey");
+      expect(JSON.parse(line)).toHaveProperty("durationMs");
+    }
+    // Upstream echoing the key in an error message is not our line to repeat.
+    expect(formatGreetingCheckResult(refused)).toContain("unauthorized");
+  });
+});
+
+describe("the Better Stack script", () => {
+  const script = readFileSync(
+    join(
+      dirname(fileURLToPath(import.meta.url)),
+      "..",
+      "langy-greeting.betterstack.js",
+    ),
+    "utf8",
+  );
+
+  /** @scenario The pasted script cannot drift from the check module */
+  it("uses the module's greeting, wait, path, header and reason names, and a random UUID per run", () => {
+    expect(script).toContain(
+      `const GREETING = ${JSON.stringify(LANGY_GREETING_TEXT)};`,
+    );
+    expect(script).toContain(
+      `const WAIT_SECONDS = ${LANGY_GREETING_WAIT_SECONDS};`,
+    );
+    expect(script).toContain(
+      `const PATH = ${JSON.stringify(LANGY_CONVERSATIONS_PATH)};`,
+    );
+    expect(script).toContain('"X-Auth-Token": apiKey');
+    expect(script).toContain("crypto.randomUUID()");
+    for (const reason of GREETING_FAILURE_REASONS) {
+      expect(script, `script must name reason ${reason}`).toContain(
+        `"${reason}"`,
+      );
+    }
+    expect(script).toContain(
+      'import { expect, test } from "@playwright/test";',
+    );
+  });
+});

--- a/platform/app/scripts/uptime/__tests__/langy-greeting-check.unit.test.ts
+++ b/platform/app/scripts/uptime/__tests__/langy-greeting-check.unit.test.ts
@@ -325,6 +325,8 @@ describe("the Better Stack script", () => {
       );
       expect(script).toContain('"X-Auth-Token": apiKey');
       expect(script).toContain("randomUUID()");
+      // Playwright defaults to a 30s test timeout; the script must raise it past the wait.
+      expect(script).toContain("test.setTimeout((WAIT_SECONDS + 20) * 1000);");
       expect(script).toContain('import { randomUUID } from "node:crypto";');
       for (const reason of GREETING_FAILURE_REASONS) {
         expect(script, `script must name reason ${reason}`).toContain(

--- a/platform/app/scripts/uptime/__tests__/langy-greeting-check.unit.test.ts
+++ b/platform/app/scripts/uptime/__tests__/langy-greeting-check.unit.test.ts
@@ -69,7 +69,7 @@ describe("buildGreetingRequest", () => {
     expect(request.url).toBe(`${BASE_URL}${LANGY_CONVERSATIONS_PATH}`);
     expect(request.headers["X-Auth-Token"]).toBe(API_KEY);
     expect(request.headers.Prefer).toBe(`wait=${LANGY_GREETING_WAIT_SECONDS}`);
-    expect(LANGY_GREETING_WAIT_SECONDS).toBeLessThan(60);
+    expect(LANGY_GREETING_WAIT_SECONDS).toBeLessThan(120);
     expect(JSON.parse(request.body)).toEqual({
       messages: [{ role: "user", content: LANGY_GREETING_TEXT }],
       idempotencyKey: "k-1",
@@ -303,7 +303,8 @@ describe("the Better Stack script", () => {
       `const PATH = ${JSON.stringify(LANGY_CONVERSATIONS_PATH)};`,
     );
     expect(script).toContain('"X-Auth-Token": apiKey');
-    expect(script).toContain("crypto.randomUUID()");
+    expect(script).toContain("randomUUID()");
+    expect(script).toContain('import { randomUUID } from "node:crypto";');
     for (const reason of GREETING_FAILURE_REASONS) {
       expect(script, `script must name reason ${reason}`).toContain(
         `"${reason}"`,

--- a/platform/app/scripts/uptime/__tests__/upsert-langy-greeting-monitor.unit.test.ts
+++ b/platform/app/scripts/uptime/__tests__/upsert-langy-greeting-monitor.unit.test.ts
@@ -81,7 +81,7 @@ describe("buildMonitorPayload", () => {
   describe("given a config and the script", () => {
     /** @scenario The monitor payload is a single-region Playwright monitor bounded under its own frequency */
     it("builds a playwright monitor with the script, env vars, one region and timeout <= frequency", () => {
-      const payload = buildMonitorPayload(config, script);
+      const payload = buildMonitorPayload({ config, script });
       expect(payload.monitor_type).toBe("playwright");
       expect(payload.playwright_script).toBe(script);
       expect(payload.scenario_name).toBe("Langy greeting");
@@ -98,22 +98,32 @@ describe("buildMonitorPayload", () => {
       );
       expect(payload).not.toHaveProperty("team_name");
       expect(
-        buildMonitorPayload({ ...config, teamName: "ops" }, script).team_name,
+        buildMonitorPayload({ config: { ...config, teamName: "ops" }, script })
+          .team_name,
       ).toBe("ops");
     });
 
     /** @scenario An unknown region or a timeout above the frequency is refused before any API call */
     it("refuses a bad region or a frequency under the timeout, naming the field", () => {
       expect(() =>
-        buildMonitorPayload({ ...config, region: "mars" }, script),
+        buildMonitorPayload({ config: { ...config, region: "mars" }, script }),
       ).toThrow(/region "mars"/);
       expect(() =>
-        buildMonitorPayload({ ...config, checkFrequencySeconds: 30 }, script),
+        buildMonitorPayload({
+          config: { ...config, checkFrequencySeconds: 30 },
+          script,
+        }),
       ).toThrow(/checkFrequencySeconds \(30\)/);
       expect(() =>
-        buildMonitorPayload({ ...config, langyApiKey: "" }, script),
+        buildMonitorPayload({ config: { ...config, langyApiKey: "" }, script }),
       ).toThrow(ProvisioningError);
-      expect(() => buildMonitorPayload(config, "  ")).toThrow(
+      expect(() =>
+        buildMonitorPayload({
+          config: { ...config, langyBaseUrl: "http://app.example.com" },
+          script,
+        }),
+      ).toThrow(/must use https/);
+      expect(() => buildMonitorPayload({ config, script: "  " })).toThrow(
         /script is empty/,
       );
     });
@@ -149,7 +159,7 @@ describe("upsertMonitor", () => {
         token: "t",
         config,
         script,
-        dryRun: false,
+        isDryRun: false,
         log: () => {},
       });
       expect(result).toEqual({
@@ -180,7 +190,7 @@ describe("upsertMonitor", () => {
         token: "t",
         config,
         script,
-        dryRun: false,
+        isDryRun: false,
         log: () => {},
       });
       expect(result).toMatchObject({ action: "updated", id: "41" });
@@ -204,7 +214,7 @@ describe("upsertMonitor", () => {
           token: "t",
           config,
           script,
-          dryRun: false,
+          isDryRun: false,
           log: () => {},
         }),
       ).rejects.toThrow(/2 monitors are named "Langy greeting" \(ids 41, 43\)/);
@@ -222,7 +232,7 @@ describe("upsertMonitor", () => {
         token: "t",
         config,
         script,
-        dryRun: true,
+        isDryRun: true,
         log: (line) => lines.push(line),
       });
       expect(result).toEqual({
@@ -237,7 +247,7 @@ describe("upsertMonitor", () => {
       expect(output).not.toContain("sk-lw-service-key");
       expect(output).not.toContain("@playwright/test");
       expect(
-        redactPayload(buildMonitorPayload(config, script))
+        redactPayload(buildMonitorPayload({ config, script }))
           .environment_variables,
       ).toEqual({
         LANGY_BASE_URL: "https://langwatch.example",
@@ -261,7 +271,7 @@ describe("upsertMonitor", () => {
         token: "t",
         config,
         script,
-        dryRun: false,
+        isDryRun: false,
         log: () => {},
       }).catch((e: unknown) => e);
       expect(error).toBeInstanceOf(ProvisioningError);

--- a/platform/app/scripts/uptime/__tests__/upsert-langy-greeting-monitor.unit.test.ts
+++ b/platform/app/scripts/uptime/__tests__/upsert-langy-greeting-monitor.unit.test.ts
@@ -1,0 +1,264 @@
+/**
+ * @vitest-environment node
+ *
+ * scripts/uptime/upsert-langy-greeting-monitor.ts — payload shape, the
+ * create/update/ambiguous decision, dry run, and API refusals.
+ *
+ * Spec: specs/langy/langy-uptime-greeting-monitor.feature
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  type ApiFetch,
+  BETTERSTACK_API_BASE,
+  buildMonitorPayload,
+  configFromEnv,
+  MONITOR_REQUEST_TIMEOUT_SECONDS,
+  type MonitorConfig,
+  ProvisioningError,
+  REDACTED,
+  readMonitorScript,
+  redactPayload,
+  upsertMonitor,
+} from "../upsert-langy-greeting-monitor";
+
+const config: MonitorConfig = {
+  name: "Langy greeting",
+  region: "eu",
+  checkFrequencySeconds: 180,
+  langyBaseUrl: "https://langwatch.example",
+  langyApiKey: "sk-lw-service-key-DO-NOT-LOG",
+};
+const script =
+  'import { test } from "@playwright/test";\ntest("x", async () => {});\n';
+
+type Call = { method: string; path: string; body?: unknown };
+
+function fakeApi(options: {
+  existing: Array<{ id: string; name: string }>;
+  writeStatus?: number;
+  writeBody?: unknown;
+}) {
+  const calls: Call[] = [];
+  const fetch: ApiFetch = async (url, init) => {
+    const path = url.replace(BETTERSTACK_API_BASE, "");
+    calls.push({
+      method: init.method,
+      path,
+      body: init.body ? JSON.parse(init.body) : undefined,
+    });
+    if (init.method === "GET") {
+      return {
+        status: 200,
+        text: async () =>
+          JSON.stringify({
+            data: options.existing.map((m) => ({
+              id: m.id,
+              type: "monitor",
+              attributes: { pronounceable_name: m.name },
+            })),
+            pagination: { next: null },
+          }),
+      };
+    }
+    return {
+      status: options.writeStatus ?? (init.method === "POST" ? 201 : 200),
+      text: async () =>
+        JSON.stringify(
+          options.writeBody ?? {
+            data: {
+              id:
+                init.method === "POST" ? "900" : path.replace("/monitors/", ""),
+            },
+          },
+        ),
+    };
+  };
+  return { fetch, calls };
+}
+
+describe("buildMonitorPayload", () => {
+  /** @scenario The monitor payload is a single-region Playwright monitor bounded under its own frequency */
+  it("builds a playwright monitor with the script, env vars, one region and timeout <= frequency", () => {
+    const payload = buildMonitorPayload(config, script);
+    expect(payload.monitor_type).toBe("playwright");
+    expect(payload.playwright_script).toBe(script);
+    expect(payload.scenario_name).toBe("Langy greeting");
+    expect(payload.pronounceable_name).toBe("Langy greeting");
+    expect(payload.environment_variables).toEqual({
+      LANGY_BASE_URL: "https://langwatch.example",
+      LANGY_API_KEY: "sk-lw-service-key-DO-NOT-LOG",
+    });
+    expect(payload.playwright_script).not.toContain("sk-lw-service-key");
+    expect(payload.regions).toEqual(["eu"]);
+    expect(payload.request_timeout).toBe(MONITOR_REQUEST_TIMEOUT_SECONDS);
+    expect(payload.request_timeout).toBeLessThanOrEqual(
+      payload.check_frequency,
+    );
+    expect(payload).not.toHaveProperty("team_name");
+    expect(
+      buildMonitorPayload({ ...config, teamName: "ops" }, script).team_name,
+    ).toBe("ops");
+  });
+
+  /** @scenario An unknown region or a timeout above the frequency is refused before any API call */
+  it("refuses a bad region or a frequency under the timeout, naming the field", () => {
+    expect(() =>
+      buildMonitorPayload({ ...config, region: "mars" }, script),
+    ).toThrow(/region "mars"/);
+    expect(() =>
+      buildMonitorPayload({ ...config, checkFrequencySeconds: 30 }, script),
+    ).toThrow(/checkFrequencySeconds \(30\)/);
+    expect(() =>
+      buildMonitorPayload({ ...config, langyApiKey: "" }, script),
+    ).toThrow(ProvisioningError);
+    expect(() => buildMonitorPayload(config, "  ")).toThrow(/script is empty/);
+  });
+
+  it("reads defaults from the environment", () => {
+    expect(
+      configFromEnv({
+        LANGY_BASE_URL: "https://x",
+        LANGY_API_KEY: "k",
+      } as NodeJS.ProcessEnv),
+    ).toEqual({
+      name: "Langy greeting",
+      region: "eu",
+      checkFrequencySeconds: 180,
+      langyBaseUrl: "https://x",
+      langyApiKey: "k",
+    });
+  });
+
+  it("reads the real script file and it is the Better Stack script", () => {
+    expect(readMonitorScript()).toContain('from "@playwright/test"');
+  });
+});
+
+describe("upsertMonitor", () => {
+  /** @scenario A monitor that does not exist yet is created */
+  it("creates when no monitor carries the name", async () => {
+    const { fetch, calls } = fakeApi({ existing: [] });
+    const result = await upsertMonitor({
+      fetch,
+      token: "t",
+      config,
+      script,
+      dryRun: false,
+      log: () => {},
+    });
+    expect(result).toEqual({
+      action: "created",
+      id: "900",
+      dashboardUrl: "https://uptime.betterstack.com/team/monitors/900",
+    });
+    expect(calls.map((c) => `${c.method} ${c.path}`)).toEqual([
+      "GET /monitors?pronounceable_name=Langy+greeting",
+      "POST /monitors",
+    ]);
+    expect(calls[1]?.body).toMatchObject({
+      monitor_type: "playwright",
+      regions: ["eu"],
+    });
+  });
+
+  /** @scenario A monitor that already exists is updated in place, never duplicated */
+  it("patches the one existing monitor and posts nothing", async () => {
+    const { fetch, calls } = fakeApi({
+      existing: [
+        { id: "41", name: "Langy greeting" },
+        { id: "42", name: "Langy greeting (staging)" },
+      ],
+    });
+    const result = await upsertMonitor({
+      fetch,
+      token: "t",
+      config,
+      script,
+      dryRun: false,
+      log: () => {},
+    });
+    expect(result).toMatchObject({ action: "updated", id: "41" });
+    expect(calls.map((c) => `${c.method} ${c.path}`)).toEqual([
+      "GET /monitors?pronounceable_name=Langy+greeting",
+      "PATCH /monitors/41",
+    ]);
+  });
+
+  /** @scenario Two monitors with the configured name is an error, not a coin flip */
+  it("refuses to choose between two monitors with the same name and writes nothing", async () => {
+    const { fetch, calls } = fakeApi({
+      existing: [
+        { id: "41", name: "Langy greeting" },
+        { id: "43", name: "Langy greeting" },
+      ],
+    });
+    await expect(
+      upsertMonitor({
+        fetch,
+        token: "t",
+        config,
+        script,
+        dryRun: false,
+        log: () => {},
+      }),
+    ).rejects.toThrow(/2 monitors are named "Langy greeting" \(ids 41, 43\)/);
+    expect(calls.filter((c) => c.method !== "GET")).toEqual([]);
+  });
+
+  /** @scenario A dry run shows the payload with the credential redacted and writes nothing */
+  it("prints the redacted payload and sends no write", async () => {
+    const { fetch, calls } = fakeApi({
+      existing: [{ id: "41", name: "Langy greeting" }],
+    });
+    const lines: string[] = [];
+    const result = await upsertMonitor({
+      fetch,
+      token: "t",
+      config,
+      script,
+      dryRun: true,
+      log: (line) => lines.push(line),
+    });
+    expect(result).toEqual({ action: "dry-run", id: "41", dashboardUrl: null });
+    expect(calls.filter((c) => c.method !== "GET")).toEqual([]);
+    const output = lines.join("\n");
+    expect(output).toContain("would update monitor 41");
+    expect(output).toContain(REDACTED);
+    expect(output).not.toContain("sk-lw-service-key");
+    expect(output).not.toContain("@playwright/test");
+    expect(
+      redactPayload(buildMonitorPayload(config, script)).environment_variables,
+    ).toEqual({
+      LANGY_BASE_URL: "https://langwatch.example",
+      LANGY_API_KEY: REDACTED,
+    });
+  });
+
+  /** @scenario A refusal from the monitoring API surfaces its status and message */
+  it("carries the API's status and error body on a refused write", async () => {
+    const { fetch } = fakeApi({
+      existing: [],
+      writeStatus: 422,
+      writeBody: {
+        errors: { base: ["Request timeout must be less than check frequency"] },
+      },
+    });
+    const error = await upsertMonitor({
+      fetch,
+      token: "t",
+      config,
+      script,
+      dryRun: false,
+      log: () => {},
+    }).catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(ProvisioningError);
+    expect((error as ProvisioningError).status).toBe(422);
+    expect((error as ProvisioningError).message).toContain(
+      "POST /monitors answered 422",
+    );
+    expect((error as ProvisioningError).message).toContain(
+      "Request timeout must be less",
+    );
+  });
+});

--- a/platform/app/scripts/uptime/__tests__/upsert-langy-greeting-monitor.unit.test.ts
+++ b/platform/app/scripts/uptime/__tests__/upsert-langy-greeting-monitor.unit.test.ts
@@ -78,187 +78,200 @@ function fakeApi(options: {
 }
 
 describe("buildMonitorPayload", () => {
-  /** @scenario The monitor payload is a single-region Playwright monitor bounded under its own frequency */
-  it("builds a playwright monitor with the script, env vars, one region and timeout <= frequency", () => {
-    const payload = buildMonitorPayload(config, script);
-    expect(payload.monitor_type).toBe("playwright");
-    expect(payload.playwright_script).toBe(script);
-    expect(payload.scenario_name).toBe("Langy greeting");
-    expect(payload.pronounceable_name).toBe("Langy greeting");
-    expect(payload.environment_variables).toEqual({
-      LANGY_BASE_URL: "https://langwatch.example",
-      LANGY_API_KEY: "sk-lw-service-key-DO-NOT-LOG",
+  describe("given a config and the script", () => {
+    /** @scenario The monitor payload is a single-region Playwright monitor bounded under its own frequency */
+    it("builds a playwright monitor with the script, env vars, one region and timeout <= frequency", () => {
+      const payload = buildMonitorPayload(config, script);
+      expect(payload.monitor_type).toBe("playwright");
+      expect(payload.playwright_script).toBe(script);
+      expect(payload.scenario_name).toBe("Langy greeting");
+      expect(payload.pronounceable_name).toBe("Langy greeting");
+      expect(payload.environment_variables).toEqual({
+        LANGY_BASE_URL: "https://langwatch.example",
+        LANGY_API_KEY: "sk-lw-service-key-DO-NOT-LOG",
+      });
+      expect(payload.playwright_script).not.toContain("sk-lw-service-key");
+      expect(payload.regions).toEqual(["eu"]);
+      expect(payload.request_timeout).toBe(MONITOR_REQUEST_TIMEOUT_SECONDS);
+      expect(payload.request_timeout).toBeLessThanOrEqual(
+        payload.check_frequency,
+      );
+      expect(payload).not.toHaveProperty("team_name");
+      expect(
+        buildMonitorPayload({ ...config, teamName: "ops" }, script).team_name,
+      ).toBe("ops");
     });
-    expect(payload.playwright_script).not.toContain("sk-lw-service-key");
-    expect(payload.regions).toEqual(["eu"]);
-    expect(payload.request_timeout).toBe(MONITOR_REQUEST_TIMEOUT_SECONDS);
-    expect(payload.request_timeout).toBeLessThanOrEqual(
-      payload.check_frequency,
-    );
-    expect(payload).not.toHaveProperty("team_name");
-    expect(
-      buildMonitorPayload({ ...config, teamName: "ops" }, script).team_name,
-    ).toBe("ops");
-  });
 
-  /** @scenario An unknown region or a timeout above the frequency is refused before any API call */
-  it("refuses a bad region or a frequency under the timeout, naming the field", () => {
-    expect(() =>
-      buildMonitorPayload({ ...config, region: "mars" }, script),
-    ).toThrow(/region "mars"/);
-    expect(() =>
-      buildMonitorPayload({ ...config, checkFrequencySeconds: 30 }, script),
-    ).toThrow(/checkFrequencySeconds \(30\)/);
-    expect(() =>
-      buildMonitorPayload({ ...config, langyApiKey: "" }, script),
-    ).toThrow(ProvisioningError);
-    expect(() => buildMonitorPayload(config, "  ")).toThrow(/script is empty/);
-  });
-
-  it("reads defaults from the environment", () => {
-    expect(
-      configFromEnv({
-        LANGY_BASE_URL: "https://x",
-        LANGY_API_KEY: "k",
-      } as NodeJS.ProcessEnv),
-    ).toEqual({
-      name: "Langy greeting",
-      region: "eu",
-      checkFrequencySeconds: 180,
-      langyBaseUrl: "https://x",
-      langyApiKey: "k",
+    /** @scenario An unknown region or a timeout above the frequency is refused before any API call */
+    it("refuses a bad region or a frequency under the timeout, naming the field", () => {
+      expect(() =>
+        buildMonitorPayload({ ...config, region: "mars" }, script),
+      ).toThrow(/region "mars"/);
+      expect(() =>
+        buildMonitorPayload({ ...config, checkFrequencySeconds: 30 }, script),
+      ).toThrow(/checkFrequencySeconds \(30\)/);
+      expect(() =>
+        buildMonitorPayload({ ...config, langyApiKey: "" }, script),
+      ).toThrow(ProvisioningError);
+      expect(() => buildMonitorPayload(config, "  ")).toThrow(
+        /script is empty/,
+      );
     });
-  });
 
-  it("reads the real script file and it is the Better Stack script", () => {
-    expect(readMonitorScript()).toContain('from "@playwright/test"');
+    it("reads defaults from the environment", () => {
+      expect(
+        configFromEnv({
+          LANGY_BASE_URL: "https://x",
+          LANGY_API_KEY: "k",
+        } as NodeJS.ProcessEnv),
+      ).toEqual({
+        name: "Langy greeting",
+        region: "eu",
+        checkFrequencySeconds: 180,
+        langyBaseUrl: "https://x",
+        langyApiKey: "k",
+      });
+    });
+
+    it("reads the real script file and it is the Better Stack script", () => {
+      expect(readMonitorScript()).toContain('from "@playwright/test"');
+    });
   });
 });
 
 describe("upsertMonitor", () => {
-  /** @scenario A monitor that does not exist yet is created */
-  it("creates when no monitor carries the name", async () => {
-    const { fetch, calls } = fakeApi({ existing: [] });
-    const result = await upsertMonitor({
-      fetch,
-      token: "t",
-      config,
-      script,
-      dryRun: false,
-      log: () => {},
-    });
-    expect(result).toEqual({
-      action: "created",
-      id: "900",
-      dashboardUrl: "https://uptime.betterstack.com/team/monitors/900",
-    });
-    expect(calls.map((c) => `${c.method} ${c.path}`)).toEqual([
-      "GET /monitors?pronounceable_name=Langy+greeting",
-      "POST /monitors",
-    ]);
-    expect(calls[1]?.body).toMatchObject({
-      monitor_type: "playwright",
-      regions: ["eu"],
-    });
-  });
-
-  /** @scenario A monitor that already exists is updated in place, never duplicated */
-  it("patches the one existing monitor and posts nothing", async () => {
-    const { fetch, calls } = fakeApi({
-      existing: [
-        { id: "41", name: "Langy greeting" },
-        { id: "42", name: "Langy greeting (staging)" },
-      ],
-    });
-    const result = await upsertMonitor({
-      fetch,
-      token: "t",
-      config,
-      script,
-      dryRun: false,
-      log: () => {},
-    });
-    expect(result).toMatchObject({ action: "updated", id: "41" });
-    expect(calls.map((c) => `${c.method} ${c.path}`)).toEqual([
-      "GET /monitors?pronounceable_name=Langy+greeting",
-      "PATCH /monitors/41",
-    ]);
-  });
-
-  /** @scenario Two monitors with the configured name is an error, not a coin flip */
-  it("refuses to choose between two monitors with the same name and writes nothing", async () => {
-    const { fetch, calls } = fakeApi({
-      existing: [
-        { id: "41", name: "Langy greeting" },
-        { id: "43", name: "Langy greeting" },
-      ],
-    });
-    await expect(
-      upsertMonitor({
+  describe("when the monitor is looked up by name", () => {
+    /** @scenario A monitor that does not exist yet is created */
+    it("creates when no monitor carries the name", async () => {
+      const { fetch, calls } = fakeApi({ existing: [] });
+      const result = await upsertMonitor({
         fetch,
         token: "t",
         config,
         script,
         dryRun: false,
         log: () => {},
-      }),
-    ).rejects.toThrow(/2 monitors are named "Langy greeting" \(ids 41, 43\)/);
-    expect(calls.filter((c) => c.method !== "GET")).toEqual([]);
-  });
+      });
+      expect(result).toEqual({
+        action: "created",
+        id: "900",
+        dashboardUrl: "https://uptime.betterstack.com/team/monitors/900",
+      });
+      expect(calls.map((c) => `${c.method} ${c.path}`)).toEqual([
+        "GET /monitors?pronounceable_name=Langy+greeting",
+        "POST /monitors",
+      ]);
+      expect(calls[1]?.body).toMatchObject({
+        monitor_type: "playwright",
+        regions: ["eu"],
+      });
+    });
 
-  /** @scenario A dry run shows the payload with the credential redacted and writes nothing */
-  it("prints the redacted payload and sends no write", async () => {
-    const { fetch, calls } = fakeApi({
-      existing: [{ id: "41", name: "Langy greeting" }],
+    /** @scenario A monitor that already exists is updated in place, never duplicated */
+    it("patches the one existing monitor and posts nothing", async () => {
+      const { fetch, calls } = fakeApi({
+        existing: [
+          { id: "41", name: "Langy greeting" },
+          { id: "42", name: "Langy greeting (staging)" },
+        ],
+      });
+      const result = await upsertMonitor({
+        fetch,
+        token: "t",
+        config,
+        script,
+        dryRun: false,
+        log: () => {},
+      });
+      expect(result).toMatchObject({ action: "updated", id: "41" });
+      expect(calls.map((c) => `${c.method} ${c.path}`)).toEqual([
+        "GET /monitors?pronounceable_name=Langy+greeting",
+        "PATCH /monitors/41",
+      ]);
     });
-    const lines: string[] = [];
-    const result = await upsertMonitor({
-      fetch,
-      token: "t",
-      config,
-      script,
-      dryRun: true,
-      log: (line) => lines.push(line),
-    });
-    expect(result).toEqual({ action: "dry-run", id: "41", dashboardUrl: null });
-    expect(calls.filter((c) => c.method !== "GET")).toEqual([]);
-    const output = lines.join("\n");
-    expect(output).toContain("would update monitor 41");
-    expect(output).toContain(REDACTED);
-    expect(output).not.toContain("sk-lw-service-key");
-    expect(output).not.toContain("@playwright/test");
-    expect(
-      redactPayload(buildMonitorPayload(config, script)).environment_variables,
-    ).toEqual({
-      LANGY_BASE_URL: "https://langwatch.example",
-      LANGY_API_KEY: REDACTED,
-    });
-  });
 
-  /** @scenario A refusal from the monitoring API surfaces its status and message */
-  it("carries the API's status and error body on a refused write", async () => {
-    const { fetch } = fakeApi({
-      existing: [],
-      writeStatus: 422,
-      writeBody: {
-        errors: { base: ["Request timeout must be less than check frequency"] },
-      },
+    /** @scenario Two monitors with the configured name is an error, not a coin flip */
+    it("refuses to choose between two monitors with the same name and writes nothing", async () => {
+      const { fetch, calls } = fakeApi({
+        existing: [
+          { id: "41", name: "Langy greeting" },
+          { id: "43", name: "Langy greeting" },
+        ],
+      });
+      await expect(
+        upsertMonitor({
+          fetch,
+          token: "t",
+          config,
+          script,
+          dryRun: false,
+          log: () => {},
+        }),
+      ).rejects.toThrow(/2 monitors are named "Langy greeting" \(ids 41, 43\)/);
+      expect(calls.filter((c) => c.method !== "GET")).toEqual([]);
     });
-    const error = await upsertMonitor({
-      fetch,
-      token: "t",
-      config,
-      script,
-      dryRun: false,
-      log: () => {},
-    }).catch((e: unknown) => e);
-    expect(error).toBeInstanceOf(ProvisioningError);
-    expect((error as ProvisioningError).status).toBe(422);
-    expect((error as ProvisioningError).message).toContain(
-      "POST /monitors answered 422",
-    );
-    expect((error as ProvisioningError).message).toContain(
-      "Request timeout must be less",
-    );
+
+    /** @scenario A dry run shows the payload with the credential redacted and writes nothing */
+    it("prints the redacted payload and sends no write", async () => {
+      const { fetch, calls } = fakeApi({
+        existing: [{ id: "41", name: "Langy greeting" }],
+      });
+      const lines: string[] = [];
+      const result = await upsertMonitor({
+        fetch,
+        token: "t",
+        config,
+        script,
+        dryRun: true,
+        log: (line) => lines.push(line),
+      });
+      expect(result).toEqual({
+        action: "dry-run",
+        id: "41",
+        dashboardUrl: null,
+      });
+      expect(calls.filter((c) => c.method !== "GET")).toEqual([]);
+      const output = lines.join("\n");
+      expect(output).toContain("would update monitor 41");
+      expect(output).toContain(REDACTED);
+      expect(output).not.toContain("sk-lw-service-key");
+      expect(output).not.toContain("@playwright/test");
+      expect(
+        redactPayload(buildMonitorPayload(config, script))
+          .environment_variables,
+      ).toEqual({
+        LANGY_BASE_URL: "https://langwatch.example",
+        LANGY_API_KEY: REDACTED,
+      });
+    });
+
+    /** @scenario A refusal from the monitoring API surfaces its status and message */
+    it("carries the API's status and error body on a refused write", async () => {
+      const { fetch } = fakeApi({
+        existing: [],
+        writeStatus: 422,
+        writeBody: {
+          errors: {
+            base: ["Request timeout must be less than check frequency"],
+          },
+        },
+      });
+      const error = await upsertMonitor({
+        fetch,
+        token: "t",
+        config,
+        script,
+        dryRun: false,
+        log: () => {},
+      }).catch((e: unknown) => e);
+      expect(error).toBeInstanceOf(ProvisioningError);
+      expect((error as ProvisioningError).status).toBe(422);
+      expect((error as ProvisioningError).message).toContain(
+        "POST /monitors answered 422",
+      );
+      expect((error as ProvisioningError).message).toContain(
+        "Request timeout must be less",
+      );
+    });
   });
 });

--- a/platform/app/scripts/uptime/langy-greeting-check.ts
+++ b/platform/app/scripts/uptime/langy-greeting-check.ts
@@ -33,6 +33,8 @@ export const LANGY_GREETING_WAIT_SECONDS = 90;
 
 export const LANGY_CONVERSATIONS_PATH = "/api/langy/conversations";
 
+export const REDACTED_SECRET = "<redacted>";
+
 export const GREETING_FAILURE_REASONS = [
   "not_settled",
   "turn_failed",
@@ -310,8 +312,6 @@ export async function runLangyGreetingCheck(input: {
     durationMs,
   };
 }
-
-export const REDACTED_SECRET = "<redacted>";
 
 /** An empty secret would split between every character; there is nothing to hide. */
 function scrubSecret(text: string, secret: string): string {

--- a/platform/app/scripts/uptime/langy-greeting-check.ts
+++ b/platform/app/scripts/uptime/langy-greeting-check.ts
@@ -1,0 +1,335 @@
+/**
+ * The Langy greeting check: one turn, one verdict.
+ *
+ * This is the source of truth for what the uptime monitor calls "healthy".
+ * `buildGreetingRequest` shapes the request `POST /api/langy/conversations`
+ * accepts (see `~/server/routes/langy-api.ts`), `classifyGreetingResponse`
+ * reads the answer, and `runLangyGreetingCheck` does both over a fetch.
+ *
+ * The Better Stack script next door (`langy-greeting.betterstack.js`) mirrors
+ * this module and is pinned to it by a drift test; it cannot import it because
+ * the monitor runs a pasted, self-contained file.
+ *
+ * Why a fresh idempotency key per check matters: the platform resolves a
+ * repeated key for the same project and user to the turn it already ran
+ * (`langy-turn-admission.prisma.repository.ts`), without running the assistant
+ * again. A monitor reusing a key replays its first check forever and stays
+ * green through an outage.
+ *
+ * Spec: specs/langy/langy-uptime-greeting-monitor.feature
+ */
+
+export const LANGY_GREETING_TEXT = "Hi Langy.";
+
+/**
+ * Under the 60s Better Stack request timeout the monitor is provisioned with,
+ * and well under the platform's own 120s wait ceiling: a hung turn fails the
+ * check as `not_settled` instead of the monitor timing out first.
+ */
+export const LANGY_GREETING_WAIT_SECONDS = 30;
+
+export const LANGY_CONVERSATIONS_PATH = "/api/langy/conversations";
+
+export const GREETING_FAILURE_REASONS = [
+  "not_settled",
+  "turn_failed",
+  "empty_reply",
+  "surface_dark",
+  "unauthorized",
+  "forbidden",
+  "unexpected_status",
+  "malformed_body",
+  "unreachable",
+] as const;
+
+export type GreetingFailureReason = (typeof GREETING_FAILURE_REASONS)[number];
+
+export type GreetingRequest = {
+  url: string;
+  method: "POST";
+  headers: Record<string, string>;
+  body: string;
+};
+
+export type GreetingOutcome =
+  | {
+      healthy: true;
+      status: 200;
+      conversationId: string;
+      turnId: string;
+      replyText: string;
+    }
+  | {
+      healthy: false;
+      reason: GreetingFailureReason;
+      status: number | null;
+      detail: string;
+      conversationId?: string;
+      turnId?: string;
+    };
+
+export type GreetingCheckResult = GreetingOutcome & {
+  idempotencyKey: string;
+  durationMs: number;
+};
+
+export function buildGreetingRequest(input: {
+  baseUrl: string;
+  apiKey: string;
+  idempotencyKey: string;
+}): GreetingRequest {
+  const base = input.baseUrl.replace(/\/+$/, "");
+  return {
+    url: `${base}${LANGY_CONVERSATIONS_PATH}`,
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Auth-Token": input.apiKey,
+      Prefer: `wait=${LANGY_GREETING_WAIT_SECONDS}`,
+    },
+    body: JSON.stringify({
+      messages: [{ role: "user", content: LANGY_GREETING_TEXT }],
+      idempotencyKey: input.idempotencyKey,
+    }),
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+/**
+ * Turn a status and parsed body into the one verdict the monitor alerts on.
+ *
+ * Only a 200 whose `reply.text` is a non-empty string is healthy. A 200 is
+ * also what a FAILED turn returns (the request succeeded; the turn did not),
+ * so status alone proves nothing — the body decides.
+ */
+export function classifyGreetingResponse(input: {
+  status: number;
+  body: unknown;
+}): GreetingOutcome {
+  const { status, body } = input;
+  const envelope = isRecord(body) ? body : undefined;
+  const ids = {
+    conversationId: readString(envelope?.conversationId),
+    turnId: readString(envelope?.turnId),
+  };
+
+  if (status === 200) return classifySettled(envelope, ids);
+  if (status === 202) {
+    return {
+      healthy: false,
+      reason: "not_settled",
+      status,
+      detail: `turn accepted but not settled within ${LANGY_GREETING_WAIT_SECONDS}s`,
+      ...ids,
+    };
+  }
+  return classifyRefusal(status, envelope);
+}
+
+/** A 200 is a settled turn; the body says whether the turn itself succeeded. */
+function classifySettled(
+  envelope: Record<string, unknown> | undefined,
+  ids: { conversationId?: string; turnId?: string },
+): GreetingOutcome {
+  const status = 200;
+  const { conversationId, turnId } = ids;
+  if (!envelope || !conversationId || !turnId) {
+    return {
+      healthy: false,
+      reason: "malformed_body",
+      status,
+      detail: "200 without a turn envelope (conversationId, turnId)",
+    };
+  }
+  const reply = isRecord(envelope.reply) ? envelope.reply : null;
+  const replyText = readString(reply?.text);
+  if (replyText === undefined) {
+    return {
+      healthy: false,
+      reason: "turn_failed",
+      status,
+      detail: describeTurnError(envelope),
+      conversationId,
+      turnId,
+    };
+  }
+  if (replyText.trim().length === 0) {
+    return {
+      healthy: false,
+      reason: "empty_reply",
+      status,
+      detail: "reply.text is empty",
+      conversationId,
+      turnId,
+    };
+  }
+  return { healthy: true, status, conversationId, turnId, replyText };
+}
+
+const REFUSAL_BY_STATUS: Record<
+  number,
+  { reason: GreetingFailureReason; fallback: string }
+> = {
+  404: {
+    reason: "surface_dark",
+    fallback:
+      "route answered 404: API-key turns flag off or route not deployed",
+  },
+  401: { reason: "unauthorized", fallback: "credential missing or invalid" },
+  403: {
+    reason: "forbidden",
+    fallback: "key lacks langy:create or its owner has no Langy access",
+  },
+};
+
+function classifyRefusal(
+  status: number,
+  envelope: Record<string, unknown> | undefined,
+): GreetingOutcome {
+  const known = REFUSAL_BY_STATUS[status];
+  const reason = known?.reason ?? "unexpected_status";
+  const fallback = known?.fallback ?? `unexpected status ${status}`;
+  // A dark surface's 404 body is whatever the router says; the flag is the fact.
+  const detail =
+    reason === "surface_dark"
+      ? fallback
+      : (describeErrorEnvelope(envelope) ?? fallback);
+  return { healthy: false, reason, status, detail };
+}
+
+function describeTurnError(envelope: Record<string, unknown>): string {
+  const turnStatus = readString(envelope.status) ?? "unknown";
+  const error = envelope.error;
+  const message = isRecord(error)
+    ? (readString(error.message) ?? JSON.stringify(error))
+    : readString(error);
+  return message
+    ? `turn ${turnStatus}: ${message}`
+    : `turn ${turnStatus} with no reply`;
+}
+
+function describeErrorEnvelope(
+  envelope: Record<string, unknown> | undefined,
+): string | undefined {
+  if (!envelope) return undefined;
+  const error = envelope.error;
+  if (isRecord(error)) {
+    const code = readString(error.code);
+    const message = readString(error.message);
+    if (code && message) return `${code}: ${message}`;
+    return message ?? code;
+  }
+  return readString(error) ?? readString(envelope.message);
+}
+
+export type FetchLike = (
+  url: string,
+  init: { method: string; headers: Record<string, string>; body: string },
+) => Promise<{ status: number; text(): Promise<string> }>;
+
+/**
+ * Run one check. Never throws: every way the request can go wrong is a named
+ * unhealthy outcome, because the monitor's job is to say what broke, and a
+ * thrown error says only that something did.
+ */
+export async function runLangyGreetingCheck(input: {
+  baseUrl: string;
+  apiKey: string;
+  fetch?: FetchLike;
+  mintKey?: () => string;
+  now?: () => number;
+}): Promise<GreetingCheckResult> {
+  const doFetch = input.fetch ?? (globalThis.fetch as unknown as FetchLike);
+  const mintKey = input.mintKey ?? (() => globalThis.crypto.randomUUID());
+  const now = input.now ?? (() => Date.now());
+
+  const idempotencyKey = mintKey();
+  const request = buildGreetingRequest({
+    baseUrl: input.baseUrl,
+    apiKey: input.apiKey,
+    idempotencyKey,
+  });
+  const started = now();
+
+  let status: number;
+  let text: string;
+  try {
+    const response = await doFetch(request.url, {
+      method: request.method,
+      headers: request.headers,
+      body: request.body,
+    });
+    status = response.status;
+    text = await response.text();
+  } catch (error) {
+    return {
+      healthy: false,
+      reason: "unreachable",
+      status: null,
+      detail: error instanceof Error ? error.message : String(error),
+      idempotencyKey,
+      durationMs: now() - started,
+    };
+  }
+  const durationMs = now() - started;
+
+  let body: unknown;
+  try {
+    body = JSON.parse(text);
+  } catch {
+    return {
+      healthy: false,
+      reason: "malformed_body",
+      status,
+      detail: `response body is not JSON (${text.length} bytes)`,
+      idempotencyKey,
+      durationMs,
+    };
+  }
+
+  const outcome = classifyGreetingResponse({ status, body });
+  return {
+    ...outcome,
+    // An upstream error message may echo the header it rejected; the detail
+    // lands in the monitor's incident timeline, so the key is scrubbed here,
+    // where it is known, and nowhere downstream needs to know it.
+    ...(outcome.healthy
+      ? {}
+      : { detail: outcome.detail.split(input.apiKey).join(REDACTED_SECRET) }),
+    idempotencyKey,
+    durationMs,
+  };
+}
+
+export const REDACTED_SECRET = "<redacted>";
+
+/**
+ * One log line per check. Carries ids and timing so a red check can be found
+ * in the platform; carries no credential, because this line lands in the
+ * monitor's incident timeline.
+ */
+export function formatGreetingCheckResult(result: GreetingCheckResult): string {
+  const base = {
+    healthy: result.healthy,
+    status: result.status,
+    durationMs: result.durationMs,
+    idempotencyKey: result.idempotencyKey,
+    conversationId: result.conversationId ?? null,
+    turnId: result.turnId ?? null,
+  };
+  if (result.healthy) {
+    return JSON.stringify({ ...base, replyChars: result.replyText.length });
+  }
+  return JSON.stringify({
+    ...base,
+    reason: result.reason,
+    detail: result.detail,
+  });
+}

--- a/platform/app/scripts/uptime/langy-greeting-check.ts
+++ b/platform/app/scripts/uptime/langy-greeting-check.ts
@@ -22,11 +22,14 @@
 export const LANGY_GREETING_TEXT = "Hi Langy.";
 
 /**
- * Under the 60s Better Stack request timeout the monitor is provisioned with,
- * and well under the platform's own 120s wait ceiling: a hung turn fails the
- * check as `not_settled` instead of the monitor timing out first.
+ * Every check opens a new conversation, so every check is a cold start: the
+ * worker is spawned, its home laid out and its skills loaded before the model
+ * sees the greeting, and nothing pre-warms it the way the panel does for a
+ * person. The budget is therefore most of the platform's 120s wait ceiling,
+ * while staying under the monitor's own request timeout so a hung turn fails
+ * the check as `not_settled` instead of the monitor timing out first.
  */
-export const LANGY_GREETING_WAIT_SECONDS = 30;
+export const LANGY_GREETING_WAIT_SECONDS = 90;
 
 export const LANGY_CONVERSATIONS_PATH = "/api/langy/conversations";
 
@@ -302,13 +305,18 @@ export async function runLangyGreetingCheck(input: {
     // where it is known, and nowhere downstream needs to know it.
     ...(outcome.healthy
       ? {}
-      : { detail: outcome.detail.split(input.apiKey).join(REDACTED_SECRET) }),
+      : { detail: scrubSecret(outcome.detail, input.apiKey) }),
     idempotencyKey,
     durationMs,
   };
 }
 
 export const REDACTED_SECRET = "<redacted>";
+
+/** An empty secret would split between every character; there is nothing to hide. */
+function scrubSecret(text: string, secret: string): string {
+  return secret.length === 0 ? text : text.split(secret).join(REDACTED_SECRET);
+}
 
 /**
  * One log line per check. Carries ids and timing so a red check can be found

--- a/platform/app/scripts/uptime/langy-greeting-check.ts
+++ b/platform/app/scripts/uptime/langy-greeting-check.ts
@@ -78,23 +78,49 @@ export type GreetingCheckResult = GreetingOutcome & {
   durationMs: number;
 };
 
-export function buildGreetingRequest(input: {
+/**
+ * The check sends its API key in `X-Auth-Token`, so the base URL decides
+ * whether that key crosses the network in the clear. Better Stack runs the
+ * monitor from its own cloud, so every hop is public internet; an `http://`
+ * origin would hand the key to anyone on the path. Reject the scheme here,
+ * where the header is attached, rather than trusting whoever set the variable.
+ */
+export function assertHttpsBaseUrl(baseUrl: string): void {
+  let parsed: URL;
+  try {
+    parsed = new URL(baseUrl);
+  } catch {
+    throw new Error(`baseUrl is not a valid URL: ${baseUrl}`);
+  }
+  if (parsed.protocol !== "https:") {
+    throw new Error(
+      `baseUrl must use https so the API key is not sent in the clear, got ${parsed.protocol}//`,
+    );
+  }
+}
+
+export function buildGreetingRequest({
+  baseUrl,
+  apiKey,
+  idempotencyKey,
+}: {
   baseUrl: string;
   apiKey: string;
   idempotencyKey: string;
 }): GreetingRequest {
-  const base = input.baseUrl.replace(/\/+$/, "");
+  assertHttpsBaseUrl(baseUrl);
+  const base = baseUrl.replace(/\/+$/, "");
   return {
     url: `${base}${LANGY_CONVERSATIONS_PATH}`,
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      "X-Auth-Token": input.apiKey,
+      "X-Auth-Token": apiKey,
       Prefer: `wait=${LANGY_GREETING_WAIT_SECONDS}`,
     },
     body: JSON.stringify({
       messages: [{ role: "user", content: LANGY_GREETING_TEXT }],
-      idempotencyKey: input.idempotencyKey,
+      idempotencyKey,
     }),
   };
 }
@@ -125,7 +151,7 @@ export function classifyGreetingResponse(input: {
     turnId: readString(envelope?.turnId),
   };
 
-  if (status === 200) return classifySettled(envelope, ids);
+  if (status === 200) return classifySettled({ envelope, ids });
   if (status === 202) {
     return {
       healthy: false,
@@ -135,14 +161,17 @@ export function classifyGreetingResponse(input: {
       ...ids,
     };
   }
-  return classifyRefusal(status, envelope);
+  return classifyRefusal({ status, envelope });
 }
 
 /** A 200 is a settled turn; the body says whether the turn itself succeeded. */
-function classifySettled(
-  envelope: Record<string, unknown> | undefined,
-  ids: { conversationId?: string; turnId?: string },
-): GreetingOutcome {
+function classifySettled({
+  envelope,
+  ids,
+}: {
+  envelope: Record<string, unknown> | undefined;
+  ids: { conversationId?: string; turnId?: string };
+}): GreetingOutcome {
   const status = 200;
   const { conversationId, turnId } = ids;
   if (!envelope || !conversationId || !turnId) {
@@ -194,10 +223,13 @@ const REFUSAL_BY_STATUS: Record<
   },
 };
 
-function classifyRefusal(
-  status: number,
-  envelope: Record<string, unknown> | undefined,
-): GreetingOutcome {
+function classifyRefusal({
+  status,
+  envelope,
+}: {
+  status: number;
+  envelope: Record<string, unknown> | undefined;
+}): GreetingOutcome {
   const known = REFUSAL_BY_STATUS[status];
   const reason = known?.reason ?? "unexpected_status";
   const fallback = known?.fallback ?? `unexpected status ${status}`;
@@ -307,14 +339,22 @@ export async function runLangyGreetingCheck(input: {
     // where it is known, and nowhere downstream needs to know it.
     ...(outcome.healthy
       ? {}
-      : { detail: scrubSecret(outcome.detail, input.apiKey) }),
+      : {
+          detail: scrubSecret({ text: outcome.detail, secret: input.apiKey }),
+        }),
     idempotencyKey,
     durationMs,
   };
 }
 
-/** An empty secret would split between every character; there is nothing to hide. */
-function scrubSecret(text: string, secret: string): string {
+/** An empty secret would split between every character, hiding no credential. */
+function scrubSecret({
+  text,
+  secret,
+}: {
+  text: string;
+  secret: string;
+}): string {
   return secret.length === 0 ? text : text.split(secret).join(REDACTED_SECRET);
 }
 

--- a/platform/app/scripts/uptime/langy-greeting.betterstack.js
+++ b/platform/app/scripts/uptime/langy-greeting.betterstack.js
@@ -1,0 +1,136 @@
+// Better Stack Playwright monitor: does Langy still answer a greeting?
+//
+// This file is pasted into the monitor verbatim by
+// scripts/uptime/upsert-langy-greeting-monitor.ts. It is self-contained on
+// purpose (the monitor runtime cannot import from this repo) and mirrors
+// scripts/uptime/langy-greeting-check.ts, which is the unit-tested source of
+// truth; a drift test pins the greeting, the wait and the reason names.
+//
+// Monitor environment variables (set by the provisioning script):
+//   LANGY_BASE_URL  - deployment origin, e.g. https://app.example.com
+//   LANGY_API_KEY   - a Langy user's project API key with langy:create
+//
+// Every run mints a NEW idempotency key. The platform replays a repeated key
+// for the same project and user without running the assistant, so a fixed key
+// would keep this monitor green through an outage.
+
+import { expect, test } from "@playwright/test";
+
+const GREETING = "Hi Langy.";
+const WAIT_SECONDS = 30;
+const PATH = "/api/langy/conversations";
+
+function required(name) {
+  const value = process.env[name];
+  if (!value)
+    throw new Error(`monitor environment variable ${name} is not set`);
+  return value;
+}
+
+function isRecord(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+// Same table as classifyGreetingResponse in langy-greeting-check.ts.
+// `null` means healthy.
+function settledReason(body) {
+  if (!isRecord(body) || !body.conversationId || !body.turnId)
+    return "malformed_body";
+  const reply = isRecord(body.reply) ? body.reply : null;
+  if (reply === null || typeof reply.text !== "string") return "turn_failed";
+  if (reply.text.trim().length === 0) return "empty_reply";
+  return null;
+}
+
+const REFUSAL_BY_STATUS = {
+  202: "not_settled",
+  404: "surface_dark",
+  401: "unauthorized",
+  403: "forbidden",
+};
+
+function reasonFor(status, body) {
+  if (status === 200) return settledReason(body);
+  return REFUSAL_BY_STATUS[status] ?? "unexpected_status";
+}
+
+function parseJson(text) {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+// The turn's own error, with the key scrubbed: an upstream message may echo
+// the header it rejected, and this string lands in the incident timeline.
+function detailOf(envelope, apiKey) {
+  const raw =
+    (isRecord(envelope.error) ? envelope.error.message : envelope.error) ??
+    envelope.status ??
+    null;
+  return typeof raw === "string" ? raw.split(apiKey).join("<redacted>") : raw;
+}
+
+async function postGreeting(baseUrl, apiKey, idempotencyKey) {
+  return fetch(`${baseUrl}${PATH}`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Auth-Token": apiKey,
+      Prefer: `wait=${WAIT_SECONDS}`,
+    },
+    body: JSON.stringify({
+      messages: [{ role: "user", content: GREETING }],
+      idempotencyKey,
+    }),
+  });
+}
+
+test("Langy answers a greeting", async () => {
+  const baseUrl = required("LANGY_BASE_URL").replace(/\/+$/, "");
+  const apiKey = required("LANGY_API_KEY");
+  const idempotencyKey = crypto.randomUUID();
+
+  const started = Date.now();
+  let response;
+  try {
+    response = await postGreeting(baseUrl, apiKey, idempotencyKey);
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    console.log(
+      JSON.stringify({
+        healthy: false,
+        reason: "unreachable",
+        idempotencyKey,
+        detail,
+      }),
+    );
+    throw new Error(`unreachable: ${detail}`);
+  }
+  const durationMs = Date.now() - started;
+
+  const body = parseJson(await response.text());
+  const reason = reasonFor(response.status, body);
+  const envelope = isRecord(body) ? body : {};
+  const detail = reason === null ? null : detailOf(envelope, apiKey);
+
+  // This line lands in the incident timeline: ids and timing, never the key.
+  console.log(
+    JSON.stringify({
+      healthy: reason === null,
+      reason,
+      status: response.status,
+      durationMs,
+      idempotencyKey,
+      conversationId: envelope.conversationId ?? null,
+      turnId: envelope.turnId ?? null,
+      detail,
+    }),
+  );
+
+  expect(
+    reason,
+    `langy greeting check failed: ${reason} (status ${response.status}${detail ? `, ${detail}` : ""})`,
+  ).toBeNull();
+});

--- a/platform/app/scripts/uptime/langy-greeting.betterstack.js
+++ b/platform/app/scripts/uptime/langy-greeting.betterstack.js
@@ -90,12 +90,13 @@ async function postGreeting(baseUrl, apiKey, idempotencyKey) {
   });
 }
 
-// Playwright's default per-test timeout is 30s, shorter than the wait. The
-// test must outlive the server-side wait plus transport, or a slow cold start
-// fails as a test timeout instead of a named reason.
-test.setTimeout((WAIT_SECONDS + 20) * 1000);
-
 test("Langy answers a greeting", async () => {
+  // Playwright's default per-test timeout is 30s, shorter than the wait. The
+  // test must outlive the server-side wait plus transport, or a slow cold start
+  // fails as a test timeout instead of a named reason. Set inside the test
+  // body, the one placement Playwright documents.
+  test.setTimeout((WAIT_SECONDS + 20) * 1000);
+
   const baseUrl = required("LANGY_BASE_URL").replace(/\/+$/, "");
   const apiKey = required("LANGY_API_KEY");
   const idempotencyKey = randomUUID();

--- a/platform/app/scripts/uptime/langy-greeting.betterstack.js
+++ b/platform/app/scripts/uptime/langy-greeting.betterstack.js
@@ -14,10 +14,11 @@
 // for the same project and user without running the assistant, so a fixed key
 // would keep this monitor green through an outage.
 
+import { randomUUID } from "node:crypto";
 import { expect, test } from "@playwright/test";
 
 const GREETING = "Hi Langy.";
-const WAIT_SECONDS = 30;
+const WAIT_SECONDS = 90;
 const PATH = "/api/langy/conversations";
 
 function required(name) {
@@ -69,7 +70,9 @@ function detailOf(envelope, apiKey) {
     (isRecord(envelope.error) ? envelope.error.message : envelope.error) ??
     envelope.status ??
     null;
-  return typeof raw === "string" ? raw.split(apiKey).join("<redacted>") : raw;
+  return typeof raw === "string" && apiKey.length > 0
+    ? raw.split(apiKey).join("<redacted>")
+    : raw;
 }
 
 async function postGreeting(baseUrl, apiKey, idempotencyKey) {
@@ -90,7 +93,7 @@ async function postGreeting(baseUrl, apiKey, idempotencyKey) {
 test("Langy answers a greeting", async () => {
   const baseUrl = required("LANGY_BASE_URL").replace(/\/+$/, "");
   const apiKey = required("LANGY_API_KEY");
-  const idempotencyKey = crypto.randomUUID();
+  const idempotencyKey = randomUUID();
 
   const started = Date.now();
   let response;

--- a/platform/app/scripts/uptime/langy-greeting.betterstack.js
+++ b/platform/app/scripts/uptime/langy-greeting.betterstack.js
@@ -28,6 +28,24 @@ function required(name) {
   return value;
 }
 
+// Mirrors assertHttpsBaseUrl in langy-greeting-check.ts. The API key rides in
+// an X-Auth-Token header from Better Stack's cloud, so an http:// origin would
+// put the key on the wire in the clear on every check.
+function requiredHttpsBaseUrl(name) {
+  const value = required(name);
+  let parsed;
+  try {
+    parsed = new URL(value);
+  } catch {
+    throw new Error(`${name} is not a valid URL: ${value}`);
+  }
+  if (parsed.protocol !== "https:")
+    throw new Error(
+      `${name} must use https so the API key is not sent in the clear, got ${parsed.protocol}//`,
+    );
+  return value;
+}
+
 function isRecord(value) {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -97,7 +115,7 @@ test("Langy answers a greeting", async () => {
   // body, the one placement Playwright documents.
   test.setTimeout((WAIT_SECONDS + 20) * 1000);
 
-  const baseUrl = required("LANGY_BASE_URL").replace(/\/+$/, "");
+  const baseUrl = requiredHttpsBaseUrl("LANGY_BASE_URL").replace(/\/+$/, "");
   const apiKey = required("LANGY_API_KEY");
   const idempotencyKey = randomUUID();
 

--- a/platform/app/scripts/uptime/langy-greeting.betterstack.js
+++ b/platform/app/scripts/uptime/langy-greeting.betterstack.js
@@ -90,6 +90,11 @@ async function postGreeting(baseUrl, apiKey, idempotencyKey) {
   });
 }
 
+// Playwright's default per-test timeout is 30s, shorter than the wait. The
+// test must outlive the server-side wait plus transport, or a slow cold start
+// fails as a test timeout instead of a named reason.
+test.setTimeout((WAIT_SECONDS + 20) * 1000);
+
 test("Langy answers a greeting", async () => {
   const baseUrl = required("LANGY_BASE_URL").replace(/\/+$/, "");
   const apiKey = required("LANGY_API_KEY");

--- a/platform/app/scripts/uptime/upsert-langy-greeting-monitor.ts
+++ b/platform/app/scripts/uptime/upsert-langy-greeting-monitor.ts
@@ -21,6 +21,7 @@
 import { readFileSync, realpathSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { assertHttpsBaseUrl } from "./langy-greeting-check";
 
 export const BETTERSTACK_API_BASE = "https://uptime.betterstack.com/api/v2";
 export const BETTERSTACK_REGIONS = ["us", "eu", "as", "au"] as const;
@@ -60,10 +61,13 @@ export class ProvisioningError extends Error {
   }
 }
 
-export function buildMonitorPayload(
-  config: MonitorConfig,
-  script: string,
-): MonitorPayload {
+export function buildMonitorPayload({
+  config,
+  script,
+}: {
+  config: MonitorConfig;
+  script: string;
+}): MonitorPayload {
   if (!(BETTERSTACK_REGIONS as readonly string[]).includes(config.region)) {
     throw new ProvisioningError(
       `region "${config.region}" is not one of ${BETTERSTACK_REGIONS.join(", ")}`,
@@ -79,6 +83,15 @@ export function buildMonitorPayload(
   }
   if (!config.langyBaseUrl || !config.langyApiKey) {
     throw new ProvisioningError("langyBaseUrl and langyApiKey are required");
+  }
+  // The key is stored on the monitor and sent as a header from Better Stack's
+  // cloud on every check, so an http:// origin leaks it on every check forever.
+  try {
+    assertHttpsBaseUrl(config.langyBaseUrl);
+  } catch (error) {
+    throw new ProvisioningError(
+      error instanceof Error ? error.message : String(error),
+    );
   }
   if (!script.trim()) {
     throw new ProvisioningError("monitor script is empty");
@@ -131,7 +144,13 @@ function parseJson(text: string): unknown {
   }
 }
 
-function describeApiError(parsed: unknown, text: string): string {
+function describeApiError({
+  parsed,
+  text,
+}: {
+  parsed: unknown;
+  text: string;
+}): string {
   return parsed && typeof parsed === "object" && "errors" in parsed
     ? JSON.stringify((parsed as { errors: unknown }).errors)
     : text.slice(0, 300);
@@ -139,10 +158,13 @@ function describeApiError(parsed: unknown, text: string): string {
 
 /** The Better Stack Uptime API, bound to one token. */
 class UptimeApi {
-  constructor(
-    private readonly fetch: ApiFetch,
-    private readonly token: string,
-  ) {}
+  private readonly fetch: ApiFetch;
+  private readonly token: string;
+
+  constructor({ fetch, token }: { fetch: ApiFetch; token: string }) {
+    this.fetch = fetch;
+    this.token = token;
+  }
 
   async call({ method, path, body }: ApiCall): Promise<unknown> {
     const response = await this.fetch(`${BETTERSTACK_API_BASE}${path}`, {
@@ -157,7 +179,7 @@ class UptimeApi {
     const parsed = parseJson(text);
     if (response.status < 200 || response.status >= 300) {
       throw new ProvisioningError(
-        `${method} ${path} answered ${response.status}: ${describeApiError(parsed, text)}`,
+        `${method} ${path} answered ${response.status}: ${describeApiError({ parsed, text })}`,
         response.status,
       );
     }
@@ -165,10 +187,13 @@ class UptimeApi {
   }
 
   /** Exact-name matches only: the API's filter is a match, not an equality. */
-  async findMonitorsByName(
-    name: string,
-    teamName?: string,
-  ): Promise<MonitorRow[]> {
+  async findMonitorsByName({
+    name,
+    teamName,
+  }: {
+    name: string;
+    teamName?: string;
+  }): Promise<MonitorRow[]> {
     const query = new URLSearchParams({ pronounceable_name: name });
     if (teamName) query.set("team_name", teamName);
     const found: MonitorRow[] = [];
@@ -201,14 +226,17 @@ export async function upsertMonitor(input: {
   token: string;
   config: MonitorConfig;
   script: string;
-  dryRun: boolean;
+  isDryRun: boolean;
   log: (line: string) => void;
 }): Promise<UpsertResult> {
-  const payload = buildMonitorPayload(input.config, input.script);
-  const api = new UptimeApi(input.fetch, input.token);
-  const current = await findTheOneMonitor(api, input.config);
+  const payload = buildMonitorPayload({
+    config: input.config,
+    script: input.script,
+  });
+  const api = new UptimeApi({ fetch: input.fetch, token: input.token });
+  const current = await findTheOneMonitor({ api, config: input.config });
 
-  if (input.dryRun) {
+  if (input.isDryRun) {
     input.log(
       `dry run: would ${current ? `update monitor ${current.id}` : "create a monitor"} with`,
     );
@@ -233,11 +261,17 @@ export async function upsertMonitor(input: {
 }
 
 /** Zero or one monitor by name; two is an error, because guessing is worse. */
-async function findTheOneMonitor(
-  api: UptimeApi,
-  config: MonitorConfig,
-): Promise<MonitorRow | null> {
-  const existing = await api.findMonitorsByName(config.name, config.teamName);
+async function findTheOneMonitor({
+  api,
+  config,
+}: {
+  api: UptimeApi;
+  config: MonitorConfig;
+}): Promise<MonitorRow | null> {
+  const existing = await api.findMonitorsByName({
+    name: config.name,
+    teamName: config.teamName,
+  });
   if (existing.length > 1) {
     throw new ProvisioningError(
       `${existing.length} monitors are named "${config.name}" (ids ${existing.map((m) => m.id).join(", ")}); rename or delete until one remains`,
@@ -276,14 +310,14 @@ export function readMonitorScript(): string {
 }
 
 async function main(): Promise<void> {
-  const dryRun = process.argv.includes("--dry-run");
+  const isDryRun = process.argv.includes("--dry-run");
   const token = requiredEnv("BETTERSTACK_API_TOKEN");
   const result = await upsertMonitor({
     fetch: globalThis.fetch as unknown as ApiFetch,
     token,
     config: configFromEnv(),
     script: readMonitorScript(),
-    dryRun,
+    isDryRun,
     log: (line) => console.log(line),
   });
   if (result.action !== "dry-run" && !result.id) {

--- a/platform/app/scripts/uptime/upsert-langy-greeting-monitor.ts
+++ b/platform/app/scripts/uptime/upsert-langy-greeting-monitor.ts
@@ -19,7 +19,7 @@
  */
 
 import { readFileSync, realpathSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
 export const BETTERSTACK_API_BASE = "https://uptime.betterstack.com/api/v2";
@@ -291,11 +291,39 @@ async function main(): Promise<void> {
   }
 }
 
-const invokedDirectly =
-  process.argv[1] !== undefined &&
-  import.meta.url === pathToFileURL(realpathSync(process.argv[1])).href;
+/**
+ * A plain compare of argv[1] against import.meta.url is fail-open through a
+ * symlink (a .bin shim, a worktree linked into place): the guard declines to
+ * run and the process exits 0 having provisioned nothing. Both sides are
+ * resolved through realpathSync; a path that does not exist falls back to its
+ * lexical form so it stays a mismatch rather than a crash.
+ */
+export function isEntryModule({
+  invokedPath,
+  modulePath,
+}: {
+  invokedPath: string | undefined;
+  modulePath: string;
+}): boolean {
+  if (invokedPath === undefined) return false;
+  return realPathOrResolved(invokedPath) === realPathOrResolved(modulePath);
+}
 
-if (invokedDirectly) {
+function realPathOrResolved(p: string): string {
+  const abs = resolve(p);
+  try {
+    return realpathSync(abs);
+  } catch {
+    return abs;
+  }
+}
+
+if (
+  isEntryModule({
+    invokedPath: process.argv[1],
+    modulePath: fileURLToPath(import.meta.url),
+  })
+) {
   main().catch((error: unknown) => {
     const message = error instanceof Error ? error.message : String(error);
     console.error(`upsert-langy-greeting-monitor: ${message}`);

--- a/platform/app/scripts/uptime/upsert-langy-greeting-monitor.ts
+++ b/platform/app/scripts/uptime/upsert-langy-greeting-monitor.ts
@@ -24,7 +24,7 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 
 export const BETTERSTACK_API_BASE = "https://uptime.betterstack.com/api/v2";
 export const BETTERSTACK_REGIONS = ["us", "eu", "as", "au"] as const;
-export const MONITOR_REQUEST_TIMEOUT_SECONDS = 60;
+export const MONITOR_REQUEST_TIMEOUT_SECONDS = 120;
 export const DEFAULT_MONITOR_NAME = "Langy greeting";
 export const DEFAULT_CHECK_FREQUENCY_SECONDS = 180;
 export const REDACTED = "<redacted>";

--- a/platform/app/scripts/uptime/upsert-langy-greeting-monitor.ts
+++ b/platform/app/scripts/uptime/upsert-langy-greeting-monitor.ts
@@ -1,0 +1,304 @@
+/**
+ * Create or update the Better Stack monitor that greets Langy.
+ *
+ *   BETTERSTACK_API_TOKEN=... LANGY_BASE_URL=https://app.example.com \
+ *   LANGY_API_KEY=... npx tsx scripts/uptime/upsert-langy-greeting-monitor.ts [--dry-run]
+ *
+ * Idempotent: the monitor is looked up by name; one match is updated in place,
+ * none is created, more than one is an error. The monitor's script is read from
+ * `langy-greeting.betterstack.js` next to this file, so the monitor never drifts
+ * from the repo by hand-editing in the dashboard.
+ *
+ * Optional environment:
+ *   BETTERSTACK_MONITOR_NAME            default "Langy greeting"
+ *   BETTERSTACK_REGION                  one of us, eu, as, au; default eu
+ *   BETTERSTACK_CHECK_FREQUENCY_SECONDS default 180
+ *   BETTERSTACK_TEAM_NAME               required only with a global API token
+ *
+ * Spec: specs/langy/langy-uptime-greeting-monitor.feature
+ */
+
+import { readFileSync, realpathSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+export const BETTERSTACK_API_BASE = "https://uptime.betterstack.com/api/v2";
+export const BETTERSTACK_REGIONS = ["us", "eu", "as", "au"] as const;
+export const MONITOR_REQUEST_TIMEOUT_SECONDS = 60;
+export const DEFAULT_MONITOR_NAME = "Langy greeting";
+export const DEFAULT_CHECK_FREQUENCY_SECONDS = 180;
+export const REDACTED = "<redacted>";
+
+export type MonitorConfig = {
+  name: string;
+  region: string;
+  checkFrequencySeconds: number;
+  langyBaseUrl: string;
+  langyApiKey: string;
+  teamName?: string;
+};
+
+export type MonitorPayload = {
+  monitor_type: "playwright";
+  pronounceable_name: string;
+  scenario_name: string;
+  playwright_script: string;
+  environment_variables: { LANGY_BASE_URL: string; LANGY_API_KEY: string };
+  regions: string[];
+  request_timeout: number;
+  check_frequency: number;
+  team_name?: string;
+};
+
+export class ProvisioningError extends Error {
+  constructor(
+    message: string,
+    readonly status?: number,
+  ) {
+    super(message);
+    this.name = "ProvisioningError";
+  }
+}
+
+export function buildMonitorPayload(
+  config: MonitorConfig,
+  script: string,
+): MonitorPayload {
+  if (!(BETTERSTACK_REGIONS as readonly string[]).includes(config.region)) {
+    throw new ProvisioningError(
+      `region "${config.region}" is not one of ${BETTERSTACK_REGIONS.join(", ")}`,
+    );
+  }
+  if (!Number.isInteger(config.checkFrequencySeconds)) {
+    throw new ProvisioningError("checkFrequencySeconds must be an integer");
+  }
+  if (config.checkFrequencySeconds < MONITOR_REQUEST_TIMEOUT_SECONDS) {
+    throw new ProvisioningError(
+      `checkFrequencySeconds (${config.checkFrequencySeconds}) must be at least the request timeout (${MONITOR_REQUEST_TIMEOUT_SECONDS})`,
+    );
+  }
+  if (!config.langyBaseUrl || !config.langyApiKey) {
+    throw new ProvisioningError("langyBaseUrl and langyApiKey are required");
+  }
+  if (!script.trim()) {
+    throw new ProvisioningError("monitor script is empty");
+  }
+  return {
+    monitor_type: "playwright",
+    pronounceable_name: config.name,
+    scenario_name: config.name,
+    playwright_script: script,
+    environment_variables: {
+      LANGY_BASE_URL: config.langyBaseUrl,
+      LANGY_API_KEY: config.langyApiKey,
+    },
+    // One region on purpose: every check is a real assistant turn, and
+    // regions would multiply the load and the noise for no extra signal.
+    regions: [config.region],
+    request_timeout: MONITOR_REQUEST_TIMEOUT_SECONDS,
+    check_frequency: config.checkFrequencySeconds,
+    ...(config.teamName ? { team_name: config.teamName } : {}),
+  };
+}
+
+export function redactPayload(
+  payload: MonitorPayload,
+): Record<string, unknown> {
+  return {
+    ...payload,
+    environment_variables: {
+      ...payload.environment_variables,
+      LANGY_API_KEY: REDACTED,
+    },
+    playwright_script: `<${payload.playwright_script.length} chars from langy-greeting.betterstack.js>`,
+  };
+}
+
+export type ApiFetch = (
+  url: string,
+  init: { method: string; headers: Record<string, string>; body?: string },
+) => Promise<{ status: number; text(): Promise<string> }>;
+
+type MonitorRow = { id: string; attributes?: { pronounceable_name?: string } };
+
+type ApiCall = { method: string; path: string; body?: unknown };
+
+function parseJson(text: string): unknown {
+  try {
+    return text ? JSON.parse(text) : null;
+  } catch {
+    return null;
+  }
+}
+
+function describeApiError(parsed: unknown, text: string): string {
+  return parsed && typeof parsed === "object" && "errors" in parsed
+    ? JSON.stringify((parsed as { errors: unknown }).errors)
+    : text.slice(0, 300);
+}
+
+/** The Better Stack Uptime API, bound to one token. */
+class UptimeApi {
+  constructor(
+    private readonly fetch: ApiFetch,
+    private readonly token: string,
+  ) {}
+
+  async call({ method, path, body }: ApiCall): Promise<unknown> {
+    const response = await this.fetch(`${BETTERSTACK_API_BASE}${path}`, {
+      method,
+      headers: {
+        Authorization: `Bearer ${this.token}`,
+        "Content-Type": "application/json",
+      },
+      ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+    });
+    const text = await response.text();
+    const parsed = parseJson(text);
+    if (response.status < 200 || response.status >= 300) {
+      throw new ProvisioningError(
+        `${method} ${path} answered ${response.status}: ${describeApiError(parsed, text)}`,
+        response.status,
+      );
+    }
+    return parsed;
+  }
+
+  /** Exact-name matches only: the API's filter is a match, not an equality. */
+  async findMonitorsByName(
+    name: string,
+    teamName?: string,
+  ): Promise<MonitorRow[]> {
+    const query = new URLSearchParams({ pronounceable_name: name });
+    if (teamName) query.set("team_name", teamName);
+    const found: MonitorRow[] = [];
+    let path: string | null = `/monitors?${query.toString()}`;
+    while (path) {
+      const page = (await this.call({ method: "GET", path })) as {
+        data?: MonitorRow[];
+        pagination?: { next?: string | null };
+      };
+      found.push(
+        ...(page.data ?? []).filter(
+          (row) => row.attributes?.pronounceable_name === name,
+        ),
+      );
+      const next = page.pagination?.next ?? null;
+      path = next ? next.replace(BETTERSTACK_API_BASE, "") : null;
+    }
+    return found;
+  }
+}
+
+export type UpsertResult = {
+  action: "created" | "updated" | "dry-run";
+  id: string | null;
+  dashboardUrl: string | null;
+};
+
+export async function upsertMonitor(input: {
+  fetch: ApiFetch;
+  token: string;
+  config: MonitorConfig;
+  script: string;
+  dryRun: boolean;
+  log: (line: string) => void;
+}): Promise<UpsertResult> {
+  const payload = buildMonitorPayload(input.config, input.script);
+  const api = new UptimeApi(input.fetch, input.token);
+  const current = await findTheOneMonitor(api, input.config);
+
+  if (input.dryRun) {
+    input.log(
+      `dry run: would ${current ? `update monitor ${current.id}` : "create a monitor"} with`,
+    );
+    input.log(JSON.stringify(redactPayload(payload), null, 2));
+    return { action: "dry-run", id: current?.id ?? null, dashboardUrl: null };
+  }
+
+  const write: ApiCall = current
+    ? { method: "PATCH", path: `/monitors/${current.id}`, body: payload }
+    : { method: "POST", path: "/monitors", body: payload };
+  const written = (await api.call(write)) as { data?: { id?: string } };
+  const id = written.data?.id ?? current?.id ?? null;
+  const dashboardUrl = id
+    ? `https://uptime.betterstack.com/team/monitors/${id}`
+    : null;
+  const action = current ? "updated" : "created";
+  input.log(
+    `${action} monitor ${id ?? "?"} (${input.config.name}) in region ${input.config.region}`,
+  );
+  if (dashboardUrl) input.log(dashboardUrl);
+  return { action, id, dashboardUrl };
+}
+
+/** Zero or one monitor by name; two is an error, because guessing is worse. */
+async function findTheOneMonitor(
+  api: UptimeApi,
+  config: MonitorConfig,
+): Promise<MonitorRow | null> {
+  const existing = await api.findMonitorsByName(config.name, config.teamName);
+  if (existing.length > 1) {
+    throw new ProvisioningError(
+      `${existing.length} monitors are named "${config.name}" (ids ${existing.map((m) => m.id).join(", ")}); rename or delete until one remains`,
+    );
+  }
+  return existing[0] ?? null;
+}
+
+function requiredEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new ProvisioningError(`${name} is not set`);
+  return value;
+}
+
+export function configFromEnv(
+  env: NodeJS.ProcessEnv = process.env,
+): MonitorConfig {
+  const frequencyRaw = env.BETTERSTACK_CHECK_FREQUENCY_SECONDS;
+  return {
+    name: env.BETTERSTACK_MONITOR_NAME || DEFAULT_MONITOR_NAME,
+    region: env.BETTERSTACK_REGION || "eu",
+    checkFrequencySeconds: frequencyRaw
+      ? Number(frequencyRaw)
+      : DEFAULT_CHECK_FREQUENCY_SECONDS,
+    langyBaseUrl: env.LANGY_BASE_URL ?? "",
+    langyApiKey: env.LANGY_API_KEY ?? "",
+    ...(env.BETTERSTACK_TEAM_NAME
+      ? { teamName: env.BETTERSTACK_TEAM_NAME }
+      : {}),
+  };
+}
+
+export function readMonitorScript(): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+  return readFileSync(join(here, "langy-greeting.betterstack.js"), "utf8");
+}
+
+async function main(): Promise<void> {
+  const dryRun = process.argv.includes("--dry-run");
+  const token = requiredEnv("BETTERSTACK_API_TOKEN");
+  const result = await upsertMonitor({
+    fetch: globalThis.fetch as unknown as ApiFetch,
+    token,
+    config: configFromEnv(),
+    script: readMonitorScript(),
+    dryRun,
+    log: (line) => console.log(line),
+  });
+  if (result.action !== "dry-run" && !result.id) {
+    throw new ProvisioningError("monitor written but no id came back");
+  }
+}
+
+const invokedDirectly =
+  process.argv[1] !== undefined &&
+  import.meta.url === pathToFileURL(realpathSync(process.argv[1])).href;
+
+if (invokedDirectly) {
+  main().catch((error: unknown) => {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`upsert-langy-greeting-monitor: ${message}`);
+    process.exit(1);
+  });
+}

--- a/platform/app/scripts/uptime/upsert-langy-greeting-monitor.ts
+++ b/platform/app/scripts/uptime/upsert-langy-greeting-monitor.ts
@@ -20,7 +20,7 @@
 
 import { readFileSync, realpathSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
-import { fileURLToPath, pathToFileURL } from "node:url";
+import { fileURLToPath } from "node:url";
 
 export const BETTERSTACK_API_BASE = "https://uptime.betterstack.com/api/v2";
 export const BETTERSTACK_REGIONS = ["us", "eu", "as", "au"] as const;

--- a/specs/langy/langy-uptime-greeting-monitor.feature
+++ b/specs/langy/langy-uptime-greeting-monitor.feature
@@ -1,0 +1,213 @@
+Feature: An uptime monitor that proves Langy answers a greeting
+
+  The status page needs one question answered on a schedule: can the assistant
+  still reply? An external monitor (Better Stack) answers it by starting a real
+  Langy turn itself — `POST /api/langy/conversations` with a project API key,
+  a fixed greeting, and `Prefer: wait=<seconds>` so the reply comes back in the
+  same response. Nothing in the platform is added for this: the surface already
+  exists (langy-api-key-turns.feature), and the monitor is the client.
+
+  The one thing a plain HTTP monitor cannot do is the reason this is a scripted
+  monitor. Every turn request must carry an `idempotencyKey`, and the platform
+  resolves a repeated key for the same project and user to the turn it already
+  ran — without running the assistant again. A monitor that sends the same body
+  every check therefore replays check one forever and stays green through an
+  outage. The check must mint a key no earlier check used, which only a script
+  can do.
+
+  The check is two pieces: a pure module that builds the request and classifies
+  the response (unit-tested, the source of truth for what "healthy" means), and
+  the Better Stack script that is pasted into the monitor and mirrors it. A
+  provisioning script creates or updates the monitor from that file, so the
+  monitor in Better Stack never drifts from the repo by hand-editing.
+
+  # ---------------------------------------------------------------------------
+  # The request
+  # ---------------------------------------------------------------------------
+
+  @unit
+  Scenario: Every check starts a turn no earlier check could have started
+    Given two consecutive checks against the same deployment with the same key
+    When each builds its greeting request
+    Then the two requests carry different idempotency keys
+    And the key is not derived from the greeting, the time, or the credential
+
+  @unit
+  Scenario: The request is the plain-text turn shape with a bounded wait
+    Given a deployment base URL and a Langy user API key
+    When the greeting request is built
+    Then it posts to the conversation-start route of the deployment
+    And it authenticates with the key in the X-Auth-Token header
+    And it asks for synchronous delivery with a wait under the monitor's timeout
+    And the body is one user message carrying the fixed greeting as plain text
+
+  @unit
+  Scenario: A trailing slash on the base URL does not double the path
+    Given a base URL ending in a slash
+    When the greeting request is built
+    Then the request URL has exactly one slash between host and path
+
+  # ---------------------------------------------------------------------------
+  # Classifying the answer — healthy means one thing only
+  # ---------------------------------------------------------------------------
+
+  @unit
+  Scenario: A settled turn with reply text is healthy
+    Given a 200 response whose body carries a settled turn and a non-empty reply text
+    When the response is classified
+    Then the check is healthy
+    And it carries the conversation id, turn id, and reply text for the check log
+
+  @unit
+  Scenario: A settled turn that failed is unhealthy even though the transport said 200
+    Given a 200 response whose body has a failed turn status and a null reply
+    When the response is classified
+    Then the check is unhealthy with reason turn_failed
+    And the turn's own error is carried as the detail
+
+  @unit
+  Scenario: A reply with no text is not a reply
+    Given a 200 response whose reply text is empty or whitespace
+    When the response is classified
+    Then the check is unhealthy with reason empty_reply
+
+  @unit
+  Scenario: An accepted turn that did not settle inside the wait is unhealthy
+    Given a 202 response carrying only the accepted turn's ids
+    When the response is classified
+    Then the check is unhealthy with reason not_settled
+    And the accepted turn's ids are carried so the run can be found afterwards
+
+  @unit
+  Scenario: A dark surface is named, not mistaken for an outage of the assistant
+    Given a 404 response
+    When the response is classified
+    Then the check is unhealthy with reason surface_dark
+
+  @unit
+  Scenario: A refused credential is named by which gate refused it
+    Given a 401 response
+    When the response is classified
+    Then the check is unhealthy with reason unauthorized
+    Given a 403 response instead
+    When the response is classified
+    Then the check is unhealthy with reason forbidden
+
+  @unit
+  Scenario: Any other status is unhealthy and keeps the status for the alert
+    Given a response with a status the contract does not define, such as 500 or 429
+    When the response is classified
+    Then the check is unhealthy with reason unexpected_status
+    And the numeric status is carried
+
+  @unit
+  Scenario: A body that is not the turn envelope is unhealthy, whatever the status
+    Given a 200 response whose body is not a JSON object with the turn fields
+    When the response is classified
+    Then the check is unhealthy with reason malformed_body
+
+  # ---------------------------------------------------------------------------
+  # Running the check end to end
+  # ---------------------------------------------------------------------------
+
+  @unit
+  Scenario: A network failure is unhealthy with the cause, not a crash
+    Given the deployment cannot be reached
+    When the check runs
+    Then the check is unhealthy with reason unreachable
+    And the failure message is carried as the detail
+
+  @unit
+  Scenario: A non-JSON response body is unhealthy with reason malformed_body
+    Given the deployment answers 200 with a body that is not JSON
+    When the check runs
+    Then the check is unhealthy with reason malformed_body
+
+  @unit
+  Scenario: The check reports how long the turn took and which key it used
+    Given a deployment that answers healthily
+    When the check runs
+    Then the outcome carries the elapsed milliseconds
+    And the idempotency key it minted, so the turn can be found in the platform
+
+  @unit
+  Scenario: The credential never appears in the check's output
+    Given a check run with a known API key
+    When the outcome is formatted for the check log
+    Then the formatted line does not contain the key
+
+  # ---------------------------------------------------------------------------
+  # The Better Stack script mirrors the module
+  # ---------------------------------------------------------------------------
+
+  @unit
+  Scenario: The pasted script cannot drift from the check module
+    Given the Better Stack script file in the repo
+    Then it sends the same greeting text and the same wait as the module
+    And it names every failure reason the module can produce
+    And it mints its idempotency key with a random UUID per run
+
+  # ---------------------------------------------------------------------------
+  # Provisioning the monitor idempotently
+  # ---------------------------------------------------------------------------
+
+  @unit
+  Scenario: The monitor payload is a single-region Playwright monitor bounded under its own frequency
+    Given the provisioning configuration
+    When the monitor payload is built
+    Then the monitor type is playwright and the script is the repo's script file
+    And the base URL and API key travel as monitor environment variables, not in the script
+    And exactly one region is set
+    And the request timeout does not exceed the check frequency
+
+  @unit
+  Scenario: An unknown region or a timeout above the frequency is refused before any API call
+    Given a configuration with a region outside Better Stack's set, or a timeout above the frequency
+    When the monitor payload is built
+    Then provisioning fails with a message naming the field
+
+  @unit
+  Scenario: A monitor that does not exist yet is created
+    Given no monitor with the configured name exists
+    When provisioning runs
+    Then one monitor is created with the payload
+    And the result names the action as created and carries the monitor id
+
+  @unit
+  Scenario: A monitor that already exists is updated in place, never duplicated
+    Given a monitor with the configured name exists
+    When provisioning runs
+    Then that monitor is updated with the payload
+    And no monitor is created
+
+  @unit
+  Scenario: Two monitors with the configured name is an error, not a coin flip
+    Given two monitors carry the configured name
+    When provisioning runs
+    Then provisioning fails naming the ambiguity
+    And nothing is written
+
+  @unit
+  Scenario: A dry run shows the payload with the credential redacted and writes nothing
+    Given provisioning is invoked as a dry run
+    When it runs
+    Then the payload is printed with the API key replaced by a placeholder
+    And no create or update request is sent
+
+  @unit
+  Scenario: A refusal from the monitoring API surfaces its status and message
+    Given the monitoring API answers a write with a 4xx and an error body
+    When provisioning runs
+    Then provisioning fails carrying that status and message
+
+  # ---------------------------------------------------------------------------
+  # Live proof
+  # ---------------------------------------------------------------------------
+
+  @e2e @unimplemented
+  Scenario: The provisioned monitor proves a deployed Langy answers, and pages when it cannot
+    Given the monitor is provisioned against a deployment with the flag on and a cohort user's key
+    When it runs on its schedule
+    Then each check starts a new turn visible in that project's Langy history
+    And a check is healthy within the monitor's timeout
+    And a check against a stopped Langy worker is unhealthy with reason not_settled

--- a/specs/langy/langy-uptime-greeting-monitor.feature
+++ b/specs/langy/langy-uptime-greeting-monitor.feature
@@ -47,6 +47,22 @@ Feature: An uptime monitor that proves Langy answers a greeting
     When the greeting request is built
     Then the request URL has exactly one slash between host and path
 
+  # The credential travels in a header on every check, from a monitor that runs
+  # outside the deployment. A plaintext origin would publish it on every check.
+
+  @unit
+  Scenario: A plaintext base URL is refused before the key is attached
+    Given a base URL whose scheme is not https
+    When the greeting request is built
+    Then the build fails saying the base URL must use https
+    And no request carrying the credential is produced
+
+  @unit
+  Scenario: A base URL that is not a URL at all is refused by name
+    Given a base URL that does not parse as a URL
+    When the greeting request is built
+    Then the build fails saying the base URL is not a valid URL
+
   # ---------------------------------------------------------------------------
   # Classifying the answer — healthy means one thing only
   # ---------------------------------------------------------------------------

--- a/specs/langy/langy-uptime-greeting-monitor.feature
+++ b/specs/langy/langy-uptime-greeting-monitor.feature
@@ -146,6 +146,7 @@ Feature: An uptime monitor that proves Langy answers a greeting
     Then it sends the same greeting text and the same wait as the module
     And it names every failure reason the module can produce
     And it mints its idempotency key with a random UUID per run
+    And it raises the Playwright test timeout past the wait, so a slow turn fails with a named reason rather than a test timeout
 
   # ---------------------------------------------------------------------------
   # Provisioning the monitor idempotently


### PR DESCRIPTION
# Related Issue

- Resolves #7944

Closes #7944

A Better Stack Playwright monitor that starts a real Langy turn every few minutes and pages when there is no reply. No platform code changes: the monitor is a client of `POST /api/langy/conversations`, the surface from #7188. The scenario-proxy design in the issue body is replaced by this direct call; the reasoning is in the issue comment.

## Why scripted, not a plain HTTP monitor

Every turn request needs an `idempotencyKey`, and Langy resolves a repeated key for the same project and user to the turn it already ran, without running the assistant again. A fixed body would replay check one forever and stay green through an outage. The script mints a new UUID per run.

## What is in the PR

- `specs/langy/langy-uptime-greeting-monitor.feature`: 24 scenarios, 23 bound, 1 `@e2e @unimplemented` (live proof).
- `platform/app/scripts/uptime/langy-greeting-check.ts`: request builder and response classifier. Healthy only on 200 with non-empty `reply.text`. Nine named failure reasons: `not_settled` (202), `turn_failed` (200 with `reply: null`), `empty_reply`, `surface_dark` (404), `unauthorized`, `forbidden`, `unexpected_status`, `malformed_body`, `unreachable`. Never throws, never logs the key (an upstream error echoing it is scrubbed).
- `platform/app/scripts/uptime/langy-greeting.betterstack.js`: the self-contained script the monitor runs. A drift test pins its greeting, wait, path, header and reason names to the module.
- `platform/app/scripts/uptime/upsert-langy-greeting-monitor.ts`: idempotent provisioning. Finds the monitor by name, creates or PATCHes in place, refuses two same-name monitors, `--dry-run` prints the payload with the key redacted. Single region, 120s request timeout, 90s greeting wait, 180s check frequency by default.
- `docs/self-hosting/langy/uptime-monitoring.mdx`: setup (project, cohort user, `langy:create` key, flag), provisioning, and what each red reason means.

## Deployment Impact

- **Environment variables:** the platform gains none. The two scripts read their own, and only when an operator runs them by hand: `BETTERSTACK_API_TOKEN`, `LANGY_BASE_URL`, `LANGY_API_KEY`, plus the optional `BETTERSTACK_MONITOR_NAME`, `BETTERSTACK_REGION`, `BETTERSTACK_CHECK_FREQUENCY_SECONDS` and `BETTERSTACK_TEAM_NAME`. No running service reads any of them, and the Langy key is stored as a Better Stack monitor variable rather than in the repository.
- **Helm values:** none added or changed. No chart, image, manifest or `.env.example` entry is touched.
- **Default `helm install` with no overrides:** unchanged. The monitor exists only once an operator provisions it, and it runs inside Better Stack rather than in the cluster.
- **BYOC dataplane:** unaffected. The check is an ordinary authenticated client of `POST /api/langy/conversations` on whichever origin `LANGY_BASE_URL` names. It crosses no new trust boundary, adds no inbound path, and needs no egress the deployment did not already serve.
- **Operator prerequisites before it can go green:** a dedicated monitoring project, a Langy cohort user, a `langy:create` key owned by that user, and `release_langy_api_key_turns_enabled` on for that project. While the flag is off the route answers 404 and the monitor reports `surface_dark`.
- **Rollback:** delete the monitor in Better Stack. There is no platform state to unwind.

## Verified

```
vitest scripts/uptime           33 passed
biome check (blocking gate)     clean
biome new-violations gate       no new violations vs merge base
check-docs-prose                clean
check-feature-parity            23/23 scenarios bound
```

## Not done in this PR

- **Live proof is pending.** It needs a Better Stack API token, a monitoring project with `release_langy_api_key_turns_enabled` on, and a key owned by a cohort user. Once those exist, `upsert-langy-greeting-monitor.ts` provisions the monitor and the first checks give the latency numbers for the issue.
- The check proves a reply exists; it does not judge the reply. History and latency live in Better Stack, not the platform.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automated uptime monitoring that verifies Langy can complete a real conversation turn.
  - Added Better Stack monitor provisioning with create, update, validation, and dry-run support.
  - Added detailed failure classification, response timing, and credential-safe logging.

- **Documentation**
  - Added setup and operational guidance for Langy uptime monitoring.
  - Added the monitoring page to the Self-Hosting documentation navigation.

- **Tests**
  - Added comprehensive coverage for monitoring checks, provisioning behavior, response handling, and secret redaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
