### PR TITLE
fix(traces): filter chips stop resizing on hover so the X stays put

### DIFF
--- a/platform/app/src/features/traces-v2/components/SearchBar/PlaceholderEditor.tsx
+++ b/platform/app/src/features/traces-v2/components/SearchBar/PlaceholderEditor.tsx
@@ -165,8 +165,9 @@ export const PlaceholderEditor: React.FC<PlaceholderEditorProps> = ({
   const segments = useMemo(() => buildSegments(queryText), [queryText]);
   // Chips store the raw id (unique) but display the resolved facet label
   // (readable) — same source the sidebar uses. The label is painted by the
-  // shared CSS overlay (see editorStyles), field prefix intact, and the raw
-  // id slides back into view on hover — identical to the live editor.
+  // shared CSS overlay (see editorStyles), field prefix intact; the raw id
+  // stays in the tooltip so the chip never resizes under the pointer —
+  // identical to the live editor.
   const resolveLabel = useFacetValueLabelResolver();
 
   return (

--- a/platform/app/src/features/traces-v2/components/SearchBar/editorStyles.ts
+++ b/platform/app/src/features/traces-v2/components/SearchBar/editorStyles.ts
@@ -57,10 +57,17 @@ export const editorStyles: SystemStyleObject = {
   // and collapse the underlying id to zero width (font-size:0). The chip then
   // hugs the *label*, not the longer id — no spare space reserved for the
   // value tail. The id stays in the DOM (selection / copy / the query
-  // language all keep it) and returns to full size on hover, where the label
-  // hides and the chip grows in place to reveal the full id. The `evaluator:`
-  // prefix is part of both the label and the id, so it never moves — only the
-  // value tail differs.
+  // language all keep it) and is surfaced on demand through the chip's
+  // `title` tooltip, which costs no layout.
+  //
+  // The chip width never changes with pointer state. An earlier version
+  // swapped the label back to the id on hover; because ids are much wider
+  // than names (`monitor_0005p7YMsdI0Oy…` vs `Ragas Response Relevancy`),
+  // the pill grew in place and pushed the remove button out from under the
+  // cursor — and the `:has(+ .filter-token-delete:hover)` half of the rule
+  // kept it expanded once the pointer arrived, so the X never settled and
+  // the chip could not be deleted. The tooltip gives the same information
+  // without moving anything.
   "& .filter-token[data-filter-chip-label]": {
     fontSize: "0px",
   },
@@ -73,17 +80,6 @@ export const editorStyles: SystemStyleObject = {
     whiteSpace: "nowrap",
     pointerEvents: "none",
   },
-  // Reveal the underlying id on hover — also when the X-button half is
-  // hovered, so the whole pill reads consistently. Restore the id text to
-  // full size and drop the label so only the id shows; the chip grows to fit.
-  "& .filter-token[data-filter-chip-label]:hover, & .filter-token[data-filter-chip-label]:has(+ .filter-token-delete:hover)":
-    {
-      fontSize: "var(--chakra-font-sizes-xs)",
-    },
-  "& .filter-token[data-filter-chip-label]:hover::after, & .filter-token[data-filter-chip-label]:has(+ .filter-token-delete:hover)::after":
-    {
-      display: "none",
-    },
   // Field name was unrecognised (typo, removed key) — still parses as a
   // tag but the rest of the platform won't filter on it. A warning tint
   // makes that visible without rejecting the query outright.

--- a/platform/app/src/features/traces-v2/components/SearchBar/filterHighlight.ts
+++ b/platform/app/src/features/traces-v2/components/SearchBar/filterHighlight.ts
@@ -480,17 +480,16 @@ export function setFilterChipLabels(
 }
 
 /**
- * The text the chip overlay paints at rest. Always field-qualified
- * (`evaluator:Policy Check`) so the field prefix stays put — only the value
- * tail swaps to the raw id on hover. Painting the bare label dropped the
- * `evaluator:` prefix at rest and snapped it back on hover, which read as a
- * jarring jump; keeping the field anchored fixes that.
+ * The text the chip paints, in every pointer state. Always field-qualified
+ * (`evaluator:Policy Check`) so the chip reads as a filter and not as a bare
+ * name. The raw id is reachable through the tooltip and by clicking the chip,
+ * never by swapping the visible text — see editorStyles for why.
  *
  * Returns undefined when there's no human label, or it equals the raw value
- * (overlaying `status:error` on `status:error` is pointless and would just
- * flicker on hover) — the CSS overlay only fires when the attr is set, so
- * omission keeps the chip in its raw text-render mode. Shared with the
- * placeholder editor so both renderers paint an identical overlay.
+ * (overlaying `status:error` on `status:error` is pointless) — the CSS
+ * overlay only fires when the attr is set, so omission keeps the chip in its
+ * raw text-render mode. Shared with the placeholder editor so both renderers
+ * paint an identical overlay.
  */
 export function chipOverlayLabel({
   field,
@@ -528,6 +527,13 @@ function computeDecorations(doc: ProseMirrorNode): DecorationSet {
           label: chipLabelLookup[slot.chipToken.field]?.[slot.chipToken.value],
         });
         if (overlay) attrs["data-filter-chip-label"] = overlay;
+        // The overlay hides the raw id behind the readable label, and the
+        // chip never resizes to reveal it (see editorStyles), so the id
+        // lives in the tooltip. Same string the placeholder renderer uses,
+        // so the hand-off doesn't change what hovering tells you.
+        attrs.title = overlay
+          ? `${slot.chipToken.field}:${slot.chipToken.value} — click to change value`
+          : "Click to change value";
       }
       decorations.push(Decoration.inline(slot.from, slot.to, attrs));
     }

--- a/specs/traces-v2/search.feature
+++ b/specs/traces-v2/search.feature
@@ -1477,21 +1477,23 @@ Rule: AI query composer (Ask AI)
 
 
 # ─────────────────────────────────────────────────────────────────────────────
-# CHIP LABELS WITH HOVER-TO-ID
+# CHIP LABELS, WITH THE ID IN THE TOOLTIP
 # ─────────────────────────────────────────────────────────────────────────────
 # Filter chips render the human-readable name of the value (evaluator
 # name, topic name, etc.) on top of the underlying id — but the field
 # prefix is always part of the overlay, so the chip reads as
-# "evaluator:Policy Check", never a bare "Policy Check". Hovering the chip
-# fades the overlay so only the value tail swaps to the raw id; the
-# "evaluator:" prefix never moves. The query language is unchanged — the
-# document still holds the id, search matching is still id-only. Names
-# exist for discovery and reading comfort only.
+# "evaluator:Policy Check", never a bare "Policy Check". The chip's size
+# does not depend on pointer state: the id is reachable through the
+# tooltip and through clicking the chip, never by swapping the visible
+# text. The query language is unchanged — the document still holds the
+# id, search matching is still id-only. Names exist for discovery and
+# reading comfort only.
 
-Rule: Chip labels are field-qualified and reveal the id on hover
+Rule: Chip labels are field-qualified and never resize on hover
   When a facet returns a `label` for a topValue, the chip paints
-  "field:label" on top of the id and reveals "field:id" on hover. The
-  field prefix shows in both states; only the value tail changes.
+  "field:label" on top of the id and keeps that text in every pointer
+  state. The raw id is surfaced through the chip's tooltip, which costs
+  no layout, so the remove button stays where the user aimed.
 
   Background:
     Given the user is authenticated with "traces:view" permission
@@ -1507,16 +1509,23 @@ Rule: Chip labels are field-qualified and reveal the id on hover
     Then the chip is only as wide as "evaluator:Policy Check"
     And no empty space is reserved for the longer id before the remove button
 
-  Scenario: Hovering the chip expands it to reveal the id, prefix intact
+  Scenario: Hovering the chip changes neither its text nor its width
     Given the search bar contains "@evaluator:eval_abc123"
     When the user hovers the chip
-    Then the chip grows in place to fit the full id
-    And the chip reads "evaluator:eval_abc123"
+    Then the chip still reads "evaluator:Policy Check"
+    And the chip's width is unchanged
 
-  Scenario: The field prefix never disappears between rest and hover
+  Scenario: Hovering the remove button leaves the chip's geometry alone
     Given the search bar contains "@evaluator:eval_abc123"
-    Then the "evaluator:" prefix is visible both at rest and on hover
-    And only the value swaps between "Policy Check" and "eval_abc123"
+    When the user moves the pointer onto the chip's remove button
+    Then the remove button does not move
+    And a single click removes the filter
+
+  Scenario: The tooltip carries the raw id
+    Given the search bar contains "@evaluator:eval_abc123" labeled "Policy Check"
+    When the user rests the pointer on the chip
+    Then the tooltip reads "evaluator:eval_abc123 — click to change value"
+    And the placeholder and the live editor show the same tooltip
 
   Scenario: The placeholder and live editor paint an identical chip
     Given the search bar contains "@evaluator:eval_abc123" on cold load


### PR DESCRIPTION
## Why

Clicking an evaluator in the traces filter sidebar inserts a chip reading `evaluator:Ragas Response Relevancy`. Moving the pointer toward that chip's × swapped the text to the underlying id — `evaluator:monitor_0005p7YMsdI0Oy56m6qklofZOl8zo` — and the pill grew to fit, sliding the remove button out from under the cursor. Because the rule also kept the chip expanded while the × itself was hovered, the button never settled back, making the filter fiddly to delete.

The reveal-on-hover behaviour was deliberate, but it buys little: the id is not something you read off a pill, and it costs the chip a stable size.

## What changed

Filter chips now paint the readable label in every pointer state and never change width. The raw id moved to the chip's tooltip, which costs no layout.

- `editorStyles.ts` — removed the two hover rules that restored the id's font size and hid the label overlay.
- `filterHighlight.ts` — the live editor's chip decoration now sets the same `title` string the placeholder renderer already used, so both renderers behave identically across the hand-off.
- `specs/traces-v2/search.feature` — the Rule pinned the old behaviour, so it is rewritten (see below).

Unchanged: the document still holds the id, search matching is still id-only, and clicking a chip still opens the value picker.

## How it works

The chip renders the raw `field:value` text at `font-size: 0` and paints `attr(data-filter-chip-label)` as `::after` content, so the pill hugs the label rather than the longer id. That part is untouched. What is gone is the pair of `:hover` / `:has(+ .filter-token-delete:hover)` rules that reversed the two — restoring the id to full size and hiding the overlay. With them removed, no selector varies the chip's metrics with pointer state.

## Test plan

- `pnpm test:unit` over `src/features/traces-v2/components/SearchBar/__tests__/` — 147 tests across 5 files pass. No existing test asserted the hover reveal (nothing referenced `fontSize` or `data-filter-chip-label`), so none needed updating.
- Biome clean on the three changed source files; the warnings it reports are pre-existing complexity notes on functions this PR does not touch.

Spec scenarios rewritten under `Rule: Chip labels are field-qualified and never resize on hover`:
- "Hovering the chip changes neither its text nor its width" (replaces "Hovering the chip expands it to reveal the id")
- "Hovering the remove button leaves the chip's geometry alone" — new, covers the reported bug directly
- "The tooltip carries the raw id" — new
- Dropped "The field prefix never disappears between rest and hover", which only had meaning while two states existed.

## Anything surprising?

**Not verified in a browser.** The change is CSS-only in effect and no automated test covers chip geometry, so the fix rests on reading the rules rather than driving the UI. Worth a manual pass on the traces explorer before merge.

**The browser test suite could not run here.** `ActiveSearchEditor.browser.test.tsx` and `SearchBar.browser.test.tsx` fail to import in this worktree because the generated Prisma client is missing — unrelated to this change, but it means those files were not exercised locally. CI will cover them.

**The id loses its last on-screen path.** Clicking a chip opens the value picker; it does not display the id as text. Hover-reveal was the only place the id was rendered, so the tooltip now carries that job. If a tooltip turns out to be too weak an affordance, the next step would be surfacing the id inside the value picker rather than bringing the resize back.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **User Experience**
  * Filter chips now maintain a consistent label and width during pointer interaction.
  * Underlying filter IDs are available through tooltips instead of expanding within the chip.
  * Tooltips provide clearer guidance for changing filter values.
  * Removing a filter preserves chip layout until the action is completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->