### PR TITLE
fix(cli): enforce batch wait deadlines during status reads

### DIFF
--- a/docs/agent-testing/run-from-ci.mdx
+++ b/docs/agent-testing/run-from-ci.mdx
@@ -21,6 +21,8 @@ A connected agent is `connected:<name>`, which runs it in `development` or in th
 
 Add `--format json` (or `-o json`) to get one final document on stdout instead of the progress lines. It contains `outcome`, `tallies` and the per-run `results`, so a job step can read the verdict without parsing prose.
 
+The wait limit also covers status requests and their response bodies. When it expires, the CLI stops waiting without cancelling the batch and exits non-zero. JSON output reports `outcome: "timeout"` with the last complete poll's counts and results; this does not mean the agent failed its tests.
+
 ## From the REST API
 
 `POST /api/v1/test-suites/{id}/run` schedules one run for each scenario of the test suite, against each target you name:

--- a/sdks/typescript/src/cli/utils/__tests__/waitForBatchRun.unit.test.ts
+++ b/sdks/typescript/src/cli/utils/__tests__/waitForBatchRun.unit.test.ts
@@ -178,6 +178,110 @@ describe("waitForBatchRun()", () => {
     });
   });
 
+  describe("when a status read stalls", () => {
+    /** @scenario "The wait deadline also bounds a stalled status read" */
+    it.each(["request", "response body", "later page"])(
+      "bounds a stalled %s and keeps the last complete poll",
+      async (stage) => {
+        vi.useFakeTimers();
+        let calls = 0;
+        let pendingSignal: AbortSignal | null | undefined;
+        vi.spyOn(globalThis, "fetch").mockImplementation(async (_input, init) => {
+          calls++;
+          if (calls === 1) {
+            return new Response(JSON.stringify({ runs: [passedRun] }));
+          }
+          if (stage === "later page" && calls === 2) {
+            return new Response(JSON.stringify({
+              runs: [failedRun],
+              hasMore: true,
+              nextCursor: "page_2",
+            }));
+          }
+          pendingSignal = init?.signal;
+          if (stage === "response body") {
+            return new Response(new ReadableStream({
+              start(controller) {
+                pendingSignal?.addEventListener(
+                  "abort",
+                  () => controller.error(new Error("read aborted")),
+                  { once: true },
+                );
+              },
+            }));
+          }
+          return new Promise<Response>((_resolve, reject) => {
+            pendingSignal?.addEventListener(
+              "abort",
+              () => reject(new Error("request aborted")),
+              { once: true },
+            );
+          });
+        });
+        const finished = vi.fn();
+        try {
+          const promise = waitForBatchRun({
+            batchRunId: "batch_123",
+            jobCount: 2,
+            subject: "run",
+            machine: true,
+            timeoutMs: 7000,
+          }).then(finished);
+          await vi.advanceTimersByTimeAsync(7000);
+
+          expect(finished).toHaveBeenCalledWith({
+            outcome: "timeout",
+            tallies: { total: 2, completed: 1, passed: 1, failed: 0 },
+            results: [{
+              scenarioRunId: "run_1",
+              scenarioId: "scenario_1",
+              status: "SUCCESS",
+              verdict: "success",
+            }],
+          });
+          await promise;
+          expect(pendingSignal?.aborted).toBe(true);
+          expect(process.exitCode).toBe(1);
+          expect(console.log).not.toHaveBeenCalled();
+          expect(vi.getTimerCount()).toBe(0);
+        } finally {
+          vi.clearAllTimers();
+          vi.useRealTimers();
+        }
+      },
+    );
+  });
+
+  describe("when the wait is shorter than the polling interval", () => {
+    /** @scenario "A short wait ends before the next poll" */
+    it("ends at the deadline without starting a status request", async () => {
+      vi.useFakeTimers();
+      const fetchSpy = answersWith([passedRun]);
+      const finished = vi.fn();
+      try {
+        const promise = waitForBatchRun({
+          batchRunId: "batch_123",
+          jobCount: 1,
+          subject: "run",
+          machine: true,
+          timeoutMs: 1000,
+        }).then(finished);
+        await vi.advanceTimersByTimeAsync(1000);
+
+        expect(finished).toHaveBeenCalledWith(
+          expect.objectContaining({ outcome: "timeout" }),
+        );
+        await promise;
+        expect(fetchSpy).not.toHaveBeenCalled();
+        expect(process.exitCode).toBe(1);
+        expect(vi.getTimerCount()).toBe(0);
+      } finally {
+        vi.clearAllTimers();
+        vi.useRealTimers();
+      }
+    });
+  });
+
   describe("when the status endpoint keeps failing", () => {
     /** @scenario "A dead status endpoint still emits the machine-readable document" */
     it("gives up after five reads in a row and answers with the poll failure outcome", async () => {

--- a/sdks/typescript/src/cli/utils/batchRunProgress.ts
+++ b/sdks/typescript/src/cli/utils/batchRunProgress.ts
@@ -85,10 +85,13 @@ export async function fetchBatchRuns({
 	endpoint,
 	batchRunId,
 	headers,
+	signal,
 }: {
 	endpoint: string;
 	batchRunId: string;
 	headers: Record<string, string>;
+	/** Cancels every page and response body when the caller stops waiting. */
+	signal?: AbortSignal;
 }): Promise<BatchRun[]> {
 	const runs: BatchRun[] = [];
 	let cursor: string | undefined;
@@ -99,7 +102,7 @@ export async function fetchBatchRuns({
 		url.searchParams.set("limit", "100");
 		if (cursor) url.searchParams.set("cursor", cursor);
 
-		const response = await langwatchFetch(url, { method: "GET", headers });
+		const response = await langwatchFetch(url, { method: "GET", headers, signal });
 		if (!response.ok) {
 			throw new Error(`status endpoint answered ${response.status}`);
 		}

--- a/sdks/typescript/src/cli/utils/waitForBatchRun.ts
+++ b/sdks/typescript/src/cli/utils/waitForBatchRun.ts
@@ -135,12 +135,13 @@ export async function waitForBatchRun({
   let latestRuns: BatchRun[] = [];
 
   while (!completed) {
-    if (Date.now() - startTime > timeoutMs) {
+    const remainingMs = timeoutMs - (Date.now() - startTime);
+    if (remainingMs <= 0) {
       outcome = "timeout";
       process.exitCode = 1;
       pollSpinner.fail(
         chalk.red(
-          `The ${subject} timed out after ${describeMinutes(timeoutMs)}`,
+          `Stopped waiting for the ${subject} after ${describeMinutes(timeoutMs)}. The batch was not cancelled.`,
         ),
       );
       if (!machine) {
@@ -153,14 +154,32 @@ export async function waitForBatchRun({
       break;
     }
 
-    await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+    await new Promise((resolve) =>
+      setTimeout(resolve, Math.min(POLL_INTERVAL_MS, remainingMs)),
+    );
+    const readBudgetMs = timeoutMs - (Date.now() - startTime);
+    if (readBudgetMs <= 0) continue;
+
+    // One budget covers all pages and their bodies. Checking only between
+    // polls cannot stop a status request that never finishes.
+    const controller = new AbortController();
+    const readTimeout = setTimeout(
+      () => controller.abort(),
+      // Node turns delays above its signed 32-bit limit into a 1ms timer.
+      Math.min(readBudgetMs, 2 ** 31 - 1),
+    );
 
     try {
-      latestRuns = await fetchBatchRuns({
+      const runs = await fetchBatchRuns({
         endpoint,
         batchRunId,
         headers: buildAuthHeaders({ apiKey }),
+        signal: controller.signal,
       });
+      if (controller.signal.aborted || Date.now() - startTime >= timeoutMs) {
+        continue;
+      }
+      latestRuns = runs;
       const progress = tallyBatchRuns(latestRuns);
 
       // The schedule knows how many jobs it dispatched; the endpoint only knows
@@ -196,6 +215,9 @@ export async function waitForBatchRun({
         }
       }
     } catch {
+      // Re-enter the deadline check instead of counting our own cancellation
+      // as a failed status poll. Keep the last fully read poll's results.
+      if (controller.signal.aborted) continue;
       consecutivePollFailures++;
       if (consecutivePollFailures >= MAX_CONSECUTIVE_POLL_FAILURES) {
         outcome = "poll_failure";
@@ -207,6 +229,8 @@ export async function waitForBatchRun({
         break;
       }
       continue;
+    } finally {
+      clearTimeout(readTimeout);
     }
     consecutivePollFailures = 0;
   }

--- a/specs/features/run-plan-cli.feature
+++ b/specs/features/run-plan-cli.feature
@@ -232,6 +232,21 @@ Feature: Run Plan CLI Commands
     And the exit code is nonzero
 
   @unit
+  Scenario: The wait deadline also bounds a stalled status read
+    Given a batch with one completed run and one unfinished run
+    And a later status request, response body or page stops responding
+    When the configured wait expires
+    Then the CLI stops reading and reports a timeout rather than a poll failure
+    And the last complete poll's counts and results are preserved
+    And the exit code is nonzero
+
+  @unit
+  Scenario: A short wait ends before the next poll
+    Given a wait shorter than the polling interval
+    When the configured wait expires
+    Then the CLI reports a timeout without starting a status request
+
+  @unit
   Scenario: Wait with a value that is not a number of minutes
     When I run "langwatch run-plan run --all --target http:agent_abc --wait soon"
     Then the command is refused before anything is scheduled


### PR DESCRIPTION
## Why

`--wait [minutes]` only checked its deadline between polls. A status request, response body, or later page that stopped responding could leave an agent-testing CI job waiting beyond that limit without a final result.

Closes #7977. Related to #7891; this keeps the existing configurable `--wait` interface and 45-minute default.

## What changed

- Bound polling sleeps and status reads by the remaining wait budget, passing an abort signal through every page of `fetchBatchRuns`.
- Return `timeout` with exit code 1 when the deadline cancels a read, preserving the last complete poll's tallies/results instead of reporting a polling failure or a partially read batch.
- Clear each request timer when the read ends. Clarify that stopping the wait does not cancel the batch, and document the JSON outcome for CI callers.

## Test plan

- Four new regression cases fail before the fix and pass afterward: stalled request, stalled response body, stalled later page, and a deadline shorter than the polling interval.
- Polling/progress suites: **19 tests pass**. Broader run-plan, test-suite, scenario and HTTP coverage: **231 tests pass**; the three existing Windows path-scan failures are noted below.
- SDK typecheck and full SDK build including postbuild version check pass. Full SDK ESLint exits 0 (nine existing warnings in untouched files); the changed TypeScript files have no lint findings.
- Built CLI exercised against a local HTTP server using real sockets: stalled headers, body and pagination all disconnect at the configured deadline; JSON and human timeout output and successful batch completion pass (five checks, no model/API credentials required).

## Anything surprising?

Validation ran on Windows with Node 22.20.0 and pnpm 10.24.0. The existing `raw-fetch-guard.unit.test.ts` compares Windows backslash paths with slash-delimited allowlist entries: its three assertions fail identically after restoring both modified production files to HEAD. That unrelated scan is unchanged. Code-generation inputs needed local LF normalization; neither those input changes nor generated OpenAPI drift are included in this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CLI wait deadlines now reliably stop stalled status requests and response processing.
  * Timeout results preserve the last completed poll’s counts and results, report a timeout outcome, and exit with a non-zero status.
  * Waiting periods shorter than the polling interval no longer start unnecessary status requests.

* **Documentation**
  * Clarified timeout behavior, including status requests, response bodies, and JSON output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->