### PR TITLE
docs(governance): spell out the cost of a legacy ledger row, nest the test

### DIFF
--- a/platform/app/ee/governance/process-manager/__tests__/pulledUsageLedger.process.unit.test.ts
+++ b/platform/app/ee/governance/process-manager/__tests__/pulledUsageLedger.process.unit.test.ts
@@ -160,38 +160,40 @@ beforeEach(() => {
 });
 
 describe("resuming an instance persisted before the state carried a filed cell", () => {
-  /**
-   * The ledger process once kept no state at all, so every instance written
-   * by that version holds `{}`. The runtime hands stored state back verbatim,
-   * with no merge over the initial state, which left `filedCell` undefined
-   * rather than null and crashed the reissue check on every re-observation
-   * of a pre-existing charge.
-   */
-  it("treats the missing cell as a first observation and files the charge", async () => {
-    const ref = {
-      processName: PULLED_USAGE_LEDGER_PROCESS_NAME,
-      projectId: GOV_PROJECT,
-      processKey: RESTATEMENT_KEY,
-    };
-    await store.commit({
-      ref,
-      tenantId: GOV_PROJECT,
-      state: {} as unknown as PulledUsageLedgerState,
-      expectedRevision: 0,
-      nextWakeAt: null,
-      sourceEventId: `legacy:${ns}`,
-      messages: [],
-      now: T0 - 1_000,
+  describe("given an instance stored by the version that kept no state", () => {
+    /**
+     * The ledger process once kept no state at all, so every instance written
+     * by that version holds `{}`. The runtime hands stored state back verbatim,
+     * with no merge over the initial state, which left `filedCell` undefined
+     * rather than null and crashed the reissue check on every re-observation
+     * of a pre-existing charge.
+     */
+    it("treats the missing cell as a first observation and files the charge", async () => {
+      const ref = {
+        processName: PULLED_USAGE_LEDGER_PROCESS_NAME,
+        projectId: GOV_PROJECT,
+        processKey: RESTATEMENT_KEY,
+      };
+      await store.commit({
+        ref,
+        tenantId: GOV_PROJECT,
+        state: {} as unknown as PulledUsageLedgerState,
+        expectedRevision: 0,
+        nextWakeAt: null,
+        sourceEventId: `legacy:${ns}`,
+        messages: [],
+        now: T0 - 1_000,
+      });
+
+      await observe(observation());
+      await drainOutbox();
+
+      expect(sendRetractPulledUsage).not.toHaveBeenCalled();
+      expect(insertPulledUsageRows).toHaveBeenCalledTimes(1);
+      const instance = await store.findByRef<PulledUsageLedgerState>({ ref });
+      expect(instance?.revision).toBe(2);
+      expect(instance?.state.filedCell).toMatchObject({ currencyCode: "USD" });
     });
-
-    await observe(observation());
-    await drainOutbox();
-
-    expect(sendRetractPulledUsage).not.toHaveBeenCalled();
-    expect(insertPulledUsageRows).toHaveBeenCalledTimes(1);
-    const instance = await store.findByRef<PulledUsageLedgerState>({ ref });
-    expect(instance?.revision).toBe(2);
-    expect(instance?.state.filedCell).toMatchObject({ currencyCode: "USD" });
   });
 });
 

--- a/platform/app/ee/governance/process-manager/pulledUsageLedger.process.ts
+++ b/platform/app/ee/governance/process-manager/pulledUsageLedger.process.ts
@@ -435,7 +435,10 @@ export function pulledUsageLedgerPM(
         // `filedCell` hold `{}`, and the runtime hands stored state back
         // verbatim rather than merging it over the initial state. Such a row
         // has never filed a cell we can name, so it is treated exactly like a
-        // first observation.
+        // first observation. The price is the lost-process-store degradation
+        // described in the file header: a reissue seen on that first
+        // post-fix observation is not withdrawn, and that day carries the
+        // charge twice until the next correction.
         const filed = state.filedCell ?? null;
         const reissued = filed !== null && isReissuedElsewhere(filed, record);
         const intents = reissued


### PR DESCRIPTION
Follow-up to #8074 (merged) for #8075. Rebased on main.

## What

Two documentation-only nits from review of #8074. No behaviour change.

- The comment above `const filed = state.filedCell ?? null;` now states the cost of tolerating a legacy row, not only the mechanism: a reissue seen on that first post-fix observation is not withdrawn, so that day carries the charge twice until the next correction. Points at the lost-process-store degradation already described in the file header.
- The regression test is nested under `describe("given an instance stored by the version that kept no state")` so it follows the given / when / then layering the rest of the file uses.

## Verification

- `pnpm exec vitest run ee/governance/process-manager/__tests__/pulledUsageLedger.process.unit.test.ts`: 8 passed
- `pnpm exec biome check` on both files: clean

Related: #8074 (fix), #8075 (issue).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage for resuming older persisted process instances.
  - Verified usage is recorded once, no unnecessary retraction is sent, and currency details are restored correctly.

- **Documentation**
  - Clarified behavior after degraded persistence: a reissued charge may temporarily be counted twice on the first observation, with correction applied on the next update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->