### PR TITLE
fix(analytics): reject aggregation not allowed for metric in getTimeseries

### DIFF
--- a/platform/app/src/pages/[project]/analytics/custom/index.tsx
+++ b/platform/app/src/pages/[project]/analytics/custom/index.tsx
@@ -574,6 +574,9 @@ export const customGraphFormToCustomGraphInput = (
 ): CustomGraphInput | undefined => {
   for (const series of formData.series) {
     const metric = getMetric(series.metric);
+    if (!metric) {
+      return undefined;
+    }
     if (metric.requiresKey && !metric.requiresKey.optional && !series.key) {
       return undefined;
     }
@@ -621,6 +624,9 @@ const customAPIinput = (
 ): CustomAPICallData | undefined => {
   for (const series of formData.series) {
     const metric = getMetric(series.metric);
+    if (!metric) {
+      return undefined;
+    }
     if (metric.requiresKey && !metric.requiresKey.optional && !series.key) {
       return undefined;
     }

--- a/platform/app/src/pages/[project]/analytics/custom/index.tsx
+++ b/platform/app/src/pages/[project]/analytics/custom/index.tsx
@@ -569,18 +569,27 @@ export const customGraphInputToFormData = (
   };
 };
 
+// A series is unusable if its metric no longer exists, or if it's missing a
+// key/subkey the metric requires. Shared by customGraphFormToCustomGraphInput
+// and customAPIinput, which both bail to `undefined` on the first bad series.
+const isSeriesMissingRequiredMetricFields = (
+  series: CustomGraphFormData["series"][number],
+): boolean => {
+  const metric = getMetric(series.metric);
+  if (!metric) {
+    return true;
+  }
+  if (metric.requiresKey && !metric.requiresKey.optional && !series.key) {
+    return true;
+  }
+  return !!metric.requiresSubkey && !series.subkey;
+};
+
 export const customGraphFormToCustomGraphInput = (
   formData: CustomGraphFormData,
 ): CustomGraphInput | undefined => {
   for (const series of formData.series) {
-    const metric = getMetric(series.metric);
-    if (!metric) {
-      return undefined;
-    }
-    if (metric.requiresKey && !metric.requiresKey.optional && !series.key) {
-      return undefined;
-    }
-    if (metric.requiresSubkey && !series.subkey) {
+    if (isSeriesMissingRequiredMetricFields(series)) {
       return undefined;
     }
   }
@@ -623,14 +632,7 @@ const customAPIinput = (
   filterParams: SharedFiltersInput,
 ): CustomAPICallData | undefined => {
   for (const series of formData.series) {
-    const metric = getMetric(series.metric);
-    if (!metric) {
-      return undefined;
-    }
-    if (metric.requiresKey && !metric.requiresKey.optional && !series.key) {
-      return undefined;
-    }
-    if (metric.requiresSubkey && !series.subkey) {
+    if (isSeriesMissingRequiredMetricFields(series)) {
       return undefined;
     }
   }

--- a/platform/app/src/server/analytics/registry.ts
+++ b/platform/app/src/server/analytics/registry.ts
@@ -368,12 +368,16 @@ export const flattenAnalyticsGroupsEnum = Object.keys(analyticsGroups).flatMap(
 
 export const getMetric = (
   groupMetric: FlattenAnalyticsMetricsEnum,
-): AnalyticsMetric => {
+): AnalyticsMetric | undefined => {
   const [group, metric_] = groupMetric.split(".") as [
     AnalyticsMetricsGroupsEnum,
     string,
   ];
-  return (analyticsMetrics[group] as any)[metric_];
+  // Optional chaining on the group lookup: an unknown group (not just an
+  // unknown metric within a known group) must return undefined here rather
+  // than throw a raw TypeError — the only caller (AnalyticsService.
+  // getTimeseries) turns `undefined` into a clean ValidationError.
+  return (analyticsMetrics[group] as any)?.[metric_];
 };
 
 export const getGroup = (

--- a/platform/app/src/server/app-layer/analytics/__tests__/analytics.service.test.ts
+++ b/platform/app/src/server/app-layer/analytics/__tests__/analytics.service.test.ts
@@ -243,6 +243,31 @@ describe("AnalyticsService", () => {
       expect(spies.runSlimTimeseries).not.toHaveBeenCalled();
     });
 
+    // Unlike an unknown metric within a known group, an unknown GROUP means
+    // `analyticsMetrics[group]` itself is undefined — indexing straight into
+    // that (no optional chaining) throws a raw TypeError before the
+    // ValidationError guard ever runs. Same crash shape as #8009, different
+    // trigger.
+    it("rejects a series naming a metric group absent from the registry", async () => {
+      const { deps, spies } = makeDeps();
+
+      await expect(
+        new AnalyticsService(deps).getTimeseries({
+          ...input,
+          series: [
+            {
+              metric: "a_group_removed_from_the_registry.some_metric" as never,
+              aggregation: "cardinality" as const,
+            },
+          ],
+        }),
+      ).rejects.toThrow(/a_group_removed_from_the_registry/);
+
+      expect(spies.runLegacy).not.toHaveBeenCalled();
+      expect(spies.runRollupTimeseries).not.toHaveBeenCalled();
+      expect(spies.runSlimTimeseries).not.toHaveBeenCalled();
+    });
+
     describe("when the tripwire flag is ON", () => {
       beforeEach(() => enableTripwire());
 

--- a/platform/app/src/server/app-layer/analytics/__tests__/analytics.service.test.ts
+++ b/platform/app/src/server/app-layer/analytics/__tests__/analytics.service.test.ts
@@ -191,6 +191,58 @@ describe("AnalyticsService", () => {
       });
     });
 
+    // #8009 — evaluation_runs declares allowedAggregations: ["cardinality"],
+    // but nothing enforced it: a "sum" request reached the slim builder,
+    // which unconditionally emits sum(EvaluationId) on a String column and
+    // ClickHouse rejects it with Code: 43 ILLEGAL_TYPE_OF_ARGUMENT. The
+    // service must reject the aggregation itself, before any repository
+    // (and therefore before ClickHouse) is ever called.
+    it("rejects a series whose aggregation is not allowed for its metric", async () => {
+      const { deps, spies } = makeDeps();
+
+      await expect(
+        new AnalyticsService(deps).getTimeseries({
+          ...input,
+          series: [
+            {
+              metric: "evaluations.evaluation_runs" as const,
+              aggregation: "sum" as const,
+            },
+          ],
+        }),
+      ).rejects.toThrow(/evaluations\.evaluation_runs.*sum/);
+
+      expect(spies.runLegacy).not.toHaveBeenCalled();
+      expect(spies.runRollupTimeseries).not.toHaveBeenCalled();
+      expect(spies.runSlimTimeseries).not.toHaveBeenCalled();
+      expect(spies.runEvalRollupTimeseries).not.toHaveBeenCalled();
+      expect(spies.runEvalSlimTimeseries).not.toHaveBeenCalled();
+    });
+
+    // graph-trigger-evaluation.service.ts builds series from stored
+    // custom-graph JSON and casts past zod — a metric renamed or removed
+    // from the registry since the graph was saved must fail clearly here,
+    // not as an undefined-property TypeError out of the aggregation guard.
+    it("rejects a series naming a metric absent from the registry", async () => {
+      const { deps, spies } = makeDeps();
+
+      await expect(
+        new AnalyticsService(deps).getTimeseries({
+          ...input,
+          series: [
+            {
+              metric: "evaluations.a_metric_removed_from_the_registry" as never,
+              aggregation: "cardinality" as const,
+            },
+          ],
+        }),
+      ).rejects.toThrow(/a_metric_removed_from_the_registry/);
+
+      expect(spies.runLegacy).not.toHaveBeenCalled();
+      expect(spies.runRollupTimeseries).not.toHaveBeenCalled();
+      expect(spies.runSlimTimeseries).not.toHaveBeenCalled();
+    });
+
     describe("when the tripwire flag is ON", () => {
       beforeEach(() => enableTripwire());
 

--- a/platform/app/src/server/app-layer/analytics/analytics.service.ts
+++ b/platform/app/src/server/app-layer/analytics/analytics.service.ts
@@ -22,9 +22,10 @@
  * `findX` / `runX` (see this module's repositories/ files).
  */
 
+import { ValidationError } from "@langwatch/handled-error";
 import { createHash } from "crypto";
 import { getLangWatchTracer } from "langwatch";
-import type { TimeseriesInputType } from "~/server/analytics/registry";
+import { getMetric, type TimeseriesInputType } from "~/server/analytics/registry";
 import type {
   AnalyticsBackend,
   FeedbacksResult,
@@ -110,6 +111,36 @@ export class AnalyticsService {
       "AnalyticsService.getTimeseries",
       { attributes: { "tenant.id": input.projectId } },
       async () => {
+        // Reject a series whose aggregation its metric does not declare
+        // BEFORE any routing or repository call — a query builder has no
+        // way to refuse an aggregation, it just emits SQL for it, and
+        // ClickHouse is the only thing left to say no (see #8009: "sum" on
+        // evaluation_runs, a String column, crashes with a raw type error).
+        for (const series of input.series) {
+          const metric = getMetric(series.metric) as
+            | ReturnType<typeof getMetric>
+            | undefined;
+          if (!metric) {
+            throw new ValidationError(
+              `Metric "${series.metric}" is not defined in the analytics registry`,
+              { meta: { metric: series.metric } },
+            );
+          }
+          if (!metric.allowedAggregations.includes(series.aggregation)) {
+            throw new ValidationError(
+              `Metric "${series.metric}" does not support aggregation "${series.aggregation}" ` +
+                `(allowed: ${metric.allowedAggregations.join(", ")})`,
+              {
+                meta: {
+                  metric: series.metric,
+                  aggregation: series.aggregation,
+                  allowedAggregations: metric.allowedAggregations,
+                },
+              },
+            );
+          }
+        }
+
         const hash = createHash("sha256")
           // `options` is part of the cache identity, not a side channel: a
           // bounded read and an unbounded one are different questions, and a

--- a/platform/app/src/server/app-layer/analytics/analytics.service.ts
+++ b/platform/app/src/server/app-layer/analytics/analytics.service.ts
@@ -25,7 +25,10 @@
 import { ValidationError } from "@langwatch/handled-error";
 import { createHash } from "crypto";
 import { getLangWatchTracer } from "langwatch";
-import { getMetric, type TimeseriesInputType } from "~/server/analytics/registry";
+import {
+  getMetric,
+  type TimeseriesInputType,
+} from "~/server/analytics/registry";
 import type {
   AnalyticsBackend,
   FeedbacksResult,
@@ -116,30 +119,7 @@ export class AnalyticsService {
         // way to refuse an aggregation, it just emits SQL for it, and
         // ClickHouse is the only thing left to say no (see #8009: "sum" on
         // evaluation_runs, a String column, crashes with a raw type error).
-        for (const series of input.series) {
-          const metric = getMetric(series.metric) as
-            | ReturnType<typeof getMetric>
-            | undefined;
-          if (!metric) {
-            throw new ValidationError(
-              `Metric "${series.metric}" is not defined in the analytics registry`,
-              { meta: { metric: series.metric } },
-            );
-          }
-          if (!metric.allowedAggregations.includes(series.aggregation)) {
-            throw new ValidationError(
-              `Metric "${series.metric}" does not support aggregation "${series.aggregation}" ` +
-                `(allowed: ${metric.allowedAggregations.join(", ")})`,
-              {
-                meta: {
-                  metric: series.metric,
-                  aggregation: series.aggregation,
-                  allowedAggregations: metric.allowedAggregations,
-                },
-              },
-            );
-          }
-        }
+        this.assertSeriesAggregationsAllowed(input);
 
         const hash = createHash("sha256")
           // `options` is part of the cache identity, not a side channel: a
@@ -197,6 +177,39 @@ export class AnalyticsService {
         return routedResult;
       },
     );
+  }
+
+  /**
+   * Throws `ValidationError` for the first series naming a metric absent
+   * from the registry, or an aggregation that metric doesn't declare in
+   * `allowedAggregations`. Split out of `getTimeseries` to keep that
+   * function's cognitive complexity under the house lint cap.
+   */
+  private assertSeriesAggregationsAllowed(input: TimeseriesInputType): void {
+    for (const series of input.series) {
+      const metric = getMetric(series.metric) as
+        | ReturnType<typeof getMetric>
+        | undefined;
+      if (!metric) {
+        throw new ValidationError(
+          `Metric "${series.metric}" is not defined in the analytics registry`,
+          { meta: { metric: series.metric } },
+        );
+      }
+      if (!metric.allowedAggregations.includes(series.aggregation)) {
+        throw new ValidationError(
+          `Metric "${series.metric}" does not support aggregation "${series.aggregation}" ` +
+            `(allowed: ${metric.allowedAggregations.join(", ")})`,
+          {
+            meta: {
+              metric: series.metric,
+              aggregation: series.aggregation,
+              allowedAggregations: metric.allowedAggregations,
+            },
+          },
+        );
+      }
+    }
   }
 
   async getFeedbacks(

--- a/platform/app/src/server/app-layer/analytics/analytics.service.ts
+++ b/platform/app/src/server/app-layer/analytics/analytics.service.ts
@@ -187,9 +187,7 @@ export class AnalyticsService {
    */
   private assertSeriesAggregationsAllowed(input: TimeseriesInputType): void {
     for (const series of input.series) {
-      const metric = getMetric(series.metric) as
-        | ReturnType<typeof getMetric>
-        | undefined;
+      const metric = getMetric(series.metric);
       if (!metric) {
         throw new ValidationError(
           `Metric "${series.metric}" is not defined in the analytics registry`,


### PR DESCRIPTION
Fixes #8009

## Bug

`evaluations.evaluation_runs` declares `allowedAggregations: ["cardinality"]` but nothing enforced it. A `sum` series on that metric (a String column) reached ClickHouse and crashed with `ILLEGAL_TYPE_OF_ARGUMENT` instead of failing at the app boundary.

## Fix

`AnalyticsService.getTimeseries` is the single entrypoint for all callers — including `graph-trigger-evaluation.service.ts`, which builds a `SeriesInputType` from stored custom-graph JSON and casts past tRPC's zod validation. So the guard lives in the service, not in a router-level schema.

Added a check before any repository/routing call: for each series, if the metric isn't in the registry, or the aggregation isn't in that metric's `allowedAggregations`, throw `ValidationError` (existing `@langwatch/handled-error` class, code `validation_error`, 422). `handledErrorMiddleware` already maps that to a coded `TRPCError` instead of `INTERNAL_SERVER_ERROR`.

## Tests

Two new tests in `analytics.service.test.ts`: disallowed aggregation, unknown metric. Both assert no repository call fires.

## Verification

- `analytics.service.test.ts`: 10/10 pass
- Sweep (`analytics`, `automations`): 1462/1468 pass — 6 pre-existing failures in `emailSuppression.service.unit.test.ts` (`NEXTAUTH_SECRET`), confirmed unrelated via `git stash`
- `npm run typecheck`: clean on this diff

## Also fixed while surfacing CI/review

- **`getMetric` threw on an unknown metric group** (CodeRabbit): `analyticsMetrics[group]` was dereferenced with no existence check, so an unrecognized group raised a raw `TypeError` instead of the same "unknown metric" validation path. `getMetric` now returns `AnalyticsMetric | undefined`; `analytics.service.ts` simplified accordingly, plus a new test.
- That signature change made `getMetric`'s result newly `undefined`-shaped at two callers in `analytics/custom/index.tsx` (`customGraphFormToCustomGraphInput`, `customAPIinput`) that assumed a match — added guards, then extracted the shared metric/key/subkey validity check (`isSeriesMissingRequiredMetricFields`) so the added branch didn't trip the biome cognitive-complexity gate.
- Lint gate: biome format + a `noExcessiveCognitiveComplexity` warning on the original `getTimeseries` guard — fixed by extracting `assertSeriesAggregationsAllowed`.

## Not fixed here (follow-up)

`requiresKey`/`requiresSubkey` on metrics/groups is enforced client-side only (`analytics/custom/index.tsx`), never in `analytics.service.ts` — an unkeyed query on a mandatory-key metric silently mixes data instead of crashing. Same bypass shape as this bug, different validation surface. Out of scope for a minimal fix; filing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Analytics time-series requests now validate that each metric exists and supports the requested aggregation before querying data.
  - Invalid metrics, metric groups, and unsupported aggregations return clear validation errors identifying the problematic value.
  - Invalid requests are rejected before analytics data sources are queried.

- **Tests**
  - Added coverage for unknown metrics, unknown metric groups, and unsupported aggregations, including verification that invalid requests do not query analytics data sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
