### PR TITLE
chore(governance): close the debt PR #8023 left (#8041)

### DIFF
--- a/dev/docs/adr/122-openai-admin-cost-puller.md
+++ b/dev/docs/adr/122-openai-admin-cost-puller.md
@@ -241,7 +241,7 @@ is shaped like its first caller. Revisit at the third provider.
 
 **12. `openai_compliance` is deprecated in place, still listed.**
 
-> **[NOT IMPLEMENTED — see revision v3.]** No code path deprecates
+> **[NOT IMPLEMENTED — see revision v3. OVERTAKEN — see revision v5.]** No code path deprecates
 > `openai_compliance`. Its catalog entry carries no `deprecated` flag
 > (`ingestionSourceCatalog.tsx:142-149`), so the picker offers it for new
 > sources exactly as before. The `deprecated` flag itself does exist and is
@@ -252,6 +252,24 @@ is shaped like its first caller. Revisit at the third provider.
 > expect that (`ingestionSourceCatalog.unit.test.ts:19,27-41`) instead of
 > staying green unchanged. Both halves of the decision below — the badge and
 > the badging of this source type — are therefore unbuilt.
+>
+> **[OVERTAKEN — see revision v5.]** The type is deprecated now, by the
+> mechanism this decision rejected rather than the one it chose.
+> `openai_compliance` carries `deprecated: true`
+> (`ingestionSourceCatalog.tsx:199`), and two other types carry it beside it:
+> `copilot_studio` (`:172`) and `claude_compliance` (`:221`).
+> `offeredSourceTypeOptions` filters every flagged entry out of the offered
+> list (`:343-344`), and the picker reads that list through
+> `gatedSourceTypeOptions` (`:376,381`), so all three are **hidden** rather
+> than shown behind a disabled badge. The entries stay in the catalog array
+> so existing rows keep their label and the completeness guard still
+> compiles. What survives of the decision is its intent — the type cannot be
+> chosen for a new source — not its mechanism.
+>
+> **No backfill was done and none is planned.** Rows already configured on
+> any of the three types, and the data those rows already pulled, are
+> untouched; nothing here repairs, re-pulls or removes them, and no owner or
+> date is attached to doing so.
 
 It stays
 registered, stays in the catalog array, and stays **visible** in the picker
@@ -311,7 +329,7 @@ can exist, so there is nothing to repair.
 | Cost figure → ledger | No — `argMax` replacement destroys the prior figure | Money | Human review, plus the no-division and costless-read tests above. A dollar figure is asserted end to end against a captured payload, not a hand-written one. |
 | Provider identity ids leaving for third-party SIEMs | No — an export is a send | Privacy | Human review. `governanceOcsfEvents.clickhouse.repository.ts:236,284` exports `RawOcsfJson` to whatever SIEM an org has wired, and `raw_payload` is **required** on every pull event (`pullerAdapter.ts:96`), so the provider's ids egress by construction. Not introduced here — Anthropic and Genie already do it — but named so it is a decision rather than an accident. |
 | `openai_admin` `pullConfig` shape | No — persists in customer rows | Small (no row exists yet) | Human review of the schema. Validated at create time by `validateConfig`. |
-| `openai_compliance` badged deprecated | Yes | Small | Automated: the two existing catalog tests must stay green **unchanged** — the picker still offers every registered type (Decision 12). **[NOT IMPLEMENTED — v3: nothing badges this type, and the catalog tests were rewritten rather than left unchanged.]** |
+| `openai_compliance` badged deprecated | Yes | Small | Automated: the two existing catalog tests must stay green **unchanged** — the picker still offers every registered type (Decision 12). **[NOT IMPLEMENTED — v3: nothing badges this type, and the catalog tests were rewritten rather than left unchanged. v5: the type is hidden instead of badged, so this gate's condition can never be met as written — see Decision 12.]** |
 | The trailing re-read window | Yes — read-only, bounded by a constant | Small | Automated: the restatement invariant above, plus a test that the watermark does not rewind. |
 | Live pull against the real Admin API | Read-only | None | Required before merge. A fixture alone has never caught a wire-shape error in this codebase. |
 
@@ -396,6 +414,8 @@ extra: {
   listed. A disabled badge achieves the same end. **[v3: the codebase since
   chose hiding for the one type it did retire, and rewrote the catalog tests
   to match; `openai_compliance` itself was never deprecated at all.]**
+  **[v5: this rejection no longer holds — hiding is what shipped, for this
+  type and two others. See Decision 12.]**
 - **A uniqueness guard on duplicate sources** — belongs on every adapter,
   not this one alone.
 - **Extract a shared bucket-report base** — n=2 is a coincidence, and the
@@ -550,6 +570,8 @@ adapter duplicates cursor logic a third provider may justify factoring out.
     the "hide it" alternative this ADR rejected — and the catalog test was
     rewritten to expect that (`ingestionSourceCatalog.unit.test.ts:19,27-41`)
     rather than staying green unchanged as the Gates row required.
+    **[Overtaken in v5: the flag is on the type now, and hiding is the
+    shipped behaviour.]**
   - Stale citations refreshed: `pullerWorker.ts:587` → `:1096`, `:602` →
     `:1110`, `activityMonitor.service.ts:354` → `:379`.
 - **v4 (2026-09-09) — the actor-field divergence is resolved in code.** v3
@@ -592,3 +614,27 @@ adapter duplicates cursor logic a third provider may justify factoring out.
     `ocsfPullEventMapping.ts:108`; `pullerWorker.ts:1080,1110-1112` →
     `ocsfPullEventMapping.ts:43-51,92,123-124`; `openaiAdmin.puller.ts:400,851`
     → `:403,864`.
+
+- **v5 (2026-09-09) — Decision 12 shipped, by the rejected mechanism.** No
+  decision is taken here. v3 recorded Decision 12 as unbuilt; it is built now,
+  and the prose describing it as unbuilt is marked rather than removed so the
+  record of what was decided, and what shipped instead, both survive.
+  - **Three source types are deprecated and hidden.** `copilot_studio`
+    (`ingestionSourceCatalog.tsx:163-179`), `openai_compliance` (`:189-200`)
+    and `claude_compliance` (`:209-222`) each carry `deprecated: true`.
+    `offeredSourceTypeOptions` removes every flagged entry from the offered
+    list (`:343-344`) and `gatedSourceTypeOptions` derives the picker from it
+    (`:376,381`), so none of the three appears in the Add source menu. Their
+    catalog entries remain, which is what keeps their labels resolvable on
+    rows that already exist.
+  - **Hidden, not badged.** Decision 12 chose a visible disabled badge and
+    named hiding as a rejected alternative; the shipped behaviour is hiding.
+    The two are equivalent on the outcome the decision cared about — the type
+    cannot be picked for a new source — and differ on whether a reader of the
+    menu can see that the type once existed. The Gates row for this decision
+    is unmeetable as written and is marked so.
+  - **No backfill.** Nothing was done to data already pulled on a deprecated
+    type, and nothing is planned. Rows stay as they are, with their label
+    intact; no owner and no date are attached to changing that.
+  - Stale citations refreshed: `ingestionSourceCatalog.tsx:142-149` →
+    `:171-181`; `ingestionSourceCatalog.tsx:293` → `:324`.

--- a/dev/docs/adr/128-governance-cost-and-identity-two-waves.md
+++ b/dev/docs/adr/128-governance-cost-and-identity-two-waves.md
@@ -991,6 +991,39 @@ The match policy for `IdentityMatch`:
 - A collision-review screen is future work (Open questions), flagged per
   the framing ruling.
 
+**How the shipped code orders these checks.** The directory department sync
+is the first caller to apply this policy, and the order it applies it in is
+the intended reading of the rule above, recorded here so a second caller
+copies it rather than re-deriving it. `provenUserId`
+(`directoryDepartmentSync.service.ts:264-305`) decides which member — if any
+— a directory row proves, in four steps:
+
+1. **The conflict check runs first, before either identifier is chosen.**
+   `decideMatch` is called on the raw actor id, the row's address and any
+   open link, and a `suspend` outcome returns nothing at all (`:288-296`).
+   No department is assigned, from any source. "Conflicts always stop the
+   machine" is therefore ordered ahead of every other rule here, not
+   weighed against them.
+2. **An accepted link wins next** (`:298`). It is somebody's dated,
+   reviewable answer to "who is this?" — human-confirmed, or proved by an
+   address the account holder confirmed — and step 1 has just handed the
+   engine its chance to contradict it. A stale directory identifier naming a
+   different member must not quietly move a department off an accepted link.
+3. **A directory identifier resolving to exactly one member is used next**
+   (`:300-302`). Resolving to more than one assigns nothing: corroboration
+   pointing two ways corroborates nothing.
+4. **The engine's own `link` outcome stands last** (`:304`), reached only
+   when no directory identifier resolved.
+
+Two things this ordering is careful about. The directory identifier never
+overrides an accepted link, which is the sense in which it "strengthens a
+match but never stands alone" — it corroborates identity, and it is only
+allowed to decide a department when nothing better has answered. And a
+no-action result from the engine means "do not open an identity link", not
+"discard the directory's department": step 3 assigns a department without
+creating an `IdentityMatch` row, so nothing about this path merges two
+people automatically.
+
 Rejects: human-confirms-everything (a 500-person org gets a 500-click
 onboarding for matches the directory already proves, and until clicked
 all spend reads "unknown person"); auto-linking look-alikes (a wrong
@@ -1941,6 +1974,11 @@ money tables, only the identity tables and read paths.
 
 ## Revisions
 
+- **v3.14 (2026-09-09).** Documentation only. §12 gains a note recording the
+  order the shipped code applies the match policy in — conflict, accepted
+  link, unique directory identifier, engine link
+  (`directoryDepartmentSync.service.ts:264-305`) — as the intended reading of
+  the precedence rule. No decision is taken and no behaviour changes.
 - **v3.13 (2026-09-09).** Documentation caught up with the code. No decision is
   taken, and no decision prose is rewritten — the §4 **diagram** is replaced and
   a marker above it says what it used to show.

--- a/docs/ai-gateway/governance/ocsf-export.mdx
+++ b/docs/ai-gateway/governance/ocsf-export.mdx
@@ -63,7 +63,9 @@ The HTTP response wraps the procedure result under `result.data.json`. The resul
 }
 ```
 
-`rawOcsfJson` is the full OCSF 1.1 event as a JSON string. The other fields are the columns your SIEM filters on. `actionName` is the tool the trace invoked, or `trace.recorded` for a trace with no tool call. `anomalyAlertId` is empty when no anomaly rule matched. An organization with no ingestion source yet returns `{ "events": [], "nextCursor": null, "nextCursorCompound": null }`.
+`rawOcsfJson` is the full OCSF 1.1 event as a JSON string. The other fields are the columns your SIEM filters on. `actionName` is the tool the trace invoked, or `trace.recorded` for a trace with no tool call. An organization with no ingestion source yet returns `{ "events": [], "nextCursor": null, "nextCursorCompound": null }`.
+
+`anomalyAlertId` is returned on every record and is **always empty**. No attribute sets it, so no exported record is ever linked to an anomaly alert, and `severityId` is always 1 (Informational). Anomaly alerts are not exported as OCSF rows at all. They are delivered by webhook, described in [Anomaly rules](/ai-governance/anomaly-rules).
 
 ## Pagination
 
@@ -95,4 +97,4 @@ curl -G "https://app.langwatch.ai/api/trpc/governance.ocsfExport" \
 
 <Warning>The session cookie is a full browser credential for that user, and this endpoint takes no other credential. It is not scoped to `complianceExport:view`, and it expires on the session's own schedule rather than the job's. Keep it out of shell history, out of the process argument list, and out of any script committed to a repository, and rotate the session when the job host changes.</Warning>
 
-**Also check:** [Anomaly rules](/ai-governance/anomaly-rules) for what sets `anomalyAlertId`, and [Retention](/ai-gateway/governance/retention) for how long the source traces are kept.
+**Also check:** [Anomaly rules](/ai-governance/anomaly-rules) for how a fired alert reaches you, which is by webhook rather than through this export, and [Retention](/ai-gateway/governance/retention) for how long the source traces are kept.

--- a/docs/ai-governance/anomaly-rules.mdx
+++ b/docs/ai-governance/anomaly-rules.mdx
@@ -147,7 +147,9 @@ Delivery is **best-effort, and the alert row is the authoritative signal**. Each
 
 A destination that never succeeds is logged and recorded on the alert. It does not fail the detector, and it does not block the other destinations.
 
-Requests go out through the same server-side-request-forgery guard the ingestion pullers use: the destination is resolved and its address pinned. A URL resolving to a private or link-local address is refused and recorded as a failed delivery when `BLOCK_LOCAL_HTTP_CALLS` is on, which it is on LangWatch Cloud. Self-hosted, that refusal only applies if you set the flag, and a host listed in `ALLOWED_PROXY_HOSTS` is allowed either way. Cloud metadata addresses are the exception: they are refused regardless of either setting and cannot be allow-listed.
+Requests go out through the same server-side-request-forgery guard the ingestion pullers use: the destination is resolved and its address pinned.
+
+A URL resolving to a private or link-local address is refused and recorded as a failed delivery when `BLOCK_LOCAL_HTTP_CALLS` is on, which it is on LangWatch Cloud. Self-hosted, that refusal only applies if you set the flag, and a host listed in `ALLOWED_PROXY_HOSTS` is allowed either way. Cloud metadata addresses are the exception: they are refused regardless of either setting and cannot be allow-listed.
 
 ## Where an existing rule's alerts go
 

--- a/docs/ai-governance/anomaly-rules.mdx
+++ b/docs/ai-governance/anomaly-rules.mdx
@@ -42,7 +42,7 @@ These are the fields a rule carries and the detector reads. No screen collects t
 | Field | Typical value | What it does |
 |-------|---------------|---------------|
 | **Name** | `Spend spike on production gateway` | Free-text label; identifies the rule on the alert it raises, and travels in the webhook payload. |
-| **Severity** | `warning`, `critical` | Recorded on the alert and carried in the webhook payload. It does not route: every destination on the rule receives every alert the rule raises. |
+| **Severity** | `warning`, `critical` | Recorded on the alert and carried in the webhook payload. It does not route: when the rule's destination configuration passes validation, every destination on it receives every alert the rule raises. A configuration that fails validation is quarantined and no request is sent to any of its destinations. |
 | **Rule type** | `spend_spike` | Pick exactly this, see coverage table above. |
 | **Scope** | `organization`, `source_type`, `source` | Filters which IngestionSources the rule applies to (see Scope coverage below). |
 | **Scope ID** | (cuid) | Required when scope is `source_type` or `source`. The IngestionSource ID is in the URL of the per-source detail page under the inventory. |
@@ -147,7 +147,7 @@ Delivery is **best-effort, and the alert row is the authoritative signal**. Each
 
 A destination that never succeeds is logged and recorded on the alert. It does not fail the detector, and it does not block the other destinations.
 
-Requests go out through the same server-side-request-forgery guard the ingestion pullers use: the destination is resolved and its address pinned. On LangWatch Cloud a URL resolving to a private or link-local address is refused and recorded as a failed delivery.
+Requests go out through the same server-side-request-forgery guard the ingestion pullers use: the destination is resolved and its address pinned. A URL resolving to a private or link-local address is refused and recorded as a failed delivery when `BLOCK_LOCAL_HTTP_CALLS` is on, which it is on LangWatch Cloud. Self-hosted, that refusal only applies if you set the flag, and a host listed in `ALLOWED_PROXY_HOSTS` is allowed either way.
 
 ## Where an existing rule's alerts go
 

--- a/docs/ai-governance/anomaly-rules.mdx
+++ b/docs/ai-governance/anomaly-rules.mdx
@@ -149,7 +149,9 @@ A destination that never succeeds is logged and recorded on the alert. It does n
 
 Requests go out through the same server-side-request-forgery guard the ingestion pullers use: the destination is resolved and its address pinned.
 
-A URL resolving to a private or link-local address is refused and recorded as a failed delivery when `BLOCK_LOCAL_HTTP_CALLS` is on, which it is on LangWatch Cloud. Self-hosted, that refusal only applies if you set the flag, and a host listed in `ALLOWED_PROXY_HOSTS` is allowed either way. Cloud metadata addresses are the exception: they are refused regardless of either setting and cannot be allow-listed.
+A URL resolving to a private or link-local address is refused and recorded as a failed delivery when `BLOCK_LOCAL_HTTP_CALLS` is on, which it is on LangWatch Cloud. Self-hosted, that refusal only applies if you set the flag, and a host listed in `ALLOWED_PROXY_HOSTS` is allowed either way.
+
+The cloud metadata hostnames and addresses themselves are refused regardless of either setting and cannot be allow-listed. An allow-listed name is trusted as written, without a lookup of where it resolves, so only allow-list names you control.
 
 ## Where an existing rule's alerts go
 

--- a/docs/ai-governance/anomaly-rules.mdx
+++ b/docs/ai-governance/anomaly-rules.mdx
@@ -1,6 +1,6 @@
 ---
 title: Anomaly rules
-description: What the anomaly detector evaluates, what a rule is made of, and why rules cannot be created in the app today.
+description: What the anomaly detector evaluates, what a rule is made of, how a fired alert reaches you, and why rules cannot be created in the app today.
 sidebarTitle: Anomaly rules
 ---
 
@@ -8,7 +8,7 @@ sidebarTitle: Anomaly rules
 
 <Note>**Available on Enterprise plans.** See [Open-core licensing](/ai-governance/open-core-licensing) for the full Apache 2.0, Enterprise split.</Note>
 
-<Warning>**Anomaly rules cannot be created or edited in LangWatch today.** There is no page for them and no public API, so this page describes what the detector does with a rule and what a rule is made of, not something you can set up right now. Rules that already exist are still evaluated, but no screen in the product lists the alerts they raise: the one place an alert reaches you is the [OCSF export](/ai-gateway/governance/ocsf-export), where a record linked to one carries its `anomalyAlertId`. To watch spend with a limit you can act on, use [Budgets](/ai-gateway/budgets), which enforce a hard limit and are available today.</Warning>
+<Warning>**Anomaly rules cannot be created or edited in LangWatch today, and the alerts they raise are not listed anywhere.** There is no page for them and no public API, so this page describes what the detector does with a rule and what a rule is made of, not something you can set up right now. Rules that already exist are still evaluated. When one fires, the one place the alert reaches you is a webhook, POSTed to whatever URL the rule's destination config names, so a rule with no destination fires into a record no screen displays. To watch spend with a limit you can act on, use [Budgets](/ai-gateway/budgets), which enforce a hard limit and are available today.</Warning>
 
 Anomaly rules are the "Detect" layer of the [governance control plane](/ai-governance/control-plane#tier-3-audit-log-ingest). A rule is a definition the [event-sourcing detector](/ai-gateway/governance/architecture) evaluates against incoming events, producing an `AnomalyAlert` row when a violation is detected.
 
@@ -37,17 +37,17 @@ If you need detection beyond `spend_spike` today, the recommended shape is one o
 
 ## What a `spend_spike` rule is made of
 
-These are the fields the detector reads, listed so the shape of a rule is known. They are not steps to follow: no page or API accepts them today.
+These are the fields a rule carries and the detector reads. No screen collects them today and no public API accepts them; they describe rules that already exist.
 
 | Field | Typical value | What it does |
 |-------|---------------|---------------|
-| **Name** | `Spend spike on Cowork prod` | Free-text label; identifies the rule on the alert it raises. |
-| **Severity** | `warning`, `critical` | Recorded on the alert, and will drive dispatch routing once C3 ships. |
+| **Name** | `Spend spike on production gateway` | Free-text label; identifies the rule on the alert it raises, and travels in the webhook payload. |
+| **Severity** | `warning`, `critical` | Recorded on the alert and carried in the webhook payload. It does not route: every destination on the rule receives every alert the rule raises. |
 | **Rule type** | `spend_spike` | Pick exactly this, see coverage table above. |
 | **Scope** | `organization`, `source_type`, `source` | Filters which IngestionSources the rule applies to (see Scope coverage below). |
 | **Scope ID** | (cuid) | Required when scope is `source_type` or `source`. The IngestionSource ID is in the URL of the per-source detail page under the inventory. |
 | **Threshold config** | (JSON object, see below) | The detector's per-rule-type tuning knobs. |
-| **Destination config** | `{}` (today) | Reserved for future Slack, PagerDuty, SIEM dispatch, see Dispatch coverage below. |
+| **Destination config** | `{"destinations": []}` | The webhook targets the alert is pushed to, see Dispatch coverage below. Empty for a rule that records alerts without pushing them anywhere. |
 
 ### Threshold config: `spend_spike`
 
@@ -85,28 +85,77 @@ Sensible starting values:
 | `team` | ⏳ Preview | Persisted but not filtered by the detector today. Don't rely on it. |
 | `project` | ⏳ Preview | Same. |
 
-## Dispatch coverage (C3 in flight)
+## Dispatch coverage
 
-A rule's **Destination config** holds a JSON object describing where to push the alert. Today the detector's dispatch path is **log-only**: the alert is recorded and carried on the OCSF export, but no Slack message, PagerDuty page or SIEM event is pushed anywhere.
-
-C3 (in flight on the [governance platform](https://github.com/langwatch/langwatch/pull/3524) branch) wires `triggerActionDispatch` so the destinationConfig values below start working:
+A rule's **Destination config** lists where to push the alert. **Webhook is the only destination type**, and it works today: when a rule fires, the alert row is written first, then POSTed to each destination on the rule.
 
 ```json
 {
-  "slack":     { "webhookUrl": "https://hooks.slack.com/services/..." },
-  "pagerduty": { "routingKey": "..." },
-  "webhook":   { "url": "https://your-siem.example.com/ingest", "secret": "..." },
-  "email":     { "addresses": ["sec-on-call@your-company.com"] }
+  "destinations": [
+    {
+      "type": "webhook",
+      "url": "https://your-siem.example.com/ingest",
+      "sharedSecret": "..."
+    }
+  ]
 }
 ```
 
-Until C3 lands, leave destinationConfig empty (`{}`). A real Slack webhook set today is stored and never called, so alerts look wired when they are not.
+| Field | Required | Meaning |
+|-------|----------|---------|
+| `type` | Yes | Must be `webhook`. No other destination type exists; Slack, PagerDuty and email are not implemented. |
+| `url` | Yes | An absolute `https` URL. Up to 10 destinations per rule. |
+| `sharedSecret` | No | When set, the request body is signed with HMAC-SHA256 and the signature travels as `X-LangWatch-Signature: sha256=<hex>`, so your receiver can verify the request came from LangWatch. |
+
+For Slack or PagerDuty, point a webhook at their own incoming-webhook or events endpoint and reshape the payload on your side.
+
+Leave `destinations` empty for a rule that records alerts without pushing them. A destination config that fails validation is quarantined: no request is sent, and the rule falls back to recording only.
+
+### What the webhook receives
+
+A POST with `Content-Type: application/json`, carrying the rule and the alert it raised:
+
+```json
+{
+  "ruleId": "...",
+  "ruleName": "Spend spike on production gateway",
+  "ruleType": "spend_spike",
+  "severity": "warning",
+  "organizationId": "...",
+  "alert": {
+    "id": "...",
+    "triggerWindowStartIso": "2026-01-08T00:00:00.000Z",
+    "triggerWindowEndIso": "2026-01-09T00:00:00.000Z",
+    "triggerSpendUsd": "42.00",
+    "triggerEventCount": null,
+    "detail": {
+      "baselineSpendUsd": 12,
+      "windowSec": 86400,
+      "reason": "...",
+      "dispatch": "pending"
+    },
+    "detectedAtIso": "2026-01-09T00:04:11.000Z"
+  }
+}
+```
+
+`detail.dispatch` reads `pending` in every payload, because the alert is written before delivery is attempted. The stored row is updated with the delivery outcome afterwards; the payload you receive is the pre-delivery snapshot.
+
+### Delivery guarantees
+
+Delivery is **best-effort, and the alert row is the authoritative signal**. Each destination gets up to three attempts with a five-second timeout each. A 5xx response is retried with exponential backoff; a 4xx fails immediately, on the reading that it is a configuration error rather than a transient one.
+
+A destination that never succeeds is logged and recorded on the alert. It does not fail the detector, and it does not block the other destinations.
+
+Requests go out through the same server-side-request-forgery guard the ingestion pullers use: the destination is resolved and its address pinned. On LangWatch Cloud a URL resolving to a private or link-local address is refused and recorded as a failed delivery.
 
 ## Where an existing rule's alerts go
 
 **In the app**: no screen lists them. Each fire is recorded as one alert keyed by `(ruleId, triggerWindowStart)`, so the detector does not raise a second alert for the same window, but the governance section has no page that reads those rows today.
 
-**In your SIEM**: the [OCSF export](/ai-gateway/governance/ocsf-export) is the one place an alert reaches you. A trace record linked to an alert carries that alert's `anomalyAlertId` and `severity_id` 4 (Medium); every other record carries `severity_id` 1 (Informational).
+**Over a webhook**: this is the one place an alert reaches you. Every fire is POSTed to each webhook destination on the rule, with the payload above. A rule with no destinations records the alert and sends no request.
+
+**Not in the OCSF export.** The [OCSF export](/ai-gateway/governance/ocsf-export) carries governance events, and no exported record is linked to an anomaly alert. Do not build a SIEM rule that waits for one. Point a webhook destination at your SIEM instead.
 
 **CLI**: `langwatch governance status` reports `hasAnomalyRules: true` once at least one rule exists. That confirms a rule is defined, not that one has fired.
 
@@ -116,7 +165,7 @@ End to end, for an organization that already has a rule:
 2. Send one OTel event with `gen_ai.usage.cost_usd: 0.05` (baseline seed), see [otel-generic, Test it now](/ai-governance/ingestion-sources/otel-generic#test-it-now-copy-paste-curl).
 3. Wait long enough for the baseline window to roll past the seed (default `windowSec: 86400` means 24h, so use the tighter values from the table above for fast iteration).
 4. Send a second event with `gen_ai.usage.cost_usd: 2.00` (the spike).
-5. Pull the [OCSF export](/ai-gateway/governance/ocsf-export) and look for a record carrying an `anomalyAlertId`.
+5. Watch your webhook receiver for the payload above. If the rule has no webhook destination, the alert is recorded and no request is sent.
 
 ## What's persisted vs what's evaluated
 

--- a/docs/ai-governance/anomaly-rules.mdx
+++ b/docs/ai-governance/anomaly-rules.mdx
@@ -147,7 +147,7 @@ Delivery is **best-effort, and the alert row is the authoritative signal**. Each
 
 A destination that never succeeds is logged and recorded on the alert. It does not fail the detector, and it does not block the other destinations.
 
-Requests go out through the same server-side-request-forgery guard the ingestion pullers use: the destination is resolved and its address pinned. A URL resolving to a private or link-local address is refused and recorded as a failed delivery when `BLOCK_LOCAL_HTTP_CALLS` is on, which it is on LangWatch Cloud. Self-hosted, that refusal only applies if you set the flag, and a host listed in `ALLOWED_PROXY_HOSTS` is allowed either way.
+Requests go out through the same server-side-request-forgery guard the ingestion pullers use: the destination is resolved and its address pinned. A URL resolving to a private or link-local address is refused and recorded as a failed delivery when `BLOCK_LOCAL_HTTP_CALLS` is on, which it is on LangWatch Cloud. Self-hosted, that refusal only applies if you set the flag, and a host listed in `ALLOWED_PROXY_HOSTS` is allowed either way. Cloud metadata addresses are the exception: they are refused regardless of either setting and cannot be allow-listed.
 
 ## Where an existing rule's alerts go
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -10817,7 +10817,9 @@ Delivery is **best-effort, and the alert row is the authoritative signal**. Each
 
 A destination that never succeeds is logged and recorded on the alert. It does not fail the detector, and it does not block the other destinations.
 
-Requests go out through the same server-side-request-forgery guard the ingestion pullers use: the destination is resolved and its address pinned. A URL resolving to a private or link-local address is refused and recorded as a failed delivery when `BLOCK_LOCAL_HTTP_CALLS` is on, which it is on LangWatch Cloud. Self-hosted, that refusal only applies if you set the flag, and a host listed in `ALLOWED_PROXY_HOSTS` is allowed either way. Cloud metadata addresses are the exception: they are refused regardless of either setting and cannot be allow-listed.
+Requests go out through the same server-side-request-forgery guard the ingestion pullers use: the destination is resolved and its address pinned.
+
+A URL resolving to a private or link-local address is refused and recorded as a failed delivery when `BLOCK_LOCAL_HTTP_CALLS` is on, which it is on LangWatch Cloud. Self-hosted, that refusal only applies if you set the flag, and a host listed in `ALLOWED_PROXY_HOSTS` is allowed either way. Cloud metadata addresses are the exception: they are refused regardless of either setting and cannot be allow-listed.
 
 ## Where an existing rule's alerts go
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -10712,7 +10712,7 @@ These are the fields a rule carries and the detector reads. No screen collects t
 | Field | Typical value | What it does |
 |-------|---------------|---------------|
 | **Name** | `Spend spike on production gateway` | Free-text label; identifies the rule on the alert it raises, and travels in the webhook payload. |
-| **Severity** | `warning`, `critical` | Recorded on the alert and carried in the webhook payload. It does not route: every destination on the rule receives every alert the rule raises. |
+| **Severity** | `warning`, `critical` | Recorded on the alert and carried in the webhook payload. It does not route: when the rule's destination configuration passes validation, every destination on it receives every alert the rule raises. A configuration that fails validation is quarantined and no request is sent to any of its destinations. |
 | **Rule type** | `spend_spike` | Pick exactly this, see coverage table above. |
 | **Scope** | `organization`, `source_type`, `source` | Filters which IngestionSources the rule applies to (see Scope coverage below). |
 | **Scope ID** | (cuid) | Required when scope is `source_type` or `source`. The IngestionSource ID is in the URL of the per-source detail page under the inventory. |
@@ -10817,7 +10817,7 @@ Delivery is **best-effort, and the alert row is the authoritative signal**. Each
 
 A destination that never succeeds is logged and recorded on the alert. It does not fail the detector, and it does not block the other destinations.
 
-Requests go out through the same server-side-request-forgery guard the ingestion pullers use: the destination is resolved and its address pinned. On LangWatch Cloud a URL resolving to a private or link-local address is refused and recorded as a failed delivery.
+Requests go out through the same server-side-request-forgery guard the ingestion pullers use: the destination is resolved and its address pinned. A URL resolving to a private or link-local address is refused and recorded as a failed delivery when `BLOCK_LOCAL_HTTP_CALLS` is on, which it is on LangWatch Cloud. Self-hosted, that refusal only applies if you set the flag, and a host listed in `ALLOWED_PROXY_HOSTS` is allowed either way.
 
 ## Where an existing rule's alerts go
 
@@ -57458,7 +57458,7 @@ deployment plan.
 | Billing spend ledger, fixed 13-month retention (with ClickHouse) | ✅ | ✅ |
 | Webhook endpoints platform (signed event delivery, retries, replay) | ❌ | ✅ |
 | Billing events APIs (spend-events pull, summaries, replay) | ❌ | ✅ |
-| Anomaly Rules, admin-curated detection + signed webhook dispatch | ❌ | ✅ |
+| Anomaly Rules, admin-curated detection + webhook dispatch (HMAC-signed when a shared secret is set) | ❌ | ✅ |
 | OCSF/SIEM export (Splunk, Datadog, Sentinel pull API) | ❌ | ✅ |
 | Audit log, org-wide cross-team | ❌ | ✅ |
 | SCIM provisioning | ❌ | ✅ |
@@ -57509,7 +57509,7 @@ require Enterprise.
 | Art. 32(1)(d), restoration | Backups (env-configured), trace store replay | Apache 2.0 |
 | Art. 30, record of processing | event_log @ 49d retention | Apache 2.0 |
 | Art. 30, record of processing (extended) | event_log under extended per-scope retention policies | **Enterprise** |
-| Art. 33, breach notification | Anomaly rule dispatch, a signed webhook POST to the rule's destination URL (rules cannot be created in the app today) | **Enterprise** |
+| Art. 33, breach notification | Anomaly rule dispatch, a webhook POST to the rule's destination URL, HMAC-signed when the destination has a shared secret (rules cannot be created in the app today) | **Enterprise** |
 | Art. 35, DPIA evidence | OCSF/SIEM export bundle | **Enterprise** |
 
 If your processor agreement requires retention longer than the 49-day
@@ -57565,7 +57565,7 @@ provider/deployer record-keeping (Art. 18) map onto:
 - **Art. 12(2)(a) period of operation**: Apache 2.0 (trace timestamps in event_log)
 - **Art. 12(2)(b) reference DB used**: Apache 2.0 (`gen_ai.system` + `gen_ai.request.model` attrs on each span)
 - **Art. 12(2)(c) input data check**: Apache 2.0 (prompt + tool-call payloads on traces, redacted via Presidio)
-- **Art. 12(2)(d) human oversight**: **Enterprise** anomaly-rule webhook dispatch (so a person reviews flagged events), with OCSF/SIEM forwarding of governance events alongside it. The two are separate paths: anomaly alerts arrive over the webhook, never as a record in the OCSF export
+- **Art. 12(2)(d) human oversight**: **Enterprise** anomaly-rule webhook dispatch (it delivers the flagged event to a URL you control; the human review of what arrives there is your receiving process, not something LangWatch performs or records), with OCSF/SIEM forwarding of governance events alongside it. The two are separate paths: anomaly alerts arrive over the webhook, never as a record in the OCSF export
 - **Art. 18(1) record-keeping ≥10y**: Enterprise extended retention policies, with windows set in years to match the record-keeping clause your assessment requires.
 
 Most enterprise-deploying-an-LLM-agent uses fall under Art. 12 (1-3

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -10819,7 +10819,9 @@ A destination that never succeeds is logged and recorded on the alert. It does n
 
 Requests go out through the same server-side-request-forgery guard the ingestion pullers use: the destination is resolved and its address pinned.
 
-A URL resolving to a private or link-local address is refused and recorded as a failed delivery when `BLOCK_LOCAL_HTTP_CALLS` is on, which it is on LangWatch Cloud. Self-hosted, that refusal only applies if you set the flag, and a host listed in `ALLOWED_PROXY_HOSTS` is allowed either way. Cloud metadata addresses are the exception: they are refused regardless of either setting and cannot be allow-listed.
+A URL resolving to a private or link-local address is refused and recorded as a failed delivery when `BLOCK_LOCAL_HTTP_CALLS` is on, which it is on LangWatch Cloud. Self-hosted, that refusal only applies if you set the flag, and a host listed in `ALLOWED_PROXY_HOSTS` is allowed either way.
+
+The cloud metadata hostnames and addresses themselves are refused regardless of either setting and cannot be allow-listed. An allow-listed name is trusted as written, without a lookup of where it resolves, so only allow-list names you control.
 
 ## Where an existing rule's alerts go
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -10817,7 +10817,7 @@ Delivery is **best-effort, and the alert row is the authoritative signal**. Each
 
 A destination that never succeeds is logged and recorded on the alert. It does not fail the detector, and it does not block the other destinations.
 
-Requests go out through the same server-side-request-forgery guard the ingestion pullers use: the destination is resolved and its address pinned. A URL resolving to a private or link-local address is refused and recorded as a failed delivery when `BLOCK_LOCAL_HTTP_CALLS` is on, which it is on LangWatch Cloud. Self-hosted, that refusal only applies if you set the flag, and a host listed in `ALLOWED_PROXY_HOSTS` is allowed either way.
+Requests go out through the same server-side-request-forgery guard the ingestion pullers use: the destination is resolved and its address pinned. A URL resolving to a private or link-local address is refused and recorded as a failed delivery when `BLOCK_LOCAL_HTTP_CALLS` is on, which it is on LangWatch Cloud. Self-hosted, that refusal only applies if you set the flag, and a host listed in `ALLOWED_PROXY_HOSTS` is allowed either way. Cloud metadata addresses are the exception: they are refused regardless of either setting and cannot be allow-listed.
 
 ## Where an existing rule's alerts go
 
@@ -57565,7 +57565,7 @@ provider/deployer record-keeping (Art. 18) map onto:
 - **Art. 12(2)(a) period of operation**: Apache 2.0 (trace timestamps in event_log)
 - **Art. 12(2)(b) reference DB used**: Apache 2.0 (`gen_ai.system` + `gen_ai.request.model` attrs on each span)
 - **Art. 12(2)(c) input data check**: Apache 2.0 (prompt + tool-call payloads on traces, redacted via Presidio)
-- **Art. 12(2)(d) human oversight**: **Enterprise** anomaly-rule webhook dispatch (it delivers the flagged event to a URL you control; the human review of what arrives there is your receiving process, not something LangWatch performs or records), with OCSF/SIEM forwarding of governance events alongside it. The two are separate paths: anomaly alerts arrive over the webhook, never as a record in the OCSF export
+- **Art. 12(2)(d) human oversight**: **Enterprise** anomaly-rule webhook dispatch (it delivers the flagged event to a URL you control; the human review of what arrives there is your receiving process, not something LangWatch performs or records today), with OCSF/SIEM forwarding of governance events alongside it. The two are separate paths: anomaly alerts arrive over the webhook, never as a record in the OCSF export
 - **Art. 18(1) record-keeping ≥10y**: Enterprise extended retention policies, with windows set in years to match the record-keeping clause your assessment requires.
 
 Most enterprise-deploying-an-LLM-agent uses fall under Art. 12 (1-3

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -6129,7 +6129,9 @@ The HTTP response wraps the procedure result under `result.data.json`. The resul
 }
 ```
 
-`rawOcsfJson` is the full OCSF 1.1 event as a JSON string. The other fields are the columns your SIEM filters on. `actionName` is the tool the trace invoked, or `trace.recorded` for a trace with no tool call. `anomalyAlertId` is empty when no anomaly rule matched. An organization with no ingestion source yet returns `{ "events": [], "nextCursor": null, "nextCursorCompound": null }`.
+`rawOcsfJson` is the full OCSF 1.1 event as a JSON string. The other fields are the columns your SIEM filters on. `actionName` is the tool the trace invoked, or `trace.recorded` for a trace with no tool call. An organization with no ingestion source yet returns `{ "events": [], "nextCursor": null, "nextCursorCompound": null }`.
+
+`anomalyAlertId` is returned on every record and is **always empty**. No attribute sets it, so no exported record is ever linked to an anomaly alert, and `severityId` is always 1 (Informational). Anomaly alerts are not exported as OCSF rows at all. They are delivered by webhook, described in [Anomaly rules](/ai-governance/anomaly-rules).
 
 ## Pagination
 
@@ -6161,7 +6163,7 @@ curl -G "https://app.langwatch.ai/api/trpc/governance.ocsfExport" \
 
 <Warning>The session cookie is a full browser credential for that user, and this endpoint takes no other credential. It is not scoped to `complianceExport:view`, and it expires on the session's own schedule rather than the job's. Keep it out of shell history, out of the process argument list, and out of any script committed to a repository, and rotate the session when the job host changes.</Warning>
 
-**Also check:** [Anomaly rules](/ai-governance/anomaly-rules) for what sets `anomalyAlertId`, and [Retention](/ai-gateway/governance/retention) for how long the source traces are kept.
+**Also check:** [Anomaly rules](/ai-governance/anomaly-rules) for how a fired alert reaches you, which is by webhook rather than through this export, and [Retention](/ai-gateway/governance/retention) for how long the source traces are kept.
 
 ---
 
@@ -10668,7 +10670,7 @@ Field by field: [Virtual keys API reference](/api-reference/gateway-virtual-keys
 
 ---
 title: Anomaly rules
-description: What the anomaly detector evaluates, what a rule is made of, and why rules cannot be created in the app today.
+description: What the anomaly detector evaluates, what a rule is made of, how a fired alert reaches you, and why rules cannot be created in the app today.
 sidebarTitle: Anomaly rules
 ---
 
@@ -10676,7 +10678,7 @@ sidebarTitle: Anomaly rules
 
 <Note>**Available on Enterprise plans.** See [Open-core licensing](/ai-governance/open-core-licensing) for the full Apache 2.0, Enterprise split.</Note>
 
-<Warning>**Anomaly rules cannot be created or edited in LangWatch today.** There is no page for them and no public API, so this page describes what the detector does with a rule and what a rule is made of, not something you can set up right now. Rules that already exist are still evaluated, but no screen in the product lists the alerts they raise: the one place an alert reaches you is the [OCSF export](/ai-gateway/governance/ocsf-export), where a record linked to one carries its `anomalyAlertId`. To watch spend with a limit you can act on, use [Budgets](/ai-gateway/budgets), which enforce a hard limit and are available today.</Warning>
+<Warning>**Anomaly rules cannot be created or edited in LangWatch today, and the alerts they raise are not listed anywhere.** There is no page for them and no public API, so this page describes what the detector does with a rule and what a rule is made of, not something you can set up right now. Rules that already exist are still evaluated. When one fires, the one place the alert reaches you is a webhook, POSTed to whatever URL the rule's destination config names, so a rule with no destination fires into a record no screen displays. To watch spend with a limit you can act on, use [Budgets](/ai-gateway/budgets), which enforce a hard limit and are available today.</Warning>
 
 Anomaly rules are the "Detect" layer of the [governance control plane](/ai-governance/control-plane#tier-3-audit-log-ingest). A rule is a definition the [event-sourcing detector](/ai-gateway/governance/architecture) evaluates against incoming events, producing an `AnomalyAlert` row when a violation is detected.
 
@@ -10705,17 +10707,17 @@ If you need detection beyond `spend_spike` today, the recommended shape is one o
 
 ## What a `spend_spike` rule is made of
 
-These are the fields the detector reads, listed so the shape of a rule is known. They are not steps to follow: no page or API accepts them today.
+These are the fields a rule carries and the detector reads. No screen collects them today and no public API accepts them; they describe rules that already exist.
 
 | Field | Typical value | What it does |
 |-------|---------------|---------------|
-| **Name** | `Spend spike on Cowork prod` | Free-text label; identifies the rule on the alert it raises. |
-| **Severity** | `warning`, `critical` | Recorded on the alert, and will drive dispatch routing once C3 ships. |
+| **Name** | `Spend spike on production gateway` | Free-text label; identifies the rule on the alert it raises, and travels in the webhook payload. |
+| **Severity** | `warning`, `critical` | Recorded on the alert and carried in the webhook payload. It does not route: every destination on the rule receives every alert the rule raises. |
 | **Rule type** | `spend_spike` | Pick exactly this, see coverage table above. |
 | **Scope** | `organization`, `source_type`, `source` | Filters which IngestionSources the rule applies to (see Scope coverage below). |
 | **Scope ID** | (cuid) | Required when scope is `source_type` or `source`. The IngestionSource ID is in the URL of the per-source detail page under the inventory. |
 | **Threshold config** | (JSON object, see below) | The detector's per-rule-type tuning knobs. |
-| **Destination config** | `{}` (today) | Reserved for future Slack, PagerDuty, SIEM dispatch, see Dispatch coverage below. |
+| **Destination config** | `{"destinations": []}` | The webhook targets the alert is pushed to, see Dispatch coverage below. Empty for a rule that records alerts without pushing them anywhere. |
 
 ### Threshold config: `spend_spike`
 
@@ -10753,28 +10755,77 @@ Sensible starting values:
 | `team` | ⏳ Preview | Persisted but not filtered by the detector today. Don't rely on it. |
 | `project` | ⏳ Preview | Same. |
 
-## Dispatch coverage (C3 in flight)
+## Dispatch coverage
 
-A rule's **Destination config** holds a JSON object describing where to push the alert. Today the detector's dispatch path is **log-only**: the alert is recorded and carried on the OCSF export, but no Slack message, PagerDuty page or SIEM event is pushed anywhere.
-
-C3 (in flight on the [governance platform](https://github.com/langwatch/langwatch/pull/3524) branch) wires `triggerActionDispatch` so the destinationConfig values below start working:
+A rule's **Destination config** lists where to push the alert. **Webhook is the only destination type**, and it works today: when a rule fires, the alert row is written first, then POSTed to each destination on the rule.
 
 ```json
 {
-  "slack":     { "webhookUrl": "https://hooks.slack.com/services/..." },
-  "pagerduty": { "routingKey": "..." },
-  "webhook":   { "url": "https://your-siem.example.com/ingest", "secret": "..." },
-  "email":     { "addresses": ["sec-on-call@your-company.com"] }
+  "destinations": [
+    {
+      "type": "webhook",
+      "url": "https://your-siem.example.com/ingest",
+      "sharedSecret": "..."
+    }
+  ]
 }
 ```
 
-Until C3 lands, leave destinationConfig empty (`{}`). A real Slack webhook set today is stored and never called, so alerts look wired when they are not.
+| Field | Required | Meaning |
+|-------|----------|---------|
+| `type` | Yes | Must be `webhook`. No other destination type exists; Slack, PagerDuty and email are not implemented. |
+| `url` | Yes | An absolute `https` URL. Up to 10 destinations per rule. |
+| `sharedSecret` | No | When set, the request body is signed with HMAC-SHA256 and the signature travels as `X-LangWatch-Signature: sha256=<hex>`, so your receiver can verify the request came from LangWatch. |
+
+For Slack or PagerDuty, point a webhook at their own incoming-webhook or events endpoint and reshape the payload on your side.
+
+Leave `destinations` empty for a rule that records alerts without pushing them. A destination config that fails validation is quarantined: no request is sent, and the rule falls back to recording only.
+
+### What the webhook receives
+
+A POST with `Content-Type: application/json`, carrying the rule and the alert it raised:
+
+```json
+{
+  "ruleId": "...",
+  "ruleName": "Spend spike on production gateway",
+  "ruleType": "spend_spike",
+  "severity": "warning",
+  "organizationId": "...",
+  "alert": {
+    "id": "...",
+    "triggerWindowStartIso": "2026-01-08T00:00:00.000Z",
+    "triggerWindowEndIso": "2026-01-09T00:00:00.000Z",
+    "triggerSpendUsd": "42.00",
+    "triggerEventCount": null,
+    "detail": {
+      "baselineSpendUsd": 12,
+      "windowSec": 86400,
+      "reason": "...",
+      "dispatch": "pending"
+    },
+    "detectedAtIso": "2026-01-09T00:04:11.000Z"
+  }
+}
+```
+
+`detail.dispatch` reads `pending` in every payload, because the alert is written before delivery is attempted. The stored row is updated with the delivery outcome afterwards; the payload you receive is the pre-delivery snapshot.
+
+### Delivery guarantees
+
+Delivery is **best-effort, and the alert row is the authoritative signal**. Each destination gets up to three attempts with a five-second timeout each. A 5xx response is retried with exponential backoff; a 4xx fails immediately, on the reading that it is a configuration error rather than a transient one.
+
+A destination that never succeeds is logged and recorded on the alert. It does not fail the detector, and it does not block the other destinations.
+
+Requests go out through the same server-side-request-forgery guard the ingestion pullers use: the destination is resolved and its address pinned. On LangWatch Cloud a URL resolving to a private or link-local address is refused and recorded as a failed delivery.
 
 ## Where an existing rule's alerts go
 
 **In the app**: no screen lists them. Each fire is recorded as one alert keyed by `(ruleId, triggerWindowStart)`, so the detector does not raise a second alert for the same window, but the governance section has no page that reads those rows today.
 
-**In your SIEM**: the [OCSF export](/ai-gateway/governance/ocsf-export) is the one place an alert reaches you. A trace record linked to an alert carries that alert's `anomalyAlertId` and `severity_id` 4 (Medium); every other record carries `severity_id` 1 (Informational).
+**Over a webhook**: this is the one place an alert reaches you. Every fire is POSTed to each webhook destination on the rule, with the payload above. A rule with no destinations records the alert and sends no request.
+
+**Not in the OCSF export.** The [OCSF export](/ai-gateway/governance/ocsf-export) carries governance events, and no exported record is linked to an anomaly alert. Do not build a SIEM rule that waits for one. Point a webhook destination at your SIEM instead.
 
 **CLI**: `langwatch governance status` reports `hasAnomalyRules: true` once at least one rule exists. That confirms a rule is defined, not that one has fired.
 
@@ -10784,7 +10835,7 @@ End to end, for an organization that already has a rule:
 2. Send one OTel event with `gen_ai.usage.cost_usd: 0.05` (baseline seed), see [otel-generic, Test it now](/ai-governance/ingestion-sources/otel-generic#test-it-now-copy-paste-curl).
 3. Wait long enough for the baseline window to roll past the seed (default `windowSec: 86400` means 24h, so use the tighter values from the table above for fast iteration).
 4. Send a second event with `gen_ai.usage.cost_usd: 2.00` (the spike).
-5. Pull the [OCSF export](/ai-gateway/governance/ocsf-export) and look for a record carrying an `anomalyAlertId`.
+5. Watch your webhook receiver for the payload above. If the rule has no webhook destination, the alert is recorded and no request is sent.
 
 ## What's persisted vs what's evaluated
 
@@ -57407,7 +57458,7 @@ deployment plan.
 | Billing spend ledger, fixed 13-month retention (with ClickHouse) | ✅ | ✅ |
 | Webhook endpoints platform (signed event delivery, retries, replay) | ❌ | ✅ |
 | Billing events APIs (spend-events pull, summaries, replay) | ❌ | ✅ |
-| Anomaly Rules, admin-curated detection + dispatch | ❌ | ✅ |
+| Anomaly Rules, admin-curated detection + signed webhook dispatch | ❌ | ✅ |
 | OCSF/SIEM export (Splunk, Datadog, Sentinel pull API) | ❌ | ✅ |
 | Audit log, org-wide cross-team | ❌ | ✅ |
 | SCIM provisioning | ❌ | ✅ |
@@ -57432,7 +57483,7 @@ the *common-criteria* baseline:
 | CC6.1, Logical access | RBAC catalog + per-project tenancy + RoleBinding scopes | Apache 2.0 |
 | CC6.6, Logical access (admin) | RBAC ADMIN role + `governance:manage` + `aiTools:manage` | Apache 2.0 |
 | CC6.7, Termination of access | CLI token revoke on user deactivation (CliTokenRevocationService, Phase 1B-1) | Apache 2.0 |
-| CC7.1, Detection | Anomaly rules on activity-event traffic (spend-spike, geo-mismatch, off-hours) | **Enterprise** |
+| CC7.1, Detection | Anomaly rules on activity-event traffic (spend-spike; the other rule types are stored but not evaluated yet) | **Enterprise** |
 | CC7.2, Monitoring | Append-only event_log + 49-day default retention | Apache 2.0 |
 | CC7.2, Monitoring (≥1y) | Per-scope retention policies with extended (multi-year) windows | **Enterprise** |
 | CC7.4, Incident response | OCSF v1.1 SIEM export with cursor pagination | **Enterprise** |
@@ -57458,7 +57509,7 @@ require Enterprise.
 | Art. 32(1)(d), restoration | Backups (env-configured), trace store replay | Apache 2.0 |
 | Art. 30, record of processing | event_log @ 49d retention | Apache 2.0 |
 | Art. 30, record of processing (extended) | event_log under extended per-scope retention policies | **Enterprise** |
-| Art. 33, breach notification | Anomaly rule dispatch (Slack, PagerDuty, SIEM webhook, email) | **Enterprise** |
+| Art. 33, breach notification | Anomaly rule dispatch, a signed webhook POST to the rule's destination URL (rules cannot be created in the app today) | **Enterprise** |
 | Art. 35, DPIA evidence | OCSF/SIEM export bundle | **Enterprise** |
 
 If your processor agreement requires retention longer than the 49-day
@@ -57514,7 +57565,7 @@ provider/deployer record-keeping (Art. 18) map onto:
 - **Art. 12(2)(a) period of operation**: Apache 2.0 (trace timestamps in event_log)
 - **Art. 12(2)(b) reference DB used**: Apache 2.0 (`gen_ai.system` + `gen_ai.request.model` attrs on each span)
 - **Art. 12(2)(c) input data check**: Apache 2.0 (prompt + tool-call payloads on traces, redacted via Presidio)
-- **Art. 12(2)(d) human oversight**: **Enterprise** anomaly-rule dispatch (so a person reviews flagged events) + OCSF/SIEM forwarding
+- **Art. 12(2)(d) human oversight**: **Enterprise** anomaly-rule webhook dispatch (so a person reviews flagged events), with OCSF/SIEM forwarding of governance events alongside it. The two are separate paths: anomaly alerts arrive over the webhook, never as a record in the OCSF export
 - **Art. 18(1) record-keeping ≥10y**: Enterprise extended retention policies, with windows set in years to match the record-keeping clause your assessment requires.
 
 Most enterprise-deploying-an-LLM-agent uses fall under Art. 12 (1-3
@@ -57526,8 +57577,10 @@ explicitly requires the Enterprise retention extension.
 These are deliberate design boundaries that keep the Apache 2.0 floor
 free to run and free to modify:
 
-- **Anomaly detection + dispatch** is Enterprise. The detection is the
-  thing you pay for.
+- **Anomaly detection + webhook dispatch** is Enterprise. The detection is
+  the thing you pay for. Webhook is the only destination type; Slack,
+  PagerDuty and email are not implemented, so route through your own
+  receiver if you need them.
 - **Extended retention** is Enterprise. The default window is sufficient for
   CC7.2 monitoring + Art. 30 GDPR processing-records-baseline.
 - **OCSF/SIEM export** is Enterprise. Apache 2.0 customers can still

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -57513,13 +57513,14 @@ require Enterprise.
 | Art. 32(1)(d), restoration | Backups (env-configured), trace store replay | Apache 2.0 |
 | Art. 30, record of processing | event_log @ 49d retention | Apache 2.0 |
 | Art. 30, record of processing (extended) | event_log under extended per-scope retention policies | **Enterprise** |
-| Art. 33, breach notification | Anomaly rule dispatch, a webhook POST to the rule's destination URL, HMAC-signed when the destination has a shared secret (rules cannot be created in the app today) | **Enterprise** |
+| Art. 33, breach detection and escalation | Anomaly rule dispatch, a webhook POST to the rule's destination URL, HMAC-signed when the destination has a shared secret (rules cannot be created in the app today). This surfaces the event to you; the notification to the supervisory authority and the breach record are yours to make | **Enterprise** |
 | Art. 35, DPIA evidence | OCSF/SIEM export bundle | **Enterprise** |
 
 If your processor agreement requires retention longer than the 49-day
-default OR a named breach-notification mechanism (Art. 33's "without
-undue delay, where feasible, not later than 72 hours"), Enterprise is
-the right tier. Self-hosted, a license is what opens a longer window at
+default OR a named breach-detection mechanism that feeds your Art. 33
+notification (its "without undue delay, where feasible, not later than
+72 hours" clock starts when you become aware), Enterprise is the right
+tier. Self-hosted, a license is what opens a longer window at
 all.
 
 This reaches customers outside the EU as well, but only where Art. 3

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -549,7 +549,7 @@ For agents: if anything in these docs is wrong, confusing, or fails when you try
 
 ## Detection
 
-- [Anomaly rules](https://langwatch.ai/docs/ai-governance/anomaly-rules.md): What the anomaly detector evaluates, what a rule is made of, and why rules cannot be created in the app today.
+- [Anomaly rules](https://langwatch.ai/docs/ai-governance/anomaly-rules.md): What the anomaly detector evaluates, what a rule is made of, how a fired alert reaches you, and why rules cannot be created in the app today.
 
 ## Compliance & Architecture
 

--- a/docs/self-hosting/compliance.mdx
+++ b/docs/self-hosting/compliance.mdx
@@ -155,7 +155,7 @@ provider/deployer record-keeping (Art. 18) map onto:
 - **Art. 12(2)(a) period of operation**: Apache 2.0 (trace timestamps in event_log)
 - **Art. 12(2)(b) reference DB used**: Apache 2.0 (`gen_ai.system` + `gen_ai.request.model` attrs on each span)
 - **Art. 12(2)(c) input data check**: Apache 2.0 (prompt + tool-call payloads on traces, redacted via Presidio)
-- **Art. 12(2)(d) human oversight**: **Enterprise** anomaly-rule webhook dispatch (it delivers the flagged event to a URL you control; the human review of what arrives there is your receiving process, not something LangWatch performs or records), with OCSF/SIEM forwarding of governance events alongside it. The two are separate paths: anomaly alerts arrive over the webhook, never as a record in the OCSF export
+- **Art. 12(2)(d) human oversight**: **Enterprise** anomaly-rule webhook dispatch (it delivers the flagged event to a URL you control; the human review of what arrives there is your receiving process, not something LangWatch performs or records today), with OCSF/SIEM forwarding of governance events alongside it. The two are separate paths: anomaly alerts arrive over the webhook, never as a record in the OCSF export
 - **Art. 18(1) record-keeping ≥10y**: Enterprise extended retention policies, with windows set in years to match the record-keeping clause your assessment requires.
 
 Most enterprise-deploying-an-LLM-agent uses fall under Art. 12 (1-3

--- a/docs/self-hosting/compliance.mdx
+++ b/docs/self-hosting/compliance.mdx
@@ -48,7 +48,7 @@ deployment plan.
 | Billing spend ledger, fixed 13-month retention (with ClickHouse) | ✅ | ✅ |
 | Webhook endpoints platform (signed event delivery, retries, replay) | ❌ | ✅ |
 | Billing events APIs (spend-events pull, summaries, replay) | ❌ | ✅ |
-| Anomaly Rules, admin-curated detection + signed webhook dispatch | ❌ | ✅ |
+| Anomaly Rules, admin-curated detection + webhook dispatch (HMAC-signed when a shared secret is set) | ❌ | ✅ |
 | OCSF/SIEM export (Splunk, Datadog, Sentinel pull API) | ❌ | ✅ |
 | Audit log, org-wide cross-team | ❌ | ✅ |
 | SCIM provisioning | ❌ | ✅ |
@@ -99,7 +99,7 @@ require Enterprise.
 | Art. 32(1)(d), restoration | Backups (env-configured), trace store replay | Apache 2.0 |
 | Art. 30, record of processing | event_log @ 49d retention | Apache 2.0 |
 | Art. 30, record of processing (extended) | event_log under extended per-scope retention policies | **Enterprise** |
-| Art. 33, breach notification | Anomaly rule dispatch, a signed webhook POST to the rule's destination URL (rules cannot be created in the app today) | **Enterprise** |
+| Art. 33, breach notification | Anomaly rule dispatch, a webhook POST to the rule's destination URL, HMAC-signed when the destination has a shared secret (rules cannot be created in the app today) | **Enterprise** |
 | Art. 35, DPIA evidence | OCSF/SIEM export bundle | **Enterprise** |
 
 If your processor agreement requires retention longer than the 49-day
@@ -155,7 +155,7 @@ provider/deployer record-keeping (Art. 18) map onto:
 - **Art. 12(2)(a) period of operation**: Apache 2.0 (trace timestamps in event_log)
 - **Art. 12(2)(b) reference DB used**: Apache 2.0 (`gen_ai.system` + `gen_ai.request.model` attrs on each span)
 - **Art. 12(2)(c) input data check**: Apache 2.0 (prompt + tool-call payloads on traces, redacted via Presidio)
-- **Art. 12(2)(d) human oversight**: **Enterprise** anomaly-rule webhook dispatch (so a person reviews flagged events), with OCSF/SIEM forwarding of governance events alongside it. The two are separate paths: anomaly alerts arrive over the webhook, never as a record in the OCSF export
+- **Art. 12(2)(d) human oversight**: **Enterprise** anomaly-rule webhook dispatch (it delivers the flagged event to a URL you control; the human review of what arrives there is your receiving process, not something LangWatch performs or records), with OCSF/SIEM forwarding of governance events alongside it. The two are separate paths: anomaly alerts arrive over the webhook, never as a record in the OCSF export
 - **Art. 18(1) record-keeping ≥10y**: Enterprise extended retention policies, with windows set in years to match the record-keeping clause your assessment requires.
 
 Most enterprise-deploying-an-LLM-agent uses fall under Art. 12 (1-3

--- a/docs/self-hosting/compliance.mdx
+++ b/docs/self-hosting/compliance.mdx
@@ -48,7 +48,7 @@ deployment plan.
 | Billing spend ledger, fixed 13-month retention (with ClickHouse) | ✅ | ✅ |
 | Webhook endpoints platform (signed event delivery, retries, replay) | ❌ | ✅ |
 | Billing events APIs (spend-events pull, summaries, replay) | ❌ | ✅ |
-| Anomaly Rules, admin-curated detection + dispatch | ❌ | ✅ |
+| Anomaly Rules, admin-curated detection + signed webhook dispatch | ❌ | ✅ |
 | OCSF/SIEM export (Splunk, Datadog, Sentinel pull API) | ❌ | ✅ |
 | Audit log, org-wide cross-team | ❌ | ✅ |
 | SCIM provisioning | ❌ | ✅ |
@@ -73,7 +73,7 @@ the *common-criteria* baseline:
 | CC6.1, Logical access | RBAC catalog + per-project tenancy + RoleBinding scopes | Apache 2.0 |
 | CC6.6, Logical access (admin) | RBAC ADMIN role + `governance:manage` + `aiTools:manage` | Apache 2.0 |
 | CC6.7, Termination of access | CLI token revoke on user deactivation (CliTokenRevocationService, Phase 1B-1) | Apache 2.0 |
-| CC7.1, Detection | Anomaly rules on activity-event traffic (spend-spike, geo-mismatch, off-hours) | **Enterprise** |
+| CC7.1, Detection | Anomaly rules on activity-event traffic (spend-spike; the other rule types are stored but not evaluated yet) | **Enterprise** |
 | CC7.2, Monitoring | Append-only event_log + 49-day default retention | Apache 2.0 |
 | CC7.2, Monitoring (≥1y) | Per-scope retention policies with extended (multi-year) windows | **Enterprise** |
 | CC7.4, Incident response | OCSF v1.1 SIEM export with cursor pagination | **Enterprise** |
@@ -99,7 +99,7 @@ require Enterprise.
 | Art. 32(1)(d), restoration | Backups (env-configured), trace store replay | Apache 2.0 |
 | Art. 30, record of processing | event_log @ 49d retention | Apache 2.0 |
 | Art. 30, record of processing (extended) | event_log under extended per-scope retention policies | **Enterprise** |
-| Art. 33, breach notification | Anomaly rule dispatch (Slack, PagerDuty, SIEM webhook, email) | **Enterprise** |
+| Art. 33, breach notification | Anomaly rule dispatch, a signed webhook POST to the rule's destination URL (rules cannot be created in the app today) | **Enterprise** |
 | Art. 35, DPIA evidence | OCSF/SIEM export bundle | **Enterprise** |
 
 If your processor agreement requires retention longer than the 49-day
@@ -155,7 +155,7 @@ provider/deployer record-keeping (Art. 18) map onto:
 - **Art. 12(2)(a) period of operation**: Apache 2.0 (trace timestamps in event_log)
 - **Art. 12(2)(b) reference DB used**: Apache 2.0 (`gen_ai.system` + `gen_ai.request.model` attrs on each span)
 - **Art. 12(2)(c) input data check**: Apache 2.0 (prompt + tool-call payloads on traces, redacted via Presidio)
-- **Art. 12(2)(d) human oversight**: **Enterprise** anomaly-rule dispatch (so a person reviews flagged events) + OCSF/SIEM forwarding
+- **Art. 12(2)(d) human oversight**: **Enterprise** anomaly-rule webhook dispatch (so a person reviews flagged events), with OCSF/SIEM forwarding of governance events alongside it. The two are separate paths: anomaly alerts arrive over the webhook, never as a record in the OCSF export
 - **Art. 18(1) record-keeping ≥10y**: Enterprise extended retention policies, with windows set in years to match the record-keeping clause your assessment requires.
 
 Most enterprise-deploying-an-LLM-agent uses fall under Art. 12 (1-3
@@ -167,8 +167,10 @@ explicitly requires the Enterprise retention extension.
 These are deliberate design boundaries that keep the Apache 2.0 floor
 free to run and free to modify:
 
-- **Anomaly detection + dispatch** is Enterprise. The detection is the
-  thing you pay for.
+- **Anomaly detection + webhook dispatch** is Enterprise. The detection is
+  the thing you pay for. Webhook is the only destination type; Slack,
+  PagerDuty and email are not implemented, so route through your own
+  receiver if you need them.
 - **Extended retention** is Enterprise. The default window is sufficient for
   CC7.2 monitoring + Art. 30 GDPR processing-records-baseline.
 - **OCSF/SIEM export** is Enterprise. Apache 2.0 customers can still

--- a/docs/self-hosting/compliance.mdx
+++ b/docs/self-hosting/compliance.mdx
@@ -99,13 +99,14 @@ require Enterprise.
 | Art. 32(1)(d), restoration | Backups (env-configured), trace store replay | Apache 2.0 |
 | Art. 30, record of processing | event_log @ 49d retention | Apache 2.0 |
 | Art. 30, record of processing (extended) | event_log under extended per-scope retention policies | **Enterprise** |
-| Art. 33, breach notification | Anomaly rule dispatch, a webhook POST to the rule's destination URL, HMAC-signed when the destination has a shared secret (rules cannot be created in the app today) | **Enterprise** |
+| Art. 33, breach detection and escalation | Anomaly rule dispatch, a webhook POST to the rule's destination URL, HMAC-signed when the destination has a shared secret (rules cannot be created in the app today). This surfaces the event to you; the notification to the supervisory authority and the breach record are yours to make | **Enterprise** |
 | Art. 35, DPIA evidence | OCSF/SIEM export bundle | **Enterprise** |
 
 If your processor agreement requires retention longer than the 49-day
-default OR a named breach-notification mechanism (Art. 33's "without
-undue delay, where feasible, not later than 72 hours"), Enterprise is
-the right tier. Self-hosted, a license is what opens a longer window at
+default OR a named breach-detection mechanism that feeds your Art. 33
+notification (its "without undue delay, where feasible, not later than
+72 hours" clock starts when you become aware), Enterprise is the right
+tier. Self-hosted, a license is what opens a longer window at
 all.
 
 This reaches customers outside the EU as well, but only where Art. 3

--- a/platform/app/ee/governance/dashboard/__tests__/pullConfigBuilderCoverage.unit.test.ts
+++ b/platform/app/ee/governance/dashboard/__tests__/pullConfigBuilderCoverage.unit.test.ts
@@ -16,31 +16,48 @@
  * than the first time the source runs.
  *
  * Spec: specs/governance/edit-pull-source-config.feature
+ *       specs/ai-gateway/governance/ingestion-sources.feature
+ *       ("Every source type that collects a secret can put it back where its
+ *        adapter reads it")
  */
 
 import { SOURCE_TYPE_OPTIONS } from "@ee/governance/dashboard/components/ingestionSourceCatalog";
 import {
+  buildClaudeCompliancePullConfig,
+  type ComposerState,
   PARSER_FIELDS,
   SOURCE_TYPES_WITH_PULL_CONFIG_BUILDER,
 } from "@ee/governance/dashboard/pages/inventory";
+import { CLAUDE_COMPLIANCE_PULL_CONFIG } from "@ee/governance/services/pullers/claudeCompliance.puller";
 import { describe, expect, it } from "vitest";
 
 /**
- * The population is the source types an admin can actually choose. A type
- * that collects a secret needs a builder to put that secret back where its
- * adapter reads it; without one the key is dropped and every run sends an
- * unresolved credential template as its header.
+ * The population is EVERY source type whose form collects a secret, hidden
+ * ones included. A type that collects a secret needs a builder to put that
+ * secret back where its adapter reads it; without one the key is dropped and
+ * every run sends an unresolved credential template as its header.
  *
- * `claude_compliance` was the one type in this population with no builder
- * (#7583). It is now hidden from the picker, so it is out of the population
- * rather than exempted from it — the assertion below is what proves that,
- * and it is the reason no exemption list survives in this file. Rows already
- * configured on it are untouched and still broken; hiding stops new ones.
+ * The population used to be the types on offer in the picker, which made
+ * hiding a type a way to leave its builder missing: that is exactly what was
+ * done to `claude_compliance` (#7583), and behind that door the form went on
+ * collecting a workspace key that nothing routed anywhere. Hidden types are
+ * in the population now, so the door is shut. Whether a type is OFFERED is a
+ * separate question, asked separately below.
  */
-describe("given the source types offered in the picker", () => {
+describe("given every source type whose form collects a secret", () => {
   const offered = SOURCE_TYPE_OPTIONS.filter((option) => !option.deprecated);
-  const secretCollecting = offered
-    .filter((option) => option.mode === "pull")
+  // Retired types are the one exclusion, and it is a fact about the product
+  // rather than a line in this file: what a retired type reads is gone or was
+  // never worth reading, so no builder would make it deliver anything. The
+  // three assertions in the first test are what keep that door from becoming
+  // the old one — a live or merely-unfinished type cannot be excused through
+  // it without the catalog saying something plainly false.
+  const retired = new Set<string>(
+    SOURCE_TYPE_OPTIONS.filter((option) => option.retired).map((o) => o.value),
+  );
+  const secretCollecting = SOURCE_TYPE_OPTIONS.filter(
+    (option) => option.mode === "pull" && !option.retired,
+  )
     .map((option) => option.value)
     .filter((value) =>
       (PARSER_FIELDS[value] ?? []).some((field) => field.secret === true),
@@ -54,8 +71,19 @@ describe("given the source types offered in the picker", () => {
       // it. A guard that cannot name what it is guarding is not one.
       expect(secretCollecting.length).toBeGreaterThan(0);
       expect(secretCollecting).toContain("anthropic_admin");
+      // The self-check on widening the population past the picker: a hidden
+      // type has to actually be in it, or the widening is cosmetic.
+      expect(secretCollecting).toContain("claude_compliance");
+      expect(offered.map((o) => o.value)).not.toContain("claude_compliance");
+      // And the self-checks on the one exclusion. It names somebody, it never
+      // covers a type still on offer, and it does not reach the type this
+      // guard was written about.
+      expect(retired.size).toBeGreaterThan(0);
+      expect(offered.filter((o) => retired.has(o.value))).toEqual([]);
+      expect(retired.has("claude_compliance")).toBe(false);
     });
 
+    /** @scenario "Every source type that collects a secret can put it back where its adapter reads it" */
     it("gives every source type that collects a secret a way to reassemble it", () => {
       const withBuilder = new Set<string>(
         SOURCE_TYPES_WITH_PULL_CONFIG_BUILDER,
@@ -66,24 +94,91 @@ describe("given the source types offered in the picker", () => {
       );
     });
 
-    it("no longer offers the compliance type that had no builder", () => {
-      // If it came back to the picker it would re-enter the population above
-      // with nothing to reassemble its workspace key, so the guard would fail
-      // on it rather than pass around it.
-      expect(secretCollecting).not.toContain("claude_compliance");
+    it("keeps the compliance type out of the picker even though it is whole again", () => {
+      // Its key reaches its adapter now, so the check above covers it like
+      // any other type. Whether it comes BACK to the picker is a separate
+      // call — the puller behind it has never run against a live tenant —
+      // and this test is what stops the fix quietly making it.
       expect(offered.map((o) => o.value)).not.toContain("claude_compliance");
-      // Its form still declares the secret, which is why it must stay hidden
-      // rather than merely be left alone.
-      expect(
-        (PARSER_FIELDS.claude_compliance ?? []).some(
-          (field) => field.secret === true,
-        ),
-      ).toBe(true);
       expect(
         new Set<string>(SOURCE_TYPES_WITH_PULL_CONFIG_BUILDER).has(
           "claude_compliance",
         ),
-      ).toBe(false);
+      ).toBe(true);
+    });
+  });
+});
+
+/**
+ * The type the guard above was written about, end to end: what the form
+ * collects has to come out the other side as the credential the adapter's
+ * frozen header actually reads.
+ *
+ * Spec: specs/ai-gateway/governance/ingestion-sources.feature
+ *       ("The Claude compliance workspace key reaches its adapter as the
+ *        token it reads")
+ */
+describe("given a Claude compliance source with a workspace key typed in", () => {
+  const WORKSPACE_KEY = "sk-ant-admin-test-key";
+
+  function composer(parserConfig: Record<string, string>): ComposerState {
+    return {
+      sourceType: "claude_compliance",
+      name: "Claude compliance log",
+      description: "",
+      parserConfig,
+      ottlStatements: [],
+      pullSchedule: "",
+      traceProjectId: null,
+    };
+  }
+
+  describe("when its pull config is assembled for saving", () => {
+    /** @scenario "The Claude compliance workspace key reaches its adapter as the token it reads" */
+    it("carries the key as the credentials token", () => {
+      const config = buildClaudeCompliancePullConfig(
+        composer({ credentialsToken: WORKSPACE_KEY }),
+      );
+
+      expect(config).not.toBeNull();
+      expect((config as Record<string, unknown>).credentials).toEqual({
+        token: WORKSPACE_KEY,
+      });
+      // The adapter is resolved by this id; the frozen config's own
+      // `adapter: "http_polling"` would dispatch the generic puller instead.
+      expect((config as Record<string, unknown>).adapter).toBe(
+        "claude_compliance",
+      );
+    });
+
+    /** @scenario "The Claude compliance workspace key reaches its adapter as the token it reads" */
+    it("resolves the adapter's frozen request header to that key", () => {
+      const config = buildClaudeCompliancePullConfig(
+        composer({ credentialsToken: WORKSPACE_KEY }),
+      ) as { credentials: { token: string } };
+
+      // The same substitution the polling adapter does at request time. The
+      // bug this pins is not a wrong value but an unsubstituted one: with the
+      // key dropped on the way through, every run sent this template verbatim.
+      const template = CLAUDE_COMPLIANCE_PULL_CONFIG.headers?.["x-api-key"];
+      expect(template).toBe("${{credentials.token}}");
+      expect(
+        template?.replace("${{credentials.token}}", config.credentials.token),
+      ).toBe(WORKSPACE_KEY);
+    });
+
+    /** @scenario "The Claude compliance workspace key reaches its adapter as the token it reads" */
+    it("refuses to save a new source with no key at all", () => {
+      // A blank key on CREATE is a source that cannot authenticate. On EDIT it
+      // means "leave the stored one alone", which is why the key is omitted
+      // rather than written empty — an empty one would overwrite a working
+      // secret on the next save.
+      expect(buildClaudeCompliancePullConfig(composer({}))).toBeNull();
+      const editing = buildClaudeCompliancePullConfig(composer({}), {
+        shouldRequireCredentials: false,
+      });
+      expect(editing).not.toBeNull();
+      expect(editing).not.toHaveProperty("credentials");
     });
   });
 });

--- a/platform/app/ee/governance/dashboard/components/IngestionSourcesTable.tsx
+++ b/platform/app/ee/governance/dashboard/components/IngestionSourcesTable.tsx
@@ -14,6 +14,7 @@ import { MoreVertical, Pencil, RotateCw, Trash2 } from "lucide-react";
 import { ListTable } from "~/components/ui/ListTable";
 import { Link } from "~/components/ui/link";
 import { Menu } from "~/components/ui/menu";
+import { confirmArchiveSource } from "../logic/confirmArchiveSource";
 import { shortPullCadence } from "../logic/pullCadence";
 import { sourceBadge } from "../logic/sourceHealthDisplay";
 import {
@@ -297,6 +298,7 @@ function SourceTableRow({
                 color="red.500"
                 onClick={(event) => {
                   event.stopPropagation();
+                  if (!confirmArchiveSource({ name: source.name })) return;
                   onArchive();
                 }}
               >

--- a/platform/app/ee/governance/dashboard/components/__tests__/IngestionSourcesTable.integration.test.tsx
+++ b/platform/app/ee/governance/dashboard/components/__tests__/IngestionSourcesTable.integration.test.tsx
@@ -8,7 +8,8 @@
  *
  * Spec: specs/ai-gateway/governance/ingestion-sources.feature
  *       ("The sources table shows delivery as a column",
- *        "Row actions live in the overflow menu")
+ *        "Row actions live in the overflow menu",
+ *        "Archiving from the row asks the same question the detail page asks")
  */
 import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
 import { cleanup, render, screen, within } from "@testing-library/react";
@@ -91,7 +92,19 @@ function renderTable({
   return handlers;
 }
 
-afterEach(() => cleanup());
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+/**
+ * jsdom leaves `window.confirm` unimplemented — calling it throws "not
+ * implemented" rather than returning — so every test that reaches the archive
+ * action has to say what the admin answered.
+ */
+function stubConfirm(answer: boolean) {
+  return vi.spyOn(window, "confirm").mockReturnValue(answer);
+}
 
 describe("given the ingestion sources table", () => {
   describe("when the fleet mixes real-time and scheduled sources", () => {
@@ -153,6 +166,7 @@ describe("given the ingestion sources table", () => {
         await screen.findByRole("menuitem", { name: /Rotate secret/ }),
       ).toBeVisible();
       expect(screen.getByRole("menuitem", { name: /Edit/ })).toBeVisible();
+      stubConfirm(true);
       await user.click(screen.getByRole("menuitem", { name: /Archive/ }));
       expect(handlers.onArchive).toHaveBeenCalledWith("src-workato");
       // No inline buttons anywhere in the row.
@@ -177,6 +191,51 @@ describe("given the ingestion sources table", () => {
       expect(
         screen.queryByRole("menuitem", { name: /Rotate secret/ }),
       ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("when an admin picks Archive from a row", () => {
+    async function openArchive() {
+      const user = userEvent.setup();
+      const handlers = renderTable();
+      await user.click(
+        screen.getByRole("button", { name: "Actions for Workato prod" }),
+      );
+      const item = await screen.findByRole("menuitem", { name: /Archive/ });
+      return { user, handlers, item };
+    }
+
+    /** @scenario "Archiving from the row asks the same question the detail page asks" */
+    it("asks a question that names the source and what survives", async () => {
+      const confirmed = stubConfirm(false);
+      const { user, item } = await openArchive();
+
+      await user.click(item);
+
+      expect(confirmed).toHaveBeenCalledTimes(1);
+      const asked = confirmed.mock.calls[0]?.[0] ?? "";
+      expect(asked).toContain("Workato prod");
+      expect(asked).toContain("Historical events stay readable");
+    });
+
+    /** @scenario "Archiving from the row asks the same question the detail page asks" */
+    it("leaves the source alone when the admin declines", async () => {
+      stubConfirm(false);
+      const { user, handlers, item } = await openArchive();
+
+      await user.click(item);
+
+      expect(handlers.onArchive).not.toHaveBeenCalled();
+    });
+
+    /** @scenario "Archiving from the row asks the same question the detail page asks" */
+    it("archives once the admin confirms", async () => {
+      stubConfirm(true);
+      const { user, handlers, item } = await openArchive();
+
+      await user.click(item);
+
+      expect(handlers.onArchive).toHaveBeenCalledWith("src-workato");
     });
   });
 

--- a/platform/app/ee/governance/dashboard/components/__tests__/ingestionSourceCatalog.unit.test.ts
+++ b/platform/app/ee/governance/dashboard/components/__tests__/ingestionSourceCatalog.unit.test.ts
@@ -71,11 +71,17 @@ describe("given the ingestion-source catalog", () => {
 
   describe("when a source type was offered before it worked", () => {
     /*
-     * The compliance pair. Both were pickable and neither had anything
-     * reading it, so a source configured on one stayed silent forever. They
-     * leave the picker exactly the way the retired Copilot type did.
+     * It was pickable with nothing reading it, so a source configured on it
+     * stayed silent forever. It leaves the picker exactly the way the retired
+     * Copilot type did.
+     *
+     * The Claude Enterprise Compliance type used to sit here beside it. Its
+     * workspace key reaches its adapter now, so the sentence this block
+     * asserts — that a source here would never deliver any data — became
+     * false for it, and it is checked separately below on the footing it
+     * actually has.
      */
-    const NEVER_BUILT = ["openai_compliance", "claude_compliance"] as const;
+    const NEVER_BUILT = ["openai_compliance"] as const;
 
     /** @scenario "A source type nothing reads can no longer be chosen" */
     it("is not offered on any plan", () => {
@@ -113,6 +119,28 @@ describe("given the ingestion-source catalog", () => {
         // The old copy described a poller that was never written.
         expect(option?.blurb).not.toMatch(/polls|pulls/i);
       }
+    });
+  });
+
+  describe("when a source type works but has not been run against a tenant", () => {
+    it("stays out of the picker without claiming it could never deliver data", () => {
+      const option = SOURCE_TYPE_OPTIONS.find(
+        (o) => o.value === "claude_compliance",
+      );
+      for (const isEnterprise of [true, false]) {
+        expect(
+          gatedSourceTypeOptions({ isEnterprise }).map((o) => o.value),
+        ).not.toContain("claude_compliance");
+      }
+      // The claim that made the old blurb true was the missing builder, and
+      // the builder exists now. Repeating it here would be a page telling a
+      // customer something we have fixed.
+      expect(option?.blurb).not.toMatch(/never deliver/i);
+      expect(option?.blurb).toMatch(/not offered/i);
+      // Hidden, but not retired: retirement says no builder is owed, and one
+      // was written. See the flag's doc comment on `SourceTypeOption`.
+      expect(option?.deprecated).toBe(true);
+      expect(option?.retired).toBeFalsy();
     });
   });
 

--- a/platform/app/ee/governance/dashboard/components/ingestionSourceCatalog.tsx
+++ b/platform/app/ee/governance/dashboard/components/ingestionSourceCatalog.tsx
@@ -86,6 +86,19 @@ export interface SourceTypeOption {
    */
   deprecated?: boolean;
   /**
+   * True when the thing this type reads is gone or was never worth reading,
+   * so no amount of work on our side would make it deliver data. Retired
+   * types are always deprecated too; the extra flag says WHY, and the why is
+   * load-bearing: a deprecated type that merely has not been finished is one
+   * we still owe a working configuration path, and the builder-coverage
+   * guard holds us to that. A retired one we owe nothing but a way to
+   * archive the rows already on it.
+   *
+   * Not a place to park a type that is broken. "Broken" is the case the
+   * guard exists to catch.
+   */
+  retired?: boolean;
+  /**
    * True when this type is left out of the sample Sources table, while
    * staying fully on offer everywhere else.
    *
@@ -157,6 +170,12 @@ export const SOURCE_TYPE_OPTIONS = [
     // Kept so existing rows keep their label and the guards below still
     // compile; filtered out of the picker by `gatedSourceTypeOptions`.
     deprecated: true,
+    // Retired rather than unfinished: directory audit has never carried a
+    // Copilot conversation, so there is no version of this source that
+    // works. Its setup form asks for an app registration the frozen adapter
+    // config cannot use either — and neither will be fixed, because the
+    // source that replaced it reads the conversations directly.
+    retired: true,
   },
   {
     value: "copilot_studio_dataverse",
@@ -191,13 +210,14 @@ export const SOURCE_TYPE_OPTIONS = [
     value: "claude_compliance",
     label: "Anthropic Claude Enterprise Compliance",
     mode: "pull",
-    blurb: "Not available. Choosing this source would never deliver any data.",
+    blurb: "Not offered for new sources.",
     icon: <Anthropic />,
-    // Same shape as the OpenAI entry above, with a known mechanism (#7583):
-    // the form collects a workspace API key that no pull-config builder ever
-    // puts where the adapter reads it, so every run authenticates with an
-    // unresolved template. Hiding it stops new sources being configured on
-    // that path; rows already on it are untouched.
+    // Not retired: the workspace key now reaches the adapter as the token it
+    // reads, so the path behind this type is whole. It stays out of the
+    // picker because nothing has yet pulled a real tenant's compliance log
+    // end to end, and offering it is a separate call from fixing it. The
+    // blurb no longer says a source here would never deliver data, because
+    // after the fix that is not true.
     deprecated: true,
   },
   {

--- a/platform/app/ee/governance/dashboard/logic/confirmArchiveSource.ts
+++ b/platform/app/ee/governance/dashboard/logic/confirmArchiveSource.ts
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+
+/**
+ * The one question asked before a source is archived, wherever the action is
+ * offered.
+ *
+ * Archiving is offered on two screens, and each used to own its own copy of
+ * this: the detail page asked, the table's row menu did not, so the same
+ * action cost one click on one screen and two on the other — and the cheaper
+ * one was the one with no way back. The wording lives here so the two cannot
+ * drift apart again.
+ *
+ * Spec: specs/ai-gateway/governance/ingestion-sources.feature
+ *       ("Archiving from the row asks the same question the detail page asks")
+ */
+export function confirmArchiveSource({ name }: { name: string }): boolean {
+  return confirm(`Archive "${name}"? Historical events stay readable.`);
+}

--- a/platform/app/ee/governance/dashboard/pages/ingestion-source-detail.tsx
+++ b/platform/app/ee/governance/dashboard/pages/ingestion-source-detail.tsx
@@ -13,6 +13,7 @@ import {
   Text,
   VStack,
 } from "@chakra-ui/react";
+import { confirmArchiveSource } from "@ee/governance/dashboard/logic/confirmArchiveSource";
 import {
   SOURCE_HEALTH_REFRESH,
   sourceBadge,
@@ -188,12 +189,7 @@ function SourceDetailHeader({
             variant="ghost"
             colorPalette="red"
             onClick={() => {
-              if (
-                !confirm(
-                  `Archive "${source.name}"? Historical events stay readable.`,
-                )
-              )
-                return;
+              if (!confirmArchiveSource({ name: source.name })) return;
               onArchive();
             }}
             loading={isArchiving}

--- a/platform/app/ee/governance/dashboard/pages/inventory.tsx
+++ b/platform/app/ee/governance/dashboard/pages/inventory.tsx
@@ -195,6 +195,7 @@ export const SOURCE_TYPES_WITH_PULL_CONFIG_BUILDER = [
   "copilot_studio_dataverse",
   "openai_admin",
   "anthropic_admin",
+  "claude_compliance",
 ] as const;
 
 type PullConfigBuilderSourceType =
@@ -236,6 +237,14 @@ function resolvePullConfig(
       shouldRequireCredentials
         ? "An organization Admin API key is required, and the backfill start must be a calendar date (2026-08-01) or an instant carrying a timezone (2026-08-01T00:00:00Z)."
         : "The backfill start must be a calendar date (2026-08-01) or an instant carrying a timezone (2026-08-01T00:00:00Z). Leave the admin API key blank to keep the current one.",
+    ],
+    claude_compliance: [
+      () =>
+        buildClaudeCompliancePullConfig(composer, { shouldRequireCredentials }),
+      "Missing workspace API key",
+      shouldRequireCredentials
+        ? "The workspace API key is required — without it every run authenticates with an unresolved template."
+        : "Leave the workspace API key blank to keep the current one.",
     ],
     anthropic_admin: [
       () =>
@@ -2823,7 +2832,12 @@ export const PARSER_FIELDS: Record<SourceType, FieldDef[]> = {
   ],
   claude_compliance: [
     {
-      key: "workspaceApiKey",
+      // `credentials*` prefix, like every other secret this form collects:
+      // it is what routes the value into the encrypted `credentials` subtree
+      // the adapter's frozen `${{credentials.token}}` header reads. Under its
+      // old name the field was collected, dropped by `parserFieldValue` as a
+      // secret, and put back by nothing.
+      key: "credentialsToken",
       label: "Workspace API key",
       placeholder: "sk-ant-admin-...",
       hint: "Generate under Anthropic Admin Console → Compliance → Workspace API Keys. We hash this server-side.",
@@ -2892,10 +2906,13 @@ export const PARSER_FIELDS: Record<SourceType, FieldDef[]> = {
       required: true,
     },
     {
-      // Named `credentials*` on purpose: `buildParserConfig` routes every
-      // `credentials*` field into the `credentials` subtree, which is the ONLY
-      // part of parserConfig the server encrypts before it reaches the
-      // database. A field named `clientId` would sit in the JSONB in plaintext.
+      // Named `credentials*` on purpose. `buildParserConfig` does not route
+      // these anywhere — it DROPS every secret field, so none is ever written
+      // to the plaintext part of parserConfig. Putting them back under
+      // `credentials`, the ONLY subtree the server encrypts before the row
+      // reaches the database, is this source type's pull-config builder's
+      // job. A field named `clientId` would be dropped just the same and
+      // never reach the adapter at all.
       key: "credentialsClientId",
       label: "Service principal client ID",
       placeholder: "0a1b2c3d-4e5f-6789-abcd-ef0123456789",
@@ -3117,6 +3134,56 @@ function buildHttpCustomPullConfig(
     // on `pullConfig.credentials.*` and the adapter substitutes them into
     // the header template via the `${{credentials.<key>}}` syntax.
     credentials: { token },
+  };
+}
+
+/**
+ * The Claude Enterprise Compliance adapter config, or null when a new source
+ * names no workspace API key.
+ *
+ * The adapter's shape is frozen — `ClaudeComplianceReferencePuller.validateConfig`
+ * returns `CLAUDE_COMPLIANCE_PULL_CONFIG` whatever is stored — so the only
+ * thing this builder has to get right is the credential: the frozen header
+ * reads `${{credentials.token}}`, and `credentials` is the one subtree the
+ * server encrypts. Everything else the form collects (the polling cadence)
+ * keeps travelling through `buildParserConfig` exactly as before.
+ *
+ * The adapter id is written explicitly rather than copied from the frozen
+ * config, which names the generic `http_polling` adapter it is built on:
+ * `resolvePullAdapter` dispatches on this field, so copying it would run the
+ * generic puller in place of this one. The frozen config is not imported here
+ * at all — it lives in a server puller module, and pulling that into the
+ * inventory page would drag the puller stack into the browser bundle.
+ *
+ * `shouldRequireCredentials` carries the same meaning as it does for the two
+ * Admin builders below: on edit a blank key means "leave it alone", so the
+ * key is OMITTED rather than emitted empty, because `updateSource` carries the
+ * stored envelope across only for a key that is genuinely absent.
+ *
+ * NEITHER PATH REACHES THIS BUILDER TODAY. The type is `deprecated` in the
+ * catalog, so the create picker never offers it, and it is absent from
+ * `EDITABLE_PULL_CONFIG_SOURCE_TYPES`, so `buildEditSubmission` never asks
+ * for it. The builder exists so that the day the type is offered again, the
+ * secret already lands where the adapter reads it (#7583) instead of under
+ * the old `workspaceApiKey` name the adapter never looked at. The coverage
+ * guard in `pullConfigBuilderCoverage.unit.test.ts` is what keeps it wired.
+ */
+export function buildClaudeCompliancePullConfig(
+  c: ComposerState,
+  {
+    shouldRequireCredentials = true,
+  }: { shouldRequireCredentials?: boolean } = {},
+): Record<string, unknown> | null {
+  const token = trimmedField(c.parserConfig, "credentialsToken");
+  if (!token && shouldRequireCredentials) return null;
+
+  return {
+    adapter: "claude_compliance",
+    schedule:
+      c.pullSchedule.trim() ||
+      PULL_SCHEDULE_DEFAULTS.claude_compliance ||
+      "*/15 * * * *",
+    ...(token ? { credentials: { token } } : {}),
   };
 }
 

--- a/platform/app/ee/governance/services/__tests__/governanceOcsfEvents.seatReports.integration.test.ts
+++ b/platform/app/ee/governance/services/__tests__/governanceOcsfEvents.seatReports.integration.test.ts
@@ -22,9 +22,13 @@
  * compaction is forced here and the same question asked on both sides of it.
  *
  * The payloads come from the production seat-event builder
- * (`microsoftSeatEvents`), so the bag the counts travel in is the real one.
- * Only the OCSF envelope around it is rebuilt locally: the puller worker's
- * mapper is module-private, and the envelope has its own coverage in
+ * (`microsoftSeatEvents`), so the bag the counts travel in is the real one,
+ * and the actor is placed by the production `ocsfActorFields` rather than
+ * assigned to a column here. A licence pool names no person, so today that
+ * places an empty string whichever way it is written; what it buys is that
+ * this fixture cannot drift into disagreeing with the mapper about which
+ * column an actor string belongs in. The rest of the OCSF envelope is rebuilt
+ * locally; it has its own coverage in
  * pullers/__tests__/pullerWorker.ocsfMapping.unit.test.ts.
  *
  * Spec: specs/governance/governance-cost-screen.feature
@@ -55,6 +59,7 @@ import {
   SEAT_REPORT_ACTION,
   type SubscribedSku,
 } from "../pullers/microsoftGraphSeats";
+import { ocsfActorFields } from "../pullers/ocsfPullEventMapping";
 
 const TABLE = "governance_ocsf_events";
 const SOURCE_TYPE = "copilot_studio";
@@ -136,8 +141,7 @@ function seatRowsFor({
       activityId: OCSF_ACTIVITY.INVOKE,
       severityId: OCSF_SEVERITY.INFO,
       eventTime: new Date(event.event_timestamp),
-      actorUserId: "",
-      actorEmail: event.actor,
+      ...ocsfActorFields(event.actor),
       actorEnduserId: "",
       actionName: event.action,
       targetName: event.target,

--- a/platform/app/ee/governance/services/__tests__/governanceOcsfExport.service.integration.test.ts
+++ b/platform/app/ee/governance/services/__tests__/governanceOcsfExport.service.integration.test.ts
@@ -20,16 +20,23 @@
  * `GovernanceOcsfExportService.list` so we exercise the full SELECT
  * path that SIEM consumers see.
  *
+ * The actor-placement block below runs the whole derive → store → export
+ * path rather than writing a row by hand: the bug it pins was in the derive
+ * step, and a test that inserted the row itself would decide the very thing
+ * under test.
+ *
  * Spec: specs/ai-gateway/governance/siem-export.feature
  */
 import type { ClickHouseClient } from "@clickhouse/client";
 import { nanoid } from "nanoid";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-
+import type { TraceSummaryData } from "~/server/app-layer/traces/types";
 import { prisma } from "~/server/db";
 import { getTestClickHouseClient } from "~/server/event-sourcing/__tests__/integration/testContainers";
+import type { TriggerContext } from "~/server/event-sourcing/pipeline/processManagerDefinition";
+import type { TraceProcessingEvent } from "~/server/event-sourcing/pipelines/trace-processing/schemas/events";
 import { cleanupTestRows } from "~/test-utils/cleanupTestRows";
-
+import { createGovernanceOcsfEventsSyncHandler } from "../../subscribers/governanceOcsfEventsSync.subscriber";
 import {
   GovernanceOcsfEventsClickHouseRepository,
   OCSF_ACTIVITY,
@@ -241,5 +248,71 @@ describe("OCSF schema-version forward-compat", () => {
       expect(rows).toHaveLength(1);
       expect(rows[0]?.OcsfSchemaVersion).toBe("1.1.0");
     });
+  });
+});
+
+describe("actor placement on the derive → export path", () => {
+  /**
+   * A governance trace fold, carrying only the attributes the OCSF
+   * subscriber reads. Cast rather than fully built: the fold state has
+   * ~30 fields and none of the others reach this path.
+   */
+  function govFoldState({
+    traceId,
+    attributes,
+  }: {
+    traceId: string;
+    attributes: Record<string, string>;
+  }): TraceSummaryData {
+    return {
+      traceId,
+      models: [],
+      occurredAt: Date.now() - 100,
+      attributes: {
+        "langwatch.origin.kind": "ingestion_source",
+        "langwatch.ingestion_source.id": `src-${ns}`,
+        "langwatch.ingestion_source.source_type": "otel_generic",
+        ...attributes,
+      },
+    } as unknown as TraceSummaryData;
+  }
+
+  /** @scenario "An actor the trace names by an opaque id is exported as a user id, never as an email" */
+  it("exports an opaque email attribute as the actor's user id, with an empty email", async () => {
+    const repo = new GovernanceOcsfEventsClickHouseRepository(async () => ch);
+    const subscriber = createGovernanceOcsfEventsSyncHandler({
+      governanceOcsfEventsRepository: repo,
+    });
+    const traceId = `trace-${ns}-opaque`;
+    // Named `user.email`, but not an address — and no user id attribute
+    // beside it to hold the identifier instead.
+    const context = {
+      tenantId: govProjectId,
+      aggregateId: traceId,
+      state: govFoldState({
+        traceId,
+        attributes: { "user.email": "user-A1b2C3d4E5" },
+      }),
+    } as TriggerContext<TraceSummaryData>;
+
+    await subscriber({} as unknown as TraceProcessingEvent, context);
+    await new Promise((resolve) => setTimeout(resolve, 500));
+
+    const service = GovernanceOcsfExportService.create({
+      prisma,
+      ocsfRepository: repo,
+    });
+    const page = await service.list({
+      organizationId,
+      sinceMs: 0,
+      limit: 50,
+    });
+
+    const exported = page.events.find((e) => e.eventId === traceId);
+    // The row must exist: an absent row would satisfy an "email is empty"
+    // assertion on its own, so the guard is checked before it is trusted.
+    expect(exported).toBeDefined();
+    expect(exported?.actorUserId).toBe("user-A1b2C3d4E5");
+    expect(exported?.actorEmail).toBe("");
   });
 });

--- a/platform/app/ee/governance/services/pullers/__tests__/anthropicAdminPuller.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/anthropicAdminPuller.unit.test.ts
@@ -1208,6 +1208,72 @@ describe("the Anthropic Admin puller", () => {
       }
     });
 
+    /** @scenario "A refused Anthropic collision names the fields the two rows differed in" */
+    it("names the field outside the key that the two rows differed in", async () => {
+      // Same day, workspace, description and model — so the same key — and a
+      // different amount, so the guard already refuses. What the operator
+      // could not see was WHY the provider split the row: the tier sat on
+      // the stored row all along, and the message never named it.
+      fetchMock.mockResolvedValue(
+        jsonResponse(
+          pageWith([
+            { ...COST_ROW, service_tier: "standard" },
+            {
+              ...COST_ROW,
+              service_tier: "priority",
+              amount: "10000.000000",
+            },
+          ]),
+        ),
+      );
+
+      let error: unknown;
+      let run: unknown;
+      try {
+        run = await new AnthropicAdminPuller().runOnce(RUN_OPTIONS, config);
+      } catch (thrown) {
+        error = thrown;
+      }
+
+      // Refused, and nothing from the page recorded: the run never returns a
+      // result, so no event reaches the sink.
+      expect(error).toBeInstanceOf(Error);
+      expect(run).toBeUndefined();
+
+      const message = (error as Error).message;
+      // The lead: the provider's own name for the coordinate it split on.
+      expect(message).toContain("service_tier");
+      // The key it already named is still there — this adds to the message,
+      // it does not replace it.
+      expect(message).toContain("1 restatement key");
+      expect(message).toContain("workspaceId");
+      expect(message).toContain("costType");
+      // Names only. The tier VALUES are provider billing coordinates and this
+      // string reaches logs and the source's error state.
+      for (const value of ["standard", "priority", "ws_1", "Claude usage"]) {
+        expect(message).not.toContain(value);
+      }
+    });
+
+    it("leaves the key alone when a row carries the differing field", async () => {
+      // The refusal names the field; it must not be answered by widening the
+      // key. A key that carried the tier would re-key every cost cell already
+      // stored, so a later correction would land beside the figure it
+      // corrects instead of replacing it.
+      async function keyForTier(tier: string): Promise<string> {
+        fetchMock.mockResolvedValue(
+          jsonResponse(pageWith([{ ...COST_ROW, service_tier: tier }])),
+        );
+        const run = await new AnthropicAdminPuller().runOnce(
+          RUN_OPTIONS,
+          config,
+        );
+        return run.events[0]!.source_event_id;
+      }
+
+      expect(await keyForTier("standard")).toBe(await keyForTier("priority"));
+    });
+
     it("accepts a row the provider repeated with the same amount", async () => {
       fetchMock.mockResolvedValue(jsonResponse(pageWith([COST_ROW, COST_ROW])));
 

--- a/platform/app/ee/governance/services/pullers/anthropicAdmin.puller.ts
+++ b/platform/app/ee/governance/services/pullers/anthropicAdmin.puller.ts
@@ -387,6 +387,15 @@ const costResultSchema = z
     cost_type: z.string().nullable().default(null),
     model: z.string().nullable().default(null),
   })
+  // Coordinates the cost key does NOT carry (context_window, service_tier,
+  // token_type, inference_geo, and whatever the provider adds next) ride
+  // through here under the provider's own names into `raw_payload`. They are
+  // deliberately NOT declared: a declaration narrows the accepted contract,
+  // so one unexpected value type would throw out of `bucketEvents` and wedge
+  // the whole run, and a `.default(null)` would write keys into `raw_payload`
+  // that the provider never sent. `assertRowsAreDistinguishable` names them
+  // from the stored payload when two rows collide, which is all they are for.
+  // They never widen the key, which is the restatement identity.
   .passthrough();
 
 /**
@@ -442,25 +451,6 @@ const pageSchema = z.object({
 });
 
 /**
- * The newest bucket start in one page.
- *
- * NOT the last element of the array. Anthropic does not promise an order
- * within a page, and reading the last bucket as the newest is only correct
- * while the page happens to ascend. On an out-of-order page it hands back an
- * earlier instant than one already emitted, so the watermark it mints re-reads
- * the window. Under an unchanged query that re-read restates rather than
- * duplicating — the ids carry the bucket and its dimensions — and the cost is
- * a window that stops advancing; it becomes duplicated spend on the usage
- * report only once a query change moves the keys (see `cursorSchema`). The
- * maximum is the only value every bucket on the page is at or behind, which is
- * exactly what a watermark has to mean.
- *
- * Instants that do not parse are ignored rather than compared as strings: a
- * value we cannot order cannot be certified as a resume point. A page where
- * none parse yields null, and null resumes from the window start — a re-read,
- * never a skip.
- */
-/**
  * The later of two instants, ignoring one that cannot be parsed.
  *
  * `newestBucketStart` orders a page against itself. Anthropic promises no
@@ -479,6 +469,25 @@ function laterInstant(a: string | null, b: string | null): string | null {
   return bMs > aMs ? b : a;
 }
 
+/**
+ * The newest bucket start in one page.
+ *
+ * NOT the last element of the array. Anthropic does not promise an order
+ * within a page, and reading the last bucket as the newest is only correct
+ * while the page happens to ascend. On an out-of-order page it hands back an
+ * earlier instant than one already emitted, so the watermark it mints re-reads
+ * the window. Under an unchanged query that re-read restates rather than
+ * duplicating — the ids carry the bucket and its dimensions — and the cost is
+ * a window that stops advancing; it becomes duplicated spend on the usage
+ * report only once a query change moves the keys (see `cursorSchema`). The
+ * maximum is the only value every bucket on the page is at or behind, which is
+ * exactly what a watermark has to mean.
+ *
+ * Instants that do not parse are ignored rather than compared as strings: a
+ * value we cannot order cannot be certified as a resume point. A page where
+ * none parse yields null, and null resumes from the window start — a re-read,
+ * never a skip.
+ */
 function newestBucketStart(
   buckets: z.infer<typeof bucketSchema>[],
 ): string | null {
@@ -579,9 +588,12 @@ function amountSignature(event: NormalizedPullEvent): string {
  * A plain `Error`, not a `HandledError`: there is no named cause a caller can
  * act on, only a provider contract we did not anticipate.
  *
- * The message carries the count and the dimension NAMES. Never the values —
- * workspace ids and free-text descriptions are customer billing coordinates,
- * and this string travels into logs and the source's error state.
+ * The message carries the count, the dimension NAMES, and the names of the
+ * fields the colliding rows actually disagree on. Never the values — workspace
+ * ids and free-text descriptions are customer billing coordinates, and this
+ * string travels into logs and the source's error state. Naming the fields is
+ * what turns "something outside the key" into a lead: the operator reads which
+ * coordinate the provider split the row by without seeing whose spend it was.
  */
 function assertRowsAreDistinguishable({
   events,
@@ -590,22 +602,102 @@ function assertRowsAreDistinguishable({
   events: NormalizedPullEvent[];
   report: AnthropicAdminPullConfig["report"];
 }): void {
+  const colliding = collidingRowsByKey(events);
+  if (colliding.size === 0) return;
+  const dimensionNames = Object.keys(emittedHint(events[0]!)?.dimensions ?? {});
+  // Per key, never across keys: rows under two different keys differ in the
+  // dimensions BY DESIGN, and naming those would report the key as its own
+  // explanation.
+  const differingNames = new Set<string>();
+  for (const rows of colliding.values()) {
+    for (const name of differingFieldNames(rows)) differingNames.add(name);
+  }
+  const differingClause =
+    differingNames.size === 0
+      ? ""
+      : `; the colliding rows differ in ${[...differingNames].sort().join(", ")}`;
+  throw new Error(
+    `anthropic ${report}_report returned one page holding ${colliding.size} restatement key(s) shared by rows reporting different amounts; the key is built from ${dimensionNames.join(", ")}, so the provider is distinguishing these rows by something outside it and recording the page would drop spend${differingClause}`,
+  );
+}
+
+/**
+ * The rows behind each key that two or more of them report different amounts
+ * under. Keys whose rows agree are not here: a provider repeating a row costs
+ * nothing, whichever copy survives the upsert.
+ */
+function collidingRowsByKey(
+  events: NormalizedPullEvent[],
+): Map<string, NormalizedPullEvent[]> {
+  const rowsByKey = new Map<string, NormalizedPullEvent[]>();
   const amountByKey = new Map<string, string>();
   const collidingKeys = new Set<string>();
   for (const event of events) {
+    const key = event.source_event_id;
+    const group = rowsByKey.get(key);
+    if (group) group.push(event);
+    else rowsByKey.set(key, [event]);
     const amount = amountSignature(event);
-    const seen = amountByKey.get(event.source_event_id);
-    if (seen === undefined) {
-      amountByKey.set(event.source_event_id, amount);
-      continue;
-    }
-    if (seen !== amount) collidingKeys.add(event.source_event_id);
+    const seen = amountByKey.get(key);
+    if (seen === undefined) amountByKey.set(key, amount);
+    else if (seen !== amount) collidingKeys.add(key);
   }
-  if (collidingKeys.size === 0) return;
-  const dimensionNames = Object.keys(emittedHint(events[0]!)?.dimensions ?? {});
-  throw new Error(
-    `anthropic ${report}_report returned one page holding ${collidingKeys.size} restatement key(s) shared by rows reporting different amounts; the key is built from ${dimensionNames.join(", ")}, so the provider is distinguishing these rows by something outside it and recording the page would drop spend`,
+  return new Map(
+    [...collidingKeys].map((key) => [key, rowsByKey.get(key) ?? []]),
   );
+}
+
+/**
+ * The provider field NAMES on which rows sharing one key disagree.
+ *
+ * Read off `raw_payload`, which is the parsed provider row — the only place
+ * the coordinates outside the key survive, since the dimensions are exactly
+ * what the key already carries. `amount` will normally be among them: that is
+ * the premise of the refusal rather than noise, and listing it costs a word
+ * where suppressing it would need a hardcoded list of money fields to drift.
+ *
+ * A payload that does not parse into an object is skipped rather than guessed
+ * at — an unnameable field is better than a wrong name, and the refusal
+ * already stands on the key alone.
+ */
+function differingFieldNames(events: NormalizedPullEvent[]): string[] {
+  const rows = events
+    .map(parsedRawPayload)
+    .filter((row): row is Record<string, unknown> => row !== null);
+  const first = rows[0];
+  if (first === undefined) return [];
+  const names = new Set<string>();
+  for (const row of rows.slice(1)) {
+    for (const name of new Set([...Object.keys(first), ...Object.keys(row)])) {
+      // Compared by serialized content rather than by identity, so a nested
+      // object (the usage report's `cache_creation`) counts as equal when it
+      // holds the same keys in the same order. Key order is not normalized:
+      // a reordered-but-equal object would be named as differing, which only
+      // adds a word to a message the amount mismatch already justified.
+      // `undefined` and an explicit null are the same absence here.
+      if (
+        JSON.stringify(first[name] ?? null) !==
+        JSON.stringify(row[name] ?? null)
+      ) {
+        names.add(name);
+      }
+    }
+  }
+  return [...names];
+}
+
+/** The parsed provider row an event carries, or null if it is not an object. */
+function parsedRawPayload(
+  event: NormalizedPullEvent,
+): Record<string, unknown> | null {
+  try {
+    const value: unknown = JSON.parse(event.raw_payload);
+    return typeof value === "object" && value !== null && !Array.isArray(value)
+      ? (value as Record<string, unknown>)
+      : null;
+  } catch {
+    return null;
+  }
 }
 
 /**

--- a/platform/app/ee/governance/subscribers/__tests__/governanceOcsfEventsSync.subscriber.unit.test.ts
+++ b/platform/app/ee/governance/subscribers/__tests__/governanceOcsfEventsSync.subscriber.unit.test.ts
@@ -230,6 +230,54 @@ describe("governanceOcsfEventsSync subscriber", () => {
       expect(row.eventTime.getTime()).toBe(FIXED_OCCURRED_AT_MS);
     });
 
+    /** @scenario "An actor the trace names by an opaque id is exported as a user id, never as an email" */
+    it("records an email attribute that is not an address as the actor's user id", async () => {
+      const { deps, insertEvent } = mockDeps();
+      const subscriber = createGovernanceOcsfEventsSyncHandler(deps);
+      // The attribute is NAMED user.email; nothing upstream checks that what
+      // sits in it is an address, and a SIEM reads the column it lands in as
+      // one. With no user id attribute to hold it, the identifier belongs in
+      // the user id column and the email column stays empty.
+      const state = createFoldState({
+        "langwatch.origin.kind": "ingestion_source",
+        "langwatch.ingestion_source.id": "is-1",
+        "langwatch.ingestion_source.source_type": "otel_generic",
+        "user.email": "user-A1b2C3d4E5",
+        "tool.name": "search_logs",
+      });
+
+      await subscriber(event, ctx(state));
+
+      const [row] = insertEvent.mock.calls[0]!;
+      expect(row.actorUserId).toBe("user-A1b2C3d4E5");
+      expect(row.actorEmail).toBe("");
+      const ocsf = JSON.parse(row.rawOcsfJson);
+      expect(ocsf.actor.user.uid).toBe("user-A1b2C3d4E5");
+      expect(ocsf.actor.user.email_addr).toBe("");
+    });
+
+    /** @scenario "An opaque email attribute beside a user id attribute is dropped, not exported as an email" */
+    it("drops an email attribute that is not an address when a user id is present", async () => {
+      const { deps, insertEvent } = mockDeps();
+      const subscriber = createGovernanceOcsfEventsSyncHandler(deps);
+      // The user id column is already taken by the attribute that means it,
+      // so the non-address string has nowhere honest to go. Leaving it in the
+      // email column would be the bug this fixes, wearing a different hat.
+      const state = createFoldState({
+        "langwatch.origin.kind": "ingestion_source",
+        "langwatch.ingestion_source.id": "is-1",
+        "langwatch.ingestion_source.source_type": "otel_generic",
+        "langwatch.user_id": "user-42",
+        "user.email": "not-an-address",
+      });
+
+      await subscriber(event, ctx(state));
+
+      const [row] = insertEvent.mock.calls[0]!;
+      expect(row.actorUserId).toBe("user-42");
+      expect(row.actorEmail).toBe("");
+    });
+
     it("emits valid OCSF JSON in rawOcsfJson", async () => {
       const { deps, insertEvent } = mockDeps();
       const subscriber = createGovernanceOcsfEventsSyncHandler(deps);

--- a/platform/app/ee/governance/subscribers/governanceOcsfEventsSync.subscriber.ts
+++ b/platform/app/ee/governance/subscribers/governanceOcsfEventsSync.subscriber.ts
@@ -15,6 +15,7 @@ import {
   GOVERNANCE_ATTR,
   isGovernanceOriginTrace,
 } from "../services/governanceAttributeKeys";
+import { ocsfActorFields } from "../services/pullers/ocsfPullEventMapping";
 
 const logger = createLogger(
   "langwatch:trace-processing:governance-ocsf-events-sync",
@@ -74,8 +75,25 @@ function buildOcsfEventRow({
 }): GovernanceOcsfEventInput {
   const sourceType =
     foldState.attributes[ATTR_INGESTION_SOURCE_TYPE] ?? "unknown";
-  const actorUserId = foldState.attributes[ATTR_USER_ID] ?? "";
-  const actorEmail = foldState.attributes[ATTR_USER_EMAIL] ?? "";
+  // The email attribute is placed by what it IS, not by what it is named.
+  // Nothing upstream constrains `user.email` to an address — an SDK writes
+  // whatever it has for a person — and the SIEM export ships `ActorEmail` to a
+  // customer's own tooling, which reads it as an address. So a value that
+  // fails the address test goes to the user id column instead, the field OCSF
+  // reserves for the provider's own identifier, and only when the user id
+  // attribute is not already there to claim it. Anything else would be a
+  // second identifier overwriting the one the trace actually named.
+  //
+  // The address test is `ocsfActorFields`, the same placement the pulled
+  // sources use, so the two paths cannot drift into disagreeing about which
+  // column a string belongs in. A trace carrying both a user id and a real
+  // address keeps both, exactly as before.
+  const placedEmail = ocsfActorFields(
+    foldState.attributes[ATTR_USER_EMAIL] ?? "",
+  );
+  const actorUserId =
+    (foldState.attributes[ATTR_USER_ID] ?? "") || placedEmail.actorUserId;
+  const actorEmail = placedEmail.actorEmail;
   const actorEnduserId = foldState.attributes[ATTR_ENDUSER_ID] ?? "";
   const actionName = foldState.attributes[ATTR_TOOL_NAME] ?? "trace.recorded";
   const targetName =

--- a/platform/app/scripts/check-feature-parity.ts
+++ b/platform/app/scripts/check-feature-parity.ts
@@ -314,7 +314,6 @@ const LEGACY_INERT: string[] = [
   "specs/ai-gateway/governance/routing-policy-scope-cascade.feature",
   "specs/ai-gateway/governance/self-hosted-setup.feature",
   "specs/ai-gateway/governance/sessions-and-devices.feature",
-  "specs/ai-gateway/governance/siem-export.feature",
   "specs/ai-gateway/governance/template-cross-bind-guard.feature",
   "specs/ai-gateway/governance/template-ottl-authoring.feature",
   "specs/ai-gateway/governance/template-ottl-principal-guard.feature",
@@ -683,6 +682,11 @@ const LEGACY_PARTIAL: string[] = [
   "specs/ai-gateway/governance/ingestion-sources.feature",
   "specs/ai-gateway/governance/ingestion-templates-catalog.feature",
   "specs/ai-gateway/governance/my-usage-dashboard.feature",
+  // Reason: #8041 tagged and bound two scenarios (opaque id placement on
+  // export, and the drop of an opaque email beside a user id) and retired
+  // its LEGACY_INERT entry. The eleven untagged scenarios describe the wider
+  // SIEM export surface and were not audited by that issue.
+  "specs/ai-gateway/governance/siem-export.feature",
   "specs/ai-gateway/governance/ui-contract.feature",
   "specs/ai-gateway/model-provider-scoping.feature",
   "specs/ai-gateway/openai-param-compat.feature",

--- a/platform/app/src/pages/governance/__tests__/platformPlaceholders.integration.test.tsx
+++ b/platform/app/src/pages/governance/__tests__/platformPlaceholders.integration.test.tsx
@@ -365,6 +365,21 @@ describe("given the Signals & Alerts screen", () => {
       screen.getByRole("link", { name: "model providers" }),
     ).toHaveAttribute("href", "/settings/model-providers");
   });
+
+  /** @scenario "The Signals header actions are offered disabled until they do something" */
+  it("offers both header actions disabled, and pressing them changes nothing", () => {
+    renderPage(SignalsPage);
+
+    const newAlert = screen.getByRole("button", { name: "New alert" });
+    const newSignal = screen.getByRole("button", { name: "New signal" });
+    expect(newAlert).toBeDisabled();
+    expect(newSignal).toBeDisabled();
+
+    const before = document.body.innerHTML;
+    fireEvent.click(newAlert);
+    fireEvent.click(newSignal);
+    expect(document.body.innerHTML).toBe(before);
+  });
 });
 
 describe("given the Analytics screen", () => {
@@ -407,8 +422,11 @@ describe("given a Platform screen a member can press things on", () => {
    * a render can only prove that the controls a test happened to name do
    * something, and the ones nobody named are exactly the ones that rot.
    *
-   * Signals is not scanned. Its two header actions are inert and are owned
-   * by the page-header restyle, not by this file.
+   * A disabled control is not inert: it is offered as not-yet-built and says
+   * so, which is the one honest way to draw a shape that has no backing. So
+   * the scan holds every ENABLED control to a handler. Signals used to be
+   * excluded from the scan entirely while its header was restyled, and its
+   * two actions stayed live and dead behind that exclusion.
    */
   const buttonTagsIn = (file: string) => {
     // Resolved from the package root (vitest's cwd), because under the
@@ -424,17 +442,40 @@ describe("given a Platform screen a member can press things on", () => {
     // match to the first ">" stops inside the very attribute being looked
     // for. Each element start is taken with the text that follows it, up to
     // the next element start, and `onClick=` is required somewhere in there.
-    const starts = [...source.matchAll(/<(?:Button|chakra\.button)\b/g)];
+    const starts = [
+      ...source.matchAll(
+        /<(?:Button|chakra\.button|PageLayout\.HeaderButton)\b/g,
+      ),
+    ];
     return starts.map((start, index) =>
       source.slice(start.index, starts[index + 1]?.index ?? source.length),
     );
   };
 
+  /**
+   * Read from the opening tag only — `[^>]*` stops at the first ">" — rather
+   * than from the whole window above, so a `disabled` belonging to some later
+   * element cannot excuse this one. An arrow handler's own ">" cuts the read
+   * short, which can only miss a `disabled`, never invent one: a control that
+   * carries both is held to its handler instead, and passes on that.
+   *
+   * Only the `disabled` PROP counts, so it must sit at a prop boundary
+   * (whitespace before it) and must not be spelled `disabled={false}`.
+   * `aria-disabled` and `data-disabled` announce a state without preventing
+   * a click, and a `false` value disables nothing; a control wearing either
+   * with no handler is still a dead control.
+   */
+  const isDisabled = (tag: string) =>
+    /^<[A-Za-z.]+\b[^>]*\sdisabled(?=[\s/>=])(?!\s*=\s*\{\s*false\s*\})/.test(
+      tag,
+    );
+
   /** @scenario "Every control the Platform screens offer does something when pressed" */
-  it("offers no control without a handler on Insights or Analytics", () => {
+  it("offers no enabled control without a handler on any Platform screen", () => {
     for (const page of [
       "src/pages/governance/insights.tsx",
       "src/pages/governance/analytics.tsx",
+      "src/pages/governance/signals.tsx",
       // The rail is where the Insights folder controls actually live, and it
       // is a component rather than the page file, so scanning the two pages
       // alone left its five controls unread.
@@ -444,9 +485,43 @@ describe("given a Platform screen a member can press things on", () => {
       // The guard against a vacuous pass: a scan that matched nothing would
       // otherwise report every page clean, including a page of dead buttons.
       expect(tags.length).toBeGreaterThan(0);
-      for (const tag of tags) {
+      for (const tag of tags.filter((tag) => !isDisabled(tag))) {
         expect(tag).toMatch(/onClick=/);
       }
+    }
+  });
+
+  /** @scenario "The Signals header actions are offered disabled until they do something" */
+  it("skips only controls that actually say they are disabled", () => {
+    // The self-check on the exemption above. Without it the filter could
+    // quietly match everything — an exemption that excuses every control is
+    // the same as no scan at all — so Signals is named as the page whose
+    // controls are ALL exempt, and Analytics as one where none is.
+    const signals = buttonTagsIn("src/pages/governance/signals.tsx");
+    expect(signals.length).toBeGreaterThanOrEqual(2);
+    expect(signals.filter(isDisabled)).toHaveLength(signals.length);
+
+    const analytics = buttonTagsIn("src/pages/governance/analytics.tsx");
+    expect(analytics.length).toBeGreaterThan(0);
+    expect(analytics.filter(isDisabled)).toHaveLength(0);
+
+    // Spellings that LOOK disabled and are not: none of them may excuse a
+    // control, or the exemption grows a hole the scan cannot see.
+    for (const tag of [
+      "<PageLayout.HeaderButton aria-disabled={true}>x",
+      "<PageLayout.HeaderButton data-disabled>x",
+      "<PageLayout.HeaderButton disabled={false}>x",
+      "<PageLayout.HeaderButton onClick={() => {}}>x",
+    ]) {
+      expect(isDisabled(tag)).toBe(false);
+    }
+    for (const tag of [
+      "<PageLayout.HeaderButton disabled>x",
+      "<PageLayout.HeaderButton disabled={true}>x",
+      "<PageLayout.HeaderButton disabled={isBusy}>",
+      "<Button size='sm' disabled/>",
+    ]) {
+      expect(isDisabled(tag)).toBe(true);
     }
   });
 

--- a/platform/app/src/pages/governance/__tests__/userDetailHonesty.integration.test.tsx
+++ b/platform/app/src/pages/governance/__tests__/userDetailHonesty.integration.test.tsx
@@ -1,0 +1,116 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The user detail page, mounted through its real page and guards. What is
+ * under test is what the page CLAIMS about the breakdowns it does not have:
+ * it says they are not available, rather than describing them as work
+ * already scheduled. Same rule, and the same shape of test, as the team
+ * detail page beside it.
+ *
+ * Spec: specs/ai-governance/dashboard/user-detail-page.feature
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const ACTOR = "ada@acme.test";
+
+const harness = vi.hoisted(() => ({
+  rows: [] as unknown[],
+}));
+
+vi.mock("~/utils/compat/next-router", () => ({
+  useRouter: () => ({ query: { id: "ada@acme.test" } }),
+}));
+vi.mock("~/hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({
+    isLoading: false,
+    organization: { id: "org-1", slug: "acme", name: "ACME", teams: [] },
+    organizations: [],
+    project: undefined,
+    hasPermission: () => true,
+    hasOrgPermission: () => true,
+    hasAnyPermission: () => true,
+  }),
+}));
+vi.mock("~/hooks/useFeatureFlag", () => ({
+  useFeatureFlag: () => ({ enabled: true, isLoading: false }),
+}));
+vi.mock("~/hooks/useActivePlan", () => ({
+  useActivePlan: () => ({ isEnterprise: true, activePlan: undefined }),
+}));
+vi.mock("~/components/governance/GovernanceLayout", () => ({
+  default: ({ children }: { children: React.ReactNode }) => children,
+}));
+vi.mock("~/utils/api", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("~/utils/api")>()),
+  api: {
+    activityMonitor: {
+      spendByUser: {
+        useQuery: () => ({
+          data: harness.rows,
+          isLoading: false,
+          error: null,
+        }),
+      },
+    },
+    governance: {
+      resolveActorPersonalProject: {
+        useQuery: () => ({ data: undefined, isLoading: false, error: null }),
+      },
+    },
+  },
+}));
+
+import UserDetailPage from "../users/[id]";
+
+const renderPage = () =>
+  render(
+    <ChakraProvider value={defaultSystem}>
+      <UserDetailPage />
+    </ChakraProvider>,
+  );
+
+beforeEach(() => {
+  harness.rows = [
+    {
+      actor: ACTOR,
+      spendUsd: 4.25,
+      requests: 118,
+      lastActivityIso: new Date().toISOString(),
+      mostUsedTarget: "gpt-5-mini",
+    },
+  ];
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("given a person with spend in the window", () => {
+  /** @scenario "The person page names the breakdowns it does not have yet" */
+  it("says the deeper breakdowns are not available yet", () => {
+    renderPage();
+
+    expect(screen.getByRole("heading", { name: ACTOR })).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Per-day spend trend and per-model breakdown for this user are not available yet.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  /** @scenario "The person page names the breakdowns it does not have yet" */
+  it("never describes them as arriving in a follow-up", () => {
+    renderPage();
+
+    const shown = document.body.textContent ?? "";
+    // The guard: prove the page rendered before asserting these absences.
+    expect(shown).toContain(ACTOR);
+    // Our release plan is not something a reader can act on.
+    for (const plan of [/follow-up/i, /will land here/i]) {
+      expect(shown).not.toMatch(plan);
+    }
+  });
+});

--- a/platform/app/src/pages/governance/signals.tsx
+++ b/platform/app/src/pages/governance/signals.tsx
@@ -13,8 +13,9 @@ import { withPermissionGuard } from "~/components/WithPermissionGuard";
  * A placeholder for the signals that will fire and the alerts that will
  * answer them. Nothing here can create a rule yet, so the page carries the
  * Preview badge and the copy stays in the future tense throughout. The two
- * header buttons still do nothing when pressed; they are owned by the
- * page-header restyle and are not this page's copy to remove.
+ * header buttons are shown disabled for the same reason: they draw the
+ * header's shape and name what is coming, and disabled is the one honest
+ * way to offer a control with nothing behind it.
  *
  * Spec: specs/governance/governance-platform-placeholders.feature
  */
@@ -37,9 +38,11 @@ function SignalsPage() {
             </Text>
           </VStack>
           <HStack gap={2} flexShrink={0}>
-            {/* Neither of these buttons has a handler. As the file comment
-                above says, they draw the shape of the screen and do nothing
-                when pressed, so this page creates no rules at all yet.
+            {/* Neither of these buttons has a handler, so both are
+                disabled: enabled and inert reads as broken, disabled reads
+                as not yet built, and the second one is the truth. They stay
+                on the page so the header keeps its shape and the reader can
+                see what is coming.
                 They are weighted anyway, by the page-header rule: one
                 outlined, the rest ghost. New signal takes the outline
                 because the screen is named for signals and that is the
@@ -53,11 +56,11 @@ function SignalsPage() {
                 than contradicted by them: they are placeholders. If you do
                 not find such a sentence, it has not landed yet or has been
                 reworded, which changes nothing here. */}
-            <Button size="sm" variant="ghost">
+            <Button size="sm" variant="ghost" disabled>
               <BellPlus size={14} />
               New alert
             </Button>
-            <PageLayout.HeaderButton>
+            <PageLayout.HeaderButton disabled>
               <Plus size={14} />
               New signal
             </PageLayout.HeaderButton>

--- a/platform/app/src/pages/governance/users/[id].tsx
+++ b/platform/app/src/pages/governance/users/[id].tsx
@@ -135,8 +135,8 @@ function GovernanceUserDetailPage() {
                 Detail metrics
               </Text>
               <Text fontSize="xs" color="fg.muted" marginBottom={3}>
-                Per-day spend trend and per-model breakdown for this user will
-                land here in a follow-up.
+                Per-day spend trend and per-model breakdown for this user are
+                not available yet.
               </Text>
               {personalProject && (
                 <>

--- a/specs/ai-gateway/governance/ingestion-sources.feature
+++ b/specs/ai-gateway/governance/ingestion-sources.feature
@@ -47,6 +47,19 @@ Feature: IngestionSource — admin configuration of cross-platform feeds
     And a viewer without ingestionSources:manage sees no row actions at all
 
   @integration
+  Scenario: Archiving from the row asks the same question the detail page asks
+    Given a source in the table
+    When the admin picks Archive from its row actions
+    Then they are asked to confirm, and the question names the source and
+      says historical events stay readable
+    And declining leaves the source as it was
+    And confirming archives it
+    # The detail page has asked this since it was built. The table's menu
+    # item archived on the first click, so the same action cost one click
+    # on one screen and two on the other, and the cheaper one was the one
+    # with no way back.
+
+  @integration
   Scenario: Add source menu lists every type by vendor, grouped in plain language
     When the admin clicks "Add source"
     Then a menu opens listing every supported source type with its vendor logo
@@ -78,10 +91,11 @@ Feature: IngestionSource — admin configuration of cross-platform feeds
       a fetch it cannot perform
     # Not locked, offered-but-locked is a sales message about what an
     # Enterprise plan unlocks, and a source that cannot deliver data is not
-    # something to sell. The two Enterprise Compliance types, for OpenAI and
-    # for Anthropic Claude, are hidden this way: an admin who picked either
-    # got a source that stayed silent, and the Claude one collects a
-    # workspace key that never reaches the adapter that would use it.
+    # something to sell. The OpenAI Enterprise Compliance type is hidden this
+    # way: an admin who picked it got a source that stayed silent. The Claude
+    # one was hidden for the same reason and is no longer in this case — its
+    # workspace key reaches the adapter now — so it stays out of the picker
+    # on a different footing, described below.
 
   @unit
   Scenario: Sources already configured on an unread type still display
@@ -481,6 +495,27 @@ Feature: IngestionSource — admin configuration of cross-platform feeds
       | openai_compliance  | display name, S3 bucket / prefix, AWS role ARN, polling cadence              |
       | claude_compliance  | display name, workspace API key, polling cadence                              |
       | s3_custom          | display name, bucket / prefix, role ARN, parser DSL                           |
+
+  @unit
+  Scenario: The Claude compliance workspace key reaches its adapter as the token it reads
+    Given the admin enters a workspace API key on a Claude compliance source
+    When the source's pull config is assembled for saving
+    Then the key is stored under the encrypted credentials as the token
+    And the adapter's frozen request header resolves to that key
+    # The form collected the key under a name nothing routed into the
+    # credentials, so it was dropped on the way through and every run sent
+    # the unresolved template as its header. Every other secret-collecting
+    # source type already names its key so the form knows where it goes.
+
+  @unit
+  Scenario: Every source type that collects a secret can put it back where its adapter reads it
+    Given the source types that collect a secret in their setup form
+    Then each of them has a way to reassemble that secret into its pull config
+    And none is left out of that check by being hidden from the picker
+    # Hiding a type from the picker was how a missing builder was worked
+    # around. The check now covers hidden types too, so a builder cannot go
+    # missing behind that door again. Whether the type comes back to the
+    # picker is a separate call and is not made here: it stays hidden.
 
   Scenario: Generic OTel passthrough is the simplest setup
     Given the admin picks "Generic OTel" as the source type

--- a/specs/ai-gateway/governance/siem-export.feature
+++ b/specs/ai-gateway/governance/siem-export.feature
@@ -64,6 +64,46 @@ Feature: SIEM export — OCSF read projection over the unified governance store
     And the caller cannot read events outside their org (tenancy invariant)
     And the underlying CH partition pruning makes large time-window exports cheap
 
+  @integration
+  Scenario: An actor the trace names by an opaque id is exported as a user id, never as an email
+    Given a trace whose email attribute carries an opaque identifier that is
+      not an address
+    And the trace carries no user id attribute
+    When its governance event is derived and later exported
+    Then the exported row carries that identifier as the actor's user id
+    And the actor's email field is empty
+    # The trace attribute is named "user.email" but nothing checks that what
+    # sits in it is an address. The pulled-source path already places the
+    # string by what it is; the trace path copied the attribute straight into
+    # the email column. A SIEM reads that column as an address, so an
+    # identifier there is a claim the row cannot back. Only the email
+    # attribute is placed by what it is. A trace that carries both a user
+    # id and an address keeps both, as it does today.
+
+  @unit
+  Scenario: An opaque email attribute beside a user id attribute is dropped, not exported as an email
+    Given a trace whose email attribute carries an opaque identifier that is
+      not an address
+    And the trace also carries a user id attribute that is not blank
+    When its governance event is derived
+    Then the actor's user id is the user id attribute
+    And the actor's email field is empty
+    And the opaque identifier is not written to either actor field
+    # The user id column is already taken by the attribute that means it.
+    # Keeping the opaque string in the email column would be the bug the
+    # scenario above fixes, wearing a different hat. Dropping it is a
+    # deliberate loss: the row no longer records that the trace named a
+    # second identifier. Stated here so a later change cannot reverse it
+    # by accident.
+    #
+    # "Not blank" is load-bearing: a user id attribute that is present but
+    # empty does not take the column, so the opaque string lands in the user
+    # id field instead, as the scenario above describes. And the email
+    # attribute reaches this derivation only as a resource attribute; the
+    # same key on a span is not carried into the trace's attributes at all,
+    # so this shape is not produced by the onboarding payloads the product
+    # hands out.
+
   Scenario: Cursor pagination returns deterministic ordering
     Given the org has many governance events
     When a caller paginates through api.governance.exportOcsf via next_cursor

--- a/specs/ai-governance/dashboard/user-detail-page.feature
+++ b/specs/ai-governance/dashboard/user-detail-page.feature
@@ -1,0 +1,23 @@
+@governance @dashboard @user-detail
+Feature: User detail — what one person's page shows today
+  The page a governance admin lands on after clicking a person in the
+  People tab. It shows that person's headline spend and activity from the
+  same rollup the tab reads. The deeper breakdowns are not built, so the
+  page says they are not available rather than describing them as work
+  already under way. Same rule as the team detail page.
+  Decision: none — copy honesty on an existing page.
+
+  Background:
+    Given an organization member with the governance view permission
+    And "release_ui_ai_governance_enabled" is enabled for the organization
+    And the member may read the activity monitor
+
+  @integration
+  Scenario: The person page names the breakdowns it does not have yet
+    When the member opens a person's detail page
+    Then the detail panel says "Per-day spend trend and per-model breakdown
+      for this user are not available yet."
+    And no copy says those breakdowns are arriving in a follow-up
+    # A reader cannot act on our release plan, and "in a follow-up" is our
+    # word for it, not theirs. What they can act on is knowing the number
+    # is not there.

--- a/specs/governance/governance-platform-placeholders.feature
+++ b/specs/governance/governance-platform-placeholders.feature
@@ -152,13 +152,23 @@ Feature: Platform placeholders — Insights, Analytics, Signals & Alerts
 
   @integration
   Scenario: Every control the Platform screens offer does something when pressed
-    When the member opens "/governance/analytics" or "/governance/insights"
-    Then pressing any control on the screen changes what the screen shows
-    And no control is offered that answers a press with nothing
+    When the member opens "/governance/analytics", "/governance/insights"
+      or "/governance/signals"
+    Then pressing any enabled control on the screen changes what the screen shows
+    And no enabled control is offered that answers a press with nothing
     # The Add filter chip on Analytics and the sample-inbox link on
-    # Insights were both offered and both did nothing. The Signals header
-    # actions are excluded here: they are owned by the page-header restyle,
-    # and are still inert.
+    # Insights were both offered and both did nothing. Signals was excluded
+    # from this scan while its header was being restyled, and its two
+    # actions stayed inert behind the exclusion. It is in the scan now.
+
+  @integration
+  Scenario: The Signals header actions are offered disabled until they do something
+    When the member opens "/governance/signals"
+    Then "New alert" and "New signal" are shown disabled
+    And pressing either changes nothing on the screen
+    # A control that looks live and does nothing reads as broken. Disabled,
+    # it reads as not yet built, which is the truth. The buttons stay on the
+    # page so the header keeps its shape and the reader sees what is coming.
 
   @integration
   Scenario: The Platform screens describe unbuilt work in the future tense

--- a/specs/governance/pulled-usage-cost-reporting.feature
+++ b/specs/governance/pulled-usage-cost-reporting.feature
@@ -57,6 +57,26 @@ Feature: Pulled provider usage becomes visible, attributed cost
     Then the reported cost reflects the corrected figure
     And the earlier figure is not added on top
 
+  @unit
+  Scenario: A refused Anthropic collision names the fields the two rows differed in
+    Given Anthropic's cost report answers with two rows for the same day,
+      workspace, model and description at different amounts
+    And the rows also differ in a field the key does not carry, such as
+      service tier, token type, context window or inference region
+    When the read runs
+    Then the page is refused and nothing from it is recorded
+    And the refusal names the key the rows share
+    And the refusal names the fields the two rows differed in
+    And the key the rows share is not changed to tell them apart
+    # The refusal already existed for two amounts under one key. It named
+    # the key and stopped there. The fields that would explain the
+    # collision were on the stored row all along; the guard never read
+    # them. Naming them turns a dead end into a lead. The guard is not widened: two rows
+    # alike in key and amount still merge, and a zero-amount repeat must
+    # not wedge the source over money that does not exist. The key is not
+    # widened either: it is what a re-read uses to replace an earlier
+    # figure in place, and changing it would record the same spend twice.
+
   # --- Money the provider reports as a credit ---
 
   @unit


### PR DESCRIPTION
## Why

Closes #8041.

PR #8023 shipped the governance identity and cost waves and left eleven small debt items behind: a misplaced doc comment, actor placement done by hand instead of through the shared helper, a collision refusal that did not say what collided, three doc pages describing features that never shipped, dead buttons that still looked live, an archive action that asked no question, and a secret stored under a name its adapter never read. This closes all eleven, plus the corrections the build surfaced in the issue text itself.

## What changed

**Anthropic Admin cost puller (items 1, 4)**
- The `newestBucketStart` JSDoc now sits on `newestBucketStart` (`anthropicAdmin.puller.ts`). No code change.
- The collision refusal now names the fields the colliding rows differ in (`context_window`, `service_tier`, `token_type`, `inference_geo`, or anything else the provider adds), read off each row's stored payload. The throw condition is unchanged (two rows under one key at different amounts). `source_event_id` is unchanged.
- The four fields are deliberately **not** declared on `costResultSchema`. The schema is `passthrough`, so they always reached the stored row; declaring them as strings would let one non-string value from the provider throw out of the whole run and wedge the source on every retry, and a `.default(null)` would write keys into `raw_payload` the provider never sent. A comment above the schema records this.

**OCSF export (items 3, 7)**
- The trace subscriber places the `user.email` attribute through `ocsfActorFields`, the same test the pulled sources use. A value that is not an address lands in the user id column when the trace names no user id. When the trace names a non-blank user id as well, the opaque value is dropped from both columns; the spec now states that loss so it cannot be reversed by accident.
- Rows already in ClickHouse keep their old placement. A SIEM reader of `ActorEmail` will see mixed data across the cutover; no backfill, as agreed.
- The seat-report test derives actor columns through `ocsfActorFields` instead of hand-placing them. Behaviourally a no-op today: the seat events carry an empty actor on purpose.

**Ingestion sources UI (items 10, 11)**
- Archiving from the table row now asks the same question the detail page asks. The wording lives in one place, `logic/confirmArchiveSource.ts`.
- The Claude Enterprise Compliance workspace key is collected as `credentialsToken`; the type has a pull-config builder that writes `credentials.token` and `adapter: "claude_compliance"`, and the coverage guard checks hidden types too. Neither UI path reaches this builder today: the type is `deprecated` in the catalog and absent from the editable list. The builder is there so the key lands in the right place the day the type is offered again (#7583). `copilot_studio` gets a `retired` flag, the one honest exemption from the guard, with self-checks. No data migration: the old field was always dropped as a secret, so nothing was stored under it.

**Governance placeholders (item 9)**
- Both Signals header buttons are disabled. The inert-control scan covers `/governance/signals`, matches `PageLayout.HeaderButton`, and exempts only a control whose own opening tag carries the real `disabled` prop (not `aria-disabled`, `data-disabled` or `disabled={false}`).
- The user detail page says which breakdowns are not available yet, instead of promising a follow-up. New spec `user-detail-page.feature` and honesty test.

**Docs and ADRs (items 5, 6, 8)**
- ADR-122 v5 records Decision 12 as overtaken: the compliance and Copilot types are hidden by the catalog's `deprecated` flag, no backfill. Citations recomputed against this branch.
- Anomaly rules and compliance pages now describe what ships: rules still cannot be created or edited in the app (the old tab is gone and the old route redirects to Inventory), alerts leave only by signed webhook, `anomalyAlertId` is never set. The OCSF export page says the column is returned and always empty.
- ADR-128 §12 gets a note on the department-sync decision order (v3.14). No behaviour change.

**Feature parity checker**
- `siem-export.feature` moves from the inert list to the partial list because it now binds two scenarios.

## Issue text corrections
- Item 2 (Azure continuation link off-host refusal) was already covered by nine host cases in `copilotStudioDataversePuller.unit.test.ts`. Nothing to add.
- Item 4 asked to "parse" the four fields. They were never parsed away, and declaring them turned out to be harmful (see above). The scenario was narrowed to naming them in the refusal.
- Item 6: `compliance.mdx` never mentioned `anomalyAlertId`. Its false claims were dispatch by chat and paging tools, geo and off-hours rule types, and anomaly rows in the OCSF export.

## Review
Three reviewers and one refuter ran on this branch. Everything P1 was fixed before opening:
- Declared cost fields could wedge a pull run → removed.
- Anomaly doc pointed readers at a rules screen that no longer renders → reverted to the "no page today" warning.
- A new scenario title collided with an existing one, so the parity checker cross-bound them → renamed.
- ADR-122 line citations were stale against this very branch → recomputed.
- The disabled exemption in the dead-control scan matched `aria-disabled` and `disabled={false}` → tightened, with self-checks.
- The secret-coverage scenario was tagged on a test that did not enforce it → tag moved.

Left as notes, not changed:
- `confirmArchiveSource` uses `window.confirm`; `ConfirmDialog` exists and is the nicer pattern. Kept the plain popup because it matches what the detail page already did and the scenario asks for parity.
- The `retired` catalog flag has no runtime consumer; only the coverage guard reads it.
- `parsedRawPayload` duplicates two existing small JSON-parse helpers.
- The differing-field list is unioned across colliding keys, so with two collisions the message does not say which key split on which field.
- The coverage guard filters on `mode === "pull"` and `secret === true`, while the drop rule also catches any `credentials*` key; no live divergence today.
- The header-substitution test proves the header with `String.replace` rather than by driving the adapter. The reviewer drove the real path and confirmed the outgoing header is correct.
- Pre-existing and untouched: `governanceAttributeKeys.ts` still says the anomaly attribute is set by a subscriber that does not exist.

### Review round on the PR

CodeRabbit raised five comments, all on the two doc pages. Four were real: the pages claimed more than the code does. Fixed in `ce078bcbcd`:

- private/link-local refusal for webhook destinations depends on `BLOCK_LOCAL_HTTP_CALLS` and `ALLOWED_PROXY_HOSTS`, so the page now says so instead of stating it flat
- the webhook is HMAC-signed only when a shared secret is set (`sharedSecret` is optional in the schema); both compliance statements now say "signed when a shared secret is set"
- an invalid destination configuration is quarantined and no request goes out; the severity row now says routing to every destination applies when the configuration validates
- webhook delivery is not human review; the Art. 12(2)(d) bullet now says the review is the receiver's process, not something LangWatch performs or records

One was declined with a reason on the thread: a request for a new dispatcher test (DNS changing between retries). The dispatcher is not touched here and #8041 scopes this PR to docs and the listed code items.

A second review pass checked those four fixes against the code (record in the PR comments). Two corrections in `8cd34bc4b9`: cloud metadata addresses are refused before the allow-list is consulted, so the page no longer says the allow-list wins "either way"; and the alert row already has review columns that no code writes, so the Art. 12(2)(d) note says LangWatch does not record review "today". `614e0bd695` splits one paragraph that exceeded the docs prose length rule. A third pass caught that "cannot be allow-listed" was itself too strong: the guard matches metadata hosts by literal name and trusts an allow-listed name without resolving it, proven with a throwaway test. `0a1461b58f` says so and tells self-hosters to allow-list only names they control. A second CodeRabbit round flagged that the compliance table called the anomaly webhook the Art. 33 breach notification; that label pre-dated this PR, but `3b21008824` relabels the row as detection and escalation and states that the notice to the authority and the breach record stay with the controller. A claim that rules can be created in the app was checked and refuted: the editor component exists but no reachable route mounts it.

## Out of scope, as agreed on the issue
Erasure logic, OCSF backfill, unregistering compliance adapters, the Q04 gate, the untagged anomaly scenarios, a cross-page collision guard, Azure end-to-end.

## Test plan
- Unit, component and integration lanes green on every changed test file; full governance unit and component suites green apart from five files that fail identically on the base commit (unbuilt SDK package in a fresh checkout).
- `check-feature-parity` passes: 12349 enforced scenarios bound.
- Biome: no new warnings on changed files. Docs prose check clean on changed pages.
- Pre-existing: the three mdx pages fail prettier at the base commit already and were not reformatted.

## Deployment Impact

No deployment impact beyond the application image itself. No env vars added or changed. No helm values added or changed. A vanilla `helm install` with no overrides behaves as before. No BYOC dataplane impact: no schema, migration, queue, or ClickHouse change. The one runtime behaviour change is in the trace-to-OCSF subscriber, which now places an opaque `user.email` attribute in the user id column of newly written export rows; rows already stored keep their old placement, and no backfill runs. The ADR and self-hosting doc edits describe existing behaviour and change nothing operators configure.

## Refusal overridden
/implement refused this on: spans more than 3 top-level directories (platform/, dev/, docs/, specs/)
Overridden by: the requester, with the reason "no major deciions to take i am assuming"
Carried over from the heavy path: /challenge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added confirmation before archiving ingestion sources, including a notice that historical events remain readable.
  - Claude compliance credentials can now be securely configured for supported workflows, while the source remains unavailable in the picker.
  - Opaque identity values are handled consistently in exported governance records.

- **Bug Fixes**
  - Conflicting cost-report rows are now rejected with clearer field details instead of being recorded ambiguously.

- **Documentation**
  - Clarified that anomaly alerts are delivered exclusively through signed webhooks and are not included in OCSF exports.
  - Updated governance documentation to reflect current feature availability and limitations.

- **UI**
  - Signals actions are visibly disabled until available.
  - User detail pages now state that unavailable breakdowns are not yet available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->