### PR TITLE
fix(cli): surface invalid simulation-run limits before setup

### DIFF
--- a/sdks/typescript/src/cli/commands/simulation-runs/__tests__/simulation-run-commands.unit.test.ts
+++ b/sdks/typescript/src/cli/commands/simulation-runs/__tests__/simulation-run-commands.unit.test.ts
@@ -5,15 +5,17 @@ vi.mock("../../../utils/apiKey", () => ({
 }));
 
 vi.mock("ora", () => ({
-  default: () => ({
+  default: vi.fn(() => ({
     start: vi.fn().mockReturnThis(),
     succeed: vi.fn(),
     fail: vi.fn(),
-  }),
+  })),
 }));
 
+import ora from "ora";
 import { listSimulationRunsCommand } from "../list";
 import { getSimulationRunCommand } from "../get";
+import { resolveCredentials } from "../../../utils/apiKey";
 import { setOutputFormat } from "../../../utils/outputScope";
 
 class ProcessExitError extends Error {
@@ -145,8 +147,8 @@ describe("listSimulationRunsCommand()", () => {
     });
   });
 
-  describe("when the platform refuses the limit", () => {
-    /** @scenario "A refused page size is reported as a validation error, not as a network error" */
+  describe("when the platform refuses another query field", () => {
+    /** @scenario "A server-rejected scenario set filter is reported as validation, not network" */
     it("keeps validation_error at 422 instead of degrading to network_error", async () => {
       mockFetch.mockResolvedValue({
         ok: false,
@@ -159,8 +161,8 @@ describe("listSimulationRunsCommand()", () => {
               {
                 code: "schema_failure",
                 meta: {
-                  field: "limit",
-                  message: "Number must be less than or equal to 100",
+                  field: "scenarioSetId",
+                  message: "Scenario set filter is invalid",
                 },
               },
             ],
@@ -170,7 +172,10 @@ describe("listSimulationRunsCommand()", () => {
       setOutputFormat("json");
       try {
         await expect(
-          listSimulationRunsCommand({ limit: "200" }),
+          listSimulationRunsCommand({
+            limit: "100",
+            scenarioSetId: "set_rejected",
+          }),
         ).rejects.toThrow(ProcessExitError);
       } finally {
         setOutputFormat(undefined);
@@ -180,8 +185,46 @@ describe("listSimulationRunsCommand()", () => {
       const doc = JSON.parse(String(logSpy.mock.calls[0]?.[0]));
       expect(doc.error.code).toBe("validation_error");
       expect(doc.error.httpStatus).toBe(422);
-      expect(JSON.stringify(doc.error.reasons)).toContain("100");
+      expect(JSON.stringify(doc.error.reasons)).toContain("scenarioSetId");
       expect((doc.error.suggestions ?? []).join(" ")).not.toContain("network");
+    });
+  });
+
+  describe("when the limit is outside the platform range", () => {
+    /** @scenario "An invalid page size is refused before setup or a request" */
+    it("rejects before credentials, spinner, or network", async () => {
+      for (const limit of ["0", "-1", "1.5", "9007199254740992", "200"]) {
+        await expect(
+          listSimulationRunsCommand({ limit }),
+        ).rejects.toMatchObject({ code: 1 });
+
+        expect(console.error).toHaveBeenCalledWith(
+          "Error: --limit must be between 1 and 100",
+        );
+        expect(resolveCredentials).not.toHaveBeenCalled();
+        expect(ora).not.toHaveBeenCalled();
+        expect(mockFetch).not.toHaveBeenCalled();
+        vi.clearAllMocks();
+      }
+    });
+  });
+
+  describe("when the limit is within the platform range", () => {
+    it("accepts the lower and upper boundaries", async () => {
+      for (const limit of ["1", "100"]) {
+        mockFetch.mockResolvedValue({
+          ok: true,
+          json: async () => ({ runs: [], hasMore: false }),
+        });
+
+        await listSimulationRunsCommand({ limit });
+
+        expect(mockFetch).toHaveBeenCalledWith(
+          expect.stringContaining(`limit=${limit}`),
+          expect.anything(),
+        );
+        mockFetch.mockClear();
+      }
     });
   });
 

--- a/sdks/typescript/src/cli/commands/simulation-runs/list.ts
+++ b/sdks/typescript/src/cli/commands/simulation-runs/list.ts
@@ -6,6 +6,7 @@ import { readFetchFailure } from "../../utils/formatFetchError";
 import { failSpinner } from "../../utils/spinnerError";
 import { formatRelativeTime } from "../../utils/formatting";
 import type { CommandResult } from "../../utils/output";
+import { parsePositiveIntOrNull } from "../../utils/positiveInt";
 import { buildAuthHeaders } from "@/internal/api/auth";
 
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
@@ -49,6 +50,14 @@ export const listSimulationRunsCommand = async (options: {
   status?: string;
   name?: string;
 }): Promise<CommandResult | void> => {
+  if (options.limit !== undefined) {
+    const parsedLimit = parsePositiveIntOrNull(options.limit);
+    if (parsedLimit === null || parsedLimit > 100) {
+      console.error(chalk.red("Error: --limit must be between 1 and 100"));
+      process.exit(1);
+    }
+  }
+
   await resolveCredentials();
 
   const apiKey = scopedApiKey() ?? process.env.LANGWATCH_API_KEY ?? "";
@@ -80,9 +89,8 @@ export const listSimulationRunsCommand = async (options: {
 
       if (!response.ok) {
         // The status and the body go to the reader together, so a handled
-        // failure keeps its code — a 422 for `--limit 200` names
-        // validation_error and the ceiling, instead of degrading to
-        // network_error the moment it is flattened into a message string.
+        // failure keeps its code and reasons instead of degrading to a network
+        // error the moment it is flattened into a message string.
         failSpinner({
           spinner,
           error: await readFetchFailure(response),

--- a/sdks/typescript/src/cli/program.ts
+++ b/sdks/typescript/src/cli/program.ts
@@ -3841,7 +3841,7 @@ export function buildProgram({ bin }: { bin?: string } = {}): Command {
       .option("--batch-run-id <id>", "Filter by batch run ID (requires --scenario-set-id)")
       .option("--status <status>", "Filter by status (e.g. SUCCESS, FAILED, ERROR, IN_PROGRESS)")
       .option("--name <substring>", "Filter by run name substring (case-insensitive)")
-      .option("--limit <n>", "Max results (default: 20)")
+      .option("--limit <n>", "Max results, up to 100 (default: 20)")
       .option("-f, --format <format>", "Output format: table (default) or json", "table"),
     async (options: { scenarioSetId?: string; batchRunId?: string; status?: string; name?: string; limit?: string }) => {
       const { listSimulationRunsCommand: impl } = await import("./commands/simulation-runs/list.js");

--- a/specs/features/simulation-runs-cli.feature
+++ b/specs/features/simulation-runs-cli.feature
@@ -123,8 +123,16 @@ Feature: Simulation Run CLI Commands
     And the message does not claim the project has no simulation runs
 
   @unit
-  Scenario: A refused page size is reported as a validation error, not as a network error
-    When I run "langwatch simulation-run list --limit 200"
+  Scenario: A server-rejected scenario set filter is reported as validation, not network
+    Given the platform rejects a scenario set filter as invalid
+    When I run "langwatch simulation-run list --limit 100 --scenario-set-id set_rejected"
     Then the failure carries the code "validation_error" at status 422
-    And the reasons name the limit field and its maximum
+    And the reasons name the scenario set field
     And no suggestion tells me to check my network
+
+  @regression @unit
+  Scenario: An invalid page size is refused before setup or a request
+    Given simulation-run page sizes must be safe integers from 1 through 100
+    When I list simulation runs with a page size outside that range
+    Then the CLI says "--limit must be between 1 and 100"
+    And it does not resolve credentials, start a spinner, or contact the platform


### PR DESCRIPTION
## Why

Closes #7898

`langwatch simulation-run list --limit 200` forwarded the value straight to the platform. The user paid for credential resolution, a spinner, and a network round trip before getting back a generic query-shape error that never named the 100-result cap — so the message didn't tell them what to type instead. `--limit 0`, `--limit -1`, and `--limit 1.5` behaved the same way: a remote failure for something knowable locally, and one that costs a request every time.

## What changed

The limit is validated against the documented range *before* `resolveCredentials()`, so an invalid value never reaches setup or the network:

```
$ langwatch simulation-run list --limit 200
Error: --limit must be between 1 and 100
```

Four small pieces:

- **`list.ts`** — validate `options.limit` at the top of the command, using the existing `parsePositiveIntOrNull` helper, and exit 1 with a message that names the range.
- **`program.ts`** — `--limit`'s help text now states the ceiling: `"Max results, up to 100 (default: 20)"`.
- **`simulation-runs-cli.feature`** — new `@regression` scenario for the local refusal; the existing server-side scenario was reworked to reject a `--scenario-set-id` filter instead, since it can no longer use `--limit` to provoke a 422.
- **unit tests** — cover the rejected values, the accepted boundaries, and the untouched server path.

## How it works

`parsePositiveIntOrNull` is reused rather than reimplemented — it uses `Number` instead of `parseInt` specifically so `"1.5"` and `"1abc"` become `null` rather than silently truncating to `1`, and it rejects anything outside the safe-integer range. The command adds only the upper bound on top of it.

Two things deliberately left alone:

- **Server-side validation is untouched.** A 422 on any other query field still surfaces as `validation_error` with its reasons intact, rather than degrading to a network error. The reworked test above is what keeps that path pinned.
- **Only the user-supplied flag is validated.** Internal pagination limit overrides pass through unchanged.

## Test plan

Focused unit tests — 20/20 passing:

- `--limit` of `0`, `-1`, `1.5`, `9007199254740992`, and `200` each exit 1 with the range message, and assert that `resolveCredentials` was **not** called, `ora` was **not** started, and `fetch` was **not** issued.
- `--limit 1` and `--limit 100` both reach the request with `limit=<n>` in the query — the boundaries stay usable.
- The reworked server-side scenario still yields `validation_error` at 422 with `scenarioSetId` in the reasons and no network suggestion.

Repository-wide:

| check | result |
| --- | --- |
| feature parity | 11725 scenarios |
| typecheck | clean |
| lint | clean |
| build | clean |
| full suite | 4223 passed |

## Anything surprising?

The existing "refused page size" scenario had to change subject. It used `--limit 200` to provoke a server-side 422, which this fix makes unreachable — so it now rejects a `--scenario-set-id` filter instead. Same assertion, same code path, different field; the coverage it provided is preserved rather than deleted.

The 1–100 range is taken from the platform's documented cap. If that ceiling is configurable or set to move, this is the one place it is now hardcoded on the client.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The simulation run list command now rejects invalid page sizes, including values below 1, above 100, decimals, and excessively large numbers, before making a request.
  * Server-side validation errors for simulation run filters now preserve and display clearer validation details without misleading network-error guidance.

* **Documentation**
  * Updated the `--limit` help text to show the allowed range of 1–100 results and the default of 20.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->