### PR TITLE
fix(voice): admit blob: script modules so the ElevenLabs worklets load under CSP (#7947)

### DIFF
--- a/platform/app/src/server/securityHeaders.ts
+++ b/platform/app/src/server/securityHeaders.ts
@@ -29,7 +29,13 @@ export function buildSecurityHeaders({
 
   const cspHeader = [
     "default-src 'self'",
-    `script-src 'self' 'unsafe-eval' 'unsafe-inline' https://*.posthog.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://*.googletagmanager.com https://*.pendo.io https://client.crisp.chat https://static.hsappstatic.net https://*.google-analytics.com https://www.google.com https://*.reo.dev${cdn}`,
+    // blob: in script-src, not only worker-src: AudioWorklet.addModule() is a
+    // script fetch, and the ElevenLabs browser client (1.23.x) registers its
+    // rawAudioProcessor / audioConcatProcessor worklets from a blob: URL. Without
+    // it the voice panel fails in production with "Failed to load the
+    // rawAudioProcessor worklet module" while working in dev, where no CSP is
+    // enforced (#7947).
+    `script-src 'self' 'unsafe-eval' 'unsafe-inline' blob: https://*.posthog.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://*.googletagmanager.com https://*.pendo.io https://client.crisp.chat https://static.hsappstatic.net https://*.google-analytics.com https://www.google.com https://*.reo.dev${cdn}`,
     `style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://*.pendo.io https://client.crisp.chat https://*.google.com https://*.reo.dev https://fonts.googleapis.com https://unpkg.com${cdn}`,
     `img-src 'self' blob: data: https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://image.crisp.chat https://*.googletagmanager.com https://*.pendo.io https://*.google-analytics.com https://www.google.com https://*.reo.dev${cdn}`,
     `font-src 'self' data: https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://client.crisp.chat https://www.google.com https://*.reo.dev https://fonts.gstatic.com${cdn}`,
@@ -55,7 +61,12 @@ export function buildSecurityHeaders({
     // without ever prompting, which reads as a user denial (#7947).
     "Permissions-Policy":
       "geolocation=(), microphone=(self), camera=(), payment=(), usb=()",
-    ...(!dev ? { "Content-Security-Policy": cspHeader } : {}),
+    // Dev enforces nothing but reports the same policy, so a directive that
+    // would break production shows up as a console violation on the first
+    // local run instead of after deploy (#7947).
+    ...(dev
+      ? { "Content-Security-Policy-Report-Only": cspHeader }
+      : { "Content-Security-Policy": cspHeader }),
     ...(!dev
       ? {
           "Strict-Transport-Security": "max-age=31536000; includeSubDomains",

--- a/platform/app/src/server/securityHeaders.unit.test.ts
+++ b/platform/app/src/server/securityHeaders.unit.test.ts
@@ -32,8 +32,33 @@ describe("buildSecurityHeaders", () => {
     expect(headers["Strict-Transport-Security"]).toBeUndefined();
   });
 
+  describe("given a development response", () => {
+    /** @scenario Development responses report the production CSP without enforcing it */
+    it("reports the production policy instead of enforcing it", () => {
+      const dev = buildSecurityHeaders({ dev: true, environment: {} });
+      const prod = buildSecurityHeaders({ dev: false, environment: {} });
+
+      expect(dev["Content-Security-Policy"]).toBeUndefined();
+      expect(dev["Content-Security-Policy-Report-Only"]).toBe(
+        prod["Content-Security-Policy"]?.replace(
+          "upgrade-insecure-requests; ",
+          "",
+        ),
+      );
+    });
+  });
+
   describe("given the voice agents panel (#7947)", () => {
     describe("when building production headers", () => {
+      /** @scenario The app's own headers allow the ElevenLabs audio worklets */
+      it("admits blob: script modules so AudioWorklet.addModule can load them", () => {
+        const csp = buildSecurityHeaders({ dev: false, environment: {} })[
+          "Content-Security-Policy"
+        ];
+
+        expect(csp).toMatch(/script-src [^;]*\bblob:/);
+      });
+
       /** @scenario The app's own headers allow the microphone and the ElevenLabs socket */
       it("allows the microphone for the app's own origin", () => {
         const headers = buildSecurityHeaders({ dev: false, environment: {} });

--- a/platform/app/src/server/securityHeaders.unit.test.ts
+++ b/platform/app/src/server/securityHeaders.unit.test.ts
@@ -33,18 +33,20 @@ describe("buildSecurityHeaders", () => {
   });
 
   describe("given a development response", () => {
-    /** @scenario Development responses report the production CSP without enforcing it */
-    it("reports the production policy instead of enforcing it", () => {
-      const dev = buildSecurityHeaders({ dev: true, environment: {} });
-      const prod = buildSecurityHeaders({ dev: false, environment: {} });
+    describe("when the CSP is built", () => {
+      /** @scenario Development responses report the production CSP without enforcing it */
+      it("reports the production policy instead of enforcing it", () => {
+        const dev = buildSecurityHeaders({ dev: true, environment: {} });
+        const prod = buildSecurityHeaders({ dev: false, environment: {} });
 
-      expect(dev["Content-Security-Policy"]).toBeUndefined();
-      expect(dev["Content-Security-Policy-Report-Only"]).toBe(
-        prod["Content-Security-Policy"]?.replace(
-          "upgrade-insecure-requests; ",
-          "",
-        ),
-      );
+        expect(dev["Content-Security-Policy"]).toBeUndefined();
+        expect(dev["Content-Security-Policy-Report-Only"]).toBe(
+          prod["Content-Security-Policy"]?.replace(
+            "upgrade-insecure-requests; ",
+            "",
+          ),
+        );
+      });
     });
   });
 

--- a/specs/features/agents/voice-agents-v1.feature
+++ b/specs/features/agents/voice-agents-v1.feature
@@ -176,6 +176,7 @@ Feature: Voice agents v1: test an ElevenLabs agent from the app
     Then its Permissions-Policy allows the microphone for the app's own origin
     And its Content-Security-Policy connect-src admits https://api.elevenlabs.io and wss://api.elevenlabs.io
 
+  @unit @regression
   Scenario: The app's own headers allow the ElevenLabs audio worklets
     Given a production response from the LangWatch app
     And the ElevenLabs browser client registers its audio worklets from a blob: URL

--- a/specs/features/agents/voice-agents-v1.feature
+++ b/specs/features/agents/voice-agents-v1.feature
@@ -176,6 +176,12 @@ Feature: Voice agents v1: test an ElevenLabs agent from the app
     Then its Permissions-Policy allows the microphone for the app's own origin
     And its Content-Security-Policy connect-src admits https://api.elevenlabs.io and wss://api.elevenlabs.io
 
+  Scenario: The app's own headers allow the ElevenLabs audio worklets
+    Given a production response from the LangWatch app
+    And the ElevenLabs browser client registers its audio worklets from a blob: URL
+    Then its Content-Security-Policy script-src admits blob:
+    And "Talk to it" does not fail with "Failed to load the rawAudioProcessor worklet module"
+
   # ---------------------------------------------------------------------------
   # Scenario wiring and run surfaces (integration)
   # ---------------------------------------------------------------------------

--- a/specs/security/mcp-documentation-fetch-hardening.feature
+++ b/specs/security/mcp-documentation-fetch-hardening.feature
@@ -65,6 +65,7 @@ Feature: MCP outbound request and browser capability hardening
       And payment is disabled
       And USB is disabled
 
+    @unit @regression
     Scenario: Development responses report the production CSP without enforcing it
       Given LangWatch is running in development mode
       When a client requests the application root

--- a/specs/security/mcp-documentation-fetch-hardening.feature
+++ b/specs/security/mcp-documentation-fetch-hardening.feature
@@ -65,6 +65,13 @@ Feature: MCP outbound request and browser capability hardening
       And payment is disabled
       And USB is disabled
 
+    Scenario: Development responses report the production CSP without enforcing it
+      Given LangWatch is running in development mode
+      When a client requests the application root
+      Then the response carries no Content-Security-Policy header
+      And it carries the production policy as Content-Security-Policy-Report-Only
+      And a directive that would break production is visible as a console violation locally
+
   Rule: Other MCP HTTP tools cannot reach non-public destinations
 
     @integration @regression


### PR DESCRIPTION
Production "Talk to it" failed on the first call after #7983 merged:

```
Could not start the call: Failed to load the rawAudioProcessor worklet module. Make sure the browser supports AudioWorklets. If you are using a strict CSP, you may need to self-host the worklet files.
```

## Why

The ElevenLabs browser client (`@elevenlabs/client` 1.23.0) registers its `rawAudioProcessor` and `audioConcatProcessor` worklets with `AudioWorklet.addModule` on a `blob:` URL (falling back to `data:`). Worklet module loads are script fetches, governed by `script-src`, not `worker-src`. Production `script-src` had no `blob:`, so Chromium refused the module.

Dev never showed it: `buildSecurityHeaders` only sends `Content-Security-Policy` when `NODE_ENV=production`. Every local and haven browser check on #7962 and #7983 ran without a CSP at all.

## What

- `script-src` gains `blob:` (`platform/app/src/server/securityHeaders.ts`), with a comment naming the worklet loader.
- Development responses now carry the same policy as `Content-Security-Policy-Report-Only`. Nothing is enforced locally, but a directive that would break production shows up as a console violation on the first local run instead of after deploy.
- Unit tests pin both; scenarios added to `voice-agents-v1.feature` and `mcp-documentation-fetch-hardening.feature`.

The alternative, self-hosting the worklet files via `workletPaths`, means vendoring three generated files from the SDK and keeping them in step with every bump. `script-src` already carries `'unsafe-inline'` and `'unsafe-eval'`, so `blob:` widens nothing that matters.

## Verification

- `securityHeaders.unit.test.ts`: 9 passed. Biome clean. `check-feature-parity`: 11,791 scenarios bound.
- Headless Chromium proof, same page served with the production CSP as built from `main` and from this branch, calling `audioWorklet.addModule(blobUrl)` the way the SDK does:

| CSP | Result |
|---|---|
| main | `AbortError: Unable to load a worklet's module` |
| this branch | `loaded` |

- typecheck runs in CI only.

## Human verification

On a production deploy, open a voice agent, press Talk to it, confirm the call connects and no worklet error appears. In dev, open DevTools console on any page and confirm `Content-Security-Policy-Report-Only` violations (if any) are listed rather than silent.

## How I can prove I was successful

![main CSP refuses the worklet](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-screenshots/voice-csp/01-main-csp-worklet-refused.png)
![branch CSP loads the worklet](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-screenshots/voice-csp/02-branch-csp-worklet-loaded.png)

The screenshots are of the blank proof page; the evidence is the `main-csp: failed` / `branch-csp: loaded` output above. A live call under production headers is the deferred proof in #7965.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01KVwRyDjKCmNUesqaKAc4At


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Talk-to-it voice agent reliability by allowing required audio modules to load in production.
  - Reduced audio worklet loading errors during voice interactions.

- **Developer Experience**
  - Development environments now report Content Security Policy violations in the browser console, helping identify issues before release.

- **Tests**
  - Added coverage for production voice agent audio loading and development security policy reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->