### PR TITLE
fix(mcp): unwrap the annotations data envelope

### DIFF
--- a/mcp/typescript/src/__tests__/annotations.unit.test.ts
+++ b/mcp/typescript/src/__tests__/annotations.unit.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../langwatch-api.js", () => ({
+  makeRequest: vi.fn(),
+}));
+
+import { makeRequest } from "../langwatch-api.js";
+import {
+  listAnnotations,
+  getAnnotation,
+  getAnnotationsByTrace,
+  createAnnotation,
+} from "../langwatch-api-annotations.js";
+import { handleListAnnotations } from "../tools/list-annotations.js";
+
+const mockMakeRequest = vi.mocked(makeRequest);
+
+const annotation = {
+  id: "annotation_1",
+  traceId: "trace_1",
+  comment: "Great answer",
+  isThumbsUp: true,
+  email: "reviewer@example.com",
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// The annotations endpoints answer `{ "data": … }` (#7866, sibling of the
+// TypeScript SDK fix in #7865). The API layer must hand callers the payload,
+// not the envelope.
+describe("annotations API envelope", () => {
+  describe("when the server answers { data: [...] }", () => {
+    it("listAnnotations returns the array, not the envelope", async () => {
+      mockMakeRequest.mockResolvedValue({ data: [annotation] });
+
+      const result = await listAnnotations();
+
+      expect(result).toEqual([annotation]);
+      expect(result.filter((a) => a.isThumbsUp)).toHaveLength(1);
+    });
+
+    it("getAnnotationsByTrace returns the array", async () => {
+      mockMakeRequest.mockResolvedValue({ data: [annotation] });
+
+      await expect(getAnnotationsByTrace("trace_1")).resolves.toEqual([
+        annotation,
+      ]);
+    });
+  });
+
+  describe("when the server answers { data: {...} }", () => {
+    it("getAnnotation returns the annotation", async () => {
+      mockMakeRequest.mockResolvedValue({ data: annotation });
+
+      await expect(getAnnotation("annotation_1")).resolves.toEqual(annotation);
+    });
+
+    it("createAnnotation returns the created annotation", async () => {
+      mockMakeRequest.mockResolvedValue({ data: annotation });
+
+      await expect(
+        createAnnotation("trace_1", { comment: "Great answer", isThumbsUp: true }),
+      ).resolves.toEqual(annotation);
+    });
+  });
+
+  describe("when a 2xx body carries no data envelope", () => {
+    it("refuses a bare array instead of returning a lookalike shape", async () => {
+      mockMakeRequest.mockResolvedValue([annotation]);
+
+      await expect(listAnnotations()).rejects.toThrow('no "data" envelope');
+    });
+
+    it("refuses a null data payload", async () => {
+      mockMakeRequest.mockResolvedValue({ data: null });
+
+      await expect(getAnnotation("annotation_1")).rejects.toThrow(
+        'no "data" envelope',
+      );
+    });
+  });
+});
+
+describe("platform_list_annotations through the tool layer", () => {
+  it("renders annotations from an enveloped response", async () => {
+    mockMakeRequest.mockResolvedValue({ data: [annotation] });
+
+    const text = await handleListAnnotations({});
+
+    expect(text).toContain("Annotations (1 total)");
+    expect(text).toContain("annotation_1");
+    expect(text).toContain("👍");
+  });
+
+  it("reports an empty project from an enveloped empty list", async () => {
+    mockMakeRequest.mockResolvedValue({ data: [] });
+
+    const text = await handleListAnnotations({});
+
+    expect(text).toContain("No annotations found");
+  });
+});

--- a/mcp/typescript/src/langwatch-api-annotations.ts
+++ b/mcp/typescript/src/langwatch-api-annotations.ts
@@ -12,33 +12,61 @@ export interface AnnotationResponse {
   updatedAt?: string;
 }
 
+/**
+ * Every annotations endpoint except delete answers `{ "data": … }` (see
+ * platform/app/src/server/routes/annotations.ts). Unwrap it, and refuse a
+ * 2xx body that carries no envelope instead of handing the caller something
+ * that only looks like the payload — the same contract the Go client
+ * enforces (#7866, sibling of the TypeScript SDK fix in #7865).
+ */
+function unwrapData<T>(response: unknown, operation: string): T {
+  if (typeof response === "object" && response !== null && "data" in response) {
+    const data = (response as { data: T | null }).data;
+    if (data != null) {
+      return data;
+    }
+  }
+  throw new Error(
+    `LangWatch ${operation} response carried no "data" envelope`,
+  );
+}
+
 export async function listAnnotations(): Promise<AnnotationResponse[]> {
-  return makeRequest("GET", "/api/annotations") as Promise<AnnotationResponse[]>;
+  return unwrapData<AnnotationResponse[]>(
+    await makeRequest("GET", "/api/annotations"),
+    "listAnnotations",
+  );
 }
 
 export async function getAnnotation(id: string): Promise<AnnotationResponse> {
-  return makeRequest(
-    "GET",
-    `/api/annotations/${encodeURIComponent(id)}`,
-  ) as Promise<AnnotationResponse>;
+  return unwrapData<AnnotationResponse>(
+    await makeRequest("GET", `/api/annotations/${encodeURIComponent(id)}`),
+    "getAnnotation",
+  );
 }
 
 export async function getAnnotationsByTrace(traceId: string): Promise<AnnotationResponse[]> {
-  return makeRequest(
-    "GET",
-    `/api/annotations/trace/${encodeURIComponent(traceId)}`,
-  ) as Promise<AnnotationResponse[]>;
+  return unwrapData<AnnotationResponse[]>(
+    await makeRequest(
+      "GET",
+      `/api/annotations/trace/${encodeURIComponent(traceId)}`,
+    ),
+    "getAnnotationsByTrace",
+  );
 }
 
 export async function createAnnotation(
   traceId: string,
   data: { comment?: string; isThumbsUp?: boolean; email?: string },
 ): Promise<AnnotationResponse> {
-  return makeRequest(
-    "POST",
-    `/api/annotations/trace/${encodeURIComponent(traceId)}`,
-    data,
-  ) as Promise<AnnotationResponse>;
+  return unwrapData<AnnotationResponse>(
+    await makeRequest(
+      "POST",
+      `/api/annotations/trace/${encodeURIComponent(traceId)}`,
+      data,
+    ),
+    "createAnnotation",
+  );
 }
 
 export async function deleteAnnotation(id: string): Promise<{ status?: string; message?: string }> {


### PR DESCRIPTION
## Problem

The annotations endpoints answer `{ "data": … }`, but the MCP server's API layer (`mcp/typescript/src/langwatch-api-annotations.ts`) cast the raw body straight to the payload type. So `platform_list_annotations` always reported an empty project (the envelope fails the tool's `Array.isArray` check even when annotations exist) and `platform_get_annotation` rendered `undefined` fields.

This is the MCP half of #7866 — the TypeScript SDK was fixed in #7865 and the Go client in #7989; the MCP server was the remaining client with the defect.

## Changes

- Unwrap the `data` envelope in the four enveloped calls (`listAnnotations`, `getAnnotation`, `getAnnotationsByTrace`, `createAnnotation`)
- Refuse a 2xx body that carries no envelope (or a null payload) instead of returning a lookalike shape — the same silent-failure contract the Go client's `decodeAnnotationEnvelope` enforces
- `deleteAnnotation` untouched: that endpoint answers `{status, message}`, not an envelope

## Testing

- New `src/__tests__/annotations.unit.test.ts`: both payload shapes, bare-body refusal, null-data refusal, and `platform_list_annotations` end to end through the tool layer (renders items from an enveloped response; reports empty correctly)
- Full MCP unit suite: 372 passed
- `tsc --noEmit`: clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Annotation API results now return the expected payload directly instead of including the server response envelope.
  * Clear errors are shown when annotation responses are missing required data.
  * Annotation displays now correctly render feedback indicators and empty-result messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->