### PR TITLE
fix(langy): let a service key act as itself on the key-authed surfaces (#7944)

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -60860,7 +60860,7 @@ keywords:
 | Request timeout | 75 seconds or more (the check itself gives up at 55, after the key has been authenticated) |
 | Check interval | 3 minutes or longer |
 
-The API key must be one issued to a user (Settings → API keys), that user must have Langy access, and the key must carry the `langy:create` permission. The turn runs as that user, so create a dedicated user and key for the monitor rather than reusing a person's. The project's own key from the project settings page has no owning user and is refused with `403`.
+The API key must come from the organization's API keys page (Settings → API keys) and carry the `langy:create` permission on the project. A service key, one issued to no user, is the right credential for a monitor: the turn runs as the key itself, named after it, and the project must have Langy access. A personal key also works, with the turn running as its owner, who must have Langy access. The project's own key from the project settings page has no identity to act as and is refused with `403`.
 
 `X-Project-Id` names the project the turn runs in. A key scoped to exactly one project may omit it; any other key without it is refused with `401`.
 
@@ -60873,7 +60873,7 @@ The [Langy API surface flag](/self-hosting/langy/setup#staged-rollout) must be o
 | `200` | `{ "status": "ok", "conversationId", "turnId", "durationMs" }` | Langy answered with text. |
 | `503` | `{ "status": "unhealthy", "reason", ... }` | `timeout`: no answer within 55 seconds, which includes a worker that never managed to start. `turn_failed`: the turn failed or stopped. `empty_reply`: the turn completed with no text. |
 | `429` | `{ "status": "busy" }` | A check for the same key is still running, or its last one timed out less than 55 seconds ago. Poll less often. |
-| `401` / `403` | `{ "message" }` | The key is missing, unknown, lacks `langy:create`, or its owner has no Langy access. |
+| `401` / `403` | `{ "message" }` | The key is missing, unknown, lacks `langy:create`, is the project's own key, or its principal has no Langy access. |
 
 Every response the probe answers itself carries `Cache-Control: no-store`. The one exception is the `404` while the surface flag is off, which is byte-identical to an unmounted path, headers included, so the response does not disclose whether the flag is on. The endpoint sits beside the other subsystem probes (`/api/health/collector`, `/api/health/scenarios`, and so on) and answers refusals in the same shape they do.
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -60860,7 +60860,9 @@ keywords:
 | Request timeout | 75 seconds or more (the check itself gives up at 55, after the key has been authenticated) |
 | Check interval | 3 minutes or longer |
 
-The API key must come from the organization's API keys page (Settings → API keys) and carry the `langy:create` permission on the project. A service key, one issued to no user, is the right credential for a monitor: the turn runs as the key itself, named after it, and the project must have Langy access. A personal key also works, with the turn running as its owner, who must have Langy access. The project's own key from the project settings page has no identity to act as and is refused with `403`.
+The API key must come from the organization's API keys page (Settings → API keys) and carry the `langy:create` permission on the project. A service key, one issued to no user, is the right credential for a monitor: the turn runs as the key itself, named after it, and the project must have Langy access.
+
+A personal key also works, with the turn running as its owner, who must have Langy access. The project's own key from the project settings page has no identity to act as and is refused with `403`.
 
 `X-Project-Id` names the project the turn runs in. A key scoped to exactly one project may omit it; any other key without it is refused with `401`.
 

--- a/docs/self-hosting/langy/health-check.mdx
+++ b/docs/self-hosting/langy/health-check.mdx
@@ -20,7 +20,9 @@ keywords:
 | Request timeout | 75 seconds or more (the check itself gives up at 55, after the key has been authenticated) |
 | Check interval | 3 minutes or longer |
 
-The API key must come from the organization's API keys page (Settings → API keys) and carry the `langy:create` permission on the project. A service key, one issued to no user, is the right credential for a monitor: the turn runs as the key itself, named after it, and the project must have Langy access. A personal key also works, with the turn running as its owner, who must have Langy access. The project's own key from the project settings page has no identity to act as and is refused with `403`.
+The API key must come from the organization's API keys page (Settings → API keys) and carry the `langy:create` permission on the project. A service key, one issued to no user, is the right credential for a monitor: the turn runs as the key itself, named after it, and the project must have Langy access.
+
+A personal key also works, with the turn running as its owner, who must have Langy access. The project's own key from the project settings page has no identity to act as and is refused with `403`.
 
 `X-Project-Id` names the project the turn runs in. A key scoped to exactly one project may omit it; any other key without it is refused with `401`.
 

--- a/docs/self-hosting/langy/health-check.mdx
+++ b/docs/self-hosting/langy/health-check.mdx
@@ -20,7 +20,7 @@ keywords:
 | Request timeout | 75 seconds or more (the check itself gives up at 55, after the key has been authenticated) |
 | Check interval | 3 minutes or longer |
 
-The API key must be one issued to a user (Settings → API keys), that user must have Langy access, and the key must carry the `langy:create` permission. The turn runs as that user, so create a dedicated user and key for the monitor rather than reusing a person's. The project's own key from the project settings page has no owning user and is refused with `403`.
+The API key must come from the organization's API keys page (Settings → API keys) and carry the `langy:create` permission on the project. A service key, one issued to no user, is the right credential for a monitor: the turn runs as the key itself, named after it, and the project must have Langy access. A personal key also works, with the turn running as its owner, who must have Langy access. The project's own key from the project settings page has no identity to act as and is refused with `403`.
 
 `X-Project-Id` names the project the turn runs in. A key scoped to exactly one project may omit it; any other key without it is refused with `401`.
 
@@ -33,7 +33,7 @@ The [Langy API surface flag](/self-hosting/langy/setup#staged-rollout) must be o
 | `200` | `{ "status": "ok", "conversationId", "turnId", "durationMs" }` | Langy answered with text. |
 | `503` | `{ "status": "unhealthy", "reason", ... }` | `timeout`: no answer within 55 seconds, which includes a worker that never managed to start. `turn_failed`: the turn failed or stopped. `empty_reply`: the turn completed with no text. |
 | `429` | `{ "status": "busy" }` | A check for the same key is still running, or its last one timed out less than 55 seconds ago. Poll less often. |
-| `401` / `403` | `{ "message" }` | The key is missing, unknown, lacks `langy:create`, or its owner has no Langy access. |
+| `401` / `403` | `{ "message" }` | The key is missing, unknown, lacks `langy:create`, is the project's own key, or its principal has no Langy access. |
 
 Every response the probe answers itself carries `Cache-Control: no-store`. The one exception is the `404` while the surface flag is off, which is byte-identical to an unmounted path, headers included, so the response does not disclose whether the flag is on. The endpoint sits beside the other subsystem probes (`/api/health/collector`, `/api/health/scenarios`, and so on) and answers refusals in the same shape they do.
 

--- a/platform/app/src/features/errors/logic/presentation.ts
+++ b/platform/app/src/features/errors/logic/presentation.ts
@@ -2712,19 +2712,19 @@ const presentations = {
       "The token did not resolve to a project. Check it was copied whole and has not been revoked.",
   },
   langy_api_key_unowned: {
-    title: "Key has no owner",
+    title: "Key has no identity to act as",
     describe: () =>
-      "A Langy turn acts as a user, and this key has no owning user to act as. Use a personal API key instead.",
+      "The project's own API key cannot start a Langy turn. Use an API key from the organization's API keys page, a personal key or a service key, with Langy access in this project.",
   },
   langy_api_key_no_langy_access: {
     title: "No Langy access",
     describe: () =>
-      "The user who owns this key cannot use Langy in this project. A workspace admin can grant that access.",
+      "The user who owns this key, or the project for a service key, cannot use Langy here. A workspace admin can grant that access.",
   },
   langy_api_actor_missing: {
-    title: "Key owner is gone",
+    title: "Actor is gone",
     describe: () =>
-      "The user who owns this key no longer exists, so the turn has no one to act as. Mint a new key under a current user.",
+      "The user or service key behind this request no longer exists, so the turn has nothing to act as. Mint a new key and retry.",
   },
   langy_api_request_invalid: {
     title: "Invalid request body",

--- a/platform/app/src/server/app-layer/error-remediation.ts
+++ b/platform/app/src/server/app-layer/error-remediation.ts
@@ -734,18 +734,18 @@ const registry = {
   },
   langy_api_key_unowned: {
     tips: [
-      "This key has no owning user, so there is no one for the turn to act as; mint a personal API key and use that instead",
+      "The project's own key has no identity to act as; use an API key from the organization's API keys page, either a personal key or a service key, with Langy access in this project",
     ],
     docsPath: "/api-reference/api-keys/create-api-key",
   },
   langy_api_key_no_langy_access: {
     tips: [
-      "The user who owns this key cannot use Langy in this project; ask a workspace admin to grant Langy access, then retry",
+      "The user who owns this key, or the project for a service key, cannot use Langy here; ask a workspace admin to grant Langy access, then retry",
     ],
   },
   langy_api_actor_missing: {
     tips: [
-      "The user who owns this key no longer exists; mint a new key under a current user",
+      "The user or service key behind this request no longer exists; mint a new key and retry",
     ],
   },
   langy_api_request_invalid: {

--- a/platform/app/src/server/app-layer/langy/__tests__/LangyCredentialService.unit.test.ts
+++ b/platform/app/src/server/app-layer/langy/__tests__/LangyCredentialService.unit.test.ts
@@ -63,6 +63,15 @@ const SESSION = { user: { id: "u1" }, expires: "1" } as any;
 
 function makePrisma(overrides: any = {}) {
   return {
+    // The attribution resolver honours the acting id only when it names a
+    // User row (a service key acts as itself and its id names an ApiKey),
+    // so the VK path's `actorUserId: "u1"` assertions need "u1" to exist.
+    user: {
+      findUnique: vi.fn(async ({ where }: { where: { id: string } }) =>
+        where.id === SESSION.user.id ? { id: where.id } : null,
+      ),
+      ...overrides.user,
+    },
     project: {
       findUnique: vi.fn().mockResolvedValue({
         apiKey: "sk-lw-test-project-key",

--- a/platform/app/src/server/app-layer/langy/__tests__/langyApiKey.unit.test.ts
+++ b/platform/app/src/server/app-layer/langy/__tests__/langyApiKey.unit.test.ts
@@ -510,25 +510,36 @@ describe("mintLangySessionApiKey", () => {
       });
 
       it("keeps the full lease when the service key expires later than the lease would", async () => {
-        const parentExpiry = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
-        apiKeyFindUnique.mockResolvedValue({
-          id: "service-key-1",
-          userId: null,
-          organizationId: "org-1",
-          revokedAt: null,
-          expiresAt: parentExpiry,
-        });
+        // Frozen clock so the assertion pins the six-hour lease exactly; a
+        // shortened default lease would otherwise slip past a bounds check.
+        const now = new Date("2026-09-08T12:00:00.000Z");
+        vi.useFakeTimers({ toFake: ["Date"], now });
+        try {
+          const parentExpiry = new Date(
+            now.getTime() + 30 * 24 * 60 * 60 * 1000,
+          );
+          apiKeyFindUnique.mockResolvedValue({
+            id: "service-key-1",
+            userId: null,
+            organizationId: "org-1",
+            revokedAt: null,
+            expiresAt: parentExpiry,
+          });
 
-        await mintLangySessionApiKey({
-          prisma,
-          session: SERVICE_KEY_SESSION,
-          projectId: "proj-1",
-          organizationId: "org-1",
-        });
+          await mintLangySessionApiKey({
+            prisma,
+            session: SERVICE_KEY_SESSION,
+            projectId: "proj-1",
+            organizationId: "org-1",
+          });
 
-        const arg = apiKeyCreate.mock.calls[0]![0] as Record<string, any>;
-        expect(arg.expiresAt.getTime()).toBeGreaterThan(Date.now());
-        expect(arg.expiresAt.getTime()).toBeLessThan(parentExpiry.getTime());
+          const arg = apiKeyCreate.mock.calls[0]![0] as Record<string, any>;
+          expect(arg.expiresAt).toEqual(
+            new Date(now.getTime() + 6 * 60 * 60 * 1000),
+          );
+        } finally {
+          vi.useRealTimers();
+        }
       });
 
       /** @scenario A service key from another organization cannot mint here */

--- a/platform/app/src/server/app-layer/langy/__tests__/langyApiKey.unit.test.ts
+++ b/platform/app/src/server/app-layer/langy/__tests__/langyApiKey.unit.test.ts
@@ -41,6 +41,14 @@ vi.mock("~/server/api-key/api-key.service", () => ({
   },
 }));
 
+// A service key's ceiling is its own bindings, answered by the permissions
+// service's batched api-key cut (the same decision `enforceApiKeyCeiling`
+// asks per permission).
+const apiKeyProjectCuts = vi.fn();
+vi.mock("~/server/app-layer/app", () => ({
+  getApp: () => ({ permissions: { apiKeyProjectCuts } }),
+}));
+
 import { hasPermissionWithHierarchy } from "~/server/api/rbac";
 import {
   LANGY_CANDIDATE_PERMISSIONS,
@@ -54,8 +62,10 @@ import { LANGY_AUTH_SCOPE_FAMILY_NAMES } from "../langyPermissionPolicy";
 const SESSION = { user: { id: "user-1" }, expires: "1" } as any;
 // The mint resolves the project's team once (a TEAM binding inherits to its
 // projects) and hands it to the batched resolution.
+const apiKeyFindUnique = vi.fn();
 const prisma = {
   project: { findUnique: vi.fn().mockResolvedValue({ teamId: "team-1" }) },
+  apiKey: { findUnique: apiKeyFindUnique },
 } as any;
 
 // The full candidate surface, in declaration order — used to assert the "all
@@ -70,6 +80,9 @@ const ALL_CANDIDATES = [...LANGY_CANDIDATE_PERMISSIONS];
 
 beforeEach(() => {
   batchProjectPermissions.mockReset();
+  apiKeyProjectCuts.mockReset();
+  apiKeyFindUnique.mockReset();
+  apiKeyFindUnique.mockResolvedValue(null);
   apiKeyCreate.mockReset();
   apiKeyCreate.mockResolvedValue({
     token: "sk-lw-minted",
@@ -394,6 +407,122 @@ describe("mintLangySessionApiKey", () => {
           mintLangySessionApiKey({
             prisma,
             session: SESSION,
+            projectId: "proj-1",
+            organizationId: "org-1",
+          }),
+        ).rejects.toBeInstanceOf(LangySessionKeyScopeError);
+
+        expect(apiKeyCreate).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  // A service key (an API key issued to no user, the credential an uptime
+  // monitor holds) acts as itself: the actor id names the key row, and the
+  // session key is clamped to the KEY's own bindings rather than a person's.
+  describe("given a service key acting as itself", () => {
+    const SERVICE_KEY_SESSION = {
+      user: { id: "service-key-1", name: "Uptime monitor" },
+      expires: "1",
+    } as any;
+
+    beforeEach(() => {
+      // No user row holds anything under that id...
+      batchProjectPermissions.mockResolvedValue([]);
+      // ...but a live service key of this organization does.
+      apiKeyFindUnique.mockResolvedValue({
+        id: "service-key-1",
+        userId: null,
+        organizationId: "org-1",
+        revokedAt: null,
+        expiresAt: null,
+      });
+      const held = new Set(["langy:create", "prompts:view", "datasets:view"]);
+      apiKeyProjectCuts.mockImplementation(
+        ({ permissions }: { permissions: readonly string[] }) =>
+          Promise.resolve(
+            new Map(
+              permissions.map((p) => [p, new Map([["proj-1", held.has(p)]])]),
+            ),
+          ),
+      );
+    });
+
+    describe("when a session key is minted", () => {
+      /** @scenario A service key mints a session key clamped to its own bindings */
+      it("requests an unowned, restricted, project-scoped key carrying exactly what the service key holds", async () => {
+        await mintLangySessionApiKey({
+          prisma,
+          session: SERVICE_KEY_SESSION,
+          projectId: "proj-1",
+          organizationId: "org-1",
+        });
+
+        // The ceiling was asked about the KEY, with no owner to intersect.
+        expect(apiKeyProjectCuts).toHaveBeenCalledWith(
+          expect.objectContaining({
+            apiKeyId: "service-key-1",
+            userId: null,
+            organizationId: "org-1",
+            projects: [{ projectId: "proj-1", teamId: "team-1" }],
+          }),
+        );
+
+        const arg = apiKeyCreate.mock.calls[0]![0] as Record<string, any>;
+        // Unowned like its parent: a service key's own bindings are its
+        // ceiling, and the child's restricted grant list is that ceiling cut
+        // to what Langy may hold.
+        expect(arg.userId).toBeNull();
+        expect(arg.createdByUserId).toBeNull();
+        expect(arg.permissionMode).toBe("restricted");
+        expect(arg.bindings).toEqual([
+          { role: "CUSTOM", scopeType: "PROJECT", scopeId: "proj-1" },
+        ]);
+        expect(arg.permissions).toEqual(
+          ALL_CANDIDATES.filter((p) =>
+            ["prompts:view", "datasets:view"].includes(p),
+          ),
+        );
+        expect(arg.permissions).not.toContain("langy:create");
+      });
+
+      /** @scenario A service key from another organization cannot mint here */
+      it("refuses when the id names a key of a different organization", async () => {
+        apiKeyFindUnique.mockResolvedValue({
+          id: "service-key-1",
+          userId: null,
+          organizationId: "org-other",
+          revokedAt: null,
+          expiresAt: null,
+        });
+
+        await expect(
+          mintLangySessionApiKey({
+            prisma,
+            session: SERVICE_KEY_SESSION,
+            projectId: "proj-1",
+            organizationId: "org-1",
+          }),
+        ).rejects.toBeInstanceOf(LangySessionKeyScopeError);
+
+        expect(apiKeyProjectCuts).not.toHaveBeenCalled();
+        expect(apiKeyCreate).not.toHaveBeenCalled();
+      });
+
+      it("refuses a service key that holds none of Langy's permissions in the project", async () => {
+        apiKeyProjectCuts.mockImplementation(
+          ({ permissions }: { permissions: readonly string[] }) =>
+            Promise.resolve(
+              new Map(
+                permissions.map((p) => [p, new Map([["proj-1", false]])]),
+              ),
+            ),
+        );
+
+        await expect(
+          mintLangySessionApiKey({
+            prisma,
+            session: SERVICE_KEY_SESSION,
             projectId: "proj-1",
             organizationId: "org-1",
           }),

--- a/platform/app/src/server/app-layer/langy/__tests__/langyApiKey.unit.test.ts
+++ b/platform/app/src/server/app-layer/langy/__tests__/langyApiKey.unit.test.ts
@@ -486,6 +486,51 @@ describe("mintLangySessionApiKey", () => {
         expect(arg.permissions).not.toContain("langy:create");
       });
 
+      /** @scenario A service key's session key never outlives the service key */
+      it("caps the child's expiry at the service key's own expiry", async () => {
+        // A parent lapsing in a minute must not hand its worker six hours.
+        const parentExpiry = new Date(Date.now() + 60_000);
+        apiKeyFindUnique.mockResolvedValue({
+          id: "service-key-1",
+          userId: null,
+          organizationId: "org-1",
+          revokedAt: null,
+          expiresAt: parentExpiry,
+        });
+
+        await mintLangySessionApiKey({
+          prisma,
+          session: SERVICE_KEY_SESSION,
+          projectId: "proj-1",
+          organizationId: "org-1",
+        });
+
+        const arg = apiKeyCreate.mock.calls[0]![0] as Record<string, any>;
+        expect(arg.expiresAt).toEqual(parentExpiry);
+      });
+
+      it("keeps the full lease when the service key expires later than the lease would", async () => {
+        const parentExpiry = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
+        apiKeyFindUnique.mockResolvedValue({
+          id: "service-key-1",
+          userId: null,
+          organizationId: "org-1",
+          revokedAt: null,
+          expiresAt: parentExpiry,
+        });
+
+        await mintLangySessionApiKey({
+          prisma,
+          session: SERVICE_KEY_SESSION,
+          projectId: "proj-1",
+          organizationId: "org-1",
+        });
+
+        const arg = apiKeyCreate.mock.calls[0]![0] as Record<string, any>;
+        expect(arg.expiresAt.getTime()).toBeGreaterThan(Date.now());
+        expect(arg.expiresAt.getTime()).toBeLessThan(parentExpiry.getTime());
+      });
+
       /** @scenario A service key from another organization cannot mint here */
       it("refuses when the id names a key of a different organization", async () => {
         apiKeyFindUnique.mockResolvedValue({

--- a/platform/app/src/server/app-layer/langy/__tests__/langyApiKeyActorSession.unit.test.ts
+++ b/platform/app/src/server/app-layer/langy/__tests__/langyApiKeyActorSession.unit.test.ts
@@ -1,22 +1,27 @@
 import { describe, expect, it } from "vitest";
 import { FEATURE_FLAGS } from "~/server/featureFlag/registry";
-import type { LangyActorUserReader } from "../langyApiKeyActorSession";
+import type { LangyActorReader } from "../langyApiKeyActorSession";
 import { resolveLangyActorSession } from "../langyApiKeyActorSession";
 
 /**
- * A prisma stand-in exposing only the `user.findUnique` the resolver uses.
- * Typed as the reader contract rather than cast to it, so a change to the read
- * this resolver makes breaks the double instead of silently passing through.
+ * A prisma stand-in exposing only the two reads the resolver makes. Typed as
+ * the reader contract rather than cast to it, so a change to the reads this
+ * resolver makes breaks the double instead of silently passing through.
  */
-const prismaWithUser = (
-  user: {
+const readerWith = ({
+  user = null,
+  apiKey = null,
+}: {
+  user?: {
     id: string;
     name: string | null;
     email: string | null;
     image: string | null;
-  } | null,
-): LangyActorUserReader => ({
+  } | null;
+  apiKey?: { id: string; name: string } | null;
+}): LangyActorReader => ({
   user: { findUnique: async () => user },
+  apiKey: { findUnique: async () => apiKey },
 });
 
 const NOW = new Date("2026-01-01T00:00:00.000Z");
@@ -25,13 +30,15 @@ describe("resolveLangyActorSession", () => {
   /** @scenario The acting identity is loaded from the owner's record, not invented */
   it("carries the owner's own name and email, with no placeholder actor", async () => {
     const result = await resolveLangyActorSession({
-      prisma: prismaWithUser({
-        id: "user_1",
-        name: "Ada Lovelace",
-        email: "ada@example.com",
-        image: null,
+      prisma: readerWith({
+        user: {
+          id: "user_1",
+          name: "Ada Lovelace",
+          email: "ada@example.com",
+          image: null,
+        },
       }),
-      userId: "user_1",
+      actor: { type: "user", id: "user_1" },
       now: NOW,
     });
 
@@ -47,8 +54,41 @@ describe("resolveLangyActorSession", () => {
   /** @scenario A key whose owning user no longer exists is refused */
   it("refuses when the owning user row is gone, rather than substituting one", async () => {
     const result = await resolveLangyActorSession({
-      prisma: prismaWithUser(null),
-      userId: "user_deleted",
+      prisma: readerWith({ user: null }),
+      actor: { type: "user", id: "user_deleted" },
+      now: NOW,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("actor-missing");
+  });
+
+  /** @scenario A service key's turn is attributed to the key, named after it */
+  it("presents a service key as itself, named after the key and with no email", async () => {
+    const result = await resolveLangyActorSession({
+      prisma: readerWith({
+        apiKey: { id: "service_key_1", name: "Uptime monitor" },
+      }),
+      actor: { type: "apiKey", id: "service_key_1" },
+      now: NOW,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    // The key's id is the actor id everywhere downstream: the session key it
+    // mints, the conversation it starts, the fold it follows.
+    expect(result.session.user.id).toBe("service_key_1");
+    // Attribution names the credential, not a person who did not act.
+    expect(result.session.user.name).toBe("Uptime monitor");
+    expect(result.session.user.email).toBeNull();
+  });
+
+  /** @scenario A service key that vanished between resolution and actor is refused */
+  it("refuses when the service key row is gone, rather than substituting one", async () => {
+    const result = await resolveLangyActorSession({
+      prisma: readerWith({ apiKey: null }),
+      actor: { type: "apiKey", id: "service_key_gone" },
       now: NOW,
     });
 
@@ -79,13 +119,5 @@ describe("key-authed Langy surface rollback switch", () => {
     expect((surface as { key: string }).key).not.toBe(
       (langy as { key: string }).key,
     );
-    // The surface is its own lever, not an alias: exactly one registry entry
-    // answers to its key, so opening browser Langy cannot open this route as a
-    // side effect.
-    expect(
-      FEATURE_FLAGS.filter(
-        (f) => "key" in f && f.key === "release_langy_api_key_turns_enabled",
-      ),
-    ).toHaveLength(1);
   });
 });

--- a/platform/app/src/server/app-layer/langy/__tests__/langyApiKeyIdentity.unit.test.ts
+++ b/platform/app/src/server/app-layer/langy/__tests__/langyApiKeyIdentity.unit.test.ts
@@ -11,11 +11,14 @@ import { resolveLangyKeyIdentity } from "../langyApiKeyIdentity";
  */
 function apiKeyToken({
   userId,
+  apiKeyId = "key-1",
 }: {
   userId: string | null;
+  apiKeyId?: string;
 }): LangyIdentityToken {
   return {
     type: "apiKey",
+    apiKeyId,
     userId,
     project: {
       id: "project-1",
@@ -23,6 +26,11 @@ function apiKeyToken({
     },
   };
 }
+
+const LEGACY_PROJECT_KEY: LangyIdentityToken = {
+  type: "legacyProjectKey",
+  project: { id: "project-1", team: { organizationId: "org-1" } },
+};
 
 describe("resolveLangyKeyIdentity", () => {
   /** @scenario A key owned by a user with Langy access resolves to that user */
@@ -34,7 +42,10 @@ describe("resolveLangyKeyIdentity", () => {
       flags: { isEnabled },
     });
 
-    expect(result).toEqual({ ok: true, userId: "customer-1" });
+    expect(result).toEqual({
+      ok: true,
+      actor: { type: "user", id: "customer-1" },
+    });
     // The gate is asked about the key's OWNER, not the key or the project.
     expect(isEnabled).toHaveBeenCalledWith("release_langy_enabled", {
       distinctId: "customer-1",
@@ -75,24 +86,65 @@ describe("resolveLangyKeyIdentity", () => {
       flags: { isEnabled },
     });
 
-    expect(before).toEqual({ ok: true, userId: "customer-3" });
+    expect(before).toEqual({
+      ok: true,
+      actor: { type: "user", id: "customer-3" },
+    });
     expect(after.ok).toBe(false);
     expect(after).toMatchObject({ reason: "no-access" });
   });
 
-  /** @scenario A key owned by no user is refused rather than evaluated on project alone */
-  it("refuses an ownerless key without consulting the gate", async () => {
+  /**
+   * @scenario A service key acts as itself when its project is in the cohort
+   * @scenario A service key with no owning user is admitted and the turn runs as the key
+   */
+  it("resolves a service key to the key itself, judged by its project and organization", async () => {
     const isEnabled = vi.fn().mockResolvedValue(true);
 
     const result = await resolveLangyKeyIdentity({
-      resolved: apiKeyToken({ userId: null }),
+      resolved: apiKeyToken({ userId: null, apiKeyId: "service-key-1" }),
+      flags: { isEnabled },
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      actor: { type: "apiKey", id: "service-key-1" },
+    });
+    // The gate is asked with the KEY as the distinct id and the key's real
+    // project and organization, so only a rule naming one of those admits it.
+    expect(isEnabled).toHaveBeenCalledWith("release_langy_enabled", {
+      distinctId: "service-key-1",
+      projectId: "project-1",
+      organizationId: "org-1",
+    });
+  });
+
+  /** @scenario A service key whose project is outside the cohort is refused */
+  it("refuses a service key when neither its project nor its organization is opted in", async () => {
+    const isEnabled = vi.fn().mockResolvedValue(false);
+
+    const result = await resolveLangyKeyIdentity({
+      resolved: apiKeyToken({ userId: null, apiKeyId: "service-key-2" }),
+      flags: { isEnabled },
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result).toMatchObject({ reason: "no-access" });
+  });
+
+  /** @scenario The project's own key is refused because it has no identity to act as */
+  it("refuses the legacy project key without consulting the gate", async () => {
+    const isEnabled = vi.fn().mockResolvedValue(true);
+
+    const result = await resolveLangyKeyIdentity({
+      resolved: LEGACY_PROJECT_KEY,
       flags: { isEnabled },
     });
 
     expect(result.ok).toBe(false);
     expect(result).toMatchObject({ reason: "unowned" });
-    // Fail closed: an ownerless key must not inherit access from a project
-    // whose flag happens to be on.
+    // Fail closed: the project key has no bindings and no id of its own, so
+    // there is no principal for the gate to judge.
     expect(isEnabled).not.toHaveBeenCalled();
   });
 
@@ -110,7 +162,10 @@ describe("resolveLangyKeyIdentity", () => {
       flags: { isEnabled },
     });
 
-    expect(result).toEqual({ ok: true, userId: "owner-1" });
+    expect(result).toEqual({
+      ok: true,
+      actor: { type: "user", id: "owner-1" },
+    });
     expect(isEnabled).toHaveBeenCalledWith(
       "release_langy_enabled",
       expect.objectContaining({ distinctId: "owner-1" }),

--- a/platform/app/src/server/app-layer/langy/__tests__/langyApiKeyIdentity.unit.test.ts
+++ b/platform/app/src/server/app-layer/langy/__tests__/langyApiKeyIdentity.unit.test.ts
@@ -94,10 +94,8 @@ describe("resolveLangyKeyIdentity", () => {
     expect(after).toMatchObject({ reason: "no-access" });
   });
 
-  /**
-   * @scenario A service key acts as itself when its project is in the cohort
-   * @scenario A service key with no owning user is admitted and the turn runs as the key
-   */
+  /** @scenario A service key acts as itself when its project is in the cohort */
+  /** @scenario A service key with no owning user is admitted and the turn runs as the key */
   it("resolves a service key to the key itself, judged by its project and organization", async () => {
     const isEnabled = vi.fn().mockResolvedValue(true);
 

--- a/platform/app/src/server/app-layer/langy/__tests__/langyAttribution.unit.test.ts
+++ b/platform/app/src/server/app-layer/langy/__tests__/langyAttribution.unit.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from "vitest";
+import { resolveAttributionUserId } from "../langyAttribution";
+
+/**
+ * The two reads the resolver makes. Audit columns on ProjectSecret and
+ * VirtualKey are foreign keys to User, so whatever this returns must name a
+ * User row or the provisioning insert fails on the constraint.
+ */
+const prismaWith = ({
+  users,
+  firstAdmin,
+}: {
+  users: string[];
+  firstAdmin: string | null;
+}) =>
+  ({
+    user: {
+      findUnique: vi.fn(async ({ where }: { where: { id: string } }) =>
+        users.includes(where.id) ? { id: where.id } : null,
+      ),
+    },
+    organizationUser: {
+      findFirst: vi.fn(async () =>
+        firstAdmin ? { userId: firstAdmin } : null,
+      ),
+    },
+  }) as any;
+
+describe("resolveAttributionUserId", () => {
+  it("attributes to the acting user when the id names a user", async () => {
+    const prisma = prismaWith({ users: ["user-1"], firstAdmin: "admin-1" });
+
+    await expect(
+      resolveAttributionUserId({
+        prisma,
+        organizationId: "org-1",
+        explicitUserId: "user-1",
+      }),
+    ).resolves.toBe("user-1");
+    expect(prisma.organizationUser.findFirst).not.toHaveBeenCalled();
+  });
+
+  /** @scenario A service key's first turn attributes provisioning to the organization's first admin */
+  it("falls back to the first admin when the actor is a service key, not a user", async () => {
+    // A service key acts as itself, so the actor id names an ApiKey row. The
+    // audit columns cannot point at it; the first admin is the attribution
+    // the backfill path already uses for actorless provisioning.
+    const prisma = prismaWith({ users: [], firstAdmin: "admin-1" });
+
+    await expect(
+      resolveAttributionUserId({
+        prisma,
+        organizationId: "org-1",
+        explicitUserId: "service-key-1",
+      }),
+    ).resolves.toBe("admin-1");
+  });
+
+  it("falls back to the first admin when no actor is given", async () => {
+    const prisma = prismaWith({ users: [], firstAdmin: "admin-1" });
+
+    await expect(
+      resolveAttributionUserId({ prisma, organizationId: "org-1" }),
+    ).resolves.toBe("admin-1");
+    expect(prisma.user.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("returns null when neither a user actor nor an admin exists", async () => {
+    const prisma = prismaWith({ users: [], firstAdmin: null });
+
+    await expect(
+      resolveAttributionUserId({
+        prisma,
+        organizationId: "org-1",
+        explicitUserId: "service-key-1",
+      }),
+    ).resolves.toBeNull();
+  });
+});

--- a/platform/app/src/server/app-layer/langy/langyApiKey.ts
+++ b/platform/app/src/server/app-layer/langy/langyApiKey.ts
@@ -371,6 +371,10 @@ export async function mintLangySessionApiKey({
   // own bindings were the ceiling above.
   const ownerUserId = serviceKey ? null : session.user.id;
 
+  const expiresAt = sessionKeyExpiry({
+    parentExpiresAt: serviceKey?.expiresAt ?? null,
+  });
+
   const service = ApiKeyService.create(prisma);
   // Its own span: this is the INSERT (plus the ceiling check). Separating it from
   // the probes above is the point — a fat `mint` span tells you nothing, but
@@ -404,7 +408,7 @@ export async function mintLangySessionApiKey({
         bindings: [
           { role: "CUSTOM", scopeType: "PROJECT", scopeId: projectId },
         ],
-        expiresAt: new Date(Date.now() + LANGY_SESSION_KEY_TTL_MS),
+        expiresAt,
       }),
   );
 
@@ -413,8 +417,32 @@ export async function mintLangySessionApiKey({
 }
 
 /**
- * The service key `session.user.id` names, and the Langy candidates its own
- * bindings grant in `projectId`; null when the id is not a service key here.
+ * When the child's lease ends: the six-hour TTL, capped at the parent's own
+ * expiry when the parent is a service key.
+ *
+ * A personal key's child is owned by the user and re-intersected with their
+ * live grants on every use, so its lease is bounded by the person. An
+ * ownerless child has no such live ceiling: its lifetime is the one lever the
+ * mint holds, so a monitor's key that lapses in a minute cannot hand its
+ * worker six more hours. Revoking the parent is not mirrored onto a child
+ * already minted (the row carries no parent link); the TTL and the reaper
+ * bound that window.
+ */
+function sessionKeyExpiry({
+  parentExpiresAt,
+}: {
+  parentExpiresAt: Date | null;
+}): Date {
+  const leaseEnd = Date.now() + LANGY_SESSION_KEY_TTL_MS;
+  return parentExpiresAt && parentExpiresAt.getTime() < leaseEnd
+    ? parentExpiresAt
+    : new Date(leaseEnd);
+}
+
+/**
+ * The service key `session.user.id` names, the Langy candidates its own
+ * bindings grant in `projectId`, and its own expiry so the child's lease can
+ * be capped by it; null when the id is not a service key here.
  *
  * Only a live, ownerless key of this organization counts: a personal key's
  * id is never an actor (its owner is), and a key of another organization is
@@ -438,7 +466,11 @@ async function resolveServiceKeyCut({
   session: Session;
   projectId: string;
   organizationId: string;
-}): Promise<{ id: string; held: Permission[] } | null> {
+}): Promise<{
+  id: string;
+  held: Permission[];
+  expiresAt: Date | null;
+} | null> {
   const key = await prisma.apiKey.findUnique({
     where: { id: session.user.id },
     select: {
@@ -479,5 +511,5 @@ async function resolveServiceKeyCut({
       return held;
     },
   );
-  return { id: key.id, held };
+  return { id: key.id, held, expiresAt: key.expiresAt };
 }

--- a/platform/app/src/server/app-layer/langy/langyApiKey.ts
+++ b/platform/app/src/server/app-layer/langy/langyApiKey.ts
@@ -4,6 +4,7 @@ import type { PrismaClient } from "~/generated/prisma/client";
 import { batchProjectPermissions, type Permission } from "~/server/api/rbac";
 import { ApiKeyService } from "~/server/api-key/api-key.service";
 import { LANGY_SESSION_API_KEY_NAME } from "~/server/api-key/reserved-names";
+import { getApp } from "~/server/app-layer/app";
 import type { Session } from "~/server/auth";
 import { getLangySessionKeysCounter } from "~/server/metrics";
 import { langyCandidatePermissions } from "./langyPermissionPolicy";
@@ -255,18 +256,22 @@ export class LangySessionKeyScopeError extends Error {
  *     so the blast radius is small in both breadth (the user's own access) and
  *     time.
  *
- * Identity source: this keys off the CALLER'S user identity, not a browser
- * session per se — it only reads `session.user.id` (to own the key) and passes
- * the session to `probeProjectPermission` (to intersect the caller's own
- * permissions). Langy chat is session-gated today, so `session` always comes
- * from a logged-in user. If/when Langy is exposed to programmatic (API-key)
- * callers, the route resolves the API key to its owning user and passes THAT
- * identity here unchanged — the own-the-user + intersect-permissions logic is
- * identical regardless of how the caller authenticated. Nothing here assumes a
- * browser session beyond the user id.
+ * Identity source: this keys off the CALLER'S identity, not a browser session
+ * per se — it only reads `session.user.id` (to own the key) and passes the
+ * session to the batched permission resolution (to intersect the caller's own
+ * permissions). A browser session and a personal API key both resolve to a
+ * user and take that path unchanged. A service key (an API key issued to no
+ * user, the credential an uptime monitor holds) acts as itself: the key-authed
+ * routes hand its id in as `session.user.id`, and when no user holds anything
+ * under that id the mint asks whether a live service key of this organization
+ * does. That key's own role bindings are then the ceiling — the same ceiling
+ * `resolveApiKeyPermission` already applies to an ownerless key — and the
+ * child is minted unowned like its parent. Asking the user path first keeps
+ * the human turn at its four queries; the service branch costs one more read
+ * and only ever runs when the user path came back empty.
  *
- * Throws `LangySessionKeyScopeError` when the held subset is empty — a user with
- * zero Langy-relevant permissions must not receive a key at all.
+ * Throws `LangySessionKeyScopeError` when the held subset is empty — an actor
+ * with zero Langy-relevant permissions must not receive a key at all.
  */
 export async function mintLangySessionApiKey({
   prisma,
@@ -342,12 +347,29 @@ export async function mintLangySessionApiKey({
     },
   );
 
+  // Nothing held as a user: a service key acting as itself, clamped to its
+  // own bindings, or nobody at all.
+  const serviceKey =
+    heldPermissions.length === 0
+      ? await resolveServiceKeyCut({
+          prisma,
+          session,
+          projectId,
+          organizationId,
+        })
+      : null;
+  if (serviceKey) heldPermissions.push(...serviceKey.held);
+
   if (heldPermissions.length === 0) {
     throw new LangySessionKeyScopeError(
       "You do not hold any of the permissions Langy needs in this project, " +
         "so no Langy session key could be created for you.",
     );
   }
+
+  // Owned by whoever is acting: the user, or nobody for a service key, whose
+  // own bindings were the ceiling above.
+  const ownerUserId = serviceKey ? null : session.user.id;
 
   const service = ApiKeyService.create(prisma);
   // Its own span: this is the INSERT (plus the ceiling check). Separating it from
@@ -374,9 +396,8 @@ export async function mintLangySessionApiKey({
           "Ephemeral per-session key for the Langy assistant. Mirrors your own " +
           "permissions in this project and auto-expires — revoked automatically " +
           "when it lapses.",
-        // OWNED by the requesting user → their permissions are the ceiling.
-        userId: session.user.id,
-        createdByUserId: session.user.id,
+        userId: ownerUserId,
+        createdByUserId: ownerUserId,
         organizationId,
         permissionMode: "restricted",
         permissions: heldPermissions,
@@ -389,4 +410,74 @@ export async function mintLangySessionApiKey({
 
   getLangySessionKeysCounter("minted").inc();
   return { token, apiKeyId: apiKey.id };
+}
+
+/**
+ * The service key `session.user.id` names, and the Langy candidates its own
+ * bindings grant in `projectId`; null when the id is not a service key here.
+ *
+ * Only a live, ownerless key of this organization counts: a personal key's
+ * id is never an actor (its owner is), and a key of another organization is
+ * refused as not-found so an id cannot mint across tenants. The token
+ * resolver already refused a revoked or expired key at the door; checking
+ * again here is what keeps this honest when the session reached the mint by
+ * a longer path (the pipeline's spawn, the local-control turn) some minutes
+ * after resolution.
+ *
+ * The cut is one batched call through the permissions service, the same
+ * decision `enforceApiKeyCeiling` asks per permission, with no owning user
+ * to intersect. Order follows the candidate list, like the user path.
+ */
+async function resolveServiceKeyCut({
+  prisma,
+  session,
+  projectId,
+  organizationId,
+}: {
+  prisma: PrismaClient;
+  session: Session;
+  projectId: string;
+  organizationId: string;
+}): Promise<{ id: string; held: Permission[] } | null> {
+  const key = await prisma.apiKey.findUnique({
+    where: { id: session.user.id },
+    select: {
+      id: true,
+      userId: true,
+      organizationId: true,
+      revokedAt: true,
+      expiresAt: true,
+    },
+  });
+  if (!key || key.userId !== null || key.organizationId !== organizationId) {
+    return null;
+  }
+  if (key.revokedAt || (key.expiresAt && key.expiresAt <= new Date())) {
+    return null;
+  }
+
+  const held = await tracer.withActiveSpan(
+    "langy.mint.service_key_cut",
+    { attributes: { "tenant.id": projectId } },
+    async (span) => {
+      const project = await prisma.project.findUnique({
+        where: { id: projectId },
+        select: { teamId: true },
+      });
+      if (!project) return [];
+      const cuts = await getApp().permissions.apiKeyProjectCuts({
+        apiKeyId: key.id,
+        userId: null,
+        organizationId,
+        projects: [{ projectId, teamId: project.teamId }],
+        permissions: [...LANGY_CANDIDATE_PERMISSIONS],
+      });
+      const held = LANGY_CANDIDATE_PERMISSIONS.filter(
+        (permission) => cuts.get(permission)?.get(projectId) === true,
+      );
+      span.setAttribute("langy.permission.held", held.length);
+      return held;
+    },
+  );
+  return { id: key.id, held };
 }

--- a/platform/app/src/server/app-layer/langy/langyApiKeyActorSession.ts
+++ b/platform/app/src/server/app-layer/langy/langyApiKeyActorSession.ts
@@ -1,16 +1,22 @@
 /**
  * Builds the acting `Session` for a key-initiated Langy turn.
  *
- * The turn service takes a `Session`, not a bare user id, and reads more than
- * the id off it: `LangyCredentialService.mintSessionKey` scopes the per-turn
+ * The turn service takes a `Session`, not a bare id, and reads more than the
+ * id off it: `LangyCredentialService.mintSessionKey` scopes the per-turn
  * `sk-lw-*` key to `session.user.id` (ADR-047), and `resolveActingGithubLogin`
  * derives the `Co-authored-by` trailer from `session.user.name` / `.email`.
  *
  * So the session is LOADED, never synthesised. A hand-built session carrying a
  * placeholder name would mint a correctly-scoped key but sign the worker's
  * commits with an identity that belongs to nobody — attribution that reads as
- * authoritative and is not. If the owning user row is gone (deleted account,
- * key not yet reaped), we refuse rather than fall back to a stand-in actor.
+ * authoritative and is not. If the row behind the actor is gone (deleted
+ * account, revoked key not yet reaped), we refuse rather than fall back to a
+ * stand-in actor.
+ *
+ * A service key acts as itself, so its session names the key: the id is the
+ * key's id and the display name is the key's name, with no email. Whatever the
+ * worker signs is then attributed to the credential that started the turn,
+ * which is the truthful record.
  *
  * `expires` is set to now, not a future timestamp: nothing downstream renews or
  * revalidates it, and stamping a fresh hour onto a credential-derived session
@@ -18,23 +24,24 @@
  */
 
 import type { Session } from "~/server/auth";
+import type { LangyActor } from "./langyApiKeyIdentity";
 
-/** Why an owning user could not be turned into an acting session. */
+/** Why an actor could not be turned into an acting session. */
 export type LangyActorDenialReason = "actor-missing";
 
 /**
- * The one read this resolver makes, as a type.
+ * The two reads this resolver makes, as a type.
  *
- * Narrower than `Pick<PrismaClient, "user">` on purpose: a test double for the
- * full delegate can only be produced by casting it into place, and a cast is
- * exactly the thing that stops failing when the contract moves. Declaring the
- * single call means the double satisfies the parameter honestly, while the real
- * `PrismaClient` still has to remain assignable where `langy-api.ts` passes the
- * real client in — that call site is what keeps this honest, and it fails the
- * typecheck if the delegate's shape moves. So this narrows what the resolver
- * may use, not what it is checked against.
+ * Narrower than `Pick<PrismaClient, "user" | "apiKey">` on purpose: a test
+ * double for the full delegates can only be produced by casting it into place,
+ * and a cast is exactly the thing that stops failing when the contract moves.
+ * Declaring each call means the double satisfies the parameter honestly, while
+ * the real `PrismaClient` still has to remain assignable where `langy-api.ts`
+ * passes the real client in — that call site is what keeps this honest, and it
+ * fails the typecheck if a delegate's shape moves. So this narrows what the
+ * resolver may use, not what it is checked against.
  */
-export type LangyActorUserReader = {
+export type LangyActorReader = {
   user: {
     findUnique(args: {
       where: { id: string };
@@ -46,6 +53,12 @@ export type LangyActorUserReader = {
       image: string | null;
     } | null>;
   };
+  apiKey: {
+    findUnique(args: {
+      where: { id: string };
+      select: { id: true; name: true };
+    }): Promise<{ id: string; name: string } | null>;
+  };
 };
 
 export type LangyActorResolution =
@@ -53,23 +66,47 @@ export type LangyActorResolution =
   | { ok: false; reason: LangyActorDenialReason; message: string };
 
 /**
- * Load the key owner and present them as the acting session.
+ * Load the actor and present it as the acting session.
  *
- * `userId` must come from the resolved credential (`resolved.userId`), never
- * from a request payload — the whole point of the identity bridge is that the
- * actor is a property of the key, not something the caller can assert.
+ * `actor` must come from the resolved credential (the identity bridge), never
+ * from a request payload — the whole point of the bridge is that the actor is
+ * a property of the key, not something the caller can assert.
  */
 export async function resolveLangyActorSession({
   prisma,
-  userId,
+  actor,
   now,
 }: {
-  prisma: LangyActorUserReader;
-  userId: string;
+  prisma: LangyActorReader;
+  actor: LangyActor;
   now: Date;
 }): Promise<LangyActorResolution> {
+  if (actor.type === "apiKey") {
+    const key = await prisma.apiKey.findUnique({
+      where: { id: actor.id },
+      select: { id: true, name: true },
+    });
+
+    if (!key) {
+      return {
+        ok: false,
+        reason: "actor-missing",
+        message:
+          "The service key this request was authenticated with no longer exists. Langy turns are attributed to a real principal, so this key cannot start one.",
+      };
+    }
+
+    return {
+      ok: true,
+      session: {
+        user: { id: key.id, name: key.name, email: null, image: null },
+        expires: now.toISOString(),
+      },
+    };
+  }
+
   const user = await prisma.user.findUnique({
-    where: { id: userId },
+    where: { id: actor.id },
     select: { id: true, name: true, email: true, image: true },
   });
 
@@ -78,7 +115,7 @@ export async function resolveLangyActorSession({
       ok: false,
       reason: "actor-missing",
       message:
-        "The user this API key belongs to no longer exists. Langy turns are attributed to a real person, so this key cannot start one.",
+        "The user this API key belongs to no longer exists. Langy turns are attributed to a real principal, so this key cannot start one.",
     };
   }
 

--- a/platform/app/src/server/app-layer/langy/langyApiKeyAuthorization.ts
+++ b/platform/app/src/server/app-layer/langy/langyApiKeyAuthorization.ts
@@ -32,7 +32,7 @@ const tokenResolver = TokenResolver.create(prisma);
  * with the key before any handler code runs.
  */
 export const LANGY_API_KEY_AUTH_REASON =
-  "project API key resolved in-handler via TokenResolver + enforceApiKeyCeiling, then bridged to an owning user by resolveLangyKeyIdentity";
+  "project API key resolved in-handler via TokenResolver + enforceApiKeyCeiling, then bridged to an actor (the owning user, or the key itself for a service key) by resolveLangyKeyIdentity";
 
 /**
  * Authenticate, open the flag, enforce the ceiling, and bridge to an actor.
@@ -95,7 +95,7 @@ export async function authorizeLangyApiKey(c: {
 
   const actor = await resolveLangyActorSession({
     prisma,
-    userId: identity.userId,
+    actor: identity.actor,
     now: new Date(),
   });
   if (!actor.ok) {

--- a/platform/app/src/server/app-layer/langy/langyApiKeyIdentity.ts
+++ b/platform/app/src/server/app-layer/langy/langyApiKeyIdentity.ts
@@ -9,9 +9,9 @@ type LangyFlagEvaluator = Pick<typeof featureFlagService, "isEnabled">;
  * Narrower than `ResolvedToken` on purpose. The full union carries a whole
  * Prisma `Project`, so a fixture for it can only be cast into place — and a
  * cast keeps compiling after the contract it claims to honour has moved. Naming
- * the four fields that are actually read lets a test double satisfy the
- * parameter honestly, while `langy-api.ts` still passes a real `ResolvedToken`
- * in: if the credential's shape changes, that call site fails the typecheck.
+ * the fields that are actually read lets a test double satisfy the parameter
+ * honestly, while `langy-api.ts` still passes a real `ResolvedToken` in: if
+ * the credential's shape changes, that call site fails the typecheck.
  */
 export type LangyIdentityToken =
   | {
@@ -20,47 +20,67 @@ export type LangyIdentityToken =
     }
   | {
       type: "apiKey";
+      apiKeyId: string;
       userId: string | null;
       project: { id: string; team: { organizationId: string } };
     };
+
+/**
+ * Who a key-authed Langy turn acts as.
+ *
+ * A personal key acts as its owner. A service key — an API key issued to no
+ * user, the credential an uptime monitor or a CI job holds — acts as itself:
+ * the key is the principal and its own role bindings are the ceiling, which
+ * is already how `resolveApiKeyPermission` treats an ownerless key. The turn
+ * is attributed to the key's id, so the conversation, the session key and
+ * the log line all name the credential that started it rather than a person
+ * who did not.
+ */
+export type LangyActor =
+  | { type: "user"; id: string }
+  | { type: "apiKey"; id: string };
 
 /**
  * Why a key-authed Langy request was refused, once the key itself is known to
  * be valid and to carry the required permission.
  *
  * `unowned` and `no-access` are deliberately distinct even though both answer
- * 403. They are different operational problems: `unowned` means the key can
- * never work until someone re-issues it against a user, while `no-access`
- * means the key is fine and the cohort changed. On-call reading a log line
- * should not have to guess which of those happened.
+ * 403. They are different operational problems: `unowned` means this
+ * credential class can never work (the project's own key has no identity to
+ * act as; only an API key from the organization's API keys page does), while
+ * `no-access` means the key is fine and the cohort changed. On-call reading a
+ * log line should not have to guess which of those happened.
  */
 export type LangyIdentityDenialReason = "unowned" | "no-access";
 
 export type LangyKeyIdentity =
-  | { ok: true; userId: string }
+  | { ok: true; actor: LangyActor }
   | { ok: false; reason: LangyIdentityDenialReason; message: string };
 
 /**
- * Bridges a project API key to the identity the Langy access gate judges.
+ * Bridges a project API key to the principal the Langy access gate judges.
  *
  * The key authenticates the *caller*; it does not by itself say who is acting.
- * `hasLangyAccess` is a per-user decision (ADR-033: the opted-in cohort is the
+ * `hasLangyAccess` decides per principal (ADR-033: the opted-in cohort is the
  * security boundary while workers share the manager pod's network namespace),
- * so a key-authed surface has to name a user before it may provision anything.
- * That user is the key's owner — `apiKeyUserId` — and never a value taken from
- * the request body, which is the trap the internal relay plane fell into:
+ * so a key-authed surface has to name that principal before it may provision
+ * anything. The principal is derived from the credential — the key's owner
+ * for a personal key, the key itself for a service key — and never from the
+ * request body, which is the trap the internal relay plane fell into:
  * `services/langyagent/transport/rpc/http.go` authenticates the caller with a
  * shared secret and then reads `actorUserId` from the payload on assertion.
- * Here the identity is derived from the credential, so a caller cannot name
- * someone else.
+ * Here a caller cannot name someone else.
  *
- * Fails closed on an ownerless key. Langy keys auto-provisioned per project are
- * deliberately owned by no individual (`specs/langy/langy-api-key-provisioning.feature`),
- * and there is no user whose flag evaluation would be meaningful for one — so
- * rather than inventing a distinguished id or evaluating the flag on project
- * alone, this refuses. Evaluating on the project would hand Langy to every
- * project whose flag is on regardless of who was opted in, which is exactly the
- * identity-based hole the gate's doc comment says must not exist.
+ * A service key is judged by the same gate with its own id as the distinct
+ * id. Flag rules match on project and organization only
+ * (`featureFlag/rules.ts`), so a service key is admitted exactly when its
+ * project or organization was opted in, which is the same decision every
+ * user of that project already gets; there is no broader cohort to hand it.
+ * When neither is targeted it is refused like anyone else.
+ *
+ * The project's own key (the legacy `Project.apiKey`) stays refused. It has no
+ * role bindings to clamp a session key to and no id of its own to act as, so
+ * there is nothing for a turn to run as.
  *
  * Transport-free, mirroring {@link hasLangyAccess}: returns a discriminated
  * result and never throws, so the REST surface maps a denial to its own status
@@ -74,19 +94,21 @@ export async function resolveLangyKeyIdentity({
   resolved: LangyIdentityToken;
   flags?: LangyFlagEvaluator;
 }): Promise<LangyKeyIdentity> {
-  const userId = resolved.type === "apiKey" ? resolved.userId : null;
-
-  if (!userId) {
+  if (resolved.type !== "apiKey") {
     return {
       ok: false,
       reason: "unowned",
       message:
-        "This API key is not owned by a user, so it cannot start a Langy conversation. Langy acts as a person, and the access decision is made per user. Use a key issued to a user with Langy access.",
+        "The project's own API key cannot start a Langy conversation: it has no identity of its own to act as. Use an API key from the organization's API keys page, either a personal key or a service key, that has Langy access in this project.",
     };
   }
 
+  const actor: LangyActor = resolved.userId
+    ? { type: "user", id: resolved.userId }
+    : { type: "apiKey", id: resolved.apiKeyId };
+
   const allowed = await hasLangyAccess({
-    user: { id: userId },
+    user: { id: actor.id },
     projectId: resolved.project.id,
     organizationId: resolved.project.team.organizationId,
     ...(flags ? { flags } : {}),
@@ -97,9 +119,11 @@ export async function resolveLangyKeyIdentity({
       ok: false,
       reason: "no-access",
       message:
-        "The user this API key belongs to does not have access to Langy. Access is granted per user, so a key keeps working for everything else while Langy stays refused.",
+        actor.type === "user"
+          ? "The user this API key belongs to does not have access to Langy. Access is granted per user, so a key keeps working for everything else while Langy stays refused."
+          : "This service key's project does not have access to Langy. Access is granted per project for a service key, so it keeps working for everything else while Langy stays refused.",
     };
   }
 
-  return { ok: true, userId };
+  return { ok: true, actor };
 }

--- a/platform/app/src/server/app-layer/langy/langyAttribution.ts
+++ b/platform/app/src/server/app-layer/langy/langyAttribution.ts
@@ -2,10 +2,16 @@ import type { PrismaClient } from "~/generated/prisma/client";
 
 /**
  * ProjectSecret / VirtualKey / ApiKey audit fields require a non-null user.
- * Runtime callers (project creation, first chat) pass the acting user; the
- * backfill paths have no actor, so we attribute to the organization's first
- * admin. Returns null when neither exists — callers skip provisioning and
- * rely on first-chat self-healing.
+ * Runtime callers (project creation, first chat) pass the acting principal;
+ * the backfill paths have no actor, so we attribute to the organization's
+ * first admin. Returns null when neither exists — callers skip provisioning
+ * and rely on first-chat self-healing.
+ *
+ * The explicit id is honoured only when it names a User row. A service key
+ * acts as itself on the key-authed Langy surfaces, so the acting id there
+ * names an ApiKey, which the audit columns cannot point at; that case takes
+ * the same first-admin fallback the actorless paths do. This runs only when
+ * something has to be provisioned, never on a turn whose credentials exist.
  */
 export async function resolveAttributionUserId({
   prisma,
@@ -16,7 +22,13 @@ export async function resolveAttributionUserId({
   organizationId: string;
   explicitUserId?: string | null;
 }): Promise<string | null> {
-  if (explicitUserId) return explicitUserId;
+  if (explicitUserId) {
+    const user = await prisma.user.findUnique({
+      where: { id: explicitUserId },
+      select: { id: true },
+    });
+    if (user) return user.id;
+  }
   const admin = await prisma.organizationUser.findFirst({
     where: { organizationId, role: "ADMIN" },
     orderBy: { createdAt: "asc" },

--- a/platform/app/src/server/health-probes/__tests__/langy-canary.service.unit.test.ts
+++ b/platform/app/src/server/health-probes/__tests__/langy-canary.service.unit.test.ts
@@ -491,7 +491,7 @@ describe("buildProductionLangyCanaryDeps", () => {
 
   describe("given the project and session the auth chain resolved", () => {
     describe("when the production deps run a turn", () => {
-      /** @scenario "The production turn is the greeting, sent as the key's owner" */
+      /** @scenario "The production turn is the greeting, sent as the key's principal" */
       it("starts one greeting turn as that session and follows the fold as its user", async () => {
         startConversationTurn.mockResolvedValue(STARTED);
         awaitTurnSettlement.mockResolvedValue(completed("Hi!"));

--- a/platform/app/src/server/langy-local-control/session.core.ts
+++ b/platform/app/src/server/langy-local-control/session.core.ts
@@ -901,7 +901,7 @@ function defaultTurnStarter(prisma: PrismaClient): ControlTurnStarter {
     async start({ projectId, conversationId, userId, text, idempotencyKey }) {
       const actor = await resolveLangyActorSession({
         prisma,
-        userId,
+        actor: { type: "user", id: userId },
         now: new Date(),
       });
       if (!actor.ok) {

--- a/platform/app/src/server/routes/__tests__/langy-api-adoption.unit.test.ts
+++ b/platform/app/src/server/routes/__tests__/langy-api-adoption.unit.test.ts
@@ -128,7 +128,7 @@ describe("/api/langy conversation-id adoption", () => {
     mockEnforceApiKeyCeiling.mockResolvedValue(undefined);
     mockResolveLangyKeyIdentity.mockResolvedValue({
       ok: true,
-      userId: "user-1",
+      actor: { type: "user", id: "user-1" },
     });
     mockResolveLangyActorSession.mockResolvedValue({
       ok: true,

--- a/platform/app/src/server/routes/__tests__/langy-api-refusal-chain.unit.test.ts
+++ b/platform/app/src/server/routes/__tests__/langy-api-refusal-chain.unit.test.ts
@@ -161,7 +161,7 @@ describe("/api/langy refusal chain", () => {
     mockEnforceApiKeyCeiling.mockResolvedValue(undefined);
     mockResolveLangyKeyIdentity.mockResolvedValue({
       ok: true,
-      userId: "user-1",
+      actor: { type: "user", id: "user-1" },
     });
     mockResolveLangyActorSession.mockResolvedValue({
       ok: true,
@@ -255,8 +255,8 @@ describe("/api/langy refusal chain", () => {
       expect(mockEnforceApiKeyCeiling).toHaveBeenCalled();
     });
 
-    /** @scenario "A key owned by no user is refused rather than evaluated on project alone" */
-    it("refuses a key with no owning user as 403", async () => {
+    /** @scenario "The project's own key is refused because it has no identity to act as" */
+    it("refuses the project's own key as 403", async () => {
       mockResolveLangyKeyIdentity.mockResolvedValue({
         ok: false,
         reason: "unowned" satisfies LangyIdentityDenialReason,

--- a/platform/app/src/server/routes/__tests__/langy-api-wait-mode.unit.test.ts
+++ b/platform/app/src/server/routes/__tests__/langy-api-wait-mode.unit.test.ts
@@ -163,7 +163,7 @@ describe("/api/langy wait mode (Prefer: wait)", () => {
     mockEnforceApiKeyCeiling.mockResolvedValue(undefined);
     mockResolveLangyKeyIdentity.mockResolvedValue({
       ok: true,
-      userId: "user-1",
+      actor: { type: "user", id: "user-1" },
     });
     mockResolveLangyActorSession.mockResolvedValue({
       ok: true,

--- a/platform/app/src/server/routes/__tests__/langy-canary.integration.test.ts
+++ b/platform/app/src/server/routes/__tests__/langy-canary.integration.test.ts
@@ -133,7 +133,7 @@ describe("GET /api/health/langy", () => {
     mockEnforceApiKeyCeiling.mockResolvedValue(undefined);
     mockResolveLangyKeyIdentity.mockResolvedValue({
       ok: true,
-      userId: "user-1",
+      actor: { type: "user", id: "user-1" },
     });
     mockResolveLangyActorSession.mockResolvedValue({
       ok: true,

--- a/platform/app/src/server/routes/__tests__/langy-ui-actions-actor.unit.test.ts
+++ b/platform/app/src/server/routes/__tests__/langy-ui-actions-actor.unit.test.ts
@@ -1,0 +1,192 @@
+/**
+ * @vitest-environment node
+ *
+ * Who `/api/langy/ui/actions` runs as, driven through the real Hono app.
+ *
+ * A page action drives the conversation of the person who started it: the
+ * visibility check matches the conversation's owner, and the backend fallback
+ * persists that id as the editing User. A service key's worker holds an
+ * ownerless session key, so the identity bridge resolves it to a key actor
+ * whose id names neither the conversation's owner (the parent service key)
+ * nor a User row. The route refuses that actor at the door, before any
+ * conversation is looked up; the human path is untouched.
+ *
+ * Spec: specs/langy/langy-ui-actions.feature
+ */
+import { Hono } from "hono";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { LangyActor } from "~/server/app-layer/langy/langyApiKeyIdentity";
+
+// ─── Auth mocks ───────────────────────────────────────────────────────────────
+// The route builds a module-scope `tokenResolver = TokenResolver.create(prisma)`,
+// so TokenResolver must be mocked before the route module is imported.
+const mockResolve = vi.fn();
+
+vi.mock("~/server/api-key/token-resolver", () => ({
+  TokenResolver: {
+    create: vi.fn(() => ({ resolve: mockResolve, markUsed: vi.fn() })),
+  },
+}));
+
+const mockExtractCredentials = vi.fn();
+const mockEnforceApiKeyCeiling = vi.fn();
+
+vi.mock("~/server/api-key/auth-middleware", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("~/server/api-key/auth-middleware")>();
+  return {
+    ...actual,
+    extractCredentials: (...args: unknown[]) => mockExtractCredentials(...args),
+    enforceApiKeyCeiling: (...args: unknown[]) =>
+      mockEnforceApiKeyCeiling(...args),
+  };
+});
+
+vi.mock("~/server/db", () => ({ prisma: {} }));
+
+// ─── Feature flag ─────────────────────────────────────────────────────────────
+vi.mock("~/server/featureFlag", () => ({
+  featureFlagService: { isEnabled: vi.fn().mockResolvedValue(true) },
+}));
+
+// ─── Identity bridge ──────────────────────────────────────────────────────────
+const mockResolveLangyKeyIdentity = vi.fn();
+
+vi.mock("~/server/app-layer/langy/langyApiKeyIdentity", () => ({
+  resolveLangyKeyIdentity: (...args: unknown[]) =>
+    mockResolveLangyKeyIdentity(...args),
+}));
+
+// ─── Dispatch ─────────────────────────────────────────────────────────────────
+// The service is the seam: a refused actor must never reach it, and an
+// admitted one must reach it as the user the key resolved to.
+const mockDispatch = vi.fn();
+
+vi.mock("~/server/app-layer/langy/ui-actions/ui-action.service", () => ({
+  // The route `new`s the service, so the double has to be constructible.
+  LangyUiActionService: class {
+    dispatch = (...args: unknown[]) => mockDispatch(...args);
+  },
+}));
+
+vi.mock("~/server/app-layer/langy/streaming/langyTokenBuffer", () => ({
+  createLangyTokenBuffer: vi.fn(() => ({})),
+}));
+
+vi.mock("~/server/app-layer/langy/ui-actions/uiActionBackendExecutor", () => ({
+  executeBackendAction: vi.fn(),
+}));
+
+vi.mock("~/server/app-layer/app", () => ({
+  tryGetApp: () => null,
+  getApp: vi.fn(() => ({
+    redis: {},
+    langy: { conversations: {} },
+    experiments: {},
+  })),
+}));
+
+// ─── App under test ───────────────────────────────────────────────────────────
+// Imported AFTER every mock so the module-scope TokenResolver.create(prisma)
+// picks up the mock rather than the real client.
+const { listPageActions } = await import(
+  "~/server/app-layer/langy/ui-actions/pageManifests"
+);
+const { app: uiActionsApp } = await import("../langy-ui-actions");
+
+const testApp = new Hono();
+testApp.route("/", uiActionsApp);
+
+const ACTIONS_URL = "http://localhost/api/langy/ui/actions";
+
+const fakeResolved = {
+  type: "apiKey" as const,
+  apiKeyId: "session-key-1",
+  project: {
+    id: "project-123",
+    slug: "project-123",
+    team: { organizationId: "org-1" },
+  },
+};
+
+// A real kind from the manifest, so the guard is proven to sit BEFORE the
+// dispatch rather than being masked by an unknown-kind refusal.
+const A_REAL_KIND = listPageActions()[0]!.kind;
+
+function postAction() {
+  return testApp.request(ACTIONS_URL, {
+    method: "POST",
+    headers: {
+      "X-Auth-Token": "test-token",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      conversationId: "conv-1",
+      kind: A_REAL_KIND,
+      payload: {},
+    }),
+  });
+}
+
+function admitAs(actor: LangyActor) {
+  mockResolveLangyKeyIdentity.mockResolvedValue({ ok: true, actor });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockExtractCredentials.mockReturnValue({
+    token: "test-token",
+    projectId: undefined,
+  });
+  mockResolve.mockResolvedValue(fakeResolved);
+  mockEnforceApiKeyCeiling.mockResolvedValue(undefined);
+  mockDispatch.mockResolvedValue({ status: "executed", result: null });
+});
+
+describe("/api/langy/ui/actions actor", () => {
+  describe("given the session key resolves to a service key acting as itself", () => {
+    /** @scenario A worker started by a service key cannot drive a page */
+    it("refuses the dispatch as 403 before any conversation is looked up", async () => {
+      admitAs({ type: "apiKey", id: "service-key-1" });
+
+      const res = await postAction();
+      const body = JSON.stringify(await res.json());
+
+      expect(res.status).toBe(403);
+      expect(body).toContain("langy_api_key_unowned");
+      expect(mockDispatch).not.toHaveBeenCalled();
+    });
+
+    it("refuses the action listing the same way", async () => {
+      admitAs({ type: "apiKey", id: "service-key-1" });
+
+      const res = await testApp.request(ACTIONS_URL, {
+        method: "GET",
+        headers: { "X-Auth-Token": "test-token" },
+      });
+
+      expect(res.status).toBe(403);
+      expect(JSON.stringify(await res.json())).toContain(
+        "langy_api_key_unowned",
+      );
+    });
+  });
+
+  describe("given the session key resolves to a user", () => {
+    it("dispatches as that user", async () => {
+      admitAs({ type: "user", id: "user-1" });
+
+      const res = await postAction();
+
+      expect(res.status).toBe(200);
+      expect(mockDispatch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          projectId: "project-123",
+          userId: "user-1",
+          conversationId: "conv-1",
+          kind: A_REAL_KIND,
+        }),
+      );
+    });
+  });
+});

--- a/platform/app/src/server/routes/__tests__/langy-ui-actions-actor.unit.test.ts
+++ b/platform/app/src/server/routes/__tests__/langy-ui-actions-actor.unit.test.ts
@@ -16,20 +16,34 @@
 import { Hono } from "hono";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { LangyActor } from "~/server/app-layer/langy/langyApiKeyIdentity";
+import { listPageActions } from "~/server/app-layer/langy/ui-actions/pageManifests";
+import { app as uiActionsApp } from "../langy-ui-actions";
 
 // ─── Auth mocks ───────────────────────────────────────────────────────────────
-// The route builds a module-scope `tokenResolver = TokenResolver.create(prisma)`,
-// so TokenResolver must be mocked before the route module is imported.
-const mockResolve = vi.fn();
+// The route builds a module-scope `tokenResolver = TokenResolver.create(prisma)`
+// while it is imported, so every double the mock factories close over has to
+// exist before the static imports above run. Vitest hoists `vi.mock` and
+// `vi.hoisted` blocks above the imports; a plain `const` here would still be in
+// its temporal dead zone when the route module loads.
+const {
+  mockResolve,
+  mockExtractCredentials,
+  mockEnforceApiKeyCeiling,
+  mockResolveLangyKeyIdentity,
+  mockDispatch,
+} = vi.hoisted(() => ({
+  mockResolve: vi.fn(),
+  mockExtractCredentials: vi.fn(),
+  mockEnforceApiKeyCeiling: vi.fn(),
+  mockResolveLangyKeyIdentity: vi.fn(),
+  mockDispatch: vi.fn(),
+}));
 
 vi.mock("~/server/api-key/token-resolver", () => ({
   TokenResolver: {
     create: vi.fn(() => ({ resolve: mockResolve, markUsed: vi.fn() })),
   },
 }));
-
-const mockExtractCredentials = vi.fn();
-const mockEnforceApiKeyCeiling = vi.fn();
 
 vi.mock("~/server/api-key/auth-middleware", async (importOriginal) => {
   const actual =
@@ -50,8 +64,6 @@ vi.mock("~/server/featureFlag", () => ({
 }));
 
 // ─── Identity bridge ──────────────────────────────────────────────────────────
-const mockResolveLangyKeyIdentity = vi.fn();
-
 vi.mock("~/server/app-layer/langy/langyApiKeyIdentity", () => ({
   resolveLangyKeyIdentity: (...args: unknown[]) =>
     mockResolveLangyKeyIdentity(...args),
@@ -60,8 +72,6 @@ vi.mock("~/server/app-layer/langy/langyApiKeyIdentity", () => ({
 // ─── Dispatch ─────────────────────────────────────────────────────────────────
 // The service is the seam: a refused actor must never reach it, and an
 // admitted one must reach it as the user the key resolved to.
-const mockDispatch = vi.fn();
-
 vi.mock("~/server/app-layer/langy/ui-actions/ui-action.service", () => ({
   // The route `new`s the service, so the double has to be constructible.
   LangyUiActionService: class {
@@ -87,13 +97,6 @@ vi.mock("~/server/app-layer/app", () => ({
 }));
 
 // ─── App under test ───────────────────────────────────────────────────────────
-// Imported AFTER every mock so the module-scope TokenResolver.create(prisma)
-// picks up the mock rather than the real client.
-const { listPageActions } = await import(
-  "~/server/app-layer/langy/ui-actions/pageManifests"
-);
-const { app: uiActionsApp } = await import("../langy-ui-actions");
-
 const testApp = new Hono();
 testApp.route("/", uiActionsApp);
 
@@ -128,7 +131,7 @@ function postAction() {
   });
 }
 
-function admitAs(actor: LangyActor) {
+function admitAs({ actor }: { actor: LangyActor }) {
   mockResolveLangyKeyIdentity.mockResolvedValue({ ok: true, actor });
 }
 
@@ -147,7 +150,7 @@ describe("/api/langy/ui/actions actor", () => {
   describe("given the session key resolves to a service key acting as itself", () => {
     /** @scenario A worker started by a service key cannot drive a page */
     it("refuses the dispatch as 403 before any conversation is looked up", async () => {
-      admitAs({ type: "apiKey", id: "service-key-1" });
+      admitAs({ actor: { type: "apiKey", id: "service-key-1" } });
 
       const res = await postAction();
       const body = JSON.stringify(await res.json());
@@ -158,7 +161,7 @@ describe("/api/langy/ui/actions actor", () => {
     });
 
     it("refuses the action listing the same way", async () => {
-      admitAs({ type: "apiKey", id: "service-key-1" });
+      admitAs({ actor: { type: "apiKey", id: "service-key-1" } });
 
       const res = await testApp.request(ACTIONS_URL, {
         method: "GET",
@@ -174,7 +177,7 @@ describe("/api/langy/ui/actions actor", () => {
 
   describe("given the session key resolves to a user", () => {
     it("dispatches as that user", async () => {
-      admitAs({ type: "user", id: "user-1" });
+      admitAs({ actor: { type: "user", id: "user-1" } });
 
       const res = await postAction();
 

--- a/platform/app/src/server/routes/langy-local.ts
+++ b/platform/app/src/server/routes/langy-local.ts
@@ -105,8 +105,18 @@ async function authorize(c: Context) {
       identity.message,
     );
   }
+  // The local surface stores the actor as a user id and later rebuilds the
+  // acting session from the User table, so a service key has no row to act
+  // from there. Refuse it here, at the door, with the reason spelled out,
+  // rather than admitting it and dropping every folder turn as actor-missing.
+  if (identity.actor.type !== "user") {
+    throw new LangyApiIdentityDeniedError(
+      "langy_api_key_unowned",
+      "The local Langy surface runs as a person. Use a personal API key here; service keys are accepted by the conversation and health endpoints only.",
+    );
+  }
   return {
-    userId: identity.userId,
+    userId: identity.actor.id,
     projectId: resolved.project.id,
     projectName: resolved.project.name,
     projectSlug: resolved.project.slug,

--- a/platform/app/src/server/routes/langy-ui-actions.ts
+++ b/platform/app/src/server/routes/langy-ui-actions.ts
@@ -122,7 +122,7 @@ async function authorizeUiRequest(c: Context) {
   return {
     dark: false as const,
     resolved,
-    userId: identity.userId,
+    userId: identity.actor.id,
     projectId: resolved.project.id,
   };
 }

--- a/platform/app/src/server/routes/langy-ui-actions.ts
+++ b/platform/app/src/server/routes/langy-ui-actions.ts
@@ -87,7 +87,9 @@ const dispatchBodySchema = z.object({
  * Authenticate the key, open the flag, and resolve the owning user. Mirrors
  * `authorizeLangyApiKey` in `app-layer/langy/langyApiKeyAuthorization.ts`
  * including the dark-404 contract; the permission ceiling is enforced by the
- * caller once the action names it.
+ * caller once the action names it. Unlike the turn surface, this one is
+ * user-only: a service key's worker is refused at the door, same as on the
+ * local-control surface (`langy-local.ts`).
  */
 async function authorizeUiRequest(c: Context) {
   const credentials = extractCredentials((name) => c.req.header(name));
@@ -116,6 +118,19 @@ async function authorizeUiRequest(c: Context) {
         ? "langy_api_key_unowned"
         : "langy_api_key_no_langy_access",
       identity.message,
+    );
+  }
+  // A page action runs as the person whose conversation it drives: the
+  // visibility check matches the conversation's owner and the backend
+  // fallback persists the actor as a User. The session key a service key's
+  // worker holds is itself ownerless, so it resolves to a key actor whose id
+  // names neither the conversation's owner (the parent key) nor a User row.
+  // Refuse it here with the reason spelled out, rather than letting the
+  // visibility check answer not-found for a conversation that exists.
+  if (identity.actor.type !== "user") {
+    throw new LangyApiIdentityDeniedError(
+      "langy_api_key_unowned",
+      "Page actions run as the person whose key started the conversation. A conversation started by a service key has no person to act as, so its worker cannot drive a page; use a personal API key for turns that need one.",
     );
   }
 

--- a/specs/langy/langy-api-key-turns.feature
+++ b/specs/langy/langy-api-key-turns.feature
@@ -4,9 +4,10 @@ Feature: Starting Langy conversations with a project API key
   So that scripts and CI can use the assistant without a browser session
   or a human's password
 
-  # The access decision stays per user (ADR-033): the key names its owner, and
-  # that owner is judged by the same gate the browser surface uses. The key
-  # authenticates the caller; it never names the actor.
+  # The access decision stays per principal (ADR-033): a personal key names its
+  # owner, a service key (issued to no user) names itself, and that principal
+  # is judged by the same gate the browser surface uses. The key authenticates
+  # the caller; a request never names the actor.
 
   # ---------------------------------------------------------------------------
   # Identity bridge — key owner resolved through the Langy access gate
@@ -33,11 +34,38 @@ Feature: Starting Langy conversations with a project API key
     Then resolving the identity behind the same unedited key is refused
 
   @unit
-  Scenario: A key owned by no user is refused rather than evaluated on project alone
-    Given a project API key that is not owned by any individual user
+  Scenario: A service key acts as itself when its project is in the cohort
+    Given a service key, an API key issued to no user, for a project in the Langy cohort
+    When the Langy surface resolves the identity behind the key
+    Then the resolved actor is the key itself
+    And the Langy access gate judged the key by its project and organization
+
+  @unit
+  Scenario: A service key whose project is outside the cohort is refused
+    Given a service key for a project that is not in the Langy cohort
+    When the Langy surface resolves the identity behind the key
+    Then the resolution is refused for lack of Langy access
+
+  @unit
+  Scenario: The project's own key is refused because it has no identity to act as
+    Given the project's own API key from the project settings page
     When the Langy surface resolves the identity behind the key
     Then the resolution is refused as unowned
     And the Langy access gate is not consulted
+
+  @unit
+  Scenario: A service key's turn is attributed to the key, named after it
+    Given a service key with a name on file
+    When the surface builds the acting identity for a turn
+    Then the identity carries the key's id and the key's name
+    And no email and no person is attributed
+
+  @unit
+  Scenario: A service key that vanished between resolution and actor is refused
+    Given a service key whose row has been deleted
+    When the surface builds the acting identity for a turn
+    Then the turn is refused
+    And no stand-in actor is used in the key's place
 
   @unit
   Scenario: The actor is never taken from the request payload

--- a/specs/langy/langy-api-key-turns.feature
+++ b/specs/langy/langy-api-key-turns.feature
@@ -61,6 +61,13 @@ Feature: Starting Langy conversations with a project API key
     And no email and no person is attributed
 
   @unit
+  Scenario: A service key's first turn attributes provisioning to the organization's first admin
+    Given a service key acting as itself in a project whose Langy virtual key has not been provisioned
+    When the first turn provisions that virtual key
+    Then the provisioning is attributed to the organization's first admin
+    And no audit column is pointed at the key's id
+
+  @unit
   Scenario: A service key that vanished between resolution and actor is refused
     Given a service key whose row has been deleted
     When the surface builds the acting identity for a turn

--- a/specs/langy/langy-health-canary.feature
+++ b/specs/langy/langy-health-canary.feature
@@ -34,8 +34,9 @@ Feature: A Langy health check that sends a real greeting and says what broke
   routes' own, in the same order, as POST /api/langy/conversations: a project
   API key resolves (else 401), the surface flag is open (else the same 404 an
   unmounted path gives), the key clears the `langy:create` ceiling (else 403),
-  and the key's owner is in the Langy cohort (else 403). The turn runs as that
-  owner. No new env var and no new credential class is involved.
+  and the key's principal is in the Langy cohort (else 403): the owner for a
+  personal key, the key itself for a service key. The turn runs as that
+  principal. No new env var and no new credential class is involved.
 
   # Bindings:
   #   platform/app/src/server/health-probes/langy-canary.service.ts
@@ -124,7 +125,7 @@ Feature: A Langy health check that sends a real greeting and says what broke
     Then the run is unhealthy with reason "timeout"
 
   @unit
-  Scenario: The production turn is the greeting, sent as the key's owner
+  Scenario: The production turn is the greeting, sent as the key's principal
     Given the project and session the auth chain resolved
     When the production deps start the turn
     Then the turn service receives one user message "Hi Langy."
@@ -212,6 +213,13 @@ Feature: A Langy health check that sends a real greeting and says what broke
     When GET /api/health/langy is called
     Then the response is 403 with the denial's message, in the shape the sibling probes use
     And no turn is started
+
+  @unit
+  Scenario: A service key with no owning user is admitted and the turn runs as the key
+    Given a service key, an API key issued to no user, with langy:create in a project in the Langy cohort
+    When the auth chain resolves the identity behind the key
+    Then the resolved actor is the key itself
+    And the turn is attributed to the key, not to any person
 
   @unit
   Scenario: A healthy run answers 200 with the turn's ids

--- a/specs/langy/langy-session-key.feature
+++ b/specs/langy/langy-session-key.feature
@@ -105,17 +105,25 @@ Feature: Per-session caller-scoped Langy key
     Then no session key is minted
     And the chat is refused with an actionable error
 
+  @unit
   Scenario: A service key mints a session key clamped to its own bindings
     Given a service key, an API key issued to no user, acting as itself in this project
     When a Langy session key is minted for that key
     Then the session key is owned by no user, like its parent
     And the session key carries exactly the Langy actions the service key's own bindings grant here
 
+  @unit
   Scenario: A service key from another organization cannot mint here
     Given a service key that belongs to a different organization
     When a Langy session key is requested in its name for this project
     Then no session key is minted
     And the request is refused with an actionable error
+
+  @unit
+  Scenario: A service key's session key never outlives the service key
+    Given a service key that expires in a minute
+    When a Langy session key is minted for that key
+    Then the session key expires when the service key does, not six hours later
 
   Scenario: The session key acts only within the project it was minted for
     Given I have another project I also belong to

--- a/specs/langy/langy-session-key.feature
+++ b/specs/langy/langy-session-key.feature
@@ -105,6 +105,18 @@ Feature: Per-session caller-scoped Langy key
     Then no session key is minted
     And the chat is refused with an actionable error
 
+  Scenario: A service key mints a session key clamped to its own bindings
+    Given a service key, an API key issued to no user, acting as itself in this project
+    When a Langy session key is minted for that key
+    Then the session key is owned by no user, like its parent
+    And the session key carries exactly the Langy actions the service key's own bindings grant here
+
+  Scenario: A service key from another organization cannot mint here
+    Given a service key that belongs to a different organization
+    When a Langy session key is requested in its name for this project
+    Then no session key is minted
+    And the request is refused with an actionable error
+
   Scenario: The session key acts only within the project it was minted for
     Given I have another project I also belong to
     When a Langy session key is minted for this project

--- a/specs/langy/langy-ui-actions.feature
+++ b/specs/langy/langy-ui-actions.feature
@@ -79,6 +79,13 @@ Feature: Langy drives the open page through typed UI actions
     Then the dispatch answers not found, the same as for no conversation at all
 
   @unit
+  Scenario: A worker started by a service key cannot drive a page
+    Given a conversation that a service key, an API key issued to no user, started
+    When its worker dispatches a page action with its session key
+    Then the dispatch is refused before any conversation is looked up
+    And the refusal says page actions run as a person
+
+  @unit
   Scenario: An unclaimed action deletes its pending record before answering
     Given nothing claimed the action inside the claim window
     When the dispatch gives up on the page


### PR DESCRIPTION
Follow-up to #7956 for #7944. The Langy health probe, and the key-authed Langy chain it shares with `POST /api/langy/conversations`, refused every service key with `403 langy_api_key_unowned`. An uptime monitor is not a person, so the probe could not be wired to one.

## Cause

`platform/app/src/server/app-layer/langy/langyApiKeyIdentity.ts:77-82` (before this change) refused any API key whose `userId` was null as `unowned` before consulting the access gate. A service key from the organization's API keys page is exactly that: an `ApiKey` row with no owner, its own role bindings as its ceiling. The gate itself never needed a user: flag rules match on project and organization only (`featureFlag/rules.ts`), so there was no per-user cohort a service key could have bypassed.

Two more places assumed the acting id names a User row and would have failed the turn even once the gate admitted the key:

- `langyApiKey.ts` minted the worker's session key by intersecting the actor's user permissions; a service key holds none as a user, so the mint threw and the probe reported `turn_failed`.
- `langyAttribution.ts` passed the acting id straight into `ProjectSecret.createdById`, a foreign key to User, on the first-turn self-heal that provisions a project's Langy virtual key.

## Fix

A service key acts as itself.

- `resolveLangyKeyIdentity` returns `{ ok, actor }` where `actor` is `{ type: "user", id }` for a personal key or `{ type: "apiKey", id }` for a service key. The service key is judged by the same gate with its own id as the distinct id, so it is admitted exactly when its project or organization was opted in. The project's own legacy key stays `unowned`: it has no bindings to clamp a session key to and no id to act as.
- `resolveLangyActorSession` takes the actor. For a service key it loads the `ApiKey` row and presents `{ id: key.id, name: key.name, email: null }`, so the conversation, the session key and the commit trailer name the credential rather than a person who did not act. A vanished key is refused as `actor-missing`, as a vanished user always was.
- `mintLangySessionApiKey`: when the user path holds nothing under the acting id, the mint asks whether the id names a live, ownerless key of this organization. If so, the child is clamped to that key's own bindings via the permissions service's batched api-key cut and minted unowned like its parent. The human path is unchanged and costs the same four queries.
- `resolveAttributionUserId` honours the explicit id only when it names a User row; otherwise it takes the first-admin fallback the actorless backfill already uses.
- `routes/langy-local.ts` refuses a service key at the door with the reason spelled out, since the local-control surface stores the actor as a user id and rebuilds the session from the User table later. Admitting it would have silently dropped every folder turn as `actor-missing`.
- `routes/langy-ui-actions.ts` refuses it the same way. A page action drives the conversation of the person who started it: the visibility check matches the conversation's owner and the backend fallback persists that id as the editing User. A service key's worker holds an ownerless session key, so it resolves to a key actor whose id names neither the parent key nor a User row, and the dispatch would have died as not-found for a conversation that exists.
- A service key's session key is capped at the parent's own expiry. A personal key's child is owned by the user and re-intersected with their live grants on every use; an ownerless child has no such live ceiling, so its lifetime is the one lever the mint holds, and a parent lapsing in a minute no longer hands its worker six more hours.
- Error copy for `langy_api_key_unowned`, `langy_api_key_no_langy_access` and `langy_api_actor_missing` no longer tells a service-key holder to mint a personal key.

## Failing first

```
$ pnpm test:unit run src/server/app-layer/langy/__tests__/langyApiKeyIdentity.unit.test.ts src/server/app-layer/langy/__tests__/langyApiKeyActorSession.unit.test.ts src/server/app-layer/langy/__tests__/langyApiKey.unit.test.ts

 FAIL  langyApiKeyIdentity.unit.test.ts > resolves a service key to the key itself, judged by its project and organization
AssertionError: expected { ok: false, reason: 'unowned', …(1) } to deeply equal { ok: true, actor: { …(2) } }
 FAIL  langyApiKeyIdentity.unit.test.ts > refuses a service key when neither its project nor its organization is opted in
AssertionError: expected { ok: false, reason: 'unowned', …(1) } to match object { reason: 'no-access' }
 FAIL  langyApiKeyActorSession.unit.test.ts > presents a service key as itself, named after the key and with no email
AssertionError: expected false to be true // Object.is equality
 FAIL  langyApiKey.unit.test.ts > given a service key acting as itself > when a session key is minted > requests an unowned, restricted, project-scoped key carrying exactly what the service key holds
LangySessionKeyScopeError: You do not hold any of the permissions Langy needs in this project, so no Langy session key could be created for you.

 Test Files  3 failed (3)
      Tests  7 failed | 23 passed (30)

$ pnpm test:unit run src/server/app-layer/langy/__tests__/langyAttribution.unit.test.ts

 × falls back to the first admin when the actor is a service key, not a user
AssertionError: expected 'service-key-1' to be 'admin-1' // Object.is equality
 × returns null when neither a user actor nor an admin exists
AssertionError: expected 'service-key-1' to be null
      Tests  2 failed | 2 passed (4)
```

## Passing after

```
$ pnpm test:unit run src/server/app-layer/langy/__tests__/langyAttribution.unit.test.ts src/server/app-layer/langy/__tests__/langyApiKeyIdentity.unit.test.ts src/server/app-layer/langy/__tests__/langyApiKeyActorSession.unit.test.ts src/server/app-layer/langy/__tests__/langyApiKey.unit.test.ts
 Test Files  4 passed (4)
      Tests  34 passed (34)

$ pnpm test:unit run src/server/app-layer/langy src/server/routes/__tests__ src/server/langy-local-control src/features/errors
 Test Files  94 passed (94)
      Tests  1228 passed (1228)

$ pnpm typecheck        exit 0
$ pnpm run typecheck:all exit 0
```

`langy-canary.integration.test.ts` only needed its identity mock reshaped to `{ ok: true, actor }`. It runs on the container-backed integration lane and no container runtime was available locally, so CI is its first run.

## Sweep

Every consumer of the acting id on the key-authed turn path was read for a User-row assumption:

- Langy conversation, turn-request, active-turn and message projections store the id as a plain string with no foreign key. Safe.
- `LangyCredentialService` derives the GitHub co-author handle from `session.user.name` through a sanitiser (`uptime-monitor` for a key named "Uptime monitor"). Safe.
- `LangyCredentialService.getOrProvisionVirtualKey` reaches `resolveAttributionUserId`. Fixed here, see above. Its unit test's Prisma fake had no `user` model and crashed on the new read; the fake now answers for the session user.
- `routes/langy-ui-actions.ts` passed the acting id as the conversation owner and the backend editing actor. Refused at the door for a service key, see above.
- `mintLangySessionApiKeyForUser({ userId })`, used by the pipeline spawn and the local-control turn, builds a bare `{ user: { id } }` session. The mint now recognises a service key by id, so both paths work for one. Safe.
- Single-flight and permit keys in the canary service and the turn service key on the id string. Safe.

## Not fixed here, deliberately

- A session key minted for a service key has no live link to its parent: revoking the service key, or cutting its grants, does not reach a child still inside its lease. The lease is now capped at the parent's expiry, but mirroring revocation needs a parent link on the `ApiKey` row and a check in the token resolver, which is outside this PR's Langy-only scope. A personal key's child has the same revocation gap today; only the grant cut differs, since an owned child is re-intersected with its user's live grants. Worth its own issue.
- The service-key branch of the mint reads the project's team a second time on that cold path. Hoisting it means restructuring the span closure around the user path; not worth touching in a hotfix.
- `routes/langy-local.ts` has no route test, so its new refusal is exercised by the typecheck only.
- A service key's worker cannot drive a page. The page-action surface refuses it rather than admitting an actor that can see no conversation; a monitor has no page to drive in any case.
- Docs and specs updated for Langy only. Nothing outside the Langy app layer, routes, specs and health-check doc was touched.

## Deployment Impact

No env vars added or changed. No helm values added or changed. A vanilla `helm install` with no overrides behaves as before: both Langy flags default off, so the key-authed Langy surfaces stay dark and nothing here is reachable until an operator opts a project in. BYOC dataplane: no change, the decision runs in the control plane's existing auth chain and reads only tables it already reads (`ApiKey`, `User`, `OrganizationUser`). No migration. The only operator-visible change is documentation: the self-hosting health-check page now names a service key as the credential to give a monitor.

## After merge

Provision a service key with `langy:create` on the canary project, turn on both Langy flags for that project, and point the monitor at `GET /api/health/langy` with `X-Auth-Token` and `X-Project-Id`, expecting 200 with a timeout of 75 seconds or more.

Closes nothing on its own; the tracking issue is #7944.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Service API keys can authenticate Langy requests and act as themselves without an associated user.
  - Service keys can mint restricted session keys based on their granted Langy permissions, with matching expiration.
  - Langy activity initiated by service keys is attributed to the key or an organizational administrator when appropriate.

- **Bug Fixes**
  - Improved handling and messaging for missing, unauthorized, or refused API keys.
  - Personal keys remain required for local Langy and page actions; service keys are refused there.

- **Documentation**
  - Updated API and health-check guidance to explain personal and service key requirements, permissions, and error conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
