### PR TITLE
spec(voice): the voice agent testing contract, one file per transport

### DIFF
--- a/platform/app/scripts/check-feature-parity.ts
+++ b/platform/app/scripts/check-feature-parity.ts
@@ -565,6 +565,12 @@ const LEGACY_INERT: string[] = [
   "specs/server/spa-fallback.feature",
   "specs/settings/decompose-model-provider-form-hook.feature",
   "specs/settings/settings-table-responsiveness.feature",
+  // The voice epic's two contract journeys (#7978). Both describe the whole
+  // user journey end to end and neither is built yet, so both scenarios are
+  // @unimplemented and the files are inert by design. They leave this list
+  // when the journeys have e2e tests bound to them.
+  "specs/simulation-testing/voice-agents/testing-elevenlabs-convai.feature",
+  "specs/simulation-testing/voice-agents/testing-phone-agents.feature",
   "specs/setup/docker-dev-worktree-isolation.feature",
   "specs/setup/simplified-setup.feature",
   "specs/skills/agent-insight-skills.feature",

--- a/specs/features/voice-agent-testing.feature
+++ b/specs/features/voice-agent-testing.feature
@@ -1,0 +1,44 @@
+Feature: Voice agent testing
+  As a LangWatch user with a voice agent
+  I want to run simulations against it from scenario authoring
+  So that I can test my agent against my own criteria and review every call
+
+  # @see https://github.com/langwatch/langwatch/issues/7978
+  # @see https://github.com/langwatch/langwatch/issues/8014
+  #
+  # This file is the contract. Everything else is implementation detail.
+
+  Background:
+    Given a LangWatch user with a project
+
+  @e2e
+  Scenario: Simulate a call against a voice agent reachable through ElevenLabs
+    Given the user has a voice agent reachable through ElevenLabs
+    When they go to Simulations and author a scenario against that voice agent
+    And they provide the criteria the simulation is judged on
+    And they run the simulation
+    Then a simulated user talks to their voice agent
+    And the run is judged against their criteria
+    And they can see the results
+    And they can see the whole conversation
+    And they can listen to the entire conversation
+    And they can listen to each part of the conversation
+    And they can see the threads and traces for their agent and for the scenario runner
+    And the traces carry the audio and they can listen to it there
+
+  @e2e
+  Scenario: Simulate a call against a voice agent reachable by phone number
+    Given the user has a voice agent reachable by a phone number alone
+    When they go to Simulations and author a scenario against that voice agent
+    And they provide the criteria the simulation is judged on
+    And they run the simulation
+    Then LangWatch places a call to that phone number
+    And a simulated user talks to their voice agent over the phone
+    And the run is judged against their criteria
+    And they can see the results
+    And they can see the whole conversation
+    And they can listen to the entire conversation
+    And they can listen to each part of the conversation
+    And they can see the threads and traces for their agent and for the scenario runner
+    And the traces carry the audio and they can listen to it there
+    And the traces carry the metadata expected of them

--- a/specs/simulation-testing/voice-agents/testing-elevenlabs-convai.feature
+++ b/specs/simulation-testing/voice-agents/testing-elevenlabs-convai.feature
@@ -10,7 +10,7 @@ Feature: Testing ElevenLabs conversational AI agents
   Background:
     Given a LangWatch user with a project
 
-  @e2e
+  @e2e @unimplemented
   Scenario: Simulate a call against a voice agent reachable through ElevenLabs
     Given the user has a voice agent reachable through ElevenLabs
     When they go to Simulations and author a scenario against that voice agent

--- a/specs/simulation-testing/voice-agents/testing-elevenlabs-convai.feature
+++ b/specs/simulation-testing/voice-agents/testing-elevenlabs-convai.feature
@@ -1,0 +1,26 @@
+Feature: Testing ElevenLabs conversational AI agents
+  As a LangWatch user with a voice agent on ElevenLabs
+  I want to run simulations against it from scenario authoring
+  So that I can test my agent against my own criteria and review every call
+
+  # @see https://github.com/langwatch/langwatch/issues/7978
+  #
+  # This file is the contract. Everything else is implementation detail.
+
+  Background:
+    Given a LangWatch user with a project
+
+  @e2e
+  Scenario: Simulate a call against a voice agent reachable through ElevenLabs
+    Given the user has a voice agent reachable through ElevenLabs
+    When they go to Simulations and author a scenario against that voice agent
+    And they provide the criteria the simulation is judged on
+    And they run the simulation
+    Then a simulated user talks to their voice agent
+    And the run is judged against their criteria
+    And they can see the results
+    And they can see the whole conversation
+    And they can listen to the entire conversation
+    And they can listen to each part of the conversation
+    And they can see the threads and traces for their agent and for the scenario runner
+    And the traces carry the audio and they can listen to it there

--- a/specs/simulation-testing/voice-agents/testing-elevenlabs-convai.feature
+++ b/specs/simulation-testing/voice-agents/testing-elevenlabs-convai.feature
@@ -19,8 +19,9 @@ Feature: Testing ElevenLabs conversational AI agents
     Then a simulated user talks to their voice agent
     And the run is judged against their criteria
     And they can see the results
-    And they can see the whole conversation
-    And they can listen to the entire conversation
+    And they can see the whole conversation as a transcript
+    And they can listen to the whole call
     And they can listen to each part of the conversation
     And they can see the threads and traces for their agent and for the scenario runner
     And the traces carry the audio and they can listen to it there
+    And the traces carry all the metadata the call makes available

--- a/specs/simulation-testing/voice-agents/testing-phone-agents.feature
+++ b/specs/simulation-testing/voice-agents/testing-phone-agents.feature
@@ -11,7 +11,7 @@ Feature: Testing voice agents by phone
   Background:
     Given a LangWatch user with a project
 
-  @e2e
+  @e2e @unimplemented
   Scenario: Simulate a call against a voice agent reachable by phone number
     Given the user has a voice agent reachable by a phone number alone
     When they go to Simulations and author a scenario against that voice agent

--- a/specs/simulation-testing/voice-agents/testing-phone-agents.feature
+++ b/specs/simulation-testing/voice-agents/testing-phone-agents.feature
@@ -21,9 +21,10 @@ Feature: Testing voice agents by phone
     And a simulated user talks to their voice agent over the phone
     And the run is judged against their criteria
     And they can see the results
-    And they can see the whole conversation
-    And they can listen to the entire conversation
+    And they can see the whole conversation as a transcript
+    And they can listen to the whole call
     And they can listen to each part of the conversation
     And they can see the threads and traces for their agent and for the scenario runner
+    And the call is one trace for its whole length
     And the traces carry the audio and they can listen to it there
-    And the traces carry the metadata expected of them
+    And the traces carry all the metadata the call makes available

--- a/specs/simulation-testing/voice-agents/testing-phone-agents.feature
+++ b/specs/simulation-testing/voice-agents/testing-phone-agents.feature
@@ -1,5 +1,5 @@
-Feature: Voice agent testing
-  As a LangWatch user with a voice agent
+Feature: Testing voice agents by phone
+  As a LangWatch user with a voice agent reachable by phone
   I want to run simulations against it from scenario authoring
   So that I can test my agent against my own criteria and review every call
 
@@ -10,21 +10,6 @@ Feature: Voice agent testing
 
   Background:
     Given a LangWatch user with a project
-
-  @e2e
-  Scenario: Simulate a call against a voice agent reachable through ElevenLabs
-    Given the user has a voice agent reachable through ElevenLabs
-    When they go to Simulations and author a scenario against that voice agent
-    And they provide the criteria the simulation is judged on
-    And they run the simulation
-    Then a simulated user talks to their voice agent
-    And the run is judged against their criteria
-    And they can see the results
-    And they can see the whole conversation
-    And they can listen to the entire conversation
-    And they can listen to each part of the conversation
-    And they can see the threads and traces for their agent and for the scenario runner
-    And the traces carry the audio and they can listen to it there
 
   @e2e
   Scenario: Simulate a call against a voice agent reachable by phone number


### PR DESCRIPTION
The voice epic has many feature files and no single statement of what the product must do. This PR adds that statement: one file per transport, one end-to-end journey each, no implementation detail.

**The contract**

- `specs/simulation-testing/voice-agents/testing-elevenlabs-convai.feature`
- `specs/simulation-testing/voice-agents/testing-phone-agents.feature`

A user with a voice agent authors a scenario against it, gives the criteria, runs the simulation, and then reviews the call: transcript, full recording, each part of the conversation, threads and traces for their agent and the runner, audio on the traces, and all the metadata the call makes available. The phone journey adds the placed call and states that a call is one trace for its whole length.

Everything else in the voice epic, including `voice-agents-v1.feature`, `voice-phone.feature` and the Helm work, is implementation detail measured against these two files.

**Decisions settled here**

- Whole conversation means transcript and recording.
- Traces carry all metadata the call makes available.
- A phone call is one trace. We dial a-leg, so one media socket holds open for the call.

**Why both files are registered as inert**

Neither journey has an end-to-end test yet, so both scenarios are `@unimplemented`. The parity gate refuses a file whose scenarios are all unimplemented unless it is registered, so both files join `LEGACY_INERT` with a reason and an exit condition. They leave that list when tests bind to them. `pnpm check:feature-parity` passes.

**Known gaps against the contract**

- Phone is not built on main. The dialer lives on `feat/voice-phone-twilio-dialer`.
- Phone has no recording. We never request one and never stitch one.
- The phone path discards metadata it already receives, and Twilio sends no call status because we register no callback.
- Thread grouping is wired for browser calls and unverified for simulation runs.
- No public endpoint is provisioned for call media on SaaS or self-hosted.

**Open questions**

- Is self-hosted in scope for phone v1?
- Retire the 7 duplicate end-to-end journeys in `voice-agents-v1.feature`?

Refs #7978, #8014

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UrzVy56QXMJEFc6NB9uQJu


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added planned end-to-end test specifications for simulations involving ElevenLabs conversational voice agents.
  - Added planned end-to-end test specifications for phone-based voice agents, including calls, conversations, transcripts, audio playback, traces, and metadata.
  - These scenarios are currently inactive and marked as unimplemented until the corresponding workflows are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->