### PR TITLE
feat(governance): give the cost rollups a retention number instead of a fixed timer

### DIFF
--- a/platform/app/src/server/clickhouse/__tests__/retentionTtl.unit.test.ts
+++ b/platform/app/src/server/clickhouse/__tests__/retentionTtl.unit.test.ts
@@ -1,7 +1,13 @@
 import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { RETENTION_MANAGED_TABLES } from "../../data-retention/retentionPolicy.schema";
+import {
+  INDEFINITE_DEFAULT_RETENTION_TABLES,
+  PRODUCTION_STORAGE_METER_TABLES,
+  RETENTION_MANAGED_TABLES,
+  RETENTION_TABLE_CATEGORY_MAP,
+  RETENTION_TTL_MANAGED_TABLES,
+} from "../../data-retention/retentionPolicy.schema";
 import {
   buildRetentionTTLExpression,
   hasRetentionTTL,
@@ -174,26 +180,132 @@ describe("gateway_spend retention exemption", () => {
   });
 });
 
-describe("governance_cost_rollup_1d retention exemption", () => {
-  // The daily cost rollup follows `gateway_spend` for the same reason: it is
-  // a cost record, and a tenant policy a customer can shrink to weeks must
-  // never be able to hard-delete one. Fixed 13-month TTL in its own migration,
-  // absent from both reconciler maps so MODIFY TTL never rewrites the clause.
-  it("is absent from tenant retention and from the TTL reconciler config", () => {
-    expect(RETENTION_MANAGED_TABLES).not.toContain("governance_cost_rollup_1d");
-    expect(
-      TABLE_TTL_CONFIG.find((c) => c.table === "governance_cost_rollup_1d"),
-    ).toBeUndefined();
+describe("governance cost tables keep data indefinitely by default", () => {
+  // These two tables used to be exempt from retention the way `gateway_spend`
+  // still is: a fixed 13-month DELETE hardcoded in their own migration and no
+  // entry in either reconciler map. That reasoning was "a customer policy must
+  // never hard-delete a cost record" — true, and the fixed timer was a blunt
+  // way to guarantee it, because it also hard-deleted the record itself after
+  // thirteen months with no way to keep it, shorten it, or ask the question
+  // per tenant.
+  //
+  // Migration 00095 replaces the timer with the `_retention_days` column,
+  // DEFAULTING TO 0. Zero is the indefinite sentinel, so the default answer is
+  // now "keep forever" and a row is deleted only if a day count is deliberately
+  // stamped on it. The original guarantee survives by a different route: these
+  // tables stay OUT of RETENTION_TABLE_CATEGORY_MAP, so no customer-facing
+  // retention policy can reach them (and they stay out of the storage meter,
+  // which the same map drives). They are in the separate
+  // INDEFINITE_DEFAULT_RETENTION_TABLES list, and the reconciler gates on the
+  // union of the two.
+  //
+  // If the "not in RETENTION_MANAGED_TABLES" assertions below fail, someone has
+  // wired money records into the customer retention cascade, where
+  // `resolveRetention` would floor them to 49 days and start deleting.
+  const GOVERNANCE_COST_TABLES = [
+    "governance_cost_rollup_1d",
+    "governance_cost_rollup_restatement_index",
+  ] as const;
+
+  it.each(GOVERNANCE_COST_TABLES)(
+    "%s is in the TTL reconciler config",
+    (table) => {
+      expect(TABLE_TTL_CONFIG.find((c) => c.table === table)).toBeDefined();
+    },
+  );
+
+  it.each(GOVERNANCE_COST_TABLES)(
+    "%s is outside the customer retention cascade and the storage meter",
+    (table) => {
+      expect(RETENTION_MANAGED_TABLES).not.toContain(table);
+      expect(RETENTION_TABLE_CATEGORY_MAP).not.toHaveProperty(table);
+      expect(PRODUCTION_STORAGE_METER_TABLES).not.toContain(table);
+    },
+  );
+
+  it.each(GOVERNANCE_COST_TABLES)(
+    "%s is in the indefinite-default list and therefore in the reconciler's gate",
+    (table) => {
+      expect(INDEFINITE_DEFAULT_RETENTION_TABLES).toContain(table);
+      expect(RETENTION_TTL_MANAGED_TABLES).toContain(table);
+    },
+  );
+
+  // The gate must be a strict superset, not a replacement: widening it must not
+  // have dropped any customer-managed table on the way through.
+  it("the reconciler gate is the customer set plus the indefinite-default set", () => {
+    for (const table of RETENTION_MANAGED_TABLES) {
+      expect(RETENTION_TTL_MANAGED_TABLES).toContain(table);
+    }
+    expect(RETENTION_TTL_MANAGED_TABLES).toHaveLength(
+      RETENTION_MANAGED_TABLES.length +
+        INDEFINITE_DEFAULT_RETENTION_TABLES.length,
+    );
   });
 
-  it("declares its fixed 13-month delete in the migration itself", () => {
-    const migration = readFileSync(
-      migrationEndingIn("_create_governance_cost_rollup_1d.sql"),
-      "utf8",
+  it.each(GOVERNANCE_COST_TABLES)(
+    "%s anchors its retention TTL on Day, with the indefinite sentinel",
+    (table) => {
+      const config = TABLE_TTL_CONFIG.find((c) => c.table === table)!;
+      const expr = buildRetentionTTLExpression(config);
+      expect(expr).toBe(
+        "IF(_retention_days > 0, toDateTime(Day) + toIntervalDay(_retention_days), toDateTime('2106-01-01')) DELETE",
+      );
+      // `hasRetentionTTL` matches on this substring, so it is what stops the
+      // reconciler re-issuing MODIFY TTL on every boot.
+      expect(hasRetentionTTL(expr!)).toBe(true);
+    },
+  );
+
+  describe("when the migration that installs the column is read", () => {
+    /**
+     * Only the statements the migration actually RUNS. Every comment line —
+     * including the house-style commented-out `down` block, which still names
+     * the old 13-month timer — starts with `--`, and so do goose's own
+     * directives, so dropping them leaves the executed SQL alone. If this
+     * filter ever emptied, the `MODIFY TTL` count below would read 0 and fail
+     * rather than pass vacuously.
+     */
+    const executedSql = (): string =>
+      readFileSync(
+        migrationEndingIn("_governance_cost_rollup_retention_days.sql"),
+        "utf8",
+      )
+        .split("\n")
+        .filter(
+          (line) => line.trim() !== "" && !line.trimStart().startsWith("--"),
+        )
+        .join("\n");
+
+    it.each(GOVERNANCE_COST_TABLES)(
+      "adds _retention_days to %s with DEFAULT 0, the keep-forever sentinel",
+      (table) => {
+        expect(executedSql()).toContain(
+          `ALTER TABLE \${CLICKHOUSE_DATABASE}.${table}\n` +
+            "  ADD COLUMN IF NOT EXISTS `_retention_days` UInt16 DEFAULT 0 CODEC(Delta(2), ZSTD(1))",
+        );
+      },
     );
-    expect(migration).toContain(
-      "TTL toDateTime(Day) + INTERVAL 13 MONTH DELETE",
+
+    it.each(GOVERNANCE_COST_TABLES)(
+      "rewrites %s's TTL to the retention expression in the same migration",
+      (table) => {
+        expect(executedSql()).toContain(
+          `ALTER TABLE \${CLICKHOUSE_DATABASE}.${table}\n` +
+            "  MODIFY TTL IF(_retention_days > 0, toDateTime(Day) + toIntervalDay(_retention_days), toDateTime('2106-01-01')) DELETE",
+        );
+      },
     );
-    expect(migration).not.toContain("_retention_days");
+
+    // The point of the change: after this migration nothing the platform runs
+    // installs a fixed timer on these tables. The phrase may survive in the
+    // commented-out `down` block; it may not survive anywhere that executes.
+    it("leaves no executed statement that reinstalls the 13-month delete", () => {
+      const sql = executedSql();
+      expect(sql.match(/MODIFY TTL/g) ?? []).toHaveLength(
+        GOVERNANCE_COST_TABLES.length,
+      );
+      expect(sql).not.toContain("INTERVAL 13 MONTH");
+    });
   });
 });

--- a/platform/app/src/server/clickhouse/__tests__/retentionTtl.unit.test.ts
+++ b/platform/app/src/server/clickhouse/__tests__/retentionTtl.unit.test.ts
@@ -207,29 +207,26 @@ describe("governance cost tables keep data indefinitely by default", () => {
     "governance_cost_rollup_restatement_index",
   ] as const;
 
-  it.each(GOVERNANCE_COST_TABLES)(
-    "%s is in the TTL reconciler config",
-    (table) => {
-      expect(TABLE_TTL_CONFIG.find((c) => c.table === table)).toBeDefined();
-    },
-  );
+  it.each(
+    GOVERNANCE_COST_TABLES,
+  )("%s is in the TTL reconciler config", (table) => {
+    expect(TABLE_TTL_CONFIG.find((c) => c.table === table)).toBeDefined();
+  });
 
-  it.each(GOVERNANCE_COST_TABLES)(
-    "%s is outside the customer retention cascade and the storage meter",
-    (table) => {
-      expect(RETENTION_MANAGED_TABLES).not.toContain(table);
-      expect(RETENTION_TABLE_CATEGORY_MAP).not.toHaveProperty(table);
-      expect(PRODUCTION_STORAGE_METER_TABLES).not.toContain(table);
-    },
-  );
+  it.each(
+    GOVERNANCE_COST_TABLES,
+  )("%s is outside the customer retention cascade and the storage meter", (table) => {
+    expect(RETENTION_MANAGED_TABLES).not.toContain(table);
+    expect(RETENTION_TABLE_CATEGORY_MAP).not.toHaveProperty(table);
+    expect(PRODUCTION_STORAGE_METER_TABLES).not.toContain(table);
+  });
 
-  it.each(GOVERNANCE_COST_TABLES)(
-    "%s is in the indefinite-default list and therefore in the reconciler's gate",
-    (table) => {
-      expect(INDEFINITE_DEFAULT_RETENTION_TABLES).toContain(table);
-      expect(RETENTION_TTL_MANAGED_TABLES).toContain(table);
-    },
-  );
+  it.each(
+    GOVERNANCE_COST_TABLES,
+  )("%s is in the indefinite-default list and therefore in the reconciler's gate", (table) => {
+    expect(INDEFINITE_DEFAULT_RETENTION_TABLES).toContain(table);
+    expect(RETENTION_TTL_MANAGED_TABLES).toContain(table);
+  });
 
   // The gate must be a strict superset, not a replacement: widening it must not
   // have dropped any customer-managed table on the way through.
@@ -243,19 +240,18 @@ describe("governance cost tables keep data indefinitely by default", () => {
     );
   });
 
-  it.each(GOVERNANCE_COST_TABLES)(
-    "%s anchors its retention TTL on Day, with the indefinite sentinel",
-    (table) => {
-      const config = TABLE_TTL_CONFIG.find((c) => c.table === table)!;
-      const expr = buildRetentionTTLExpression(config);
-      expect(expr).toBe(
-        "IF(_retention_days > 0, toDateTime(Day) + toIntervalDay(_retention_days), toDateTime('2106-01-01')) DELETE",
-      );
-      // `hasRetentionTTL` matches on this substring, so it is what stops the
-      // reconciler re-issuing MODIFY TTL on every boot.
-      expect(hasRetentionTTL(expr!)).toBe(true);
-    },
-  );
+  it.each(
+    GOVERNANCE_COST_TABLES,
+  )("%s anchors its retention TTL on Day, with the indefinite sentinel", (table) => {
+    const config = TABLE_TTL_CONFIG.find((c) => c.table === table)!;
+    const expr = buildRetentionTTLExpression(config);
+    expect(expr).toBe(
+      "IF(_retention_days > 0, toDateTime(Day) + toIntervalDay(_retention_days), toDateTime('2106-01-01')) DELETE",
+    );
+    // `hasRetentionTTL` matches on this substring, so it is what stops the
+    // reconciler re-issuing MODIFY TTL on every boot.
+    expect(hasRetentionTTL(expr!)).toBe(true);
+  });
 
   describe("when the migration that installs the column is read", () => {
     /**
@@ -277,25 +273,23 @@ describe("governance cost tables keep data indefinitely by default", () => {
         )
         .join("\n");
 
-    it.each(GOVERNANCE_COST_TABLES)(
-      "adds _retention_days to %s with DEFAULT 0, the keep-forever sentinel",
-      (table) => {
-        expect(executedSql()).toContain(
-          `ALTER TABLE \${CLICKHOUSE_DATABASE}.${table}\n` +
-            "  ADD COLUMN IF NOT EXISTS `_retention_days` UInt16 DEFAULT 0 CODEC(Delta(2), ZSTD(1))",
-        );
-      },
-    );
+    it.each(
+      GOVERNANCE_COST_TABLES,
+    )("adds _retention_days to %s with DEFAULT 0, the keep-forever sentinel", (table) => {
+      expect(executedSql()).toContain(
+        `ALTER TABLE \${CLICKHOUSE_DATABASE}.${table}\n` +
+          "  ADD COLUMN IF NOT EXISTS `_retention_days` UInt16 DEFAULT 0 CODEC(Delta(2), ZSTD(1))",
+      );
+    });
 
-    it.each(GOVERNANCE_COST_TABLES)(
-      "rewrites %s's TTL to the retention expression in the same migration",
-      (table) => {
-        expect(executedSql()).toContain(
-          `ALTER TABLE \${CLICKHOUSE_DATABASE}.${table}\n` +
-            "  MODIFY TTL IF(_retention_days > 0, toDateTime(Day) + toIntervalDay(_retention_days), toDateTime('2106-01-01')) DELETE",
-        );
-      },
-    );
+    it.each(
+      GOVERNANCE_COST_TABLES,
+    )("rewrites %s's TTL to the retention expression in the same migration", (table) => {
+      expect(executedSql()).toContain(
+        `ALTER TABLE \${CLICKHOUSE_DATABASE}.${table}\n` +
+          "  MODIFY TTL IF(_retention_days > 0, toDateTime(Day) + toIntervalDay(_retention_days), toDateTime('2106-01-01')) DELETE",
+      );
+    });
 
     // The point of the change: after this migration nothing the platform runs
     // installs a fixed timer on these tables. The phrase may survive in the

--- a/platform/app/src/server/clickhouse/__tests__/ttlReconciler.unit.test.ts
+++ b/platform/app/src/server/clickhouse/__tests__/ttlReconciler.unit.test.ts
@@ -358,6 +358,11 @@ describe("ttlReconciler", () => {
         "trace_analytics_rollup",
         "evaluation_analytics",
         "evaluation_analytics_rollup",
+        // ADR-128 governance cost tables. In this config but deliberately NOT
+        // in the customer retention cascade: their `_retention_days` defaults
+        // to 0 (keep forever) rather than to a category-resolved day count.
+        "governance_cost_rollup_1d",
+        "governance_cost_rollup_restatement_index",
       ]);
     });
 

--- a/platform/app/src/server/clickhouse/migrations/00095_governance_cost_rollup_retention_days.sql
+++ b/platform/app/src/server/clickhouse/migrations/00095_governance_cost_rollup_retention_days.sql
@@ -1,0 +1,128 @@
+-- +goose Up
+-- +goose ENVSUB ON
+
+-- ============================================================================
+-- The two governance cost tables stop expiring on a fixed timer and start
+-- carrying their own retention number, defaulting to "keep forever".
+--
+--   governance_cost_rollup_1d
+--   governance_cost_rollup_restatement_index
+--
+-- Both were created (00092, 00094) with `TTL toDateTime(Day) + INTERVAL
+-- 13 MONTH DELETE` hardcoded into the table. That timer is the whole of their
+-- retention story today: there is no way to keep a row longer, no way to expire
+-- one sooner, and no way to answer a per-tenant or per-source retention
+-- question about them without a migration. Thirteen months was also never a
+-- derived number — it was borrowed from `gateway_spend` (00067), which borrowed
+-- it from the usage-estimate ledgers.
+--
+-- This migration replaces the timer with the same `_retention_days` mechanism
+-- every other TTL-carrying table uses (00032), with ONE difference that is the
+-- entire point: the column DEFAULTS TO 0, not to 308.
+--
+-- 0 is the indefinite sentinel. `buildRetentionTTLExpression` (ttlReconciler)
+-- maps it to a year-2106 expiry, so a row stamped 0 is never deleted. Since
+-- nothing writes the column — the inserts are JSONEachRow object literals with
+-- no explicit column list, so an added column is simply omitted and takes its
+-- DEFAULT — every existing and every future row reads 0 and is kept.
+--
+-- NET BEHAVIOUR CHANGE, stated plainly: the 13-month hard delete stops. Nothing
+-- else moves. What is bought is the knob: stamp a non-zero day count on a row
+-- (or on a future write path) and that row ages out on the next merge, with no
+-- further migration and no change to the reconciler.
+--
+-- WHY NOT THE CUSTOMER RETENTION MAP. These two tables carry `_retention_days`
+-- but are deliberately NOT added to RETENTION_TABLE_CATEGORY_MAP. That map is
+-- the CUSTOMER-facing cascade: its categories are traces/scenarios/experiments
+-- (money is none of them), `resolveRetention` floors every mapped category to
+-- the 49-day platform default (the opposite of the indefinite default this
+-- migration installs), and membership is also what enrolls a table in the
+-- customer storage meter. They join the separate
+-- INDEFINITE_DEFAULT_RETENTION_TABLES list instead, and the reconciler gates on
+-- the union of the two (RETENTION_TTL_MANAGED_TABLES). See
+-- retentionPolicy.schema.ts.
+--
+-- SUPERSEDED COMMENTS IN 00092 AND 00094. Both of those migrations contain a
+-- "Retention:" paragraph stating that the table is exempt from tenant
+-- retention, that a fixed 13-month TTL is declared there, and that the table is
+-- absent from TABLE_TTL_CONFIG so the reconciler never rewrites the clause. As
+-- of this migration all three of those statements are false: the fixed TTL is
+-- replaced below, both tables are now in TABLE_TTL_CONFIG, and the reconciler
+-- does maintain their TTL clause. Those files are NOT edited — an applied
+-- migration is immutable history, and rewriting the comment would misdescribe
+-- what that migration actually did on the day it ran. What remains true from
+-- them: both tables still sit outside the customer retention map, and
+-- `RawActorId` still carries provider-supplied personal data, so a
+-- subject-deletion request must still reach these tables explicitly. It always
+-- had to — the 13-month TTL was a holding bound, never an erasure mechanism —
+-- but with the default now indefinite there is no timer behind it at all.
+--
+-- Each statement is its own StatementBegin block: ClickHouse does not support
+-- multi-statement queries.
+--
+-- The ADD COLUMNs are metadata-only — ClickHouse does not scan or rewrite
+-- existing parts, and sparse encoding compresses an all-default column to
+-- ~zero bytes.
+--
+-- The MODIFY TTLs deliberately do NOT set `materialize_ttl_after_modify = 0`.
+-- The reconciler passes 0 because it re-runs on every boot and only ever
+-- re-installs a clause the parts already satisfy. Here the old 13-month bound
+-- is recorded in each existing part's own ttl_infos, computed when the part was
+-- written; skipping materialization would leave those parts still carrying it
+-- and a part could be dropped by a rule this migration exists to remove. The
+-- recompute is a mutation over tables that hold at most one row per day per
+-- dimension cell and were created only a few migrations ago, so it is cheap;
+-- `mutations_sync = 0` keeps the deploy from waiting on it either way.
+-- ============================================================================
+
+-- governance_cost_rollup_1d: _retention_days, defaulting to indefinite.
+-- +goose StatementBegin
+ALTER TABLE ${CLICKHOUSE_DATABASE}.governance_cost_rollup_1d
+  ADD COLUMN IF NOT EXISTS `_retention_days` UInt16 DEFAULT 0 CODEC(Delta(2), ZSTD(1))
+  SETTINGS alter_sync = 1, mutations_sync = 0;
+-- +goose StatementEnd
+
+-- governance_cost_rollup_restatement_index: same column, same default, so an
+-- index row can never outlive — or be outlived by — the cell it points at.
+-- +goose StatementBegin
+ALTER TABLE ${CLICKHOUSE_DATABASE}.governance_cost_rollup_restatement_index
+  ADD COLUMN IF NOT EXISTS `_retention_days` UInt16 DEFAULT 0 CODEC(Delta(2), ZSTD(1))
+  SETTINGS alter_sync = 1, mutations_sync = 0;
+-- +goose StatementEnd
+
+-- Replace the fixed 13-month DELETE with the retention expression. This is
+-- character-for-character what `buildRetentionTTLExpression` emits for these
+-- two TABLE_TTL_CONFIG entries (anchor `toDateTime(Day)`), so the reconciler's
+-- first pass after this migration finds the clause already correct — the
+-- `_retention_days` substring is exactly what `hasRetentionTTL` looks for — and
+-- issues no ALTER of its own.
+-- +goose StatementBegin
+ALTER TABLE ${CLICKHOUSE_DATABASE}.governance_cost_rollup_1d
+  MODIFY TTL IF(_retention_days > 0, toDateTime(Day) + toIntervalDay(_retention_days), toDateTime('2106-01-01')) DELETE
+  SETTINGS alter_sync = 1, mutations_sync = 0;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+ALTER TABLE ${CLICKHOUSE_DATABASE}.governance_cost_rollup_restatement_index
+  MODIFY TTL IF(_retention_days > 0, toDateTime(Day) + toIntervalDay(_retention_days), toDateTime('2106-01-01')) DELETE
+  SETTINGS alter_sync = 1, mutations_sync = 0;
+-- +goose StatementEnd
+
+-- +goose Down
+
+-- Down migrations are intentionally commented out to prevent accidental data
+-- loss. To roll back, uncomment and run manually.
+--
+-- Rolling back is DESTRUCTIVE in a way the `up` is not. Restoring the fixed
+-- 13-month TTL re-arms a hard delete over every row older than thirteen months
+-- that this migration has been keeping — rows that, after any length of time on
+-- the indefinite default, no longer exist anywhere else once the merge runs.
+-- Restore the TTL first and the column second, and only after deciding those
+-- rows are genuinely disposable.
+
+-- +goose StatementBegin
+-- ALTER TABLE ${CLICKHOUSE_DATABASE}.governance_cost_rollup_1d MODIFY TTL toDateTime(Day) + INTERVAL 13 MONTH DELETE;
+-- ALTER TABLE ${CLICKHOUSE_DATABASE}.governance_cost_rollup_restatement_index MODIFY TTL toDateTime(Day) + INTERVAL 13 MONTH DELETE;
+-- ALTER TABLE ${CLICKHOUSE_DATABASE}.governance_cost_rollup_1d DROP COLUMN IF EXISTS `_retention_days`;
+-- ALTER TABLE ${CLICKHOUSE_DATABASE}.governance_cost_rollup_restatement_index DROP COLUMN IF EXISTS `_retention_days`;
+-- +goose StatementEnd

--- a/platform/app/src/server/clickhouse/ttlReconciler.ts
+++ b/platform/app/src/server/clickhouse/ttlReconciler.ts
@@ -1,7 +1,7 @@
 import { createClient } from "@clickhouse/client";
 
 import { createLogger } from "@langwatch/observability";
-import { RETENTION_MANAGED_TABLES } from "../data-retention/retentionPolicy.schema";
+import { RETENTION_TTL_MANAGED_TABLES } from "../data-retention/retentionPolicy.schema";
 import { parseConnectionUrl } from "./goose";
 
 const logger = createLogger("langwatch:clickhouse:ttl-reconciler");
@@ -192,6 +192,40 @@ export const TABLE_TTL_CONFIG: readonly TableTTLEntry[] = [
     retentionTTLColumn: "BucketStart",
     retentionTTLColumnExpression: "toDateTime(BucketStart)",
     envVar: "CLICKHOUSE_COLD_STORAGE_EVALUATION_ANALYTICS_ROLLUP_TTL_DAYS",
+    hardcodedDefault: 49,
+  },
+  // ADR-128: the governance cost tables. They anchor on `Day` (a Date, and the
+  // partition leaf on the rollup) and reached the reconciler by a different
+  // route from everything above: they are NOT in the customer retention
+  // cascade, they are in INDEFINITE_DEFAULT_RETENTION_TABLES, so their
+  // `_retention_days` column defaults to 0 and nothing expires unless a day
+  // count is deliberately stamped. Entries here are what installs and maintains
+  // the TTL clause that reads that column (migration 00095 installs it first);
+  // the cold-storage MOVE half follows the same 49-day default as every other
+  // table, since it only relocates parts and deletes nothing.
+  //
+  // The two `...ColumnExpression` overrides below spell out `toDateTime(Day)`,
+  // which is byte-for-byte what the default would build anyway. They are
+  // written out because `Day` is a `Date`, not a DateTime, and the wrap is the
+  // thing that makes the interval arithmetic legal — not because the default
+  // would produce anything different.
+  {
+    table: "governance_cost_rollup_1d",
+    ttlColumn: "Day",
+    ttlColumnExpression: "toDateTime(Day)",
+    retentionTTLColumn: "Day",
+    retentionTTLColumnExpression: "toDateTime(Day)",
+    envVar: "CLICKHOUSE_COLD_STORAGE_GOVERNANCE_COST_ROLLUP_TTL_DAYS",
+    hardcodedDefault: 49,
+  },
+  {
+    table: "governance_cost_rollup_restatement_index",
+    ttlColumn: "Day",
+    ttlColumnExpression: "toDateTime(Day)",
+    retentionTTLColumn: "Day",
+    retentionTTLColumnExpression: "toDateTime(Day)",
+    envVar:
+      "CLICKHOUSE_COLD_STORAGE_GOVERNANCE_COST_ROLLUP_RESTATEMENT_INDEX_TTL_DAYS",
     hardcodedDefault: 49,
   },
 ] as const;
@@ -395,9 +429,7 @@ export async function reconcileTTL(
         const retentionTTLExpr = buildRetentionTTLExpression(tableConfig);
         if (
           retentionTTLExpr &&
-          (RETENTION_MANAGED_TABLES as readonly string[]).includes(
-            tableConfig.table,
-          ) &&
+          RETENTION_TTL_MANAGED_TABLES.includes(tableConfig.table) &&
           !hasRetentionTTL(tableInfo.engine_full)
         ) {
           // No ON CLUSTER: whenever a cluster is configured the database uses
@@ -432,14 +464,15 @@ export async function reconcileTTL(
       const currentDays = parseTTLDaysFromEngineMetadata(engineFull);
 
       const retentionTTLExpr = buildRetentionTTLExpression(tableConfig);
-      const isManaged = (
-        RETENTION_MANAGED_TABLES as readonly string[]
-      ).includes(tableConfig.table);
+      const carriesRetentionTTL = RETENTION_TTL_MANAGED_TABLES.includes(
+        tableConfig.table,
+      );
       // Whether the cold TTL alone is enough to skip this run — i.e. nothing
-      // has changed in the cold-TTL space. For managed tables we must still
-      // run when retention TTL is missing from the table (first-time apply).
+      // has changed in the cold-TTL space. For a table that carries the
+      // retention clause we must still run when the clause is absent from the
+      // table (first-time apply).
       const retentionMissing =
-        isManaged && retentionTTLExpr && !hasRetentionTTL(engineFull);
+        carriesRetentionTTL && retentionTTLExpr && !hasRetentionTTL(engineFull);
 
       if (
         !shouldRewriteTTL({ currentDays, desiredDays, engineFull }) &&
@@ -460,13 +493,13 @@ export async function reconcileTTL(
         days: desiredDays,
       });
 
-      // MODIFY TTL replaces the whole expression atomically, so for managed
-      // tables we ALWAYS re-emit retentionTTLExpr — even when it's already
-      // present — otherwise a hot-days bump silently drops the retention
-      // DELETE clause from the table.
+      // MODIFY TTL replaces the whole expression atomically, so for a table
+      // that carries the retention clause we ALWAYS re-emit retentionTTLExpr —
+      // even when it's already present — otherwise a hot-days bump silently
+      // drops the retention DELETE clause from the table.
       const ttlClauses = [
         coldTTLExpr,
-        isManaged && retentionTTLExpr ? retentionTTLExpr : null,
+        carriesRetentionTTL && retentionTTLExpr ? retentionTTLExpr : null,
       ]
         .filter(Boolean)
         .join(",\n  ");
@@ -482,7 +515,7 @@ export async function reconcileTTL(
             table: tableConfig.table,
             from: currentDays,
             to: desiredDays,
-            retentionTTL: isManaged && !!retentionTTLExpr,
+            retentionTTL: carriesRetentionTTL && !!retentionTTLExpr,
           },
           "Updating TTL",
         );

--- a/platform/app/src/server/data-retention/retentionPolicy.schema.ts
+++ b/platform/app/src/server/data-retention/retentionPolicy.schema.ts
@@ -283,6 +283,59 @@ export const RETENTION_MANAGED_TABLES = Object.keys(
 ) as RetentionManagedTable[];
 
 /**
+ * Tables that carry the `_retention_days` column but are NOT part of the
+ * customer retention cascade — their column DEFAULTS TO 0
+ * (`INDEFINITE_RETENTION_DAYS`), so nothing is ever deleted unless a day count
+ * is deliberately stamped on a row.
+ *
+ * These MUST NOT be moved into `RETENTION_TABLE_CATEGORY_MAP`, and the
+ * temptation to "tidy" them in is exactly what this comment exists to stop.
+ * Three separate things would break:
+ *
+ *  1. The map's values are `RetentionCategory` — traces / scenarios /
+ *     experiments. Governance cost is none of those, so it would have to be
+ *     mislabelled as one of them to typecheck.
+ *  2. `resolveRetention` floors every mapped category to
+ *     PLATFORM_DEFAULT_RETENTION_DAYS (49) when no override exists. Mapping
+ *     these tables would therefore turn "keep forever" into "delete after
+ *     seven weeks" — the precise inverse of the intent — for money records.
+ *  3. Map membership is what enrolls a table in the customer storage meter
+ *     (`PRODUCTION_STORAGE_METER_TABLES`). These tables are platform
+ *     bookkeeping, not customer payload, and must not be billed as storage.
+ *
+ * What they DO share with the mapped tables is the TTL mechanism itself: the
+ * reconciler installs the same
+ * `IF(_retention_days > 0, ... , toDateTime('2106-01-01')) DELETE` clause, and
+ * a non-zero value in the column expires the row exactly the same way. The
+ * difference is only where the number comes from and what it defaults to.
+ *
+ * Introduced with the governance cost tables' move off a hardcoded 13-month
+ * TTL (migration 00095); see that migration's header for the full reasoning.
+ */
+export const INDEFINITE_DEFAULT_RETENTION_TABLES = [
+  "governance_cost_rollup_1d",
+  "governance_cost_rollup_restatement_index",
+] as const;
+
+export type IndefiniteDefaultRetentionTable =
+  (typeof INDEFINITE_DEFAULT_RETENTION_TABLES)[number];
+
+/**
+ * Every table the TTL reconciler installs a `_retention_days` DELETE clause on.
+ *
+ * This is the RECONCILER's gate, and it is deliberately wider than
+ * `RETENTION_MANAGED_TABLES`, which is the CUSTOMER-facing set (the category
+ * cascade, the settings UI, and the storage meter). Anything asking "does a
+ * customer's retention policy govern this table?" wants
+ * RETENTION_MANAGED_TABLES; only the reconciler, which asks "does this table's
+ * TTL reference `_retention_days` at all?", wants this one.
+ */
+export const RETENTION_TTL_MANAGED_TABLES: readonly string[] = [
+  ...RETENTION_MANAGED_TABLES,
+  ...INDEFINITE_DEFAULT_RETENTION_TABLES,
+];
+
+/**
  * Tables included in the customer-visible production storage meter. Canonical
  * metrics follow trace retention, but remain shadow-only for pricing: their
  * raw source bytes and derived rows must not affect billed storage totals.

--- a/specs/governance/governance-identity-and-erasure.feature
+++ b/specs/governance/governance-identity-and-erasure.feature
@@ -255,8 +255,11 @@ Feature: Erasing a person from the governance data, and making it stick
     # cleared the totals and stopped there. At several providers the
     # identifier a bill arrives under is the person's email address, and one
     # note is written for every pulled charge rather than only for corrected
-    # ones, so what stayed behind was every day the person spent on — for the
-    # thirteen months the note is kept.
+    # ones, so what stayed behind was every day the person spent on — for as
+    # long as the note is kept, which is now indefinitely: the fixed thirteen
+    # month timer these tables were created with has been replaced by a
+    # per-row retention that defaults to keep-forever, so overwriting the
+    # identifier is the only thing that ever removes it.
     #
     # Both halves are asserted together because either alone is satisfied by a
     # wrong fix. Removing the note clears the identifier and is the obvious


### PR DESCRIPTION
## For humans

Two internal tables that record what AI usage cost were set up to throw away
any row older than thirteen months. That deletion was hardcoded into the
tables themselves — there was no setting, no override, and no way to keep a
record longer or expire one sooner without writing a database migration. The
thirteen months was not a considered number either; it was copied from a
neighbouring table, which had copied it from somewhere else again.

This change stops the automatic deletion and replaces it with a number that
lives on each row. The number defaults to zero, which means "keep forever",
so nothing is written and nothing is deleted. The point is that the dial now
exists: set a row's number to 90 and it will be cleaned up after 90 days, no
migration required.

These tables stay out of the customer-facing retention settings on purpose —
they are our own bookkeeping about money, not customer data, and folding them
into that system would have quietly turned "keep forever" into "delete after
seven weeks".

## Why

`governance_cost_rollup_1d` and `governance_cost_rollup_restatement_index`
were created (migrations 00092, 00094) with
`TTL toDateTime(Day) + INTERVAL 13 MONTH DELETE` hardcoded into the table.
That fixed timer was their entire retention story: no way to keep a row
longer, no way to expire one sooner, no way to answer the question per tenant
without a migration.

Thirteen months was never derived. It was borrowed from `gateway_spend`,
which borrowed it from the usage-estimate ledgers.

## What changed

Migration `00095` replaces the timer with the same `_retention_days` column
mechanism every other TTL-carrying table uses, with one deliberate
difference: **the column defaults to 0**.

Zero is `INDEFINITE_RETENTION_DAYS`, the documented keep-forever sentinel,
which `buildRetentionTTLExpression` maps to a year-2106 expiry. Nothing
writes the column — the inserts are `JSONEachRow` object literals with no
explicit column list, so an added column is simply omitted and takes its
DEFAULT. Every existing and future row therefore reads 0 and is kept.

**Net behaviour change, stated plainly: the 13-month hard delete stops.
Nothing else moves.** What is bought is the knob — stamp a non-zero day
count and that row ages out on the next merge, with no migration and no
reconciler change.

## How it works

The two tables carry `_retention_days` but are deliberately **not** added to
`RETENTION_TABLE_CATEGORY_MAP`, the customer-facing cascade. Three reasons:

1. That map's values are typed to traces / scenarios / experiments, and money
   is none of them — it would have to be mislabelled as one of them to
   typecheck.
2. `resolveRetention` floors every mapped category to the 49-day platform
   default, which would turn keep-forever into delete-after-seven-weeks for
   money records — the precise inverse of the intent.
3. Map membership is also what enrolls a table in the customer storage meter.
   These are platform bookkeeping, not customer payload, and must not be
   billed as storage.

They join a new `INDEFINITE_DEFAULT_RETENTION_TABLES` list instead, and the
reconciler now gates on the union of the two,
`RETENTION_TTL_MANAGED_TABLES`. `RETENTION_MANAGED_TABLES` keeps its old
meaning — "does a customer's retention policy govern this table?" — and only
the reconciler, which asks the narrower "does this table's TTL reference
`_retention_days` at all?", reads the wider list.

The migration issues `MODIFY TTL` itself rather than waiting for the
reconciler, so the 13-month delete is gone at apply time. The expression it
writes is character-for-character what `buildRetentionTTLExpression` emits,
so the reconciler's first pass finds the clause already correct and issues no
ALTER of its own.

## Test plan

Nothing was run locally when this was first prepared. CI has since run the
suite on this branch and the relevant jobs are green:

- `retentionTtl.unit.test.ts` — 26 tests pass (unit shard 5/5)
- `ttlReconciler.unit.test.ts` — 33 tests pass (unit shard 4/5)
- `typecheck`, `build`, `test-component`, `test-integration` and
  `migration-order` — all pass
- `lint` — the first push carried a single blocking Biome formatter error in
  the retention TTL test, fixed by reformatting it in `9bd956c`. That commit
  is token-identical to its parent once whitespace and commas are stripped.
  The new-violations gate reports `no new Biome violations` against the merge
  base.

**The migration has still NOT been applied to a real ClickHouse instance.**
The unit tests assert the SQL as text. Nothing has executed it.

The change ships updated unit tests covering the new expression and the
widened reconciler gate:

- `platform/app/src/server/clickhouse/__tests__/retentionTtl.unit.test.ts`
- `platform/app/src/server/clickhouse/__tests__/ttlReconciler.unit.test.ts`

and the spec update in
`specs/governance/governance-identity-and-erasure.feature`.

## Reviewer notes

- **The migration deliberately does not set
  `materialize_ttl_after_modify = 0`**, which is a deviation from how the
  reconciler calls the same statement. The old 13-month bound is baked into
  each existing part's `ttl_infos`, computed when the part was written;
  skipping materialization would leave those parts still carrying it, and a
  part could be dropped by the very rule this change removes. Both tables are
  days old and small, so the recompute is cheap, and `mutations_sync = 0`
  keeps the deploy from waiting on it.
- **`governance_cost_rollup_restatement_index` has no `PARTITION BY` at
  all.** Harmless today, since with the default 0 nothing is ever eligible.
  But if a real day count is ever stamped on that table, expiry is a
  whole-table row-level mutation, not a partition drop.

## Left alone, deliberately

- `dev/docs/adr/128-governance-cost-and-identity-two-waves.md` still states
  the fixed 13-month TTL and the "deliberately outside the retention map"
  reasoning as decided (around lines 1251-1261, 1372, 1741, 1756, 1936).
  Editing an accepted ADR needs a revision-log entry with a named owner, so
  it is not done here.
- The "Retention:" comments in `00092` and `00094` are now false about the
  TTL. Not edited — an applied migration is immutable history. The `00095`
  header says so explicitly.
- `gateway_spend` carries the same 13-month rule for the same borrowed
  reasoning, but it is not a governance table and is out of scope here.

