### PR TITLE
fix(annotations): keep projectId visible to the tenancy guard on queue-walk reads

### DIFF
--- a/platform/app/src/server/api/routers/__tests__/annotation.queue-walk.unit.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/annotation.queue-walk.unit.test.ts
@@ -10,6 +10,7 @@
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { PrismaClient } from "~/generated/prisma/client";
+import { guardProjectId } from "~/utils/dbMultiTenancyProtection";
 import { createInnerTRPCContext } from "../../trpc";
 import { annotationRouter } from "../annotation";
 
@@ -114,6 +115,35 @@ const readsTowardsFrontOfQueue = (args: {
   orderBy?: { createdAt?: string }[];
 }) => args.orderBy?.[0]?.createdAt === "asc";
 
+/**
+ * One queue-item read, answered only if the real multitenancy guard lets it
+ * through.
+ *
+ * The stub routes every `AnnotationQueueItem` call through the middleware the
+ * live client runs rather than answering blindly, so these tests execute the
+ * real tenancy check against the real `where` the router builds. A stub that
+ * skips the guard cannot observe a walk that throws on every call in
+ * production, which is exactly what shipped: the guard reads `projectId` at
+ * the top level only for a model outside `SCOPED_MODELS`
+ * (`~/utils/dbMultiTenancyProtection.ts:894`), so a `where` wrapped in `AND`
+ * hides the tenancy predicate from it.
+ */
+const guardedQueueItemRead =
+  (action: string, answer: (args: any) => unknown) =>
+  async (args: unknown) => {
+    await guardProjectId(
+      {
+        model: "AnnotationQueueItem",
+        action,
+        args,
+        dataPath: [],
+        runInTransaction: false,
+      } as never,
+      async () => undefined,
+    );
+    return answer(args);
+  };
+
 function makePrismaStub(): PrismaClient {
   mockQueueItemCount
     .mockResolvedValueOnce(QUEUE_LENGTH)
@@ -132,9 +162,9 @@ function makePrismaStub(): PrismaClient {
 
   return {
     annotationQueueItem: {
-      findFirst: mockQueueItemFindFirst,
-      findMany: mockQueueItemFindMany,
-      count: mockQueueItemCount,
+      findFirst: guardedQueueItemRead("findFirst", mockQueueItemFindFirst),
+      findMany: guardedQueueItemRead("findMany", mockQueueItemFindMany),
+      count: guardedQueueItemRead("count", mockQueueItemCount),
     },
     annotation: { findMany: mockAnnotationFindMany },
     annotationQueue: { findMany: mockQueueFindMany },
@@ -147,6 +177,7 @@ function makePrismaStub(): PrismaClient {
 }
 
 let caller: ReturnType<typeof annotationRouter.createCaller>;
+let prisma: PrismaClient;
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -162,7 +193,8 @@ beforeEach(() => {
     permissionChecked: true,
     publiclyShared: false,
   });
-  ctx.prisma = makePrismaStub();
+  prisma = makePrismaStub();
+  ctx.prisma = prisma;
   caller = annotationRouter.createCaller(ctx);
 });
 
@@ -246,6 +278,47 @@ describe("given a queue far longer than one read could carry", () => {
 
       expect(step.queueFinished).toBe(false);
       expect(mockFindExistingTraceIds).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when the reads are checked for tenancy the way the live client checks them", () => {
+    /**
+     * The stub only has teeth if the guard it runs can actually refuse, so
+     * prove that first: a read with no tenancy predicate must be turned away.
+     * Without this the three tests below would pass on a guard that had been
+     * quietly disarmed.
+     */
+    it("refuses a queue-item read that carries no tenancy predicate", async () => {
+      await expect(
+        prisma.annotationQueueItem.findFirst({ where: { id: "qi-2" } }),
+      ).rejects.toThrow(/requires a 'projectId'/);
+    });
+
+    describe("when the reviewer opens the item a link names", () => {
+      it("resolves that item", async () => {
+        const step = await caller.getQueueWalkStep({
+          projectId: PROJECT_ID,
+          queueItemId: "qi-2",
+        });
+
+        expect(step.item?.id).toBe(WALKED_ITEM.id);
+      });
+    });
+
+    describe("when the reviewer opens the walk with no item named", () => {
+      /**
+       * Naming no item takes the walk down the one lookup that reads the
+       * `where` as built, so every remaining read is a neighbourhood seek:
+       * the count of what is ahead and the two ids either side. Anything that
+       * throws here is one of those three, not the named-item lookup.
+       */
+      it("reads back its place and the ids either side", async () => {
+        const step = await caller.getQueueWalkStep({ projectId: PROJECT_ID });
+
+        expect(step.position).toBe(AHEAD_OF_WALKED + 1);
+        expect(step.previousItemId).toBe("qi-1");
+        expect(step.nextItemId).toBe("qi-3");
+      });
     });
   });
 

--- a/platform/app/src/server/api/routers/__tests__/annotation.queue-walk.unit.test.ts
+++ b/platform/app/src/server/api/routers/__tests__/annotation.queue-walk.unit.test.ts
@@ -129,8 +129,7 @@ const readsTowardsFrontOfQueue = (args: {
  * hides the tenancy predicate from it.
  */
 const guardedQueueItemRead =
-  (action: string, answer: (args: any) => unknown) =>
-  async (args: unknown) => {
+  (action: string, answer: (args: any) => unknown) => async (args: unknown) => {
     await guardProjectId(
       {
         model: "AnnotationQueueItem",

--- a/platform/app/src/server/api/routers/annotation.ts
+++ b/platform/app/src/server/api/routers/annotation.ts
@@ -298,6 +298,28 @@ type QueueItemWhere = Prisma.AnnotationQueueItemWhereInput & {
 };
 
 /**
+ * A queue-item `where` narrowed by one more clause.
+ *
+ * `projectId` is lifted back to the top on purpose. For a model outside
+ * `SCOPED_MODELS` the multitenancy guard looks for tenancy at the top of the
+ * `where` and never recurses into `AND`
+ * (`src/utils/dbMultiTenancyProtection.ts:894`), so wrapping a `where` that
+ * carries `projectId` inside a plain `AND` hides it from the guard and every
+ * such read throws. Keeping the whole original clause inside the `AND` leaves
+ * what the query matches exactly as it was.
+ */
+const narrowQueueItemWhere = ({
+  where,
+  clause,
+}: {
+  where: QueueItemWhere;
+  clause: Prisma.AnnotationQueueItemWhereInput;
+}): Prisma.AnnotationQueueItemWhereInput => ({
+  projectId: where.projectId,
+  AND: [where, clause],
+});
+
+/**
  * Which queue items the optimized list reads. The clauses stack rather than
  * replace: the caller's reach is settled first, and the reviewer's own pick of
  * queues is applied last, so a queue id from anywhere else can subtract rows
@@ -1452,7 +1474,7 @@ const findWalkItem = async ({
 }) => {
   const named = queueItemId
     ? await ctx.prisma.annotationQueueItem.findFirst({
-        where: { AND: [where, { id: queueItemId }] },
+        where: narrowQueueItemWhere({ where, clause: { id: queueItemId } }),
         include,
       })
     : null;
@@ -1488,14 +1510,16 @@ const resolveWalkPlace = async ({
   const after = queueWalkNeighbourhood(current, "after");
 
   const [ahead, previous, next] = await Promise.all([
-    ctx.prisma.annotationQueueItem.count({ where: { AND: [where, before] } }),
+    ctx.prisma.annotationQueueItem.count({
+      where: narrowQueueItemWhere({ where, clause: before }),
+    }),
     ctx.prisma.annotationQueueItem.findFirst({
-      where: { AND: [where, before] },
+      where: narrowQueueItemWhere({ where, clause: before }),
       orderBy: queueWalkOrderReversed,
       select: { id: true },
     }),
     ctx.prisma.annotationQueueItem.findFirst({
-      where: { AND: [where, after] },
+      where: narrowQueueItemWhere({ where, clause: after }),
       orderBy: queueWalkOrder,
       select: { id: true },
     }),


### PR DESCRIPTION
## Why

`annotation.getQueueWalkStep` — the procedure #8059 added — throws on every call in production. It has never once succeeded.

The walk narrows its `where` by wrapping it, `{ AND: [where, clause] }`. That moves the `projectId` the clause already carried down one level. `AnnotationQueueItem` is not in `SCOPED_MODELS`, so it falls to the default multitenancy guard, and that guard reads tenancy at the top of the `where` only — it never recurses into `AND` (`platform/app/src/utils/dbMultiTenancyProtection.ts:894`). With `projectId` hidden inside the array the guard sees an unscoped read and refuses it:

```
The findFirst action on the AnnotationQueueItem model requires a
'projectId' or 'projectId.in' in the where clause
```

Nothing surfaces that to the reviewer. `useAnnotationQueueWalk` turns the failed step into a null item, the drawer resolves no thread id from it, and the page renders "No turns found in this conversation" (`ConversationView.tsx:239`). The reviewer sees a working page with nothing in it, which is why this reads as a rendering bug rather than a 500.

### Production evidence

Every call to the procedure since it deployed, from the app's own request logs on build `git-3451d24`:

| | |
|---|---|
| Requests to `getQueueWalkStep` | 31 |
| HTTP 500 | 27 |
| HTTP 207 (tRPC multi-status, the same call failing inside a batch) | 4 |
| Successful | **0** |
| Latency | p50 39 ms, p95 131 ms — it fails fast, it is not slow |

The guard error appears 31 times in the same window under logger `langwatch:trpc`.

## What changed

One helper, `narrowQueueItemWhere`, lifts `projectId` back to the top level and keeps the whole original clause inside the `AND`. What the query matches is unchanged; only its shape is.

It replaces the wrap at all four narrowing sites — the named-item lookup in `findWalkItem`, and the count plus two neighbour seeks in `resolveWalkPlace`. A repo-wide sweep for the same shape (`AND: [where`) returns no other occurrence.

## How this got past the tests

The existing suite's Prisma stub answered calls directly, so no guard ever ran against the `where` the router builds. Five tests passed against a procedure that could not execute.

The stub now routes every `AnnotationQueueItem` read through the real `guardProjectId` middleware — the same technique `seedTopicModel.unit.test.ts` already uses for the equivalent bug in ADR-051. The first new test asserts the guard can still refuse a read carrying no tenancy predicate, so the suite cannot pass on a guard that has been quietly disarmed.

## Test plan

- `pnpm test:unit run src/server/api/routers/__tests__/annotation.queue-walk.unit.test.ts` — 8 passed.
- **Reverting `annotation.ts` to `main` while keeping the new tests fails 7 of 8**, each with the production error above, thrown from `_guardProjectId` (`dbMultiTenancyProtection.ts:902`) via `resolveWalkPlace` (`annotation.ts:1491`). The one that still passes is the guard's own teeth-check, which is the point of it.
- `pnpm typecheck` — exit 0, no TypeScript errors.

## Deliberately not fixed here

**The default guard is still not recursive.** `_guardProjectId` checks the top level and a flat `OR`, while `SCOPED_MODELS` entries get `validateRecursive`, which does walk `AND`/`OR`. Every model outside `SCOPED_MODELS` remains one `AND` wrap away from this same failure, and `dbMultiTenancyProtection.unit.test.ts:670` documents the discrepancy without resolving it — an AND-wrapped `where` is asserted safe there because that model's config recurses. Making the default recursive widens what passes a tenancy check, which is an ADR decision, not a hotfix.

**The walk's Postgres cost.** `AnnotationQueueItem` carries no index ending in `createdAt` (`schema.prisma:2380-2387`), and the walk sorts on it. The count and the two seeks in `resolveWalkPlace` therefore scan the filtered set on every step. #8059 flagged this in its own description and it is untouched here; this PR only makes the path execute at all. It has never run in production, so there is no measurement of it yet — that arrives once this ships.

Refs #8059, #8057


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved annotation queue navigation to consistently enforce project-level data isolation.
  * Fixed queue-item lookups and neighborhood navigation so tenancy checks remain effective when additional filters are applied.
* **Tests**
  * Added coverage verifying that unscoped queue-item reads are rejected.
  * Added coverage for navigating to named queue items and their surrounding entries through guarded reads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->