### PR TITLE
fix(governance): prevent duplicate Azure bills and address review regressions

### DIFF
--- a/platform/app/.env.example
+++ b/platform/app/.env.example
@@ -604,7 +604,6 @@ LANGY_INTERNAL_SECRET=
 # "timeout" means the 120s total budget ran out — including a wedged run plan
 # lookup, which shares that same single budget with the run phase rather than
 # getting a budget of its own.
-||||||| parent of 450c76b515 (feat(governance): adr-128 wave 2 — identity model + erasure (#7746) (#7820))
 
 # GOVERNANCE
 # The key that turns an erased person's identifier into the stand-in that

--- a/platform/app/ee/governance/dashboard/pages/inventory.tsx
+++ b/platform/app/ee/governance/dashboard/pages/inventory.tsx
@@ -828,6 +828,7 @@ function InventoryTabs({
       onValueChange={({ value }) => selectInventoryTab(value)}
       variant="line"
       lazyMount
+      unmountOnExit
     >
       <Tabs.List>
         <Tabs.Trigger

--- a/platform/app/ee/governance/projections/__tests__/governanceCostRollupRestatement.unit.test.ts
+++ b/platform/app/ee/governance/projections/__tests__/governanceCostRollupRestatement.unit.test.ts
@@ -148,6 +148,44 @@ function fold(events: unknown[]): GovernanceCostRollupState {
 }
 
 describe("the restatement marker", () => {
+  describe("when one pull revises two items in the same cell", () => {
+    /** @scenario "One pull revising several items preserves the previous whole-cell total" */
+    it.each([
+      false,
+      true,
+    ])("rewinds both revisions with reversed delivery %s", (reverse) => {
+      const opening = [
+        observedEvent({
+          restatementKey: "a",
+          costNanoMinor: 10_000_000_000,
+          observedAtMs: FIRST_PULL,
+        }),
+        observedEvent({
+          restatementKey: "b",
+          costNanoMinor: 20_000_000_000,
+          observedAtMs: FIRST_PULL,
+        }),
+      ];
+      const revisions = [
+        observedEvent({
+          restatementKey: "a",
+          costNanoMinor: 15_000_000_000,
+          observedAtMs: SECOND_PULL,
+        }),
+        observedEvent({
+          restatementKey: "b",
+          costNanoMinor: 30_000_000_000,
+          observedAtMs: SECOND_PULL,
+        }),
+      ];
+      const state = fold([
+        ...opening,
+        ...(reverse ? revisions.reverse() : revisions),
+      ]);
+      expect(state.previousAmountNanoUsd).toBe(30_000_000_000);
+    });
+  });
+
   describe("given the provider restates a day at a different amount", () => {
     /** @scenario "A restated day shows what it was before" */
     it("names the amount the day held before, and when the change was seen", () => {

--- a/platform/app/ee/governance/projections/governanceCostRollup.foldProjection.ts
+++ b/platform/app/ee/governance/projections/governanceCostRollup.foldProjection.ts
@@ -736,47 +736,40 @@ export class GovernanceCostRollupFoldProjection
   private withDerivedRevisionMarkers(
     state: GovernanceCostRollupState,
   ): GovernanceCostRollupState {
-    let newestKey: string | null = null;
     let revisedAt: number | null = null;
 
-    for (const [key, item] of Object.entries(state.pulledItems)) {
+    for (const item of Object.values(state.pulledItems)) {
       // A revision is a CHANGE to the figure, not merely a second look at it.
       // The provider re-reporting the same amount is the confirming
       // observation §15 relies on, and treating it as a revision would put
       // "revised, was $X" on a cell whose X never moved. Items that never
       // moved carry no `revisedAtMs` at all.
       if (item.revisedAtMs === undefined) continue;
-      // Ties broken by key so two items revised in the same pull still name
-      // one winner, whichever order they arrived in.
-      if (
-        revisedAt === null ||
-        item.revisedAtMs > revisedAt ||
-        (item.revisedAtMs === revisedAt && key < newestKey!)
-      ) {
+      if (revisedAt === null || item.revisedAtMs > revisedAt) {
         revisedAt = item.revisedAtMs;
-        newestKey = key;
       }
     }
 
-    if (newestKey === null) {
+    if (revisedAt === null) {
       return { ...state, revisedAt: null, previousAmountNanoUsd: null };
     }
 
-    // "was $X" is the whole cell as it stood immediately before its newest
-    // revision: that one item at its prior figure, every other item where it
-    // stands now. Totalled through the same helper the live figure uses, so
-    // the two cannot drift on currency handling.
-    const newest = state.pulledItems[newestKey]!;
+    // Every item revised by the same pull shares its observation time. Rewind
+    // all of them so the prior total describes the cell before that pull.
     const before = governanceCostRollupTotals({
       ...state,
-      pulledItems: {
-        ...state.pulledItems,
-        [newestKey]: {
-          ...newest,
-          amountNanoMinor: newest.priorAmountNanoMinor!,
-          amountNanoUsd: newest.priorAmountNanoUsd,
-        },
-      },
+      pulledItems: Object.fromEntries(
+        Object.entries(state.pulledItems).map(([key, item]) => [
+          key,
+          item.revisedAtMs === revisedAt
+            ? {
+                ...item,
+                amountNanoMinor: item.priorAmountNanoMinor!,
+                amountNanoUsd: item.priorAmountNanoUsd,
+              }
+            : item,
+        ]),
+      ),
     }).amountNanoUsd;
 
     return { ...state, revisedAt, previousAmountNanoUsd: before };

--- a/platform/app/ee/governance/services/__tests__/azureBillClaimOnEdit.unit.test.ts
+++ b/platform/app/ee/governance/services/__tests__/azureBillClaimOnEdit.unit.test.ts
@@ -51,7 +51,10 @@ const rowWith = (over: Record<string, unknown> = {}) => ({
   ...over,
 });
 
-const fakePrisma = (row: ReturnType<typeof rowWith>) => {
+const fakePrisma = (
+  row: ReturnType<typeof rowWith>,
+  history: ReturnType<typeof rowWith>[] = [],
+) => {
   const update = vi
     .fn()
     .mockImplementation(({ data }: { data: Record<string, unknown> }) =>
@@ -62,7 +65,16 @@ const fakePrisma = (row: ReturnType<typeof rowWith>) => {
       findUnique: vi.fn().mockResolvedValue(row),
       // The bill-ownership listing. The row itself is the only source, and it
       // is excluded from its own check by id.
-      findMany: vi.fn().mockResolvedValue([row]),
+      findMany: vi
+        .fn()
+        .mockImplementation(({ where }) =>
+          Promise.resolve(
+            [row, ...history].filter(
+              (candidate) =>
+                where.archivedAt !== null || candidate.archivedAt === null,
+            ),
+          ),
+        ),
       update,
     },
   };
@@ -72,6 +84,31 @@ const fakePrisma = (row: ReturnType<typeof rowWith>) => {
 describe("updateSource, when the edit touches the Azure bill claim", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  /** @scenario "A replacement Azure source restates the original bill" */
+  it("inherits the archived source's billing identity when adding its subscription", async () => {
+    const old = rowWith({
+      id: "src_original",
+      archivedAt: new Date(),
+      parserConfig: { azureSubscriptionId: SUBSCRIPTION },
+    });
+    const { client, update } = fakePrisma(rowWith(), [old]);
+    await IngestionSourceService.create(client).updateSource({
+      id: SOURCE_ID,
+      organizationId: ORG,
+      parserConfig: {
+        environmentUrl: "https://orgacme01.crm4.dynamics.com",
+        azureSubscriptionId: SUBSCRIPTION,
+        credentials: {
+          billingClientId: "billing-id",
+          billingClientSecret: "billing-secret",
+        },
+      },
+    });
+    expect(update.mock.calls[0]![0].data.parserConfig).toMatchObject({
+      _azureBillSourceId: "src_original",
+    });
   });
 
   describe("given a source whose stored config claims no subscription", () => {

--- a/platform/app/ee/governance/services/__tests__/governanceCost.service.unit.test.ts
+++ b/platform/app/ee/governance/services/__tests__/governanceCost.service.unit.test.ts
@@ -716,6 +716,35 @@ describe("GovernanceCostService.summary", () => {
   });
 
   describe("given every source is still pulling", () => {
+    /** @scenario "A replacement Azure source restates the original bill" */
+    it("recognizes bill rows stored under the original source after replacement", async () => {
+      const rollup = rollupReturning();
+      vi.mocked(rollup.hasRowsForSource).mockImplementation(
+        async ({ ingestionSourceId }) => ingestionSourceId === "original",
+      );
+      const service = createService({
+        prisma: prismaWithGovProject("gov-1", [
+          {
+            id: "replacement",
+            parserConfig: {
+              azureSubscriptionId: "subscription",
+              _azureBillSourceId: "original",
+            },
+            pollerCursor: JSON.stringify({
+              costPricedThroughDay: "2026-09-08",
+              costHeldSinceMs: null,
+            }),
+          },
+        ]),
+        costRollup: rollup,
+      });
+      const result = await service.summary({
+        organizationId: "org-1",
+        windowDays: 30,
+      });
+      expect(result.azureBilling).toBeNull();
+    });
+
     describe("when requesting the summary", () => {
       const healthy = {
         name: "Azure Billing",

--- a/platform/app/ee/governance/services/activity-monitor/__tests__/azureBillIdentity.unit.test.ts
+++ b/platform/app/ee/governance/services/activity-monitor/__tests__/azureBillIdentity.unit.test.ts
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+
+import { describe, expect, it, vi } from "vitest";
+import type { PrismaClient } from "~/generated/prisma/client";
+import { azureBillSourceId, withAzureBillIdentity } from "../azureBillIdentity";
+
+const subscription = "aaaaaaaa-0000-4000-8000-000000000001";
+function clientWith(
+  history: Array<{ id: string; parserConfig: Record<string, unknown> }>,
+) {
+  return {
+    ingestionSource: { findMany: vi.fn().mockResolvedValue(history) },
+  } as unknown as PrismaClient;
+}
+
+describe("withAzureBillIdentity()", () => {
+  it("keeps the original identity through several archived replacements", async () => {
+    const config = await withAzureBillIdentity({
+      prisma: clientWith([
+        { id: "first", parserConfig: { azureSubscriptionId: subscription } },
+        {
+          id: "second",
+          parserConfig: {
+            azureSubscriptionId: subscription,
+            _azureBillSourceId: "first",
+          },
+        },
+      ]),
+      organizationId: "org",
+      parserConfig: { azureSubscriptionId: subscription.toUpperCase() },
+    });
+    expect(azureBillSourceId({ id: "third", parserConfig: config })).toBe(
+      "first",
+    );
+  });
+
+  it("remembers a disconnected subscription for a later replacement", async () => {
+    const removed = await withAzureBillIdentity({
+      prisma: clientWith([]),
+      organizationId: "org",
+      sourceId: "first",
+      storedConfig: { azureSubscriptionId: subscription },
+      parserConfig: {},
+    });
+    const replacement = await withAzureBillIdentity({
+      prisma: clientWith([{ id: "first", parserConfig: removed }]),
+      organizationId: "org",
+      parserConfig: { azureSubscriptionId: subscription },
+    });
+    expect(azureBillSourceId({ id: "second", parserConfig: replacement })).toBe(
+      "first",
+    );
+  });
+
+  it("ignores a caller's forged billing identity on create", async () => {
+    const config = await withAzureBillIdentity({
+      prisma: clientWith([]),
+      organizationId: "org",
+      parserConfig: {
+        azureSubscriptionId: subscription,
+        _azureBillSourceId: "victim",
+        _azureBillSubscriptionId: "other",
+      },
+    });
+    expect(azureBillSourceId({ id: "new", parserConfig: config })).toBe("new");
+  });
+
+  it("keeps the stored identity when an edit attempts to replace it", async () => {
+    const config = await withAzureBillIdentity({
+      prisma: clientWith([]),
+      organizationId: "org",
+      sourceId: "second",
+      storedConfig: {
+        azureSubscriptionId: subscription,
+        _azureBillSourceId: "first",
+      },
+      parserConfig: {
+        azureSubscriptionId: subscription,
+        _azureBillSourceId: "victim",
+      },
+    });
+    expect(azureBillSourceId({ id: "second", parserConfig: config })).toBe(
+      "first",
+    );
+  });
+
+  it("does not reuse a different subscription's history", async () => {
+    const config = await withAzureBillIdentity({
+      prisma: clientWith([
+        { id: "other", parserConfig: { azureSubscriptionId: "different" } },
+      ]),
+      organizationId: "org",
+      parserConfig: { azureSubscriptionId: subscription },
+    });
+    expect(azureBillSourceId({ id: "new", parserConfig: config })).toBe("new");
+  });
+
+  it("refuses an ambiguous history instead of silently moving existing money", async () => {
+    await expect(
+      withAzureBillIdentity({
+        prisma: clientWith(
+          ["first", "second"].map((id) => ({
+            id,
+            parserConfig: { azureSubscriptionId: subscription },
+          })),
+        ),
+        organizationId: "org",
+        parserConfig: { azureSubscriptionId: subscription },
+      }),
+    ).rejects.toThrow(/multiple billing histories/);
+  });
+
+  it("scopes the historical lookup to the requesting organization", async () => {
+    const prisma = clientWith([]);
+    await withAzureBillIdentity({
+      prisma,
+      organizationId: "org",
+      parserConfig: { azureSubscriptionId: subscription },
+    });
+    expect(prisma.ingestionSource.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          organizationId: "org",
+          sourceType: "copilot_studio_dataverse",
+        },
+      }),
+    );
+  });
+});

--- a/platform/app/ee/governance/services/activity-monitor/__tests__/ingestionSourceKeySuppression.unit.test.ts
+++ b/platform/app/ee/governance/services/activity-monitor/__tests__/ingestionSourceKeySuppression.unit.test.ts
@@ -30,7 +30,7 @@ vi.mock("@ee/governance/services/governanceProject.service", () => ({
 
 import { IngestionSourceService } from "../ingestionSource.service";
 
-function createServiceForCreate() {
+function createServiceForCreate(history: Record<string, unknown>[] = []) {
   const captured: { data?: Record<string, unknown> } = {};
   const prisma = {
     ingestionSource: {
@@ -41,7 +41,15 @@ function createServiceForCreate() {
       }),
       findFirst: vi.fn().mockResolvedValue(null),
       findUnique: vi.fn().mockResolvedValue(null),
-      findMany: vi.fn().mockResolvedValue([]),
+      findMany: vi
+        .fn()
+        .mockImplementation(({ where }) =>
+          Promise.resolve(
+            history.filter(
+              (row) => where.archivedAt !== null || row.archivedAt === null,
+            ),
+          ),
+        ),
       update: vi.fn().mockResolvedValue(null),
       updateMany: vi.fn().mockResolvedValue({ count: 0 }),
     },
@@ -66,6 +74,39 @@ function createServiceForRotate(existing: Record<string, unknown>) {
 
 describe("pull-source key suppression (#7616)", () => {
   describe("when createSource is called", () => {
+    /** @scenario "A replacement Azure source restates the original bill" */
+    it("reuses the archived Azure source's billing identity", async () => {
+      const subscription = "00000000-0000-4000-8000-000000000001";
+      const { service, captured } = createServiceForCreate([
+        {
+          id: "src_original",
+          archivedAt: new Date(),
+          parserConfig: { azureSubscriptionId: subscription },
+        },
+      ]);
+      await service.createSource({
+        organizationId: "org_1",
+        sourceType: "copilot_studio_dataverse",
+        name: "Replacement",
+        actorUserId: "user_1",
+        pullConfig: {
+          adapter: "copilot_studio_dataverse",
+          environmentUrl: "https://orgacme01.crm4.dynamics.com",
+          azureSubscriptionId: subscription,
+          credentials: {
+            tenantId: "tenant",
+            clientId: "client",
+            clientSecret: "secret",
+            billingClientId: "billing",
+            billingClientSecret: "billing-secret",
+          },
+        },
+      });
+      expect(captured.data?.parserConfig).toMatchObject({
+        _azureBillSourceId: "src_original",
+      });
+    });
+
     /** @scenario "The rotate-secret button is hidden for non-push sources on the list" */
     /** @scenario "The rotate-secret button is hidden for non-push sources on the detail page" */
     it("pull type → empty sentinel hash, null secret", async () => {

--- a/platform/app/ee/governance/services/activity-monitor/azureBillIdentity.ts
+++ b/platform/app/ee/governance/services/activity-monitor/azureBillIdentity.ts
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+
+import { ValidationError } from "@langwatch/handled-error";
+import type { PrismaClient } from "~/generated/prisma/client";
+import { readClaimedSubscription } from "./azureBillOwnership";
+
+const SOURCE_FIELD = "_azureBillSourceId";
+const SUBSCRIPTION_FIELD = "_azureBillSubscriptionId";
+type Config = Record<string, unknown>;
+
+/** The first source remains the bill's storage identity across replacements. */
+export function azureBillSourceId(source: {
+  id: string;
+  parserConfig?: unknown;
+}): string {
+  const value = (source.parserConfig as Config | null)?.[SOURCE_FIELD];
+  return typeof value === "string" && value !== "" ? value : source.id;
+}
+
+function subscriptionIdentity(config: Config | null): string | null {
+  const value = config?.[SUBSCRIPTION_FIELD];
+  return typeof value === "string" ? value : readClaimedSubscription(config);
+}
+
+/**
+ * Internal fields are server-owned and excluded from source responses. Keep
+ * the subscription identity even when billing is disconnected: its recorded
+ * money still exists, and a later connection must restate those same rows.
+ * Legacy sources need no backfill; their own id and claim are the identity.
+ */
+export async function withAzureBillIdentity({
+  prisma,
+  organizationId,
+  parserConfig,
+  sourceId,
+  storedConfig,
+}: {
+  prisma: PrismaClient;
+  organizationId: string;
+  parserConfig: Config;
+  sourceId?: string;
+  storedConfig?: Config;
+}): Promise<Config> {
+  const config = { ...parserConfig };
+  delete config[SOURCE_FIELD];
+  delete config[SUBSCRIPTION_FIELD];
+  const claimed = readClaimedSubscription(config)?.toLowerCase();
+  const stored = subscriptionIdentity(storedConfig ?? null)?.toLowerCase();
+
+  if (sourceId && stored && (!claimed || claimed === stored)) {
+    config[SOURCE_FIELD] = azureBillSourceId({
+      id: sourceId,
+      parserConfig: storedConfig,
+    });
+    config[SUBSCRIPTION_FIELD] = stored;
+    return config;
+  }
+  if (!claimed) return config;
+
+  const history = await prisma.ingestionSource.findMany({
+    where: { organizationId, sourceType: "copilot_studio_dataverse" },
+    select: { id: true, parserConfig: true },
+  });
+  const owners = new Set(
+    history
+      .filter(
+        (row) =>
+          row.id !== sourceId &&
+          subscriptionIdentity(
+            row.parserConfig as Config | null,
+          )?.toLowerCase() === claimed,
+      )
+      .map(azureBillSourceId),
+  );
+  if (owners.size > 1) {
+    const message =
+      "This Azure subscription has multiple billing histories. Reconcile the existing records before connecting it again to avoid duplicate spend.";
+    throw new ValidationError(message, { meta: { formErrors: [message] } });
+  }
+  const owner = owners.values().next().value ?? sourceId;
+  if (owner) config[SOURCE_FIELD] = owner;
+  config[SUBSCRIPTION_FIELD] = claimed;
+  return config;
+}

--- a/platform/app/ee/governance/services/activity-monitor/ingestionSource.service.ts
+++ b/platform/app/ee/governance/services/activity-monitor/ingestionSource.service.ts
@@ -41,6 +41,7 @@ import {
 } from "~/generated/prisma/client";
 import { isEnterpriseTier } from "~/server/api/enterprise";
 import { getApp } from "~/server/app-layer/app";
+import { withAzureBillIdentity } from "./azureBillIdentity";
 import {
   type AzureBillReader,
   assertAzureBillHasItsOwnCredential,
@@ -674,6 +675,15 @@ export class IngestionSourceService {
     });
   }
 
+  /** Seal credentials after resolving the server-owned billing identity. */
+  private async prepareParserConfig(
+    params: Omit<Parameters<typeof withAzureBillIdentity>[0], "prisma">,
+  ): Promise<Prisma.InputJsonValue> {
+    return encryptParserConfigCredentials(
+      await withAzureBillIdentity({ ...params, prisma: this.prisma }),
+    ) as Prisma.InputJsonValue;
+  }
+
   /**
    * Every live source in the org that already reads an Azure bill.
    *
@@ -780,9 +790,10 @@ export class IngestionSourceService {
       organizationId: input.organizationId,
       traceProjectId: input.traceProjectId,
     });
-    const mergedParserConfig = encryptParserConfigCredentials(
-      requestedParserConfig,
-    )!;
+    const mergedParserConfig = await this.prepareParserConfig({
+      organizationId: input.organizationId,
+      parserConfig: requestedParserConfig,
+    });
 
     // The @@unique([organizationId, name]) constraint spans all rows
     // including archived ones. If an archived source holds the name,
@@ -882,9 +893,12 @@ export class IngestionSourceService {
         incoming,
         existing,
       });
-      data.parserConfig = encryptParserConfigCredentials(
-        incoming,
-      ) as Prisma.InputJsonValue;
+      data.parserConfig = await this.prepareParserConfig({
+        organizationId: input.organizationId,
+        parserConfig: incoming,
+        sourceId: existing.id,
+        storedConfig: stored,
+      });
     }
     if (input.status !== undefined) data.status = input.status;
     if (input.pullSchedule !== undefined)

--- a/platform/app/ee/governance/services/governanceCost.service.ts
+++ b/platform/app/ee/governance/services/governanceCost.service.ts
@@ -46,6 +46,7 @@ import {
   GOVERNANCE_COST_SOURCE,
   GOVERNANCE_SETTLING_WINDOW_DAYS,
 } from "../projections/governanceCostRollup.constants";
+import { azureBillSourceId } from "./activity-monitor/azureBillIdentity";
 import {
   readClaimedSubscription,
   readPrepaidDeclared,
@@ -662,7 +663,7 @@ export class GovernanceCostService {
         fromDay,
         toDay,
         costSource: GOVERNANCE_COST_SOURCE.PULLED,
-        ingestionSourceId: claiming.id,
+        ingestionSourceId: azureBillSourceId(claiming),
       }),
       costPricedThroughDay: cursor.costPricedThroughDay,
       costHeldSinceMs: cursor.costHeldSinceMs,

--- a/platform/app/ee/governance/services/pullers/__tests__/pullerWorkerPulledUsage.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/pullerWorkerPulledUsage.unit.test.ts
@@ -28,6 +28,7 @@ vi.mock("~/server/featureFlag", () => ({
 }));
 vi.mock("~/server/db", () => ({
   prisma: {
+    erasedIdentifierSuppression: { findMany: async () => [] },
     ingestionSource: {
       findUnique: (...a: unknown[]) => findUnique(...a),
       // A run that drops a price records the window it lost. Pinned in
@@ -70,6 +71,11 @@ vi.mock("../index", async (importOriginal) => {
   };
 });
 
+import {
+  GovernanceCostRollupFoldProjection,
+  governanceCostRollupTotals,
+} from "../../../projections/governanceCostRollup.foldProjection";
+import { azureCostEvents } from "../azureCostManagement";
 import { runIngestionPull } from "../pullerWorker";
 
 const SOURCE_ROW = {
@@ -125,6 +131,104 @@ beforeEach(() => {
 });
 
 describe("the pull effect's pulled-usage emit seam", () => {
+  /** @scenario "A replacement Azure source restates the original bill" */
+  it("keeps non-bill usage attached to the replacement source", async () => {
+    findUnique.mockResolvedValue({
+      ...SOURCE_ROW,
+      id: "src_replacement",
+      sourceType: "copilot_studio_dataverse",
+      parserConfig: {
+        adapter: "test_adapter",
+        _azureBillSourceId: "src_original",
+      },
+    });
+    runOnce.mockResolvedValue({
+      events: [usageEvent({}, "conversation:123")],
+      cursor: null,
+      errorCount: 0,
+    });
+    const recordPulledUsage = vi.fn().mockResolvedValue(undefined);
+    await runIngestionPull({
+      sourceId: "src_replacement",
+      cursor: null,
+      pulledUsage: { recordPulledUsage },
+    });
+    expect(recordPulledUsage.mock.calls[0]![0].ingestionSourceId).toBe(
+      "src_replacement",
+    );
+    expect(insertEvent.mock.calls[0]![0].sourceId).toBe("src_replacement");
+  });
+
+  /** @scenario "A replacement Azure source restates the original bill" */
+  it("keeps the bill total when an archived source is replaced", async () => {
+    const recordPulledUsage = vi.fn().mockResolvedValue(undefined);
+    vi.useFakeTimers();
+    try {
+      for (const [index, id] of ["src_original", "src_replacement"].entries()) {
+        vi.setSystemTime(new Date(`2026-09-09T0${index}:00:00Z`));
+        findUnique.mockResolvedValue({
+          ...SOURCE_ROW,
+          id,
+          sourceType: "copilot_studio_dataverse",
+          createdAt: new Date("2026-09-01"),
+          parserConfig: {
+            adapter: "test_adapter",
+            _azureBillSourceId: "src_original",
+          },
+        });
+        runOnce.mockResolvedValue({
+          events: azureCostEvents({
+            subscriptionId: "subscription-1",
+            days: [
+              {
+                day: "2026-09-08",
+                meterCategory: "Copilot Studio",
+                costMinor: index === 0 ? "100" : "125",
+                costUsd: null,
+                currencyCode: "USD",
+              },
+            ],
+          }),
+          cursor: null,
+          errorCount: 0,
+        });
+        await runIngestionPull({
+          sourceId: id,
+          cursor: null,
+          pulledUsage: { recordPulledUsage },
+        });
+      }
+      const projection = new GovernanceCostRollupFoldProjection({
+        store: { store: async () => undefined, get: async () => null },
+      });
+      const cells = new Map<string, ReturnType<typeof projection.init>>();
+      for (const [index, [data]] of recordPulledUsage.mock.calls.entries()) {
+        const event = {
+          id: `event-${index}`,
+          type: "lw.obs.pulled_usage.observed",
+          tenantId: data.tenantId,
+          aggregateId: data.restatementKey,
+          occurredAt: data.occurredAt,
+          data,
+        } as never;
+        const key = projection.key(event);
+        cells.set(
+          key,
+          projection.apply(cells.get(key) ?? projection.init(), event),
+        );
+      }
+      const total = [...cells.values()].reduce(
+        (sum, state) =>
+          sum + (governanceCostRollupTotals(state).amountNanoUsd ?? 0),
+        0,
+      );
+      expect(total).toBe(125_000_000_000);
+      expect(insertEvent.mock.calls[1]![0].sourceId).toBe("src_replacement");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   describe("when an adapter returns a priced usage event", () => {
     it("appends one record carrying the source's own attribution", async () => {
       runOnce.mockResolvedValue({

--- a/platform/app/ee/governance/services/pullers/pullerWorker.ts
+++ b/platform/app/ee/governance/services/pullers/pullerWorker.ts
@@ -34,6 +34,7 @@ import {
   toError,
   withScope,
 } from "~/utils/posthogErrorCapture";
+import { azureBillSourceId } from "../activity-monitor/azureBillIdentity";
 import { decryptCredentials } from "../activity-monitor/ingestionCredentials";
 import type { SourceType } from "../activity-monitor/ingestionSource.service";
 import { DirectoryDepartmentSyncService } from "../directoryDepartmentSync.service";
@@ -407,6 +408,7 @@ export async function runIngestionPull(params: {
 /** The IngestionSource fields the write paths below actually read. */
 type PullingSource = {
   id: string;
+  parserConfig?: unknown;
   sourceType: string;
   organizationId: string;
   teamId: string | null;
@@ -909,7 +911,13 @@ async function recordPulledUsageFor({
     record = buildPulledUsageRecord({
       event,
       source: {
-        ingestionSourceId: source.id,
+        // Only the subscription bill shares history with a retired source.
+        // Conversation usage and audit records keep the current source id.
+        ingestionSourceId:
+          source.sourceType === "copilot_studio_dataverse" &&
+          event.source_event_id.startsWith("azure_cost:")
+            ? azureBillSourceId(source)
+            : source.id,
         sourceType: source.sourceType,
         organizationId: source.organizationId,
         teamId: source.teamId,

--- a/platform/app/src/pages/governance/__tests__/agentsPageControls.integration.test.tsx
+++ b/platform/app/src/pages/governance/__tests__/agentsPageControls.integration.test.tsx
@@ -173,6 +173,16 @@ afterEach(() => {
   window.sessionStorage.clear();
 });
 
+/** @scenario "Switching governance tabs unmounts the inactive content" */
+it("unmounts the agent cards when switching to Applications", async () => {
+  renderAgentsAt();
+  const card = screen.getAllByTestId("governance-agent-card")[0]!;
+  await userEvent
+    .setup()
+    .click(screen.getByRole("tab", { name: "Applications" }));
+  await waitFor(() => expect(card).not.toBeInTheDocument());
+});
+
 describe("the agents page sample cards", () => {
   describe("when a governance viewer opens a page with nothing measured on it", () => {
     /** @scenario "The empty agents page shows samples when requested" */

--- a/platform/app/src/pages/governance/__tests__/inventoryTabShell.integration.test.tsx
+++ b/platform/app/src/pages/governance/__tests__/inventoryTabShell.integration.test.tsx
@@ -28,6 +28,7 @@ import {
   screen,
   waitFor,
 } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom/vitest";
 import type React from "react";
 import { createMemoryRouter, RouterProvider } from "react-router";
@@ -189,10 +190,11 @@ afterEach(() => cleanup());
 describe("the inventory tab shell", () => {
   /** @scenario "Switching governance tabs unmounts the inactive content" */
   it("unmounts the catalog content when switching to Sources", async () => {
+    const user = userEvent.setup();
     renderInventoryAt(["/governance/inventory"]);
     const content = screen.getByRole("tabpanel").firstElementChild;
     expect(content).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("tab", { name: /^Sources/ }));
+    await user.click(screen.getByRole("tab", { name: /^Sources/ }));
     await waitFor(() => expect(content).not.toBeInTheDocument());
   });
 

--- a/platform/app/src/pages/governance/__tests__/inventoryTabShell.integration.test.tsx
+++ b/platform/app/src/pages/governance/__tests__/inventoryTabShell.integration.test.tsx
@@ -187,6 +187,15 @@ beforeEach(() => {
 afterEach(() => cleanup());
 
 describe("the inventory tab shell", () => {
+  /** @scenario "Switching governance tabs unmounts the inactive content" */
+  it("unmounts the catalog content when switching to Sources", async () => {
+    renderInventoryAt(["/governance/inventory"]);
+    const content = screen.getByRole("tabpanel").firstElementChild;
+    expect(content).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("tab", { name: /^Sources/ }));
+    await waitFor(() => expect(content).not.toBeInTheDocument());
+  });
+
   describe("when an admin opens the bare address", () => {
     /** @scenario "The inventory default tab stays out of the address" */
     it("selects Catalog, mounts the tools catalog, and writes no tab parameter", () => {

--- a/platform/app/src/pages/governance/__tests__/peopleTabs.integration.test.tsx
+++ b/platform/app/src/pages/governance/__tests__/peopleTabs.integration.test.tsx
@@ -235,6 +235,17 @@ beforeEach(() => {
 afterEach(() => cleanup());
 
 describe("the People page tab shell", () => {
+  /** @scenario "Switching governance tabs unmounts the inactive content" */
+  it("removes the People table when switching to Departments", async () => {
+    harness.answers["activityMonitor.spendByUser"] = { data: [JANE] };
+    renderPeopleAt(["/governance/people"]);
+    const table = screen.getByRole("table");
+    await userEvent
+      .setup()
+      .click(screen.getByRole("tab", { name: "Departments" }));
+    await waitFor(() => expect(table).not.toBeInTheDocument());
+  });
+
   describe("when a viewer opens the bare address", () => {
     /** @scenario "The default tab is People" */
     it("selects People, requests the table, and writes no tab parameter", () => {

--- a/platform/app/src/pages/governance/__tests__/platformPlaceholders.integration.test.tsx
+++ b/platform/app/src/pages/governance/__tests__/platformPlaceholders.integration.test.tsx
@@ -168,6 +168,22 @@ afterEach(() => {
   cleanup();
 });
 
+/** @scenario "Switching governance tabs unmounts the inactive content" */
+it("unmounts Explore when switching to Dashboards", async () => {
+  renderPage(AnalyticsPage);
+  fireEvent.click(screen.getByRole("button", { name: "Requests by model" }));
+  const content = screen.getByRole("tabpanel", {
+    name: "Explore",
+  }).firstElementChild;
+  expect(content).toBeInTheDocument();
+  fireEvent.click(screen.getByRole("tab", { name: /Dashboards/ }));
+  await waitFor(() => expect(content).not.toBeInTheDocument());
+  fireEvent.click(screen.getByRole("tab", { name: "Explore" }));
+  expect(
+    await screen.findByText("usage | summarize count() by model, bin(1d)"),
+  ).toBeInTheDocument();
+});
+
 describe("given the billed-cost flag is off for a permitted viewer", () => {
   /** @scenario "The Platform screens are unreachable with the billed-cost flag off" */
   it("shows the not-found scene on every Platform screen", () => {

--- a/platform/app/src/pages/governance/__tests__/platformPlaceholders.integration.test.tsx
+++ b/platform/app/src/pages/governance/__tests__/platformPlaceholders.integration.test.tsx
@@ -18,6 +18,7 @@ import {
   waitFor,
   within,
 } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom/vitest";
 import type React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -170,15 +171,16 @@ afterEach(() => {
 
 /** @scenario "Switching governance tabs unmounts the inactive content" */
 it("unmounts Explore when switching to Dashboards", async () => {
+  const user = userEvent.setup();
   renderPage(AnalyticsPage);
   fireEvent.click(screen.getByRole("button", { name: "Requests by model" }));
   const content = screen.getByRole("tabpanel", {
     name: "Explore",
   }).firstElementChild;
   expect(content).toBeInTheDocument();
-  fireEvent.click(screen.getByRole("tab", { name: /Dashboards/ }));
+  await user.click(screen.getByRole("tab", { name: /Dashboards/ }));
   await waitFor(() => expect(content).not.toBeInTheDocument());
-  fireEvent.click(screen.getByRole("tab", { name: "Explore" }));
+  await user.click(screen.getByRole("tab", { name: "Explore" }));
   expect(
     await screen.findByText("usage | summarize count() by model, bin(1d)"),
   ).toBeInTheDocument();

--- a/platform/app/src/pages/governance/agents.tsx
+++ b/platform/app/src/pages/governance/agents.tsx
@@ -254,6 +254,7 @@ function AgentsPage() {
           onValueChange={({ value }) => selectAgentsTab(value)}
           variant="line"
           lazyMount
+          unmountOnExit
         >
           <Tabs.List>
             <Tabs.Trigger

--- a/platform/app/src/pages/governance/analytics.tsx
+++ b/platform/app/src/pages/governance/analytics.tsx
@@ -54,6 +54,9 @@ function AnalyticsPage() {
   const [timeWindow, setTimeWindow] = useState<ExploreWindow>(
     DEFAULT_EXPLORE_WINDOW,
   );
+  const [selection, setSelection] = useState<ExploreSelection>(
+    DEFAULT_EXPLORE_SELECTION,
+  );
 
   return (
     <GovernanceLayout pageTitle="Analytics · AI Governance · LangWatch">
@@ -77,7 +80,12 @@ function AnalyticsPage() {
           />
         </HStack>
 
-        <Tabs.Root defaultValue="explore" variant="line">
+        <Tabs.Root
+          defaultValue="explore"
+          variant="line"
+          lazyMount
+          unmountOnExit
+        >
           <Tabs.List>
             <Tabs.Trigger
               value="explore"
@@ -98,7 +106,12 @@ function AnalyticsPage() {
             </Tabs.Trigger>
           </Tabs.List>
           <Tabs.Content value="explore" paddingTop={4}>
-            <ExploreTab orgName={orgName} timeWindow={timeWindow} />
+            <ExploreTab
+              orgName={orgName}
+              timeWindow={timeWindow}
+              selection={selection}
+              onSelectionChange={setSelection}
+            />
           </Tabs.Content>
           <Tabs.Content value="dashboards" paddingTop={4}>
             <Text color="fg.muted">No dashboards yet.</Text>
@@ -113,19 +126,20 @@ function AnalyticsPage() {
 function ExploreTab({
   orgName,
   timeWindow,
+  selection,
+  onSelectionChange,
 }: {
   orgName: string;
   timeWindow: ExploreWindow;
+  selection: ExploreSelection;
+  onSelectionChange: (selection: ExploreSelection) => void;
 }) {
-  const [selection, setSelection] = useState<ExploreSelection>(
-    DEFAULT_EXPLORE_SELECTION,
-  );
   const patch = (next: Partial<ExploreSelection>) =>
-    setSelection((current) => ({ ...current, ...next }));
+    onSelectionChange({ ...selection, ...next });
 
   return (
     <VStack align="stretch" gap={4}>
-      <TemplateChips selection={selection} onPick={setSelection} />
+      <TemplateChips selection={selection} onPick={onSelectionChange} />
       <HStack
         gap={4}
         flexWrap="wrap"

--- a/platform/app/src/pages/governance/people.tsx
+++ b/platform/app/src/pages/governance/people.tsx
@@ -275,6 +275,7 @@ function PeoplePage() {
           onValueChange={({ value }) => selectTab(value)}
           variant="line"
           lazyMount
+          unmountOnExit
         >
           <PeopleTabsList />
           <Tabs.Content value="people" paddingTop={4}>

--- a/specs/ai-governance/dashboard/governance-ui-controls.feature
+++ b/specs/ai-governance/dashboard/governance-ui-controls.feature
@@ -3,6 +3,12 @@ Feature: The controls every AI Governance page renders the same way
   I want each page's filters, actions and sample data to look and behave alike
   So that a control I learned on one page is the same control on the next
 
+  @integration @regression
+  Scenario: Switching governance tabs unmounts the inactive content
+    Given a governance page with a populated tab
+    When the reader switches to another tab
+    Then the previous tab's content is removed from the document
+
   # ---------------------------------------------------------------------------
   # This file is the section's UI rulebook. It exists because the Costs page
   # got two things right that nothing wrote down, and five more pages were

--- a/specs/features/agents/voice-agents-v1.feature
+++ b/specs/features/agents/voice-agents-v1.feature
@@ -163,6 +163,7 @@ Feature: Voice agents v1: test an ElevenLabs agent from the app
     And the panel does not stay on "Connecting"
     And no run is created for that attempt
 
+  @integration
   Scenario: A page-level microphone block is named, not reported as a denial
     Given "Talk to it" was pressed
     And the page's Permissions-Policy does not allow the microphone
@@ -171,6 +172,7 @@ Feature: Voice agents v1: test an ElevenLabs agent from the app
     And the browser is never asked for the microphone
     And no run is created for that attempt
 
+  @unit
   Scenario: The app's own headers allow the microphone and the ElevenLabs socket
     Given a production response from the LangWatch app
     Then its Permissions-Policy allows the microphone for the app's own origin

--- a/specs/governance/azure-billing-identity.feature
+++ b/specs/governance/azure-billing-identity.feature
@@ -23,6 +23,14 @@ Feature: Azure billing identity — the bill is read with its own credential
     Given a Copilot Studio source that reads a tenant's conversations
     And the tenant's spend is billed to an Azure subscription
 
+  @unit @regression
+  Scenario: A replacement Azure source restates the original bill
+    Given an archived source recorded 100 dollars for an Azure subscription and day
+    When a replacement source reads the same bill revised to 125 dollars
+    Then the daily cost total is 125 dollars
+    And the replacement inherits the original source's billing identity
+    And its conversation records still belong to the replacement source
+
   @unit
   Scenario: The bill is asked for with the billing credential, not the conversation one
     Given the source holds a billing credential beside the conversation one

--- a/specs/governance/governance-cost-restatement-markers.feature
+++ b/specs/governance/governance-cost-restatement-markers.feature
@@ -10,6 +10,12 @@ Feature: A cost day says how much to trust its own figure
   Background:
     Given an organization with recorded cost events
 
+  @unit @regression
+  Scenario: One pull revising several items preserves the previous whole-cell total
+    Given two items in one daily cell previously cost 10 and 20 dollars
+    When one pull restates them to 15 and 30 dollars
+    Then the previous cell total is 30 dollars regardless of delivery order
+
   @unit
   Scenario: A restated day shows what it was before
     Given a day was reported at one amount


### PR DESCRIPTION
## Why

Follow-up to #7650, based on its head after #8002. Replacing an archived Azure source could count the same bill twice, and a pull revising several cost items could show the wrong previous total.

## What changed

- Preserve the original Azure billing identity across source replacements, while keeping audit and conversation records attached to the current source.
- Calculate the previous daily total across every item revised in the same pull.
- Unmount inactive People, Agents, Inventory, and Analytics tabs; preserve Analytics selections across tab switches.
- Tag two existing voice scenarios so feature parity passes, and remove a leftover conflict marker from `.env.example`.

## How it works

Server-owned source metadata retains the original billing identity and subscription. Replacement bill reads restate the existing cost rows. Ambiguous histories are rejected rather than choosing an arbitrary original source.

## Test plan

- Regression tests reproduced duplicate billing, incorrect previous totals, and retained inactive tab content before the fixes.
- 311 relevant backend tests and 86 component tests pass, including replacement billing, ownership guards, source edits, tab unmounting, and voice controls.
- `pnpm typecheck`, `pnpm typecheck:all`, `pnpm lint`, and feature parity pass.
- CI's comparison against the base reports no new Biome violations.

## Anything surprising?

This PR targets main because #7650 has merged. It prevents replacement sources from duplicating future reads; it does not reconcile money already duplicated by older sources. All required CI checks passed on `7fa5668360`; CodeRabbit findings are resolved. Browser verification is blocked because the only running app belongs to another worktree; no browser PASS is claimed.

## Deployment Impact

No environment variables or Helm values are added or changed; `.env.example` only loses a leftover conflict marker. A default Helm install needs no new configuration, and BYOC dataplanes need no operator action. The existing governance feature flags continue to apply. Azure source replacements retain their original billing identity in existing parser configuration storage; no schema migration or historical data rewrite is included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Azure billing continuity is preserved when sources are replaced, including historical billing attribution and usage totals.
  - Cost restatement markers now reflect all items revised in the same update.
  - Inactive governance tabs are unloaded when switching tabs.

- **Bug Fixes**
  - Corrected Azure billing checks and subscription identity handling for archived and replacement sources.
  - Removed an accidental merge-conflict marker from the sample environment configuration.

- **Tests**
  - Added regression coverage for Azure billing continuity, cost restatements, and tab content unloading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->