### PR TITLE
fix(ci): exempt process-substrate-alerting.feature as partially tagged

### DIFF
--- a/platform/app/scripts/check-feature-parity.ts
+++ b/platform/app/scripts/check-feature-parity.ts
@@ -750,6 +750,14 @@ const LEGACY_PARTIAL: string[] = [
   "specs/monitors/online-evaluator-loop-prevention.feature",
   "specs/navigation/shared-section-navigation-layout.feature",
   "specs/npx-installer/07-lean-install.feature",
+  // Reason: became partially tagged after this list was seeded (#7932 added
+  // three @unit metric scenarios and correctly retired the file's LEGACY_INERT
+  // entry, which no longer applied). Its eight untagged scenarios describe
+  // Prometheus alert rules, Helm chart packaging and dashboards kept in a
+  // separate repository — nothing this TypeScript-only scanner can bind (#3770).
+  // Whether each is implemented is not established, so they are left untagged
+  // rather than mislabelled; the per-scenario audit is tracked by #8024.
+  "specs/observability/process-substrate-alerting.feature",
   "specs/ops/internal-feature-flags.feature",
   "specs/optimization-studio/component-execution.feature",
   "specs/otlp/canonical-metric-ingestion.feature",

--- a/platform/app/scripts/check-feature-parity.ts
+++ b/platform/app/scripts/check-feature-parity.ts
@@ -752,11 +752,11 @@ const LEGACY_PARTIAL: string[] = [
   "specs/npx-installer/07-lean-install.feature",
   // Reason: became partially tagged after this list was seeded (#7932 added
   // three @unit metric scenarios and correctly retired the file's LEGACY_INERT
-  // entry, which no longer applied). Its eight untagged scenarios describe
-  // Prometheus alert rules, Helm chart packaging and dashboards kept in a
-  // separate repository — nothing this TypeScript-only scanner can bind (#3770).
-  // Whether each is implemented is not established, so they are left untagged
-  // rather than mislabelled; the per-scenario audit is tracked by #8024.
+  // entry). Its eight untagged scenarios describe alert rules, their delivery
+  // and dashboards, which ADR-054 keeps in a separate infrastructure
+  // repository — so whether each is implemented cannot be established from
+  // here, and tagging them either way would assert what this repo cannot
+  // check. Per-scenario audit tracked by #8024.
   "specs/observability/process-substrate-alerting.feature",
   "specs/ops/internal-feature-flags.feature",
   "specs/optimization-studio/component-execution.feature",

--- a/platform/app/scripts/check-feature-parity.ts
+++ b/platform/app/scripts/check-feature-parity.ts
@@ -750,13 +750,11 @@ const LEGACY_PARTIAL: string[] = [
   "specs/monitors/online-evaluator-loop-prevention.feature",
   "specs/navigation/shared-section-navigation-layout.feature",
   "specs/npx-installer/07-lean-install.feature",
-  // Reason: became partially tagged after this list was seeded (#7932 added
-  // three @unit metric scenarios and correctly retired the file's LEGACY_INERT
-  // entry). Its eight untagged scenarios describe alert rules, their delivery
-  // and dashboards, which ADR-054 keeps in a separate infrastructure
-  // repository — so whether each is implemented cannot be established from
-  // here, and tagging them either way would assert what this repo cannot
-  // check. Per-scenario audit tracked by #8024.
+  // Reason: arrived partially tagged when #7932 added three @unit metric
+  // scenarios and retired its LEGACY_INERT entry. The eight untagged ones
+  // describe alert rules, their delivery and dashboards, which ADR-054 keeps
+  // in a separate infrastructure repository, so their status cannot be
+  // established here. Per-scenario audit tracked by #8024.
   "specs/observability/process-substrate-alerting.feature",
   "specs/ops/internal-feature-flags.feature",
   "specs/optimization-studio/component-execution.feature",


### PR DESCRIPTION
Fixes #8024.

## Why

`feature-parity` fails on `main`, and it feeds `langwatch-app-complete`, which the branch ruleset requires. Any pull request that re-runs CI is blocked by it, whatever that pull request changed.

The checker is right and the code it checks is fine. A spec file changed category and the exemption covering it was removed without its replacement being added.

`specs/observability/process-substrate-alerting.feature` holds 11 scenarios: three tagged `@unit` and bound, eight with no tag at all. The gate treats that mix — some scenarios enforced, others silently unmeasured — as fatal unless the file is listed in `LEGACY_PARTIAL`.

#7932 added the three `@unit` scenarios and correctly retired the file's `LEGACY_INERT` entry, since that list covers files yielding *no* enforced scenario and the file now yields three. It did not add the file to `LEGACY_PARTIAL`. `LEGACY_PARTIAL` was seeded by #7669 from the files partially tagged at that moment; this one was still inert then, so its absence from the seed was correct and #7932 was in flight across the boundary.

## What changed

One entry in `LEGACY_PARTIAL`, in sort position, with a reason comment following the precedent at `check-feature-parity.ts:669-671`.

## What this deliberately does not do

It does not tag the eight scenarios. They describe alert rules, their delivery, and dashboards — which ADR-054 keeps in a separate infrastructure repository, not here.

- **`@unit` would bind nothing that exists.** Each of the eight titles was searched across every `.ts`, `.tsx`, `.py` and `.go` file under `platform/`: zero hits. `charts/langwatch` has 73 files and not one carries `PrometheusRule`, `alert:` or `expr:`. ADR-054 states it plainly — the public repo ships no alert rule, and `charts/langwatch/files/alerting-rules.yml` has no git history, so it never did.
- **`@unimplemented` would be a false claim.** It asserts the behaviour does not exist. ADR-054 Decision #2 says prod dashboards are provisioned from reviewed, versioned JSON in the infrastructure repo, and Decision #1 says the reviewed alert rules are provisioned alongside them. So the behaviour these scenarios describe may well exist — just not here. Asserting a gap that is not there writes a false statement into a spec, which is the exact defect class this gate was built to expose.

The exemption asserts only what is true and checkable: the scenarios are untagged, and that is tracked. The per-scenario audit needs the observability author and is scoped in #8024 — the same shape as #7675.

This is not a permanent escape. The script asserts every `LEGACY_PARTIAL` entry still resolves to a real file and is still partially tagged (`check-feature-parity.ts:663-666`), so the entry must be removed once the audit tags the file, and a stale entry fails the run.

### Corrected after self-review

The first commit gave the wrong reason for the same change. It said the scanner, being TypeScript-only, structurally cannot bind these scenarios, citing #3770. That is wrong twice over: #3770 is about scenarios whose tests are written in Python or Go, and this repo already binds Helm-chart scenarios from TypeScript — `specs/setup/helm-auth-base-url.feature` and `specs/setup/helm-langevals-memory.feature` are both `@unit`, bound by unit tests that read `charts/langwatch` templates and values.

The obstacle is not the scanner. It is that the artifacts live in another repository. `bfac11c` corrects the comment; the list entry is unchanged.

One thing an auditor should know up front: scenario 7 (`:46`, *"Every alert ships with the deployment that ships the metrics"*) describes the design ADR-054 Decision #1 was **amended to reverse** — the chart deliberately does not ship alert rules. ADR-054's Consequences section was not updated with that amendment and still claims the opposite (*"Self-hosted operators inherit sane alerts for free"*, *"Rules are chart-tested by the existing `helm template` CI matrix"*). That contradiction is noted in #8024.

## Verification

| Gate | Result |
| --- | --- |
| `pnpm check:feature-parity` | exit 0 (was exit 1 on a clean branch off `main`) |
| `pnpm lint` (full tree, as CI runs it) | 0 errors |
| `biome-new-violations.sh` vs `origin/main` | no new violations |
| `pnpm typecheck` | pass |
| `scripts/__tests__/check-feature-parity.unit.test.ts` | 48/48 pass |

The gate still reports the file in its tolerated section rather than hiding it, so the untagged eight stay visible in every run.

**The exemption does not weaken binding enforcement**, verified by experiment rather than by reading: with the entry in place, renaming one of the file's three `@unit` scenarios so its binding broke made the gate fail — `✗ THIS RUN FAILS: 1 unbound scenario(s) in enforced files`. `LEGACY_PARTIAL` tolerates only the untagged scenarios; the tagged ones stay enforced. Probe reverted, tree clean.

Sort position is correct (byte order, between `specs/npx-installer/07-lean-install.feature` and `specs/ops/internal-feature-flags.feature`), though note the script does **not** enforce ordering — it is convention only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated feature coverage records for observability process-substrate alerting scenarios.
  - Clarified that some scenarios are tracked separately because automated coverage checks cannot currently evaluate all of them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->