### PR TITLE
fix(navigation): scope the personal workspace lookup to the selected organization

### DIFF
--- a/platform/app/src/components/PersonalSidebar.tsx
+++ b/platform/app/src/components/PersonalSidebar.tsx
@@ -103,17 +103,22 @@ function usePersonalWorkspace(): {
   features: PersonalWorkspaceFeatures | undefined;
 } {
   const session = useRequiredSession();
-  const { organizations } = useOrganizationTeamProject({
+  const { organizations, organization } = useOrganizationTeamProject({
     redirectToOnboarding: false,
     redirectToProjectOnboarding: false,
   });
+  // Scoped to the organization the chrome is showing: a personal workspace
+  // exists per organization, and linking to another one's navigates out of the
+  // current organization, which the header then reflects by re-deriving the
+  // organization from the project slug in the URL.
   const personalProject = useMemo(
     () =>
       findPersonalProject({
         organizations,
         userId: session.data?.user?.id,
+        organizationId: organization?.id,
       }),
-    [organizations, session.data?.user?.id],
+    [organizations, session.data?.user?.id, organization?.id],
   );
   const personalProjectId = personalProject?.id ?? null;
   const featuresQuery = api.personalWorkspaceFeatures.get.useQuery(

--- a/platform/app/src/components/__tests__/PersonalSidebar.integration.test.tsx
+++ b/platform/app/src/components/__tests__/PersonalSidebar.integration.test.tsx
@@ -1,0 +1,148 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The Me sidebar's Traces entry addresses the personal workspace by project
+ * slug, and a user who belongs to several organizations owns one personal
+ * workspace per organization. The entry has to follow the organization the
+ * chrome is currently showing: pointing at another organization's personal
+ * project navigates away from the selected organization, and the header then
+ * re-derives the organization from the project slug in the URL, so the
+ * organization visibly flips.
+ *
+ * Spec: specs/navigation/product-sidebars.feature
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { PersonalSidebarLinks } from "../PersonalSidebar";
+
+type Org = {
+  id: string;
+  teams: Array<{
+    isPersonal: boolean;
+    ownerUserId: string | null;
+    projects: Array<{ id: string; slug: string }>;
+  }>;
+};
+
+const state: {
+  organizations: Org[];
+  organization: { id: string } | undefined;
+} = { organizations: [], organization: undefined };
+
+vi.mock("~/utils/compat/next-router", () => ({
+  useRouter: () => ({
+    query: {},
+    asPath: "/me",
+    pathname: "/me",
+    push: vi.fn(),
+    replace: vi.fn(),
+  }),
+}));
+
+vi.mock("~/utils/compat/next-link", () => ({
+  default: ({
+    href,
+    children,
+  }: {
+    href: string;
+    children: React.ReactNode;
+  }) => <a href={href}>{children}</a>,
+}));
+
+vi.mock("~/hooks/useRequiredSession", () => ({
+  useRequiredSession: () => ({ data: { user: { id: "user-1" } } }),
+}));
+
+vi.mock("~/hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({
+    organizations: state.organizations,
+    organization: state.organization,
+  }),
+}));
+
+vi.mock("~/utils/api", () => ({
+  api: {
+    personalWorkspaceFeatures: {
+      get: { useQuery: () => ({ data: undefined }) },
+    },
+  },
+}));
+
+const orgWithPersonalProject = (orgId: string, slug: string): Org => ({
+  id: orgId,
+  teams: [
+    {
+      isPersonal: true,
+      ownerUserId: "user-1",
+      projects: [{ id: `proj-${slug}`, slug }],
+    },
+  ],
+});
+
+function renderLinks() {
+  return render(
+    <ChakraProvider value={defaultSystem}>
+      <PersonalSidebarLinks showExpanded={true} />
+    </ChakraProvider>,
+  );
+}
+
+const tracesHref = () =>
+  screen.queryByRole("link", { name: "Traces" })?.getAttribute("href") ?? null;
+
+describe("PersonalSidebarLinks", () => {
+  beforeEach(() => {
+    state.organizations = [
+      orgWithPersonalProject("org-first", "personal-first"),
+      orgWithPersonalProject("org-second", "personal-second"),
+    ];
+    state.organization = { id: "org-second" };
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  describe("given the user owns a personal workspace in several organizations", () => {
+    it("links Traces to the personal project of the selected organization", () => {
+      renderLinks();
+
+      expect(tracesHref()).toBe("/personal-second/traces");
+    });
+
+    it("follows the selection when a different organization is showing", () => {
+      state.organization = { id: "org-first" };
+
+      renderLinks();
+
+      expect(tracesHref()).toBe("/personal-first/traces");
+    });
+  });
+
+  describe("given the selected organization holds no personal workspace", () => {
+    it("renders no Traces entry rather than one for another organization", () => {
+      state.organizations = [
+        orgWithPersonalProject("org-first", "personal-first"),
+        { id: "org-shared", teams: [] },
+      ];
+      state.organization = { id: "org-shared" };
+
+      renderLinks();
+
+      expect(tracesHref()).toBeNull();
+    });
+  });
+
+  it("always renders the organization-independent personal entries", () => {
+    renderLinks();
+
+    expect(
+      screen.getByRole("link", { name: "Sessions" }).getAttribute("href"),
+    ).toBe("/me/sessions");
+    expect(
+      screen.getByRole("link", { name: "Configure" }).getAttribute("href"),
+    ).toBe("/me/configure");
+  });
+});

--- a/platform/app/src/components/__tests__/PersonalSidebar.integration.test.tsx
+++ b/platform/app/src/components/__tests__/PersonalSidebar.integration.test.tsx
@@ -70,7 +70,13 @@ vi.mock("~/utils/api", () => ({
   },
 }));
 
-const orgWithPersonalProject = (orgId: string, slug: string): Org => ({
+const orgWithPersonalProject = ({
+  orgId,
+  slug,
+}: {
+  orgId: string;
+  slug: string;
+}): Org => ({
   id: orgId,
   teams: [
     {
@@ -95,8 +101,8 @@ const tracesHref = () =>
 describe("PersonalSidebarLinks", () => {
   beforeEach(() => {
     state.organizations = [
-      orgWithPersonalProject("org-first", "personal-first"),
-      orgWithPersonalProject("org-second", "personal-second"),
+      orgWithPersonalProject({ orgId: "org-first", slug: "personal-first" }),
+      orgWithPersonalProject({ orgId: "org-second", slug: "personal-second" }),
     ];
     state.organization = { id: "org-second" };
   });
@@ -106,6 +112,7 @@ describe("PersonalSidebarLinks", () => {
   });
 
   describe("given the user owns a personal workspace in several organizations", () => {
+    /** @scenario "The Me sidebar's Traces entry stays inside the selected organization" */
     it("links Traces to the personal project of the selected organization", () => {
       renderLinks();
 
@@ -122,9 +129,10 @@ describe("PersonalSidebarLinks", () => {
   });
 
   describe("given the loaded organization holds no personal workspace", () => {
+    /** @scenario "The Me sidebar offers no Traces entry until it can see one here" */
     it("renders no Traces entry", () => {
       state.organizations = [
-        orgWithPersonalProject("org-first", "personal-first"),
+        orgWithPersonalProject({ orgId: "org-first", slug: "personal-first" }),
         { id: "org-shared", teams: [] },
       ];
       state.organization = { id: "org-shared" };
@@ -135,14 +143,16 @@ describe("PersonalSidebarLinks", () => {
     });
   });
 
-  it("always renders the organization-independent personal entries", () => {
-    renderLinks();
+  describe("given the personal entries that address no organization", () => {
+    it("renders them whichever organization is selected", () => {
+      renderLinks();
 
-    expect(
-      screen.getByRole("link", { name: "Sessions" }).getAttribute("href"),
-    ).toBe("/me/sessions");
-    expect(
-      screen.getByRole("link", { name: "Configure" }).getAttribute("href"),
-    ).toBe("/me/configure");
+      expect(
+        screen.getByRole("link", { name: "Sessions" }).getAttribute("href"),
+      ).toBe("/me/sessions");
+      expect(
+        screen.getByRole("link", { name: "Configure" }).getAttribute("href"),
+      ).toBe("/me/configure");
+    });
   });
 });

--- a/platform/app/src/components/__tests__/PersonalSidebar.integration.test.tsx
+++ b/platform/app/src/components/__tests__/PersonalSidebar.integration.test.tsx
@@ -121,8 +121,8 @@ describe("PersonalSidebarLinks", () => {
     });
   });
 
-  describe("given the selected organization holds no personal workspace", () => {
-    it("renders no Traces entry rather than one for another organization", () => {
+  describe("given the loaded organization holds no personal workspace", () => {
+    it("renders no Traces entry", () => {
       state.organizations = [
         orgWithPersonalProject("org-first", "personal-first"),
         { id: "org-shared", teams: [] },

--- a/platform/app/src/pages/cli/FirstTraceRedirect.tsx
+++ b/platform/app/src/pages/cli/FirstTraceRedirect.tsx
@@ -92,16 +92,23 @@ type FirstTraceWatchState = "hidden" | "waiting" | "redirecting";
  * "waiting" is the confirmed never-synced poll, "redirecting" the brief
  * announcement before navigation; "hidden" covers every case that keeps the
  * current close-this-tab behavior.
+ *
+ * The personal project is resolved within the organization now selected: the
+ * approval this page follows was granted against one organization and the
+ * CLI's personal workspace was ensured in that same one, so the watcher must
+ * not poll whichever personal project the payload happens to list first.
  */
 function useFirstTraceWatch(): FirstTraceWatchState {
   const router = useRouter();
   const { data: session } = useSession();
-  const { organizations } = useOrganizationTeamProject({
+  const { organizations, organization } = useOrganizationTeamProject({
     redirectToOnboarding: false,
   });
+  const userId = session?.user?.id;
+  const organizationId = organization?.id;
   const personalProject = useMemo(
-    () => findPersonalProject({ organizations, userId: session?.user?.id }),
-    [organizations, session?.user?.id],
+    () => findPersonalProject({ organizations, userId, organizationId }),
+    [organizations, userId, organizationId],
   );
 
   const [hasResult, setHasResult] = useState(false);

--- a/platform/app/src/pages/cli/FirstTraceRedirect.tsx
+++ b/platform/app/src/pages/cli/FirstTraceRedirect.tsx
@@ -93,19 +93,21 @@ type FirstTraceWatchState = "hidden" | "waiting" | "redirecting";
  * announcement before navigation; "hidden" covers every case that keeps the
  * current close-this-tab behavior.
  *
- * The personal project is resolved within the organization now selected: the
- * approval this page follows was granted against one organization and the
- * CLI's personal workspace was ensured in that same one, so the watcher must
- * not poll whichever personal project the payload happens to list first.
+ * The personal project is resolved within the organization the approval was
+ * granted against — the one the page passes in, the same id it sends to
+ * /api/auth/cli/approve and names in the card above this widget. NOT the
+ * ambient organization: a user who picks a different organization in the
+ * chooser would otherwise be watched against the one they navigated in with.
  */
-function useFirstTraceWatch(): FirstTraceWatchState {
+function useFirstTraceWatch(
+  organizationId: string | null | undefined,
+): FirstTraceWatchState {
   const router = useRouter();
   const { data: session } = useSession();
-  const { organizations, organization } = useOrganizationTeamProject({
+  const { organizations } = useOrganizationTeamProject({
     redirectToOnboarding: false,
   });
   const userId = session?.user?.id;
-  const organizationId = organization?.id;
   const personalProject = useMemo(
     () => findPersonalProject({ organizations, userId, organizationId }),
     [organizations, userId, organizationId],
@@ -180,8 +182,13 @@ function useFirstTraceWatch(): FirstTraceWatchState {
   return "hidden";
 }
 
-export function FirstTraceRedirect() {
-  const watchState = useFirstTraceWatch();
+export function FirstTraceRedirect({
+  organizationId,
+}: {
+  /** The organization the CLI approval was granted against. */
+  organizationId: string | null | undefined;
+}) {
+  const watchState = useFirstTraceWatch(organizationId);
 
   if (watchState === "redirecting") {
     return (

--- a/platform/app/src/pages/cli/FirstTraceRedirect.tsx
+++ b/platform/app/src/pages/cli/FirstTraceRedirect.tsx
@@ -99,9 +99,11 @@ type FirstTraceWatchState = "hidden" | "waiting" | "redirecting";
  * ambient organization: a user who picks a different organization in the
  * chooser would otherwise be watched against the one they navigated in with.
  */
-function useFirstTraceWatch(
-  organizationId: string | null | undefined,
-): FirstTraceWatchState {
+function useFirstTraceWatch({
+  organizationId,
+}: {
+  organizationId: string | null | undefined;
+}): FirstTraceWatchState {
   const router = useRouter();
   const { data: session } = useSession();
   const { organizations } = useOrganizationTeamProject({
@@ -188,7 +190,7 @@ export function FirstTraceRedirect({
   /** The organization the CLI approval was granted against. */
   organizationId: string | null | undefined;
 }) {
-  const watchState = useFirstTraceWatch(organizationId);
+  const watchState = useFirstTraceWatch({ organizationId });
 
   if (watchState === "redirecting") {
     return (

--- a/platform/app/src/pages/cli/__tests__/cliAuthFirstTraceRedirect.integration.test.tsx
+++ b/platform/app/src/pages/cli/__tests__/cliAuthFirstTraceRedirect.integration.test.tsx
@@ -101,6 +101,32 @@ const organizationsFixture = [
       },
     ],
   },
+  // A second organization, so the page renders its organization picker at all
+  // (it is hidden for a single-organization user). Its personal project is
+  // what a watcher reading the live selection instead of the approved
+  // organization would land on.
+  {
+    id: "org-2",
+    name: "Second Org",
+    teams: [
+      {
+        id: "team-personal-2",
+        slug: "personal-team-2",
+        name: "Personal",
+        isPersonal: true,
+        ownerUserId: "user-1",
+        projects: [
+          {
+            id: "proj-personal-2",
+            slug: "personal-proj-2",
+            name: "Personal project",
+            isPersonal: true,
+            kind: "application",
+          },
+        ],
+      },
+    ],
+  },
 ];
 
 vi.mock("~/utils/api", async () => {
@@ -308,5 +334,61 @@ describe("/cli/auth first-trace watch", () => {
 
     expect(screen.queryByText(/Waiting for your first trace/i)).toBeNull();
     expect(mockRouter.push).not.toHaveBeenCalled();
+  });
+
+  // The picker stays interactive while the approval request is in flight, so
+  // the organization the page shows can move after the request has gone out.
+  // The approval was granted against one organization: the card names it and
+  // the watcher must poll that organization's personal project, not whichever
+  // one the picker happens to be sitting on when the response lands.
+  describe("given the organization is changed while the approval is in flight", () => {
+    it("watches the approved organization, not the one now selected", async () => {
+      let releaseApproval = () => {};
+      const approvalSent = new Promise<void>((resolve) => {
+        releaseApproval = resolve;
+      });
+      const baseFetch = fetchMock.getMockImplementation()!;
+      fetchMock.mockImplementation(async (input: RequestInfo | URL) => {
+        if (String(input).includes("/api/auth/cli/approve")) {
+          await approvalSent;
+        }
+        return baseFetch(input);
+      });
+
+      const user = userEvent.setup();
+      renderPage();
+      await confirmCode();
+      await waitFor(() =>
+        expect(screen.getByRole("button", { name: "Approve" })).toBeDefined(),
+      );
+
+      void user.click(screen.getByRole("button", { name: "Approve" }));
+      await waitFor(() =>
+        expect(
+          fetchMock.mock.calls.some(([input]) =>
+            String(input).includes("/api/auth/cli/approve"),
+          ),
+        ).toBe(true),
+      );
+
+      await user.click(screen.getByRole("button", { name: "Second Org" }));
+      releaseApproval();
+
+      await waitFor(() =>
+        expect(screen.getByText(/You're signed in!/i)).toBeDefined(),
+      );
+      expect(screen.getByText("Acme Org")).toBeDefined();
+
+      act(() => firstMessageState.set(true));
+
+      await waitFor(
+        () =>
+          expect(mockRouter.push).toHaveBeenCalledWith("/personal-proj/traces"),
+        { timeout: 4_000 },
+      );
+      expect(mockRouter.push).not.toHaveBeenCalledWith(
+        "/personal-proj-2/traces",
+      );
+    });
   });
 });

--- a/platform/app/src/pages/cli/__tests__/cliAuthFirstTraceRedirect.integration.test.tsx
+++ b/platform/app/src/pages/cli/__tests__/cliAuthFirstTraceRedirect.integration.test.tsx
@@ -341,54 +341,64 @@ describe("/cli/auth first-trace watch", () => {
   // The approval was granted against one organization: the card names it and
   // the watcher must poll that organization's personal project, not whichever
   // one the picker happens to be sitting on when the response lands.
-  describe("given the organization is changed while the approval is in flight", () => {
-    it("watches the approved organization, not the one now selected", async () => {
-      let releaseApproval = () => {};
-      const approvalSent = new Promise<void>((resolve) => {
-        releaseApproval = resolve;
+  describe("given an approval request that has not yet completed", () => {
+    /** Holds the approve response open until the returned release is called. */
+    const holdApprovalOpen = () => {
+      let release = () => {};
+      const held = new Promise<void>((resolve) => {
+        release = resolve;
       });
       const baseFetch = fetchMock.getMockImplementation()!;
       fetchMock.mockImplementation(async (input: RequestInfo | URL) => {
         if (String(input).includes("/api/auth/cli/approve")) {
-          await approvalSent;
+          await held;
         }
         return baseFetch(input);
       });
+      return () => release();
+    };
 
-      const user = userEvent.setup();
-      renderPage();
-      await confirmCode();
-      await waitFor(() =>
-        expect(screen.getByRole("button", { name: "Approve" })).toBeDefined(),
-      );
+    describe("when the organization is changed before the response lands", () => {
+      it("watches the approved organization, not the one now selected", async () => {
+        const releaseApproval = holdApprovalOpen();
 
-      void user.click(screen.getByRole("button", { name: "Approve" }));
-      await waitFor(() =>
-        expect(
-          fetchMock.mock.calls.some(([input]) =>
-            String(input).includes("/api/auth/cli/approve"),
-          ),
-        ).toBe(true),
-      );
+        const user = userEvent.setup();
+        renderPage();
+        await confirmCode();
+        await waitFor(() =>
+          expect(screen.getByRole("button", { name: "Approve" })).toBeDefined(),
+        );
 
-      await user.click(screen.getByRole("button", { name: "Second Org" }));
-      releaseApproval();
+        void user.click(screen.getByRole("button", { name: "Approve" }));
+        await waitFor(() =>
+          expect(
+            fetchMock.mock.calls.some(([input]) =>
+              String(input).includes("/api/auth/cli/approve"),
+            ),
+          ).toBe(true),
+        );
 
-      await waitFor(() =>
-        expect(screen.getByText(/You're signed in!/i)).toBeDefined(),
-      );
-      expect(screen.getByText("Acme Org")).toBeDefined();
+        await user.click(screen.getByRole("button", { name: "Second Org" }));
+        releaseApproval();
 
-      act(() => firstMessageState.set(true));
+        await waitFor(() =>
+          expect(screen.getByText(/You're signed in!/i)).toBeDefined(),
+        );
+        expect(screen.getByText("Acme Org")).toBeDefined();
 
-      await waitFor(
-        () =>
-          expect(mockRouter.push).toHaveBeenCalledWith("/personal-proj/traces"),
-        { timeout: 4_000 },
-      );
-      expect(mockRouter.push).not.toHaveBeenCalledWith(
-        "/personal-proj-2/traces",
-      );
+        act(() => firstMessageState.set(true));
+
+        await waitFor(
+          () =>
+            expect(mockRouter.push).toHaveBeenCalledWith(
+              "/personal-proj/traces",
+            ),
+          { timeout: 4_000 },
+        );
+        expect(mockRouter.push).not.toHaveBeenCalledWith(
+          "/personal-proj-2/traces",
+        );
+      });
     });
   });
 });

--- a/platform/app/src/pages/cli/auth.tsx
+++ b/platform/app/src/pages/cli/auth.tsx
@@ -101,6 +101,14 @@ type ActionState =
   | { kind: "submitting" }
   | {
       kind: "success";
+      /**
+       * The organization the approval actually went out for, captured before
+       * the request rather than read back off `selectedOrgId`. The picker
+       * stays interactive while the request is in flight, so a selection
+       * changed in that window would otherwise rename the card and re-point
+       * the first-trace watcher at an organization nobody approved.
+       */
+      organizationId: string;
       organizationName: string;
       credentialType: CredentialType;
       projectName?: string;
@@ -546,6 +554,7 @@ export default function CliAuthPage() {
 
   const handleApprove = async () => {
     if (!selectedOrgId || !userCode) return;
+    const approvedOrgId = selectedOrgId;
     if (requiresProject && !selectedProjectId) return;
     if (isDeviceSessionSelectionIncomplete) return;
     // Same binding as the render gates, restated on the action itself: the
@@ -559,7 +568,7 @@ export default function CliAuthPage() {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           user_code: userCode,
-          organization_id: selectedOrgId,
+          organization_id: approvedOrgId,
           ...(requiresProject && selectedProjectId
             ? { project_id: selectedProjectId }
             : {}),
@@ -592,13 +601,14 @@ export default function CliAuthPage() {
         return;
       }
       const orgName =
-        organizations?.find((o) => o.id === selectedOrgId)?.name ??
+        organizations?.find((o) => o.id === approvedOrgId)?.name ??
         "your organization";
       const projectName = requiresProject
         ? offeredProjects.find((p) => p.id === selectedProjectId)?.name
         : undefined;
       setAction({
         kind: "success",
+        organizationId: approvedOrgId,
         organizationName: orgName,
         credentialType,
         projectName,
@@ -1011,7 +1021,7 @@ export default function CliAuthPage() {
                     <strong>{action.organizationName}</strong>. You can close
                     this tab and return to your terminal.
                   </StatusCard>
-                  <FirstTraceRedirect organizationId={selectedOrgId} />
+                  <FirstTraceRedirect organizationId={action.organizationId} />
                 </>
               )}
             </>

--- a/platform/app/src/pages/cli/auth.tsx
+++ b/platform/app/src/pages/cli/auth.tsx
@@ -1011,7 +1011,7 @@ export default function CliAuthPage() {
                     <strong>{action.organizationName}</strong>. You can close
                     this tab and return to your terminal.
                   </StatusCard>
-                  <FirstTraceRedirect />
+                  <FirstTraceRedirect organizationId={selectedOrgId} />
                 </>
               )}
             </>

--- a/platform/app/src/utils/__tests__/personalProject.unit.test.ts
+++ b/platform/app/src/utils/__tests__/personalProject.unit.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest";
+
+import { findPersonalProject } from "../personalProject";
+
+/**
+ * A personal workspace is created per organization
+ * (PersonalWorkspaceService.ensure takes an organizationId), so a user who
+ * belongs to several organizations owns several personal projects. The
+ * resolution therefore has to name which organization it is asking about:
+ * without one it returned whichever personal team came first in an unordered
+ * organization list, and the Me sidebar linked to another organization's
+ * personal workspace.
+ */
+
+const USER = "user-1";
+
+const orgWithPersonalProject = (
+  orgId: string,
+  project: { id: string; slug: string },
+  ownerUserId: string = USER,
+) => ({
+  id: orgId,
+  teams: [
+    {
+      isPersonal: true,
+      ownerUserId,
+      projects: [project],
+    },
+  ],
+});
+
+const FIRST_ORG = orgWithPersonalProject("org-first", {
+  id: "proj-first",
+  slug: "personal-first",
+});
+const SECOND_ORG = orgWithPersonalProject("org-second", {
+  id: "proj-second",
+  slug: "personal-second",
+});
+
+describe("findPersonalProject", () => {
+  describe("given the user owns a personal project in more than one organization", () => {
+    const organizations = [FIRST_ORG, SECOND_ORG];
+
+    it("resolves the personal project of the organization asked about", () => {
+      expect(
+        findPersonalProject({
+          organizations,
+          userId: USER,
+          organizationId: "org-second",
+        }),
+      ).toEqual({ id: "proj-second", slug: "personal-second" });
+    });
+
+    it("still resolves the first organization when that is the one asked about", () => {
+      expect(
+        findPersonalProject({
+          organizations,
+          userId: USER,
+          organizationId: "org-first",
+        }),
+      ).toEqual({ id: "proj-first", slug: "personal-first" });
+    });
+  });
+
+  describe("given the organization asked about holds no personal project", () => {
+    it("resolves nothing rather than another organization's", () => {
+      const sharedOnly = {
+        id: "org-shared",
+        teams: [
+          {
+            isPersonal: false,
+            ownerUserId: null,
+            projects: [{ id: "proj-shared", slug: "shared" }],
+          },
+        ],
+      };
+
+      expect(
+        findPersonalProject({
+          organizations: [FIRST_ORG, sharedOnly],
+          userId: USER,
+          organizationId: "org-shared",
+        }),
+      ).toBeNull();
+    });
+  });
+
+  describe("given no organization has been resolved yet", () => {
+    it("resolves nothing", () => {
+      expect(
+        findPersonalProject({
+          organizations: [FIRST_ORG],
+          userId: USER,
+          organizationId: undefined,
+        }),
+      ).toBeNull();
+    });
+  });
+
+  it("ignores a personal team owned by somebody else in the same organization", () => {
+    const someoneElses = orgWithPersonalProject(
+      "org-first",
+      { id: "proj-theirs", slug: "personal-theirs" },
+      "user-2",
+    );
+
+    expect(
+      findPersonalProject({
+        organizations: [someoneElses],
+        userId: USER,
+        organizationId: "org-first",
+      }),
+    ).toBeNull();
+  });
+
+  it("resolves nothing without a user", () => {
+    expect(
+      findPersonalProject({
+        organizations: [FIRST_ORG],
+        userId: null,
+        organizationId: "org-first",
+      }),
+    ).toBeNull();
+  });
+
+  it("resolves nothing before the organizations have loaded", () => {
+    expect(
+      findPersonalProject({
+        organizations: undefined,
+        userId: USER,
+        organizationId: "org-first",
+      }),
+    ).toBeNull();
+  });
+});

--- a/platform/app/src/utils/__tests__/personalProject.unit.test.ts
+++ b/platform/app/src/utils/__tests__/personalProject.unit.test.ts
@@ -14,11 +14,15 @@ import { findPersonalProject } from "../personalProject";
 
 const USER = "user-1";
 
-const orgWithPersonalProject = (
-  orgId: string,
-  project: { id: string; slug: string },
-  ownerUserId: string = USER,
-) => ({
+const orgWithPersonalProject = ({
+  orgId,
+  project,
+  ownerUserId = USER,
+}: {
+  orgId: string;
+  project: { id: string; slug: string };
+  ownerUserId?: string;
+}) => ({
   id: orgId,
   teams: [
     {
@@ -29,13 +33,13 @@ const orgWithPersonalProject = (
   ],
 });
 
-const FIRST_ORG = orgWithPersonalProject("org-first", {
-  id: "proj-first",
-  slug: "personal-first",
+const FIRST_ORG = orgWithPersonalProject({
+  orgId: "org-first",
+  project: { id: "proj-first", slug: "personal-first" },
 });
-const SECOND_ORG = orgWithPersonalProject("org-second", {
-  id: "proj-second",
-  slug: "personal-second",
+const SECOND_ORG = orgWithPersonalProject({
+  orgId: "org-second",
+  project: { id: "proj-second", slug: "personal-second" },
 });
 
 describe("findPersonalProject", () => {
@@ -98,39 +102,45 @@ describe("findPersonalProject", () => {
     });
   });
 
-  it("ignores a personal team owned by somebody else in the same organization", () => {
-    const someoneElses = orgWithPersonalProject(
-      "org-first",
-      { id: "proj-theirs", slug: "personal-theirs" },
-      "user-2",
-    );
+  describe("given the organization asked about holds somebody else's personal project", () => {
+    it("resolves nothing", () => {
+      const someoneElses = orgWithPersonalProject({
+        orgId: "org-first",
+        project: { id: "proj-theirs", slug: "personal-theirs" },
+        ownerUserId: "user-2",
+      });
 
-    expect(
-      findPersonalProject({
-        organizations: [someoneElses],
-        userId: USER,
-        organizationId: "org-first",
-      }),
-    ).toBeNull();
+      expect(
+        findPersonalProject({
+          organizations: [someoneElses],
+          userId: USER,
+          organizationId: "org-first",
+        }),
+      ).toBeNull();
+    });
   });
 
-  it("resolves nothing without a user", () => {
-    expect(
-      findPersonalProject({
-        organizations: [FIRST_ORG],
-        userId: null,
-        organizationId: "org-first",
-      }),
-    ).toBeNull();
+  describe("given no user has been resolved yet", () => {
+    it("resolves nothing", () => {
+      expect(
+        findPersonalProject({
+          organizations: [FIRST_ORG],
+          userId: null,
+          organizationId: "org-first",
+        }),
+      ).toBeNull();
+    });
   });
 
-  it("resolves nothing before the organizations have loaded", () => {
-    expect(
-      findPersonalProject({
-        organizations: undefined,
-        userId: USER,
-        organizationId: "org-first",
-      }),
-    ).toBeNull();
+  describe("given the organizations have not loaded yet", () => {
+    it("resolves nothing", () => {
+      expect(
+        findPersonalProject({
+          organizations: undefined,
+          userId: USER,
+          organizationId: "org-first",
+        }),
+      ).toBeNull();
+    });
   });
 });

--- a/platform/app/src/utils/personalProject.ts
+++ b/platform/app/src/utils/personalProject.ts
@@ -3,13 +3,23 @@
  * payload: the personal team owned by the user carries exactly one personal
  * project. Shared by PersonalSidebar (personal nav links) and the /cli/auth
  * first-trace watcher, so the traversal lives in one place.
+ *
+ * A personal workspace belongs to ONE organization — PersonalWorkspaceService
+ * .ensure takes an organizationId and creates a workspace per organization —
+ * so a user in several organizations owns several personal projects and the
+ * caller has to name which organization it is asking about. `organizationId`
+ * is required rather than optional for that reason: scanning every
+ * organization returned whichever personal team came first in a list the
+ * server sends unordered, which is not a choice any caller means to make.
  */
 export function findPersonalProject({
   organizations,
   userId,
+  organizationId,
 }: {
   organizations:
     | Array<{
+        id: string;
         teams?: Array<{
           isPersonal?: boolean | null;
           ownerUserId?: string | null;
@@ -18,15 +28,17 @@ export function findPersonalProject({
       }>
     | undefined;
   userId: string | null | undefined;
+  /** The organization the caller is showing. Nothing resolves without it. */
+  organizationId: string | null | undefined;
 }): { id: string; slug: string } | null {
-  if (!userId || !organizations) return null;
-  for (const org of organizations) {
-    for (const team of org.teams ?? []) {
-      if (team.isPersonal && team.ownerUserId === userId) {
-        const project = team.projects?.[0];
-        if (project) return { id: project.id, slug: project.slug };
-      }
-    }
-  }
-  return null;
+  if (!userId || !organizationId) return null;
+  const organization = organizations?.find((org) => org.id === organizationId);
+  const team = organization?.teams?.find(
+    (candidate) =>
+      candidate.isPersonal &&
+      candidate.ownerUserId === userId &&
+      !!candidate.projects?.[0],
+  );
+  const project = team?.projects?.[0];
+  return project ? { id: project.id, slug: project.slug } : null;
 }

--- a/specs/navigation/product-sidebars.feature
+++ b/specs/navigation/product-sidebars.feature
@@ -46,6 +46,22 @@ Feature: Product sidebars
     Then the sidebar shows the personal pages
     And the Govern group is not there
 
+  # A personal workspace belongs to one organization, so a reader in several
+  # organizations owns several of them. The Traces entry addresses one by
+  # project slug, and the header reads the organization back off that slug, so
+  # an entry pointing at the wrong workspace also switches the organization.
+  @integration
+  Scenario: The Me sidebar's Traces entry stays inside the selected organization
+    Given I own a personal workspace in more than one organization
+    When I am on a Me page with one of them selected
+    Then the Traces entry addresses that organization's personal workspace
+
+  @integration
+  Scenario: The Me sidebar offers no Traces entry without a personal workspace here
+    Given the selected organization holds no personal workspace of mine
+    When I am on a Me page
+    Then there is no Traces entry rather than one for another organization
+
   @integration
   Scenario: The Gateway sidebar promotes the gateway pages
     Given I am on a Gateway page

--- a/specs/navigation/product-sidebars.feature
+++ b/specs/navigation/product-sidebars.feature
@@ -56,11 +56,17 @@ Feature: Product sidebars
     When I am on a Me page with one of them selected
     Then the Traces entry addresses that organization's personal workspace
 
+  # Visiting a Me page creates the personal workspace in the selected
+  # organization if it is missing, but the payload the sidebar reads is
+  # already loaded and is not refetched, so the entry stays absent for the
+  # rest of the session. Absent is the wanted outcome either way: an entry
+  # addressing another organization's workspace would move the reader
+  # between organizations, which is the failure the scenario above pins.
   @integration
-  Scenario: The Me sidebar offers no Traces entry without a personal workspace here
-    Given the selected organization holds no personal workspace of mine
+  Scenario: The Me sidebar offers no Traces entry until it can see one here
+    Given the loaded organization holds no personal workspace of mine
     When I am on a Me page
-    Then there is no Traces entry rather than one for another organization
+    Then there is no Traces entry
 
   @integration
   Scenario: The Gateway sidebar promotes the gateway pages


### PR DESCRIPTION
## Why

A user who belongs to more than one organization owns a personal workspace in
each of them — `PersonalWorkspaceService.ensure` takes an `organizationId` and
creates one per organization. The Me sidebar's Traces entry did not say which
organization it was asking about, so it linked to whichever personal workspace
came first in an organization list the server sends unordered. Clicking it
navigated to another organization's personal project, and because the header
re-derives the organization from the project slug in the URL, the organization
in the chrome visibly flipped.

Cause: `platform/app/src/utils/personalProject.ts:23` looped every organization
and returned the first personal team owned by the user, with no organization
argument to constrain it.

Closes #7984

## What changed

`findPersonalProject` now takes a required `organizationId` and resolves only
within that organization. Both callers pass the organization the chrome has
resolved:

- `PersonalSidebar` — the Traces entry, and the library entries gated on the
  same project id, now address the selected organization's personal workspace.
  When the selected organization holds no personal workspace of the user's, no
  Traces entry renders at all, instead of one pointing somewhere else.
- `FirstTraceRedirect` (the `/cli/auth` first-trace watcher) — the CLI approval
  is granted against one organization and the personal workspace is ensured in
  that same one, so the watcher now polls that organization's personal project.

The parameter is required rather than optional on purpose: scanning every
organization is not a choice any caller means to make, and leaving it optional
would let a future caller re-introduce the defect silently.

One more thing came out of review on the CLI page. Naming the organization was
not enough on its own, because the value being named could still move: the
organization picker stays interactive while the approval request is in flight
(only Approve and Deny take the loading state), so a user who changes the
selection in that window had the approval go out for one organization and the
watcher poll another. The success card had the same hazard — it resolved the
organization name after the request returned, not from the id it sent.
`handleApprove` now captures the id once before the request and carries it in
the success state, so the card and the watcher both name the organization the
approval was actually granted against, and neither can be moved afterwards.

## How it works

In the sidebar the organization comes from `useOrganizationTeamProject`, which
already resolves it from the URL slug, then the remembered selection, then the
first organization. On the CLI page it comes from the approval itself: the id
sent to `/api/auth/cli/approve`, kept in the success state and passed down as a
prop. `cliAuthProjects` (the CLI project picker) already scoped its own
personal-workspace lookup this way — `organizations.find(o => o.id ===
selectedOrgId)` — so this brings the two remaining callers onto the same
footing rather than inventing a mechanism.

## Test plan

Two new suites, both written before the fix and watched fail.

`src/utils/__tests__/personalProject.unit.test.ts` — before the fix, 3 of 7
failed:

```
FAIL  findPersonalProject > given the user owns a personal project in more than one organization > resolves the personal project of the organization asked about
FAIL  findPersonalProject > given the organization asked about holds no personal project > resolves nothing rather than another organization's
  AssertionError: expected { id: 'proj-first', …(1) } to be null
FAIL  findPersonalProject > given no organization has been resolved yet > resolves nothing
  AssertionError: expected { id: 'proj-first', …(1) } to be null

Test Files  1 failed (1)
     Tests  3 failed | 4 passed (7)
```

`src/components/__tests__/PersonalSidebar.integration.test.tsx` — before the
fix, 2 of 4 failed, reproducing the reported symptom directly:

```
FAIL  PersonalSidebarLinks > given the user owns a personal workspace in several organizations > links Traces to the personal project of the selected organization
  AssertionError: expected '/personal-first/traces' to be '/personal-second/traces'
FAIL  PersonalSidebarLinks > given the loaded organization holds no personal workspace > renders no Traces entry
  AssertionError: expected '/personal-first/traces' to be null

Test Files  1 failed (1)
     Tests  2 failed | 2 passed (4)
```

`src/pages/cli/__tests__/cliAuthFirstTraceRedirect.integration.test.tsx` gained
one case for the in-flight organization change. It holds the approval request
open, clicks a different organization, releases the request, and asserts the
redirect lands on the approved organization's personal project. Before the fix
it redirected to the newly selected organization's project instead:

```
FAIL  /cli/auth first-trace watch > given the organization is changed while the approval is in flight > watches the approved organization, not the one now selected
  expected "push" to be called with [ '/personal-proj/traces' ]

Test Files  1 failed (1)
     Tests  1 failed | 3 passed (4)
```

After the fix:

```
src/utils/__tests__/personalProject.unit.test.ts      Tests  7 passed (7)
component lane, src/components/__tests__ + src/pages/cli/__tests__
                                          Test Files  43 passed (43)
                                               Tests  208 passed (208)
```

`cliAuthFirstTraceRedirect.integration.test.tsx` passes 4/4 with the changed
watcher, and `check-feature-parity` exits 0: both new `@integration` scenarios
carry a `@scenario` annotation on the test that covers them, which they did not
at first — the check was failing on exactly that.

Wider unit lane over `src/utils`, `src/hooks`, `src/components`, `src/pages/cli`:
3736 passed, 303 files. Two files fail to load in this worktree
(`dbOrganizationIdProtection.unit.test.ts`,
`useModelProviderApiKeyValidation.unit.test.ts`) — both on
`import { getLangWatchTracer } from "langwatch"`, the workspace SDK whose
`dist/` is not built locally. Neither touches this diff, and the same missing
build produces the only `typecheck:all` errors (`Cannot find module 'langwatch'`
and its knock-on implicit-anys). No typecheck error names any file in this
change. Biome is clean on all five files.

Spec: added two scenarios to `specs/navigation/product-sidebars.feature`
alongside the existing Me-sidebar rule, which is what the new component test
cites.

## Anything surprising?

**Swept, not fixed — organization ordering.**
`organization.prisma.repository.ts:718` (`getAllForUser`) runs `findMany` with
no `orderBy`, so "first organization" is whatever Postgres returns. That is what
made this bug's symptom non-deterministic, but it is a separate defect: with the
lookup scoped, sidebar behaviour no longer depends on that order at all. Adding
an `orderBy` changes which organization the chrome defaults to when nothing is
remembered, which deserves its own change. Recorded in #7984.

**Sweep result.** Every other client-side "find my personal team" site is
already scoped to a resolved organization or team — `useOrganizationTeamProject`
(`organization?.teams.find`), `cliAuthProjects` (`organizations.find(o => o.id
=== selectedOrgId)`), and the four hooks that read the singular already-resolved
`team` (`useShowLangy`, `useNavigationV2ShellState`, `DashboardPageBody`,
`usePersonalFeatureGate`). `useWorkspaceData` filters personal teams out
entirely and `WorkspaceSwitcher` keys its personal entries by `orgId`.
`findPersonalProject` was the only unscoped one.

**Not verified in a browser.** The component test asserts the rendered `href`,
which is the whole mechanism, but nobody clicked it in a running app.

**`FirstTraceRedirect` was a judgment call.** Making the parameter required
forced that call site to name an organization; the CLI approval flow ensures the
personal workspace against one specific organization, so the resolved one is the
right answer. If the intent there was ever "any personal project the user owns",
this changes behaviour for a multi-organization user — flagged rather than
assumed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Personal workspace links now consistently open the workspace for the currently selected organization.
  - The Traces sidebar entry no longer points to a workspace from another organization.
  - The Traces entry is hidden when the selected organization has no personal workspace.
  - CLI approval results and first-trace redirects remain tied to the organization approved during submission.

- **Tests**
  - Added coverage for organization-specific workspace selection, missing workspaces, organization switching, and stable CLI approval redirects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
