### PR TITLE
fix(governance): bound and pin the five Costs spend reads

### DIFF
--- a/platform/app/ee/governance/services/activity-monitor/__tests__/activityMonitor.clickhouse.repository.unit.test.ts
+++ b/platform/app/ee/governance/services/activity-monitor/__tests__/activityMonitor.clickhouse.repository.unit.test.ts
@@ -37,6 +37,7 @@ describe("ActivityMonitorClickHouseRepository", () => {
         tenantId: "t",
         thisStart: 0,
         prevStart: 0,
+        windowEnd: Date.now(),
       });
 
       expect(row).toEqual({ thisSpend: 1.5, prevSpend: 0.75, thisUsers: 3 });
@@ -106,6 +107,7 @@ describe("ActivityMonitorClickHouseRepository", () => {
         tenantId: "t",
         thisStart: 0,
         prevStart: 0,
+        windowEnd: Date.now(),
       });
 
       expect(row).toEqual({ thisSpend: 0, prevSpend: 0, thisUsers: 0 });
@@ -125,6 +127,7 @@ describe("ActivityMonitorClickHouseRepository", () => {
       const rows = await repo.findSpendByUser({
         tenantId: "t",
         windowStart: 0,
+        windowEnd: Date.now(),
         sortBy: "spend",
         sortDir: "desc",
         limit: 50,
@@ -156,6 +159,7 @@ describe("ActivityMonitorClickHouseRepository", () => {
         tenantId: "t",
         thisStart: 0,
         prevStart: 0,
+        windowEnd: Date.now(),
       });
 
       expect(row).toEqual({ thisSpend: 0, prevSpend: 0, thisUsers: 0 });
@@ -187,6 +191,7 @@ describe("ActivityMonitorClickHouseRepository", () => {
         tenantId: "t",
         thisStart: 0,
         prevStart: 0,
+        windowEnd: Date.now(),
       });
       expect(row).toEqual({ thisSpend: 0, prevSpend: 0, thisUsers: 0 });
     });
@@ -204,6 +209,7 @@ describe("ActivityMonitorClickHouseRepository", () => {
         repo.findSpendByUser({
           tenantId: "t",
           windowStart: 0,
+          windowEnd: Date.now(),
           sortBy: "spend",
           sortDir: "desc",
           limit: 50,
@@ -221,6 +227,7 @@ describe("ActivityMonitorClickHouseRepository", () => {
         tenantId: "t",
         thisStart: 0,
         prevStart: 0,
+        windowEnd: Date.now(),
       });
 
       // .finite().catch(0) rejects NaN/Infinity → defaults to 0
@@ -291,6 +298,7 @@ describe("ActivityMonitorClickHouseRepository", () => {
       const rows = await repo.findSpendByUser({
         tenantId: "t",
         windowStart: 0,
+        windowEnd: Date.now(),
         sortBy: "spend",
         sortDir: "desc",
         limit: 50,
@@ -336,6 +344,7 @@ describe("ActivityMonitorClickHouseRepository", () => {
       const rows = await repo.findSpendOverTime({
         tenantId: "t",
         windowStart: 0,
+        windowEnd: Date.now(),
         groupBy: "team",
       });
 

--- a/platform/app/ee/governance/services/activity-monitor/__tests__/activityMonitorSpendQueryBounds.unit.test.ts
+++ b/platform/app/ee/governance/services/activity-monitor/__tests__/activityMonitorSpendQueryBounds.unit.test.ts
@@ -23,8 +23,8 @@
  * because the two halves are filtered independently — see the same
  * both-halves treatment in aggregation-builder.ts:137.
  *
- * These reads also carry no ClickHouse settings, so a single wide scan has no
- * ceiling on threads or runtime. Storage metering already pins both
+ * These reads previously carried no ClickHouse settings, so a single wide scan
+ * had no ceiling on threads or runtime. Storage metering already pinned both
  * (storageMeter.service.ts:63-67).
  *
  * Each test drives the real repository through its production constructor
@@ -75,7 +75,7 @@ const READS: Array<{
         thisStart: WINDOW_START,
         prevStart: WINDOW_START,
         windowEnd: WINDOW_END,
-      } as never),
+      }),
   },
   {
     name: "findSpendByUser",
@@ -88,7 +88,7 @@ const READS: Array<{
         sortDir: "desc",
         limit: 8,
         offset: 0,
-      } as never),
+      }),
   },
   {
     name: "findSpendByDepartment",
@@ -97,7 +97,7 @@ const READS: Array<{
         tenantIds: ["tenant-a", "tenant-b"],
         windowStart: WINDOW_START,
         windowEnd: WINDOW_END,
-      } as never),
+      }),
   },
   {
     name: "findSpendByTeamSource",
@@ -107,7 +107,7 @@ const READS: Array<{
         thisStart: WINDOW_START,
         prevStart: WINDOW_START,
         windowEnd: WINDOW_END,
-      } as never),
+      }),
   },
   {
     name: "findSpendOverTime",
@@ -117,7 +117,7 @@ const READS: Array<{
         windowStart: WINDOW_START,
         windowEnd: WINDOW_END,
         groupBy: "team",
-      } as never),
+      }),
   },
 ];
 

--- a/platform/app/ee/governance/services/activity-monitor/__tests__/activityMonitorSpendQueryBounds.unit.test.ts
+++ b/platform/app/ee/governance/services/activity-monitor/__tests__/activityMonitorSpendQueryBounds.unit.test.ts
@@ -35,6 +35,11 @@ import { describe, expect, it, vi } from "vitest";
 
 import { ActivityMonitorSpendClickHouseRepository } from "../activityMonitor.spend.clickhouse.repository";
 
+/**
+ * Builds the real repository over a mock ClickHouse client, so the assertions
+ * run against the SQL production would actually send rather than a stub.
+ * Returns the repository and the query spy that captured the call.
+ */
 function makeRepo() {
   const query = vi.fn(async () => ({
     json: async () => [] as unknown[],
@@ -50,6 +55,10 @@ type CapturedCall = {
   clickhouse_settings?: Record<string, unknown>;
 };
 
+/**
+ * Pulls the first call handed to the mock client, which is the SQL, bound
+ * parameters and ClickHouse settings the read issued.
+ */
 function captured(query: { mock: { calls: unknown[][] } }): CapturedCall {
   const first = query.mock.calls[0]?.[0];
   return first as CapturedCall;
@@ -158,10 +167,11 @@ describe("ActivityMonitorSpendClickHouseRepository query bounds", () => {
 
         const call = captured(query);
         expect(call.clickhouse_settings).toBeDefined();
-        expect(typeof call.clickhouse_settings?.max_execution_time).toBe(
-          "number",
-        );
-        expect(typeof call.clickhouse_settings?.max_threads).toBe("number");
+        // Exact values, not just "a number": the point of this test is to lock
+        // the guardrail, so weakening either limit must fail here and be a
+        // deliberate edit to both the constant and this line.
+        expect(call.clickhouse_settings?.max_execution_time).toBe(45);
+        expect(call.clickhouse_settings?.max_threads).toBe(2);
       });
     }
   });

--- a/platform/app/ee/governance/services/activity-monitor/__tests__/activityMonitorSpendQueryBounds.unit.test.ts
+++ b/platform/app/ee/governance/services/activity-monitor/__tests__/activityMonitorSpendQueryBounds.unit.test.ts
@@ -131,7 +131,7 @@ const READS: Array<{
 ];
 
 describe("ActivityMonitorSpendClickHouseRepository query bounds", () => {
-  describe("when a spend read is issued (#8072 step 2: open upper bound)", () => {
+  describe("when a spend read is issued (#8072 step 2: closed upper bound)", () => {
     for (const read of READS) {
       it(`${read.name} binds the upper end of the time range`, async () => {
         const { repo, query } = makeRepo();
@@ -158,7 +158,7 @@ describe("ActivityMonitorSpendClickHouseRepository query bounds", () => {
     }
   });
 
-  describe("when a spend read is issued (#8072 step 3: no query ceiling)", () => {
+  describe("when a spend read is issued (#8072 step 3: query execution ceiling)", () => {
     for (const read of READS) {
       it(`${read.name} caps execution time and thread count`, async () => {
         const { repo, query } = makeRepo();

--- a/platform/app/ee/governance/services/activity-monitor/__tests__/activityMonitorSpendQueryBounds.unit.test.ts
+++ b/platform/app/ee/governance/services/activity-monitor/__tests__/activityMonitorSpendQueryBounds.unit.test.ts
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+
+/**
+ * Regression test for langwatch/langwatch#8072 steps 2 and 3.
+ *
+ * Every spend read in this repository filters `OccurredAt` with a floor and
+ * no ceiling.
+ *
+ * The ceiling is NOT here for partition pruning. `trace_summaries` is
+ * `PARTITION BY toYearWeek(OccurredAt)` (migrations/00002_create_schema.sql:179)
+ * and the existing floor already prunes the old side; bounding the top at
+ * `now` prunes little, because few or no partitions sit above `now` — the
+ * clock-skew rows in (2) below being the exception, and exactly the data the
+ * bound removes. The ceiling is here for two other reasons:
+ *
+ *   1. Determinism. An open-ended read answers differently on every call, so
+ *      its result cannot be cached under a stable key. A closed range is the
+ *      prerequisite for the caching work in #8072 step 1, which is deferred.
+ *   2. Clock skew. Rows landing with `OccurredAt` in the future are counted
+ *      today and should not be.
+ *
+ * The bound goes into the inner dedup subquery as well as the outer query
+ * because the two halves are filtered independently — see the same
+ * both-halves treatment in aggregation-builder.ts:137.
+ *
+ * These reads also carry no ClickHouse settings, so a single wide scan has no
+ * ceiling on threads or runtime. Storage metering already pins both
+ * (storageMeter.service.ts:63-67).
+ *
+ * Each test drives the real repository through its production constructor
+ * contract with a mock client, then asserts on the SQL that was actually
+ * handed to ClickHouse.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import { ActivityMonitorSpendClickHouseRepository } from "../activityMonitor.spend.clickhouse.repository";
+
+function makeRepo() {
+  const query = vi.fn(async () => ({
+    json: async () => [] as unknown[],
+  }));
+  const ch = { query } as never;
+  const repo = new ActivityMonitorSpendClickHouseRepository(async () => ch);
+  return { repo, query };
+}
+
+type CapturedCall = {
+  query: string;
+  query_params: Record<string, unknown>;
+  clickhouse_settings?: Record<string, unknown>;
+};
+
+function captured(query: { mock: { calls: unknown[][] } }): CapturedCall {
+  const first = query.mock.calls[0]?.[0];
+  return first as CapturedCall;
+}
+
+const WINDOW_START = Date.UTC(2026, 0, 1);
+const WINDOW_END = Date.UTC(2026, 1, 1);
+
+/**
+ * Each entry drives one read to completion and hands back the SQL it sent.
+ * Keeping them in one table means a sixth read added later without a bound
+ * fails here rather than shipping unbounded.
+ */
+const READS: Array<{
+  name: string;
+  run: (repo: ActivityMonitorSpendClickHouseRepository) => Promise<unknown>;
+}> = [
+  {
+    name: "findSummarySpend",
+    run: (repo) =>
+      repo.findSummarySpend({
+        tenantId: "tenant-a",
+        thisStart: WINDOW_START,
+        prevStart: WINDOW_START,
+        windowEnd: WINDOW_END,
+      } as never),
+  },
+  {
+    name: "findSpendByUser",
+    run: (repo) =>
+      repo.findSpendByUser({
+        tenantId: "tenant-a",
+        windowStart: WINDOW_START,
+        windowEnd: WINDOW_END,
+        sortBy: "spend",
+        sortDir: "desc",
+        limit: 8,
+        offset: 0,
+      } as never),
+  },
+  {
+    name: "findSpendByDepartment",
+    run: (repo) =>
+      repo.findSpendByDepartment({
+        tenantIds: ["tenant-a", "tenant-b"],
+        windowStart: WINDOW_START,
+        windowEnd: WINDOW_END,
+      } as never),
+  },
+  {
+    name: "findSpendByTeamSource",
+    run: (repo) =>
+      repo.findSpendByTeamSource({
+        tenantId: "tenant-a",
+        thisStart: WINDOW_START,
+        prevStart: WINDOW_START,
+        windowEnd: WINDOW_END,
+      } as never),
+  },
+  {
+    name: "findSpendOverTime",
+    run: (repo) =>
+      repo.findSpendOverTime({
+        tenantId: "tenant-a",
+        windowStart: WINDOW_START,
+        windowEnd: WINDOW_END,
+        groupBy: "team",
+      } as never),
+  },
+];
+
+describe("ActivityMonitorSpendClickHouseRepository query bounds", () => {
+  describe("when a spend read is issued (#8072 step 2: open upper bound)", () => {
+    for (const read of READS) {
+      it(`${read.name} binds the upper end of the time range`, async () => {
+        const { repo, query } = makeRepo();
+
+        await read.run(repo);
+
+        const call = captured(query);
+        expect(call.query_params).toHaveProperty("windowEnd");
+        expect(call.query_params.windowEnd).toBe(WINDOW_END);
+      });
+
+      it(`${read.name} pushes the upper bound into the dedup subquery too`, async () => {
+        const { repo, query } = makeRepo();
+
+        await read.run(repo);
+
+        // Outer query and inner dedup subquery must BOTH carry the ceiling,
+        // otherwise the subquery still scans every partition to the present
+        // and the outer bound prunes nothing.
+        const call = captured(query);
+        const occurrences = call.query.match(/\{windowEnd:UInt64\}/g) ?? [];
+        expect(occurrences.length).toBeGreaterThanOrEqual(2);
+      });
+    }
+  });
+
+  describe("when a spend read is issued (#8072 step 3: no query ceiling)", () => {
+    for (const read of READS) {
+      it(`${read.name} caps execution time and thread count`, async () => {
+        const { repo, query } = makeRepo();
+
+        await read.run(repo);
+
+        const call = captured(query);
+        expect(call.clickhouse_settings).toBeDefined();
+        expect(typeof call.clickhouse_settings?.max_execution_time).toBe(
+          "number",
+        );
+        expect(typeof call.clickhouse_settings?.max_threads).toBe("number");
+      });
+    }
+  });
+});

--- a/platform/app/ee/governance/services/activity-monitor/activityMonitor.clickhouse.repository.ts
+++ b/platform/app/ee/governance/services/activity-monitor/activityMonitor.clickhouse.repository.ts
@@ -49,6 +49,7 @@ export class ActivityMonitorClickHouseRepository {
     tenantId: string;
     thisStart: number;
     prevStart: number;
+    windowEnd: number;
   }): Promise<SummarySpendChRow> {
     return this.spend.findSummarySpend(params);
   }
@@ -56,6 +57,7 @@ export class ActivityMonitorClickHouseRepository {
   findSpendByUser(params: {
     tenantId: string;
     windowStart: number;
+    windowEnd: number;
     sortBy: SpendSortField;
     sortDir: SortDir;
     limit: number;
@@ -67,6 +69,7 @@ export class ActivityMonitorClickHouseRepository {
   findSpendByDepartment(params: {
     tenantIds: string[];
     windowStart: number;
+    windowEnd: number;
   }): Promise<SpendByDepartmentChRow[]> {
     return this.spend.findSpendByDepartment(params);
   }
@@ -75,6 +78,7 @@ export class ActivityMonitorClickHouseRepository {
     tenantId: string;
     thisStart: number;
     prevStart: number;
+    windowEnd: number;
   }): Promise<SpendByTeamSourceChRow[]> {
     return this.spend.findSpendByTeamSource(params);
   }
@@ -82,6 +86,7 @@ export class ActivityMonitorClickHouseRepository {
   findSpendOverTime(params: {
     tenantId: string;
     windowStart: number;
+    windowEnd: number;
     groupBy: SpendOverTimeGroupBy;
   }): Promise<SpendOverTimeChRow[]> {
     return this.spend.findSpendOverTime(params);

--- a/platform/app/ee/governance/services/activity-monitor/activityMonitor.service.ts
+++ b/platform/app/ee/governance/services/activity-monitor/activityMonitor.service.ts
@@ -483,6 +483,7 @@ export class ActivityMonitorService {
       tenantId: govProjectId,
       thisStart: thisWindowStart,
       prevStart: previousWindowStart,
+      windowEnd: now,
     });
 
     return {
@@ -538,6 +539,7 @@ export class ActivityMonitorService {
     const rows = await this.repository.findSpendByUser({
       tenantId: govProjectId,
       windowStart: now - windowMs,
+      windowEnd: now,
       sortBy: input.sortBy ?? "spend",
       sortDir: input.sortDir ?? "desc",
       limit: input.limit ?? 50,
@@ -612,6 +614,7 @@ export class ActivityMonitorService {
     const rows = await this.repository.findSpendByDepartment({
       tenantIds,
       windowStart,
+      windowEnd: now,
     });
 
     return assembleDepartmentRows({
@@ -729,6 +732,7 @@ export class ActivityMonitorService {
       tenantId: govProjectId,
       thisStart: now - windowMs,
       prevStart: previousWindowStart,
+      windowEnd: now,
     });
     if (sourceRows.length === 0) return [];
 
@@ -799,6 +803,7 @@ export class ActivityMonitorService {
     const rows = await this.repository.findSpendOverTime({
       tenantId: govProjectId,
       windowStart,
+      windowEnd: now,
       groupBy: input.groupBy,
     });
 

--- a/platform/app/ee/governance/services/activity-monitor/activityMonitor.spend.clickhouse.repository.ts
+++ b/platform/app/ee/governance/services/activity-monitor/activityMonitor.spend.clickhouse.repository.ts
@@ -35,6 +35,19 @@ import {
   summarySpendRowSchema,
 } from "./activityMonitor.clickhouse.schemas";
 
+// These reads scan `trace_summaries`, which is PARTITION BY toYearWeek(OccurredAt)
+// and holds every traced request for the tenant. The dashboard asks for a
+// bounded window, so a read that overruns is a read that is scanning far more
+// than the window — there is nothing to wait for. Capping threads keeps one
+// dashboard load from taking the whole pool, and capping execution time fails
+// that single read rather than letting it grind. Same guardrail and rationale
+// as storage metering (storageMeter.service.ts:63-67).
+const GOVERNANCE_SPEND_MAX_EXECUTION_SECONDS = 45;
+const GOVERNANCE_SPEND_CLICKHOUSE_SETTINGS = {
+  max_threads: 2,
+  max_execution_time: GOVERNANCE_SPEND_MAX_EXECUTION_SECONDS,
+} as const;
+
 export class ActivityMonitorSpendClickHouseRepository {
   constructor(private readonly resolveClient: ClickHouseClientResolver) {}
 
@@ -46,10 +59,12 @@ export class ActivityMonitorSpendClickHouseRepository {
     tenantId,
     thisStart,
     prevStart,
+    windowEnd,
   }: {
     tenantId: string;
     thisStart: number;
     prevStart: number;
+    windowEnd: number;
   }): Promise<SummarySpendChRow> {
     const ch = await this.resolveClient(tenantId);
     const result = await ch.query({
@@ -65,12 +80,14 @@ export class ActivityMonitorSpendClickHouseRepository {
         FROM trace_summaries ts
         WHERE ts.TenantId = {tenantId:String}
           AND ts.OccurredAt >= fromUnixTimestamp64Milli({prevStart:UInt64})
+          AND ts.OccurredAt < fromUnixTimestamp64Milli({windowEnd:UInt64})
           AND ts.Attributes[{originKey:String}] = {originValue:String}
           AND (ts.TenantId, ts.TraceId, ts.UpdatedAt) IN (
             SELECT TenantId, TraceId, max(UpdatedAt)
             FROM trace_summaries
             WHERE TenantId = {tenantId:String}
               AND OccurredAt >= fromUnixTimestamp64Milli({prevStart:UInt64})
+              AND OccurredAt < fromUnixTimestamp64Milli({windowEnd:UInt64})
             GROUP BY TenantId, TraceId
           )
       `,
@@ -78,10 +95,12 @@ export class ActivityMonitorSpendClickHouseRepository {
         tenantId,
         thisStart,
         prevStart,
+        windowEnd,
         originKey: ATTR_ORIGIN_KIND,
         originValue: ORIGIN_KIND_VALUE,
         userKey: ATTR_USER_ID,
       },
+      clickhouse_settings: GOVERNANCE_SPEND_CLICKHOUSE_SETTINGS,
       format: "JSONEachRow",
     });
     const rows = summarySpendRowSchema.array().parse(await result.json());
@@ -102,6 +121,7 @@ export class ActivityMonitorSpendClickHouseRepository {
   async findSpendByUser({
     tenantId,
     windowStart,
+    windowEnd,
     sortBy,
     sortDir,
     limit,
@@ -109,6 +129,7 @@ export class ActivityMonitorSpendClickHouseRepository {
   }: {
     tenantId: string;
     windowStart: number;
+    windowEnd: number;
     sortBy: SpendSortField;
     sortDir: SortDir;
     limit: number;
@@ -140,6 +161,7 @@ export class ActivityMonitorSpendClickHouseRepository {
           FROM trace_summaries ts
           WHERE ts.TenantId = {tenantId:String}
             AND ts.OccurredAt >= fromUnixTimestamp64Milli({windowStart:UInt64})
+            AND ts.OccurredAt < fromUnixTimestamp64Milli({windowEnd:UInt64})
             AND ts.Attributes[{originKey:String}] = {originValue:String}
             AND ts.Attributes[{userKey:String}] != ''
             AND (ts.TenantId, ts.TraceId, ts.UpdatedAt) IN (
@@ -147,6 +169,7 @@ export class ActivityMonitorSpendClickHouseRepository {
               FROM trace_summaries
               WHERE TenantId = {tenantId:String}
                 AND OccurredAt >= fromUnixTimestamp64Milli({windowStart:UInt64})
+                AND OccurredAt < fromUnixTimestamp64Milli({windowEnd:UInt64})
               GROUP BY TenantId, TraceId
             )
         )
@@ -157,12 +180,14 @@ export class ActivityMonitorSpendClickHouseRepository {
       query_params: {
         tenantId,
         windowStart,
+        windowEnd,
         originKey: ATTR_ORIGIN_KIND,
         originValue: ORIGIN_KIND_VALUE,
         userKey: ATTR_USER_ID,
         limit,
         offset,
       },
+      clickhouse_settings: GOVERNANCE_SPEND_CLICKHOUSE_SETTINGS,
       format: "JSONEachRow",
     });
     return spendByUserRowSchema.array().parse(await result.json());
@@ -176,9 +201,11 @@ export class ActivityMonitorSpendClickHouseRepository {
   async findSpendByDepartment({
     tenantIds,
     windowStart,
+    windowEnd,
   }: {
     tenantIds: string[];
     windowStart: number;
+    windowEnd: number;
   }): Promise<SpendByDepartmentChRow[]> {
     // Multi-tenant read across the org's projects; the shared client serves
     // every project, so resolving by any one of them routes identically.
@@ -194,11 +221,13 @@ export class ActivityMonitorSpendClickHouseRepository {
         FROM trace_summaries ts
         WHERE ts.TenantId IN ({tenantIds:Array(String)})
           AND ts.OccurredAt >= fromUnixTimestamp64Milli({windowStart:UInt64})
+          AND ts.OccurredAt < fromUnixTimestamp64Milli({windowEnd:UInt64})
           AND (ts.TenantId, ts.TraceId, ts.UpdatedAt) IN (
             SELECT TenantId, TraceId, max(UpdatedAt)
             FROM trace_summaries
             WHERE TenantId IN ({tenantIds:Array(String)})
               AND OccurredAt >= fromUnixTimestamp64Milli({windowStart:UInt64})
+              AND OccurredAt < fromUnixTimestamp64Milli({windowEnd:UInt64})
             GROUP BY TenantId, TraceId
           )
         GROUP BY projectId, actor
@@ -206,8 +235,10 @@ export class ActivityMonitorSpendClickHouseRepository {
       query_params: {
         tenantIds,
         windowStart,
+        windowEnd,
         userKey: ATTR_USER_ID,
       },
+      clickhouse_settings: GOVERNANCE_SPEND_CLICKHOUSE_SETTINGS,
       format: "JSONEachRow",
     });
     return spendByDepartmentRowSchema.array().parse(await result.json());
@@ -221,10 +252,12 @@ export class ActivityMonitorSpendClickHouseRepository {
     tenantId,
     thisStart,
     prevStart,
+    windowEnd,
   }: {
     tenantId: string;
     thisStart: number;
     prevStart: number;
+    windowEnd: number;
   }): Promise<SpendByTeamSourceChRow[]> {
     const ch = await this.resolveClient(tenantId);
     const result = await ch.query({
@@ -243,6 +276,7 @@ export class ActivityMonitorSpendClickHouseRepository {
           FROM trace_summaries ts
           WHERE ts.TenantId = {tenantId:String}
             AND ts.OccurredAt >= fromUnixTimestamp64Milli({prevStart:UInt64})
+            AND ts.OccurredAt < fromUnixTimestamp64Milli({windowEnd:UInt64})
             AND ts.Attributes[{originKey:String}] = {originValue:String}
             AND ts.Attributes[{sourceKey:String}] != ''
             AND (ts.TenantId, ts.TraceId, ts.UpdatedAt) IN (
@@ -250,6 +284,7 @@ export class ActivityMonitorSpendClickHouseRepository {
               FROM trace_summaries
               WHERE TenantId = {tenantId:String}
                 AND OccurredAt >= fromUnixTimestamp64Milli({prevStart:UInt64})
+                AND OccurredAt < fromUnixTimestamp64Milli({windowEnd:UInt64})
               GROUP BY TenantId, TraceId
             )
         )
@@ -259,10 +294,12 @@ export class ActivityMonitorSpendClickHouseRepository {
         tenantId,
         thisStart,
         prevStart,
+        windowEnd,
         originKey: ATTR_ORIGIN_KIND,
         originValue: ORIGIN_KIND_VALUE,
         sourceKey: ATTR_INGESTION_SOURCE_ID,
       },
+      clickhouse_settings: GOVERNANCE_SPEND_CLICKHOUSE_SETTINGS,
       format: "JSONEachRow",
     });
     return spendByTeamSourceRowSchema.array().parse(await result.json());
@@ -275,10 +312,12 @@ export class ActivityMonitorSpendClickHouseRepository {
   async findSpendOverTime({
     tenantId,
     windowStart,
+    windowEnd,
     groupBy,
   }: {
     tenantId: string;
     windowStart: number;
+    windowEnd: number;
     groupBy: SpendOverTimeGroupBy;
   }): Promise<SpendOverTimeChRow[]> {
     const ch = await this.resolveClient(tenantId);
@@ -303,12 +342,14 @@ export class ActivityMonitorSpendClickHouseRepository {
         FROM trace_summaries ts
         WHERE ts.TenantId = {tenantId:String}
           AND ts.OccurredAt >= fromUnixTimestamp64Milli({windowStart:UInt64})
+          AND ts.OccurredAt < fromUnixTimestamp64Milli({windowEnd:UInt64})
           AND ts.Attributes[{originKey:String}] = {originValue:String}
           AND (ts.TenantId, ts.TraceId, ts.UpdatedAt) IN (
             SELECT TenantId, TraceId, max(UpdatedAt)
             FROM trace_summaries
             WHERE TenantId = {tenantId:String}
               AND OccurredAt >= fromUnixTimestamp64Milli({windowStart:UInt64})
+              AND OccurredAt < fromUnixTimestamp64Milli({windowEnd:UInt64})
             GROUP BY TenantId, TraceId
           )
         GROUP BY bucketMs, groupKey
@@ -317,11 +358,13 @@ export class ActivityMonitorSpendClickHouseRepository {
       query_params: {
         tenantId,
         windowStart,
+        windowEnd,
         originKey: ATTR_ORIGIN_KIND,
         originValue: ORIGIN_KIND_VALUE,
         sourceKey: ATTR_INGESTION_SOURCE_ID,
         userKey: ATTR_USER_ID,
       },
+      clickhouse_settings: GOVERNANCE_SPEND_CLICKHOUSE_SETTINGS,
       format: "JSONEachRow",
     });
     return spendOverTimeRowSchema.array().parse(await result.json());


### PR DESCRIPTION
## For humans

The Costs page asks ClickHouse five questions about spend. Each one said "everything from this date onwards" with no end date, and none of them told the database how much machine to use.

Two consequences. A read with no end date answers slightly differently every time you call it, because "now" keeps moving, so its answer can never be cached. And an unpinned read takes as many threads as it likes from a pool shared with everything else.

This change gives all five reads an end date and pins their thread count and time limit.

It does not change what any number on the page means. It does not add caching. It does not touch the arithmetic behind the period-over-period comparison.

## What changed

Five reads in `activityMonitor.spend.clickhouse.repository.ts`: `findSummarySpend`, `findSpendByUser`, `findSpendByDepartment`, `findSpendByTeamSource`, `findSpendOverTime`.

Each gets a `windowEnd` ceiling. The bound goes into **both halves** of the query, the outer read and the inner dedup subquery. The two halves filter independently, so bounding only the outer one leaves the inner scanning full history. This follows the existing both-halves pattern at `aggregation-builder.ts:137`.

Each also gets `max_threads: 2` and `max_execution_time: 45`, following the storage-metering precedent at `storageMeter.service.ts:63-67`.

Call sites updated in `activityMonitor.service.ts` and the facade in `activityMonitor.clickhouse.repository.ts`, all passing the existing `now`.

## Why the ceiling, precisely

Not partition pruning. `trace_summaries` is `PARTITION BY toYearWeek(OccurredAt)` (`migrations/00002_create_schema.sql:179`) and the existing floor already prunes the old side. Few or no partitions sit above `now`, so a ceiling prunes little.

The two real reasons:

1. **Determinism.** An open-ended read answers differently on every call and cannot be cached under a stable key. A closed range is the prerequisite for any caching work.
2. **Clock skew.** Rows landing dated ahead of wall clock are counted today and should not be.

## Two corrections to issue #8072

Posted in full at [#8072](https://github.com/langwatch/langwatch/issues/8072#issuecomment-5631688363).

- The issue called `previousWindowStart = now - 2 * windowMs` a defect to cut. It is the period-over-period comparison baseline, feeding `windowOverPreviousPct` (`:490`) and `hasPriorBaseline` (`:491`). Cutting it would halve the scan and also blank two returned fields. Left untouched here.
- The issue justified the ceiling by partition pruning. Corrected above.

A separate finding, filed but not acted on: both of those computed fields appear unread on this path, so the summary scans two windows to render one active-user count. Narrowing a returned field is a contract change and needs its own decision.

## Not in this change

Step 1 of the issue, the cache. It would wire invalidation into the cost rollup insert path and make a customer-visible spend figure possibly stale. That needs a locked decision first.

## Verification

- New test `activityMonitorSpendQueryBounds.unit.test.ts` drives all five reads and asserts the bound appears at least twice per query, that `windowEnd` reaches `query_params`, and that the settings are exactly `max_threads: 2` and `max_execution_time: 45`. Red before, green after.
- `pnpm --filter @langwatch/web test:unit run ee/governance/services/activity-monitor` — 17 files, 166 tests, all passing.
- `pnpm lint` gate against merge base `1c240181`: 3350 diagnostics on base and head, no new violations.
- `pnpm typecheck` and `pnpm typecheck:all`: no error names any touched file.

Six unrelated suites in `ee/governance` fail in this worktree on `Failed to resolve entry for package "langwatch"`, an unbuilt workspace package whose `dist` directory does not exist. None of them imports the spend reads.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Activity Monitor spend reporting so results consistently respect the selected time range’s end date.
  - Corrected summary, user, department, team/source, and timeline spend views to exclude records outside the requested period.

- **Performance**
  - Added safeguards to help prevent excessive resource usage and keep spend reporting responsive.

- **Tests**
  - Added regression coverage for time boundaries and query execution safeguards across spend reporting views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
