### PR TITLE
feat(voice): drawer calls write traces only, scenario calls keep writing runs

### DIFF
--- a/docs/agent-testing/voice-agents-in-app.mdx
+++ b/docs/agent-testing/voice-agents-in-app.mdx
@@ -29,6 +29,8 @@ A **Voice** agent type in **Agents** points at an ElevenLabs Conversational AI a
 
 A normal scenario run needs no manual call: the simulated caller speaks the scenario using the caller voice configured on it.
 
+Phone number targets are being added in the app. They sit behind the `release_voice_phone_targets_enabled` flag until the voice worker that dials them ships (see [issue #8014](https://github.com/langwatch/langwatch/issues/8014)).
+
 ## Turn it on
 
 In-app voice agents are in private beta. The feature sits behind the product flag `release_voice_agents_enabled`, off by default. To request access, reach out to support at support@langwatch.ai.

--- a/docs/agent-testing/voice-agents-in-app.mdx
+++ b/docs/agent-testing/voice-agents-in-app.mdx
@@ -20,7 +20,7 @@ A **Voice** agent type in **Agents** points at an ElevenLabs Conversational AI a
 | **Run a scenario** | Normal scenario run | A simulated caller, speaking the scenario with a caller voice |
 
 <Note>
-  **Talk to it** works before the agent is saved, as soon as the agent id and the ElevenLabs key exist. The agent is saved on hang-up, and the call is stored as a run in the **voice-calls** set with caller `human`, a transcript and a link to the recording.
+  **Talk to it** works before the agent is saved, as soon as the agent id and the ElevenLabs key exist. The agent is saved on hang-up. The panel then shows the transcript and, when the recording is ready, a Play control. The call is not stored as a run; instead each exchange is recorded as a trace, so the conversation stays queryable in the Trace Explorer without a run. To score a call against a scenario, use **Call it myself**, which does write a judged run.
 </Note>
 
 **Call it myself** opens the same panel from the Run dialog of a scenario, in scenario mode. The run is named after the scenario.

--- a/docs/agent-testing/voice-agents-in-app.mdx
+++ b/docs/agent-testing/voice-agents-in-app.mdx
@@ -20,7 +20,9 @@ A **Voice** agent type in **Agents** points at an ElevenLabs Conversational AI a
 | **Run a scenario** | Normal scenario run | A simulated caller, speaking the scenario with a caller voice |
 
 <Note>
-  **Talk to it** works before the agent is saved, as soon as the agent id and the ElevenLabs key exist. The agent is saved on hang-up. The panel then shows the transcript and, when the recording is ready, a Play control. The call is not stored as a run; instead each exchange is recorded as a trace, so the conversation stays queryable in the Trace Explorer without a run. To score a call against a scenario, use **Call it myself**, which does write a judged run.
+  **Talk to it** works before the agent is saved, as soon as the agent id and the ElevenLabs key exist. The agent is saved on hang-up. The panel then shows the transcript and, when the recording is ready, a Play control. The call is not stored as a run; instead each exchange is recorded as a trace, so the conversation stays queryable in the Trace Explorer without a run.
+
+  To score a call against a scenario, use **Call it myself**. That writes a run under the scenario, scored the same way a simulated run is.
 </Note>
 
 **Call it myself** opens the same panel from the Run dialog of a scenario, in scenario mode. The run is named after the scenario.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -35395,7 +35395,7 @@ A **Voice** agent type in **Agents** points at an ElevenLabs Conversational AI a
 | **Run a scenario** | Normal scenario run | A simulated caller, speaking the scenario with a caller voice |
 
 <Note>
-  **Talk to it** works before the agent is saved, as soon as the agent id and the ElevenLabs key exist. The agent is saved on hang-up, and the call is stored as a run in the **voice-calls** set with caller `human`, a transcript and a link to the recording.
+  **Talk to it** works before the agent is saved, as soon as the agent id and the ElevenLabs key exist. The agent is saved on hang-up. The panel then shows the transcript and, when the recording is ready, a Play control. The call is not stored as a run; instead each exchange is recorded as a trace, so the conversation stays queryable in the Trace Explorer without a run. To score a call against a scenario, use **Call it myself**, which does write a judged run.
 </Note>
 
 **Call it myself** opens the same panel from the Run dialog of a scenario, in scenario mode. The run is named after the scenario.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -35395,7 +35395,9 @@ A **Voice** agent type in **Agents** points at an ElevenLabs Conversational AI a
 | **Run a scenario** | Normal scenario run | A simulated caller, speaking the scenario with a caller voice |
 
 <Note>
-  **Talk to it** works before the agent is saved, as soon as the agent id and the ElevenLabs key exist. The agent is saved on hang-up. The panel then shows the transcript and, when the recording is ready, a Play control. The call is not stored as a run; instead each exchange is recorded as a trace, so the conversation stays queryable in the Trace Explorer without a run. To score a call against a scenario, use **Call it myself**, which does write a judged run.
+  **Talk to it** works before the agent is saved, as soon as the agent id and the ElevenLabs key exist. The agent is saved on hang-up. The panel then shows the transcript and, when the recording is ready, a Play control. The call is not stored as a run; instead each exchange is recorded as a trace, so the conversation stays queryable in the Trace Explorer without a run.
+
+  To score a call against a scenario, use **Call it myself**. That writes a run under the scenario, scored the same way a simulated run is.
 </Note>
 
 **Call it myself** opens the same panel from the Run dialog of a scenario, in scenario mode. The run is named after the scenario.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -35404,6 +35404,8 @@ A **Voice** agent type in **Agents** points at an ElevenLabs Conversational AI a
 
 A normal scenario run needs no manual call: the simulated caller speaks the scenario using the caller voice configured on it.
 
+Phone number targets are being added in the app. They sit behind the `release_voice_phone_targets_enabled` flag until the voice worker that dials them ships (see [issue #8014](https://github.com/langwatch/langwatch/issues/8014)).
+
 ## Turn it on
 
 In-app voice agents are in private beta. The feature sits behind the product flag `release_voice_agents_enabled`, off by default. To request access, reach out to support at support@langwatch.ai.

--- a/platform/app/src/app/api/voice/[[...route]]/__tests__/voice-api.unit.test.ts
+++ b/platform/app/src/app/api/voice/[[...route]]/__tests__/voice-api.unit.test.ts
@@ -411,6 +411,41 @@ describe("Feature: Voice session HTTP door", () => {
     });
   });
 
+  describe("given a drawer finish that names no scenario", () => {
+    describe("when the finish is handled", () => {
+      /** @scenario "A drawer Talk to it call writes no run" */
+      it("succeeds with no run id, since a drawer call writes no run", async () => {
+        const token = signVoiceSessionToken({
+          payload: {
+            sessionId: "sess_1",
+            projectId: PROJECT_ID,
+            agentId: "agent_row",
+            agentExternalId: "el_agent",
+            transport: "elevenlabs_convai",
+            exp: Date.now() + 60_000,
+          },
+        });
+        fetchCallRecord.mockResolvedValue(null);
+
+        const res = await post("/api/voice/session/conv_1/finish", {
+          projectId: PROJECT_ID,
+          sessionToken: token,
+          conversationId: "conv_1",
+          transcript: [{ role: "caller", text: "hi" }],
+          startedAt: 1,
+          endedAt: 2,
+        });
+
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        // A drawer call is not persisted as a run (#8020): the response carries
+        // no run id and no scenario set id.
+        expect(body.runId).toBe("");
+        expect(body.scenarioSetId).toBeUndefined();
+      });
+    });
+  });
+
   describe("given a finish with a bad session token", () => {
     describe("when the finish request is sent", () => {
       /** @scenario "A finish with an invalid or expired session token is refused" */

--- a/platform/app/src/app/api/voice/[[...route]]/__tests__/voice-api.unit.test.ts
+++ b/platform/app/src/app/api/voice/[[...route]]/__tests__/voice-api.unit.test.ts
@@ -70,10 +70,14 @@ vi.mock("~/server/app-layer/app", () => ({
 }));
 
 const findById = vi.fn();
+const findByIdentityKey = vi.fn();
 vi.mock("~/server/agents/agent.repository", () => ({
   AgentRepository: class {
     findById(...args: unknown[]) {
       return findById(...args);
+    }
+    findByIdentityKey(...args: unknown[]) {
+      return findByIdentityKey(...args);
     }
   },
 }));
@@ -130,6 +134,8 @@ beforeEach(() => {
     type: "voice",
     config: { transport: "elevenlabs_convai", agentId: "el_agent" },
   });
+  // No saved voice agent matches by default; drawer-authz tests opt in.
+  findByIdentityKey.mockResolvedValue(null);
 });
 
 describe("Feature: Voice session HTTP door", () => {
@@ -535,15 +541,77 @@ describe("Feature: Voice session HTTP door", () => {
   });
 
   describe("given a recording request for a conversation with no run", () => {
-    describe("when the audio proxy is requested", () => {
-      /** @scenario "The recording proxy refuses a conversation with no run in the project" */
-      it("answers recording_unavailable and never fetches the provider", async () => {
+    describe("when the provider record is not a saved voice agent's call", () => {
+      /** @scenario "The recording proxy refuses a conversation that is neither a run nor a saved voice agent's call in the project" */
+      it("answers recording_unavailable after checking the provider with this project's credential", async () => {
         getScenarioRunData.mockResolvedValue(null);
+        findByIdentityKey.mockResolvedValue(null);
+        fetchCallRecord.mockResolvedValue({
+          conversationId: "conv_1",
+          transport: "elevenlabs_convai",
+          agentExternalId: "el_agent_someone_else",
+          startedAt: 1,
+          endedAt: 2,
+          durationMs: 1,
+          turns: [],
+          isCutAtLimit: false,
+          source: "provider",
+        });
+
         const res = await app.request(
           `/api/voice/session/conv_1/audio?projectId=${PROJECT_ID}`,
         );
+
         expect(res.status).toBe(404);
         expect((await res.json()).error).toBe("voice_recording_unavailable");
+        expect(fetchCallRecord).toHaveBeenCalledWith(
+          expect.objectContaining({
+            credential: expect.objectContaining({ apiKey: "sk-secret" }),
+          }),
+        );
+      });
+    });
+
+    describe("when the provider record is a saved voice agent's call", () => {
+      /** @scenario "A drawer call's recording still plays after hang-up" */
+      it("streams the recording once the provider agent matches a saved row", async () => {
+        getScenarioRunData.mockResolvedValue(null);
+        fetchCallRecord.mockResolvedValue({
+          conversationId: "conv_1",
+          transport: "elevenlabs_convai",
+          agentExternalId: "el_agent",
+          startedAt: 1,
+          endedAt: 2,
+          durationMs: 1,
+          turns: [],
+          isCutAtLimit: false,
+          source: "provider",
+        });
+        findByIdentityKey.mockResolvedValue({
+          id: "agent_row",
+          projectId: PROJECT_ID,
+          type: "voice",
+          config: { transport: "elevenlabs_convai", agentId: "el_agent" },
+        });
+        const upstreamFetch = vi.fn(async () => ({
+          ok: true,
+          body: new ReadableStream(),
+          headers: new Headers({ "content-type": "audio/mpeg" }),
+        }));
+        vi.stubGlobal("fetch", upstreamFetch);
+
+        // finally so a failing assertion cannot leak the stub onto later tests (isolate: false)
+        try {
+          const res = await app.request(
+            `/api/voice/session/conv_1/audio?projectId=${PROJECT_ID}`,
+          );
+
+          expect(res.status).toBe(200);
+          expect(res.headers.get("cache-control")).toBe("no-store");
+          expect(upstreamFetch).toHaveBeenCalled();
+        } finally {
+          vi.unstubAllGlobals();
+        }
       });
     });
   });

--- a/platform/app/src/app/api/voice/[[...route]]/app.ts
+++ b/platform/app/src/app/api/voice/[[...route]]/app.ts
@@ -27,22 +27,20 @@ import {
 } from "~/server/agents/voice/voice-agent.config";
 import { createServiceApp, handlerManagedAuth } from "~/server/api/security";
 import { validator as zValidator } from "~/server/api/validation";
-import { getApp } from "~/server/app-layer/app";
 import { ProjectPermissionDeniedError } from "~/server/app-layer/permissions/errors";
 import { probeProjectPermission } from "~/server/app-layer/permissions/imperative";
 import { getServerAuthSession } from "~/server/auth";
 import { isVoiceAgentsEnabledForProject } from "~/server/featureFlag/voiceAgents";
-import { scenarioRunIdForConversation } from "~/server/scenarios/voice/call-record";
 import {
   VOICE_HTTP_TIMEOUT_MS,
   voiceCallMaxSeconds,
 } from "~/server/scenarios/voice/voice-limits";
 import { voiceSessionPorts as ports } from "~/server/scenarios/voice/voice-session.ports";
 import {
+  authorizeRecordingPlayback,
   finishVoiceSession,
   mintVoiceSession,
   VoiceAgentsGateDisabledError,
-  VoiceRecordingKeyMissingError,
   VoiceRecordingUnavailableError,
   VoiceSessionInvalidError,
   VoiceUnauthenticatedError,
@@ -309,20 +307,16 @@ export const route = secured
         permissions: ["scenarios:view"],
       });
 
-      // Only proxy when a run for this conversation exists in the authorised
-      // project — otherwise one project could stream another's recording.
-      const run = await getApp().simulations.runs.getScenarioRunData({
+      // Authorize playback and resolve the provider credential in the service:
+      // a scenario run for the conversation allows it directly, and a drawer
+      // call (which writes no run) only when the conversation ran against a
+      // voice agent this project saved, so one project cannot stream another's
+      // recording (#8020). The credential is returned only when authorized.
+      const credential = await authorizeRecordingPlayback({
+        ports,
         projectId,
-        scenarioRunId: scenarioRunIdForConversation(conversationId),
+        conversationId,
       });
-      if (!run) throw new VoiceRecordingUnavailableError();
-
-      // Drawer calls only run on ElevenLabs today.
-      const credential = await ports.resolveCredential({
-        projectId,
-        transport: "elevenlabs_convai",
-      });
-      if (!credential) throw new VoiceRecordingKeyMissingError();
 
       // A timeout on the connect/headers phase only: once the response
       // arrives we stop racing the timeout against the body so a long

--- a/platform/app/src/components/agent-testing/drawers/RunDrawerContent.tsx
+++ b/platform/app/src/components/agent-testing/drawers/RunDrawerContent.tsx
@@ -162,6 +162,12 @@ function ConversationSection({ detail }: { detail: RunDetail }) {
     status: scenarioState.status,
   });
 
+  // A voice "Call it myself" run's caller is a real person, so their turns read
+  // as "You", not the LLM "User Simulator" (#8020). Same metadata field the
+  // results-table caller badge reads (caller-display.ts).
+  const isHumanCaller =
+    scenarioState.metadata?.langwatch?.callerKind === "human";
+
   if (!detail.hasConversation) {
     return (
       <ConversationBox>
@@ -185,6 +191,7 @@ function ConversationSection({ detail }: { detail: RunDetail }) {
           variant="drawer"
           projectId={project?.id ?? ""}
           typingRole={typingRole}
+          isHumanCaller={isHumanCaller}
         />
       </ConversationExpandContext.Provider>
     </ConversationBox>

--- a/platform/app/src/components/agent-testing/drawers/RunDrawerContent.tsx
+++ b/platform/app/src/components/agent-testing/drawers/RunDrawerContent.tsx
@@ -21,6 +21,7 @@ import {
   Text,
   VStack,
 } from "@chakra-ui/react";
+import { isHumanCallerRun } from "~/components/agent-testing/results/caller-display";
 import { nextSpeakerOf } from "~/components/simulations/next-speaker";
 import { RunDetailSection } from "~/components/simulations/RunDetailSection";
 import { ScenarioMessageRenderer } from "~/components/simulations/ScenarioMessageRenderer";
@@ -165,8 +166,7 @@ function ConversationSection({ detail }: { detail: RunDetail }) {
   // A voice "Call it myself" run's caller is a real person, so their turns read
   // as "You", not the LLM "User Simulator" (#8020). Same metadata field the
   // results-table caller badge reads (caller-display.ts).
-  const isHumanCaller =
-    scenarioState.metadata?.langwatch?.callerKind === "human";
+  const isHumanCaller = isHumanCallerRun(scenarioState.metadata);
 
   if (!detail.hasConversation) {
     return (

--- a/platform/app/src/components/agent-testing/results/__tests__/caller-display.unit.test.ts
+++ b/platform/app/src/components/agent-testing/results/__tests__/caller-display.unit.test.ts
@@ -1,0 +1,44 @@
+/**
+ * @vitest-environment node
+ *
+ * `isHumanCallerRun` reads the same metadata field the results-table caller
+ * badge (`runCallerKind`) and the message renderer's caller-label fix read,
+ * so a drawer's live scenario-state stream and a stored run row agree on
+ * whether the caller was a real person (#8020, decision 5).
+ *
+ * @see specs/features/agents/voice-agents-v1.feature
+ */
+import { describe, expect, it } from "vitest";
+import { isHumanCallerRun } from "../caller-display";
+
+describe("isHumanCallerRun", () => {
+  describe("given metadata naming a human caller", () => {
+    it("returns true", () => {
+      expect(isHumanCallerRun({ langwatch: { callerKind: "human" } })).toBe(
+        true,
+      );
+    });
+  });
+
+  describe("given metadata naming a simulated caller", () => {
+    it("returns false", () => {
+      expect(isHumanCallerRun({ langwatch: { callerKind: "simulated" } })).toBe(
+        false,
+      );
+    });
+  });
+
+  describe("given metadata with no caller kind", () => {
+    it("returns false", () => {
+      expect(isHumanCallerRun({ langwatch: {} })).toBe(false);
+      expect(isHumanCallerRun({})).toBe(false);
+    });
+  });
+
+  describe("given no metadata", () => {
+    it("returns false", () => {
+      expect(isHumanCallerRun(null)).toBe(false);
+      expect(isHumanCallerRun(undefined)).toBe(false);
+    });
+  });
+});

--- a/platform/app/src/components/agent-testing/results/caller-display.ts
+++ b/platform/app/src/components/agent-testing/results/caller-display.ts
@@ -10,8 +10,28 @@ import type { ScenarioRunData } from "~/server/scenarios/scenario-event.types";
 
 export type CallerKind = "simulated" | "human";
 
+/** The slice of run/scenario-state metadata this module actually reads. */
+type CallerMetadata =
+  | { langwatch?: { callerKind?: CallerKind | null } | null }
+  | null
+  | undefined;
+
+function callerKindOf(metadata: CallerMetadata): CallerKind | null {
+  return metadata?.langwatch?.callerKind ?? null;
+}
+
 export function runCallerKind(run: ScenarioRunData): CallerKind | null {
-  return run.metadata?.langwatch?.callerKind ?? null;
+  return callerKindOf(run.metadata);
+}
+
+/**
+ * True when a run's caller is a real person (a voice "Call it myself" call),
+ * so their turns render as "You" rather than the LLM "User Simulator"
+ * (#8020). Takes just the metadata slice so both a run row and a live
+ * drawer's scenario-state stream can call it directly.
+ */
+export function isHumanCallerRun(metadata: CallerMetadata): boolean {
+  return callerKindOf(metadata) === "human";
 }
 
 /**

--- a/platform/app/src/components/agent-testing/run/voice-call-target.ts
+++ b/platform/app/src/components/agent-testing/run/voice-call-target.ts
@@ -55,6 +55,10 @@ export function voiceCallTargetOf({
   if (!agent) return null;
   const parsed = voiceAgentConfigSchema.safeParse(agent.config);
   if (!parsed.success) return null;
+  // The browser call reaches an ElevenLabs agent only; a phone target has no
+  // in-browser call, so no target is resolved for it (the drawer offers the
+  // scenario run instead).
+  if (parsed.data.transport !== "elevenlabs_convai") return null;
   // A call is scored against a scenario only when exactly one scenario is in
   // scope: a single case, or a suite that holds exactly one scenario. Every
   // other scope has no single scenario to write the run under, so no target is

--- a/platform/app/src/components/agents/AgentVoiceEditorDrawer.tsx
+++ b/platform/app/src/components/agents/AgentVoiceEditorDrawer.tsx
@@ -57,13 +57,22 @@ type VoiceAgentDraft = {
   phoneNumber: string;
 };
 
+/**
+ * What actually reaches sessionStorage. The phone number is deliberately absent:
+ * it is a personal identifier and CodeQL flags storing it in clear text, so the
+ * draft never persists it. A saved phone target still shows its number on reopen
+ * (that comes from the agent record), so only an unsaved, in-progress number is
+ * lost across the detour to add a key.
+ */
+type PersistedVoiceAgentDraft = Omit<VoiceAgentDraft, "phoneNumber">;
+
 const draftKey = (projectId: string) => `voice-agent-draft:${projectId}`;
 
 function readDraft(projectId: string): VoiceAgentDraft | null {
   try {
     const raw = sessionStorage.getItem(draftKey(projectId));
     if (!raw) return null;
-    const parsed = JSON.parse(raw) as Partial<VoiceAgentDraft>;
+    const parsed = JSON.parse(raw) as Partial<PersistedVoiceAgentDraft>;
     if (typeof parsed.agentId !== "string" || typeof parsed.name !== "string") {
       return null;
     }
@@ -76,17 +85,23 @@ function readDraft(projectId: string): VoiceAgentDraft | null {
       name: parsed.name,
       transport,
       agentId: parsed.agentId,
-      phoneNumber:
-        typeof parsed.phoneNumber === "string" ? parsed.phoneNumber : "",
+      // Never read from storage: the phone number is not persisted.
+      phoneNumber: "",
     };
   } catch {
     return null;
   }
 }
 
-function writeDraft(projectId: string, draft: VoiceAgentDraft): void {
+function writeDraft(projectId: string, draft: PersistedVoiceAgentDraft): void {
   try {
-    sessionStorage.setItem(draftKey(projectId), JSON.stringify(draft));
+    // Only the non-sensitive fields are stored; phoneNumber is never persisted.
+    const persisted: PersistedVoiceAgentDraft = {
+      name: draft.name,
+      transport: draft.transport,
+      agentId: draft.agentId,
+    };
+    sessionStorage.setItem(draftKey(projectId), JSON.stringify(persisted));
   } catch {
     // sessionStorage may be unavailable (private mode, quota); the draft is a
     // convenience, so a failure to persist is silent.
@@ -335,17 +350,8 @@ function useVoiceFormState({
       name,
       transport,
       agentId: voiceAgentId,
-      phoneNumber,
     });
-  }, [
-    isCreating,
-    isOpen,
-    projectId,
-    name,
-    transport,
-    voiceAgentId,
-    phoneNumber,
-  ]);
+  }, [isCreating, isOpen, projectId, name, transport, voiceAgentId]);
 
   return {
     name,

--- a/platform/app/src/components/agents/AgentVoiceEditorDrawer.tsx
+++ b/platform/app/src/components/agents/AgentVoiceEditorDrawer.tsx
@@ -26,6 +26,7 @@ import {
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 import type { AgentWithFields } from "~/server/agents/agent-fields";
 import {
+  E164_PHONE_PATTERN,
   VOICE_TRANSPORT_LABELS,
   VOICE_TRANSPORTS,
   type VoiceTransport,
@@ -33,6 +34,7 @@ import {
 import { api } from "~/utils/api";
 import { TalkToItPanel } from "./voice/TalkToItPanel";
 import { useVoiceAgentsEnabled } from "./voice/useVoiceAgentsEnabled";
+import { useVoicePhoneTargetsEnabled } from "./voice/useVoicePhoneTargetsEnabled";
 
 // ============================================================================
 // Constants
@@ -52,6 +54,7 @@ type VoiceAgentDraft = {
   name: string;
   transport: VoiceTransport;
   agentId: string;
+  phoneNumber: string;
 };
 
 const draftKey = (projectId: string) => `voice-agent-draft:${projectId}`;
@@ -69,7 +72,13 @@ function readDraft(projectId: string): VoiceAgentDraft | null {
     )
       ? (parsed.transport as VoiceTransport)
       : DEFAULT_TRANSPORT;
-    return { name: parsed.name, transport, agentId: parsed.agentId };
+    return {
+      name: parsed.name,
+      transport,
+      agentId: parsed.agentId,
+      phoneNumber:
+        typeof parsed.phoneNumber === "string" ? parsed.phoneNumber : "",
+    };
   } catch {
     return null;
   }
@@ -108,7 +117,41 @@ export type AgentVoiceEditorDrawerProps = {
 // Pure helpers
 // ============================================================================
 
-type VoiceForm = { name: string; transport: VoiceTransport; agentId: string };
+type VoiceForm = {
+  name: string;
+  transport: VoiceTransport;
+  agentId: string;
+  phoneNumber: string;
+};
+
+/** The form values seeded from a saved agent's stored config. */
+function formFromAgent(agentData: {
+  name?: string | null;
+  config?: unknown;
+}): VoiceForm {
+  const config = (agentData.config ?? {}) as {
+    transport?: VoiceTransport;
+    agentId?: string;
+    phoneNumber?: string;
+  };
+  return {
+    name: agentData.name ?? "",
+    transport: config.transport ?? DEFAULT_TRANSPORT,
+    agentId: config.agentId ?? "",
+    phoneNumber: config.phoneNumber ?? "",
+  };
+}
+
+/** The form values seeded from the per-project create draft (else empty). */
+function formFromDraft(projectId: string): VoiceForm {
+  const draft = readDraft(projectId);
+  return {
+    name: draft?.name ?? "",
+    transport: draft?.transport ?? DEFAULT_TRANSPORT,
+    agentId: draft?.agentId ?? "",
+    phoneNumber: draft?.phoneNumber ?? "",
+  };
+}
 
 /**
  * The values the form initializes to: the saved agent when editing, the draft
@@ -125,25 +168,8 @@ function resolveInitialForm({
   isOpen: boolean;
   projectId: string;
 }): VoiceForm | null {
-  if (agentData) {
-    const config = (agentData.config ?? {}) as {
-      transport?: VoiceTransport;
-      agentId?: string;
-    };
-    return {
-      name: agentData.name ?? "",
-      transport: config.transport ?? DEFAULT_TRANSPORT,
-      agentId: config.agentId ?? "",
-    };
-  }
-  if (isCreating && isOpen && projectId) {
-    const draft = readDraft(projectId);
-    return {
-      name: draft?.name ?? "",
-      transport: draft?.transport ?? DEFAULT_TRANSPORT,
-      agentId: draft?.agentId ?? "",
-    };
-  }
+  if (agentData) return formFromAgent(agentData);
+  if (isCreating && isOpen && projectId) return formFromDraft(projectId);
   return null;
 }
 
@@ -212,22 +238,35 @@ function addKeyHref(): string {
   return `${MODEL_PROVIDERS_ROUTE}?returnTo=${returnTo}`;
 }
 
-/** Both required fields are filled, so the agent can be saved. */
+/** The name and the transport's own required field are filled, so the agent
+ *  can be saved. Phone validates the number in E.164 form; ElevenLabs needs a
+ *  non-empty agent id. */
 function isVoiceFormValid(form: {
   name: string;
+  transport: VoiceTransport;
   voiceAgentId: string;
+  phoneNumber: string;
 }): boolean {
-  return form.name.trim().length > 0 && form.voiceAgentId.trim().length > 0;
+  if (form.name.trim().length === 0) return false;
+  if (form.transport === "phone") {
+    return E164_PHONE_PATTERN.test(form.phoneNumber.trim());
+  }
+  return form.voiceAgentId.trim().length > 0;
 }
 
 /** The tooltip naming whichever "Talk to it" prerequisite is still missing. */
 function talkTooltipFor({
+  transport,
   voiceAgentId,
   hasElevenLabsKey,
 }: {
+  transport: VoiceTransport;
   voiceAgentId: string;
   hasElevenLabsKey: boolean;
 }): string | undefined {
+  if (transport === "phone") {
+    return "Browser calls are not available for phone targets. Call it from a scenario run.";
+  }
   if (voiceAgentId.trim().length === 0) return "Enter the agent id first";
   if (!hasElevenLabsKey) return "Add an ElevenLabs key first";
   return undefined;
@@ -256,6 +295,7 @@ function useVoiceFormState({
   const [name, setName] = useState("");
   const [transport, setTransport] = useState<VoiceTransport>(DEFAULT_TRANSPORT);
   const [voiceAgentId, setVoiceAgentId] = useState("");
+  const [phoneNumber, setPhoneNumber] = useState("");
   const formInitializedRef = useRef(false);
   const lastAgentIdRef = useRef<string | undefined>(undefined);
 
@@ -276,6 +316,7 @@ function useVoiceFormState({
     setName(initial.name);
     setTransport(initial.transport);
     setVoiceAgentId(initial.agentId);
+    setPhoneNumber(initial.phoneNumber);
     formInitializedRef.current = true;
   }, [agentData, agentId, isCreating, isOpen, projectId]);
 
@@ -290,8 +331,21 @@ function useVoiceFormState({
     if (!isCreating || !isOpen || !projectId || !formInitializedRef.current) {
       return;
     }
-    writeDraft(projectId, { name, transport, agentId: voiceAgentId });
-  }, [isCreating, isOpen, projectId, name, transport, voiceAgentId]);
+    writeDraft(projectId, {
+      name,
+      transport,
+      agentId: voiceAgentId,
+      phoneNumber,
+    });
+  }, [
+    isCreating,
+    isOpen,
+    projectId,
+    name,
+    transport,
+    voiceAgentId,
+    phoneNumber,
+  ]);
 
   return {
     name,
@@ -300,6 +354,8 @@ function useVoiceFormState({
     setTransport,
     voiceAgentId,
     setVoiceAgentId,
+    phoneNumber,
+    setPhoneNumber,
   };
 }
 
@@ -383,15 +439,20 @@ function submitVoiceAgent({
   isValid: boolean;
   agentId: string | undefined;
   createdAgentRowId: string | undefined;
-  form: { name: string; transport: VoiceTransport; voiceAgentId: string };
+  form: {
+    name: string;
+    transport: VoiceTransport;
+    voiceAgentId: string;
+    phoneNumber: string;
+  };
   createMutation: ReturnType<typeof api.agents.create.useMutation>;
   updateMutation: ReturnType<typeof api.agents.update.useMutation>;
 }): void {
   if (!projectId || !isValid) return;
-  const config = {
-    transport: form.transport,
-    agentId: form.voiceAgentId.trim(),
-  };
+  const config =
+    form.transport === "phone"
+      ? { transport: form.transport, phoneNumber: form.phoneNumber.trim() }
+      : { transport: form.transport, agentId: form.voiceAgentId.trim() };
   const savedAgentId = agentId ?? createdAgentRowId;
   if (savedAgentId) {
     updateMutation.mutate({
@@ -425,7 +486,12 @@ function useSaveVoiceAgent({
   isValid: boolean;
   agentId: string | undefined;
   createdAgentRowId: string | undefined;
-  form: { name: string; transport: VoiceTransport; voiceAgentId: string };
+  form: {
+    name: string;
+    transport: VoiceTransport;
+    voiceAgentId: string;
+    phoneNumber: string;
+  };
   createMutation: ReturnType<typeof api.agents.create.useMutation>;
   updateMutation: ReturnType<typeof api.agents.update.useMutation>;
 }): { handleSave: () => void; hasAttemptedSubmit: boolean } {
@@ -462,7 +528,12 @@ function useSaveVoiceAgent({
  * create/update mutations, and the same flow-callback forwarding so the run
  * dialog and the scenario editor can open it and be told about the saved agent.
  */
-function useVoiceAgentEditor(props: AgentVoiceEditorDrawerProps) {
+/**
+ * The drawer's resolved inputs, local state, and the data/form/mutation hooks
+ * it composes. Kept apart from {@link useVoiceAgentEditor} so each stays a small
+ * function; the editor hook layers the derived flags and callbacks on top.
+ */
+function useVoiceEditorState(props: AgentVoiceEditorDrawerProps) {
   const { project } = useOrganizationTeamProject();
   const { closeDrawer, canGoBack, goBack } = useDrawer();
   const projectId = project?.id ?? "";
@@ -474,19 +545,17 @@ function useVoiceAgentEditor(props: AgentVoiceEditorDrawerProps) {
     drawerParams,
     flowCallbacksForSave: getFlowCallbacks("agentVoiceEditor"),
   });
-
   // The card menu's Talk to it action opens the drawer straight onto the call
   // panel via ?drawer.talk=1, rather than making the user click Talk to it
   // again once the editor has loaded (#23).
   const [isTalkOpen, setIsTalkOpen] = useState(drawerParams.talk === "1");
   const [createdAgentRowId, setCreatedAgentRowId] = useState<string>();
-
+  const phoneTargetsEnabled = useVoicePhoneTargetsEnabled();
   const { agentQuery, hasElevenLabsKey } = useVoiceAgentData({
     agentId,
     projectId,
     isOpen,
   });
-
   const form = useVoiceFormState({
     agentData: agentQuery.data,
     agentId,
@@ -499,6 +568,40 @@ function useVoiceAgentEditor(props: AgentVoiceEditorDrawerProps) {
     onSave,
     onClose,
   });
+  return {
+    project,
+    canGoBack,
+    goBack,
+    agentId,
+    isOpen,
+    isCreating,
+    projectId,
+    onClose,
+    form,
+    hasElevenLabsKey,
+    phoneTargetsEnabled,
+    isTalkOpen,
+    setIsTalkOpen,
+    createdAgentRowId,
+    setCreatedAgentRowId,
+    agentQuery,
+    createMutation,
+    updateMutation,
+    utils,
+  };
+}
+
+function useVoiceAgentEditor(props: AgentVoiceEditorDrawerProps) {
+  const state = useVoiceEditorState(props);
+  const {
+    projectId,
+    onClose,
+    agentId,
+    form,
+    createdAgentRowId,
+    createMutation,
+    updateMutation,
+  } = state;
 
   const isSaving = createMutation.isPending || updateMutation.isPending;
   const isValid = isVoiceFormValid(form);
@@ -519,25 +622,26 @@ function useVoiceAgentEditor(props: AgentVoiceEditorDrawerProps) {
   }, [projectId, onClose]);
 
   return {
-    project,
-    canGoBack,
-    goBack,
+    project: state.project,
+    canGoBack: state.canGoBack,
+    goBack: state.goBack,
     agentId,
-    isOpen,
+    isOpen: state.isOpen,
     projectId,
     form,
-    hasElevenLabsKey,
+    hasElevenLabsKey: state.hasElevenLabsKey,
+    phoneTargetsEnabled: state.phoneTargetsEnabled,
     isSaving,
     isValid,
     hasAttemptedSubmit,
-    isLoading: agentQuery.isLoading,
-    isTalkOpen,
-    setIsTalkOpen,
+    isLoading: state.agentQuery.isLoading,
+    isTalkOpen: state.isTalkOpen,
+    setIsTalkOpen: state.setIsTalkOpen,
     createdAgentRowId,
-    setCreatedAgentRowId,
+    setCreatedAgentRowId: state.setCreatedAgentRowId,
     handleSave,
     handleClose,
-    utils,
+    utils: state.utils,
   };
 }
 
@@ -608,45 +712,11 @@ export function AgentVoiceEditorDrawer(props: AgentVoiceEditorDrawerProps) {
           goBack={editor.goBack}
           agentId={editor.agentId}
         />
-        <Drawer.Body
-          display="flex"
-          flexDirection="column"
-          overflow="hidden"
-          padding={0}
-        >
-          {editor.isTalkOpen ? (
-            <VoiceAgentTalkView
-              project={editor.project}
-              projectId={editor.projectId}
-              transport={form.transport}
-              voiceAgentId={form.voiceAgentId}
-              name={form.name}
-              agentId={editor.agentId}
-              createdAgentRowId={editor.createdAgentRowId}
-              setCreatedAgentRowId={editor.setCreatedAgentRowId}
-              utils={editor.utils}
-              onBack={() => editor.setIsTalkOpen(false)}
-            />
-          ) : editor.agentId && editor.isLoading ? (
-            <HStack justify="center" paddingY={8}>
-              <Spinner size="md" />
-            </HStack>
-          ) : (
-            <VoiceAgentForm
-              name={form.name}
-              setName={form.setName}
-              transport={form.transport}
-              setTransport={form.setTransport}
-              voiceAgentId={form.voiceAgentId}
-              setVoiceAgentId={form.setVoiceAgentId}
-              hasElevenLabsKey={editor.hasElevenLabsKey}
-              hasAttemptedSubmit={editor.hasAttemptedSubmit}
-            />
-          )}
-        </Drawer.Body>
+        <VoiceAgentDrawerBody editor={editor} />
         <VoiceAgentFooter
           agentId={editor.agentId}
           createdAgentRowId={editor.createdAgentRowId}
+          transport={form.transport}
           voiceAgentId={form.voiceAgentId}
           hasElevenLabsKey={editor.hasElevenLabsKey}
           isSaving={editor.isSaving}
@@ -662,6 +732,60 @@ export function AgentVoiceEditorDrawer(props: AgentVoiceEditorDrawerProps) {
 // ============================================================================
 // Presentational sub-components
 // ============================================================================
+
+/**
+ * The drawer body: the call panel, the loading spinner while an existing agent
+ * loads, or the edit form. Split out of {@link AgentVoiceEditorDrawer} so that
+ * component stays small.
+ */
+function VoiceAgentDrawerBody({
+  editor,
+}: {
+  editor: ReturnType<typeof useVoiceAgentEditor>;
+}) {
+  const { form } = editor;
+  return (
+    <Drawer.Body
+      display="flex"
+      flexDirection="column"
+      overflow="hidden"
+      padding={0}
+    >
+      {editor.isTalkOpen ? (
+        <VoiceAgentTalkView
+          project={editor.project}
+          projectId={editor.projectId}
+          transport={form.transport}
+          voiceAgentId={form.voiceAgentId}
+          name={form.name}
+          agentId={editor.agentId}
+          createdAgentRowId={editor.createdAgentRowId}
+          setCreatedAgentRowId={editor.setCreatedAgentRowId}
+          utils={editor.utils}
+          onBack={() => editor.setIsTalkOpen(false)}
+        />
+      ) : editor.agentId && editor.isLoading ? (
+        <HStack justify="center" paddingY={8}>
+          <Spinner size="md" />
+        </HStack>
+      ) : (
+        <VoiceAgentForm
+          name={form.name}
+          setName={form.setName}
+          transport={form.transport}
+          setTransport={form.setTransport}
+          voiceAgentId={form.voiceAgentId}
+          setVoiceAgentId={form.setVoiceAgentId}
+          phoneNumber={form.phoneNumber}
+          setPhoneNumber={form.setPhoneNumber}
+          phoneTargetsEnabled={editor.phoneTargetsEnabled}
+          hasElevenLabsKey={editor.hasElevenLabsKey}
+          hasAttemptedSubmit={editor.hasAttemptedSubmit}
+        />
+      )}
+    </Drawer.Body>
+  );
+}
 
 function VoiceAgentHeader({
   canGoBack,
@@ -750,6 +874,24 @@ function VoiceAgentTalkView({
   );
 }
 
+/**
+ * The transports offered in the "Reached via" select. Phone stays hidden until
+ * the `release_voice_phone_targets_enabled` flag is on, but an agent already
+ * configured as phone still lists it so its own transport renders (the gate is
+ * on the OPTION, not on an existing target).
+ */
+function visibleTransportsFor({
+  phoneTargetsEnabled,
+  transport,
+}: {
+  phoneTargetsEnabled: boolean;
+  transport: VoiceTransport;
+}): readonly VoiceTransport[] {
+  return VOICE_TRANSPORTS.filter(
+    (t) => t !== "phone" || phoneTargetsEnabled || transport === "phone",
+  );
+}
+
 function VoiceAgentForm({
   name,
   setName,
@@ -757,6 +899,9 @@ function VoiceAgentForm({
   setTransport,
   voiceAgentId,
   setVoiceAgentId,
+  phoneNumber,
+  setPhoneNumber,
+  phoneTargetsEnabled,
   hasElevenLabsKey,
   hasAttemptedSubmit,
 }: {
@@ -766,13 +911,23 @@ function VoiceAgentForm({
   setTransport: (value: VoiceTransport) => void;
   voiceAgentId: string;
   setVoiceAgentId: (value: string) => void;
+  phoneNumber: string;
+  setPhoneNumber: (value: string) => void;
+  phoneTargetsEnabled: boolean;
   hasElevenLabsKey: boolean;
   hasAttemptedSubmit: boolean;
 }) {
   const nameInvalid = hasAttemptedSubmit && name.trim().length === 0;
   const voiceAgentIdInvalid =
     hasAttemptedSubmit && voiceAgentId.trim().length === 0;
-  const transportOptionsDisabled = VOICE_TRANSPORTS.length <= 1;
+  const phoneNumberInvalid =
+    hasAttemptedSubmit && !E164_PHONE_PATTERN.test(phoneNumber.trim());
+  const isPhone = transport === "phone";
+  const visibleTransports = visibleTransportsFor({
+    phoneTargetsEnabled,
+    transport,
+  });
+  const transportOptionsDisabled = visibleTransports.length <= 1;
   return (
     <VStack
       gap={4}
@@ -801,7 +956,7 @@ function VoiceAgentForm({
             onChange={(e) => setTransport(e.target.value as VoiceTransport)}
             data-testid="voice-agent-transport-select"
           >
-            {VOICE_TRANSPORTS.map((t) => (
+            {visibleTransports.map((t) => (
               <option key={t} value={t}>
                 {VOICE_TRANSPORT_LABELS[t]}
               </option>
@@ -811,7 +966,70 @@ function VoiceAgentForm({
         </NativeSelect.Root>
       </Field.Root>
 
-      <Field.Root required invalid={voiceAgentIdInvalid}>
+      {isPhone ? (
+        <PhoneNumberField
+          phoneNumber={phoneNumber}
+          setPhoneNumber={setPhoneNumber}
+          invalid={phoneNumberInvalid}
+        />
+      ) : (
+        <ElevenLabsAgentIdField
+          voiceAgentId={voiceAgentId}
+          setVoiceAgentId={setVoiceAgentId}
+          invalid={voiceAgentIdInvalid}
+          hasElevenLabsKey={hasElevenLabsKey}
+        />
+      )}
+    </VStack>
+  );
+}
+
+/** The phone target's E.164 number, the whole identity of a phone target. */
+function PhoneNumberField({
+  phoneNumber,
+  setPhoneNumber,
+  invalid,
+}: {
+  phoneNumber: string;
+  setPhoneNumber: (value: string) => void;
+  invalid: boolean;
+}) {
+  return (
+    <Field.Root required invalid={invalid}>
+      <Field.Label>Phone number</Field.Label>
+      <Input
+        value={phoneNumber}
+        onChange={(e) => setPhoneNumber(e.target.value)}
+        placeholder="+14155550123"
+        data-testid="voice-agent-phone-input"
+      />
+      <Field.HelperText>
+        In E.164 form: a plus sign, the country code, then the number.
+      </Field.HelperText>
+      {invalid && (
+        <Field.ErrorText>
+          Enter the number in E.164 form, like +14155550123
+        </Field.ErrorText>
+      )}
+    </Field.Root>
+  );
+}
+
+/** The ElevenLabs agent id, with the provider-key line beneath it. */
+function ElevenLabsAgentIdField({
+  voiceAgentId,
+  setVoiceAgentId,
+  invalid,
+  hasElevenLabsKey,
+}: {
+  voiceAgentId: string;
+  setVoiceAgentId: (value: string) => void;
+  invalid: boolean;
+  hasElevenLabsKey: boolean;
+}) {
+  return (
+    <>
+      <Field.Root required invalid={invalid}>
         <Field.Label>Agent id</Field.Label>
         <Input
           value={voiceAgentId}
@@ -822,17 +1040,15 @@ function VoiceAgentForm({
         <Field.HelperText>
           From the ElevenLabs dashboard: Agents, your agent, Agent ID
         </Field.HelperText>
-        {voiceAgentIdInvalid && (
-          <Field.ErrorText>Agent id is required</Field.ErrorText>
-        )}
+        {invalid && <Field.ErrorText>Agent id is required</Field.ErrorText>}
       </Field.Root>
 
       <CredentialsLine hasElevenLabsKey={hasElevenLabsKey} />
-    </VStack>
+    </>
   );
 }
 
-/** The credentials line — the key lives on the ElevenLabs provider row. */
+/** The credentials line: the key lives on the ElevenLabs provider row. */
 function CredentialsLine({ hasElevenLabsKey }: { hasElevenLabsKey: boolean }) {
   if (hasElevenLabsKey) {
     return (
@@ -858,6 +1074,7 @@ function CredentialsLine({ hasElevenLabsKey }: { hasElevenLabsKey: boolean }) {
 function VoiceAgentFooter({
   agentId,
   createdAgentRowId,
+  transport,
   voiceAgentId,
   hasElevenLabsKey,
   isSaving,
@@ -867,6 +1084,7 @@ function VoiceAgentFooter({
 }: {
   agentId: string | undefined;
   createdAgentRowId: string | undefined;
+  transport: VoiceTransport;
   voiceAgentId: string;
   hasElevenLabsKey: boolean;
   isSaving: boolean;
@@ -874,13 +1092,19 @@ function VoiceAgentFooter({
   onTalk: () => void;
   onSave: () => void;
 }) {
-  // Once "Talk to it" has created the row, further saves update it — the
+  // Once "Talk to it" has created the row, further saves update it: the
   // panel's created id stands in for the editor's own agentId (#20).
   const savedAgentId = agentId ?? createdAgentRowId;
   // Talk to it is enabled as soon as the transport's agent id is filled and the
-  // project has a key — no save-first. The tooltip names whichever is missing.
-  const canTalk = voiceAgentId.trim().length > 0 && hasElevenLabsKey;
-  const talkTooltip = talkTooltipFor({ voiceAgentId, hasElevenLabsKey });
+  // project has a key, no save-first. The tooltip names whichever is missing.
+  // Phone has no browser call, so it is always off with an explaining tooltip.
+  const canTalk =
+    transport !== "phone" && voiceAgentId.trim().length > 0 && hasElevenLabsKey;
+  const talkTooltip = talkTooltipFor({
+    transport,
+    voiceAgentId,
+    hasElevenLabsKey,
+  });
   return (
     <Drawer.Footer borderTopWidth="1px" borderColor="border">
       <HStack gap={3}>

--- a/platform/app/src/components/agents/__tests__/AgentVoiceEditorDrawer.integration.test.tsx
+++ b/platform/app/src/components/agents/__tests__/AgentVoiceEditorDrawer.integration.test.tsx
@@ -222,6 +222,38 @@ describe("AgentVoiceEditorDrawer", () => {
         screen.getByRole("option", { name: "Phone number" }),
       ).toBeInTheDocument();
     });
+
+    it("never persists the typed phone number in the sessionStorage draft", async () => {
+      mockPhoneTargetsEnabled = true;
+      const user = userEvent.setup();
+      renderVoiceDrawer();
+      await user.type(
+        await screen.findByTestId("voice-agent-name-input"),
+        "Hotline draft",
+      );
+      await user.selectOptions(
+        screen.getByTestId("voice-agent-transport-select"),
+        "phone",
+      );
+      await user.type(
+        await screen.findByTestId("voice-agent-phone-input"),
+        "+14155550123",
+      );
+
+      await waitFor(() => {
+        expect(
+          sessionStorage.getItem("voice-agent-draft:test-project"),
+        ).not.toBeNull();
+      });
+      const stored = JSON.parse(
+        sessionStorage.getItem("voice-agent-draft:test-project") ?? "{}",
+      ) as Record<string, unknown>;
+      // The sensitive field is stripped; the rest of the draft still persists.
+      expect(stored).not.toHaveProperty("phoneNumber");
+      expect(JSON.stringify(stored)).not.toContain("+14155550123");
+      expect(stored.name).toBe("Hotline draft");
+      expect(stored.transport).toBe("phone");
+    });
   });
 
   describe("when a new voice agent drawer is drawn", () => {

--- a/platform/app/src/components/agents/__tests__/AgentVoiceEditorDrawer.integration.test.tsx
+++ b/platform/app/src/components/agents/__tests__/AgentVoiceEditorDrawer.integration.test.tsx
@@ -61,6 +61,13 @@ vi.mock("../voice/useVoiceAgentsEnabled", () => ({
   useVoiceAgentsEnabled: () => mockVoiceAgentsEnabled,
 }));
 
+/** Overridden per test; false by default so the phone option stays gated off
+ * for the editor's own behavior tests. */
+let mockPhoneTargetsEnabled = false;
+vi.mock("../voice/useVoicePhoneTargetsEnabled", () => ({
+  useVoicePhoneTargetsEnabled: () => mockPhoneTargetsEnabled,
+}));
+
 /** What `agents.getById` answers with, so a test can open a saved agent. */
 let mockAgentById: {
   id: string;
@@ -156,6 +163,7 @@ describe("AgentVoiceEditorDrawer", () => {
     mockAgentById = null;
     mockProviders = [];
     mockVoiceAgentsEnabled = true;
+    mockPhoneTargetsEnabled = false;
     mockDrawerParams = {};
     try {
       sessionStorage.clear();
@@ -176,6 +184,43 @@ describe("AgentVoiceEditorDrawer", () => {
       expect(
         screen.queryByTestId("voice-agent-name-input"),
       ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("given the phone targets flag gates the Phone number option", () => {
+    /** @scenario "The phone option is hidden until the phone targets flag is on" */
+    it("hides the Phone number option while off and offers it once on", async () => {
+      mockPhoneTargetsEnabled = false;
+      const { unmount } = renderVoiceDrawer();
+      await screen.findByTestId("voice-agent-transport-select");
+      expect(
+        screen.queryByRole("option", { name: "Phone number" }),
+      ).not.toBeInTheDocument();
+      unmount();
+
+      mockPhoneTargetsEnabled = true;
+      renderVoiceDrawer();
+      await screen.findByTestId("voice-agent-transport-select");
+      expect(
+        screen.getByRole("option", { name: "Phone number" }),
+      ).toBeInTheDocument();
+    });
+
+    it("still renders an existing phone target's fields with the flag off", async () => {
+      mockPhoneTargetsEnabled = false;
+      mockAgentById = {
+        id: "agent_phone",
+        name: "Hotline",
+        config: { transport: "phone", phoneNumber: "+14155550123" },
+      };
+      renderVoiceDrawer({ agentId: "agent_phone" });
+      const input = (await screen.findByTestId(
+        "voice-agent-phone-input",
+      )) as HTMLInputElement;
+      expect(input.value).toBe("+14155550123");
+      expect(
+        screen.getByRole("option", { name: "Phone number" }),
+      ).toBeInTheDocument();
     });
   });
 
@@ -329,6 +374,25 @@ describe("AgentVoiceEditorDrawer", () => {
       expect(
         screen.queryByTestId("voice-agent-name-input"),
       ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("given a saved phone target", () => {
+    /** @scenario "A phone target's drawer explains why Talk to it is off" */
+    it("disables Talk to it with the phone-has-no-browser-call tooltip", async () => {
+      mockAgentById = {
+        id: "agent_phone",
+        name: "Hotline",
+        config: { transport: "phone", phoneNumber: "+14155550123" },
+      };
+      mockProviders = [ELEVENLABS_KEYED_PROVIDER];
+      renderVoiceDrawer({ agentId: "agent_phone" });
+      const talk = await screen.findByTestId("voice-agent-talk");
+      expect(talk).toBeDisabled();
+      expect(talk).toHaveAttribute(
+        "title",
+        "Browser calls are not available for phone targets. Call it from a scenario run.",
+      );
     });
   });
 

--- a/platform/app/src/components/agents/voice/TalkToItPanel.tsx
+++ b/platform/app/src/components/agents/voice/TalkToItPanel.tsx
@@ -31,13 +31,18 @@ import {
   talkReducer,
 } from "./talkToItMachine";
 import {
+  getVoiceTransportClient,
   type VoiceCallSession,
   type VoiceTurn,
-  voiceTransportClientRegistry,
 } from "./voice-transport-client.registry";
 
 /** The settings route that adds a model provider key (mirrors the drawer). */
 const MODEL_PROVIDERS_ROUTE = "/settings/model-providers";
+
+/** Shown instead of the call controls for a transport with no browser client
+ *  (a phone target is dialled from a scenario run, not from the browser). */
+export const PHONE_NO_BROWSER_CALL_NOTICE =
+  "This agent is reached by phone. Call it from a scenario run; browser calls are not available for phone targets.";
 
 /** Placeholder cap before minting; the session mint response replaces it. */
 const PRE_MINT_MAX_SECONDS_PLACEHOLDER = VOICE_CALL_MAX_SECONDS_DEFAULT;
@@ -401,9 +406,21 @@ async function runStart({
   refs.sessionToken.current = mint.sessionToken;
   refs.startedAt.current = Date.now();
 
+  const client = getVoiceTransportClient(props.transport);
+  if (!client) {
+    // A transport with no browser client cannot open a call here; the panel
+    // renders the phone notice instead of ever reaching this path.
+    dispatch({
+      type: "MINT_FAILED",
+      code: "mint_failed",
+      message: PHONE_NO_BROWSER_CALL_NOTICE,
+    });
+    return;
+  }
+
   let session: VoiceCallSession;
   try {
-    session = await voiceTransportClientRegistry[props.transport].openCall({
+    session = await client.openCall({
       signedUrl: mint.connect.signedUrl,
       handlers: {
         onConnected: ({ conversationId }) => {
@@ -549,6 +566,27 @@ function useTalkToItCall(props: TalkToItPanelProps) {
  * @see specs/features/agents/voice-agents-v1.feature
  */
 export function TalkToItPanel(props: TalkToItPanelProps) {
+  // A transport with no browser client (phone) is dialled from a scenario run,
+  // not the browser: show the notice instead of the call machine, which would
+  // otherwise try to mint a session it cannot open. Split so the call hooks
+  // below never run for such a transport.
+  if (!getVoiceTransportClient(props.transport)) {
+    return (
+      <VStack align="stretch" gap={4} data-testid="talk-to-it-panel">
+        <Text
+          fontSize="sm"
+          color="fg.muted"
+          data-testid="talk-phone-no-browser-notice"
+        >
+          {PHONE_NO_BROWSER_CALL_NOTICE}
+        </Text>
+      </VStack>
+    );
+  }
+  return <BrowserCallPanel {...props} />;
+}
+
+function BrowserCallPanel(props: TalkToItPanelProps) {
   const {
     state,
     micLevel,

--- a/platform/app/src/components/agents/voice/TalkToItPanel.tsx
+++ b/platform/app/src/components/agents/voice/TalkToItPanel.tsx
@@ -13,7 +13,6 @@ import { useCallback, useEffect, useReducer, useRef, useState } from "react";
 import { z } from "zod";
 
 import {
-  VOICE_CALL_SCENARIO_SET_ID,
   VOICE_TRANSPORTS,
   type VoiceTransport,
 } from "~/server/agents/voice/voice-agent.config";
@@ -122,7 +121,12 @@ function createTalkRefs(agentRowId: string | undefined): TalkRefs {
   };
 }
 
-/** The run link the done view offers, or undefined until a run exists. */
+/**
+ * The run link the done view offers, or undefined when there is no run to link.
+ * Only a "Call it myself" call writes a run (#8020), and that path always
+ * learns its set from the finish response, so a run id without a set never
+ * occurs; a drawer call has an empty run id and links nowhere.
+ */
 function runHrefOf({
   state,
   runSetId,
@@ -132,10 +136,10 @@ function runHrefOf({
   runSetId: string | undefined;
   projectSlug: string;
 }): string | undefined {
-  if (state.kind !== "done" || !state.runId) return undefined;
-  return `/${projectSlug}/simulations/${
-    runSetId ?? VOICE_CALL_SCENARIO_SET_ID
-  }/${encodeURIComponent(state.runId)}`;
+  if (state.kind !== "done" || !state.runId || !runSetId) return undefined;
+  return `/${projectSlug}/simulations/${runSetId}/${encodeURIComponent(
+    state.runId,
+  )}`;
 }
 
 function stopTick(refs: TalkRefs): void {

--- a/platform/app/src/components/agents/voice/__tests__/TalkToItPanel.integration.test.tsx
+++ b/platform/app/src/components/agents/voice/__tests__/TalkToItPanel.integration.test.tsx
@@ -20,11 +20,17 @@ const { openCall } = vi.hoisted(() => ({
     hangUp: vi.fn(async () => {}),
   })),
 }));
-vi.mock("../voice-transport-client.registry", () => ({
-  voiceTransportClientRegistry: { elevenlabs_convai: { openCall } },
-}));
+vi.mock("../voice-transport-client.registry", () => {
+  const registry: Record<string, { openCall: typeof openCall }> = {
+    elevenlabs_convai: { openCall },
+  };
+  return {
+    voiceTransportClientRegistry: registry,
+    getVoiceTransportClient: (transport: string) => registry[transport],
+  };
+});
 
-import { TalkToItPanel } from "../TalkToItPanel";
+import { PHONE_NO_BROWSER_CALL_NOTICE, TalkToItPanel } from "../TalkToItPanel";
 import {
   CONSENT_NOTICE,
   MIC_BLOCKED_MESSAGE,
@@ -74,6 +80,27 @@ describe("TalkToItPanel", () => {
           CONSENT_NOTICE,
         );
       });
+    });
+  });
+
+  describe("when the transport is a phone target", () => {
+    /** @scenario "A phone target has no browser call" */
+    it("shows the phone notice and never opens a browser call", async () => {
+      render(
+        <TalkToItPanel
+          projectId="p1"
+          projectSlug="proj"
+          transport="phone"
+          agentId=""
+        />,
+        { wrapper: Wrapper },
+      );
+      await waitFor(() => {
+        expect(
+          screen.getByTestId("talk-phone-no-browser-notice"),
+        ).toHaveTextContent(PHONE_NO_BROWSER_CALL_NOTICE);
+      });
+      expect(openCall).not.toHaveBeenCalled();
     });
   });
 

--- a/platform/app/src/components/agents/voice/__tests__/TalkToItPanel.integration.test.tsx
+++ b/platform/app/src/components/agents/voice/__tests__/TalkToItPanel.integration.test.tsx
@@ -131,6 +131,9 @@ describe("TalkToItPanel", () => {
 
       const player = await screen.findByTestId("talk-play");
       expect(player.querySelector("audio")).toHaveAttribute("src", audioUrl);
+      // A drawer call is not a run (#8020): the panel offers no run link, only
+      // the transcript and the Play control.
+      expect(screen.queryByTestId("talk-run-link")).toBeNull();
     });
   });
 

--- a/platform/app/src/components/agents/voice/useVoicePhoneTargetsEnabled.ts
+++ b/platform/app/src/components/agents/voice/useVoicePhoneTargetsEnabled.ts
@@ -1,0 +1,35 @@
+/**
+ * Whether the Phone number transport option is offered in the voice agent
+ * drawer for the current project.
+ *
+ * Mirrors {@link useVoiceAgentsEnabled}: it reads
+ * `release_voice_phone_targets_enabled` with the ids from
+ * `useOrganizationTeamProject`, so the drawer gates the option the same way
+ * every other flag surface reads its flag. Off until the voice worker that
+ * dials phone targets ships (#8014); an existing phone target still renders its
+ * fields regardless of this flag, so the gate is on the OPTION only.
+ *
+ * @see specs/features/agents/voice-phone.feature
+ */
+
+import { useFeatureFlag } from "~/hooks/useFeatureFlag";
+import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
+import { NOT_TARGETED } from "~/server/featureFlag/targeting";
+
+export const VOICE_PHONE_TARGETS_FLAG_KEY =
+  "release_voice_phone_targets_enabled" as const;
+
+export function useVoicePhoneTargetsEnabled(): boolean {
+  const { project, organization } = useOrganizationTeamProject({
+    redirectToOnboarding: false,
+    redirectToProjectOnboarding: false,
+  });
+
+  const { enabled, isLoading } = useFeatureFlag(VOICE_PHONE_TARGETS_FLAG_KEY, {
+    projectId: project?.id ?? NOT_TARGETED,
+    organizationId: organization?.id,
+    enabled: !!organization?.id,
+  });
+
+  return !isLoading && enabled;
+}

--- a/platform/app/src/components/agents/voice/voice-transport-client.registry.ts
+++ b/platform/app/src/components/agents/voice/voice-transport-client.registry.ts
@@ -38,9 +38,20 @@ export interface VoiceTransportClient {
   }): Promise<VoiceCallSession>;
 }
 
-export const voiceTransportClientRegistry: Record<
-  VoiceTransport,
-  VoiceTransportClient
+/**
+ * Not every transport has a browser client: a phone target is dialled from the
+ * voice worker, not the browser, so it has no "Talk to it" client at all. The
+ * registry is a partial map, and {@link getVoiceTransportClient} returns
+ * `undefined` for a transport with no browser call.
+ */
+export const voiceTransportClientRegistry: Partial<
+  Record<VoiceTransport, VoiceTransportClient>
 > = {
   elevenlabs_convai: elevenLabsConvaiClient,
 };
+
+/** The browser client for a transport, or `undefined` when it has none (phone
+ *  targets are called from a scenario run, never from the browser). */
+export const getVoiceTransportClient = (
+  transport: VoiceTransport,
+): VoiceTransportClient | undefined => voiceTransportClientRegistry[transport];

--- a/platform/app/src/components/simulations/ScenarioMessageRenderer.tsx
+++ b/platform/app/src/components/simulations/ScenarioMessageRenderer.tsx
@@ -61,6 +61,10 @@ interface ScenarioMessageRendererProps {
   projectId: string;
   /** Whose message the run is waiting for, drawn as dots under the thread. */
   typingRole?: NextSpeaker;
+  /** True when the run's "user" turns were spoken by a real person (a voice
+   *  "Call it myself" run), so they render as "You", not "User Simulator"
+   *  (#8020). */
+  isHumanCaller?: boolean;
 }
 
 export function ScenarioMessageRenderer({
@@ -69,6 +73,7 @@ export function ScenarioMessageRenderer({
   variant,
   projectId,
   typingRole,
+  isHumanCaller = false,
 }: ScenarioMessageRendererProps) {
   const smallerView = variant === "grid";
   const endRef = useRef<HTMLDivElement>(null);
@@ -116,7 +121,7 @@ export function ScenarioMessageRenderer({
         // (right/purple, flask icon).
         const visuals = getDisplayRoleVisuals(
           item.role === "assistant" ? "assistant" : "user",
-          { isScenario: true },
+          { isScenario: true, isHumanCaller },
         );
         const RoleIcon = visuals.Icon;
         return (

--- a/platform/app/src/components/simulations/ScenarioRunDetailDrawer.tsx
+++ b/platform/app/src/components/simulations/ScenarioRunDetailDrawer.tsx
@@ -10,6 +10,7 @@ import {
 } from "@chakra-ui/react";
 import { ChevronsDownUp, ChevronsUpDown, Inbox } from "lucide-react";
 import { lazy, Suspense, useCallback, useState } from "react";
+import { isHumanCallerRun } from "~/components/agent-testing/results/caller-display";
 import { CopyButton } from "~/components/CopyButton";
 import { RunScenarioModal } from "~/components/scenarios/RunScenarioModal";
 import { ScenarioFormDrawer } from "~/components/scenarios/ScenarioFormDrawer";
@@ -440,10 +441,7 @@ function ClassicScenarioRunDetailDrawer({
                         projectId={project?.id ?? ""}
                         // A voice "Call it myself" caller is a real person, so
                         // their turns read as "You", not "User Simulator" (#8020).
-                        isHumanCaller={
-                          scenarioState.metadata?.langwatch?.callerKind ===
-                          "human"
-                        }
+                        isHumanCaller={isHumanCallerRun(scenarioState.metadata)}
                       />
                     </ConversationExpandContext.Provider>
                   </RunDetailSection>

--- a/platform/app/src/components/simulations/ScenarioRunDetailDrawer.tsx
+++ b/platform/app/src/components/simulations/ScenarioRunDetailDrawer.tsx
@@ -438,6 +438,12 @@ function ClassicScenarioRunDetailDrawer({
                         streamingMessages={streamingMessages}
                         variant="drawer"
                         projectId={project?.id ?? ""}
+                        // A voice "Call it myself" caller is a real person, so
+                        // their turns read as "You", not "User Simulator" (#8020).
+                        isHumanCaller={
+                          scenarioState.metadata?.langwatch?.callerKind ===
+                          "human"
+                        }
                       />
                     </ConversationExpandContext.Provider>
                   </RunDetailSection>

--- a/platform/app/src/features/errors/logic/codes.ts
+++ b/platform/app/src/features/errors/logic/codes.ts
@@ -441,6 +441,7 @@ export const APP_ERROR_CODES = [
   "voice_key_missing",
   "voice_mint_failed",
   "voice_name_required",
+  "voice_phone_transport_unavailable",
   "voice_recording_key_missing",
   "voice_recording_unavailable",
   "voice_session_invalid",

--- a/platform/app/src/features/errors/logic/presentation.ts
+++ b/platform/app/src/features/errors/logic/presentation.ts
@@ -3222,6 +3222,11 @@ const presentations = {
     title: "A name is required to save the agent",
     describe: () => "",
   },
+  voice_phone_transport_unavailable: {
+    title: "Phone targets are not available yet",
+    describe: () =>
+      "Phone targets are called from the voice worker, which is not available yet. Track langwatch/langwatch#8014.",
+  },
   voice_recording_unavailable: {
     title: "The call recording is not available",
     describe: () => "",

--- a/platform/app/src/features/traces-v2/components/TraceDrawer/TraceDrawerContent.tsx
+++ b/platform/app/src/features/traces-v2/components/TraceDrawer/TraceDrawerContent.tsx
@@ -172,6 +172,10 @@ export function TraceDrawerContent({
                 isScenario={
                   !!(trace.scenarioRunId ?? trace.attributes["scenario.run_id"])
                 }
+                // A voice call's caller is a real person: their side reads as
+                // "You", not the "User Simulator" the scenario swap would
+                // otherwise apply (#8020). Stamped by the voice trace writer.
+                isHumanCaller={trace.attributes["voice.call.caller"] === "human"}
               >
                 {/* Conversation view is suppressed for read-only share
                     viewers: it is backed by `tracesV2.list` (disabled without

--- a/platform/app/src/features/traces-v2/components/TraceDrawer/TraceDrawerContent.tsx
+++ b/platform/app/src/features/traces-v2/components/TraceDrawer/TraceDrawerContent.tsx
@@ -175,7 +175,9 @@ export function TraceDrawerContent({
                 // A voice call's caller is a real person: their side reads as
                 // "You", not the "User Simulator" the scenario swap would
                 // otherwise apply (#8020). Stamped by the voice trace writer.
-                isHumanCaller={trace.attributes["voice.call.caller"] === "human"}
+                isHumanCaller={
+                  trace.attributes["voice.call.caller"] === "human"
+                }
               >
                 {/* Conversation view is suppressed for read-only share
                     viewers: it is backed by `tracesV2.list` (disabled without

--- a/platform/app/src/features/traces-v2/components/TraceDrawer/__tests__/scenarioRoles.unit.test.ts
+++ b/platform/app/src/features/traces-v2/components/TraceDrawer/__tests__/scenarioRoles.unit.test.ts
@@ -1,0 +1,60 @@
+/**
+ * @vitest-environment node
+ *
+ * The scenario role swap normally renders a run's "user" side as the LLM "User
+ * Simulator". On a voice "Call it myself" run the caller is a real person, so
+ * their turns read as "You" instead (#8020, decision 5).
+ *
+ * @see specs/features/agents/voice-agents-v1.feature
+ */
+import { describe, expect, it } from "vitest";
+import { getDisplayRoleVisuals } from "../scenarioRoles";
+
+describe("getDisplayRoleVisuals", () => {
+  describe("given a scenario run", () => {
+    describe("when the user turn is an LLM user-simulator", () => {
+      it("labels it User Simulator", () => {
+        const visuals = getDisplayRoleVisuals("user", { isScenario: true });
+
+        expect(visuals.label).toBe("USER SIMULATOR");
+        expect(visuals.bubbleLabel).toBe("User Simulator");
+      });
+    });
+
+    describe("when the user turn is a real human caller", () => {
+      /** @scenario "A human caller's turns render as You, not User Simulator" */
+      it("labels it You with a person icon, not a flask", () => {
+        const simulator = getDisplayRoleVisuals("user", { isScenario: true });
+        const human = getDisplayRoleVisuals("user", {
+          isScenario: true,
+          isHumanCaller: true,
+        });
+
+        expect(human.label).toBe("YOU");
+        expect(human.bubbleLabel).toBe("You");
+        // A different icon than the flask the simulator carries.
+        expect(human.Icon).not.toBe(simulator.Icon);
+      });
+
+      it("does not relabel the agent side", () => {
+        const agent = getDisplayRoleVisuals("assistant", {
+          isScenario: true,
+          isHumanCaller: true,
+        });
+
+        expect(agent.bubbleLabel).toBe("Agent");
+      });
+    });
+  });
+
+  describe("given a non-scenario trace", () => {
+    it("ignores the human-caller flag and keeps the plain User label", () => {
+      const visuals = getDisplayRoleVisuals("user", {
+        isScenario: false,
+        isHumanCaller: true,
+      });
+
+      expect(visuals.bubbleLabel).toBe("User");
+    });
+  });
+});

--- a/platform/app/src/features/traces-v2/components/TraceDrawer/scenarioRoles.tsx
+++ b/platform/app/src/features/traces-v2/components/TraceDrawer/scenarioRoles.tsx
@@ -105,7 +105,7 @@ export function getDisplayRoleVisuals(
   }
   // The user side of a scenario run is normally an LLM user-simulator. On a
   // voice "Call it myself" run it is the person who spoke the call, so it reads
-  // as "You" — keeping the same side, but a human icon and no flask (#8020).
+  // as "You", keeping the same side, but a human icon and no flask (#8020).
   if (role === "user") {
     return isHumanCaller
       ? {

--- a/platform/app/src/features/traces-v2/components/TraceDrawer/scenarioRoles.tsx
+++ b/platform/app/src/features/traces-v2/components/TraceDrawer/scenarioRoles.tsx
@@ -21,36 +21,50 @@ import { create } from "zustand";
 
 interface ScenarioRoleState {
   isScenario: boolean;
-  setIsScenario: (value: boolean) => void;
+  /** True when the "user" side of this run is a real person who spoke on the
+   *  call (a voice "Call it myself" run), not an LLM user-simulator. Their
+   *  turns read as "You" rather than "User Simulator" (#8020). */
+  isHumanCaller: boolean;
+  setScenarioRole: (value: {
+    isScenario: boolean;
+    isHumanCaller: boolean;
+  }) => void;
 }
 
 const useScenarioRoleStore = create<ScenarioRoleState>((set) => ({
   isScenario: false,
-  setIsScenario: (value) => set({ isScenario: value }),
+  isHumanCaller: false,
+  setScenarioRole: (value) => set(value),
 }));
 
 /**
- * Sets the scenario flag for the lifetime of the wrapping component.
+ * Sets the scenario flags for the lifetime of the wrapping component.
  * Replaces a prior React Context (banned by traces-v2 STANDARDS §2). Only
  * one drawer mounts at a time, so the single shared store is safe.
  */
 export function ScenarioRoleProvider({
   isScenario,
+  isHumanCaller = false,
   children,
 }: {
   isScenario: boolean;
+  isHumanCaller?: boolean;
   children: ReactNode;
 }) {
-  const setIsScenario = useScenarioRoleStore((s) => s.setIsScenario);
+  const setScenarioRole = useScenarioRoleStore((s) => s.setScenarioRole);
   useEffect(() => {
-    setIsScenario(isScenario);
-    return () => setIsScenario(false);
-  }, [isScenario, setIsScenario]);
+    setScenarioRole({ isScenario, isHumanCaller });
+    return () => setScenarioRole({ isScenario: false, isHumanCaller: false });
+  }, [isScenario, isHumanCaller, setScenarioRole]);
   return <>{children}</>;
 }
 
 export function useIsScenarioRole(): boolean {
   return useScenarioRoleStore((s) => s.isScenario);
+}
+
+export function useIsHumanCaller(): boolean {
+  return useScenarioRoleStore((s) => s.isHumanCaller);
 }
 
 export type SourceRole = "user" | "assistant";
@@ -69,7 +83,10 @@ export interface DisplayRoleVisuals {
 
 export function getDisplayRoleVisuals(
   role: SourceRole,
-  { isScenario }: { isScenario: boolean },
+  {
+    isScenario,
+    isHumanCaller = false,
+  }: { isScenario: boolean; isHumanCaller?: boolean },
 ): DisplayRoleVisuals {
   if (!isScenario) {
     return role === "user"
@@ -86,23 +103,35 @@ export function getDisplayRoleVisuals(
           Icon: LuBot,
         };
   }
-  return role === "user"
-    ? {
-        displayRole: "assistant",
-        label: "USER SIMULATOR",
-        bubbleLabel: "User Simulator",
-        Icon: LuFlaskConical,
-      }
-    : {
-        displayRole: "user",
-        label: "AGENT",
-        bubbleLabel: "Agent",
-        Icon: LuBot,
-      };
+  // The user side of a scenario run is normally an LLM user-simulator. On a
+  // voice "Call it myself" run it is the person who spoke the call, so it reads
+  // as "You" — keeping the same side, but a human icon and no flask (#8020).
+  if (role === "user") {
+    return isHumanCaller
+      ? {
+          displayRole: "assistant",
+          label: "YOU",
+          bubbleLabel: "You",
+          Icon: LuUser,
+        }
+      : {
+          displayRole: "assistant",
+          label: "USER SIMULATOR",
+          bubbleLabel: "User Simulator",
+          Icon: LuFlaskConical,
+        };
+  }
+  return {
+    displayRole: "user",
+    label: "AGENT",
+    bubbleLabel: "Agent",
+    Icon: LuBot,
+  };
 }
 
 /** Hook variant — consumes scenario state and returns visuals in one call. */
 export function useDisplayRoleVisuals(role: SourceRole): DisplayRoleVisuals {
   const isScenario = useIsScenarioRole();
-  return getDisplayRoleVisuals(role, { isScenario });
+  const isHumanCaller = useIsHumanCaller();
+  return getDisplayRoleVisuals(role, { isScenario, isHumanCaller });
 }

--- a/platform/app/src/server/agents/__tests__/agent.service.voice-create.integration.test.ts
+++ b/platform/app/src/server/agents/__tests__/agent.service.voice-create.integration.test.ts
@@ -1,0 +1,110 @@
+/**
+ * @vitest-environment node
+ *
+ * {@link AgentService.createVoiceAgent} against a real database: a retried
+ * drawer finish for an unsaved agent reuses the one row, and two finishes
+ * racing the same not-yet-saved agent still settle on one row (#8020,
+ * decision 1). The unit test covers the same contract against a mocked
+ * repository; this proves it against Postgres's own unique constraint.
+ *
+ * @see specs/features/agents/voice-agents-v1.feature
+ */
+import { nanoid } from "nanoid";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { prisma } from "~/server/db";
+import { cleanupTestRows } from "~/test-utils/cleanupTestRows";
+import { getTestUser } from "~/utils/testUtils";
+import { AgentService } from "../agent.service";
+import { voiceAgentIdentityKey } from "../voice/voice-agent.config";
+
+const projectId = `test-voice-agent-${nanoid(8)}`;
+
+const service = AgentService.create(prisma);
+
+beforeAll(async () => {
+  await getTestUser();
+  const organization = await prisma.organization.findUnique({
+    where: { slug: "test-organization" },
+  });
+  const team = await prisma.team.findFirst({
+    where: { slug: "test-team", organizationId: organization!.id },
+  });
+  await prisma.project.create({
+    data: {
+      id: projectId,
+      name: projectId,
+      slug: projectId,
+      apiKey: `sk-lw-${projectId}`,
+      teamId: team!.id,
+      language: "en",
+      framework: "test",
+    },
+  });
+});
+
+afterAll(async () => {
+  await cleanupTestRows(prisma, [
+    ["agent", { projectId }],
+    ["project", { id: projectId }],
+  ]);
+});
+
+describe("AgentService.createVoiceAgent", () => {
+  describe("when the same voice identity registers twice", () => {
+    /** @scenario "A retried drawer finish for an unsaved agent reuses the one agent row" */
+    it("reuses the same row instead of creating a second", async () => {
+      const agentExternalId = `el_agent_${nanoid(6)}`;
+      const input = {
+        id: `agent_${nanoid()}`,
+        projectId,
+        name: "Support line",
+        transport: "elevenlabs_convai" as const,
+        agentId: agentExternalId,
+      };
+
+      const first = await service.createVoiceAgent(input);
+      const second = await service.createVoiceAgent({
+        ...input,
+        id: `agent_${nanoid()}`,
+      });
+
+      expect(second.id).toBe(first.id);
+      const identityKey = voiceAgentIdentityKey({
+        transport: input.transport,
+        agentExternalId,
+      });
+      const rows = await prisma.agent.findMany({
+        where: { projectId, identityKey },
+      });
+      expect(rows).toHaveLength(1);
+    });
+  });
+
+  describe("when two finishes race to create the same unsaved agent", () => {
+    /** @scenario "A retried drawer finish for an unsaved agent reuses the one agent row" */
+    it("settles on one row under a concurrent double create", async () => {
+      const agentExternalId = `el_agent_${nanoid(6)}`;
+      const input = {
+        projectId,
+        name: "Support line",
+        transport: "elevenlabs_convai" as const,
+        agentId: agentExternalId,
+      };
+
+      const [first, second] = await Promise.all([
+        service.createVoiceAgent({ ...input, id: `agent_${nanoid()}` }),
+        service.createVoiceAgent({ ...input, id: `agent_${nanoid()}` }),
+      ]);
+
+      expect(second.id).toBe(first.id);
+      const identityKey = voiceAgentIdentityKey({
+        transport: input.transport,
+        agentExternalId,
+      });
+      const rows = await prisma.agent.findMany({
+        where: { projectId, identityKey },
+      });
+      expect(rows).toHaveLength(1);
+    });
+  });
+});

--- a/platform/app/src/server/agents/__tests__/agent.service.voice-create.unit.test.ts
+++ b/platform/app/src/server/agents/__tests__/agent.service.voice-create.unit.test.ts
@@ -1,0 +1,108 @@
+/**
+ * @vitest-environment node
+ *
+ * {@link AgentService.createVoiceAgent} folds a voice agent onto one row by its
+ * identity key, so a first "Talk to it" hang-up before the agent is saved — or
+ * two tabs racing the same not-yet-saved agent — cannot create a second row
+ * (#8020, decision 1). This replaces the old run-based guard, which stopped
+ * covering the drawer path once a drawer call no longer writes a run.
+ *
+ * @see specs/features/agents/voice-agents-v1.feature
+ */
+import { describe, expect, it, vi } from "vitest";
+import type { PrismaClient } from "~/generated/prisma/client";
+import { voiceAgentIdentityKey } from "~/server/agents/voice/voice-agent.config";
+import { AgentRepository, type TypedAgent } from "../agent.repository";
+import { AgentService } from "../agent.service";
+
+const IDENTITY_KEY = voiceAgentIdentityKey({
+  transport: "elevenlabs_convai",
+  agentExternalId: "el_agent_1",
+});
+
+function voiceRow(id: string): TypedAgent {
+  return {
+    id,
+    projectId: "project_1",
+    name: "Support line",
+    type: "voice",
+    config: { transport: "elevenlabs_convai", agentId: "el_agent_1" },
+    identityKey: IDENTITY_KEY,
+  } as unknown as TypedAgent;
+}
+
+const INPUT = {
+  id: "agent_new",
+  projectId: "project_1",
+  name: "Support line",
+  transport: "elevenlabs_convai" as const,
+  agentId: "el_agent_1",
+};
+
+function serviceWith(repo: Partial<AgentRepository>): AgentService {
+  return new AgentService(
+    {} as unknown as PrismaClient,
+    repo as unknown as AgentRepository,
+  );
+}
+
+describe("AgentService.createVoiceAgent", () => {
+  describe("given a row already exists for the identity key", () => {
+    /** @scenario "A retried drawer finish for an unsaved agent reuses the one agent row" */
+    it("reuses the existing row without creating a second", async () => {
+      const create = vi.fn();
+      const findByIdentityKey = vi.fn(async () => voiceRow("agent_existing"));
+      const service = serviceWith({ findByIdentityKey, create });
+
+      const result = await service.createVoiceAgent(INPUT);
+
+      expect(result.id).toBe("agent_existing");
+      expect(findByIdentityKey).toHaveBeenCalledWith({
+        projectId: "project_1",
+        identityKey: IDENTITY_KEY,
+      });
+      expect(create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("given no row yet for the identity key", () => {
+    it("creates the row carrying that identity key", async () => {
+      const findByIdentityKey = vi.fn(async () => null);
+      const create = vi.fn(async () => voiceRow("agent_new"));
+      const service = serviceWith({ findByIdentityKey, create });
+
+      const result = await service.createVoiceAgent(INPUT);
+
+      expect(result.id).toBe("agent_new");
+      expect(create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          projectId: "project_1",
+          type: "voice",
+          config: { transport: "elevenlabs_convai", agentId: "el_agent_1" },
+          identityKey: IDENTITY_KEY,
+        }),
+      );
+    });
+  });
+
+  describe("given two finishes race to create the same unsaved agent", () => {
+    /** @scenario "A retried drawer finish for an unsaved agent reuses the one agent row" */
+    it("reuses the winner's row on a unique-key race", async () => {
+      // First lookup sees nothing; the create hits the unique constraint the
+      // winner already wrote; the re-read returns the winner's row.
+      const findByIdentityKey = vi
+        .fn()
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(voiceRow("agent_winner"));
+      const create = vi.fn(async () => {
+        throw { code: "P2002" };
+      });
+      const service = serviceWith({ findByIdentityKey, create });
+
+      const result = await service.createVoiceAgent(INPUT);
+
+      expect(result.id).toBe("agent_winner");
+      expect(findByIdentityKey).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/platform/app/src/server/agents/__tests__/agent.service.voice-create.unit.test.ts
+++ b/platform/app/src/server/agents/__tests__/agent.service.voice-create.unit.test.ts
@@ -12,7 +12,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type { PrismaClient } from "~/generated/prisma/client";
 import { voiceAgentIdentityKey } from "~/server/agents/voice/voice-agent.config";
-import { AgentRepository, type TypedAgent } from "../agent.repository";
+import type { AgentRepository, TypedAgent } from "../agent.repository";
 import { AgentService } from "../agent.service";
 
 const IDENTITY_KEY = voiceAgentIdentityKey({

--- a/platform/app/src/server/agents/__tests__/agent.service.voice-create.unit.test.ts
+++ b/platform/app/src/server/agents/__tests__/agent.service.voice-create.unit.test.ts
@@ -2,8 +2,8 @@
  * @vitest-environment node
  *
  * {@link AgentService.createVoiceAgent} folds a voice agent onto one row by its
- * identity key, so a first "Talk to it" hang-up before the agent is saved — or
- * two tabs racing the same not-yet-saved agent — cannot create a second row
+ * identity key, so a first "Talk to it" hang-up before the agent is saved (or
+ * two tabs racing the same not-yet-saved agent) cannot create a second row
  * (#8020, decision 1). This replaces the old run-based guard, which stopped
  * covering the drawer path once a drawer call no longer writes a run.
  *

--- a/platform/app/src/server/agents/agent.repository.ts
+++ b/platform/app/src/server/agents/agent.repository.ts
@@ -121,6 +121,13 @@ export type CreateAgentInput = {
   copiedFromAgentId?: string;
   /** The identity of a connected agent (ADR-128); unset for every other type. */
   identity?: ConnectedAgentIdentity;
+  /** The natural key a non-connected agent dedups on, sharing the same
+   *  `(projectId, identityKey)` unique constraint as a connected agent's
+   *  {@link ConnectedAgentIdentity.identityKey}. Voice agents set it so a first
+   *  hang-up before the row is saved cannot create a second row on a retry
+   *  (#8020). Distinct from `identity`, which also carries the connected-only
+   *  environment/scope/lastSeenAt fields; unset for a connected agent. */
+  identityKey?: string;
 };
 
 /**
@@ -338,6 +345,12 @@ export class AgentRepository {
           identityKey: input.identity.identityKey,
           lastSeenAt: new Date(),
         }),
+        // A non-connected agent's natural key, without the connected-only
+        // environment/scope/lastSeenAt fields. Mutually exclusive with
+        // `identity` in practice, so this never overrides that block's key.
+        ...(input.identityKey && !input.identity
+          ? { identityKey: input.identityKey }
+          : {}),
       },
     });
 

--- a/platform/app/src/server/agents/agent.repository.ts
+++ b/platform/app/src/server/agents/agent.repository.ts
@@ -358,8 +358,9 @@ export class AgentRepository {
   }
 
   /**
-   * Finds a connected agent by its identity key, whatever its state, so a
-   * process that registers the same identity writes the row it already has.
+   * Finds an agent by its natural key (identity key), whatever its state, so
+   * a process that registers the same identity writes the row it already
+   * has. Used by both connected agents and voice agents.
    */
   async findByIdentityKey(input: {
     projectId: string;

--- a/platform/app/src/server/agents/agent.service.ts
+++ b/platform/app/src/server/agents/agent.service.ts
@@ -5,6 +5,10 @@ import type {
   ConnectedComponentConfig,
   Workflow,
 } from "~/optimization_studio/types/dsl";
+import {
+  type VoiceTransport,
+  voiceAgentIdentityKey,
+} from "~/server/agents/voice/voice-agent.config";
 import type { ScenarioParameterDefinition } from "~/server/scenarios/parameters";
 import type { RunActor } from "~/server/scenarios/run-actor";
 import {
@@ -219,6 +223,53 @@ export class AgentService {
       projectId: input.projectId,
     });
     return enriched!;
+  }
+
+  /**
+   * Creates the voice agent row a "Talk to it" call is saved under on first
+   * hang-up, deduped by its natural identity key so a retried finish for a
+   * not-yet-saved agent — or two browser tabs racing the same one — reuses the
+   * one row rather than creating a second (#8020, decision 1). This replaces the
+   * old run-based guard, which stopped covering the drawer path once a drawer
+   * call no longer writes a run.
+   *
+   * Race-safe the same way {@link registerConnected} is: look up the identity
+   * key, create, and on the unique-constraint race re-read and reuse the winner.
+   */
+  async createVoiceAgent(input: {
+    id: string;
+    projectId: string;
+    name: string;
+    transport: VoiceTransport;
+    agentId: string;
+  }): Promise<TypedAgent> {
+    const identityKey = voiceAgentIdentityKey({
+      transport: input.transport,
+      agentExternalId: input.agentId,
+    });
+    const existing = await this.repository.findByIdentityKey({
+      projectId: input.projectId,
+      identityKey,
+    });
+    if (existing) return existing;
+    try {
+      return await this.repository.create({
+        id: input.id,
+        projectId: input.projectId,
+        name: input.name,
+        type: "voice",
+        config: { transport: input.transport, agentId: input.agentId },
+        identityKey,
+      });
+    } catch (error) {
+      if (!isUniqueConstraintViolation(error)) throw error;
+      const raced = await this.repository.findByIdentityKey({
+        projectId: input.projectId,
+        identityKey,
+      });
+      if (!raced) throw error;
+      return raced;
+    }
   }
 
   /**

--- a/platform/app/src/server/agents/agent.service.ts
+++ b/platform/app/src/server/agents/agent.service.ts
@@ -6,6 +6,7 @@ import type {
   Workflow,
 } from "~/optimization_studio/types/dsl";
 import {
+  type VoiceAgentConfig,
   type VoiceTransport,
   voiceAgentIdentityKey,
 } from "~/server/agents/voice/voice-agent.config";
@@ -252,13 +253,21 @@ export class AgentService {
       identityKey,
     });
     if (existing) return existing;
+    // The external id (agentId) carries the identity for either transport: the
+    // ElevenLabs agent id, or the phone number. Store it under the field the
+    // transport's config member names, narrowing so the discriminated union
+    // stays valid without a cast.
+    const config: VoiceAgentConfig =
+      input.transport === "phone"
+        ? { transport: "phone", phoneNumber: input.agentId }
+        : { transport: input.transport, agentId: input.agentId };
     try {
       return await this.repository.create({
         id: input.id,
         projectId: input.projectId,
         name: input.name,
         type: "voice",
-        config: { transport: input.transport, agentId: input.agentId },
+        config,
         identityKey,
       });
     } catch (error) {

--- a/platform/app/src/server/agents/agent.service.ts
+++ b/platform/app/src/server/agents/agent.service.ts
@@ -273,6 +273,27 @@ export class AgentService {
   }
 
   /**
+   * Whether this project saved a voice agent for the given vendor agent id,
+   * matched on the identity key drawer hang-up dedupes rows by. Used to
+   * authorize recording playback for a drawer call, which writes no run (#8020).
+   */
+  async hasVoiceAgentForExternalId(input: {
+    projectId: string;
+    transport: VoiceTransport;
+    agentExternalId: string;
+  }): Promise<boolean> {
+    const identityKey = voiceAgentIdentityKey({
+      transport: input.transport,
+      agentExternalId: input.agentExternalId,
+    });
+    const agent = await this.repository.findByIdentityKey({
+      projectId: input.projectId,
+      identityKey,
+    });
+    return agent?.type === "voice";
+  }
+
+  /**
    * Updates an existing agent.
    *
    * A connected agent takes no edit at all: the row is what the SDK

--- a/platform/app/src/server/agents/agent.service.ts
+++ b/platform/app/src/server/agents/agent.service.ts
@@ -228,7 +228,7 @@ export class AgentService {
   /**
    * Creates the voice agent row a "Talk to it" call is saved under on first
    * hang-up, deduped by its natural identity key so a retried finish for a
-   * not-yet-saved agent — or two browser tabs racing the same one — reuses the
+   * not-yet-saved agent (or two browser tabs racing the same one) reuses the
    * one row rather than creating a second (#8020, decision 1). This replaces the
    * old run-based guard, which stopped covering the drawer path once a drawer
    * call no longer writes a run.

--- a/platform/app/src/server/agents/voice/__tests__/voice-agent.config.unit.test.ts
+++ b/platform/app/src/server/agents/voice/__tests__/voice-agent.config.unit.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   parseVoiceAgentConfig,
   voiceAgentConfigSchema,
+  voiceAgentExternalId,
 } from "../voice-agent.config";
 
 describe("voiceAgentConfigSchema", () => {
@@ -40,11 +41,67 @@ describe("voiceAgentConfigSchema", () => {
       /** @scenario "A voice agent config with an unrecognised transport is rejected" */
       it("rejects it", () => {
         const result = voiceAgentConfigSchema.safeParse({
-          transport: "phone",
+          transport: "carrier_pigeon",
           agentId: "agent_123",
         });
         expect(result.success).toBe(false);
       });
+    });
+  });
+
+  describe("given a phone transport with an E.164 number", () => {
+    describe("when the config is validated", () => {
+      /** @scenario "A phone target stores its number in E.164 form" */
+      it("accepts it and trims the number", () => {
+        const parsed = parseVoiceAgentConfig({
+          transport: "phone",
+          phoneNumber: "  +14155550123  ",
+        });
+        expect(parsed).toEqual({
+          transport: "phone",
+          phoneNumber: "+14155550123",
+        });
+      });
+    });
+  });
+
+  describe("given a phone transport whose number is not E.164", () => {
+    describe("when the config is validated", () => {
+      /** @scenario "A phone target rejects a number that is not E.164" */
+      it("rejects it", () => {
+        const rejected = ["415-555-0123", "+0123456789", "+1234567890123456"];
+        for (const phoneNumber of rejected) {
+          const result = voiceAgentConfigSchema.safeParse({
+            transport: "phone",
+            phoneNumber,
+          });
+          expect(result.success).toBe(false);
+        }
+      });
+    });
+  });
+});
+
+describe("voiceAgentExternalId", () => {
+  describe("given an ElevenLabs transport", () => {
+    it("returns the agent id", () => {
+      expect(
+        voiceAgentExternalId({
+          transport: "elevenlabs_convai",
+          agentId: "agent_123",
+        }),
+      ).toBe("agent_123");
+    });
+  });
+
+  describe("given a phone transport", () => {
+    it("returns the phone number", () => {
+      expect(
+        voiceAgentExternalId({
+          transport: "phone",
+          phoneNumber: "+14155550123",
+        }),
+      ).toBe("+14155550123");
     });
   });
 });

--- a/platform/app/src/server/agents/voice/voice-agent.config.ts
+++ b/platform/app/src/server/agents/voice/voice-agent.config.ts
@@ -40,7 +40,26 @@ export const VOICE_TRANSPORT_PROVIDER: Record<VoiceTransport, "elevenlabs"> = {
 export const parseVoiceAgentConfig = (config: unknown): VoiceAgentConfig =>
   voiceAgentConfigSchema.parse(config);
 
-/** The scenario set every drawer "Talk to it" call is written into, so those
- *  runs group apart from scenario runs. Client-safe (the panel builds the run
- *  link from it; the run writer writes into it). */
+/**
+ * The legacy scenario set drawer "Talk to it" calls used to be written into,
+ * before #8020 stopped persisting a drawer call as a run. Nothing is written
+ * here any more (a drawer call now leaves only its per-exchange traces), but
+ * pre-#8020 `voicecall_` runs still carry this set id in ClickHouse, so run
+ * listings exclude it (see `AGENT_TEST_SET_EXCLUSION`). A run someone has a
+ * direct link to still opens by its own id.
+ */
 export const VOICE_CALL_SCENARIO_SET_ID = "voice-calls";
+
+/**
+ * The natural key that folds every "Talk to it" against the same vendor agent
+ * onto one row, so a first hang-up before the agent is saved cannot create a
+ * second agent row on a retry (or from two browser tabs racing). Shares the
+ * `(projectId, identityKey)` unique constraint the connected agents use.
+ */
+export const voiceAgentIdentityKey = ({
+  transport,
+  agentExternalId,
+}: {
+  transport: VoiceTransport;
+  agentExternalId: string;
+}): string => `voice:${transport}:${agentExternalId}`;

--- a/platform/app/src/server/agents/voice/voice-agent.config.ts
+++ b/platform/app/src/server/agents/voice/voice-agent.config.ts
@@ -14,7 +14,7 @@
 import { z } from "zod";
 
 /** Every transport a voice agent can be reached through. */
-export const VOICE_TRANSPORTS = ["elevenlabs_convai"] as const;
+export const VOICE_TRANSPORTS = ["elevenlabs_convai", "phone"] as const;
 export type VoiceTransport = (typeof VOICE_TRANSPORTS)[number];
 
 export const elevenLabsConvaiTransportSchema = z.object({
@@ -22,23 +22,64 @@ export const elevenLabsConvaiTransportSchema = z.object({
   agentId: z.string().trim().min(1, "Agent id is required").max(128),
 });
 
+/**
+ * E.164: a leading `+`, a non-zero country code digit, then up to 14 more
+ * digits. The number is the whole identity of a phone target, so it is
+ * validated at the schema boundary rather than trusted from the form.
+ */
+export const E164_PHONE_PATTERN = /^\+[1-9]\d{1,14}$/;
+
+export const phoneTransportSchema = z.object({
+  transport: z.literal("phone"),
+  phoneNumber: z
+    .string()
+    .trim()
+    .regex(
+      E164_PHONE_PATTERN,
+      "Enter the number in E.164 form, like +14155550123",
+    ),
+});
+
 export const voiceAgentConfigSchema = z.discriminatedUnion("transport", [
   elevenLabsConvaiTransportSchema,
+  phoneTransportSchema,
 ]);
 export type VoiceAgentConfig = z.infer<typeof voiceAgentConfigSchema>;
 
 /** The words a customer reads for each transport in the drawer. */
 export const VOICE_TRANSPORT_LABELS: Record<VoiceTransport, string> = {
   elevenlabs_convai: "ElevenLabs agent",
+  phone: "Phone number",
 };
 
 /** Model provider whose key signs sessions for this transport. */
-export const VOICE_TRANSPORT_PROVIDER: Record<VoiceTransport, "elevenlabs"> = {
+export const VOICE_TRANSPORT_PROVIDER: Record<
+  VoiceTransport,
+  "elevenlabs" | "twilio"
+> = {
   elevenlabs_convai: "elevenlabs",
+  phone: "twilio",
 };
 
 export const parseVoiceAgentConfig = (config: unknown): VoiceAgentConfig =>
   voiceAgentConfigSchema.parse(config);
+
+/**
+ * The transport's own external identifier for a voice agent: the ElevenLabs
+ * agent id, or the phone number for a phone target. This is the value that
+ * forms the identity key ({@link voiceAgentIdentityKey}), so a phone target
+ * keys on its number (voice:phone:+14155550123). Narrows on the transport with
+ * an exhaustive switch, so a new transport member is a compile error here until
+ * it says which field carries its identity.
+ */
+export const voiceAgentExternalId = (config: VoiceAgentConfig): string => {
+  switch (config.transport) {
+    case "elevenlabs_convai":
+      return config.agentId;
+    case "phone":
+      return config.phoneNumber;
+  }
+};
 
 /**
  * The legacy scenario set drawer "Talk to it" calls used to be written into,

--- a/platform/app/src/server/app-layer/simulations/repositories/__tests__/simulation.clickhouse.repository.unit.test.ts
+++ b/platform/app/src/server/app-layer/simulations/repositories/__tests__/simulation.clickhouse.repository.unit.test.ts
@@ -93,6 +93,24 @@ describe("SimulationClickHouseRepository", () => {
           .calls[0]?.[0] as { query: string } | undefined;
         expect(firstCallArg?.query).toContain("IF(ScenarioSetId = '',");
       });
+
+      /** @scenario "The legacy voice-calls set is excluded from run listings" */
+      it("excludes the agent-test suffix and the voice-calls set", async () => {
+        const mockClient = makeMockClient();
+        const resolver = vi.fn().mockResolvedValue(mockClient);
+        const repo = new SimulationClickHouseRepository(resolver);
+
+        await repo.getDistinctExternalSetIds({
+          projectIds: ["project-1"],
+        });
+
+        const firstCallArg = (mockClient.query as ReturnType<typeof vi.fn>).mock
+          .calls[0]?.[0] as { query: string } | undefined;
+        expect(firstCallArg?.query).toContain(
+          "endsWith(ScenarioSetId, '__agent-test')",
+        );
+        expect(firstCallArg?.query).toContain("ScenarioSetId != 'voice-calls'");
+      });
     });
 
     describe("when called with empty projectIds", () => {
@@ -138,6 +156,25 @@ describe("SimulationClickHouseRepository", () => {
         });
 
         expect(result).toEqual(new Set([DEFAULT_SET_ID]));
+      });
+    });
+  });
+
+  describe("getExternalSetSummaries()", () => {
+    describe("when called for a project", () => {
+      /** @scenario "The legacy voice-calls set is excluded from run listings" */
+      it("excludes the agent-test suffix and the voice-calls set", async () => {
+        const { client, getCapturedQueries } = makeMockClientWithQueryCapture({
+          rowsForQuery: () => [],
+        });
+        const resolver = vi.fn().mockResolvedValue(client);
+        const repo = new SimulationClickHouseRepository(resolver);
+
+        await repo.getExternalSetSummaries({ projectId: "project-1" });
+
+        const query = getCapturedQueries()[0]?.query;
+        expect(query).toContain("endsWith(ScenarioSetId, '__agent-test')");
+        expect(query).toContain("ScenarioSetId != 'voice-calls'");
       });
     });
   });

--- a/platform/app/src/server/app-layer/simulations/repositories/simulation.clickhouse.repository.ts
+++ b/platform/app/src/server/app-layer/simulations/repositories/simulation.clickhouse.repository.ts
@@ -1,5 +1,6 @@
 import type { ClickHouseClient } from "@clickhouse/client";
 import type { ClickHouseClientResolver } from "~/server/clickhouse/clickhouseClient";
+import { VOICE_CALL_SCENARIO_SET_ID } from "~/server/agents/voice/voice-agent.config";
 import { AGENT_TEST_SET_SUFFIX } from "~/server/scenarios/agent-test-scenario";
 import {
   DEFAULT_SET_ID,
@@ -62,11 +63,13 @@ const RUNNING_STATUSES =
   "'IN_PROGRESS','PENDING','PENDING_EVALUATION','QUEUED','RUNNING'";
 
 /**
- * Leaves the "Test agent" runs out of a list. They are one-off checks of an
- * agent, not results of a scenario, so no set list, batch list or last-result
- * summary shows them. A run is still read by its own id.
+ * Leaves out runs that are not results of a scenario: the "Test agent" one-off
+ * checks, and the legacy `voice-calls` set that pre-#8020 drawer "Talk to it"
+ * calls landed in (a drawer call no longer writes a run at all). No set list,
+ * batch list or last-result summary shows them. A run is still read by its own
+ * id, so a direct link to an old voice-call run still opens.
  */
-const AGENT_TEST_SET_EXCLUSION = `AND NOT endsWith(ScenarioSetId, '${AGENT_TEST_SET_SUFFIX}')`;
+const AGENT_TEST_SET_EXCLUSION = `AND NOT endsWith(ScenarioSetId, '${AGENT_TEST_SET_SUFFIX}') AND ScenarioSetId != '${VOICE_CALL_SCENARIO_SET_ID}'`;
 
 /**
  * Batch-level aggregate SELECT list, shared by the batch history page and the

--- a/platform/app/src/server/app-layer/simulations/repositories/simulation.clickhouse.repository.ts
+++ b/platform/app/src/server/app-layer/simulations/repositories/simulation.clickhouse.repository.ts
@@ -1,6 +1,6 @@
 import type { ClickHouseClient } from "@clickhouse/client";
-import type { ClickHouseClientResolver } from "~/server/clickhouse/clickhouseClient";
 import { VOICE_CALL_SCENARIO_SET_ID } from "~/server/agents/voice/voice-agent.config";
+import type { ClickHouseClientResolver } from "~/server/clickhouse/clickhouseClient";
 import { AGENT_TEST_SET_SUFFIX } from "~/server/scenarios/agent-test-scenario";
 import {
   DEFAULT_SET_ID,
@@ -1436,7 +1436,7 @@ export class SimulationClickHouseRepository implements SimulationRepository {
 
     const wherePredicate =
       filter === "external"
-        ? "AND NOT startsWith(ScenarioSetId, '__internal__')"
+        ? `AND NOT startsWith(ScenarioSetId, '__internal__') ${AGENT_TEST_SET_EXCLUSION}`
         : "AND startsWith(ScenarioSetId, '__internal__') AND endsWith(ScenarioSetId, '__suite')";
 
     // External sets normalize empty ScenarioSetId to 'default'
@@ -1650,6 +1650,7 @@ export class SimulationClickHouseRepository implements SimulationRepository {
          FROM ${TABLE_NAME}
          WHERE TenantId IN ({projectIds:Array(String)})
            AND NOT startsWith(ScenarioSetId, '${INTERNAL_SET_PREFIX}')
+           ${AGENT_TEST_SET_EXCLUSION}
          GROUP BY TenantId, ScenarioSetId, BatchRunId, ScenarioRunId
        )
        WHERE latestIsActive`,

--- a/platform/app/src/server/app-layer/simulations/result-atoms/__tests__/atom-sql.unit.test.ts
+++ b/platform/app/src/server/app-layer/simulations/result-atoms/__tests__/atom-sql.unit.test.ts
@@ -104,6 +104,15 @@ describe("buildAtomFilters", () => {
     });
   });
 
+  describe("when the project holds legacy voice-call runs", () => {
+    /** @scenario "The legacy voice-calls set is excluded from run listings" */
+    it("excludes the voice-calls set from every atom read, alongside the agent-test set", () => {
+      const filters = buildAtomFilters(base);
+
+      expect(filters.stableClause).toContain("ScenarioSetId != 'voice-calls'");
+    });
+  });
+
   describe("when the query dedups a run to its latest version", () => {
     /**
      * StartedAt moves between versions of one run, so a dedup scope bounded

--- a/platform/app/src/server/app-layer/simulations/result-atoms/atom-sql.ts
+++ b/platform/app/src/server/app-layer/simulations/result-atoms/atom-sql.ts
@@ -1,3 +1,4 @@
+import { VOICE_CALL_SCENARIO_SET_ID } from "~/server/agents/voice/voice-agent.config";
 import { AGENT_TEST_SET_SUFFIX } from "~/server/scenarios/agent-test-scenario";
 import { expandSetIdFilter } from "~/server/scenarios/internal-set-id";
 import { TABLE_NAME } from "../repositories/simulation.clickhouse.repository";
@@ -292,8 +293,11 @@ function stableFilterParts(filter: ResultsFilter): FilterParts {
   // as a row with no name.
   const parts: string[] = [
     "ScenarioId != ''",
-    // A "Test agent" run is a check of an agent, not a result of a scenario.
+    // A "Test agent" run is a check of an agent, not a result of a scenario;
+    // the legacy `voice-calls` set is a pre-#8020 drawer call, likewise never a
+    // scenario result (a drawer call no longer writes a run at all).
     `NOT endsWith(ScenarioSetId, '${AGENT_TEST_SET_SUFFIX}')`,
+    `ScenarioSetId != '${VOICE_CALL_SCENARIO_SET_ID}'`,
   ];
   const params: Record<string, string | string[]> = {};
 

--- a/platform/app/src/server/featureFlag/frontendFeatureFlags.ts
+++ b/platform/app/src/server/featureFlag/frontendFeatureFlags.ts
@@ -63,6 +63,11 @@ export const FRONTEND_FEATURE_FLAGS = [
   // run, and run scenarios with a simulated caller. Off by default.
   // See useVoiceAgentsEnabled and specs/features/agents/voice-agents-v1.feature.
   "release_voice_agents_enabled",
+  // The Phone number transport option in the voice agent drawer. Off by default
+  // until the voice worker that dials phone targets ships (#8014); an existing
+  // phone target still renders its fields regardless of this flag. See
+  // AgentVoiceEditorDrawer and specs/features/agents/voice-phone.feature.
+  "release_voice_phone_targets_enabled",
   // Governance: gates the personal-keys / admin oversight /
   // RoutingPolicy / IngestionSource UI surfaces. On by default
   // (ADR-038 Decision 7); SaaS rollout and per-org kill switches are

--- a/platform/app/src/server/featureFlag/registry.ts
+++ b/platform/app/src/server/featureFlag/registry.ts
@@ -192,6 +192,13 @@ export const FEATURE_FLAGS = [
     description:
       "Voice agents: register an ElevenLabs agent, talk to it, call it from a run, and run scenarios with a simulated caller. Off by default; enable per project or organization via the operator store.",
   },
+  {
+    key: "release_voice_phone_targets_enabled",
+    scope: "PRODUCT",
+    defaultValue: false,
+    description:
+      "Reveals the Phone number transport option in the voice agent drawer. Off by default until the voice worker that dials phone targets ships (langwatch/langwatch#8014); an existing phone target still renders its fields regardless. For local dev use FEATURE_FLAG_FORCE_ENABLE=release_voice_phone_targets_enabled.",
+  },
   // Per-project gate for the transient S3 spool at the ingestion edge
   // (#4215 / ADR-022). ON by default, so a deployment with object storage
   // configured keeps oversized span content intact with no flag setup: a span

--- a/platform/app/src/server/scenarios/execution/data-prefetcher.ts
+++ b/platform/app/src/server/scenarios/execution/data-prefetcher.ts
@@ -73,6 +73,7 @@ import {
   type CallerVoiceConfig,
   parseCallerVoiceConfig,
 } from "../voice/caller-voice.config";
+import { VoicePhoneTransportUnavailableError } from "../voice/transports/phone.transport";
 import { voiceCallMaxSeconds } from "../voice/voice-limits";
 import { resolveTraceWaitTimeoutMs } from "./ingest-lag.service";
 import {
@@ -1044,6 +1045,12 @@ async function fetchVoiceAgentData({
   if (agent?.type !== "voice") return null;
 
   const config = parseVoiceAgentConfig(agent.config);
+  // Slice 1: a phone target has no voice worker yet, so a scenario run of one
+  // fails with the transport's own typed error rather than reaching the vendor.
+  // Only the ElevenLabs branch below reads an agent id and a credential.
+  if (config.transport !== "elevenlabs_convai") {
+    throw new VoicePhoneTransportUnavailableError();
+  }
 
   const provider = await findElevenLabsProviderForProject({ projectId });
   const credential = provider

--- a/platform/app/src/server/scenarios/execution/serialized-adapters/__tests__/voice-agent.adapter.unit.test.ts
+++ b/platform/app/src/server/scenarios/execution/serialized-adapters/__tests__/voice-agent.adapter.unit.test.ts
@@ -1,5 +1,6 @@
 import type { AgentAdapter } from "@langwatch/scenario";
 import { describe, expect, it, vi } from "vitest";
+import { phoneTransport } from "../../../voice/transports/phone.transport";
 import type { voiceTransportRegistry } from "../../../voice/voice-transport.registry";
 import type { VoiceAgentData } from "../../types";
 import {
@@ -20,6 +21,7 @@ function fakeRegistry(
       fetchCallRecord: vi.fn(),
       endCall: vi.fn(),
     },
+    phone: phoneTransport,
   };
 }
 

--- a/platform/app/src/server/scenarios/voice/__tests__/phone.transport.unit.test.ts
+++ b/platform/app/src/server/scenarios/voice/__tests__/phone.transport.unit.test.ts
@@ -1,0 +1,81 @@
+/**
+ * @see specs/features/agents/voice-phone.feature
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  PHONE_TRANSPORT_UNAVAILABLE_MESSAGE,
+  phoneTransport,
+  VoicePhoneTransportUnavailableError,
+} from "../transports/phone.transport";
+import type {
+  VoiceTransportCredential,
+  VoiceTransportRunner,
+} from "../voice-transport.registry";
+
+const credential: VoiceTransportCredential = {
+  apiKey: "k",
+  baseUrl: "https://x",
+};
+
+describe("phoneTransport (stub runner)", () => {
+  describe("given the voice worker that dials phone targets does not exist yet", () => {
+    describe("when any runner method is called", () => {
+      /** @scenario "Running a phone target before the voice worker exists fails with a clear message" */
+      it("throws the unavailable error with the tracking message from every method", () => {
+        const expectThrows = (call: () => unknown) => {
+          expect(call).toThrow(VoicePhoneTransportUnavailableError);
+          try {
+            call();
+          } catch (error) {
+            expect((error as VoicePhoneTransportUnavailableError).code).toBe(
+              "voice_phone_transport_unavailable",
+            );
+            expect((error as Error).message).toBe(
+              PHONE_TRANSPORT_UNAVAILABLE_MESSAGE,
+            );
+          }
+        };
+
+        const runner: VoiceTransportRunner = phoneTransport;
+        expectThrows(() =>
+          runner.createAgentAdapter({
+            agentId: "a",
+            credential,
+            maxCallSeconds: 60,
+          }),
+        );
+        expectThrows(() =>
+          runner.fetchCallRecord({
+            conversationId: "c",
+            credential,
+            audioProxyUrl: "/audio",
+          }),
+        );
+        expectThrows(() =>
+          runner.endCall({} as Parameters<VoiceTransportRunner["endCall"]>[0]),
+        );
+      });
+    });
+
+    describe("when a browser session mint is attempted", () => {
+      /** @scenario "A phone target has no browser call" */
+      it("throws rather than minting, because phone has no browser call", () => {
+        const mint = () =>
+          phoneTransport.mintSession({ agentId: "a", credential });
+        expect(mint).toThrow(VoicePhoneTransportUnavailableError);
+        try {
+          mint();
+        } catch (error) {
+          expect((error as VoicePhoneTransportUnavailableError).code).toBe(
+            "voice_phone_transport_unavailable",
+          );
+          expect((error as Error).message).toBe(
+            PHONE_TRANSPORT_UNAVAILABLE_MESSAGE,
+          );
+        }
+      });
+    });
+  });
+});

--- a/platform/app/src/server/scenarios/voice/__tests__/voice-run-writer.unit.test.ts
+++ b/platform/app/src/server/scenarios/voice/__tests__/voice-run-writer.unit.test.ts
@@ -69,6 +69,7 @@ describe("writeVoiceCallRun", () => {
           agentRowId: "agent_1",
           agentDisplayName: "Support Bot",
           record: fakeRecord({ isCutAtLimit: true }),
+          scenario: { scenarioId: "scenario_1", scenarioSetId: "set_x" },
           turnTraceIds: [],
         });
 
@@ -98,6 +99,7 @@ describe("writeVoiceCallRun", () => {
           agentRowId: "agent_1",
           agentDisplayName: "Support Bot",
           record,
+          scenario: { scenarioId: "scenario_1", scenarioSetId: "set_x" },
           turnTraceIds: ["trace_0"],
         };
 
@@ -123,6 +125,7 @@ describe("writeVoiceCallRun", () => {
           agentRowId: "agent_1",
           agentDisplayName: "Support Bot",
           record,
+          scenario: { scenarioId: "scenario_1", scenarioSetId: "set_x" },
           turnTraceIds: ["trace_0", "trace_0"],
         };
 
@@ -157,6 +160,7 @@ describe("writeVoiceCallRun", () => {
           agentDisplayName: "Support Bot",
           record,
           // Both turns are one exchange, so they share the trace id.
+          scenario: { scenarioId: "scenario_1", scenarioSetId: "set_x" },
           turnTraceIds: ["trace_a", "trace_a"],
         });
 

--- a/platform/app/src/server/scenarios/voice/__tests__/voice-session.ports.unit.test.ts
+++ b/platform/app/src/server/scenarios/voice/__tests__/voice-session.ports.unit.test.ts
@@ -30,6 +30,7 @@ function fakeAgentService(over: {
   }) => Promise<AgentWithFields | null>;
   create?: (input: unknown) => Promise<AgentWithFields>;
   createVoiceAgent?: (input: unknown) => Promise<{ id: string }>;
+  hasVoiceAgentForExternalId?: (input: unknown) => Promise<boolean>;
 }) {
   return {
     getById: over.getById ?? vi.fn(async () => null),
@@ -43,6 +44,8 @@ function fakeAgentService(over: {
       vi.fn(async () => {
         throw new Error("not stubbed");
       }),
+    hasVoiceAgentForExternalId:
+      over.hasVoiceAgentForExternalId ?? vi.fn(async () => false),
   };
 }
 
@@ -165,6 +168,31 @@ describe("Feature: voice-session ports composition", () => {
             agentId: "el_agent_1",
           }),
         );
+      });
+    });
+  });
+
+  describe("given hasVoiceAgentForExternalId", () => {
+    describe("when the request carries a project, transport and vendor agent id", () => {
+      it("delegates the identity-key match to the service", async () => {
+        const hasVoiceAgentForExternalId = vi.fn(async () => true);
+        const ports = createVoiceSessionPortsFromServices({
+          agentService: fakeAgentService({ hasVoiceAgentForExternalId }),
+          scenarioService: fakeScenarioService({}),
+        });
+
+        const matched = await ports.hasVoiceAgentForExternalId({
+          projectId: "project_1",
+          transport: "elevenlabs_convai",
+          agentExternalId: "el_agent_1",
+        });
+
+        expect(matched).toBe(true);
+        expect(hasVoiceAgentForExternalId).toHaveBeenCalledWith({
+          projectId: "project_1",
+          transport: "elevenlabs_convai",
+          agentExternalId: "el_agent_1",
+        });
       });
     });
   });

--- a/platform/app/src/server/scenarios/voice/__tests__/voice-session.ports.unit.test.ts
+++ b/platform/app/src/server/scenarios/voice/__tests__/voice-session.ports.unit.test.ts
@@ -29,11 +29,17 @@ function fakeAgentService(over: {
     projectId: string;
   }) => Promise<AgentWithFields | null>;
   create?: (input: unknown) => Promise<AgentWithFields>;
+  createVoiceAgent?: (input: unknown) => Promise<{ id: string }>;
 }) {
   return {
     getById: over.getById ?? vi.fn(async () => null),
     create:
       over.create ??
+      vi.fn(async () => {
+        throw new Error("not stubbed");
+      }),
+    createVoiceAgent:
+      over.createVoiceAgent ??
       vi.fn(async () => {
         throw new Error("not stubbed");
       }),
@@ -134,10 +140,12 @@ describe("Feature: voice-session ports composition", () => {
 
   describe("given createVoiceAgent", () => {
     describe("when a new voice agent is created", () => {
-      it("creates a voice-typed agent row through the service", async () => {
-        const create = vi.fn(async () => voiceAgentRow({ id: "agent_new" }));
+      it("creates the voice agent through the identity-key-deduped service method", async () => {
+        // The port delegates to AgentService.createVoiceAgent, which folds the
+        // row on its identity key so a retried finish reuses one row (#8020).
+        const createVoiceAgent = vi.fn(async () => ({ id: "agent_new" }));
         const ports = createVoiceSessionPortsFromServices({
-          agentService: fakeAgentService({ create }),
+          agentService: fakeAgentService({ createVoiceAgent }),
           scenarioService: fakeScenarioService({}),
         });
 
@@ -149,12 +157,12 @@ describe("Feature: voice-session ports composition", () => {
         });
 
         expect(created).toEqual({ id: "agent_new" });
-        expect(create).toHaveBeenCalledWith(
+        expect(createVoiceAgent).toHaveBeenCalledWith(
           expect.objectContaining({
             projectId: "project_1",
             name: "New agent",
-            type: "voice",
-            config: { transport: "elevenlabs_convai", agentId: "el_agent_1" },
+            transport: "elevenlabs_convai",
+            agentId: "el_agent_1",
           }),
         );
       });

--- a/platform/app/src/server/scenarios/voice/__tests__/voice-session.service.unit.test.ts
+++ b/platform/app/src/server/scenarios/voice/__tests__/voice-session.service.unit.test.ts
@@ -6,11 +6,14 @@ import { describe, expect, it, vi } from "vitest";
 import { ScenarioRunStatus } from "~/server/scenarios/scenario-event.enums";
 import type { CallRecord } from "../call-record";
 import {
+  authorizeRecordingPlayback,
   finishVoiceSession,
   mintVoiceSession,
   VoiceAgentRowNotFoundError,
   VoiceConversationMismatchError,
   VoiceKeyMissingError,
+  VoiceRecordingKeyMissingError,
+  VoiceRecordingUnavailableError,
   VoiceScenarioNotFoundError,
   type VoiceSessionPorts,
 } from "../voice-session.service";
@@ -51,6 +54,7 @@ function fakePorts({
       id: "agent_row",
       agentExternalId: "agent_xyz",
     })),
+    hasVoiceAgentForExternalId: vi.fn(async () => false),
     findExistingRun: vi.fn(async () => null),
     createVoiceAgent: vi.fn(async () => ({ id: "agent_created" })),
     // One deterministic trace id per turn, so a caller/assertion can read them
@@ -999,6 +1003,136 @@ describe("finishVoiceSession", () => {
         expect(writeCallRun.mock.calls[0]?.[0].turnTraceIds).toEqual([
           "trace_x",
         ]);
+      });
+    });
+  });
+});
+
+describe("authorizeRecordingPlayback", () => {
+  describe("given a recording-playback request", () => {
+    describe("when a scenario run exists for the conversation", () => {
+      it("authorizes with the credential and never calls the provider", async () => {
+        const fetchCallRecord = vi.fn(async () => null);
+        const ports = fakePorts({
+          runner: fakeRunner({ fetchCallRecord }),
+          over: {
+            findExistingRun: vi.fn(async () => ({
+              agentId: "agent_row",
+              status: ScenarioRunStatus.SUCCESS,
+              source: "provider" as const,
+              audioUrl: "/api/voice/session/conv_1/audio?projectId=p1",
+              scenarioId: "scenario_1",
+              scenarioSetId: "set_x",
+            })),
+          },
+        });
+
+        const credential = await authorizeRecordingPlayback({
+          ports,
+          projectId: "p1",
+          conversationId: "conv_1",
+        });
+
+        expect(credential).toEqual(CREDENTIAL);
+        expect(fetchCallRecord).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("when there is no run but the provider agent id matches a saved row", () => {
+      /** @scenario "A drawer call's recording still plays after hang-up" */
+      it("authorizes with the credential", async () => {
+        const hasVoiceAgentForExternalId = vi.fn(async () => true);
+        const fetchCallRecord = vi.fn(
+          async () =>
+            ({
+              agentExternalId: "agent_xyz",
+              turns: [],
+              source: "provider",
+            }) as CallRecord,
+        );
+        const ports = fakePorts({
+          runner: fakeRunner({ fetchCallRecord }),
+          over: { hasVoiceAgentForExternalId },
+        });
+
+        const credential = await authorizeRecordingPlayback({
+          ports,
+          projectId: "p1",
+          conversationId: "conv_1",
+        });
+
+        expect(credential).toEqual(CREDENTIAL);
+        expect(hasVoiceAgentForExternalId).toHaveBeenCalledWith({
+          projectId: "p1",
+          transport: "elevenlabs_convai",
+          agentExternalId: "agent_xyz",
+        });
+      });
+    });
+
+    describe("when there is no run and no saved row matches", () => {
+      it("refuses and never returns the credential", async () => {
+        const ports = fakePorts({
+          runner: fakeRunner({
+            fetchCallRecord: vi.fn(
+              async () =>
+                ({
+                  agentExternalId: "agent_other",
+                  turns: [],
+                  source: "provider",
+                }) as CallRecord,
+            ),
+          }),
+          over: { hasVoiceAgentForExternalId: vi.fn(async () => false) },
+        });
+
+        await expect(
+          authorizeRecordingPlayback({
+            ports,
+            projectId: "p1",
+            conversationId: "conv_1",
+          }),
+        ).rejects.toBeInstanceOf(VoiceRecordingUnavailableError);
+      });
+    });
+
+    describe("when there is no run and the provider fetch fails", () => {
+      it("refuses without consulting the agent rows", async () => {
+        const hasVoiceAgentForExternalId = vi.fn(async () => true);
+        const ports = fakePorts({
+          runner: fakeRunner({
+            fetchCallRecord: vi.fn(async () => {
+              throw new Error("provider down");
+            }),
+          }),
+          over: { hasVoiceAgentForExternalId },
+        });
+
+        await expect(
+          authorizeRecordingPlayback({
+            ports,
+            projectId: "p1",
+            conversationId: "conv_1",
+          }),
+        ).rejects.toBeInstanceOf(VoiceRecordingUnavailableError);
+        expect(hasVoiceAgentForExternalId).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("when the project has no provider key", () => {
+      it("refuses with the key-missing error", async () => {
+        const ports = fakePorts({
+          runner: fakeRunner(),
+          over: { resolveCredential: vi.fn(async () => null) },
+        });
+
+        await expect(
+          authorizeRecordingPlayback({
+            ports,
+            projectId: "p1",
+            conversationId: "conv_1",
+          }),
+        ).rejects.toBeInstanceOf(VoiceRecordingKeyMissingError);
       });
     });
   });

--- a/platform/app/src/server/scenarios/voice/__tests__/voice-session.service.unit.test.ts
+++ b/platform/app/src/server/scenarios/voice/__tests__/voice-session.service.unit.test.ts
@@ -230,7 +230,6 @@ describe("mintVoiceSession", () => {
   });
 });
 
-
 describe("finishVoiceSession", () => {
   describe("given the voice session ports", () => {
     // A "Call it myself" call names a scenario, so it is written as a run and
@@ -682,7 +681,7 @@ describe("finishVoiceSession", () => {
 
     describe("when the call is scored under a scenario", () => {
       /** @scenario "Call it myself against a scenario and be scored on its criteria" */
-      /** @scenario "Call it myself still writes and judges a run after 8020" */
+      /** @scenario "Call it myself still writes a run under its scenario after 8020" */
       it("writes the run under the scenario and its set so the scenario grades it", async () => {
         const runner = fakeRunner();
         const writeCallRun = vi.fn<VoiceSessionPorts["writeCallRun"]>(

--- a/platform/app/src/server/scenarios/voice/__tests__/voice-session.service.unit.test.ts
+++ b/platform/app/src/server/scenarios/voice/__tests__/voice-session.service.unit.test.ts
@@ -309,7 +309,7 @@ describe("finishVoiceSession", () => {
         // find for a conversation id with no scenario (#8020).
         expect(writeCallRun).not.toHaveBeenCalled();
         expect(findExistingRun).not.toHaveBeenCalled();
-        // The traces are still recorded — that is where the transcript lives.
+        // The traces are still recorded; that is where the transcript lives.
         expect(recordCallTraces).toHaveBeenCalledTimes(1);
         // The finish carries no run id and no scenario set id.
         expect(result.runId).toBe("");

--- a/platform/app/src/server/scenarios/voice/__tests__/voice-session.service.unit.test.ts
+++ b/platform/app/src/server/scenarios/voice/__tests__/voice-session.service.unit.test.ts
@@ -6,6 +6,10 @@ import { describe, expect, it, vi } from "vitest";
 import { ScenarioRunStatus } from "~/server/scenarios/scenario-event.enums";
 import type { CallRecord } from "../call-record";
 import {
+  phoneTransport,
+  VoicePhoneTransportUnavailableError,
+} from "../transports/phone.transport";
+import {
   authorizeRecordingPlayback,
   finishVoiceSession,
   mintVoiceSession,
@@ -72,7 +76,7 @@ function fakePorts({
     signSessionToken: (payload) => JSON.stringify(payload),
     now: () => 1000,
     newSessionId: () => "sess_generated",
-    registry: { elevenlabs_convai: runner },
+    registry: { elevenlabs_convai: runner, phone: phoneTransport },
     ...over,
   };
 }
@@ -229,6 +233,43 @@ describe("mintVoiceSession", () => {
           }),
         ).rejects.toBeInstanceOf(VoiceKeyMissingError);
         expect(runner.mintSession).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("when the transport cannot run yet (the phone stub)", () => {
+      /** @scenario "Running a phone target before the voice worker exists fails with a clear message" */
+      it("rejects with the unavailable error before any credential lookup", async () => {
+        const runner = fakeRunner();
+        const resolveCredential = vi.fn(async () => CREDENTIAL);
+        const ports = fakePorts({
+          runner,
+          over: {
+            resolveCredential,
+            registry: { elevenlabs_convai: runner, phone: phoneTransport },
+          },
+        });
+
+        await expect(
+          mintVoiceSession({
+            ports,
+            projectId: "p1",
+            transport: "phone",
+            agentId: "+14155550123",
+            maxDurationSeconds: 300,
+          }),
+        ).rejects.toMatchObject({
+          code: "voice_phone_transport_unavailable",
+        });
+        await expect(
+          mintVoiceSession({
+            ports,
+            projectId: "p1",
+            transport: "phone",
+            agentId: "+14155550123",
+            maxDurationSeconds: 300,
+          }),
+        ).rejects.toBeInstanceOf(VoicePhoneTransportUnavailableError);
+        expect(resolveCredential).not.toHaveBeenCalled();
       });
     });
   });

--- a/platform/app/src/server/scenarios/voice/__tests__/voice-session.service.unit.test.ts
+++ b/platform/app/src/server/scenarios/voice/__tests__/voice-session.service.unit.test.ts
@@ -1043,12 +1043,17 @@ describe("authorizeRecordingPlayback", () => {
       it("authorizes with the credential", async () => {
         const hasVoiceAgentForExternalId = vi.fn(async () => true);
         const fetchCallRecord = vi.fn(
-          async () =>
-            ({
-              agentExternalId: "agent_xyz",
-              turns: [],
-              source: "provider",
-            }) as CallRecord,
+          async (): Promise<CallRecord> => ({
+            conversationId: "conv_1",
+            transport: "elevenlabs_convai",
+            agentExternalId: "agent_xyz",
+            startedAt: 1000,
+            endedAt: 2000,
+            durationMs: 1000,
+            turns: [],
+            isCutAtLimit: false,
+            source: "provider",
+          }),
         );
         const ports = fakePorts({
           runner: fakeRunner({ fetchCallRecord }),
@@ -1075,12 +1080,17 @@ describe("authorizeRecordingPlayback", () => {
         const ports = fakePorts({
           runner: fakeRunner({
             fetchCallRecord: vi.fn(
-              async () =>
-                ({
-                  agentExternalId: "agent_other",
-                  turns: [],
-                  source: "provider",
-                }) as CallRecord,
+              async (): Promise<CallRecord> => ({
+                conversationId: "conv_1",
+                transport: "elevenlabs_convai",
+                agentExternalId: "agent_other",
+                startedAt: 1000,
+                endedAt: 2000,
+                durationMs: 1000,
+                turns: [],
+                isCutAtLimit: false,
+                source: "provider",
+              }),
             ),
           }),
           over: { hasVoiceAgentForExternalId: vi.fn(async () => false) },

--- a/platform/app/src/server/scenarios/voice/__tests__/voice-session.service.unit.test.ts
+++ b/platform/app/src/server/scenarios/voice/__tests__/voice-session.service.unit.test.ts
@@ -59,6 +59,9 @@ function fakePorts({
       turnTraceIds: record.turns.map((_, index) => `trace_${index}`),
     })),
     writeCallRun: vi.fn(async () => {}),
+    // A scenario call resolves its set here; a drawer call never reaches it.
+    // Individual tests override to assert it is or is not called.
+    resolveScenarioSet: vi.fn(async () => ({ scenarioSetId: "set_x" })),
     audioProxyUrl: ({ conversationId, projectId }) =>
       `/api/voice/session/${conversationId}/audio?projectId=${projectId}`,
     // A fake signer that round-trips the payload so tests can read the claims.
@@ -227,9 +230,21 @@ describe("mintVoiceSession", () => {
   });
 });
 
+
 describe("finishVoiceSession", () => {
   describe("given the voice session ports", () => {
-    describe("when the same conversation is finished twice", () => {
+    // A "Call it myself" call names a scenario, so it is written as a run and
+    // judged; a drawer "Talk to it" call names none and is never written as a
+    // run (#8020). Most run-writing behaviour below is therefore exercised on
+    // the scenario path, with `scenarioId` set and `resolveScenarioSet`
+    // resolving it. The drawer path is exercised in its own block.
+    const SCENARIO_FINISH = {
+      ...FINISH_BASE,
+      token: { ...TOKEN, agentId: "agent_row" },
+      scenarioId: "scenario_1",
+    };
+
+    describe("when the same Call it myself conversation is finished twice", () => {
       /** @scenario "Hanging up twice produces exactly one run" */
       it("writes the run once and returns the existing run the second time", async () => {
         const runner = fakeRunner();
@@ -246,36 +261,112 @@ describe("finishVoiceSession", () => {
                 status: ScenarioRunStatus.SUCCESS,
                 source: "provider" as const,
                 audioUrl: null,
-                scenarioId: null,
-                scenarioSetId: null,
+                scenarioId: "scenario_1",
+                scenarioSetId: "set_x",
               }
             : null,
         );
         const ports = fakePorts({
           runner,
-          over: {
-            writeCallRun,
-            findExistingRun,
-            createVoiceAgent: vi.fn(async () => ({ id: "agent_row" })),
-          },
+          over: { writeCallRun, findExistingRun },
         });
 
-        const first = await finishVoiceSession({
-          ports,
-          ...FINISH_BASE,
-          name: "Support",
-        });
-        const second = await finishVoiceSession({
-          ports,
-          ...FINISH_BASE,
-          name: "Support",
-        });
+        const first = await finishVoiceSession({ ports, ...SCENARIO_FINISH });
+        const second = await finishVoiceSession({ ports, ...SCENARIO_FINISH });
 
         expect(writeCallRun).toHaveBeenCalledTimes(1);
         expect(first.runId).toBe(second.runId);
-        // The token names no agent, so the short-circuit answers with the id
-        // the existing run attached (terminalRunResult's agentId fallback).
         expect(second.agentId).toBe("agent_row");
+      });
+    });
+
+    describe("when a drawer call is finished", () => {
+      /** @scenario "A drawer Talk to it call writes no run" */
+      /** @scenario "A drawer finish never mints a synthetic scenario id" */
+      it("records the call traces but never writes a run or looks one up", async () => {
+        const writeCallRun = vi.fn<VoiceSessionPorts["writeCallRun"]>(
+          async () => {},
+        );
+        const findExistingRun = vi.fn<VoiceSessionPorts["findExistingRun"]>(
+          async () => null,
+        );
+        const recordCallTraces = vi.fn<VoiceSessionPorts["recordCallTraces"]>(
+          async () => ({
+            turnTraceIds: ["trace_0"],
+          }),
+        );
+        const ports = fakePorts({
+          runner: fakeRunner(),
+          over: { writeCallRun, findExistingRun, recordCallTraces },
+        });
+
+        const result = await finishVoiceSession({
+          ports,
+          ...FINISH_BASE,
+          token: { ...TOKEN, agentId: "agent_row" },
+        });
+
+        // No run is written for a drawer call, and there is never a run to
+        // find for a conversation id with no scenario (#8020).
+        expect(writeCallRun).not.toHaveBeenCalled();
+        expect(findExistingRun).not.toHaveBeenCalled();
+        // The traces are still recorded — that is where the transcript lives.
+        expect(recordCallTraces).toHaveBeenCalledTimes(1);
+        // The finish carries no run id and no scenario set id.
+        expect(result.runId).toBe("");
+        expect(result.scenarioSetId).toBeUndefined();
+        // The agent id is still returned so the panel can register the row.
+        expect(result.agentId).toBe("agent_row");
+      });
+
+      /** @scenario "Hanging up twice on a drawer call records traces and writes no run" */
+      it("writes no run and records traces on each of two drawer finishes", async () => {
+        const writeCallRun = vi.fn<VoiceSessionPorts["writeCallRun"]>(
+          async () => {},
+        );
+        const recordCallTraces = vi.fn<VoiceSessionPorts["recordCallTraces"]>(
+          async () => ({
+            turnTraceIds: ["trace_0"],
+          }),
+        );
+        const ports = fakePorts({
+          runner: fakeRunner(),
+          over: { writeCallRun, recordCallTraces },
+        });
+
+        const drawer = {
+          ...FINISH_BASE,
+          token: { ...TOKEN, agentId: "agent_row" },
+        };
+        const first = await finishVoiceSession({ ports, ...drawer });
+        const second = await finishVoiceSession({ ports, ...drawer });
+
+        // No run is ever written; the traces re-record with the same
+        // deterministic ids, which the trace fold dedupes.
+        expect(writeCallRun).not.toHaveBeenCalled();
+        expect(recordCallTraces).toHaveBeenCalledTimes(2);
+        expect(first.runId).toBe("");
+        expect(second.runId).toBe("");
+      });
+
+      it("creates the voice agent from the form values on first hang-up", async () => {
+        const runner = fakeRunner();
+        const createVoiceAgent = vi.fn(async () => ({ id: "agent_new" }));
+        const ports = fakePorts({ runner, over: { createVoiceAgent } });
+
+        const result = await finishVoiceSession({
+          ports,
+          ...FINISH_BASE,
+          name: "Support line",
+        });
+
+        expect(createVoiceAgent).toHaveBeenCalledWith(
+          expect.objectContaining({
+            name: "Support line",
+            agentId: "agent_xyz",
+          }),
+        );
+        expect(result.agentId).toBe("agent_new");
       });
     });
 
@@ -294,17 +385,13 @@ describe("finishVoiceSession", () => {
               status: ScenarioRunStatus.SUCCESS,
               source: "provider" as const,
               audioUrl: null,
-              scenarioId: null,
-              scenarioSetId: null,
+              scenarioId: "scenario_1",
+              scenarioSetId: "set_x",
             })),
           },
         });
 
-        const result = await finishVoiceSession({
-          ports,
-          ...FINISH_BASE,
-          token: { ...TOKEN, agentId: "agent_row" },
-        });
+        const result = await finishVoiceSession({ ports, ...SCENARIO_FINISH });
 
         expect(writeCallRun).not.toHaveBeenCalled();
         expect(result.agentId).toBe("agent_row");
@@ -325,17 +412,13 @@ describe("finishVoiceSession", () => {
               source: "browser" as const,
               // Same-origin proxy URL the transport wrote, read back verbatim.
               audioUrl: "/api/voice/session/conv_1/audio?projectId=p1",
-              scenarioId: null,
+              scenarioId: "scenario_1",
               scenarioSetId: "set_terminal",
             })),
           },
         });
 
-        const result = await finishVoiceSession({
-          ports,
-          ...FINISH_BASE,
-          token: { ...TOKEN, agentId: "agent_row" },
-        });
+        const result = await finishVoiceSession({ ports, ...SCENARIO_FINISH });
 
         expect(writeCallRun).not.toHaveBeenCalled();
         expect(result.source).toBe("browser");
@@ -374,14 +457,41 @@ describe("finishVoiceSession", () => {
 
         const result = await finishVoiceSession({
           ports,
-          ...FINISH_BASE,
-          token: { ...TOKEN, agentId: "agent_row" },
+          ...SCENARIO_FINISH,
           scenarioId: "scenario_gone",
         });
 
         expect(resolveScenarioSet).not.toHaveBeenCalled();
         expect(writeCallRun).not.toHaveBeenCalled();
         expect(result.runId).toBeTruthy();
+      });
+
+      /** @scenario "A retried hang-up leaves a terminal run untouched" */
+      it("records no traces and writes no run on the terminal short-circuit", async () => {
+        const recordCallTraces = vi.fn(async () => ({ turnTraceIds: [] }));
+        const writeCallRun = vi.fn<VoiceSessionPorts["writeCallRun"]>(
+          async () => {},
+        );
+        const ports = fakePorts({
+          runner: fakeRunner(),
+          over: {
+            recordCallTraces,
+            writeCallRun,
+            findExistingRun: vi.fn(async () => ({
+              agentId: "agent_existing",
+              status: ScenarioRunStatus.SUCCESS,
+              source: "provider" as const,
+              audioUrl: null,
+              scenarioId: "scenario_1",
+              scenarioSetId: "set_x",
+            })),
+          },
+        });
+
+        await finishVoiceSession({ ports, ...SCENARIO_FINISH });
+
+        expect(recordCallTraces).not.toHaveBeenCalled();
+        expect(writeCallRun).not.toHaveBeenCalled();
       });
     });
 
@@ -400,17 +510,13 @@ describe("finishVoiceSession", () => {
               status: ScenarioRunStatus.IN_PROGRESS,
               source: "provider" as const,
               audioUrl: null,
-              scenarioId: null,
-              scenarioSetId: null,
+              scenarioId: "scenario_1",
+              scenarioSetId: "set_x",
             })),
           },
         });
 
-        const result = await finishVoiceSession({
-          ports,
-          ...FINISH_BASE,
-          token: { ...TOKEN, agentId: "agent_row" },
-        });
+        const result = await finishVoiceSession({ ports, ...SCENARIO_FINISH });
 
         expect(writeCallRun).toHaveBeenCalledTimes(1);
         expect(writeCallRun.mock.calls[0]?.[0].scenarioRunId).toBe(
@@ -434,8 +540,8 @@ describe("finishVoiceSession", () => {
               status: ScenarioRunStatus.IN_PROGRESS,
               source: null,
               audioUrl: null,
-              scenarioId: null,
-              scenarioSetId: null,
+              scenarioId: "scenario_1",
+              scenarioSetId: "set_x",
             })),
           },
         });
@@ -447,6 +553,7 @@ describe("finishVoiceSession", () => {
           ports,
           ...FINISH_BASE,
           token: { ...TOKEN, agentId: null },
+          scenarioId: "scenario_1",
         });
 
         expect(createVoiceAgent).not.toHaveBeenCalled();
@@ -467,17 +574,13 @@ describe("finishVoiceSession", () => {
               status: ScenarioRunStatus.CANCELLED,
               source: null,
               audioUrl: null,
-              scenarioId: null,
-              scenarioSetId: null,
+              scenarioId: "scenario_1",
+              scenarioSetId: "set_x",
             })),
           },
         });
 
-        const result = await finishVoiceSession({
-          ports,
-          ...FINISH_BASE,
-          token: { ...TOKEN, agentId: "agent_row" },
-        });
+        const result = await finishVoiceSession({ ports, ...SCENARIO_FINISH });
 
         expect(writeCallRun).toHaveBeenCalledTimes(1);
         expect(writeCallRun.mock.calls[0]?.[0].scenarioRunId).toBe(
@@ -511,8 +614,7 @@ describe("finishVoiceSession", () => {
 
         await finishVoiceSession({
           ports,
-          ...FINISH_BASE,
-          token: { ...TOKEN, agentId: "agent_row" },
+          ...SCENARIO_FINISH,
           scenarioId: "scenario_archived",
         });
 
@@ -525,28 +627,6 @@ describe("finishVoiceSession", () => {
             },
           }),
         );
-      });
-    });
-
-    describe("when the drawer had no saved agent row", () => {
-      it("creates the voice agent from the form values before writing the run", async () => {
-        const runner = fakeRunner();
-        const createVoiceAgent = vi.fn(async () => ({ id: "agent_new" }));
-        const ports = fakePorts({ runner, over: { createVoiceAgent } });
-
-        const result = await finishVoiceSession({
-          ports,
-          ...FINISH_BASE,
-          name: "Support line",
-        });
-
-        expect(createVoiceAgent).toHaveBeenCalledWith(
-          expect.objectContaining({
-            name: "Support line",
-            agentId: "agent_xyz",
-          }),
-        );
-        expect(result.agentId).toBe("agent_new");
       });
     });
 
@@ -573,11 +653,7 @@ describe("finishVoiceSession", () => {
         const ports = fakePorts({ runner, over: { writeCallRun } });
 
         await expect(
-          finishVoiceSession({
-            ports,
-            ...FINISH_BASE,
-            token: { ...TOKEN, agentId: "agent_row" },
-          }),
+          finishVoiceSession({ ports, ...SCENARIO_FINISH }),
         ).rejects.toBeInstanceOf(VoiceConversationMismatchError);
         expect(writeCallRun).not.toHaveBeenCalled();
       });
@@ -593,8 +669,7 @@ describe("finishVoiceSession", () => {
 
         await finishVoiceSession({
           ports,
-          ...FINISH_BASE,
-          token: { ...TOKEN, agentId: "agent_row" },
+          ...SCENARIO_FINISH,
           isCutAtLimit: true,
         });
 
@@ -607,6 +682,7 @@ describe("finishVoiceSession", () => {
 
     describe("when the call is scored under a scenario", () => {
       /** @scenario "Call it myself against a scenario and be scored on its criteria" */
+      /** @scenario "Call it myself still writes and judges a run after 8020" */
       it("writes the run under the scenario and its set so the scenario grades it", async () => {
         const runner = fakeRunner();
         const writeCallRun = vi.fn<VoiceSessionPorts["writeCallRun"]>(
@@ -617,19 +693,10 @@ describe("finishVoiceSession", () => {
         }));
         const ports = fakePorts({
           runner,
-          over: {
-            writeCallRun,
-            resolveScenarioSet,
-            createVoiceAgent: vi.fn(async () => ({ id: "agent_row" })),
-          },
+          over: { writeCallRun, resolveScenarioSet },
         });
 
-        const result = await finishVoiceSession({
-          ports,
-          ...FINISH_BASE,
-          token: { ...TOKEN, agentId: "agent_row" },
-          scenarioId: "scenario_1",
-        });
+        const result = await finishVoiceSession({ ports, ...SCENARIO_FINISH });
 
         expect(resolveScenarioSet).toHaveBeenCalledWith({
           projectId: "p1",
@@ -643,7 +710,8 @@ describe("finishVoiceSession", () => {
         expect(result.scenarioSetId).toBe("set_x");
       });
 
-      it("keeps a drawer call out of any scenario set when no scenario is named", async () => {
+      /** @scenario "A drawer Talk to it call writes no run" */
+      it("keeps a drawer call out of any scenario set and writes no run", async () => {
         const runner = fakeRunner();
         const writeCallRun = vi.fn<VoiceSessionPorts["writeCallRun"]>(
           async () => {},
@@ -663,7 +731,7 @@ describe("finishVoiceSession", () => {
         });
 
         expect(resolveScenarioSet).not.toHaveBeenCalled();
-        expect(writeCallRun.mock.calls[0]?.[0]).not.toHaveProperty("scenario");
+        expect(writeCallRun).not.toHaveBeenCalled();
         expect(result.scenarioSetId).toBeUndefined();
       });
     });
@@ -672,19 +740,9 @@ describe("finishVoiceSession", () => {
       /** @scenario "No ElevenLabs key leaves the server through any response or log" */
       it("returns no ElevenLabs key in the finish response", async () => {
         const runner = fakeRunner();
-        const ports = fakePorts({
-          runner,
-          over: {
-            resolveScenarioSet: vi.fn(async () => ({ scenarioSetId: "set_x" })),
-          },
-        });
+        const ports = fakePorts({ runner });
 
-        const result = await finishVoiceSession({
-          ports,
-          ...FINISH_BASE,
-          token: { ...TOKEN, agentId: "agent_row" },
-          scenarioId: "scenario_1",
-        });
+        const result = await finishVoiceSession({ ports, ...SCENARIO_FINISH });
 
         expect(JSON.stringify(result)).not.toContain(CREDENTIAL.apiKey);
       });
@@ -713,11 +771,7 @@ describe("finishVoiceSession", () => {
         );
         const ports = fakePorts({ runner, over: { writeCallRun } });
 
-        const result = await finishVoiceSession({
-          ports,
-          ...FINISH_BASE,
-          token: { ...TOKEN, agentId: "agent_row" },
-        });
+        const result = await finishVoiceSession({ ports, ...SCENARIO_FINISH });
 
         const written = writeCallRun.mock.calls[0]?.[0] as {
           record: CallRecord;
@@ -753,11 +807,7 @@ describe("finishVoiceSession", () => {
         );
         const ports = fakePorts({ runner, over: { writeCallRun } });
 
-        const result = await finishVoiceSession({
-          ports,
-          ...FINISH_BASE,
-          token: { ...TOKEN, agentId: "agent_row" },
-        });
+        const result = await finishVoiceSession({ ports, ...SCENARIO_FINISH });
 
         const written = writeCallRun.mock.calls[0]?.[0] as {
           record: CallRecord;
@@ -792,12 +842,11 @@ describe("finishVoiceSession", () => {
 
         const result = await finishVoiceSession({
           ports,
-          ...FINISH_BASE,
+          ...SCENARIO_FINISH,
           transcript: [
             { role: "caller" as const, text: "hi" },
             { role: "agent" as const, text: "hello" },
           ],
-          token: { ...TOKEN, agentId: "agent_row" },
         });
 
         const written = writeCallRun.mock.calls[0]?.[0] as {
@@ -826,11 +875,7 @@ describe("finishVoiceSession", () => {
         );
         const ports = fakePorts({ runner, over: { writeCallRun } });
 
-        const result = await finishVoiceSession({
-          ports,
-          ...FINISH_BASE,
-          token: { ...TOKEN, agentId: "agent_row" },
-        });
+        const result = await finishVoiceSession({ ports, ...SCENARIO_FINISH });
 
         const written = writeCallRun.mock.calls[0]?.[0] as {
           record: CallRecord;
@@ -860,8 +905,7 @@ describe("finishVoiceSession", () => {
         await expect(
           finishVoiceSession({
             ports,
-            ...FINISH_BASE,
-            token: { ...TOKEN, agentId: "agent_row" },
+            ...SCENARIO_FINISH,
             scenarioId: "scenario_gone",
           }),
         ).rejects.toBeInstanceOf(VoiceScenarioNotFoundError);
@@ -879,11 +923,7 @@ describe("finishVoiceSession", () => {
         });
         const ports = fakePorts({ runner });
 
-        const result = await finishVoiceSession({
-          ports,
-          ...FINISH_BASE,
-          token: { ...TOKEN, agentId: "agent_row" },
-        });
+        const result = await finishVoiceSession({ ports, ...SCENARIO_FINISH });
 
         expect(result.hasFetchFailed).toBe(true);
         expect(result.source).toBe("browser");
@@ -907,11 +947,7 @@ describe("finishVoiceSession", () => {
           over: { recordCallTraces, writeCallRun },
         });
 
-        await finishVoiceSession({
-          ports,
-          ...FINISH_BASE,
-          token: { ...TOKEN, agentId: "agent_row" },
-        });
+        await finishVoiceSession({ ports, ...SCENARIO_FINISH });
 
         expect(recordCallTraces).toHaveBeenCalledTimes(1);
         // Ordering: the traces are recorded before the run is written.
@@ -931,48 +967,14 @@ describe("finishVoiceSession", () => {
       });
     });
 
-    describe("when the finish short-circuits on a terminal run", () => {
-      /** @scenario "A retried hang-up leaves a terminal run untouched" */
-      it("records no traces and writes no run", async () => {
-        const recordCallTraces = vi.fn<VoiceSessionPorts["recordCallTraces"]>(
-          async () => ({ turnTraceIds: [] }),
-        );
-        const writeCallRun = vi.fn<VoiceSessionPorts["writeCallRun"]>(
-          async () => {},
-        );
-        const ports = fakePorts({
-          runner: fakeRunner(),
-          over: {
-            recordCallTraces,
-            writeCallRun,
-            findExistingRun: vi.fn(async () => ({
-              agentId: "agent_existing",
-              status: ScenarioRunStatus.SUCCESS,
-              source: "provider" as const,
-              audioUrl: null,
-              scenarioId: null,
-              scenarioSetId: null,
-            })),
-          },
-        });
-
-        await finishVoiceSession({
-          ports,
-          ...FINISH_BASE,
-          token: { ...TOKEN, agentId: "agent_row" },
-        });
-
-        expect(recordCallTraces).not.toHaveBeenCalled();
-        expect(writeCallRun).not.toHaveBeenCalled();
-      });
-    });
-
     describe("when a half-written run is re-driven", () => {
       /** @scenario "A re-driven finish writes the same trace ids" */
       it("records the call traces again so the deterministic ids re-attach", async () => {
-        const recordCallTraces = vi.fn(async () => ({
-          turnTraceIds: ["trace_x"],
-        }));
+        const recordCallTraces = vi.fn<VoiceSessionPorts["recordCallTraces"]>(
+          async () => ({
+            turnTraceIds: ["trace_x"],
+          }),
+        );
         const writeCallRun = vi.fn<VoiceSessionPorts["writeCallRun"]>(
           async () => {},
         );
@@ -986,17 +988,13 @@ describe("finishVoiceSession", () => {
               status: ScenarioRunStatus.IN_PROGRESS,
               source: "provider" as const,
               audioUrl: null,
-              scenarioId: null,
-              scenarioSetId: null,
+              scenarioId: "scenario_1",
+              scenarioSetId: "set_x",
             })),
           },
         });
 
-        await finishVoiceSession({
-          ports,
-          ...FINISH_BASE,
-          token: { ...TOKEN, agentId: "agent_row" },
-        });
+        await finishVoiceSession({ ports, ...SCENARIO_FINISH });
 
         expect(recordCallTraces).toHaveBeenCalledTimes(1);
         expect(writeCallRun.mock.calls[0]?.[0].turnTraceIds).toEqual([

--- a/platform/app/src/server/scenarios/voice/transports/phone.transport.ts
+++ b/platform/app/src/server/scenarios/voice/transports/phone.transport.ts
@@ -1,0 +1,66 @@
+/**
+ * The phone (Twilio) transport: stub.
+ *
+ * A phone target is dialled from the voice worker, which does not exist yet
+ * (langwatch/langwatch#8014). This module keeps the phone member selectable and
+ * inert: every method of the runner throws one typed, customer-facing error, so
+ * nothing can be run over phone until the worker ships. It mirrors the file
+ * layout of {@link elevenLabsConvaiTransport}: this is the ONE module that
+ * will later name Twilio, but wires no vendor SDK yet.
+ *
+ * `mintSession` throws it too: there is no browser call over phone, so a
+ * "Talk to it" mint has nothing to mint.
+ */
+
+import { HandledError } from "@langwatch/handled-error";
+import type { AgentAdapter } from "@langwatch/scenario";
+import type { VoiceTransportRunner } from "../voice-transport.registry";
+
+/** Shown on any attempt to run a phone target before the voice worker exists. */
+export const PHONE_TRANSPORT_UNAVAILABLE_MESSAGE =
+  "Phone targets are called from the voice worker, which is not available yet. Track langwatch/langwatch#8014.";
+
+/**
+ * A phone target was exercised before the voice worker that dials it exists.
+ * Every method of the stub runner throws this one code, so the failure reads
+ * the same wherever it surfaces. Extends the same {@link HandledError} base the
+ * voice-session errors use, with the base's default customer fault.
+ */
+export class VoicePhoneTransportUnavailableError extends HandledError {
+  declare readonly code: "voice_phone_transport_unavailable";
+  constructor() {
+    super(
+      "voice_phone_transport_unavailable",
+      PHONE_TRANSPORT_UNAVAILABLE_MESSAGE,
+      { httpStatus: 400 },
+    );
+    this.name = "VoicePhoneTransportUnavailableError";
+  }
+}
+
+export const phoneTransport: VoiceTransportRunner = {
+  missingKeyMessage: PHONE_TRANSPORT_UNAVAILABLE_MESSAGE,
+
+  // Runs before the credential lookup, so the API reports the phone-unavailable
+  // error rather than a missing-key error the credential absence would raise.
+  assertAvailable(): never {
+    throw new VoicePhoneTransportUnavailableError();
+  },
+
+  // No browser call over phone: there is nothing to mint.
+  mintSession(): Promise<never> {
+    throw new VoicePhoneTransportUnavailableError();
+  },
+
+  fetchCallRecord(): Promise<never> {
+    throw new VoicePhoneTransportUnavailableError();
+  },
+
+  endCall(): Promise<never> {
+    throw new VoicePhoneTransportUnavailableError();
+  },
+
+  createAgentAdapter(): AgentAdapter {
+    throw new VoicePhoneTransportUnavailableError();
+  },
+};

--- a/platform/app/src/server/scenarios/voice/voice-run-writer.ts
+++ b/platform/app/src/server/scenarios/voice/voice-run-writer.ts
@@ -3,16 +3,14 @@
  * render: one message per turn (caller → user, agent → assistant), the caller
  * marked human.
  *
- * Two shapes, one writer:
- *  - A drawer call ("Talk to it") lands in the voice-call set under a synthetic
- *    per-agent scenario id, and carries no verdict — it is not judged against a
- *    scenario (AC13).
- *  - A "Call it myself" scenario call (AC23) lands under the real scenario id
- *    and its set, beside the scenario's simulated runs, tagged
- *    `metadata.langwatch.callerKind = "human"`. Finishing it emits a
- *    RunFinished that names the scenario, which is what the scenario-evaluations
- *    subscriber keys on to grade the human transcript against the scenario's
- *    attached evaluators — the same grading a simulated run gets.
+ * Only a "Call it myself" scenario call is written here (#8020): it lands under
+ * the real scenario id and its set, beside the scenario's simulated runs,
+ * tagged `metadata.langwatch.callerKind = "human"`. Finishing it emits a
+ * RunFinished that names the scenario, which is what the scenario-evaluations
+ * subscriber keys on to grade the human transcript against the scenario's
+ * attached evaluators — the same grading a simulated run gets. A drawer "Talk
+ * to it" call has no scenario, so it is never written as a run at all; it
+ * leaves only its per-exchange traces (3a).
  *
  * Kept apart from the session service so the service stays a pure orchestrator
  * over injected ports.
@@ -21,7 +19,6 @@
 import { HandledError } from "@langwatch/handled-error";
 
 import { AgentRepository } from "~/server/agents/agent.repository";
-import { VOICE_CALL_SCENARIO_SET_ID } from "~/server/agents/voice/voice-agent.config";
 import { getApp } from "~/server/app-layer/app";
 import { prisma } from "~/server/db";
 import type { SimulationMessage } from "~/server/event-sourcing/pipelines/simulation-processing/schemas/shared";
@@ -69,7 +66,8 @@ function toMessages(
 
 /**
  * The scenario a "Call it myself" run is written under, and the set it shares
- * with that scenario's simulated runs. Absent for a drawer call.
+ * with that scenario's simulated runs. Always present: only a scenario call is
+ * ever written as a run (#8020).
  */
 export interface VoiceRunScenario {
   scenarioId: string;
@@ -90,7 +88,7 @@ export async function writeVoiceCallRun({
   agentRowId: string;
   agentDisplayName: string;
   record: CallRecord;
-  scenario?: VoiceRunScenario;
+  scenario: VoiceRunScenario;
   /** The trace id each turn links to, one per `record.turns[i]` in order, from
    *  {@link recordVoiceCallTraces}. Set on the message and the run's trace list
    *  so the drawer probes the exchange's trace. */
@@ -104,10 +102,10 @@ export async function writeVoiceCallRun({
   });
   if (!agent) throw new VoiceAgentNotFoundError();
 
-  // A scenario call lands under the real scenario and its set; a drawer call
-  // lands in the voice-call set under a synthetic per-agent id.
-  const scenarioId = scenario?.scenarioId ?? `voiceagent_${agentRowId}`;
-  const scenarioSetId = scenario?.scenarioSetId ?? VOICE_CALL_SCENARIO_SET_ID;
+  // The call lands under the real scenario and its set, beside that scenario's
+  // simulated runs.
+  const scenarioId = scenario.scenarioId;
+  const scenarioSetId = scenario.scenarioSetId;
 
   const metadata = {
     name: agentDisplayName,
@@ -150,22 +148,17 @@ export async function writeVoiceCallRun({
     occurredAt: record.endedAt,
   });
 
-  // No results envelope: the verdict is not decided here. A drawer call carries
-  // no verdict at all (AC13). A scenario call is finished SUCCESS with the
-  // scenario id named on the event, so the scenario-evaluations subscriber
-  // grades the transcript against the scenario's attached evaluators (AC23) —
-  // exactly the path a simulated run's finish takes.
+  // No results envelope: the verdict is not decided here. The run is finished
+  // SUCCESS with the scenario id named on the event, so the scenario-evaluations
+  // subscriber grades the transcript against the scenario's attached evaluators
+  // (AC23) — exactly the path a simulated run's finish takes.
   await getApp().simulations.finishRun({
     tenantId: projectId,
     scenarioRunId,
     status: "SUCCESS",
-    ...(scenario
-      ? {
-          scenarioId: scenario.scenarioId,
-          scenarioSetId: scenario.scenarioSetId,
-          batchRunId: scenarioRunId,
-        }
-      : {}),
+    scenarioId: scenario.scenarioId,
+    scenarioSetId: scenario.scenarioSetId,
+    batchRunId: scenarioRunId,
     occurredAt: record.endedAt,
   });
 }

--- a/platform/app/src/server/scenarios/voice/voice-run-writer.ts
+++ b/platform/app/src/server/scenarios/voice/voice-run-writer.ts
@@ -8,7 +8,7 @@
  * tagged `metadata.langwatch.callerKind = "human"`. Finishing it emits a
  * RunFinished that names the scenario, which is what the scenario-evaluations
  * subscriber keys on to grade the human transcript against the scenario's
- * attached evaluators — the same grading a simulated run gets. A drawer "Talk
+ * attached evaluators, the same grading a simulated run gets. A drawer "Talk
  * to it" call has no scenario, so it is never written as a run at all; it
  * leaves only its per-exchange traces (3a).
  *
@@ -151,7 +151,7 @@ export async function writeVoiceCallRun({
   // No results envelope: the verdict is not decided here. The run is finished
   // SUCCESS with the scenario id named on the event, so the scenario-evaluations
   // subscriber grades the transcript against the scenario's attached evaluators
-  // (AC23) — exactly the path a simulated run's finish takes.
+  // (AC23): exactly the path a simulated run's finish takes.
   await getApp().simulations.finishRun({
     tenantId: projectId,
     scenarioRunId,

--- a/platform/app/src/server/scenarios/voice/voice-session.ports.ts
+++ b/platform/app/src/server/scenarios/voice/voice-session.ports.ts
@@ -19,6 +19,7 @@ import {
   parseVoiceAgentConfig,
   VOICE_TRANSPORT_PROVIDER,
   type VoiceTransport,
+  voiceAgentExternalId,
 } from "~/server/agents/voice/voice-agent.config";
 import { getApp } from "~/server/app-layer/app";
 import { prisma } from "~/server/db";
@@ -121,7 +122,7 @@ export function createVoiceSessionPortsFromServices({
       const agent = await agentService.getById({ id: agentRowId, projectId });
       if (agent?.type !== "voice") return null;
       const config = parseVoiceAgentConfig(agent.config);
-      return { id: agent.id, agentExternalId: config.agentId };
+      return { id: agent.id, agentExternalId: voiceAgentExternalId(config) };
     },
 
     /** Whether the project saved a voice agent for this vendor agent id: the

--- a/platform/app/src/server/scenarios/voice/voice-session.ports.ts
+++ b/platform/app/src/server/scenarios/voice/voice-session.ports.ts
@@ -18,6 +18,7 @@ import type { AgentWithFields } from "~/server/agents/agent-fields";
 import {
   parseVoiceAgentConfig,
   VOICE_TRANSPORT_PROVIDER,
+  type VoiceTransport,
 } from "~/server/agents/voice/voice-agent.config";
 import { getApp } from "~/server/app-layer/app";
 import { prisma } from "~/server/db";
@@ -46,6 +47,15 @@ export interface VoiceSessionServices {
       projectId: string;
     }): Promise<AgentWithFields | null>;
     create(input: CreateAgentInput): Promise<AgentWithFields>;
+    /** Creates the voice agent row deduped by its identity key, so a retried
+     *  finish for a not-yet-saved agent reuses the one row (#8020). */
+    createVoiceAgent(input: {
+      id: string;
+      projectId: string;
+      name: string;
+      transport: VoiceTransport;
+      agentId: string;
+    }): Promise<{ id: string }>;
   };
   scenarioService: {
     getById(input: { id: string; projectId: string }): Promise<Scenario | null>;
@@ -129,12 +139,14 @@ export function createVoiceSessionPortsFromServices({
     },
 
     async createVoiceAgent({ projectId, name, transport, agentId }) {
-      const created = await agentService.create({
+      // Deduped by identity key inside the service, so a retried finish for a
+      // not-yet-saved agent reuses the one row (#8020, decision 1).
+      const created = await agentService.createVoiceAgent({
         id: `agent_${nanoid()}`,
         projectId,
         name,
-        type: "voice",
-        config: { transport, agentId },
+        transport,
+        agentId,
       });
       return { id: created.id };
     },

--- a/platform/app/src/server/scenarios/voice/voice-session.ports.ts
+++ b/platform/app/src/server/scenarios/voice/voice-session.ports.ts
@@ -56,6 +56,13 @@ export interface VoiceSessionServices {
       transport: VoiceTransport;
       agentId: string;
     }): Promise<{ id: string }>;
+    /** Whether this project saved a voice agent for the given vendor agent id.
+     *  Authorizes drawer recording playback, which writes no run (#8020). */
+    hasVoiceAgentForExternalId(input: {
+      projectId: string;
+      transport: VoiceTransport;
+      agentExternalId: string;
+    }): Promise<boolean>;
   };
   scenarioService: {
     getById(input: { id: string; projectId: string }): Promise<Scenario | null>;
@@ -115,6 +122,17 @@ export function createVoiceSessionPortsFromServices({
       if (agent?.type !== "voice") return null;
       const config = parseVoiceAgentConfig(agent.config);
       return { id: agent.id, agentExternalId: config.agentId };
+    },
+
+    /** Whether the project saved a voice agent for this vendor agent id: the
+     *  provider conversation's agent id is matched to the row a drawer hang-up
+     *  created, so its recording plays back without a run to check (#8020). */
+    hasVoiceAgentForExternalId({ projectId, transport, agentExternalId }) {
+      return agentService.hasVoiceAgentForExternalId({
+        projectId,
+        transport,
+        agentExternalId,
+      });
     },
 
     async findExistingRun({ projectId, scenarioRunId }) {

--- a/platform/app/src/server/scenarios/voice/voice-session.service.ts
+++ b/platform/app/src/server/scenarios/voice/voice-session.service.ts
@@ -635,7 +635,7 @@ async function ingestFinishedCall(
   // Record one trace per exchange before any run is written, so every message
   // links to its exchange's trace (3a). Best effort: recording failures are
   // swallowed inside the port, and the ids come back regardless (decision 7).
-  // Re-run on a re-drive — the ids are deterministic, so the fold dedupes.
+  // Re-run on a re-drive: the ids are deterministic, so the fold dedupes.
   const { turnTraceIds } = await ports.recordCallTraces({
     projectId: input.projectId,
     record,
@@ -652,7 +652,7 @@ async function ingestFinishedCall(
  * call is scored against no scenario, so it is NOT written as a run (#8020).
  * Writing it as a SUCCESS run with no verdict is exactly the forever-"the judge
  * is reading the conversation" state this issue removes. The agent row is still
- * created on first hang-up (unrelated to run-writing — decision 3), deduped by
+ * created on first hang-up (unrelated to run-writing, decision 3), deduped by
  * its identity key so a retried finish for a not-yet-saved agent reuses the
  * same row rather than creating a second one (decision 1).
  */

--- a/platform/app/src/server/scenarios/voice/voice-session.service.ts
+++ b/platform/app/src/server/scenarios/voice/voice-session.service.ts
@@ -186,6 +186,14 @@ export interface VoiceSessionPorts {
     projectId: string;
     agentRowId: string;
   }): Promise<{ id: string; agentExternalId: string } | null>;
+  /** Whether this project saved a voice agent for the given vendor agent id,
+   *  matched on the row's identity key. A drawer call writes no run to check
+   *  playback against (#8020), so this is what authorizes its recording. */
+  hasVoiceAgentForExternalId(input: {
+    projectId: string;
+    transport: VoiceTransport;
+    agentExternalId: string;
+  }): Promise<boolean>;
   /** The run already written for this id, or null. Returns the agent id it
    *  attached so a duplicate finish can answer with it, and the run status so a
    *  finish short-circuits on a written run but re-drives a half-written one
@@ -805,4 +813,91 @@ export async function finishVoiceSession(input: {
     audioUrl: record.audioUrl,
     scenarioSetId: scenarioContext.scenarioSetId,
   };
+}
+
+/**
+ * Whether a drawer call's recording belongs to this project. A drawer call is
+ * never written as a run (#8020), so there is nothing to authorize its playback
+ * against; instead the provider is asked which agent the conversation ran
+ * against, and playback is allowed only when this project saved that voice
+ * agent. A refused redirect, a not-yet-ready record or a fetch failure all read
+ * the same way: not this project's to play. Traces are deliberately not
+ * consulted, since a trace write goes through the ingest pipeline and can lag
+ * the hang-up.
+ */
+async function drawerRecordingBelongsToProject(
+  ports: VoiceSessionPorts,
+  {
+    projectId,
+    transport,
+    conversationId,
+    credential,
+  }: {
+    projectId: string;
+    transport: VoiceTransport;
+    conversationId: string;
+    credential: VoiceTransportCredential;
+  },
+): Promise<boolean> {
+  let record: CallRecord | null;
+  try {
+    record = await runnerFor(ports, transport).fetchCallRecord({
+      conversationId,
+      credential,
+      audioProxyUrl: ports.audioProxyUrl({ conversationId, projectId }),
+    });
+  } catch {
+    return false;
+  }
+  const agentExternalId = record?.agentExternalId;
+  if (!agentExternalId) return false;
+  return ports.hasVoiceAgentForExternalId({
+    projectId,
+    transport,
+    agentExternalId,
+  });
+}
+
+/**
+ * Authorize a recording-playback request and return the provider credential the
+ * route streams the audio with. A scenario "Call it myself" run authorizes
+ * playback directly (a run for the conversation exists in this project). A
+ * drawer call writes no run (#8020), so it is authorized only when the provider
+ * conversation ran against a voice agent this project saved. Anything else
+ * throws {@link VoiceRecordingUnavailableError}; the credential is returned only
+ * on success, so it never leaks on a refusal. Throws
+ * {@link VoiceRecordingKeyMissingError} when the project has no provider key.
+ * Drawer calls only run on ElevenLabs today.
+ */
+export async function authorizeRecordingPlayback({
+  ports,
+  projectId,
+  conversationId,
+}: {
+  ports: VoiceSessionPorts;
+  projectId: string;
+  conversationId: string;
+}): Promise<VoiceTransportCredential> {
+  const transport: VoiceTransport = "elevenlabs_convai";
+  const existing = await ports.findExistingRun({
+    projectId,
+    scenarioRunId: scenarioRunIdForConversation(conversationId),
+  });
+
+  const credential = await ports.resolveCredential({ projectId, transport });
+  if (!credential) throw new VoiceRecordingKeyMissingError();
+
+  // A scenario run authorizes playback directly; no provider call needed.
+  if (existing) return credential;
+
+  // No run was written (a drawer call, #8020): authorize only when the provider
+  // conversation ran against a voice agent this project actually saved.
+  const allowed = await drawerRecordingBelongsToProject(ports, {
+    projectId,
+    transport,
+    conversationId,
+    credential,
+  });
+  if (!allowed) throw new VoiceRecordingUnavailableError();
+  return credential;
 }

--- a/platform/app/src/server/scenarios/voice/voice-session.service.ts
+++ b/platform/app/src/server/scenarios/voice/voice-session.service.ts
@@ -225,16 +225,17 @@ export interface VoiceSessionPorts {
     scenario?: { scenarioId: string; scenarioSetId: string };
     scenarioRunId: string;
   }): Promise<{ turnTraceIds: string[] }>;
-  /** Write the call down as a run the results pages render. When `scenario`
-   *  is given the run lands under that scenario (a "Call it myself" run);
-   *  otherwise it lands in the voice-call set (a drawer call). */
+  /** Write the call down as a run the results pages render. Only ever called
+   *  for a "Call it myself" call, so `scenario` is always named: the run lands
+   *  under that scenario and its set and is judged. A drawer call is never
+   *  written as a run (#8020). */
   writeCallRun(input: {
     projectId: string;
     scenarioRunId: string;
     agentRowId: string;
     agentDisplayName: string;
     record: CallRecord;
-    scenario?: { scenarioId: string; scenarioSetId: string };
+    scenario: { scenarioId: string; scenarioSetId: string };
     turnTraceIds: readonly string[];
   }): Promise<void>;
   /** The set a scenario's runs are listed under, so a "Call it myself" run
@@ -439,16 +440,15 @@ async function resolveAgentRow(
 
 /**
  * Resolve the scenario a "Call it myself" run is written under and the set it
- * shares with that scenario's simulated runs (AC23). Undefined only for a
- * drawer call (no scenario id). A named scenario that cannot be resolved throws
- * {@link VoiceScenarioNotFoundError}: writing it as an unscored drawer call
- * would lose the verdict the caller asked for (#8019).
+ * shares with that scenario's simulated runs (AC23). A named scenario that
+ * cannot be resolved throws {@link VoiceScenarioNotFoundError}: writing it as
+ * an unscored run would lose the verdict the caller asked for (#8019). Called
+ * only on the scenario branch, so `scenarioId` is always present.
  */
 async function resolveScenarioContext(
   ports: VoiceSessionPorts,
-  { projectId, scenarioId }: { projectId: string; scenarioId?: string },
-): Promise<{ scenarioId: string; scenarioSetId: string } | undefined> {
-  if (!scenarioId) return undefined;
+  { projectId, scenarioId }: { projectId: string; scenarioId: string },
+): Promise<{ scenarioId: string; scenarioSetId: string }> {
   const scenario = await ports.resolveScenarioSet?.({ projectId, scenarioId });
   if (!scenario) throw new VoiceScenarioNotFoundError();
   return { scenarioId, scenarioSetId: scenario.scenarioSetId };
@@ -564,17 +564,149 @@ const WRITTEN_STATUSES: ReadonlySet<ScenarioRunStatus> = new Set([
   ScenarioRunStatus.SUCCESS,
   ScenarioRunStatus.FAILED,
 ]);
+/**
+ * The shared tail of a finished call: read the provider record (or fall back to
+ * the live transcript), reject a conversation the token has no claim to,
+ * resolve the agent row and record one trace per exchange. Returns the record
+ * and agent id both branches build their result from. A drawer call runs only
+ * this much; a scenario call goes on to write the run.
+ */
+async function ingestFinishedCall(
+  input: {
+    ports: VoiceSessionPorts;
+    token: VoiceSessionTokenPayload;
+    projectId: string;
+    name?: string;
+    transcript: BrowserTranscriptTurn[];
+    startedAt: number;
+    endedAt: number;
+    isCutAtLimit: boolean;
+  },
+  {
+    transport,
+    conversationId,
+    scenarioRunId,
+    scenario,
+    existingAgentId,
+  }: {
+    transport: VoiceTransport;
+    conversationId: string;
+    scenarioRunId: string;
+    scenario?: { scenarioId: string; scenarioSetId: string };
+    existingAgentId?: string;
+  },
+): Promise<{
+  record: CallRecord;
+  hasFetchFailed: boolean;
+  agentRowId: string;
+  agentDisplayName: string;
+  turnTraceIds: readonly string[];
+}> {
+  const { ports, token } = input;
+
+  // Prefer the provider's record; fall back to the live transcript when it is
+  // not ready or the fetch fails. Fetched BEFORE the agent row is created so a
+  // mismatched conversation is rejected without leaving an orphan agent behind.
+  const { record: providerRecord, hasFetchFailed } = await fetchProviderRecord(
+    ports,
+    { transport, conversationId, projectId: input.projectId },
+  );
+
+  assertProviderRecordMatchesToken(providerRecord, token);
+
+  const { agentRowId, agentDisplayName } = await resolveAgentRow(ports, {
+    token,
+    projectId: input.projectId,
+    transport,
+    name: input.name,
+    existingAgentId,
+  });
+
+  const record = selectCallRecord({
+    providerRecord,
+    transcript: input.transcript,
+    conversationId,
+    transport,
+    startedAt: input.startedAt,
+    endedAt: input.endedAt,
+    isCutAtLimit: input.isCutAtLimit,
+  });
+
+  // Record one trace per exchange before any run is written, so every message
+  // links to its exchange's trace (3a). Best effort: recording failures are
+  // swallowed inside the port, and the ids come back regardless (decision 7).
+  // Re-run on a re-drive — the ids are deterministic, so the fold dedupes.
+  const { turnTraceIds } = await ports.recordCallTraces({
+    projectId: input.projectId,
+    record,
+    scenarioRunId,
+    ...(scenario ? { scenario } : {}),
+  });
+
+  return { record, hasFetchFailed, agentRowId, agentDisplayName, turnTraceIds };
+}
 
 /**
- * Ingest a finished call as a run, exactly once per conversation.
+ * Finish a drawer "Talk to it" call. Every browser call records one trace per
+ * exchange (3a), which is where the transcript and recording live; a drawer
+ * call is scored against no scenario, so it is NOT written as a run (#8020).
+ * Writing it as a SUCCESS run with no verdict is exactly the forever-"the judge
+ * is reading the conversation" state this issue removes. The agent row is still
+ * created on first hang-up (unrelated to run-writing — decision 3), deduped by
+ * its identity key so a retried finish for a not-yet-saved agent reuses the
+ * same row rather than creating a second one (decision 1).
+ */
+async function finishDrawerCall(
+  input: {
+    ports: VoiceSessionPorts;
+    token: VoiceSessionTokenPayload;
+    projectId: string;
+    name?: string;
+    transcript: BrowserTranscriptTurn[];
+    startedAt: number;
+    endedAt: number;
+    isCutAtLimit: boolean;
+  },
+  {
+    transport,
+    conversationId,
+    scenarioRunId,
+  }: {
+    transport: VoiceTransport;
+    conversationId: string;
+    scenarioRunId: string;
+  },
+): Promise<FinishResult> {
+  const { record, hasFetchFailed, agentRowId } = await ingestFinishedCall(
+    input,
+    { transport, conversationId, scenarioRunId },
+  );
+
+  return {
+    // No run: a drawer call is not persisted as one (#8020). The agent id is
+    // still returned so the panel can register the row it just created.
+    runId: "",
+    agentId: agentRowId,
+    source: record.source,
+    hasFetchFailed,
+    hasAudio: Boolean(record.audioUrl),
+    audioUrl: record.audioUrl,
+  };
+}
+
+/**
+ * Ingest a finished call.
  *
- * Idempotent on the conversation id: a second hang-up, a mid-call reload or a
- * late webhook all resolve to the same run id. A fully written run
- * (SUCCESS/FAILED) is returned untouched (AC14, #7973 AC1); a half-written or
- * cancelled run is re-driven through `writeCallRun` (#7973 AC2). Creates the
- * agent row when the drawer had none; falls back
- * to the live transcript when the provider record is not ready or the fetch
- * fails, marking the latter so the panel can say so (AC15).
+ * Two shapes, split on whether the call names a scenario:
+ *  - A drawer "Talk to it" call (no scenario id) records its traces and returns;
+ *    it is never written as a run (#8020). See {@link finishDrawerCall}.
+ *  - A "Call it myself" call (a scenario id) is written as a run and judged,
+ *    idempotently on the conversation id: a second hang-up, a mid-call reload or
+ *    a late webhook all resolve to the same run id. A fully written run
+ *    (SUCCESS/FAILED) is returned untouched (AC14, #7973 AC1); a half-written or
+ *    cancelled run is re-driven through `writeCallRun` (#7973 AC2). Falls back to
+ *    the live transcript when the provider record is not ready or the fetch
+ *    fails, marking the latter so the panel can say so (AC15).
  */
 export async function finishVoiceSession(input: {
   ports: VoiceSessionPorts;
@@ -589,13 +721,24 @@ export async function finishVoiceSession(input: {
   isCutAtLimit: boolean;
   conversationId?: string;
   /** Set for a "Call it myself" run: the scenario the call is scored under
-   *  (AC23). Absent for a drawer call. */
+   *  (AC23). Absent for a drawer call, which is not written as a run (#8020). */
   scenarioId?: string;
 }): Promise<FinishResult> {
   const { ports, token } = input;
   const transport = token.transport;
   const conversationId = input.conversationId?.trim() || token.sessionId;
   const scenarioRunId = scenarioRunIdForConversation(conversationId);
+
+  // A drawer call is scored against no scenario, so it is never written as a
+  // run: there is never a run to find, re-drive or write for its conversation id
+  // (#8020). It still records its traces and creates the agent row.
+  if (!input.scenarioId) {
+    return finishDrawerCall(input, {
+      transport,
+      conversationId,
+      scenarioRunId,
+    });
+  }
 
   // A terminal run is complete: a duplicate finish returns it untouched (AC14,
   // #7973 AC1). A non-terminal run is half-written — startRun landed but a
@@ -634,44 +777,14 @@ export async function finishVoiceSession(input: {
           scenarioId: input.scenarioId,
         });
 
-  // Prefer the provider's record; fall back to the live transcript when it is
-  // not ready or the fetch fails. Fetched BEFORE the agent row is created so a
-  // mismatched conversation is rejected without leaving an orphan agent behind.
-  const { record: providerRecord, hasFetchFailed } = await fetchProviderRecord(
-    ports,
-    { transport, conversationId, projectId: input.projectId },
-  );
-
-  assertProviderRecordMatchesToken(providerRecord, token);
-
-  const { agentRowId, agentDisplayName } = await resolveAgentRow(ports, {
-    token,
-    projectId: input.projectId,
-    transport,
-    name: input.name,
-    existingAgentId: existing?.agentId ?? undefined,
-  });
-
-  const record = selectCallRecord({
-    providerRecord,
-    transcript: input.transcript,
-    conversationId,
-    transport,
-    startedAt: input.startedAt,
-    endedAt: input.endedAt,
-    isCutAtLimit: input.isCutAtLimit,
-  });
-
-  // Record one trace per exchange before the run is written, so every message
-  // links to its exchange's trace (decision 1). Best effort: recording failures
-  // are swallowed inside the port, and the ids come back regardless (decision
-  // 7). Re-run on a re-drive — the ids are deterministic, so the fold dedupes.
-  const { turnTraceIds } = await ports.recordCallTraces({
-    projectId: input.projectId,
-    record,
-    scenarioRunId,
-    ...(scenarioContext ? { scenario: scenarioContext } : {}),
-  });
+  const { record, hasFetchFailed, agentRowId, agentDisplayName, turnTraceIds } =
+    await ingestFinishedCall(input, {
+      transport,
+      conversationId,
+      scenarioRunId,
+      scenario: scenarioContext,
+      existingAgentId: existing?.agentId ?? undefined,
+    });
 
   await ports.writeCallRun({
     projectId: input.projectId,
@@ -680,7 +793,7 @@ export async function finishVoiceSession(input: {
     agentDisplayName,
     record,
     turnTraceIds,
-    ...(scenarioContext ? { scenario: scenarioContext } : {}),
+    scenario: scenarioContext,
   });
 
   return {
@@ -690,6 +803,6 @@ export async function finishVoiceSession(input: {
     hasFetchFailed,
     hasAudio: Boolean(record.audioUrl),
     audioUrl: record.audioUrl,
-    scenarioSetId: scenarioContext?.scenarioSetId,
+    scenarioSetId: scenarioContext.scenarioSetId,
   };
 }

--- a/platform/app/src/server/scenarios/voice/voice-session.service.ts
+++ b/platform/app/src/server/scenarios/voice/voice-session.service.ts
@@ -322,6 +322,7 @@ export async function mintVoiceSession({
   const agentId = row?.agentExternalId ?? bodyAgentId;
 
   const runner = runnerFor(ports, transport);
+  runner.assertAvailable?.();
   const credential = await ports.resolveCredential({ projectId, transport });
   if (!credential) throw new VoiceKeyMissingError(runner.missingKeyMessage);
 
@@ -386,10 +387,12 @@ async function fetchProviderRecord(
     projectId,
   }: { transport: VoiceTransport; conversationId: string; projectId: string },
 ): Promise<{ record: CallRecord | null; hasFetchFailed: boolean }> {
+  const runner = runnerFor(ports, transport);
+  runner.assertAvailable?.();
   const credential = await ports.resolveCredential({ projectId, transport });
   if (!credential) return { record: null, hasFetchFailed: false };
   try {
-    const record = await runnerFor(ports, transport).fetchCallRecord({
+    const record = await runner.fetchCallRecord({
       conversationId,
       credential,
       audioProxyUrl: ports.audioProxyUrl({ conversationId, projectId }),

--- a/platform/app/src/server/scenarios/voice/voice-transport.registry.ts
+++ b/platform/app/src/server/scenarios/voice/voice-transport.registry.ts
@@ -9,6 +9,7 @@ import type { AgentAdapter } from "@langwatch/scenario";
 import type { VoiceTransport } from "~/server/agents/voice/voice-agent.config";
 import type { CallRecord } from "./call-record";
 import { elevenLabsConvaiTransport } from "./transports/elevenlabs-convai.transport";
+import { phoneTransport } from "./transports/phone.transport";
 
 /** The provider key and host a runner reads a conversation back with. Never
  *  reaches the browser — a runner keeps it and returns only the signed URL. */
@@ -25,6 +26,14 @@ export interface VoiceSessionConnect {
 }
 
 export interface VoiceTransportRunner {
+  /**
+   * Guard that runs before any credential lookup, so a transport that cannot
+   * run yet fails with its own typed error rather than the generic
+   * {@link VoiceTransportRunner.missingKeyMessage} key-missing error. Left
+   * unimplemented by transports that are ready; the phone stub throws here
+   * until the voice worker that dials it ships.
+   */
+  assertAvailable?(): void;
   /** Build the SDK agent adapter the pool child drives for this transport. */
   createAgentAdapter(input: {
     agentId: string;
@@ -68,4 +77,5 @@ export const voiceTransportRegistry: Record<
   VoiceTransportRunner
 > = {
   elevenlabs_convai: elevenLabsConvaiTransport,
+  phone: phoneTransport,
 };

--- a/specs/features/agents/voice-agents-v1.feature
+++ b/specs/features/agents/voice-agents-v1.feature
@@ -25,7 +25,7 @@ Feature: Voice agents v1: test an ElevenLabs agent from the app
     When I save the agent
     Then "Support line" appears in the agents list with the mic icon
     When I press "Talk to it", allow the microphone, say "I want to cancel my order" and hang up after the agent answers
-    Then the panel shows the transcript, a Play control and a link to a run with caller "You"
+    Then the panel shows the transcript and a Play control, and no run exists for that conversation id
     When I open New scenario, write the situation, the persona and the criteria for "Angry cancellation"
     And under Agent I pick "Support line", keep the project default caller voice and save
     And I press "Run"
@@ -40,8 +40,8 @@ Feature: Voice agents v1: test an ElevenLabs agent from the app
     Then the panel shows Connecting, then a running timer and a live two-speaker transcript
     When I say "I want to cancel my order" and the agent answers
     And I press "Hang up"
-    Then the panel shows the transcript, a Play control and a link to the run
-    And that run has caller "You", per-turn audio and the transcript
+    Then the panel shows the transcript and a Play control, and no run exists for that conversation id
+    And a trace exists for that conversation id with per-turn audio and the transcript
 
   # AC19, AC24
   @e2e @unimplemented
@@ -148,11 +148,19 @@ Feature: Voice agents v1: test an ElevenLabs agent from the app
     And the panel shows "Recording could not be fetched from ElevenLabs" instead of a generic error
 
   # AC14
-  @integration
+  @unit @regression
   Scenario: Hanging up twice produces exactly one run
-    Given a live call against "Support line" with a known conversation id
+    Given a live "Call it myself" call against a scenario with a known conversation id
     When Hang up is pressed twice for that conversation id
     Then exactly one run exists for that conversation id
+
+  # #8020 AC1
+  @unit @regression
+  Scenario: Hanging up twice on a drawer call records traces and writes no run
+    Given a live drawer "Talk to it" call with a known conversation id and no scenario in scope
+    When Hang up is pressed twice for that conversation id
+    Then no run is ever written for that conversation id
+    And the call's traces are recorded, deduped by their deterministic ids
 
   # AC27
   @integration
@@ -733,3 +741,55 @@ Feature: Voice agents v1: test an ElevenLabs agent from the app
     Given a half-written run is re-driven for the same conversation
     When the call is finished again
     Then the recomputed trace ids are identical to the first attempt
+
+  # ---------------------------------------------------------------------------
+  # A drawer call is not persisted as a run (#8020)
+  # ---------------------------------------------------------------------------
+
+  # #8020 AC1
+  @unit @regression
+  Scenario: A drawer Talk to it call writes no run
+    Given a finish with no scenario id
+    When the call is finished
+    Then writeCallRun is never called
+    And findExistingRun is never called
+    And the call's traces are still recorded
+    And the finish result carries no run id and no scenario set id
+
+  # #8020 AC2
+  @unit @regression
+  Scenario: Call it myself still writes and judges a run after 8020
+    Given a "Call it myself" finish naming a resolvable scenario id
+    When the call is finished
+    Then writeCallRun is called with that scenario and its set
+    And the finish event names the scenario, so the run is judged
+
+  # #8020 AC3
+  @unit @regression
+  Scenario: A drawer finish never mints a synthetic scenario id
+    Given a finish with no scenario id
+    When the call is finished
+    Then writeCallRun is never called
+    And no scenarioId of the form "voiceagent_<agentId>" is ever produced
+
+  # #8020 decision 1
+  @unit @regression
+  Scenario: A retried drawer finish for an unsaved agent reuses the one agent row
+    Given two drawer finishes for the same never-saved voice agent
+    When each finish creates the voice agent row
+    Then the identity key folds them onto the same row rather than creating a second
+
+  # #8020 decision 2
+  @unit @regression
+  Scenario: The legacy voice-calls set is excluded from run listings
+    Given a run-listing query is built
+    When its set exclusion is applied
+    Then the "voice-calls" set is excluded alongside the agent-test set
+    And a run is still read by its own id
+
+  # #8020 decision 5
+  @unit @regression
+  Scenario: A human caller's turns render as You, not User Simulator
+    Given a scenario run whose caller kind is "human"
+    When the conversation body renders a caller turn
+    Then it reads "You" with a person icon, not "User Simulator" with a flask

--- a/specs/features/agents/voice-agents-v1.feature
+++ b/specs/features/agents/voice-agents-v1.feature
@@ -793,3 +793,12 @@ Feature: Voice agents v1: test an ElevenLabs agent from the app
     Given a scenario run whose caller kind is "human"
     When the conversation body renders a caller turn
     Then it reads "You" with a person icon, not "User Simulator" with a flask
+
+  # #8020 regression: a drawer call writes no run, so its recording must be
+  # authorized by matching the provider conversation to a saved voice agent.
+  @unit @regression
+  Scenario: A drawer call's recording still plays after hang-up
+    Given a finished drawer call whose conversation ran against a voice agent saved in the project
+    When the recording is requested and no run exists for that conversation id
+    Then playback is authorized by matching the provider agent id to the saved voice agent row
+    And the provider credential is returned only when the match holds

--- a/specs/features/agents/voice-agents-v1.feature
+++ b/specs/features/agents/voice-agents-v1.feature
@@ -758,7 +758,7 @@ Feature: Voice agents v1: test an ElevenLabs agent from the app
 
   # #8020 AC2
   @unit @regression
-  Scenario: Call it myself still writes and judges a run after 8020
+  Scenario: Call it myself still writes a run under its scenario after 8020
     Given a "Call it myself" finish naming a resolvable scenario id
     When the call is finished
     Then writeCallRun is called with that scenario and its set

--- a/specs/features/agents/voice-agents-v1.feature
+++ b/specs/features/agents/voice-agents-v1.feature
@@ -328,10 +328,11 @@ Feature: Voice agents v1: test an ElevenLabs agent from the app
 
   # AC15
   @integration
-  Scenario: The recording proxy refuses a conversation with no run in the project
+  Scenario: The recording proxy refuses a conversation that is neither a run nor a saved voice agent's call in the project
     Given a recording is requested for a conversation with no run in the authorised project
+    And the provider record's agent does not match any saved voice agent in the project
     When the proxy is handled
-    Then it answers "Recording unavailable" and never fetches the provider
+    Then it answers "Recording unavailable" without streaming the audio
 
   # AC13
   @integration

--- a/specs/features/agents/voice-phone.feature
+++ b/specs/features/agents/voice-phone.feature
@@ -1,0 +1,58 @@
+Feature: Voice agents: reach an agent by phone
+  As a team whose voice agent answers a phone number
+  I want to register that number as a target in the app
+  So that a scenario run can call it once the voice worker ships
+
+  # @see https://github.com/langwatch/langwatch/issues/8014
+  # Slice 1 is additive and inert: the phone member is selectable behind a flag,
+  # but every run over phone fails with a clear message until the voice worker
+  # that dials it exists.
+
+  # ---------------------------------------------------------------------------
+  # Config schema
+  # ---------------------------------------------------------------------------
+
+  @unit
+  Scenario: A phone target stores its number in E.164 form
+    Given a voice agent config for the phone transport with number " +14155550123 "
+    When the config is validated
+    Then it is accepted and the number is trimmed to "+14155550123"
+
+  @unit
+  Scenario: A phone target rejects a number that is not E.164
+    Given a voice agent config for the phone transport with number "415-555-0123"
+    When the config is validated
+    Then it is rejected
+
+  # ---------------------------------------------------------------------------
+  # Runner (stub until the voice worker ships)
+  # ---------------------------------------------------------------------------
+
+  @integration
+  Scenario: A phone target has no browser call
+    Given the phone transport runner
+    When a browser session mint is attempted
+    Then it fails because phone targets have no browser call
+
+  @unit
+  Scenario: Running a phone target before the voice worker exists fails with a clear message
+    Given the phone transport runner
+    When any of its call methods is invoked
+    Then it fails with a message that points at issue 8014
+
+  # ---------------------------------------------------------------------------
+  # Drawer option gating
+  # ---------------------------------------------------------------------------
+
+  @integration
+  Scenario: The phone option is hidden until the phone targets flag is on
+    Given the voice agent editor with the phone targets flag off
+    Then the "Reached via" list offers no Phone number option
+    When the phone targets flag is on
+    Then the "Reached via" list offers the Phone number option
+
+  @integration
+  Scenario: A phone target's drawer explains why Talk to it is off
+    Given the voice agent editor open on a saved phone target
+    Then the Talk to it button is disabled
+    And its tooltip says browser calls are not available for phone targets


### PR DESCRIPTION
## What

Drawer "Talk to it" calls stop writing a synthetic scenario run. They record one trace per exchange (from #8037) and return no run id. "Call it myself" calls, which carry a scenario, write a run under that scenario, scored the same way a simulated run is. Plan step 3b of #7978.

This PR also carries #8014 slice 1 (the phone transport member behind a flag, with a stub runner), merged down from #8049 at `c721b925d2` on the maintainer's instruction so both land on main in one merge. Its full description, screenshots and proof are in the last section, "Also in this PR: #8014 slice 1".

## Why

Every drawer call used to be written as a run under a made-up `voiceagent_<id>` scenario in a `voice-calls` set, finished as SUCCESS and never scored, so the run drawer showed "the judge is reading" forever and the Agent Testing listing filled with runs nobody asked for. The broken production run in #7973 came from that path. A drawer call is a conversation, not a test: its record is the trace.

## Changes

- `voice-session.service.ts`: `finishVoiceSession` branches on the presence of a scenario. Both paths share `ingestFinishedCall` (traces first); only the scenario path writes a run. The drawer path skips the run lookup and returns `runId: ""`.
- `voice-run-writer.ts`: the synthetic scenario fallback is gone; `scenario` is a required argument and `finishRun` always names the scenario it belongs to.
- `agent.service.ts` / `agent.repository.ts`: `createVoiceAgent` folds repeated calls onto one agent row through the existing `(projectId, identityKey)` unique key with `identityKey = "voice:<transport>:<agentExternalId>"`, using the same race-safe pattern as `registerConnected`. A Postgres integration test covers the concurrent case.
- `simulation.clickhouse.repository.ts` / `atom-sql.ts`: the `voice-calls` set joins the existing exclusion list in every set-listing and aggregate query, including `getSetSummaries` (which feeds the Agent Testing run-plan list and the suites sidebar) and `getDistinctExternalSetIds`. Runs written before this change disappear from listings while their pages still open by id. `VOICE_CALL_SCENARIO_SET_ID` stays as the single source of that literal.
- `caller-display.ts`, `scenarioRoles.tsx`, `ScenarioMessageRenderer.tsx`, `RunDrawerContent.tsx`, `ScenarioRunDetailDrawer.tsx`, `TraceDrawerContent.tsx`: a human caller renders as "You" instead of "User Simulator", driven by the run's caller kind through the shared `isHumanCallerRun` helper and by the trace's `voice.call.caller` attribute.
- `TalkToItPanel.tsx`: the run link and the set-id fallback are removed; the panel no longer knows about scenario runs.
- Docs `docs/agent-testing/voice-agents-in-app.mdx` (mirrored in `docs/llms-full.txt`) and the feature file: the "Hanging up twice" scenario is split into the scenario path (one run) and the drawer path (traces, no run).

## Verification

- 121 unit and component tests across the nine touched vitest files pass locally (voice session service, run writer, ports, voice API route, agent voice-create, scenario roles, caller display, ClickHouse repository SQL, atom SQL, TalkToItPanel), plus the two-case Postgres integration test for the identity-key race.
- Feature parity check binds every new scenario to a test.
- `git grep voiceagent_ platform/app/src` returns nothing.
- Biome and the docs prose check are clean on every touched file.

## Human verification

1. Open an agent's Talk to it drawer, hold a short call, hang up. No run appears under Agent Testing; the trace list shows one `Voice Call Turn` trace per exchange with the caller labelled "You".
2. Run "Call it myself" on a voice scenario, hold the call, hang up. A run appears under that scenario and its drawer shows your side as "You" with a "View trace" link per turn.
3. Confirm the Agent Testing results listing no longer shows the `voice-calls` set, while an old run from that set still opens by URL.
4. Start two drawer calls for the same agent: only one agent row exists for it.
5. After a drawer call hangs up, press play on the recording shown in the drawer. It plays, although no run was written for that call.

## How I can prove I was successful

Dev proof captured with the app at `51732e258a` (the branch was afterwards rebased onto main once #8025 merged, with no content change). Transcript: [`pr-8020/transcripts/proof-3b-v4.txt`](https://github.com/langwatch/pr-screenshots/blob/main/pr-8020/transcripts/proof-3b-v4.txt).

1. Finish endpoints and ClickHouse readback: two drawer finishes return `runId: ""` and the same `agentId` (one Postgres row with `identityKey = voice:elevenlabs_convai:agent_6201…`), the "Call it myself" finish returns a `voicecall_` run under its suite set, zero `voiceagent_` runs in the window, five `Voice Call Turn` spans with `voice.call.caller = human` and no `scenario.run_id`, and the legacy `voice-calls` rows are excluded by the listing predicate.
   ![finish endpoints and readback](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-8020/finish-endpoints-and-readback.png)
2. The "Call it myself" run opens by id under its scenario; the caller side reads "You" and every turn has a "View trace" link.
   ![call it myself run](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-8020/call-it-myself-run-caller-you.png)
3. A drawer call's trace in Trace Explorer, Conversation tab: three turns for `conv_proof_3b_talk_v4`, service `langwatch-voice`, no run behind it.
   ![drawer call trace](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-8020/drawer-call-trace-conversation.png)
4. Agent Testing results at the same commit: three run plans, none of them `voice-calls`, although eight legacy rows still exist in that set.
   ![results listing without voice-calls](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-8020/results-listing-without-voice-calls.png)

5. Drawer recording playback, fixed in `767b940f59`, `46ac2952ce` and `a92a9103cd` for the review finding on `voice-session.service.ts:740`: before the fix the drawer finish for a real ElevenLabs conversation returned `hasAudio: true` and its proxy URL, yet fetching that URL answered HTTP 404 `voice_recording_unavailable` because the proxy only authorized conversations that had a run. After the fix the same conversation streams HTTP 200 `audio/mpeg` (122,157 bytes) with still no run written, and an unknown conversation still gets 404. Transcripts: [after](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-8020/transcripts/drawer-recording-playback.txt), [before](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-8020/transcripts/drawer-recording-playback-before-fix.txt).

Closes #8020

## Also in this PR: #8014 slice 1, phone transport plumbing (merged down from #8049)

Squash of #8049 (`557b3f0beb`, its own review verdict and ready check are on that PR) into this branch as `c721b925d2`, plus `655caf3479`, which answers the CodeQL alert the combined head raised: the drawer's sessionStorage draft no longer persists the phone number (only name, transport and agent id are stored; a component test covers it). Additive and inert: nothing can be dialled yet.

### What

Slice 1 of #8014: the phone transport member, behind a flag, with a stub runner. Additive and inert. Nothing can be dialled yet; the real Twilio runner, project config (allowed callees, max call seconds) and the voice worker are slices 2 and 3, which wait on scenario SDK 2.0.0 (langwatch/scenario#977).

- `voice-agent.config.ts`: `"phone"` joins `VOICE_TRANSPORTS`; zod branch `{ transport: "phone", phoneNumber }` validated as E.164 (`/^\+[1-9]\d{1,14}$/`) with the message "Enter the number in E.164 form, like +14155550123"; label "Phone number"; provider "twilio". The identity key reuses #8040's helper, so a phone target dedups on `voice:phone:<phoneNumber>`.
- `transports/phone.transport.ts`: a `VoiceTransportRunner` whose every method throws `VoicePhoneTransportUnavailableError` (code `voice_phone_transport_unavailable`, customer fault, message points at #8014). Registered in the server registry; error code registered in `codes.ts` and `presentation.ts`.
- `voice-transport-client.registry.ts`: now `Partial<Record<VoiceTransport, VoiceTransportClient>>` with `getVoiceTransportClient()`. Phone has no browser client, so `TalkToItPanel` shows "This agent is reached by phone. Call it from a scenario run; browser calls are not available for phone targets." instead of the call machine.
- `AgentVoiceEditorDrawer.tsx`: a "Reached via: Phone number" option with an E.164 input, offered only when `release_voice_phone_targets_enabled` is on (new flag, default off, `useVoicePhoneTargetsEnabled`). An existing phone target still renders its fields with the flag off. Its footer "Talk to it" button is disabled for phone with the tooltip "Browser calls are not available for phone targets. Call it from a scenario run."
- `voice-transport.registry.ts` / `voice-session.service.ts`: optional `VoiceTransportRunner.assertAvailable()` runs before any credential lookup in `mintVoiceSession` and the finish path, so a phone target fails with `voice_phone_transport_unavailable` rather than `voice_key_missing`. ElevenLabs does not implement it.
- `specs/features/agents/voice-phone.feature`: six scenarios, all bound. One sentence added to `docs/agent-testing/voice-agents-in-app.mdx` and mirrored in `docs/llms-full.txt`.

### Why

#8014 wants phone targets for voice scenario runs. Landing the schema, the flag, the error code and the UI gate first keeps slices 2 and 3 (Twilio runner + worker) small and lets the SDK major bump be reviewed on its own.

### Human verification

Screenshots below are from the dev app at `557b3f0beb` on a project with the flag flipped through the `FeatureFlag` table.

1. Flag off: the voice agent drawer offers only "ElevenLabs agent" under "Reached via".
   ![flag off](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-8014/drawer-flag-off-elevenlabs-only.png)
2. Flag on: "Phone number" appears; a non-E.164 value shows the validation message; a valid number saves.
   ![flag on, validation](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-8014/drawer-phone-option-e164-validation.png)
   ![phone target saved](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-8014/drawer-phone-target-saved.png)
3. Talk to it on the saved phone target shows the "reached by phone" notice instead of the call machine; the drawer footer button is disabled with the phone tooltip (transcript below).
   ![talk to it notice](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-8014/talk-panel-phone-notice.png)
4. `POST /api/voice/session` for the saved phone target returns HTTP 400 with code `voice_phone_transport_unavailable`, while the same call for an ElevenLabs agent still returns a session: [mint transcript](https://github.com/langwatch/pr-screenshots/blob/main/pr-8014/transcripts/mint-session-phone-target.txt).

### How I can prove I was successful

From `platform/app`:

```
NODE_ENV=test PINO_LOG_LEVEL=warn DATABASE_URL=postgresql://prisma:x@127.0.0.1:1/none pnpm -s exec vitest run \
  src/server/agents/voice/__tests__/voice-agent.config.unit.test.ts \
  src/server/scenarios/voice/__tests__/phone.transport.unit.test.ts \
  src/server/scenarios/voice/__tests__/voice-session.service.unit.test.ts
NODE_ENV=test PINO_LOG_LEVEL=warn DATABASE_URL=postgresql://prisma:x@127.0.0.1:1/none pnpm -s exec vitest run -c vitest.component.config.ts \
  src/components/agents/__tests__/AgentVoiceEditorDrawer.integration.test.tsx \
  src/components/agents/voice/__tests__/TalkToItPanel.integration.test.tsx
pnpm -s exec tsx scripts/check-feature-parity.ts
```

Expected: 43 unit and 24 component tests pass; parity exits 0 with `voice-phone.feature` 6/6 bound. Biome from the app root is clean on the touched files apart from three pre-existing warnings.

### CI follow-up

The first CI run at the old head caught seven typecheck errors and three new Biome complexity warnings that the local checks had missed. Fixes now in the single commit: a `voiceAgentExternalId` helper (agent id for ElevenLabs, phone number for phone) used wherever identity was read from the config; the run drawer's browser-call target returns null for phone; the scenario prefetcher throws `VoicePhoneTransportUnavailableError` for phone before any credential read; the two transport-record test fixtures gained a `phone` entry; and the voice editor drawer's `resolveInitialForm`, `useVoiceAgentEditor` and `AgentVoiceEditorDrawer` were split so the file stays inside the repo's complexity limits. The CI lint gate reproduced locally reports no new Biome violations against the base.

Refs #7978, #7973, #8037, #8014
