### PR TITLE
feat(voice): show the phone option as disabled instead of hiding it

### DIFF
--- a/platform/app/src/components/agents/AgentVoiceEditorDrawer.tsx
+++ b/platform/app/src/components/agents/AgentVoiceEditorDrawer.tsx
@@ -901,21 +901,29 @@ function VoiceAgentTalkView({
 }
 
 /**
- * The transports offered in the "Reached via" select. Phone stays hidden until
- * the project has a Twilio provider in Settings > Model Providers, but an agent
- * already configured as phone still lists it so its own transport renders (the
- * gate is on the OPTION, not on an existing target).
+ * The transports offered in the "Reached via" select. Every transport is
+ * always rendered as an option; phone is disabled and labelled "Unavailable"
+ * until the project has a Twilio provider in Settings > Model Providers, but
+ * an agent already configured as phone keeps its own transport selectable
+ * (the gate is on the OPTION, not on an existing target).
  */
-function visibleTransportsFor({
+function transportOptionsFor({
   hasTwilioKey,
   transport,
 }: {
   hasTwilioKey: boolean;
   transport: VoiceTransport;
-}): readonly VoiceTransport[] {
-  return VOICE_TRANSPORTS.filter(
-    (t) => t !== "phone" || hasTwilioKey || transport === "phone",
-  );
+}): readonly { value: VoiceTransport; label: string; disabled: boolean }[] {
+  return VOICE_TRANSPORTS.map((t) => {
+    const disabled = t === "phone" && !hasTwilioKey && transport !== "phone";
+    return {
+      value: t,
+      label: disabled
+        ? `${VOICE_TRANSPORT_LABELS[t]} (Unavailable)`
+        : VOICE_TRANSPORT_LABELS[t],
+      disabled,
+    };
+  });
 }
 
 function VoiceAgentForm({
@@ -949,11 +957,10 @@ function VoiceAgentForm({
   const phoneNumberInvalid =
     hasAttemptedSubmit && !E164_PHONE_PATTERN.test(phoneNumber.trim());
   const isPhone = transport === "phone";
-  const visibleTransports = visibleTransportsFor({
+  const transportOptions = transportOptionsFor({
     hasTwilioKey,
     transport,
   });
-  const transportOptionsDisabled = visibleTransports.length <= 1;
   return (
     <VStack
       gap={4}
@@ -976,15 +983,15 @@ function VoiceAgentForm({
 
       <Field.Root>
         <Field.Label>Reached via</Field.Label>
-        <NativeSelect.Root disabled={transportOptionsDisabled}>
+        <NativeSelect.Root>
           <NativeSelect.Field
             value={transport}
             onChange={(e) => setTransport(e.target.value as VoiceTransport)}
             data-testid="voice-agent-transport-select"
           >
-            {visibleTransports.map((t) => (
-              <option key={t} value={t}>
-                {VOICE_TRANSPORT_LABELS[t]}
+            {transportOptions.map((o) => (
+              <option key={o.value} value={o.value} disabled={o.disabled}>
+                {o.label}
               </option>
             ))}
           </NativeSelect.Field>
@@ -992,8 +999,16 @@ function VoiceAgentForm({
         </NativeSelect.Root>
         {!hasTwilioKey && !isPhone && (
           <Field.HelperText data-testid="voice-agent-phone-hint">
-            To reach an agent by phone, add Twilio in Settings &gt; Model
-            Providers.
+            To reach an agent by phone, add Twilio in Settings &gt;{" "}
+            <Link
+              href="/settings/model-providers"
+              target="_blank"
+              rel="noopener noreferrer"
+              data-testid="voice-agent-model-providers-link"
+            >
+              Model Providers
+            </Link>
+            .
           </Field.HelperText>
         )}
       </Field.Root>

--- a/platform/app/src/components/agents/__tests__/AgentVoiceEditorDrawer.integration.test.tsx
+++ b/platform/app/src/components/agents/__tests__/AgentVoiceEditorDrawer.integration.test.tsx
@@ -198,35 +198,46 @@ describe("AgentVoiceEditorDrawer", () => {
   });
 
   describe("given a Twilio provider gates the Phone number option", () => {
-    /** @scenario "The Phone number option appears only when a Twilio provider is configured" */
-    it("hides the option with a hint when no Twilio provider, and offers it once one exists", async () => {
+    /** @scenario "The Phone number option is always listed, disabled and marked Unavailable without a Twilio provider" */
+    it("lists the option disabled with a hint when no Twilio provider, and enables it once one exists", async () => {
       mockProviders = [];
       const { unmount } = renderVoiceDrawer();
       await screen.findByTestId("voice-agent-transport-select");
-      expect(
-        screen.queryByRole("option", { name: "Phone number" }),
-      ).not.toBeInTheDocument();
+      const disabledOption = screen.getByRole("option", {
+        name: /Phone number/,
+      }) as HTMLOptionElement;
+      expect(disabledOption).toBeDisabled();
+      expect(disabledOption.textContent).toContain("(Unavailable)");
       expect(screen.getByTestId("voice-agent-phone-hint")).toBeInTheDocument();
+      const link = screen.getByTestId("voice-agent-model-providers-link");
+      expect(link).toBeInTheDocument();
+      expect(link).toHaveAttribute("href", "/settings/model-providers");
+      expect(link).toHaveAttribute("target", "_blank");
+      expect(link.getAttribute("rel")).toContain("noopener");
       unmount();
 
       mockProviders = [TWILIO_KEYED_PROVIDER];
       renderVoiceDrawer();
       await screen.findByTestId("voice-agent-transport-select");
-      expect(
-        screen.getByRole("option", { name: "Phone number" }),
-      ).toBeInTheDocument();
+      const enabledOption = screen.getByRole("option", {
+        name: "Phone number",
+      }) as HTMLOptionElement;
+      expect(enabledOption).not.toBeDisabled();
+      expect(enabledOption.textContent).not.toContain("(Unavailable)");
       expect(
         screen.queryByTestId("voice-agent-phone-hint"),
       ).not.toBeInTheDocument();
     });
 
-    it("keeps the option hidden when the only Twilio row is an env-fed system row missing the other two keys", async () => {
+    it("keeps the option disabled when the only Twilio row is an env-fed system row missing the other two keys", async () => {
       mockProviders = [TWILIO_SYSTEM_ROW_MISSING_KEYS];
       renderVoiceDrawer();
       await screen.findByTestId("voice-agent-transport-select");
-      expect(
-        screen.queryByRole("option", { name: "Phone number" }),
-      ).not.toBeInTheDocument();
+      const option = screen.getByRole("option", {
+        name: /Phone number/,
+      }) as HTMLOptionElement;
+      expect(option).toBeDisabled();
+      expect(option.textContent).toContain("(Unavailable)");
       expect(screen.getByTestId("voice-agent-phone-hint")).toBeInTheDocument();
     });
 
@@ -242,9 +253,11 @@ describe("AgentVoiceEditorDrawer", () => {
         "voice-agent-phone-input",
       )) as HTMLInputElement;
       expect(input.value).toBe("+14155550123");
-      expect(
-        screen.getByRole("option", { name: "Phone number" }),
-      ).toBeInTheDocument();
+      const option = screen.getByRole("option", {
+        name: "Phone number",
+      }) as HTMLOptionElement;
+      expect(option).toBeInTheDocument();
+      expect(option).not.toBeDisabled();
     });
 
     it("never persists the typed phone number in the sessionStorage draft", async () => {

--- a/specs/features/agents/voice-phone.feature
+++ b/specs/features/agents/voice-phone.feature
@@ -143,11 +143,11 @@ Feature: Voice agents: reach an agent by phone
   # ---------------------------------------------------------------------------
 
   @integration
-  Scenario: The Phone number option appears only when a Twilio provider is configured
+  Scenario: The Phone number option is always listed, disabled and marked Unavailable without a Twilio provider
     Given the voice agent editor with no Twilio provider in the project
-    Then the "Reached via" list offers no Phone number option, and a hint points at Settings > Model Providers
+    Then the "Reached via" list offers a disabled Phone number (Unavailable) option, and a hint links to Settings > Model Providers that opens in a new tab
     When the project has a Twilio provider
-    Then the "Reached via" list offers the Phone number option
+    Then the "Reached via" list offers the Phone number option enabled
 
   @integration
   Scenario: A phone target's drawer explains why Talk to it is off


### PR DESCRIPTION
## What

In the voice agent editor's "Reached via" select, the Phone number option was **hidden** when the project had no Twilio provider. Two changes:

1. The option is **always listed**. Without a Twilio provider it is `disabled` and labelled **"Phone number (Unavailable)"**, so the capability is discoverable rather than invisible.
2. "Model Providers" in the helper text is now a **link that opens in a new tab** (`/settings/model-providers`, `target="_blank"`, `rel="noopener noreferrer"`), so the drawer and its unsaved draft stay put while someone adds Twilio.

An agent already configured as phone keeps its own transport selectable — the same carve-out the old filter had.

## Proof

- `AgentVoiceEditorDrawer.integration.test.tsx`: **16 tests pass** under `vitest.component.config.ts`. The assertions have teeth — they check the option element is actually `toBeDisabled()`, that its text contains `(Unavailable)`, that the link carries the exact `href`/`target`/`rel`, and that with a keyed Twilio provider the option is **not** disabled and carries no `(Unavailable)` text.
- Spec parity: `check-feature-parity.ts` reports **OK, 12547 enforced scenarios bound**. The bound scenario in `specs/features/agents/voice-phone.feature` was rewritten to describe the new behaviour and its `@scenario` annotation updated to match.
- Biome clean on both changed TypeScript files.

## Spec change

`specs/features/agents/voice-phone.feature` scenario renamed from *"The Phone number option appears only when a Twilio provider is configured"* to *"The Phone number option is always listed, disabled and marked Unavailable without a Twilio provider"*, with its steps rewritten to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E92pTLjgaeGS6jZX3WVrpm


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The “Phone number” option is now always visible in the “Reached via” menu.
  * When phone calling is unavailable, the option is clearly marked and disabled, with a link to Model Providers settings.
  * The option becomes enabled when a supported provider is configured.
  * The settings link opens in a new tab.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->