### PR TITLE
fix(governance): seven wrongs from the wave-2 audit

### DIFF
--- a/platform/app/ee/event-sourcing/pipelines/ingestion-pull-processing/process-manager/__tests__/ingestionPullEffects.unit.test.ts
+++ b/platform/app/ee/event-sourcing/pipelines/ingestion-pull-processing/process-manager/__tests__/ingestionPullEffects.unit.test.ts
@@ -173,7 +173,12 @@ describe("ingestion pull outbox effect", () => {
       });
     });
 
-    it("falls back to the diagnostic message when the refusal carries no customer sentence", async () => {
+    /** @scenario "A refusal with no customer sentence shows the generic failure text" */
+    it("records a refusal without a customer sentence under the generic failed code, never the refused one", async () => {
+      // The status layer shows the refused code's text as written, so a
+      // refusal that only carries the adapter's diagnostic must not be
+      // filed under it: the diagnostic goes to the event for the log, and
+      // the generic code makes the page fall back to its fixed sentence.
       const recordRunFailed = vi.fn();
       const handler = createIngestionPullRunHandler({
         agentListingPort: { list: () => Promise.reject(new Error("unused")) },
@@ -181,7 +186,7 @@ describe("ingestion pull outbox effect", () => {
         runPort: {
           run: vi.fn().mockRejectedValue(
             new DispatchError({
-              message: "refused outright",
+              message: "HTTP 403 (anthropic cost_report): sk-admin refused",
               retryable: false,
             }),
           ),
@@ -189,11 +194,12 @@ describe("ingestion pull outbox effect", () => {
         commands: () => commandsStub({ recordRunFailed }),
       });
 
-      await handler(intent, context(1));
+      await expect(handler(intent, context(1))).resolves.toBeUndefined();
+      expect(recordRunFailed).toHaveBeenCalledTimes(1);
       expect(recordRunFailed).toHaveBeenCalledWith(
         expect.objectContaining({
-          error: "refused outright",
-          errorCode: "pull_refused",
+          error: "HTTP 403 (anthropic cost_report): sk-admin refused",
+          errorCode: "pull_failed",
           retryable: false,
         }),
       );

--- a/platform/app/ee/event-sourcing/pipelines/ingestion-pull-processing/process-manager/__tests__/ingestionPullEffects.unit.test.ts
+++ b/platform/app/ee/event-sourcing/pipelines/ingestion-pull-processing/process-manager/__tests__/ingestionPullEffects.unit.test.ts
@@ -2,6 +2,7 @@ import { register } from "prom-client";
 import { describe, expect, it, vi } from "vitest";
 
 import type { IntentContext } from "~/server/event-sourcing/pipeline/processManagerDefinition";
+import { DispatchError } from "~/server/event-sourcing/queues/dispatchError";
 
 import {
   createIngestionPullRunHandler,
@@ -134,6 +135,123 @@ describe("ingestion pull outbox effect", () => {
         retryable: false,
       }),
     );
+  });
+
+  describe("when the provider refuses the source's credentials on the first attempt", () => {
+    const refusal = () =>
+      new DispatchError({
+        message: "HTTP 401 (anthropic cost_report): key refused",
+        retryable: false,
+        customerMessage:
+          "Anthropic refused this key. Check the admin key and its permissions.",
+      });
+
+    /** @scenario "A refused key ends the run at once and the source keeps its schedule" */
+    it("records the failure at once with the customer sentence and does not rethrow", async () => {
+      const recordRunFailed = vi.fn();
+      const handler = createIngestionPullRunHandler({
+        agentListingPort: { list: () => Promise.reject(new Error("unused")) },
+        peopleListingPort: { list: () => Promise.reject(new Error("unused")) },
+        runPort: { run: vi.fn().mockRejectedValue(refusal()) },
+        commands: () => commandsStub({ recordRunFailed }),
+        clock: () => 200,
+      });
+
+      await expect(handler(intent, context(1))).resolves.toBeUndefined();
+      expect(recordRunFailed).toHaveBeenCalledTimes(1);
+      expect(recordRunFailed).toHaveBeenCalledWith({
+        tenantId: "gov-project",
+        occurredAt: 200,
+        sourceId: "source-1",
+        runId: "run-1",
+        scheduledFor: 100,
+        error:
+          "Anthropic refused this key. Check the admin key and its permissions.",
+        errorCode: "pull_refused",
+        retryable: false,
+        retryAfterMs: null,
+      });
+    });
+
+    it("falls back to the diagnostic message when the refusal carries no customer sentence", async () => {
+      const recordRunFailed = vi.fn();
+      const handler = createIngestionPullRunHandler({
+        agentListingPort: { list: () => Promise.reject(new Error("unused")) },
+        peopleListingPort: { list: () => Promise.reject(new Error("unused")) },
+        runPort: {
+          run: vi.fn().mockRejectedValue(
+            new DispatchError({
+              message: "refused outright",
+              retryable: false,
+            }),
+          ),
+        },
+        commands: () => commandsStub({ recordRunFailed }),
+      });
+
+      await handler(intent, context(1));
+      expect(recordRunFailed).toHaveBeenCalledWith(
+        expect.objectContaining({
+          error: "refused outright",
+          errorCode: "pull_refused",
+          retryable: false,
+        }),
+      );
+    });
+
+    it("counts it as a final failure, never as retryable noise", async () => {
+      const before = await metricValue({
+        name: "ingestion_pull_total",
+        labels: { outcome: "failed_final" },
+      });
+      const retryableBefore = await metricValue({
+        name: "ingestion_pull_total",
+        labels: { outcome: "failed_retryable" },
+      });
+      const handler = createIngestionPullRunHandler({
+        agentListingPort: { list: () => Promise.reject(new Error("unused")) },
+        peopleListingPort: { list: () => Promise.reject(new Error("unused")) },
+        runPort: { run: vi.fn().mockRejectedValue(refusal()) },
+        commands: () => commandsStub(),
+      });
+
+      await handler(intent, context(1));
+      expect(
+        await metricValue({
+          name: "ingestion_pull_total",
+          labels: { outcome: "failed_final" },
+        }),
+      ).toBe(before + 1);
+      expect(
+        await metricValue({
+          name: "ingestion_pull_total",
+          labels: { outcome: "failed_retryable" },
+        }),
+      ).toBe(retryableBefore);
+    });
+
+    it("still retries a rejection the provider marked as worth retrying", async () => {
+      const recordRunFailed = vi.fn();
+      const handler = createIngestionPullRunHandler({
+        agentListingPort: { list: () => Promise.reject(new Error("unused")) },
+        peopleListingPort: { list: () => Promise.reject(new Error("unused")) },
+        runPort: {
+          run: vi.fn().mockRejectedValue(
+            new DispatchError({
+              message: "Anthropic rate limit exceeded (HTTP 429).",
+              retryable: true,
+              retryAfterMs: 120_000,
+            }),
+          ),
+        },
+        commands: () => commandsStub({ recordRunFailed }),
+      });
+
+      await expect(handler(intent, context(1))).rejects.toMatchObject({
+        retryAfterMs: 120_000,
+      });
+      expect(recordRunFailed).not.toHaveBeenCalled();
+    });
   });
 
   it("does not translate a completion-command failure into a pull failure", async () => {

--- a/platform/app/ee/event-sourcing/pipelines/ingestion-pull-processing/process-manager/ingestionPullEffects.ts
+++ b/platform/app/ee/event-sourcing/pipelines/ingestion-pull-processing/process-manager/ingestionPullEffects.ts
@@ -11,6 +11,10 @@ import {
 } from "~/server/metrics";
 
 import { LISTING_FAILED_REASON } from "../schemas/constants";
+import {
+  PULL_FAILED_ERROR_CODE,
+  PULL_REFUSED_ERROR_CODE,
+} from "../schemas/events";
 import type {
   IngestionPullListingIntent,
   IngestionPullRunIntent,
@@ -308,16 +312,25 @@ export function createIngestionPullRunHandler(
           },
           "Ingestion pull refused by the provider; not retrying this run",
         );
+        // The source page shows the refused code's text as written, so that
+        // code is only ever paired with a sentence we wrote ourselves. An
+        // adapter that refuses without one gets the generic failed code, and
+        // the page falls back to its fixed sentence; the diagnostic detail
+        // still lands in the event for the log, never on the screen.
+        const refusal =
+          error.customerMessage === undefined
+            ? { error: detail, errorCode: PULL_FAILED_ERROR_CODE }
+            : {
+                error: error.customerMessage,
+                errorCode: PULL_REFUSED_ERROR_CODE,
+              };
         await commands.recordRunFailed({
           tenantId: intentContext.projectId,
           occurredAt: clock(),
           sourceId: payload.sourceId,
           runId: payload.runId,
           scheduledFor: payload.scheduledFor,
-          // The customer sentence is the one the page may show as written;
-          // the diagnostic message is the fallback and carries no reply body.
-          error: error.customerMessage ?? detail,
-          errorCode: "pull_refused",
+          ...refusal,
           retryable: false,
           retryAfterMs: providerRetryAfterMs(error),
         });
@@ -345,7 +358,7 @@ export function createIngestionPullRunHandler(
         runId: payload.runId,
         scheduledFor: payload.scheduledFor,
         error: detail,
-        errorCode: "pull_failed",
+        errorCode: PULL_FAILED_ERROR_CODE,
         // Retries are exhausted — nothing will retry THIS run. The next
         // scheduled wake starts a fresh run from the durable cursor.
         retryable: false,

--- a/platform/app/ee/event-sourcing/pipelines/ingestion-pull-processing/process-manager/ingestionPullEffects.ts
+++ b/platform/app/ee/event-sourcing/pipelines/ingestion-pull-processing/process-manager/ingestionPullEffects.ts
@@ -4,7 +4,10 @@ import type {
   IntentContext,
   IntentExecutor,
 } from "~/server/event-sourcing/pipeline/processManagerDefinition";
-import { isDispatchError } from "~/server/event-sourcing/queues/dispatchError";
+import {
+  type DispatchError,
+  isDispatchError,
+} from "~/server/event-sourcing/queues/dispatchError";
 import {
   incrementIngestionPullTotal,
   observeIngestionPullDuration,
@@ -293,80 +296,13 @@ export function createIngestionPullRunHandler(
         cursor: payload.cursor,
       });
     } catch (error) {
-      const detail = error instanceof Error ? error.message : String(error);
-      if (isDispatchError(error) && error.retryable === false) {
-        // The provider refused the source outright (a key it no longer
-        // accepts, for one). Another attempt gets the same answer, and the
-        // outbox retires a non-retryable error before the retry ladder
-        // reaches the branch below that writes run_failed — so a refusal
-        // that is rethrown is never recorded. Record it now, on this
-        // attempt, and end the run. The source keeps its schedule: the next
-        // wake starts a fresh run, which is what an admin who has since
-        // replaced the key needs.
-        incrementIngestionPullTotal({ outcome: "failed_final" });
-        logger.warn(
-          {
-            sourceId: payload.sourceId,
-            attempt: intentContext.attempt,
-            error: detail,
-          },
-          "Ingestion pull refused by the provider; not retrying this run",
-        );
-        // The source page shows the refused code's text as written, so that
-        // code is only ever paired with a sentence we wrote ourselves. An
-        // adapter that refuses without one gets the generic failed code, and
-        // the page falls back to its fixed sentence; the diagnostic detail
-        // still lands in the event for the log, never on the screen.
-        const refusal =
-          error.customerMessage === undefined
-            ? { error: detail, errorCode: PULL_FAILED_ERROR_CODE }
-            : {
-                error: error.customerMessage,
-                errorCode: PULL_REFUSED_ERROR_CODE,
-              };
-        await commands.recordRunFailed({
-          tenantId: intentContext.projectId,
-          occurredAt: clock(),
-          sourceId: payload.sourceId,
-          runId: payload.runId,
-          scheduledFor: payload.scheduledFor,
-          ...refusal,
-          retryable: false,
-          retryAfterMs: providerRetryAfterMs(error),
-        });
-        return;
-      }
-      if (intentContext.attempt < maxAttempts) {
-        incrementIngestionPullTotal({ outcome: "failed_retryable" });
-        logger.warn(
-          {
-            sourceId: payload.sourceId,
-            attempt: intentContext.attempt,
-            error: detail,
-          },
-          "Ingestion pull failed; retrying from durable cursor",
-        );
-        throw error;
-      }
-      // The alertable outcome (ADR-054): retries exhausted, run_failed
-      // recorded. failed_retryable above is expected provider noise.
-      incrementIngestionPullTotal({ outcome: "failed_final" });
-      await commands.recordRunFailed({
-        tenantId: intentContext.projectId,
-        occurredAt: clock(),
-        sourceId: payload.sourceId,
-        runId: payload.runId,
-        scheduledFor: payload.scheduledFor,
-        error: detail,
-        errorCode: PULL_FAILED_ERROR_CODE,
-        // Retries are exhausted — nothing will retry THIS run. The next
-        // scheduled wake starts a fresh run from the durable cursor.
-        retryable: false,
-        // The wait leaves with the run rather than dying with it. Every
-        // attempt of this run has now been refused, so the next wake is the
-        // thing that must not walk back into the window the provider closed,
-        // and it reads this off the connection.
-        retryAfterMs: providerRetryAfterMs(error),
+      await settleFailedPull({
+        commands,
+        payload,
+        intentContext,
+        error,
+        maxAttempts,
+        clock,
       });
       return;
     }
@@ -384,6 +320,154 @@ export function createIngestionPullRunHandler(
       ...result,
     });
   };
+}
+
+/**
+ * What a failed pull leaves behind: a refusal is recorded at once, a failure
+ * with attempts left is rethrown so the outbox retries it from the durable
+ * cursor, and a failure with none left is recorded as final.
+ */
+async function settleFailedPull({
+  commands,
+  payload,
+  intentContext,
+  error,
+  maxAttempts,
+  clock,
+}: {
+  commands: IngestionPullOutcomeCommands;
+  payload: IngestionPullRunIntent;
+  intentContext: IntentContext;
+  error: unknown;
+  maxAttempts: number;
+  clock: () => number;
+}): Promise<void> {
+  const detail = error instanceof Error ? error.message : String(error);
+  if (isDispatchError(error) && error.retryable === false) {
+    await recordRefusedRun({
+      commands,
+      payload,
+      intentContext,
+      error,
+      detail,
+      clock,
+    });
+    return;
+  }
+  if (intentContext.attempt < maxAttempts) {
+    incrementIngestionPullTotal({ outcome: "failed_retryable" });
+    logger.warn(
+      {
+        sourceId: payload.sourceId,
+        attempt: intentContext.attempt,
+        error: detail,
+      },
+      "Ingestion pull failed; retrying from durable cursor",
+    );
+    throw error;
+  }
+  await recordExhaustedRun({
+    commands,
+    payload,
+    intentContext,
+    error,
+    detail,
+    clock,
+  });
+}
+
+/**
+ * The provider refused the source outright (a key it no longer accepts, for
+ * one). Another attempt gets the same answer, and the outbox retires a
+ * non-retryable error before the retry ladder reaches the branch that writes
+ * run_failed — so a refusal that is rethrown is never recorded. Record it now,
+ * on this attempt, and end the run. The source keeps its schedule: the next
+ * wake starts a fresh run, which is what an admin who has since replaced the
+ * key needs.
+ */
+async function recordRefusedRun({
+  commands,
+  payload,
+  intentContext,
+  error,
+  detail,
+  clock,
+}: {
+  commands: IngestionPullOutcomeCommands;
+  payload: IngestionPullRunIntent;
+  intentContext: IntentContext;
+  error: DispatchError;
+  detail: string;
+  clock: () => number;
+}): Promise<void> {
+  incrementIngestionPullTotal({ outcome: "failed_final" });
+  logger.warn(
+    {
+      sourceId: payload.sourceId,
+      attempt: intentContext.attempt,
+      error: detail,
+    },
+    "Ingestion pull refused by the provider; not retrying this run",
+  );
+  // The source page shows the refused code's text as written, so that code is
+  // only ever paired with a sentence we wrote ourselves. An adapter that
+  // refuses without one gets the generic failed code, and the page falls back
+  // to its fixed sentence; the diagnostic detail still lands in the event for
+  // the log, never on the screen.
+  const refusal =
+    error.customerMessage === undefined
+      ? { error: detail, errorCode: PULL_FAILED_ERROR_CODE }
+      : { error: error.customerMessage, errorCode: PULL_REFUSED_ERROR_CODE };
+  await commands.recordRunFailed({
+    tenantId: intentContext.projectId,
+    occurredAt: clock(),
+    sourceId: payload.sourceId,
+    runId: payload.runId,
+    scheduledFor: payload.scheduledFor,
+    ...refusal,
+    retryable: false,
+    retryAfterMs: providerRetryAfterMs(error),
+  });
+}
+
+/**
+ * The alertable outcome (ADR-054): retries exhausted, run_failed recorded.
+ * `failed_retryable` on the attempts before this one is expected provider
+ * noise.
+ */
+async function recordExhaustedRun({
+  commands,
+  payload,
+  intentContext,
+  error,
+  detail,
+  clock,
+}: {
+  commands: IngestionPullOutcomeCommands;
+  payload: IngestionPullRunIntent;
+  intentContext: IntentContext;
+  error: unknown;
+  detail: string;
+  clock: () => number;
+}): Promise<void> {
+  incrementIngestionPullTotal({ outcome: "failed_final" });
+  await commands.recordRunFailed({
+    tenantId: intentContext.projectId,
+    occurredAt: clock(),
+    sourceId: payload.sourceId,
+    runId: payload.runId,
+    scheduledFor: payload.scheduledFor,
+    error: detail,
+    errorCode: PULL_FAILED_ERROR_CODE,
+    // Retries are exhausted — nothing will retry THIS run. The next scheduled
+    // wake starts a fresh run from the durable cursor.
+    retryable: false,
+    // The wait leaves with the run rather than dying with it. Every attempt of
+    // this run has now been refused, so the next wake is the thing that must
+    // not walk back into the window the provider closed, and it reads this
+    // off the connection.
+    retryAfterMs: providerRetryAfterMs(error),
+  });
 }
 
 /**

--- a/platform/app/ee/event-sourcing/pipelines/ingestion-pull-processing/process-manager/ingestionPullEffects.ts
+++ b/platform/app/ee/event-sourcing/pipelines/ingestion-pull-processing/process-manager/ingestionPullEffects.ts
@@ -4,6 +4,7 @@ import type {
   IntentContext,
   IntentExecutor,
 } from "~/server/event-sourcing/pipeline/processManagerDefinition";
+import { isDispatchError } from "~/server/event-sourcing/queues/dispatchError";
 import {
   incrementIngestionPullTotal,
   observeIngestionPullDuration,
@@ -289,6 +290,39 @@ export function createIngestionPullRunHandler(
       });
     } catch (error) {
       const detail = error instanceof Error ? error.message : String(error);
+      if (isDispatchError(error) && error.retryable === false) {
+        // The provider refused the source outright (a key it no longer
+        // accepts, for one). Another attempt gets the same answer, and the
+        // outbox retires a non-retryable error before the retry ladder
+        // reaches the branch below that writes run_failed — so a refusal
+        // that is rethrown is never recorded. Record it now, on this
+        // attempt, and end the run. The source keeps its schedule: the next
+        // wake starts a fresh run, which is what an admin who has since
+        // replaced the key needs.
+        incrementIngestionPullTotal({ outcome: "failed_final" });
+        logger.warn(
+          {
+            sourceId: payload.sourceId,
+            attempt: intentContext.attempt,
+            error: detail,
+          },
+          "Ingestion pull refused by the provider; not retrying this run",
+        );
+        await commands.recordRunFailed({
+          tenantId: intentContext.projectId,
+          occurredAt: clock(),
+          sourceId: payload.sourceId,
+          runId: payload.runId,
+          scheduledFor: payload.scheduledFor,
+          // The customer sentence is the one the page may show as written;
+          // the diagnostic message is the fallback and carries no reply body.
+          error: error.customerMessage ?? detail,
+          errorCode: "pull_refused",
+          retryable: false,
+          retryAfterMs: providerRetryAfterMs(error),
+        });
+        return;
+      }
       if (intentContext.attempt < maxAttempts) {
         incrementIngestionPullTotal({ outcome: "failed_retryable" });
         logger.warn(

--- a/platform/app/ee/event-sourcing/pipelines/ingestion-pull-processing/schemas/events.ts
+++ b/platform/app/ee/event-sourcing/pipelines/ingestion-pull-processing/schemas/events.ts
@@ -121,10 +121,30 @@ export type IngestionPullRunCompletedEventData = z.infer<
   typeof ingestionPullRunCompletedEventDataSchema
 >;
 
+/**
+ * The provider refused the source outright and said so in a sentence we
+ * wrote ourselves (`DispatchError.customerMessage`). It is the one failure
+ * code whose `error` carries no provider reply, so the source page may show
+ * that text as written; every other code collapses to a fixed sentence there.
+ */
+export const PULL_REFUSED_ERROR_CODE = "pull_refused" as const;
+/**
+ * The run ended without a sentence of ours to show: retries exhausted, or a
+ * refusal that carried no customer message. `error` holds the diagnostic
+ * detail for the log and must never reach the page.
+ */
+export const PULL_FAILED_ERROR_CODE = "pull_failed" as const;
+
 export const ingestionPullRunFailedEventDataSchema = sourceEnvelope.extend({
   runId: z.string().min(1),
   scheduledFor: z.number(),
   error: z.string(),
+  /**
+   * Kept as a free string because the log is append-only and early failures
+   * carry codes this file never named. Known values: `PULL_REFUSED_ERROR_CODE`,
+   * `PULL_FAILED_ERROR_CODE`, and `run_abandoned` (written when a replacement
+   * run takes over, see `replacedByRunId`).
+   */
   errorCode: z.string(),
   retryable: z.boolean(),
   /**

--- a/platform/app/ee/governance/dashboard/pages/__tests__/genieComposerFields.unit.test.ts
+++ b/platform/app/ee/governance/dashboard/pages/__tests__/genieComposerFields.unit.test.ts
@@ -47,7 +47,7 @@ describe("given the Genie composer field definitions", () => {
     });
 
     /** @scenario "Genie setup asks for the service principal first" */
-    it("marks the token, space IDs, and warehouse ID as Advanced", () => {
+    it("marks the token, space IDs, warehouse ID and paid bill switch as Advanced", () => {
       const advancedKeys = genieFields
         .filter((f) => f.advanced)
         .map((f) => f.key);
@@ -55,7 +55,15 @@ describe("given the Genie composer field definitions", () => {
         "credentialsToken",
         "spaceIds",
         "warehouseId",
+        "readPaidGenieBill",
       ]);
+    });
+
+    /** @scenario "The paid Genie bill read is off unless switched on" */
+    it("offers the paid bill read as a switch that starts off", () => {
+      const field = genieFields.find((f) => f.key === "readPaidGenieBill");
+      expect(field?.control).toBe("switch");
+      expect(field?.defaultOn).toBe(false);
     });
 
     /** @scenario "Genie setup asks for the service principal first" */
@@ -123,6 +131,41 @@ describe("given the create input for a pull-mode source", () => {
       expect((input?.pullConfig as { spaceIds?: string[] }).spaceIds).toEqual(
         [],
       );
+    });
+  });
+
+  describe("when the paid bill switch was never touched", () => {
+    /** @scenario "The paid Genie bill read is off unless switched on" */
+    it("sends the adapter a real false, never a missing setting", () => {
+      const input = buildCreateInput({
+        composer: genieComposer({}),
+        organizationId: "org-1",
+      });
+      expect(
+        (input?.pullConfig as { readPaidGenieBill?: unknown })
+          .readPaidGenieBill,
+      ).toBe(false);
+    });
+  });
+
+  describe("when the admin switched the paid bill read on", () => {
+    /** @scenario "The paid Genie bill read is off unless switched on" */
+    it("sends the adapter a real true", () => {
+      const input = buildCreateInput({
+        composer: genieComposer({
+          parserConfig: {
+            workspaceUrl: "https://adb-123.7.azuredatabricks.net",
+            credentialsClientId: "client-id",
+            credentialsClientSecret: "client-secret",
+            readPaidGenieBill: "true",
+          },
+        }),
+        organizationId: "org-1",
+      });
+      expect(
+        (input?.pullConfig as { readPaidGenieBill?: unknown })
+          .readPaidGenieBill,
+      ).toBe(true);
     });
   });
 

--- a/platform/app/ee/governance/dashboard/pages/__tests__/parserConfigFields.integration.test.tsx
+++ b/platform/app/ee/governance/dashboard/pages/__tests__/parserConfigFields.integration.test.tsx
@@ -84,11 +84,14 @@ describe("given the Genie source-specific fields", () => {
     });
 
     /** @scenario "Genie setup asks for the service principal first" */
-    it("keeps the token, space IDs, and warehouse ID hidden until Advanced expands", async () => {
+    it("keeps the token, space IDs, warehouse ID, and bill-line switch hidden until Advanced expands", async () => {
       renderFields("databricks_genie");
       expect(screen.queryByText("Workspace token")).toBeNull();
       expect(screen.queryByText(/Genie space IDs/)).toBeNull();
       expect(screen.queryByText(/SQL warehouse ID/)).toBeNull();
+      expect(
+        screen.queryByText(/Also record Genie's own bill line/),
+      ).toBeNull();
 
       const user = userEvent.setup();
       await user.click(screen.getByText("Advanced"));
@@ -97,6 +100,9 @@ describe("given the Genie source-specific fields", () => {
       });
       expect(screen.getByText(/Genie space IDs/)).toBeTruthy();
       expect(screen.getByText(/SQL warehouse ID/)).toBeTruthy();
+      expect(
+        screen.getByText(/Also record Genie's own bill line/),
+      ).toBeTruthy();
     });
   });
 

--- a/platform/app/ee/governance/dashboard/pages/inventory.tsx
+++ b/platform/app/ee/governance/dashboard/pages/inventory.tsx
@@ -3135,7 +3135,19 @@ export const PARSER_FIELDS: Record<SourceType, FieldDef[]> = {
       label: "SQL warehouse ID (optional)",
       advanced: true,
       placeholder: "095eb666b2ed2762",
-      hint: "Any warehouse this credential can run a query on. It is where the billing lookup itself runs — NOT the warehouse being priced, which is every warehouse the questions used. Set it to attribute the compute behind each question to the person who asked; leave it empty and questions are recorded at zero cost, which is what Genie itself charges. Naming one makes every run submit a query, so a stopped warehouse is started and billed on the source's schedule. The token additionally needs SELECT on the `system` catalogue, which only a metastore admin can grant — without it questions are still recorded, without cost. The figure is a share of the hourly bill at list prices, so it is an estimate, not the invoice.",
+      hint: "Any warehouse this credential can run a query on. It is where the billing lookup itself runs — NOT the warehouse being priced, which is every warehouse the questions used. Set it to attribute the compute behind each question to the person who asked; leave it empty and questions are recorded without an amount, since the compute behind them was never read. Naming one makes every run submit a query, so a stopped warehouse is started and billed on the source's schedule. The token additionally needs SELECT on the `system` catalogue, which only a metastore admin can grant — without it questions are still recorded, without cost. The figure is a share of the hourly bill at list prices, so it is an estimate, not the invoice.",
+    },
+    {
+      key: "readPaidGenieBill",
+      label: "Also record Genie's own bill line",
+      placeholder: "",
+      hint: "Reads the usage Databricks bills under the Genie product itself — the per-message and inference charges, separate from the warehouse compute the questions run on — and records it per person, per day, per price line, at list price. It runs on the same SQL warehouse as the question pricing and needs the same SELECT on the `system` catalogue; with no warehouse named the read cannot start and the run says so. Off by default because most workspaces are still on Genie's free line, which this read records as usage with no amount.",
+      control: "switch",
+      defaultOn: false,
+      // Advanced for the same reason the warehouse id beside it is: it is a
+      // billing read a metastore admin has to grant, not part of getting the
+      // source to record conversations at all.
+      advanced: true,
     },
   ],
   s3_custom: [
@@ -3716,6 +3728,13 @@ function buildDatabricksGeniePullConfig(
     // "do not price these questions", and an empty string is a warehouse id it
     // would then ask the workspace about.
     ...(warehouseId ? { warehouseId } : {}),
+    // A real boolean, from the same constant the field declares, so what the
+    // adapter reads is what the switch showed: off unless the admin turned it
+    // on, never the absence of a form value read as a setting.
+    readPaidGenieBill: switchFieldIsOn({
+      value: p.readPaidGenieBill,
+      defaultOn: false,
+    }),
     credentials,
   };
 }
@@ -4400,7 +4419,15 @@ const PULL_CONFIG_OWNED_FIELDS: Partial<Record<SourceType, readonly string[]>> =
     // `warehouseId` is here because the builder DROPS it when empty. Left to
     // the merge, the raw form value would persist `warehouseId: ""`, which the
     // adapter reads as a warehouse to go ask the workspace about.
-    databricks_genie: ["workspaceUrl", "spaceIds", "warehouseId"],
+    // `readPaidGenieBill` for the reason `readSeats` is owned further down:
+    // the builder turns the switch's form value into a real boolean, and the
+    // raw value winning the merge would hand the adapter a string.
+    databricks_genie: [
+      "workspaceUrl",
+      "spaceIds",
+      "warehouseId",
+      "readPaidGenieBill",
+    ],
     // The builder normalises `environmentUrl` (trailing slashes stripped) and
     // turns `botIds` from a comma-separated string into an array. The raw form
     // values winning the merge would leave a string where the adapter's schema

--- a/platform/app/ee/governance/routers/__tests__/ingestionSourceDto.unit.test.ts
+++ b/platform/app/ee/governance/routers/__tests__/ingestionSourceDto.unit.test.ts
@@ -43,6 +43,7 @@ describe("a source's latest pull result", () => {
         LastRunAt: 1,
         LastRunOutcome: "failed",
         LastRunError: "Anthropic rate limit exceeded (HTTP 429).",
+        LastRunErrorCode: "pull_failed",
       },
     });
     expect(dto.pullStatus.error).toBe(
@@ -64,6 +65,7 @@ describe("a source's latest pull result", () => {
         LastRunAt: Date.parse("2026-02-02T12:00:00Z"),
         LastRunOutcome: "failed",
         LastRunError: "Too many simultaneous queries; private upstream payload",
+        LastRunErrorCode: "pull_failed",
       },
     });
     expect(dto.pullStatus).toEqual({

--- a/platform/app/ee/governance/services/pullers/__tests__/anthropicAdminPuller.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/anthropicAdminPuller.unit.test.ts
@@ -21,6 +21,7 @@ vi.mock("~/utils/ssrfProtection", () => ({
   ssrfSafeFetch: (...args: unknown[]) => fetchMock(...args),
 }));
 
+import { DispatchError } from "~/server/event-sourcing/queues/dispatchError";
 import { AnthropicAdminPuller } from "../anthropicAdmin.puller";
 import { buildPulledUsageRecord } from "../pulledUsageRecord";
 
@@ -1035,6 +1036,60 @@ describe("the Anthropic Admin puller", () => {
           bucketWidth: "1d",
           schedule: "0 * * * *",
         },
+      );
+
+      expect(result.errorCount).toBe(1);
+      expect(result.cursor).toBe(
+        '{"startingAt":"2026-08-01T00:00:00Z","page":null}',
+      );
+      expect(result.events).toHaveLength(0);
+    });
+  });
+
+  describe("when the provider refuses the admin key", () => {
+    const CONFIG = {
+      adapter: "anthropic_admin",
+      report: "cost",
+      bucketWidth: "1d",
+      schedule: "0 * * * *",
+    } as const;
+
+    /** @scenario "A key the provider refuses is reported as refused and is not retried as an outage" */
+    it.each([
+      401, 403,
+    ])("ends the run as refused and not worth retrying on HTTP %i, without quoting the reply or the key", async (status) => {
+      fetchMock.mockResolvedValue(
+        new Response('{"error":{"message":"invalid x-api-key sk-admin"}}', {
+          status,
+        }),
+      );
+
+      const run = new AnthropicAdminPuller().runOnce(RUN_OPTIONS, CONFIG);
+      await expect(run).rejects.toBeInstanceOf(DispatchError);
+      await expect(run).rejects.toMatchObject({
+        retryable: false,
+        message: `HTTP ${status} (anthropic cost_report): key refused`,
+        customerMessage:
+          "Anthropic refused this key. Check the admin key and its permissions.",
+      });
+      const error = await run.catch((e: unknown) => e as DispatchError);
+      expect(error.message).not.toContain("sk-admin");
+      expect(error.message).not.toContain("invalid x-api-key");
+      expect(error.customerMessage).not.toContain("sk-admin");
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("still treats a server fault as a transport failure that holds the cursor for a retry", async () => {
+      fetchMock.mockResolvedValue(
+        new Response("upstream fell over", { status: 500 }),
+      );
+
+      const result = await new AnthropicAdminPuller().runOnce(
+        {
+          ...RUN_OPTIONS,
+          cursor: '{"startingAt":"2026-08-01T00:00:00Z","page":null}',
+        },
+        CONFIG,
       );
 
       expect(result.errorCount).toBe(1);

--- a/platform/app/ee/governance/services/pullers/__tests__/anthropicAdminPuller.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/anthropicAdminPuller.unit.test.ts
@@ -1072,7 +1072,9 @@ describe("the Anthropic Admin puller", () => {
         customerMessage:
           "Anthropic refused this key. Check the admin key and its permissions.",
       });
-      const error = await run.catch((e: unknown) => e as DispatchError);
+      // `run` is typed by its resolved value, so the rejection has to be read
+      // off the promise and cast: the assertions above already proved what it is.
+      const error = (await run.catch((e: unknown) => e)) as DispatchError;
       expect(error.message).not.toContain("sk-admin");
       expect(error.message).not.toContain("invalid x-api-key");
       expect(error.customerMessage).not.toContain("sk-admin");

--- a/platform/app/ee/governance/services/pullers/__tests__/databricksGeniePaidBill.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/databricksGeniePaidBill.unit.test.ts
@@ -217,8 +217,11 @@ function cursorOf(result: { cursor: string | null }) {
 /** The bound value of one named parameter on the first bill statement posted. */
 function firstBillParameter(name: string): string {
   const asked = billStatements();
-  expect(asked.length).toBeGreaterThan(0);
-  return (asked[0]!.parameters as { name: string; value: string }[]).find(
+  const first = asked[0];
+  if (first === undefined) {
+    throw new Error("no bill statement was posted");
+  }
+  return (first.parameters as { name: string; value: string }[]).find(
     (p) => p.name === name,
   )!.value;
 }

--- a/platform/app/ee/governance/services/pullers/__tests__/databricksGeniePaidBill.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/databricksGeniePaidBill.unit.test.ts
@@ -33,8 +33,21 @@ const WORKSPACE_URL = "https://adb-1.azuredatabricks.net";
 const WAREHOUSE_ID = "095eb666b2ed2762";
 const PAID_SKU = "PREMIUM_GENIE_SERVERLESS_REAL_TIME_INFERENCE_EU_WEST";
 const FREE_SKU = "GENIE_FREE_USAGE";
-const DAY = "2026-09-08";
 const HOUR_MS = 60 * 60 * 1000;
+const ONE_DAY_MS = 24 * HOUR_MS;
+/**
+ * The day the fixture bills on: two days back, from the clock. The read's
+ * first-run window is the last thirty days through tomorrow and the fixture
+ * only serves rows inside the window it was asked about, so a day pinned to
+ * the calendar would fall out of the window a month after it was written and
+ * every row-landing test would fail with nothing landed.
+ */
+const DAY = new Date(Date.now() - 2 * ONE_DAY_MS).toISOString().slice(0, 10);
+/** Where a first read with no configured start begins: thirty days back, day-aligned. */
+const FIRST_RUN_FLOOR_MS =
+  Math.floor((Date.now() - 30 * ONE_DAY_MS) / ONE_DAY_MS) * ONE_DAY_MS;
+/** The same limit the warehouse read holds for. */
+const MAX_HOLD_MS = 7 * ONE_DAY_MS;
 
 const reply = (body: unknown, status = 200) =>
   ({
@@ -195,7 +208,17 @@ function cursorOf(result: { cursor: string | null }) {
     sinceMs: number;
     costHeldSinceMs: number | null;
     paidBillReadThroughMs: number | null;
+    paidBillHeldSinceMs: number | null;
   };
+}
+
+/** The bound value of one named parameter on the first bill statement posted. */
+function firstBillParameter(name: string): string {
+  const asked = billStatements();
+  expect(asked.length).toBeGreaterThan(0);
+  return (asked[0]!.parameters as { name: string; value: string }[]).find(
+    (p) => p.name === name,
+  )!.value;
 }
 
 const paidRow = (
@@ -336,6 +359,40 @@ describe("given a Genie source with the paid bill read switched on", () => {
       // No zero anywhere on it: no price is not a price of nothing.
       expect(JSON.stringify(event)).not.toContain('"0"');
     });
+
+    const zeroPriced: { name: string; sku: string }[] = [
+      { name: "a free row priced at zero", sku: FREE_SKU },
+      { name: "a paid price line listed at zero", sku: PAID_SKU },
+    ];
+    for (const { name, sku } of zeroPriced) {
+      /** @scenario "A free Genie row lands with its usage count and no amount" */
+      it(`${name} still lands with no amount`, async () => {
+        // The day Databricks publishes a list price of zero, the statement's
+        // multiplication yields a well-formed decimal zero rather than null.
+        billPlan = {
+          kind: "rows",
+          rows: [
+            paidRow({
+              sku,
+              quantity: "40",
+              amount: "0.000000000000",
+              currency: "USD",
+            }),
+          ],
+        };
+
+        const result = await pull({ readPaidGenieBill: true });
+        const events = billEvents(result);
+
+        expect(events).toHaveLength(1);
+        const event = events[0]!;
+        expect(event.extra?.quantity).toBe("40");
+        expect(event.cost_usd).toBeUndefined();
+        expect(event.cost_amount).toBeUndefined();
+        expect(hintOf(event)).not.toHaveProperty("costUsd");
+        expect(JSON.stringify(event)).not.toContain("0.000000000000");
+      });
+    }
   });
 
   describe("when a person's day spans several surfaces and channels", () => {
@@ -417,8 +474,10 @@ describe("given a Genie source with the paid bill read switched on", () => {
         expect(billEvents(result)).toHaveLength(0);
         expect(result.errorCount).toBe(0);
         const cursor = cursorOf(result);
-        // Its own place: a fresh read that could not finish has none to move.
-        expect(cursor.paidBillReadThroughMs).toBeNull();
+        // Its own place: a fresh read that could not finish holds at the
+        // floor it started from, and writes that floor down.
+        expect(cursor.paidBillReadThroughMs).toBe(FIRST_RUN_FLOOR_MS);
+        expect(cursor.paidBillHeldSinceMs).not.toBeNull();
         // And the warehouse read's place is untouched by it: that read priced
         // its window whole, so the watermark moved and nothing is held.
         expect(cursor.sinceMs).toBeGreaterThan(Date.now() - HOUR_MS);
@@ -459,11 +518,7 @@ describe("given a Genie source with the paid bill read switched on", () => {
         cursor: first.cursor,
       });
 
-      const asked = billStatements();
-      expect(asked.length).toBeGreaterThan(0);
-      const from = (
-        asked[0]!.parameters as { name: string; value: string }[]
-      ).find((p) => p.name === "from_date")!.value;
+      const from = firstBillParameter("from_date");
       // Behind where it reached — a day's bill keeps landing after the day —
       // but not back at the start of history.
       expect(Date.parse(from)).toBeLessThanOrEqual(reachedMs);
@@ -471,6 +526,126 @@ describe("given a Genie source with the paid bill read switched on", () => {
       expect(cursorOf(second).paidBillReadThroughMs).toBeGreaterThanOrEqual(
         reachedMs,
       );
+    });
+  });
+
+  describe("when the bill is refused on every run", () => {
+    /** @scenario "A held paid Genie read keeps its floor across runs" */
+    it("keeps the floor it first held at instead of sliding it forward", async () => {
+      billPlan = { kind: "http", status: 403 };
+
+      const first = await pull({ readPaidGenieBill: true });
+      const firstCursor = cursorOf(first);
+      expect(firstCursor.paidBillReadThroughMs).toBe(FIRST_RUN_FLOOR_MS);
+      const heldSinceMs = firstCursor.paidBillHeldSinceMs!;
+      expect(heldSinceMs).not.toBeNull();
+
+      statementBodies = [];
+      const second = await pull({
+        readPaidGenieBill: true,
+        cursor: first.cursor,
+      });
+      const secondCursor = cursorOf(second);
+
+      // The same floor, and the same hold: neither the position nor the
+      // instant the hold began moved with the clock.
+      expect(secondCursor.paidBillReadThroughMs).toBe(FIRST_RUN_FLOOR_MS);
+      expect(secondCursor.paidBillHeldSinceMs).toBe(heldSinceMs);
+      // And the second run asked about the held period again, from at or
+      // before the floor — never from a floor that crept forward.
+      expect(Date.parse(firstBillParameter("from_date"))).toBeLessThanOrEqual(
+        FIRST_RUN_FLOOR_MS,
+      );
+      expect(billEvents(second)).toHaveLength(0);
+      expect(second.notices).toContain(PAID_GENIE_BILL_UNREADABLE);
+    });
+
+    /** @scenario "A held paid Genie read keeps its floor across runs" */
+    it("still reads a cursor written before the hold had a clock", async () => {
+      billPlan = { kind: "http", status: 403 };
+      const sinceMs = Date.now() - 3 * ONE_DAY_MS;
+      const cursor = JSON.stringify({
+        sinceMs,
+        spaceId: null,
+        conversationId: null,
+        sweepHadGap: false,
+        spaceSetFingerprint: null,
+        sweepOldestPendingMs: null,
+        sweepStartedAtMs: null,
+        costHeldSinceMs: null,
+        paidBillReadThroughMs: FIRST_RUN_FLOOR_MS,
+      });
+
+      const result = await pull({ readPaidGenieBill: true, cursor });
+      const next = cursorOf(result);
+
+      // Not restarted from the configured watermark: the old cursor parsed,
+      // the floor it carried is kept, and the hold starts its clock now.
+      expect(next.paidBillReadThroughMs).toBe(FIRST_RUN_FLOOR_MS);
+      expect(next.paidBillHeldSinceMs).toBeGreaterThan(Date.now() - HOUR_MS);
+      expect(next.sinceMs).toBeGreaterThanOrEqual(sinceMs);
+    });
+
+    /** @scenario "A paid Genie hold older than the limit moves on" */
+    it("moves past the window once the hold is older than the limit, recording nothing for it", async () => {
+      billPlan = { kind: "http", status: 403 };
+      const heldSinceMs = Date.now() - MAX_HOLD_MS - ONE_DAY_MS;
+      const held = await pull({ readPaidGenieBill: true });
+      const cursor = JSON.stringify({
+        ...cursorOf(held),
+        paidBillHeldSinceMs: heldSinceMs,
+      });
+
+      const result = await pull({ readPaidGenieBill: true, cursor });
+      const next = cursorOf(result);
+
+      // Moved on: the position is at the end of the window it asked about,
+      // and the hold is released so the next one ages from its own start.
+      const endOfTodayMs =
+        Math.floor(Date.now() / ONE_DAY_MS) * ONE_DAY_MS + ONE_DAY_MS;
+      expect(next.paidBillReadThroughMs).toBe(endOfTodayMs);
+      expect(next.paidBillHeldSinceMs).toBeNull();
+      // Nothing recorded for the span it gave up on — no row, so no zero.
+      expect(billEvents(result)).toHaveLength(0);
+      expect(JSON.stringify(result.events)).not.toContain("genie_bill");
+      // The refusal is still named in the run's result.
+      expect(result.notices).toContain(PAID_GENIE_BILL_UNREADABLE);
+      // And the warehouse read's hold is not the one that was aged.
+      expect(next.costHeldSinceMs).toBeNull();
+    });
+
+    /** @scenario "A paid Genie hold older than the limit moves on" */
+    it("keeps holding while the hold is younger than the limit", async () => {
+      billPlan = { kind: "http", status: 403 };
+      const heldSinceMs = Date.now() - MAX_HOLD_MS + ONE_DAY_MS;
+      const held = await pull({ readPaidGenieBill: true });
+      const cursor = JSON.stringify({
+        ...cursorOf(held),
+        paidBillHeldSinceMs: heldSinceMs,
+      });
+
+      const next = cursorOf(await pull({ readPaidGenieBill: true, cursor }));
+
+      expect(next.paidBillReadThroughMs).toBe(FIRST_RUN_FLOOR_MS);
+      expect(next.paidBillHeldSinceMs).toBe(heldSinceMs);
+    });
+
+    /** @scenario "A held paid Genie read keeps its floor across runs" */
+    it("releases the hold on the run the bill reads whole", async () => {
+      billPlan = { kind: "http", status: 403 };
+      const held = await pull({ readPaidGenieBill: true });
+      expect(cursorOf(held).paidBillHeldSinceMs).not.toBeNull();
+
+      billPlan = { kind: "rows", rows: [paidRow()] };
+      const result = await pull({
+        readPaidGenieBill: true,
+        cursor: held.cursor,
+      });
+      const next = cursorOf(result);
+
+      expect(billEvents(result)).toHaveLength(1);
+      expect(next.paidBillHeldSinceMs).toBeNull();
+      expect(next.paidBillReadThroughMs).toBeGreaterThan(FIRST_RUN_FLOOR_MS);
     });
   });
 
@@ -483,7 +658,10 @@ describe("given a Genie source with the paid bill read switched on", () => {
 
       expect(billStatements()).toHaveLength(0);
       expect(billEvents(result)).toHaveLength(0);
+      // No window was asked about, so there is no floor to write and no
+      // hold to age: the read starts fresh once a warehouse is named.
       expect(cursorOf(result).paidBillReadThroughMs).toBeNull();
+      expect(cursorOf(result).paidBillHeldSinceMs).toBeNull();
       expect(result.notices).toContain(PAID_GENIE_BILL_UNREADABLE);
     });
   });

--- a/platform/app/ee/governance/services/pullers/__tests__/databricksGeniePaidBill.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/databricksGeniePaidBill.unit.test.ts
@@ -1,0 +1,490 @@
+// SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+
+/**
+ * @vitest-environment node
+ *
+ * The paid Genie bill line: Databricks bills paid Genie usage per person and
+ * per day on its own line in `system.billing.usage`, with no warehouse behind
+ * it, so the warehouse allocation can never see it. This is the separate read
+ * that asks for those rows directly — switched on per source, priced from
+ * list prices where one is published, and walking on a position of its own.
+ *
+ * Driven through `runOnce` with the transport mocked. The fixture answers the
+ * two statements the adapter can post by what each one asks about: the
+ * warehouse allocation names the query history, the bill line names its
+ * billing origin.
+ *
+ * Spec: specs/governance/pulled-usage-cost-reporting.feature
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  DatabricksGeniePuller,
+  databricksGeniePullConfigSchema,
+  PAID_GENIE_BILL_UNREADABLE,
+} from "../databricksGenie.puller";
+import { PULLED_USAGE_HINT_KEY } from "../pulledUsageRecord";
+
+vi.mock("~/utils/ssrfProtection", () => ({ ssrfSafeFetch: vi.fn() }));
+const { ssrfSafeFetch } = await import("~/utils/ssrfProtection");
+const fetchMock = vi.mocked(ssrfSafeFetch);
+
+const WORKSPACE_URL = "https://adb-1.azuredatabricks.net";
+const WAREHOUSE_ID = "095eb666b2ed2762";
+const PAID_SKU = "PREMIUM_GENIE_SERVERLESS_REAL_TIME_INFERENCE_EU_WEST";
+const FREE_SKU = "GENIE_FREE_USAGE";
+const DAY = "2026-09-08";
+const HOUR_MS = 60 * 60 * 1000;
+
+const reply = (body: unknown, status = 200) =>
+  ({
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? "" : "refused",
+    json: async () => body,
+  }) as unknown as Awaited<ReturnType<typeof ssrfSafeFetch>>;
+
+const WAREHOUSE_COST_COLUMNS = [
+  "statement_id",
+  "usage_hour",
+  "execution_ms_in_hour",
+  "hour_total_ms",
+  "hour_billable_usd",
+  "currency_code",
+  "sku_name",
+];
+
+const PAID_BILL_COLUMNS = [
+  "run_as",
+  "usage_date",
+  "sku_name",
+  "quantity",
+  "amount",
+  "currency_code",
+  "surfaces",
+  "channels",
+];
+
+type StatementPlan =
+  | { kind: "rows"; rows: (string | null)[][]; cutShort?: boolean }
+  | { kind: "http"; status: number }
+  | { kind: "state"; state: string };
+
+let warehousePlan: StatementPlan;
+let billPlan: StatementPlan;
+/** Every statement body the adapter posted, in order. */
+let statementBodies: Record<string, unknown>[];
+
+function billStatements(): Record<string, unknown>[] {
+  return statementBodies.filter((body) =>
+    String(body.statement).includes("billing_origin_product"),
+  );
+}
+
+/**
+ * The rows a real reply would carry for the window it was asked about. The
+ * bill is read a week at a time and the weeks tile the window half-open on
+ * the date, so a day belongs to exactly one of them — a fixture that served
+ * every row to every week would land the same day once per week.
+ */
+function rowsInWindow({
+  rows,
+  columns,
+  body,
+}: {
+  rows: (string | null)[][];
+  columns: string[];
+  body: Record<string, unknown>;
+}): (string | null)[][] {
+  const at = columns.indexOf("usage_date");
+  if (at === -1) return rows;
+  const parameters = (body.parameters ?? []) as {
+    name: string;
+    value: string;
+  }[];
+  const bound = (name: string) =>
+    Date.parse(parameters.find((p) => p.name === name)?.value ?? "");
+  const fromMs = bound("from_date");
+  const toMs = bound("to_date");
+  if (!Number.isFinite(fromMs) || !Number.isFinite(toMs)) return rows;
+  return rows.filter((row) => {
+    const dayMs = Date.parse(String(row[at]));
+    return !Number.isFinite(dayMs) || (dayMs >= fromMs && dayMs < toMs);
+  });
+}
+
+function answer(
+  plan: StatementPlan,
+  columns: string[],
+  body: Record<string, unknown>,
+) {
+  if (plan.kind === "http") return reply({}, plan.status);
+  if (plan.kind === "state") {
+    return reply({
+      statement_id: "fixture",
+      status: { state: plan.state, error: { message: "no grant" } },
+    });
+  }
+  return reply({
+    statement_id: "fixture",
+    status: { state: "SUCCEEDED" },
+    manifest: { schema: { columns: columns.map((name) => ({ name })) } },
+    result: {
+      data_array: rowsInWindow({ rows: plan.rows, columns, body }),
+      ...(plan.cutShort ? { next_chunk_index: 1 } : {}),
+    },
+  });
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  statementBodies = [];
+  warehousePlan = { kind: "rows", rows: [] };
+  billPlan = { kind: "rows", rows: [] };
+
+  fetchMock.mockImplementation(async (url: string, init) => {
+    const path = String(url).replace(WORKSPACE_URL, "");
+    if (path.startsWith("/api/2.0/genie/spaces?")) {
+      return reply({ spaces: [] });
+    }
+    if (path === "/api/2.0/sql/statements" && init?.method === "POST") {
+      const body = JSON.parse(String(init.body)) as Record<string, unknown>;
+      statementBodies.push(body);
+      return String(body.statement).includes("billing_origin_product")
+        ? answer(billPlan, PAID_BILL_COLUMNS, body)
+        : answer(warehousePlan, WAREHOUSE_COST_COLUMNS, body);
+    }
+    return reply({ error: `unrouted ${path}` }, 404);
+  });
+});
+
+async function pull({
+  readPaidGenieBill,
+  warehouseId = WAREHOUSE_ID,
+  cursor = null,
+}: {
+  readPaidGenieBill?: boolean;
+  warehouseId?: string;
+  cursor?: string | null;
+}) {
+  return await new DatabricksGeniePuller().runOnce(
+    { cursor, credentials: { token: "dapi-fixture" } },
+    {
+      adapter: "databricks_genie",
+      workspaceUrl: WORKSPACE_URL,
+      spaceIds: [],
+      schedule: "*/15 * * * *",
+      ...(warehouseId ? { warehouseId } : {}),
+      ...(readPaidGenieBill === undefined ? {} : { readPaidGenieBill }),
+    },
+  );
+}
+
+function billEvents(result: Awaited<ReturnType<typeof pull>>) {
+  return result.events.filter((event) => event.action === "genie_bill");
+}
+
+function hintOf(event: { extra?: Record<string, unknown> }) {
+  return event.extra?.[PULLED_USAGE_HINT_KEY] as
+    | Record<string, unknown>
+    | undefined;
+}
+
+function cursorOf(result: { cursor: string | null }) {
+  return JSON.parse(result.cursor!) as {
+    sinceMs: number;
+    costHeldSinceMs: number | null;
+    paidBillReadThroughMs: number | null;
+  };
+}
+
+const paidRow = (
+  overrides: Partial<{
+    runAs: string;
+    day: string;
+    sku: string;
+    quantity: string;
+    amount: string | null;
+    currency: string | null;
+    surfaces: string;
+    channels: string;
+  }> = {},
+): (string | null)[] => [
+  overrides.runAs ?? "u_123@acme.test",
+  overrides.day ?? DAY,
+  overrides.sku ?? PAID_SKU,
+  overrides.quantity ?? "12.5",
+  overrides.amount === undefined ? "3.125" : overrides.amount,
+  overrides.currency === undefined ? "USD" : overrides.currency,
+  overrides.surfaces ?? "GENIE_ONE",
+  overrides.channels ?? "",
+];
+
+describe("given a Genie source that has not switched the paid bill read on", () => {
+  /** @scenario "The paid Genie bill read is off unless switched on" */
+  it("reads as off when the setting is absent", () => {
+    const parsed = databricksGeniePullConfigSchema.parse({
+      adapter: "databricks_genie",
+      workspaceUrl: WORKSPACE_URL,
+    });
+    expect(parsed.readPaidGenieBill).toBe(false);
+  });
+
+  /** @scenario "The paid Genie bill read is off unless switched on" */
+  it("never asks the workspace for the Genie bill and records no bill row", async () => {
+    billPlan = { kind: "rows", rows: [paidRow()] };
+
+    const result = await pull({});
+
+    expect(billStatements()).toHaveLength(0);
+    expect(billEvents(result)).toHaveLength(0);
+    expect(cursorOf(result).paidBillReadThroughMs).toBeNull();
+  });
+});
+
+describe("given a Genie source with the paid bill read switched on", () => {
+  describe("when the workspace bills a person's usage under a price line with a list price", () => {
+    /** @scenario "A paid Genie charge lands on the person who ran it, for that day and that price line" */
+    it("records one cost row for that person, day and price line at the list price", async () => {
+      billPlan = { kind: "rows", rows: [paidRow()] };
+
+      const result = await pull({ readPaidGenieBill: true });
+      const events = billEvents(result);
+
+      expect(events).toHaveLength(1);
+      const event = events[0]!;
+      expect(event.actor).toBe("u_123@acme.test");
+      expect(event.event_timestamp).toBe(`${DAY}T00:00:00.000Z`);
+      expect(event.cost_usd).toBe("3.125");
+
+      const hint = hintOf(event)!;
+      expect(hint.costBasis).toBe("provider_reported");
+      expect(hint.costStatus).toBe("estimate");
+      expect(hint.costUsd).toBe("3.125");
+      expect(hint.model).toBe(PAID_SKU);
+      // Never a warehouse as the agent: the bill names no space and no
+      // warehouse ran it, so the row carries no agent at all.
+      expect(hint).not.toHaveProperty("agentId");
+      expect(JSON.stringify(event)).not.toContain(WAREHOUSE_ID);
+      // The quantity travels with the row for whoever reads it.
+      expect(event.extra?.quantity).toBe("12.5");
+    });
+
+    /** @scenario "A paid Genie charge lands on the person who ran it, for that day and that price line" */
+    it("asks the workspace for the Genie bill line on the configured warehouse", async () => {
+      billPlan = { kind: "rows", rows: [] };
+
+      await pull({ readPaidGenieBill: true });
+
+      const asked = billStatements();
+      expect(asked.length).toBeGreaterThan(0);
+      const body = asked[0]!;
+      expect(body.warehouse_id).toBe(WAREHOUSE_ID);
+      const sql = String(body.statement);
+      expect(sql).toContain("FROM system.billing.usage");
+      expect(sql).toContain("billing_origin_product = 'GENIE'");
+      expect(sql).toContain("LEFT JOIN system.billing.list_prices");
+      expect(sql).toContain("identity_metadata.run_as");
+      // A separate read: the warehouse allocation's own filter, which drops
+      // every row this read exists for, is nowhere in it.
+      expect(sql).not.toContain("warehouse_id IS NOT NULL");
+      expect(sql).not.toContain("system.query.history");
+    });
+
+    /** @scenario "A paid Genie charge lands on the person who ran it, for that day and that price line" */
+    it("carries the currency when the only list price is not in dollars", async () => {
+      billPlan = {
+        kind: "rows",
+        rows: [paidRow({ amount: "2.80", currency: "EUR" })],
+      };
+
+      const result = await pull({ readPaidGenieBill: true });
+      const hint = hintOf(billEvents(result)[0]!)!;
+
+      expect(hint.costUsd).toBe("2.80");
+      expect(hint.currency).toBe("EUR");
+      // Not a dollar figure, so not in the dollar field.
+      expect(billEvents(result)[0]?.cost_usd).toBeUndefined();
+    });
+  });
+
+  describe("when the workspace reports usage under a price line with no list price", () => {
+    /** @scenario "A free Genie row lands with its usage count and no amount" */
+    it("records the row with its quantity and no amount", async () => {
+      billPlan = {
+        kind: "rows",
+        rows: [
+          paidRow({
+            sku: FREE_SKU,
+            quantity: "40",
+            amount: null,
+            currency: null,
+          }),
+        ],
+      };
+
+      const result = await pull({ readPaidGenieBill: true });
+      const events = billEvents(result);
+
+      expect(events).toHaveLength(1);
+      const event = events[0]!;
+      expect(event.extra?.quantity).toBe("40");
+      expect(event.cost_usd).toBeUndefined();
+      const hint = hintOf(event)!;
+      expect(hint).not.toHaveProperty("costUsd");
+      expect(hint.model).toBe(FREE_SKU);
+      // No zero anywhere on it: no price is not a price of nothing.
+      expect(JSON.stringify(event)).not.toContain('"0"');
+    });
+  });
+
+  describe("when a person's day spans several surfaces and channels", () => {
+    /** @scenario "Surface and channel are labels and do not split a person's day" */
+    it("asks for one row per person, day and price line, with surface and channel folded in", async () => {
+      billPlan = { kind: "rows", rows: [] };
+
+      await pull({ readPaidGenieBill: true });
+
+      const sql = String(billStatements()[0]!.statement);
+      const groupBy = sql.match(/GROUP BY\s+([^\n]+)/)?.[1] ?? "";
+      expect(groupBy).toBe("1, 2, 3");
+      expect(sql).toContain("usage_metadata.genie.surface");
+      expect(sql).toContain("usage_metadata.genie.channel");
+    });
+
+    /** @scenario "Surface and channel are labels and do not split a person's day" */
+    it("keeps surface and channel out of what identifies the row", async () => {
+      billPlan = {
+        kind: "rows",
+        rows: [
+          paidRow({
+            surfaces: "GENIE_CODE,GENIE_ONE",
+            channels: "SLACK,TEAMS",
+          }),
+        ],
+      };
+
+      const result = await pull({ readPaidGenieBill: true });
+      const event = billEvents(result)[0]!;
+      const hint = hintOf(event)!;
+
+      // Labels, on the row.
+      expect(event.extra?.surfaces).toBe("GENIE_CODE,GENIE_ONE");
+      expect(event.extra?.channels).toBe("SLACK,TEAMS");
+      // Not in the key: the dimensions the restatement key hashes name the
+      // person and the price line and nothing else about the usage.
+      expect(hint.dimensions).toEqual({
+        line: "genie_bill",
+        runAs: "u_123@acme.test",
+        skuName: PAID_SKU,
+      });
+      expect(event.source_event_id).not.toContain("GENIE_CODE");
+      expect(event.source_event_id).not.toContain("SLACK");
+    });
+  });
+
+  describe("when the bill answer stops short", () => {
+    const stops: { name: string; plan: StatementPlan; reported: boolean }[] = [
+      {
+        name: "it comes back cut short",
+        plan: { kind: "rows", rows: [paidRow()], cutShort: true },
+        reported: false,
+      },
+      {
+        name: "it runs out of time",
+        plan: { kind: "state", state: "CANCELED" },
+        reported: false,
+      },
+      {
+        name: "it is refused",
+        plan: { kind: "http", status: 403 },
+        reported: true,
+      },
+      {
+        name: "the statement itself fails",
+        plan: { kind: "state", state: "FAILED" },
+        reported: true,
+      },
+    ];
+
+    for (const stop of stops) {
+      /** @scenario "A paid Genie read that stops short holds its place and lands nothing" */
+      it(`lands nothing and holds its own place when ${stop.name}`, async () => {
+        billPlan = stop.plan;
+
+        const result = await pull({ readPaidGenieBill: true });
+
+        expect(billEvents(result)).toHaveLength(0);
+        expect(result.errorCount).toBe(0);
+        const cursor = cursorOf(result);
+        // Its own place: a fresh read that could not finish has none to move.
+        expect(cursor.paidBillReadThroughMs).toBeNull();
+        // And the warehouse read's place is untouched by it: that read priced
+        // its window whole, so the watermark moved and nothing is held.
+        expect(cursor.sinceMs).toBeGreaterThan(Date.now() - HOUR_MS);
+        expect(cursor.costHeldSinceMs).toBeNull();
+        if (stop.reported) {
+          expect(result.notices).toContain(PAID_GENIE_BILL_UNREADABLE);
+        } else {
+          expect(result.notices ?? []).not.toContain(
+            PAID_GENIE_BILL_UNREADABLE,
+          );
+        }
+      });
+    }
+
+    /** @scenario "A paid Genie read that stops short holds its place and lands nothing" */
+    it("keeps the paid bill's own place moving when the warehouse read is the one held", async () => {
+      warehousePlan = { kind: "http", status: 403 };
+      billPlan = { kind: "rows", rows: [paidRow()] };
+
+      const result = await pull({ readPaidGenieBill: true });
+      const cursor = cursorOf(result);
+
+      expect(billEvents(result)).toHaveLength(1);
+      expect(cursor.paidBillReadThroughMs).not.toBeNull();
+      expect(cursor.costHeldSinceMs).not.toBeNull();
+    });
+
+    /** @scenario "A paid Genie read that stops short holds its place and lands nothing" */
+    it("starts the next read from where the last one reached, looking back a little", async () => {
+      billPlan = { kind: "rows", rows: [] };
+      const first = await pull({ readPaidGenieBill: true });
+      const reachedMs = cursorOf(first).paidBillReadThroughMs!;
+      expect(reachedMs).toBeGreaterThan(Date.now() - 24 * HOUR_MS);
+
+      statementBodies = [];
+      const second = await pull({
+        readPaidGenieBill: true,
+        cursor: first.cursor,
+      });
+
+      const asked = billStatements();
+      expect(asked.length).toBeGreaterThan(0);
+      const from = (
+        asked[0]!.parameters as { name: string; value: string }[]
+      ).find((p) => p.name === "from_date")!.value;
+      // Behind where it reached — a day's bill keeps landing after the day —
+      // but not back at the start of history.
+      expect(Date.parse(from)).toBeLessThanOrEqual(reachedMs);
+      expect(Date.parse(from)).toBeGreaterThan(reachedMs - 4 * 24 * HOUR_MS);
+      expect(cursorOf(second).paidBillReadThroughMs).toBeGreaterThanOrEqual(
+        reachedMs,
+      );
+    });
+  });
+
+  describe("when the source names no warehouse to run the read on", () => {
+    /** @scenario "A paid Genie read that stops short holds its place and lands nothing" */
+    it("lands nothing, holds its place and says a warehouse is needed", async () => {
+      billPlan = { kind: "rows", rows: [paidRow()] };
+
+      const result = await pull({ readPaidGenieBill: true, warehouseId: "" });
+
+      expect(billStatements()).toHaveLength(0);
+      expect(billEvents(result)).toHaveLength(0);
+      expect(cursorOf(result).paidBillReadThroughMs).toBeNull();
+      expect(result.notices).toContain(PAID_GENIE_BILL_UNREADABLE);
+    });
+  });
+});

--- a/platform/app/ee/governance/services/pullers/__tests__/databricksGeniePaidBill.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/databricksGeniePaidBill.unit.test.ts
@@ -188,7 +188,9 @@ async function pull({
       spaceIds: [],
       schedule: "*/15 * * * *",
       ...(warehouseId ? { warehouseId } : {}),
-      ...(readPaidGenieBill === undefined ? {} : { readPaidGenieBill }),
+      // What the schema's default would have filled in; the config is built
+      // by hand here rather than parsed.
+      readPaidGenieBill: readPaidGenieBill ?? false,
     },
   );
 }

--- a/platform/app/ee/governance/services/pullers/__tests__/databricksGeniePuller.integration.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/databricksGeniePuller.integration.test.ts
@@ -866,15 +866,17 @@ describe("given a Genie workspace the credential can fully read", () => {
       expect(row.ActorEmail).toBe("priya.nair@acme.test");
     });
 
-    /** @scenario "A question costs nothing when no warehouse is named" */
-    it("records the questions with no cost attached", async () => {
+    /** @scenario "A question carries no amount when no warehouse is named" */
+    it("lands no money row for the questions: no amount, not zero", async () => {
       const totals = await pulledTotalsFor({
         tenantId: seeded.govProjectId,
         scopeIds: [seeded.teamId, seeded.organizationId],
       });
-      expect(totals.items).toBe(4);
+      // The four questions sit in the audit trail (asserted above). With no
+      // warehouse named there is no bill behind them, so nothing reaches the
+      // money ledger: a zero row here would be a measurement nobody made.
+      expect(totals.items).toBe(0);
       expect(totals.spentNanoUsd).toBe(0);
-      expect(totals.spentUsd).toBe("0");
     });
 
     it("anchors the watermark to when the sweep began, not to the newest message", () => {

--- a/platform/app/ee/governance/services/pullers/__tests__/databricksGenieSpaceWalk.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/databricksGenieSpaceWalk.unit.test.ts
@@ -36,6 +36,7 @@ const config = {
   workspaceUrl,
   spaceIds: [],
   schedule: "*/15 * * * *",
+  readPaidGenieBill: false,
 };
 
 const requestedUrls = () =>

--- a/platform/app/ee/governance/services/pullers/__tests__/databricksGenieUnpricedHold.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/databricksGenieUnpricedHold.unit.test.ts
@@ -1,0 +1,328 @@
+// SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+
+/**
+ * @vitest-environment node
+ *
+ * A Genie question is never a measured zero.
+ *
+ * Genie bills nothing per question; the compute behind it is on the
+ * warehouse's bill, which lands later and only when the credential can read
+ * the billing tables. Two things follow, and both are asserted here through
+ * `runOnce` with the transport mocked: a question whose bill has not answered
+ * carries no amount at all rather than zero, and a warehouse whose bill cannot
+ * be read holds the source's place instead of closing the period at zero.
+ *
+ * Spec: specs/governance/pulled-usage-cost-reporting.feature
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  DatabricksGeniePuller,
+  WAREHOUSE_COST_UNREADABLE,
+} from "../databricksGenie.puller";
+import { PULLED_USAGE_HINT_KEY } from "../pulledUsageRecord";
+
+vi.mock("~/utils/ssrfProtection", () => ({ ssrfSafeFetch: vi.fn() }));
+const { ssrfSafeFetch } = await import("~/utils/ssrfProtection");
+const fetchMock = vi.mocked(ssrfSafeFetch);
+
+const WORKSPACE_URL = "https://adb-1.azuredatabricks.net";
+const WAREHOUSE_ID = "095eb666b2ed2762";
+const STATEMENT_ID = "stmt-abc";
+const HOUR_MS = 60 * 60 * 1000;
+
+const reply = (body: unknown, status = 200) =>
+  ({
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? "" : "refused",
+    json: async () => body,
+  }) as unknown as Awaited<ReturnType<typeof ssrfSafeFetch>>;
+
+const WAREHOUSE_COST_COLUMNS = [
+  "statement_id",
+  "usage_hour",
+  "execution_ms_in_hour",
+  "hour_total_ms",
+  "hour_billable_usd",
+  "currency_code",
+  "sku_name",
+];
+
+/** The whole hour an instant falls in, as the workspace would report it. */
+function usageHourOf(atMs: number): string {
+  return new Date(Math.floor(atMs / HOUR_MS) * HOUR_MS).toISOString();
+}
+
+type BillingAnswer =
+  | { kind: "rows"; rows: (string | null)[][] }
+  | { kind: "http"; status: number }
+  | { kind: "state"; state: string };
+
+let billing: BillingAnswer;
+let messageCreatedMs: number;
+
+/** Every call the adapter made to run a statement, in order. */
+function statementCalls(): number {
+  return fetchMock.mock.calls.filter(([url]) =>
+    String(url).includes("/api/2.0/sql/statements"),
+  ).length;
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  billing = { kind: "rows", rows: [] };
+  messageCreatedMs = Date.now() - 60_000;
+
+  fetchMock.mockImplementation(async (url: string, init) => {
+    const path = String(url).replace(WORKSPACE_URL, "");
+    if (path.startsWith("/api/2.0/genie/spaces?")) {
+      return reply({ spaces: [{ space_id: "space-1", title: "Revenue" }] });
+    }
+    if (path.startsWith("/api/2.0/genie/spaces/space-1/conversations?")) {
+      return reply({
+        conversations: [{ conversation_id: "conv-1", title: "How many?" }],
+      });
+    }
+    if (
+      path.startsWith(
+        "/api/2.0/genie/spaces/space-1/conversations/conv-1/messages",
+      )
+    ) {
+      return reply({
+        messages: [
+          {
+            message_id: "msg-1",
+            content: "How many orders last week?",
+            status: "COMPLETED",
+            created_timestamp: messageCreatedMs,
+            user_id: 42,
+            attachments: [
+              {
+                query: {
+                  query: "SELECT count(*) FROM orders",
+                  statement_id: STATEMENT_ID,
+                  query_result_metadata: { row_count: 1 },
+                },
+              },
+            ],
+          },
+        ],
+      });
+    }
+    if (path.startsWith("/api/2.0/preview/scim/v2/Users/")) {
+      return reply({
+        id: "42",
+        userName: "u_123@acme.test",
+        displayName: "Dana",
+        active: true,
+      });
+    }
+    if (path === "/api/2.0/sql/statements" && init?.method === "POST") {
+      if (billing.kind === "http") return reply({}, billing.status);
+      if (billing.kind === "state") {
+        return reply({
+          statement_id: "fixture",
+          status: { state: billing.state, error: { message: "no grant" } },
+        });
+      }
+      return reply({
+        statement_id: "fixture",
+        status: { state: "SUCCEEDED" },
+        manifest: {
+          schema: { columns: WAREHOUSE_COST_COLUMNS.map((name) => ({ name })) },
+        },
+        result: { data_array: billing.rows },
+      });
+    }
+    return reply({ error: `unrouted ${path}` }, 404);
+  });
+});
+
+async function pull({
+  warehouseId,
+  cursor = null,
+}: {
+  warehouseId?: string;
+  cursor?: string | null;
+}) {
+  return await new DatabricksGeniePuller().runOnce(
+    { cursor, credentials: { token: "dapi-fixture" } },
+    {
+      adapter: "databricks_genie",
+      workspaceUrl: WORKSPACE_URL,
+      spaceIds: [],
+      schedule: "*/15 * * * *",
+      ...(warehouseId ? { warehouseId } : {}),
+    },
+  );
+}
+
+function hintOf(result: { events: { extra?: Record<string, unknown> }[] }) {
+  const extra = result.events[0]?.extra;
+  return extra?.[PULLED_USAGE_HINT_KEY] as Record<string, unknown> | undefined;
+}
+
+function cursorOf(result: { cursor: string | null }) {
+  return JSON.parse(result.cursor!) as {
+    sinceMs: number;
+    costHeldSinceMs: number | null;
+  };
+}
+
+describe("given a Genie question whose bill has not answered", () => {
+  describe("when the source names no warehouse", () => {
+    /** @scenario "A Genie message whose bill has not answered carries no amount" */
+    it("records the question with no amount at all, not zero", async () => {
+      const result = await pull({});
+
+      expect(result.events).toHaveLength(1);
+      expect(result.events[0]?.cost_usd).toBeUndefined();
+      // The hint is still there — it is what makes the message a cost item
+      // once a bill lands — but it names no amount.
+      expect(hintOf(result)).toBeDefined();
+      expect(hintOf(result)).not.toHaveProperty("costUsd");
+      expect(statementCalls()).toBe(0);
+    });
+  });
+
+  describe("when the warehouse has not billed the question's hour yet", () => {
+    /** @scenario "A Genie message whose bill has not answered carries no amount" */
+    it("records the question with no amount and no zero anywhere on it", async () => {
+      // Seen in the query history, no billing row yet: a null SKU.
+      billing = {
+        kind: "rows",
+        rows: [
+          [
+            STATEMENT_ID,
+            usageHourOf(messageCreatedMs),
+            "1800000",
+            "3600000",
+            null,
+            null,
+            null,
+          ],
+        ],
+      };
+
+      const result = await pull({ warehouseId: WAREHOUSE_ID });
+
+      expect(result.events).toHaveLength(1);
+      expect(result.events[0]?.cost_usd).toBeUndefined();
+      expect(hintOf(result)).toBeDefined();
+      expect(hintOf(result)).not.toHaveProperty("costUsd");
+      expect(JSON.stringify(result.events[0])).not.toContain('"0"');
+    });
+
+    /** @scenario "A Genie message whose bill has not answered carries no amount" */
+    it("prices the question on the run the bill lands", async () => {
+      billing = { kind: "rows", rows: [] };
+      const first = await pull({ warehouseId: WAREHOUSE_ID });
+      expect(hintOf(first)).not.toHaveProperty("costUsd");
+
+      billing = {
+        kind: "rows",
+        rows: [
+          [
+            STATEMENT_ID,
+            usageHourOf(messageCreatedMs),
+            "1800000",
+            "3600000",
+            "6.00",
+            "USD",
+            "PREMIUM_SERVERLESS_SQL_COMPUTE_EU_WEST",
+          ],
+        ],
+      };
+      const second = await pull({
+        warehouseId: WAREHOUSE_ID,
+        cursor: first.cursor,
+      });
+
+      expect(hintOf(second)?.costUsd).toBe("3");
+      expect(second.events[0]?.cost_usd).toBe("3");
+    });
+  });
+});
+
+describe("given a warehouse whose bill cannot be read", () => {
+  const refusals: { name: string; answer: BillingAnswer }[] = [
+    {
+      name: "the billing query is refused",
+      answer: { kind: "http", status: 403 },
+    },
+    {
+      name: "the warehouse no longer exists",
+      answer: { kind: "http", status: 404 },
+    },
+    {
+      name: "the statement itself fails",
+      answer: { kind: "state", state: "FAILED" },
+    },
+  ];
+
+  for (const refusal of refusals) {
+    describe(`when ${refusal.name}`, () => {
+      /** @scenario "A warehouse that cannot be read holds the day open instead of closing it at zero" */
+      it("keeps the questions unpriced and holds its place for the next run", async () => {
+        billing = refusal.answer;
+        const startedFrom = Date.now() - 3 * 24 * HOUR_MS;
+
+        const result = await pull({
+          warehouseId: WAREHOUSE_ID,
+          cursor: JSON.stringify({ sinceMs: startedFrom }),
+        });
+
+        // Still recorded, still a run that worked.
+        expect(result.events).toHaveLength(1);
+        expect(result.errorCount).toBe(0);
+        expect(result.events[0]?.cost_usd).toBeUndefined();
+        expect(hintOf(result)).not.toHaveProperty("costUsd");
+
+        // Held, not closed: the watermark did not move past the period the
+        // bill could not answer for, and the hold clock started.
+        const cursor = cursorOf(result);
+        expect(cursor.sinceMs).toBe(startedFrom);
+        expect(cursor.costHeldSinceMs).not.toBeNull();
+
+        // And the run says so, in a form a reader of the source can be shown.
+        expect(result.notices).toContain(WAREHOUSE_COST_UNREADABLE);
+      });
+    });
+  }
+
+  describe("when the bill can be read again on a later run", () => {
+    /** @scenario "A warehouse that cannot be read holds the day open instead of closing it at zero" */
+    it("prices the held question and releases the hold", async () => {
+      billing = { kind: "http", status: 404 };
+      const first = await pull({
+        warehouseId: WAREHOUSE_ID,
+        cursor: JSON.stringify({ sinceMs: Date.now() - 3 * 24 * HOUR_MS }),
+      });
+      expect(cursorOf(first).costHeldSinceMs).not.toBeNull();
+
+      billing = {
+        kind: "rows",
+        rows: [
+          [
+            STATEMENT_ID,
+            usageHourOf(messageCreatedMs),
+            "1800000",
+            "3600000",
+            "6.00",
+            "USD",
+            "PREMIUM_SERVERLESS_SQL_COMPUTE_EU_WEST",
+          ],
+        ],
+      };
+      const second = await pull({
+        warehouseId: WAREHOUSE_ID,
+        cursor: first.cursor,
+      });
+
+      expect(hintOf(second)?.costUsd).toBe("3");
+      expect(cursorOf(second).costHeldSinceMs).toBeNull();
+      expect(second.notices ?? []).not.toContain(WAREHOUSE_COST_UNREADABLE);
+    });
+  });
+});

--- a/platform/app/ee/governance/services/pullers/__tests__/databricksGenieUnpricedHold.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/databricksGenieUnpricedHold.unit.test.ts
@@ -153,6 +153,7 @@ async function pull({
       workspaceUrl: WORKSPACE_URL,
       spaceIds: [],
       schedule: "*/15 * * * *",
+      readPaidGenieBill: false,
       ...(warehouseId ? { warehouseId } : {}),
     },
   );

--- a/platform/app/ee/governance/services/pullers/__tests__/databricksGenieWarehouseCost.integration.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/databricksGenieWarehouseCost.integration.test.ts
@@ -277,6 +277,7 @@ async function pull({
       workspaceUrl: baseUrl,
       spaceIds: [],
       schedule: "*/15 * * * *",
+      readPaidGenieBill: false,
       ...(warehouseId ? { warehouseId } : {}),
     },
   );
@@ -617,6 +618,7 @@ describe("a source that names a warehouse", () => {
         workspaceUrl: baseUrl,
         spaceIds: [],
         schedule: "*/15 * * * *",
+        readPaidGenieBill: false,
         warehouseId: WAREHOUSE_ID,
       },
     );
@@ -913,6 +915,7 @@ describe("a source that names a warehouse", () => {
         workspaceUrl: baseUrl,
         spaceIds: [],
         schedule: "*/15 * * * *",
+        readPaidGenieBill: false,
         warehouseId: WAREHOUSE_ID,
       },
     );
@@ -981,6 +984,7 @@ describe("a source that names a warehouse", () => {
         workspaceUrl: baseUrl,
         spaceIds: [],
         schedule: "*/15 * * * *",
+        readPaidGenieBill: false,
         warehouseId: WAREHOUSE_ID,
       },
     );
@@ -1055,6 +1059,7 @@ describe("a source that names a warehouse", () => {
           workspaceUrl: baseUrl,
           spaceIds: [],
           schedule: "*/15 * * * *",
+          readPaidGenieBill: false,
           warehouseId: WAREHOUSE_ID,
         },
       );
@@ -1118,6 +1123,7 @@ describe("a source that names a warehouse", () => {
         workspaceUrl: baseUrl,
         spaceIds: [],
         schedule: "*/15 * * * *",
+        readPaidGenieBill: false,
         warehouseId: WAREHOUSE_ID,
       },
     );
@@ -1299,6 +1305,7 @@ describe("a source that names a warehouse", () => {
         workspaceUrl: baseUrl,
         spaceIds: [],
         schedule: "*/15 * * * *",
+        readPaidGenieBill: false,
         warehouseId: WAREHOUSE_ID,
       },
     );
@@ -1339,6 +1346,7 @@ describe("a source that names a warehouse", () => {
         workspaceUrl: baseUrl,
         spaceIds: [],
         schedule: "*/15 * * * *",
+        readPaidGenieBill: false,
       },
     );
 
@@ -1429,6 +1437,7 @@ describe("a billing answer that did not come back", () => {
         workspaceUrl: baseUrl,
         spaceIds: [],
         schedule: "*/15 * * * *",
+        readPaidGenieBill: false,
         warehouseId: WAREHOUSE_ID,
       },
     );

--- a/platform/app/ee/governance/services/pullers/__tests__/databricksGenieWarehouseCost.integration.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/databricksGenieWarehouseCost.integration.test.ts
@@ -34,6 +34,7 @@ import {
   DATABRICKS_GENIE_ADAPTER_ID,
   DatabricksGeniePuller,
   WAREHOUSE_COST_ROW_LIMIT,
+  WAREHOUSE_COST_UNREADABLE,
 } from "../databricksGenie.puller";
 import {
   WAREHOUSE_COST_MAX_HOLD_MS,
@@ -288,13 +289,15 @@ function hintOf(result: { events: { extra?: Record<string, unknown> }[] }) {
 }
 
 describe("a source with no warehouse", () => {
-  /** @scenario "A question costs nothing when no warehouse is named" */
-  it("records the question at zero and never asks about billing", async () => {
+  /** @scenario "A question carries no amount when no warehouse is named" */
+  it("records the question with no amount and never asks about billing", async () => {
     const result = await pull({});
 
     expect(result.events).toHaveLength(1);
-    expect(result.events[0]?.cost_usd).toBe("0");
-    expect(hintOf(result).costUsd).toBe("0");
+    // No amount, not zero: there is no bill to back a figure, and a zero here
+    // would land on the ledger as a measurement.
+    expect(result.events[0]?.cost_usd).toBeUndefined();
+    expect(hintOf(result)).not.toHaveProperty("costUsd");
     // The claim that matters: not merely that cost is zero, but that a source
     // which opted out never went near the billing tables.
     expect(statementBodies).toHaveLength(0);
@@ -316,7 +319,7 @@ describe("a source whose run has no time left to read billing", () => {
     // The questions survive, unpriced. That is the whole point: an unpriced
     // window is asked again next run, a discarded sweep is not.
     expect(result.events).toHaveLength(1);
-    expect(result.events[0]?.cost_usd).toBe("0");
+    expect(result.events[0]?.cost_usd).toBeUndefined();
     // And it never opened a request it could not have finished.
     expect(statementBodies).toHaveLength(0);
   });
@@ -658,7 +661,7 @@ describe("a source that names a warehouse", () => {
     const result = await pull({ warehouseId: WAREHOUSE_ID });
 
     expect(result.events).toHaveLength(1);
-    expect(hintOf(result).costUsd).toBe("0");
+    expect(hintOf(result)).not.toHaveProperty("costUsd");
   });
 
   /** @scenario "Billing answered in a shape we did not ask for is not priced from" */
@@ -683,7 +686,7 @@ describe("a source that names a warehouse", () => {
     const result = await pull({ warehouseId: WAREHOUSE_ID });
 
     expect(result.events).toHaveLength(1);
-    expect(hintOf(result).costUsd).toBe("0");
+    expect(hintOf(result)).not.toHaveProperty("costUsd");
   });
 
   /** @scenario "A question that ran no SQL is charged nothing" */
@@ -707,7 +710,7 @@ describe("a source that names a warehouse", () => {
 
     expect(result.events).toHaveLength(1);
     // A priced statement exists in the window; this question simply is not it.
-    expect(hintOf(result).costUsd).toBe("0");
+    expect(hintOf(result)).not.toHaveProperty("costUsd");
   });
 
   /** @scenario "The puller's own billing query is not charged to a question" */
@@ -730,7 +733,7 @@ describe("a source that names a warehouse", () => {
 
     // Compute that belongs to no Genie question — the puller's own billing
     // query among it — is never handed to whichever question happens to be here.
-    expect(hintOf(result).costUsd).toBe("0");
+    expect(hintOf(result)).not.toHaveProperty("costUsd");
   });
 
   /** @scenario "A priced question calls its figure an estimate" */
@@ -791,7 +794,7 @@ describe("a source that names a warehouse", () => {
 
     const result = await pull({ warehouseId: WAREHOUSE_ID });
 
-    expect(hintOf(result).costUsd).toBe("0");
+    expect(hintOf(result)).not.toHaveProperty("costUsd");
   });
 
   /** @scenario "A cost answer that was cut short prices nothing" */
@@ -817,7 +820,7 @@ describe("a source that names a warehouse", () => {
 
     const result = await pull({ warehouseId: WAREHOUSE_ID });
 
-    expect(hintOf(result).costUsd).toBe("0");
+    expect(hintOf(result)).not.toHaveProperty("costUsd");
   });
 
   /** @scenario "A cost answer that was cut short prices nothing" */
@@ -839,7 +842,7 @@ describe("a source that names a warehouse", () => {
 
     const result = await pull({ warehouseId: WAREHOUSE_ID });
 
-    expect(hintOf(result).costUsd).toBe("0");
+    expect(hintOf(result)).not.toHaveProperty("costUsd");
   });
 
   /** @scenario "A window whose cost was cut short is asked about again" */
@@ -867,7 +870,7 @@ describe("a source that names a warehouse", () => {
     const result = await pull({ warehouseId: WAREHOUSE_ID });
     const cursor = JSON.parse(result.cursor!) as { sinceMs: number };
 
-    expect(hintOf(result).costUsd).toBe("0");
+    expect(hintOf(result)).not.toHaveProperty("costUsd");
     // Still back at the start of the window, not up at the sweep's clock.
     expect(cursor.sinceMs).toBeLessThan(Date.now() - 29 * 24 * 60 * 60 * 1000);
     // And it stopped at the first period it could not price, rather than
@@ -946,7 +949,7 @@ describe("a source that names a warehouse", () => {
     const cursor = JSON.parse(result.cursor!) as { sinceMs: number };
 
     // Recorded at zero for now — its bill does not exist yet to price from.
-    expect(hintOf(result).costUsd).toBe("0");
+    expect(hintOf(result)).not.toHaveProperty("costUsd");
     // But the watermark held BEHIND the unbilled hour, not at the sweep's
     // clock. This is the assertion the old code failed: a seen-but-unbilled
     // statement would have been passed over for good. The bound is the hour
@@ -998,20 +1001,24 @@ describe("a source that names a warehouse", () => {
     expect(cursor.sinceMs).toBeGreaterThan(Date.now() - 60 * 60 * 1000);
   });
 
-  /** @scenario "A window whose cost was cut short is asked about again" */
-  it("moves the watermark on when billing refuses the question outright", async () => {
-    // Deliberately NOT held. A cut-short answer proves rows exist that a
-    // narrower question could still reach; a refusal proves nothing, and asking
-    // again would be refused the same way. Holding here would stall a workspace
-    // that never granted the billing tables, forever, with no way out but
-    // turning the feature off — a worse failure than the questions carrying no
-    // cost, which is what they carried before any of this existed.
+  /** @scenario "A warehouse that cannot be read holds the day open instead of closing it at zero" */
+  it("holds the watermark when billing refuses the question outright", async () => {
+    // Held, the same way an answer cut short is. A refusal used to move the
+    // watermark on, on the argument that asking again would be refused the
+    // same way — but the questions it moved past carried no amount, and
+    // moving past them made that permanent. The hold is bounded by
+    // `WAREHOUSE_COST_MAX_HOLD_MS`, which is what keeps a workspace that never
+    // granted the billing tables from pinning itself forever.
     costPlan = { status: 403 };
 
     const result = await pull({ warehouseId: WAREHOUSE_ID });
-    const cursor = JSON.parse(result.cursor!) as { sinceMs: number };
+    const cursor = JSON.parse(result.cursor!) as {
+      sinceMs: number;
+      costHeldSinceMs: number | null;
+    };
 
-    expect(cursor.sinceMs).toBeGreaterThan(Date.now() - 60 * 60 * 1000);
+    expect(cursor.sinceMs).toBeLessThan(Date.now() - 29 * 24 * 60 * 60 * 1000);
+    expect(cursor.costHeldSinceMs).not.toBeNull();
   });
 
   /** @scenario "A window whose cost was cut short is asked about again" */
@@ -1124,9 +1131,9 @@ describe("a source that names a warehouse", () => {
     // And the stamp is cleared with it. Left behind, it would expire every
     // future hold the moment it started and the retry would never work again.
     expect(cursor.costHeldSinceMs).toBeNull();
-    // The questions in the abandoned period keep the zero they came with,
-    // rather than being dropped or invented.
-    expect(hintOf(result).costUsd).toBe("0");
+    // The questions in the abandoned period stay unpriced — no amount, never
+    // a zero — rather than being dropped or invented.
+    expect(hintOf(result)).not.toHaveProperty("costUsd");
   });
 
   /** @scenario "Cost that arrives late corrects the record rather than adding one" */
@@ -1136,7 +1143,7 @@ describe("a source that names a warehouse", () => {
     // First run: the compute has not been published yet.
     costPlan = { rows: [] };
     const first = await pull({ warehouseId: WAREHOUSE_ID });
-    expect(hintOf(first).costUsd).toBe("0");
+    expect(hintOf(first)).not.toHaveProperty("costUsd");
 
     // Second run, after the bill lands.
     costPlan = {
@@ -1202,7 +1209,7 @@ describe("a source that names a warehouse", () => {
     const result = await pull({ warehouseId: WAREHOUSE_ID });
 
     expect(result.events).toHaveLength(1);
-    expect(hintOf(result).costUsd).toBe("0");
+    expect(hintOf(result)).not.toHaveProperty("costUsd");
   });
 
   /** @scenario "A billing outage does not discard the questions" */
@@ -1212,11 +1219,13 @@ describe("a source that names a warehouse", () => {
     const result = await pull({ warehouseId: WAREHOUSE_ID });
 
     expect(result.events).toHaveLength(1);
-    expect(hintOf(result).costUsd).toBe("0");
+    expect(hintOf(result)).not.toHaveProperty("costUsd");
     // Not an error count: the sweep did its job. A source that reported a
     // failure here would look broken to an admin who has simply not granted
-    // the billing tables.
+    // the billing tables. The refusal is reported as a notice instead, which
+    // a reader of the source can be shown.
     expect(result.errorCount).toBe(0);
+    expect(result.notices).toContain(WAREHOUSE_COST_UNREADABLE);
   });
 
   it("keeps the questions when the billing query is cancelled on its wait", async () => {
@@ -1225,7 +1234,7 @@ describe("a source that names a warehouse", () => {
     const result = await pull({ warehouseId: WAREHOUSE_ID });
 
     expect(result.events).toHaveLength(1);
-    expect(hintOf(result).costUsd).toBe("0");
+    expect(hintOf(result)).not.toHaveProperty("costUsd");
   });
 
   /** @scenario "Compute the workspace prices in another currency is not converted" */
@@ -1247,7 +1256,7 @@ describe("a source that names a warehouse", () => {
     const result = await pull({ warehouseId: WAREHOUSE_ID });
 
     expect(result.events).toHaveLength(1);
-    expect(hintOf(result).costUsd).toBe("0");
+    expect(hintOf(result)).not.toHaveProperty("costUsd");
   });
 
   /** @scenario "A source that prices its questions keeps looking back far enough" */
@@ -1386,7 +1395,7 @@ describe("a billing answer that did not come back", () => {
     const result = await pull({ warehouseId: WAREHOUSE_ID });
     const cursor = JSON.parse(result.cursor!) as { sinceMs: number };
 
-    expect(hintOf(result).costUsd).toBe("0");
+    expect(hintOf(result)).not.toHaveProperty("costUsd");
     // Still back at the start of the month. A watermark up at the sweep's clock
     // means those thirty days are never looked at again and their zero is final.
     expect(cursor.sinceMs).toBeLessThan(Date.now() - 29 * 24 * 60 * 60 * 1000);
@@ -1432,34 +1441,62 @@ describe("a billing answer that did not come back", () => {
     expect(hintOf(second).costUsd).toBe("6");
   });
 
-  /** @scenario "Billing refusing the question outright is still not held" */
-  it("moves on when the statement itself fails", async () => {
+  /** @scenario "A warehouse that cannot be read holds the day open instead of closing it at zero" */
+  it("holds and reports when the statement itself fails", async () => {
     // A missing grant comes back as a request that succeeded carrying a
     // statement that did not. Asking about less would fail the same way, so
-    // holding here would stall the source with no way out but turning the
-    // feature off. Green before the change above and required to stay green
-    // after it: that is the whole reason the cancelled case is phrased about
-    // time rather than about failure.
+    // the pieces are not tried — but the period is held, not written off: the
+    // questions carry no amount, and moving past them would make that
+    // permanent. The run says why it is holding.
     costPlan = { state: "FAILED", rows: [] };
 
     const result = await pull({ warehouseId: WAREHOUSE_ID });
-    const cursor = JSON.parse(result.cursor!) as { sinceMs: number };
+    const cursor = JSON.parse(result.cursor!) as {
+      sinceMs: number;
+      costHeldSinceMs: number | null;
+    };
 
     expect(result.events).toHaveLength(1);
-    expect(cursor.sinceMs).toBeGreaterThan(Date.now() - 60 * 60 * 1000);
+    expect(cursor.sinceMs).toBeLessThan(Date.now() - 29 * 24 * 60 * 60 * 1000);
+    expect(cursor.costHeldSinceMs).not.toBeNull();
+    expect(result.notices).toContain(WAREHOUSE_COST_UNREADABLE);
   });
 
-  /** @scenario "Billing refusing the question outright is still not held" */
-  it("moves on when the workspace rejects the request outright", async () => {
+  /** @scenario "A warehouse that cannot be read holds the day open instead of closing it at zero" */
+  it("holds and reports when the workspace rejects the request outright", async () => {
     // The other door to the same answer: a revoked or unprivileged token is
     // refused before any statement runs. Both have to reach the same place.
     costPlan = { status: 403 };
 
     const result = await pull({ warehouseId: WAREHOUSE_ID });
-    const cursor = JSON.parse(result.cursor!) as { sinceMs: number };
+    const cursor = JSON.parse(result.cursor!) as {
+      sinceMs: number;
+      costHeldSinceMs: number | null;
+    };
 
     expect(result.events).toHaveLength(1);
-    expect(cursor.sinceMs).toBeGreaterThan(Date.now() - 60 * 60 * 1000);
+    expect(cursor.sinceMs).toBeLessThan(Date.now() - 29 * 24 * 60 * 60 * 1000);
+    expect(cursor.costHeldSinceMs).not.toBeNull();
+    expect(result.notices).toContain(WAREHOUSE_COST_UNREADABLE);
+  });
+
+  /** @scenario "A warehouse that cannot be read holds the day open instead of closing it at zero" */
+  it("holds and reports when the warehouse no longer exists", async () => {
+    // A deleted warehouse is the refusal an admin can put right by naming
+    // another one. Until then the period is held, not closed at zero.
+    costPlan = { status: 404 };
+
+    const result = await pull({ warehouseId: WAREHOUSE_ID });
+    const cursor = JSON.parse(result.cursor!) as {
+      sinceMs: number;
+      costHeldSinceMs: number | null;
+    };
+
+    expect(result.events).toHaveLength(1);
+    expect(hintOf(result)).not.toHaveProperty("costUsd");
+    expect(cursor.sinceMs).toBeLessThan(Date.now() - 29 * 24 * 60 * 60 * 1000);
+    expect(cursor.costHeldSinceMs).not.toBeNull();
+    expect(result.notices).toContain(WAREHOUSE_COST_UNREADABLE);
   });
 });
 

--- a/platform/app/ee/governance/services/pullers/__tests__/openaiCompliancePuller.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/openaiCompliancePuller.unit.test.ts
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+
+/**
+ * The OpenAI compliance reference puller. The S3 transport is stubbed; what is
+ * under test is the locked mapping: who the audit row says acted, and what of
+ * the provider's line survives into the record.
+ *
+ * Every compliance line carries the person's id AND their email. The id is
+ * the actor; the address must reach neither the event nor the audit row, and
+ * a verbatim copy of the line would carry it there by the back door.
+ *
+ * Spec: specs/ai-governance/puller-framework/s3-polling.feature
+ */
+import { Readable } from "node:stream";
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const stub = vi.hoisted(() => ({
+  objects: [] as { key: string; body: string }[],
+}));
+
+vi.mock("@aws-sdk/client-s3", () => {
+  class ListObjectsV2Command {
+    constructor(readonly input: { Prefix?: string; StartAfter?: string }) {}
+  }
+  class GetObjectCommand {
+    constructor(readonly input: { Bucket: string; Key: string }) {}
+  }
+  class S3Client {
+    async send(cmd: ListObjectsV2Command | GetObjectCommand) {
+      if (cmd instanceof ListObjectsV2Command) {
+        return {
+          Contents: stub.objects.map((o) => ({ Key: o.key })),
+          IsTruncated: false,
+        };
+      }
+      const found = stub.objects.find((o) => o.key === cmd.input.Key);
+      if (!found) throw new Error(`stub: missing ${cmd.input.Key}`);
+      return { Body: Readable.from([Buffer.from(found.body, "utf-8")]) };
+    }
+  }
+  return { S3Client, ListObjectsV2Command, GetObjectCommand };
+});
+
+import { mapToOcsfRow } from "../ocsfPullEventMapping";
+import { OpenAiComplianceReferencePuller } from "../openaiCompliance.puller";
+
+const PERSON_ID = "u_123";
+const PERSON_EMAIL = "person@acme.example";
+
+/** One line in the shape OpenAI documents for its compliance export. */
+const COMPLIANCE_LINE = {
+  id: "evt-1",
+  object: "audit_log",
+  type: "completion",
+  user: { id: PERSON_ID, email: PERSON_EMAIL },
+  model: "gpt-5-mini",
+  created_at: "2026-09-01T10:00:00Z",
+  tokens: { input: 50, output: 12 },
+  cost: { usd: 0.0023 },
+};
+
+const ADMIN_INPUT = {
+  bucket: "acme-audit",
+  prefix: "openai/compliance/",
+  region: "us-east-1",
+};
+
+async function pullOneLine() {
+  stub.objects = [
+    {
+      key: "openai/compliance/2026-09-01-10.ndjson",
+      body: JSON.stringify(COMPLIANCE_LINE),
+    },
+  ];
+  const puller = new OpenAiComplianceReferencePuller();
+  const config = puller.validateConfig(ADMIN_INPUT);
+  const result = await puller.runOnce(
+    { cursor: null, credentials: {} },
+    config,
+  );
+  expect(result.errorCount).toBe(0);
+  expect(result.events).toHaveLength(1);
+  return result.events[0]!;
+}
+
+beforeEach(() => {
+  stub.objects = [];
+});
+
+describe("given an OpenAI compliance line that carries both the person's id and their email", () => {
+  describe("when the puller reads the line", () => {
+    /** @scenario "An OpenAI compliance event names the person by their provider id, never by email" */
+    it("names the person by their provider id", async () => {
+      const event = await pullOneLine();
+
+      expect(event.actor).toBe(PERSON_ID);
+    });
+
+    /** @scenario "An OpenAI compliance event names the person by their provider id, never by email" */
+    it("lets the email reach nowhere in the emitted record", async () => {
+      const event = await pullOneLine();
+
+      expect(JSON.stringify(event)).not.toContain(PERSON_EMAIL);
+    });
+
+    /** @scenario "An OpenAI compliance event keeps no raw copy of what the provider sent" */
+    it("keeps no verbatim copy of the provider's line", async () => {
+      const event = await pullOneLine();
+
+      expect(event.raw_payload).toBe("");
+    });
+  });
+
+  describe("when the worker maps it to an audit row", () => {
+    /** @scenario "An OpenAI compliance event keeps no raw copy of what the provider sent" */
+    it("carries no raw copy and no email into the audit row", async () => {
+      const event = await pullOneLine();
+
+      const row = mapToOcsfRow({
+        event,
+        tenantId: "gov-proj-1",
+        ingestionSourceId: "src-1",
+        sourceType: "openai_compliance",
+      });
+      const extension = (
+        JSON.parse(row.rawOcsfJson) as {
+          metadata: { extension: Record<string, unknown> };
+        }
+      ).metadata.extension;
+
+      expect(row.actorUserId).toBe(PERSON_ID);
+      expect(row.actorEmail).toBe("");
+      expect(extension.raw_event ?? "").toBe("");
+      expect(JSON.stringify(row)).not.toContain(PERSON_EMAIL);
+      // The line's own marker: if any verbatim copy survived, this is in it.
+      expect(JSON.stringify(row)).not.toContain('"object":"audit_log"');
+    });
+  });
+});

--- a/platform/app/ee/governance/services/pullers/__tests__/openaiCompliancePuller.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/openaiCompliancePuller.unit.test.ts
@@ -79,8 +79,13 @@ async function pullOneLine() {
     { cursor: null, credentials: {} },
     config,
   );
-  expect(result.errorCount).toBe(0);
-  expect(result.events).toHaveLength(1);
+  // A precondition of every test below, not an assertion of any of them: a
+  // line that failed to parse would make each test fail on a missing event.
+  if (result.errorCount !== 0 || result.events.length !== 1) {
+    throw new Error(
+      `expected one clean event, got ${result.events.length} with ${result.errorCount} error(s)`,
+    );
+  }
   return result.events[0]!;
 }
 

--- a/platform/app/ee/governance/services/pullers/__tests__/sourcePullStatus.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/sourcePullStatus.unit.test.ts
@@ -45,3 +45,20 @@ describe("given a source whose last run ended because the provider refused its k
     expect(JSON.stringify(pull)).not.toContain("sk-admin");
   });
 });
+
+describe("given a source whose last run was refused without a sentence of ours to show", () => {
+  /** @scenario "A refusal with no customer sentence shows the generic failure text" */
+  it("shows the generic failure text and quotes nothing from the provider", () => {
+    // The run handler writes the generic failed code for such a refusal, so
+    // the raw diagnostic arrives under `pull_failed`, never `pull_refused`.
+    const pull = status({
+      LastRunAt: 1,
+      LastRunOutcome: "failed",
+      LastRunError: "HTTP 403 (anthropic cost_report): sk-admin refused",
+      LastRunErrorCode: "pull_failed",
+    });
+    expect(pull?.error).toBe("The last pull failed.");
+    expect(JSON.stringify(pull)).not.toContain("sk-admin");
+    expect(JSON.stringify(pull)).not.toContain("403");
+  });
+});

--- a/platform/app/ee/governance/services/pullers/__tests__/sourcePullStatus.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/sourcePullStatus.unit.test.ts
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+/**
+ * What the source page says about a pull that failed.
+ * Spec: specs/governance/ingestion-source-health.feature
+ *
+ * The provider's reply may carry a token, so nearly every failure collapses
+ * to a fixed sentence. A refused key is the one failure whose message the
+ * run handler wrote itself, and the one an admin can act on, so it is the
+ * one that is shown as written.
+ */
+import { describe, expect, it } from "vitest";
+
+import { sourcePullStatus } from "../sourcePullStatus";
+
+const status = (pullRun: Parameters<typeof sourcePullStatus>[0]["pullRun"]) =>
+  sourcePullStatus({
+    sourceType: "anthropic_admin",
+    cursor: null,
+    pullRun,
+  });
+
+describe("given a source whose last run ended because the provider refused its key", () => {
+  /** @scenario "The source health row says the key was refused" */
+  it("says the provider refused the key and what to check", () => {
+    const pull = status({
+      LastRunAt: 1,
+      LastRunOutcome: "failed",
+      LastRunError:
+        "Anthropic refused this key. Check the admin key and its permissions.",
+      LastRunErrorCode: "pull_refused",
+    });
+    expect(pull?.error).toBe(
+      "Anthropic refused this key. Check the admin key and its permissions.",
+    );
+  });
+
+  it("still collapses any other failure to the generic sentence", () => {
+    const pull = status({
+      LastRunAt: 1,
+      LastRunOutcome: "failed",
+      LastRunError: "HTTP 500 (anthropic cost_report): sk-admin leaked here",
+      LastRunErrorCode: "pull_failed",
+    });
+    expect(pull?.error).toBe("The last pull failed.");
+    expect(JSON.stringify(pull)).not.toContain("sk-admin");
+  });
+});

--- a/platform/app/ee/governance/services/pullers/anthropicAdmin.puller.ts
+++ b/platform/app/ee/governance/services/pullers/anthropicAdmin.puller.ts
@@ -1125,6 +1125,20 @@ export class AnthropicAdminPuller
         retryAfterMs: parseRetryAfterMs(response.headers.get("retry-after")),
       });
     }
+    if (response.status === 401 || response.status === 403) {
+      // A refused key answers the same way on every retry, so it is not an
+      // outage to wait out: `retryable: false` stops the ladder, and the
+      // customer sentence names the one thing an admin can act on. The body
+      // is drained and never read — a refusal from this endpoint can echo
+      // request material, and nothing here should quote it.
+      await response.body?.cancel().catch(() => void 0);
+      throw new DispatchError({
+        message: `HTTP ${response.status} (anthropic ${config.report}_report): key refused`,
+        retryable: false,
+        customerMessage:
+          "Anthropic refused this key. Check the admin key and its permissions.",
+      });
+    }
     if (!response.ok) {
       throw await fetchPageError(response, config.report);
     }

--- a/platform/app/ee/governance/services/pullers/databricksGenie.puller.ts
+++ b/platform/app/ee/governance/services/pullers/databricksGenie.puller.ts
@@ -61,6 +61,7 @@ import {
   allocateWarehouseCost,
   costReadFloorMs,
   GENIE_CLIENT_APPLICATION,
+  GENIE_FREE_USAGE_SKU_MARKER,
   mergeWarehouseCost,
   WAREHOUSE_COST_MAX_HOLD_MS,
   WAREHOUSE_COST_STRADDLE_LOOKBACK_MS,
@@ -103,25 +104,29 @@ const GENIE_MODEL = "databricks/genie" as const;
 
 /**
  * The run held its place because the warehouse bill could not be read, and
- * said so.
+ * said so in its result.
  *
  * A code rather than a sentence, on `PER_KEY_ATTRIBUTION_UNAVAILABLE`'s
- * precedent: it is read by a source-health surface that owns its own wording
- * and has to survive a trip through storage. The questions are still recorded
- * — unpriced — and the period is asked about again next run; what a reader of
- * the source needs to know is that the figure they are not seeing is being
- * waited for, not that it is zero.
+ * precedent, so that it can survive a trip through storage once something
+ * stores it. Today nothing does: the run returns it in `notices`, the tests
+ * assert on it, and the worker that runs the adapter drops `notices` on the
+ * floor — no screen and no person sees this code yet. The questions are still
+ * recorded, unpriced, and the period is asked about again next run; the log
+ * line beside it is where a reader finds out that the figure they are not
+ * seeing is being waited for, not that it is zero.
  */
 export const WAREHOUSE_COST_UNREADABLE = "warehouse_cost_unreadable" as const;
 
 /**
- * The paid Genie bill line could not be read this run, and the run said so.
+ * The paid Genie bill line could not be read this run, and the run said so
+ * in its result.
  *
- * Same shape and same reason as `WAREHOUSE_COST_UNREADABLE`, for the other
+ * Same shape and same standing as `WAREHOUSE_COST_UNREADABLE`, for the other
  * read: the bill was refused, the statement failed, or the source has the read
- * switched on with no warehouse to run it on. The read holds its own place and
- * asks again next run; what the reader of the source needs to know is that the
- * rows they are not seeing are being waited for.
+ * switched on with no warehouse to run it on. Returned in `notices`, asserted
+ * by the tests, and read by nothing downstream yet. The read holds its own
+ * place and asks again next run, for as long as `WAREHOUSE_COST_MAX_HOLD_MS`
+ * allows.
  */
 export const PAID_GENIE_BILL_UNREADABLE = "paid_genie_bill_unreadable" as const;
 
@@ -748,10 +753,14 @@ function warehouseCostParameters(chunk: {
  * The two refusals are kept apart because the caller can do something about
  * one of them and nothing about the other. `cut_short` means rows exist that
  * did not arrive — asking about a smaller window can get them, so the window
- * is worth holding open and retrying. `failed` means the question was not
- * answered at all; a smaller window would be refused the same way, and holding
- * the watermark on it would stall a workspace whose billing tables simply
- * cannot be read, forever, with no way out but turning the feature off.
+ * is re-asked in pieces before it is held. `failed` means the question was
+ * not answered at all; a smaller window would be refused the same way, so the
+ * pieces are not tried and the window is held as it is. Both holds age on the
+ * same clock, `costHeldSinceMs`, and both run out at
+ * `WAREHOUSE_COST_MAX_HOLD_MS`: a workspace whose billing tables simply
+ * cannot be read holds for that long, is reported as unreadable meanwhile,
+ * and then moves on with its questions left unpriced rather than pinning the
+ * source to one instant for good.
  *
  * Collapsing the two — which is what a bare `null` did — is what let a busy
  * first sweep record a month of questions at zero and move on.
@@ -1055,7 +1064,9 @@ function readWarehouseCost({
  * Priced from `system.billing.list_prices`, LEFT joined: a SKU with no
  * published price (Genie's free line, `GENIE_FREE_USAGE`) comes back with its
  * quantity and a null amount, and lands that way — no price is not a price of
- * nothing. The price picked is the one in force during the day, dollars
+ * nothing. A SKU published AT zero is caught on the way in by
+ * `withoutZeroPrice`, so it lands the same way rather than as a measured
+ * zero. The price picked is the one in force during the day, dollars
  * preferred, latest start first; a price that changes part-way through a day
  * is applied to the whole day, which is the resolution the bill itself has.
  *
@@ -1189,6 +1200,23 @@ type PaidGenieBillRead =
   | { outcome: "failed" };
 
 /**
+ * What one run of the paid bill read leaves behind for the cursor.
+ *
+ * `window` is null when no window was asked about at all — the read is off,
+ * or on with no warehouse to run it on — so there is nothing to hold and no
+ * hold to age. Otherwise `readThroughMs` is where the read's position lands:
+ * the window's end when it finished, the start of the stopped piece when it
+ * was `held`. `endMs` is where the position lands INSTEAD once a hold has
+ * been aged out by `nextCursor`; carrying it here keeps that decision in the
+ * one place that has the clock and the previous cursor.
+ */
+type PaidGenieBillOutcome = {
+  events: NormalizedPullEvent[];
+  window: { readThroughMs: number; endMs: number; held: boolean } | null;
+  unreadable: boolean;
+};
+
+/**
  * Turn one bill reply into rows, or refuse the whole reply. Refusing whole is
  * the same rule the warehouse read follows: a partial answer lands some of a
  * period's rows and leaves the rest absent, and absent is indistinguishable
@@ -1263,7 +1291,7 @@ function readPaidGenieBill({
       unreadable += 1;
       return [];
     }
-    return [parsed.data];
+    return [withoutZeroPrice(parsed.data)];
   });
   if (unreadable > 0) {
     logger.warn(
@@ -1272,6 +1300,25 @@ function readPaidGenieBill({
     );
   }
   return { outcome: "priced", rows };
+}
+
+/**
+ * A row priced at nothing lands with no amount, not with a zero.
+ *
+ * The statement's LEFT JOIN gives Genie's free line a null amount because no
+ * list price exists for it — today. The day Databricks publishes that line at
+ * zero, `quantity * 0` comes back as a well-formed decimal, passes the parse,
+ * and lands as a measured zero dollars for usage nobody was billed for. The
+ * same holds for any SKU listed at zero: a price of nothing is not a bill,
+ * and the ledger reads a zero as one. So the free line (matched on the same
+ * marker the warehouse allocation uses) and any zero amount are stripped to
+ * quantity-only rows, which the record seam declines to price.
+ */
+function withoutZeroPrice(row: PaidGenieBillRow): PaidGenieBillRow {
+  const free =
+    row.skuName.includes(GENIE_FREE_USAGE_SKU_MARKER) ||
+    (row.amount !== null && Number(row.amount) === 0);
+  return free ? { ...row, amount: null, currencyCode: null } : row;
 }
 
 /**
@@ -1535,6 +1582,12 @@ const cursorSchema = z.object({
    * sweep read whole. A held bill read leaves this where the hold began, so
    * the next run asks about that period again; a finished one sets it to the
    * end of the window it read. `Math.max` on the way in keeps it monotonic.
+   *
+   * Written on a HELD first read as well as a finished one, and that is what
+   * pins the floor: with no configured start the floor is "thirty days ago",
+   * which is a different instant every run, so a first read that was refused
+   * and wrote nothing would ask about a window that starts a day later each
+   * day — losing a day of history per day while claiming to hold.
    */
   paidBillReadThroughMs: z
     .number()
@@ -1542,6 +1595,21 @@ const cursorSchema = z.object({
     .nonnegative()
     .nullable()
     .default(null),
+  /**
+   * When the paid bill read first stopped for a window it could not finish,
+   * or null when it is not stopped for one.
+   *
+   * `costHeldSinceMs` for the other read, and for the same reason: a hold is
+   * a bet that the bill is merely late, and a workspace that refuses the
+   * billing tables every run would otherwise re-ask the same window forever.
+   * Aged against `WAREHOUSE_COST_MAX_HOLD_MS`; once it runs out the position
+   * moves to the end of the window that was asked about, the rows in it stay
+   * unrecorded — with no amount, never zero — and the stamp is cleared so
+   * the next hold ages from its own start. Cleared the moment a run reads its
+   * window whole. Nullable with a default so a cursor written before the
+   * field existed still parses.
+   */
+  paidBillHeldSinceMs: z.number().int().positive().nullable().default(null),
 });
 type GenieCursor = z.infer<typeof cursorSchema>;
 
@@ -1694,6 +1762,7 @@ function parseCursor(
     sweepStartedAtMs: null,
     costHeldSinceMs: null,
     paidBillReadThroughMs: null,
+    paidBillHeldSinceMs: null,
   };
 }
 
@@ -2200,9 +2269,9 @@ export class DatabricksGeniePuller
     // The second, independent read: the paid Genie bill line, on its own
     // position. Only when the source switched it on; a source that did not
     // never posts the statement and its cursor field stays null.
-    const paidBill = config.readPaidGenieBill
+    const paidBill: PaidGenieBillOutcome = config.readPaidGenieBill
       ? await this.paidGenieBill({ config, token, options, budget, cursor })
-      : { events: [], readThroughMs: null, unreadable: false };
+      : { events: [], window: null, unreadable: false };
 
     return {
       events: [
@@ -2223,7 +2292,7 @@ export class DatabricksGeniePuller
           sweep,
           sweepStartedAtMs,
           pricedThroughMs,
-          paidBillReadThroughMs: paidBill.readThroughMs,
+          paidBillWindow: paidBill.window,
           nowMs: Date.now(),
         }),
       ),
@@ -2240,10 +2309,12 @@ export class DatabricksGeniePuller
    * week at a time, with a week that cannot be answered whole re-asked in days
    * — the same shape and the same helpers as `warehouseCost`, and the same hold
    * rule: cut short, timed out or refused, the walk stops and this read's own
-   * position stays at the stopped piece. What is different is what lands:
-   * every whole chunk or piece read before the stop lands its rows; the answer
-   * that stopped short lands nothing, since which rows it left out is exactly
-   * what it cannot say.
+   * position stays at the stopped piece, for as long as
+   * `WAREHOUSE_COST_MAX_HOLD_MS` allows — `nextCursor` ages the hold and moves
+   * the position to the window's end once it runs out. What is different is
+   * what lands: every whole chunk or piece read before the stop lands its
+   * rows; the answer that stopped short lands nothing, since which rows it
+   * left out is exactly what it cannot say.
    *
    * Never throws, for the reason `warehouseCost` never does: the sweep's job
    * does not depend on this one.
@@ -2260,22 +2331,18 @@ export class DatabricksGeniePuller
     options: PullRunOptions;
     budget: RunBudget;
     cursor: GenieCursor;
-  }): Promise<{
-    events: NormalizedPullEvent[];
-    /** Where this read reached; null when it could not finish one window. */
-    readThroughMs: number | null;
-    unreadable: boolean;
-  }> {
+  }): Promise<PaidGenieBillOutcome> {
     const warehouseId = config.warehouseId;
     if (!warehouseId) {
       // Switched on with nothing to run it on. The statement needs a warehouse
       // to execute; without one the read cannot start, and the source has to
-      // be told rather than left quietly reading nothing.
+      // be told rather than left quietly reading nothing. No window either:
+      // nothing was asked, so there is no place to hold and no hold to age.
       logger.warn(
         { adapter: this.id, workspaceUrl: config.workspaceUrl },
         "databricks genie bill read is switched on but the source names no warehouse to run it on",
       );
-      return { events: [], readThroughMs: null, unreadable: true };
+      return { events: [], window: null, unreadable: true };
     }
 
     // Day-aligned both ends: the bill is per day and the statement filters on
@@ -2298,14 +2365,18 @@ export class DatabricksGeniePuller
         warehouseId,
         chunk,
       });
+    const held = ({
+      heldAt,
+      unreadable,
+    }: {
+      heldAt: { fromMs: number; toMs: number };
+      unreadable: boolean;
+    }) =>
+      this.paidGenieBillHeld({ rows, heldAt, windowEndMs: toMs, unreadable });
 
     for (const chunk of warehouseCostChunks({ fromMs, toMs })) {
       if (budget.exhaustedWithin(WAREHOUSE_COST_TIMEOUT_MS)) {
-        return this.paidGenieBillHeld({
-          rows,
-          heldAt: chunk,
-          unreadable: false,
-        });
+        return held({ heldAt: chunk, unreadable: false });
       }
       const answer = await read(chunk);
       if (answer.outcome === "priced") {
@@ -2313,38 +2384,25 @@ export class DatabricksGeniePuller
         continue;
       }
       if (answer.outcome === "failed") {
-        return this.paidGenieBillHeld({
-          rows,
-          heldAt: chunk,
-          unreadable: true,
-        });
+        return held({ heldAt: chunk, unreadable: true });
       }
 
       // Cut short or timed out: ask about less before holding, exactly as the
       // warehouse read does, so the days that answer on their own still land.
       const pieces = warehouseCostPieces(chunk);
       if (pieces.length === 0) {
-        return this.paidGenieBillHeld({
-          rows,
-          heldAt: chunk,
-          unreadable: false,
-        });
+        return held({ heldAt: chunk, unreadable: false });
       }
       for (const piece of pieces) {
         if (budget.exhaustedWithin(WAREHOUSE_COST_TIMEOUT_MS)) {
-          return this.paidGenieBillHeld({
-            rows,
-            heldAt: piece,
-            unreadable: false,
-          });
+          return held({ heldAt: piece, unreadable: false });
         }
         const pieceAnswer = await read(piece);
         if (pieceAnswer.outcome === "priced") {
           rows.push(...pieceAnswer.rows);
           continue;
         }
-        return this.paidGenieBillHeld({
-          rows,
+        return held({
           heldAt: piece,
           unreadable: pieceAnswer.outcome === "failed",
         });
@@ -2353,7 +2411,7 @@ export class DatabricksGeniePuller
 
     return {
       events: rows.map(paidGenieBillEvent),
-      readThroughMs: toMs,
+      window: { readThroughMs: toMs, endMs: toMs, held: false },
       unreadable: false,
     };
   }
@@ -2361,22 +2419,23 @@ export class DatabricksGeniePuller
   /**
    * The walk stopped at `heldAt`. Everything read before it lands; the
    * position holds at the start of the stopped piece so it is asked about
-   * again — or stays null when nothing at all was read, which reads as "never
-   * finished a window" and starts the next run from the same floor.
+   * again — whether or not anything landed. A read that stopped at its very
+   * first chunk holds at the window's floor, and writing that floor down is
+   * what keeps it: a first run's floor is "thirty days ago" unless the source
+   * was told otherwise, so a hold that wrote nothing would start a day later
+   * on every run and quietly lose the day before it each time.
    */
   private paidGenieBillHeld({
     rows,
     heldAt,
+    windowEndMs,
     unreadable,
   }: {
     rows: PaidGenieBillRow[];
     heldAt: { fromMs: number; toMs: number };
+    windowEndMs: number;
     unreadable: boolean;
-  }): {
-    events: NormalizedPullEvent[];
-    readThroughMs: number | null;
-    unreadable: boolean;
-  } {
+  }): PaidGenieBillOutcome {
     logger.warn(
       {
         adapter: this.id,
@@ -2389,7 +2448,7 @@ export class DatabricksGeniePuller
     );
     return {
       events: rows.map(paidGenieBillEvent),
-      readThroughMs: rows.length === 0 ? null : heldAt.fromMs,
+      window: { readThroughMs: heldAt.fromMs, endMs: windowEndMs, held: true },
       unreadable,
     };
   }
@@ -3979,7 +4038,7 @@ function nextCursor({
   sweep,
   sweepStartedAtMs,
   pricedThroughMs,
-  paidBillReadThroughMs,
+  paidBillWindow,
   nowMs,
 }: {
   previous: GenieCursor;
@@ -3988,12 +4047,12 @@ function nextCursor({
   /** Where cost knowledge ran out this run — see `nextWatermark`. */
   pricedThroughMs: number | null;
   /**
-   * Where the paid bill read reached this run, or null when it did not run
-   * or could not finish a single window. Its own position — see the cursor
-   * field — so it is folded here and nowhere near `sinceMs`.
+   * What the paid bill read did this run, or null when it asked about no
+   * window. Its own position — see the cursor field — so it is folded here
+   * and nowhere near `sinceMs` or the cost hold.
    */
-  paidBillReadThroughMs: number | null;
-  /** This run's clock, for ageing the cost hold. */
+  paidBillWindow: PaidGenieBillOutcome["window"];
+  /** This run's clock, for ageing both holds. */
   nowMs: number;
 }): GenieCursor {
   // `sweep.hadGap` is already sweep-scoped — it was seeded from this cursor —
@@ -4010,6 +4069,26 @@ function nextCursor({
   const holdExpired =
     costHeldSinceMs !== null &&
     nowMs - costHeldSinceMs > WAREHOUSE_COST_MAX_HOLD_MS;
+
+  // The bill read's hold, aged the same way on its own stamp. A run that asked
+  // about no window — the read is off, or on with no warehouse — clears it:
+  // the source is not waiting on a bill, and a stamp left running against a
+  // misconfiguration would expire the hold the moment the source was fixed.
+  // Once expired, the position moves to the end of the window this run asked
+  // about — the rows in it stay unrecorded, with no amount — and the stamp is
+  // cleared so the next hold ages from its own start.
+  const paidBillHeldSinceMs = paidBillWindow?.held
+    ? (previous.paidBillHeldSinceMs ?? nowMs)
+    : null;
+  const paidBillHoldExpired =
+    paidBillHeldSinceMs !== null &&
+    nowMs - paidBillHeldSinceMs > WAREHOUSE_COST_MAX_HOLD_MS;
+  const paidBillReadThroughMs =
+    paidBillWindow === null
+      ? null
+      : paidBillHoldExpired
+        ? paidBillWindow.endMs
+        : paidBillWindow.readThroughMs;
 
   return {
     // A sweep that walked past something it never read is not whole, no matter
@@ -4044,12 +4123,15 @@ function nextCursor({
     // moved past the period, so leaving the stamp would expire every subsequent
     // hold on arrival and the retry would never work again.
     costHeldSinceMs: holdExpired ? null : costHeldSinceMs,
-    // Never backwards, and never touched by anything above: a run that did
-    // not read the bill, or read none of it, leaves the position exactly
-    // where the last run that did put it.
+    // Never backwards, and never touched by anything above: a run that asked
+    // about no window leaves the position exactly where the last run that did
+    // put it. A held read writes its floor too — that is the whole point of
+    // the hold — and the max keeps the settling look-back from walking the
+    // floor backwards a run at a time.
     paidBillReadThroughMs:
       paidBillReadThroughMs === null
         ? previous.paidBillReadThroughMs
         : Math.max(previous.paidBillReadThroughMs ?? 0, paidBillReadThroughMs),
+    paidBillHeldSinceMs: paidBillHoldExpired ? null : paidBillHeldSinceMs,
   };
 }

--- a/platform/app/ee/governance/services/pullers/databricksGenie.puller.ts
+++ b/platform/app/ee/governance/services/pullers/databricksGenie.puller.ts
@@ -101,6 +101,54 @@ const MAX_REQUESTS_PER_RUN = 400;
 /** The ledger's model label. Genie is one product, not a family of models. */
 const GENIE_MODEL = "databricks/genie" as const;
 
+/**
+ * The run held its place because the warehouse bill could not be read, and
+ * said so.
+ *
+ * A code rather than a sentence, on `PER_KEY_ATTRIBUTION_UNAVAILABLE`'s
+ * precedent: it is read by a source-health surface that owns its own wording
+ * and has to survive a trip through storage. The questions are still recorded
+ * — unpriced — and the period is asked about again next run; what a reader of
+ * the source needs to know is that the figure they are not seeing is being
+ * waited for, not that it is zero.
+ */
+export const WAREHOUSE_COST_UNREADABLE = "warehouse_cost_unreadable" as const;
+
+/**
+ * The paid Genie bill line could not be read this run, and the run said so.
+ *
+ * Same shape and same reason as `WAREHOUSE_COST_UNREADABLE`, for the other
+ * read: the bill was refused, the statement failed, or the source has the read
+ * switched on with no warehouse to run it on. The read holds its own place and
+ * asks again next run; what the reader of the source needs to know is that the
+ * rows they are not seeing are being waited for.
+ */
+export const PAID_GENIE_BILL_UNREADABLE = "paid_genie_bill_unreadable" as const;
+
+/**
+ * The line a paid Genie bill row lands under, in the restatement key.
+ *
+ * A constant coordinate in `dimensions`, so a bill row can never share a key
+ * with anything else this adapter emits for the same person and day — and so
+ * the key says what it is, for whoever reads it back.
+ */
+const PAID_GENIE_BILL_LINE = "genie_bill" as const;
+
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * How far behind its own position the paid bill read starts each run.
+ *
+ * The bill is published per DAY, and a day's row keeps growing until the day
+ * is over and the billing tables have caught up. A read that reached the end
+ * of today therefore re-reads today and yesterday next time, so the row lands
+ * whole; re-emitting a day REPLACES its ledger row rather than adding one, so
+ * the re-read costs one request and never a double count. Two days covers the
+ * day boundary plus the documented lag of the billing tables with room to
+ * spare.
+ */
+const PAID_GENIE_BILL_SETTLING_LAG_MS = 2 * ONE_DAY_MS;
+
 export const DATABRICKS_GENIE_ADAPTER_ID = "databricks_genie" as const;
 
 /**
@@ -185,6 +233,23 @@ export const databricksGeniePullConfigSchema = z.object({
    * should still get its Genie activity rather than a failing source.
    */
   warehouseId: z.string().min(1).optional(),
+  /**
+   * Whether to also read the paid Genie bill line.
+   *
+   * Databricks bills paid Genie usage on its own line in
+   * `system.billing.usage`, per person and per day, under
+   * `billing_origin_product = 'GENIE'` — and with no warehouse id, which is
+   * exactly why the warehouse allocation above can never see it. This is a
+   * separate read of that line, walking on a position of its own
+   * (`cursorSchema.paidBillReadThroughMs`), priced from list prices where one
+   * is published and landing with its quantity and no amount where none is.
+   *
+   * Off by default and opt-in per source. It needs the same executor warehouse
+   * and the same `SELECT` on `system` the warehouse read needs, and it lands
+   * rows under a new key — a key cannot be changed once money sits under it,
+   * so switching it on is a decision rather than a default.
+   */
+  readPaidGenieBill: z.boolean().default(false),
 });
 export type DatabricksGeniePullConfig = z.infer<
   typeof databricksGeniePullConfigSchema
@@ -716,8 +781,24 @@ type WarehouseCostRead =
    * whole unpriced remainder of its window written off at zero for good.
    */
   | { outcome: "timed_out" }
-  /** Answered, and the answer was no. Asking again would be answered no. */
+  /**
+   * Answered, and the answer was no. Asking about LESS would be answered no
+   * the same way, so the pieces are not tried — but the period is still held
+   * rather than written off, because the questions in it have no amount and
+   * moving past them would make that permanent. See `priceWarehouseCostChunk`.
+   */
   | { outcome: "failed" };
+
+/**
+ * What one chunk of the cost walk decided. `done` stops the walk with a
+ * ceiling — `pricedThroughMs` is where the watermark holds, `null` when the
+ * chunk owes none — and `unreadable` says whether that hold is for a bill
+ * that was refused outright, which the run reports as a notice. `!done`
+ * carries the walk to the next chunk.
+ */
+type WarehouseCostChunkOutcome =
+  | { done: true; pricedThroughMs: number | null; unreadable: boolean }
+  | { done: false };
 
 type WarehouseCostStatement = z.infer<typeof warehouseCostResponseSchema>;
 
@@ -811,7 +892,7 @@ function readUnsuccessfulWarehouseCost({
     },
     unfinished
       ? "databricks warehouse cost query ran out of time; holding the window so it is asked again"
-      : "databricks warehouse cost query did not succeed; recording the questions without cost",
+      : "databricks warehouse cost query did not succeed; the questions stay unpriced and the window is held",
   );
   return { outcome: unfinished ? "timed_out" : "failed" };
 }
@@ -954,6 +1035,312 @@ function readWarehouseCost({
 }
 
 /**
+ * The paid Genie bill line, per person, per day, per price line.
+ *
+ * A separate statement from `WAREHOUSE_COST_STATEMENT`, and it has to be: that
+ * one filters `usage_metadata.warehouse_id IS NOT NULL` because it prices
+ * warehouse hours, and the rows this one reads carry no warehouse id at all.
+ * Databricks bills Genie's own metered usage under
+ * `billing_origin_product = 'GENIE'`, attributed to `identity_metadata.run_as`,
+ * with `usage_metadata.genie.surface` and `.channel` describing where the
+ * usage came from.
+ *
+ * Grouped by person, day and SKU — and NOT by surface or channel. Those two are
+ * how Databricks describes the usage, not what it bills, and the grouping here
+ * is what becomes the row's identity downstream: a key cannot be changed once
+ * money sits under it, so grouping on a description the provider is free to
+ * add values to would mint a fresh row per description. They ride along as
+ * labels, folded into a sorted list.
+ *
+ * Priced from `system.billing.list_prices`, LEFT joined: a SKU with no
+ * published price (Genie's free line, `GENIE_FREE_USAGE`) comes back with its
+ * quantity and a null amount, and lands that way — no price is not a price of
+ * nothing. The price picked is the one in force during the day, dollars
+ * preferred, latest start first; a price that changes part-way through a day
+ * is applied to the whole day, which is the resolution the bill itself has.
+ *
+ * Dates are bound as DATE parameters rather than cast from timestamps, because
+ * a cast goes through the session time zone and a UTC-midnight instant would
+ * name the previous day in a workspace set west of Greenwich.
+ */
+const PAID_GENIE_BILL_STATEMENT = `
+WITH genie_day AS (
+  SELECT
+    COALESCE(identity_metadata.run_as, '') AS run_as,
+    usage_date,
+    sku_name,
+    SUM(usage_quantity) AS quantity,
+    concat_ws(',', sort_array(collect_set(usage_metadata.genie.surface))) AS surfaces,
+    concat_ws(',', sort_array(collect_set(usage_metadata.genie.channel))) AS channels
+  FROM system.billing.usage
+  WHERE billing_origin_product = 'GENIE'
+    AND usage_date >= :from_date
+    AND usage_date < :to_date
+  GROUP BY 1, 2, 3
+),
+priced AS (
+  SELECT run_as, usage_date, sku_name, quantity, surfaces, channels, currency_code, amount
+  FROM (
+    SELECT
+      d.run_as,
+      d.usage_date,
+      d.sku_name,
+      d.quantity,
+      d.surfaces,
+      d.channels,
+      p.currency_code,
+      CAST(d.quantity * p.pricing.effective_list.default AS DECIMAL(38, 12)) AS amount,
+      ROW_NUMBER() OVER (
+        PARTITION BY d.run_as, d.usage_date, d.sku_name
+        ORDER BY CASE WHEN p.currency_code = 'USD' THEN 0 ELSE 1 END,
+                 p.price_start_time DESC
+      ) AS pick
+    FROM genie_day d
+    LEFT JOIN system.billing.list_prices p
+      ON p.sku_name = d.sku_name
+     AND p.price_start_time < CAST(date_add(d.usage_date, 1) AS TIMESTAMP)
+     AND (p.price_end_time IS NULL OR p.price_end_time > CAST(d.usage_date AS TIMESTAMP))
+  )
+  WHERE pick = 1
+)
+SELECT
+  run_as,
+  CAST(usage_date AS STRING) AS usage_date,
+  sku_name,
+  CAST(quantity AS STRING)  AS quantity,
+  CAST(amount AS STRING)    AS amount,
+  currency_code,
+  surfaces,
+  channels
+FROM priced
+LIMIT ${WAREHOUSE_COST_ROW_LIMIT}
+`;
+
+/**
+ * The columns `PAID_GENIE_BILL_STATEMENT` selects, in order. Checked against
+ * the manifest for the same reason `WAREHOUSE_COST_COLUMNS` is: rows are
+ * positional strings, and a reordered SELECT would file the quantity as the
+ * amount without failing any parse.
+ */
+const PAID_GENIE_BILL_COLUMNS = [
+  "run_as",
+  "usage_date",
+  "sku_name",
+  "quantity",
+  "amount",
+  "currency_code",
+  "surfaces",
+  "channels",
+] as const;
+
+/** A decimal as the Statement Execution API renders one: digits, no float. */
+const DECIMAL_STRING = /^-?\d+(\.\d+)?$/;
+
+/**
+ * One row of the paid bill: a person, a day, a price line, how much, and —
+ * when a list price exists — what that is worth.
+ */
+const paidGenieBillRowSchema = z.object({
+  /** Who ran the usage, as Databricks names them. Empty when it names nobody. */
+  runAs: z.string(),
+  usageDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  skuName: z.string().min(1),
+  quantity: z.string().regex(DECIMAL_STRING),
+  /** Null when no list price is published for the SKU on that day. */
+  amount: z.string().regex(DECIMAL_STRING).nullable(),
+  currencyCode: z.string().nullable(),
+  surfaces: z.string(),
+  channels: z.string(),
+});
+type PaidGenieBillRow = z.infer<typeof paidGenieBillRowSchema>;
+
+/**
+ * Whole days, both ends, as DATE parameters. The window arrives hour-aligned
+ * from `warehouseCostChunks`; a day-aligned window in gives day boundaries
+ * out, and the statement filters on `usage_date` half-open so consecutive
+ * chunks never both carry the same day.
+ */
+function paidGenieBillParameters(chunk: {
+  fromMs: number;
+  toMs: number;
+}): { name: string; value: string; type: string }[] {
+  return [
+    {
+      name: "from_date",
+      value: new Date(chunk.fromMs).toISOString().slice(0, 10),
+      type: "DATE",
+    },
+    {
+      name: "to_date",
+      value: new Date(chunk.toMs).toISOString().slice(0, 10),
+      type: "DATE",
+    },
+  ];
+}
+
+/**
+ * What one bill reply turned out to be worth. The same four answers as
+ * `WarehouseCostRead`, for the same reasons, with rows instead of shares.
+ */
+type PaidGenieBillRead =
+  | { outcome: "priced"; rows: PaidGenieBillRow[] }
+  | { outcome: "cut_short" }
+  | { outcome: "timed_out" }
+  | { outcome: "failed" };
+
+/**
+ * Turn one bill reply into rows, or refuse the whole reply. Refusing whole is
+ * the same rule the warehouse read follows: a partial answer lands some of a
+ * period's rows and leaves the rest absent, and absent is indistinguishable
+ * from nobody having used Genie that day.
+ */
+function readPaidGenieBill({
+  payload,
+  adapter,
+  warehouseId,
+}: {
+  payload: unknown;
+  adapter: string;
+  warehouseId: string;
+}): PaidGenieBillRead {
+  const statement = warehouseCostResponseSchema.parse(payload);
+  const log = { adapter, executorWarehouseId: warehouseId, read: "genie_bill" };
+
+  if (statement.status.state !== "SUCCEEDED") {
+    const unfinished = WAREHOUSE_COST_UNFINISHED_STATES.has(
+      statement.status.state,
+    );
+    logger.warn(
+      {
+        ...log,
+        state: statement.status.state,
+        error: statement.status.error?.message,
+      },
+      unfinished
+        ? "databricks genie bill query ran out of time; holding the read so it is asked again"
+        : "databricks genie bill query did not succeed; holding the read so it is asked again",
+    );
+    return { outcome: unfinished ? "timed_out" : "failed" };
+  }
+
+  const served = statement.manifest?.schema?.columns?.map((c) => c.name);
+  if (!served || !PAID_GENIE_BILL_COLUMNS.every((n, i) => served[i] === n)) {
+    logger.error(
+      { ...log, expected: PAID_GENIE_BILL_COLUMNS, served },
+      "databricks genie bill query answered with unexpected columns; refusing to read from it",
+    );
+    return { outcome: "failed" };
+  }
+
+  const data = statement.result?.data_array ?? [];
+  if (warehouseAnswerCutShort({ statement, dataLength: data.length })) {
+    logger.error(
+      {
+        ...log,
+        rows: data.length,
+        limit: WAREHOUSE_COST_ROW_LIMIT,
+        totalRowCount: statement.manifest?.total_row_count,
+        nextChunkIndex: statement.result?.next_chunk_index,
+      },
+      "databricks genie bill answer was cut short; refusing a partial answer",
+    );
+    return { outcome: "cut_short" };
+  }
+
+  let unreadable = 0;
+  const rows = data.flatMap((columns) => {
+    const parsed = paidGenieBillRowSchema.safeParse({
+      runAs: columns[0] ?? "",
+      usageDate: columns[1],
+      skuName: columns[2],
+      quantity: columns[3],
+      amount: columns[4] ?? null,
+      currencyCode: columns[5] ?? null,
+      surfaces: columns[6] ?? "",
+      channels: columns[7] ?? "",
+    });
+    if (!parsed.success) {
+      unreadable += 1;
+      return [];
+    }
+    return [parsed.data];
+  });
+  if (unreadable > 0) {
+    logger.warn(
+      { ...log, unreadable, rows: data.length },
+      "some databricks genie bill rows could not be read; those rows are not recorded",
+    );
+  }
+  return { outcome: "priced", rows };
+}
+
+/**
+ * One bill row as the event the ledger and the audit sink read.
+ *
+ * The person the bill names is the actor; the price line is the model; there
+ * is no agent, because the bill names no space and no warehouse ran it — a
+ * warehouse id here would put compute on the agents screen as if it were a
+ * thing people talk to. The day is the event's timestamp, so the record seam
+ * buckets it under that day, and `dimensions` carries the person and the
+ * price line and nothing else: surface and channel are labels on the row and
+ * no part of its key. The rollup keys on TenantId, Day, CostSource, source,
+ * Provider, Model, AgentId, CurrencyCode and RawActorId, and `Model` here is
+ * the SKU where the warehouse allocation's is `databricks/genie`, so a bill
+ * row and a warehouse row for the same person and day never share a cell.
+ *
+ * An amount only where a list price produced one. A row with none carries its
+ * quantity and no `costUsd`, which the record seam declines to price — an
+ * unpriced row, never a zero one.
+ */
+function paidGenieBillEvent(row: PaidGenieBillRow): NormalizedPullEvent {
+  const currency = row.currencyCode ?? "USD";
+  const money =
+    row.amount === null
+      ? {}
+      : currency === "USD"
+        ? { cost_usd: row.amount }
+        : { cost_amount: row.amount, cost_currency: currency };
+  const hintMoney =
+    row.amount === null
+      ? {}
+      : { costUsd: row.amount, ...(currency === "USD" ? {} : { currency }) };
+
+  return {
+    source_event_id: `${PAID_GENIE_BILL_LINE}:${row.usageDate}:${row.skuName}:${row.runAs}`,
+    event_timestamp: `${row.usageDate}T00:00:00.000Z`,
+    actor: row.runAs,
+    action: PAID_GENIE_BILL_LINE,
+    target: row.skuName,
+    ...money,
+    tokens_input: 0,
+    tokens_output: 0,
+    raw_payload: JSON.stringify(row),
+    extra: {
+      runAs: row.runAs,
+      usageDate: row.usageDate,
+      skuName: row.skuName,
+      quantity: row.quantity,
+      surfaces: row.surfaces,
+      channels: row.channels,
+      priceCurrency: row.currencyCode ?? "",
+      [PULLED_USAGE_HINT_KEY]: {
+        costBasis: "provider_reported",
+        // A list price, not the account's negotiated rate — an estimate by
+        // construction, for the same reason the warehouse share is one.
+        costStatus: "estimate",
+        ...hintMoney,
+        dimensions: {
+          line: PAID_GENIE_BILL_LINE,
+          runAs: row.runAs,
+          skuName: row.skuName,
+        },
+        model: row.skuName,
+      },
+    },
+  };
+}
+
+/**
  * Anything below this is epoch SECONDS; anything above it is epoch
  * MILLISECONDS. `1e11` splits them with no overlap that can occur in practice:
  * as milliseconds it is 1973-03-03, as seconds it is the year 5138.
@@ -983,6 +1370,11 @@ function startOfHourMs(ms: number): number {
 
 function endOfHourMs(ms: number): number {
   return Math.ceil(ms / ONE_HOUR_MS) * ONE_HOUR_MS;
+}
+
+/** The UTC midnight an instant falls after — the bill is published per day. */
+function startOfDayMs(ms: number): number {
+  return Math.floor(ms / ONE_DAY_MS) * ONE_DAY_MS;
 }
 
 /**
@@ -1132,6 +1524,24 @@ const cursorSchema = z.object({
    * bought starvation. This is the billing tables' version of the same trade.
    */
   costHeldSinceMs: z.number().int().positive().nullable().default(null),
+  /**
+   * How far the paid Genie bill read has reached, or null when it has never
+   * finished a window — including when the read is switched off.
+   *
+   * The bill read's OWN position, and never the watermark's. The two reads
+   * answer on different tables and fail independently: the warehouse
+   * allocation holding for a late bill must not pin the bill line, and a bill
+   * line cut short must not stop the watermark from moving over questions the
+   * sweep read whole. A held bill read leaves this where the hold began, so
+   * the next run asks about that period again; a finished one sets it to the
+   * end of the window it read. `Math.max` on the way in keeps it monotonic.
+   */
+  paidBillReadThroughMs: z
+    .number()
+    .int()
+    .nonnegative()
+    .nullable()
+    .default(null),
 });
 type GenieCursor = z.infer<typeof cursorSchema>;
 
@@ -1274,11 +1684,8 @@ function parseCursor(
       );
     }
   }
-  const sinceMs = config.startingAt
-    ? Date.parse(config.startingAt)
-    : defaultSinceMs();
   return {
-    sinceMs: Number.isFinite(sinceMs) ? sinceMs : defaultSinceMs(),
+    sinceMs: configuredSinceMs(config),
     spaceId: null,
     conversationId: null,
     sweepHadGap: false,
@@ -1286,7 +1693,21 @@ function parseCursor(
     sweepOldestPendingMs: null,
     sweepStartedAtMs: null,
     costHeldSinceMs: null,
+    paidBillReadThroughMs: null,
   };
+}
+
+/**
+ * Where a read with no position yet starts: the configured instant, or the
+ * last 30 days. Shared by the watermark's first run and the paid bill read's
+ * first run, so switching the bill read on late still reads the same history
+ * the source was told to begin at.
+ */
+function configuredSinceMs(config: DatabricksGeniePullConfig): number {
+  const sinceMs = config.startingAt
+    ? Date.parse(config.startingAt)
+    : defaultSinceMs();
+  return Number.isFinite(sinceMs) ? sinceMs : defaultSinceMs();
 }
 
 /** A first run with no configured watermark reads the last 30 days. */
@@ -1762,26 +2183,37 @@ export class DatabricksGeniePuller
     // once, and the window it asks about is the window the sweep actually read.
     // Asking first would either guess that window or ask per space. It is one
     // read of that window, taken a day at a time — see `warehouseCost`.
-    const { costByStatementId, pricedThroughMs } = await this.warehouseCost({
-      config,
-      token,
-      options,
-      budget,
-      fromMs: costReadFloorMs({
-        sinceMs: cursor.sinceMs,
-        nowMs: sweepStartedAtMs,
-        costEnabled: config.warehouseId !== undefined,
-      }),
-      toMs: Date.now(),
-    });
+    const { costByStatementId, pricedThroughMs, unreadable } =
+      await this.warehouseCost({
+        config,
+        token,
+        options,
+        budget,
+        fromMs: costReadFloorMs({
+          sinceMs: cursor.sinceMs,
+          nowMs: sweepStartedAtMs,
+          costEnabled: config.warehouseId !== undefined,
+        }),
+        toMs: Date.now(),
+      });
+
+    // The second, independent read: the paid Genie bill line, on its own
+    // position. Only when the source switched it on; a source that did not
+    // never posts the statement and its cursor field stays null.
+    const paidBill = config.readPaidGenieBill
+      ? await this.paidGenieBill({ config, token, options, budget, cursor })
+      : { events: [], readThroughMs: null, unreadable: false };
 
     return {
-      events: withWarehouseCost({
-        events: sweep.events,
-        costByStatementId,
-        costEnabled: config.warehouseId !== undefined,
-        watermarkMs: cursor.sinceMs,
-      }),
+      events: [
+        ...withWarehouseCost({
+          events: sweep.events,
+          costByStatementId,
+          costEnabled: config.warehouseId !== undefined,
+          watermarkMs: cursor.sinceMs,
+        }),
+        ...paidBill.events,
+      ],
       cursor: encode(
         // The cost read is part of what this run knows, so the watermark answers
         // to it as well as to the sweep. Without that, a window whose bill could
@@ -1791,11 +2223,253 @@ export class DatabricksGeniePuller
           sweep,
           sweepStartedAtMs,
           pricedThroughMs,
+          paidBillReadThroughMs: paidBill.readThroughMs,
           nowMs: Date.now(),
         }),
       ),
       errorCount: 0,
+      ...runNotices({
+        unreadable,
+        paidBillUnreadable: paidBill.unreadable,
+      }),
     };
+  }
+
+  /**
+   * The paid Genie bill line for the window this read owes, oldest first, a
+   * week at a time, with a week that cannot be answered whole re-asked in days
+   * — the same shape and the same helpers as `warehouseCost`, and the same hold
+   * rule: cut short, timed out or refused, the walk stops and this read's own
+   * position stays at the stopped piece. What is different is what lands:
+   * every whole chunk or piece read before the stop lands its rows; the answer
+   * that stopped short lands nothing, since which rows it left out is exactly
+   * what it cannot say.
+   *
+   * Never throws, for the reason `warehouseCost` never does: the sweep's job
+   * does not depend on this one.
+   */
+  private async paidGenieBill({
+    config,
+    token,
+    options,
+    budget,
+    cursor,
+  }: {
+    config: DatabricksGeniePullConfig;
+    token: string;
+    options: PullRunOptions;
+    budget: RunBudget;
+    cursor: GenieCursor;
+  }): Promise<{
+    events: NormalizedPullEvent[];
+    /** Where this read reached; null when it could not finish one window. */
+    readThroughMs: number | null;
+    unreadable: boolean;
+  }> {
+    const warehouseId = config.warehouseId;
+    if (!warehouseId) {
+      // Switched on with nothing to run it on. The statement needs a warehouse
+      // to execute; without one the read cannot start, and the source has to
+      // be told rather than left quietly reading nothing.
+      logger.warn(
+        { adapter: this.id, workspaceUrl: config.workspaceUrl },
+        "databricks genie bill read is switched on but the source names no warehouse to run it on",
+      );
+      return { events: [], readThroughMs: null, unreadable: true };
+    }
+
+    // Day-aligned both ends: the bill is per day and the statement filters on
+    // the date. Through the end of TODAY, so today's partial row lands and is
+    // re-read next run — the settling lag on the way in is what re-reads it.
+    const fromMs = startOfDayMs(
+      cursor.paidBillReadThroughMs === null
+        ? configuredSinceMs(config)
+        : cursor.paidBillReadThroughMs - PAID_GENIE_BILL_SETTLING_LAG_MS,
+    );
+    const toMs = startOfDayMs(Date.now()) + ONE_DAY_MS;
+
+    const rows: PaidGenieBillRow[] = [];
+    const read = (chunk: { fromMs: number; toMs: number }) =>
+      this.paidGenieBillChunk({
+        config,
+        token,
+        options,
+        budget,
+        warehouseId,
+        chunk,
+      });
+
+    for (const chunk of warehouseCostChunks({ fromMs, toMs })) {
+      if (budget.exhaustedWithin(WAREHOUSE_COST_TIMEOUT_MS)) {
+        return this.paidGenieBillHeld({
+          rows,
+          heldAt: chunk,
+          unreadable: false,
+        });
+      }
+      const answer = await read(chunk);
+      if (answer.outcome === "priced") {
+        rows.push(...answer.rows);
+        continue;
+      }
+      if (answer.outcome === "failed") {
+        return this.paidGenieBillHeld({
+          rows,
+          heldAt: chunk,
+          unreadable: true,
+        });
+      }
+
+      // Cut short or timed out: ask about less before holding, exactly as the
+      // warehouse read does, so the days that answer on their own still land.
+      const pieces = warehouseCostPieces(chunk);
+      if (pieces.length === 0) {
+        return this.paidGenieBillHeld({
+          rows,
+          heldAt: chunk,
+          unreadable: false,
+        });
+      }
+      for (const piece of pieces) {
+        if (budget.exhaustedWithin(WAREHOUSE_COST_TIMEOUT_MS)) {
+          return this.paidGenieBillHeld({
+            rows,
+            heldAt: piece,
+            unreadable: false,
+          });
+        }
+        const pieceAnswer = await read(piece);
+        if (pieceAnswer.outcome === "priced") {
+          rows.push(...pieceAnswer.rows);
+          continue;
+        }
+        return this.paidGenieBillHeld({
+          rows,
+          heldAt: piece,
+          unreadable: pieceAnswer.outcome === "failed",
+        });
+      }
+    }
+
+    return {
+      events: rows.map(paidGenieBillEvent),
+      readThroughMs: toMs,
+      unreadable: false,
+    };
+  }
+
+  /**
+   * The walk stopped at `heldAt`. Everything read before it lands; the
+   * position holds at the start of the stopped piece so it is asked about
+   * again — or stays null when nothing at all was read, which reads as "never
+   * finished a window" and starts the next run from the same floor.
+   */
+  private paidGenieBillHeld({
+    rows,
+    heldAt,
+    unreadable,
+  }: {
+    rows: PaidGenieBillRow[];
+    heldAt: { fromMs: number; toMs: number };
+    unreadable: boolean;
+  }): {
+    events: NormalizedPullEvent[];
+    readThroughMs: number | null;
+    unreadable: boolean;
+  } {
+    logger.warn(
+      {
+        adapter: this.id,
+        heldFrom: new Date(heldAt.fromMs).toISOString(),
+        heldTo: new Date(heldAt.toMs).toISOString(),
+        landed: rows.length,
+        unreadable,
+      },
+      "databricks genie bill read stopped short; holding its place so the period is asked about again",
+    );
+    return {
+      events: rows.map(paidGenieBillEvent),
+      readThroughMs: rows.length === 0 ? null : heldAt.fromMs,
+      unreadable,
+    };
+  }
+
+  /** One window of the bill line, read or refused. */
+  private async paidGenieBillChunk({
+    config,
+    token,
+    options,
+    budget,
+    warehouseId,
+    chunk,
+  }: {
+    config: DatabricksGeniePullConfig;
+    token: string;
+    options: PullRunOptions;
+    budget: RunBudget;
+    warehouseId: string;
+    chunk: { fromMs: number; toMs: number };
+  }): Promise<PaidGenieBillRead> {
+    const askedAtMs = Date.now();
+    const observed = {
+      adapter: this.id,
+      warehouseId,
+      read: "genie_bill",
+      askedFrom: new Date(chunk.fromMs).toISOString(),
+      askedTo: new Date(chunk.toMs).toISOString(),
+    };
+    try {
+      const payload = await this.post({
+        config,
+        token,
+        options,
+        budget,
+        path: "/api/2.0/sql/statements",
+        body: {
+          warehouse_id: warehouseId,
+          statement: PAID_GENIE_BILL_STATEMENT,
+          // Same wait as the warehouse read, for the same measured reason.
+          wait_timeout: "50s",
+          on_wait_timeout: "CANCEL",
+          format: "JSON_ARRAY",
+          disposition: "INLINE",
+          parameters: paidGenieBillParameters(chunk),
+        },
+      });
+      const read = readPaidGenieBill({
+        payload,
+        adapter: this.id,
+        warehouseId,
+      });
+      logger.info(
+        {
+          ...observed,
+          outcome: read.outcome,
+          elapsedMs: Date.now() - askedAtMs,
+          rows: read.outcome === "priced" ? read.rows.length : 0,
+        },
+        "databricks genie bill question answered",
+      );
+      return read;
+    } catch (error) {
+      // The same split as `warehouseCostChunk`: only an answer that will be
+      // the same next run is a refusal.
+      const unfinished =
+        !(error instanceof GenieHttpError) ||
+        error.status === 429 ||
+        error.status >= 500;
+      logger.warn(
+        {
+          ...observed,
+          elapsedMs: Date.now() - askedAtMs,
+          error: error instanceof Error ? error.message : String(error),
+        },
+        unfinished
+          ? "databricks genie bill could not be reached; holding the read so it is asked again"
+          : "databricks genie bill was refused; holding the read so it is asked again",
+      );
+      return { outcome: unfinished ? "timed_out" : "failed" };
+    }
   }
 
   /**
@@ -2565,11 +3239,15 @@ export class DatabricksGeniePuller
       actor: identity.email || identity.key,
       action: "genie_query",
       target: space.title ?? space.space_id,
-      // Zero at the point the message is built, always. Genie bills nothing per
-      // message, and the warehouse compute behind it is not on this API — a
-      // source that names a warehouse has that share attached afterwards, once
-      // the run's billing read has answered. See `withWarehouseCost`.
-      cost_usd: "0",
+      // No amount at the point the message is built — not zero. Genie bills
+      // nothing per message, and the warehouse compute behind it is not on
+      // this API; a source that names a warehouse has that share attached
+      // afterwards, once the run's billing read has answered (see
+      // `withWarehouseCost`). Until then there is no bill to back a figure,
+      // and a zero here is indistinguishable from a question that genuinely
+      // cost nothing: the record seam reads `cost_usd` as the reported amount
+      // when the hint names none, so a "0" would land on the ledger as a
+      // measurement.
       tokens_input: 0,
       tokens_output: 0,
       raw_payload: JSON.stringify(message),
@@ -2594,13 +3272,17 @@ export class DatabricksGeniePuller
         actorUserId: message.user_id === null ? "" : String(message.user_id),
         [PULLED_USAGE_HINT_KEY]: {
           costBasis: "provider_reported",
-          // Never `exact`, whether or not a warehouse is named. With none, zero
-          // is only Genie's own per-message price and says nothing about the
-          // compute behind the question. With one, the figure is a share of an
+          // Never `exact`. The figure, when one is attached, is a share of an
           // hourly bill worked out from LIST prices, because the account's
           // negotiated rate is on no table this token can read.
           costStatus: "estimate",
-          costUsd: "0",
+          // No `costUsd` here, deliberately. The hint declares the message a
+          // cost item and names its coordinates; the amount is attached by
+          // `withCost` once the warehouse bill has answered, and a
+          // provider-reported hint with no amount is one the record seam
+          // declines to price — an unpriced question, never a zero one. A
+          // source that names no warehouse has no bill to attach and stays
+          // unpriced for good, which is the honest figure for it.
           dimensions,
           // The space IS the agent here — the configured thing people talk to
           // (#7881). Same value as `dimensions.spaceId`, deliberately: the
@@ -2636,10 +3318,15 @@ export class DatabricksGeniePuller
    * A chunk that cannot be answered whole is re-asked in days before the walk
    * gives up on it. Only a chunk that is REFUSED — the question reached billing
    * and billing said no — skips that, since asking the same question about less
-   * gets the same no.
+   * gets the same no. A refusal still holds the watermark, exactly as an
+   * answer cut short does: the questions in that period are recorded without
+   * an amount, and moving past them would turn "not yet priced" into a figure
+   * nothing later corrects. A credential that is refused forever is what the
+   * hold's expiry (`WAREHOUSE_COST_MAX_HOLD_MS`) is for — the source moves on
+   * after it, and the questions it leaves behind stay unpriced rather than
+   * zero.
    *
-   * `null` means no ceiling is owed: either the whole window priced, or the
-   * question was refused and re-asking it would not help.
+   * `null` means no ceiling is owed: the whole window priced.
    */
   private async warehouseCost({
     config,
@@ -2659,9 +3346,21 @@ export class DatabricksGeniePuller
     costByStatementId: Map<string, WarehousePricedStatement> | null;
     /** The instant past which cost is not known. `null` owes no ceiling. */
     pricedThroughMs: number | null;
+    /**
+     * Whether the hold above is for a bill that was REFUSED rather than merely
+     * late or large — the case a reader of the source has to be told about,
+     * because waiting will not fix it on its own.
+     */
+    unreadable: boolean;
   }> {
     const warehouseId = config.warehouseId;
-    if (!warehouseId) return { costByStatementId: null, pricedThroughMs: null };
+    if (!warehouseId) {
+      return {
+        costByStatementId: null,
+        pricedThroughMs: null,
+        unreadable: false,
+      };
+    }
 
     const costByStatementId = new Map<string, WarehousePricedStatement>();
 
@@ -2676,11 +3375,15 @@ export class DatabricksGeniePuller
         costByStatementId,
       });
       if (outcome.done) {
-        return { costByStatementId, pricedThroughMs: outcome.pricedThroughMs };
+        return {
+          costByStatementId,
+          pricedThroughMs: outcome.pricedThroughMs,
+          unreadable: outcome.unreadable,
+        };
       }
     }
 
-    return { costByStatementId, pricedThroughMs: null };
+    return { costByStatementId, pricedThroughMs: null, unreadable: false };
   }
 
   /**
@@ -2704,9 +3407,7 @@ export class DatabricksGeniePuller
     warehouseId: string;
     chunk: { fromMs: number; toMs: number };
     costByStatementId: Map<string, WarehousePricedStatement>;
-  }): Promise<
-    { done: true; pricedThroughMs: number | null } | { done: false }
-  > {
+  }): Promise<WarehouseCostChunkOutcome> {
     // Out of requests, or out of the time one more would need, with days still
     // unpriced. Those days are not refused, just unread, so the watermark holds
     // here and the next run starts its cost read where this one ran out — which
@@ -2728,7 +3429,11 @@ export class DatabricksGeniePuller
         },
         "databricks warehouse cost has no room left in this run; holding the watermark at the last priced day",
       );
-      return { done: true, pricedThroughMs: unpricedFloor(chunk) };
+      return {
+        done: true,
+        pricedThroughMs: unpricedFloor(chunk),
+        unreadable: false,
+      };
     }
 
     const read = await this.warehouseCostChunk({
@@ -2741,12 +3446,29 @@ export class DatabricksGeniePuller
     });
 
     // The question itself was answered, and the answer was no. Asking about
-    // less would be answered no the same way, so no ceiling is owed: the
-    // questions are recorded without cost, exactly as they were before any of
-    // this existed, and the source keeps moving rather than stalling on billing
-    // tables it may never read.
+    // less would be answered no the same way, so the pieces are not tried —
+    // but the period is HELD, not written off. The questions in it are
+    // recorded without an amount, and the watermark stops here so they are
+    // asked about again: a warehouse that was deleted, a grant that was
+    // revoked, or a token that lost its scope can all be put right, and the
+    // day the bill answers is the day those questions get their figure.
+    // Moving on instead would leave them unpriced forever with nothing
+    // reporting it. `WAREHOUSE_COST_MAX_HOLD_MS` is what stops a refusal that
+    // is never put right from pinning the source.
     if (read.outcome === "failed") {
-      return { done: true, pricedThroughMs: null };
+      logger.error(
+        {
+          adapter: this.id,
+          warehouseId,
+          pricedThrough: new Date(chunk.fromMs).toISOString(),
+        },
+        "databricks warehouse cost could not be read; holding the watermark so the period is asked about again",
+      );
+      return {
+        done: true,
+        pricedThroughMs: unpricedFloor(chunk),
+        unreadable: true,
+      };
     }
 
     if (read.outcome === "priced") {
@@ -2767,7 +3489,11 @@ export class DatabricksGeniePuller
       // same figure. The hold is bounded by `WAREHOUSE_COST_MAX_HOLD_MS`, so a
       // statement that is never billed stops holding the source after that.
       if (read.owed) {
-        return { done: true, pricedThroughMs: unpricedFloor(chunk) };
+        return {
+          done: true,
+          pricedThroughMs: unpricedFloor(chunk),
+          unreadable: false,
+        };
       }
       return { done: false };
     }
@@ -2820,9 +3546,7 @@ export class DatabricksGeniePuller
     chunk: { fromMs: number; toMs: number };
     read: WarehouseCostRead;
     costByStatementId: Map<string, WarehousePricedStatement>;
-  }): Promise<
-    { done: true; pricedThroughMs: number | null } | { done: false }
-  > {
+  }): Promise<WarehouseCostChunkOutcome> {
     const pieces = warehouseCostPieces(chunk);
     logger.warn(
       {
@@ -2838,7 +3562,7 @@ export class DatabricksGeniePuller
 
     const walked =
       pieces.length === 0
-        ? chunk
+        ? { heldAt: chunk, unreadable: false }
         : await this.walkWarehouseCostPieces({
             config,
             token,
@@ -2849,24 +3573,22 @@ export class DatabricksGeniePuller
             costByStatementId,
           });
 
-    // A refusal to a piece is still a refusal to the question, and it is the
-    // same one whichever size it was asked at.
-    if (walked === "failed") {
-      return { done: true, pricedThroughMs: null };
-    }
-    const refused = walked;
-
-    if (refused) {
+    if (walked.heldAt) {
       logger.error(
         {
           adapter: this.id,
           warehouseId,
-          pricedThrough: new Date(refused.fromMs).toISOString(),
-          refusedTo: new Date(refused.toMs).toISOString(),
+          pricedThrough: new Date(walked.heldAt.fromMs).toISOString(),
+          refusedTo: new Date(walked.heldAt.toMs).toISOString(),
+          unreadable: walked.unreadable,
         },
         "databricks warehouse cost could not price a period even in pieces; holding the watermark so it is asked again",
       );
-      return { done: true, pricedThroughMs: unpricedFloor(refused) };
+      return {
+        done: true,
+        pricedThroughMs: unpricedFloor(walked.heldAt),
+        unreadable: walked.unreadable,
+      };
     }
 
     return { done: false };
@@ -2875,9 +3597,12 @@ export class DatabricksGeniePuller
   /**
    * The pieces in order: every piece that prices is merged — even one still
    * owing a bill keeps its billed hours' worth — and the first that stops the
-   * walk (refused, owing, or outrunning the run's budget) is returned as where
-   * the watermark holds. `"failed"` ends the whole sweep; `null` says every
-   * piece priced whole.
+   * walk (refused, owing, cut short, or outrunning the run's budget) is
+   * returned as where the watermark holds. A refusal to a piece is still a
+   * refusal to the question, and it is the same one whichever size it was
+   * asked at: it holds at that piece like every other stop, and is flagged
+   * `unreadable` so the run can say so. `heldAt: null` says every piece
+   * priced whole.
    */
   private async walkWarehouseCostPieces({
     config,
@@ -2895,10 +3620,13 @@ export class DatabricksGeniePuller
     warehouseId: string;
     pieces: { fromMs: number; toMs: number }[];
     costByStatementId: Map<string, WarehousePricedStatement>;
-  }): Promise<{ fromMs: number; toMs: number } | "failed" | null> {
+  }): Promise<{
+    heldAt: { fromMs: number; toMs: number } | null;
+    unreadable: boolean;
+  }> {
     for (const piece of pieces) {
       if (budget.exhaustedWithin(WAREHOUSE_COST_TIMEOUT_MS)) {
-        return piece;
+        return { heldAt: piece, unreadable: false };
       }
 
       const pieceRead = await this.warehouseCostChunk({
@@ -2911,10 +3639,10 @@ export class DatabricksGeniePuller
       });
 
       if (pieceRead.outcome === "failed") {
-        return "failed";
+        return { heldAt: piece, unreadable: true };
       }
       if (pieceRead.outcome !== "priced") {
-        return piece;
+        return { heldAt: piece, unreadable: false };
       }
       // Merged BEFORE the owed check, the same order the full-chunk path
       // uses: a piece can be owed for one hour and priced for others, and the
@@ -2930,10 +3658,10 @@ export class DatabricksGeniePuller
       // as a refusal to it would: the pieces before it kept their cost and are
       // never re-asked, and this one is re-read once its billing settles.
       if (pieceRead.owed) {
-        return piece;
+        return { heldAt: piece, unreadable: false };
       }
     }
-    return null;
+    return { heldAt: null, unreadable: false };
   }
 
   /** One chunk of the window, priced or refused. */
@@ -3012,11 +3740,12 @@ export class DatabricksGeniePuller
     } catch (error) {
       // The same split the statement states get, at the other door. A request
       // this end gave up on, or one the workspace could not serve right now,
-      // says nothing about whether the window can ever be priced — writing it
-      // off puts a permanent zero on questions over a hiccup. Only an answer
-      // that will be the same next run is a refusal: a token without the grant
-      // is refused identically forever, and holding for it would stall the
-      // source with no way out but turning the feature off.
+      // says nothing about whether the window can ever be priced. Only an
+      // answer that will be the same next run is a refusal: a token without
+      // the grant, or a warehouse that no longer exists, is refused
+      // identically until an admin puts it right. Both hold the window; the
+      // difference is that a refusal skips the smaller pieces and is reported
+      // to whoever reads the source, since waiting alone will not fix it.
       const unfinished =
         !(error instanceof GenieHttpError) ||
         error.status === 429 ||
@@ -3029,7 +3758,7 @@ export class DatabricksGeniePuller
         },
         unfinished
           ? "databricks warehouse cost could not be reached; holding the window so it is asked again"
-          : "databricks warehouse cost is unavailable; recording the questions without cost",
+          : "databricks warehouse cost was refused; the questions stay unpriced and the window is held",
       );
       return { outcome: unfinished ? "timed_out" : "failed" };
     }
@@ -3127,16 +3856,18 @@ export class DatabricksGeniePuller
  * So the three cases are kept apart:
  *
  *   priced          → carry the cost.
- *   new, unpriced   → carry zero, as a question with no known cost always has.
+ *   new, unpriced   → carry the hint with NO amount, so the ledger declines
+ *                     to write a figure: an unpriced question, never a zero
+ *                     one. The amount lands on the re-read that prices it.
  *   re-read, unpriced → carry NO usage hint at all, so the event is audit-only
  *                     and the ledger is not asked to write anything.
  *
  * That last case is the whole reason this function knows about the watermark.
  * A re-read happens only because the source is trying to learn a cost; if it
  * did not learn one — billing was refused, the hour is not published yet — then
- * emitting zero would overwrite a figure an earlier run had already worked out
- * correctly, and a few minutes of billing trouble would quietly wipe the spend
- * it could not confirm.
+ * emitting anything would overwrite a figure an earlier run had already worked
+ * out correctly, and a few minutes of billing trouble would quietly wipe the
+ * spend it could not confirm.
  */
 function withWarehouseCost({
   events,
@@ -3216,6 +3947,27 @@ function encode(cursor: GenieCursor): string {
 }
 
 /**
+ * The notices field, or nothing at all.
+ *
+ * Absent rather than empty on a clean run, on `openaiAdmin.puller.ts`'s
+ * precedent: a reader never has to tell an adapter that reported no notices
+ * from one that reports none because it does not know how.
+ */
+function runNotices({
+  unreadable,
+  paidBillUnreadable,
+}: {
+  unreadable: boolean;
+  paidBillUnreadable: boolean;
+}): { notices?: string[] } {
+  const notices = [
+    ...(unreadable ? [WAREHOUSE_COST_UNREADABLE] : []),
+    ...(paidBillUnreadable ? [PAID_GENIE_BILL_UNREADABLE] : []),
+  ];
+  return notices.length > 0 ? { notices } : {};
+}
+
+/**
  * The cursor one run hands to the next.
  *
  * The whole in-flight/finished distinction lives here: a sweep that still owes
@@ -3227,6 +3979,7 @@ function nextCursor({
   sweep,
   sweepStartedAtMs,
   pricedThroughMs,
+  paidBillReadThroughMs,
   nowMs,
 }: {
   previous: GenieCursor;
@@ -3234,6 +3987,12 @@ function nextCursor({
   sweepStartedAtMs: number;
   /** Where cost knowledge ran out this run — see `nextWatermark`. */
   pricedThroughMs: number | null;
+  /**
+   * Where the paid bill read reached this run, or null when it did not run
+   * or could not finish a single window. Its own position — see the cursor
+   * field — so it is folded here and nowhere near `sinceMs`.
+   */
+  paidBillReadThroughMs: number | null;
   /** This run's clock, for ageing the cost hold. */
   nowMs: number;
 }): GenieCursor {
@@ -3285,5 +4044,12 @@ function nextCursor({
     // moved past the period, so leaving the stamp would expire every subsequent
     // hold on arrival and the retry would never work again.
     costHeldSinceMs: holdExpired ? null : costHeldSinceMs,
+    // Never backwards, and never touched by anything above: a run that did
+    // not read the bill, or read none of it, leaves the position exactly
+    // where the last run that did put it.
+    paidBillReadThroughMs:
+      paidBillReadThroughMs === null
+        ? previous.paidBillReadThroughMs
+        : Math.max(previous.paidBillReadThroughMs ?? 0, paidBillReadThroughMs),
   };
 }

--- a/platform/app/ee/governance/services/pullers/databricksGenie.puller.ts
+++ b/platform/app/ee/governance/services/pullers/databricksGenie.puller.ts
@@ -1217,6 +1217,15 @@ type PaidGenieBillOutcome = {
 };
 
 /**
+ * Where a bill walk stopped short: the chunk or piece it could not read, and
+ * whether that was a refusal rather than a period too large or too slow.
+ */
+type PaidGenieBillStop = {
+  heldAt: { fromMs: number; toMs: number };
+  unreadable: boolean;
+};
+
+/**
  * Turn one bill reply into rows, or refuse the whole reply. Refusing whole is
  * the same rule the warehouse read follows: a partial answer lands some of a
  * period's rows and leaves the rest absent, and absent is indistinguishable
@@ -2356,55 +2365,22 @@ export class DatabricksGeniePuller
     const toMs = startOfDayMs(Date.now()) + ONE_DAY_MS;
 
     const rows: PaidGenieBillRow[] = [];
-    const read = (chunk: { fromMs: number; toMs: number }) =>
-      this.paidGenieBillChunk({
+    for (const chunk of warehouseCostChunks({ fromMs, toMs })) {
+      const stop = await this.walkPaidGenieBillChunk({
         config,
         token,
         options,
         budget,
         warehouseId,
         chunk,
+        rows,
       });
-    const held = ({
-      heldAt,
-      unreadable,
-    }: {
-      heldAt: { fromMs: number; toMs: number };
-      unreadable: boolean;
-    }) =>
-      this.paidGenieBillHeld({ rows, heldAt, windowEndMs: toMs, unreadable });
-
-    for (const chunk of warehouseCostChunks({ fromMs, toMs })) {
-      if (budget.exhaustedWithin(WAREHOUSE_COST_TIMEOUT_MS)) {
-        return held({ heldAt: chunk, unreadable: false });
-      }
-      const answer = await read(chunk);
-      if (answer.outcome === "priced") {
-        rows.push(...answer.rows);
-        continue;
-      }
-      if (answer.outcome === "failed") {
-        return held({ heldAt: chunk, unreadable: true });
-      }
-
-      // Cut short or timed out: ask about less before holding, exactly as the
-      // warehouse read does, so the days that answer on their own still land.
-      const pieces = warehouseCostPieces(chunk);
-      if (pieces.length === 0) {
-        return held({ heldAt: chunk, unreadable: false });
-      }
-      for (const piece of pieces) {
-        if (budget.exhaustedWithin(WAREHOUSE_COST_TIMEOUT_MS)) {
-          return held({ heldAt: piece, unreadable: false });
-        }
-        const pieceAnswer = await read(piece);
-        if (pieceAnswer.outcome === "priced") {
-          rows.push(...pieceAnswer.rows);
-          continue;
-        }
-        return held({
-          heldAt: piece,
-          unreadable: pieceAnswer.outcome === "failed",
+      if (stop !== null) {
+        return this.paidGenieBillHeld({
+          rows,
+          heldAt: stop.heldAt,
+          windowEndMs: toMs,
+          unreadable: stop.unreadable,
         });
       }
     }
@@ -2414,6 +2390,108 @@ export class DatabricksGeniePuller
       window: { readThroughMs: toMs, endMs: toMs, held: false },
       unreadable: false,
     };
+  }
+
+  /**
+   * One chunk of the bill window: whether the run still has room for it, the
+   * answer, and — when the answer is not whole — the pieces. Rows land on
+   * `rows` as they answer. Returns where the walk stopped, or null once the
+   * whole chunk has landed, the same split `priceWarehouseCostChunk` makes.
+   */
+  private async walkPaidGenieBillChunk({
+    config,
+    token,
+    options,
+    budget,
+    warehouseId,
+    chunk,
+    rows,
+  }: {
+    config: DatabricksGeniePullConfig;
+    token: string;
+    options: PullRunOptions;
+    budget: RunBudget;
+    warehouseId: string;
+    chunk: { fromMs: number; toMs: number };
+    rows: PaidGenieBillRow[];
+  }): Promise<PaidGenieBillStop | null> {
+    if (budget.exhaustedWithin(WAREHOUSE_COST_TIMEOUT_MS)) {
+      return { heldAt: chunk, unreadable: false };
+    }
+    const answer = await this.paidGenieBillChunk({
+      config,
+      token,
+      options,
+      budget,
+      warehouseId,
+      chunk,
+    });
+    if (answer.outcome === "priced") {
+      rows.push(...answer.rows);
+      return null;
+    }
+    if (answer.outcome === "failed") {
+      return { heldAt: chunk, unreadable: true };
+    }
+
+    // Cut short or timed out: ask about less before holding, exactly as the
+    // warehouse read does, so the days that answer on their own still land.
+    const pieces = warehouseCostPieces(chunk);
+    if (pieces.length === 0) {
+      return { heldAt: chunk, unreadable: false };
+    }
+    return await this.walkPaidGenieBillPieces({
+      config,
+      token,
+      options,
+      budget,
+      warehouseId,
+      pieces,
+      rows,
+    });
+  }
+
+  /**
+   * The pieces of a chunk that would not answer whole, in order. Every piece
+   * that answers lands its rows; the first that does not stops the walk there,
+   * so the days before it are never re-asked.
+   */
+  private async walkPaidGenieBillPieces({
+    config,
+    token,
+    options,
+    budget,
+    warehouseId,
+    pieces,
+    rows,
+  }: {
+    config: DatabricksGeniePullConfig;
+    token: string;
+    options: PullRunOptions;
+    budget: RunBudget;
+    warehouseId: string;
+    pieces: { fromMs: number; toMs: number }[];
+    rows: PaidGenieBillRow[];
+  }): Promise<PaidGenieBillStop | null> {
+    for (const piece of pieces) {
+      if (budget.exhaustedWithin(WAREHOUSE_COST_TIMEOUT_MS)) {
+        return { heldAt: piece, unreadable: false };
+      }
+      const answer = await this.paidGenieBillChunk({
+        config,
+        token,
+        options,
+        budget,
+        warehouseId,
+        chunk: piece,
+      });
+      if (answer.outcome === "priced") {
+        rows.push(...answer.rows);
+        continue;
+      }
+      return { heldAt: piece, unreadable: answer.outcome === "failed" };
+    }
+    return null;
   }
 
   /**
@@ -4070,26 +4148,6 @@ function nextCursor({
     costHeldSinceMs !== null &&
     nowMs - costHeldSinceMs > WAREHOUSE_COST_MAX_HOLD_MS;
 
-  // The bill read's hold, aged the same way on its own stamp. A run that asked
-  // about no window — the read is off, or on with no warehouse — clears it:
-  // the source is not waiting on a bill, and a stamp left running against a
-  // misconfiguration would expire the hold the moment the source was fixed.
-  // Once expired, the position moves to the end of the window this run asked
-  // about — the rows in it stay unrecorded, with no amount — and the stamp is
-  // cleared so the next hold ages from its own start.
-  const paidBillHeldSinceMs = paidBillWindow?.held
-    ? (previous.paidBillHeldSinceMs ?? nowMs)
-    : null;
-  const paidBillHoldExpired =
-    paidBillHeldSinceMs !== null &&
-    nowMs - paidBillHeldSinceMs > WAREHOUSE_COST_MAX_HOLD_MS;
-  const paidBillReadThroughMs =
-    paidBillWindow === null
-      ? null
-      : paidBillHoldExpired
-        ? paidBillWindow.endMs
-        : paidBillWindow.readThroughMs;
-
   return {
     // A sweep that walked past something it never read is not whole, no matter
     // how tidily it finished. Holding the window costs a re-read of the same
@@ -4123,15 +4181,56 @@ function nextCursor({
     // moved past the period, so leaving the stamp would expire every subsequent
     // hold on arrival and the retry would never work again.
     costHeldSinceMs: holdExpired ? null : costHeldSinceMs,
-    // Never backwards, and never touched by anything above: a run that asked
-    // about no window leaves the position exactly where the last run that did
-    // put it. A held read writes its floor too — that is the whole point of
-    // the hold — and the max keeps the settling look-back from walking the
-    // floor backwards a run at a time.
-    paidBillReadThroughMs:
-      paidBillReadThroughMs === null
-        ? previous.paidBillReadThroughMs
-        : Math.max(previous.paidBillReadThroughMs ?? 0, paidBillReadThroughMs),
-    paidBillHeldSinceMs: paidBillHoldExpired ? null : paidBillHeldSinceMs,
+    // The bill read's own position and hold, folded here and nowhere near
+    // `sinceMs` or the cost hold above.
+    ...nextPaidBillPosition({ previous, paidBillWindow, nowMs }),
+  };
+}
+
+/**
+ * The paid bill read's position and hold for the next run.
+ *
+ * The hold is aged the same way as the cost hold, on its own stamp. A run that
+ * asked about no window — the read is off, or on with no warehouse — clears
+ * it: the source is not waiting on a bill, and a stamp left running against a
+ * misconfiguration would expire the hold the moment the source was fixed.
+ * Once expired, the position moves to the end of the window this run asked
+ * about — the rows in it stay unrecorded, with no amount — and the stamp is
+ * cleared so the next hold ages from its own start.
+ *
+ * The position never moves backwards: a run that asked about no window leaves
+ * it exactly where the last run that did put it. A held read writes its floor
+ * too — that is the whole point of the hold — and the max keeps the settling
+ * look-back from walking the floor backwards a run at a time.
+ */
+function nextPaidBillPosition({
+  previous,
+  paidBillWindow,
+  nowMs,
+}: {
+  previous: GenieCursor;
+  paidBillWindow: PaidGenieBillOutcome["window"];
+  nowMs: number;
+}): Pick<GenieCursor, "paidBillReadThroughMs" | "paidBillHeldSinceMs"> {
+  if (paidBillWindow === null) {
+    return {
+      paidBillReadThroughMs: previous.paidBillReadThroughMs,
+      paidBillHeldSinceMs: null,
+    };
+  }
+  const heldSinceMs = paidBillWindow.held
+    ? (previous.paidBillHeldSinceMs ?? nowMs)
+    : null;
+  const expired =
+    heldSinceMs !== null && nowMs - heldSinceMs > WAREHOUSE_COST_MAX_HOLD_MS;
+  const readThroughMs = expired
+    ? paidBillWindow.endMs
+    : paidBillWindow.readThroughMs;
+  return {
+    paidBillReadThroughMs: Math.max(
+      previous.paidBillReadThroughMs ?? 0,
+      readThroughMs,
+    ),
+    paidBillHeldSinceMs: expired ? null : heldSinceMs,
   };
 }

--- a/platform/app/ee/governance/services/pullers/openaiCompliance.puller.ts
+++ b/platform/app/ee/governance/services/pullers/openaiCompliance.puller.ts
@@ -20,6 +20,15 @@
  *     "cost": { "usd": F }
  *   }
  *
+ * The person is named by `user.id`, never by `user.email`: the id is the
+ * provider's stable handle and the erasure suppression list is keyed on
+ * exactly the actor string, the same choice the OpenAI Admin cost adapter
+ * makes. The address is left on the line, and the line is not kept
+ * (`retainRawPayload: false`), so it reaches neither the event nor the
+ * audit row. Matching the id to an account is the identity engine's job.
+ *
+ * Spec: specs/ai-governance/puller-framework/s3-polling.feature
+ *       (the OpenAI compliance rule)
  * Spec: specs/ai-governance/puller-framework/copilot-studio-reference.feature
  *       (same lock-the-shape pattern; openai/claude follow as ⏳ rows)
  */
@@ -51,17 +60,17 @@ export const OPENAI_COMPLIANCE_PULL_CONFIG: Omit<
   eventMapping: {
     source_event_id: "$.id",
     event_timestamp: "$.created_at",
-    actor: "$.user.email",
+    actor: "$.user.id",
     action: "$.type",
     target: "$.model",
     cost_usd: "$.cost.usd",
     tokens_input: "$.tokens.input",
     tokens_output: "$.tokens.output",
     extra: {
-      user_id: "$.user.id",
       object: "$.object",
     },
   },
+  retainRawPayload: false,
 };
 
 interface OpenAiAdminInput {

--- a/platform/app/ee/governance/services/pullers/s3PollingPullerAdapter.ts
+++ b/platform/app/ee/governance/services/pullers/s3PollingPullerAdapter.ts
@@ -72,6 +72,17 @@ const s3PollingConfigSchema = z.object({
   parser: z.enum(["ndjson", "json-array", "csv"]),
   schedule: z.string().min(1),
   eventMapping: eventMappingSchema,
+  /**
+   * Whether each event keeps a verbatim copy of the line it was mapped from.
+   *
+   * On by default: the contract reserves `raw_payload` for a replay against a
+   * future mapping, and the audit row exports it for a SIEM to drill back to.
+   * A source turns it off when the line carries what the mapping was written
+   * to leave out. The OpenAI compliance export puts the person's email beside
+   * the id on every line; the mapping names the person by the id, and a kept
+   * copy would carry the address into the audit row by the back door.
+   */
+  retainRawPayload: z.boolean().default(true),
 });
 
 export type S3PollingConfig = z.infer<typeof s3PollingConfigSchema>;
@@ -513,7 +524,9 @@ export class S3PollingPullerAdapter implements PullerAdapter<S3PollingConfig> {
       cost_usd: asDecimalString(get(config.eventMapping.cost_usd)),
       tokens_input: asInt(get(config.eventMapping.tokens_input)),
       tokens_output: asInt(get(config.eventMapping.tokens_output)),
-      raw_payload: JSON.stringify(rawEvent),
+      // Empty, not absent, when the copy is not kept: the contract types the
+      // field as a string, and an empty string carries nothing of the line.
+      raw_payload: config.retainRawPayload ? JSON.stringify(rawEvent) : "",
       ...(Object.keys(extras).length > 0 ? { extra: extras } : {}),
     };
   }

--- a/platform/app/ee/governance/services/pullers/sourcePullStatus.ts
+++ b/platform/app/ee/governance/services/pullers/sourcePullStatus.ts
@@ -1,20 +1,14 @@
 // SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
 
+import { PULL_REFUSED_ERROR_CODE } from "@ee/event-sourcing/pipelines/ingestion-pull-processing/schemas/events";
 import { z } from "zod";
 import type { IngestionPullRunProjection } from "~/generated/prisma/client";
 
 export type PullRunSummary = Pick<
   IngestionPullRunProjection,
-  "LastRunAt" | "LastRunOutcome" | "LastRunError"
-> &
-  Partial<Pick<IngestionPullRunProjection, "LastRunErrorCode">>;
+  "LastRunAt" | "LastRunOutcome" | "LastRunError" | "LastRunErrorCode"
+>;
 
-/**
- * The one failure whose message the run handler wrote itself, so it carries
- * no provider reply and can be shown as written
- * (`ingestionPullEffects.ts`, the non-retryable branch).
- */
-const REFUSED_ERROR_CODE = "pull_refused";
 const progressSchema = z.object({
   startingAt: z.string().datetime(),
   watermark: z.string().datetime().nullish(),
@@ -55,7 +49,10 @@ function failureMessage({
   error: string | null | undefined;
   errorCode: string | null | undefined;
 }): string {
-  if (errorCode === REFUSED_ERROR_CODE && error) return error;
+  // The refused code is only ever written beside a sentence we wrote
+  // ourselves (the run handler's non-retryable branch), so it is the one
+  // failure whose text can be shown as written.
+  if (errorCode === PULL_REFUSED_ERROR_CODE && error) return error;
   if (/Too many simultaneous queries/i.test(error ?? ""))
     return "The database is busy.";
   if (/HTTP 429|rate limit exceeded/i.test(error ?? ""))

--- a/platform/app/ee/governance/services/pullers/sourcePullStatus.ts
+++ b/platform/app/ee/governance/services/pullers/sourcePullStatus.ts
@@ -6,7 +6,15 @@ import type { IngestionPullRunProjection } from "~/generated/prisma/client";
 export type PullRunSummary = Pick<
   IngestionPullRunProjection,
   "LastRunAt" | "LastRunOutcome" | "LastRunError"
->;
+> &
+  Partial<Pick<IngestionPullRunProjection, "LastRunErrorCode">>;
+
+/**
+ * The one failure whose message the run handler wrote itself, so it carries
+ * no provider reply and can be shown as written
+ * (`ingestionPullEffects.ts`, the non-retryable branch).
+ */
+const REFUSED_ERROR_CODE = "pull_refused";
 const progressSchema = z.object({
   startingAt: z.string().datetime(),
   watermark: z.string().datetime().nullish(),
@@ -40,7 +48,14 @@ function billingProgress(sourceType: string, cursor: unknown) {
   }
 }
 
-function failureMessage(error: string | null | undefined): string {
+function failureMessage({
+  error,
+  errorCode,
+}: {
+  error: string | null | undefined;
+  errorCode: string | null | undefined;
+}): string {
+  if (errorCode === REFUSED_ERROR_CODE && error) return error;
   if (/Too many simultaneous queries/i.test(error ?? ""))
     return "The database is busy.";
   if (/HTTP 429|rate limit exceeded/i.test(error ?? ""))
@@ -66,7 +81,10 @@ export function sourcePullStatus({
     outcome: pullRun?.LastRunOutcome ?? null,
     error:
       pullRun?.LastRunOutcome === "failed"
-        ? failureMessage(pullRun.LastRunError)
+        ? failureMessage({
+            error: pullRun.LastRunError,
+            errorCode: pullRun.LastRunErrorCode,
+          })
         : null,
     ...billingProgress(sourceType, cursor),
   };

--- a/platform/app/src/components/governance/costs/CostCharts.tsx
+++ b/platform/app/src/components/governance/costs/CostCharts.tsx
@@ -420,6 +420,49 @@ function seriesKeysOf(buckets: DailyBucket[]): Array<{
   return [...labelByKey.entries()].map(([key, label]) => ({ key, label }));
 }
 
+/**
+ * A bucket that may say its bar is not the whole figure.
+ *
+ * `withheld` is optional so the invented series and the panels whose figures
+ * are always whole need not say so; a bucket that omits it is drawn as whole.
+ * The chart does not decide what "short" means — the fold that built the
+ * bucket does, since only it saw the rows — it only draws what it is told.
+ */
+export type StackedBucket = DailyBucket & { withheld?: boolean };
+
+/** Stroke on a bar whose period holds a figure we do not have. */
+const WITHHELD_STROKE = "#94a3b8";
+/** How much of the series colour a short bar keeps. */
+const WITHHELD_FILL = 0.45;
+
+/** The words a short bar's tooltip adds after the period's name. */
+export const WITHHELD_TOOLTIP_NOTE = "part of this period has no dollar figure";
+
+/**
+ * One cell per bar, fading and dash-edging the bars whose period is short, so
+ * a short bar reads as "not the whole figure" before the tooltip or the note
+ * under the chart is. Nothing at all when no bucket is short: recharts draws
+ * each bar from its own cell list, and a full list of plain cells on every
+ * chart is work for nothing.
+ */
+function withheldCells(
+  rows: Array<Record<string, number | string>>,
+  withheldDays: ReadonlySet<string>,
+): ReactNode {
+  if (withheldDays.size === 0) return null;
+  return rows.map((row) => {
+    const short = withheldDays.has(String(row.day));
+    return (
+      <Cell
+        key={String(row.day)}
+        fillOpacity={short ? WITHHELD_FILL : 1}
+        stroke={short ? WITHHELD_STROKE : undefined}
+        strokeDasharray={short ? "3 2" : undefined}
+      />
+    );
+  });
+}
+
 function widenBuckets(
   buckets: DailyBucket[],
   keys: Array<{ key: string; label: string }>,
@@ -476,7 +519,13 @@ export function CostStackedBars({
   empty,
   onSelectSeries,
 }: {
-  buckets: DailyBucket[] | null;
+  /**
+   * Null while unanswered. A bucket flagged `withheld` is drawn faded with a
+   * dashed edge and its tooltip says why: its bar is the sum of the days that
+   * held a figure, which is short by however much was left out, and a short
+   * bar drawn like a whole one reads as a cheap period.
+   */
+  buckets: StackedBucket[] | null;
   height?: string;
   format?: (value: number) => string;
   showLegend?: boolean;
@@ -513,6 +562,13 @@ export function CostStackedBars({
     () => widenBuckets(buckets ?? [], keys),
     [buckets, keys],
   );
+  // Kept beside the rows rather than widened into them: a row is a bag of
+  // series values and a flag in it would be one more key for recharts to try
+  // to draw as a series.
+  const withheldDays = useMemo(
+    () => new Set((buckets ?? []).filter((b) => b.withheld).map((b) => b.day)),
+    [buckets],
+  );
 
   if (buckets === null)
     return <EmptyPanel height={height} unanswered empty={empty} />;
@@ -543,7 +599,12 @@ export function CostStackedBars({
               format(Number(value)),
               keys.find((k) => k.key === String(name))?.label ?? String(name),
             ]}
-            labelFormatter={(label) => formatDayTick(label as string, interval)}
+            labelFormatter={(label) => {
+              const period = formatDayTick(label as string, interval);
+              return withheldDays.has(label as string)
+                ? `${period} · ${WITHHELD_TOOLTIP_NOTE}`
+                : period;
+            }}
             contentStyle={CHART_TOOLTIP_CONTENT}
             labelStyle={CHART_TOOLTIP_LABEL}
             cursor={CHART_TOOLTIP_CURSOR}
@@ -576,7 +637,9 @@ export function CostStackedBars({
                     }
                   : undefined
               }
-            />
+            >
+              {withheldCells(rows, withheldDays)}
+            </Bar>
           ))}
         </BarChart>
       </ResponsiveContainer>

--- a/platform/app/src/components/governance/costs/CostCharts.tsx
+++ b/platform/app/src/components/governance/costs/CostCharts.tsx
@@ -1,6 +1,6 @@
 import { Box, HStack, Text, VStack } from "@chakra-ui/react";
 import numeral from "numeral";
-import { type ReactNode, useMemo } from "react";
+import { type ReactElement, type ReactNode, useMemo } from "react";
 import {
   Area,
   AreaChart,
@@ -11,6 +11,8 @@ import {
   Legend,
   Pie,
   PieChart,
+  Rectangle,
+  type RectangleProps,
   ReferenceArea,
   ReferenceLine,
   ResponsiveContainer,
@@ -430,37 +432,132 @@ function seriesKeysOf(buckets: DailyBucket[]): Array<{
  */
 export type StackedBucket = DailyBucket & { withheld?: boolean };
 
+/**
+ * The slate ink for a quantity that is NOT a measurement of what happened.
+ *
+ * Two marks on this screen mean that, and they share it on purpose: the
+ * forecast's projected span, and the edge of a bar whose period holds a figure
+ * we do not have. A hex rather than a token because the chart palette has no
+ * hue for "not a measurement" — every palette hue carries a figure, and a
+ * figure is the one thing neither of these marks is — and no Chakra semantic
+ * token names the idea either; `fg.muted` is an ink for text, which the
+ * mark-colour guard rightly refuses on a drawn shape. `CHART_SEAT_CONTRACT_FILL`
+ * in `chartTheme` is the same slate for the same reason.
+ */
+const PROJECTION_INK = "#94a3b8";
 /** Stroke on a bar whose period holds a figure we do not have. */
-const WITHHELD_STROKE = "#94a3b8";
+const WITHHELD_STROKE = PROJECTION_INK;
 /** How much of the series colour a short bar keeps. */
 const WITHHELD_FILL = 0.45;
+/**
+ * The dash a short bar's edge is drawn in. The cue that is not a colour: a
+ * faded fill alone disappears under greyscale and under most colour-blindness,
+ * and a mark that means "not the whole figure" cannot be one only some readers
+ * can see.
+ */
+const WITHHELD_DASH = "3 2";
+/**
+ * The height, in pixels, of the mark drawn where a bar would be when the period
+ * has NO figure at all — every day withheld, nothing to add up. Tall enough to
+ * carry the dash, short enough not to read as a small amount.
+ */
+const WITHHELD_EMPTY_HEIGHT = 6;
 
 /** The words a short bar's tooltip adds after the period's name. */
 export const WITHHELD_TOOLTIP_NOTE = "part of this period has no dollar figure";
+/** What a screen reader says on a bar that is short. */
+export const WITHHELD_BAR_LABEL =
+  "Amount withheld: part of this period has no dollar figure";
+/** What a screen reader says where a bar would be, when the whole period is withheld. */
+export const WITHHELD_EMPTY_BAR_LABEL =
+  "Amount withheld: no dollar figure for this period";
 
 /**
- * One cell per bar, fading and dash-edging the bars whose period is short, so
- * a short bar reads as "not the whole figure" before the tooltip or the note
- * under the chart is. Nothing at all when no bucket is short: recharts draws
- * each bar from its own cell list, and a full list of plain cells on every
- * chart is work for nothing.
+ * Which periods the chart must draw as short, and which of those it must draw
+ * a stand-in for because there is no bar to mark.
  */
-function withheldCells(
-  rows: Array<Record<string, number | string>>,
-  withheldDays: ReadonlySet<string>,
-): ReactNode {
-  if (withheldDays.size === 0) return null;
-  return rows.map((row) => {
-    const short = withheldDays.has(String(row.day));
+export type WithheldMarks = {
+  /** Periods holding some figure we do not have: the bar is drawn short. */
+  withheldDays: ReadonlySet<string>;
+  /**
+   * Periods holding NO figure at all: recharts draws nothing for a bar of
+   * height zero, so a mark stands in for the bar. A single-provider tenant
+   * with one unanswered bill used to get an empty slot here, indistinguishable
+   * from a period nobody spent anything in — the exact reading a withheld
+   * figure exists to prevent.
+   */
+  emptyDays: ReadonlySet<string>;
+  /**
+   * Whether this series draws the stand-in. Exactly one series per chart
+   * does: every series in a stack is handed the same zero-height rectangle at
+   * the same spot, and N of them drawing N marks on top of one another is one
+   * mark to the eye and N to a screen reader.
+   */
+  drawsEmptyMark: boolean;
+};
+
+/**
+ * The geometry recharts hands a bar's shape, and the row the bar was drawn
+ * from. Narrower than recharts' own `BarShapeProps` so a test can build one
+ * by hand for the zero-height case that jsdom cannot lay out.
+ */
+export type WithheldBarShapeProps = RectangleProps & {
+  payload?: { day?: unknown };
+};
+
+/**
+ * One bar, drawn as recharts would unless its period is short.
+ *
+ * A short bar keeps recharts' own rectangle — so it still answers to
+ * `.recharts-rectangle` and to the click that opens a period — faded and
+ * dash-edged, wrapped in a group that says why to a screen reader. A period
+ * with nothing to draw gets the stand-in instead. Handed to `<Bar shape>`
+ * rather than done with `<Cell>`s because a cell can only restyle a
+ * rectangle recharts decided to draw, and for a height of zero it decides
+ * not to; a custom shape is called for every bar, zero-height ones included.
+ */
+export function withheldBarShape(
+  props: WithheldBarShapeProps,
+  marks: WithheldMarks,
+): ReactElement | null {
+  const day = typeof props.payload?.day === "string" ? props.payload.day : null;
+  if (day === null || !marks.withheldDays.has(day)) {
+    return <Rectangle {...props} />;
+  }
+  if (marks.emptyDays.has(day)) {
+    if (!marks.drawsEmptyMark) return null;
+    const { x = 0, y = 0, width = 0 } = props;
     return (
-      <Cell
-        key={String(row.day)}
-        fillOpacity={short ? WITHHELD_FILL : 1}
-        stroke={short ? WITHHELD_STROKE : undefined}
-        strokeDasharray={short ? "3 2" : undefined}
-      />
+      <g role="img" aria-label={WITHHELD_EMPTY_BAR_LABEL} data-withheld="empty">
+        <title>{WITHHELD_EMPTY_BAR_LABEL}</title>
+        <rect
+          x={x}
+          // Up from the baseline, where the bar would have started.
+          y={y - WITHHELD_EMPTY_HEIGHT}
+          width={width}
+          height={WITHHELD_EMPTY_HEIGHT}
+          fill="none"
+          stroke={WITHHELD_STROKE}
+          strokeDasharray={WITHHELD_DASH}
+        />
+      </g>
     );
-  });
+  }
+  // A series with nothing in this period, stacked on one that has: recharts
+  // would draw nothing for it, and a labelled group around nothing is a
+  // second "withheld" a screen reader would read out for one bar.
+  if (!props.height || !props.width) return null;
+  return (
+    <g role="img" aria-label={WITHHELD_BAR_LABEL} data-withheld="short">
+      <title>{WITHHELD_BAR_LABEL}</title>
+      <Rectangle
+        {...props}
+        fillOpacity={WITHHELD_FILL}
+        stroke={WITHHELD_STROKE}
+        strokeDasharray={WITHHELD_DASH}
+      />
+    </g>
+  );
 }
 
 function widenBuckets(
@@ -523,7 +620,9 @@ export function CostStackedBars({
    * Null while unanswered. A bucket flagged `withheld` is drawn faded with a
    * dashed edge and its tooltip says why: its bar is the sum of the days that
    * held a figure, which is short by however much was left out, and a short
-   * bar drawn like a whole one reads as a cheap period.
+   * bar drawn like a whole one reads as a cheap period. A withheld bucket
+   * with no figure at all gets a dashed stand-in where its bar would be, so
+   * it is never an empty slot. See `withheldBarShape`.
    */
   buckets: StackedBucket[] | null;
   height?: string;
@@ -569,6 +668,17 @@ export function CostStackedBars({
     () => new Set((buckets ?? []).filter((b) => b.withheld).map((b) => b.day)),
     [buckets],
   );
+  // A withheld period with nothing in it at all: no series holds a figure,
+  // so there is no bar for the dash to sit on, and a mark stands in for one.
+  const emptyDays = useMemo(
+    () =>
+      new Set(
+        (buckets ?? [])
+          .filter((b) => b.withheld && b.points.every((p) => p.value === 0))
+          .map((b) => b.day),
+      ),
+    [buckets],
+  );
 
   if (buckets === null)
     return <EmptyPanel height={height} unanswered empty={empty} />;
@@ -610,7 +720,7 @@ export function CostStackedBars({
             cursor={CHART_TOOLTIP_CURSOR}
           />
           {showLegend && ChartLegend({ keys })}
-          {keys.map((k) => (
+          {keys.map((k, index) => (
             <Bar
               key={k.key}
               dataKey={k.key}
@@ -620,6 +730,19 @@ export function CostStackedBars({
               stackId={grouped ? undefined : "cost"}
               fill={colorFor?.(k.key) ?? getHexColorForString(k.label)}
               isAnimationActive={false}
+              // Only when some period is short: a custom shape makes recharts
+              // hand over zero-height bars it would otherwise skip, and a
+              // chart with nothing to mark has no use for them.
+              shape={
+                withheldDays.size > 0
+                  ? (shapeProps: WithheldBarShapeProps) =>
+                      withheldBarShape(shapeProps, {
+                        withheldDays,
+                        emptyDays,
+                        drawsEmptyMark: index === 0,
+                      })
+                  : undefined
+              }
               cursor={onSelectSeries ? "pointer" : undefined}
               onClick={
                 onSelectSeries
@@ -637,9 +760,7 @@ export function CostStackedBars({
                     }
                   : undefined
               }
-            >
-              {withheldCells(rows, withheldDays)}
-            </Bar>
+            />
           ))}
         </BarChart>
       </ResponsiveContainer>
@@ -651,8 +772,6 @@ export function CostStackedBars({
 const MEASURED_FILL = 0.42;
 /** Opacity of the same series over the months still to come. */
 const PROJECTED_FILL = 0.07;
-/** The projected span's own wash, over the top of the faded series. */
-const PROJECTION_INK = "#94a3b8";
 
 /**
  * Where the projection begins: the LAST MEASURED bucket, and its position as a

--- a/platform/app/src/components/governance/costs/CostCharts.tsx
+++ b/platform/app/src/components/governance/costs/CostCharts.tsx
@@ -597,6 +597,42 @@ function ChartLegend({
 }
 
 /**
+ * The days a stacked chart has to mark, kept beside the rows rather than
+ * widened into them: a row is a bag of series values and a flag in it would be
+ * one more key for recharts to try to draw as a series.
+ *
+ * `emptyDays` is the subset with nothing in it at all: no series holds a
+ * figure, so there is no bar for the dash to sit on, and a mark stands in for
+ * one.
+ */
+function withheldDaysOf(buckets: StackedBucket[]): {
+  withheldDays: Set<string>;
+  emptyDays: Set<string>;
+} {
+  const withheld = buckets.filter((b) => b.withheld);
+  return {
+    withheldDays: new Set(withheld.map((b) => b.day)),
+    emptyDays: new Set(
+      withheld
+        .filter((b) => b.points.every((p) => p.value === 0))
+        .map((b) => b.day),
+    ),
+  };
+}
+
+/**
+ * A series' bar shape, only when some period is short: a custom shape makes
+ * recharts hand over zero-height bars it would otherwise skip, and a chart
+ * with nothing to mark has no use for them.
+ */
+function withheldShapeFor(
+  marks: WithheldMarks,
+): ((props: WithheldBarShapeProps) => ReactElement | null) | undefined {
+  if (marks.withheldDays.size === 0) return undefined;
+  return (props) => withheldBarShape(props, marks);
+}
+
+/**
  * Stacked bars over the time axis — the shape the cost-evolution panels want.
  *
  * `grouped` puts the series side by side instead of on top of one another, for
@@ -661,22 +697,8 @@ export function CostStackedBars({
     () => widenBuckets(buckets ?? [], keys),
     [buckets, keys],
   );
-  // Kept beside the rows rather than widened into them: a row is a bag of
-  // series values and a flag in it would be one more key for recharts to try
-  // to draw as a series.
-  const withheldDays = useMemo(
-    () => new Set((buckets ?? []).filter((b) => b.withheld).map((b) => b.day)),
-    [buckets],
-  );
-  // A withheld period with nothing in it at all: no series holds a figure,
-  // so there is no bar for the dash to sit on, and a mark stands in for one.
-  const emptyDays = useMemo(
-    () =>
-      new Set(
-        (buckets ?? [])
-          .filter((b) => b.withheld && b.points.every((p) => p.value === 0))
-          .map((b) => b.day),
-      ),
+  const { withheldDays, emptyDays } = useMemo(
+    () => withheldDaysOf(buckets ?? []),
     [buckets],
   );
 
@@ -730,19 +752,11 @@ export function CostStackedBars({
               stackId={grouped ? undefined : "cost"}
               fill={colorFor?.(k.key) ?? getHexColorForString(k.label)}
               isAnimationActive={false}
-              // Only when some period is short: a custom shape makes recharts
-              // hand over zero-height bars it would otherwise skip, and a
-              // chart with nothing to mark has no use for them.
-              shape={
-                withheldDays.size > 0
-                  ? (shapeProps: WithheldBarShapeProps) =>
-                      withheldBarShape(shapeProps, {
-                        withheldDays,
-                        emptyDays,
-                        drawsEmptyMark: index === 0,
-                      })
-                  : undefined
-              }
+              shape={withheldShapeFor({
+                withheldDays,
+                emptyDays,
+                drawsEmptyMark: index === 0,
+              })}
               cursor={onSelectSeries ? "pointer" : undefined}
               onClick={
                 onSelectSeries

--- a/platform/app/src/components/governance/costs/CostProviderDayPanel.tsx
+++ b/platform/app/src/components/governance/costs/CostProviderDayPanel.tsx
@@ -99,15 +99,7 @@ export function CostProviderDayPanel({
         interval={interval}
         onSelectSeries={(provider, period) => setOpened({ provider, period })}
       />
-      {partialProviders.length > 0 && (
-        <Text
-          fontSize="xs"
-          color="fg.muted"
-          aria-label="Some bars cover only part of what was spent"
-        >
-          Part of {partialProviders.join(", ")} spend has no dollar figure
-        </Text>
-      )}
+      <PartialSpendNote providers={partialProviders} />
       {openedPeriod && (
         <PeriodRecords
           organizationId={organizationId}
@@ -116,6 +108,32 @@ export function CostProviderDayPanel({
         />
       )}
     </VStack>
+  );
+}
+
+/**
+ * The line under a chart whose bars are short, naming who left them short.
+ *
+ * Shared by the total chart and the provider split beside it: they are folded
+ * from the same rows, so a period short in one is short in the other, and the
+ * two panels have to say so in the same words. Renders nothing when no bar is
+ * short, so the caller need not guard it.
+ */
+export function PartialSpendNote({
+  providers,
+}: {
+  /** From `partialProviderNotes`: one phrase per short provider. */
+  providers: readonly string[];
+}) {
+  if (providers.length === 0) return null;
+  return (
+    <Text
+      fontSize="xs"
+      color="fg.muted"
+      aria-label="Some bars cover only part of what was spent"
+    >
+      Part of {providers.join(", ")} spend has no dollar figure
+    </Text>
   );
 }
 
@@ -176,12 +194,24 @@ export const TOTAL_SPEND_KEY = "total";
 export function costTotalBuckets(
   rows: readonly GovernanceCostProviderDayRowDto[],
   interval: TimeInterval,
-): DailyBucket[] {
+): CostTotalBucket[] {
   const byDay = new Map<string, number>();
+  // Which providers left a period short, keyed by the period's first day —
+  // the same fold `aggregateBuckets` applies to the figures, so a mark and
+  // the bar it sits on can never disagree about which period they mean.
+  const withheldByPeriod = new Map<string, Set<string>>();
   for (const row of rows) {
     // A withheld day adds nothing rather than being guessed at, exactly as it
-    // does in the stack. The line under that chart says the height is short.
+    // does in the stack — and the bucket SAYS it is short. A bar quietly
+    // drawn at the sum of the days that held a figure reads as a cheap
+    // period, which is the one thing a withheld figure exists to prevent.
     byDay.set(row.day, (byDay.get(row.day) ?? 0) + (row.amountUsd ?? 0));
+    if (row.amountUsd === null) {
+      const period = bucketStartOf(row.day, interval);
+      const held = withheldByPeriod.get(period) ?? new Set<string>();
+      held.add(row.provider);
+      withheldByPeriod.set(period, held);
+    }
   }
   const daily = [...byDay.entries()]
     .sort(([a], [b]) => a.localeCompare(b))
@@ -189,8 +219,29 @@ export function costTotalBuckets(
       day,
       points: [{ key: TOTAL_SPEND_KEY, label: "Spend", value }],
     }));
-  return aggregateBuckets(daily, interval);
+  return aggregateBuckets(daily, interval).map((bucket) => {
+    const withheldProviders = [...(withheldByPeriod.get(bucket.day) ?? [])];
+    return {
+      ...bucket,
+      withheld: withheldProviders.length > 0,
+      withheldProviders: withheldProviders.sort(),
+    };
+  });
 }
+
+/**
+ * One period of the total chart, carrying whether its bar is the whole figure.
+ *
+ * `withheld` is true when any row folded into the period holds no dollar
+ * figure at all. The bar is then the sum of the days that did, which is SHORT
+ * by however much was left out, and the chart draws it as short rather than as
+ * a period nobody spent much in. `withheldProviders` names who left it short,
+ * sorted, so the note under the chart can say which bill to go and look at.
+ */
+export type CostTotalBucket = DailyBucket & {
+  withheld: boolean;
+  withheldProviders: string[];
+};
 
 /** The rows as one stackable bucket per day, one series per provider. */
 export function providerDayBuckets(

--- a/platform/app/src/components/governance/costs/CostProviderDayPanel.tsx
+++ b/platform/app/src/components/governance/costs/CostProviderDayPanel.tsx
@@ -52,28 +52,28 @@ export function CostProviderDayPanel({
   } | null>(null);
 
   const buckets = useMemo(
-    () => aggregateBuckets(providerDayBuckets(rows), interval),
+    () => providerSplitBuckets(rows, interval),
     [rows, interval],
   );
   const periods = useMemo(
     () => providerPeriods(rows, interval),
     [rows, interval],
   );
-
-  if (rows.length === 0) return null;
-
   // A provider whose window total was withheld still has periods that each
   // hold a real number, so a reader who adds the bars up rebuilds exactly the
   // partial sum the total refused to show them. Saying so under the chart is
   // what stops the bars from BEING that sum.
   //
-  // TWO WAYS TO BE SHORT, one note. A bar is missing money either because a
-  // cell held no amount at all — `amountUsd === null` — or because a cell was
-  // billed in a currency we could not convert, which leaves the bar drawn at a
-  // real but incomplete number with nothing null about it. The second kind
-  // reads as complete unless it is said, and it is the one a reader can act
-  // on, so the currency is named rather than merely counted.
-  const partialProviders = partialProviderNotes(rows);
+  // Read off the buckets the chart draws, not off the rows again: the bars
+  // and the note under them are then two readings of one fold, and a period
+  // the chart marks short is a period the note names. See `rowIsShort` for
+  // the two ways a period gets short.
+  const partialProviders = useMemo(
+    () => partialProviderNotes(buckets),
+    [buckets],
+  );
+
+  if (rows.length === 0) return null;
 
   const openedPeriod =
     opened === null
@@ -155,7 +155,7 @@ export type ProviderPeriod = {
   toDay: string;
   /** The sum of the days that held a figure. See `partial`. */
   amountUsd: number;
-  /** Whether some day inside this period held no dollar figure at all. */
+  /** Whether some day inside this period is short. See `rowIsShort`. */
   partial: boolean;
 };
 
@@ -194,24 +194,15 @@ export const TOTAL_SPEND_KEY = "total";
 export function costTotalBuckets(
   rows: readonly GovernanceCostProviderDayRowDto[],
   interval: TimeInterval,
-): CostTotalBucket[] {
+): WithheldBucket[] {
   const byDay = new Map<string, number>();
-  // Which providers left a period short, keyed by the period's first day —
-  // the same fold `aggregateBuckets` applies to the figures, so a mark and
-  // the bar it sits on can never disagree about which period they mean.
-  const withheldByPeriod = new Map<string, Set<string>>();
   for (const row of rows) {
     // A withheld day adds nothing rather than being guessed at, exactly as it
-    // does in the stack — and the bucket SAYS it is short. A bar quietly
-    // drawn at the sum of the days that held a figure reads as a cheap
-    // period, which is the one thing a withheld figure exists to prevent.
+    // does in the stack — and the bucket SAYS it is short, below. A bar
+    // quietly drawn at the sum of the days that held a figure reads as a
+    // cheap period, which is the one thing a withheld figure exists to
+    // prevent.
     byDay.set(row.day, (byDay.get(row.day) ?? 0) + (row.amountUsd ?? 0));
-    if (row.amountUsd === null) {
-      const period = bucketStartOf(row.day, interval);
-      const held = withheldByPeriod.get(period) ?? new Set<string>();
-      held.add(row.provider);
-      withheldByPeriod.set(period, held);
-    }
   }
   const daily = [...byDay.entries()]
     .sort(([a], [b]) => a.localeCompare(b))
@@ -219,29 +210,126 @@ export function costTotalBuckets(
       day,
       points: [{ key: TOTAL_SPEND_KEY, label: "Spend", value }],
     }));
-  return aggregateBuckets(daily, interval).map((bucket) => {
-    const withheldProviders = [...(withheldByPeriod.get(bucket.day) ?? [])];
+  return markWithheldPeriods(aggregateBuckets(daily, interval), rows, interval);
+}
+
+/**
+ * The same rows folded to one period per interval, one series per provider:
+ * what `Cost over time · by provider` draws.
+ *
+ * Marked by the SAME fold as the total chart. The two panels are folded from
+ * one set of rows, so a period short in one is short in the other, and for a
+ * while only the total chart said so: this one was built straight from
+ * `aggregateBuckets`, which knows nothing of withheld days, so the same period
+ * was drawn faded on the left and plain on the right.
+ */
+export function providerSplitBuckets(
+  rows: readonly GovernanceCostProviderDayRowDto[],
+  interval: TimeInterval,
+): WithheldBucket[] {
+  return markWithheldPeriods(
+    aggregateBuckets(providerDayBuckets(rows), interval),
+    rows,
+    interval,
+  );
+}
+
+/**
+ * Whether a row's figure is not the whole of what was spent that day.
+ *
+ * THE ONE DEFINITION OF SHORT. There are two ways a day gets short: a cell
+ * held no amount at all, so `amountUsd` is null, or a cell was billed in a
+ * currency we could not convert, which leaves `amountUsd` a real but
+ * incomplete number with nothing null about it. Each fold on this screen used
+ * to spell the rule out for itself, and two of them spelled out only the
+ * first half — so a day billed in dollars and euros drew a whole bar over a
+ * note saying part of its spend had no dollar figure. Every fold asks here
+ * now, and a bar, a period and the note under them cannot disagree.
+ */
+export function rowIsShort(
+  row: Pick<
+    GovernanceCostProviderDayRowDto,
+    "amountUsd" | "currenciesWithoutUsdAmount"
+  >,
+): boolean {
+  return row.amountUsd === null || row.currenciesWithoutUsdAmount.length > 0;
+}
+
+/**
+ * One provider that left a period short, and the currencies its shortfall
+ * was billed in when it has any. Empty currencies means a cell with no amount
+ * at all.
+ */
+export type ProviderShortfall = {
+  provider: string;
+  /** Sorted. */
+  currencies: string[];
+};
+
+/**
+ * One period of a cost chart, carrying whether its bar is the whole figure.
+ *
+ * `withheld` is true when any row folded into the period is short (see
+ * `rowIsShort`). The bar is then the sum of the figures we do hold, which is
+ * SHORT by however much was left out, and the chart draws it as short rather
+ * than as a period nobody spent much in. `withheldProviders` names who left it
+ * short, sorted by provider, and is what the note under the chart is built
+ * from — so the note names exactly the providers whose bars are marked.
+ */
+export type WithheldBucket = DailyBucket & {
+  withheld: boolean;
+  withheldProviders: ProviderShortfall[];
+};
+
+/**
+ * Attach to each folded period whether the rows behind it left it short, and
+ * who did. Keyed by the period's first day — the same fold `aggregateBuckets`
+ * applies to the figures, so a mark and the bar it sits on can never disagree
+ * about which period they mean.
+ *
+ * Shared by the total chart and the provider split beside it on purpose:
+ * one fold, two charts, no way for a period to be short in one and whole in
+ * the other.
+ */
+function markWithheldPeriods(
+  buckets: DailyBucket[],
+  rows: readonly GovernanceCostProviderDayRowDto[],
+  interval: TimeInterval,
+): WithheldBucket[] {
+  const shortfallsByPeriod = new Map<string, Map<string, Set<string>>>();
+  for (const row of rows) {
+    if (!rowIsShort(row)) continue;
+    const period = bucketStartOf(row.day, interval);
+    const byProvider =
+      shortfallsByPeriod.get(period) ?? new Map<string, Set<string>>();
+    const currencies = byProvider.get(row.provider) ?? new Set<string>();
+    for (const currency of row.currenciesWithoutUsdAmount)
+      currencies.add(currency);
+    byProvider.set(row.provider, currencies);
+    shortfallsByPeriod.set(period, byProvider);
+  }
+  return buckets.map((bucket) => {
+    const withheldProviders = shortfallsOf(shortfallsByPeriod.get(bucket.day));
     return {
       ...bucket,
       withheld: withheldProviders.length > 0,
-      withheldProviders: withheldProviders.sort(),
+      withheldProviders,
     };
   });
 }
 
-/**
- * One period of the total chart, carrying whether its bar is the whole figure.
- *
- * `withheld` is true when any row folded into the period holds no dollar
- * figure at all. The bar is then the sum of the days that did, which is SHORT
- * by however much was left out, and the chart draws it as short rather than as
- * a period nobody spent much in. `withheldProviders` names who left it short,
- * sorted, so the note under the chart can say which bill to go and look at.
- */
-export type CostTotalBucket = DailyBucket & {
-  withheld: boolean;
-  withheldProviders: string[];
-};
+/** A provider→currencies map as a sorted list, or nothing for no map. */
+function shortfallsOf(
+  byProvider: ReadonlyMap<string, ReadonlySet<string>> | undefined,
+): ProviderShortfall[] {
+  if (!byProvider) return [];
+  return [...byProvider.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([provider, currencies]) => ({
+      provider,
+      currencies: [...currencies].sort(),
+    }));
+}
 
 /** The rows as one stackable bucket per day, one series per provider. */
 export function providerDayBuckets(
@@ -255,7 +343,7 @@ export function providerDayBuckets(
       byDay.set(row.day, bucket);
     }
     // A withheld day contributes nothing to the height rather than being
-    // guessed at. The line under the chart is what says the height is short.
+    // guessed at. `markWithheldPeriods` is what says the height is short.
     bucket.points.push({
       key: row.provider,
       label: providerName(row.provider),
@@ -282,14 +370,14 @@ export function providerPeriods(
         fromDay: row.day,
         toDay: row.day,
         amountUsd: row.amountUsd ?? 0,
-        partial: row.amountUsd === null,
+        partial: rowIsShort(row),
       });
       continue;
     }
     if (row.day < held.fromDay) held.fromDay = row.day;
     if (row.day > held.toDay) held.toDay = row.day;
     held.amountUsd += row.amountUsd ?? 0;
-    held.partial = held.partial || row.amountUsd === null;
+    held.partial = held.partial || rowIsShort(row);
   }
   return [...byKey.values()].sort(
     (a, b) =>
@@ -301,34 +389,34 @@ export function providerPeriods(
  * One phrase per provider whose bars are short, naming the currency when the
  * shortfall has one.
  *
- * Exported for the same reason the bucket builders above are: it is the whole
- * of a claim the screen makes in prose, and a claim about money is worth
- * testing without a chart in the way.
+ * Built from the buckets the chart draws rather than from the rows a second
+ * time, so the note under a chart names exactly the providers whose bars it
+ * marked: one fold, read twice. Exported for the same reason the bucket
+ * builders above are — it is the whole of a claim the screen makes in prose,
+ * and a claim about money is worth testing without a chart in the way.
  *
  * A provider short both ways — some cells with no amount at all, some billed
- * in a currency we could not convert — is listed ONCE, with its currencies. Two
- * entries for one provider would read as two providers, and the reader is being
- * told which names to go and look at.
+ * in a currency we could not convert — is listed ONCE, with its currencies,
+ * however many periods it was short in. Two entries for one provider would
+ * read as two providers, and the reader is being told which names to go and
+ * look at.
  */
 export function partialProviderNotes(
-  rows: readonly GovernanceCostProviderDayRowDto[],
+  buckets: readonly WithheldBucket[],
 ): string[] {
   const currenciesByProvider = new Map<string, Set<string>>();
-  for (const row of rows) {
-    const short =
-      row.amountUsd === null || row.currenciesWithoutUsdAmount.length > 0;
-    if (!short) continue;
-    const held = currenciesByProvider.get(row.provider) ?? new Set<string>();
-    for (const currency of row.currenciesWithoutUsdAmount) held.add(currency);
-    currenciesByProvider.set(row.provider, held);
+  for (const bucket of buckets) {
+    for (const { provider, currencies } of bucket.withheldProviders) {
+      const held = currenciesByProvider.get(provider) ?? new Set<string>();
+      for (const currency of currencies) held.add(currency);
+      currenciesByProvider.set(provider, held);
+    }
   }
-  return [...currenciesByProvider.entries()]
-    .sort(([a], [b]) => a.localeCompare(b))
-    .map(([provider, currencies]) => {
-      const name = providerName(provider);
-      if (currencies.size === 0) return name;
-      return `${name} (${[...currencies].sort().join(", ")})`;
-    });
+  return shortfallsOf(currenciesByProvider).map(({ provider, currencies }) => {
+    const name = providerName(provider);
+    if (currencies.length === 0) return name;
+    return `${name} (${currencies.join(", ")})`;
+  });
 }
 
 /**

--- a/platform/app/src/components/governance/costs/__tests__/costSampleMode.unit.test.ts
+++ b/platform/app/src/components/governance/costs/__tests__/costSampleMode.unit.test.ts
@@ -80,6 +80,28 @@ describe("reading the headline summary as a real-data read", () => {
     });
   });
 
+  describe("given a bill billed only in a currency nobody converted", () => {
+    it("counts the euro total as real data even with no dollar figure and no unpriced cells", () => {
+      // Every cell holds an amount, in euros, and none was ever converted:
+      // the dollar figure is null and NOTHING is unpriced. The lane reported
+      // — the money has a total of its own — so the screen must not fall
+      // back to invented figures over the top of a real bill.
+      const read = summaryAsRead(
+        summary({
+          billed: {
+            amountUsd: null,
+            cellsWithoutAmount: 0,
+            currenciesWithoutUsdAmount: [],
+            currencyTotals: [
+              { currencyCode: "EUR", amount: 40, cellsWithoutAmount: 0 },
+            ],
+          },
+        }),
+      );
+      expect(read?.length).toBeGreaterThan(0);
+    });
+  });
+
   describe("given seat pools and no money", () => {
     it("counts as real data", () => {
       const read = summaryAsRead(

--- a/platform/app/src/components/governance/costs/__tests__/providerPeriods.unit.test.ts
+++ b/platform/app/src/components/governance/costs/__tests__/providerPeriods.unit.test.ts
@@ -163,6 +163,49 @@ describe("the provider breakdown fold", () => {
     );
   });
 
+  it("marks the period holding a withheld day as withheld, naming the provider", () => {
+    const withWithheld = [
+      {
+        day: "2026-01-15",
+        provider: "openai_admin",
+        amountUsd: 60,
+        cellsWithoutAmount: 0,
+        currenciesWithoutUsdAmount: [],
+      },
+      {
+        day: "2026-01-16",
+        provider: "anthropic_admin",
+        amountUsd: null,
+        cellsWithoutAmount: 1,
+        currenciesWithoutUsdAmount: [],
+      },
+      {
+        day: "2026-04-02",
+        provider: "anthropic_admin",
+        amountUsd: 9,
+        cellsWithoutAmount: 0,
+        currenciesWithoutUsdAmount: [],
+      },
+    ];
+
+    const folded = costTotalBuckets(withWithheld, "quarter");
+
+    // The first quarter is SHORT: one of its days holds no dollar figure, so
+    // the bar it draws is not the whole of what was spent. The bucket says
+    // so, and says who, rather than leaving the height to speak for itself.
+    expect(folded.map((bucket) => bucket.day)).toEqual([
+      "2026-01-01",
+      "2026-04-01",
+    ]);
+    expect(folded[0]).toMatchObject({
+      withheld: true,
+      withheldProviders: ["anthropic_admin"],
+    });
+    expect(seriesIn(folded[0]!)).toEqual({ total: 60 });
+    // The second quarter holds every figure and carries no mark.
+    expect(folded[1]).toMatchObject({ withheld: false, withheldProviders: [] });
+  });
+
   it("counts a withheld day as no money rather than guessing at one", () => {
     const withWithheld = [
       {

--- a/platform/app/src/components/governance/costs/__tests__/providerPeriods.unit.test.ts
+++ b/platform/app/src/components/governance/costs/__tests__/providerPeriods.unit.test.ts
@@ -14,8 +14,12 @@ import { describe, expect, it } from "vitest";
 
 import {
   costTotalBuckets,
+  partialProviderNotes,
   providerDayBuckets,
   providerPeriods,
+  providerSplitBuckets,
+  rowIsShort,
+  type WithheldBucket,
 } from "../CostProviderDayPanel";
 import { aggregateBuckets } from "../costsWindow";
 
@@ -199,11 +203,128 @@ describe("the provider breakdown fold", () => {
     ]);
     expect(folded[0]).toMatchObject({
       withheld: true,
-      withheldProviders: ["anthropic_admin"],
+      withheldProviders: [{ provider: "anthropic_admin", currencies: [] }],
     });
     expect(seriesIn(folded[0]!)).toEqual({ total: 60 });
     // The second quarter holds every figure and carries no mark.
     expect(folded[1]).toMatchObject({ withheld: false, withheldProviders: [] });
+    // And the note under the chart is read off those same buckets, so it
+    // names exactly the provider whose bar is marked.
+    expect(partialProviderNotes(folded)).toEqual(["Anthropic"]);
+  });
+
+  /** @scenario "The provider split marks a short period the same way the total chart does" */
+  it("marks the same period short in the provider split as in the total chart", () => {
+    const withWithheld = [
+      {
+        day: "2026-01-15",
+        provider: "openai_admin",
+        amountUsd: 60,
+        cellsWithoutAmount: 0,
+        currenciesWithoutUsdAmount: [],
+      },
+      {
+        day: "2026-01-16",
+        provider: "anthropic_admin",
+        amountUsd: null,
+        cellsWithoutAmount: 1,
+        currenciesWithoutUsdAmount: [],
+      },
+      {
+        day: "2026-04-02",
+        provider: "anthropic_admin",
+        amountUsd: 9,
+        cellsWithoutAmount: 0,
+        currenciesWithoutUsdAmount: [],
+      },
+    ];
+
+    const total = costTotalBuckets(withWithheld, "quarter");
+    const split = providerSplitBuckets(withWithheld, "quarter");
+
+    // Same periods, same marks, same names: one fold read two ways. The
+    // split used to be built straight from the day buckets, which know
+    // nothing of withheld days, so the same quarter was faded on one chart
+    // and plain on the other.
+    const marksOf = (buckets: WithheldBucket[]) =>
+      buckets.map(({ day, withheld, withheldProviders }) => ({
+        day,
+        withheld,
+        withheldProviders,
+      }));
+    expect(marksOf(split)).toEqual(marksOf(total));
+    expect(split[0]).toMatchObject({ day: "2026-01-01", withheld: true });
+    // And the split still carries a figure per provider inside the period.
+    expect(seriesIn(split[0]!)).toEqual({
+      openai_admin: 60,
+      anthropic_admin: 0,
+    });
+  });
+
+  /** @scenario "A day billed partly in a currency with no dollar figure leaves its period short" */
+  it("marks a period short when a day holds a dollar figure beside a bill in a currency with none", () => {
+    const partlyInEuros = [
+      {
+        day: "2026-01-15",
+        provider: "anthropic_admin",
+        // A real figure — the dollar half of the day — with nothing null
+        // about it. The euro half is the shortfall.
+        amountUsd: 50,
+        cellsWithoutAmount: 0,
+        currenciesWithoutUsdAmount: ["EUR"],
+      },
+    ];
+
+    // The one predicate every fold asks.
+    expect(rowIsShort(partlyInEuros[0]!)).toBe(true);
+    expect(rowIsShort({ amountUsd: 50, currenciesWithoutUsdAmount: [] })).toBe(
+      false,
+    );
+    expect(
+      rowIsShort({ amountUsd: null, currenciesWithoutUsdAmount: [] }),
+    ).toBe(true);
+
+    // The total chart's bucket is short and says in what currency...
+    const total = costTotalBuckets(partlyInEuros, "quarter");
+    expect(total[0]).toMatchObject({
+      withheld: true,
+      withheldProviders: [{ provider: "anthropic_admin", currencies: ["EUR"] }],
+    });
+    // ...as is the split's...
+    expect(providerSplitBuckets(partlyInEuros, "quarter")[0]).toMatchObject({
+      withheld: true,
+    });
+    // ...the note names the provider and the currency...
+    expect(partialProviderNotes(total)).toEqual(["Anthropic (EUR)"]);
+    // ...and the period a reader would open is partial. Before the one
+    // predicate, the bucket and the period said whole while the note said
+    // short: a whole bar drawn over a note contradicting it.
+    expect(providerPeriods(partlyInEuros, "quarter")[0]?.partial).toBe(true);
+  });
+
+  it("lists a provider short in two ways once, with its currencies", () => {
+    const shortBothWays = [
+      {
+        day: "2026-01-15",
+        provider: "anthropic_admin",
+        amountUsd: null,
+        cellsWithoutAmount: 1,
+        currenciesWithoutUsdAmount: [],
+      },
+      {
+        day: "2026-04-02",
+        provider: "anthropic_admin",
+        amountUsd: 9,
+        cellsWithoutAmount: 0,
+        currenciesWithoutUsdAmount: ["GBP", "EUR"],
+      },
+    ];
+
+    // Two periods, two kinds of short, one provider: one entry. Two would
+    // read as two providers to a reader told which names to go and look at.
+    expect(
+      partialProviderNotes(costTotalBuckets(shortBothWays, "quarter")),
+    ).toEqual(["Anthropic (EUR, GBP)"]);
   });
 
   it("counts a withheld day as no money rather than guessing at one", () => {

--- a/platform/app/src/components/governance/costs/__tests__/withheldBarShape.unit.test.tsx
+++ b/platform/app/src/components/governance/costs/__tests__/withheldBarShape.unit.test.tsx
@@ -1,0 +1,119 @@
+/**
+ * @vitest-environment node
+ *
+ * The shape a cost bar is drawn in when its period is short.
+ *
+ * Called directly with the geometry recharts would hand it, rather than through
+ * a chart: the case that matters most is a bar of height zero, and that is the
+ * one case a chart under a layout-less renderer cannot be made to produce on
+ * purpose. What comes back is a React element, read without a DOM.
+ *
+ * Spec: specs/governance/governance-cost-screen.feature
+ */
+import type { ReactElement } from "react";
+import { describe, expect, it } from "vitest";
+
+import {
+  WITHHELD_BAR_LABEL,
+  WITHHELD_EMPTY_BAR_LABEL,
+  type WithheldMarks,
+  withheldBarShape,
+} from "../CostCharts";
+
+const PERIOD = "2026-01-01";
+
+/** The geometry recharts hands a bar that has nothing to draw. */
+const ZERO_HEIGHT = {
+  x: 40,
+  y: 200,
+  width: 24,
+  height: 0,
+  fill: "#3b82f6",
+  payload: { day: PERIOD },
+};
+
+const marks = (over: Partial<WithheldMarks> = {}): WithheldMarks => ({
+  withheldDays: new Set([PERIOD]),
+  emptyDays: new Set([PERIOD]),
+  drawsEmptyMark: true,
+  ...over,
+});
+
+const propsOf = (element: ReactElement | null) =>
+  (element?.props ?? {}) as Record<string, unknown>;
+
+describe("the shape of a bar whose period is short", () => {
+  describe("when the period has no figure at all", () => {
+    /** @scenario "A period whose every day is withheld still shows a withheld mark" */
+    it("draws a dashed stand-in where the bar would be, labelled withheld", () => {
+      const drawn = withheldBarShape(ZERO_HEIGHT, marks());
+
+      // Something, where recharts alone would draw nothing for a height of
+      // zero. It says what it is to a screen reader and to a test alike.
+      expect(drawn).not.toBeNull();
+      expect(propsOf(drawn)).toMatchObject({
+        "data-withheld": "empty",
+        "aria-label": WITHHELD_EMPTY_BAR_LABEL,
+      });
+      // The cue is a dash, not a colour: it has to survive greyscale.
+      const rect = (propsOf(drawn).children as ReactElement[]).find(
+        (child) => child.type === "rect",
+      );
+      expect(rect).toBeDefined();
+      expect(propsOf(rect!)).toMatchObject({
+        x: 40,
+        width: 24,
+        fill: "none",
+        strokeDasharray: expect.stringMatching(/\d/),
+      });
+      // Up from the baseline, with a height a reader can see.
+      expect(Number(propsOf(rect!).height)).toBeGreaterThan(0);
+      expect(Number(propsOf(rect!).y)).toBeLessThan(ZERO_HEIGHT.y);
+    });
+
+    it("lets only one series of a stack draw the stand-in", () => {
+      // Every series in a stack is handed the same zero-height rectangle. One
+      // mark to the eye and one to a screen reader, not one per series.
+      expect(
+        withheldBarShape(ZERO_HEIGHT, marks({ drawsEmptyMark: false })),
+      ).toBeNull();
+    });
+  });
+
+  describe("when the period holds some figure", () => {
+    it("keeps the bar, faded and dash-edged, and says why", () => {
+      const drawn = withheldBarShape(
+        { ...ZERO_HEIGHT, height: 80, y: 120 },
+        marks({ emptyDays: new Set() }),
+      );
+
+      expect(propsOf(drawn)).toMatchObject({
+        "data-withheld": "short",
+        "aria-label": WITHHELD_BAR_LABEL,
+      });
+      // The bar inside is recharts' own rectangle, so it still answers to
+      // the click that opens a period — restyled, not replaced.
+      const bar = (propsOf(drawn).children as ReactElement[]).find(
+        (child) => typeof child.type !== "string",
+      );
+      expect(propsOf(bar!)).toMatchObject({
+        height: 80,
+        strokeDasharray: expect.stringMatching(/\d/),
+      });
+      expect(Number(propsOf(bar!).fillOpacity)).toBeLessThan(1);
+    });
+  });
+
+  describe("when the period is whole", () => {
+    it("draws the bar exactly as recharts would", () => {
+      const drawn = withheldBarShape(
+        { ...ZERO_HEIGHT, height: 80, payload: { day: "2026-04-01" } },
+        marks(),
+      );
+
+      expect(propsOf(drawn)["data-withheld"]).toBeUndefined();
+      expect(propsOf(drawn)).toMatchObject({ height: 80, fill: "#3b82f6" });
+      expect(propsOf(drawn).strokeDasharray).toBeUndefined();
+    });
+  });
+});

--- a/platform/app/src/components/governance/costs/__tests__/withheldPeriods.integration.test.tsx
+++ b/platform/app/src/components/governance/costs/__tests__/withheldPeriods.integration.test.tsx
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+
+/**
+ * @vitest-environment jsdom
+ *
+ * What the two cost-over-time charts draw for a period that is short.
+ *
+ * Both charts are rendered through the same chart component with the sized
+ * container `periodRecords.integration.test.tsx` gives it, so recharts lays
+ * the bars out and the shape each one is drawn in is real. jsdom has no
+ * layout of its own, so the assertions are on the elements and what they say,
+ * never on pixels.
+ *
+ * Spec: specs/governance/governance-cost-screen.feature
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, screen, within } from "@testing-library/react";
+import { cloneElement, type ReactElement } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("recharts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("recharts")>();
+  return {
+    ...actual,
+    // The only reason the chart draws at all. Everything below it is
+    // recharts' own.
+    ResponsiveContainer: ({
+      children,
+    }: {
+      children: ReactElement<{ width?: number; height?: number }>;
+    }) => cloneElement(children, { width: 640, height: 240 }),
+  };
+});
+
+vi.mock("~/utils/api", () => ({
+  api: {
+    governanceCost: {
+      periodRecords: {
+        useQuery: () => ({ data: undefined, isLoading: false, isError: false }),
+      },
+    },
+  },
+}));
+
+import {
+  CostStackedBars,
+  WITHHELD_BAR_LABEL,
+  WITHHELD_EMPTY_BAR_LABEL,
+} from "../CostCharts";
+import {
+  CostProviderDayPanel,
+  costTotalBuckets,
+  PartialSpendNote,
+  partialProviderNotes,
+} from "../CostProviderDayPanel";
+
+/** A single-provider window whose ONLY day holds no dollar figure. */
+const EVERY_DAY_WITHHELD = [
+  {
+    day: "2026-01-16",
+    provider: "anthropic_admin",
+    amountUsd: null,
+    cellsWithoutAmount: 1,
+    currenciesWithoutUsdAmount: [],
+  },
+];
+
+/** Two providers in one month, one of them with a withheld day. */
+const ONE_DAY_WITHHELD = [
+  {
+    day: "2026-01-15",
+    provider: "openai_admin",
+    amountUsd: 60,
+    cellsWithoutAmount: 0,
+    currenciesWithoutUsdAmount: [],
+  },
+  {
+    day: "2026-01-16",
+    provider: "anthropic_admin",
+    amountUsd: null,
+    cellsWithoutAmount: 1,
+    currenciesWithoutUsdAmount: [],
+  },
+];
+
+/** The total chart the way the Costs screen mounts it. */
+function TotalChart({ rows }: { rows: typeof ONE_DAY_WITHHELD }) {
+  const buckets = costTotalBuckets(rows, "month");
+  return (
+    <div aria-label="Cost over time">
+      <CostStackedBars buckets={buckets} interval="month" showLegend={false} />
+      <PartialSpendNote providers={partialProviderNotes(buckets)} />
+    </div>
+  );
+}
+
+const renderBoth = (rows: typeof ONE_DAY_WITHHELD) =>
+  render(
+    <ChakraProvider value={defaultSystem}>
+      <TotalChart rows={rows} />
+      <CostProviderDayPanel
+        organizationId="org-1"
+        rows={rows as never}
+        interval="month"
+      />
+    </ChakraProvider>,
+  );
+
+const totalChart = () => within(screen.getByLabelText("Cost over time"));
+const splitChart = () =>
+  within(screen.getByLabelText("Cost over time · by provider"));
+
+afterEach(() => cleanup());
+
+describe("a short period on the cost-over-time charts", () => {
+  describe("given every day of the window is withheld", () => {
+    /** @scenario "A period whose every day is withheld still shows a withheld mark" */
+    it("stands a withheld mark where the bar would be, on both charts", () => {
+      renderBoth(EVERY_DAY_WITHHELD);
+
+      // There is no bar: nothing was added up. A chart left to itself draws
+      // nothing for a height of zero, and an empty slot reads as a period
+      // nobody spent anything in — which is not what we know.
+      for (const chart of [totalChart(), splitChart()]) {
+        const mark = chart.getByLabelText(WITHHELD_EMPTY_BAR_LABEL);
+        expect(mark).toHaveAttribute("data-withheld", "empty");
+        // A dash, not a colour, is the cue.
+        const outline = mark.querySelector("rect");
+        expect(outline).not.toBeNull();
+        expect(outline).toHaveAttribute("stroke-dasharray");
+        expect(outline).toHaveAttribute("fill", "none");
+      }
+      // And nothing on either chart claims to be a short bar with a figure.
+      expect(document.querySelectorAll('[data-withheld="short"]')).toHaveLength(
+        0,
+      );
+    });
+  });
+
+  describe("given one provider has a day we hold no dollar figure for", () => {
+    /** @scenario "The provider split marks a short period the same way the total chart does" */
+    it("marks the period short on the provider split exactly as on the total chart", () => {
+      renderBoth(ONE_DAY_WITHHELD);
+
+      // The same period, the same mark, the same words under each chart.
+      for (const chart of [totalChart(), splitChart()]) {
+        const bar = chart.getByLabelText(WITHHELD_BAR_LABEL);
+        expect(bar).toHaveAttribute("data-withheld", "short");
+        // Recharts' own rectangle is still inside, faded and dash-edged,
+        // so the click that opens a period still lands on it.
+        const rectangle = bar.querySelector(".recharts-rectangle");
+        expect(rectangle).not.toBeNull();
+        expect(rectangle).toHaveAttribute("stroke-dasharray");
+        expect(
+          chart.getByLabelText(/cover only part of what was spent/i),
+        ).toHaveTextContent(/Anthropic/);
+      }
+      // There is a bar to mark, so no stand-in is drawn.
+      expect(document.querySelectorAll('[data-withheld="empty"]')).toHaveLength(
+        0,
+      );
+    });
+  });
+});

--- a/platform/app/src/components/governance/costs/costSampleMode.ts
+++ b/platform/app/src/components/governance/costs/costSampleMode.ts
@@ -19,7 +19,16 @@ export function isRefusedRead(
   return code === "FORBIDDEN" || code === "UNAUTHORIZED";
 }
 
-/** Count lanes holding money, unpriced cells or reported seats. */
+/**
+ * Count lanes holding money, unpriced cells, a total in any currency, or
+ * reported seats.
+ *
+ * A lane billed ONLY in a currency nobody converted has a null dollar figure
+ * and no unpriced cell at all — every cell holds an amount, in euros — so the
+ * first two tests both say "nothing". The currency totals are the third way a
+ * lane reports, and the one this used to miss: a real euro bill read as no
+ * bill, and the screen fell back to invented figures over the top of it.
+ */
 export function summaryAsRead(
   data: SummaryForSampleDecision | undefined,
 ): { length: number } | null {
@@ -28,7 +37,11 @@ export function summaryAsRead(
   const laneReported = (lane: {
     amountUsd: number | null;
     cellsWithoutAmount: number;
-  }) => lane.amountUsd !== null || lane.cellsWithoutAmount > 0;
+    currencyTotals: readonly unknown[];
+  }) =>
+    lane.amountUsd !== null ||
+    lane.cellsWithoutAmount > 0 ||
+    lane.currencyTotals.length > 0;
   const reported =
     (laneReported(data.billed) ? 1 : 0) +
     (laneReported(data.gateway) ? 1 : 0) +

--- a/platform/app/src/pages/governance/__tests__/agentsSyncControl.integration.test.tsx
+++ b/platform/app/src/pages/governance/__tests__/agentsSyncControl.integration.test.tsx
@@ -38,7 +38,7 @@ const harness = vi.hoisted(() => ({
   mutated: [] as { procedure: string; input: unknown }[],
   /** What the sync mutation reports back to the page's `onSuccess`. */
   requestListingResult: { requested: 0, sources: [] as unknown[] },
-  toasts: [] as { title?: string; description?: string }[],
+  toasts: [] as { title?: string; description?: string; type?: string }[],
 }));
 
 const VIEWER = ["organization:view", "governance:view"];
@@ -83,7 +83,11 @@ vi.mock("~/utils/compat/next-router", () => ({
 
 vi.mock("~/components/ui/toaster", () => ({
   toaster: {
-    create: (toast: { title?: string; description?: string }) => {
+    create: (toast: {
+      title?: string;
+      description?: string;
+      type?: string;
+    }) => {
       harness.toasts.push(toast);
     },
   },
@@ -167,7 +171,7 @@ const listed = <T extends object>(source: T) => ({
 /** A provider that would not answer, and what a person does about it. */
 const refused = <T extends object>(
   source: T,
-  cause: "access" | "unreachable",
+  cause: "access" | "unreachable" | "incomplete",
 ) => ({ ...source, lastListing: { outcome: "refused", cause } });
 
 function renderAgents() {
@@ -279,6 +283,51 @@ describe("the agents sync control", () => {
       await userEvent.click(syncButton());
 
       expect(harness.mutated).toHaveLength(1);
+    });
+  });
+
+  describe("given a connected provider that is not scheduled to be asked", () => {
+    /**
+     * The service asks only the sources the scheduler will pull, so a press
+     * can record NOTHING while a provider is plainly connected. That is not
+     * a request, and the page must not remember it as one: latching
+     * `hasAsked` here would disable the control with "already asked" over a
+     * press that asked nobody, and "Asked 0 providers" is a sentence that
+     * reads as the page counting wrong.
+     */
+    beforeEach(() => {
+      harness.queryResults["governanceAgents.syncSources"] = { data: [GENIE] };
+      harness.requestListingResult = { requested: 0, sources: [] };
+    });
+
+    /** @scenario "Sync with nothing scheduled says so and stays pressable" */
+    it("says no provider is scheduled rather than that zero were asked", async () => {
+      renderAgents();
+
+      await userEvent.click(syncButton());
+
+      expect(harness.toasts).toHaveLength(1);
+      const [toast] = harness.toasts;
+      expect(toast?.description).toBe(
+        "No connected provider is scheduled to be asked right now.",
+      );
+      expect(toast?.type).toBe("info");
+      expect(toast?.title).not.toBe("Sync requested");
+      expect(toast?.description).not.toMatch(/Asked 0/);
+    });
+
+    /** @scenario "Sync with nothing scheduled says so and stays pressable" */
+    it("stays pressable and dispatches again on a second press", async () => {
+      renderAgents();
+
+      await userEvent.click(syncButton());
+
+      expect(syncButton()).toBeEnabled();
+      expect(syncButton()).toHaveAttribute("data-state", "ready");
+
+      await userEvent.click(syncButton());
+
+      expect(harness.mutated).toHaveLength(2);
     });
   });
 
@@ -539,6 +588,80 @@ describe("the agents page's empty table, once a provider has answered", () => {
 
       expect(screen.getByTestId("agents-empty-refused")).toBeVisible();
       expect(screen.queryByTestId("agents-empty-listed")).toBeNull();
+    });
+  });
+
+  describe("given a provider that refused, for each cause the server can name", () => {
+    /**
+     * One row per value of `AgentsListingRefusalCause`, because each cause
+     * asks something different of the reader and a page that maps two of
+     * them to one sentence sends somebody to do the wrong thing. The third
+     * row is the one that was missing: `incomplete` used to fall into the
+     * unreachable arm and tell the reader to ask again, which that cause's
+     * own contract says is the one thing not worth doing.
+     */
+    /** @scenario "Every reason a provider refuses is named on the agents page" */
+    it.each([
+      {
+        cause: "access" as const,
+        advice: "Check that connection's credentials and permissions",
+        never: "Ask again in a moment",
+      },
+      {
+        cause: "unreachable" as const,
+        advice: "Ask again in a moment",
+        never: "credentials and permissions",
+      },
+      {
+        cause: "incomplete" as const,
+        advice: "asking again will not help",
+        never: "Ask again in a moment",
+      },
+    ])("gives the $cause advice and not another cause's", ({
+      cause,
+      advice,
+      never,
+    }) => {
+      sourcesAre([refused(GENIE, cause)]);
+      renderAgents();
+
+      const empty = screen.getByTestId("agents-empty-refused");
+      expect(empty).toHaveTextContent(advice);
+      expect(empty).not.toHaveTextContent(never);
+    });
+  });
+
+  describe("given two providers refusing for different causes", () => {
+    /**
+     * One pane, so one instruction, and it has to be the one worth acting on:
+     * a fix outranks a wait, and a wait outranks a limit nobody can change.
+     * Each pair below lists the LOWER-ranked cause first, which is the order
+     * a first-match reading would get wrong.
+     */
+    /** @scenario "Two refusing providers show the advice that matters most" */
+    it("puts a fix ahead of a wait", () => {
+      sourcesAre([refused(GENIE, "unreachable"), refused(COPILOT, "access")]);
+      renderAgents();
+
+      const empty = screen.getByTestId("agents-empty-refused");
+      expect(empty).toHaveTextContent("credentials and permissions");
+      expect(empty).not.toHaveTextContent("Ask again in a moment");
+      // Both refused, so both are named.
+      expect(empty).toHaveTextContent("Prod Genie");
+      expect(empty).toHaveTextContent("Copilot tenant");
+    });
+
+    /** @scenario "Two refusing providers show the advice that matters most" */
+    it("puts a wait ahead of a limit that asking again cannot move", () => {
+      sourcesAre([
+        refused(GENIE, "incomplete"),
+        refused(COPILOT, "unreachable"),
+      ]);
+      renderAgents();
+
+      const empty = screen.getByTestId("agents-empty-refused");
+      expect(empty).toHaveTextContent("Ask again in a moment");
+      expect(empty).not.toHaveTextContent("asking again will not help");
     });
   });
 

--- a/platform/app/src/pages/governance/__tests__/costBreakdowns.integration.test.tsx
+++ b/platform/app/src/pages/governance/__tests__/costBreakdowns.integration.test.tsx
@@ -146,12 +146,46 @@ vi.mock("~/utils/api", () => ({
           data: {
             unavailableReason: null,
             providers: harness.providers,
+            // In the DTO's own shape: the US dollar line IS the lane's dollar
+            // figure, and a lane that reported nothing has no line at all.
             billed: harness.lanesReport
-              ? { amountUsd: 123.45, cellsWithoutAmount: 0 }
-              : { amountUsd: null, cellsWithoutAmount: 0 },
+              ? {
+                  amountUsd: 123.45,
+                  cellsWithoutAmount: 0,
+                  currenciesWithoutUsdAmount: [],
+                  currencyTotals: [
+                    {
+                      currencyCode: "USD",
+                      amount: 123.45,
+                      cellsWithoutAmount: 0,
+                    },
+                  ],
+                }
+              : {
+                  amountUsd: null,
+                  cellsWithoutAmount: 0,
+                  currenciesWithoutUsdAmount: [],
+                  currencyTotals: [],
+                },
             gateway: harness.lanesReport
-              ? { amountUsd: 67.89, cellsWithoutAmount: 0 }
-              : { amountUsd: null, cellsWithoutAmount: 0 },
+              ? {
+                  amountUsd: 67.89,
+                  cellsWithoutAmount: 0,
+                  currenciesWithoutUsdAmount: [],
+                  currencyTotals: [
+                    {
+                      currencyCode: "USD",
+                      amount: 67.89,
+                      cellsWithoutAmount: 0,
+                    },
+                  ],
+                }
+              : {
+                  amountUsd: null,
+                  cellsWithoutAmount: 0,
+                  currenciesWithoutUsdAmount: [],
+                  currencyTotals: [],
+                },
             seats: { status: "awaiting_data" },
             series: harness.lanesReport
               ? [{ day: "2026-08-01", billedUsd: 123.45, gatewayUsd: 67.89 }]
@@ -726,6 +760,48 @@ describe("the cost breakdown panels", () => {
       // them and a bare caveat leaves a reader unable to tell which bar to
       // distrust.
       expect(region.getByText(/Anthropic/)).toBeInTheDocument();
+    });
+  });
+
+  describe("given the window holds a day we have no dollar figure for", () => {
+    /** @scenario "A day with a withheld amount shows as withheld in cost over time, not as a smaller bar" */
+    it("marks the cost-over-time chart as short and names the provider that withheld", () => {
+      harness.providers = [
+        { provider: "openai_admin", amountUsd: 90, cellsWithoutAmount: 0 },
+        { provider: "anthropic_admin", amountUsd: null, cellsWithoutAmount: 1 },
+      ];
+      harness.dailyByProvider = {
+        rows: [
+          {
+            day: "2026-01-15",
+            provider: "openai_admin",
+            amountUsd: 90,
+            cellsWithoutAmount: 0,
+            currenciesWithoutUsdAmount: [],
+          },
+          {
+            day: "2026-01-16",
+            provider: "anthropic_admin",
+            amountUsd: null,
+            cellsWithoutAmount: 1,
+            currenciesWithoutUsdAmount: [],
+          },
+        ],
+      };
+      renderScreen();
+
+      // Scoped to THIS panel: the provider split beside it carries the same
+      // note for the same rows, and a page-wide search would pass on that one
+      // while the total chart stayed silent — which is the bug.
+      const panel = screen
+        .getByText("Cost over time")
+        .closest('[data-testid="cost-panel"]');
+      expect(panel).not.toBeNull();
+      const region = within(panel as HTMLElement);
+      const note = region.getByLabelText(/cover only part of what was spent/i);
+      // Names WHO withheld, so a reader knows which bill to go and look at.
+      expect(note).toHaveTextContent(/Anthropic/);
+      expect(note).not.toHaveTextContent(/OpenAI/);
     });
   });
 

--- a/platform/app/src/pages/governance/__tests__/costDepartmentFilter.integration.test.tsx
+++ b/platform/app/src/pages/governance/__tests__/costDepartmentFilter.integration.test.tsx
@@ -83,8 +83,22 @@ vi.mock("~/utils/api", () => ({
         useQuery: () => ({
           data: {
             unavailableReason: null,
-            billed: { amountUsd: 123.45, cellsWithoutAmount: 0 },
-            gateway: { amountUsd: 67.89, cellsWithoutAmount: 0 },
+            billed: {
+              amountUsd: 123.45,
+              cellsWithoutAmount: 0,
+              currenciesWithoutUsdAmount: [],
+              currencyTotals: [
+                { currencyCode: "USD", amount: 123.45, cellsWithoutAmount: 0 },
+              ],
+            },
+            gateway: {
+              amountUsd: 67.89,
+              cellsWithoutAmount: 0,
+              currenciesWithoutUsdAmount: [],
+              currencyTotals: [
+                { currencyCode: "USD", amount: 67.89, cellsWithoutAmount: 0 },
+              ],
+            },
             seats: { status: "awaiting_data" },
             series: [
               { day: "2026-08-01", billedUsd: 123.45, gatewayUsd: 67.89 },

--- a/platform/app/src/pages/governance/__tests__/costProviderDayRead.integration.test.tsx
+++ b/platform/app/src/pages/governance/__tests__/costProviderDayRead.integration.test.tsx
@@ -105,8 +105,22 @@ vi.mock("~/utils/api", () => ({
                 currenciesWithoutUsdAmount: [],
               },
             ],
-            billed: { amountUsd: 90, cellsWithoutAmount: 0 },
-            gateway: { amountUsd: 67.89, cellsWithoutAmount: 0 },
+            billed: {
+              amountUsd: 90,
+              cellsWithoutAmount: 0,
+              currenciesWithoutUsdAmount: [],
+              currencyTotals: [
+                { currencyCode: "USD", amount: 90, cellsWithoutAmount: 0 },
+              ],
+            },
+            gateway: {
+              amountUsd: 67.89,
+              cellsWithoutAmount: 0,
+              currenciesWithoutUsdAmount: [],
+              currencyTotals: [
+                { currencyCode: "USD", amount: 67.89, cellsWithoutAmount: 0 },
+              ],
+            },
             seats: { status: "awaiting_data" },
             series: [{ day: "2026-01-15", billedUsd: 90, gatewayUsd: 67.89 }],
             windowDays: 30,

--- a/platform/app/src/pages/governance/__tests__/costSampleFill.integration.test.tsx
+++ b/platform/app/src/pages/governance/__tests__/costSampleFill.integration.test.tsx
@@ -91,8 +91,22 @@ vi.mock("~/utils/api", () => {
                     amountUsd: harness.realFigures ? 987654 : null,
                     cellsWithoutAmount: 0,
                     currenciesWithoutUsdAmount: [],
+                    currencyTotals: harness.realFigures
+                      ? [
+                          {
+                            currencyCode: "USD",
+                            amount: 987654,
+                            cellsWithoutAmount: 0,
+                          },
+                        ]
+                      : [],
                   },
-                  gateway: { amountUsd: null, cellsWithoutAmount: 0 },
+                  gateway: {
+                    amountUsd: null,
+                    cellsWithoutAmount: 0,
+                    currenciesWithoutUsdAmount: [],
+                    currencyTotals: [],
+                  },
                   seats: { status: "awaiting_data" },
                   series: [],
                   staleSources: null,

--- a/platform/app/src/pages/governance/__tests__/costSampleMode.integration.test.tsx
+++ b/platform/app/src/pages/governance/__tests__/costSampleMode.integration.test.tsx
@@ -136,8 +136,23 @@ const withReadsBackInFlight = (rerender: (ui: React.ReactElement) => void) => {
 /** A headline summary whose lanes hold the given money, or nothing. */
 const costSummary = ({ billedUsd }: { billedUsd: number | null }) => ({
   unavailableReason: null,
-  billed: { amountUsd: billedUsd, cellsWithoutAmount: 0 },
-  gateway: { amountUsd: null, cellsWithoutAmount: 0 },
+  // In the DTO's own shape: the US dollar line IS the lane's dollar figure,
+  // and a lane that reported nothing has no line at all.
+  billed: {
+    amountUsd: billedUsd,
+    cellsWithoutAmount: 0,
+    currenciesWithoutUsdAmount: [],
+    currencyTotals:
+      billedUsd === null
+        ? []
+        : [{ currencyCode: "USD", amount: billedUsd, cellsWithoutAmount: 0 }],
+  },
+  gateway: {
+    amountUsd: null,
+    cellsWithoutAmount: 0,
+    currenciesWithoutUsdAmount: [],
+    currencyTotals: [],
+  },
   seats: { status: "awaiting_data" },
   series:
     billedUsd === null

--- a/platform/app/src/pages/governance/__tests__/costScreen.integration.test.tsx
+++ b/platform/app/src/pages/governance/__tests__/costScreen.integration.test.tsx
@@ -432,11 +432,13 @@ describe("the governance cost screen", () => {
             amountUsd: null,
             cellsWithoutAmount: 0,
             currenciesWithoutUsdAmount: [],
+            currencyTotals: [],
           },
           gateway: {
             amountUsd: null,
             cellsWithoutAmount: 0,
             currenciesWithoutUsdAmount: [],
+            currencyTotals: [],
           },
           series: [],
         }),
@@ -460,6 +462,9 @@ describe("the governance cost screen", () => {
             amountUsd: -42.5,
             cellsWithoutAmount: 0,
             currenciesWithoutUsdAmount: [],
+            currencyTotals: [
+              { currencyCode: "USD", amount: -42.5, cellsWithoutAmount: 0 },
+            ],
           },
           series: [
             {
@@ -504,11 +509,17 @@ describe("the governance cost screen", () => {
             amountUsd: 365_000,
             cellsWithoutAmount: 0,
             currenciesWithoutUsdAmount: [],
+            currencyTotals: [
+              { currencyCode: "USD", amount: 365_000, cellsWithoutAmount: 0 },
+            ],
           },
           gateway: {
             amountUsd: 182_500,
             cellsWithoutAmount: 0,
             currenciesWithoutUsdAmount: [],
+            currencyTotals: [
+              { currencyCode: "USD", amount: 182_500, cellsWithoutAmount: 0 },
+            ],
           },
           series,
           windowDays: 365,
@@ -637,6 +648,52 @@ describe("the governance cost screen", () => {
     });
   });
 
+  describe("given a window billed only in a currency nobody converted", () => {
+    /** @scenario "A currency nobody converted still totals in the currency it was billed in" */
+    it("shows the euro total on its own and leaves the dollar figure withheld", () => {
+      harness.query = {
+        data: summaryFixture({
+          billed: {
+            // Every cell holds an amount, in euros, and none was converted:
+            // no dollar figure, and NOTHING unpriced. The lane still
+            // reported — the money totals in the currency it was billed in.
+            amountUsd: null,
+            cellsWithoutAmount: 0,
+            currenciesWithoutUsdAmount: [],
+            currencyTotals: [
+              { currencyCode: "EUR", amount: 40, cellsWithoutAmount: 0 },
+            ],
+          },
+          // The other lane is empty too, so this passes only if the euro
+          // total alone is enough to count the bill as reported. With a
+          // dollar figure beside it the screen would show the lanes anyway
+          // and the regression — a euro-only bill reading as no bill at all
+          // — would slip through.
+          gateway: {
+            amountUsd: null,
+            cellsWithoutAmount: 0,
+            currenciesWithoutUsdAmount: [],
+            currencyTotals: [],
+          },
+        }),
+        isLoading: false,
+        isError: false,
+      };
+      renderScreen();
+
+      // The lanes render: this is a real bill, not an account with nothing
+      // recorded against it.
+      const lane = screen.getByTestId("cost-lane-billed");
+      const spoken = lane.textContent ?? "";
+      // The euros total in euros, and the dollar figure is untouched by
+      // them: no dollar amount is shown at all, and no rate produced one.
+      expect(spoken.match(/[A-Z]{3} -?[\d,]+(?:\.\d+)?/g) ?? []).toEqual([
+        "EUR 40.00",
+      ]);
+      expect(spoken.match(/-?\$[\d,]+(?:\.\d+)?/g) ?? []).toEqual([]);
+    });
+  });
+
   describe("given the read side sent an Azure billing note", () => {
     // These render the actual wiring — DTO field to page to panel — which the
     // note's decision and sentence unit tests cannot see: deleting the
@@ -650,6 +707,7 @@ describe("the governance cost screen", () => {
             amountUsd: null,
             cellsWithoutAmount: 0,
             currenciesWithoutUsdAmount: [],
+            currencyTotals: [],
           },
         }),
         isLoading: false,

--- a/platform/app/src/pages/governance/__tests__/costTimeControls.integration.test.tsx
+++ b/platform/app/src/pages/governance/__tests__/costTimeControls.integration.test.tsx
@@ -77,8 +77,22 @@ vi.mock("~/utils/api", () => {
         spendByModel: recording(undefined),
         summary: recording({
           unavailableReason: null,
-          billed: { amountUsd: 900, cellsWithoutAmount: 0 },
-          gateway: { amountUsd: 700, cellsWithoutAmount: 0 },
+          billed: {
+            amountUsd: 900,
+            cellsWithoutAmount: 0,
+            currenciesWithoutUsdAmount: [],
+            currencyTotals: [
+              { currencyCode: "USD", amount: 900, cellsWithoutAmount: 0 },
+            ],
+          },
+          gateway: {
+            amountUsd: 700,
+            cellsWithoutAmount: 0,
+            currenciesWithoutUsdAmount: [],
+            currencyTotals: [
+              { currencyCode: "USD", amount: 700, cellsWithoutAmount: 0 },
+            ],
+          },
           seats: { status: "awaiting_data" },
           series: [
             // Two days inside the same quarter. Drawn by day they are two

--- a/platform/app/src/pages/governance/agents.tsx
+++ b/platform/app/src/pages/governance/agents.tsx
@@ -1,5 +1,8 @@
 import { Box, Heading, HStack, Spinner, VStack } from "@chakra-ui/react";
-import type { AgentsListingOutcome } from "@ee/governance/services/pullers/agentsListingOutcome";
+import type {
+  AgentsListingOutcome,
+  AgentsListingRefusalCause,
+} from "@ee/governance/services/pullers/agentsListingOutcome";
 import { Plus } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { useSearchParams } from "react-router";
@@ -325,6 +328,21 @@ function useAgentSync({
   );
   const mutation = api.governanceAgents.requestListing.useMutation({
     onSuccess: (result) => {
+      // Zero is not an ask. The service only asks the sources the scheduler
+      // will pull, so a provider can be connected and still leave this at
+      // zero — and then nothing was recorded, nothing will answer, and there
+      // is nothing for a reload to show. Latching `hasAsked` here would put
+      // the control into "already asked, reload to see" over a press that
+      // asked nobody, and "Asked 0 providers" reads as the page miscounting.
+      if (result.requested === 0) {
+        toaster.create({
+          title: "Nothing to ask",
+          description:
+            "No connected provider is scheduled to be asked right now.",
+          type: "info",
+        });
+        return;
+      }
       setAsked(true);
       toaster.create({
         title: "Sync requested",
@@ -487,14 +505,44 @@ function AgentsPane({
  * function sees the whole set, which is why the gate is here and not in the
  * copy.
  *
- * MIXED CAUSES RESOLVE TO `access`. Two providers refusing for different
- * reasons produce one pane, and it has to carry the instruction that is worth
- * acting on: a permission that will keep refusing forever outranks a provider
- * that was briefly unreachable, and "ask again in a moment" would bury it.
+ * MIXED CAUSES RESOLVE TO THE ONE MOST WORTH ACTING ON. Two providers
+ * refusing for different reasons produce one pane, and it has to carry the
+ * instruction the reader would regret not seeing: a permission that will keep
+ * refusing forever outranks a provider that was briefly unreachable, and a
+ * wait outranks a listing our own page limit cut short, which no press can
+ * change. The order lives in {@link REFUSAL_CAUSE_RANK}, keyed over the whole
+ * cause union so a fourth cause cannot silently fall into somebody else's
+ * advice — which is exactly how `incomplete` used to be told "ask again".
  *
  * The copy itself lives in `emptyStates.ts`; what belongs here is the reading
  * of the page's own state, and the press that goes with each one.
  */
+/**
+ * Which refusal cause wins the pane when several providers refused.
+ *
+ * Higher is more worth acting on. A `Record` over the whole union rather
+ * than a `some(access)` check, so that adding a cause to
+ * `AgentsListingRefusalCause` is a compile error here rather than a silent
+ * fall-through into whichever arm the ternary defaulted to.
+ */
+const REFUSAL_CAUSE_RANK: Record<AgentsListingRefusalCause, number> = {
+  // Somebody has to fix something; asking again changes nothing until then.
+  access: 3,
+  // Asking again later is the whole remedy.
+  unreachable: 2,
+  // Nothing is wrong and asking again walks the same pages to the same bound.
+  incomplete: 1,
+};
+
+/** `causes` is never empty here: the caller only asks once a refusal exists. */
+function mostActionableCause(
+  causes: readonly AgentsListingRefusalCause[],
+): AgentsListingRefusalCause {
+  return causes.reduce((best, cause) =>
+    REFUSAL_CAUSE_RANK[cause] > REFUSAL_CAUSE_RANK[best] ? cause : best,
+  );
+}
+
 function chooseNoAgentsState({
   connected,
   canAsk,
@@ -530,13 +578,13 @@ function chooseNoAgentsState({
         // blame it for a fault it does not have, and send its owner to audit a
         // credential that is working.
         providerNames: refused.map((source) => source.name),
-        cause: refused.some(
-          (source) =>
-            source.lastListing?.outcome === "refused" &&
-            source.lastListing.cause === "access",
-        )
-          ? "access"
-          : "unreachable",
+        cause: mostActionableCause(
+          refused.flatMap((source) =>
+            source.lastListing?.outcome === "refused"
+              ? [source.lastListing.cause]
+              : [],
+          ),
+        ),
         canAsk,
       }),
       onAct: onSync,

--- a/platform/app/src/pages/governance/costs.tsx
+++ b/platform/app/src/pages/governance/costs.tsx
@@ -52,6 +52,8 @@ import { CostProviderBreakdown } from "~/components/governance/costs/CostProvide
 import {
   CostProviderDayPanel,
   costTotalBuckets,
+  PartialSpendNote,
+  partialProviderNotes,
 } from "~/components/governance/costs/CostProviderDayPanel";
 import {
   CostSpenderError,
@@ -1307,31 +1309,42 @@ function CostTotalPanel({
   sample: SampleSeries;
   showSample: boolean;
 }) {
+  const measured = useMemo(
+    () =>
+      providerDays === null ? null : costTotalBuckets(providerDays, interval),
+    [providerDays, interval],
+  );
+  // A period short in the provider split beside this is short here too —
+  // same rows, same fold — and both panels say so in the same words. A bar
+  // drawn at the sum of the days that held a figure reads as a cheap period
+  // unless something says the figure is not whole; the bar is drawn short
+  // (see `CostStackedBars`) and this line says who left it short.
+  const partialProviders = useMemo(
+    () => (providerDays === null ? [] : partialProviderNotes(providerDays)),
+    [providerDays],
+  );
   return (
     <CostPanel title="Cost over time" sample={showSample}>
       {!showSample && hasFailure ? (
         <CostPanelUnrefreshed />
       ) : (
-        <CostStackedBars
-          buckets={
-            showSample
-              ? sample.overTime
-              : providerDays === null
-                ? null
-                : costTotalBuckets(providerDays, interval)
-          }
-          interval={interval}
-          // The measured chart is ONE series and the axis already says it
-          // is money, so a legend there spends a line repeating the panel's
-          // own title. The invented one still carries several, and those do
-          // need naming.
-          showLegend={showSample}
-          empty={costPanelEmpty({
-            what: "What was spent, period by period.",
-            source: "Fills from the bills a connected source reports.",
-            action: ADD_A_SOURCE,
-          })}
-        />
+        <VStack align="stretch" gap={2}>
+          <CostStackedBars
+            buckets={showSample ? sample.overTime : measured}
+            interval={interval}
+            // The measured chart is ONE series and the axis already says it
+            // is money, so a legend there spends a line repeating the panel's
+            // own title. The invented one still carries several, and those do
+            // need naming.
+            showLegend={showSample}
+            empty={costPanelEmpty({
+              what: "What was spent, period by period.",
+              source: "Fills from the bills a connected source reports.",
+              action: ADD_A_SOURCE,
+            })}
+          />
+          {!showSample && <PartialSpendNote providers={partialProviders} />}
+        </VStack>
       )}
     </CostPanel>
   );

--- a/platform/app/src/pages/governance/costs.tsx
+++ b/platform/app/src/pages/governance/costs.tsx
@@ -1318,10 +1318,12 @@ function CostTotalPanel({
   // same rows, same fold — and both panels say so in the same words. A bar
   // drawn at the sum of the days that held a figure reads as a cheap period
   // unless something says the figure is not whole; the bar is drawn short
-  // (see `CostStackedBars`) and this line says who left it short.
+  // (see `CostStackedBars`) and this line says who left it short. Read off
+  // the buckets the chart draws, so the note names exactly the providers
+  // whose bars are marked.
   const partialProviders = useMemo(
-    () => (providerDays === null ? [] : partialProviderNotes(providerDays)),
-    [providerDays],
+    () => (measured === null ? [] : partialProviderNotes(measured)),
+    [measured],
   );
   return (
     <CostPanel title="Cost over time" sample={showSample}>

--- a/platform/app/test-setup.ts
+++ b/platform/app/test-setup.ts
@@ -181,6 +181,7 @@ vi.mock("recharts", () => {
     ZAxis: MockComponent,
     ReferenceLine: MockComponent,
     ReferenceArea: MockComponent,
+    Rectangle: MockComponent,
     Brush: MockComponent,
     Scatter: MockComponent,
     ScatterChart: MockComponent,

--- a/specs/ai-governance/dashboard/agents-page.feature
+++ b/specs/ai-governance/dashboard/agents-page.feature
@@ -288,6 +288,19 @@ Feature: The AI Governance Agents page
     And a second press dispatches nothing
 
   @integration
+  Scenario: Sync with nothing scheduled says so and stays pressable
+    Given an administrator on the Agents page with a provider connected
+    And that provider is not scheduled to be asked
+    When they press the sync control
+    Then it says no connected provider is scheduled to be asked right now
+    And it does not say that zero providers were asked
+    And the control stays pressable
+    # Nothing was requested, so nothing is remembered as requested: the
+    # "already asked, reload to see" state is for a press that recorded an
+    # ask, and going quiet over one that recorded none would leave the reader
+    # waiting on an answer nobody was sent to fetch.
+
+  @integration
   Scenario: An organization with no listing provider is told so
     Given an organization with no provider that can list agents
     When an administrator opens the Agents page
@@ -380,6 +393,33 @@ Feature: The AI Governance Agents page
     Given an organization with a provider that could not be reached
     When an administrator opens the Agents page
     Then the empty state says to ask again rather than to check a permission
+
+  # The server narrows every refusal to one of three things a person does
+  # differently, and the page must speak for all three. A cause the page has
+  # no words for used to fall into the "ask again" arm, which for a listing cut
+  # short by our own page limit is the one thing not worth doing.
+  @integration
+  Scenario Outline: Every reason a provider refuses is named on the agents page
+    Given an organization with a provider that refused because of <cause>
+    When an administrator opens the Agents page
+    Then the empty state says <advice>
+    And it does not give another cause's advice
+
+    Examples:
+      | cause                          | advice                                        |
+      | a credential or permission     | to check that connection's credentials        |
+      | the provider not answering     | to ask again in a moment                      |
+      | the list being cut short by us | that asking again will not help               |
+
+  @integration
+  Scenario: Two refusing providers show the advice that matters most
+    Given two providers refused for different reasons
+    When an administrator opens the Agents page
+    Then the empty state names both providers
+    And its advice is the one for the reason that most needs acting on
+    # A fix outranks a wait, and a wait outranks a limit nobody here can
+    # change. One pane carries one instruction, so it has to be the one the
+    # reader would regret not seeing.
 
   @integration
   Scenario: A refusal never shows the HTTP status behind it

--- a/specs/ai-governance/puller-framework/databricks-genie.feature
+++ b/specs/ai-governance/puller-framework/databricks-genie.feature
@@ -7,8 +7,9 @@ Feature: Databricks AI/BI Genie puller
   Genie charges nothing per message. The warehouse compute that answers the
   question does, and that spend is billed to the customer whether or not anyone
   attributes it. So a source that names a warehouse gets each question's share
-  of that compute; a source that names none carries a cost of zero and must
-  never invent one.
+  of that compute; a source that names none carries no amount at all and must
+  never invent one — not even zero, which the ledger would read as a figure the
+  bill backs.
 
   Background:
     Given an IngestionSource of type `databricks_genie`
@@ -34,13 +35,15 @@ Feature: Databricks AI/BI Genie puller
     # account's own, and nothing anywhere reports a failure.
 
   @integration
-  Scenario: A question costs nothing when no warehouse is named
+  Scenario: A question carries no amount when no warehouse is named
     Given a Genie source configured without a warehouse
     When the puller records a message
-    Then the recorded cost is zero
+    Then the question is recorded with no amount
     And the puller does not ask the workspace about billing
     # Genie itself bills nothing per message. Naming the warehouse is what
-    # opts a source into attributing the compute behind the question.
+    # opts a source into attributing the compute behind the question. With
+    # none named there is no bill to back a figure, and no figure is what is
+    # recorded — never a zero, which reads on the ledger as a measurement.
 
   Rule: A named warehouse turns each question's share of compute into cost
 
@@ -106,7 +109,7 @@ Feature: Databricks AI/BI Genie puller
     Scenario: A question whose SQL has not reached the billing tables yet
       Given a message whose generated SQL is too recent to appear in query history
       When the puller records it
-      Then the record carries a cost of zero
+      Then the record carries no amount
       And the message is recorded for visibility regardless
 
     @integration
@@ -139,7 +142,7 @@ Feature: Databricks AI/BI Genie puller
     Scenario: A question that ran no SQL is charged nothing
       Given a message Genie answered without running a query
       When the puller records it
-      Then the recorded cost is zero
+      Then the record carries no amount
 
     @integration
     Scenario: A priced question calls its figure an estimate
@@ -192,29 +195,34 @@ Feature: Databricks AI/BI Genie puller
       Given a period the warehouse has refused to price for longer than the hold allows
       When the puller reads the cost
       Then the watermark moves on without it
-      And those questions keep the zero they already carry
+      And those questions stay unpriced, carrying no amount
       # Refusing a partial answer is only half the job. A first sweep reads
       # thirty days, and later runs re-read only the settling window, so a
-      # watermark that moved past those thirty days would make their zeros the
-      # permanent answer — the same undercount the refusal was meant to prevent,
-      # just spread evenly. The cost is a re-read of a period already recorded,
-      # and re-emitting a question replaces its ledger row rather than adding
-      # one, so the real figure lands as soon as the bill does.
+      # watermark that moved past those thirty days would leave them unpriced
+      # for good — the same undercount the refusal was meant to prevent, just
+      # spread evenly. The cost is a re-read of a period already recorded, and
+      # re-emitting a question replaces its ledger row rather than adding one,
+      # so the real figure lands as soon as the bill does.
       #
       # The window is read a week at a time so that holding it is recoverable
       # rather than a stall: a week busy enough to be refused does not stop the
       # ones priced before it from keeping their cost, and the refused week is
       # re-asked in days rather than surrendered whole.
       #
-      # Held when the answer was CUT SHORT, and when it RAN OUT OF TIME. Billing
-      # refusing the question outright is not held: a narrower question would be
-      # refused the same way, and holding would stall a workspace that never
-      # granted the billing tables, with no way out but turning the feature off.
+      # Held when the answer was CUT SHORT, when it RAN OUT OF TIME, and when
+      # billing REFUSED the question outright — a deleted warehouse, a revoked
+      # grant. The refusal skips the smaller pieces, since a narrower question
+      # is refused the same way, but it holds like the others: the questions
+      # carry no amount, and moving past them would make that permanent. This
+      # hold's expiry is what keeps a workspace that never granted the billing
+      # tables from pinning itself forever. See "A warehouse that cannot be
+      # read holds the day open instead of closing it at zero" in
+      # specs/governance/pulled-usage-cost-reporting.feature.
       #
       # Running out of time is not refusing. The two arrive as the same shape —
       # an answer that is not a success — and reading them as one was worth a
       # month of silent zeroes on a workspace whose billing tables are merely
-      # slow. The scenarios below hold the two apart.
+      # slow. They are still told apart: only a refusal is reported as one.
 
     @integration
     Scenario: A cost answer cancelled for taking too long is asked about again
@@ -234,22 +242,15 @@ Feature: Databricks AI/BI Genie puller
       # questions carry becomes the final answer to a question billing was
       # merely slow to answer.
 
-    @integration
-    Scenario: Billing refusing the question outright is still not held
-      Given a workspace that will not let this credential read its billing
-      When the puller reads the cost
-      Then the watermark moves on without it
-      And the questions are still recorded
-      # The counterpart to the scenario above, and the reason that one is phrased
-      # about time rather than about failure. A credential without the billing
-      # grant is refused identically forever; holding for it would stall the
-      # source with no way out but turning the feature off.
-      #
-      # Deliberately silent on how the refusal arrives. A missing grant comes
-      # back as a successful request carrying a failed statement, while a revoked
-      # token comes back as the request itself being rejected — two different
-      # paths that must reach the same answer, and a scenario naming either one
-      # would leave the other free to hold forever.
+    # Billing refusing the question outright used to move the watermark on,
+    # so a workspace that never granted the billing tables would not stall.
+    # It now holds like every other unanswered bill, bounded by the same
+    # expiry, because the questions it moved past carried no amount and moving
+    # past them made that permanent. The scenario lives in
+    # specs/governance/pulled-usage-cost-reporting.feature: "A warehouse that
+    # cannot be read holds the day open instead of closing it at zero". Both
+    # doors — a successful request carrying a failed statement, and the
+    # request itself rejected — are bound there.
 
     @integration
     Scenario: A period the answer cannot carry whole is re-asked in smaller pieces

--- a/specs/ai-governance/puller-framework/s3-polling.feature
+++ b/specs/ai-governance/puller-framework/s3-polling.feature
@@ -73,3 +73,28 @@ Feature: S3PollingPullerAdapter (universal S3-polling adapter)
     Given the credentialRef resolves to NEW credentials on a subsequent run
     When the adapter requests a fresh AWS S3 client
     Then it fetches the latest credentials (no in-process credential caching across runOnce calls)
+
+  Rule: The OpenAI compliance export names people by id and keeps nothing it does not need
+
+    OpenAI's compliance export carries both the person's id and their email
+    on every line. The audit trail names the person by the id the provider
+    owns; the address is left where it came from. And because that address
+    would otherwise ride along inside a verbatim copy of the line, the
+    OpenAI compliance source keeps no such copy: the audit row holds the
+    fields it was mapped to and nothing else.
+
+    Background:
+      Given an IngestionSource of type `openai_compliance`
+      And the bucket holds a compliance line whose `user` has both an `id` and an `email`
+
+    @unit
+    Scenario: An OpenAI compliance event names the person by their provider id, never by email
+      When the puller reads the line
+      Then the event's actor is the person's provider id
+      And the email appears nowhere in the emitted record
+
+    @unit
+    Scenario: An OpenAI compliance event keeps no raw copy of what the provider sent
+      When the puller reads the line and the worker maps it to an audit row
+      Then the audit row carries no verbatim copy of the provider's line
+      And the email appears nowhere in the audit row

--- a/specs/governance/governance-cost-screen.feature
+++ b/specs/governance/governance-cost-screen.feature
@@ -943,6 +943,45 @@ Feature: One cost screen, three honest lanes
     # A chart draws nothing under a test renderer with no layout, so the
     # note under it is the part of this scenario the screen test can see.
 
+  @integration
+  Scenario: A period whose every day is withheld still shows a withheld mark
+    Given a window in which a provider's only days hold no dollar figure
+    When a permitted viewer reads the cost over time
+    Then a dashed mark stands where that period's bar would be
+    And the mark says the amount is withheld, in words a screen reader reads out
+    # The rule above says a short period is drawn faded and dash-edged. For a
+    # period with SOME figure that is enough, because there is a bar to fade.
+    # A period with no figure at all has no bar: the chart draws nothing for a
+    # height of zero, so a single-provider tenant with one unanswered bill got
+    # an empty slot, indistinguishable from a period nobody spent anything
+    # in — the exact reading a withheld figure exists to prevent. The mark is
+    # a dash and a label, not a colour, so it survives greyscale and a screen
+    # reader alike.
+
+  @integration
+  Scenario: The provider split marks a short period the same way the total chart does
+    Given a window in which one provider has a day we hold no dollar figure for
+    When a permitted viewer reads the cost over time by provider
+    Then the period holding that day is drawn as short there too
+    # One fold, two charts. Both panels are built from the same rows, and for
+    # a while only the total chart carried the mark: the split was folded
+    # straight from the day buckets, which know nothing of withheld days, so
+    # the same period was faded on the left and plain on the right.
+
+  @unit
+  Scenario: A day billed partly in a currency with no dollar figure leaves its period short
+    Given a day at one provider holding a dollar figure and a bill in a currency we hold no dollar figure for
+    When the cost over time is folded
+    Then the period holding that day is marked as short
+    And the note under the chart names that provider and the currency
+    And the period a reader would open is marked as partial
+    # ONE DEFINITION OF SHORT. There are two ways a day gets short: a cell with
+    # no amount at all, and a cell billed in a currency we could not convert,
+    # which leaves a real but incomplete dollar figure. Each fold used to spell
+    # the rule out for itself and two of them spelled out only the first half,
+    # so a day billed in dollars and euros drew a whole bar over a note saying
+    # part of its spend had no dollar figure. Every fold asks one predicate now.
+
   @unit
   Scenario: The period a reader opens is the span its bar was drawn from
     Given a provider billed on several days inside one period

--- a/specs/governance/governance-cost-screen.feature
+++ b/specs/governance/governance-cost-screen.feature
@@ -953,15 +953,24 @@ Feature: One cost screen, three honest lanes
     And no figure on the screen combines the two
     And no exchange rate is applied to produce either
 
-  @unit
+  @integration
   Scenario: A currency nobody converted still totals in the currency it was billed in
     Given spend billed in a currency the provider published no dollar figure for
-    When the window totals are read
+    And nothing else was billed in the window
+    When a permitted viewer opens the cost screen
     Then that currency has a total of its own
     And the dollar total is unchanged by it
+    And the screen shows the bill rather than treating the window as unbilled
     # The amount in the provider's own currency has been stored on every row
     # since the summary was built and has never been read by any total. The
     # dollar column being empty is not the same as there being no money.
+    #
+    # The last line is the regression this scenario now guards. A lane billed
+    # only in euros has no dollar figure and no unpriced cell — every cell
+    # holds an amount, in euros — and the check that decides whether a bill
+    # was reported asked only those two questions. A real euro bill read as
+    # no bill, and the screen fell back to invented figures over the top of
+    # it.
 
   @unit
   Scenario: A currency total is withheld when part of what it covers holds no amount

--- a/specs/governance/governance-cost-screen.feature
+++ b/specs/governance/governance-cost-screen.feature
@@ -923,6 +923,26 @@ Feature: One cost screen, three honest lanes
     # up rebuilds exactly the partial sum the lane refused to show them.
     # The mark on the bars is what stops the chart from being that sum.
 
+  @integration
+  Scenario: A day with a withheld amount shows as withheld in cost over time, not as a smaller bar
+    Given a window in which one provider has a day we hold no dollar figure for
+    When a permitted viewer reads the cost over time
+    Then the period holding that day is drawn as short, not as a smaller bar
+    And a note under the chart names the provider that withheld
+    # The total chart folds the same rows as the provider split beside it,
+    # and a withheld day added nothing to either. The split said so under its
+    # bars; the total chart said nothing, so the same period read as a cheap
+    # one there and as an incomplete one a panel to the right. A figure
+    # without a bill behind it is withheld, never zero, and a bar drawn at
+    # the sum of the days that held a figure is a zero for the day that did
+    # not — quietly, at the bottom of the bar.
+    #
+    # The bar itself is checked on the fold rather than on the render: the
+    # bucket carries whether it is short and who left it so, and the chart
+    # draws a short bucket faded and dash-edged and says so in its tooltip.
+    # A chart draws nothing under a test renderer with no layout, so the
+    # note under it is the part of this scenario the screen test can see.
+
   @unit
   Scenario: The period a reader opens is the span its bar was drawn from
     Given a provider billed on several days inside one period

--- a/specs/governance/ingestion-source-health.feature
+++ b/specs/governance/ingestion-source-health.feature
@@ -131,3 +131,44 @@ Feature: A broken puller is visible, a flaky one is not
     # Silence is the worst answer available here. A source that has never
     # completed a run has no successful run to date a gap from, so a rule
     # that reads only that date drops the one source most likely to be wrong.
+
+  # --- A refused key is not an outage ---
+  # A provider answering "this key is not allowed" will answer the same way
+  # on every retry. Treating it like a timeout burns the retry ladder against
+  # a permanent answer and leaves the screen saying only that the pull
+  # failed, when the one thing the admin needs to hear is which key to fix.
+
+  @unit
+  Scenario: A key the provider refuses is reported as refused and is not retried as an outage
+    Given an Anthropic source whose admin key the provider no longer accepts
+    When a run asks the provider for the report
+    Then the run ends saying the provider refused the key
+    And it asks the admin to check the key and its permissions
+    And the run is marked as not worth retrying
+    And nothing from the provider's reply or the key itself is quoted
+    # A request limit and a server fault keep their answers: the first still
+    # carries the provider's wait, the second is still a fault worth retrying.
+
+  @unit
+  Scenario: A refused key ends the run at once and the source keeps its schedule
+    Given an Anthropic source whose admin key the provider no longer accepts
+    When the first attempt of a run is refused
+    Then the run is recorded as failed straight away, without further attempts
+    And the failure names the provider's refusal and what to check
+    And the source is not disabled and its next scheduled run still happens
+    # Retrying a refusal three times buys nothing and hides the answer for
+    # the length of the retry ladder; and the ladder's end is where the
+    # outbox retires a permanent failure, so a refusal that keeps being
+    # rethrown is retired before anything writes it down. Writing it on the
+    # first attempt is what puts it on the screen at all.
+
+  @unit
+  Scenario: The source health row says the key was refused
+    Given a source whose last run ended because the provider refused its key
+    When a viewer looks at the source
+    Then the row says the provider refused the key and asks them to check the key and its permissions
+    And it quotes nothing from the provider's reply and no part of the key
+    # Every other failure collapses to "The last pull failed." on purpose,
+    # because a provider's reply can carry a token. The refusal is the one
+    # failure whose message we wrote ourselves, so it is the one that can be
+    # shown as written.

--- a/specs/governance/ingestion-source-health.feature
+++ b/specs/governance/ingestion-source-health.feature
@@ -172,3 +172,15 @@ Feature: A broken puller is visible, a flaky one is not
     # because a provider's reply can carry a token. The refusal is the one
     # failure whose message we wrote ourselves, so it is the one that can be
     # shown as written.
+
+  @unit
+  Scenario: A refusal with no customer sentence shows the generic failure text
+    Given a source whose last run was refused by the provider
+    And the refusal came with no sentence of ours to show
+    When a viewer looks at the source
+    Then the row says only that the last pull failed
+    And it quotes nothing from the provider's reply and no part of the key
+    # The refused code is the one whose text the page shows as written, so it
+    # is only ever written beside a sentence we wrote. A refusal that arrives
+    # with just the adapter's diagnostic is filed as a plain failure instead:
+    # the diagnostic reaches the log, never the screen.

--- a/specs/governance/pulled-usage-cost-reporting.feature
+++ b/specs/governance/pulled-usage-cost-reporting.feature
@@ -393,3 +393,91 @@ Feature: Pulled provider usage becomes visible, attributed cost
     When the agent list is read
     Then every agent the tenant holds is listed
     And no agent is left showing an identifier in place of its name
+
+  # --- A Genie question is never a measured zero ---
+  # Genie bills nothing per question. The compute behind it is on the
+  # warehouse's bill, which lands later and only when the credential can read
+  # the billing tables. A question recorded at zero dollars before that bill
+  # answers is indistinguishable from one that genuinely cost nothing, and if
+  # the bill can never be read the zero stays and reads as a measurement.
+
+  @unit
+  Scenario: A Genie message whose bill has not answered carries no amount
+    Given a Genie source whose warehouse bill has not answered for a question yet
+    When the source records that question
+    Then the question is recorded with no amount rather than at zero
+    And the question is still recorded
+    And the amount lands when the bill answers on a later run
+    # Also true of a source that names no warehouse at all: there is no bill
+    # to back a figure, so no figure is recorded.
+
+  @unit
+  Scenario: A warehouse that cannot be read holds the day open instead of closing it at zero
+    Given a Genie source whose warehouse bill is refused, or whose warehouse no longer exists
+    When the source runs
+    Then the questions are still recorded, with no amount
+    And the source keeps its place so the same period is asked about again
+    And the run reports that the bill could not be read
+    And no question is recorded at zero
+    # Held the same way an answer cut short or timed out is held, and bounded
+    # by the same hold: a bill refused for longer than the hold allows lets
+    # the source move on, and the questions it leaves behind stay unpriced.
+
+  # --- The paid Genie bill line ---
+  # Databricks bills paid Genie usage on its own line, per person and per day,
+  # with no warehouse behind it. The warehouse allocation above can never see
+  # those rows. This read asks for them directly and is a separate read with
+  # its own position, switched on per source.
+
+  @unit
+  Scenario: The paid Genie bill read is off unless switched on
+    Given a Genie source that has not switched the paid bill read on
+    When the source runs
+    Then it never asks the workspace for the Genie bill
+    And no bill row is recorded
+
+  @unit
+  Scenario: A paid Genie charge lands on the person who ran it, for that day and that price line
+    Given a Genie source with the paid bill read switched on
+    And the workspace bills a person's Genie usage on a day under a price line that has a list price
+    When the source runs
+    Then a cost row is recorded for that person, that day and that price line
+    And its amount is the usage quantity at the list price in force that day
+    And the row names Genie's price line as its model and never a warehouse as its agent
+    And the amount is marked an estimate
+    # List prices, not the account's negotiated rate, which is on no table this
+    # credential can read. An estimate by construction and recorded as one.
+
+  @unit
+  Scenario: A free Genie row lands with its usage count and no amount
+    Given a Genie source with the paid bill read switched on
+    And the workspace reports a person's Genie usage under a price line with no list price
+    When the source runs
+    Then the row is recorded with its usage quantity
+    And the row carries no amount
+    # Free usage has no price, and no price is not zero. Inventing one would
+    # put a figure on the screen the bill cannot back.
+
+  @unit
+  Scenario: A paid Genie read that stops short holds its place and lands nothing
+    Given a Genie source with the paid bill read switched on
+    And a bill answer that comes back cut short, times out, or is refused
+    When the source runs
+    Then no bill row from that answer is recorded
+    And the paid bill read keeps its own place so the period is asked about again
+    And the warehouse read's place is not moved by it
+    # Two reads, two positions. The warehouse allocation and the bill line
+    # answer on different tables and fail independently, so one holding must
+    # never pin or free the other.
+
+  @unit
+  Scenario: Surface and channel are labels and do not split a person's day
+    Given a Genie source with the paid bill read switched on
+    And a person's usage on one day under one price line spans several surfaces and channels
+    When the source runs
+    Then one row is recorded for that person, day and price line
+    And the surfaces and channels travel on the row as labels only
+    And they are no part of what identifies the row
+    # A key cannot be changed once money sits under it. Surface and channel
+    # are how Databricks describes the usage, not what it bills, and keying on
+    # them would mint a fresh row for every description the provider adds.

--- a/specs/governance/pulled-usage-cost-reporting.feature
+++ b/specs/governance/pulled-usage-cost-reporting.feature
@@ -417,8 +417,11 @@ Feature: Pulled provider usage becomes visible, attributed cost
     When the source runs
     Then the questions are still recorded, with no amount
     And the source keeps its place so the same period is asked about again
-    And the run reports that the bill could not be read
+    And the run's result names that the bill could not be read
     And no question is recorded at zero
+    # "Names" in its result, as data the run hands back: nothing downstream
+    # reads that code yet, so no screen and no person sees it. The log line
+    # beside it is where a reader finds out today.
     # Held the same way an answer cut short or timed out is held, and bounded
     # by the same hold: a bill refused for longer than the hold allows lets
     # the source move on, and the questions it leaves behind stay unpriced.
@@ -455,8 +458,12 @@ Feature: Pulled provider usage becomes visible, attributed cost
     When the source runs
     Then the row is recorded with its usage quantity
     And the row carries no amount
+    And a price line published at zero counts as no list price
     # Free usage has no price, and no price is not zero. Inventing one would
-    # put a figure on the screen the bill cannot back.
+    # put a figure on the screen the bill cannot back. The day the provider
+    # lists the free line at zero, the bill's arithmetic yields a well-formed
+    # zero rather than nothing; that zero is stripped on the way in, so a row
+    # nobody was billed for never lands as a measured zero dollars.
 
   @unit
   Scenario: A paid Genie read that stops short holds its place and lands nothing
@@ -469,6 +476,32 @@ Feature: Pulled provider usage becomes visible, attributed cost
     # Two reads, two positions. The warehouse allocation and the bill line
     # answer on different tables and fail independently, so one holding must
     # never pin or free the other.
+
+  @unit
+  Scenario: A held paid Genie read keeps its floor across runs
+    Given a Genie source with the paid bill read switched on and no configured start
+    And the bill is refused on its first run and again on the next
+    When the source runs twice
+    Then the paid bill read holds at the same floor both times
+    And the second run asks about the held period again from that floor
+    And the hold is released on the first run that reads the bill whole
+    # A first read with no configured start begins thirty days back, which is
+    # a different instant every run. A hold that wrote nothing down would
+    # begin a day later each day and quietly lose the day before it while
+    # claiming to hold. The floor is written on the held run so it stays put.
+
+  @unit
+  Scenario: A paid Genie hold older than the limit moves on
+    Given a Genie source whose paid bill has been refused for longer than the hold allows
+    When the source runs
+    Then the paid bill read moves past the window it was holding
+    And no row is recorded for that window, with no amount rather than zero
+    And the run's result still names that the bill could not be read
+    And the warehouse read's hold is not the one that was aged
+    # The same limit the warehouse read holds for. A workspace that refuses
+    # the billing tables every run would otherwise re-ask the same window
+    # forever; once the hold runs out the source moves on, the rows for that
+    # span stay unrecorded, and the next hold ages from its own start.
 
   @unit
   Scenario: Surface and channel are labels and do not split a person's day


### PR DESCRIPTION
## For humans

Seven things the governance cost and identity screens got wrong are fixed here. People pulled from OpenAI's compliance feed are now named by an id, not an email, and no raw copy of the feed is kept. A bill paid only in euros no longer reads as "no bill". Databricks Genie questions no longer show a made-up zero while the bill is still being fetched, and a bill that cannot be read keeps the day open instead of closing it at zero. Genie's own paid bill line can now be recorded, switched on per source. The cost-over-time chart marks periods with a missing amount instead of drawing a shorter bar. The agents page names the real reason a provider refused, and Sync with nothing to ask says so. A refused Anthropic key is reported as refused instead of being retried as an outage.

Closes langwatch/langwatch-saas#1224 (wrongs 2 to 9; wrong 1 dropped, wrong 7 left for later).

Stacked on #8043 (`worktree-governance-entity-sync`). One commit per wrong, except Genie where wrongs 4 and 5 share one commit because both live in the same puller file and were built as one lane.

## What changed

**Wrong 2: OpenAI compliance feed named people by email and kept a raw copy.**
The feed now keys the actor by the person's id, no longer copies the id into an extra field, and stores no raw payload. The polling adapter gained a `retainRawPayload` setting (default keeps today's behaviour; the OpenAI compliance feed turns it off).

**Wrong 3: a lane billed only in a currency nobody converted read as unbilled.**
The sample-mode decision now counts a lane as billed when it carries any currency total, not only a dollar figure.

**Wrong 4: paid Genie bill line was dropped.**
A separate, opt-in read of the Databricks bill (`readPaidGenieBill`, default off, Advanced switch on the Genie source form) lands paid Genie rows keyed by the person who ran it, the day, and the price line. It keeps its own read position and its own hold rule. Free rows land with a usage count and no amount. Surface and channel are labels only, never part of the key. No existing row is re-keyed and the rollup sort key is untouched.

**Wrong 5: a Genie question landed at zero until its bill answered, and a failed bill read closed the day at zero.**
The question now carries no amount anywhere. A warehouse read that fails, is refused, or names a deleted warehouse holds the day open instead of closing it. The run reports the hold as a notice.

**Wrong 6: cost over time drew a smaller bar for a day with a withheld amount.**
Periods holding a withheld day are drawn faded with a dashed edge, the tooltip says so, and a note under the chart names the providers concerned.

**Wrong 8: agents page collapsed refusal causes, and Sync with nothing scheduled latched to "asked".**
Every refusal cause now maps to its own empty state by rank (access, unreachable, incomplete). Sync with no provider scheduled says so and does not latch.

**Wrong 9: an Anthropic key refusal was retried as an outage.**
A 401 or 403 from the Anthropic admin API ends the run at once as refused, with a customer-facing sentence, and the source keeps its schedule. The health row shows that sentence.

## Refusal overridden

The `/implement` light path raised two checks that would normally block it: this change touches money rows, and it adds a new config key. The requester overrode both and asked to proceed. The `/challenge` pass was also skipped by the requester. Recorded here per the ceremony.

## After review

A review pass after the first push, and the CI gates after that, changed these things on top of the seven fixes above:

- **Paid Genie bill read**: the first-run floor no longer slides a day per run while the read is held, and the hold expires after seven days like the warehouse read. The cursor gained one nullable field for the bill read's own hold stamp, with a default, so existing cursors keep parsing. A bill row with no price or a free line lands with its quantity and no amount, never a measured zero.
- **Cost over time**: a period whose every day is withheld is still drawn, as a dashed stand-in with an accessible label, instead of an empty slot. One definition of "short" is shared by the chart, the provider split chart and the note under it, and the note names the providers concerned with their currencies.
- **Refused key**: a provider refusal that arrives without a sentence of our own falls back to the generic failed code, so the health row never shows a raw provider message. The refused code is one exported constant beside the event schema, and the error code on the run summary is required rather than optional.
- **CI gates**: the test typecheck failed on hand-built Genie configs missing the new switch and on one rejection read off a promise; fixed in the tests. The lint gate found nine new violations from the added code; the pull failure path, the bill walk, the cursor fold and the stacked bar chart were split into smaller functions with the same behaviour, and two test helpers throw instead of asserting outside a test.

## Noticed, not fixed

- `ocsfPullEventMapping.ts` still writes an empty `raw_event` key when the payload is empty; `raw_payload` stays a required string on the normalized event type.
- The OpenAI admin puller has the same 401/403 gap the Anthropic puller had; out of lane, left alone.
- A refused key is counted under the `failed_final` metric outcome; a distinct `failed_customer` label was considered and not added.
- Cost over time: a period short only because of an unconverted currency gets the note but not the faded marker (the marker keys on a null dollar amount only).
- Genie: an unpriced question produces no ledger row, because the record seam on the base branch already refuses an amountless provider-reported item. The question stays in the audit trail and is priced when the bill answers. An explicit no-amount ledger row would be a record-seam change.
- Genie: the seven-day maximum hold still expires a refused warehouse read; after that the watermark moves and those questions stay unpriced, never zero.
- Genie paid bill: cost status is "estimate" (list price, not the account's negotiated rate); no agent id on bill rows (the bill names no space); price join is per day; switch on with no warehouse named reads nothing and reports a notice.
- Genie spec: three scenarios that asserted the old zero-cost behaviour were retitled or flipped and their tests rebound ("A question costs nothing when no warehouse is named" became "A question carries no amount when no warehouse is named"; "Billing refusing the question outright is still not held" retired in favour of the hold scenarios).
- Cost screen tests: hand-built lane fixtures across seven test files were brought up to the full DTO shape (they omitted the currency total fields).
- Genie integration tests could not run locally (no container runtime); they rely on CI.

## Verification

- lint clean, typecheck clean, feature parity check OK
- unit suite locally: every failure traced to the local machine (an unbuilt workspace package and a refusing DNS resolver), none in files this branch touches; see the checks on this PR for the real answer
- component suite locally: one failure in the Genie source form test, fixed and folded into the Genie commit

