### PR TITLE
refactor(scenarios): one helper for best-effort recorders

### DIFF
--- a/platform/app/src/server/scenarios/__tests__/scenario-processor-record-best-effort.unit.test.ts
+++ b/platform/app/src/server/scenarios/__tests__/scenario-processor-record-best-effort.unit.test.ts
@@ -1,0 +1,35 @@
+/**
+ * The one try/catch/log shape shared by every post-exit recorder: a throwing
+ * recorder is logged with the run and project ids and never fails the job
+ * (#8029).
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import { recordBestEffort } from "../scenario.processor";
+
+const JOB = {
+  projectId: "proj_123",
+  scenarioRunId: "scenariorun_test123",
+};
+
+describe("recordBestEffort", () => {
+  describe("given a recorder that succeeds", () => {
+    it("runs it once and resolves", async () => {
+      const record = vi.fn().mockResolvedValue(undefined);
+
+      await recordBestEffort({ what: "a detail", jobData: JOB, record });
+
+      expect(record).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("given a recorder that throws", () => {
+    it("swallows the failure so the completed job is never lost", async () => {
+      const record = vi.fn().mockRejectedValue(new Error("side channel down"));
+
+      await expect(
+        recordBestEffort({ what: "a detail", jobData: JOB, record }),
+      ).resolves.toBeUndefined();
+    });
+  });
+});

--- a/platform/app/src/server/scenarios/scenario.processor.ts
+++ b/platform/app/src/server/scenarios/scenario.processor.ts
@@ -164,32 +164,57 @@ export async function handleSucceededJobResult({
   deps: ProcessorDependencies;
 }): Promise<void> {
   if (result.agentInstance) {
-    try {
-      await deps.agentInstanceRecorder.recordAgentInstance({
-        projectId: jobData.projectId,
-        scenarioRunId: jobData.scenarioRunId,
-        agentInstance: result.agentInstance,
-      });
-    } catch (err) {
-      logger.warn(
-        { err, scenarioRunId: jobData.scenarioRunId },
-        "Could not record the agent instance that served the run",
-      );
-    }
+    const agentInstance = result.agentInstance;
+    await recordBestEffort({
+      what: "the agent instance that served the run",
+      jobData,
+      record: () =>
+        deps.agentInstanceRecorder.recordAgentInstance({
+          projectId: jobData.projectId,
+          scenarioRunId: jobData.scenarioRunId,
+          agentInstance,
+        }),
+    });
   }
 
   if (result.isCutAtLimit) {
-    try {
-      await deps.cutAtLimitRecorder.recordCutAtLimit({
-        projectId: jobData.projectId,
+    await recordBestEffort({
+      what: "that the run was cut at the call limit",
+      jobData,
+      record: () =>
+        deps.cutAtLimitRecorder.recordCutAtLimit({
+          projectId: jobData.projectId,
+          scenarioRunId: jobData.scenarioRunId,
+        }),
+    });
+  }
+}
+
+/**
+ * Run one best-effort recorder: a throwing recorder is logged with the run
+ * and project ids and swallowed, so a side-channel write can never fail a
+ * job that already ran to the end (#8029).
+ */
+export async function recordBestEffort({
+  what,
+  jobData,
+  record,
+}: {
+  what: string;
+  jobData: Pick<ExecutionJobData, "projectId" | "scenarioRunId">;
+  record: () => Promise<unknown>;
+}): Promise<void> {
+  try {
+    await record();
+  } catch (err) {
+    logger.warn(
+      {
+        err,
         scenarioRunId: jobData.scenarioRunId,
-      });
-    } catch (err) {
-      logger.warn(
-        { err, scenarioRunId: jobData.scenarioRunId },
-        "Could not record that the run was cut at the call limit",
-      );
-    }
+        projectId: jobData.projectId,
+      },
+      `Could not record ${what}`,
+    );
   }
 }
 


### PR DESCRIPTION
## Problem

`handleSucceededJobResult` carries two near-identical best-effort blocks (agent-instance recorder and cut-at-limit recorder, #8021): each is a try/catch that logs and swallows so the run's success is never lost to a side-channel write. A third recorder would copy the block again.

Fixes #8029

## Changes

- New `recordBestEffort({ what, jobData, record })` owns the try/catch/log shape once; both existing recorders call it (AC1)
- Behavior unchanged: a throwing recorder is logged and does not fail the job — log messages are byte-identical, and the log context now carries the project id alongside the run id, per the acceptance criteria (AC2)
- All 1277 existing scenario unit tests pass without modification; the helper has its own two tests (AC3)

## Testing

- `src/server/scenarios` unit suites: 92 files, 1277 tests passed before adding the helper test; 8/8 on the touched test files after

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when recording agent-instance and call-limit results after successful jobs.
  - Recording failures are now handled without interrupting job result processing, while retaining warning logs with relevant context.

- **Tests**
  - Added coverage for successful recording, rejected recording operations, and ensuring each recorder runs only once.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->