### PR TITLE
feat(agents): the connected agent drawer test turn takes parameter overrides

### DIFF
--- a/platform/app/src/components/agents/AgentTestPanel.tsx
+++ b/platform/app/src/components/agents/AgentTestPanel.tsx
@@ -3,7 +3,9 @@
  *
  * The same panel sits at the bottom of the connected, HTTP and code agent
  * drawers. It sends one message on the path a simulation turn takes and
- * shows the answer, or the refusal in the words of the error registry.
+ * shows the answer, or the refusal in the words of the error registry. A
+ * connected agent that declares parameters takes per-turn overrides on one
+ * line, the way the Run dialog does.
  *
  * @see specs/agents/agent-test-run.feature
  */
@@ -11,9 +13,16 @@
 import { Box, Button, HStack, Input, Text, VStack } from "@chakra-ui/react";
 import { Play } from "lucide-react";
 import { useState } from "react";
+import { ParameterLineField } from "~/components/agent-testing/run/ParameterLineField";
+import { toLineRunParameters } from "~/components/agent-testing/run/parameter-line";
+import { parameterPlaceholder } from "~/components/agent-testing/run/parameter-suggestions";
+import { FieldLabel } from "~/components/agent-testing/shared/DialogFields";
 import { OFFLINE_AGENT_TEST_COPY } from "~/components/agents/offlineAgentCopy";
+import type { DeclaredParameter } from "~/components/suites/useRunSuite";
+import { FieldInfoTooltip } from "~/components/ui/FieldInfoTooltip";
 import { Tooltip } from "~/components/ui/tooltip";
 import { HandledErrorAlert, readHandledError } from "~/features/errors";
+import type { ScenarioParameterDefinition } from "~/server/scenarios/parameters";
 import { api } from "~/utils/api";
 
 /** The message the panel sends when nothing else is typed. */
@@ -24,15 +33,24 @@ export type AgentTestPanelProps = {
   projectId: string;
   /** When true, the turn cannot be sent and the panel says why. */
   offline?: boolean;
+  /**
+   * The parameters the agent declares, when it declares any. The panel then
+   * takes `name=value` pairs the turn overrides the code defaults with; a
+   * name left out reads the default the code declares.
+   */
+  parameters?: readonly ScenarioParameterDefinition[];
 };
 
 export function AgentTestPanel({
   agentId,
   projectId,
   offline = false,
+  parameters,
 }: AgentTestPanelProps) {
   const [message, setMessage] = useState(AGENT_TEST_DEFAULT_MESSAGE);
+  const [parameterLine, setParameterLine] = useState("");
   const test = api.agents.testTurn.useMutation();
+  const plainParameters = plainParametersOf(parameters);
 
   return (
     <VStack align="stretch" gap={2} data-testid="agent-test">
@@ -60,7 +78,15 @@ export function AgentTestPanel({
               loading={test.isPending}
               disabled={offline || message.trim().length === 0}
               onClick={() =>
-                test.mutate({ id: agentId, projectId, message: message.trim() })
+                test.mutate({
+                  id: agentId,
+                  projectId,
+                  message: message.trim(),
+                  ...turnParameters({
+                    line: parameterLine,
+                    definitions: plainParameters,
+                  }),
+                })
               }
               data-testid="agent-test-run"
             >
@@ -70,6 +96,11 @@ export function AgentTestPanel({
           </Box>
         </Tooltip>
       </HStack>
+      <ParameterLine
+        definitions={plainParameters}
+        value={parameterLine}
+        onChange={setParameterLine}
+      />
       <TestError error={test.error} />
       {test.data ? (
         <VStack
@@ -97,6 +128,82 @@ export function AgentTestPanel({
         </VStack>
       ) : null}
     </VStack>
+  );
+}
+
+/** The declared parameters a line can carry: a secret never rides on one. */
+function plainParametersOf(
+  parameters: readonly ScenarioParameterDefinition[] | undefined,
+): ScenarioParameterDefinition[] {
+  return (parameters ?? []).filter((definition) => definition.secret !== true);
+}
+
+/**
+ * The overrides one turn carries, read off the line the way the Run dialog
+ * reads its own. Nothing typed, or no parameter declared, sends no `params`
+ * key at all, so the code defaults apply.
+ */
+function turnParameters({
+  line,
+  definitions,
+}: {
+  line: string;
+  definitions: readonly ScenarioParameterDefinition[];
+}): { params?: Record<string, string | number | boolean> } {
+  if (definitions.length === 0) return {};
+  const params = toLineRunParameters({
+    line,
+    secretValues: {},
+    definitions,
+  });
+  return params ? { params } : {};
+}
+
+/**
+ * One line of `name=value` pairs, shown only when the agent declares any. The
+ * field is the one the Run dialog and the case modal edit their parameters
+ * with, so it offers the same list and takes the same keys.
+ */
+
+/** The words the case modal shows for the same field. */
+const PARAMETERS_HELP =
+  "Parameters reach your agent as arguments of the function you annotated. Use them to run the same scenario as a free or a pro customer, in another locale, or on another model.";
+
+function ParameterLine({
+  definitions,
+  value,
+  onChange,
+}: {
+  definitions: readonly ScenarioParameterDefinition[];
+  value: string;
+  onChange: (line: string) => void;
+}) {
+  if (definitions.length === 0) return null;
+  const declared: DeclaredParameter[] = definitions.map((definition) => ({
+    ...definition,
+    source: "agent",
+  }));
+  return (
+    <Box data-testid="agent-test-parameters-block">
+      <FieldLabel>
+        Parameters
+        <FieldInfoTooltip
+          description={PARAMETERS_HELP}
+          docHref="/agent-testing/run-parameters"
+          docLabel="How to annotate an agent"
+          trigger="hover"
+          testId="agent-test-parameters-info"
+        />
+      </FieldLabel>
+      <ParameterLineField
+        ariaLabel="Parameters"
+        placeholder={parameterPlaceholder(declared)}
+        value={value}
+        onChange={onChange}
+        definitions={declared}
+        testId="agent-test-parameters"
+      />
+    </Box>
   );
 }
 

--- a/platform/app/src/components/agents/connected/ConnectedAgentDrawer.tsx
+++ b/platform/app/src/components/agents/connected/ConnectedAgentDrawer.tsx
@@ -194,6 +194,7 @@ function AgentBody({
         agentId={agent.id}
         projectId={projectId}
         offline={agent.status === "offline"}
+        parameters={agent.parameters}
       />
     </VStack>
   );

--- a/platform/app/src/components/agents/connected/__tests__/ConnectedAgentDrawer.integration.test.tsx
+++ b/platform/app/src/components/agents/connected/__tests__/ConnectedAgentDrawer.integration.test.tsx
@@ -236,26 +236,28 @@ describe("<ConnectedAgentDrawer />", () => {
       expect(result).toHaveTextContent("build-box (eu-pod)");
     });
 
-    /** @scenario "The connected agent drawer test turn takes parameter overrides" */
-    it("suggests the declared parameter, sends a typed value and sends nothing when the line is empty", async () => {
-      const user = userEvent.setup();
-      await renderDrawer();
+    describe("given the agent declares a parameter", () => {
+      /** @scenario "The connected agent drawer test turn takes parameter overrides" */
+      it("suggests the declared parameter, sends a typed value and sends nothing when the line is empty", async () => {
+        const user = userEvent.setup();
+        await renderDrawer();
 
-      const line = await screen.findByTestId("agent-test-parameters");
-      expect(line).toHaveAttribute("placeholder", "model=gpt-5-mini");
+        const line = await screen.findByTestId("agent-test-parameters");
+        expect(line).toHaveAttribute("placeholder", "model=gpt-5-mini");
 
-      await user.type(line, "model=gpt-5");
-      await user.click(screen.getByTestId("agent-test-run"));
-      expect(testMutate).toHaveBeenLastCalledWith({
-        id: "agent_1",
-        projectId: "project_1",
-        message: "ping",
-        params: { model: "gpt-5" },
+        await user.type(line, "model=gpt-5");
+        await user.click(screen.getByTestId("agent-test-run"));
+        expect(testMutate).toHaveBeenLastCalledWith({
+          id: "agent_1",
+          projectId: "project_1",
+          message: "ping",
+          params: { model: "gpt-5" },
+        });
+
+        await user.clear(line);
+        await user.click(screen.getByTestId("agent-test-run"));
+        expect(testMutate.mock.lastCall?.[0]).not.toHaveProperty("params");
       });
-
-      await user.clear(line);
-      await user.click(screen.getByTestId("agent-test-run"));
-      expect(testMutate.mock.lastCall?.[0]).not.toHaveProperty("params");
     });
   });
 });

--- a/platform/app/src/components/agents/connected/__tests__/ConnectedAgentDrawer.integration.test.tsx
+++ b/platform/app/src/components/agents/connected/__tests__/ConnectedAgentDrawer.integration.test.tsx
@@ -235,5 +235,27 @@ describe("<ConnectedAgentDrawer />", () => {
       expect(result).toHaveTextContent("Hello back");
       expect(result).toHaveTextContent("build-box (eu-pod)");
     });
+
+    /** @scenario "The connected agent drawer test turn takes parameter overrides" */
+    it("suggests the declared parameter, sends a typed value and sends nothing when the line is empty", async () => {
+      const user = userEvent.setup();
+      await renderDrawer();
+
+      const line = await screen.findByTestId("agent-test-parameters");
+      expect(line).toHaveAttribute("placeholder", "model=gpt-5-mini");
+
+      await user.type(line, "model=gpt-5");
+      await user.click(screen.getByTestId("agent-test-run"));
+      expect(testMutate).toHaveBeenLastCalledWith({
+        id: "agent_1",
+        projectId: "project_1",
+        message: "ping",
+        params: { model: "gpt-5" },
+      });
+
+      await user.clear(line);
+      await user.click(screen.getByTestId("agent-test-run"));
+      expect(testMutate.mock.lastCall?.[0]).not.toHaveProperty("params");
+    });
   });
 });

--- a/platform/app/src/server/agents/__tests__/agent-test-turn.unit.test.ts
+++ b/platform/app/src/server/agents/__tests__/agent-test-turn.unit.test.ts
@@ -1,8 +1,9 @@
 /**
  * @vitest-environment node
  *
- * One turn from the Test panel to an agent that is not connected: the call
- * deadline the platform holds every kind of agent to.
+ * One turn from the Test panel: the call deadline the platform holds every
+ * kind of agent to, and the parameter checks a connected agent's overrides
+ * go through.
  *
  * @see specs/agents/agent-test-run.feature
  */
@@ -29,6 +30,10 @@ vi.mock("~/server/connected-agents/runtime", () => ({
 
 vi.mock("~/server/suites/connected-targets", () => ({
   assertConnectedAgentsRunnable: vi.fn().mockResolvedValue(undefined),
+  agentParameterDefinitionsOf: (agent: { config: unknown }) => {
+    const config = agent.config as { parameters?: unknown[] } | null;
+    return config?.parameters ?? [];
+  },
 }));
 
 const prefetchScenarioData = vi.fn();
@@ -89,6 +94,42 @@ function sendTurn() {
   });
 }
 
+/** A connected agent whose code declares one parameter with two options. */
+function connectedAgent(): AgentWithFields {
+  return {
+    ...httpAgent(),
+    id: "agent_connected",
+    name: "support-agent",
+    type: "connected",
+    config: {
+      parameters: [
+        {
+          name: "model",
+          type: "string",
+          options: ["gpt-4", "gpt-5"],
+          defaultValue: "gpt-4",
+        },
+      ],
+      sdk: { name: "langwatch", version: "1.0.0", language: "python" },
+    },
+    environment: "production",
+  } as AgentWithFields;
+}
+
+function sendConnectedTurn(params: Record<string, string | number | boolean>) {
+  return sendAgentTestTurn({
+    projectId: "proj_1",
+    agentId: "agent_connected",
+    message: "ping",
+    params,
+    actor: { id: "user_1", label: "user" },
+    deps: {
+      readAgent: vi.fn().mockResolvedValue(connectedAgent()),
+      users: {} as Pick<PrismaClient, "user">,
+    },
+  });
+}
+
 beforeEach(() => {
   prefetchScenarioData.mockResolvedValue({
     success: true,
@@ -129,6 +170,26 @@ describe("given an HTTP agent that answers inside the deadline", () => {
 
       expect(result.output).toBe("pong");
       expect(result.instance).toBeNull();
+    });
+  });
+});
+
+describe("given a connected agent that declares the parameter model", () => {
+  describe("when a test turn names a parameter it does not declare", () => {
+    /** @scenario "A test turn naming an undeclared parameter is refused" */
+    it("is refused as scenario_parameter_unknown before any instance is reached", async () => {
+      await expect(sendConnectedTurn({ locale: "de" })).rejects.toMatchObject({
+        code: "scenario_parameter_unknown",
+      });
+    });
+  });
+
+  describe("when a test turn sets model outside its options", () => {
+    /** @scenario "A test turn value outside the declared options is refused" */
+    it("is refused as scenario_parameter_option_invalid before any instance is reached", async () => {
+      await expect(sendConnectedTurn({ model: "gpt-6" })).rejects.toMatchObject(
+        { code: "scenario_parameter_option_invalid" },
+      );
     });
   });
 });

--- a/platform/app/src/server/agents/__tests__/agent-test-turn.unit.test.ts
+++ b/platform/app/src/server/agents/__tests__/agent-test-turn.unit.test.ts
@@ -22,10 +22,13 @@ vi.mock("~/env.mjs", () => ({
   },
 }));
 
-vi.mock("~/server/connected-agents/runtime", () => ({
-  getConnectedAgentRuntime: () => {
+const { getConnectedAgentRuntime } = vi.hoisted(() => ({
+  getConnectedAgentRuntime: vi.fn(() => {
     throw new Error("no connected agent is reached in these tests");
-  },
+  }),
+}));
+vi.mock("~/server/connected-agents/runtime", () => ({
+  getConnectedAgentRuntime,
 }));
 
 vi.mock("~/server/suites/connected-targets", () => ({
@@ -116,7 +119,11 @@ function connectedAgent(): AgentWithFields {
   } as AgentWithFields;
 }
 
-function sendConnectedTurn(params: Record<string, string | number | boolean>) {
+function sendConnectedTurn({
+  params,
+}: {
+  params?: Record<string, string | number | boolean>;
+} = {}) {
   return sendAgentTestTurn({
     projectId: "proj_1",
     agentId: "agent_connected",
@@ -131,6 +138,7 @@ function sendConnectedTurn(params: Record<string, string | number | boolean>) {
 }
 
 beforeEach(() => {
+  getConnectedAgentRuntime.mockClear();
   prefetchScenarioData.mockResolvedValue({
     success: true,
     data: { adapterData: {}, nlpServiceUrl: "http://langwatch_nlp:5561" },
@@ -178,18 +186,22 @@ describe("given a connected agent that declares the parameter model", () => {
   describe("when a test turn names a parameter it does not declare", () => {
     /** @scenario "A test turn naming an undeclared parameter is refused" */
     it("is refused as scenario_parameter_unknown before any instance is reached", async () => {
-      await expect(sendConnectedTurn({ locale: "de" })).rejects.toMatchObject({
+      await expect(
+        sendConnectedTurn({ params: { locale: "de" } }),
+      ).rejects.toMatchObject({
         code: "scenario_parameter_unknown",
       });
+      expect(getConnectedAgentRuntime).not.toHaveBeenCalled();
     });
   });
 
   describe("when a test turn sets model outside its options", () => {
     /** @scenario "A test turn value outside the declared options is refused" */
     it("is refused as scenario_parameter_option_invalid before any instance is reached", async () => {
-      await expect(sendConnectedTurn({ model: "gpt-6" })).rejects.toMatchObject(
-        { code: "scenario_parameter_option_invalid" },
-      );
+      await expect(
+        sendConnectedTurn({ params: { model: "gpt-6" } }),
+      ).rejects.toMatchObject({ code: "scenario_parameter_option_invalid" });
+      expect(getConnectedAgentRuntime).not.toHaveBeenCalled();
     });
   });
 });

--- a/platform/app/src/server/agents/agent-test-turn.ts
+++ b/platform/app/src/server/agents/agent-test-turn.ts
@@ -30,8 +30,12 @@ import {
   prefetchScenarioData,
 } from "~/server/scenarios/execution/data-prefetcher";
 import { createAdapter } from "~/server/scenarios/execution/serialized-adapter.registry";
+import { resolveRunParameters } from "~/server/scenarios/resolve-run-parameters";
 import type { RunActor } from "~/server/scenarios/run-actor";
-import { assertConnectedAgentsRunnable } from "~/server/suites/connected-targets";
+import {
+  agentParameterDefinitionsOf,
+  assertConnectedAgentsRunnable,
+} from "~/server/suites/connected-targets";
 import type { AgentWithFields } from "./agent-fields";
 import { agentTestTarget } from "./agent-test-run";
 import { AgentNotFoundError, AgentTestRefusedError } from "./errors";
@@ -156,6 +160,10 @@ async function dispatchConnectedTurn({
  * @throws {AgentNotFoundError} when no such agent is in the project
  * @throws {AgentTestRefusedError} when the agent cannot be run as it is
  * @throws {AgentOwnerOnlyError} when the agent belongs to someone else
+ * @throws {ScenarioParameterUnknownError} when a value names a parameter the
+ *   connected agent does not declare
+ * @throws {ScenarioParameterOptionInvalidError} when a value is outside the
+ *   options the connected agent declares
  */
 export async function sendAgentTestTurn({
   projectId,
@@ -196,6 +204,15 @@ export async function sendAgentTestTurn({
   });
 
   if (agent.type === "connected") {
+    // The checks the Run dialog's values go through: a name the agent does
+    // not declare and a value outside its options are refused by name, before
+    // any instance is reached. A name left out reads the code default.
+    await resolveRunParameters({
+      scenarios: [],
+      targetDefinitions: agentParameterDefinitionsOf(agent),
+      targetLabel: agent.name,
+      values: params,
+    });
     return await dispatchConnectedTurn({ projectId, agent, message, params });
   }
 

--- a/platform/app/src/server/suites/connected-targets.ts
+++ b/platform/app/src/server/suites/connected-targets.ts
@@ -313,14 +313,16 @@ export async function assertConnectedAgentsOnline({
  * row whose declarations this version does not understand runs with none.
  */
 export function agentParameterDefinitionsOf(
-  agent: AgentIdentityRow | undefined,
+  agent: (Pick<AgentIdentityRow, "type"> & { config: unknown }) | undefined,
 ): ScenarioParameterDefinition[] {
   if (agent?.type !== "connected") return [];
-  const config = agent.config;
+  const config: unknown = agent.config;
   if (typeof config !== "object" || config === null || Array.isArray(config)) {
     return [];
   }
-  return parseScenarioParameterDefinitions(config.parameters);
+  return parseScenarioParameterDefinitions(
+    "parameters" in config ? config.parameters : undefined,
+  );
 }
 
 /** The display names of the owners of the personal agents among these. */

--- a/specs/agents/agent-test-run.feature
+++ b/specs/agents/agent-test-run.feature
@@ -223,6 +223,36 @@ Feature: Test agent with one scripted run
       Given the HTTP agent editor drawer open for a new agent
       Then no "Test agent" panel is shown
 
+  Rule: A test turn overrides the code defaults with values typed for it
+
+    # A connected agent registers the defaults its code declares. The panel
+    # keeps them as the baseline and takes per-turn overrides on one line,
+    # the way the Run dialog does for a scenario. A name left out reads the
+    # code default; a name the agent does not declare, or a value outside
+    # its options, is refused by name before any instance is reached.
+
+    @integration
+    Scenario: The connected agent drawer test turn takes parameter overrides
+      Given an online connected agent that declares a parameter with a default
+      When the test panel is opened
+      Then a parameters field suggests the declared name and its default
+      And starting the test with "model=gpt-5" typed sends the turn with that value
+      And starting the test with the field empty sends the turn with no parameter, so the code default applies
+
+    @unit
+    Scenario: A test turn naming an undeclared parameter is refused
+      Given a connected agent that declares the parameter model
+      When a test turn is sent with a value for a parameter it does not declare
+      Then the turn is refused as scenario_parameter_unknown
+      And no instance is reached
+
+    @unit
+    Scenario: A test turn value outside the declared options is refused
+      Given a connected agent whose model parameter has options gpt-4 and gpt-5
+      When a test turn is sent with model=gpt-6
+      Then the turn is refused as scenario_parameter_option_invalid
+      And no instance is reached
+
   Rule: A turn answers inside the platform call deadline
 
     # Every kind of agent answers inside the same ceiling the connected path


### PR DESCRIPTION
## Why

Closes https://github.com/langwatch/langwatch/issues/7948

The connected agent drawer's test panel could send a message but had no way to try a parameter override. The Run dialog and the case modal both let you type `name=value` overrides; the test panel could not.

This issue first shipped as https://github.com/langwatch/langwatch/pull/7950, a design where users edit and persist their own parameter defaults in the UI. The repository owner closed that PR and ruled the scope down: the code wrapper's config registers the defaults when the agent connects, and testing overrides them with dynamic variables, exactly like a scenario run. Editing the defaults themselves is out of scope. This PR is that ruled scope, opened fresh from `main`.

## What changed

- The test panel (`AgentTestPanel`) gains a parameters line when the agent declares any, using the same `ParameterLineField` component, placeholder suggestions, and "Parameters" label with info tooltip the Run dialog and the case modal already use.
- A name left out of the line reads the default the agent's code declares. A typed value overrides it for that one turn only, never persisted.
- The server (`sendAgentTestTurn`) runs the typed values through `resolveRunParameters` against the agent's declared parameter definitions before dispatching the turn. A name the agent does not declare is refused as `scenario_parameter_unknown`; a value outside the declared options is refused as `scenario_parameter_option_invalid` — the same two errors the Run dialog already produces. The panel renders both through the handled-error registry, so the refusal reads in plain words, not a raw error dump.
- `ConnectedAgentDrawer` passes the agent's declared parameters into the test panel.
- `agentParameterDefinitionsOf` (in `connected-targets.ts`) now takes its agent's `config` as `unknown` rather than the typed repository row, so the same reader works from a plain agent row inside `agent-test-turn.ts`, not only from the suite-execution path it originally served.

## How it works

The test panel treats the connected agent's declared parameters exactly like a scenario run treats them: code declares the shape and the default, a per-turn value overrides it, nothing is written back. That symmetry is what let this reuse `resolveRunParameters` and `ParameterLineField` outright instead of building a second parameter surface — the validation rules a reviewer already knows from the Run dialog are the same rules here.

## Test plan

Feature file: `specs/agents/agent-test-run.feature` gained one new Rule with three scenarios — a drawer test turn takes overrides (`@integration`), an undeclared parameter name is refused (`@unit`), and a value outside the declared options is refused (`@unit`). All three are bound; `pnpm check:feature-parity` reports `agent-test-run.feature` 31/31 scenarios bound.

Run this session:

| Command | Result |
|---|---|
| `pnpm test:unit run src/server/agents/__tests__/agent-test-turn.unit.test.ts` | 4 passed |
| `pnpm test:component run src/components/agents/connected/__tests__/ConnectedAgentDrawer.integration.test.tsx` | 7 passed |
| `pnpm test:component run src/components/agents/__tests__/AgentEditorTestPanel.integration.test.tsx` | 3 passed |
| `pnpm typecheck` | no errors |
| biome (changed files) | clean |
| `pnpm check:feature-parity` | `agent-test-run.feature` 31/31 scenarios bound |

## Files

**Changed**
- `specs/agents/agent-test-run.feature` — new Rule, three scenarios
- `platform/app/src/components/agents/AgentTestPanel.tsx` — the parameters line, override wiring, error rendering
- `platform/app/src/components/agents/connected/ConnectedAgentDrawer.tsx` — passes `agent.parameters` into the test panel
- `platform/app/src/components/agents/connected/__tests__/ConnectedAgentDrawer.integration.test.tsx` — the drawer-level override scenario
- `platform/app/src/server/agents/agent-test-turn.ts` — runs `resolveRunParameters` before dispatching a connected-agent turn
- `platform/app/src/server/agents/__tests__/agent-test-turn.unit.test.ts` — the two refusal scenarios
- `platform/app/src/server/suites/connected-targets.ts` — `agentParameterDefinitionsOf` reads `config` as `unknown` so a plain typed agent row can call it too

## Human verification

Steps a reviewer can run locally against the SDK example at `sdks/typescript/examples/agent/support-agent.ts`:

1. Run the example so it registers as a connected agent declaring a `model` parameter with options and a default.
2. In the app, open the Agents page and open that agent's drawer.
3. In the test panel at the bottom, confirm the Parameters line shows a placeholder suggesting `model=<default>`. VERIFIED, screenshot 1.
4. Leave the line empty, send a test message, and confirm the reply uses the code's default model. VERIFIED, screenshot 2.
5. Type `model=<one of the other declared options>`, send, and confirm the reply reflects that override. VERIFIED, screenshot 3.
6. Type a name the agent does not declare (for example `bogus=1`), send, and confirm the panel shows a plain-language refusal rather than a raw error. VERIFIED, screenshot 4.
7. Type a value outside the declared options (for example `model=gpt-6`), send, and confirm the panel names the allowed options in the refusal. VERIFIED, screenshot 5.

The repository owner exercised this earlier against a running dev app through a tunnel, and an operator then captured the five screenshots above against the running dev app with an echo agent declaring `model` (options `gpt-4`/`gpt-5`, default `gpt-4`) and `plan` (default `free`). Before the API process was restarted during the owner's session, a `model=gloop` turn reached the agent and failed generically, because the API process does not hot-reload server files; after the restart the server-side refusal was live, as screenshot 5 shows.

## How I can prove I was successful

| # | Scenario | Tag | Status |
|---|---|---|---|
| 1 | Drawer test turn takes overrides, and an empty line sends none | `@integration` | Proven — `ConnectedAgentDrawer.integration.test.tsx`, 7 passed |
| 2 | Undeclared parameter name refused as `scenario_parameter_unknown` | `@unit` | Proven — `agent-test-turn.unit.test.ts`, 4 passed |
| 3 | Value outside declared options refused as `scenario_parameter_option_invalid` | `@unit` | Proven — `agent-test-turn.unit.test.ts`, 4 passed |
| 4 | Real-browser walkthrough: type an override in the drawer, see the reply reflect it; type an invalid value, see the named refusal | — | Proven — screenshots below, captured against the running dev app with an echo agent declaring `model` (options gpt-4/gpt-5, default gpt-4) and `plan` (default free) |

Use-proof screenshots (published to `langwatch/pr-screenshots`, `pr-7959/`):

1. Drawer open, Parameters line suggests the code default `model=gpt-4`:
   ![drawer open with placeholder](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-7959/01-drawer-open-placeholder.png)
2. Empty line, reply echoes the code defaults `model=gpt-4 plan=free`:
   ![empty parameters, code default](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-7959/02-empty-params-code-default.png)
3. `model=gpt-5` typed, reply echoes the override:
   ![model override echoed](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-7959/03-model-gpt5-override.png)
4. `bogus=1` typed, the named refusal "Nothing in this run declares a parameter by that name":
   ![unknown parameter refusal](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-7959/04-unknown-param-refusal.png)
5. `model=gloop` typed, the named refusal "This value is not one of the parameter's options" listing gpt-4 and gpt-5:
   ![invalid option refusal](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-7959/05-invalid-option-refusal.png)

## Deployment Impact

- Migrations: none.
- Environment variables or secrets: none.
- Runtime: the server-side refusal lives in the API process (`sendAgentTestTurn`), which does not hot-reload server files in dev; a restart of the API process is needed to pick it up, as the repository owner saw during manual testing. In production a normal deploy covers this.
- Feature exposure: the parameters line only renders in the connected agent drawer's test panel when the agent declares parameters; agents that declare none see no change.
- Rollback: revert the single commit; nothing is persisted by this change.

## Anything surprising?

The repository owner's manual test caught a real gap worth flagging to reviewers: the API process does not hot-reload server-side files, so a code change to the refusal path (like this one) needs a process restart before it takes effect in a running dev app. Before that restart, an invalid parameter value reached the agent and failed generically instead of being refused. Nothing in this PR's own tests depends on hot-reload, but it is worth knowing when manually verifying this change against a live dev server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Claude-Session: https://claude.ai/code/session_01A6DSCfZG3Ss8EB4RPAXBYJ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added parameter overrides to connected agent test runs.
  * Users can enter declared parameter names and values, with code defaults applied when no override is provided.
  * Secret parameters are excluded from the override field.
  * Invalid parameter names and unsupported values are rejected before the test runs.

* **Tests**
  * Added coverage for parameter suggestions, overrides, defaults, and validation errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->