### PR TITLE
perf(clickhouse): read the feedback events map only for spans that carry one

### DIFF
--- a/platform/app/src/server/analytics/clickhouse/__tests__/aggregation-builder.test.ts
+++ b/platform/app/src/server/analytics/clickhouse/__tests__/aggregation-builder.test.ts
@@ -1713,6 +1713,37 @@ describe("aggregation-builder", () => {
       );
     });
 
+    it("pushes the event-name predicate into the stored_spans subquery", () => {
+      const result = buildFeedbacksQuery(projectId, startDate, endDate);
+
+      // Located rather than merely matched. The predicate is only worth
+      // anything inside the subquery, where it reaches PREWHERE ahead of the
+      // heavy Events.Attributes map; asserting the fragment alone would pass on
+      // a query that had it in the outer WHERE, which is where it already was.
+      const subqueryStart = result.sql.indexOf("FROM stored_spans WHERE");
+      const subqueryEnd = result.sql.indexOf(") ss ON", subqueryStart);
+      const predicate = result.sql.indexOf(
+        `has("Events.Name", 'thumbs_up_down')`,
+      );
+      expect(subqueryStart).toBeGreaterThan(-1);
+      expect(subqueryEnd).toBeGreaterThan(subqueryStart);
+      expect(predicate).toBeGreaterThan(subqueryStart);
+      expect(predicate).toBeLessThan(subqueryEnd);
+    });
+
+    it("names the same event in the subquery predicate and the outer filter", () => {
+      const result = buildFeedbacksQuery(projectId, startDate, endDate);
+
+      // The subquery predicate only preserves the result while it names the
+      // event the outer filter keeps. If someone changes one literal, this
+      // fails rather than silently dropping every feedback row.
+      const pushed = /has\("Events\.Name", ('[^']+')\)/.exec(result.sql);
+      const outer = /event_name = ('[^']+')/.exec(result.sql);
+      expect(pushed?.[1]).toBeDefined();
+      expect(outer?.[1]).toBeDefined();
+      expect(pushed?.[1]).toBe(outer?.[1]);
+    });
+
     it("includes filters when provided with parameterized values", () => {
       const filters = {
         "metadata.user_id": ["user-1"],

--- a/platform/app/src/server/analytics/clickhouse/aggregation-builder.ts
+++ b/platform/app/src/server/analytics/clickhouse/aggregation-builder.ts
@@ -84,6 +84,17 @@ const SPAN_TIME_FILTER_START_END =
   "AND StartTime >= {startDate:DateTime64(3)} - INTERVAL 2 DAY " +
   "AND StartTime < {endDate:DateTime64(3)} + INTERVAL 2 DAY";
 
+/**
+ * The event the feedbacks query reads, as a SQL literal.
+ *
+ * One constant because two places have to agree on it: the outer filter that
+ * selects the exploded event, and the predicate pushed into the stored_spans
+ * subquery so `Events.Attributes` is only read for spans that carry the event.
+ * The second is only result-preserving while it names the same event as the
+ * first, so they are not allowed to drift apart.
+ */
+const FEEDBACK_EVENT_NAME_SQL = "'thumbs_up_down'";
+
 // Partition-pruning bounds for the evaluation_runs JOIN subquery. The query
 // windows on trace OccurredAt, but evaluation_runs is partitioned by
 // ScheduledAt per the migrations (and by UpdatedAt on long-lived deployments
@@ -3224,6 +3235,19 @@ export function buildFeedbacksQuery(
   // Prune the stored_spans JOIN to identity columns plus the Events.* arrays
   // the feedback ARRAY JOIN reads, and push the StartTime window into the
   // subquery, instead of joining the full analytics column set (#2551 / #2605).
+  //
+  // The event-name predicate rides along for a different reason. It prunes no
+  // granules, because nothing indexes `Events.Name`; what it does is reach
+  // PREWHERE, so the light `Array(LowCardinality(String))` is read first and
+  // `Events.Attributes` is materialised only for the spans that carry a vote
+  // event. That map is `Array(Map(LowCardinality(String), String))` and is by
+  // far the widest column in the select list, and a span carrying a vote is a
+  // small minority of the window.
+  //
+  // It cannot change the result: the outer query ARRAY JOINs these arrays and
+  // then keeps only `event_name = 'thumbs_up_down'`, which a span satisfies
+  // exactly when its `Events.Name` contains that value. Every row this drops is
+  // one the outer filter would have dropped anyway.
   const spanJoin = buildJoinClause({
     table: "stored_spans",
     requiredColumns: new Set([
@@ -3232,6 +3256,7 @@ export function buildFeedbacksQuery(
       '"Events.Attributes"',
     ]),
     spanTimeFilter: SPAN_TIME_FILTER_START_END,
+    spanRowFilter: `AND has("Events.Name", ${FEEDBACK_EVENT_NAME_SQL})`,
   });
 
   const sql = `
@@ -3250,7 +3275,7 @@ export function buildFeedbacksQuery(
     WHERE ${ts}.TenantId = {tenantId:String}
       AND ${ts}.OccurredAt >= {startDate:DateTime64(3)}
       AND ${ts}.OccurredAt < {endDate:DateTime64(3)}
-      AND event_name = 'thumbs_up_down'
+      AND event_name = ${FEEDBACK_EVENT_NAME_SQL}
       AND mapContains(event_attrs, 'event.metrics.vote')
       ${filterWhere}
     ORDER BY event_timestamp DESC

--- a/platform/app/src/server/analytics/clickhouse/field-mappings.ts
+++ b/platform/app/src/server/analytics/clickhouse/field-mappings.ts
@@ -481,6 +481,17 @@ export function getTableAlias(table: CHTable): string {
 }
 
 /**
+ * Render an optional WHERE fragment, leading space and all, or nothing.
+ *
+ * The subqueries below append several of these, and each one written inline is
+ * a branch the reader has to hold; naming it once keeps the clause assembly
+ * readable as a list of what may be appended.
+ */
+function optionalPredicate(fragment: string | undefined): string {
+  return fragment ? ` ${fragment}` : "";
+}
+
+/**
  * Build JOIN clause for a table, selecting only the columns needed.
  *
  * @param table - The table to JOIN
@@ -493,6 +504,14 @@ export function getTableAlias(table: CHTable): string {
  *   on `TenantId` only and cold-scans every weekly partition (incl. S3-tiered
  *   ones). The caller passes the fragment matching its date regime; the referenced
  *   params are bound by the outer query. Ignored for non-`stored_spans` tables.
+ * @param spanRowFilter - Optional SQL fragment restricting which `stored_spans`
+ *   rows the subquery returns (e.g. `AND has("Events.Name", 'thumbs_up_down')`).
+ *   Distinct from `spanTimeFilter`, which prunes partitions: this one prunes
+ *   nothing, and exists so a predicate on a light column reaches PREWHERE ahead
+ *   of the heavy columns in the select list. A caller may only pass a predicate
+ *   its outer query already implies, since the subquery feeds an inner JOIN and
+ *   a row dropped here is a row the outer query never sees. Ignored for
+ *   non-`stored_spans` tables.
  * @param evalTimeFilter - Optional SQL fragment bounding the `evaluation_runs`
  *   subquery's partition column (e.g. `AND ScheduledAt >= {startDate} - INTERVAL
  *   7 DAY AND UpdatedAt >= {startDate} - INTERVAL 7 DAY`). Same disease as
@@ -506,11 +525,13 @@ export function buildJoinClause({
   table,
   requiredColumns,
   spanTimeFilter,
+  spanRowFilter,
   evalTimeFilter,
 }: {
   table: CHTable;
   requiredColumns?: ReadonlySet<string>;
   spanTimeFilter?: string;
+  spanRowFilter?: string;
   evalTimeFilter?: string;
 }): string {
   const alias = tableAliases[table];
@@ -521,14 +542,15 @@ export function buildJoinClause({
       const columns = requiredColumns
         ? mergeWithIdentity(requiredColumns, SPAN_IDENTITY_COLUMNS)
         : SPAN_ANALYTICS_COLUMNS;
-      const timeBound = spanTimeFilter ? ` ${spanTimeFilter}` : "";
-      return `JOIN (SELECT ${Array.from(columns).join(", ")} FROM stored_spans WHERE TenantId = {tenantId:String}${timeBound}) ${alias} ON ${baseAlias}.TenantId = ${alias}.TenantId AND ${baseAlias}.TraceId = ${alias}.TraceId`;
+      const timeBound = optionalPredicate(spanTimeFilter);
+      const rowBound = optionalPredicate(spanRowFilter);
+      return `JOIN (SELECT ${Array.from(columns).join(", ")} FROM stored_spans WHERE TenantId = {tenantId:String}${timeBound}${rowBound}) ${alias} ON ${baseAlias}.TenantId = ${alias}.TenantId AND ${baseAlias}.TraceId = ${alias}.TraceId`;
     }
     case "evaluation_runs": {
       const columns = requiredColumns
         ? mergeWithIdentity(requiredColumns, EVALUATION_IDENTITY_COLUMNS)
         : EVALUATION_ANALYTICS_COLUMNS;
-      const evalTimeBound = evalTimeFilter ? ` ${evalTimeFilter}` : "";
+      const evalTimeBound = optionalPredicate(evalTimeFilter);
       return `JOIN (
         SELECT ${Array.from(columns).join(", ")} FROM evaluation_runs
         WHERE TenantId = {tenantId:String}${evalTimeBound}


### PR DESCRIPTION
## Evidence

The feedbacks table (`FeedbacksTable.tsx` -> `api.analytics.feedbacks` -> `AnalyticsService.getFeedbacks` -> `buildFeedbacksQuery`) joins `stored_spans` for three `Events.*` arrays, ARRAY JOINs them, and only then keeps rows whose event name is `thumbs_up_down`.

The stored_spans subquery carries a tenant predicate and a `StartTime` window, but nothing about the event. So `Events.Attributes` is read for every span in the window. That column is `Array(Map(LowCardinality(String), String))` and is by a wide margin the heaviest thing in the select list, while a span carrying a vote event is a small minority of any window.

This is the same column behind #7571 and #7603, reached the same way: through the outer array.

## Suspected cause

The filter that says which spans matter lives after the ARRAY JOIN, in the outer `WHERE`. By then the map has already been read. Nothing was available to the read to say the row would not survive.

## Proposed fix

Push `has("Events.Name", 'thumbs_up_down')` into the subquery, so it reaches PREWHERE alongside the tenant and time predicates.

`Events.Name` is `Array(LowCardinality(String))`, so the filter is cheap to evaluate, and PREWHERE means `Events.Attributes` is only materialised for the rows that pass it.

`buildJoinClause` gains a named `spanRowFilter` next to the existing `spanTimeFilter`, because the two do different jobs and the distinction is the whole point: one prunes partitions, the other narrows rows ahead of the wide columns. Its doc states the precondition for using it, which is that the caller may only pass a predicate its outer query already implies, since this subquery feeds an inner JOIN.

## Why it cannot change the result

The outer query keeps only `event_name = 'thumbs_up_down'` after `ARRAY JOIN`. A span produces a surviving row exactly when its `Events.Name` array contains that value, which is what `has` tests. Every row the new predicate drops is one the outer filter would have dropped anyway.

The two literals are now one constant, so the pushed predicate cannot come to name a different event from the outer filter. A test fails if they diverge.

## Expected impact

Bytes read, not partitions or granules. Worth being explicit: **parts and granules are unchanged**, because nothing indexes `Events.Name`. Anyone checking this with `EXPLAIN INDEXES` should expect identical granule counts and look at the PREWHERE line instead.

The saving is the difference between reading the events map for every span in the window and reading it only for spans carrying a vote.

## EXPLAIN check

`EXPLAIN PLAN indexes = 1, actions = 1` against production, on the subquery as it ships and with the predicate, for a large project over a seven-day window. Tenant id redacted.

Before:

```
ReadFromMergeTree (langwatch.stored_spans)
Parts: 16
Granules: 326
Prewhere info
  Prewhere filter column: and(greaterOrEquals(StartTime, ...), less(StartTime, ...), equals(TenantId, ...))
```

After:

```
ReadFromMergeTree (langwatch.stored_spans)
Parts: 16
Granules: 326
Prewhere info
  Prewhere filter column: and(has(Events.Name, 'thumbs_up_down'), greaterOrEquals(StartTime, ...), less(StartTime, ...), equals(TenantId, ...))
```

The predicate is admitted to PREWHERE. Granule counts match, as expected for a read-width change.

## Test plan

Two tests added to the existing `buildFeedbacksQuery` suite:

- The predicate lands **inside** the stored_spans subquery, asserted by locating it between `FROM stored_spans WHERE` and the `) ss ON` that closes the subquery. Asserting the fragment alone would pass on a query that left it in the outer `WHERE`, which is where it already was.
- The subquery predicate and the outer filter name the same event, extracted from the built SQL and compared. This is the guard on the correctness argument above.

Both were confirmed to fail with the source change reverted and pass with it.

`src/server/analytics/` unit suites: 46 files, 953 tests, all passing. Typecheck clean. Biome warning count on the three changed files is 21, identical to main.

One pre-existing failure worth naming so it is not mistaken for this change: `memory-safety.integration.test.ts` fails two cases locally on a 1 GiB ClickHouse test container. It fails identically with these files reverted to main, on a freshly recreated container, and main's own CI is green, so it is a local container-sizing artifact rather than something this branch introduces.

## Scope

Only the feedbacks query. The same pattern would help the `sentiment.thumbs_up_down` group-by and the event metric translations, but those reach `stored_spans` through a join shared with other metrics in the same query, where dropping spans can drop traces that those other metrics still need to count. That needs its own reasoning per call site rather than a blanket push, so it is deliberately left alone here.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X6dprWrgqkU3CSdjbw9mCH


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved analytics feedback query efficiency by filtering relevant voting events earlier, reducing unnecessary processing of event data.

* **Bug Fixes**
  * Ensured feedback event filtering remains consistent throughout query processing, helping prevent valid feedback records from being missed.

* **Tests**
  * Added coverage verifying that feedback event filters are applied correctly and consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->