### PR TITLE
fix(voice): address the review findings left open on slice 3

### DIFF
--- a/platform/app/src/server/scenarios/voice/__tests__/voice-nonce-registry.unit.test.ts
+++ b/platform/app/src/server/scenarios/voice/__tests__/voice-nonce-registry.unit.test.ts
@@ -22,7 +22,6 @@ describe("VoiceNonceRegistry", () => {
       const first = registry.consume("abc");
       expect(first).toEqual({ ok: true, child: fakeChild });
 
-      // Single use: the same nonce is unknown on a replay.
       expect(registry.consume("abc")).toEqual({ ok: false, reason: "unknown" });
     });
   });

--- a/platform/app/src/server/scenarios/voice/__tests__/voice-socket-handoff.unit.test.ts
+++ b/platform/app/src/server/scenarios/voice/__tests__/voice-socket-handoff.unit.test.ts
@@ -32,6 +32,46 @@ describe("isVoiceMediaSocketMessage", () => {
     expect(isVoiceMediaSocketMessage(null)).toBe(false);
     expect(isVoiceMediaSocketMessage("string")).toBe(false);
   });
+
+  describe("when the discriminator matches but a required field is malformed", () => {
+    it("rejects a message with no headBase64", () => {
+      const { headBase64: _headBase64, ...rest } = message();
+      expect(isVoiceMediaSocketMessage(rest)).toBe(false);
+    });
+
+    it("rejects a message with a non-string nonce", () => {
+      expect(isVoiceMediaSocketMessage({ ...message(), nonce: 123 })).toBe(
+        false,
+      );
+    });
+
+    it("rejects a message with null headers", () => {
+      expect(isVoiceMediaSocketMessage({ ...message(), headers: null })).toBe(
+        false,
+      );
+    });
+
+    it("rejects a message with array headers", () => {
+      expect(
+        isVoiceMediaSocketMessage({ ...message(), headers: ["websocket"] }),
+      ).toBe(false);
+    });
+
+    it("rejects a message with a non-string, non-array header value", () => {
+      expect(
+        isVoiceMediaSocketMessage({
+          ...message(),
+          headers: { upgrade: 42 },
+        }),
+      ).toBe(false);
+    });
+  });
+
+  describe("when the message is well-formed", () => {
+    it("accepts it", () => {
+      expect(isVoiceMediaSocketMessage(message())).toBe(true);
+    });
+  });
 });
 
 describe("createVoiceSocketReceiver", () => {

--- a/platform/app/src/server/scenarios/voice/voice-socket-handoff.ts
+++ b/platform/app/src/server/scenarios/voice/voice-socket-handoff.ts
@@ -45,14 +45,40 @@ export interface VoiceMediaSocketMessage {
   headBase64: string;
 }
 
-/** Narrows an arbitrary IPC message to the voice handoff message. */
+/** True when every header value is a string, a string array, or undefined. */
+function isVoiceMediaSocketHeaders(
+  value: unknown,
+): value is Record<string, string | string[] | undefined> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+  return Object.values(value).every(
+    (headerValue) =>
+      typeof headerValue === "string" ||
+      headerValue === undefined ||
+      (Array.isArray(headerValue) &&
+        headerValue.every((entry) => typeof entry === "string")),
+  );
+}
+
+/**
+ * Narrows an arbitrary IPC message to the voice handoff message. Validates
+ * every required field, not just the discriminator - a message with the right
+ * `type` but a missing or malformed `headBase64` would otherwise reach
+ * `Buffer.from`, which throws and can kill the scenario child.
+ */
 export function isVoiceMediaSocketMessage(
   message: unknown,
 ): message is VoiceMediaSocketMessage {
+  if (typeof message !== "object" || message === null) return false;
+  const candidate = message as Record<string, unknown>;
   return (
-    typeof message === "object" &&
-    message !== null &&
-    (message as { type?: unknown }).type === VOICE_MEDIA_SOCKET_MESSAGE
+    candidate.type === VOICE_MEDIA_SOCKET_MESSAGE &&
+    typeof candidate.nonce === "string" &&
+    typeof candidate.url === "string" &&
+    typeof candidate.method === "string" &&
+    typeof candidate.headBase64 === "string" &&
+    isVoiceMediaSocketHeaders(candidate.headers)
   );
 }
 

--- a/platform/app/src/server/workers/__tests__/voice-ws-listener.childprocess.unit.test.ts
+++ b/platform/app/src/server/workers/__tests__/voice-ws-listener.childprocess.unit.test.ts
@@ -27,10 +27,15 @@ const silentLogger = {
  * `exit` or `error` so a dead child hangs the wait until the Vitest timeout
  * instead of failing loud. Removes every listener it attached once settled.
  */
-function waitForChildMessage<T>(
-  child: ChildProcess,
-  matches: (message: T) => boolean,
-): Promise<T> {
+interface WaitForChildMessageOptions<T> {
+  child: ChildProcess;
+  matches: (message: T) => boolean;
+}
+
+function waitForChildMessage<T>({
+  child,
+  matches,
+}: WaitForChildMessageOptions<T>): Promise<T> {
   return new Promise<T>((resolve, reject) => {
     const onMessage = (message: T): void => {
       if (matches(message)) {
@@ -92,10 +97,10 @@ describe("voice media socket handoff to a real child process", () => {
     });
     const theChild = child;
 
-    await waitForChildMessage<{ ready?: boolean }>(
-      theChild,
-      (msg) => !!msg.ready,
-    );
+    await waitForChildMessage<{ ready?: boolean }>({
+      child: theChild,
+      matches: (msg) => !!msg.ready,
+    });
 
     const registry = new VoiceNonceRegistry();
     listener = await bootVoiceWsListener({
@@ -111,7 +116,7 @@ describe("voice media socket handoff to a real child process", () => {
       received?: boolean;
       nonce: string;
       head: string;
-    }>(theChild, (msg) => !!msg.received);
+    }>({ child: theChild, matches: (msg) => !!msg.received });
 
     // Write the upgrade request plus extra bytes after the header block, so
     // the head buffer the child must receive is non-empty.

--- a/platform/app/src/server/workers/__tests__/voice-ws-listener.childprocess.unit.test.ts
+++ b/platform/app/src/server/workers/__tests__/voice-ws-listener.childprocess.unit.test.ts
@@ -22,6 +22,45 @@ const silentLogger = {
   error: () => undefined,
 } as unknown as Logger;
 
+/**
+ * Wait for one IPC message matching `matches`, but also reject on an early
+ * `exit` or `error` so a dead child hangs the wait until the Vitest timeout
+ * instead of failing loud. Removes every listener it attached once settled.
+ */
+function waitForChildMessage<T>(
+  child: ChildProcess,
+  matches: (message: T) => boolean,
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const onMessage = (message: T): void => {
+      if (matches(message)) {
+        cleanup();
+        resolve(message);
+      }
+    };
+    const onExit = (code: number | null, signal: string | null): void => {
+      cleanup();
+      reject(
+        new Error(
+          `child exited before sending the expected message (code=${code}, signal=${signal})`,
+        ),
+      );
+    };
+    const onError = (error: Error): void => {
+      cleanup();
+      reject(error);
+    };
+    const cleanup = (): void => {
+      child.off("message", onMessage);
+      child.off("exit", onExit);
+      child.off("error", onError);
+    };
+    child.on("message", onMessage);
+    child.on("exit", onExit);
+    child.on("error", onError);
+  });
+}
+
 // A minimal child that installs the receiver shape by hand (the real receiver
 // lives in TS the child cannot import), reads the head, and reports back.
 const CHILD_SOURCE = `
@@ -53,12 +92,10 @@ describe("voice media socket handoff to a real child process", () => {
     });
     const theChild = child;
 
-    await new Promise<void>((resolve, reject) => {
-      theChild.once("error", reject);
-      theChild.on("message", (msg: { ready?: boolean }) => {
-        if (msg.ready) resolve();
-      });
-    });
+    await waitForChildMessage<{ ready?: boolean }>(
+      theChild,
+      (msg) => !!msg.ready,
+    );
 
     const registry = new VoiceNonceRegistry();
     listener = await bootVoiceWsListener({
@@ -70,14 +107,11 @@ describe("voice media socket handoff to a real child process", () => {
     const port = (listener.address as AddressInfo).port;
     registry.register({ nonce: "handoff", child: theChild });
 
-    const received = new Promise<{ nonce: string; head: string }>((resolve) => {
-      theChild.on(
-        "message",
-        (msg: { received?: boolean; nonce: string; head: string }) => {
-          if (msg.received) resolve({ nonce: msg.nonce, head: msg.head });
-        },
-      );
-    });
+    const received = waitForChildMessage<{
+      received?: boolean;
+      nonce: string;
+      head: string;
+    }>(theChild, (msg) => !!msg.received);
 
     // Write the upgrade request plus extra bytes after the header block, so
     // the head buffer the child must receive is non-empty.

--- a/platform/app/src/server/workers/__tests__/voice-ws-listener.unit.test.ts
+++ b/platform/app/src/server/workers/__tests__/voice-ws-listener.unit.test.ts
@@ -149,7 +149,7 @@ describe("bootVoiceWsListener", () => {
   it("closes an upgrade on a non-media path with 404", async () => {
     const port = await boot();
     const { statusLine, socket } = await rawUpgrade(port, "/not-twilio");
-    expect(statusLine).toContain("404");
+    expect(statusLine).toBe("HTTP/1.1 404 Not Found");
     socket.destroy();
   });
 
@@ -157,7 +157,7 @@ describe("bootVoiceWsListener", () => {
   it("closes an upgrade with an unknown nonce with 403", async () => {
     const port = await boot();
     const { statusLine, socket } = await rawUpgrade(port, "/twilio/unknown");
-    expect(statusLine).toContain("403");
+    expect(statusLine).toBe("HTTP/1.1 403 Forbidden");
     socket.destroy();
   });
 

--- a/platform/app/src/server/workers/voice-ws-listener.ts
+++ b/platform/app/src/server/workers/voice-ws-listener.ts
@@ -94,13 +94,15 @@ export function routeVoiceUpgrade(params: {
   return { action: "handoff", nonce, child: lookup.child };
 }
 
-/** Write a bare HTTP status line to a pre-handshake socket and close it. */
+/**
+ * Write a bare HTTP status line to a pre-handshake socket, then end it. Uses
+ * `socket.end` rather than a `write` followed by `destroy` - destroy can tear
+ * the socket down before the write flushes, so the client would see a
+ * connection reset instead of the intended status.
+ */
 function refuseSocket(socket: Duplex, status: 404 | 403): void {
   const reasonPhrase = status === 404 ? "Not Found" : "Forbidden";
-  socket.write(
-    `HTTP/1.1 ${status} ${reasonPhrase}\r\nConnection: close\r\n\r\n`,
-  );
-  socket.destroy();
+  socket.end(`HTTP/1.1 ${status} ${reasonPhrase}\r\nConnection: close\r\n\r\n`);
 }
 
 /** The plain-HTTP handler: 200 at the liveness path, 404 for everything else. */


### PR DESCRIPTION
Follow-up to #8053, which merged with five unresolved review threads. Each is fixed here against `main`.

### What changed

| Thread | File | Fix |
| --- | --- | --- |
| Validate the IPC message before narrowing | `voice-socket-handoff.ts` | The guard checked only the `type` discriminator, so a message carrying the right discriminator but missing `headBase64` passed it and then threw inside `Buffer.from` in the receiver, which can take down the scenario child. It now validates every required string field and the `headers` record, including that each header value is a string, an array of strings, or undefined. |
| Flush before closing | `voice-ws-listener.ts` | `refuseSocket` wrote the status line and immediately destroyed the socket, so a refused upgrade could see a connection reset instead of its 403 or 404. It now uses `socket.end(response)`. |
| Reject the IPC waits on child exit | `voice-ws-listener.childprocess.unit.test.ts` | Both waits resolved only on a matching message, so a child that died early hung the test until the Vitest timeout and hid the real cause. A shared helper now rejects on `exit` with the code and signal, rejects on `error`, and removes its listeners once settled. |
| Boolean naming | `voice-worker-env.ts`, `worker-boot-plan.ts`, `startWorkers.ts` | Renamed `voiceWorkerOnly` to `isVoiceWorkerOnly` at every call site and in the tests. The `VOICE_WORKER_ONLY` environment variable name is unchanged. |
| Redundant comment | `voice-nonce-registry.unit.test.ts` | Removed a comment that restated the assertion below it. |

### Tests

New cases in `voice-socket-handoff.unit.test.ts` prove the widened guard rejects a message with the correct discriminator but a missing `headBase64`, a non-string `nonce`, null headers, array headers, and a numeric header value, plus one case proving a well-formed message is still accepted so the guard is not vacuously false. The two refusal tests in `voice-ws-listener.unit.test.ts` now assert the exact status line rather than a substring.

Local run of the touched suites: 23 files, 200 tests, all passing. Biome clean.

### Not covered here

This does not wire slice 2's dial path to slice 3's media listener. Slice 3 remains inert infrastructure that only boots under `VOICE_WORKER_ONLY`. That wiring needs two new seams in the scenario SDK and is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Session: https://claude.ai/code/session_01E92pTLjgaeGS6jZX3WVrpm


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation of voice handoff messages to reject malformed or incomplete data.
  - Voice WebSocket rejection responses now close connections more cleanly.
  - Verified accurate HTTP status responses for unsupported requests and unknown nonces.

- **Tests**
  - Added coverage for valid and invalid voice handoff messages.
  - Improved reliability of child-process communication tests and message handling assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->