### PR TITLE
fix(dashboard): plan-limit banners stack above page content that bleeds over them

### DIFF
--- a/platform/app/src/components/DashboardPageBody.tsx
+++ b/platform/app/src/components/DashboardPageBody.tsx
@@ -159,170 +159,189 @@ export const DashboardPageBody = ({
 
   return (
     <VStack width="full" gap={0} {...props}>
-      {/* Alert banners */}
-      {publicEnv.data &&
-        (!publicEnv.data?.HAS_LANGWATCH_NLP_SERVICE ||
-          !publicEnv.data?.HAS_LANGEVALS_ENDPOINT) && (
-          <Alert.Root
-            status="warning"
-            width="full"
-            borderBottom="1px solid"
-            borderBottomColor="yellow.300"
-            borderTopLeftRadius="2xl"
-          >
-            <Alert.Indicator />
-            <Alert.Content>
-              <Text>
-                Please check your environment variables, the following variables
-                are not set which are required for evaluations and workflows:
-              </Text>
-              {!publicEnv.data?.HAS_LANGWATCH_NLP_SERVICE && (
-                <Text>LANGWATCH_NLP_SERVICE</Text>
-              )}
-              {!publicEnv.data?.HAS_LANGEVALS_ENDPOINT && (
-                <Text>LANGEVALS_ENDPOINT</Text>
-              )}
-            </Alert.Content>
-          </Alert.Root>
-        )}
-      {usage.data?.messageLimitInfo &&
-        usage.data.messageLimitInfo.status !== "ok" && (
-          <Alert.Root
-            status={
-              usage.data.messageLimitInfo.status === "exceeded"
-                ? "error"
-                : "warning"
-            }
-            width="full"
-            borderBottom="1px solid"
-            borderBottomColor={
-              usage.data.messageLimitInfo.status === "exceeded"
-                ? "red.300"
-                : "yellow.300"
-            }
-          >
-            <Alert.Indicator />
-            <Alert.Content>
-              <Text>
-                {usage.data.messageLimitInfo.message}{" "}
-                <Link
-                  href={planManagementUrl}
-                  textDecoration="underline"
-                  _hover={{
-                    textDecoration: "none",
-                  }}
-                  onClick={() => {
-                    trackEvent("subscription_hook_click", {
-                      project_id: project?.id,
-                      hook:
-                        usage.data?.messageLimitInfo.status === "exceeded"
-                          ? "messages_limit_reached"
-                          : "messages_limit_warning",
-                    });
-                  }}
-                >
-                  Click here
-                </Link>{" "}
-                to upgrade your plan.
-              </Text>
-            </Alert.Content>
-          </Alert.Root>
-        )}
-      {usage.data &&
-        usage.data.currentMonthCost > usage.data.maxMonthlyUsageLimit && (
-          <Alert.Root
-            status="warning"
-            width="full"
-            borderBottom="1px solid"
-            borderBottomColor="yellow.300"
-          >
-            <Alert.Indicator />
-            <Alert.Content>
-              <Text>
-                You reached the limit of{" "}
-                {numeral(usage.data.maxMonthlyUsageLimit).format("$0.00")} usage
-                cost for this month, evaluations and guardrails will not be
-                processed.{" "}
-                <Link
-                  href="/settings/usage"
-                  textDecoration="underline"
-                  _hover={{
-                    textDecoration: "none",
-                  }}
-                  onClick={() => {
-                    trackEvent("subscription_hook_click", {
-                      project_id: project?.id,
-                      hook: "usage_cost_limit_reached",
-                    });
-                  }}
-                >
-                  Go to settings
-                </Link>{" "}
-                to check your usage spending limit or upgrade your plan.
-              </Text>
-            </Alert.Content>
-          </Alert.Root>
-        )}
+      {/* Alert banners.
 
-      <AnnouncementBanner />
-
-      {adminViewingAs && (
-        <AdminViewingAsBanner workspaceLabel={adminViewingAs.label} />
-      )}
-
-      {ssoStatus?.pendingSsoSetup && (
-        <Alert.Root
-          status="error"
-          width="full"
-          border="1px solid"
-          borderColor="colorPalette.muted"
-          marginX={4}
-          marginTop={3}
-          borderRadius="lg"
-          maxWidth="calc(100% - 22px)"
-        >
-          <Alert.Indicator />
-          <Alert.Content>
-            <HStack width="full" gap={4}>
-              <VStack align="start" gap={0} flex={1}>
-                <Alert.Title fontWeight="bold">
-                  Action Required: Link your SSO account
-                </Alert.Title>
-                <Text fontSize="sm">
-                  Your organization requires SSO login. Please link your account
-                  by logging in via the email input box on the sign-in page.
+          A positioned layer on purpose. Pages are free to paint outside their
+          own box (the home hero's light-mode bloom bleeds upward by almost
+          half its height) and to stack their own containers with a
+          `zIndex`. A static banner loses to both: the bloom washed the
+          "You reached the limit" alert out to a smear a customer could not
+          read. Banners are chrome, so they stack above whatever the page
+          does — `docked` is the lowest token above page-level layering and
+          still under every portaled overlay. */}
+      <VStack
+        width="full"
+        gap={0}
+        position="relative"
+        zIndex="docked"
+        data-part="page-banners"
+      >
+        {publicEnv.data &&
+          (!publicEnv.data?.HAS_LANGWATCH_NLP_SERVICE ||
+            !publicEnv.data?.HAS_LANGEVALS_ENDPOINT) && (
+            <Alert.Root
+              status="warning"
+              width="full"
+              borderBottom="1px solid"
+              borderBottomColor="yellow.300"
+              borderTopLeftRadius="2xl"
+            >
+              <Alert.Indicator />
+              <Alert.Content>
+                <Text>
+                  Please check your environment variables, the following
+                  variables are not set which are required for evaluations and
+                  workflows:
                 </Text>
-              </VStack>
-              <Button
-                size="sm"
-                colorPalette="red"
-                flexShrink={0}
-                color="white"
-                asChild
-              >
-                <Link href="/settings/authentication">
-                  <KeyRound size={14} />
-                  Link SSO Account
-                </Link>
-              </Button>
-            </HStack>
-          </Alert.Content>
-        </Alert.Root>
-      )}
+                {!publicEnv.data?.HAS_LANGWATCH_NLP_SERVICE && (
+                  <Text>LANGWATCH_NLP_SERVICE</Text>
+                )}
+                {!publicEnv.data?.HAS_LANGEVALS_ENDPOINT && (
+                  <Text>LANGEVALS_ENDPOINT</Text>
+                )}
+              </Alert.Content>
+            </Alert.Root>
+          )}
+        {usage.data?.messageLimitInfo &&
+          usage.data.messageLimitInfo.status !== "ok" && (
+            <Alert.Root
+              status={
+                usage.data.messageLimitInfo.status === "exceeded"
+                  ? "error"
+                  : "warning"
+              }
+              width="full"
+              borderBottom="1px solid"
+              borderBottomColor={
+                usage.data.messageLimitInfo.status === "exceeded"
+                  ? "red.300"
+                  : "yellow.300"
+              }
+            >
+              <Alert.Indicator />
+              <Alert.Content>
+                <Text>
+                  {usage.data.messageLimitInfo.message}{" "}
+                  <Link
+                    href={planManagementUrl}
+                    textDecoration="underline"
+                    _hover={{
+                      textDecoration: "none",
+                    }}
+                    onClick={() => {
+                      trackEvent("subscription_hook_click", {
+                        project_id: project?.id,
+                        hook:
+                          usage.data?.messageLimitInfo.status === "exceeded"
+                            ? "messages_limit_reached"
+                            : "messages_limit_warning",
+                      });
+                    }}
+                  >
+                    Click here
+                  </Link>{" "}
+                  to upgrade your plan.
+                </Text>
+              </Alert.Content>
+            </Alert.Root>
+          )}
+        {usage.data &&
+          usage.data.currentMonthCost > usage.data.maxMonthlyUsageLimit && (
+            <Alert.Root
+              status="warning"
+              width="full"
+              borderBottom="1px solid"
+              borderBottomColor="yellow.300"
+            >
+              <Alert.Indicator />
+              <Alert.Content>
+                <Text>
+                  You reached the limit of{" "}
+                  {numeral(usage.data.maxMonthlyUsageLimit).format("$0.00")}{" "}
+                  usage cost for this month, evaluations and guardrails will not
+                  be processed.{" "}
+                  <Link
+                    href="/settings/usage"
+                    textDecoration="underline"
+                    _hover={{
+                      textDecoration: "none",
+                    }}
+                    onClick={() => {
+                      trackEvent("subscription_hook_click", {
+                        project_id: project?.id,
+                        hook: "usage_cost_limit_reached",
+                      });
+                    }}
+                  >
+                    Go to settings
+                  </Link>{" "}
+                  to check your usage spending limit or upgrade your plan.
+                </Text>
+              </Alert.Content>
+            </Alert.Root>
+          )}
 
-      {publicEnv.data?.DEMO_PROJECT_SLUG &&
-        publicEnv.data.DEMO_PROJECT_SLUG === router.query.project && (
-          <HStack width="full" backgroundColor="orange.400" padding={1}>
-            <Spacer />
-            <Text fontSize="sm">
-              Viewing Demo Project - Go back to yours{" "}
-              <Link href="/" textDecoration="underline">
-                here
-              </Link>
-            </Text>
-            <Spacer />
-          </HStack>
+        <AnnouncementBanner />
+
+        {adminViewingAs && (
+          <AdminViewingAsBanner workspaceLabel={adminViewingAs.label} />
         )}
+
+        {ssoStatus?.pendingSsoSetup && (
+          <Alert.Root
+            status="error"
+            width="full"
+            border="1px solid"
+            borderColor="colorPalette.muted"
+            marginX={4}
+            marginTop={3}
+            borderRadius="lg"
+            maxWidth="calc(100% - 22px)"
+          >
+            <Alert.Indicator />
+            <Alert.Content>
+              <HStack width="full" gap={4}>
+                <VStack align="start" gap={0} flex={1}>
+                  <Alert.Title fontWeight="bold">
+                    Action Required: Link your SSO account
+                  </Alert.Title>
+                  <Text fontSize="sm">
+                    Your organization requires SSO login. Please link your
+                    account by logging in via the email input box on the sign-in
+                    page.
+                  </Text>
+                </VStack>
+                <Button
+                  size="sm"
+                  colorPalette="red"
+                  flexShrink={0}
+                  color="white"
+                  asChild
+                >
+                  <Link href="/settings/authentication">
+                    <KeyRound size={14} />
+                    Link SSO Account
+                  </Link>
+                </Button>
+              </HStack>
+            </Alert.Content>
+          </Alert.Root>
+        )}
+
+        {publicEnv.data?.DEMO_PROJECT_SLUG &&
+          publicEnv.data.DEMO_PROJECT_SLUG === router.query.project && (
+            <HStack width="full" backgroundColor="orange.400" padding={1}>
+              <Spacer />
+              <Text fontSize="sm">
+                Viewing Demo Project - Go back to yours{" "}
+                <Link href="/" textDecoration="underline">
+                  here
+                </Link>
+              </Text>
+              <Spacer />
+            </HStack>
+          )}
+      </VStack>
 
       <CurrentDrawer />
       {/* v2 trace drawer is mounted globally so cross-page opens

--- a/platform/app/src/components/__tests__/DashboardPageBody.bannersAbovePage.integration.test.tsx
+++ b/platform/app/src/components/__tests__/DashboardPageBody.bannersAbovePage.integration.test.tsx
@@ -113,9 +113,8 @@ function PageWithPositionedLayer() {
   );
 }
 
-describe("DashboardPageBody banners", () => {
-  describe("when the message limit is exceeded and the page paints a positioned layer", () => {
-    /** @scenario The plan-limit banner stays above page content that bleeds over it */
+describe("given a project whose message limit is exceeded", () => {
+  describe("when the page paints a positioned layer of its own", () => {
     it("stacks the banner above the page's own layer", () => {
       render(
         <ChakraProvider value={defaultSystem}>

--- a/platform/app/src/components/__tests__/DashboardPageBody.bannersAbovePage.integration.test.tsx
+++ b/platform/app/src/components/__tests__/DashboardPageBody.bannersAbovePage.integration.test.tsx
@@ -1,0 +1,140 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The plan-limit banners are chrome. A page that paints positioned layers
+ * outside its own box (the home hero's light-mode bloom bleeds upward by
+ * almost half its height) used to wash the "You reached the limit" alert
+ * out to a faint smear, because the alert was a static box and the page's
+ * container was a positioned `zIndex` layer above it. Customer report: the
+ * message-limit banner was unreadable on the home page.
+ */
+
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("~/utils/compat/next-router", () => ({
+  useRouter: () => ({ pathname: "/[project]", query: { project: "acme" } }),
+}));
+
+vi.mock("../../hooks/useRequiredSession", () => ({
+  useRequiredSession: () => ({
+    data: { user: { id: "user_1" } },
+    status: "authenticated",
+  }),
+}));
+
+vi.mock("../../hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({
+    organization: { id: "org_1" },
+    team: { id: "team_1", name: "Team", isPersonal: false },
+    project: { id: "proj_1" },
+    organizationRole: "MEMBER",
+    hasPermission: () => true,
+  }),
+  userBelongsToTeam: () => true,
+}));
+
+vi.mock("../../hooks/usePublicEnv", () => ({
+  usePublicEnv: () => ({
+    data: {
+      NODE_ENV: "test",
+      HAS_LANGWATCH_NLP_SERVICE: true,
+      HAS_LANGEVALS_ENDPOINT: true,
+    },
+  }),
+}));
+
+vi.mock("../../hooks/usePlanManagementUrl", () => ({
+  usePlanManagementUrl: () => ({ url: "/settings/subscription" }),
+}));
+
+vi.mock("../../hooks/useSavedViews", () => ({
+  SavedViewsProvider: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+
+vi.mock("../../utils/api", () => ({
+  api: {
+    limits: {
+      getUsage: {
+        useQuery: () => ({
+          data: {
+            currentMonthCost: 0,
+            maxMonthlyUsageLimit: 100,
+            messageLimitInfo: {
+              status: "exceeded",
+              message: "You reached the limit of 1,000 messages this month.",
+            },
+          },
+        }),
+      },
+    },
+    user: { getSsoStatus: { useQuery: () => ({ data: undefined }) } },
+    governance: {
+      recordWorkspaceView: {
+        useMutation: () => ({ mutate: vi.fn(), isPending: false }),
+      },
+    },
+  },
+}));
+
+vi.mock("../../utils/tracking", () => ({ trackEvent: vi.fn() }));
+vi.mock("../AnnouncementBanner", () => ({ AnnouncementBanner: () => null }));
+vi.mock("../CurrentDrawer", () => ({ CurrentDrawer: () => null }));
+vi.mock("../UpgradeModal", () => ({ GlobalUpgradeModal: () => null }));
+vi.mock("../SavedViewsBar", () => ({ SavedViewsBar: () => null }));
+vi.mock("../../features/traces-v2/components/GlobalTraceV2DrawerMount", () => ({
+  GlobalTraceV2DrawerMount: () => null,
+}));
+
+import { Box } from "@chakra-ui/react";
+import { DashboardPageBody } from "../DashboardPageBody";
+
+afterEach(() => cleanup());
+
+/**
+ * jsdom does not resolve custom properties, so a token-valued `zIndex`
+ * computes to its `var(--chakra-z-index-*)` reference. Resolve it through
+ * the same system that emitted it.
+ */
+function resolveZIndex(raw: string): number {
+  const token = /^var\(--chakra-z-index-([\w-]+)\)$/.exec(raw)?.[1];
+  return Number(token ? defaultSystem.token(`zIndex.${token}`) : raw);
+}
+
+/** What the home page does: a positioned container that stacks above static siblings. */
+function PageWithPositionedLayer() {
+  return (
+    <Box position="relative" zIndex={1} data-testid="page-layer">
+      page content
+    </Box>
+  );
+}
+
+describe("DashboardPageBody banners", () => {
+  describe("when the message limit is exceeded and the page paints a positioned layer", () => {
+    /** @scenario The plan-limit banner stays above page content that bleeds over it */
+    it("stacks the banner above the page's own layer", () => {
+      render(
+        <ChakraProvider value={defaultSystem}>
+          <DashboardPageBody>
+            <PageWithPositionedLayer />
+          </DashboardPageBody>
+        </ChakraProvider>,
+      );
+
+      const alert = screen.getByText(/You reached the limit/);
+      const banners = alert.closest("[data-part='page-banners']");
+      expect(banners).not.toBeNull();
+
+      const bannerStyle = getComputedStyle(banners!);
+      const pageStyle = getComputedStyle(screen.getByTestId("page-layer"));
+      expect(bannerStyle.position).not.toBe("static");
+      expect(resolveZIndex(bannerStyle.zIndex)).toBeGreaterThan(
+        resolveZIndex(pageStyle.zIndex),
+      );
+    });
+  });
+});


### PR DESCRIPTION
## For humans

When a workspace runs out of messages for the month, the app shows a red "You reached the limit…" banner at the top of every page. On the home page that banner was almost invisible: the new home's glowing background painted over it and washed the words out to a faint smear. This makes the banner sit on top of the page again, everywhere, so nothing a page draws can cover it.

## Why

Reported from the app: the message-limit banner on the home page was unreadable (screenshot showed only "You reached the…" and "…your plan." bleeding through a white haze).

Root cause: the home hero's light-mode bloom is an absolutely positioned layer that bleeds upward by ~45% of the hero's height (`HomePageBanners.tsx`), and the home page's container is a positioned `zIndex={1}` layer (`HomePage.tsx`). The limit alerts in `DashboardPageBody.tsx` were static boxes, so both painted over them.

## What changed

The banner stack in `DashboardPageBody` (env warnings, message-limit, cost-limit, announcement, admin-viewing-as, SSO, demo-project) is now wrapped in one positioned layer at the `docked` z-index. Banners are chrome: they stack above whatever a page does inside its own box, and stay under every portaled overlay (dropdown/modal/toast tokens are all higher).

The rest of the diff in `DashboardPageBody.tsx` is re-indentation from the wrapper.

## Test plan

- New `DashboardPageBody.bannersAbovePage.integration.test.tsx` renders the body with an exceeded message limit and a page that has its own `position: relative; z-index: 1` layer, and asserts the banner layer is positioned with a higher resolved z-index. Fails on `main` (no banner layer), passes with the fix.
- `pnpm test:component run src/components/__tests__/` for the two Dashboard tests: green.

## Anything surprising?

Not verified in a browser: reproducing "limit exceeded" needs a plan state I did not set up locally. The stacking-order fix is mechanical, but a screenshot on a limited account would confirm.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved alert banner stacking so important notices remain visible above positioned page content.
  * Applied consistent layering across dashboard banners, including usage limits, announcements, SSO notices, and demo-project alerts.

* **Tests**
  * Added coverage to verify that dashboard alerts appear above overlapping page layers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
