### PR TITLE
feat(voice): record one trace per exchange for browser voice calls

### DIFF
--- a/platform/app/src/app/api/voice/[[...route]]/__tests__/voice-api.unit.test.ts
+++ b/platform/app/src/app/api/voice/[[...route]]/__tests__/voice-api.unit.test.ts
@@ -57,6 +57,9 @@ const appStub = {
     messageSnapshot: vi.fn(async () => {}),
     finishRun: vi.fn(async () => {}),
   },
+  // No-op span recording: a finish records one trace per exchange before the
+  // run write; the authz tests only care about who is let in.
+  traces: { recordSpan: vi.fn(async () => {}) },
 };
 vi.mock("~/server/app-layer/app", () => ({
   getApp: () => appStub,

--- a/platform/app/src/server/scenarios/voice/__tests__/voice-call-trace-writer.unit.test.ts
+++ b/platform/app/src/server/scenarios/voice/__tests__/voice-call-trace-writer.unit.test.ts
@@ -40,7 +40,6 @@ function fakeRecord(over: Partial<CallRecord> = {}): CallRecord {
   };
 }
 
-/** The single recorded span, as an attribute-key lookup. */
 function attrsOf(call: number): Record<string, unknown> {
   const arg = mockRecordSpan.mock.calls[call]?.[0] as {
     span: { attributes: { key: string; value: Record<string, unknown> }[] };

--- a/platform/app/src/server/scenarios/voice/__tests__/voice-call-trace-writer.unit.test.ts
+++ b/platform/app/src/server/scenarios/voice/__tests__/voice-call-trace-writer.unit.test.ts
@@ -1,0 +1,360 @@
+/**
+ * @vitest-environment node
+ * @see specs/features/agents/voice-agents-v1.feature
+ *
+ * Unit tests for the voice-call trace writer: how turns group into exchanges,
+ * the deterministic ids a re-drive recomputes, the OTLP span attributes the
+ * fold and previews read, the timestamp fallback, and the best-effort posture
+ * on a `recordSpan` failure.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockRecordSpan } = vi.hoisted(() => ({
+  mockRecordSpan: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("~/server/app-layer/app", () => ({
+  getApp: () => ({
+    traces: { recordSpan: (...a: unknown[]) => mockRecordSpan(...a) },
+  }),
+}));
+
+import type { CallRecord, CallTurn } from "../call-record";
+import {
+  groupTurnsIntoExchanges,
+  recordVoiceCallTraces,
+  voiceCallTraceIds,
+} from "../voice-call-trace-writer";
+
+function fakeRecord(over: Partial<CallRecord> = {}): CallRecord {
+  return {
+    conversationId: "conv_1",
+    transport: "elevenlabs_convai",
+    startedAt: 1_000,
+    endedAt: 5_000,
+    durationMs: 4_000,
+    turns: [],
+    isCutAtLimit: false,
+    source: "browser",
+    ...over,
+  };
+}
+
+/** The single recorded span, as an attribute-key lookup. */
+function attrsOf(call: number): Record<string, unknown> {
+  const arg = mockRecordSpan.mock.calls[call]?.[0] as {
+    span: { attributes: { key: string; value: Record<string, unknown> }[] };
+  };
+  const map: Record<string, unknown> = {};
+  for (const a of arg.span.attributes) {
+    map[a.key] = a.value.stringValue ?? a.value.intValue;
+  }
+  return map;
+}
+
+describe("groupTurnsIntoExchanges", () => {
+  describe("when the agent greets before the caller speaks", () => {
+    it("makes the greeting exchange 0 with no caller input", () => {
+      const turns: CallTurn[] = [
+        { role: "agent", text: "Hi, how can I help?" },
+        { role: "caller", text: "Cancel my order" },
+        { role: "agent", text: "Sure" },
+      ];
+      const exchanges = groupTurnsIntoExchanges(turns);
+      expect(exchanges).toHaveLength(2);
+      expect(exchanges[0]).toMatchObject({
+        index: 0,
+        turnIndices: [0],
+        agentText: "Hi, how can I help?",
+      });
+      expect(exchanges[0]?.callerText).toBeUndefined();
+      expect(exchanges[1]).toMatchObject({
+        index: 1,
+        turnIndices: [1, 2],
+        callerText: "Cancel my order",
+        agentText: "Sure",
+      });
+    });
+  });
+
+  describe("when two caller turns come in a row", () => {
+    it("opens a separate exchange for each", () => {
+      const turns: CallTurn[] = [
+        { role: "caller", text: "Hello" },
+        { role: "caller", text: "Anyone there?" },
+        { role: "agent", text: "Yes" },
+      ];
+      const exchanges = groupTurnsIntoExchanges(turns);
+      expect(exchanges.map((e) => e.turnIndices)).toEqual([[0], [1, 2]]);
+      expect(exchanges[0]?.agentText).toBeUndefined();
+      expect(exchanges[1]?.agentText).toBe("Yes");
+    });
+  });
+});
+
+describe("voiceCallTraceIds", () => {
+  describe("when the same conversation and exchange are hashed again", () => {
+    /** @scenario "A re-driven finish writes the same trace ids" */
+    it("returns identical 32-hex trace and 16-hex span ids", () => {
+      const a = voiceCallTraceIds({
+        conversationId: "conv_1",
+        exchangeIndex: 0,
+      });
+      const b = voiceCallTraceIds({
+        conversationId: "conv_1",
+        exchangeIndex: 0,
+      });
+      expect(a).toEqual(b);
+      expect(a.traceId).toMatch(/^[0-9a-f]{32}$/);
+      expect(a.spanId).toMatch(/^[0-9a-f]{16}$/);
+    });
+  });
+
+  describe("when the exchange index differs", () => {
+    it("returns different ids", () => {
+      const a = voiceCallTraceIds({
+        conversationId: "conv_1",
+        exchangeIndex: 0,
+      });
+      const b = voiceCallTraceIds({
+        conversationId: "conv_1",
+        exchangeIndex: 1,
+      });
+      expect(a.traceId).not.toBe(b.traceId);
+      expect(a.spanId).not.toBe(b.spanId);
+    });
+  });
+});
+
+describe("recordVoiceCallTraces", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRecordSpan.mockResolvedValue(undefined);
+  });
+
+  describe("given a call with a greeting and one exchange", () => {
+    /** @scenario "A finished browser call writes one trace per exchange and every message links to its exchange's trace" */
+    it("returns one trace id per turn, shared within an exchange", async () => {
+      const record = fakeRecord({
+        turns: [
+          { role: "agent", text: "Hi" },
+          { role: "caller", text: "Cancel" },
+          { role: "agent", text: "Done" },
+        ],
+      });
+
+      const { turnTraceIds } = await recordVoiceCallTraces({
+        projectId: "p1",
+        record,
+        scenarioRunId: "run_1",
+      });
+
+      expect(turnTraceIds).toHaveLength(3);
+      // Turns 1 and 2 share exchange 1's trace; turn 0 is exchange 0.
+      expect(turnTraceIds[0]).not.toBe(turnTraceIds[1]);
+      expect(turnTraceIds[1]).toBe(turnTraceIds[2]);
+      expect(mockRecordSpan).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("given a drawer call (no scenario)", () => {
+    it("records application-origin spans with the input/output message JSON", async () => {
+      const record = fakeRecord({
+        turns: [
+          { role: "caller", text: "Cancel my order" },
+          { role: "agent", text: "Okay" },
+        ],
+      });
+
+      await recordVoiceCallTraces({
+        projectId: "p1",
+        record,
+        scenarioRunId: "run_1",
+      });
+
+      const attrs = attrsOf(0);
+      expect(attrs["gen_ai.conversation.id"]).toBe("conv_1");
+      expect(attrs["langwatch.origin"]).toBe("application");
+      expect(attrs["langwatch.span.type"]).toBe("agent");
+      expect(attrs["voice.call.caller"]).toBe("human");
+      expect(attrs["voice.turn.index"]).toBe(0);
+      expect(attrs["gen_ai.input.messages"]).toBe(
+        JSON.stringify([{ role: "user", content: "Cancel my order" }]),
+      );
+      expect(attrs["gen_ai.output.messages"]).toBe(
+        JSON.stringify([{ role: "assistant", content: "Okay" }]),
+      );
+      expect(attrs["scenario.id"]).toBeUndefined();
+    });
+  });
+
+  describe("given a leading greeting exchange", () => {
+    it("omits the input messages when the exchange has no caller utterance", async () => {
+      const record = fakeRecord({ turns: [{ role: "agent", text: "Hi" }] });
+
+      await recordVoiceCallTraces({
+        projectId: "p1",
+        record,
+        scenarioRunId: "run_1",
+      });
+
+      const attrs = attrsOf(0);
+      expect(attrs["gen_ai.input.messages"]).toBeUndefined();
+      expect(attrs["gen_ai.output.messages"]).toBe(
+        JSON.stringify([{ role: "assistant", content: "Hi" }]),
+      );
+    });
+  });
+
+  describe("given a scenario context", () => {
+    it("marks the origin simulation and carries the scenario attributes", async () => {
+      const record = fakeRecord({ turns: [{ role: "caller", text: "Hi" }] });
+
+      await recordVoiceCallTraces({
+        projectId: "p1",
+        record,
+        scenarioRunId: "run_1",
+        scenario: { scenarioId: "scenario_1", scenarioSetId: "set_1" },
+      });
+
+      const attrs = attrsOf(0);
+      expect(attrs["langwatch.origin"]).toBe("simulation");
+      expect(attrs["scenario.id"]).toBe("scenario_1");
+      expect(attrs["scenario.set_id"]).toBe("set_1");
+      expect(attrs["scenario.run_id"]).toBe("run_1");
+    });
+  });
+
+  describe("given turns with no reported offsets", () => {
+    it("splits the call window evenly across the exchanges", async () => {
+      const record = fakeRecord({
+        startedAt: 0,
+        endedAt: 4_000,
+        turns: [
+          { role: "caller", text: "one" },
+          { role: "caller", text: "two" },
+        ],
+      });
+
+      await recordVoiceCallTraces({
+        projectId: "p1",
+        record,
+        scenarioRunId: "run_1",
+      });
+
+      const nano = (call: number) => {
+        const span = mockRecordSpan.mock.calls[call]?.[0] as {
+          span: { startTimeUnixNano: string; endTimeUnixNano: string };
+        };
+        return span.span;
+      };
+      // Two exchanges over [0, 4000] ms => [0,2000] and [2000,4000], in nanos.
+      expect(nano(0).startTimeUnixNano).toBe(String(0));
+      expect(nano(0).endTimeUnixNano).toBe(String(2_000 * 1_000_000));
+      expect(nano(1).startTimeUnixNano).toBe(String(2_000 * 1_000_000));
+      expect(nano(1).endTimeUnixNano).toBe(String(4_000 * 1_000_000));
+    });
+  });
+
+  describe("given turns that report their own offsets", () => {
+    it("uses the turn offsets relative to the call start", async () => {
+      const record = fakeRecord({
+        startedAt: 1_000,
+        endedAt: 9_000,
+        turns: [{ role: "caller", text: "hi", startMs: 100, endMs: 500 }],
+      });
+
+      await recordVoiceCallTraces({
+        projectId: "p1",
+        record,
+        scenarioRunId: "run_1",
+      });
+
+      const span = mockRecordSpan.mock.calls[0]?.[0] as {
+        span: { startTimeUnixNano: string; endTimeUnixNano: string };
+      };
+      expect(span.span.startTimeUnixNano).toBe(String(1_100 * 1_000_000));
+      expect(span.span.endTimeUnixNano).toBe(String(1_500 * 1_000_000));
+    });
+  });
+
+  describe("given a call where only some turns report offsets", () => {
+    it("falls back to the even split for the whole call, keeping windows monotonic and non-overlapping", async () => {
+      const record = fakeRecord({
+        startedAt: 0,
+        endedAt: 4_000,
+        turns: [
+          { role: "caller", text: "one", startMs: 100, endMs: 500 },
+          { role: "caller", text: "two" },
+        ],
+      });
+
+      await recordVoiceCallTraces({
+        projectId: "p1",
+        record,
+        scenarioRunId: "run_1",
+      });
+
+      const windows = mockRecordSpan.mock.calls.map((call) => {
+        const { span } = call[0] as {
+          span: { startTimeUnixNano: string; endTimeUnixNano: string };
+        };
+        return {
+          start: Number(span.startTimeUnixNano),
+          end: Number(span.endTimeUnixNano),
+        };
+      });
+
+      expect(windows).toHaveLength(2);
+      for (const w of windows) {
+        expect(w.end).toBeGreaterThanOrEqual(w.start);
+      }
+      // Each window starts no earlier than the previous one ended.
+      windows.reduce((prev, w) => {
+        expect(w.start).toBeGreaterThanOrEqual(prev.end);
+        return w;
+      });
+      // The lone measured offset is ignored: even split [0,2000],[2000,4000].
+      expect(windows[0]).toEqual({ start: 0, end: 2_000 * 1_000_000 });
+      expect(windows[1]).toEqual({
+        start: 2_000 * 1_000_000,
+        end: 4_000 * 1_000_000,
+      });
+    });
+  });
+
+  describe("when recordSpan fails", () => {
+    /** @scenario "A finished browser call writes one trace per exchange and every message links to its exchange's trace" */
+    it("swallows the failure and still returns the ids", async () => {
+      mockRecordSpan.mockRejectedValue(new Error("queue down"));
+      const record = fakeRecord({
+        turns: [
+          { role: "caller", text: "hi" },
+          { role: "agent", text: "hello" },
+        ],
+      });
+
+      const { turnTraceIds } = await recordVoiceCallTraces({
+        projectId: "p1",
+        record,
+        scenarioRunId: "run_1",
+      });
+
+      expect(turnTraceIds).toHaveLength(2);
+      expect(turnTraceIds[0]).toMatch(/^[0-9a-f]{32}$/);
+    });
+  });
+
+  describe("when the call has no turns", () => {
+    it("records nothing and returns no ids", async () => {
+      const { turnTraceIds } = await recordVoiceCallTraces({
+        projectId: "p1",
+        record: fakeRecord({ turns: [] }),
+        scenarioRunId: "run_1",
+      });
+
+      expect(turnTraceIds).toEqual([]);
+      expect(mockRecordSpan).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/platform/app/src/server/scenarios/voice/__tests__/voice-run-writer.unit.test.ts
+++ b/platform/app/src/server/scenarios/voice/__tests__/voice-run-writer.unit.test.ts
@@ -69,6 +69,7 @@ describe("writeVoiceCallRun", () => {
           agentRowId: "agent_1",
           agentDisplayName: "Support Bot",
           record: fakeRecord({ isCutAtLimit: true }),
+          turnTraceIds: [],
         });
 
         const { metadata } = mockStartRun.mock.calls[0]?.[0] as {
@@ -97,6 +98,7 @@ describe("writeVoiceCallRun", () => {
           agentRowId: "agent_1",
           agentDisplayName: "Support Bot",
           record,
+          turnTraceIds: ["trace_0"],
         };
 
         await expect(writeVoiceCallRun(args)).rejects.toThrow();
@@ -121,6 +123,7 @@ describe("writeVoiceCallRun", () => {
           agentRowId: "agent_1",
           agentDisplayName: "Support Bot",
           record,
+          turnTraceIds: ["trace_0", "trace_0"],
         };
 
         await writeVoiceCallRun(args);
@@ -134,6 +137,38 @@ describe("writeVoiceCallRun", () => {
           ).messages.map((m) => m.id);
         expect(idsOf(0)).toEqual(["run_1-0", "run_1-1"]);
         expect(idsOf(0)).toEqual(idsOf(1));
+      });
+    });
+
+    describe("when the turns carry per-exchange trace ids", () => {
+      /** @scenario "A finished browser call writes one trace per exchange and every message links to its exchange's trace" */
+      it("sets trace_id on each message and lists the ids on the snapshot", async () => {
+        const record = fakeRecord({
+          turns: [
+            { role: "caller", text: "hi" },
+            { role: "agent", text: "hello" },
+          ],
+        });
+
+        await writeVoiceCallRun({
+          projectId: "project_1",
+          scenarioRunId: "run_1",
+          agentRowId: "agent_1",
+          agentDisplayName: "Support Bot",
+          record,
+          // Both turns are one exchange, so they share the trace id.
+          turnTraceIds: ["trace_a", "trace_a"],
+        });
+
+        const snapshot = mockMessageSnapshot.mock.calls[0]?.[0] as {
+          messages: { trace_id?: string }[];
+          traceIds: string[];
+        };
+        expect(snapshot.messages.map((m) => m.trace_id)).toEqual([
+          "trace_a",
+          "trace_a",
+        ]);
+        expect(snapshot.traceIds).toEqual(["trace_a", "trace_a"]);
       });
     });
   });

--- a/platform/app/src/server/scenarios/voice/__tests__/voice-session.ports.unit.test.ts
+++ b/platform/app/src/server/scenarios/voice/__tests__/voice-session.ports.unit.test.ts
@@ -295,6 +295,19 @@ describe("Feature: voice-session ports composition", () => {
     });
   });
 
+  describe("given recordCallTraces", () => {
+    describe("when the ports are composed", () => {
+      it("binds the trace writer as the recordCallTraces port", () => {
+        const ports = createVoiceSessionPortsFromServices({
+          agentService: fakeAgentService({}),
+          scenarioService: fakeScenarioService({}),
+        });
+
+        expect(typeof ports.recordCallTraces).toBe("function");
+      });
+    });
+  });
+
   describe("given audioProxyUrl", () => {
     describe("when the proxy url is built", () => {
       it("builds the same-origin proxy path carrying the project", () => {

--- a/platform/app/src/server/scenarios/voice/__tests__/voice-session.service.unit.test.ts
+++ b/platform/app/src/server/scenarios/voice/__tests__/voice-session.service.unit.test.ts
@@ -894,9 +894,11 @@ describe("finishVoiceSession", () => {
     describe("when a fresh call is finished", () => {
       /** @scenario "A finished browser call writes one trace per exchange and every message links to its exchange's trace" */
       it("records the call traces before writing the run and passes the ids through", async () => {
-        const recordCallTraces = vi.fn<VoiceSessionPorts["recordCallTraces"]>(async () => ({
-          turnTraceIds: ["trace_x"],
-        }));
+        const recordCallTraces = vi.fn<VoiceSessionPorts["recordCallTraces"]>(
+          async () => ({
+            turnTraceIds: ["trace_x"],
+          }),
+        );
         const writeCallRun = vi.fn<VoiceSessionPorts["writeCallRun"]>(
           async () => {},
         );
@@ -932,7 +934,9 @@ describe("finishVoiceSession", () => {
     describe("when the finish short-circuits on a terminal run", () => {
       /** @scenario "A retried hang-up leaves a terminal run untouched" */
       it("records no traces and writes no run", async () => {
-        const recordCallTraces = vi.fn<VoiceSessionPorts["recordCallTraces"]>(async () => ({ turnTraceIds: [] }));
+        const recordCallTraces = vi.fn<VoiceSessionPorts["recordCallTraces"]>(
+          async () => ({ turnTraceIds: [] }),
+        );
         const writeCallRun = vi.fn<VoiceSessionPorts["writeCallRun"]>(
           async () => {},
         );

--- a/platform/app/src/server/scenarios/voice/__tests__/voice-session.service.unit.test.ts
+++ b/platform/app/src/server/scenarios/voice/__tests__/voice-session.service.unit.test.ts
@@ -53,6 +53,11 @@ function fakePorts({
     })),
     findExistingRun: vi.fn(async () => null),
     createVoiceAgent: vi.fn(async () => ({ id: "agent_created" })),
+    // One deterministic trace id per turn, so a caller/assertion can read them
+    // back off the writeCallRun call.
+    recordCallTraces: vi.fn(async ({ record }: { record: CallRecord }) => ({
+      turnTraceIds: record.turns.map((_, index) => `trace_${index}`),
+    })),
     writeCallRun: vi.fn(async () => {}),
     audioProxyUrl: ({ conversationId, projectId }) =>
       `/api/voice/session/${conversationId}/audio?projectId=${projectId}`,
@@ -883,6 +888,116 @@ describe("finishVoiceSession", () => {
         expect(result.hasFetchFailed).toBe(true);
         expect(result.source).toBe("browser");
         expect(result.hasAudio).toBe(false);
+      });
+    });
+
+    describe("when a fresh call is finished", () => {
+      /** @scenario "A finished browser call writes one trace per exchange and every message links to its exchange's trace" */
+      it("records the call traces before writing the run and passes the ids through", async () => {
+        const recordCallTraces = vi.fn(async () => ({
+          turnTraceIds: ["trace_x"],
+        }));
+        const writeCallRun = vi.fn<VoiceSessionPorts["writeCallRun"]>(
+          async () => {},
+        );
+        const ports = fakePorts({
+          runner: fakeRunner(),
+          over: { recordCallTraces, writeCallRun },
+        });
+
+        await finishVoiceSession({
+          ports,
+          ...FINISH_BASE,
+          token: { ...TOKEN, agentId: "agent_row" },
+        });
+
+        expect(recordCallTraces).toHaveBeenCalledTimes(1);
+        // Ordering: the traces are recorded before the run is written.
+        expect(
+          (recordCallTraces.mock.invocationCallOrder[0] ?? 0) <
+            (writeCallRun.mock.invocationCallOrder[0] ?? 0),
+        ).toBe(true);
+        // The record and run id the run write sees are the ones the traces were
+        // recorded from.
+        expect(recordCallTraces.mock.calls[0]?.[0]).toMatchObject({
+          projectId: "p1",
+          scenarioRunId: writeCallRun.mock.calls[0]?.[0].scenarioRunId,
+        });
+        expect(writeCallRun.mock.calls[0]?.[0].turnTraceIds).toEqual([
+          "trace_x",
+        ]);
+      });
+    });
+
+    describe("when the finish short-circuits on a terminal run", () => {
+      /** @scenario "A retried hang-up leaves a terminal run untouched" */
+      it("records no traces and writes no run", async () => {
+        const recordCallTraces = vi.fn(async () => ({ turnTraceIds: [] }));
+        const writeCallRun = vi.fn<VoiceSessionPorts["writeCallRun"]>(
+          async () => {},
+        );
+        const ports = fakePorts({
+          runner: fakeRunner(),
+          over: {
+            recordCallTraces,
+            writeCallRun,
+            findExistingRun: vi.fn(async () => ({
+              agentId: "agent_existing",
+              status: ScenarioRunStatus.SUCCESS,
+              source: "provider" as const,
+              audioUrl: null,
+              scenarioId: null,
+              scenarioSetId: null,
+            })),
+          },
+        });
+
+        await finishVoiceSession({
+          ports,
+          ...FINISH_BASE,
+          token: { ...TOKEN, agentId: "agent_row" },
+        });
+
+        expect(recordCallTraces).not.toHaveBeenCalled();
+        expect(writeCallRun).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("when a half-written run is re-driven", () => {
+      /** @scenario "A re-driven finish writes the same trace ids" */
+      it("records the call traces again so the deterministic ids re-attach", async () => {
+        const recordCallTraces = vi.fn(async () => ({
+          turnTraceIds: ["trace_x"],
+        }));
+        const writeCallRun = vi.fn<VoiceSessionPorts["writeCallRun"]>(
+          async () => {},
+        );
+        const ports = fakePorts({
+          runner: fakeRunner(),
+          over: {
+            recordCallTraces,
+            writeCallRun,
+            findExistingRun: vi.fn(async () => ({
+              agentId: "agent_row",
+              status: ScenarioRunStatus.IN_PROGRESS,
+              source: "provider" as const,
+              audioUrl: null,
+              scenarioId: null,
+              scenarioSetId: null,
+            })),
+          },
+        });
+
+        await finishVoiceSession({
+          ports,
+          ...FINISH_BASE,
+          token: { ...TOKEN, agentId: "agent_row" },
+        });
+
+        expect(recordCallTraces).toHaveBeenCalledTimes(1);
+        expect(writeCallRun.mock.calls[0]?.[0].turnTraceIds).toEqual([
+          "trace_x",
+        ]);
       });
     });
   });

--- a/platform/app/src/server/scenarios/voice/__tests__/voice-session.service.unit.test.ts
+++ b/platform/app/src/server/scenarios/voice/__tests__/voice-session.service.unit.test.ts
@@ -894,7 +894,7 @@ describe("finishVoiceSession", () => {
     describe("when a fresh call is finished", () => {
       /** @scenario "A finished browser call writes one trace per exchange and every message links to its exchange's trace" */
       it("records the call traces before writing the run and passes the ids through", async () => {
-        const recordCallTraces = vi.fn(async () => ({
+        const recordCallTraces = vi.fn<VoiceSessionPorts["recordCallTraces"]>(async () => ({
           turnTraceIds: ["trace_x"],
         }));
         const writeCallRun = vi.fn<VoiceSessionPorts["writeCallRun"]>(
@@ -932,7 +932,7 @@ describe("finishVoiceSession", () => {
     describe("when the finish short-circuits on a terminal run", () => {
       /** @scenario "A retried hang-up leaves a terminal run untouched" */
       it("records no traces and writes no run", async () => {
-        const recordCallTraces = vi.fn(async () => ({ turnTraceIds: [] }));
+        const recordCallTraces = vi.fn<VoiceSessionPorts["recordCallTraces"]>(async () => ({ turnTraceIds: [] }));
         const writeCallRun = vi.fn<VoiceSessionPorts["writeCallRun"]>(
           async () => {},
         );

--- a/platform/app/src/server/scenarios/voice/voice-call-trace-writer.ts
+++ b/platform/app/src/server/scenarios/voice/voice-call-trace-writer.ts
@@ -1,0 +1,333 @@
+/**
+ * Writes one trace per exchange of a finished voice call, so every message the
+ * run renders can deep-link the trace of the exchange it belongs to (the drawer
+ * probes `msg.trace_id`). This is the browser-call counterpart of the traces a
+ * simulated run emits: same ingestion path (`getApp().traces.recordSpan` → the
+ * standard OTLP fold), same thread grouping (`gen_ai.conversation.id`), same
+ * `gen_ai.input/output.messages` shape the previews read.
+ *
+ * An exchange is one caller utterance plus the agent utterances that answer it;
+ * a leading agent greeting is exchange 0 with no caller input. Every turn in an
+ * exchange carries that exchange's trace id.
+ *
+ * The ids are derived from the conversation id and the exchange index alone, so
+ * a re-driven finish (a retried hang-up completing a half-written run — #7973)
+ * recomputes the identical ids and the fold dedupes rather than duplicating.
+ *
+ * Best effort: a `recordSpan` failure is logged and swallowed. The ids are
+ * still returned so the messages link to them; the fold picks the span up if a
+ * later attempt succeeds.
+ *
+ * Server-only: derives the ids with `node:crypto`.
+ */
+
+import { createHash } from "node:crypto";
+
+import { createLogger } from "@langwatch/observability";
+
+import { getApp } from "~/server/app-layer/app";
+import { DEFAULT_PII_REDACTION_LEVEL } from "~/server/event-sourcing/pipelines/trace-processing/schemas/commands";
+import type { CallRecord, CallTurn } from "./call-record";
+import { HUMAN_CALLER_KIND } from "./voice-run-writer";
+
+const logger = createLogger("langwatch:voice:call-trace-writer");
+
+/** The scenario a "Call it myself" call is scored under. Absent for a drawer
+ *  call, which flips the span origin to `application`. */
+export interface VoiceTraceScenario {
+  scenarioId: string;
+  scenarioSetId: string;
+}
+
+/**
+ * One exchange: a single caller utterance and the agent utterances that answer
+ * it. `callerText` is absent for a leading agent greeting; `agentText` is absent
+ * when the caller spoke and the agent has not answered yet (two caller turns in
+ * a row).
+ */
+export interface VoiceExchange {
+  index: number;
+  /** Indices into `record.turns` that belong to this exchange, in order. */
+  turnIndices: number[];
+  callerText?: string;
+  agentText?: string;
+  startMs?: number;
+  endMs?: number;
+}
+
+function isCallerTurn(turn: CallTurn): boolean {
+  return turn.role === "caller";
+}
+
+/** Open a fresh exchange at the next index and register it. */
+function openExchange(exchanges: VoiceExchange[]): VoiceExchange {
+  const exchange: VoiceExchange = {
+    index: exchanges.length,
+    turnIndices: [],
+  };
+  exchanges.push(exchange);
+  return exchange;
+}
+
+/** Fold a turn's text into its exchange: a caller utterance is the input, agent
+ *  utterances are joined into the output. */
+function applyTurnContent(exchange: VoiceExchange, turn: CallTurn): void {
+  if (isCallerTurn(turn)) {
+    // At most one caller turn reaches an exchange: groupTurnsIntoExchanges opens
+    // a new exchange on every caller turn, so this never overwrites.
+    exchange.callerText = turn.text;
+    return;
+  }
+  exchange.agentText =
+    exchange.agentText === undefined
+      ? turn.text
+      : `${exchange.agentText}\n${turn.text}`;
+}
+
+/** Widen the exchange window to cover a turn's reported offsets, when it has
+ *  any. */
+function applyTurnTiming(exchange: VoiceExchange, turn: CallTurn): void {
+  if (turn.startMs !== undefined) {
+    exchange.startMs = Math.min(exchange.startMs ?? turn.startMs, turn.startMs);
+  }
+  if (turn.endMs !== undefined) {
+    exchange.endMs = Math.max(exchange.endMs ?? turn.endMs, turn.endMs);
+  }
+}
+
+/**
+ * Group a call's turns into exchanges. A caller turn opens a new exchange; agent
+ * turns append to the open one, or open exchange 0 when they lead the call (a
+ * greeting before the caller speaks).
+ */
+export function groupTurnsIntoExchanges(turns: CallTurn[]): VoiceExchange[] {
+  const exchanges: VoiceExchange[] = [];
+  let open: VoiceExchange | undefined;
+  turns.forEach((turn, index) => {
+    const current =
+      isCallerTurn(turn) || open === undefined ? openExchange(exchanges) : open;
+    open = current;
+    current.turnIndices.push(index);
+    applyTurnContent(current, turn);
+    applyTurnTiming(current, turn);
+  });
+  return exchanges;
+}
+
+/**
+ * The deterministic trace and root-span ids for an exchange, derived from the
+ * conversation id and the exchange index alone (mirrors
+ * `scenarioRunIdForConversation`). A trace id is 32 hex chars, a span id 16.
+ */
+export function voiceCallTraceIds({
+  conversationId,
+  exchangeIndex,
+}: {
+  conversationId: string;
+  exchangeIndex: number;
+}): { traceId: string; spanId: string } {
+  const sha = (input: string) =>
+    createHash("sha256").update(input).digest("hex");
+  return {
+    traceId: sha(`${conversationId}:${exchangeIndex}`).slice(0, 32),
+    spanId: sha(`${conversationId}:${exchangeIndex}:root`).slice(0, 16),
+  };
+}
+
+type OtlpAttribute = {
+  key: string;
+  value: { stringValue?: string; intValue?: number };
+};
+
+/** The span attributes for one exchange (decision 4). */
+function exchangeAttributes({
+  exchange,
+  record,
+  scenario,
+  scenarioRunId,
+}: {
+  exchange: VoiceExchange;
+  record: CallRecord;
+  scenario?: VoiceTraceScenario;
+  scenarioRunId: string;
+}): OtlpAttribute[] {
+  const attrs: OtlpAttribute[] = [
+    {
+      key: "gen_ai.conversation.id",
+      value: { stringValue: record.conversationId },
+    },
+    { key: "langwatch.span.type", value: { stringValue: "agent" } },
+    {
+      key: "langwatch.origin",
+      value: { stringValue: scenario ? "simulation" : "application" },
+    },
+    { key: "voice.turn.index", value: { intValue: exchange.index } },
+    { key: "voice.call.id", value: { stringValue: record.conversationId } },
+    { key: "voice.call.transport", value: { stringValue: record.transport } },
+    { key: "voice.call.source", value: { stringValue: record.source } },
+    {
+      key: "voice.call.caller",
+      value: { stringValue: HUMAN_CALLER_KIND },
+    },
+  ];
+  if (exchange.callerText !== undefined) {
+    attrs.push({
+      key: "gen_ai.input.messages",
+      value: {
+        stringValue: JSON.stringify([
+          { role: "user", content: exchange.callerText },
+        ]),
+      },
+    });
+  }
+  if (exchange.agentText !== undefined) {
+    attrs.push({
+      key: "gen_ai.output.messages",
+      value: {
+        stringValue: JSON.stringify([
+          { role: "assistant", content: exchange.agentText },
+        ]),
+      },
+    });
+  }
+  if (scenario) {
+    attrs.push(
+      { key: "scenario.id", value: { stringValue: scenario.scenarioId } },
+      {
+        key: "scenario.set_id",
+        value: { stringValue: scenario.scenarioSetId },
+      },
+      { key: "scenario.run_id", value: { stringValue: scenarioRunId } },
+    );
+  }
+  return attrs;
+}
+
+/** Whether every turn reports both a start and end offset, so the measured
+ *  windows can be trusted for the whole call. */
+function everyTurnHasOffsets(turns: CallTurn[]): boolean {
+  return turns.every(
+    (turn) => turn.startMs !== undefined && turn.endMs !== undefined,
+  );
+}
+
+/** The exchange's [start, end] in epoch ms. When every turn in the call reports
+ *  both offsets (`useMeasuredOffsets`), each exchange uses its own measured
+ *  window; otherwise the whole call falls back to an even split across the
+ *  exchanges. The choice is call-wide so windows are always monotonic and
+ *  non-overlapping — never mixing a real timestamp with a neighbour's split. */
+function exchangeWindowMs({
+  exchange,
+  exchangeCount,
+  record,
+  useMeasuredOffsets,
+}: {
+  exchange: VoiceExchange;
+  exchangeCount: number;
+  record: CallRecord;
+  useMeasuredOffsets: boolean;
+}): { startMs: number; endMs: number } {
+  if (
+    useMeasuredOffsets &&
+    exchange.startMs !== undefined &&
+    exchange.endMs !== undefined
+  ) {
+    return {
+      startMs: record.startedAt + exchange.startMs,
+      endMs: record.startedAt + exchange.endMs,
+    };
+  }
+  const slice =
+    (record.endedAt - record.startedAt) / Math.max(exchangeCount, 1);
+  const startMs = record.startedAt + slice * exchange.index;
+  return { startMs, endMs: startMs + slice };
+}
+
+/**
+ * Emit one root span per exchange and return the per-turn trace ids (one entry
+ * per `record.turns[i]`, in order). Failures are logged and swallowed; the ids
+ * are returned regardless (decision 7).
+ */
+export async function recordVoiceCallTraces({
+  projectId,
+  record,
+  scenario,
+  scenarioRunId,
+}: {
+  projectId: string;
+  record: CallRecord;
+  scenario?: VoiceTraceScenario;
+  scenarioRunId: string;
+}): Promise<{ turnTraceIds: string[] }> {
+  const exchanges = groupTurnsIntoExchanges(record.turns);
+  const useMeasuredOffsets = everyTurnHasOffsets(record.turns);
+  const turnTraceIds: string[] = new Array(record.turns.length);
+
+  for (const exchange of exchanges) {
+    const { traceId, spanId } = voiceCallTraceIds({
+      conversationId: record.conversationId,
+      exchangeIndex: exchange.index,
+    });
+    for (const turnIndex of exchange.turnIndices)
+      turnTraceIds[turnIndex] = traceId;
+
+    const { startMs, endMs } = exchangeWindowMs({
+      exchange,
+      exchangeCount: exchanges.length,
+      record,
+      useMeasuredOffsets,
+    });
+    try {
+      await getApp().traces.recordSpan({
+        tenantId: projectId,
+        span: {
+          traceId,
+          spanId,
+          traceState: null,
+          parentSpanId: null,
+          name: "Voice Call Turn",
+          kind: 1,
+          startTimeUnixNano: String(Math.round(startMs) * 1_000_000),
+          endTimeUnixNano: String(Math.round(endMs) * 1_000_000),
+          attributes: exchangeAttributes({
+            exchange,
+            record,
+            scenario,
+            scenarioRunId,
+          }),
+          events: [],
+          links: [],
+          status: { code: 1 },
+          droppedAttributesCount: 0,
+          droppedEventsCount: 0,
+          droppedLinksCount: 0,
+        },
+        resource: {
+          attributes: [
+            {
+              key: "langwatch.origin.source",
+              value: { stringValue: "platform" },
+            },
+            { key: "service.name", value: { stringValue: "langwatch-voice" } },
+          ],
+        },
+        instrumentationScope: { name: "langwatch.voice", version: null },
+        piiRedactionLevel: DEFAULT_PII_REDACTION_LEVEL,
+        occurredAt: record.endedAt,
+      });
+    } catch (err) {
+      logger.error(
+        {
+          err,
+          projectId,
+          scenarioRunId,
+          traceId,
+          exchangeIndex: exchange.index,
+        },
+        "Failed to record voice call trace",
+      );
+    }
+  }
+
+  return { turnTraceIds };
+}

--- a/platform/app/src/server/scenarios/voice/voice-call-trace-writer.ts
+++ b/platform/app/src/server/scenarios/voice/voice-call-trace-writer.ts
@@ -59,7 +59,6 @@ function isCallerTurn(turn: CallTurn): boolean {
   return turn.role === "caller";
 }
 
-/** Open a fresh exchange at the next index and register it. */
 function openExchange(exchanges: VoiceExchange[]): VoiceExchange {
   const exchange: VoiceExchange = {
     index: exchanges.length,
@@ -84,8 +83,6 @@ function applyTurnContent(exchange: VoiceExchange, turn: CallTurn): void {
       : `${exchange.agentText}\n${turn.text}`;
 }
 
-/** Widen the exchange window to cover a turn's reported offsets, when it has
- *  any. */
 function applyTurnTiming(exchange: VoiceExchange, turn: CallTurn): void {
   if (turn.startMs !== undefined) {
     exchange.startMs = Math.min(exchange.startMs ?? turn.startMs, turn.startMs);
@@ -139,7 +136,6 @@ type OtlpAttribute = {
   value: { stringValue?: string; intValue?: number };
 };
 
-/** The span attributes for one exchange (decision 4). */
 function exchangeAttributes({
   exchange,
   record,
@@ -243,6 +239,102 @@ function exchangeWindowMs({
   return { startMs, endMs: startMs + slice };
 }
 
+type RecordSpanInput = Parameters<
+  ReturnType<typeof getApp>["traces"]["recordSpan"]
+>[0];
+
+/** The raw-OTLP `recordSpan` payload for one exchange's root span. */
+function buildExchangeSpanInput({
+  projectId,
+  record,
+  scenario,
+  scenarioRunId,
+  exchange,
+  traceId,
+  spanId,
+  startMs,
+  endMs,
+}: {
+  projectId: string;
+  record: CallRecord;
+  scenario?: VoiceTraceScenario;
+  scenarioRunId: string;
+  exchange: VoiceExchange;
+  traceId: string;
+  spanId: string;
+  startMs: number;
+  endMs: number;
+}): RecordSpanInput {
+  return {
+    tenantId: projectId,
+    span: {
+      traceId,
+      spanId,
+      traceState: null,
+      parentSpanId: null,
+      name: "Voice Call Turn",
+      kind: 1,
+      startTimeUnixNano: String(Math.round(startMs) * 1_000_000),
+      endTimeUnixNano: String(Math.round(endMs) * 1_000_000),
+      attributes: exchangeAttributes({
+        exchange,
+        record,
+        scenario,
+        scenarioRunId,
+      }),
+      events: [],
+      links: [],
+      status: { code: 1 },
+      droppedAttributesCount: 0,
+      droppedEventsCount: 0,
+      droppedLinksCount: 0,
+    },
+    resource: {
+      attributes: [
+        {
+          key: "langwatch.origin.source",
+          value: { stringValue: "platform" },
+        },
+        { key: "service.name", value: { stringValue: "langwatch-voice" } },
+      ],
+    },
+    instrumentationScope: { name: "langwatch.voice", version: null },
+    piiRedactionLevel: DEFAULT_PII_REDACTION_LEVEL,
+    occurredAt: record.endedAt,
+  };
+}
+
+/** Record one exchange's root span; a failure is logged and swallowed
+ *  (decision 7) so the caller can always attach the derived ids. */
+async function recordExchangeSpan({
+  projectId,
+  scenarioRunId,
+  exchange,
+  traceId,
+  input,
+}: {
+  projectId: string;
+  scenarioRunId: string;
+  exchange: VoiceExchange;
+  traceId: string;
+  input: RecordSpanInput;
+}): Promise<void> {
+  try {
+    await getApp().traces.recordSpan(input);
+  } catch (err) {
+    logger.error(
+      {
+        err,
+        projectId,
+        scenarioRunId,
+        traceId,
+        exchangeIndex: exchange.index,
+      },
+      "Failed to record voice call trace",
+    );
+  }
+}
+
 /**
  * Emit one root span per exchange and return the per-turn trace ids (one entry
  * per `record.turns[i]`, in order). Failures are logged and swallowed; the ids
@@ -277,56 +369,24 @@ export async function recordVoiceCallTraces({
       record,
       useMeasuredOffsets,
     });
-    try {
-      await getApp().traces.recordSpan({
-        tenantId: projectId,
-        span: {
-          traceId,
-          spanId,
-          traceState: null,
-          parentSpanId: null,
-          name: "Voice Call Turn",
-          kind: 1,
-          startTimeUnixNano: String(Math.round(startMs) * 1_000_000),
-          endTimeUnixNano: String(Math.round(endMs) * 1_000_000),
-          attributes: exchangeAttributes({
-            exchange,
-            record,
-            scenario,
-            scenarioRunId,
-          }),
-          events: [],
-          links: [],
-          status: { code: 1 },
-          droppedAttributesCount: 0,
-          droppedEventsCount: 0,
-          droppedLinksCount: 0,
-        },
-        resource: {
-          attributes: [
-            {
-              key: "langwatch.origin.source",
-              value: { stringValue: "platform" },
-            },
-            { key: "service.name", value: { stringValue: "langwatch-voice" } },
-          ],
-        },
-        instrumentationScope: { name: "langwatch.voice", version: null },
-        piiRedactionLevel: DEFAULT_PII_REDACTION_LEVEL,
-        occurredAt: record.endedAt,
-      });
-    } catch (err) {
-      logger.error(
-        {
-          err,
-          projectId,
-          scenarioRunId,
-          traceId,
-          exchangeIndex: exchange.index,
-        },
-        "Failed to record voice call trace",
-      );
-    }
+    const input = buildExchangeSpanInput({
+      projectId,
+      record,
+      scenario,
+      scenarioRunId,
+      exchange,
+      traceId,
+      spanId,
+      startMs,
+      endMs,
+    });
+    await recordExchangeSpan({
+      projectId,
+      scenarioRunId,
+      exchange,
+      traceId,
+      input,
+    });
   }
 
   return { turnTraceIds };

--- a/platform/app/src/server/scenarios/voice/voice-run-writer.ts
+++ b/platform/app/src/server/scenarios/voice/voice-run-writer.ts
@@ -54,11 +54,15 @@ export class VoiceAgentNotFoundError extends HandledError {
 function toMessages(
   record: CallRecord,
   scenarioRunId: string,
+  turnTraceIds: readonly string[],
 ): SimulationMessage[] {
   return record.turns.map((turn, index) => ({
     id: `${scenarioRunId}-${index}`,
     role: turn.role === "agent" ? "assistant" : "user",
     content: turn.text,
+    // Links the message to its exchange's trace so the drawer can render the
+    // trace-preview separator (it probes `msg.trace_id`).
+    ...(turnTraceIds[index] ? { trace_id: turnTraceIds[index] } : {}),
     ...(turn.audioUrl ? { audioUrl: turn.audioUrl } : {}),
   }));
 }
@@ -79,6 +83,7 @@ export async function writeVoiceCallRun({
   agentDisplayName,
   record,
   scenario,
+  turnTraceIds,
 }: {
   projectId: string;
   scenarioRunId: string;
@@ -86,6 +91,10 @@ export async function writeVoiceCallRun({
   agentDisplayName: string;
   record: CallRecord;
   scenario?: VoiceRunScenario;
+  /** The trace id each turn links to, one per `record.turns[i]` in order, from
+   *  {@link recordVoiceCallTraces}. Set on the message and the run's trace list
+   *  so the drawer probes the exchange's trace. */
+  turnTraceIds: readonly string[];
 }): Promise<void> {
   // The row id is trusted only as far as the token that carried it; the row
   // itself must exist in this project before a run is written under it.
@@ -134,8 +143,10 @@ export async function writeVoiceCallRun({
   await getApp().simulations.messageSnapshot({
     tenantId: projectId,
     scenarioRunId,
-    messages: toMessages(record, scenarioRunId),
-    traceIds: [],
+    messages: toMessages(record, scenarioRunId, turnTraceIds),
+    // The run-level trace list may repeat an id (two turns share their
+    // exchange's trace), mirroring the SDK; the fold dedupes it.
+    traceIds: [...turnTraceIds],
     occurredAt: record.endedAt,
   });
 

--- a/platform/app/src/server/scenarios/voice/voice-session.ports.ts
+++ b/platform/app/src/server/scenarios/voice/voice-session.ports.ts
@@ -28,6 +28,7 @@ import {
 import { getOnPlatformSetId } from "~/server/scenarios/internal-set-id";
 import { ScenarioService } from "~/server/scenarios/scenario.service";
 import { getSuiteSetId } from "~/server/suites/suite-set-id";
+import { recordVoiceCallTraces } from "./voice-call-trace-writer";
 import { writeVoiceCallRun } from "./voice-run-writer";
 import type { VoiceSessionPorts } from "./voice-session.service";
 import { signVoiceSessionToken } from "./voice-session-token";
@@ -137,6 +138,8 @@ export function createVoiceSessionPortsFromServices({
       });
       return { id: created.id };
     },
+
+    recordCallTraces: recordVoiceCallTraces,
 
     writeCallRun: writeVoiceCallRun,
 

--- a/platform/app/src/server/scenarios/voice/voice-session.service.ts
+++ b/platform/app/src/server/scenarios/voice/voice-session.service.ts
@@ -214,6 +214,17 @@ export interface VoiceSessionPorts {
     transport: VoiceTransport;
     agentId: string;
   }): Promise<{ id: string }>;
+  /** Record one trace per exchange of the call, before the run is written, and
+   *  return the per-turn trace ids (one per `record.turns[i]`, in order) so the
+   *  run write links each message to its exchange's trace. Best effort: a
+   *  recording failure is swallowed and the ids are still returned (decision 7).
+   *  Re-run on a re-drive — the ids are deterministic, so the fold dedupes. */
+  recordCallTraces(input: {
+    projectId: string;
+    record: CallRecord;
+    scenario?: { scenarioId: string; scenarioSetId: string };
+    scenarioRunId: string;
+  }): Promise<{ turnTraceIds: string[] }>;
   /** Write the call down as a run the results pages render. When `scenario`
    *  is given the run lands under that scenario (a "Call it myself" run);
    *  otherwise it lands in the voice-call set (a drawer call). */
@@ -224,6 +235,7 @@ export interface VoiceSessionPorts {
     agentDisplayName: string;
     record: CallRecord;
     scenario?: { scenarioId: string; scenarioSetId: string };
+    turnTraceIds: readonly string[];
   }): Promise<void>;
   /** The set a scenario's runs are listed under, so a "Call it myself" run
    *  lands beside that scenario's simulated runs. Null when the scenario is
@@ -650,12 +662,24 @@ export async function finishVoiceSession(input: {
     isCutAtLimit: input.isCutAtLimit,
   });
 
+  // Record one trace per exchange before the run is written, so every message
+  // links to its exchange's trace (decision 1). Best effort: recording failures
+  // are swallowed inside the port, and the ids come back regardless (decision
+  // 7). Re-run on a re-drive — the ids are deterministic, so the fold dedupes.
+  const { turnTraceIds } = await ports.recordCallTraces({
+    projectId: input.projectId,
+    record,
+    scenarioRunId,
+    ...(scenarioContext ? { scenario: scenarioContext } : {}),
+  });
+
   await ports.writeCallRun({
     projectId: input.projectId,
     scenarioRunId,
     agentRowId,
     agentDisplayName,
     record,
+    turnTraceIds,
     ...(scenarioContext ? { scenario: scenarioContext } : {}),
   });
 

--- a/specs/features/agents/voice-agents-v1.feature
+++ b/specs/features/agents/voice-agents-v1.feature
@@ -713,3 +713,23 @@ Feature: Voice agents v1: test an ElevenLabs agent from the app
     Given a run whose metadata marks it cut at the call limit
     When the run header renders
     Then it shows the "Cut at the call limit" marker
+
+  # ---------------------------------------------------------------------------
+  # Every browser voice call writes a trace (3a)
+  # ---------------------------------------------------------------------------
+
+  # 3a AC1
+  @unit @regression
+  Scenario: A finished browser call writes one trace per exchange and every message links to its exchange's trace
+    Given a finished call whose turns group into exchanges
+    When the call is finished
+    Then one trace is recorded per exchange before the run is written
+    And every message carries the trace id of the exchange it belongs to
+    And a trace recording failure does not block the run write
+
+  # 3a AC2
+  @unit @regression
+  Scenario: A re-driven finish writes the same trace ids
+    Given a half-written run is re-driven for the same conversation
+    When the call is finished again
+    Then the recomputed trace ids are identical to the first attempt


### PR DESCRIPTION
## Why

Epic #7978, plan step 3a (user item 2, "missing traces from the scenario run"). SDK-driven simulated voice runs already record one trace per turn, so their run drawer shows turn separators with trace previews and Trace Explorer lists them. The two browser paths, the "Talk to it" drawer call and the "Call it myself" scenario call, wrote `traceIds: []`, so a human call had no turn separators and left nothing in Trace Explorer. This brings the browser paths to parity. #8020 and #7968 reuse the same seam.

## What changed

- New `src/server/scenarios/voice/voice-call-trace-writer.ts`: groups a call's turns into exchanges, derives deterministic ids, emits one raw-OTLP root span `Voice Call Turn` per exchange through `getApp().traces.recordSpan`, and returns one trace id per turn.
- `voice-session.service.ts`: new `recordCallTraces` port on `VoiceSessionPorts`; `finishVoiceSession` calls it on the writing path only, before `writeCallRun`, and threads the ids through. The terminal short-circuit records nothing.
- `voice-session.ports.ts`: binds the port to the new module.
- `voice-run-writer.ts`: `writeVoiceCallRun` takes `turnTraceIds`, sets `trace_id` per message and `traceIds` on the snapshot (one entry per turn, the SDK's shape).
- Tests: new `voice-call-trace-writer.unit.test.ts`; additions to the run-writer, service and ports tests; the voice API test stub gains a no-op `traces.recordSpan`.
- `specs/features/agents/voice-agents-v1.feature`: two scenarios, "A finished browser call writes one trace per exchange and every message links to its exchange's trace" and "A re-driven finish writes the same trace ids".
- No drawer or component changes: the existing turn separators and trace previews light up because the data is now there.

## How it works

An exchange is a caller utterance plus the agent utterances that follow it; a leading agent greeting is exchange 0 with no input. `traceId = sha256("<conversationId>:<exchangeIndex>")[0:32]` and the root `spanId = sha256("…:root")[0:16]`, so a re-driven finish derives the same ids and the ReplacingMergeTree store collapses duplicates. The span carries `gen_ai.conversation.id` (thread grouping, same key the SDK uses), `langwatch.span.type=agent`, `langwatch.origin` (`simulation` when the call has scenario context, else `application`), `gen_ai.input.messages` / `gen_ai.output.messages`, `voice.turn.index`, `voice.call.*`, and `scenario.id/set_id/run_id` only for "Call it myself"; resource `service.name=langwatch-voice`, `langwatch.origin.source=platform`; scope `langwatch.voice`. Timestamps use the client's per-turn offsets only when every turn has them, otherwise the call window is split evenly, so windows never overlap. `recordSpan` failures are logged and swallowed; the ids still attach to the run. No audio is placed on the spans (epic decision 1 is still open).

## Test plan

- 82 unit tests across the five voice test files pass.
- `check-feature-parity` OK; both new scenarios bound by `@scenario` tags.
- Biome clean on all touched files.
- Hygiene review: no blockers; the two should-fixes (shared `HUMAN_CALLER_KIND`, call-wide timing rule with a mixed-offset test) are in this commit.

## Human verification

Local dev app, project `browser-test-org-awkQTI`, admin session, real signed voice tokens against the running app.

1. Finish a drawer call with an agent greeting first and six turns: the run drawer shows Turn 1, 2, 3 separators, each with "View trace"; clicking one opens the trace drawer for that exchange.
2. Finish a "Call it myself" call with `scenarioId` set and four turns: the run drawer for that scenario set shows Turn 1 and 2 separators; the trace carries `scenario.id` and origin `simulation`.
3. Open Trace Explorer: the `Voice Call Turn` traces are listed with origin Simulation (scenario call) or Application (drawer call) and the exchange's input and output.
4. In ClickHouse, `simulation_runs.Messages.TraceId` shares one id per exchange and `stored_spans` holds one `Voice Call Turn` span per exchange.

## How I can prove I was successful

Run drawer for the drawer call (agent greeting first): Turn 2 and Turn 3 separators with "View trace", Turn 1 above the greeting.

![run drawer for a drawer call shows turn separators with View trace](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-voice-3a/run-drawer-drawer-call-turn-separators.png)

Clicking "View trace" on Turn 2 opens the trace drawer: `Voice Call Turn`, conversation context "turn 2 of 3", input and output, origin `application`, `gen_ai.conversation.id` = the conversation id.

![trace drawer for turn 2 of 3](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-voice-3a/trace-drawer-turn-2-of-3.png)

Run drawer for the "Call it myself" scenario call: Turn 1 and Turn 2 separators with "View trace".

![run drawer for a Call it myself run shows turn separators](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-voice-3a/run-drawer-call-it-myself-turn-separators.png)

Trace Explorer lists the voice traces with Simulation and Application origins and the exchange text.

![trace explorer lists Voice Call Turn traces](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-voice-3a/trace-explorer-voice-call-turns.png)

Raw transcript of the two finishes and the ClickHouse readback (`simulation_runs`, `stored_spans`, `trace_summaries`): https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-voice-3a/transcripts/finish-and-clickhouse-readback.txt

```
voicecall_1259c448…  TraceIds=6  Messages.Role=[assistant,user,assistant,user,assistant,assistant]  msg_traces=[e55937ae,3e201258,3e201258,622758f1,622758f1,622758f1]
voicecall_f2dcc570…  TraceIds=4  Messages.Role=[user,assistant,user,assistant]                      msg_traces=[d01057cd,d01057cd,a97827f2,a97827f2]
stored_spans: 5 x "Voice Call Turn", scope langwatch.voice, service langwatch-voice, voice.turn.index 0..2 / 0..1,
              origin application (drawer call) / simulation + scenario.id (Call it myself), langwatch.origin.source=platform
```

## Anything surprising?

- The drawer still labels the human caller "User Simulator" and the right pane says "The judge is reading the conversation" for a drawer call. That is #8020 (plan step 3b), next in the epic, not this PR.
- Trace summaries store `gen_ai.conversation.id` and map it to the thread id at read time; the new traces therefore group by conversation exactly like SDK runs, with no `thread_id` attribute written.
- The epoch-ms to nanosecond string conversion mirrors `trace-metadata.service.ts` and loses sub-ms precision the same way; a shared BigInt helper is a follow-up, not this PR's job.

Refs #7978, #8020, #7968


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Browser voice calls now generate trace records for each conversation exchange.
  * Voice call messages include links to their corresponding exchange traces.
  * Reprocessing a completed call preserves consistent trace links.
  * Trace-recording issues no longer prevent the call run from being saved.

* **Tests**
  * Added coverage for trace creation, message linking, failure handling, and session completion scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->