### PR TITLE
fix(sdk-go): decode the annotations envelope and regenerate the REST client

### DIFF
--- a/sdks/go/client/annotations.go
+++ b/sdks/go/client/annotations.go
@@ -2,6 +2,8 @@ package client
 
 import (
 	"context"
+	"errors"
+	"net/http"
 
 	"github.com/langwatch/langwatch/sdks/go/client/internal/openapi"
 )
@@ -17,13 +19,51 @@ type AnnotationsService struct {
 // schema.
 type Annotation = openapi.Annotation
 
-// AnnotationParams is the body for creating or updating an annotation. All
-// fields are optional; supply the ones you wish to set.
+// errNoDataEnvelope is the cause reported when an annotations response decodes
+// cleanly but carried no "data" key at all.
+var errNoDataEnvelope = errors.New(`response carried no "data" envelope`)
+
+// annotationEnvelope is the {"data": …} wrapper every annotations endpoint
+// returns except Delete.
+//
+// Data is a pointer on purpose. JSON decoding ignores unknown keys, so a 2xx
+// body in some other shape — an older self-hosted server still returning the
+// bare value, or a future one that moves the payload again — decodes without
+// error and leaves Data nil. Decoding into a value instead would hand the
+// caller a zero-valued Annotation and no error, which is the silent failure
+// this envelope handling exists to prevent.
+type annotationEnvelope[T any] struct {
+	Data *T `json:"data"`
+}
+
+// decodeAnnotationEnvelope decodes a data-enveloped annotations response, and
+// refuses one whose body carried no envelope.
+func decodeAnnotationEnvelope[T any](operation string, resp *http.Response, err error) (*T, error) {
+	var env annotationEnvelope[T]
+	if derr := decodeInto(operation, resp, err, &env); derr != nil {
+		return nil, derr
+	}
+	// decodeInto only returns nil once it has seen a 2xx, so resp is non-nil
+	// here. An empty body reaches this point too: decodeInto treats io.EOF as
+	// "nothing to decode", which leaves Data nil and is equally not an answer.
+	if env.Data == nil {
+		return nil, newDecodeError(operation, resp, errNoDataEnvelope)
+	}
+	return env.Data, nil
+}
+
+// AnnotationParams is the body for creating or updating an annotation.
+//
+// Comment and IsThumbsUp are both REQUIRED by the API, on create and on update
+// alike: it rejects a body missing either with 400. They carry omitempty, so a
+// zero Comment or a nil IsThumbsUp is dropped from the request rather than sent
+// as an empty value — which means an empty comment cannot be written, and a
+// call that sets only one of the two is rejected. Set both.
 type AnnotationParams struct {
-	// Comment is free-text feedback.
+	// Comment is free-text feedback. Required; must be non-empty.
 	Comment string `json:"comment,omitempty"`
-	// IsThumbsUp records a thumbs-up/down. Pass a pointer to set it explicitly;
-	// nil leaves it unset.
+	// IsThumbsUp records a thumbs-up/down. Required; pass a pointer so the value
+	// is sent explicitly, because a nil is omitted from the body and rejected.
 	IsThumbsUp *bool `json:"isThumbsUp,omitempty"`
 	// Email attributes the annotation to a user.
 	Email string `json:"email,omitempty"`
@@ -41,11 +81,11 @@ type AnnotationParams struct {
 //	annotations, err := lw.Annotations.List(ctx)
 func (s *AnnotationsService) List(ctx context.Context) ([]Annotation, error) {
 	resp, err := s.client.gen.GetApiAnnotations(ctx, nil)
-	var out []Annotation
-	if derr := decodeInto("Annotations.List", resp, err, &out); derr != nil {
+	data, derr := decodeAnnotationEnvelope[[]Annotation]("Annotations.List", resp, err)
+	if derr != nil {
 		return nil, derr
 	}
-	return out, nil
+	return *data, nil
 }
 
 // Get fetches a single annotation by ID.
@@ -53,11 +93,7 @@ func (s *AnnotationsService) List(ctx context.Context) ([]Annotation, error) {
 //	a, err := lw.Annotations.Get(ctx, "annotation_abc")
 func (s *AnnotationsService) Get(ctx context.Context, id string) (*Annotation, error) {
 	resp, err := s.client.gen.GetApiAnnotationsId(ctx, id)
-	var out Annotation
-	if derr := decodeInto("Annotations.Get", resp, err, &out); derr != nil {
-		return nil, derr
-	}
-	return &out, nil
+	return decodeAnnotationEnvelope[Annotation]("Annotations.Get", resp, err)
 }
 
 // ListByTrace returns every annotation attached to a given trace.
@@ -65,11 +101,11 @@ func (s *AnnotationsService) Get(ctx context.Context, id string) (*Annotation, e
 //	annotations, err := lw.Annotations.ListByTrace(ctx, "trace_abc123")
 func (s *AnnotationsService) ListByTrace(ctx context.Context, traceID string) ([]Annotation, error) {
 	resp, err := s.client.gen.GetApiAnnotationsTraceId(ctx, traceID, nil)
-	var out []Annotation
-	if derr := decodeInto("Annotations.ListByTrace", resp, err, &out); derr != nil {
+	data, derr := decodeAnnotationEnvelope[[]Annotation]("Annotations.ListByTrace", resp, err)
+	if derr != nil {
 		return nil, derr
 	}
-	return out, nil
+	return *data, nil
 }
 
 // CreateForTrace attaches a new annotation to a trace.
@@ -85,27 +121,24 @@ func (s *AnnotationsService) CreateForTrace(ctx context.Context, traceID string,
 		return nil, err
 	}
 	resp, err := s.client.gen.PostApiAnnotationsTraceIdWithBody(ctx, traceID, contentTypeJSON, body)
-	var out Annotation
-	if derr := decodeInto("Annotations.CreateForTrace", resp, err, &out); derr != nil {
-		return nil, derr
-	}
-	return &out, nil
+	return decodeAnnotationEnvelope[Annotation]("Annotations.CreateForTrace", resp, err)
 }
 
-// Update modifies an existing annotation.
+// Update modifies an existing annotation. Both fields are required; see
+// [AnnotationParams].
 //
-//	a, err := lw.Annotations.Update(ctx, "annotation_abc", client.AnnotationParams{Comment: "Edited"})
+//	up := true
+//	a, err := lw.Annotations.Update(ctx, "annotation_abc", client.AnnotationParams{
+//		Comment:    "Edited",
+//		IsThumbsUp: &up,
+//	})
 func (s *AnnotationsService) Update(ctx context.Context, id string, params AnnotationParams) (*Annotation, error) {
 	body, err := jsonReader(params)
 	if err != nil {
 		return nil, err
 	}
 	resp, err := s.client.gen.PatchApiAnnotationsIdWithBody(ctx, id, contentTypeJSON, body)
-	var out Annotation
-	if derr := decodeInto("Annotations.Update", resp, err, &out); derr != nil {
-		return nil, derr
-	}
-	return &out, nil
+	return decodeAnnotationEnvelope[Annotation]("Annotations.Update", resp, err)
 }
 
 // Delete removes an annotation by ID.

--- a/sdks/go/client/internal/openapi/zz_generated.gen.go
+++ b/sdks/go/client/internal/openapi/zz_generated.gen.go
@@ -4011,19 +4011,19 @@ func (e PostApiGatewayV1VirtualKeysByIdRotate200JSONResponseBodyVirtualKeyPurpos
 
 // Defines values for PostApiGatewayV1VirtualKeysByIdRotate200JSONResponseBodyVirtualKeyRoutingMode.
 const (
-	FallbackAll PostApiGatewayV1VirtualKeysByIdRotate200JSONResponseBodyVirtualKeyRoutingMode = "fallback_all"
-	None        PostApiGatewayV1VirtualKeysByIdRotate200JSONResponseBodyVirtualKeyRoutingMode = "none"
-	Policy      PostApiGatewayV1VirtualKeysByIdRotate200JSONResponseBodyVirtualKeyRoutingMode = "policy"
+	PostApiGatewayV1VirtualKeysByIdRotate200JSONResponseBodyVirtualKeyRoutingModeFallbackAll PostApiGatewayV1VirtualKeysByIdRotate200JSONResponseBodyVirtualKeyRoutingMode = "fallback_all"
+	PostApiGatewayV1VirtualKeysByIdRotate200JSONResponseBodyVirtualKeyRoutingModeNone        PostApiGatewayV1VirtualKeysByIdRotate200JSONResponseBodyVirtualKeyRoutingMode = "none"
+	PostApiGatewayV1VirtualKeysByIdRotate200JSONResponseBodyVirtualKeyRoutingModePolicy      PostApiGatewayV1VirtualKeysByIdRotate200JSONResponseBodyVirtualKeyRoutingMode = "policy"
 )
 
 // Valid indicates whether the value is a known member of the PostApiGatewayV1VirtualKeysByIdRotate200JSONResponseBodyVirtualKeyRoutingMode enum.
 func (e PostApiGatewayV1VirtualKeysByIdRotate200JSONResponseBodyVirtualKeyRoutingMode) Valid() bool {
 	switch e {
-	case FallbackAll:
+	case PostApiGatewayV1VirtualKeysByIdRotate200JSONResponseBodyVirtualKeyRoutingModeFallbackAll:
 		return true
-	case None:
+	case PostApiGatewayV1VirtualKeysByIdRotate200JSONResponseBodyVirtualKeyRoutingModeNone:
 		return true
-	case Policy:
+	case PostApiGatewayV1VirtualKeysByIdRotate200JSONResponseBodyVirtualKeyRoutingModePolicy:
 		return true
 	default:
 		return false
@@ -10909,6 +10909,33 @@ func (e PostApiScenarioEventsJSONBody0Type) Valid() bool {
 	}
 }
 
+// Defines values for PostApiScenarioEventsJSONBody1ResultsEvaluationsStatus.
+const (
+	PostApiScenarioEventsJSONBody1ResultsEvaluationsStatusError   PostApiScenarioEventsJSONBody1ResultsEvaluationsStatus = "error"
+	PostApiScenarioEventsJSONBody1ResultsEvaluationsStatusFailed  PostApiScenarioEventsJSONBody1ResultsEvaluationsStatus = "failed"
+	PostApiScenarioEventsJSONBody1ResultsEvaluationsStatusPassed  PostApiScenarioEventsJSONBody1ResultsEvaluationsStatus = "passed"
+	PostApiScenarioEventsJSONBody1ResultsEvaluationsStatusScored  PostApiScenarioEventsJSONBody1ResultsEvaluationsStatus = "scored"
+	PostApiScenarioEventsJSONBody1ResultsEvaluationsStatusSkipped PostApiScenarioEventsJSONBody1ResultsEvaluationsStatus = "skipped"
+)
+
+// Valid indicates whether the value is a known member of the PostApiScenarioEventsJSONBody1ResultsEvaluationsStatus enum.
+func (e PostApiScenarioEventsJSONBody1ResultsEvaluationsStatus) Valid() bool {
+	switch e {
+	case PostApiScenarioEventsJSONBody1ResultsEvaluationsStatusError:
+		return true
+	case PostApiScenarioEventsJSONBody1ResultsEvaluationsStatusFailed:
+		return true
+	case PostApiScenarioEventsJSONBody1ResultsEvaluationsStatusPassed:
+		return true
+	case PostApiScenarioEventsJSONBody1ResultsEvaluationsStatusScored:
+		return true
+	case PostApiScenarioEventsJSONBody1ResultsEvaluationsStatusSkipped:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for PostApiScenarioEventsJSONBody1ResultsVerdict.
 const (
 	PostApiScenarioEventsJSONBody1ResultsVerdictFailure      PostApiScenarioEventsJSONBody1ResultsVerdict = "failure"
@@ -11302,6 +11329,60 @@ const (
 func (e GetApiSimulationRunsParamsInclude) Valid() bool {
 	switch e {
 	case Messages:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for GetApiSimulationRuns200JSONResponseBodyRunsResultsEvaluationsStatus.
+const (
+	GetApiSimulationRuns200JSONResponseBodyRunsResultsEvaluationsStatusError   GetApiSimulationRuns200JSONResponseBodyRunsResultsEvaluationsStatus = "error"
+	GetApiSimulationRuns200JSONResponseBodyRunsResultsEvaluationsStatusFailed  GetApiSimulationRuns200JSONResponseBodyRunsResultsEvaluationsStatus = "failed"
+	GetApiSimulationRuns200JSONResponseBodyRunsResultsEvaluationsStatusPassed  GetApiSimulationRuns200JSONResponseBodyRunsResultsEvaluationsStatus = "passed"
+	GetApiSimulationRuns200JSONResponseBodyRunsResultsEvaluationsStatusScored  GetApiSimulationRuns200JSONResponseBodyRunsResultsEvaluationsStatus = "scored"
+	GetApiSimulationRuns200JSONResponseBodyRunsResultsEvaluationsStatusSkipped GetApiSimulationRuns200JSONResponseBodyRunsResultsEvaluationsStatus = "skipped"
+)
+
+// Valid indicates whether the value is a known member of the GetApiSimulationRuns200JSONResponseBodyRunsResultsEvaluationsStatus enum.
+func (e GetApiSimulationRuns200JSONResponseBodyRunsResultsEvaluationsStatus) Valid() bool {
+	switch e {
+	case GetApiSimulationRuns200JSONResponseBodyRunsResultsEvaluationsStatusError:
+		return true
+	case GetApiSimulationRuns200JSONResponseBodyRunsResultsEvaluationsStatusFailed:
+		return true
+	case GetApiSimulationRuns200JSONResponseBodyRunsResultsEvaluationsStatusPassed:
+		return true
+	case GetApiSimulationRuns200JSONResponseBodyRunsResultsEvaluationsStatusScored:
+		return true
+	case GetApiSimulationRuns200JSONResponseBodyRunsResultsEvaluationsStatusSkipped:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for GetApiSimulationRunsByScenarioRunId200JSONResponseBodyResultsEvaluationsStatus.
+const (
+	GetApiSimulationRunsByScenarioRunId200JSONResponseBodyResultsEvaluationsStatusError   GetApiSimulationRunsByScenarioRunId200JSONResponseBodyResultsEvaluationsStatus = "error"
+	GetApiSimulationRunsByScenarioRunId200JSONResponseBodyResultsEvaluationsStatusFailed  GetApiSimulationRunsByScenarioRunId200JSONResponseBodyResultsEvaluationsStatus = "failed"
+	GetApiSimulationRunsByScenarioRunId200JSONResponseBodyResultsEvaluationsStatusPassed  GetApiSimulationRunsByScenarioRunId200JSONResponseBodyResultsEvaluationsStatus = "passed"
+	GetApiSimulationRunsByScenarioRunId200JSONResponseBodyResultsEvaluationsStatusScored  GetApiSimulationRunsByScenarioRunId200JSONResponseBodyResultsEvaluationsStatus = "scored"
+	GetApiSimulationRunsByScenarioRunId200JSONResponseBodyResultsEvaluationsStatusSkipped GetApiSimulationRunsByScenarioRunId200JSONResponseBodyResultsEvaluationsStatus = "skipped"
+)
+
+// Valid indicates whether the value is a known member of the GetApiSimulationRunsByScenarioRunId200JSONResponseBodyResultsEvaluationsStatus enum.
+func (e GetApiSimulationRunsByScenarioRunId200JSONResponseBodyResultsEvaluationsStatus) Valid() bool {
+	switch e {
+	case GetApiSimulationRunsByScenarioRunId200JSONResponseBodyResultsEvaluationsStatusError:
+		return true
+	case GetApiSimulationRunsByScenarioRunId200JSONResponseBodyResultsEvaluationsStatusFailed:
+		return true
+	case GetApiSimulationRunsByScenarioRunId200JSONResponseBodyResultsEvaluationsStatusPassed:
+		return true
+	case GetApiSimulationRunsByScenarioRunId200JSONResponseBodyResultsEvaluationsStatusScored:
+		return true
+	case GetApiSimulationRunsByScenarioRunId200JSONResponseBodyResultsEvaluationsStatusSkipped:
 		return true
 	default:
 		return false
@@ -12496,6 +12577,24 @@ func (e PatchApiTriggersById200JSONResponseBodyAlertType) Valid() bool {
 	}
 }
 
+// Defines values for ListAgents200JSONResponseBodyDataNotSelectableReason.
+const (
+	ListAgents200JSONResponseBodyDataNotSelectableReasonLessThannil          ListAgents200JSONResponseBodyDataNotSelectableReason = "<nil>"
+	ListAgents200JSONResponseBodyDataNotSelectableReasonOwnedByAnotherPerson ListAgents200JSONResponseBodyDataNotSelectableReason = "owned_by_another_person"
+)
+
+// Valid indicates whether the value is a known member of the ListAgents200JSONResponseBodyDataNotSelectableReason enum.
+func (e ListAgents200JSONResponseBodyDataNotSelectableReason) Valid() bool {
+	switch e {
+	case ListAgents200JSONResponseBodyDataNotSelectableReasonLessThannil:
+		return true
+	case ListAgents200JSONResponseBodyDataNotSelectableReasonOwnedByAnotherPerson:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for ListAgents200JSONResponseBodyDataParametersType.
 const (
 	ListAgents200JSONResponseBodyDataParametersTypeBoolean ListAgents200JSONResponseBodyDataParametersType = "boolean"
@@ -12589,6 +12688,24 @@ func (e CreateAgentJSONBodyType) Valid() bool {
 	}
 }
 
+// Defines values for CreateAgent201JSONResponseBodyNotSelectableReason.
+const (
+	CreateAgent201JSONResponseBodyNotSelectableReasonLessThannil          CreateAgent201JSONResponseBodyNotSelectableReason = "<nil>"
+	CreateAgent201JSONResponseBodyNotSelectableReasonOwnedByAnotherPerson CreateAgent201JSONResponseBodyNotSelectableReason = "owned_by_another_person"
+)
+
+// Valid indicates whether the value is a known member of the CreateAgent201JSONResponseBodyNotSelectableReason enum.
+func (e CreateAgent201JSONResponseBodyNotSelectableReason) Valid() bool {
+	switch e {
+	case CreateAgent201JSONResponseBodyNotSelectableReasonLessThannil:
+		return true
+	case CreateAgent201JSONResponseBodyNotSelectableReasonOwnedByAnotherPerson:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for CreateAgent201JSONResponseBodyParametersType.
 const (
 	CreateAgent201JSONResponseBodyParametersTypeBoolean CreateAgent201JSONResponseBodyParametersType = "boolean"
@@ -12672,13 +12789,13 @@ func (e PostConnectedAgentFramesJSONBodyFrames0Protocol) Valid() bool {
 
 // Defines values for PostConnectedAgentFramesJSONBodyFrames0Type.
 const (
-	Ack PostConnectedAgentFramesJSONBodyFrames0Type = "ack"
+	PostConnectedAgentFramesJSONBodyFrames0TypeAck PostConnectedAgentFramesJSONBodyFrames0Type = "ack"
 )
 
 // Valid indicates whether the value is a known member of the PostConnectedAgentFramesJSONBodyFrames0Type enum.
 func (e PostConnectedAgentFramesJSONBodyFrames0Type) Valid() bool {
 	switch e {
-	case Ack:
+	case PostConnectedAgentFramesJSONBodyFrames0TypeAck:
 		return true
 	default:
 		return false
@@ -12702,13 +12819,13 @@ func (e PostConnectedAgentFramesJSONBodyFrames1Protocol) Valid() bool {
 
 // Defines values for PostConnectedAgentFramesJSONBodyFrames1Type.
 const (
-	Result PostConnectedAgentFramesJSONBodyFrames1Type = "result"
+	PostConnectedAgentFramesJSONBodyFrames1TypeResult PostConnectedAgentFramesJSONBodyFrames1Type = "result"
 )
 
 // Valid indicates whether the value is a known member of the PostConnectedAgentFramesJSONBodyFrames1Type enum.
 func (e PostConnectedAgentFramesJSONBodyFrames1Type) Valid() bool {
 	switch e {
-	case Result:
+	case PostConnectedAgentFramesJSONBodyFrames1TypeResult:
 		return true
 	default:
 		return false
@@ -12732,13 +12849,13 @@ func (e PostConnectedAgentFramesJSONBodyFrames2Protocol) Valid() bool {
 
 // Defines values for PostConnectedAgentFramesJSONBodyFrames2Type.
 const (
-	Deregister PostConnectedAgentFramesJSONBodyFrames2Type = "deregister"
+	PostConnectedAgentFramesJSONBodyFrames2TypeDeregister PostConnectedAgentFramesJSONBodyFrames2Type = "deregister"
 )
 
 // Valid indicates whether the value is a known member of the PostConnectedAgentFramesJSONBodyFrames2Type enum.
 func (e PostConnectedAgentFramesJSONBodyFrames2Type) Valid() bool {
 	switch e {
-	case Deregister:
+	case PostConnectedAgentFramesJSONBodyFrames2TypeDeregister:
 		return true
 	default:
 		return false
@@ -12762,13 +12879,13 @@ func (e PollConnectedAgentInstance200JSONResponseBodyFrames0Protocol) Valid() bo
 
 // Defines values for PollConnectedAgentInstance200JSONResponseBodyFrames0Type.
 const (
-	Call PollConnectedAgentInstance200JSONResponseBodyFrames0Type = "call"
+	PollConnectedAgentInstance200JSONResponseBodyFrames0TypeCall PollConnectedAgentInstance200JSONResponseBodyFrames0Type = "call"
 )
 
 // Valid indicates whether the value is a known member of the PollConnectedAgentInstance200JSONResponseBodyFrames0Type enum.
 func (e PollConnectedAgentInstance200JSONResponseBodyFrames0Type) Valid() bool {
 	switch e {
-	case Call:
+	case PollConnectedAgentInstance200JSONResponseBodyFrames0TypeCall:
 		return true
 	default:
 		return false
@@ -12792,13 +12909,13 @@ func (e PollConnectedAgentInstance200JSONResponseBodyFrames1Protocol) Valid() bo
 
 // Defines values for PollConnectedAgentInstance200JSONResponseBodyFrames1Type.
 const (
-	Cancel PollConnectedAgentInstance200JSONResponseBodyFrames1Type = "cancel"
+	PollConnectedAgentInstance200JSONResponseBodyFrames1TypeCancel PollConnectedAgentInstance200JSONResponseBodyFrames1Type = "cancel"
 )
 
 // Valid indicates whether the value is a known member of the PollConnectedAgentInstance200JSONResponseBodyFrames1Type enum.
 func (e PollConnectedAgentInstance200JSONResponseBodyFrames1Type) Valid() bool {
 	switch e {
-	case Cancel:
+	case PollConnectedAgentInstance200JSONResponseBodyFrames1TypeCancel:
 		return true
 	default:
 		return false
@@ -12822,13 +12939,13 @@ func (e RegisterConnectedAgentInstanceJSONBodyProtocol) Valid() bool {
 
 // Defines values for RegisterConnectedAgentInstanceJSONBodyType.
 const (
-	Register RegisterConnectedAgentInstanceJSONBodyType = "register"
+	RegisterConnectedAgentInstanceJSONBodyTypeRegister RegisterConnectedAgentInstanceJSONBodyType = "register"
 )
 
 // Valid indicates whether the value is a known member of the RegisterConnectedAgentInstanceJSONBodyType enum.
 func (e RegisterConnectedAgentInstanceJSONBodyType) Valid() bool {
 	switch e {
-	case Register:
+	case RegisterConnectedAgentInstanceJSONBodyTypeRegister:
 		return true
 	default:
 		return false
@@ -12852,13 +12969,13 @@ func (e RegisterConnectedAgentInstance200JSONResponseBodyFrame0Protocol) Valid()
 
 // Defines values for RegisterConnectedAgentInstance200JSONResponseBodyFrame0Type.
 const (
-	Registered RegisterConnectedAgentInstance200JSONResponseBodyFrame0Type = "registered"
+	RegisterConnectedAgentInstance200JSONResponseBodyFrame0TypeRegistered RegisterConnectedAgentInstance200JSONResponseBodyFrame0Type = "registered"
 )
 
 // Valid indicates whether the value is a known member of the RegisterConnectedAgentInstance200JSONResponseBodyFrame0Type enum.
 func (e RegisterConnectedAgentInstance200JSONResponseBodyFrame0Type) Valid() bool {
 	switch e {
-	case Registered:
+	case RegisterConnectedAgentInstance200JSONResponseBodyFrame0TypeRegistered:
 		return true
 	default:
 		return false
@@ -12867,34 +12984,34 @@ func (e RegisterConnectedAgentInstance200JSONResponseBodyFrame0Type) Valid() boo
 
 // Defines values for RegisterConnectedAgentInstance200JSONResponseBodyFrame1Code.
 const (
-	ApiKeyInvalid           RegisterConnectedAgentInstance200JSONResponseBodyFrame1Code = "api_key_invalid"
-	EnvironmentInvalid      RegisterConnectedAgentInstance200JSONResponseBodyFrame1Code = "environment_invalid"
-	KeyTypeNotAllowed       RegisterConnectedAgentInstance200JSONResponseBodyFrame1Code = "key_type_not_allowed"
-	ParametersInvalid       RegisterConnectedAgentInstance200JSONResponseBodyFrame1Code = "parameters_invalid"
-	PermissionDenied        RegisterConnectedAgentInstance200JSONResponseBodyFrame1Code = "permission_denied"
-	ProjectRequired         RegisterConnectedAgentInstance200JSONResponseBodyFrame1Code = "project_required"
-	ProtocolInvalid         RegisterConnectedAgentInstance200JSONResponseBodyFrame1Code = "protocol_invalid"
-	ReplicaCountUnsupported RegisterConnectedAgentInstance200JSONResponseBodyFrame1Code = "replica_count_unsupported"
+	RegisterConnectedAgentInstance200JSONResponseBodyFrame1CodeApiKeyInvalid           RegisterConnectedAgentInstance200JSONResponseBodyFrame1Code = "api_key_invalid"
+	RegisterConnectedAgentInstance200JSONResponseBodyFrame1CodeEnvironmentInvalid      RegisterConnectedAgentInstance200JSONResponseBodyFrame1Code = "environment_invalid"
+	RegisterConnectedAgentInstance200JSONResponseBodyFrame1CodeKeyTypeNotAllowed       RegisterConnectedAgentInstance200JSONResponseBodyFrame1Code = "key_type_not_allowed"
+	RegisterConnectedAgentInstance200JSONResponseBodyFrame1CodeParametersInvalid       RegisterConnectedAgentInstance200JSONResponseBodyFrame1Code = "parameters_invalid"
+	RegisterConnectedAgentInstance200JSONResponseBodyFrame1CodePermissionDenied        RegisterConnectedAgentInstance200JSONResponseBodyFrame1Code = "permission_denied"
+	RegisterConnectedAgentInstance200JSONResponseBodyFrame1CodeProjectRequired         RegisterConnectedAgentInstance200JSONResponseBodyFrame1Code = "project_required"
+	RegisterConnectedAgentInstance200JSONResponseBodyFrame1CodeProtocolInvalid         RegisterConnectedAgentInstance200JSONResponseBodyFrame1Code = "protocol_invalid"
+	RegisterConnectedAgentInstance200JSONResponseBodyFrame1CodeReplicaCountUnsupported RegisterConnectedAgentInstance200JSONResponseBodyFrame1Code = "replica_count_unsupported"
 )
 
 // Valid indicates whether the value is a known member of the RegisterConnectedAgentInstance200JSONResponseBodyFrame1Code enum.
 func (e RegisterConnectedAgentInstance200JSONResponseBodyFrame1Code) Valid() bool {
 	switch e {
-	case ApiKeyInvalid:
+	case RegisterConnectedAgentInstance200JSONResponseBodyFrame1CodeApiKeyInvalid:
 		return true
-	case EnvironmentInvalid:
+	case RegisterConnectedAgentInstance200JSONResponseBodyFrame1CodeEnvironmentInvalid:
 		return true
-	case KeyTypeNotAllowed:
+	case RegisterConnectedAgentInstance200JSONResponseBodyFrame1CodeKeyTypeNotAllowed:
 		return true
-	case ParametersInvalid:
+	case RegisterConnectedAgentInstance200JSONResponseBodyFrame1CodeParametersInvalid:
 		return true
-	case PermissionDenied:
+	case RegisterConnectedAgentInstance200JSONResponseBodyFrame1CodePermissionDenied:
 		return true
-	case ProjectRequired:
+	case RegisterConnectedAgentInstance200JSONResponseBodyFrame1CodeProjectRequired:
 		return true
-	case ProtocolInvalid:
+	case RegisterConnectedAgentInstance200JSONResponseBodyFrame1CodeProtocolInvalid:
 		return true
-	case ReplicaCountUnsupported:
+	case RegisterConnectedAgentInstance200JSONResponseBodyFrame1CodeReplicaCountUnsupported:
 		return true
 	default:
 		return false
@@ -12918,13 +13035,13 @@ func (e RegisterConnectedAgentInstance200JSONResponseBodyFrame1Protocol) Valid()
 
 // Defines values for RegisterConnectedAgentInstance200JSONResponseBodyFrame1Type.
 const (
-	Refused RegisterConnectedAgentInstance200JSONResponseBodyFrame1Type = "refused"
+	RegisterConnectedAgentInstance200JSONResponseBodyFrame1TypeRefused RegisterConnectedAgentInstance200JSONResponseBodyFrame1Type = "refused"
 )
 
 // Valid indicates whether the value is a known member of the RegisterConnectedAgentInstance200JSONResponseBodyFrame1Type enum.
 func (e RegisterConnectedAgentInstance200JSONResponseBodyFrame1Type) Valid() bool {
 	switch e {
-	case Refused:
+	case RegisterConnectedAgentInstance200JSONResponseBodyFrame1TypeRefused:
 		return true
 	default:
 		return false
@@ -12952,6 +13069,24 @@ func (e ArchiveAgent200JSONResponseBodyType) Valid() bool {
 	case ArchiveAgent200JSONResponseBodyTypeSignature:
 		return true
 	case ArchiveAgent200JSONResponseBodyTypeWorkflow:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for GetAgent200JSONResponseBodyNotSelectableReason.
+const (
+	GetAgent200JSONResponseBodyNotSelectableReasonLessThannil          GetAgent200JSONResponseBodyNotSelectableReason = "<nil>"
+	GetAgent200JSONResponseBodyNotSelectableReasonOwnedByAnotherPerson GetAgent200JSONResponseBodyNotSelectableReason = "owned_by_another_person"
+)
+
+// Valid indicates whether the value is a known member of the GetAgent200JSONResponseBodyNotSelectableReason enum.
+func (e GetAgent200JSONResponseBodyNotSelectableReason) Valid() bool {
+	switch e {
+	case GetAgent200JSONResponseBodyNotSelectableReasonLessThannil:
+		return true
+	case GetAgent200JSONResponseBodyNotSelectableReasonOwnedByAnotherPerson:
 		return true
 	default:
 		return false
@@ -13051,6 +13186,24 @@ func (e UpdateAgentJSONBodyType) Valid() bool {
 	}
 }
 
+// Defines values for UpdateAgent200JSONResponseBodyNotSelectableReason.
+const (
+	UpdateAgent200JSONResponseBodyNotSelectableReasonLessThannil          UpdateAgent200JSONResponseBodyNotSelectableReason = "<nil>"
+	UpdateAgent200JSONResponseBodyNotSelectableReasonOwnedByAnotherPerson UpdateAgent200JSONResponseBodyNotSelectableReason = "owned_by_another_person"
+)
+
+// Valid indicates whether the value is a known member of the UpdateAgent200JSONResponseBodyNotSelectableReason enum.
+func (e UpdateAgent200JSONResponseBodyNotSelectableReason) Valid() bool {
+	switch e {
+	case UpdateAgent200JSONResponseBodyNotSelectableReasonLessThannil:
+		return true
+	case UpdateAgent200JSONResponseBodyNotSelectableReasonOwnedByAnotherPerson:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for UpdateAgent200JSONResponseBodyParametersType.
 const (
 	UpdateAgent200JSONResponseBodyParametersTypeBoolean UpdateAgent200JSONResponseBodyParametersType = "boolean"
@@ -13144,6 +13297,24 @@ func (e ReplaceAgentJSONBodyType) Valid() bool {
 	}
 }
 
+// Defines values for ReplaceAgent200JSONResponseBodyNotSelectableReason.
+const (
+	ReplaceAgent200JSONResponseBodyNotSelectableReasonLessThannil          ReplaceAgent200JSONResponseBodyNotSelectableReason = "<nil>"
+	ReplaceAgent200JSONResponseBodyNotSelectableReasonOwnedByAnotherPerson ReplaceAgent200JSONResponseBodyNotSelectableReason = "owned_by_another_person"
+)
+
+// Valid indicates whether the value is a known member of the ReplaceAgent200JSONResponseBodyNotSelectableReason enum.
+func (e ReplaceAgent200JSONResponseBodyNotSelectableReason) Valid() bool {
+	switch e {
+	case ReplaceAgent200JSONResponseBodyNotSelectableReasonLessThannil:
+		return true
+	case ReplaceAgent200JSONResponseBodyNotSelectableReasonOwnedByAnotherPerson:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for ReplaceAgent200JSONResponseBodyParametersType.
 const (
 	ReplaceAgent200JSONResponseBodyParametersTypeBoolean ReplaceAgent200JSONResponseBodyParametersType = "boolean"
@@ -13210,13 +13381,901 @@ func (e ReplaceAgent200JSONResponseBodyType) Valid() bool {
 	}
 }
 
-// Defines values for PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyGranularitySeconds0.
+// Defines values for PostLangyControlFramesJSONBodyFrames0Protocol.
 const (
-	N1 PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyGranularitySeconds0 = 1
+	PostLangyControlFramesJSONBodyFrames0ProtocolN1 PostLangyControlFramesJSONBodyFrames0Protocol = 1
 )
 
-// Valid indicates whether the value is a known member of the PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyGranularitySeconds0 enum.
-func (e PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyGranularitySeconds0) Valid() bool {
+// Valid indicates whether the value is a known member of the PostLangyControlFramesJSONBodyFrames0Protocol enum.
+func (e PostLangyControlFramesJSONBodyFrames0Protocol) Valid() bool {
+	switch e {
+	case PostLangyControlFramesJSONBodyFrames0ProtocolN1:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for PostLangyControlFramesJSONBodyFrames0Type.
+const (
+	PostLangyControlFramesJSONBodyFrames0TypeRegister PostLangyControlFramesJSONBodyFrames0Type = "register"
+)
+
+// Valid indicates whether the value is a known member of the PostLangyControlFramesJSONBodyFrames0Type enum.
+func (e PostLangyControlFramesJSONBodyFrames0Type) Valid() bool {
+	switch e {
+	case PostLangyControlFramesJSONBodyFrames0TypeRegister:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for PostLangyControlFramesJSONBodyFrames1Protocol.
+const (
+	PostLangyControlFramesJSONBodyFrames1ProtocolN1 PostLangyControlFramesJSONBodyFrames1Protocol = 1
+)
+
+// Valid indicates whether the value is a known member of the PostLangyControlFramesJSONBodyFrames1Protocol enum.
+func (e PostLangyControlFramesJSONBodyFrames1Protocol) Valid() bool {
+	switch e {
+	case PostLangyControlFramesJSONBodyFrames1ProtocolN1:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for PostLangyControlFramesJSONBodyFrames1Type.
+const (
+	PostLangyControlFramesJSONBodyFrames1TypeAck PostLangyControlFramesJSONBodyFrames1Type = "ack"
+)
+
+// Valid indicates whether the value is a known member of the PostLangyControlFramesJSONBodyFrames1Type enum.
+func (e PostLangyControlFramesJSONBodyFrames1Type) Valid() bool {
+	switch e {
+	case PostLangyControlFramesJSONBodyFrames1TypeAck:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for PostLangyControlFramesJSONBodyFrames2ErrorCode.
+const (
+	PostLangyControlFramesJSONBodyFrames2ErrorCodeCancelled         PostLangyControlFramesJSONBodyFrames2ErrorCode = "cancelled"
+	PostLangyControlFramesJSONBodyFrames2ErrorCodeCommandRefused    PostLangyControlFramesJSONBodyFrames2ErrorCode = "command_refused"
+	PostLangyControlFramesJSONBodyFrames2ErrorCodeExecFailed        PostLangyControlFramesJSONBodyFrames2ErrorCode = "exec_failed"
+	PostLangyControlFramesJSONBodyFrames2ErrorCodeNotFound          PostLangyControlFramesJSONBodyFrames2ErrorCode = "not_found"
+	PostLangyControlFramesJSONBodyFrames2ErrorCodePathRefused       PostLangyControlFramesJSONBodyFrames2ErrorCode = "path_refused"
+	PostLangyControlFramesJSONBodyFrames2ErrorCodePermissionDenied  PostLangyControlFramesJSONBodyFrames2ErrorCode = "permission_denied"
+	PostLangyControlFramesJSONBodyFrames2ErrorCodePermissionExpired PostLangyControlFramesJSONBodyFrames2ErrorCode = "permission_expired"
+	PostLangyControlFramesJSONBodyFrames2ErrorCodeTimeout           PostLangyControlFramesJSONBodyFrames2ErrorCode = "timeout"
+)
+
+// Valid indicates whether the value is a known member of the PostLangyControlFramesJSONBodyFrames2ErrorCode enum.
+func (e PostLangyControlFramesJSONBodyFrames2ErrorCode) Valid() bool {
+	switch e {
+	case PostLangyControlFramesJSONBodyFrames2ErrorCodeCancelled:
+		return true
+	case PostLangyControlFramesJSONBodyFrames2ErrorCodeCommandRefused:
+		return true
+	case PostLangyControlFramesJSONBodyFrames2ErrorCodeExecFailed:
+		return true
+	case PostLangyControlFramesJSONBodyFrames2ErrorCodeNotFound:
+		return true
+	case PostLangyControlFramesJSONBodyFrames2ErrorCodePathRefused:
+		return true
+	case PostLangyControlFramesJSONBodyFrames2ErrorCodePermissionDenied:
+		return true
+	case PostLangyControlFramesJSONBodyFrames2ErrorCodePermissionExpired:
+		return true
+	case PostLangyControlFramesJSONBodyFrames2ErrorCodeTimeout:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for PostLangyControlFramesJSONBodyFrames2Protocol.
+const (
+	PostLangyControlFramesJSONBodyFrames2ProtocolN1 PostLangyControlFramesJSONBodyFrames2Protocol = 1
+)
+
+// Valid indicates whether the value is a known member of the PostLangyControlFramesJSONBodyFrames2Protocol enum.
+func (e PostLangyControlFramesJSONBodyFrames2Protocol) Valid() bool {
+	switch e {
+	case PostLangyControlFramesJSONBodyFrames2ProtocolN1:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for PostLangyControlFramesJSONBodyFrames2Type.
+const (
+	PostLangyControlFramesJSONBodyFrames2TypeResult PostLangyControlFramesJSONBodyFrames2Type = "result"
+)
+
+// Valid indicates whether the value is a known member of the PostLangyControlFramesJSONBodyFrames2Type enum.
+func (e PostLangyControlFramesJSONBodyFrames2Type) Valid() bool {
+	switch e {
+	case PostLangyControlFramesJSONBodyFrames2TypeResult:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for PostLangyControlFramesJSONBodyFrames3Protocol.
+const (
+	PostLangyControlFramesJSONBodyFrames3ProtocolN1 PostLangyControlFramesJSONBodyFrames3Protocol = 1
+)
+
+// Valid indicates whether the value is a known member of the PostLangyControlFramesJSONBodyFrames3Protocol enum.
+func (e PostLangyControlFramesJSONBodyFrames3Protocol) Valid() bool {
+	switch e {
+	case PostLangyControlFramesJSONBodyFrames3ProtocolN1:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for PostLangyControlFramesJSONBodyFrames3Type.
+const (
+	PermissionRequired PostLangyControlFramesJSONBodyFrames3Type = "permission_required"
+)
+
+// Valid indicates whether the value is a known member of the PostLangyControlFramesJSONBodyFrames3Type enum.
+func (e PostLangyControlFramesJSONBodyFrames3Type) Valid() bool {
+	switch e {
+	case PermissionRequired:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for PostLangyControlFramesJSONBodyFrames4Decision.
+const (
+	PostLangyControlFramesJSONBodyFrames4DecisionAllowOnce    PostLangyControlFramesJSONBodyFrames4Decision = "allow_once"
+	PostLangyControlFramesJSONBodyFrames4DecisionAllowPattern PostLangyControlFramesJSONBodyFrames4Decision = "allow_pattern"
+	PostLangyControlFramesJSONBodyFrames4DecisionDeny         PostLangyControlFramesJSONBodyFrames4Decision = "deny"
+)
+
+// Valid indicates whether the value is a known member of the PostLangyControlFramesJSONBodyFrames4Decision enum.
+func (e PostLangyControlFramesJSONBodyFrames4Decision) Valid() bool {
+	switch e {
+	case PostLangyControlFramesJSONBodyFrames4DecisionAllowOnce:
+		return true
+	case PostLangyControlFramesJSONBodyFrames4DecisionAllowPattern:
+		return true
+	case PostLangyControlFramesJSONBodyFrames4DecisionDeny:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for PostLangyControlFramesJSONBodyFrames4Protocol.
+const (
+	PostLangyControlFramesJSONBodyFrames4ProtocolN1 PostLangyControlFramesJSONBodyFrames4Protocol = 1
+)
+
+// Valid indicates whether the value is a known member of the PostLangyControlFramesJSONBodyFrames4Protocol enum.
+func (e PostLangyControlFramesJSONBodyFrames4Protocol) Valid() bool {
+	switch e {
+	case PostLangyControlFramesJSONBodyFrames4ProtocolN1:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for PostLangyControlFramesJSONBodyFrames4Type.
+const (
+	PermissionAnswered PostLangyControlFramesJSONBodyFrames4Type = "permission_answered"
+)
+
+// Valid indicates whether the value is a known member of the PostLangyControlFramesJSONBodyFrames4Type enum.
+func (e PostLangyControlFramesJSONBodyFrames4Type) Valid() bool {
+	switch e {
+	case PermissionAnswered:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for PostLangyControlFramesJSONBodyFrames5Protocol.
+const (
+	PostLangyControlFramesJSONBodyFrames5ProtocolN1 PostLangyControlFramesJSONBodyFrames5Protocol = 1
+)
+
+// Valid indicates whether the value is a known member of the PostLangyControlFramesJSONBodyFrames5Protocol enum.
+func (e PostLangyControlFramesJSONBodyFrames5Protocol) Valid() bool {
+	switch e {
+	case PostLangyControlFramesJSONBodyFrames5ProtocolN1:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for PostLangyControlFramesJSONBodyFrames5Type.
+const (
+	PostLangyControlFramesJSONBodyFrames5TypeDeregister PostLangyControlFramesJSONBodyFrames5Type = "deregister"
+)
+
+// Valid indicates whether the value is a known member of the PostLangyControlFramesJSONBodyFrames5Type enum.
+func (e PostLangyControlFramesJSONBodyFrames5Type) Valid() bool {
+	switch e {
+	case PostLangyControlFramesJSONBodyFrames5TypeDeregister:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for PollLangyControlSession200JSONResponseBodyFrames0Protocol.
+const (
+	PollLangyControlSession200JSONResponseBodyFrames0ProtocolN1 PollLangyControlSession200JSONResponseBodyFrames0Protocol = 1
+)
+
+// Valid indicates whether the value is a known member of the PollLangyControlSession200JSONResponseBodyFrames0Protocol enum.
+func (e PollLangyControlSession200JSONResponseBodyFrames0Protocol) Valid() bool {
+	switch e {
+	case PollLangyControlSession200JSONResponseBodyFrames0ProtocolN1:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for PollLangyControlSession200JSONResponseBodyFrames0Type.
+const (
+	PollLangyControlSession200JSONResponseBodyFrames0TypeRegistered PollLangyControlSession200JSONResponseBodyFrames0Type = "registered"
+)
+
+// Valid indicates whether the value is a known member of the PollLangyControlSession200JSONResponseBodyFrames0Type enum.
+func (e PollLangyControlSession200JSONResponseBodyFrames0Type) Valid() bool {
+	switch e {
+	case PollLangyControlSession200JSONResponseBodyFrames0TypeRegistered:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for PollLangyControlSession200JSONResponseBodyFrames1Code.
+const (
+	PollLangyControlSession200JSONResponseBodyFrames1CodeApiKeyInvalid             PollLangyControlSession200JSONResponseBodyFrames1Code = "api_key_invalid"
+	PollLangyControlSession200JSONResponseBodyFrames1CodeConversationMismatch      PollLangyControlSession200JSONResponseBodyFrames1Code = "conversation_mismatch"
+	PollLangyControlSession200JSONResponseBodyFrames1CodeKeyTypeNotAllowed         PollLangyControlSession200JSONResponseBodyFrames1Code = "key_type_not_allowed"
+	PollLangyControlSession200JSONResponseBodyFrames1CodeProtocolInvalid           PollLangyControlSession200JSONResponseBodyFrames1Code = "protocol_invalid"
+	PollLangyControlSession200JSONResponseBodyFrames1CodeReplicaCountUnsupported   PollLangyControlSession200JSONResponseBodyFrames1Code = "replica_count_unsupported"
+	PollLangyControlSession200JSONResponseBodyFrames1CodeWorkspaceAlreadyConnected PollLangyControlSession200JSONResponseBodyFrames1Code = "workspace_already_connected"
+)
+
+// Valid indicates whether the value is a known member of the PollLangyControlSession200JSONResponseBodyFrames1Code enum.
+func (e PollLangyControlSession200JSONResponseBodyFrames1Code) Valid() bool {
+	switch e {
+	case PollLangyControlSession200JSONResponseBodyFrames1CodeApiKeyInvalid:
+		return true
+	case PollLangyControlSession200JSONResponseBodyFrames1CodeConversationMismatch:
+		return true
+	case PollLangyControlSession200JSONResponseBodyFrames1CodeKeyTypeNotAllowed:
+		return true
+	case PollLangyControlSession200JSONResponseBodyFrames1CodeProtocolInvalid:
+		return true
+	case PollLangyControlSession200JSONResponseBodyFrames1CodeReplicaCountUnsupported:
+		return true
+	case PollLangyControlSession200JSONResponseBodyFrames1CodeWorkspaceAlreadyConnected:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for PollLangyControlSession200JSONResponseBodyFrames1Protocol.
+const (
+	PollLangyControlSession200JSONResponseBodyFrames1ProtocolN1 PollLangyControlSession200JSONResponseBodyFrames1Protocol = 1
+)
+
+// Valid indicates whether the value is a known member of the PollLangyControlSession200JSONResponseBodyFrames1Protocol enum.
+func (e PollLangyControlSession200JSONResponseBodyFrames1Protocol) Valid() bool {
+	switch e {
+	case PollLangyControlSession200JSONResponseBodyFrames1ProtocolN1:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for PollLangyControlSession200JSONResponseBodyFrames1Type.
+const (
+	PollLangyControlSession200JSONResponseBodyFrames1TypeRefused PollLangyControlSession200JSONResponseBodyFrames1Type = "refused"
+)
+
+// Valid indicates whether the value is a known member of the PollLangyControlSession200JSONResponseBodyFrames1Type enum.
+func (e PollLangyControlSession200JSONResponseBodyFrames1Type) Valid() bool {
+	switch e {
+	case PollLangyControlSession200JSONResponseBodyFrames1TypeRefused:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for PollLangyControlSession200JSONResponseBodyFrames2Call0Tool.
+const (
+	LocalRead PollLangyControlSession200JSONResponseBodyFrames2Call0Tool = "local_read"
+)
+
+// Valid indicates whether the value is a known member of the PollLangyControlSession200JSONResponseBodyFrames2Call0Tool enum.
+func (e PollLangyControlSession200JSONResponseBodyFrames2Call0Tool) Valid() bool {
+	switch e {
+	case LocalRead:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for PollLangyControlSession200JSONResponseBodyFrames2Call1Tool.
+const (
+	LocalWrite PollLangyControlSession200JSONResponseBodyFrames2Call1Tool = "local_write"
+)
+
+// Valid indicates whether the value is a known member of the PollLangyControlSession200JSONResponseBodyFrames2Call1Tool enum.
+func (e PollLangyControlSession200JSONResponseBodyFrames2Call1Tool) Valid() bool {
+	switch e {
+	case LocalWrite:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for PollLangyControlSession200JSONResponseBodyFrames2Call2Tool.
+const (
+	LocalEdit PollLangyControlSession200JSONResponseBodyFrames2Call2Tool = "local_edit"
+)
+
+// Valid indicates whether the value is a known member of the PollLangyControlSession200JSONResponseBodyFrames2Call2Tool enum.
+func (e PollLangyControlSession200JSONResponseBodyFrames2Call2Tool) Valid() bool {
+	switch e {
+	case LocalEdit:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for PollLangyControlSession200JSONResponseBodyFrames2Call3Tool.
+const (
+	LocalBash PollLangyControlSession200JSONResponseBodyFrames2Call3Tool = "local_bash"
+)
+
+// Valid indicates whether the value is a known member of the PollLangyControlSession200JSONResponseBodyFrames2Call3Tool enum.
+func (e PollLangyControlSession200JSONResponseBodyFrames2Call3Tool) Valid() bool {
+	switch e {
+	case LocalBash:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for PollLangyControlSession200JSONResponseBodyFrames2Call4Tool.
+const (
+	LocalGrep PollLangyControlSession200JSONResponseBodyFrames2Call4Tool = "local_grep"
+)
+
+// Valid indicates whether the value is a known member of the PollLangyControlSession200JSONResponseBodyFrames2Call4Tool enum.
+func (e PollLangyControlSession200JSONResponseBodyFrames2Call4Tool) Valid() bool {
+	switch e {
+	case LocalGrep:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for PollLangyControlSession200JSONResponseBodyFrames2Call5Tool.
+const (
+	LocalFind PollLangyControlSession200JSONResponseBodyFrames2Call5Tool = "local_find"
+)
+
+// Valid indicates whether the value is a known member of the PollLangyControlSession200JSONResponseBodyFrames2Call5Tool enum.
+func (e PollLangyControlSession200JSONResponseBodyFrames2Call5Tool) Valid() bool {
+	switch e {
+	case LocalFind:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for PollLangyControlSession200JSONResponseBodyFrames2Call6Tool.
+const (
+	LocalLs PollLangyControlSession200JSONResponseBodyFrames2Call6Tool = "local_ls"
+)
+
+// Valid indicates whether the value is a known member of the PollLangyControlSession200JSONResponseBodyFrames2Call6Tool enum.
+func (e PollLangyControlSession200JSONResponseBodyFrames2Call6Tool) Valid() bool {
+	switch e {
+	case LocalLs:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for PollLangyControlSession200JSONResponseBodyFrames2Protocol.
+const (
+	PollLangyControlSession200JSONResponseBodyFrames2ProtocolN1 PollLangyControlSession200JSONResponseBodyFrames2Protocol = 1
+)
+
+// Valid indicates whether the value is a known member of the PollLangyControlSession200JSONResponseBodyFrames2Protocol enum.
+func (e PollLangyControlSession200JSONResponseBodyFrames2Protocol) Valid() bool {
+	switch e {
+	case PollLangyControlSession200JSONResponseBodyFrames2ProtocolN1:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for PollLangyControlSession200JSONResponseBodyFrames2Type.
+const (
+	PollLangyControlSession200JSONResponseBodyFrames2TypeCall PollLangyControlSession200JSONResponseBodyFrames2Type = "call"
+)
+
+// Valid indicates whether the value is a known member of the PollLangyControlSession200JSONResponseBodyFrames2Type enum.
+func (e PollLangyControlSession200JSONResponseBodyFrames2Type) Valid() bool {
+	switch e {
+	case PollLangyControlSession200JSONResponseBodyFrames2TypeCall:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for PollLangyControlSession200JSONResponseBodyFrames3Protocol.
+const (
+	PollLangyControlSession200JSONResponseBodyFrames3ProtocolN1 PollLangyControlSession200JSONResponseBodyFrames3Protocol = 1
+)
+
+// Valid indicates whether the value is a known member of the PollLangyControlSession200JSONResponseBodyFrames3Protocol enum.
+func (e PollLangyControlSession200JSONResponseBodyFrames3Protocol) Valid() bool {
+	switch e {
+	case PollLangyControlSession200JSONResponseBodyFrames3ProtocolN1:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for PollLangyControlSession200JSONResponseBodyFrames3Type.
+const (
+	PollLangyControlSession200JSONResponseBodyFrames3TypeCancel PollLangyControlSession200JSONResponseBodyFrames3Type = "cancel"
+)
+
+// Valid indicates whether the value is a known member of the PollLangyControlSession200JSONResponseBodyFrames3Type enum.
+func (e PollLangyControlSession200JSONResponseBodyFrames3Type) Valid() bool {
+	switch e {
+	case PollLangyControlSession200JSONResponseBodyFrames3TypeCancel:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for PollLangyControlSession200JSONResponseBodyFrames4Decision.
+const (
+	PollLangyControlSession200JSONResponseBodyFrames4DecisionAllowOnce    PollLangyControlSession200JSONResponseBodyFrames4Decision = "allow_once"
+	PollLangyControlSession200JSONResponseBodyFrames4DecisionAllowPattern PollLangyControlSession200JSONResponseBodyFrames4Decision = "allow_pattern"
+	PollLangyControlSession200JSONResponseBodyFrames4DecisionDeny         PollLangyControlSession200JSONResponseBodyFrames4Decision = "deny"
+	PollLangyControlSession200JSONResponseBodyFrames4DecisionExpired      PollLangyControlSession200JSONResponseBodyFrames4Decision = "expired"
+)
+
+// Valid indicates whether the value is a known member of the PollLangyControlSession200JSONResponseBodyFrames4Decision enum.
+func (e PollLangyControlSession200JSONResponseBodyFrames4Decision) Valid() bool {
+	switch e {
+	case PollLangyControlSession200JSONResponseBodyFrames4DecisionAllowOnce:
+		return true
+	case PollLangyControlSession200JSONResponseBodyFrames4DecisionAllowPattern:
+		return true
+	case PollLangyControlSession200JSONResponseBodyFrames4DecisionDeny:
+		return true
+	case PollLangyControlSession200JSONResponseBodyFrames4DecisionExpired:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for PollLangyControlSession200JSONResponseBodyFrames4Protocol.
+const (
+	PollLangyControlSession200JSONResponseBodyFrames4ProtocolN1 PollLangyControlSession200JSONResponseBodyFrames4Protocol = 1
+)
+
+// Valid indicates whether the value is a known member of the PollLangyControlSession200JSONResponseBodyFrames4Protocol enum.
+func (e PollLangyControlSession200JSONResponseBodyFrames4Protocol) Valid() bool {
+	switch e {
+	case PollLangyControlSession200JSONResponseBodyFrames4ProtocolN1:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for PollLangyControlSession200JSONResponseBodyFrames4Type.
+const (
+	Permission PollLangyControlSession200JSONResponseBodyFrames4Type = "permission"
+)
+
+// Valid indicates whether the value is a known member of the PollLangyControlSession200JSONResponseBodyFrames4Type enum.
+func (e PollLangyControlSession200JSONResponseBodyFrames4Type) Valid() bool {
+	switch e {
+	case Permission:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for PollLangyControlSession200JSONResponseBodyFrames5Protocol.
+const (
+	PollLangyControlSession200JSONResponseBodyFrames5ProtocolN1 PollLangyControlSession200JSONResponseBodyFrames5Protocol = 1
+)
+
+// Valid indicates whether the value is a known member of the PollLangyControlSession200JSONResponseBodyFrames5Protocol enum.
+func (e PollLangyControlSession200JSONResponseBodyFrames5Protocol) Valid() bool {
+	switch e {
+	case PollLangyControlSession200JSONResponseBodyFrames5ProtocolN1:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for PollLangyControlSession200JSONResponseBodyFrames5Type.
+const (
+	PollLangyControlSession200JSONResponseBodyFrames5TypePolicy PollLangyControlSession200JSONResponseBodyFrames5Type = "policy"
+)
+
+// Valid indicates whether the value is a known member of the PollLangyControlSession200JSONResponseBodyFrames5Type enum.
+func (e PollLangyControlSession200JSONResponseBodyFrames5Type) Valid() bool {
+	switch e {
+	case PollLangyControlSession200JSONResponseBodyFrames5TypePolicy:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for PollLangyControlSession200JSONResponseBodyFrames6Protocol.
+const (
+	PollLangyControlSession200JSONResponseBodyFrames6ProtocolN1 PollLangyControlSession200JSONResponseBodyFrames6Protocol = 1
+)
+
+// Valid indicates whether the value is a known member of the PollLangyControlSession200JSONResponseBodyFrames6Protocol enum.
+func (e PollLangyControlSession200JSONResponseBodyFrames6Protocol) Valid() bool {
+	switch e {
+	case PollLangyControlSession200JSONResponseBodyFrames6ProtocolN1:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for PollLangyControlSession200JSONResponseBodyFrames6Type.
+const (
+	Disconnect PollLangyControlSession200JSONResponseBodyFrames6Type = "disconnect"
+)
+
+// Valid indicates whether the value is a known member of the PollLangyControlSession200JSONResponseBodyFrames6Type enum.
+func (e PollLangyControlSession200JSONResponseBodyFrames6Type) Valid() bool {
+	switch e {
+	case Disconnect:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for RegisterLangyControlSessionJSONBodyProtocol.
+const (
+	RegisterLangyControlSessionJSONBodyProtocolN1 RegisterLangyControlSessionJSONBodyProtocol = 1
+)
+
+// Valid indicates whether the value is a known member of the RegisterLangyControlSessionJSONBodyProtocol enum.
+func (e RegisterLangyControlSessionJSONBodyProtocol) Valid() bool {
+	switch e {
+	case RegisterLangyControlSessionJSONBodyProtocolN1:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for RegisterLangyControlSessionJSONBodyType.
+const (
+	Register RegisterLangyControlSessionJSONBodyType = "register"
+)
+
+// Valid indicates whether the value is a known member of the RegisterLangyControlSessionJSONBodyType enum.
+func (e RegisterLangyControlSessionJSONBodyType) Valid() bool {
+	switch e {
+	case Register:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for RegisterLangyControlSession200JSONResponseBodyFrame0Protocol.
+const (
+	RegisterLangyControlSession200JSONResponseBodyFrame0ProtocolN1 RegisterLangyControlSession200JSONResponseBodyFrame0Protocol = 1
+)
+
+// Valid indicates whether the value is a known member of the RegisterLangyControlSession200JSONResponseBodyFrame0Protocol enum.
+func (e RegisterLangyControlSession200JSONResponseBodyFrame0Protocol) Valid() bool {
+	switch e {
+	case RegisterLangyControlSession200JSONResponseBodyFrame0ProtocolN1:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for RegisterLangyControlSession200JSONResponseBodyFrame0Type.
+const (
+	Registered RegisterLangyControlSession200JSONResponseBodyFrame0Type = "registered"
+)
+
+// Valid indicates whether the value is a known member of the RegisterLangyControlSession200JSONResponseBodyFrame0Type enum.
+func (e RegisterLangyControlSession200JSONResponseBodyFrame0Type) Valid() bool {
+	switch e {
+	case Registered:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for RegisterLangyControlSession200JSONResponseBodyFrame1Code.
+const (
+	RegisterLangyControlSession200JSONResponseBodyFrame1CodeApiKeyInvalid             RegisterLangyControlSession200JSONResponseBodyFrame1Code = "api_key_invalid"
+	RegisterLangyControlSession200JSONResponseBodyFrame1CodeConversationMismatch      RegisterLangyControlSession200JSONResponseBodyFrame1Code = "conversation_mismatch"
+	RegisterLangyControlSession200JSONResponseBodyFrame1CodeKeyTypeNotAllowed         RegisterLangyControlSession200JSONResponseBodyFrame1Code = "key_type_not_allowed"
+	RegisterLangyControlSession200JSONResponseBodyFrame1CodeProtocolInvalid           RegisterLangyControlSession200JSONResponseBodyFrame1Code = "protocol_invalid"
+	RegisterLangyControlSession200JSONResponseBodyFrame1CodeReplicaCountUnsupported   RegisterLangyControlSession200JSONResponseBodyFrame1Code = "replica_count_unsupported"
+	RegisterLangyControlSession200JSONResponseBodyFrame1CodeWorkspaceAlreadyConnected RegisterLangyControlSession200JSONResponseBodyFrame1Code = "workspace_already_connected"
+)
+
+// Valid indicates whether the value is a known member of the RegisterLangyControlSession200JSONResponseBodyFrame1Code enum.
+func (e RegisterLangyControlSession200JSONResponseBodyFrame1Code) Valid() bool {
+	switch e {
+	case RegisterLangyControlSession200JSONResponseBodyFrame1CodeApiKeyInvalid:
+		return true
+	case RegisterLangyControlSession200JSONResponseBodyFrame1CodeConversationMismatch:
+		return true
+	case RegisterLangyControlSession200JSONResponseBodyFrame1CodeKeyTypeNotAllowed:
+		return true
+	case RegisterLangyControlSession200JSONResponseBodyFrame1CodeProtocolInvalid:
+		return true
+	case RegisterLangyControlSession200JSONResponseBodyFrame1CodeReplicaCountUnsupported:
+		return true
+	case RegisterLangyControlSession200JSONResponseBodyFrame1CodeWorkspaceAlreadyConnected:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for RegisterLangyControlSession200JSONResponseBodyFrame1Protocol.
+const (
+	RegisterLangyControlSession200JSONResponseBodyFrame1ProtocolN1 RegisterLangyControlSession200JSONResponseBodyFrame1Protocol = 1
+)
+
+// Valid indicates whether the value is a known member of the RegisterLangyControlSession200JSONResponseBodyFrame1Protocol enum.
+func (e RegisterLangyControlSession200JSONResponseBodyFrame1Protocol) Valid() bool {
+	switch e {
+	case RegisterLangyControlSession200JSONResponseBodyFrame1ProtocolN1:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for RegisterLangyControlSession200JSONResponseBodyFrame1Type.
+const (
+	Refused RegisterLangyControlSession200JSONResponseBodyFrame1Type = "refused"
+)
+
+// Valid indicates whether the value is a known member of the RegisterLangyControlSession200JSONResponseBodyFrame1Type enum.
+func (e RegisterLangyControlSession200JSONResponseBodyFrame1Type) Valid() bool {
+	switch e {
+	case Refused:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for CancelLangyControlRequest200JSONResponseBodyCancelled.
+const (
+	CancelLangyControlRequest200JSONResponseBodyCancelledTrue CancelLangyControlRequest200JSONResponseBodyCancelled = true
+)
+
+// Valid indicates whether the value is a known member of the CancelLangyControlRequest200JSONResponseBodyCancelled enum.
+func (e CancelLangyControlRequest200JSONResponseBodyCancelled) Valid() bool {
+	switch e {
+	case CancelLangyControlRequest200JSONResponseBodyCancelledTrue:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBodyDataDefinitionQueriesParametersType.
+const (
+	GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBodyDataDefinitionQueriesParametersTypeBoolean GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBodyDataDefinitionQueriesParametersType = "boolean"
+	GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBodyDataDefinitionQueriesParametersTypeNumber  GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBodyDataDefinitionQueriesParametersType = "number"
+	GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBodyDataDefinitionQueriesParametersTypeString  GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBodyDataDefinitionQueriesParametersType = "string"
+)
+
+// Valid indicates whether the value is a known member of the GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBodyDataDefinitionQueriesParametersType enum.
+func (e GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBodyDataDefinitionQueriesParametersType) Valid() bool {
+	switch e {
+	case GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBodyDataDefinitionQueriesParametersTypeBoolean:
+		return true
+	case GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBodyDataDefinitionQueriesParametersTypeNumber:
+		return true
+	case GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBodyDataDefinitionQueriesParametersTypeString:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBodyQueriesParametersType.
+const (
+	PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBodyQueriesParametersTypeBoolean PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBodyQueriesParametersType = "boolean"
+	PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBodyQueriesParametersTypeNumber  PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBodyQueriesParametersType = "number"
+	PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBodyQueriesParametersTypeString  PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBodyQueriesParametersType = "string"
+)
+
+// Valid indicates whether the value is a known member of the PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBodyQueriesParametersType enum.
+func (e PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBodyQueriesParametersType) Valid() bool {
+	switch e {
+	case PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBodyQueriesParametersTypeBoolean:
+		return true
+	case PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBodyQueriesParametersTypeNumber:
+		return true
+	case PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBodyQueriesParametersTypeString:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBodyDefinitionQueriesParametersType.
+const (
+	PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBodyDefinitionQueriesParametersTypeBoolean PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBodyDefinitionQueriesParametersType = "boolean"
+	PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBodyDefinitionQueriesParametersTypeNumber  PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBodyDefinitionQueriesParametersType = "number"
+	PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBodyDefinitionQueriesParametersTypeString  PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBodyDefinitionQueriesParametersType = "string"
+)
+
+// Valid indicates whether the value is a known member of the PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBodyDefinitionQueriesParametersType enum.
+func (e PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBodyDefinitionQueriesParametersType) Valid() bool {
+	switch e {
+	case PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBodyDefinitionQueriesParametersTypeBoolean:
+		return true
+	case PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBodyDefinitionQueriesParametersTypeNumber:
+		return true
+	case PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBodyDefinitionQueriesParametersTypeString:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersType.
+const (
+	GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersTypeBoolean GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersType = "boolean"
+	GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersTypeNumber  GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersType = "number"
+	GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersTypeString  GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersType = "string"
+)
+
+// Valid indicates whether the value is a known member of the GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersType enum.
+func (e GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersType) Valid() bool {
+	switch e {
+	case GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersTypeBoolean:
+		return true
+	case GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersTypeNumber:
+		return true
+	case GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersTypeString:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBodyQueriesParametersType.
+const (
+	PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBodyQueriesParametersTypeBoolean PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBodyQueriesParametersType = "boolean"
+	PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBodyQueriesParametersTypeNumber  PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBodyQueriesParametersType = "number"
+	PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBodyQueriesParametersTypeString  PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBodyQueriesParametersType = "string"
+)
+
+// Valid indicates whether the value is a known member of the PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBodyQueriesParametersType enum.
+func (e PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBodyQueriesParametersType) Valid() bool {
+	switch e {
+	case PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBodyQueriesParametersTypeBoolean:
+		return true
+	case PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBodyQueriesParametersTypeNumber:
+		return true
+	case PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBodyQueriesParametersTypeString:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersType.
+const (
+	PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersTypeBoolean PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersType = "boolean"
+	PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersTypeNumber  PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersType = "number"
+	PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersTypeString  PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersType = "string"
+)
+
+// Valid indicates whether the value is a known member of the PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersType enum.
+func (e PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersType) Valid() bool {
+	switch e {
+	case PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersTypeBoolean:
+		return true
+	case PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersTypeNumber:
+		return true
+	case PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersTypeString:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBodyDefinitionQueriesParametersType.
+const (
+	PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBodyDefinitionQueriesParametersTypeBoolean PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBodyDefinitionQueriesParametersType = "boolean"
+	PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBodyDefinitionQueriesParametersTypeNumber  PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBodyDefinitionQueriesParametersType = "number"
+	PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBodyDefinitionQueriesParametersTypeString  PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBodyDefinitionQueriesParametersType = "string"
+)
+
+// Valid indicates whether the value is a known member of the PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBodyDefinitionQueriesParametersType enum.
+func (e PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBodyDefinitionQueriesParametersType) Valid() bool {
+	switch e {
+	case PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBodyDefinitionQueriesParametersTypeBoolean:
+		return true
+	case PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBodyDefinitionQueriesParametersTypeNumber:
+		return true
+	case PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBodyDefinitionQueriesParametersTypeString:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for PostApiV1QueryJSONBodyGranularitySeconds0.
+const (
+	N1 PostApiV1QueryJSONBodyGranularitySeconds0 = 1
+)
+
+// Valid indicates whether the value is a known member of the PostApiV1QueryJSONBodyGranularitySeconds0 enum.
+func (e PostApiV1QueryJSONBodyGranularitySeconds0) Valid() bool {
 	switch e {
 	case N1:
 		return true
@@ -13225,13 +14284,13 @@ func (e PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyGranularityS
 	}
 }
 
-// Defines values for PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyGranularitySeconds1.
+// Defines values for PostApiV1QueryJSONBodyGranularitySeconds1.
 const (
-	N60 PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyGranularitySeconds1 = 60
+	N60 PostApiV1QueryJSONBodyGranularitySeconds1 = 60
 )
 
-// Valid indicates whether the value is a known member of the PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyGranularitySeconds1 enum.
-func (e PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyGranularitySeconds1) Valid() bool {
+// Valid indicates whether the value is a known member of the PostApiV1QueryJSONBodyGranularitySeconds1 enum.
+func (e PostApiV1QueryJSONBodyGranularitySeconds1) Valid() bool {
 	switch e {
 	case N60:
 		return true
@@ -13240,13 +14299,13 @@ func (e PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyGranularityS
 	}
 }
 
-// Defines values for PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyGranularitySeconds2.
+// Defines values for PostApiV1QueryJSONBodyGranularitySeconds2.
 const (
-	N3600 PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyGranularitySeconds2 = 3600
+	N3600 PostApiV1QueryJSONBodyGranularitySeconds2 = 3600
 )
 
-// Valid indicates whether the value is a known member of the PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyGranularitySeconds2 enum.
-func (e PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyGranularitySeconds2) Valid() bool {
+// Valid indicates whether the value is a known member of the PostApiV1QueryJSONBodyGranularitySeconds2 enum.
+func (e PostApiV1QueryJSONBodyGranularitySeconds2) Valid() bool {
 	switch e {
 	case N3600:
 		return true
@@ -13255,17 +14314,17 @@ func (e PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyGranularityS
 	}
 }
 
-// Defines values for PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouse200JSONResponseBodyDiagnosticsCode.
+// Defines values for PostApiV1Query200JSONResponseBodyDiagnosticsCode.
 const (
-	INCOMPLETECOMPARISONPERIOD PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouse200JSONResponseBodyDiagnosticsCode = "INCOMPLETE_COMPARISON_PERIOD"
-	MISSINGTIMEBUCKETS         PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouse200JSONResponseBodyDiagnosticsCode = "MISSING_TIME_BUCKETS"
-	POSSIBLEFANOUT             PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouse200JSONResponseBodyDiagnosticsCode = "POSSIBLE_FANOUT"
-	RESULTTRUNCATED            PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouse200JSONResponseBodyDiagnosticsCode = "RESULT_TRUNCATED"
-	UNBOUNDEDTIMERANGE         PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouse200JSONResponseBodyDiagnosticsCode = "UNBOUNDED_TIME_RANGE"
+	INCOMPLETECOMPARISONPERIOD PostApiV1Query200JSONResponseBodyDiagnosticsCode = "INCOMPLETE_COMPARISON_PERIOD"
+	MISSINGTIMEBUCKETS         PostApiV1Query200JSONResponseBodyDiagnosticsCode = "MISSING_TIME_BUCKETS"
+	POSSIBLEFANOUT             PostApiV1Query200JSONResponseBodyDiagnosticsCode = "POSSIBLE_FANOUT"
+	RESULTTRUNCATED            PostApiV1Query200JSONResponseBodyDiagnosticsCode = "RESULT_TRUNCATED"
+	UNBOUNDEDTIMERANGE         PostApiV1Query200JSONResponseBodyDiagnosticsCode = "UNBOUNDED_TIME_RANGE"
 )
 
-// Valid indicates whether the value is a known member of the PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouse200JSONResponseBodyDiagnosticsCode enum.
-func (e PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouse200JSONResponseBodyDiagnosticsCode) Valid() bool {
+// Valid indicates whether the value is a known member of the PostApiV1Query200JSONResponseBodyDiagnosticsCode enum.
+func (e PostApiV1Query200JSONResponseBodyDiagnosticsCode) Valid() bool {
 	switch e {
 	case INCOMPLETECOMPARISONPERIOD:
 		return true
@@ -13282,48 +14341,99 @@ func (e PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouse200JSONResponseBodyD
 	}
 }
 
-// Defines values for GetApiV1ProjectsByProjectIdAnalyticsSchema200JSONResponseBodyDatasetsColumnsGates.
+// Defines values for GetApiV1QuerySchema200JSONResponseBodyDatasetsColumnsGates.
 const (
-	GetApiV1ProjectsByProjectIdAnalyticsSchema200JSONResponseBodyDatasetsColumnsGatesCosts  GetApiV1ProjectsByProjectIdAnalyticsSchema200JSONResponseBodyDatasetsColumnsGates = "costs"
-	GetApiV1ProjectsByProjectIdAnalyticsSchema200JSONResponseBodyDatasetsColumnsGatesInput  GetApiV1ProjectsByProjectIdAnalyticsSchema200JSONResponseBodyDatasetsColumnsGates = "input"
-	GetApiV1ProjectsByProjectIdAnalyticsSchema200JSONResponseBodyDatasetsColumnsGatesOutput GetApiV1ProjectsByProjectIdAnalyticsSchema200JSONResponseBodyDatasetsColumnsGates = "output"
+	GetApiV1QuerySchema200JSONResponseBodyDatasetsColumnsGatesCosts  GetApiV1QuerySchema200JSONResponseBodyDatasetsColumnsGates = "costs"
+	GetApiV1QuerySchema200JSONResponseBodyDatasetsColumnsGatesInput  GetApiV1QuerySchema200JSONResponseBodyDatasetsColumnsGates = "input"
+	GetApiV1QuerySchema200JSONResponseBodyDatasetsColumnsGatesOutput GetApiV1QuerySchema200JSONResponseBodyDatasetsColumnsGates = "output"
 )
 
-// Valid indicates whether the value is a known member of the GetApiV1ProjectsByProjectIdAnalyticsSchema200JSONResponseBodyDatasetsColumnsGates enum.
-func (e GetApiV1ProjectsByProjectIdAnalyticsSchema200JSONResponseBodyDatasetsColumnsGates) Valid() bool {
+// Valid indicates whether the value is a known member of the GetApiV1QuerySchema200JSONResponseBodyDatasetsColumnsGates enum.
+func (e GetApiV1QuerySchema200JSONResponseBodyDatasetsColumnsGates) Valid() bool {
 	switch e {
-	case GetApiV1ProjectsByProjectIdAnalyticsSchema200JSONResponseBodyDatasetsColumnsGatesCosts:
+	case GetApiV1QuerySchema200JSONResponseBodyDatasetsColumnsGatesCosts:
 		return true
-	case GetApiV1ProjectsByProjectIdAnalyticsSchema200JSONResponseBodyDatasetsColumnsGatesInput:
+	case GetApiV1QuerySchema200JSONResponseBodyDatasetsColumnsGatesInput:
 		return true
-	case GetApiV1ProjectsByProjectIdAnalyticsSchema200JSONResponseBodyDatasetsColumnsGatesOutput:
+	case GetApiV1QuerySchema200JSONResponseBodyDatasetsColumnsGatesOutput:
 		return true
 	default:
 		return false
 	}
 }
 
-// Defines values for GetApiV1ProjectsByProjectIdAnalyticsSchema200JSONResponseBodyDatasetsColumnsUnit.
+// Defines values for GetApiV1QuerySchema200JSONResponseBodyDatasetsColumnsUnit.
 const (
-	LessThannil GetApiV1ProjectsByProjectIdAnalyticsSchema200JSONResponseBodyDatasetsColumnsUnit = "<nil>"
-	Ms          GetApiV1ProjectsByProjectIdAnalyticsSchema200JSONResponseBodyDatasetsColumnsUnit = "ms"
-	Tokens      GetApiV1ProjectsByProjectIdAnalyticsSchema200JSONResponseBodyDatasetsColumnsUnit = "tokens"
-	Tokenss     GetApiV1ProjectsByProjectIdAnalyticsSchema200JSONResponseBodyDatasetsColumnsUnit = "tokens/s"
-	USD         GetApiV1ProjectsByProjectIdAnalyticsSchema200JSONResponseBodyDatasetsColumnsUnit = "USD"
+	GetApiV1QuerySchema200JSONResponseBodyDatasetsColumnsUnitLessThannil GetApiV1QuerySchema200JSONResponseBodyDatasetsColumnsUnit = "<nil>"
+	GetApiV1QuerySchema200JSONResponseBodyDatasetsColumnsUnitMs          GetApiV1QuerySchema200JSONResponseBodyDatasetsColumnsUnit = "ms"
+	GetApiV1QuerySchema200JSONResponseBodyDatasetsColumnsUnitTokens      GetApiV1QuerySchema200JSONResponseBodyDatasetsColumnsUnit = "tokens"
+	GetApiV1QuerySchema200JSONResponseBodyDatasetsColumnsUnitTokenss     GetApiV1QuerySchema200JSONResponseBodyDatasetsColumnsUnit = "tokens/s"
+	GetApiV1QuerySchema200JSONResponseBodyDatasetsColumnsUnitUSD         GetApiV1QuerySchema200JSONResponseBodyDatasetsColumnsUnit = "USD"
 )
 
-// Valid indicates whether the value is a known member of the GetApiV1ProjectsByProjectIdAnalyticsSchema200JSONResponseBodyDatasetsColumnsUnit enum.
-func (e GetApiV1ProjectsByProjectIdAnalyticsSchema200JSONResponseBodyDatasetsColumnsUnit) Valid() bool {
+// Valid indicates whether the value is a known member of the GetApiV1QuerySchema200JSONResponseBodyDatasetsColumnsUnit enum.
+func (e GetApiV1QuerySchema200JSONResponseBodyDatasetsColumnsUnit) Valid() bool {
 	switch e {
-	case LessThannil:
+	case GetApiV1QuerySchema200JSONResponseBodyDatasetsColumnsUnitLessThannil:
 		return true
-	case Ms:
+	case GetApiV1QuerySchema200JSONResponseBodyDatasetsColumnsUnitMs:
 		return true
-	case Tokens:
+	case GetApiV1QuerySchema200JSONResponseBodyDatasetsColumnsUnitTokens:
 		return true
-	case Tokenss:
+	case GetApiV1QuerySchema200JSONResponseBodyDatasetsColumnsUnitTokenss:
 		return true
-	case USD:
+	case GetApiV1QuerySchema200JSONResponseBodyDatasetsColumnsUnitUSD:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for ListRunPlans200JSONResponseBodyEvaluatorsMappings0SourceId.
+const (
+	ListRunPlans200JSONResponseBodyEvaluatorsMappings0SourceIdConversation ListRunPlans200JSONResponseBodyEvaluatorsMappings0SourceId = "conversation"
+	ListRunPlans200JSONResponseBodyEvaluatorsMappings0SourceIdScenario     ListRunPlans200JSONResponseBodyEvaluatorsMappings0SourceId = "scenario"
+	ListRunPlans200JSONResponseBodyEvaluatorsMappings0SourceIdTrace        ListRunPlans200JSONResponseBodyEvaluatorsMappings0SourceId = "trace"
+)
+
+// Valid indicates whether the value is a known member of the ListRunPlans200JSONResponseBodyEvaluatorsMappings0SourceId enum.
+func (e ListRunPlans200JSONResponseBodyEvaluatorsMappings0SourceId) Valid() bool {
+	switch e {
+	case ListRunPlans200JSONResponseBodyEvaluatorsMappings0SourceIdConversation:
+		return true
+	case ListRunPlans200JSONResponseBodyEvaluatorsMappings0SourceIdScenario:
+		return true
+	case ListRunPlans200JSONResponseBodyEvaluatorsMappings0SourceIdTrace:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for ListRunPlans200JSONResponseBodyEvaluatorsMappings0Type.
+const (
+	ListRunPlans200JSONResponseBodyEvaluatorsMappings0TypeSource ListRunPlans200JSONResponseBodyEvaluatorsMappings0Type = "source"
+)
+
+// Valid indicates whether the value is a known member of the ListRunPlans200JSONResponseBodyEvaluatorsMappings0Type enum.
+func (e ListRunPlans200JSONResponseBodyEvaluatorsMappings0Type) Valid() bool {
+	switch e {
+	case ListRunPlans200JSONResponseBodyEvaluatorsMappings0TypeSource:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for ListRunPlans200JSONResponseBodyEvaluatorsMappings1Type.
+const (
+	ListRunPlans200JSONResponseBodyEvaluatorsMappings1TypeValue ListRunPlans200JSONResponseBodyEvaluatorsMappings1Type = "value"
+)
+
+// Valid indicates whether the value is a known member of the ListRunPlans200JSONResponseBodyEvaluatorsMappings1Type enum.
+func (e ListRunPlans200JSONResponseBodyEvaluatorsMappings1Type) Valid() bool {
+	switch e {
+	case ListRunPlans200JSONResponseBodyEvaluatorsMappings1TypeValue:
 		return true
 	default:
 		return false
@@ -13411,6 +14521,57 @@ func (e ListRunPlans200JSONResponseBodyTargetsType) Valid() bool {
 	case ListRunPlans200JSONResponseBodyTargetsTypePrompt:
 		return true
 	case ListRunPlans200JSONResponseBodyTargetsTypeWorkflow:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for RunRunPlanJSONBodyConfigEvaluatorsMappings0SourceId.
+const (
+	RunRunPlanJSONBodyConfigEvaluatorsMappings0SourceIdConversation RunRunPlanJSONBodyConfigEvaluatorsMappings0SourceId = "conversation"
+	RunRunPlanJSONBodyConfigEvaluatorsMappings0SourceIdScenario     RunRunPlanJSONBodyConfigEvaluatorsMappings0SourceId = "scenario"
+	RunRunPlanJSONBodyConfigEvaluatorsMappings0SourceIdTrace        RunRunPlanJSONBodyConfigEvaluatorsMappings0SourceId = "trace"
+)
+
+// Valid indicates whether the value is a known member of the RunRunPlanJSONBodyConfigEvaluatorsMappings0SourceId enum.
+func (e RunRunPlanJSONBodyConfigEvaluatorsMappings0SourceId) Valid() bool {
+	switch e {
+	case RunRunPlanJSONBodyConfigEvaluatorsMappings0SourceIdConversation:
+		return true
+	case RunRunPlanJSONBodyConfigEvaluatorsMappings0SourceIdScenario:
+		return true
+	case RunRunPlanJSONBodyConfigEvaluatorsMappings0SourceIdTrace:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for RunRunPlanJSONBodyConfigEvaluatorsMappings0Type.
+const (
+	RunRunPlanJSONBodyConfigEvaluatorsMappings0TypeSource RunRunPlanJSONBodyConfigEvaluatorsMappings0Type = "source"
+)
+
+// Valid indicates whether the value is a known member of the RunRunPlanJSONBodyConfigEvaluatorsMappings0Type enum.
+func (e RunRunPlanJSONBodyConfigEvaluatorsMappings0Type) Valid() bool {
+	switch e {
+	case RunRunPlanJSONBodyConfigEvaluatorsMappings0TypeSource:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for RunRunPlanJSONBodyConfigEvaluatorsMappings1Type.
+const (
+	RunRunPlanJSONBodyConfigEvaluatorsMappings1TypeValue RunRunPlanJSONBodyConfigEvaluatorsMappings1Type = "value"
+)
+
+// Valid indicates whether the value is a known member of the RunRunPlanJSONBodyConfigEvaluatorsMappings1Type enum.
+func (e RunRunPlanJSONBodyConfigEvaluatorsMappings1Type) Valid() bool {
+	switch e {
+	case RunRunPlanJSONBodyConfigEvaluatorsMappings1TypeValue:
 		return true
 	default:
 		return false
@@ -13546,6 +14707,57 @@ func (e ArchiveRunPlan200JSONResponseBodyArchived) Valid() bool {
 	}
 }
 
+// Defines values for GetRunPlan200JSONResponseBodyEvaluatorsMappings0SourceId.
+const (
+	GetRunPlan200JSONResponseBodyEvaluatorsMappings0SourceIdConversation GetRunPlan200JSONResponseBodyEvaluatorsMappings0SourceId = "conversation"
+	GetRunPlan200JSONResponseBodyEvaluatorsMappings0SourceIdScenario     GetRunPlan200JSONResponseBodyEvaluatorsMappings0SourceId = "scenario"
+	GetRunPlan200JSONResponseBodyEvaluatorsMappings0SourceIdTrace        GetRunPlan200JSONResponseBodyEvaluatorsMappings0SourceId = "trace"
+)
+
+// Valid indicates whether the value is a known member of the GetRunPlan200JSONResponseBodyEvaluatorsMappings0SourceId enum.
+func (e GetRunPlan200JSONResponseBodyEvaluatorsMappings0SourceId) Valid() bool {
+	switch e {
+	case GetRunPlan200JSONResponseBodyEvaluatorsMappings0SourceIdConversation:
+		return true
+	case GetRunPlan200JSONResponseBodyEvaluatorsMappings0SourceIdScenario:
+		return true
+	case GetRunPlan200JSONResponseBodyEvaluatorsMappings0SourceIdTrace:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for GetRunPlan200JSONResponseBodyEvaluatorsMappings0Type.
+const (
+	GetRunPlan200JSONResponseBodyEvaluatorsMappings0TypeSource GetRunPlan200JSONResponseBodyEvaluatorsMappings0Type = "source"
+)
+
+// Valid indicates whether the value is a known member of the GetRunPlan200JSONResponseBodyEvaluatorsMappings0Type enum.
+func (e GetRunPlan200JSONResponseBodyEvaluatorsMappings0Type) Valid() bool {
+	switch e {
+	case GetRunPlan200JSONResponseBodyEvaluatorsMappings0TypeSource:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for GetRunPlan200JSONResponseBodyEvaluatorsMappings1Type.
+const (
+	GetRunPlan200JSONResponseBodyEvaluatorsMappings1TypeValue GetRunPlan200JSONResponseBodyEvaluatorsMappings1Type = "value"
+)
+
+// Valid indicates whether the value is a known member of the GetRunPlan200JSONResponseBodyEvaluatorsMappings1Type enum.
+func (e GetRunPlan200JSONResponseBodyEvaluatorsMappings1Type) Valid() bool {
+	switch e {
+	case GetRunPlan200JSONResponseBodyEvaluatorsMappings1TypeValue:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for GetRunPlan200JSONResponseBodyScope0Mode.
 const (
 	GetRunPlan200JSONResponseBodyScope0ModeAll GetRunPlan200JSONResponseBodyScope0Mode = "all"
@@ -13660,6 +14872,222 @@ func (e RerunRunPlan200JSONResponseBodyItemsTargetType) Valid() bool {
 	}
 }
 
+// Defines values for ListTestSuites200JSONResponseBodyEvaluatorsMappings0SourceId.
+const (
+	ListTestSuites200JSONResponseBodyEvaluatorsMappings0SourceIdConversation ListTestSuites200JSONResponseBodyEvaluatorsMappings0SourceId = "conversation"
+	ListTestSuites200JSONResponseBodyEvaluatorsMappings0SourceIdScenario     ListTestSuites200JSONResponseBodyEvaluatorsMappings0SourceId = "scenario"
+	ListTestSuites200JSONResponseBodyEvaluatorsMappings0SourceIdTrace        ListTestSuites200JSONResponseBodyEvaluatorsMappings0SourceId = "trace"
+)
+
+// Valid indicates whether the value is a known member of the ListTestSuites200JSONResponseBodyEvaluatorsMappings0SourceId enum.
+func (e ListTestSuites200JSONResponseBodyEvaluatorsMappings0SourceId) Valid() bool {
+	switch e {
+	case ListTestSuites200JSONResponseBodyEvaluatorsMappings0SourceIdConversation:
+		return true
+	case ListTestSuites200JSONResponseBodyEvaluatorsMappings0SourceIdScenario:
+		return true
+	case ListTestSuites200JSONResponseBodyEvaluatorsMappings0SourceIdTrace:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for ListTestSuites200JSONResponseBodyEvaluatorsMappings0Type.
+const (
+	ListTestSuites200JSONResponseBodyEvaluatorsMappings0TypeSource ListTestSuites200JSONResponseBodyEvaluatorsMappings0Type = "source"
+)
+
+// Valid indicates whether the value is a known member of the ListTestSuites200JSONResponseBodyEvaluatorsMappings0Type enum.
+func (e ListTestSuites200JSONResponseBodyEvaluatorsMappings0Type) Valid() bool {
+	switch e {
+	case ListTestSuites200JSONResponseBodyEvaluatorsMappings0TypeSource:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for ListTestSuites200JSONResponseBodyEvaluatorsMappings1Type.
+const (
+	ListTestSuites200JSONResponseBodyEvaluatorsMappings1TypeValue ListTestSuites200JSONResponseBodyEvaluatorsMappings1Type = "value"
+)
+
+// Valid indicates whether the value is a known member of the ListTestSuites200JSONResponseBodyEvaluatorsMappings1Type enum.
+func (e ListTestSuites200JSONResponseBodyEvaluatorsMappings1Type) Valid() bool {
+	switch e {
+	case ListTestSuites200JSONResponseBodyEvaluatorsMappings1TypeValue:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for ListTestSuites200JSONResponseBodyFieldsType.
+const (
+	ListTestSuites200JSONResponseBodyFieldsTypeBoolean ListTestSuites200JSONResponseBodyFieldsType = "boolean"
+	ListTestSuites200JSONResponseBodyFieldsTypeNumber  ListTestSuites200JSONResponseBodyFieldsType = "number"
+	ListTestSuites200JSONResponseBodyFieldsTypeText    ListTestSuites200JSONResponseBodyFieldsType = "text"
+)
+
+// Valid indicates whether the value is a known member of the ListTestSuites200JSONResponseBodyFieldsType enum.
+func (e ListTestSuites200JSONResponseBodyFieldsType) Valid() bool {
+	switch e {
+	case ListTestSuites200JSONResponseBodyFieldsTypeBoolean:
+		return true
+	case ListTestSuites200JSONResponseBodyFieldsTypeNumber:
+		return true
+	case ListTestSuites200JSONResponseBodyFieldsTypeText:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for CreateTestSuiteJSONBodyEvaluatorsMappings0SourceId.
+const (
+	CreateTestSuiteJSONBodyEvaluatorsMappings0SourceIdConversation CreateTestSuiteJSONBodyEvaluatorsMappings0SourceId = "conversation"
+	CreateTestSuiteJSONBodyEvaluatorsMappings0SourceIdScenario     CreateTestSuiteJSONBodyEvaluatorsMappings0SourceId = "scenario"
+	CreateTestSuiteJSONBodyEvaluatorsMappings0SourceIdTrace        CreateTestSuiteJSONBodyEvaluatorsMappings0SourceId = "trace"
+)
+
+// Valid indicates whether the value is a known member of the CreateTestSuiteJSONBodyEvaluatorsMappings0SourceId enum.
+func (e CreateTestSuiteJSONBodyEvaluatorsMappings0SourceId) Valid() bool {
+	switch e {
+	case CreateTestSuiteJSONBodyEvaluatorsMappings0SourceIdConversation:
+		return true
+	case CreateTestSuiteJSONBodyEvaluatorsMappings0SourceIdScenario:
+		return true
+	case CreateTestSuiteJSONBodyEvaluatorsMappings0SourceIdTrace:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for CreateTestSuiteJSONBodyEvaluatorsMappings0Type.
+const (
+	CreateTestSuiteJSONBodyEvaluatorsMappings0TypeSource CreateTestSuiteJSONBodyEvaluatorsMappings0Type = "source"
+)
+
+// Valid indicates whether the value is a known member of the CreateTestSuiteJSONBodyEvaluatorsMappings0Type enum.
+func (e CreateTestSuiteJSONBodyEvaluatorsMappings0Type) Valid() bool {
+	switch e {
+	case CreateTestSuiteJSONBodyEvaluatorsMappings0TypeSource:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for CreateTestSuiteJSONBodyEvaluatorsMappings1Type.
+const (
+	CreateTestSuiteJSONBodyEvaluatorsMappings1TypeValue CreateTestSuiteJSONBodyEvaluatorsMappings1Type = "value"
+)
+
+// Valid indicates whether the value is a known member of the CreateTestSuiteJSONBodyEvaluatorsMappings1Type enum.
+func (e CreateTestSuiteJSONBodyEvaluatorsMappings1Type) Valid() bool {
+	switch e {
+	case CreateTestSuiteJSONBodyEvaluatorsMappings1TypeValue:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for CreateTestSuiteJSONBodyFieldsType.
+const (
+	CreateTestSuiteJSONBodyFieldsTypeBoolean CreateTestSuiteJSONBodyFieldsType = "boolean"
+	CreateTestSuiteJSONBodyFieldsTypeNumber  CreateTestSuiteJSONBodyFieldsType = "number"
+	CreateTestSuiteJSONBodyFieldsTypeText    CreateTestSuiteJSONBodyFieldsType = "text"
+)
+
+// Valid indicates whether the value is a known member of the CreateTestSuiteJSONBodyFieldsType enum.
+func (e CreateTestSuiteJSONBodyFieldsType) Valid() bool {
+	switch e {
+	case CreateTestSuiteJSONBodyFieldsTypeBoolean:
+		return true
+	case CreateTestSuiteJSONBodyFieldsTypeNumber:
+		return true
+	case CreateTestSuiteJSONBodyFieldsTypeText:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for CreateTestSuite201JSONResponseBodyEvaluatorsMappings0SourceId.
+const (
+	CreateTestSuite201JSONResponseBodyEvaluatorsMappings0SourceIdConversation CreateTestSuite201JSONResponseBodyEvaluatorsMappings0SourceId = "conversation"
+	CreateTestSuite201JSONResponseBodyEvaluatorsMappings0SourceIdScenario     CreateTestSuite201JSONResponseBodyEvaluatorsMappings0SourceId = "scenario"
+	CreateTestSuite201JSONResponseBodyEvaluatorsMappings0SourceIdTrace        CreateTestSuite201JSONResponseBodyEvaluatorsMappings0SourceId = "trace"
+)
+
+// Valid indicates whether the value is a known member of the CreateTestSuite201JSONResponseBodyEvaluatorsMappings0SourceId enum.
+func (e CreateTestSuite201JSONResponseBodyEvaluatorsMappings0SourceId) Valid() bool {
+	switch e {
+	case CreateTestSuite201JSONResponseBodyEvaluatorsMappings0SourceIdConversation:
+		return true
+	case CreateTestSuite201JSONResponseBodyEvaluatorsMappings0SourceIdScenario:
+		return true
+	case CreateTestSuite201JSONResponseBodyEvaluatorsMappings0SourceIdTrace:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for CreateTestSuite201JSONResponseBodyEvaluatorsMappings0Type.
+const (
+	CreateTestSuite201JSONResponseBodyEvaluatorsMappings0TypeSource CreateTestSuite201JSONResponseBodyEvaluatorsMappings0Type = "source"
+)
+
+// Valid indicates whether the value is a known member of the CreateTestSuite201JSONResponseBodyEvaluatorsMappings0Type enum.
+func (e CreateTestSuite201JSONResponseBodyEvaluatorsMappings0Type) Valid() bool {
+	switch e {
+	case CreateTestSuite201JSONResponseBodyEvaluatorsMappings0TypeSource:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for CreateTestSuite201JSONResponseBodyEvaluatorsMappings1Type.
+const (
+	CreateTestSuite201JSONResponseBodyEvaluatorsMappings1TypeValue CreateTestSuite201JSONResponseBodyEvaluatorsMappings1Type = "value"
+)
+
+// Valid indicates whether the value is a known member of the CreateTestSuite201JSONResponseBodyEvaluatorsMappings1Type enum.
+func (e CreateTestSuite201JSONResponseBodyEvaluatorsMappings1Type) Valid() bool {
+	switch e {
+	case CreateTestSuite201JSONResponseBodyEvaluatorsMappings1TypeValue:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for CreateTestSuite201JSONResponseBodyFieldsType.
+const (
+	CreateTestSuite201JSONResponseBodyFieldsTypeBoolean CreateTestSuite201JSONResponseBodyFieldsType = "boolean"
+	CreateTestSuite201JSONResponseBodyFieldsTypeNumber  CreateTestSuite201JSONResponseBodyFieldsType = "number"
+	CreateTestSuite201JSONResponseBodyFieldsTypeText    CreateTestSuite201JSONResponseBodyFieldsType = "text"
+)
+
+// Valid indicates whether the value is a known member of the CreateTestSuite201JSONResponseBodyFieldsType enum.
+func (e CreateTestSuite201JSONResponseBodyFieldsType) Valid() bool {
+	switch e {
+	case CreateTestSuite201JSONResponseBodyFieldsTypeBoolean:
+		return true
+	case CreateTestSuite201JSONResponseBodyFieldsTypeNumber:
+		return true
+	case CreateTestSuite201JSONResponseBodyFieldsTypeText:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for ArchiveTestSuite200JSONResponseBodyArchived.
 const (
 	ArchiveTestSuite200JSONResponseBodyArchivedTrue ArchiveTestSuite200JSONResponseBodyArchived = true
@@ -13669,6 +15097,222 @@ const (
 func (e ArchiveTestSuite200JSONResponseBodyArchived) Valid() bool {
 	switch e {
 	case ArchiveTestSuite200JSONResponseBodyArchivedTrue:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for GetTestSuite200JSONResponseBodyEvaluatorsMappings0SourceId.
+const (
+	GetTestSuite200JSONResponseBodyEvaluatorsMappings0SourceIdConversation GetTestSuite200JSONResponseBodyEvaluatorsMappings0SourceId = "conversation"
+	GetTestSuite200JSONResponseBodyEvaluatorsMappings0SourceIdScenario     GetTestSuite200JSONResponseBodyEvaluatorsMappings0SourceId = "scenario"
+	GetTestSuite200JSONResponseBodyEvaluatorsMappings0SourceIdTrace        GetTestSuite200JSONResponseBodyEvaluatorsMappings0SourceId = "trace"
+)
+
+// Valid indicates whether the value is a known member of the GetTestSuite200JSONResponseBodyEvaluatorsMappings0SourceId enum.
+func (e GetTestSuite200JSONResponseBodyEvaluatorsMappings0SourceId) Valid() bool {
+	switch e {
+	case GetTestSuite200JSONResponseBodyEvaluatorsMappings0SourceIdConversation:
+		return true
+	case GetTestSuite200JSONResponseBodyEvaluatorsMappings0SourceIdScenario:
+		return true
+	case GetTestSuite200JSONResponseBodyEvaluatorsMappings0SourceIdTrace:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for GetTestSuite200JSONResponseBodyEvaluatorsMappings0Type.
+const (
+	GetTestSuite200JSONResponseBodyEvaluatorsMappings0TypeSource GetTestSuite200JSONResponseBodyEvaluatorsMappings0Type = "source"
+)
+
+// Valid indicates whether the value is a known member of the GetTestSuite200JSONResponseBodyEvaluatorsMappings0Type enum.
+func (e GetTestSuite200JSONResponseBodyEvaluatorsMappings0Type) Valid() bool {
+	switch e {
+	case GetTestSuite200JSONResponseBodyEvaluatorsMappings0TypeSource:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for GetTestSuite200JSONResponseBodyEvaluatorsMappings1Type.
+const (
+	GetTestSuite200JSONResponseBodyEvaluatorsMappings1TypeValue GetTestSuite200JSONResponseBodyEvaluatorsMappings1Type = "value"
+)
+
+// Valid indicates whether the value is a known member of the GetTestSuite200JSONResponseBodyEvaluatorsMappings1Type enum.
+func (e GetTestSuite200JSONResponseBodyEvaluatorsMappings1Type) Valid() bool {
+	switch e {
+	case GetTestSuite200JSONResponseBodyEvaluatorsMappings1TypeValue:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for GetTestSuite200JSONResponseBodyFieldsType.
+const (
+	GetTestSuite200JSONResponseBodyFieldsTypeBoolean GetTestSuite200JSONResponseBodyFieldsType = "boolean"
+	GetTestSuite200JSONResponseBodyFieldsTypeNumber  GetTestSuite200JSONResponseBodyFieldsType = "number"
+	GetTestSuite200JSONResponseBodyFieldsTypeText    GetTestSuite200JSONResponseBodyFieldsType = "text"
+)
+
+// Valid indicates whether the value is a known member of the GetTestSuite200JSONResponseBodyFieldsType enum.
+func (e GetTestSuite200JSONResponseBodyFieldsType) Valid() bool {
+	switch e {
+	case GetTestSuite200JSONResponseBodyFieldsTypeBoolean:
+		return true
+	case GetTestSuite200JSONResponseBodyFieldsTypeNumber:
+		return true
+	case GetTestSuite200JSONResponseBodyFieldsTypeText:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for UpdateTestSuiteJSONBodyEvaluatorsMappings0SourceId.
+const (
+	UpdateTestSuiteJSONBodyEvaluatorsMappings0SourceIdConversation UpdateTestSuiteJSONBodyEvaluatorsMappings0SourceId = "conversation"
+	UpdateTestSuiteJSONBodyEvaluatorsMappings0SourceIdScenario     UpdateTestSuiteJSONBodyEvaluatorsMappings0SourceId = "scenario"
+	UpdateTestSuiteJSONBodyEvaluatorsMappings0SourceIdTrace        UpdateTestSuiteJSONBodyEvaluatorsMappings0SourceId = "trace"
+)
+
+// Valid indicates whether the value is a known member of the UpdateTestSuiteJSONBodyEvaluatorsMappings0SourceId enum.
+func (e UpdateTestSuiteJSONBodyEvaluatorsMappings0SourceId) Valid() bool {
+	switch e {
+	case UpdateTestSuiteJSONBodyEvaluatorsMappings0SourceIdConversation:
+		return true
+	case UpdateTestSuiteJSONBodyEvaluatorsMappings0SourceIdScenario:
+		return true
+	case UpdateTestSuiteJSONBodyEvaluatorsMappings0SourceIdTrace:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for UpdateTestSuiteJSONBodyEvaluatorsMappings0Type.
+const (
+	UpdateTestSuiteJSONBodyEvaluatorsMappings0TypeSource UpdateTestSuiteJSONBodyEvaluatorsMappings0Type = "source"
+)
+
+// Valid indicates whether the value is a known member of the UpdateTestSuiteJSONBodyEvaluatorsMappings0Type enum.
+func (e UpdateTestSuiteJSONBodyEvaluatorsMappings0Type) Valid() bool {
+	switch e {
+	case UpdateTestSuiteJSONBodyEvaluatorsMappings0TypeSource:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for UpdateTestSuiteJSONBodyEvaluatorsMappings1Type.
+const (
+	UpdateTestSuiteJSONBodyEvaluatorsMappings1TypeValue UpdateTestSuiteJSONBodyEvaluatorsMappings1Type = "value"
+)
+
+// Valid indicates whether the value is a known member of the UpdateTestSuiteJSONBodyEvaluatorsMappings1Type enum.
+func (e UpdateTestSuiteJSONBodyEvaluatorsMappings1Type) Valid() bool {
+	switch e {
+	case UpdateTestSuiteJSONBodyEvaluatorsMappings1TypeValue:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for UpdateTestSuiteJSONBodyFieldsType.
+const (
+	UpdateTestSuiteJSONBodyFieldsTypeBoolean UpdateTestSuiteJSONBodyFieldsType = "boolean"
+	UpdateTestSuiteJSONBodyFieldsTypeNumber  UpdateTestSuiteJSONBodyFieldsType = "number"
+	UpdateTestSuiteJSONBodyFieldsTypeText    UpdateTestSuiteJSONBodyFieldsType = "text"
+)
+
+// Valid indicates whether the value is a known member of the UpdateTestSuiteJSONBodyFieldsType enum.
+func (e UpdateTestSuiteJSONBodyFieldsType) Valid() bool {
+	switch e {
+	case UpdateTestSuiteJSONBodyFieldsTypeBoolean:
+		return true
+	case UpdateTestSuiteJSONBodyFieldsTypeNumber:
+		return true
+	case UpdateTestSuiteJSONBodyFieldsTypeText:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for UpdateTestSuite200JSONResponseBodyEvaluatorsMappings0SourceId.
+const (
+	UpdateTestSuite200JSONResponseBodyEvaluatorsMappings0SourceIdConversation UpdateTestSuite200JSONResponseBodyEvaluatorsMappings0SourceId = "conversation"
+	UpdateTestSuite200JSONResponseBodyEvaluatorsMappings0SourceIdScenario     UpdateTestSuite200JSONResponseBodyEvaluatorsMappings0SourceId = "scenario"
+	UpdateTestSuite200JSONResponseBodyEvaluatorsMappings0SourceIdTrace        UpdateTestSuite200JSONResponseBodyEvaluatorsMappings0SourceId = "trace"
+)
+
+// Valid indicates whether the value is a known member of the UpdateTestSuite200JSONResponseBodyEvaluatorsMappings0SourceId enum.
+func (e UpdateTestSuite200JSONResponseBodyEvaluatorsMappings0SourceId) Valid() bool {
+	switch e {
+	case UpdateTestSuite200JSONResponseBodyEvaluatorsMappings0SourceIdConversation:
+		return true
+	case UpdateTestSuite200JSONResponseBodyEvaluatorsMappings0SourceIdScenario:
+		return true
+	case UpdateTestSuite200JSONResponseBodyEvaluatorsMappings0SourceIdTrace:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for UpdateTestSuite200JSONResponseBodyEvaluatorsMappings0Type.
+const (
+	Source UpdateTestSuite200JSONResponseBodyEvaluatorsMappings0Type = "source"
+)
+
+// Valid indicates whether the value is a known member of the UpdateTestSuite200JSONResponseBodyEvaluatorsMappings0Type enum.
+func (e UpdateTestSuite200JSONResponseBodyEvaluatorsMappings0Type) Valid() bool {
+	switch e {
+	case Source:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for UpdateTestSuite200JSONResponseBodyEvaluatorsMappings1Type.
+const (
+	Value UpdateTestSuite200JSONResponseBodyEvaluatorsMappings1Type = "value"
+)
+
+// Valid indicates whether the value is a known member of the UpdateTestSuite200JSONResponseBodyEvaluatorsMappings1Type enum.
+func (e UpdateTestSuite200JSONResponseBodyEvaluatorsMappings1Type) Valid() bool {
+	switch e {
+	case Value:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for UpdateTestSuite200JSONResponseBodyFieldsType.
+const (
+	Boolean UpdateTestSuite200JSONResponseBodyFieldsType = "boolean"
+	Number  UpdateTestSuite200JSONResponseBodyFieldsType = "number"
+	Text    UpdateTestSuite200JSONResponseBodyFieldsType = "text"
+)
+
+// Valid indicates whether the value is a known member of the UpdateTestSuite200JSONResponseBodyFieldsType enum.
+func (e UpdateTestSuite200JSONResponseBodyFieldsType) Valid() bool {
+	switch e {
+	case Boolean:
+		return true
+	case Number:
+		return true
+	case Text:
 		return true
 	default:
 		return false
@@ -13923,13 +15567,13 @@ func (e PostApiWebhooksV1Endpoints201JSONResponseBodyData1Status) Valid() bool {
 
 // Defines values for DeleteApiWebhooksV1EndpointsById200JSONResponseBodyDataArchived.
 const (
-	True DeleteApiWebhooksV1EndpointsById200JSONResponseBodyDataArchived = true
+	DeleteApiWebhooksV1EndpointsById200JSONResponseBodyDataArchivedTrue DeleteApiWebhooksV1EndpointsById200JSONResponseBodyDataArchived = true
 )
 
 // Valid indicates whether the value is a known member of the DeleteApiWebhooksV1EndpointsById200JSONResponseBodyDataArchived enum.
 func (e DeleteApiWebhooksV1EndpointsById200JSONResponseBodyDataArchived) Valid() bool {
 	switch e {
-	case True:
+	case DeleteApiWebhooksV1EndpointsById200JSONResponseBodyDataArchivedTrue:
 		return true
 	default:
 		return false
@@ -14338,31 +15982,31 @@ func (e PostApiWorkflowsByWorkflowIdByVersionIdRun200JSONResponseBodyStatus) Val
 // Annotation defines model for Annotation.
 type Annotation struct {
 	// Comment The comment of the annotation
-	Comment *string `json:"comment,omitempty"`
+	Comment *string `json:"comment"`
 
 	// CreatedAt The created at of the annotation
-	CreatedAt *string `json:"createdAt,omitempty"`
+	CreatedAt string `json:"createdAt"`
 
 	// Email The email of the user
-	Email *string `json:"email,omitempty"`
+	Email *string `json:"email"`
 
 	// Id The ID of the annotation
-	Id *string `json:"id,omitempty"`
+	Id string `json:"id"`
 
 	// IsThumbsUp The thumbs up status of the annotation
-	IsThumbsUp *bool `json:"isThumbsUp,omitempty"`
+	IsThumbsUp *bool `json:"isThumbsUp"`
 
 	// ProjectId The ID of the project
-	ProjectId *string `json:"projectId,omitempty"`
+	ProjectId string `json:"projectId"`
 
 	// TraceId The ID of the trace
-	TraceId *string `json:"traceId,omitempty"`
+	TraceId string `json:"traceId"`
 
 	// UpdatedAt The updated at of the annotation
-	UpdatedAt *string `json:"updatedAt,omitempty"`
+	UpdatedAt string `json:"updatedAt"`
 
 	// UserId The ID of the user
-	UserId *string `json:"userId,omitempty"`
+	UserId *string `json:"userId"`
 }
 
 // ApiKeyInfo defines model for ApiKeyInfo.
@@ -16453,16 +18097,16 @@ type GetApiAnnotationsTraceIdParamsAnchor string
 
 // PostApiAnnotationsTraceIdJSONBody defines parameters for PostApiAnnotationsTraceId.
 type PostApiAnnotationsTraceIdJSONBody struct {
-	Comment    *string `json:"comment,omitempty"`
+	Comment    string  `json:"comment"`
 	Email      *string `json:"email,omitempty"`
-	IsThumbsUp *bool   `json:"isThumbsUp,omitempty"`
+	IsThumbsUp bool    `json:"isThumbsUp"`
 }
 
 // PatchApiAnnotationsIdJSONBody defines parameters for PatchApiAnnotationsId.
 type PatchApiAnnotationsIdJSONBody struct {
-	Comment    *string `json:"comment,omitempty"`
+	Comment    string  `json:"comment"`
 	Email      *string `json:"email,omitempty"`
-	IsThumbsUp *bool   `json:"isThumbsUp,omitempty"`
+	IsThumbsUp bool    `json:"isThumbsUp"`
 }
 
 // CreateApiKeyJSONBody defines parameters for CreateApiKey.
@@ -20631,7 +22275,22 @@ type PostApiScenarioEventsJSONBody1 struct {
 	BatchRunId string      `json:"batchRunId"`
 	RawEvent   interface{} `json:"rawEvent,omitempty"`
 	Results    *struct {
-		Error         *string                                      `json:"error,omitempty"`
+		Error       *string `json:"error,omitempty"`
+		Evaluations *[]struct {
+			Cost *struct {
+				Amount   float32 `json:"amount"`
+				Currency string  `json:"currency"`
+			} `json:"cost,omitempty"`
+			Details     *string                                                `json:"details,omitempty"`
+			EvaluatorId string                                                 `json:"evaluatorId"`
+			Inputs      *map[string]string                                     `json:"inputs,omitempty"`
+			Label       *string                                                `json:"label,omitempty"`
+			Name        string                                                 `json:"name"`
+			Passed      *bool                                                  `json:"passed,omitempty"`
+			Required    bool                                                   `json:"required"`
+			Score       *float32                                               `json:"score,omitempty"`
+			Status      PostApiScenarioEventsJSONBody1ResultsEvaluationsStatus `json:"status"`
+		} `json:"evaluations,omitempty"`
 		MetCriteria   []string                                     `json:"metCriteria"`
 		Reasoning     *string                                      `json:"reasoning,omitempty"`
 		UnmetCriteria []string                                     `json:"unmetCriteria"`
@@ -20644,6 +22303,9 @@ type PostApiScenarioEventsJSONBody1 struct {
 	Timestamp     float32                              `json:"timestamp"`
 	Type          PostApiScenarioEventsJSONBody1Type   `json:"type"`
 }
+
+// PostApiScenarioEventsJSONBody1ResultsEvaluationsStatus defines parameters for PostApiScenarioEvents.
+type PostApiScenarioEventsJSONBody1ResultsEvaluationsStatus string
 
 // PostApiScenarioEventsJSONBody1ResultsVerdict defines parameters for PostApiScenarioEvents.
 type PostApiScenarioEventsJSONBody1ResultsVerdict string
@@ -20780,6 +22442,20 @@ type PostApiScenarioEventsBrowserTabJSONBody struct {
 	TabKey        string  `json:"tabKey"`
 }
 
+// GetApiScenarios200JSONResponseBodyFields0 defines parameters for GetApiScenarios.
+type GetApiScenarios200JSONResponseBodyFields0 = string
+
+// GetApiScenarios200JSONResponseBodyFields1 defines parameters for GetApiScenarios.
+type GetApiScenarios200JSONResponseBodyFields1 = float32
+
+// GetApiScenarios200JSONResponseBodyFields2 defines parameters for GetApiScenarios.
+type GetApiScenarios200JSONResponseBodyFields2 = bool
+
+// GetApiScenarios200JSONResponseBody_Fields_AdditionalProperties defines parameters for GetApiScenarios.
+type GetApiScenarios200JSONResponseBody_Fields_AdditionalProperties struct {
+	union json.RawMessage
+}
+
 // GetApiScenarios200JSONResponseBodyParametersDefaultValue0 defines parameters for GetApiScenarios.
 type GetApiScenarios200JSONResponseBodyParametersDefaultValue0 = string
 
@@ -20815,6 +22491,9 @@ type GetApiScenarios200JSONResponseBodyParametersType string
 type PostApiScenariosJSONBody struct {
 	Criteria *[]string `json:"criteria,omitempty"`
 
+	// Fields The value for each field the test suite declares, keyed by field identifier: text, a number or a boolean, in the field's own type. A field the suite does not declare answers 422 scenario_field_unknown; a value of the wrong type answers 422 scenario_field_type_invalid. An empty value clears the field.
+	Fields *map[string]PostApiScenariosJSONBody_Fields_AdditionalProperties `json:"fields,omitempty"`
+
 	// JudgeModel Model for the judge, e.g. openai/gpt-5-mini. Null uses the project default.
 	JudgeModel *string   `json:"judgeModel,omitempty"`
 	Labels     *[]string `json:"labels,omitempty"`
@@ -20843,6 +22522,20 @@ type PostApiScenariosJSONBody struct {
 
 	// TestSuiteId The test suite to file this scenario in. It must name a non-archived test suite of the same project. null files the scenario into the project's Default test suite.
 	TestSuiteId *string `json:"testSuiteId,omitempty"`
+}
+
+// PostApiScenariosJSONBodyFields0 defines parameters for PostApiScenarios.
+type PostApiScenariosJSONBodyFields0 = string
+
+// PostApiScenariosJSONBodyFields1 defines parameters for PostApiScenarios.
+type PostApiScenariosJSONBodyFields1 = float32
+
+// PostApiScenariosJSONBodyFields2 defines parameters for PostApiScenarios.
+type PostApiScenariosJSONBodyFields2 = bool
+
+// PostApiScenariosJSONBody_Fields_AdditionalProperties defines parameters for PostApiScenarios.
+type PostApiScenariosJSONBody_Fields_AdditionalProperties struct {
+	union json.RawMessage
 }
 
 // PostApiScenariosJSONBodyParametersDefaultValue0 defines parameters for PostApiScenarios.
@@ -20876,6 +22569,20 @@ type PostApiScenariosJSONBody_Parameters_Options_Item struct {
 // PostApiScenariosJSONBodyParametersType defines parameters for PostApiScenarios.
 type PostApiScenariosJSONBodyParametersType string
 
+// PostApiScenarios201JSONResponseBodyFields0 defines parameters for PostApiScenarios.
+type PostApiScenarios201JSONResponseBodyFields0 = string
+
+// PostApiScenarios201JSONResponseBodyFields1 defines parameters for PostApiScenarios.
+type PostApiScenarios201JSONResponseBodyFields1 = float32
+
+// PostApiScenarios201JSONResponseBodyFields2 defines parameters for PostApiScenarios.
+type PostApiScenarios201JSONResponseBodyFields2 = bool
+
+// PostApiScenarios201JSONResponseBody_Fields_AdditionalProperties defines parameters for PostApiScenarios.
+type PostApiScenarios201JSONResponseBody_Fields_AdditionalProperties struct {
+	union json.RawMessage
+}
+
 // PostApiScenarios201JSONResponseBodyParametersDefaultValue0 defines parameters for PostApiScenarios.
 type PostApiScenarios201JSONResponseBodyParametersDefaultValue0 = string
 
@@ -20906,6 +22613,20 @@ type PostApiScenarios201JSONResponseBody_Parameters_Options_Item struct {
 
 // PostApiScenarios201JSONResponseBodyParametersType defines parameters for PostApiScenarios.
 type PostApiScenarios201JSONResponseBodyParametersType string
+
+// GetApiScenariosById200JSONResponseBodyFields0 defines parameters for GetApiScenariosById.
+type GetApiScenariosById200JSONResponseBodyFields0 = string
+
+// GetApiScenariosById200JSONResponseBodyFields1 defines parameters for GetApiScenariosById.
+type GetApiScenariosById200JSONResponseBodyFields1 = float32
+
+// GetApiScenariosById200JSONResponseBodyFields2 defines parameters for GetApiScenariosById.
+type GetApiScenariosById200JSONResponseBodyFields2 = bool
+
+// GetApiScenariosById200JSONResponseBody_Fields_AdditionalProperties defines parameters for GetApiScenariosById.
+type GetApiScenariosById200JSONResponseBody_Fields_AdditionalProperties struct {
+	union json.RawMessage
+}
 
 // GetApiScenariosById200JSONResponseBodyParametersDefaultValue0 defines parameters for GetApiScenariosById.
 type GetApiScenariosById200JSONResponseBodyParametersDefaultValue0 = string
@@ -20942,6 +22663,9 @@ type GetApiScenariosById200JSONResponseBodyParametersType string
 type PatchApiScenariosByIdJSONBody struct {
 	Criteria *[]string `json:"criteria,omitempty"`
 
+	// Fields The value for each field the test suite declares, keyed by field identifier: text, a number or a boolean, in the field's own type. A field the suite does not declare answers 422 scenario_field_unknown; a value of the wrong type answers 422 scenario_field_type_invalid. An empty value clears the field. Send the full record; an empty record clears every value.
+	Fields *map[string]PatchApiScenariosByIdJSONBody_Fields_AdditionalProperties `json:"fields,omitempty"`
+
 	// JudgeModel Model for the judge, e.g. openai/gpt-5-mini. Null uses the project default.
 	JudgeModel *string   `json:"judgeModel,omitempty"`
 	Labels     *[]string `json:"labels,omitempty"`
@@ -20970,6 +22694,20 @@ type PatchApiScenariosByIdJSONBody struct {
 
 	// TestSuiteId The test suite to file this scenario in. It must name a non-archived test suite of the same project. null files the scenario into the project's Default test suite.
 	TestSuiteId *string `json:"testSuiteId,omitempty"`
+}
+
+// PatchApiScenariosByIdJSONBodyFields0 defines parameters for PatchApiScenariosById.
+type PatchApiScenariosByIdJSONBodyFields0 = string
+
+// PatchApiScenariosByIdJSONBodyFields1 defines parameters for PatchApiScenariosById.
+type PatchApiScenariosByIdJSONBodyFields1 = float32
+
+// PatchApiScenariosByIdJSONBodyFields2 defines parameters for PatchApiScenariosById.
+type PatchApiScenariosByIdJSONBodyFields2 = bool
+
+// PatchApiScenariosByIdJSONBody_Fields_AdditionalProperties defines parameters for PatchApiScenariosById.
+type PatchApiScenariosByIdJSONBody_Fields_AdditionalProperties struct {
+	union json.RawMessage
 }
 
 // PatchApiScenariosByIdJSONBodyParametersDefaultValue0 defines parameters for PatchApiScenariosById.
@@ -21002,6 +22740,20 @@ type PatchApiScenariosByIdJSONBody_Parameters_Options_Item struct {
 
 // PatchApiScenariosByIdJSONBodyParametersType defines parameters for PatchApiScenariosById.
 type PatchApiScenariosByIdJSONBodyParametersType string
+
+// PatchApiScenariosById200JSONResponseBodyFields0 defines parameters for PatchApiScenariosById.
+type PatchApiScenariosById200JSONResponseBodyFields0 = string
+
+// PatchApiScenariosById200JSONResponseBodyFields1 defines parameters for PatchApiScenariosById.
+type PatchApiScenariosById200JSONResponseBodyFields1 = float32
+
+// PatchApiScenariosById200JSONResponseBodyFields2 defines parameters for PatchApiScenariosById.
+type PatchApiScenariosById200JSONResponseBodyFields2 = bool
+
+// PatchApiScenariosById200JSONResponseBody_Fields_AdditionalProperties defines parameters for PatchApiScenariosById.
+type PatchApiScenariosById200JSONResponseBody_Fields_AdditionalProperties struct {
+	union json.RawMessage
+}
 
 // PatchApiScenariosById200JSONResponseBodyParametersDefaultValue0 defines parameters for PatchApiScenariosById.
 type PatchApiScenariosById200JSONResponseBodyParametersDefaultValue0 = string
@@ -21038,6 +22790,9 @@ type PatchApiScenariosById200JSONResponseBodyParametersType string
 type PutApiScenariosByIdJSONBody struct {
 	Criteria *[]string `json:"criteria,omitempty"`
 
+	// Fields The value for each field the test suite declares, keyed by field identifier: text, a number or a boolean, in the field's own type. A field the suite does not declare answers 422 scenario_field_unknown; a value of the wrong type answers 422 scenario_field_type_invalid. An empty value clears the field. Send the full record; an empty record clears every value.
+	Fields *map[string]PutApiScenariosByIdJSONBody_Fields_AdditionalProperties `json:"fields,omitempty"`
+
 	// JudgeModel Model for the judge, e.g. openai/gpt-5-mini. Null uses the project default.
 	JudgeModel *string   `json:"judgeModel,omitempty"`
 	Labels     *[]string `json:"labels,omitempty"`
@@ -21066,6 +22821,20 @@ type PutApiScenariosByIdJSONBody struct {
 
 	// TestSuiteId The test suite to file this scenario in. It must name a non-archived test suite of the same project. null files the scenario into the project's Default test suite.
 	TestSuiteId *string `json:"testSuiteId,omitempty"`
+}
+
+// PutApiScenariosByIdJSONBodyFields0 defines parameters for PutApiScenariosById.
+type PutApiScenariosByIdJSONBodyFields0 = string
+
+// PutApiScenariosByIdJSONBodyFields1 defines parameters for PutApiScenariosById.
+type PutApiScenariosByIdJSONBodyFields1 = float32
+
+// PutApiScenariosByIdJSONBodyFields2 defines parameters for PutApiScenariosById.
+type PutApiScenariosByIdJSONBodyFields2 = bool
+
+// PutApiScenariosByIdJSONBody_Fields_AdditionalProperties defines parameters for PutApiScenariosById.
+type PutApiScenariosByIdJSONBody_Fields_AdditionalProperties struct {
+	union json.RawMessage
 }
 
 // PutApiScenariosByIdJSONBodyParametersDefaultValue0 defines parameters for PutApiScenariosById.
@@ -21098,6 +22867,20 @@ type PutApiScenariosByIdJSONBody_Parameters_Options_Item struct {
 
 // PutApiScenariosByIdJSONBodyParametersType defines parameters for PutApiScenariosById.
 type PutApiScenariosByIdJSONBodyParametersType string
+
+// PutApiScenariosById200JSONResponseBodyFields0 defines parameters for PutApiScenariosById.
+type PutApiScenariosById200JSONResponseBodyFields0 = string
+
+// PutApiScenariosById200JSONResponseBodyFields1 defines parameters for PutApiScenariosById.
+type PutApiScenariosById200JSONResponseBodyFields1 = float32
+
+// PutApiScenariosById200JSONResponseBodyFields2 defines parameters for PutApiScenariosById.
+type PutApiScenariosById200JSONResponseBodyFields2 = bool
+
+// PutApiScenariosById200JSONResponseBody_Fields_AdditionalProperties defines parameters for PutApiScenariosById.
+type PutApiScenariosById200JSONResponseBody_Fields_AdditionalProperties struct {
+	union json.RawMessage
+}
 
 // PutApiScenariosById200JSONResponseBodyParametersDefaultValue0 defines parameters for PutApiScenariosById.
 type PutApiScenariosById200JSONResponseBodyParametersDefaultValue0 = string
@@ -21136,6 +22919,20 @@ type GetApiScenariosByIdVersionsParams struct {
 
 	// Cursor Read the page below this version number.
 	Cursor *int `form:"cursor,omitempty" json:"cursor,omitempty"`
+}
+
+// GetApiScenariosByIdVersionsByVersion200JSONResponseBodySnapshotFields0 defines parameters for GetApiScenariosByIdVersionsByVersion.
+type GetApiScenariosByIdVersionsByVersion200JSONResponseBodySnapshotFields0 = string
+
+// GetApiScenariosByIdVersionsByVersion200JSONResponseBodySnapshotFields1 defines parameters for GetApiScenariosByIdVersionsByVersion.
+type GetApiScenariosByIdVersionsByVersion200JSONResponseBodySnapshotFields1 = float32
+
+// GetApiScenariosByIdVersionsByVersion200JSONResponseBodySnapshotFields2 defines parameters for GetApiScenariosByIdVersionsByVersion.
+type GetApiScenariosByIdVersionsByVersion200JSONResponseBodySnapshotFields2 = bool
+
+// GetApiScenariosByIdVersionsByVersion200JSONResponseBody_Snapshot_Fields_AdditionalProperties defines parameters for GetApiScenariosByIdVersionsByVersion.
+type GetApiScenariosByIdVersionsByVersion200JSONResponseBody_Snapshot_Fields_AdditionalProperties struct {
+	union json.RawMessage
 }
 
 // GetApiScenariosByIdVersionsByVersion200JSONResponseBodySnapshotParametersDefaultValue0 defines parameters for GetApiScenariosByIdVersionsByVersion.
@@ -21236,12 +23033,18 @@ type GetApiSimulationRunsParams struct {
 // GetApiSimulationRunsParamsInclude defines parameters for GetApiSimulationRuns.
 type GetApiSimulationRunsParamsInclude string
 
+// GetApiSimulationRuns200JSONResponseBodyRunsResultsEvaluationsStatus defines parameters for GetApiSimulationRuns.
+type GetApiSimulationRuns200JSONResponseBodyRunsResultsEvaluationsStatus string
+
 // GetApiSimulationRunsBatchesListParams defines parameters for GetApiSimulationRunsBatchesList.
 type GetApiSimulationRunsBatchesListParams struct {
 	ScenarioSetId string  `form:"scenarioSetId" json:"scenarioSetId"`
 	Limit         *int    `form:"limit,omitempty" json:"limit,omitempty"`
 	Cursor        *string `form:"cursor,omitempty" json:"cursor,omitempty"`
 }
+
+// GetApiSimulationRunsByScenarioRunId200JSONResponseBodyResultsEvaluationsStatus defines parameters for GetApiSimulationRunsByScenarioRunId.
+type GetApiSimulationRunsByScenarioRunId200JSONResponseBodyResultsEvaluationsStatus string
 
 // GetApiSuitesParams defines parameters for GetApiSuites.
 type GetApiSuitesParams struct {
@@ -22881,6 +24684,9 @@ type ListAgentsParams struct {
 	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
 }
 
+// ListAgents200JSONResponseBodyDataNotSelectableReason defines parameters for ListAgents.
+type ListAgents200JSONResponseBodyDataNotSelectableReason string
+
 // ListAgents200JSONResponseBodyDataParametersDefaultValue0 defines parameters for ListAgents.
 type ListAgents200JSONResponseBodyDataParametersDefaultValue0 = string
 
@@ -22930,6 +24736,9 @@ type CreateAgentJSONBody struct {
 
 // CreateAgentJSONBodyType defines parameters for CreateAgent.
 type CreateAgentJSONBodyType string
+
+// CreateAgent201JSONResponseBodyNotSelectableReason defines parameters for CreateAgent.
+type CreateAgent201JSONResponseBodyNotSelectableReason string
 
 // CreateAgent201JSONResponseBodyParametersDefaultValue0 defines parameters for CreateAgent.
 type CreateAgent201JSONResponseBodyParametersDefaultValue0 = string
@@ -23120,7 +24929,6 @@ type PollConnectedAgentInstance200JSONResponseBody_Frames_Item struct {
 type RegisterConnectedAgentInstanceJSONBody struct {
 	Agents []struct {
 		Concurrency *int                    `json:"concurrency,omitempty"`
-		Description *string                 `json:"description,omitempty"`
 		Environment string                  `json:"environment"`
 		Name        string                  `json:"name"`
 		Parameters  *map[string]interface{} `json:"parameters,omitempty"`
@@ -23199,6 +25007,9 @@ type RegisterConnectedAgentInstance200JSONResponseBody_Frame struct {
 // ArchiveAgent200JSONResponseBodyType defines parameters for ArchiveAgent.
 type ArchiveAgent200JSONResponseBodyType string
 
+// GetAgent200JSONResponseBodyNotSelectableReason defines parameters for GetAgent.
+type GetAgent200JSONResponseBodyNotSelectableReason string
+
 // GetAgent200JSONResponseBodyParametersDefaultValue0 defines parameters for GetAgent.
 type GetAgent200JSONResponseBodyParametersDefaultValue0 = string
 
@@ -23249,6 +25060,9 @@ type UpdateAgentJSONBody struct {
 // UpdateAgentJSONBodyType defines parameters for UpdateAgent.
 type UpdateAgentJSONBodyType string
 
+// UpdateAgent200JSONResponseBodyNotSelectableReason defines parameters for UpdateAgent.
+type UpdateAgent200JSONResponseBodyNotSelectableReason string
+
 // UpdateAgent200JSONResponseBodyParametersDefaultValue0 defines parameters for UpdateAgent.
 type UpdateAgent200JSONResponseBodyParametersDefaultValue0 = string
 
@@ -23298,6 +25112,9 @@ type ReplaceAgentJSONBody struct {
 
 // ReplaceAgentJSONBodyType defines parameters for ReplaceAgent.
 type ReplaceAgentJSONBodyType string
+
+// ReplaceAgent200JSONResponseBodyNotSelectableReason defines parameters for ReplaceAgent.
+type ReplaceAgent200JSONResponseBodyNotSelectableReason string
 
 // ReplaceAgent200JSONResponseBodyParametersDefaultValue0 defines parameters for ReplaceAgent.
 type ReplaceAgent200JSONResponseBodyParametersDefaultValue0 = string
@@ -23413,6 +25230,478 @@ type CallConnectedAgent200JSONResponseBody_Output struct {
 	union json.RawMessage
 }
 
+// GetPullRequestUsageParams defines parameters for GetPullRequestUsage.
+type GetPullRequestUsageParams struct {
+	// Repository The repository as "owner/name".
+	Repository string `form:"repository" json:"repository"`
+
+	// PullRequest The pull request number.
+	PullRequest int `form:"pullRequest" json:"pullRequest"`
+
+	// Host The GitHub host. Defaults to this instance's configured GitHub host, which is github.com unless an operator named a GitHub Enterprise Server.
+	Host *string `form:"host,omitempty" json:"host,omitempty"`
+}
+
+// PostLangyControlFramesJSONBody defines parameters for PostLangyControlFrames.
+type PostLangyControlFramesJSONBody struct {
+	// Frames Ack, result, permission_required and deregister frames, in order.
+	Frames []PostLangyControlFramesJSONBody_Frames_Item `json:"frames"`
+}
+
+// PostLangyControlFramesJSONBodyFrames0 defines parameters for PostLangyControlFrames.
+type PostLangyControlFramesJSONBodyFrames0 struct {
+	Cli struct {
+		Name    string `json:"name"`
+		Version string `json:"version"`
+	} `json:"cli"`
+	Instance struct {
+		Hostname        string    `json:"hostname"`
+		Id              string    `json:"id"`
+		InFlightCallIds *[]string `json:"inFlightCallIds,omitempty"`
+		Pid             int       `json:"pid"`
+		StartedAt       string    `json:"startedAt"`
+		Username        string    `json:"username"`
+	} `json:"instance"`
+	Protocol  PostLangyControlFramesJSONBodyFrames0Protocol `json:"protocol"`
+	Type      PostLangyControlFramesJSONBodyFrames0Type     `json:"type"`
+	Workspace struct {
+		GhAuthenticated *bool   `json:"ghAuthenticated,omitempty"`
+		GitBranch       *string `json:"gitBranch,omitempty"`
+		GitDirty        *bool   `json:"gitDirty,omitempty"`
+		GitRemote       *string `json:"gitRemote,omitempty"`
+		Name            string  `json:"name"`
+		NodeVersion     *string `json:"nodeVersion,omitempty"`
+		Os              string  `json:"os"`
+		PackageManager  *string `json:"packageManager,omitempty"`
+		PythonVersion   *string `json:"pythonVersion,omitempty"`
+		Root            string  `json:"root"`
+	} `json:"workspace"`
+}
+
+// PostLangyControlFramesJSONBodyFrames0Protocol defines parameters for PostLangyControlFrames.
+type PostLangyControlFramesJSONBodyFrames0Protocol float32
+
+// PostLangyControlFramesJSONBodyFrames0Type defines parameters for PostLangyControlFrames.
+type PostLangyControlFramesJSONBodyFrames0Type string
+
+// PostLangyControlFramesJSONBodyFrames1 defines parameters for PostLangyControlFrames.
+type PostLangyControlFramesJSONBodyFrames1 struct {
+	CallId   string                                        `json:"callId"`
+	Protocol PostLangyControlFramesJSONBodyFrames1Protocol `json:"protocol"`
+	Type     PostLangyControlFramesJSONBodyFrames1Type     `json:"type"`
+}
+
+// PostLangyControlFramesJSONBodyFrames1Protocol defines parameters for PostLangyControlFrames.
+type PostLangyControlFramesJSONBodyFrames1Protocol float32
+
+// PostLangyControlFramesJSONBodyFrames1Type defines parameters for PostLangyControlFrames.
+type PostLangyControlFramesJSONBodyFrames1Type string
+
+// PostLangyControlFramesJSONBodyFrames2 defines parameters for PostLangyControlFrames.
+type PostLangyControlFramesJSONBodyFrames2 struct {
+	CallId string `json:"callId"`
+	Error  *struct {
+		Code    PostLangyControlFramesJSONBodyFrames2ErrorCode `json:"code"`
+		Message string                                         `json:"message"`
+	} `json:"error,omitempty"`
+	Ok     bool `json:"ok"`
+	Output *struct {
+		DurationMs int     `json:"durationMs"`
+		ExitCode   *int    `json:"exitCode"`
+		LogPath    *string `json:"logPath,omitempty"`
+		Pid        *int    `json:"pid,omitempty"`
+		Stderr     string  `json:"stderr"`
+		Stdout     string  `json:"stdout"`
+		Truncated  bool    `json:"truncated"`
+	} `json:"output,omitempty"`
+	Protocol PostLangyControlFramesJSONBodyFrames2Protocol `json:"protocol"`
+	Text     *string                                       `json:"text,omitempty"`
+	Type     PostLangyControlFramesJSONBodyFrames2Type     `json:"type"`
+}
+
+// PostLangyControlFramesJSONBodyFrames2ErrorCode defines parameters for PostLangyControlFrames.
+type PostLangyControlFramesJSONBodyFrames2ErrorCode string
+
+// PostLangyControlFramesJSONBodyFrames2Protocol defines parameters for PostLangyControlFrames.
+type PostLangyControlFramesJSONBodyFrames2Protocol float32
+
+// PostLangyControlFramesJSONBodyFrames2Type defines parameters for PostLangyControlFrames.
+type PostLangyControlFramesJSONBodyFrames2Type string
+
+// PostLangyControlFramesJSONBodyFrames3 defines parameters for PostLangyControlFrames.
+type PostLangyControlFramesJSONBodyFrames3 struct {
+	CallId   string                                        `json:"callId"`
+	Pattern  string                                        `json:"pattern"`
+	Protocol PostLangyControlFramesJSONBodyFrames3Protocol `json:"protocol"`
+	Reason   string                                        `json:"reason"`
+	Segments *[]struct {
+		Command  string `json:"command"`
+		Pattern  string `json:"pattern"`
+		ReadOnly bool   `json:"readOnly"`
+	} `json:"segments,omitempty"`
+	SkipOffered    bool                                      `json:"skipOffered"`
+	Summary        string                                    `json:"summary"`
+	TimeoutSeconds *int                                      `json:"timeoutSeconds,omitempty"`
+	Type           PostLangyControlFramesJSONBodyFrames3Type `json:"type"`
+}
+
+// PostLangyControlFramesJSONBodyFrames3Protocol defines parameters for PostLangyControlFrames.
+type PostLangyControlFramesJSONBodyFrames3Protocol float32
+
+// PostLangyControlFramesJSONBodyFrames3Type defines parameters for PostLangyControlFrames.
+type PostLangyControlFramesJSONBodyFrames3Type string
+
+// PostLangyControlFramesJSONBodyFrames4 defines parameters for PostLangyControlFrames.
+type PostLangyControlFramesJSONBodyFrames4 struct {
+	CallId   string                                        `json:"callId"`
+	Decision PostLangyControlFramesJSONBodyFrames4Decision `json:"decision"`
+	Patterns *[]string                                     `json:"patterns,omitempty"`
+	Protocol PostLangyControlFramesJSONBodyFrames4Protocol `json:"protocol"`
+	Type     PostLangyControlFramesJSONBodyFrames4Type     `json:"type"`
+}
+
+// PostLangyControlFramesJSONBodyFrames4Decision defines parameters for PostLangyControlFrames.
+type PostLangyControlFramesJSONBodyFrames4Decision string
+
+// PostLangyControlFramesJSONBodyFrames4Protocol defines parameters for PostLangyControlFrames.
+type PostLangyControlFramesJSONBodyFrames4Protocol float32
+
+// PostLangyControlFramesJSONBodyFrames4Type defines parameters for PostLangyControlFrames.
+type PostLangyControlFramesJSONBodyFrames4Type string
+
+// PostLangyControlFramesJSONBodyFrames5 defines parameters for PostLangyControlFrames.
+type PostLangyControlFramesJSONBodyFrames5 struct {
+	Protocol PostLangyControlFramesJSONBodyFrames5Protocol `json:"protocol"`
+	Type     PostLangyControlFramesJSONBodyFrames5Type     `json:"type"`
+}
+
+// PostLangyControlFramesJSONBodyFrames5Protocol defines parameters for PostLangyControlFrames.
+type PostLangyControlFramesJSONBodyFrames5Protocol float32
+
+// PostLangyControlFramesJSONBodyFrames5Type defines parameters for PostLangyControlFrames.
+type PostLangyControlFramesJSONBodyFrames5Type string
+
+// PostLangyControlFramesJSONBody_Frames_Item defines parameters for PostLangyControlFrames.
+type PostLangyControlFramesJSONBody_Frames_Item struct {
+	union json.RawMessage
+}
+
+// PollLangyControlSession200JSONResponseBodyFrames0 defines parameters for PollLangyControlSession.
+type PollLangyControlSession200JSONResponseBodyFrames0 struct {
+	Conversation struct {
+		Id    string `json:"id"`
+		Title string `json:"title"`
+		Url   string `json:"url"`
+	} `json:"conversation"`
+	HeartbeatIntervalMs int    `json:"heartbeatIntervalMs"`
+	InstanceId          string `json:"instanceId"`
+	Policy              struct {
+		SkipPermissions bool `json:"skipPermissions"`
+	} `json:"policy"`
+	Protocol PollLangyControlSession200JSONResponseBodyFrames0Protocol `json:"protocol"`
+	Type     PollLangyControlSession200JSONResponseBodyFrames0Type     `json:"type"`
+}
+
+// PollLangyControlSession200JSONResponseBodyFrames0Protocol defines parameters for PollLangyControlSession.
+type PollLangyControlSession200JSONResponseBodyFrames0Protocol float32
+
+// PollLangyControlSession200JSONResponseBodyFrames0Type defines parameters for PollLangyControlSession.
+type PollLangyControlSession200JSONResponseBodyFrames0Type string
+
+// PollLangyControlSession200JSONResponseBodyFrames1 defines parameters for PollLangyControlSession.
+type PollLangyControlSession200JSONResponseBodyFrames1 struct {
+	Code     PollLangyControlSession200JSONResponseBodyFrames1Code     `json:"code"`
+	Message  string                                                    `json:"message"`
+	Protocol PollLangyControlSession200JSONResponseBodyFrames1Protocol `json:"protocol"`
+	Type     PollLangyControlSession200JSONResponseBodyFrames1Type     `json:"type"`
+}
+
+// PollLangyControlSession200JSONResponseBodyFrames1Code defines parameters for PollLangyControlSession.
+type PollLangyControlSession200JSONResponseBodyFrames1Code string
+
+// PollLangyControlSession200JSONResponseBodyFrames1Protocol defines parameters for PollLangyControlSession.
+type PollLangyControlSession200JSONResponseBodyFrames1Protocol float32
+
+// PollLangyControlSession200JSONResponseBodyFrames1Type defines parameters for PollLangyControlSession.
+type PollLangyControlSession200JSONResponseBodyFrames1Type string
+
+// PollLangyControlSession200JSONResponseBodyFrames2 defines parameters for PollLangyControlSession.
+type PollLangyControlSession200JSONResponseBodyFrames2 struct {
+	Call     PollLangyControlSession200JSONResponseBody_Frames_2_Call  `json:"call"`
+	Protocol PollLangyControlSession200JSONResponseBodyFrames2Protocol `json:"protocol"`
+	Type     PollLangyControlSession200JSONResponseBodyFrames2Type     `json:"type"`
+}
+
+// PollLangyControlSession200JSONResponseBodyFrames2Call0 defines parameters for PollLangyControlSession.
+type PollLangyControlSession200JSONResponseBodyFrames2Call0 struct {
+	Params struct {
+		Limit  *int   `json:"limit,omitempty"`
+		Offset *int   `json:"offset,omitempty"`
+		Path   string `json:"path"`
+	} `json:"params"`
+	Tool PollLangyControlSession200JSONResponseBodyFrames2Call0Tool `json:"tool"`
+}
+
+// PollLangyControlSession200JSONResponseBodyFrames2Call0Tool defines parameters for PollLangyControlSession.
+type PollLangyControlSession200JSONResponseBodyFrames2Call0Tool string
+
+// PollLangyControlSession200JSONResponseBodyFrames2Call1 defines parameters for PollLangyControlSession.
+type PollLangyControlSession200JSONResponseBodyFrames2Call1 struct {
+	Params struct {
+		Content string `json:"content"`
+		Path    string `json:"path"`
+	} `json:"params"`
+	Tool PollLangyControlSession200JSONResponseBodyFrames2Call1Tool `json:"tool"`
+}
+
+// PollLangyControlSession200JSONResponseBodyFrames2Call1Tool defines parameters for PollLangyControlSession.
+type PollLangyControlSession200JSONResponseBodyFrames2Call1Tool string
+
+// PollLangyControlSession200JSONResponseBodyFrames2Call2 defines parameters for PollLangyControlSession.
+type PollLangyControlSession200JSONResponseBodyFrames2Call2 struct {
+	Params struct {
+		Edits []struct {
+			NewText string `json:"newText"`
+			OldText string `json:"oldText"`
+		} `json:"edits"`
+		Path string `json:"path"`
+	} `json:"params"`
+	Tool PollLangyControlSession200JSONResponseBodyFrames2Call2Tool `json:"tool"`
+}
+
+// PollLangyControlSession200JSONResponseBodyFrames2Call2Tool defines parameters for PollLangyControlSession.
+type PollLangyControlSession200JSONResponseBodyFrames2Call2Tool string
+
+// PollLangyControlSession200JSONResponseBodyFrames2Call3 defines parameters for PollLangyControlSession.
+type PollLangyControlSession200JSONResponseBodyFrames2Call3 struct {
+	Params struct {
+		Background *bool  `json:"background,omitempty"`
+		Command    string `json:"command"`
+		Timeout    *int   `json:"timeout,omitempty"`
+	} `json:"params"`
+	Tool PollLangyControlSession200JSONResponseBodyFrames2Call3Tool `json:"tool"`
+}
+
+// PollLangyControlSession200JSONResponseBodyFrames2Call3Tool defines parameters for PollLangyControlSession.
+type PollLangyControlSession200JSONResponseBodyFrames2Call3Tool string
+
+// PollLangyControlSession200JSONResponseBodyFrames2Call4 defines parameters for PollLangyControlSession.
+type PollLangyControlSession200JSONResponseBodyFrames2Call4 struct {
+	Params struct {
+		Context    *int    `json:"context,omitempty"`
+		Glob       *string `json:"glob,omitempty"`
+		IgnoreCase *bool   `json:"ignoreCase,omitempty"`
+		Limit      *int    `json:"limit,omitempty"`
+		Literal    *bool   `json:"literal,omitempty"`
+		Path       *string `json:"path,omitempty"`
+		Pattern    string  `json:"pattern"`
+	} `json:"params"`
+	Tool PollLangyControlSession200JSONResponseBodyFrames2Call4Tool `json:"tool"`
+}
+
+// PollLangyControlSession200JSONResponseBodyFrames2Call4Tool defines parameters for PollLangyControlSession.
+type PollLangyControlSession200JSONResponseBodyFrames2Call4Tool string
+
+// PollLangyControlSession200JSONResponseBodyFrames2Call5 defines parameters for PollLangyControlSession.
+type PollLangyControlSession200JSONResponseBodyFrames2Call5 struct {
+	Params struct {
+		Limit   *int    `json:"limit,omitempty"`
+		Path    *string `json:"path,omitempty"`
+		Pattern string  `json:"pattern"`
+	} `json:"params"`
+	Tool PollLangyControlSession200JSONResponseBodyFrames2Call5Tool `json:"tool"`
+}
+
+// PollLangyControlSession200JSONResponseBodyFrames2Call5Tool defines parameters for PollLangyControlSession.
+type PollLangyControlSession200JSONResponseBodyFrames2Call5Tool string
+
+// PollLangyControlSession200JSONResponseBodyFrames2Call6 defines parameters for PollLangyControlSession.
+type PollLangyControlSession200JSONResponseBodyFrames2Call6 struct {
+	Params struct {
+		Limit *int    `json:"limit,omitempty"`
+		Path  *string `json:"path,omitempty"`
+	} `json:"params"`
+	Tool PollLangyControlSession200JSONResponseBodyFrames2Call6Tool `json:"tool"`
+}
+
+// PollLangyControlSession200JSONResponseBodyFrames2Call6Tool defines parameters for PollLangyControlSession.
+type PollLangyControlSession200JSONResponseBodyFrames2Call6Tool string
+
+// PollLangyControlSession200JSONResponseBody_Frames_2_Call defines parameters for PollLangyControlSession.
+type PollLangyControlSession200JSONResponseBody_Frames_2_Call struct {
+	CallId         string `json:"callId"`
+	ConversationId string `json:"conversationId"`
+	DeadlineAt     int    `json:"deadlineAt"`
+	TurnId         string `json:"turnId"`
+	union          json.RawMessage
+}
+
+// PollLangyControlSession200JSONResponseBodyFrames2Protocol defines parameters for PollLangyControlSession.
+type PollLangyControlSession200JSONResponseBodyFrames2Protocol float32
+
+// PollLangyControlSession200JSONResponseBodyFrames2Type defines parameters for PollLangyControlSession.
+type PollLangyControlSession200JSONResponseBodyFrames2Type string
+
+// PollLangyControlSession200JSONResponseBodyFrames3 defines parameters for PollLangyControlSession.
+type PollLangyControlSession200JSONResponseBodyFrames3 struct {
+	CallId   string                                                    `json:"callId"`
+	Protocol PollLangyControlSession200JSONResponseBodyFrames3Protocol `json:"protocol"`
+	Type     PollLangyControlSession200JSONResponseBodyFrames3Type     `json:"type"`
+}
+
+// PollLangyControlSession200JSONResponseBodyFrames3Protocol defines parameters for PollLangyControlSession.
+type PollLangyControlSession200JSONResponseBodyFrames3Protocol float32
+
+// PollLangyControlSession200JSONResponseBodyFrames3Type defines parameters for PollLangyControlSession.
+type PollLangyControlSession200JSONResponseBodyFrames3Type string
+
+// PollLangyControlSession200JSONResponseBodyFrames4 defines parameters for PollLangyControlSession.
+type PollLangyControlSession200JSONResponseBodyFrames4 struct {
+	CallId   string                                                    `json:"callId"`
+	Decision PollLangyControlSession200JSONResponseBodyFrames4Decision `json:"decision"`
+	Protocol PollLangyControlSession200JSONResponseBodyFrames4Protocol `json:"protocol"`
+	Type     PollLangyControlSession200JSONResponseBodyFrames4Type     `json:"type"`
+}
+
+// PollLangyControlSession200JSONResponseBodyFrames4Decision defines parameters for PollLangyControlSession.
+type PollLangyControlSession200JSONResponseBodyFrames4Decision string
+
+// PollLangyControlSession200JSONResponseBodyFrames4Protocol defines parameters for PollLangyControlSession.
+type PollLangyControlSession200JSONResponseBodyFrames4Protocol float32
+
+// PollLangyControlSession200JSONResponseBodyFrames4Type defines parameters for PollLangyControlSession.
+type PollLangyControlSession200JSONResponseBodyFrames4Type string
+
+// PollLangyControlSession200JSONResponseBodyFrames5 defines parameters for PollLangyControlSession.
+type PollLangyControlSession200JSONResponseBodyFrames5 struct {
+	Protocol        PollLangyControlSession200JSONResponseBodyFrames5Protocol `json:"protocol"`
+	SkipPermissions bool                                                      `json:"skipPermissions"`
+	Type            PollLangyControlSession200JSONResponseBodyFrames5Type     `json:"type"`
+}
+
+// PollLangyControlSession200JSONResponseBodyFrames5Protocol defines parameters for PollLangyControlSession.
+type PollLangyControlSession200JSONResponseBodyFrames5Protocol float32
+
+// PollLangyControlSession200JSONResponseBodyFrames5Type defines parameters for PollLangyControlSession.
+type PollLangyControlSession200JSONResponseBodyFrames5Type string
+
+// PollLangyControlSession200JSONResponseBodyFrames6 defines parameters for PollLangyControlSession.
+type PollLangyControlSession200JSONResponseBodyFrames6 struct {
+	Protocol PollLangyControlSession200JSONResponseBodyFrames6Protocol `json:"protocol"`
+	Reason   string                                                    `json:"reason"`
+	Type     PollLangyControlSession200JSONResponseBodyFrames6Type     `json:"type"`
+}
+
+// PollLangyControlSession200JSONResponseBodyFrames6Protocol defines parameters for PollLangyControlSession.
+type PollLangyControlSession200JSONResponseBodyFrames6Protocol float32
+
+// PollLangyControlSession200JSONResponseBodyFrames6Type defines parameters for PollLangyControlSession.
+type PollLangyControlSession200JSONResponseBodyFrames6Type string
+
+// PollLangyControlSession200JSONResponseBody_Frames_Item defines parameters for PollLangyControlSession.
+type PollLangyControlSession200JSONResponseBody_Frames_Item struct {
+	union json.RawMessage
+}
+
+// RegisterLangyControlSessionJSONBody defines parameters for RegisterLangyControlSession.
+type RegisterLangyControlSessionJSONBody struct {
+	Cli struct {
+		Name    string `json:"name"`
+		Version string `json:"version"`
+	} `json:"cli"`
+	Instance struct {
+		Hostname        string    `json:"hostname"`
+		Id              string    `json:"id"`
+		InFlightCallIds *[]string `json:"inFlightCallIds,omitempty"`
+		Pid             int       `json:"pid"`
+		StartedAt       string    `json:"startedAt"`
+		Username        string    `json:"username"`
+	} `json:"instance"`
+	Protocol  RegisterLangyControlSessionJSONBodyProtocol `json:"protocol"`
+	Type      RegisterLangyControlSessionJSONBodyType     `json:"type"`
+	Workspace struct {
+		GhAuthenticated *bool   `json:"ghAuthenticated,omitempty"`
+		GitBranch       *string `json:"gitBranch,omitempty"`
+		GitDirty        *bool   `json:"gitDirty,omitempty"`
+		GitRemote       *string `json:"gitRemote,omitempty"`
+		Name            string  `json:"name"`
+		NodeVersion     *string `json:"nodeVersion,omitempty"`
+		Os              string  `json:"os"`
+		PackageManager  *string `json:"packageManager,omitempty"`
+		PythonVersion   *string `json:"pythonVersion,omitempty"`
+		Root            string  `json:"root"`
+	} `json:"workspace"`
+}
+
+// RegisterLangyControlSessionJSONBodyProtocol defines parameters for RegisterLangyControlSession.
+type RegisterLangyControlSessionJSONBodyProtocol float32
+
+// RegisterLangyControlSessionJSONBodyType defines parameters for RegisterLangyControlSession.
+type RegisterLangyControlSessionJSONBodyType string
+
+// RegisterLangyControlSession200JSONResponseBodyFrame0 defines parameters for RegisterLangyControlSession.
+type RegisterLangyControlSession200JSONResponseBodyFrame0 struct {
+	Conversation struct {
+		Id    string `json:"id"`
+		Title string `json:"title"`
+		Url   string `json:"url"`
+	} `json:"conversation"`
+	HeartbeatIntervalMs int    `json:"heartbeatIntervalMs"`
+	InstanceId          string `json:"instanceId"`
+	Policy              struct {
+		SkipPermissions bool `json:"skipPermissions"`
+	} `json:"policy"`
+	Protocol RegisterLangyControlSession200JSONResponseBodyFrame0Protocol `json:"protocol"`
+	Type     RegisterLangyControlSession200JSONResponseBodyFrame0Type     `json:"type"`
+}
+
+// RegisterLangyControlSession200JSONResponseBodyFrame0Protocol defines parameters for RegisterLangyControlSession.
+type RegisterLangyControlSession200JSONResponseBodyFrame0Protocol float32
+
+// RegisterLangyControlSession200JSONResponseBodyFrame0Type defines parameters for RegisterLangyControlSession.
+type RegisterLangyControlSession200JSONResponseBodyFrame0Type string
+
+// RegisterLangyControlSession200JSONResponseBodyFrame1 defines parameters for RegisterLangyControlSession.
+type RegisterLangyControlSession200JSONResponseBodyFrame1 struct {
+	Code     RegisterLangyControlSession200JSONResponseBodyFrame1Code     `json:"code"`
+	Message  string                                                       `json:"message"`
+	Protocol RegisterLangyControlSession200JSONResponseBodyFrame1Protocol `json:"protocol"`
+	Type     RegisterLangyControlSession200JSONResponseBodyFrame1Type     `json:"type"`
+}
+
+// RegisterLangyControlSession200JSONResponseBodyFrame1Code defines parameters for RegisterLangyControlSession.
+type RegisterLangyControlSession200JSONResponseBodyFrame1Code string
+
+// RegisterLangyControlSession200JSONResponseBodyFrame1Protocol defines parameters for RegisterLangyControlSession.
+type RegisterLangyControlSession200JSONResponseBodyFrame1Protocol float32
+
+// RegisterLangyControlSession200JSONResponseBodyFrame1Type defines parameters for RegisterLangyControlSession.
+type RegisterLangyControlSession200JSONResponseBodyFrame1Type string
+
+// RegisterLangyControlSession200JSONResponseBody_Frame defines parameters for RegisterLangyControlSession.
+type RegisterLangyControlSession200JSONResponseBody_Frame struct {
+	union json.RawMessage
+}
+
+// ApproveLangyControlRequestJSONBody defines parameters for ApproveLangyControlRequest.
+type ApproveLangyControlRequestJSONBody struct {
+	Workspace struct {
+		GhAuthenticated *bool   `json:"ghAuthenticated,omitempty"`
+		GitBranch       *string `json:"gitBranch,omitempty"`
+		GitDirty        *bool   `json:"gitDirty,omitempty"`
+		GitRemote       *string `json:"gitRemote,omitempty"`
+		Name            string  `json:"name"`
+		NodeVersion     *string `json:"nodeVersion,omitempty"`
+		Os              string  `json:"os"`
+		PackageManager  *string `json:"packageManager,omitempty"`
+		PythonVersion   *string `json:"pythonVersion,omitempty"`
+		Root            string  `json:"root"`
+	} `json:"workspace"`
+}
+
+// CancelLangyControlRequest200JSONResponseBodyCancelled defines parameters for CancelLangyControlRequest.
+type CancelLangyControlRequest200JSONResponseBodyCancelled bool
+
 // PostApiV1ProjectsByProjectIdAnalyticsChartsJSONBody defines parameters for PostApiV1ProjectsByProjectIdAnalyticsCharts.
 type PostApiV1ProjectsByProjectIdAnalyticsChartsJSONBody struct {
 	Definition interface{} `json:"definition,omitempty"`
@@ -23434,86 +25723,267 @@ type PutApiV1ProjectsByProjectIdAnalyticsChartsByChartIdPlacementJSONBody struct
 	RowSpan     *int   `json:"rowSpan,omitempty"`
 }
 
-// PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody defines parameters for PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouse.
-type PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody struct {
-	GranularitySeconds *PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_GranularitySeconds                          `json:"granularitySeconds,omitempty"`
-	Parameters         *map[string]*PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_Parameters_AdditionalProperties `json:"parameters,omitempty"`
-	Sql                string                                                                                                    `json:"sql"`
+// GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBodyDataDefinitionQueriesParametersDefault0 defines parameters for GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets.
+type GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBodyDataDefinitionQueriesParametersDefault0 = string
+
+// GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBodyDataDefinitionQueriesParametersDefault1 defines parameters for GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets.
+type GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBodyDataDefinitionQueriesParametersDefault1 = float32
+
+// GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBodyDataDefinitionQueriesParametersDefault2 defines parameters for GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets.
+type GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBodyDataDefinitionQueriesParametersDefault2 = bool
+
+// GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBody_Data_Definition_Queries_Parameters_Default defines parameters for GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets.
+type GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBody_Data_Definition_Queries_Parameters_Default struct {
+	union json.RawMessage
+}
+
+// GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBodyDataDefinitionQueriesParametersType defines parameters for GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets.
+type GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBodyDataDefinitionQueriesParametersType string
+
+// PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBody defines parameters for PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets.
+type PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBody struct {
+	Code    string `json:"code"`
+	Name    string `json:"name"`
+	Queries []struct {
+		Name       string `json:"name"`
+		Parameters *[]struct {
+			Default *PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBody_Queries_Parameters_Default `json:"default,omitempty"`
+			Name    string                                                                                    `json:"name"`
+			Type    PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBodyQueriesParametersType        `json:"type"`
+		} `json:"parameters,omitempty"`
+		Sql string `json:"sql"`
+	} `json:"queries"`
+}
+
+// PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBodyQueriesParametersDefault0 defines parameters for PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets.
+type PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBodyQueriesParametersDefault0 = string
+
+// PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBodyQueriesParametersDefault1 defines parameters for PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets.
+type PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBodyQueriesParametersDefault1 = float32
+
+// PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBodyQueriesParametersDefault2 defines parameters for PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets.
+type PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBodyQueriesParametersDefault2 = bool
+
+// PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBody_Queries_Parameters_Default defines parameters for PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets.
+type PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBody_Queries_Parameters_Default struct {
+	union json.RawMessage
+}
+
+// PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBodyQueriesParametersType defines parameters for PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets.
+type PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBodyQueriesParametersType string
+
+// PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBodyDefinitionQueriesParametersDefault0 defines parameters for PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets.
+type PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBodyDefinitionQueriesParametersDefault0 = string
+
+// PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBodyDefinitionQueriesParametersDefault1 defines parameters for PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets.
+type PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBodyDefinitionQueriesParametersDefault1 = float32
+
+// PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBodyDefinitionQueriesParametersDefault2 defines parameters for PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets.
+type PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBodyDefinitionQueriesParametersDefault2 = bool
+
+// PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBody_Definition_Queries_Parameters_Default defines parameters for PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets.
+type PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBody_Definition_Queries_Parameters_Default struct {
+	union json.RawMessage
+}
+
+// PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBodyDefinitionQueriesParametersType defines parameters for PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets.
+type PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBodyDefinitionQueriesParametersType string
+
+// GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault0 defines parameters for GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId.
+type GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault0 = string
+
+// GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault1 defines parameters for GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId.
+type GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault1 = float32
+
+// GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault2 defines parameters for GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId.
+type GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault2 = bool
+
+// GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBody_Definition_Queries_Parameters_Default defines parameters for GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId.
+type GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBody_Definition_Queries_Parameters_Default struct {
+	union json.RawMessage
+}
+
+// GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersType defines parameters for GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId.
+type GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersType string
+
+// PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBody defines parameters for PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId.
+type PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBody struct {
+	Code    *string `json:"code,omitempty"`
+	Name    *string `json:"name,omitempty"`
+	Queries *[]struct {
+		Name       string `json:"name"`
+		Parameters *[]struct {
+			Default *PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBody_Queries_Parameters_Default `json:"default,omitempty"`
+			Name    string                                                                                               `json:"name"`
+			Type    PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBodyQueriesParametersType        `json:"type"`
+		} `json:"parameters,omitempty"`
+		Sql string `json:"sql"`
+	} `json:"queries,omitempty"`
+}
+
+// PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBodyQueriesParametersDefault0 defines parameters for PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId.
+type PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBodyQueriesParametersDefault0 = string
+
+// PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBodyQueriesParametersDefault1 defines parameters for PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId.
+type PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBodyQueriesParametersDefault1 = float32
+
+// PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBodyQueriesParametersDefault2 defines parameters for PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId.
+type PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBodyQueriesParametersDefault2 = bool
+
+// PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBody_Queries_Parameters_Default defines parameters for PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId.
+type PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBody_Queries_Parameters_Default struct {
+	union json.RawMessage
+}
+
+// PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBodyQueriesParametersType defines parameters for PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId.
+type PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBodyQueriesParametersType string
+
+// PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault0 defines parameters for PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId.
+type PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault0 = string
+
+// PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault1 defines parameters for PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId.
+type PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault1 = float32
+
+// PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault2 defines parameters for PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId.
+type PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault2 = bool
+
+// PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBody_Definition_Queries_Parameters_Default defines parameters for PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId.
+type PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBody_Definition_Queries_Parameters_Default struct {
+	union json.RawMessage
+}
+
+// PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersType defines parameters for PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId.
+type PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersType string
+
+// PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboardJSONBody defines parameters for PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard.
+type PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboardJSONBody struct {
+	DashboardId string `json:"dashboardId"`
+}
+
+// PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBodyDefinitionQueriesParametersDefault0 defines parameters for PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard.
+type PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBodyDefinitionQueriesParametersDefault0 = string
+
+// PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBodyDefinitionQueriesParametersDefault1 defines parameters for PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard.
+type PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBodyDefinitionQueriesParametersDefault1 = float32
+
+// PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBodyDefinitionQueriesParametersDefault2 defines parameters for PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard.
+type PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBodyDefinitionQueriesParametersDefault2 = bool
+
+// PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBody_Definition_Queries_Parameters_Default defines parameters for PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard.
+type PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBody_Definition_Queries_Parameters_Default struct {
+	union json.RawMessage
+}
+
+// PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBodyDefinitionQueriesParametersType defines parameters for PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard.
+type PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBodyDefinitionQueriesParametersType string
+
+// PostApiV1QueryJSONBody defines parameters for PostApiV1Query.
+type PostApiV1QueryJSONBody struct {
+	GranularitySeconds *PostApiV1QueryJSONBody_GranularitySeconds                          `json:"granularitySeconds,omitempty"`
+	Parameters         *map[string]*PostApiV1QueryJSONBody_Parameters_AdditionalProperties `json:"parameters,omitempty"`
+	Sql                string                                                              `json:"sql"`
 	TimeWindow         *struct {
-		End   PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_TimeWindow_End   `json:"end"`
-		Start PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_TimeWindow_Start `json:"start"`
+		End   PostApiV1QueryJSONBody_TimeWindow_End   `json:"end"`
+		Start PostApiV1QueryJSONBody_TimeWindow_Start `json:"start"`
 	} `json:"timeWindow,omitempty"`
 }
 
-// PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyGranularitySeconds0 defines parameters for PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouse.
-type PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyGranularitySeconds0 float32
+// PostApiV1QueryJSONBodyGranularitySeconds0 defines parameters for PostApiV1Query.
+type PostApiV1QueryJSONBodyGranularitySeconds0 float32
 
-// PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyGranularitySeconds1 defines parameters for PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouse.
-type PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyGranularitySeconds1 float32
+// PostApiV1QueryJSONBodyGranularitySeconds1 defines parameters for PostApiV1Query.
+type PostApiV1QueryJSONBodyGranularitySeconds1 float32
 
-// PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyGranularitySeconds2 defines parameters for PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouse.
-type PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyGranularitySeconds2 float32
+// PostApiV1QueryJSONBodyGranularitySeconds2 defines parameters for PostApiV1Query.
+type PostApiV1QueryJSONBodyGranularitySeconds2 float32
 
-// PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_GranularitySeconds defines parameters for PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouse.
-type PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_GranularitySeconds struct {
+// PostApiV1QueryJSONBody_GranularitySeconds defines parameters for PostApiV1Query.
+type PostApiV1QueryJSONBody_GranularitySeconds struct {
 	union json.RawMessage
 }
 
-// PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyParameters0 defines parameters for PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouse.
-type PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyParameters0 = string
+// PostApiV1QueryJSONBodyParameters0 defines parameters for PostApiV1Query.
+type PostApiV1QueryJSONBodyParameters0 = string
 
-// PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyParameters1 defines parameters for PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouse.
-type PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyParameters1 = float32
+// PostApiV1QueryJSONBodyParameters1 defines parameters for PostApiV1Query.
+type PostApiV1QueryJSONBodyParameters1 = float32
 
-// PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyParameters2 defines parameters for PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouse.
-type PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyParameters2 = bool
+// PostApiV1QueryJSONBodyParameters2 defines parameters for PostApiV1Query.
+type PostApiV1QueryJSONBodyParameters2 = bool
 
-// PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_Parameters_AdditionalProperties defines parameters for PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouse.
-type PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_Parameters_AdditionalProperties struct {
+// PostApiV1QueryJSONBody_Parameters_AdditionalProperties defines parameters for PostApiV1Query.
+type PostApiV1QueryJSONBody_Parameters_AdditionalProperties struct {
 	union json.RawMessage
 }
 
-// PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowEnd0 defines parameters for PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouse.
-type PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowEnd0 = string
+// PostApiV1QueryJSONBodyTimeWindowEnd0 defines parameters for PostApiV1Query.
+type PostApiV1QueryJSONBodyTimeWindowEnd0 = string
 
-// PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowEnd1 defines parameters for PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouse.
-type PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowEnd1 = float32
+// PostApiV1QueryJSONBodyTimeWindowEnd1 defines parameters for PostApiV1Query.
+type PostApiV1QueryJSONBodyTimeWindowEnd1 = float32
 
-// PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowEnd2 defines parameters for PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouse.
-type PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowEnd2 = string
+// PostApiV1QueryJSONBodyTimeWindowEnd2 defines parameters for PostApiV1Query.
+type PostApiV1QueryJSONBodyTimeWindowEnd2 = string
 
-// PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_TimeWindow_End defines parameters for PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouse.
-type PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_TimeWindow_End struct {
+// PostApiV1QueryJSONBody_TimeWindow_End defines parameters for PostApiV1Query.
+type PostApiV1QueryJSONBody_TimeWindow_End struct {
 	union json.RawMessage
 }
 
-// PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowStart0 defines parameters for PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouse.
-type PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowStart0 = string
+// PostApiV1QueryJSONBodyTimeWindowStart0 defines parameters for PostApiV1Query.
+type PostApiV1QueryJSONBodyTimeWindowStart0 = string
 
-// PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowStart1 defines parameters for PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouse.
-type PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowStart1 = float32
+// PostApiV1QueryJSONBodyTimeWindowStart1 defines parameters for PostApiV1Query.
+type PostApiV1QueryJSONBodyTimeWindowStart1 = float32
 
-// PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowStart2 defines parameters for PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouse.
-type PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowStart2 = string
+// PostApiV1QueryJSONBodyTimeWindowStart2 defines parameters for PostApiV1Query.
+type PostApiV1QueryJSONBodyTimeWindowStart2 = string
 
-// PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_TimeWindow_Start defines parameters for PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouse.
-type PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_TimeWindow_Start struct {
+// PostApiV1QueryJSONBody_TimeWindow_Start defines parameters for PostApiV1Query.
+type PostApiV1QueryJSONBody_TimeWindow_Start struct {
 	union json.RawMessage
 }
 
-// PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouse200JSONResponseBodyDiagnosticsCode defines parameters for PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouse.
-type PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouse200JSONResponseBodyDiagnosticsCode string
+// PostApiV1Query200JSONResponseBodyDiagnosticsCode defines parameters for PostApiV1Query.
+type PostApiV1Query200JSONResponseBodyDiagnosticsCode string
 
-// GetApiV1ProjectsByProjectIdAnalyticsSchema200JSONResponseBodyDatasetsColumnsGates defines parameters for GetApiV1ProjectsByProjectIdAnalyticsSchema.
-type GetApiV1ProjectsByProjectIdAnalyticsSchema200JSONResponseBodyDatasetsColumnsGates string
+// GetApiV1QuerySchema200JSONResponseBodyDatasetsColumnsGates defines parameters for GetApiV1QuerySchema.
+type GetApiV1QuerySchema200JSONResponseBodyDatasetsColumnsGates string
 
-// GetApiV1ProjectsByProjectIdAnalyticsSchema200JSONResponseBodyDatasetsColumnsUnit defines parameters for GetApiV1ProjectsByProjectIdAnalyticsSchema.
-type GetApiV1ProjectsByProjectIdAnalyticsSchema200JSONResponseBodyDatasetsColumnsUnit string
+// GetApiV1QuerySchema200JSONResponseBodyDatasetsColumnsUnit defines parameters for GetApiV1QuerySchema.
+type GetApiV1QuerySchema200JSONResponseBodyDatasetsColumnsUnit string
 
 // ListRunPlansParams defines parameters for ListRunPlans.
 type ListRunPlansParams struct {
 	// IncludeArchived Include archived run plans in the list. true, 1, yes for yes; false, 0, no or omitted for no.
 	IncludeArchived *string `form:"includeArchived,omitempty" json:"includeArchived,omitempty"`
+}
+
+// ListRunPlans200JSONResponseBodyEvaluatorsMappings0 defines parameters for ListRunPlans.
+type ListRunPlans200JSONResponseBodyEvaluatorsMappings0 struct {
+	Path     []string                                                   `json:"path"`
+	SourceId ListRunPlans200JSONResponseBodyEvaluatorsMappings0SourceId `json:"sourceId"`
+	Type     ListRunPlans200JSONResponseBodyEvaluatorsMappings0Type     `json:"type"`
+}
+
+// ListRunPlans200JSONResponseBodyEvaluatorsMappings0SourceId defines parameters for ListRunPlans.
+type ListRunPlans200JSONResponseBodyEvaluatorsMappings0SourceId string
+
+// ListRunPlans200JSONResponseBodyEvaluatorsMappings0Type defines parameters for ListRunPlans.
+type ListRunPlans200JSONResponseBodyEvaluatorsMappings0Type string
+
+// ListRunPlans200JSONResponseBodyEvaluatorsMappings1 defines parameters for ListRunPlans.
+type ListRunPlans200JSONResponseBodyEvaluatorsMappings1 struct {
+	Type  ListRunPlans200JSONResponseBodyEvaluatorsMappings1Type `json:"type"`
+	Value string                                                 `json:"value"`
+}
+
+// ListRunPlans200JSONResponseBodyEvaluatorsMappings1Type defines parameters for ListRunPlans.
+type ListRunPlans200JSONResponseBodyEvaluatorsMappings1Type string
+
+// ListRunPlans200JSONResponseBody_Evaluators_Mappings_AdditionalProperties defines parameters for ListRunPlans.
+type ListRunPlans200JSONResponseBody_Evaluators_Mappings_AdditionalProperties struct {
+	union json.RawMessage
 }
 
 // ListRunPlans200JSONResponseBodyScope0 defines parameters for ListRunPlans.
@@ -23576,6 +26046,21 @@ type ListRunPlans200JSONResponseBodyTargetsType string
 type RunRunPlanJSONBody struct {
 	// Config What this run covers and what it runs against. Written onto the run plan the name resolves.
 	Config struct {
+		// Evaluators The plan's own evaluators, run beside the ones attached to the test suites its scenarios belong to. A plan evaluator reads the conversation and the trace, never a scenario field. Leave it out to keep what the plan already holds.
+		Evaluators *[]struct {
+			// EvaluatorId The id of the saved evaluator this attachment runs.
+			EvaluatorId string `json:"evaluatorId"`
+
+			// Id The attachment id. Stable across edits of the attachment.
+			Id string `json:"id"`
+
+			// Mappings Where each evaluator input reads its value, keyed by input name. Inputs left out are unmapped; a required input left unmapped refuses the run.
+			Mappings map[string]RunRunPlanJSONBody_Config_Evaluators_Mappings_AdditionalProperties `json:"mappings"`
+
+			// Required Whether a failing result fails the scenario. A score-only evaluator reports and never gates.
+			Required bool `json:"required"`
+		} `json:"evaluators,omitempty"`
+
 		// JudgeModel The model that judges every scenario in the run. Overrides each scenario's own choice. Leave it out for the scenario or project default.
 		JudgeModel *string `json:"judgeModel,omitempty"`
 
@@ -23615,6 +26100,33 @@ type RunRunPlanJSONBody struct {
 
 	// Parameters Constant values applied to every scenario in the run, e.g. a fixture id or a tenant. A value supplied here overrides the scenario's own default for that name, and a target that names the same parameter in its runParameters overrides it for that target.
 	Parameters *map[string]RunRunPlanJSONBody_Parameters_AdditionalProperties `json:"parameters,omitempty"`
+}
+
+// RunRunPlanJSONBodyConfigEvaluatorsMappings0 defines parameters for RunRunPlan.
+type RunRunPlanJSONBodyConfigEvaluatorsMappings0 struct {
+	Path     []string                                            `json:"path"`
+	SourceId RunRunPlanJSONBodyConfigEvaluatorsMappings0SourceId `json:"sourceId"`
+	Type     RunRunPlanJSONBodyConfigEvaluatorsMappings0Type     `json:"type"`
+}
+
+// RunRunPlanJSONBodyConfigEvaluatorsMappings0SourceId defines parameters for RunRunPlan.
+type RunRunPlanJSONBodyConfigEvaluatorsMappings0SourceId string
+
+// RunRunPlanJSONBodyConfigEvaluatorsMappings0Type defines parameters for RunRunPlan.
+type RunRunPlanJSONBodyConfigEvaluatorsMappings0Type string
+
+// RunRunPlanJSONBodyConfigEvaluatorsMappings1 defines parameters for RunRunPlan.
+type RunRunPlanJSONBodyConfigEvaluatorsMappings1 struct {
+	Type  RunRunPlanJSONBodyConfigEvaluatorsMappings1Type `json:"type"`
+	Value string                                          `json:"value"`
+}
+
+// RunRunPlanJSONBodyConfigEvaluatorsMappings1Type defines parameters for RunRunPlan.
+type RunRunPlanJSONBodyConfigEvaluatorsMappings1Type string
+
+// RunRunPlanJSONBody_Config_Evaluators_Mappings_AdditionalProperties defines parameters for RunRunPlan.
+type RunRunPlanJSONBody_Config_Evaluators_Mappings_AdditionalProperties struct {
+	union json.RawMessage
 }
 
 // RunRunPlanJSONBodyConfigScope0 defines parameters for RunRunPlan.
@@ -23706,6 +26218,33 @@ type RunRunPlan200JSONResponseBodyItemsTargetType string
 
 // ArchiveRunPlan200JSONResponseBodyArchived defines parameters for ArchiveRunPlan.
 type ArchiveRunPlan200JSONResponseBodyArchived bool
+
+// GetRunPlan200JSONResponseBodyEvaluatorsMappings0 defines parameters for GetRunPlan.
+type GetRunPlan200JSONResponseBodyEvaluatorsMappings0 struct {
+	Path     []string                                                 `json:"path"`
+	SourceId GetRunPlan200JSONResponseBodyEvaluatorsMappings0SourceId `json:"sourceId"`
+	Type     GetRunPlan200JSONResponseBodyEvaluatorsMappings0Type     `json:"type"`
+}
+
+// GetRunPlan200JSONResponseBodyEvaluatorsMappings0SourceId defines parameters for GetRunPlan.
+type GetRunPlan200JSONResponseBodyEvaluatorsMappings0SourceId string
+
+// GetRunPlan200JSONResponseBodyEvaluatorsMappings0Type defines parameters for GetRunPlan.
+type GetRunPlan200JSONResponseBodyEvaluatorsMappings0Type string
+
+// GetRunPlan200JSONResponseBodyEvaluatorsMappings1 defines parameters for GetRunPlan.
+type GetRunPlan200JSONResponseBodyEvaluatorsMappings1 struct {
+	Type  GetRunPlan200JSONResponseBodyEvaluatorsMappings1Type `json:"type"`
+	Value string                                               `json:"value"`
+}
+
+// GetRunPlan200JSONResponseBodyEvaluatorsMappings1Type defines parameters for GetRunPlan.
+type GetRunPlan200JSONResponseBodyEvaluatorsMappings1Type string
+
+// GetRunPlan200JSONResponseBody_Evaluators_Mappings_AdditionalProperties defines parameters for GetRunPlan.
+type GetRunPlan200JSONResponseBody_Evaluators_Mappings_AdditionalProperties struct {
+	union json.RawMessage
+}
 
 // GetRunPlan200JSONResponseBodyScope0 defines parameters for GetRunPlan.
 type GetRunPlan200JSONResponseBodyScope0 struct {
@@ -23812,20 +26351,248 @@ type ListTestSuitesParams struct {
 	IncludeArchived *string `form:"includeArchived,omitempty" json:"includeArchived,omitempty"`
 }
 
+// ListTestSuites200JSONResponseBodyEvaluatorsMappings0 defines parameters for ListTestSuites.
+type ListTestSuites200JSONResponseBodyEvaluatorsMappings0 struct {
+	Path     []string                                                     `json:"path"`
+	SourceId ListTestSuites200JSONResponseBodyEvaluatorsMappings0SourceId `json:"sourceId"`
+	Type     ListTestSuites200JSONResponseBodyEvaluatorsMappings0Type     `json:"type"`
+}
+
+// ListTestSuites200JSONResponseBodyEvaluatorsMappings0SourceId defines parameters for ListTestSuites.
+type ListTestSuites200JSONResponseBodyEvaluatorsMappings0SourceId string
+
+// ListTestSuites200JSONResponseBodyEvaluatorsMappings0Type defines parameters for ListTestSuites.
+type ListTestSuites200JSONResponseBodyEvaluatorsMappings0Type string
+
+// ListTestSuites200JSONResponseBodyEvaluatorsMappings1 defines parameters for ListTestSuites.
+type ListTestSuites200JSONResponseBodyEvaluatorsMappings1 struct {
+	Type  ListTestSuites200JSONResponseBodyEvaluatorsMappings1Type `json:"type"`
+	Value string                                                   `json:"value"`
+}
+
+// ListTestSuites200JSONResponseBodyEvaluatorsMappings1Type defines parameters for ListTestSuites.
+type ListTestSuites200JSONResponseBodyEvaluatorsMappings1Type string
+
+// ListTestSuites200JSONResponseBody_Evaluators_Mappings_AdditionalProperties defines parameters for ListTestSuites.
+type ListTestSuites200JSONResponseBody_Evaluators_Mappings_AdditionalProperties struct {
+	union json.RawMessage
+}
+
+// ListTestSuites200JSONResponseBodyFieldsType defines parameters for ListTestSuites.
+type ListTestSuites200JSONResponseBodyFieldsType string
+
 // CreateTestSuiteJSONBody defines parameters for CreateTestSuite.
 type CreateTestSuiteJSONBody struct {
+	// Evaluators The evaluators that run after every scenario run. Up to 20. A required evaluator that fails fails the scenario; a score-only evaluator reports and never gates.
+	Evaluators *[]struct {
+		// EvaluatorId The id of the saved evaluator this attachment runs.
+		EvaluatorId string `json:"evaluatorId"`
+
+		// Id The attachment id. Stable across edits of the attachment.
+		Id string `json:"id"`
+
+		// Mappings Where each evaluator input reads its value, keyed by input name. Inputs left out are unmapped; a required input left unmapped refuses the run.
+		Mappings map[string]CreateTestSuiteJSONBody_Evaluators_Mappings_AdditionalProperties `json:"mappings"`
+
+		// Required Whether a failing result fails the scenario. A score-only evaluator reports and never gates.
+		Required bool `json:"required"`
+	} `json:"evaluators,omitempty"`
+
+	// Fields The fields the test suite declares, in the order the platform shows them. Up to 30. An identifier is lowercase letters, digits and underscores, starting with a letter; the type is text, number or boolean.
+	Fields *[]struct {
+		// Identifier The field name, as scenarios and evaluator mappings address it. Lowercase letters, digits and underscores, starting with a letter.
+		Identifier string `json:"identifier"`
+
+		// Type The value type every scenario carries for this field.
+		Type CreateTestSuiteJSONBodyFieldsType `json:"type"`
+	} `json:"fields,omitempty"`
+
 	// Name The test suite name, as it reads in the platform.
 	Name string `json:"name"`
 }
+
+// CreateTestSuiteJSONBodyEvaluatorsMappings0 defines parameters for CreateTestSuite.
+type CreateTestSuiteJSONBodyEvaluatorsMappings0 struct {
+	Path     []string                                           `json:"path"`
+	SourceId CreateTestSuiteJSONBodyEvaluatorsMappings0SourceId `json:"sourceId"`
+	Type     CreateTestSuiteJSONBodyEvaluatorsMappings0Type     `json:"type"`
+}
+
+// CreateTestSuiteJSONBodyEvaluatorsMappings0SourceId defines parameters for CreateTestSuite.
+type CreateTestSuiteJSONBodyEvaluatorsMappings0SourceId string
+
+// CreateTestSuiteJSONBodyEvaluatorsMappings0Type defines parameters for CreateTestSuite.
+type CreateTestSuiteJSONBodyEvaluatorsMappings0Type string
+
+// CreateTestSuiteJSONBodyEvaluatorsMappings1 defines parameters for CreateTestSuite.
+type CreateTestSuiteJSONBodyEvaluatorsMappings1 struct {
+	Type  CreateTestSuiteJSONBodyEvaluatorsMappings1Type `json:"type"`
+	Value string                                         `json:"value"`
+}
+
+// CreateTestSuiteJSONBodyEvaluatorsMappings1Type defines parameters for CreateTestSuite.
+type CreateTestSuiteJSONBodyEvaluatorsMappings1Type string
+
+// CreateTestSuiteJSONBody_Evaluators_Mappings_AdditionalProperties defines parameters for CreateTestSuite.
+type CreateTestSuiteJSONBody_Evaluators_Mappings_AdditionalProperties struct {
+	union json.RawMessage
+}
+
+// CreateTestSuiteJSONBodyFieldsType defines parameters for CreateTestSuite.
+type CreateTestSuiteJSONBodyFieldsType string
+
+// CreateTestSuite201JSONResponseBodyEvaluatorsMappings0 defines parameters for CreateTestSuite.
+type CreateTestSuite201JSONResponseBodyEvaluatorsMappings0 struct {
+	Path     []string                                                      `json:"path"`
+	SourceId CreateTestSuite201JSONResponseBodyEvaluatorsMappings0SourceId `json:"sourceId"`
+	Type     CreateTestSuite201JSONResponseBodyEvaluatorsMappings0Type     `json:"type"`
+}
+
+// CreateTestSuite201JSONResponseBodyEvaluatorsMappings0SourceId defines parameters for CreateTestSuite.
+type CreateTestSuite201JSONResponseBodyEvaluatorsMappings0SourceId string
+
+// CreateTestSuite201JSONResponseBodyEvaluatorsMappings0Type defines parameters for CreateTestSuite.
+type CreateTestSuite201JSONResponseBodyEvaluatorsMappings0Type string
+
+// CreateTestSuite201JSONResponseBodyEvaluatorsMappings1 defines parameters for CreateTestSuite.
+type CreateTestSuite201JSONResponseBodyEvaluatorsMappings1 struct {
+	Type  CreateTestSuite201JSONResponseBodyEvaluatorsMappings1Type `json:"type"`
+	Value string                                                    `json:"value"`
+}
+
+// CreateTestSuite201JSONResponseBodyEvaluatorsMappings1Type defines parameters for CreateTestSuite.
+type CreateTestSuite201JSONResponseBodyEvaluatorsMappings1Type string
+
+// CreateTestSuite201JSONResponseBody_Evaluators_Mappings_AdditionalProperties defines parameters for CreateTestSuite.
+type CreateTestSuite201JSONResponseBody_Evaluators_Mappings_AdditionalProperties struct {
+	union json.RawMessage
+}
+
+// CreateTestSuite201JSONResponseBodyFieldsType defines parameters for CreateTestSuite.
+type CreateTestSuite201JSONResponseBodyFieldsType string
 
 // ArchiveTestSuite200JSONResponseBodyArchived defines parameters for ArchiveTestSuite.
 type ArchiveTestSuite200JSONResponseBodyArchived bool
 
-// RenameTestSuiteJSONBody defines parameters for RenameTestSuite.
-type RenameTestSuiteJSONBody struct {
-	// Name The test suite name, as it reads in the platform.
-	Name string `json:"name"`
+// GetTestSuite200JSONResponseBodyEvaluatorsMappings0 defines parameters for GetTestSuite.
+type GetTestSuite200JSONResponseBodyEvaluatorsMappings0 struct {
+	Path     []string                                                   `json:"path"`
+	SourceId GetTestSuite200JSONResponseBodyEvaluatorsMappings0SourceId `json:"sourceId"`
+	Type     GetTestSuite200JSONResponseBodyEvaluatorsMappings0Type     `json:"type"`
 }
+
+// GetTestSuite200JSONResponseBodyEvaluatorsMappings0SourceId defines parameters for GetTestSuite.
+type GetTestSuite200JSONResponseBodyEvaluatorsMappings0SourceId string
+
+// GetTestSuite200JSONResponseBodyEvaluatorsMappings0Type defines parameters for GetTestSuite.
+type GetTestSuite200JSONResponseBodyEvaluatorsMappings0Type string
+
+// GetTestSuite200JSONResponseBodyEvaluatorsMappings1 defines parameters for GetTestSuite.
+type GetTestSuite200JSONResponseBodyEvaluatorsMappings1 struct {
+	Type  GetTestSuite200JSONResponseBodyEvaluatorsMappings1Type `json:"type"`
+	Value string                                                 `json:"value"`
+}
+
+// GetTestSuite200JSONResponseBodyEvaluatorsMappings1Type defines parameters for GetTestSuite.
+type GetTestSuite200JSONResponseBodyEvaluatorsMappings1Type string
+
+// GetTestSuite200JSONResponseBody_Evaluators_Mappings_AdditionalProperties defines parameters for GetTestSuite.
+type GetTestSuite200JSONResponseBody_Evaluators_Mappings_AdditionalProperties struct {
+	union json.RawMessage
+}
+
+// GetTestSuite200JSONResponseBodyFieldsType defines parameters for GetTestSuite.
+type GetTestSuite200JSONResponseBodyFieldsType string
+
+// UpdateTestSuiteJSONBody defines parameters for UpdateTestSuite.
+type UpdateTestSuiteJSONBody struct {
+	// Evaluators The full list of evaluators attached to the suite. An evaluator the project does not hold answers 422 suite_evaluator_not_found; a mapping the run cannot read answers 422 suite_evaluator_mapping_invalid.
+	Evaluators *[]struct {
+		// EvaluatorId The id of the saved evaluator this attachment runs.
+		EvaluatorId string `json:"evaluatorId"`
+
+		// Id The attachment id. Stable across edits of the attachment.
+		Id string `json:"id"`
+
+		// Mappings Where each evaluator input reads its value, keyed by input name. Inputs left out are unmapped; a required input left unmapped refuses the run.
+		Mappings map[string]UpdateTestSuiteJSONBody_Evaluators_Mappings_AdditionalProperties `json:"mappings"`
+
+		// Required Whether a failing result fails the scenario. A score-only evaluator reports and never gates.
+		Required bool `json:"required"`
+	} `json:"evaluators,omitempty"`
+
+	// Fields The full list of fields the suite declares. A field an attached evaluator still reads cannot be removed: answers 422 suite_field_in_use.
+	Fields *[]struct {
+		// Identifier The field name, as scenarios and evaluator mappings address it. Lowercase letters, digits and underscores, starting with a letter.
+		Identifier string `json:"identifier"`
+
+		// Type The value type every scenario carries for this field.
+		Type UpdateTestSuiteJSONBodyFieldsType `json:"type"`
+	} `json:"fields,omitempty"`
+
+	// Name The new name. The slug is kept.
+	Name *string `json:"name,omitempty"`
+}
+
+// UpdateTestSuiteJSONBodyEvaluatorsMappings0 defines parameters for UpdateTestSuite.
+type UpdateTestSuiteJSONBodyEvaluatorsMappings0 struct {
+	Path     []string                                           `json:"path"`
+	SourceId UpdateTestSuiteJSONBodyEvaluatorsMappings0SourceId `json:"sourceId"`
+	Type     UpdateTestSuiteJSONBodyEvaluatorsMappings0Type     `json:"type"`
+}
+
+// UpdateTestSuiteJSONBodyEvaluatorsMappings0SourceId defines parameters for UpdateTestSuite.
+type UpdateTestSuiteJSONBodyEvaluatorsMappings0SourceId string
+
+// UpdateTestSuiteJSONBodyEvaluatorsMappings0Type defines parameters for UpdateTestSuite.
+type UpdateTestSuiteJSONBodyEvaluatorsMappings0Type string
+
+// UpdateTestSuiteJSONBodyEvaluatorsMappings1 defines parameters for UpdateTestSuite.
+type UpdateTestSuiteJSONBodyEvaluatorsMappings1 struct {
+	Type  UpdateTestSuiteJSONBodyEvaluatorsMappings1Type `json:"type"`
+	Value string                                         `json:"value"`
+}
+
+// UpdateTestSuiteJSONBodyEvaluatorsMappings1Type defines parameters for UpdateTestSuite.
+type UpdateTestSuiteJSONBodyEvaluatorsMappings1Type string
+
+// UpdateTestSuiteJSONBody_Evaluators_Mappings_AdditionalProperties defines parameters for UpdateTestSuite.
+type UpdateTestSuiteJSONBody_Evaluators_Mappings_AdditionalProperties struct {
+	union json.RawMessage
+}
+
+// UpdateTestSuiteJSONBodyFieldsType defines parameters for UpdateTestSuite.
+type UpdateTestSuiteJSONBodyFieldsType string
+
+// UpdateTestSuite200JSONResponseBodyEvaluatorsMappings0 defines parameters for UpdateTestSuite.
+type UpdateTestSuite200JSONResponseBodyEvaluatorsMappings0 struct {
+	Path     []string                                                      `json:"path"`
+	SourceId UpdateTestSuite200JSONResponseBodyEvaluatorsMappings0SourceId `json:"sourceId"`
+	Type     UpdateTestSuite200JSONResponseBodyEvaluatorsMappings0Type     `json:"type"`
+}
+
+// UpdateTestSuite200JSONResponseBodyEvaluatorsMappings0SourceId defines parameters for UpdateTestSuite.
+type UpdateTestSuite200JSONResponseBodyEvaluatorsMappings0SourceId string
+
+// UpdateTestSuite200JSONResponseBodyEvaluatorsMappings0Type defines parameters for UpdateTestSuite.
+type UpdateTestSuite200JSONResponseBodyEvaluatorsMappings0Type string
+
+// UpdateTestSuite200JSONResponseBodyEvaluatorsMappings1 defines parameters for UpdateTestSuite.
+type UpdateTestSuite200JSONResponseBodyEvaluatorsMappings1 struct {
+	Type  UpdateTestSuite200JSONResponseBodyEvaluatorsMappings1Type `json:"type"`
+	Value string                                                    `json:"value"`
+}
+
+// UpdateTestSuite200JSONResponseBodyEvaluatorsMappings1Type defines parameters for UpdateTestSuite.
+type UpdateTestSuite200JSONResponseBodyEvaluatorsMappings1Type string
+
+// UpdateTestSuite200JSONResponseBody_Evaluators_Mappings_AdditionalProperties defines parameters for UpdateTestSuite.
+type UpdateTestSuite200JSONResponseBody_Evaluators_Mappings_AdditionalProperties struct {
+	union json.RawMessage
+}
+
+// UpdateTestSuite200JSONResponseBodyFieldsType defines parameters for UpdateTestSuite.
+type UpdateTestSuite200JSONResponseBodyFieldsType string
 
 // RunTestSuiteJSONBody defines parameters for RunTestSuite.
 type RunTestSuiteJSONBody struct {
@@ -24726,6 +27493,15 @@ type ReplaceAgentJSONRequestBody ReplaceAgentJSONBody
 // CallConnectedAgentJSONRequestBody defines body for CallConnectedAgent for application/json ContentType.
 type CallConnectedAgentJSONRequestBody CallConnectedAgentJSONBody
 
+// PostLangyControlFramesJSONRequestBody defines body for PostLangyControlFrames for application/json ContentType.
+type PostLangyControlFramesJSONRequestBody PostLangyControlFramesJSONBody
+
+// RegisterLangyControlSessionJSONRequestBody defines body for RegisterLangyControlSession for application/json ContentType.
+type RegisterLangyControlSessionJSONRequestBody RegisterLangyControlSessionJSONBody
+
+// ApproveLangyControlRequestJSONRequestBody defines body for ApproveLangyControlRequest for application/json ContentType.
+type ApproveLangyControlRequestJSONRequestBody ApproveLangyControlRequestJSONBody
+
 // PostApiV1ProjectsByProjectIdAnalyticsChartsJSONRequestBody defines body for PostApiV1ProjectsByProjectIdAnalyticsCharts for application/json ContentType.
 type PostApiV1ProjectsByProjectIdAnalyticsChartsJSONRequestBody PostApiV1ProjectsByProjectIdAnalyticsChartsJSONBody
 
@@ -24735,8 +27511,17 @@ type PatchApiV1ProjectsByProjectIdAnalyticsChartsByChartIdJSONRequestBody PatchA
 // PutApiV1ProjectsByProjectIdAnalyticsChartsByChartIdPlacementJSONRequestBody defines body for PutApiV1ProjectsByProjectIdAnalyticsChartsByChartIdPlacement for application/json ContentType.
 type PutApiV1ProjectsByProjectIdAnalyticsChartsByChartIdPlacementJSONRequestBody PutApiV1ProjectsByProjectIdAnalyticsChartsByChartIdPlacementJSONBody
 
-// PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONRequestBody defines body for PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouse for application/json ContentType.
-type PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONRequestBody PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody
+// PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONRequestBody defines body for PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets for application/json ContentType.
+type PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONRequestBody PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBody
+
+// PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONRequestBody defines body for PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId for application/json ContentType.
+type PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONRequestBody PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBody
+
+// PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboardJSONRequestBody defines body for PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard for application/json ContentType.
+type PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboardJSONRequestBody PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboardJSONBody
+
+// PostApiV1QueryJSONRequestBody defines body for PostApiV1Query for application/json ContentType.
+type PostApiV1QueryJSONRequestBody PostApiV1QueryJSONBody
 
 // RunRunPlanJSONRequestBody defines body for RunRunPlan for application/json ContentType.
 type RunRunPlanJSONRequestBody RunRunPlanJSONBody
@@ -24747,8 +27532,8 @@ type RerunRunPlanJSONRequestBody RerunRunPlanJSONBody
 // CreateTestSuiteJSONRequestBody defines body for CreateTestSuite for application/json ContentType.
 type CreateTestSuiteJSONRequestBody CreateTestSuiteJSONBody
 
-// RenameTestSuiteJSONRequestBody defines body for RenameTestSuite for application/json ContentType.
-type RenameTestSuiteJSONRequestBody RenameTestSuiteJSONBody
+// UpdateTestSuiteJSONRequestBody defines body for UpdateTestSuite for application/json ContentType.
+type UpdateTestSuiteJSONRequestBody UpdateTestSuiteJSONBody
 
 // RunTestSuiteJSONRequestBody defines body for RunTestSuite for application/json ContentType.
 type RunTestSuiteJSONRequestBody RunTestSuiteJSONBody
@@ -50466,6 +53251,94 @@ func (t *PostApiScenarioEventsJSONBody_0_Metadata_Langwatch_TargetParameters_Add
 	return err
 }
 
+// AsGetApiScenarios200JSONResponseBodyFields0 returns the union data inside the GetApiScenarios200JSONResponseBody_Fields_AdditionalProperties as a GetApiScenarios200JSONResponseBodyFields0
+func (t GetApiScenarios200JSONResponseBody_Fields_AdditionalProperties) AsGetApiScenarios200JSONResponseBodyFields0() (GetApiScenarios200JSONResponseBodyFields0, error) {
+	var body GetApiScenarios200JSONResponseBodyFields0
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromGetApiScenarios200JSONResponseBodyFields0 overwrites any union data inside the GetApiScenarios200JSONResponseBody_Fields_AdditionalProperties as the provided GetApiScenarios200JSONResponseBodyFields0
+func (t *GetApiScenarios200JSONResponseBody_Fields_AdditionalProperties) FromGetApiScenarios200JSONResponseBodyFields0(v GetApiScenarios200JSONResponseBodyFields0) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeGetApiScenarios200JSONResponseBodyFields0 performs a merge with any union data inside the GetApiScenarios200JSONResponseBody_Fields_AdditionalProperties, using the provided GetApiScenarios200JSONResponseBodyFields0
+func (t *GetApiScenarios200JSONResponseBody_Fields_AdditionalProperties) MergeGetApiScenarios200JSONResponseBodyFields0(v GetApiScenarios200JSONResponseBodyFields0) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsGetApiScenarios200JSONResponseBodyFields1 returns the union data inside the GetApiScenarios200JSONResponseBody_Fields_AdditionalProperties as a GetApiScenarios200JSONResponseBodyFields1
+func (t GetApiScenarios200JSONResponseBody_Fields_AdditionalProperties) AsGetApiScenarios200JSONResponseBodyFields1() (GetApiScenarios200JSONResponseBodyFields1, error) {
+	var body GetApiScenarios200JSONResponseBodyFields1
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromGetApiScenarios200JSONResponseBodyFields1 overwrites any union data inside the GetApiScenarios200JSONResponseBody_Fields_AdditionalProperties as the provided GetApiScenarios200JSONResponseBodyFields1
+func (t *GetApiScenarios200JSONResponseBody_Fields_AdditionalProperties) FromGetApiScenarios200JSONResponseBodyFields1(v GetApiScenarios200JSONResponseBodyFields1) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeGetApiScenarios200JSONResponseBodyFields1 performs a merge with any union data inside the GetApiScenarios200JSONResponseBody_Fields_AdditionalProperties, using the provided GetApiScenarios200JSONResponseBodyFields1
+func (t *GetApiScenarios200JSONResponseBody_Fields_AdditionalProperties) MergeGetApiScenarios200JSONResponseBodyFields1(v GetApiScenarios200JSONResponseBodyFields1) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsGetApiScenarios200JSONResponseBodyFields2 returns the union data inside the GetApiScenarios200JSONResponseBody_Fields_AdditionalProperties as a GetApiScenarios200JSONResponseBodyFields2
+func (t GetApiScenarios200JSONResponseBody_Fields_AdditionalProperties) AsGetApiScenarios200JSONResponseBodyFields2() (GetApiScenarios200JSONResponseBodyFields2, error) {
+	var body GetApiScenarios200JSONResponseBodyFields2
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromGetApiScenarios200JSONResponseBodyFields2 overwrites any union data inside the GetApiScenarios200JSONResponseBody_Fields_AdditionalProperties as the provided GetApiScenarios200JSONResponseBodyFields2
+func (t *GetApiScenarios200JSONResponseBody_Fields_AdditionalProperties) FromGetApiScenarios200JSONResponseBodyFields2(v GetApiScenarios200JSONResponseBodyFields2) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeGetApiScenarios200JSONResponseBodyFields2 performs a merge with any union data inside the GetApiScenarios200JSONResponseBody_Fields_AdditionalProperties, using the provided GetApiScenarios200JSONResponseBodyFields2
+func (t *GetApiScenarios200JSONResponseBody_Fields_AdditionalProperties) MergeGetApiScenarios200JSONResponseBodyFields2(v GetApiScenarios200JSONResponseBodyFields2) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+func (t GetApiScenarios200JSONResponseBody_Fields_AdditionalProperties) MarshalJSON() ([]byte, error) {
+	b, err := t.union.MarshalJSON()
+	return b, err
+}
+
+func (t *GetApiScenarios200JSONResponseBody_Fields_AdditionalProperties) UnmarshalJSON(b []byte) error {
+	err := t.union.UnmarshalJSON(b)
+	return err
+}
+
 // AsGetApiScenarios200JSONResponseBodyParametersDefaultValue0 returns the union data inside the GetApiScenarios200JSONResponseBody_Parameters_DefaultValue as a GetApiScenarios200JSONResponseBodyParametersDefaultValue0
 func (t GetApiScenarios200JSONResponseBody_Parameters_DefaultValue) AsGetApiScenarios200JSONResponseBodyParametersDefaultValue0() (GetApiScenarios200JSONResponseBodyParametersDefaultValue0, error) {
 	var body GetApiScenarios200JSONResponseBodyParametersDefaultValue0
@@ -50638,6 +53511,94 @@ func (t GetApiScenarios200JSONResponseBody_Parameters_Options_Item) MarshalJSON(
 }
 
 func (t *GetApiScenarios200JSONResponseBody_Parameters_Options_Item) UnmarshalJSON(b []byte) error {
+	err := t.union.UnmarshalJSON(b)
+	return err
+}
+
+// AsPostApiScenariosJSONBodyFields0 returns the union data inside the PostApiScenariosJSONBody_Fields_AdditionalProperties as a PostApiScenariosJSONBodyFields0
+func (t PostApiScenariosJSONBody_Fields_AdditionalProperties) AsPostApiScenariosJSONBodyFields0() (PostApiScenariosJSONBodyFields0, error) {
+	var body PostApiScenariosJSONBodyFields0
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromPostApiScenariosJSONBodyFields0 overwrites any union data inside the PostApiScenariosJSONBody_Fields_AdditionalProperties as the provided PostApiScenariosJSONBodyFields0
+func (t *PostApiScenariosJSONBody_Fields_AdditionalProperties) FromPostApiScenariosJSONBodyFields0(v PostApiScenariosJSONBodyFields0) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergePostApiScenariosJSONBodyFields0 performs a merge with any union data inside the PostApiScenariosJSONBody_Fields_AdditionalProperties, using the provided PostApiScenariosJSONBodyFields0
+func (t *PostApiScenariosJSONBody_Fields_AdditionalProperties) MergePostApiScenariosJSONBodyFields0(v PostApiScenariosJSONBodyFields0) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsPostApiScenariosJSONBodyFields1 returns the union data inside the PostApiScenariosJSONBody_Fields_AdditionalProperties as a PostApiScenariosJSONBodyFields1
+func (t PostApiScenariosJSONBody_Fields_AdditionalProperties) AsPostApiScenariosJSONBodyFields1() (PostApiScenariosJSONBodyFields1, error) {
+	var body PostApiScenariosJSONBodyFields1
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromPostApiScenariosJSONBodyFields1 overwrites any union data inside the PostApiScenariosJSONBody_Fields_AdditionalProperties as the provided PostApiScenariosJSONBodyFields1
+func (t *PostApiScenariosJSONBody_Fields_AdditionalProperties) FromPostApiScenariosJSONBodyFields1(v PostApiScenariosJSONBodyFields1) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergePostApiScenariosJSONBodyFields1 performs a merge with any union data inside the PostApiScenariosJSONBody_Fields_AdditionalProperties, using the provided PostApiScenariosJSONBodyFields1
+func (t *PostApiScenariosJSONBody_Fields_AdditionalProperties) MergePostApiScenariosJSONBodyFields1(v PostApiScenariosJSONBodyFields1) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsPostApiScenariosJSONBodyFields2 returns the union data inside the PostApiScenariosJSONBody_Fields_AdditionalProperties as a PostApiScenariosJSONBodyFields2
+func (t PostApiScenariosJSONBody_Fields_AdditionalProperties) AsPostApiScenariosJSONBodyFields2() (PostApiScenariosJSONBodyFields2, error) {
+	var body PostApiScenariosJSONBodyFields2
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromPostApiScenariosJSONBodyFields2 overwrites any union data inside the PostApiScenariosJSONBody_Fields_AdditionalProperties as the provided PostApiScenariosJSONBodyFields2
+func (t *PostApiScenariosJSONBody_Fields_AdditionalProperties) FromPostApiScenariosJSONBodyFields2(v PostApiScenariosJSONBodyFields2) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergePostApiScenariosJSONBodyFields2 performs a merge with any union data inside the PostApiScenariosJSONBody_Fields_AdditionalProperties, using the provided PostApiScenariosJSONBodyFields2
+func (t *PostApiScenariosJSONBody_Fields_AdditionalProperties) MergePostApiScenariosJSONBodyFields2(v PostApiScenariosJSONBodyFields2) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+func (t PostApiScenariosJSONBody_Fields_AdditionalProperties) MarshalJSON() ([]byte, error) {
+	b, err := t.union.MarshalJSON()
+	return b, err
+}
+
+func (t *PostApiScenariosJSONBody_Fields_AdditionalProperties) UnmarshalJSON(b []byte) error {
 	err := t.union.UnmarshalJSON(b)
 	return err
 }
@@ -50818,6 +53779,94 @@ func (t *PostApiScenariosJSONBody_Parameters_Options_Item) UnmarshalJSON(b []byt
 	return err
 }
 
+// AsPostApiScenarios201JSONResponseBodyFields0 returns the union data inside the PostApiScenarios201JSONResponseBody_Fields_AdditionalProperties as a PostApiScenarios201JSONResponseBodyFields0
+func (t PostApiScenarios201JSONResponseBody_Fields_AdditionalProperties) AsPostApiScenarios201JSONResponseBodyFields0() (PostApiScenarios201JSONResponseBodyFields0, error) {
+	var body PostApiScenarios201JSONResponseBodyFields0
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromPostApiScenarios201JSONResponseBodyFields0 overwrites any union data inside the PostApiScenarios201JSONResponseBody_Fields_AdditionalProperties as the provided PostApiScenarios201JSONResponseBodyFields0
+func (t *PostApiScenarios201JSONResponseBody_Fields_AdditionalProperties) FromPostApiScenarios201JSONResponseBodyFields0(v PostApiScenarios201JSONResponseBodyFields0) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergePostApiScenarios201JSONResponseBodyFields0 performs a merge with any union data inside the PostApiScenarios201JSONResponseBody_Fields_AdditionalProperties, using the provided PostApiScenarios201JSONResponseBodyFields0
+func (t *PostApiScenarios201JSONResponseBody_Fields_AdditionalProperties) MergePostApiScenarios201JSONResponseBodyFields0(v PostApiScenarios201JSONResponseBodyFields0) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsPostApiScenarios201JSONResponseBodyFields1 returns the union data inside the PostApiScenarios201JSONResponseBody_Fields_AdditionalProperties as a PostApiScenarios201JSONResponseBodyFields1
+func (t PostApiScenarios201JSONResponseBody_Fields_AdditionalProperties) AsPostApiScenarios201JSONResponseBodyFields1() (PostApiScenarios201JSONResponseBodyFields1, error) {
+	var body PostApiScenarios201JSONResponseBodyFields1
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromPostApiScenarios201JSONResponseBodyFields1 overwrites any union data inside the PostApiScenarios201JSONResponseBody_Fields_AdditionalProperties as the provided PostApiScenarios201JSONResponseBodyFields1
+func (t *PostApiScenarios201JSONResponseBody_Fields_AdditionalProperties) FromPostApiScenarios201JSONResponseBodyFields1(v PostApiScenarios201JSONResponseBodyFields1) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergePostApiScenarios201JSONResponseBodyFields1 performs a merge with any union data inside the PostApiScenarios201JSONResponseBody_Fields_AdditionalProperties, using the provided PostApiScenarios201JSONResponseBodyFields1
+func (t *PostApiScenarios201JSONResponseBody_Fields_AdditionalProperties) MergePostApiScenarios201JSONResponseBodyFields1(v PostApiScenarios201JSONResponseBodyFields1) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsPostApiScenarios201JSONResponseBodyFields2 returns the union data inside the PostApiScenarios201JSONResponseBody_Fields_AdditionalProperties as a PostApiScenarios201JSONResponseBodyFields2
+func (t PostApiScenarios201JSONResponseBody_Fields_AdditionalProperties) AsPostApiScenarios201JSONResponseBodyFields2() (PostApiScenarios201JSONResponseBodyFields2, error) {
+	var body PostApiScenarios201JSONResponseBodyFields2
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromPostApiScenarios201JSONResponseBodyFields2 overwrites any union data inside the PostApiScenarios201JSONResponseBody_Fields_AdditionalProperties as the provided PostApiScenarios201JSONResponseBodyFields2
+func (t *PostApiScenarios201JSONResponseBody_Fields_AdditionalProperties) FromPostApiScenarios201JSONResponseBodyFields2(v PostApiScenarios201JSONResponseBodyFields2) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergePostApiScenarios201JSONResponseBodyFields2 performs a merge with any union data inside the PostApiScenarios201JSONResponseBody_Fields_AdditionalProperties, using the provided PostApiScenarios201JSONResponseBodyFields2
+func (t *PostApiScenarios201JSONResponseBody_Fields_AdditionalProperties) MergePostApiScenarios201JSONResponseBodyFields2(v PostApiScenarios201JSONResponseBodyFields2) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+func (t PostApiScenarios201JSONResponseBody_Fields_AdditionalProperties) MarshalJSON() ([]byte, error) {
+	b, err := t.union.MarshalJSON()
+	return b, err
+}
+
+func (t *PostApiScenarios201JSONResponseBody_Fields_AdditionalProperties) UnmarshalJSON(b []byte) error {
+	err := t.union.UnmarshalJSON(b)
+	return err
+}
+
 // AsPostApiScenarios201JSONResponseBodyParametersDefaultValue0 returns the union data inside the PostApiScenarios201JSONResponseBody_Parameters_DefaultValue as a PostApiScenarios201JSONResponseBodyParametersDefaultValue0
 func (t PostApiScenarios201JSONResponseBody_Parameters_DefaultValue) AsPostApiScenarios201JSONResponseBodyParametersDefaultValue0() (PostApiScenarios201JSONResponseBodyParametersDefaultValue0, error) {
 	var body PostApiScenarios201JSONResponseBodyParametersDefaultValue0
@@ -50990,6 +54039,94 @@ func (t PostApiScenarios201JSONResponseBody_Parameters_Options_Item) MarshalJSON
 }
 
 func (t *PostApiScenarios201JSONResponseBody_Parameters_Options_Item) UnmarshalJSON(b []byte) error {
+	err := t.union.UnmarshalJSON(b)
+	return err
+}
+
+// AsGetApiScenariosById200JSONResponseBodyFields0 returns the union data inside the GetApiScenariosById200JSONResponseBody_Fields_AdditionalProperties as a GetApiScenariosById200JSONResponseBodyFields0
+func (t GetApiScenariosById200JSONResponseBody_Fields_AdditionalProperties) AsGetApiScenariosById200JSONResponseBodyFields0() (GetApiScenariosById200JSONResponseBodyFields0, error) {
+	var body GetApiScenariosById200JSONResponseBodyFields0
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromGetApiScenariosById200JSONResponseBodyFields0 overwrites any union data inside the GetApiScenariosById200JSONResponseBody_Fields_AdditionalProperties as the provided GetApiScenariosById200JSONResponseBodyFields0
+func (t *GetApiScenariosById200JSONResponseBody_Fields_AdditionalProperties) FromGetApiScenariosById200JSONResponseBodyFields0(v GetApiScenariosById200JSONResponseBodyFields0) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeGetApiScenariosById200JSONResponseBodyFields0 performs a merge with any union data inside the GetApiScenariosById200JSONResponseBody_Fields_AdditionalProperties, using the provided GetApiScenariosById200JSONResponseBodyFields0
+func (t *GetApiScenariosById200JSONResponseBody_Fields_AdditionalProperties) MergeGetApiScenariosById200JSONResponseBodyFields0(v GetApiScenariosById200JSONResponseBodyFields0) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsGetApiScenariosById200JSONResponseBodyFields1 returns the union data inside the GetApiScenariosById200JSONResponseBody_Fields_AdditionalProperties as a GetApiScenariosById200JSONResponseBodyFields1
+func (t GetApiScenariosById200JSONResponseBody_Fields_AdditionalProperties) AsGetApiScenariosById200JSONResponseBodyFields1() (GetApiScenariosById200JSONResponseBodyFields1, error) {
+	var body GetApiScenariosById200JSONResponseBodyFields1
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromGetApiScenariosById200JSONResponseBodyFields1 overwrites any union data inside the GetApiScenariosById200JSONResponseBody_Fields_AdditionalProperties as the provided GetApiScenariosById200JSONResponseBodyFields1
+func (t *GetApiScenariosById200JSONResponseBody_Fields_AdditionalProperties) FromGetApiScenariosById200JSONResponseBodyFields1(v GetApiScenariosById200JSONResponseBodyFields1) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeGetApiScenariosById200JSONResponseBodyFields1 performs a merge with any union data inside the GetApiScenariosById200JSONResponseBody_Fields_AdditionalProperties, using the provided GetApiScenariosById200JSONResponseBodyFields1
+func (t *GetApiScenariosById200JSONResponseBody_Fields_AdditionalProperties) MergeGetApiScenariosById200JSONResponseBodyFields1(v GetApiScenariosById200JSONResponseBodyFields1) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsGetApiScenariosById200JSONResponseBodyFields2 returns the union data inside the GetApiScenariosById200JSONResponseBody_Fields_AdditionalProperties as a GetApiScenariosById200JSONResponseBodyFields2
+func (t GetApiScenariosById200JSONResponseBody_Fields_AdditionalProperties) AsGetApiScenariosById200JSONResponseBodyFields2() (GetApiScenariosById200JSONResponseBodyFields2, error) {
+	var body GetApiScenariosById200JSONResponseBodyFields2
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromGetApiScenariosById200JSONResponseBodyFields2 overwrites any union data inside the GetApiScenariosById200JSONResponseBody_Fields_AdditionalProperties as the provided GetApiScenariosById200JSONResponseBodyFields2
+func (t *GetApiScenariosById200JSONResponseBody_Fields_AdditionalProperties) FromGetApiScenariosById200JSONResponseBodyFields2(v GetApiScenariosById200JSONResponseBodyFields2) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeGetApiScenariosById200JSONResponseBodyFields2 performs a merge with any union data inside the GetApiScenariosById200JSONResponseBody_Fields_AdditionalProperties, using the provided GetApiScenariosById200JSONResponseBodyFields2
+func (t *GetApiScenariosById200JSONResponseBody_Fields_AdditionalProperties) MergeGetApiScenariosById200JSONResponseBodyFields2(v GetApiScenariosById200JSONResponseBodyFields2) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+func (t GetApiScenariosById200JSONResponseBody_Fields_AdditionalProperties) MarshalJSON() ([]byte, error) {
+	b, err := t.union.MarshalJSON()
+	return b, err
+}
+
+func (t *GetApiScenariosById200JSONResponseBody_Fields_AdditionalProperties) UnmarshalJSON(b []byte) error {
 	err := t.union.UnmarshalJSON(b)
 	return err
 }
@@ -51170,6 +54307,94 @@ func (t *GetApiScenariosById200JSONResponseBody_Parameters_Options_Item) Unmarsh
 	return err
 }
 
+// AsPatchApiScenariosByIdJSONBodyFields0 returns the union data inside the PatchApiScenariosByIdJSONBody_Fields_AdditionalProperties as a PatchApiScenariosByIdJSONBodyFields0
+func (t PatchApiScenariosByIdJSONBody_Fields_AdditionalProperties) AsPatchApiScenariosByIdJSONBodyFields0() (PatchApiScenariosByIdJSONBodyFields0, error) {
+	var body PatchApiScenariosByIdJSONBodyFields0
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromPatchApiScenariosByIdJSONBodyFields0 overwrites any union data inside the PatchApiScenariosByIdJSONBody_Fields_AdditionalProperties as the provided PatchApiScenariosByIdJSONBodyFields0
+func (t *PatchApiScenariosByIdJSONBody_Fields_AdditionalProperties) FromPatchApiScenariosByIdJSONBodyFields0(v PatchApiScenariosByIdJSONBodyFields0) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergePatchApiScenariosByIdJSONBodyFields0 performs a merge with any union data inside the PatchApiScenariosByIdJSONBody_Fields_AdditionalProperties, using the provided PatchApiScenariosByIdJSONBodyFields0
+func (t *PatchApiScenariosByIdJSONBody_Fields_AdditionalProperties) MergePatchApiScenariosByIdJSONBodyFields0(v PatchApiScenariosByIdJSONBodyFields0) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsPatchApiScenariosByIdJSONBodyFields1 returns the union data inside the PatchApiScenariosByIdJSONBody_Fields_AdditionalProperties as a PatchApiScenariosByIdJSONBodyFields1
+func (t PatchApiScenariosByIdJSONBody_Fields_AdditionalProperties) AsPatchApiScenariosByIdJSONBodyFields1() (PatchApiScenariosByIdJSONBodyFields1, error) {
+	var body PatchApiScenariosByIdJSONBodyFields1
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromPatchApiScenariosByIdJSONBodyFields1 overwrites any union data inside the PatchApiScenariosByIdJSONBody_Fields_AdditionalProperties as the provided PatchApiScenariosByIdJSONBodyFields1
+func (t *PatchApiScenariosByIdJSONBody_Fields_AdditionalProperties) FromPatchApiScenariosByIdJSONBodyFields1(v PatchApiScenariosByIdJSONBodyFields1) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergePatchApiScenariosByIdJSONBodyFields1 performs a merge with any union data inside the PatchApiScenariosByIdJSONBody_Fields_AdditionalProperties, using the provided PatchApiScenariosByIdJSONBodyFields1
+func (t *PatchApiScenariosByIdJSONBody_Fields_AdditionalProperties) MergePatchApiScenariosByIdJSONBodyFields1(v PatchApiScenariosByIdJSONBodyFields1) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsPatchApiScenariosByIdJSONBodyFields2 returns the union data inside the PatchApiScenariosByIdJSONBody_Fields_AdditionalProperties as a PatchApiScenariosByIdJSONBodyFields2
+func (t PatchApiScenariosByIdJSONBody_Fields_AdditionalProperties) AsPatchApiScenariosByIdJSONBodyFields2() (PatchApiScenariosByIdJSONBodyFields2, error) {
+	var body PatchApiScenariosByIdJSONBodyFields2
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromPatchApiScenariosByIdJSONBodyFields2 overwrites any union data inside the PatchApiScenariosByIdJSONBody_Fields_AdditionalProperties as the provided PatchApiScenariosByIdJSONBodyFields2
+func (t *PatchApiScenariosByIdJSONBody_Fields_AdditionalProperties) FromPatchApiScenariosByIdJSONBodyFields2(v PatchApiScenariosByIdJSONBodyFields2) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergePatchApiScenariosByIdJSONBodyFields2 performs a merge with any union data inside the PatchApiScenariosByIdJSONBody_Fields_AdditionalProperties, using the provided PatchApiScenariosByIdJSONBodyFields2
+func (t *PatchApiScenariosByIdJSONBody_Fields_AdditionalProperties) MergePatchApiScenariosByIdJSONBodyFields2(v PatchApiScenariosByIdJSONBodyFields2) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+func (t PatchApiScenariosByIdJSONBody_Fields_AdditionalProperties) MarshalJSON() ([]byte, error) {
+	b, err := t.union.MarshalJSON()
+	return b, err
+}
+
+func (t *PatchApiScenariosByIdJSONBody_Fields_AdditionalProperties) UnmarshalJSON(b []byte) error {
+	err := t.union.UnmarshalJSON(b)
+	return err
+}
+
 // AsPatchApiScenariosByIdJSONBodyParametersDefaultValue0 returns the union data inside the PatchApiScenariosByIdJSONBody_Parameters_DefaultValue as a PatchApiScenariosByIdJSONBodyParametersDefaultValue0
 func (t PatchApiScenariosByIdJSONBody_Parameters_DefaultValue) AsPatchApiScenariosByIdJSONBodyParametersDefaultValue0() (PatchApiScenariosByIdJSONBodyParametersDefaultValue0, error) {
 	var body PatchApiScenariosByIdJSONBodyParametersDefaultValue0
@@ -51342,6 +54567,94 @@ func (t PatchApiScenariosByIdJSONBody_Parameters_Options_Item) MarshalJSON() ([]
 }
 
 func (t *PatchApiScenariosByIdJSONBody_Parameters_Options_Item) UnmarshalJSON(b []byte) error {
+	err := t.union.UnmarshalJSON(b)
+	return err
+}
+
+// AsPatchApiScenariosById200JSONResponseBodyFields0 returns the union data inside the PatchApiScenariosById200JSONResponseBody_Fields_AdditionalProperties as a PatchApiScenariosById200JSONResponseBodyFields0
+func (t PatchApiScenariosById200JSONResponseBody_Fields_AdditionalProperties) AsPatchApiScenariosById200JSONResponseBodyFields0() (PatchApiScenariosById200JSONResponseBodyFields0, error) {
+	var body PatchApiScenariosById200JSONResponseBodyFields0
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromPatchApiScenariosById200JSONResponseBodyFields0 overwrites any union data inside the PatchApiScenariosById200JSONResponseBody_Fields_AdditionalProperties as the provided PatchApiScenariosById200JSONResponseBodyFields0
+func (t *PatchApiScenariosById200JSONResponseBody_Fields_AdditionalProperties) FromPatchApiScenariosById200JSONResponseBodyFields0(v PatchApiScenariosById200JSONResponseBodyFields0) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergePatchApiScenariosById200JSONResponseBodyFields0 performs a merge with any union data inside the PatchApiScenariosById200JSONResponseBody_Fields_AdditionalProperties, using the provided PatchApiScenariosById200JSONResponseBodyFields0
+func (t *PatchApiScenariosById200JSONResponseBody_Fields_AdditionalProperties) MergePatchApiScenariosById200JSONResponseBodyFields0(v PatchApiScenariosById200JSONResponseBodyFields0) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsPatchApiScenariosById200JSONResponseBodyFields1 returns the union data inside the PatchApiScenariosById200JSONResponseBody_Fields_AdditionalProperties as a PatchApiScenariosById200JSONResponseBodyFields1
+func (t PatchApiScenariosById200JSONResponseBody_Fields_AdditionalProperties) AsPatchApiScenariosById200JSONResponseBodyFields1() (PatchApiScenariosById200JSONResponseBodyFields1, error) {
+	var body PatchApiScenariosById200JSONResponseBodyFields1
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromPatchApiScenariosById200JSONResponseBodyFields1 overwrites any union data inside the PatchApiScenariosById200JSONResponseBody_Fields_AdditionalProperties as the provided PatchApiScenariosById200JSONResponseBodyFields1
+func (t *PatchApiScenariosById200JSONResponseBody_Fields_AdditionalProperties) FromPatchApiScenariosById200JSONResponseBodyFields1(v PatchApiScenariosById200JSONResponseBodyFields1) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergePatchApiScenariosById200JSONResponseBodyFields1 performs a merge with any union data inside the PatchApiScenariosById200JSONResponseBody_Fields_AdditionalProperties, using the provided PatchApiScenariosById200JSONResponseBodyFields1
+func (t *PatchApiScenariosById200JSONResponseBody_Fields_AdditionalProperties) MergePatchApiScenariosById200JSONResponseBodyFields1(v PatchApiScenariosById200JSONResponseBodyFields1) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsPatchApiScenariosById200JSONResponseBodyFields2 returns the union data inside the PatchApiScenariosById200JSONResponseBody_Fields_AdditionalProperties as a PatchApiScenariosById200JSONResponseBodyFields2
+func (t PatchApiScenariosById200JSONResponseBody_Fields_AdditionalProperties) AsPatchApiScenariosById200JSONResponseBodyFields2() (PatchApiScenariosById200JSONResponseBodyFields2, error) {
+	var body PatchApiScenariosById200JSONResponseBodyFields2
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromPatchApiScenariosById200JSONResponseBodyFields2 overwrites any union data inside the PatchApiScenariosById200JSONResponseBody_Fields_AdditionalProperties as the provided PatchApiScenariosById200JSONResponseBodyFields2
+func (t *PatchApiScenariosById200JSONResponseBody_Fields_AdditionalProperties) FromPatchApiScenariosById200JSONResponseBodyFields2(v PatchApiScenariosById200JSONResponseBodyFields2) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergePatchApiScenariosById200JSONResponseBodyFields2 performs a merge with any union data inside the PatchApiScenariosById200JSONResponseBody_Fields_AdditionalProperties, using the provided PatchApiScenariosById200JSONResponseBodyFields2
+func (t *PatchApiScenariosById200JSONResponseBody_Fields_AdditionalProperties) MergePatchApiScenariosById200JSONResponseBodyFields2(v PatchApiScenariosById200JSONResponseBodyFields2) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+func (t PatchApiScenariosById200JSONResponseBody_Fields_AdditionalProperties) MarshalJSON() ([]byte, error) {
+	b, err := t.union.MarshalJSON()
+	return b, err
+}
+
+func (t *PatchApiScenariosById200JSONResponseBody_Fields_AdditionalProperties) UnmarshalJSON(b []byte) error {
 	err := t.union.UnmarshalJSON(b)
 	return err
 }
@@ -51522,6 +54835,94 @@ func (t *PatchApiScenariosById200JSONResponseBody_Parameters_Options_Item) Unmar
 	return err
 }
 
+// AsPutApiScenariosByIdJSONBodyFields0 returns the union data inside the PutApiScenariosByIdJSONBody_Fields_AdditionalProperties as a PutApiScenariosByIdJSONBodyFields0
+func (t PutApiScenariosByIdJSONBody_Fields_AdditionalProperties) AsPutApiScenariosByIdJSONBodyFields0() (PutApiScenariosByIdJSONBodyFields0, error) {
+	var body PutApiScenariosByIdJSONBodyFields0
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromPutApiScenariosByIdJSONBodyFields0 overwrites any union data inside the PutApiScenariosByIdJSONBody_Fields_AdditionalProperties as the provided PutApiScenariosByIdJSONBodyFields0
+func (t *PutApiScenariosByIdJSONBody_Fields_AdditionalProperties) FromPutApiScenariosByIdJSONBodyFields0(v PutApiScenariosByIdJSONBodyFields0) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergePutApiScenariosByIdJSONBodyFields0 performs a merge with any union data inside the PutApiScenariosByIdJSONBody_Fields_AdditionalProperties, using the provided PutApiScenariosByIdJSONBodyFields0
+func (t *PutApiScenariosByIdJSONBody_Fields_AdditionalProperties) MergePutApiScenariosByIdJSONBodyFields0(v PutApiScenariosByIdJSONBodyFields0) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsPutApiScenariosByIdJSONBodyFields1 returns the union data inside the PutApiScenariosByIdJSONBody_Fields_AdditionalProperties as a PutApiScenariosByIdJSONBodyFields1
+func (t PutApiScenariosByIdJSONBody_Fields_AdditionalProperties) AsPutApiScenariosByIdJSONBodyFields1() (PutApiScenariosByIdJSONBodyFields1, error) {
+	var body PutApiScenariosByIdJSONBodyFields1
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromPutApiScenariosByIdJSONBodyFields1 overwrites any union data inside the PutApiScenariosByIdJSONBody_Fields_AdditionalProperties as the provided PutApiScenariosByIdJSONBodyFields1
+func (t *PutApiScenariosByIdJSONBody_Fields_AdditionalProperties) FromPutApiScenariosByIdJSONBodyFields1(v PutApiScenariosByIdJSONBodyFields1) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergePutApiScenariosByIdJSONBodyFields1 performs a merge with any union data inside the PutApiScenariosByIdJSONBody_Fields_AdditionalProperties, using the provided PutApiScenariosByIdJSONBodyFields1
+func (t *PutApiScenariosByIdJSONBody_Fields_AdditionalProperties) MergePutApiScenariosByIdJSONBodyFields1(v PutApiScenariosByIdJSONBodyFields1) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsPutApiScenariosByIdJSONBodyFields2 returns the union data inside the PutApiScenariosByIdJSONBody_Fields_AdditionalProperties as a PutApiScenariosByIdJSONBodyFields2
+func (t PutApiScenariosByIdJSONBody_Fields_AdditionalProperties) AsPutApiScenariosByIdJSONBodyFields2() (PutApiScenariosByIdJSONBodyFields2, error) {
+	var body PutApiScenariosByIdJSONBodyFields2
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromPutApiScenariosByIdJSONBodyFields2 overwrites any union data inside the PutApiScenariosByIdJSONBody_Fields_AdditionalProperties as the provided PutApiScenariosByIdJSONBodyFields2
+func (t *PutApiScenariosByIdJSONBody_Fields_AdditionalProperties) FromPutApiScenariosByIdJSONBodyFields2(v PutApiScenariosByIdJSONBodyFields2) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergePutApiScenariosByIdJSONBodyFields2 performs a merge with any union data inside the PutApiScenariosByIdJSONBody_Fields_AdditionalProperties, using the provided PutApiScenariosByIdJSONBodyFields2
+func (t *PutApiScenariosByIdJSONBody_Fields_AdditionalProperties) MergePutApiScenariosByIdJSONBodyFields2(v PutApiScenariosByIdJSONBodyFields2) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+func (t PutApiScenariosByIdJSONBody_Fields_AdditionalProperties) MarshalJSON() ([]byte, error) {
+	b, err := t.union.MarshalJSON()
+	return b, err
+}
+
+func (t *PutApiScenariosByIdJSONBody_Fields_AdditionalProperties) UnmarshalJSON(b []byte) error {
+	err := t.union.UnmarshalJSON(b)
+	return err
+}
+
 // AsPutApiScenariosByIdJSONBodyParametersDefaultValue0 returns the union data inside the PutApiScenariosByIdJSONBody_Parameters_DefaultValue as a PutApiScenariosByIdJSONBodyParametersDefaultValue0
 func (t PutApiScenariosByIdJSONBody_Parameters_DefaultValue) AsPutApiScenariosByIdJSONBodyParametersDefaultValue0() (PutApiScenariosByIdJSONBodyParametersDefaultValue0, error) {
 	var body PutApiScenariosByIdJSONBodyParametersDefaultValue0
@@ -51698,6 +55099,94 @@ func (t *PutApiScenariosByIdJSONBody_Parameters_Options_Item) UnmarshalJSON(b []
 	return err
 }
 
+// AsPutApiScenariosById200JSONResponseBodyFields0 returns the union data inside the PutApiScenariosById200JSONResponseBody_Fields_AdditionalProperties as a PutApiScenariosById200JSONResponseBodyFields0
+func (t PutApiScenariosById200JSONResponseBody_Fields_AdditionalProperties) AsPutApiScenariosById200JSONResponseBodyFields0() (PutApiScenariosById200JSONResponseBodyFields0, error) {
+	var body PutApiScenariosById200JSONResponseBodyFields0
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromPutApiScenariosById200JSONResponseBodyFields0 overwrites any union data inside the PutApiScenariosById200JSONResponseBody_Fields_AdditionalProperties as the provided PutApiScenariosById200JSONResponseBodyFields0
+func (t *PutApiScenariosById200JSONResponseBody_Fields_AdditionalProperties) FromPutApiScenariosById200JSONResponseBodyFields0(v PutApiScenariosById200JSONResponseBodyFields0) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergePutApiScenariosById200JSONResponseBodyFields0 performs a merge with any union data inside the PutApiScenariosById200JSONResponseBody_Fields_AdditionalProperties, using the provided PutApiScenariosById200JSONResponseBodyFields0
+func (t *PutApiScenariosById200JSONResponseBody_Fields_AdditionalProperties) MergePutApiScenariosById200JSONResponseBodyFields0(v PutApiScenariosById200JSONResponseBodyFields0) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsPutApiScenariosById200JSONResponseBodyFields1 returns the union data inside the PutApiScenariosById200JSONResponseBody_Fields_AdditionalProperties as a PutApiScenariosById200JSONResponseBodyFields1
+func (t PutApiScenariosById200JSONResponseBody_Fields_AdditionalProperties) AsPutApiScenariosById200JSONResponseBodyFields1() (PutApiScenariosById200JSONResponseBodyFields1, error) {
+	var body PutApiScenariosById200JSONResponseBodyFields1
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromPutApiScenariosById200JSONResponseBodyFields1 overwrites any union data inside the PutApiScenariosById200JSONResponseBody_Fields_AdditionalProperties as the provided PutApiScenariosById200JSONResponseBodyFields1
+func (t *PutApiScenariosById200JSONResponseBody_Fields_AdditionalProperties) FromPutApiScenariosById200JSONResponseBodyFields1(v PutApiScenariosById200JSONResponseBodyFields1) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergePutApiScenariosById200JSONResponseBodyFields1 performs a merge with any union data inside the PutApiScenariosById200JSONResponseBody_Fields_AdditionalProperties, using the provided PutApiScenariosById200JSONResponseBodyFields1
+func (t *PutApiScenariosById200JSONResponseBody_Fields_AdditionalProperties) MergePutApiScenariosById200JSONResponseBodyFields1(v PutApiScenariosById200JSONResponseBodyFields1) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsPutApiScenariosById200JSONResponseBodyFields2 returns the union data inside the PutApiScenariosById200JSONResponseBody_Fields_AdditionalProperties as a PutApiScenariosById200JSONResponseBodyFields2
+func (t PutApiScenariosById200JSONResponseBody_Fields_AdditionalProperties) AsPutApiScenariosById200JSONResponseBodyFields2() (PutApiScenariosById200JSONResponseBodyFields2, error) {
+	var body PutApiScenariosById200JSONResponseBodyFields2
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromPutApiScenariosById200JSONResponseBodyFields2 overwrites any union data inside the PutApiScenariosById200JSONResponseBody_Fields_AdditionalProperties as the provided PutApiScenariosById200JSONResponseBodyFields2
+func (t *PutApiScenariosById200JSONResponseBody_Fields_AdditionalProperties) FromPutApiScenariosById200JSONResponseBodyFields2(v PutApiScenariosById200JSONResponseBodyFields2) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergePutApiScenariosById200JSONResponseBodyFields2 performs a merge with any union data inside the PutApiScenariosById200JSONResponseBody_Fields_AdditionalProperties, using the provided PutApiScenariosById200JSONResponseBodyFields2
+func (t *PutApiScenariosById200JSONResponseBody_Fields_AdditionalProperties) MergePutApiScenariosById200JSONResponseBodyFields2(v PutApiScenariosById200JSONResponseBodyFields2) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+func (t PutApiScenariosById200JSONResponseBody_Fields_AdditionalProperties) MarshalJSON() ([]byte, error) {
+	b, err := t.union.MarshalJSON()
+	return b, err
+}
+
+func (t *PutApiScenariosById200JSONResponseBody_Fields_AdditionalProperties) UnmarshalJSON(b []byte) error {
+	err := t.union.UnmarshalJSON(b)
+	return err
+}
+
 // AsPutApiScenariosById200JSONResponseBodyParametersDefaultValue0 returns the union data inside the PutApiScenariosById200JSONResponseBody_Parameters_DefaultValue as a PutApiScenariosById200JSONResponseBodyParametersDefaultValue0
 func (t PutApiScenariosById200JSONResponseBody_Parameters_DefaultValue) AsPutApiScenariosById200JSONResponseBodyParametersDefaultValue0() (PutApiScenariosById200JSONResponseBodyParametersDefaultValue0, error) {
 	var body PutApiScenariosById200JSONResponseBodyParametersDefaultValue0
@@ -51870,6 +55359,94 @@ func (t PutApiScenariosById200JSONResponseBody_Parameters_Options_Item) MarshalJ
 }
 
 func (t *PutApiScenariosById200JSONResponseBody_Parameters_Options_Item) UnmarshalJSON(b []byte) error {
+	err := t.union.UnmarshalJSON(b)
+	return err
+}
+
+// AsGetApiScenariosByIdVersionsByVersion200JSONResponseBodySnapshotFields0 returns the union data inside the GetApiScenariosByIdVersionsByVersion200JSONResponseBody_Snapshot_Fields_AdditionalProperties as a GetApiScenariosByIdVersionsByVersion200JSONResponseBodySnapshotFields0
+func (t GetApiScenariosByIdVersionsByVersion200JSONResponseBody_Snapshot_Fields_AdditionalProperties) AsGetApiScenariosByIdVersionsByVersion200JSONResponseBodySnapshotFields0() (GetApiScenariosByIdVersionsByVersion200JSONResponseBodySnapshotFields0, error) {
+	var body GetApiScenariosByIdVersionsByVersion200JSONResponseBodySnapshotFields0
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromGetApiScenariosByIdVersionsByVersion200JSONResponseBodySnapshotFields0 overwrites any union data inside the GetApiScenariosByIdVersionsByVersion200JSONResponseBody_Snapshot_Fields_AdditionalProperties as the provided GetApiScenariosByIdVersionsByVersion200JSONResponseBodySnapshotFields0
+func (t *GetApiScenariosByIdVersionsByVersion200JSONResponseBody_Snapshot_Fields_AdditionalProperties) FromGetApiScenariosByIdVersionsByVersion200JSONResponseBodySnapshotFields0(v GetApiScenariosByIdVersionsByVersion200JSONResponseBodySnapshotFields0) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeGetApiScenariosByIdVersionsByVersion200JSONResponseBodySnapshotFields0 performs a merge with any union data inside the GetApiScenariosByIdVersionsByVersion200JSONResponseBody_Snapshot_Fields_AdditionalProperties, using the provided GetApiScenariosByIdVersionsByVersion200JSONResponseBodySnapshotFields0
+func (t *GetApiScenariosByIdVersionsByVersion200JSONResponseBody_Snapshot_Fields_AdditionalProperties) MergeGetApiScenariosByIdVersionsByVersion200JSONResponseBodySnapshotFields0(v GetApiScenariosByIdVersionsByVersion200JSONResponseBodySnapshotFields0) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsGetApiScenariosByIdVersionsByVersion200JSONResponseBodySnapshotFields1 returns the union data inside the GetApiScenariosByIdVersionsByVersion200JSONResponseBody_Snapshot_Fields_AdditionalProperties as a GetApiScenariosByIdVersionsByVersion200JSONResponseBodySnapshotFields1
+func (t GetApiScenariosByIdVersionsByVersion200JSONResponseBody_Snapshot_Fields_AdditionalProperties) AsGetApiScenariosByIdVersionsByVersion200JSONResponseBodySnapshotFields1() (GetApiScenariosByIdVersionsByVersion200JSONResponseBodySnapshotFields1, error) {
+	var body GetApiScenariosByIdVersionsByVersion200JSONResponseBodySnapshotFields1
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromGetApiScenariosByIdVersionsByVersion200JSONResponseBodySnapshotFields1 overwrites any union data inside the GetApiScenariosByIdVersionsByVersion200JSONResponseBody_Snapshot_Fields_AdditionalProperties as the provided GetApiScenariosByIdVersionsByVersion200JSONResponseBodySnapshotFields1
+func (t *GetApiScenariosByIdVersionsByVersion200JSONResponseBody_Snapshot_Fields_AdditionalProperties) FromGetApiScenariosByIdVersionsByVersion200JSONResponseBodySnapshotFields1(v GetApiScenariosByIdVersionsByVersion200JSONResponseBodySnapshotFields1) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeGetApiScenariosByIdVersionsByVersion200JSONResponseBodySnapshotFields1 performs a merge with any union data inside the GetApiScenariosByIdVersionsByVersion200JSONResponseBody_Snapshot_Fields_AdditionalProperties, using the provided GetApiScenariosByIdVersionsByVersion200JSONResponseBodySnapshotFields1
+func (t *GetApiScenariosByIdVersionsByVersion200JSONResponseBody_Snapshot_Fields_AdditionalProperties) MergeGetApiScenariosByIdVersionsByVersion200JSONResponseBodySnapshotFields1(v GetApiScenariosByIdVersionsByVersion200JSONResponseBodySnapshotFields1) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsGetApiScenariosByIdVersionsByVersion200JSONResponseBodySnapshotFields2 returns the union data inside the GetApiScenariosByIdVersionsByVersion200JSONResponseBody_Snapshot_Fields_AdditionalProperties as a GetApiScenariosByIdVersionsByVersion200JSONResponseBodySnapshotFields2
+func (t GetApiScenariosByIdVersionsByVersion200JSONResponseBody_Snapshot_Fields_AdditionalProperties) AsGetApiScenariosByIdVersionsByVersion200JSONResponseBodySnapshotFields2() (GetApiScenariosByIdVersionsByVersion200JSONResponseBodySnapshotFields2, error) {
+	var body GetApiScenariosByIdVersionsByVersion200JSONResponseBodySnapshotFields2
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromGetApiScenariosByIdVersionsByVersion200JSONResponseBodySnapshotFields2 overwrites any union data inside the GetApiScenariosByIdVersionsByVersion200JSONResponseBody_Snapshot_Fields_AdditionalProperties as the provided GetApiScenariosByIdVersionsByVersion200JSONResponseBodySnapshotFields2
+func (t *GetApiScenariosByIdVersionsByVersion200JSONResponseBody_Snapshot_Fields_AdditionalProperties) FromGetApiScenariosByIdVersionsByVersion200JSONResponseBodySnapshotFields2(v GetApiScenariosByIdVersionsByVersion200JSONResponseBodySnapshotFields2) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeGetApiScenariosByIdVersionsByVersion200JSONResponseBodySnapshotFields2 performs a merge with any union data inside the GetApiScenariosByIdVersionsByVersion200JSONResponseBody_Snapshot_Fields_AdditionalProperties, using the provided GetApiScenariosByIdVersionsByVersion200JSONResponseBodySnapshotFields2
+func (t *GetApiScenariosByIdVersionsByVersion200JSONResponseBody_Snapshot_Fields_AdditionalProperties) MergeGetApiScenariosByIdVersionsByVersion200JSONResponseBodySnapshotFields2(v GetApiScenariosByIdVersionsByVersion200JSONResponseBodySnapshotFields2) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+func (t GetApiScenariosByIdVersionsByVersion200JSONResponseBody_Snapshot_Fields_AdditionalProperties) MarshalJSON() ([]byte, error) {
+	b, err := t.union.MarshalJSON()
+	return b, err
+}
+
+func (t *GetApiScenariosByIdVersionsByVersion200JSONResponseBody_Snapshot_Fields_AdditionalProperties) UnmarshalJSON(b []byte) error {
 	err := t.union.UnmarshalJSON(b)
 	return err
 }
@@ -60364,22 +63941,22 @@ func (t *CallConnectedAgent200JSONResponseBody_Output) UnmarshalJSON(b []byte) e
 	return err
 }
 
-// AsPostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyGranularitySeconds0 returns the union data inside the PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_GranularitySeconds as a PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyGranularitySeconds0
-func (t PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_GranularitySeconds) AsPostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyGranularitySeconds0() (PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyGranularitySeconds0, error) {
-	var body PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyGranularitySeconds0
+// AsPostLangyControlFramesJSONBodyFrames0 returns the union data inside the PostLangyControlFramesJSONBody_Frames_Item as a PostLangyControlFramesJSONBodyFrames0
+func (t PostLangyControlFramesJSONBody_Frames_Item) AsPostLangyControlFramesJSONBodyFrames0() (PostLangyControlFramesJSONBodyFrames0, error) {
+	var body PostLangyControlFramesJSONBodyFrames0
 	err := json.Unmarshal(t.union, &body)
 	return body, err
 }
 
-// FromPostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyGranularitySeconds0 overwrites any union data inside the PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_GranularitySeconds as the provided PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyGranularitySeconds0
-func (t *PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_GranularitySeconds) FromPostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyGranularitySeconds0(v PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyGranularitySeconds0) error {
+// FromPostLangyControlFramesJSONBodyFrames0 overwrites any union data inside the PostLangyControlFramesJSONBody_Frames_Item as the provided PostLangyControlFramesJSONBodyFrames0
+func (t *PostLangyControlFramesJSONBody_Frames_Item) FromPostLangyControlFramesJSONBodyFrames0(v PostLangyControlFramesJSONBodyFrames0) error {
 	b, err := json.Marshal(v)
 	t.union = b
 	return err
 }
 
-// MergePostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyGranularitySeconds0 performs a merge with any union data inside the PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_GranularitySeconds, using the provided PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyGranularitySeconds0
-func (t *PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_GranularitySeconds) MergePostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyGranularitySeconds0(v PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyGranularitySeconds0) error {
+// MergePostLangyControlFramesJSONBodyFrames0 performs a merge with any union data inside the PostLangyControlFramesJSONBody_Frames_Item, using the provided PostLangyControlFramesJSONBodyFrames0
+func (t *PostLangyControlFramesJSONBody_Frames_Item) MergePostLangyControlFramesJSONBodyFrames0(v PostLangyControlFramesJSONBodyFrames0) error {
 	b, err := json.Marshal(v)
 	if err != nil {
 		return err
@@ -60390,22 +63967,22 @@ func (t *PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_Granularit
 	return err
 }
 
-// AsPostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyGranularitySeconds1 returns the union data inside the PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_GranularitySeconds as a PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyGranularitySeconds1
-func (t PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_GranularitySeconds) AsPostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyGranularitySeconds1() (PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyGranularitySeconds1, error) {
-	var body PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyGranularitySeconds1
+// AsPostLangyControlFramesJSONBodyFrames1 returns the union data inside the PostLangyControlFramesJSONBody_Frames_Item as a PostLangyControlFramesJSONBodyFrames1
+func (t PostLangyControlFramesJSONBody_Frames_Item) AsPostLangyControlFramesJSONBodyFrames1() (PostLangyControlFramesJSONBodyFrames1, error) {
+	var body PostLangyControlFramesJSONBodyFrames1
 	err := json.Unmarshal(t.union, &body)
 	return body, err
 }
 
-// FromPostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyGranularitySeconds1 overwrites any union data inside the PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_GranularitySeconds as the provided PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyGranularitySeconds1
-func (t *PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_GranularitySeconds) FromPostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyGranularitySeconds1(v PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyGranularitySeconds1) error {
+// FromPostLangyControlFramesJSONBodyFrames1 overwrites any union data inside the PostLangyControlFramesJSONBody_Frames_Item as the provided PostLangyControlFramesJSONBodyFrames1
+func (t *PostLangyControlFramesJSONBody_Frames_Item) FromPostLangyControlFramesJSONBodyFrames1(v PostLangyControlFramesJSONBodyFrames1) error {
 	b, err := json.Marshal(v)
 	t.union = b
 	return err
 }
 
-// MergePostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyGranularitySeconds1 performs a merge with any union data inside the PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_GranularitySeconds, using the provided PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyGranularitySeconds1
-func (t *PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_GranularitySeconds) MergePostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyGranularitySeconds1(v PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyGranularitySeconds1) error {
+// MergePostLangyControlFramesJSONBodyFrames1 performs a merge with any union data inside the PostLangyControlFramesJSONBody_Frames_Item, using the provided PostLangyControlFramesJSONBodyFrames1
+func (t *PostLangyControlFramesJSONBody_Frames_Item) MergePostLangyControlFramesJSONBodyFrames1(v PostLangyControlFramesJSONBodyFrames1) error {
 	b, err := json.Marshal(v)
 	if err != nil {
 		return err
@@ -60416,22 +63993,22 @@ func (t *PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_Granularit
 	return err
 }
 
-// AsPostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyGranularitySeconds2 returns the union data inside the PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_GranularitySeconds as a PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyGranularitySeconds2
-func (t PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_GranularitySeconds) AsPostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyGranularitySeconds2() (PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyGranularitySeconds2, error) {
-	var body PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyGranularitySeconds2
+// AsPostLangyControlFramesJSONBodyFrames2 returns the union data inside the PostLangyControlFramesJSONBody_Frames_Item as a PostLangyControlFramesJSONBodyFrames2
+func (t PostLangyControlFramesJSONBody_Frames_Item) AsPostLangyControlFramesJSONBodyFrames2() (PostLangyControlFramesJSONBodyFrames2, error) {
+	var body PostLangyControlFramesJSONBodyFrames2
 	err := json.Unmarshal(t.union, &body)
 	return body, err
 }
 
-// FromPostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyGranularitySeconds2 overwrites any union data inside the PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_GranularitySeconds as the provided PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyGranularitySeconds2
-func (t *PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_GranularitySeconds) FromPostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyGranularitySeconds2(v PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyGranularitySeconds2) error {
+// FromPostLangyControlFramesJSONBodyFrames2 overwrites any union data inside the PostLangyControlFramesJSONBody_Frames_Item as the provided PostLangyControlFramesJSONBodyFrames2
+func (t *PostLangyControlFramesJSONBody_Frames_Item) FromPostLangyControlFramesJSONBodyFrames2(v PostLangyControlFramesJSONBodyFrames2) error {
 	b, err := json.Marshal(v)
 	t.union = b
 	return err
 }
 
-// MergePostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyGranularitySeconds2 performs a merge with any union data inside the PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_GranularitySeconds, using the provided PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyGranularitySeconds2
-func (t *PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_GranularitySeconds) MergePostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyGranularitySeconds2(v PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyGranularitySeconds2) error {
+// MergePostLangyControlFramesJSONBodyFrames2 performs a merge with any union data inside the PostLangyControlFramesJSONBody_Frames_Item, using the provided PostLangyControlFramesJSONBodyFrames2
+func (t *PostLangyControlFramesJSONBody_Frames_Item) MergePostLangyControlFramesJSONBodyFrames2(v PostLangyControlFramesJSONBodyFrames2) error {
 	b, err := json.Marshal(v)
 	if err != nil {
 		return err
@@ -60442,32 +64019,110 @@ func (t *PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_Granularit
 	return err
 }
 
-func (t PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_GranularitySeconds) MarshalJSON() ([]byte, error) {
+// AsPostLangyControlFramesJSONBodyFrames3 returns the union data inside the PostLangyControlFramesJSONBody_Frames_Item as a PostLangyControlFramesJSONBodyFrames3
+func (t PostLangyControlFramesJSONBody_Frames_Item) AsPostLangyControlFramesJSONBodyFrames3() (PostLangyControlFramesJSONBodyFrames3, error) {
+	var body PostLangyControlFramesJSONBodyFrames3
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromPostLangyControlFramesJSONBodyFrames3 overwrites any union data inside the PostLangyControlFramesJSONBody_Frames_Item as the provided PostLangyControlFramesJSONBodyFrames3
+func (t *PostLangyControlFramesJSONBody_Frames_Item) FromPostLangyControlFramesJSONBodyFrames3(v PostLangyControlFramesJSONBodyFrames3) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergePostLangyControlFramesJSONBodyFrames3 performs a merge with any union data inside the PostLangyControlFramesJSONBody_Frames_Item, using the provided PostLangyControlFramesJSONBodyFrames3
+func (t *PostLangyControlFramesJSONBody_Frames_Item) MergePostLangyControlFramesJSONBodyFrames3(v PostLangyControlFramesJSONBodyFrames3) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsPostLangyControlFramesJSONBodyFrames4 returns the union data inside the PostLangyControlFramesJSONBody_Frames_Item as a PostLangyControlFramesJSONBodyFrames4
+func (t PostLangyControlFramesJSONBody_Frames_Item) AsPostLangyControlFramesJSONBodyFrames4() (PostLangyControlFramesJSONBodyFrames4, error) {
+	var body PostLangyControlFramesJSONBodyFrames4
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromPostLangyControlFramesJSONBodyFrames4 overwrites any union data inside the PostLangyControlFramesJSONBody_Frames_Item as the provided PostLangyControlFramesJSONBodyFrames4
+func (t *PostLangyControlFramesJSONBody_Frames_Item) FromPostLangyControlFramesJSONBodyFrames4(v PostLangyControlFramesJSONBodyFrames4) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergePostLangyControlFramesJSONBodyFrames4 performs a merge with any union data inside the PostLangyControlFramesJSONBody_Frames_Item, using the provided PostLangyControlFramesJSONBodyFrames4
+func (t *PostLangyControlFramesJSONBody_Frames_Item) MergePostLangyControlFramesJSONBodyFrames4(v PostLangyControlFramesJSONBodyFrames4) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsPostLangyControlFramesJSONBodyFrames5 returns the union data inside the PostLangyControlFramesJSONBody_Frames_Item as a PostLangyControlFramesJSONBodyFrames5
+func (t PostLangyControlFramesJSONBody_Frames_Item) AsPostLangyControlFramesJSONBodyFrames5() (PostLangyControlFramesJSONBodyFrames5, error) {
+	var body PostLangyControlFramesJSONBodyFrames5
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromPostLangyControlFramesJSONBodyFrames5 overwrites any union data inside the PostLangyControlFramesJSONBody_Frames_Item as the provided PostLangyControlFramesJSONBodyFrames5
+func (t *PostLangyControlFramesJSONBody_Frames_Item) FromPostLangyControlFramesJSONBodyFrames5(v PostLangyControlFramesJSONBodyFrames5) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergePostLangyControlFramesJSONBodyFrames5 performs a merge with any union data inside the PostLangyControlFramesJSONBody_Frames_Item, using the provided PostLangyControlFramesJSONBodyFrames5
+func (t *PostLangyControlFramesJSONBody_Frames_Item) MergePostLangyControlFramesJSONBodyFrames5(v PostLangyControlFramesJSONBodyFrames5) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+func (t PostLangyControlFramesJSONBody_Frames_Item) MarshalJSON() ([]byte, error) {
 	b, err := t.union.MarshalJSON()
 	return b, err
 }
 
-func (t *PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_GranularitySeconds) UnmarshalJSON(b []byte) error {
+func (t *PostLangyControlFramesJSONBody_Frames_Item) UnmarshalJSON(b []byte) error {
 	err := t.union.UnmarshalJSON(b)
 	return err
 }
 
-// AsPostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyParameters0 returns the union data inside the PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_Parameters_AdditionalProperties as a PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyParameters0
-func (t PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_Parameters_AdditionalProperties) AsPostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyParameters0() (PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyParameters0, error) {
-	var body PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyParameters0
+// AsPollLangyControlSession200JSONResponseBodyFrames2Call0 returns the union data inside the PollLangyControlSession200JSONResponseBody_Frames_2_Call as a PollLangyControlSession200JSONResponseBodyFrames2Call0
+func (t PollLangyControlSession200JSONResponseBody_Frames_2_Call) AsPollLangyControlSession200JSONResponseBodyFrames2Call0() (PollLangyControlSession200JSONResponseBodyFrames2Call0, error) {
+	var body PollLangyControlSession200JSONResponseBodyFrames2Call0
 	err := json.Unmarshal(t.union, &body)
 	return body, err
 }
 
-// FromPostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyParameters0 overwrites any union data inside the PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_Parameters_AdditionalProperties as the provided PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyParameters0
-func (t *PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_Parameters_AdditionalProperties) FromPostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyParameters0(v PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyParameters0) error {
+// FromPollLangyControlSession200JSONResponseBodyFrames2Call0 overwrites any union data inside the PollLangyControlSession200JSONResponseBody_Frames_2_Call as the provided PollLangyControlSession200JSONResponseBodyFrames2Call0
+func (t *PollLangyControlSession200JSONResponseBody_Frames_2_Call) FromPollLangyControlSession200JSONResponseBodyFrames2Call0(v PollLangyControlSession200JSONResponseBodyFrames2Call0) error {
 	b, err := json.Marshal(v)
 	t.union = b
 	return err
 }
 
-// MergePostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyParameters0 performs a merge with any union data inside the PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_Parameters_AdditionalProperties, using the provided PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyParameters0
-func (t *PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_Parameters_AdditionalProperties) MergePostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyParameters0(v PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyParameters0) error {
+// MergePollLangyControlSession200JSONResponseBodyFrames2Call0 performs a merge with any union data inside the PollLangyControlSession200JSONResponseBody_Frames_2_Call, using the provided PollLangyControlSession200JSONResponseBodyFrames2Call0
+func (t *PollLangyControlSession200JSONResponseBody_Frames_2_Call) MergePollLangyControlSession200JSONResponseBodyFrames2Call0(v PollLangyControlSession200JSONResponseBodyFrames2Call0) error {
 	b, err := json.Marshal(v)
 	if err != nil {
 		return err
@@ -60478,22 +64133,22 @@ func (t *PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_Parameters
 	return err
 }
 
-// AsPostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyParameters1 returns the union data inside the PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_Parameters_AdditionalProperties as a PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyParameters1
-func (t PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_Parameters_AdditionalProperties) AsPostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyParameters1() (PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyParameters1, error) {
-	var body PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyParameters1
+// AsPollLangyControlSession200JSONResponseBodyFrames2Call1 returns the union data inside the PollLangyControlSession200JSONResponseBody_Frames_2_Call as a PollLangyControlSession200JSONResponseBodyFrames2Call1
+func (t PollLangyControlSession200JSONResponseBody_Frames_2_Call) AsPollLangyControlSession200JSONResponseBodyFrames2Call1() (PollLangyControlSession200JSONResponseBodyFrames2Call1, error) {
+	var body PollLangyControlSession200JSONResponseBodyFrames2Call1
 	err := json.Unmarshal(t.union, &body)
 	return body, err
 }
 
-// FromPostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyParameters1 overwrites any union data inside the PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_Parameters_AdditionalProperties as the provided PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyParameters1
-func (t *PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_Parameters_AdditionalProperties) FromPostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyParameters1(v PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyParameters1) error {
+// FromPollLangyControlSession200JSONResponseBodyFrames2Call1 overwrites any union data inside the PollLangyControlSession200JSONResponseBody_Frames_2_Call as the provided PollLangyControlSession200JSONResponseBodyFrames2Call1
+func (t *PollLangyControlSession200JSONResponseBody_Frames_2_Call) FromPollLangyControlSession200JSONResponseBodyFrames2Call1(v PollLangyControlSession200JSONResponseBodyFrames2Call1) error {
 	b, err := json.Marshal(v)
 	t.union = b
 	return err
 }
 
-// MergePostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyParameters1 performs a merge with any union data inside the PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_Parameters_AdditionalProperties, using the provided PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyParameters1
-func (t *PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_Parameters_AdditionalProperties) MergePostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyParameters1(v PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyParameters1) error {
+// MergePollLangyControlSession200JSONResponseBodyFrames2Call1 performs a merge with any union data inside the PollLangyControlSession200JSONResponseBody_Frames_2_Call, using the provided PollLangyControlSession200JSONResponseBodyFrames2Call1
+func (t *PollLangyControlSession200JSONResponseBody_Frames_2_Call) MergePollLangyControlSession200JSONResponseBodyFrames2Call1(v PollLangyControlSession200JSONResponseBodyFrames2Call1) error {
 	b, err := json.Marshal(v)
 	if err != nil {
 		return err
@@ -60504,22 +64159,22 @@ func (t *PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_Parameters
 	return err
 }
 
-// AsPostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyParameters2 returns the union data inside the PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_Parameters_AdditionalProperties as a PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyParameters2
-func (t PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_Parameters_AdditionalProperties) AsPostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyParameters2() (PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyParameters2, error) {
-	var body PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyParameters2
+// AsPollLangyControlSession200JSONResponseBodyFrames2Call2 returns the union data inside the PollLangyControlSession200JSONResponseBody_Frames_2_Call as a PollLangyControlSession200JSONResponseBodyFrames2Call2
+func (t PollLangyControlSession200JSONResponseBody_Frames_2_Call) AsPollLangyControlSession200JSONResponseBodyFrames2Call2() (PollLangyControlSession200JSONResponseBodyFrames2Call2, error) {
+	var body PollLangyControlSession200JSONResponseBodyFrames2Call2
 	err := json.Unmarshal(t.union, &body)
 	return body, err
 }
 
-// FromPostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyParameters2 overwrites any union data inside the PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_Parameters_AdditionalProperties as the provided PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyParameters2
-func (t *PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_Parameters_AdditionalProperties) FromPostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyParameters2(v PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyParameters2) error {
+// FromPollLangyControlSession200JSONResponseBodyFrames2Call2 overwrites any union data inside the PollLangyControlSession200JSONResponseBody_Frames_2_Call as the provided PollLangyControlSession200JSONResponseBodyFrames2Call2
+func (t *PollLangyControlSession200JSONResponseBody_Frames_2_Call) FromPollLangyControlSession200JSONResponseBodyFrames2Call2(v PollLangyControlSession200JSONResponseBodyFrames2Call2) error {
 	b, err := json.Marshal(v)
 	t.union = b
 	return err
 }
 
-// MergePostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyParameters2 performs a merge with any union data inside the PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_Parameters_AdditionalProperties, using the provided PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyParameters2
-func (t *PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_Parameters_AdditionalProperties) MergePostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyParameters2(v PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyParameters2) error {
+// MergePollLangyControlSession200JSONResponseBodyFrames2Call2 performs a merge with any union data inside the PollLangyControlSession200JSONResponseBody_Frames_2_Call, using the provided PollLangyControlSession200JSONResponseBodyFrames2Call2
+func (t *PollLangyControlSession200JSONResponseBody_Frames_2_Call) MergePollLangyControlSession200JSONResponseBodyFrames2Call2(v PollLangyControlSession200JSONResponseBodyFrames2Call2) error {
 	b, err := json.Marshal(v)
 	if err != nil {
 		return err
@@ -60530,32 +64185,397 @@ func (t *PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_Parameters
 	return err
 }
 
-func (t PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_Parameters_AdditionalProperties) MarshalJSON() ([]byte, error) {
+// AsPollLangyControlSession200JSONResponseBodyFrames2Call3 returns the union data inside the PollLangyControlSession200JSONResponseBody_Frames_2_Call as a PollLangyControlSession200JSONResponseBodyFrames2Call3
+func (t PollLangyControlSession200JSONResponseBody_Frames_2_Call) AsPollLangyControlSession200JSONResponseBodyFrames2Call3() (PollLangyControlSession200JSONResponseBodyFrames2Call3, error) {
+	var body PollLangyControlSession200JSONResponseBodyFrames2Call3
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromPollLangyControlSession200JSONResponseBodyFrames2Call3 overwrites any union data inside the PollLangyControlSession200JSONResponseBody_Frames_2_Call as the provided PollLangyControlSession200JSONResponseBodyFrames2Call3
+func (t *PollLangyControlSession200JSONResponseBody_Frames_2_Call) FromPollLangyControlSession200JSONResponseBodyFrames2Call3(v PollLangyControlSession200JSONResponseBodyFrames2Call3) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergePollLangyControlSession200JSONResponseBodyFrames2Call3 performs a merge with any union data inside the PollLangyControlSession200JSONResponseBody_Frames_2_Call, using the provided PollLangyControlSession200JSONResponseBodyFrames2Call3
+func (t *PollLangyControlSession200JSONResponseBody_Frames_2_Call) MergePollLangyControlSession200JSONResponseBodyFrames2Call3(v PollLangyControlSession200JSONResponseBodyFrames2Call3) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsPollLangyControlSession200JSONResponseBodyFrames2Call4 returns the union data inside the PollLangyControlSession200JSONResponseBody_Frames_2_Call as a PollLangyControlSession200JSONResponseBodyFrames2Call4
+func (t PollLangyControlSession200JSONResponseBody_Frames_2_Call) AsPollLangyControlSession200JSONResponseBodyFrames2Call4() (PollLangyControlSession200JSONResponseBodyFrames2Call4, error) {
+	var body PollLangyControlSession200JSONResponseBodyFrames2Call4
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromPollLangyControlSession200JSONResponseBodyFrames2Call4 overwrites any union data inside the PollLangyControlSession200JSONResponseBody_Frames_2_Call as the provided PollLangyControlSession200JSONResponseBodyFrames2Call4
+func (t *PollLangyControlSession200JSONResponseBody_Frames_2_Call) FromPollLangyControlSession200JSONResponseBodyFrames2Call4(v PollLangyControlSession200JSONResponseBodyFrames2Call4) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergePollLangyControlSession200JSONResponseBodyFrames2Call4 performs a merge with any union data inside the PollLangyControlSession200JSONResponseBody_Frames_2_Call, using the provided PollLangyControlSession200JSONResponseBodyFrames2Call4
+func (t *PollLangyControlSession200JSONResponseBody_Frames_2_Call) MergePollLangyControlSession200JSONResponseBodyFrames2Call4(v PollLangyControlSession200JSONResponseBodyFrames2Call4) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsPollLangyControlSession200JSONResponseBodyFrames2Call5 returns the union data inside the PollLangyControlSession200JSONResponseBody_Frames_2_Call as a PollLangyControlSession200JSONResponseBodyFrames2Call5
+func (t PollLangyControlSession200JSONResponseBody_Frames_2_Call) AsPollLangyControlSession200JSONResponseBodyFrames2Call5() (PollLangyControlSession200JSONResponseBodyFrames2Call5, error) {
+	var body PollLangyControlSession200JSONResponseBodyFrames2Call5
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromPollLangyControlSession200JSONResponseBodyFrames2Call5 overwrites any union data inside the PollLangyControlSession200JSONResponseBody_Frames_2_Call as the provided PollLangyControlSession200JSONResponseBodyFrames2Call5
+func (t *PollLangyControlSession200JSONResponseBody_Frames_2_Call) FromPollLangyControlSession200JSONResponseBodyFrames2Call5(v PollLangyControlSession200JSONResponseBodyFrames2Call5) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergePollLangyControlSession200JSONResponseBodyFrames2Call5 performs a merge with any union data inside the PollLangyControlSession200JSONResponseBody_Frames_2_Call, using the provided PollLangyControlSession200JSONResponseBodyFrames2Call5
+func (t *PollLangyControlSession200JSONResponseBody_Frames_2_Call) MergePollLangyControlSession200JSONResponseBodyFrames2Call5(v PollLangyControlSession200JSONResponseBodyFrames2Call5) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsPollLangyControlSession200JSONResponseBodyFrames2Call6 returns the union data inside the PollLangyControlSession200JSONResponseBody_Frames_2_Call as a PollLangyControlSession200JSONResponseBodyFrames2Call6
+func (t PollLangyControlSession200JSONResponseBody_Frames_2_Call) AsPollLangyControlSession200JSONResponseBodyFrames2Call6() (PollLangyControlSession200JSONResponseBodyFrames2Call6, error) {
+	var body PollLangyControlSession200JSONResponseBodyFrames2Call6
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromPollLangyControlSession200JSONResponseBodyFrames2Call6 overwrites any union data inside the PollLangyControlSession200JSONResponseBody_Frames_2_Call as the provided PollLangyControlSession200JSONResponseBodyFrames2Call6
+func (t *PollLangyControlSession200JSONResponseBody_Frames_2_Call) FromPollLangyControlSession200JSONResponseBodyFrames2Call6(v PollLangyControlSession200JSONResponseBodyFrames2Call6) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergePollLangyControlSession200JSONResponseBodyFrames2Call6 performs a merge with any union data inside the PollLangyControlSession200JSONResponseBody_Frames_2_Call, using the provided PollLangyControlSession200JSONResponseBodyFrames2Call6
+func (t *PollLangyControlSession200JSONResponseBody_Frames_2_Call) MergePollLangyControlSession200JSONResponseBodyFrames2Call6(v PollLangyControlSession200JSONResponseBodyFrames2Call6) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+func (t PollLangyControlSession200JSONResponseBody_Frames_2_Call) MarshalJSON() ([]byte, error) {
+	b, err := t.union.MarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	object := make(map[string]json.RawMessage)
+	if t.union != nil {
+		err = json.Unmarshal(b, &object)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	object["callId"], err = json.Marshal(t.CallId)
+	if err != nil {
+		return nil, fmt.Errorf("error marshaling 'callId': %w", err)
+	}
+
+	object["conversationId"], err = json.Marshal(t.ConversationId)
+	if err != nil {
+		return nil, fmt.Errorf("error marshaling 'conversationId': %w", err)
+	}
+
+	object["deadlineAt"], err = json.Marshal(t.DeadlineAt)
+	if err != nil {
+		return nil, fmt.Errorf("error marshaling 'deadlineAt': %w", err)
+	}
+
+	object["turnId"], err = json.Marshal(t.TurnId)
+	if err != nil {
+		return nil, fmt.Errorf("error marshaling 'turnId': %w", err)
+	}
+
+	b, err = json.Marshal(object)
+	return b, err
+}
+
+func (t *PollLangyControlSession200JSONResponseBody_Frames_2_Call) UnmarshalJSON(b []byte) error {
+	err := t.union.UnmarshalJSON(b)
+	if err != nil {
+		return err
+	}
+	object := make(map[string]json.RawMessage)
+	err = json.Unmarshal(b, &object)
+	if err != nil {
+		return err
+	}
+
+	if raw, found := object["callId"]; found {
+		err = json.Unmarshal(raw, &t.CallId)
+		if err != nil {
+			return fmt.Errorf("error reading 'callId': %w", err)
+		}
+	}
+
+	if raw, found := object["conversationId"]; found {
+		err = json.Unmarshal(raw, &t.ConversationId)
+		if err != nil {
+			return fmt.Errorf("error reading 'conversationId': %w", err)
+		}
+	}
+
+	if raw, found := object["deadlineAt"]; found {
+		err = json.Unmarshal(raw, &t.DeadlineAt)
+		if err != nil {
+			return fmt.Errorf("error reading 'deadlineAt': %w", err)
+		}
+	}
+
+	if raw, found := object["turnId"]; found {
+		err = json.Unmarshal(raw, &t.TurnId)
+		if err != nil {
+			return fmt.Errorf("error reading 'turnId': %w", err)
+		}
+	}
+
+	return err
+}
+
+// AsPollLangyControlSession200JSONResponseBodyFrames0 returns the union data inside the PollLangyControlSession200JSONResponseBody_Frames_Item as a PollLangyControlSession200JSONResponseBodyFrames0
+func (t PollLangyControlSession200JSONResponseBody_Frames_Item) AsPollLangyControlSession200JSONResponseBodyFrames0() (PollLangyControlSession200JSONResponseBodyFrames0, error) {
+	var body PollLangyControlSession200JSONResponseBodyFrames0
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromPollLangyControlSession200JSONResponseBodyFrames0 overwrites any union data inside the PollLangyControlSession200JSONResponseBody_Frames_Item as the provided PollLangyControlSession200JSONResponseBodyFrames0
+func (t *PollLangyControlSession200JSONResponseBody_Frames_Item) FromPollLangyControlSession200JSONResponseBodyFrames0(v PollLangyControlSession200JSONResponseBodyFrames0) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergePollLangyControlSession200JSONResponseBodyFrames0 performs a merge with any union data inside the PollLangyControlSession200JSONResponseBody_Frames_Item, using the provided PollLangyControlSession200JSONResponseBodyFrames0
+func (t *PollLangyControlSession200JSONResponseBody_Frames_Item) MergePollLangyControlSession200JSONResponseBodyFrames0(v PollLangyControlSession200JSONResponseBodyFrames0) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsPollLangyControlSession200JSONResponseBodyFrames1 returns the union data inside the PollLangyControlSession200JSONResponseBody_Frames_Item as a PollLangyControlSession200JSONResponseBodyFrames1
+func (t PollLangyControlSession200JSONResponseBody_Frames_Item) AsPollLangyControlSession200JSONResponseBodyFrames1() (PollLangyControlSession200JSONResponseBodyFrames1, error) {
+	var body PollLangyControlSession200JSONResponseBodyFrames1
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromPollLangyControlSession200JSONResponseBodyFrames1 overwrites any union data inside the PollLangyControlSession200JSONResponseBody_Frames_Item as the provided PollLangyControlSession200JSONResponseBodyFrames1
+func (t *PollLangyControlSession200JSONResponseBody_Frames_Item) FromPollLangyControlSession200JSONResponseBodyFrames1(v PollLangyControlSession200JSONResponseBodyFrames1) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergePollLangyControlSession200JSONResponseBodyFrames1 performs a merge with any union data inside the PollLangyControlSession200JSONResponseBody_Frames_Item, using the provided PollLangyControlSession200JSONResponseBodyFrames1
+func (t *PollLangyControlSession200JSONResponseBody_Frames_Item) MergePollLangyControlSession200JSONResponseBodyFrames1(v PollLangyControlSession200JSONResponseBodyFrames1) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsPollLangyControlSession200JSONResponseBodyFrames2 returns the union data inside the PollLangyControlSession200JSONResponseBody_Frames_Item as a PollLangyControlSession200JSONResponseBodyFrames2
+func (t PollLangyControlSession200JSONResponseBody_Frames_Item) AsPollLangyControlSession200JSONResponseBodyFrames2() (PollLangyControlSession200JSONResponseBodyFrames2, error) {
+	var body PollLangyControlSession200JSONResponseBodyFrames2
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromPollLangyControlSession200JSONResponseBodyFrames2 overwrites any union data inside the PollLangyControlSession200JSONResponseBody_Frames_Item as the provided PollLangyControlSession200JSONResponseBodyFrames2
+func (t *PollLangyControlSession200JSONResponseBody_Frames_Item) FromPollLangyControlSession200JSONResponseBodyFrames2(v PollLangyControlSession200JSONResponseBodyFrames2) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergePollLangyControlSession200JSONResponseBodyFrames2 performs a merge with any union data inside the PollLangyControlSession200JSONResponseBody_Frames_Item, using the provided PollLangyControlSession200JSONResponseBodyFrames2
+func (t *PollLangyControlSession200JSONResponseBody_Frames_Item) MergePollLangyControlSession200JSONResponseBodyFrames2(v PollLangyControlSession200JSONResponseBodyFrames2) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsPollLangyControlSession200JSONResponseBodyFrames3 returns the union data inside the PollLangyControlSession200JSONResponseBody_Frames_Item as a PollLangyControlSession200JSONResponseBodyFrames3
+func (t PollLangyControlSession200JSONResponseBody_Frames_Item) AsPollLangyControlSession200JSONResponseBodyFrames3() (PollLangyControlSession200JSONResponseBodyFrames3, error) {
+	var body PollLangyControlSession200JSONResponseBodyFrames3
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromPollLangyControlSession200JSONResponseBodyFrames3 overwrites any union data inside the PollLangyControlSession200JSONResponseBody_Frames_Item as the provided PollLangyControlSession200JSONResponseBodyFrames3
+func (t *PollLangyControlSession200JSONResponseBody_Frames_Item) FromPollLangyControlSession200JSONResponseBodyFrames3(v PollLangyControlSession200JSONResponseBodyFrames3) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergePollLangyControlSession200JSONResponseBodyFrames3 performs a merge with any union data inside the PollLangyControlSession200JSONResponseBody_Frames_Item, using the provided PollLangyControlSession200JSONResponseBodyFrames3
+func (t *PollLangyControlSession200JSONResponseBody_Frames_Item) MergePollLangyControlSession200JSONResponseBodyFrames3(v PollLangyControlSession200JSONResponseBodyFrames3) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsPollLangyControlSession200JSONResponseBodyFrames4 returns the union data inside the PollLangyControlSession200JSONResponseBody_Frames_Item as a PollLangyControlSession200JSONResponseBodyFrames4
+func (t PollLangyControlSession200JSONResponseBody_Frames_Item) AsPollLangyControlSession200JSONResponseBodyFrames4() (PollLangyControlSession200JSONResponseBodyFrames4, error) {
+	var body PollLangyControlSession200JSONResponseBodyFrames4
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromPollLangyControlSession200JSONResponseBodyFrames4 overwrites any union data inside the PollLangyControlSession200JSONResponseBody_Frames_Item as the provided PollLangyControlSession200JSONResponseBodyFrames4
+func (t *PollLangyControlSession200JSONResponseBody_Frames_Item) FromPollLangyControlSession200JSONResponseBodyFrames4(v PollLangyControlSession200JSONResponseBodyFrames4) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergePollLangyControlSession200JSONResponseBodyFrames4 performs a merge with any union data inside the PollLangyControlSession200JSONResponseBody_Frames_Item, using the provided PollLangyControlSession200JSONResponseBodyFrames4
+func (t *PollLangyControlSession200JSONResponseBody_Frames_Item) MergePollLangyControlSession200JSONResponseBodyFrames4(v PollLangyControlSession200JSONResponseBodyFrames4) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsPollLangyControlSession200JSONResponseBodyFrames5 returns the union data inside the PollLangyControlSession200JSONResponseBody_Frames_Item as a PollLangyControlSession200JSONResponseBodyFrames5
+func (t PollLangyControlSession200JSONResponseBody_Frames_Item) AsPollLangyControlSession200JSONResponseBodyFrames5() (PollLangyControlSession200JSONResponseBodyFrames5, error) {
+	var body PollLangyControlSession200JSONResponseBodyFrames5
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromPollLangyControlSession200JSONResponseBodyFrames5 overwrites any union data inside the PollLangyControlSession200JSONResponseBody_Frames_Item as the provided PollLangyControlSession200JSONResponseBodyFrames5
+func (t *PollLangyControlSession200JSONResponseBody_Frames_Item) FromPollLangyControlSession200JSONResponseBodyFrames5(v PollLangyControlSession200JSONResponseBodyFrames5) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergePollLangyControlSession200JSONResponseBodyFrames5 performs a merge with any union data inside the PollLangyControlSession200JSONResponseBody_Frames_Item, using the provided PollLangyControlSession200JSONResponseBodyFrames5
+func (t *PollLangyControlSession200JSONResponseBody_Frames_Item) MergePollLangyControlSession200JSONResponseBodyFrames5(v PollLangyControlSession200JSONResponseBodyFrames5) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsPollLangyControlSession200JSONResponseBodyFrames6 returns the union data inside the PollLangyControlSession200JSONResponseBody_Frames_Item as a PollLangyControlSession200JSONResponseBodyFrames6
+func (t PollLangyControlSession200JSONResponseBody_Frames_Item) AsPollLangyControlSession200JSONResponseBodyFrames6() (PollLangyControlSession200JSONResponseBodyFrames6, error) {
+	var body PollLangyControlSession200JSONResponseBodyFrames6
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromPollLangyControlSession200JSONResponseBodyFrames6 overwrites any union data inside the PollLangyControlSession200JSONResponseBody_Frames_Item as the provided PollLangyControlSession200JSONResponseBodyFrames6
+func (t *PollLangyControlSession200JSONResponseBody_Frames_Item) FromPollLangyControlSession200JSONResponseBodyFrames6(v PollLangyControlSession200JSONResponseBodyFrames6) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergePollLangyControlSession200JSONResponseBodyFrames6 performs a merge with any union data inside the PollLangyControlSession200JSONResponseBody_Frames_Item, using the provided PollLangyControlSession200JSONResponseBodyFrames6
+func (t *PollLangyControlSession200JSONResponseBody_Frames_Item) MergePollLangyControlSession200JSONResponseBodyFrames6(v PollLangyControlSession200JSONResponseBodyFrames6) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+func (t PollLangyControlSession200JSONResponseBody_Frames_Item) MarshalJSON() ([]byte, error) {
 	b, err := t.union.MarshalJSON()
 	return b, err
 }
 
-func (t *PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_Parameters_AdditionalProperties) UnmarshalJSON(b []byte) error {
+func (t *PollLangyControlSession200JSONResponseBody_Frames_Item) UnmarshalJSON(b []byte) error {
 	err := t.union.UnmarshalJSON(b)
 	return err
 }
 
-// AsPostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowEnd0 returns the union data inside the PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_TimeWindow_End as a PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowEnd0
-func (t PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_TimeWindow_End) AsPostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowEnd0() (PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowEnd0, error) {
-	var body PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowEnd0
+// AsRegisterLangyControlSession200JSONResponseBodyFrame0 returns the union data inside the RegisterLangyControlSession200JSONResponseBody_Frame as a RegisterLangyControlSession200JSONResponseBodyFrame0
+func (t RegisterLangyControlSession200JSONResponseBody_Frame) AsRegisterLangyControlSession200JSONResponseBodyFrame0() (RegisterLangyControlSession200JSONResponseBodyFrame0, error) {
+	var body RegisterLangyControlSession200JSONResponseBodyFrame0
 	err := json.Unmarshal(t.union, &body)
 	return body, err
 }
 
-// FromPostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowEnd0 overwrites any union data inside the PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_TimeWindow_End as the provided PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowEnd0
-func (t *PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_TimeWindow_End) FromPostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowEnd0(v PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowEnd0) error {
+// FromRegisterLangyControlSession200JSONResponseBodyFrame0 overwrites any union data inside the RegisterLangyControlSession200JSONResponseBody_Frame as the provided RegisterLangyControlSession200JSONResponseBodyFrame0
+func (t *RegisterLangyControlSession200JSONResponseBody_Frame) FromRegisterLangyControlSession200JSONResponseBodyFrame0(v RegisterLangyControlSession200JSONResponseBodyFrame0) error {
 	b, err := json.Marshal(v)
 	t.union = b
 	return err
 }
 
-// MergePostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowEnd0 performs a merge with any union data inside the PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_TimeWindow_End, using the provided PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowEnd0
-func (t *PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_TimeWindow_End) MergePostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowEnd0(v PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowEnd0) error {
+// MergeRegisterLangyControlSession200JSONResponseBodyFrame0 performs a merge with any union data inside the RegisterLangyControlSession200JSONResponseBody_Frame, using the provided RegisterLangyControlSession200JSONResponseBodyFrame0
+func (t *RegisterLangyControlSession200JSONResponseBody_Frame) MergeRegisterLangyControlSession200JSONResponseBodyFrame0(v RegisterLangyControlSession200JSONResponseBodyFrame0) error {
 	b, err := json.Marshal(v)
 	if err != nil {
 		return err
@@ -60566,22 +64586,22 @@ func (t *PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_TimeWindow
 	return err
 }
 
-// AsPostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowEnd1 returns the union data inside the PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_TimeWindow_End as a PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowEnd1
-func (t PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_TimeWindow_End) AsPostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowEnd1() (PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowEnd1, error) {
-	var body PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowEnd1
+// AsRegisterLangyControlSession200JSONResponseBodyFrame1 returns the union data inside the RegisterLangyControlSession200JSONResponseBody_Frame as a RegisterLangyControlSession200JSONResponseBodyFrame1
+func (t RegisterLangyControlSession200JSONResponseBody_Frame) AsRegisterLangyControlSession200JSONResponseBodyFrame1() (RegisterLangyControlSession200JSONResponseBodyFrame1, error) {
+	var body RegisterLangyControlSession200JSONResponseBodyFrame1
 	err := json.Unmarshal(t.union, &body)
 	return body, err
 }
 
-// FromPostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowEnd1 overwrites any union data inside the PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_TimeWindow_End as the provided PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowEnd1
-func (t *PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_TimeWindow_End) FromPostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowEnd1(v PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowEnd1) error {
+// FromRegisterLangyControlSession200JSONResponseBodyFrame1 overwrites any union data inside the RegisterLangyControlSession200JSONResponseBody_Frame as the provided RegisterLangyControlSession200JSONResponseBodyFrame1
+func (t *RegisterLangyControlSession200JSONResponseBody_Frame) FromRegisterLangyControlSession200JSONResponseBodyFrame1(v RegisterLangyControlSession200JSONResponseBodyFrame1) error {
 	b, err := json.Marshal(v)
 	t.union = b
 	return err
 }
 
-// MergePostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowEnd1 performs a merge with any union data inside the PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_TimeWindow_End, using the provided PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowEnd1
-func (t *PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_TimeWindow_End) MergePostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowEnd1(v PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowEnd1) error {
+// MergeRegisterLangyControlSession200JSONResponseBodyFrame1 performs a merge with any union data inside the RegisterLangyControlSession200JSONResponseBody_Frame, using the provided RegisterLangyControlSession200JSONResponseBodyFrame1
+func (t *RegisterLangyControlSession200JSONResponseBody_Frame) MergeRegisterLangyControlSession200JSONResponseBodyFrame1(v RegisterLangyControlSession200JSONResponseBodyFrame1) error {
 	b, err := json.Marshal(v)
 	if err != nil {
 		return err
@@ -60592,58 +64612,32 @@ func (t *PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_TimeWindow
 	return err
 }
 
-// AsPostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowEnd2 returns the union data inside the PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_TimeWindow_End as a PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowEnd2
-func (t PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_TimeWindow_End) AsPostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowEnd2() (PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowEnd2, error) {
-	var body PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowEnd2
-	err := json.Unmarshal(t.union, &body)
-	return body, err
-}
-
-// FromPostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowEnd2 overwrites any union data inside the PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_TimeWindow_End as the provided PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowEnd2
-func (t *PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_TimeWindow_End) FromPostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowEnd2(v PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowEnd2) error {
-	b, err := json.Marshal(v)
-	t.union = b
-	return err
-}
-
-// MergePostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowEnd2 performs a merge with any union data inside the PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_TimeWindow_End, using the provided PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowEnd2
-func (t *PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_TimeWindow_End) MergePostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowEnd2(v PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowEnd2) error {
-	b, err := json.Marshal(v)
-	if err != nil {
-		return err
-	}
-
-	merged, err := runtime.JSONMerge(t.union, b)
-	t.union = merged
-	return err
-}
-
-func (t PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_TimeWindow_End) MarshalJSON() ([]byte, error) {
+func (t RegisterLangyControlSession200JSONResponseBody_Frame) MarshalJSON() ([]byte, error) {
 	b, err := t.union.MarshalJSON()
 	return b, err
 }
 
-func (t *PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_TimeWindow_End) UnmarshalJSON(b []byte) error {
+func (t *RegisterLangyControlSession200JSONResponseBody_Frame) UnmarshalJSON(b []byte) error {
 	err := t.union.UnmarshalJSON(b)
 	return err
 }
 
-// AsPostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowStart0 returns the union data inside the PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_TimeWindow_Start as a PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowStart0
-func (t PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_TimeWindow_Start) AsPostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowStart0() (PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowStart0, error) {
-	var body PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowStart0
+// AsGetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBodyDataDefinitionQueriesParametersDefault0 returns the union data inside the GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBody_Data_Definition_Queries_Parameters_Default as a GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBodyDataDefinitionQueriesParametersDefault0
+func (t GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBody_Data_Definition_Queries_Parameters_Default) AsGetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBodyDataDefinitionQueriesParametersDefault0() (GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBodyDataDefinitionQueriesParametersDefault0, error) {
+	var body GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBodyDataDefinitionQueriesParametersDefault0
 	err := json.Unmarshal(t.union, &body)
 	return body, err
 }
 
-// FromPostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowStart0 overwrites any union data inside the PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_TimeWindow_Start as the provided PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowStart0
-func (t *PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_TimeWindow_Start) FromPostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowStart0(v PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowStart0) error {
+// FromGetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBodyDataDefinitionQueriesParametersDefault0 overwrites any union data inside the GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBody_Data_Definition_Queries_Parameters_Default as the provided GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBodyDataDefinitionQueriesParametersDefault0
+func (t *GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBody_Data_Definition_Queries_Parameters_Default) FromGetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBodyDataDefinitionQueriesParametersDefault0(v GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBodyDataDefinitionQueriesParametersDefault0) error {
 	b, err := json.Marshal(v)
 	t.union = b
 	return err
 }
 
-// MergePostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowStart0 performs a merge with any union data inside the PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_TimeWindow_Start, using the provided PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowStart0
-func (t *PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_TimeWindow_Start) MergePostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowStart0(v PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowStart0) error {
+// MergeGetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBodyDataDefinitionQueriesParametersDefault0 performs a merge with any union data inside the GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBody_Data_Definition_Queries_Parameters_Default, using the provided GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBodyDataDefinitionQueriesParametersDefault0
+func (t *GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBody_Data_Definition_Queries_Parameters_Default) MergeGetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBodyDataDefinitionQueriesParametersDefault0(v GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBodyDataDefinitionQueriesParametersDefault0) error {
 	b, err := json.Marshal(v)
 	if err != nil {
 		return err
@@ -60654,22 +64648,22 @@ func (t *PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_TimeWindow
 	return err
 }
 
-// AsPostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowStart1 returns the union data inside the PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_TimeWindow_Start as a PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowStart1
-func (t PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_TimeWindow_Start) AsPostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowStart1() (PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowStart1, error) {
-	var body PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowStart1
+// AsGetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBodyDataDefinitionQueriesParametersDefault1 returns the union data inside the GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBody_Data_Definition_Queries_Parameters_Default as a GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBodyDataDefinitionQueriesParametersDefault1
+func (t GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBody_Data_Definition_Queries_Parameters_Default) AsGetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBodyDataDefinitionQueriesParametersDefault1() (GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBodyDataDefinitionQueriesParametersDefault1, error) {
+	var body GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBodyDataDefinitionQueriesParametersDefault1
 	err := json.Unmarshal(t.union, &body)
 	return body, err
 }
 
-// FromPostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowStart1 overwrites any union data inside the PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_TimeWindow_Start as the provided PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowStart1
-func (t *PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_TimeWindow_Start) FromPostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowStart1(v PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowStart1) error {
+// FromGetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBodyDataDefinitionQueriesParametersDefault1 overwrites any union data inside the GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBody_Data_Definition_Queries_Parameters_Default as the provided GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBodyDataDefinitionQueriesParametersDefault1
+func (t *GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBody_Data_Definition_Queries_Parameters_Default) FromGetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBodyDataDefinitionQueriesParametersDefault1(v GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBodyDataDefinitionQueriesParametersDefault1) error {
 	b, err := json.Marshal(v)
 	t.union = b
 	return err
 }
 
-// MergePostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowStart1 performs a merge with any union data inside the PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_TimeWindow_Start, using the provided PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowStart1
-func (t *PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_TimeWindow_Start) MergePostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowStart1(v PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowStart1) error {
+// MergeGetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBodyDataDefinitionQueriesParametersDefault1 performs a merge with any union data inside the GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBody_Data_Definition_Queries_Parameters_Default, using the provided GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBodyDataDefinitionQueriesParametersDefault1
+func (t *GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBody_Data_Definition_Queries_Parameters_Default) MergeGetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBodyDataDefinitionQueriesParametersDefault1(v GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBodyDataDefinitionQueriesParametersDefault1) error {
 	b, err := json.Marshal(v)
 	if err != nil {
 		return err
@@ -60680,22 +64674,22 @@ func (t *PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_TimeWindow
 	return err
 }
 
-// AsPostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowStart2 returns the union data inside the PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_TimeWindow_Start as a PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowStart2
-func (t PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_TimeWindow_Start) AsPostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowStart2() (PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowStart2, error) {
-	var body PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowStart2
+// AsGetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBodyDataDefinitionQueriesParametersDefault2 returns the union data inside the GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBody_Data_Definition_Queries_Parameters_Default as a GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBodyDataDefinitionQueriesParametersDefault2
+func (t GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBody_Data_Definition_Queries_Parameters_Default) AsGetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBodyDataDefinitionQueriesParametersDefault2() (GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBodyDataDefinitionQueriesParametersDefault2, error) {
+	var body GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBodyDataDefinitionQueriesParametersDefault2
 	err := json.Unmarshal(t.union, &body)
 	return body, err
 }
 
-// FromPostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowStart2 overwrites any union data inside the PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_TimeWindow_Start as the provided PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowStart2
-func (t *PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_TimeWindow_Start) FromPostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowStart2(v PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowStart2) error {
+// FromGetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBodyDataDefinitionQueriesParametersDefault2 overwrites any union data inside the GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBody_Data_Definition_Queries_Parameters_Default as the provided GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBodyDataDefinitionQueriesParametersDefault2
+func (t *GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBody_Data_Definition_Queries_Parameters_Default) FromGetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBodyDataDefinitionQueriesParametersDefault2(v GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBodyDataDefinitionQueriesParametersDefault2) error {
 	b, err := json.Marshal(v)
 	t.union = b
 	return err
 }
 
-// MergePostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowStart2 performs a merge with any union data inside the PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_TimeWindow_Start, using the provided PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowStart2
-func (t *PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_TimeWindow_Start) MergePostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowStart2(v PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBodyTimeWindowStart2) error {
+// MergeGetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBodyDataDefinitionQueriesParametersDefault2 performs a merge with any union data inside the GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBody_Data_Definition_Queries_Parameters_Default, using the provided GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBodyDataDefinitionQueriesParametersDefault2
+func (t *GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBody_Data_Definition_Queries_Parameters_Default) MergeGetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBodyDataDefinitionQueriesParametersDefault2(v GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBodyDataDefinitionQueriesParametersDefault2) error {
 	b, err := json.Marshal(v)
 	if err != nil {
 		return err
@@ -60706,12 +64700,954 @@ func (t *PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_TimeWindow
 	return err
 }
 
-func (t PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_TimeWindow_Start) MarshalJSON() ([]byte, error) {
+func (t GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBody_Data_Definition_Queries_Parameters_Default) MarshalJSON() ([]byte, error) {
 	b, err := t.union.MarshalJSON()
 	return b, err
 }
 
-func (t *PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONBody_TimeWindow_Start) UnmarshalJSON(b []byte) error {
+func (t *GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBody_Data_Definition_Queries_Parameters_Default) UnmarshalJSON(b []byte) error {
+	err := t.union.UnmarshalJSON(b)
+	return err
+}
+
+// AsPostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBodyQueriesParametersDefault0 returns the union data inside the PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBody_Queries_Parameters_Default as a PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBodyQueriesParametersDefault0
+func (t PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBody_Queries_Parameters_Default) AsPostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBodyQueriesParametersDefault0() (PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBodyQueriesParametersDefault0, error) {
+	var body PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBodyQueriesParametersDefault0
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromPostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBodyQueriesParametersDefault0 overwrites any union data inside the PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBody_Queries_Parameters_Default as the provided PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBodyQueriesParametersDefault0
+func (t *PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBody_Queries_Parameters_Default) FromPostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBodyQueriesParametersDefault0(v PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBodyQueriesParametersDefault0) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergePostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBodyQueriesParametersDefault0 performs a merge with any union data inside the PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBody_Queries_Parameters_Default, using the provided PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBodyQueriesParametersDefault0
+func (t *PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBody_Queries_Parameters_Default) MergePostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBodyQueriesParametersDefault0(v PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBodyQueriesParametersDefault0) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsPostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBodyQueriesParametersDefault1 returns the union data inside the PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBody_Queries_Parameters_Default as a PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBodyQueriesParametersDefault1
+func (t PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBody_Queries_Parameters_Default) AsPostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBodyQueriesParametersDefault1() (PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBodyQueriesParametersDefault1, error) {
+	var body PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBodyQueriesParametersDefault1
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromPostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBodyQueriesParametersDefault1 overwrites any union data inside the PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBody_Queries_Parameters_Default as the provided PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBodyQueriesParametersDefault1
+func (t *PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBody_Queries_Parameters_Default) FromPostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBodyQueriesParametersDefault1(v PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBodyQueriesParametersDefault1) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergePostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBodyQueriesParametersDefault1 performs a merge with any union data inside the PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBody_Queries_Parameters_Default, using the provided PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBodyQueriesParametersDefault1
+func (t *PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBody_Queries_Parameters_Default) MergePostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBodyQueriesParametersDefault1(v PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBodyQueriesParametersDefault1) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsPostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBodyQueriesParametersDefault2 returns the union data inside the PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBody_Queries_Parameters_Default as a PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBodyQueriesParametersDefault2
+func (t PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBody_Queries_Parameters_Default) AsPostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBodyQueriesParametersDefault2() (PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBodyQueriesParametersDefault2, error) {
+	var body PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBodyQueriesParametersDefault2
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromPostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBodyQueriesParametersDefault2 overwrites any union data inside the PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBody_Queries_Parameters_Default as the provided PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBodyQueriesParametersDefault2
+func (t *PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBody_Queries_Parameters_Default) FromPostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBodyQueriesParametersDefault2(v PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBodyQueriesParametersDefault2) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergePostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBodyQueriesParametersDefault2 performs a merge with any union data inside the PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBody_Queries_Parameters_Default, using the provided PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBodyQueriesParametersDefault2
+func (t *PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBody_Queries_Parameters_Default) MergePostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBodyQueriesParametersDefault2(v PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBodyQueriesParametersDefault2) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+func (t PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBody_Queries_Parameters_Default) MarshalJSON() ([]byte, error) {
+	b, err := t.union.MarshalJSON()
+	return b, err
+}
+
+func (t *PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONBody_Queries_Parameters_Default) UnmarshalJSON(b []byte) error {
+	err := t.union.UnmarshalJSON(b)
+	return err
+}
+
+// AsPostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBodyDefinitionQueriesParametersDefault0 returns the union data inside the PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBody_Definition_Queries_Parameters_Default as a PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBodyDefinitionQueriesParametersDefault0
+func (t PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBody_Definition_Queries_Parameters_Default) AsPostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBodyDefinitionQueriesParametersDefault0() (PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBodyDefinitionQueriesParametersDefault0, error) {
+	var body PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBodyDefinitionQueriesParametersDefault0
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromPostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBodyDefinitionQueriesParametersDefault0 overwrites any union data inside the PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBody_Definition_Queries_Parameters_Default as the provided PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBodyDefinitionQueriesParametersDefault0
+func (t *PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBody_Definition_Queries_Parameters_Default) FromPostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBodyDefinitionQueriesParametersDefault0(v PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBodyDefinitionQueriesParametersDefault0) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergePostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBodyDefinitionQueriesParametersDefault0 performs a merge with any union data inside the PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBody_Definition_Queries_Parameters_Default, using the provided PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBodyDefinitionQueriesParametersDefault0
+func (t *PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBody_Definition_Queries_Parameters_Default) MergePostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBodyDefinitionQueriesParametersDefault0(v PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBodyDefinitionQueriesParametersDefault0) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsPostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBodyDefinitionQueriesParametersDefault1 returns the union data inside the PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBody_Definition_Queries_Parameters_Default as a PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBodyDefinitionQueriesParametersDefault1
+func (t PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBody_Definition_Queries_Parameters_Default) AsPostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBodyDefinitionQueriesParametersDefault1() (PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBodyDefinitionQueriesParametersDefault1, error) {
+	var body PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBodyDefinitionQueriesParametersDefault1
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromPostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBodyDefinitionQueriesParametersDefault1 overwrites any union data inside the PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBody_Definition_Queries_Parameters_Default as the provided PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBodyDefinitionQueriesParametersDefault1
+func (t *PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBody_Definition_Queries_Parameters_Default) FromPostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBodyDefinitionQueriesParametersDefault1(v PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBodyDefinitionQueriesParametersDefault1) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergePostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBodyDefinitionQueriesParametersDefault1 performs a merge with any union data inside the PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBody_Definition_Queries_Parameters_Default, using the provided PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBodyDefinitionQueriesParametersDefault1
+func (t *PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBody_Definition_Queries_Parameters_Default) MergePostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBodyDefinitionQueriesParametersDefault1(v PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBodyDefinitionQueriesParametersDefault1) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsPostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBodyDefinitionQueriesParametersDefault2 returns the union data inside the PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBody_Definition_Queries_Parameters_Default as a PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBodyDefinitionQueriesParametersDefault2
+func (t PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBody_Definition_Queries_Parameters_Default) AsPostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBodyDefinitionQueriesParametersDefault2() (PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBodyDefinitionQueriesParametersDefault2, error) {
+	var body PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBodyDefinitionQueriesParametersDefault2
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromPostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBodyDefinitionQueriesParametersDefault2 overwrites any union data inside the PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBody_Definition_Queries_Parameters_Default as the provided PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBodyDefinitionQueriesParametersDefault2
+func (t *PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBody_Definition_Queries_Parameters_Default) FromPostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBodyDefinitionQueriesParametersDefault2(v PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBodyDefinitionQueriesParametersDefault2) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergePostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBodyDefinitionQueriesParametersDefault2 performs a merge with any union data inside the PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBody_Definition_Queries_Parameters_Default, using the provided PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBodyDefinitionQueriesParametersDefault2
+func (t *PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBody_Definition_Queries_Parameters_Default) MergePostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBodyDefinitionQueriesParametersDefault2(v PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBodyDefinitionQueriesParametersDefault2) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+func (t PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBody_Definition_Queries_Parameters_Default) MarshalJSON() ([]byte, error) {
+	b, err := t.union.MarshalJSON()
+	return b, err
+}
+
+func (t *PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBody_Definition_Queries_Parameters_Default) UnmarshalJSON(b []byte) error {
+	err := t.union.UnmarshalJSON(b)
+	return err
+}
+
+// AsGetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault0 returns the union data inside the GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBody_Definition_Queries_Parameters_Default as a GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault0
+func (t GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBody_Definition_Queries_Parameters_Default) AsGetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault0() (GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault0, error) {
+	var body GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault0
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromGetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault0 overwrites any union data inside the GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBody_Definition_Queries_Parameters_Default as the provided GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault0
+func (t *GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBody_Definition_Queries_Parameters_Default) FromGetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault0(v GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault0) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeGetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault0 performs a merge with any union data inside the GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBody_Definition_Queries_Parameters_Default, using the provided GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault0
+func (t *GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBody_Definition_Queries_Parameters_Default) MergeGetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault0(v GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault0) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsGetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault1 returns the union data inside the GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBody_Definition_Queries_Parameters_Default as a GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault1
+func (t GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBody_Definition_Queries_Parameters_Default) AsGetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault1() (GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault1, error) {
+	var body GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault1
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromGetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault1 overwrites any union data inside the GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBody_Definition_Queries_Parameters_Default as the provided GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault1
+func (t *GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBody_Definition_Queries_Parameters_Default) FromGetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault1(v GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault1) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeGetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault1 performs a merge with any union data inside the GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBody_Definition_Queries_Parameters_Default, using the provided GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault1
+func (t *GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBody_Definition_Queries_Parameters_Default) MergeGetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault1(v GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault1) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsGetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault2 returns the union data inside the GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBody_Definition_Queries_Parameters_Default as a GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault2
+func (t GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBody_Definition_Queries_Parameters_Default) AsGetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault2() (GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault2, error) {
+	var body GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault2
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromGetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault2 overwrites any union data inside the GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBody_Definition_Queries_Parameters_Default as the provided GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault2
+func (t *GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBody_Definition_Queries_Parameters_Default) FromGetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault2(v GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault2) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeGetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault2 performs a merge with any union data inside the GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBody_Definition_Queries_Parameters_Default, using the provided GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault2
+func (t *GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBody_Definition_Queries_Parameters_Default) MergeGetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault2(v GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault2) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+func (t GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBody_Definition_Queries_Parameters_Default) MarshalJSON() ([]byte, error) {
+	b, err := t.union.MarshalJSON()
+	return b, err
+}
+
+func (t *GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBody_Definition_Queries_Parameters_Default) UnmarshalJSON(b []byte) error {
+	err := t.union.UnmarshalJSON(b)
+	return err
+}
+
+// AsPatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBodyQueriesParametersDefault0 returns the union data inside the PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBody_Queries_Parameters_Default as a PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBodyQueriesParametersDefault0
+func (t PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBody_Queries_Parameters_Default) AsPatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBodyQueriesParametersDefault0() (PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBodyQueriesParametersDefault0, error) {
+	var body PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBodyQueriesParametersDefault0
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromPatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBodyQueriesParametersDefault0 overwrites any union data inside the PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBody_Queries_Parameters_Default as the provided PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBodyQueriesParametersDefault0
+func (t *PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBody_Queries_Parameters_Default) FromPatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBodyQueriesParametersDefault0(v PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBodyQueriesParametersDefault0) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergePatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBodyQueriesParametersDefault0 performs a merge with any union data inside the PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBody_Queries_Parameters_Default, using the provided PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBodyQueriesParametersDefault0
+func (t *PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBody_Queries_Parameters_Default) MergePatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBodyQueriesParametersDefault0(v PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBodyQueriesParametersDefault0) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsPatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBodyQueriesParametersDefault1 returns the union data inside the PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBody_Queries_Parameters_Default as a PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBodyQueriesParametersDefault1
+func (t PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBody_Queries_Parameters_Default) AsPatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBodyQueriesParametersDefault1() (PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBodyQueriesParametersDefault1, error) {
+	var body PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBodyQueriesParametersDefault1
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromPatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBodyQueriesParametersDefault1 overwrites any union data inside the PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBody_Queries_Parameters_Default as the provided PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBodyQueriesParametersDefault1
+func (t *PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBody_Queries_Parameters_Default) FromPatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBodyQueriesParametersDefault1(v PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBodyQueriesParametersDefault1) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergePatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBodyQueriesParametersDefault1 performs a merge with any union data inside the PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBody_Queries_Parameters_Default, using the provided PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBodyQueriesParametersDefault1
+func (t *PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBody_Queries_Parameters_Default) MergePatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBodyQueriesParametersDefault1(v PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBodyQueriesParametersDefault1) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsPatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBodyQueriesParametersDefault2 returns the union data inside the PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBody_Queries_Parameters_Default as a PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBodyQueriesParametersDefault2
+func (t PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBody_Queries_Parameters_Default) AsPatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBodyQueriesParametersDefault2() (PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBodyQueriesParametersDefault2, error) {
+	var body PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBodyQueriesParametersDefault2
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromPatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBodyQueriesParametersDefault2 overwrites any union data inside the PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBody_Queries_Parameters_Default as the provided PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBodyQueriesParametersDefault2
+func (t *PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBody_Queries_Parameters_Default) FromPatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBodyQueriesParametersDefault2(v PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBodyQueriesParametersDefault2) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergePatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBodyQueriesParametersDefault2 performs a merge with any union data inside the PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBody_Queries_Parameters_Default, using the provided PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBodyQueriesParametersDefault2
+func (t *PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBody_Queries_Parameters_Default) MergePatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBodyQueriesParametersDefault2(v PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBodyQueriesParametersDefault2) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+func (t PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBody_Queries_Parameters_Default) MarshalJSON() ([]byte, error) {
+	b, err := t.union.MarshalJSON()
+	return b, err
+}
+
+func (t *PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONBody_Queries_Parameters_Default) UnmarshalJSON(b []byte) error {
+	err := t.union.UnmarshalJSON(b)
+	return err
+}
+
+// AsPatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault0 returns the union data inside the PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBody_Definition_Queries_Parameters_Default as a PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault0
+func (t PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBody_Definition_Queries_Parameters_Default) AsPatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault0() (PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault0, error) {
+	var body PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault0
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromPatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault0 overwrites any union data inside the PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBody_Definition_Queries_Parameters_Default as the provided PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault0
+func (t *PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBody_Definition_Queries_Parameters_Default) FromPatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault0(v PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault0) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergePatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault0 performs a merge with any union data inside the PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBody_Definition_Queries_Parameters_Default, using the provided PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault0
+func (t *PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBody_Definition_Queries_Parameters_Default) MergePatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault0(v PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault0) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsPatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault1 returns the union data inside the PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBody_Definition_Queries_Parameters_Default as a PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault1
+func (t PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBody_Definition_Queries_Parameters_Default) AsPatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault1() (PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault1, error) {
+	var body PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault1
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromPatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault1 overwrites any union data inside the PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBody_Definition_Queries_Parameters_Default as the provided PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault1
+func (t *PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBody_Definition_Queries_Parameters_Default) FromPatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault1(v PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault1) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergePatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault1 performs a merge with any union data inside the PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBody_Definition_Queries_Parameters_Default, using the provided PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault1
+func (t *PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBody_Definition_Queries_Parameters_Default) MergePatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault1(v PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault1) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsPatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault2 returns the union data inside the PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBody_Definition_Queries_Parameters_Default as a PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault2
+func (t PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBody_Definition_Queries_Parameters_Default) AsPatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault2() (PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault2, error) {
+	var body PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault2
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromPatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault2 overwrites any union data inside the PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBody_Definition_Queries_Parameters_Default as the provided PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault2
+func (t *PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBody_Definition_Queries_Parameters_Default) FromPatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault2(v PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault2) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergePatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault2 performs a merge with any union data inside the PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBody_Definition_Queries_Parameters_Default, using the provided PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault2
+func (t *PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBody_Definition_Queries_Parameters_Default) MergePatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault2(v PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersDefault2) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+func (t PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBody_Definition_Queries_Parameters_Default) MarshalJSON() ([]byte, error) {
+	b, err := t.union.MarshalJSON()
+	return b, err
+}
+
+func (t *PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBody_Definition_Queries_Parameters_Default) UnmarshalJSON(b []byte) error {
+	err := t.union.UnmarshalJSON(b)
+	return err
+}
+
+// AsPostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBodyDefinitionQueriesParametersDefault0 returns the union data inside the PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBody_Definition_Queries_Parameters_Default as a PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBodyDefinitionQueriesParametersDefault0
+func (t PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBody_Definition_Queries_Parameters_Default) AsPostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBodyDefinitionQueriesParametersDefault0() (PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBodyDefinitionQueriesParametersDefault0, error) {
+	var body PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBodyDefinitionQueriesParametersDefault0
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromPostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBodyDefinitionQueriesParametersDefault0 overwrites any union data inside the PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBody_Definition_Queries_Parameters_Default as the provided PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBodyDefinitionQueriesParametersDefault0
+func (t *PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBody_Definition_Queries_Parameters_Default) FromPostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBodyDefinitionQueriesParametersDefault0(v PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBodyDefinitionQueriesParametersDefault0) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergePostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBodyDefinitionQueriesParametersDefault0 performs a merge with any union data inside the PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBody_Definition_Queries_Parameters_Default, using the provided PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBodyDefinitionQueriesParametersDefault0
+func (t *PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBody_Definition_Queries_Parameters_Default) MergePostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBodyDefinitionQueriesParametersDefault0(v PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBodyDefinitionQueriesParametersDefault0) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsPostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBodyDefinitionQueriesParametersDefault1 returns the union data inside the PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBody_Definition_Queries_Parameters_Default as a PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBodyDefinitionQueriesParametersDefault1
+func (t PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBody_Definition_Queries_Parameters_Default) AsPostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBodyDefinitionQueriesParametersDefault1() (PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBodyDefinitionQueriesParametersDefault1, error) {
+	var body PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBodyDefinitionQueriesParametersDefault1
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromPostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBodyDefinitionQueriesParametersDefault1 overwrites any union data inside the PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBody_Definition_Queries_Parameters_Default as the provided PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBodyDefinitionQueriesParametersDefault1
+func (t *PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBody_Definition_Queries_Parameters_Default) FromPostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBodyDefinitionQueriesParametersDefault1(v PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBodyDefinitionQueriesParametersDefault1) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergePostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBodyDefinitionQueriesParametersDefault1 performs a merge with any union data inside the PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBody_Definition_Queries_Parameters_Default, using the provided PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBodyDefinitionQueriesParametersDefault1
+func (t *PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBody_Definition_Queries_Parameters_Default) MergePostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBodyDefinitionQueriesParametersDefault1(v PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBodyDefinitionQueriesParametersDefault1) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsPostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBodyDefinitionQueriesParametersDefault2 returns the union data inside the PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBody_Definition_Queries_Parameters_Default as a PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBodyDefinitionQueriesParametersDefault2
+func (t PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBody_Definition_Queries_Parameters_Default) AsPostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBodyDefinitionQueriesParametersDefault2() (PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBodyDefinitionQueriesParametersDefault2, error) {
+	var body PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBodyDefinitionQueriesParametersDefault2
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromPostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBodyDefinitionQueriesParametersDefault2 overwrites any union data inside the PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBody_Definition_Queries_Parameters_Default as the provided PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBodyDefinitionQueriesParametersDefault2
+func (t *PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBody_Definition_Queries_Parameters_Default) FromPostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBodyDefinitionQueriesParametersDefault2(v PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBodyDefinitionQueriesParametersDefault2) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergePostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBodyDefinitionQueriesParametersDefault2 performs a merge with any union data inside the PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBody_Definition_Queries_Parameters_Default, using the provided PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBodyDefinitionQueriesParametersDefault2
+func (t *PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBody_Definition_Queries_Parameters_Default) MergePostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBodyDefinitionQueriesParametersDefault2(v PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBodyDefinitionQueriesParametersDefault2) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+func (t PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBody_Definition_Queries_Parameters_Default) MarshalJSON() ([]byte, error) {
+	b, err := t.union.MarshalJSON()
+	return b, err
+}
+
+func (t *PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBody_Definition_Queries_Parameters_Default) UnmarshalJSON(b []byte) error {
+	err := t.union.UnmarshalJSON(b)
+	return err
+}
+
+// AsPostApiV1QueryJSONBodyGranularitySeconds0 returns the union data inside the PostApiV1QueryJSONBody_GranularitySeconds as a PostApiV1QueryJSONBodyGranularitySeconds0
+func (t PostApiV1QueryJSONBody_GranularitySeconds) AsPostApiV1QueryJSONBodyGranularitySeconds0() (PostApiV1QueryJSONBodyGranularitySeconds0, error) {
+	var body PostApiV1QueryJSONBodyGranularitySeconds0
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromPostApiV1QueryJSONBodyGranularitySeconds0 overwrites any union data inside the PostApiV1QueryJSONBody_GranularitySeconds as the provided PostApiV1QueryJSONBodyGranularitySeconds0
+func (t *PostApiV1QueryJSONBody_GranularitySeconds) FromPostApiV1QueryJSONBodyGranularitySeconds0(v PostApiV1QueryJSONBodyGranularitySeconds0) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergePostApiV1QueryJSONBodyGranularitySeconds0 performs a merge with any union data inside the PostApiV1QueryJSONBody_GranularitySeconds, using the provided PostApiV1QueryJSONBodyGranularitySeconds0
+func (t *PostApiV1QueryJSONBody_GranularitySeconds) MergePostApiV1QueryJSONBodyGranularitySeconds0(v PostApiV1QueryJSONBodyGranularitySeconds0) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsPostApiV1QueryJSONBodyGranularitySeconds1 returns the union data inside the PostApiV1QueryJSONBody_GranularitySeconds as a PostApiV1QueryJSONBodyGranularitySeconds1
+func (t PostApiV1QueryJSONBody_GranularitySeconds) AsPostApiV1QueryJSONBodyGranularitySeconds1() (PostApiV1QueryJSONBodyGranularitySeconds1, error) {
+	var body PostApiV1QueryJSONBodyGranularitySeconds1
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromPostApiV1QueryJSONBodyGranularitySeconds1 overwrites any union data inside the PostApiV1QueryJSONBody_GranularitySeconds as the provided PostApiV1QueryJSONBodyGranularitySeconds1
+func (t *PostApiV1QueryJSONBody_GranularitySeconds) FromPostApiV1QueryJSONBodyGranularitySeconds1(v PostApiV1QueryJSONBodyGranularitySeconds1) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergePostApiV1QueryJSONBodyGranularitySeconds1 performs a merge with any union data inside the PostApiV1QueryJSONBody_GranularitySeconds, using the provided PostApiV1QueryJSONBodyGranularitySeconds1
+func (t *PostApiV1QueryJSONBody_GranularitySeconds) MergePostApiV1QueryJSONBodyGranularitySeconds1(v PostApiV1QueryJSONBodyGranularitySeconds1) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsPostApiV1QueryJSONBodyGranularitySeconds2 returns the union data inside the PostApiV1QueryJSONBody_GranularitySeconds as a PostApiV1QueryJSONBodyGranularitySeconds2
+func (t PostApiV1QueryJSONBody_GranularitySeconds) AsPostApiV1QueryJSONBodyGranularitySeconds2() (PostApiV1QueryJSONBodyGranularitySeconds2, error) {
+	var body PostApiV1QueryJSONBodyGranularitySeconds2
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromPostApiV1QueryJSONBodyGranularitySeconds2 overwrites any union data inside the PostApiV1QueryJSONBody_GranularitySeconds as the provided PostApiV1QueryJSONBodyGranularitySeconds2
+func (t *PostApiV1QueryJSONBody_GranularitySeconds) FromPostApiV1QueryJSONBodyGranularitySeconds2(v PostApiV1QueryJSONBodyGranularitySeconds2) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergePostApiV1QueryJSONBodyGranularitySeconds2 performs a merge with any union data inside the PostApiV1QueryJSONBody_GranularitySeconds, using the provided PostApiV1QueryJSONBodyGranularitySeconds2
+func (t *PostApiV1QueryJSONBody_GranularitySeconds) MergePostApiV1QueryJSONBodyGranularitySeconds2(v PostApiV1QueryJSONBodyGranularitySeconds2) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+func (t PostApiV1QueryJSONBody_GranularitySeconds) MarshalJSON() ([]byte, error) {
+	b, err := t.union.MarshalJSON()
+	return b, err
+}
+
+func (t *PostApiV1QueryJSONBody_GranularitySeconds) UnmarshalJSON(b []byte) error {
+	err := t.union.UnmarshalJSON(b)
+	return err
+}
+
+// AsPostApiV1QueryJSONBodyParameters0 returns the union data inside the PostApiV1QueryJSONBody_Parameters_AdditionalProperties as a PostApiV1QueryJSONBodyParameters0
+func (t PostApiV1QueryJSONBody_Parameters_AdditionalProperties) AsPostApiV1QueryJSONBodyParameters0() (PostApiV1QueryJSONBodyParameters0, error) {
+	var body PostApiV1QueryJSONBodyParameters0
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromPostApiV1QueryJSONBodyParameters0 overwrites any union data inside the PostApiV1QueryJSONBody_Parameters_AdditionalProperties as the provided PostApiV1QueryJSONBodyParameters0
+func (t *PostApiV1QueryJSONBody_Parameters_AdditionalProperties) FromPostApiV1QueryJSONBodyParameters0(v PostApiV1QueryJSONBodyParameters0) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergePostApiV1QueryJSONBodyParameters0 performs a merge with any union data inside the PostApiV1QueryJSONBody_Parameters_AdditionalProperties, using the provided PostApiV1QueryJSONBodyParameters0
+func (t *PostApiV1QueryJSONBody_Parameters_AdditionalProperties) MergePostApiV1QueryJSONBodyParameters0(v PostApiV1QueryJSONBodyParameters0) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsPostApiV1QueryJSONBodyParameters1 returns the union data inside the PostApiV1QueryJSONBody_Parameters_AdditionalProperties as a PostApiV1QueryJSONBodyParameters1
+func (t PostApiV1QueryJSONBody_Parameters_AdditionalProperties) AsPostApiV1QueryJSONBodyParameters1() (PostApiV1QueryJSONBodyParameters1, error) {
+	var body PostApiV1QueryJSONBodyParameters1
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromPostApiV1QueryJSONBodyParameters1 overwrites any union data inside the PostApiV1QueryJSONBody_Parameters_AdditionalProperties as the provided PostApiV1QueryJSONBodyParameters1
+func (t *PostApiV1QueryJSONBody_Parameters_AdditionalProperties) FromPostApiV1QueryJSONBodyParameters1(v PostApiV1QueryJSONBodyParameters1) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergePostApiV1QueryJSONBodyParameters1 performs a merge with any union data inside the PostApiV1QueryJSONBody_Parameters_AdditionalProperties, using the provided PostApiV1QueryJSONBodyParameters1
+func (t *PostApiV1QueryJSONBody_Parameters_AdditionalProperties) MergePostApiV1QueryJSONBodyParameters1(v PostApiV1QueryJSONBodyParameters1) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsPostApiV1QueryJSONBodyParameters2 returns the union data inside the PostApiV1QueryJSONBody_Parameters_AdditionalProperties as a PostApiV1QueryJSONBodyParameters2
+func (t PostApiV1QueryJSONBody_Parameters_AdditionalProperties) AsPostApiV1QueryJSONBodyParameters2() (PostApiV1QueryJSONBodyParameters2, error) {
+	var body PostApiV1QueryJSONBodyParameters2
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromPostApiV1QueryJSONBodyParameters2 overwrites any union data inside the PostApiV1QueryJSONBody_Parameters_AdditionalProperties as the provided PostApiV1QueryJSONBodyParameters2
+func (t *PostApiV1QueryJSONBody_Parameters_AdditionalProperties) FromPostApiV1QueryJSONBodyParameters2(v PostApiV1QueryJSONBodyParameters2) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergePostApiV1QueryJSONBodyParameters2 performs a merge with any union data inside the PostApiV1QueryJSONBody_Parameters_AdditionalProperties, using the provided PostApiV1QueryJSONBodyParameters2
+func (t *PostApiV1QueryJSONBody_Parameters_AdditionalProperties) MergePostApiV1QueryJSONBodyParameters2(v PostApiV1QueryJSONBodyParameters2) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+func (t PostApiV1QueryJSONBody_Parameters_AdditionalProperties) MarshalJSON() ([]byte, error) {
+	b, err := t.union.MarshalJSON()
+	return b, err
+}
+
+func (t *PostApiV1QueryJSONBody_Parameters_AdditionalProperties) UnmarshalJSON(b []byte) error {
+	err := t.union.UnmarshalJSON(b)
+	return err
+}
+
+// AsPostApiV1QueryJSONBodyTimeWindowEnd0 returns the union data inside the PostApiV1QueryJSONBody_TimeWindow_End as a PostApiV1QueryJSONBodyTimeWindowEnd0
+func (t PostApiV1QueryJSONBody_TimeWindow_End) AsPostApiV1QueryJSONBodyTimeWindowEnd0() (PostApiV1QueryJSONBodyTimeWindowEnd0, error) {
+	var body PostApiV1QueryJSONBodyTimeWindowEnd0
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromPostApiV1QueryJSONBodyTimeWindowEnd0 overwrites any union data inside the PostApiV1QueryJSONBody_TimeWindow_End as the provided PostApiV1QueryJSONBodyTimeWindowEnd0
+func (t *PostApiV1QueryJSONBody_TimeWindow_End) FromPostApiV1QueryJSONBodyTimeWindowEnd0(v PostApiV1QueryJSONBodyTimeWindowEnd0) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergePostApiV1QueryJSONBodyTimeWindowEnd0 performs a merge with any union data inside the PostApiV1QueryJSONBody_TimeWindow_End, using the provided PostApiV1QueryJSONBodyTimeWindowEnd0
+func (t *PostApiV1QueryJSONBody_TimeWindow_End) MergePostApiV1QueryJSONBodyTimeWindowEnd0(v PostApiV1QueryJSONBodyTimeWindowEnd0) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsPostApiV1QueryJSONBodyTimeWindowEnd1 returns the union data inside the PostApiV1QueryJSONBody_TimeWindow_End as a PostApiV1QueryJSONBodyTimeWindowEnd1
+func (t PostApiV1QueryJSONBody_TimeWindow_End) AsPostApiV1QueryJSONBodyTimeWindowEnd1() (PostApiV1QueryJSONBodyTimeWindowEnd1, error) {
+	var body PostApiV1QueryJSONBodyTimeWindowEnd1
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromPostApiV1QueryJSONBodyTimeWindowEnd1 overwrites any union data inside the PostApiV1QueryJSONBody_TimeWindow_End as the provided PostApiV1QueryJSONBodyTimeWindowEnd1
+func (t *PostApiV1QueryJSONBody_TimeWindow_End) FromPostApiV1QueryJSONBodyTimeWindowEnd1(v PostApiV1QueryJSONBodyTimeWindowEnd1) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergePostApiV1QueryJSONBodyTimeWindowEnd1 performs a merge with any union data inside the PostApiV1QueryJSONBody_TimeWindow_End, using the provided PostApiV1QueryJSONBodyTimeWindowEnd1
+func (t *PostApiV1QueryJSONBody_TimeWindow_End) MergePostApiV1QueryJSONBodyTimeWindowEnd1(v PostApiV1QueryJSONBodyTimeWindowEnd1) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsPostApiV1QueryJSONBodyTimeWindowEnd2 returns the union data inside the PostApiV1QueryJSONBody_TimeWindow_End as a PostApiV1QueryJSONBodyTimeWindowEnd2
+func (t PostApiV1QueryJSONBody_TimeWindow_End) AsPostApiV1QueryJSONBodyTimeWindowEnd2() (PostApiV1QueryJSONBodyTimeWindowEnd2, error) {
+	var body PostApiV1QueryJSONBodyTimeWindowEnd2
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromPostApiV1QueryJSONBodyTimeWindowEnd2 overwrites any union data inside the PostApiV1QueryJSONBody_TimeWindow_End as the provided PostApiV1QueryJSONBodyTimeWindowEnd2
+func (t *PostApiV1QueryJSONBody_TimeWindow_End) FromPostApiV1QueryJSONBodyTimeWindowEnd2(v PostApiV1QueryJSONBodyTimeWindowEnd2) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergePostApiV1QueryJSONBodyTimeWindowEnd2 performs a merge with any union data inside the PostApiV1QueryJSONBody_TimeWindow_End, using the provided PostApiV1QueryJSONBodyTimeWindowEnd2
+func (t *PostApiV1QueryJSONBody_TimeWindow_End) MergePostApiV1QueryJSONBodyTimeWindowEnd2(v PostApiV1QueryJSONBodyTimeWindowEnd2) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+func (t PostApiV1QueryJSONBody_TimeWindow_End) MarshalJSON() ([]byte, error) {
+	b, err := t.union.MarshalJSON()
+	return b, err
+}
+
+func (t *PostApiV1QueryJSONBody_TimeWindow_End) UnmarshalJSON(b []byte) error {
+	err := t.union.UnmarshalJSON(b)
+	return err
+}
+
+// AsPostApiV1QueryJSONBodyTimeWindowStart0 returns the union data inside the PostApiV1QueryJSONBody_TimeWindow_Start as a PostApiV1QueryJSONBodyTimeWindowStart0
+func (t PostApiV1QueryJSONBody_TimeWindow_Start) AsPostApiV1QueryJSONBodyTimeWindowStart0() (PostApiV1QueryJSONBodyTimeWindowStart0, error) {
+	var body PostApiV1QueryJSONBodyTimeWindowStart0
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromPostApiV1QueryJSONBodyTimeWindowStart0 overwrites any union data inside the PostApiV1QueryJSONBody_TimeWindow_Start as the provided PostApiV1QueryJSONBodyTimeWindowStart0
+func (t *PostApiV1QueryJSONBody_TimeWindow_Start) FromPostApiV1QueryJSONBodyTimeWindowStart0(v PostApiV1QueryJSONBodyTimeWindowStart0) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergePostApiV1QueryJSONBodyTimeWindowStart0 performs a merge with any union data inside the PostApiV1QueryJSONBody_TimeWindow_Start, using the provided PostApiV1QueryJSONBodyTimeWindowStart0
+func (t *PostApiV1QueryJSONBody_TimeWindow_Start) MergePostApiV1QueryJSONBodyTimeWindowStart0(v PostApiV1QueryJSONBodyTimeWindowStart0) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsPostApiV1QueryJSONBodyTimeWindowStart1 returns the union data inside the PostApiV1QueryJSONBody_TimeWindow_Start as a PostApiV1QueryJSONBodyTimeWindowStart1
+func (t PostApiV1QueryJSONBody_TimeWindow_Start) AsPostApiV1QueryJSONBodyTimeWindowStart1() (PostApiV1QueryJSONBodyTimeWindowStart1, error) {
+	var body PostApiV1QueryJSONBodyTimeWindowStart1
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromPostApiV1QueryJSONBodyTimeWindowStart1 overwrites any union data inside the PostApiV1QueryJSONBody_TimeWindow_Start as the provided PostApiV1QueryJSONBodyTimeWindowStart1
+func (t *PostApiV1QueryJSONBody_TimeWindow_Start) FromPostApiV1QueryJSONBodyTimeWindowStart1(v PostApiV1QueryJSONBodyTimeWindowStart1) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergePostApiV1QueryJSONBodyTimeWindowStart1 performs a merge with any union data inside the PostApiV1QueryJSONBody_TimeWindow_Start, using the provided PostApiV1QueryJSONBodyTimeWindowStart1
+func (t *PostApiV1QueryJSONBody_TimeWindow_Start) MergePostApiV1QueryJSONBodyTimeWindowStart1(v PostApiV1QueryJSONBodyTimeWindowStart1) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsPostApiV1QueryJSONBodyTimeWindowStart2 returns the union data inside the PostApiV1QueryJSONBody_TimeWindow_Start as a PostApiV1QueryJSONBodyTimeWindowStart2
+func (t PostApiV1QueryJSONBody_TimeWindow_Start) AsPostApiV1QueryJSONBodyTimeWindowStart2() (PostApiV1QueryJSONBodyTimeWindowStart2, error) {
+	var body PostApiV1QueryJSONBodyTimeWindowStart2
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromPostApiV1QueryJSONBodyTimeWindowStart2 overwrites any union data inside the PostApiV1QueryJSONBody_TimeWindow_Start as the provided PostApiV1QueryJSONBodyTimeWindowStart2
+func (t *PostApiV1QueryJSONBody_TimeWindow_Start) FromPostApiV1QueryJSONBodyTimeWindowStart2(v PostApiV1QueryJSONBodyTimeWindowStart2) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergePostApiV1QueryJSONBodyTimeWindowStart2 performs a merge with any union data inside the PostApiV1QueryJSONBody_TimeWindow_Start, using the provided PostApiV1QueryJSONBodyTimeWindowStart2
+func (t *PostApiV1QueryJSONBody_TimeWindow_Start) MergePostApiV1QueryJSONBodyTimeWindowStart2(v PostApiV1QueryJSONBodyTimeWindowStart2) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+func (t PostApiV1QueryJSONBody_TimeWindow_Start) MarshalJSON() ([]byte, error) {
+	b, err := t.union.MarshalJSON()
+	return b, err
+}
+
+func (t *PostApiV1QueryJSONBody_TimeWindow_Start) UnmarshalJSON(b []byte) error {
+	err := t.union.UnmarshalJSON(b)
+	return err
+}
+
+// AsListRunPlans200JSONResponseBodyEvaluatorsMappings0 returns the union data inside the ListRunPlans200JSONResponseBody_Evaluators_Mappings_AdditionalProperties as a ListRunPlans200JSONResponseBodyEvaluatorsMappings0
+func (t ListRunPlans200JSONResponseBody_Evaluators_Mappings_AdditionalProperties) AsListRunPlans200JSONResponseBodyEvaluatorsMappings0() (ListRunPlans200JSONResponseBodyEvaluatorsMappings0, error) {
+	var body ListRunPlans200JSONResponseBodyEvaluatorsMappings0
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromListRunPlans200JSONResponseBodyEvaluatorsMappings0 overwrites any union data inside the ListRunPlans200JSONResponseBody_Evaluators_Mappings_AdditionalProperties as the provided ListRunPlans200JSONResponseBodyEvaluatorsMappings0
+func (t *ListRunPlans200JSONResponseBody_Evaluators_Mappings_AdditionalProperties) FromListRunPlans200JSONResponseBodyEvaluatorsMappings0(v ListRunPlans200JSONResponseBodyEvaluatorsMappings0) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeListRunPlans200JSONResponseBodyEvaluatorsMappings0 performs a merge with any union data inside the ListRunPlans200JSONResponseBody_Evaluators_Mappings_AdditionalProperties, using the provided ListRunPlans200JSONResponseBodyEvaluatorsMappings0
+func (t *ListRunPlans200JSONResponseBody_Evaluators_Mappings_AdditionalProperties) MergeListRunPlans200JSONResponseBodyEvaluatorsMappings0(v ListRunPlans200JSONResponseBodyEvaluatorsMappings0) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsListRunPlans200JSONResponseBodyEvaluatorsMappings1 returns the union data inside the ListRunPlans200JSONResponseBody_Evaluators_Mappings_AdditionalProperties as a ListRunPlans200JSONResponseBodyEvaluatorsMappings1
+func (t ListRunPlans200JSONResponseBody_Evaluators_Mappings_AdditionalProperties) AsListRunPlans200JSONResponseBodyEvaluatorsMappings1() (ListRunPlans200JSONResponseBodyEvaluatorsMappings1, error) {
+	var body ListRunPlans200JSONResponseBodyEvaluatorsMappings1
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromListRunPlans200JSONResponseBodyEvaluatorsMappings1 overwrites any union data inside the ListRunPlans200JSONResponseBody_Evaluators_Mappings_AdditionalProperties as the provided ListRunPlans200JSONResponseBodyEvaluatorsMappings1
+func (t *ListRunPlans200JSONResponseBody_Evaluators_Mappings_AdditionalProperties) FromListRunPlans200JSONResponseBodyEvaluatorsMappings1(v ListRunPlans200JSONResponseBodyEvaluatorsMappings1) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeListRunPlans200JSONResponseBodyEvaluatorsMappings1 performs a merge with any union data inside the ListRunPlans200JSONResponseBody_Evaluators_Mappings_AdditionalProperties, using the provided ListRunPlans200JSONResponseBodyEvaluatorsMappings1
+func (t *ListRunPlans200JSONResponseBody_Evaluators_Mappings_AdditionalProperties) MergeListRunPlans200JSONResponseBodyEvaluatorsMappings1(v ListRunPlans200JSONResponseBodyEvaluatorsMappings1) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+func (t ListRunPlans200JSONResponseBody_Evaluators_Mappings_AdditionalProperties) MarshalJSON() ([]byte, error) {
+	b, err := t.union.MarshalJSON()
+	return b, err
+}
+
+func (t *ListRunPlans200JSONResponseBody_Evaluators_Mappings_AdditionalProperties) UnmarshalJSON(b []byte) error {
 	err := t.union.UnmarshalJSON(b)
 	return err
 }
@@ -60914,6 +65850,68 @@ func (t ListRunPlans200JSONResponseBody_Targets_RunParameters_AdditionalProperti
 }
 
 func (t *ListRunPlans200JSONResponseBody_Targets_RunParameters_AdditionalProperties) UnmarshalJSON(b []byte) error {
+	err := t.union.UnmarshalJSON(b)
+	return err
+}
+
+// AsRunRunPlanJSONBodyConfigEvaluatorsMappings0 returns the union data inside the RunRunPlanJSONBody_Config_Evaluators_Mappings_AdditionalProperties as a RunRunPlanJSONBodyConfigEvaluatorsMappings0
+func (t RunRunPlanJSONBody_Config_Evaluators_Mappings_AdditionalProperties) AsRunRunPlanJSONBodyConfigEvaluatorsMappings0() (RunRunPlanJSONBodyConfigEvaluatorsMappings0, error) {
+	var body RunRunPlanJSONBodyConfigEvaluatorsMappings0
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromRunRunPlanJSONBodyConfigEvaluatorsMappings0 overwrites any union data inside the RunRunPlanJSONBody_Config_Evaluators_Mappings_AdditionalProperties as the provided RunRunPlanJSONBodyConfigEvaluatorsMappings0
+func (t *RunRunPlanJSONBody_Config_Evaluators_Mappings_AdditionalProperties) FromRunRunPlanJSONBodyConfigEvaluatorsMappings0(v RunRunPlanJSONBodyConfigEvaluatorsMappings0) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeRunRunPlanJSONBodyConfigEvaluatorsMappings0 performs a merge with any union data inside the RunRunPlanJSONBody_Config_Evaluators_Mappings_AdditionalProperties, using the provided RunRunPlanJSONBodyConfigEvaluatorsMappings0
+func (t *RunRunPlanJSONBody_Config_Evaluators_Mappings_AdditionalProperties) MergeRunRunPlanJSONBodyConfigEvaluatorsMappings0(v RunRunPlanJSONBodyConfigEvaluatorsMappings0) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsRunRunPlanJSONBodyConfigEvaluatorsMappings1 returns the union data inside the RunRunPlanJSONBody_Config_Evaluators_Mappings_AdditionalProperties as a RunRunPlanJSONBodyConfigEvaluatorsMappings1
+func (t RunRunPlanJSONBody_Config_Evaluators_Mappings_AdditionalProperties) AsRunRunPlanJSONBodyConfigEvaluatorsMappings1() (RunRunPlanJSONBodyConfigEvaluatorsMappings1, error) {
+	var body RunRunPlanJSONBodyConfigEvaluatorsMappings1
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromRunRunPlanJSONBodyConfigEvaluatorsMappings1 overwrites any union data inside the RunRunPlanJSONBody_Config_Evaluators_Mappings_AdditionalProperties as the provided RunRunPlanJSONBodyConfigEvaluatorsMappings1
+func (t *RunRunPlanJSONBody_Config_Evaluators_Mappings_AdditionalProperties) FromRunRunPlanJSONBodyConfigEvaluatorsMappings1(v RunRunPlanJSONBodyConfigEvaluatorsMappings1) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeRunRunPlanJSONBodyConfigEvaluatorsMappings1 performs a merge with any union data inside the RunRunPlanJSONBody_Config_Evaluators_Mappings_AdditionalProperties, using the provided RunRunPlanJSONBodyConfigEvaluatorsMappings1
+func (t *RunRunPlanJSONBody_Config_Evaluators_Mappings_AdditionalProperties) MergeRunRunPlanJSONBodyConfigEvaluatorsMappings1(v RunRunPlanJSONBodyConfigEvaluatorsMappings1) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+func (t RunRunPlanJSONBody_Config_Evaluators_Mappings_AdditionalProperties) MarshalJSON() ([]byte, error) {
+	b, err := t.union.MarshalJSON()
+	return b, err
+}
+
+func (t *RunRunPlanJSONBody_Config_Evaluators_Mappings_AdditionalProperties) UnmarshalJSON(b []byte) error {
 	err := t.union.UnmarshalJSON(b)
 	return err
 }
@@ -61296,6 +66294,68 @@ func (t *RunRunPlan200JSONResponseBody_Items_Target_RunParameters_AdditionalProp
 	return err
 }
 
+// AsGetRunPlan200JSONResponseBodyEvaluatorsMappings0 returns the union data inside the GetRunPlan200JSONResponseBody_Evaluators_Mappings_AdditionalProperties as a GetRunPlan200JSONResponseBodyEvaluatorsMappings0
+func (t GetRunPlan200JSONResponseBody_Evaluators_Mappings_AdditionalProperties) AsGetRunPlan200JSONResponseBodyEvaluatorsMappings0() (GetRunPlan200JSONResponseBodyEvaluatorsMappings0, error) {
+	var body GetRunPlan200JSONResponseBodyEvaluatorsMappings0
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromGetRunPlan200JSONResponseBodyEvaluatorsMappings0 overwrites any union data inside the GetRunPlan200JSONResponseBody_Evaluators_Mappings_AdditionalProperties as the provided GetRunPlan200JSONResponseBodyEvaluatorsMappings0
+func (t *GetRunPlan200JSONResponseBody_Evaluators_Mappings_AdditionalProperties) FromGetRunPlan200JSONResponseBodyEvaluatorsMappings0(v GetRunPlan200JSONResponseBodyEvaluatorsMappings0) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeGetRunPlan200JSONResponseBodyEvaluatorsMappings0 performs a merge with any union data inside the GetRunPlan200JSONResponseBody_Evaluators_Mappings_AdditionalProperties, using the provided GetRunPlan200JSONResponseBodyEvaluatorsMappings0
+func (t *GetRunPlan200JSONResponseBody_Evaluators_Mappings_AdditionalProperties) MergeGetRunPlan200JSONResponseBodyEvaluatorsMappings0(v GetRunPlan200JSONResponseBodyEvaluatorsMappings0) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsGetRunPlan200JSONResponseBodyEvaluatorsMappings1 returns the union data inside the GetRunPlan200JSONResponseBody_Evaluators_Mappings_AdditionalProperties as a GetRunPlan200JSONResponseBodyEvaluatorsMappings1
+func (t GetRunPlan200JSONResponseBody_Evaluators_Mappings_AdditionalProperties) AsGetRunPlan200JSONResponseBodyEvaluatorsMappings1() (GetRunPlan200JSONResponseBodyEvaluatorsMappings1, error) {
+	var body GetRunPlan200JSONResponseBodyEvaluatorsMappings1
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromGetRunPlan200JSONResponseBodyEvaluatorsMappings1 overwrites any union data inside the GetRunPlan200JSONResponseBody_Evaluators_Mappings_AdditionalProperties as the provided GetRunPlan200JSONResponseBodyEvaluatorsMappings1
+func (t *GetRunPlan200JSONResponseBody_Evaluators_Mappings_AdditionalProperties) FromGetRunPlan200JSONResponseBodyEvaluatorsMappings1(v GetRunPlan200JSONResponseBodyEvaluatorsMappings1) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeGetRunPlan200JSONResponseBodyEvaluatorsMappings1 performs a merge with any union data inside the GetRunPlan200JSONResponseBody_Evaluators_Mappings_AdditionalProperties, using the provided GetRunPlan200JSONResponseBodyEvaluatorsMappings1
+func (t *GetRunPlan200JSONResponseBody_Evaluators_Mappings_AdditionalProperties) MergeGetRunPlan200JSONResponseBodyEvaluatorsMappings1(v GetRunPlan200JSONResponseBodyEvaluatorsMappings1) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+func (t GetRunPlan200JSONResponseBody_Evaluators_Mappings_AdditionalProperties) MarshalJSON() ([]byte, error) {
+	b, err := t.union.MarshalJSON()
+	return b, err
+}
+
+func (t *GetRunPlan200JSONResponseBody_Evaluators_Mappings_AdditionalProperties) UnmarshalJSON(b []byte) error {
+	err := t.union.UnmarshalJSON(b)
+	return err
+}
+
 // AsGetRunPlan200JSONResponseBodyScope0 returns the union data inside the GetRunPlan200JSONResponseBody_Scope as a GetRunPlan200JSONResponseBodyScope0
 func (t GetRunPlan200JSONResponseBody_Scope) AsGetRunPlan200JSONResponseBodyScope0() (GetRunPlan200JSONResponseBodyScope0, error) {
 	var body GetRunPlan200JSONResponseBodyScope0
@@ -61670,6 +66730,378 @@ func (t RerunRunPlan200JSONResponseBody_Items_Target_RunParameters_AdditionalPro
 }
 
 func (t *RerunRunPlan200JSONResponseBody_Items_Target_RunParameters_AdditionalProperties) UnmarshalJSON(b []byte) error {
+	err := t.union.UnmarshalJSON(b)
+	return err
+}
+
+// AsListTestSuites200JSONResponseBodyEvaluatorsMappings0 returns the union data inside the ListTestSuites200JSONResponseBody_Evaluators_Mappings_AdditionalProperties as a ListTestSuites200JSONResponseBodyEvaluatorsMappings0
+func (t ListTestSuites200JSONResponseBody_Evaluators_Mappings_AdditionalProperties) AsListTestSuites200JSONResponseBodyEvaluatorsMappings0() (ListTestSuites200JSONResponseBodyEvaluatorsMappings0, error) {
+	var body ListTestSuites200JSONResponseBodyEvaluatorsMappings0
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromListTestSuites200JSONResponseBodyEvaluatorsMappings0 overwrites any union data inside the ListTestSuites200JSONResponseBody_Evaluators_Mappings_AdditionalProperties as the provided ListTestSuites200JSONResponseBodyEvaluatorsMappings0
+func (t *ListTestSuites200JSONResponseBody_Evaluators_Mappings_AdditionalProperties) FromListTestSuites200JSONResponseBodyEvaluatorsMappings0(v ListTestSuites200JSONResponseBodyEvaluatorsMappings0) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeListTestSuites200JSONResponseBodyEvaluatorsMappings0 performs a merge with any union data inside the ListTestSuites200JSONResponseBody_Evaluators_Mappings_AdditionalProperties, using the provided ListTestSuites200JSONResponseBodyEvaluatorsMappings0
+func (t *ListTestSuites200JSONResponseBody_Evaluators_Mappings_AdditionalProperties) MergeListTestSuites200JSONResponseBodyEvaluatorsMappings0(v ListTestSuites200JSONResponseBodyEvaluatorsMappings0) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsListTestSuites200JSONResponseBodyEvaluatorsMappings1 returns the union data inside the ListTestSuites200JSONResponseBody_Evaluators_Mappings_AdditionalProperties as a ListTestSuites200JSONResponseBodyEvaluatorsMappings1
+func (t ListTestSuites200JSONResponseBody_Evaluators_Mappings_AdditionalProperties) AsListTestSuites200JSONResponseBodyEvaluatorsMappings1() (ListTestSuites200JSONResponseBodyEvaluatorsMappings1, error) {
+	var body ListTestSuites200JSONResponseBodyEvaluatorsMappings1
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromListTestSuites200JSONResponseBodyEvaluatorsMappings1 overwrites any union data inside the ListTestSuites200JSONResponseBody_Evaluators_Mappings_AdditionalProperties as the provided ListTestSuites200JSONResponseBodyEvaluatorsMappings1
+func (t *ListTestSuites200JSONResponseBody_Evaluators_Mappings_AdditionalProperties) FromListTestSuites200JSONResponseBodyEvaluatorsMappings1(v ListTestSuites200JSONResponseBodyEvaluatorsMappings1) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeListTestSuites200JSONResponseBodyEvaluatorsMappings1 performs a merge with any union data inside the ListTestSuites200JSONResponseBody_Evaluators_Mappings_AdditionalProperties, using the provided ListTestSuites200JSONResponseBodyEvaluatorsMappings1
+func (t *ListTestSuites200JSONResponseBody_Evaluators_Mappings_AdditionalProperties) MergeListTestSuites200JSONResponseBodyEvaluatorsMappings1(v ListTestSuites200JSONResponseBodyEvaluatorsMappings1) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+func (t ListTestSuites200JSONResponseBody_Evaluators_Mappings_AdditionalProperties) MarshalJSON() ([]byte, error) {
+	b, err := t.union.MarshalJSON()
+	return b, err
+}
+
+func (t *ListTestSuites200JSONResponseBody_Evaluators_Mappings_AdditionalProperties) UnmarshalJSON(b []byte) error {
+	err := t.union.UnmarshalJSON(b)
+	return err
+}
+
+// AsCreateTestSuiteJSONBodyEvaluatorsMappings0 returns the union data inside the CreateTestSuiteJSONBody_Evaluators_Mappings_AdditionalProperties as a CreateTestSuiteJSONBodyEvaluatorsMappings0
+func (t CreateTestSuiteJSONBody_Evaluators_Mappings_AdditionalProperties) AsCreateTestSuiteJSONBodyEvaluatorsMappings0() (CreateTestSuiteJSONBodyEvaluatorsMappings0, error) {
+	var body CreateTestSuiteJSONBodyEvaluatorsMappings0
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromCreateTestSuiteJSONBodyEvaluatorsMappings0 overwrites any union data inside the CreateTestSuiteJSONBody_Evaluators_Mappings_AdditionalProperties as the provided CreateTestSuiteJSONBodyEvaluatorsMappings0
+func (t *CreateTestSuiteJSONBody_Evaluators_Mappings_AdditionalProperties) FromCreateTestSuiteJSONBodyEvaluatorsMappings0(v CreateTestSuiteJSONBodyEvaluatorsMappings0) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeCreateTestSuiteJSONBodyEvaluatorsMappings0 performs a merge with any union data inside the CreateTestSuiteJSONBody_Evaluators_Mappings_AdditionalProperties, using the provided CreateTestSuiteJSONBodyEvaluatorsMappings0
+func (t *CreateTestSuiteJSONBody_Evaluators_Mappings_AdditionalProperties) MergeCreateTestSuiteJSONBodyEvaluatorsMappings0(v CreateTestSuiteJSONBodyEvaluatorsMappings0) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsCreateTestSuiteJSONBodyEvaluatorsMappings1 returns the union data inside the CreateTestSuiteJSONBody_Evaluators_Mappings_AdditionalProperties as a CreateTestSuiteJSONBodyEvaluatorsMappings1
+func (t CreateTestSuiteJSONBody_Evaluators_Mappings_AdditionalProperties) AsCreateTestSuiteJSONBodyEvaluatorsMappings1() (CreateTestSuiteJSONBodyEvaluatorsMappings1, error) {
+	var body CreateTestSuiteJSONBodyEvaluatorsMappings1
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromCreateTestSuiteJSONBodyEvaluatorsMappings1 overwrites any union data inside the CreateTestSuiteJSONBody_Evaluators_Mappings_AdditionalProperties as the provided CreateTestSuiteJSONBodyEvaluatorsMappings1
+func (t *CreateTestSuiteJSONBody_Evaluators_Mappings_AdditionalProperties) FromCreateTestSuiteJSONBodyEvaluatorsMappings1(v CreateTestSuiteJSONBodyEvaluatorsMappings1) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeCreateTestSuiteJSONBodyEvaluatorsMappings1 performs a merge with any union data inside the CreateTestSuiteJSONBody_Evaluators_Mappings_AdditionalProperties, using the provided CreateTestSuiteJSONBodyEvaluatorsMappings1
+func (t *CreateTestSuiteJSONBody_Evaluators_Mappings_AdditionalProperties) MergeCreateTestSuiteJSONBodyEvaluatorsMappings1(v CreateTestSuiteJSONBodyEvaluatorsMappings1) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+func (t CreateTestSuiteJSONBody_Evaluators_Mappings_AdditionalProperties) MarshalJSON() ([]byte, error) {
+	b, err := t.union.MarshalJSON()
+	return b, err
+}
+
+func (t *CreateTestSuiteJSONBody_Evaluators_Mappings_AdditionalProperties) UnmarshalJSON(b []byte) error {
+	err := t.union.UnmarshalJSON(b)
+	return err
+}
+
+// AsCreateTestSuite201JSONResponseBodyEvaluatorsMappings0 returns the union data inside the CreateTestSuite201JSONResponseBody_Evaluators_Mappings_AdditionalProperties as a CreateTestSuite201JSONResponseBodyEvaluatorsMappings0
+func (t CreateTestSuite201JSONResponseBody_Evaluators_Mappings_AdditionalProperties) AsCreateTestSuite201JSONResponseBodyEvaluatorsMappings0() (CreateTestSuite201JSONResponseBodyEvaluatorsMappings0, error) {
+	var body CreateTestSuite201JSONResponseBodyEvaluatorsMappings0
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromCreateTestSuite201JSONResponseBodyEvaluatorsMappings0 overwrites any union data inside the CreateTestSuite201JSONResponseBody_Evaluators_Mappings_AdditionalProperties as the provided CreateTestSuite201JSONResponseBodyEvaluatorsMappings0
+func (t *CreateTestSuite201JSONResponseBody_Evaluators_Mappings_AdditionalProperties) FromCreateTestSuite201JSONResponseBodyEvaluatorsMappings0(v CreateTestSuite201JSONResponseBodyEvaluatorsMappings0) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeCreateTestSuite201JSONResponseBodyEvaluatorsMappings0 performs a merge with any union data inside the CreateTestSuite201JSONResponseBody_Evaluators_Mappings_AdditionalProperties, using the provided CreateTestSuite201JSONResponseBodyEvaluatorsMappings0
+func (t *CreateTestSuite201JSONResponseBody_Evaluators_Mappings_AdditionalProperties) MergeCreateTestSuite201JSONResponseBodyEvaluatorsMappings0(v CreateTestSuite201JSONResponseBodyEvaluatorsMappings0) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsCreateTestSuite201JSONResponseBodyEvaluatorsMappings1 returns the union data inside the CreateTestSuite201JSONResponseBody_Evaluators_Mappings_AdditionalProperties as a CreateTestSuite201JSONResponseBodyEvaluatorsMappings1
+func (t CreateTestSuite201JSONResponseBody_Evaluators_Mappings_AdditionalProperties) AsCreateTestSuite201JSONResponseBodyEvaluatorsMappings1() (CreateTestSuite201JSONResponseBodyEvaluatorsMappings1, error) {
+	var body CreateTestSuite201JSONResponseBodyEvaluatorsMappings1
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromCreateTestSuite201JSONResponseBodyEvaluatorsMappings1 overwrites any union data inside the CreateTestSuite201JSONResponseBody_Evaluators_Mappings_AdditionalProperties as the provided CreateTestSuite201JSONResponseBodyEvaluatorsMappings1
+func (t *CreateTestSuite201JSONResponseBody_Evaluators_Mappings_AdditionalProperties) FromCreateTestSuite201JSONResponseBodyEvaluatorsMappings1(v CreateTestSuite201JSONResponseBodyEvaluatorsMappings1) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeCreateTestSuite201JSONResponseBodyEvaluatorsMappings1 performs a merge with any union data inside the CreateTestSuite201JSONResponseBody_Evaluators_Mappings_AdditionalProperties, using the provided CreateTestSuite201JSONResponseBodyEvaluatorsMappings1
+func (t *CreateTestSuite201JSONResponseBody_Evaluators_Mappings_AdditionalProperties) MergeCreateTestSuite201JSONResponseBodyEvaluatorsMappings1(v CreateTestSuite201JSONResponseBodyEvaluatorsMappings1) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+func (t CreateTestSuite201JSONResponseBody_Evaluators_Mappings_AdditionalProperties) MarshalJSON() ([]byte, error) {
+	b, err := t.union.MarshalJSON()
+	return b, err
+}
+
+func (t *CreateTestSuite201JSONResponseBody_Evaluators_Mappings_AdditionalProperties) UnmarshalJSON(b []byte) error {
+	err := t.union.UnmarshalJSON(b)
+	return err
+}
+
+// AsGetTestSuite200JSONResponseBodyEvaluatorsMappings0 returns the union data inside the GetTestSuite200JSONResponseBody_Evaluators_Mappings_AdditionalProperties as a GetTestSuite200JSONResponseBodyEvaluatorsMappings0
+func (t GetTestSuite200JSONResponseBody_Evaluators_Mappings_AdditionalProperties) AsGetTestSuite200JSONResponseBodyEvaluatorsMappings0() (GetTestSuite200JSONResponseBodyEvaluatorsMappings0, error) {
+	var body GetTestSuite200JSONResponseBodyEvaluatorsMappings0
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromGetTestSuite200JSONResponseBodyEvaluatorsMappings0 overwrites any union data inside the GetTestSuite200JSONResponseBody_Evaluators_Mappings_AdditionalProperties as the provided GetTestSuite200JSONResponseBodyEvaluatorsMappings0
+func (t *GetTestSuite200JSONResponseBody_Evaluators_Mappings_AdditionalProperties) FromGetTestSuite200JSONResponseBodyEvaluatorsMappings0(v GetTestSuite200JSONResponseBodyEvaluatorsMappings0) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeGetTestSuite200JSONResponseBodyEvaluatorsMappings0 performs a merge with any union data inside the GetTestSuite200JSONResponseBody_Evaluators_Mappings_AdditionalProperties, using the provided GetTestSuite200JSONResponseBodyEvaluatorsMappings0
+func (t *GetTestSuite200JSONResponseBody_Evaluators_Mappings_AdditionalProperties) MergeGetTestSuite200JSONResponseBodyEvaluatorsMappings0(v GetTestSuite200JSONResponseBodyEvaluatorsMappings0) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsGetTestSuite200JSONResponseBodyEvaluatorsMappings1 returns the union data inside the GetTestSuite200JSONResponseBody_Evaluators_Mappings_AdditionalProperties as a GetTestSuite200JSONResponseBodyEvaluatorsMappings1
+func (t GetTestSuite200JSONResponseBody_Evaluators_Mappings_AdditionalProperties) AsGetTestSuite200JSONResponseBodyEvaluatorsMappings1() (GetTestSuite200JSONResponseBodyEvaluatorsMappings1, error) {
+	var body GetTestSuite200JSONResponseBodyEvaluatorsMappings1
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromGetTestSuite200JSONResponseBodyEvaluatorsMappings1 overwrites any union data inside the GetTestSuite200JSONResponseBody_Evaluators_Mappings_AdditionalProperties as the provided GetTestSuite200JSONResponseBodyEvaluatorsMappings1
+func (t *GetTestSuite200JSONResponseBody_Evaluators_Mappings_AdditionalProperties) FromGetTestSuite200JSONResponseBodyEvaluatorsMappings1(v GetTestSuite200JSONResponseBodyEvaluatorsMappings1) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeGetTestSuite200JSONResponseBodyEvaluatorsMappings1 performs a merge with any union data inside the GetTestSuite200JSONResponseBody_Evaluators_Mappings_AdditionalProperties, using the provided GetTestSuite200JSONResponseBodyEvaluatorsMappings1
+func (t *GetTestSuite200JSONResponseBody_Evaluators_Mappings_AdditionalProperties) MergeGetTestSuite200JSONResponseBodyEvaluatorsMappings1(v GetTestSuite200JSONResponseBodyEvaluatorsMappings1) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+func (t GetTestSuite200JSONResponseBody_Evaluators_Mappings_AdditionalProperties) MarshalJSON() ([]byte, error) {
+	b, err := t.union.MarshalJSON()
+	return b, err
+}
+
+func (t *GetTestSuite200JSONResponseBody_Evaluators_Mappings_AdditionalProperties) UnmarshalJSON(b []byte) error {
+	err := t.union.UnmarshalJSON(b)
+	return err
+}
+
+// AsUpdateTestSuiteJSONBodyEvaluatorsMappings0 returns the union data inside the UpdateTestSuiteJSONBody_Evaluators_Mappings_AdditionalProperties as a UpdateTestSuiteJSONBodyEvaluatorsMappings0
+func (t UpdateTestSuiteJSONBody_Evaluators_Mappings_AdditionalProperties) AsUpdateTestSuiteJSONBodyEvaluatorsMappings0() (UpdateTestSuiteJSONBodyEvaluatorsMappings0, error) {
+	var body UpdateTestSuiteJSONBodyEvaluatorsMappings0
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromUpdateTestSuiteJSONBodyEvaluatorsMappings0 overwrites any union data inside the UpdateTestSuiteJSONBody_Evaluators_Mappings_AdditionalProperties as the provided UpdateTestSuiteJSONBodyEvaluatorsMappings0
+func (t *UpdateTestSuiteJSONBody_Evaluators_Mappings_AdditionalProperties) FromUpdateTestSuiteJSONBodyEvaluatorsMappings0(v UpdateTestSuiteJSONBodyEvaluatorsMappings0) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeUpdateTestSuiteJSONBodyEvaluatorsMappings0 performs a merge with any union data inside the UpdateTestSuiteJSONBody_Evaluators_Mappings_AdditionalProperties, using the provided UpdateTestSuiteJSONBodyEvaluatorsMappings0
+func (t *UpdateTestSuiteJSONBody_Evaluators_Mappings_AdditionalProperties) MergeUpdateTestSuiteJSONBodyEvaluatorsMappings0(v UpdateTestSuiteJSONBodyEvaluatorsMappings0) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsUpdateTestSuiteJSONBodyEvaluatorsMappings1 returns the union data inside the UpdateTestSuiteJSONBody_Evaluators_Mappings_AdditionalProperties as a UpdateTestSuiteJSONBodyEvaluatorsMappings1
+func (t UpdateTestSuiteJSONBody_Evaluators_Mappings_AdditionalProperties) AsUpdateTestSuiteJSONBodyEvaluatorsMappings1() (UpdateTestSuiteJSONBodyEvaluatorsMappings1, error) {
+	var body UpdateTestSuiteJSONBodyEvaluatorsMappings1
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromUpdateTestSuiteJSONBodyEvaluatorsMappings1 overwrites any union data inside the UpdateTestSuiteJSONBody_Evaluators_Mappings_AdditionalProperties as the provided UpdateTestSuiteJSONBodyEvaluatorsMappings1
+func (t *UpdateTestSuiteJSONBody_Evaluators_Mappings_AdditionalProperties) FromUpdateTestSuiteJSONBodyEvaluatorsMappings1(v UpdateTestSuiteJSONBodyEvaluatorsMappings1) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeUpdateTestSuiteJSONBodyEvaluatorsMappings1 performs a merge with any union data inside the UpdateTestSuiteJSONBody_Evaluators_Mappings_AdditionalProperties, using the provided UpdateTestSuiteJSONBodyEvaluatorsMappings1
+func (t *UpdateTestSuiteJSONBody_Evaluators_Mappings_AdditionalProperties) MergeUpdateTestSuiteJSONBodyEvaluatorsMappings1(v UpdateTestSuiteJSONBodyEvaluatorsMappings1) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+func (t UpdateTestSuiteJSONBody_Evaluators_Mappings_AdditionalProperties) MarshalJSON() ([]byte, error) {
+	b, err := t.union.MarshalJSON()
+	return b, err
+}
+
+func (t *UpdateTestSuiteJSONBody_Evaluators_Mappings_AdditionalProperties) UnmarshalJSON(b []byte) error {
+	err := t.union.UnmarshalJSON(b)
+	return err
+}
+
+// AsUpdateTestSuite200JSONResponseBodyEvaluatorsMappings0 returns the union data inside the UpdateTestSuite200JSONResponseBody_Evaluators_Mappings_AdditionalProperties as a UpdateTestSuite200JSONResponseBodyEvaluatorsMappings0
+func (t UpdateTestSuite200JSONResponseBody_Evaluators_Mappings_AdditionalProperties) AsUpdateTestSuite200JSONResponseBodyEvaluatorsMappings0() (UpdateTestSuite200JSONResponseBodyEvaluatorsMappings0, error) {
+	var body UpdateTestSuite200JSONResponseBodyEvaluatorsMappings0
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromUpdateTestSuite200JSONResponseBodyEvaluatorsMappings0 overwrites any union data inside the UpdateTestSuite200JSONResponseBody_Evaluators_Mappings_AdditionalProperties as the provided UpdateTestSuite200JSONResponseBodyEvaluatorsMappings0
+func (t *UpdateTestSuite200JSONResponseBody_Evaluators_Mappings_AdditionalProperties) FromUpdateTestSuite200JSONResponseBodyEvaluatorsMappings0(v UpdateTestSuite200JSONResponseBodyEvaluatorsMappings0) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeUpdateTestSuite200JSONResponseBodyEvaluatorsMappings0 performs a merge with any union data inside the UpdateTestSuite200JSONResponseBody_Evaluators_Mappings_AdditionalProperties, using the provided UpdateTestSuite200JSONResponseBodyEvaluatorsMappings0
+func (t *UpdateTestSuite200JSONResponseBody_Evaluators_Mappings_AdditionalProperties) MergeUpdateTestSuite200JSONResponseBodyEvaluatorsMappings0(v UpdateTestSuite200JSONResponseBodyEvaluatorsMappings0) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsUpdateTestSuite200JSONResponseBodyEvaluatorsMappings1 returns the union data inside the UpdateTestSuite200JSONResponseBody_Evaluators_Mappings_AdditionalProperties as a UpdateTestSuite200JSONResponseBodyEvaluatorsMappings1
+func (t UpdateTestSuite200JSONResponseBody_Evaluators_Mappings_AdditionalProperties) AsUpdateTestSuite200JSONResponseBodyEvaluatorsMappings1() (UpdateTestSuite200JSONResponseBodyEvaluatorsMappings1, error) {
+	var body UpdateTestSuite200JSONResponseBodyEvaluatorsMappings1
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromUpdateTestSuite200JSONResponseBodyEvaluatorsMappings1 overwrites any union data inside the UpdateTestSuite200JSONResponseBody_Evaluators_Mappings_AdditionalProperties as the provided UpdateTestSuite200JSONResponseBodyEvaluatorsMappings1
+func (t *UpdateTestSuite200JSONResponseBody_Evaluators_Mappings_AdditionalProperties) FromUpdateTestSuite200JSONResponseBodyEvaluatorsMappings1(v UpdateTestSuite200JSONResponseBodyEvaluatorsMappings1) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeUpdateTestSuite200JSONResponseBodyEvaluatorsMappings1 performs a merge with any union data inside the UpdateTestSuite200JSONResponseBody_Evaluators_Mappings_AdditionalProperties, using the provided UpdateTestSuite200JSONResponseBodyEvaluatorsMappings1
+func (t *UpdateTestSuite200JSONResponseBody_Evaluators_Mappings_AdditionalProperties) MergeUpdateTestSuite200JSONResponseBodyEvaluatorsMappings1(v UpdateTestSuite200JSONResponseBodyEvaluatorsMappings1) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+func (t UpdateTestSuite200JSONResponseBody_Evaluators_Mappings_AdditionalProperties) MarshalJSON() ([]byte, error) {
+	b, err := t.union.MarshalJSON()
+	return b, err
+}
+
+func (t *UpdateTestSuite200JSONResponseBody_Evaluators_Mappings_AdditionalProperties) UnmarshalJSON(b []byte) error {
 	err := t.union.UnmarshalJSON(b)
 	return err
 }
@@ -63373,6 +68805,33 @@ type ClientInterface interface {
 	// TestAgent request
 	TestAgent(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// GetPullRequestUsage request
+	GetPullRequestUsage(ctx context.Context, params *GetPullRequestUsageParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// PostLangyControlFramesWithBody request with any body
+	PostLangyControlFramesWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	PostLangyControlFrames(ctx context.Context, body PostLangyControlFramesJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// PollLangyControlSession request
+	PollLangyControlSession(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// RegisterLangyControlSessionWithBody request with any body
+	RegisterLangyControlSessionWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	RegisterLangyControlSession(ctx context.Context, body RegisterLangyControlSessionJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ListLangyControlRequests request
+	ListLangyControlRequests(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ApproveLangyControlRequestWithBody request with any body
+	ApproveLangyControlRequestWithBody(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	ApproveLangyControlRequest(ctx context.Context, id string, body ApproveLangyControlRequestJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// CancelLangyControlRequest request
+	CancelLangyControlRequest(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// GetApiV1ProjectsByProjectIdAnalyticsCharts request
 	GetApiV1ProjectsByProjectIdAnalyticsCharts(ctx context.Context, projectId string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -63400,13 +68859,37 @@ type ClientInterface interface {
 
 	PutApiV1ProjectsByProjectIdAnalyticsChartsByChartIdPlacement(ctx context.Context, projectId string, chartId string, body PutApiV1ProjectsByProjectIdAnalyticsChartsByChartIdPlacementJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseWithBody request with any body
-	PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseWithBody(ctx context.Context, projectId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets request
+	GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets(ctx context.Context, projectId string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouse(ctx context.Context, projectId string, body PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsWithBody request with any body
+	PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsWithBody(ctx context.Context, projectId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// GetApiV1ProjectsByProjectIdAnalyticsSchema request
-	GetApiV1ProjectsByProjectIdAnalyticsSchema(ctx context.Context, projectId string, reqEditors ...RequestEditorFn) (*http.Response, error)
+	PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets(ctx context.Context, projectId string, body PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// DeleteApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId request
+	DeleteApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId(ctx context.Context, projectId string, widgetId string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId request
+	GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId(ctx context.Context, projectId string, widgetId string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdWithBody request with any body
+	PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdWithBody(ctx context.Context, projectId string, widgetId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId(ctx context.Context, projectId string, widgetId string, body PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboardWithBody request with any body
+	PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboardWithBody(ctx context.Context, projectId string, widgetId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard(ctx context.Context, projectId string, widgetId string, body PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboardJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// PostApiV1QueryWithBody request with any body
+	PostApiV1QueryWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	PostApiV1Query(ctx context.Context, body PostApiV1QueryJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetApiV1QuerySchema request
+	GetApiV1QuerySchema(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// ListRunPlans request
 	ListRunPlans(ctx context.Context, params *ListRunPlansParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -63441,10 +68924,10 @@ type ClientInterface interface {
 	// GetTestSuite request
 	GetTestSuite(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// RenameTestSuiteWithBody request with any body
-	RenameTestSuiteWithBody(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// UpdateTestSuiteWithBody request with any body
+	UpdateTestSuiteWithBody(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	RenameTestSuite(ctx context.Context, id string, body RenameTestSuiteJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	UpdateTestSuite(ctx context.Context, id string, body UpdateTestSuiteJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// RunTestSuiteWithBody request with any body
 	RunTestSuiteWithBody(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -67757,6 +73240,126 @@ func (c *Client) TestAgent(ctx context.Context, id string, reqEditors ...Request
 	return c.Client.Do(req)
 }
 
+func (c *Client) GetPullRequestUsage(ctx context.Context, params *GetPullRequestUsageParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetPullRequestUsageRequest(c.Server, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PostLangyControlFramesWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPostLangyControlFramesRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PostLangyControlFrames(ctx context.Context, body PostLangyControlFramesJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPostLangyControlFramesRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PollLangyControlSession(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPollLangyControlSessionRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) RegisterLangyControlSessionWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewRegisterLangyControlSessionRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) RegisterLangyControlSession(ctx context.Context, body RegisterLangyControlSessionJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewRegisterLangyControlSessionRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ListLangyControlRequests(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListLangyControlRequestsRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ApproveLangyControlRequestWithBody(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewApproveLangyControlRequestRequestWithBody(c.Server, id, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ApproveLangyControlRequest(ctx context.Context, id string, body ApproveLangyControlRequestJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewApproveLangyControlRequestRequest(c.Server, id, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CancelLangyControlRequest(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCancelLangyControlRequestRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
 func (c *Client) GetApiV1ProjectsByProjectIdAnalyticsCharts(ctx context.Context, projectId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewGetApiV1ProjectsByProjectIdAnalyticsChartsRequest(c.Server, projectId)
 	if err != nil {
@@ -67877,8 +73480,8 @@ func (c *Client) PutApiV1ProjectsByProjectIdAnalyticsChartsByChartIdPlacement(ct
 	return c.Client.Do(req)
 }
 
-func (c *Client) PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseWithBody(ctx context.Context, projectId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewPostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseRequestWithBody(c.Server, projectId, contentType, body)
+func (c *Client) GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets(ctx context.Context, projectId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsRequest(c.Server, projectId)
 	if err != nil {
 		return nil, err
 	}
@@ -67889,8 +73492,8 @@ func (c *Client) PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseWithBody(ct
 	return c.Client.Do(req)
 }
 
-func (c *Client) PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouse(ctx context.Context, projectId string, body PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewPostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseRequest(c.Server, projectId, body)
+func (c *Client) PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsWithBody(ctx context.Context, projectId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsRequestWithBody(c.Server, projectId, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -67901,8 +73504,116 @@ func (c *Client) PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouse(ctx contex
 	return c.Client.Do(req)
 }
 
-func (c *Client) GetApiV1ProjectsByProjectIdAnalyticsSchema(ctx context.Context, projectId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetApiV1ProjectsByProjectIdAnalyticsSchemaRequest(c.Server, projectId)
+func (c *Client) PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets(ctx context.Context, projectId string, body PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsRequest(c.Server, projectId, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) DeleteApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId(ctx context.Context, projectId string, widgetId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeleteApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdRequest(c.Server, projectId, widgetId)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId(ctx context.Context, projectId string, widgetId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdRequest(c.Server, projectId, widgetId)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdWithBody(ctx context.Context, projectId string, widgetId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdRequestWithBody(c.Server, projectId, widgetId, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId(ctx context.Context, projectId string, widgetId string, body PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdRequest(c.Server, projectId, widgetId, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboardWithBody(ctx context.Context, projectId string, widgetId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboardRequestWithBody(c.Server, projectId, widgetId, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard(ctx context.Context, projectId string, widgetId string, body PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboardJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboardRequest(c.Server, projectId, widgetId, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PostApiV1QueryWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPostApiV1QueryRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PostApiV1Query(ctx context.Context, body PostApiV1QueryJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPostApiV1QueryRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetApiV1QuerySchema(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetApiV1QuerySchemaRequest(c.Server)
 	if err != nil {
 		return nil, err
 	}
@@ -68057,8 +73768,8 @@ func (c *Client) GetTestSuite(ctx context.Context, id string, reqEditors ...Requ
 	return c.Client.Do(req)
 }
 
-func (c *Client) RenameTestSuiteWithBody(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewRenameTestSuiteRequestWithBody(c.Server, id, contentType, body)
+func (c *Client) UpdateTestSuiteWithBody(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateTestSuiteRequestWithBody(c.Server, id, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -68069,8 +73780,8 @@ func (c *Client) RenameTestSuiteWithBody(ctx context.Context, id string, content
 	return c.Client.Do(req)
 }
 
-func (c *Client) RenameTestSuite(ctx context.Context, id string, body RenameTestSuiteJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewRenameTestSuiteRequest(c.Server, id, body)
+func (c *Client) UpdateTestSuite(ctx context.Context, id string, body UpdateTestSuiteJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateTestSuiteRequest(c.Server, id, body)
 	if err != nil {
 		return nil, err
 	}
@@ -79777,6 +85488,291 @@ func NewTestAgentRequest(server string, id string) (*http.Request, error) {
 	return req, nil
 }
 
+// NewGetPullRequestUsageRequest generates requests for GetPullRequestUsage
+func NewGetPullRequestUsageRequest(server string, params *GetPullRequestUsageParams) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/coding-agent/pull-request-usage")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		// queryValues collects non-styled parameters (passthrough, JSON)
+		// that are safe to round-trip through url.Values.Encode().
+		queryValues := queryURL.Query()
+		// rawQueryFragments collects pre-encoded query fragments from
+		// styled parameters, preserving literal commas as delimiters
+		// per the OpenAPI spec (e.g. "color=blue,black,brown").
+		var rawQueryFragments []string
+
+		if queryFrag, err := runtime.StyleParamWithOptions("form", true, "repository", params.Repository, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+			return nil, err
+		} else {
+			for _, qp := range strings.Split(queryFrag, "&") {
+				rawQueryFragments = append(rawQueryFragments, qp)
+			}
+		}
+
+		if queryFrag, err := runtime.StyleParamWithOptions("form", true, "pullRequest", params.PullRequest, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "integer", Format: ""}); err != nil {
+			return nil, err
+		} else {
+			for _, qp := range strings.Split(queryFrag, "&") {
+				rawQueryFragments = append(rawQueryFragments, qp)
+			}
+		}
+
+		if params.Host != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "host", *params.Host, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if encoded := queryValues.Encode(); encoded != "" {
+			rawQueryFragments = append(rawQueryFragments, encoded)
+		}
+		queryURL.RawQuery = strings.Join(rawQueryFragments, "&")
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewPostLangyControlFramesRequest calls the generic PostLangyControlFrames builder with application/json body
+func NewPostLangyControlFramesRequest(server string, body PostLangyControlFramesJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewPostLangyControlFramesRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewPostLangyControlFramesRequestWithBody generates requests for PostLangyControlFrames with any type of body
+func NewPostLangyControlFramesRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/langy/control/connect/frames")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewPollLangyControlSessionRequest generates requests for PollLangyControlSession
+func NewPollLangyControlSessionRequest(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/langy/control/connect/poll")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewRegisterLangyControlSessionRequest calls the generic RegisterLangyControlSession builder with application/json body
+func NewRegisterLangyControlSessionRequest(server string, body RegisterLangyControlSessionJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewRegisterLangyControlSessionRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewRegisterLangyControlSessionRequestWithBody generates requests for RegisterLangyControlSession with any type of body
+func NewRegisterLangyControlSessionRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/langy/control/connect/register")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewListLangyControlRequestsRequest generates requests for ListLangyControlRequests
+func NewListLangyControlRequestsRequest(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/langy/control/requests")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewApproveLangyControlRequestRequest calls the generic ApproveLangyControlRequest builder with application/json body
+func NewApproveLangyControlRequestRequest(server string, id string, body ApproveLangyControlRequestJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewApproveLangyControlRequestRequestWithBody(server, id, "application/json", bodyReader)
+}
+
+// NewApproveLangyControlRequestRequestWithBody generates requests for ApproveLangyControlRequest with any type of body
+func NewApproveLangyControlRequestRequestWithBody(server string, id string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/langy/control/requests/%s/approve", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewCancelLangyControlRequestRequest generates requests for CancelLangyControlRequest
+func NewCancelLangyControlRequestRequest(server string, id string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/langy/control/requests/%s/cancel", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewGetApiV1ProjectsByProjectIdAnalyticsChartsRequest generates requests for GetApiV1ProjectsByProjectIdAnalyticsCharts
 func NewGetApiV1ProjectsByProjectIdAnalyticsChartsRequest(server string, projectId string) (*http.Request, error) {
 	var err error
@@ -80089,19 +86085,8 @@ func NewPutApiV1ProjectsByProjectIdAnalyticsChartsByChartIdPlacementRequestWithB
 	return req, nil
 }
 
-// NewPostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseRequest calls the generic PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouse builder with application/json body
-func NewPostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseRequest(server string, projectId string, body PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONRequestBody) (*http.Request, error) {
-	var bodyReader io.Reader
-	buf, err := json.Marshal(body)
-	if err != nil {
-		return nil, err
-	}
-	bodyReader = bytes.NewReader(buf)
-	return NewPostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseRequestWithBody(server, projectId, "application/json", bodyReader)
-}
-
-// NewPostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseRequestWithBody generates requests for PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouse with any type of body
-func NewPostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseRequestWithBody(server string, projectId string, contentType string, body io.Reader) (*http.Request, error) {
+// NewGetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsRequest generates requests for GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets
+func NewGetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsRequest(server string, projectId string) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -80116,7 +86101,52 @@ func NewPostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseRequestWithBody(serv
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v1/projects/%s/analytics/query/clickhouse", pathParam0)
+	operationPath := fmt.Sprintf("/api/v1/projects/%s/analytics/dashboard-widgets", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewPostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsRequest calls the generic PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets builder with application/json body
+func NewPostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsRequest(server string, projectId string, body PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewPostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsRequestWithBody(server, projectId, "application/json", bodyReader)
+}
+
+// NewPostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsRequestWithBody generates requests for PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets with any type of body
+func NewPostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsRequestWithBody(server string, projectId string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "projectId", projectId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/projects/%s/analytics/dashboard-widgets", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -80136,8 +86166,8 @@ func NewPostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseRequestWithBody(serv
 	return req, nil
 }
 
-// NewGetApiV1ProjectsByProjectIdAnalyticsSchemaRequest generates requests for GetApiV1ProjectsByProjectIdAnalyticsSchema
-func NewGetApiV1ProjectsByProjectIdAnalyticsSchemaRequest(server string, projectId string) (*http.Request, error) {
+// NewDeleteApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdRequest generates requests for DeleteApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId
+func NewDeleteApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdRequest(server string, projectId string, widgetId string) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -80147,12 +86177,235 @@ func NewGetApiV1ProjectsByProjectIdAnalyticsSchemaRequest(server string, project
 		return nil, err
 	}
 
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "widgetId", widgetId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
 	serverURL, err := url.Parse(server)
 	if err != nil {
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v1/projects/%s/analytics/schema", pathParam0)
+	operationPath := fmt.Sprintf("/api/v1/projects/%s/analytics/dashboard-widgets/%s", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodDelete, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewGetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdRequest generates requests for GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId
+func NewGetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdRequest(server string, projectId string, widgetId string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "projectId", projectId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "widgetId", widgetId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/projects/%s/analytics/dashboard-widgets/%s", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewPatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdRequest calls the generic PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId builder with application/json body
+func NewPatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdRequest(server string, projectId string, widgetId string, body PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewPatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdRequestWithBody(server, projectId, widgetId, "application/json", bodyReader)
+}
+
+// NewPatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdRequestWithBody generates requests for PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId with any type of body
+func NewPatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdRequestWithBody(server string, projectId string, widgetId string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "projectId", projectId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "widgetId", widgetId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/projects/%s/analytics/dashboard-widgets/%s", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPatch, queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewPostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboardRequest calls the generic PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard builder with application/json body
+func NewPostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboardRequest(server string, projectId string, widgetId string, body PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboardJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewPostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboardRequestWithBody(server, projectId, widgetId, "application/json", bodyReader)
+}
+
+// NewPostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboardRequestWithBody generates requests for PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard with any type of body
+func NewPostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboardRequestWithBody(server string, projectId string, widgetId string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "projectId", projectId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "widgetId", widgetId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/projects/%s/analytics/dashboard-widgets/%s/dashboard", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewPostApiV1QueryRequest calls the generic PostApiV1Query builder with application/json body
+func NewPostApiV1QueryRequest(server string, body PostApiV1QueryJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewPostApiV1QueryRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewPostApiV1QueryRequestWithBody generates requests for PostApiV1Query with any type of body
+func NewPostApiV1QueryRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/query")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewGetApiV1QuerySchemaRequest generates requests for GetApiV1QuerySchema
+func NewGetApiV1QuerySchemaRequest(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/query/schema")
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -80541,19 +86794,19 @@ func NewGetTestSuiteRequest(server string, id string) (*http.Request, error) {
 	return req, nil
 }
 
-// NewRenameTestSuiteRequest calls the generic RenameTestSuite builder with application/json body
-func NewRenameTestSuiteRequest(server string, id string, body RenameTestSuiteJSONRequestBody) (*http.Request, error) {
+// NewUpdateTestSuiteRequest calls the generic UpdateTestSuite builder with application/json body
+func NewUpdateTestSuiteRequest(server string, id string, body UpdateTestSuiteJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
-	return NewRenameTestSuiteRequestWithBody(server, id, "application/json", bodyReader)
+	return NewUpdateTestSuiteRequestWithBody(server, id, "application/json", bodyReader)
 }
 
-// NewRenameTestSuiteRequestWithBody generates requests for RenameTestSuite with any type of body
-func NewRenameTestSuiteRequestWithBody(server string, id string, contentType string, body io.Reader) (*http.Request, error) {
+// NewUpdateTestSuiteRequestWithBody generates requests for UpdateTestSuite with any type of body
+func NewUpdateTestSuiteRequestWithBody(server string, id string, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -82459,6 +88712,33 @@ type ClientWithResponsesInterface interface {
 	// TestAgentWithResponse request
 	TestAgentWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*TestAgentResponse, error)
 
+	// GetPullRequestUsageWithResponse request
+	GetPullRequestUsageWithResponse(ctx context.Context, params *GetPullRequestUsageParams, reqEditors ...RequestEditorFn) (*GetPullRequestUsageResponse, error)
+
+	// PostLangyControlFramesWithBodyWithResponse request with any body
+	PostLangyControlFramesWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostLangyControlFramesResponse, error)
+
+	PostLangyControlFramesWithResponse(ctx context.Context, body PostLangyControlFramesJSONRequestBody, reqEditors ...RequestEditorFn) (*PostLangyControlFramesResponse, error)
+
+	// PollLangyControlSessionWithResponse request
+	PollLangyControlSessionWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*PollLangyControlSessionResponse, error)
+
+	// RegisterLangyControlSessionWithBodyWithResponse request with any body
+	RegisterLangyControlSessionWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*RegisterLangyControlSessionResponse, error)
+
+	RegisterLangyControlSessionWithResponse(ctx context.Context, body RegisterLangyControlSessionJSONRequestBody, reqEditors ...RequestEditorFn) (*RegisterLangyControlSessionResponse, error)
+
+	// ListLangyControlRequestsWithResponse request
+	ListLangyControlRequestsWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListLangyControlRequestsResponse, error)
+
+	// ApproveLangyControlRequestWithBodyWithResponse request with any body
+	ApproveLangyControlRequestWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*ApproveLangyControlRequestResponse, error)
+
+	ApproveLangyControlRequestWithResponse(ctx context.Context, id string, body ApproveLangyControlRequestJSONRequestBody, reqEditors ...RequestEditorFn) (*ApproveLangyControlRequestResponse, error)
+
+	// CancelLangyControlRequestWithResponse request
+	CancelLangyControlRequestWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*CancelLangyControlRequestResponse, error)
+
 	// GetApiV1ProjectsByProjectIdAnalyticsChartsWithResponse request
 	GetApiV1ProjectsByProjectIdAnalyticsChartsWithResponse(ctx context.Context, projectId string, reqEditors ...RequestEditorFn) (*GetApiV1ProjectsByProjectIdAnalyticsChartsResponse, error)
 
@@ -82486,13 +88766,37 @@ type ClientWithResponsesInterface interface {
 
 	PutApiV1ProjectsByProjectIdAnalyticsChartsByChartIdPlacementWithResponse(ctx context.Context, projectId string, chartId string, body PutApiV1ProjectsByProjectIdAnalyticsChartsByChartIdPlacementJSONRequestBody, reqEditors ...RequestEditorFn) (*PutApiV1ProjectsByProjectIdAnalyticsChartsByChartIdPlacementResponse, error)
 
-	// PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseWithBodyWithResponse request with any body
-	PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseWithBodyWithResponse(ctx context.Context, projectId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseResponse, error)
+	// GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsWithResponse request
+	GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsWithResponse(ctx context.Context, projectId string, reqEditors ...RequestEditorFn) (*GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsResponse, error)
 
-	PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseWithResponse(ctx context.Context, projectId string, body PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONRequestBody, reqEditors ...RequestEditorFn) (*PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseResponse, error)
+	// PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsWithBodyWithResponse request with any body
+	PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsWithBodyWithResponse(ctx context.Context, projectId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsResponse, error)
 
-	// GetApiV1ProjectsByProjectIdAnalyticsSchemaWithResponse request
-	GetApiV1ProjectsByProjectIdAnalyticsSchemaWithResponse(ctx context.Context, projectId string, reqEditors ...RequestEditorFn) (*GetApiV1ProjectsByProjectIdAnalyticsSchemaResponse, error)
+	PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsWithResponse(ctx context.Context, projectId string, body PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONRequestBody, reqEditors ...RequestEditorFn) (*PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsResponse, error)
+
+	// DeleteApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdWithResponse request
+	DeleteApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdWithResponse(ctx context.Context, projectId string, widgetId string, reqEditors ...RequestEditorFn) (*DeleteApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdResponse, error)
+
+	// GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdWithResponse request
+	GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdWithResponse(ctx context.Context, projectId string, widgetId string, reqEditors ...RequestEditorFn) (*GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdResponse, error)
+
+	// PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdWithBodyWithResponse request with any body
+	PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdWithBodyWithResponse(ctx context.Context, projectId string, widgetId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdResponse, error)
+
+	PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdWithResponse(ctx context.Context, projectId string, widgetId string, body PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONRequestBody, reqEditors ...RequestEditorFn) (*PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdResponse, error)
+
+	// PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboardWithBodyWithResponse request with any body
+	PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboardWithBodyWithResponse(ctx context.Context, projectId string, widgetId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboardResponse, error)
+
+	PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboardWithResponse(ctx context.Context, projectId string, widgetId string, body PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboardJSONRequestBody, reqEditors ...RequestEditorFn) (*PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboardResponse, error)
+
+	// PostApiV1QueryWithBodyWithResponse request with any body
+	PostApiV1QueryWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostApiV1QueryResponse, error)
+
+	PostApiV1QueryWithResponse(ctx context.Context, body PostApiV1QueryJSONRequestBody, reqEditors ...RequestEditorFn) (*PostApiV1QueryResponse, error)
+
+	// GetApiV1QuerySchemaWithResponse request
+	GetApiV1QuerySchemaWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetApiV1QuerySchemaResponse, error)
 
 	// ListRunPlansWithResponse request
 	ListRunPlansWithResponse(ctx context.Context, params *ListRunPlansParams, reqEditors ...RequestEditorFn) (*ListRunPlansResponse, error)
@@ -82527,10 +88831,10 @@ type ClientWithResponsesInterface interface {
 	// GetTestSuiteWithResponse request
 	GetTestSuiteWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*GetTestSuiteResponse, error)
 
-	// RenameTestSuiteWithBodyWithResponse request with any body
-	RenameTestSuiteWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*RenameTestSuiteResponse, error)
+	// UpdateTestSuiteWithBodyWithResponse request with any body
+	UpdateTestSuiteWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateTestSuiteResponse, error)
 
-	RenameTestSuiteWithResponse(ctx context.Context, id string, body RenameTestSuiteJSONRequestBody, reqEditors ...RequestEditorFn) (*RenameTestSuiteResponse, error)
+	UpdateTestSuiteWithResponse(ctx context.Context, id string, body UpdateTestSuiteJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateTestSuiteResponse, error)
 
 	// RunTestSuiteWithBodyWithResponse request with any body
 	RunTestSuiteWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*RunTestSuiteResponse, error)
@@ -83135,8 +89439,10 @@ func (r PostApiAnalyticsTimeseriesResponse) ContentType() string {
 type GetApiAnnotationsResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *[]Annotation
-	JSON400      *Error
+	JSON200      *struct {
+		Data []Annotation `json:"data"`
+	}
+	JSON400 *Error
 }
 
 // Status returns HTTPResponse.Status
@@ -83166,8 +89472,10 @@ func (r GetApiAnnotationsResponse) ContentType() string {
 type GetApiAnnotationsTraceIdResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *[]Annotation
-	JSON400      *Error
+	JSON200      *struct {
+		Data []Annotation `json:"data"`
+	}
+	JSON400 *Error
 }
 
 // Status returns HTTPResponse.Status
@@ -83197,8 +89505,10 @@ func (r GetApiAnnotationsTraceIdResponse) ContentType() string {
 type PostApiAnnotationsTraceIdResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *Annotation
-	JSON400      *Error
+	JSON200      *struct {
+		Data Annotation `json:"data"`
+	}
+	JSON400 *Error
 }
 
 // Status returns HTTPResponse.Status
@@ -83262,8 +89572,10 @@ func (r DeleteApiAnnotationsIdResponse) ContentType() string {
 type GetApiAnnotationsIdResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *Annotation
-	JSON400      *Error
+	JSON200      *struct {
+		Data Annotation `json:"data"`
+	}
+	JSON400 *Error
 }
 
 // Status returns HTTPResponse.Status
@@ -83294,8 +89606,7 @@ type PatchApiAnnotationsIdResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *struct {
-		Message *string `json:"message,omitempty"`
-		Status  *string `json:"status,omitempty"`
+		Data Annotation `json:"data"`
 	}
 	JSON400 *Error
 }
@@ -93338,7 +99649,10 @@ type GetApiScenariosResponse struct {
 	HTTPResponse *http.Response
 	JSON200      *[]struct {
 		Criteria []string `json:"criteria"`
-		Id       string   `json:"id"`
+
+		// Fields The value this scenario carries for each field its test suite declares, keyed by field identifier. A field with no value has no key. Absent on servers that predate suite fields.
+		Fields *map[string]GetApiScenarios200JSONResponseBody_Fields_AdditionalProperties `json:"fields,omitempty"`
+		Id     string                                                                     `json:"id"`
 
 		// JudgeModel The model that judges the run, or null for the project default. Absent on servers that predate model overrides on this family.
 		JudgeModel *string  `json:"judgeModel,omitempty"`
@@ -93415,7 +99729,10 @@ type PostApiScenariosResponse struct {
 	HTTPResponse *http.Response
 	JSON201      *struct {
 		Criteria []string `json:"criteria"`
-		Id       string   `json:"id"`
+
+		// Fields The value this scenario carries for each field its test suite declares, keyed by field identifier. A field with no value has no key. Absent on servers that predate suite fields.
+		Fields *map[string]PostApiScenarios201JSONResponseBody_Fields_AdditionalProperties `json:"fields,omitempty"`
+		Id     string                                                                      `json:"id"`
 
 		// JudgeModel The model that judges the run, or null for the project default. Absent on servers that predate model overrides on this family.
 		JudgeModel *string  `json:"judgeModel,omitempty"`
@@ -93545,7 +99862,10 @@ type GetApiScenariosByIdResponse struct {
 	HTTPResponse *http.Response
 	JSON200      *struct {
 		Criteria []string `json:"criteria"`
-		Id       string   `json:"id"`
+
+		// Fields The value this scenario carries for each field its test suite declares, keyed by field identifier. A field with no value has no key. Absent on servers that predate suite fields.
+		Fields *map[string]GetApiScenariosById200JSONResponseBody_Fields_AdditionalProperties `json:"fields,omitempty"`
+		Id     string                                                                         `json:"id"`
 
 		// JudgeModel The model that judges the run, or null for the project default. Absent on servers that predate model overrides on this family.
 		JudgeModel *string  `json:"judgeModel,omitempty"`
@@ -93626,7 +99946,10 @@ type PatchApiScenariosByIdResponse struct {
 	HTTPResponse *http.Response
 	JSON200      *struct {
 		Criteria []string `json:"criteria"`
-		Id       string   `json:"id"`
+
+		// Fields The value this scenario carries for each field its test suite declares, keyed by field identifier. A field with no value has no key. Absent on servers that predate suite fields.
+		Fields *map[string]PatchApiScenariosById200JSONResponseBody_Fields_AdditionalProperties `json:"fields,omitempty"`
+		Id     string                                                                           `json:"id"`
 
 		// JudgeModel The model that judges the run, or null for the project default. Absent on servers that predate model overrides on this family.
 		JudgeModel *string  `json:"judgeModel,omitempty"`
@@ -93707,7 +100030,10 @@ type PutApiScenariosByIdResponse struct {
 	HTTPResponse *http.Response
 	JSON200      *struct {
 		Criteria []string `json:"criteria"`
-		Id       string   `json:"id"`
+
+		// Fields The value this scenario carries for each field its test suite declares, keyed by field identifier. A field with no value has no key. Absent on servers that predate suite fields.
+		Fields *map[string]PutApiScenariosById200JSONResponseBody_Fields_AdditionalProperties `json:"fields,omitempty"`
+		Id     string                                                                         `json:"id"`
 
 		// JudgeModel The model that judges the run, or null for the project default. Absent on servers that predate model overrides on this family.
 		JudgeModel *string  `json:"judgeModel,omitempty"`
@@ -93881,12 +100207,15 @@ type GetApiScenariosByIdVersionsByVersionResponse struct {
 
 		// Snapshot The editable content of the scenario as this version saved it.
 		Snapshot struct {
-			Criteria   []string `json:"criteria"`
-			JudgeModel *string  `json:"judgeModel"`
-			Labels     []string `json:"labels"`
-			MaxTurns   *float32 `json:"maxTurns"`
-			MinTurns   *float32 `json:"minTurns"`
-			Name       string   `json:"name"`
+			Criteria []string `json:"criteria"`
+
+			// Fields The field values as this version saved them. Absent on servers that predate suite fields.
+			Fields     *map[string]GetApiScenariosByIdVersionsByVersion200JSONResponseBody_Snapshot_Fields_AdditionalProperties `json:"fields,omitempty"`
+			JudgeModel *string                                                                                                  `json:"judgeModel"`
+			Labels     []string                                                                                                 `json:"labels"`
+			MaxTurns   *float32                                                                                                 `json:"maxTurns"`
+			MinTurns   *float32                                                                                                 `json:"minTurns"`
+			Name       string                                                                                                   `json:"name"`
 			Parameters []struct {
 				DefaultValue *GetApiScenariosByIdVersionsByVersion200JSONResponseBody_Snapshot_Parameters_DefaultValue   `json:"defaultValue,omitempty"`
 				Description  *string                                                                                     `json:"description,omitempty"`
@@ -95483,7 +101812,24 @@ type GetApiSimulationRunsResponse struct {
 			Note        *string `json:"note,omitempty"`
 			PlatformUrl string  `json:"platformUrl"`
 			Results     *struct {
-				Error         *string   `json:"error,omitempty"`
+				Error *string `json:"error,omitempty"`
+
+				// Evaluations One result per evaluator that ran on the scenario. Absent on a run with no evaluators, and on servers that predate evaluators.
+				Evaluations *[]struct {
+					Cost *struct {
+						Amount   float32 `json:"amount"`
+						Currency string  `json:"currency"`
+					} `json:"cost,omitempty"`
+					Details     *string                                                             `json:"details,omitempty"`
+					EvaluatorId string                                                              `json:"evaluatorId"`
+					Inputs      *map[string]string                                                  `json:"inputs,omitempty"`
+					Label       *string                                                             `json:"label,omitempty"`
+					Name        string                                                              `json:"name"`
+					Passed      *bool                                                               `json:"passed,omitempty"`
+					Required    bool                                                                `json:"required"`
+					Score       *float32                                                            `json:"score,omitempty"`
+					Status      GetApiSimulationRuns200JSONResponseBodyRunsResultsEvaluationsStatus `json:"status"`
+				} `json:"evaluations,omitempty"`
 				MetCriteria   *[]string `json:"metCriteria,omitempty"`
 				Reasoning     *string   `json:"reasoning,omitempty"`
 				UnmetCriteria *[]string `json:"unmetCriteria,omitempty"`
@@ -95702,7 +102048,24 @@ type GetApiSimulationRunsByScenarioRunIdResponse struct {
 		Note        *string `json:"note,omitempty"`
 		PlatformUrl string  `json:"platformUrl"`
 		Results     *struct {
-			Error         *string   `json:"error,omitempty"`
+			Error *string `json:"error,omitempty"`
+
+			// Evaluations One result per evaluator that ran on the scenario. Absent on a run with no evaluators, and on servers that predate evaluators.
+			Evaluations *[]struct {
+				Cost *struct {
+					Amount   float32 `json:"amount"`
+					Currency string  `json:"currency"`
+				} `json:"cost,omitempty"`
+				Details     *string                                                                        `json:"details,omitempty"`
+				EvaluatorId string                                                                         `json:"evaluatorId"`
+				Inputs      *map[string]string                                                             `json:"inputs,omitempty"`
+				Label       *string                                                                        `json:"label,omitempty"`
+				Name        string                                                                         `json:"name"`
+				Passed      *bool                                                                          `json:"passed,omitempty"`
+				Required    bool                                                                           `json:"required"`
+				Score       *float32                                                                       `json:"score,omitempty"`
+				Status      GetApiSimulationRunsByScenarioRunId200JSONResponseBodyResultsEvaluationsStatus `json:"status"`
+			} `json:"evaluations,omitempty"`
 			MetCriteria   *[]string `json:"metCriteria,omitempty"`
 			Reasoning     *string   `json:"reasoning,omitempty"`
 			UnmetCriteria *[]string `json:"unmetCriteria,omitempty"`
@@ -97406,6 +103769,9 @@ type ListAgentsResponse struct {
 			LastSeenAt *string `json:"lastSeenAt"`
 			Name       string  `json:"name"`
 
+			// NotSelectableReason Why the agent cannot be run by this credential. Null when it can.
+			NotSelectableReason *ListAgents200JSONResponseBodyDataNotSelectableReason `json:"notSelectableReason"`
+
 			// Owner The person a personal development agent belongs to. Null when the agent is shared or host-scoped.
 			Owner *struct {
 				Name   *string `json:"name"`
@@ -97426,6 +103792,9 @@ type ListAgentsResponse struct {
 				Type         *ListAgents200JSONResponseBodyDataParametersType              `json:"type,omitempty"`
 			} `json:"parameters"`
 			PlatformUrl string `json:"platformUrl"`
+
+			// Selectable Whether the credential making this request can run simulations against the agent. False for a personal development agent that belongs to somebody else, which is listed all the same so it can be told apart from the other agents of the same name.
+			Selectable bool `json:"selectable"`
 
 			// Status online while at least one process running the connected agent is connected; offline otherwise, and always for every other kind.
 			Status ListAgents200JSONResponseBodyDataStatus `json:"status"`
@@ -97502,6 +103871,9 @@ type CreateAgentResponse struct {
 		LastSeenAt *string `json:"lastSeenAt"`
 		Name       string  `json:"name"`
 
+		// NotSelectableReason Why the agent cannot be run by this credential. Null when it can.
+		NotSelectableReason *CreateAgent201JSONResponseBodyNotSelectableReason `json:"notSelectableReason"`
+
 		// Owner The person a personal development agent belongs to. Null when the agent is shared or host-scoped.
 		Owner *struct {
 			Name   *string `json:"name"`
@@ -97522,6 +103894,9 @@ type CreateAgentResponse struct {
 			Type         *CreateAgent201JSONResponseBodyParametersType             `json:"type,omitempty"`
 		} `json:"parameters"`
 		PlatformUrl string `json:"platformUrl"`
+
+		// Selectable Whether the credential making this request can run simulations against the agent. False for a personal development agent that belongs to somebody else, which is listed all the same so it can be told apart from the other agents of the same name.
+		Selectable bool `json:"selectable"`
 
 		// Status online while at least one process running the connected agent is connected; offline otherwise, and always for every other kind.
 		Status CreateAgent201JSONResponseBodyStatus `json:"status"`
@@ -97728,6 +104103,9 @@ type GetAgentResponse struct {
 		LastSeenAt *string `json:"lastSeenAt"`
 		Name       string  `json:"name"`
 
+		// NotSelectableReason Why the agent cannot be run by this credential. Null when it can.
+		NotSelectableReason *GetAgent200JSONResponseBodyNotSelectableReason `json:"notSelectableReason"`
+
 		// Owner The person a personal development agent belongs to. Null when the agent is shared or host-scoped.
 		Owner *struct {
 			Name   *string `json:"name"`
@@ -97748,6 +104126,9 @@ type GetAgentResponse struct {
 			Type         *GetAgent200JSONResponseBodyParametersType             `json:"type,omitempty"`
 		} `json:"parameters"`
 		PlatformUrl string `json:"platformUrl"`
+
+		// Selectable Whether the credential making this request can run simulations against the agent. False for a personal development agent that belongs to somebody else, which is listed all the same so it can be told apart from the other agents of the same name.
+		Selectable bool `json:"selectable"`
 
 		// Status online while at least one process running the connected agent is connected; offline otherwise, and always for every other kind.
 		Status GetAgent200JSONResponseBodyStatus `json:"status"`
@@ -97817,6 +104198,9 @@ type UpdateAgentResponse struct {
 		LastSeenAt *string `json:"lastSeenAt"`
 		Name       string  `json:"name"`
 
+		// NotSelectableReason Why the agent cannot be run by this credential. Null when it can.
+		NotSelectableReason *UpdateAgent200JSONResponseBodyNotSelectableReason `json:"notSelectableReason"`
+
 		// Owner The person a personal development agent belongs to. Null when the agent is shared or host-scoped.
 		Owner *struct {
 			Name   *string `json:"name"`
@@ -97837,6 +104221,9 @@ type UpdateAgentResponse struct {
 			Type         *UpdateAgent200JSONResponseBodyParametersType             `json:"type,omitempty"`
 		} `json:"parameters"`
 		PlatformUrl string `json:"platformUrl"`
+
+		// Selectable Whether the credential making this request can run simulations against the agent. False for a personal development agent that belongs to somebody else, which is listed all the same so it can be told apart from the other agents of the same name.
+		Selectable bool `json:"selectable"`
 
 		// Status online while at least one process running the connected agent is connected; offline otherwise, and always for every other kind.
 		Status UpdateAgent200JSONResponseBodyStatus `json:"status"`
@@ -97906,6 +104293,9 @@ type ReplaceAgentResponse struct {
 		LastSeenAt *string `json:"lastSeenAt"`
 		Name       string  `json:"name"`
 
+		// NotSelectableReason Why the agent cannot be run by this credential. Null when it can.
+		NotSelectableReason *ReplaceAgent200JSONResponseBodyNotSelectableReason `json:"notSelectableReason"`
+
 		// Owner The person a personal development agent belongs to. Null when the agent is shared or host-scoped.
 		Owner *struct {
 			Name   *string `json:"name"`
@@ -97926,6 +104316,9 @@ type ReplaceAgentResponse struct {
 			Type         *ReplaceAgent200JSONResponseBodyParametersType             `json:"type,omitempty"`
 		} `json:"parameters"`
 		PlatformUrl string `json:"platformUrl"`
+
+		// Selectable Whether the credential making this request can run simulations against the agent. False for a personal development agent that belongs to somebody else, which is listed all the same so it can be told apart from the other agents of the same name.
+		Selectable bool `json:"selectable"`
 
 		// Status online while at least one process running the connected agent is connected; offline otherwise, and always for every other kind.
 		Status ReplaceAgent200JSONResponseBodyStatus `json:"status"`
@@ -98035,6 +104428,305 @@ func (r TestAgentResponse) StatusCode() int {
 
 // ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
 func (r TestAgentResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type GetPullRequestUsageResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *struct {
+		ModelBreakdown []struct {
+			CacheCreationTokens float32  `json:"cacheCreationTokens"`
+			CacheReadTokens     float32  `json:"cacheReadTokens"`
+			CostUsd             *float32 `json:"costUsd"`
+			InputTokens         float32  `json:"inputTokens"`
+			Model               string   `json:"model"`
+			OutputTokens        float32  `json:"outputTokens"`
+			TokensKnown         bool     `json:"tokensKnown"`
+			TotalTokens         float32  `json:"totalTokens"`
+		} `json:"modelBreakdown"`
+		PullRequest struct {
+			AuthorLogin        *string  `json:"authorLogin"`
+			HeadBranch         string   `json:"headBranch"`
+			HtmlUrl            string   `json:"htmlUrl"`
+			IsDraft            bool     `json:"isDraft"`
+			PrClosedAtMs       *float32 `json:"prClosedAtMs"`
+			PrCreatedAtMs      float32  `json:"prCreatedAtMs"`
+			PrMergedAtMs       *float32 `json:"prMergedAtMs"`
+			PrNumber           float32  `json:"prNumber"`
+			RepositoryFullName string   `json:"repositoryFullName"`
+			RepositoryHost     string   `json:"repositoryHost"`
+			State              string   `json:"state"`
+		} `json:"pullRequest"`
+		Rows []struct {
+			Agent                string   `json:"agent"`
+			BilledCostUsd        *float32 `json:"billedCostUsd"`
+			CacheCreationTokens  float32  `json:"cacheCreationTokens"`
+			CacheReadTokens      float32  `json:"cacheReadTokens"`
+			ContributorIsProject bool     `json:"contributorIsProject"`
+			ContributorLabel     string   `json:"contributorLabel"`
+			CostUsd              *float32 `json:"costUsd"`
+			InputTokens          float32  `json:"inputTokens"`
+			Models               []string `json:"models"`
+			NonBilledCostUsd     *float32 `json:"nonBilledCostUsd"`
+			OutputTokens         float32  `json:"outputTokens"`
+			ProjectId            string   `json:"projectId"`
+			ProjectSlug          string   `json:"projectSlug"`
+			SessionsCount        float32  `json:"sessionsCount"`
+			TotalTokens          float32  `json:"totalTokens"`
+		} `json:"rows"`
+		Totals struct {
+			BilledCostUsd       *float32 `json:"billedCostUsd"`
+			CacheCreationTokens float32  `json:"cacheCreationTokens"`
+			CacheReadTokens     float32  `json:"cacheReadTokens"`
+			CostUsd             *float32 `json:"costUsd"`
+			InputTokens         float32  `json:"inputTokens"`
+			NonBilledCostUsd    *float32 `json:"nonBilledCostUsd"`
+			OutputTokens        float32  `json:"outputTokens"`
+			SessionsCount       float32  `json:"sessionsCount"`
+			TotalTokens         float32  `json:"totalTokens"`
+		} `json:"totals"`
+	}
+}
+
+// Status returns HTTPResponse.Status
+func (r GetPullRequestUsageResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetPullRequestUsageResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r GetPullRequestUsageResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type PostLangyControlFramesResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *struct {
+		// Accepted How many frames were taken.
+		Accepted int `json:"accepted"`
+	}
+}
+
+// Status returns HTTPResponse.Status
+func (r PostLangyControlFramesResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r PostLangyControlFramesResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r PostLangyControlFramesResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type PollLangyControlSessionResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *struct {
+		// Frames The frames waiting for the folder; empty once the poll wait passes with none.
+		Frames []PollLangyControlSession200JSONResponseBody_Frames_Item `json:"frames"`
+	}
+}
+
+// Status returns HTTPResponse.Status
+func (r PollLangyControlSessionResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r PollLangyControlSessionResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r PollLangyControlSessionResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type RegisterLangyControlSessionResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *struct {
+		// Frame The registered frame, or the refused frame with its reason.
+		Frame RegisterLangyControlSession200JSONResponseBody_Frame `json:"frame"`
+
+		// InstanceToken The token the poll and frames endpoints are addressed with, in the X-Agent-Instance-Token header. Present when the register was accepted.
+		InstanceToken *string `json:"instanceToken,omitempty"`
+	}
+}
+
+// Status returns HTTPResponse.Status
+func (r RegisterLangyControlSessionResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r RegisterLangyControlSessionResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r RegisterLangyControlSessionResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type ListLangyControlRequestsResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *struct {
+		Requests []struct {
+			ConversationId    string `json:"conversationId"`
+			ConversationTitle string `json:"conversationTitle"`
+			ConversationUrl   string `json:"conversationUrl"`
+			CreatedAt         string `json:"createdAt"`
+			ExpiresAt         string `json:"expiresAt"`
+			Id                string `json:"id"`
+			ProjectId         string `json:"projectId"`
+			ProjectName       string `json:"projectName"`
+		} `json:"requests"`
+	}
+}
+
+// Status returns HTTPResponse.Status
+func (r ListLangyControlRequestsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListLangyControlRequestsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r ListLangyControlRequestsResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type ApproveLangyControlRequestResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *struct {
+		Conversation struct {
+			Id    string `json:"id"`
+			Title string `json:"title"`
+			Url   string `json:"url"`
+		} `json:"conversation"`
+		Endpoint   string `json:"endpoint"`
+		SessionKey string `json:"sessionKey"`
+	}
+}
+
+// Status returns HTTPResponse.Status
+func (r ApproveLangyControlRequestResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ApproveLangyControlRequestResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r ApproveLangyControlRequestResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type CancelLangyControlRequestResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *struct {
+		// Cancelled Always true once the request is gone.
+		Cancelled CancelLangyControlRequest200JSONResponseBodyCancelled `json:"cancelled"`
+
+		// Id The request that was cancelled.
+		Id string `json:"id"`
+	}
+}
+
+// Status returns HTTPResponse.Status
+func (r CancelLangyControlRequestResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r CancelLangyControlRequestResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r CancelLangyControlRequestResponse) ContentType() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Header.Get("Content-Type")
 	}
@@ -98666,7 +105358,588 @@ func (r PutApiV1ProjectsByProjectIdAnalyticsChartsByChartIdPlacementResponse) Co
 	return ""
 }
 
-type PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseResponse struct {
+type GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *struct {
+		Data []struct {
+			ColSpan     int     `json:"colSpan"`
+			CreatedAt   string  `json:"createdAt"`
+			DashboardId *string `json:"dashboardId"`
+			Definition  struct {
+				Code    string `json:"code"`
+				Queries []struct {
+					Name       string `json:"name"`
+					Parameters *[]struct {
+						Default *GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBody_Data_Definition_Queries_Parameters_Default `json:"default,omitempty"`
+						Name    string                                                                                                              `json:"name"`
+						Type    GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBodyDataDefinitionQueriesParametersType          `json:"type"`
+					} `json:"parameters,omitempty"`
+					Sql string `json:"sql"`
+				} `json:"queries"`
+				Version float32 `json:"version"`
+			} `json:"definition"`
+			GridColumn  int    `json:"gridColumn"`
+			GridRow     int    `json:"gridRow"`
+			Id          string `json:"id"`
+			Name        string `json:"name"`
+			PlatformUrl string `json:"platformUrl"`
+			RowSpan     int    `json:"rowSpan"`
+			UpdatedAt   string `json:"updatedAt"`
+		} `json:"data"`
+	}
+	JSON400 *struct {
+		Error struct {
+			Code    string                  `json:"code"`
+			Message string                  `json:"message"`
+			Meta    *map[string]interface{} `json:"meta,omitempty"`
+			SpanId  *string                 `json:"span_id,omitempty"`
+			TraceId *string                 `json:"trace_id,omitempty"`
+			Type    string                  `json:"type"`
+		} `json:"error"`
+	}
+	JSON401 *struct {
+		Error struct {
+			Code    string                  `json:"code"`
+			Message string                  `json:"message"`
+			Meta    *map[string]interface{} `json:"meta,omitempty"`
+			SpanId  *string                 `json:"span_id,omitempty"`
+			TraceId *string                 `json:"trace_id,omitempty"`
+			Type    string                  `json:"type"`
+		} `json:"error"`
+	}
+	JSON403 *struct {
+		Error struct {
+			Code    string                  `json:"code"`
+			Message string                  `json:"message"`
+			Meta    *map[string]interface{} `json:"meta,omitempty"`
+			SpanId  *string                 `json:"span_id,omitempty"`
+			TraceId *string                 `json:"trace_id,omitempty"`
+			Type    string                  `json:"type"`
+		} `json:"error"`
+	}
+	JSON500 *struct {
+		Error struct {
+			Code    string                  `json:"code"`
+			Message string                  `json:"message"`
+			Meta    *map[string]interface{} `json:"meta,omitempty"`
+			SpanId  *string                 `json:"span_id,omitempty"`
+			TraceId *string                 `json:"trace_id,omitempty"`
+			Type    string                  `json:"type"`
+		} `json:"error"`
+	}
+}
+
+// Status returns HTTPResponse.Status
+func (r GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON201      *struct {
+		ColSpan     int     `json:"colSpan"`
+		CreatedAt   string  `json:"createdAt"`
+		DashboardId *string `json:"dashboardId"`
+		Definition  struct {
+			Code    string `json:"code"`
+			Queries []struct {
+				Name       string `json:"name"`
+				Parameters *[]struct {
+					Default *PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBody_Definition_Queries_Parameters_Default `json:"default,omitempty"`
+					Name    string                                                                                                          `json:"name"`
+					Type    PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBodyDefinitionQueriesParametersType         `json:"type"`
+				} `json:"parameters,omitempty"`
+				Sql string `json:"sql"`
+			} `json:"queries"`
+			Version float32 `json:"version"`
+		} `json:"definition"`
+		GridColumn  int    `json:"gridColumn"`
+		GridRow     int    `json:"gridRow"`
+		Id          string `json:"id"`
+		Name        string `json:"name"`
+		PlatformUrl string `json:"platformUrl"`
+		RowSpan     int    `json:"rowSpan"`
+		UpdatedAt   string `json:"updatedAt"`
+	}
+	JSON400 *struct {
+		Error struct {
+			Code    string                  `json:"code"`
+			Message string                  `json:"message"`
+			Meta    *map[string]interface{} `json:"meta,omitempty"`
+			SpanId  *string                 `json:"span_id,omitempty"`
+			TraceId *string                 `json:"trace_id,omitempty"`
+			Type    string                  `json:"type"`
+		} `json:"error"`
+	}
+	JSON401 *struct {
+		Error struct {
+			Code    string                  `json:"code"`
+			Message string                  `json:"message"`
+			Meta    *map[string]interface{} `json:"meta,omitempty"`
+			SpanId  *string                 `json:"span_id,omitempty"`
+			TraceId *string                 `json:"trace_id,omitempty"`
+			Type    string                  `json:"type"`
+		} `json:"error"`
+	}
+	JSON403 *struct {
+		Error struct {
+			Code    string                  `json:"code"`
+			Message string                  `json:"message"`
+			Meta    *map[string]interface{} `json:"meta,omitempty"`
+			SpanId  *string                 `json:"span_id,omitempty"`
+			TraceId *string                 `json:"trace_id,omitempty"`
+			Type    string                  `json:"type"`
+		} `json:"error"`
+	}
+	JSON500 *struct {
+		Error struct {
+			Code    string                  `json:"code"`
+			Message string                  `json:"message"`
+			Meta    *map[string]interface{} `json:"meta,omitempty"`
+			SpanId  *string                 `json:"span_id,omitempty"`
+			TraceId *string                 `json:"trace_id,omitempty"`
+			Type    string                  `json:"type"`
+		} `json:"error"`
+	}
+}
+
+// Status returns HTTPResponse.Status
+func (r PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type DeleteApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON400      *struct {
+		Error struct {
+			Code    string                  `json:"code"`
+			Message string                  `json:"message"`
+			Meta    *map[string]interface{} `json:"meta,omitempty"`
+			SpanId  *string                 `json:"span_id,omitempty"`
+			TraceId *string                 `json:"trace_id,omitempty"`
+			Type    string                  `json:"type"`
+		} `json:"error"`
+	}
+	JSON401 *struct {
+		Error struct {
+			Code    string                  `json:"code"`
+			Message string                  `json:"message"`
+			Meta    *map[string]interface{} `json:"meta,omitempty"`
+			SpanId  *string                 `json:"span_id,omitempty"`
+			TraceId *string                 `json:"trace_id,omitempty"`
+			Type    string                  `json:"type"`
+		} `json:"error"`
+	}
+	JSON403 *struct {
+		Error struct {
+			Code    string                  `json:"code"`
+			Message string                  `json:"message"`
+			Meta    *map[string]interface{} `json:"meta,omitempty"`
+			SpanId  *string                 `json:"span_id,omitempty"`
+			TraceId *string                 `json:"trace_id,omitempty"`
+			Type    string                  `json:"type"`
+		} `json:"error"`
+	}
+	JSON404 *struct {
+		Error struct {
+			Code    string                  `json:"code"`
+			Message string                  `json:"message"`
+			Meta    *map[string]interface{} `json:"meta,omitempty"`
+			SpanId  *string                 `json:"span_id,omitempty"`
+			TraceId *string                 `json:"trace_id,omitempty"`
+			Type    string                  `json:"type"`
+		} `json:"error"`
+	}
+	JSON500 *struct {
+		Error struct {
+			Code    string                  `json:"code"`
+			Message string                  `json:"message"`
+			Meta    *map[string]interface{} `json:"meta,omitempty"`
+			SpanId  *string                 `json:"span_id,omitempty"`
+			TraceId *string                 `json:"trace_id,omitempty"`
+			Type    string                  `json:"type"`
+		} `json:"error"`
+	}
+}
+
+// Status returns HTTPResponse.Status
+func (r DeleteApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r DeleteApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r DeleteApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *struct {
+		ColSpan     int     `json:"colSpan"`
+		CreatedAt   string  `json:"createdAt"`
+		DashboardId *string `json:"dashboardId"`
+		Definition  struct {
+			Code    string `json:"code"`
+			Queries []struct {
+				Name       string `json:"name"`
+				Parameters *[]struct {
+					Default *GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBody_Definition_Queries_Parameters_Default `json:"default,omitempty"`
+					Name    string                                                                                                                   `json:"name"`
+					Type    GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersType         `json:"type"`
+				} `json:"parameters,omitempty"`
+				Sql string `json:"sql"`
+			} `json:"queries"`
+			Version float32 `json:"version"`
+		} `json:"definition"`
+		GridColumn  int    `json:"gridColumn"`
+		GridRow     int    `json:"gridRow"`
+		Id          string `json:"id"`
+		Name        string `json:"name"`
+		PlatformUrl string `json:"platformUrl"`
+		RowSpan     int    `json:"rowSpan"`
+		UpdatedAt   string `json:"updatedAt"`
+	}
+	JSON400 *struct {
+		Error struct {
+			Code    string                  `json:"code"`
+			Message string                  `json:"message"`
+			Meta    *map[string]interface{} `json:"meta,omitempty"`
+			SpanId  *string                 `json:"span_id,omitempty"`
+			TraceId *string                 `json:"trace_id,omitempty"`
+			Type    string                  `json:"type"`
+		} `json:"error"`
+	}
+	JSON401 *struct {
+		Error struct {
+			Code    string                  `json:"code"`
+			Message string                  `json:"message"`
+			Meta    *map[string]interface{} `json:"meta,omitempty"`
+			SpanId  *string                 `json:"span_id,omitempty"`
+			TraceId *string                 `json:"trace_id,omitempty"`
+			Type    string                  `json:"type"`
+		} `json:"error"`
+	}
+	JSON403 *struct {
+		Error struct {
+			Code    string                  `json:"code"`
+			Message string                  `json:"message"`
+			Meta    *map[string]interface{} `json:"meta,omitempty"`
+			SpanId  *string                 `json:"span_id,omitempty"`
+			TraceId *string                 `json:"trace_id,omitempty"`
+			Type    string                  `json:"type"`
+		} `json:"error"`
+	}
+	JSON404 *struct {
+		Error struct {
+			Code    string                  `json:"code"`
+			Message string                  `json:"message"`
+			Meta    *map[string]interface{} `json:"meta,omitempty"`
+			SpanId  *string                 `json:"span_id,omitempty"`
+			TraceId *string                 `json:"trace_id,omitempty"`
+			Type    string                  `json:"type"`
+		} `json:"error"`
+	}
+	JSON500 *struct {
+		Error struct {
+			Code    string                  `json:"code"`
+			Message string                  `json:"message"`
+			Meta    *map[string]interface{} `json:"meta,omitempty"`
+			SpanId  *string                 `json:"span_id,omitempty"`
+			TraceId *string                 `json:"trace_id,omitempty"`
+			Type    string                  `json:"type"`
+		} `json:"error"`
+	}
+}
+
+// Status returns HTTPResponse.Status
+func (r GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *struct {
+		ColSpan     int     `json:"colSpan"`
+		CreatedAt   string  `json:"createdAt"`
+		DashboardId *string `json:"dashboardId"`
+		Definition  struct {
+			Code    string `json:"code"`
+			Queries []struct {
+				Name       string `json:"name"`
+				Parameters *[]struct {
+					Default *PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBody_Definition_Queries_Parameters_Default `json:"default,omitempty"`
+					Name    string                                                                                                                     `json:"name"`
+					Type    PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersType         `json:"type"`
+				} `json:"parameters,omitempty"`
+				Sql string `json:"sql"`
+			} `json:"queries"`
+			Version float32 `json:"version"`
+		} `json:"definition"`
+		GridColumn  int    `json:"gridColumn"`
+		GridRow     int    `json:"gridRow"`
+		Id          string `json:"id"`
+		Name        string `json:"name"`
+		PlatformUrl string `json:"platformUrl"`
+		RowSpan     int    `json:"rowSpan"`
+		UpdatedAt   string `json:"updatedAt"`
+	}
+	JSON400 *struct {
+		Error struct {
+			Code    string                  `json:"code"`
+			Message string                  `json:"message"`
+			Meta    *map[string]interface{} `json:"meta,omitempty"`
+			SpanId  *string                 `json:"span_id,omitempty"`
+			TraceId *string                 `json:"trace_id,omitempty"`
+			Type    string                  `json:"type"`
+		} `json:"error"`
+	}
+	JSON401 *struct {
+		Error struct {
+			Code    string                  `json:"code"`
+			Message string                  `json:"message"`
+			Meta    *map[string]interface{} `json:"meta,omitempty"`
+			SpanId  *string                 `json:"span_id,omitempty"`
+			TraceId *string                 `json:"trace_id,omitempty"`
+			Type    string                  `json:"type"`
+		} `json:"error"`
+	}
+	JSON403 *struct {
+		Error struct {
+			Code    string                  `json:"code"`
+			Message string                  `json:"message"`
+			Meta    *map[string]interface{} `json:"meta,omitempty"`
+			SpanId  *string                 `json:"span_id,omitempty"`
+			TraceId *string                 `json:"trace_id,omitempty"`
+			Type    string                  `json:"type"`
+		} `json:"error"`
+	}
+	JSON404 *struct {
+		Error struct {
+			Code    string                  `json:"code"`
+			Message string                  `json:"message"`
+			Meta    *map[string]interface{} `json:"meta,omitempty"`
+			SpanId  *string                 `json:"span_id,omitempty"`
+			TraceId *string                 `json:"trace_id,omitempty"`
+			Type    string                  `json:"type"`
+		} `json:"error"`
+	}
+	JSON500 *struct {
+		Error struct {
+			Code    string                  `json:"code"`
+			Message string                  `json:"message"`
+			Meta    *map[string]interface{} `json:"meta,omitempty"`
+			SpanId  *string                 `json:"span_id,omitempty"`
+			TraceId *string                 `json:"trace_id,omitempty"`
+			Type    string                  `json:"type"`
+		} `json:"error"`
+	}
+}
+
+// Status returns HTTPResponse.Status
+func (r PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboardResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *struct {
+		ColSpan     int     `json:"colSpan"`
+		CreatedAt   string  `json:"createdAt"`
+		DashboardId *string `json:"dashboardId"`
+		Definition  struct {
+			Code    string `json:"code"`
+			Queries []struct {
+				Name       string `json:"name"`
+				Parameters *[]struct {
+					Default *PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBody_Definition_Queries_Parameters_Default `json:"default,omitempty"`
+					Name    string                                                                                                                             `json:"name"`
+					Type    PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBodyDefinitionQueriesParametersType         `json:"type"`
+				} `json:"parameters,omitempty"`
+				Sql string `json:"sql"`
+			} `json:"queries"`
+			Version float32 `json:"version"`
+		} `json:"definition"`
+		GridColumn  int    `json:"gridColumn"`
+		GridRow     int    `json:"gridRow"`
+		Id          string `json:"id"`
+		Name        string `json:"name"`
+		PlatformUrl string `json:"platformUrl"`
+		RowSpan     int    `json:"rowSpan"`
+		UpdatedAt   string `json:"updatedAt"`
+	}
+	JSON400 *struct {
+		Error struct {
+			Code    string                  `json:"code"`
+			Message string                  `json:"message"`
+			Meta    *map[string]interface{} `json:"meta,omitempty"`
+			SpanId  *string                 `json:"span_id,omitempty"`
+			TraceId *string                 `json:"trace_id,omitempty"`
+			Type    string                  `json:"type"`
+		} `json:"error"`
+	}
+	JSON401 *struct {
+		Error struct {
+			Code    string                  `json:"code"`
+			Message string                  `json:"message"`
+			Meta    *map[string]interface{} `json:"meta,omitempty"`
+			SpanId  *string                 `json:"span_id,omitempty"`
+			TraceId *string                 `json:"trace_id,omitempty"`
+			Type    string                  `json:"type"`
+		} `json:"error"`
+	}
+	JSON403 *struct {
+		Error struct {
+			Code    string                  `json:"code"`
+			Message string                  `json:"message"`
+			Meta    *map[string]interface{} `json:"meta,omitempty"`
+			SpanId  *string                 `json:"span_id,omitempty"`
+			TraceId *string                 `json:"trace_id,omitempty"`
+			Type    string                  `json:"type"`
+		} `json:"error"`
+	}
+	JSON404 *struct {
+		Error struct {
+			Code    string                  `json:"code"`
+			Message string                  `json:"message"`
+			Meta    *map[string]interface{} `json:"meta,omitempty"`
+			SpanId  *string                 `json:"span_id,omitempty"`
+			TraceId *string                 `json:"trace_id,omitempty"`
+			Type    string                  `json:"type"`
+		} `json:"error"`
+	}
+	JSON500 *struct {
+		Error struct {
+			Code    string                  `json:"code"`
+			Message string                  `json:"message"`
+			Meta    *map[string]interface{} `json:"meta,omitempty"`
+			SpanId  *string                 `json:"span_id,omitempty"`
+			TraceId *string                 `json:"trace_id,omitempty"`
+			Type    string                  `json:"type"`
+		} `json:"error"`
+	}
+}
+
+// Status returns HTTPResponse.Status
+func (r PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboardResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboardResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboardResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type PostApiV1QueryResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *struct {
@@ -98676,9 +105949,9 @@ type PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseResponse struct {
 			Type string `json:"type"`
 		} `json:"columns"`
 		Diagnostics []struct {
-			Code    PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouse200JSONResponseBodyDiagnosticsCode `json:"code"`
-			Message string                                                                                 `json:"message"`
-			Meta    *map[string]interface{}                                                                `json:"meta,omitempty"`
+			Code    PostApiV1Query200JSONResponseBodyDiagnosticsCode `json:"code"`
+			Message string                                           `json:"message"`
+			Meta    *map[string]interface{}                          `json:"meta,omitempty"`
 		} `json:"diagnostics"`
 		FollowsGranularity bool                     `json:"followsGranularity"`
 		FollowsTimeWindow  bool                     `json:"followsTimeWindow"`
@@ -98745,7 +106018,7 @@ type PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseResponse) Status() string {
+func (r PostApiV1QueryResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -98753,7 +106026,7 @@ func (r PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseResponse) Status() s
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseResponse) StatusCode() int {
+func (r PostApiV1QueryResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -98761,26 +106034,26 @@ func (r PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseResponse) StatusCode
 }
 
 // ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
-func (r PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseResponse) ContentType() string {
+func (r PostApiV1QueryResponse) ContentType() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Header.Get("Content-Type")
 	}
 	return ""
 }
 
-type GetApiV1ProjectsByProjectIdAnalyticsSchemaResponse struct {
+type GetApiV1QuerySchemaResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *struct {
 		Database string `json:"database"`
 		Datasets []struct {
 			Columns []struct {
-				Available   bool                                                                                `json:"available"`
-				Description string                                                                              `json:"description"`
-				Gates       []GetApiV1ProjectsByProjectIdAnalyticsSchema200JSONResponseBodyDatasetsColumnsGates `json:"gates"`
-				Name        string                                                                              `json:"name"`
-				Type        string                                                                              `json:"type"`
-				Unit        *GetApiV1ProjectsByProjectIdAnalyticsSchema200JSONResponseBodyDatasetsColumnsUnit   `json:"unit"`
+				Available   bool                                                         `json:"available"`
+				Description string                                                       `json:"description"`
+				Gates       []GetApiV1QuerySchema200JSONResponseBodyDatasetsColumnsGates `json:"gates"`
+				Name        string                                                       `json:"name"`
+				Type        string                                                       `json:"type"`
+				Unit        *GetApiV1QuerySchema200JSONResponseBodyDatasetsColumnsUnit   `json:"unit"`
 			} `json:"columns"`
 			Description string   `json:"description"`
 			ExampleSql  string   `json:"exampleSql"`
@@ -98834,7 +106107,7 @@ type GetApiV1ProjectsByProjectIdAnalyticsSchemaResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r GetApiV1ProjectsByProjectIdAnalyticsSchemaResponse) Status() string {
+func (r GetApiV1QuerySchemaResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -98842,7 +106115,7 @@ func (r GetApiV1ProjectsByProjectIdAnalyticsSchemaResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r GetApiV1ProjectsByProjectIdAnalyticsSchemaResponse) StatusCode() int {
+func (r GetApiV1QuerySchemaResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -98850,7 +106123,7 @@ func (r GetApiV1ProjectsByProjectIdAnalyticsSchemaResponse) StatusCode() int {
 }
 
 // ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
-func (r GetApiV1ProjectsByProjectIdAnalyticsSchemaResponse) ContentType() string {
+func (r GetApiV1QuerySchemaResponse) ContentType() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Header.Get("Content-Type")
 	}
@@ -98866,6 +106139,21 @@ type ListRunPlansResponse struct {
 
 		// CreatedAt When the plan was created.
 		CreatedAt string `json:"createdAt"`
+
+		// Evaluators The plan's own evaluators. Absent on servers that predate evaluators on this family.
+		Evaluators *[]struct {
+			// EvaluatorId The id of the saved evaluator this attachment runs.
+			EvaluatorId string `json:"evaluatorId"`
+
+			// Id The attachment id. Stable across edits of the attachment.
+			Id string `json:"id"`
+
+			// Mappings Where each evaluator input reads its value, keyed by input name. Inputs left out are unmapped; a required input left unmapped refuses the run.
+			Mappings map[string]ListRunPlans200JSONResponseBody_Evaluators_Mappings_AdditionalProperties `json:"mappings"`
+
+			// Required Whether a failing result fails the scenario. A score-only evaluator reports and never gates.
+			Required bool `json:"required"`
+		} `json:"evaluators,omitempty"`
 
 		// Id The run plan id.
 		Id string `json:"id"`
@@ -99071,6 +106359,21 @@ type GetRunPlanResponse struct {
 		// CreatedAt When the plan was created.
 		CreatedAt string `json:"createdAt"`
 
+		// Evaluators The plan's own evaluators. Absent on servers that predate evaluators on this family.
+		Evaluators *[]struct {
+			// EvaluatorId The id of the saved evaluator this attachment runs.
+			EvaluatorId string `json:"evaluatorId"`
+
+			// Id The attachment id. Stable across edits of the attachment.
+			Id string `json:"id"`
+
+			// Mappings Where each evaluator input reads its value, keyed by input name. Inputs left out are unmapped; a required input left unmapped refuses the run.
+			Mappings map[string]GetRunPlan200JSONResponseBody_Evaluators_Mappings_AdditionalProperties `json:"mappings"`
+
+			// Required Whether a failing result fails the scenario. A score-only evaluator reports and never gates.
+			Required bool `json:"required"`
+		} `json:"evaluators,omitempty"`
+
 		// Id The run plan id.
 		Id string `json:"id"`
 
@@ -99239,6 +106542,30 @@ type ListTestSuitesResponse struct {
 		// CreatedAt When the suite was created.
 		CreatedAt string `json:"createdAt"`
 
+		// Evaluators The evaluators attached to the test suite. Absent on servers that predate evaluators on this family.
+		Evaluators *[]struct {
+			// EvaluatorId The id of the saved evaluator this attachment runs.
+			EvaluatorId string `json:"evaluatorId"`
+
+			// Id The attachment id. Stable across edits of the attachment.
+			Id string `json:"id"`
+
+			// Mappings Where each evaluator input reads its value, keyed by input name. Inputs left out are unmapped; a required input left unmapped refuses the run.
+			Mappings map[string]ListTestSuites200JSONResponseBody_Evaluators_Mappings_AdditionalProperties `json:"mappings"`
+
+			// Required Whether a failing result fails the scenario. A score-only evaluator reports and never gates.
+			Required bool `json:"required"`
+		} `json:"evaluators,omitempty"`
+
+		// Fields The fields the test suite declares. Absent on servers that predate fields on this family.
+		Fields *[]struct {
+			// Identifier The field name, as scenarios and evaluator mappings address it. Lowercase letters, digits and underscores, starting with a letter.
+			Identifier string `json:"identifier"`
+
+			// Type The value type every scenario carries for this field.
+			Type ListTestSuites200JSONResponseBodyFieldsType `json:"type"`
+		} `json:"fields,omitempty"`
+
 		// Id The test suite id.
 		Id string `json:"id"`
 
@@ -99295,6 +106622,30 @@ type CreateTestSuiteResponse struct {
 
 		// CreatedAt When the suite was created.
 		CreatedAt string `json:"createdAt"`
+
+		// Evaluators The evaluators attached to the test suite. Absent on servers that predate evaluators on this family.
+		Evaluators *[]struct {
+			// EvaluatorId The id of the saved evaluator this attachment runs.
+			EvaluatorId string `json:"evaluatorId"`
+
+			// Id The attachment id. Stable across edits of the attachment.
+			Id string `json:"id"`
+
+			// Mappings Where each evaluator input reads its value, keyed by input name. Inputs left out are unmapped; a required input left unmapped refuses the run.
+			Mappings map[string]CreateTestSuite201JSONResponseBody_Evaluators_Mappings_AdditionalProperties `json:"mappings"`
+
+			// Required Whether a failing result fails the scenario. A score-only evaluator reports and never gates.
+			Required bool `json:"required"`
+		} `json:"evaluators,omitempty"`
+
+		// Fields The fields the test suite declares. Absent on servers that predate fields on this family.
+		Fields *[]struct {
+			// Identifier The field name, as scenarios and evaluator mappings address it. Lowercase letters, digits and underscores, starting with a letter.
+			Identifier string `json:"identifier"`
+
+			// Type The value type every scenario carries for this field.
+			Type CreateTestSuite201JSONResponseBodyFieldsType `json:"type"`
+		} `json:"fields,omitempty"`
 
 		// Id The test suite id.
 		Id string `json:"id"`
@@ -99389,6 +106740,30 @@ type GetTestSuiteResponse struct {
 		// CreatedAt When the suite was created.
 		CreatedAt string `json:"createdAt"`
 
+		// Evaluators The evaluators attached to the test suite. Absent on servers that predate evaluators on this family.
+		Evaluators *[]struct {
+			// EvaluatorId The id of the saved evaluator this attachment runs.
+			EvaluatorId string `json:"evaluatorId"`
+
+			// Id The attachment id. Stable across edits of the attachment.
+			Id string `json:"id"`
+
+			// Mappings Where each evaluator input reads its value, keyed by input name. Inputs left out are unmapped; a required input left unmapped refuses the run.
+			Mappings map[string]GetTestSuite200JSONResponseBody_Evaluators_Mappings_AdditionalProperties `json:"mappings"`
+
+			// Required Whether a failing result fails the scenario. A score-only evaluator reports and never gates.
+			Required bool `json:"required"`
+		} `json:"evaluators,omitempty"`
+
+		// Fields The fields the test suite declares. Absent on servers that predate fields on this family.
+		Fields *[]struct {
+			// Identifier The field name, as scenarios and evaluator mappings address it. Lowercase letters, digits and underscores, starting with a letter.
+			Identifier string `json:"identifier"`
+
+			// Type The value type every scenario carries for this field.
+			Type GetTestSuite200JSONResponseBodyFieldsType `json:"type"`
+		} `json:"fields,omitempty"`
+
 		// Id The test suite id.
 		Id string `json:"id"`
 
@@ -99445,7 +106820,7 @@ func (r GetTestSuiteResponse) ContentType() string {
 	return ""
 }
 
-type RenameTestSuiteResponse struct {
+type UpdateTestSuiteResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *struct {
@@ -99454,6 +106829,30 @@ type RenameTestSuiteResponse struct {
 
 		// CreatedAt When the suite was created.
 		CreatedAt string `json:"createdAt"`
+
+		// Evaluators The evaluators attached to the test suite. Absent on servers that predate evaluators on this family.
+		Evaluators *[]struct {
+			// EvaluatorId The id of the saved evaluator this attachment runs.
+			EvaluatorId string `json:"evaluatorId"`
+
+			// Id The attachment id. Stable across edits of the attachment.
+			Id string `json:"id"`
+
+			// Mappings Where each evaluator input reads its value, keyed by input name. Inputs left out are unmapped; a required input left unmapped refuses the run.
+			Mappings map[string]UpdateTestSuite200JSONResponseBody_Evaluators_Mappings_AdditionalProperties `json:"mappings"`
+
+			// Required Whether a failing result fails the scenario. A score-only evaluator reports and never gates.
+			Required bool `json:"required"`
+		} `json:"evaluators,omitempty"`
+
+		// Fields The fields the test suite declares. Absent on servers that predate fields on this family.
+		Fields *[]struct {
+			// Identifier The field name, as scenarios and evaluator mappings address it. Lowercase letters, digits and underscores, starting with a letter.
+			Identifier string `json:"identifier"`
+
+			// Type The value type every scenario carries for this field.
+			Type UpdateTestSuite200JSONResponseBodyFieldsType `json:"type"`
+		} `json:"fields,omitempty"`
 
 		// Id The test suite id.
 		Id string `json:"id"`
@@ -99479,7 +106878,7 @@ type RenameTestSuiteResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r RenameTestSuiteResponse) Status() string {
+func (r UpdateTestSuiteResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -99487,7 +106886,7 @@ func (r RenameTestSuiteResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r RenameTestSuiteResponse) StatusCode() int {
+func (r UpdateTestSuiteResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -99495,7 +106894,7 @@ func (r RenameTestSuiteResponse) StatusCode() int {
 }
 
 // ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
-func (r RenameTestSuiteResponse) ContentType() string {
+func (r UpdateTestSuiteResponse) ContentType() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Header.Get("Content-Type")
 	}
@@ -104049,6 +111448,93 @@ func (c *ClientWithResponses) TestAgentWithResponse(ctx context.Context, id stri
 	return ParseTestAgentResponse(rsp)
 }
 
+// GetPullRequestUsageWithResponse request returning *GetPullRequestUsageResponse
+func (c *ClientWithResponses) GetPullRequestUsageWithResponse(ctx context.Context, params *GetPullRequestUsageParams, reqEditors ...RequestEditorFn) (*GetPullRequestUsageResponse, error) {
+	rsp, err := c.GetPullRequestUsage(ctx, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetPullRequestUsageResponse(rsp)
+}
+
+// PostLangyControlFramesWithBodyWithResponse request with arbitrary body returning *PostLangyControlFramesResponse
+func (c *ClientWithResponses) PostLangyControlFramesWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostLangyControlFramesResponse, error) {
+	rsp, err := c.PostLangyControlFramesWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePostLangyControlFramesResponse(rsp)
+}
+
+func (c *ClientWithResponses) PostLangyControlFramesWithResponse(ctx context.Context, body PostLangyControlFramesJSONRequestBody, reqEditors ...RequestEditorFn) (*PostLangyControlFramesResponse, error) {
+	rsp, err := c.PostLangyControlFrames(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePostLangyControlFramesResponse(rsp)
+}
+
+// PollLangyControlSessionWithResponse request returning *PollLangyControlSessionResponse
+func (c *ClientWithResponses) PollLangyControlSessionWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*PollLangyControlSessionResponse, error) {
+	rsp, err := c.PollLangyControlSession(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePollLangyControlSessionResponse(rsp)
+}
+
+// RegisterLangyControlSessionWithBodyWithResponse request with arbitrary body returning *RegisterLangyControlSessionResponse
+func (c *ClientWithResponses) RegisterLangyControlSessionWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*RegisterLangyControlSessionResponse, error) {
+	rsp, err := c.RegisterLangyControlSessionWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseRegisterLangyControlSessionResponse(rsp)
+}
+
+func (c *ClientWithResponses) RegisterLangyControlSessionWithResponse(ctx context.Context, body RegisterLangyControlSessionJSONRequestBody, reqEditors ...RequestEditorFn) (*RegisterLangyControlSessionResponse, error) {
+	rsp, err := c.RegisterLangyControlSession(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseRegisterLangyControlSessionResponse(rsp)
+}
+
+// ListLangyControlRequestsWithResponse request returning *ListLangyControlRequestsResponse
+func (c *ClientWithResponses) ListLangyControlRequestsWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListLangyControlRequestsResponse, error) {
+	rsp, err := c.ListLangyControlRequests(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListLangyControlRequestsResponse(rsp)
+}
+
+// ApproveLangyControlRequestWithBodyWithResponse request with arbitrary body returning *ApproveLangyControlRequestResponse
+func (c *ClientWithResponses) ApproveLangyControlRequestWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*ApproveLangyControlRequestResponse, error) {
+	rsp, err := c.ApproveLangyControlRequestWithBody(ctx, id, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseApproveLangyControlRequestResponse(rsp)
+}
+
+func (c *ClientWithResponses) ApproveLangyControlRequestWithResponse(ctx context.Context, id string, body ApproveLangyControlRequestJSONRequestBody, reqEditors ...RequestEditorFn) (*ApproveLangyControlRequestResponse, error) {
+	rsp, err := c.ApproveLangyControlRequest(ctx, id, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseApproveLangyControlRequestResponse(rsp)
+}
+
+// CancelLangyControlRequestWithResponse request returning *CancelLangyControlRequestResponse
+func (c *ClientWithResponses) CancelLangyControlRequestWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*CancelLangyControlRequestResponse, error) {
+	rsp, err := c.CancelLangyControlRequest(ctx, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCancelLangyControlRequestResponse(rsp)
+}
+
 // GetApiV1ProjectsByProjectIdAnalyticsChartsWithResponse request returning *GetApiV1ProjectsByProjectIdAnalyticsChartsResponse
 func (c *ClientWithResponses) GetApiV1ProjectsByProjectIdAnalyticsChartsWithResponse(ctx context.Context, projectId string, reqEditors ...RequestEditorFn) (*GetApiV1ProjectsByProjectIdAnalyticsChartsResponse, error) {
 	rsp, err := c.GetApiV1ProjectsByProjectIdAnalyticsCharts(ctx, projectId, reqEditors...)
@@ -104136,30 +111622,108 @@ func (c *ClientWithResponses) PutApiV1ProjectsByProjectIdAnalyticsChartsByChartI
 	return ParsePutApiV1ProjectsByProjectIdAnalyticsChartsByChartIdPlacementResponse(rsp)
 }
 
-// PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseWithBodyWithResponse request with arbitrary body returning *PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseResponse
-func (c *ClientWithResponses) PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseWithBodyWithResponse(ctx context.Context, projectId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseResponse, error) {
-	rsp, err := c.PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseWithBody(ctx, projectId, contentType, body, reqEditors...)
+// GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsWithResponse request returning *GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsResponse
+func (c *ClientWithResponses) GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsWithResponse(ctx context.Context, projectId string, reqEditors ...RequestEditorFn) (*GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsResponse, error) {
+	rsp, err := c.GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets(ctx, projectId, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParsePostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseResponse(rsp)
+	return ParseGetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsResponse(rsp)
 }
 
-func (c *ClientWithResponses) PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseWithResponse(ctx context.Context, projectId string, body PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseJSONRequestBody, reqEditors ...RequestEditorFn) (*PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseResponse, error) {
-	rsp, err := c.PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouse(ctx, projectId, body, reqEditors...)
+// PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsWithBodyWithResponse request with arbitrary body returning *PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsResponse
+func (c *ClientWithResponses) PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsWithBodyWithResponse(ctx context.Context, projectId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsResponse, error) {
+	rsp, err := c.PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsWithBody(ctx, projectId, contentType, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParsePostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseResponse(rsp)
+	return ParsePostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsResponse(rsp)
 }
 
-// GetApiV1ProjectsByProjectIdAnalyticsSchemaWithResponse request returning *GetApiV1ProjectsByProjectIdAnalyticsSchemaResponse
-func (c *ClientWithResponses) GetApiV1ProjectsByProjectIdAnalyticsSchemaWithResponse(ctx context.Context, projectId string, reqEditors ...RequestEditorFn) (*GetApiV1ProjectsByProjectIdAnalyticsSchemaResponse, error) {
-	rsp, err := c.GetApiV1ProjectsByProjectIdAnalyticsSchema(ctx, projectId, reqEditors...)
+func (c *ClientWithResponses) PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsWithResponse(ctx context.Context, projectId string, body PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsJSONRequestBody, reqEditors ...RequestEditorFn) (*PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsResponse, error) {
+	rsp, err := c.PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets(ctx, projectId, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseGetApiV1ProjectsByProjectIdAnalyticsSchemaResponse(rsp)
+	return ParsePostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsResponse(rsp)
+}
+
+// DeleteApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdWithResponse request returning *DeleteApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdResponse
+func (c *ClientWithResponses) DeleteApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdWithResponse(ctx context.Context, projectId string, widgetId string, reqEditors ...RequestEditorFn) (*DeleteApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdResponse, error) {
+	rsp, err := c.DeleteApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId(ctx, projectId, widgetId, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDeleteApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdResponse(rsp)
+}
+
+// GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdWithResponse request returning *GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdResponse
+func (c *ClientWithResponses) GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdWithResponse(ctx context.Context, projectId string, widgetId string, reqEditors ...RequestEditorFn) (*GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdResponse, error) {
+	rsp, err := c.GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId(ctx, projectId, widgetId, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdResponse(rsp)
+}
+
+// PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdWithBodyWithResponse request with arbitrary body returning *PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdResponse
+func (c *ClientWithResponses) PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdWithBodyWithResponse(ctx context.Context, projectId string, widgetId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdResponse, error) {
+	rsp, err := c.PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdWithBody(ctx, projectId, widgetId, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdResponse(rsp)
+}
+
+func (c *ClientWithResponses) PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdWithResponse(ctx context.Context, projectId string, widgetId string, body PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdJSONRequestBody, reqEditors ...RequestEditorFn) (*PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdResponse, error) {
+	rsp, err := c.PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId(ctx, projectId, widgetId, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdResponse(rsp)
+}
+
+// PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboardWithBodyWithResponse request with arbitrary body returning *PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboardResponse
+func (c *ClientWithResponses) PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboardWithBodyWithResponse(ctx context.Context, projectId string, widgetId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboardResponse, error) {
+	rsp, err := c.PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboardWithBody(ctx, projectId, widgetId, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboardResponse(rsp)
+}
+
+func (c *ClientWithResponses) PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboardWithResponse(ctx context.Context, projectId string, widgetId string, body PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboardJSONRequestBody, reqEditors ...RequestEditorFn) (*PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboardResponse, error) {
+	rsp, err := c.PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard(ctx, projectId, widgetId, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboardResponse(rsp)
+}
+
+// PostApiV1QueryWithBodyWithResponse request with arbitrary body returning *PostApiV1QueryResponse
+func (c *ClientWithResponses) PostApiV1QueryWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostApiV1QueryResponse, error) {
+	rsp, err := c.PostApiV1QueryWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePostApiV1QueryResponse(rsp)
+}
+
+func (c *ClientWithResponses) PostApiV1QueryWithResponse(ctx context.Context, body PostApiV1QueryJSONRequestBody, reqEditors ...RequestEditorFn) (*PostApiV1QueryResponse, error) {
+	rsp, err := c.PostApiV1Query(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePostApiV1QueryResponse(rsp)
+}
+
+// GetApiV1QuerySchemaWithResponse request returning *GetApiV1QuerySchemaResponse
+func (c *ClientWithResponses) GetApiV1QuerySchemaWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetApiV1QuerySchemaResponse, error) {
+	rsp, err := c.GetApiV1QuerySchema(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetApiV1QuerySchemaResponse(rsp)
 }
 
 // ListRunPlansWithResponse request returning *ListRunPlansResponse
@@ -104267,21 +111831,21 @@ func (c *ClientWithResponses) GetTestSuiteWithResponse(ctx context.Context, id s
 	return ParseGetTestSuiteResponse(rsp)
 }
 
-// RenameTestSuiteWithBodyWithResponse request with arbitrary body returning *RenameTestSuiteResponse
-func (c *ClientWithResponses) RenameTestSuiteWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*RenameTestSuiteResponse, error) {
-	rsp, err := c.RenameTestSuiteWithBody(ctx, id, contentType, body, reqEditors...)
+// UpdateTestSuiteWithBodyWithResponse request with arbitrary body returning *UpdateTestSuiteResponse
+func (c *ClientWithResponses) UpdateTestSuiteWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateTestSuiteResponse, error) {
+	rsp, err := c.UpdateTestSuiteWithBody(ctx, id, contentType, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseRenameTestSuiteResponse(rsp)
+	return ParseUpdateTestSuiteResponse(rsp)
 }
 
-func (c *ClientWithResponses) RenameTestSuiteWithResponse(ctx context.Context, id string, body RenameTestSuiteJSONRequestBody, reqEditors ...RequestEditorFn) (*RenameTestSuiteResponse, error) {
-	rsp, err := c.RenameTestSuite(ctx, id, body, reqEditors...)
+func (c *ClientWithResponses) UpdateTestSuiteWithResponse(ctx context.Context, id string, body UpdateTestSuiteJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateTestSuiteResponse, error) {
+	rsp, err := c.UpdateTestSuite(ctx, id, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseRenameTestSuiteResponse(rsp)
+	return ParseUpdateTestSuiteResponse(rsp)
 }
 
 // RunTestSuiteWithBodyWithResponse request with arbitrary body returning *RunTestSuiteResponse
@@ -105208,7 +112772,9 @@ func ParseGetApiAnnotationsResponse(rsp *http.Response) (*GetApiAnnotationsRespo
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest []Annotation
+		var dest struct {
+			Data []Annotation `json:"data"`
+		}
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -105241,7 +112807,9 @@ func ParseGetApiAnnotationsTraceIdResponse(rsp *http.Response) (*GetApiAnnotatio
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest []Annotation
+		var dest struct {
+			Data []Annotation `json:"data"`
+		}
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -105274,7 +112842,9 @@ func ParsePostApiAnnotationsTraceIdResponse(rsp *http.Response) (*PostApiAnnotat
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest Annotation
+		var dest struct {
+			Data Annotation `json:"data"`
+		}
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -105343,7 +112913,9 @@ func ParseGetApiAnnotationsIdResponse(rsp *http.Response) (*GetApiAnnotationsIdR
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest Annotation
+		var dest struct {
+			Data Annotation `json:"data"`
+		}
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -105377,8 +112949,7 @@ func ParsePatchApiAnnotationsIdResponse(rsp *http.Response) (*PatchApiAnnotation
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest struct {
-			Message *string `json:"message,omitempty"`
-			Status  *string `json:"status,omitempty"`
+			Data Annotation `json:"data"`
 		}
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
@@ -116987,7 +124558,10 @@ func ParseGetApiScenariosResponse(rsp *http.Response) (*GetApiScenariosResponse,
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest []struct {
 			Criteria []string `json:"criteria"`
-			Id       string   `json:"id"`
+
+			// Fields The value this scenario carries for each field its test suite declares, keyed by field identifier. A field with no value has no key. Absent on servers that predate suite fields.
+			Fields *map[string]GetApiScenarios200JSONResponseBody_Fields_AdditionalProperties `json:"fields,omitempty"`
+			Id     string                                                                     `json:"id"`
 
 			// JudgeModel The model that judges the run, or null for the project default. Absent on servers that predate model overrides on this family.
 			JudgeModel *string  `json:"judgeModel,omitempty"`
@@ -117084,7 +124658,10 @@ func ParsePostApiScenariosResponse(rsp *http.Response) (*PostApiScenariosRespons
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
 		var dest struct {
 			Criteria []string `json:"criteria"`
-			Id       string   `json:"id"`
+
+			// Fields The value this scenario carries for each field its test suite declares, keyed by field identifier. A field with no value has no key. Absent on servers that predate suite fields.
+			Fields *map[string]PostApiScenarios201JSONResponseBody_Fields_AdditionalProperties `json:"fields,omitempty"`
+			Id     string                                                                      `json:"id"`
 
 			// JudgeModel The model that judges the run, or null for the project default. Absent on servers that predate model overrides on this family.
 			JudgeModel *string  `json:"judgeModel,omitempty"`
@@ -117260,7 +124837,10 @@ func ParseGetApiScenariosByIdResponse(rsp *http.Response) (*GetApiScenariosByIdR
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest struct {
 			Criteria []string `json:"criteria"`
-			Id       string   `json:"id"`
+
+			// Fields The value this scenario carries for each field its test suite declares, keyed by field identifier. A field with no value has no key. Absent on servers that predate suite fields.
+			Fields *map[string]GetApiScenariosById200JSONResponseBody_Fields_AdditionalProperties `json:"fields,omitempty"`
+			Id     string                                                                         `json:"id"`
 
 			// JudgeModel The model that judges the run, or null for the project default. Absent on servers that predate model overrides on this family.
 			JudgeModel *string  `json:"judgeModel,omitempty"`
@@ -117367,7 +124947,10 @@ func ParsePatchApiScenariosByIdResponse(rsp *http.Response) (*PatchApiScenariosB
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest struct {
 			Criteria []string `json:"criteria"`
-			Id       string   `json:"id"`
+
+			// Fields The value this scenario carries for each field its test suite declares, keyed by field identifier. A field with no value has no key. Absent on servers that predate suite fields.
+			Fields *map[string]PatchApiScenariosById200JSONResponseBody_Fields_AdditionalProperties `json:"fields,omitempty"`
+			Id     string                                                                           `json:"id"`
 
 			// JudgeModel The model that judges the run, or null for the project default. Absent on servers that predate model overrides on this family.
 			JudgeModel *string  `json:"judgeModel,omitempty"`
@@ -117474,7 +125057,10 @@ func ParsePutApiScenariosByIdResponse(rsp *http.Response) (*PutApiScenariosByIdR
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest struct {
 			Criteria []string `json:"criteria"`
-			Id       string   `json:"id"`
+
+			// Fields The value this scenario carries for each field its test suite declares, keyed by field identifier. A field with no value has no key. Absent on servers that predate suite fields.
+			Fields *map[string]PutApiScenariosById200JSONResponseBody_Fields_AdditionalProperties `json:"fields,omitempty"`
+			Id     string                                                                         `json:"id"`
 
 			// JudgeModel The model that judges the run, or null for the project default. Absent on servers that predate model overrides on this family.
 			JudgeModel *string  `json:"judgeModel,omitempty"`
@@ -117700,12 +125286,15 @@ func ParseGetApiScenariosByIdVersionsByVersionResponse(rsp *http.Response) (*Get
 
 			// Snapshot The editable content of the scenario as this version saved it.
 			Snapshot struct {
-				Criteria   []string `json:"criteria"`
-				JudgeModel *string  `json:"judgeModel"`
-				Labels     []string `json:"labels"`
-				MaxTurns   *float32 `json:"maxTurns"`
-				MinTurns   *float32 `json:"minTurns"`
-				Name       string   `json:"name"`
+				Criteria []string `json:"criteria"`
+
+				// Fields The field values as this version saved them. Absent on servers that predate suite fields.
+				Fields     *map[string]GetApiScenariosByIdVersionsByVersion200JSONResponseBody_Snapshot_Fields_AdditionalProperties `json:"fields,omitempty"`
+				JudgeModel *string                                                                                                  `json:"judgeModel"`
+				Labels     []string                                                                                                 `json:"labels"`
+				MaxTurns   *float32                                                                                                 `json:"maxTurns"`
+				MinTurns   *float32                                                                                                 `json:"minTurns"`
+				Name       string                                                                                                   `json:"name"`
 				Parameters []struct {
 					DefaultValue *GetApiScenariosByIdVersionsByVersion200JSONResponseBody_Snapshot_Parameters_DefaultValue   `json:"defaultValue,omitempty"`
 					Description  *string                                                                                     `json:"description,omitempty"`
@@ -119608,7 +127197,24 @@ func ParseGetApiSimulationRunsResponse(rsp *http.Response) (*GetApiSimulationRun
 				Note        *string `json:"note,omitempty"`
 				PlatformUrl string  `json:"platformUrl"`
 				Results     *struct {
-					Error         *string   `json:"error,omitempty"`
+					Error *string `json:"error,omitempty"`
+
+					// Evaluations One result per evaluator that ran on the scenario. Absent on a run with no evaluators, and on servers that predate evaluators.
+					Evaluations *[]struct {
+						Cost *struct {
+							Amount   float32 `json:"amount"`
+							Currency string  `json:"currency"`
+						} `json:"cost,omitempty"`
+						Details     *string                                                             `json:"details,omitempty"`
+						EvaluatorId string                                                              `json:"evaluatorId"`
+						Inputs      *map[string]string                                                  `json:"inputs,omitempty"`
+						Label       *string                                                             `json:"label,omitempty"`
+						Name        string                                                              `json:"name"`
+						Passed      *bool                                                               `json:"passed,omitempty"`
+						Required    bool                                                                `json:"required"`
+						Score       *float32                                                            `json:"score,omitempty"`
+						Status      GetApiSimulationRuns200JSONResponseBodyRunsResultsEvaluationsStatus `json:"status"`
+					} `json:"evaluations,omitempty"`
 					MetCriteria   *[]string `json:"metCriteria,omitempty"`
 					Reasoning     *string   `json:"reasoning,omitempty"`
 					UnmetCriteria *[]string `json:"unmetCriteria,omitempty"`
@@ -119893,7 +127499,24 @@ func ParseGetApiSimulationRunsByScenarioRunIdResponse(rsp *http.Response) (*GetA
 			Note        *string `json:"note,omitempty"`
 			PlatformUrl string  `json:"platformUrl"`
 			Results     *struct {
-				Error         *string   `json:"error,omitempty"`
+				Error *string `json:"error,omitempty"`
+
+				// Evaluations One result per evaluator that ran on the scenario. Absent on a run with no evaluators, and on servers that predate evaluators.
+				Evaluations *[]struct {
+					Cost *struct {
+						Amount   float32 `json:"amount"`
+						Currency string  `json:"currency"`
+					} `json:"cost,omitempty"`
+					Details     *string                                                                        `json:"details,omitempty"`
+					EvaluatorId string                                                                         `json:"evaluatorId"`
+					Inputs      *map[string]string                                                             `json:"inputs,omitempty"`
+					Label       *string                                                                        `json:"label,omitempty"`
+					Name        string                                                                         `json:"name"`
+					Passed      *bool                                                                          `json:"passed,omitempty"`
+					Required    bool                                                                           `json:"required"`
+					Score       *float32                                                                       `json:"score,omitempty"`
+					Status      GetApiSimulationRunsByScenarioRunId200JSONResponseBodyResultsEvaluationsStatus `json:"status"`
+				} `json:"evaluations,omitempty"`
 				MetCriteria   *[]string `json:"metCriteria,omitempty"`
 				Reasoning     *string   `json:"reasoning,omitempty"`
 				UnmetCriteria *[]string `json:"unmetCriteria,omitempty"`
@@ -121928,6 +129551,9 @@ func ParseListAgentsResponse(rsp *http.Response) (*ListAgentsResponse, error) {
 				LastSeenAt *string `json:"lastSeenAt"`
 				Name       string  `json:"name"`
 
+				// NotSelectableReason Why the agent cannot be run by this credential. Null when it can.
+				NotSelectableReason *ListAgents200JSONResponseBodyDataNotSelectableReason `json:"notSelectableReason"`
+
 				// Owner The person a personal development agent belongs to. Null when the agent is shared or host-scoped.
 				Owner *struct {
 					Name   *string `json:"name"`
@@ -121948,6 +129574,9 @@ func ParseListAgentsResponse(rsp *http.Response) (*ListAgentsResponse, error) {
 					Type         *ListAgents200JSONResponseBodyDataParametersType              `json:"type,omitempty"`
 				} `json:"parameters"`
 				PlatformUrl string `json:"platformUrl"`
+
+				// Selectable Whether the credential making this request can run simulations against the agent. False for a personal development agent that belongs to somebody else, which is listed all the same so it can be told apart from the other agents of the same name.
+				Selectable bool `json:"selectable"`
 
 				// Status online while at least one process running the connected agent is connected; offline otherwise, and always for every other kind.
 				Status ListAgents200JSONResponseBodyDataStatus `json:"status"`
@@ -122020,6 +129649,9 @@ func ParseCreateAgentResponse(rsp *http.Response) (*CreateAgentResponse, error) 
 			LastSeenAt *string `json:"lastSeenAt"`
 			Name       string  `json:"name"`
 
+			// NotSelectableReason Why the agent cannot be run by this credential. Null when it can.
+			NotSelectableReason *CreateAgent201JSONResponseBodyNotSelectableReason `json:"notSelectableReason"`
+
 			// Owner The person a personal development agent belongs to. Null when the agent is shared or host-scoped.
 			Owner *struct {
 				Name   *string `json:"name"`
@@ -122040,6 +129672,9 @@ func ParseCreateAgentResponse(rsp *http.Response) (*CreateAgentResponse, error) 
 				Type         *CreateAgent201JSONResponseBodyParametersType             `json:"type,omitempty"`
 			} `json:"parameters"`
 			PlatformUrl string `json:"platformUrl"`
+
+			// Selectable Whether the credential making this request can run simulations against the agent. False for a personal development agent that belongs to somebody else, which is listed all the same so it can be told apart from the other agents of the same name.
+			Selectable bool `json:"selectable"`
 
 			// Status online while at least one process running the connected agent is connected; offline otherwise, and always for every other kind.
 			Status CreateAgent201JSONResponseBodyStatus `json:"status"`
@@ -122226,6 +129861,9 @@ func ParseGetAgentResponse(rsp *http.Response) (*GetAgentResponse, error) {
 			LastSeenAt *string `json:"lastSeenAt"`
 			Name       string  `json:"name"`
 
+			// NotSelectableReason Why the agent cannot be run by this credential. Null when it can.
+			NotSelectableReason *GetAgent200JSONResponseBodyNotSelectableReason `json:"notSelectableReason"`
+
 			// Owner The person a personal development agent belongs to. Null when the agent is shared or host-scoped.
 			Owner *struct {
 				Name   *string `json:"name"`
@@ -122246,6 +129884,9 @@ func ParseGetAgentResponse(rsp *http.Response) (*GetAgentResponse, error) {
 				Type         *GetAgent200JSONResponseBodyParametersType             `json:"type,omitempty"`
 			} `json:"parameters"`
 			PlatformUrl string `json:"platformUrl"`
+
+			// Selectable Whether the credential making this request can run simulations against the agent. False for a personal development agent that belongs to somebody else, which is listed all the same so it can be told apart from the other agents of the same name.
+			Selectable bool `json:"selectable"`
 
 			// Status online while at least one process running the connected agent is connected; offline otherwise, and always for every other kind.
 			Status GetAgent200JSONResponseBodyStatus `json:"status"`
@@ -122311,6 +129952,9 @@ func ParseUpdateAgentResponse(rsp *http.Response) (*UpdateAgentResponse, error) 
 			LastSeenAt *string `json:"lastSeenAt"`
 			Name       string  `json:"name"`
 
+			// NotSelectableReason Why the agent cannot be run by this credential. Null when it can.
+			NotSelectableReason *UpdateAgent200JSONResponseBodyNotSelectableReason `json:"notSelectableReason"`
+
 			// Owner The person a personal development agent belongs to. Null when the agent is shared or host-scoped.
 			Owner *struct {
 				Name   *string `json:"name"`
@@ -122331,6 +129975,9 @@ func ParseUpdateAgentResponse(rsp *http.Response) (*UpdateAgentResponse, error) 
 				Type         *UpdateAgent200JSONResponseBodyParametersType             `json:"type,omitempty"`
 			} `json:"parameters"`
 			PlatformUrl string `json:"platformUrl"`
+
+			// Selectable Whether the credential making this request can run simulations against the agent. False for a personal development agent that belongs to somebody else, which is listed all the same so it can be told apart from the other agents of the same name.
+			Selectable bool `json:"selectable"`
 
 			// Status online while at least one process running the connected agent is connected; offline otherwise, and always for every other kind.
 			Status UpdateAgent200JSONResponseBodyStatus `json:"status"`
@@ -122396,6 +130043,9 @@ func ParseReplaceAgentResponse(rsp *http.Response) (*ReplaceAgentResponse, error
 			LastSeenAt *string `json:"lastSeenAt"`
 			Name       string  `json:"name"`
 
+			// NotSelectableReason Why the agent cannot be run by this credential. Null when it can.
+			NotSelectableReason *ReplaceAgent200JSONResponseBodyNotSelectableReason `json:"notSelectableReason"`
+
 			// Owner The person a personal development agent belongs to. Null when the agent is shared or host-scoped.
 			Owner *struct {
 				Name   *string `json:"name"`
@@ -122416,6 +130066,9 @@ func ParseReplaceAgentResponse(rsp *http.Response) (*ReplaceAgentResponse, error
 				Type         *ReplaceAgent200JSONResponseBodyParametersType             `json:"type,omitempty"`
 			} `json:"parameters"`
 			PlatformUrl string `json:"platformUrl"`
+
+			// Selectable Whether the credential making this request can run simulations against the agent. False for a personal development agent that belongs to somebody else, which is listed all the same so it can be told apart from the other agents of the same name.
+			Selectable bool `json:"selectable"`
 
 			// Status online while at least one process running the connected agent is connected; offline otherwise, and always for every other kind.
 			Status ReplaceAgent200JSONResponseBodyStatus `json:"status"`
@@ -122496,6 +130149,277 @@ func ParseTestAgentResponse(rsp *http.Response) (*TestAgentResponse, error) {
 
 			// SetId The internal set that holds agent test runs.
 			SetId string `json:"setId"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetPullRequestUsageResponse parses an HTTP response from a GetPullRequestUsageWithResponse call
+func ParseGetPullRequestUsageResponse(rsp *http.Response) (*GetPullRequestUsageResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetPullRequestUsageResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest struct {
+			ModelBreakdown []struct {
+				CacheCreationTokens float32  `json:"cacheCreationTokens"`
+				CacheReadTokens     float32  `json:"cacheReadTokens"`
+				CostUsd             *float32 `json:"costUsd"`
+				InputTokens         float32  `json:"inputTokens"`
+				Model               string   `json:"model"`
+				OutputTokens        float32  `json:"outputTokens"`
+				TokensKnown         bool     `json:"tokensKnown"`
+				TotalTokens         float32  `json:"totalTokens"`
+			} `json:"modelBreakdown"`
+			PullRequest struct {
+				AuthorLogin        *string  `json:"authorLogin"`
+				HeadBranch         string   `json:"headBranch"`
+				HtmlUrl            string   `json:"htmlUrl"`
+				IsDraft            bool     `json:"isDraft"`
+				PrClosedAtMs       *float32 `json:"prClosedAtMs"`
+				PrCreatedAtMs      float32  `json:"prCreatedAtMs"`
+				PrMergedAtMs       *float32 `json:"prMergedAtMs"`
+				PrNumber           float32  `json:"prNumber"`
+				RepositoryFullName string   `json:"repositoryFullName"`
+				RepositoryHost     string   `json:"repositoryHost"`
+				State              string   `json:"state"`
+			} `json:"pullRequest"`
+			Rows []struct {
+				Agent                string   `json:"agent"`
+				BilledCostUsd        *float32 `json:"billedCostUsd"`
+				CacheCreationTokens  float32  `json:"cacheCreationTokens"`
+				CacheReadTokens      float32  `json:"cacheReadTokens"`
+				ContributorIsProject bool     `json:"contributorIsProject"`
+				ContributorLabel     string   `json:"contributorLabel"`
+				CostUsd              *float32 `json:"costUsd"`
+				InputTokens          float32  `json:"inputTokens"`
+				Models               []string `json:"models"`
+				NonBilledCostUsd     *float32 `json:"nonBilledCostUsd"`
+				OutputTokens         float32  `json:"outputTokens"`
+				ProjectId            string   `json:"projectId"`
+				ProjectSlug          string   `json:"projectSlug"`
+				SessionsCount        float32  `json:"sessionsCount"`
+				TotalTokens          float32  `json:"totalTokens"`
+			} `json:"rows"`
+			Totals struct {
+				BilledCostUsd       *float32 `json:"billedCostUsd"`
+				CacheCreationTokens float32  `json:"cacheCreationTokens"`
+				CacheReadTokens     float32  `json:"cacheReadTokens"`
+				CostUsd             *float32 `json:"costUsd"`
+				InputTokens         float32  `json:"inputTokens"`
+				NonBilledCostUsd    *float32 `json:"nonBilledCostUsd"`
+				OutputTokens        float32  `json:"outputTokens"`
+				SessionsCount       float32  `json:"sessionsCount"`
+				TotalTokens         float32  `json:"totalTokens"`
+			} `json:"totals"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParsePostLangyControlFramesResponse parses an HTTP response from a PostLangyControlFramesWithResponse call
+func ParsePostLangyControlFramesResponse(rsp *http.Response) (*PostLangyControlFramesResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &PostLangyControlFramesResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest struct {
+			// Accepted How many frames were taken.
+			Accepted int `json:"accepted"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParsePollLangyControlSessionResponse parses an HTTP response from a PollLangyControlSessionWithResponse call
+func ParsePollLangyControlSessionResponse(rsp *http.Response) (*PollLangyControlSessionResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &PollLangyControlSessionResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest struct {
+			// Frames The frames waiting for the folder; empty once the poll wait passes with none.
+			Frames []PollLangyControlSession200JSONResponseBody_Frames_Item `json:"frames"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseRegisterLangyControlSessionResponse parses an HTTP response from a RegisterLangyControlSessionWithResponse call
+func ParseRegisterLangyControlSessionResponse(rsp *http.Response) (*RegisterLangyControlSessionResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &RegisterLangyControlSessionResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest struct {
+			// Frame The registered frame, or the refused frame with its reason.
+			Frame RegisterLangyControlSession200JSONResponseBody_Frame `json:"frame"`
+
+			// InstanceToken The token the poll and frames endpoints are addressed with, in the X-Agent-Instance-Token header. Present when the register was accepted.
+			InstanceToken *string `json:"instanceToken,omitempty"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListLangyControlRequestsResponse parses an HTTP response from a ListLangyControlRequestsWithResponse call
+func ParseListLangyControlRequestsResponse(rsp *http.Response) (*ListLangyControlRequestsResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListLangyControlRequestsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest struct {
+			Requests []struct {
+				ConversationId    string `json:"conversationId"`
+				ConversationTitle string `json:"conversationTitle"`
+				ConversationUrl   string `json:"conversationUrl"`
+				CreatedAt         string `json:"createdAt"`
+				ExpiresAt         string `json:"expiresAt"`
+				Id                string `json:"id"`
+				ProjectId         string `json:"projectId"`
+				ProjectName       string `json:"projectName"`
+			} `json:"requests"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseApproveLangyControlRequestResponse parses an HTTP response from a ApproveLangyControlRequestWithResponse call
+func ParseApproveLangyControlRequestResponse(rsp *http.Response) (*ApproveLangyControlRequestResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ApproveLangyControlRequestResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest struct {
+			Conversation struct {
+				Id    string `json:"id"`
+				Title string `json:"title"`
+				Url   string `json:"url"`
+			} `json:"conversation"`
+			Endpoint   string `json:"endpoint"`
+			SessionKey string `json:"sessionKey"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseCancelLangyControlRequestResponse parses an HTTP response from a CancelLangyControlRequestWithResponse call
+func ParseCancelLangyControlRequestResponse(rsp *http.Response) (*CancelLangyControlRequestResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &CancelLangyControlRequestResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest struct {
+			// Cancelled Always true once the request is gone.
+			Cancelled CancelLangyControlRequest200JSONResponseBodyCancelled `json:"cancelled"`
+
+			// Id The request that was cancelled.
+			Id string `json:"id"`
 		}
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
@@ -123290,15 +131214,734 @@ func ParsePutApiV1ProjectsByProjectIdAnalyticsChartsByChartIdPlacementResponse(r
 	return response, nil
 }
 
-// ParsePostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseResponse parses an HTTP response from a PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseWithResponse call
-func ParsePostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseResponse(rsp *http.Response) (*PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseResponse, error) {
+// ParseGetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsResponse parses an HTTP response from a GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsWithResponse call
+func ParseGetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsResponse(rsp *http.Response) (*GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseResponse{
+	response := &GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest struct {
+			Data []struct {
+				ColSpan     int     `json:"colSpan"`
+				CreatedAt   string  `json:"createdAt"`
+				DashboardId *string `json:"dashboardId"`
+				Definition  struct {
+					Code    string `json:"code"`
+					Queries []struct {
+						Name       string `json:"name"`
+						Parameters *[]struct {
+							Default *GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBody_Data_Definition_Queries_Parameters_Default `json:"default,omitempty"`
+							Name    string                                                                                                              `json:"name"`
+							Type    GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgets200JSONResponseBodyDataDefinitionQueriesParametersType          `json:"type"`
+						} `json:"parameters,omitempty"`
+						Sql string `json:"sql"`
+					} `json:"queries"`
+					Version float32 `json:"version"`
+				} `json:"definition"`
+				GridColumn  int    `json:"gridColumn"`
+				GridRow     int    `json:"gridRow"`
+				Id          string `json:"id"`
+				Name        string `json:"name"`
+				PlatformUrl string `json:"platformUrl"`
+				RowSpan     int    `json:"rowSpan"`
+				UpdatedAt   string `json:"updatedAt"`
+			} `json:"data"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest struct {
+			Error struct {
+				Code    string                  `json:"code"`
+				Message string                  `json:"message"`
+				Meta    *map[string]interface{} `json:"meta,omitempty"`
+				SpanId  *string                 `json:"span_id,omitempty"`
+				TraceId *string                 `json:"trace_id,omitempty"`
+				Type    string                  `json:"type"`
+			} `json:"error"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest struct {
+			Error struct {
+				Code    string                  `json:"code"`
+				Message string                  `json:"message"`
+				Meta    *map[string]interface{} `json:"meta,omitempty"`
+				SpanId  *string                 `json:"span_id,omitempty"`
+				TraceId *string                 `json:"trace_id,omitempty"`
+				Type    string                  `json:"type"`
+			} `json:"error"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest struct {
+			Error struct {
+				Code    string                  `json:"code"`
+				Message string                  `json:"message"`
+				Meta    *map[string]interface{} `json:"meta,omitempty"`
+				SpanId  *string                 `json:"span_id,omitempty"`
+				TraceId *string                 `json:"trace_id,omitempty"`
+				Type    string                  `json:"type"`
+			} `json:"error"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest struct {
+			Error struct {
+				Code    string                  `json:"code"`
+				Message string                  `json:"message"`
+				Meta    *map[string]interface{} `json:"meta,omitempty"`
+				SpanId  *string                 `json:"span_id,omitempty"`
+				TraceId *string                 `json:"trace_id,omitempty"`
+				Type    string                  `json:"type"`
+			} `json:"error"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParsePostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsResponse parses an HTTP response from a PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsWithResponse call
+func ParsePostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsResponse(rsp *http.Response) (*PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
+		var dest struct {
+			ColSpan     int     `json:"colSpan"`
+			CreatedAt   string  `json:"createdAt"`
+			DashboardId *string `json:"dashboardId"`
+			Definition  struct {
+				Code    string `json:"code"`
+				Queries []struct {
+					Name       string `json:"name"`
+					Parameters *[]struct {
+						Default *PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBody_Definition_Queries_Parameters_Default `json:"default,omitempty"`
+						Name    string                                                                                                          `json:"name"`
+						Type    PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgets201JSONResponseBodyDefinitionQueriesParametersType         `json:"type"`
+					} `json:"parameters,omitempty"`
+					Sql string `json:"sql"`
+				} `json:"queries"`
+				Version float32 `json:"version"`
+			} `json:"definition"`
+			GridColumn  int    `json:"gridColumn"`
+			GridRow     int    `json:"gridRow"`
+			Id          string `json:"id"`
+			Name        string `json:"name"`
+			PlatformUrl string `json:"platformUrl"`
+			RowSpan     int    `json:"rowSpan"`
+			UpdatedAt   string `json:"updatedAt"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON201 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest struct {
+			Error struct {
+				Code    string                  `json:"code"`
+				Message string                  `json:"message"`
+				Meta    *map[string]interface{} `json:"meta,omitempty"`
+				SpanId  *string                 `json:"span_id,omitempty"`
+				TraceId *string                 `json:"trace_id,omitempty"`
+				Type    string                  `json:"type"`
+			} `json:"error"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest struct {
+			Error struct {
+				Code    string                  `json:"code"`
+				Message string                  `json:"message"`
+				Meta    *map[string]interface{} `json:"meta,omitempty"`
+				SpanId  *string                 `json:"span_id,omitempty"`
+				TraceId *string                 `json:"trace_id,omitempty"`
+				Type    string                  `json:"type"`
+			} `json:"error"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest struct {
+			Error struct {
+				Code    string                  `json:"code"`
+				Message string                  `json:"message"`
+				Meta    *map[string]interface{} `json:"meta,omitempty"`
+				SpanId  *string                 `json:"span_id,omitempty"`
+				TraceId *string                 `json:"trace_id,omitempty"`
+				Type    string                  `json:"type"`
+			} `json:"error"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest struct {
+			Error struct {
+				Code    string                  `json:"code"`
+				Message string                  `json:"message"`
+				Meta    *map[string]interface{} `json:"meta,omitempty"`
+				SpanId  *string                 `json:"span_id,omitempty"`
+				TraceId *string                 `json:"trace_id,omitempty"`
+				Type    string                  `json:"type"`
+			} `json:"error"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseDeleteApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdResponse parses an HTTP response from a DeleteApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdWithResponse call
+func ParseDeleteApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdResponse(rsp *http.Response) (*DeleteApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &DeleteApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest struct {
+			Error struct {
+				Code    string                  `json:"code"`
+				Message string                  `json:"message"`
+				Meta    *map[string]interface{} `json:"meta,omitempty"`
+				SpanId  *string                 `json:"span_id,omitempty"`
+				TraceId *string                 `json:"trace_id,omitempty"`
+				Type    string                  `json:"type"`
+			} `json:"error"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest struct {
+			Error struct {
+				Code    string                  `json:"code"`
+				Message string                  `json:"message"`
+				Meta    *map[string]interface{} `json:"meta,omitempty"`
+				SpanId  *string                 `json:"span_id,omitempty"`
+				TraceId *string                 `json:"trace_id,omitempty"`
+				Type    string                  `json:"type"`
+			} `json:"error"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest struct {
+			Error struct {
+				Code    string                  `json:"code"`
+				Message string                  `json:"message"`
+				Meta    *map[string]interface{} `json:"meta,omitempty"`
+				SpanId  *string                 `json:"span_id,omitempty"`
+				TraceId *string                 `json:"trace_id,omitempty"`
+				Type    string                  `json:"type"`
+			} `json:"error"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest struct {
+			Error struct {
+				Code    string                  `json:"code"`
+				Message string                  `json:"message"`
+				Meta    *map[string]interface{} `json:"meta,omitempty"`
+				SpanId  *string                 `json:"span_id,omitempty"`
+				TraceId *string                 `json:"trace_id,omitempty"`
+				Type    string                  `json:"type"`
+			} `json:"error"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest struct {
+			Error struct {
+				Code    string                  `json:"code"`
+				Message string                  `json:"message"`
+				Meta    *map[string]interface{} `json:"meta,omitempty"`
+				SpanId  *string                 `json:"span_id,omitempty"`
+				TraceId *string                 `json:"trace_id,omitempty"`
+				Type    string                  `json:"type"`
+			} `json:"error"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdResponse parses an HTTP response from a GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdWithResponse call
+func ParseGetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdResponse(rsp *http.Response) (*GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest struct {
+			ColSpan     int     `json:"colSpan"`
+			CreatedAt   string  `json:"createdAt"`
+			DashboardId *string `json:"dashboardId"`
+			Definition  struct {
+				Code    string `json:"code"`
+				Queries []struct {
+					Name       string `json:"name"`
+					Parameters *[]struct {
+						Default *GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBody_Definition_Queries_Parameters_Default `json:"default,omitempty"`
+						Name    string                                                                                                                   `json:"name"`
+						Type    GetApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersType         `json:"type"`
+					} `json:"parameters,omitempty"`
+					Sql string `json:"sql"`
+				} `json:"queries"`
+				Version float32 `json:"version"`
+			} `json:"definition"`
+			GridColumn  int    `json:"gridColumn"`
+			GridRow     int    `json:"gridRow"`
+			Id          string `json:"id"`
+			Name        string `json:"name"`
+			PlatformUrl string `json:"platformUrl"`
+			RowSpan     int    `json:"rowSpan"`
+			UpdatedAt   string `json:"updatedAt"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest struct {
+			Error struct {
+				Code    string                  `json:"code"`
+				Message string                  `json:"message"`
+				Meta    *map[string]interface{} `json:"meta,omitempty"`
+				SpanId  *string                 `json:"span_id,omitempty"`
+				TraceId *string                 `json:"trace_id,omitempty"`
+				Type    string                  `json:"type"`
+			} `json:"error"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest struct {
+			Error struct {
+				Code    string                  `json:"code"`
+				Message string                  `json:"message"`
+				Meta    *map[string]interface{} `json:"meta,omitempty"`
+				SpanId  *string                 `json:"span_id,omitempty"`
+				TraceId *string                 `json:"trace_id,omitempty"`
+				Type    string                  `json:"type"`
+			} `json:"error"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest struct {
+			Error struct {
+				Code    string                  `json:"code"`
+				Message string                  `json:"message"`
+				Meta    *map[string]interface{} `json:"meta,omitempty"`
+				SpanId  *string                 `json:"span_id,omitempty"`
+				TraceId *string                 `json:"trace_id,omitempty"`
+				Type    string                  `json:"type"`
+			} `json:"error"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest struct {
+			Error struct {
+				Code    string                  `json:"code"`
+				Message string                  `json:"message"`
+				Meta    *map[string]interface{} `json:"meta,omitempty"`
+				SpanId  *string                 `json:"span_id,omitempty"`
+				TraceId *string                 `json:"trace_id,omitempty"`
+				Type    string                  `json:"type"`
+			} `json:"error"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest struct {
+			Error struct {
+				Code    string                  `json:"code"`
+				Message string                  `json:"message"`
+				Meta    *map[string]interface{} `json:"meta,omitempty"`
+				SpanId  *string                 `json:"span_id,omitempty"`
+				TraceId *string                 `json:"trace_id,omitempty"`
+				Type    string                  `json:"type"`
+			} `json:"error"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParsePatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdResponse parses an HTTP response from a PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdWithResponse call
+func ParsePatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdResponse(rsp *http.Response) (*PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest struct {
+			ColSpan     int     `json:"colSpan"`
+			CreatedAt   string  `json:"createdAt"`
+			DashboardId *string `json:"dashboardId"`
+			Definition  struct {
+				Code    string `json:"code"`
+				Queries []struct {
+					Name       string `json:"name"`
+					Parameters *[]struct {
+						Default *PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBody_Definition_Queries_Parameters_Default `json:"default,omitempty"`
+						Name    string                                                                                                                     `json:"name"`
+						Type    PatchApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetId200JSONResponseBodyDefinitionQueriesParametersType         `json:"type"`
+					} `json:"parameters,omitempty"`
+					Sql string `json:"sql"`
+				} `json:"queries"`
+				Version float32 `json:"version"`
+			} `json:"definition"`
+			GridColumn  int    `json:"gridColumn"`
+			GridRow     int    `json:"gridRow"`
+			Id          string `json:"id"`
+			Name        string `json:"name"`
+			PlatformUrl string `json:"platformUrl"`
+			RowSpan     int    `json:"rowSpan"`
+			UpdatedAt   string `json:"updatedAt"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest struct {
+			Error struct {
+				Code    string                  `json:"code"`
+				Message string                  `json:"message"`
+				Meta    *map[string]interface{} `json:"meta,omitempty"`
+				SpanId  *string                 `json:"span_id,omitempty"`
+				TraceId *string                 `json:"trace_id,omitempty"`
+				Type    string                  `json:"type"`
+			} `json:"error"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest struct {
+			Error struct {
+				Code    string                  `json:"code"`
+				Message string                  `json:"message"`
+				Meta    *map[string]interface{} `json:"meta,omitempty"`
+				SpanId  *string                 `json:"span_id,omitempty"`
+				TraceId *string                 `json:"trace_id,omitempty"`
+				Type    string                  `json:"type"`
+			} `json:"error"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest struct {
+			Error struct {
+				Code    string                  `json:"code"`
+				Message string                  `json:"message"`
+				Meta    *map[string]interface{} `json:"meta,omitempty"`
+				SpanId  *string                 `json:"span_id,omitempty"`
+				TraceId *string                 `json:"trace_id,omitempty"`
+				Type    string                  `json:"type"`
+			} `json:"error"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest struct {
+			Error struct {
+				Code    string                  `json:"code"`
+				Message string                  `json:"message"`
+				Meta    *map[string]interface{} `json:"meta,omitempty"`
+				SpanId  *string                 `json:"span_id,omitempty"`
+				TraceId *string                 `json:"trace_id,omitempty"`
+				Type    string                  `json:"type"`
+			} `json:"error"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest struct {
+			Error struct {
+				Code    string                  `json:"code"`
+				Message string                  `json:"message"`
+				Meta    *map[string]interface{} `json:"meta,omitempty"`
+				SpanId  *string                 `json:"span_id,omitempty"`
+				TraceId *string                 `json:"trace_id,omitempty"`
+				Type    string                  `json:"type"`
+			} `json:"error"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParsePostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboardResponse parses an HTTP response from a PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboardWithResponse call
+func ParsePostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboardResponse(rsp *http.Response) (*PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboardResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboardResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest struct {
+			ColSpan     int     `json:"colSpan"`
+			CreatedAt   string  `json:"createdAt"`
+			DashboardId *string `json:"dashboardId"`
+			Definition  struct {
+				Code    string `json:"code"`
+				Queries []struct {
+					Name       string `json:"name"`
+					Parameters *[]struct {
+						Default *PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBody_Definition_Queries_Parameters_Default `json:"default,omitempty"`
+						Name    string                                                                                                                             `json:"name"`
+						Type    PostApiV1ProjectsByProjectIdAnalyticsDashboardWidgetsByWidgetIdDashboard200JSONResponseBodyDefinitionQueriesParametersType         `json:"type"`
+					} `json:"parameters,omitempty"`
+					Sql string `json:"sql"`
+				} `json:"queries"`
+				Version float32 `json:"version"`
+			} `json:"definition"`
+			GridColumn  int    `json:"gridColumn"`
+			GridRow     int    `json:"gridRow"`
+			Id          string `json:"id"`
+			Name        string `json:"name"`
+			PlatformUrl string `json:"platformUrl"`
+			RowSpan     int    `json:"rowSpan"`
+			UpdatedAt   string `json:"updatedAt"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest struct {
+			Error struct {
+				Code    string                  `json:"code"`
+				Message string                  `json:"message"`
+				Meta    *map[string]interface{} `json:"meta,omitempty"`
+				SpanId  *string                 `json:"span_id,omitempty"`
+				TraceId *string                 `json:"trace_id,omitempty"`
+				Type    string                  `json:"type"`
+			} `json:"error"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest struct {
+			Error struct {
+				Code    string                  `json:"code"`
+				Message string                  `json:"message"`
+				Meta    *map[string]interface{} `json:"meta,omitempty"`
+				SpanId  *string                 `json:"span_id,omitempty"`
+				TraceId *string                 `json:"trace_id,omitempty"`
+				Type    string                  `json:"type"`
+			} `json:"error"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest struct {
+			Error struct {
+				Code    string                  `json:"code"`
+				Message string                  `json:"message"`
+				Meta    *map[string]interface{} `json:"meta,omitempty"`
+				SpanId  *string                 `json:"span_id,omitempty"`
+				TraceId *string                 `json:"trace_id,omitempty"`
+				Type    string                  `json:"type"`
+			} `json:"error"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest struct {
+			Error struct {
+				Code    string                  `json:"code"`
+				Message string                  `json:"message"`
+				Meta    *map[string]interface{} `json:"meta,omitempty"`
+				SpanId  *string                 `json:"span_id,omitempty"`
+				TraceId *string                 `json:"trace_id,omitempty"`
+				Type    string                  `json:"type"`
+			} `json:"error"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest struct {
+			Error struct {
+				Code    string                  `json:"code"`
+				Message string                  `json:"message"`
+				Meta    *map[string]interface{} `json:"meta,omitempty"`
+				SpanId  *string                 `json:"span_id,omitempty"`
+				TraceId *string                 `json:"trace_id,omitempty"`
+				Type    string                  `json:"type"`
+			} `json:"error"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParsePostApiV1QueryResponse parses an HTTP response from a PostApiV1QueryWithResponse call
+func ParsePostApiV1QueryResponse(rsp *http.Response) (*PostApiV1QueryResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &PostApiV1QueryResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -123312,9 +131955,9 @@ func ParsePostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseResponse(rsp *http
 				Type string `json:"type"`
 			} `json:"columns"`
 			Diagnostics []struct {
-				Code    PostApiV1ProjectsByProjectIdAnalyticsQueryClickhouse200JSONResponseBodyDiagnosticsCode `json:"code"`
-				Message string                                                                                 `json:"message"`
-				Meta    *map[string]interface{}                                                                `json:"meta,omitempty"`
+				Code    PostApiV1Query200JSONResponseBodyDiagnosticsCode `json:"code"`
+				Message string                                           `json:"message"`
+				Meta    *map[string]interface{}                          `json:"meta,omitempty"`
 			} `json:"diagnostics"`
 			FollowsGranularity bool                     `json:"followsGranularity"`
 			FollowsTimeWindow  bool                     `json:"followsTimeWindow"`
@@ -123418,15 +132061,15 @@ func ParsePostApiV1ProjectsByProjectIdAnalyticsQueryClickhouseResponse(rsp *http
 	return response, nil
 }
 
-// ParseGetApiV1ProjectsByProjectIdAnalyticsSchemaResponse parses an HTTP response from a GetApiV1ProjectsByProjectIdAnalyticsSchemaWithResponse call
-func ParseGetApiV1ProjectsByProjectIdAnalyticsSchemaResponse(rsp *http.Response) (*GetApiV1ProjectsByProjectIdAnalyticsSchemaResponse, error) {
+// ParseGetApiV1QuerySchemaResponse parses an HTTP response from a GetApiV1QuerySchemaWithResponse call
+func ParseGetApiV1QuerySchemaResponse(rsp *http.Response) (*GetApiV1QuerySchemaResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &GetApiV1ProjectsByProjectIdAnalyticsSchemaResponse{
+	response := &GetApiV1QuerySchemaResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -123437,12 +132080,12 @@ func ParseGetApiV1ProjectsByProjectIdAnalyticsSchemaResponse(rsp *http.Response)
 			Database string `json:"database"`
 			Datasets []struct {
 				Columns []struct {
-					Available   bool                                                                                `json:"available"`
-					Description string                                                                              `json:"description"`
-					Gates       []GetApiV1ProjectsByProjectIdAnalyticsSchema200JSONResponseBodyDatasetsColumnsGates `json:"gates"`
-					Name        string                                                                              `json:"name"`
-					Type        string                                                                              `json:"type"`
-					Unit        *GetApiV1ProjectsByProjectIdAnalyticsSchema200JSONResponseBodyDatasetsColumnsUnit   `json:"unit"`
+					Available   bool                                                         `json:"available"`
+					Description string                                                       `json:"description"`
+					Gates       []GetApiV1QuerySchema200JSONResponseBodyDatasetsColumnsGates `json:"gates"`
+					Name        string                                                       `json:"name"`
+					Type        string                                                       `json:"type"`
+					Unit        *GetApiV1QuerySchema200JSONResponseBodyDatasetsColumnsUnit   `json:"unit"`
 				} `json:"columns"`
 				Description string   `json:"description"`
 				ExampleSql  string   `json:"exampleSql"`
@@ -123548,6 +132191,21 @@ func ParseListRunPlansResponse(rsp *http.Response) (*ListRunPlansResponse, error
 
 			// CreatedAt When the plan was created.
 			CreatedAt string `json:"createdAt"`
+
+			// Evaluators The plan's own evaluators. Absent on servers that predate evaluators on this family.
+			Evaluators *[]struct {
+				// EvaluatorId The id of the saved evaluator this attachment runs.
+				EvaluatorId string `json:"evaluatorId"`
+
+				// Id The attachment id. Stable across edits of the attachment.
+				Id string `json:"id"`
+
+				// Mappings Where each evaluator input reads its value, keyed by input name. Inputs left out are unmapped; a required input left unmapped refuses the run.
+				Mappings map[string]ListRunPlans200JSONResponseBody_Evaluators_Mappings_AdditionalProperties `json:"mappings"`
+
+				// Required Whether a failing result fails the scenario. A score-only evaluator reports and never gates.
+				Required bool `json:"required"`
+			} `json:"evaluators,omitempty"`
 
 			// Id The run plan id.
 			Id string `json:"id"`
@@ -123741,6 +132399,21 @@ func ParseGetRunPlanResponse(rsp *http.Response) (*GetRunPlanResponse, error) {
 			// CreatedAt When the plan was created.
 			CreatedAt string `json:"createdAt"`
 
+			// Evaluators The plan's own evaluators. Absent on servers that predate evaluators on this family.
+			Evaluators *[]struct {
+				// EvaluatorId The id of the saved evaluator this attachment runs.
+				EvaluatorId string `json:"evaluatorId"`
+
+				// Id The attachment id. Stable across edits of the attachment.
+				Id string `json:"id"`
+
+				// Mappings Where each evaluator input reads its value, keyed by input name. Inputs left out are unmapped; a required input left unmapped refuses the run.
+				Mappings map[string]GetRunPlan200JSONResponseBody_Evaluators_Mappings_AdditionalProperties `json:"mappings"`
+
+				// Required Whether a failing result fails the scenario. A score-only evaluator reports and never gates.
+				Required bool `json:"required"`
+			} `json:"evaluators,omitempty"`
+
 			// Id The run plan id.
 			Id string `json:"id"`
 
@@ -123901,6 +132574,30 @@ func ParseListTestSuitesResponse(rsp *http.Response) (*ListTestSuitesResponse, e
 			// CreatedAt When the suite was created.
 			CreatedAt string `json:"createdAt"`
 
+			// Evaluators The evaluators attached to the test suite. Absent on servers that predate evaluators on this family.
+			Evaluators *[]struct {
+				// EvaluatorId The id of the saved evaluator this attachment runs.
+				EvaluatorId string `json:"evaluatorId"`
+
+				// Id The attachment id. Stable across edits of the attachment.
+				Id string `json:"id"`
+
+				// Mappings Where each evaluator input reads its value, keyed by input name. Inputs left out are unmapped; a required input left unmapped refuses the run.
+				Mappings map[string]ListTestSuites200JSONResponseBody_Evaluators_Mappings_AdditionalProperties `json:"mappings"`
+
+				// Required Whether a failing result fails the scenario. A score-only evaluator reports and never gates.
+				Required bool `json:"required"`
+			} `json:"evaluators,omitempty"`
+
+			// Fields The fields the test suite declares. Absent on servers that predate fields on this family.
+			Fields *[]struct {
+				// Identifier The field name, as scenarios and evaluator mappings address it. Lowercase letters, digits and underscores, starting with a letter.
+				Identifier string `json:"identifier"`
+
+				// Type The value type every scenario carries for this field.
+				Type ListTestSuites200JSONResponseBodyFieldsType `json:"type"`
+			} `json:"fields,omitempty"`
+
 			// Id The test suite id.
 			Id string `json:"id"`
 
@@ -123953,6 +132650,30 @@ func ParseCreateTestSuiteResponse(rsp *http.Response) (*CreateTestSuiteResponse,
 
 			// CreatedAt When the suite was created.
 			CreatedAt string `json:"createdAt"`
+
+			// Evaluators The evaluators attached to the test suite. Absent on servers that predate evaluators on this family.
+			Evaluators *[]struct {
+				// EvaluatorId The id of the saved evaluator this attachment runs.
+				EvaluatorId string `json:"evaluatorId"`
+
+				// Id The attachment id. Stable across edits of the attachment.
+				Id string `json:"id"`
+
+				// Mappings Where each evaluator input reads its value, keyed by input name. Inputs left out are unmapped; a required input left unmapped refuses the run.
+				Mappings map[string]CreateTestSuite201JSONResponseBody_Evaluators_Mappings_AdditionalProperties `json:"mappings"`
+
+				// Required Whether a failing result fails the scenario. A score-only evaluator reports and never gates.
+				Required bool `json:"required"`
+			} `json:"evaluators,omitempty"`
+
+			// Fields The fields the test suite declares. Absent on servers that predate fields on this family.
+			Fields *[]struct {
+				// Identifier The field name, as scenarios and evaluator mappings address it. Lowercase letters, digits and underscores, starting with a letter.
+				Identifier string `json:"identifier"`
+
+				// Type The value type every scenario carries for this field.
+				Type CreateTestSuite201JSONResponseBodyFieldsType `json:"type"`
+			} `json:"fields,omitempty"`
 
 			// Id The test suite id.
 			Id string `json:"id"`
@@ -124039,6 +132760,30 @@ func ParseGetTestSuiteResponse(rsp *http.Response) (*GetTestSuiteResponse, error
 			// CreatedAt When the suite was created.
 			CreatedAt string `json:"createdAt"`
 
+			// Evaluators The evaluators attached to the test suite. Absent on servers that predate evaluators on this family.
+			Evaluators *[]struct {
+				// EvaluatorId The id of the saved evaluator this attachment runs.
+				EvaluatorId string `json:"evaluatorId"`
+
+				// Id The attachment id. Stable across edits of the attachment.
+				Id string `json:"id"`
+
+				// Mappings Where each evaluator input reads its value, keyed by input name. Inputs left out are unmapped; a required input left unmapped refuses the run.
+				Mappings map[string]GetTestSuite200JSONResponseBody_Evaluators_Mappings_AdditionalProperties `json:"mappings"`
+
+				// Required Whether a failing result fails the scenario. A score-only evaluator reports and never gates.
+				Required bool `json:"required"`
+			} `json:"evaluators,omitempty"`
+
+			// Fields The fields the test suite declares. Absent on servers that predate fields on this family.
+			Fields *[]struct {
+				// Identifier The field name, as scenarios and evaluator mappings address it. Lowercase letters, digits and underscores, starting with a letter.
+				Identifier string `json:"identifier"`
+
+				// Type The value type every scenario carries for this field.
+				Type GetTestSuite200JSONResponseBodyFieldsType `json:"type"`
+			} `json:"fields,omitempty"`
+
 			// Id The test suite id.
 			Id string `json:"id"`
 
@@ -124079,15 +132824,15 @@ func ParseGetTestSuiteResponse(rsp *http.Response) (*GetTestSuiteResponse, error
 	return response, nil
 }
 
-// ParseRenameTestSuiteResponse parses an HTTP response from a RenameTestSuiteWithResponse call
-func ParseRenameTestSuiteResponse(rsp *http.Response) (*RenameTestSuiteResponse, error) {
+// ParseUpdateTestSuiteResponse parses an HTTP response from a UpdateTestSuiteWithResponse call
+func ParseUpdateTestSuiteResponse(rsp *http.Response) (*UpdateTestSuiteResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &RenameTestSuiteResponse{
+	response := &UpdateTestSuiteResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -124100,6 +132845,30 @@ func ParseRenameTestSuiteResponse(rsp *http.Response) (*RenameTestSuiteResponse,
 
 			// CreatedAt When the suite was created.
 			CreatedAt string `json:"createdAt"`
+
+			// Evaluators The evaluators attached to the test suite. Absent on servers that predate evaluators on this family.
+			Evaluators *[]struct {
+				// EvaluatorId The id of the saved evaluator this attachment runs.
+				EvaluatorId string `json:"evaluatorId"`
+
+				// Id The attachment id. Stable across edits of the attachment.
+				Id string `json:"id"`
+
+				// Mappings Where each evaluator input reads its value, keyed by input name. Inputs left out are unmapped; a required input left unmapped refuses the run.
+				Mappings map[string]UpdateTestSuite200JSONResponseBody_Evaluators_Mappings_AdditionalProperties `json:"mappings"`
+
+				// Required Whether a failing result fails the scenario. A score-only evaluator reports and never gates.
+				Required bool `json:"required"`
+			} `json:"evaluators,omitempty"`
+
+			// Fields The fields the test suite declares. Absent on servers that predate fields on this family.
+			Fields *[]struct {
+				// Identifier The field name, as scenarios and evaluator mappings address it. Lowercase letters, digits and underscores, starting with a letter.
+				Identifier string `json:"identifier"`
+
+				// Type The value type every scenario carries for this field.
+				Type UpdateTestSuite200JSONResponseBodyFieldsType `json:"type"`
+			} `json:"fields,omitempty"`
 
 			// Id The test suite id.
 			Id string `json:"id"`

--- a/sdks/go/client/services_test.go
+++ b/sdks/go/client/services_test.go
@@ -120,8 +120,40 @@ func TestTraces(t *testing.T) {
 }
 
 func TestAnnotations(t *testing.T) {
-	t.Run("given a trace", func(t *testing.T) {
-		t.Run("when creating an annotation", func(t *testing.T) {
+	t.Run("given the API wraps annotations in a data envelope", func(t *testing.T) {
+		t.Run("when listing every annotation", func(t *testing.T) {
+			c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, "/api/annotations", r.URL.Path)
+				_, _ = w.Write([]byte(`{"data":[{"id":"ann_1"},{"id":"ann_2"}]}`))
+			})
+			list, err := c.Annotations.List(context.Background())
+			require.NoError(t, err)
+			require.Len(t, list, 2)
+			assert.Equal(t, "ann_1", list[0].Id)
+		})
+
+		t.Run("when fetching one annotation by id", func(t *testing.T) {
+			c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, "/api/annotations/ann_1", r.URL.Path)
+				_, _ = w.Write([]byte(`{"data":{"id":"ann_1","comment":"Great"}}`))
+			})
+			a, err := c.Annotations.Get(context.Background(), "ann_1")
+			require.NoError(t, err)
+			assert.Equal(t, "ann_1", a.Id)
+		})
+
+		t.Run("when listing the annotations on a trace", func(t *testing.T) {
+			c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, "/api/annotations/trace/trace_1", r.URL.Path)
+				_, _ = w.Write([]byte(`{"data":[{"id":"ann_1"}]}`))
+			})
+			list, err := c.Annotations.ListByTrace(context.Background(), "trace_1")
+			require.NoError(t, err)
+			require.Len(t, list, 1)
+			assert.Equal(t, "ann_1", list[0].Id)
+		})
+
+		t.Run("when attaching an annotation to a trace", func(t *testing.T) {
 			var mu sync.Mutex
 			var gotBody map[string]any
 			c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
@@ -131,7 +163,7 @@ func TestAnnotations(t *testing.T) {
 				mu.Lock()
 				_ = json.Unmarshal(raw, &gotBody)
 				mu.Unlock()
-				_, _ = w.Write([]byte(`{"id":"ann_1","traceId":"trace_1","comment":"Great","isThumbsUp":true}`))
+				_, _ = w.Write([]byte(`{"data":{"id":"ann_1","traceId":"trace_1","comment":"Great","isThumbsUp":true}}`))
 			})
 
 			up := true
@@ -144,18 +176,99 @@ func TestAnnotations(t *testing.T) {
 			defer mu.Unlock()
 			assert.Equal(t, "Great", gotBody["comment"])
 			assert.Equal(t, true, gotBody["isThumbsUp"])
-			require.NotNil(t, a.Id)
-			assert.Equal(t, "ann_1", *a.Id)
+			assert.Equal(t, "ann_1", a.Id)
 		})
 
-		t.Run("when listing by trace", func(t *testing.T) {
+		t.Run("when updating an annotation", func(t *testing.T) {
+			var mu sync.Mutex
+			var gotBody map[string]any
 			c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
-				assert.Equal(t, "/api/annotations/trace/trace_1", r.URL.Path)
-				_, _ = w.Write([]byte(`[{"id":"ann_1"}]`))
+				assert.Equal(t, http.MethodPatch, r.Method)
+				assert.Equal(t, "/api/annotations/ann_1", r.URL.Path)
+				raw, _ := io.ReadAll(r.Body)
+				mu.Lock()
+				_ = json.Unmarshal(raw, &gotBody)
+				mu.Unlock()
+				_, _ = w.Write([]byte(`{"data":{"id":"ann_1","comment":"Edited","isThumbsUp":false}}`))
 			})
-			list, err := c.Annotations.ListByTrace(context.Background(), "trace_1")
+
+			down := false
+			a, err := c.Annotations.Update(context.Background(), "ann_1", AnnotationParams{
+				Comment:    "Edited",
+				IsThumbsUp: &down,
+			})
 			require.NoError(t, err)
-			require.Len(t, list, 1)
+			mu.Lock()
+			defer mu.Unlock()
+			// The API requires both fields on a patch, so both must reach the wire.
+			assert.Equal(t, "Edited", gotBody["comment"])
+			assert.Equal(t, false, gotBody["isThumbsUp"])
+			require.NotNil(t, a.Comment)
+			assert.Equal(t, "Edited", *a.Comment)
+		})
+	})
+
+	t.Run("given a project with no annotations", func(t *testing.T) {
+		t.Run("when listing annotations", func(t *testing.T) {
+			c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodGet, r.Method)
+				assert.Equal(t, "/api/annotations", r.URL.Path)
+				_, _ = w.Write([]byte(`{"data":[]}`))
+			})
+			list, err := c.Annotations.List(context.Background())
+			require.NoError(t, err)
+			assert.Empty(t, list)
+		})
+	})
+
+	t.Run("given a server that answers without the envelope", func(t *testing.T) {
+		// A 2xx in some other shape decodes cleanly, because JSON ignores keys it
+		// was not asked for. Without the nil check in decodeAnnotationEnvelope
+		// every one of these would hand back a zero-valued Annotation and no
+		// error, which is the failure the envelope handling exists to prevent.
+		t.Run("when a read returns the bare value", func(t *testing.T) {
+			c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+				_, _ = w.Write([]byte(`{"id":"ann_1","comment":"Great"}`))
+			})
+			a, err := c.Annotations.Get(context.Background(), "ann_1")
+			require.Error(t, err)
+			assert.Nil(t, a)
+			assert.Contains(t, err.Error(), "data")
+		})
+
+		t.Run("when a list returns an unrelated object", func(t *testing.T) {
+			c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+				_, _ = w.Write([]byte(`{"annotations":[{"id":"ann_1"}]}`))
+			})
+			list, err := c.Annotations.List(context.Background())
+			require.Error(t, err)
+			assert.Nil(t, list)
+		})
+
+		t.Run("when a write returns an empty body", func(t *testing.T) {
+			c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			})
+			up := true
+			a, err := c.Annotations.CreateForTrace(context.Background(), "trace_1", AnnotationParams{
+				Comment:    "Great",
+				IsThumbsUp: &up,
+			})
+			require.Error(t, err)
+			assert.Nil(t, a)
+		})
+	})
+
+	t.Run("given the API rejects the request", func(t *testing.T) {
+		t.Run("when the annotation does not exist", func(t *testing.T) {
+			c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = w.Write([]byte(`{"message":"not found"}`))
+			})
+			a, err := c.Annotations.Get(context.Background(), "ann_missing")
+			require.Error(t, err)
+			assert.Nil(t, a)
+			assert.True(t, IsNotFound(err))
 		})
 	})
 }


### PR DESCRIPTION
## What this does

The annotation endpoints return their payload inside a `data` envelope. The Go wrapper decoded the bare value, so `List`, `Get`, `ListByTrace`, `CreateForTrace` and `Update` did not match the response shape. `Delete` decodes nothing and was unaffected.

All five now go through one `decodeAnnotationEnvelope` helper, replacing five copies of the same anonymous struct.

**The envelope holds `data` as a pointer, and that is the point.** JSON decoding ignores keys it was not asked for, so a 2xx body in some other shape — an older self-hosted server still sending the bare value, or a future one that moves the payload again — decodes without error. Into a value that yields a zero-valued `Annotation` and a nil error, which is a worse failure than the one this PR set out to fix: the caller cannot tell it from a real annotation. Into a pointer it is a decode error naming the missing envelope.

Three tests hold that down, and all three fail if the nil check is removed.

`AnnotationParams` claimed every field was optional. The API requires both `comment` and `isThumbsUp` on create and update alike, so `Update`'s own documented example was a call the server always rejects with 400. Both are now documented as required, along with the `omitempty` consequence: an empty comment cannot be written.

## Regeneration

The committed REST client was eight spec commits behind the OpenAPI document. Regenerating drops 2 operations, adds 15, and picks up the `fields` and `evaluations` properties that scenarios and simulation runs gained. Those are additive.

## Breaking change

Five `Annotation` fields are values rather than pointers, because the schema marks them required: `Id`, `CreatedAt`, `UpdatedAt`, `ProjectId` and `TraceId`. `client.Annotation` is public surface, so callers that dereference them (`*a.Id`) should read the field directly. The nullable fields — `Comment`, `Email`, `IsThumbsUp`, `UserId` — are unchanged and stay pointers.

This PR touches `sdks/go` and nothing else, so that break stays inside one release component. `release-scope-guard` rejected an earlier revision that also carried `specs/` and `.github/` files. The spec and the CI job are stacked on this in #7990.

## Verification

- Every Go SDK module green under `./test-all.sh -race`, which is what CI runs.
- The envelope tests fail against the previous wrapper; the three missing-envelope tests fail if the nil guard is removed. Both checked by reverting, not assumed.
- `sdk-go-ci` green with `test`, `build` and `typecheck` executed rather than draft-skipped.

One `go-ci` run failed in `TestLLMProxy` under the Langy OTel relay, a package this branch does not touch. A re-run with no code change passed, so it is a flake there.

`golangci-lint` reports pre-existing issues in this module, including `bodyclose` false positives that map to the `decodeInto` call sites — the shared decoder closes the body in a deferred function the linter cannot follow. This module sits outside the `go-ci` lint scope, so none were enforced, and they are not in scope here.

## Known gap, not addressed here

The tests stub the wire shape as string literals, so they pin the SDK against a shape written by hand rather than against the OpenAPI document. A future schema change would update the generated client and leave these tests passing. Closing that means deriving fixtures from the schema, which is a larger change than this fix.

## Release note

The version this lands under needs a decision before release. `Release-As: 1.0.0` on #4998 is not being picked up, because that commit now sits 605 commits back and release-please's default commit search depth is 500, with no override configured. #6828 therefore proposes 0.4.0 from the one commit still inside the window, and four of the six Go SDK commits since 0.3.0 are absent from its changelog.

I have not touched the release configuration. Raising the search depth would also re-expose the two `Release-As` footers that the squash merge collapsed into that single commit.
