### PR TITLE
fix(governance): show provider costs and clarify import health

### DIFF
--- a/dev/docs/adr/122-openai-admin-cost-puller.md
+++ b/dev/docs/adr/122-openai-admin-cost-puller.md
@@ -109,19 +109,37 @@ general hazard recorded against the Genie warehouse-cost work; it is
 restated here because it is easy to reintroduce and silent when wrong.
 
 **6. Identity rides the event as raw provider ids, in the extras bag.**
-`actor` carries `user_email`. The raw `user_id` and the `api_key_id` ride in
-`extra`, which `pullerWorker.ts:587` spreads into `metadata.extension` —
-exactly the shape `databricksGenie.puller.ts:2596-2602` already ships for
-per-person attribution. **`NormalizedPullEvent` does not change**, so no
-published contract moves and no sibling adapter is touched.
+
+> **[CORRECTED — see revision v3.]** This decision was written as "`actor`
+> carries `user_email`". The adapter shipped the opposite and deliberately
+> so: `actor` carries the provider's **opaque `user-…` id**, and the email
+> reaches `raw_payload` only, through the row schema's `.passthrough()`
+> (`openaiAdmin.puller.ts:400,851` and the comment above them). The id is the
+> stable key, the erasure suppression list is keyed on exactly that string,
+> and a raw address is heavier on a money row. The decision below stands with
+> "the raw user id" read wherever it says "`user_email`".
+
+`actor` carries the row's raw `user_id`. That same id and the `api_key_id`
+also ride in `extra`, which `pullerWorker.ts:1096` spreads into
+`metadata.extension` — exactly the shape `databricksGenie.puller.ts` already
+ships for per-person attribution. **`NormalizedPullEvent` does not change**,
+so no published contract moves and no sibling adapter is touched.
 
 Populating the real `ActorUserId` column was considered and rejected. It is
-hardcoded to `""` for every puller (`pullerWorker.ts:602`), and the one
-surface named to justify filling it — `activityMonitor.service.ts:354` —
-reads `actorEmail || actorUserId || actorEnduserId`. OpenAI sends
-`user_email` on **every** row, so the email always wins that `||` and the
-column write would never be read. A published-contract change for a value
-nothing observes is cost with no benefit.
+hardcoded to `""` for every puller (`pullerWorker.ts:1110`), and the one
+surface named to justify filling it — `activityMonitor.service.ts:379` —
+reads `actorEmail || actorUserId || actorEnduserId`, so whatever `actor`
+holds wins that `||` and a column write would never be read.
+
+> **[SUPERSEDED IN PART — see revision v3.]** The rejection above was
+> reasoned from an email in `actor`. With an opaque id there instead, the
+> consequence is that the OCSF **actor email** column
+> (`pullerWorker.ts:1080,1112`) receives an opaque id rather than an address,
+> while the actor **id** column beside it stays `""`. The intended contract
+> is the plain one: **opaque ids belong in the actor id field, and the email
+> field carries addresses only** — a column named for an address must not be
+> read as holding one. This ADR records the divergence; it does not rule on
+> how the fields are filled.
 
 This follows ADR-088 Decision 13's principle — write the provider's raw id,
 resolve the person later, never call a directory at pull time. OpenAI
@@ -199,7 +217,21 @@ diverge on money units, timestamp format, page-token binding and a
 retention floor Anthropic has no equivalent of. An abstraction built at n=2
 is shaped like its first caller. Revisit at the third provider.
 
-**12. `openai_compliance` is deprecated in place, still listed.** It stays
+**12. `openai_compliance` is deprecated in place, still listed.**
+
+> **[NOT IMPLEMENTED — see revision v3.]** No code path deprecates
+> `openai_compliance`. Its catalog entry carries no `deprecated` flag
+> (`ingestionSourceCatalog.tsx:142-149`), so the picker offers it for new
+> sources exactly as before. The `deprecated` flag itself does exist and is
+> carried by one other type, but its shipped behaviour is the opposite of
+> what this decision chose: `gatedSourceTypeOptions` **filters a deprecated
+> option out of the picker** (`ingestionSourceCatalog.tsx:293`) rather than
+> showing it behind a disabled badge, and the catalog test was rewritten to
+> expect that (`ingestionSourceCatalog.unit.test.ts:19,27-41`) instead of
+> staying green unchanged. Both halves of the decision below — the badge and
+> the badging of this source type — are therefore unbuilt.
+
+It stays
 registered, stays in the catalog array, and stays **visible** in the picker
 behind a `deprecated` badge that disables it for new sources. Hiding it was
 rejected: `ingestionSourceCatalog.unit.test.ts:27-31` asserts the picker
@@ -231,7 +263,7 @@ can exist, so there is nothing to repair.
 | No float round-trip on money | Sub-cent figures keep every digit | `amount` parsed as `string \| number` and stringified once; a string input survives byte-identical |
 | A costless read writes no money | A missing row never overwrites a present one | Unit test: a bucket whose row vanished emits an event with **no** `pulled_usage` key, and `buildPulledUsageRecord` returns null |
 | Re-pulling an unchanged window records nothing new | At-least-once delivery is free | Same window pulled twice; ledger row count unchanged |
-| Identity reaches the audit row | Attribution is visible where a surface already reads it | OCSF row asserts `ActorEmail` = the row's email, and `metadata.extension.actorUserId` / `.apiKeyId` = the row's raw ids |
+| Identity reaches the audit row | Attribution is visible where a surface already reads it | OCSF row asserts the actor field = the row's raw `user_id`, and `metadata.extension.actorUserId` / `.apiKeyId` = the row's raw ids. **[v3: as shipped that actor field is the OCSF actor *email* column, which is the divergence Decision 6 now records — the address itself reaches `raw_payload` only.]** |
 | The watermark never moves backwards | A re-read window, or a page returned out of order, must not rewind progress | Unit test: a response whose last bucket precedes the stored watermark leaves the watermark unchanged |
 | A corrected bucket replaces, never adds | Restatement is the whole point of the re-read window | Same window pulled twice with a changed `amount.value`; the ledger shows the new figure once, and the row count is unchanged |
 | Below the floor the day survives, only the key is lost | A 400 on key grouping must not cost history | Unit test: a floor 400 triggers one retry with `user_id` only, and the resulting rows still carry `user_id` |
@@ -257,7 +289,7 @@ can exist, so there is nothing to repair.
 | Cost figure → ledger | No — `argMax` replacement destroys the prior figure | Money | Human review, plus the no-division and costless-read tests above. A dollar figure is asserted end to end against a captured payload, not a hand-written one. |
 | Provider identity ids leaving for third-party SIEMs | No — an export is a send | Privacy | Human review. `governanceOcsfEvents.clickhouse.repository.ts:236,284` exports `RawOcsfJson` to whatever SIEM an org has wired, and `raw_payload` is **required** on every pull event (`pullerAdapter.ts:96`), so the provider's ids egress by construction. Not introduced here — Anthropic and Genie already do it — but named so it is a decision rather than an accident. |
 | `openai_admin` `pullConfig` shape | No — persists in customer rows | Small (no row exists yet) | Human review of the schema. Validated at create time by `validateConfig`. |
-| `openai_compliance` badged deprecated | Yes | Small | Automated: the two existing catalog tests must stay green **unchanged** — the picker still offers every registered type (Decision 12). |
+| `openai_compliance` badged deprecated | Yes | Small | Automated: the two existing catalog tests must stay green **unchanged** — the picker still offers every registered type (Decision 12). **[NOT IMPLEMENTED — v3: nothing badges this type, and the catalog tests were rewritten rather than left unchanged.]** |
 | The trailing re-read window | Yes — read-only, bounded by a constant | Small | Automated: the restatement invariant above, plus a test that the watermark does not rewind. |
 | Live pull against the real Admin API | Read-only | None | Required before merge. A fixture alone has never caught a wire-shape error in this codebase. |
 
@@ -266,7 +298,9 @@ can exist, so there is nothing to repair.
 **No migration, and no contract change.** `NormalizedPullEvent` is untouched
 (Decision 6): identity travels in the existing `extra` bag, which the worker
 already spreads into `metadata.extension`. `ActorUserId` stays the empty
-string, as it is for every puller today.
+string, as it is for every puller today — which is the half of the field pair
+Decision 6's v3 correction names: the id column is empty while the column
+named for an email holds an opaque id.
 
 ```ts
 // What the adapter puts in the existing `extra` record. Raw and unresolved:
@@ -316,8 +350,8 @@ extra: {
   correction never reaches the ledger, in a product where nothing would
   notice. Rejected in Decision 9.
 - **Extend `NormalizedPullEvent` and populate `ActorUserId`** — a
-  published-contract change whose value no surface reads, because
-  `actorEmail` always wins the `||` that would have exposed it.
+  published-contract change whose value no surface reads, because whatever
+  `actor` holds always wins the `||` that would have exposed it.
 - **The declarative `http_polling` adapter** — the framework's documented
   default, and genuinely unusable here: its `eventMapping.extra` is a flat
   `z.record(z.string())` that cannot build the nested `dimensions` map the
@@ -326,7 +360,9 @@ extra: {
   beyond an opaque page token.
 - **Hide `openai_compliance` from the picker** — breaks two passing catalog
   tests and contradicts a spec scenario promising every supported type is
-  listed. A disabled badge achieves the same end.
+  listed. A disabled badge achieves the same end. **[v3: the codebase since
+  chose hiding for the one type it did retire, and rewrote the catalog tests
+  to match; `openai_compliance` itself was never deprecated at all.]**
 - **A uniqueness guard on duplicate sources** — belongs on every adapter,
   not this one alone.
 - **Extract a shared bucket-report base** — n=2 is a coincidence, and the
@@ -424,7 +460,8 @@ adapter duplicates cursor logic a third provider may justify factoring out.
   ships the extras shape. Decision 12 now keeps `openai_compliance`
   **visible with a disabled badge**: hiding it would have broken two passing
   catalog tests and a spec scenario promising every supported type is
-  listed.
+  listed. **[v3: neither half of that shipped — see the marker on Decision
+  12.]**
 
   Four gaps were closed without reopening a fork: the watermark takes
   `max(watermark, lastBucketStart)`, retiring an unstated dependence on
@@ -445,3 +482,29 @@ adapter duplicates cursor logic a third provider may justify factoring out.
   one day after page one ended. That observation is recorded as **not
   relied upon**. Two findings survived every attack unchanged: money-unit
   handling, and the costless-read guard. Captain: Sergio Esteban.
+- **v3 (2026-09-09) — documentation caught up with the code.** No decision is
+  taken here; two statements the ADR made are corrected against the adapter as
+  it stands, and the prose they correct is left in place so the record of the
+  decision survives.
+  - **Decision 6's `actor` is the raw `user_id`, not `user_email`.** The
+    adapter reads the id deliberately and says why in its own comment
+    (`openaiAdmin.puller.ts:390-401,835-851`): the id is stable, the erasure
+    suppression list is keyed on exactly that string, and the address is
+    heavier on a money row. The email is not dropped — it survives into
+    `raw_payload` through the row schema's `.passthrough()`.
+  - **Consequence, recorded rather than ruled on:** the worker writes
+    `actorEmail: event.actor` and `actorUserId: ""`
+    (`pullerWorker.ts:1080,1110-1112`), so today the OCSF column named for an
+    email address holds an opaque provider id while the actor id column beside
+    it is empty. The intended contract is the plain one — opaque ids belong in
+    the actor id field, and the email field carries addresses only.
+  - **Decision 12 was never implemented.** `openai_compliance` carries no
+    `deprecated` flag (`ingestionSourceCatalog.tsx:142-149`) and the picker
+    still offers it for new sources. The `deprecated` flag exists and one other
+    source type carries it, but `gatedSourceTypeOptions` **removes** a
+    deprecated option from the picker (`ingestionSourceCatalog.tsx:293`) —
+    the "hide it" alternative this ADR rejected — and the catalog test was
+    rewritten to expect that (`ingestionSourceCatalog.unit.test.ts:19,27-41`)
+    rather than staying green unchanged as the Gates row required.
+  - Stale citations refreshed: `pullerWorker.ts:587` → `:1096`, `:602` →
+    `:1110`, `activityMonitor.service.ts:354` → `:379`.

--- a/dev/docs/adr/122-openai-admin-cost-puller.md
+++ b/dev/docs/adr/122-openai-admin-cost-puller.md
@@ -114,32 +114,54 @@ restated here because it is easy to reintroduce and silent when wrong.
 > carries `user_email`". The adapter shipped the opposite and deliberately
 > so: `actor` carries the provider's **opaque `user-…` id**, and the email
 > reaches `raw_payload` only, through the row schema's `.passthrough()`
-> (`openaiAdmin.puller.ts:400,851` and the comment above them). The id is the
+> (`openaiAdmin.puller.ts:403,864` and the comments above them). The id is the
 > stable key, the erasure suppression list is keyed on exactly that string,
 > and a raw address is heavier on a money row. The decision below stands with
 > "the raw user id" read wherever it says "`user_email`".
 
 `actor` carries the row's raw `user_id`. That same id and the `api_key_id`
-also ride in `extra`, which `pullerWorker.ts:1096` spreads into
+also ride in `extra`, which `ocsfPullEventMapping.ts:108` spreads into
 `metadata.extension` — exactly the shape `databricksGenie.puller.ts` already
 ships for per-person attribution. **`NormalizedPullEvent` does not change**,
 so no published contract moves and no sibling adapter is touched.
 
-Populating the real `ActorUserId` column was considered and rejected. It is
-hardcoded to `""` for every puller (`pullerWorker.ts:1110`), and the one
-surface named to justify filling it — `activityMonitor.service.ts:379` —
-reads `actorEmail || actorUserId || actorEnduserId`, so whatever `actor`
-holds wins that `||` and a column write would never be read.
+Populating the real `ActorUserId` column was considered and rejected. As
+written, it was hardcoded to `""` for every puller, and the one surface named
+to justify filling it — `activityMonitor.service.ts:379` — reads
+`actorEmail || actorUserId || actorEnduserId`, so whatever `actor` holds wins
+that `||` and a column write would never be read.
 
-> **[SUPERSEDED IN PART — see revision v3.]** The rejection above was
-> reasoned from an email in `actor`. With an opaque id there instead, the
-> consequence is that the OCSF **actor email** column
-> (`pullerWorker.ts:1080,1112`) receives an opaque id rather than an address,
-> while the actor **id** column beside it stays `""`. The intended contract
-> is the plain one: **opaque ids belong in the actor id field, and the email
-> field carries addresses only** — a column named for an address must not be
-> read as holding one. This ADR records the divergence; it does not rule on
-> how the fields are filled.
+> **[SUPERSEDED IN PART — see revision v3. RESOLVED — see revision v4.]** The
+> rejection above was reasoned from an email in `actor`. With an opaque id
+> there instead, the consequence was that the OCSF **actor email** column
+> received an opaque id rather than an address, while the actor **id** column
+> beside it stayed `""`. That divergence was real, and it is fixed: the
+> contract this paragraph called the plain one — **opaque ids belong in the
+> actor id field, and the email field carries addresses only** — is now the
+> shipped one.
+>
+> The routing is decided in one place. `ocsfActorFields`
+> (`ocsfPullEventMapping.ts:43-51`) sends an address to `actorEmail` and
+> anything else — an opaque `user-…` id, a directory GUID — to `actorUserId`,
+> and the same placement is applied to the raw OCSF payload
+> (`ocsfPullEventMapping.ts:92,123-124`), so the row and its JSON cannot
+> disagree. The address test is `normalizeEmail`
+> (`identityEvidence.ts:151-155`), the identity match engine's own, so the
+> audit row and the matcher cannot drift apart on what an address is; the
+> value is stored verbatim, because an audit row records what the provider
+> said rather than a rewrite of it.
+>
+> Half the rejection above still stands, and it is the published-contract
+> half: `NormalizedPullEvent` did not change and no sibling adapter was
+> touched. What changed is where the worker puts a string it already had.
+> Attribution did not move either — the read at
+> `activityMonitor.service.ts:379` takes the first of
+> `actorEmail || actorUserId || actorEnduserId` that is set, so an opaque id
+> now arrives on the second term instead of the first; and identity matching,
+> department sync, person discovery, erasure suppression and the cost records
+> all key on the pull event's own `actor`, never on this column.
+>
+> **Rows written before the fix are not corrected** — see Open questions.
 
 This follows ADR-088 Decision 13's principle — write the provider's raw id,
 resolve the person later, never call a directory at pull time. OpenAI
@@ -263,7 +285,7 @@ can exist, so there is nothing to repair.
 | No float round-trip on money | Sub-cent figures keep every digit | `amount` parsed as `string \| number` and stringified once; a string input survives byte-identical |
 | A costless read writes no money | A missing row never overwrites a present one | Unit test: a bucket whose row vanished emits an event with **no** `pulled_usage` key, and `buildPulledUsageRecord` returns null |
 | Re-pulling an unchanged window records nothing new | At-least-once delivery is free | Same window pulled twice; ledger row count unchanged |
-| Identity reaches the audit row | Attribution is visible where a surface already reads it | OCSF row asserts the actor field = the row's raw `user_id`, and `metadata.extension.actorUserId` / `.apiKeyId` = the row's raw ids. **[v3: as shipped that actor field is the OCSF actor *email* column, which is the divergence Decision 6 now records — the address itself reaches `raw_payload` only.]** |
+| Identity reaches the audit row | Attribution is visible where a surface already reads it | OCSF row asserts the actor field = the row's raw `user_id`, and `metadata.extension.actorUserId` / `.apiKeyId` = the row's raw ids. **[v3: as shipped that actor field was the OCSF actor *email* column — the divergence Decision 6 records. v4: resolved. An opaque id now lands in `ActorUserId` with `ActorEmail` left blank, asserted against the real mapper rather than a copy of it (`pullerWorker.ocsfMapping.unit.test.ts:125-151`). The address itself still reaches `raw_payload` only.]** |
 | The watermark never moves backwards | A re-read window, or a page returned out of order, must not rewind progress | Unit test: a response whose last bucket precedes the stored watermark leaves the watermark unchanged |
 | A corrected bucket replaces, never adds | Restatement is the whole point of the re-read window | Same window pulled twice with a changed `amount.value`; the ledger shows the new figure once, and the row count is unchanged |
 | Below the floor the day survives, only the key is lost | A 400 on key grouping must not cost history | Unit test: a floor 400 triggers one retry with `user_id` only, and the resulting rows still carry `user_id` |
@@ -296,11 +318,15 @@ can exist, so there is nothing to repair.
 ## Schema
 
 **No migration, and no contract change.** `NormalizedPullEvent` is untouched
-(Decision 6): identity travels in the existing `extra` bag, which the worker
-already spreads into `metadata.extension`. `ActorUserId` stays the empty
-string, as it is for every puller today — which is the half of the field pair
-Decision 6's v3 correction names: the id column is empty while the column
-named for an email holds an opaque id.
+(Decision 6): identity travels in the existing `extra` bag, which
+`ocsfPullEventMapping.ts:108` spreads into `metadata.extension`. `ActorUserId`
+is no longer the empty string it was for every puller when this was written:
+since the v4 correction the mapper fills it whenever the actor is not an
+address (`ocsfPullEventMapping.ts:43-51`), so an OpenAI row carries its opaque
+`user-…` id there and leaves `ActorEmail` blank. That is a change of column
+placement, not of schema — both columns already existed and both are written
+by the same insert. Rows written before the fix keep the id in `ActorEmail`
+with `ActorUserId` empty beside it; see Open questions.
 
 ```ts
 // What the adapter puts in the existing `extra` record. Raw and unresolved:
@@ -352,6 +378,13 @@ extra: {
 - **Extend `NormalizedPullEvent` and populate `ActorUserId`** — a
   published-contract change whose value no surface reads, because whatever
   `actor` holds always wins the `||` that would have exposed it.
+  **[PARTLY OVERTAKEN — see revision v4.]** The contract half of the rejection
+  stands: `NormalizedPullEvent` never changed. The column half did not.
+  `ActorUserId` is now populated without touching the contract, because the
+  mapper places the actor string it already had by what that string *is*
+  (`ocsfPullEventMapping.ts:43-51`). The `||` argument was about which term a
+  reader wins, which is not the same question as which column may honestly
+  hold an id.
 - **The declarative `http_polling` adapter** — the framework's documented
   default, and genuinely unusable here: its `eventMapping.extra` is a flat
   `z.record(z.string())` that cannot build the nested `dimensions` map the
@@ -420,6 +453,15 @@ adapter duplicates cursor logic a third provider may justify factoring out.
   unassigned; it is the gap that makes a wrong figure undetectable.
 - **Why does the cost surface bill image generation that `/usage/images`
   reports zero rows for?** Out of scope here; recorded in #7579.
+- **Rows written before the actor-field fix still name the person in the
+  wrong column.** Every `governance_ocsf_events` row this puller wrote before
+  revision v4 carries the opaque `user-…` id in `ActorEmail`, and
+  `ActorUserId` is empty on exactly those rows. The fix places new rows
+  correctly and leaves the written ones alone. Whether that history is
+  corrected at all is a separate decision that has not been taken — no owner,
+  no date, and nothing here proposes or describes how it would be done.
+  Recorded because anyone querying either column across the full range will
+  otherwise read the old rows as evidence that the fix never landed.
 - **A uniqueness guard across all provider adapters** — owner unassigned.
 
 ## Revisions
@@ -492,12 +534,14 @@ adapter duplicates cursor logic a third provider may justify factoring out.
     suppression list is keyed on exactly that string, and the address is
     heavier on a money row. The email is not dropped — it survives into
     `raw_payload` through the row schema's `.passthrough()`.
-  - **Consequence, recorded rather than ruled on:** the worker writes
-    `actorEmail: event.actor` and `actorUserId: ""`
-    (`pullerWorker.ts:1080,1110-1112`), so today the OCSF column named for an
-    email address holds an opaque provider id while the actor id column beside
-    it is empty. The intended contract is the plain one — opaque ids belong in
-    the actor id field, and the email field carries addresses only.
+  - **Consequence, recorded rather than ruled on:** the worker wrote
+    `actorEmail: event.actor` and `actorUserId: ""`, so at v3 the OCSF column
+    named for an email address held an opaque provider id while the actor id
+    column beside it was empty. The intended contract is the plain one —
+    opaque ids belong in the actor id field, and the email field carries
+    addresses only. **[Ruled on and fixed in v4; the citation this bullet
+    carried, `pullerWorker.ts:1080,1110-1112`, no longer resolves — the
+    mapping now lives in `ocsfPullEventMapping.ts`.]**
   - **Decision 12 was never implemented.** `openai_compliance` carries no
     `deprecated` flag (`ingestionSourceCatalog.tsx:142-149`) and the picker
     still offers it for new sources. The `deprecated` flag exists and one other
@@ -508,3 +552,43 @@ adapter duplicates cursor logic a third provider may justify factoring out.
     rather than staying green unchanged as the Gates row required.
   - Stale citations refreshed: `pullerWorker.ts:587` → `:1096`, `:602` →
     `:1110`, `activityMonitor.service.ts:354` → `:379`.
+- **v4 (2026-09-09) — the actor-field divergence is resolved in code.** v3
+  recorded the divergence and explicitly declined to rule on it. The rule is
+  now made and shipped, so the prose describing it as live is corrected. The
+  v3 markers stay: a reader should still be able to see that this ADR once
+  claimed `actor` carries `user_email`, that the adapter deliberately ships
+  the opaque id instead, and that for a period the column named for an email
+  held one.
+  - **The placement is decided in one place.** `ocsfActorFields`
+    (`ocsfPullEventMapping.ts:43-51`) routes an address to `actorEmail` and
+    anything else to `actorUserId` — the field OCSF already reserves for the
+    provider's own identifier for the actor (`actor.user.uid`) — and
+    `mapToOcsfRow` applies that same placement to the row and to the raw OCSF
+    payload (`ocsfPullEventMapping.ts:83,92,123-124`), so the two cannot
+    disagree. The mapping moved out of the worker into that pure module for
+    exactly this reason; the worker now calls it (`pullerWorker.ts:66,566`).
+  - **The address test is the identity engine's own.** What counts as an
+    address is `normalizeEmail` (`identityEvidence.ts:151-155`), the function
+    the match engine already uses to decide what proves a link, so the audit
+    row and the matcher cannot drift into disagreeing. The value is stored
+    verbatim rather than normalized, because an audit row records what the
+    provider said.
+  - **Why the bug survived: the test asserted against its own copy of the
+    mapping.** `mapToOcsfRow` was an unexported function inside
+    `pullerWorker.ts`, so the unit test could not call it. Instead the file
+    kept a hand-copied `mapToOcsfRowSemantic` beside it — with
+    `actorEmail: event.actor` written into the copy — under a comment telling
+    the reader to keep the two in sync by hand. The test asserted against the
+    copy and stayed green while the real mapper wrote opaque ids into the
+    email column. It now imports the real functions
+    (`pullerWorker.ocsfMapping.unit.test.ts:17`) and exercises them over the
+    address, opaque-id, directory-GUID and empty-actor cases (`:102-192`).
+  - **Not corrected: the rows already written.** History in
+    `governance_ocsf_events` still carries opaque ids in `ActorEmail`, with
+    `ActorUserId` empty on those same rows. Recorded as known-outstanding in
+    Open questions; no decision has been taken on it and none is proposed
+    here.
+  - Stale citations refreshed: `pullerWorker.ts:1096` →
+    `ocsfPullEventMapping.ts:108`; `pullerWorker.ts:1080,1110-1112` →
+    `ocsfPullEventMapping.ts:43-51,92,123-124`; `openaiAdmin.puller.ts:400,851`
+    → `:403,864`.

--- a/dev/docs/adr/128-governance-cost-and-identity-two-waves.md
+++ b/dev/docs/adr/128-governance-cost-and-identity-two-waves.md
@@ -254,15 +254,69 @@ amortized *billed* money, and ours is a list-rate estimate.
 
 ### §4. One daily rollup, filled by a fold projection, read through a thin service
 
-The screen never talks to providers and never merges numbers itself:
+The screen never talks to providers and never merges numbers itself.
 
-```text
-event_log ── gateway-spend events ──┬─(existing projections)──► gateway_spend / budget ledger  (sibling tables)
-          ├─ pulled-usage events  ──┴─(rollup fold projection)──► governance_cost_rollup_1d ──┐
-          └─ roster count events ─────(seat count projection)───► governance_seat_count_1d ───┤   ← designed only, not built (v3.12)
-                                                                                              ├──► thin cost service ──► screen
-                                                      Postgres (names, seat price list) ──────┘
+> **[DIAGRAM REPLACED — see revision v3.13.]** One ASCII diagram stood here,
+> and three things it drew are not what the code does: seat counts do not come
+> from a projection table (`governance_seat_count_1d` was never built — v3.12),
+> Postgres holds no seat price list (§6's pricing was reversed — v3.11), and it
+> had no lane for source health, which §4a's own implementation note says is
+> derived at read from the same Postgres rows. Replaced by the two below, split
+> because the write path and the read path fail in different ways and a reader
+> is nearly always asking about one of them. The decision above is unchanged.
+
+```mermaid
+flowchart LR
+  P["Provider APIs<br/>(OpenAI, Anthropic, Microsoft,<br/>Databricks, Azure)"]
+  W["Pull run, bounded<br/>page cap, chunk cap,<br/>watermark, settling re-read"]
+  G["AI Gateway<br/>request metering"]
+  EL[("event_log")]
+  FP["GovernanceCostRollupFoldProjection<br/>registered on BOTH money pipelines"]
+  R[("governance_cost_rollup_1d<br/>CostSource: pulled or gateway")]
+  OE[("governance_ocsf_events<br/>audit rows and seat reports")]
+  GS[("gateway_spend and budget ledger<br/>sibling projections")]
+  PG[("Postgres<br/>IngestionSource run history,<br/>DiscoveredPerson")]
+
+  P --> W
+  W -->|"audit event per row"| OE
+  W -->|"priced usage event<br/>(omitted when a read yields no row)"| EL
+  W -->|"run outcome: errorCount,<br/>lastSuccessAt, unpriced window"| PG
+  G --> EL
+  EL --> FP
+  EL --> GS
+  FP --> R
 ```
+
+*Write path: bounded pull runs and gateway metering both append events; one
+fold projection registered on both money pipelines writes one daily rollup.*
+
+```mermaid
+flowchart LR
+  R[("governance_cost_rollup_1d")]
+  OE[("governance_ocsf_events")]
+  PG[("Postgres")]
+  S["GovernanceCostService"]
+  B["Billed card<br/>every provider's own reported total,<br/>summed across the window"]
+  M["Metered card<br/>gateway total"]
+  ST["Seat card<br/>counts only, never money"]
+  N["Notices: sources that stopped pulling,<br/>unpriced window, Azure bill note"]
+  SP["Spender breakdown<br/>(provider, rawActorId, agent)"]
+
+  R -->|"sumDaysByLane: CostSource = pulled"| S
+  R -->|"sumDaysByLane: CostSource = gateway"| S
+  R -->|"sumWindowBySpender: pulled lane only"| S
+  OE -->|"findLatestSeatReports"| S
+  PG -->|"run history, then deriveSourceHealth<br/>read-time, never written to status"| S
+  PG -->|"DiscoveredPerson display text"| S
+  S --> B
+  S --> M
+  S --> ST
+  S --> N
+  S --> SP
+```
+
+*Read path: one service, four stores, three lanes that are labeled separately
+and never summed into one figure.*
 
 The rollup projection consumes the **events** (gateway-spend and
 pulled-usage events on the log) — the `gateway_spend` table and the
@@ -1887,6 +1941,38 @@ money tables, only the identity tables and read paths.
 
 ## Revisions
 
+- **v3.13 (2026-09-09).** Documentation caught up with the code. No decision is
+  taken, and no decision prose is rewritten — the §4 **diagram** is replaced and
+  a marker above it says what it used to show.
+  - **The §4 diagram is now two mermaid diagrams**, write path and read path,
+    drawn from `governanceCostRollup.foldProjection.ts:501-516` and
+    `governanceCost.service.ts:363-410`. Three things the old diagram drew are
+    not what ships: the seat lane comes from the latest seat-report rows in
+    `governance_ocsf_events` (`governanceCost.service.ts:679-695`), not from
+    `governance_seat_count_1d`, which was never built (v3.12); Postgres holds
+    no seat price list, since §6's pricing was reversed (v3.11); and the
+    diagram had no lane at all for **source health**, which §4a's own
+    implementation note says is derived at read from `IngestionSource` run
+    history (`governanceCost.service.ts:573-609`,
+    `pullers/sourceHealth.ts`) — the notices beside the cards are as much a
+    read of the cost service as the figures are.
+  - **The write path now shows the pull run as bounded.** A run reads a capped
+    number of pages or chunks, advances a watermark and re-reads a settling
+    window (`anthropicAdmin.puller.ts:145-149`,
+    `databricksWarehouseCost.ts:55-115`) rather than crawling a history — the
+    property that makes "a pull that changes nothing still appends an event"
+    affordable, and the one the old single-line diagram left implicit.
+  - **The billed card is named for what it is:** every pulled provider's own
+    reported total, summed across the window
+    (`governanceCost.service.ts:900-914`). §2's connected view, which would
+    have split that total by gateway detail, is still unbuilt — and its input,
+    §7's key-to-bill mapping, was deleted (v3.11). The eight parked
+    key-coverage scenarios in `specs/governance/governance-cost-screen.feature`
+    that described that split were removed in the same pass; the shipped
+    contract they are replaced by is already bound by scenarios elsewhere in
+    that file ("Each lane renders its own labeled total", "A refund-heavy
+    billed day renders negative as reported", "A lane with usage we cannot
+    state in US dollars holds no total").
 - **v3.12 (2026-09-08, captain: Sergio Esteban).** Two internal-consistency
   findings from review, both about wave assignment being readable from the
   document rather than inferred. No design reversal:

--- a/dev/docs/adr/128-governance-cost-and-identity-two-waves.md
+++ b/dev/docs/adr/128-governance-cost-and-identity-two-waves.md
@@ -1240,7 +1240,7 @@ then.
   becomes journal-backed on a separate infra track; not an ADR
   risk.
 - **Puller success/failure must be recorded per run** — today
-  `assertRunMadeProgress` (`pullerWorker.ts:261-289`) raises but records
+  `assertRunMadeProgress` (`pullerWorker.ts:280-307`) raises but records
   no consecutive-failure count, the error counter has no
   production writer, and no last-successful-pull field exists
   (`lastEventAt` is not pull success), so a silently-failing puller is

--- a/dev/docs/adr/128-governance-cost-and-identity-two-waves.md
+++ b/dev/docs/adr/128-governance-cost-and-identity-two-waves.md
@@ -299,7 +299,7 @@ flowchart LR
   B["Billed card<br/>every provider's own reported total,<br/>summed across the window"]
   M["Metered card<br/>gateway total"]
   ST["Seat card<br/>counts only, never money"]
-  N["Notices: sources that stopped pulling,<br/>unpriced window, Azure bill note"]
+  N["Notices: sources with failing pulls,<br/>unpriced window, Azure bill note"]
   SP["Spender breakdown<br/>(provider, rawActorId, agent)"]
 
   R -->|"sumDaysByLane: CostSource = pulled"| S

--- a/dev/docs/adr/129-pulled-spend-names-its-spender-from-a-line-forward.md
+++ b/dev/docs/adr/129-pulled-spend-names-its-spender-from-a-line-forward.md
@@ -181,7 +181,7 @@ function actorForPulledDay(opts: {
 
 - Positive: the cost screen answers "who spent this" for OpenAI and most Databricks bills (the #7880 ruling made real); no migration, no rebuild, no rollout risk beyond the dark flag.
 - Negative: history before the line stays nameless **forever** for pre-existing sources — bought deliberately as the twice-guard. Anthropic and Copilot money stays nameless while paused, so per-person totals will not sum to the company total; the gap is exactly those providers and should read as "not assignable to a person", not as a bug.
-- Neutral: rollup row count grows per-actor for post-line days (bounded by provider-reported user counts; `RawActorId` sits last in the sort key so cardinality never widens the prefix — ADR-128 §21). Newly named actors flow into person discovery on the existing pull path (`pullerWorker.ts:534-536`, `syncPeopleFactsFromPull`), so OpenAI user ids start minting discovered-person rows once the flag opens.
+- Neutral: rollup row count grows per-actor for post-line days (bounded by provider-reported user counts; `RawActorId` sits last in the sort key so cardinality never widens the prefix — ADR-128 §21). Newly named actors flow into person discovery on the existing pull path (`pullerWorker.ts:516-519`, `syncPeopleFactsFromPull`), so OpenAI user ids start minting discovered-person rows once the flag opens.
 
 ## Open questions
 

--- a/dev/docs/adr/129-pulled-spend-names-its-spender-from-a-line-forward.md
+++ b/dev/docs/adr/129-pulled-spend-names-its-spender-from-a-line-forward.md
@@ -78,9 +78,18 @@ only rebuilt by replay.
      `userId` (`:802`), so naming adds no new buckets — only the event's
      actor field changes, under Decision 2's line.
    - **Databricks: surface `executed_by` into the actor payload** for the
-     billing-usage rows that carry it (~80% of spend; the Genie lane is $0
+     statement-history rows that carry it (~80% of spend; the Genie lane is $0
      until 2027-01-31). Restatement keys and buckets stay byte-identical
      (Decision 4); rows without a resolvable single person stay `""`.
+     **[CORRECTED — see revision v3.]** v2 wrote "the billing-usage rows".
+     `executed_by` is a column of **`system.query.history`**, the statement
+     history the warehouse-cost query already reads
+     (`databricksGenie.puller.ts:406`). `system.billing.usage`
+     (`databricksGenie.puller.ts:497`) names no person at all — it is read for
+     hourly DBU quantity per warehouse and SKU, priced through
+     `system.billing.list_prices` (`:519`) — so the money and the name come
+     from two different tables joined by hour and warehouse, which is why an
+     unbilled hour can carry a name and no dollars.
    - **Anthropic: paused.** The admin usage report structurally has no
      person dimension (`anthropicAdmin.puller.ts:751` — deliberately `""`),
      and the compliance feed's actor is a raw **email address**
@@ -131,7 +140,7 @@ only rebuilt by replay.
 |---|---|---|---|
 | Event schema field (defaulted, additive) | Yes | Large (log contract) | Automated: legacy-fixture parse test |
 | Fold cell keying by actor | Yes (code), rows accrue | Large (money display) | Automated: invariant tests above; ships dark behind `release_pulled_usage_cost_enabled` (`registry.ts:165`, FALSE) |
-| Databricks billing query change | Yes | Medium (customer warehouse, read-only) | Automated: adapter unit + key-parity test (Decision 4) |
+| Databricks warehouse-cost query change | Yes | Medium (customer warehouse, read-only) | Automated: adapter unit + key-parity test (Decision 4). The change adds a column to the `system.query.history` leg, not to the `system.billing.usage` aggregate |
 | `PULLED_ACTOR_NAMING_STARTS_AT` value | **No** (wrong value = double count in the gap) | Large | Human review in the release PR: constant ≥ merge date, checked by a named reviewer |
 | Rollup rebuild / migration | — | — | **None. Deliberately: nothing to gate — no migration ships.** |
 
@@ -182,3 +191,4 @@ None blocking. Follow-up (owner: Sergio): whether to surface "named from <date>"
 
 - v1 (2026-09-06) — Initial. Framing + four forks locked by Sergio Esteban (captain). Overruled recommendations recorded: provider scope (all, not two), shared helper (yes, not one-off).
 - v2 (2026-09-06) — Post-red-team rewrite, direction approved by Sergio. Scope narrowed by Sergio's ruling to **OpenAI + Databricks now, Anthropic + Copilot paused** (supersedes v1's "all pullers"; the v1 fork record stands as history). New Decision 4: actor rides the payload, never the key — restatement keys and buckets are byte-identical before and after. Citations corrected against code (OpenAI `userId` dimension `:802`, actor `:848`; `currencyCode` defaults `"USD"`; compliance actor is an email `:50`). Added: pre-event erasure suppression note (Decision 6), person-discovery consequence.
+- v3 (2026-09-09) — Documentation caught up with the code. No decision is taken here. **Correction:** Decision 5 attributed `executed_by` to "the billing-usage rows". It is a column of `system.query.history` (`databricksGenie.puller.ts:406`); `system.billing.usage` (`:497`) carries no person column and is read only for hourly DBU quantity by warehouse and SKU, priced against `system.billing.list_prices` (`:519`). The Gates row naming a "Databricks billing query" is renamed to the warehouse-cost query for the same reason.

--- a/docs/ai-governance/anomaly-rules.mdx
+++ b/docs/ai-governance/anomaly-rules.mdx
@@ -4,11 +4,11 @@ description: What the anomaly detector evaluates, what a rule is made of, and wh
 sidebarTitle: Anomaly rules
 ---
 
-<Info>**Pairs with:** [AI Gateway → Budgets](/ai-gateway/budgets). Budgets enforce hard spend limits; anomaly rules detect patterns *before* a budget breach (spend-spike, geo-mismatch, off-hours).</Info>
+<Info>**Pairs with:** [AI Gateway → Budgets](/ai-gateway/budgets). Budgets enforce hard spend limits; anomaly rules are meant to catch a pattern *before* a budget breach, though only the spend-spike type is evaluated today.</Info>
 
 <Note>**Available on Enterprise plans.** See [Open-core licensing](/ai-governance/open-core-licensing) for the full Apache 2.0, Enterprise split.</Note>
 
-<Warning>**Anomaly rules cannot be created or edited in LangWatch today.** There is no page for them and no public API, so this page describes what the detector does with a rule and what a rule is made of, not something you can set up right now. Rules that already exist are still evaluated, and the alerts they raise still appear on `/governance`. To watch spend without a rule, use [Budgets](/ai-gateway/budgets), which enforce a hard limit and are available today.</Warning>
+<Warning>**Anomaly rules cannot be created or edited in LangWatch today.** There is no page for them and no public API, so this page describes what the detector does with a rule and what a rule is made of, not something you can set up right now. Rules that already exist are still evaluated, but no screen in the product lists the alerts they raise: the one place an alert reaches you is the [OCSF export](/ai-gateway/governance/ocsf-export), where a record linked to one carries its `anomalyAlertId`. To watch spend with a limit you can act on, use [Budgets](/ai-gateway/budgets), which enforce a hard limit and are available today.</Warning>
 
 Anomaly rules are the "Detect" layer of the [governance control plane](/ai-governance/control-plane#tier-3-audit-log-ingest). A rule is a definition the [event-sourcing detector](/ai-gateway/governance/architecture) evaluates against incoming events, producing an `AnomalyAlert` row when a violation is detected.
 
@@ -16,7 +16,7 @@ This page documents what the detector evaluates and what is preview-only, so tha
 
 ## Rule-type coverage
 
-The composer's rule-type dropdown surfaces every shape the schema can hold; the detector only evaluates one of them today.
+The schema holds every rule type below; the detector evaluates one of them today.
 
 | Rule type | Detector coverage | What it detects | Threshold config keys |
 |-----------|------------------|------------------|------------------------|
@@ -28,7 +28,7 @@ The composer's rule-type dropdown surfaces every shape the schema can hold; the 
 | `pii_leak` | ⏳ Preview | Outbound payload matches a PII regex set | (config schema TBD) |
 | `custom` | ⏳ Preview | User-defined CEL, SQL predicate | (config schema TBD) |
 
-**⏳ Preview** rules can be created and the row shows `active` in the list, but the detector logs `debug` and skips them, no AnomalyAlert is produced. Until the detector slice for each ships, treat them as "save the rule for the future, don't expect alerts."
+A **⏳ Preview** rule type is persisted and reads as `active`, but the detector logs `debug` and skips it, so no alert is produced. Until the detector slice for each ships, treat such a rule as stored for later rather than as watching anything.
 
 If you need detection beyond `spend_spike` today, the recommended shape is one of:
 
@@ -41,8 +41,8 @@ These are the fields the detector reads, listed so the shape of a rule is known.
 
 | Field | Typical value | What it does |
 |-------|---------------|---------------|
-| **Name** | `Spend spike on Cowork prod` | Free-text label; surfaces in `recentAnomalies` and the alert dispatch payload. |
-| **Severity** | `warning`, `critical` | Drives the `/governance` KPI breakdown (`anomalyBreakdown.{critical,warning,info}`) and downstream dispatch routing once C3 ships. |
+| **Name** | `Spend spike on Cowork prod` | Free-text label; identifies the rule on the alert it raises. |
+| **Severity** | `warning`, `critical` | Recorded on the alert, and will drive dispatch routing once C3 ships. |
 | **Rule type** | `spend_spike` | Pick exactly this, see coverage table above. |
 | **Scope** | `organization`, `source_type`, `source` | Filters which IngestionSources the rule applies to (see Scope coverage below). |
 | **Scope ID** | (cuid) | Required when scope is `source_type` or `source`. The IngestionSource ID is in the URL of the per-source detail page under the inventory. |
@@ -87,7 +87,7 @@ Sensible starting values:
 
 ## Dispatch coverage (C3 in flight)
 
-The composer's **Destination config** field accepts a JSON object describing where to push the alert. Today the detector's dispatch path is **log-only**: alerts surface on the `/governance` dashboard's "Recent anomalies" section but no Slack message, PagerDuty page, SIEM event is generated.
+A rule's **Destination config** holds a JSON object describing where to push the alert. Today the detector's dispatch path is **log-only**: the alert is recorded and carried on the OCSF export, but no Slack message, PagerDuty page or SIEM event is pushed anywhere.
 
 C3 (in flight on the [governance platform](https://github.com/langwatch/langwatch/pull/3524) branch) wires `triggerActionDispatch` so the destinationConfig values below start working:
 
@@ -100,15 +100,15 @@ C3 (in flight on the [governance platform](https://github.com/langwatch/langwatc
 }
 ```
 
-Until C3 lands, leave destinationConfig empty (`{}`) and rely on the dashboard to surface alerts. A real Slack webhook set today is stored and never called, so alerts look wired when they are not.
+Until C3 lands, leave destinationConfig empty (`{}`). A real Slack webhook set today is stored and never called, so alerts look wired when they are not.
 
-## Where an existing rule's alerts show up
+## Where an existing rule's alerts go
 
-Two angles, same data:
+**In the app**: no screen lists them. Each fire is recorded as one alert keyed by `(ruleId, triggerWindowStart)`, so the detector does not raise a second alert for the same window, but the governance section has no page that reads those rows today.
 
-**Web**: open `/governance` and look for the rule's name in the "Recent anomalies" section. Each fire creates one row keyed by `(ruleId, triggerWindowStart)` so the detector doesn't double-alert on a single window.
+**In your SIEM**: the [OCSF export](/ai-gateway/governance/ocsf-export) is the one place an alert reaches you. A trace record linked to an alert carries that alert's `anomalyAlertId` and `severity_id` 4 (Medium); every other record carries `severity_id` 1 (Informational).
 
-**CLI**: `langwatch governance status` shows `hasAnomalyRules: true` once at least one rule exists. The `recentAnomalies` query is wired into the same `api.activityMonitor.recentAnomalies` tRPC procedure the dashboard reads.
+**CLI**: `langwatch governance status` reports `hasAnomalyRules: true` once at least one rule exists. That confirms a rule is defined, not that one has fired.
 
 End to end, for an organization that already has a rule:
 
@@ -116,8 +116,8 @@ End to end, for an organization that already has a rule:
 2. Send one OTel event with `gen_ai.usage.cost_usd: 0.05` (baseline seed), see [otel-generic, Test it now](/ai-governance/ingestion-sources/otel-generic#test-it-now-copy-paste-curl).
 3. Wait long enough for the baseline window to roll past the seed (default `windowSec: 86400` means 24h, so use the tighter values from the table above for fast iteration).
 4. Send a second event with `gen_ai.usage.cost_usd: 2.00` (the spike).
-5. Reload `/governance`, the alert should appear in "Recent anomalies" with `state: open` and a populated `detail.ratio`.
+5. Pull the [OCSF export](/ai-gateway/governance/ocsf-export) and look for a record carrying an `anomalyAlertId`.
 
 ## What's persisted vs what's evaluated
 
-A rule that's persisted but unevaluated is intentional, admins can pre-stage rules so when the detector slice ships, no rework. But it's a real failure mode if you don't know which is which. The two coverage tables above are the source of truth: **only `spend_spike` + (`organization` | `source_type` | `source`) actually fires today**. Everything else is preview state.
+A rule that is persisted but unevaluated is intentional: a rule can wait for the detector slice that will read it, so there is no rework when that slice ships. But it's a real failure mode if you don't know which is which. The two coverage tables above are the source of truth: **only `spend_spike` + (`organization` | `source_type` | `source`) actually fires today**. Everything else is preview state.

--- a/docs/ai-governance/anomaly-rules.mdx
+++ b/docs/ai-governance/anomaly-rules.mdx
@@ -1,16 +1,18 @@
 ---
 title: Anomaly rules
-description: Define detection rules that fire AnomalyAlerts when activity-event traffic crosses a threshold, what the detector evaluates today, what is preview-only, and how to write a working rule.
+description: What the anomaly detector evaluates, what a rule is made of, and why rules cannot be created in the app today.
 sidebarTitle: Anomaly rules
 ---
 
 <Info>**Pairs with:** [AI Gateway → Budgets](/ai-gateway/budgets). Budgets enforce hard spend limits; anomaly rules detect patterns *before* a budget breach (spend-spike, geo-mismatch, off-hours).</Info>
 
-<Note>**Available on Enterprise plans.** Non-enterprise organizations see an upgrade card on `/governance/anomaly-rules` instead of the composer. See [Open-core licensing](/ai-governance/open-core-licensing) for the full Apache 2.0, Enterprise split.</Note>
+<Note>**Available on Enterprise plans.** See [Open-core licensing](/ai-governance/open-core-licensing) for the full Apache 2.0, Enterprise split.</Note>
 
-Anomaly rules are the "Detect" layer of the [governance control plane](/ai-governance/control-plane#tier-3-audit-log-ingest). The composer at `/governance/anomaly-rules` accepts a rule definition and persists it; the [event-sourcing detector](/ai-gateway/governance/architecture) evaluates each rule against incoming events and produces an `AnomalyAlert` row when a violation is detected.
+<Warning>**Anomaly rules cannot be created or edited in LangWatch today.** There is no page for them and no public API, so this page describes what the detector does with a rule and what a rule is made of, not something you can set up right now. Rules that already exist are still evaluated, and the alerts they raise still appear on `/governance`. To watch spend without a rule, use [Budgets](/ai-gateway/budgets), which enforce a hard limit and are available today.</Warning>
 
-This page documents what the detector evaluates today and what is preview-only, so you don't author rules that look "active" in the list but never fire.
+Anomaly rules are the "Detect" layer of the [governance control plane](/ai-governance/control-plane#tier-3-audit-log-ingest). A rule is a definition the [event-sourcing detector](/ai-gateway/governance/architecture) evaluates against incoming events, producing an `AnomalyAlert` row when a violation is detected.
+
+This page documents what the detector evaluates and what is preview-only, so that a rule which looks "active" is not mistaken for one that fires.
 
 ## Rule-type coverage
 
@@ -33,11 +35,9 @@ If you need detection beyond `spend_spike` today, the recommended shape is one o
 - Stand up Prometheus + Grafana against the gateway metrics endpoint, see [Cookbook · Prometheus alerts](/ai-gateway/cookbooks/prometheus-alerts) for the alert ruleset.
 - Hook your SIEM to the OTel trace stream LangWatch already emits per project.
 
-## Writing a working `spend_spike` rule
+## What a `spend_spike` rule is made of
 
-Open `/governance/anomaly-rules` → click **New anomaly rule**.
-
-Fields the detector reads:
+These are the fields the detector reads, listed so the shape of a rule is known. They are not steps to follow: no page or API accepts them today.
 
 | Field | Typical value | What it does |
 |-------|---------------|---------------|
@@ -45,7 +45,7 @@ Fields the detector reads:
 | **Severity** | `warning`, `critical` | Drives the `/governance` KPI breakdown (`anomalyBreakdown.{critical,warning,info}`) and downstream dispatch routing once C3 ships. |
 | **Rule type** | `spend_spike` | Pick exactly this, see coverage table above. |
 | **Scope** | `organization`, `source_type`, `source` | Filters which IngestionSources the rule applies to (see Scope coverage below). |
-| **Scope ID** | (cuid) | Required when scope is `source_type` or `source`. The IngestionSource ID can be copied from `/governance/ingestion-sources/<id>` or the URL of the per-source detail page. |
+| **Scope ID** | (cuid) | Required when scope is `source_type` or `source`. The IngestionSource ID is in the URL of the per-source detail page under the inventory. |
 | **Threshold config** | (JSON object, see below) | The detector's per-rule-type tuning knobs. |
 | **Destination config** | `{}` (today) | Reserved for future Slack, PagerDuty, SIEM dispatch, see Dispatch coverage below. |
 
@@ -102,7 +102,7 @@ C3 (in flight on the [governance platform](https://github.com/langwatch/langwatc
 
 Until C3 lands, leave destinationConfig empty (`{}`) and rely on the dashboard to surface alerts. A real Slack webhook set today is stored and never called, so alerts look wired when they are not.
 
-## Verify a rule is firing
+## Where an existing rule's alerts show up
 
 Two angles, same data:
 
@@ -110,9 +110,9 @@ Two angles, same data:
 
 **CLI**: `langwatch governance status` shows `hasAnomalyRules: true` once at least one rule exists. The `recentAnomalies` query is wired into the same `api.activityMonitor.recentAnomalies` tRPC procedure the dashboard reads.
 
-To verify it yourself, end to end:
+End to end, for an organization that already has a rule:
 
-1. Create a `spend_spike` rule scoped to your test IngestionSource with `minBaselineUsd: 0.001` (tiny floor) and `ratioVsBaseline: 1.5`.
+1. Start from a `spend_spike` rule scoped to your test IngestionSource with `minBaselineUsd: 0.001` (tiny floor) and `ratioVsBaseline: 1.5`.
 2. Send one OTel event with `gen_ai.usage.cost_usd: 0.05` (baseline seed), see [otel-generic, Test it now](/ai-governance/ingestion-sources/otel-generic#test-it-now-copy-paste-curl).
 3. Wait long enough for the baseline window to roll past the seed (default `windowSec: 86400` means 24h, so use the tighter values from the table above for fast iteration).
 4. Send a second event with `gen_ai.usage.cost_usd: 2.00` (the spike).

--- a/docs/ai-governance/api.mdx
+++ b/docs/ai-governance/api.mdx
@@ -33,9 +33,10 @@ Both paths call into the same service-layer functions, there is no business-logi
 
 Governance resources expose the full CRUD set, `list`, `get`, `create`, `update`, `delete`, over Hono, the CLI, and the MCP server, except where the table below names a narrower verb set (`audit-log` is read-only, ingestion keys mint through their own route). The umbrella spec lists the resource set; each resource gets its own OpenAPI path group.
 
+Anomaly rules are not in the table: they have no REST surface and no authoring page, see [Anomaly rules](/ai-governance/anomaly-rules).
+
 | Resource | OpenAPI path group | Detail page |
 |---|---|---|
-| Anomaly rules | `/api/governance/anomaly-rules` | [Anomaly rules](/ai-governance/anomaly-rules) |
 | Audit log (read-only) | `/api/governance/audit-log` | [Audit log](/platform/audit-log) |
 | Gateway budgets | `/api/governance/gateway-budgets` | [Control plane](/ai-governance/control-plane) |
 | Ingestion sources | `/api/governance/ingestion-sources` | [Ingestion sources](/ai-governance/ingestion-sources) |

--- a/docs/ai-governance/cli-debug.mdx
+++ b/docs/ai-governance/cli-debug.mdx
@@ -30,7 +30,7 @@ The `ingest` and `governance` subcommands are always registered: `langwatch --he
 
 ## `langwatch governance status`
 
-The org-level setup-state OR-of-flags. Mirrors `api.governance.setupState` exactly, same boolean shape that promotes the MainMenu **Govern** entry from hidden → visible once any 3 of 5 are true.
+The org-level setup-state OR-of-flags. Mirrors `api.governance.setupState` exactly, same boolean shape that promotes the MainMenu **Govern** entry from hidden → visible once any one of them is true.
 
 ```text
 $ langwatch governance status

--- a/docs/ai-governance/control-plane.mdx
+++ b/docs/ai-governance/control-plane.mdx
@@ -331,11 +331,12 @@ In flight on the same branch:
 
 ## Admin oversight on real data
 
-Once a source is `active` and events are flowing, the admin
-oversight dashboard at `/governance` queries
-`gateway_activity_events` via the `api.activityMonitor.*` tRPC
-procedures. Empty data renders a setup checklist; data present
-renders live cards + per-user table + source-health strip.
+Once a source is `active` and events are flowing, its events land in
+`gateway_activity_events`, and the governance screens read them
+through the `api.activityMonitor.*` tRPC procedures. The overview at
+`/governance` issues no such read of its own: the spend cards, the
+per-user table and the source-health strip sit on the screens that
+own them, and the overview is the way in.
 
 Tier 2, Tier 5 are deferred; the architecture doesn't preclude them
 and the control-plane primitives already accommodate them.

--- a/docs/ai-governance/control-plane.mdx
+++ b/docs/ai-governance/control-plane.mdx
@@ -25,7 +25,9 @@ existing routes:
 | `/governance` | Daily-use **org governance home**: spend, ingestion-source health, anomalies, per-user breakdown. Read-mostly. | Org admins whose org's `setupState.governanceActive` is `true` (see [Persona-based home routing](#persona-based-home-routing--the-setup-state-signal) below) | Top-level route, org-scoped. |
 | `/me`, `/me/settings` | Daily-use **personal home**: your usage, your budget, your personal VK, your IDE setup snippet. | Any user with a personal VK | Top-level route, principal-scoped. |
 | `/[project]/...` | LLMOps daily-use, traces, evals, datasets, scenarios, workflows. | Project members | Per-project routes. **Unchanged** from current LangWatch. |
-| `/governance/ingestion-sources`, `/governance/anomaly-rules`, `/gateway/routing-policies` | Admin-authoring (CRUD), create, rotate, archive sources, write rules, publish routing policies. | The governance pages open on `governance:view` and `/gateway/routing-policies` on `routingPolicies:view`. Each write control needs the matching `:manage` grant (`ingestionSources:manage`, `anomalyRules:manage`, `routingPolicies:manage`) and is hidden without it. | Governance sub-routes, deliberately separate from daily-use surfaces. |
+| `/governance/ingestion-sources`, `/gateway/routing-policies` | Admin-authoring (CRUD), create, rotate, archive sources, publish routing policies. | The governance pages open on `governance:view` and `/gateway/routing-policies` on `routingPolicies:view`. Each write control needs the matching `:manage` grant (`ingestionSources:manage`, `routingPolicies:manage`) and is hidden without it. | Governance sub-routes, deliberately separate from daily-use surfaces. |
+
+Anomaly rules have no authoring surface: see [Anomaly rules](/ai-governance/anomaly-rules).
 
 The whole governance product sits at the top level, not under Settings.
 The daily home is `/governance`, and the create, rotate and archive tools

--- a/docs/ai-governance/getting-started-admin.mdx
+++ b/docs/ai-governance/getting-started-admin.mdx
@@ -1,6 +1,6 @@
 ---
 title: From zero to your first governed request (admin)
-description: A 30-minute admin walkthrough, publish a routing policy, configure an ingestion source, import the AI Tools Portal starter pack, invite a developer, and watch their first request land. Each step links into the deeper admin docs.
+description: A 30-minute admin walkthrough to publish a routing policy, configure an ingestion source, import the AI Tools Portal starter pack, invite a developer, and watch their first request land. Each step links into the deeper admin docs.
 sidebarTitle: First 30 minutes (admin)
 ---
 

--- a/docs/ai-governance/getting-started-admin.mdx
+++ b/docs/ai-governance/getting-started-admin.mdx
@@ -1,6 +1,6 @@
 ---
-title: From zero to first detected anomaly (admin)
-description: A 30-minute admin walkthrough, publish a routing policy, configure an ingestion source, import the AI Tools Portal starter pack, invite a developer, watch their first request land, and write the spend-spike rule that catches the next outlier. Each step links into the deeper admin docs.
+title: From zero to your first governed request (admin)
+description: A 30-minute admin walkthrough, publish a routing policy, configure an ingestion source, import the AI Tools Portal starter pack, invite a developer, and watch their first request land. Each step links into the deeper admin docs.
 sidebarTitle: First 30 minutes (admin)
 ---
 
@@ -9,7 +9,7 @@ You are an org admin on a fresh LangWatch deployment. By the end of this page yo
 - Published a default [Routing Policy](/ai-gateway/governance/routing-policies) so developers can sign in via `langwatch login`.
 - Configured an [Ingestion Source](/ai-governance/ingestion-sources/index) that lands telemetry from your gateway (or any OTLP-compatible upstream) in the unified trace store.
 - Imported the [AI Tools Portal](/ai-governance/personal-portal/admin-catalog#starter-pack) starter pack so every developer's `/me` page renders a real catalog instead of an empty state.
-- Invited a colleague through `/settings/members`, watched their first request land in `/governance`, and written a [`spend_spike`](/ai-governance/anomaly-rules) rule that will alert when their daily spend doubles.
+- Invited a colleague through `/settings/members` and watched their first request land in `/governance`.
 
 If you are a developer trying to *use* the org as a developer (not configure it), jump to the [developer walkthrough](/ai-governance/getting-started-developer) instead.
 
@@ -118,31 +118,13 @@ The budget is enforced by the gateway data plane on every request. The audit log
 
 The deep reference for budget shape, fallback semantics, and the WARN response tag header lives in [Budgets](/ai-gateway/budgets).
 
-## Step 8: Write your first anomaly rule
+## Step 8: Watch what the budget does not catch
 
-Budgets enforce *at* the limit. [Anomaly rules](/ai-governance/anomaly-rules) detect *before* it, the patterns that precede a breach (spend spike, geo-mismatch, off-hours usage). The detector evaluates `spend_spike` rules live today; other rule types are preview-only (the [coverage table](/ai-governance/anomaly-rules#rule-type-coverage) marks which is which).
+A budget enforces *at* the limit. The patterns that precede a breach, a spend spike or a burst of off-hours usage, show up before it.
 
-Write a starter `spend_spike` rule:
+The anomaly detector covers the spend-spike case, and any alert it raises appears in **Recent anomalies** on `/governance`. Anomaly rules cannot be created in LangWatch today, so this step has no setup to do: see [Anomaly rules](/ai-governance/anomaly-rules) for what the detector evaluates and what a rule is made of.
 
-1. Navigate to **Governance → Anomaly Rules** (`/governance/anomaly-rules`).
-2. Click **+ New anomaly rule**.
-3. Fill in:
-   - **Name**: `Daily spend doubles vs last week`
-   - **Severity**: `warning`
-   - **Rule type**: `spend_spike`
-   - **Scope**: `organization`
-   - **Threshold config**:
-     ```json
-     {
-       "windowSec": 86400,
-       "baselineOffsetSec": 604800,
-       "ratioVsBaseline": 2.0,
-       "minBaselineUsd": 1.0
-     }
-     ```
-4. Click **Create rule**.
-
-The detector starts evaluating from the next ingest event. When today's 24h spend exceeds 2× last week's same-day baseline (and the baseline was at least \$1, to avoid noise on quiet days), the detector writes an `AnomalyAlert` row visible in `/governance` and surfaces it in the [`activityMonitor.recentAnomalies`](/ai-governance/anomaly-rules) procedure.
+In the meantime, [Budgets](/ai-gateway/budgets) are the control that is available today, and the `/governance` overview is where a spike is visible without one.
 
 ## Where to next
 

--- a/docs/ai-governance/getting-started-admin.mdx
+++ b/docs/ai-governance/getting-started-admin.mdx
@@ -88,7 +88,7 @@ Once invited, point them at the [developer walkthrough](/ai-governance/getting-s
 
 After your colleague runs `langwatch login` and makes one Claude Code request, two surfaces should update within seconds:
 
-- **`/governance`**, the [governance home](/ai-governance/control-plane#daily-use-surfaces-vs-admin-authoring-surfaces) shows org-wide spend, anomalies, ingestion-source health, per-user breakdown.
+- **`/governance`**, the [governance home](/ai-governance/control-plane#daily-use-surfaces-vs-admin-authoring-surfaces), the way in to the inventory, agents and people screens.
 - **`/settings/audit-log`**, the [audit log](/platform/audit-log) records every governance mutation (member invited, routing policy published, ingestion source created, virtual key minted, budget created…) with timestamp, actor, target kind, target ID, and IP.
 
 If you don't see the request, the [CLI debug commands](/ai-governance/cli-debug) take 30 seconds to localise the problem:
@@ -122,9 +122,9 @@ The deep reference for budget shape, fallback semantics, and the WARN response t
 
 A budget enforces *at* the limit. The patterns that precede a breach, a spend spike or a burst of off-hours usage, show up before it.
 
-The anomaly detector covers the spend-spike case, and any alert it raises appears in **Recent anomalies** on `/governance`. Anomaly rules cannot be created in LangWatch today, so this step has no setup to do: see [Anomaly rules](/ai-governance/anomaly-rules) for what the detector evaluates and what a rule is made of.
+The anomaly detector covers the spend-spike case. Any alert it raises is recorded and carried on the [OCSF export](/ai-gateway/governance/ocsf-export) rather than shown on a screen. Anomaly rules cannot be created in LangWatch today, so this step has no setup to do: see [Anomaly rules](/ai-governance/anomaly-rules) for what the detector evaluates and what a rule is made of.
 
-In the meantime, [Budgets](/ai-gateway/budgets) are the control that is available today, and the `/governance` overview is where a spike is visible without one.
+In the meantime, [Budgets](/ai-gateway/budgets) are the control that is available today.
 
 ## Where to next
 
@@ -140,5 +140,5 @@ In the meantime, [Budgets](/ai-gateway/budgets) are the control that is availabl
 | Developer sees `409 no_default_routing_policy` on `langwatch login` | Step 2 skipped or no policy marked default | [Routing Policies](/ai-gateway/governance/routing-policies): pick one, tick **Mark as default**. |
 | `/me` shows "your IT team is still setting things up" empty state | Step 4 skipped | Open `/governance/inventory?tab=catalog` → **Import starter pack**. |
 | Ingestion source sits at `awaiting_first_event` forever | Source-type doesn't have a wired adapter yet | [Ingestion Sources index → State of each receiver](/ai-governance/ingestion-sources/index#state-of-each-receiver-at-a-glance): three rows are setup-contract-only as of this release. |
-| `/governance` doesn't appear in your sidebar | Org's [setup-state OR-of-flags](/ai-governance/control-plane#persona-based-home-routing-the-setup-state-signal) hasn't tripped yet | Need any 3 of 5: Personal VKs, Routing Policies, Ingestion Sources, Anomaly Rules, Recent activity (30d). After Steps 2-7 above, you'll have 4. |
+| `/governance` doesn't appear in your sidebar | Org's [setup-state OR-of-flags](/ai-governance/control-plane#persona-based-home-routing-the-setup-state-signal) hasn't tripped yet | Any one of these is enough: Personal VKs, Routing Policies, Ingestion Sources, Anomaly Rules, Recent activity (30d). After Steps 2-7 above you will have several. |
 | Member colleague got an `Access Restricted` page on `/settings/audit-log` | Working as designed, audit log is admin-only | Either elevate them to `Admin` or grant a custom role with `organization:manage` (delegable via the `CustomRolePermissions` JSON column). |

--- a/docs/ai-governance/getting-started-developer.mdx
+++ b/docs/ai-governance/getting-started-developer.mdx
@@ -24,7 +24,7 @@ Before you start, your IT admin should already have:
 2. Published at least one default [Routing Policy](/ai-gateway/governance/routing-policies). If they haven't, the CLI fails with a `409 no_default_routing_policy` error, see the [CLI error catalog](/ai-governance/cli-debug#error-catalog) and ping your admin.
 3. Optionally: published an [AI Tools Portal](/ai-governance/personal-portal/overview) catalog (the card grid you'll see on `/me`). If they haven't, your `/me` page shows a "your IT team is still setting things up" empty state, you can still use the CLI directly.
 
-If any of those are missing your admin's first stop is [From zero to first detected anomaly](/ai-governance/getting-started-admin).
+If any of those are missing your admin's first stop is [From zero to your first governed request](/ai-governance/getting-started-admin).
 
 ## Step 1: Install the CLI
 

--- a/docs/ai-governance/governance-dashboard.mdx
+++ b/docs/ai-governance/governance-dashboard.mdx
@@ -63,7 +63,7 @@ The list of `AnomalyAlert` rows in the window, sorted newest first. Each row sho
 - **Current vs baseline** values for spend-spike anomalies.
 - **Scope** (organization, source_type, source).
 
-Click a row to expand the AnomalyAlert detail (the rule definition that matched, the event window that triggered it, the per-actor breakdown). Click the rule name to navigate to the [anomaly-rule editor](/ai-governance/anomaly-rules).
+Click a row to expand the AnomalyAlert detail (the rule definition that matched, the event window that triggered it, the per-actor breakdown). The rules themselves cannot be edited in LangWatch today, see [Anomaly rules](/ai-governance/anomaly-rules).
 
 ## When the entry shows up
 
@@ -105,7 +105,6 @@ The dashboard is read-mostly, but every section deep-links into the admin-author
 - KPI strip → click "Total spend" KPI → drills into per-user breakdown table.
 - Spend over time chart → click a day → opens that day's per-user breakdown filtered to ±2 hours of the spike.
 - Ingestion-source health row → click into the per-source detail page.
-- Anomalies row → click the rule name → opens the [anomaly-rule editor](/ai-governance/anomaly-rules) at that rule.
 
 If the dashboard surfaces something you want to *act* on (rotate a key, edit a rule threshold, archive a source), follow the deep link into the corresponding admin-authoring page under `/governance/*`.
 

--- a/docs/ai-governance/governance-dashboard.mdx
+++ b/docs/ai-governance/governance-dashboard.mdx
@@ -1,117 +1,58 @@
 ---
-title: /governance dashboard
-description: The daily-use org governance home, spend, anomalies, ingestion-source health, per-user activity. Read-mostly; the admin-authoring CRUD pages still live under /governance/*. Available only after the org's setup-state OR-of-flags trips.
+title: The /governance overview
+description: What the /governance page shows today, where each governance number actually lives, and the setup-state signal behind the section.
 sidebarTitle: /governance dashboard
 ---
 
-The `/governance` route is the **org governance daily home**: the read-mostly oversight dashboard an admin opens to answer *"is the gateway healthy, are we within budget, did anything anomalous happen overnight, are users actually using this?"*. It's the counterpart of `/me` for the admin persona.
+`/governance` is the way into the AI Governance section rather than an oversight dashboard of its own. It opens with a greeting, one field for asking a question or jumping to a screen, an **Add Source** action for admins who may manage ingestion sources, and shortcuts to add people, an agent or a tool.
 
-It is intentionally distinct from the **admin-authoring** surface at `/governance/*`, see [Control plane → Daily-use vs admin-authoring](/ai-governance/control-plane#daily-use-surfaces-vs-admin-authoring-surfaces) for why the split exists.
+Under those sit two lists. **Insights** fills once your ingestion sources are pulling, and **Recent activity** lists the screens you were last on. Before your first source reports an event, each list carries one line saying what will fill it.
 
-<Info>**Pairs with:** [Control plane & integration tiers](/ai-governance/control-plane) for the surface map, [Anomaly rules](/ai-governance/anomaly-rules) for what populates the anomalies strip, and [Departments](/ai-governance/people) for how the **Spend by department** card attributes spend across the org.</Info>
+The page issues no spend, anomaly or source-health read of its own. That is deliberate: it used to carry a panel per subject, each on its own permission, so a reader whose plan or role did not cover one met an error before they met the page.
 
-<Note>**Visibility**: the `/governance` entry only appears in the main sidebar once the org's setup-state OR-of-flags trips (see [When the entry shows up](#when-the-entry-shows-up) below). A brand-new org sees the **Governance** admin pages instead until they have data flowing.</Note>
+<Info>**Pairs with:** [AI Governance](/ai-governance/overview), which describes this screen and the rest of the section in full.</Info>
 
-## What you see
+## Where the numbers live
 
-The dashboard groups data into four strips, top to bottom.
+This page carries no strips of metrics. Each subject has its own screen in the section:
 
-### 1. KPI strip
-
-Five at-a-glance numbers for the selected window (default: last 30 days):
-
-| KPI | What it shows |
+| To see | Go to |
 |---|---|
-| **Total spend** | USD across every gateway request the org saw, summed |
-| **Active users** | Distinct principal IDs that hit the gateway in the window |
-| **Active sources** | IngestionSources in `active` state (have received at least one event) |
-| **Anomaly count** | `AnomalyAlert` rows in the window, broken down by severity (`anomalyBreakdown.{critical,warning,info}`) |
-| **Recent activity** | Count of governance-tagged events in the last 24h |
+| The systems reporting AI activity, and the tool catalog | [Inventory](/ai-governance/ingestion-sources/index) |
+| The agents and applications detected across the organization | **Agents** in the sidebar |
+| Departments, and how spend rolls up by them | [People](/ai-governance/people) |
 
-The window selector at the top right adjusts every strip simultaneously.
+Alerts raised by the anomaly detector are listed on none of these. See [Anomaly rules](/ai-governance/anomaly-rules) for where an alert does reach you.
 
-### 2. Spend over time
+## When the section becomes an admin's landing page
 
-A daily bar chart of org-wide spend. Click a bar to drill into the per-user breakdown for that day.
-
-The chart is the unified view across:
-
-- Personal Virtual Keys minted via `/me`.
-- Project Virtual Keys minted from project pages.
-- Anything else that hit the gateway with a `vk-lw-*` Bearer.
-
-It does not include Ingestion Source events (those are governance-tagged but don't carry cost), those land in [Ingestion-source health](#3-ingestion-source-health) below.
-
-### 3. Ingestion-source health
-
-A status row per active IngestionSource:
-
-- **Status pill**: `active`, `awaiting_first_event`, `error`.
-- **Source type**: `otel_generic`, `claude_cowork`, `workato`, etc.
-- **Last event**: relative timestamp of the most recent successful ingest.
-- **Event count**: 24h, 7d, 30d, picked from the same `ingestionSources.healthMetrics` tRPC procedure that `langwatch ingest health` uses (so the CLI and the web UI are byte-for-byte identical on `--json`).
-
-A red dot on a source means the receiver hasn't seen events in the configured window, see the [per-source detail page](/ai-governance/ingestion-sources/index) for the timeline + the receiver-side error log.
-
-### 4. Anomalies
-
-The list of `AnomalyAlert` rows in the window, sorted newest first. Each row shows:
-
-- **Severity chip** (critical, warning, info).
-- **Rule name** that fired.
-- **Triggered at** timestamp.
-- **Current vs baseline** values for spend-spike anomalies.
-- **Scope** (organization, source_type, source).
-
-Click a row to expand the AnomalyAlert detail (the rule definition that matched, the event window that triggered it, the per-actor breakdown). The rules themselves cannot be edited in LangWatch today, see [Anomaly rules](/ai-governance/anomaly-rules).
-
-## When the entry shows up
-
-`/governance` is gated by an OR-of-flags signal that the org has *activated* governance. The signal is the `api.governance.setupState({ organizationId })` tRPC procedure (read-only, cheap, server-side):
+A setup-state signal decides whether an org admin is sent here, read by the `governance.setupState({ organizationId })` tRPC procedure:
 
 ```ts
 {
-  hasPersonalVKs:      boolean,  // any user has minted a personal VK
-  hasRoutingPolicies:  boolean,  // at least one routing policy exists
-  hasIngestionSources: boolean,  // at least one source exists
-  hasAnomalyRules:     boolean,  // at least one rule defined
-  hasRecentActivity:   boolean,  // any governance event in the last 30d
+  hasPersonalVKs:       boolean,  // any user has minted a personal VK
+  hasRoutingPolicies:   boolean,  // at least one routing policy exists
+  hasIngestionSources:  boolean,  // at least one source exists
+  hasAnomalyRules:      boolean,  // at least one rule defined
+  hasRecentActivity:    boolean,  // any governance event in the last 30d
+  hasApplicationTraces: boolean,  // an application project has traces
 }
 ```
 
-`Governance active = any 3 of 5`. After the [admin walkthrough](/ai-governance/getting-started-admin) you'll have at least 4 (routing policies + ingestion sources + recent activity from the dev pass + the budget you create implies personal VKs once a developer signs in).
+Governance reads as active when **any one** of the first five is true. `hasApplicationTraces` is reported alongside them and does not feed that answer.
 
-The same signal drives:
-
-- The **Govern (Preview)** entry visibility in the main sidebar.
-- The CLI `langwatch governance status` output (mirrors the same booleans).
-- The post-onboarding redirect, when an admin lands on `/`, the persona-2 home picker sends them to `/governance` if active, else to `/governance` to keep configuring.
+The same signal backs the `langwatch governance status` output, so the CLI and the app agree on whether an organization has activated governance.
 
 ## Permissions
 
-The `/governance` page itself is gated to `governance:view` (granted to ADMIN by default). Underlying procedures:
+Opening `/governance` needs `governance:view`, which an organization Admin holds by default.
 
-- `governance.kpis(organizationId, window)`, KPI strip.
-- `governance.spendOverTime(organizationId, window)`, bar chart.
-- `ingestionSources.healthMetrics(organizationId)`, health strip.
-- `activityMonitor.recentAnomalies(organizationId, window)`, anomaly list (this lives in the `activityMonitor` router, not `governance`, for routing-through-service reasons).
-
-The activity monitor procedures cap at `activityMonitor:view`, the recommended permission to grant a security-analyst custom role that should see anomalies without managing rules.
-
-## What you can do FROM here
-
-The dashboard is read-mostly, but every section deep-links into the admin-authoring surface where you'd actually change something:
-
-- KPI strip → click "Total spend" KPI → drills into per-user breakdown table.
-- Spend over time chart → click a day → opens that day's per-user breakdown filtered to ±2 hours of the spike.
-- Ingestion-source health row → click into the per-source detail page.
-
-If the dashboard surfaces something you want to *act* on (rotate a key, edit a rule threshold, archive a source), follow the deep link into the corresponding admin-authoring page under `/governance/*`.
+The reads behind the section's other screens are permissioned separately. The activity-monitor procedures cap at `activityMonitor:view`, the permission to grant a security analyst who should see activity without managing rules.
 
 ## Where to next
 
-- **Detect anomalies**: [Anomaly rules](/ai-governance/anomaly-rules).
+- **The section and its four pages**: [AI Governance](/ai-governance/overview).
+- **What the detector evaluates, and where an alert goes**: [Anomaly rules](/ai-governance/anomaly-rules).
 - **Inspect ingestion-source health from the terminal**: [CLI debug](/ai-governance/cli-debug).
 - **Export to your SIEM**: [Compliance architecture](/ai-governance/compliance-architecture).
-- **Tighten privacy**: [No-spy mode](/ai-governance/no-spy-mode).
 - **Audit who did what when**: [Audit log](/platform/audit-log).

--- a/docs/ai-governance/overview.mdx
+++ b/docs/ai-governance/overview.mdx
@@ -7,7 +7,7 @@ keywords: ai governance, ai inventory, ingestion sources, tool catalog, anomaly 
 
 AI Governance is the part of LangWatch where you administer the AI tools your company uses. It is for the platform or IT team that approves those tools and watches their use, and it gives every developer one page with the tools they may use and their own usage.
 
-The section is in the sidebar under **AI Governance**, with four pages: **Overview**, **Inventory**, **Anomaly Rules** and **People**. Opening them needs the `governance:view` permission, which an organization Admin holds. Each developer also has a personal home page at `/me`.
+The section is in the sidebar under **AI Governance**, with three pages: **Overview**, **Inventory** and **People**. Opening them needs the `governance:view` permission, which an organization Admin holds. Each developer also has a personal home page at `/me`.
 
 ## The overview page
 

--- a/docs/ai-governance/overview.mdx
+++ b/docs/ai-governance/overview.mdx
@@ -1,21 +1,23 @@
 ---
 title: AI Governance
-description: An inventory of every AI tool and source in the company, the people who use them, anomaly rules on their activity, and a personal home page for each developer.
+description: An inventory of every AI tool and source in the company, the people who use them, the agents they run, and a personal home page for each developer.
 sidebarTitle: Overview
-keywords: ai governance, ai inventory, ingestion sources, tool catalog, anomaly rules, departments, langwatch
+keywords: ai governance, ai inventory, ingestion sources, tool catalog, agents, departments, langwatch
 ---
 
 AI Governance is the part of LangWatch where you administer the AI tools your company uses. It is for the platform or IT team that approves those tools and watches their use, and it gives every developer one page with the tools they may use and their own usage.
 
-The section is in the sidebar under **AI Governance**, with three pages: **Overview**, **Inventory** and **People**. Opening them needs the `governance:view` permission, which an organization Admin holds. Each developer also has a personal home page at `/me`.
+The section is in the sidebar under **AI Governance**, with four pages: **Overview**, **Inventory**, **Agents** and **People**. Opening them needs the `governance:view` permission, which an organization Admin holds. Each developer also has a personal home page at `/me`.
 
 ## The overview page
 
-The overview at `/governance` shows the last 30 days: spend over time, the spend share across teams, the top teams and users by spend, spend by department, the recent anomalies and the status of each ingestion source. The panels roll up the events of your ingestion sources. LangWatch AI Gateway traffic is under **Gateway > Usage**.
+The overview at `/governance` is the way into the section rather than a dashboard of its own. It opens with a greeting, one field for asking a question or jumping to a screen, an **Add Source** action for admins who may manage ingestion sources, and shortcuts to add people, an agent or a tool.
 
-Until the first ingestion source reports an event, the page shows a setup checklist instead: add tools to the catalog, define a routing policy, connect an ingestion source and define anomaly rules.
+Under those sit two lists. **Insights** fills once your ingestion sources are pulling, and **Recent activity** lists the screens you were last on. LangWatch AI Gateway traffic is under **Gateway > Usage**.
 
-<Frame caption="The overview before the first ingestion source reports an event: the setup checklist with all four steps complete.">
+Before your first ingestion source reports an event the page looks the same: each of the two lists carries one line saying what will fill it.
+
+<Frame caption="The overview as an earlier build drew it, with a setup checklist. The page no longer shows this checklist.">
   ![The AI Governance overview with the setup checklist](/images/ai-governance/governance-overview.png)
 </Frame>
 
@@ -31,14 +33,6 @@ The inventory has two tabs. **Sources** lists the systems that report AI activit
 
 <Frame caption="The Catalog tab after the starter pack import: four coding assistants and four model providers, each scoped to the organization.">
   ![The Catalog tab of the inventory](/images/ai-governance/governance-inventory-catalog.png)
-</Frame>
-
-## Anomaly Rules
-
-Rules are grouped by severity: Critical, Warning and Info. Each rule has a type, a description and a scope.
-
-<Frame caption="One Warning rule of type spend_spike, scoped to the organization.">
-  ![The Anomaly Rules page with one rule](/images/ai-governance/governance-anomaly-rule.png)
 </Frame>
 
 ## Personal home page
@@ -59,7 +53,7 @@ Rules are grouped by severity: Critical, Warning and Info. Each rule has a type,
     The coding assistants, model providers and internal tools that developers see on their personal home page. Import the starter pack, then scope each tile to the whole organization or to departments.
   </Card>
   <Card title="Anomaly Rules" icon="triangle-exclamation" href="/ai-governance/anomaly-rules">
-    Rules with a severity (Critical, Warning or Info) and a scope (the organization, one source type or one source) that raise an alert when activity crosses a threshold. Available on Enterprise plans.
+    What the anomaly detector evaluates and what a rule is made of. Rules cannot be created or edited in LangWatch today. Available on Enterprise plans.
   </Card>
   <Card title="People" icon="users" href="/ai-governance/people">
     Departments: the accounting label that spend rolls up by. Assign people, teams and projects to a department, and personal AI use follows the person.

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -96,7 +96,7 @@ Start with the area that matches what you are working on today. You can add the 
   />
   <Card
     title="Govern AI use across the company"
-    description="See every AI tool in use, who uses it, and set anomaly rules."
+    description="See every AI tool in use, who uses it, and what it costs."
     icon="shield-halved"
     href="/ai-governance/overview"
     arrow

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -99,7 +99,7 @@ Start with the area that matches what you are working on today. You can add the 
   />
   <Card
     title="Govern AI use across the company"
-    description="See every AI tool in use, who uses it, and set anomaly rules."
+    description="See every AI tool in use, who uses it, and what it costs."
     icon="shield-halved"
     href="/ai-governance/overview"
     arrow
@@ -10668,17 +10668,19 @@ Field by field: [Virtual keys API reference](/api-reference/gateway-virtual-keys
 
 ---
 title: Anomaly rules
-description: Define detection rules that fire AnomalyAlerts when activity-event traffic crosses a threshold, what the detector evaluates today, what is preview-only, and how to write a working rule.
+description: What the anomaly detector evaluates, what a rule is made of, and why rules cannot be created in the app today.
 sidebarTitle: Anomaly rules
 ---
 
 <Info>**Pairs with:** [AI Gateway → Budgets](/ai-gateway/budgets). Budgets enforce hard spend limits; anomaly rules detect patterns *before* a budget breach (spend-spike, geo-mismatch, off-hours).</Info>
 
-<Note>**Available on Enterprise plans.** Non-enterprise organizations see an upgrade card on `/governance/anomaly-rules` instead of the composer. See [Open-core licensing](/ai-governance/open-core-licensing) for the full Apache 2.0, Enterprise split.</Note>
+<Note>**Available on Enterprise plans.** See [Open-core licensing](/ai-governance/open-core-licensing) for the full Apache 2.0, Enterprise split.</Note>
 
-Anomaly rules are the "Detect" layer of the [governance control plane](/ai-governance/control-plane#tier-3-audit-log-ingest). The composer at `/governance/anomaly-rules` accepts a rule definition and persists it; the [event-sourcing detector](/ai-gateway/governance/architecture) evaluates each rule against incoming events and produces an `AnomalyAlert` row when a violation is detected.
+<Warning>**Anomaly rules cannot be created or edited in LangWatch today.** There is no page for them and no public API, so this page describes what the detector does with a rule and what a rule is made of, not something you can set up right now. Rules that already exist are still evaluated, and the alerts they raise still appear on `/governance`. To watch spend without a rule, use [Budgets](/ai-gateway/budgets), which enforce a hard limit and are available today.</Warning>
 
-This page documents what the detector evaluates today and what is preview-only, so you don't author rules that look "active" in the list but never fire.
+Anomaly rules are the "Detect" layer of the [governance control plane](/ai-governance/control-plane#tier-3-audit-log-ingest). A rule is a definition the [event-sourcing detector](/ai-gateway/governance/architecture) evaluates against incoming events, producing an `AnomalyAlert` row when a violation is detected.
+
+This page documents what the detector evaluates and what is preview-only, so that a rule which looks "active" is not mistaken for one that fires.
 
 ## Rule-type coverage
 
@@ -10701,11 +10703,9 @@ If you need detection beyond `spend_spike` today, the recommended shape is one o
 - Stand up Prometheus + Grafana against the gateway metrics endpoint, see [Cookbook · Prometheus alerts](/ai-gateway/cookbooks/prometheus-alerts) for the alert ruleset.
 - Hook your SIEM to the OTel trace stream LangWatch already emits per project.
 
-## Writing a working `spend_spike` rule
+## What a `spend_spike` rule is made of
 
-Open `/governance/anomaly-rules` → click **New anomaly rule**.
-
-Fields the detector reads:
+These are the fields the detector reads, listed so the shape of a rule is known. They are not steps to follow: no page or API accepts them today.
 
 | Field | Typical value | What it does |
 |-------|---------------|---------------|
@@ -10713,7 +10713,7 @@ Fields the detector reads:
 | **Severity** | `warning`, `critical` | Drives the `/governance` KPI breakdown (`anomalyBreakdown.{critical,warning,info}`) and downstream dispatch routing once C3 ships. |
 | **Rule type** | `spend_spike` | Pick exactly this, see coverage table above. |
 | **Scope** | `organization`, `source_type`, `source` | Filters which IngestionSources the rule applies to (see Scope coverage below). |
-| **Scope ID** | (cuid) | Required when scope is `source_type` or `source`. The IngestionSource ID can be copied from `/governance/ingestion-sources/<id>` or the URL of the per-source detail page. |
+| **Scope ID** | (cuid) | Required when scope is `source_type` or `source`. The IngestionSource ID is in the URL of the per-source detail page under the inventory. |
 | **Threshold config** | (JSON object, see below) | The detector's per-rule-type tuning knobs. |
 | **Destination config** | `{}` (today) | Reserved for future Slack, PagerDuty, SIEM dispatch, see Dispatch coverage below. |
 
@@ -10770,7 +10770,7 @@ C3 (in flight on the [governance platform](https://github.com/langwatch/langwatc
 
 Until C3 lands, leave destinationConfig empty (`{}`) and rely on the dashboard to surface alerts. A real Slack webhook set today is stored and never called, so alerts look wired when they are not.
 
-## Verify a rule is firing
+## Where an existing rule's alerts show up
 
 Two angles, same data:
 
@@ -10778,9 +10778,9 @@ Two angles, same data:
 
 **CLI**: `langwatch governance status` shows `hasAnomalyRules: true` once at least one rule exists. The `recentAnomalies` query is wired into the same `api.activityMonitor.recentAnomalies` tRPC procedure the dashboard reads.
 
-To verify it yourself, end to end:
+End to end, for an organization that already has a rule:
 
-1. Create a `spend_spike` rule scoped to your test IngestionSource with `minBaselineUsd: 0.001` (tiny floor) and `ratioVsBaseline: 1.5`.
+1. Start from a `spend_spike` rule scoped to your test IngestionSource with `minBaselineUsd: 0.001` (tiny floor) and `ratioVsBaseline: 1.5`.
 2. Send one OTel event with `gen_ai.usage.cost_usd: 0.05` (baseline seed), see [otel-generic, Test it now](/ai-governance/ingestion-sources/otel-generic#test-it-now-copy-paste-curl).
 3. Wait long enough for the baseline window to roll past the seed (default `windowSec: 86400` means 24h, so use the tighter values from the table above for fast iteration).
 4. Send a second event with `gen_ai.usage.cost_usd: 2.00` (the spike).
@@ -10829,9 +10829,10 @@ Both paths call into the same service-layer functions, there is no business-logi
 
 Governance resources expose the full CRUD set, `list`, `get`, `create`, `update`, `delete`, over Hono, the CLI, and the MCP server, except where the table below names a narrower verb set (`audit-log` is read-only, ingestion keys mint through their own route). The umbrella spec lists the resource set; each resource gets its own OpenAPI path group.
 
+Anomaly rules are not in the table: they have no REST surface and no authoring page, see [Anomaly rules](/ai-governance/anomaly-rules).
+
 | Resource | OpenAPI path group | Detail page |
 |---|---|---|
-| Anomaly rules | `/api/governance/anomaly-rules` | [Anomaly rules](/ai-governance/anomaly-rules) |
 | Audit log (read-only) | `/api/governance/audit-log` | [Audit log](/platform/audit-log) |
 | Gateway budgets | `/api/governance/gateway-budgets` | [Control plane](/ai-governance/control-plane) |
 | Ingestion sources | `/api/governance/ingestion-sources` | [Ingestion sources](/ai-governance/ingestion-sources) |
@@ -11568,7 +11569,9 @@ existing routes:
 | `/governance` | Daily-use **org governance home**: spend, ingestion-source health, anomalies, per-user breakdown. Read-mostly. | Org admins whose org's `setupState.governanceActive` is `true` (see [Persona-based home routing](#persona-based-home-routing--the-setup-state-signal) below) | Top-level route, org-scoped. |
 | `/me`, `/me/settings` | Daily-use **personal home**: your usage, your budget, your personal VK, your IDE setup snippet. | Any user with a personal VK | Top-level route, principal-scoped. |
 | `/[project]/...` | LLMOps daily-use, traces, evals, datasets, scenarios, workflows. | Project members | Per-project routes. **Unchanged** from current LangWatch. |
-| `/governance/ingestion-sources`, `/governance/anomaly-rules`, `/gateway/routing-policies` | Admin-authoring (CRUD), create, rotate, archive sources, write rules, publish routing policies. | The governance pages open on `governance:view` and `/gateway/routing-policies` on `routingPolicies:view`. Each write control needs the matching `:manage` grant (`ingestionSources:manage`, `anomalyRules:manage`, `routingPolicies:manage`) and is hidden without it. | Governance sub-routes, deliberately separate from daily-use surfaces. |
+| `/governance/ingestion-sources`, `/gateway/routing-policies` | Admin-authoring (CRUD), create, rotate, archive sources, publish routing policies. | The governance pages open on `governance:view` and `/gateway/routing-policies` on `routingPolicies:view`. Each write control needs the matching `:manage` grant (`ingestionSources:manage`, `routingPolicies:manage`) and is hidden without it. | Governance sub-routes, deliberately separate from daily-use surfaces. |
+
+Anomaly rules have no authoring surface: see [Anomaly rules](/ai-governance/anomaly-rules).
 
 The whole governance product sits at the top level, not under Settings.
 The daily home is `/governance`, and the create, rotate and archive tools
@@ -11920,8 +11923,8 @@ Governance sits behind a single fence on each surface:
 # FILE: ./ai-governance/getting-started-admin.mdx
 
 ---
-title: From zero to first detected anomaly (admin)
-description: A 30-minute admin walkthrough, publish a routing policy, configure an ingestion source, import the AI Tools Portal starter pack, invite a developer, watch their first request land, and write the spend-spike rule that catches the next outlier. Each step links into the deeper admin docs.
+title: From zero to your first governed request (admin)
+description: A 30-minute admin walkthrough, publish a routing policy, configure an ingestion source, import the AI Tools Portal starter pack, invite a developer, and watch their first request land. Each step links into the deeper admin docs.
 sidebarTitle: First 30 minutes (admin)
 ---
 
@@ -11930,7 +11933,7 @@ You are an org admin on a fresh LangWatch deployment. By the end of this page yo
 - Published a default [Routing Policy](/ai-gateway/governance/routing-policies) so developers can sign in via `langwatch login`.
 - Configured an [Ingestion Source](/ai-governance/ingestion-sources/index) that lands telemetry from your gateway (or any OTLP-compatible upstream) in the unified trace store.
 - Imported the [AI Tools Portal](/ai-governance/personal-portal/admin-catalog#starter-pack) starter pack so every developer's `/me` page renders a real catalog instead of an empty state.
-- Invited a colleague through `/settings/members`, watched their first request land in `/governance`, and written a [`spend_spike`](/ai-governance/anomaly-rules) rule that will alert when their daily spend doubles.
+- Invited a colleague through `/settings/members` and watched their first request land in `/governance`.
 
 If you are a developer trying to *use* the org as a developer (not configure it), jump to the [developer walkthrough](/ai-governance/getting-started-developer) instead.
 
@@ -12039,31 +12042,13 @@ The budget is enforced by the gateway data plane on every request. The audit log
 
 The deep reference for budget shape, fallback semantics, and the WARN response tag header lives in [Budgets](/ai-gateway/budgets).
 
-## Step 8: Write your first anomaly rule
+## Step 8: Watch what the budget does not catch
 
-Budgets enforce *at* the limit. [Anomaly rules](/ai-governance/anomaly-rules) detect *before* it, the patterns that precede a breach (spend spike, geo-mismatch, off-hours usage). The detector evaluates `spend_spike` rules live today; other rule types are preview-only (the [coverage table](/ai-governance/anomaly-rules#rule-type-coverage) marks which is which).
+A budget enforces *at* the limit. The patterns that precede a breach, a spend spike or a burst of off-hours usage, show up before it.
 
-Write a starter `spend_spike` rule:
+The anomaly detector covers the spend-spike case, and any alert it raises appears in **Recent anomalies** on `/governance`. Anomaly rules cannot be created in LangWatch today, so this step has no setup to do: see [Anomaly rules](/ai-governance/anomaly-rules) for what the detector evaluates and what a rule is made of.
 
-1. Navigate to **Governance → Anomaly Rules** (`/governance/anomaly-rules`).
-2. Click **+ New anomaly rule**.
-3. Fill in:
-   - **Name**: `Daily spend doubles vs last week`
-   - **Severity**: `warning`
-   - **Rule type**: `spend_spike`
-   - **Scope**: `organization`
-   - **Threshold config**:
-     ```json
-     {
-       "windowSec": 86400,
-       "baselineOffsetSec": 604800,
-       "ratioVsBaseline": 2.0,
-       "minBaselineUsd": 1.0
-     }
-     ```
-4. Click **Create rule**.
-
-The detector starts evaluating from the next ingest event. When today's 24h spend exceeds 2× last week's same-day baseline (and the baseline was at least \$1, to avoid noise on quiet days), the detector writes an `AnomalyAlert` row visible in `/governance` and surfaces it in the [`activityMonitor.recentAnomalies`](/ai-governance/anomaly-rules) procedure.
+In the meantime, [Budgets](/ai-gateway/budgets) are the control that is available today, and the `/governance` overview is where a spike is visible without one.
 
 ## Where to next
 
@@ -12112,7 +12097,7 @@ Before you start, your IT admin should already have:
 2. Published at least one default [Routing Policy](/ai-gateway/governance/routing-policies). If they haven't, the CLI fails with a `409 no_default_routing_policy` error, see the [CLI error catalog](/ai-governance/cli-debug#error-catalog) and ping your admin.
 3. Optionally: published an [AI Tools Portal](/ai-governance/personal-portal/overview) catalog (the card grid you'll see on `/me`). If they haven't, your `/me` page shows a "your IT team is still setting things up" empty state, you can still use the CLI directly.
 
-If any of those are missing your admin's first stop is [From zero to first detected anomaly](/ai-governance/getting-started-admin).
+If any of those are missing your admin's first stop is [From zero to your first governed request](/ai-governance/getting-started-admin).
 
 ## Step 1: Install the CLI
 
@@ -12288,7 +12273,7 @@ The list of `AnomalyAlert` rows in the window, sorted newest first. Each row sho
 - **Current vs baseline** values for spend-spike anomalies.
 - **Scope** (organization, source_type, source).
 
-Click a row to expand the AnomalyAlert detail (the rule definition that matched, the event window that triggered it, the per-actor breakdown). Click the rule name to navigate to the [anomaly-rule editor](/ai-governance/anomaly-rules).
+Click a row to expand the AnomalyAlert detail (the rule definition that matched, the event window that triggered it, the per-actor breakdown). The rules themselves cannot be edited in LangWatch today, see [Anomaly rules](/ai-governance/anomaly-rules).
 
 ## When the entry shows up
 
@@ -12330,7 +12315,6 @@ The dashboard is read-mostly, but every section deep-links into the admin-author
 - KPI strip → click "Total spend" KPI → drills into per-user breakdown table.
 - Spend over time chart → click a day → opens that day's per-user breakdown filtered to ±2 hours of the spike.
 - Ingestion-source health row → click into the per-source detail page.
-- Anomalies row → click the rule name → opens the [anomaly-rule editor](/ai-governance/anomaly-rules) at that rule.
 
 If the dashboard surfaces something you want to *act* on (rotate a key, edit a rule threshold, archive a source), follow the deep link into the corresponding admin-authoring page under `/governance/*`.
 
@@ -13821,7 +13805,7 @@ keywords: ai governance, ai inventory, ingestion sources, tool catalog, anomaly 
 
 AI Governance is the part of LangWatch where you administer the AI tools your company uses. It is for the platform or IT team that approves those tools and watches their use, and it gives every developer one page with the tools they may use and their own usage.
 
-The section is in the sidebar under **AI Governance**, with four pages: **Overview**, **Inventory**, **Anomaly Rules** and **People**. Opening them needs the `governance:view` permission, which an organization Admin holds. Each developer also has a personal home page at `/me`.
+The section is in the sidebar under **AI Governance**, with three pages: **Overview**, **Inventory** and **People**. Opening them needs the `governance:view` permission, which an organization Admin holds. Each developer also has a personal home page at `/me`.
 
 ## The overview page
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -11875,11 +11875,12 @@ In flight on the same branch:
 
 ## Admin oversight on real data
 
-Once a source is `active` and events are flowing, the admin
-oversight dashboard at `/governance` queries
-`gateway_activity_events` via the `api.activityMonitor.*` tRPC
-procedures. Empty data renders a setup checklist; data present
-renders live cards + per-user table + source-health strip.
+Once a source is `active` and events are flowing, its events land in
+`gateway_activity_events`, and the governance screens read them
+through the `api.activityMonitor.*` tRPC procedures. The overview at
+`/governance` issues no such read of its own: the spend cards, the
+per-user table and the source-health strip sit on the screens that
+own them, and the overview is the way in.
 
 Tier 2, Tier 5 are deferred; the architecture doesn't preclude them
 and the control-plane primitives already accommodate them.
@@ -13798,22 +13799,24 @@ Turning on the Enterprise feature surface takes a real signed license key. There
 
 ---
 title: AI Governance
-description: An inventory of every AI tool and source in the company, the people who use them, anomaly rules on their activity, and a personal home page for each developer.
+description: An inventory of every AI tool and source in the company, the people who use them, the agents they run, and a personal home page for each developer.
 sidebarTitle: Overview
-keywords: ai governance, ai inventory, ingestion sources, tool catalog, anomaly rules, departments, langwatch
+keywords: ai governance, ai inventory, ingestion sources, tool catalog, agents, departments, langwatch
 ---
 
 AI Governance is the part of LangWatch where you administer the AI tools your company uses. It is for the platform or IT team that approves those tools and watches their use, and it gives every developer one page with the tools they may use and their own usage.
 
-The section is in the sidebar under **AI Governance**, with three pages: **Overview**, **Inventory** and **People**. Opening them needs the `governance:view` permission, which an organization Admin holds. Each developer also has a personal home page at `/me`.
+The section is in the sidebar under **AI Governance**, with four pages: **Overview**, **Inventory**, **Agents** and **People**. Opening them needs the `governance:view` permission, which an organization Admin holds. Each developer also has a personal home page at `/me`.
 
 ## The overview page
 
-The overview at `/governance` shows the last 30 days: spend over time, the spend share across teams, the top teams and users by spend, spend by department, the recent anomalies and the status of each ingestion source. The panels roll up the events of your ingestion sources. LangWatch AI Gateway traffic is under **Gateway > Usage**.
+The overview at `/governance` is the way into the section rather than a dashboard of its own. It opens with a greeting, one field for asking a question or jumping to a screen, an **Add Source** action for admins who may manage ingestion sources, and shortcuts to add people, an agent or a tool.
 
-Until the first ingestion source reports an event, the page shows a setup checklist instead: add tools to the catalog, define a routing policy, connect an ingestion source and define anomaly rules.
+Under those sit two lists. **Insights** fills once your ingestion sources are pulling, and **Recent activity** lists the screens you were last on. LangWatch AI Gateway traffic is under **Gateway > Usage**.
 
-<Frame caption="The overview before the first ingestion source reports an event: the setup checklist with all four steps complete.">
+Before your first ingestion source reports an event the page looks the same: each of the two lists carries one line saying what will fill it.
+
+<Frame caption="The overview as an earlier build drew it, with a setup checklist. The page no longer shows this checklist.">
   ![The AI Governance overview with the setup checklist](/images/ai-governance/governance-overview.png)
 </Frame>
 
@@ -13829,14 +13832,6 @@ The inventory has two tabs. **Sources** lists the systems that report AI activit
 
 <Frame caption="The Catalog tab after the starter pack import: four coding assistants and four model providers, each scoped to the organization.">
   ![The Catalog tab of the inventory](/images/ai-governance/governance-inventory-catalog.png)
-</Frame>
-
-## Anomaly Rules
-
-Rules are grouped by severity: Critical, Warning and Info. Each rule has a type, a description and a scope.
-
-<Frame caption="One Warning rule of type spend_spike, scoped to the organization.">
-  ![The Anomaly Rules page with one rule](/images/ai-governance/governance-anomaly-rule.png)
 </Frame>
 
 ## Personal home page
@@ -13857,7 +13852,7 @@ Rules are grouped by severity: Critical, Warning and Info. Each rule has a type,
     The coding assistants, model providers and internal tools that developers see on their personal home page. Import the starter pack, then scope each tile to the whole organization or to departments.
   </Card>
   <Card title="Anomaly Rules" icon="triangle-exclamation" href="/ai-governance/anomaly-rules">
-    Rules with a severity (Critical, Warning or Info) and a scope (the organization, one source type or one source) that raise an alert when activity crosses a threshold. Available on Enterprise plans.
+    What the anomaly detector evaluates and what a rule is made of. Rules cannot be created or edited in LangWatch today. Available on Enterprise plans.
   </Card>
   <Card title="People" icon="users" href="/ai-governance/people">
     Departments: the accounting label that spend rolls up by. Assign people, teams and projects to a department, and personal AI use follows the person.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -10672,11 +10672,11 @@ description: What the anomaly detector evaluates, what a rule is made of, and wh
 sidebarTitle: Anomaly rules
 ---
 
-<Info>**Pairs with:** [AI Gateway → Budgets](/ai-gateway/budgets). Budgets enforce hard spend limits; anomaly rules detect patterns *before* a budget breach (spend-spike, geo-mismatch, off-hours).</Info>
+<Info>**Pairs with:** [AI Gateway → Budgets](/ai-gateway/budgets). Budgets enforce hard spend limits; anomaly rules are meant to catch a pattern *before* a budget breach, though only the spend-spike type is evaluated today.</Info>
 
 <Note>**Available on Enterprise plans.** See [Open-core licensing](/ai-governance/open-core-licensing) for the full Apache 2.0, Enterprise split.</Note>
 
-<Warning>**Anomaly rules cannot be created or edited in LangWatch today.** There is no page for them and no public API, so this page describes what the detector does with a rule and what a rule is made of, not something you can set up right now. Rules that already exist are still evaluated, and the alerts they raise still appear on `/governance`. To watch spend without a rule, use [Budgets](/ai-gateway/budgets), which enforce a hard limit and are available today.</Warning>
+<Warning>**Anomaly rules cannot be created or edited in LangWatch today.** There is no page for them and no public API, so this page describes what the detector does with a rule and what a rule is made of, not something you can set up right now. Rules that already exist are still evaluated, but no screen in the product lists the alerts they raise: the one place an alert reaches you is the [OCSF export](/ai-gateway/governance/ocsf-export), where a record linked to one carries its `anomalyAlertId`. To watch spend with a limit you can act on, use [Budgets](/ai-gateway/budgets), which enforce a hard limit and are available today.</Warning>
 
 Anomaly rules are the "Detect" layer of the [governance control plane](/ai-governance/control-plane#tier-3-audit-log-ingest). A rule is a definition the [event-sourcing detector](/ai-gateway/governance/architecture) evaluates against incoming events, producing an `AnomalyAlert` row when a violation is detected.
 
@@ -10684,7 +10684,7 @@ This page documents what the detector evaluates and what is preview-only, so tha
 
 ## Rule-type coverage
 
-The composer's rule-type dropdown surfaces every shape the schema can hold; the detector only evaluates one of them today.
+The schema holds every rule type below; the detector evaluates one of them today.
 
 | Rule type | Detector coverage | What it detects | Threshold config keys |
 |-----------|------------------|------------------|------------------------|
@@ -10696,7 +10696,7 @@ The composer's rule-type dropdown surfaces every shape the schema can hold; the 
 | `pii_leak` | ⏳ Preview | Outbound payload matches a PII regex set | (config schema TBD) |
 | `custom` | ⏳ Preview | User-defined CEL, SQL predicate | (config schema TBD) |
 
-**⏳ Preview** rules can be created and the row shows `active` in the list, but the detector logs `debug` and skips them, no AnomalyAlert is produced. Until the detector slice for each ships, treat them as "save the rule for the future, don't expect alerts."
+A **⏳ Preview** rule type is persisted and reads as `active`, but the detector logs `debug` and skips it, so no alert is produced. Until the detector slice for each ships, treat such a rule as stored for later rather than as watching anything.
 
 If you need detection beyond `spend_spike` today, the recommended shape is one of:
 
@@ -10709,8 +10709,8 @@ These are the fields the detector reads, listed so the shape of a rule is known.
 
 | Field | Typical value | What it does |
 |-------|---------------|---------------|
-| **Name** | `Spend spike on Cowork prod` | Free-text label; surfaces in `recentAnomalies` and the alert dispatch payload. |
-| **Severity** | `warning`, `critical` | Drives the `/governance` KPI breakdown (`anomalyBreakdown.{critical,warning,info}`) and downstream dispatch routing once C3 ships. |
+| **Name** | `Spend spike on Cowork prod` | Free-text label; identifies the rule on the alert it raises. |
+| **Severity** | `warning`, `critical` | Recorded on the alert, and will drive dispatch routing once C3 ships. |
 | **Rule type** | `spend_spike` | Pick exactly this, see coverage table above. |
 | **Scope** | `organization`, `source_type`, `source` | Filters which IngestionSources the rule applies to (see Scope coverage below). |
 | **Scope ID** | (cuid) | Required when scope is `source_type` or `source`. The IngestionSource ID is in the URL of the per-source detail page under the inventory. |
@@ -10755,7 +10755,7 @@ Sensible starting values:
 
 ## Dispatch coverage (C3 in flight)
 
-The composer's **Destination config** field accepts a JSON object describing where to push the alert. Today the detector's dispatch path is **log-only**: alerts surface on the `/governance` dashboard's "Recent anomalies" section but no Slack message, PagerDuty page, SIEM event is generated.
+A rule's **Destination config** holds a JSON object describing where to push the alert. Today the detector's dispatch path is **log-only**: the alert is recorded and carried on the OCSF export, but no Slack message, PagerDuty page or SIEM event is pushed anywhere.
 
 C3 (in flight on the [governance platform](https://github.com/langwatch/langwatch/pull/3524) branch) wires `triggerActionDispatch` so the destinationConfig values below start working:
 
@@ -10768,15 +10768,15 @@ C3 (in flight on the [governance platform](https://github.com/langwatch/langwatc
 }
 ```
 
-Until C3 lands, leave destinationConfig empty (`{}`) and rely on the dashboard to surface alerts. A real Slack webhook set today is stored and never called, so alerts look wired when they are not.
+Until C3 lands, leave destinationConfig empty (`{}`). A real Slack webhook set today is stored and never called, so alerts look wired when they are not.
 
-## Where an existing rule's alerts show up
+## Where an existing rule's alerts go
 
-Two angles, same data:
+**In the app**: no screen lists them. Each fire is recorded as one alert keyed by `(ruleId, triggerWindowStart)`, so the detector does not raise a second alert for the same window, but the governance section has no page that reads those rows today.
 
-**Web**: open `/governance` and look for the rule's name in the "Recent anomalies" section. Each fire creates one row keyed by `(ruleId, triggerWindowStart)` so the detector doesn't double-alert on a single window.
+**In your SIEM**: the [OCSF export](/ai-gateway/governance/ocsf-export) is the one place an alert reaches you. A trace record linked to an alert carries that alert's `anomalyAlertId` and `severity_id` 4 (Medium); every other record carries `severity_id` 1 (Informational).
 
-**CLI**: `langwatch governance status` shows `hasAnomalyRules: true` once at least one rule exists. The `recentAnomalies` query is wired into the same `api.activityMonitor.recentAnomalies` tRPC procedure the dashboard reads.
+**CLI**: `langwatch governance status` reports `hasAnomalyRules: true` once at least one rule exists. That confirms a rule is defined, not that one has fired.
 
 End to end, for an organization that already has a rule:
 
@@ -10784,11 +10784,11 @@ End to end, for an organization that already has a rule:
 2. Send one OTel event with `gen_ai.usage.cost_usd: 0.05` (baseline seed), see [otel-generic, Test it now](/ai-governance/ingestion-sources/otel-generic#test-it-now-copy-paste-curl).
 3. Wait long enough for the baseline window to roll past the seed (default `windowSec: 86400` means 24h, so use the tighter values from the table above for fast iteration).
 4. Send a second event with `gen_ai.usage.cost_usd: 2.00` (the spike).
-5. Reload `/governance`, the alert should appear in "Recent anomalies" with `state: open` and a populated `detail.ratio`.
+5. Pull the [OCSF export](/ai-gateway/governance/ocsf-export) and look for a record carrying an `anomalyAlertId`.
 
 ## What's persisted vs what's evaluated
 
-A rule that's persisted but unevaluated is intentional, admins can pre-stage rules so when the detector slice ships, no rework. But it's a real failure mode if you don't know which is which. The two coverage tables above are the source of truth: **only `spend_spike` + (`organization` | `source_type` | `source`) actually fires today**. Everything else is preview state.
+A rule that is persisted but unevaluated is intentional: a rule can wait for the detector slice that will read it, so there is no rework when that slice ships. But it's a real failure mode if you don't know which is which. The two coverage tables above are the source of truth: **only `spend_spike` + (`organization` | `source_type` | `source`) actually fires today**. Everything else is preview state.
 
 ---
 
@@ -11009,7 +11009,7 @@ The `ingest` and `governance` subcommands are always registered: `langwatch --he
 
 ## `langwatch governance status`
 
-The org-level setup-state OR-of-flags. Mirrors `api.governance.setupState` exactly, same boolean shape that promotes the MainMenu **Govern** entry from hidden → visible once any 3 of 5 are true.
+The org-level setup-state OR-of-flags. Mirrors `api.governance.setupState` exactly, same boolean shape that promotes the MainMenu **Govern** entry from hidden → visible once any one of them is true.
 
 ```text
 $ langwatch governance status
@@ -12013,7 +12013,7 @@ Once invited, point them at the [developer walkthrough](/ai-governance/getting-s
 
 After your colleague runs `langwatch login` and makes one Claude Code request, two surfaces should update within seconds:
 
-- **`/governance`**, the [governance home](/ai-governance/control-plane#daily-use-surfaces-vs-admin-authoring-surfaces) shows org-wide spend, anomalies, ingestion-source health, per-user breakdown.
+- **`/governance`**, the [governance home](/ai-governance/control-plane#daily-use-surfaces-vs-admin-authoring-surfaces), the way in to the inventory, agents and people screens.
 - **`/settings/audit-log`**, the [audit log](/platform/audit-log) records every governance mutation (member invited, routing policy published, ingestion source created, virtual key minted, budget created…) with timestamp, actor, target kind, target ID, and IP.
 
 If you don't see the request, the [CLI debug commands](/ai-governance/cli-debug) take 30 seconds to localise the problem:
@@ -12047,9 +12047,9 @@ The deep reference for budget shape, fallback semantics, and the WARN response t
 
 A budget enforces *at* the limit. The patterns that precede a breach, a spend spike or a burst of off-hours usage, show up before it.
 
-The anomaly detector covers the spend-spike case, and any alert it raises appears in **Recent anomalies** on `/governance`. Anomaly rules cannot be created in LangWatch today, so this step has no setup to do: see [Anomaly rules](/ai-governance/anomaly-rules) for what the detector evaluates and what a rule is made of.
+The anomaly detector covers the spend-spike case. Any alert it raises is recorded and carried on the [OCSF export](/ai-gateway/governance/ocsf-export) rather than shown on a screen. Anomaly rules cannot be created in LangWatch today, so this step has no setup to do: see [Anomaly rules](/ai-governance/anomaly-rules) for what the detector evaluates and what a rule is made of.
 
-In the meantime, [Budgets](/ai-gateway/budgets) are the control that is available today, and the `/governance` overview is where a spike is visible without one.
+In the meantime, [Budgets](/ai-gateway/budgets) are the control that is available today.
 
 ## Where to next
 
@@ -12065,7 +12065,7 @@ In the meantime, [Budgets](/ai-gateway/budgets) are the control that is availabl
 | Developer sees `409 no_default_routing_policy` on `langwatch login` | Step 2 skipped or no policy marked default | [Routing Policies](/ai-gateway/governance/routing-policies): pick one, tick **Mark as default**. |
 | `/me` shows "your IT team is still setting things up" empty state | Step 4 skipped | Open `/governance/inventory?tab=catalog` → **Import starter pack**. |
 | Ingestion source sits at `awaiting_first_event` forever | Source-type doesn't have a wired adapter yet | [Ingestion Sources index → State of each receiver](/ai-governance/ingestion-sources/index#state-of-each-receiver-at-a-glance): three rows are setup-contract-only as of this release. |
-| `/governance` doesn't appear in your sidebar | Org's [setup-state OR-of-flags](/ai-governance/control-plane#persona-based-home-routing-the-setup-state-signal) hasn't tripped yet | Need any 3 of 5: Personal VKs, Routing Policies, Ingestion Sources, Anomaly Rules, Recent activity (30d). After Steps 2-7 above, you'll have 4. |
+| `/governance` doesn't appear in your sidebar | Org's [setup-state OR-of-flags](/ai-governance/control-plane#persona-based-home-routing-the-setup-state-signal) hasn't tripped yet | Any one of these is enough: Personal VKs, Routing Policies, Ingestion Sources, Anomaly Rules, Recent activity (30d). After Steps 2-7 above you will have several. |
 | Member colleague got an `Access Restricted` page on `/settings/audit-log` | Working as designed, audit log is admin-only | Either elevate them to `Admin` or grant a custom role with `organization:manage` (delegable via the `CustomRolePermissions` JSON column). |
 
 ---
@@ -12210,121 +12210,62 @@ Your spend, budget, and audit trail still flow normally, the portal grid is a co
 # FILE: ./ai-governance/governance-dashboard.mdx
 
 ---
-title: /governance dashboard
-description: The daily-use org governance home, spend, anomalies, ingestion-source health, per-user activity. Read-mostly; the admin-authoring CRUD pages still live under /governance/*. Available only after the org's setup-state OR-of-flags trips.
+title: The /governance overview
+description: What the /governance page shows today, where each governance number actually lives, and the setup-state signal behind the section.
 sidebarTitle: /governance dashboard
 ---
 
-The `/governance` route is the **org governance daily home**: the read-mostly oversight dashboard an admin opens to answer *"is the gateway healthy, are we within budget, did anything anomalous happen overnight, are users actually using this?"*. It's the counterpart of `/me` for the admin persona.
+`/governance` is the way into the AI Governance section rather than an oversight dashboard of its own. It opens with a greeting, one field for asking a question or jumping to a screen, an **Add Source** action for admins who may manage ingestion sources, and shortcuts to add people, an agent or a tool.
 
-It is intentionally distinct from the **admin-authoring** surface at `/governance/*`, see [Control plane → Daily-use vs admin-authoring](/ai-governance/control-plane#daily-use-surfaces-vs-admin-authoring-surfaces) for why the split exists.
+Under those sit two lists. **Insights** fills once your ingestion sources are pulling, and **Recent activity** lists the screens you were last on. Before your first source reports an event, each list carries one line saying what will fill it.
 
-<Info>**Pairs with:** [Control plane & integration tiers](/ai-governance/control-plane) for the surface map, [Anomaly rules](/ai-governance/anomaly-rules) for what populates the anomalies strip, and [Departments](/ai-governance/people) for how the **Spend by department** card attributes spend across the org.</Info>
+The page issues no spend, anomaly or source-health read of its own. That is deliberate: it used to carry a panel per subject, each on its own permission, so a reader whose plan or role did not cover one met an error before they met the page.
 
-<Note>**Visibility**: the `/governance` entry only appears in the main sidebar once the org's setup-state OR-of-flags trips (see [When the entry shows up](#when-the-entry-shows-up) below). A brand-new org sees the **Governance** admin pages instead until they have data flowing.</Note>
+<Info>**Pairs with:** [AI Governance](/ai-governance/overview), which describes this screen and the rest of the section in full.</Info>
 
-## What you see
+## Where the numbers live
 
-The dashboard groups data into four strips, top to bottom.
+This page carries no strips of metrics. Each subject has its own screen in the section:
 
-### 1. KPI strip
-
-Five at-a-glance numbers for the selected window (default: last 30 days):
-
-| KPI | What it shows |
+| To see | Go to |
 |---|---|
-| **Total spend** | USD across every gateway request the org saw, summed |
-| **Active users** | Distinct principal IDs that hit the gateway in the window |
-| **Active sources** | IngestionSources in `active` state (have received at least one event) |
-| **Anomaly count** | `AnomalyAlert` rows in the window, broken down by severity (`anomalyBreakdown.{critical,warning,info}`) |
-| **Recent activity** | Count of governance-tagged events in the last 24h |
+| The systems reporting AI activity, and the tool catalog | [Inventory](/ai-governance/ingestion-sources/index) |
+| The agents and applications detected across the organization | **Agents** in the sidebar |
+| Departments, and how spend rolls up by them | [People](/ai-governance/people) |
 
-The window selector at the top right adjusts every strip simultaneously.
+Alerts raised by the anomaly detector are listed on none of these. See [Anomaly rules](/ai-governance/anomaly-rules) for where an alert does reach you.
 
-### 2. Spend over time
+## When the section becomes an admin's landing page
 
-A daily bar chart of org-wide spend. Click a bar to drill into the per-user breakdown for that day.
-
-The chart is the unified view across:
-
-- Personal Virtual Keys minted via `/me`.
-- Project Virtual Keys minted from project pages.
-- Anything else that hit the gateway with a `vk-lw-*` Bearer.
-
-It does not include Ingestion Source events (those are governance-tagged but don't carry cost), those land in [Ingestion-source health](#3-ingestion-source-health) below.
-
-### 3. Ingestion-source health
-
-A status row per active IngestionSource:
-
-- **Status pill**: `active`, `awaiting_first_event`, `error`.
-- **Source type**: `otel_generic`, `claude_cowork`, `workato`, etc.
-- **Last event**: relative timestamp of the most recent successful ingest.
-- **Event count**: 24h, 7d, 30d, picked from the same `ingestionSources.healthMetrics` tRPC procedure that `langwatch ingest health` uses (so the CLI and the web UI are byte-for-byte identical on `--json`).
-
-A red dot on a source means the receiver hasn't seen events in the configured window, see the [per-source detail page](/ai-governance/ingestion-sources/index) for the timeline + the receiver-side error log.
-
-### 4. Anomalies
-
-The list of `AnomalyAlert` rows in the window, sorted newest first. Each row shows:
-
-- **Severity chip** (critical, warning, info).
-- **Rule name** that fired.
-- **Triggered at** timestamp.
-- **Current vs baseline** values for spend-spike anomalies.
-- **Scope** (organization, source_type, source).
-
-Click a row to expand the AnomalyAlert detail (the rule definition that matched, the event window that triggered it, the per-actor breakdown). The rules themselves cannot be edited in LangWatch today, see [Anomaly rules](/ai-governance/anomaly-rules).
-
-## When the entry shows up
-
-`/governance` is gated by an OR-of-flags signal that the org has *activated* governance. The signal is the `api.governance.setupState({ organizationId })` tRPC procedure (read-only, cheap, server-side):
+A setup-state signal decides whether an org admin is sent here, read by the `governance.setupState({ organizationId })` tRPC procedure:
 
 ```ts
 {
-  hasPersonalVKs:      boolean,  // any user has minted a personal VK
-  hasRoutingPolicies:  boolean,  // at least one routing policy exists
-  hasIngestionSources: boolean,  // at least one source exists
-  hasAnomalyRules:     boolean,  // at least one rule defined
-  hasRecentActivity:   boolean,  // any governance event in the last 30d
+  hasPersonalVKs:       boolean,  // any user has minted a personal VK
+  hasRoutingPolicies:   boolean,  // at least one routing policy exists
+  hasIngestionSources:  boolean,  // at least one source exists
+  hasAnomalyRules:      boolean,  // at least one rule defined
+  hasRecentActivity:    boolean,  // any governance event in the last 30d
+  hasApplicationTraces: boolean,  // an application project has traces
 }
 ```
 
-`Governance active = any 3 of 5`. After the [admin walkthrough](/ai-governance/getting-started-admin) you'll have at least 4 (routing policies + ingestion sources + recent activity from the dev pass + the budget you create implies personal VKs once a developer signs in).
+Governance reads as active when **any one** of the first five is true. `hasApplicationTraces` is reported alongside them and does not feed that answer.
 
-The same signal drives:
-
-- The **Govern (Preview)** entry visibility in the main sidebar.
-- The CLI `langwatch governance status` output (mirrors the same booleans).
-- The post-onboarding redirect, when an admin lands on `/`, the persona-2 home picker sends them to `/governance` if active, else to `/governance` to keep configuring.
+The same signal backs the `langwatch governance status` output, so the CLI and the app agree on whether an organization has activated governance.
 
 ## Permissions
 
-The `/governance` page itself is gated to `governance:view` (granted to ADMIN by default). Underlying procedures:
+Opening `/governance` needs `governance:view`, which an organization Admin holds by default.
 
-- `governance.kpis(organizationId, window)`, KPI strip.
-- `governance.spendOverTime(organizationId, window)`, bar chart.
-- `ingestionSources.healthMetrics(organizationId)`, health strip.
-- `activityMonitor.recentAnomalies(organizationId, window)`, anomaly list (this lives in the `activityMonitor` router, not `governance`, for routing-through-service reasons).
-
-The activity monitor procedures cap at `activityMonitor:view`, the recommended permission to grant a security-analyst custom role that should see anomalies without managing rules.
-
-## What you can do FROM here
-
-The dashboard is read-mostly, but every section deep-links into the admin-authoring surface where you'd actually change something:
-
-- KPI strip → click "Total spend" KPI → drills into per-user breakdown table.
-- Spend over time chart → click a day → opens that day's per-user breakdown filtered to ±2 hours of the spike.
-- Ingestion-source health row → click into the per-source detail page.
-
-If the dashboard surfaces something you want to *act* on (rotate a key, edit a rule threshold, archive a source), follow the deep link into the corresponding admin-authoring page under `/governance/*`.
+The reads behind the section's other screens are permissioned separately. The activity-monitor procedures cap at `activityMonitor:view`, the permission to grant a security analyst who should see activity without managing rules.
 
 ## Where to next
 
-- **Detect anomalies**: [Anomaly rules](/ai-governance/anomaly-rules).
+- **The section and its four pages**: [AI Governance](/ai-governance/overview).
+- **What the detector evaluates, and where an alert goes**: [Anomaly rules](/ai-governance/anomaly-rules).
 - **Inspect ingestion-source health from the terminal**: [CLI debug](/ai-governance/cli-debug).
 - **Export to your SIEM**: [Compliance architecture](/ai-governance/compliance-architecture).
-- **Tighten privacy**: [No-spy mode](/ai-governance/no-spy-mode).
 - **Audit who did what when**: [Audit log](/platform/audit-log).
 
 ---

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -11925,7 +11925,7 @@ Governance sits behind a single fence on each surface:
 
 ---
 title: From zero to your first governed request (admin)
-description: A 30-minute admin walkthrough, publish a routing policy, configure an ingestion source, import the AI Tools Portal starter pack, invite a developer, and watch their first request land. Each step links into the deeper admin docs.
+description: A 30-minute admin walkthrough to publish a routing policy, configure an ingestion source, import the AI Tools Portal starter pack, invite a developer, and watch their first request land. Each step links into the deeper admin docs.
 sidebarTitle: First 30 minutes (admin)
 ---
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -509,7 +509,7 @@ For agents: if anything in these docs is wrong, confusing, or fails when you try
 
 ## Get Started
 
-- [AI Governance](https://langwatch.ai/docs/ai-governance/overview.md): An inventory of every AI tool and source in the company, the people who use them, anomaly rules on their activity, and a personal home page for each developer.
+- [AI Governance](https://langwatch.ai/docs/ai-governance/overview.md): An inventory of every AI tool and source in the company, the people who use them, the agents they run, and a personal home page for each developer.
 - [Your first 5 minutes (developer)](https://langwatch.ai/docs/ai-governance/getting-started-developer.md): A new-developer walkthrough, install the LangWatch CLI, sign in via your company SSO, land on /me, run your first request through the gateway, and read your spend back. Each step links into the deeper docs.
 - [From zero to your first governed request (admin)](https://langwatch.ai/docs/ai-governance/getting-started-admin.md): A 30-minute admin walkthrough, publish a routing policy, configure an ingestion source, import the AI Tools Portal starter pack, invite a developer, and watch their first request land. Each step links into the deeper admin docs.
 - [Open-core licensing](https://langwatch.ai/docs/ai-governance/open-core-licensing.md): LangWatch is open-core. The Apache 2.0 floor covers Personal Virtual Keys, the AI Tools Portal, Routing Policies, and CLI debugging. Multi-source ingestion, anomaly detection, OCSF, SIEM export, and extended retention require an Enterprise plan.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -511,7 +511,7 @@ For agents: if anything in these docs is wrong, confusing, or fails when you try
 
 - [AI Governance](https://langwatch.ai/docs/ai-governance/overview.md): An inventory of every AI tool and source in the company, the people who use them, anomaly rules on their activity, and a personal home page for each developer.
 - [Your first 5 minutes (developer)](https://langwatch.ai/docs/ai-governance/getting-started-developer.md): A new-developer walkthrough, install the LangWatch CLI, sign in via your company SSO, land on /me, run your first request through the gateway, and read your spend back. Each step links into the deeper docs.
-- [From zero to first detected anomaly (admin)](https://langwatch.ai/docs/ai-governance/getting-started-admin.md): A 30-minute admin walkthrough, publish a routing policy, configure an ingestion source, import the AI Tools Portal starter pack, invite a developer, watch their first request land, and write the spend-spike rule that catches the next outlier. Each step links into the deeper admin docs.
+- [From zero to your first governed request (admin)](https://langwatch.ai/docs/ai-governance/getting-started-admin.md): A 30-minute admin walkthrough, publish a routing policy, configure an ingestion source, import the AI Tools Portal starter pack, invite a developer, and watch their first request land. Each step links into the deeper admin docs.
 - [Open-core licensing](https://langwatch.ai/docs/ai-governance/open-core-licensing.md): LangWatch is open-core. The Apache 2.0 floor covers Personal Virtual Keys, the AI Tools Portal, Routing Policies, and CLI debugging. Multi-source ingestion, anomaly detection, OCSF, SIEM export, and extended retention require an Enterprise plan.
 
 ## Personal Portal
@@ -549,7 +549,7 @@ For agents: if anything in these docs is wrong, confusing, or fails when you try
 
 ## Detection
 
-- [Anomaly rules](https://langwatch.ai/docs/ai-governance/anomaly-rules.md): Define detection rules that fire AnomalyAlerts when activity-event traffic crosses a threshold, what the detector evaluates today, what is preview-only, and how to write a working rule.
+- [Anomaly rules](https://langwatch.ai/docs/ai-governance/anomaly-rules.md): What the anomaly detector evaluates, what a rule is made of, and why rules cannot be created in the app today.
 
 ## Compliance & Architecture
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -511,7 +511,7 @@ For agents: if anything in these docs is wrong, confusing, or fails when you try
 
 - [AI Governance](https://langwatch.ai/docs/ai-governance/overview.md): An inventory of every AI tool and source in the company, the people who use them, the agents they run, and a personal home page for each developer.
 - [Your first 5 minutes (developer)](https://langwatch.ai/docs/ai-governance/getting-started-developer.md): A new-developer walkthrough, install the LangWatch CLI, sign in via your company SSO, land on /me, run your first request through the gateway, and read your spend back. Each step links into the deeper docs.
-- [From zero to your first governed request (admin)](https://langwatch.ai/docs/ai-governance/getting-started-admin.md): A 30-minute admin walkthrough, publish a routing policy, configure an ingestion source, import the AI Tools Portal starter pack, invite a developer, and watch their first request land. Each step links into the deeper admin docs.
+- [From zero to your first governed request (admin)](https://langwatch.ai/docs/ai-governance/getting-started-admin.md): A 30-minute admin walkthrough to publish a routing policy, configure an ingestion source, import the AI Tools Portal starter pack, invite a developer, and watch their first request land. Each step links into the deeper admin docs.
 - [Open-core licensing](https://langwatch.ai/docs/ai-governance/open-core-licensing.md): LangWatch is open-core. The Apache 2.0 floor covers Personal Virtual Keys, the AI Tools Portal, Routing Policies, and CLI debugging. Multi-source ingestion, anomaly detection, OCSF, SIEM export, and extended retention require an Enterprise plan.
 
 ## Personal Portal

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -528,7 +528,7 @@ For agents: if anything in these docs is wrong, confusing, or fails when you try
 
 ## Dashboards
 
-- [/governance dashboard](https://langwatch.ai/docs/ai-governance/governance-dashboard.md): The daily-use org governance home, spend, anomalies, ingestion-source health, per-user activity. Read-mostly; the admin-authoring CRUD pages still live under /governance/*. Available only after the org's setup-state OR-of-flags trips.
+- [The /governance overview](https://langwatch.ai/docs/ai-governance/governance-dashboard.md): What the /governance page shows today, where each governance number actually lives, and the setup-state signal behind the section.
 - [People](https://langwatch.ai/docs/ai-governance/people.md): Departments group the people, teams and projects of your organization for spend accounting, so every request rolls up to exactly one department, including personal AI use.
 
 ## Privacy

--- a/platform/app/ee/governance/dashboard/__tests__/pullConfigBuilderCoverage.unit.test.ts
+++ b/platform/app/ee/governance/dashboard/__tests__/pullConfigBuilderCoverage.unit.test.ts
@@ -26,19 +26,21 @@ import {
 import { describe, expect, it } from "vitest";
 
 /**
- * Known broken, tracked in #7583: `claude_compliance` declares a
- * `secret: true` workspace API key and has no builder, so the key is dropped
- * and every run sends an unresolved credential template as its header. It is a
- * different source type from the one this branch adds, and fixing it here
- * would mean guessing which key its adapter reads, so it is named rather than
- * silently excluded. Deleting this entry is how that issue gets closed.
+ * The population is the source types an admin can actually choose. A type
+ * that collects a secret needs a builder to put that secret back where its
+ * adapter reads it; without one the key is dropped and every run sends an
+ * unresolved credential template as its header.
+ *
+ * `claude_compliance` was the one type in this population with no builder
+ * (#7583). It is now hidden from the picker, so it is out of the population
+ * rather than exempted from it — the assertion below is what proves that,
+ * and it is the reason no exemption list survives in this file. Rows already
+ * configured on it are untouched and still broken; hiding stops new ones.
  */
-const KNOWN_MISSING_BUILDER = new Set(["claude_compliance"]);
-
 describe("given the source types offered in the picker", () => {
-  const secretCollecting = SOURCE_TYPE_OPTIONS.filter(
-    (option) => !option.deprecated && option.mode === "pull",
-  )
+  const offered = SOURCE_TYPE_OPTIONS.filter((option) => !option.deprecated);
+  const secretCollecting = offered
+    .filter((option) => option.mode === "pull")
     .map((option) => option.value)
     .filter((value) =>
       (PARSER_FIELDS[value] ?? []).some((field) => field.secret === true),
@@ -51,30 +53,37 @@ describe("given the source types offered in the picker", () => {
       // and the guard passed against a codebase with a known-broken source in
       // it. A guard that cannot name what it is guarding is not one.
       expect(secretCollecting.length).toBeGreaterThan(0);
-      expect(secretCollecting).toContain("claude_compliance");
+      expect(secretCollecting).toContain("anthropic_admin");
     });
 
     it("gives every source type that collects a secret a way to reassemble it", () => {
       const withBuilder = new Set<string>(
         SOURCE_TYPES_WITH_PULL_CONFIG_BUILDER,
       );
-      const dropped = secretCollecting
-        .filter((type) => !withBuilder.has(type))
-        .filter((type) => !KNOWN_MISSING_BUILDER.has(type));
 
-      expect(dropped).toEqual([]);
+      expect(secretCollecting.filter((type) => !withBuilder.has(type))).toEqual(
+        [],
+      );
     });
 
-    it("keeps the known-broken list honest, so a fix cannot leave it stale", () => {
-      // A type listed as broken that has since gained a builder means the list
-      // is out of date, and a stale exemption is how the guard above quietly
-      // stops covering something.
-      const withBuilder = new Set<string>(
-        SOURCE_TYPES_WITH_PULL_CONFIG_BUILDER,
-      );
-      for (const type of KNOWN_MISSING_BUILDER) {
-        expect(withBuilder.has(type)).toBe(false);
-      }
+    it("no longer offers the compliance type that had no builder", () => {
+      // If it came back to the picker it would re-enter the population above
+      // with nothing to reassemble its workspace key, so the guard would fail
+      // on it rather than pass around it.
+      expect(secretCollecting).not.toContain("claude_compliance");
+      expect(offered.map((o) => o.value)).not.toContain("claude_compliance");
+      // Its form still declares the secret, which is why it must stay hidden
+      // rather than merely be left alone.
+      expect(
+        (PARSER_FIELDS.claude_compliance ?? []).some(
+          (field) => field.secret === true,
+        ),
+      ).toBe(true);
+      expect(
+        new Set<string>(SOURCE_TYPES_WITH_PULL_CONFIG_BUILDER).has(
+          "claude_compliance",
+        ),
+      ).toBe(false);
     });
   });
 });

--- a/platform/app/ee/governance/dashboard/components/IngestionSourcesTable.tsx
+++ b/platform/app/ee/governance/dashboard/components/IngestionSourcesTable.tsx
@@ -203,7 +203,7 @@ function SourceTableRow({
 }) {
   const sourceType = source.sourceType as SourceType;
   // Health wins over configured status (a source whose last runs all failed
-  // is "Not pulling", not "Active"); see sourceHealthDisplay.
+  // is "Pulls failing", not "Active"); see sourceHealthDisplay.
   const status = sourceBadge({
     status: source.status,
     errorCount: source.errorCount,

--- a/platform/app/ee/governance/dashboard/components/__tests__/AddIngestionSourceMenu.integration.test.tsx
+++ b/platform/app/ee/governance/dashboard/components/__tests__/AddIngestionSourceMenu.integration.test.tsx
@@ -64,9 +64,7 @@ describe("given the Add source menu", () => {
         "Anthropic Claude (Cowork)",
         "Workato",
         "Microsoft Copilot Studio",
-        "OpenAI Enterprise Compliance",
         "OpenAI Admin",
-        "Anthropic Claude Enterprise Compliance",
         "Anthropic Admin API (usage & cost)",
         "Databricks AI/BI Genie",
         "Custom S3 audit log",
@@ -80,6 +78,18 @@ describe("given the Add source menu", () => {
       expect(
         screen.queryByText("Microsoft Copilot Studio (Purview)"),
       ).toBeNull();
+
+      // The two Enterprise Compliance types are defined but never offered:
+      // neither has a finished data path, so picking one buys a source that
+      // stays silent. The loop above is what proves this menu renders its
+      // items at all, so their absence here reads as filtering rather than
+      // an empty menu.
+      for (const withheld of [
+        "OpenAI Enterprise Compliance",
+        "Anthropic Claude Enterprise Compliance",
+      ]) {
+        expect(screen.queryByText(withheld)).toBeNull();
+      }
     });
 
     /** @scenario "Add source menu lists every type by vendor, grouped in plain language" */

--- a/platform/app/ee/governance/dashboard/components/__tests__/ingestionSourceCatalog.unit.test.ts
+++ b/platform/app/ee/governance/dashboard/components/__tests__/ingestionSourceCatalog.unit.test.ts
@@ -69,6 +69,53 @@ describe("given the ingestion-source catalog", () => {
     });
   });
 
+  describe("when a source type was offered before it worked", () => {
+    /*
+     * The compliance pair. Both were pickable and neither had anything
+     * reading it, so a source configured on one stayed silent forever. They
+     * leave the picker exactly the way the retired Copilot type did.
+     */
+    const NEVER_BUILT = ["openai_compliance", "claude_compliance"] as const;
+
+    /** @scenario "A source type nothing reads can no longer be chosen" */
+    it("is not offered on any plan", () => {
+      for (const isEnterprise of [true, false]) {
+        const offered = gatedSourceTypeOptions({ isEnterprise }).map(
+          (o) => o.value,
+        );
+        // The guard against a vacuous pass: a filter that dropped everything
+        // would satisfy the absences below while breaking the whole menu.
+        expect(offered).toContain("otel_generic");
+        expect(offered).toContain("openai_admin");
+        for (const value of NEVER_BUILT) {
+          expect(offered).not.toContain(value);
+        }
+      }
+    });
+
+    /** @scenario "Sources already configured on an unread type still display" */
+    it("still resolves the display definition for sources configured on it", () => {
+      for (const value of NEVER_BUILT) {
+        // A configured row reads its name here without a fallback, so the
+        // entry has to survive the hiding or the row's name goes blank.
+        expect(SOURCE_TYPE_LABEL[value]).toBeTruthy();
+        const option = SOURCE_TYPE_OPTIONS.find((o) => o.value === value);
+        expect(option).toBeDefined();
+        expect(option?.icon).toBeTruthy();
+      }
+    });
+
+    /** @scenario "A source type nothing reads can no longer be chosen" */
+    it("says in the blurb that the source is not available", () => {
+      for (const value of NEVER_BUILT) {
+        const option = SOURCE_TYPE_OPTIONS.find((o) => o.value === value);
+        expect(option?.blurb).toMatch(/not available/i);
+        // The old copy described a poller that was never written.
+        expect(option?.blurb).not.toMatch(/polls|pulls/i);
+      }
+    });
+  });
+
   describe("when an enterprise plan gates the options", () => {
     /** @scenario "The composer and the menu share one plan gate" */
     it("locks nothing", () => {

--- a/platform/app/ee/governance/dashboard/components/ingestionSourceCatalog.tsx
+++ b/platform/app/ee/governance/dashboard/components/ingestionSourceCatalog.tsx
@@ -74,6 +74,9 @@ export interface SourceTypeOption {
   /**
    * True when this source type may no longer be chosen for a new source,
    * but rows already configured on it still exist and must keep rendering.
+   * Covers both a type that was retired and one that was offered before it
+   * worked: either way, choosing it buys an admin a source that stays
+   * silent, so it leaves the picker and keeps its definition.
    *
    * Deprecating rather than deleting is deliberate. The completeness guard
    * below requires every `SourceType` to appear here, and `SOURCE_TYPE_LABEL`
@@ -143,9 +146,13 @@ export const SOURCE_TYPE_OPTIONS = [
     value: "openai_compliance",
     label: "OpenAI Enterprise Compliance",
     mode: "s3",
-    blurb:
-      "Pulls compliance JSONL drops from an S3 bucket OpenAI writes to (Enterprise Compliance API).",
+    blurb: "Not available. Choosing this source would never deliver any data.",
     icon: <OpenAI />,
+    // Offered before the path behind it was finished, so an admin who picked
+    // it got a source that stayed silent. Kept rather than deleted for the
+    // same reason as the Copilot entry above: the completeness guard below
+    // and `SOURCE_TYPE_LABEL` both need it.
+    deprecated: true,
   },
   {
     value: "openai_admin",
@@ -159,8 +166,14 @@ export const SOURCE_TYPE_OPTIONS = [
     value: "claude_compliance",
     label: "Anthropic Claude Enterprise Compliance",
     mode: "pull",
-    blurb: "Polls Anthropic's compliance API with a workspace API key.",
+    blurb: "Not available. Choosing this source would never deliver any data.",
     icon: <Anthropic />,
+    // Same shape as the OpenAI entry above, with a known mechanism (#7583):
+    // the form collects a workspace API key that no pull-config builder ever
+    // puts where the adapter reads it, so every run authenticates with an
+    // unresolved template. Hiding it stops new sources being configured on
+    // that path; rows already on it are untouched.
+    deprecated: true,
   },
   {
     value: "anthropic_admin",

--- a/platform/app/ee/governance/dashboard/components/sampleIngestionSources.ts
+++ b/platform/app/ee/governance/dashboard/components/sampleIngestionSources.ts
@@ -19,6 +19,13 @@ export const SAMPLE_INGESTION_SOURCES: Source[] = SAMPLE_TOOL_CARDS.flatMap(
             status: "active",
             errorCount: 0,
             lastSuccessAt: null,
+            pullStatus: {
+              lastRunAt: null,
+              outcome: null,
+              error: null,
+              backfillThrough: null,
+              hasMore: null,
+            },
             lastEventAt: null,
             traceProjectId: null,
             traceProjectArchived: false,

--- a/platform/app/ee/governance/dashboard/logic/sourceHealthDisplay.ts
+++ b/platform/app/ee/governance/dashboard/logic/sourceHealthDisplay.ts
@@ -4,6 +4,26 @@ import { deriveSourceHealth } from "@ee/governance/services/pullers/sourceHealth
 import { CircleAlert, CircleCheck, CircleDashed, CircleX } from "lucide-react";
 
 /**
+ * Health is derived at read time from the failure count below, so it only
+ * changes when a pull actually runs — and pulls run on the server's own
+ * schedule, never in response to anything this page does. Without a periodic
+ * refetch the badge keeps whatever it had at mount, so an admin who has just
+ * repaired a source's credentials watches a red badge that is already stale,
+ * and a source that started failing while the tab was open never turns red at
+ * all.
+ *
+ * Background polling stays off, because that reader is the only one this is
+ * for: an inventory tab left open behind other windows would otherwise keep
+ * an org-wide health query running for nobody. Focus is the cheap catch-up
+ * for the interval the hidden tab skipped.
+ */
+export const SOURCE_HEALTH_REFRESH = {
+  refetchOnWindowFocus: true,
+  refetchInterval: 30_000,
+  refetchIntervalInBackground: false,
+} as const;
+
+/**
  * What the source badge says, on the inventory list and the detail header.
  *
  * Two different questions share one badge. Status is what an admin
@@ -23,13 +43,6 @@ import { CircleAlert, CircleCheck, CircleDashed, CircleX } from "lucide-react";
  * through to fix an outage and finds nothing wrong. Configuration wins here
  * because health is only interesting about a source we are asking to run.
  */
-/** Refresh visible source health after scheduled pulls, without polling hidden tabs. */
-export const SOURCE_HEALTH_REFRESH = {
-  refetchOnWindowFocus: true,
-  refetchInterval: 30_000,
-  refetchIntervalInBackground: false,
-} as const;
-
 export interface SourceBadge {
   icon: typeof CircleCheck;
   label: string;

--- a/platform/app/ee/governance/dashboard/logic/sourceHealthDisplay.ts
+++ b/platform/app/ee/governance/dashboard/logic/sourceHealthDisplay.ts
@@ -18,11 +18,18 @@ import { CircleAlert, CircleCheck, CircleDashed, CircleX } from "lucide-react";
  * goes unnoticed for a week.
  *
  * The exception is "disabled". A disabled source is not expected to be
- * pulling, so "Not pulling" is not news about it — it is the state an admin
+ * pulling, so "Pulls failing" is not news about it — it is the state an admin
  * chose, restated in red. Worse, it is unactionable: the reader clicks
  * through to fix an outage and finds nothing wrong. Configuration wins here
  * because health is only interesting about a source we are asking to run.
  */
+/** Refresh visible source health after scheduled pulls, without polling hidden tabs. */
+export const SOURCE_HEALTH_REFRESH = {
+  refetchOnWindowFocus: true,
+  refetchInterval: 30_000,
+  refetchIntervalInBackground: false,
+} as const;
+
 export interface SourceBadge {
   icon: typeof CircleCheck;
   label: string;
@@ -41,7 +48,7 @@ export const SOURCE_STATUS_META: Record<string, SourceBadge> = {
 
 export const SOURCE_UNHEALTHY_META: SourceBadge = {
   icon: CircleAlert,
-  label: "Not pulling",
+  label: "Pulls failing",
   color: "red.500",
 };
 

--- a/platform/app/ee/governance/dashboard/pages/ingestion-source-detail.tsx
+++ b/platform/app/ee/governance/dashboard/pages/ingestion-source-detail.tsx
@@ -14,7 +14,7 @@ import {
   VStack,
 } from "@chakra-ui/react";
 import {
-  noDataSinceNotice,
+  SOURCE_HEALTH_REFRESH,
   sourceBadge,
 } from "@ee/governance/dashboard/logic/sourceHealthDisplay";
 import {
@@ -206,34 +206,55 @@ function SourceDetailHeader({
   );
 }
 
-/**
- * Where the numbers below stop being trustworthy.
- *
- * A source that has failed three runs in a row has not been asked about
- * anything since its last successful pull, so every day after that is
- * unknown -- not a day it spent nothing. Saying so here is what stops a
- * reader taking an empty chart for a cheap week (ADR-128).
- */
-function NoDataSinceCallout({ source }: { source: Source }) {
-  const notice = noDataSinceNotice({
-    status: source.status,
-    errorCount: source.errorCount,
-    lastSuccessAt: source.lastSuccessAt,
-  });
-  if (!notice) return null;
+/** Pull completion time and provider record time answer different questions. */
+function SourcePullStatus({ source }: { source: Source }) {
+  if (!source.pullSchedule) return null;
+  const pull = source.pullStatus;
+  const retrying = source.status !== "disabled" && !source.archivedAt;
   return (
-    <Box
+    <VStack
+      align="stretch"
+      gap={2}
       borderWidth="1px"
-      borderColor="red.200"
-      borderRadius="sm"
-      background="red.50"
+      borderRadius="md"
       padding={3}
     >
-      <Text fontSize="sm" color="red.700">
-        No data since {fmtRelative(notice.lastSuccessIso)}. This source is
-        failing to pull, so spend after that point is unknown rather than zero.
+      <Text fontSize="sm">
+        Last successful pull:{" "}
+        {source.lastSuccessAt
+          ? new Date(source.lastSuccessAt).toLocaleString()
+          : "No successful pull yet"}
       </Text>
-    </Box>
+      {pull?.lastRunAt && (
+        <Text fontSize="sm">
+          Last attempt: {new Date(pull.lastRunAt).toLocaleString()} (
+          {pull.outcome})
+        </Text>
+      )}
+      {pull?.error && (
+        <Text fontSize="sm" color="red.600">
+          {pull.error}{" "}
+          {retrying
+            ? "The next scheduled pull will retry."
+            : "This source is disabled."}{" "}
+          Saved records may be incomplete.
+        </Text>
+      )}
+      {pull?.backfillThrough && (
+        <Text fontSize="sm">
+          Backfill reached: {new Date(pull.backfillThrough).toLocaleString()}.
+          This is the latest saved checkpoint.
+        </Text>
+      )}
+      {pull?.hasMore && (
+        <Text fontSize="sm" color="fg.muted">
+          More history remains.
+          {retrying
+            ? " The next scheduled pull continues from the saved checkpoint."
+            : " Resume the source to continue."}
+        </Text>
+      )}
+    </VStack>
   );
 }
 
@@ -324,7 +345,7 @@ function SourceActivityPanels({
   const health = healthQuery.data;
   return (
     <>
-      <NoDataSinceCallout source={source} />
+      <SourcePullStatus source={source} />
       <SourceHealthCards
         health={health}
         error={healthQuery.error}
@@ -462,13 +483,16 @@ function useIngestionSourceDetailPage() {
 
   const sourceQuery = api.ingestionSources.get.useQuery(
     { organizationId: orgId, id: sourceId ?? "" },
-    { enabled: !!orgId && !!sourceId && canRead, refetchOnWindowFocus: false },
+    {
+      enabled: !!orgId && !!sourceId && canRead,
+      ...SOURCE_HEALTH_REFRESH,
+    },
   );
   const healthQuery = api.activityMonitor.sourceHealthMetrics.useQuery(
     { organizationId: orgId, sourceId: sourceId ?? "" },
     {
-      enabled: !!orgId && !!sourceId && canReadActivity,
-      refetchOnWindowFocus: false,
+      enabled: !!orgId && !!sourceId && canRead && canReadActivity,
+      ...SOURCE_HEALTH_REFRESH,
     },
   );
   // The events table walks the timestamp cursor itself (see
@@ -699,13 +723,6 @@ function StaleTimestampCallout({
   health: SourceHealthMetrics | null;
   eventsCount: number;
 }) {
-  // F-OTEL-2 frontend leg (Sergey diagnosis): if health metrics show 0
-  // events across 24h/7d/30d but the events list has rows, the user
-  // most likely sent test events with stale `startTimeUnixNano`. CH
-  // health queries filter by EventTimestamp, the events list does not
-  // - they appear contradictory. Surface a callout that names the
-  // diagnosis + the fix (use Date.now() at the moment you fire the
-  // event).
   if (!health) return null;
   const all30dZero =
     (health.events24h ?? 0) === 0 &&
@@ -713,24 +730,11 @@ function StaleTimestampCallout({
     (health.events30d ?? 0) === 0;
   if (!all30dZero || eventsCount === 0) return null;
   return (
-    <Box
-      borderWidth="1px"
-      borderColor="amber.300"
-      backgroundColor="amber.50"
-      padding={3}
-      borderRadius="md"
-    >
-      <Text fontSize="sm" color="amber.900">
-        <strong>Heads up:</strong> the events table below has loaded{" "}
-        {eventsCount} event
-        {eventsCount === 1 ? "" : "s"}, but the rolling
-        24h&nbsp;/&nbsp;7d&nbsp;/&nbsp;30d health windows are all zero. Your
-        events likely have a stale <Code fontSize="xs">startTimeUnixNano</Code>{" "}
-        (timestamps before today). When firing test events, set{" "}
-        <Code fontSize="xs">startTimeUnixNano</Code> to{" "}
-        <Code fontSize="xs">String(Date.now() * 1_000_000)</Code> so the event
-        lands inside the rolling window. The secret-reveal modal&apos;s
-        &quot;Test it now&quot; curl already does this for you.
+    <Box borderWidth="1px" borderColor="border" padding={3} borderRadius="md">
+      <Text fontSize="sm" color="fg.muted">
+        The table contains older records outside the last 30 days. Recent
+        counters use each record's original date, so historical imports can show
+        records here while those counters remain zero.
       </Text>
     </Box>
   );

--- a/platform/app/ee/governance/dashboard/pages/inventory.tsx
+++ b/platform/app/ee/governance/dashboard/pages/inventory.tsx
@@ -98,6 +98,7 @@ import { useActivePlan } from "~/hooks/useActivePlan";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 import { api } from "~/utils/api";
 import { SAMPLE_INGESTION_SOURCES } from "../components/sampleIngestionSources";
+import { SOURCE_HEALTH_REFRESH } from "../logic/sourceHealthDisplay";
 import {
   type DestinationContext,
   type Source,
@@ -528,7 +529,7 @@ function useInventoryPanes({
     { organizationId: orgId },
     {
       enabled: !!orgId && canRead && canReadActivity,
-      refetchOnWindowFocus: false,
+      ...SOURCE_HEALTH_REFRESH,
       retry: false,
     },
   );
@@ -595,7 +596,7 @@ function useIngestionSourcesPage() {
 
   const sourcesQuery = api.ingestionSources.list.useQuery(
     { organizationId: orgId },
-    { enabled: !!orgId && canRead, refetchOnWindowFocus: false },
+    { enabled: !!orgId && canRead, ...SOURCE_HEALTH_REFRESH },
   );
 
   const panes = useInventoryPanes({

--- a/platform/app/ee/governance/repositories/governanceIdentity.repository.ts
+++ b/platform/app/ee/governance/repositories/governanceIdentity.repository.ts
@@ -176,6 +176,35 @@ export class DiscoveredPersonRepository {
     });
   }
 
+  /**
+   * The people behind a batch of provider identifiers, keyed the way a pull
+   * arrives: by the identifier the provider used, not by our own row id.
+   *
+   * Scoped by provider as well as organization because `rawActorId` only means
+   * something relative to the provider that issued it — the same opaque id at
+   * two providers is two people, and `DiscoveredPerson` is unique on the triple
+   * for exactly that reason. An empty list short-circuits so a batch that
+   * proved nobody pays no query.
+   */
+  async findByActorIds(
+    client: Client,
+    params: {
+      organizationId: string;
+      provider: string;
+      rawActorIds: string[];
+    },
+  ): Promise<{ id: string; rawActorId: string }[]> {
+    if (params.rawActorIds.length === 0) return [];
+    return await client.discoveredPerson.findMany({
+      where: {
+        organizationId: params.organizationId,
+        provider: params.provider,
+        rawActorId: { in: params.rawActorIds },
+      },
+      select: { id: true, rawActorId: true },
+    });
+  }
+
   /** The identity screen's read: an organization's people, newest-seen first. */
   listByOrganization(client: Client, params: { organizationId: string }) {
     return client.discoveredPerson.findMany({

--- a/platform/app/ee/governance/routers/__tests__/governanceCostSpenders.integration.test.ts
+++ b/platform/app/ee/governance/routers/__tests__/governanceCostSpenders.integration.test.ts
@@ -247,6 +247,61 @@ describe("governanceCost.spenders — router integration", () => {
     return appRouter.createCaller(ctx);
   }
 
+  /** @scenario "Provider totals use corrected rollup cells within the selected window" */
+  it("aggregates only surviving pulled cells by provider, including unnamed costs", async () => {
+    const repo = new GovernanceCostRollupClickHouseRepository(async () => ch);
+    const providerTenant = `providers-${ns}`;
+    const stamp = Date.now();
+    const seed = (overrides: Partial<GovernanceCostRollupRow>) =>
+      repo.upsert(
+        cell({ TenantId: providerTenant, EventTimestamp: stamp, ...overrides }),
+      );
+    await seed({ AmountNanoUsd: 10 * NANO });
+    await seed({ AmountNanoUsd: 6 * NANO, EventTimestamp: stamp + 1 });
+    await seed({ RawActorId: "named-person", AmountNanoUsd: 3 * NANO });
+    await seed({ Model: "refund", AmountNanoUsd: -2 * NANO });
+    await seed({ Provider: "anthropic_admin", AmountNanoUsd: 20 * NANO });
+    await seed({
+      Provider: "anthropic_admin",
+      AmountNanoUsd: null,
+      EventTimestamp: stamp + 1,
+    });
+    await seed({
+      CostSource: GOVERNANCE_COST_SOURCE.GATEWAY,
+      AmountNanoUsd: 500 * NANO,
+    });
+    await seed({
+      Day: new Date(Date.parse(day) - 86_400_000).toISOString().slice(0, 10),
+      AmountNanoUsd: 500 * NANO,
+    });
+    await seed({
+      Version: "old-projection",
+      Model: "old",
+      AmountNanoUsd: 500 * NANO,
+    });
+
+    expect(
+      await repo.sumWindowByProvider({
+        tenantId: providerTenant,
+        fromDay: day,
+        toDay: day,
+      }),
+    ).toEqual([
+      {
+        provider: "anthropic_admin",
+        amountNanoUsd: null,
+        cellsWithoutAmount: 1,
+        currenciesWithoutUsdAmount: [],
+      },
+      {
+        provider: "openai_admin",
+        amountNanoUsd: 7 * NANO,
+        cellsWithoutAmount: 0,
+        currenciesWithoutUsdAmount: [],
+      },
+    ]);
+  });
+
   describe("given pulled cost recorded under a spender discovery has seen", () => {
     /** @scenario The cost screen shows who spent the pulled money */
     it("lists that spender with their window total, labeled with the display text", async () => {
@@ -285,6 +340,9 @@ describe("governanceCost.spenders — router integration", () => {
         windowDays: 30,
       });
       expect(summary.unavailableReason).toBeNull();
+      expect(summary.providers).toEqual([
+        { provider: "openai_admin", amountUsd: 7, cellsWithoutAmount: 0 },
+      ]);
     });
   });
 });

--- a/platform/app/ee/governance/routers/__tests__/ingestionSourceDto.unit.test.ts
+++ b/platform/app/ee/governance/routers/__tests__/ingestionSourceDto.unit.test.ts
@@ -34,6 +34,67 @@ const row = (overrides: Record<string, unknown> = {}) =>
     ...overrides,
   }) as Parameters<typeof toIngestionSourceDto>[0]["row"];
 
+describe("a source's latest pull result", () => {
+  it("distinguishes provider rate limits from a busy local database", () => {
+    const dto = toIngestionSourceDto({
+      row: row(),
+      liveTraceProjectIds: new Set(),
+      pullRun: {
+        LastRunAt: 1,
+        LastRunOutcome: "failed",
+        LastRunError: "Anthropic rate limit exceeded (HTTP 429).",
+      },
+    });
+    expect(dto.pullStatus.error).toBe(
+      "The provider's request limit was reached.",
+    );
+  });
+  it("shows a safe failure reason and saved billing progress without exposing provider tokens or error payloads", () => {
+    const dto = toIngestionSourceDto({
+      row: row({
+        sourceType: "anthropic_admin",
+        pollerCursor: JSON.stringify({
+          startingAt: "2026-01-01T00:00:00Z",
+          watermark: "2026-02-01T00:00:00Z",
+          page: "private-page-token",
+        }),
+      }),
+      liveTraceProjectIds: new Set(),
+      pullRun: {
+        LastRunAt: Date.parse("2026-02-02T12:00:00Z"),
+        LastRunOutcome: "failed",
+        LastRunError: "Too many simultaneous queries; private upstream payload",
+      },
+    });
+    expect(dto.pullStatus).toEqual({
+      lastRunAt: "2026-02-02T12:00:00.000Z",
+      outcome: "failed",
+      error: "The database is busy.",
+      backfillThrough: "2026-02-01T00:00:00.000Z",
+      hasMore: true,
+    });
+    expect(JSON.stringify(dto)).not.toContain("private");
+  });
+
+  it("does not present an unstarted or unreadable cursor as completed history", () => {
+    for (const pollerCursor of [
+      null,
+      "not-json",
+      JSON.stringify({
+        startingAt: "2026-01-01T00:00:00Z",
+        page: "private",
+        watermark: null,
+      }),
+    ]) {
+      const dto = toIngestionSourceDto({
+        row: row({ sourceType: "openai_admin", pollerCursor }),
+        liveTraceProjectIds: new Set(),
+      });
+      expect(dto.pullStatus?.backfillThrough).toBeNull();
+    }
+  });
+});
+
 describe("given an ingestion source with a trace destination", () => {
   describe("when the destination is still a live project of this org", () => {
     it("reports it as not archived", () => {

--- a/platform/app/ee/governance/routers/ingestionSources.ts
+++ b/platform/app/ee/governance/routers/ingestionSources.ts
@@ -30,6 +30,10 @@ import {
   OTTL_ENABLED_SOURCE_TYPES,
 } from "@ee/governance/services/activity-monitor/ottlStarterTemplates";
 import { hasPollerCursor } from "@ee/governance/services/pullers/pollerCursor";
+import {
+  type PullRunSummary,
+  sourcePullStatus,
+} from "@ee/governance/services/pullers/sourcePullStatus";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 
@@ -58,6 +62,7 @@ const statusSchema = z.enum(["active", "disabled", "awaiting_first_event"]);
 export function toIngestionSourceDto({
   row,
   liveTraceProjectIds,
+  pullRun,
 }: {
   row: {
     id: string;
@@ -97,6 +102,7 @@ export function toIngestionSourceDto({
    * is the one thing the drawer must say and cannot work out for itself.
    */
   liveTraceProjectIds: ReadonlySet<string>;
+  pullRun?: PullRunSummary | null;
 }) {
   const parser = (row.parserConfig as Record<string, unknown>) ?? {};
   const safeParser = Object.fromEntries(
@@ -150,6 +156,11 @@ export function toIngestionSourceDto({
      */
     errorCount: row.errorCount,
     lastSuccessAt: row.lastSuccessAt,
+    pullStatus: sourcePullStatus({
+      sourceType: row.sourceType,
+      cursor: row.pollerCursor,
+      pullRun,
+    }),
     traceProjectId: row.traceProjectId,
     traceProjectArchived: row.traceProjectId
       ? !liveTraceProjectIds.has(row.traceProjectId)
@@ -204,7 +215,17 @@ export const ingestionSourcesRouter = createTRPCRouter({
         // client has to sniff out of the tRPC envelope.
         throw new IngestionSourceNotFoundError(input.id);
       }
-      return dtoForRow(service, row, input.organizationId);
+      const pullRun = row.pullSchedule
+        ? await service.lastPullRun({
+            sourceId: row.id,
+            organizationId: input.organizationId,
+          })
+        : null;
+      const liveTraceProjectIds = await service.liveTraceProjectIds(
+        [row],
+        input.organizationId,
+      );
+      return toIngestionSourceDto({ row, liveTraceProjectIds, pullRun });
     }),
 
   /**

--- a/platform/app/ee/governance/services/__tests__/directoryDepartmentSync.integration.test.ts
+++ b/platform/app/ee/governance/services/__tests__/directoryDepartmentSync.integration.test.ts
@@ -243,6 +243,7 @@ describe("Feature: directory departments land on the entities we already have", 
 
       const outcome = await service().applyDirectoryEvents({
         organizationId,
+        provider: PROVIDER,
         events: [
           directoryEvent({
             actor: JONAS_OID,

--- a/platform/app/ee/governance/services/__tests__/directoryDepartmentSync.integration.test.ts
+++ b/platform/app/ee/governance/services/__tests__/directoryDepartmentSync.integration.test.ts
@@ -19,6 +19,7 @@ import { prisma } from "~/server/db";
 import { cleanupTestRows } from "~/test-utils/cleanupTestRows";
 import { DepartmentService } from "../department/department.service";
 import { DirectoryDepartmentSyncService } from "../directoryDepartmentSync.service";
+import { COPILOT_STUDIO_DATAVERSE_ADAPTER_ID } from "../pullers/dataverseEnvironment";
 import { DIRECTORY_REPORT_ACTION } from "../pullers/microsoftGraphDirectory";
 import type { NormalizedPullEvent } from "../pullers/pullerAdapter";
 
@@ -33,6 +34,9 @@ const JONAS_OID = "f6481ec4-0000-4000-8000-000000000002";
 const STRANGER_OID = "f6481ec4-0000-4000-8000-000000000003";
 
 const service = () => DirectoryDepartmentSyncService.create(prisma);
+
+/** The source type the same pull records its discovered people under. */
+const PROVIDER = COPILOT_STUDIO_DATAVERSE_ADAPTER_ID;
 
 const directoryEvent = (over: {
   actor: string;
@@ -155,6 +159,7 @@ describe("Feature: directory departments land on the entities we already have", 
 
     const outcome = await service().applyDirectoryEvents({
       organizationId,
+      provider: PROVIDER,
       events: [
         directoryEvent({
           actor: MARIA_OID,
@@ -174,6 +179,7 @@ describe("Feature: directory departments land on the entities we already have", 
   it("creates a department the organization has not created yet — the SCIM costCenter call", async () => {
     await service().applyDirectoryEvents({
       organizationId,
+      provider: PROVIDER,
       events: [
         directoryEvent({
           actor: MARIA_OID,
@@ -191,6 +197,7 @@ describe("Feature: directory departments land on the entities we already have", 
   it("assigns through the SSO connection's directory id when no address is confirmed", async () => {
     const outcome = await service().applyDirectoryEvents({
       organizationId,
+      provider: PROVIDER,
       events: [
         directoryEvent({
           actor: JONAS_OID,
@@ -254,6 +261,7 @@ describe("Feature: directory departments land on the entities we already have", 
   it("assigns nobody from a row that proves nobody, and creates no department for it", async () => {
     const outcome = await service().applyDirectoryEvents({
       organizationId,
+      provider: PROVIDER,
       events: [
         directoryEvent({
           actor: STRANGER_OID,
@@ -279,6 +287,7 @@ describe("Feature: directory departments land on the entities we already have", 
 
     await service().applyDirectoryEvents({
       organizationId,
+      provider: PROVIDER,
       events: [
         directoryEvent({
           actor: MARIA_OID,
@@ -302,10 +311,12 @@ describe("Feature: directory departments land on the entities we already have", 
 
     const first = await service().applyDirectoryEvents({
       organizationId,
+      provider: PROVIDER,
       events,
     });
     const second = await service().applyDirectoryEvents({
       organizationId,
+      provider: PROVIDER,
       events,
     });
 
@@ -329,6 +340,7 @@ describe("Feature: directory departments land on the entities we already have", 
 
     const outcome = await service().applyDirectoryEvents({
       organizationId,
+      provider: PROVIDER,
       events: [
         directoryEvent({
           actor: MARIA_OID,

--- a/platform/app/ee/governance/services/__tests__/directoryDepartmentSync.unit.test.ts
+++ b/platform/app/ee/governance/services/__tests__/directoryDepartmentSync.unit.test.ts
@@ -1,0 +1,255 @@
+// SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+
+/**
+ * @vitest-environment node
+ *
+ * What the department sync does with an identity link that already exists.
+ *
+ * The proof rule itself is exercised against real join paths in
+ * `directoryDepartmentSync.integration.test.ts`; this file is the seam above
+ * it — every read is a stub, so the only thing under test is which account a
+ * directory row's department lands on when an accepted link disagrees with the
+ * directory index.
+ *
+ * Spec: specs/governance/governance-people-discovery.feature
+ * Decision: ADR-128 §12
+ */
+import { describe, expect, it } from "vitest";
+
+import type { PrismaClient } from "~/generated/prisma/client";
+import type {
+  DiscoveredPersonRepository,
+  IdentityMatchRepository,
+} from "../../repositories/governanceIdentity.repository";
+import type { DepartmentService } from "../department/department.service";
+import { DirectoryDepartmentSyncService } from "../directoryDepartmentSync.service";
+import type { IdentityMatchService } from "../identityMatch.service";
+import { COPILOT_STUDIO_DATAVERSE_ADAPTER_ID } from "../pullers/dataverseEnvironment";
+import { DIRECTORY_REPORT_ACTION } from "../pullers/microsoftGraphDirectory";
+import type { NormalizedPullEvent } from "../pullers/pullerAdapter";
+
+const organizationId = "org_dirdept_unit";
+const provider = COPILOT_STUDIO_DATAVERSE_ADAPTER_ID;
+
+const MARIA_OID = "f6481ec4-0000-4000-8000-0000000000a1";
+const LINKED_USER = "user_linked";
+const DIRECTORY_USER = "user_from_stale_directory_id";
+const DEPARTMENT_ID = "dept_engineering";
+
+const directoryEvent = ({
+  actor,
+  mail = "",
+  department,
+}: {
+  actor: string;
+  mail?: string;
+  department: string;
+}): NormalizedPullEvent => ({
+  source_event_id: "dir_1",
+  event_timestamp: "2026-09-03T00:00:00.000Z",
+  actor,
+  action: DIRECTORY_REPORT_ACTION,
+  target: department,
+  cost_usd: "0",
+  tokens_input: 0,
+  tokens_output: 0,
+  raw_payload: "{}",
+  extra: { directoryId: actor, mail, department },
+});
+
+/**
+ * The two reads `assignWhereChanged` makes straight off the client, stubbed so
+ * every candidate reads as a member of the organization carrying no department
+ * yet — the state in which any assignment at all is a write.
+ */
+const prismaStub = () =>
+  ({
+    organizationUser: {
+      findMany: async ({ where }: { where: { userId: { in: string[] } } }) =>
+        where.userId.in.map((userId) => ({ userId, departmentId: null })),
+    },
+    departmentMembershipHistory: { findMany: async () => [] },
+  }) as unknown as PrismaClient;
+
+/** Records every assignment the sync asked for, in order. */
+const departmentsStub = () => {
+  const assignments: { userId: string; departmentId: string | null }[] = [];
+  const service = {
+    resolveByNameOrCreate: async () => ({ id: DEPARTMENT_ID }),
+    assignUser: async (params: {
+      organizationId: string;
+      userId: string;
+      departmentId: string | null;
+    }) => {
+      assignments.push({
+        userId: params.userId,
+        departmentId: params.departmentId,
+      });
+    },
+  } as unknown as DepartmentService;
+  return { service, assignments };
+};
+
+const matcherStub = ({
+  usersByVerifiedEmail = new Map<string, string[]>(),
+  usersByDirectoryId = new Map<string, string[]>(),
+}: {
+  usersByVerifiedEmail?: Map<string, string[]>;
+  usersByDirectoryId?: Map<string, string[]>;
+}) =>
+  ({
+    loadAccountIndex: async () => ({
+      usersByVerifiedEmail,
+      usersByDirectoryId,
+    }),
+  }) as unknown as IdentityMatchService;
+
+const peopleStub = (rows: { id: string; rawActorId: string }[]) =>
+  ({
+    findByActorIds: async () => rows,
+  }) as unknown as DiscoveredPersonRepository;
+
+const matchesStub = (
+  rows: { discoveredPersonId: string; userId: string | null }[],
+) =>
+  ({
+    findOpenByOrganization: async () => rows,
+  }) as unknown as IdentityMatchRepository;
+
+describe("Feature: the department sync reads the accepted identity link", () => {
+  describe("given the directory row's identifier names a different account than the accepted link", () => {
+    /** @scenario "An accepted identity link outranks a disagreeing directory row" */
+    it("assigns the department to the linked account and never to the directory's", async () => {
+      const departments = departmentsStub();
+      const service = new DirectoryDepartmentSyncService({
+        prisma: prismaStub(),
+        departments: departments.service,
+        // A stale `ScimExternalId` still points this directory id at somebody
+        // else. No confirmed address is in play, so nothing else can settle it.
+        matcher: matcherStub({
+          usersByDirectoryId: new Map([[MARIA_OID, [DIRECTORY_USER]]]),
+        }),
+        discoveredPeople: peopleStub([
+          { id: "person_1", rawActorId: MARIA_OID },
+        ]),
+        matches: matchesStub([
+          { discoveredPersonId: "person_1", userId: LINKED_USER },
+        ]),
+      });
+
+      const outcome = await service.applyDirectoryEvents({
+        organizationId,
+        provider,
+        events: [
+          directoryEvent({ actor: MARIA_OID, department: "Engineering" }),
+        ],
+      });
+
+      expect(outcome.assigned).toBe(1);
+      expect(departments.assignments).toEqual([
+        { userId: LINKED_USER, departmentId: DEPARTMENT_ID },
+      ]);
+    });
+  });
+
+  describe("given the person holds no identity link", () => {
+    it("assigns through the directory identifier exactly as before", async () => {
+      const departments = departmentsStub();
+      const service = new DirectoryDepartmentSyncService({
+        prisma: prismaStub(),
+        departments: departments.service,
+        matcher: matcherStub({
+          usersByDirectoryId: new Map([[MARIA_OID, [DIRECTORY_USER]]]),
+        }),
+        discoveredPeople: peopleStub([
+          { id: "person_1", rawActorId: MARIA_OID },
+        ]),
+        matches: matchesStub([]),
+      });
+
+      const outcome = await service.applyDirectoryEvents({
+        organizationId,
+        provider,
+        events: [
+          directoryEvent({ actor: MARIA_OID, department: "Engineering" }),
+        ],
+      });
+
+      expect(outcome.assigned).toBe(1);
+      expect(departments.assignments).toEqual([
+        { userId: DIRECTORY_USER, departmentId: DEPARTMENT_ID },
+      ]);
+    });
+  });
+
+  describe("given a confirmed address names an account the accepted link does not", () => {
+    it("assigns nobody, because the contradiction halts the row", async () => {
+      const departments = departmentsStub();
+      const service = new DirectoryDepartmentSyncService({
+        prisma: prismaStub(),
+        departments: departments.service,
+        matcher: matcherStub({
+          usersByVerifiedEmail: new Map([
+            ["m.silva@acme.test", [DIRECTORY_USER]],
+          ]),
+        }),
+        discoveredPeople: peopleStub([
+          { id: "person_1", rawActorId: MARIA_OID },
+        ]),
+        matches: matchesStub([
+          { discoveredPersonId: "person_1", userId: LINKED_USER },
+        ]),
+      });
+
+      const outcome = await service.applyDirectoryEvents({
+        organizationId,
+        provider,
+        events: [
+          directoryEvent({
+            actor: MARIA_OID,
+            mail: "m.silva@acme.test",
+            department: "Engineering",
+          }),
+        ],
+      });
+
+      expect(outcome.assigned).toBe(0);
+      expect(departments.assignments).toEqual([]);
+    });
+  });
+
+  describe("given an erasure blanked the account off the link", () => {
+    it("treats the person as unlinked rather than as spoken for", async () => {
+      const departments = departmentsStub();
+      const service = new DirectoryDepartmentSyncService({
+        prisma: prismaStub(),
+        departments: departments.service,
+        matcher: matcherStub({
+          usersByDirectoryId: new Map([[MARIA_OID, [DIRECTORY_USER]]]),
+        }),
+        discoveredPeople: peopleStub([
+          { id: "person_1", rawActorId: MARIA_OID },
+        ]),
+        // What `findOpenByOrganization` actually returns for a blanked link:
+        // nothing. Stubbed as the row it filters out would be, so a future
+        // change that stops filtering fails here rather than in production.
+        matches: matchesStub([
+          { discoveredPersonId: "person_1", userId: null },
+        ]),
+      });
+
+      const outcome = await service.applyDirectoryEvents({
+        organizationId,
+        provider,
+        events: [
+          directoryEvent({ actor: MARIA_OID, department: "Engineering" }),
+        ],
+      });
+
+      expect(outcome.assigned).toBe(1);
+      expect(departments.assignments).toEqual([
+        { userId: DIRECTORY_USER, departmentId: DEPARTMENT_ID },
+      ]);
+    });
+  });
+});

--- a/platform/app/ee/governance/services/__tests__/governanceCost.service.unit.test.ts
+++ b/platform/app/ee/governance/services/__tests__/governanceCost.service.unit.test.ts
@@ -112,6 +112,16 @@ function rollupReturning({
 } = {}) {
   return {
     sumDaysByLane: vi.fn().mockResolvedValue(rows),
+    sumWindowByProvider: vi.fn().mockResolvedValue(
+      rows
+        .filter((row) => row.costSource === "pulled")
+        .map((row) => ({
+          provider: "openai_admin",
+          amountNanoUsd: row.amountNanoUsd,
+          cellsWithoutAmount: row.cellsWithoutAmount,
+          currenciesWithoutUsdAmount: row.currenciesWithoutUsdAmount,
+        })),
+    ),
     hasRowsForSource: vi.fn().mockResolvedValue(hasSourceRows),
   } as unknown as GovernanceCostRollupClickHouseRepository;
 }
@@ -138,6 +148,70 @@ function laneRow(
 const NANO = 1_000_000_000;
 
 describe("GovernanceCostService.summary", () => {
+  it("keeps the billed headline and provider costs on the same read during ingestion", async () => {
+    const costRollup = rollupReturning({
+      rows: [laneRow({ costSource: "pulled", amountNanoUsd: 100 * NANO })],
+    });
+    Object.assign(costRollup, {
+      sumWindowByProvider: vi.fn().mockResolvedValue([
+        {
+          provider: "openai_admin",
+          amountNanoUsd: 101 * NANO,
+          cellsWithoutAmount: 0,
+          currenciesWithoutUsdAmount: [],
+        },
+      ]),
+    });
+    const result = await createService({
+      prisma: prismaWithGovProject("gov-1"),
+      costRollup,
+    }).summary({ organizationId: "org-1", windowDays: 7 });
+    expect(result.billed.amountUsd).toBe(101);
+    expect(result.providers[0]?.amountUsd).toBe(result.billed.amountUsd);
+  });
+  it("reads provider amounts for the same tenant and window and withholds incomplete USD", async () => {
+    const costRollup = rollupReturning();
+    const readProviders = vi.fn().mockResolvedValue([
+      {
+        provider: "openai_admin",
+        amountNanoUsd: 3 * NANO,
+        cellsWithoutAmount: 0,
+        currenciesWithoutUsdAmount: [],
+      },
+      {
+        provider: "anthropic_admin",
+        amountNanoUsd: 9 * NANO,
+        cellsWithoutAmount: 1,
+        currenciesWithoutUsdAmount: ["EUR"],
+      },
+      {
+        provider: "copilot_studio",
+        amountNanoUsd: -2 * NANO,
+        cellsWithoutAmount: 0,
+        currenciesWithoutUsdAmount: [],
+      },
+    ]);
+    Object.assign(costRollup, { sumWindowByProvider: readProviders });
+    const service = createService({
+      prisma: prismaWithGovProject("gov-1"),
+      costRollup,
+    });
+    const result = await service.summary({
+      organizationId: "org-1",
+      windowDays: 7,
+      now: new Date("2026-08-07T12:00:00Z"),
+    });
+    expect(readProviders).toHaveBeenCalledWith({
+      tenantId: "gov-1",
+      fromDay: "2026-08-01",
+      toDay: "2026-08-07",
+    });
+    expect(result.providers).toEqual([
+      { provider: "openai_admin", amountUsd: 3, cellsWithoutAmount: 0 },
+      { provider: "anthropic_admin", amountUsd: null, cellsWithoutAmount: 1 },
+      { provider: "copilot_studio", amountUsd: -2, cellsWithoutAmount: 0 },
+    ]);
+  });
   describe("given a deployment with no cost store", () => {
     describe("when requesting the summary", () => {
       it("reports unavailable with null amounts rather than zeros", async () => {
@@ -624,6 +698,7 @@ describe("GovernanceCostService.summary", () => {
         const service = createService({
           prisma: prismaWithGovProject("gov-1"),
           costRollup: {
+            sumWindowByProvider: vi.fn().mockResolvedValue([]),
             sumDaysByLane: vi
               .fn()
               .mockRejectedValue(new Error("cost rollup is down")),

--- a/platform/app/ee/governance/services/activity-monitor/__tests__/activityMonitorPulledEvents.unit.test.ts
+++ b/platform/app/ee/governance/services/activity-monitor/__tests__/activityMonitorPulledEvents.unit.test.ts
@@ -232,6 +232,61 @@ describe("ActivityMonitorService pulled and pushed source events", () => {
     );
   });
 
+  describe("given a provider that names the actor by an opaque id", () => {
+    describe("when the stored row therefore has no actor email", () => {
+      it("attributes the event to the opaque id rather than to nobody", async () => {
+        // The OpenAI cost report sends `user-…` and no address, so the audit
+        // row carries it in ActorUserId and leaves ActorEmail blank. Reading
+        // the email alone would blank the actor column for every OpenAI row.
+        query.mockImplementation(async ({ query: sql }: { query: string }) => ({
+          json: async () =>
+            sql.includes("governance_ocsf_events")
+              ? [
+                  {
+                    eventId: "openai-cost-line",
+                    eventType: "openai_admin",
+                    actorUserId: "user-A1b2C3d4E5",
+                    actorEmail: "",
+                    actorEnduserId: "",
+                    action: "cost_report",
+                    target: "gpt-5-mini",
+                    occurredMs: "1786619820000",
+                    createdMs: "1786619821000",
+                    rawPayload: JSON.stringify({
+                      metadata: { extension: { cost_usd: 1.25 } },
+                    }),
+                  },
+                ]
+              : [],
+        }));
+
+        const prisma = {
+          project: { findFirst: vi.fn(async () => ({ id: "gov-project" })) },
+        };
+        const service = ActivityMonitorService.create({
+          prisma: prisma as never,
+          repository: new ActivityMonitorClickHouseRepository(
+            async () => ({ query }) as never,
+          ),
+        });
+
+        const rows = await service.eventsForSource({
+          organizationId: "org",
+          sourceId: "source",
+          limit: 50,
+        });
+
+        expect(rows[0]).toEqual(
+          expect.objectContaining({
+            eventId: "openai-cost-line",
+            actor: "user-A1b2C3d4E5",
+            action: "cost_report",
+          }),
+        );
+      });
+    });
+  });
+
   it("includes pulled OCSF events in source health counts and last event", async () => {
     const prisma = {
       project: { findFirst: vi.fn(async () => ({ id: "gov-project" })) },

--- a/platform/app/ee/governance/services/activity-monitor/__tests__/sourceHealthHistory.integration.test.ts
+++ b/platform/app/ee/governance/services/activity-monitor/__tests__/sourceHealthHistory.integration.test.ts
@@ -1,0 +1,98 @@
+/** @vitest-environment node */
+import { randomUUID } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  getTestClickHouseClient,
+  startTestContainers,
+  stopTestContainers,
+} from "~/server/event-sourcing/__tests__/integration/testContainers";
+import { ActivityMonitorHealthClickHouseRepository } from "../activityMonitor.health.clickhouse.repository";
+
+describe("source health during a historical provider import", () => {
+  beforeAll(async () => {
+    await startTestContainers();
+  });
+  afterAll(async () => {
+    await stopTestContainers();
+  });
+  it.each([
+    "pulled",
+    "traced",
+    "logged",
+  ] as const)("keeps %s counts at zero while reporting the newest historical event, scoped to this source and tenant", async (kind) => {
+    const ch = getTestClickHouseClient()!;
+    const tenantId = `health-history-${randomUUID()}`;
+    const old = Date.now() - 90 * 86_400_000;
+    const timestamp = (ms: number) =>
+      new Date(ms).toISOString().replace("T", " ").replace("Z", "");
+    const table = {
+      pulled: "governance_ocsf_events",
+      traced: "trace_summaries",
+      logged: "stored_log_records",
+    }[kind];
+    const records = [
+      { tenant: tenantId, source: "source", id: "old", time: old },
+      { tenant: tenantId, source: "other", id: "other", time: Date.now() },
+      {
+        tenant: `${tenantId}-other`,
+        source: "source",
+        id: "foreign",
+        time: Date.now(),
+      },
+    ];
+    const values = records.map(({ tenant, source, id, time }) => {
+      const base = { TenantId: tenant, TraceId: `pull:${id}` };
+      if (kind === "pulled")
+        return {
+          ...base,
+          SourceId: source,
+          EventId: id,
+          EventTime: timestamp(time),
+        };
+      const attrs = {
+        "langwatch.origin.kind": "ingestion_source",
+        "langwatch.ingestion_source.id": source,
+      };
+      return {
+        ...base,
+        ProjectionId: id,
+        Attributes: attrs,
+        CreatedAt: timestamp(time),
+        UpdatedAt: timestamp(time),
+        ...(kind === "traced"
+          ? { OccurredAt: timestamp(time), Version: "v1" }
+          : { TimeUnixMs: timestamp(time) }),
+      };
+    });
+    await ch.insert({
+      table,
+      format: "JSONEachRow",
+      values,
+      clickhouse_settings: { async_insert: 0 },
+    });
+    const repository = new ActivityMonitorHealthClickHouseRepository(
+      async () => ch,
+    );
+    const methods = {
+      pulled: "findPulledEventWindowCounts",
+      traced: "findTracedEventWindowCounts",
+      logged: "findLoggedEventWindowCounts",
+    } as const;
+    try {
+      const row = await repository[methods[kind]]({
+        tenantId,
+        sourceId: "source",
+        since24h: Date.now() - 86_400_000,
+        since7d: Date.now() - 7 * 86_400_000,
+        since30d: Date.now() - 30 * 86_400_000,
+      });
+      expect(row).toMatchObject({ c24: 0, c7: 0, c30: 0 });
+      expect(Number(row?.lastMs)).toBe(old);
+    } finally {
+      await ch.command({
+        query: `ALTER TABLE ${table} DELETE WHERE TenantId IN ({tenants:Array(String)})`,
+        query_params: { tenants: [tenantId, `${tenantId}-other`] },
+      });
+    }
+  });
+});

--- a/platform/app/ee/governance/services/activity-monitor/activityMonitor.health.clickhouse.repository.ts
+++ b/platform/app/ee/governance/services/activity-monitor/activityMonitor.health.clickhouse.repository.ts
@@ -44,7 +44,9 @@ export class ActivityMonitorHealthClickHouseRepository {
           countIf(ts.OccurredAt >= fromUnixTimestamp64Milli({since24h:UInt64})) AS c24,
           countIf(ts.OccurredAt >= fromUnixTimestamp64Milli({since7d:UInt64})) AS c7,
           count() AS c30,
-          toString(toUnixTimestamp64Milli(max(ts.OccurredAt))) AS lastMs
+          (SELECT toString(toUnixTimestamp64Milli(max(OccurredAt)))
+           FROM trace_summaries
+           WHERE TenantId = {tenantId:String} AND Attributes[{originKey:String}] = {originValue:String} AND Attributes[{sourceKey:String}] = {sourceId:String}) AS lastMs
         FROM trace_summaries ts
         WHERE ts.TenantId = {tenantId:String}
           AND ts.OccurredAt >= fromUnixTimestamp64Milli({since30d:UInt64})
@@ -95,7 +97,9 @@ export class ActivityMonitorHealthClickHouseRepository {
           countIf(lr.TimeUnixMs >= fromUnixTimestamp64Milli({since24h:UInt64})) AS c24,
           countIf(lr.TimeUnixMs >= fromUnixTimestamp64Milli({since7d:UInt64})) AS c7,
           count() AS c30,
-          toString(toUnixTimestamp64Milli(max(lr.TimeUnixMs))) AS lastMs
+          (SELECT toString(toUnixTimestamp64Milli(max(TimeUnixMs)))
+           FROM stored_log_records
+           WHERE TenantId = {tenantId:String} AND Attributes[{originKey:String}] = {originValue:String} AND Attributes[{sourceKey:String}] = {sourceId:String}) AS lastMs
         FROM stored_log_records lr
         WHERE lr.TenantId = {tenantId:String}
           AND lr.TimeUnixMs >= fromUnixTimestamp64Milli({since30d:UInt64})
@@ -139,7 +143,9 @@ export class ActivityMonitorHealthClickHouseRepository {
           countIf(EventTime >= fromUnixTimestamp64Milli({since24h:UInt64})) AS c24,
           countIf(EventTime >= fromUnixTimestamp64Milli({since7d:UInt64})) AS c7,
           count() AS c30,
-          toString(toUnixTimestamp64Milli(max(EventTime))) AS lastMs
+          (SELECT toString(toUnixTimestamp64Milli(max(EventTime)))
+           FROM governance_ocsf_events
+           WHERE TenantId = {tenantId:String} AND startsWith(TraceId, 'pull:') AND SourceId = {sourceId:String}) AS lastMs
         FROM governance_ocsf_events
         WHERE TenantId = {tenantId:String}
           AND startsWith(TraceId, 'pull:')

--- a/platform/app/ee/governance/services/activity-monitor/ingestionSource.service.ts
+++ b/platform/app/ee/governance/services/activity-monitor/ingestionSource.service.ts
@@ -41,6 +41,9 @@ import {
 } from "~/generated/prisma/client";
 import { isEnterpriseTier } from "~/server/api/enterprise";
 import { getApp } from "~/server/app-layer/app";
+import { createTenantId } from "~/server/event-sourcing/domain/tenantId";
+import { resolveGovProjectId } from "../govProject";
+import { PrismaIngestionPullRunProjectionRepository } from "../pullers/repositories/ingestion-pull-run-projection.prisma.repository";
 import { withAzureBillIdentity } from "./azureBillIdentity";
 import {
   type AzureBillReader,
@@ -491,6 +494,27 @@ export class IngestionSourceService {
       where: { organizationId, archivedAt: null },
       orderBy: [{ name: "asc" }],
     });
+  }
+
+  async lastPullRun({
+    sourceId,
+    organizationId,
+  }: {
+    sourceId: string;
+    organizationId: string;
+  }) {
+    const projectId = await resolveGovProjectId({
+      prisma: this.prisma,
+      organizationId,
+    });
+    if (!projectId) return null;
+    const projection = await new PrismaIngestionPullRunProjectionRepository(
+      this.prisma,
+    ).load(sourceId, {
+      tenantId: createTenantId(projectId),
+      aggregateId: sourceId,
+    });
+    return projection?.state ?? null;
   }
 
   /**

--- a/platform/app/ee/governance/services/directoryDepartmentSync.service.ts
+++ b/platform/app/ee/governance/services/directoryDepartmentSync.service.ts
@@ -12,8 +12,9 @@
  * text on the person row.
  *
  * Assignment uses the match engine's conflict rule and account index
- * (`loadAccountIndex`): the directory id the org's SSO connection recorded,
- * or an address a member has CONFIRMED. Directory-only assignment remains
+ * (`loadAccountIndex`): the accepted identity link when the person already
+ * holds one, otherwise the directory id the org's SSO connection recorded, or
+ * an address a member has CONFIRMED. Directory-only assignment remains
  * supported here; opening an identity link has a stricter evidence rule. An
  * unconfirmed address is a claim anyone can type in, and two candidates are
  * a contradiction, not a coin toss — both assign nobody.
@@ -38,6 +39,10 @@
 import { createLogger } from "@langwatch/observability";
 import type { PrismaClient } from "~/generated/prisma/client";
 
+import {
+  DiscoveredPersonRepository,
+  IdentityMatchRepository,
+} from "../repositories/governanceIdentity.repository";
 import { DepartmentService } from "./department/department.service";
 import { IdentityMatchService } from "./identityMatch.service";
 import {
@@ -55,15 +60,29 @@ function extraString(event: NormalizedPullEvent, field: string): string {
   return typeof value === "string" ? value : "";
 }
 
+export interface DirectoryDepartmentSyncDeps {
+  prisma: PrismaClient;
+  departments?: DepartmentService;
+  matcher?: IdentityMatchService;
+  discoveredPeople?: DiscoveredPersonRepository;
+  matches?: IdentityMatchRepository;
+}
+
 export class DirectoryDepartmentSyncService {
   private readonly prisma: PrismaClient;
   private readonly departments: DepartmentService;
   private readonly matcher: IdentityMatchService;
+  private readonly discoveredPeople: DiscoveredPersonRepository;
+  private readonly matches: IdentityMatchRepository;
 
-  constructor({ prisma }: { prisma: PrismaClient }) {
-    this.prisma = prisma;
-    this.departments = DepartmentService.create(prisma);
-    this.matcher = IdentityMatchService.create(prisma);
+  constructor(deps: DirectoryDepartmentSyncDeps) {
+    this.prisma = deps.prisma;
+    this.departments =
+      deps.departments ?? DepartmentService.create(deps.prisma);
+    this.matcher = deps.matcher ?? IdentityMatchService.create(deps.prisma);
+    this.discoveredPeople =
+      deps.discoveredPeople ?? new DiscoveredPersonRepository();
+    this.matches = deps.matches ?? new IdentityMatchRepository();
   }
 
   static create(prisma: PrismaClient): DirectoryDepartmentSyncService {
@@ -73,16 +92,23 @@ export class DirectoryDepartmentSyncService {
   /**
    * Applies whatever department facts a batch of directory events carries.
    *
-   * One account-index load per batch, one department resolve per distinct
-   * name, and no write at all for a member already where the directory says
-   * they belong — the read runs daily, and an idempotent day must cost
-   * nothing.
+   * One account-index load per batch, one open-link load per batch, one
+   * department resolve per distinct name, and no write at all for a member
+   * already where the directory says they belong — the read runs daily, and an
+   * idempotent day must cost nothing.
+   *
+   * `provider` is the source type the same pull recorded its discovered people
+   * under (`personDiscovery.service.ts`), and it is what makes the open-link
+   * read exact: `rawActorId` only identifies somebody relative to the provider
+   * that issued it.
    */
   async applyDirectoryEvents({
     organizationId,
+    provider,
     events,
   }: {
     organizationId: string;
+    provider: string;
     events: NormalizedPullEvent[];
   }): Promise<{ assigned: number }> {
     const rows = events.filter(
@@ -92,14 +118,25 @@ export class DirectoryDepartmentSyncService {
     );
     if (rows.length === 0) return { assigned: 0 };
 
-    const accounts = await this.matcher.loadAccountIndex({ organizationId });
+    const [accounts, openLinkByActor] = await Promise.all([
+      this.matcher.loadAccountIndex({ organizationId }),
+      this.loadOpenLinkByActor({
+        organizationId,
+        provider,
+        rawActorIds: [...new Set(rows.map((row) => row.actor))],
+      }),
+    ]);
 
     // userId → department name, resolved through the proof rule. Built first
     // so the current-assignment read below is one query for the whole batch.
     const desired = new Map<string, string>();
     for (const row of rows) {
       const department = extraString(row, "department").trim();
-      const userId = provenUserId({ row, accounts });
+      const userId = provenUserId({
+        row,
+        accounts,
+        openLinkUserId: openLinkByActor.get(row.actor) ?? null,
+      });
       if (userId !== null) desired.set(userId, department);
     }
     if (desired.size === 0) return { assigned: 0 };
@@ -113,6 +150,50 @@ export class DirectoryDepartmentSyncService {
       );
     }
     return { assigned };
+  }
+
+  /**
+   * The account each of this batch's directory identifiers is already linked
+   * to, by the provider's own identifier.
+   *
+   * The accepted link is evidence in its own right — a human confirmed it, or
+   * an earlier pass proved it — and without it here a directory row that
+   * disagrees is free to re-file somebody's department under a different
+   * account. Two reads rather than a join: `IdentityMatch` carries the person
+   * id and `DiscoveredPerson` the provider identifier, and each table belongs
+   * to its own repository. Links an erasure blanked are excluded by
+   * `findOpenByOrganization`, which is what we want — a link to nobody has
+   * nothing to contradict.
+   */
+  private async loadOpenLinkByActor({
+    organizationId,
+    provider,
+    rawActorIds,
+  }: {
+    organizationId: string;
+    provider: string;
+    rawActorIds: string[];
+  }): Promise<Map<string, string>> {
+    const people = await this.discoveredPeople.findByActorIds(this.prisma, {
+      organizationId,
+      provider,
+      rawActorIds,
+    });
+    if (people.length === 0) return new Map();
+
+    const openLinks = await this.matches.findOpenByOrganization(this.prisma, {
+      organizationId,
+    });
+    const userByPersonId = new Map(
+      openLinks.map((link) => [link.discoveredPersonId, link.userId]),
+    );
+
+    const byActor = new Map<string, string>();
+    for (const person of people) {
+      const userId = userByPersonId.get(person.id);
+      if (typeof userId === "string") byActor.set(person.rawActorId, userId);
+    }
+    return byActor;
   }
 
   /** Writes each changed assignment, resolving each department name once. */
@@ -186,19 +267,35 @@ export class DirectoryDepartmentSyncService {
  * Conflicting proof is rejected before choosing either identifier. Otherwise
  * keep directory-only assignment: the match engine's no-action result means
  * "do not open an identity link", not "discard the directory's department".
+ *
+ * An accepted link outranks the directory index. It is somebody's dated,
+ * reviewable answer to "who is this?" — human-confirmed, or proved by an
+ * address the account holder confirmed — and `decideMatch` has just been
+ * handed the chance to contradict it. A stale `ScimExternalId` naming a
+ * different member must not quietly move a department off the account an
+ * admin accepted; the directory identifier corroborates, it never stands
+ * alone (ADR-128 §12).
  */
 function provenUserId({
   row,
   accounts,
+  openLinkUserId,
 }: {
   row: NormalizedPullEvent;
   accounts: OrganizationAccountIndex;
+  openLinkUserId: string | null;
 }): string | null {
   const decision = decideMatch({
-    identity: { rawActorId: row.actor, displayText: extraString(row, "mail") },
+    identity: {
+      rawActorId: row.actor,
+      displayText: extraString(row, "mail"),
+      openLinkUserId,
+    },
     accounts,
   });
   if (decision.outcome === "suspend") return null;
+
+  if (openLinkUserId !== null) return openLinkUserId;
 
   const byDirectory = accounts.usersByDirectoryId.get(row.actor) ?? [];
   if (byDirectory.length === 1) return byDirectory[0] ?? null;

--- a/platform/app/ee/governance/services/governanceCost.service.ts
+++ b/platform/app/ee/governance/services/governanceCost.service.ts
@@ -226,6 +226,12 @@ export interface GovernanceCostSummaryDto {
   unavailableReason: GovernanceCostUnavailableReason | null;
   /** What the provider billed, pulled from their own reporting. */
   billed: GovernanceCostLaneDto;
+  /** Pulled rollup costs by provider, regardless of person attribution. */
+  providers: Array<{
+    provider: string;
+    amountUsd: number | null;
+    cellsWithoutAmount: number;
+  }>;
   /** What the gateway metered as it served the traffic. */
   gateway: GovernanceCostLaneDto;
   /**
@@ -306,6 +312,7 @@ function unavailable({
   return {
     unavailableReason: reason,
     billed: laneWithoutFigure(),
+    providers: [],
     gateway: laneWithoutFigure(),
     azureBilling: null,
     seats: { status: "awaiting_data" },
@@ -394,18 +401,32 @@ export class GovernanceCostService {
     // still fails the whole summary: this screen is about money, and a money
     // lane that swallowed its own failure would render an absence as a
     // measurement.
-    const [rows, seats, staleSources, azureBilling, unpricedWindow] =
+    const [rows, seats, staleSources, azureBilling, unpricedWindow, providers] =
       await Promise.all([
         costRollup.sumDaysByLane({ tenantId, fromDay, toDay }),
         this.readSeats({ tenantId }),
         this.readStaleSources({ organizationId }),
         this.readAzureBillingNote({ organizationId, tenantId, fromDay, toDay }),
         this.readUnpricedWindow({ organizationId }),
+        costRollup.sumWindowByProvider({ tenantId, fromDay, toDay }),
       ]);
 
     return {
       unavailableReason: null,
-      billed: totalFor(rows, GOVERNANCE_COST_SOURCE.PULLED),
+      // Ingestion can advance between reads. The headline and provider bars
+      // must describe the same snapshot, even while a backfill is writing.
+      billed: {
+        ...spenderFigure(providers),
+        currenciesWithoutUsdAmount: [
+          ...new Set(
+            providers.flatMap((row) => row.currenciesWithoutUsdAmount),
+          ),
+        ].sort(),
+      },
+      providers: providers.map((row) => ({
+        provider: row.provider,
+        ...spenderFigure([row]),
+      })),
       gateway: totalFor(rows, GOVERNANCE_COST_SOURCE.GATEWAY),
       azureBilling,
       seats,
@@ -828,7 +849,9 @@ function spenderKey(provider: string, rawActorId: string): string {
  * total (`figureFor`): any unpriced cell withholds the whole figure, because
  * the priced part alone reads as the complete one.
  */
-function spenderFigure(rows: readonly SpenderGroup[]): {
+function spenderFigure(
+  rows: readonly Pick<SpenderGroup, "amountNanoUsd" | "cellsWithoutAmount">[],
+): {
   amountUsd: number | null;
   cellsWithoutAmount: number;
 } {

--- a/platform/app/ee/governance/services/governanceCostRollup.clickhouse.repository.ts
+++ b/platform/app/ee/governance/services/governanceCostRollup.clickhouse.repository.ts
@@ -566,6 +566,69 @@ export class GovernanceCostRollupClickHouseRepository {
     }));
   }
 
+  /** Current pulled costs by provider, including cells without a named actor.
+   * Collapse replacements before summing so retries and corrections do not
+   * double the bill. Tuple-wrapping preserves corrections to a null amount.
+   */
+  async sumWindowByProvider(input: {
+    tenantId: string;
+    /** Inclusive, YYYY-MM-DD. */
+    fromDay: string;
+    /** Inclusive, YYYY-MM-DD. */
+    toDay: string;
+  }): Promise<
+    Array<{
+      provider: string;
+      amountNanoUsd: number | null;
+      cellsWithoutAmount: number;
+      currenciesWithoutUsdAmount: string[];
+    }>
+  > {
+    const client = await this.resolveClient(input.tenantId);
+    const result = await client.query({
+      query: `
+        SELECT
+          Provider,
+          sumOrNull(LatestAmountNanoUsd) AS AmountNanoUsd,
+          countIf(LatestAmountNanoUsd IS NULL) AS CellsWithoutAmount,
+          arraySort(groupUniqArrayIf(${UNPRICED_CURRENCY_SAMPLE_LIMIT})(
+            CurrencyCode,
+            LatestAmountNanoUsd IS NULL AND CurrencyCode != {usd:String}
+          )) AS CurrenciesWithoutUsdAmount
+        FROM (
+          SELECT
+            ${KEY_COLUMNS.join(", ")},
+            argMax(tuple(AmountNanoUsd), EventTimestamp).1 AS LatestAmountNanoUsd
+          FROM ${GOVERNANCE_COST_ROLLUP_TABLE}
+          WHERE TenantId = {tenantid:String}
+            AND Day >= {fromday:Date}
+            AND Day <= {today:Date}
+            AND CostSource = {costsource:String}
+            AND Version = {version:String}
+          GROUP BY ${KEY_COLUMNS.join(", ")}
+        )
+        GROUP BY Provider
+        ORDER BY Provider
+      `,
+      query_params: {
+        usd: GOVERNANCE_COST_CURRENCY_USD,
+        tenantid: input.tenantId,
+        fromday: input.fromDay,
+        today: input.toDay,
+        costsource: GOVERNANCE_COST_SOURCE.PULLED,
+        version: GOVERNANCE_COST_ROLLUP_PROJECTION_VERSION_LATEST,
+      },
+      format: "JSONEachRow",
+    });
+    const rows = (await result.json()) as Record<string, unknown>[];
+    return rows.map((row) => ({
+      provider: str(row.Provider),
+      amountNanoUsd: nullableInt(row.AmountNanoUsd),
+      cellsWithoutAmount: int(row.CellsWithoutAmount),
+      currenciesWithoutUsdAmount: strArray(row.CurrenciesWithoutUsdAmount),
+    }));
+  }
+
   /**
    * Whether ONE source put any cell at all into a lane over a day range —
    * priced or not.

--- a/platform/app/ee/governance/services/pullers/__tests__/anthropicAdminPuller.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/anthropicAdminPuller.unit.test.ts
@@ -925,6 +925,27 @@ describe("the Anthropic Admin puller", () => {
   });
 
   describe("when the transport fails", () => {
+    it("preserves the provider's rate-limit wait for the durable retry without leaking the response body", async () => {
+      fetchMock.mockResolvedValue(
+        new Response("private upstream payload", {
+          status: 429,
+          headers: { "retry-after": "120" },
+        }),
+      );
+      await expect(
+        new AnthropicAdminPuller().runOnce(RUN_OPTIONS, {
+          adapter: "anthropic_admin",
+          report: "cost",
+          bucketWidth: "1d",
+          schedule: "0 * * * *",
+        }),
+      ).rejects.toMatchObject({
+        message: "Anthropic rate limit exceeded (HTTP 429).",
+        retryAfterMs: 120_000,
+      });
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
     it("leaves the cursor where it was so the window is retried", async () => {
       fetchMock.mockRejectedValue(new Error("connection reset"));
 

--- a/platform/app/ee/governance/services/pullers/__tests__/anthropicAdminPuller.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/anthropicAdminPuller.unit.test.ts
@@ -1067,9 +1067,10 @@ describe("the Anthropic Admin puller", () => {
       const run = await new AnthropicAdminPuller().runOnce(RUN_OPTIONS, config);
 
       // The last element would send the next run back to 2026-08-01 and
-      // re-read two buckets — on the usage report that is duplicated spend
-      // rather than a restatement, because a re-read lands beside the rows it
-      // repeats instead of replacing them.
+      // re-read two buckets. Under an unchanged query that re-read restates
+      // (the id is `usage:<bucket>:<dimensions>`, so it lands on the same
+      // key) — the cost is a window that stops advancing, and duplication
+      // only once the query identity changes and the keys move with it.
       expect(run.events).toHaveLength(3);
       expect(JSON.parse(run.cursor!)).toMatchObject({
         startingAt: "2026-08-03T00:00:00Z",
@@ -1089,6 +1090,44 @@ describe("the Anthropic Admin puller", () => {
       expect(JSON.parse(run.cursor!)).toMatchObject({
         page: "p2",
         watermark: "2026-08-03T00:00:00Z",
+      });
+    });
+
+    it("resumes a drained window from the newest bucket across pages, not the last page's", async () => {
+      // Each page is internally ordered, so the per-page maximum is not what
+      // is being tested: page two's newest bucket is simply OLDER than page
+      // one's. Anthropic promises no order across pages either, and taking
+      // the last page's maximum would mint 2026-08-02 and hand the next run
+      // a window start behind buckets this one already emitted — which, if
+      // the provider's page order is stable, it would then re-mint forever.
+      fetchMock
+        .mockResolvedValueOnce(
+          jsonResponse({
+            data: [
+              { starting_at: "2026-08-04T00:00:00Z", results: [USAGE_ROW] },
+              { starting_at: "2026-08-05T00:00:00Z", results: [USAGE_ROW] },
+            ],
+            has_more: true,
+            next_page: "p2",
+          }),
+        )
+        .mockResolvedValueOnce(
+          jsonResponse({
+            data: [
+              { starting_at: "2026-08-01T00:00:00Z", results: [USAGE_ROW] },
+              { starting_at: "2026-08-02T00:00:00Z", results: [USAGE_ROW] },
+            ],
+            has_more: false,
+            next_page: null,
+          }),
+        );
+
+      const run = await new AnthropicAdminPuller().runOnce(RUN_OPTIONS, config);
+
+      expect(run.events).toHaveLength(4);
+      expect(JSON.parse(run.cursor!)).toMatchObject({
+        startingAt: "2026-08-05T00:00:00Z",
+        watermark: null,
       });
     });
   });

--- a/platform/app/ee/governance/services/pullers/__tests__/anthropicAdminPuller.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/anthropicAdminPuller.unit.test.ts
@@ -946,6 +946,36 @@ describe("the Anthropic Admin puller", () => {
       expect(fetchMock).toHaveBeenCalledTimes(1);
     });
 
+    it("still reports the rate-limit wait when draining the body fails", async () => {
+      // Cancelling the body is housekeeping for the connection pool. An
+      // already-errored stream rejects it, and unguarded that rejection leaves
+      // the 429 branch INSTEAD of the DispatchError — the caller's
+      // `instanceof DispatchError` guard then fails and the wait is gone. A
+      // real Response resolves cancel(), so the rejection has to be planted.
+      const response = new Response("private upstream payload", {
+        status: 429,
+        headers: { "retry-after": "120" },
+      });
+      Object.defineProperty(response, "body", {
+        value: {
+          cancel: () => Promise.reject(new Error("stream already errored")),
+        },
+      });
+      fetchMock.mockResolvedValue(response);
+
+      await expect(
+        new AnthropicAdminPuller().runOnce(RUN_OPTIONS, {
+          adapter: "anthropic_admin",
+          report: "cost",
+          bucketWidth: "1d",
+          schedule: "0 * * * *",
+        }),
+      ).rejects.toMatchObject({
+        message: "Anthropic rate limit exceeded (HTTP 429).",
+        retryAfterMs: 120_000,
+      });
+    });
+
     it("leaves the cursor where it was so the window is retried", async () => {
       fetchMock.mockRejectedValue(new Error("connection reset"));
 

--- a/platform/app/ee/governance/services/pullers/__tests__/anthropicAdminPuller.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/anthropicAdminPuller.unit.test.ts
@@ -1146,10 +1146,22 @@ describe("the Anthropic Admin puller", () => {
       expect(message).toContain("costType");
       // …and none of the values, which are customer billing coordinates and
       // money. This string reaches logs and the source's error state.
+      //
+      // The money has to be named in the form the code would actually emit.
+      // `amount` arrives in CENTS, so the fixture rows carry "41280.000000"
+      // and "10000.000000": asserting only the dollar conversions would let
+      // an implementation interpolate the raw provider string and still pass,
+      // which is a guard that cannot fail. Both forms are listed, plus the
+      // bare integers, so neither the pre- nor the post-conversion value can
+      // slip through.
       for (const value of [
         "ws_1",
         "Claude usage",
         "claude-opus-5",
+        "41280.000000",
+        "10000.000000",
+        "41280",
+        "10000",
         "412.80",
         "100.00",
       ]) {

--- a/platform/app/ee/governance/services/pullers/__tests__/anthropicAdminPuller.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/anthropicAdminPuller.unit.test.ts
@@ -1008,4 +1008,138 @@ describe("the Anthropic Admin puller", () => {
       );
     });
   });
+
+  describe("when a page returns its buckets out of order", () => {
+    const USAGE_ROW = USAGE_PAGE.data[0]!.results[0]!;
+    /**
+     * Newest in the MIDDLE, oldest last. Anthropic promises no order within a
+     * page, and reading the last element as the newest gets 2026-08-01 here —
+     * behind two buckets this very run already emitted.
+     */
+    const OUT_OF_ORDER = [
+      { starting_at: "2026-08-02T00:00:00Z", results: [USAGE_ROW] },
+      { starting_at: "2026-08-03T00:00:00Z", results: [USAGE_ROW] },
+      { starting_at: "2026-08-01T00:00:00Z", results: [USAGE_ROW] },
+    ];
+    const config = {
+      adapter: "anthropic_admin" as const,
+      report: "usage" as const,
+      bucketWidth: "1d" as const,
+      schedule: "0 * * * *",
+      startingAt: "2026-08-01T00:00:00.000Z",
+    };
+
+    it("resumes a drained window from the newest bucket, not the last one in the array", async () => {
+      fetchMock.mockResolvedValue(
+        jsonResponse({ data: OUT_OF_ORDER, has_more: false, next_page: null }),
+      );
+
+      const run = await new AnthropicAdminPuller().runOnce(RUN_OPTIONS, config);
+
+      // The last element would send the next run back to 2026-08-01 and
+      // re-read two buckets — on the usage report that is duplicated spend
+      // rather than a restatement, because a re-read lands beside the rows it
+      // repeats instead of replacing them.
+      expect(run.events).toHaveLength(3);
+      expect(JSON.parse(run.cursor!)).toMatchObject({
+        startingAt: "2026-08-03T00:00:00Z",
+        watermark: null,
+      });
+    });
+
+    it("records the newest bucket as the in-window watermark when the run is cut off", async () => {
+      fetchMock.mockResolvedValue(
+        jsonResponse({ data: OUT_OF_ORDER, has_more: true, next_page: "p2" }),
+      );
+
+      const run = await new AnthropicAdminPuller().runOnce(RUN_OPTIONS, config);
+
+      // The watermark is what a later query-identity mismatch resumes from,
+      // so an understated one widens the re-read it exists to bound.
+      expect(JSON.parse(run.cursor!)).toMatchObject({
+        page: "p2",
+        watermark: "2026-08-03T00:00:00Z",
+      });
+    });
+  });
+
+  describe("when one page holds two rows the cost key cannot tell apart", () => {
+    const COST_ROW = COST_PAGE.data[0]!.results[0]!;
+    const config = {
+      adapter: "anthropic_admin" as const,
+      report: "cost" as const,
+      bucketWidth: "1d" as const,
+      schedule: "0 * * * *",
+    };
+    /** One bucket, whose rows differ only outside the key. */
+    function pageWith(rows: unknown[]) {
+      return {
+        data: [{ starting_at: "2026-08-01T00:00:00Z", results: rows }],
+        has_more: false,
+        next_page: null,
+      };
+    }
+
+    it("refuses the page rather than letting the second row overwrite the first", async () => {
+      // `model` is parsed by `costResultSchema` and is NOT a cost dimension,
+      // so these two rows join to one `source_event_id` — the sink's dedup
+      // key — and only the last one written survives.
+      fetchMock.mockResolvedValue(
+        jsonResponse(
+          pageWith([
+            { ...COST_ROW, model: "anthropic/claude-sonnet-5" },
+            {
+              ...COST_ROW,
+              model: "anthropic/claude-opus-5",
+              amount: "10000.000000",
+            },
+          ]),
+        ),
+      );
+
+      let error: unknown;
+      try {
+        await new AnthropicAdminPuller().runOnce(RUN_OPTIONS, config);
+      } catch (thrown) {
+        error = thrown;
+      }
+
+      // A plain Error, not a HandledError: nobody outside can act on a
+      // provider contract that moved.
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).name).toBe("Error");
+      const message = (error as Error).message;
+      // The count and the key's dimension NAMES, so an operator can see which
+      // coordinates failed to separate the rows.
+      expect(message).toContain("1 restatement key");
+      expect(message).toContain("workspaceId");
+      expect(message).toContain("costType");
+      // …and none of the values, which are customer billing coordinates and
+      // money. This string reaches logs and the source's error state.
+      for (const value of [
+        "ws_1",
+        "Claude usage",
+        "claude-opus-5",
+        "412.80",
+        "100.00",
+      ]) {
+        expect(message).not.toContain(value);
+      }
+    });
+
+    it("accepts a row the provider repeated with the same amount", async () => {
+      fetchMock.mockResolvedValue(jsonResponse(pageWith([COST_ROW, COST_ROW])));
+
+      const run = await new AnthropicAdminPuller().runOnce(RUN_OPTIONS, config);
+
+      // Same key, same money: whichever survives the upsert the figure
+      // recorded is identical, so a repeat costs nothing and must not fail a
+      // window of real spend.
+      expect(run.errorCount).toBe(0);
+      expect(run.events).toHaveLength(2);
+      expect(run.events[0]!.source_event_id).toBe(
+        run.events[1]!.source_event_id,
+      );
+    });
+  });
 });

--- a/platform/app/ee/governance/services/pullers/__tests__/azureCostManagement.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/azureCostManagement.unit.test.ts
@@ -211,6 +211,27 @@ describe("reading an Azure Cost Management daily reply", () => {
         null,
       );
     });
+
+    /** @scenario "A cost reply spread over several pages is read whole" */
+    it.each(["", " ", "\n\t"])(
+      "reports no link when the field is present but empty (%j), keeping the days it read",
+      (nextLink) => {
+        const read = readAzureCostRows({
+          response: replyOf({
+            columns: ["Cost", "UsageDate", "MeterCategory"],
+            rows: [[1.25, 20260823, "Storage"]],
+            nextLink,
+          }),
+        });
+
+        // An empty marker is "there is no next page". Reported as a link it
+        // would reach the caller's host check, name no host, be refused like a
+        // foreign one, and cost the window the day below.
+        expect(read.nextLink).toBe(null);
+        expect(read.days).toHaveLength(1);
+        expect(read.days[0]?.day).toBe("2026-08-23");
+      },
+    );
   });
 
   describe("when the reply is not the shape this reads at all", () => {

--- a/platform/app/ee/governance/services/pullers/__tests__/azureCostManagement.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/azureCostManagement.unit.test.ts
@@ -213,25 +213,26 @@ describe("reading an Azure Cost Management daily reply", () => {
     });
 
     /** @scenario "A cost reply spread over several pages is read whole" */
-    it.each(["", " ", "\n\t"])(
-      "reports no link when the field is present but empty (%j), keeping the days it read",
-      (nextLink) => {
-        const read = readAzureCostRows({
-          response: replyOf({
-            columns: ["Cost", "UsageDate", "MeterCategory"],
-            rows: [[1.25, 20260823, "Storage"]],
-            nextLink,
-          }),
-        });
+    it.each([
+      "",
+      " ",
+      "\n\t",
+    ])("reports no link when the field is present but empty (%j), keeping the days it read", (nextLink) => {
+      const read = readAzureCostRows({
+        response: replyOf({
+          columns: ["Cost", "UsageDate", "MeterCategory"],
+          rows: [[1.25, 20260823, "Storage"]],
+          nextLink,
+        }),
+      });
 
-        // An empty marker is "there is no next page". Reported as a link it
-        // would reach the caller's host check, name no host, be refused like a
-        // foreign one, and cost the window the day below.
-        expect(read.nextLink).toBe(null);
-        expect(read.days).toHaveLength(1);
-        expect(read.days[0]?.day).toBe("2026-08-23");
-      },
-    );
+      // An empty marker is "there is no next page". Reported as a link it
+      // would reach the caller's host check, name no host, be refused like a
+      // foreign one, and cost the window the day below.
+      expect(read.nextLink).toBe(null);
+      expect(read.days).toHaveLength(1);
+      expect(read.days[0]?.day).toBe("2026-08-23");
+    });
   });
 
   describe("when the reply is not the shape this reads at all", () => {

--- a/platform/app/ee/governance/services/pullers/__tests__/copilotStudioDataverseDirectory.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/copilotStudioDataverseDirectory.unit.test.ts
@@ -171,6 +171,7 @@ describe("the directory read inside the Dataverse source", () => {
   });
 
   describe("when the source reads the directory", () => {
+    /** @scenario "A directory read records a row per person beside the conversations" */
     it("records a directory event per user beside the conversations", async () => {
       const result = await runPull({ readDirectory: true });
 
@@ -185,6 +186,7 @@ describe("the directory read inside the Dataverse source", () => {
       expect(storedDirectoryDay(result.cursor)).toBe(today());
     });
 
+    /** @scenario "The directory read asks only for the fields it records" */
     it("selects only the fields it records, and keeps the token off redirects", async () => {
       await runPull({ readDirectory: true });
       const [call] = usersCalls();
@@ -204,6 +206,7 @@ describe("the directory read inside the Dataverse source", () => {
       expect(usersCalls()).toHaveLength(1);
     });
 
+    /** @scenario "A directory spanning pages is read to the end and counted as one day" */
     it("follows Graph's own next link and records both pages as one day", async () => {
       usersReplies = [
         {
@@ -224,6 +227,7 @@ describe("the directory read inside the Dataverse source", () => {
       expect(storedDirectoryDay(result.cursor)).toBe(today());
     });
 
+    /** @scenario "A directory next-page link off Microsoft Graph is refused and the day held" */
     it("refuses a next link that is not Microsoft Graph, and holds the day", async () => {
       usersReplies = [
         {
@@ -264,6 +268,7 @@ describe("the directory read inside the Dataverse source", () => {
       expect(storedDirectoryDay(result.cursor)).toBeNull();
     });
 
+    /** @scenario "A directory answer that is not a page holds the day rather than emptying the tenant" */
     it("holds a body that is not a page rather than recording an empty tenant", async () => {
       usersReplies = [{ status: 200, body: { error: "oops" } }];
 

--- a/platform/app/ee/governance/services/pullers/__tests__/copilotStudioDataversePuller.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/copilotStudioDataversePuller.unit.test.ts
@@ -1314,6 +1314,29 @@ describe("given an Azure bill that does not fit in one reply", () => {
     });
   });
 
+  describe("when the next page field is present but empty", () => {
+    /** @scenario "A cost reply spread over several pages is read whole" */
+    it.each(["", "   "])(
+      "ends the walk on %j and keeps the days it already read",
+      async (nextLink) => {
+        responseQueue.push({
+          status: 200,
+          body: costPage({ day: 20260801, cost: 1.5, nextLink }),
+        });
+
+        const days = await readTheBill();
+
+        // Null here would hold the window and later give it up with the day
+        // below unpriced again, which is what an empty marker used to cost.
+        expect(days?.map((day) => day.day)).toEqual(["2026-08-01"]);
+        expect(costCalls()).toHaveLength(1);
+        expect(errors.join(" ")).not.toContain(
+          "refusing an Azure cost next-page link",
+        );
+      },
+    );
+  });
+
   describe("when the next page points somewhere that is not Azure", () => {
     /** @scenario "A next page cannot move the Azure token to another host" */
     it("holds the window rather than report half a bill", async () => {

--- a/platform/app/ee/governance/services/pullers/__tests__/copilotStudioDataversePuller.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/copilotStudioDataversePuller.unit.test.ts
@@ -1316,25 +1316,25 @@ describe("given an Azure bill that does not fit in one reply", () => {
 
   describe("when the next page field is present but empty", () => {
     /** @scenario "A cost reply spread over several pages is read whole" */
-    it.each(["", "   "])(
-      "ends the walk on %j and keeps the days it already read",
-      async (nextLink) => {
-        responseQueue.push({
-          status: 200,
-          body: costPage({ day: 20260801, cost: 1.5, nextLink }),
-        });
+    it.each([
+      "",
+      "   ",
+    ])("ends the walk on %j and keeps the days it already read", async (nextLink) => {
+      responseQueue.push({
+        status: 200,
+        body: costPage({ day: 20260801, cost: 1.5, nextLink }),
+      });
 
-        const days = await readTheBill();
+      const days = await readTheBill();
 
-        // Null here would hold the window and later give it up with the day
-        // below unpriced again, which is what an empty marker used to cost.
-        expect(days?.map((day) => day.day)).toEqual(["2026-08-01"]);
-        expect(costCalls()).toHaveLength(1);
-        expect(errors.join(" ")).not.toContain(
-          "refusing an Azure cost next-page link",
-        );
-      },
-    );
+      // Null here would hold the window and later give it up with the day
+      // below unpriced again, which is what an empty marker used to cost.
+      expect(days?.map((day) => day.day)).toEqual(["2026-08-01"]);
+      expect(costCalls()).toHaveLength(1);
+      expect(errors.join(" ")).not.toContain(
+        "refusing an Azure cost next-page link",
+      );
+    });
   });
 
   describe("when the next page points somewhere that is not Azure", () => {

--- a/platform/app/ee/governance/services/pullers/__tests__/copilotStudioTraceMapper.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/copilotStudioTraceMapper.unit.test.ts
@@ -890,17 +890,23 @@ describe("given a tool call the agent ran", () => {
 
 describe("given what the agent was running", () => {
   /** @scenario "The trace names the product, never the model the agent was running" */
-  it("names the product and reports no configured model", () => {
+  it("labels the turn with the product and reports no model of its own", () => {
     const events = [
       copilotEvent(transcriptRow({ activities: CHAT }), {
         botModifiedOn: "2026-08-20T10:00:00Z",
       }),
     ];
     const attrs = attrsOf(spansOf(events)[0]!);
-    // The `bot` table has no model column — see BotFacts. Asserting the
-    // absence rather than deleting the case: the previous version of this
-    // test injected a `botModel` no query produces and passed on data
-    // production cannot emit.
+    // Nothing the adapter reads names a model — the `bot` read asks for
+    // `botid,name,modifiedon` and the transcript row carries the conversation,
+    // not the agent's settings; see BotFacts. That is an absent field in what
+    // is read, not proof the agent has no configured model: the model does
+    // sit on the same `bot` row, in the `configuration` column this query does
+    // not request, and it is left unread because a per-agent series name is
+    // neither an exact model nor tied to the turn being priced.
+    // Asserting the absence rather than deleting the case: the previous
+    // version of this test injected a `botModel` no query here produces and
+    // passed on data production cannot emit.
     expect(attrs["copilot_studio.agent_model"]).toBeUndefined();
     expect(attrs["copilot_studio.agent_changed_since"]).toBeUndefined();
 
@@ -926,7 +932,7 @@ describe("given what the agent was running", () => {
     expect(attrs["copilot_studio.agent_changed_since"]).toBe("true");
   });
 
-  it("never prices a conversation — the agent name resolves to no model", () => {
+  it("leaves a conversation unpriced because the product label matches no price row", () => {
     const turns = turnSpansOf([
       copilotEvent(transcriptRow({ activities: CHAT })),
     ]);

--- a/platform/app/ee/governance/services/pullers/__tests__/microsoftGraphDirectory.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/microsoftGraphDirectory.unit.test.ts
@@ -29,6 +29,7 @@ const graphUser = (over: Record<string, unknown> = {}) => ({
 });
 
 describe("reading a directory page", () => {
+  /** @scenario "A directory page hands back its rows and the link to the next one" */
   it("reads the rows and hands back the next link beside them", () => {
     const read = readDirectoryUserRows({
       response: {
@@ -43,6 +44,7 @@ describe("reading a directory page", () => {
     expect(read.nextLink).toContain("$skiptoken");
   });
 
+  /** @scenario "A directory row that cannot be read costs the row, not the page" */
   it("counts an unreadable row rather than dropping the page", () => {
     const read = readDirectoryUserRows({
       response: { value: [graphUser(), { id: "not-a-guid" }] },
@@ -52,6 +54,7 @@ describe("reading a directory page", () => {
     expect(read.unreadableRows).toBe(1);
   });
 
+  /** @scenario "A directory row carrying nothing but an id is still a person" */
   it("keeps a row that carries nothing but its id — Graph omits absent fields", () => {
     const read = readDirectoryUserRows({
       response: { value: [{ id: USER_ID }] },
@@ -61,6 +64,7 @@ describe("reading a directory page", () => {
     expect(read.unreadableRows).toBe(0);
   });
 
+  /** @scenario "A directory answer that is not a page is malformed, not an empty tenant" */
   it("calls a body that is not a page malformed, not an empty tenant", () => {
     const read = readDirectoryUserRows({ response: { error: "oops" } });
 
@@ -70,6 +74,7 @@ describe("reading a directory page", () => {
 });
 
 describe("shaping directory events", () => {
+  /** @scenario "A directory row is recorded against the person and the day" */
   it("keys the event on the person and the day, with the directory id as actor", () => {
     const [event] = microsoftDirectoryEvents({
       users: [graphUser()],
@@ -93,6 +98,7 @@ describe("shaping directory events", () => {
     });
   });
 
+  /** @scenario "A directory field the tenant left empty is recorded empty" */
   it("shapes absent fields as empty strings, never as the word undefined", () => {
     const [event] = microsoftDirectoryEvents({
       users: [
@@ -117,6 +123,7 @@ describe("shaping directory events", () => {
 });
 
 describe("the next-page host gate", () => {
+  /** @scenario "A next-page link is followed only when it is Microsoft Graph over https" */
   it("accepts only https Microsoft Graph with a clean authority", () => {
     expect(
       isMicrosoftGraphUrl(

--- a/platform/app/ee/governance/services/pullers/__tests__/openaiAdminPuller.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/openaiAdminPuller.unit.test.ts
@@ -145,6 +145,21 @@ describe("given an OpenAI Admin cost source", () => {
     fetchMock.mockReset();
     for (const level of Object.values(logged)) level.mockReset();
   });
+  it("preserves a provider rate-limit wait for the durable retry", async () => {
+    fetchMock.mockResolvedValue(
+      new Response("private upstream payload", {
+        status: 429,
+        headers: { "retry-after": "120" },
+      }),
+    );
+    await expect(
+      new OpenAiAdminPuller().runOnce(RUN_OPTIONS, CONFIG),
+    ).rejects.toMatchObject({
+      message: "OpenAI rate limit exceeded (HTTP 429).",
+      retryAfterMs: 120_000,
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
 
   describe("when the provider reports a day's spend", () => {
     /** @scenario "A day's spend is recorded as the dollars the provider reported" */

--- a/platform/app/ee/governance/services/pullers/__tests__/openaiAdminPuller.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/openaiAdminPuller.unit.test.ts
@@ -177,6 +177,30 @@ describe("given an OpenAI Admin cost source", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+  it("still reports the rate-limit wait when draining the body fails", async () => {
+    // Same guard as the Anthropic puller's: a rejected cancel() must not
+    // escape in place of the DispatchError, or the provider's Retry-After
+    // never reaches the scheduler. A real Response resolves cancel(), so the
+    // rejection is planted here.
+    const response = new Response("private upstream payload", {
+      status: 429,
+      headers: { "retry-after": "120" },
+    });
+    Object.defineProperty(response, "body", {
+      value: {
+        cancel: () => Promise.reject(new Error("stream already errored")),
+      },
+    });
+    fetchMock.mockResolvedValue(response);
+
+    await expect(
+      new OpenAiAdminPuller().runOnce(RUN_OPTIONS, CONFIG),
+    ).rejects.toMatchObject({
+      message: "OpenAI rate limit exceeded (HTTP 429).",
+      retryAfterMs: 120_000,
+    });
+  });
+
   describe("when the provider reports a day's spend", () => {
     /** @scenario "A day's spend is recorded as the dollars the provider reported" */
     it("records the provider's dollars without converting them", async () => {

--- a/platform/app/ee/governance/services/pullers/__tests__/openaiAdminPuller.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/openaiAdminPuller.unit.test.ts
@@ -100,10 +100,21 @@ const KEY_GROUPING_REFUSAL = errorResponse({
  * `amount.value` is a JSON number in DOLLARS. The sibling adapter's provider
  * reports cents; a decimal shift here would report a hundred times this.
  *
- * The field list is the endpoint's own and nothing more. There is deliberately
- * no email here: the cost result carries amount, line_item, project_id,
- * user_id, api_key_id and quantity, and inventing an address in the fixture is
- * exactly what let the adapter read one that never arrives and name nobody.
+ * The field list is the endpoint's entire key set, checked against the saved
+ * raw responses rather than against what this adapter happens to read — a
+ * fixture trimmed to the fields under test cannot show that the ones left over
+ * are tolerated, and this schema passes them through into `raw_payload`.
+ *
+ * The report DOES send a `user_email` beside the opaque `user-…` id — every
+ * one of the 2,720 captured rows carries both — so the fixture carries one
+ * too: the adapter deliberately reads the id and never the address, and a
+ * fixture that omitted the address could not tell that choice apart from there
+ * being nothing to read. Both fields ride along because the request groups by
+ * the user dimension; the address is an attribute of that grouping, not a
+ * dimension you can group by. Note the user grouping is wire-verified rather
+ * than contract-guaranteed — OpenAI's published schema omits `user_id` from
+ * the cost `group_by` enum the live API accepts, so it could change without a
+ * deprecation and without anything here going red.
  */
 function costRow(overrides: Record<string, unknown> = {}) {
   return {
@@ -111,8 +122,13 @@ function costRow(overrides: Record<string, unknown> = {}) {
     amount: { value: 0.0025945, currency: "usd" },
     line_item: "gpt-5, input",
     project_id: "proj_a",
+    project_name: "Default project",
     organization_id: "org_acme",
+    organization_name: "ACME",
+    quantity: 5189,
+    quantity_unit: "tokens",
     user_id: "user-1",
+    user_email: "person@acme.test",
     api_key_id: "key_a",
     ...overrides,
   };
@@ -214,7 +230,7 @@ describe("given an OpenAI Admin cost source", () => {
     });
 
     /** @scenario "Spend is attributed to the person the provider named" */
-    it("names the person by the identifier on the row, not by an address the report never sends", async () => {
+    it("names the person by the opaque id on the row, not by the address sent beside it", async () => {
       fetchMock.mockResolvedValue(jsonResponse(page()));
 
       const result = await new OpenAiAdminPuller().runOnce(RUN_OPTIONS, CONFIG);
@@ -224,6 +240,13 @@ describe("given an OpenAI Admin cost source", () => {
       // is the whole provider discovering nobody.
       expect(event.actor).toBe("user-1");
       expect(event.extra?.actorUserId).toBe("user-1");
+      // The row the adapter read did carry an address — this is the half that
+      // makes the two lines above a choice rather than the only thing on offer.
+      expect(JSON.parse(event.raw_payload as string).user_email).toBe(
+        "person@acme.test",
+      );
+      expect(event.actor).not.toContain("@");
+      expect(event.extra?.actorUserId).not.toContain("@");
     });
 
     /** @scenario "Spend the provider attributes to nobody names nobody" */

--- a/platform/app/ee/governance/services/pullers/__tests__/pullerWorker.ocsfMapping.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/pullerWorker.ocsfMapping.unit.test.ts
@@ -1,29 +1,21 @@
 /**
- * Unit coverage for the puller worker's NormalizedPullEvent → OCSF
- * row mapping. The full effect shape (Prisma + CH + process outbox) is
- * exercised by the integration tier; this file documents the
- * pure-function shape of the mapping that's hardest to get right
- * (eventId composition, raw_event preservation, time-coercion fallback).
+ * Unit coverage for the puller framework's NormalizedPullEvent → OCSF row
+ * mapping. The full effect shape (Prisma + CH + process outbox) is exercised
+ * by the integration tier; this file covers the pure mapping the worker calls
+ * (eventId composition, raw_event preservation, time-coercion fallback, and
+ * which actor field a provider's actor string lands in).
+ *
+ * The real `mapToOcsfRow` is imported, not re-implemented: an earlier version
+ * of this file kept a hand-copied "semantic contract" beside the worker's
+ * mapper, which passed happily while the mapper itself put opaque ids in the
+ * email column.
  *
  * Spec: specs/ai-governance/puller-framework/puller-adapter-contract.feature
  */
 import { describe, expect, it } from "vitest";
 
+import { mapToOcsfRow, ocsfActorFields } from "../ocsfPullEventMapping";
 import type { NormalizedPullEvent } from "../pullerAdapter";
-
-// We re-import the mapping helper from the worker module's internals
-// via a small shim. Keeping the helper unexported keeps the worker
-// surface narrow; the test accesses it through a module-internal
-// import alias.
-async function loadMapper() {
-  const mod: any = await import("../pullerWorker");
-  // Expose the internal function for testing — falling back to dynamic
-  // resolution via the module's source if the export shape changes.
-  // We don't ship a runtime export to keep the API surface minimal,
-  // so this test re-implements the semantic contract that the worker
-  // relies on. If you change `mapToOcsfRow`, mirror the change here.
-  return mod;
-}
 
 const baseEvent: NormalizedPullEvent = {
   source_event_id: "evt-123",
@@ -37,89 +29,164 @@ const baseEvent: NormalizedPullEvent = {
   raw_payload: '{"id":"evt-123","raw":"data"}',
 };
 
-describe("PullerWorker — OCSF mapping (semantic contract)", () => {
-  it("loads the worker module without crashing", async () => {
-    const mod = await loadMapper();
-    expect(mod.runIngestionPull).toBeTypeOf("function");
+function mapEvent(event: NormalizedPullEvent) {
+  return mapToOcsfRow({
+    event,
+    tenantId: "gov-proj-1",
+    ingestionSourceId: "src-1",
+    sourceType: "copilot_studio",
   });
+}
 
-  // Direct test of the semantic shape — this matches the implementation
-  // in pullerWorker.ts. Keep them in sync.
-  describe("when reproducing the worker's mapping shape inline", () => {
-    function mapToOcsfRowSemantic({
-      event,
-      tenantId,
-      ingestionSourceId,
-      sourceType,
-    }: {
-      event: NormalizedPullEvent;
-      tenantId: string;
-      ingestionSourceId: string;
-      sourceType: string;
-    }) {
-      const eventTime = new Date(event.event_timestamp);
-      const safeEventTime = Number.isFinite(eventTime.getTime())
-        ? eventTime
-        : new Date();
-      const eventId = `${sourceType}:${ingestionSourceId}:${event.source_event_id}`;
-      return {
-        tenantId,
-        eventId,
-        traceId: `pull:${eventId}`,
-        sourceId: ingestionSourceId,
-        sourceType,
-        eventTime: safeEventTime,
-        actorEmail: event.actor,
-        actionName: event.action,
-        targetName: event.target,
-      };
+function actorOf(rawOcsfJson: string): {
+  user: { uid: string; email_addr: string };
+} {
+  return (
+    JSON.parse(rawOcsfJson) as {
+      actor: { user: { uid: string; email_addr: string } };
     }
+  ).actor;
+}
 
+describe("given a pulled provider event", () => {
+  describe("when the worker maps it to an OCSF audit row", () => {
     it("composes eventId as `<sourceType>:<sourceId>:<source_event_id>`", () => {
-      const row = mapToOcsfRowSemantic({
-        event: baseEvent,
-        tenantId: "gov-proj-1",
-        ingestionSourceId: "src-1",
-        sourceType: "copilot_studio",
-      });
+      const row = mapEvent(baseEvent);
+
       expect(row.eventId).toBe("copilot_studio:src-1:evt-123");
       expect(row.traceId).toBe("pull:copilot_studio:src-1:evt-123");
     });
 
-    it("uses the org's hidden internal_governance Project ID as tenantId", () => {
-      // Same key the trace-fold subscriber + OCSF export service use, so
-      // pull events surface alongside trace-derived events on the SIEM
-      // export path.
-      const row = mapToOcsfRowSemantic({
+    it("uses the org's hidden governance project id as tenantId", () => {
+      // Same key the trace-fold subscriber + OCSF export service use, so pull
+      // events surface alongside trace-derived events on the SIEM export path.
+      const row = mapToOcsfRow({
         event: baseEvent,
         tenantId: "gov-proj-acme-42",
         ingestionSourceId: "src-1",
         sourceType: "copilot_studio",
       });
+
       expect(row.tenantId).toBe("gov-proj-acme-42");
     });
 
-    it("falls back to current time when event_timestamp is unparseable", () => {
-      const row = mapToOcsfRowSemantic({
-        event: { ...baseEvent, event_timestamp: "not-a-date" },
-        tenantId: "gov-proj-1",
-        ingestionSourceId: "src-1",
-        sourceType: "x",
-      });
+    it("carries action and target through without transformation", () => {
+      const row = mapEvent(baseEvent);
+
+      expect(row.actionName).toBe("completion");
+      expect(row.targetName).toBe("gpt-5-mini");
+    });
+
+    it("preserves the provider's raw payload under the OCSF extension", () => {
+      const row = mapEvent(baseEvent);
+      const extension = (
+        JSON.parse(row.rawOcsfJson) as {
+          metadata: { extension: { raw_event: string } };
+        }
+      ).metadata.extension;
+
+      expect(extension.raw_event).toBe('{"id":"evt-123","raw":"data"}');
+    });
+  });
+
+  describe("when event_timestamp is unparseable", () => {
+    it("falls back to a usable time rather than an invalid date", () => {
+      const row = mapEvent({ ...baseEvent, event_timestamp: "not-a-date" });
+
       expect(row.eventTime).toBeInstanceOf(Date);
       expect(Number.isFinite(row.eventTime.getTime())).toBe(true);
     });
+  });
+});
 
-    it("propagates actor/action/target to the OCSF fields without transformation", () => {
-      const row = mapToOcsfRowSemantic({
-        event: baseEvent,
-        tenantId: "gov-proj-1",
-        ingestionSourceId: "src-1",
-        sourceType: "x",
-      });
+describe("given a provider that names the actor by an address", () => {
+  describe("when the row is mapped", () => {
+    it("records the address verbatim in the actor email field", () => {
+      const row = mapEvent(baseEvent);
+
       expect(row.actorEmail).toBe("alice@acme.test");
-      expect(row.actionName).toBe("completion");
-      expect(row.targetName).toBe("gpt-5-mini");
+      expect(row.actorUserId).toBe("");
+      expect(actorOf(row.rawOcsfJson).user).toEqual({
+        uid: "",
+        email_addr: "alice@acme.test",
+      });
+    });
+
+    it("keeps the provider's own casing rather than normalizing it", () => {
+      // An audit row states what the provider said. Matching is where an
+      // address gets lowercased, and it does its own normalizing.
+      const row = mapEvent({ ...baseEvent, actor: "M.Silva@Acme.test" });
+
+      expect(row.actorEmail).toBe("M.Silva@Acme.test");
+    });
+  });
+});
+
+describe("given a provider that names the actor by an opaque id", () => {
+  describe("when the row is mapped", () => {
+    it("keeps the id out of the actor email field", () => {
+      // The OpenAI cost report names a person only by `user-…` and sends no
+      // address at all. An id in an email-named column is not proof of an
+      // address, and the SIEM export ships that column to customer tooling.
+      const row = mapEvent({ ...baseEvent, actor: "user-A1b2C3d4E5" });
+
+      expect(row.actorEmail).toBe("");
+      expect(row.actorUserId).toBe("user-A1b2C3d4E5");
+      expect(actorOf(row.rawOcsfJson).user).toEqual({
+        uid: "user-A1b2C3d4E5",
+        email_addr: "",
+      });
+    });
+
+    it("keeps a directory GUID out of the actor email field too", () => {
+      const row = mapEvent({
+        ...baseEvent,
+        actor: "11111111-2222-3333-4444-555555555555",
+      });
+
+      expect(row.actorEmail).toBe("");
+      expect(row.actorUserId).toBe("11111111-2222-3333-4444-555555555555");
+    });
+  });
+});
+
+describe("given a provider that names nobody", () => {
+  describe("when the row is mapped", () => {
+    it("leaves every actor field blank", () => {
+      const row = mapEvent({ ...baseEvent, actor: "" });
+
+      expect(row.actorEmail).toBe("");
+      expect(row.actorUserId).toBe("");
+      expect(row.actorEnduserId).toBe("");
+    });
+  });
+});
+
+describe("given the actor-field placement rule on its own", () => {
+  describe("when it is handed strings adapters actually emit", () => {
+    it("routes addresses to email and everything else to the user id", () => {
+      expect(ocsfActorFields("dana.hoffman@acme.test")).toEqual({
+        actorEmail: "dana.hoffman@acme.test",
+        actorUserId: "",
+      });
+      // A user principal name is address-shaped and reaches us as one.
+      expect(ocsfActorFields("dana@acme.onmicrosoft.test")).toEqual({
+        actorEmail: "dana@acme.onmicrosoft.test",
+        actorUserId: "",
+      });
+      // Not addresses, however much they look like identifiers of people.
+      expect(ocsfActorFields("user-A1b2C3d4E5")).toEqual({
+        actorEmail: "",
+        actorUserId: "user-A1b2C3d4E5",
+      });
+      expect(ocsfActorFields("Dana Hoffman")).toEqual({
+        actorEmail: "",
+        actorUserId: "Dana Hoffman",
+      });
+      expect(ocsfActorFields("Dana Hoffman <dana@acme.test>")).toEqual({
+        actorEmail: "",
+        actorUserId: "Dana Hoffman <dana@acme.test>",
+      });
     });
   });
 });

--- a/platform/app/ee/governance/services/pullers/__tests__/pullerWorker.ocsfMapping.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/pullerWorker.ocsfMapping.unit.test.ts
@@ -57,9 +57,12 @@ describe("given a pulled provider event", () => {
       expect(row.traceId).toBe("pull:copilot_studio:src-1:evt-123");
     });
 
-    it("uses the org's hidden governance project id as tenantId", () => {
-      // Same key the trace-fold subscriber + OCSF export service use, so pull
-      // events surface alongside trace-derived events on the SIEM export path.
+    it("carries the tenant id it was handed through untouched", () => {
+      // The caller passes the org's hidden internal_governance project id —
+      // the same key the trace-fold subscriber and the OCSF export service
+      // use, so pull events surface alongside trace-derived ones on the SIEM
+      // export path. Which id that is, is the caller's decision and is not
+      // established here; all the mapping owes is to not rewrite it.
       const row = mapToOcsfRow({
         event: baseEvent,
         tenantId: "gov-proj-acme-42",
@@ -124,10 +127,18 @@ describe("given a provider that names the actor by an address", () => {
 
 describe("given a provider that names the actor by an opaque id", () => {
   describe("when the row is mapped", () => {
-    it("keeps the id out of the actor email field", () => {
-      // The OpenAI cost report names a person only by `user-…` and sends no
-      // address at all. An id in an email-named column is not proof of an
-      // address, and the SIEM export ships that column to customer tooling.
+    it("routes the id to the actor id field, not the email field", () => {
+      // What is pinned here is the placement rule, not a permanently empty
+      // column: the mapper places the actor string by what that string IS, and
+      // an opaque id is not an address. The SIEM export ships the email column
+      // to a customer's own tooling, which reads it as an address.
+      //
+      // The OpenAI cost report does send a `user_email` beside the `user-…`
+      // id — every one of the 2,720 captured rows carries both — but the
+      // adapter deliberately puts the id in `actor`, so an address is not what
+      // this mapping is handed. Whether the column should instead be filled
+      // from the payload's address is an open question about the adapter, and
+      // this case does not settle it either way.
       const row = mapEvent({ ...baseEvent, actor: "user-A1b2C3d4E5" });
 
       expect(row.actorEmail).toBe("");

--- a/platform/app/ee/governance/services/pullers/anthropicAdmin.puller.ts
+++ b/platform/app/ee/governance/services/pullers/anthropicAdmin.puller.ts
@@ -814,7 +814,14 @@ export class AnthropicAdminPuller
       followRedirects: false,
     });
     if (response.status === 429) {
-      await response.body?.cancel();
+      // Draining the body keeps undici's connection poolable, but it is only
+      // housekeeping and must never become the error that leaves this branch:
+      // an unguarded reject would propagate INSTEAD of the DispatchError
+      // below, and a plain Error fails the `instanceof DispatchError` guard in
+      // the caller, so the run degrades to a generic failure and the outbox
+      // falls back to its default backoff — throwing away the one thing this
+      // branch exists to carry.
+      await response.body?.cancel().catch(() => void 0);
       throw new DispatchError({
         message: "Anthropic rate limit exceeded (HTTP 429).",
         retryable: true,

--- a/platform/app/ee/governance/services/pullers/anthropicAdmin.puller.ts
+++ b/platform/app/ee/governance/services/pullers/anthropicAdmin.puller.ts
@@ -35,7 +35,10 @@
 
 import { createLogger } from "@langwatch/observability";
 import { z } from "zod";
-
+import {
+  DispatchError,
+  parseRetryAfterMs,
+} from "~/server/event-sourcing/queues/dispatchError";
 import { ssrfSafeFetch } from "~/utils/ssrfProtection";
 import { PULLED_USAGE_HINT_KEY } from "./pulledUsageRecord";
 import type {
@@ -612,6 +615,10 @@ export class AnthropicAdminPuller
     try {
       body = await this.fetchPage({ config, startingAt, page, options });
     } catch (error) {
+      // Keep Retry-After on the thrown error: the durable outbox already
+      // schedules its next attempt no earlier than this provider minimum.
+      // Returning only errorCount would discard both the wait and the cause.
+      if (error instanceof DispatchError) throw error;
       logger.error(
         {
           adapter: this.id,
@@ -685,6 +692,14 @@ export class AnthropicAdminPuller
       // host, so a redirect would hand the key to wherever it points.
       followRedirects: false,
     });
+    if (response.status === 429) {
+      await response.body?.cancel();
+      throw new DispatchError({
+        message: "Anthropic rate limit exceeded (HTTP 429).",
+        retryable: true,
+        retryAfterMs: parseRetryAfterMs(response.headers.get("retry-after")),
+      });
+    }
     if (!response.ok) {
       throw await fetchPageError(response, config.report);
     }

--- a/platform/app/ee/governance/services/pullers/anthropicAdmin.puller.ts
+++ b/platform/app/ee/governance/services/pullers/anthropicAdmin.puller.ts
@@ -442,6 +442,37 @@ const pageSchema = z.object({
 });
 
 /**
+ * The newest bucket start in one page.
+ *
+ * NOT the last element of the array. Anthropic does not promise an order
+ * within a page, and reading the last bucket as the newest is only correct
+ * while the page happens to ascend. On an out-of-order page it hands back an
+ * earlier instant than one already emitted, and the watermark it mints either
+ * re-reads the window — which, on the usage report, is duplicated spend rather
+ * than a restatement — or, once a later page overwrites it, resumes past
+ * buckets that were never read. The maximum is the only value every bucket on
+ * the page is at or behind, which is exactly what a watermark has to mean.
+ *
+ * Instants that do not parse are ignored rather than compared as strings: a
+ * value we cannot order cannot be certified as a resume point. A page where
+ * none parse yields null, and null resumes from the window start — a re-read,
+ * never a skip.
+ */
+function newestBucketStart(
+  buckets: z.infer<typeof bucketSchema>[],
+): string | null {
+  let newest: string | null = null;
+  let newestMs = Number.NEGATIVE_INFINITY;
+  for (const bucket of buckets) {
+    const ms = Date.parse(bucket.starting_at);
+    if (Number.isNaN(ms) || ms <= newestMs) continue;
+    newest = bucket.starting_at;
+    newestMs = ms;
+  }
+  return newest;
+}
+
+/**
  * Dimension values are the identity of a bucket, so an absent one has to be a
  * STABLE token rather than an omitted key: dropping "workspace_id" from one
  * pull and including it as null on the next would mint two keys for one
@@ -467,6 +498,93 @@ function dimension(value: string | null): string {
  */
 function dimensionPath(dimensions: Record<string, string>): string {
   return Object.values(dimensions).map(encodeURIComponent).join(":");
+}
+
+/** The hint this adapter attaches under `PULLED_USAGE_HINT_KEY`, read back. */
+interface EmittedUsageHint {
+  dimensions?: Record<string, string>;
+  tokensCacheRead?: number;
+  tokensCacheWrite?: number;
+}
+
+/**
+ * The hint off an event this adapter emitted. `extra` is an untyped bag on the
+ * shared event shape, so reading our own hint back needs the cast; every event
+ * built below carries one.
+ */
+function emittedHint(event: NormalizedPullEvent): EmittedUsageHint | undefined {
+  return event.extra?.[PULLED_USAGE_HINT_KEY] as EmittedUsageHint | undefined;
+}
+
+/**
+ * Everything a row contributes to the ledger, with none of its identity.
+ *
+ * Two rows sharing a key AND this signature are interchangeable: whichever one
+ * survives the upsert, the money and the quantities recorded are the same, so
+ * a provider that repeats a row costs nothing. Two rows sharing a key and
+ * differing here are two different figures competing for one cell, and only
+ * the last one written survives.
+ */
+function amountSignature(event: NormalizedPullEvent): string {
+  const hint = emittedHint(event);
+  return JSON.stringify([
+    event.cost_usd,
+    event.tokens_input,
+    event.tokens_output,
+    hint?.tokensCacheRead ?? 0,
+    hint?.tokensCacheWrite ?? 0,
+  ]);
+}
+
+/**
+ * Refuse a page whose own rows cannot be told apart.
+ *
+ * A row is stored under the dimensions `usageEvent`/`costEvent` build, and on
+ * the cost report that set is narrower than what the endpoint hands back:
+ * `costResultSchema` parses a `model` that no dimension carries, and the schema
+ * is `passthrough`, so any further coordinate Anthropic breaks a row out by
+ * without being asked — a tier, a token type, a region — is outside the key
+ * too. Two such rows collapse onto one `source_event_id`, which is the sink's
+ * dedup key, and the second silently overwrites the first: spend that was
+ * fetched, parsed, and then dropped with nothing anywhere reporting a loss.
+ *
+ * WIDENING the key is not the fix, and deliberately not done here. The
+ * dimensions ARE the restatement identity: adding one re-keys every cell
+ * already stored, so every later correction would land beside the figure it
+ * corrects instead of replacing it. That migration is owned separately. Until
+ * it lands, the page fails loudly — the run records an error and an operator
+ * sees a figure that is missing rather than one that is quietly wrong.
+ *
+ * A plain `Error`, not a `HandledError`: there is no named cause a caller can
+ * act on, only a provider contract we did not anticipate.
+ *
+ * The message carries the count and the dimension NAMES. Never the values —
+ * workspace ids and free-text descriptions are customer billing coordinates,
+ * and this string travels into logs and the source's error state.
+ */
+function assertRowsAreDistinguishable({
+  events,
+  report,
+}: {
+  events: NormalizedPullEvent[];
+  report: AnthropicAdminPullConfig["report"];
+}): void {
+  const amountByKey = new Map<string, string>();
+  const collidingKeys = new Set<string>();
+  for (const event of events) {
+    const amount = amountSignature(event);
+    const seen = amountByKey.get(event.source_event_id);
+    if (seen === undefined) {
+      amountByKey.set(event.source_event_id, amount);
+      continue;
+    }
+    if (seen !== amount) collidingKeys.add(event.source_event_id);
+  }
+  if (collidingKeys.size === 0) return;
+  const dimensionNames = Object.keys(emittedHint(events[0]!)?.dimensions ?? {});
+  throw new Error(
+    `anthropic ${report}_report returned one page holding ${collidingKeys.size} restatement key(s) shared by rows reporting different amounts; the key is built from ${dimensionNames.join(", ")}, so the provider is distinguishing these rows by something outside it and recording the page would drop spend`,
+  );
 }
 
 /**
@@ -645,11 +763,14 @@ export class AnthropicAdminPuller
     const events = parsed.data.flatMap((bucket) =>
       this.bucketEvents({ bucket, config }),
     );
+    // Same class of refusal as the `has_more` check above: not a window to
+    // retry, a shape whose rows we cannot store without losing one of them.
+    assertRowsAreDistinguishable({ events, report: config.report });
     return {
       ok: true,
       events,
       nextPage: parsed.next_page,
-      watermark: parsed.data.at(-1)?.starting_at ?? null,
+      watermark: newestBucketStart(parsed.data),
     };
   }
 

--- a/platform/app/ee/governance/services/pullers/anthropicAdmin.puller.ts
+++ b/platform/app/ee/governance/services/pullers/anthropicAdmin.puller.ts
@@ -447,17 +447,38 @@ const pageSchema = z.object({
  * NOT the last element of the array. Anthropic does not promise an order
  * within a page, and reading the last bucket as the newest is only correct
  * while the page happens to ascend. On an out-of-order page it hands back an
- * earlier instant than one already emitted, and the watermark it mints either
- * re-reads the window — which, on the usage report, is duplicated spend rather
- * than a restatement — or, once a later page overwrites it, resumes past
- * buckets that were never read. The maximum is the only value every bucket on
- * the page is at or behind, which is exactly what a watermark has to mean.
+ * earlier instant than one already emitted, so the watermark it mints re-reads
+ * the window. Under an unchanged query that re-read restates rather than
+ * duplicating — the ids carry the bucket and its dimensions — and the cost is
+ * a window that stops advancing; it becomes duplicated spend on the usage
+ * report only once a query change moves the keys (see `cursorSchema`). The
+ * maximum is the only value every bucket on the page is at or behind, which is
+ * exactly what a watermark has to mean.
  *
  * Instants that do not parse are ignored rather than compared as strings: a
  * value we cannot order cannot be certified as a resume point. A page where
  * none parse yields null, and null resumes from the window start — a re-read,
  * never a skip.
  */
+/**
+ * The later of two instants, ignoring one that cannot be parsed.
+ *
+ * `newestBucketStart` orders a page against itself. Anthropic promises no
+ * order ACROSS pages either, so the run needs the same maximum one level up:
+ * without it the last page read wins, and a final page whose newest bucket is
+ * older than an earlier page's lowers the resume point below buckets this run
+ * has already emitted.
+ */
+function laterInstant(a: string | null, b: string | null): string | null {
+  if (a === null) return b;
+  if (b === null) return a;
+  const aMs = Date.parse(a);
+  const bMs = Date.parse(b);
+  if (Number.isNaN(bMs)) return a;
+  if (Number.isNaN(aMs)) return b;
+  return bMs > aMs ? b : a;
+}
+
 function newestBucketStart(
   buckets: z.infer<typeof bucketSchema>[],
 ): string | null {
@@ -652,6 +673,21 @@ export class AnthropicAdminPuller
     const query = queryIdentity(config);
     let page = cursor.page;
     let watermark = cursor.watermark;
+    /**
+     * The newest bucket emitted across EVERY page this run read, which is what
+     * a drained window resumes from.
+     *
+     * Separate from `watermark` on purpose. `watermark` is the resume point a
+     * run that was CUT OFF leaves behind, and pages beyond the cut are unread,
+     * so raising it to a cross-page maximum could carry the next run past
+     * buckets nobody has fetched. At the drain there is no unread page left in
+     * the window, so the maximum is simply the newest thing emitted — and
+     * taking it is what stops a trailing out-of-order page from lowering the
+     * window start. Left lowered, a provider whose page order is stable
+     * re-mints the same low start every run, the window never advances, and it
+     * grows until it needs more than MAX_PAGES_PER_RUN to drain.
+     */
+    let newestEmitted = cursor.watermark;
 
     for (let pageCount = 0; pageCount < MAX_PAGES_PER_RUN; pageCount += 1) {
       if (options.deadlineMs !== undefined && Date.now() > options.deadlineMs) {
@@ -672,15 +708,17 @@ export class AnthropicAdminPuller
       }
       events.push(...read.events);
       watermark = read.watermark ?? watermark;
+      newestEmitted = laterInstant(newestEmitted, read.watermark);
 
       if (read.nextPage === null) {
-        // Drained. The next run starts from the newest bucket read, so the
-        // watermark only ever moves forward — and the in-window watermark is
-        // retired: `startingAt` itself is now the resume point.
+        // Drained. The next run starts from the newest bucket this run
+        // emitted across all of its pages, so the window start only ever
+        // moves forward — and the in-window watermark is retired:
+        // `startingAt` itself is now the resume point.
         return {
           events,
           cursor: encodeCursor({
-            startingAt: watermark ?? startingAt,
+            startingAt: newestEmitted ?? startingAt,
             page: null,
             query,
             watermark: null,

--- a/platform/app/ee/governance/services/pullers/azureCostManagement.ts
+++ b/platform/app/ee/governance/services/pullers/azureCostManagement.ts
@@ -201,7 +201,12 @@ export interface AzureCostRead {
    * that reports errors would cost the run its conversations.
    */
   unreadableRows: number;
-  /** The next page, when the reply offers one. */
+  /**
+   * The next page, when the reply offers one.
+   *
+   * Null both when Azure sends `null` and when it sends `""` — see
+   * `nextPageMarker`, which is where the two are made to mean the same thing.
+   */
   nextLink: string | null;
   /**
    * The whole reply was not the shape this reads — an HTTP 200 carrying an
@@ -358,6 +363,24 @@ export function azureCostRequestBody({
 }
 
 /**
+ * The reply's next-page link, or null when the reply is the last one.
+ *
+ * Azure ends the walk two ways: `nextLink: null`, and `nextLink: ""`. Only the
+ * first reads as an ending on its own. The empty string is still a string, so
+ * it reaches the caller's host check, fails it — an empty string names no host
+ * — and is refused as though it pointed off Resource Manager. The window is
+ * then held and eventually given up with `pricedThroughDay` rolled back, so
+ * days that were in fact read whole are unpriced again on the next run.
+ *
+ * Normalised here, at the one place that reads the field, so the host check
+ * keeps its only job: refusing a link that genuinely points somewhere else. A
+ * non-empty foreign link is untouched and still refused there.
+ */
+function nextPageMarker(nextLink: string | null): string | null {
+  return nextLink !== null && nextLink.trim() !== "" ? nextLink : null;
+}
+
+/**
  * One reply, as the days it names.
  *
  * Values are read by COLUMN NAME rather than position — see the module note:
@@ -378,7 +401,8 @@ export function readAzureCostRows({
   if (!parsed.success) {
     return { days: [], unreadableRows: 0, nextLink: null, malformed: true };
   }
-  const { columns, rows, nextLink } = parsed.data.properties;
+  const { columns, rows } = parsed.data.properties;
+  const nextLink = nextPageMarker(parsed.data.properties.nextLink);
 
   const indexOf = new Map(columns.map((column, at) => [column.name, at]));
   const at = (row: unknown[], name: string): unknown => {

--- a/platform/app/ee/governance/services/pullers/copilotStudioTraceMapper.ts
+++ b/platform/app/ee/governance/services/pullers/copilotStudioTraceMapper.ts
@@ -57,8 +57,9 @@ export const COPILOT_CONVERSATION_ACTION = "copilot_conversation" as const;
 /**
  * Agent identity on every turn. A product label, not a priced model: cost
  * enrichment runs on `llm` spans and must find no price row here. The model
- * the agent was actually running is recorded separately, as an attribute,
- * because it cannot be trusted enough to price anything.
+ * the agent runs on IS recorded in the environment, but nothing this adapter
+ * reads names it — see `BotFacts` — so this label is the only thing on the
+ * span, and it is not trusted enough to price a conversation.
  */
 const COPILOT_AGENT_MODEL = "microsoft/copilot-studio" as const;
 
@@ -159,12 +160,34 @@ interface TranscriptRow {
 /**
  * What the adapter supplies about the agent, read from the joined bot row.
  *
- * There is no model here, and that is a finding rather than an omission. The
- * `bot` table carries `name`, `schemaname`, `language`, `authenticationmode`,
- * `statecode`, `publishedon` and `modifiedon` — and nothing naming a model.
- * An earlier draft emitted `copilot_studio.agent_model` from a field no query
- * could ever populate, which is worse than saying nothing: a reader would have
- * taken its absence as "not configured" rather than "not knowable from here".
+ * There is no model here, and that is a finding rather than an omission — but
+ * a narrow one, and the two halves must not be run together.
+ *
+ * What is verified is that nothing this adapter reads names a model. The `bot`
+ * read asks for `botid,name,modifiedon`, and the transcript row carries the
+ * conversation rather than the agent's settings — a sweep of all 35 distinct
+ * scalar leaf paths in transcript `content` matches nothing model-shaped.
+ *
+ * What is NOT claimed is that the environment cannot say. It can: the model
+ * sits on this same `bot` row, in the `configuration` JSON at
+ * `agentSettings.model.series`, one column the `$select` above does not
+ * request. Reading it needs no permission the source does not already hold.
+ *
+ * It is deliberately not requested, because it would not answer the question a
+ * priced span asks. It is a SERIES, a family name with no build, date or
+ * deployment id, so it is not an exact model identifier. It is CURRENT
+ * configuration rather than history, so a month-old transcript would silently
+ * be labelled with today's model; `modifiedon` against the transcript's
+ * `createdon` detects that drift (which is what `agent_changed_since` reports)
+ * but Dataverse keeps no version history of the column, so it can never be
+ * repaired. And it is PER AGENT, not per turn: orchestration falling back to
+ * another model for some turns is not observable at all.
+ *
+ * So the absence recorded here is "this adapter did not read one", never "the
+ * agent has none". An earlier draft emitted `copilot_studio.agent_model` from
+ * a field no query here could populate, which is worse than saying nothing: a
+ * reader would have taken its absence as "not configured" rather than "not
+ * read from here".
  */
 interface BotFacts {
   botName?: string;

--- a/platform/app/ee/governance/services/pullers/ocsfPullEventMapping.ts
+++ b/platform/app/ee/governance/services/pullers/ocsfPullEventMapping.ts
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+
+/**
+ * One pulled provider event → one OCSF v1.1 audit row.
+ *
+ * Pure, and split out of the worker for that reason: this is the file where
+ * "the audit trail names the wrong person" would happen, and the worker around
+ * it is Prisma, ClickHouse and an outbox. Nothing here reads or writes.
+ *
+ * Spec: specs/ai-governance/puller-framework/puller-adapter-contract.feature
+ */
+import {
+  type GovernanceOcsfEventInput,
+  OCSF_ACTIVITY,
+  OCSF_SEVERITY,
+} from "../governanceOcsfEvents.clickhouse.repository";
+import { normalizeEmail } from "../logic/identityEvidence";
+import type { NormalizedPullEvent } from "./pullerAdapter";
+
+/**
+ * Where one provider's actor string belongs among the OCSF actor fields.
+ *
+ * Adapters disagree about what they can name a person by, and the contract
+ * says only "string": Copilot sends a user principal name, Claude an address,
+ * the OpenAI cost report an opaque `user-…` id and no address at all, the
+ * directory read a GUID. Writing all of them into `ActorEmail` made the
+ * column's name a lie — an identifier sitting in an email-named field is not
+ * evidence of an address, and the SIEM export ships that field to a customer's
+ * own tooling, which reads it as one.
+ *
+ * So the string is placed by what it *is*: an address goes to `actorEmail`,
+ * anything else to `actorUserId`, the field OCSF already reserves for the
+ * provider's own identifier for the actor (`actor.user.uid`). Attribution is
+ * unchanged — readers take the first of email / user id / enduser id that is
+ * set — while the audit row stops claiming an address it never had.
+ *
+ * The address test is {@link normalizeEmail}, the same one the identity match
+ * engine uses to decide what proves a link, so the two cannot drift into
+ * disagreeing about what an address is. The value is stored verbatim rather
+ * than normalized: this is an audit row, and it records what the provider
+ * said, not a lowercased rewrite of it.
+ */
+export function ocsfActorFields(actor: string): {
+  actorUserId: string;
+  actorEmail: string;
+} {
+  if (normalizeEmail(actor) !== null) {
+    return { actorUserId: "", actorEmail: actor };
+  }
+  return { actorUserId: actor, actorEmail: "" };
+}
+
+/**
+ * Map a NormalizedPullEvent to a GovernanceOcsfEventInput row. Each
+ * pull event becomes ONE OCSF row (ClassUid 6003 / API Activity, with
+ * ActivityId INVOKE for completion-style events). The raw_payload is
+ * preserved verbatim under metadata.extension.raw_event so SIEM
+ * consumers can still drill back to the source-of-truth bytes.
+ *
+ * EventId includes the source id so two same-type sources cannot collide.
+ *
+ * `tenantId` MUST be the hidden internal_governance Project ID for the
+ * org — same key the trace-fold subscriber and OCSF export service use.
+ * Resolved by the worker before this is called.
+ */
+export function mapToOcsfRow({
+  event,
+  tenantId,
+  ingestionSourceId,
+  sourceType,
+}: {
+  event: NormalizedPullEvent;
+  tenantId: string;
+  ingestionSourceId: string;
+  sourceType: string;
+}): GovernanceOcsfEventInput {
+  const eventTime = new Date(event.event_timestamp);
+  const safeEventTime = Number.isFinite(eventTime.getTime())
+    ? eventTime
+    : new Date();
+  const eventId = `${sourceType}:${ingestionSourceId}:${event.source_event_id}`;
+  const occurredAtMs = safeEventTime.getTime();
+  const { actorUserId, actorEmail } = ocsfActorFields(event.actor);
+  const rawOcsfJson = JSON.stringify({
+    class_uid: 6003,
+    category_uid: 6,
+    activity_id: OCSF_ACTIVITY.INVOKE,
+    type_uid: 6003 * 100 + OCSF_ACTIVITY.INVOKE,
+    severity_id: OCSF_SEVERITY.INFO,
+    time: occurredAtMs,
+    actor: {
+      user: { uid: actorUserId, email_addr: actorEmail },
+      enduser: { uid: "" },
+    },
+    api: { operation: event.action },
+    dst_endpoint: { name: event.target },
+    metadata: {
+      product: { name: "LangWatch", vendor_name: "LangWatch" },
+      extension: {
+        uid: "langwatch.governance",
+        source_type: sourceType,
+        source_id: ingestionSourceId,
+        ingest_mode: "pull",
+        cost_usd: event.cost_usd,
+        tokens_input: event.tokens_input,
+        tokens_output: event.tokens_output,
+        raw_event: event.raw_payload,
+        ...(event.extra ?? {}),
+      },
+    },
+  });
+  return {
+    tenantId,
+    eventId,
+    // Pull events are atomic — synthesize a stable trace id from the
+    // event id so SIEM-side pivot ("show me this trace") still works.
+    traceId: `pull:${eventId}`,
+    sourceId: ingestionSourceId,
+    sourceType,
+    activityId: OCSF_ACTIVITY.INVOKE,
+    severityId: OCSF_SEVERITY.INFO,
+    eventTime: safeEventTime,
+    actorUserId,
+    actorEmail,
+    actorEnduserId: "",
+    actionName: event.action,
+    targetName: event.target,
+    anomalyAlertId: "",
+    rawOcsfJson,
+  };
+}

--- a/platform/app/ee/governance/services/pullers/openaiAdmin.puller.ts
+++ b/platform/app/ee/governance/services/pullers/openaiAdmin.puller.ts
@@ -62,14 +62,34 @@ const API_BASE = "https://api.openai.com/v1/organization";
 const REQUEST_TIMEOUT_MS = 30_000;
 
 /** A run stops here rather than paginating forever; the cursor carries the
- *  rest into the next one. At `PAGE_LIMIT` buckets a page this bounds a run at
- *  roughly ten years, so it is a runaway guard rather than a throttle. */
+ *  rest into the next one. The bound is 20 pages of what the provider actually
+ *  returns, and for daily cost buckets that is 31 a page, not the 180 this
+ *  adapter asks for (see `PAGE_LIMIT`) — so a run reaches about 620 days,
+ *  under two years. Reading the bound off the requested limit overstates it
+ *  nearly six-fold as a decade. A backfill deeper than 620 days therefore
+ *  takes several runs to walk; the cursor makes that safe, but an operator
+ *  sizing a first backfill should expect it. */
 const MAX_PAGES_PER_RUN = 20;
 
 /**
- * The API's own ceiling. Above it the request is REJECTED rather than clamped
- * ("Limit must be less than or equal to 180."), so this is a contract value,
- * not a preference. One page is about six months of daily buckets.
+ * The `limit` this adapter asks for, and NOT what it gets.
+ *
+ * 180 is the published contract value — OpenAI's own OpenAPI document gives it
+ * as the cost report's maximum. The wire does not honour it and does not
+ * complain either: asking `/costs` for `limit=32` answers HTTP 200 with 31
+ * buckets, clamped silently rather than rejected (probe A14), and the probe
+ * kit records the wire ceiling for daily cost buckets as 31 against the
+ * published 180. Where the two disagree the wire is what an integration
+ * receives, so a page here is about one month of daily buckets, not six.
+ *
+ * Not the USAGE endpoints' behaviour, which is the opposite and must not be
+ * blurred with it: those DO reject an over-ceiling limit, naming a maximum per
+ * bucket width (probe A13 — 1440 for `1m`, 168 for `1h`, 31 for `1d`). This
+ * adapter never calls them.
+ *
+ * The value stays at 180 deliberately. Paging follows `next_page` rather than
+ * a row count, so asking for more than the provider will give simply returns
+ * the provider's page and costs nothing.
  */
 const PAGE_LIMIT = 180;
 
@@ -145,6 +165,10 @@ export type OpenAiAdminPullConfig = z.infer<typeof openaiAdminPullConfigSchema>;
  * other, and this adapter holds the cursor still on failure — so without the
  * binding one config edit mid-window would wedge the source permanently, every
  * retry replaying the same dead token.
+ *
+ * That binding is wire-verified (probes A32-A35) but UNCONTRACTED: OpenAI
+ * publishes no promise about it, so it can change without a deprecation and
+ * without anything here going red.
  *
  * `hasKeyGrouping` records whether the in-flight window is being read WITH
  * `api_key_id` in the group-by. It has to be durable for the same reason
@@ -354,10 +378,11 @@ async function safeResponseText(response: {
  * Gated on `param` AND `code` together, and never on the message. Both halves
  * are load-bearing: the endpoint's other rejections carry `param: "start_time"`
  * with `code: "invalid_type"` (an unparseable date), or `code:
- * "invalid_request_error"` with `param: null` (a missing date, an over-ceiling
- * limit). Only this refusal carries both. Reading the English instead would
- * make a sentence the provider is free to reword decide whether months of
- * history are attributed.
+ * "invalid_request_error"` with `param: null` (a missing date). Only this
+ * refusal carries both. An over-ceiling `limit` is NOT among them — this
+ * endpoint clamps it and answers 200 (probe A14). Reading the English instead
+ * would make a sentence the provider is free to reword decide whether months
+ * of history are attributed.
  */
 function isKeyGroupingRefusal(body: string): boolean {
   try {

--- a/platform/app/ee/governance/services/pullers/openaiAdmin.puller.ts
+++ b/platform/app/ee/governance/services/pullers/openaiAdmin.puller.ts
@@ -38,7 +38,10 @@
 
 import { createLogger } from "@langwatch/observability";
 import { z } from "zod";
-
+import {
+  DispatchError,
+  parseRetryAfterMs,
+} from "~/server/event-sourcing/queues/dispatchError";
 import { ssrfSafeFetch } from "~/utils/ssrfProtection";
 import { PULLED_USAGE_HINT_KEY } from "./pulledUsageRecord";
 import type {
@@ -614,6 +617,8 @@ export class OpenAiAdminPuller implements PullerAdapter<OpenAiAdminPullConfig> {
         options,
       });
     } catch (error) {
+      // Let the durable outbox retain Retry-After instead of losing it in errorCount.
+      if (error instanceof DispatchError) throw error;
       logger.error(
         {
           adapter: this.id,
@@ -738,6 +743,14 @@ export class OpenAiAdminPuller implements PullerAdapter<OpenAiAdminPullConfig> {
       },
       signal,
     });
+    if (response.status === 429) {
+      await response.body?.cancel();
+      throw new DispatchError({
+        message: "OpenAI rate limit exceeded (HTTP 429).",
+        retryable: true,
+        retryAfterMs: parseRetryAfterMs(response.headers.get("retry-after")),
+      });
+    }
     if (!response.ok) {
       const detail = await safeResponseText(response);
       if (response.status === 400 && isKeyGroupingRefusal(detail)) {

--- a/platform/app/ee/governance/services/pullers/openaiAdmin.puller.ts
+++ b/platform/app/ee/governance/services/pullers/openaiAdmin.puller.ts
@@ -769,7 +769,10 @@ export class OpenAiAdminPuller implements PullerAdapter<OpenAiAdminPullConfig> {
       signal,
     });
     if (response.status === 429) {
-      await response.body?.cancel();
+      // Best-effort drain, for the reason spelled out in the Anthropic
+      // puller's matching branch: a rejected cancel must not replace the
+      // DispatchError, or the Retry-After never reaches the scheduler.
+      await response.body?.cancel().catch(() => void 0);
       throw new DispatchError({
         message: "OpenAI rate limit exceeded (HTTP 429).",
         retryable: true,

--- a/platform/app/ee/governance/services/pullers/pullerWorker.ts
+++ b/platform/app/ee/governance/services/pullers/pullerWorker.ts
@@ -627,6 +627,7 @@ async function syncPeopleFactsFromPull({
   try {
     await DirectoryDepartmentSyncService.create(prisma).applyDirectoryEvents({
       organizationId: source.organizationId,
+      provider: source.sourceType,
       events,
     });
   } catch (error) {

--- a/platform/app/ee/governance/services/pullers/pullerWorker.ts
+++ b/platform/app/ee/governance/services/pullers/pullerWorker.ts
@@ -42,11 +42,6 @@ import {
   loadErasureSuppression,
   partitionSuppressedEvents,
 } from "../erasureSuppression.service";
-import {
-  type GovernanceOcsfEventInput,
-  OCSF_ACTIVITY,
-  OCSF_SEVERITY,
-} from "../governanceOcsfEvents.clickhouse.repository";
 import { ensureHiddenGovernanceProject } from "../governanceProject.service";
 import { PersonDiscoveryService } from "../personDiscovery.service";
 import type {
@@ -68,6 +63,7 @@ import {
   pullerAdapterRegistry,
   registerBuiltInPullers,
 } from "./index";
+import { mapToOcsfRow } from "./ocsfPullEventMapping";
 import { buildPulledUsageRecord } from "./pulledUsageRecord";
 
 const logger = createLogger("langwatch:workers:ingestionPuller");
@@ -479,10 +475,11 @@ async function writePulledEvents({
   // their next pass: each re-reads a window behind its own watermark so a
   // restated figure is not missed, so an actor erased today is re-read and
   // re-written on the next run (ADR-128 §9 step 1). `event.actor` is what
-  // becomes `ActorEmail` and rides inside the raw OCSF payload, and it is the
-  // actor id the cost record carries — one check covers both writes because a
-  // suppressed event is not written at all rather than written and erased
-  // again later.
+  // becomes the audit row's actor — `ActorEmail` when it is an address and
+  // `ActorUserId` when it is anything else (`ocsfActorFields`) — and rides
+  // inside the raw OCSF payload, and it is the actor id the cost record
+  // carries. One check covers every one of those writes because a suppressed
+  // event is not written at all rather than written and erased again later.
   const suppression = await loadErasureSuppression({
     prisma,
     organizationId: source.organizationId,
@@ -1038,83 +1035,4 @@ function earliest(existing: Date | null, candidate: Date): Date {
 
 function latest(existing: Date | null, candidate: Date): Date {
   return existing && existing > candidate ? existing : candidate;
-}
-
-/**
- * Map a NormalizedPullEvent to a GovernanceOcsfEventInput row. Each
- * pull event becomes ONE OCSF row (ClassUid 6003 / API Activity, with
- * ActivityId INVOKE for completion-style events). The raw_payload is
- * preserved verbatim under metadata.extension.raw_event so SIEM
- * consumers can still drill back to the source-of-truth bytes.
- *
- * EventId includes the source id so two same-type sources cannot collide.
- *
- * `tenantId` MUST be the hidden internal_governance Project ID for the
- * org — same key the trace-fold subscriber and OCSF export service use.
- * Resolved by the worker before this is called.
- */
-function mapToOcsfRow({
-  event,
-  tenantId,
-  ingestionSourceId,
-  sourceType,
-}: {
-  event: NormalizedPullEvent;
-  tenantId: string;
-  ingestionSourceId: string;
-  sourceType: string;
-}): GovernanceOcsfEventInput {
-  const eventTime = new Date(event.event_timestamp);
-  const safeEventTime = Number.isFinite(eventTime.getTime())
-    ? eventTime
-    : new Date();
-  const eventId = `${sourceType}:${ingestionSourceId}:${event.source_event_id}`;
-  const occurredAtMs = safeEventTime.getTime();
-  const rawOcsfJson = JSON.stringify({
-    class_uid: 6003,
-    category_uid: 6,
-    activity_id: OCSF_ACTIVITY.INVOKE,
-    type_uid: 6003 * 100 + OCSF_ACTIVITY.INVOKE,
-    severity_id: OCSF_SEVERITY.INFO,
-    time: occurredAtMs,
-    actor: {
-      user: { uid: "", email_addr: event.actor },
-      enduser: { uid: "" },
-    },
-    api: { operation: event.action },
-    dst_endpoint: { name: event.target },
-    metadata: {
-      product: { name: "LangWatch", vendor_name: "LangWatch" },
-      extension: {
-        uid: "langwatch.governance",
-        source_type: sourceType,
-        source_id: ingestionSourceId,
-        ingest_mode: "pull",
-        cost_usd: event.cost_usd,
-        tokens_input: event.tokens_input,
-        tokens_output: event.tokens_output,
-        raw_event: event.raw_payload,
-        ...(event.extra ?? {}),
-      },
-    },
-  });
-  return {
-    tenantId,
-    eventId,
-    // Pull events are atomic — synthesize a stable trace id from the
-    // event id so SIEM-side pivot ("show me this trace") still works.
-    traceId: `pull:${eventId}`,
-    sourceId: ingestionSourceId,
-    sourceType,
-    activityId: OCSF_ACTIVITY.INVOKE,
-    severityId: OCSF_SEVERITY.INFO,
-    eventTime: safeEventTime,
-    actorUserId: "",
-    actorEmail: event.actor,
-    actorEnduserId: "",
-    actionName: event.action,
-    targetName: event.target,
-    anomalyAlertId: "",
-    rawOcsfJson,
-  };
 }

--- a/platform/app/ee/governance/services/pullers/sourcePullStatus.ts
+++ b/platform/app/ee/governance/services/pullers/sourcePullStatus.ts
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+
+import { z } from "zod";
+import type { IngestionPullRunProjection } from "~/generated/prisma/client";
+
+export type PullRunSummary = Pick<
+  IngestionPullRunProjection,
+  "LastRunAt" | "LastRunOutcome" | "LastRunError"
+>;
+const progressSchema = z.object({
+  startingAt: z.string().datetime(),
+  watermark: z.string().datetime().nullish(),
+  page: z.string().nullable(),
+});
+
+function iso(value: unknown): string | null {
+  if (typeof value !== "string" && typeof value !== "number") return null;
+  const date = new Date(value);
+  return Number.isFinite(date.getTime()) ? date.toISOString() : null;
+}
+
+function billingProgress(sourceType: string, cursor: unknown) {
+  const unknownProgress = { backfillThrough: null, hasMore: null };
+  if (sourceType !== "anthropic_admin" && sourceType !== "openai_admin")
+    return unknownProgress;
+  try {
+    const parsed = progressSchema.safeParse(
+      typeof cursor === "string" ? JSON.parse(cursor) : cursor,
+    );
+    if (!parsed.success) return unknownProgress;
+    const hasMore = parsed.data.page !== null;
+    return {
+      backfillThrough: iso(
+        hasMore ? parsed.data.watermark : parsed.data.startingAt,
+      ),
+      hasMore,
+    };
+  } catch {
+    return unknownProgress;
+  }
+}
+
+function failureMessage(error: string | null | undefined): string {
+  if (/Too many simultaneous queries/i.test(error ?? ""))
+    return "The database is busy.";
+  if (/HTTP 429|rate limit exceeded/i.test(error ?? ""))
+    return "The provider's request limit was reached.";
+  return "The last pull failed.";
+}
+
+/** Only dates and a continuation flag leave the server, never opaque tokens or
+ * upstream error bodies (which can contain credentials and provider payloads).
+ * A watermark is the last bucket emitted, not a guarantee that history is complete.
+ */
+export function sourcePullStatus({
+  sourceType,
+  cursor,
+  pullRun,
+}: {
+  sourceType: string;
+  cursor: unknown;
+  pullRun?: PullRunSummary | null;
+}) {
+  return {
+    lastRunAt: iso(pullRun?.LastRunAt),
+    outcome: pullRun?.LastRunOutcome ?? null,
+    error:
+      pullRun?.LastRunOutcome === "failed"
+        ? failureMessage(pullRun.LastRunError)
+        : null,
+    ...billingProgress(sourceType, cursor),
+  };
+}

--- a/platform/app/scripts/dogfood/governance/smoke-puller.ts
+++ b/platform/app/scripts/dogfood/governance/smoke-puller.ts
@@ -159,6 +159,7 @@ async function main(): Promise<void> {
         SELECT
           EventId,
           ActorEmail,
+          ActorUserId,
           ActionName,
           TargetName,
           SourceType,
@@ -178,7 +179,7 @@ async function main(): Promise<void> {
     );
     for (const row of rows) {
       console.log(
-        `  - ${row.EventId} | actor=${row.ActorEmail} | model=${row.TargetName} | trace=${row.TraceId}`,
+        `  - ${row.EventId} | actor=${row.ActorEmail || row.ActorUserId} | model=${row.TargetName} | trace=${row.TraceId}`,
       );
     }
 

--- a/platform/app/src/components/governance/CostLanePanel.tsx
+++ b/platform/app/src/components/governance/CostLanePanel.tsx
@@ -1,9 +1,9 @@
 import { Box, Heading, HStack, Text, VStack } from "@chakra-ui/react";
-
 import type {
   GovernanceSeatLaneDto,
   GovernanceSeatPoolDto,
 } from "@ee/governance/services/governanceCost.service";
+import type { ReactNode } from "react";
 
 import type { TimeInterval } from "~/components/governance/filters";
 import { MeterBar } from "~/components/ui/MeterBar";
@@ -44,6 +44,7 @@ export function CostLanePanel({
   interval,
   sample = false,
   testId,
+  children,
 }: {
   label: string;
   description: string;
@@ -83,6 +84,8 @@ export function CostLanePanel({
    */
   sample?: boolean;
   testId: string;
+  /** Optional detail belonging to this lane, below its trend. */
+  children?: ReactNode;
 }) {
   const badge = laneTrendBadge(trendPct ?? null);
   return (
@@ -130,6 +133,7 @@ export function CostLanePanel({
             and the question a single figure always raises is which way it has
             been moving — so the space holds the window's own shape. */}
         {trend && <LaneSparkline points={trend} interval={interval} />}
+        {children}
         {/* The claim sits at the top of the card and what it means sits at the
             bottom, so three cards of different content still agree on two
             lines. `marginTop="auto"` takes the slack in the middle: a card

--- a/platform/app/src/components/governance/__tests__/sourcePullHealth.browser.test.tsx
+++ b/platform/app/src/components/governance/__tests__/sourcePullHealth.browser.test.tsx
@@ -1,0 +1,154 @@
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import SourcePage from "@ee/governance/dashboard/pages/ingestion-source-detail";
+import {
+  QueryClient,
+  QueryClientProvider,
+  useQuery,
+} from "@tanstack/react-query";
+import { act, cleanup, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { MemoryRouter } from "react-router";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const fixture = vi.hoisted(() => ({
+  source: {
+    id: "source",
+    name: "Anthropic import",
+    sourceType: "anthropic_admin",
+    status: "active",
+    errorCount: 3,
+    lastSuccessAt: "2026-01-02T12:00:00Z",
+    parserConfig: { startingAt: "2026-01-01T00:00:00Z" },
+    pullSchedule: "*/10 * * * *",
+    pullStatus: {
+      lastRunAt: "2026-01-02T12:10:00Z",
+      outcome: "failed",
+      error: "The database is busy.",
+      backfillThrough: "2026-01-02T00:00:00Z",
+      hasMore: true,
+    },
+  },
+}));
+
+vi.mock("~/components/governance/GovernanceLayout", () => ({
+  default: ({ children }: { children: ReactNode }) => children,
+}));
+vi.mock("~/components/enterprise/EnterpriseLockedSurface", () => ({
+  EnterpriseLockedSurface: ({ children }: { children: ReactNode }) => children,
+}));
+vi.mock("~/components/WithFeatureFlagGuard", () => ({
+  withFeatureFlagGuard: () => (component: unknown) => component,
+}));
+vi.mock("~/components/WithPermissionGuard", () => ({
+  withPermissionGuard: () => (component: unknown) => component,
+}));
+vi.mock("~/hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({
+    organization: { id: "org" },
+    hasAnyPermission: () => true,
+  }),
+}));
+vi.mock("~/utils/compat/next-router", () => ({
+  useRouter: () => ({ query: { id: "source" } }),
+}));
+vi.mock("@ee/governance/dashboard/pages/ingestionSourceForms", () => ({
+  useDestinationContext: () => ({}),
+}));
+vi.mock("@ee/governance/dashboard/pages/inventory", () => ({
+  SourceEditDrawer: () => null,
+}));
+vi.mock("@ee/governance/dashboard/components/SourceEventsTable", () => ({
+  SourceEventsTable: () => <div>Historical provider records</div>,
+}));
+vi.mock("@ee/governance/dashboard/components/useSourceEventsPager", () => ({
+  useSourceEventsPager: () => ({ loadedCount: 25, status: "ready", rows: [] }),
+}));
+vi.mock("~/utils/api", () => ({
+  api: {
+    useUtils: () => ({
+      activityMonitor: { eventsForSource: { fetch: vi.fn() } },
+    }),
+    ingestionSources: {
+      get: {
+        useQuery: (_input: unknown, options: object) =>
+          useQuery({
+            queryKey: ["source"],
+            queryFn: async () => ({ ...fixture.source }),
+            ...options,
+          }),
+      },
+      update: { useMutation: () => ({}) },
+      rotateSecret: { useMutation: () => ({}) },
+      archive: { useMutation: () => ({}) },
+    },
+    activityMonitor: {
+      sourceHealthMetrics: {
+        useQuery: () => ({
+          data: {
+            events24h: 0,
+            events7d: 0,
+            events30d: 0,
+            lastSuccessIso: "2026-01-02T00:00:00Z",
+          },
+          isLoading: false,
+        }),
+      },
+    },
+  },
+}));
+
+let client: QueryClient;
+function mount() {
+  client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  render(
+    <MemoryRouter>
+      <QueryClientProvider client={client}>
+        <ChakraProvider value={defaultSystem}>
+          <SourcePage />
+        </ChakraProvider>
+      </QueryClientProvider>
+    </MemoryRouter>,
+  );
+}
+afterEach(() => {
+  cleanup();
+  client?.clear();
+  vi.useRealTimers();
+  fixture.source.errorCount = 3;
+  fixture.source.pullStatus.outcome = "failed";
+  fixture.source.pullStatus.error = "The database is busy.";
+});
+
+describe("a historical provider import with partially saved data", () => {
+  it("describes failed attempts without claiming collection stopped, and shows the failure and backfill progress", async () => {
+    mount();
+    expect(await screen.findByText("Pulls failing")).toBeVisible();
+    expect(screen.getByText(/The database is busy/)).toBeVisible();
+    expect(screen.getByText(/Backfill reached/)).toBeVisible();
+    expect(screen.getByText(/Last successful pull/)).toBeVisible();
+  });
+
+  it("explains older billing dates without asking to rewrite timestamps", async () => {
+    mount();
+    await screen.findByText("Historical provider records");
+    expect(screen.queryByText(/startTimeUnixNano/)).not.toBeInTheDocument();
+    expect(screen.getByText(/outside the last 30 days/)).toBeVisible();
+  });
+
+  it("refreshes the status when the next pull recovers, without reloading the page", async () => {
+    vi.useFakeTimers();
+    mount();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100);
+    });
+    expect(screen.getByText("Anthropic import")).toBeVisible();
+    fixture.source.errorCount = 0;
+    fixture.source.pullStatus.outcome = "completed";
+    fixture.source.pullStatus.error = "";
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(31_000);
+    });
+    expect(screen.getByText("Active")).toBeVisible();
+    vi.useRealTimers();
+  });
+});

--- a/platform/app/src/components/governance/costs/CostProviderBreakdown.tsx
+++ b/platform/app/src/components/governance/costs/CostProviderBreakdown.tsx
@@ -1,0 +1,64 @@
+import { Box, HStack, Text, VStack } from "@chakra-ui/react";
+import type { GovernanceCostSummaryDto } from "@ee/governance/services/governanceCost.service";
+
+import { formatLaneUsd } from "../costLaneFormat";
+import { CostRankList } from "./CostCharts";
+
+const PROVIDER_NAMES: Record<string, string> = {
+  openai_admin: "OpenAI",
+  anthropic_admin: "Anthropic",
+  databricks_genie: "Databricks",
+  copilot_studio: "Microsoft Copilot Studio (Purview)",
+  copilot_studio_dataverse: "Microsoft Copilot Studio",
+};
+
+const providerName = (provider: string) =>
+  PROVIDER_NAMES[provider] ?? (provider || "Unknown provider");
+
+/** Provider reporting needs no person attribution. Missing USD stays unknown. */
+export function CostProviderBreakdown({
+  providers,
+}: {
+  providers: GovernanceCostSummaryDto["providers"];
+}) {
+  if (providers.length === 0) return null;
+
+  const priced = providers.flatMap((row) =>
+    row.amountUsd === null
+      ? []
+      : [
+          {
+            key: row.provider,
+            label: providerName(row.provider),
+            value: row.amountUsd,
+          },
+        ],
+  );
+
+  return (
+    <Box width="full" paddingY={3} aria-label="Cost by provider">
+      {priced.length > 0 && (
+        <CostRankList
+          rows={priced}
+          maxRows={priced.length}
+          format={formatLaneUsd}
+        />
+      )}
+      <VStack align="stretch" gap={2} marginTop={priced.length > 0 ? 2 : 0}>
+        {providers
+          .filter((row) => row.amountUsd === null)
+          .map((row) => (
+            <HStack
+              key={row.provider}
+              justify="space-between"
+              fontSize="sm"
+              gap={3}
+            >
+              <Text>{providerName(row.provider)}</Text>
+              <Text color="fg.muted">USD amount unavailable</Text>
+            </HStack>
+          ))}
+      </VStack>
+    </Box>
+  );
+}

--- a/platform/app/src/components/governance/costs/sampleLanes.ts
+++ b/platform/app/src/components/governance/costs/sampleLanes.ts
@@ -79,6 +79,15 @@ export function sampleCostSummary(periods: string[]): GovernanceCostSummaryDto {
       cellsWithoutAmount: 0,
       currenciesWithoutUsdAmount: [],
     },
+    providers: [
+      { provider: "openai_admin", share: 0.6 },
+      { provider: "anthropic_admin", share: 0.4 },
+    ].map(({ provider, share }) => ({
+      provider,
+      amountUsd:
+        series.reduce((sum, day) => sum + (day.billedUsd ?? 0), 0) * share,
+      cellsWithoutAmount: 0,
+    })),
     gateway: {
       amountUsd: series.reduce((sum, day) => sum + (day.gatewayUsd ?? 0), 0),
       cellsWithoutAmount: 0,

--- a/platform/app/src/features/navigation/__tests__/ProductSwitcherShell.integration.test.tsx
+++ b/platform/app/src/features/navigation/__tests__/ProductSwitcherShell.integration.test.tsx
@@ -710,14 +710,42 @@ describe("the product-switcher top bar", () => {
 
   describe("when on a Gateway page", () => {
     /** @scenario Gateway and Governance carry no scope control */
-    it("shows no project chip and no personal badge", () => {
+    it("shows no project chip", () => {
+      // The ambient team from the outer beforeEach holds projects and renders
+      // the chip on `/[project]`, so the only thing withholding it here is the
+      // page. Without a team that has projects this would assert the absence
+      // of something nothing was going to draw.
       mockPathname = "/gateway/virtual-keys";
       renderShell();
 
       expect(
         screen.queryByRole("button", { name: "Switch project" }),
       ).not.toBeInTheDocument();
+    });
+
+    /** @scenario Gateway and Governance carry no scope control */
+    it("shows no personal badge even when the scope resolved is a personal workspace", () => {
+      // Both drivers of the badge are switched ON deliberately: the personal
+      // workspace is the ambient scope and `personalScope` is set. Rendered
+      // without them — as this case used to be — the badge could not appear
+      // whatever the code did, and deleting the suppression left it green.
+      // The control below is what proves these inputs draw a badge at all.
+      mockPathname = "/gateway/virtual-keys";
+      mockAmbientTeam = personalTeam;
+      renderShell();
+
       expect(screen.queryByText("Personal")).not.toBeInTheDocument();
+    });
+
+    it("draws that badge on a page that does carry a scope control, on the same inputs", () => {
+      // The positive control for the case above, and the only reason its
+      // `not.toBeInTheDocument()` means anything. If this one ever goes red,
+      // the guard beside it has stopped guarding rather than started passing.
+      mockPathname = "/[project]";
+      mockAmbientTeam = personalTeam;
+      renderShell();
+
+      expect(screen.getByText("Personal")).toBeInTheDocument();
     });
   });
 

--- a/platform/app/src/features/navigation/logic/__tests__/resolveShellRoute.unit.test.ts
+++ b/platform/app/src/features/navigation/logic/__tests__/resolveShellRoute.unit.test.ts
@@ -81,6 +81,47 @@ describe("shell route classification", () => {
     });
   });
 
+  describe("when the reader's sticky scope is their own personal workspace", () => {
+    // The control, and the reason the two below are not vacuous: this input
+    // does put the reader in the personal shell wherever it is allowed to.
+    it("puts a project page in the personal shell", () => {
+      const route = resolveShellRoute({
+        ...base,
+        isOnOwnPersonalProject: true,
+        pathname: "/[project]/traces",
+      });
+
+      expect(route.isPersonalScopeRoute).toBe(true);
+      expect(route.activeProductId).toBe("me");
+    });
+
+    /** @scenario "A sticky personal workspace does not follow me onto an org-wide page" */
+    it("leaves a Gateway page organization-scoped", () => {
+      const route = resolveShellRoute({
+        ...base,
+        isOnOwnPersonalProject: true,
+        pathname: "/gateway/virtual-keys",
+      });
+
+      expect(route.isPersonalScopeRoute).toBe(false);
+      expect(route.activeProductId).toBe("gateway");
+      expect(route.isOrgScopeRoute).toBe(true);
+    });
+
+    /** @scenario "A sticky personal workspace does not follow me onto an org-wide page" */
+    it("leaves a Governance page organization-scoped", () => {
+      const route = resolveShellRoute({
+        ...base,
+        isOnOwnPersonalProject: true,
+        pathname: "/governance/costs",
+      });
+
+      expect(route.isPersonalScopeRoute).toBe(false);
+      expect(route.activeProductId).toBe("governance");
+      expect(route.isOrgScopeRoute).toBe(true);
+    });
+  });
+
   describe("when the address is an internal ops page", () => {
     /** @scenario Internal ops pages render in the new settings shell */
     it("takes the settings detour so the settings shell draws around it", () => {

--- a/platform/app/src/features/navigation/logic/resolveShellRoute.ts
+++ b/platform/app/src/features/navigation/logic/resolveShellRoute.ts
@@ -1,4 +1,5 @@
 import {
+  isOrganizationScopedProduct,
   isPathUnder,
   isSettingsShellRoute,
   type ProductId,
@@ -48,8 +49,9 @@ export function resolveShellRoute({
   // The product the ADDRESS names, before any sticky scope is applied.
   const addressedProductId = productFromPathname(pathname);
   /**
-   * Gateway and Governance are organization-wide surfaces, so a personal
-   * scope can never be the one they are read in.
+   * Products the registry marks organization-wide (Gateway, Governance) are
+   * read across the whole organization, so a personal scope can never be the
+   * one they are read in.
    *
    * This matters because `isOnOwnPersonalProject` is a fact about the sticky
    * ambient team, not about the address: a reader whose last project was their
@@ -59,8 +61,7 @@ export function resolveShellRoute({
    * the address said Gateway. Settings was already excluded for exactly this
    * reason and on exactly this line.
    */
-  const isOrgScopedProduct =
-    addressedProductId === "gateway" || addressedProductId === "governance";
+  const isOrgScopedProduct = isOrganizationScopedProduct(addressedProductId);
   const isPersonalScopeRoute =
     !isSettingsRoute &&
     !isOrgScopedProduct &&
@@ -73,8 +74,7 @@ export function resolveShellRoute({
   const isOrgScopeRoute =
     isOrgScope ||
     isSettingsRoute ||
-    activeProductId === "gateway" ||
-    activeProductId === "governance";
+    isOrganizationScopedProduct(activeProductId);
 
   return {
     isSettingsRoute,

--- a/platform/app/src/features/navigation/logic/resolveShellRoute.ts
+++ b/platform/app/src/features/navigation/logic/resolveShellRoute.ts
@@ -45,15 +45,31 @@ export function resolveShellRoute({
   isOnOwnPersonalProject: boolean;
 }): ShellRoute {
   const isSettingsRoute = isSettingsShellRoute(pathname);
+  // The product the ADDRESS names, before any sticky scope is applied.
+  const addressedProductId = productFromPathname(pathname);
+  /**
+   * Gateway and Governance are organization-wide surfaces, so a personal
+   * scope can never be the one they are read in.
+   *
+   * This matters because `isOnOwnPersonalProject` is a fact about the sticky
+   * ambient team, not about the address: a reader whose last project was their
+   * own workspace carries it into every later page. Without this exclusion
+   * they arrived at /gateway and got the Me shell — the Personal badge in the
+   * top bar, the personal sidebar, and "Me" lit in the product switcher while
+   * the address said Gateway. Settings was already excluded for exactly this
+   * reason and on exactly this line.
+   */
+  const isOrgScopedProduct =
+    addressedProductId === "gateway" || addressedProductId === "governance";
   const isPersonalScopeRoute =
     !isSettingsRoute &&
+    !isOrgScopedProduct &&
     (isPersonalScope ||
       isPathUnder({ pathname, base: "/me" }) ||
       isOnOwnPersonalProject);
   const activeProductId = isSettingsRoute
     ? null
-    : ((isPersonalScopeRoute ? "me" : productFromPathname(pathname)) ??
-      "llm-ops");
+    : ((isPersonalScopeRoute ? "me" : addressedProductId) ?? "llm-ops");
   const isOrgScopeRoute =
     isOrgScope ||
     isSettingsRoute ||

--- a/platform/app/src/features/navigation/products.ts
+++ b/platform/app/src/features/navigation/products.ts
@@ -96,6 +96,28 @@ export function productById(id: ProductId): ProductDefinition {
 }
 
 /**
+ * Whether a product is an organization-wide surface, read off the registry
+ * rather than from a list of product names. The scope of a product is a
+ * fact the registry owns; the shell route resolver used to type out
+ * "gateway" and "governance" by hand in two separate places, so a fifth
+ * org-wide product meant remembering to edit both. Now it is one entry
+ * here.
+ *
+ * Takes a nullable id because the callers work from the address: there is
+ * no active product on the settings detour, and `productFromPathname`
+ * returns null for every non-product page. A missing product is not
+ * organization-wide, so this looks the id up without `productById`, which
+ * throws on anything unknown.
+ */
+export function isOrganizationScopedProduct(id: ProductId | null): boolean {
+  if (!id) return false;
+  return (
+    PRODUCTS.find((candidate) => candidate.id === id)?.scopeKind ===
+    "organization"
+  );
+}
+
+/**
  * Whether an address is a top-level base or sits under it, matched on the
  * segment boundary. A plain `startsWith` would read a project named
  * "metadata" as the Me product and "settings-team" as Settings, because a

--- a/platform/app/src/legacyRedirects.tsx
+++ b/platform/app/src/legacyRedirects.tsx
@@ -80,8 +80,12 @@ export const legacyRedirectRoutes: RouteObject[] = [
     ),
   },
   {
-    // Anomaly rules became a tab inside the inventory. Pinned, because the
-    // inventory default tab is Catalog and the old address meant rules.
+    // Anomaly rules have no page of their own and no inventory tab any
+    // more, so the old address lands on the inventory. The pinned tab is
+    // kept rather than dropped: it names no tab the inventory renders, so
+    // the inventory falls back to Catalog either way, and leaving it in
+    // place keeps the redirect's shape for whenever rules get a home
+    // again. Nothing in the product offers rule authoring today.
     path: "/governance/anomaly-rules",
     element: (
       <LegacyPrefixRedirect

--- a/platform/app/src/pages/governance/__tests__/costScreen.integration.test.tsx
+++ b/platform/app/src/pages/governance/__tests__/costScreen.integration.test.tsx
@@ -187,6 +187,45 @@ beforeEach(() => {
 afterEach(() => cleanup());
 
 describe("the governance cost screen", () => {
+  /** @scenario "A cost-only viewer sees provider costs inside the billed card" */
+  it("shows provider bars in the billed card without people or activity permissions", () => {
+    harness.permissions = ["governanceCost:view", "organization:view"];
+    harness.query.data = summaryFixture({
+      providers: [
+        { provider: "openai_admin", amountUsd: 100, cellsWithoutAmount: 0 },
+        {
+          provider: "anthropic_admin",
+          amountUsd: 23.45,
+          cellsWithoutAmount: 0,
+        },
+      ],
+    });
+    renderScreen();
+    const card = within(screen.getByTestId("cost-lane-billed"));
+    expect(card.getByText("$123.45")).toBeInTheDocument();
+    expect(card.getByText("OpenAI")).toBeInTheDocument();
+    expect(card.getByText("Anthropic")).toBeInTheDocument();
+    expect(card.getByText("$100.00")).toBeInTheDocument();
+    expect(card.getByText("$23.45")).toBeInTheDocument();
+    expect(card.queryByText("$67.89")).not.toBeInTheDocument();
+  });
+
+  /** @scenario "Missing provider prices are not displayed as zero" */
+  it("shows an unavailable provider amount and preserves a refund", () => {
+    harness.query.data = summaryFixture({
+      providers: [
+        { provider: "openai_admin", amountUsd: null, cellsWithoutAmount: 1 },
+        { provider: "anthropic_admin", amountUsd: -2, cellsWithoutAmount: 0 },
+      ],
+    });
+    renderScreen();
+    const card = within(screen.getByTestId("cost-lane-billed"));
+    expect(card.getByText("OpenAI")).toBeInTheDocument();
+    expect(card.getByText("USD amount unavailable")).toBeInTheDocument();
+    expect(card.getByText("-$2.00")).toBeInTheDocument();
+    expect(card.queryByText("$0.00")).not.toBeInTheDocument();
+  });
+
   describe("given an admin with Costs enabled", () => {
     /** @scenario "The unfinished Billed address stays unavailable when Costs is enabled" */
     it("shows not found at the unfinished Billed address", () => {

--- a/platform/app/src/pages/governance/__tests__/platformPlaceholders.integration.test.tsx
+++ b/platform/app/src/pages/governance/__tests__/platformPlaceholders.integration.test.tsx
@@ -20,6 +20,8 @@ import {
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom/vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import type React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -116,6 +118,7 @@ vi.mock("~/components/ModelSelector", () => ({
   ),
 }));
 
+import { EXPLORE_TEMPLATES } from "~/components/governance/platform/exploreQuery";
 import { useLangyStore } from "~/features/langy/stores/langyStore";
 import AnalyticsPage from "../analytics";
 import InsightsPage from "../insights";
@@ -220,8 +223,11 @@ describe("given the Insights screen", () => {
     ).toBeInTheDocument();
     expect(
       screen.getByText(
-        "Every morning a background job reads yesterday's traffic and files a couple of high-signal insights: not fifteen a day.",
+        "A couple of things worth acting on each day, never a feed of fifteen. Nothing has been filed here yet.",
       ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Langy will write your brief here"),
     ).toBeInTheDocument();
     expect(screen.queryByText(/Push back on one/)).not.toBeInTheDocument();
     expect(
@@ -350,9 +356,7 @@ describe("given the Signals & Alerts screen", () => {
       screen.getByRole("heading", { name: "Signals & Alerts" }),
     ).toBeInTheDocument();
     expect(
-      screen.getByText(
-        "No rules scoped here yet. Create one from any chart's bell icon.",
-      ),
+      screen.getByText("No rules here yet. Creating one is coming."),
     ).toBeInTheDocument();
     expect(
       screen.getByRole("link", { name: "Insights inbox" }),
@@ -372,7 +376,9 @@ describe("given the Analytics screen", () => {
       screen.getByRole("heading", { name: "Analytics" }),
     ).toBeInTheDocument();
     expect(screen.getByText("Cost by department · weekly")).toBeInTheDocument();
-    expect(screen.getByText("No data yet")).toBeInTheDocument();
+    expect(
+      screen.getByText("This chart is not connected to your data yet"),
+    ).toBeInTheDocument();
     expect(
       screen.getByText("usage | summarize sum(cost) by department, bin(1w)"),
     ).toBeInTheDocument();
@@ -390,5 +396,119 @@ describe("given the Analytics screen", () => {
     expect(
       screen.getByText("usage | summarize count() by model, bin(1d)"),
     ).toBeInTheDocument();
+  });
+});
+
+describe("given a Platform screen a member can press things on", () => {
+  /**
+   * Every control the screen offers, by accessible name, so the assertion
+   * below is about the WHOLE surface rather than the controls a test
+   * remembered to name. Buttons only: links carry an href a reader can see,
+   * and the tabs and selects are covered by the scenarios above.
+   */
+  const controlNames = (Page: React.ComponentType) => {
+    renderPage(Page);
+    const names = screen
+      .getAllByRole("button")
+      .map((button) => button.textContent?.trim() ?? "");
+    cleanup();
+    return names;
+  };
+
+  /**
+   * A control is inert when it is offered, looks pressable, and answers a
+   * press with nothing. That is a property of the SOURCE — a `<Button>` with
+   * no `onClick` — so it is read there rather than inferred from a render:
+   * a render can only prove that the controls a test happened to name do
+   * something, and the ones nobody named are exactly the ones that rot.
+   *
+   * Signals is not scanned. Its two header actions are inert and are owned
+   * by the page-header restyle, not by this file.
+   */
+  const buttonTagsIn = (page: string) => {
+    // Resolved from the package root (vitest's cwd), because under the
+    // jsdom environment `import.meta.url` carries the served path, not the
+    // filesystem one, and reading it silently misses the file.
+    const source = readFileSync(
+      join(process.cwd(), "src/pages/governance", page),
+      "utf-8",
+    );
+    return source.match(/<Button\b[^>]*>/g) ?? [];
+  };
+
+  /** @scenario "Every control the Platform screens offer does something when pressed" */
+  it("offers no control without a handler on Insights or Analytics", () => {
+    for (const page of ["insights.tsx", "analytics.tsx"]) {
+      const tags = buttonTagsIn(page);
+      // The guard against a vacuous pass: a scan that matched nothing would
+      // otherwise report every page clean, including a page of dead buttons.
+      expect(tags.length).toBeGreaterThan(0);
+      for (const tag of tags) {
+        expect(tag).toMatch(/onClick=/);
+      }
+    }
+  });
+
+  /** @scenario "Every control the Platform screens offer does something when pressed" */
+  it("offers exactly the controls the tests above press", () => {
+    // The render-side half of the same guard: a control added later shows up
+    // here as an unexpected name, so it cannot slip in unpressed. Each name
+    // below is pressed by a test in this file.
+    renderPage(InsightsPage);
+    expect(
+      screen
+        .getAllByRole("button")
+        .map((button) => button.textContent?.trim() ?? ""),
+    ).toEqual([
+      "Inbox0",
+      "Stale0",
+      "Archived0",
+      "Alerts0",
+      "Notifications0",
+      "Set up data",
+      "Open Langy",
+    ]);
+    // Offered here, and did nothing when pressed.
+    expect(
+      screen.queryByRole("button", { name: /sample inbox/ }),
+    ).not.toBeInTheDocument();
+    cleanup();
+
+    renderPage(AnalyticsPage);
+    expect(
+      screen
+        .getAllByRole("button")
+        .map((button) => button.textContent?.trim() ?? ""),
+    ).toEqual(EXPLORE_TEMPLATES.map((template) => template.label));
+    expect(
+      screen.queryByRole("button", { name: "Add filter" }),
+    ).not.toBeInTheDocument();
+  });
+
+  /** @scenario "The Platform screens describe unbuilt work in the future tense" */
+  it("never says a rule fires, a job runs or a query executes today", () => {
+    // Present-tense claims about work that does not exist. Each one was on
+    // one of these screens before: a morning job, a chart's bell icon, a
+    // query engine behind the explore controls.
+    const promises = [
+      /background job/i,
+      /bell icon/i,
+      /alerts notify/i,
+      /automations act/i,
+      /the same engine that powers/i,
+      /compiles to this/i,
+    ];
+
+    for (const Page of [InsightsPage, AnalyticsPage, SignalsPage]) {
+      renderPage(Page);
+      const shown = document.body.textContent ?? "";
+      // The guard: prove the screen rendered before asserting an absence.
+      expect(shown.length).toBeGreaterThan(50);
+      for (const promise of promises) {
+        expect(shown).not.toMatch(promise);
+      }
+      expect(screen.getAllByText("Preview").length).toBeGreaterThan(0);
+      cleanup();
+    }
   });
 });

--- a/platform/app/src/pages/governance/__tests__/platformPlaceholders.integration.test.tsx
+++ b/platform/app/src/pages/governance/__tests__/platformPlaceholders.integration.test.tsx
@@ -401,21 +401,6 @@ describe("given the Analytics screen", () => {
 
 describe("given a Platform screen a member can press things on", () => {
   /**
-   * Every control the screen offers, by accessible name, so the assertion
-   * below is about the WHOLE surface rather than the controls a test
-   * remembered to name. Buttons only: links carry an href a reader can see,
-   * and the tabs and selects are covered by the scenarios above.
-   */
-  const controlNames = (Page: React.ComponentType) => {
-    renderPage(Page);
-    const names = screen
-      .getAllByRole("button")
-      .map((button) => button.textContent?.trim() ?? "");
-    cleanup();
-    return names;
-  };
-
-  /**
    * A control is inert when it is offered, looks pressable, and answers a
    * press with nothing. That is a property of the SOURCE — a `<Button>` with
    * no `onClick` — so it is read there rather than inferred from a render:

--- a/platform/app/src/pages/governance/__tests__/platformPlaceholders.integration.test.tsx
+++ b/platform/app/src/pages/governance/__tests__/platformPlaceholders.integration.test.tsx
@@ -410,20 +410,36 @@ describe("given a Platform screen a member can press things on", () => {
    * Signals is not scanned. Its two header actions are inert and are owned
    * by the page-header restyle, not by this file.
    */
-  const buttonTagsIn = (page: string) => {
+  const buttonTagsIn = (file: string) => {
     // Resolved from the package root (vitest's cwd), because under the
     // jsdom environment `import.meta.url` carries the served path, not the
     // filesystem one, and reading it silently misses the file.
-    const source = readFileSync(
-      join(process.cwd(), "src/pages/governance", page),
-      "utf-8",
+    const source = readFileSync(join(process.cwd(), file), "utf-8");
+    // Two element forms, because a control is not always a `<Button>`: the
+    // Insights rail's folders are `<chakra.button>`. Scanning for one form
+    // only is how five of this screen's controls went unchecked.
+    //
+    // The window, rather than a match to the tag's closing ">", is the point:
+    // an arrow handler contains ">" itself (`onClick={() => …}`), so a lazy
+    // match to the first ">" stops inside the very attribute being looked
+    // for. Each element start is taken with the text that follows it, up to
+    // the next element start, and `onClick=` is required somewhere in there.
+    const starts = [...source.matchAll(/<(?:Button|chakra\.button)\b/g)];
+    return starts.map((start, index) =>
+      source.slice(start.index, starts[index + 1]?.index ?? source.length),
     );
-    return source.match(/<Button\b[^>]*>/g) ?? [];
   };
 
   /** @scenario "Every control the Platform screens offer does something when pressed" */
   it("offers no control without a handler on Insights or Analytics", () => {
-    for (const page of ["insights.tsx", "analytics.tsx"]) {
+    for (const page of [
+      "src/pages/governance/insights.tsx",
+      "src/pages/governance/analytics.tsx",
+      // The rail is where the Insights folder controls actually live, and it
+      // is a component rather than the page file, so scanning the two pages
+      // alone left its five controls unread.
+      "src/components/governance/platform/InsightsRail.tsx",
+    ]) {
       const tags = buttonTagsIn(page);
       // The guard against a vacuous pass: a scan that matched nothing would
       // otherwise report every page clean, including a page of dead buttons.
@@ -437,8 +453,15 @@ describe("given a Platform screen a member can press things on", () => {
   /** @scenario "Every control the Platform screens offer does something when pressed" */
   it("offers exactly the controls the tests above press", () => {
     // The render-side half of the same guard: a control added later shows up
-    // here as an unexpected name, so it cannot slip in unpressed. Each name
-    // below is pressed by a test in this file.
+    // here as an unexpected name, so it cannot slip in unnoticed.
+    //
+    // Not all of them are pressed here, and the split is worth naming. "Set
+    // up data" and "Open Langy" are the page's own two controls and each is
+    // pressed with its result asserted by a test in this file. The five
+    // folder names above them come from the Insights rail, and what holds
+    // them is the scan above — extended to the rail's own file — plus this
+    // roster. Pressing them would assert the page's folder-selection state,
+    // which is not what this scenario is about.
     renderPage(InsightsPage);
     expect(
       screen

--- a/platform/app/src/pages/governance/__tests__/teamDetailHonesty.integration.test.tsx
+++ b/platform/app/src/pages/governance/__tests__/teamDetailHonesty.integration.test.tsx
@@ -1,0 +1,168 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The team detail page, mounted through its real page and guards. What is
+ * under test is what the page CLAIMS: it names the breakdowns it does not
+ * have instead of describing them as work under way, it offers no control
+ * that answers a press with nothing, and it describes its two links in the
+ * reader's own words rather than ours.
+ *
+ * Spec: specs/ai-governance/dashboard/team-detail-page.feature
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const TEAM_ID = "team-1";
+const TEAM_NAME = "Platform";
+const PROJECT_SLUG = "platform-project";
+
+const harness = vi.hoisted(() => ({
+  rows: [] as unknown[],
+}));
+
+vi.mock("~/utils/compat/next-router", () => ({
+  useRouter: () => ({ query: { id: "team-1" } }),
+}));
+vi.mock("~/hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({
+    isLoading: false,
+    organization: { id: "org-1", slug: "acme", name: "ACME", teams: [] },
+    organizations: [
+      {
+        teams: [{ id: "team-1", projects: [{ slug: "platform-project" }] }],
+      },
+    ],
+    project: undefined,
+    hasPermission: () => true,
+    hasOrgPermission: () => true,
+    hasAnyPermission: () => true,
+  }),
+}));
+vi.mock("~/hooks/useFeatureFlag", () => ({
+  useFeatureFlag: () => ({ enabled: true, isLoading: false }),
+}));
+vi.mock("~/hooks/useActivePlan", () => ({
+  useActivePlan: () => ({ isEnterprise: true, activePlan: undefined }),
+}));
+vi.mock("~/components/governance/GovernanceLayout", () => ({
+  default: ({ children }: { children: React.ReactNode }) => children,
+}));
+vi.mock("~/utils/api", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("~/utils/api")>()),
+  api: {
+    activityMonitor: {
+      spendByTeam: {
+        useQuery: () => ({
+          data: harness.rows,
+          isLoading: false,
+          error: null,
+        }),
+      },
+    },
+  },
+}));
+
+import TeamDetailPage from "../teams/[id]";
+
+const renderPage = () =>
+  render(
+    <ChakraProvider value={defaultSystem}>
+      <TeamDetailPage />
+    </ChakraProvider>,
+  );
+
+beforeEach(() => {
+  harness.rows = [
+    {
+      teamId: TEAM_ID,
+      teamName: TEAM_NAME,
+      spendUsd: 12.5,
+      requestCount: 340,
+      lastActivityIso: new Date().toISOString(),
+      sourceCount: 2,
+    },
+  ];
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("given a team with spend in the window", () => {
+  /** @scenario "The page names the breakdowns it does not have yet" */
+  it("says the deeper breakdowns are not available yet", () => {
+    renderPage();
+
+    expect(
+      screen.getByRole("heading", { name: TEAM_NAME }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Per-day spend, per-user breakdown and model mix for this team are not available yet.",
+      ),
+    ).toBeInTheDocument();
+    // Our release plan is not something a reader can act on.
+    expect(screen.queryByText(/follow-up/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/will land here/i)).not.toBeInTheDocument();
+  });
+
+  /** @scenario "The links describe where they land in the reader's own words" */
+  it("describes both links without jargon or an internal route", () => {
+    renderPage();
+
+    expect(
+      screen.getByRole("link", { name: /workspace traces/ }),
+    ).toHaveAttribute("href", `/${PROJECT_SLUG}/traces`);
+    expect(
+      screen.getByText(/A 'Viewing as admin' banner stays on screen/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/shows this team's spend next to every other team's/),
+    ).toBeInTheDocument();
+
+    const shown = document.body.textContent ?? "";
+    // The guard: prove the page rendered before asserting these absences.
+    expect(shown).toContain(TEAM_NAME);
+    for (const jargon of [
+      /orthogonal/i,
+      /drilldown/i,
+      /\/settings\/audit-log/,
+      /stays present \+/,
+    ]) {
+      expect(shown).not.toMatch(jargon);
+    }
+  });
+
+  /** @scenario "Every control on the page navigates somewhere real" */
+  it("offers only links, each with a destination", () => {
+    renderPage();
+
+    // Nothing on this page is a button, so nothing on it can be inert: every
+    // control is a link, and every link resolves somewhere.
+    expect(screen.queryAllByRole("button")).toHaveLength(0);
+    const links = screen.getAllByRole("link");
+    // The guard against a vacuous pass: an empty list would satisfy the
+    // loop below without proving anything about the page's controls.
+    expect(links.length).toBeGreaterThan(2);
+    for (const link of links) {
+      expect(link.getAttribute("href")).toBeTruthy();
+    }
+  });
+
+  /** @scenario "Every control on the page navigates somewhere real" */
+  it("offers no control without a handler in the source", () => {
+    const source = readFileSync(
+      join(process.cwd(), "src/pages/governance/teams/[id].tsx"),
+      "utf-8",
+    );
+    // Read from the source for the same reason the Platform screens are:
+    // a render only proves the controls a test named do something, and a
+    // `<Button>` added here later would carry no handler unnoticed.
+    expect(source).toContain("<Link");
+    expect(source.match(/<Button\b/g) ?? []).toHaveLength(0);
+  });
+});

--- a/platform/app/src/pages/governance/__tests__/teamDetailHonesty.integration.test.tsx
+++ b/platform/app/src/pages/governance/__tests__/teamDetailHonesty.integration.test.tsx
@@ -118,11 +118,17 @@ describe("given a team with spend in the window", () => {
       screen.getByRole("link", { name: /workspace traces/ }),
     ).toHaveAttribute("href", `/${PROJECT_SLUG}/traces`);
     expect(
-      screen.getByText(/A 'Viewing as admin' banner stays on screen/),
+      screen.getByText(/The trace explorer opens with this team's data/),
     ).toBeInTheDocument();
     expect(
       screen.getByText(/shows this team's spend next to every other team's/),
     ).toBeInTheDocument();
+    // The promise that used to sit here — a "Viewing as admin" banner and an
+    // audit-log entry — is not kept for a team. Both key off a personal
+    // workspace owned by somebody else, so asserting the copy was requiring
+    // the page to keep saying something untrue.
+    expect(screen.queryByText(/Viewing as admin/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/audit log/i)).not.toBeInTheDocument();
 
     const shown = document.body.textContent ?? "";
     // The guard: prove the page rendered before asserting these absences.

--- a/platform/app/src/pages/governance/analytics.tsx
+++ b/platform/app/src/pages/governance/analytics.tsx
@@ -10,7 +10,6 @@ import {
   Text,
   VStack,
 } from "@chakra-ui/react";
-import { Copy, Filter } from "lucide-react";
 import { useMemo, useState } from "react";
 
 import GovernanceLayout from "~/components/governance/GovernanceLayout";
@@ -41,7 +40,8 @@ import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
  * The explore surface before there is an engine under it.
  *
  * The controls are real and drive the title and the query line; the chart
- * body is not, and says so. Nothing here runs a query.
+ * body is not, and says so. Nothing here runs a query, so the page carries
+ * the Preview badge and no control that cannot act.
  *
  * Spec: specs/governance/governance-platform-placeholders.feature
  */
@@ -63,10 +63,15 @@ function AnalyticsPage() {
       <VStack align="stretch" gap={5} width="full">
         <HStack justify="space-between" align="start" gap={6}>
           <VStack align="start" gap={1}>
-            <Heading size="md">Analytics</Heading>
+            <HStack gap={2}>
+              <Heading size="md">Analytics</Heading>
+              <Badge colorPalette="purple" size="sm" variant="surface">
+                Preview
+              </Badge>
+            </HStack>
             <Text color="fg.muted">
-              Explore anything in {orgName} using the same engine that powers
-              every chart, dashboard, signal and alert.
+              A preview of how you will explore activity in {orgName}. The
+              controls below shape a query; running it is coming.
             </Text>
           </VStack>
           <SegmentedControl
@@ -114,7 +119,7 @@ function AnalyticsPage() {
             />
           </Tabs.Content>
           <Tabs.Content value="dashboards" paddingTop={4}>
-            <Text color="fg.muted">No dashboards yet.</Text>
+            <Text color="fg.muted">Dashboards are not available yet.</Text>
           </Tabs.Content>
         </Tabs.Root>
       </VStack>
@@ -167,15 +172,6 @@ function ExploreTab({
           onChange={(value) => patch({ interval: value as ExploreInterval })}
           options={EXPLORE_INTERVALS}
         />
-        <Button
-          size="sm"
-          variant="outline"
-          borderStyle="dashed"
-          fontWeight="normal"
-        >
-          <Filter size={14} />
-          Add filter
-        </Button>
       </HStack>
       <ExploreChart
         selection={selection}
@@ -226,7 +222,7 @@ function TemplateChips({
   );
 }
 
-/** The chart body is not real yet and says so. */
+/** The chart body is not connected to anything yet and says so. */
 function ExploreChart({
   selection,
   orgName,
@@ -251,7 +247,9 @@ function ExploreChart({
         {orgName} · last {timeWindow}
       </Text>
       <Box flex={1} display="flex" alignItems="center" justifyContent="center">
-        <Text color="fg.muted">No data yet</Text>
+        <Text color="fg.muted">
+          This chart is not connected to your data yet
+        </Text>
       </Box>
     </VStack>
   );
@@ -276,12 +274,9 @@ function QueryLine({ selection }: { selection: ExploreSelection }) {
           {exploreQueryLine(selection)}
         </Text>
       </HStack>
-      <HStack gap={2} color="fg.muted">
-        <Copy size={14} />
-        <Text fontSize="sm">
-          every surface (dashboards, signals, alerts, Langy) compiles to this
-        </Text>
-      </HStack>
+      <Text fontSize="sm" color="fg.muted">
+        the query these controls describe, once queries run
+      </Text>
     </HStack>
   );
 }

--- a/platform/app/src/pages/governance/costs.tsx
+++ b/platform/app/src/pages/governance/costs.tsx
@@ -21,7 +21,6 @@ import {
   useMemo,
   useState,
 } from "react";
-
 import {
   CostLanePanel,
   SeatLanePanel,
@@ -48,6 +47,7 @@ import {
   CostPanelEmpty,
   costPanelEmpty,
 } from "~/components/governance/costs/CostPanelEmpty";
+import { CostProviderBreakdown } from "~/components/governance/costs/CostProviderBreakdown";
 import {
   CostSpenderError,
   CostSpenderList,
@@ -560,9 +560,8 @@ function CostLanes({
   interval: TimeInterval;
   sample: boolean;
 }) {
-  // Both lanes' shapes come off the one series the totals above them were
-  // summed from, so a card's sparkline and its figure cannot describe
-  // different money.
+  // Trends use daily rollup totals; provider bars and the billed headline
+  // share their own window read so ongoing ingestion cannot split them.
   const seriesOf = (pick: (day: GovernanceCostDayDto) => number | null) =>
     data.series.map((day) => ({ day: day.day, value: pick(day) }));
   const trendOf = (pick: (day: GovernanceCostDayDto) => number | null) =>
@@ -583,7 +582,7 @@ function CostLanes({
         <CostLanePanel
           testId="cost-lane-billed"
           label="Billed by provider"
-          description="What your providers report they will invoice."
+          description="Provider-reported costs recorded for this period."
           amountUsd={data.billed.amountUsd}
           cellsWithoutAmount={data.billed.cellsWithoutAmount}
           currenciesWithoutUsdAmount={data.billed.currenciesWithoutUsdAmount}
@@ -596,7 +595,9 @@ function CostLanes({
           trendPct={trendPctOf((day) => day.billedUsd)}
           interval={interval}
           sample={sample}
-        />
+        >
+          <CostProviderBreakdown providers={data.providers ?? []} />
+        </CostLanePanel>
         <CostLanePanel
           testId="cost-lane-gateway"
           label="Metered by gateway"

--- a/platform/app/src/pages/governance/insights.tsx
+++ b/platform/app/src/pages/governance/insights.tsx
@@ -1,4 +1,12 @@
-import { Box, Button, Heading, HStack, Text, VStack } from "@chakra-ui/react";
+import {
+  Badge,
+  Box,
+  Button,
+  Heading,
+  HStack,
+  Text,
+  VStack,
+} from "@chakra-ui/react";
 import { useState } from "react";
 
 import GovernanceLayout from "~/components/governance/GovernanceLayout";
@@ -25,7 +33,8 @@ import { useLangyStore } from "~/features/langy/stores/langyStore";
  * A placeholder for the brief Langy will write: one card that says what
  * will land here and offers the two ways in. The Setup drawer's values
  * live in this page's state for the sitting and nowhere else — there is
- * no store behind them yet, and nothing here says otherwise.
+ * no store behind them yet, and nothing here says otherwise. The page
+ * carries the Preview badge and offers no control that cannot act.
  *
  * Spec: specs/governance/governance-platform-placeholders.feature
  */
@@ -39,10 +48,15 @@ function InsightsPage() {
     <GovernanceLayout pageTitle="Insights · AI Governance · LangWatch">
       <VStack align="stretch" gap={6} width="full">
         <VStack align="start" gap={1}>
-          <Heading size="md">Insights</Heading>
+          <HStack gap={2}>
+            <Heading size="md">Insights</Heading>
+            <Badge colorPalette="purple" size="sm" variant="surface">
+              Preview
+            </Badge>
+          </HStack>
           <Text color="fg.muted">
-            Langy&apos;s brief: a few things worth acting on, kept fresh, never
-            a feed. Alerts and notifications ride on top.
+            A preview of the inbox where Langy will file the few things worth
+            acting on. Nothing is filed yet.
           </Text>
         </VStack>
 
@@ -119,7 +133,7 @@ function InboxEmptyBrief({
             textAlign="center"
             marginTop={4}
           >
-            Langy writes your brief here
+            Langy will write your brief here
           </Text>
           <Text
             textStyle="sm"
@@ -130,8 +144,8 @@ function InboxEmptyBrief({
             maxWidth="380px"
             marginTop={2}
           >
-            Every morning a background job reads yesterday&apos;s traffic and
-            files a couple of high-signal insights: not fifteen a day.
+            A couple of things worth acting on each day, never a feed of
+            fifteen. Nothing has been filed here yet.
           </Text>
           <HStack gap={2} marginTop={6}>
             <Button size="sm" colorPalette="orange" onClick={onSetup}>
@@ -141,15 +155,6 @@ function InboxEmptyBrief({
               Open Langy
             </Button>
           </HStack>
-          <Button
-            variant="plain"
-            size="xs"
-            fontWeight="400"
-            color="fg.subtle"
-            marginTop={3}
-          >
-            or preview a sample inbox
-          </Button>
         </VStack>
       </LangyPanelSurface>
     </>

--- a/platform/app/src/pages/governance/signals.tsx
+++ b/platform/app/src/pages/governance/signals.tsx
@@ -1,4 +1,4 @@
-import { Button, Heading, HStack, Text, VStack } from "@chakra-ui/react";
+import { Badge, Button, Heading, HStack, Text, VStack } from "@chakra-ui/react";
 import { BellPlus, Target } from "lucide-react";
 
 import GovernanceLayout from "~/components/governance/GovernanceLayout";
@@ -9,9 +9,11 @@ import { withPermissionGuard } from "~/components/WithPermissionGuard";
 /**
  * The rule registry before there are any rules.
  *
- * A placeholder for the signals that fire and the alerts and automations
- * that answer them. Nothing here can create a rule yet; the two header
- * buttons draw the shape of the screen and do nothing when pressed.
+ * A placeholder for the signals that will fire and the alerts that will
+ * answer them. Nothing here can create a rule yet, so the page carries the
+ * Preview badge and the copy stays in the future tense throughout. The two
+ * header buttons still do nothing when pressed; they are owned by the
+ * page-header restyle and are not this page's copy to remove.
  *
  * Spec: specs/governance/governance-platform-placeholders.feature
  */
@@ -21,11 +23,16 @@ function SignalsPage() {
       <VStack align="stretch" gap={8} width="full">
         <HStack justify="space-between" align="start" gap={6}>
           <VStack align="start" gap={1}>
-            <Heading size="md">Signals &amp; Alerts</Heading>
+            <HStack gap={2}>
+              <Heading size="md">Signals &amp; Alerts</Heading>
+              <Badge colorPalette="purple" size="sm" variant="surface">
+                Preview
+              </Badge>
+            </HStack>
             <Text color="fg.muted">
-              A signal is the condition: a judge, a metric or a query. Alerts
-              and automations are what happens when one fires: who gets told,
-              what gets done.
+              A preview of where signal rules will live: a condition to watch
+              for, and what happens when one fires. Nothing is being watched
+              yet.
             </Text>
           </VStack>
           <HStack gap={2} flexShrink={0}>
@@ -42,10 +49,10 @@ function SignalsPage() {
 
         <VStack align="stretch" gap={3}>
           <HStack gap={2} align="baseline" flexWrap="wrap">
-            <Text fontWeight="semibold">When a signal fires</Text>
+            <Text fontWeight="semibold">What this page will hold</Text>
             <Text fontSize="sm" color="fg.muted">
-              alerts notify, automations act: one registry of rules. Recent
-              fires land in the{" "}
+              one registry for the rules that watch your activity. The alerts
+              they raise will be listed in the{" "}
               <Link href="/governance/insights">Insights inbox</Link>.
             </Text>
           </HStack>
@@ -58,16 +65,14 @@ function SignalsPage() {
             paddingX={6}
           >
             <Text color="fg.muted">
-              No rules scoped here yet. Create one from any chart&apos;s bell
-              icon.
+              No rules here yet. Creating one is coming.
             </Text>
           </VStack>
         </VStack>
 
         <Text fontSize="sm" color="fg.muted">
-          Judges run on the org&apos;s{" "}
-          <Link href="/settings/model-providers">model providers</Link> (the
-          same credentials the Gateway routes through).
+          A signal that uses a model will run on your organization&apos;s{" "}
+          <Link href="/settings/model-providers">model providers</Link>.
         </Text>
       </VStack>
     </GovernanceLayout>

--- a/platform/app/src/pages/governance/teams/[id].tsx
+++ b/platform/app/src/pages/governance/teams/[id].tsx
@@ -47,6 +47,11 @@ const fmtRelative = (date: Date | string | null): string => {
  * deep-link. Detail-data depth (per-day spend, per-user breakdown,
  * model mix) defers to a follow-up; this page exists today to honor
  * the bird's-eye click-through invariant.
+ *
+ * Every control on the page is a link that navigates; the copy names only
+ * what the page shows today and marks the rest as not available yet.
+ *
+ * Spec: specs/ai-governance/dashboard/team-detail-page.feature
  */
 function GovernanceTeamDetailPage() {
   const router = useRouter();
@@ -159,8 +164,8 @@ function GovernanceTeamDetailPage() {
                 Detail metrics
               </Text>
               <Text fontSize="xs" color="fg.muted" marginBottom={3}>
-                Per-day spend, per-user breakdown, and model mix for this team
-                will land here in a follow-up.
+                Per-day spend, per-user breakdown and model mix for this team
+                are not available yet.
               </Text>
               {teamProjectSlug && (
                 <>
@@ -178,9 +183,9 @@ function GovernanceTeamDetailPage() {
                     marginTop={1}
                     marginBottom={3}
                   >
-                    The trace explorer opens with the team's data. A 'Viewing as
-                    admin' banner stays present + the access is logged to
-                    /settings/audit-log.
+                    The trace explorer opens with this team's data. A 'Viewing
+                    as admin' banner stays on screen, and the access is recorded
+                    in your audit log.
                   </Text>
                 </>
               )}
@@ -193,8 +198,8 @@ function GovernanceTeamDetailPage() {
                 See this team in the bird's-eye chart →
               </Link>
               <Text fontSize="xs" color="fg.subtle" marginTop={1}>
-                The chart's {`'By Team'`} toggle exercises the same data through
-                one orthogonal lens until the dedicated drilldown ships.
+                The chart's {`'By team'`} view shows this team's spend next to
+                every other team's.
               </Text>
             </Box>
           </>

--- a/platform/app/src/pages/governance/teams/[id].tsx
+++ b/platform/app/src/pages/governance/teams/[id].tsx
@@ -65,9 +65,10 @@ function GovernanceTeamDetailPage() {
   // Resolve the team's first project slug for the bird's-eye drill-in
   // link. Teams typically have a primary project (or a small set);
   // navigating to /[projectSlug]/traces lands the admin on the team's
-  // workspace via the existing project-shell + auto-switches to
-  // PersonalSidebar via the v2 chrome retention discriminator (admin's
-  // not a TeamUser → AdminViewingAsBanner fires from DashboardLayout).
+  // workspace via the existing project-shell. No "viewing as admin" banner
+  // comes with it: that banner keys off a PERSONAL workspace owned by
+  // somebody else (see DashboardPageBody), and an org team is not one, so a
+  // team drill-through is silent and unlogged.
   const teamProjectSlug =
     organizations
       ?.flatMap((org) => org.teams ?? [])
@@ -183,9 +184,7 @@ function GovernanceTeamDetailPage() {
                     marginTop={1}
                     marginBottom={3}
                   >
-                    The trace explorer opens with this team's data. A 'Viewing
-                    as admin' banner stays on screen, and the access is recorded
-                    in your audit log.
+                    The trace explorer opens with this team's data.
                   </Text>
                 </>
               )}

--- a/platform/app/src/server/api/routers/__tests__/personal-workspace-invariants.integration.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/personal-workspace-invariants.integration.test.ts
@@ -1002,16 +1002,23 @@ function movingAMemberWithAPersonalWorkspaceToALiteSeat() {
 
   /** @scenario A personal workspace is not listed among the access an admin manages */
   it("keeps every member's workspace out of the organization-wide list", async () => {
+    // The population first, or the two exclusions below prove nothing: an
+    // empty answer excludes every workspace too, and a fixture that stopped
+    // minting these bindings would read as the guard holding. Both workspaces
+    // hold a binding, and the listing returns a workspace it is meant to.
+    await expect(teamBindingRoles(seatPersonalTeamId)).resolves.toEqual([
+      TeamUserRole.ADMIN,
+    ]);
+    expect(await ownerBindingsOnPersonalTeam()).not.toHaveLength(0);
+
     const bindings = await callerAsOwner().roleBinding.listForOrg({
       organizationId,
     });
+    const scopeIds = bindings.map((binding) => binding.scopeId);
 
-    expect(bindings.map((binding) => binding.scopeId)).not.toContain(
-      seatPersonalTeamId,
-    );
-    expect(bindings.map((binding) => binding.scopeId)).not.toContain(
-      personalTeamId,
-    );
+    expect(scopeIds).toContain(sharedTeamId);
+    expect(scopeIds).not.toContain(seatPersonalTeamId);
+    expect(scopeIds).not.toContain(personalTeamId);
   });
 }
 

--- a/platform/app/src/server/api/routers/onboarding/__tests__/onboarding.personal-workspace.integration.test.ts
+++ b/platform/app/src/server/api/routers/onboarding/__tests__/onboarding.personal-workspace.integration.test.ts
@@ -157,10 +157,19 @@ describe("onboarding.initializeOrganization personal workspace", () => {
 
     /** @scenario Governance signup creates organization and team, but no shared project */
     it("creates no shared project", async () => {
+      // The population first, in the same query minus the predicate under
+      // test: this organization does hold a project. An organization holding
+      // none at all would satisfy the assertion below without the filter
+      // doing any work, and so would a query that had stopped returning rows.
+      const allProjects = await prisma.project.findMany({
+        where: { team: { organizationId } },
+      });
       const sharedProjects = await prisma.project.findMany({
         where: { team: { organizationId }, isPersonal: false },
       });
 
+      expect(allProjects).toHaveLength(1);
+      expect(allProjects[0]!.isPersonal).toBe(true);
       expect(sharedProjects).toHaveLength(0);
     });
 

--- a/platform/app/src/server/modelProviders/__tests__/governanceSignup.providerScope.integration.test.ts
+++ b/platform/app/src/server/modelProviders/__tests__/governanceSignup.providerScope.integration.test.ts
@@ -247,10 +247,22 @@ describe("AGENT_GOVERNANCE signup then adding a model provider (real DB)", () =>
     });
 
     it("still creates no shared project as a side effect", async () => {
+      // The population first, in the same query minus the predicate under
+      // test: the organization does hold a project, and it is the personal
+      // one. A count of zero from an organization holding no projects at all
+      // would pass the assertion below with the filter doing no work.
+      const allProjects = await prisma.project.count({
+        where: { team: { organizationId } },
+      });
+      const personalProjects = await prisma.project.count({
+        where: { team: { organizationId }, isPersonal: true },
+      });
       const sharedProjects = await prisma.project.count({
         where: { team: { organizationId }, isPersonal: false },
       });
 
+      expect(allProjects).toBe(1);
+      expect(personalProjects).toBe(1);
       expect(sharedProjects).toBe(0);
     });
   });

--- a/specs/ai-gateway/governance/ingestion-sources.feature
+++ b/specs/ai-gateway/governance/ingestion-sources.feature
@@ -67,6 +67,30 @@ Feature: IngestionSource — admin configuration of cross-platform feeds
     And each locked entry says it needs an Enterprise plan
     And picking a locked entry does not open the composer
 
+  # --- Types that are defined but must not be offered ---
+
+  @unit
+  Scenario: A source type nothing reads can no longer be chosen
+    Given a source type whose data path was never finished
+    When the admin opens the "Add source" menu on any plan
+    Then that type is not offered
+    And its blurb says the source is not available rather than describing
+      a fetch it cannot perform
+    # Not locked, offered-but-locked is a sales message about what an
+    # Enterprise plan unlocks, and a source that cannot deliver data is not
+    # something to sell. The two Enterprise Compliance types, for OpenAI and
+    # for Anthropic Claude, are hidden this way: an admin who picked either
+    # got a source that stayed silent, and the Claude one collects a
+    # workspace key that never reaches the adapter that would use it.
+
+  @unit
+  Scenario: Sources already configured on an unread type still display
+    Given an ingestion source already configured on one of those types
+    When an admin opens the inventory
+    Then that source still shows its name and vendor mark rather than a blank
+    # Which is why the entry is hidden rather than deleted: the label map is
+    # built from the same list and read without a fallback.
+
   @unit
   Scenario: The composer and the menu share one plan gate
     Given the org is on a non-enterprise plan

--- a/specs/ai-governance/dashboard/team-detail-page.feature
+++ b/specs/ai-governance/dashboard/team-detail-page.feature
@@ -39,10 +39,13 @@ Feature: Team detail — what one team's page shows today
   Scenario: The links describe where they land in the reader's own words
     Given the team has spend in the last 30 days
     When the member opens that team's detail page
-    Then the traces link is described as opening this team's data, with a
-      "Viewing as admin" banner on screen and the access recorded in the
-      audit log
+    Then the traces link is described as opening this team's data
     And the chart link is described as showing this team's spend next to
       every other team's
+    # The line stops there deliberately. It used to promise a "Viewing as
+    # admin" banner and an audit-log entry, and a team drill-through gets
+    # neither: both key off a personal workspace owned by somebody else, and
+    # an org team is not one. See admin-trace-access.feature, which says no
+    # banner renders because an org admin's membership cascades to every team.
     # Neither line may name an internal route, spell "and" as a plus sign,
     # or reach for "orthogonal lens" and "drilldown" to say "view".

--- a/specs/ai-governance/dashboard/team-detail-page.feature
+++ b/specs/ai-governance/dashboard/team-detail-page.feature
@@ -1,0 +1,48 @@
+@governance @dashboard @team-detail
+Feature: Team detail — what one team's page shows today
+  The page a governance admin lands on after clicking a team in the
+  bird's-eye chart. It shows that team's headline spend and activity from
+  the same rollup the chart reads, and offers two links out: the team's
+  workspace traces, and the chart itself. The deeper breakdowns are not
+  built, so the page says they are not available rather than describing
+  them as work already under way.
+
+  Every control on the page navigates. There is no control that answers a
+  press with nothing, and no sentence that describes an unbuilt breakdown
+  as something that exists.
+  Decision: none — copy and control honesty on an existing page.
+
+  Background:
+    Given an organization member with the governance view permission
+    And "release_ui_ai_governance_enabled" is enabled for the organization
+    And the member may read the activity monitor
+
+  @integration
+  Scenario: The page names the breakdowns it does not have yet
+    Given the team has spend in the last 30 days
+    When the member opens that team's detail page
+    Then the detail panel says "Per-day spend, per-user breakdown and model
+      mix for this team are not available yet."
+    And no copy says those breakdowns are arriving in a follow-up
+    # A reader cannot act on our release plan, and "in a follow-up" is our
+    # word for it, not theirs. What they can act on is knowing the number
+    # is not there.
+
+  @integration
+  Scenario: Every control on the page navigates somewhere real
+    Given the team has spend in the last 30 days
+    When the member opens that team's detail page
+    Then every control on the page is a link with a destination
+    And no control is offered that answers a press with nothing
+
+  @integration
+  Scenario: The links describe where they land in the reader's own words
+    Given the team has spend in the last 30 days
+    When the member opens that team's detail page
+    Then the traces link is described as opening this team's data, with a
+      "Viewing as admin" banner on screen and the access recorded in the
+      audit log
+    And the chart link is described as showing this team's spend next to
+      every other team's
+    # Neither line may name an internal route, spell "and" as a plus sign,
+    # or reach for "orthogonal lens" and "drilldown" to say "view".

--- a/specs/ai-governance/puller-framework/copilot-studio-dataverse.feature
+++ b/specs/ai-governance/puller-framework/copilot-studio-dataverse.feature
@@ -516,9 +516,14 @@ Feature: Microsoft Copilot Studio conversations, read from Dataverse
     Given Microsoft answers the cost read with more rows than one page holds
     When the cost read runs
     Then the days on every page are recorded
+    And a reply offering an empty next page ends the walk with those days kept
     # The captured probe fits in one page and still carries the field that
     # offers a second. A reader that stops at the first page under-reports
     # the bill and does so silently.
+    # An empty next-page field is Microsoft saying there is no next page, not
+    # a link to nowhere. Read as a link it names no host, fails the host check
+    # and is refused like a foreign one, which holds the window and later
+    # gives it up with the days already read unpriced again.
 
   @unit
   Scenario: A next page cannot move the Azure token to another host

--- a/specs/ai-governance/puller-framework/copilot-studio-dataverse.feature
+++ b/specs/ai-governance/puller-framework/copilot-studio-dataverse.feature
@@ -203,10 +203,16 @@ Feature: Microsoft Copilot Studio conversations, read from Dataverse
     When the puller records the conversation
     Then every turn names the product "microsoft/copilot-studio" as its model
     And no attribute reports which model the agent was configured with
-    # Written expecting a real model and revised on the evidence: the agent
-    # record in the environment carries a name, a language, an authentication
-    # mode and dates, and no model. There is nothing to read, so the trace
-    # reports no model rather than a field no query can fill.
+    # Written expecting a real model and revised on the evidence: nothing the
+    # source reads names one. It asks the agent record for its id, its name and
+    # when it changed, and the conversation row carries the conversation rather
+    # than the agent's settings. That is an absent field in what is read, not a
+    # claim the agent has no model configured — the model is recorded, on that
+    # same agent record, in a settings column this source does not ask for. It
+    # stays unasked-for because it names a model family for the agent as it is
+    # configured today, not the model that answered this turn, so it could not
+    # price a conversation without inventing precision. The trace therefore
+    # reports no model rather than a field no query here can fill.
     #
     # Both halves are the requirement, and stating only the second would be
     # wrong: a product label IS emitted, on purpose. Cost enrichment runs on

--- a/specs/ai-governance/puller-framework/openai-admin-cost.feature
+++ b/specs/ai-governance/puller-framework/openai-admin-cost.feature
@@ -150,8 +150,10 @@ Feature: OpenAI Admin cost puller
       When the puller records it
       Then the record names that person by the identifier the provider gave
       And the record carries the provider's own id for that person
-      # The identifier is an opaque one, not an email address: the cost report
-      # has no address field. Turning it into a name is the identity engine's
+      # The identifier is the provider's opaque one, not an email address. The
+      # report does send an address beside it, and reading that instead is the
+      # thing being refused: the id is stable and an address on a money row is
+      # heavier to erase. Turning the id into a name is the identity engine's
       # job, and it needs the record to name somebody at all to have anything
       # to work from.
 

--- a/specs/ai-governance/puller-framework/openai-admin-cost.feature
+++ b/specs/ai-governance/puller-framework/openai-admin-cost.feature
@@ -221,7 +221,9 @@ Feature: OpenAI Admin cost puller
       And the source starts the new question from the beginning
       # The provider binds a page token to the exact question that produced it
       # and refuses it under any other, so a replayed token fails the run rather
-      # than returning the wrong page.
+      # than returning the wrong page. That binding is verified against the live
+      # API but the provider publishes no promise about it, so it can change
+      # without notice and without this scenario going red.
 
     @integration
     Scenario: Widening the backfill start makes the source read the older days

--- a/specs/governance/governance-cost-screen.feature
+++ b/specs/governance/governance-cost-screen.feature
@@ -1014,73 +1014,40 @@ Feature: One cost screen, three honest lanes
       Then the request is refused
       And the cost lanes still answer for them
 
-  Rule: The total shown is the bill; gateway detail splits it
-
-    # Every scenario under this rule says what a reader is SHOWN, and nothing
-    # shows it yet: there is no connected view, and no arithmetic behind it —
-    # the caller-less `combineProviderDay` and its tests were removed as dead
-    # code (#7923). So these stay parked rather than bound. They become @unit
-    # the day a reader can see the numbers, and the day something says which
-    # bill pays for which gateway key — that link is not recorded yet.
-
-    @unimplemented
-    Scenario: Gateway detail splits the bill and the remainder is its own line
-      Given a bill of six dollars for a provider day
-      And four dollars twenty of gateway spend on keys that bill covers
-      When the connected view is drawn
-      Then the total shown is six dollars
-      And four dollars twenty is shown as attributed
-      And one dollar eighty is shown as not seen by the gateway
-
-    @unimplemented
-    Scenario: Gateway spend above the bill is shown as a variance, never subtracted
-      Given a bill of six dollars for a provider day
-      And six dollars fifty of gateway spend on keys that bill covers
-      When the connected view is drawn
-      Then the total shown is still six dollars
-      And fifty cents is shown as metering running over the bill
-      And nothing is subtracted from the total
-
-    @unimplemented
-    Scenario: A refunded day stays negative
-      Given a provider day whose bill is a refund
-      When the connected view is drawn
-      Then the total shown is negative
-      # Clamping it to zero would silently eat money.
-
-    @unimplemented
-    Scenario: A day the bill has not reached yet is marked estimated
-      Given a key covered by a bill
-      And gateway spend on a day no bill has reported yet
-      When the connected view is drawn
-      Then the day shows the gateway figure marked as estimated
-
-    @unimplemented
-    Scenario: The estimate becomes the bill when the bill lands
-      Given a day shown as estimated from gateway spend
-      When the provider's bill for that day arrives
-      Then the day shows the bill and is no longer marked estimated
-
-    @unimplemented
-    Scenario: Gateway spend no bill covers stands alone
-      Given gateway spend on a key no bill covers
-      When the connected view is drawn
-      Then that spend is shown on its own as metered
-      And it is not counted against any bill
-
-    @unimplemented
-    Scenario: A bill and its keys in different currencies are not combined
-      Given a bill in euros covering keys metered in dollars
-      And the provider published no dollar figure of its own
-      When the connected view is drawn
-      Then the bill and the gateway spend are shown separately in their own currencies
-      And no split is shown for that day
-
-    @unimplemented
-    Scenario: The parts of a day always add up to its total
-      Given any provider day with a bill
-      When the connected view is drawn
-      Then the attributed part and the part not seen by the gateway add up to the total exactly
+  # =========================================================================
+  # THE CONNECTED VIEW WAS DESIGNED AND ITS INPUT WAS REMOVED.
+  #
+  # A rule here used to park eight scenarios for a view that would show one
+  # provider day as a bill split into the part the gateway saw and the part it
+  # did not — "$4.20 of the $6.00 attributed; $1.80 not seen by gateway" — plus
+  # a variance line when metering ran over, and an estimated tag until the bill
+  # landed. Every one of them started from an admin's mapping saying which
+  # gateway keys a given bill pays for. That mapping was deleted outright on
+  # 2026-09-04 (ADR-128 section 7, marked deleted; the model, migration,
+  # service, repository, tests and its own fifteen-scenario spec all went with
+  # it), and nothing replaced it. A scenario cannot describe a split whose only
+  # input no longer exists, so the eight were removed rather than left parked:
+  # a parked scenario is a promise, and this one had stopped being one.
+  #
+  # What ships instead is the wave-1 shape, and it is bound elsewhere in this
+  # file rather than restated here:
+  #
+  #   - the lanes stand side by side, each labeled with its own figure, and
+  #     nothing merges them - "Each lane renders its own labeled total";
+  #   - a provider day that is a refund shows negative, unclamped - "A
+  #     refund-heavy billed day renders negative as reported";
+  #   - a lane holding usage billed in a currency we cannot state in dollars
+  #     withholds its total and says which currency - "A lane with usage we
+  #     cannot state in US dollars holds no total" and "A lane with no total
+  #     says why instead of showing a figure";
+  #   - a day the provider may still restate is marked as able to change, from
+  #     the settling window rather than from the absence of a bill - see
+  #     specs/governance/governance-cost-restatement-markers.feature.
+  #
+  # If the connected view is ever revived it needs a new coverage decision
+  # first; these scenarios would be written against that, not recovered from
+  # here.
+  # =========================================================================
 
   # A REFUSAL IS NOT A FAILURE.
   #

--- a/specs/governance/governance-cost-screen.feature
+++ b/specs/governance/governance-cost-screen.feature
@@ -22,6 +22,30 @@ Feature: One cost screen, three honest lanes
     Given an organization with billed and gateway cost available
 
   @integration
+  Scenario: A cost-only viewer sees provider costs inside the billed card
+    Given OpenAI and Anthropic have recorded costs without named people
+    And the viewer holds governanceCost:view without identity or activity access
+    When the viewer opens Costs
+    Then the billed card shows its combined total and a labeled bar for each provider
+    And gateway costs are not included in those bars
+
+  @integration
+  Scenario: Provider totals use corrected rollup cells within the selected window
+    Given multiple cost cells, corrections, and a refund for one provider
+    And another provider has an unpriced cell
+    When provider costs are read for the organization and selected window
+    Then only the latest current-projection pulled cells in that window are counted
+    And named and unnamed spending both contribute to their provider
+    And the unpriced provider's amount is unavailable
+
+  @integration
+  Scenario: Missing provider prices are not displayed as zero
+    Given a provider has no complete USD amount
+    When the viewer opens Costs
+    Then that provider is labeled with an unavailable USD amount
+    And a recorded refund keeps its negative amount
+
+  @integration
   Scenario: The department filter explains that it changes only the department breakdown
     Given cost activity in two departments
     And the viewer holds both governanceCost:view and activityMonitor:view

--- a/specs/governance/governance-people-discovery.feature
+++ b/specs/governance/governance-people-discovery.feature
@@ -98,6 +98,115 @@ Feature: Provider rows become discovered people
     # Same contract as the seat read, including naming HTTP 403 for what it
     # is: consent never granted, not a role misassigned.
 
+  # ── What one directory page is worth ──────────────────────────────────────
+  # The read is one paged listing of a tenant's own people, and the ways it
+  # goes wrong all look alike from the outside: an empty tenant, a page the
+  # reader could not parse, and a page that arrived from somewhere else all
+  # deliver zero people. Telling them apart is the whole job below, because
+  # only one of the three is a fact about the tenant.
+
+  @unit
+  Scenario: A directory page hands back its rows and the link to the next one
+    Given a directory page of people that names a next page
+    When the page is read
+    Then the people on it are returned
+    And the link to the next page is returned beside them
+
+  @unit
+  Scenario: A directory row that cannot be read costs the row, not the page
+    Given a directory page carrying one readable person and one row that is not
+    When the page is read
+    Then the readable person is returned
+    And the unreadable row is counted
+    # Dropping the page instead would lose a whole tenant's morning over one
+    # malformed record, and counting it is what makes the loss visible.
+
+  @unit
+  Scenario: A directory row carrying nothing but an id is still a person
+    Given a directory row that carries an id and no other field
+    When the page is read
+    Then that person is returned
+    And no row is counted as unreadable
+    # The directory omits fields it has no value for rather than sending them
+    # empty, so a sparse row is the ordinary case, not a broken one.
+
+  @unit
+  Scenario: A directory answer that is not a page is malformed, not an empty tenant
+    Given an answer to the directory read that is not a page of people at all
+    When the answer is read
+    Then the answer is called malformed
+    And no people are returned
+    # An empty tenant and an unreadable answer both yield nobody. Recording
+    # the second as the first would report a company as having no staff.
+
+  @unit
+  Scenario: A directory answer that is not a page holds the day rather than emptying the tenant
+    Given a Copilot source with the directory read switched on
+    When the directory answers with something that is not a page of people
+    Then no directory rows are recorded
+    And the directory day is held to be retried, not marked read
+
+  @unit
+  Scenario: A directory row is recorded against the person and the day
+    Given the directory names a person, their address and their department
+    When the row is shaped into a record
+    Then the record is identified by that person and that day
+    And the record names the person by their directory id, not their address
+    And the record carries what the directory said about them
+    # The id is what the tenant's other rows call the same human, and what an
+    # erasure of this provider suppresses. An address is neither.
+
+  @unit
+  Scenario: A directory field the tenant left empty is recorded empty
+    Given a directory row whose name, address and department are all absent
+    When the row is shaped into a record
+    Then each absent field is recorded as empty text
+    # Never the word "undefined". These land in display text a person reads.
+
+  @unit
+  Scenario: A directory read records a row per person beside the conversations
+    Given a Copilot source with the directory read switched on
+    When the source runs
+    Then a directory record is delivered for each person
+    And the conversations are delivered alongside them
+    And the day is marked read
+
+  @unit
+  Scenario: The directory read asks only for the fields it records
+    Given a Copilot source with the directory read switched on
+    When the source reads the directory
+    Then the request names only the fields the record carries
+    And the request refuses to follow a redirect
+    # The request carries the tenant's token; a redirect would hand it to
+    # whoever answered. Asking for nothing more than is recorded keeps the
+    # blast radius of that token to what the feature actually needs.
+
+  @unit
+  Scenario: A directory spanning pages is read to the end and counted as one day
+    Given a directory whose people span two pages
+    When the source reads it
+    Then everybody on both pages is recorded
+    And the day is marked read once
+
+  @unit
+  Scenario: A next-page link is followed only when it is Microsoft Graph over https
+    Given candidate next-page links, one of them the real directory over https
+    When each is checked before being followed
+    Then only the real directory over https is accepted
+    # Plain http, a lookalike host, an embedded credential and a stray port
+    # are each refused on their own. The token rides this request, so the
+    # check is on the authority, not on the text of the link.
+
+  @unit
+  Scenario: A directory next-page link off Microsoft Graph is refused and the day held
+    Given a Copilot source with the directory read switched on
+    And the directory answers with a next-page link that is not the directory
+    When the source reads it
+    Then the link is not followed
+    And no directory rows are recorded
+    And the conversations are still delivered
+    And the directory day is held to be retried, not marked read
+
   @integration
   Scenario: A directory row enriches a discovered person's display text
     Given a discovered person whose display text is a bare directory id

--- a/specs/governance/governance-people-discovery.feature
+++ b/specs/governance/governance-people-discovery.feature
@@ -182,6 +182,17 @@ Feature: Provider rows become discovered people
     # This correction preserves directory-only assignment. It does not change
     # identity-link review; it stops assignment from ignoring conflicting proof.
 
+  @unit
+  Scenario: An accepted identity link outranks a disagreeing directory row
+    Given a discovered person whose accepted identity link names one member
+    And the directory identifier on their row names a different member
+    When the directory sync runs
+    Then the department lands on the member the accepted link names
+    # The link is somebody's dated, reviewable answer to "who is this?", and
+    # the sync now hands it to the same conflict rule the match engine uses.
+    # Without it a stale directory identifier silently re-files a person's
+    # department under another account.
+
   @integration
   Scenario: A directory row proving no member assigns nobody
     Given a directory row whose identity proves no platform member

--- a/specs/governance/governance-platform-placeholders.feature
+++ b/specs/governance/governance-platform-placeholders.feature
@@ -8,7 +8,9 @@ Feature: Platform placeholders — Insights, Analytics, Signals & Alerts
   They exist so the whole flow can be walked and judged in one sitting.
   Nothing on them stores anything, and nothing on them may
   claim to. A control with no backing does nothing; it never reports
-  success. The three sit in a "Platform" group of the governance
+  success. Each screen is marked Preview and its copy stays in the future
+  tense: it says what the screen shows today and what is coming, and it
+  never describes unbuilt work as something already running. The three sit in a "Platform" group of the governance
   sidebar, behind the same release flag as Costs and Billed, and behind
   the governance view permission.
   Decision: none — placeholder UI, reversible, no stored state.
@@ -49,11 +51,14 @@ Feature: Platform placeholders — Insights, Analytics, Signals & Alerts
   @integration
   Scenario: Insights opens on an empty brief with one sentence of promise
     When the member opens "/governance/insights"
-    Then the heading reads "Insights"
-    And the body says "Every morning a background job reads yesterday's
-      traffic and files a couple of high-signal insights: not fifteen a
-      day." and nothing longer
+    Then the heading reads "Insights" and carries a "Preview" badge
+    And the body says "A couple of things worth acting on each day, never a
+      feed of fifteen. Nothing has been filed here yet." and nothing longer
+    And the display line reads "Langy will write your brief here"
     And a "Set up data" action and an "Open Langy" action are offered
+    # Future tense throughout: no morning job runs, so no copy may say one
+    # does. The two actions are the only ones offered, because the sample
+    # inbox they used to sit beside had nothing behind it.
 
   @integration
   Scenario: The inbox rail is in place at zero
@@ -103,11 +108,13 @@ Feature: Platform placeholders — Insights, Analytics, Signals & Alerts
   @integration
   Scenario: Signals & Alerts opens on an empty registry
     When the member opens "/governance/signals"
-    Then the heading reads "Signals & Alerts"
-    And the registry says "No rules scoped here yet. Create one from any
-      chart's bell icon."
+    Then the heading reads "Signals & Alerts" and carries a "Preview" badge
+    And the registry says "No rules here yet. Creating one is coming."
     And "Insights inbox" links to "/governance/insights"
     And "model providers" links to "/settings/model-providers"
+    # The old line sent the reader to a chart bell icon that was never
+    # built. Nothing watches activity yet, so the copy promises no rule
+    # firing, no alert notifying and no automation acting.
 
   # ---------------------------------------------------------------------------
   # Analytics
@@ -116,10 +123,12 @@ Feature: Platform placeholders — Insights, Analytics, Signals & Alerts
   @integration
   Scenario: Analytics opens on the spend-by-department template
     When the member opens "/governance/analytics"
-    Then the heading reads "Analytics"
+    Then the heading reads "Analytics" and carries a "Preview" badge
     And the chart is titled "Cost by department · weekly"
-    And the chart body says "No data yet"
+    And the chart body says "This chart is not connected to your data yet"
     And the query line reads "usage | summarize sum(cost) by department, bin(1w)"
+    # "No data yet" reads as an empty organization. Nothing queries
+    # anything, so the body names the real reason instead.
 
   @unit
   Scenario: The query line follows the measure, breakdown and interval
@@ -136,3 +145,25 @@ Feature: Platform placeholders — Insights, Analytics, Signals & Alerts
     Then the measure reads "Requests", the breakdown "Model" and the
       interval "Daily"
     And the query line reads "usage | summarize count() by model, bin(1d)"
+
+  # ---------------------------------------------------------------------------
+  # Honesty — every control acts, and the copy claims nothing more
+  # ---------------------------------------------------------------------------
+
+  @integration
+  Scenario: Every control the Platform screens offer does something when pressed
+    When the member opens "/governance/analytics" or "/governance/insights"
+    Then pressing any control on the screen changes what the screen shows
+    And no control is offered that answers a press with nothing
+    # The Add filter chip on Analytics and the sample-inbox link on
+    # Insights were both offered and both did nothing. The Signals header
+    # actions are excluded here: they are owned by the page-header restyle,
+    # and are still inert.
+
+  @integration
+  Scenario: The Platform screens describe unbuilt work in the future tense
+    When the member opens "/governance/signals", "/governance/analytics"
+      or "/governance/insights"
+    Then no copy on the screen says that a rule fires, an alert notifies,
+      an automation acts, a job runs or a query is executed today
+    And each screen names the one thing it does show

--- a/specs/navigation/product-switcher-navigation.feature
+++ b/specs/navigation/product-switcher-navigation.feature
@@ -104,6 +104,19 @@ Feature: Product switcher navigation
     Given I am on a Gateway page in the product-switcher mode
     Then the top bar shows no project chip and no personal badge
 
+  @unit
+  Scenario: A sticky personal workspace does not follow me onto an org-wide page
+    Given the workspace I last worked in was my own personal one
+    When I open a Gateway or a Governance page
+    Then the page keeps the organization scope its address asks for
+    And it does not render as my personal surface
+    # The scope carried between pages is the workspace I was last in, not
+    # something the address said. Gateway and Governance are organization-wide
+    # by definition, so letting that sticky workspace decide put a Personal
+    # badge, the personal sidebar and a lit-up Me in the switcher on a page
+    # that is about the whole organization. Settings was already exempt for
+    # the same reason.
+
   @integration
   Scenario: The sidebar ignores the page's auto-hide request in the new modes
     Given a page that collapses the sidebar in the current chrome

--- a/tools/thuishaven/domain/domain_test.go
+++ b/tools/thuishaven/domain/domain_test.go
@@ -148,6 +148,21 @@ func TestOverlayEmitsClickHouseURLOnlyWhenManaged(t *testing.T) {
 	}
 }
 
+func TestManagedClickHouseClientsLeaveRoomForOtherLocalProcesses(t *testing.T) {
+	stack := Stack{ClickHouseHTTPPort: 18123, ClickHouseDatabase: "lw_test"}
+	if got := valueOf(stack.OverlayEnv(), "CLICKHOUSE_SERVER_MAX_CONCURRENT_QUERIES"); got != "32" {
+		t.Errorf("client must know the managed server budget: got %q", got)
+	}
+	if got := valueOf(stack.OverlayEnv(), "CLICKHOUSE_MAX_OPEN_CONNECTIONS"); got != "4" {
+		t.Errorf("local API and worker clients must leave headroom for other stacks: got %q", got)
+	}
+	for _, key := range []string{"CLICKHOUSE_SERVER_MAX_CONCURRENT_QUERIES", "CLICKHOUSE_MAX_OPEN_CONNECTIONS"} {
+		if hasKey((Stack{}).OverlayEnv(), key) {
+			t.Errorf("unmanaged ClickHouse must retain its own configuration: %s", key)
+		}
+	}
+}
+
 func TestOverlayDisablesGoogleDLPWhenAsked(t *testing.T) {
 	base := Stack{Slug: "brave-otter", APIPort: 1, Services: []Service{
 		{Name: "app", URL: "https://app.brave-otter.langwatch.localhost"},

--- a/tools/thuishaven/domain/domain_test.go
+++ b/tools/thuishaven/domain/domain_test.go
@@ -148,21 +148,6 @@ func TestOverlayEmitsClickHouseURLOnlyWhenManaged(t *testing.T) {
 	}
 }
 
-func TestManagedClickHouseClientsLeaveRoomForOtherLocalProcesses(t *testing.T) {
-	stack := Stack{ClickHouseHTTPPort: 18123, ClickHouseDatabase: "lw_test"}
-	if got := valueOf(stack.OverlayEnv(), "CLICKHOUSE_SERVER_MAX_CONCURRENT_QUERIES"); got != "32" {
-		t.Errorf("client must know the managed server budget: got %q", got)
-	}
-	if got := valueOf(stack.OverlayEnv(), "CLICKHOUSE_MAX_OPEN_CONNECTIONS"); got != "4" {
-		t.Errorf("local API and worker clients must leave headroom for other stacks: got %q", got)
-	}
-	for _, key := range []string{"CLICKHOUSE_SERVER_MAX_CONCURRENT_QUERIES", "CLICKHOUSE_MAX_OPEN_CONNECTIONS"} {
-		if hasKey((Stack{}).OverlayEnv(), key) {
-			t.Errorf("unmanaged ClickHouse must retain its own configuration: %s", key)
-		}
-	}
-}
-
 func TestOverlayDisablesGoogleDLPWhenAsked(t *testing.T) {
 	base := Stack{Slug: "brave-otter", APIPort: 1, Services: []Service{
 		{Name: "app", URL: "https://app.brave-otter.langwatch.localhost"},

--- a/tools/thuishaven/domain/overlay.go
+++ b/tools/thuishaven/domain/overlay.go
@@ -183,14 +183,6 @@ func (s Stack) OverlayEnv() []string {
 	if s.ClickHouseHTTPPort != 0 && s.ClickHouseDatabase != "" {
 		env = append(env, fmt.Sprintf("CLICKHOUSE_URL=http://%s:%s@127.0.0.1:%d/%s",
 			ClickHouseUser, ClickHousePassword, s.ClickHouseHTTPPort, s.ClickHouseDatabase))
-		// The production fallback is 64 statements per process, but the shared
-		// local server admits only 32. Keep each API/worker process small enough
-		// that concurrent backfills leave room for other stacks and local reads.
-		// This is a conservative local default, not a fleet-wide reservation.
-		env = append(env,
-			"CLICKHOUSE_SERVER_MAX_CONCURRENT_QUERIES=32",
-			"CLICKHOUSE_MAX_OPEN_CONNECTIONS=4",
-		)
 		// Backup-status gauges query system.backup_log, which only exists once
 		// backups are configured, a production concern. The app collects them by
 		// default (unset must not disarm the production alerts that read them), so

--- a/tools/thuishaven/domain/overlay.go
+++ b/tools/thuishaven/domain/overlay.go
@@ -183,6 +183,14 @@ func (s Stack) OverlayEnv() []string {
 	if s.ClickHouseHTTPPort != 0 && s.ClickHouseDatabase != "" {
 		env = append(env, fmt.Sprintf("CLICKHOUSE_URL=http://%s:%s@127.0.0.1:%d/%s",
 			ClickHouseUser, ClickHousePassword, s.ClickHouseHTTPPort, s.ClickHouseDatabase))
+		// The production fallback is 64 statements per process, but the shared
+		// local server admits only 32. Keep each API/worker process small enough
+		// that concurrent backfills leave room for other stacks and local reads.
+		// This is a conservative local default, not a fleet-wide reservation.
+		env = append(env,
+			"CLICKHOUSE_SERVER_MAX_CONCURRENT_QUERIES=32",
+			"CLICKHOUSE_MAX_OPEN_CONNECTIONS=4",
+		)
 		// Backup-status gauges query system.backup_log, which only exists once
 		// backups are configured, a production concern. The app collects them by
 		// default (unset must not disarm the production alerts that read them), so


### PR DESCRIPTION
## Why

The Costs card combined every provider into one total, so a reader could not tell providers apart — least of all for spend with no named person against it. Source health labels hid whether an import had saved anything or recovered, and provider rate-limit replies lost their retry timing before reaching the durable scheduler.

Alongside that, this branch carries a set of corrections found while reading the governance surface against what the code and the provider probe kits actually support: several screens and docs promised behaviour that was not built, and two ingestion source types were on offer with no working data path behind them.

Closes #8022.

## What changed

**Costs and provider attribution**

- Labelled provider cost bars inside the top billed card, including spend with no person attributed. The selected window is read from `governance_cost_rollup_1d`, corrected cells are collapsed before summing, refunds and unavailable USD amounts survive, and the headline is derived from the same provider result so an in-flight import cannot make the two disagree.
- Anthropic watermarks take the maximum rather than the last value seen, and colliding cost keys are refused instead of silently merged.
- An empty Azure `nextLink` is treated as the last page rather than a link to follow.

**Imports and identity**

- Anthropic and OpenAI HTTP 429 replies keep their `Retry-After` through the existing durable retry scheduler. Draining the response body is best-effort, so a failed drain cannot replace the error that carries the wait. Response bodies and page tokens stay off the client.
- Department sync honours an already-accepted identity link instead of re-resolving it.
- Opaque OpenAI actor ids stay out of the actor email field; the mapper behind that routing is now a pure module.
- Source health refreshes every 30 seconds while visible and on window focus, never in a hidden tab. "Not pulling" became "Pulls failing", and the detail view shows the last successful pull, the latest completed attempt, a safe failure reason and any saved backfill checkpoint.
- Historical records are explained without recommending timestamp edits: the newest event is found across retained history while the activity counters stay bounded to 24 hours, 7 days and 30 days.

**Honesty about what exists**

- The two Enterprise Compliance source types (OpenAI and Anthropic Claude) are no longer offered. Neither had a finished data path, so picking one bought an admin a source that stayed silent. They are hidden rather than deleted, because the label map is built from the same list and read without a fallback — sources already configured on them keep rendering their name and vendor mark.
- Preview screens no longer describe an unbuilt dashboard, anomaly rules are no longer presented as shipped, and the OpenAI cost report's page-size claims match what the wire returns rather than the published maximum.
- ADR-122, ADR-128 and ADR-129 are reconciled with the code at head, including recording the actor-field fix as resolved.
- Gateway and Governance keep their organization scope instead of inheriting a sticky personal one from the reader's last project.

## Deployment Impact

No operator action. No migration, no new environment variable, no chart or service change — the only deployment-surface paths in the diff are the three ADR documents, which are text.

Two behaviour changes are worth knowing before the deploy lands:

- The OpenAI and Anthropic Claude Enterprise Compliance types disappear from the "Add source" menu. Existing sources configured on them are untouched and still render; they simply cannot be chosen for a new source.
- The inventory and source-health queries poll every 30 seconds while their tab is visible, and stop while it is not. This adds a bounded read load per open inventory tab and none for tabs left in the background.

## Test plan

Regression tests reproduced each defect before its fix:

```text
Browser: Unable to find an element with the text: Pulls failing
Source DTO: expected undefined to deeply equal { ... }
Historical source query: expected +0 to be [the seeded historical timestamp]
Provider retry: promise resolved "{ events: [], cursor: null, …(1) }" instead of rejecting
Rate-limit drain: promise rejected "stream already errored" instead of the DispatchError
```

The rate-limit drain guard is pinned by a test in each puller that plants a rejecting `cancel()` — a real `Response` resolves it, so the rejection has to be constructed. Both were confirmed to fail with the guard removed and pass with it restored.

Provider-card validation: 51 service and repository unit tests, 78 Costs-page component tests, and 3 router tests against real PostgreSQL and ClickHouse. The tests first reproduced the missing labels and the total/provider discrepancy under concurrent ingestion.

Whole-tree `pnpm lint` and `pnpm typecheck:all` both pass, as does the Biome new-violations gate against the merge base. An authenticated GET through the running local app returned HTTP 200 with both provider rows.

## Anything surprising?

The sweep covered all three source-health database paths, both source-status surfaces, and the swallowed rate-limit errors in both admin adapters.

Known limits, deliberately not handled here: a provider delay longer than the existing 30-minute stale-run threshold can still overlap a replacement run, and the final exhausted attempt does not carry its delay into the next scheduled run. This change preserves delays between durable retry attempts, not a provider-wide cooldown. Other provider retry policies and provider-wide quota coordination are out of scope.

Provider totals cross the repository boundary as a JavaScript number, which is exact to $9,007,199.25 per provider per 30-day window. Beyond that the loss is a billionth of a dollar, and the DTO field it feeds is a `number` anyway, so the exactness cannot be observed downstream. Four sibling read paths in the same repository share the treatment; moving all of them plus the DTO to decimal strings is its own change, not this one.

Full-page browser visual confirmation is still outstanding; the component tests here mock the API boundary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Ingestion source details now show recent pull outcomes, failures, backfill progress, and remaining history.
  - Costs now include provider-by-provider billed-cost breakdowns, unavailable USD amounts, and refunds.
  - Insights, Signals, and Analytics pages are clearly labeled as previews.
- **Bug Fixes**
  - Provider rate limits now preserve retry timing for failed pulls.
  - Source health refreshes when returning to a page and periodically while visible.
  - Historical activity dates remain accurate outside standard reporting windows.
  - Gateway and Governance pages now retain the correct organization scope.
  - Unavailable ingestion source types are hidden from the source picker while existing sources remain visible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
