### PR TITLE
fix(governance): drop the admin feed email, two real tests, six wording fixes

### DIFF
--- a/dev/docs/adr/122-openai-admin-cost-puller.md
+++ b/dev/docs/adr/122-openai-admin-cost-puller.md
@@ -114,7 +114,7 @@ restated here because it is easy to reintroduce and silent when wrong.
 > carries `user_email`". The adapter shipped the opposite and deliberately
 > so: `actor` carries the provider's **opaque `user-…` id**, and the email is
 > now dropped from the row before it is stringified into `raw_payload`
-> (`openaiAdmin.puller.ts:417,885-891` and the comments above them), so
+> (`openaiAdmin.puller.ts:416-428,885-891` and the comments above them), so
 > the address is never stored. The id is the
 > stable key, the erasure suppression list is keyed on exactly that string,
 > and a raw address is heavier on a money row. The decision below stands with
@@ -552,7 +552,7 @@ adapter duplicates cursor logic a third provider may justify factoring out.
   decision survives.
   - **Decision 6's `actor` is the raw `user_id`, not `user_email`.** The
     adapter reads the id deliberately and says why in its own comment
-    (`openaiAdmin.puller.ts:390-401,835-851`): the id is stable, the erasure
+    (`openaiAdmin.puller.ts:416-428,885-891`): the id is stable, the erasure
     suppression list is keyed on exactly that string, and the address is
     heavier on a money row. At v3 the email was not dropped — it survived into
     `raw_payload` through the row schema's `.passthrough()`. **[No longer true:
@@ -642,3 +642,13 @@ adapter duplicates cursor logic a third provider may justify factoring out.
     intact; no owner and no date are attached to changing that.
   - Stale citations refreshed: `ingestionSourceCatalog.tsx:142-149` →
     `:171-181`; `ingestionSourceCatalog.tsx:293` → `:324`.
+
+- **v6 (2026-09-10) — the stored payload no longer carries the address.** No
+  decision is taken here. `costEvent` drops `user_email` before the row is
+  stringified into `raw_payload` (`openaiAdmin.puller.ts:885-891`), so the
+  address is stored nowhere and does not reach a wired-up SIEM; the four
+  places this ADR said otherwise are corrected in place
+  (langwatch/langwatch-saas#1225, item 1).
+  - Stale citations refreshed: `openaiAdmin.puller.ts:403,864` →
+    `:416-428,885-891`; `openaiAdmin.puller.ts:390-401,835-851` →
+    `:416-428,885-891`.

--- a/dev/docs/adr/122-openai-admin-cost-puller.md
+++ b/dev/docs/adr/122-openai-admin-cost-puller.md
@@ -112,9 +112,10 @@ restated here because it is easy to reintroduce and silent when wrong.
 
 > **[CORRECTED — see revision v3.]** This decision was written as "`actor`
 > carries `user_email`". The adapter shipped the opposite and deliberately
-> so: `actor` carries the provider's **opaque `user-…` id**, and the email
-> reaches `raw_payload` only, through the row schema's `.passthrough()`
-> (`openaiAdmin.puller.ts:403,864` and the comments above them). The id is the
+> so: `actor` carries the provider's **opaque `user-…` id**, and the email is
+> now dropped from the row before it is stringified into `raw_payload`
+> (`openaiAdmin.puller.ts:417,885-891` and the comments above them), so
+> the address is never stored. The id is the
 > stable key, the erasure suppression list is keyed on exactly that string,
 > and a raw address is heavier on a money row. The decision below stands with
 > "the raw user id" read wherever it says "`user_email`".
@@ -303,7 +304,8 @@ can exist, so there is nothing to repair.
 | No float round-trip on money | Sub-cent figures keep every digit | `amount` parsed as `string \| number` and stringified once; a string input survives byte-identical |
 | A costless read writes no money | A missing row never overwrites a present one | Unit test: a bucket whose row vanished emits an event with **no** `pulled_usage` key, and `buildPulledUsageRecord` returns null |
 | Re-pulling an unchanged window records nothing new | At-least-once delivery is free | Same window pulled twice; ledger row count unchanged |
-| Identity reaches the audit row | Attribution is visible where a surface already reads it | OCSF row asserts the actor field = the row's raw `user_id`, and `metadata.extension.actorUserId` / `.apiKeyId` = the row's raw ids. **[v3: as shipped that actor field was the OCSF actor *email* column — the divergence Decision 6 records. v4: resolved. An opaque id now lands in `ActorUserId` with `ActorEmail` left blank, asserted against the real mapper rather than a copy of it (`pullerWorker.ocsfMapping.unit.test.ts:125-151`). The address itself still reaches `raw_payload` only.]** |
+| Identity reaches the audit row | Attribution is visible where a surface already reads it | OCSF row asserts the actor field = the row's raw `user_id`, and `metadata.extension.actorUserId` / `.apiKeyId` = the row's raw ids. **[v3: as shipped that actor field was the OCSF actor *email* column — the divergence Decision 6 records. v4: resolved. An opaque id now lands in `ActorUserId` with `ActorEmail` left blank, asserted against the real mapper rather than a copy of it (`pullerWorker.ocsfMapping.unit.test.ts:125-151`). The address itself is now dropped before `raw_payload` is written, so it is
+stored nowhere.]** |
 | The watermark never moves backwards | A re-read window, or a page returned out of order, must not rewind progress | Unit test: a response whose last bucket precedes the stored watermark leaves the watermark unchanged |
 | A corrected bucket replaces, never adds | Restatement is the whole point of the re-read window | Same window pulled twice with a changed `amount.value`; the ledger shows the new figure once, and the row count is unchanged |
 | Below the floor the day survives, only the key is lost | A 400 on key grouping must not cost history | Unit test: a floor 400 triggers one retry with `user_id` only, and the resulting rows still carry `user_id` |
@@ -447,11 +449,11 @@ bucket lands beside the old rows instead of replacing them. Whether
 attribution claim carries an untested assumption. Key-level detail is absent
 below the provider's floor.
 
-The provider's user id, email and key id are exported to any third-party
-SIEM the organization has wired up, because `raw_payload` is required on
-every pull event and the whole raw row ships inside `RawOcsfJson`. That is
-inherited framework behaviour, not new here, and it is why Decision 6
-changes nothing about exposure.
+The provider's user id and key id are exported to any third-party SIEM the
+organization has wired up, because `raw_payload` is required on every pull
+event and the raw row ships inside `RawOcsfJson`. The email address is not
+among them: the adapter drops it before the row is stored, so it never
+egresses.
 
 **Neutral.** `openai_compliance` stays registered, listed and inert. The
 adapter duplicates cursor logic a third provider may justify factoring out.
@@ -552,8 +554,10 @@ adapter duplicates cursor logic a third provider may justify factoring out.
     adapter reads the id deliberately and says why in its own comment
     (`openaiAdmin.puller.ts:390-401,835-851`): the id is stable, the erasure
     suppression list is keyed on exactly that string, and the address is
-    heavier on a money row. The email is not dropped — it survives into
-    `raw_payload` through the row schema's `.passthrough()`.
+    heavier on a money row. At v3 the email was not dropped — it survived into
+    `raw_payload` through the row schema's `.passthrough()`. **[No longer true:
+    the adapter now drops the address before the row is stringified into
+    `raw_payload`, so it is stored nowhere.]**
   - **Consequence, recorded rather than ruled on:** the worker wrote
     `actorEmail: event.actor` and `actorUserId: ""`, so at v3 the OCSF column
     named for an email address held an opaque provider id while the actor id

--- a/platform/app/ee/governance/process-manager/__tests__/pulledUsageLedger.process.unit.test.ts
+++ b/platform/app/ee/governance/process-manager/__tests__/pulledUsageLedger.process.unit.test.ts
@@ -67,7 +67,7 @@ let clock: number;
  * test so that every observation in a test lands on the same stream — which is
  * exactly the production shape, since the key is the aggregate id.
  */
-const RESTATEMENT_KEY = `azure:${ns}:sub-1:2026-08-01`;
+const RESTATEMENT_KEY = `example:${ns}:sub-1:2026-08-01`;
 
 function observation(
   overrides: Partial<PulledUsageObservedEventData> = {},
@@ -276,25 +276,14 @@ describe("recognising a reissued charge", () => {
    */
   describe("given a period that holds more than one model", () => {
     const OMITS_MODEL_SOURCE = "example_cost_source";
-    /**
-     * The block's own key, so the two observations still land on ONE instance
-     * without borrowing the file's Azure-prefixed one — the source here is not
-     * Azure.
-     */
-    const OMITS_MODEL_KEY = `example:${ns}:sub-1:2026-08-01`;
 
     /** @scenario A reissue is recognised from the currency, the agent and the spender only */
     it("withdraws nothing when only the model differs", async () => {
       await observe(
-        observation({
-          restatementKey: OMITS_MODEL_KEY,
-          source: OMITS_MODEL_SOURCE,
-          model: "example/meter-a",
-        }),
+        observation({ source: OMITS_MODEL_SOURCE, model: "example/meter-a" }),
       );
       await observe(
         observation({
-          restatementKey: OMITS_MODEL_KEY,
           source: OMITS_MODEL_SOURCE,
           model: "example/meter-b",
           observedAtMs: T0 + 3_600_000,
@@ -310,15 +299,10 @@ describe("recognising a reissued charge", () => {
 
     it("still addresses the superseded model when the currency moves too", async () => {
       await observe(
-        observation({
-          restatementKey: OMITS_MODEL_KEY,
-          source: OMITS_MODEL_SOURCE,
-          model: "example/meter-a",
-        }),
+        observation({ source: OMITS_MODEL_SOURCE, model: "example/meter-a" }),
       );
       await observe(
         observation({
-          restatementKey: OMITS_MODEL_KEY,
           source: OMITS_MODEL_SOURCE,
           model: "example/meter-b",
           currencyCode: "EUR",

--- a/platform/app/ee/governance/process-manager/__tests__/pulledUsageLedger.process.unit.test.ts
+++ b/platform/app/ee/governance/process-manager/__tests__/pulledUsageLedger.process.unit.test.ts
@@ -276,14 +276,25 @@ describe("recognising a reissued charge", () => {
    */
   describe("given a period that holds more than one model", () => {
     const OMITS_MODEL_SOURCE = "example_cost_source";
+    /**
+     * The block's own key, so the two observations still land on ONE instance
+     * without borrowing the file's Azure-prefixed one — the source here is not
+     * Azure.
+     */
+    const OMITS_MODEL_KEY = `example:${ns}:sub-1:2026-08-01`;
 
     /** @scenario A reissue is recognised from the currency, the agent and the spender only */
     it("withdraws nothing when only the model differs", async () => {
       await observe(
-        observation({ source: OMITS_MODEL_SOURCE, model: "example/meter-a" }),
+        observation({
+          restatementKey: OMITS_MODEL_KEY,
+          source: OMITS_MODEL_SOURCE,
+          model: "example/meter-a",
+        }),
       );
       await observe(
         observation({
+          restatementKey: OMITS_MODEL_KEY,
           source: OMITS_MODEL_SOURCE,
           model: "example/meter-b",
           observedAtMs: T0 + 3_600_000,
@@ -299,10 +310,15 @@ describe("recognising a reissued charge", () => {
 
     it("still addresses the superseded model when the currency moves too", async () => {
       await observe(
-        observation({ source: OMITS_MODEL_SOURCE, model: "example/meter-a" }),
+        observation({
+          restatementKey: OMITS_MODEL_KEY,
+          source: OMITS_MODEL_SOURCE,
+          model: "example/meter-a",
+        }),
       );
       await observe(
         observation({
+          restatementKey: OMITS_MODEL_KEY,
           source: OMITS_MODEL_SOURCE,
           model: "example/meter-b",
           currencyCode: "EUR",

--- a/platform/app/ee/governance/process-manager/__tests__/pulledUsageLedger.process.unit.test.ts
+++ b/platform/app/ee/governance/process-manager/__tests__/pulledUsageLedger.process.unit.test.ts
@@ -265,21 +265,32 @@ describe("recognising a reissued charge", () => {
     });
   });
 
+  /**
+   * Two models of one period landing on ONE process instance, which is what a
+   * shared restatement key means. `restatementKeyFor` (pulledUsageRecord)
+   * hashes the adapter's `dimensions`, so this models an adapter that omits
+   * the model from its dimensions. Azure is not one: it pins `meterCategory`
+   * and `model` into `dimensions` (azureCostManagement.ts), so two Azure
+   * meters never share a key. Hence the neutral source label here rather than
+   * the file's Azure one.
+   */
   describe("given a period that holds more than one model", () => {
+    const OMITS_MODEL_SOURCE = "example_cost_source";
+
     /** @scenario A reissue is recognised from the currency, the agent and the spender only */
     it("withdraws nothing when only the model differs", async () => {
-      await observe(observation({ model: "azure/meter-a" }));
+      await observe(
+        observation({ source: OMITS_MODEL_SOURCE, model: "example/meter-a" }),
+      );
       await observe(
         observation({
-          model: "azure/meter-b",
+          source: OMITS_MODEL_SOURCE,
+          model: "example/meter-b",
           observedAtMs: T0 + 3_600_000,
         }),
       );
       await drainOutbox();
 
-      // An adapter that does not list the model among its dimensions gives
-      // both models of one period the SAME restatement key, so this arrives on
-      // this very instance — the premise is reachable, not hypothetical.
       // Withdrawing here would zero money that was really spent, which is
       // strictly worse than the double-count the detector exists to prevent.
       expect(sendRetractPulledUsage).not.toHaveBeenCalled();
@@ -287,10 +298,13 @@ describe("recognising a reissued charge", () => {
     });
 
     it("still addresses the superseded model when the currency moves too", async () => {
-      await observe(observation({ model: "azure/meter-a" }));
+      await observe(
+        observation({ source: OMITS_MODEL_SOURCE, model: "example/meter-a" }),
+      );
       await observe(
         observation({
-          model: "azure/meter-b",
+          source: OMITS_MODEL_SOURCE,
+          model: "example/meter-b",
           currencyCode: "EUR",
           costNanoUsd: null,
           observedAtMs: T0 + 3_600_000,
@@ -303,7 +317,7 @@ describe("recognising a reissued charge", () => {
       // this charge and leave the one that does untouched.
       expect(sendRetractPulledUsage).toHaveBeenCalledTimes(1);
       expect(sendRetractPulledUsage.mock.calls[0]?.[0]).toMatchObject({
-        model: "azure/meter-a",
+        model: "example/meter-a",
         currencyCode: "USD",
       });
     });

--- a/platform/app/ee/governance/projections/__tests__/governanceCostRollupSortKey.unit.test.ts
+++ b/platform/app/ee/governance/projections/__tests__/governanceCostRollupSortKey.unit.test.ts
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+
+/**
+ * Guard: the rollup's sort key exists in three places, and nothing at runtime
+ * forces them to agree.
+ *
+ *   1. The table's own `ORDER BY` in migration 00092 — what ClickHouse
+ *      actually dedupes and prunes on.
+ *   2. `GOVERNANCE_COST_ROLLUP_KEY_FIELDS`, the order the fold packs into the
+ *      key a cell is addressed by.
+ *   3. `KEY_COLUMNS` on the read side, which builds the point-lookup
+ *      predicate.
+ *
+ * A reorder in any one of them is silent. If the fold's order drifts from the
+ * table's, two different dimension tuples can still encode to distinct keys,
+ * so nothing throws — the rows just land under an address the read side
+ * cannot reproduce, and money rows go missing or a lookup returns a
+ * neighbouring cell's amount. If `KEY_COLUMNS` drifts, the predicate stops
+ * being a prefix of the sort key and the point lookup degrades to a scan.
+ * This test is the only thing that notices any of it.
+ *
+ * The migration is read as text on purpose: it is the deployed DDL, and it is
+ * immutable history, so it is the fixed end of the contract that the two
+ * TypeScript copies are held against.
+ */
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { KEY_COLUMNS } from "../../services/governanceCostRollup.clickhouse.repository";
+import { GOVERNANCE_COST_ROLLUP_TABLE } from "../governanceCostRollup.constants";
+import { GOVERNANCE_COST_ROLLUP_KEY_FIELDS } from "../governanceCostRollup.foldProjection";
+
+const MIGRATION = readFileSync(
+  resolve(
+    process.cwd(),
+    "src/server/clickhouse/migrations/00092_create_governance_cost_rollup_1d.sql",
+  ),
+  "utf8",
+);
+
+/**
+ * The column list of the migration's `ORDER BY (...)`. Throws rather than
+ * returning something empty: a parse that quietly found nothing would make
+ * every assertion below vacuous, which is the failure mode this whole file
+ * exists to rule out.
+ */
+function orderByColumns(sql: string): string[] {
+  const clauses = [...sql.matchAll(/^ORDER BY \(([^)]*)\)/gm)];
+  if (clauses.length !== 1) {
+    throw new Error(
+      `expected exactly one ORDER BY in migration 00092, found ${clauses.length}`,
+    );
+  }
+  const columns = clauses[0]![1]!.split(",").map((column) => column.trim());
+  if (columns.length === 0 || columns.some((column) => column === "")) {
+    throw new Error(`unparseable ORDER BY column list: ${clauses[0]![1]!}`);
+  }
+  return columns;
+}
+
+/** `tenantId` → `TenantId`: the two sides spell the same dimension differently. */
+function asColumnName(field: string): string {
+  return field.charAt(0).toUpperCase() + field.slice(1);
+}
+
+describe("the governance cost rollup sort key", () => {
+  describe("given the deployed table definition in migration 00092", () => {
+    it("parses a non-empty ORDER BY off the rollup table", () => {
+      // The self-check: everything below compares against this list, so a
+      // silently-empty parse would turn the guard green while pinning nothing.
+      expect(MIGRATION).toContain(GOVERNANCE_COST_ROLLUP_TABLE);
+      expect(orderByColumns(MIGRATION).length).toBeGreaterThan(0);
+    });
+
+    it("orders the read side's key columns exactly as the table does", () => {
+      expect([...KEY_COLUMNS]).toEqual(orderByColumns(MIGRATION));
+    });
+
+    it("orders the fold's key fields exactly as the table does", () => {
+      expect(GOVERNANCE_COST_ROLLUP_KEY_FIELDS.map(asColumnName)).toEqual(
+        orderByColumns(MIGRATION),
+      );
+    });
+  });
+});

--- a/platform/app/ee/governance/projections/governanceCostRollup.foldProjection.ts
+++ b/platform/app/ee/governance/projections/governanceCostRollup.foldProjection.ts
@@ -385,6 +385,26 @@ export function governanceCostRollupKey(event: {
 }
 
 /**
+ * The dimension fields making up a key, IN SORT-KEY ORDER — the same order,
+ * column for column, as the `ORDER BY` of the rollup table in migration 00092
+ * and as `KEY_COLUMNS` on the read side. The three are one contract in three
+ * places, and a test pins them to each other, so the order lives in a named
+ * constant rather than inline in the encoder where a reorder would look like
+ * a formatting change.
+ */
+export const GOVERNANCE_COST_ROLLUP_KEY_FIELDS = [
+  "tenantId",
+  "day",
+  "costSource",
+  "ingestionSourceId",
+  "provider",
+  "model",
+  "agentId",
+  "currencyCode",
+  "rawActorId",
+] as const satisfies readonly (keyof GovernanceCostRollupCell)[];
+
+/**
  * The key a cell is addressed by. The comparator reaches for this to ask what
  * key a STORED row would have been written under — the alternative, a second
  * copy of the encoding on the read side, is a pair that can disagree, and a
@@ -395,17 +415,9 @@ export function encodeGovernanceCostRollupKey(
   cell: GovernanceCostRollupCell,
 ): string {
   const payload = Buffer.from(
-    JSON.stringify([
-      cell.tenantId,
-      cell.day,
-      cell.costSource,
-      cell.ingestionSourceId,
-      cell.provider,
-      cell.model,
-      cell.agentId,
-      cell.currencyCode,
-      cell.rawActorId,
-    ]),
+    JSON.stringify(
+      GOVERNANCE_COST_ROLLUP_KEY_FIELDS.map((field) => cell[field]),
+    ),
     "utf8",
   ).toString("base64url");
   return `cost1d:${cell.tenantId}:${cell.day}:${cell.costSource}:${payload}`;

--- a/platform/app/ee/governance/services/governanceCost.service.ts
+++ b/platform/app/ee/governance/services/governanceCost.service.ts
@@ -746,17 +746,22 @@ export class GovernanceCostService {
    * This panel used to read the metered trace store, which in a deployment
    * whose only money arrives on pulled bills holds nothing — so a screen with
    * a fully populated `Model` column sat there reporting "nothing in this
-   * window yet". Same rollup as every other figure on this screen now, which
-   * is also what makes it add up against the billed lane beside it.
+   * window yet". Same rollup as every other figure on this screen now — but
+   * NOT the same withholding rule: this read withholds on a cell with no USD
+   * amount, the billed lane beside it only on a cell with no amount in any
+   * currency, so a window holding one euro cell shows a withheld model list
+   * next to a lane that states a figure. `sumWindowByModel`
+   * (governanceCostRollup.clickhouse.repository) carries why the model read
+   * keeps the stricter rule.
    *
    * Ordered by spend rather than alphabetically, because the panel is a ranked
    * list and the question it answers is which model costs the most. A withheld
    * figure sorts last: it is not a small number, it is an unknown one, and
    * putting it at the top or in the middle would read as a measurement.
    *
-   * Each figure obeys the same withholding rule as every other on this screen:
-   * a model holding any cell we have no USD amount for states no figure,
-   * because the priced part alone reads as the whole one.
+   * Each figure obeys that stricter rule: a model holding any cell we have no
+   * USD amount for states no figure, because the priced part alone reads as
+   * the whole one.
    */
   async spendByModel({
     organizationId,

--- a/platform/app/ee/governance/services/governanceCostRollup.clickhouse.repository.ts
+++ b/platform/app/ee/governance/services/governanceCostRollup.clickhouse.repository.ts
@@ -70,8 +70,13 @@ export interface GovernanceCostRollupRestatementIndexRow {
   EventTimestamp: number;
 }
 
-/** The columns that make a row's identity, in sort-key order. */
-const KEY_COLUMNS = [
+/**
+ * The columns that make a row's identity, in sort-key order. Exported so a
+ * test can hold it against the table's own `ORDER BY` in migration 00092 and
+ * against the fold's key field order — three copies of one contract that
+ * nothing else forces to agree.
+ */
+export const KEY_COLUMNS = [
   "TenantId",
   "Day",
   "CostSource",

--- a/platform/app/ee/governance/services/pullers/__tests__/anthropicAdminPuller.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/anthropicAdminPuller.unit.test.ts
@@ -9,6 +9,7 @@
  * Spec: specs/governance/pulled-usage-cost-reporting.feature
  * Decision: ADR-088 (Decisions 6 and 7).
  */
+import { inspect } from "node:util";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ZodError } from "zod";
 
@@ -1087,13 +1088,11 @@ describe("the Anthropic Admin puller", () => {
       const error = (await run.catch((e: unknown) => e)) as DispatchError;
       // Three surfaces, because the reply reaches a person through any of
       // them: the log line (`message`), the sentence an admin is shown
-      // (`customerMessage`), and whatever an outbox row or a log serialiser
-      // writes down. The last is the widest — `Object.getOwnPropertyNames`
-      // pulls in `stack` and `cause`, which a plain `JSON.stringify` drops.
-      const serialised = JSON.stringify(
-        error,
-        Object.getOwnPropertyNames(error),
-      );
+      // (`customerMessage`), and whatever a log serialiser writes down. The
+      // last is rendered with `util.inspect`, which walks own properties,
+      // `stack` and a `cause` to any depth — so a body tucked inside an
+      // object-valued `cause` is caught rather than flattened away.
+      const serialised = inspect(error, { depth: null, showHidden: true });
       for (const fragment of [REFUSAL_KEY, REFUSAL_WORKSPACE, REFUSAL_PROSE]) {
         expect(error.message).not.toContain(fragment);
         expect(error.customerMessage).not.toContain(fragment);

--- a/platform/app/ee/governance/services/pullers/__tests__/anthropicAdminPuller.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/anthropicAdminPuller.unit.test.ts
@@ -1054,15 +1054,25 @@ describe("the Anthropic Admin puller", () => {
       schedule: "0 * * * *",
     } as const;
 
+    // The body the provider is made to refuse with. Every fragment is a fake,
+    // and each is distinctive enough that finding it anywhere in the thrown
+    // error can only mean the reply was quoted: a key-shaped string, the
+    // workspace it names, and the provider's own error prose.
+    const REFUSAL_KEY = "sk-ant-admin-FAKE000";
+    const REFUSAL_WORKSPACE = "wrkspc_QUOTED_BODY_MARKER";
+    const REFUSAL_PROSE = "authentication_error";
+    const REFUSAL_BODY = JSON.stringify({
+      error: {
+        type: REFUSAL_PROSE,
+        message: `invalid x-api-key ${REFUSAL_KEY} for workspace ${REFUSAL_WORKSPACE}`,
+      },
+    });
+
     /** @scenario "A key the provider refuses is reported as refused and is not retried as an outage" */
     it.each([
       401, 403,
     ])("ends the run as refused and not worth retrying on HTTP %i, without quoting the reply or the key", async (status) => {
-      fetchMock.mockResolvedValue(
-        new Response('{"error":{"message":"invalid x-api-key sk-admin"}}', {
-          status,
-        }),
-      );
+      fetchMock.mockResolvedValue(new Response(REFUSAL_BODY, { status }));
 
       const run = new AnthropicAdminPuller().runOnce(RUN_OPTIONS, CONFIG);
       await expect(run).rejects.toBeInstanceOf(DispatchError);
@@ -1075,9 +1085,20 @@ describe("the Anthropic Admin puller", () => {
       // `run` is typed by its resolved value, so the rejection has to be read
       // off the promise and cast: the assertions above already proved what it is.
       const error = (await run.catch((e: unknown) => e)) as DispatchError;
-      expect(error.message).not.toContain("sk-admin");
-      expect(error.message).not.toContain("invalid x-api-key");
-      expect(error.customerMessage).not.toContain("sk-admin");
+      // Three surfaces, because the reply reaches a person through any of
+      // them: the log line (`message`), the sentence an admin is shown
+      // (`customerMessage`), and whatever an outbox row or a log serialiser
+      // writes down. The last is the widest — `Object.getOwnPropertyNames`
+      // pulls in `stack` and `cause`, which a plain `JSON.stringify` drops.
+      const serialised = JSON.stringify(
+        error,
+        Object.getOwnPropertyNames(error),
+      );
+      for (const fragment of [REFUSAL_KEY, REFUSAL_WORKSPACE, REFUSAL_PROSE]) {
+        expect(error.message).not.toContain(fragment);
+        expect(error.customerMessage).not.toContain(fragment);
+        expect(serialised).not.toContain(fragment);
+      }
       expect(fetchMock).toHaveBeenCalledTimes(1);
     });
 

--- a/platform/app/ee/governance/services/pullers/__tests__/databricksGeniePaidBill.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/databricksGeniePaidBill.unit.test.ts
@@ -272,7 +272,7 @@ describe("given a Genie source that has not switched the paid bill read on", () 
 
 describe("given a Genie source with the paid bill read switched on", () => {
   describe("when the workspace bills a person's usage under a price line with a list price", () => {
-    /** @scenario "A paid Genie charge lands on the person who ran it, for that day and that price line" */
+    /** @scenario "A paid Genie charge lands on the identity the bill names as run_as, for that day and that price line" */
     it("records one cost row for that person, day and price line at the list price", async () => {
       billPlan = { kind: "rows", rows: [paidRow()] };
 
@@ -298,7 +298,7 @@ describe("given a Genie source with the paid bill read switched on", () => {
       expect(event.extra?.quantity).toBe("12.5");
     });
 
-    /** @scenario "A paid Genie charge lands on the person who ran it, for that day and that price line" */
+    /** @scenario "A paid Genie charge lands on the identity the bill names as run_as, for that day and that price line" */
     it("asks the workspace for the Genie bill line on the configured warehouse", async () => {
       billPlan = { kind: "rows", rows: [] };
 
@@ -319,7 +319,7 @@ describe("given a Genie source with the paid bill read switched on", () => {
       expect(sql).not.toContain("system.query.history");
     });
 
-    /** @scenario "A paid Genie charge lands on the person who ran it, for that day and that price line" */
+    /** @scenario "A paid Genie charge lands on the identity the bill names as run_as, for that day and that price line" */
     it("carries the currency when the only list price is not in dollars", async () => {
       billPlan = {
         kind: "rows",

--- a/platform/app/ee/governance/services/pullers/__tests__/openaiAdminPuller.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/openaiAdminPuller.unit.test.ts
@@ -266,9 +266,12 @@ describe("given an OpenAI Admin cost source", () => {
       expect(event.extra?.actorUserId).toBe("user-1");
       // The row the adapter read did carry an address — this is the half that
       // makes the two lines above a choice rather than the only thing on offer.
-      expect(JSON.parse(event.raw_payload as string).user_email).toBe(
-        "person@acme.test",
+      // The address is dropped before the row is stored, so it is absent from
+      // the retained payload and from anywhere else on the event.
+      expect(JSON.parse(event.raw_payload as string)).not.toHaveProperty(
+        "user_email",
       );
+      expect(JSON.stringify(event)).not.toContain("person@acme.test");
       expect(event.actor).not.toContain("@");
       expect(event.extra?.actorUserId).not.toContain("@");
     });

--- a/platform/app/ee/governance/services/pullers/databricksGenie.puller.ts
+++ b/platform/app/ee/governance/services/pullers/databricksGenie.puller.ts
@@ -1050,9 +1050,11 @@ function readWarehouseCost({
  * one filters `usage_metadata.warehouse_id IS NOT NULL` because it prices
  * warehouse hours, and the rows this one reads carry no warehouse id at all.
  * Databricks bills Genie's own metered usage under
- * `billing_origin_product = 'GENIE'`, attributed to `identity_metadata.run_as`,
- * with `usage_metadata.genie.surface` and `.channel` describing where the
- * usage came from.
+ * `billing_origin_product = 'GENIE'`, attributed to `identity_metadata.run_as`
+ * — the identity the workload ran as, which is the job or query owner and not
+ * necessarily the person who typed the question.
+ * `usage_metadata.genie.surface` and `.channel` describe where the usage came
+ * from.
  *
  * Grouped by person, day and SKU — and NOT by surface or channel. Those two are
  * how Databricks describes the usage, not what it bills, and the grouping here
@@ -1333,7 +1335,9 @@ function withoutZeroPrice(row: PaidGenieBillRow): PaidGenieBillRow {
 /**
  * One bill row as the event the ledger and the audit sink read.
  *
- * The person the bill names is the actor; the price line is the model; there
+ * The identity the bill names in `run_as` is the actor — the owner the
+ * workload ran as, not necessarily whoever asked the question, and the only
+ * person Databricks puts on the charge. The price line is the model; there
  * is no agent, because the bill names no space and no warehouse ran it — a
  * warehouse id here would put compute on the agents screen as if it were a
  * thing people talk to. The day is the event's timestamp, so the record seam

--- a/platform/app/ee/governance/services/pullers/openaiAdmin.puller.ts
+++ b/platform/app/ee/governance/services/pullers/openaiAdmin.puller.ts
@@ -419,8 +419,9 @@ const costResultSchema = z
      * saved raw responses (2026-08-25, re-confirmed 2026-09-06: 2,720/2,720
      * rows populated) — and this adapter deliberately reads the id, not the
      * address: the id is stable, and a raw email is heavier on a money row
-     * (erasure, exposure). The email still reaches `raw_payload` via
-     * `.passthrough()` below.
+     * (erasure, exposure). `.passthrough()` below carries the address as far
+     * as this function and no further: `costEvent` drops it before the row is
+     * stringified into `raw_payload`, so the address is never stored.
      *
      * Null whenever the row was not grouped by user, so it is read through
      * `dimension()` like every other coordinate.
@@ -881,6 +882,14 @@ export class OpenAiAdminPuller implements PullerAdapter<OpenAiAdminPullConfig> {
     // shifts a decimal here and porting that reports 100x the real spend.
     const amountUsd = result.amount.value;
 
+    // Everything the provider sent EXCEPT the billed person's email address.
+    // `.passthrough()` keeps unknown fields so a later question about a row can
+    // be answered from what was stored; the address is the one field excluded,
+    // because no screen, query or export reads it and keeping a raw address on
+    // every money row only adds erasure and exposure surface. The opaque
+    // `user_id` stays — it is the actor and the erasure key.
+    const { user_email: _droppedEmail, ...retainedPayload } = result;
+
     return {
       source_event_id: `cost:${startingAt}:${dimensionPath(dimensions)}`,
       event_timestamp: startingAt,
@@ -899,10 +908,11 @@ export class OpenAiAdminPuller implements PullerAdapter<OpenAiAdminPullConfig> {
        * exactly this string (`partitionSuppressedEvents` reads `event.actor`,
        * and a discovered person's `rawActorId` is where the digest comes from),
        * so the two agree: erasing this person suppresses this id. The provider
-       * DOES send a `user_email` beside the id (it survives into `raw_payload`
-       * via the schema's `.passthrough()`); it is deliberately not the actor,
-       * so matching an id to an account is the identity engine's job, not this
-       * adapter's.
+       * DOES send a `user_email` beside the id; it is deliberately not the
+       * actor, and it is dropped from the retained payload below rather than
+       * stored, because nothing in the product reads it and an address on a
+       * money row is pure liability (erasure, exposure). Matching an id to an
+       * account is the identity engine's job, not this adapter's.
        */
       actor: dimension(result.user_id),
       action: "cost_report",
@@ -910,7 +920,7 @@ export class OpenAiAdminPuller implements PullerAdapter<OpenAiAdminPullConfig> {
       cost_usd: amountUsd,
       tokens_input: 0,
       tokens_output: 0,
-      raw_payload: JSON.stringify(result),
+      raw_payload: JSON.stringify(retainedPayload),
       extra: {
         // Raw provider ids, resolved never (ADR-088 Decision 13). The worker
         // spreads `extra` into the audit row's metadata extension, which is

--- a/platform/app/ee/governance/services/pullers/pullerAdapter.ts
+++ b/platform/app/ee/governance/services/pullers/pullerAdapter.ts
@@ -224,6 +224,12 @@ export interface PullResult {
    * A degradation a reader of the source needs to know about — "the money is
    * here but nobody is attributed to it" — has to survive as data. A log line
    * cannot be shown to someone looking at the source.
+   *
+   * Today nothing carries it that far: `runPuller` (pullerWorker) returns
+   * `nextCursor`, `eventCount`, `errorCount`, `completeness` and
+   * `readThroughAt` and drops `notices` on the floor, so no screen and no
+   * person sees a code set here. The tests assert on them; nothing else reads
+   * them yet.
    */
   notices?: string[];
 }

--- a/platform/app/src/server/clickhouse/migrations/00095_governance_cost_rollup_retention_days.sql
+++ b/platform/app/src/server/clickhouse/migrations/00095_governance_cost_rollup_retention_days.sql
@@ -26,16 +26,10 @@
 -- no explicit column list, so an added column is simply omitted and takes its
 -- DEFAULT — every existing and every future row reads 0 and is kept.
 --
--- NET BEHAVIOUR CHANGE, stated plainly: the 13-month hard delete stops. The
--- cold-storage MOVE does not. Both tables have reconciler entries carrying
--- `hardcodedDefault: 49` (ttlReconciler), so on a cluster with
--- CLICKHOUSE_COLD_STORAGE_ENABLED="true" and the tiered storage policy the
--- reconciler keeps rendering `toDateTime(Day) + INTERVAL 49 DAY TO VOLUME
--- 'cold'` against them. That clause relocates parts to the cold volume and
--- deletes nothing, so rows stamped 0 still live forever — they just live on
--- cheaper disk after 49 days. What is bought is the knob: stamp a non-zero day
--- count on a row (or on a future write path) and that row ages out on the next
--- merge, with no further migration and no change to the reconciler.
+-- NET BEHAVIOUR CHANGE, stated plainly: the 13-month hard delete stops. Nothing
+-- else moves. What is bought is the knob: stamp a non-zero day count on a row
+-- (or on a future write path) and that row ages out on the next merge, with no
+-- further migration and no change to the reconciler.
 --
 -- WHY NOT THE CUSTOMER RETENTION MAP. These two tables carry `_retention_days`
 -- but are deliberately NOT added to RETENTION_TABLE_CATEGORY_MAP. That map is

--- a/platform/app/src/server/clickhouse/migrations/00095_governance_cost_rollup_retention_days.sql
+++ b/platform/app/src/server/clickhouse/migrations/00095_governance_cost_rollup_retention_days.sql
@@ -26,10 +26,16 @@
 -- no explicit column list, so an added column is simply omitted and takes its
 -- DEFAULT — every existing and every future row reads 0 and is kept.
 --
--- NET BEHAVIOUR CHANGE, stated plainly: the 13-month hard delete stops. Nothing
--- else moves. What is bought is the knob: stamp a non-zero day count on a row
--- (or on a future write path) and that row ages out on the next merge, with no
--- further migration and no change to the reconciler.
+-- NET BEHAVIOUR CHANGE, stated plainly: the 13-month hard delete stops. The
+-- cold-storage MOVE does not. Both tables have reconciler entries carrying
+-- `hardcodedDefault: 49` (ttlReconciler), so on a cluster with
+-- CLICKHOUSE_COLD_STORAGE_ENABLED="true" and the tiered storage policy the
+-- reconciler keeps rendering `toDateTime(Day) + INTERVAL 49 DAY TO VOLUME
+-- 'cold'` against them. That clause relocates parts to the cold volume and
+-- deletes nothing, so rows stamped 0 still live forever — they just live on
+-- cheaper disk after 49 days. What is bought is the knob: stamp a non-zero day
+-- count on a row (or on a future write path) and that row ages out on the next
+-- merge, with no further migration and no change to the reconciler.
 --
 -- WHY NOT THE CUSTOMER RETENTION MAP. These two tables carry `_retention_days`
 -- but are deliberately NOT added to RETENTION_TABLE_CATEGORY_MAP. That map is

--- a/platform/app/src/server/clickhouse/ttlReconciler.ts
+++ b/platform/app/src/server/clickhouse/ttlReconciler.ts
@@ -209,6 +209,14 @@ export const TABLE_TTL_CONFIG: readonly TableTTLEntry[] = [
   // written out because `Day` is a `Date`, not a DateTime, and the wrap is the
   // thing that makes the interval arithmetic legal — not because the default
   // would produce anything different.
+  //
+  // Migration 00095 stopped the 13-month hard delete on both of these tables,
+  // and its header says nothing else moves them. That is wrong about this
+  // file: the two entries below keep rendering the 49-day
+  // `MOVE ... TO VOLUME 'cold'` clause on any cluster with cold storage
+  // enabled and the tiered policy. The MOVE relocates parts and deletes
+  // nothing, so a row whose `_retention_days` is 0 still lives forever — it
+  // just lives on cheaper disk once it is 49 days old.
   {
     table: "governance_cost_rollup_1d",
     ttlColumn: "Day",

--- a/specs/governance/pulled-usage-cost-reporting.feature
+++ b/specs/governance/pulled-usage-cost-reporting.feature
@@ -440,7 +440,7 @@ Feature: Pulled provider usage becomes visible, attributed cost
     And no bill row is recorded
 
   @unit
-  Scenario: A paid Genie charge lands on the person who ran it, for that day and that price line
+  Scenario: A paid Genie charge lands on the identity the bill names as run_as, for that day and that price line
     Given a Genie source with the paid bill read switched on
     And the workspace bills a person's Genie usage on a day under a price line that has a list price
     When the source runs


### PR DESCRIPTION
Closes langwatch/langwatch-saas#1225. Follow-on to the seven-wrongs batch (#8062) and the retention change (#8063).

## For humans

Eight small things, no migration, no schema change, no new scenario. One privacy fix, two tests that can now fail, five comments and one scenario title that now say what the code does. Nine commits: three that did the work, one that put migration 00095 back byte for byte after CI refused the edit, and five that answered a review round.

**The one that matters.** The OpenAI admin usage feed stored the user's email address in every cost row's `raw_payload`, and a unit test asserted that it did. The compliance feed was fixed in #8062; the admin feed was not. The product keys the person on the opaque id and never reads the address. The row is now stripped of the address before it is stringified, and the test asserts the address is absent from the payload and from the whole serialised event. Rows stored before this change still hold the address; purging them is a data decision, not made here.

**Two tests that were not testing.** The Anthropic refusal guard asserted a string literal did not contain a key, which cannot fail. It now feeds a refused body carrying a fake key and provider text and checks `message`, `customerMessage`, and the serialised error including `cause` and `stack`. The rollup sort key lived in three places with nothing pinning them: the 00092 `ORDER BY`, the fold group key, and `KEY_COLUMNS`. A new test parses the migration from disk and asserts both code copies match it in order; the fold key fields are extracted to one exported constant the encoder maps over.

**Five wording fixes.** The 00095 header says nothing else moves; on a tiered cluster the reconciler's 49-day cold-storage move continues. Merged migrations cannot change (CI's migration-order guard), so the correction sits as a comment in `ttlReconciler.ts` above the two rollup entries that render the move. The Genie comments and scenario title said the charge lands on the person who ran the query; Databricks records the identity the workload ran as, the owner, so the wording now says that. The retraction test's two-cells-one-key example named Azure meters, which never share a key; it now names a hypothetical adapter and says why. The `notices` doc comment described a screen that does not exist; it now matches the Genie puller's admission that the worker drops it. The model-panel comment claimed it adds up against the billed lane; the two reads use different withholding rules and the comment now points at the repository comment explaining why.

## Cause, per item

1. `openaiAdmin.puller.ts:913` stringified the whole parsed row, which `.passthrough()` lets carry `user_email`.
2. `00095_governance_cost_rollup_retention_days.sql:29-30` contradicted `ttlReconciler.ts:213-230, 321`.
3. `databricksGenie.puller.ts:1052-1053, 1336` and `pulled-usage-cost-reporting.feature:443` named the executor; `identity_metadata.run_as` is the owner.
4. `pulledUsageLedger.process.unit.test.ts:271-282` used Azure meters; `azureCostManagement.ts:667-670, 715` pins the meter into the key.
5. `pullerAdapter.ts:222-228` vs `pullerWorker.ts:462-467`, which drops `notices`.
6. `governanceCost.service.ts:749-750` vs `governanceCostRollup.clickhouse.repository.ts:1287-1293, 1218-1223`.
7. `anthropicAdminPuller.unit.test.ts:1078-1080` asserted against a literal.
8. Three copies of the sort key, no test naming any of them.

## Failing first, then passing

Item 1, before the fix:

```
AssertionError: expected { amount: { …(2) }, …(11) } to not have property "user_email"
- Expected: undefined
+ Received: "<the fixture address>"
 ❯ ee/governance/services/pullers/__tests__/openaiAdminPuller.unit.test.ts:271:59
 Tests  1 failed | 40 passed (41)
```

After: `Tests  41 passed (41)`.

Item 7, with the refused body deliberately placed in `cause`:

```
AssertionError: expected '{"stack":"DispatchError: HTTP 401 (an…' not to contain 'sk-ant-admin-FAKE000'
 ❯ anthropicAdminPuller.unit.test.ts:1100:32   expect(serialised).not.toContain(fragment);
 Tests  2 failed
```

After, with the temporary leak reverted and the puller diff empty: all pass.

Item 8, with `costSource` and `ingestionSourceId` swapped in the fold constant:

```
AssertionError: expected [ 'TenantId', 'Day', …(7) ] to deeply equal [ 'TenantId', 'Day', …(7) ]
-   "CostSource",
    "IngestionSourceId",
+   "CostSource",
 Tests  1 failed | 2 passed (3)
```

After, real order restored: `3 passed (3)`.

## Sweep

Every place a provider row is stringified into `raw_payload` under `ee/governance` was read. Anthropic admin: no email field exists, clean. Databricks Genie uses the login address as the actor by a documented choice because the API offers no opaque id; different mechanism, left alone. Microsoft Graph directory feed stringifies a directory person; that feed's purpose is naming people, not this bug. Activity-monitor cost extractor carries a `userEmail` read downstream for budget scopes; in use, out of scope.

## Noticed, not fixed

- `decodeGovernanceCostRollupKey` in the fold projection still spells the nine fields inline as a destructuring; a fourth copy of the order the new test does not pin. Refactoring it is not mechanical.
- The Genie feed's use of the login address as actor is a product decision worth its own issue.
- `laneTrendPct` in `costLaneFormat.ts` was on the original list and is correct; dropped after verification.
- The `raw_payload` doc comment in `pullerAdapter.ts` promises verbatim retention, which six of the eleven adapters already did not honour before this PR, and it never mentions the existing opt-out in the S3 polling adapter. Inherited, worth its own issue.
- Rows written before this PR still carry the address, and `governance_ocsf_events` has no time-to-live, so they stay until a backfill removes them. Named out of scope in the issue.
- The Anthropic guard is forward-looking: today's refusal branch cancels the body without reading it, so the three asserted surfaces are built from literals and the test has no positive control that would fire against the current code.

## Review round

An independent review found no P0 or P1. Three findings were fixed, across five commits. The first pass took one commit each: the Anthropic guard used a `JSON.stringify` allowlist that went blind one level down, so it now asserts on a full-depth inspect and was proven to catch an object-valued cause; four sentences in ADR-122 still said the email is stored and egresses, now corrected; the two de-Azured retraction cases still ran on a process key whose literal began with azure, now neutral. Two of the three then took a follow-up commit: ADR-122 gained a v6 revision entry and both stale citations were refreshed to current lines rather than left annotated; and the retraction fixture's Azure prefix was removed by renaming the shared key constant once, replacing a block-local override that only masked it in two cases. Two candidate blockers were refuted by executed code: the key-field extraction encodes byte-identically to base across three adversarial cells, and no consumer of `raw_payload` reads the address.

## Deployment Impact

No environment variable is added, removed or changed. No helm value is added, removed or changed. A vanilla `helm install` with no overrides behaves exactly as it does today: no migration runs, no schema changes, no service or job is added, and no new configuration surface appears. The one file touched outside the governance module is a comment block in the ClickHouse time-to-live reconciler, which renders no differently.

One runtime behaviour does change the moment the new image is running. The OpenAI admin cost puller stops writing the billed person's email address into the stored payload of each governance cost row. An operator forwarding those events onward will see that field disappear from newly written rows; nothing in the product ever read it, so no screen, query or export loses anything. Rows written before the deploy keep the address, and that table has no time-to-live, so they stay until a backfill removes them. No backfill ships here, and none is required to deploy.

BYOC dataplane: unaffected. No dataplane image, chart, contract or credential is touched by this change, and the deploy is safe to roll back — reverting restores the previous payload contents for rows written after the revert, and changes nothing already stored.

## Test plan

Five test files changed. Run together from the worktree root:

```
pnpm --filter @langwatch/web test:unit run \
  ee/governance/process-manager/__tests__/pulledUsageLedger.process.unit.test.ts \
  ee/governance/projections/__tests__/governanceCostRollupSortKey.unit.test.ts \
  ee/governance/services/pullers/__tests__/anthropicAdminPuller.unit.test.ts \
  ee/governance/services/pullers/__tests__/databricksGeniePaidBill.unit.test.ts \
  ee/governance/services/pullers/__tests__/openaiAdminPuller.unit.test.ts

 Test Files  5 passed (5)
      Tests  120 passed (120)
   Duration  496ms
```

Each of the three new assertions fails without its fix; those failures are quoted verbatim under "Failing first, then passing" above, together with the deliberate break that produced each one.

Whole module suite, same command against `ee/governance`:

```
 Test Files  149 passed (149)
      Tests  1748 passed (1748)
   Duration  13.60s
```

On `e7423e1`, every job in the app CI workflow is green: `typecheck`, `lint` (the gate that diffs new Biome violations against the merge base), `ast-grep`, `feature-parity`, `openapi-completeness`, `build`, `test-unit` across five shards, `test-component` across three, `test-integration` across four, plus `e2e`, CodeQL and the security scanners. No check is red and none is skipped for this diff.
