### PR TITLE
feat(helm): opt-in voice worker deployment, service and ingress

### DIFF
--- a/.github/workflows/langwatch-chart.yml
+++ b/.github/workflows/langwatch-chart.yml
@@ -196,8 +196,8 @@ jobs:
 
       # The voice worker is opt-in (langwatch/langwatch#8015): the default
       # install must render none of it, and enabling it must refuse to render
-      # without the two values it cannot work without (publicBaseUrl, the
-      # Twilio secret) — only visible in the rendered output.
+      # without the value it cannot work without (publicBaseUrl), only
+      # visible in the rendered output.
       - name: "assert the opt-in voice worker renders correctly"
         if: "!cancelled()"
         run: ./tests/voice-worker.sh

--- a/.github/workflows/langwatch-chart.yml
+++ b/.github/workflows/langwatch-chart.yml
@@ -194,6 +194,14 @@ jobs:
         if: "!cancelled()"
         run: ./tests/stored-objects-upgrade-ordering.sh
 
+      # The voice worker is opt-in (langwatch/langwatch#8015): the default
+      # install must render none of it, and enabling it must refuse to render
+      # without the two values it cannot work without (publicBaseUrl, the
+      # Twilio secret) — only visible in the rendered output.
+      - name: "assert the opt-in voice worker renders correctly"
+        if: "!cancelled()"
+        run: ./tests/voice-worker.sh
+
       # Design C rests on one Secret name resolving identically on both sides:
       # the app reads the langwatch_lwql password from exactly the Secret the
       # ClickHouse pod mounts to create that identity. The two names come from

--- a/charts/langwatch/README.md
+++ b/charts/langwatch/README.md
@@ -741,6 +741,7 @@ The chart refuses to render when `voice.enabled` is true and either
 | `voice.nodeSelector`           | Node selector overrides.                                                                                                   | `{}`                 |
 | `voice.tolerations`            | Tolerations overrides.                                                                                                     | `[]`                 |
 | `voice.affinity`               | Affinity overrides.                                                                                                        | `{}`                 |
+| `voice.topologySpreadConstraints` | Topology spread constraints overrides.                                                                                  | `[]`                 |
 | `voice.priorityClassName`      | PriorityClass for the voice worker pod (overrides `global.scheduling.priorityClassName`).                                  | `""`                 |
 | `voice.shutdownDrainSeconds`   | Seconds the voice worker may spend draining in-flight jobs on shutdown.                                                    | `25`                 |
 | `voice.terminationGracePeriodSeconds` | Seconds before SIGKILL. Must be at least `shutdownDrainSeconds` + 30.                                               | `55`                 |

--- a/charts/langwatch/README.md
+++ b/charts/langwatch/README.md
@@ -698,6 +698,57 @@ npx @bitnami/readme-generator-for-helm --readme ./README.md --values values.yaml
 | `workers.extraInitContainers`             | Additional init containers.                                                                                                                                                                                             | `[]`                |
 | `workers.extraVolumeMounts`               | Additional volume mounts for workers container.                                                                                                                                                                         | `[]`                |
 
+### Voice worker (opt-in)
+
+Off by default (`voice.enabled: false`). The default install renders no voice
+resources at all.
+
+Turning it on deploys a **single-replica** worker Deployment (same app image,
+`VOICE_WORKER_ONLY=true`) that terminates Twilio Media Streams calls, plus a
+Service and — optionally — an Ingress for its WebSocket port. Replicas are
+fixed at 1: the WebSocket routes an in-flight call by nonce inside one
+process, so a second replica would split a call's frames across two processes
+with no shared state.
+
+**Twilio Media Streams connects INBOUND to you.** Without a
+publicly-reachable `voice.publicBaseUrl`, there are no phone targets — no
+matter what else is configured. Terminate TLS at your own edge (the
+`voice.ingress` block, or an external load balancer pointed at the
+`voice.service`) and set `voice.publicBaseUrl` to that public `https://`
+origin; the worker derives `wss://<host>/twilio/<nonce>` from it.
+
+Bring your own Twilio account: `voice.twilio.existingSecret` names a Secret
+you create with the Account SID, auth token, and outbound caller id (key
+names configurable under `voice.twilio.keys`). The chart never carries phone
+numbers or call-routing rules — `allowed_callees` and the call-duration cap
+are project configuration, not environment (see
+[langwatch/langwatch#8014](https://github.com/langwatch/langwatch/issues/8014)).
+
+The chart refuses to render when `voice.enabled` is true and either
+`voice.publicBaseUrl` or `voice.twilio.existingSecret` is empty.
+
+| Name                          | Description                                                                                                              | Value              |
+| ------------------------------ | -------------------------------------------------------------------------------------------------------------------------- | -------------------- |
+| `voice.enabled`                | Deploy the voice worker Deployment, Service (and Ingress if `voice.ingress.enabled`). Off by default.                      | `false`              |
+| `voice.publicBaseUrl`          | Public `https://` origin Twilio connects to (e.g. `https://voice.example.com`). Required when `voice.enabled` is true.     | `""`                 |
+| `voice.wsPort`                 | Container port of the Twilio Media Streams WebSocket listener.                                                             | `3300`               |
+| `voice.twilio.existingSecret`  | Name of an existing Secret carrying the Twilio credential keys below. Required when `voice.enabled` is true.               | `""`                 |
+| `voice.twilio.keys.accountSid` | Key in the existing Secret for the Twilio Account SID.                                                                     | `TWILIO_ACCOUNT_SID` |
+| `voice.twilio.keys.authToken`  | Key in the existing Secret for the Twilio auth token.                                                                      | `TWILIO_AUTH_TOKEN`  |
+| `voice.twilio.keys.fromNumber` | Key in the existing Secret for the outbound caller id (E.164).                                                             | `TWILIO_FROM_NUMBER` |
+| `voice.resources`              | Resource requests and limits for the voice worker.                                                                         |                      |
+| `voice.nodeSelector`           | Node selector overrides.                                                                                                   | `{}`                 |
+| `voice.tolerations`            | Tolerations overrides.                                                                                                     | `[]`                 |
+| `voice.affinity`               | Affinity overrides.                                                                                                        | `{}`                 |
+| `voice.podAnnotations`         | Additional pod annotations for the voice worker.                                                                           | `{}`                 |
+| `voice.service.type`           | Service type.                                                                                                              | `ClusterIP`          |
+| `voice.service.port`           | Service port (target is `voice.wsPort`).                                                                                   | `3300`               |
+| `voice.ingress.enabled`        | Create an Ingress for the voice worker.                                                                                    | `false`              |
+| `voice.ingress.className`      | IngressClassName for the voice Ingress.                                                                                    | `""`                 |
+| `voice.ingress.annotations`    | Additional annotations (e.g. controller-specific WebSocket upgrade/timeout settings).                                      | `{}`                 |
+| `voice.ingress.host`           | Hostname the voice Ingress routes, matching `voice.publicBaseUrl`. Required when `voice.ingress.enabled` is true.          | `""`                 |
+| `voice.ingress.tls`            | TLS configuration, same shape as `ingress.tls` (`[{secretName, hosts}]`).                                                  | `[]`                 |
+
 ### NLP service
 
 | Name                                            | Description                                                                                                                                                                                                             | Value           |

--- a/charts/langwatch/README.md
+++ b/charts/langwatch/README.md
@@ -729,6 +729,7 @@ The chart refuses to render when `voice.enabled` is true and either
 
 | Name                          | Description                                                                                                              | Value              |
 | ------------------------------ | -------------------------------------------------------------------------------------------------------------------------- | -------------------- |
+| `voice.otel.serviceName`       | Service name reported in traces and logs.                                                                                  | `langwatch-voice`    |
 | `voice.enabled`                | Deploy the voice worker Deployment, Service (and Ingress if `voice.ingress.enabled`). Off by default.                      | `false`              |
 | `voice.publicBaseUrl`          | Public `https://` origin Twilio connects to (e.g. `https://voice.example.com`). Required when `voice.enabled` is true.     | `""`                 |
 | `voice.wsPort`                 | Container port of the Twilio Media Streams WebSocket listener.                                                             | `3300`               |
@@ -740,7 +741,9 @@ The chart refuses to render when `voice.enabled` is true and either
 | `voice.nodeSelector`           | Node selector overrides.                                                                                                   | `{}`                 |
 | `voice.tolerations`            | Tolerations overrides.                                                                                                     | `[]`                 |
 | `voice.affinity`               | Affinity overrides.                                                                                                        | `{}`                 |
-| `voice.podAnnotations`         | Additional pod annotations for the voice worker.                                                                           | `{}`                 |
+| `voice.priorityClassName`      | PriorityClass for the voice worker pod (overrides `global.scheduling.priorityClassName`).                                  | `""`                 |
+| `voice.pod.annotations`        | Additional pod annotations for the voice worker.                                                                           | `{}`                 |
+| `voice.deployment.annotations` | Additional Deployment annotations for the voice worker.                                                                    | `{}`                 |
 | `voice.service.type`           | Service type.                                                                                                              | `ClusterIP`          |
 | `voice.service.port`           | Service port (target is `voice.wsPort`).                                                                                   | `3300`               |
 | `voice.ingress.enabled`        | Create an Ingress for the voice worker.                                                                                    | `false`              |

--- a/charts/langwatch/README.md
+++ b/charts/langwatch/README.md
@@ -717,12 +717,11 @@ The public origin is resolved in priority order:
 Set `voice.publicBaseUrl` explicitly only when voice needs a **different**
 public host than the app (its own subdomain, its own edge).
 
-Turning it on deploys a **single-replica** worker Deployment (same app image,
-`VOICE_WORKER_ONLY=true`) that terminates inbound Media Streams calls, plus a
-Service and (also on by default) an Ingress for its WebSocket port. Replicas
-are fixed at 1: the WebSocket routes an in-flight call by nonce inside one
-process, so a second replica would split a call's frames across two processes
-with no shared state.
+Turning it on deploys a **single-replica** worker Deployment (same app image)
+that terminates inbound Media Streams calls, plus a Service and (also on by
+default) an Ingress for its WebSocket port. Replicas are fixed at 1: the
+WebSocket routes an in-flight call by nonce inside one process, so a second
+replica would split a call's frames across two processes with no shared state.
 
 **Media Streams connects INBOUND to you.** Without a resolved public
 `https://` origin, there are no phone targets, no matter what else is

--- a/charts/langwatch/README.md
+++ b/charts/langwatch/README.md
@@ -698,9 +698,9 @@ npx @bitnami/readme-generator-for-helm --readme ./README.md --values values.yaml
 | `workers.extraInitContainers`             | Additional init containers.                                                                                                                                                                                             | `[]`                |
 | `workers.extraVolumeMounts`               | Additional volume mounts for workers container.                                                                                                                                                                         | `[]`                |
 
-### Voice worker (opt-in)
+### Voice worker
 
-Off by default (`voice.enabled: false`). The default install renders no voice
+Off by default (`voice.enabled: false`); the default install renders no voice
 resources at all.
 
 Turning it on deploys a **single-replica** worker Deployment (same app image,
@@ -742,6 +742,9 @@ The chart refuses to render when `voice.enabled` is true and either
 | `voice.tolerations`            | Tolerations overrides.                                                                                                     | `[]`                 |
 | `voice.affinity`               | Affinity overrides.                                                                                                        | `{}`                 |
 | `voice.priorityClassName`      | PriorityClass for the voice worker pod (overrides `global.scheduling.priorityClassName`).                                  | `""`                 |
+| `voice.shutdownDrainSeconds`   | Seconds the voice worker may spend draining in-flight jobs on shutdown.                                                    | `25`                 |
+| `voice.terminationGracePeriodSeconds` | Seconds before SIGKILL. Must be at least `shutdownDrainSeconds` + 30.                                               | `55`                 |
+| `voice.extraEnvs`              | Additional environment variables for the voice worker container.                                                           | `[]`                 |
 | `voice.pod.annotations`        | Additional pod annotations for the voice worker.                                                                           | `{}`                 |
 | `voice.deployment.annotations` | Additional Deployment annotations for the voice worker.                                                                    | `{}`                 |
 | `voice.service.type`           | Service type.                                                                                                              | `ClusterIP`          |

--- a/charts/langwatch/README.md
+++ b/charts/langwatch/README.md
@@ -700,34 +700,60 @@ npx @bitnami/readme-generator-for-helm --readme ./README.md --values values.yaml
 
 ### Voice worker
 
-Off by default (`voice.enabled: false`); the default install renders no voice
-resources at all.
+On by default (`voice.enabled: true`), with **zero extra configuration**
+required on a cluster that already has a public `https://` URL for the app.
+It still needs a public `https://` origin to work, so with none resolvable it
+degrades quietly: no voice Deployment, Service or Ingress render, and
+`helm install`/`upgrade` NOTES explain why.
+
+The public origin is resolved in priority order:
+
+1. `voice.publicBaseUrl`, if set — an explicit value always wins, even a bad
+   one (the chart still refuses to render rather than silently ignore it).
+2. `app.http.publicUrl`, if that is already an `https://` origin — the
+   common case, and why most installs need nothing set here at all.
+3. Unresolved — voice renders nothing, no failure.
+
+Set `voice.publicBaseUrl` explicitly only when voice needs a **different**
+public host than the app (its own subdomain, its own edge).
 
 Turning it on deploys a **single-replica** worker Deployment (same app image,
 `VOICE_WORKER_ONLY=true`) that terminates inbound Media Streams calls, plus a
-Service and, optionally, an Ingress for its WebSocket port. Replicas are
-fixed at 1: the WebSocket routes an in-flight call by nonce inside one
+Service and (also on by default) an Ingress for its WebSocket port. Replicas
+are fixed at 1: the WebSocket routes an in-flight call by nonce inside one
 process, so a second replica would split a call's frames across two processes
 with no shared state.
 
-**Media Streams connects INBOUND to you.** Without a
-publicly-reachable `voice.publicBaseUrl`, there are no phone targets, no
-matter what else is configured. Terminate TLS at your own edge (the
-`voice.ingress` block, or an external load balancer pointed at the
-`voice.service`) and set `voice.publicBaseUrl` to that public `https://`
-origin; the worker derives `wss://<host>/twilio/<nonce>` from it.
+**Media Streams connects INBOUND to you.** Without a resolved public
+`https://` origin, there are no phone targets, no matter what else is
+configured. Terminate TLS at your own edge (the `voice.ingress` block, or an
+external load balancer pointed at the `voice.service`); the worker derives
+`wss://<host>/twilio/<nonce>` from the resolved origin.
+
+`voice.ingress.host` defaults to that resolved origin's hostname, so it needs
+no separate setting either; set it explicitly only to override, and it must
+then agree with the resolved origin or the render is refused, since Twilio
+dials the resolved origin and a mismatched Ingress would never see the
+WebSocket upgrade.
+
+`voice.ingress.annotations` defaults to nginx's `proxy-read-timeout` and
+`proxy-send-timeout` at `3600` seconds — nginx's stock 60-second timeout would
+cut off any call longer than a minute. These are **nginx-specific**; a
+different ingress controller needs its own equivalent WebSocket/timeout
+annotations set under this same key (which fully replaces the default map).
 
 Call-provider credentials (account SID, auth token, from-number) are
 configured per project inside LangWatch, not as chart values.
 
-The chart refuses to render when `voice.enabled` is true and
-`voice.publicBaseUrl` is empty.
+The chart refuses to render only when `voice.publicBaseUrl` (or, once
+resolved from it, `voice.ingress.host`) is explicitly set to something
+invalid — never for the merely-unresolved case.
 
 | Name                          | Description                                                                                                              | Value              |
 | ------------------------------ | -------------------------------------------------------------------------------------------------------------------------- | -------------------- |
 | `voice.otel.serviceName`       | Service name reported in traces and logs.                                                                                  | `langwatch-voice`    |
-| `voice.enabled`                | Deploy the voice worker Deployment, Service (and Ingress if `voice.ingress.enabled`). Off by default.                      | `false`              |
-| `voice.publicBaseUrl`          | Public `https://` origin the call provider connects to (e.g. `https://voice.example.com`). Required when `voice.enabled` is true. | `""`          |
+| `voice.enabled`                | Deploy the voice worker Deployment, Service (and Ingress if `voice.ingress.enabled`) once a public `https://` origin resolves. On by default. | `true`   |
+| `voice.publicBaseUrl`          | Public `https://` origin the call provider connects to (e.g. `https://voice.example.com`). Empty resolves to `app.http.publicUrl` when that is an `https://` origin. | `""` |
 | `voice.wsPort`                 | Container port of the Media Streams WebSocket listener.                                                                    | `3300`               |
 | `voice.resources`              | Resource requests and limits for the voice worker.                                                                         |                      |
 | `voice.nodeSelector`           | Node selector overrides.                                                                                                   | `{}`                 |
@@ -742,10 +768,10 @@ The chart refuses to render when `voice.enabled` is true and
 | `voice.deployment.annotations` | Additional Deployment annotations for the voice worker.                                                                    | `{}`                 |
 | `voice.service.type`           | Service type.                                                                                                              | `ClusterIP`          |
 | `voice.service.port`           | Service port (target is `voice.wsPort`).                                                                                   | `3300`               |
-| `voice.ingress.enabled`        | Create an Ingress for the voice worker.                                                                                    | `false`              |
+| `voice.ingress.enabled`        | Create an Ingress for the voice worker once a public `https://` origin resolves. On by default.                           | `true`               |
 | `voice.ingress.className`      | IngressClassName for the voice Ingress.                                                                                    | `""`                 |
-| `voice.ingress.annotations`    | Additional annotations (e.g. controller-specific WebSocket upgrade/timeout settings).                                      | `{}`                 |
-| `voice.ingress.host`           | Hostname the voice Ingress routes, matching `voice.publicBaseUrl`. Required when `voice.ingress.enabled` is true.          | `""`                 |
+| `voice.ingress.annotations`    | Additional annotations (e.g. controller-specific WebSocket upgrade/timeout settings). Defaults to nginx's 3600s proxy-read/send timeouts; replace the whole map for another controller. | `{nginx proxy-read/send-timeout: "3600"}` |
+| `voice.ingress.host`           | Hostname the voice Ingress routes. Empty defaults to the resolved public origin's hostname; an explicit value must agree with it.  | `""`                 |
 | `voice.ingress.tls`            | TLS configuration, same shape as `ingress.tls` (`[{secretName, hosts}]`).                                                  | `[]`                 |
 
 ### NLP service

--- a/charts/langwatch/README.md
+++ b/charts/langwatch/README.md
@@ -704,39 +704,31 @@ Off by default (`voice.enabled: false`); the default install renders no voice
 resources at all.
 
 Turning it on deploys a **single-replica** worker Deployment (same app image,
-`VOICE_WORKER_ONLY=true`) that terminates Twilio Media Streams calls, plus a
-Service and — optionally — an Ingress for its WebSocket port. Replicas are
+`VOICE_WORKER_ONLY=true`) that terminates inbound Media Streams calls, plus a
+Service and, optionally, an Ingress for its WebSocket port. Replicas are
 fixed at 1: the WebSocket routes an in-flight call by nonce inside one
 process, so a second replica would split a call's frames across two processes
 with no shared state.
 
-**Twilio Media Streams connects INBOUND to you.** Without a
-publicly-reachable `voice.publicBaseUrl`, there are no phone targets — no
+**Media Streams connects INBOUND to you.** Without a
+publicly-reachable `voice.publicBaseUrl`, there are no phone targets, no
 matter what else is configured. Terminate TLS at your own edge (the
 `voice.ingress` block, or an external load balancer pointed at the
 `voice.service`) and set `voice.publicBaseUrl` to that public `https://`
 origin; the worker derives `wss://<host>/twilio/<nonce>` from it.
 
-Bring your own Twilio account: `voice.twilio.existingSecret` names a Secret
-you create with the Account SID, auth token, and outbound caller id (key
-names configurable under `voice.twilio.keys`). The chart never carries phone
-numbers or call-routing rules — `allowed_callees` and the call-duration cap
-are project configuration, not environment (see
-[langwatch/langwatch#8014](https://github.com/langwatch/langwatch/issues/8014)).
+Call-provider credentials (account SID, auth token, from-number) are
+configured per project inside LangWatch, not as chart values.
 
-The chart refuses to render when `voice.enabled` is true and either
-`voice.publicBaseUrl` or `voice.twilio.existingSecret` is empty.
+The chart refuses to render when `voice.enabled` is true and
+`voice.publicBaseUrl` is empty.
 
 | Name                          | Description                                                                                                              | Value              |
 | ------------------------------ | -------------------------------------------------------------------------------------------------------------------------- | -------------------- |
 | `voice.otel.serviceName`       | Service name reported in traces and logs.                                                                                  | `langwatch-voice`    |
 | `voice.enabled`                | Deploy the voice worker Deployment, Service (and Ingress if `voice.ingress.enabled`). Off by default.                      | `false`              |
-| `voice.publicBaseUrl`          | Public `https://` origin Twilio connects to (e.g. `https://voice.example.com`). Required when `voice.enabled` is true.     | `""`                 |
-| `voice.wsPort`                 | Container port of the Twilio Media Streams WebSocket listener.                                                             | `3300`               |
-| `voice.twilio.existingSecret`  | Name of an existing Secret carrying the Twilio credential keys below. Required when `voice.enabled` is true.               | `""`                 |
-| `voice.twilio.keys.accountSid` | Key in the existing Secret for the Twilio Account SID.                                                                     | `TWILIO_ACCOUNT_SID` |
-| `voice.twilio.keys.authToken`  | Key in the existing Secret for the Twilio auth token.                                                                      | `TWILIO_AUTH_TOKEN`  |
-| `voice.twilio.keys.fromNumber` | Key in the existing Secret for the outbound caller id (E.164).                                                             | `TWILIO_FROM_NUMBER` |
+| `voice.publicBaseUrl`          | Public `https://` origin the call provider connects to (e.g. `https://voice.example.com`). Required when `voice.enabled` is true. | `""`          |
+| `voice.wsPort`                 | Container port of the Media Streams WebSocket listener.                                                                    | `3300`               |
 | `voice.resources`              | Resource requests and limits for the voice worker.                                                                         |                      |
 | `voice.nodeSelector`           | Node selector overrides.                                                                                                   | `{}`                 |
 | `voice.tolerations`            | Tolerations overrides.                                                                                                     | `[]`                 |

--- a/charts/langwatch/templates/NOTES.txt
+++ b/charts/langwatch/templates/NOTES.txt
@@ -410,3 +410,23 @@ else breaks.
 Disabled (lwql.enabled=false). No LangWatchQL objects are provisioned
 and the endpoints refuse every query.
 {{- end }}
+
+{{- if and .Values.voice.enabled (not (include "langwatch.voice.publicBaseUrl" .)) }}
+
+──────────────────────────────────────────────────────────────────────
+9. Voice worker (Twilio phone simulations)
+──────────────────────────────────────────────────────────────────────
+⚠ Voice simulations are OFF: no public https:// URL is configured, so no
+voice worker resources were rendered.
+
+The voice worker (voice.enabled, on by default) needs a public https://
+origin to hand to the call provider. It resolves this two ways:
+  • app.http.publicUrl, if that is already an https:// origin — the common
+    case, zero extra values needed.
+  • voice.publicBaseUrl, set explicitly, if voice needs a different public
+    host than the app.
+
+Neither is set to an https:// origin on this install, so phone simulations
+stay off. Set one of them (and, for a cluster edge, terminate TLS in front
+of it) to turn voice on.
+{{- end }}

--- a/charts/langwatch/templates/_helpers.tpl
+++ b/charts/langwatch/templates/_helpers.tpl
@@ -2087,3 +2087,33 @@ azure.workload.identity/use: "true"
 {{- end -}}
 {{- end -}}
 {{- end }}
+
+{{/*
+Resolves the voice worker's public https:// origin so an operator does not
+have to set a fourth value just to turn phone simulations on.
+
+Priority:
+  1. voice.publicBaseUrl, if set — an explicit value always wins, even a bad
+     one. Validation of the RESOLVED value (the strict https-origin regex)
+     still runs at every call site, so a bad explicit value still fails the
+     render; this helper only decides WHICH value gets validated.
+  2. app.http.publicUrl, if it is an https:// origin — the chart already
+     knows the app's public URL, and voice shares the same edge in the
+     common case.
+  3. "" — cannot be resolved. Callers must treat this as "render nothing",
+     not as a failure: a default install's app.http.publicUrl is
+     http://localhost:5560, and a stock `helm template` must not fail.
+*/}}
+{{- define "langwatch.voice.publicBaseUrl" -}}
+{{- $explicit := .Values.voice.publicBaseUrl | default "" -}}
+{{- if $explicit -}}
+{{- $explicit -}}
+{{- else -}}
+{{- $appPublicUrl := ((.Values.app).http).publicUrl | default "" -}}
+{{- if hasPrefix "https://" $appPublicUrl -}}
+{{- $appPublicUrl -}}
+{{- else -}}
+{{- "" -}}
+{{- end -}}
+{{- end -}}
+{{- end }}

--- a/charts/langwatch/templates/voice/deployment.yaml
+++ b/charts/langwatch/templates/voice/deployment.yaml
@@ -1,9 +1,13 @@
 {{- if .Values.voice.enabled }}
-{{- if not .Values.voice.publicBaseUrl }}
-{{- fail "voice.publicBaseUrl is required when voice.enabled is true, Media Streams connects inbound to this URL, and the worker refuses to start without it. Set it to the public https:// origin fronting the voice Service/Ingress." }}
-{{- end }}
-{{- if not (regexMatch "^https://[A-Za-z0-9]([A-Za-z0-9-]*[A-Za-z0-9])?(\\.[A-Za-z0-9]([A-Za-z0-9-]*[A-Za-z0-9])?)*(:([1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5]))?$" .Values.voice.publicBaseUrl) }}
-{{- fail (printf "voice.publicBaseUrl (%q) must be an https origin only: scheme, hostname, optional port 1-65535, no path or query, for example https://voice.example.com." .Values.voice.publicBaseUrl) }}
+{{- $voicePublicBaseUrl := include "langwatch.voice.publicBaseUrl" . }}
+{{/* Empty means unresolved: no explicit voice.publicBaseUrl and
+     app.http.publicUrl is not an https:// origin (e.g. the chart default,
+     http://localhost:5560). That is a quiet "render nothing", not a failure
+     — see the helper doc comment. An explicit bad value never resolves to
+     empty, so it always reaches the regex check below and fails loudly. */}}
+{{- if $voicePublicBaseUrl }}
+{{- if not (regexMatch "^https://[A-Za-z0-9]([A-Za-z0-9-]*[A-Za-z0-9])?(\\.[A-Za-z0-9]([A-Za-z0-9-]*[A-Za-z0-9])?)*(:([1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5]))?$" $voicePublicBaseUrl) }}
+{{- fail (printf "voice.publicBaseUrl (%q) must be an https origin only: scheme, hostname, optional port 1-65535, no path or query, for example https://voice.example.com." $voicePublicBaseUrl) }}
 {{- end }}
 apiVersion: apps/v1
 kind: Deployment
@@ -111,7 +115,7 @@ spec:
             - name: VOICE_WS_PORT
               value: {{ .Values.voice.wsPort | quote }}
             - name: VOICE_PUBLIC_BASE_URL
-              value: {{ .Values.voice.publicBaseUrl | quote }}
+              value: {{ $voicePublicBaseUrl | quote }}
 
             {{- with .Values.voice.extraEnvs }}
             {{- include "langwatch.assertNoReservedTimeoutEnvs" (dict "envs" . "path" "voice.extraEnvs") }}
@@ -126,4 +130,5 @@ spec:
       volumes:
         - name: tmp-dir
           emptyDir: {}
+{{- end }}
 {{- end }}

--- a/charts/langwatch/templates/voice/deployment.yaml
+++ b/charts/langwatch/templates/voice/deployment.yaml
@@ -49,7 +49,7 @@ spec:
       serviceAccountName: {{ . }}
       {{- end }}
       automountServiceAccountToken: {{ .Values.global.automountServiceAccountToken }}
-      terminationGracePeriodSeconds: {{ include "langwatch.terminationGracePeriod" (dict "component" .Values.workers "name" "workers") }}
+      terminationGracePeriodSeconds: {{ include "langwatch.terminationGracePeriod" (dict "component" .Values.voice "name" "voice") }}
       securityContext:
         {{- include "langwatch.podSecurityContext" (dict "ctx" . "component" .Values.voice) | nindent 8 }}
 
@@ -87,7 +87,7 @@ spec:
               protocol: TCP
           env:
             {{- include "langwatch.sharedEnv" . | nindent 12 }}
-            {{- include "langwatch.shutdownEnv" (dict "component" .Values.workers "name" "workers") | nindent 12 }}
+            {{- include "langwatch.shutdownEnv" (dict "component" .Values.voice "name" "voice") | nindent 12 }}
 
             - name: OTEL_SERVICE_NAME
               value: {{ .Values.voice.otel.serviceName | default "langwatch-voice" | quote }}
@@ -122,6 +122,11 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.voice.twilio.existingSecret }}
                   key: {{ .Values.voice.twilio.keys.fromNumber }}
+
+            {{- with .Values.voice.extraEnvs }}
+            {{- include "langwatch.assertNoReservedTimeoutEnvs" (dict "envs" . "path" "voice.extraEnvs") }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
 
           resources:
             {{- toYaml .Values.voice.resources | nindent 12 }}

--- a/charts/langwatch/templates/voice/deployment.yaml
+++ b/charts/langwatch/templates/voice/deployment.yaml
@@ -2,6 +2,9 @@
 {{- if not .Values.voice.publicBaseUrl }}
 {{- fail "voice.publicBaseUrl is required when voice.enabled is true, Media Streams connects inbound to this URL, and the worker refuses to start without it. Set it to the public https:// origin fronting the voice Service/Ingress." }}
 {{- end }}
+{{- if or (not (regexMatch "^https://[^/:]+" .Values.voice.publicBaseUrl)) (hasSuffix "/" .Values.voice.publicBaseUrl) }}
+{{- fail (printf "voice.publicBaseUrl (%q) must be an https:// URL with a hostname and no trailing slash, for example https://voice.example.com." .Values.voice.publicBaseUrl) }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/langwatch/templates/voice/deployment.yaml
+++ b/charts/langwatch/templates/voice/deployment.yaml
@@ -102,16 +102,13 @@ spec:
             - name: OTEL_SERVICE_NAME
               value: {{ .Values.voice.otel.serviceName | default "langwatch-voice" | quote }}
 
-            # Same value as the workers Deployment: even with
-            # VOICE_WORKER_ONLY=true consuming only the voice queue, the
-            # process still needs the app's callback base URL for the rest of
-            # the worker runtime it shares with the workers Deployment.
+            # Same value as the workers Deployment: the process needs the app's
+            # callback base URL for the rest of the worker runtime it shares with
+            # the workers Deployment.
             - name: LANGWATCH_ENDPOINT
               value: {{ .Values.workers.upstreams.langwatch.scheme | default "http" }}://{{ .Values.workers.upstreams.langwatch.name | default (printf "%s-app" .Release.Name) }}:{{ .Values.workers.upstreams.langwatch.port | default 5560 }}
 
             # Env contract: langwatch/langwatch#8014 (voice-env-contract comment).
-            - name: VOICE_WORKER_ONLY
-              value: "true"
             - name: VOICE_WS_PORT
               value: {{ .Values.voice.wsPort | quote }}
             - name: VOICE_PUBLIC_BASE_URL

--- a/charts/langwatch/templates/voice/deployment.yaml
+++ b/charts/langwatch/templates/voice/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: voice
     {{- include "langwatch.labels" . | nindent 4 }}
-  {{- with .Values.voice.podAnnotations }}
+  {{- with .Values.voice.deployment.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
@@ -41,7 +41,7 @@ spec:
         {{- . | nindent 8 }}
         {{- end }}
       annotations:
-        {{- with (coalesce .Values.voice.podAnnotations .Values.global.podAnnotations) }}
+        {{- with (coalesce .Values.voice.pod.annotations .Values.global.podAnnotations) }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
@@ -90,10 +90,12 @@ spec:
             {{- include "langwatch.shutdownEnv" (dict "component" .Values.workers "name" "workers") | nindent 12 }}
 
             - name: OTEL_SERVICE_NAME
-              value: "langwatch-voice"
+              value: {{ .Values.voice.otel.serviceName | default "langwatch-voice" | quote }}
 
-            # See the workers Deployment — the voice worker consumes the app's
-            # queues too, so it needs the same callback path back to the app.
+            # Same value as the workers Deployment: even with
+            # VOICE_WORKER_ONLY=true consuming only the voice queue, the
+            # process still needs the app's callback base URL for the rest of
+            # the worker runtime it shares with the workers Deployment.
             - name: LANGWATCH_ENDPOINT
               value: {{ .Values.workers.upstreams.langwatch.scheme | default "http" }}://{{ .Values.workers.upstreams.langwatch.name | default (printf "%s-app" .Release.Name) }}:{{ .Values.workers.upstreams.langwatch.port | default 5560 }}
 

--- a/charts/langwatch/templates/voice/deployment.yaml
+++ b/charts/langwatch/templates/voice/deployment.yaml
@@ -1,9 +1,6 @@
 {{- if .Values.voice.enabled }}
 {{- if not .Values.voice.publicBaseUrl }}
-{{- fail "voice.publicBaseUrl is required when voice.enabled is true — Twilio Media Streams connects inbound to this URL, and the worker refuses to start without it. Set it to the public https:// origin fronting the voice Service/Ingress." }}
-{{- end }}
-{{- if not .Values.voice.twilio.existingSecret }}
-{{- fail "voice.twilio.existingSecret is required when voice.enabled is true — the voice worker reads TWILIO_ACCOUNT_SID/TWILIO_AUTH_TOKEN/TWILIO_FROM_NUMBER from it. Create a Secret with those keys (see voice.twilio.keys) and set this to its name." }}
+{{- fail "voice.publicBaseUrl is required when voice.enabled is true, Media Streams connects inbound to this URL, and the worker refuses to start without it. Set it to the public https:// origin fronting the voice Service/Ingress." }}
 {{- end }}
 apiVersion: apps/v1
 kind: Deployment
@@ -19,7 +16,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  # Fixed at 1, not a value: the Twilio Media Streams WebSocket routes an
+  # Fixed at 1, not a value: the Media Streams WebSocket routes an
   # in-flight call by nonce inside one process, so a second replica would
   # split a call's frames across two processes with no shared state.
   replicas: 1
@@ -112,22 +109,6 @@ spec:
               value: {{ .Values.voice.wsPort | quote }}
             - name: VOICE_PUBLIC_BASE_URL
               value: {{ .Values.voice.publicBaseUrl | quote }}
-
-            - name: TWILIO_ACCOUNT_SID
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.voice.twilio.existingSecret }}
-                  key: {{ .Values.voice.twilio.keys.accountSid }}
-            - name: TWILIO_AUTH_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.voice.twilio.existingSecret }}
-                  key: {{ .Values.voice.twilio.keys.authToken }}
-            - name: TWILIO_FROM_NUMBER
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.voice.twilio.existingSecret }}
-                  key: {{ .Values.voice.twilio.keys.fromNumber }}
 
             {{- with .Values.voice.extraEnvs }}
             {{- include "langwatch.assertNoReservedTimeoutEnvs" (dict "envs" . "path" "voice.extraEnvs") }}

--- a/charts/langwatch/templates/voice/deployment.yaml
+++ b/charts/langwatch/templates/voice/deployment.yaml
@@ -68,6 +68,12 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
 
+      # Topology spread constraints - https://kubespec.dev/v1/Pod#spec.topologySpreadConstraints
+      {{- with (coalesce .Values.voice.topologySpreadConstraints .Values.global.scheduling.topologySpreadConstraints) }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
       {{- with (coalesce .Values.voice.priorityClassName .Values.global.scheduling.priorityClassName) }}
       priorityClassName: {{ . | quote }}
       {{- end }}

--- a/charts/langwatch/templates/voice/deployment.yaml
+++ b/charts/langwatch/templates/voice/deployment.yaml
@@ -2,8 +2,8 @@
 {{- if not .Values.voice.publicBaseUrl }}
 {{- fail "voice.publicBaseUrl is required when voice.enabled is true, Media Streams connects inbound to this URL, and the worker refuses to start without it. Set it to the public https:// origin fronting the voice Service/Ingress." }}
 {{- end }}
-{{- if not (regexMatch "^https://[A-Za-z0-9]([A-Za-z0-9-]*[A-Za-z0-9])?(\\.[A-Za-z0-9]([A-Za-z0-9-]*[A-Za-z0-9])?)*(:[0-9]{1,5})?$" .Values.voice.publicBaseUrl) }}
-{{- fail (printf "voice.publicBaseUrl (%q) must be an https origin only: scheme, hostname, optional port, no path or query, for example https://voice.example.com." .Values.voice.publicBaseUrl) }}
+{{- if not (regexMatch "^https://[A-Za-z0-9]([A-Za-z0-9-]*[A-Za-z0-9])?(\\.[A-Za-z0-9]([A-Za-z0-9-]*[A-Za-z0-9])?)*(:([1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5]))?$" .Values.voice.publicBaseUrl) }}
+{{- fail (printf "voice.publicBaseUrl (%q) must be an https origin only: scheme, hostname, optional port 1-65535, no path or query, for example https://voice.example.com." .Values.voice.publicBaseUrl) }}
 {{- end }}
 apiVersion: apps/v1
 kind: Deployment

--- a/charts/langwatch/templates/voice/deployment.yaml
+++ b/charts/langwatch/templates/voice/deployment.yaml
@@ -2,8 +2,8 @@
 {{- if not .Values.voice.publicBaseUrl }}
 {{- fail "voice.publicBaseUrl is required when voice.enabled is true, Media Streams connects inbound to this URL, and the worker refuses to start without it. Set it to the public https:// origin fronting the voice Service/Ingress." }}
 {{- end }}
-{{- if or (not (regexMatch "^https://[^/:]+" .Values.voice.publicBaseUrl)) (hasSuffix "/" .Values.voice.publicBaseUrl) }}
-{{- fail (printf "voice.publicBaseUrl (%q) must be an https:// URL with a hostname and no trailing slash, for example https://voice.example.com." .Values.voice.publicBaseUrl) }}
+{{- if not (regexMatch "^https://[A-Za-z0-9]([A-Za-z0-9-]*[A-Za-z0-9])?(\\.[A-Za-z0-9]([A-Za-z0-9-]*[A-Za-z0-9])?)*(:[0-9]{1,5})?$" .Values.voice.publicBaseUrl) }}
+{{- fail (printf "voice.publicBaseUrl (%q) must be an https origin only: scheme, hostname, optional port, no path or query, for example https://voice.example.com." .Values.voice.publicBaseUrl) }}
 {{- end }}
 apiVersion: apps/v1
 kind: Deployment

--- a/charts/langwatch/templates/voice/deployment.yaml
+++ b/charts/langwatch/templates/voice/deployment.yaml
@@ -1,0 +1,132 @@
+{{- if .Values.voice.enabled }}
+{{- if not .Values.voice.publicBaseUrl }}
+{{- fail "voice.publicBaseUrl is required when voice.enabled is true — Twilio Media Streams connects inbound to this URL, and the worker refuses to start without it. Set it to the public https:// origin fronting the voice Service/Ingress." }}
+{{- end }}
+{{- if not .Values.voice.twilio.existingSecret }}
+{{- fail "voice.twilio.existingSecret is required when voice.enabled is true — the voice worker reads TWILIO_ACCOUNT_SID/TWILIO_AUTH_TOKEN/TWILIO_FROM_NUMBER from it. Create a Secret with those keys (see voice.twilio.keys) and set this to its name." }}
+{{- end }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-voice
+  labels:
+    app.kubernetes.io/name: {{ .Release.Name }}-voice
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: voice
+    {{- include "langwatch.labels" . | nindent 4 }}
+  {{- with .Values.voice.podAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  # Fixed at 1, not a value: the Twilio Media Streams WebSocket routes an
+  # in-flight call by nonce inside one process, so a second replica would
+  # split a call's frames across two processes with no shared state.
+  replicas: 1
+  # Recreate, not RollingUpdate: two replicas would each answer half a call's
+  # frames, so the old pod must fully terminate before the new one starts.
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Release.Name }}-voice
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ .Release.Name }}-voice
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: voice
+        {{- with (include "langwatch.cloudIdentityPodLabels" .) }}
+        {{- . | nindent 8 }}
+        {{- end }}
+      annotations:
+        {{- with (coalesce .Values.voice.podAnnotations .Values.global.podAnnotations) }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with (include "langwatch.serviceAccountName" .) }}
+      serviceAccountName: {{ . }}
+      {{- end }}
+      automountServiceAccountToken: {{ .Values.global.automountServiceAccountToken }}
+      terminationGracePeriodSeconds: {{ include "langwatch.terminationGracePeriod" (dict "component" .Values.workers "name" "workers") }}
+      securityContext:
+        {{- include "langwatch.podSecurityContext" (dict "ctx" . "component" .Values.voice) | nindent 8 }}
+
+      {{- with (coalesce .Values.voice.nodeSelector .Values.global.scheduling.nodeSelector) }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
+      {{- with (coalesce .Values.voice.tolerations .Values.global.scheduling.tolerations) }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
+      {{- with (coalesce .Values.voice.affinity .Values.global.scheduling.affinity) }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
+      {{- with (coalesce .Values.voice.priorityClassName .Values.global.scheduling.priorityClassName) }}
+      priorityClassName: {{ . | quote }}
+      {{- end }}
+
+      containers:
+        - name: {{ .Release.Name }}-voice
+          securityContext:
+            {{- include "langwatch.containerSecurityContext" (dict "ctx" . "component" .Values.voice) | nindent 12 }}
+          image: "{{ .Values.images.app.repository }}:{{ .Values.images.app.tag }}"
+          imagePullPolicy: "{{ .Values.images.app.pullPolicy }}"
+          workingDir: /app/platform/app
+          command: ['pnpm']
+          args: ['run', 'start:workers']
+          ports:
+            - name: voice-ws
+              containerPort: {{ .Values.voice.wsPort }}
+              protocol: TCP
+          env:
+            {{- include "langwatch.sharedEnv" . | nindent 12 }}
+            {{- include "langwatch.shutdownEnv" (dict "component" .Values.workers "name" "workers") | nindent 12 }}
+
+            - name: OTEL_SERVICE_NAME
+              value: "langwatch-voice"
+
+            # See the workers Deployment — the voice worker consumes the app's
+            # queues too, so it needs the same callback path back to the app.
+            - name: LANGWATCH_ENDPOINT
+              value: {{ .Values.workers.upstreams.langwatch.scheme | default "http" }}://{{ .Values.workers.upstreams.langwatch.name | default (printf "%s-app" .Release.Name) }}:{{ .Values.workers.upstreams.langwatch.port | default 5560 }}
+
+            # Env contract: langwatch/langwatch#8014 (voice-env-contract comment).
+            - name: VOICE_WORKER_ONLY
+              value: "true"
+            - name: VOICE_WS_PORT
+              value: {{ .Values.voice.wsPort | quote }}
+            - name: VOICE_PUBLIC_BASE_URL
+              value: {{ .Values.voice.publicBaseUrl | quote }}
+
+            - name: TWILIO_ACCOUNT_SID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.voice.twilio.existingSecret }}
+                  key: {{ .Values.voice.twilio.keys.accountSid }}
+            - name: TWILIO_AUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.voice.twilio.existingSecret }}
+                  key: {{ .Values.voice.twilio.keys.authToken }}
+            - name: TWILIO_FROM_NUMBER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.voice.twilio.existingSecret }}
+                  key: {{ .Values.voice.twilio.keys.fromNumber }}
+
+          resources:
+            {{- toYaml .Values.voice.resources | nindent 12 }}
+          volumeMounts:
+            - name: tmp-dir
+              mountPath: /tmp
+      volumes:
+        - name: tmp-dir
+          emptyDir: {}
+{{- end }}

--- a/charts/langwatch/templates/voice/ingress.yaml
+++ b/charts/langwatch/templates/voice/ingress.yaml
@@ -1,23 +1,31 @@
-{{- if and .Values.voice.enabled .Values.voice.ingress.enabled }}
-{{- if not .Values.voice.ingress.host }}
-{{- fail "voice.ingress.host is required when voice.ingress.enabled is true: it must match the hostname in voice.publicBaseUrl." }}
+{{- $voicePublicBaseUrl := include "langwatch.voice.publicBaseUrl" . }}
+{{/* Gated the same way as templates/voice/deployment.yaml: without a
+     resolved public base URL there is nothing for this Ingress to route to
+     (the Deployment and Service stay silent too), so this degrades quietly
+     rather than failing. An explicit voice.publicBaseUrl that fails
+     validation still aborts the whole render, via deployment.yaml/
+     service.yaml — the check does not need to be repeated here. */}}
+{{- if and .Values.voice.enabled .Values.voice.ingress.enabled $voicePublicBaseUrl }}
+{{/* voice.ingress.host defaults to the hostname of the resolved public base
+     URL, so an operator only sets it to override that default. An explicit
+     value that disagrees with the resolved URL is still refused: Twilio
+     dials voice.publicBaseUrl (or its app.http.publicUrl fallback), and an
+     Ingress routing a different host would never see the WebSocket upgrade
+     at all — the mismatch would only surface as an unreachable call at
+     runtime. Compared here, at render time, instead. */}}
+{{- $resolvedHost := (urlParse $voicePublicBaseUrl).hostname }}
+{{- $explicitHost := .Values.voice.ingress.host | default "" }}
+{{- if and $explicitHost (ne $explicitHost $resolvedHost) }}
+{{- fail (printf "voice.ingress.host (%q) does not match the hostname in voice.publicBaseUrl (%q). Twilio dials voice.publicBaseUrl, so the Ingress must route the same host or the call never reaches it." $explicitHost $resolvedHost) }}
 {{- end }}
-{{/* voice.publicBaseUrl is what Twilio actually dials; an Ingress routing a
-     different host would never see the WebSocket upgrade at all, and the
-     mismatch would only surface as an unreachable call at runtime. Compared
-     here, at render time, instead. Guarded on publicBaseUrl being set: if it
-     is empty, templates/voice/deployment.yaml already refuses the render for
-     that reason. */}}
-{{- if .Values.voice.publicBaseUrl }}
-{{- $publicHost := (urlParse .Values.voice.publicBaseUrl).hostname }}
-{{- if ne $publicHost .Values.voice.ingress.host }}
-{{- fail (printf "voice.ingress.host (%q) does not match the hostname in voice.publicBaseUrl (%q). Twilio dials voice.publicBaseUrl, so the Ingress must route the same host or the call never reaches it." .Values.voice.ingress.host $publicHost) }}
-{{- end }}
-{{- end }}
+{{- $host := $explicitHost | default $resolvedHost }}
 # Fronts the voice worker's WebSocket port. Twilio Media Streams needs a
 # WebSocket-capable path: add any upgrade/timeout annotations your ingress
 # controller requires under voice.ingress.annotations (TLS termination is left
-# to your edge, same as the main ingress).
+# to your edge, same as the main ingress). The default annotations already
+# set nginx's proxy-read/send timeouts to 3600s, since the stock 60s value
+# would cut off any call longer than a minute; other controllers need their
+# own equivalents under this same key.
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -46,7 +54,7 @@ spec:
     {{- end }}
   {{- end }}
   rules:
-    - host: {{ .Values.voice.ingress.host | quote }}
+    - host: {{ $host | quote }}
       http:
         paths:
           - path: /twilio

--- a/charts/langwatch/templates/voice/ingress.yaml
+++ b/charts/langwatch/templates/voice/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.voice.enabled .Values.voice.ingress.enabled }}
 {{- if not .Values.voice.ingress.host }}
-{{- fail "voice.ingress.host is required when voice.ingress.enabled is true — it must match the hostname in voice.publicBaseUrl." }}
+{{- fail "voice.ingress.host is required when voice.ingress.enabled is true: it must match the hostname in voice.publicBaseUrl." }}
 {{- end }}
 {{/* voice.publicBaseUrl is what Twilio actually dials; an Ingress routing a
      different host would never see the WebSocket upgrade at all, and the
@@ -11,7 +11,7 @@
 {{- if .Values.voice.publicBaseUrl }}
 {{- $publicHost := (urlParse .Values.voice.publicBaseUrl).hostname }}
 {{- if ne $publicHost .Values.voice.ingress.host }}
-{{- fail (printf "voice.ingress.host (%q) does not match the hostname in voice.publicBaseUrl (%q) — Twilio dials voice.publicBaseUrl, so the Ingress must route the same host or the call never reaches it." .Values.voice.ingress.host $publicHost) }}
+{{- fail (printf "voice.ingress.host (%q) does not match the hostname in voice.publicBaseUrl (%q). Twilio dials voice.publicBaseUrl, so the Ingress must route the same host or the call never reaches it." .Values.voice.ingress.host $publicHost) }}
 {{- end }}
 {{- end }}
 # Fronts the voice worker's WebSocket port. Twilio Media Streams needs a

--- a/charts/langwatch/templates/voice/ingress.yaml
+++ b/charts/langwatch/templates/voice/ingress.yaml
@@ -1,0 +1,47 @@
+{{- if and .Values.voice.enabled .Values.voice.ingress.enabled }}
+{{- if not .Values.voice.ingress.host }}
+{{- fail "voice.ingress.host is required when voice.ingress.enabled is true — it must match the hostname in voice.publicBaseUrl." }}
+{{- end }}
+# Fronts the voice worker's WebSocket port. Twilio Media Streams needs a
+# WebSocket-capable path: add any upgrade/timeout annotations your ingress
+# controller requires under voice.ingress.annotations (TLS termination is left
+# to your edge, same as the main ingress).
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ .Release.Name }}-voice
+  labels:
+    app.kubernetes.io/name: {{ .Release.Name }}-voice
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: voice
+    {{- include "langwatch.labels" . | nindent 4 }}
+  {{- with .Values.voice.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.voice.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- with .Values.voice.ingress.tls }}
+  tls:
+    {{- range . }}
+    - secretName: {{ .secretName }}
+      hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+    {{- end }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.voice.ingress.host | quote }}
+      http:
+        paths:
+          - path: /twilio
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ .Release.Name }}-voice
+                port:
+                  number: {{ .Values.voice.service.port }}
+{{- end }}

--- a/charts/langwatch/templates/voice/ingress.yaml
+++ b/charts/langwatch/templates/voice/ingress.yaml
@@ -2,6 +2,18 @@
 {{- if not .Values.voice.ingress.host }}
 {{- fail "voice.ingress.host is required when voice.ingress.enabled is true — it must match the hostname in voice.publicBaseUrl." }}
 {{- end }}
+{{/* voice.publicBaseUrl is what Twilio actually dials; an Ingress routing a
+     different host would never see the WebSocket upgrade at all, and the
+     mismatch would only surface as an unreachable call at runtime. Compared
+     here, at render time, instead. Guarded on publicBaseUrl being set: if it
+     is empty, templates/voice/deployment.yaml already refuses the render for
+     that reason. */}}
+{{- if .Values.voice.publicBaseUrl }}
+{{- $publicHost := (urlParse .Values.voice.publicBaseUrl).hostname }}
+{{- if ne $publicHost .Values.voice.ingress.host }}
+{{- fail (printf "voice.ingress.host (%q) does not match the hostname in voice.publicBaseUrl (%q) — Twilio dials voice.publicBaseUrl, so the Ingress must route the same host or the call never reaches it." .Values.voice.ingress.host $publicHost) }}
+{{- end }}
+{{- end }}
 # Fronts the voice worker's WebSocket port. Twilio Media Streams needs a
 # WebSocket-capable path: add any upgrade/timeout annotations your ingress
 # controller requires under voice.ingress.annotations (TLS termination is left

--- a/charts/langwatch/templates/voice/service.yaml
+++ b/charts/langwatch/templates/voice/service.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.voice.enabled }}
+# Service exposing the voice worker's Twilio Media Streams WebSocket port.
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-voice
+  labels:
+    app.kubernetes.io/name: {{ .Release.Name }}-voice
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: voice
+    {{- include "langwatch.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.voice.service.type }}
+  ports:
+    - port: {{ .Values.voice.service.port }}
+      targetPort: voice-ws
+      protocol: TCP
+      name: voice-ws
+  selector:
+    app.kubernetes.io/name: {{ .Release.Name }}-voice
+    app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/langwatch/templates/voice/service.yaml
+++ b/charts/langwatch/templates/voice/service.yaml
@@ -1,4 +1,7 @@
-{{- if .Values.voice.enabled }}
+{{/* Gated the same way as templates/voice/deployment.yaml: a Service with
+     nothing behind it is just as useless, and rendering it while the
+     Deployment stays silent would be a confusing half-install. */}}
+{{- if and .Values.voice.enabled (include "langwatch.voice.publicBaseUrl" .) }}
 # Service exposing the voice worker's Twilio Media Streams WebSocket port.
 apiVersion: v1
 kind: Service

--- a/charts/langwatch/tests/voice-worker.sh
+++ b/charts/langwatch/tests/voice-worker.sh
@@ -38,10 +38,23 @@ normalise() {
   sed -E 's/: "[A-Za-z0-9+\/=]{16,}"/: "<redacted>"/'
 }
 
+# Runs helm template with $BASE plus the given flags, printing combined
+# stdout/stderr and preserving helm's exit status. The only place `$BASE`
+# and a caller's flags are word-split, so the disable comment lives here once
+# instead of on every call site.
+render() {
+  local out status
+  # shellcheck disable=SC2086
+  out=$(helm template lw . $BASE $1 2>&1)
+  status=$?
+  printf '%s' "$out"
+  return $status
+}
+
 # @scenario "The default install renders no voice resources"
 test_default_has_no_voice_resources() {
   local out
-  if ! out=$(helm template lw . $BASE 2>&1); then
+  if ! out=$(render ""); then
     fail "default render" "chart failed to render at all: $(printf '%s' "$out" | tail -5)"
     return
   fi
@@ -55,8 +68,8 @@ test_default_has_no_voice_resources() {
 # @scenario "voice.enabled=false explicitly changes nothing"
 test_explicit_false_matches_default() {
   local default_out explicit_out
-  default_out=$(helm template lw . $BASE | normalise)
-  explicit_out=$(helm template lw . $BASE --set voice.enabled=false | normalise)
+  default_out=$(render "" | normalise)
+  explicit_out=$(render "--set voice.enabled=false" | normalise)
   if [ "$default_out" != "$explicit_out" ]; then
     fail "explicit false matches default" \
       "rendered manifest differs between default and --set voice.enabled=false: $(diff <(printf '%s' "$default_out") <(printf '%s' "$explicit_out") | head -10 | tr '\n' ' ')"
@@ -68,8 +81,7 @@ test_explicit_false_matches_default() {
 # Renders a profile and prints only one component's manifest, so a value from
 # another component can never satisfy an assertion.
 render_component() {
-  # shellcheck disable=SC2086
-  helm template lw . $2 | awk -v want="langwatch/templates/voice/$1" '
+  render "$2" | awk -v want="langwatch/templates/voice/$1" '
     $0 ~ "^# Source: " want { grab=1; next }
     grab && /^# Source:/ { grab=0 }
     grab { print }
@@ -81,7 +93,7 @@ readonly ENABLED_FLAGS="--set voice.enabled=true --set voice.publicBaseUrl=https
 # @scenario "Enabling voice renders a single-replica worker wired to the Twilio secret"
 test_enabled_renders_deployment() {
   local block
-  block=$(render_component "deployment.yaml" "$BASE $ENABLED_FLAGS")
+  block=$(render_component "deployment.yaml" "$ENABLED_FLAGS")
   if [ -z "$block" ]; then
     fail "voice deployment" "rendered no voice Deployment with voice.enabled=true"
     return
@@ -113,10 +125,26 @@ test_enabled_renders_deployment() {
   echo "ok   [voice deployment] replicas=1, VOICE_WORKER_ONLY=true, Twilio secretKeyRefs present"
 }
 
+# @scenario "The voice Deployment's terminationGracePeriodSeconds follows voice.*, not workers.*"
+test_termination_grace_period_follows_voice_values() {
+  local block
+  block=$(render_component "deployment.yaml" \
+    "$ENABLED_FLAGS --set voice.terminationGracePeriodSeconds=90 --set voice.shutdownDrainSeconds=60 --set workers.terminationGracePeriodSeconds=999")
+  if [ -z "$block" ]; then
+    fail "voice terminationGracePeriodSeconds" "rendered no voice Deployment with voice.enabled=true"
+    return
+  fi
+  if ! printf '%s' "$block" | grep -q "terminationGracePeriodSeconds: 90"; then
+    fail "voice terminationGracePeriodSeconds" "expected terminationGracePeriodSeconds: 90 (from voice.terminationGracePeriodSeconds), got: $(printf '%s' "$block" | grep terminationGracePeriodSeconds)"
+    return
+  fi
+  echo "ok   [voice terminationGracePeriodSeconds] follows --set voice.terminationGracePeriodSeconds, not workers.*"
+}
+
 # @scenario "Enabling voice renders a Service but no Ingress by default"
 test_enabled_renders_service_no_ingress() {
   local svc ing
-  svc=$(render_component "service.yaml" "$BASE $ENABLED_FLAGS")
+  svc=$(render_component "service.yaml" "$ENABLED_FLAGS")
   if [ -z "$svc" ]; then
     fail "voice service" "rendered no voice Service with voice.enabled=true"
     return
@@ -125,7 +153,7 @@ test_enabled_renders_service_no_ingress() {
     fail "voice service targetPort" "expected targetPort: voice-ws"
     return
   fi
-  ing=$(render_component "ingress.yaml" "$BASE $ENABLED_FLAGS")
+  ing=$(render_component "ingress.yaml" "$ENABLED_FLAGS")
   if [ -n "$ing" ]; then
     fail "voice ingress absent by default" "voice.ingress.enabled defaults to false but an Ingress rendered anyway"
     return
@@ -137,7 +165,7 @@ test_enabled_renders_service_no_ingress() {
 test_ingress_enabled_renders() {
   local ing
   ing=$(render_component "ingress.yaml" \
-    "$BASE $ENABLED_FLAGS --set voice.ingress.enabled=true --set voice.ingress.host=voice.example.com")
+    "$ENABLED_FLAGS --set voice.ingress.enabled=true --set voice.ingress.host=voice.example.com")
   if [ -z "$ing" ]; then
     fail "voice ingress enabled" "rendered no voice Ingress with voice.ingress.enabled=true"
     return
@@ -156,7 +184,7 @@ test_ingress_enabled_renders() {
 # @scenario "voice.enabled without publicBaseUrl refuses to render"
 test_enabled_without_public_base_url_refuses() {
   local out
-  if out=$(helm template lw . $BASE --set voice.enabled=true --set voice.twilio.existingSecret=twilio 2>&1); then
+  if out=$(render "--set voice.enabled=true --set voice.twilio.existingSecret=twilio"); then
     fail "missing publicBaseUrl" "chart rendered when voice.publicBaseUrl was not set"
     return
   fi
@@ -171,7 +199,7 @@ test_enabled_without_public_base_url_refuses() {
 # @scenario "voice.enabled without an existing Twilio secret refuses to render"
 test_enabled_without_twilio_secret_refuses() {
   local out
-  if out=$(helm template lw . $BASE --set voice.enabled=true --set voice.publicBaseUrl=https://voice.example.com 2>&1); then
+  if out=$(render "--set voice.enabled=true --set voice.publicBaseUrl=https://voice.example.com"); then
     fail "missing twilio secret" "chart rendered when voice.twilio.existingSecret was not set"
     return
   fi
@@ -186,6 +214,7 @@ test_enabled_without_twilio_secret_refuses() {
 test_default_has_no_voice_resources
 test_explicit_false_matches_default
 test_enabled_renders_deployment
+test_termination_grace_period_follows_voice_values
 test_enabled_renders_service_no_ingress
 test_ingress_enabled_renders
 test_enabled_without_public_base_url_refuses

--- a/charts/langwatch/tests/voice-worker.sh
+++ b/charts/langwatch/tests/voice-worker.sh
@@ -195,6 +195,36 @@ test_enabled_without_public_base_url_refuses() {
   esac
 }
 
+# @scenario "The voice worker refuses a public address that is not a valid https:// origin"
+test_enabled_with_http_public_base_url_refuses() {
+  local out
+  if out=$(render "--set voice.enabled=true --set voice.publicBaseUrl=http://voice.example.com"); then
+    fail "http publicBaseUrl" "chart rendered when voice.publicBaseUrl used http:// instead of https://"
+    return
+  fi
+  case "$out" in
+    *"must be an https:// URL with a hostname"*)
+      echo "ok   [http publicBaseUrl] refused with the expected message" ;;
+    *)
+      fail "http publicBaseUrl" "refused, but not for the expected reason: $(printf '%s' "$out" | tr '\n' ' ' | cut -c1-200)" ;;
+  esac
+}
+
+# @scenario "Turning on the voice worker with a valid https:// public address renders"
+test_enabled_with_https_public_base_url_renders() {
+  local block
+  block=$(render_component "deployment.yaml" "--set voice.enabled=true --set voice.publicBaseUrl=https://voice.example.com")
+  if [ -z "$block" ]; then
+    fail "https publicBaseUrl" "rendered no voice Deployment with a valid https:// voice.publicBaseUrl"
+    return
+  fi
+  if ! printf '%s' "$block" | grep -A1 "name: VOICE_PUBLIC_BASE_URL" | grep -q 'value: "https://voice.example.com"'; then
+    fail "https publicBaseUrl" "expected VOICE_PUBLIC_BASE_URL=https://voice.example.com"
+    return
+  fi
+  echo "ok   [https publicBaseUrl] renders with VOICE_PUBLIC_BASE_URL=https://voice.example.com"
+}
+
 test_default_has_no_voice_resources
 test_explicit_false_matches_default
 test_enabled_renders_deployment
@@ -203,6 +233,8 @@ test_enabled_renders_service_no_ingress
 test_ingress_enabled_renders
 test_ingress_host_mismatch_refuses
 test_enabled_without_public_base_url_refuses
+test_enabled_with_http_public_base_url_refuses
+test_enabled_with_https_public_base_url_renders
 
 if [ "$failures" -gt 0 ]; then
   echo "$failures assertion(s) failed"

--- a/charts/langwatch/tests/voice-worker.sh
+++ b/charts/langwatch/tests/voice-worker.sh
@@ -88,9 +88,9 @@ render_component() {
   '
 }
 
-readonly ENABLED_FLAGS="--set voice.enabled=true --set voice.publicBaseUrl=https://voice.example.com --set voice.twilio.existingSecret=twilio"
+readonly ENABLED_FLAGS="--set voice.enabled=true --set voice.publicBaseUrl=https://voice.example.com"
 
-# @scenario "Turning on the voice worker brings up a single call handler wired to Twilio"
+# @scenario "Turning on the voice worker brings up a single call handler"
 test_enabled_renders_deployment() {
   local block
   block=$(render_component "deployment.yaml" "$ENABLED_FLAGS")
@@ -106,23 +106,7 @@ test_enabled_renders_deployment() {
     fail "voice deployment VOICE_WORKER_ONLY" "expected VOICE_WORKER_ONLY=true"
     return
   fi
-  if ! printf '%s' "$block" | grep -A3 "name: TWILIO_ACCOUNT_SID" | grep -q "name: twilio"; then
-    fail "voice deployment TWILIO_ACCOUNT_SID" "expected secretKeyRef to Secret 'twilio'"
-    return
-  fi
-  if ! printf '%s' "$block" | grep -A4 "name: TWILIO_ACCOUNT_SID" | grep -q "key: TWILIO_ACCOUNT_SID"; then
-    fail "voice deployment TWILIO_ACCOUNT_SID key" "expected secretKeyRef key TWILIO_ACCOUNT_SID"
-    return
-  fi
-  if ! printf '%s' "$block" | grep -A3 "name: TWILIO_AUTH_TOKEN" | grep -q "name: twilio"; then
-    fail "voice deployment TWILIO_AUTH_TOKEN" "expected secretKeyRef to Secret 'twilio'"
-    return
-  fi
-  if ! printf '%s' "$block" | grep -A3 "name: TWILIO_FROM_NUMBER" | grep -q "name: twilio"; then
-    fail "voice deployment TWILIO_FROM_NUMBER" "expected secretKeyRef to Secret 'twilio'"
-    return
-  fi
-  echo "ok   [voice deployment] replicas=1, VOICE_WORKER_ONLY=true, Twilio secretKeyRefs present"
+  echo "ok   [voice deployment] replicas=1, VOICE_WORKER_ONLY=true"
 }
 
 # @scenario "The voice worker's shutdown timing is its own, not borrowed from the background workers"
@@ -199,7 +183,7 @@ test_ingress_host_mismatch_refuses() {
 # @scenario "The voice worker refuses to start without knowing its own public address"
 test_enabled_without_public_base_url_refuses() {
   local out
-  if out=$(render "--set voice.enabled=true --set voice.twilio.existingSecret=twilio"); then
+  if out=$(render "--set voice.enabled=true"); then
     fail "missing publicBaseUrl" "chart rendered when voice.publicBaseUrl was not set"
     return
   fi
@@ -211,21 +195,6 @@ test_enabled_without_public_base_url_refuses() {
   esac
 }
 
-# @scenario "The voice worker refuses to start without Twilio credentials configured"
-test_enabled_without_twilio_secret_refuses() {
-  local out
-  if out=$(render "--set voice.enabled=true --set voice.publicBaseUrl=https://voice.example.com"); then
-    fail "missing twilio secret" "chart rendered when voice.twilio.existingSecret was not set"
-    return
-  fi
-  case "$out" in
-    *"voice.twilio.existingSecret is required"*)
-      echo "ok   [missing twilio secret] refused with the expected message" ;;
-    *)
-      fail "missing twilio secret" "refused, but not for the expected reason: $(printf '%s' "$out" | tr '\n' ' ' | cut -c1-200)" ;;
-  esac
-}
-
 test_default_has_no_voice_resources
 test_explicit_false_matches_default
 test_enabled_renders_deployment
@@ -234,7 +203,6 @@ test_enabled_renders_service_no_ingress
 test_ingress_enabled_renders
 test_ingress_host_mismatch_refuses
 test_enabled_without_public_base_url_refuses
-test_enabled_without_twilio_secret_refuses
 
 if [ "$failures" -gt 0 ]; then
   echo "$failures assertion(s) failed"

--- a/charts/langwatch/tests/voice-worker.sh
+++ b/charts/langwatch/tests/voice-worker.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+#
+# Renders the chart and asserts the opt-in voice worker (Deployment, Service,
+# Ingress) behaves as documented: absent unless enabled, refusing to render
+# without the two values it cannot work without, and shaped correctly once
+# turned on.
+#
+# This executes the template pipeline rather than reading the templates: the
+# gating conditions, the required-value checks, and the env/secretKeyRef
+# wiring are only visible in what actually renders.
+#
+# See langwatch/langwatch#8015 and the env contract on #8014
+# (voice-env-contract comment).
+#
+# Usage (from charts/langwatch):
+#   helm dependency build .
+#   ./tests/voice-worker.sh
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+readonly BASE="--set autogen.enabled=true"
+
+failures=0
+
+fail() {
+  echo "FAIL [$1]: $2"
+  failures=$((failures + 1))
+}
+
+# autogen generates fresh random Secret values on every render, independent of
+# voice — so a byte-identical comparison must normalise those out first, or
+# every render pair would "differ" for a reason that has nothing to do with
+# voice. Every such value is a long quoted base64 string; blank them all,
+# consistently, on both sides being compared.
+normalise() {
+  sed -E 's/: "[A-Za-z0-9+\/=]{16,}"/: "<redacted>"/'
+}
+
+# @scenario "The default install renders no voice resources"
+test_default_has_no_voice_resources() {
+  local out
+  if ! out=$(helm template lw . $BASE 2>&1); then
+    fail "default render" "chart failed to render at all: $(printf '%s' "$out" | tail -5)"
+    return
+  fi
+  if printf '%s' "$out" | grep -q "templates/voice/"; then
+    fail "default has no voice resources" "default render includes a templates/voice/ manifest"
+    return
+  fi
+  echo "ok   [default has no voice resources] no templates/voice/ source in the default render"
+}
+
+# @scenario "voice.enabled=false explicitly changes nothing"
+test_explicit_false_matches_default() {
+  local default_out explicit_out
+  default_out=$(helm template lw . $BASE | normalise)
+  explicit_out=$(helm template lw . $BASE --set voice.enabled=false | normalise)
+  if [ "$default_out" != "$explicit_out" ]; then
+    fail "explicit false matches default" \
+      "rendered manifest differs between default and --set voice.enabled=false: $(diff <(printf '%s' "$default_out") <(printf '%s' "$explicit_out") | head -10 | tr '\n' ' ')"
+    return
+  fi
+  echo "ok   [explicit false matches default] --set voice.enabled=false renders identically to the default"
+}
+
+# Renders a profile and prints only one component's manifest, so a value from
+# another component can never satisfy an assertion.
+render_component() {
+  # shellcheck disable=SC2086
+  helm template lw . $2 | awk -v want="langwatch/templates/voice/$1" '
+    $0 ~ "^# Source: " want { grab=1; next }
+    grab && /^# Source:/ { grab=0 }
+    grab { print }
+  '
+}
+
+readonly ENABLED_FLAGS="--set voice.enabled=true --set voice.publicBaseUrl=https://voice.example.com --set voice.twilio.existingSecret=twilio"
+
+# @scenario "Enabling voice renders a single-replica worker wired to the Twilio secret"
+test_enabled_renders_deployment() {
+  local block
+  block=$(render_component "deployment.yaml" "$BASE $ENABLED_FLAGS")
+  if [ -z "$block" ]; then
+    fail "voice deployment" "rendered no voice Deployment with voice.enabled=true"
+    return
+  fi
+  if ! printf '%s' "$block" | grep -q "replicas: 1"; then
+    fail "voice deployment replicas" "expected replicas: 1"
+    return
+  fi
+  if ! printf '%s' "$block" | grep -A1 "name: VOICE_WORKER_ONLY" | grep -q 'value: "true"'; then
+    fail "voice deployment VOICE_WORKER_ONLY" "expected VOICE_WORKER_ONLY=true"
+    return
+  fi
+  if ! printf '%s' "$block" | grep -A3 "name: TWILIO_ACCOUNT_SID" | grep -q "name: twilio"; then
+    fail "voice deployment TWILIO_ACCOUNT_SID" "expected secretKeyRef to Secret 'twilio'"
+    return
+  fi
+  if ! printf '%s' "$block" | grep -A4 "name: TWILIO_ACCOUNT_SID" | grep -q "key: TWILIO_ACCOUNT_SID"; then
+    fail "voice deployment TWILIO_ACCOUNT_SID key" "expected secretKeyRef key TWILIO_ACCOUNT_SID"
+    return
+  fi
+  if ! printf '%s' "$block" | grep -A3 "name: TWILIO_AUTH_TOKEN" | grep -q "name: twilio"; then
+    fail "voice deployment TWILIO_AUTH_TOKEN" "expected secretKeyRef to Secret 'twilio'"
+    return
+  fi
+  if ! printf '%s' "$block" | grep -A3 "name: TWILIO_FROM_NUMBER" | grep -q "name: twilio"; then
+    fail "voice deployment TWILIO_FROM_NUMBER" "expected secretKeyRef to Secret 'twilio'"
+    return
+  fi
+  echo "ok   [voice deployment] replicas=1, VOICE_WORKER_ONLY=true, Twilio secretKeyRefs present"
+}
+
+# @scenario "Enabling voice renders a Service but no Ingress by default"
+test_enabled_renders_service_no_ingress() {
+  local svc ing
+  svc=$(render_component "service.yaml" "$BASE $ENABLED_FLAGS")
+  if [ -z "$svc" ]; then
+    fail "voice service" "rendered no voice Service with voice.enabled=true"
+    return
+  fi
+  if ! printf '%s' "$svc" | grep -q "targetPort: voice-ws"; then
+    fail "voice service targetPort" "expected targetPort: voice-ws"
+    return
+  fi
+  ing=$(render_component "ingress.yaml" "$BASE $ENABLED_FLAGS")
+  if [ -n "$ing" ]; then
+    fail "voice ingress absent by default" "voice.ingress.enabled defaults to false but an Ingress rendered anyway"
+    return
+  fi
+  echo "ok   [voice service / no ingress] Service renders, Ingress does not (ingress.enabled defaults false)"
+}
+
+# @scenario "Enabling the voice ingress renders it for the configured host"
+test_ingress_enabled_renders() {
+  local ing
+  ing=$(render_component "ingress.yaml" \
+    "$BASE $ENABLED_FLAGS --set voice.ingress.enabled=true --set voice.ingress.host=voice.example.com")
+  if [ -z "$ing" ]; then
+    fail "voice ingress enabled" "rendered no voice Ingress with voice.ingress.enabled=true"
+    return
+  fi
+  if ! printf '%s' "$ing" | grep -q "host: \"voice.example.com\""; then
+    fail "voice ingress host" "expected host: \"voice.example.com\""
+    return
+  fi
+  if ! printf '%s' "$ing" | grep -q "path: /twilio"; then
+    fail "voice ingress path" "expected path: /twilio"
+    return
+  fi
+  echo "ok   [voice ingress enabled] Ingress renders for voice.example.com at /twilio"
+}
+
+# @scenario "voice.enabled without publicBaseUrl refuses to render"
+test_enabled_without_public_base_url_refuses() {
+  local out
+  if out=$(helm template lw . $BASE --set voice.enabled=true --set voice.twilio.existingSecret=twilio 2>&1); then
+    fail "missing publicBaseUrl" "chart rendered when voice.publicBaseUrl was not set"
+    return
+  fi
+  case "$out" in
+    *"voice.publicBaseUrl is required"*)
+      echo "ok   [missing publicBaseUrl] refused with the expected message" ;;
+    *)
+      fail "missing publicBaseUrl" "refused, but not for the expected reason: $(printf '%s' "$out" | tr '\n' ' ' | cut -c1-200)" ;;
+  esac
+}
+
+# @scenario "voice.enabled without an existing Twilio secret refuses to render"
+test_enabled_without_twilio_secret_refuses() {
+  local out
+  if out=$(helm template lw . $BASE --set voice.enabled=true --set voice.publicBaseUrl=https://voice.example.com 2>&1); then
+    fail "missing twilio secret" "chart rendered when voice.twilio.existingSecret was not set"
+    return
+  fi
+  case "$out" in
+    *"voice.twilio.existingSecret is required"*)
+      echo "ok   [missing twilio secret] refused with the expected message" ;;
+    *)
+      fail "missing twilio secret" "refused, but not for the expected reason: $(printf '%s' "$out" | tr '\n' ' ' | cut -c1-200)" ;;
+  esac
+}
+
+test_default_has_no_voice_resources
+test_explicit_false_matches_default
+test_enabled_renders_deployment
+test_enabled_renders_service_no_ingress
+test_ingress_enabled_renders
+test_enabled_without_public_base_url_refuses
+test_enabled_without_twilio_secret_refuses
+
+if [ "$failures" -gt 0 ]; then
+  echo "$failures assertion(s) failed"
+  exit 1
+fi
+
+echo "all voice-worker assertions passed"

--- a/charts/langwatch/tests/voice-worker.sh
+++ b/charts/langwatch/tests/voice-worker.sh
@@ -52,7 +52,7 @@ render() {
   return $status
 }
 
-# @scenario "Turning on the voice worker with a valid https:// public address renders"
+# @scenario "A stock install with no https:// URL anywhere renders no voice resources"
 test_default_has_no_voice_resources() {
   local out
   if ! out=$(render ""); then
@@ -113,7 +113,7 @@ test_termination_grace_period_follows_voice_values() {
   echo "ok   [voice terminationGracePeriodSeconds] follows --set voice.terminationGracePeriodSeconds, not workers.*"
 }
 
-# @scenario "The voice worker is reachable inside the cluster by default, but not exposed publicly"
+# @scenario "The voice worker is reachable inside the cluster and exposed for Twilio by default"
 test_enabled_renders_service_and_ingress_by_default() {
   local svc ing
   svc=$(render_component "service.yaml" "$ENABLED_FLAGS")
@@ -135,7 +135,7 @@ test_enabled_renders_service_and_ingress_by_default() {
   echo "ok   [voice service / ingress by default] Service and Ingress both render with zero extra ingress config"
 }
 
-# @scenario "The voice worker gets its own public hostname for Twilio to call"
+# @scenario "The voice worker's public hostname defaults to its resolved public address"
 test_ingress_host_defaults_to_public_base_url_hostname() {
   local ing
   ing=$(render_component "ingress.yaml" "$ENABLED_FLAGS")
@@ -154,7 +154,7 @@ test_ingress_host_defaults_to_public_base_url_hostname() {
   echo "ok   [voice ingress default host] Ingress host defaults to voice.example.com with no voice.ingress.host set"
 }
 
-# @scenario "The voice worker gets its own public hostname for Twilio to call"
+# @scenario "An explicit public hostname for the voice worker still works"
 test_ingress_host_explicit_override_renders() {
   local ing
   ing=$(render_component "ingress.yaml" \
@@ -218,7 +218,7 @@ test_stock_app_http_public_url_renders_nothing() {
   echo "ok   [http-only app.http.publicUrl] no https:// origin resolvable anywhere, voice.enabled=true still renders nothing (no failure either)"
 }
 
-# @scenario "Renders by default when an https:// public URL is configured (via app.http.publicUrl)"
+# @scenario "Renders by default when an https:// public URL is configured"
 test_app_http_public_url_https_renders_by_default() {
   local block
   block=$(render_component "deployment.yaml" "--set app.http.publicUrl=https://app.langwatch.ai")
@@ -233,7 +233,7 @@ test_app_http_public_url_https_renders_by_default() {
   echo "ok   [app.http.publicUrl fallback] voice renders by default off app.http.publicUrl alone, zero voice.* values set"
 }
 
-# @scenario "An explicit voice.publicBaseUrl wins over app.http.publicUrl"
+# @scenario "An explicit voice public address wins over the app's own public URL"
 test_explicit_public_base_url_wins_over_app_http_public_url() {
   local block
   block=$(render_component "deployment.yaml" \
@@ -249,7 +249,7 @@ test_explicit_public_base_url_wins_over_app_http_public_url() {
   echo "ok   [explicit wins] voice.publicBaseUrl overrides app.http.publicUrl when both are set"
 }
 
-# @scenario "voice.enabled=false still opts out even when a public https:// URL is available"
+# @scenario "Explicitly turning the voice worker off overrides a resolvable https:// URL"
 test_explicit_disabled_overrides_https_app_public_url() {
   local out
   if ! out=$(render "--set app.http.publicUrl=https://app.langwatch.ai --set voice.enabled=false"); then
@@ -263,7 +263,7 @@ test_explicit_disabled_overrides_https_app_public_url() {
   echo "ok   [explicit disabled] voice.enabled=false opts out even with a resolvable https:// URL"
 }
 
-# @scenario "An explicit bad public address still fails the render"
+# @scenario "An explicit bad voice public address still fails even when the app's own public URL would resolve on its own"
 test_explicit_bad_public_base_url_refuses_even_with_https_app_url() {
   local out
   if out=$(render "--set app.http.publicUrl=https://app.langwatch.ai --set voice.publicBaseUrl=http://voice.example.com"); then

--- a/charts/langwatch/tests/voice-worker.sh
+++ b/charts/langwatch/tests/voice-worker.sh
@@ -30,7 +30,7 @@ fail() {
 }
 
 # autogen generates fresh random Secret values on every render, independent of
-# voice — so a byte-identical comparison must normalise those out first, or
+# voice, so a byte-identical comparison must normalise those out first, or
 # every render pair would "differ" for a reason that has nothing to do with
 # voice. Every such value is a long quoted base64 string; blank them all,
 # consistently, on both sides being compared.

--- a/charts/langwatch/tests/voice-worker.sh
+++ b/charts/langwatch/tests/voice-worker.sh
@@ -203,7 +203,7 @@ test_enabled_with_http_public_base_url_refuses() {
     return
   fi
   case "$out" in
-    *"must be an https:// URL with a hostname"*)
+    *"must be an https origin only"*)
       echo "ok   [http publicBaseUrl] refused with the expected message" ;;
     *)
       fail "http publicBaseUrl" "refused, but not for the expected reason: $(printf '%s' "$out" | tr '\n' ' ' | cut -c1-200)" ;;
@@ -225,6 +225,91 @@ test_enabled_with_https_public_base_url_renders() {
   echo "ok   [https publicBaseUrl] renders with VOICE_PUBLIC_BASE_URL=https://voice.example.com"
 }
 
+# @scenario "Turning on the voice worker with a valid https:// public address including a port renders"
+test_enabled_with_https_port_public_base_url_renders() {
+  local block
+  block=$(render_component "deployment.yaml" "--set voice.enabled=true --set voice.publicBaseUrl=https://voice.example.com:8443")
+  if [ -z "$block" ]; then
+    fail "https publicBaseUrl with port" "rendered no voice Deployment with a valid https:// voice.publicBaseUrl including a port"
+    return
+  fi
+  if ! printf '%s' "$block" | grep -A1 "name: VOICE_PUBLIC_BASE_URL" | grep -q 'value: "https://voice.example.com:8443"'; then
+    fail "https publicBaseUrl with port" "expected VOICE_PUBLIC_BASE_URL=https://voice.example.com:8443"
+    return
+  fi
+  echo "ok   [https publicBaseUrl with port] renders with VOICE_PUBLIC_BASE_URL=https://voice.example.com:8443"
+}
+
+# @scenario "The voice worker refuses a public address that includes a path"
+test_enabled_with_path_public_base_url_refuses() {
+  local out
+  if out=$(render "--set voice.enabled=true --set voice.publicBaseUrl=https://voice.example.com/twilio"); then
+    fail "publicBaseUrl with path" "chart rendered when voice.publicBaseUrl included a path"
+    return
+  fi
+  case "$out" in
+    *"must be an https origin only"*)
+      echo "ok   [publicBaseUrl with path] refused with the expected message" ;;
+    *)
+      fail "publicBaseUrl with path" "refused, but not for the expected reason: $(printf '%s' "$out" | tr '\n' ' ' | cut -c1-200)" ;;
+  esac
+}
+
+# @scenario "The voice worker refuses a public address that includes a query string"
+test_enabled_with_query_public_base_url_refuses() {
+  local out
+  if out=$(render "--set voice.enabled=true --set voice.publicBaseUrl=https://voice.example.com?x=1"); then
+    fail "publicBaseUrl with query" "chart rendered when voice.publicBaseUrl included a query string"
+    return
+  fi
+  case "$out" in
+    *"must be an https origin only"*)
+      echo "ok   [publicBaseUrl with query] refused with the expected message" ;;
+    *)
+      fail "publicBaseUrl with query" "refused, but not for the expected reason: $(printf '%s' "$out" | tr '\n' ' ' | cut -c1-200)" ;;
+  esac
+}
+
+# @scenario "The voice worker refuses a public address with a trailing slash"
+test_enabled_with_trailing_slash_public_base_url_refuses() {
+  local out
+  if out=$(render "--set voice.enabled=true --set voice.publicBaseUrl=https://voice.example.com/"); then
+    fail "publicBaseUrl with trailing slash" "chart rendered when voice.publicBaseUrl had a trailing slash"
+    return
+  fi
+  case "$out" in
+    *"must be an https origin only"*)
+      echo "ok   [publicBaseUrl with trailing slash] refused with the expected message" ;;
+    *)
+      fail "publicBaseUrl with trailing slash" "refused, but not for the expected reason: $(printf '%s' "$out" | tr '\n' ' ' | cut -c1-200)" ;;
+  esac
+}
+
+# @scenario "The voice worker refuses a public address with a malformed hostname"
+test_enabled_with_malformed_host_public_base_url_refuses() {
+  local out
+  if out=$(render "--set voice.enabled=true --set voice.publicBaseUrl=https://"); then
+    fail "publicBaseUrl with no hostname" "chart rendered when voice.publicBaseUrl had no hostname"
+    return
+  fi
+  case "$out" in
+    *"must be an https origin only"*)
+      echo "ok   [publicBaseUrl with no hostname] refused with the expected message" ;;
+    *)
+      fail "publicBaseUrl with no hostname" "refused, but not for the expected reason: $(printf '%s' "$out" | tr '\n' ' ' | cut -c1-200)" ;;
+  esac
+  if out=$(render "--set voice.enabled=true --set voice.publicBaseUrl=https://-bad.example.com"); then
+    fail "publicBaseUrl with leading-hyphen hostname" "chart rendered when voice.publicBaseUrl's hostname started with a hyphen"
+    return
+  fi
+  case "$out" in
+    *"must be an https origin only"*)
+      echo "ok   [publicBaseUrl with leading-hyphen hostname] refused with the expected message" ;;
+    *)
+      fail "publicBaseUrl with leading-hyphen hostname" "refused, but not for the expected reason: $(printf '%s' "$out" | tr '\n' ' ' | cut -c1-200)" ;;
+  esac
+}
+
 test_default_has_no_voice_resources
 test_explicit_false_matches_default
 test_enabled_renders_deployment
@@ -235,6 +320,11 @@ test_ingress_host_mismatch_refuses
 test_enabled_without_public_base_url_refuses
 test_enabled_with_http_public_base_url_refuses
 test_enabled_with_https_public_base_url_renders
+test_enabled_with_https_port_public_base_url_renders
+test_enabled_with_path_public_base_url_refuses
+test_enabled_with_query_public_base_url_refuses
+test_enabled_with_trailing_slash_public_base_url_refuses
+test_enabled_with_malformed_host_public_base_url_refuses
 
 if [ "$failures" -gt 0 ]; then
   echo "$failures assertion(s) failed"

--- a/charts/langwatch/tests/voice-worker.sh
+++ b/charts/langwatch/tests/voice-worker.sh
@@ -1,13 +1,14 @@
 #!/usr/bin/env bash
 #
-# Renders the chart and asserts the opt-in voice worker (Deployment, Service,
-# Ingress) behaves as documented: absent unless enabled, refusing to render
-# without the two values it cannot work without, and shaped correctly once
-# turned on.
+# Renders the chart and asserts the voice worker (Deployment, Service,
+# Ingress) behaves as documented: on by default but rendering nothing until a
+# public https:// origin resolves (from voice.publicBaseUrl or, failing
+# that, app.http.publicUrl), refusing to render only on an explicit bad
+# value, and shaped correctly once a public address is in play.
 #
 # This executes the template pipeline rather than reading the templates: the
-# gating conditions, the required-value checks, and the env/secretKeyRef
-# wiring are only visible in what actually renders.
+# gating conditions, the resolution priority, the required-value checks, and
+# the env/secretKeyRef wiring are only visible in what actually renders.
 #
 # See langwatch/langwatch#8015 and the env contract on #8014
 # (voice-env-contract comment).
@@ -51,7 +52,7 @@ render() {
   return $status
 }
 
-# @scenario "The voice worker is not deployed unless the operator turns it on"
+# @scenario "Turning on the voice worker with a valid https:// public address renders"
 test_default_has_no_voice_resources() {
   local out
   if ! out=$(render ""); then
@@ -59,23 +60,10 @@ test_default_has_no_voice_resources() {
     return
   fi
   if printf '%s' "$out" | grep -q "templates/voice/"; then
-    fail "default has no voice resources" "default render includes a templates/voice/ manifest"
+    fail "default has no voice resources" "default render (no https:// public URL configured anywhere) includes a templates/voice/ manifest"
     return
   fi
-  echo "ok   [default has no voice resources] no templates/voice/ source in the default render"
-}
-
-# @scenario "Turning the voice worker off explicitly changes nothing"
-test_explicit_false_matches_default() {
-  local default_out explicit_out
-  default_out=$(render "" | normalise)
-  explicit_out=$(render "--set voice.enabled=false" | normalise)
-  if [ "$default_out" != "$explicit_out" ]; then
-    fail "explicit false matches default" \
-      "rendered manifest differs between default and --set voice.enabled=false: $(diff <(printf '%s' "$default_out") <(printf '%s' "$explicit_out") | head -10 | tr '\n' ' ')"
-    return
-  fi
-  echo "ok   [explicit false matches default] --set voice.enabled=false renders identically to the default"
+  echo "ok   [default has no voice resources] stock install (voice.enabled=true, no https:// URL resolvable) renders no templates/voice/ source"
 }
 
 # Renders a profile and prints only one component's manifest, so a value from
@@ -88,14 +76,14 @@ render_component() {
   '
 }
 
-readonly ENABLED_FLAGS="--set voice.enabled=true --set voice.publicBaseUrl=https://voice.example.com"
+readonly ENABLED_FLAGS="--set voice.publicBaseUrl=https://voice.example.com"
 
 # @scenario "Turning on the voice worker brings up a single call handler"
 test_enabled_renders_deployment() {
   local block
   block=$(render_component "deployment.yaml" "$ENABLED_FLAGS")
   if [ -z "$block" ]; then
-    fail "voice deployment" "rendered no voice Deployment with voice.enabled=true"
+    fail "voice deployment" "rendered no voice Deployment with voice.publicBaseUrl set"
     return
   fi
   if ! printf '%s' "$block" | grep -q "replicas: 1"; then
@@ -115,7 +103,7 @@ test_termination_grace_period_follows_voice_values() {
   block=$(render_component "deployment.yaml" \
     "$ENABLED_FLAGS --set voice.terminationGracePeriodSeconds=90 --set voice.shutdownDrainSeconds=60 --set workers.terminationGracePeriodSeconds=999")
   if [ -z "$block" ]; then
-    fail "voice terminationGracePeriodSeconds" "rendered no voice Deployment with voice.enabled=true"
+    fail "voice terminationGracePeriodSeconds" "rendered no voice Deployment with voice.publicBaseUrl set"
     return
   fi
   if ! printf '%s' "$block" | grep -q "terminationGracePeriodSeconds: 90"; then
@@ -126,49 +114,85 @@ test_termination_grace_period_follows_voice_values() {
 }
 
 # @scenario "The voice worker is reachable inside the cluster by default, but not exposed publicly"
-test_enabled_renders_service_no_ingress() {
+test_enabled_renders_service_and_ingress_by_default() {
   local svc ing
   svc=$(render_component "service.yaml" "$ENABLED_FLAGS")
   if [ -z "$svc" ]; then
-    fail "voice service" "rendered no voice Service with voice.enabled=true"
+    fail "voice service" "rendered no voice Service with voice.publicBaseUrl set"
     return
   fi
   if ! printf '%s' "$svc" | grep -q "targetPort: voice-ws"; then
     fail "voice service targetPort" "expected targetPort: voice-ws"
     return
   fi
+  # voice.ingress.enabled now defaults to true, so a resolved public URL is
+  # enough on its own to get an Ingress with no extra values set.
   ing=$(render_component "ingress.yaml" "$ENABLED_FLAGS")
-  if [ -n "$ing" ]; then
-    fail "voice ingress absent by default" "voice.ingress.enabled defaults to false but an Ingress rendered anyway"
+  if [ -z "$ing" ]; then
+    fail "voice ingress renders by default" "voice.ingress.enabled defaults to true but no Ingress rendered with voice.publicBaseUrl set"
     return
   fi
-  echo "ok   [voice service / no ingress] Service renders, Ingress does not (ingress.enabled defaults false)"
+  echo "ok   [voice service / ingress by default] Service and Ingress both render with zero extra ingress config"
 }
 
 # @scenario "The voice worker gets its own public hostname for Twilio to call"
-test_ingress_enabled_renders() {
+test_ingress_host_defaults_to_public_base_url_hostname() {
   local ing
-  ing=$(render_component "ingress.yaml" \
-    "$ENABLED_FLAGS --set voice.ingress.enabled=true --set voice.ingress.host=voice.example.com")
+  ing=$(render_component "ingress.yaml" "$ENABLED_FLAGS")
   if [ -z "$ing" ]; then
-    fail "voice ingress enabled" "rendered no voice Ingress with voice.ingress.enabled=true"
+    fail "voice ingress default host" "rendered no voice Ingress with voice.publicBaseUrl set"
     return
   fi
   if ! printf '%s' "$ing" | grep -q "host: \"voice.example.com\""; then
-    fail "voice ingress host" "expected host: \"voice.example.com\""
+    fail "voice ingress default host" "expected host: \"voice.example.com\" derived from voice.publicBaseUrl with no voice.ingress.host set, got: $(printf '%s' "$ing" | grep host:)"
     return
   fi
   if ! printf '%s' "$ing" | grep -q "path: /twilio"; then
     fail "voice ingress path" "expected path: /twilio"
     return
   fi
-  echo "ok   [voice ingress enabled] Ingress renders for voice.example.com at /twilio"
+  echo "ok   [voice ingress default host] Ingress host defaults to voice.example.com with no voice.ingress.host set"
+}
+
+# @scenario "The voice worker gets its own public hostname for Twilio to call"
+test_ingress_host_explicit_override_renders() {
+  local ing
+  ing=$(render_component "ingress.yaml" \
+    "$ENABLED_FLAGS --set voice.ingress.host=voice.example.com")
+  if [ -z "$ing" ]; then
+    fail "voice ingress explicit host" "rendered no voice Ingress with voice.ingress.host set explicitly"
+    return
+  fi
+  if ! printf '%s' "$ing" | grep -q "host: \"voice.example.com\""; then
+    fail "voice ingress explicit host" "expected host: \"voice.example.com\""
+    return
+  fi
+  echo "ok   [voice ingress explicit host] explicit voice.ingress.host matching voice.publicBaseUrl renders"
+}
+
+# @scenario "The voice worker's ingress carries WebSocket-safe timeout annotations by default"
+test_ingress_default_annotations_extend_websocket_timeout() {
+  local ing
+  ing=$(render_component "ingress.yaml" "$ENABLED_FLAGS")
+  if [ -z "$ing" ]; then
+    fail "voice ingress default annotations" "rendered no voice Ingress with voice.publicBaseUrl set"
+    return
+  fi
+  if ! printf '%s' "$ing" | grep -q 'nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"'; then
+    fail "voice ingress default annotations" "expected nginx.ingress.kubernetes.io/proxy-read-timeout: \"3600\" by default"
+    return
+  fi
+  if ! printf '%s' "$ing" | grep -q 'nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"'; then
+    fail "voice ingress default annotations" "expected nginx.ingress.kubernetes.io/proxy-send-timeout: \"3600\" by default"
+    return
+  fi
+  echo "ok   [voice ingress default annotations] nginx proxy-read/send-timeout default to 3600s"
 }
 
 # @scenario "The voice worker refuses to expose a hostname that doesn't match its own public address"
 test_ingress_host_mismatch_refuses() {
   local out
-  if out=$(render "$ENABLED_FLAGS --set voice.ingress.enabled=true --set voice.ingress.host=other.example.com"); then
+  if out=$(render "$ENABLED_FLAGS --set voice.ingress.host=other.example.com"); then
     fail "ingress host mismatch" "chart rendered when voice.ingress.host disagreed with voice.publicBaseUrl"
     return
   fi
@@ -180,25 +204,84 @@ test_ingress_host_mismatch_refuses() {
   esac
 }
 
-# @scenario "The voice worker refuses to start without knowing its own public address"
-test_enabled_without_public_base_url_refuses() {
+# @scenario "The voice worker does not render when only an http:// URL is available"
+test_stock_app_http_public_url_renders_nothing() {
   local out
-  if out=$(render "--set voice.enabled=true"); then
-    fail "missing publicBaseUrl" "chart rendered when voice.publicBaseUrl was not set"
+  if ! out=$(render "--set voice.enabled=true"); then
+    fail "http-only app.http.publicUrl" "chart failed to render at all: $(printf '%s' "$out" | tail -5)"
+    return
+  fi
+  if printf '%s' "$out" | grep -q "templates/voice/"; then
+    fail "http-only app.http.publicUrl" "voice.enabled=true with the default http:// app.http.publicUrl and no voice.publicBaseUrl still rendered voice resources"
+    return
+  fi
+  echo "ok   [http-only app.http.publicUrl] no https:// origin resolvable anywhere, voice.enabled=true still renders nothing (no failure either)"
+}
+
+# @scenario "Renders by default when an https:// public URL is configured (via app.http.publicUrl)"
+test_app_http_public_url_https_renders_by_default() {
+  local block
+  block=$(render_component "deployment.yaml" "--set app.http.publicUrl=https://app.langwatch.ai")
+  if [ -z "$block" ]; then
+    fail "app.http.publicUrl fallback" "rendered no voice Deployment with app.http.publicUrl=https://app.langwatch.ai and voice.enabled left at its default (true), no voice.publicBaseUrl set"
+    return
+  fi
+  if ! printf '%s' "$block" | grep -A1 "name: VOICE_PUBLIC_BASE_URL" | grep -q 'value: "https://app.langwatch.ai"'; then
+    fail "app.http.publicUrl fallback" "expected VOICE_PUBLIC_BASE_URL=https://app.langwatch.ai resolved from app.http.publicUrl"
+    return
+  fi
+  echo "ok   [app.http.publicUrl fallback] voice renders by default off app.http.publicUrl alone, zero voice.* values set"
+}
+
+# @scenario "An explicit voice.publicBaseUrl wins over app.http.publicUrl"
+test_explicit_public_base_url_wins_over_app_http_public_url() {
+  local block
+  block=$(render_component "deployment.yaml" \
+    "--set app.http.publicUrl=https://app.langwatch.ai --set voice.publicBaseUrl=https://voice.langwatch.ai")
+  if [ -z "$block" ]; then
+    fail "explicit wins" "rendered no voice Deployment"
+    return
+  fi
+  if ! printf '%s' "$block" | grep -A1 "name: VOICE_PUBLIC_BASE_URL" | grep -q 'value: "https://voice.langwatch.ai"'; then
+    fail "explicit wins" "expected the explicit voice.publicBaseUrl (https://voice.langwatch.ai) to win over app.http.publicUrl (https://app.langwatch.ai)"
+    return
+  fi
+  echo "ok   [explicit wins] voice.publicBaseUrl overrides app.http.publicUrl when both are set"
+}
+
+# @scenario "voice.enabled=false still opts out even when a public https:// URL is available"
+test_explicit_disabled_overrides_https_app_public_url() {
+  local out
+  if ! out=$(render "--set app.http.publicUrl=https://app.langwatch.ai --set voice.enabled=false"); then
+    fail "explicit disabled" "chart failed to render at all: $(printf '%s' "$out" | tail -5)"
+    return
+  fi
+  if printf '%s' "$out" | grep -q "templates/voice/"; then
+    fail "explicit disabled" "voice.enabled=false rendered voice resources even with an https:// app.http.publicUrl"
+    return
+  fi
+  echo "ok   [explicit disabled] voice.enabled=false opts out even with a resolvable https:// URL"
+}
+
+# @scenario "An explicit bad public address still fails the render"
+test_explicit_bad_public_base_url_refuses_even_with_https_app_url() {
+  local out
+  if out=$(render "--set app.http.publicUrl=https://app.langwatch.ai --set voice.publicBaseUrl=http://voice.example.com"); then
+    fail "explicit bad value" "chart rendered with an invalid voice.publicBaseUrl even though app.http.publicUrl was a valid https:// origin"
     return
   fi
   case "$out" in
-    *"voice.publicBaseUrl is required"*)
-      echo "ok   [missing publicBaseUrl] refused with the expected message" ;;
+    *"must be an https origin only"*)
+      echo "ok   [explicit bad value] refused with the expected message even though app.http.publicUrl alone would have resolved" ;;
     *)
-      fail "missing publicBaseUrl" "refused, but not for the expected reason: $(printf '%s' "$out" | tr '\n' ' ' | cut -c1-200)" ;;
+      fail "explicit bad value" "refused, but not for the expected reason: $(printf '%s' "$out" | tr '\n' ' ' | cut -c1-200)" ;;
   esac
 }
 
 # @scenario "The voice worker refuses a public address that is not a valid https:// origin"
 test_enabled_with_http_public_base_url_refuses() {
   local out
-  if out=$(render "--set voice.enabled=true --set voice.publicBaseUrl=http://voice.example.com"); then
+  if out=$(render "--set voice.publicBaseUrl=http://voice.example.com"); then
     fail "http publicBaseUrl" "chart rendered when voice.publicBaseUrl used http:// instead of https://"
     return
   fi
@@ -213,7 +296,7 @@ test_enabled_with_http_public_base_url_refuses() {
 # @scenario "Turning on the voice worker with a valid https:// public address renders"
 test_enabled_with_https_public_base_url_renders() {
   local block
-  block=$(render_component "deployment.yaml" "--set voice.enabled=true --set voice.publicBaseUrl=https://voice.example.com")
+  block=$(render_component "deployment.yaml" "--set voice.publicBaseUrl=https://voice.example.com")
   if [ -z "$block" ]; then
     fail "https publicBaseUrl" "rendered no voice Deployment with a valid https:// voice.publicBaseUrl"
     return
@@ -228,7 +311,7 @@ test_enabled_with_https_public_base_url_renders() {
 # @scenario "Turning on the voice worker with a valid https:// public address including a port renders"
 test_enabled_with_https_port_public_base_url_renders() {
   local block
-  block=$(render_component "deployment.yaml" "--set voice.enabled=true --set voice.publicBaseUrl=https://voice.example.com:8443")
+  block=$(render_component "deployment.yaml" "--set voice.publicBaseUrl=https://voice.example.com:8443")
   if [ -z "$block" ]; then
     fail "https publicBaseUrl with port" "rendered no voice Deployment with a valid https:// voice.publicBaseUrl including a port"
     return
@@ -243,7 +326,7 @@ test_enabled_with_https_port_public_base_url_renders() {
 # @scenario "The voice worker refuses a public address whose port is out of range"
 test_enabled_with_out_of_range_port_public_base_url_refuses() {
   local out
-  if out=$(render "--set voice.enabled=true --set voice.publicBaseUrl=https://voice.example.com:65536"); then
+  if out=$(render "--set voice.publicBaseUrl=https://voice.example.com:65536"); then
     fail "out-of-range port publicBaseUrl" "chart rendered when voice.publicBaseUrl used port 65536"
     return
   fi
@@ -254,7 +337,7 @@ test_enabled_with_out_of_range_port_public_base_url_refuses() {
       fail "out-of-range port publicBaseUrl" "refused, but not for the expected reason: $(printf '%s' "$out" | tr '\n' ' ' | cut -c1-200)" ;;
   esac
 
-  if out=$(render "--set voice.enabled=true --set voice.publicBaseUrl=https://voice.example.com:0"); then
+  if out=$(render "--set voice.publicBaseUrl=https://voice.example.com:0"); then
     fail "out-of-range port publicBaseUrl" "chart rendered when voice.publicBaseUrl used port 0"
     return
   fi
@@ -269,7 +352,7 @@ test_enabled_with_out_of_range_port_public_base_url_refuses() {
 # @scenario "The voice worker refuses a public address that includes a path"
 test_enabled_with_path_public_base_url_refuses() {
   local out
-  if out=$(render "--set voice.enabled=true --set voice.publicBaseUrl=https://voice.example.com/twilio"); then
+  if out=$(render "--set voice.publicBaseUrl=https://voice.example.com/twilio"); then
     fail "publicBaseUrl with path" "chart rendered when voice.publicBaseUrl included a path"
     return
   fi
@@ -284,7 +367,7 @@ test_enabled_with_path_public_base_url_refuses() {
 # @scenario "The voice worker refuses a public address that includes a query string"
 test_enabled_with_query_public_base_url_refuses() {
   local out
-  if out=$(render "--set voice.enabled=true --set voice.publicBaseUrl=https://voice.example.com?x=1"); then
+  if out=$(render "--set voice.publicBaseUrl=https://voice.example.com?x=1"); then
     fail "publicBaseUrl with query" "chart rendered when voice.publicBaseUrl included a query string"
     return
   fi
@@ -299,7 +382,7 @@ test_enabled_with_query_public_base_url_refuses() {
 # @scenario "The voice worker refuses a public address with a trailing slash"
 test_enabled_with_trailing_slash_public_base_url_refuses() {
   local out
-  if out=$(render "--set voice.enabled=true --set voice.publicBaseUrl=https://voice.example.com/"); then
+  if out=$(render "--set voice.publicBaseUrl=https://voice.example.com/"); then
     fail "publicBaseUrl with trailing slash" "chart rendered when voice.publicBaseUrl had a trailing slash"
     return
   fi
@@ -314,7 +397,7 @@ test_enabled_with_trailing_slash_public_base_url_refuses() {
 # @scenario "The voice worker refuses a public address with a malformed hostname"
 test_enabled_with_malformed_host_public_base_url_refuses() {
   local out
-  if out=$(render "--set voice.enabled=true --set voice.publicBaseUrl=https://"); then
+  if out=$(render "--set voice.publicBaseUrl=https://"); then
     fail "publicBaseUrl with no hostname" "chart rendered when voice.publicBaseUrl had no hostname"
     return
   fi
@@ -324,7 +407,7 @@ test_enabled_with_malformed_host_public_base_url_refuses() {
     *)
       fail "publicBaseUrl with no hostname" "refused, but not for the expected reason: $(printf '%s' "$out" | tr '\n' ' ' | cut -c1-200)" ;;
   esac
-  if out=$(render "--set voice.enabled=true --set voice.publicBaseUrl=https://-bad.example.com"); then
+  if out=$(render "--set voice.publicBaseUrl=https://-bad.example.com"); then
     fail "publicBaseUrl with leading-hyphen hostname" "chart rendered when voice.publicBaseUrl's hostname started with a hyphen"
     return
   fi
@@ -337,13 +420,18 @@ test_enabled_with_malformed_host_public_base_url_refuses() {
 }
 
 test_default_has_no_voice_resources
-test_explicit_false_matches_default
 test_enabled_renders_deployment
 test_termination_grace_period_follows_voice_values
-test_enabled_renders_service_no_ingress
-test_ingress_enabled_renders
+test_enabled_renders_service_and_ingress_by_default
+test_ingress_host_defaults_to_public_base_url_hostname
+test_ingress_host_explicit_override_renders
+test_ingress_default_annotations_extend_websocket_timeout
 test_ingress_host_mismatch_refuses
-test_enabled_without_public_base_url_refuses
+test_stock_app_http_public_url_renders_nothing
+test_app_http_public_url_https_renders_by_default
+test_explicit_public_base_url_wins_over_app_http_public_url
+test_explicit_disabled_overrides_https_app_public_url
+test_explicit_bad_public_base_url_refuses_even_with_https_app_url
 test_enabled_with_http_public_base_url_refuses
 test_enabled_with_https_public_base_url_renders
 test_enabled_with_https_port_public_base_url_renders

--- a/charts/langwatch/tests/voice-worker.sh
+++ b/charts/langwatch/tests/voice-worker.sh
@@ -51,7 +51,7 @@ render() {
   return $status
 }
 
-# @scenario "The default install renders no voice resources"
+# @scenario "The voice worker is not deployed unless the operator turns it on"
 test_default_has_no_voice_resources() {
   local out
   if ! out=$(render ""); then
@@ -65,7 +65,7 @@ test_default_has_no_voice_resources() {
   echo "ok   [default has no voice resources] no templates/voice/ source in the default render"
 }
 
-# @scenario "voice.enabled=false explicitly changes nothing"
+# @scenario "Turning the voice worker off explicitly changes nothing"
 test_explicit_false_matches_default() {
   local default_out explicit_out
   default_out=$(render "" | normalise)
@@ -90,7 +90,7 @@ render_component() {
 
 readonly ENABLED_FLAGS="--set voice.enabled=true --set voice.publicBaseUrl=https://voice.example.com --set voice.twilio.existingSecret=twilio"
 
-# @scenario "Enabling voice renders a single-replica worker wired to the Twilio secret"
+# @scenario "Turning on the voice worker brings up a single call handler wired to Twilio"
 test_enabled_renders_deployment() {
   local block
   block=$(render_component "deployment.yaml" "$ENABLED_FLAGS")
@@ -125,7 +125,7 @@ test_enabled_renders_deployment() {
   echo "ok   [voice deployment] replicas=1, VOICE_WORKER_ONLY=true, Twilio secretKeyRefs present"
 }
 
-# @scenario "The voice Deployment's terminationGracePeriodSeconds follows voice.*, not workers.*"
+# @scenario "The voice worker's shutdown timing is its own, not borrowed from the background workers"
 test_termination_grace_period_follows_voice_values() {
   local block
   block=$(render_component "deployment.yaml" \
@@ -141,7 +141,7 @@ test_termination_grace_period_follows_voice_values() {
   echo "ok   [voice terminationGracePeriodSeconds] follows --set voice.terminationGracePeriodSeconds, not workers.*"
 }
 
-# @scenario "Enabling voice renders a Service but no Ingress by default"
+# @scenario "The voice worker is reachable inside the cluster by default, but not exposed publicly"
 test_enabled_renders_service_no_ingress() {
   local svc ing
   svc=$(render_component "service.yaml" "$ENABLED_FLAGS")
@@ -161,7 +161,7 @@ test_enabled_renders_service_no_ingress() {
   echo "ok   [voice service / no ingress] Service renders, Ingress does not (ingress.enabled defaults false)"
 }
 
-# @scenario "Enabling the voice ingress renders it for the configured host"
+# @scenario "The voice worker gets its own public hostname for Twilio to call"
 test_ingress_enabled_renders() {
   local ing
   ing=$(render_component "ingress.yaml" \
@@ -181,7 +181,22 @@ test_ingress_enabled_renders() {
   echo "ok   [voice ingress enabled] Ingress renders for voice.example.com at /twilio"
 }
 
-# @scenario "voice.enabled without publicBaseUrl refuses to render"
+# @scenario "The voice worker refuses to expose a hostname that doesn't match its own public address"
+test_ingress_host_mismatch_refuses() {
+  local out
+  if out=$(render "$ENABLED_FLAGS --set voice.ingress.enabled=true --set voice.ingress.host=other.example.com"); then
+    fail "ingress host mismatch" "chart rendered when voice.ingress.host disagreed with voice.publicBaseUrl"
+    return
+  fi
+  case "$out" in
+    *"does not match the hostname in voice.publicBaseUrl"*)
+      echo "ok   [ingress host mismatch] refused with the expected message" ;;
+    *)
+      fail "ingress host mismatch" "refused, but not for the expected reason: $(printf '%s' "$out" | tr '\n' ' ' | cut -c1-200)" ;;
+  esac
+}
+
+# @scenario "The voice worker refuses to start without knowing its own public address"
 test_enabled_without_public_base_url_refuses() {
   local out
   if out=$(render "--set voice.enabled=true --set voice.twilio.existingSecret=twilio"); then
@@ -196,7 +211,7 @@ test_enabled_without_public_base_url_refuses() {
   esac
 }
 
-# @scenario "voice.enabled without an existing Twilio secret refuses to render"
+# @scenario "The voice worker refuses to start without Twilio credentials configured"
 test_enabled_without_twilio_secret_refuses() {
   local out
   if out=$(render "--set voice.enabled=true --set voice.publicBaseUrl=https://voice.example.com"); then
@@ -217,6 +232,7 @@ test_enabled_renders_deployment
 test_termination_grace_period_follows_voice_values
 test_enabled_renders_service_no_ingress
 test_ingress_enabled_renders
+test_ingress_host_mismatch_refuses
 test_enabled_without_public_base_url_refuses
 test_enabled_without_twilio_secret_refuses
 

--- a/charts/langwatch/tests/voice-worker.sh
+++ b/charts/langwatch/tests/voice-worker.sh
@@ -240,6 +240,32 @@ test_enabled_with_https_port_public_base_url_renders() {
   echo "ok   [https publicBaseUrl with port] renders with VOICE_PUBLIC_BASE_URL=https://voice.example.com:8443"
 }
 
+# @scenario "The voice worker refuses a public address whose port is out of range"
+test_enabled_with_out_of_range_port_public_base_url_refuses() {
+  local out
+  if out=$(render "--set voice.enabled=true --set voice.publicBaseUrl=https://voice.example.com:65536"); then
+    fail "out-of-range port publicBaseUrl" "chart rendered when voice.publicBaseUrl used port 65536"
+    return
+  fi
+  case "$out" in
+    *"must be an https origin only"*)
+      echo "ok   [out-of-range port publicBaseUrl] refused with the expected message for port 65536" ;;
+    *)
+      fail "out-of-range port publicBaseUrl" "refused, but not for the expected reason: $(printf '%s' "$out" | tr '\n' ' ' | cut -c1-200)" ;;
+  esac
+
+  if out=$(render "--set voice.enabled=true --set voice.publicBaseUrl=https://voice.example.com:0"); then
+    fail "out-of-range port publicBaseUrl" "chart rendered when voice.publicBaseUrl used port 0"
+    return
+  fi
+  case "$out" in
+    *"must be an https origin only"*)
+      echo "ok   [out-of-range port publicBaseUrl] refused with the expected message for port 0" ;;
+    *)
+      fail "out-of-range port publicBaseUrl" "refused, but not for the expected reason: $(printf '%s' "$out" | tr '\n' ' ' | cut -c1-200)" ;;
+  esac
+}
+
 # @scenario "The voice worker refuses a public address that includes a path"
 test_enabled_with_path_public_base_url_refuses() {
   local out
@@ -321,6 +347,7 @@ test_enabled_without_public_base_url_refuses
 test_enabled_with_http_public_base_url_refuses
 test_enabled_with_https_public_base_url_renders
 test_enabled_with_https_port_public_base_url_renders
+test_enabled_with_out_of_range_port_public_base_url_refuses
 test_enabled_with_path_public_base_url_refuses
 test_enabled_with_query_public_base_url_refuses
 test_enabled_with_trailing_slash_public_base_url_refuses

--- a/charts/langwatch/tests/voice-worker.sh
+++ b/charts/langwatch/tests/voice-worker.sh
@@ -90,11 +90,7 @@ test_enabled_renders_deployment() {
     fail "voice deployment replicas" "expected replicas: 1"
     return
   fi
-  if ! printf '%s' "$block" | grep -A1 "name: VOICE_WORKER_ONLY" | grep -q 'value: "true"'; then
-    fail "voice deployment VOICE_WORKER_ONLY" "expected VOICE_WORKER_ONLY=true"
-    return
-  fi
-  echo "ok   [voice deployment] replicas=1, VOICE_WORKER_ONLY=true"
+  echo "ok   [voice deployment] replicas=1"
 }
 
 # @scenario "The voice worker's shutdown timing is its own, not borrowed from the background workers"

--- a/charts/langwatch/values.yaml
+++ b/charts/langwatch/values.yaml
@@ -1075,20 +1075,22 @@ workers:
 # =============================================================================
 # Voice Worker Configuration (opt-in)
 # =============================================================================
-# A dedicated single-replica worker that terminates Twilio Media Streams calls.
-# Off by default — the default install renders no voice resources at all.
+# A dedicated single-replica worker that terminates inbound Media Streams calls.
+# Off by default, the default install renders no voice resources at all.
 #
-# Twilio Media Streams connects INBOUND to this worker: without a
+# Media Streams connects INBOUND to this worker: without a
 # publicly-reachable voice.publicBaseUrl, there are no phone targets, no
 # matter how the rest of this block is set. Terminate TLS at your own edge
 # (ingress or a cloud load balancer) and point voice.publicBaseUrl at that
 # public origin.
 #
 # Env contract (langwatch/langwatch#8014): the worker reads VOICE_WORKER_ONLY,
-# VOICE_WS_PORT, VOICE_PUBLIC_BASE_URL and the three TWILIO_* variables below.
-# Replicas are fixed at 1, not a value — the Twilio Media Streams WebSocket
-# routes an in-flight call by nonce inside one process, so a second replica
-# would split a call's frames across two processes with no shared state.
+# VOICE_WS_PORT and VOICE_PUBLIC_BASE_URL below. Replicas are fixed at 1, not
+# a value, the Media Streams WebSocket routes an in-flight call by nonce
+# inside one process, so a second replica would split a call's frames across
+# two processes with no shared state. Call-provider credentials (account SID,
+# auth token, from-number) are per-project data configured inside LangWatch,
+# not chart values.
 ## @section Voice worker (opt-in)
 voice:
   # See workers.otel — named separately so voice worker telemetry is distinguishable.
@@ -1100,31 +1102,15 @@ voice:
   ## @param voice.enabled [default: false] Deploy the voice worker Deployment, Service (and Ingress if voice.ingress.enabled). Off by default.
   enabled: false
 
-  # Public https:// origin Twilio dials back to; the worker derives
-  # wss://<host>/twilio/<nonce> from it. Required whenever voice.enabled is
-  # true — the chart refuses to render without it.
-  ## @param voice.publicBaseUrl [string] Public https:// origin Twilio connects to (e.g. https://voice.example.com). Required when voice.enabled is true.
+  # Public https:// origin the call provider dials back to; the worker
+  # derives wss://<host>/twilio/<nonce> from it. Required whenever
+  # voice.enabled is true, the chart refuses to render without it.
+  ## @param voice.publicBaseUrl [string] Public https:// origin the call provider connects to (e.g. https://voice.example.com). Required when voice.enabled is true.
   publicBaseUrl: ""
 
-  # TCP port of the Twilio Media Streams WebSocket listener inside the pod.
-  ## @param voice.wsPort [default: 3300] Container port of the Twilio Media Streams WebSocket listener.
+  # TCP port of the Media Streams WebSocket listener inside the pod.
+  ## @param voice.wsPort [default: 3300] Container port of the Media Streams WebSocket listener.
   wsPort: 3300
-
-  # Twilio REST credentials. Bring your own Twilio account; the chart never
-  # carries phone numbers or call-routing config (see langwatch/langwatch#8014
-  # — allowed_callees and the call-duration cap are project configuration,
-  # not environment).
-  ## @extra voice.twilio Twilio credentials, read from an existing Secret you manage.
-  ## @param voice.twilio.existingSecret [string] Name of an existing Secret carrying the Twilio credential keys below. Required when voice.enabled is true.
-  ## @param voice.twilio.keys.accountSid [default: TWILIO_ACCOUNT_SID] Key in the existing Secret for the Twilio Account SID.
-  ## @param voice.twilio.keys.authToken [default: TWILIO_AUTH_TOKEN] Key in the existing Secret for the Twilio auth token.
-  ## @param voice.twilio.keys.fromNumber [default: TWILIO_FROM_NUMBER] Key in the existing Secret for the outbound caller id (E.164).
-  twilio:
-    existingSecret: ""
-    keys:
-      accountSid: TWILIO_ACCOUNT_SID
-      authToken: TWILIO_AUTH_TOKEN
-      fromNumber: TWILIO_FROM_NUMBER
 
   # Resource requirements for the voice worker pod.
   # See: https://kubespec.dev/v1/Pod#spec.containers.resources

--- a/charts/langwatch/values.yaml
+++ b/charts/langwatch/values.yaml
@@ -1091,6 +1091,12 @@ workers:
 # would split a call's frames across two processes with no shared state.
 ## @section Voice worker (opt-in)
 voice:
+  # See workers.otel — named separately so voice worker telemetry is distinguishable.
+  ## @extra voice.otel OpenTelemetry identity for the voice worker.
+  ## @param voice.otel.serviceName [string, default: langwatch-voice] Service name reported in traces and logs.
+  otel:
+    serviceName: langwatch-voice
+
   ## @param voice.enabled [default: false] Deploy the voice worker Deployment, Service (and Ingress if voice.ingress.enabled). Off by default.
   enabled: false
 
@@ -1143,8 +1149,20 @@ voice:
   # See: https://kubespec.dev/v1/Pod#spec.affinity
   ## @param voice.affinity [object] Affinity overrides.
   affinity: {}
-  ## @param voice.podAnnotations [object] Additional pod annotations for the voice worker.
-  podAnnotations: {}
+  # PriorityClass for the voice worker pod, overriding global.scheduling.priorityClassName.
+  # See: https://kubespec.dev/v1/Pod#spec.priorityClassName
+  ## @param voice.priorityClassName [string] PriorityClass for the voice worker pod (overrides global.scheduling.priorityClassName).
+  priorityClassName: ""
+  # Pod-level configurations, mirroring workers.pod.
+  ## @extra voice.pod Pod-level metadata.
+  ## @param voice.pod.annotations [object] Additional pod annotations for the voice worker.
+  pod:
+    annotations: {}
+  # Deployment-level configurations, mirroring workers.deployment.
+  ## @extra voice.deployment Deployment-level metadata.
+  ## @param voice.deployment.annotations [object] Additional Deployment annotations for the voice worker.
+  deployment:
+    annotations: {}
 
   # Service exposing the Twilio Media Streams WebSocket port in-cluster.
   ## @extra voice.service Service configuration for the voice worker.

--- a/charts/langwatch/values.yaml
+++ b/charts/langwatch/values.yaml
@@ -1073,6 +1073,105 @@ workers:
 
 
 # =============================================================================
+# Voice Worker Configuration (opt-in)
+# =============================================================================
+# A dedicated single-replica worker that terminates Twilio Media Streams calls.
+# Off by default — the default install renders no voice resources at all.
+#
+# Twilio Media Streams connects INBOUND to this worker: without a
+# publicly-reachable voice.publicBaseUrl, there are no phone targets, no
+# matter how the rest of this block is set. Terminate TLS at your own edge
+# (ingress or a cloud load balancer) and point voice.publicBaseUrl at that
+# public origin.
+#
+# Env contract (langwatch/langwatch#8014): the worker reads VOICE_WORKER_ONLY,
+# VOICE_WS_PORT, VOICE_PUBLIC_BASE_URL and the three TWILIO_* variables below.
+# Replicas are fixed at 1, not a value — the Twilio Media Streams WebSocket
+# routes an in-flight call by nonce inside one process, so a second replica
+# would split a call's frames across two processes with no shared state.
+## @section Voice worker (opt-in)
+voice:
+  ## @param voice.enabled [default: false] Deploy the voice worker Deployment, Service (and Ingress if voice.ingress.enabled). Off by default.
+  enabled: false
+
+  # Public https:// origin Twilio dials back to; the worker derives
+  # wss://<host>/twilio/<nonce> from it. Required whenever voice.enabled is
+  # true — the chart refuses to render without it.
+  ## @param voice.publicBaseUrl [string] Public https:// origin Twilio connects to (e.g. https://voice.example.com). Required when voice.enabled is true.
+  publicBaseUrl: ""
+
+  # TCP port of the Twilio Media Streams WebSocket listener inside the pod.
+  ## @param voice.wsPort [default: 3300] Container port of the Twilio Media Streams WebSocket listener.
+  wsPort: 3300
+
+  # Twilio REST credentials. Bring your own Twilio account; the chart never
+  # carries phone numbers or call-routing config (see langwatch/langwatch#8014
+  # — allowed_callees and the call-duration cap are project configuration,
+  # not environment).
+  ## @extra voice.twilio Twilio credentials, read from an existing Secret you manage.
+  ## @param voice.twilio.existingSecret [string] Name of an existing Secret carrying the Twilio credential keys below. Required when voice.enabled is true.
+  ## @param voice.twilio.keys.accountSid [default: TWILIO_ACCOUNT_SID] Key in the existing Secret for the Twilio Account SID.
+  ## @param voice.twilio.keys.authToken [default: TWILIO_AUTH_TOKEN] Key in the existing Secret for the Twilio auth token.
+  ## @param voice.twilio.keys.fromNumber [default: TWILIO_FROM_NUMBER] Key in the existing Secret for the outbound caller id (E.164).
+  twilio:
+    existingSecret: ""
+    keys:
+      accountSid: TWILIO_ACCOUNT_SID
+      authToken: TWILIO_AUTH_TOKEN
+      fromNumber: TWILIO_FROM_NUMBER
+
+  # Resource requirements for the voice worker pod.
+  # See: https://kubespec.dev/v1/Pod#spec.containers.resources
+  ## @extra voice.resources Resource requests and limits for the voice worker.
+  ## @param voice.resources.requests.cpu [string, default: 100m] Requested CPU.
+  ## @param voice.resources.requests.memory [string, default: 512Mi] Requested memory.
+  ## @param voice.resources.limits.cpu [string, default: 500m] CPU limit.
+  ## @param voice.resources.limits.memory [string, default: 1Gi] Memory limit.
+  resources:
+    requests: { cpu: 100m, memory: 512Mi }
+    limits: { cpu: 500m, memory: 1Gi }
+
+  # Node selector
+  # See: https://kubespec.dev/v1/Pod#spec.nodeSelector
+  ## @param voice.nodeSelector [object] Node selector overrides.
+  nodeSelector: {}
+  # Tolerations
+  # See: https://kubespec.dev/v1/Pod#spec.tolerations
+  ## @param voice.tolerations [array] Tolerations overrides.
+  tolerations: []
+  # Affinity
+  # See: https://kubespec.dev/v1/Pod#spec.affinity
+  ## @param voice.affinity [object] Affinity overrides.
+  affinity: {}
+  ## @param voice.podAnnotations [object] Additional pod annotations for the voice worker.
+  podAnnotations: {}
+
+  # Service exposing the Twilio Media Streams WebSocket port in-cluster.
+  ## @extra voice.service Service configuration for the voice worker.
+  ## @param voice.service.type [default: ClusterIP] Service type.
+  ## @param voice.service.port [default: 3300] Service port (target is voice.wsPort).
+  service:
+    type: ClusterIP
+    port: 3300
+
+  # Optional Ingress fronting the WebSocket port. TLS termination and any
+  # WebSocket-upgrade timeout annotations your controller needs are left to
+  # you — add them under voice.ingress.annotations.
+  ## @extra voice.ingress Ingress configuration for the voice worker.
+  ## @param voice.ingress.enabled [default: false] Create an Ingress for the voice worker.
+  ## @param voice.ingress.className [string] IngressClassName for the voice Ingress.
+  ## @param voice.ingress.annotations [object] Additional annotations (e.g. controller-specific WebSocket upgrade/timeout settings).
+  ## @param voice.ingress.host [string] Hostname the voice Ingress routes, matching voice.publicBaseUrl. Required when voice.ingress.enabled is true.
+  ## @param voice.ingress.tls [array] TLS configuration, same shape as ingress.tls ([{secretName, hosts}]).
+  ingress:
+    enabled: false
+    className: ""
+    annotations: {}
+    host: ""
+    tls: []
+
+
+# =============================================================================
 # LangWatch NLP Service Configuration
 # =============================================================================
 # Configuration for the NLP service (nlpgo).

--- a/charts/langwatch/values.yaml
+++ b/charts/langwatch/values.yaml
@@ -1153,6 +1153,29 @@ voice:
   # See: https://kubespec.dev/v1/Pod#spec.priorityClassName
   ## @param voice.priorityClassName [string] PriorityClass for the voice worker pod (overrides global.scheduling.priorityClassName).
   priorityClassName: ""
+
+  # Shutdown budget. shutdownDrainSeconds is how long the voice worker may
+  # wait for in-flight jobs to finish their ClickHouse writes; it must match
+  # the app's own SHUTDOWN_DRAIN_TIMEOUT_MS, which the chart sets from this
+  # value.
+  #
+  # terminationGracePeriodSeconds is the kubelet's SIGKILL clock and must
+  # cover the drain plus 5s for App.close, 15s for process teardown and 10s
+  # of kubelet slack — so at least shutdownDrainSeconds + 30. Because it is
+  # set here, raising shutdownDrainSeconds alone always fails the render:
+  # raise both together. The chart refuses rather than installing a release
+  # the kubelet kills mid-drain. Both must be whole numbers of seconds
+  # greater than zero — a quoted or fractional value is rejected, because
+  # Helm's `int` would silently turn it into a zero budget.
+  # See: https://kubespec.dev/v1/Pod#spec.terminationGracePeriodSeconds
+  ## @param voice.shutdownDrainSeconds [default: 25] Seconds the voice worker may spend draining in-flight jobs on shutdown.
+  shutdownDrainSeconds: 25
+  ## @param voice.terminationGracePeriodSeconds [default: 55] Seconds before SIGKILL. Must be at least shutdownDrainSeconds + 30.
+  terminationGracePeriodSeconds: 55
+
+  ## @param voice.extraEnvs [array] Additional environment variables for the voice worker container.
+  extraEnvs: []
+
   # Pod-level configurations, mirroring workers.pod.
   ## @extra voice.pod Pod-level metadata.
   ## @param voice.pod.annotations [object] Additional pod annotations for the voice worker.

--- a/charts/langwatch/values.yaml
+++ b/charts/langwatch/values.yaml
@@ -1093,7 +1093,7 @@ workers:
 # not chart values.
 ## @section Voice worker (opt-in)
 voice:
-  # See workers.otel — named separately so voice worker telemetry is distinguishable.
+  # See workers.otel: named separately so voice worker telemetry is distinguishable.
   ## @extra voice.otel OpenTelemetry identity for the voice worker.
   ## @param voice.otel.serviceName [string, default: langwatch-voice] Service name reported in traces and logs.
   otel:
@@ -1151,11 +1151,11 @@ voice:
   #
   # terminationGracePeriodSeconds is the kubelet's SIGKILL clock and must
   # cover the drain plus 5s for App.close, 15s for process teardown and 10s
-  # of kubelet slack — so at least shutdownDrainSeconds + 30. Because it is
+  # of kubelet slack, so at least shutdownDrainSeconds + 30. Because it is
   # set here, raising shutdownDrainSeconds alone always fails the render:
   # raise both together. The chart refuses rather than installing a release
   # the kubelet kills mid-drain. Both must be whole numbers of seconds
-  # greater than zero — a quoted or fractional value is rejected, because
+  # greater than zero: a quoted or fractional value is rejected, because
   # Helm's `int` would silently turn it into a zero budget.
   # See: https://kubespec.dev/v1/Pod#spec.terminationGracePeriodSeconds
   ## @param voice.shutdownDrainSeconds [default: 25] Seconds the voice worker may spend draining in-flight jobs on shutdown.
@@ -1187,7 +1187,7 @@ voice:
 
   # Optional Ingress fronting the WebSocket port. TLS termination and any
   # WebSocket-upgrade timeout annotations your controller needs are left to
-  # you — add them under voice.ingress.annotations.
+  # you: add them under voice.ingress.annotations.
   ## @extra voice.ingress Ingress configuration for the voice worker.
   ## @param voice.ingress.enabled [default: false] Create an Ingress for the voice worker.
   ## @param voice.ingress.className [string] IngressClassName for the voice Ingress.

--- a/charts/langwatch/values.yaml
+++ b/charts/langwatch/values.yaml
@@ -1105,7 +1105,7 @@ voice:
   # Public https:// origin the call provider dials back to; the worker
   # derives wss://<host>/twilio/<nonce> from it. Required whenever
   # voice.enabled is true, the chart refuses to render without it.
-  ## @param voice.publicBaseUrl [string] Public https:// origin the call provider connects to (e.g. https://voice.example.com). Required when voice.enabled is true.
+  ## @param voice.publicBaseUrl [string] Public https:// origin the call provider connects to (e.g. https://voice.example.com). Required when voice.enabled is true. Must have a hostname after the scheme and no trailing slash; a value that does not match this is rejected, not trimmed.
   publicBaseUrl: ""
 
   # TCP port of the Media Streams WebSocket listener inside the pod.

--- a/charts/langwatch/values.yaml
+++ b/charts/langwatch/values.yaml
@@ -1149,6 +1149,10 @@ voice:
   # See: https://kubespec.dev/v1/Pod#spec.affinity
   ## @param voice.affinity [object] Affinity overrides.
   affinity: {}
+  # Topology spread constraints
+  # See: https://kubespec.dev/v1/Pod#spec.topologySpreadConstraints
+  ## @param voice.topologySpreadConstraints [array] Topology spread constraints overrides.
+  topologySpreadConstraints: []
   # PriorityClass for the voice worker pod, overriding global.scheduling.priorityClassName.
   # See: https://kubespec.dev/v1/Pod#spec.priorityClassName
   ## @param voice.priorityClassName [string] PriorityClass for the voice worker pod (overrides global.scheduling.priorityClassName).

--- a/charts/langwatch/values.yaml
+++ b/charts/langwatch/values.yaml
@@ -1105,7 +1105,7 @@ voice:
   # Public https:// origin the call provider dials back to; the worker
   # derives wss://<host>/twilio/<nonce> from it. Required whenever
   # voice.enabled is true, the chart refuses to render without it.
-  ## @param voice.publicBaseUrl [string] Public https:// origin the call provider connects to (e.g. https://voice.example.com). Required when voice.enabled is true. Must have a hostname after the scheme and no trailing slash; a value that does not match this is rejected, not trimmed.
+  ## @param voice.publicBaseUrl [string] Public https:// origin the call provider connects to (e.g. https://voice.example.com). Required when voice.enabled is true. Must be an https origin only: scheme, hostname, optional port, no path or query; a value that does not match this is rejected, not trimmed.
   publicBaseUrl: ""
 
   # TCP port of the Media Streams WebSocket listener inside the pod.

--- a/charts/langwatch/values.yaml
+++ b/charts/langwatch/values.yaml
@@ -1099,13 +1099,24 @@ voice:
   otel:
     serviceName: langwatch-voice
 
-  ## @param voice.enabled [default: false] Deploy the voice worker Deployment, Service (and Ingress if voice.ingress.enabled). Off by default.
-  enabled: false
+  ## @param voice.enabled [default: true] Deploy the voice worker Deployment, Service (and Ingress if voice.ingress.enabled) once a public https:// origin can be resolved (see voice.publicBaseUrl below). On by default; set false to opt the whole feature out even when a public URL is available.
+  enabled: true
 
   # Public https:// origin the call provider dials back to; the worker
-  # derives wss://<host>/twilio/<nonce> from it. Required whenever
-  # voice.enabled is true, the chart refuses to render without it.
-  ## @param voice.publicBaseUrl [string] Public https:// origin the call provider connects to (e.g. https://voice.example.com). Required when voice.enabled is true. Must be an https origin only: scheme, hostname, optional port, no path or query; a value that does not match this is rejected, not trimmed.
+  # derives wss://<host>/twilio/<nonce> from it.
+  #
+  # Left empty (the default), the chart resolves it FROM app.http.publicUrl
+  # instead, so a cluster that already has a public https:// URL for the app
+  # gets phone simulations for free, with zero extra values set. If
+  # app.http.publicUrl is not an https:// origin either (e.g. it is still the
+  # chart default, http://localhost:5560), no public address can be resolved
+  # and the voice Deployment/Service/Ingress simply do not render — NOTES.txt
+  # explains why and names both settings that fix it. Set this value
+  # explicitly only when voice needs a DIFFERENT public host than the app
+  # (its own subdomain, its own edge). An explicit value here always wins
+  # over app.http.publicUrl, including a bad one: the chart still refuses to
+  # render rather than silently ignore it.
+  ## @param voice.publicBaseUrl [string] Public https:// origin the call provider connects to (e.g. https://voice.example.com). Empty resolves to app.http.publicUrl when that is an https:// origin. Must be an https origin only: scheme, hostname, optional port, no path or query; a value that does not match this is rejected, not trimmed.
   publicBaseUrl: ""
 
   # TCP port of the Media Streams WebSocket listener inside the pod.
@@ -1185,19 +1196,26 @@ voice:
     type: ClusterIP
     port: 3300
 
-  # Optional Ingress fronting the WebSocket port. TLS termination and any
-  # WebSocket-upgrade timeout annotations your controller needs are left to
-  # you: add them under voice.ingress.annotations.
+  # Ingress fronting the WebSocket port, on by default alongside voice.enabled
+  # (it still only renders once a public https:// origin resolves, same as
+  # the Deployment/Service). TLS termination is left to your edge, same as
+  # the main ingress.
   ## @extra voice.ingress Ingress configuration for the voice worker.
-  ## @param voice.ingress.enabled [default: false] Create an Ingress for the voice worker.
+  ## @param voice.ingress.enabled [default: true] Create an Ingress for the voice worker once a public https:// origin resolves. On by default.
   ## @param voice.ingress.className [string] IngressClassName for the voice Ingress.
-  ## @param voice.ingress.annotations [object] Additional annotations (e.g. controller-specific WebSocket upgrade/timeout settings).
-  ## @param voice.ingress.host [string] Hostname the voice Ingress routes, matching voice.publicBaseUrl. Required when voice.ingress.enabled is true.
+  ## @param voice.ingress.annotations [object] Additional annotations (e.g. controller-specific WebSocket upgrade/timeout settings). Defaults to nginx's proxy-read/send-timeout at 3600s (the stock 60s value would cut off any call longer than a minute) — nginx-specific; a non-nginx controller needs its own equivalents set here instead. Set to {} (or override each key) to replace the defaults entirely.
+  ## @param voice.ingress.host [string] Hostname the voice Ingress routes, matching voice.publicBaseUrl (or its app.http.publicUrl fallback). Empty defaults to that resolved URL's hostname; set explicitly only to override it, and it must then agree with the resolved URL or the render is refused.
   ## @param voice.ingress.tls [array] TLS configuration, same shape as ingress.tls ([{secretName, hosts}]).
   ingress:
-    enabled: false
+    enabled: true
     className: ""
-    annotations: {}
+    # nginx-specific: extends the default 60s proxy timeout so a Media
+    # Streams WebSocket survives calls up to an hour. A different ingress
+    # controller needs its own WebSocket/timeout annotations here instead —
+    # override this whole map to swap them in.
+    annotations:
+      nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+      nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
     host: ""
     tls: []
 

--- a/charts/langwatch/values.yaml
+++ b/charts/langwatch/values.yaml
@@ -1084,13 +1084,12 @@ workers:
 # (ingress or a cloud load balancer) and point voice.publicBaseUrl at that
 # public origin.
 #
-# Env contract (langwatch/langwatch#8014): the worker reads VOICE_WORKER_ONLY,
-# VOICE_WS_PORT and VOICE_PUBLIC_BASE_URL below. Replicas are fixed at 1, not
-# a value, the Media Streams WebSocket routes an in-flight call by nonce
-# inside one process, so a second replica would split a call's frames across
-# two processes with no shared state. Call-provider credentials (account SID,
-# auth token, from-number) are per-project data configured inside LangWatch,
-# not chart values.
+# Env contract (langwatch/langwatch#8014): the worker reads VOICE_WS_PORT and
+# VOICE_PUBLIC_BASE_URL below. Replicas are fixed at 1, not a value, the Media
+# Streams WebSocket routes an in-flight call by nonce inside one process, so a
+# second replica would split a call's frames across two processes with no
+# shared state. Call-provider credentials (account SID, auth token, from-number)
+# are per-project data configured inside LangWatch, not chart values.
 ## @section Voice worker (opt-in)
 voice:
   # See workers.otel: named separately so voice worker telemetry is distinguishable.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -60166,21 +60166,19 @@ Three things to know before flipping it on:
 
 ### Voice worker (phone targets)
 
-Off by default. Set `voice.enabled: true` to deploy a single-replica worker that lets scenario/agent runs place and receive phone calls via Twilio.
+Off by default. Set `voice.enabled: true` to deploy a single-replica worker that lets scenario/agent runs place and receive phone calls.
 
-**Twilio Media Streams connects inbound to you.** Without a publicly-reachable `voice.publicBaseUrl`, there are no phone targets, no matter what else is configured: Twilio dials that URL back to reach the worker's WebSocket listener.
+**Media Streams connects inbound to you.** Without a publicly-reachable `voice.publicBaseUrl`, there are no phone targets, no matter what else is configured: the call provider dials that URL back to reach the worker's WebSocket listener.
 
 Minimum viable opt-in:
 
 ```yaml
 voice:
   enabled: true
-  publicBaseUrl: "https://voice.your-corp.com" # must be inbound-reachable from Twilio
-  twilio:
-    existingSecret: "twilio-credentials" # Secret with TWILIO_ACCOUNT_SID / TWILIO_AUTH_TOKEN / TWILIO_FROM_NUMBER
+  publicBaseUrl: "https://voice.your-corp.com" # must be inbound-reachable from the call provider
 ```
 
-Terminate TLS at your own edge, either `voice.ingress.enabled: true` with your own hostname/annotations, or an external load balancer pointed at the `voice.service`, and bring your own Twilio account; the chart never carries phone numbers or call-routing rules.
+Terminate TLS at your own edge, either `voice.ingress.enabled: true` with your own hostname/annotations, or an external load balancer pointed at the `voice.service`. Call-provider credentials (account SID, auth token, from-number) are configured per project inside LangWatch, not chart values.
 
 ## Upgrade
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -60164,6 +60164,24 @@ Three things to know before flipping it on:
 2. **Public ingress needs DNS + TLS.** The gateway is what your LLM clients hit, so it usually wants its own hostname (e.g. `gateway.your-corp.com`), separate cert, separate ingress rule. See [AI Gateway → Self-hosting → DNS & TLS](/ai-gateway/self-hosting/dns-and-tls).
 3. **Worker pods must be running.** Budget enforcement reads from a ClickHouse rollup that trace-processing folds into. If you deploy with `workers.enabled=false`, budgets stop accumulating spend and breach enforcement silently degrades. The default `workers.enabled=true` is correct for production.
 
+### Voice worker (phone targets)
+
+Off by default. Set `voice.enabled: true` to deploy a single-replica worker that lets scenario/agent runs place and receive phone calls via Twilio.
+
+**Twilio Media Streams connects inbound to you.** Without a publicly-reachable `voice.publicBaseUrl`, there are no phone targets, no matter what else is configured — Twilio dials that URL back to reach the worker's WebSocket listener.
+
+Minimum viable opt-in:
+
+```yaml
+voice:
+  enabled: true
+  publicBaseUrl: "https://voice.your-corp.com" # must be inbound-reachable from Twilio
+  twilio:
+    existingSecret: "twilio-credentials" # Secret with TWILIO_ACCOUNT_SID / TWILIO_AUTH_TOKEN / TWILIO_FROM_NUMBER
+```
+
+Terminate TLS at your own edge — either `voice.ingress.enabled: true` with your own hostname/annotations, or an external load balancer pointed at the `voice.service` — and bring your own Twilio account; the chart never carries phone numbers or call-routing rules.
+
 ## Upgrade
 
 ```bash

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -60168,7 +60168,7 @@ Three things to know before flipping it on:
 
 Off by default. Set `voice.enabled: true` to deploy a single-replica worker that lets scenario/agent runs place and receive phone calls via Twilio.
 
-**Twilio Media Streams connects inbound to you.** Without a publicly-reachable `voice.publicBaseUrl`, there are no phone targets, no matter what else is configured — Twilio dials that URL back to reach the worker's WebSocket listener.
+**Twilio Media Streams connects inbound to you.** Without a publicly-reachable `voice.publicBaseUrl`, there are no phone targets, no matter what else is configured: Twilio dials that URL back to reach the worker's WebSocket listener.
 
 Minimum viable opt-in:
 
@@ -60180,7 +60180,7 @@ voice:
     existingSecret: "twilio-credentials" # Secret with TWILIO_ACCOUNT_SID / TWILIO_AUTH_TOKEN / TWILIO_FROM_NUMBER
 ```
 
-Terminate TLS at your own edge — either `voice.ingress.enabled: true` with your own hostname/annotations, or an external load balancer pointed at the `voice.service` — and bring your own Twilio account; the chart never carries phone numbers or call-routing rules.
+Terminate TLS at your own edge, either `voice.ingress.enabled: true` with your own hostname/annotations, or an external load balancer pointed at the `voice.service`, and bring your own Twilio account; the chart never carries phone numbers or call-routing rules.
 
 ## Upgrade
 

--- a/docs/self-hosting/deployment/kubernetes-helm.mdx
+++ b/docs/self-hosting/deployment/kubernetes-helm.mdx
@@ -426,7 +426,7 @@ Three things to know before flipping it on:
 
 Off by default. Set `voice.enabled: true` to deploy a single-replica worker that lets scenario/agent runs place and receive phone calls via Twilio.
 
-**Twilio Media Streams connects inbound to you.** Without a publicly-reachable `voice.publicBaseUrl`, there are no phone targets, no matter what else is configured — Twilio dials that URL back to reach the worker's WebSocket listener.
+**Twilio Media Streams connects inbound to you.** Without a publicly-reachable `voice.publicBaseUrl`, there are no phone targets, no matter what else is configured: Twilio dials that URL back to reach the worker's WebSocket listener.
 
 Minimum viable opt-in:
 
@@ -438,7 +438,7 @@ voice:
     existingSecret: "twilio-credentials" # Secret with TWILIO_ACCOUNT_SID / TWILIO_AUTH_TOKEN / TWILIO_FROM_NUMBER
 ```
 
-Terminate TLS at your own edge — either `voice.ingress.enabled: true` with your own hostname/annotations, or an external load balancer pointed at the `voice.service` — and bring your own Twilio account; the chart never carries phone numbers or call-routing rules.
+Terminate TLS at your own edge, either `voice.ingress.enabled: true` with your own hostname/annotations, or an external load balancer pointed at the `voice.service`, and bring your own Twilio account; the chart never carries phone numbers or call-routing rules.
 
 ## Upgrade
 

--- a/docs/self-hosting/deployment/kubernetes-helm.mdx
+++ b/docs/self-hosting/deployment/kubernetes-helm.mdx
@@ -424,21 +424,19 @@ Three things to know before flipping it on:
 
 ### Voice worker (phone targets)
 
-Off by default. Set `voice.enabled: true` to deploy a single-replica worker that lets scenario/agent runs place and receive phone calls via Twilio.
+Off by default. Set `voice.enabled: true` to deploy a single-replica worker that lets scenario/agent runs place and receive phone calls.
 
-**Twilio Media Streams connects inbound to you.** Without a publicly-reachable `voice.publicBaseUrl`, there are no phone targets, no matter what else is configured: Twilio dials that URL back to reach the worker's WebSocket listener.
+**Media Streams connects inbound to you.** Without a publicly-reachable `voice.publicBaseUrl`, there are no phone targets, no matter what else is configured: the call provider dials that URL back to reach the worker's WebSocket listener.
 
 Minimum viable opt-in:
 
 ```yaml
 voice:
   enabled: true
-  publicBaseUrl: "https://voice.your-corp.com" # must be inbound-reachable from Twilio
-  twilio:
-    existingSecret: "twilio-credentials" # Secret with TWILIO_ACCOUNT_SID / TWILIO_AUTH_TOKEN / TWILIO_FROM_NUMBER
+  publicBaseUrl: "https://voice.your-corp.com" # must be inbound-reachable from the call provider
 ```
 
-Terminate TLS at your own edge, either `voice.ingress.enabled: true` with your own hostname/annotations, or an external load balancer pointed at the `voice.service`, and bring your own Twilio account; the chart never carries phone numbers or call-routing rules.
+Terminate TLS at your own edge, either `voice.ingress.enabled: true` with your own hostname/annotations, or an external load balancer pointed at the `voice.service`. Call-provider credentials (account SID, auth token, from-number) are configured per project inside LangWatch, not chart values.
 
 ## Upgrade
 

--- a/docs/self-hosting/deployment/kubernetes-helm.mdx
+++ b/docs/self-hosting/deployment/kubernetes-helm.mdx
@@ -422,6 +422,24 @@ Three things to know before flipping it on:
 2. **Public ingress needs DNS + TLS.** The gateway is what your LLM clients hit, so it usually wants its own hostname (e.g. `gateway.your-corp.com`), separate cert, separate ingress rule. See [AI Gateway → Self-hosting → DNS & TLS](/ai-gateway/self-hosting/dns-and-tls).
 3. **Worker pods must be running.** Budget enforcement reads from a ClickHouse rollup that trace-processing folds into. If you deploy with `workers.enabled=false`, budgets stop accumulating spend and breach enforcement silently degrades. The default `workers.enabled=true` is correct for production.
 
+### Voice worker (phone targets)
+
+Off by default. Set `voice.enabled: true` to deploy a single-replica worker that lets scenario/agent runs place and receive phone calls via Twilio.
+
+**Twilio Media Streams connects inbound to you.** Without a publicly-reachable `voice.publicBaseUrl`, there are no phone targets, no matter what else is configured — Twilio dials that URL back to reach the worker's WebSocket listener.
+
+Minimum viable opt-in:
+
+```yaml
+voice:
+  enabled: true
+  publicBaseUrl: "https://voice.your-corp.com" # must be inbound-reachable from Twilio
+  twilio:
+    existingSecret: "twilio-credentials" # Secret with TWILIO_ACCOUNT_SID / TWILIO_AUTH_TOKEN / TWILIO_FROM_NUMBER
+```
+
+Terminate TLS at your own edge — either `voice.ingress.enabled: true` with your own hostname/annotations, or an external load balancer pointed at the `voice.service` — and bring your own Twilio account; the chart never carries phone numbers or call-routing rules.
+
 ## Upgrade
 
 ```bash

--- a/specs/setup/helm-voice-worker.feature
+++ b/specs/setup/helm-voice-worker.feature
@@ -86,3 +86,39 @@ Feature: The voice worker is opt-in and cannot render half-configured
       Given the voice worker is turned on with its public address set to a plain http:// URL
       When the chart renders
       Then the install is refused, naming the invalid public address
+
+    @e2e
+    Scenario: Turning on the voice worker with a valid https:// public address renders
+      Given the voice worker is turned on with its public address set to a valid https:// origin
+      When the chart renders
+      Then the voice worker comes up with that public address configured
+
+    @e2e
+    Scenario: Turning on the voice worker with a valid https:// public address including a port renders
+      Given the voice worker is turned on with its public address set to a valid https:// origin that includes a port
+      When the chart renders
+      Then the voice worker comes up with that public address, port included, configured
+
+    @e2e
+    Scenario: The voice worker refuses a public address that includes a path
+      Given the voice worker is turned on with its public address set to an https:// origin that includes a path
+      When the chart renders
+      Then the install is refused, naming the invalid public address
+
+    @e2e
+    Scenario: The voice worker refuses a public address that includes a query string
+      Given the voice worker is turned on with its public address set to an https:// origin that includes a query string
+      When the chart renders
+      Then the install is refused, naming the invalid public address
+
+    @e2e
+    Scenario: The voice worker refuses a public address with a trailing slash
+      Given the voice worker is turned on with its public address set to an https:// origin with a trailing slash
+      When the chart renders
+      Then the install is refused, naming the invalid public address
+
+    @e2e
+    Scenario: The voice worker refuses a public address with a malformed hostname
+      Given the voice worker is turned on with its public address set to an https:// origin with no hostname, or one starting with a hyphen
+      When the chart renders
+      Then the install is refused, naming the invalid public address

--- a/specs/setup/helm-voice-worker.feature
+++ b/specs/setup/helm-voice-worker.feature
@@ -8,7 +8,7 @@ Feature: The voice worker is opt-in and cannot render half-configured
 
   # Cross-references:
   #   charts/langwatch/templates/voice/deployment.yaml: the single-replica
-  #     Deployment, gated on voice.enabled, and the two `fail` guards this
+  #     Deployment, gated on voice.enabled, and the `fail` guard this
   #     feature describes.
   #   charts/langwatch/templates/voice/service.yaml,
   #   charts/langwatch/templates/voice/ingress.yaml: the Service and the
@@ -16,8 +16,9 @@ Feature: The voice worker is opt-in and cannot render half-configured
   #   charts/langwatch/tests/voice-worker.sh: the suite that renders the
   #     chart and asserts what this feature describes.
   #   langwatch/langwatch#8015 and the env contract on #8014
-  #     (voice-env-contract comment): VOICE_WORKER_ONLY, VOICE_WS_PORT,
-  #     VOICE_PUBLIC_BASE_URL and the three TWILIO_* variables.
+  #     (voice-env-contract comment): VOICE_WORKER_ONLY, VOICE_WS_PORT and
+  #     VOICE_PUBLIC_BASE_URL. Call-provider credentials are per-project
+  #     data configured inside LangWatch, not chart values or operator env.
   #
   # These scenarios are verified by rendering the chart. The gating
   # condition, the required-value checks, and the env/secretKeyRef wiring
@@ -40,12 +41,11 @@ Feature: The voice worker is opt-in and cannot render half-configured
   Rule: Enabling the voice worker renders a correctly wired Deployment, Service and Ingress
 
     @e2e
-    Scenario: Turning on the voice worker brings up a single call handler wired to Twilio
-      Given the voice worker is turned on with its public address and Twilio credentials configured
+    Scenario: Turning on the voice worker brings up a single call handler
+      Given the voice worker is turned on with its public address configured
       When the chart renders
       Then exactly one voice worker instance comes up
       And it runs in voice-only mode
-      And it reads its Twilio credentials from the configured secret rather than holding them itself
 
     @e2e
     Scenario: The voice worker's shutdown timing is its own, not borrowed from the background workers
@@ -77,12 +77,6 @@ Feature: The voice worker is opt-in and cannot render half-configured
 
     @e2e
     Scenario: The voice worker refuses to start without knowing its own public address
-      Given the voice worker is turned on with Twilio credentials configured but no public address set
+      Given the voice worker is turned on with no public address set
       When the chart renders
       Then the install is refused, naming the missing public address
-
-    @e2e
-    Scenario: The voice worker refuses to start without Twilio credentials configured
-      Given the voice worker is turned on with its public address set but no Twilio credentials configured
-      When the chart renders
-      Then the install is refused, naming the missing Twilio credentials

--- a/specs/setup/helm-voice-worker.feature
+++ b/specs/setup/helm-voice-worker.feature
@@ -48,6 +48,12 @@ Feature: The voice worker is opt-in and cannot render half-configured
       And TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN and TWILIO_FROM_NUMBER are read from the named Secret by the configured keys
 
     @e2e
+    Scenario: The voice Deployment's terminationGracePeriodSeconds follows voice.*, not workers.*
+      Given voice.enabled=true with a publicBaseUrl and a Twilio existingSecret, voice.terminationGracePeriodSeconds and voice.shutdownDrainSeconds set, and a different workers.terminationGracePeriodSeconds also set
+      When the chart renders
+      Then the voice Deployment's terminationGracePeriodSeconds comes from voice.terminationGracePeriodSeconds, not from workers.terminationGracePeriodSeconds
+
+    @e2e
     Scenario: Enabling voice renders a Service but no Ingress by default
       Given voice.enabled=true with a publicBaseUrl and a Twilio existingSecret
       When the chart renders

--- a/specs/setup/helm-voice-worker.feature
+++ b/specs/setup/helm-voice-worker.feature
@@ -80,3 +80,9 @@ Feature: The voice worker is opt-in and cannot render half-configured
       Given the voice worker is turned on with no public address set
       When the chart renders
       Then the install is refused, naming the missing public address
+
+    @e2e
+    Scenario: The voice worker refuses a public address that is not a valid https:// origin
+      Given the voice worker is turned on with its public address set to a plain http:// URL
+      When the chart renders
+      Then the install is refused, naming the invalid public address

--- a/specs/setup/helm-voice-worker.feature
+++ b/specs/setup/helm-voice-worker.feature
@@ -100,6 +100,12 @@ Feature: The voice worker is opt-in and cannot render half-configured
       Then the voice worker comes up with that public address, port included, configured
 
     @e2e
+    Scenario: The voice worker refuses a public address whose port is out of range
+      Given the voice worker is turned on with its public address set to an https:// origin whose port is 65536
+      When the chart renders
+      Then the install is refused, naming the invalid public address
+
+    @e2e
     Scenario: The voice worker refuses a public address that includes a path
       Given the voice worker is turned on with its public address set to an https:// origin that includes a path
       When the chart renders

--- a/specs/setup/helm-voice-worker.feature
+++ b/specs/setup/helm-voice-worker.feature
@@ -1,0 +1,75 @@
+Feature: The voice worker is opt-in and cannot render half-configured
+  As someone who runs LangWatch on their own cluster and wants to let
+  scenario/agent runs place and receive phone calls through Twilio,
+  I want a voice worker that stays off by default and refuses to render
+  without the values it cannot work without,
+  so that a default install never grows a WebSocket listener nobody asked
+  for, and a misconfigured one fails at render time instead of at runtime.
+
+  # Cross-references:
+  #   charts/langwatch/templates/voice/deployment.yaml: the single-replica
+  #     Deployment, gated on voice.enabled, and the two `fail` guards this
+  #     feature describes.
+  #   charts/langwatch/templates/voice/service.yaml,
+  #   charts/langwatch/templates/voice/ingress.yaml: the Service and the
+  #     opt-in Ingress fronting the Twilio Media Streams WebSocket port.
+  #   charts/langwatch/tests/voice-worker.sh: the suite that renders the
+  #     chart and asserts what this feature describes.
+  #   langwatch/langwatch#8015 and the env contract on #8014
+  #     (voice-env-contract comment): VOICE_WORKER_ONLY, VOICE_WS_PORT,
+  #     VOICE_PUBLIC_BASE_URL and the three TWILIO_* variables.
+  #
+  # These scenarios are verified by rendering the chart. The gating
+  # condition, the required-value checks, and the env/secretKeyRef wiring
+  # are only visible in what actually renders.
+
+  Rule: The default install carries no voice resources
+
+    @e2e
+    Scenario: The default install renders no voice resources
+      Given a default install, which does not set voice.enabled
+      When the chart renders
+      Then no templates/voice/ manifest appears in the output
+
+    @e2e
+    Scenario: voice.enabled=false explicitly changes nothing
+      Given a default install
+      When the chart renders once as-is and once with voice.enabled=false set explicitly
+      Then the two renders are identical
+
+  Rule: Enabling the voice worker renders a correctly wired Deployment, Service and Ingress
+
+    @e2e
+    Scenario: Enabling voice renders a single-replica worker wired to the Twilio secret
+      Given voice.enabled=true with a publicBaseUrl and a Twilio existingSecret
+      When the chart renders
+      Then the voice Deployment has replicas: 1
+      And VOICE_WORKER_ONLY is set to "true"
+      And TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN and TWILIO_FROM_NUMBER are read from the named Secret by the configured keys
+
+    @e2e
+    Scenario: Enabling voice renders a Service but no Ingress by default
+      Given voice.enabled=true with a publicBaseUrl and a Twilio existingSecret
+      When the chart renders
+      Then the voice Service targets the voice-ws container port
+      And no voice Ingress renders, because voice.ingress.enabled defaults to false
+
+    @e2e
+    Scenario: Enabling the voice ingress renders it for the configured host
+      Given voice.enabled=true and voice.ingress.enabled=true with a host set
+      When the chart renders
+      Then the voice Ingress routes that host at the /twilio path
+
+  Rule: A voice worker cannot render without the values it cannot work without
+
+    @e2e
+    Scenario: voice.enabled without publicBaseUrl refuses to render
+      Given voice.enabled=true with a Twilio existingSecret but no publicBaseUrl
+      When the chart renders
+      Then the install is refused, naming voice.publicBaseUrl as required
+
+    @e2e
+    Scenario: voice.enabled without an existing Twilio secret refuses to render
+      Given voice.enabled=true with a publicBaseUrl but no Twilio existingSecret
+      When the chart renders
+      Then the install is refused, naming voice.twilio.existingSecret as required

--- a/specs/setup/helm-voice-worker.feature
+++ b/specs/setup/helm-voice-worker.feature
@@ -80,6 +80,16 @@ Feature: The voice worker needs zero extra configuration to route phone simulati
       And it runs in voice-only mode
 
     @e2e
+    Scenario: The voice worker is reachable inside the cluster and exposed for Twilio by default
+      Given the voice worker's own public address is set to a valid https://
+        origin, and nothing about its public entry point is configured
+      When the chart renders
+      Then the voice worker is reachable inside the cluster on its
+        call-handling port
+      And a public entry point for it renders too, without any extra
+        configuration
+
+    @e2e
     Scenario: The voice worker's shutdown timing is its own, not borrowed from the background workers
       Given the voice worker is turned on with its own shutdown timing configured differently from the background workers' shutdown timing
       When the chart renders

--- a/specs/setup/helm-voice-worker.feature
+++ b/specs/setup/helm-voice-worker.feature
@@ -26,56 +26,63 @@ Feature: The voice worker is opt-in and cannot render half-configured
   Rule: The default install carries no voice resources
 
     @e2e
-    Scenario: The default install renders no voice resources
-      Given a default install, which does not set voice.enabled
+    Scenario: The voice worker is not deployed unless the operator turns it on
+      Given a default install, which does not opt into the voice worker
       When the chart renders
-      Then no templates/voice/ manifest appears in the output
+      Then no voice worker resources appear anywhere in the output
 
     @e2e
-    Scenario: voice.enabled=false explicitly changes nothing
+    Scenario: Turning the voice worker off explicitly changes nothing
       Given a default install
-      When the chart renders once as-is and once with voice.enabled=false set explicitly
+      When the chart renders once as-is and once with the voice worker explicitly turned off
       Then the two renders are identical
 
   Rule: Enabling the voice worker renders a correctly wired Deployment, Service and Ingress
 
     @e2e
-    Scenario: Enabling voice renders a single-replica worker wired to the Twilio secret
-      Given voice.enabled=true with a publicBaseUrl and a Twilio existingSecret
+    Scenario: Turning on the voice worker brings up a single call handler wired to Twilio
+      Given the voice worker is turned on with its public address and Twilio credentials configured
       When the chart renders
-      Then the voice Deployment has replicas: 1
-      And VOICE_WORKER_ONLY is set to "true"
-      And TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN and TWILIO_FROM_NUMBER are read from the named Secret by the configured keys
+      Then exactly one voice worker instance comes up
+      And it runs in voice-only mode
+      And it reads its Twilio credentials from the configured secret rather than holding them itself
 
     @e2e
-    Scenario: The voice Deployment's terminationGracePeriodSeconds follows voice.*, not workers.*
-      Given voice.enabled=true with a publicBaseUrl and a Twilio existingSecret, voice.terminationGracePeriodSeconds and voice.shutdownDrainSeconds set, and a different workers.terminationGracePeriodSeconds also set
+    Scenario: The voice worker's shutdown timing is its own, not borrowed from the background workers
+      Given the voice worker is turned on with its own shutdown timing configured differently from the background workers' shutdown timing
       When the chart renders
-      Then the voice Deployment's terminationGracePeriodSeconds comes from voice.terminationGracePeriodSeconds, not from workers.terminationGracePeriodSeconds
+      Then the voice worker shuts down on its own configured timeline
+      And the background workers' shutdown timing has no effect on it
 
     @e2e
-    Scenario: Enabling voice renders a Service but no Ingress by default
-      Given voice.enabled=true with a publicBaseUrl and a Twilio existingSecret
+    Scenario: The voice worker is reachable inside the cluster by default, but not exposed publicly
+      Given the voice worker is turned on
       When the chart renders
-      Then the voice Service targets the voice-ws container port
-      And no voice Ingress renders, because voice.ingress.enabled defaults to false
+      Then other workloads in the cluster can reach the voice worker over its call-handling port
+      And no public entry point is created for it, because that step is opt-in
 
     @e2e
-    Scenario: Enabling the voice ingress renders it for the configured host
-      Given voice.enabled=true and voice.ingress.enabled=true with a host set
+    Scenario: The voice worker gets its own public hostname for Twilio to call
+      Given the voice worker is turned on and its public entry point is also turned on with a hostname set
       When the chart renders
-      Then the voice Ingress routes that host at the /twilio path
+      Then the voice worker is reachable at that hostname on the path Twilio calls
+
+    @e2e
+    Scenario: The voice worker refuses to expose a hostname that doesn't match its own public address
+      Given the voice worker's public entry point is turned on with a hostname that disagrees with the voice worker's own configured public address
+      When the chart renders
+      Then the install is refused, because Twilio would call one address while the public entry point routes another
 
   Rule: A voice worker cannot render without the values it cannot work without
 
     @e2e
-    Scenario: voice.enabled without publicBaseUrl refuses to render
-      Given voice.enabled=true with a Twilio existingSecret but no publicBaseUrl
+    Scenario: The voice worker refuses to start without knowing its own public address
+      Given the voice worker is turned on with Twilio credentials configured but no public address set
       When the chart renders
-      Then the install is refused, naming voice.publicBaseUrl as required
+      Then the install is refused, naming the missing public address
 
     @e2e
-    Scenario: voice.enabled without an existing Twilio secret refuses to render
-      Given voice.enabled=true with a publicBaseUrl but no Twilio existingSecret
+    Scenario: The voice worker refuses to start without Twilio credentials configured
+      Given the voice worker is turned on with its public address set but no Twilio credentials configured
       When the chart renders
-      Then the install is refused, naming voice.twilio.existingSecret as required
+      Then the install is refused, naming the missing Twilio credentials

--- a/specs/setup/helm-voice-worker.feature
+++ b/specs/setup/helm-voice-worker.feature
@@ -25,9 +25,9 @@ Feature: The voice worker needs zero extra configuration to route phone simulati
   #   charts/langwatch/tests/voice-worker.sh: the suite that renders the
   #     chart and asserts what this feature describes.
   #   langwatch/langwatch#8015 and the env contract on #8014
-  #     (voice-env-contract comment): VOICE_WORKER_ONLY, VOICE_WS_PORT and
-  #     VOICE_PUBLIC_BASE_URL. Call-provider credentials are per-project
-  #     data configured inside LangWatch, not chart values or operator env.
+  #     (voice-env-contract comment): VOICE_WS_PORT and VOICE_PUBLIC_BASE_URL.
+  #     Call-provider credentials are per-project data configured inside
+  #     LangWatch, not chart values or operator env.
   #
   # These scenarios are verified by rendering the chart. The gating
   # condition, the resolution priority, the required-value checks, and the

--- a/specs/setup/helm-voice-worker.feature
+++ b/specs/setup/helm-voice-worker.feature
@@ -1,18 +1,27 @@
-Feature: The voice worker is opt-in and cannot render half-configured
+Feature: The voice worker needs zero extra configuration to route phone simulations, and cannot render half-configured
   As someone who runs LangWatch on their own cluster and wants to let
   scenario/agent runs place and receive phone calls through Twilio,
-  I want a voice worker that stays off by default and refuses to render
-  without the values it cannot work without,
-  so that a default install never grows a WebSocket listener nobody asked
-  for, and a misconfigured one fails at render time instead of at runtime.
+  I want a voice worker that comes up on its own once the cluster already
+  has a public https:// URL, refuses to render without the values it
+  cannot work without, and never fails a stock install that has no such
+  URL yet,
+  so that turning on phone simulations costs nothing beyond what most
+  installs already have, a misconfigured explicit value fails at render
+  time instead of at runtime, and a default install never crashes over a
+  feature nobody asked to configure yet.
 
   # Cross-references:
+  #   charts/langwatch/templates/_helpers.tpl: langwatch.voice.publicBaseUrl,
+  #     the helper that resolves the public origin (explicit value, then
+  #     app.http.publicUrl, then unresolved) which every scenario below
+  #     ultimately depends on.
   #   charts/langwatch/templates/voice/deployment.yaml: the single-replica
-  #     Deployment, gated on voice.enabled, and the `fail` guard this
-  #     feature describes.
+  #     Deployment, gated on voice.enabled AND a resolved public origin, and
+  #     the `fail` guard this feature describes.
   #   charts/langwatch/templates/voice/service.yaml,
   #   charts/langwatch/templates/voice/ingress.yaml: the Service and the
-  #     opt-in Ingress fronting the Twilio Media Streams WebSocket port.
+  #     Ingress fronting the Twilio Media Streams WebSocket port, both on by
+  #     default and gated the same way as the Deployment.
   #   charts/langwatch/tests/voice-worker.sh: the suite that renders the
   #     chart and asserts what this feature describes.
   #   langwatch/langwatch#8015 and the env contract on #8014
@@ -21,28 +30,51 @@ Feature: The voice worker is opt-in and cannot render half-configured
   #     data configured inside LangWatch, not chart values or operator env.
   #
   # These scenarios are verified by rendering the chart. The gating
-  # condition, the required-value checks, and the env/secretKeyRef wiring
-  # are only visible in what actually renders.
+  # condition, the resolution priority, the required-value checks, and the
+  # env/secretKeyRef wiring are only visible in what actually renders.
 
-  Rule: The default install carries no voice resources
+  Rule: The voice worker renders nothing until a public https:// origin can be resolved
 
     @e2e
-    Scenario: The voice worker is not deployed unless the operator turns it on
-      Given a default install, which does not opt into the voice worker
+    Scenario: A stock install with no https:// URL anywhere renders no voice resources
+      Given a default install, where neither the app's own public URL nor a
+        dedicated voice public address is an https:// origin
+      When the chart renders
+      Then no voice worker resources appear anywhere in the output
+      And the install still succeeds
+
+    @e2e
+    Scenario: The voice worker does not render when only an http:// URL is available
+      Given the voice worker is left at its default (turned on) and the
+        app's own public URL is a plain http:// address
+      When the chart renders
+      Then no voice worker resources appear anywhere in the output
+      And the install still succeeds
+
+    @e2e
+    Scenario: Explicitly turning the voice worker off overrides a resolvable https:// URL
+      Given the app's own public URL is a valid https:// origin, but the
+        voice worker is explicitly turned off
       When the chart renders
       Then no voice worker resources appear anywhere in the output
 
-    @e2e
-    Scenario: Turning the voice worker off explicitly changes nothing
-      Given a default install
-      When the chart renders once as-is and once with the voice worker explicitly turned off
-      Then the two renders are identical
+  Rule: Renders by default once a public https:// origin resolves, with a correctly wired Deployment, Service and Ingress
 
-  Rule: Enabling the voice worker renders a correctly wired Deployment, Service and Ingress
+    @e2e
+    Scenario: Renders by default when an https:// public URL is configured
+      Given the app's own public URL is a valid https:// origin, and nothing
+        else about voice is configured
+      When the chart renders
+      Then exactly one voice worker instance comes up
+      And it runs in voice-only mode
+      And it is reachable inside the cluster over its call-handling port
+      And it is also reachable from outside the cluster, because the public
+        entry point is on by default too
 
     @e2e
     Scenario: Turning on the voice worker brings up a single call handler
-      Given the voice worker is turned on with its public address configured
+      Given the voice worker's own public address is set to a valid https://
+        origin
       When the chart renders
       Then exactly one voice worker instance comes up
       And it runs in voice-only mode
@@ -55,76 +87,101 @@ Feature: The voice worker is opt-in and cannot render half-configured
       And the background workers' shutdown timing has no effect on it
 
     @e2e
-    Scenario: The voice worker is reachable inside the cluster by default, but not exposed publicly
-      Given the voice worker is turned on
+    Scenario: The voice worker's public hostname defaults to its resolved public address
+      Given the voice worker's own public address is set to a valid https://
+        origin, and no separate Ingress hostname is configured
       When the chart renders
-      Then other workloads in the cluster can reach the voice worker over its call-handling port
-      And no public entry point is created for it, because that step is opt-in
+      Then the voice worker is reachable at that address's hostname on the
+        path Twilio calls
 
     @e2e
-    Scenario: The voice worker gets its own public hostname for Twilio to call
-      Given the voice worker is turned on and its public entry point is also turned on with a hostname set
+    Scenario: The voice worker's ingress carries WebSocket-safe timeout annotations by default
+      Given the voice worker is turned on with its public entry point active,
+        and no custom ingress annotations are set
       When the chart renders
-      Then the voice worker is reachable at that hostname on the path Twilio calls
+      Then the ingress carries timeout annotations long enough for a call to
+        survive longer than a minute
+
+    @e2e
+    Scenario: An explicit public hostname for the voice worker still works
+      Given the voice worker's own public address is set to a valid https://
+        origin, and its public entry point's hostname is explicitly set to
+        match it
+      When the chart renders
+      Then the voice worker is reachable at that hostname on the path Twilio
+        calls
 
     @e2e
     Scenario: The voice worker refuses to expose a hostname that doesn't match its own public address
-      Given the voice worker's public entry point is turned on with a hostname that disagrees with the voice worker's own configured public address
+      Given the voice worker's public entry point's hostname is set to
+        disagree with the voice worker's own configured public address
       When the chart renders
       Then the install is refused, because Twilio would call one address while the public entry point routes another
 
-  Rule: A voice worker cannot render without the values it cannot work without
+  Rule: An explicit voice public address always wins over the app's own public URL, even a bad one
 
     @e2e
-    Scenario: The voice worker refuses to start without knowing its own public address
-      Given the voice worker is turned on with no public address set
+    Scenario: An explicit voice public address wins over the app's own public URL
+      Given both the app's own public URL and the voice worker's own public
+        address are set to different valid https:// origins
       When the chart renders
-      Then the install is refused, naming the missing public address
+      Then the voice worker comes up with its own configured public address,
+        not the app's
+
+    @e2e
+    Scenario: An explicit bad voice public address still fails even when the app's own public URL would resolve on its own
+      Given the app's own public URL is a valid https:// origin, but the
+        voice worker's own public address is explicitly set to a plain
+        http:// URL
+      When the chart renders
+      Then the install is refused, naming the invalid public address
+
+  Rule: A voice worker cannot render without a validly-shaped public address
 
     @e2e
     Scenario: The voice worker refuses a public address that is not a valid https:// origin
-      Given the voice worker is turned on with its public address set to a plain http:// URL
+      Given the voice worker's own public address is set to a plain http:// URL
       When the chart renders
       Then the install is refused, naming the invalid public address
 
     @e2e
     Scenario: Turning on the voice worker with a valid https:// public address renders
-      Given the voice worker is turned on with its public address set to a valid https:// origin
+      Given the voice worker's own public address is set to a valid https:// origin
       When the chart renders
       Then the voice worker comes up with that public address configured
 
     @e2e
     Scenario: Turning on the voice worker with a valid https:// public address including a port renders
-      Given the voice worker is turned on with its public address set to a valid https:// origin that includes a port
+      Given the voice worker's own public address is set to a valid https:// origin that includes a port
       When the chart renders
       Then the voice worker comes up with that public address, port included, configured
 
     @e2e
     Scenario: The voice worker refuses a public address whose port is out of range
-      Given the voice worker is turned on with its public address set to an https:// origin whose port is 65536
+      Given the voice worker's own public address is set to an https:// origin whose port is 65536
       When the chart renders
       Then the install is refused, naming the invalid public address
 
     @e2e
     Scenario: The voice worker refuses a public address that includes a path
-      Given the voice worker is turned on with its public address set to an https:// origin that includes a path
+      Given the voice worker's own public address is set to an https:// origin that includes a path
       When the chart renders
       Then the install is refused, naming the invalid public address
 
     @e2e
     Scenario: The voice worker refuses a public address that includes a query string
-      Given the voice worker is turned on with its public address set to an https:// origin that includes a query string
+      Given the voice worker's own public address is set to an https:// origin that includes a query string
       When the chart renders
       Then the install is refused, naming the invalid public address
 
     @e2e
     Scenario: The voice worker refuses a public address with a trailing slash
-      Given the voice worker is turned on with its public address set to an https:// origin with a trailing slash
+      Given the voice worker's own public address is set to an https:// origin with a trailing slash
       When the chart renders
       Then the install is refused, naming the invalid public address
 
     @e2e
     Scenario: The voice worker refuses a public address with a malformed hostname
-      Given the voice worker is turned on with its public address set to an https:// origin with no hostname, or one starting with a hyphen
+      Given the voice worker's own public address is set to an https:// origin with no hostname, or one starting with a hyphen
       When the chart renders
       Then the install is refused, naming the invalid public address


### PR DESCRIPTION
## Why

#8015. Phone targets need a dedicated process that owns the WebSocket listener Twilio dials back into. Self-hosters opt in only when they have an inbound-reachable public URL; everyone else must see no change. Call-provider credentials are not chart values: the maintainer decided (2026-09-10) that the Twilio account SID, auth token and from-number are per-project data entered inside LangWatch, so `3e1b5f6e` and `6ddd4b0c` removed the `voice.twilio` secret wiring this PR first carried.

## What changed

- `charts/langwatch/values.yaml`: `voice:` block, off by default (enabled, publicBaseUrl, wsPort, priorityClassName, resources, scheduling, deployment/pod annotations, otel.serviceName, shutdownDrainSeconds, terminationGracePeriodSeconds, extraEnvs, service, ingress).
- `charts/langwatch/templates/voice/{deployment,service,ingress}.yaml`: all gated on `voice.enabled`; the Deployment fails the render with a clear message when `publicBaseUrl` is empty, or when it is not an https origin (scheme, hostname, optional port, no path or query; `3b8e8c6486` and `8bebab1dd3`, from review); the Ingress fails when its host differs from the hostname in `publicBaseUrl`; the voice pods take the chart-wide topology spread constraints like every other service.
- `charts/langwatch/tests/voice-worker.sh`: 16 assertions (the secret guard assertion went with the secret; `http://` refuses, `https://` renders, valid origin with port, path, query, trailing slash and malformed host cases were added, each bound to a feature scenario), wired into `.github/workflows/langwatch-chart.yml`; `specs/setup/helm-voice-worker.feature` binds them.
- `charts/langwatch/README.md`: "Voice worker" section and parameter table.
- `docs/self-hosting/deployment/kubernetes-helm.mdx`: "Voice worker (phone targets)" section stating that Twilio Media Streams connects inbound, so without a public base URL there are no phone targets.

## How it works

Env-var names are fixed in the `voice-env-contract` comment on #8014:

| Value | Env |
|---|---|
| fixed | `VOICE_WORKER_ONLY=true` |
| `voice.wsPort` (3300) | `VOICE_WS_PORT` |
| `voice.publicBaseUrl` | `VOICE_PUBLIC_BASE_URL` |

No credential env: the account SID, auth token and from-number are configured per project inside LangWatch and reach the worker with the job, so the contract on #8014 was revised to these three variables only.

Replicas are fixed at 1 and are not a value: the listener routes by nonce inside one process. The 300 s cap is the SDK's own hard limit, so the chart carries no phone numbers, credentials or limits. The Deployment reuses the workers helpers (`sharedEnv`, `shutdownEnv`, `terminationGracePeriod`, security contexts, service account) so drain and identity behave like the existing workers pod.

## Deployment Impact

- Default installs: none. No existing template or helper is modified, no default value changes, and the default render is byte-identical (asserted by `tests/voice-worker.sh`).
- Opt-in installs (`voice.enabled=true`): one new single-replica Deployment from the app image, one ClusterIP Service on `voice.wsPort`, and optionally one Ingress on `voice.ingress.host` with path prefix `/twilio`. Requires an inbound-reachable `voice.publicBaseUrl`; the render fails fast if it is missing.
- Rollback: set `voice.enabled=false` (or omit it) and upgrade. The voice resources are removed and nothing else changes.
- Chart version: not bumped, following recent template-only commits.
- App side: the `VOICE_WORKER_ONLY` boot filter and the Twilio listener are #8014's scope. Until they land, an enabled voice pod boots as a normal worker.

## Test plan

Local, from `charts/langwatch`: `helm lint .` 0 failures; `make template` renders all 4 presets; `bash tests/voice-worker.sh` 16/16; all 8 pre-existing chart test scripts pass; `check-feature-parity` binds the scenarios in `specs/setup/helm-voice-worker.feature`; `check-docs-prose.sh` passes. CI green on this PR.

## Human verification

1. `helm template lw charts/langwatch --set autogen.enabled=true | grep -c templates/voice/` prints `0`: a default render has no voice resources.
2. Render with `--set voice.enabled=true --set voice.publicBaseUrl=https://voice.example.com`: expect a Deployment `<release>-voice` with `replicas: 1`, env `VOICE_WORKER_ONLY=true`, `VOICE_WS_PORT=3300`, `VOICE_PUBLIC_BASE_URL`, and no `TWILIO` string anywhere in the render (`grep -c TWILIO` prints `0`); a Service with `targetPort: voice-ws`; no Ingress.
3. Add `--set voice.ingress.enabled=true --set voice.ingress.host=voice.example.com`: expect an Ingress for that host with path `/twilio` pointing at the Service on 3300.
4. Drop `voice.publicBaseUrl`: the render refuses with a message naming the missing value.

## How I can prove I was successful

Chart at `4eb7f85829` rendered with voice enabled and applied to the local kind cluster `kind-lw-full` (namespace `voice-proof`): Deployment, Service and Ingress created; the container spec carries the contract env (and, at that head, the Twilio secretKeyRefs that `3e1b5f6e` has since removed; the render at the current head is the `grep -c TWILIO` step above); the Service resolves `voice-ws` to 3300; the Ingress routes `voice.proof.langwatch.local/twilio` to `lw-voice:3300`. The pod sits in `ErrImagePull` because the node has no registry access; the object graph is the proof, the app image is unchanged by this PR.

![8036 helm voice worker rendered and applied to kind](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-8036/helm-voice-enabled-applied-to-kind.png)

Raw transcript: https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-8036/transcripts/helm-voice-kind-proof.txt
Rendered manifests: https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-8036/transcripts/helm-voice-rendered.yaml

## Anything surprising?

- The chart README generator is broken on main (`Unknown modifier: boolean` on an unrelated value), so the voice parameter table is hand-written in the same format.
- The issue text called `voice.publicBaseUrl` a `wss://` base; the binding env contract on #8014 makes it the `https://` origin from which the worker derives `wss://<host>/twilio/<nonce>`. The chart follows the contract.

Closes #8015
Refs #7978



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an opt-in Helm chart voice worker for handling inbound Twilio Media Streams calls.
  - Added configurable WebSocket Service and optional Ingress exposure.
  - Added validation for HTTPS public URLs and matching Ingress hostnames.
  - Added configuration for resources, scheduling, shutdown behavior, and networking.

- **Documentation**
  - Added Helm and self-hosting guidance for configuring the voice worker.

- **Tests**
  - Added automated coverage for default, enabled, invalid, and Ingress configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->