### PR TITLE
feat(gateway): bind the Scenario voice e2e cell to a dispatch-only gateway run

### DIFF
--- a/.github/workflows/scenario-voice-gateway-cell.yml
+++ b/.github/workflows/scenario-voice-gateway-cell.yml
@@ -6,13 +6,6 @@
 name: Scenario voice gateway cell
 
 on:
-  # TEMPORARY (#6180 proof run): GitHub only registers workflow_dispatch
-  # workflows once they exist on the default branch, so this push trigger is
-  # the only way to get a real run on the PR branch. It is removed before the
-  # PR leaves draft. Never widen it.
-  push:
-    branches:
-      - feat/6180-scenario-voice-gateway-cell
   workflow_dispatch:
     inputs:
       gateway_url:

--- a/.github/workflows/scenario-voice-gateway-cell.yml
+++ b/.github/workflows/scenario-voice-gateway-cell.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
     inputs:
       gateway_url:
-        description: Gateway base URL the audio calls route through
+        description: Gateway base URL the audio calls route through. Must be an https URL whose host is gateway.langwatch.ai or ends with .langwatch.ai; anything else fails the run before a request is made.
         required: false
         default: https://gateway.langwatch.ai/v1
 
@@ -39,6 +39,62 @@ jobs:
       - name: Setup Python UV
         working-directory: sdks/python
         run: uv sync --all-groups --all-extras
+
+      - name: Refuse a gateway URL outside langwatch.ai
+        # The virtual key rides in the Authorization header of every request,
+        # so an arbitrary gateway_url would hand the secret to whoever runs
+        # that host. Only LangWatch-controlled https origins are accepted.
+        env:
+          SCENARIO_VOICE_GATEWAY_URL: ${{ inputs.gateway_url }}
+        run: |
+          url="$SCENARIO_VOICE_GATEWAY_URL"
+
+          # Check if URL is empty
+          if [ -z "$url" ]; then
+            echo "::error::gateway_url is empty"
+            exit 1
+          fi
+
+          # Check if URL starts with https://
+          case "$url" in
+            https://*)
+              ;;
+            *)
+              echo "::error::gateway_url '$url' must use https://"
+              exit 1
+              ;;
+          esac
+
+          # Extract host from URL: remove https:// prefix, then remove everything from first / or : onward
+          host="${url#https://}"        # remove https:// prefix
+          host="${host%%/*}"             # remove everything from first /
+          host="${host%%:*}"             # remove everything from first : (port)
+
+          # Check if host is empty
+          if [ -z "$host" ]; then
+            echo "::error::gateway_url '$url' has an empty host"
+            exit 1
+          fi
+
+          # Check for @ in host (userinfo trick like https://gateway.langwatch.ai@evil.com)
+          case "$host" in
+            *@*)
+              echo "::error::gateway_url '$url' contains @ in the host part, which could be used to redirect to another host"
+              exit 1
+              ;;
+          esac
+
+          # Check if host matches the allowlist
+          # Only gateway.langwatch.ai or subdomains under langwatch.ai are permitted
+          case "$host" in
+            gateway.langwatch.ai|*.langwatch.ai)
+              # Valid hostname - this is a LangWatch-controlled origin
+              ;;
+            *)
+              echo "::error::gateway_url '$url' is not an https origin under langwatch.ai; refusing to send the virtual key there"
+              exit 1
+              ;;
+          esac
 
       # The test file skips when SCENARIO_VOICE_GATEWAY_VK is absent so the
       # per-push lane stays free, but this dedicated cell must never go green by

--- a/.github/workflows/scenario-voice-gateway-cell.yml
+++ b/.github/workflows/scenario-voice-gateway-cell.yml
@@ -49,13 +49,11 @@ jobs:
         run: |
           url="$SCENARIO_VOICE_GATEWAY_URL"
 
-          # Check if URL is empty
           if [ -z "$url" ]; then
             echo "::error::gateway_url is empty"
             exit 1
           fi
 
-          # Check if URL starts with https://
           case "$url" in
             https://*)
               ;;
@@ -65,30 +63,26 @@ jobs:
               ;;
           esac
 
-          # Extract host from URL: remove https:// prefix, then remove everything from first / or : onward
-          host="${url#https://}"        # remove https:// prefix
-          host="${host%%/*}"             # remove everything from first /
-          host="${host%%:*}"             # remove everything from first : (port)
+          authority="${url#https://}"
+          authority="${authority%%/*}"
 
-          # Check if host is empty
-          if [ -z "$host" ]; then
+          if [ -z "$authority" ]; then
             echo "::error::gateway_url '$url' has an empty host"
             exit 1
           fi
 
-          # Check for @ in host (userinfo trick like https://gateway.langwatch.ai@evil.com)
-          case "$host" in
+          # Reject userinfo in authority (e.g., attacker@host would let attacker sit before @ while httpx connects elsewhere)
+          case "$authority" in
             *@*)
-              echo "::error::gateway_url '$url' contains @ in the host part, which could be used to redirect to another host"
+              echo "::error::gateway_url '$url' contains @ in the authority, which could be used to redirect to another host"
               exit 1
               ;;
           esac
 
-          # Check if host matches the allowlist
-          # Only gateway.langwatch.ai or subdomains under langwatch.ai are permitted
+          host="${authority%%:*}"
+
           case "$host" in
             gateway.langwatch.ai|*.langwatch.ai)
-              # Valid hostname - this is a LangWatch-controlled origin
               ;;
             *)
               echo "::error::gateway_url '$url' is not an https origin under langwatch.ai; refusing to send the virtual key there"

--- a/.github/workflows/scenario-voice-gateway-cell.yml
+++ b/.github/workflows/scenario-voice-gateway-cell.yml
@@ -6,6 +6,13 @@
 name: Scenario voice gateway cell
 
 on:
+  # TEMPORARY (#6180 proof run): GitHub only registers workflow_dispatch
+  # workflows once they exist on the default branch, so this push trigger is
+  # the only way to get a real run on the PR branch. It is removed before the
+  # PR leaves draft. Never widen it.
+  push:
+    branches:
+      - feat/6180-scenario-voice-gateway-cell
   workflow_dispatch:
     inputs:
       gateway_url:
@@ -39,5 +46,5 @@ jobs:
         env:
           LANGWATCH_DEBUG: "true"
           SCENARIO_VOICE_GATEWAY_VK: ${{ secrets.PYTHON_SDK_GATEWAY_VIRTUAL_KEY }}
-          SCENARIO_VOICE_GATEWAY_URL: ${{ inputs.gateway_url }}
+          SCENARIO_VOICE_GATEWAY_URL: ${{ inputs.gateway_url || 'https://gateway.langwatch.ai/v1' }}
         run: uv run pytest -s -vv -m e2e tests/e2e/test_scenario_voice_gateway_e2e.py

--- a/.github/workflows/scenario-voice-gateway-cell.yml
+++ b/.github/workflows/scenario-voice-gateway-cell.yml
@@ -1,0 +1,43 @@
+# Dispatch-only: this cell drives real TTS + STT through the deployed LangWatch
+# AI Gateway and so spends real provider money on every run. It must never fire
+# on push or PR. The per-push sdk-python-ci job skips this test automatically
+# because SCENARIO_VOICE_GATEWAY_VK is absent in that job's environment; here we
+# provision it from a secret so the cell actually runs. Tracked in issue #6180.
+name: Scenario voice gateway cell
+
+on:
+  workflow_dispatch:
+    inputs:
+      gateway_url:
+        description: Gateway base URL the audio calls route through
+        required: false
+        default: https://gateway.langwatch.ai/v1
+
+permissions:
+  contents: read
+
+jobs:
+  voice-cell:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+
+      - name: Setup UV
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          enable-cache: true
+          cache-dependency-glob: "sdks/python/uv.lock"
+
+      - name: Setup Python UV
+        working-directory: sdks/python
+        run: uv sync --all-groups --all-extras
+
+      - name: Run the Scenario voice gateway cell
+        working-directory: sdks/python
+        env:
+          LANGWATCH_DEBUG: "true"
+          SCENARIO_VOICE_GATEWAY_VK: ${{ secrets.PYTHON_SDK_GATEWAY_VIRTUAL_KEY }}
+          SCENARIO_VOICE_GATEWAY_URL: ${{ inputs.gateway_url }}
+        run: uv run pytest -s -vv -m e2e tests/e2e/test_scenario_voice_gateway_e2e.py

--- a/.github/workflows/scenario-voice-gateway-cell.yml
+++ b/.github/workflows/scenario-voice-gateway-cell.yml
@@ -16,6 +16,12 @@ on:
 permissions:
   contents: read
 
+# Each run spends real provider money, so accidental double dispatches queue
+# instead of running twice.
+concurrency:
+  group: scenario-voice-gateway-cell
+  cancel-in-progress: false
+
 jobs:
   voice-cell:
     runs-on: ubuntu-latest
@@ -34,10 +40,23 @@ jobs:
         working-directory: sdks/python
         run: uv sync --all-groups --all-extras
 
+      # The test file skips when SCENARIO_VOICE_GATEWAY_VK is absent so the
+      # per-push lane stays free, but this dedicated cell must never go green by
+      # skipping — fail loudly when the secret is not configured.
+      - name: Fail loudly if the virtual key secret is not configured
+        env:
+          SCENARIO_VOICE_GATEWAY_VK: ${{ secrets.PYTHON_SDK_GATEWAY_VIRTUAL_KEY }}
+        run: |
+          if [ -z "$SCENARIO_VOICE_GATEWAY_VK" ]; then
+            echo "::error::PYTHON_SDK_GATEWAY_VIRTUAL_KEY is not set for this repository; the voice cell would skip instead of run"
+            exit 1
+          fi
+
       - name: Run the Scenario voice gateway cell
         working-directory: sdks/python
         env:
           LANGWATCH_DEBUG: "true"
+          PYTHONPATH: .
           SCENARIO_VOICE_GATEWAY_VK: ${{ secrets.PYTHON_SDK_GATEWAY_VIRTUAL_KEY }}
-          SCENARIO_VOICE_GATEWAY_URL: ${{ inputs.gateway_url || 'https://gateway.langwatch.ai/v1' }}
+          SCENARIO_VOICE_GATEWAY_URL: ${{ inputs.gateway_url }}
         run: uv run pytest -s -vv -m e2e tests/e2e/test_scenario_voice_gateway_e2e.py

--- a/sdks/python/tests/e2e/test_scenario_voice_gateway_e2e.py
+++ b/sdks/python/tests/e2e/test_scenario_voice_gateway_e2e.py
@@ -150,14 +150,14 @@ class RequestRecorder:
             if response.status_code >= 300:
                 try:
                     # Safe: httpx caches the body, so the OpenAI client still
-                    # reads the same bytes. The bare except is deliberate —
-                    # logging must never break the real call.
+                    # reads the same bytes. Catch specific transport and decode
+                    # errors, never raising — logging must never break the real call.
                     body_bytes = await response.aread()
                     body_text = body_bytes.decode("utf-8", errors="replace")
                     body_collapsed = " ".join(body_text.split())
                     record.body = body_collapsed[:300]
-                except Exception:
-                    pass
+                except (httpx.HTTPError, UnicodeDecodeError, RuntimeError) as exc:
+                    record.body = f"<body unreadable: {type(exc).__name__}: {exc}>"
             return response
 
         httpx.AsyncClient.send = send  # type: ignore[assignment,method-assign]

--- a/sdks/python/tests/e2e/test_scenario_voice_gateway_e2e.py
+++ b/sdks/python/tests/e2e/test_scenario_voice_gateway_e2e.py
@@ -6,8 +6,9 @@ text-to-speech (the scripted user turns) and speech-to-text (the agent-turn
 transcription) entirely through the gateway's ``/v1/audio/speech`` and
 ``/v1/audio/transcriptions`` routes — never against ``api.openai.com`` — and
 the gateway answers each call with its own response headers. The agent under
-test simply echoes the user's audio back, so the STT transcript is a mechanical
-function of the spoken input and the judge needs no LLM.
+test simply echoes the user's audio back. The judge needs no LLM — its grading
+is deterministic string matching — but the transcript it grades is real STT
+output of the real TTS audio, produced by the STT model.
 
 Required environment:
     SCENARIO_VOICE_GATEWAY_VK   (required) a LangWatch virtual key. When absent
@@ -40,7 +41,6 @@ import pytest
 import scenario
 from scenario.types import ScenarioResult
 from scenario.voice import AdapterCapabilities, AudioChunk, VoiceAgentAdapter
-from scenario.voice.audio_chunk import PCM16_SAMPLE_RATE, PCM16_SAMPLE_WIDTH_BYTES
 from scenario.voice.tts import clear_cache
 
 pytestmark = pytest.mark.e2e
@@ -56,11 +56,6 @@ LINE_2_STEMS = ("purple", "elephant", "juggle", "orange")
 
 SPEECH_ROUTE = "/audio/speech"
 TRANSCRIPTION_ROUTE = "/audio/transcriptions"
-
-
-def _pcm_seconds(data: bytes) -> float:
-    """Duration in seconds of a PCM16 mono 24kHz byte buffer."""
-    return (len(data) // PCM16_SAMPLE_WIDTH_BYTES) / PCM16_SAMPLE_RATE
 
 
 class GatewayEchoAgent(VoiceAgentAdapter):
@@ -154,6 +149,9 @@ class RequestRecorder:
             record.provider = response.headers.get("X-LangWatch-Provider")
             if response.status_code >= 300:
                 try:
+                    # Safe: httpx caches the body, so the OpenAI client still
+                    # reads the same bytes. The bare except is deliberate —
+                    # logging must never break the real call.
                     body_bytes = await response.aread()
                     body_text = body_bytes.decode("utf-8", errors="replace")
                     body_collapsed = " ".join(body_text.split())
@@ -190,12 +188,22 @@ def _request_length(request: httpx.Request) -> Optional[int]:
     raw = request.headers.get("content-length")
     if raw is not None:
         return int(raw)
-    content = getattr(request, "content", None)
+    # httpx.Request.content is a property that raises RequestNotRead when the
+    # body is not buffered; this runs before the real send, so never let it
+    # abort a live request — an unknown length is fine.
+    try:
+        content = request.content
+    except (AttributeError, httpx.RequestNotRead):
+        return None
     return len(content) if content is not None else None
 
 
 async def mechanical_judge(state: scenario.ScenarioState) -> ScenarioResult:
-    """Grade the recording with mechanical, LLM-free criteria.
+    """Grade the recording with deterministic, LLM-free string matching.
+
+    No LLM is involved in the grading itself. Criterion 4 nonetheless grades
+    real STT output of the real TTS audio, so its stem lists tolerate the
+    plural/inflection drift a transcription model introduces.
 
     Returning a ScenarioResult from a script step ends the run with that
     verdict — see ``ScenarioExecutor.run`` (the ``isinstance(result,
@@ -290,7 +298,11 @@ async def test_scenario_voice_runs_through_the_gateway(
                 agents=[
                     GatewayEchoAgent(),
                     scenario.UserSimulatorAgent(
-                        model="openai/gpt-5-mini", voice="openai/nova"
+                        # model is required by the constructor but unused here:
+                        # the scripted scenario.user(text) turns are TTS-only, so
+                        # no chat completion is part of what this cell verifies.
+                        model="openai/gpt-5-mini",
+                        voice="openai/nova",
                     ),
                 ],
                 script=[
@@ -308,34 +320,38 @@ async def test_scenario_voice_runs_through_the_gateway(
     # Print BEFORE any assertion so a failing run always shows the wire log.
     print(f"\nresolved base_url={base_url} gateway_host={gateway_host}")
     print(recorder.format())
+    if run_error is not None:
+        # Surface a crash that is unrelated to routing (raised after the route
+        # assertions below) so it is not misread as a routing failure.
+        print(f"run raised {type(run_error).__name__}: {run_error}")
 
     audio = recorder.audio_requests()
     speech = [r for r in audio if r.path.endswith(SPEECH_ROUTE)]
     transcriptions = [r for r in audio if r.path.endswith(TRANSCRIPTION_ROUTE)]
 
-    # (a) TTS route reached the gateway and returned 200.
-    assert speech, (
-        f"no POST {base_url}{SPEECH_ROUTE} was recorded against {gateway_host}; "
-        f"log:\n{recorder.format()}"
-    )
-    bad_speech = [r for r in speech if r.status != 200]
-    assert not bad_speech, (
-        f"POST {bad_speech[0].path} returned "
-        f"{[r.status or r.error for r in bad_speech]} from {gateway_host} "
-        f"(expected 200) first error body: {bad_speech[0].body!r}"
-    )
+    # The OpenAI SDK retries 429/5xx up to 2 times by default and each attempt
+    # is its own send, so a transient failure retried to a 200 is still a pass —
+    # judge each route by the LAST recorded response, not by every attempt.
+    def _assert_route_ok(recorded: List[RecordedRequest], route: str) -> None:
+        assert recorded, (
+            f"no POST {base_url}{route} was recorded against {gateway_host}; "
+            f"log:\n{recorder.format()}"
+        )
+        statuses = [r.status or r.error for r in recorded]
+        first_bad = next((r for r in recorded if r.status != 200), None)
+        last = recorded[-1]
+        ok = last.status == 200 and any(r.status == 200 for r in recorded)
+        assert ok, (
+            f"POST {last.path} returned {statuses} from {gateway_host} "
+            f"(expected 200) first error body: "
+            f"{first_bad.body if first_bad is not None else None!r}"
+        )
 
-    # (b) STT route reached the gateway and returned 200.
-    assert transcriptions, (
-        f"no POST {base_url}{TRANSCRIPTION_ROUTE} was recorded against "
-        f"{gateway_host}; log:\n{recorder.format()}"
-    )
-    bad_stt = [r for r in transcriptions if r.status != 200]
-    assert not bad_stt, (
-        f"POST {bad_stt[0].path} returned "
-        f"{[r.status or r.error for r in bad_stt]} from {gateway_host} "
-        f"(expected 200) first error body: {bad_stt[0].body!r}"
-    )
+    # (a) TTS route reached the gateway and ended on a 200.
+    _assert_route_ok(speech, SPEECH_ROUTE)
+
+    # (b) STT route reached the gateway and ended on a 200.
+    _assert_route_ok(transcriptions, TRANSCRIPTION_ROUTE)
 
     # (c) every audio call went to the gateway host and none to the provider.
     for r in audio:
@@ -372,7 +388,7 @@ async def test_scenario_voice_runs_through_the_gateway(
         f"{len(agent_segs)} agent audio segments"
     )
 
-    stt_seconds = sum(_pcm_seconds(s.audio) for s in agent_segs)
+    stt_seconds = sum(AudioChunk(data=s.audio).duration_seconds for s in agent_segs)
     tts_chars = len(LINE_1) + len(LINE_2)
     print(
         f"scenario-voice-gateway-cell: success={result.success} "

--- a/sdks/python/tests/e2e/test_scenario_voice_gateway_e2e.py
+++ b/sdks/python/tests/e2e/test_scenario_voice_gateway_e2e.py
@@ -112,6 +112,7 @@ class RecordedRequest:
     trace_id: Optional[str] = None
     provider: Optional[str] = None
     error: Optional[str] = None
+    body: Optional[str] = None
 
     def is_audio(self) -> bool:
         return self.path.endswith(SPEECH_ROUTE) or self.path.endswith(
@@ -151,6 +152,14 @@ class RequestRecorder:
             record.gateway_version = response.headers.get("X-LangWatch-Gateway-Version")
             record.trace_id = response.headers.get("X-LangWatch-Trace-Id")
             record.provider = response.headers.get("X-LangWatch-Provider")
+            if response.status_code >= 300:
+                try:
+                    body_bytes = await response.aread()
+                    body_text = body_bytes.decode("utf-8", errors="replace")
+                    body_collapsed = " ".join(body_text.split())
+                    record.body = body_collapsed[:300]
+                except Exception:
+                    pass
             return response
 
         httpx.AsyncClient.send = send  # type: ignore[assignment,method-assign]
@@ -166,11 +175,14 @@ class RequestRecorder:
         lines: List[str] = []
         for r in self.requests:
             status = f"{r.status}" if r.status is not None else f"ERR:{r.error}"
-            lines.append(
+            line = (
                 f"{r.method} {r.host} {r.path} -> {status} "
                 f"gateway={r.gateway_version} trace={r.trace_id} "
                 f"provider={r.provider} bytes={r.content_length}"
             )
+            if r.body is not None:
+                line += f" body={r.body!r}"
+            lines.append(line)
         return "\n".join(lines) if lines else "(no requests recorded)"
 
 
@@ -310,7 +322,7 @@ async def test_scenario_voice_runs_through_the_gateway(
     assert not bad_speech, (
         f"POST {bad_speech[0].path} returned "
         f"{[r.status or r.error for r in bad_speech]} from {gateway_host} "
-        "(expected 200)"
+        f"(expected 200) first error body: {bad_speech[0].body!r}"
     )
 
     # (b) STT route reached the gateway and returned 200.
@@ -322,7 +334,7 @@ async def test_scenario_voice_runs_through_the_gateway(
     assert not bad_stt, (
         f"POST {bad_stt[0].path} returned "
         f"{[r.status or r.error for r in bad_stt]} from {gateway_host} "
-        "(expected 200)"
+        f"(expected 200) first error body: {bad_stt[0].body!r}"
     )
 
     # (c) every audio call went to the gateway host and none to the provider.

--- a/sdks/python/tests/e2e/test_scenario_voice_gateway_e2e.py
+++ b/sdks/python/tests/e2e/test_scenario_voice_gateway_e2e.py
@@ -1,0 +1,370 @@
+"""
+End-to-end cell: a Scenario voice run through the LangWatch AI Gateway.
+
+What this proves: a deterministic two-turn voice scenario drives real
+text-to-speech (the scripted user turns) and speech-to-text (the agent-turn
+transcription) entirely through the gateway's ``/v1/audio/speech`` and
+``/v1/audio/transcriptions`` routes — never against ``api.openai.com`` — and
+the gateway answers each call with its own response headers. The agent under
+test simply echoes the user's audio back, so the STT transcript is a mechanical
+function of the spoken input and the judge needs no LLM.
+
+Required environment:
+    SCENARIO_VOICE_GATEWAY_VK   (required) a LangWatch virtual key. When absent
+                                the test skips — it runs only from the
+                                scenario-voice-gateway-cell workflow, which
+                                spends real provider money on a provisioned key.
+    SCENARIO_VOICE_GATEWAY_URL  (optional) gateway base URL; defaults to
+                                https://gateway.langwatch.ai/v1
+
+Run locally:
+    SCENARIO_VOICE_GATEWAY_VK=<vk> \
+        uv run pytest -s -vv -m e2e \
+        tests/e2e/test_scenario_voice_gateway_e2e.py
+
+The OpenAI Realtime websocket path is a deliberate exception and is out of
+scope here — this cell exercises only the REST audio routes.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from dataclasses import dataclass, field
+from typing import List, Optional
+from urllib.parse import urlsplit
+
+import httpx
+import pytest
+
+import scenario
+from scenario.types import ScenarioResult
+from scenario.voice import AdapterCapabilities, AudioChunk, VoiceAgentAdapter
+from scenario.voice.audio_chunk import PCM16_SAMPLE_RATE, PCM16_SAMPLE_WIDTH_BYTES
+from scenario.voice.tts import clear_cache
+
+pytestmark = pytest.mark.e2e
+
+DEFAULT_GATEWAY_URL = "https://gateway.langwatch.ai/v1"
+
+# Two scripted user lines with distinctive words. The echo agent replays the
+# audio, so each line's stems must resurface in the matching agent transcript.
+LINE_1 = "The quick brown fox jumps over the lazy dog"
+LINE_2 = "Purple elephants juggle seventeen oranges"
+LINE_1_STEMS = ("quick", "brown", "fox", "lazy", "dog")
+LINE_2_STEMS = ("purple", "elephant", "juggle", "orange")
+
+SPEECH_ROUTE = "/audio/speech"
+TRANSCRIPTION_ROUTE = "/audio/transcriptions"
+
+
+def _pcm_seconds(data: bytes) -> float:
+    """Duration in seconds of a PCM16 mono 24kHz byte buffer."""
+    return (len(data) // PCM16_SAMPLE_WIDTH_BYTES) / PCM16_SAMPLE_RATE
+
+
+class GatewayEchoAgent(VoiceAgentAdapter):
+    """Agent under test that echoes the user's audio back with no transcript.
+
+    Returning the audio without a transcript is what forces the base class to
+    run STT through the gateway — the whole point of the cell. A single-slot
+    buffer holds the last sent chunk; ``recv_audio`` hands it back once and then
+    signals tail silence with ``TimeoutError``, the base class's normal
+    end-of-turn cue.
+    """
+
+    capabilities = AdapterCapabilities()
+    response_tail_silence = 0.1
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._pending: Optional[bytes] = None
+
+    async def connect(self) -> None:
+        self._pending = None
+
+    async def disconnect(self) -> None:
+        self._pending = None
+
+    async def send_audio(self, chunk: AudioChunk) -> None:
+        self._pending = chunk.data
+
+    async def recv_audio(self, timeout: float) -> AudioChunk:
+        if self._pending is None:
+            # Nothing queued: the base drain reads this as tail silence and ends
+            # the agent turn — do NOT return an empty chunk (that path means a
+            # terminal chunk, not silence).
+            raise asyncio.TimeoutError
+        data, self._pending = self._pending, None
+        return AudioChunk(data=data)
+
+
+@dataclass
+class RecordedRequest:
+    """One HTTP request/response observed at the httpx transport seam."""
+
+    method: str
+    host: str
+    path: str
+    content_length: Optional[int]
+    status: Optional[int] = None
+    gateway_version: Optional[str] = None
+    trace_id: Optional[str] = None
+    provider: Optional[str] = None
+    error: Optional[str] = None
+
+    def is_audio(self) -> bool:
+        return self.path.endswith(SPEECH_ROUTE) or self.path.endswith(
+            TRANSCRIPTION_ROUTE
+        )
+
+
+@dataclass
+class RequestRecorder:
+    """Patches ``httpx.AsyncClient.send`` to log every request the run makes.
+
+    The class-attribute patch is deliberate: ``scenario.run`` executes on a
+    separate thread with its own event loop, so an instance-level or
+    contextvar hook set on the caller's loop would never see those requests.
+    """
+
+    requests: List[RecordedRequest] = field(default_factory=list)
+
+    def __enter__(self) -> "RequestRecorder":
+        self._original = httpx.AsyncClient.send
+        recorder = self
+
+        async def send(client, request, *args, **kwargs):  # type: ignore[no-untyped-def]
+            record = RecordedRequest(
+                method=request.method,
+                host=request.url.host,
+                path=request.url.path,
+                content_length=_request_length(request),
+            )
+            recorder.requests.append(record)
+            try:
+                response = await recorder._original(client, request, *args, **kwargs)
+            except Exception as exc:
+                record.error = type(exc).__name__
+                raise
+            record.status = response.status_code
+            record.gateway_version = response.headers.get("X-LangWatch-Gateway-Version")
+            record.trace_id = response.headers.get("X-LangWatch-Trace-Id")
+            record.provider = response.headers.get("X-LangWatch-Provider")
+            return response
+
+        httpx.AsyncClient.send = send  # type: ignore[assignment,method-assign]
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        httpx.AsyncClient.send = self._original  # type: ignore[method-assign]
+
+    def audio_requests(self) -> List[RecordedRequest]:
+        return [r for r in self.requests if r.is_audio()]
+
+    def format(self) -> str:
+        lines: List[str] = []
+        for r in self.requests:
+            status = f"{r.status}" if r.status is not None else f"ERR:{r.error}"
+            lines.append(
+                f"{r.method} {r.host} {r.path} -> {status} "
+                f"gateway={r.gateway_version} trace={r.trace_id} "
+                f"provider={r.provider} bytes={r.content_length}"
+            )
+        return "\n".join(lines) if lines else "(no requests recorded)"
+
+
+def _request_length(request: httpx.Request) -> Optional[int]:
+    raw = request.headers.get("content-length")
+    if raw is not None:
+        return int(raw)
+    content = getattr(request, "content", None)
+    return len(content) if content is not None else None
+
+
+async def mechanical_judge(state: scenario.ScenarioState) -> ScenarioResult:
+    """Grade the recording with mechanical, LLM-free criteria.
+
+    Returning a ScenarioResult from a script step ends the run with that
+    verdict — see ``ScenarioExecutor.run`` (the ``isinstance(result,
+    ScenarioResult)`` branch that returns it after attaching voice output).
+    """
+    recording = getattr(state._executor, "_voice_recording", None)
+    segments = list(getattr(recording, "segments", []) or [])
+    user_segs = [s for s in segments if s.speaker == "user"]
+    agent_segs = [s for s in segments if s.speaker == "agent"]
+
+    failures: List[str] = []
+
+    # 1. turn count
+    if len(user_segs) < 2 or len(agent_segs) < 2:
+        failures.append(
+            f"criterion 1 (turn count): expected >=2 user and >=2 agent "
+            f"segments, got {len(user_segs)} user / {len(agent_segs)} agent"
+        )
+
+    # 2. every segment carries non-empty audio
+    for seg in segments:
+        if not seg.audio:
+            failures.append(
+                f"criterion 2 (audio present): a {seg.speaker} segment has no audio"
+            )
+            break
+
+    # 3. every agent segment carries a non-empty transcript (the STT output)
+    for idx, seg in enumerate(agent_segs):
+        if not (seg.transcript or "").strip():
+            failures.append(
+                f"criterion 3 (agent transcript): agent segment {idx} has no transcript"
+            )
+
+    # 4. the distinctive stems of each scripted line surface in the matching
+    #    agent transcript (the echo transcribed back through STT).
+    for idx, stems in enumerate((LINE_1_STEMS, LINE_2_STEMS)):
+        if idx >= len(agent_segs):
+            continue
+        transcript = (agent_segs[idx].transcript or "").lower()
+        missing = [w for w in stems if w not in transcript]
+        if missing:
+            failures.append(
+                f"criterion 4 (spoken words): agent transcript {idx} "
+                f"{transcript!r} is missing {missing}"
+            )
+
+    if failures:
+        return await state._executor.fail("; ".join(failures))
+    return await state._executor.succeed(
+        "All mechanical criteria passed: two turns each side, audio present, "
+        "agent transcripts carry the spoken words echoed back through STT."
+    )
+
+
+# @scenario "Scenario's voice tests run end to end through the gateway"
+@pytest.mark.asyncio
+async def test_scenario_voice_runs_through_the_gateway(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    virtual_key = os.environ.get("SCENARIO_VOICE_GATEWAY_VK")
+    if not virtual_key:
+        pytest.skip(
+            "SCENARIO_VOICE_GATEWAY_VK not set; the Scenario voice gateway cell "
+            "runs only from the scenario-voice-gateway-cell workflow "
+            "(workflow_dispatch) with a provisioned LangWatch virtual key"
+        )
+
+    base_url = os.environ.get("SCENARIO_VOICE_GATEWAY_URL", DEFAULT_GATEWAY_URL)
+    gateway_host = urlsplit(base_url).hostname or ""
+
+    # Scenario's TTS/STT construct a bare AsyncOpenAI() per call, which reads
+    # these at construction time — so pointing them at the gateway routes every
+    # audio call through it. Clear the process-wide TTS cache so the run makes
+    # real synthesis calls rather than serving cached bytes from a prior run.
+    clear_cache()
+    monkeypatch.setenv("OPENAI_API_KEY", virtual_key)
+    monkeypatch.setenv("OPENAI_BASE_URL", base_url)
+    monkeypatch.setenv("OPENAI_API_BASE", base_url)
+
+    result: Optional[ScenarioResult] = None
+    run_error: Optional[Exception] = None
+    with RequestRecorder() as recorder:
+        try:
+            result = await scenario.run(
+                name="Scenario voice through the gateway",
+                description=(
+                    "A two-turn voice conversation whose user turns are "
+                    "synthesized and whose agent turns are transcribed, all "
+                    "through the LangWatch AI Gateway."
+                ),
+                agents=[
+                    GatewayEchoAgent(),
+                    scenario.UserSimulatorAgent(
+                        model="openai/gpt-5-mini", voice="openai/nova"
+                    ),
+                ],
+                script=[
+                    scenario.user(LINE_1),
+                    scenario.agent(),
+                    scenario.user(LINE_2),
+                    scenario.agent(),
+                    mechanical_judge,
+                ],
+                max_turns=6,
+            )
+        except Exception as exc:  # captured; re-raised after route assertions
+            run_error = exc
+
+    # Print BEFORE any assertion so a failing run always shows the wire log.
+    print(f"\nresolved base_url={base_url} gateway_host={gateway_host}")
+    print(recorder.format())
+
+    audio = recorder.audio_requests()
+    speech = [r for r in audio if r.path.endswith(SPEECH_ROUTE)]
+    transcriptions = [r for r in audio if r.path.endswith(TRANSCRIPTION_ROUTE)]
+
+    # (a) TTS route reached the gateway and returned 200.
+    assert speech, (
+        f"no POST {base_url}{SPEECH_ROUTE} was recorded against {gateway_host}; "
+        f"log:\n{recorder.format()}"
+    )
+    bad_speech = [r for r in speech if r.status != 200]
+    assert not bad_speech, (
+        f"POST {bad_speech[0].path} returned "
+        f"{[r.status or r.error for r in bad_speech]} from {gateway_host} "
+        "(expected 200)"
+    )
+
+    # (b) STT route reached the gateway and returned 200.
+    assert transcriptions, (
+        f"no POST {base_url}{TRANSCRIPTION_ROUTE} was recorded against "
+        f"{gateway_host}; log:\n{recorder.format()}"
+    )
+    bad_stt = [r for r in transcriptions if r.status != 200]
+    assert not bad_stt, (
+        f"POST {bad_stt[0].path} returned "
+        f"{[r.status or r.error for r in bad_stt]} from {gateway_host} "
+        "(expected 200)"
+    )
+
+    # (c) every audio call went to the gateway host and none to the provider.
+    for r in audio:
+        assert r.host == gateway_host, (
+            f"audio request {r.method} {r.path} went to {r.host}, "
+            f"not the gateway {gateway_host}"
+        )
+        assert r.host != "api.openai.com", (
+            f"audio request {r.method} {r.path} bypassed the gateway to "
+            "api.openai.com"
+        )
+
+    # (d) the gateway answered each audio call with its own version header.
+    for r in audio:
+        assert r.gateway_version, (
+            f"audio request {r.method} {r.path} carried no "
+            f"X-LangWatch-Gateway-Version header (status {r.status}); a bypass "
+            "or a non-gateway host answered it"
+        )
+
+    if run_error is not None:
+        raise run_error
+
+    assert result is not None
+    # (e) the run succeeded on the mechanical criteria.
+    assert result.success is True, f"scenario failed: {result.reasoning}"
+
+    # (f) run shape: at least two user and two agent audio segments.
+    segments = list(getattr(result.audio, "segments", []) or [])
+    user_segs = [s for s in segments if s.speaker == "user"]
+    agent_segs = [s for s in segments if s.speaker == "agent"]
+    assert len(user_segs) >= 2 and len(agent_segs) >= 2, (
+        f"expected a >=2-turn voice run, got {len(user_segs)} user and "
+        f"{len(agent_segs)} agent audio segments"
+    )
+
+    stt_seconds = sum(_pcm_seconds(s.audio) for s in agent_segs)
+    tts_chars = len(LINE_1) + len(LINE_2)
+    print(
+        f"scenario-voice-gateway-cell: success={result.success} "
+        f"base_url={base_url} speech_calls={len(speech)} "
+        f"transcription_calls={len(transcriptions)} tts_chars={tts_chars} "
+        f"stt_audio_seconds={stt_seconds:.2f}"
+    )

--- a/sdks/python/tests/e2e/test_scenario_voice_gateway_e2e.py
+++ b/sdks/python/tests/e2e/test_scenario_voice_gateway_e2e.py
@@ -12,9 +12,10 @@ output of the real TTS audio, produced by the STT model.
 
 Required environment:
     SCENARIO_VOICE_GATEWAY_VK   (required) a LangWatch virtual key. When absent
-                                the test skips — it runs only from the
-                                scenario-voice-gateway-cell workflow, which
-                                spends real provider money on a provisioned key.
+                                the module skips at collection time — it runs
+                                only from the scenario-voice-gateway-cell
+                                workflow, which spends real provider money on a
+                                provisioned key.
     SCENARIO_VOICE_GATEWAY_URL  (optional) gateway base URL; defaults to
                                 https://gateway.langwatch.ai/v1
 
@@ -37,6 +38,18 @@ from urllib.parse import urlsplit
 
 import httpx
 import pytest
+
+# Skip at import time, not inside the test: the SDK unit job collects this
+# tree with `-m "not e2e"`, and a module-level `import scenario` would still
+# run during that collection (it drags in joblib and numpy). Without the key
+# nothing below is needed, so the module never imports scenario at all.
+SKIP_REASON = (
+    "SCENARIO_VOICE_GATEWAY_VK not set; the Scenario voice gateway cell "
+    "runs only from the scenario-voice-gateway-cell workflow "
+    "(workflow_dispatch) with a provisioned LangWatch virtual key"
+)
+if not os.environ.get("SCENARIO_VOICE_GATEWAY_VK"):
+    pytest.skip(SKIP_REASON, allow_module_level=True)
 
 import scenario
 from scenario.types import ScenarioResult
@@ -265,12 +278,6 @@ async def test_scenario_voice_runs_through_the_gateway(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     virtual_key = os.environ.get("SCENARIO_VOICE_GATEWAY_VK")
-    if not virtual_key:
-        pytest.skip(
-            "SCENARIO_VOICE_GATEWAY_VK not set; the Scenario voice gateway cell "
-            "runs only from the scenario-voice-gateway-cell workflow "
-            "(workflow_dispatch) with a provisioned LangWatch virtual key"
-        )
 
     base_url = os.environ.get("SCENARIO_VOICE_GATEWAY_URL", DEFAULT_GATEWAY_URL)
     gateway_host = urlsplit(base_url).hostname or ""
@@ -340,8 +347,8 @@ async def test_scenario_voice_runs_through_the_gateway(
         statuses = [r.status or r.error for r in recorded]
         first_bad = next((r for r in recorded if r.status != 200), None)
         last = recorded[-1]
-        ok = last.status == 200 and any(r.status == 200 for r in recorded)
-        assert ok, (
+        is_route_successful = last.status == 200 and any(r.status == 200 for r in recorded)
+        assert is_route_successful, (
             f"POST {last.path} returned {statuses} from {gateway_host} "
             f"(expected 200) first error body: "
             f"{first_bad.body if first_bad is not None else None!r}"

--- a/specs/ai-gateway/audio-endpoints.feature
+++ b/specs/ai-gateway/audio-endpoints.feature
@@ -238,12 +238,17 @@ Feature: Gateway audio endpoints, OpenAI-compatible TTS and STT for OpenAI and E
   # Group: Dogfood (proven with the Scenario voice harness)
   # ============================================================
 
-  # Exercised live on PR #6168 (OpenAI-model and ElevenLabs-model runs, both
-  # success: True); automation is tracked in issue #6180 and lands when the
-  # Scenario repo's voice CI points at the deployed gateway.
-  @e2e @unimplemented
+  # The cell lives in the Python SDK e2e tests
+  # (sdks/python/tests/e2e/test_scenario_voice_gateway_e2e.py). It runs only
+  # from the scenario-voice-gateway-cell workflow (workflow_dispatch) with a
+  # provisioned LangWatch virtual key (SCENARIO_VOICE_GATEWAY_VK), because it
+  # spends real provider money; absent that variable it skips naming it, so the
+  # per-push SDK CI never pays for it. Tracked in issue #6180.
+  # The OpenAI Realtime websocket is a deliberate exception and is out of scope here.
+  @e2e
   Scenario: Scenario's voice tests run end to end through the gateway
     Given OPENAI_BASE_URL pointing at the gateway and a virtual key as OPENAI_API_KEY
     When a Scenario voice test synthesizes user turns (TTS) and the judge transcribes segments (STT)
-    Then the run completes with result.success without any direct provider call
-    And the gateway shows the audio usage for the run
+    Then the run completes with result.success
+    And every /v1/audio/speech and /v1/audio/transcriptions request went to the gateway and none went to the provider directly
+    And the gateway answered each audio request with its own response headers


### PR DESCRIPTION
> **Status (living):** head 76137c005a. CodeRabbit's second pass found a userinfo bypass in the gateway_url guard (port stripped before the @ check), fixed at 76137c005a. After un-drafting, the draft-gated sdk-python-ci unit job went red on module-level scenario import during full-tree collection, fixed by a module-level skip; two CodeRabbit threads fixed (gateway_url allowlist, boolean rename). Review pass applied at 316316baf7 (retry tolerance, RequestNotRead guard, fail-loud secret step, concurrency group); local skip/404/parity proofs re-run at that head. Local proofs done for AC3/AC4/AC5/AC6a/AC7a/AC8/AC9. Two real gateway runs reached gateway.langwatch.ai and got 429 credit_balance_exhausted on the shared virtual key, so AC1/AC2/AC6b/AC7b are UNVERIFIED until a key with gateway credit is provisioned. The temporary push trigger is reverted; the workflow is workflow_dispatch-only. The code-quality bot's bare-except finding is fixed at b33788906e (the recorder records why an error body was unreadable). 404 proof re-run at that head. All bot threads resolved; CI green at ba19725d3b, re-running at 76137c005a.

**Scariest thing** — the cell is bound in feature parity but gated on an opt-in variable, so if the skip ever turned into a silent pass the parity count would launder an unexercised gateway path into green. The skip path names the variable and the workflow, and the 404 run shows the cell fails loudly when the gateway does not serve audio.
**Start here** — `sdks/python/tests/e2e/test_scenario_voice_gateway_e2e.py`, the `RequestRecorder` and the assertion order in the test: the wire log is printed before any assertion, and the route assertions run before the run outcome is examined, so a broken gateway names the route rather than a generic Scenario error.

## Why

Closes #6180. The Dogfood scenario in `specs/ai-gateway/audio-endpoints.feature` has been parked `@unimplemented` since #6168 because the only Scenario-voice automation lived in the `langwatch/scenario` repo, was dispatch-only, and never went green due to LLM-judge nondeterminism. Option A (owner decision on the issue) is to build a deterministic cell in this repo that proves the gateway's `/v1/audio/speech` and `/v1/audio/transcriptions` routes end to end.

## What changed

- **Echo voice adapter plus a mechanical judge** -> a real voice agent with an LLM judge -> removes both nondeterminism sources the issue names; the agent echoes the user's audio so the STT transcript is a mechanical function of the scripted line, and the judge checks only audio bytes, transcript presence, turn count and spoken words.
- **Dedicated opt-in variable `SCENARIO_VOICE_GATEWAY_VK`** -> gating on `OPENAI_API_KEY` -> the per-push `sdk-python-ci` e2e job already exports a gateway virtual key as `OPENAI_API_KEY`, so gating on it would spend real money on every push; the cell skips there and runs only where the opt-in variable is set.
- **Request recorder at the httpx seam** -> gateway-side usage lookup -> the run's own log of every request (host, path, status, gateway headers) needs no project API key and is what proves the gateway, not the provider, answered.
- **Review hardening (316316baf7).** The recorder's request-length probe now catches `httpx.RequestNotRead` (the property raises that, not `AttributeError`, so the old code could abort a real request before it was sent). Route assertions accept a 429/5xx that the OpenAI SDK retried to a 200: the last response on each route must be 200. The dispatch workflow fails instead of skipping when the secret is empty, serialises runs in a `concurrency` group so a double dispatch cannot double the spend, and sets `PYTHONPATH` like the Makefile's e2e target.
- **`workflow_dispatch`-only workflow** supplies the secret. GitHub registers dispatch workflows only from the default branch, so two proof runs used a temporary branch-scoped push trigger (commits 3ca719ea28 and 4c5b34e1a8 add and remove it); the final head has no push trigger.
- **Post-undraft fixes (ba19725d3b).** The key check now skips at module level before `import scenario`, so the SDK unit job (which collects the whole tests tree with -m "not e2e") never imports scenario/joblib/numpy. A new workflow step `Refuse a gateway URL outside langwatch.ai` accepts only https URLs whose host is gateway.langwatch.ai or ends with .langwatch.ai, run before the key check, because the virtual key rides in the Authorization header of every request. `ok` renamed to `is_route_successful`. **76137c005a:** the guard checks the full authority for @ before stripping the port, so https://gateway.langwatch.ai:443@attacker.example/v1 is refused; restating comments removed.

## How it works

```
specs/ai-gateway/audio-endpoints.feature        scenario un-parked (@e2e), Then steps name the routes
sdks/python/tests/e2e/
  test_scenario_voice_gateway_e2e.py            the cell
    GatewayEchoAgent                            VoiceAgentAdapter: returns the sent audio without a transcript,
                                                so Scenario's base class runs STT through the gateway
    RequestRecorder                             patches httpx.AsyncClient.send (class level, so it sees the
                                                executor thread) and logs method/host/path/status/gateway headers
    mechanical_judge                            script step returning a ScenarioResult from four mechanical criteria
    test_scenario_voice_runs_through_the_gateway  skip gate, env wiring, run, wire log, ordered assertions, cost line
.github/workflows/scenario-voice-gateway-cell.yml  dispatch-only runner mapping the repo secret onto the opt-in variable
```

Scenario's TTS and STT construct a bare `AsyncOpenAI()` per call, so setting `OPENAI_BASE_URL` and `OPENAI_API_KEY` from the opt-in variables routes every audio call through the gateway. The in-process TTS cache is cleared at the start so a second run still hits `/v1/audio/speech`.

## Human verification

1. In `sdks/python` run `uv sync --group dev --group tests`, then `uv run pytest -s -vv -m e2e tests/e2e/test_scenario_voice_gateway_e2e.py` with `SCENARIO_VOICE_GATEWAY_VK` unset. Confirm one SKIPPED whose reason names the variable and the `scenario-voice-gateway-cell` workflow.
2. Start any local server that answers 404 to everything on port 8404, then run the same command with `SCENARIO_VOICE_GATEWAY_VK=placeholder SCENARIO_VOICE_GATEWAY_URL=http://127.0.0.1:8404/v1`. Confirm the wire log prints `POST 127.0.0.1 /v1/audio/speech -> 404` and the failure reads `POST /v1/audio/speech returned [404] ... (expected 200)`.
3. With a real LangWatch virtual key, run the same command with `SCENARIO_VOICE_GATEWAY_VK=<vk>`. Confirm the log shows two `/v1/audio/speech` and two `/v1/audio/transcriptions` calls against `gateway.langwatch.ai`, each 200 with a `gateway=git-...` header, no `api.openai.com` line, and a final `scenario-voice-gateway-cell: success=True` line.
4. Run `pnpm tsx scripts/check-feature-parity.ts` from `platform/app` and confirm `specs/ai-gateway/audio-endpoints.feature` reports 27/27 bound.
5. Open `.github/workflows/scenario-voice-gateway-cell.yml` and confirm the `on:` block is `workflow_dispatch` only (after the temporary trigger is reverted).

## How I can prove I was successful

| AC | Claim | Status | Evidence |
|---|---|---|---|
| AC1 | Run completes through prod gateway with `success: True` over a real 2+2-turn exchange | missing | two runs (34187561002, 34187861131) reached the gateway and got 429 `credit_balance_exhausted` on `PYTHON_SDK_GATEWAY_VIRTUAL_KEY`; UNVERIFIED until a key with gateway credit exists. Exact command once #7963 is merged: `gh workflow run scenario-voice-gateway-cell.yml --ref main` |
| AC2 | >=1 `POST /v1/audio/speech` and >=1 `POST /v1/audio/transcriptions` against the gateway, 200, gateway header, no `api.openai.com` | partial | run 34187861131 wire log below: every `POST /v1/audio/speech` went to `gateway.langwatch.ai` with `X-LangWatch-Gateway-Version: git-9a5cec7` and a trace id, none to `api.openai.com`; the 200 half and the transcription half are UNVERIFIED for the same credit reason |
| AC3 | Scenario un-parked and bound in a scanned root | proven | parity before: `audio-endpoints.feature 26/26 scenarios bound`, `OK: 11674 enforced scenario(s) bound`; after: `27/27 scenarios bound`, `OK: 11675 enforced scenario(s) bound` |
| AC4 | 404 base URL fails naming the audio route and status | proven | re-run at ba19725d3b, same assertion: see 404 run below |
| AC5 | Key absent skips naming the variable; parity still bound | proven | skip now happens at collection time (:52), proven both under `-m e2e` and under the unit filter `-m "not integration and not e2e"` (1 skipped, scenario and numpy absent from sys.modules); see skip run below; parity after shows 27/27. The dispatch workflow itself never skips: a guard step exits 1 with `::error::PYTHON_SDK_GATEWAY_VIRTUAL_KEY is not set` when the secret is empty. |
| AC6a | Judge criteria mechanical only | proven | `mechanical_judge` in the test: criterion 1 turn count (>=2 user, >=2 agent), 2 audio bytes present on every segment, 3 non-empty agent transcript, 4 scripted stems present in the matching agent transcript; no LLM judge |
| AC6b | 3 consecutive prod passes | missing | needs three passing dispatches: `gh workflow run scenario-voice-gateway-cell.yml --ref main` x3 after a key with credit is provisioned |
| AC7a | Not wired to push or PR | proven | final `on:` block is `workflow_dispatch` only (head 4c5b34e1a8); the per-push `sdk-python-ci` job skips the cell because `SCENARIO_VOICE_GATEWAY_VK` is absent; no voice-cell run fired for the push of 4c5b34e1a8. URL allowlist step added to refuse gateway_url outside langwatch.ai |
| AC7b | Per-run spend measured | missing | recorded from the run's `tts_chars` / `stt_audio_seconds` line once a passing run exists; both failed runs spent nothing (429 before any audio) |
| AC8 | httpapi audio tests and `live_audio` matrix unaffected | proven | see Go checks below |
| AC9 | Bound-but-unprovisioned cell is legibly inert | proven | skip reason below names the variable and the workflow; feature-file comment states the cell runs only on dispatch with a provisioned key |

Skip run (AC5, AC9), local, `SCENARIO_VOICE_GATEWAY_VK` unset:

```
platform linux -- Python 3.11.14, pytest-9.1.1, pluggy-1.6.0
collected 1 item
SKIPPED [1] tests/e2e/test_scenario_voice_gateway_e2e.py:52: SCENARIO_VOICE_GATEWAY_VK not set; the Scenario voice gateway cell runs only from the scenario-voice-gateway-cell workflow (workflow_dispatch) with a provisioned LangWatch virtual key
======================== 1 skipped, 1 warning in 4.05s =========================
```

404 run (AC4), local server answering 404 to every route, placeholder key present:

```
resolved base_url=http://127.0.0.1:8404/v1 gateway_host=127.0.0.1
POST 127.0.0.1 /v1/audio/speech -> 404 gateway=None trace=None provider=None bytes=120
E       AssertionError: POST /v1/audio/speech returned [404] from 127.0.0.1 (expected 200)
run raised NotFoundError: Error code: 404 - {'error': 'not found'}
========================= 1 failed, 1 warning in 6.24s =========================
```

Feature parity (AC3, AC5), `platform/app/scripts/check-feature-parity.ts` before and after:

```
before:  specs/ai-gateway/audio-endpoints.feature  26/26 scenarios bound   OK: 11674 enforced scenario(s) bound across 1251 file(s).
after:   specs/ai-gateway/audio-endpoints.feature  27/27 scenarios bound   OK: 11675 enforced scenario(s) bound across 1251 file(s).
```

Real gateway run (AC2 partial, AC4 in prod), run 34187861131 from the temporary trigger, `SCENARIO_VOICE_GATEWAY_VK` = the repo's `PYTHON_SDK_GATEWAY_VIRTUAL_KEY`:

```
resolved base_url=https://gateway.langwatch.ai/v1 gateway_host=gateway.langwatch.ai
POST gateway.langwatch.ai /v1/audio/speech -> 429 gateway=git-9a5cec7 trace=8a9be3b369ebf4c1c34ec063c4de11b4 provider=openai bytes=120 body='{"error":{"param":null,"code":"credit_balance_exhausted","message":"Your organization\'s AI gateway access is exhausted. Contact your LangWatch admin.","type":"insufficient_quota"}}'
POST gateway.langwatch.ai /v1/audio/speech -> 429 gateway=git-9a5cec7 trace=c2306a4e4ceb9635128590a6060bf846 provider=openai bytes=120 body='{"error":{...,"code":"credit_balance_exhausted"}}'
POST gateway.langwatch.ai /v1/audio/speech -> 429 gateway=git-9a5cec7 trace=d3743621b55911c3848fddda6230c0aa provider=openai bytes=120 body='{"error":{...,"code":"credit_balance_exhausted"}}'
E       AssertionError: POST /v1/audio/speech returned [429, 429, 429] from gateway.langwatch.ai (expected 200) first error body: '{"error":{"param":null,"code":"credit_balance_exhausted",...,"type":"insufficient_quota"}}'
========================= 1 failed, 1 warning in 7.99s =========================
```

Go checks (AC8), local, nice/ionice:

```
== go test ./adapters/httpapi/... ==
ok  	github.com/langwatch/langwatch/services/aigateway/adapters/httpapi	0.924s
== go vet -tags=live_audio ./tests/matrix/... ==
vet_exit=0
== go test -tags=live_audio -run TestAudio -v ./tests/matrix/... ==
--- SKIP: TestAudio_OpenAI_SpeechToTranscriptionRoundTrip (0.00s)
--- SKIP: TestAudio_OpenAI_SpeechMP3 (0.00s)
--- SKIP: TestAudio_ElevenLabs_SpeechToOpenAITranscription (0.00s)
--- SKIP: TestAudio_ElevenLabs_Transcription (0.00s)
--- SKIP: TestAudio_ElevenLabsNative_SpeechToTranscriptionRoundTrip (0.00s)
PASS
ok  	github.com/langwatch/langwatch/services/aigateway/tests/matrix	0.003s
```

Proof screenshots:

Skip run (AC5, AC9):

![skip run](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-7963/proof/skip-run.png)

404 run (AC4):

![404 run](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-7963/proof/run-404.png)

Real gateway run 34187861131 (AC2 partial, credit exhausted):

![gateway run](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-7963/proof/gateway-run-2.png)

## Deployment impact

None. No runtime, schema or gateway code changes. One new dispatch-only workflow that uses the existing `PYTHON_SDK_GATEWAY_VIRTUAL_KEY` secret and spends provider money only when a human dispatches it.

## Anything surprising?

- The issue text names `langwatch/scripts/check-feature-parity.ts`; the script lives at `platform/app/scripts/check-feature-parity.ts`.
- GitHub does not register a `workflow_dispatch` workflow until it exists on the default branch, so the dispatch cannot be exercised from a PR branch. A temporary branch-scoped push trigger was added (3ca719ea28) for two proof runs and removed (4c5b34e1a8); reviewers should confirm the head has no `push:` trigger.
- The organization behind the shared `PYTHON_SDK_GATEWAY_VIRTUAL_KEY` has no gateway credit (`credit_balance_exhausted`), so the key-dependent ACs cannot go green from this PR. Provisioning credit or a dedicated virtual key for the cell is the follow-up; no code change is needed for it.
- The OpenAI Realtime websocket is out of scope, as the issue states; the cell covers the REST audio routes only.
- The OpenAI SDK retries 429/5xx twice by default and each attempt is its own `httpx` send, which is why the failed gateway runs show three identical 429 lines; the route assertions now judge the last response per route so a transient 429 retried to a 200 passes.
- The unit job only started running once the PR left draft (ready_for_review gate), which is why the collection failure surfaced late.

URL allowlist guard cases (gateway_url parameter):

| gateway_url | result |
| --- | --- |
| https://gateway.langwatch.ai/v1 | accepted |
| https://staging-gateway.langwatch.ai/v1 | accepted |
| https://gateway.langwatch.ai:443/v1 | accepted |
| http://gateway.langwatch.ai/v1 | refused |
| https://evil.com/gateway.langwatch.ai/v1 | refused |
| https://gateway.langwatch.ai@evil.com/v1 | refused |
| https://gateway.langwatch.ai:443@attacker.example/v1 | refused |
| https://evil-langwatch.ai/v1 | refused |
| (empty) | refused |

The last case is the regression CodeRabbit caught at ba19725d3b.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for two-turn voice conversations routed through the AI Gateway.
  * Verifies speech-to-text and text-to-speech routing, gateway response headers, retries, transcripts, successful completion, and audio results.
  * Confirms audio requests do not bypass the gateway or connect directly to providers.

* **Chores**
  * Added a manually triggered workflow for running voice gateway tests against a deployed gateway.
  * Validates gateway configuration and credentials, and prevents overlapping runs to control provider usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->