### PR TITLE
feat(ui): add charts sections

### DIFF
--- a/platform/app/ee/governance/services/__tests__/directoryDepartmentSync.integration.test.ts
+++ b/platform/app/ee/governance/services/__tests__/directoryDepartmentSync.integration.test.ts
@@ -17,7 +17,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
 import { prisma } from "~/server/db";
 import { cleanupTestRows } from "~/test-utils/cleanupTestRows";
-
+import { DepartmentService } from "../department/department.service";
 import { DirectoryDepartmentSyncService } from "../directoryDepartmentSync.service";
 import { DIRECTORY_REPORT_ACTION } from "../pullers/microsoftGraphDirectory";
 import type { NormalizedPullEvent } from "../pullers/pullerAdapter";
@@ -203,6 +203,51 @@ describe("Feature: directory departments land on the entities we already have", 
 
     expect(outcome.assigned).toBe(1);
     expect((await membership(jonasUserId)).departmentId).not.toBeNull();
+  });
+
+  describe("given directory and confirmed email evidence name different members", () => {
+    /** @scenario "Conflicting directory and confirmed email proof changes no department" */
+    it("leaves both assignments and their histories untouched", async () => {
+      const departmentService = DepartmentService.create(prisma);
+      for (const [userId, name] of [
+        [mariaUserId, "Engineering"],
+        [jonasUserId, "Operations"],
+      ] as const) {
+        const department = await departmentService.resolveByNameOrCreate({
+          organizationId,
+          name,
+        });
+        await departmentService.assignUser({
+          organizationId,
+          userId,
+          departmentId: department.id,
+        });
+      }
+      const readState = async () => ({
+        maria: await membership(mariaUserId),
+        jonas: await membership(jonasUserId),
+        history: await prisma.departmentMembershipHistory.findMany({
+          where: { organizationId },
+          orderBy: { id: "asc" },
+        }),
+        departments: await departments(),
+      });
+      const before = await readState();
+
+      const outcome = await service().applyDirectoryEvents({
+        organizationId,
+        events: [
+          directoryEvent({
+            actor: JONAS_OID,
+            mail: `m.silva-${ns}@acme.test`,
+            department: "Conflicting New Department",
+          }),
+        ],
+      });
+
+      expect(outcome.assigned).toBe(0);
+      expect(await readState()).toEqual(before);
+    });
   });
 
   /** @scenario "A directory row proving no member assigns nobody" */

--- a/platform/app/ee/governance/services/directoryDepartmentSync.service.ts
+++ b/platform/app/ee/governance/services/directoryDepartmentSync.service.ts
@@ -11,9 +11,10 @@
  * through the identical two calls — no parallel department shape, no free
  * text on the person row.
  *
- * Who a row may assign is decided by the match engine's own proof standard,
- * through the same account index (`loadAccountIndex`): the directory id the
- * org's SSO connection recorded, or an address a member has CONFIRMED. An
+ * Assignment uses the match engine's conflict rule and account index
+ * (`loadAccountIndex`): the directory id the org's SSO connection recorded,
+ * or an address a member has CONFIRMED. Directory-only assignment remains
+ * supported here; opening an identity link has a stricter evidence rule. An
  * unconfirmed address is a claim anyone can type in, and two candidates are
  * a contradiction, not a coin toss — both assign nobody.
  *
@@ -40,7 +41,7 @@ import type { PrismaClient } from "~/generated/prisma/client";
 import { DepartmentService } from "./department/department.service";
 import { IdentityMatchService } from "./identityMatch.service";
 import {
-  normalizeEmail,
+  decideMatch,
   type OrganizationAccountIndex,
 } from "./logic/identityEvidence";
 import { DIRECTORY_REPORT_ACTION } from "./pullers/microsoftGraphDirectory";
@@ -182,10 +183,9 @@ export class DirectoryDepartmentSyncService {
 /**
  * The one member a directory row proves, or null.
  *
- * The directory id is checked first — it is the identifier the row IS keyed
- * by — and the confirmed address second. Either way, exactly one candidate
- * or nobody: the engine suspends automatic linking on a contradiction, and
- * an assignment must not out-run the engine's own caution.
+ * Conflicting proof is rejected before choosing either identifier. Otherwise
+ * keep directory-only assignment: the match engine's no-action result means
+ * "do not open an identity link", not "discard the directory's department".
  */
 function provenUserId({
   row,
@@ -194,12 +194,15 @@ function provenUserId({
   row: NormalizedPullEvent;
   accounts: OrganizationAccountIndex;
 }): string | null {
+  const decision = decideMatch({
+    identity: { rawActorId: row.actor, displayText: extraString(row, "mail") },
+    accounts,
+  });
+  if (decision.outcome === "suspend") return null;
+
   const byDirectory = accounts.usersByDirectoryId.get(row.actor) ?? [];
   if (byDirectory.length === 1) return byDirectory[0] ?? null;
   if (byDirectory.length > 1) return null;
 
-  const mailKey = normalizeEmail(extraString(row, "mail"));
-  if (mailKey === null) return null;
-  const byMail = accounts.usersByVerifiedEmail.get(mailKey) ?? [];
-  return byMail.length === 1 ? (byMail[0] ?? null) : null;
+  return decision.outcome === "link" ? decision.userId : null;
 }

--- a/platform/app/src/__tests__/inventoryBouncerExemption.unit.test.ts
+++ b/platform/app/src/__tests__/inventoryBouncerExemption.unit.test.ts
@@ -36,6 +36,9 @@ describe("the no-organization bouncer exemption list", () => {
       expect(noOrgBouncerRoutes).toContain("/governance/people");
       expect(noOrgBouncerRoutes).toContain("/governance/costs");
       expect(noOrgBouncerRoutes).toContain("/governance/billed");
+      expect(noOrgBouncerRoutes).toContain("/governance/insights");
+      expect(noOrgBouncerRoutes).toContain("/governance/analytics");
+      expect(noOrgBouncerRoutes).toContain("/governance/signals");
 
       // ...and ROUTE_PATTERNS must resolve a concrete detail address to the
       // exact pattern the list holds, or the `.includes` match misses.
@@ -46,6 +49,15 @@ describe("the no-organization bouncer exemption list", () => {
         "/governance/inventory",
       );
       expect(resolvePathname("/governance/people")).toBe("/governance/people");
+      expect(resolvePathname("/governance/insights")).toBe(
+        "/governance/insights",
+      );
+      expect(resolvePathname("/governance/analytics")).toBe(
+        "/governance/analytics",
+      );
+      expect(resolvePathname("/governance/signals")).toBe(
+        "/governance/signals",
+      );
     });
 
     /** @scenario The inventory family is exempt from the no-organization onboarding bouncer */

--- a/platform/app/src/components/ModelSelector.tsx
+++ b/platform/app/src/components/ModelSelector.tsx
@@ -331,6 +331,7 @@ export const ModelSelector = React.memo(function ModelSelector({
   mode,
   showConfigureAction = false,
   forFeatureLabel,
+  featureKey,
   open,
   onOpenChange,
 }: {
@@ -339,6 +340,11 @@ export const ModelSelector = React.memo(function ModelSelector({
   onChange: (model: string) => void;
   size?: "sm" | "md" | "full";
   mode?: "chat" | "embedding";
+  /** The feature this picker serves, for the restricted-provider gate
+   *  (`filterRestrictedModels`): a picker that names a codex-licensed
+   *  feature (e.g. Langy's `langy.chat`) may offer codex models; one
+   *  that names none never sees them. */
+  featureKey?: string;
   /** When true, shows a "Configure available models" link at the bottom of the dropdown */
   showConfigureAction?: boolean;
   /** Surface-specific label used in the empty-state callout when no
@@ -351,7 +357,7 @@ export const ModelSelector = React.memo(function ModelSelector({
   onOpenChange?: (open: boolean) => void;
 }) {
   const { selectOptions, groupedByProvider, isEmpty, isLoading } =
-    useModelSelectionOptions(options, model, mode);
+    useModelSelectionOptions(options, model, mode, { featureKey });
 
   // ALL hooks must run unconditionally — keep the empty-state early
   // return *after* every hook below so we don't violate React's rules

--- a/platform/app/src/components/governance/GovernanceLayout.tsx
+++ b/platform/app/src/components/governance/GovernanceLayout.tsx
@@ -9,7 +9,8 @@ import { useVisibleSectionNavItems } from "~/features/navigation/useVisibleSecti
  * + "Organization-scoped" indicator) and renders a thin org-level
  * sub-navigation in the left column. The item list itself lives in
  * `~/features/navigation/sectionNavItems` so every shell renders the
- * same navigation.
+ * same navigation. Grouped entries (`group`) list flat here, in the same
+ * order: only the navigation-v2 sidebar has a grouping affordance.
  *
  * Spec: specs/ai-gateway/governance/governance-home-routing.feature
  */

--- a/platform/app/src/components/governance/costs/CostFilterBar.tsx
+++ b/platform/app/src/components/governance/costs/CostFilterBar.tsx
@@ -171,6 +171,9 @@ export function CostFilterBar({
           </MenuItem>
         ))}
       </FilterChip>
+      <Text width="full" fontSize="xs" color="fg.muted">
+        Department filters only the Cost by department chart.
+      </Text>
     </HStack>
   );
 }

--- a/platform/app/src/components/governance/platform/InsightsRail.tsx
+++ b/platform/app/src/components/governance/platform/InsightsRail.tsx
@@ -1,11 +1,4 @@
-import {
-  Badge,
-  chakra,
-  HStack,
-  Separator,
-  Text,
-  VStack,
-} from "@chakra-ui/react";
+import { Badge, chakra, Separator, Text, VStack } from "@chakra-ui/react";
 import { Archive, Bell, Clock, Inbox, Mail } from "lucide-react";
 
 /**
@@ -97,7 +90,7 @@ export function InsightsRail({
             ) : null}
             <chakra.button
               type="button"
-              aria-current={active ? "page" : undefined}
+              aria-current={active ? "true" : undefined}
               onClick={() => onSelect(folder.id)}
               display="flex"
               alignItems="center"
@@ -114,25 +107,33 @@ export function InsightsRail({
               _hover={{ background: "bg.muted/60" }}
             >
               <Icon size={15} />
-              <Text flex={1}>{folder.label}</Text>
-              <HStack gap={0} aria-label={`${folder.label} count`}>
-                {folder.stream ? (
-                  <Badge
-                    size="sm"
-                    borderRadius="full"
-                    variant={count > 0 ? "solid" : "subtle"}
-                    colorPalette={count > 0 ? "orange" : "gray"}
-                    minWidth="22px"
-                    justifyContent="center"
-                  >
-                    {count}
-                  </Badge>
-                ) : (
-                  <Text fontSize="10.5px" fontWeight="500" color="fg.subtle">
-                    {count}
-                  </Text>
-                )}
-              </HStack>
+              <Text as="span" flex={1}>
+                {folder.label}
+              </Text>
+              {/* The count is plain text in the row, so the button's own
+                  name carries it ("Inbox 0"): no label on a generic box,
+                  which assistive tech would ignore (see RunsSidebarEntry). */}
+              {folder.stream ? (
+                <Badge
+                  size="sm"
+                  borderRadius="full"
+                  variant={count > 0 ? "solid" : "subtle"}
+                  colorPalette={count > 0 ? "orange" : "gray"}
+                  minWidth="22px"
+                  justifyContent="center"
+                >
+                  {count}
+                </Badge>
+              ) : (
+                <Text
+                  as="span"
+                  fontSize="10.5px"
+                  fontWeight="500"
+                  color="fg.subtle"
+                >
+                  {count}
+                </Text>
+              )}
             </chakra.button>
           </VStack>
         );

--- a/platform/app/src/components/governance/platform/InsightsRail.tsx
+++ b/platform/app/src/components/governance/platform/InsightsRail.tsx
@@ -1,0 +1,142 @@
+import {
+  Badge,
+  chakra,
+  HStack,
+  Separator,
+  Text,
+  VStack,
+} from "@chakra-ui/react";
+import { Archive, Bell, Clock, Inbox, Mail } from "lucide-react";
+
+/**
+ * The inbox's folder rail: what Langy filed, what went stale, what was put
+ * away, and the two streams that ride on top. Every count is zero until
+ * there is a job to fill them, and the rail says zero rather than hiding
+ * the numbers: an empty inbox with its folders in place reads as an inbox,
+ * not as a page that forgot its navigation.
+ *
+ * Same grammar as the annotations rail (AnnotationsLayout): 12.5px rows,
+ * the selected row on `bg.muted`, the count in the trailing slot. Folders
+ * are page state, not routes, because nothing lives behind them yet.
+ *
+ * Spec: specs/governance/governance-platform-placeholders.feature
+ */
+export type InsightsFolder =
+  | "inbox"
+  | "stale"
+  | "archived"
+  | "alerts"
+  | "notifications";
+
+export type InsightsRailCounts = Record<InsightsFolder, number>;
+
+export const EMPTY_INSIGHTS_COUNTS: InsightsRailCounts = {
+  inbox: 0,
+  stale: 0,
+  archived: 0,
+  alerts: 0,
+  notifications: 0,
+};
+
+/** What each folder says when it is empty; the inbox has its own card. */
+export const EMPTY_FOLDER_LINE: Record<
+  Exclude<InsightsFolder, "inbox">,
+  string
+> = {
+  stale:
+    "Nothing has gone stale. Insights land here when their validity runs out.",
+  archived: "Nothing archived. Insights you put away keep their evidence here.",
+  alerts: "No alerts. Signals that trip land here, on top of the brief.",
+  notifications:
+    "No notifications. Mentions and hand-offs from Langy land here.",
+};
+
+const FOLDERS: Array<{
+  id: InsightsFolder;
+  label: string;
+  icon: typeof Inbox;
+  /** Streams wear a badge; folders a quiet number. */
+  stream: boolean;
+}> = [
+  { id: "inbox", label: "Inbox", icon: Inbox, stream: false },
+  { id: "stale", label: "Stale", icon: Clock, stream: false },
+  { id: "archived", label: "Archived", icon: Archive, stream: false },
+  { id: "alerts", label: "Alerts", icon: Bell, stream: true },
+  { id: "notifications", label: "Notifications", icon: Mail, stream: true },
+];
+
+export function InsightsRail({
+  selected,
+  counts,
+  onSelect,
+}: {
+  selected: InsightsFolder;
+  counts: InsightsRailCounts;
+  onSelect: (folder: InsightsFolder) => void;
+}) {
+  return (
+    <VStack
+      as="nav"
+      aria-label="Insights folders"
+      align="stretch"
+      gap={0.5}
+      minWidth="200px"
+      fontSize="12.5px"
+      flexShrink={0}
+    >
+      {FOLDERS.map((folder, index) => {
+        const active = folder.id === selected;
+        const count = counts[folder.id];
+        const Icon = folder.icon;
+        return (
+          <VStack key={folder.id} align="stretch" gap={0.5}>
+            {/* The streams sit under a rule: they are not folders of the
+                brief, they ride on top of it. */}
+            {index > 0 && folder.stream && !FOLDERS[index - 1]?.stream ? (
+              <Separator marginY={1.5} />
+            ) : null}
+            <chakra.button
+              type="button"
+              aria-current={active ? "page" : undefined}
+              onClick={() => onSelect(folder.id)}
+              display="flex"
+              alignItems="center"
+              gap={2.5}
+              width="full"
+              paddingX="10px"
+              paddingY="6px"
+              borderRadius="lg"
+              textAlign="left"
+              fontWeight={active ? "medium" : "normal"}
+              color={active ? "fg" : "fg.muted"}
+              background={active ? "bg.muted" : "transparent"}
+              cursor="pointer"
+              _hover={{ background: "bg.muted/60" }}
+            >
+              <Icon size={15} />
+              <Text flex={1}>{folder.label}</Text>
+              <HStack gap={0} aria-label={`${folder.label} count`}>
+                {folder.stream ? (
+                  <Badge
+                    size="sm"
+                    borderRadius="full"
+                    variant={count > 0 ? "solid" : "subtle"}
+                    colorPalette={count > 0 ? "orange" : "gray"}
+                    minWidth="22px"
+                    justifyContent="center"
+                  >
+                    {count}
+                  </Badge>
+                ) : (
+                  <Text fontSize="10.5px" fontWeight="500" color="fg.subtle">
+                    {count}
+                  </Text>
+                )}
+              </HStack>
+            </chakra.button>
+          </VStack>
+        );
+      })}
+    </VStack>
+  );
+}

--- a/platform/app/src/components/governance/platform/InsightsRail.tsx
+++ b/platform/app/src/components/governance/platform/InsightsRail.tsx
@@ -58,6 +58,15 @@ const FOLDERS: Array<{
   { id: "notifications", label: "Notifications", icon: Mail, stream: true },
 ];
 
+type Folder = (typeof FOLDERS)[number];
+
+/** Streams sit under a rule: they are not folders of the brief, they ride on top of it. */
+function opensStreamGroup({ index }: { index: number }): boolean {
+  const folder = FOLDERS[index];
+  const previous = FOLDERS[index - 1];
+  return Boolean(folder?.stream) && previous !== undefined && !previous.stream;
+}
+
 export function InsightsRail({
   selected,
   counts,
@@ -77,67 +86,83 @@ export function InsightsRail({
       fontSize="12.5px"
       flexShrink={0}
     >
-      {FOLDERS.map((folder, index) => {
-        const active = folder.id === selected;
-        const count = counts[folder.id];
-        const Icon = folder.icon;
-        return (
-          <VStack key={folder.id} align="stretch" gap={0.5}>
-            {/* The streams sit under a rule: they are not folders of the
-                brief, they ride on top of it. */}
-            {index > 0 && folder.stream && !FOLDERS[index - 1]?.stream ? (
-              <Separator marginY={1.5} />
-            ) : null}
-            <chakra.button
-              type="button"
-              aria-current={active ? "true" : undefined}
-              onClick={() => onSelect(folder.id)}
-              display="flex"
-              alignItems="center"
-              gap={2.5}
-              width="full"
-              paddingX="10px"
-              paddingY="6px"
-              borderRadius="lg"
-              textAlign="left"
-              fontWeight={active ? "medium" : "normal"}
-              color={active ? "fg" : "fg.muted"}
-              background={active ? "bg.muted" : "transparent"}
-              cursor="pointer"
-              _hover={{ background: "bg.muted/60" }}
-            >
-              <Icon size={15} />
-              <Text as="span" flex={1}>
-                {folder.label}
-              </Text>
-              {/* The count is plain text in the row, so the button's own
-                  name carries it ("Inbox 0"): no label on a generic box,
-                  which assistive tech would ignore (see RunsSidebarEntry). */}
-              {folder.stream ? (
-                <Badge
-                  size="sm"
-                  borderRadius="full"
-                  variant={count > 0 ? "solid" : "subtle"}
-                  colorPalette={count > 0 ? "orange" : "gray"}
-                  minWidth="22px"
-                  justifyContent="center"
-                >
-                  {count}
-                </Badge>
-              ) : (
-                <Text
-                  as="span"
-                  fontSize="10.5px"
-                  fontWeight="500"
-                  color="fg.subtle"
-                >
-                  {count}
-                </Text>
-              )}
-            </chakra.button>
-          </VStack>
-        );
-      })}
+      {FOLDERS.map((folder, index) => (
+        <VStack key={folder.id} align="stretch" gap={0.5}>
+          {opensStreamGroup({ index }) ? <Separator marginY={1.5} /> : null}
+          <FolderRow
+            folder={folder}
+            active={folder.id === selected}
+            count={counts[folder.id]}
+            onSelect={onSelect}
+          />
+        </VStack>
+      ))}
     </VStack>
+  );
+}
+
+function FolderRow({
+  folder,
+  active,
+  count,
+  onSelect,
+}: {
+  folder: Folder;
+  active: boolean;
+  count: number;
+  onSelect: (folder: InsightsFolder) => void;
+}) {
+  const Icon = folder.icon;
+  return (
+    <chakra.button
+      type="button"
+      aria-current={active ? "true" : undefined}
+      onClick={() => onSelect(folder.id)}
+      display="flex"
+      alignItems="center"
+      gap={2.5}
+      width="full"
+      paddingX="10px"
+      paddingY="6px"
+      borderRadius="lg"
+      textAlign="left"
+      fontWeight={active ? "medium" : "normal"}
+      color={active ? "fg" : "fg.muted"}
+      background={active ? "bg.muted" : "transparent"}
+      cursor="pointer"
+      _hover={{ background: "bg.muted/60" }}
+    >
+      <Icon size={15} />
+      <Text as="span" flex={1}>
+        {folder.label}
+      </Text>
+      {/* The count is plain text in the row, so the button's own name
+          carries it ("Inbox 0"): no label on a generic box, which
+          assistive tech would ignore (see RunsSidebarEntry). */}
+      <FolderCount stream={folder.stream} count={count} />
+    </chakra.button>
+  );
+}
+
+/** Streams wear a badge; folders a quiet number. */
+function FolderCount({ stream, count }: { stream: boolean; count: number }) {
+  if (stream) {
+    return (
+      <Badge
+        size="sm"
+        borderRadius="full"
+        variant={count > 0 ? "solid" : "subtle"}
+        colorPalette={count > 0 ? "orange" : "gray"}
+        minWidth="22px"
+        justifyContent="center"
+      >
+        {count}
+      </Badge>
+    );
+  }
+  return (
+    <Text as="span" fontSize="10.5px" fontWeight="500" color="fg.subtle">
+      {count}
+    </Text>
   );
 }

--- a/platform/app/src/components/governance/platform/InsightsSetupDialog.tsx
+++ b/platform/app/src/components/governance/platform/InsightsSetupDialog.tsx
@@ -118,7 +118,7 @@ export function InsightsSetupDialog({
       <DialogContent>
         <DialogHeader>
           <HStack gap={3} align="baseline">
-            <Sparkles size={18} color="var(--chakra-colors-purple-500)" />
+            <Sparkles size={18} />
             <DialogTitle>Insights</DialogTitle>
             <Text fontSize="sm" color="fg.muted">
               schedule, session and skill
@@ -251,7 +251,7 @@ export function InsightsSetupDialog({
           <Button variant="ghost" onClick={onCancel}>
             Cancel
           </Button>
-          <Button colorPalette="purple" onClick={() => onSave(draft)}>
+          <Button colorPalette="orange" onClick={() => onSave(draft)}>
             Save
           </Button>
         </DialogFooter>

--- a/platform/app/src/components/governance/platform/InsightsSetupDialog.tsx
+++ b/platform/app/src/components/governance/platform/InsightsSetupDialog.tsx
@@ -181,8 +181,13 @@ export function InsightsSetupDialog({
               label="Model"
               hint="The model the eternal session runs on"
             >
-              <NativeSelect.Root>
-                <NativeSelect.Field aria-label="Model" value={draft.model}>
+              {/* One option and nothing to write it to: read-only, not a
+                  controlled field pretending to accept a change. */}
+              <NativeSelect.Root disabled>
+                <NativeSelect.Field
+                  aria-label="Model"
+                  defaultValue={draft.model}
+                >
                   <option value="langy-default">
                     claude-sonnet-4.5 · Langy default
                   </option>

--- a/platform/app/src/components/governance/platform/InsightsSetupDialog.tsx
+++ b/platform/app/src/components/governance/platform/InsightsSetupDialog.tsx
@@ -1,0 +1,261 @@
+import {
+  Box,
+  Button,
+  HStack,
+  Input,
+  NativeSelect,
+  Separator,
+  Text,
+  Textarea,
+  VStack,
+} from "@chakra-ui/react";
+import { Sparkles, UserRoundCog } from "lucide-react";
+import { type ReactNode, useEffect, useState } from "react";
+
+import {
+  DialogBody,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogRoot,
+  DialogTitle,
+} from "~/components/ui/dialog";
+
+/**
+ * What the daily Insights job would be told, if there were a job.
+ *
+ * Nothing behind this dialog stores anything yet. The page owns the values
+ * and hands them in; Save hands the edited copy back and closes, Cancel
+ * closes and drops the edits. There is no toast and no "saved" wording on
+ * purpose: a confirmation here would claim a write that never happened.
+ *
+ * Spec: specs/governance/governance-platform-placeholders.feature
+ */
+export interface InsightsSettings {
+  runs: "daily" | "weekdays" | "weekly";
+  at: string;
+  volume: "langy" | "one" | "three";
+  model: "langy-default";
+  skillInstructions: string;
+}
+
+export const DEFAULT_INSIGHTS_SETTINGS: InsightsSettings = {
+  runs: "daily",
+  at: "07:00",
+  volume: "langy",
+  model: "langy-default",
+  skillInstructions: [
+    "Every morning at 07:00, review yesterday's traffic across the whole substrate.",
+    "",
+    "- File a couple of insights at most. Insist on the issues that matter; fifteen a day is noise nobody acts on.",
+    "- Write the headline in plain english. The reader should decide in one sentence whether to care.",
+    "- Judge each one: good news or bad. The inbox takes its color from the balance.",
+    "- Estimate how many days each insight stays true and set its validity. Let stale ones fall away.",
+    "- If an open insight is still true, renew it instead of filing a duplicate.",
+    "- Attach evidence: the query and chart that show it, the signal that caught it, or the traces that prove it.",
+  ].join("\n"),
+};
+
+/** What steering would have left behind. Illustrative until there is a session. */
+const LEARNED_PREFERENCES = [
+  "Weekend Databricks batch load is expected: the ETL jobs moved to Saturdays in late July.",
+  "Skip insights about the staging project; its traffic is synthetic.",
+];
+
+function SettingRow({
+  label,
+  hint,
+  children,
+}: {
+  label: string;
+  hint: string;
+  children: ReactNode;
+}) {
+  return (
+    <HStack align="center" gap={6} paddingY={3}>
+      <VStack align="start" gap={0.5} flex={1} minWidth={0}>
+        <Text fontWeight="medium">{label}</Text>
+        <Text fontSize="sm" color="fg.muted">
+          {hint}
+        </Text>
+      </VStack>
+      <Box flex={1} minWidth={0}>
+        {children}
+      </Box>
+    </HStack>
+  );
+}
+
+export function InsightsSetupDialog({
+  open,
+  settings,
+  onCancel,
+  onSave,
+}: {
+  open: boolean;
+  settings: InsightsSettings;
+  onCancel: () => void;
+  onSave: (next: InsightsSettings) => void;
+}) {
+  const [draft, setDraft] = useState(settings);
+  // A fresh draft every time the dialog opens: the last sitting's Cancel
+  // must not leak into this one.
+  useEffect(() => {
+    if (open) setDraft(settings);
+  }, [open, settings]);
+  const patch = (next: Partial<InsightsSettings>) =>
+    setDraft((current) => ({ ...current, ...next }));
+
+  return (
+    <DialogRoot
+      open={open}
+      onOpenChange={({ open: next }) => {
+        if (!next) onCancel();
+      }}
+      size="lg"
+      placement="center"
+    >
+      <DialogContent>
+        <DialogHeader>
+          <HStack gap={3} align="baseline">
+            <Sparkles size={18} color="var(--chakra-colors-purple-500)" />
+            <DialogTitle>Insights</DialogTitle>
+            <Text fontSize="sm" color="fg.muted">
+              schedule, session and skill
+            </Text>
+          </HStack>
+        </DialogHeader>
+        <DialogBody>
+          <VStack align="stretch" gap={0} separator={<Separator />}>
+            <SettingRow
+              label="Runs"
+              hint="How often the background job messages Langy"
+            >
+              <NativeSelect.Root>
+                <NativeSelect.Field
+                  aria-label="Runs"
+                  value={draft.runs}
+                  onChange={(event) =>
+                    patch({
+                      runs: event.target.value as InsightsSettings["runs"],
+                    })
+                  }
+                >
+                  <option value="daily">Daily</option>
+                  <option value="weekdays">Weekdays</option>
+                  <option value="weekly">Weekly</option>
+                </NativeSelect.Field>
+                <NativeSelect.Indicator />
+              </NativeSelect.Root>
+            </SettingRow>
+            <SettingRow label="At" hint="Europe/Amsterdam">
+              <Input
+                aria-label="At"
+                type="time"
+                value={draft.at}
+                onChange={(event) => patch({ at: event.target.value })}
+              />
+            </SettingRow>
+            <SettingRow
+              label="Volume"
+              hint="Few insights that matter beat fifteen that don't"
+            >
+              <NativeSelect.Root>
+                <NativeSelect.Field
+                  aria-label="Volume"
+                  value={draft.volume}
+                  onChange={(event) =>
+                    patch({
+                      volume: event.target.value as InsightsSettings["volume"],
+                    })
+                  }
+                >
+                  <option value="langy">Let Langy decide (recommended)</option>
+                  <option value="one">At most one a day</option>
+                  <option value="three">At most three a day</option>
+                </NativeSelect.Field>
+                <NativeSelect.Indicator />
+              </NativeSelect.Root>
+            </SettingRow>
+            <SettingRow
+              label="Model"
+              hint="The model the eternal session runs on"
+            >
+              <NativeSelect.Root>
+                <NativeSelect.Field aria-label="Model" value={draft.model}>
+                  <option value="langy-default">
+                    claude-sonnet-4.5 · Langy default
+                  </option>
+                </NativeSelect.Field>
+                <NativeSelect.Indicator />
+              </NativeSelect.Root>
+            </SettingRow>
+            <SettingRow
+              label="Session"
+              hint="One eternal conversation: every run appends, and your feedback steers it"
+            >
+              <HStack gap={3}>
+                <Button variant="outline" size="sm">
+                  Open session
+                </Button>
+                <Button variant="ghost" size="sm" color="fg.muted">
+                  Clear session…
+                </Button>
+              </HStack>
+            </SettingRow>
+          </VStack>
+
+          <VStack align="stretch" gap={2} paddingTop={5}>
+            <Text fontWeight="medium">Skill instructions</Text>
+            <Text fontSize="sm" color="fg.muted">
+              What the daily job tells Langy. Edit it and the next run obeys.
+            </Text>
+            <Textarea
+              aria-label="Skill instructions"
+              value={draft.skillInstructions}
+              onChange={(event) =>
+                patch({ skillInstructions: event.target.value })
+              }
+              rows={8}
+              fontSize="sm"
+              lineHeight="1.6"
+            />
+          </VStack>
+
+          <VStack align="stretch" gap={2} paddingTop={5}>
+            <HStack gap={2}>
+              <UserRoundCog size={14} />
+              <Text fontWeight="medium">Learned preferences</Text>
+            </HStack>
+            <Text fontSize="sm" color="fg.muted">
+              What steering left behind. Complain about an insight and the
+              correction lands here.
+            </Text>
+            <VStack
+              align="stretch"
+              gap={0}
+              borderWidth="1px"
+              borderColor="border.subtle"
+              borderRadius="md"
+              separator={<Separator />}
+            >
+              {LEARNED_PREFERENCES.map((preference) => (
+                <Text key={preference} fontSize="sm" paddingX={3} paddingY={2}>
+                  {preference}
+                </Text>
+              ))}
+            </VStack>
+          </VStack>
+        </DialogBody>
+        <DialogFooter>
+          <Button variant="ghost" onClick={onCancel}>
+            Cancel
+          </Button>
+          <Button colorPalette="purple" onClick={() => onSave(draft)}>
+            Save
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </DialogRoot>
+  );
+}

--- a/platform/app/src/components/governance/platform/InsightsSetupDrawer.tsx
+++ b/platform/app/src/components/governance/platform/InsightsSetupDrawer.tsx
@@ -1,33 +1,31 @@
 import {
-  Box,
   Button,
   HStack,
   Input,
   NativeSelect,
   Separator,
+  Spacer,
   Text,
   Textarea,
   VStack,
 } from "@chakra-ui/react";
-import { Sparkles, UserRoundCog } from "lucide-react";
+import { UserRoundCog } from "lucide-react";
 import { type ReactNode, useEffect, useState } from "react";
 
-import {
-  DialogBody,
-  DialogContent,
-  DialogFooter,
-  DialogHeader,
-  DialogRoot,
-  DialogTitle,
-} from "~/components/ui/dialog";
+import { Drawer } from "~/components/ui/drawer";
 
 /**
  * What the daily Insights job would be told, if there were a job.
  *
- * Nothing behind this dialog stores anything yet. The page owns the values
+ * Nothing behind this drawer stores anything yet. The page owns the values
  * and hands them in; Save hands the edited copy back and closes, Cancel
  * closes and drops the edits. There is no toast and no "saved" wording on
  * purpose: a confirmation here would claim a write that never happened.
+ *
+ * A drawer, not a modal, on the same shell the governance settings forms
+ * use (DepartmentEditDrawer, RoutingPolicyDrawer): a right-hand sheet the
+ * page stays visible behind, so the reader keeps the inbox in view while
+ * they tune what fills it.
  *
  * Spec: specs/governance/governance-platform-placeholders.feature
  */
@@ -62,6 +60,7 @@ const LEARNED_PREFERENCES = [
   "Skip insights about the staging project; its traffic is synthetic.",
 ];
 
+/** Label and hint over the control: a drawer is too narrow for two columns. */
 function SettingRow({
   label,
   hint,
@@ -72,21 +71,21 @@ function SettingRow({
   children: ReactNode;
 }) {
   return (
-    <HStack align="center" gap={6} paddingY={3}>
-      <VStack align="start" gap={0.5} flex={1} minWidth={0}>
-        <Text fontWeight="medium">{label}</Text>
-        <Text fontSize="sm" color="fg.muted">
+    <VStack align="stretch" gap={2} paddingY={4}>
+      <VStack align="start" gap={0.5}>
+        <Text fontSize="sm" fontWeight="medium">
+          {label}
+        </Text>
+        <Text fontSize="xs" color="fg.muted">
           {hint}
         </Text>
       </VStack>
-      <Box flex={1} minWidth={0}>
-        {children}
-      </Box>
-    </HStack>
+      {children}
+    </VStack>
   );
 }
 
-export function InsightsSetupDialog({
+export function InsightsSetupDrawer({
   open,
   settings,
   onCancel,
@@ -98,7 +97,7 @@ export function InsightsSetupDialog({
   onSave: (next: InsightsSettings) => void;
 }) {
   const [draft, setDraft] = useState(settings);
-  // A fresh draft every time the dialog opens: the last sitting's Cancel
+  // A fresh draft every time the drawer opens: the last sitting's Cancel
   // must not leak into this one.
   useEffect(() => {
     if (open) setDraft(settings);
@@ -107,31 +106,31 @@ export function InsightsSetupDialog({
     setDraft((current) => ({ ...current, ...next }));
 
   return (
-    <DialogRoot
+    <Drawer.Root
       open={open}
       onOpenChange={({ open: next }) => {
         if (!next) onCancel();
       }}
-      size="lg"
-      placement="center"
+      placement="end"
+      size="md"
     >
-      <DialogContent>
-        <DialogHeader>
-          <HStack gap={3} align="baseline">
-            <Sparkles size={18} />
-            <DialogTitle>Insights</DialogTitle>
-            <Text fontSize="sm" color="fg.muted">
-              schedule, session and skill
+      <Drawer.Content bg="bg">
+        <Drawer.Header>
+          <VStack align="start" gap={0.5}>
+            <Drawer.Title>Set up Insights</Drawer.Title>
+            <Text fontSize="sm" color="fg.muted" fontWeight="normal">
+              Schedule, session and skill
             </Text>
-          </HStack>
-        </DialogHeader>
-        <DialogBody>
+          </VStack>
+          <Drawer.CloseTrigger />
+        </Drawer.Header>
+        <Drawer.Body>
           <VStack align="stretch" gap={0} separator={<Separator />}>
             <SettingRow
               label="Runs"
               hint="How often the background job messages Langy"
             >
-              <NativeSelect.Root>
+              <NativeSelect.Root size="sm">
                 <NativeSelect.Field
                   aria-label="Runs"
                   value={draft.runs}
@@ -152,6 +151,7 @@ export function InsightsSetupDialog({
               <Input
                 aria-label="At"
                 type="time"
+                size="sm"
                 value={draft.at}
                 onChange={(event) => patch({ at: event.target.value })}
               />
@@ -160,7 +160,7 @@ export function InsightsSetupDialog({
               label="Volume"
               hint="Few insights that matter beat fifteen that don't"
             >
-              <NativeSelect.Root>
+              <NativeSelect.Root size="sm">
                 <NativeSelect.Field
                   aria-label="Volume"
                   value={draft.volume}
@@ -183,7 +183,7 @@ export function InsightsSetupDialog({
             >
               {/* One option and nothing to write it to: read-only, not a
                   controlled field pretending to accept a change. */}
-              <NativeSelect.Root disabled>
+              <NativeSelect.Root size="sm" disabled>
                 <NativeSelect.Field
                   aria-label="Model"
                   defaultValue={draft.model}
@@ -199,68 +199,75 @@ export function InsightsSetupDialog({
               label="Session"
               hint="One eternal conversation: every run appends, and your feedback steers it"
             >
-              <HStack gap={3}>
-                <Button variant="outline" size="sm">
+              <HStack gap={2}>
+                <Button variant="outline" size="xs">
                   Open session
                 </Button>
-                <Button variant="ghost" size="sm" color="fg.muted">
+                <Button variant="ghost" size="xs" color="fg.muted">
                   Clear session…
                 </Button>
               </HStack>
             </SettingRow>
-          </VStack>
-
-          <VStack align="stretch" gap={2} paddingTop={5}>
-            <Text fontWeight="medium">Skill instructions</Text>
-            <Text fontSize="sm" color="fg.muted">
-              What the daily job tells Langy. Edit it and the next run obeys.
-            </Text>
-            <Textarea
-              aria-label="Skill instructions"
-              value={draft.skillInstructions}
-              onChange={(event) =>
-                patch({ skillInstructions: event.target.value })
-              }
-              rows={8}
-              fontSize="sm"
-              lineHeight="1.6"
-            />
-          </VStack>
-
-          <VStack align="stretch" gap={2} paddingTop={5}>
-            <HStack gap={2}>
-              <UserRoundCog size={14} />
-              <Text fontWeight="medium">Learned preferences</Text>
-            </HStack>
-            <Text fontSize="sm" color="fg.muted">
-              What steering left behind. Complain about an insight and the
-              correction lands here.
-            </Text>
-            <VStack
-              align="stretch"
-              gap={0}
-              borderWidth="1px"
-              borderColor="border.subtle"
-              borderRadius="md"
-              separator={<Separator />}
+            <SettingRow
+              label="Skill instructions"
+              hint="What the daily job tells Langy. Edit it and the next run obeys."
             >
-              {LEARNED_PREFERENCES.map((preference) => (
-                <Text key={preference} fontSize="sm" paddingX={3} paddingY={2}>
-                  {preference}
+              <Textarea
+                aria-label="Skill instructions"
+                value={draft.skillInstructions}
+                onChange={(event) =>
+                  patch({ skillInstructions: event.target.value })
+                }
+                rows={10}
+                fontSize="sm"
+                lineHeight="1.6"
+              />
+            </SettingRow>
+            <VStack align="stretch" gap={2} paddingY={4}>
+              <HStack gap={2}>
+                <UserRoundCog size={14} />
+                <Text fontSize="sm" fontWeight="medium">
+                  Learned preferences
                 </Text>
-              ))}
+              </HStack>
+              <Text fontSize="xs" color="fg.muted">
+                What steering left behind. Complain about an insight and the
+                correction lands here.
+              </Text>
+              <VStack
+                align="stretch"
+                gap={0}
+                borderWidth="1px"
+                borderColor="border.muted"
+                borderRadius="md"
+                separator={<Separator />}
+              >
+                {LEARNED_PREFERENCES.map((preference) => (
+                  <Text
+                    key={preference}
+                    fontSize="sm"
+                    paddingX={3}
+                    paddingY={2}
+                  >
+                    {preference}
+                  </Text>
+                ))}
+              </VStack>
             </VStack>
           </VStack>
-        </DialogBody>
-        <DialogFooter>
-          <Button variant="ghost" onClick={onCancel}>
-            Cancel
-          </Button>
-          <Button colorPalette="orange" onClick={() => onSave(draft)}>
-            Save
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </DialogRoot>
+        </Drawer.Body>
+        <Drawer.Footer>
+          <HStack width="full">
+            <Spacer />
+            <Button variant="ghost" onClick={onCancel}>
+              Cancel
+            </Button>
+            <Button colorPalette="orange" onClick={() => onSave(draft)}>
+              Save
+            </Button>
+          </HStack>
+        </Drawer.Footer>
+      </Drawer.Content>
+    </Drawer.Root>
   );
 }

--- a/platform/app/src/components/governance/platform/InsightsSetupDrawer.tsx
+++ b/platform/app/src/components/governance/platform/InsightsSetupDrawer.tsx
@@ -140,7 +140,12 @@ export function InsightsSetupDrawer({
 
   // Same two queries the Langy panel seeds its own picker from: the model
   // Langy's gate resolves for this project, and the models it may use.
-  const { project } = useOrganizationTeamProject();
+  // Governance is org-level and may have no project; like costs.tsx, never
+  // let this hook bounce the reader to onboarding on its own.
+  const { project } = useOrganizationTeamProject({
+    redirectToOnboarding: false,
+    redirectToProjectOnboarding: false,
+  });
   const projectId = project?.id ?? "";
   const langyDefaultQuery = api.modelProvider.getResolvedDefault.useQuery(
     { projectId, featureKey: LANGY_CHAT_FEATURE_KEY },

--- a/platform/app/src/components/governance/platform/InsightsSetupDrawer.tsx
+++ b/platform/app/src/components/governance/platform/InsightsSetupDrawer.tsx
@@ -254,6 +254,10 @@ export function InsightsSetupDrawer({
                 mode="chat"
                 showConfigureAction
                 forFeatureLabel="for Insights"
+                // Langy is a codex-licensed surface; without its key the
+                // picker would drop the very model Langy may be configured
+                // with and paint it as unknown.
+                featureKey={LANGY_CHAT_FEATURE_KEY}
               />
             </SettingRow>
             <SettingRow

--- a/platform/app/src/components/governance/platform/InsightsSetupDrawer.tsx
+++ b/platform/app/src/components/governance/platform/InsightsSetupDrawer.tsx
@@ -4,6 +4,7 @@ import {
   Field,
   HStack,
   Input,
+  type ListCollection,
   Separator,
   Spacer,
   Text,
@@ -137,30 +138,9 @@ export function InsightsSetupDrawer({
   }, [open, settings]);
   const patch = (next: Partial<InsightsSettings>) =>
     setDraft((current) => ({ ...current, ...next }));
-
-  // Same two queries the Langy panel seeds its own picker from: the model
-  // Langy's gate resolves for this project, and the models it may use.
-  // Governance is org-level and may have no project; like costs.tsx, never
-  // let this hook bounce the reader to onboarding on its own.
-  const { project } = useOrganizationTeamProject({
-    redirectToOnboarding: false,
-    redirectToProjectOnboarding: false,
+  const { langyDefaultModel, modelOptions } = useLangyModelChoice({
+    enabled: open,
   });
-  const projectId = project?.id ?? "";
-  const langyDefaultQuery = api.modelProvider.getResolvedDefault.useQuery(
-    { projectId, featureKey: LANGY_CHAT_FEATURE_KEY },
-    { enabled: !!projectId && open, staleTime: 300_000 },
-  );
-  const modelsAllowedQuery = api.langy.modelsAllowed.useQuery(
-    { projectId },
-    { enabled: !!projectId && open, staleTime: 300_000 },
-  );
-  const modelOptions = useMemo(
-    () => modelsAllowedQuery.data?.modelsAllowed ?? allModelOptions,
-    [modelsAllowedQuery.data?.modelsAllowed],
-  );
-  const langyDefaultModel = langyDefaultQuery.data?.model ?? "";
-  const shownModel = draft.model ?? langyDefaultModel;
 
   return (
     <Drawer.Root
@@ -183,66 +163,7 @@ export function InsightsSetupDrawer({
         </Drawer.Header>
         <Drawer.Body>
           <VStack align="stretch" gap={0} separator={<Separator />}>
-            <SettingRow
-              label="Runs"
-              hint="How often the background job messages Langy"
-            >
-              <Select.Root
-                collection={RUNS_OPTIONS}
-                size="sm"
-                value={[draft.runs]}
-                onValueChange={({ value }) => {
-                  const runs = value[0] as InsightsSettings["runs"] | undefined;
-                  if (runs) patch({ runs });
-                }}
-              >
-                <Select.Trigger>
-                  <Select.ValueText />
-                </Select.Trigger>
-                <Select.Content>
-                  {RUNS_OPTIONS.items.map((item) => (
-                    <Select.Item key={item.value} item={item}>
-                      {item.label}
-                    </Select.Item>
-                  ))}
-                </Select.Content>
-              </Select.Root>
-            </SettingRow>
-            <SettingRow label="At" hint="Europe/Amsterdam">
-              <Input
-                type="time"
-                size="sm"
-                value={draft.at}
-                onChange={(event) => patch({ at: event.target.value })}
-              />
-            </SettingRow>
-            <SettingRow
-              label="Volume"
-              hint="Few insights that matter beat fifteen that don't"
-            >
-              <Select.Root
-                collection={VOLUME_OPTIONS}
-                size="sm"
-                value={[draft.volume]}
-                onValueChange={({ value }) => {
-                  const volume = value[0] as
-                    | InsightsSettings["volume"]
-                    | undefined;
-                  if (volume) patch({ volume });
-                }}
-              >
-                <Select.Trigger>
-                  <Select.ValueText />
-                </Select.Trigger>
-                <Select.Content>
-                  {VOLUME_OPTIONS.items.map((item) => (
-                    <Select.Item key={item.value} item={item}>
-                      {item.label}
-                    </Select.Item>
-                  ))}
-                </Select.Content>
-              </Select.Root>
-            </SettingRow>
+            <ScheduleRows draft={draft} patch={patch} />
             <SettingRow
               label="Model"
               hint={
@@ -252,7 +173,7 @@ export function InsightsSetupDrawer({
               }
             >
               <ModelSelector
-                model={shownModel}
+                model={draft.model ?? langyDefaultModel}
                 options={modelOptions}
                 onChange={(model) => patch({ model })}
                 size="full"
@@ -265,64 +186,8 @@ export function InsightsSetupDrawer({
                 featureKey={LANGY_CHAT_FEATURE_KEY}
               />
             </SettingRow>
-            <SettingRow
-              label="Session"
-              hint="One eternal conversation: every run appends, and your feedback steers it"
-            >
-              <HStack gap={2}>
-                <Button variant="outline" size="xs">
-                  Open session
-                </Button>
-                <Button variant="ghost" size="xs" color="fg.muted">
-                  Clear session…
-                </Button>
-              </HStack>
-            </SettingRow>
-            <SettingRow
-              label="Skill instructions"
-              hint="What the daily job tells Langy. Edit it and the next run obeys."
-            >
-              <Textarea
-                value={draft.skillInstructions}
-                onChange={(event) =>
-                  patch({ skillInstructions: event.target.value })
-                }
-                rows={10}
-                fontSize="sm"
-                lineHeight="1.6"
-              />
-            </SettingRow>
-            <VStack align="stretch" gap={2} paddingY={4}>
-              <HStack gap={2}>
-                <UserRoundCog size={14} />
-                <Text fontSize="sm" fontWeight="medium">
-                  Learned preferences
-                </Text>
-              </HStack>
-              <Text fontSize="xs" color="fg.muted">
-                What steering left behind. Complain about an insight and the
-                correction lands here.
-              </Text>
-              <VStack
-                align="stretch"
-                gap={0}
-                borderWidth="1px"
-                borderColor="border.muted"
-                borderRadius="md"
-                separator={<Separator />}
-              >
-                {LEARNED_PREFERENCES.map((preference) => (
-                  <Text
-                    key={preference}
-                    fontSize="sm"
-                    paddingX={3}
-                    paddingY={2}
-                  >
-                    {preference}
-                  </Text>
-                ))}
-              </VStack>
-            </VStack>
+            <SessionRows draft={draft} patch={patch} />
+            <LearnedPreferences />
           </VStack>
         </Drawer.Body>
         <Drawer.Footer>
@@ -338,5 +203,174 @@ export function InsightsSetupDrawer({
         </Drawer.Footer>
       </Drawer.Content>
     </Drawer.Root>
+  );
+}
+
+/**
+ * Same two queries the Langy panel seeds its own picker from: the model
+ * Langy's gate resolves for this project, and the models it may use.
+ * Governance is org-level and may have no project; like costs.tsx, never
+ * let this hook bounce the reader to onboarding on its own.
+ */
+function useLangyModelChoice({ enabled }: { enabled: boolean }) {
+  const { project } = useOrganizationTeamProject({
+    redirectToOnboarding: false,
+    redirectToProjectOnboarding: false,
+  });
+  const projectId = project?.id ?? "";
+  const langyDefaultQuery = api.modelProvider.getResolvedDefault.useQuery(
+    { projectId, featureKey: LANGY_CHAT_FEATURE_KEY },
+    { enabled: !!projectId && enabled, staleTime: 300_000 },
+  );
+  const modelsAllowedQuery = api.langy.modelsAllowed.useQuery(
+    { projectId },
+    { enabled: !!projectId && enabled, staleTime: 300_000 },
+  );
+  const modelOptions = useMemo(
+    () => modelsAllowedQuery.data?.modelsAllowed ?? allModelOptions,
+    [modelsAllowedQuery.data?.modelsAllowed],
+  );
+  return {
+    langyDefaultModel: langyDefaultQuery.data?.model ?? "",
+    modelOptions,
+  };
+}
+
+type DraftProps = {
+  draft: InsightsSettings;
+  patch: (next: Partial<InsightsSettings>) => void;
+};
+
+/** When the job runs and how much it may file. */
+function ScheduleRows({ draft, patch }: DraftProps) {
+  return (
+    <>
+      <SettingRow
+        label="Runs"
+        hint="How often the background job messages Langy"
+      >
+        <ChoiceSelect
+          collection={RUNS_OPTIONS}
+          value={draft.runs}
+          onChange={(runs) => patch({ runs })}
+        />
+      </SettingRow>
+      <SettingRow label="At" hint="Europe/Amsterdam">
+        <Input
+          type="time"
+          size="sm"
+          value={draft.at}
+          onChange={(event) => patch({ at: event.target.value })}
+        />
+      </SettingRow>
+      <SettingRow
+        label="Volume"
+        hint="Few insights that matter beat fifteen that don't"
+      >
+        <ChoiceSelect
+          collection={VOLUME_OPTIONS}
+          value={draft.volume}
+          onChange={(volume) => patch({ volume })}
+        />
+      </SettingRow>
+    </>
+  );
+}
+
+/** The eternal session and the skill it runs. */
+function SessionRows({ draft, patch }: DraftProps) {
+  return (
+    <>
+      <SettingRow
+        label="Session"
+        hint="One eternal conversation: every run appends, and your feedback steers it"
+      >
+        <HStack gap={2}>
+          <Button variant="outline" size="xs">
+            Open session
+          </Button>
+          <Button variant="ghost" size="xs" color="fg.muted">
+            Clear session…
+          </Button>
+        </HStack>
+      </SettingRow>
+      <SettingRow
+        label="Skill instructions"
+        hint="What the daily job tells Langy. Edit it and the next run obeys."
+      >
+        <Textarea
+          value={draft.skillInstructions}
+          onChange={(event) => patch({ skillInstructions: event.target.value })}
+          rows={10}
+          fontSize="sm"
+          lineHeight="1.6"
+        />
+      </SettingRow>
+    </>
+  );
+}
+
+/** A single-value pick from a fixed list; the repo Select under the row's Field. */
+function ChoiceSelect<T extends string>({
+  collection,
+  value,
+  onChange,
+}: {
+  collection: ListCollection<{ value: T; label: string }>;
+  value: T;
+  onChange: (value: T) => void;
+}) {
+  return (
+    <Select.Root
+      collection={collection}
+      size="sm"
+      value={[value]}
+      onValueChange={({ value: next }) => {
+        const picked = next[0] as T | undefined;
+        if (picked) onChange(picked);
+      }}
+    >
+      <Select.Trigger>
+        <Select.ValueText />
+      </Select.Trigger>
+      <Select.Content>
+        {collection.items.map((item) => (
+          <Select.Item key={item.value} item={item}>
+            {item.label}
+          </Select.Item>
+        ))}
+      </Select.Content>
+    </Select.Root>
+  );
+}
+
+function LearnedPreferences() {
+  return (
+    <VStack align="stretch" gap={2} paddingY={4}>
+      <HStack gap={2}>
+        <UserRoundCog size={14} />
+        <Text fontSize="sm" fontWeight="medium">
+          Learned preferences
+        </Text>
+      </HStack>
+      <Text fontSize="xs" color="fg.muted">
+        What steering left behind. Complain about an insight and the correction
+        lands here.
+      </Text>
+      <VStack
+        align="stretch"
+        gap={0}
+        borderWidth="1px"
+        borderColor="border.muted"
+        borderRadius="md"
+        separator={<Separator />}
+      >
+        {LEARNED_PREFERENCES.map((preference) => (
+          <Text key={preference} fontSize="sm" paddingX={3} paddingY={2}>
+            {preference}
+          </Text>
+        ))}
+      </VStack>
+    </VStack>
   );
 }

--- a/platform/app/src/components/governance/platform/InsightsSetupDrawer.tsx
+++ b/platform/app/src/components/governance/platform/InsightsSetupDrawer.tsx
@@ -22,10 +22,13 @@ import { Drawer } from "~/components/ui/drawer";
  * closes and drops the edits. There is no toast and no "saved" wording on
  * purpose: a confirmation here would claim a write that never happened.
  *
- * A drawer, not a modal, on the same shell the governance settings forms
- * use (DepartmentEditDrawer, RoutingPolicyDrawer): a right-hand sheet the
- * page stays visible behind, so the reader keeps the inbox in view while
- * they tune what fills it.
+ * A drawer, not a modal, on the same shell DepartmentEditDrawer uses: a
+ * right-hand sheet the page stays visible behind, so the reader keeps the
+ * inbox in view while they tune what fills it. Like that drawer it is
+ * page-owned rather than registered in drawerRegistry: the registry can
+ * only pass URL params, and this one needs the page's settings and its
+ * onSave callback. The known cost is that Langy's drawer dodge keys on the
+ * registry, so a floating Langy can sit over this sheet.
  *
  * Spec: specs/governance/governance-platform-placeholders.feature
  */

--- a/platform/app/src/components/governance/platform/InsightsSetupDrawer.tsx
+++ b/platform/app/src/components/governance/platform/InsightsSetupDrawer.tsx
@@ -1,8 +1,9 @@
 import {
   Button,
+  createListCollection,
+  Field,
   HStack,
   Input,
-  NativeSelect,
   Separator,
   Spacer,
   Text,
@@ -10,9 +11,14 @@ import {
   VStack,
 } from "@chakra-ui/react";
 import { UserRoundCog } from "lucide-react";
-import { type ReactNode, useEffect, useState } from "react";
+import { type ReactNode, useEffect, useMemo, useState } from "react";
 
+import { allModelOptions, ModelSelector } from "~/components/ModelSelector";
 import { Drawer } from "~/components/ui/drawer";
+import { Select } from "~/components/ui/select";
+import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
+import { LANGY_CHAT_FEATURE_KEY } from "~/server/modelProviders/codexRestrictions";
+import { api } from "~/utils/api";
 
 /**
  * What the daily Insights job would be told, if there were a job.
@@ -30,13 +36,21 @@ import { Drawer } from "~/components/ui/drawer";
  * onSave callback. The known cost is that Langy's drawer dodge keys on the
  * registry, so a floating Langy can sit over this sheet.
  *
+ * The Model row is the one control already wired to something real: it
+ * reads the model Langy's own routing resolves for this project (the same
+ * query the Langy panel seeds its picker from) and lists the same allowed
+ * models, through the shared ModelSelector. `model: null` means "whatever
+ * Langy is configured with", so a change in Model Providers follows here
+ * without anyone re-saving this drawer.
+ *
  * Spec: specs/governance/governance-platform-placeholders.feature
  */
 export interface InsightsSettings {
   runs: "daily" | "weekdays" | "weekly";
   at: string;
   volume: "langy" | "one" | "three";
-  model: "langy-default";
+  /** `provider/name`, or null to follow Langy's configured default. */
+  model: string | null;
   skillInstructions: string;
 }
 
@@ -44,7 +58,7 @@ export const DEFAULT_INSIGHTS_SETTINGS: InsightsSettings = {
   runs: "daily",
   at: "07:00",
   volume: "langy",
-  model: "langy-default",
+  model: null,
   skillInstructions: [
     "Every morning at 07:00, review yesterday's traffic across the whole substrate.",
     "",
@@ -56,6 +70,22 @@ export const DEFAULT_INSIGHTS_SETTINGS: InsightsSettings = {
     "- Attach evidence: the query and chart that show it, the signal that caught it, or the traces that prove it.",
   ].join("\n"),
 };
+
+const RUNS_OPTIONS = createListCollection({
+  items: [
+    { value: "daily", label: "Daily" },
+    { value: "weekdays", label: "Weekdays" },
+    { value: "weekly", label: "Weekly" },
+  ] satisfies Array<{ value: InsightsSettings["runs"]; label: string }>,
+});
+
+const VOLUME_OPTIONS = createListCollection({
+  items: [
+    { value: "langy", label: "Let Langy decide (recommended)" },
+    { value: "one", label: "At most one a day" },
+    { value: "three", label: "At most three a day" },
+  ] satisfies Array<{ value: InsightsSettings["volume"]; label: string }>,
+});
 
 /** What steering would have left behind. Illustrative until there is a session. */
 const LEARNED_PREFERENCES = [
@@ -74,17 +104,17 @@ function SettingRow({
   children: ReactNode;
 }) {
   return (
-    <VStack align="stretch" gap={2} paddingY={4}>
+    <Field.Root paddingY={4} gap={2}>
       <VStack align="start" gap={0.5}>
-        <Text fontSize="sm" fontWeight="medium">
+        <Field.Label fontSize="sm" fontWeight="medium">
           {label}
-        </Text>
-        <Text fontSize="xs" color="fg.muted">
+        </Field.Label>
+        <Field.HelperText fontSize="xs" color="fg.muted" marginTop={0}>
           {hint}
-        </Text>
+        </Field.HelperText>
       </VStack>
       {children}
-    </VStack>
+    </Field.Root>
   );
 }
 
@@ -107,6 +137,25 @@ export function InsightsSetupDrawer({
   }, [open, settings]);
   const patch = (next: Partial<InsightsSettings>) =>
     setDraft((current) => ({ ...current, ...next }));
+
+  // Same two queries the Langy panel seeds its own picker from: the model
+  // Langy's gate resolves for this project, and the models it may use.
+  const { project } = useOrganizationTeamProject();
+  const projectId = project?.id ?? "";
+  const langyDefaultQuery = api.modelProvider.getResolvedDefault.useQuery(
+    { projectId, featureKey: LANGY_CHAT_FEATURE_KEY },
+    { enabled: !!projectId && open, staleTime: 300_000 },
+  );
+  const modelsAllowedQuery = api.langy.modelsAllowed.useQuery(
+    { projectId },
+    { enabled: !!projectId && open, staleTime: 300_000 },
+  );
+  const modelOptions = useMemo(
+    () => modelsAllowedQuery.data?.modelsAllowed ?? allModelOptions,
+    [modelsAllowedQuery.data?.modelsAllowed],
+  );
+  const langyDefaultModel = langyDefaultQuery.data?.model ?? "";
+  const shownModel = draft.model ?? langyDefaultModel;
 
   return (
     <Drawer.Root
@@ -133,26 +182,29 @@ export function InsightsSetupDrawer({
               label="Runs"
               hint="How often the background job messages Langy"
             >
-              <NativeSelect.Root size="sm">
-                <NativeSelect.Field
-                  aria-label="Runs"
-                  value={draft.runs}
-                  onChange={(event) =>
-                    patch({
-                      runs: event.target.value as InsightsSettings["runs"],
-                    })
-                  }
-                >
-                  <option value="daily">Daily</option>
-                  <option value="weekdays">Weekdays</option>
-                  <option value="weekly">Weekly</option>
-                </NativeSelect.Field>
-                <NativeSelect.Indicator />
-              </NativeSelect.Root>
+              <Select.Root
+                collection={RUNS_OPTIONS}
+                size="sm"
+                value={[draft.runs]}
+                onValueChange={({ value }) => {
+                  const runs = value[0] as InsightsSettings["runs"] | undefined;
+                  if (runs) patch({ runs });
+                }}
+              >
+                <Select.Trigger>
+                  <Select.ValueText />
+                </Select.Trigger>
+                <Select.Content>
+                  {RUNS_OPTIONS.items.map((item) => (
+                    <Select.Item key={item.value} item={item}>
+                      {item.label}
+                    </Select.Item>
+                  ))}
+                </Select.Content>
+              </Select.Root>
             </SettingRow>
             <SettingRow label="At" hint="Europe/Amsterdam">
               <Input
-                aria-label="At"
                 type="time"
                 size="sm"
                 value={draft.at}
@@ -163,40 +215,46 @@ export function InsightsSetupDrawer({
               label="Volume"
               hint="Few insights that matter beat fifteen that don't"
             >
-              <NativeSelect.Root size="sm">
-                <NativeSelect.Field
-                  aria-label="Volume"
-                  value={draft.volume}
-                  onChange={(event) =>
-                    patch({
-                      volume: event.target.value as InsightsSettings["volume"],
-                    })
-                  }
-                >
-                  <option value="langy">Let Langy decide (recommended)</option>
-                  <option value="one">At most one a day</option>
-                  <option value="three">At most three a day</option>
-                </NativeSelect.Field>
-                <NativeSelect.Indicator />
-              </NativeSelect.Root>
+              <Select.Root
+                collection={VOLUME_OPTIONS}
+                size="sm"
+                value={[draft.volume]}
+                onValueChange={({ value }) => {
+                  const volume = value[0] as
+                    | InsightsSettings["volume"]
+                    | undefined;
+                  if (volume) patch({ volume });
+                }}
+              >
+                <Select.Trigger>
+                  <Select.ValueText />
+                </Select.Trigger>
+                <Select.Content>
+                  {VOLUME_OPTIONS.items.map((item) => (
+                    <Select.Item key={item.value} item={item}>
+                      {item.label}
+                    </Select.Item>
+                  ))}
+                </Select.Content>
+              </Select.Root>
             </SettingRow>
             <SettingRow
               label="Model"
-              hint="The model the eternal session runs on"
+              hint={
+                draft.model
+                  ? "The model the eternal session runs on"
+                  : "Langy's configured model. Pick another to override it here."
+              }
             >
-              {/* One option and nothing to write it to: read-only, not a
-                  controlled field pretending to accept a change. */}
-              <NativeSelect.Root size="sm" disabled>
-                <NativeSelect.Field
-                  aria-label="Model"
-                  defaultValue={draft.model}
-                >
-                  <option value="langy-default">
-                    claude-sonnet-4.5 · Langy default
-                  </option>
-                </NativeSelect.Field>
-                <NativeSelect.Indicator />
-              </NativeSelect.Root>
+              <ModelSelector
+                model={shownModel}
+                options={modelOptions}
+                onChange={(model) => patch({ model })}
+                size="full"
+                mode="chat"
+                showConfigureAction
+                forFeatureLabel="for Insights"
+              />
             </SettingRow>
             <SettingRow
               label="Session"
@@ -216,7 +274,6 @@ export function InsightsSetupDrawer({
               hint="What the daily job tells Langy. Edit it and the next run obeys."
             >
               <Textarea
-                aria-label="Skill instructions"
                 value={draft.skillInstructions}
                 onChange={(event) =>
                   patch({ skillInstructions: event.target.value })

--- a/platform/app/src/components/governance/platform/__tests__/exploreQuery.unit.test.ts
+++ b/platform/app/src/components/governance/platform/__tests__/exploreQuery.unit.test.ts
@@ -1,0 +1,63 @@
+/**
+ * The explore chart's title and query line are pure functions of the three
+ * controls. Pinned here so the sketch never drifts from what the controls
+ * say, and so the copy stays in full words.
+ *
+ * Spec: specs/governance/governance-platform-placeholders.feature
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_EXPLORE_SELECTION,
+  EXPLORE_TEMPLATES,
+  exploreChartTitle,
+  exploreQueryLine,
+} from "../exploreQuery";
+
+describe("the explore query line", () => {
+  describe("when the controls are changed", () => {
+    /** @scenario "The query line follows the measure, breakdown and interval" */
+    it("rewrites the aggregate, dimension and bin from the selection", () => {
+      const selection = {
+        measure: "requests",
+        breakdown: "model",
+        interval: "day",
+      } as const;
+
+      expect(exploreQueryLine(selection)).toBe(
+        "usage | summarize count() by model, bin(1d)",
+      );
+      expect(exploreChartTitle(selection)).toBe("Requests by model · daily");
+    });
+
+    it("opens on spend by department, weekly, in full words", () => {
+      expect(exploreQueryLine(DEFAULT_EXPLORE_SELECTION)).toBe(
+        "usage | summarize sum(cost) by department, bin(1w)",
+      );
+      expect(exploreChartTitle(DEFAULT_EXPLORE_SELECTION)).toBe(
+        "Cost by department · weekly",
+      );
+    });
+  });
+
+  describe("when a template is picked", () => {
+    /** @scenario "A template rewrites the three controls at once" */
+    it("carries a complete selection, so nothing is left over from before", () => {
+      const byModel = EXPLORE_TEMPLATES.find(
+        (template) => template.label === "Requests by model",
+      );
+      expect(byModel?.selection).toEqual({
+        measure: "requests",
+        breakdown: "model",
+        interval: "day",
+      });
+      for (const template of EXPLORE_TEMPLATES) {
+        expect(Object.keys(template.selection).sort()).toEqual([
+          "breakdown",
+          "interval",
+          "measure",
+        ]);
+      }
+    });
+  });
+});

--- a/platform/app/src/components/governance/platform/exploreQuery.ts
+++ b/platform/app/src/components/governance/platform/exploreQuery.ts
@@ -1,0 +1,130 @@
+/**
+ * The explore chart's three controls, and the two strings they drive: the
+ * chart title and the query line under it.
+ *
+ * The query line is a sketch of the language every governance surface is
+ * meant to compile through one day. Nothing parses it yet; it is copy, and
+ * it is kept here as a pure mapping so the title and the line can never
+ * disagree with the controls or with each other.
+ *
+ * Spec: specs/governance/governance-platform-placeholders.feature
+ */
+
+export type ExploreMeasure = "cost" | "requests" | "tokens" | "error_rate";
+export type ExploreBreakdown =
+  | "department"
+  | "tool"
+  | "model"
+  | "person"
+  | "project";
+export type ExploreInterval = "day" | "week" | "month";
+
+export interface ExploreSelection {
+  measure: ExploreMeasure;
+  breakdown: ExploreBreakdown;
+  interval: ExploreInterval;
+}
+
+export const EXPLORE_MEASURES: ReadonlyArray<{
+  value: ExploreMeasure;
+  label: string;
+  aggregate: string;
+}> = [
+  { value: "cost", label: "Cost", aggregate: "sum(cost)" },
+  { value: "requests", label: "Requests", aggregate: "count()" },
+  { value: "tokens", label: "Tokens", aggregate: "sum(tokens)" },
+  { value: "error_rate", label: "Error rate", aggregate: "avg(is_error)" },
+];
+
+export const EXPLORE_BREAKDOWNS: ReadonlyArray<{
+  value: ExploreBreakdown;
+  label: string;
+}> = [
+  { value: "department", label: "Department" },
+  { value: "tool", label: "Tool" },
+  { value: "model", label: "Model" },
+  { value: "person", label: "Person" },
+  { value: "project", label: "Project" },
+];
+
+export const EXPLORE_INTERVALS: ReadonlyArray<{
+  value: ExploreInterval;
+  label: string;
+  adverb: string;
+  bin: string;
+}> = [
+  { value: "day", label: "Daily", adverb: "daily", bin: "1d" },
+  { value: "week", label: "Weekly", adverb: "weekly", bin: "1w" },
+  { value: "month", label: "Monthly", adverb: "monthly", bin: "1M" },
+];
+
+export const EXPLORE_WINDOWS = ["24h", "7d", "30d", "90d", "1y"] as const;
+export type ExploreWindow = (typeof EXPLORE_WINDOWS)[number];
+export const DEFAULT_EXPLORE_WINDOW: ExploreWindow = "30d";
+
+export const DEFAULT_EXPLORE_SELECTION: ExploreSelection = {
+  measure: "cost",
+  breakdown: "department",
+  interval: "week",
+};
+
+/** Named starting points. Each carries a whole selection, never a patch. */
+export const EXPLORE_TEMPLATES: ReadonlyArray<{
+  label: string;
+  selection: ExploreSelection;
+}> = [
+  { label: "Spend by department", selection: DEFAULT_EXPLORE_SELECTION },
+  {
+    label: "Spend by tool",
+    selection: { measure: "cost", breakdown: "tool", interval: "week" },
+  },
+  {
+    label: "Requests by model",
+    selection: { measure: "requests", breakdown: "model", interval: "day" },
+  },
+  {
+    label: "Top people by spend",
+    selection: { measure: "cost", breakdown: "person", interval: "week" },
+  },
+  {
+    label: "Spend by project",
+    selection: { measure: "cost", breakdown: "project", interval: "week" },
+  },
+  {
+    label: "Error rate by department",
+    selection: {
+      measure: "error_rate",
+      breakdown: "department",
+      interval: "day",
+    },
+  },
+];
+
+function measureOf(selection: ExploreSelection) {
+  return EXPLORE_MEASURES.find((m) => m.value === selection.measure)!;
+}
+function intervalOf(selection: ExploreSelection) {
+  return EXPLORE_INTERVALS.find((i) => i.value === selection.interval)!;
+}
+
+/** "Cost by department · weekly" — full words, the same ones the query uses. */
+export function exploreChartTitle(selection: ExploreSelection): string {
+  return `${measureOf(selection).label} by ${selection.breakdown} · ${intervalOf(selection).adverb}`;
+}
+
+/** "usage | summarize sum(cost) by department, bin(1w)" */
+export function exploreQueryLine(selection: ExploreSelection): string {
+  return `usage | summarize ${measureOf(selection).aggregate} by ${selection.breakdown}, bin(${intervalOf(selection).bin})`;
+}
+
+/** Whether a selection is exactly one of the templates. */
+export function matchesTemplate(
+  selection: ExploreSelection,
+  template: { selection: ExploreSelection },
+): boolean {
+  return (
+    selection.measure === template.selection.measure &&
+    selection.breakdown === template.selection.breakdown &&
+    selection.interval === template.selection.interval
+  );
+}

--- a/platform/app/src/features/navigation/__tests__/ProductSidebar.integration.test.tsx
+++ b/platform/app/src/features/navigation/__tests__/ProductSidebar.integration.test.tsx
@@ -371,6 +371,32 @@ describe("the product sidebar", () => {
       // Tool Tiles folded into Inventory's Catalog tab.
       expect(screen.queryByText("Tool Tiles")).not.toBeInTheDocument();
     });
+
+    /** @scenario "The Platform group lists its three entries under one label" */
+    it("groups the Platform entries under one label, after the ungrouped ones", () => {
+      mockPathname = "/governance";
+      renderSidebar("governance");
+
+      expect(
+        screen.getByRole("button", { name: "Collapse Platform" }),
+      ).toBeInTheDocument();
+      // DOM order, not presence: the group sits after every flat entry
+      // and keeps its own order inside.
+      const labels = screen
+        .getAllByRole("link")
+        .map((link) => link.textContent?.trim())
+        .filter((label) =>
+          ["People", "Insights", "Analytics", "Signals & Alerts"].includes(
+            label ?? "",
+          ),
+        );
+      expect(labels).toEqual([
+        "People",
+        "Insights",
+        "Analytics",
+        "Signals & Alerts",
+      ]);
+    });
   });
 
   describe("when a page is opened by its address", () => {

--- a/platform/app/src/features/navigation/__tests__/ProductSidebar.integration.test.tsx
+++ b/platform/app/src/features/navigation/__tests__/ProductSidebar.integration.test.tsx
@@ -364,10 +364,9 @@ describe("the product sidebar", () => {
       expect(screen.getByText("Inventory")).toBeInTheDocument();
       expect(screen.getByText("Anomaly Rules")).toBeInTheDocument();
       expect(screen.getByText("People")).toBeInTheDocument();
-      // The flag mock reports every flag enabled, so the billed-cost
-      // placeholders are visible here too.
+      // Enabling Costs must not expose the unfinished Billed destination.
       expect(screen.getByText("Costs")).toBeInTheDocument();
-      expect(screen.getByText("Billed")).toBeInTheDocument();
+      expect(screen.queryByText("Billed")).not.toBeInTheDocument();
       // Tool Tiles folded into Inventory's Catalog tab.
       expect(screen.queryByText("Tool Tiles")).not.toBeInTheDocument();
     });

--- a/platform/app/src/features/navigation/__tests__/sectionNavParity.integration.test.tsx
+++ b/platform/app/src/features/navigation/__tests__/sectionNavParity.integration.test.tsx
@@ -131,8 +131,8 @@ describe("given the governance section navigation data", () => {
   });
 
   describe("when the governance layout renders with the billed-cost flag on", () => {
-    /** @scenario With the billed-cost flag on, Costs and Billed appear as placeholders */
-    it("lists Costs and Billed between Overview and Inventory, and the Platform entries after People", () => {
+    /** @scenario With the billed-cost flag on, Costs appears without the unfinished Billed destination */
+    it("lists Costs without Billed and keeps the Platform entries after People", () => {
       harness.enabledFlags = ["release_ui_governance_billed_cost_enabled"];
       render(<GovernanceLayout>x</GovernanceLayout>);
 
@@ -141,7 +141,6 @@ describe("given the governance section navigation data", () => {
       ).toEqual([
         { label: "Overview", href: "/governance" },
         { label: "Costs", href: "/governance/costs" },
-        { label: "Billed", href: "/governance/billed" },
         { label: "Inventory", href: "/governance/inventory" },
         { label: "Anomaly Rules", href: "/governance/anomaly-rules" },
         { label: "People", href: "/governance/people" },

--- a/platform/app/src/features/navigation/__tests__/sectionNavParity.integration.test.tsx
+++ b/platform/app/src/features/navigation/__tests__/sectionNavParity.integration.test.tsx
@@ -132,7 +132,7 @@ describe("given the governance section navigation data", () => {
 
   describe("when the governance layout renders with the billed-cost flag on", () => {
     /** @scenario With the billed-cost flag on, Costs and Billed appear as placeholders */
-    it("lists Costs and Billed between Overview and Inventory", () => {
+    it("lists Costs and Billed between Overview and Inventory, and the Platform entries after People", () => {
       harness.enabledFlags = ["release_ui_governance_billed_cost_enabled"];
       render(<GovernanceLayout>x</GovernanceLayout>);
 
@@ -145,6 +145,11 @@ describe("given the governance section navigation data", () => {
         { label: "Inventory", href: "/governance/inventory" },
         { label: "Anomaly Rules", href: "/governance/anomaly-rules" },
         { label: "People", href: "/governance/people" },
+        // The legacy rail has no grouping affordance, so the Platform
+        // entries list flat here; the v2 sidebar groups them.
+        { label: "Insights", href: "/governance/insights" },
+        { label: "Analytics", href: "/governance/analytics" },
+        { label: "Signals & Alerts", href: "/governance/signals" },
       ]);
 
       // The flag must resolve in organization context, gated on the org

--- a/platform/app/src/features/navigation/sectionNavItems.ts
+++ b/platform/app/src/features/navigation/sectionNavItems.ts
@@ -4,6 +4,7 @@ import {
   Coins,
   Eye,
   Gauge,
+  Inbox,
   KeyRound,
   LineChart,
   type LucideIcon,
@@ -11,6 +12,7 @@ import {
   ReceiptText,
   Route,
   Shield,
+  Target,
   Users,
   Webhook,
   Zap,
@@ -35,6 +37,12 @@ export interface SectionNavItemData {
    * presentations agree on what exists.
    */
   featureFlag?: FrontendFeatureFlag;
+  /**
+   * Listed under a labelled group in the navigation-v2 sidebar, after
+   * every ungrouped entry. The legacy section rail has no grouping
+   * affordance and lists grouped entries flat, in the same order.
+   */
+  group?: string;
 }
 
 export const gatewayNavItems: readonly SectionNavItemData[] = [
@@ -131,5 +139,33 @@ export const governanceNavItems: readonly SectionNavItemData[] = [
     href: "/governance/people",
     includePath: "/governance/people",
     icon: Users,
+  },
+  // The Platform group: placeholder screens for the brief, explore and
+  // rule registry that the cost work leads into. They ride the billed-cost
+  // flag so the audience previewing Costs previews these too.
+  // Spec: specs/governance/governance-platform-placeholders.feature
+  {
+    label: "Insights",
+    href: "/governance/insights",
+    includePath: "/governance/insights",
+    icon: Inbox,
+    featureFlag: "release_ui_governance_billed_cost_enabled",
+    group: "Platform",
+  },
+  {
+    label: "Analytics",
+    href: "/governance/analytics",
+    includePath: "/governance/analytics",
+    icon: LineChart,
+    featureFlag: "release_ui_governance_billed_cost_enabled",
+    group: "Platform",
+  },
+  {
+    label: "Signals & Alerts",
+    href: "/governance/signals",
+    includePath: "/governance/signals",
+    icon: Target,
+    featureFlag: "release_ui_governance_billed_cost_enabled",
+    group: "Platform",
   },
 ];

--- a/platform/app/src/features/navigation/sectionNavItems.ts
+++ b/platform/app/src/features/navigation/sectionNavItems.ts
@@ -116,13 +116,6 @@ export const governanceNavItems: readonly SectionNavItemData[] = [
     featureFlag: "release_ui_governance_billed_cost_enabled",
   },
   {
-    label: "Billed",
-    href: "/governance/billed",
-    includePath: "/governance/billed",
-    icon: ReceiptText,
-    featureFlag: "release_ui_governance_billed_cost_enabled",
-  },
-  {
     label: "Inventory",
     href: "/governance/inventory",
     includePath: "/governance/inventory",

--- a/platform/app/src/features/navigation/shell/ProductSidebar.tsx
+++ b/platform/app/src/features/navigation/shell/ProductSidebar.tsx
@@ -251,6 +251,9 @@ function SectionItemsNav({
   return (
     <>
       {ungrouped.map(renderLink)}
+      {/* The groups sit at the foot of the column, above the bottom block,
+          so the product's own pages stay in one place at the top. */}
+      {groups.size > 0 && <Box flex={1} width="full" />}
       {[...groups.entries()].map(([group, groupItems]) => (
         <SidebarSection
           key={group}

--- a/platform/app/src/features/navigation/shell/ProductSidebar.tsx
+++ b/platform/app/src/features/navigation/shell/ProductSidebar.tsx
@@ -216,6 +216,8 @@ function SettingsMenuBody({ showExpanded }: { showExpanded: boolean }) {
 /**
  * The Gateway and Governance sidebar bodies: the same registry data the
  * legacy section rails render, promoted to first-class sidebar entries.
+ * Ungrouped entries list flat first; each `group` then lists under its own
+ * collapsible label, in the order the groups first appear in the data.
  */
 function SectionItemsNav({
   items,
@@ -226,21 +228,38 @@ function SectionItemsNav({
 }) {
   const pathname = usePathname();
   const visibleItems = useVisibleSectionNavItems(items);
+  const ungrouped = visibleItems.filter((item) => item.group === undefined);
+  const groups = new Map<string, SectionNavItemData[]>();
+  for (const item of visibleItems) {
+    if (item.group === undefined) continue;
+    groups.set(item.group, [...(groups.get(item.group) ?? []), item]);
+  }
+  const renderLink = (item: SectionNavItemData) => (
+    <SideMenuLink
+      key={item.href}
+      icon={item.icon}
+      label={item.label}
+      href={item.href}
+      isActive={
+        item.includePath
+          ? isPathUnder({ pathname, base: item.includePath })
+          : pathname === item.href
+      }
+      showLabel={showExpanded}
+    />
+  );
   return (
     <>
-      {visibleItems.map((item) => (
-        <SideMenuLink
-          key={item.href}
-          icon={item.icon}
-          label={item.label}
-          href={item.href}
-          isActive={
-            item.includePath
-              ? isPathUnder({ pathname, base: item.includePath })
-              : pathname === item.href
-          }
-          showLabel={showExpanded}
-        />
+      {ungrouped.map(renderLink)}
+      {[...groups.entries()].map(([group, groupItems]) => (
+        <SidebarSection
+          key={group}
+          id={group.toLowerCase()}
+          label={group}
+          showExpanded={showExpanded}
+        >
+          {groupItems.map(renderLink)}
+        </SidebarSection>
       ))}
     </>
   );

--- a/platform/app/src/hooks/useRequiredSession.ts
+++ b/platform/app/src/hooks/useRequiredSession.ts
@@ -53,6 +53,9 @@ export const noOrgBouncerRoutes = [
   "/governance/people",
   "/governance/costs",
   "/governance/billed",
+  "/governance/insights",
+  "/governance/analytics",
+  "/governance/signals",
   // The retired addresses stay exempt so each redirect route renders
   // before the bouncer fires (cost-centers precedent below).
   "/governance/catalog",

--- a/platform/app/src/pages/governance/__tests__/costDepartmentFilter.integration.test.tsx
+++ b/platform/app/src/pages/governance/__tests__/costDepartmentFilter.integration.test.tsx
@@ -163,6 +163,35 @@ beforeEach(() => {
 afterEach(() => cleanup());
 
 describe("the department filter", () => {
+  describe("given real totals and activity in two departments", () => {
+    /** @scenario "The department filter explains that it changes only the department chart" */
+    it("names its panel-only scope and leaves totals and user costs unchanged", async () => {
+      renderScreen();
+      const userPanel = () =>
+        screen.getByText("Cost by user").closest('[data-testid="cost-panel"]')
+          ?.textContent;
+      const originalUserPanel = userPanel();
+      expect(originalUserPanel).toContain("ada@acme.test");
+      expect(screen.getByText("$123.45")).toBeInTheDocument();
+      expect(screen.getByText("$67.89")).toBeInTheDocument();
+
+      await pickFilter("Department", "Engineering");
+
+      expect(
+        screen.getByText(
+          "Department filters only the Cost by department chart.",
+        ),
+      ).toBeInTheDocument();
+      const departmentPanel = screen
+        .getByText("Cost by department")
+        .closest('[data-testid="cost-panel"]');
+      expect(departmentPanel?.textContent).toContain("Engineering");
+      expect(departmentPanel?.textContent).not.toContain("Support");
+      expect(screen.getByText("$123.45")).toBeInTheDocument();
+      expect(screen.getByText("$67.89")).toBeInTheDocument();
+      expect(userPanel()).toBe(originalUserPanel);
+    });
+  });
   describe("given a department is selected and the window then drops it", () => {
     it("never labels the chip all departments while still filtering by one", async () => {
       renderScreen();

--- a/platform/app/src/pages/governance/__tests__/costScreen.integration.test.tsx
+++ b/platform/app/src/pages/governance/__tests__/costScreen.integration.test.tsx
@@ -116,6 +116,7 @@ vi.mock("~/utils/api", () => {
   };
 });
 
+import BilledPage from "../billed";
 import CostsPage from "../costs";
 
 /** Every string a reader — eyes or screen reader — could get from a subtree. */
@@ -185,6 +186,20 @@ beforeEach(() => {
 afterEach(() => cleanup());
 
 describe("the governance cost screen", () => {
+  describe("given an admin with Costs enabled", () => {
+    /** @scenario "The unfinished Billed address stays unavailable when Costs is enabled" */
+    it("shows not found at the unfinished Billed address", () => {
+      render(
+        <ChakraProvider value={defaultSystem}>
+          <BilledPage />
+        </ChakraProvider>,
+      );
+      expect(screen.getByText("this page does not exist")).toBeInTheDocument();
+      expect(
+        screen.queryByRole("heading", { name: "Billed" }),
+      ).not.toBeInTheDocument();
+    });
+  });
   describe("given a permitted viewer and both lanes reporting", () => {
     /** @scenario "Each lane renders its own labeled total" */
     it("renders each lane's own amount under its own label", () => {

--- a/platform/app/src/pages/governance/__tests__/platformPlaceholders.integration.test.tsx
+++ b/platform/app/src/pages/governance/__tests__/platformPlaceholders.integration.test.tsx
@@ -4,7 +4,7 @@
  * The three Platform placeholder screens, mounted through their real pages
  * and guards. What is under test is the small set of promises the screens
  * make: they stay behind the billed-cost flag, they say exactly what they
- * say, Open Langy opens Langy, and the Setup dialog keeps its edits for the
+ * say, Open Langy opens Langy, and the Setup drawer keeps its edits for the
  * sitting without ever claiming to have stored them.
  *
  * Spec: specs/governance/governance-platform-placeholders.feature
@@ -163,7 +163,7 @@ describe("given the Insights screen", () => {
     expect(useLangyStore.getState().isOpen).toBe(true);
   });
 
-  /** @scenario "The Setup dialog keeps its edits for the sitting and never claims to save" */
+  /** @scenario "The Setup drawer keeps its edits for the sitting and never claims to save" */
   it("keeps a saved edit across close and reopen, with no confirmation", async () => {
     renderPage(InsightsPage);
 

--- a/platform/app/src/pages/governance/__tests__/platformPlaceholders.integration.test.tsx
+++ b/platform/app/src/pages/governance/__tests__/platformPlaceholders.integration.test.tsx
@@ -142,6 +142,17 @@ describe("given the Insights screen", () => {
     ).toBeInTheDocument();
   });
 
+  /** @scenario "Insights opens on an empty brief with one sentence of promise" */
+  it("paints the Langy mark without the Langy panel mounted", () => {
+    // Outside `.langy-root` the mark fills from an SVG gradient that only
+    // the Langy panel mounts, so a viewer without Langy would see nothing.
+    // Inside it the theme paints the mark in currentColor. The card must
+    // therefore BE the scope, not merely sit near one.
+    const { container } = renderPage(InsightsPage);
+    expect(container.querySelector(".langy-root .langy-mark")).not.toBeNull();
+    expect(container.querySelector(".langy-root linearGradient")).toBeNull();
+  });
+
   /** @scenario "Open Langy opens the Langy panel" */
   it("opens the Langy panel from Open Langy", () => {
     renderPage(InsightsPage);

--- a/platform/app/src/pages/governance/__tests__/platformPlaceholders.integration.test.tsx
+++ b/platform/app/src/pages/governance/__tests__/platformPlaceholders.integration.test.tsx
@@ -230,6 +230,7 @@ describe("given the Insights screen", () => {
     renderPage(InsightsPage);
     const rail = screen.getByRole("navigation", { name: "Insights folders" });
 
+    // The count rides in the row's own accessible name: "Inbox 0".
     for (const label of [
       "Inbox",
       "Stale",
@@ -237,13 +238,15 @@ describe("given the Insights screen", () => {
       "Alerts",
       "Notifications",
     ]) {
-      expect(within(rail).getByLabelText(`${label} count`)).toHaveTextContent(
-        "0",
-      );
+      expect(
+        within(rail).getByRole("button", {
+          name: new RegExp(`^${label}\\s*0$`),
+        }),
+      ).toBeInTheDocument();
     }
     expect(within(rail).getByRole("button", { name: /Inbox/ })).toHaveAttribute(
       "aria-current",
-      "page",
+      "true",
     );
 
     fireEvent.click(within(rail).getByRole("button", { name: /Stale/ }));

--- a/platform/app/src/pages/governance/__tests__/platformPlaceholders.integration.test.tsx
+++ b/platform/app/src/pages/governance/__tests__/platformPlaceholders.integration.test.tsx
@@ -142,20 +142,6 @@ describe("given the Insights screen", () => {
     ).toBeInTheDocument();
   });
 
-  /** @scenario "Insights opens on an empty brief with one sentence of promise" */
-  it("paints the Langy mark without the Langy panel mounted", () => {
-    // The mark fills from an SVG gradient by id. The Langy sidecar mounts
-    // one, but a viewer without Langy never has it, so the page must carry
-    // its own or the tile holds an invisible mark.
-    const { container } = renderPage(InsightsPage);
-    const mark = container.querySelector(".langy-mark path");
-    const gradientId = mark?.getAttribute("fill")?.match(/^url\(#(.+)\)$/)?.[1];
-    expect(gradientId).toBeTruthy();
-    expect(
-      container.querySelector(`linearGradient#${gradientId}`),
-    ).not.toBeNull();
-  });
-
   /** @scenario "Open Langy opens the Langy panel" */
   it("opens the Langy panel from Open Langy", () => {
     renderPage(InsightsPage);

--- a/platform/app/src/pages/governance/__tests__/platformPlaceholders.integration.test.tsx
+++ b/platform/app/src/pages/governance/__tests__/platformPlaceholders.integration.test.tsx
@@ -16,6 +16,7 @@ import {
   render,
   screen,
   waitFor,
+  within,
 } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
 import type React from "react";
@@ -70,6 +71,50 @@ vi.mock("~/components/LoadingScreen", () => ({
   LoadingScreen: () => <div>loading</div>,
 }));
 
+// The Model row reads the same two queries the Langy panel seeds its picker
+// from. Stubbed at the tRPC boundary so the assertion is about the WIRING:
+// what Langy is configured with is what the row shows.
+const LANGY_CONFIGURED_MODEL = "anthropic/claude-sonnet-4.5";
+const modelQueries = vi.hoisted(() => ({
+  getResolvedDefault: vi.fn(),
+  modelsAllowed: vi.fn(),
+}));
+vi.mock("~/utils/api", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("~/utils/api")>()),
+  api: {
+    modelProvider: {
+      getResolvedDefault: { useQuery: modelQueries.getResolvedDefault },
+    },
+    langy: { modelsAllowed: { useQuery: modelQueries.modelsAllowed } },
+  },
+}));
+// The shared picker drags the providers query and the registry along; a
+// native select standing in for it keeps this file about the drawer.
+vi.mock("~/components/ModelSelector", () => ({
+  allModelOptions: ["openai/gpt-5-mini"],
+  ModelSelector: ({
+    model,
+    options,
+    onChange,
+  }: {
+    model: string;
+    options: string[];
+    onChange: (model: string) => void;
+  }) => (
+    <select
+      data-testid="model-selector"
+      value={model}
+      onChange={(event) => onChange(event.target.value)}
+    >
+      {options.map((option) => (
+        <option key={option} value={option}>
+          {option}
+        </option>
+      ))}
+    </select>
+  ),
+}));
+
 import { useLangyStore } from "~/features/langy/stores/langyStore";
 import AnalyticsPage from "../analytics";
 import InsightsPage from "../insights";
@@ -83,9 +128,36 @@ function renderPage(Page: React.ComponentType) {
   );
 }
 
+/** The standard Select keeps a hidden native <select> in sync with its
+ *  state (zag's hidden select handles change), and the Field label names
+ *  both it and the trigger. The native one is the one a test can read and
+ *  change without portals. */
+const hiddenSelect = (label: string) =>
+  screen.getByLabelText(label, { selector: "select" });
+const findHiddenSelect = (label: string) =>
+  screen.findByLabelText(label, { selector: "select" });
+/** The state machine delivers the change a tick later; the trigger's text
+ *  is the proof it landed, so wait on that before pressing anything. */
+const pickOption = async (label: string, value: string, shown: string) => {
+  fireEvent.change(await findHiddenSelect(label), { target: { value } });
+  await waitFor(() =>
+    expect(screen.getByRole("combobox", { name: label })).toHaveTextContent(
+      shown,
+    ),
+  );
+};
+
 beforeEach(() => {
   harness.permissions = getOrganizationRolePermissions("ADMIN");
   harness.flagEnabled = true;
+  modelQueries.getResolvedDefault.mockReturnValue({
+    data: { model: LANGY_CONFIGURED_MODEL },
+    isLoading: false,
+  });
+  modelQueries.modelsAllowed.mockReturnValue({
+    data: { modelsAllowed: [LANGY_CONFIGURED_MODEL, "openai/gpt-5-mini"] },
+    isLoading: false,
+  });
   // The store persists `isOpen` and the unit lane shares the module between
   // files, so the panel can arrive already open. Start closed, every time.
   localStorage.clear();
@@ -153,6 +225,37 @@ describe("given the Insights screen", () => {
     expect(container.querySelector(".langy-root linearGradient")).toBeNull();
   });
 
+  /** @scenario "The inbox rail is in place at zero" */
+  it("shows the five folders at zero and swaps the body per folder", () => {
+    renderPage(InsightsPage);
+    const rail = screen.getByRole("navigation", { name: "Insights folders" });
+
+    for (const label of [
+      "Inbox",
+      "Stale",
+      "Archived",
+      "Alerts",
+      "Notifications",
+    ]) {
+      expect(within(rail).getByLabelText(`${label} count`)).toHaveTextContent(
+        "0",
+      );
+    }
+    expect(within(rail).getByRole("button", { name: /Inbox/ })).toHaveAttribute(
+      "aria-current",
+      "page",
+    );
+
+    fireEvent.click(within(rail).getByRole("button", { name: /Stale/ }));
+    expect(screen.getByText(/Nothing has gone stale/)).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("insights-empty-brief"),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(within(rail).getByRole("button", { name: /Inbox/ }));
+    expect(screen.getByTestId("insights-empty-brief")).toBeInTheDocument();
+  });
+
   /** @scenario "Open Langy opens the Langy panel" */
   it("opens the Langy panel from Open Langy", () => {
     renderPage(InsightsPage);
@@ -168,9 +271,8 @@ describe("given the Insights screen", () => {
     renderPage(InsightsPage);
 
     fireEvent.click(screen.getByRole("button", { name: "Set up data" }));
-    const runs = await screen.findByLabelText("Runs");
-    expect(runs).toHaveValue("daily");
-    fireEvent.change(runs, { target: { value: "weekly" } });
+    expect(await findHiddenSelect("Runs")).toHaveValue("daily");
+    await pickOption("Runs", "weekly", "Weekly");
     fireEvent.click(screen.getByRole("button", { name: "Save" }));
 
     await waitFor(() =>
@@ -179,7 +281,27 @@ describe("given the Insights screen", () => {
     expect(screen.queryByText(/saved/i)).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "Set up data" }));
-    expect(await screen.findByLabelText("Runs")).toHaveValue("weekly");
+    expect(await findHiddenSelect("Runs")).toHaveValue("weekly");
+  });
+
+  /** @scenario "The Model row follows Langy's configured model" */
+  it("shows the model Langy is configured with, from Langy's own gate", async () => {
+    renderPage(InsightsPage);
+
+    fireEvent.click(screen.getByRole("button", { name: "Set up data" }));
+
+    expect(await screen.findByTestId("model-selector")).toHaveValue(
+      LANGY_CONFIGURED_MODEL,
+    );
+    expect(modelQueries.getResolvedDefault).toHaveBeenCalledWith(
+      expect.objectContaining({ featureKey: "langy.chat" }),
+      expect.anything(),
+    );
+    expect(
+      screen.getByText(
+        "Langy's configured model. Pick another to override it here.",
+      ),
+    ).toBeInTheDocument();
   });
 
   /** @scenario "Cancel discards the sitting's edits" */
@@ -187,16 +309,14 @@ describe("given the Insights screen", () => {
     renderPage(InsightsPage);
 
     fireEvent.click(screen.getByRole("button", { name: "Set up data" }));
-    fireEvent.change(await screen.findByLabelText("Runs"), {
-      target: { value: "weekly" },
-    });
+    await pickOption("Runs", "weekly", "Weekly");
     fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
     await waitFor(() =>
       expect(screen.queryByLabelText("Runs")).not.toBeInTheDocument(),
     );
 
     fireEvent.click(screen.getByRole("button", { name: "Set up data" }));
-    expect(await screen.findByLabelText("Runs")).toHaveValue("daily");
+    expect(await findHiddenSelect("Runs")).toHaveValue("daily");
   });
 });
 
@@ -243,9 +363,9 @@ describe("given the Analytics screen", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Requests by model" }));
 
-    expect(screen.getByLabelText("Measure")).toHaveValue("requests");
-    expect(screen.getByLabelText("Break down by")).toHaveValue("model");
-    expect(screen.getByLabelText("Over time")).toHaveValue("day");
+    expect(hiddenSelect("Measure")).toHaveValue("requests");
+    expect(hiddenSelect("Break down by")).toHaveValue("model");
+    expect(hiddenSelect("Over time")).toHaveValue("day");
     expect(
       screen.getByText("usage | summarize count() by model, bin(1d)"),
     ).toBeInTheDocument();

--- a/platform/app/src/pages/governance/__tests__/platformPlaceholders.integration.test.tsx
+++ b/platform/app/src/pages/governance/__tests__/platformPlaceholders.integration.test.tsx
@@ -142,6 +142,20 @@ describe("given the Insights screen", () => {
     ).toBeInTheDocument();
   });
 
+  /** @scenario "Insights opens on an empty brief with one sentence of promise" */
+  it("paints the Langy mark without the Langy panel mounted", () => {
+    // The mark fills from an SVG gradient by id. The Langy sidecar mounts
+    // one, but a viewer without Langy never has it, so the page must carry
+    // its own or the tile holds an invisible mark.
+    const { container } = renderPage(InsightsPage);
+    const mark = container.querySelector(".langy-mark path");
+    const gradientId = mark?.getAttribute("fill")?.match(/^url\(#(.+)\)$/)?.[1];
+    expect(gradientId).toBeTruthy();
+    expect(
+      container.querySelector(`linearGradient#${gradientId}`),
+    ).not.toBeNull();
+  });
+
   /** @scenario "Open Langy opens the Langy panel" */
   it("opens the Langy panel from Open Langy", () => {
     renderPage(InsightsPage);

--- a/platform/app/src/pages/governance/__tests__/platformPlaceholders.integration.test.tsx
+++ b/platform/app/src/pages/governance/__tests__/platformPlaceholders.integration.test.tsx
@@ -1,0 +1,242 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The three Platform placeholder screens, mounted through their real pages
+ * and guards. What is under test is the small set of promises the screens
+ * make: they stay behind the billed-cost flag, they say exactly what they
+ * say, Open Langy opens Langy, and the Setup dialog keeps its edits for the
+ * sitting without ever claiming to have stored them.
+ *
+ * Spec: specs/governance/governance-platform-placeholders.feature
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import type React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  getOrganizationRolePermissions,
+  hasPermissionWithHierarchy,
+} from "~/server/api/rbac";
+
+const harness = vi.hoisted(() => ({
+  permissions: [] as string[],
+  flagEnabled: true,
+}));
+
+vi.mock("~/hooks/useOrganizationTeamProject", () => {
+  const holds = (permission: string) =>
+    hasPermissionWithHierarchy(harness.permissions, permission);
+  return {
+    useOrganizationTeamProject: () => ({
+      isLoading: false,
+      organization: { id: "org-1", slug: "acme", name: "ACME", teams: [] },
+      organizations: [],
+      project: undefined,
+      hasPermission: holds,
+      hasOrgPermission: holds,
+      hasAnyPermission: holds,
+    }),
+  };
+});
+
+vi.mock("~/hooks/useFeatureFlag", () => ({
+  useFeatureFlag: (flag: string) => ({
+    // The section-wide flag stays on so the tests are about THIS flag.
+    enabled:
+      flag === "release_ui_governance_billed_cost_enabled"
+        ? harness.flagEnabled
+        : true,
+    isLoading: false,
+  }),
+}));
+vi.mock("~/hooks/useActivePlan", () => ({
+  useActivePlan: () => ({ isEnterprise: true, activePlan: undefined }),
+}));
+vi.mock("~/components/governance/GovernanceLayout", () => ({
+  default: ({ children }: { children: React.ReactNode }) => children,
+}));
+vi.mock("~/components/NotFoundScene", () => ({
+  NotFoundScene: () => <div>this page does not exist</div>,
+}));
+vi.mock("~/components/LoadingScreen", () => ({
+  LoadingScreen: () => <div>loading</div>,
+}));
+
+import { useLangyStore } from "~/features/langy/stores/langyStore";
+import AnalyticsPage from "../analytics";
+import InsightsPage from "../insights";
+import SignalsPage from "../signals";
+
+function renderPage(Page: React.ComponentType) {
+  return render(
+    <ChakraProvider value={defaultSystem}>
+      <Page />
+    </ChakraProvider>,
+  );
+}
+
+beforeEach(() => {
+  harness.permissions = getOrganizationRolePermissions("ADMIN");
+  harness.flagEnabled = true;
+  // The store persists `isOpen` and the unit lane shares the module between
+  // files, so the panel can arrive already open. Start closed, every time.
+  localStorage.clear();
+  useLangyStore.setState({ isOpen: false });
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("given the billed-cost flag is off for a permitted viewer", () => {
+  /** @scenario "The Platform screens are unreachable with the billed-cost flag off" */
+  it("shows the not-found scene on every Platform screen", () => {
+    expect(
+      hasPermissionWithHierarchy(harness.permissions, "governance:view"),
+    ).toBe(true);
+    harness.flagEnabled = false;
+
+    for (const Page of [InsightsPage, AnalyticsPage, SignalsPage]) {
+      renderPage(Page);
+      expect(screen.getByText("this page does not exist")).toBeInTheDocument();
+      cleanup();
+    }
+
+    // The identical setup with the flag ON renders the screens, which is
+    // what makes the assertion above about the FLAG.
+    harness.flagEnabled = true;
+    renderPage(InsightsPage);
+    expect(
+      screen.getByRole("heading", { name: "Insights" }),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("given the Insights screen", () => {
+  /** @scenario "Insights opens on an empty brief with one sentence of promise" */
+  it("opens on the empty brief with exactly one sentence of promise", () => {
+    renderPage(InsightsPage);
+
+    expect(
+      screen.getByRole("heading", { name: "Insights" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Every morning a background job reads yesterday's traffic and files a couple of high-signal insights: not fifteen a day.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/Push back on one/)).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Set up data" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Open Langy" }),
+    ).toBeInTheDocument();
+  });
+
+  /** @scenario "Open Langy opens the Langy panel" */
+  it("opens the Langy panel from Open Langy", () => {
+    renderPage(InsightsPage);
+    expect(useLangyStore.getState().isOpen).toBe(false);
+
+    fireEvent.click(screen.getByRole("button", { name: "Open Langy" }));
+
+    expect(useLangyStore.getState().isOpen).toBe(true);
+  });
+
+  /** @scenario "The Setup dialog keeps its edits for the sitting and never claims to save" */
+  it("keeps a saved edit across close and reopen, with no confirmation", async () => {
+    renderPage(InsightsPage);
+
+    fireEvent.click(screen.getByRole("button", { name: "Set up data" }));
+    const runs = await screen.findByLabelText("Runs");
+    expect(runs).toHaveValue("daily");
+    fireEvent.change(runs, { target: { value: "weekly" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() =>
+      expect(screen.queryByLabelText("Runs")).not.toBeInTheDocument(),
+    );
+    expect(screen.queryByText(/saved/i)).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Set up data" }));
+    expect(await screen.findByLabelText("Runs")).toHaveValue("weekly");
+  });
+
+  /** @scenario "Cancel discards the sitting's edits" */
+  it("discards an edit on Cancel", async () => {
+    renderPage(InsightsPage);
+
+    fireEvent.click(screen.getByRole("button", { name: "Set up data" }));
+    fireEvent.change(await screen.findByLabelText("Runs"), {
+      target: { value: "weekly" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    await waitFor(() =>
+      expect(screen.queryByLabelText("Runs")).not.toBeInTheDocument(),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Set up data" }));
+    expect(await screen.findByLabelText("Runs")).toHaveValue("daily");
+  });
+});
+
+describe("given the Signals & Alerts screen", () => {
+  /** @scenario "Signals & Alerts opens on an empty registry" */
+  it("opens on the empty registry with its two links", () => {
+    renderPage(SignalsPage);
+
+    expect(
+      screen.getByRole("heading", { name: "Signals & Alerts" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "No rules scoped here yet. Create one from any chart's bell icon.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "Insights inbox" }),
+    ).toHaveAttribute("href", "/governance/insights");
+    expect(
+      screen.getByRole("link", { name: "model providers" }),
+    ).toHaveAttribute("href", "/settings/model-providers");
+  });
+});
+
+describe("given the Analytics screen", () => {
+  /** @scenario "Analytics opens on the spend-by-department template" */
+  it("opens on spend by department, weekly, with no data", () => {
+    renderPage(AnalyticsPage);
+
+    expect(
+      screen.getByRole("heading", { name: "Analytics" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Cost by department · weekly")).toBeInTheDocument();
+    expect(screen.getByText("No data yet")).toBeInTheDocument();
+    expect(
+      screen.getByText("usage | summarize sum(cost) by department, bin(1w)"),
+    ).toBeInTheDocument();
+  });
+
+  /** @scenario "A template rewrites the three controls at once" */
+  it("rewrites measure, breakdown and interval from a template", () => {
+    renderPage(AnalyticsPage);
+
+    fireEvent.click(screen.getByRole("button", { name: "Requests by model" }));
+
+    expect(screen.getByLabelText("Measure")).toHaveValue("requests");
+    expect(screen.getByLabelText("Break down by")).toHaveValue("model");
+    expect(screen.getByLabelText("Over time")).toHaveValue("day");
+    expect(
+      screen.getByText("usage | summarize count() by model, bin(1d)"),
+    ).toBeInTheDocument();
+  });
+});

--- a/platform/app/src/pages/governance/analytics.tsx
+++ b/platform/app/src/pages/governance/analytics.tsx
@@ -125,7 +125,7 @@ function AnalyticsPage() {
                       key={template.label}
                       size="xs"
                       variant={active ? "subtle" : "outline"}
-                      colorPalette={active ? "purple" : "gray"}
+                      colorPalette={active ? "orange" : "gray"}
                       borderRadius="full"
                       fontWeight={active ? "medium" : "normal"}
                       onClick={() => setSelection(template.selection)}
@@ -216,8 +216,8 @@ function AnalyticsPage() {
               >
                 <HStack gap={3}>
                   <Badge
-                    background="gray.900"
-                    color="white"
+                    background="fg"
+                    color="bg"
                     fontFamily="mono"
                     fontSize="xs"
                   >

--- a/platform/app/src/pages/governance/analytics.tsx
+++ b/platform/app/src/pages/governance/analytics.tsx
@@ -3,6 +3,7 @@ import {
   Box,
   Button,
   createListCollection,
+  Field,
   Heading,
   HStack,
   Tabs,
@@ -258,37 +259,36 @@ function ControlSelect({
     [options],
   );
   return (
-    <Select.Root
-      collection={collection}
-      size="sm"
-      width="auto"
-      flexDirection="row"
-      alignItems="center"
-      gap={2}
-      value={[value]}
-      onValueChange={({ value: next }) => {
-        if (next[0]) onChange(next[0]);
-      }}
-    >
-      <Select.Label
+    <Field.Root orientation="horizontal" width="auto" gap={2}>
+      <Field.Label
         fontSize="sm"
         color="fg.muted"
         fontWeight="normal"
         whiteSpace="nowrap"
       >
         {label}
-      </Select.Label>
-      <Select.Trigger width="150px" fontWeight="medium">
-        <Select.ValueText />
-      </Select.Trigger>
-      <Select.Content>
-        {options.map((option) => (
-          <Select.Item key={option.value} item={option}>
-            {option.label}
-          </Select.Item>
-        ))}
-      </Select.Content>
-    </Select.Root>
+      </Field.Label>
+      <Select.Root
+        collection={collection}
+        size="sm"
+        width="150px"
+        value={[value]}
+        onValueChange={({ value: next }) => {
+          if (next[0]) onChange(next[0]);
+        }}
+      >
+        <Select.Trigger fontWeight="medium">
+          <Select.ValueText />
+        </Select.Trigger>
+        <Select.Content>
+          {options.map((option) => (
+            <Select.Item key={option.value} item={option}>
+              {option.label}
+            </Select.Item>
+          ))}
+        </Select.Content>
+      </Select.Root>
+    </Field.Root>
   );
 }
 

--- a/platform/app/src/pages/governance/analytics.tsx
+++ b/platform/app/src/pages/governance/analytics.tsx
@@ -54,11 +54,6 @@ function AnalyticsPage() {
   const [timeWindow, setTimeWindow] = useState<ExploreWindow>(
     DEFAULT_EXPLORE_WINDOW,
   );
-  const [selection, setSelection] = useState<ExploreSelection>(
-    DEFAULT_EXPLORE_SELECTION,
-  );
-  const patch = (next: Partial<ExploreSelection>) =>
-    setSelection((current) => ({ ...current, ...next }));
 
   return (
     <GovernanceLayout pageTitle="Analytics · AI Governance · LangWatch">
@@ -103,136 +98,7 @@ function AnalyticsPage() {
             </Tabs.Trigger>
           </Tabs.List>
           <Tabs.Content value="explore" paddingTop={4}>
-            <VStack align="stretch" gap={4}>
-              <HStack gap={2} flexWrap="wrap">
-                <Text
-                  fontSize="xs"
-                  fontWeight="semibold"
-                  letterSpacing="0.08em"
-                  color="fg.muted"
-                  textTransform="uppercase"
-                  paddingRight={1}
-                >
-                  Templates
-                </Text>
-                {EXPLORE_TEMPLATES.map((template) => {
-                  const active = matchesTemplate(selection, template);
-                  return (
-                    <Button
-                      key={template.label}
-                      size="xs"
-                      variant={active ? "subtle" : "outline"}
-                      colorPalette={active ? "orange" : "gray"}
-                      borderRadius="full"
-                      fontWeight={active ? "medium" : "normal"}
-                      onClick={() => setSelection(template.selection)}
-                    >
-                      {template.label}
-                    </Button>
-                  );
-                })}
-              </HStack>
-
-              <HStack
-                gap={4}
-                flexWrap="wrap"
-                borderWidth="1px"
-                borderColor="border.muted"
-                borderRadius="lg"
-                paddingX={4}
-                paddingY={3}
-              >
-                <ControlSelect
-                  label="Measure"
-                  value={selection.measure}
-                  onChange={(value) =>
-                    patch({ measure: value as ExploreMeasure })
-                  }
-                  options={EXPLORE_MEASURES}
-                />
-                <ControlSelect
-                  label="Break down by"
-                  value={selection.breakdown}
-                  onChange={(value) =>
-                    patch({ breakdown: value as ExploreBreakdown })
-                  }
-                  options={EXPLORE_BREAKDOWNS}
-                />
-                <ControlSelect
-                  label="Over time"
-                  value={selection.interval}
-                  onChange={(value) =>
-                    patch({ interval: value as ExploreInterval })
-                  }
-                  options={EXPLORE_INTERVALS}
-                />
-                <Button
-                  size="sm"
-                  variant="outline"
-                  borderStyle="dashed"
-                  fontWeight="normal"
-                >
-                  <Filter size={14} />
-                  Add filter
-                </Button>
-              </HStack>
-
-              <VStack
-                align="stretch"
-                gap={1}
-                borderWidth="1px"
-                borderColor="border.muted"
-                borderRadius="lg"
-                padding={5}
-                minHeight="440px"
-              >
-                <Text fontWeight="semibold">
-                  {exploreChartTitle(selection)}
-                </Text>
-                <Text fontSize="sm" color="fg.muted">
-                  {orgName} · last {timeWindow}
-                </Text>
-                <Box
-                  flex={1}
-                  display="flex"
-                  alignItems="center"
-                  justifyContent="center"
-                >
-                  <Text color="fg.muted">No data yet</Text>
-                </Box>
-              </VStack>
-
-              <HStack
-                justify="space-between"
-                gap={4}
-                flexWrap="wrap"
-                background="bg.muted"
-                borderRadius="lg"
-                paddingX={4}
-                paddingY={3}
-              >
-                <HStack gap={3}>
-                  <Badge
-                    background="fg"
-                    color="bg"
-                    fontFamily="mono"
-                    fontSize="xs"
-                  >
-                    lwql
-                  </Badge>
-                  <Text fontFamily="mono" fontSize="sm">
-                    {exploreQueryLine(selection)}
-                  </Text>
-                </HStack>
-                <HStack gap={2} color="fg.muted">
-                  <Copy size={14} />
-                  <Text fontSize="sm">
-                    every surface (dashboards, signals, alerts, Langy) compiles
-                    to this
-                  </Text>
-                </HStack>
-              </HStack>
-            </VStack>
+            <ExploreTab orgName={orgName} timeWindow={timeWindow} />
           </Tabs.Content>
           <Tabs.Content value="dashboards" paddingTop={4}>
             <Text color="fg.muted">No dashboards yet.</Text>
@@ -240,6 +106,169 @@ function AnalyticsPage() {
         </Tabs.Root>
       </VStack>
     </GovernanceLayout>
+  );
+}
+
+/** Template chips, the three controls, the chart body and the query line. */
+function ExploreTab({
+  orgName,
+  timeWindow,
+}: {
+  orgName: string;
+  timeWindow: ExploreWindow;
+}) {
+  const [selection, setSelection] = useState<ExploreSelection>(
+    DEFAULT_EXPLORE_SELECTION,
+  );
+  const patch = (next: Partial<ExploreSelection>) =>
+    setSelection((current) => ({ ...current, ...next }));
+
+  return (
+    <VStack align="stretch" gap={4}>
+      <TemplateChips selection={selection} onPick={setSelection} />
+      <HStack
+        gap={4}
+        flexWrap="wrap"
+        borderWidth="1px"
+        borderColor="border.muted"
+        borderRadius="lg"
+        paddingX={4}
+        paddingY={3}
+      >
+        <ControlSelect
+          label="Measure"
+          value={selection.measure}
+          onChange={(value) => patch({ measure: value as ExploreMeasure })}
+          options={EXPLORE_MEASURES}
+        />
+        <ControlSelect
+          label="Break down by"
+          value={selection.breakdown}
+          onChange={(value) => patch({ breakdown: value as ExploreBreakdown })}
+          options={EXPLORE_BREAKDOWNS}
+        />
+        <ControlSelect
+          label="Over time"
+          value={selection.interval}
+          onChange={(value) => patch({ interval: value as ExploreInterval })}
+          options={EXPLORE_INTERVALS}
+        />
+        <Button
+          size="sm"
+          variant="outline"
+          borderStyle="dashed"
+          fontWeight="normal"
+        >
+          <Filter size={14} />
+          Add filter
+        </Button>
+      </HStack>
+      <ExploreChart
+        selection={selection}
+        orgName={orgName}
+        timeWindow={timeWindow}
+      />
+      <QueryLine selection={selection} />
+    </VStack>
+  );
+}
+
+function TemplateChips({
+  selection,
+  onPick,
+}: {
+  selection: ExploreSelection;
+  onPick: (selection: ExploreSelection) => void;
+}) {
+  return (
+    <HStack gap={2} flexWrap="wrap">
+      <Text
+        fontSize="xs"
+        fontWeight="semibold"
+        letterSpacing="0.08em"
+        color="fg.muted"
+        textTransform="uppercase"
+        paddingRight={1}
+      >
+        Templates
+      </Text>
+      {EXPLORE_TEMPLATES.map((template) => {
+        const active = matchesTemplate(selection, template);
+        return (
+          <Button
+            key={template.label}
+            size="xs"
+            variant={active ? "subtle" : "outline"}
+            colorPalette={active ? "orange" : "gray"}
+            borderRadius="full"
+            fontWeight={active ? "medium" : "normal"}
+            onClick={() => onPick(template.selection)}
+          >
+            {template.label}
+          </Button>
+        );
+      })}
+    </HStack>
+  );
+}
+
+/** The chart body is not real yet and says so. */
+function ExploreChart({
+  selection,
+  orgName,
+  timeWindow,
+}: {
+  selection: ExploreSelection;
+  orgName: string;
+  timeWindow: ExploreWindow;
+}) {
+  return (
+    <VStack
+      align="stretch"
+      gap={1}
+      borderWidth="1px"
+      borderColor="border.muted"
+      borderRadius="lg"
+      padding={5}
+      minHeight="440px"
+    >
+      <Text fontWeight="semibold">{exploreChartTitle(selection)}</Text>
+      <Text fontSize="sm" color="fg.muted">
+        {orgName} · last {timeWindow}
+      </Text>
+      <Box flex={1} display="flex" alignItems="center" justifyContent="center">
+        <Text color="fg.muted">No data yet</Text>
+      </Box>
+    </VStack>
+  );
+}
+
+function QueryLine({ selection }: { selection: ExploreSelection }) {
+  return (
+    <HStack
+      justify="space-between"
+      gap={4}
+      flexWrap="wrap"
+      background="bg.muted"
+      borderRadius="lg"
+      paddingX={4}
+      paddingY={3}
+    >
+      <HStack gap={3}>
+        <Badge background="fg" color="bg" fontFamily="mono" fontSize="xs">
+          lwql
+        </Badge>
+        <Text fontFamily="mono" fontSize="sm">
+          {exploreQueryLine(selection)}
+        </Text>
+      </HStack>
+      <HStack gap={2} color="fg.muted">
+        <Copy size={14} />
+        <Text fontSize="sm">
+          every surface (dashboards, signals, alerts, Langy) compiles to this
+        </Text>
+      </HStack>
+    </HStack>
   );
 }
 

--- a/platform/app/src/pages/governance/analytics.tsx
+++ b/platform/app/src/pages/governance/analytics.tsx
@@ -1,0 +1,294 @@
+import {
+  Badge,
+  Box,
+  Button,
+  Heading,
+  HStack,
+  NativeSelect,
+  SegmentGroup,
+  Tabs,
+  Text,
+  VStack,
+} from "@chakra-ui/react";
+import { Copy, Filter } from "lucide-react";
+import { useState } from "react";
+
+import GovernanceLayout from "~/components/governance/GovernanceLayout";
+import {
+  DEFAULT_EXPLORE_SELECTION,
+  DEFAULT_EXPLORE_WINDOW,
+  EXPLORE_BREAKDOWNS,
+  EXPLORE_INTERVALS,
+  EXPLORE_MEASURES,
+  EXPLORE_TEMPLATES,
+  EXPLORE_WINDOWS,
+  type ExploreBreakdown,
+  type ExploreInterval,
+  type ExploreMeasure,
+  type ExploreSelection,
+  type ExploreWindow,
+  exploreChartTitle,
+  exploreQueryLine,
+  matchesTemplate,
+} from "~/components/governance/platform/exploreQuery";
+import { withFeatureFlagGuard } from "~/components/WithFeatureFlagGuard";
+import { withPermissionGuard } from "~/components/WithPermissionGuard";
+import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
+
+/**
+ * The explore surface before there is an engine under it.
+ *
+ * The controls are real and drive the title and the query line; the chart
+ * body is not, and says so. Nothing here runs a query.
+ *
+ * Spec: specs/governance/governance-platform-placeholders.feature
+ */
+function AnalyticsPage() {
+  const { organization } = useOrganizationTeamProject({
+    redirectToOnboarding: false,
+    redirectToProjectOnboarding: false,
+  });
+  const orgName = organization?.name ?? "your organization";
+  const [window, setWindow] = useState<ExploreWindow>(DEFAULT_EXPLORE_WINDOW);
+  const [selection, setSelection] = useState<ExploreSelection>(
+    DEFAULT_EXPLORE_SELECTION,
+  );
+  const patch = (next: Partial<ExploreSelection>) =>
+    setSelection((current) => ({ ...current, ...next }));
+
+  return (
+    <GovernanceLayout pageTitle="Analytics · AI Governance · LangWatch">
+      <VStack align="stretch" gap={5} width="full">
+        <HStack justify="space-between" align="start" gap={6}>
+          <VStack align="start" gap={1}>
+            <Heading size="md">Analytics</Heading>
+            <Text color="fg.muted">
+              Explore anything in {orgName} using the same engine that powers
+              every chart, dashboard, signal and alert.
+            </Text>
+          </VStack>
+          <SegmentGroup.Root
+            size="sm"
+            value={window}
+            onValueChange={({ value }) => {
+              if (value) setWindow(value as ExploreWindow);
+            }}
+            flexShrink={0}
+          >
+            <SegmentGroup.Indicator />
+            {EXPLORE_WINDOWS.map((option) => (
+              <SegmentGroup.Item key={option} value={option}>
+                <SegmentGroup.ItemText>{option}</SegmentGroup.ItemText>
+                <SegmentGroup.ItemHiddenInput />
+              </SegmentGroup.Item>
+            ))}
+          </SegmentGroup.Root>
+        </HStack>
+
+        <Tabs.Root defaultValue="explore" variant="line">
+          <Tabs.List>
+            <Tabs.Trigger
+              value="explore"
+              color="fg.muted"
+              _selected={{ color: "fg", fontWeight: "semibold" }}
+            >
+              Explore
+            </Tabs.Trigger>
+            <Tabs.Trigger
+              value="dashboards"
+              color="fg.muted"
+              _selected={{ color: "fg", fontWeight: "semibold" }}
+            >
+              Dashboards
+              <Badge size="xs" variant="subtle" colorPalette="gray">
+                0
+              </Badge>
+            </Tabs.Trigger>
+          </Tabs.List>
+          <Tabs.Content value="explore" paddingTop={4}>
+            <VStack align="stretch" gap={4}>
+              <HStack gap={2} flexWrap="wrap">
+                <Text
+                  fontSize="xs"
+                  fontWeight="semibold"
+                  letterSpacing="0.08em"
+                  color="fg.muted"
+                  textTransform="uppercase"
+                  paddingRight={1}
+                >
+                  Templates
+                </Text>
+                {EXPLORE_TEMPLATES.map((template) => {
+                  const active = matchesTemplate(selection, template);
+                  return (
+                    <Button
+                      key={template.label}
+                      size="xs"
+                      variant={active ? "subtle" : "outline"}
+                      colorPalette={active ? "purple" : "gray"}
+                      borderRadius="full"
+                      fontWeight={active ? "medium" : "normal"}
+                      onClick={() => setSelection(template.selection)}
+                    >
+                      {template.label}
+                    </Button>
+                  );
+                })}
+              </HStack>
+
+              <HStack
+                gap={4}
+                flexWrap="wrap"
+                borderWidth="1px"
+                borderColor="border.subtle"
+                borderRadius="lg"
+                paddingX={4}
+                paddingY={3}
+              >
+                <ControlSelect
+                  label="Measure"
+                  value={selection.measure}
+                  onChange={(value) =>
+                    patch({ measure: value as ExploreMeasure })
+                  }
+                  options={EXPLORE_MEASURES}
+                />
+                <ControlSelect
+                  label="Break down by"
+                  value={selection.breakdown}
+                  onChange={(value) =>
+                    patch({ breakdown: value as ExploreBreakdown })
+                  }
+                  options={EXPLORE_BREAKDOWNS}
+                />
+                <ControlSelect
+                  label="Over time"
+                  value={selection.interval}
+                  onChange={(value) =>
+                    patch({ interval: value as ExploreInterval })
+                  }
+                  options={EXPLORE_INTERVALS}
+                />
+                <Button
+                  size="sm"
+                  variant="outline"
+                  borderStyle="dashed"
+                  fontWeight="normal"
+                >
+                  <Filter size={14} />
+                  Add filter
+                </Button>
+              </HStack>
+
+              <VStack
+                align="stretch"
+                gap={1}
+                borderWidth="1px"
+                borderColor="border.subtle"
+                borderRadius="lg"
+                padding={5}
+                minHeight="440px"
+              >
+                <Text fontWeight="semibold">
+                  {exploreChartTitle(selection)}
+                </Text>
+                <Text fontSize="sm" color="fg.muted">
+                  {orgName} · last {window}
+                </Text>
+                <Box
+                  flex={1}
+                  display="flex"
+                  alignItems="center"
+                  justifyContent="center"
+                >
+                  <Text color="fg.muted">No data yet</Text>
+                </Box>
+              </VStack>
+
+              <HStack
+                justify="space-between"
+                gap={4}
+                flexWrap="wrap"
+                background="bg.muted"
+                borderRadius="lg"
+                paddingX={4}
+                paddingY={3}
+              >
+                <HStack gap={3}>
+                  <Badge
+                    background="gray.900"
+                    color="white"
+                    fontFamily="mono"
+                    fontSize="xs"
+                  >
+                    lwql
+                  </Badge>
+                  <Text fontFamily="mono" fontSize="sm">
+                    {exploreQueryLine(selection)}
+                  </Text>
+                </HStack>
+                <HStack gap={2} color="fg.muted">
+                  <Copy size={14} />
+                  <Text fontSize="sm">
+                    every surface (dashboards, signals, alerts, Langy) compiles
+                    to this
+                  </Text>
+                </HStack>
+              </HStack>
+            </VStack>
+          </Tabs.Content>
+          <Tabs.Content value="dashboards" paddingTop={4}>
+            <Text color="fg.muted">No dashboards yet.</Text>
+          </Tabs.Content>
+        </Tabs.Root>
+      </VStack>
+    </GovernanceLayout>
+  );
+}
+
+function ControlSelect({
+  label,
+  value,
+  onChange,
+  options,
+}: {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  options: ReadonlyArray<{ value: string; label: string }>;
+}) {
+  return (
+    <HStack gap={2}>
+      <Text fontSize="sm" color="fg.muted" whiteSpace="nowrap">
+        {label}
+      </Text>
+      <NativeSelect.Root size="sm" width="150px">
+        <NativeSelect.Field
+          aria-label={label}
+          value={value}
+          fontWeight="medium"
+          onChange={(event) => onChange(event.target.value)}
+        >
+          {options.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </NativeSelect.Field>
+        <NativeSelect.Indicator />
+      </NativeSelect.Root>
+    </HStack>
+  );
+}
+
+export default withFeatureFlagGuard("release_ui_ai_governance_enabled", {
+  bypassOnboardingRedirect: true,
+})(
+  withFeatureFlagGuard("release_ui_governance_billed_cost_enabled", {
+    bypassOnboardingRedirect: true,
+  })(
+    withPermissionGuard("governance:view", {
+      bypassOnboardingRedirect: true,
+    })(AnalyticsPage),
+  ),
+);

--- a/platform/app/src/pages/governance/analytics.tsx
+++ b/platform/app/src/pages/governance/analytics.tsx
@@ -2,15 +2,15 @@ import {
   Badge,
   Box,
   Button,
+  createListCollection,
   Heading,
   HStack,
-  NativeSelect,
   Tabs,
   Text,
   VStack,
 } from "@chakra-ui/react";
 import { Copy, Filter } from "lucide-react";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 
 import GovernanceLayout from "~/components/governance/GovernanceLayout";
 import {
@@ -31,6 +31,7 @@ import {
   matchesTemplate,
 } from "~/components/governance/platform/exploreQuery";
 import { SegmentedControl } from "~/components/ui/segmented-control";
+import { Select } from "~/components/ui/select";
 import { withFeatureFlagGuard } from "~/components/WithFeatureFlagGuard";
 import { withPermissionGuard } from "~/components/WithPermissionGuard";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
@@ -252,27 +253,42 @@ function ControlSelect({
   onChange: (value: string) => void;
   options: ReadonlyArray<{ value: string; label: string }>;
 }) {
+  const collection = useMemo(
+    () => createListCollection({ items: [...options] }),
+    [options],
+  );
   return (
-    <HStack gap={2}>
-      <Text fontSize="sm" color="fg.muted" whiteSpace="nowrap">
+    <Select.Root
+      collection={collection}
+      size="sm"
+      width="auto"
+      flexDirection="row"
+      alignItems="center"
+      gap={2}
+      value={[value]}
+      onValueChange={({ value: next }) => {
+        if (next[0]) onChange(next[0]);
+      }}
+    >
+      <Select.Label
+        fontSize="sm"
+        color="fg.muted"
+        fontWeight="normal"
+        whiteSpace="nowrap"
+      >
         {label}
-      </Text>
-      <NativeSelect.Root size="sm" width="150px">
-        <NativeSelect.Field
-          aria-label={label}
-          value={value}
-          fontWeight="medium"
-          onChange={(event) => onChange(event.target.value)}
-        >
-          {options.map((option) => (
-            <option key={option.value} value={option.value}>
-              {option.label}
-            </option>
-          ))}
-        </NativeSelect.Field>
-        <NativeSelect.Indicator />
-      </NativeSelect.Root>
-    </HStack>
+      </Select.Label>
+      <Select.Trigger width="150px" fontWeight="medium">
+        <Select.ValueText />
+      </Select.Trigger>
+      <Select.Content>
+        {options.map((option) => (
+          <Select.Item key={option.value} item={option}>
+            {option.label}
+          </Select.Item>
+        ))}
+      </Select.Content>
+    </Select.Root>
   );
 }
 

--- a/platform/app/src/pages/governance/analytics.tsx
+++ b/platform/app/src/pages/governance/analytics.tsx
@@ -5,7 +5,6 @@ import {
   Heading,
   HStack,
   NativeSelect,
-  SegmentGroup,
   Tabs,
   Text,
   VStack,
@@ -31,6 +30,7 @@ import {
   exploreQueryLine,
   matchesTemplate,
 } from "~/components/governance/platform/exploreQuery";
+import { SegmentedControl } from "~/components/ui/segmented-control";
 import { withFeatureFlagGuard } from "~/components/WithFeatureFlagGuard";
 import { withPermissionGuard } from "~/components/WithPermissionGuard";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
@@ -49,7 +49,9 @@ function AnalyticsPage() {
     redirectToProjectOnboarding: false,
   });
   const orgName = organization?.name ?? "your organization";
-  const [window, setWindow] = useState<ExploreWindow>(DEFAULT_EXPLORE_WINDOW);
+  const [timeWindow, setTimeWindow] = useState<ExploreWindow>(
+    DEFAULT_EXPLORE_WINDOW,
+  );
   const [selection, setSelection] = useState<ExploreSelection>(
     DEFAULT_EXPLORE_SELECTION,
   );
@@ -67,22 +69,15 @@ function AnalyticsPage() {
               every chart, dashboard, signal and alert.
             </Text>
           </VStack>
-          <SegmentGroup.Root
+          <SegmentedControl
             size="sm"
-            value={window}
+            value={timeWindow}
             onValueChange={({ value }) => {
-              if (value) setWindow(value as ExploreWindow);
+              if (value) setTimeWindow(value as ExploreWindow);
             }}
+            items={[...EXPLORE_WINDOWS]}
             flexShrink={0}
-          >
-            <SegmentGroup.Indicator />
-            {EXPLORE_WINDOWS.map((option) => (
-              <SegmentGroup.Item key={option} value={option}>
-                <SegmentGroup.ItemText>{option}</SegmentGroup.ItemText>
-                <SegmentGroup.ItemHiddenInput />
-              </SegmentGroup.Item>
-            ))}
-          </SegmentGroup.Root>
+          />
         </HStack>
 
         <Tabs.Root defaultValue="explore" variant="line">
@@ -140,7 +135,7 @@ function AnalyticsPage() {
                 gap={4}
                 flexWrap="wrap"
                 borderWidth="1px"
-                borderColor="border.subtle"
+                borderColor="border.muted"
                 borderRadius="lg"
                 paddingX={4}
                 paddingY={3}
@@ -184,7 +179,7 @@ function AnalyticsPage() {
                 align="stretch"
                 gap={1}
                 borderWidth="1px"
-                borderColor="border.subtle"
+                borderColor="border.muted"
                 borderRadius="lg"
                 padding={5}
                 minHeight="440px"
@@ -193,7 +188,7 @@ function AnalyticsPage() {
                   {exploreChartTitle(selection)}
                 </Text>
                 <Text fontSize="sm" color="fg.muted">
-                  {orgName} · last {window}
+                  {orgName} · last {timeWindow}
                 </Text>
                 <Box
                   flex={1}

--- a/platform/app/src/pages/governance/billed.tsx
+++ b/platform/app/src/pages/governance/billed.tsx
@@ -1,28 +1,16 @@
-import { Heading, Text, VStack } from "@chakra-ui/react";
-
-import GovernanceLayout from "~/components/governance/GovernanceLayout";
+import { NotFoundScene } from "~/components/NotFoundScene";
 import { withFeatureFlagGuard } from "~/components/WithFeatureFlagGuard";
 import { withPermissionGuard } from "~/components/WithPermissionGuard";
 
 /**
- * Placeholder for the Billed view: the page and its nav item ship behind
- * `release_ui_governance_billed_cost_enabled` ahead of the spend views,
- * so the rail shape lands before the data does. No queries, no state.
+ * The unfinished Billed destination stays unavailable even when Costs is
+ * enabled. Keep its existing guards and route, but expose no placeholder.
  *
  * Spec: specs/ai-gateway/governance/governance-home-routing.feature
  * (the billed-cost flag section).
  */
 function BilledPage() {
-  return (
-    <GovernanceLayout pageTitle="Billed · AI Governance · LangWatch">
-      <VStack align="stretch" gap={6} width="full">
-        <Heading size="md">Billed</Heading>
-        <Text color="fg.muted">
-          Billed views are on their way. Nothing to see here yet.
-        </Text>
-      </VStack>
-    </GovernanceLayout>
-  );
+  return <NotFoundScene />;
 }
 
 // Composed on top of the section-wide governance flag, never instead of

--- a/platform/app/src/pages/governance/insights.tsx
+++ b/platform/app/src/pages/governance/insights.tsx
@@ -4,8 +4,8 @@ import { useState } from "react";
 import GovernanceLayout from "~/components/governance/GovernanceLayout";
 import {
   DEFAULT_INSIGHTS_SETTINGS,
-  InsightsSetupDialog,
-} from "~/components/governance/platform/InsightsSetupDialog";
+  InsightsSetupDrawer,
+} from "~/components/governance/platform/InsightsSetupDrawer";
 import { withFeatureFlagGuard } from "~/components/WithFeatureFlagGuard";
 import { withPermissionGuard } from "~/components/WithPermissionGuard";
 import { LangyPanelSurface } from "~/features/asaplangy/components/LangyPanelSurface";
@@ -17,7 +17,7 @@ import { useLangyStore } from "~/features/langy/stores/langyStore";
  * The Insights inbox before there is anything in it.
  *
  * A placeholder for the brief Langy will write: one card that says what
- * will land here and offers the two ways in. The Setup dialog's values
+ * will land here and offers the two ways in. The Setup drawer's values
  * live in this page's state for the sitting and nowhere else — there is
  * no store behind them yet, and nothing here says otherwise.
  *
@@ -106,7 +106,7 @@ function InsightsPage() {
         </LangyPanelSurface>
       </VStack>
 
-      <InsightsSetupDialog
+      <InsightsSetupDrawer
         open={setupOpen}
         settings={settings}
         onCancel={() => setSetupOpen(false)}

--- a/platform/app/src/pages/governance/insights.tsx
+++ b/platform/app/src/pages/governance/insights.tsx
@@ -1,7 +1,13 @@
-import { Button, Heading, HStack, Text, VStack } from "@chakra-ui/react";
+import { Box, Button, Heading, HStack, Text, VStack } from "@chakra-ui/react";
 import { useState } from "react";
 
 import GovernanceLayout from "~/components/governance/GovernanceLayout";
+import {
+  EMPTY_FOLDER_LINE,
+  EMPTY_INSIGHTS_COUNTS,
+  type InsightsFolder,
+  InsightsRail,
+} from "~/components/governance/platform/InsightsRail";
 import {
   DEFAULT_INSIGHTS_SETTINGS,
   InsightsSetupDrawer,
@@ -26,6 +32,7 @@ import { useLangyStore } from "~/features/langy/stores/langyStore";
 function InsightsPage() {
   const [setupOpen, setSetupOpen] = useState(false);
   const [settings, setSettings] = useState(DEFAULT_INSIGHTS_SETTINGS);
+  const [folder, setFolder] = useState<InsightsFolder>("inbox");
   const openLangy = useLangyStore((state) => state.openPanel);
 
   return (
@@ -39,71 +46,25 @@ function InsightsPage() {
           </Text>
         </VStack>
 
-        {/* Langy's own empty state on Langy's own material. The surface is
-            the one the home briefing wears (`langy-root`, hairline, no
-            shadow, the panel's palette in dark); inside it, the panel's
-            empty-state grammar: the bare mark, the serif display line, one
-            quiet sentence, then the keys — see
-            features/langy/components/EmptyState.tsx. The scope also paints
-            the mark in currentColor (langyTheme.css), which is why the card
-            carries no gradient defs: outside it the mark would fill from a
-            paint server only the Langy panel mounts. */}
-        <LangyPanelSurface
-          data-testid="insights-empty-brief"
-          alignSelf="center"
-          maxWidth="900px"
-        >
-          <VStack gap={0} paddingY={16} paddingX={8}>
-            <LangyMark size={44} />
-            <Text
-              as="h2"
-              fontFamily={SERIF}
-              // 44px mark ÷ φ, the same pairing the panel's greeting uses.
-              fontSize="27px"
-              fontWeight="500"
-              letterSpacing="-0.02em"
-              lineHeight="1.2"
-              color="fg"
-              textAlign="center"
-              marginTop={4}
-            >
-              Langy writes your brief here
-            </Text>
-            <Text
-              textStyle="sm"
-              color="fg.muted"
-              lineHeight="1.5"
-              textAlign="center"
-              textWrap="balance"
-              maxWidth="380px"
-              marginTop={2}
-            >
-              Every morning a background job reads yesterday&apos;s traffic and
-              files a couple of high-signal insights: not fifteen a day.
-            </Text>
-            <HStack gap={2} marginTop={6}>
-              <Button
-                size="sm"
-                colorPalette="orange"
-                onClick={() => setSetupOpen(true)}
-              >
-                Set up data
-              </Button>
-              <Button size="sm" variant="subtle" onClick={openLangy}>
-                Open Langy
-              </Button>
-            </HStack>
-            <Button
-              variant="plain"
-              size="xs"
-              fontWeight="400"
-              color="fg.subtle"
-              marginTop={3}
-            >
-              or preview a sample inbox
-            </Button>
-          </VStack>
-        </LangyPanelSurface>
+        <HStack align="start" gap={8} width="full">
+          <InsightsRail
+            selected={folder}
+            counts={EMPTY_INSIGHTS_COUNTS}
+            onSelect={setFolder}
+          />
+          <Box flex={1} minWidth={0}>
+            {folder === "inbox" ? (
+              <InboxEmptyBrief
+                onSetup={() => setSetupOpen(true)}
+                onOpenLangy={openLangy}
+              />
+            ) : (
+              <Text color="fg.muted" paddingY={4}>
+                {EMPTY_FOLDER_LINE[folder]}
+              </Text>
+            )}
+          </Box>
+        </HStack>
       </VStack>
 
       <InsightsSetupDrawer
@@ -116,6 +77,82 @@ function InsightsPage() {
         }}
       />
     </GovernanceLayout>
+  );
+}
+
+function InboxEmptyBrief({
+  onSetup,
+  onOpenLangy,
+}: {
+  onSetup: () => void;
+  onOpenLangy: () => void;
+}) {
+  return (
+    <>
+      {/* Langy's own empty state on Langy's own material. The surface is
+            the one the home briefing wears (`langy-root`, hairline, no
+            shadow, the panel's palette in dark); inside it, the panel's
+            empty-state grammar: the bare mark, the serif display line, one
+            quiet sentence, then the keys — see
+            features/langy/components/EmptyState.tsx. The scope also paints
+            the mark in currentColor (langyTheme.css), which is why the card
+            carries no gradient defs: outside it the mark would fill from a
+            paint server only the Langy panel mounts. */}
+      {/* The surface wraps its card in a full-width scope box, so the
+            card centres as a block (auto margins), not as a flex item. */}
+      <LangyPanelSurface
+        data-testid="insights-empty-brief"
+        maxWidth="900px"
+        marginX="auto"
+      >
+        <VStack gap={0} paddingY={16} paddingX={8}>
+          <LangyMark size={44} />
+          <Text
+            as="h2"
+            fontFamily={SERIF}
+            // 44px mark ÷ φ, the same pairing the panel's greeting uses.
+            fontSize="27px"
+            fontWeight="500"
+            letterSpacing="-0.02em"
+            lineHeight="1.2"
+            color="fg"
+            textAlign="center"
+            marginTop={4}
+          >
+            Langy writes your brief here
+          </Text>
+          <Text
+            textStyle="sm"
+            color="fg.muted"
+            lineHeight="1.5"
+            textAlign="center"
+            textWrap="balance"
+            maxWidth="380px"
+            marginTop={2}
+          >
+            Every morning a background job reads yesterday&apos;s traffic and
+            files a couple of high-signal insights: not fifteen a day.
+          </Text>
+          <HStack gap={2} marginTop={6}>
+            <Button size="sm" colorPalette="orange" onClick={onSetup}>
+              Set up data
+            </Button>
+            <Button size="sm" variant="subtle" onClick={onOpenLangy}>
+              Open Langy
+            </Button>
+          </HStack>
+          <Button
+            variant="plain"
+            size="xs"
+            fontWeight="400"
+            color="fg.subtle"
+            marginTop={3}
+          >
+            or preview a sample inbox
+          </Button>
+        </VStack>
+      </LangyPanelSurface>
+    </>
   );
 }
 

--- a/platform/app/src/pages/governance/insights.tsx
+++ b/platform/app/src/pages/governance/insights.tsx
@@ -50,7 +50,7 @@ function InsightsPage() {
           borderRadius="xl"
         >
           <Box
-            background="gray.900"
+            background="fg"
             borderRadius="xl"
             width="72px"
             height="72px"
@@ -68,7 +68,7 @@ function InsightsPage() {
             files a couple of high-signal insights: not fifteen a day.
           </Text>
           <HStack gap={3} paddingTop={2}>
-            <Button colorPalette="purple" onClick={() => setSetupOpen(true)}>
+            <Button colorPalette="orange" onClick={() => setSetupOpen(true)}>
               Set up data
             </Button>
             <Button
@@ -78,7 +78,7 @@ function InsightsPage() {
               Open Langy
             </Button>
           </HStack>
-          <Button variant="plain" size="sm" color="purple.600">
+          <Button variant="plain" size="sm" color="fg.muted">
             or preview a sample inbox
           </Button>
         </VStack>

--- a/platform/app/src/pages/governance/insights.tsx
+++ b/platform/app/src/pages/governance/insights.tsx
@@ -1,5 +1,4 @@
-import { Box, Button, Heading, HStack, Text, VStack } from "@chakra-ui/react";
-import { Castle } from "lucide-react";
+import { Button, Heading, HStack, Text, VStack } from "@chakra-ui/react";
 import { useState } from "react";
 
 import GovernanceLayout from "~/components/governance/GovernanceLayout";
@@ -9,7 +8,18 @@ import {
 } from "~/components/governance/platform/InsightsSetupDialog";
 import { withFeatureFlagGuard } from "~/components/WithFeatureFlagGuard";
 import { withPermissionGuard } from "~/components/WithPermissionGuard";
+import {
+  LangyMark,
+  LangyMarkGradientDefs,
+} from "~/features/langy/components/LangyMark";
 import { useLangyStore } from "~/features/langy/stores/langyStore";
+
+/**
+ * Own paint server for the mark. The Langy panel mounts the shared one,
+ * but a viewer without Langy never has it, and a mark filled from a missing
+ * gradient paints nothing.
+ */
+const INSIGHTS_MARK_GRADIENT_ID = "governance-insights-mark-grad";
 
 /**
  * The Insights inbox before there is anything in it.
@@ -37,50 +47,74 @@ function InsightsPage() {
           </Text>
         </VStack>
 
+        {/* Langy's own empty state, transplanted: the bare mark, the serif
+            display line under it, one quiet sentence, then the keys. No tile
+            behind the mark, one hairline, no shadow — see
+            features/langy/components/EmptyState.tsx and langyTheme.ts for
+            why each of those is a rule and not a taste. `langy-root` scopes
+            Langy's type face and dark palette to the card. */}
         <VStack
+          className="langy-root"
           data-testid="insights-empty-brief"
           alignSelf="center"
           width="full"
           maxWidth="900px"
-          gap={5}
-          paddingY={20}
+          gap={0}
+          paddingY={16}
           paddingX={8}
-          borderWidth="2px"
+          borderWidth="1px"
           borderStyle="dashed"
-          borderColor="border.muted"
+          borderColor="border"
           borderRadius="xl"
+          background="bg.surface"
         >
-          {/* The glyph the brief's mocks use: a plain outline on the tile,
-              not the gradient logo — that one is Langy's launcher, and it
-              needs a paint server this page would otherwise have to carry. */}
-          <Box
-            background="fg"
-            color="bg"
-            borderRadius="xl"
-            width="72px"
-            height="72px"
-            display="flex"
-            alignItems="center"
-            justifyContent="center"
+          <LangyMarkGradientDefs id={INSIGHTS_MARK_GRADIENT_ID} />
+          <LangyMark size={44} gradientId={INSIGHTS_MARK_GRADIENT_ID} />
+          <Text
+            as="h2"
+            fontFamily="var(--langy-font-serif)"
+            // 44px mark ÷ φ, the same pairing the panel's greeting uses.
+            fontSize="27px"
+            fontWeight="500"
+            letterSpacing="-0.02em"
+            lineHeight="1.2"
+            color="fg"
+            textAlign="center"
+            marginTop={4}
           >
-            <Castle size={32} strokeWidth={1.75} aria-hidden />
-          </Box>
-          <Heading size="lg" textAlign="center">
             Langy writes your brief here
-          </Heading>
-          <Text color="fg.muted" textAlign="center" maxWidth="640px">
+          </Text>
+          <Text
+            textStyle="sm"
+            color="fg.muted"
+            lineHeight="1.5"
+            textAlign="center"
+            textWrap="balance"
+            maxWidth="380px"
+            marginTop={2}
+          >
             Every morning a background job reads yesterday&apos;s traffic and
             files a couple of high-signal insights: not fifteen a day.
           </Text>
-          <HStack gap={3} paddingTop={2}>
-            <Button colorPalette="orange" onClick={() => setSetupOpen(true)}>
+          <HStack gap={2} marginTop={6}>
+            <Button
+              size="sm"
+              colorPalette="orange"
+              onClick={() => setSetupOpen(true)}
+            >
               Set up data
             </Button>
-            <Button variant="subtle" onClick={openLangy}>
+            <Button size="sm" variant="subtle" onClick={openLangy}>
               Open Langy
             </Button>
           </HStack>
-          <Button variant="plain" size="sm" color="fg.muted">
+          <Button
+            variant="plain"
+            size="xs"
+            fontWeight="400"
+            color="fg.subtle"
+            marginTop={3}
+          >
             or preview a sample inbox
           </Button>
         </VStack>

--- a/platform/app/src/pages/governance/insights.tsx
+++ b/platform/app/src/pages/governance/insights.tsx
@@ -1,4 +1,5 @@
 import { Box, Button, Heading, HStack, Text, VStack } from "@chakra-ui/react";
+import { Castle } from "lucide-react";
 import { useState } from "react";
 
 import GovernanceLayout from "~/components/governance/GovernanceLayout";
@@ -8,18 +9,7 @@ import {
 } from "~/components/governance/platform/InsightsSetupDialog";
 import { withFeatureFlagGuard } from "~/components/WithFeatureFlagGuard";
 import { withPermissionGuard } from "~/components/WithPermissionGuard";
-import {
-  LangyMark,
-  LangyMarkGradientDefs,
-} from "~/features/langy/components/LangyMark";
 import { useLangyStore } from "~/features/langy/stores/langyStore";
-
-/**
- * Own paint server. The Langy sidecar mounts the shared one, but a viewer
- * without Langy never has it, and a mark filled from a missing gradient
- * paints nothing.
- */
-const INSIGHTS_MARK_GRADIENT_ID = "governance-insights-mark-grad";
 
 /**
  * The Insights inbox before there is anything in it.
@@ -60,8 +50,12 @@ function InsightsPage() {
           borderColor="border.muted"
           borderRadius="xl"
         >
+          {/* The glyph the brief's mocks use: a plain outline on the tile,
+              not the gradient logo — that one is Langy's launcher, and it
+              needs a paint server this page would otherwise have to carry. */}
           <Box
             background="fg"
+            color="bg"
             borderRadius="xl"
             width="72px"
             height="72px"
@@ -69,8 +63,7 @@ function InsightsPage() {
             alignItems="center"
             justifyContent="center"
           >
-            <LangyMarkGradientDefs id={INSIGHTS_MARK_GRADIENT_ID} />
-            <LangyMark size={36} gradientId={INSIGHTS_MARK_GRADIENT_ID} />
+            <Castle size={32} strokeWidth={1.75} aria-hidden />
           </Box>
           <Heading size="lg" textAlign="center">
             Langy writes your brief here

--- a/platform/app/src/pages/governance/insights.tsx
+++ b/platform/app/src/pages/governance/insights.tsx
@@ -1,0 +1,110 @@
+import { Box, Button, Heading, HStack, Text, VStack } from "@chakra-ui/react";
+import { useState } from "react";
+
+import GovernanceLayout from "~/components/governance/GovernanceLayout";
+import {
+  DEFAULT_INSIGHTS_SETTINGS,
+  InsightsSetupDialog,
+} from "~/components/governance/platform/InsightsSetupDialog";
+import { withFeatureFlagGuard } from "~/components/WithFeatureFlagGuard";
+import { withPermissionGuard } from "~/components/WithPermissionGuard";
+import { LangyMark } from "~/features/langy/components/LangyMark";
+import { useLangyStore } from "~/features/langy/stores/langyStore";
+
+/**
+ * The Insights inbox before there is anything in it.
+ *
+ * A placeholder for the brief Langy will write: one card that says what
+ * will land here and offers the two ways in. The Setup dialog's values
+ * live in this page's state for the sitting and nowhere else — there is
+ * no store behind them yet, and nothing here says otherwise.
+ *
+ * Spec: specs/governance/governance-platform-placeholders.feature
+ */
+function InsightsPage() {
+  const [setupOpen, setSetupOpen] = useState(false);
+  const [settings, setSettings] = useState(DEFAULT_INSIGHTS_SETTINGS);
+
+  return (
+    <GovernanceLayout pageTitle="Insights · AI Governance · LangWatch">
+      <VStack align="stretch" gap={6} width="full">
+        <VStack align="start" gap={1}>
+          <Heading size="md">Insights</Heading>
+          <Text color="fg.muted">
+            Langy&apos;s brief: a few things worth acting on, kept fresh, never
+            a feed. Alerts and notifications ride on top.
+          </Text>
+        </VStack>
+
+        <VStack
+          data-testid="insights-empty-brief"
+          alignSelf="center"
+          width="full"
+          maxWidth="900px"
+          gap={5}
+          paddingY={20}
+          paddingX={8}
+          borderWidth="2px"
+          borderStyle="dashed"
+          borderColor="border.subtle"
+          borderRadius="xl"
+        >
+          <Box
+            background="gray.900"
+            borderRadius="xl"
+            width="72px"
+            height="72px"
+            display="flex"
+            alignItems="center"
+            justifyContent="center"
+          >
+            <LangyMark size={36} />
+          </Box>
+          <Heading size="lg" textAlign="center">
+            Langy writes your brief here
+          </Heading>
+          <Text color="fg.muted" textAlign="center" maxWidth="640px">
+            Every morning a background job reads yesterday&apos;s traffic and
+            files a couple of high-signal insights: not fifteen a day.
+          </Text>
+          <HStack gap={3} paddingTop={2}>
+            <Button colorPalette="purple" onClick={() => setSetupOpen(true)}>
+              Set up data
+            </Button>
+            <Button
+              variant="subtle"
+              onClick={() => useLangyStore.getState().openPanel()}
+            >
+              Open Langy
+            </Button>
+          </HStack>
+          <Button variant="plain" size="sm" color="purple.600">
+            or preview a sample inbox
+          </Button>
+        </VStack>
+      </VStack>
+
+      <InsightsSetupDialog
+        open={setupOpen}
+        settings={settings}
+        onCancel={() => setSetupOpen(false)}
+        onSave={(next) => {
+          setSettings(next);
+          setSetupOpen(false);
+        }}
+      />
+    </GovernanceLayout>
+  );
+}
+
+export default withFeatureFlagGuard("release_ui_ai_governance_enabled", {
+  bypassOnboardingRedirect: true,
+})(
+  withFeatureFlagGuard("release_ui_governance_billed_cost_enabled", {
+    bypassOnboardingRedirect: true,
+  })(
+    withPermissionGuard("governance:view", {
+      bypassOnboardingRedirect: true,
+    })(InsightsPage),
+  ),
+);

--- a/platform/app/src/pages/governance/insights.tsx
+++ b/platform/app/src/pages/governance/insights.tsx
@@ -8,18 +8,10 @@ import {
 } from "~/components/governance/platform/InsightsSetupDialog";
 import { withFeatureFlagGuard } from "~/components/WithFeatureFlagGuard";
 import { withPermissionGuard } from "~/components/WithPermissionGuard";
-import {
-  LangyMark,
-  LangyMarkGradientDefs,
-} from "~/features/langy/components/LangyMark";
+import { LangyPanelSurface } from "~/features/asaplangy/components/LangyPanelSurface";
+import { SERIF } from "~/features/asaplangy/tokens";
+import { LangyMark } from "~/features/langy/components/LangyMark";
 import { useLangyStore } from "~/features/langy/stores/langyStore";
-
-/**
- * Own paint server for the mark. The Langy panel mounts the shared one,
- * but a viewer without Langy never has it, and a mark filled from a missing
- * gradient paints nothing.
- */
-const INSIGHTS_MARK_GRADIENT_ID = "governance-insights-mark-grad";
 
 /**
  * The Insights inbox before there is anything in it.
@@ -47,77 +39,71 @@ function InsightsPage() {
           </Text>
         </VStack>
 
-        {/* Langy's own empty state, transplanted: the bare mark, the serif
-            display line under it, one quiet sentence, then the keys. No tile
-            behind the mark, one hairline, no shadow — see
-            features/langy/components/EmptyState.tsx and langyTheme.ts for
-            why each of those is a rule and not a taste. `langy-root` scopes
-            Langy's type face and dark palette to the card. */}
-        <VStack
-          className="langy-root"
+        {/* Langy's own empty state on Langy's own material. The surface is
+            the one the home briefing wears (`langy-root`, hairline, no
+            shadow, the panel's palette in dark); inside it, the panel's
+            empty-state grammar: the bare mark, the serif display line, one
+            quiet sentence, then the keys — see
+            features/langy/components/EmptyState.tsx. The scope also paints
+            the mark in currentColor (langyTheme.css), which is why the card
+            carries no gradient defs: outside it the mark would fill from a
+            paint server only the Langy panel mounts. */}
+        <LangyPanelSurface
           data-testid="insights-empty-brief"
           alignSelf="center"
-          width="full"
           maxWidth="900px"
-          gap={0}
-          paddingY={16}
-          paddingX={8}
-          borderWidth="1px"
-          borderStyle="dashed"
-          borderColor="border"
-          borderRadius="xl"
-          background="bg.surface"
         >
-          <LangyMarkGradientDefs id={INSIGHTS_MARK_GRADIENT_ID} />
-          <LangyMark size={44} gradientId={INSIGHTS_MARK_GRADIENT_ID} />
-          <Text
-            as="h2"
-            fontFamily="var(--langy-font-serif)"
-            // 44px mark ÷ φ, the same pairing the panel's greeting uses.
-            fontSize="27px"
-            fontWeight="500"
-            letterSpacing="-0.02em"
-            lineHeight="1.2"
-            color="fg"
-            textAlign="center"
-            marginTop={4}
-          >
-            Langy writes your brief here
-          </Text>
-          <Text
-            textStyle="sm"
-            color="fg.muted"
-            lineHeight="1.5"
-            textAlign="center"
-            textWrap="balance"
-            maxWidth="380px"
-            marginTop={2}
-          >
-            Every morning a background job reads yesterday&apos;s traffic and
-            files a couple of high-signal insights: not fifteen a day.
-          </Text>
-          <HStack gap={2} marginTop={6}>
-            <Button
-              size="sm"
-              colorPalette="orange"
-              onClick={() => setSetupOpen(true)}
+          <VStack gap={0} paddingY={16} paddingX={8}>
+            <LangyMark size={44} />
+            <Text
+              as="h2"
+              fontFamily={SERIF}
+              // 44px mark ÷ φ, the same pairing the panel's greeting uses.
+              fontSize="27px"
+              fontWeight="500"
+              letterSpacing="-0.02em"
+              lineHeight="1.2"
+              color="fg"
+              textAlign="center"
+              marginTop={4}
             >
-              Set up data
+              Langy writes your brief here
+            </Text>
+            <Text
+              textStyle="sm"
+              color="fg.muted"
+              lineHeight="1.5"
+              textAlign="center"
+              textWrap="balance"
+              maxWidth="380px"
+              marginTop={2}
+            >
+              Every morning a background job reads yesterday&apos;s traffic and
+              files a couple of high-signal insights: not fifteen a day.
+            </Text>
+            <HStack gap={2} marginTop={6}>
+              <Button
+                size="sm"
+                colorPalette="orange"
+                onClick={() => setSetupOpen(true)}
+              >
+                Set up data
+              </Button>
+              <Button size="sm" variant="subtle" onClick={openLangy}>
+                Open Langy
+              </Button>
+            </HStack>
+            <Button
+              variant="plain"
+              size="xs"
+              fontWeight="400"
+              color="fg.subtle"
+              marginTop={3}
+            >
+              or preview a sample inbox
             </Button>
-            <Button size="sm" variant="subtle" onClick={openLangy}>
-              Open Langy
-            </Button>
-          </HStack>
-          <Button
-            variant="plain"
-            size="xs"
-            fontWeight="400"
-            color="fg.subtle"
-            marginTop={3}
-          >
-            or preview a sample inbox
-          </Button>
-        </VStack>
+          </VStack>
+        </LangyPanelSurface>
       </VStack>
 
       <InsightsSetupDialog

--- a/platform/app/src/pages/governance/insights.tsx
+++ b/platform/app/src/pages/governance/insights.tsx
@@ -8,8 +8,18 @@ import {
 } from "~/components/governance/platform/InsightsSetupDialog";
 import { withFeatureFlagGuard } from "~/components/WithFeatureFlagGuard";
 import { withPermissionGuard } from "~/components/WithPermissionGuard";
-import { LangyMark } from "~/features/langy/components/LangyMark";
+import {
+  LangyMark,
+  LangyMarkGradientDefs,
+} from "~/features/langy/components/LangyMark";
 import { useLangyStore } from "~/features/langy/stores/langyStore";
+
+/**
+ * Own paint server. The Langy sidecar mounts the shared one, but a viewer
+ * without Langy never has it, and a mark filled from a missing gradient
+ * paints nothing.
+ */
+const INSIGHTS_MARK_GRADIENT_ID = "governance-insights-mark-grad";
 
 /**
  * The Insights inbox before there is anything in it.
@@ -24,6 +34,7 @@ import { useLangyStore } from "~/features/langy/stores/langyStore";
 function InsightsPage() {
   const [setupOpen, setSetupOpen] = useState(false);
   const [settings, setSettings] = useState(DEFAULT_INSIGHTS_SETTINGS);
+  const openLangy = useLangyStore((state) => state.openPanel);
 
   return (
     <GovernanceLayout pageTitle="Insights · AI Governance · LangWatch">
@@ -46,7 +57,7 @@ function InsightsPage() {
           paddingX={8}
           borderWidth="2px"
           borderStyle="dashed"
-          borderColor="border.subtle"
+          borderColor="border.muted"
           borderRadius="xl"
         >
           <Box
@@ -58,7 +69,8 @@ function InsightsPage() {
             alignItems="center"
             justifyContent="center"
           >
-            <LangyMark size={36} />
+            <LangyMarkGradientDefs id={INSIGHTS_MARK_GRADIENT_ID} />
+            <LangyMark size={36} gradientId={INSIGHTS_MARK_GRADIENT_ID} />
           </Box>
           <Heading size="lg" textAlign="center">
             Langy writes your brief here
@@ -71,10 +83,7 @@ function InsightsPage() {
             <Button colorPalette="orange" onClick={() => setSetupOpen(true)}>
               Set up data
             </Button>
-            <Button
-              variant="subtle"
-              onClick={() => useLangyStore.getState().openPanel()}
-            >
+            <Button variant="subtle" onClick={openLangy}>
               Open Langy
             </Button>
           </HStack>

--- a/platform/app/src/pages/governance/signals.tsx
+++ b/platform/app/src/pages/governance/signals.tsx
@@ -33,7 +33,7 @@ function SignalsPage() {
               <BellPlus size={16} />
               New alert
             </Button>
-            <Button colorPalette="purple">
+            <Button colorPalette="orange">
               <Target size={16} />
               New signal
             </Button>
@@ -46,10 +46,7 @@ function SignalsPage() {
             <Text fontSize="sm" color="fg.muted">
               alerts notify, automations act: one registry of rules. Recent
               fires land in the{" "}
-              <Link href="/governance/insights" color="purple.600">
-                Insights inbox
-              </Link>
-              .
+              <Link href="/governance/insights">Insights inbox</Link>.
             </Text>
           </HStack>
           <VStack
@@ -69,10 +66,8 @@ function SignalsPage() {
 
         <Text fontSize="sm" color="fg.muted">
           Judges run on the org&apos;s{" "}
-          <Link href="/settings/model-providers" color="purple.600">
-            model providers
-          </Link>{" "}
-          (the same credentials the Gateway routes through).
+          <Link href="/settings/model-providers">model providers</Link> (the
+          same credentials the Gateway routes through).
         </Text>
       </VStack>
     </GovernanceLayout>

--- a/platform/app/src/pages/governance/signals.tsx
+++ b/platform/app/src/pages/governance/signals.tsx
@@ -52,7 +52,7 @@ function SignalsPage() {
           <VStack
             data-testid="signals-empty-registry"
             borderWidth="1px"
-            borderColor="border.subtle"
+            borderColor="border.muted"
             borderRadius="lg"
             paddingY={14}
             paddingX={6}

--- a/platform/app/src/pages/governance/signals.tsx
+++ b/platform/app/src/pages/governance/signals.tsx
@@ -1,0 +1,92 @@
+import { Button, Heading, HStack, Text, VStack } from "@chakra-ui/react";
+import { BellPlus, Target } from "lucide-react";
+
+import GovernanceLayout from "~/components/governance/GovernanceLayout";
+import { Link } from "~/components/ui/link";
+import { withFeatureFlagGuard } from "~/components/WithFeatureFlagGuard";
+import { withPermissionGuard } from "~/components/WithPermissionGuard";
+
+/**
+ * The rule registry before there are any rules.
+ *
+ * A placeholder for the signals that fire and the alerts and automations
+ * that answer them. Nothing here can create a rule yet; the two header
+ * buttons draw the shape of the screen and do nothing when pressed.
+ *
+ * Spec: specs/governance/governance-platform-placeholders.feature
+ */
+function SignalsPage() {
+  return (
+    <GovernanceLayout pageTitle="Signals & Alerts · AI Governance · LangWatch">
+      <VStack align="stretch" gap={8} width="full">
+        <HStack justify="space-between" align="start" gap={6}>
+          <VStack align="start" gap={1}>
+            <Heading size="md">Signals &amp; Alerts</Heading>
+            <Text color="fg.muted">
+              A signal is the condition: a judge, a metric or a query. Alerts
+              and automations are what happens when one fires: who gets told,
+              what gets done.
+            </Text>
+          </VStack>
+          <HStack gap={2} flexShrink={0}>
+            <Button variant="outline">
+              <BellPlus size={16} />
+              New alert
+            </Button>
+            <Button colorPalette="purple">
+              <Target size={16} />
+              New signal
+            </Button>
+          </HStack>
+        </HStack>
+
+        <VStack align="stretch" gap={3}>
+          <HStack gap={2} align="baseline" flexWrap="wrap">
+            <Text fontWeight="semibold">When a signal fires</Text>
+            <Text fontSize="sm" color="fg.muted">
+              alerts notify, automations act: one registry of rules. Recent
+              fires land in the{" "}
+              <Link href="/governance/insights" color="purple.600">
+                Insights inbox
+              </Link>
+              .
+            </Text>
+          </HStack>
+          <VStack
+            data-testid="signals-empty-registry"
+            borderWidth="1px"
+            borderColor="border.subtle"
+            borderRadius="lg"
+            paddingY={14}
+            paddingX={6}
+          >
+            <Text color="fg.muted">
+              No rules scoped here yet. Create one from any chart&apos;s bell
+              icon.
+            </Text>
+          </VStack>
+        </VStack>
+
+        <Text fontSize="sm" color="fg.muted">
+          Judges run on the org&apos;s{" "}
+          <Link href="/settings/model-providers" color="purple.600">
+            model providers
+          </Link>{" "}
+          (the same credentials the Gateway routes through).
+        </Text>
+      </VStack>
+    </GovernanceLayout>
+  );
+}
+
+export default withFeatureFlagGuard("release_ui_ai_governance_enabled", {
+  bypassOnboardingRedirect: true,
+})(
+  withFeatureFlagGuard("release_ui_governance_billed_cost_enabled", {
+    bypassOnboardingRedirect: true,
+  })(
+    withPermissionGuard("governance:view", {
+      bypassOnboardingRedirect: true,
+    })(SignalsPage),
+  ),
+);

--- a/platform/app/src/routes.tsx
+++ b/platform/app/src/routes.tsx
@@ -253,6 +253,21 @@ const routes: RouteObject[] = [
         ...page(() => import("./pages/governance/billed")),
       },
       {
+        // The Platform placeholders, behind the same flag as costs/billed
+        // (each page carries its own guard; see
+        // specs/governance/governance-platform-placeholders.feature).
+        path: "/governance/insights",
+        ...page(() => import("./pages/governance/insights")),
+      },
+      {
+        path: "/governance/analytics",
+        ...page(() => import("./pages/governance/analytics")),
+      },
+      {
+        path: "/governance/signals",
+        ...page(() => import("./pages/governance/signals")),
+      },
+      {
         // The people page has been cost centers and then departments; old
         // bookmarks land on the newest name in one hop (the legacy
         // /settings/governance/cost-centers address chains through here,

--- a/platform/app/src/server/featureFlag/frontendFeatureFlags.ts
+++ b/platform/app/src/server/featureFlag/frontendFeatureFlags.ts
@@ -66,11 +66,11 @@ export const FRONTEND_FEATURE_FLAGS = [
   // because the gateway product ships on its own flag.
   // Force off in dev: `RELEASE_UI_AI_GOVERNANCE_ENABLED=0`.
   "release_ui_ai_governance_enabled",
-  // The Costs and Billed pages + their governance nav items. Composed ON
+  // Costs and the Platform preview pages + their governance nav items. Composed ON
   // TOP of `release_ui_ai_governance_enabled` (never instead of it): the
   // section flag off still hides everything. Off by default. Costs renders
-  // the real cost lanes (ADR-128 wave 1); Billed is still a placeholder
-  // shipped ahead of its view. See
+  // the real cost lanes (ADR-128); the unfinished Billed address stays
+  // unavailable even when enabled. See
   // specs/ai-gateway/governance/governance-home-routing.feature and
   // specs/governance/governance-cost-screen.feature.
   "release_ui_governance_billed_cost_enabled",

--- a/platform/app/src/server/featureFlag/registry.ts
+++ b/platform/app/src/server/featureFlag/registry.ts
@@ -265,7 +265,7 @@ export const FEATURE_FLAGS = [
     scope: "PRODUCT",
     defaultValue: false,
     description:
-      "Reveals the Costs and Billed governance pages and their sidebar items (specs: specs/ai-gateway/governance/governance-home-routing.feature, specs/governance/governance-cost-screen.feature). Composed ON TOP of release_ui_ai_governance_enabled, never instead of it: the section flag off still hides everything. Default off. Costs now renders the real billed/gateway/seat lanes (ADR-128 wave 1); Billed is still a placeholder shell. Enable per organization via the operator store; for local dev use FEATURE_FLAG_FORCE_ENABLE=release_ui_governance_billed_cost_enabled.",
+      "Reveals Costs and the Platform preview pages (Insights, Analytics, Signals & Alerts) and their sidebar items. Composed ON TOP of release_ui_ai_governance_enabled: the section flag off still hides everything. Default off. Costs renders billed/gateway amounts and seat counts; the unfinished Billed address stays unavailable. Enable per organization via the operator store; for local dev use FEATURE_FLAG_FORCE_ENABLE=release_ui_governance_billed_cost_enabled. Specs: specs/ai-gateway/governance/governance-home-routing.feature, specs/governance/governance-cost-screen.feature.",
     family: "Governance",
   },
   // ADR-034 Phase 3 — routes analytics getTimeseries reads to the slim

--- a/platform/app/src/utils/compat/next-router.ts
+++ b/platform/app/src/utils/compat/next-router.ts
@@ -76,6 +76,9 @@ const ROUTE_PATTERNS = [
   "/governance/people",
   "/governance/costs",
   "/governance/billed",
+  "/governance/insights",
+  "/governance/analytics",
+  "/governance/signals",
   // Retired addresses — kept so each redirect route resolves to a known
   // pattern while it forwards to its new home (inventory / people).
   "/governance/catalog/:id",

--- a/specs/ai-gateway/governance/governance-home-routing.feature
+++ b/specs/ai-gateway/governance/governance-home-routing.feature
@@ -173,7 +173,9 @@ Feature: Governance home — route, nav promotion, persona detection
   Scenario: The inventory family is exempt from the no-organization onboarding bouncer
     Given a session that belongs to no organization yet
     When it sits on "/governance/inventory", "/governance/inventory/<id>",
-      "/governance/people", "/governance/costs" or "/governance/billed"
+      "/governance/people", "/governance/costs", "/governance/billed",
+      "/governance/insights", "/governance/analytics" or
+      "/governance/signals"
     Then the route is recognized as bouncer-exempt, like every sibling
       governance route, instead of bouncing to "/onboarding/welcome"
     # The bounce fires only for zero-ORG sessions (an org with zero
@@ -337,7 +339,17 @@ Feature: Governance home — route, nav promotion, persona detection
     When the admin looks at the GOVERNANCE rail
     Then "Costs" (/governance/costs) and "Billed" (/governance/billed)
       are listed between Overview and Inventory
+    And "Insights" (/governance/insights), "Analytics"
+      (/governance/analytics) and "Signals & Alerts"
+      (/governance/signals) are listed after People, in that order
     And each page renders its heading
+    # The three Platform entries ride the same flag on purpose: they are
+    # placeholder screens for the Langy-driven brief, explore and rule
+    # registry that ADR-128's cost work leads into, and they are meant
+    # to be previewed by the same audience that previews Costs. Their
+    # bodies and headings are specified and bound in specs/governance/
+    # governance-platform-placeholders.feature; this scenario pins only
+    # the rail listing, and its binding renders no page.
     # Costs has since grown its real content — the billed/gateway/seat
     # lanes of specs/governance/governance-cost-screen.feature (ADR-128
     # wave 1). Billed is still the placeholder shell this scenario was

--- a/specs/ai-gateway/governance/governance-home-routing.feature
+++ b/specs/ai-gateway/governance/governance-home-routing.feature
@@ -4,9 +4,10 @@ Feature: Governance home — route, nav promotion, persona detection
   lives there: `/governance/inventory*`, `/governance/anomaly-rules`,
   `/governance/people`, and — behind the
   `release_ui_governance_billed_cost_enabled` flag — `/governance/costs`,
-  `/governance/billed` and the Platform placeholders
+  and the Platform placeholders
   `/governance/insights`, `/governance/analytics` and
-  `/governance/signals`. Routing policies are gateway behavior and
+  `/governance/signals`. The unfinished `/governance/billed` address
+  stays unavailable even with that flag on. Routing policies are gateway behavior and
   live at `/gateway/routing-policies` instead. The legacy
   `/settings/governance*` and `/settings/routing-policies` addresses
   redirect permanently to the new ones
@@ -292,8 +293,8 @@ Feature: Governance home — route, nav promotion, persona detection
       | Anomaly Rules     | /governance/anomaly-rules                     |
       | People            | /governance/people                            |
     # Tool Tiles is gone from the rail — it lives inside Inventory as
-    # the Catalog tab. Costs and Billed join the rail only when
-    # release_ui_governance_billed_cost_enabled is on (see the
+    # the Catalog tab. Costs and Platform join the rail only when
+    # release_ui_governance_billed_cost_enabled is on; Billed stays absent (see the
     # billed-cost flag section below).
 
   # The former "Admin-authoring sub-routes share the GovernanceLayout chrome"
@@ -315,7 +316,7 @@ Feature: Governance home — route, nav promotion, persona detection
       project=null
 
   # ---------------------------------------------------------------------------
-  # Costs + Billed placeholders — behind release_ui_governance_billed_cost_enabled
+  # Costs release gate; the unfinished Billed destination stays unavailable
   # ---------------------------------------------------------------------------
 
   @bdd @ui @governance-home @billed-cost-flag @integration
@@ -335,16 +336,15 @@ Feature: Governance home — route, nav promotion, persona detection
     # still hides every governance surface on its own.
 
   @bdd @ui @governance-home @billed-cost-flag @integration
-  Scenario: With the billed-cost flag on, Costs and Billed appear as placeholders
+  Scenario: With the billed-cost flag on, Costs appears without the unfinished Billed destination
     Given "release_ui_governance_billed_cost_enabled" is enabled
       for the organization
     When the admin looks at the GOVERNANCE rail
-    Then "Costs" (/governance/costs) and "Billed" (/governance/billed)
-      are listed between Overview and Inventory
+    Then "Costs" (/governance/costs) is listed between Overview and Inventory
+    And no "Billed" entry is listed
     And "Insights" (/governance/insights), "Analytics"
       (/governance/analytics) and "Signals & Alerts"
       (/governance/signals) are listed after People, in that order
-    And each page renders its heading
     # The three Platform entries ride the same flag on purpose: they are
     # placeholder screens for the Langy-driven brief, explore and rule
     # registry that ADR-128's cost work leads into, and they are meant
@@ -352,9 +352,10 @@ Feature: Governance home — route, nav promotion, persona detection
     # bodies and headings are specified and bound in specs/governance/
     # governance-platform-placeholders.feature; this scenario pins only
     # the rail listing, and its binding renders no page.
-    # Costs has since grown its real content — the billed/gateway/seat
-    # lanes of specs/governance/governance-cost-screen.feature (ADR-128
-    # wave 1). Billed is still the placeholder shell this scenario was
-    # written for. The scenario TITLE is left verbatim because it is the
-    # parity binding key for sectionNavParity.integration.test.tsx, which
-    # asserts the rail listing and not either page's body.
+
+  @bdd @ui @governance-home @billed-cost-flag @integration
+  Scenario: The unfinished Billed address stays unavailable when Costs is enabled
+    Given "release_ui_governance_billed_cost_enabled" is enabled
+      for the organization
+    When the admin cold-loads "/governance/billed"
+    Then the not-found scene is shown instead of an unfinished page

--- a/specs/ai-gateway/governance/governance-home-routing.feature
+++ b/specs/ai-gateway/governance/governance-home-routing.feature
@@ -3,8 +3,10 @@ Feature: Governance home — route, nav promotion, persona detection
   daily-use org-scoped home), NOT under Settings. The whole family
   lives there: `/governance/inventory*`, `/governance/anomaly-rules`,
   `/governance/people`, and — behind the
-  `release_ui_governance_billed_cost_enabled` flag — `/governance/costs`
-  and `/governance/billed`. Routing policies are gateway behavior and
+  `release_ui_governance_billed_cost_enabled` flag — `/governance/costs`,
+  `/governance/billed` and the Platform placeholders
+  `/governance/insights`, `/governance/analytics` and
+  `/governance/signals`. Routing policies are gateway behavior and
   live at `/gateway/routing-policies` instead. The legacy
   `/settings/governance*` and `/settings/routing-policies` addresses
   redirect permanently to the new ones

--- a/specs/governance/governance-cost-screen.feature
+++ b/specs/governance/governance-cost-screen.feature
@@ -22,6 +22,15 @@ Feature: One cost screen, three honest lanes
     Given an organization with billed and gateway cost available
 
   @integration
+  Scenario: The department filter explains that it changes only the department chart
+    Given cost activity in two departments
+    And the viewer holds both governanceCost:view and activityMonitor:view
+    When a permitted viewer selects one department on the cost screen
+    Then the filter says it applies only to the Cost by department chart
+    And that chart shows only the selected department
+    And the billed total, gateway total and cost-by-user panel stay unchanged
+
+  @integration
   Scenario: Each lane renders its own labeled total
     Given billed and gateway totals that differ from each other
     When a permitted viewer opens the cost screen

--- a/specs/governance/governance-people-discovery.feature
+++ b/specs/governance/governance-people-discovery.feature
@@ -171,6 +171,18 @@ Feature: Provider rows become discovered people
     # the field blank, and blank must not erase an admin's hand-work daily.
 
   @integration
+  Scenario: Conflicting directory and confirmed email proof changes no department
+    Given a directory row whose directory id identifies one platform member
+    And its email is confirmed by a different platform member
+    And both members already have department assignments
+    And the row names a new nonblank department
+    When the directory sync runs
+    Then neither member's assignment or dated department history changes
+    And no department is created from the conflicting row
+    # This correction preserves directory-only assignment. It does not change
+    # identity-link review; it stops assignment from ignoring conflicting proof.
+
+  @integration
   Scenario: A directory row proving no member assigns nobody
     Given a directory row whose identity proves no platform member
     When the directory sync runs

--- a/specs/governance/governance-platform-placeholders.feature
+++ b/specs/governance/governance-platform-placeholders.feature
@@ -4,8 +4,9 @@ Feature: Platform placeholders — Insights, Analytics, Signals & Alerts
   any of them has a backend: the brief Langy will write, the explore
   surface every chart is meant to compile through, and the registry of
   rules that fire alerts. The query line under the explore chart is a
-  sketch of that future language; nothing in the platform parses it yet. They exist so the whole flow can be walked and judged in
-  one sitting. Nothing on them stores anything, and nothing on them may
+  sketch of that future language; nothing in the platform parses it yet.
+  They exist so the whole flow can be walked and judged in one sitting.
+  Nothing on them stores anything, and nothing on them may
   claim to. A control with no backing does nothing; it never reports
   success. The three sit in a "Platform" group of the governance
   sidebar, behind the same release flag as Costs and Billed, and behind

--- a/specs/governance/governance-platform-placeholders.feature
+++ b/specs/governance/governance-platform-placeholders.feature
@@ -1,0 +1,119 @@
+@governance @platform @placeholder
+Feature: Platform placeholders — Insights, Analytics, Signals & Alerts
+  Three screens that show the shape of the governance product before
+  any of them has a backend: the brief Langy will write, the explore
+  surface every chart is meant to compile through, and the registry of
+  rules that fire alerts. The query line under the explore chart is a
+  sketch of that future language; nothing in the platform parses it yet. They exist so the whole flow can be walked and judged in
+  one sitting. Nothing on them stores anything, and nothing on them may
+  claim to. A control with no backing does nothing; it never reports
+  success. The three sit in a "Platform" group of the governance
+  sidebar, behind the same release flag as Costs and Billed, and behind
+  the governance view permission.
+  Decision: none — placeholder UI, reversible, no stored state.
+
+  Background:
+    Given an organization member with the governance view permission
+    And "release_ui_ai_governance_enabled" is enabled for the organization
+
+  # ---------------------------------------------------------------------------
+  # Reachability — the same gate Costs and Billed already use
+  # ---------------------------------------------------------------------------
+
+  @integration
+  Scenario: The Platform screens are unreachable with the billed-cost flag off
+    Given "release_ui_governance_billed_cost_enabled" is disabled
+      for the organization
+    When the member cold-loads "/governance/insights",
+      "/governance/analytics" or "/governance/signals"
+    Then the not-found scene renders
+    # Unreachable, not merely unlisted: the nav item is filtered by the
+    # same flag, but a route with no guard on its page is a half-gate.
+
+  @integration
+  Scenario: The Platform group lists its three entries under one label
+    Given "release_ui_governance_billed_cost_enabled" is enabled
+      for the organization
+    When the member opens the navigation-v2 governance sidebar
+    Then a section labelled "Platform" lists "Insights", "Analytics"
+      and "Signals & Alerts", in that order, after the ungrouped entries
+    # The legacy governance rail lists the same three entries flat; only
+    # the v2 sidebar has a grouping affordance. Parity of the LIST is
+    # pinned by governance-home-routing.feature; this pins the grouping.
+
+  # ---------------------------------------------------------------------------
+  # Insights
+  # ---------------------------------------------------------------------------
+
+  @integration
+  Scenario: Insights opens on an empty brief with one sentence of promise
+    When the member opens "/governance/insights"
+    Then the heading reads "Insights"
+    And the body says "Every morning a background job reads yesterday's
+      traffic and files a couple of high-signal insights: not fifteen a
+      day." and nothing longer
+    And a "Set up data" action and an "Open Langy" action are offered
+
+  @integration
+  Scenario: Open Langy opens the Langy panel
+    When the member presses "Open Langy" on the Insights screen
+    Then the Langy panel is opened
+    # The panel itself renders only where Langy is mounted and enabled
+    # for the ambient project; with Langy off the request is a no-op
+    # and the screen says nothing about it. Not a success claim.
+
+  @integration
+  Scenario: The Setup dialog keeps its edits for the sitting and never claims to save
+    When the member presses "Set up data" and changes the schedule
+    And presses "Save"
+    Then the dialog closes with no confirmation of anything being stored
+    And reopening the dialog shows the changed schedule
+    # Local state for the sitting. A reload returns the defaults; there
+    # is no store behind this dialog yet and no toast may pretend there is.
+
+  @integration
+  Scenario: Cancel discards the sitting's edits
+    When the member presses "Set up data" and changes the schedule
+    And presses "Cancel"
+    Then reopening the dialog shows the schedule it had before
+
+  # ---------------------------------------------------------------------------
+  # Signals & Alerts
+  # ---------------------------------------------------------------------------
+
+  @integration
+  Scenario: Signals & Alerts opens on an empty registry
+    When the member opens "/governance/signals"
+    Then the heading reads "Signals & Alerts"
+    And the registry says "No rules scoped here yet. Create one from any
+      chart's bell icon."
+    And "Insights inbox" links to "/governance/insights"
+    And "model providers" links to "/settings/model-providers"
+
+  # ---------------------------------------------------------------------------
+  # Analytics
+  # ---------------------------------------------------------------------------
+
+  @integration
+  Scenario: Analytics opens on the spend-by-department template
+    When the member opens "/governance/analytics"
+    Then the heading reads "Analytics"
+    And the chart is titled "Cost by department · weekly"
+    And the chart body says "No data yet"
+    And the query line reads "usage | summarize sum(cost) by department, bin(1w)"
+
+  @unit
+  Scenario: The query line follows the measure, breakdown and interval
+    When the measure is "Requests", the breakdown is "Model" and the
+      interval is "Daily"
+    Then the query line reads "usage | summarize count() by model, bin(1d)"
+    And the chart title reads "Requests by model · daily"
+    # Full words in the title and the query, never "dept": the title is
+    # copy and the query is meant to be read aloud by the same person.
+
+  @integration
+  Scenario: A template rewrites the three controls at once
+    When the member picks the "Requests by model" template
+    Then the measure reads "Requests", the breakdown "Model" and the
+      interval "Daily"
+    And the query line reads "usage | summarize count() by model, bin(1d)"

--- a/specs/governance/governance-platform-placeholders.feature
+++ b/specs/governance/governance-platform-placeholders.feature
@@ -64,19 +64,19 @@ Feature: Platform placeholders — Insights, Analytics, Signals & Alerts
     # and the screen says nothing about it. Not a success claim.
 
   @integration
-  Scenario: The Setup dialog keeps its edits for the sitting and never claims to save
+  Scenario: The Setup drawer keeps its edits for the sitting and never claims to save
     When the member presses "Set up data" and changes the schedule
     And presses "Save"
-    Then the dialog closes with no confirmation of anything being stored
-    And reopening the dialog shows the changed schedule
+    Then the drawer closes with no confirmation of anything being stored
+    And reopening the drawer shows the changed schedule
     # Local state for the sitting. A reload returns the defaults; there
-    # is no store behind this dialog yet and no toast may pretend there is.
+    # is no store behind this drawer yet and no toast may pretend there is.
 
   @integration
   Scenario: Cancel discards the sitting's edits
     When the member presses "Set up data" and changes the schedule
     And presses "Cancel"
-    Then reopening the dialog shows the schedule it had before
+    Then reopening the drawer shows the schedule it had before
 
   # ---------------------------------------------------------------------------
   # Signals & Alerts

--- a/specs/governance/governance-platform-placeholders.feature
+++ b/specs/governance/governance-platform-placeholders.feature
@@ -56,6 +56,15 @@ Feature: Platform placeholders — Insights, Analytics, Signals & Alerts
     And a "Set up data" action and an "Open Langy" action are offered
 
   @integration
+  Scenario: The inbox rail is in place at zero
+    Then the screen carries a folder rail: Inbox, Stale, Archived, then Alerts and Notifications under a rule
+    And every folder counts zero, shown rather than hidden
+    And Inbox is the current folder, with Langy's brief as its body
+    When the member picks another folder
+    Then the body is that folder's one-line empty state
+    # Folders are page state, not routes: nothing lives behind them yet.
+
+  @integration
   Scenario: Open Langy opens the Langy panel
     When the member presses "Open Langy" on the Insights screen
     Then the Langy panel is opened
@@ -71,6 +80,15 @@ Feature: Platform placeholders — Insights, Analytics, Signals & Alerts
     And reopening the drawer shows the changed schedule
     # Local state for the sitting. A reload returns the defaults; there
     # is no store behind this drawer yet and no toast may pretend there is.
+
+  @integration
+  Scenario: The Model row follows Langy's configured model
+    When the member presses "Set up data"
+    Then the Model row shows the model Langy's own routing resolves for the project
+    And offers the same models Langy is allowed to use, through the shared model picker
+    # The one control on this drawer that is wired to something real. It
+    # reads Langy's gate (feature key "langy.chat"), not a hand-typed name,
+    # so a change under Settings > Model Providers follows here unasked.
 
   @integration
   Scenario: Cancel discards the sitting's edits


### PR DESCRIPTION
## For humans

The AI Governance area gets a new **Platform** group at the bottom of its sidebar with three screens: **Insights**, **Analytics** and **Signals & Alerts**. They show what each screen will look like and how it will be laid out, but nothing behind them runs yet: no insights are generated, no queries execute, no alerts exist. Settings you type into the Insights setup panel are kept while the panel is open and dropped when you leave the page. The screens only appear when the billed-cost preview flag is on, so nobody sees them by accident.

Two small governance fixes ride along: contradictory directory evidence no longer assigns a person to a department, and the Costs screen now says which chart the department filter narrows. The unfinished Billed screen is hidden.

## Why

The governance sidebar grows a **Platform** group with three preview screens so the shape of the product can be reviewed before the engine under it exists. They share the Costs flag (`release_ui_governance_billed_cost_enabled`) and require `governance:view`. Stacked on #7650; this is not the full governance launch.

## What changed

**Sidebar.** `SectionNavItemData` gains an optional `group`. The v2 sidebar lists ungrouped entries first, then pushes each group to the foot of the column under a collapsible label, above the bottom block. The legacy rail lists the same entries flat in the same order.

**Routes.** `/governance/insights`, `/governance/analytics` and `/governance/signals`, each wrapped in the same three guards as `costs.tsx` (governance flag, billed-cost flag, `governance:view`), registered in `ROUTE_PATTERNS` and `noOrgBouncerRoutes` so a zero-project org admin is not bounced to onboarding.

**Insights.** An empty brief on Langy's own surface with one sentence of promise and two actions, "Set up data" and "Open Langy". A folder rail with Inbox, Stale and Archived, then a rule, then the two streams Alerts and Notifications; every count reads zero rather than hiding, and the count sits in the row's own accessible name. Folders are page state, not routes.

**Setup drawer.** Opened from "Set up data", a right-hand sheet the inbox stays visible behind. Rows: Runs, At, Volume, Model, Session, Skill instructions, Learned preferences. Every select is the repo `Select` under a `Field`, so the label reaches the control. Edits are kept for the sitting: Save hands the draft back and closes, Cancel drops it, and there is no toast or "saved" wording because nothing is written anywhere yet.

**Model row.** The one control wired to something real. It shows the model Langy's own routing resolves for this project (`modelProvider.getResolvedDefault` with Langy's `featureKey`) and lists the models Langy may use, through the shared `ModelSelector`. `model: null` means "whatever Langy is configured with", so a change in Model Providers follows here without re-saving. `ModelSelector` accepts a `featureKey` so codex-licensed models survive its gate.

**Signals & Alerts.** An empty registry with a short explanation of what fires and where it lands, linking to the Insights inbox and to model providers.

**Analytics.** A time-window control, Explore and Dashboards tabs, template chips, Measure / Break down by / Over time selects, a chart body that says "No data yet", and an `lwql` query line. Title and query line are a pure mapping in `exploreQuery.ts`; picking a template rewrites all three controls at once. Copy uses full words ("department", not "dept").

**Governance fixes.** Directory sync runs the existing identity conflict rule before assigning a department; contradictory directory ID and confirmed email create no department and change neither membership nor dated history. Costs explains "Department filters only the Cost by department chart." Billed is removed from both navigation layouts and its guarded route returns Not Found.

**Lint.** The three placeholder files are split into small components so Biome's new-violation gate passes: `InsightsRail` (row and count components), `InsightsSetupDrawer` (row groups plus a `useLangyModelChoice` hook), `analytics.tsx` (explore tab tree).

Out of scope: persistent Insights settings, an org-scoped query engine, a rule registry, dashboards content, compliance-option changes.

## Test plan

Spec: `specs/governance/governance-platform-placeholders.feature` (12 scenarios, all bound; `pnpm check:feature-parity` reports 11,202 enforced bindings).

- `platform/app/src/pages/governance/__tests__/platformPlaceholders.integration.test.tsx` — 11 tests: flag-off not-found on all three screens, empty brief, rail at zero and body swap per folder, Open Langy, drawer keeps edits across close and reopen with no confirmation, Model row shows Langy's resolved model, Cancel discards, Signals empty registry, Analytics default template, template rewrite.
- `platform/app/src/components/governance/platform/__tests__/exploreQuery.unit.test.ts` — the query line follows measure, breakdown and interval.
- `platform/app/src/features/navigation/__tests__/ProductSidebar.integration.test.tsx` and `sectionNavParity.integration.test.tsx` — Platform group under one label, legacy rail parity.
- `platform/app/src/pages/governance/__tests__/costDepartmentFilter.integration.test.tsx`, `costScreen.integration.test.tsx` — department filter scope copy, Billed hidden.
- `platform/app/ee/governance/.../directoryDepartmentSync.integration.test.ts` — contradictory proof assigns nothing (8 tests, fresh PostgreSQL).
- `inventoryBouncerExemption.unit.test.ts` — the three routes are exempt from the no-org bouncer.
- `pnpm typecheck` clean on touched files; the CI Biome new-violation gate run locally against the merge base reports no new violations.

Not done: browser verification against a running stack.

## Deployment Impact

No new schema, migrations, environment variables or flags relative to #7650. The Costs flag stays default-off. Billed is unavailable regardless of that flag. Directory sync skips contradictory evidence on future pulls only; past assignments are not repaired. Apply the base PR's migrations as documented in #7650.

## Anything surprising?

The Setup drawer is page-owned rather than registered in the drawer registry, because the registry only passes URL params and this drawer needs the page's settings and its save callback. The known cost is that Langy's drawer dodge keys on the registry, so a floating Langy can sit over this sheet.

The directory-proof correction touches cost attribution; it was implemented on the requester's explicit instruction after the implement flow flagged it as money-path.
