### PR TITLE
fix(governance): a pull failure without a wait no longer parks the source

### DIFF
--- a/platform/app/ee/event-sourcing/pipelines/ingestion-pull-processing/process-manager/__tests__/persistedStateShape.unit.test.ts
+++ b/platform/app/ee/event-sourcing/pipelines/ingestion-pull-processing/process-manager/__tests__/persistedStateShape.unit.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Process state is persisted as JSON, and the persistence boundary refuses
+ * `undefined` outright rather than letting `JSON.stringify` drop it. A handler
+ * that copies an optional field forward with `state.field` therefore has to
+ * coalesce it: on a state written before the field existed the key is absent,
+ * and naming an absent key writes `undefined`.
+ *
+ * This is not theoretical. The first pull failure that named no wait, on a
+ * source whose state predated cooldowns, threw
+ * `Value at $.cooldownUntil is not JSON-safe: undefined` from the subscriber
+ * — and kept throwing, because evolve re-runs the same committed event on every
+ * retry. The source stayed parked until the code changed.
+ *
+ * Spec: specs/ai-gateway/governance/ingestion-sources.feature
+ */
+
+import { INGESTION_PULL_EVENT_TYPES } from "@ee/event-sourcing/pipelines/ingestion-pull-processing/schemas/constants";
+import { describe, expect, it } from "vitest";
+import { ensureJsonSafe } from "~/server/event-sourcing/process-manager/json";
+
+import type { IngestionPullProcessState } from "../ingestionPullProcess.types";
+import {
+  bootConfigured,
+  CONFIGURED_AT,
+  envelope,
+  evolve,
+} from "./listingProcess.fixture";
+
+/**
+ * A state row as it was written before cooldowns and listings existed: the
+ * optional keys are not null, they are not there at all.
+ */
+function legacyState(): IngestionPullProcessState {
+  const { cooldownUntil, currentAgentsListing, currentPeopleListing, ...rest } =
+    bootConfigured().state;
+  void cooldownUntil;
+  void currentAgentsListing;
+  void currentPeopleListing;
+  return rest;
+}
+
+const LATER = CONFIGURED_AT + 60_000;
+
+describe("given a state written before cooldowns existed", () => {
+  describe("when a run fails without naming a wait", () => {
+    const result = evolve({
+      previousState: {
+        ...legacyState(),
+        currentRun: { runId: "run-1", scheduledFor: LATER, startedAt: LATER },
+      },
+      event: envelope({
+        eventType: INGESTION_PULL_EVENT_TYPES.RUN_FAILED,
+        occurredAt: LATER,
+        payload: { sourceId: "source-1", runId: "run-1", retryAfterMs: null },
+      }),
+      now: LATER,
+    });
+
+    it("produces a state the persistence boundary accepts", () => {
+      expect(() => ensureJsonSafe(result.state)).not.toThrow();
+    });
+
+    it("records the absence of a wait as null, not undefined", () => {
+      expect(result.state.cooldownUntil).toBeNull();
+    });
+  });
+});
+
+describe("given a state written before listings existed", () => {
+  describe("when a listing outcome arrives that the state is not tracking", () => {
+    const result = evolve({
+      previousState: legacyState(),
+      event: envelope({
+        eventType: INGESTION_PULL_EVENT_TYPES.AGENTS_LISTING_REFUSED,
+        occurredAt: LATER,
+        payload: { sourceId: "source-1", requestId: "stale-request" },
+      }),
+      now: LATER,
+    });
+
+    it("produces a state the persistence boundary accepts", () => {
+      expect(() => ensureJsonSafe(result.state)).not.toThrow();
+    });
+
+    it("records the free slot as null, not undefined", () => {
+      expect(result.state.currentAgentsListing).toBeNull();
+    });
+  });
+});

--- a/platform/app/ee/event-sourcing/pipelines/ingestion-pull-processing/process-manager/__tests__/providerCooldown.unit.test.ts
+++ b/platform/app/ee/event-sourcing/pipelines/ingestion-pull-processing/process-manager/__tests__/providerCooldown.unit.test.ts
@@ -22,6 +22,7 @@ import type {
   ProcessEventEnvelope,
   ProcessInput,
 } from "~/server/event-sourcing/process-manager";
+import { ensureJsonSafe } from "~/server/event-sourcing/process-manager/json";
 import { buildProcessDefinition } from "~/server/event-sourcing/process-manager/processRuntime";
 
 import { INGESTION_PULL_MAX_COOLDOWN_MS } from "../ingestionPull.process";
@@ -198,7 +199,10 @@ describe("given a wait that cannot be read as a length of time", () => {
   it("records no wait at all, so nothing downstream reads a figure it cannot use", () => {
     const result = refusedAt({ at: T0, retryAfterMs: Number.NaN });
 
-    expect(result.state.cooldownUntil ?? null).toBeNull();
+    // Exactly null, never absent-or-undefined: the state is persisted as
+    // JSON, and `undefined` at this key is what used to park the source.
+    expect(result.state.cooldownUntil).toBeNull();
+    expect(() => ensureJsonSafe(result.state)).not.toThrow();
   });
 
   /** @scenario "A wait that cannot be read as a length of time is treated as no wait" */

--- a/platform/app/ee/event-sourcing/pipelines/ingestion-pull-processing/process-manager/ingestionPull.process.ts
+++ b/platform/app/ee/event-sourcing/pipelines/ingestion-pull-processing/process-manager/ingestionPull.process.ts
@@ -258,9 +258,15 @@ export const handlePullRunFailed: EventHandler<
         state.currentRun?.runId === view.runId ? null : state.currentRun,
       // Never shortens a wait already running: two refusals in a row leave the
       // later instant standing rather than the most recent one.
+      //
+      // `?? null`, not the bare field: a state written before cooldowns
+      // existed has no such key, and naming an absent key here would write
+      // `undefined`, which the persistence boundary refuses. The refusal is
+      // permanent, because evolve re-runs the same committed event on every
+      // retry, so the first failure without a wait would park the source.
       cooldownUntil:
         told === null
-          ? state.cooldownUntil
+          ? (state.cooldownUntil ?? null)
           : Math.max(told, state.cooldownUntil ?? 0),
     },
     after: schedulingRef(ctx),
@@ -289,7 +295,10 @@ function clearListing({
   slot: ListingSlot;
 }): IngestionPullProcessState {
   const isCurrent = requestId !== null && state[slot]?.requestId === requestId;
-  return { ...state, [slot]: isCurrent ? null : state[slot] };
+  // `?? null` for the same reason as `cooldownUntil`: the slot is absent on
+  // state written before listings existed, and an absent key must not be
+  // re-written as `undefined`.
+  return { ...state, [slot]: isCurrent ? null : (state[slot] ?? null) };
 }
 
 /**


### PR DESCRIPTION
Closes #8079

## For humans

A connected source whose scheduled pull failed once, without the provider naming how long to wait, stopped being scheduled at all. The failure showed up in the queue as `Value at $.cooldownUntil is not JSON-safe: undefined`, and it repeated on every retry. This fixes the cause and adds tests that would have caught it.

## Cause

`handlePullRunFailed` copies `state.cooldownUntil` forward when the failure named no wait (`ingestionPull.process.ts`). On a source whose state was written before cooldowns existed (#8043, merged 2026-09-11 00:09 CEST) the key is absent, so the spread wrote it as an own key holding `undefined`. `ensureJsonSafe` in `processManagerService.ts` refuses that before commit. Evolve re-runs the same committed event on every retry, so the subscriber threw forever and the source stayed parked.

Reproduced deterministically: `{ ...state, cooldownUntil: state.cooldownUntil }` on a state without the key yields `Object.hasOwn(next, "cooldownUntil") === true`, `typeof === "undefined"`.

The same shape existed in `clearListing`, which copies an optional listing slot forward the same way. Fixed in the same change.

## Fix

- Both writes coalesce to `null`: `state.cooldownUntil ?? null`, `state[slot] ?? null`.
- The existing cooldown test asserted `cooldownUntil ?? null`, which hid exactly this. It now asserts `null` and runs `ensureJsonSafe` on the state.
- New `persistedStateShape.unit.test.ts` evolves a legacy-shaped state (optional keys absent) through both handlers and checks the result passes the persistence boundary. It fails 4 tests on main, passes here.

## After deploy

No manual intervention. The poisoned subscribers re-run the same committed event with the new code and commit. Nothing in any environment was changed during the investigation.

## Verification

- `pnpm test:unit run ee/event-sourcing/pipelines/ingestion-pull-processing/process-manager/__tests__/`: 95 passed
- `tslsp-cli diagnostics` on the three touched files: clean
- biome: clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ingestion pull processing when handling legacy state that lacks cooldown or listing information.
  * Ensured cleared cooldown and listing values are stored as explicit `null` values, allowing state to be persisted safely.
  * Added safeguards for failure and listing-refusal scenarios involving uninitialized state fields.

* **Tests**
  * Added coverage for JSON-safe state persistence across legacy and invalid cooldown scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->