### PR TITLE
docs(agent-testing): a development agent in a container registers a new row per hostname

### DIFF
--- a/docs/agent-testing/connect-your-agent.mdx
+++ b/docs/agent-testing/connect-your-agent.mdx
@@ -229,7 +229,7 @@ Use `session` when the agent's API creates its own conversation and cannot accep
 
 The SDK reads the environment from the `environment` argument, then `LANGWATCH_AGENT_ENVIRONMENT`, then `APP_ENV`, `ENVIRONMENT` and `NODE_ENV`, and falls back to `development`. Each environment is a separate row on the agents page, so production and a developer machine are two targets that a comparison run puts side by side.
 
-`development` makes the agent personal: only its owner can run it when the key is personal, and only that machine registers it when the key is a project key. Name the environment `dev-shared` for a development box the whole team runs against.
+`development` makes the agent personal: only its owner can run it when the key is personal, and only that machine registers it when the key is a project key. Name the environment `dev-shared` for a development box the whole team runs against. On a project key the machine is its hostname, so a container whose hostname changes on every recreate registers a new row each start; give it an environment name or pin the hostname (`hostname:` in Compose, `--hostname` on `docker run`).
 
 Leave `environment` out when the service already sets `LANGWATCH_AGENT_ENVIRONMENT`, `APP_ENV`, `ENVIRONMENT` or `NODE_ENV`. The SDK reads them on its own.
 
@@ -439,6 +439,7 @@ Run it with `--target http:<agent-id>`, and follow Step 5 and Step 6 otherwise u
 | `langwatch agent get` lists a parameter without `options`, or does not list it at all | The annotation is not a `Literal`, an `Enum` or a `z.enum`, or the parameter has no default and the platform reads it as required. | Change the annotation or add the default, then restart the process. |
 | The run is refused with `agent_offline` | No instance was connected when the run started. | Start the agent process and run again. |
 | The run is refused with `agent_owner_only` | The agent registered under `development` with a personal key, so only its owner can run it. | Run it as the owner, or register it under a shared environment name such as `dev-shared`. |
+| A new agent row appears on every start, each with a different host label | The agent registered under `development` with a project key from a container, and the container's hostname changes on every recreate. | Set `LANGWATCH_AGENT_ENVIRONMENT` to a name other than `development`, or pin the container's hostname with `hostname:` in Compose or `--hostname` on `docker run`. |
 | The run is refused with `scenario_parameter_option_invalid` | A value is outside the closed option list the agent declares. | Use one of the listed options, or widen the `Literal` (Python) or `z.enum` (TypeScript) list in the code. |
 | A turn fails with `agent_call_timeout` | The call took longer than the agent's timeout. | Raise `timeout` on the connect function (up to 300 seconds), or make the agent answer faster. |
 | Trace-dependent criteria come back inconclusive | The agent reports its traces to a different LangWatch project, or it reports none at all. | Point the agent's tracing at the same project's API key. Set it up with the `tracing` skill. |
@@ -777,7 +778,7 @@ The SDK resolves the environment in this order:
 3. `APP_ENV`, then `ENVIRONMENT`, then `NODE_ENV`.
 4. `development`.
 
-`development` makes the agent **personal**. With a personal API key it belongs to the key's owner, and only that person can run it. With a project API key it belongs to the machine, and the team can see and run it. Every other environment name is shared by the whole project.
+`development` makes the agent **personal**. With a personal API key it belongs to the key's owner, and only that person can run it. With a project API key it belongs to the machine, and the team can see and run it. Every other environment name is shared by the whole project. On a project key the machine is identified by its hostname, which in a container changes every time the container is recreated, see [Containers and the machine identity](/agent-testing/environments#containers-and-the-machine-identity).
 
 For a development box the team runs against, give it a name of its own:
 
@@ -925,6 +926,7 @@ The run settings also record which instance served each run, so a result from a 
 | The row reads **Offline** | The process stopped, or its outbound connection is blocked by a proxy or a firewall. | Restart the process. On a network that blocks WebSockets, set `LANGWATCH_AGENT_TRANSPORT=http`, see [Behind a proxy that blocks WebSockets](#behind-a-proxy-that-blocks-websockets). |
 | The run is refused with `agent_offline` | No instance was connected when the run started. | Start the agent process, then run again. |
 | The run is refused with `agent_owner_only` | The agent registered under `development` with a personal key, so it belongs to one person. | Run it as its owner, or register it under a shared environment name. |
+| A new agent row appears on every start, each with a different host label | The agent registered under `development` with a project key from a container, and the container's hostname changes on every recreate. | Set `LANGWATCH_AGENT_ENVIRONMENT` to a name other than `development`, or pin the container's hostname, see [Containers and the machine identity](/agent-testing/environments#containers-and-the-machine-identity). |
 | A turn fails with `agent_call_timeout` | The function took longer than the agent's timeout. | Raise `timeout`, up to 300 seconds, or make the agent answer faster. |
 | A turn fails with `agent_busy` | Every instance was already running as many calls as it accepts. | Raise `concurrency` above its default of 10, or start more instances. |
 | Trace-dependent criteria come back inconclusive | The agent reports its traces to a different project, or it reports none at all. | Point the agent's tracing at the project that runs the scenarios. |

--- a/docs/agent-testing/environments.mdx
+++ b/docs/agent-testing/environments.mdx
@@ -1,7 +1,7 @@
 ---
 title: Environments and Personal Agents
 sidebarTitle: Environments
-keywords: langwatch, agent simulations, environments, personal agents, development, staging, production, local development, comparison run
+keywords: langwatch, agent simulations, environments, personal agents, development, staging, production, local development, comparison run, docker, container, hostname
 description: One agent name, one row per environment. Your machine, staging and production are separate targets that a single run compares.
 ---
 
@@ -31,7 +31,7 @@ Environment names use lower-case letters, digits, dashes and underscores, up to 
 | The process authenticates with | The agent belongs to | Who can run it |
 |---|---|---|
 | A personal API key | The key's owner | The owner only |
-| A project API key | The machine that registered it | Everyone on the project |
+| A project API key | The machine that registered it, identified by its hostname | Everyone on the project |
 | Any key, environment other than `development` | The project | Everyone on the project |
 
 The platform refuses a run against a teammate's personal agent with `agent_owner_only`, and the message includes the owner's name. The rule applies at every door: the run dialog, the CLI, the REST API and the MCP server.
@@ -43,6 +43,34 @@ For a development machine the whole team runs suites against, give it its own en
 ```bash
 LANGWATCH_AGENT_ENVIRONMENT=dev-shared
 ```
+
+## Containers and the machine identity
+
+For a development agent on a project key, the machine identity is the hostname the SDK reads from the operating system. On a laptop or a VM that hostname stays the same across restarts, so a process that stops and starts again lands on the same row.
+
+In a container the default hostname is the container id, and that id is new every time the container is recreated. Each start registers a new row, and the agents page fills with offline rows of the same name, one per host label. Kubernetes pods from a Deployment behave the same way, since a pod gets a new random suffix on every recreate.
+
+Two ways to keep one row:
+
+**Name the environment.** Give it a value other than `development`:
+
+```bash
+LANGWATCH_AGENT_ENVIRONMENT=dev-alex
+```
+
+The row is then shared by everyone on the project who uses the same value, so a per-person value keeps people apart.
+
+**Pin the hostname.** In Docker Compose, set it on the service:
+
+```yaml
+services:
+  agent:
+    hostname: alex-dev
+```
+
+Use `docker run --hostname alex-dev` outside Compose; `container_name` does not set the hostname. On Kubernetes, a StatefulSet gives pods stable names, a Deployment does not.
+
+Old rows disappear from the agents page after 30 days unseen, or you can delete them. A deleted row comes back if a process registers under its identity again.
 
 ## The local loop
 

--- a/docs/agent-testing/environments.mdx
+++ b/docs/agent-testing/environments.mdx
@@ -41,7 +41,7 @@ The run dialog shows teammates' personal agents disabled. The tooltip on the car
 For a development machine the whole team runs suites against, give it its own environment name and it is shared like any other:
 
 ```bash
-LANGWATCH_AGENT_ENVIRONMENT=dev-shared
+export LANGWATCH_AGENT_ENVIRONMENT=dev-shared
 ```
 
 ## Containers and the machine identity
@@ -55,7 +55,7 @@ Two ways to keep one row:
 **Name the environment.** Give it a value other than `development`:
 
 ```bash
-LANGWATCH_AGENT_ENVIRONMENT=dev-alex
+export LANGWATCH_AGENT_ENVIRONMENT=dev-alex
 ```
 
 The row is then shared by everyone on the project who uses the same value, so a per-person value keeps people apart.

--- a/docs/integration/python/agent-reference.mdx
+++ b/docs/integration/python/agent-reference.mdx
@@ -44,7 +44,7 @@ The process connects only with an API key. The SDK reads `LANGWATCH_API_KEY` fro
 
 `environment`, then `LANGWATCH_AGENT_ENVIRONMENT`, then `APP_ENV`, `ENVIRONMENT` and `NODE_ENV`, then `development`.
 
-`development` makes the agent personal: it belongs to the API key's owner when the key is personal, and to the machine when the key is a project key. Every other name is shared by the project. See [Environments and personal agents](/agent-testing/environments).
+`development` makes the agent personal: it belongs to the API key's owner when the key is personal, and to the machine, identified by its hostname, when the key is a project key. Every other name is shared by the project. See [Environments and personal agents](/agent-testing/environments).
 
 ### Turn fields
 

--- a/docs/integration/typescript/agent-reference.mdx
+++ b/docs/integration/typescript/agent-reference.mdx
@@ -57,7 +57,7 @@ The process connects only with an API key. The SDK reads `LANGWATCH_API_KEY` fro
 
 `environment`, then `LANGWATCH_AGENT_ENVIRONMENT`, then `APP_ENV`, `ENVIRONMENT` and `NODE_ENV`, then `development`.
 
-`development` makes the agent personal: it belongs to the API key's owner when the key is personal, and to the machine when the key is a project key. Every other name is shared by the project. See [Environments and personal agents](/agent-testing/environments).
+`development` makes the agent personal: it belongs to the API key's owner when the key is personal, and to the machine, identified by its hostname, when the key is a project key. Every other name is shared by the project. See [Environments and personal agents](/agent-testing/environments).
 
 ### The handler argument
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -31833,7 +31833,7 @@ Use `session` when the agent's API creates its own conversation and cannot accep
 
 The SDK reads the environment from the `environment` argument, then `LANGWATCH_AGENT_ENVIRONMENT`, then `APP_ENV`, `ENVIRONMENT` and `NODE_ENV`, and falls back to `development`. Each environment is a separate row on the agents page, so production and a developer machine are two targets that a comparison run puts side by side.
 
-`development` makes the agent personal: only its owner can run it when the key is personal, and only that machine registers it when the key is a project key. Name the environment `dev-shared` for a development box the whole team runs against.
+`development` makes the agent personal: only its owner can run it when the key is personal, and only that machine registers it when the key is a project key. Name the environment `dev-shared` for a development box the whole team runs against. On a project key the machine is its hostname, so a container whose hostname changes on every recreate registers a new row each start; give it an environment name or pin the hostname (`hostname:` in Compose, `--hostname` on `docker run`).
 
 Leave `environment` out when the service already sets `LANGWATCH_AGENT_ENVIRONMENT`, `APP_ENV`, `ENVIRONMENT` or `NODE_ENV`. The SDK reads them on its own.
 
@@ -32043,6 +32043,7 @@ Run it with `--target http:<agent-id>`, and follow Step 5 and Step 6 otherwise u
 | `langwatch agent get` lists a parameter without `options`, or does not list it at all | The annotation is not a `Literal`, an `Enum` or a `z.enum`, or the parameter has no default and the platform reads it as required. | Change the annotation or add the default, then restart the process. |
 | The run is refused with `agent_offline` | No instance was connected when the run started. | Start the agent process and run again. |
 | The run is refused with `agent_owner_only` | The agent registered under `development` with a personal key, so only its owner can run it. | Run it as the owner, or register it under a shared environment name such as `dev-shared`. |
+| A new agent row appears on every start, each with a different host label | The agent registered under `development` with a project key from a container, and the container's hostname changes on every recreate. | Set `LANGWATCH_AGENT_ENVIRONMENT` to a name other than `development`, or pin the container's hostname with `hostname:` in Compose or `--hostname` on `docker run`. |
 | The run is refused with `scenario_parameter_option_invalid` | A value is outside the closed option list the agent declares. | Use one of the listed options, or widen the `Literal` (Python) or `z.enum` (TypeScript) list in the code. |
 | A turn fails with `agent_call_timeout` | The call took longer than the agent's timeout. | Raise `timeout` on the connect function (up to 300 seconds), or make the agent answer faster. |
 | Trace-dependent criteria come back inconclusive | The agent reports its traces to a different LangWatch project, or it reports none at all. | Point the agent's tracing at the same project's API key. Set it up with the `tracing` skill. |
@@ -32391,7 +32392,7 @@ The SDK resolves the environment in this order:
 3. `APP_ENV`, then `ENVIRONMENT`, then `NODE_ENV`.
 4. `development`.
 
-`development` makes the agent **personal**. With a personal API key it belongs to the key's owner, and only that person can run it. With a project API key it belongs to the machine, and the team can see and run it. Every other environment name is shared by the whole project.
+`development` makes the agent **personal**. With a personal API key it belongs to the key's owner, and only that person can run it. With a project API key it belongs to the machine, and the team can see and run it. Every other environment name is shared by the whole project. On a project key the machine is identified by its hostname, which in a container changes every time the container is recreated, see [Containers and the machine identity](/agent-testing/environments#containers-and-the-machine-identity).
 
 For a development box the team runs against, give it a name of its own:
 
@@ -32541,6 +32542,7 @@ The run settings also record which instance served each run, so a result from a 
 | The row reads **Offline** | The process stopped, or its outbound connection is blocked by a proxy or a firewall. | Restart the process. On a network that blocks WebSockets, set `LANGWATCH_AGENT_TRANSPORT=http`, see [Behind a proxy that blocks WebSockets](#behind-a-proxy-that-blocks-websockets). |
 | The run is refused with `agent_offline` | No instance was connected when the run started. | Start the agent process, then run again. |
 | The run is refused with `agent_owner_only` | The agent registered under `development` with a personal key, so it belongs to one person. | Run it as its owner, or register it under a shared environment name. |
+| A new agent row appears on every start, each with a different host label | The agent registered under `development` with a project key from a container, and the container's hostname changes on every recreate. | Set `LANGWATCH_AGENT_ENVIRONMENT` to a name other than `development`, or pin the container's hostname, see [Containers and the machine identity](/agent-testing/environments#containers-and-the-machine-identity). |
 | A turn fails with `agent_call_timeout` | The function took longer than the agent's timeout. | Raise `timeout`, up to 300 seconds, or make the agent answer faster. |
 | A turn fails with `agent_busy` | Every instance was already running as many calls as it accepts. | Raise `concurrency` above its default of 10, or start more instances. |
 | Trace-dependent criteria come back inconclusive | The agent reports its traces to a different project, or it reports none at all. | Point the agent's tracing at the project that runs the scenarios. |
@@ -32569,7 +32571,7 @@ The run settings also record which instance served each run, so a result from a 
 ---
 title: Environments and Personal Agents
 sidebarTitle: Environments
-keywords: langwatch, agent simulations, environments, personal agents, development, staging, production, local development, comparison run
+keywords: langwatch, agent simulations, environments, personal agents, development, staging, production, local development, comparison run, docker, container, hostname
 description: One agent name, one row per environment. Your machine, staging and production are separate targets that a single run compares.
 ---
 
@@ -32599,7 +32601,7 @@ Environment names use lower-case letters, digits, dashes and underscores, up to 
 | The process authenticates with | The agent belongs to | Who can run it |
 |---|---|---|
 | A personal API key | The key's owner | The owner only |
-| A project API key | The machine that registered it | Everyone on the project |
+| A project API key | The machine that registered it, identified by its hostname | Everyone on the project |
 | Any key, environment other than `development` | The project | Everyone on the project |
 
 The platform refuses a run against a teammate's personal agent with `agent_owner_only`, and the message includes the owner's name. The rule applies at every door: the run dialog, the CLI, the REST API and the MCP server.
@@ -32611,6 +32613,34 @@ For a development machine the whole team runs suites against, give it its own en
 ```bash
 LANGWATCH_AGENT_ENVIRONMENT=dev-shared
 ```
+
+## Containers and the machine identity
+
+For a development agent on a project key, the machine identity is the hostname the SDK reads from the operating system. On a laptop or a VM that hostname stays the same across restarts, so a process that stops and starts again lands on the same row.
+
+In a container the default hostname is the container id, and that id is new every time the container is recreated. Each start registers a new row, and the agents page fills with offline rows of the same name, one per host label. Kubernetes pods from a Deployment behave the same way, since a pod gets a new random suffix on every recreate.
+
+Two ways to keep one row:
+
+**Name the environment.** Give it a value other than `development`:
+
+```bash
+LANGWATCH_AGENT_ENVIRONMENT=dev-alex
+```
+
+The row is then shared by everyone on the project who uses the same value, so a per-person value keeps people apart.
+
+**Pin the hostname.** In Docker Compose, set it on the service:
+
+```yaml
+services:
+  agent:
+    hostname: alex-dev
+```
+
+Use `docker run --hostname alex-dev` outside Compose; `container_name` does not set the hostname. On Kubernetes, a StatefulSet gives pods stable names, a Deployment does not.
+
+Old rows disappear from the agents page after 30 days unseen, or you can delete them. A deleted row comes back if a process registers under its identity again.
 
 ## The local loop
 
@@ -49276,7 +49306,7 @@ Use `session` when the agent's API creates its own conversation and cannot accep
 
 The SDK reads the environment from the `environment` argument, then `LANGWATCH_AGENT_ENVIRONMENT`, then `APP_ENV`, `ENVIRONMENT` and `NODE_ENV`, and falls back to `development`. Each environment is a separate row on the agents page, so production and a developer machine are two targets that a comparison run puts side by side.
 
-`development` makes the agent personal: only its owner can run it when the key is personal, and only that machine registers it when the key is a project key. Name the environment `dev-shared` for a development box the whole team runs against.
+`development` makes the agent personal: only its owner can run it when the key is personal, and only that machine registers it when the key is a project key. Name the environment `dev-shared` for a development box the whole team runs against. On a project key the machine is its hostname, so a container whose hostname changes on every recreate registers a new row each start; give it an environment name or pin the hostname (`hostname:` in Compose, `--hostname` on `docker run`).
 
 Leave `environment` out when the service already sets `LANGWATCH_AGENT_ENVIRONMENT`, `APP_ENV`, `ENVIRONMENT` or `NODE_ENV`. The SDK reads them on its own.
 
@@ -49486,6 +49516,7 @@ Run it with `--target http:<agent-id>`, and follow Step 5 and Step 6 otherwise u
 | `langwatch agent get` lists a parameter without `options`, or does not list it at all | The annotation is not a `Literal`, an `Enum` or a `z.enum`, or the parameter has no default and the platform reads it as required. | Change the annotation or add the default, then restart the process. |
 | The run is refused with `agent_offline` | No instance was connected when the run started. | Start the agent process and run again. |
 | The run is refused with `agent_owner_only` | The agent registered under `development` with a personal key, so only its owner can run it. | Run it as the owner, or register it under a shared environment name such as `dev-shared`. |
+| A new agent row appears on every start, each with a different host label | The agent registered under `development` with a project key from a container, and the container's hostname changes on every recreate. | Set `LANGWATCH_AGENT_ENVIRONMENT` to a name other than `development`, or pin the container's hostname with `hostname:` in Compose or `--hostname` on `docker run`. |
 | The run is refused with `scenario_parameter_option_invalid` | A value is outside the closed option list the agent declares. | Use one of the listed options, or widen the `Literal` (Python) or `z.enum` (TypeScript) list in the code. |
 | A turn fails with `agent_call_timeout` | The call took longer than the agent's timeout. | Raise `timeout` on the connect function (up to 300 seconds), or make the agent answer faster. |
 | Trace-dependent criteria come back inconclusive | The agent reports its traces to a different LangWatch project, or it reports none at all. | Point the agent's tracing at the same project's API key. Set it up with the `tracing` skill. |

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -32611,7 +32611,7 @@ The run dialog shows teammates' personal agents disabled. The tooltip on the car
 For a development machine the whole team runs suites against, give it its own environment name and it is shared like any other:
 
 ```bash
-LANGWATCH_AGENT_ENVIRONMENT=dev-shared
+export LANGWATCH_AGENT_ENVIRONMENT=dev-shared
 ```
 
 ## Containers and the machine identity
@@ -32625,7 +32625,7 @@ Two ways to keep one row:
 **Name the environment.** Give it a value other than `development`:
 
 ```bash
-LANGWATCH_AGENT_ENVIRONMENT=dev-alex
+export LANGWATCH_AGENT_ENVIRONMENT=dev-alex
 ```
 
 The row is then shared by everyone on the project who uses the same value, so a per-person value keeps people apart.

--- a/docs/skills/directory.mdx
+++ b/docs/skills/directory.mdx
@@ -2160,7 +2160,7 @@ Use `session` when the agent's API creates its own conversation and cannot accep
 
 The SDK reads the environment from the `environment` argument, then `LANGWATCH_AGENT_ENVIRONMENT`, then `APP_ENV`, `ENVIRONMENT` and `NODE_ENV`, and falls back to `development`. Each environment is a separate row on the agents page, so production and a developer machine are two targets that a comparison run puts side by side.
 
-`development` makes the agent personal: only its owner can run it when the key is personal, and only that machine registers it when the key is a project key. Name the environment `dev-shared` for a development box the whole team runs against.
+`development` makes the agent personal: only its owner can run it when the key is personal, and only that machine registers it when the key is a project key. Name the environment `dev-shared` for a development box the whole team runs against. On a project key the machine is its hostname, so a container whose hostname changes on every recreate registers a new row each start; give it an environment name or pin the hostname (`hostname:` in Compose, `--hostname` on `docker run`).
 
 Leave `environment` out when the service already sets `LANGWATCH_AGENT_ENVIRONMENT`, `APP_ENV`, `ENVIRONMENT` or `NODE_ENV`. The SDK reads them on its own.
 
@@ -2370,6 +2370,7 @@ Run it with `--target http:<agent-id>`, and follow Step 5 and Step 6 otherwise u
 | `langwatch agent get` lists a parameter without `options`, or does not list it at all | The annotation is not a `Literal`, an `Enum` or a `z.enum`, or the parameter has no default and the platform reads it as required. | Change the annotation or add the default, then restart the process. |
 | The run is refused with `agent_offline` | No instance was connected when the run started. | Start the agent process and run again. |
 | The run is refused with `agent_owner_only` | The agent registered under `development` with a personal key, so only its owner can run it. | Run it as the owner, or register it under a shared environment name such as `dev-shared`. |
+| A new agent row appears on every start, each with a different host label | The agent registered under `development` with a project key from a container, and the container's hostname changes on every recreate. | Set `LANGWATCH_AGENT_ENVIRONMENT` to a name other than `development`, or pin the container's hostname with `hostname:` in Compose or `--hostname` on `docker run`. |
 | The run is refused with `scenario_parameter_option_invalid` | A value is outside the closed option list the agent declares. | Use one of the listed options, or widen the `Literal` (Python) or `z.enum` (TypeScript) list in the code. |
 | A turn fails with `agent_call_timeout` | The call took longer than the agent's timeout. | Raise `timeout` on the connect function (up to 300 seconds), or make the agent answer faster. |
 | Trace-dependent criteria come back inconclusive | The agent reports its traces to a different LangWatch project, or it reports none at all. | Point the agent's tracing at the same project's API key. Set it up with the `tracing` skill. |

--- a/services/langyagent/internal/assets/skills/connect-agent/SKILL.md
+++ b/services/langyagent/internal/assets/skills/connect-agent/SKILL.md
@@ -142,7 +142,7 @@ Use `session` when the agent's API creates its own conversation and cannot accep
 
 The SDK reads the environment from the `environment` argument, then `LANGWATCH_AGENT_ENVIRONMENT`, then `APP_ENV`, `ENVIRONMENT` and `NODE_ENV`, and falls back to `development`. Each environment is a separate row on the agents page, so production and a developer machine are two targets that a comparison run puts side by side.
 
-`development` makes the agent personal: only its owner can run it when the key is personal, and only that machine registers it when the key is a project key. Name the environment `dev-shared` for a development box the whole team runs against.
+`development` makes the agent personal: only its owner can run it when the key is personal, and only that machine registers it when the key is a project key. Name the environment `dev-shared` for a development box the whole team runs against. On a project key the machine is its hostname, so a container whose hostname changes on every recreate registers a new row each start; give it an environment name or pin the hostname (`hostname:` in Compose, `--hostname` on `docker run`).
 
 Leave `environment` out when the service already sets `LANGWATCH_AGENT_ENVIRONMENT`, `APP_ENV`, `ENVIRONMENT` or `NODE_ENV`. The SDK reads them on its own.
 
@@ -352,6 +352,7 @@ Run it with `--target http:<agent-id>`, and follow Step 5 and Step 6 otherwise u
 | `langwatch agent get` lists a parameter without `options`, or does not list it at all | The annotation is not a `Literal`, an `Enum` or a `z.enum`, or the parameter has no default and the platform reads it as required. | Change the annotation or add the default, then restart the process. |
 | The run is refused with `agent_offline` | No instance was connected when the run started. | Start the agent process and run again. |
 | The run is refused with `agent_owner_only` | The agent registered under `development` with a personal key, so only its owner can run it. | Run it as the owner, or register it under a shared environment name such as `dev-shared`. |
+| A new agent row appears on every start, each with a different host label | The agent registered under `development` with a project key from a container, and the container's hostname changes on every recreate. | Set `LANGWATCH_AGENT_ENVIRONMENT` to a name other than `development`, or pin the container's hostname with `hostname:` in Compose or `--hostname` on `docker run`. |
 | The run is refused with `scenario_parameter_option_invalid` | A value is outside the closed option list the agent declares. | Use one of the listed options, or widen the `Literal` (Python) or `z.enum` (TypeScript) list in the code. |
 | A turn fails with `agent_call_timeout` | The call took longer than the agent's timeout. | Raise `timeout` on the connect function (up to 300 seconds), or make the agent answer faster. |
 | Trace-dependent criteria come back inconclusive | The agent reports its traces to a different LangWatch project, or it reports none at all. | Point the agent's tracing at the same project's API key. Set it up with the `tracing` skill. |

--- a/skills/_compiled/native/connect-agent/SKILL.md
+++ b/skills/_compiled/native/connect-agent/SKILL.md
@@ -142,7 +142,7 @@ Use `session` when the agent's API creates its own conversation and cannot accep
 
 The SDK reads the environment from the `environment` argument, then `LANGWATCH_AGENT_ENVIRONMENT`, then `APP_ENV`, `ENVIRONMENT` and `NODE_ENV`, and falls back to `development`. Each environment is a separate row on the agents page, so production and a developer machine are two targets that a comparison run puts side by side.
 
-`development` makes the agent personal: only its owner can run it when the key is personal, and only that machine registers it when the key is a project key. Name the environment `dev-shared` for a development box the whole team runs against.
+`development` makes the agent personal: only its owner can run it when the key is personal, and only that machine registers it when the key is a project key. Name the environment `dev-shared` for a development box the whole team runs against. On a project key the machine is its hostname, so a container whose hostname changes on every recreate registers a new row each start; give it an environment name or pin the hostname (`hostname:` in Compose, `--hostname` on `docker run`).
 
 Leave `environment` out when the service already sets `LANGWATCH_AGENT_ENVIRONMENT`, `APP_ENV`, `ENVIRONMENT` or `NODE_ENV`. The SDK reads them on its own.
 
@@ -352,6 +352,7 @@ Run it with `--target http:<agent-id>`, and follow Step 5 and Step 6 otherwise u
 | `langwatch agent get` lists a parameter without `options`, or does not list it at all | The annotation is not a `Literal`, an `Enum` or a `z.enum`, or the parameter has no default and the platform reads it as required. | Change the annotation or add the default, then restart the process. |
 | The run is refused with `agent_offline` | No instance was connected when the run started. | Start the agent process and run again. |
 | The run is refused with `agent_owner_only` | The agent registered under `development` with a personal key, so only its owner can run it. | Run it as the owner, or register it under a shared environment name such as `dev-shared`. |
+| A new agent row appears on every start, each with a different host label | The agent registered under `development` with a project key from a container, and the container's hostname changes on every recreate. | Set `LANGWATCH_AGENT_ENVIRONMENT` to a name other than `development`, or pin the container's hostname with `hostname:` in Compose or `--hostname` on `docker run`. |
 | The run is refused with `scenario_parameter_option_invalid` | A value is outside the closed option list the agent declares. | Use one of the listed options, or widen the `Literal` (Python) or `z.enum` (TypeScript) list in the code. |
 | A turn fails with `agent_call_timeout` | The call took longer than the agent's timeout. | Raise `timeout` on the connect function (up to 300 seconds), or make the agent answer faster. |
 | Trace-dependent criteria come back inconclusive | The agent reports its traces to a different LangWatch project, or it reports none at all. | Point the agent's tracing at the same project's API key. Set it up with the `tracing` skill. |

--- a/skills/connect-agent/SKILL.mdx
+++ b/skills/connect-agent/SKILL.mdx
@@ -150,7 +150,7 @@ Use `session` when the agent's API creates its own conversation and cannot accep
 
 The SDK reads the environment from the `environment` argument, then `LANGWATCH_AGENT_ENVIRONMENT`, then `APP_ENV`, `ENVIRONMENT` and `NODE_ENV`, and falls back to `development`. Each environment is a separate row on the agents page, so production and a developer machine are two targets that a comparison run puts side by side.
 
-`development` makes the agent personal: only its owner can run it when the key is personal, and only that machine registers it when the key is a project key. Name the environment `dev-shared` for a development box the whole team runs against.
+`development` makes the agent personal: only its owner can run it when the key is personal, and only that machine registers it when the key is a project key. Name the environment `dev-shared` for a development box the whole team runs against. On a project key the machine is its hostname, so a container whose hostname changes on every recreate registers a new row each start; give it an environment name or pin the hostname (`hostname:` in Compose, `--hostname` on `docker run`).
 
 Leave `environment` out when the service already sets `LANGWATCH_AGENT_ENVIRONMENT`, `APP_ENV`, `ENVIRONMENT` or `NODE_ENV`. The SDK reads them on its own.
 
@@ -353,6 +353,7 @@ Run it with `--target http:<agent-id>`, and follow Step 5 and Step 6 otherwise u
 | `langwatch agent get` lists a parameter without `options`, or does not list it at all | The annotation is not a `Literal`, an `Enum` or a `z.enum`, or the parameter has no default and the platform reads it as required. | Change the annotation or add the default, then restart the process. |
 | The run is refused with `agent_offline` | No instance was connected when the run started. | Start the agent process and run again. |
 | The run is refused with `agent_owner_only` | The agent registered under `development` with a personal key, so only its owner can run it. | Run it as the owner, or register it under a shared environment name such as `dev-shared`. |
+| A new agent row appears on every start, each with a different host label | The agent registered under `development` with a project key from a container, and the container's hostname changes on every recreate. | Set `LANGWATCH_AGENT_ENVIRONMENT` to a name other than `development`, or pin the container's hostname with `hostname:` in Compose or `--hostname` on `docker run`. |
 | The run is refused with `scenario_parameter_option_invalid` | A value is outside the closed option list the agent declares. | Use one of the listed options, or widen the `Literal` (Python) or `z.enum` (TypeScript) list in the code. |
 | A turn fails with `agent_call_timeout` | The call took longer than the agent's timeout. | Raise `timeout` on the connect function (up to 300 seconds), or make the agent answer faster. |
 | Trace-dependent criteria come back inconclusive | The agent reports its traces to a different LangWatch project, or it reports none at all. | Point the agent's tracing at the same project's API key. Set it up with the `tracing` skill. |


### PR DESCRIPTION
## What

A customer saw a new connected agent row on every start. Reproduced on production: a `development` agent registered with a project key is keyed by `name@development/host:<hostname>`, and a container's default hostname is its container id, new on every recreate. A plain restart on a laptop or VM reuses the row; only a changed hostname, a drifting `NODE_ENV`-style variable, or a key switch creates another.

This documents the mechanism and the two zero-code fixes:

- `LANGWATCH_AGENT_ENVIRONMENT` set to anything other than `development` (the row is then shared by everyone using that value, so per-person values keep people apart)
- a pinned hostname (`hostname:` in Compose, `--hostname` on `docker run`; `container_name` does not set it)

## Where

- `docs/agent-testing/environments.mdx`: new section "Containers and the machine identity", table cell names the hostname, keywords
- `docs/agent-testing/connect-your-agent.mdx`: one sentence in the environments section and a common-failures row (human section), plus the regenerated skill accordion
- `docs/integration/{python,typescript}/agent-reference.mdx`: "identified by its hostname"
- `skills/connect-agent/SKILL.mdx`: one sentence and a common-failures row; `_compiled/native`, `services/langyagent/.../skills` and `docs/skills/directory.mdx` regenerated with `docs/scripts/sync-prompts.sh` and `_compiler/native.ts`

No product change. Whether the identity model should change (explicit identity override, SDK warning on the `development` fallback, grouping host scopes in the UI) is a separate design decision.

## Verification

- `skills/_tests/native-skills.test.ts`: 16 passed
- Generated files diff only in the edited sentences

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GEAX11S88NKFAhsd5thJHM


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added guidance explaining how container and Kubernetes hostname changes can create a new agent entry after each recreation.
  - Documented ways to maintain a consistent agent entry by naming the environment or pinning the container hostname.
  - Clarified how project keys associate agents with machine hostnames.
  - Added troubleshooting guidance for repeated agent entries across agent setup documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->