### PR TITLE
fix(governance): tolerate pre-filedCell ledger state on re-observation

### DIFF
--- a/platform/app/ee/governance/process-manager/__tests__/pulledUsageLedger.process.unit.test.ts
+++ b/platform/app/ee/governance/process-manager/__tests__/pulledUsageLedger.process.unit.test.ts
@@ -159,6 +159,42 @@ beforeEach(() => {
   });
 });
 
+describe("resuming an instance persisted before the state carried a filed cell", () => {
+  /**
+   * The ledger process once kept no state at all, so every instance written
+   * by that version holds `{}`. The runtime hands stored state back verbatim,
+   * with no merge over the initial state, which left `filedCell` undefined
+   * rather than null and crashed the reissue check on every re-observation
+   * of a pre-existing charge.
+   */
+  it("treats the missing cell as a first observation and files the charge", async () => {
+    const ref = {
+      processName: PULLED_USAGE_LEDGER_PROCESS_NAME,
+      projectId: GOV_PROJECT,
+      processKey: RESTATEMENT_KEY,
+    };
+    await store.commit({
+      ref,
+      tenantId: GOV_PROJECT,
+      state: {} as unknown as PulledUsageLedgerState,
+      expectedRevision: 0,
+      nextWakeAt: null,
+      sourceEventId: `legacy:${ns}`,
+      messages: [],
+      now: T0 - 1_000,
+    });
+
+    await observe(observation());
+    await drainOutbox();
+
+    expect(sendRetractPulledUsage).not.toHaveBeenCalled();
+    expect(insertPulledUsageRows).toHaveBeenCalledTimes(1);
+    const instance = await store.findByRef<PulledUsageLedgerState>({ ref });
+    expect(instance?.revision).toBe(2);
+    expect(instance?.state.filedCell).toMatchObject({ currencyCode: "USD" });
+  });
+});
+
 describe("recognising a reissued charge", () => {
   describe("given a day's bill already pulled in one currency", () => {
     /** @scenario A bill reissued in another currency is withdrawn by the pull that finds it */

--- a/platform/app/ee/governance/process-manager/pulledUsageLedger.process.ts
+++ b/platform/app/ee/governance/process-manager/pulledUsageLedger.process.ts
@@ -398,7 +398,9 @@ function writePayloadFor(
 
 /**
  * One instance per usage item. The event is already whole, so the handler
- * freezes exactly one deterministic write intent and keeps no state.
+ * freezes exactly one deterministic write intent. The only state it keeps is
+ * the cell the charge was last filed in, so a later pull that moves the same
+ * charge elsewhere can withdraw the version it leaves behind.
  *
  * The intent key is the restatement key plus the observation instant, which is
  * what keeps a correction from colliding with the figure it corrects: two
@@ -429,7 +431,12 @@ export function pulledUsageLedgerPM(
         // into another currency, and that is exactly the observation the
         // ledger has no dollar figure for — returning early on it would blind
         // the detector to its own headline case.
-        const filed = state.filedCell;
+        // `?? null`: instances persisted before this state carried a
+        // `filedCell` hold `{}`, and the runtime hands stored state back
+        // verbatim rather than merging it over the initial state. Such a row
+        // has never filed a cell we can name, so it is treated exactly like a
+        // first observation.
+        const filed = state.filedCell ?? null;
         const reissued = filed !== null && isReissuedElsewhere(filed, record);
         const intents = reissued
           ? [


### PR DESCRIPTION
## Why

After #8043 shipped, the `pulledUsageLedger` process manager started keeping a `filedCell` in its state. Instances written before that commit still hold `{}`. The process-manager runtime hands stored state back verbatim (`processManagerService.ts` `existing?.state ?? initialState`), so on those rows `state.filedCell` is `undefined`, not `null`. The `filed !== null` guard passes and `isReissuedElsewhere` dereferences `undefined`:

```
TypeError: Cannot read properties of undefined (reading 'currencyCode')
    at isReissuedElsewhere (pulledUsageLedger.process.ts:180:11)
```

Every retry hits the same crash, so any pre-existing restatement key stops consuming events. In production this is ~21k instances, and any backfill that restates one of those keys fails on it.

## What

- `state.filedCell ?? null` so a legacy row is treated as a first observation and files the charge normally. No data migration; rows heal on their next observation.
- Regression test that seeds a `{}` instance via `store.commit` and re-observes it. It reproduces the exact `TypeError` without the fix.
- Fixed the handler doc comment, which still claimed the process keeps no state.

## Known limitation

A legacy `{}` row cannot name the cell it was originally filed in, so if the very first post-fix observation of such a charge arrives in a different currency, that first reissue is not withdrawn. Subsequent reissues are handled normally.

## Verification

- `pnpm exec vitest run ee/governance/process-manager/__tests__/pulledUsageLedger.process.unit.test.ts` — 8 passed (new test fails with the prod TypeError when the one-line fix is reverted).
- `biome check` clean on both files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed resumed usage records with legacy state so their first observation is handled correctly.
  * Ensured charges are filed without unnecessary retractions when the previous filing location is unavailable.
  * Improved tracking of the last filing location for subsequent usage updates.

* **Tests**
  * Added regression coverage for restoring persisted records with legacy state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->