### PR TITLE
fix(seed): seed a license the running app can verify, and never clobber an activated one

### DIFF
--- a/platform/app/ee/licensing/constants.ts
+++ b/platform/app/ee/licensing/constants.ts
@@ -117,7 +117,7 @@ export const FREE_PLAN: PlanInfo = {
  */
 // gitleaks:allow — public keys
 
-const PLACEHOLDER_PUBLIC_KEY = `-----BEGIN PUBLIC KEY-----
+export const PLACEHOLDER_PUBLIC_KEY = `-----BEGIN PUBLIC KEY-----
 MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvyNNiu5B0lretFaxowsu
 fM907tHWnBITXVDfnpPAwUgzrODdjfTt73XW1S+EDd8AM0FzOpx0YolXipS4+SNK
 axSXwNO0S0XjJGLW7wz9Nv8/PP9V23LtiLQQOj8eGol/texr5pIZy2CRjVeEYcBZ

--- a/platform/app/prisma/seed.ts
+++ b/platform/app/prisma/seed.ts
@@ -67,8 +67,12 @@ import { hash as hashPassword } from "bcrypt";
 import { parse as parseDotenv } from "dotenv";
 import fs from "fs";
 import path from "path";
+import { ENTERPRISE_LICENSE_KEY as TEST_SUITE_ENTERPRISE_LICENSE_KEY } from "../ee/licensing/__tests__/fixtures/testLicenses";
 import { PUBLIC_KEY } from "../ee/licensing/constants";
-import { resolveSeedLicense } from "../scripts/localDevLicense";
+import {
+  LOCAL_DEV_ENTERPRISE_LICENSE_KEY,
+  resolveSeedLicense,
+} from "../scripts/localDevLicense";
 import {
   PrismaClient,
   RoleBindingScopeType,
@@ -152,7 +156,8 @@ async function main() {
   // The license must verify against the key this app boots with, otherwise
   // every settings page reports it as invalid. `resolveSeedLicense` keeps a
   // license that already verifies (someone activated a real one) and only
-  // replaces what does not.
+  // replaces what does not. The local-dev key verifies under the default key;
+  // the test-suite fixture is there for CI, which seeds under the test key.
   const existingOrganization = await prisma.organization.findUnique({
     where: { id: ORG_ID },
     select: { license: true },
@@ -160,6 +165,10 @@ async function main() {
   const license = resolveSeedLicense({
     stored: existingOrganization?.license ?? null,
     publicKey: PUBLIC_KEY,
+    candidates: [
+      LOCAL_DEV_ENTERPRISE_LICENSE_KEY,
+      TEST_SUITE_ENTERPRISE_LICENSE_KEY,
+    ],
   });
   const organization = await prisma.organization.upsert({
     where: { id: ORG_ID },

--- a/platform/app/prisma/seed.ts
+++ b/platform/app/prisma/seed.ts
@@ -67,7 +67,8 @@ import { hash as hashPassword } from "bcrypt";
 import { parse as parseDotenv } from "dotenv";
 import fs from "fs";
 import path from "path";
-import { ENTERPRISE_LICENSE_KEY } from "../ee/licensing/__tests__/fixtures/testLicenses";
+import { PUBLIC_KEY } from "../ee/licensing/constants";
+import { resolveSeedLicense } from "../scripts/localDevLicense";
 import {
   PrismaClient,
   RoleBindingScopeType,
@@ -148,15 +149,27 @@ async function main() {
     ? firstMessageOverride === "1" || firstMessageOverride === "true"
     : process.env.HAVEN_SEED_PRESET === "demo";
 
+  // The license must verify against the key this app boots with, otherwise
+  // every settings page reports it as invalid. `resolveSeedLicense` keeps a
+  // license that already verifies (someone activated a real one) and only
+  // replaces what does not.
+  const existingOrganization = await prisma.organization.findUnique({
+    where: { id: ORG_ID },
+    select: { license: true },
+  });
+  const license = resolveSeedLicense({
+    stored: existingOrganization?.license ?? null,
+    publicKey: PUBLIC_KEY,
+  });
   const organization = await prisma.organization.upsert({
     where: { id: ORG_ID },
     create: {
       id: ORG_ID,
       name: ORG_NAME,
       slug: ORG_SLUG,
-      license: ENTERPRISE_LICENSE_KEY,
+      license,
     },
-    update: { license: ENTERPRISE_LICENSE_KEY },
+    update: { license },
   });
 
   // Prompt tags are org-defined, and `production` is the one

--- a/platform/app/scripts/__tests__/localDevLicense.unit.test.ts
+++ b/platform/app/scripts/__tests__/localDevLicense.unit.test.ts
@@ -14,7 +14,13 @@ import {
   resolveSeedLicense,
 } from "../localDevLicense";
 
-function isSignedFor(licenseKey: string, publicKey: string): boolean {
+function isSignedFor({
+  licenseKey,
+  publicKey,
+}: {
+  licenseKey: string;
+  publicKey: string;
+}): boolean {
   const parsed = parseLicenseKey(licenseKey);
   return parsed !== null && verifySignature(parsed, publicKey);
 }
@@ -25,19 +31,29 @@ const SEED_CANDIDATES = [
 ] as const;
 
 describe("LOCAL_DEV_ENTERPRISE_LICENSE_KEY", () => {
-  describe("when verified with the key the app boots with by default", () => {
-    it("verifies", () => {
-      expect(
-        isSignedFor(LOCAL_DEV_ENTERPRISE_LICENSE_KEY, DEFAULT_PUBLIC_KEY),
-      ).toBe(true);
+  describe("given the app boots with the default key", () => {
+    describe("when the local-dev license is verified", () => {
+      it("verifies", () => {
+        expect(
+          isSignedFor({
+            licenseKey: LOCAL_DEV_ENTERPRISE_LICENSE_KEY,
+            publicKey: DEFAULT_PUBLIC_KEY,
+          }),
+        ).toBe(true);
+      });
     });
 
     // Documents why the seed used to show an invalid license: the ee fixture
     // is signed with the test-suite private key, not the default one.
-    it("rejects the ee test fixture license", () => {
-      expect(isSignedFor(TEST_SUITE_LICENSE_KEY, DEFAULT_PUBLIC_KEY)).toBe(
-        false,
-      );
+    describe("when the ee test fixture license is verified", () => {
+      it("rejects it", () => {
+        expect(
+          isSignedFor({
+            licenseKey: TEST_SUITE_LICENSE_KEY,
+            publicKey: DEFAULT_PUBLIC_KEY,
+          }),
+        ).toBe(false);
+      });
     });
   });
 });
@@ -81,11 +97,13 @@ describe("resolveSeedLicense", () => {
     describe("when the stored license already verifies", () => {
       it("keeps it, so a re-seed never clobbers a license someone activated", () => {
         const activated = LOCAL_DEV_ENTERPRISE_LICENSE_KEY;
+        // Candidates deliberately exclude the stored key, so a resolver that
+        // skipped the stored branch could not pass by coincidence.
         expect(
           resolveSeedLicense({
             stored: activated,
             publicKey: DEFAULT_PUBLIC_KEY,
-            candidates: SEED_CANDIDATES,
+            candidates: [TEST_SUITE_LICENSE_KEY],
           }),
         ).toBe(activated);
       });

--- a/platform/app/scripts/__tests__/localDevLicense.unit.test.ts
+++ b/platform/app/scripts/__tests__/localDevLicense.unit.test.ts
@@ -1,0 +1,85 @@
+import fs from "fs";
+import path from "path";
+import { describe, expect, it } from "vitest";
+import { ENTERPRISE_LICENSE_KEY as EE_TEST_FIXTURE_LICENSE_KEY } from "../../ee/licensing/__tests__/fixtures/testLicenses";
+// The key the app boots with when LANGWATCH_LICENSE_PUBLIC_KEY is unset,
+// which is what `haven up` runs. The vitest setup swaps `PUBLIC_KEY` for the
+// test-suite key, so that export would test the wrong deployment.
+import { PLACEHOLDER_PUBLIC_KEY as PUBLIC_KEY } from "../../ee/licensing/constants";
+import {
+  parseLicenseKey,
+  verifySignature,
+} from "../../ee/licensing/validation";
+import {
+  LOCAL_DEV_ENTERPRISE_LICENSE_KEY,
+  resolveSeedLicense,
+} from "../localDevLicense";
+
+function isSignedByLangWatch(licenseKey: string): boolean {
+  const parsed = parseLicenseKey(licenseKey);
+  return parsed !== null && verifySignature(parsed, PUBLIC_KEY);
+}
+
+describe("localDevLicense", () => {
+  describe("given the verification key the app boots with", () => {
+    it("verifies the local-dev enterprise license", () => {
+      expect(isSignedByLangWatch(LOCAL_DEV_ENTERPRISE_LICENSE_KEY)).toBe(true);
+    });
+
+    // Documents why the seed must never write the ee test fixture: it is
+    // signed with the test-suite private key, so the running app reports it
+    // as an invalid license on every settings page.
+    it("rejects the ee test fixture license", () => {
+      expect(isSignedByLangWatch(EE_TEST_FIXTURE_LICENSE_KEY)).toBe(false);
+    });
+  });
+
+  describe("resolveSeedLicense", () => {
+    describe("when the organization has no license yet", () => {
+      it("returns the local-dev enterprise license", () => {
+        expect(
+          resolveSeedLicense({ stored: null, publicKey: PUBLIC_KEY }),
+        ).toBe(LOCAL_DEV_ENTERPRISE_LICENSE_KEY);
+      });
+    });
+
+    describe("when the stored license does not verify", () => {
+      it("replaces an unreadable value", () => {
+        expect(
+          resolveSeedLicense({
+            stored: "not-a-license",
+            publicKey: PUBLIC_KEY,
+          }),
+        ).toBe(LOCAL_DEV_ENTERPRISE_LICENSE_KEY);
+      });
+
+      it("replaces a fixture left behind by an older seed", () => {
+        expect(
+          resolveSeedLicense({
+            stored: EE_TEST_FIXTURE_LICENSE_KEY,
+            publicKey: PUBLIC_KEY,
+          }),
+        ).toBe(LOCAL_DEV_ENTERPRISE_LICENSE_KEY);
+      });
+    });
+
+    describe("when the stored license already verifies", () => {
+      it("keeps it, so a re-seed never clobbers a license someone activated", () => {
+        const activated = LOCAL_DEV_ENTERPRISE_LICENSE_KEY;
+        expect(
+          resolveSeedLicense({ stored: activated, publicKey: PUBLIC_KEY }),
+        ).toBe(activated);
+      });
+    });
+  });
+
+  describe("prisma/seed.ts", () => {
+    it("does not source its license from the ee test fixtures", () => {
+      const source = fs.readFileSync(
+        path.resolve(__dirname, "../../prisma/seed.ts"),
+        "utf8",
+      );
+      expect(source).not.toMatch(/ee\/licensing\/__tests__/);
+    });
+  });
+});

--- a/platform/app/scripts/__tests__/localDevLicense.unit.test.ts
+++ b/platform/app/scripts/__tests__/localDevLicense.unit.test.ts
@@ -1,11 +1,10 @@
-import fs from "fs";
-import path from "path";
 import { describe, expect, it } from "vitest";
-import { ENTERPRISE_LICENSE_KEY as EE_TEST_FIXTURE_LICENSE_KEY } from "../../ee/licensing/__tests__/fixtures/testLicenses";
+import { TEST_PUBLIC_KEY } from "../../ee/licensing/__tests__/fixtures/testKeys";
+import { ENTERPRISE_LICENSE_KEY as TEST_SUITE_LICENSE_KEY } from "../../ee/licensing/__tests__/fixtures/testLicenses";
 // The key the app boots with when LANGWATCH_LICENSE_PUBLIC_KEY is unset,
 // which is what `haven up` runs. The vitest setup swaps `PUBLIC_KEY` for the
 // test-suite key, so that export would test the wrong deployment.
-import { PLACEHOLDER_PUBLIC_KEY as PUBLIC_KEY } from "../../ee/licensing/constants";
+import { PLACEHOLDER_PUBLIC_KEY as DEFAULT_PUBLIC_KEY } from "../../ee/licensing/constants";
 import {
   parseLicenseKey,
   verifySignature,
@@ -15,30 +14,44 @@ import {
   resolveSeedLicense,
 } from "../localDevLicense";
 
-function isSignedByLangWatch(licenseKey: string): boolean {
+function isSignedFor(licenseKey: string, publicKey: string): boolean {
   const parsed = parseLicenseKey(licenseKey);
-  return parsed !== null && verifySignature(parsed, PUBLIC_KEY);
+  return parsed !== null && verifySignature(parsed, publicKey);
 }
 
-describe("localDevLicense", () => {
-  describe("given the verification key the app boots with", () => {
-    it("verifies the local-dev enterprise license", () => {
-      expect(isSignedByLangWatch(LOCAL_DEV_ENTERPRISE_LICENSE_KEY)).toBe(true);
+const SEED_CANDIDATES = [
+  LOCAL_DEV_ENTERPRISE_LICENSE_KEY,
+  TEST_SUITE_LICENSE_KEY,
+] as const;
+
+describe("LOCAL_DEV_ENTERPRISE_LICENSE_KEY", () => {
+  describe("when verified with the key the app boots with by default", () => {
+    it("verifies", () => {
+      expect(
+        isSignedFor(LOCAL_DEV_ENTERPRISE_LICENSE_KEY, DEFAULT_PUBLIC_KEY),
+      ).toBe(true);
     });
 
-    // Documents why the seed must never write the ee test fixture: it is
-    // signed with the test-suite private key, so the running app reports it
-    // as an invalid license on every settings page.
+    // Documents why the seed used to show an invalid license: the ee fixture
+    // is signed with the test-suite private key, not the default one.
     it("rejects the ee test fixture license", () => {
-      expect(isSignedByLangWatch(EE_TEST_FIXTURE_LICENSE_KEY)).toBe(false);
+      expect(isSignedFor(TEST_SUITE_LICENSE_KEY, DEFAULT_PUBLIC_KEY)).toBe(
+        false,
+      );
     });
   });
+});
 
-  describe("resolveSeedLicense", () => {
+describe("resolveSeedLicense", () => {
+  describe("given the app boots with the default key", () => {
     describe("when the organization has no license yet", () => {
       it("returns the local-dev enterprise license", () => {
         expect(
-          resolveSeedLicense({ stored: null, publicKey: PUBLIC_KEY }),
+          resolveSeedLicense({
+            stored: null,
+            publicKey: DEFAULT_PUBLIC_KEY,
+            candidates: SEED_CANDIDATES,
+          }),
         ).toBe(LOCAL_DEV_ENTERPRISE_LICENSE_KEY);
       });
     });
@@ -48,7 +61,8 @@ describe("localDevLicense", () => {
         expect(
           resolveSeedLicense({
             stored: "not-a-license",
-            publicKey: PUBLIC_KEY,
+            publicKey: DEFAULT_PUBLIC_KEY,
+            candidates: SEED_CANDIDATES,
           }),
         ).toBe(LOCAL_DEV_ENTERPRISE_LICENSE_KEY);
       });
@@ -56,8 +70,9 @@ describe("localDevLicense", () => {
       it("replaces a fixture left behind by an older seed", () => {
         expect(
           resolveSeedLicense({
-            stored: EE_TEST_FIXTURE_LICENSE_KEY,
-            publicKey: PUBLIC_KEY,
+            stored: TEST_SUITE_LICENSE_KEY,
+            publicKey: DEFAULT_PUBLIC_KEY,
+            candidates: SEED_CANDIDATES,
           }),
         ).toBe(LOCAL_DEV_ENTERPRISE_LICENSE_KEY);
       });
@@ -67,19 +82,42 @@ describe("localDevLicense", () => {
       it("keeps it, so a re-seed never clobbers a license someone activated", () => {
         const activated = LOCAL_DEV_ENTERPRISE_LICENSE_KEY;
         expect(
-          resolveSeedLicense({ stored: activated, publicKey: PUBLIC_KEY }),
+          resolveSeedLicense({
+            stored: activated,
+            publicKey: DEFAULT_PUBLIC_KEY,
+            candidates: SEED_CANDIDATES,
+          }),
         ).toBe(activated);
       });
     });
   });
 
-  describe("prisma/seed.ts", () => {
-    it("does not source its license from the ee test fixtures", () => {
-      const source = fs.readFileSync(
-        path.resolve(__dirname, "../../prisma/seed.ts"),
-        "utf8",
-      );
-      expect(source).not.toMatch(/ee\/licensing\/__tests__/);
+  describe("given the app boots with the test-suite key, as CI seeds do", () => {
+    describe("when the organization has no license yet", () => {
+      it("returns the ee test fixture, the candidate that verifies there", () => {
+        expect(
+          resolveSeedLicense({
+            stored: null,
+            publicKey: TEST_PUBLIC_KEY,
+            candidates: SEED_CANDIDATES,
+          }),
+        ).toBe(TEST_SUITE_LICENSE_KEY);
+      });
+    });
+  });
+
+  describe("given no candidate verifies against the boot key", () => {
+    describe("when the organization has no license yet", () => {
+      it("falls back to the first candidate so the org still has a readable license", () => {
+        expect(
+          resolveSeedLicense({
+            stored: null,
+            publicKey:
+              "-----BEGIN PUBLIC KEY-----\nnot-a-key\n-----END PUBLIC KEY-----",
+            candidates: SEED_CANDIDATES,
+          }),
+        ).toBe(LOCAL_DEV_ENTERPRISE_LICENSE_KEY);
+      });
     });
   });
 });

--- a/platform/app/scripts/localDevLicense.ts
+++ b/platform/app/scripts/localDevLicense.ts
@@ -4,8 +4,9 @@ import { parseLicenseKey, verifySignature } from "../ee/licensing/validation";
 /**
  * Local-dev enterprise license key for seed/dev-tooling scripts.
  *
- * This is a self-signed, pre-generated ENTERPRISE license used only to
- * bootstrap a fresh local install with enterprise features unlocked,
+ * This is a pre-generated ENTERPRISE license signed for the public key the
+ * app boots with by default, used only to bootstrap a fresh local install
+ * with enterprise features unlocked,
  * including webhookEndpointsEnabled (regenerated when the flag landed). It is
  * intentionally NOT sourced from the ee test fixtures — test fixtures are not
  * a runtime dependency surface, and rotating them must not break local seeding.
@@ -18,23 +19,31 @@ export const LOCAL_DEV_ENTERPRISE_LICENSE_KEY =
  *
  * The seed runs on every `haven up` as an idempotent upsert, so it must never
  * clobber a license somebody activated by hand: a stored license that verifies
- * against the key the app boots with stays. Anything else (no license, an
- * unreadable value, or the ee test fixture an older seed wrote, which is signed
- * with the test-suite key and reports as invalid in the running app) is
- * replaced with the local-dev key.
+ * against the key the app boots with stays. Otherwise the first candidate that
+ * verifies against that key wins, so the seed writes the local-dev key under
+ * the default key and the ee fixture under the test-suite key (CI seeds with
+ * `LANGWATCH_LICENSE_PUBLIC_KEY` set to it). If nothing verifies, the first
+ * candidate is written so the org still has a readable license.
  */
 export function resolveSeedLicense({
   stored,
   publicKey,
+  candidates = [LOCAL_DEV_ENTERPRISE_LICENSE_KEY],
 }: {
   stored: string | null;
   publicKey: string;
+  candidates?: readonly [string, ...string[]];
 }): string {
-  if (stored) {
-    const parsed = parseLicenseKey(stored);
-    if (parsed && verifySignature(parsed, publicKey)) {
-      return stored;
-    }
+  if (stored && isSignedFor(stored, publicKey)) {
+    return stored;
   }
-  return LOCAL_DEV_ENTERPRISE_LICENSE_KEY;
+  return (
+    candidates.find((candidate) => isSignedFor(candidate, publicKey)) ??
+    candidates[0]
+  );
+}
+
+function isSignedFor(licenseKey: string, publicKey: string): boolean {
+  const parsed = parseLicenseKey(licenseKey);
+  return parsed !== null && verifySignature(parsed, publicKey);
 }

--- a/platform/app/scripts/localDevLicense.ts
+++ b/platform/app/scripts/localDevLicense.ts
@@ -34,16 +34,22 @@ export function resolveSeedLicense({
   publicKey: string;
   candidates?: readonly [string, ...string[]];
 }): string {
-  if (stored && isSignedFor(stored, publicKey)) {
+  if (stored && isSignedFor({ licenseKey: stored, publicKey })) {
     return stored;
   }
   return (
-    candidates.find((candidate) => isSignedFor(candidate, publicKey)) ??
+    candidates.find((licenseKey) => isSignedFor({ licenseKey, publicKey })) ??
     candidates[0]
   );
 }
 
-function isSignedFor(licenseKey: string, publicKey: string): boolean {
+function isSignedFor({
+  licenseKey,
+  publicKey,
+}: {
+  licenseKey: string;
+  publicKey: string;
+}): boolean {
   const parsed = parseLicenseKey(licenseKey);
   return parsed !== null && verifySignature(parsed, publicKey);
 }

--- a/platform/app/scripts/localDevLicense.ts
+++ b/platform/app/scripts/localDevLicense.ts
@@ -1,4 +1,6 @@
 // gitleaks:allow — local-dev enterprise license key, not a real secret
+import { parseLicenseKey, verifySignature } from "../ee/licensing/validation";
+
 /**
  * Local-dev enterprise license key for seed/dev-tooling scripts.
  *
@@ -10,3 +12,29 @@
  */
 export const LOCAL_DEV_ENTERPRISE_LICENSE_KEY =
   "eyJkYXRhIjp7ImxpY2Vuc2VJZCI6ImxpYy1kNmYwZjIwYy1mMWY5LTQ0ODktYmMwYS03N2IxNTY5ODZiMGMiLCJ2ZXJzaW9uIjoxLCJvcmdhbml6YXRpb25OYW1lIjoiQWNtZSBDb3JwIiwiZW1haWwiOiJhZG1pbkBhY21lLmNvcnAiLCJpc3N1ZWRBdCI6IjIwMjYtMDctMzFUMTU6MzE6NDkuOTA0WiIsImV4cGlyZXNBdCI6IjIwMjctMDctMzFUMTU6MzE6NDkuOTA0WiIsInBsYW4iOnsidHlwZSI6IkVOVEVSUFJJU0UiLCJuYW1lIjoiRW50ZXJwcmlzZSIsIm1heE1lbWJlcnMiOjEwMCwibWF4TWVtYmVyc0xpdGUiOjUwLCJtYXhUZWFtcyI6MTAwLCJtYXhQcm9qZWN0cyI6NTAwLCJtYXhNZXNzYWdlc1Blck1vbnRoIjoxMDAwMDAwMCwiZXZhbHVhdGlvbnNDcmVkaXQiOjAsIm1heFdvcmtmbG93cyI6MTAwMCwibWF4UHJvbXB0cyI6MTAwMCwibWF4RXZhbHVhdG9ycyI6MTAwMCwibWF4U2NlbmFyaW9zIjoxMDAwLCJtYXhBZ2VudHMiOjEwMDAsIm1heEV4cGVyaW1lbnRzIjoxMDAwLCJtYXhPbmxpbmVFdmFsdWF0aW9ucyI6MTAwMCwibWF4RGF0YXNldHMiOjEwMDAsIm1heERhc2hib2FyZHMiOjEwMDAsIm1heEN1c3RvbUdyYXBocyI6MTAwMCwibWF4QXV0b21hdGlvbnMiOjEwMDAsImNhblB1Ymxpc2giOnRydWUsIndlYmhvb2tFbmRwb2ludHNFbmFibGVkIjp0cnVlLCJ1c2FnZVVuaXQiOiJ0cmFjZXMifX0sInNpZ25hdHVyZSI6IlQ1ZG9ZdFh2dGxZWlNBaEVVRHJZQzhBdkFqWitDeVc2d0EzTURkWXNGcktuVStINkhTNVJXMXBUUmZ5cmFLWll1MHdYL1JLRzFVNGVjMEg5a05LaXFzdDlhaVBxTTBFSWxUYlB2RllJSEZRd2NCK2t3Q3RjRDc0VmsvVW92U1h1VUpDM2ozUWpnazhQMlNCWWlnZUd4MU83SVpYR0k1L1VBV0p0YmpPT04wSitOZmFaUE8vM2lmN1lMOWpscHNwY2FqYjlrbjU4U0k0VlBNV0VuL05Tell6ZzVYcVRrZmpJNnIxK1JSTzFKR0gyT1RlUHZSU0IvR01JWlYrbEczYlVkcW5iRjFlM3dtNVBKMUVQRzVqWDFmREZPNkM1OHlSb1BpQ0NGZ3ZOTzhtaWZZa0ZodjlxQTQwOGtUdE4rQjM3Uk0yOXdINHhZbmd5UFZNNUtoNXE1UT09In0=";
+
+/**
+ * Picks the license the seed writes for the local-dev organization.
+ *
+ * The seed runs on every `haven up` as an idempotent upsert, so it must never
+ * clobber a license somebody activated by hand: a stored license that verifies
+ * against the key the app boots with stays. Anything else (no license, an
+ * unreadable value, or the ee test fixture an older seed wrote, which is signed
+ * with the test-suite key and reports as invalid in the running app) is
+ * replaced with the local-dev key.
+ */
+export function resolveSeedLicense({
+  stored,
+  publicKey,
+}: {
+  stored: string | null;
+  publicKey: string;
+}): string {
+  if (stored) {
+    const parsed = parseLicenseKey(stored);
+    if (parsed && verifySignature(parsed, publicKey)) {
+      return stored;
+    }
+  }
+  return LOCAL_DEV_ENTERPRISE_LICENSE_KEY;
+}


### PR DESCRIPTION
## For humans

Every `make haven up` left the local organization with a license the app called invalid, and it overwrote any license you had activated by hand. The seed was writing a license signed with the test-suite key, which the running app cannot verify. It now writes a license the app does verify, and it leaves a valid license alone.

## Why

`haven up` runs `prisma:seed` on every start. The seed upserted `ENTERPRISE_LICENSE_KEY` from `ee/licensing/__tests__/fixtures/testLicenses.ts` into the local-dev organization. That fixture is signed with the test-suite private key; the app boots verifying against the production public key (`ee/licensing/constants.ts`, `LANGWATCH_LICENSE_PUBLIC_KEY` unset), so `validateLicense` fails the signature and the settings page shows the license as invalid. Because the upsert's `update` branch always rewrote the column, a license activated through the UI was clobbered on the next `haven up`.

`scripts/localDevLicense.ts` already carried a local-dev enterprise key signed for the runtime verification key, and `seed-local-admin.ts` already used it. `prisma/seed.ts` was never switched.

One CI job (`sdk-javascript-ci`) seeds with `LANGWATCH_LICENSE_PUBLIC_KEY` set to the test-suite key. There the local-dev key is the one that does not verify, so the seed picks whichever candidate verifies against the key the app boots with.

## What changed

- `resolveSeedLicense` (in `scripts/localDevLicense.ts`) keeps a stored license that verifies against the boot key. Otherwise it writes the first candidate that verifies, falling back to the first candidate.
- `prisma/seed.ts` passes `[LOCAL_DEV_ENTERPRISE_LICENSE_KEY, ee fixture]`: local-dev under the default key (`haven up`), the fixture under the test key (CI).
- `PLACEHOLDER_PUBLIC_KEY` is exported so a test can target the key the app boots with under `haven up`, since the vitest setup swaps `PUBLIC_KEY` for the test-suite key.

## Test plan

- `scripts/__tests__/localDevLicense.unit.test.ts` (8 tests): the local-dev key verifies against the default key and the ee fixture does not; `resolveSeedLicense` keeps a verifying license, replaces a null, unreadable, or fixture value, picks the fixture under the test key, and falls back to the first candidate when nothing verifies. Fails on main (`resolveSeedLicense` missing).
- Re-ran the seed against a haven database that held the old fixture: stored license went from the 1112-char fixture to the 1392-char local-dev key. Subsequent runs kept it.
- `tslsp-cli diagnostics` clean on all changed files; biome clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved local development and test environment setup by selecting a license that matches the active signing key.
  - Existing valid licenses are preserved, while invalid or outdated seeded licenses are replaced automatically.

- **Tests**
  - Added coverage for license selection across default, test-suite, missing, invalid, and mismatched license scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->