### PR TITLE
feat(voice): add the phone transport member behind a flag, with a stub runner (#8014 slice 1)

### DIFF
--- a/docs/agent-testing/voice-agents-in-app.mdx
+++ b/docs/agent-testing/voice-agents-in-app.mdx
@@ -29,6 +29,8 @@ A **Voice** agent type in **Agents** points at an ElevenLabs Conversational AI a
 
 A normal scenario run needs no manual call: the simulated caller speaks the scenario using the caller voice configured on it.
 
+Phone number targets are being added in the app. They sit behind the `release_voice_phone_targets_enabled` flag until the voice worker that dials them ships (see [issue #8014](https://github.com/langwatch/langwatch/issues/8014)).
+
 ## Turn it on
 
 In-app voice agents are in private beta. The feature sits behind the product flag `release_voice_agents_enabled`, off by default. To request access, reach out to support at support@langwatch.ai.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -35404,6 +35404,8 @@ A **Voice** agent type in **Agents** points at an ElevenLabs Conversational AI a
 
 A normal scenario run needs no manual call: the simulated caller speaks the scenario using the caller voice configured on it.
 
+Phone number targets are being added in the app. They sit behind the `release_voice_phone_targets_enabled` flag until the voice worker that dials them ships (see [issue #8014](https://github.com/langwatch/langwatch/issues/8014)).
+
 ## Turn it on
 
 In-app voice agents are in private beta. The feature sits behind the product flag `release_voice_agents_enabled`, off by default. To request access, reach out to support at support@langwatch.ai.

--- a/platform/app/src/components/agent-testing/run/voice-call-target.ts
+++ b/platform/app/src/components/agent-testing/run/voice-call-target.ts
@@ -55,6 +55,10 @@ export function voiceCallTargetOf({
   if (!agent) return null;
   const parsed = voiceAgentConfigSchema.safeParse(agent.config);
   if (!parsed.success) return null;
+  // The browser call reaches an ElevenLabs agent only; a phone target has no
+  // in-browser call, so no target is resolved for it (the drawer offers the
+  // scenario run instead).
+  if (parsed.data.transport !== "elevenlabs_convai") return null;
   // A call is scored against a scenario only when exactly one scenario is in
   // scope: a single case, or a suite that holds exactly one scenario. Every
   // other scope has no single scenario to write the run under, so no target is

--- a/platform/app/src/components/agents/AgentVoiceEditorDrawer.tsx
+++ b/platform/app/src/components/agents/AgentVoiceEditorDrawer.tsx
@@ -26,6 +26,7 @@ import {
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 import type { AgentWithFields } from "~/server/agents/agent-fields";
 import {
+  E164_PHONE_PATTERN,
   VOICE_TRANSPORT_LABELS,
   VOICE_TRANSPORTS,
   type VoiceTransport,
@@ -33,6 +34,7 @@ import {
 import { api } from "~/utils/api";
 import { TalkToItPanel } from "./voice/TalkToItPanel";
 import { useVoiceAgentsEnabled } from "./voice/useVoiceAgentsEnabled";
+import { useVoicePhoneTargetsEnabled } from "./voice/useVoicePhoneTargetsEnabled";
 
 // ============================================================================
 // Constants
@@ -52,6 +54,7 @@ type VoiceAgentDraft = {
   name: string;
   transport: VoiceTransport;
   agentId: string;
+  phoneNumber: string;
 };
 
 const draftKey = (projectId: string) => `voice-agent-draft:${projectId}`;
@@ -69,7 +72,13 @@ function readDraft(projectId: string): VoiceAgentDraft | null {
     )
       ? (parsed.transport as VoiceTransport)
       : DEFAULT_TRANSPORT;
-    return { name: parsed.name, transport, agentId: parsed.agentId };
+    return {
+      name: parsed.name,
+      transport,
+      agentId: parsed.agentId,
+      phoneNumber:
+        typeof parsed.phoneNumber === "string" ? parsed.phoneNumber : "",
+    };
   } catch {
     return null;
   }
@@ -108,7 +117,41 @@ export type AgentVoiceEditorDrawerProps = {
 // Pure helpers
 // ============================================================================
 
-type VoiceForm = { name: string; transport: VoiceTransport; agentId: string };
+type VoiceForm = {
+  name: string;
+  transport: VoiceTransport;
+  agentId: string;
+  phoneNumber: string;
+};
+
+/** The form values seeded from a saved agent's stored config. */
+function formFromAgent(agentData: {
+  name?: string | null;
+  config?: unknown;
+}): VoiceForm {
+  const config = (agentData.config ?? {}) as {
+    transport?: VoiceTransport;
+    agentId?: string;
+    phoneNumber?: string;
+  };
+  return {
+    name: agentData.name ?? "",
+    transport: config.transport ?? DEFAULT_TRANSPORT,
+    agentId: config.agentId ?? "",
+    phoneNumber: config.phoneNumber ?? "",
+  };
+}
+
+/** The form values seeded from the per-project create draft (else empty). */
+function formFromDraft(projectId: string): VoiceForm {
+  const draft = readDraft(projectId);
+  return {
+    name: draft?.name ?? "",
+    transport: draft?.transport ?? DEFAULT_TRANSPORT,
+    agentId: draft?.agentId ?? "",
+    phoneNumber: draft?.phoneNumber ?? "",
+  };
+}
 
 /**
  * The values the form initializes to: the saved agent when editing, the draft
@@ -125,25 +168,8 @@ function resolveInitialForm({
   isOpen: boolean;
   projectId: string;
 }): VoiceForm | null {
-  if (agentData) {
-    const config = (agentData.config ?? {}) as {
-      transport?: VoiceTransport;
-      agentId?: string;
-    };
-    return {
-      name: agentData.name ?? "",
-      transport: config.transport ?? DEFAULT_TRANSPORT,
-      agentId: config.agentId ?? "",
-    };
-  }
-  if (isCreating && isOpen && projectId) {
-    const draft = readDraft(projectId);
-    return {
-      name: draft?.name ?? "",
-      transport: draft?.transport ?? DEFAULT_TRANSPORT,
-      agentId: draft?.agentId ?? "",
-    };
-  }
+  if (agentData) return formFromAgent(agentData);
+  if (isCreating && isOpen && projectId) return formFromDraft(projectId);
   return null;
 }
 
@@ -212,22 +238,35 @@ function addKeyHref(): string {
   return `${MODEL_PROVIDERS_ROUTE}?returnTo=${returnTo}`;
 }
 
-/** Both required fields are filled, so the agent can be saved. */
+/** The name and the transport's own required field are filled, so the agent
+ *  can be saved. Phone validates the number in E.164 form; ElevenLabs needs a
+ *  non-empty agent id. */
 function isVoiceFormValid(form: {
   name: string;
+  transport: VoiceTransport;
   voiceAgentId: string;
+  phoneNumber: string;
 }): boolean {
-  return form.name.trim().length > 0 && form.voiceAgentId.trim().length > 0;
+  if (form.name.trim().length === 0) return false;
+  if (form.transport === "phone") {
+    return E164_PHONE_PATTERN.test(form.phoneNumber.trim());
+  }
+  return form.voiceAgentId.trim().length > 0;
 }
 
 /** The tooltip naming whichever "Talk to it" prerequisite is still missing. */
 function talkTooltipFor({
+  transport,
   voiceAgentId,
   hasElevenLabsKey,
 }: {
+  transport: VoiceTransport;
   voiceAgentId: string;
   hasElevenLabsKey: boolean;
 }): string | undefined {
+  if (transport === "phone") {
+    return "Browser calls are not available for phone targets. Call it from a scenario run.";
+  }
   if (voiceAgentId.trim().length === 0) return "Enter the agent id first";
   if (!hasElevenLabsKey) return "Add an ElevenLabs key first";
   return undefined;
@@ -256,6 +295,7 @@ function useVoiceFormState({
   const [name, setName] = useState("");
   const [transport, setTransport] = useState<VoiceTransport>(DEFAULT_TRANSPORT);
   const [voiceAgentId, setVoiceAgentId] = useState("");
+  const [phoneNumber, setPhoneNumber] = useState("");
   const formInitializedRef = useRef(false);
   const lastAgentIdRef = useRef<string | undefined>(undefined);
 
@@ -276,6 +316,7 @@ function useVoiceFormState({
     setName(initial.name);
     setTransport(initial.transport);
     setVoiceAgentId(initial.agentId);
+    setPhoneNumber(initial.phoneNumber);
     formInitializedRef.current = true;
   }, [agentData, agentId, isCreating, isOpen, projectId]);
 
@@ -290,8 +331,21 @@ function useVoiceFormState({
     if (!isCreating || !isOpen || !projectId || !formInitializedRef.current) {
       return;
     }
-    writeDraft(projectId, { name, transport, agentId: voiceAgentId });
-  }, [isCreating, isOpen, projectId, name, transport, voiceAgentId]);
+    writeDraft(projectId, {
+      name,
+      transport,
+      agentId: voiceAgentId,
+      phoneNumber,
+    });
+  }, [
+    isCreating,
+    isOpen,
+    projectId,
+    name,
+    transport,
+    voiceAgentId,
+    phoneNumber,
+  ]);
 
   return {
     name,
@@ -300,6 +354,8 @@ function useVoiceFormState({
     setTransport,
     voiceAgentId,
     setVoiceAgentId,
+    phoneNumber,
+    setPhoneNumber,
   };
 }
 
@@ -383,15 +439,20 @@ function submitVoiceAgent({
   isValid: boolean;
   agentId: string | undefined;
   createdAgentRowId: string | undefined;
-  form: { name: string; transport: VoiceTransport; voiceAgentId: string };
+  form: {
+    name: string;
+    transport: VoiceTransport;
+    voiceAgentId: string;
+    phoneNumber: string;
+  };
   createMutation: ReturnType<typeof api.agents.create.useMutation>;
   updateMutation: ReturnType<typeof api.agents.update.useMutation>;
 }): void {
   if (!projectId || !isValid) return;
-  const config = {
-    transport: form.transport,
-    agentId: form.voiceAgentId.trim(),
-  };
+  const config =
+    form.transport === "phone"
+      ? { transport: form.transport, phoneNumber: form.phoneNumber.trim() }
+      : { transport: form.transport, agentId: form.voiceAgentId.trim() };
   const savedAgentId = agentId ?? createdAgentRowId;
   if (savedAgentId) {
     updateMutation.mutate({
@@ -425,7 +486,12 @@ function useSaveVoiceAgent({
   isValid: boolean;
   agentId: string | undefined;
   createdAgentRowId: string | undefined;
-  form: { name: string; transport: VoiceTransport; voiceAgentId: string };
+  form: {
+    name: string;
+    transport: VoiceTransport;
+    voiceAgentId: string;
+    phoneNumber: string;
+  };
   createMutation: ReturnType<typeof api.agents.create.useMutation>;
   updateMutation: ReturnType<typeof api.agents.update.useMutation>;
 }): { handleSave: () => void; hasAttemptedSubmit: boolean } {
@@ -462,7 +528,12 @@ function useSaveVoiceAgent({
  * create/update mutations, and the same flow-callback forwarding so the run
  * dialog and the scenario editor can open it and be told about the saved agent.
  */
-function useVoiceAgentEditor(props: AgentVoiceEditorDrawerProps) {
+/**
+ * The drawer's resolved inputs, local state, and the data/form/mutation hooks
+ * it composes. Kept apart from {@link useVoiceAgentEditor} so each stays a small
+ * function; the editor hook layers the derived flags and callbacks on top.
+ */
+function useVoiceEditorState(props: AgentVoiceEditorDrawerProps) {
   const { project } = useOrganizationTeamProject();
   const { closeDrawer, canGoBack, goBack } = useDrawer();
   const projectId = project?.id ?? "";
@@ -474,19 +545,17 @@ function useVoiceAgentEditor(props: AgentVoiceEditorDrawerProps) {
     drawerParams,
     flowCallbacksForSave: getFlowCallbacks("agentVoiceEditor"),
   });
-
   // The card menu's Talk to it action opens the drawer straight onto the call
   // panel via ?drawer.talk=1, rather than making the user click Talk to it
   // again once the editor has loaded (#23).
   const [isTalkOpen, setIsTalkOpen] = useState(drawerParams.talk === "1");
   const [createdAgentRowId, setCreatedAgentRowId] = useState<string>();
-
+  const phoneTargetsEnabled = useVoicePhoneTargetsEnabled();
   const { agentQuery, hasElevenLabsKey } = useVoiceAgentData({
     agentId,
     projectId,
     isOpen,
   });
-
   const form = useVoiceFormState({
     agentData: agentQuery.data,
     agentId,
@@ -499,6 +568,40 @@ function useVoiceAgentEditor(props: AgentVoiceEditorDrawerProps) {
     onSave,
     onClose,
   });
+  return {
+    project,
+    canGoBack,
+    goBack,
+    agentId,
+    isOpen,
+    isCreating,
+    projectId,
+    onClose,
+    form,
+    hasElevenLabsKey,
+    phoneTargetsEnabled,
+    isTalkOpen,
+    setIsTalkOpen,
+    createdAgentRowId,
+    setCreatedAgentRowId,
+    agentQuery,
+    createMutation,
+    updateMutation,
+    utils,
+  };
+}
+
+function useVoiceAgentEditor(props: AgentVoiceEditorDrawerProps) {
+  const state = useVoiceEditorState(props);
+  const {
+    projectId,
+    onClose,
+    agentId,
+    form,
+    createdAgentRowId,
+    createMutation,
+    updateMutation,
+  } = state;
 
   const isSaving = createMutation.isPending || updateMutation.isPending;
   const isValid = isVoiceFormValid(form);
@@ -519,25 +622,26 @@ function useVoiceAgentEditor(props: AgentVoiceEditorDrawerProps) {
   }, [projectId, onClose]);
 
   return {
-    project,
-    canGoBack,
-    goBack,
+    project: state.project,
+    canGoBack: state.canGoBack,
+    goBack: state.goBack,
     agentId,
-    isOpen,
+    isOpen: state.isOpen,
     projectId,
     form,
-    hasElevenLabsKey,
+    hasElevenLabsKey: state.hasElevenLabsKey,
+    phoneTargetsEnabled: state.phoneTargetsEnabled,
     isSaving,
     isValid,
     hasAttemptedSubmit,
-    isLoading: agentQuery.isLoading,
-    isTalkOpen,
-    setIsTalkOpen,
+    isLoading: state.agentQuery.isLoading,
+    isTalkOpen: state.isTalkOpen,
+    setIsTalkOpen: state.setIsTalkOpen,
     createdAgentRowId,
-    setCreatedAgentRowId,
+    setCreatedAgentRowId: state.setCreatedAgentRowId,
     handleSave,
     handleClose,
-    utils,
+    utils: state.utils,
   };
 }
 
@@ -608,45 +712,11 @@ export function AgentVoiceEditorDrawer(props: AgentVoiceEditorDrawerProps) {
           goBack={editor.goBack}
           agentId={editor.agentId}
         />
-        <Drawer.Body
-          display="flex"
-          flexDirection="column"
-          overflow="hidden"
-          padding={0}
-        >
-          {editor.isTalkOpen ? (
-            <VoiceAgentTalkView
-              project={editor.project}
-              projectId={editor.projectId}
-              transport={form.transport}
-              voiceAgentId={form.voiceAgentId}
-              name={form.name}
-              agentId={editor.agentId}
-              createdAgentRowId={editor.createdAgentRowId}
-              setCreatedAgentRowId={editor.setCreatedAgentRowId}
-              utils={editor.utils}
-              onBack={() => editor.setIsTalkOpen(false)}
-            />
-          ) : editor.agentId && editor.isLoading ? (
-            <HStack justify="center" paddingY={8}>
-              <Spinner size="md" />
-            </HStack>
-          ) : (
-            <VoiceAgentForm
-              name={form.name}
-              setName={form.setName}
-              transport={form.transport}
-              setTransport={form.setTransport}
-              voiceAgentId={form.voiceAgentId}
-              setVoiceAgentId={form.setVoiceAgentId}
-              hasElevenLabsKey={editor.hasElevenLabsKey}
-              hasAttemptedSubmit={editor.hasAttemptedSubmit}
-            />
-          )}
-        </Drawer.Body>
+        <VoiceAgentDrawerBody editor={editor} />
         <VoiceAgentFooter
           agentId={editor.agentId}
           createdAgentRowId={editor.createdAgentRowId}
+          transport={form.transport}
           voiceAgentId={form.voiceAgentId}
           hasElevenLabsKey={editor.hasElevenLabsKey}
           isSaving={editor.isSaving}
@@ -662,6 +732,60 @@ export function AgentVoiceEditorDrawer(props: AgentVoiceEditorDrawerProps) {
 // ============================================================================
 // Presentational sub-components
 // ============================================================================
+
+/**
+ * The drawer body: the call panel, the loading spinner while an existing agent
+ * loads, or the edit form. Split out of {@link AgentVoiceEditorDrawer} so that
+ * component stays small.
+ */
+function VoiceAgentDrawerBody({
+  editor,
+}: {
+  editor: ReturnType<typeof useVoiceAgentEditor>;
+}) {
+  const { form } = editor;
+  return (
+    <Drawer.Body
+      display="flex"
+      flexDirection="column"
+      overflow="hidden"
+      padding={0}
+    >
+      {editor.isTalkOpen ? (
+        <VoiceAgentTalkView
+          project={editor.project}
+          projectId={editor.projectId}
+          transport={form.transport}
+          voiceAgentId={form.voiceAgentId}
+          name={form.name}
+          agentId={editor.agentId}
+          createdAgentRowId={editor.createdAgentRowId}
+          setCreatedAgentRowId={editor.setCreatedAgentRowId}
+          utils={editor.utils}
+          onBack={() => editor.setIsTalkOpen(false)}
+        />
+      ) : editor.agentId && editor.isLoading ? (
+        <HStack justify="center" paddingY={8}>
+          <Spinner size="md" />
+        </HStack>
+      ) : (
+        <VoiceAgentForm
+          name={form.name}
+          setName={form.setName}
+          transport={form.transport}
+          setTransport={form.setTransport}
+          voiceAgentId={form.voiceAgentId}
+          setVoiceAgentId={form.setVoiceAgentId}
+          phoneNumber={form.phoneNumber}
+          setPhoneNumber={form.setPhoneNumber}
+          phoneTargetsEnabled={editor.phoneTargetsEnabled}
+          hasElevenLabsKey={editor.hasElevenLabsKey}
+          hasAttemptedSubmit={editor.hasAttemptedSubmit}
+        />
+      )}
+    </Drawer.Body>
+  );
+}
 
 function VoiceAgentHeader({
   canGoBack,
@@ -750,6 +874,24 @@ function VoiceAgentTalkView({
   );
 }
 
+/**
+ * The transports offered in the "Reached via" select. Phone stays hidden until
+ * the `release_voice_phone_targets_enabled` flag is on, but an agent already
+ * configured as phone still lists it so its own transport renders (the gate is
+ * on the OPTION, not on an existing target).
+ */
+function visibleTransportsFor({
+  phoneTargetsEnabled,
+  transport,
+}: {
+  phoneTargetsEnabled: boolean;
+  transport: VoiceTransport;
+}): readonly VoiceTransport[] {
+  return VOICE_TRANSPORTS.filter(
+    (t) => t !== "phone" || phoneTargetsEnabled || transport === "phone",
+  );
+}
+
 function VoiceAgentForm({
   name,
   setName,
@@ -757,6 +899,9 @@ function VoiceAgentForm({
   setTransport,
   voiceAgentId,
   setVoiceAgentId,
+  phoneNumber,
+  setPhoneNumber,
+  phoneTargetsEnabled,
   hasElevenLabsKey,
   hasAttemptedSubmit,
 }: {
@@ -766,13 +911,23 @@ function VoiceAgentForm({
   setTransport: (value: VoiceTransport) => void;
   voiceAgentId: string;
   setVoiceAgentId: (value: string) => void;
+  phoneNumber: string;
+  setPhoneNumber: (value: string) => void;
+  phoneTargetsEnabled: boolean;
   hasElevenLabsKey: boolean;
   hasAttemptedSubmit: boolean;
 }) {
   const nameInvalid = hasAttemptedSubmit && name.trim().length === 0;
   const voiceAgentIdInvalid =
     hasAttemptedSubmit && voiceAgentId.trim().length === 0;
-  const transportOptionsDisabled = VOICE_TRANSPORTS.length <= 1;
+  const phoneNumberInvalid =
+    hasAttemptedSubmit && !E164_PHONE_PATTERN.test(phoneNumber.trim());
+  const isPhone = transport === "phone";
+  const visibleTransports = visibleTransportsFor({
+    phoneTargetsEnabled,
+    transport,
+  });
+  const transportOptionsDisabled = visibleTransports.length <= 1;
   return (
     <VStack
       gap={4}
@@ -801,7 +956,7 @@ function VoiceAgentForm({
             onChange={(e) => setTransport(e.target.value as VoiceTransport)}
             data-testid="voice-agent-transport-select"
           >
-            {VOICE_TRANSPORTS.map((t) => (
+            {visibleTransports.map((t) => (
               <option key={t} value={t}>
                 {VOICE_TRANSPORT_LABELS[t]}
               </option>
@@ -811,7 +966,70 @@ function VoiceAgentForm({
         </NativeSelect.Root>
       </Field.Root>
 
-      <Field.Root required invalid={voiceAgentIdInvalid}>
+      {isPhone ? (
+        <PhoneNumberField
+          phoneNumber={phoneNumber}
+          setPhoneNumber={setPhoneNumber}
+          invalid={phoneNumberInvalid}
+        />
+      ) : (
+        <ElevenLabsAgentIdField
+          voiceAgentId={voiceAgentId}
+          setVoiceAgentId={setVoiceAgentId}
+          invalid={voiceAgentIdInvalid}
+          hasElevenLabsKey={hasElevenLabsKey}
+        />
+      )}
+    </VStack>
+  );
+}
+
+/** The phone target's E.164 number, the whole identity of a phone target. */
+function PhoneNumberField({
+  phoneNumber,
+  setPhoneNumber,
+  invalid,
+}: {
+  phoneNumber: string;
+  setPhoneNumber: (value: string) => void;
+  invalid: boolean;
+}) {
+  return (
+    <Field.Root required invalid={invalid}>
+      <Field.Label>Phone number</Field.Label>
+      <Input
+        value={phoneNumber}
+        onChange={(e) => setPhoneNumber(e.target.value)}
+        placeholder="+14155550123"
+        data-testid="voice-agent-phone-input"
+      />
+      <Field.HelperText>
+        In E.164 form: a plus sign, the country code, then the number.
+      </Field.HelperText>
+      {invalid && (
+        <Field.ErrorText>
+          Enter the number in E.164 form, like +14155550123
+        </Field.ErrorText>
+      )}
+    </Field.Root>
+  );
+}
+
+/** The ElevenLabs agent id, with the provider-key line beneath it. */
+function ElevenLabsAgentIdField({
+  voiceAgentId,
+  setVoiceAgentId,
+  invalid,
+  hasElevenLabsKey,
+}: {
+  voiceAgentId: string;
+  setVoiceAgentId: (value: string) => void;
+  invalid: boolean;
+  hasElevenLabsKey: boolean;
+}) {
+  return (
+    <>
+      <Field.Root required invalid={invalid}>
         <Field.Label>Agent id</Field.Label>
         <Input
           value={voiceAgentId}
@@ -822,17 +1040,15 @@ function VoiceAgentForm({
         <Field.HelperText>
           From the ElevenLabs dashboard: Agents, your agent, Agent ID
         </Field.HelperText>
-        {voiceAgentIdInvalid && (
-          <Field.ErrorText>Agent id is required</Field.ErrorText>
-        )}
+        {invalid && <Field.ErrorText>Agent id is required</Field.ErrorText>}
       </Field.Root>
 
       <CredentialsLine hasElevenLabsKey={hasElevenLabsKey} />
-    </VStack>
+    </>
   );
 }
 
-/** The credentials line — the key lives on the ElevenLabs provider row. */
+/** The credentials line: the key lives on the ElevenLabs provider row. */
 function CredentialsLine({ hasElevenLabsKey }: { hasElevenLabsKey: boolean }) {
   if (hasElevenLabsKey) {
     return (
@@ -858,6 +1074,7 @@ function CredentialsLine({ hasElevenLabsKey }: { hasElevenLabsKey: boolean }) {
 function VoiceAgentFooter({
   agentId,
   createdAgentRowId,
+  transport,
   voiceAgentId,
   hasElevenLabsKey,
   isSaving,
@@ -867,6 +1084,7 @@ function VoiceAgentFooter({
 }: {
   agentId: string | undefined;
   createdAgentRowId: string | undefined;
+  transport: VoiceTransport;
   voiceAgentId: string;
   hasElevenLabsKey: boolean;
   isSaving: boolean;
@@ -874,13 +1092,19 @@ function VoiceAgentFooter({
   onTalk: () => void;
   onSave: () => void;
 }) {
-  // Once "Talk to it" has created the row, further saves update it — the
+  // Once "Talk to it" has created the row, further saves update it: the
   // panel's created id stands in for the editor's own agentId (#20).
   const savedAgentId = agentId ?? createdAgentRowId;
   // Talk to it is enabled as soon as the transport's agent id is filled and the
-  // project has a key — no save-first. The tooltip names whichever is missing.
-  const canTalk = voiceAgentId.trim().length > 0 && hasElevenLabsKey;
-  const talkTooltip = talkTooltipFor({ voiceAgentId, hasElevenLabsKey });
+  // project has a key, no save-first. The tooltip names whichever is missing.
+  // Phone has no browser call, so it is always off with an explaining tooltip.
+  const canTalk =
+    transport !== "phone" && voiceAgentId.trim().length > 0 && hasElevenLabsKey;
+  const talkTooltip = talkTooltipFor({
+    transport,
+    voiceAgentId,
+    hasElevenLabsKey,
+  });
   return (
     <Drawer.Footer borderTopWidth="1px" borderColor="border">
       <HStack gap={3}>

--- a/platform/app/src/components/agents/__tests__/AgentVoiceEditorDrawer.integration.test.tsx
+++ b/platform/app/src/components/agents/__tests__/AgentVoiceEditorDrawer.integration.test.tsx
@@ -61,6 +61,13 @@ vi.mock("../voice/useVoiceAgentsEnabled", () => ({
   useVoiceAgentsEnabled: () => mockVoiceAgentsEnabled,
 }));
 
+/** Overridden per test; false by default so the phone option stays gated off
+ * for the editor's own behavior tests. */
+let mockPhoneTargetsEnabled = false;
+vi.mock("../voice/useVoicePhoneTargetsEnabled", () => ({
+  useVoicePhoneTargetsEnabled: () => mockPhoneTargetsEnabled,
+}));
+
 /** What `agents.getById` answers with, so a test can open a saved agent. */
 let mockAgentById: {
   id: string;
@@ -156,6 +163,7 @@ describe("AgentVoiceEditorDrawer", () => {
     mockAgentById = null;
     mockProviders = [];
     mockVoiceAgentsEnabled = true;
+    mockPhoneTargetsEnabled = false;
     mockDrawerParams = {};
     try {
       sessionStorage.clear();
@@ -176,6 +184,43 @@ describe("AgentVoiceEditorDrawer", () => {
       expect(
         screen.queryByTestId("voice-agent-name-input"),
       ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("given the phone targets flag gates the Phone number option", () => {
+    /** @scenario "The phone option is hidden until the phone targets flag is on" */
+    it("hides the Phone number option while off and offers it once on", async () => {
+      mockPhoneTargetsEnabled = false;
+      const { unmount } = renderVoiceDrawer();
+      await screen.findByTestId("voice-agent-transport-select");
+      expect(
+        screen.queryByRole("option", { name: "Phone number" }),
+      ).not.toBeInTheDocument();
+      unmount();
+
+      mockPhoneTargetsEnabled = true;
+      renderVoiceDrawer();
+      await screen.findByTestId("voice-agent-transport-select");
+      expect(
+        screen.getByRole("option", { name: "Phone number" }),
+      ).toBeInTheDocument();
+    });
+
+    it("still renders an existing phone target's fields with the flag off", async () => {
+      mockPhoneTargetsEnabled = false;
+      mockAgentById = {
+        id: "agent_phone",
+        name: "Hotline",
+        config: { transport: "phone", phoneNumber: "+14155550123" },
+      };
+      renderVoiceDrawer({ agentId: "agent_phone" });
+      const input = (await screen.findByTestId(
+        "voice-agent-phone-input",
+      )) as HTMLInputElement;
+      expect(input.value).toBe("+14155550123");
+      expect(
+        screen.getByRole("option", { name: "Phone number" }),
+      ).toBeInTheDocument();
     });
   });
 
@@ -329,6 +374,25 @@ describe("AgentVoiceEditorDrawer", () => {
       expect(
         screen.queryByTestId("voice-agent-name-input"),
       ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("given a saved phone target", () => {
+    /** @scenario "A phone target's drawer explains why Talk to it is off" */
+    it("disables Talk to it with the phone-has-no-browser-call tooltip", async () => {
+      mockAgentById = {
+        id: "agent_phone",
+        name: "Hotline",
+        config: { transport: "phone", phoneNumber: "+14155550123" },
+      };
+      mockProviders = [ELEVENLABS_KEYED_PROVIDER];
+      renderVoiceDrawer({ agentId: "agent_phone" });
+      const talk = await screen.findByTestId("voice-agent-talk");
+      expect(talk).toBeDisabled();
+      expect(talk).toHaveAttribute(
+        "title",
+        "Browser calls are not available for phone targets. Call it from a scenario run.",
+      );
     });
   });
 

--- a/platform/app/src/components/agents/voice/TalkToItPanel.tsx
+++ b/platform/app/src/components/agents/voice/TalkToItPanel.tsx
@@ -31,13 +31,18 @@ import {
   talkReducer,
 } from "./talkToItMachine";
 import {
+  getVoiceTransportClient,
   type VoiceCallSession,
   type VoiceTurn,
-  voiceTransportClientRegistry,
 } from "./voice-transport-client.registry";
 
 /** The settings route that adds a model provider key (mirrors the drawer). */
 const MODEL_PROVIDERS_ROUTE = "/settings/model-providers";
+
+/** Shown instead of the call controls for a transport with no browser client
+ *  (a phone target is dialled from a scenario run, not from the browser). */
+export const PHONE_NO_BROWSER_CALL_NOTICE =
+  "This agent is reached by phone. Call it from a scenario run; browser calls are not available for phone targets.";
 
 /** Placeholder cap before minting; the session mint response replaces it. */
 const PRE_MINT_MAX_SECONDS_PLACEHOLDER = VOICE_CALL_MAX_SECONDS_DEFAULT;
@@ -401,9 +406,21 @@ async function runStart({
   refs.sessionToken.current = mint.sessionToken;
   refs.startedAt.current = Date.now();
 
+  const client = getVoiceTransportClient(props.transport);
+  if (!client) {
+    // A transport with no browser client cannot open a call here; the panel
+    // renders the phone notice instead of ever reaching this path.
+    dispatch({
+      type: "MINT_FAILED",
+      code: "mint_failed",
+      message: PHONE_NO_BROWSER_CALL_NOTICE,
+    });
+    return;
+  }
+
   let session: VoiceCallSession;
   try {
-    session = await voiceTransportClientRegistry[props.transport].openCall({
+    session = await client.openCall({
       signedUrl: mint.connect.signedUrl,
       handlers: {
         onConnected: ({ conversationId }) => {
@@ -549,6 +566,27 @@ function useTalkToItCall(props: TalkToItPanelProps) {
  * @see specs/features/agents/voice-agents-v1.feature
  */
 export function TalkToItPanel(props: TalkToItPanelProps) {
+  // A transport with no browser client (phone) is dialled from a scenario run,
+  // not the browser: show the notice instead of the call machine, which would
+  // otherwise try to mint a session it cannot open. Split so the call hooks
+  // below never run for such a transport.
+  if (!getVoiceTransportClient(props.transport)) {
+    return (
+      <VStack align="stretch" gap={4} data-testid="talk-to-it-panel">
+        <Text
+          fontSize="sm"
+          color="fg.muted"
+          data-testid="talk-phone-no-browser-notice"
+        >
+          {PHONE_NO_BROWSER_CALL_NOTICE}
+        </Text>
+      </VStack>
+    );
+  }
+  return <BrowserCallPanel {...props} />;
+}
+
+function BrowserCallPanel(props: TalkToItPanelProps) {
   const {
     state,
     micLevel,

--- a/platform/app/src/components/agents/voice/__tests__/TalkToItPanel.integration.test.tsx
+++ b/platform/app/src/components/agents/voice/__tests__/TalkToItPanel.integration.test.tsx
@@ -20,11 +20,17 @@ const { openCall } = vi.hoisted(() => ({
     hangUp: vi.fn(async () => {}),
   })),
 }));
-vi.mock("../voice-transport-client.registry", () => ({
-  voiceTransportClientRegistry: { elevenlabs_convai: { openCall } },
-}));
+vi.mock("../voice-transport-client.registry", () => {
+  const registry: Record<string, { openCall: typeof openCall }> = {
+    elevenlabs_convai: { openCall },
+  };
+  return {
+    voiceTransportClientRegistry: registry,
+    getVoiceTransportClient: (transport: string) => registry[transport],
+  };
+});
 
-import { TalkToItPanel } from "../TalkToItPanel";
+import { PHONE_NO_BROWSER_CALL_NOTICE, TalkToItPanel } from "../TalkToItPanel";
 import {
   CONSENT_NOTICE,
   MIC_BLOCKED_MESSAGE,
@@ -74,6 +80,27 @@ describe("TalkToItPanel", () => {
           CONSENT_NOTICE,
         );
       });
+    });
+  });
+
+  describe("when the transport is a phone target", () => {
+    /** @scenario "A phone target has no browser call" */
+    it("shows the phone notice and never opens a browser call", async () => {
+      render(
+        <TalkToItPanel
+          projectId="p1"
+          projectSlug="proj"
+          transport="phone"
+          agentId=""
+        />,
+        { wrapper: Wrapper },
+      );
+      await waitFor(() => {
+        expect(
+          screen.getByTestId("talk-phone-no-browser-notice"),
+        ).toHaveTextContent(PHONE_NO_BROWSER_CALL_NOTICE);
+      });
+      expect(openCall).not.toHaveBeenCalled();
     });
   });
 

--- a/platform/app/src/components/agents/voice/useVoicePhoneTargetsEnabled.ts
+++ b/platform/app/src/components/agents/voice/useVoicePhoneTargetsEnabled.ts
@@ -1,0 +1,35 @@
+/**
+ * Whether the Phone number transport option is offered in the voice agent
+ * drawer for the current project.
+ *
+ * Mirrors {@link useVoiceAgentsEnabled}: it reads
+ * `release_voice_phone_targets_enabled` with the ids from
+ * `useOrganizationTeamProject`, so the drawer gates the option the same way
+ * every other flag surface reads its flag. Off until the voice worker that
+ * dials phone targets ships (#8014); an existing phone target still renders its
+ * fields regardless of this flag, so the gate is on the OPTION only.
+ *
+ * @see specs/features/agents/voice-phone.feature
+ */
+
+import { useFeatureFlag } from "~/hooks/useFeatureFlag";
+import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
+import { NOT_TARGETED } from "~/server/featureFlag/targeting";
+
+export const VOICE_PHONE_TARGETS_FLAG_KEY =
+  "release_voice_phone_targets_enabled" as const;
+
+export function useVoicePhoneTargetsEnabled(): boolean {
+  const { project, organization } = useOrganizationTeamProject({
+    redirectToOnboarding: false,
+    redirectToProjectOnboarding: false,
+  });
+
+  const { enabled, isLoading } = useFeatureFlag(VOICE_PHONE_TARGETS_FLAG_KEY, {
+    projectId: project?.id ?? NOT_TARGETED,
+    organizationId: organization?.id,
+    enabled: !!organization?.id,
+  });
+
+  return !isLoading && enabled;
+}

--- a/platform/app/src/components/agents/voice/voice-transport-client.registry.ts
+++ b/platform/app/src/components/agents/voice/voice-transport-client.registry.ts
@@ -38,9 +38,20 @@ export interface VoiceTransportClient {
   }): Promise<VoiceCallSession>;
 }
 
-export const voiceTransportClientRegistry: Record<
-  VoiceTransport,
-  VoiceTransportClient
+/**
+ * Not every transport has a browser client: a phone target is dialled from the
+ * voice worker, not the browser, so it has no "Talk to it" client at all. The
+ * registry is a partial map, and {@link getVoiceTransportClient} returns
+ * `undefined` for a transport with no browser call.
+ */
+export const voiceTransportClientRegistry: Partial<
+  Record<VoiceTransport, VoiceTransportClient>
 > = {
   elevenlabs_convai: elevenLabsConvaiClient,
 };
+
+/** The browser client for a transport, or `undefined` when it has none (phone
+ *  targets are called from a scenario run, never from the browser). */
+export const getVoiceTransportClient = (
+  transport: VoiceTransport,
+): VoiceTransportClient | undefined => voiceTransportClientRegistry[transport];

--- a/platform/app/src/features/errors/logic/codes.ts
+++ b/platform/app/src/features/errors/logic/codes.ts
@@ -441,6 +441,7 @@ export const APP_ERROR_CODES = [
   "voice_key_missing",
   "voice_mint_failed",
   "voice_name_required",
+  "voice_phone_transport_unavailable",
   "voice_recording_key_missing",
   "voice_recording_unavailable",
   "voice_session_invalid",

--- a/platform/app/src/features/errors/logic/presentation.ts
+++ b/platform/app/src/features/errors/logic/presentation.ts
@@ -3222,6 +3222,11 @@ const presentations = {
     title: "A name is required to save the agent",
     describe: () => "",
   },
+  voice_phone_transport_unavailable: {
+    title: "Phone targets are not available yet",
+    describe: () =>
+      "Phone targets are called from the voice worker, which is not available yet. Track langwatch/langwatch#8014.",
+  },
   voice_recording_unavailable: {
     title: "The call recording is not available",
     describe: () => "",

--- a/platform/app/src/server/agents/agent.service.ts
+++ b/platform/app/src/server/agents/agent.service.ts
@@ -6,6 +6,7 @@ import type {
   Workflow,
 } from "~/optimization_studio/types/dsl";
 import {
+  type VoiceAgentConfig,
   type VoiceTransport,
   voiceAgentIdentityKey,
 } from "~/server/agents/voice/voice-agent.config";
@@ -252,13 +253,21 @@ export class AgentService {
       identityKey,
     });
     if (existing) return existing;
+    // The external id (agentId) carries the identity for either transport: the
+    // ElevenLabs agent id, or the phone number. Store it under the field the
+    // transport's config member names, narrowing so the discriminated union
+    // stays valid without a cast.
+    const config: VoiceAgentConfig =
+      input.transport === "phone"
+        ? { transport: "phone", phoneNumber: input.agentId }
+        : { transport: input.transport, agentId: input.agentId };
     try {
       return await this.repository.create({
         id: input.id,
         projectId: input.projectId,
         name: input.name,
         type: "voice",
-        config: { transport: input.transport, agentId: input.agentId },
+        config,
         identityKey,
       });
     } catch (error) {

--- a/platform/app/src/server/agents/voice/__tests__/voice-agent.config.unit.test.ts
+++ b/platform/app/src/server/agents/voice/__tests__/voice-agent.config.unit.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   parseVoiceAgentConfig,
   voiceAgentConfigSchema,
+  voiceAgentExternalId,
 } from "../voice-agent.config";
 
 describe("voiceAgentConfigSchema", () => {
@@ -40,11 +41,67 @@ describe("voiceAgentConfigSchema", () => {
       /** @scenario "A voice agent config with an unrecognised transport is rejected" */
       it("rejects it", () => {
         const result = voiceAgentConfigSchema.safeParse({
-          transport: "phone",
+          transport: "carrier_pigeon",
           agentId: "agent_123",
         });
         expect(result.success).toBe(false);
       });
+    });
+  });
+
+  describe("given a phone transport with an E.164 number", () => {
+    describe("when the config is validated", () => {
+      /** @scenario "A phone target stores its number in E.164 form" */
+      it("accepts it and trims the number", () => {
+        const parsed = parseVoiceAgentConfig({
+          transport: "phone",
+          phoneNumber: "  +14155550123  ",
+        });
+        expect(parsed).toEqual({
+          transport: "phone",
+          phoneNumber: "+14155550123",
+        });
+      });
+    });
+  });
+
+  describe("given a phone transport whose number is not E.164", () => {
+    describe("when the config is validated", () => {
+      /** @scenario "A phone target rejects a number that is not E.164" */
+      it("rejects it", () => {
+        const rejected = ["415-555-0123", "+0123456789", "+1234567890123456"];
+        for (const phoneNumber of rejected) {
+          const result = voiceAgentConfigSchema.safeParse({
+            transport: "phone",
+            phoneNumber,
+          });
+          expect(result.success).toBe(false);
+        }
+      });
+    });
+  });
+});
+
+describe("voiceAgentExternalId", () => {
+  describe("given an ElevenLabs transport", () => {
+    it("returns the agent id", () => {
+      expect(
+        voiceAgentExternalId({
+          transport: "elevenlabs_convai",
+          agentId: "agent_123",
+        }),
+      ).toBe("agent_123");
+    });
+  });
+
+  describe("given a phone transport", () => {
+    it("returns the phone number", () => {
+      expect(
+        voiceAgentExternalId({
+          transport: "phone",
+          phoneNumber: "+14155550123",
+        }),
+      ).toBe("+14155550123");
     });
   });
 });

--- a/platform/app/src/server/agents/voice/voice-agent.config.ts
+++ b/platform/app/src/server/agents/voice/voice-agent.config.ts
@@ -14,7 +14,7 @@
 import { z } from "zod";
 
 /** Every transport a voice agent can be reached through. */
-export const VOICE_TRANSPORTS = ["elevenlabs_convai"] as const;
+export const VOICE_TRANSPORTS = ["elevenlabs_convai", "phone"] as const;
 export type VoiceTransport = (typeof VOICE_TRANSPORTS)[number];
 
 export const elevenLabsConvaiTransportSchema = z.object({
@@ -22,23 +22,64 @@ export const elevenLabsConvaiTransportSchema = z.object({
   agentId: z.string().trim().min(1, "Agent id is required").max(128),
 });
 
+/**
+ * E.164: a leading `+`, a non-zero country code digit, then up to 14 more
+ * digits. The number is the whole identity of a phone target, so it is
+ * validated at the schema boundary rather than trusted from the form.
+ */
+export const E164_PHONE_PATTERN = /^\+[1-9]\d{1,14}$/;
+
+export const phoneTransportSchema = z.object({
+  transport: z.literal("phone"),
+  phoneNumber: z
+    .string()
+    .trim()
+    .regex(
+      E164_PHONE_PATTERN,
+      "Enter the number in E.164 form, like +14155550123",
+    ),
+});
+
 export const voiceAgentConfigSchema = z.discriminatedUnion("transport", [
   elevenLabsConvaiTransportSchema,
+  phoneTransportSchema,
 ]);
 export type VoiceAgentConfig = z.infer<typeof voiceAgentConfigSchema>;
 
 /** The words a customer reads for each transport in the drawer. */
 export const VOICE_TRANSPORT_LABELS: Record<VoiceTransport, string> = {
   elevenlabs_convai: "ElevenLabs agent",
+  phone: "Phone number",
 };
 
 /** Model provider whose key signs sessions for this transport. */
-export const VOICE_TRANSPORT_PROVIDER: Record<VoiceTransport, "elevenlabs"> = {
+export const VOICE_TRANSPORT_PROVIDER: Record<
+  VoiceTransport,
+  "elevenlabs" | "twilio"
+> = {
   elevenlabs_convai: "elevenlabs",
+  phone: "twilio",
 };
 
 export const parseVoiceAgentConfig = (config: unknown): VoiceAgentConfig =>
   voiceAgentConfigSchema.parse(config);
+
+/**
+ * The transport's own external identifier for a voice agent: the ElevenLabs
+ * agent id, or the phone number for a phone target. This is the value that
+ * forms the identity key ({@link voiceAgentIdentityKey}), so a phone target
+ * keys on its number (voice:phone:+14155550123). Narrows on the transport with
+ * an exhaustive switch, so a new transport member is a compile error here until
+ * it says which field carries its identity.
+ */
+export const voiceAgentExternalId = (config: VoiceAgentConfig): string => {
+  switch (config.transport) {
+    case "elevenlabs_convai":
+      return config.agentId;
+    case "phone":
+      return config.phoneNumber;
+  }
+};
 
 /**
  * The legacy scenario set drawer "Talk to it" calls used to be written into,

--- a/platform/app/src/server/featureFlag/frontendFeatureFlags.ts
+++ b/platform/app/src/server/featureFlag/frontendFeatureFlags.ts
@@ -63,6 +63,11 @@ export const FRONTEND_FEATURE_FLAGS = [
   // run, and run scenarios with a simulated caller. Off by default.
   // See useVoiceAgentsEnabled and specs/features/agents/voice-agents-v1.feature.
   "release_voice_agents_enabled",
+  // The Phone number transport option in the voice agent drawer. Off by default
+  // until the voice worker that dials phone targets ships (#8014); an existing
+  // phone target still renders its fields regardless of this flag. See
+  // AgentVoiceEditorDrawer and specs/features/agents/voice-phone.feature.
+  "release_voice_phone_targets_enabled",
   // Governance: gates the personal-keys / admin oversight /
   // RoutingPolicy / IngestionSource UI surfaces. On by default
   // (ADR-038 Decision 7); SaaS rollout and per-org kill switches are

--- a/platform/app/src/server/featureFlag/registry.ts
+++ b/platform/app/src/server/featureFlag/registry.ts
@@ -192,6 +192,13 @@ export const FEATURE_FLAGS = [
     description:
       "Voice agents: register an ElevenLabs agent, talk to it, call it from a run, and run scenarios with a simulated caller. Off by default; enable per project or organization via the operator store.",
   },
+  {
+    key: "release_voice_phone_targets_enabled",
+    scope: "PRODUCT",
+    defaultValue: false,
+    description:
+      "Reveals the Phone number transport option in the voice agent drawer. Off by default until the voice worker that dials phone targets ships (langwatch/langwatch#8014); an existing phone target still renders its fields regardless. For local dev use FEATURE_FLAG_FORCE_ENABLE=release_voice_phone_targets_enabled.",
+  },
   // Per-project gate for the transient S3 spool at the ingestion edge
   // (#4215 / ADR-022). ON by default, so a deployment with object storage
   // configured keeps oversized span content intact with no flag setup: a span

--- a/platform/app/src/server/scenarios/execution/data-prefetcher.ts
+++ b/platform/app/src/server/scenarios/execution/data-prefetcher.ts
@@ -73,6 +73,7 @@ import {
   type CallerVoiceConfig,
   parseCallerVoiceConfig,
 } from "../voice/caller-voice.config";
+import { VoicePhoneTransportUnavailableError } from "../voice/transports/phone.transport";
 import { voiceCallMaxSeconds } from "../voice/voice-limits";
 import { resolveTraceWaitTimeoutMs } from "./ingest-lag.service";
 import {
@@ -1044,6 +1045,12 @@ async function fetchVoiceAgentData({
   if (agent?.type !== "voice") return null;
 
   const config = parseVoiceAgentConfig(agent.config);
+  // Slice 1: a phone target has no voice worker yet, so a scenario run of one
+  // fails with the transport's own typed error rather than reaching the vendor.
+  // Only the ElevenLabs branch below reads an agent id and a credential.
+  if (config.transport !== "elevenlabs_convai") {
+    throw new VoicePhoneTransportUnavailableError();
+  }
 
   const provider = await findElevenLabsProviderForProject({ projectId });
   const credential = provider

--- a/platform/app/src/server/scenarios/execution/serialized-adapters/__tests__/voice-agent.adapter.unit.test.ts
+++ b/platform/app/src/server/scenarios/execution/serialized-adapters/__tests__/voice-agent.adapter.unit.test.ts
@@ -1,5 +1,6 @@
 import type { AgentAdapter } from "@langwatch/scenario";
 import { describe, expect, it, vi } from "vitest";
+import { phoneTransport } from "../../../voice/transports/phone.transport";
 import type { voiceTransportRegistry } from "../../../voice/voice-transport.registry";
 import type { VoiceAgentData } from "../../types";
 import {
@@ -20,6 +21,7 @@ function fakeRegistry(
       fetchCallRecord: vi.fn(),
       endCall: vi.fn(),
     },
+    phone: phoneTransport,
   };
 }
 

--- a/platform/app/src/server/scenarios/voice/__tests__/phone.transport.unit.test.ts
+++ b/platform/app/src/server/scenarios/voice/__tests__/phone.transport.unit.test.ts
@@ -1,0 +1,81 @@
+/**
+ * @see specs/features/agents/voice-phone.feature
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  PHONE_TRANSPORT_UNAVAILABLE_MESSAGE,
+  phoneTransport,
+  VoicePhoneTransportUnavailableError,
+} from "../transports/phone.transport";
+import type {
+  VoiceTransportCredential,
+  VoiceTransportRunner,
+} from "../voice-transport.registry";
+
+const credential: VoiceTransportCredential = {
+  apiKey: "k",
+  baseUrl: "https://x",
+};
+
+describe("phoneTransport (stub runner)", () => {
+  describe("given the voice worker that dials phone targets does not exist yet", () => {
+    describe("when any runner method is called", () => {
+      /** @scenario "Running a phone target before the voice worker exists fails with a clear message" */
+      it("throws the unavailable error with the tracking message from every method", () => {
+        const expectThrows = (call: () => unknown) => {
+          expect(call).toThrow(VoicePhoneTransportUnavailableError);
+          try {
+            call();
+          } catch (error) {
+            expect((error as VoicePhoneTransportUnavailableError).code).toBe(
+              "voice_phone_transport_unavailable",
+            );
+            expect((error as Error).message).toBe(
+              PHONE_TRANSPORT_UNAVAILABLE_MESSAGE,
+            );
+          }
+        };
+
+        const runner: VoiceTransportRunner = phoneTransport;
+        expectThrows(() =>
+          runner.createAgentAdapter({
+            agentId: "a",
+            credential,
+            maxCallSeconds: 60,
+          }),
+        );
+        expectThrows(() =>
+          runner.fetchCallRecord({
+            conversationId: "c",
+            credential,
+            audioProxyUrl: "/audio",
+          }),
+        );
+        expectThrows(() =>
+          runner.endCall({} as Parameters<VoiceTransportRunner["endCall"]>[0]),
+        );
+      });
+    });
+
+    describe("when a browser session mint is attempted", () => {
+      /** @scenario "A phone target has no browser call" */
+      it("throws rather than minting, because phone has no browser call", () => {
+        const mint = () =>
+          phoneTransport.mintSession({ agentId: "a", credential });
+        expect(mint).toThrow(VoicePhoneTransportUnavailableError);
+        try {
+          mint();
+        } catch (error) {
+          expect((error as VoicePhoneTransportUnavailableError).code).toBe(
+            "voice_phone_transport_unavailable",
+          );
+          expect((error as Error).message).toBe(
+            PHONE_TRANSPORT_UNAVAILABLE_MESSAGE,
+          );
+        }
+      });
+    });
+  });
+});

--- a/platform/app/src/server/scenarios/voice/__tests__/voice-session.service.unit.test.ts
+++ b/platform/app/src/server/scenarios/voice/__tests__/voice-session.service.unit.test.ts
@@ -6,6 +6,10 @@ import { describe, expect, it, vi } from "vitest";
 import { ScenarioRunStatus } from "~/server/scenarios/scenario-event.enums";
 import type { CallRecord } from "../call-record";
 import {
+  phoneTransport,
+  VoicePhoneTransportUnavailableError,
+} from "../transports/phone.transport";
+import {
   authorizeRecordingPlayback,
   finishVoiceSession,
   mintVoiceSession,
@@ -72,7 +76,7 @@ function fakePorts({
     signSessionToken: (payload) => JSON.stringify(payload),
     now: () => 1000,
     newSessionId: () => "sess_generated",
-    registry: { elevenlabs_convai: runner },
+    registry: { elevenlabs_convai: runner, phone: phoneTransport },
     ...over,
   };
 }
@@ -229,6 +233,43 @@ describe("mintVoiceSession", () => {
           }),
         ).rejects.toBeInstanceOf(VoiceKeyMissingError);
         expect(runner.mintSession).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("when the transport cannot run yet (the phone stub)", () => {
+      /** @scenario "Running a phone target before the voice worker exists fails with a clear message" */
+      it("rejects with the unavailable error before any credential lookup", async () => {
+        const runner = fakeRunner();
+        const resolveCredential = vi.fn(async () => CREDENTIAL);
+        const ports = fakePorts({
+          runner,
+          over: {
+            resolveCredential,
+            registry: { elevenlabs_convai: runner, phone: phoneTransport },
+          },
+        });
+
+        await expect(
+          mintVoiceSession({
+            ports,
+            projectId: "p1",
+            transport: "phone",
+            agentId: "+14155550123",
+            maxDurationSeconds: 300,
+          }),
+        ).rejects.toMatchObject({
+          code: "voice_phone_transport_unavailable",
+        });
+        await expect(
+          mintVoiceSession({
+            ports,
+            projectId: "p1",
+            transport: "phone",
+            agentId: "+14155550123",
+            maxDurationSeconds: 300,
+          }),
+        ).rejects.toBeInstanceOf(VoicePhoneTransportUnavailableError);
+        expect(resolveCredential).not.toHaveBeenCalled();
       });
     });
   });

--- a/platform/app/src/server/scenarios/voice/transports/phone.transport.ts
+++ b/platform/app/src/server/scenarios/voice/transports/phone.transport.ts
@@ -1,0 +1,66 @@
+/**
+ * The phone (Twilio) transport: stub.
+ *
+ * A phone target is dialled from the voice worker, which does not exist yet
+ * (langwatch/langwatch#8014). This module keeps the phone member selectable and
+ * inert: every method of the runner throws one typed, customer-facing error, so
+ * nothing can be run over phone until the worker ships. It mirrors the file
+ * layout of {@link elevenLabsConvaiTransport}: this is the ONE module that
+ * will later name Twilio, but wires no vendor SDK yet.
+ *
+ * `mintSession` throws it too: there is no browser call over phone, so a
+ * "Talk to it" mint has nothing to mint.
+ */
+
+import { HandledError } from "@langwatch/handled-error";
+import type { AgentAdapter } from "@langwatch/scenario";
+import type { VoiceTransportRunner } from "../voice-transport.registry";
+
+/** Shown on any attempt to run a phone target before the voice worker exists. */
+export const PHONE_TRANSPORT_UNAVAILABLE_MESSAGE =
+  "Phone targets are called from the voice worker, which is not available yet. Track langwatch/langwatch#8014.";
+
+/**
+ * A phone target was exercised before the voice worker that dials it exists.
+ * Every method of the stub runner throws this one code, so the failure reads
+ * the same wherever it surfaces. Extends the same {@link HandledError} base the
+ * voice-session errors use, with the base's default customer fault.
+ */
+export class VoicePhoneTransportUnavailableError extends HandledError {
+  declare readonly code: "voice_phone_transport_unavailable";
+  constructor() {
+    super(
+      "voice_phone_transport_unavailable",
+      PHONE_TRANSPORT_UNAVAILABLE_MESSAGE,
+      { httpStatus: 400 },
+    );
+    this.name = "VoicePhoneTransportUnavailableError";
+  }
+}
+
+export const phoneTransport: VoiceTransportRunner = {
+  missingKeyMessage: PHONE_TRANSPORT_UNAVAILABLE_MESSAGE,
+
+  // Runs before the credential lookup, so the API reports the phone-unavailable
+  // error rather than a missing-key error the credential absence would raise.
+  assertAvailable(): never {
+    throw new VoicePhoneTransportUnavailableError();
+  },
+
+  // No browser call over phone: there is nothing to mint.
+  mintSession(): Promise<never> {
+    throw new VoicePhoneTransportUnavailableError();
+  },
+
+  fetchCallRecord(): Promise<never> {
+    throw new VoicePhoneTransportUnavailableError();
+  },
+
+  endCall(): Promise<never> {
+    throw new VoicePhoneTransportUnavailableError();
+  },
+
+  createAgentAdapter(): AgentAdapter {
+    throw new VoicePhoneTransportUnavailableError();
+  },
+};

--- a/platform/app/src/server/scenarios/voice/voice-session.ports.ts
+++ b/platform/app/src/server/scenarios/voice/voice-session.ports.ts
@@ -19,6 +19,7 @@ import {
   parseVoiceAgentConfig,
   VOICE_TRANSPORT_PROVIDER,
   type VoiceTransport,
+  voiceAgentExternalId,
 } from "~/server/agents/voice/voice-agent.config";
 import { getApp } from "~/server/app-layer/app";
 import { prisma } from "~/server/db";
@@ -121,7 +122,7 @@ export function createVoiceSessionPortsFromServices({
       const agent = await agentService.getById({ id: agentRowId, projectId });
       if (agent?.type !== "voice") return null;
       const config = parseVoiceAgentConfig(agent.config);
-      return { id: agent.id, agentExternalId: config.agentId };
+      return { id: agent.id, agentExternalId: voiceAgentExternalId(config) };
     },
 
     /** Whether the project saved a voice agent for this vendor agent id: the

--- a/platform/app/src/server/scenarios/voice/voice-session.service.ts
+++ b/platform/app/src/server/scenarios/voice/voice-session.service.ts
@@ -322,6 +322,7 @@ export async function mintVoiceSession({
   const agentId = row?.agentExternalId ?? bodyAgentId;
 
   const runner = runnerFor(ports, transport);
+  runner.assertAvailable?.();
   const credential = await ports.resolveCredential({ projectId, transport });
   if (!credential) throw new VoiceKeyMissingError(runner.missingKeyMessage);
 
@@ -386,10 +387,12 @@ async function fetchProviderRecord(
     projectId,
   }: { transport: VoiceTransport; conversationId: string; projectId: string },
 ): Promise<{ record: CallRecord | null; hasFetchFailed: boolean }> {
+  const runner = runnerFor(ports, transport);
+  runner.assertAvailable?.();
   const credential = await ports.resolveCredential({ projectId, transport });
   if (!credential) return { record: null, hasFetchFailed: false };
   try {
-    const record = await runnerFor(ports, transport).fetchCallRecord({
+    const record = await runner.fetchCallRecord({
       conversationId,
       credential,
       audioProxyUrl: ports.audioProxyUrl({ conversationId, projectId }),

--- a/platform/app/src/server/scenarios/voice/voice-transport.registry.ts
+++ b/platform/app/src/server/scenarios/voice/voice-transport.registry.ts
@@ -9,6 +9,7 @@ import type { AgentAdapter } from "@langwatch/scenario";
 import type { VoiceTransport } from "~/server/agents/voice/voice-agent.config";
 import type { CallRecord } from "./call-record";
 import { elevenLabsConvaiTransport } from "./transports/elevenlabs-convai.transport";
+import { phoneTransport } from "./transports/phone.transport";
 
 /** The provider key and host a runner reads a conversation back with. Never
  *  reaches the browser — a runner keeps it and returns only the signed URL. */
@@ -25,6 +26,14 @@ export interface VoiceSessionConnect {
 }
 
 export interface VoiceTransportRunner {
+  /**
+   * Guard that runs before any credential lookup, so a transport that cannot
+   * run yet fails with its own typed error rather than the generic
+   * {@link VoiceTransportRunner.missingKeyMessage} key-missing error. Left
+   * unimplemented by transports that are ready; the phone stub throws here
+   * until the voice worker that dials it ships.
+   */
+  assertAvailable?(): void;
   /** Build the SDK agent adapter the pool child drives for this transport. */
   createAgentAdapter(input: {
     agentId: string;
@@ -68,4 +77,5 @@ export const voiceTransportRegistry: Record<
   VoiceTransportRunner
 > = {
   elevenlabs_convai: elevenLabsConvaiTransport,
+  phone: phoneTransport,
 };

--- a/specs/features/agents/voice-phone.feature
+++ b/specs/features/agents/voice-phone.feature
@@ -1,0 +1,58 @@
+Feature: Voice agents: reach an agent by phone
+  As a team whose voice agent answers a phone number
+  I want to register that number as a target in the app
+  So that a scenario run can call it once the voice worker ships
+
+  # @see https://github.com/langwatch/langwatch/issues/8014
+  # Slice 1 is additive and inert: the phone member is selectable behind a flag,
+  # but every run over phone fails with a clear message until the voice worker
+  # that dials it exists.
+
+  # ---------------------------------------------------------------------------
+  # Config schema
+  # ---------------------------------------------------------------------------
+
+  @unit
+  Scenario: A phone target stores its number in E.164 form
+    Given a voice agent config for the phone transport with number " +14155550123 "
+    When the config is validated
+    Then it is accepted and the number is trimmed to "+14155550123"
+
+  @unit
+  Scenario: A phone target rejects a number that is not E.164
+    Given a voice agent config for the phone transport with number "415-555-0123"
+    When the config is validated
+    Then it is rejected
+
+  # ---------------------------------------------------------------------------
+  # Runner (stub until the voice worker ships)
+  # ---------------------------------------------------------------------------
+
+  @integration
+  Scenario: A phone target has no browser call
+    Given the phone transport runner
+    When a browser session mint is attempted
+    Then it fails because phone targets have no browser call
+
+  @unit
+  Scenario: Running a phone target before the voice worker exists fails with a clear message
+    Given the phone transport runner
+    When any of its call methods is invoked
+    Then it fails with a message that points at issue 8014
+
+  # ---------------------------------------------------------------------------
+  # Drawer option gating
+  # ---------------------------------------------------------------------------
+
+  @integration
+  Scenario: The phone option is hidden until the phone targets flag is on
+    Given the voice agent editor with the phone targets flag off
+    Then the "Reached via" list offers no Phone number option
+    When the phone targets flag is on
+    Then the "Reached via" list offers the Phone number option
+
+  @integration
+  Scenario: A phone target's drawer explains why Talk to it is off
+    Given the voice agent editor open on a saved phone target
+    Then the Talk to it button is disabled
+    And its tooltip says browser calls are not available for phone targets


### PR DESCRIPTION
## What

Slice 1 of #8014: the phone transport member, behind a flag, with a stub runner. Additive and inert. Nothing can be dialled yet; the real Twilio runner, project config (allowed callees, max call seconds) and the voice worker are slices 2 and 3, which wait on scenario SDK 2.0.0 (langwatch/scenario#977).

Stacked on #8040 (`feat/voice-drawer-call-decouple`); merge that first.

- `voice-agent.config.ts`: `"phone"` joins `VOICE_TRANSPORTS`; zod branch `{ transport: "phone", phoneNumber }` validated as E.164 (`/^\+[1-9]\d{1,14}$/`) with the message "Enter the number in E.164 form, like +14155550123"; label "Phone number"; provider "twilio". The identity key reuses #8040's helper, so a phone target dedups on `voice:phone:<phoneNumber>`.
- `transports/phone.transport.ts`: a `VoiceTransportRunner` whose every method throws `VoicePhoneTransportUnavailableError` (code `voice_phone_transport_unavailable`, customer fault, message points at #8014). Registered in the server registry; error code registered in `codes.ts` and `presentation.ts`.
- `voice-transport-client.registry.ts`: now `Partial<Record<VoiceTransport, VoiceTransportClient>>` with `getVoiceTransportClient()`. Phone has no browser client, so `TalkToItPanel` shows "This agent is reached by phone. Call it from a scenario run; browser calls are not available for phone targets." instead of the call machine.
- `AgentVoiceEditorDrawer.tsx`: a "Reached via: Phone number" option with an E.164 input, offered only when `release_voice_phone_targets_enabled` is on (new flag, default off, `useVoicePhoneTargetsEnabled`). An existing phone target still renders its fields with the flag off. Its footer "Talk to it" button is disabled for phone with the tooltip "Browser calls are not available for phone targets. Call it from a scenario run."
- `voice-transport.registry.ts` / `voice-session.service.ts`: optional `VoiceTransportRunner.assertAvailable()` runs before any credential lookup in `mintVoiceSession` and the finish path, so a phone target fails with `voice_phone_transport_unavailable` rather than `voice_key_missing`. ElevenLabs does not implement it.
- `specs/features/agents/voice-phone.feature`: six scenarios, all bound. One sentence added to `docs/agent-testing/voice-agents-in-app.mdx` and mirrored in `docs/llms-full.txt`.

## Why

#8014 wants phone targets for voice scenario runs. Landing the schema, the flag, the error code and the UI gate first keeps slices 2 and 3 (Twilio runner + worker) small and lets the SDK major bump be reviewed on its own.

## Human verification

Screenshots below are from the dev app at `557b3f0beb` on a project with the flag flipped through the `FeatureFlag` table.

1. Flag off: the voice agent drawer offers only "ElevenLabs agent" under "Reached via".
   ![flag off](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-8014/drawer-flag-off-elevenlabs-only.png)
2. Flag on: "Phone number" appears; a non-E.164 value shows the validation message; a valid number saves.
   ![flag on, validation](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-8014/drawer-phone-option-e164-validation.png)
   ![phone target saved](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-8014/drawer-phone-target-saved.png)
3. Talk to it on the saved phone target shows the "reached by phone" notice instead of the call machine; the drawer footer button is disabled with the phone tooltip (transcript below).
   ![talk to it notice](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-8014/talk-panel-phone-notice.png)
4. `POST /api/voice/session` for the saved phone target returns HTTP 400 with code `voice_phone_transport_unavailable`, while the same call for an ElevenLabs agent still returns a session: [mint transcript](https://github.com/langwatch/pr-screenshots/blob/main/pr-8014/transcripts/mint-session-phone-target.txt).

## How I can prove I was successful

From `platform/app`:

```
NODE_ENV=test PINO_LOG_LEVEL=warn DATABASE_URL=postgresql://prisma:x@127.0.0.1:1/none pnpm -s exec vitest run \
  src/server/agents/voice/__tests__/voice-agent.config.unit.test.ts \
  src/server/scenarios/voice/__tests__/phone.transport.unit.test.ts \
  src/server/scenarios/voice/__tests__/voice-session.service.unit.test.ts
NODE_ENV=test PINO_LOG_LEVEL=warn DATABASE_URL=postgresql://prisma:x@127.0.0.1:1/none pnpm -s exec vitest run -c vitest.component.config.ts \
  src/components/agents/__tests__/AgentVoiceEditorDrawer.integration.test.tsx \
  src/components/agents/voice/__tests__/TalkToItPanel.integration.test.tsx
pnpm -s exec tsx scripts/check-feature-parity.ts
```

Expected: 43 unit and 24 component tests pass; parity exits 0 with `voice-phone.feature` 6/6 bound. Biome from the app root is clean on the touched files apart from three pre-existing warnings.

## CI follow-up in this PR

The first CI run at the old head caught seven typecheck errors and three new Biome complexity warnings that the local checks had missed. Fixes now in the single commit: a `voiceAgentExternalId` helper (agent id for ElevenLabs, phone number for phone) used wherever identity was read from the config; the run drawer's browser-call target returns null for phone; the scenario prefetcher throws `VoicePhoneTransportUnavailableError` for phone before any credential read; the two transport-record test fixtures gained a `phone` entry; and the voice editor drawer's `resolveInitialForm`, `useVoiceAgentEditor` and `AgentVoiceEditorDrawer` were split so the file stays inside the repo's complexity limits. The CI lint gate reproduced locally reports no new Biome violations against the base.

Refs #8014 #7978
