### PR TITLE
feat(governance): withdraw a pulled charge the provider reissued elsewhere

### DIFF
--- a/platform/app/ee/event-sourcing/pipelineSet.ts
+++ b/platform/app/ee/event-sourcing/pipelineSet.ts
@@ -1,6 +1,7 @@
 import { createIngestionPullProcessingPipeline } from "@ee/event-sourcing/pipelines/ingestion-pull-processing";
 import type { IngestionPullOutcomeCommands } from "@ee/event-sourcing/pipelines/ingestion-pull-processing/process-manager/ingestionPullEffects";
 import { createPulledUsageProcessingPipeline } from "@ee/event-sourcing/pipelines/pulled-usage-processing";
+import type { PulledUsageRetractedEventData } from "@ee/event-sourcing/pipelines/pulled-usage-processing/schemas/events";
 import type { PulledUsageLedgerProcessDeps } from "@ee/governance/process-manager/pulledUsageLedger.process";
 import type { GovernanceCostRollupState } from "@ee/governance/projections/governanceCostRollup.foldProjection";
 import { createAgentListingPort } from "@ee/governance/services/pullers/agentListingPort";
@@ -27,8 +28,16 @@ export interface EnterprisePipelineSetConfig {
   /**
    * The pulled-usage ledger writer. Absent without ClickHouse — the pipeline
    * still records every observation, only the ledger row is skipped.
+   *
+   * Missing its withdrawal dispatcher, and that is the type saying so. The
+   * command it sends belongs to the pipeline this dep is being passed INTO, so
+   * the composition root cannot hold it; `registerPulledUsagePipeline`
+   * completes the object once the pipeline it closes over exists.
    */
-  pulledUsageLedger?: PulledUsageLedgerProcessDeps;
+  pulledUsageLedger?: Omit<
+    PulledUsageLedgerProcessDeps,
+    "sendRetractPulledUsage"
+  >;
   /**
    * ADR-128's daily cost rollup store. Absent without ClickHouse — the
    * pipeline still records every observation, only the summary is skipped.
@@ -140,15 +149,46 @@ function registerIngestionPullPipeline(
  * is per-source and per-run, this one is per usage item, and a per-run stream
  * cannot carry a per-item price. The puller effect dispatches
  * `recordPulledUsage` in the same loop that writes the OCSF audit row.
+ *
+ * Its process manager also dispatches back INTO this pipeline, which is the
+ * knot the holder below unties: the withdrawal command exists only once the
+ * pipeline is registered, and registering it needs the process manager that
+ * sends it. The same shape `spendSettlement` uses, for the same reason.
  */
 function registerPulledUsagePipeline(deps: EnterprisePipelineRuntimeDeps) {
+  let sendRetract:
+    | ((data: PulledUsageRetractedEventData) => Promise<void>)
+    | null = null;
+  const ledger = deps.pulledUsageLedger
+    ? {
+        ...deps.pulledUsageLedger,
+        sendRetractPulledUsage: async (
+          data: PulledUsageRetractedEventData,
+        ): Promise<void> => {
+          if (!sendRetract) {
+            // Unreachable in composition order, and thrown rather than
+            // swallowed because the outbox retries a throw. Dropping the
+            // withdrawal would leave two live versions of one charge, which
+            // is money reported twice.
+            throw new Error(
+              "pulled usage retraction dispatched before its pipeline was registered",
+            );
+          }
+          await sendRetract(data);
+        },
+      }
+    : undefined;
   const pipeline = deps.eventSourcing.register(
     createPulledUsageProcessingPipeline({
-      ledger: deps.pulledUsageLedger,
+      ledger,
       costRollupStore: deps.governanceCostRollupStore,
     }),
   );
-  return { commands: mapCommands(pipeline.commands) };
+  const commands = mapCommands(pipeline.commands);
+  sendRetract = async (data) => {
+    await commands.retractPulledUsage(data as never);
+  };
+  return { commands };
 }
 
 /**
@@ -203,6 +243,7 @@ export function createNoopEnterprisePipelineCommands(): EnterprisePipelineComman
     },
     pulledUsage: {
       recordPulledUsage: noop,
+      retractPulledUsage: noop,
     },
   } satisfies EnterprisePipelineCommands;
 }

--- a/platform/app/ee/event-sourcing/pipelines/pulled-usage-processing/commands.ts
+++ b/platform/app/ee/event-sourcing/pipelines/pulled-usage-processing/commands.ts
@@ -9,7 +9,9 @@ import {
 } from "./schemas/constants";
 import {
   type PulledUsageObservedEventData,
+  type PulledUsageRetractedEventData,
   pulledUsageObservedEventDataSchema,
+  pulledUsageRetractedEventDataSchema,
 } from "./schemas/events";
 
 /**
@@ -55,6 +57,61 @@ function pulledUsageObservationKey(data: PulledUsageObservedEventData): string {
     data.observedAtMs,
   ].join(":");
 }
+
+/**
+ * The retraction key — what makes one withdrawal a distinct fact.
+ *
+ * Prefixed, and the prefix is the point. `findCostEventsForDay` collapses the
+ * day's events on `(TenantId, AggregateType, AggregateId, IdempotencyKey)`,
+ * and a retraction shares its aggregate id with every observation of the same
+ * charge. A key that could collide with an observation's would let one of the
+ * two silently replace the other in the comparator's read of the day; the
+ * literal makes that impossible by construction rather than by luck.
+ *
+ * The rest is the RETRACTED cell's address plus the observation instant that
+ * superseded it. Address, because two different cells of one charge are two
+ * different withdrawals; instant, because a charge corrected twice must
+ * withdraw twice. Re-delivering the same superseding observation reproduces
+ * the same key and is dropped here, which is what keeps an at-least-once
+ * outbox from filing the one withdrawal twice.
+ */
+function pulledUsageRetractionKey(data: PulledUsageRetractedEventData): string {
+  return [
+    "retract",
+    data.restatementKey,
+    data.currencyCode,
+    data.agentId,
+    data.rawActorId,
+    data.model,
+    data.observedAtMs,
+  ].join(":");
+}
+
+/**
+ * Withdraws the version of a charge that a later pull superseded.
+ *
+ * Same `aggregateId` as the observation it corrects — the restatement key —
+ * because the fold has to see the withdrawal and the charge on one ordered
+ * stream. A retraction on its own stream would be applied against whatever
+ * the projection happened to hold at the time, which is the race the single
+ * stream exists to remove.
+ */
+export const RetractPulledUsageCommand = defineCommand({
+  commandType: PULLED_USAGE_COMMAND_TYPES.RETRACT,
+  eventType: PULLED_USAGE_EVENT_TYPES.RETRACTED,
+  eventVersion: PULLED_USAGE_EVENT_VERSIONS.RETRACTED,
+  aggregateType: PULLED_USAGE_AGGREGATE_TYPE,
+  schema: pulledUsageRetractedEventDataSchema,
+  aggregateId: (data) => data.restatementKey,
+  idempotencyKey: (data) => pulledUsageRetractionKey(data),
+  spanAttributes: (data) => ({
+    "payload.source": data.source,
+    "payload.ingestion_source_id": data.ingestionSourceId,
+    "payload.currency_code": data.currencyCode,
+    "payload.retracted_model": data.model,
+  }),
+  makeJobId: (data) => pulledUsageRetractionKey(data),
+});
 
 /**
  * Records one priced pulled usage item.

--- a/platform/app/ee/event-sourcing/pipelines/pulled-usage-processing/pipeline.ts
+++ b/platform/app/ee/event-sourcing/pipelines/pulled-usage-processing/pipeline.ts
@@ -13,7 +13,10 @@ import {
 import { definePipeline } from "~/server/event-sourcing";
 import type { FoldProjectionStore } from "~/server/event-sourcing/projections/foldProjection.types";
 
-import { RecordPulledUsageCommand } from "./commands";
+import {
+  RecordPulledUsageCommand,
+  RetractPulledUsageCommand,
+} from "./commands";
 import {
   PULLED_USAGE_AGGREGATE_TYPE,
   PULLED_USAGE_PIPELINE_NAME,
@@ -28,7 +31,12 @@ import type { PulledUsageProcessingEvent } from "./schemas/events";
  * figure it corrects instead of beside it.
  *
  * Write surface: `recordPulledUsage`, dispatched from the puller effect in the
- * same loop that writes the OCSF audit row.
+ * same loop that writes the OCSF audit row, and `retractPulledUsage`,
+ * dispatched by this pipeline's OWN process manager when it recognises that a
+ * charge has been reissued into a different rollup cell. The second command is
+ * registered unconditionally even though only the process manager sends it: a
+ * deployment that drops the ledger dep still has to be able to APPLY a
+ * withdrawal that an earlier deployment wrote to the log.
  *
  * Process manager: `pulledUsageLedger` — the sole writer of pulled cost into
  * `gateway_budget_ledger_events`. Optional, and absent it the pipeline still
@@ -52,7 +60,8 @@ export function createPulledUsageProcessingPipeline(
   let pipeline = definePipeline<PulledUsageProcessingEvent>()
     .withName(PULLED_USAGE_PIPELINE_NAME)
     .withAggregateType(PULLED_USAGE_AGGREGATE_TYPE)
-    .withCommand("recordPulledUsage", RecordPulledUsageCommand);
+    .withCommand("recordPulledUsage", RecordPulledUsageCommand)
+    .withCommand("retractPulledUsage", RetractPulledUsageCommand);
   if (deps.costRollupStore) {
     pipeline = pipeline.withFoldProjection(
       GOVERNANCE_COST_ROLLUP_PROJECTION_NAME,

--- a/platform/app/ee/event-sourcing/pipelines/pulled-usage-processing/schemas/constants.ts
+++ b/platform/app/ee/event-sourcing/pipelines/pulled-usage-processing/schemas/constants.ts
@@ -36,10 +36,20 @@ export type PulledUsageProcessingEventType =
 
 export const PULLED_USAGE_COMMAND_TYPES = {
   RECORD: "lw.obs.pulled_usage.record",
+  /**
+   * Withdraws the version of a charge that a later pull superseded.
+   *
+   * Separate from RECORD rather than a flag on it because the two carry
+   * different addresses: RECORD names the cell the charge is landing in, and
+   * this names the cell it is leaving. One command that meant both would have
+   * to guess which of its dimensions were the address.
+   */
+  RETRACT: "lw.obs.pulled_usage.retract",
 } as const;
 
 export const PULLED_USAGE_PROCESSING_COMMAND_TYPES = [
   PULLED_USAGE_COMMAND_TYPES.RECORD,
+  PULLED_USAGE_COMMAND_TYPES.RETRACT,
 ] as const;
 
 export type PulledUsageProcessingCommandType =

--- a/platform/app/ee/governance/process-manager/__tests__/pulledUsageLedger.process.unit.test.ts
+++ b/platform/app/ee/governance/process-manager/__tests__/pulledUsageLedger.process.unit.test.ts
@@ -1,0 +1,328 @@
+// SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+
+/**
+ * The reissue detector: what the process manager WITHDRAWS, and what it
+ * refuses to.
+ *
+ * The definition under test is the exact one the runtime mounts, built through
+ * the pipeline's own applier and driven through the real process service and
+ * the real outbox dispatcher, so the ordering these assertions depend on is
+ * the runtime's rather than the test's.
+ *
+ * Every version of one charge arrives on ONE process instance, because the
+ * process key is the restatement key. That is the whole mechanism: it is the
+ * only place where the cell a charge sits in and the cell the next pull is
+ * about to land in are ever both in scope.
+ *
+ * Spec: specs/governance/governance-cost-rollup.feature
+ * Decision: ADR-088, ADR-128.
+ */
+
+import { PULLED_USAGE_EVENT_TYPES } from "@ee/event-sourcing/pipelines/pulled-usage-processing/schemas/constants";
+import type { PulledUsageObservedEventData } from "@ee/event-sourcing/pipelines/pulled-usage-processing/schemas/events";
+import { nanoid } from "nanoid";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { buildProcessManager } from "~/server/event-sourcing/pipeline/processBuilder";
+import {
+  InMemoryProcessStore,
+  type ProcessDefinition,
+  ProcessManagerService,
+} from "~/server/event-sourcing/process-manager";
+import { OutboxDispatcherService } from "~/server/event-sourcing/process-manager/outbox/outboxDispatcherService";
+import type { ProcessEventEnvelope } from "~/server/event-sourcing/process-manager/processManager.types";
+import {
+  buildIntentHandlers,
+  buildProcessDefinition,
+} from "~/server/event-sourcing/process-manager/processRuntime";
+
+import {
+  PULLED_USAGE_LEDGER_PROCESS_NAME,
+  type PulledUsageLedgerProcessDeps,
+  type PulledUsageLedgerState,
+  pulledUsageLedgerPM,
+} from "../pulledUsageLedger.process";
+
+const ns = `pulled-pm-${nanoid(8)}`;
+const T0 = Date.UTC(2026, 7, 3, 0, 0, 0);
+const GOV_PROJECT = `proj-gov-${ns}`;
+const ORG_ID = `org-${ns}`;
+const TEAM_ID = `team-${ns}`;
+const SOURCE = "azure_cost_management";
+const INGESTION_SOURCE_ID = `src-${ns}`;
+
+/** The day the charge falls in. Every version below corrects THIS day. */
+const OCCURRED_AT = Date.UTC(2026, 7, 1, 0, 0, 0);
+
+let store: InMemoryProcessStore;
+let service: ProcessManagerService<PulledUsageLedgerState>;
+let dispatcher: OutboxDispatcherService;
+let sendRetractPulledUsage: ReturnType<typeof vi.fn>;
+let insertPulledUsageRows: ReturnType<typeof vi.fn>;
+let retractionEnabled: ReturnType<typeof vi.fn>;
+let clock: number;
+
+/**
+ * One charge, one restatement key, one process instance. Shared across every
+ * test so that every observation in a test lands on the same stream — which is
+ * exactly the production shape, since the key is the aggregate id.
+ */
+const RESTATEMENT_KEY = `azure:${ns}:sub-1:2026-08-01`;
+
+function observation(
+  overrides: Partial<PulledUsageObservedEventData> = {},
+): PulledUsageObservedEventData {
+  return {
+    itemKey: `item-${ns}`,
+    restatementKey: RESTATEMENT_KEY,
+    source: SOURCE,
+    ingestionSourceId: INGESTION_SOURCE_ID,
+    organizationId: ORG_ID,
+    teamId: TEAM_ID,
+    projectId: null,
+    model: "azure/meter-cognitive-services",
+    tokensInput: 0,
+    tokensOutput: 0,
+    tokensCacheRead: 0,
+    tokensCacheWrite: 0,
+    costNanoMinor: 12_000_000_000,
+    currencyCode: "USD",
+    costNanoUsd: 12_000_000_000,
+    rateVersion: null,
+    costBasis: "provider_reported",
+    costStatus: "exact",
+    rawActorId: "",
+    agentId: "",
+    occurredAtMs: OCCURRED_AT,
+    observedAtMs: T0,
+    ...overrides,
+  };
+}
+
+/**
+ * Delivers one observation the way the live subscriber does, on the process
+ * key the command's `aggregateId` gives it.
+ */
+async function observe(data: PulledUsageObservedEventData): Promise<void> {
+  const envelope: ProcessEventEnvelope = {
+    eventId: `obs:${data.restatementKey}:${data.observedAtMs}`,
+    eventType: PULLED_USAGE_EVENT_TYPES.OBSERVED,
+    occurredAt: data.occurredAtMs,
+    tenantId: GOV_PROJECT,
+    projectId: GOV_PROJECT,
+    processKey: data.restatementKey,
+    payload: data as unknown as Record<string, unknown>,
+  };
+  await service.handleEvent({ envelope, now: clock });
+}
+
+async function drainOutbox(passes = 4): Promise<void> {
+  for (let i = 0; i < passes; i++) {
+    clock += 1_000;
+    await dispatcher.runOnce({ now: clock, limit: 50 });
+  }
+}
+
+beforeEach(() => {
+  clock = T0;
+  sendRetractPulledUsage = vi.fn().mockResolvedValue(undefined);
+  insertPulledUsageRows = vi.fn().mockResolvedValue(undefined);
+  retractionEnabled = vi.fn().mockResolvedValue(true);
+  const deps: PulledUsageLedgerProcessDeps = {
+    budgetCHRepository: {
+      insertPulledUsageRows,
+    } as unknown as PulledUsageLedgerProcessDeps["budgetCHRepository"],
+    sendRetractPulledUsage:
+      sendRetractPulledUsage as unknown as PulledUsageLedgerProcessDeps["sendRetractPulledUsage"],
+    retractionEnabled:
+      retractionEnabled as unknown as PulledUsageLedgerProcessDeps["retractionEnabled"],
+  };
+  store = new InMemoryProcessStore();
+  service = new ProcessManagerService<PulledUsageLedgerState>({
+    store,
+    definition: buildProcessDefinition(
+      buildProcessManager({
+        name: PULLED_USAGE_LEDGER_PROCESS_NAME,
+        applier: pulledUsageLedgerPM(deps),
+      }).config,
+    ) as ProcessDefinition<PulledUsageLedgerState>,
+  });
+  dispatcher = new OutboxDispatcherService({
+    store,
+    handlers: buildIntentHandlers(
+      buildProcessManager({
+        name: PULLED_USAGE_LEDGER_PROCESS_NAME,
+        applier: pulledUsageLedgerPM(deps),
+      }).config,
+    ),
+    processNames: [PULLED_USAGE_LEDGER_PROCESS_NAME],
+  });
+});
+
+describe("recognising a reissued charge", () => {
+  describe("given a day's bill already pulled in one currency", () => {
+    /** @scenario A bill reissued in another currency is withdrawn by the pull that finds it */
+    it("withdraws the first currency's version when the next pull returns another currency", async () => {
+      await observe(observation({ currencyCode: "EUR", costNanoUsd: null }));
+      await observe(
+        observation({
+          currencyCode: "USD",
+          costNanoMinor: 13_000_000_000,
+          costNanoUsd: 13_000_000_000,
+          observedAtMs: T0 + 86_400_000,
+        }),
+      );
+      await drainOutbox();
+
+      expect(sendRetractPulledUsage).toHaveBeenCalledTimes(1);
+      const withdrawal = sendRetractPulledUsage.mock.calls[0]?.[0];
+      // Addressed to the cell being LEFT, not the one being landed in. A
+      // withdrawal carrying the new currency would empty the cell that holds
+      // the correct figure and leave the superseded one standing, which is the
+      // same double-count with the surviving version chosen at random.
+      expect(withdrawal).toMatchObject({
+        restatementKey: RESTATEMENT_KEY,
+        currencyCode: "EUR",
+        costNanoMinor: 0,
+      });
+      // Dated to the day it CORRECTS. The daily check re-derives a day from
+      // the events falling inside it, so a withdrawal stamped with the day the
+      // correction ARRIVED is never read by the day it was meant to fix.
+      expect(withdrawal.occurredAtMs).toBe(OCCURRED_AT);
+      // Ordered by the pull that superseded it, which is strictly later than
+      // the version being withdrawn — the fold drops a withdrawal that is not.
+      expect(withdrawal.observedAtMs).toBe(T0 + 86_400_000);
+    });
+
+    /**
+     * The euro version is precisely the one the ledger has no dollar figure
+     * for, so a detector that gave up where the ledger does would be blind to
+     * its own headline case.
+     */
+    it("remembers a version it could not write a ledger row for", async () => {
+      await observe(observation({ currencyCode: "EUR", costNanoUsd: null }));
+
+      expect(insertPulledUsageRows).not.toHaveBeenCalled();
+      const instance = await store.findByRef<PulledUsageLedgerState>({
+        ref: {
+          processName: PULLED_USAGE_LEDGER_PROCESS_NAME,
+          projectId: GOV_PROJECT,
+          processKey: RESTATEMENT_KEY,
+        },
+      });
+      expect(instance?.state.filedCell).toMatchObject({ currencyCode: "EUR" });
+    });
+  });
+
+  describe("given a charge whose reissue has already been withdrawn", () => {
+    /** @scenario Pulling the corrected day again withdraws nothing */
+    it("withdraws nothing when the corrected day is pulled again unchanged", async () => {
+      await observe(observation({ currencyCode: "EUR", costNanoUsd: null }));
+      await observe(
+        observation({ currencyCode: "USD", observedAtMs: T0 + 86_400_000 }),
+      );
+      await drainOutbox();
+      expect(sendRetractPulledUsage).toHaveBeenCalledTimes(1);
+
+      // The same corrected day, pulled again. A later instant, because the
+      // observation key includes it and an unchanged re-pull still appends.
+      await observe(
+        observation({ currencyCode: "USD", observedAtMs: T0 + 172_800_000 }),
+      );
+      await drainOutbox();
+
+      // Asserted on the SEND rather than on a total, because a second
+      // withdrawal would move no money — it would empty a cell already at
+      // zero — while the day's revision markers climbed forever against a
+      // correction that happened once.
+      expect(sendRetractPulledUsage).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("given a charge already reissued once", () => {
+    /** @scenario A charge reissued a second time is compared against where it sits now */
+    it("withdraws the version it currently sits in, not the one it started in", async () => {
+      await observe(observation({ currencyCode: "EUR", costNanoUsd: null }));
+      await observe(
+        observation({ currencyCode: "USD", observedAtMs: T0 + 86_400_000 }),
+      );
+      await observe(
+        observation({
+          currencyCode: "USD",
+          rawActorId: "someone-else",
+          observedAtMs: T0 + 172_800_000,
+        }),
+      );
+      await drainOutbox();
+
+      expect(sendRetractPulledUsage).toHaveBeenCalledTimes(2);
+      const second = sendRetractPulledUsage.mock.calls[1]?.[0];
+      // The MIDDLE version. Comparing against where the charge first landed
+      // would withdraw the euro cell a second time — a cell the first
+      // withdrawal already emptied — and leave the dollar version live on top
+      // of the newest one.
+      expect(second).toMatchObject({ currencyCode: "USD", rawActorId: "" });
+    });
+  });
+
+  describe("given a period that holds more than one model", () => {
+    /** @scenario A reissue is recognised from the currency, the agent and the spender only */
+    it("withdraws nothing when only the model differs", async () => {
+      await observe(observation({ model: "azure/meter-a" }));
+      await observe(
+        observation({
+          model: "azure/meter-b",
+          observedAtMs: T0 + 3_600_000,
+        }),
+      );
+      await drainOutbox();
+
+      // An adapter that does not list the model among its dimensions gives
+      // both models of one period the SAME restatement key, so this arrives on
+      // this very instance — the premise is reachable, not hypothetical.
+      // Withdrawing here would zero money that was really spent, which is
+      // strictly worse than the double-count the detector exists to prevent.
+      expect(sendRetractPulledUsage).not.toHaveBeenCalled();
+      expect(insertPulledUsageRows).toHaveBeenCalledTimes(2);
+    });
+
+    it("still addresses the superseded model when the currency moves too", async () => {
+      await observe(observation({ model: "azure/meter-a" }));
+      await observe(
+        observation({
+          model: "azure/meter-b",
+          currencyCode: "EUR",
+          costNanoUsd: null,
+          observedAtMs: T0 + 3_600_000,
+        }),
+      );
+      await drainOutbox();
+
+      // The model is not a TRIGGER, but it is part of the cell's address. A
+      // withdrawal carrying the new model would empty a cell that never held
+      // this charge and leave the one that does untouched.
+      expect(sendRetractPulledUsage).toHaveBeenCalledTimes(1);
+      expect(sendRetractPulledUsage.mock.calls[0]?.[0]).toMatchObject({
+        model: "azure/meter-a",
+        currencyCode: "USD",
+      });
+    });
+  });
+
+  describe("given the withdrawal switch is off for the organization", () => {
+    it("detects the reissue but withdraws nothing", async () => {
+      retractionEnabled.mockResolvedValue(false);
+
+      await observe(observation({ currencyCode: "EUR", costNanoUsd: null }));
+      await observe(
+        observation({ currencyCode: "USD", observedAtMs: T0 + 86_400_000 }),
+      );
+      await drainOutbox();
+
+      // Read at EMIT time and per organization. A gate resolved when the
+      // process was registered would keep withdrawing for as long as the
+      // process lived after somebody switched it off.
+      expect(retractionEnabled).toHaveBeenCalledWith(ORG_ID);
+      expect(sendRetractPulledUsage).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/platform/app/ee/governance/process-manager/pulledUsageLedger.process.ts
+++ b/platform/app/ee/governance/process-manager/pulledUsageLedger.process.ts
@@ -4,6 +4,7 @@ import { PULLED_USAGE_EVENT_TYPES } from "@ee/event-sourcing/pipelines/pulled-us
 import type {
   PulledUsageObservedEventData,
   PulledUsageProcessingEvent,
+  PulledUsageRetractedEventData,
 } from "@ee/event-sourcing/pipelines/pulled-usage-processing/schemas/events";
 import { createLogger } from "@langwatch/observability";
 import { z } from "zod";
@@ -25,11 +26,32 @@ export const PULLED_USAGE_LEDGER_PROCESS_NAME = "pulledUsageLedger" as const;
  * order. That is what makes "newest wins" a property of the stream rather than
  * a race between two writers.
  *
- * It carries no state, and that is the point rather than an omission. The
- * gateway's debit process manager has to join an admission to an outcome
- * because the price and the attribution arrive in different events; a pulled
- * record is already whole when it is minted — priced, attributed, timestamped
- * — so there is nothing to wait for and nothing to remember.
+ * It remembers exactly one thing: the rollup cell this charge was last filed
+ * in. Nothing about writing the ledger needs it — a pulled record is already
+ * whole when it is minted, priced and attributed and timestamped, so the
+ * ledger write has nothing to wait for. It is remembered because NOTHING ELSE
+ * CAN. The restatement key deliberately excludes the currency, the agent and
+ * the spender, so a provider reissuing one charge under any of those files it
+ * in a different rollup cell and leaves the first version standing with its
+ * money; a total across the day then carries the one bill twice. Recognising
+ * that needs the previous cell and the new one side by side, and this is the
+ * only place both are ever in scope: the aggregate is the restatement key, so
+ * every version of one charge runs through this one instance, in order.
+ *
+ * The projection cannot do it — a fold sees one cell, never the pair, and a
+ * projection that emitted would write into the log it is rebuilt from. The
+ * puller cannot do it — it holds the new figure and has never read the old
+ * one. Neither is a layering objection; both are simply blind to the
+ * comparison.
+ *
+ * This state is NOT reconstructible from the event log, and that is a real
+ * cost rather than a hidden one. Losing the process store loses the memory of
+ * where each charge sits, and the next pull of an already-corrected charge
+ * finds nothing to compare against and withdraws nothing. That fails to the
+ * defect this exists to fix, never past it: a forgotten charge is a
+ * double-count nobody withdrew, not a withdrawal of money that was really
+ * spent. It does not touch the rebuild invariant either, which binds
+ * projection tables — this is not one.
  *
  * What it deliberately does NOT do: resolve budgets, detect threshold
  * crossings, or emit BUDGET_UPDATED. Money spent outside the gateway cannot be
@@ -70,8 +92,114 @@ export const writePulledUsageSchema = z.object({
 });
 export type WritePulledUsagePayload = z.infer<typeof writePulledUsageSchema>;
 
+/**
+ * The withdrawal an intent carries, which is the SUPERSEDED cell's address.
+ *
+ * Defaulted on `writePulledUsageSchema`'s rule and for its reason: this is a
+ * durable outbox row, read back by whatever build drains it.
+ *
+ * `model` rides along without being compared. It is part of the cell's
+ * address, so a withdrawal that omitted it would empty the wrong cell — but a
+ * charge whose model alone changed is NOT a reissue, and the comparison below
+ * is what draws that line.
+ */
+export const retractPulledUsageSchema = z.object({
+  restatement_key: z.string(),
+  /** The org's hidden governance project — the storage partition. */
+  tenant_id: z.string(),
+  organization_id: z.string(),
+  source: z.string(),
+  ingestion_source_id: z.string(),
+  /** The superseded cell's address. Every field of it, stated. */
+  model: z.string().default(""),
+  currency_code: z.string().default("USD"),
+  agent_id: z.string().default(""),
+  raw_actor_id: z.string().default(""),
+  /** The day this CORRECTS, never the day the correction arrived. */
+  occurred_at_ms: z.number().int().positive(),
+  /** When the superseding pull happened. The ordering field. */
+  observed_at_ms: z.number().int().positive(),
+});
+
+export type RetractPulledUsagePayload = z.infer<
+  typeof retractPulledUsageSchema
+>;
+
+/**
+ * Where one charge is filed: the parts of its rollup cell that can move while
+ * its restatement key stays the same.
+ *
+ * The rest of the cell's address cannot move for a given key — the tenant, the
+ * day, the source and the ingestion source are all fixed by the key itself or
+ * by the period it names — so remembering them would remember a constant.
+ */
+interface FiledCell {
+  model: string;
+  currencyCode: string;
+  agentId: string;
+  rawActorId: string;
+  /**
+   * The day the superseded version sat in. Carried rather than taken from the
+   * new observation: it is the retraction's `occurredAtMs`, and that field
+   * dates the withdrawal to the day it CORRECTS.
+   */
+  occurredAtMs: number;
+}
+
+export interface PulledUsageLedgerState {
+  /** Null until this charge's first observation. */
+  filedCell: FiledCell | null;
+}
+
+export const INITIAL_PULLED_USAGE_LEDGER_STATE: PulledUsageLedgerState = {
+  filedCell: null,
+};
+
+/**
+ * Whether a charge has been reissued into a different cell.
+ *
+ * The currency, the agent and the spender, and deliberately NOT the model.
+ * Those three are exactly what the restatement key excludes, so a change in
+ * any of them means one charge now occupies two cells. The model is excluded
+ * for the opposite reason: an adapter that does not list the model among its
+ * dimensions gives every model of one period the SAME restatement key, so a
+ * second model arriving is ordinary spend rather than a correction, and
+ * withdrawing on it would zero money that was really spent. That failure is
+ * strictly worse than the double-count this whole path exists to prevent —
+ * a missing withdrawal overstates a bill, a wrong one destroys a record of
+ * money the customer actually paid.
+ */
+function isReissuedElsewhere(
+  filed: FiledCell,
+  next: Pick<
+    PulledUsageObservedEventData,
+    "currencyCode" | "agentId" | "rawActorId"
+  >,
+): boolean {
+  return (
+    filed.currencyCode !== next.currencyCode ||
+    filed.agentId !== next.agentId ||
+    filed.rawActorId !== next.rawActorId
+  );
+}
+
 export interface PulledUsageLedgerProcessDeps {
   budgetCHRepository: GatewayBudgetClickHouseRepository;
+  /**
+   * Injected lazily so the process manager can be registered while the
+   * pipeline that owns the command is still being built — the same reason
+   * `spendSettlement` takes its send this way.
+   */
+  sendRetractPulledUsage: (
+    data: PulledUsageRetractedEventData,
+  ) => Promise<void>;
+  /**
+   * Read at EMIT time, per organization, never cached across a run. A kill
+   * switch consulted when the process manager was registered would still be
+   * emitting withdrawals long after somebody turned it off, which is the one
+   * thing a kill switch is for.
+   */
+  retractionEnabled: (organizationId: string) => Promise<boolean>;
 }
 
 /**
@@ -87,6 +215,66 @@ export function pulledUsageScopeId(
   record: Pick<PulledUsageObservedEventData, "organizationId" | "teamId">,
 ): string {
   return record.teamId ?? record.organizationId;
+}
+
+/**
+ * Withdraws the superseded version, behind the outbox lease.
+ *
+ * Here rather than in the wake handler because a wake handler must be pure and
+ * synchronous — the commit that persists the evolution is what fences racing
+ * workers — so the flag read and the send run as an intent, on
+ * `spendSettlement`'s precedent.
+ *
+ * `costNanoMinor` is stated as zero rather than omitted, and that is
+ * load-bearing: the read path falls back to reading the amount out of
+ * `costNanoUsd` in dollars when it is absent, so a withdrawal that omitted it
+ * would address the DOLLAR cell and leave the euro one live — the exact
+ * double-count this is here to end.
+ *
+ * Rethrown on failure so the outbox retries. A withdrawal that is dropped
+ * leaves two live versions of one charge, which is money reported twice.
+ */
+export function runRetractPulledUsage(deps: PulledUsageLedgerProcessDeps) {
+  return async (payload: RetractPulledUsagePayload): Promise<void> => {
+    if (!(await deps.retractionEnabled(payload.organization_id))) {
+      logger.info(
+        {
+          restatementKey: payload.restatement_key,
+          organizationId: payload.organization_id,
+        },
+        "pulled usage reissue detected but withdrawal is disabled; the superseded version is left standing",
+      );
+      return;
+    }
+
+    logger.info(
+      {
+        restatementKey: payload.restatement_key,
+        source: payload.source,
+        retractedCurrencyCode: payload.currency_code,
+        retractedAgentId: payload.agent_id,
+        retractedRawActorId: payload.raw_actor_id,
+        retractedModel: payload.model,
+        observedAtMs: payload.observed_at_ms,
+      },
+      "withdrawing a pulled usage version superseded by a reissue",
+    );
+
+    await deps.sendRetractPulledUsage({
+      restatementKey: payload.restatement_key,
+      source: payload.source,
+      ingestionSourceId: payload.ingestion_source_id,
+      organizationId: payload.organization_id,
+      model: payload.model,
+      costNanoMinor: 0,
+      currencyCode: payload.currency_code,
+      costNanoUsd: null,
+      rawActorId: payload.raw_actor_id,
+      agentId: payload.agent_id,
+      occurredAtMs: payload.occurred_at_ms,
+      observedAtMs: payload.observed_at_ms,
+    });
+  };
 }
 
 export function runWritePulledUsage(deps: PulledUsageLedgerProcessDeps) {
@@ -155,14 +343,59 @@ export function pulledUsageLedgerPM(
 ): ProcessManagerApplier<PulledUsageProcessingEvent> {
   return (pm) =>
     pm
-      .state({})
+      .state<PulledUsageLedgerState>(INITIAL_PULLED_USAGE_LEDGER_STATE)
       .intent(
         "writePulledUsage",
         writePulledUsageSchema,
         runWritePulledUsage(deps),
       )
+      .intent(
+        "retractPulledUsage",
+        retractPulledUsageSchema,
+        runRetractPulledUsage(deps),
+      )
       .on(PULLED_USAGE_EVENT_TYPES.OBSERVED, (state, data, ctx) => {
         const record = data as PulledUsageObservedEventData;
+
+        // Detection first, and deliberately BEFORE the unpriced-currency
+        // return below. The reissue that matters most is a bill re-denominated
+        // into another currency, and that is exactly the observation the
+        // ledger has no dollar figure for — returning early on it would blind
+        // the detector to its own headline case.
+        const filed = state.filedCell;
+        const reissued = filed !== null && isReissuedElsewhere(filed, record);
+        const intents = reissued
+          ? [
+              ctx.intents.retractPulledUsage(`retract:${record.observedAtMs}`, {
+                restatement_key: record.restatementKey,
+                tenant_id: ctx.projectId,
+                organization_id: record.organizationId,
+                source: record.source,
+                ingestion_source_id: record.ingestionSourceId,
+                model: filed.model,
+                currency_code: filed.currencyCode,
+                agent_id: filed.agentId,
+                raw_actor_id: filed.rawActorId,
+                occurred_at_ms: filed.occurredAtMs,
+                observed_at_ms: record.observedAtMs,
+              } satisfies RetractPulledUsagePayload),
+            ]
+          : [];
+
+        // Where the charge sits NOW, which is what the next version is
+        // compared against. Recording where it FIRST landed instead would name
+        // a cell the first correction already emptied, so every later pull
+        // would withdraw from nothing while the middle version stayed live.
+        const nextState: PulledUsageLedgerState = {
+          filedCell: {
+            model: record.model,
+            currencyCode: record.currencyCode,
+            agentId: record.agentId,
+            rawActorId: record.rawActorId,
+            occurredAtMs: record.occurredAtMs,
+          },
+        };
+
         const costNanoUsd = ledgerAmountNanoUsd(record);
         // The ledger column is nano-DOLLARS. An item billed in another
         // currency that the biller published no conversion for has no honest
@@ -179,11 +412,12 @@ export function pulledUsageLedgerPM(
             },
             "pulled usage is in a currency the biller published no dollar figure for; it is summarized but not written to the dollar ledger",
           );
-          return { state, intents: [] };
+          return { state: nextState, intents };
         }
         return {
-          state,
+          state: nextState,
           intents: [
+            ...intents,
             ctx.intents.writePulledUsage(`pulled:${record.observedAtMs}`, {
               restatement_key: record.restatementKey,
               tenant_id: ctx.projectId,

--- a/platform/app/src/server/app-layer/presets.ts
+++ b/platform/app/src/server/app-layer/presets.ts
@@ -73,7 +73,9 @@ import { prisma as globalPrisma } from "~/server/db";
 import type { LangyConversationProcessingEvent } from "~/server/event-sourcing/pipelines/langy-conversation-processing/schemas/events";
 import { bindProcessFleetMetricsSource } from "~/server/event-sourcing/process-manager/metrics";
 import { BillableEventsMeterClickHouseRepository } from "~/server/event-sourcing/projections/global/repositories/billable-events.clickhouse.repository";
+import { featureFlagService } from "~/server/featureFlag";
 import { getFeatureFlagStore } from "~/server/featureFlag/featureFlagStore.postgres";
+import { NOT_TARGETED } from "~/server/featureFlag/targeting";
 import { FilterService } from "~/server/filters/filter.service";
 import { GatewayBudgetClickHouseRepository } from "~/server/gateway/budget.clickhouse.repository";
 import { createBudgetChangeEventDedupeService } from "~/server/gateway/budgetChangeEventDedupe.service";
@@ -1488,6 +1490,20 @@ export function initializeDefaultApp(options?: {
             budgetCHRepository: new GatewayBudgetClickHouseRepository(
               resolveClickHouseClient,
             ),
+            // Called at EMIT time, once per withdrawal, never memoized here.
+            // A gate resolved when the app booted would keep withdrawing for
+            // as long as the process lived after somebody switched it off.
+            retractionEnabled: async (organizationId: string) =>
+              await featureFlagService.isEnabled(
+                "release_pulled_usage_retraction_enabled",
+                {
+                  distinctId: organizationId,
+                  // Pulled usage is priced for a whole organization, so the
+                  // gate is too — matching the recording flag beside it.
+                  projectId: NOT_TARGETED,
+                  organizationId,
+                },
+              ),
           }
         : undefined,
       governanceCostRollupStore,

--- a/platform/app/src/server/featureFlag/registry.ts
+++ b/platform/app/src/server/featureFlag/registry.ts
@@ -170,6 +170,21 @@ export const FEATURE_FLAGS = [
     family: "Governance",
   },
 
+  // Deliberately its own key rather than a reuse of the one above, and it
+  // gates strictly less. That one decides whether pulled cost is RECORDED at
+  // all; this one decides whether a version of a charge that a later pull
+  // superseded is WITHDRAWN. Turning the recording off to stop bad
+  // withdrawals would also stop every good record, so the two need separate
+  // switches or the only available remedy is far too blunt.
+  {
+    key: "release_pulled_usage_retraction_enabled",
+    scope: "PRODUCT",
+    defaultValue: false,
+    description:
+      "Withdraws the superseded version of a pulled charge when a provider reissues it under a different currency, agent or spender, so a day does not total the same bill twice (ADR-088/ADR-128). Off by default; enable per organization via the operator store or a PostHog rule. With it off the reissue is still detected and logged, but nothing is withdrawn and the day keeps double-counting. For local dev use FEATURE_FLAG_FORCE_ENABLE=release_pulled_usage_retraction_enabled.",
+    family: "Governance",
+  },
+
   // ----- PRODUCT -----
   {
     key: "release_lwql_workbench",

--- a/platform/app/src/server/gateway/__tests__/pulledUsageLedger.integration.test.ts
+++ b/platform/app/src/server/gateway/__tests__/pulledUsageLedger.integration.test.ts
@@ -203,7 +203,17 @@ beforeAll(async () => {
   };
   chRepo = new GatewayBudgetClickHouseRepository(resolveClient);
   service = new GatewayBudgetService(prisma, undefined, undefined, chRepo);
-  const deps: PulledUsageLedgerProcessDeps = { budgetCHRepository: chRepo };
+  // The withdrawal half is not exercised here — this file is about what the
+  // LEDGER holds — so its two deps are stubbed rather than wired. A stub that
+  // threw would be the honest choice if anything below could reach them, and
+  // nothing can: `runWritePulledUsage` is the only runner this file drives.
+  const deps: PulledUsageLedgerProcessDeps = {
+    budgetCHRepository: chRepo,
+    sendRetractPulledUsage: async () => {
+      throw new Error("unreachable: this suite drives the ledger writer only");
+    },
+    retractionEnabled: async () => false,
+  };
   writePulledUsage = runWritePulledUsage(deps);
 }, 180_000);
 

--- a/specs/governance/governance-cost-rollup.feature
+++ b/specs/governance/governance-cost-rollup.feature
@@ -223,3 +223,73 @@ Feature: Daily cost rollup that can always be rebuilt and never lies
     # that touches a foreign bill, and tells the reader we hold no figure for
     # money we hold a perfectly good figure for.
 
+  # --- Recognising the reissue, rather than being told about it ---
+  # Everything above describes what a retraction DOES once one exists. What
+  # produces one is the gap: nothing compares the cell a charge sits in
+  # against the cell the next pull of that same charge is about to land in.
+  # So a reissue is only ever corrected by someone constructing the
+  # correction by hand, and a day that nobody looks at carries the one bill
+  # twice for as long as it is kept.
+  #
+  # Every version of one charge arrives on ONE ordered stream, because the
+  # charge's restatement key is that stream's identity. So the comparison is
+  # against where the charge sits NOW rather than where it first landed. A
+  # record that never moves points at the original cell forever: the first
+  # correction empties that cell, and every later pull withdraws from a cell
+  # already holding nothing.
+  #
+  # The dimensions that may trigger this are exactly the three a charge is
+  # deliberately not identified by - the currency, the agent and the spender.
+  # The model is NOT among them: an adapter that does not list the model
+  # among its dimensions files two models of one period under ONE restatement
+  # key, so a comparison that included the model would read the second model
+  # as a reissue of the first and withdraw money that was really spent.
+
+  @integration
+  Scenario: A bill reissued in another currency is withdrawn by the pull that finds it
+    Given a source that has already pulled a day's bill issued in one currency
+    When the next pull of that same day returns the bill in another currency
+    Then the pull emits a retraction addressed to the first currency's cell
+    And that cell is left stating zero rather than removed
+    And the day totals the reissued amount only
+    # The pull is the ONLY input. Nothing here constructs the correction,
+    # which is what separates this from every scenario above it: those
+    # describe a retraction that already exists, and this one is about
+    # whether anything ever makes one. The emptied cell states zero rather
+    # than going away because removing it would take its restatement key too.
+
+  @integration
+  Scenario: Pulling the corrected day again withdraws nothing
+    Given a source whose reissued bill has already been withdrawn once
+    When that same corrected day is pulled again unchanged
+    Then the pull emits no retraction at all
+    And the day still totals the reissued amount
+    # Asserted on what the pull EMITS, because the totals alone would hold
+    # even if a second retraction fired: it would withdraw from a cell
+    # already at zero and move no money, while the day's revision markers
+    # climbed forever against a correction that happened once.
+
+  @integration
+  Scenario: A charge reissued a second time is compared against where it sits now
+    Given a source whose bill has already been reissued once in another currency
+    When the provider reissues that same bill again against a different spender
+    Then the pull emits a retraction addressed to the second cell, not the first
+    And no earlier version of that bill is left holding money
+    # Two corrections to one charge is the case a record of where the charge
+    # FIRST landed gets wrong: the second correction would be compared
+    # against a cell the first already emptied, leaving the middle version
+    # live and the day carrying it on top of the newest one.
+
+  @unit
+  Scenario: A reissue is recognised from the currency, the agent and the spender only
+    Given a charge already summarized for one model in a period
+    When a charge for a different model arrives under that same restatement key
+    Then nothing withdraws the first model's amount
+    And both models' spend is left standing
+    # A period holding several models is the ordinary case, not a correction,
+    # and an adapter that does not list the model among its dimensions gives
+    # both of them the same restatement key - so this premise is reachable,
+    # not hypothetical. Comparing on the model would withdraw money that was
+    # really spent, which is the one failure here that is worse than the
+    # double-count this whole block exists to prevent.
+


### PR DESCRIPTION
Fixes #8060. Stacked on #8043 — review that first.

## The defect

The restatement key deliberately excludes the currency, the agent and the spender. A provider that reissues one charge under any of those files it in a **different** daily rollup cell, and the first version is left standing holding its money. A total across the day then carries the one bill twice.

The retraction event that fixes this already existed. So did the fold that applies it, and five scenarios describing its behaviour — all passing. **Nothing ever emitted one.** Every test constructed the event by hand, so the whole path read green while the defect it describes was live.

## Where the producer went, and why

| Site | Verdict | Why |
|---|---|---|
| The projection store | dead | A fold sees one cell, never the pair. And a projection that emitted would write new events into the log it is rebuilt from — `architecture-invariants.feature:318` |
| The puller | dead | It holds the new figure and has never read the old one |
| **The ledger process manager** | **chosen** | Its aggregate **is** the restatement key (`commands.ts:72`), so every version of one charge runs through one instance, in order. The only place both cells are ever in scope |

The wake handler stays pure and synchronous; the flag read and the send run as an intent behind the outbox lease, on `spendSettlement.process.ts:105,173`'s precedent. Projection refold does not run process managers, so a rebuild emits nothing.

## The guard that matters most

The comparison is **currency, agent and spender only — never the model.**

An adapter that does not list the model among its dimensions (Anthropic's cost report, for one) gives every model of one period the **same** restatement key. So a second model genuinely arrives on this very instance. Comparing on the model would read it as a reissue and withdraw money that was really spent — strictly worse than the double-count this fixes. The model still rides the withdrawal, because it is part of the cell's address.

Detection also runs **before** the unpriced-currency return, not after. A bill re-denominated into another currency is exactly the observation the dollar ledger has no figure for; giving up where the ledger does would have been blind to the headline case.

## Safety

- Its **own** flag, `release_pulled_usage_retraction_enabled`, read per organization **at emit time**. The existing flag gates whether pulled cost is *recorded*; turning that off to stop a bad withdrawal would also stop every good record.
- A log line at every emit, and one at every suppression.
- Idempotency key literal-prefixed `retract:` so it can never collide with an observation's in the comparator's read of the day.
- Process-manager state is **not** reconstructible from the event log. Losing the process store means the next pull of an already-corrected charge withdraws nothing — it fails **to** the defect, never past it. Stated in the docblock rather than hidden.

## Tests

7 new unit tests driving the **real** process service and outbox dispatcher with the definition the runtime mounts. Each was proven to bind by breaking the thing it tests:

| Break | Red |
|---|---|
| detector always returns false | 5 of 7 |
| comparison wrongly includes model | the model guard |
| unpriced-currency early return restored | 6 of 7 |

`24/24 scenarios bound` on the feature file. Typecheck clean; 1960 neighbouring unit tests pass.

## Known gap

Scenarios 1–3 are tagged `@integration` but bound at the process-manager level with a stubbed dispatcher. The end-to-end "the day totals the reissued amount only" through real ClickHouse is **not** covered by a new test — the consumer half is already covered by existing integration tests, so the untested seam is the command→event dispatch itself.
