### PR TITLE
fix(governance): metered lane reads the gateway ledger, gateway half of the rollup dropped

### DIFF
--- a/dev/docs/adr/128-governance-cost-and-identity-two-waves.md
+++ b/dev/docs/adr/128-governance-cost-and-identity-two-waves.md
@@ -33,6 +33,12 @@ project as the *home* of every pulled row and separates "home" from
 > resolved **at read time** from three **dated identity tables** this
 > document defines — in **two waves**: money first, people second.
 
+> **[REVISED — see revision v3.16.]** "Folds into one daily rollup" holds
+> for the provider bills alone. Gateway traffic no longer folds into the
+> rollup: the metered lane is read straight off the gateway's own
+> per-request ledger, `gateway_spend`, and the rollup holds the pulled lane
+> only. The rest of the line stands.
+
 ## Context
 
 Customers running AI across providers (Anthropic, OpenAI, Azure/Copilot,
@@ -271,10 +277,11 @@ flowchart LR
   W["Pull run, bounded<br/>page cap, chunk cap,<br/>watermark, settling re-read"]
   G["AI Gateway<br/>request metering"]
   EL[("event_log")]
-  FP["GovernanceCostRollupFoldProjection<br/>registered on BOTH money pipelines"]
-  R[("governance_cost_rollup_1d<br/>CostSource: pulled or gateway")]
+  FP["GovernanceCostRollupFoldProjection<br/>registered on the pulled-usage pipeline ONLY (v3.16)"]
+  R[("governance_cost_rollup_1d<br/>CostSource: pulled<br/>(gateway rows written before v3.16<br/>remain and are read by nothing)")]
   OE[("governance_ocsf_events<br/>audit rows and seat reports")]
-  GS[("gateway_spend and budget ledger<br/>sibling projections")]
+  GS[("gateway_spend<br/>one row per request, latest status —<br/>the metered lane's own store (v3.16)")]
+  BL[("budget ledger<br/>sibling projection")]
   PG[("Postgres<br/>IngestionSource run history,<br/>DiscoveredPerson")]
 
   P --> W
@@ -282,29 +289,34 @@ flowchart LR
   W -->|"priced usage event<br/>(omitted when a read yields no row)"| EL
   W -->|"run outcome: errorCount,<br/>lastSuccessAt, unpriced window"| PG
   G --> EL
-  EL --> FP
-  EL --> GS
+  EL -->|"pulled-usage events only"| FP
+  EL -->|"gateway-spend events"| GS
+  EL --> BL
   FP --> R
 ```
 
-*Write path: bounded pull runs and gateway metering both append events; one
-fold projection registered on both money pipelines writes one daily rollup.*
+*Write path: bounded pull runs and gateway metering both append events. The
+fold projection is registered on the pulled-usage pipeline alone and writes
+the billed lane's daily rollup; gateway events reach the per-request ledger
+and never the rollup (v3.16).*
 
 ```mermaid
 flowchart LR
   R[("governance_cost_rollup_1d")]
+  GS[("gateway_spend")]
   OE[("governance_ocsf_events")]
   PG[("Postgres")]
   S["GovernanceCostService"]
   B["Billed card<br/>every provider's own reported total,<br/>summed across the window"]
-  M["Metered card<br/>gateway total"]
+  M["Metered card<br/>gateway total, per UTC start day,<br/>'N requests with no dollar amount' beside it"]
   ST["Seat card<br/>counts only, never money"]
   N["Notices: sources with failing pulls,<br/>unpriced window, Azure bill note"]
   SP["Spender breakdown<br/>(provider, rawActorId, agent)"]
 
   R -->|"sumDaysByLane: CostSource = pulled"| S
-  R -->|"sumDaysByLane: CostSource = gateway"| S
   R -->|"sumWindowBySpender: pulled lane only"| S
+  GS -->|"sumDaysForOrganizationProjects (v3.16):<br/>every project of the organization,<br/>one row per request, confirmed + failed,<br/>window on the request's own start day"| S
+  PG -->|"every project id of the organization<br/>(the metered lane's tenant scope)"| S
   OE -->|"findLatestSeatReports"| S
   PG -->|"run history, then deriveSourceHealth<br/>read-time, never written to status"| S
   PG -->|"DiscoveredPerson display text"| S
@@ -315,15 +327,19 @@ flowchart LR
   S --> SP
 ```
 
-*Read path: one service, four stores, three lanes that are labeled separately
-and never summed into one figure.*
+*Read path: one service, five stores, three lanes that are labeled separately
+and never summed into one figure. The billed lane reads the rollup; the
+metered lane reads the gateway's per-request ledger (v3.16).*
 
-The rollup projection consumes the **events** (gateway-spend and
-pulled-usage events on the log) — the `gateway_spend` table and the
-budget ledger are *sibling projection outputs* of those same streams,
-not the rollup's inputs. Projections register per-pipeline, so this is
-two registrations (one on each money pipeline) writing one table; replay
-means replaying both aggregates from the log.
+The rollup projection consumes the **pulled-usage events** on the log and
+nothing else (v3.16). The `gateway_spend` table and the budget ledger are
+*sibling projection outputs* of the gateway-spend stream, and `gateway_spend`
+is the metered lane's read store, not a rollup input. One registration, on
+the pulled-usage pipeline, writes the rollup; replay means replaying that one
+aggregate from the log. Until v3.16 the fold was also registered on the
+gateway-spend pipeline and wrote gateway cells under the traffic's own project
+tenant, where the screen — reading under the governance tenant — never found
+them; those rows remain in the table and every read filters them out.
 
 - **`governance_cost_rollup_1d`** — one row per tenant × day × ingestion
   source × cost_source × provider × model × agent × currency ×
@@ -2047,6 +2063,61 @@ money tables, only the identity tables and read paths.
 
 ## Revisions
 
+- **v3.16 (2026-09-11).** The metered lane reads the gateway's own
+  per-request ledger; the rollup's gateway half is removed. One decision is
+  revised: the "one daily rollup" of the one-line summary now holds the pulled
+  lane alone. Tracking issue langwatch-saas #1228; implementation PR #8080.
+  - **Why.** The fold wrote gateway cells under the tenant of the project whose
+    traffic it was, while the cost screen read the rollup under the hidden
+    governance project's tenant. Nothing ever landed where the screen looked,
+    so the metered lane read empty for every real organization and only
+    fixtures ever filled it. The comparator's gateway half looked under the
+    same tenant, found nothing on both sides, and passed every night. Two
+    writers on one table made the mismatch possible, so the gateway writer is
+    removed rather than repaired.
+  - **Write side.** The fold is no longer registered on the gateway-spend
+    pipeline (`gateway-spend-processing/pipeline.ts:82`); its gateway handlers,
+    the gateway branch of its cell addressing and its gateway state fields are
+    deleted, and addressing an undeclared event type throws. The comparator
+    compares the pulled lane only (`costRollupComparatorSchedule.ts:67`); an
+    active scheduled row for the retired gateway check is switched off at boot
+    and never recreated (`:76-86`), and a retired row that fires anyway settles
+    without comparing (`costRollupComparator.service.ts:265`). Gateway rows the
+    old fold wrote stay in the rollup; every rollup read carries a pulled-only
+    predicate and an integration test proves they count nowhere.
+  - **Read side.** `GovernanceGatewaySpendClickHouseRepository` reads
+    `gateway_spend` for every project of the organization, archived ones
+    included (`governanceCost.service.ts:579`), because the ledger's tenant is
+    the traffic's own project. One row per request first — `argMax` over
+    `(TenantId, GatewayRequestId)` — then the sum
+    (`governanceGatewaySpend.clickhouse.repository.ts:97`): the ledger is
+    partitioned by the month a request started in and an outcome that lands
+    before its admission leaves the same request in two partitions, which a
+    plain `FINAL` sum counts twice. The window is the read's only time
+    predicate and applies to the collapsed request's start day (`:113`), never
+    to its versions, since a late admission moves the start time back by a gap
+    nothing bounds; the tenant-led sort key keeps the scan to one organization.
+    Confirmed and failed requests are charged; the day is the request's UTC
+    start day; the read carries its own 20-second cap (`:77`). Groupings are
+    model and virtual key only — the ledger sits outside §9's erasure, so no
+    person column is ever selected.
+  - **Marked, not withheld.** The metered lane deviates from §3's withhold rule
+    on purpose: a request the ledger holds no dollar amount for — priced at zero
+    with tokens consumed, or settled with its cost never confirmed — is counted
+    beside the total as "N requests with no dollar amount", never inside it and
+    never as a reason to blank the figure. The figure stands when at least one
+    request was priced, or when requests were charged and none lacks an amount;
+    otherwise the day and the window read null, never $0.00
+    (`governanceCost.service.ts:1523`, `:136`). A window of only such requests
+    still renders the lane, with a dash and the count
+    (`costSampleMode.ts:55-59`).
+  - **Diagrams.** The §4 write-path diagram shows one registration; the
+    read-path diagram gains the ledger as the metered lane's store and the
+    project-id scope from Postgres.
+  - **Deferred, tracked separately.** Erasure coverage of `gateway_spend`
+    (which is why the metered lane has no per-person grouping); cleanup of the
+    old gateway rows in the rollup; the by-model and by-key ledger reads exist
+    and are tested but no screen calls them yet.
 - **v3.15 (2026-09-09).** Documentation caught up with the code, plus one
   correction. No new decision is taken; what changes is that §15's prose
   stopped describing what ships.

--- a/platform/app/ee/governance/projections/__tests__/governanceCostRollup.foldProjection.unit.test.ts
+++ b/platform/app/ee/governance/projections/__tests__/governanceCostRollup.foldProjection.unit.test.ts
@@ -37,59 +37,6 @@ function projection() {
   });
 }
 
-/** One priced gateway outcome, as the ingest seam appends it. */
-function confirmedEvent({
-  costNanoUsd,
-  principalUserId = "user_ada",
-  model = "openai/gpt-5-mini",
-  occurredAt = DAY_MS,
-  id = `evt-${costNanoUsd}-${principalUserId}`,
-}: {
-  costNanoUsd: number;
-  principalUserId?: string;
-  model?: string;
-  occurredAt?: number;
-  id?: string;
-}) {
-  return {
-    id,
-    type: "lw.gateway.spend.confirmed",
-    tenantId: TENANT,
-    aggregateId: `gwreq-${id}`,
-    occurredAt,
-    data: {
-      gateway_request_id: `gwreq-${id}`,
-      occurred_at: occurredAt,
-      tenantId: TENANT,
-      organization_id: "org_acme",
-      virtual_key_id: "vk_1",
-      principal_user_id: principalUserId,
-      end_user_id: "",
-      trace_id: "",
-      request_type: "chat",
-      labels: [],
-      metadata: "",
-      admitted_at: occurredAt,
-      team_id: "",
-      model,
-      model_provider_id: "openai",
-      usage: {
-        input_tokens: 100,
-        output_tokens: 20,
-        cache_read_input_tokens: 0,
-        cache_creation_input_tokens: 0,
-        reasoning_tokens: 0,
-        input_audio_tokens: 0,
-        output_audio_tokens: 0,
-        input_chars: 0,
-      },
-      rate_version: "registry@2026-08-01",
-      duration_ms: 120,
-      cost_nano_usd: costNanoUsd,
-    },
-  } as never;
-}
-
 /**
  * One pulled observation of one provider bucket.
  *
@@ -107,7 +54,8 @@ function observedEvent({
   observedAtMs,
   occurredAtMs = DAY_MS,
   costStatus = "estimate",
-  id = `evt-pulled-${observedAtMs}`,
+  id = `evt-pulled-${restatementKey}-${observedAtMs}`,
+  tenantId = TENANT,
   rawActorId,
   agentId,
 }: {
@@ -119,6 +67,7 @@ function observedEvent({
   occurredAtMs?: number;
   costStatus?: "exact" | "estimate";
   id?: string;
+  tenantId?: string;
   /** Omitted by default: the legacy shape, from before spend named a spender. */
   rawActorId?: string;
   /** Omitted by default, same legacy contract as `rawActorId` (#7881). */
@@ -127,7 +76,7 @@ function observedEvent({
   return {
     id,
     type: "lw.obs.pulled_usage.observed",
-    tenantId: TENANT,
+    tenantId,
     aggregateId: restatementKey,
     occurredAt: occurredAtMs,
     data: {
@@ -137,7 +86,7 @@ function observedEvent({
       ingestionSourceId: "src_1",
       organizationId: "org_acme",
       teamId: "team_platform",
-      projectId: TENANT,
+      projectId: tenantId,
       model: "anthropic/claude-sonnet-5",
       tokensInput: 1_000,
       tokensOutput: 200,
@@ -167,33 +116,43 @@ function fold(events: unknown[]): GovernanceCostRollupState {
 }
 
 describe("governanceCostRollupKey", () => {
-  describe("given two gateway outcomes that differ only by spender", () => {
+  describe("given two pulled items that differ only by spender", () => {
     /** @scenario "Two spenders with identical numbers stay two rows after compaction" */
     it("puts each spender in its own group", () => {
       const ada = governanceCostRollupKey(
-        confirmedEvent({ costNanoUsd: 5_000, principalUserId: "user_ada" }),
+        observedEvent({
+          costNanoMinor: 5_000,
+          observedAtMs: DAY_MS,
+          rawActorId: "user_ada",
+        }),
       );
       const grace = governanceCostRollupKey(
-        confirmedEvent({ costNanoUsd: 5_000, principalUserId: "user_grace" }),
+        observedEvent({
+          costNanoMinor: 5_000,
+          observedAtMs: DAY_MS,
+          rawActorId: "user_grace",
+        }),
       );
       expect(ada).not.toBe(grace);
     });
   });
 
-  describe("given two outcomes on the same day and dimensions", () => {
+  describe("given two items on the same day and dimensions", () => {
     it("puts them in one group so the day is one row", () => {
       const morning = governanceCostRollupKey(
-        confirmedEvent({
-          costNanoUsd: 5_000,
-          occurredAt: Date.parse("2026-08-01T01:00:00.000Z"),
-          id: "a",
+        observedEvent({
+          costNanoMinor: 5_000,
+          observedAtMs: DAY_MS,
+          occurredAtMs: Date.parse("2026-08-01T01:00:00.000Z"),
+          restatementKey: "bucket-a",
         }),
       );
       const evening = governanceCostRollupKey(
-        confirmedEvent({
-          costNanoUsd: 7_000,
-          occurredAt: Date.parse("2026-08-01T23:59:59.000Z"),
-          id: "b",
+        observedEvent({
+          costNanoMinor: 7_000,
+          observedAtMs: DAY_MS,
+          occurredAtMs: Date.parse("2026-08-01T23:59:59.000Z"),
+          restatementKey: "bucket-b",
         }),
       );
       expect(morning).toBe(evening);
@@ -201,17 +160,17 @@ describe("governanceCostRollupKey", () => {
 
     it("splits the group at the UTC day boundary", () => {
       const lastMoment = governanceCostRollupKey(
-        confirmedEvent({
-          costNanoUsd: 1,
-          occurredAt: Date.parse("2026-08-01T23:59:59.999Z"),
-          id: "a",
+        observedEvent({
+          costNanoMinor: 1,
+          observedAtMs: DAY_MS,
+          occurredAtMs: Date.parse("2026-08-01T23:59:59.999Z"),
         }),
       );
       const firstMoment = governanceCostRollupKey(
-        confirmedEvent({
-          costNanoUsd: 1,
-          occurredAt: Date.parse("2026-08-02T00:00:00.000Z"),
-          id: "b",
+        observedEvent({
+          costNanoMinor: 1,
+          observedAtMs: DAY_MS,
+          occurredAtMs: Date.parse("2026-08-02T00:00:00.000Z"),
         }),
       );
       expect(lastMoment).not.toBe(firstMoment);
@@ -220,29 +179,33 @@ describe("governanceCostRollupKey", () => {
 
   describe("given the same dimensions under two tenants", () => {
     it("never shares a group across tenants", () => {
-      const mine = governanceCostRollupKey(confirmedEvent({ costNanoUsd: 1 }));
-      const theirs = governanceCostRollupKey({
-        ...(confirmedEvent({ costNanoUsd: 1 }) as never as Record<
-          string,
-          unknown
-        >),
-        tenantId: "proj_someone_else",
-      } as never);
+      const mine = governanceCostRollupKey(
+        observedEvent({ costNanoMinor: 1, observedAtMs: DAY_MS }),
+      );
+      const theirs = governanceCostRollupKey(
+        observedEvent({
+          costNanoMinor: 1,
+          observedAtMs: DAY_MS,
+          tenantId: "proj_someone_else",
+        }),
+      );
       expect(mine).not.toBe(theirs);
     });
   });
 
-  describe("given a gateway event and a pulled event", () => {
-    // The two lanes are two writers of one table. If they could ever address
-    // the same row they would race and each would overwrite the other's total.
-    it("never shares a group between the gateway and pulled lanes", () => {
-      const gateway = governanceCostRollupKey(
-        confirmedEvent({ costNanoUsd: 1 }),
-      );
-      const pulled = governanceCostRollupKey(
-        observedEvent({ costNanoMinor: 1, observedAtMs: DAY_MS }),
-      );
-      expect(gateway).not.toBe(pulled);
+  describe("given a gateway spend event", () => {
+    // The metered lane is read straight off its own per-request ledger; this
+    // fold has no branch for it any more. Addressing one anyway would file
+    // money under a cell the cost screen never reads, so the fold refuses
+    // loudly rather than guessing a cell.
+    it("refuses to address a cell for it", () => {
+      expect(() =>
+        governanceCostRollupKey({
+          type: "lw.gateway.spend.confirmed",
+          tenantId: TENANT,
+          data: { occurred_at: DAY_MS, model: "openai/gpt-5-mini" },
+        }),
+      ).toThrow(/lw\.gateway\.spend\.confirmed/);
     });
   });
 
@@ -327,12 +290,20 @@ describe("governanceCostRollupKey", () => {
 });
 
 describe("GovernanceCostRollupFoldProjection", () => {
-  describe("given several gateway outcomes on one day and dimension combination", () => {
+  describe("given several pulled items on one day and dimension combination", () => {
     /** @scenario "A day's spend lands as one summary row per dimension combination" */
-    it("holds the sum of those outcomes as the day's amount", () => {
+    it("holds the sum of those items as the day's amount", () => {
       const state = fold([
-        confirmedEvent({ costNanoUsd: 5_000_000_000, id: "a" }),
-        confirmedEvent({ costNanoUsd: 7_340_000_000, id: "b" }),
+        observedEvent({
+          costNanoMinor: 5_000_000_000,
+          observedAtMs: DAY_MS,
+          restatementKey: "bucket-a",
+        }),
+        observedEvent({
+          costNanoMinor: 7_340_000_000,
+          observedAtMs: DAY_MS,
+          restatementKey: "bucket-b",
+        }),
       ]);
       expect(governanceCostRollupTotals(state).amountNanoUsd).toBe(
         12_340_000_000,
@@ -341,62 +312,49 @@ describe("GovernanceCostRollupFoldProjection", () => {
     });
 
     it("keeps the provider's business day, not the ingest day", () => {
-      const state = fold([confirmedEvent({ costNanoUsd: 1_000 })]);
+      const state = fold([
+        observedEvent({
+          costNanoMinor: 1_000,
+          observedAtMs: Date.parse("2026-08-03T04:00:00.000Z"),
+        }),
+      ]);
       expect(state.day).toBe("2026-08-01");
     });
 
-    it("states the currency rather than leaving it implied", () => {
-      const state = fold([confirmedEvent({ costNanoUsd: 1_000 })]);
+    it("states the currency and the lane rather than leaving them implied", () => {
+      const state = fold([
+        observedEvent({ costNanoMinor: 1_000, observedAtMs: DAY_MS }),
+      ]);
       expect(state.currencyCode).toBe(GOVERNANCE_COST_CURRENCY_USD);
-      expect(state.costSource).toBe(GOVERNANCE_COST_SOURCE.GATEWAY);
+      expect(state.costSource).toBe(GOVERNANCE_COST_SOURCE.PULLED);
     });
   });
 
-  describe("given a failed outcome that still consumed tokens", () => {
-    // Partial usage before a mid-stream failure is real spend on several
-    // providers, and the shipped budget ledger debits it (gatewayDebits mints
-    // `debits:failed` as readily as `debits:confirmed`). The rollup counts the
-    // same money the ledger charges for, or the two disagree by construction.
-    it("counts the money a failure already cost", () => {
-      const failed = {
-        ...(confirmedEvent({ costNanoUsd: 900, id: "f" }) as never as Record<
-          string,
-          unknown
-        >),
-        type: "lw.gateway.spend.failed",
-      } as never;
-      (failed as unknown as { data: Record<string, unknown> }).data.error = {
-        type: "provider_timeout",
-        http_status: 504,
-      };
-      expect(governanceCostRollupTotals(fold([failed])).amountNanoUsd).toBe(
-        900,
-      );
-    });
-  });
-
-  describe("given an admission or a settlement", () => {
-    // Neither carries a cost, and their dimensions are pre-resolution — the
-    // gateway only settles model and provider after dispatch — so grouping
-    // them would file a permanent amount-less row beside the real one.
-    //
+  describe("given the events the fold subscribes to", () => {
     // The list stays EXACT rather than becoming a "does not include" check.
     // Exactness is what makes an accidental subscription fail here, and a
     // subscription is not a thing anyone adds by accident twice.
     //
-    // The retraction belongs on it and is not a counter-example to the rule
-    // above: it is not pre-resolution and it does not lack a cost. It carries
-    // the retracted cell's own resolved dimensions and states its amount as
-    // zero on purpose, so it addresses one existing cell rather than filing a
-    // new amount-less one. Leaving it off is what breaks the fold — the
-    // projection would never see the event that withdraws a superseded charge.
-    it("does not react to the events that carry no money", () => {
+    // The retraction belongs on it: it carries the retracted cell's own
+    // resolved dimensions and states its amount as zero on purpose, so it
+    // addresses one existing cell rather than filing a new amount-less one.
+    // Leaving it off is what breaks the fold — the projection would never see
+    // the event that withdraws a superseded charge.
+    it("reacts to the two pulled events and nothing else", () => {
       expect(projection().eventTypes).toEqual([
-        "lw.gateway.spend.confirmed",
-        "lw.gateway.spend.failed",
         "lw.obs.pulled_usage.observed",
         "lw.obs.pulled_usage.retracted",
       ]);
+    });
+
+    // The metered lane once folded here too, writing gateway cells the cost
+    // screen never read. It is served from its own per-request ledger now, so
+    // a gateway subscription reappearing on this fold is the regression.
+    it("subscribes to no gateway event", () => {
+      const gatewayTypes = projection().eventTypes.filter((type) =>
+        type.startsWith("lw.gateway."),
+      );
+      expect(gatewayTypes).toEqual([]);
     });
   });
 
@@ -410,13 +368,15 @@ describe("GovernanceCostRollupFoldProjection", () => {
   });
 
   describe("given a figure the provider stated in another currency", () => {
-    // Both wave-1 producers emit USD. The rule still has to hold before the
-    // first non-USD producer arrives, or it arrives to a table that has been
-    // silently reading its figures as dollars.
     it("reports no dollar amount rather than passing the foreign figure off as dollars", () => {
-      const state = fold([confirmedEvent({ costNanoUsd: 5_000 })]);
-      const inEuros = { ...state, currencyCode: "EUR" };
-      const totals = governanceCostRollupTotals(inEuros);
+      const state = fold([
+        observedEvent({
+          costNanoMinor: 5_000,
+          currencyCode: "EUR",
+          observedAtMs: DAY_MS,
+        }),
+      ]);
+      const totals = governanceCostRollupTotals(state);
       expect(totals.amountNanoUsd).toBe(null);
       expect(totals.amountNanoMinor).toBe(5_000);
     });
@@ -490,40 +450,30 @@ describe("GovernanceCostRollupFoldProjection", () => {
   describe("given events arriving out of business-time order", () => {
     // The executor's re-fold loads history by `context.aggregateId`
     // (foldProjectionExecutor.ts) — the EVENT's aggregate, which for this fold
-    // is one gateway request or one pulled item, never the day-wide group the
-    // key names. A re-fold would therefore rebuild the day out of one
-    // request's events and throw the rest of the day away. The fold's
-    // accumulators commute and its restatement rule keys on data the event
-    // carries (`observedAtMs`), so there is nothing a replay could derive.
+    // is one pulled item, never the day-wide group the key names. A re-fold
+    // would therefore rebuild the day out of one item's events and throw the
+    // rest of the day away. The fold's accumulators commute and its
+    // restatement rule keys on data the event carries (`observedAtMs`), so
+    // there is nothing a replay could derive.
     it("declines the out-of-order re-fold that would load the wrong population", () => {
       expect(projection().options.refoldOnOutOfOrder).toBe(false);
     });
 
-    it("reaches the same total whichever order the outcomes arrive in", () => {
-      const forwards = fold([
-        confirmedEvent({
-          costNanoUsd: 300,
-          occurredAt: Date.parse("2026-08-01T01:00:00.000Z"),
-          id: "a",
-        }),
-        confirmedEvent({
-          costNanoUsd: 700,
-          occurredAt: Date.parse("2026-08-01T02:00:00.000Z"),
-          id: "b",
-        }),
-      ]);
-      const backwards = fold([
-        confirmedEvent({
-          costNanoUsd: 700,
-          occurredAt: Date.parse("2026-08-01T02:00:00.000Z"),
-          id: "b",
-        }),
-        confirmedEvent({
-          costNanoUsd: 300,
-          occurredAt: Date.parse("2026-08-01T01:00:00.000Z"),
-          id: "a",
-        }),
-      ]);
+    it("reaches the same total whichever order the items arrive in", () => {
+      const first = observedEvent({
+        costNanoMinor: 300,
+        restatementKey: "bucket-a",
+        observedAtMs: Date.parse("2026-08-02T01:00:00.000Z"),
+        id: "a",
+      });
+      const second = observedEvent({
+        costNanoMinor: 700,
+        restatementKey: "bucket-b",
+        observedAtMs: Date.parse("2026-08-02T02:00:00.000Z"),
+        id: "b",
+      });
+      const forwards = fold([first, second]);
+      const backwards = fold([second, first]);
       // The value first, then the equality. `toBe` is Object.is, so NaN
       // equals NaN — an assertion of equality alone passes for a fold that
       // read the money field under a name the events do not carry, which is

--- a/platform/app/ee/governance/projections/__tests__/governanceCostRollup.integration.test.ts
+++ b/platform/app/ee/governance/projections/__tests__/governanceCostRollup.integration.test.ts
@@ -37,10 +37,7 @@ import {
   type GovernanceCostRollupState,
   governanceCostRollupKey,
 } from "../governanceCostRollup.foldProjection";
-import {
-  GovernanceCostRollupStore,
-  projectGovernanceCostRollupStateToRow,
-} from "../governanceCostRollup.store";
+import { GovernanceCostRollupStore } from "../governanceCostRollup.store";
 
 /** Well inside the 13-month TTL horizon, so nothing is swept mid-test. */
 const DAY = "2026-08-01";
@@ -50,58 +47,6 @@ let ch: ClickHouseClient;
 let repo: GovernanceCostRollupClickHouseRepository;
 let store: GovernanceCostRollupStore;
 let tenantId: string;
-
-function confirmed({
-  costNanoUsd,
-  principalUserId = "user_ada",
-  model = "openai/gpt-5-mini",
-  id = nanoid(),
-  occurredAt = DAY_MS,
-}: {
-  costNanoUsd: number;
-  principalUserId?: string;
-  model?: string;
-  id?: string;
-  occurredAt?: number;
-}) {
-  return {
-    id,
-    type: "lw.gateway.spend.confirmed",
-    tenantId,
-    aggregateId: `gwreq-${id}`,
-    occurredAt,
-    data: {
-      gateway_request_id: `gwreq-${id}`,
-      occurred_at: occurredAt,
-      tenantId,
-      organization_id: "org_acme",
-      virtual_key_id: "vk_1",
-      principal_user_id: principalUserId,
-      end_user_id: "",
-      trace_id: "",
-      request_type: "chat",
-      labels: [],
-      metadata: "",
-      admitted_at: occurredAt,
-      team_id: "",
-      model,
-      model_provider_id: "openai",
-      usage: {
-        input_tokens: 100,
-        output_tokens: 20,
-        cache_read_input_tokens: 0,
-        cache_creation_input_tokens: 0,
-        reasoning_tokens: 0,
-        input_audio_tokens: 0,
-        output_audio_tokens: 0,
-        input_chars: 0,
-      },
-      rate_version: "registry@2026-08-01",
-      duration_ms: 120,
-      cost_nano_usd: costNanoUsd,
-    },
-  };
-}
 
 /**
  * One pulled observation.
@@ -118,6 +63,7 @@ function observed({
   observedAtMs,
   restatementKey = "bucket-hash",
   costStatus = "estimate",
+  rawActorId = "",
   id = nanoid(),
 }: {
   costNanoMinor: number;
@@ -126,6 +72,7 @@ function observed({
   observedAtMs: number;
   restatementKey?: string;
   costStatus?: "exact" | "estimate";
+  rawActorId?: string;
   id?: string;
 }) {
   return {
@@ -153,6 +100,7 @@ function observed({
       rateVersion: "registry@2026-08-01",
       costBasis: "computed",
       costStatus,
+      rawActorId,
       occurredAtMs: DAY_MS,
       observedAtMs,
     },
@@ -242,10 +190,7 @@ async function restatementIndexRows(
 
 /** Folds an event through the real executor, so redelivery dedup is exercised. */
 async function foldThroughExecutor(
-  event:
-    | ReturnType<typeof confirmed>
-    | ReturnType<typeof observed>
-    | ReturnType<typeof retracted>,
+  event: ReturnType<typeof observed> | ReturnType<typeof retracted>,
   { deliveryAttempt = 1 }: { deliveryAttempt?: number } = {},
 ): Promise<void> {
   const projection = new GovernanceCostRollupFoldProjection({ store });
@@ -374,6 +319,29 @@ function pricedCell({
   };
 }
 
+/**
+ * A metered-lane row an older build left behind. The fold no longer writes
+ * these — the metered lane is read straight off its own per-request ledger —
+ * but production still holds the ones it wrote, so a test about the pulled
+ * lane's reads has to survive one sitting beside its rows.
+ */
+function leftoverGatewayCell({
+  amountNanoUsd,
+  at,
+}: {
+  amountNanoUsd: number;
+  at: number;
+}): GovernanceCostRollupRow {
+  return {
+    ...pricedCell({ amountNanoUsd, at }),
+    CostSource: GOVERNANCE_COST_SOURCE.GATEWAY,
+    IngestionSourceId: "",
+    Provider: "openai",
+    Model: "openai/gpt-5-mini",
+    RawActorId: "user_ada",
+  };
+}
+
 describe("governance cost rollup", () => {
   beforeAll(async () => {
     const client = getTestClickHouseClient();
@@ -415,8 +383,22 @@ describe("governance cost rollup", () => {
   describe("given cost events for one day and one dimension combination", () => {
     /** @scenario "A day's spend lands as one summary row per dimension combination" */
     it("holds exactly one row whose amount is the sum of those events", async () => {
-      await foldThroughExecutor(confirmed({ costNanoUsd: 5_000_000_000 }));
-      await foldThroughExecutor(confirmed({ costNanoUsd: 7_340_000_000 }));
+      // Two different provider items sharing one cell, so the day is a SUM
+      // rather than a restatement of one item.
+      await foldThroughExecutor(
+        observed({
+          costNanoMinor: 5_000_000_000,
+          restatementKey: "bucket-a",
+          observedAtMs: DAY_MS,
+        }),
+      );
+      await foldThroughExecutor(
+        observed({
+          costNanoMinor: 7_340_000_000,
+          restatementKey: "bucket-b",
+          observedAtMs: DAY_MS,
+        }),
+      );
 
       const cells = await repo.findCellsForDay({ tenantId, day: DAY });
       expect(cells).toHaveLength(1);
@@ -432,12 +414,19 @@ describe("governance cost rollup", () => {
     /** @scenario "Two spenders with identical numbers stay two rows after compaction" */
     it("still holds a separate row for each spender", async () => {
       await foldThroughExecutor(
-        confirmed({ costNanoUsd: 5_000_000_000, principalUserId: "user_ada" }),
+        observed({
+          costNanoMinor: 5_000_000_000,
+          restatementKey: "bucket-ada",
+          rawActorId: "user_ada",
+          observedAtMs: DAY_MS,
+        }),
       );
       await foldThroughExecutor(
-        confirmed({
-          costNanoUsd: 5_000_000_000,
-          principalUserId: "user_grace",
+        observed({
+          costNanoMinor: 5_000_000_000,
+          restatementKey: "bucket-grace",
+          rawActorId: "user_grace",
+          observedAtMs: DAY_MS,
         }),
       );
 
@@ -460,28 +449,20 @@ describe("governance cost rollup", () => {
   describe("given one day has events in two currencies", () => {
     /** @scenario "Amounts in different currencies stay separate rows after compaction" */
     it("keeps each currency's own total and produces no combined figure", async () => {
-      // Both wave-1 producers emit USD, so the second currency is written
-      // through the same projection function the fold writes with — what is
-      // under test is the dedup KEY, which is what the first non-USD producer
-      // will arrive to.
-      const base = new GovernanceCostRollupFoldProjection({ store }).apply(
-        new GovernanceCostRollupFoldProjection({ store }).init(),
-        confirmed({ costNanoUsd: 5_000_000_000 }) as never,
-      );
+      // Two provider items billed in two currencies, folded through the real
+      // store: what is under test is the dedup KEY, so the currency has to
+      // survive the trip from the event rather than be set on a hand-built
+      // row. The euro item carries no dollar figure of its own.
       for (const [currencyCode, amount] of [
         ["USD", 5_000_000_000],
         ["EUR", 4_200_000_000],
       ] as const) {
-        await repo.upsert(
-          projectGovernanceCostRollupStateToRow({
-            state: {
-              ...base,
-              currencyCode,
-              gatewayAmountNanoMinor: amount,
-            },
-            tenantId,
-            version: GOVERNANCE_COST_ROLLUP_PROJECTION_VERSION_LATEST,
-            appliedEventIds: [],
+        await foldThroughExecutor(
+          observed({
+            costNanoMinor: amount,
+            currencyCode,
+            restatementKey: `bucket-${currencyCode}`,
+            observedAtMs: DAY_MS,
           }),
         );
       }
@@ -761,7 +742,7 @@ describe("governance cost rollup", () => {
   });
 
   describe("given a restated day read through the screen's range query", () => {
-    it("totals only the surviving version, and keeps the two lanes apart", async () => {
+    it("totals only the surviving version, and keeps a leftover metered row out of it", async () => {
       await foldThroughExecutor(
         observed({
           costNanoMinor: 12_340_000_000,
@@ -775,13 +756,16 @@ describe("governance cost rollup", () => {
           costStatus: "exact",
         }),
       );
-      await foldThroughExecutor(confirmed({ costNanoUsd: 5_000_000_000 }));
+      // A metered row an older build wrote, still on disk in production.
+      await repo.upsert(
+        leftoverGatewayCell({ amountNanoUsd: 5_000_000_000, at: 1_000 }),
+      );
 
       // Deliberately NOT compacted: the superseded version is still there, so
-      // the read has to survive it rather than wait for a merge.
-      // Deliberately NOT compacted. The self-check: the table must still hold
-      // more physical rows than the read returns cells, or this test would be
-      // asserting dedup against data that has nothing left to dedup.
+      // the read has to survive it rather than wait for a merge. The
+      // self-check: the table must still hold more physical rows than the read
+      // returns cells, or this test would be asserting dedup against data that
+      // has nothing left to dedup.
       const rawRows = await rawRowCount();
       expect(rawRows).toBe(3);
 
@@ -794,12 +778,13 @@ describe("governance cost rollup", () => {
       expect(rawRows).toBeGreaterThan(lanes.length);
 
       const pulled = lanes.find((lane) => lane.costSource === "pulled");
-      const gateway = lanes.find((lane) => lane.costSource === "gateway");
       expect(pulled?.amountNanoUsd).toBe(9_000_000_000);
-      expect(gateway?.amountNanoUsd).toBe(5_000_000_000);
-      // The lanes are never combined — a summed figure is the defect.
-      expect(lanes).toHaveLength(2);
       expect(pulled?.day).toBe(DAY);
+      // The leftover is never folded into the pulled figure — a summed
+      // 14_000_000_000 anywhere in the answer is the defect.
+      expect(lanes.every((lane) => lane.amountNanoUsd !== 14_000_000_000)).toBe(
+        true,
+      );
     });
 
     it("answers null, never zero, for a window nothing reported", async () => {
@@ -882,11 +867,16 @@ describe("governance cost rollup", () => {
   });
 
   describe("given the same event is redelivered after its state was stored", () => {
-    // Queue delivery is at-least-once and this fold ACCUMULATES: without the
-    // applied-event-id watermark riding on the row, a retry that reaches a
-    // cold cache re-adds the same money and the day silently doubles.
+    // Queue delivery is at-least-once. The applied-event-id watermark riding
+    // on the row is what stops a retry that reaches a cold cache from folding
+    // the same event a second time; the pulled lane's restatement rule would
+    // catch this particular redelivery too, so this pins the seam rather than
+    // proving the watermark alone.
     it("does not count the money twice", async () => {
-      const event = confirmed({ costNanoUsd: 5_000_000_000 });
+      const event = observed({
+        costNanoMinor: 5_000_000_000,
+        observedAtMs: DAY_MS,
+      });
       await foldThroughExecutor(event);
       await foldThroughExecutor(event, { deliveryAttempt: 2 });
 
@@ -900,11 +890,23 @@ describe("governance cost rollup", () => {
     /** @scenario "Rebuilding the summary from history reproduces it exactly" */
     it("reproduces every row when rebuilt from the event history", async () => {
       const history = [
-        confirmed({ costNanoUsd: 5_000_000_000, principalUserId: "user_ada" }),
-        confirmed({ costNanoUsd: 7_340_000_000, principalUserId: "user_ada" }),
-        confirmed({
-          costNanoUsd: 1_000_000_000,
-          principalUserId: "user_grace",
+        observed({
+          costNanoMinor: 5_000_000_000,
+          restatementKey: "bucket-ada-1",
+          rawActorId: "user_ada",
+          observedAtMs: DAY_MS,
+        }),
+        observed({
+          costNanoMinor: 7_340_000_000,
+          restatementKey: "bucket-ada-2",
+          rawActorId: "user_ada",
+          observedAtMs: DAY_MS,
+        }),
+        observed({
+          costNanoMinor: 1_000_000_000,
+          restatementKey: "bucket-grace",
+          rawActorId: "user_grace",
+          observedAtMs: DAY_MS,
         }),
       ];
       for (const event of history) await foldThroughExecutor(event);
@@ -978,14 +980,16 @@ describe("governance cost rollup", () => {
         clickhouse_settings: { async_insert: 0, wait_for_async_insert: 0 },
       });
 
-      await foldThroughExecutor(confirmed({ costNanoUsd: 5_000_000_000 }));
+      await foldThroughExecutor(
+        observed({ costNanoMinor: 5_000_000_000, observedAtMs: DAY_MS }),
+      );
 
       const cells = await repo.findCellsForDay({ tenantId, day: DAY });
       // The trace's 42.5 USD is nowhere in the summary, under any label: the
-      // only row is the gateway one, and the lane vocabulary has no third
+      // only row is the pulled one, and the lane vocabulary has no third
       // value for a trace to hide behind.
       expect(cells).toHaveLength(1);
-      expect(cells[0]!.CostSource).toBe(GOVERNANCE_COST_SOURCE.GATEWAY);
+      expect(cells[0]!.CostSource).toBe(GOVERNANCE_COST_SOURCE.PULLED);
       expect(cells[0]!.AmountNanoUsd).toBe(5_000_000_000);
       expect(cells.some((cell) => cell.CostSource.includes("trace"))).toBe(
         false,

--- a/platform/app/ee/governance/projections/__tests__/governanceCostRollupRestatement.unit.test.ts
+++ b/platform/app/ee/governance/projections/__tests__/governanceCostRollupRestatement.unit.test.ts
@@ -95,55 +95,6 @@ function observedEvent({
   } as never;
 }
 
-/** One priced gateway outcome, as the ingest seam appends it. */
-function confirmedEvent({
-  costNanoUsd,
-  occurredAt = DAY_MS,
-  id = `evt-gw-${occurredAt}`,
-}: {
-  costNanoUsd: number;
-  occurredAt?: number;
-  id?: string;
-}) {
-  return {
-    id,
-    type: "lw.gateway.spend.confirmed",
-    tenantId: TENANT,
-    aggregateId: `gwreq-${id}`,
-    occurredAt,
-    data: {
-      gateway_request_id: `gwreq-${id}`,
-      occurred_at: occurredAt,
-      tenantId: TENANT,
-      organization_id: "org_acme",
-      virtual_key_id: "vk_1",
-      principal_user_id: "user_ada",
-      end_user_id: "",
-      trace_id: "",
-      request_type: "chat",
-      labels: [],
-      metadata: "",
-      admitted_at: occurredAt,
-      team_id: "",
-      model: "openai/gpt-5-mini",
-      model_provider_id: "openai",
-      usage: {
-        input_tokens: 100,
-        output_tokens: 20,
-        cache_read_input_tokens: 0,
-        cache_creation_input_tokens: 0,
-        reasoning_tokens: 0,
-        input_audio_tokens: 0,
-        output_audio_tokens: 0,
-        input_chars: 0,
-      },
-      rate_version: "registry@2026-08-01",
-      duration_ms: 120,
-      cost_nano_usd: costNanoUsd,
-    },
-  } as never;
-}
-
 /**
  * The event that withdraws what one restatement key holds in the cell it is
  * currently filed under.
@@ -395,19 +346,6 @@ describe("the restatement marker", () => {
       expect(reversed.revisionCount).toBe(2);
     });
   });
-
-  describe("given a gateway outcome", () => {
-    it("never marks the day revised, because nothing restates one", () => {
-      const state = fold([
-        confirmedEvent({ costNanoUsd: 5_000, id: "a" }),
-        confirmedEvent({ costNanoUsd: 7_000, id: "b" }),
-      ]);
-
-      expect(governanceCostRollupTotals(state).amountNanoUsd).toBe(12_000);
-      expect(state.revisedAt).toBe(null);
-      expect(state.revisionCount).toBe(0);
-    });
-  });
 });
 
 describe("the last-observed anchor", () => {
@@ -492,20 +430,6 @@ describe("the last-observed anchor", () => {
       // log delivered newest-first needs every observation of the item, not
       // just the newest two. Left as its own decision rather than quietly
       // redefined into "how many items changed".
-    });
-  });
-
-  describe("given a gateway outcome", () => {
-    it("anchors on the moment the request was served", () => {
-      const served = Date.parse("2026-08-01T18:00:00.000Z");
-      const state = fold([
-        confirmedEvent({ costNanoUsd: 5_000, occurredAt: served }),
-      ]);
-
-      // We metered it as we served it, so serving time IS observation time
-      // here. The read side exempts the lane from the provisional marker
-      // outright rather than relying on this arithmetic.
-      expect(state.lastObservedAt).toBe(served);
     });
   });
 });

--- a/platform/app/ee/governance/projections/governanceCostRollup.constants.ts
+++ b/platform/app/ee/governance/projections/governanceCostRollup.constants.ts
@@ -3,9 +3,10 @@
 /**
  * Identifiers for the daily governance cost rollup (ADR-128 wave 1).
  *
- * The fold is registered on TWO pipelines — gateway spend and pulled usage —
- * so its name, version and table live here rather than under either pipeline's
- * own `schemas/`.
+ * The fold is registered on the pulled-usage pipeline alone; the metered lane
+ * is read straight off the gateway ledger and never reaches it. The name,
+ * version and table still live here rather than under that pipeline's own
+ * `schemas/`, because the comparator and the cost screen read them too.
  */
 
 export const GOVERNANCE_COST_ROLLUP_PROJECTION_NAME = "governanceCostRollup";

--- a/platform/app/ee/governance/projections/governanceCostRollup.foldProjection.ts
+++ b/platform/app/ee/governance/projections/governanceCostRollup.foldProjection.ts
@@ -8,12 +8,6 @@ import {
   readPulledUsageMoney,
 } from "@ee/event-sourcing/pipelines/pulled-usage-processing/schemas/events";
 import {
-  type GatewaySpendConfirmedEvent,
-  type GatewaySpendFailedEvent,
-  gatewaySpendConfirmedEventSchema,
-  gatewaySpendFailedEventSchema,
-} from "~/server/event-sourcing/pipelines/gateway-spend-processing/schemas/events";
-import {
   AbstractFoldProjection,
   type FoldEventHandlers,
 } from "~/server/event-sourcing/projections/abstractFoldProjection";
@@ -29,18 +23,16 @@ import {
 } from "./governanceCostRollup.constants";
 
 /**
- * The events that carry money.
+ * The events that carry money: the pulled lane's observation and the
+ * retraction that withdraws one.
  *
- * `admitted` and `settled` are deliberately absent. Neither carries a cost —
- * admission is a request, settlement is the admission of not knowing — and
- * their dimensions are PRE-resolution: the gateway only settles model and
- * provider after dispatch, so grouping an admission by its requested model
- * would file it under a cell its own outcome never joins, leaving a permanent
- * amount-less row beside the real one.
+ * No gateway event, deliberately. The metered lane is read straight off
+ * `gateway_spend`, the per-request ledger its own pipeline projects, so a
+ * rollup half for it summarized cells the cost screen never read. Adding one
+ * back here would put the fold on two pipelines again and file gateway money
+ * under the trace project's tenant, which is where the unread cells went.
  */
 const governanceCostRollupEvents = [
-  gatewaySpendConfirmedEventSchema,
-  gatewaySpendFailedEventSchema,
   PulledUsageObservedEventSchema,
   PulledUsageRetractedEventSchema,
 ] as const;
@@ -122,25 +114,15 @@ export interface GovernanceCostRollupState {
   exactOrEstimate: "" | "exact" | "estimate";
 
   /**
-   * The gateway lane's running total. Gateway outcomes are never restated —
-   * one priced outcome per request, which is the same assumption the shipped
-   * budget ledger makes (`gatewayDebits` mints one debit per outcome) — so the
-   * lane is pure accumulation, made safe against redelivery by the store's
-   * applied-event-id watermark rather than by a per-request ledger.
-   */
-  gatewayAmountNanoMinor: number;
-  gatewayTokensInput: number;
-  gatewayTokensOutput: number;
-  gatewayTokensCacheRead: number;
-  gatewayTokensCacheWrite: number;
-  gatewayRequestCount: number;
-
-  /**
-   * The pulled lane's newest observation per provider item. This is what makes
-   * a restatement REPLACE rather than add. Bounded by the number of distinct
+   * The newest observation per provider item. This is what makes a
+   * restatement REPLACE rather than add. Bounded by the number of distinct
    * provider items sharing this one day x dimension cell — one, for the
    * bucketed admin-API pullers wave 1 ships, whose restatement key hashes the
    * same coordinates this cell is keyed by.
+   *
+   * The only money the cell holds. There is no second, accumulating lane
+   * beside it: the metered lane never reaches this fold (see the event list),
+   * so every figure the row carries is derived from this map.
    */
   pulledItems: Record<string, PulledContribution>;
 
@@ -322,43 +304,25 @@ function dimensionsOf(event: {
       // parses these events on the way in, so a legacy event would otherwise
       // put `undefined` in the key.
       //
-      // Routed through the erasure substitution exactly like the gateway
-      // branch below, and for the same reason: this tuple is the row's key,
-      // and a replay that re-derived an erased original would write it back
-      // beside the pseudonymized row and double the amount.
+      // Substituted for a pseudonym when this identifier has been erased
+      // (ADR-128 §9 step 5). It has to happen HERE rather than at the store,
+      // because this tuple is also the row's key: erasure removes the old
+      // rows and replays the days, and a replay that re-derived the original
+      // would write it back beside the pseudonymized row and double the
+      // amount.
       rawActorId: actorIdForRollupWrite({
         tenantId: event.tenantId,
         rawActorId: d.rawActorId ?? "",
       }),
     };
   }
-  const d = event.data as unknown as GatewaySpendConfirmedEvent["data"];
-  return {
-    tenantId: event.tenantId,
-    day: utcDayOf(d.occurred_at),
-    costSource: GOVERNANCE_COST_SOURCE.GATEWAY,
-    ingestionSourceId: "",
-    provider: d.model_provider_id,
-    model: d.model,
-    // Honestly blank, not a stub (#7881): the gateway spend event carries no
-    // agent field, so this lane has nothing to report until it does.
-    agentId: "",
-    // The gateway prices every outcome off its own dollar-denominated rate
-    // table, so this lane has one currency and it is not read off the event.
-    currencyCode: GOVERNANCE_COST_CURRENCY_USD,
-    // The spender is the key's principal; the caller's own end user is the
-    // fallback for a key with no resolved principal.
-    //
-    // Substituted for a pseudonym when this identifier has been erased
-    // (ADR-128 §9 step 5). It has to happen HERE rather than at the store,
-    // because this tuple is also the row's key: erasure removes the old rows
-    // and replays the days, and a replay that re-derived the original would
-    // write it back beside the pseudonymized row and double the amount.
-    rawActorId: actorIdForRollupWrite({
-      tenantId: event.tenantId,
-      rawActorId: d.principal_user_id || d.end_user_id,
-    }),
-  };
+  // Loud rather than a guessed cell. The only way an undeclared type reaches
+  // this is a caller folding events the projection does not subscribe to (the
+  // comparator's re-derivation, say); addressing a row for it would write
+  // money under a cell nothing else can account for.
+  throw new Error(
+    `governance cost rollup cannot address a cell for a ${event.type} event`,
+  );
 }
 
 /** The dimension tuple a rollup key addresses. */
@@ -470,10 +434,10 @@ export function decodeGovernanceCostRollupKey(
  *
  * Three cases, and the order matters. A cell nothing has contributed to has no
  * figure at all. A cell billed in dollars needs no conversion — the amount IS
- * the dollar amount, for either lane. A cell billed in anything else can only
- * be stated in dollars by the BILLER, so it is the sum of the biller's own
- * per-item figures, and only when every item carries one: a partial sum reads
- * as the day's whole spend while silently omitting the part nobody converted.
+ * the dollar amount. A cell billed in anything else can only be stated in
+ * dollars by the BILLER, so it is the sum of the biller's own per-item
+ * figures, and only when every item carries one: a partial sum reads as the
+ * day's whole spend while silently omitting the part nobody converted.
  *
  * No rate is applied here or anywhere else (ADR-128 §3). Null, never 0: zero
  * is a real amount and charts as free usage, while the absence of a figure is
@@ -482,21 +446,16 @@ export function decodeGovernanceCostRollupKey(
 function amountNanoUsdOf({
   state,
   amountNanoMinor,
-  contributed,
 }: {
   state: GovernanceCostRollupState;
   amountNanoMinor: number;
-  contributed: boolean;
 }): number | null {
-  if (!contributed) return null;
+  const items = Object.values(state.pulledItems);
+  if (items.length === 0) return null;
   if (state.currencyCode === GOVERNANCE_COST_CURRENCY_USD) {
     return amountNanoMinor;
   }
-  // Below here the cell is not in dollars. The gateway lane never is, so a
-  // gateway contribution in a non-dollar cell is a cell we cannot state.
-  if (state.gatewayRequestCount > 0) return null;
 
-  const items = Object.values(state.pulledItems);
   let total = 0;
   for (const item of items) {
     const billerUsd = item.amountNanoUsd ?? null;
@@ -507,7 +466,7 @@ function amountNanoUsdOf({
 }
 
 /**
- * The cell's figures, derived from the two lanes' contributions.
+ * The cell's figures, derived from the items it holds.
  *
  * `amountNanoUsd` is NULL, never 0, when the cell holds no USD figure — see
  * `amountNanoUsdOf` for the three cases.
@@ -522,46 +481,42 @@ export function governanceCostRollupTotals(state: GovernanceCostRollupState): {
   requestCount: number;
 } {
   const items = Object.values(state.pulledItems);
-  const amountNanoMinor =
-    state.gatewayAmountNanoMinor +
-    items.reduce((sum, item) => sum + item.amountNanoMinor, 0);
-  const contributed = state.gatewayRequestCount > 0 || items.length > 0;
+  const amountNanoMinor = items.reduce(
+    (sum, item) => sum + item.amountNanoMinor,
+    0,
+  );
   return {
-    amountNanoUsd: amountNanoUsdOf({ state, amountNanoMinor, contributed }),
+    amountNanoUsd: amountNanoUsdOf({ state, amountNanoMinor }),
     amountNanoMinor,
-    tokensInput:
-      state.gatewayTokensInput +
-      items.reduce((sum, item) => sum + item.tokensInput, 0),
-    tokensOutput:
-      state.gatewayTokensOutput +
-      items.reduce((sum, item) => sum + item.tokensOutput, 0),
-    tokensCacheRead:
-      state.gatewayTokensCacheRead +
-      items.reduce((sum, item) => sum + item.tokensCacheRead, 0),
-    tokensCacheWrite:
-      state.gatewayTokensCacheWrite +
-      items.reduce((sum, item) => sum + item.tokensCacheWrite, 0),
-    requestCount: state.gatewayRequestCount + items.length,
+    tokensInput: items.reduce((sum, item) => sum + item.tokensInput, 0),
+    tokensOutput: items.reduce((sum, item) => sum + item.tokensOutput, 0),
+    tokensCacheRead: items.reduce((sum, item) => sum + item.tokensCacheRead, 0),
+    tokensCacheWrite: items.reduce(
+      (sum, item) => sum + item.tokensCacheWrite,
+      0,
+    ),
+    requestCount: items.length,
   };
 }
 
 /**
  * The daily cost rollup fold (ADR-128 wave 1).
  *
- * Registered on TWO pipelines — gateway spend and pulled usage — because the
- * customer's question ("what did this day cost") spans both lanes and a rollup
- * per pipeline would answer half of it. The two can never contend for a row:
- * `costSource` is part of the key, so a gateway cell and a pulled cell are
- * different cells by construction.
+ * Registered on the pulled-usage pipeline alone. It once sat on the gateway
+ * spend pipeline too, but the cost screen reads the metered lane straight off
+ * `gateway_spend`, so the gateway cells it wrote were never read — and were
+ * filed under the trace project's tenant besides. `costSource` stays in the
+ * key because rows from that time are still on disk and the read side filters
+ * on it.
  *
  * The trace lane is RESERVED and excluded: ADR-128 keeps trace cost a separate
  * per-request system, and no pipeline carrying it registers this fold, so no
  * row can carry trace cost under any label.
  *
- * Money is copied, never recomputed: both lanes price once at their own ingest
- * seam and carry an integer nano-USD figure, which this fold sums. Re-pricing
- * is a rebuild against the log, never a side effect of whichever consumer ran
- * after a catalog deploy.
+ * Money is copied, never recomputed: the puller prices once at its own ingest
+ * seam and carries an integer nano-minor figure, which this fold sums.
+ * Re-pricing is a rebuild against the log, never a side effect of whichever
+ * consumer ran after a catalog deploy.
  */
 export class GovernanceCostRollupFoldProjection
   extends AbstractFoldProjection<
@@ -647,37 +602,12 @@ export class GovernanceCostRollupFoldProjection
       rawActorId: "",
       organizationId: "",
       exactOrEstimate: "",
-      gatewayAmountNanoMinor: 0,
-      gatewayTokensInput: 0,
-      gatewayTokensOutput: 0,
-      gatewayTokensCacheRead: 0,
-      gatewayTokensCacheWrite: 0,
-      gatewayRequestCount: 0,
       pulledItems: {},
       revisionCount: 0,
       previousAmountNanoUsd: null,
       revisedAt: null,
       lastObservedAt: 0,
     };
-  }
-
-  handleGatewaySpendConfirmed(
-    event: GatewaySpendConfirmedEvent,
-    state: GovernanceCostRollupState,
-  ): GovernanceCostRollupState {
-    return this.addGatewayOutcome(event, state);
-  }
-
-  /**
-   * A failure that already consumed tokens is real spend on several providers,
-   * and the shipped budget ledger charges for it. Counting it here keeps the
-   * rollup and the ledger stating the same money.
-   */
-  handleGatewaySpendFailed(
-    event: GatewaySpendFailedEvent,
-    state: GovernanceCostRollupState,
-  ): GovernanceCostRollupState {
-    return this.addGatewayOutcome(event, state);
   }
 
   handlePulledUsageObserved(
@@ -925,37 +855,5 @@ export class GovernanceCostRollupFoldProjection
     }).amountNanoUsd;
 
     return { ...state, revisedAt, previousAmountNanoUsd: before };
-  }
-
-  private addGatewayOutcome(
-    event: GatewaySpendConfirmedEvent | GatewaySpendFailedEvent,
-    state: GovernanceCostRollupState,
-  ): GovernanceCostRollupState {
-    const d = event.data;
-    const usage = d.usage;
-    return {
-      ...state,
-      ...dimensionsOf(event as never),
-      organizationId: d.organization_id || state.organizationId,
-      // A gateway outcome is the provider's own charge for a served request:
-      // there is no later invoice to reconcile it against.
-      exactOrEstimate: "exact",
-      gatewayAmountNanoMinor: state.gatewayAmountNanoMinor + d.cost_nano_usd,
-      gatewayTokensInput: state.gatewayTokensInput + usage.input_tokens,
-      gatewayTokensOutput: state.gatewayTokensOutput + usage.output_tokens,
-      gatewayTokensCacheRead:
-        state.gatewayTokensCacheRead + usage.cache_read_input_tokens,
-      gatewayTokensCacheWrite:
-        state.gatewayTokensCacheWrite + usage.cache_creation_input_tokens,
-      gatewayRequestCount: state.gatewayRequestCount + 1,
-      // We metered this as we served it, so serving time IS observation time
-      // for this lane — same column, same meaning, no clock read. It never
-      // makes a gateway day render provisional: nothing restates a gateway
-      // outcome, so the read side exempts the lane outright rather than
-      // relying on the arithmetic to come out right (§15).
-      lastObservedAt: Math.max(state.lastObservedAt, d.occurred_at),
-      // `revisedAt`, `revisionCount` and `previousAmountNanoUsd` stay
-      // untouched: one priced outcome per request, never restated.
-    };
   }
 }

--- a/platform/app/ee/governance/projections/governanceCostRollup.store.ts
+++ b/platform/app/ee/governance/projections/governanceCostRollup.store.ts
@@ -81,25 +81,18 @@ export function projectGovernanceCostRollupStateToRow({
   };
 }
 
-/** Row → state, the inverse. */
+/**
+ * Row → state, the inverse.
+ *
+ * The row's total columns are not read back: every figure the fold states is
+ * derived from the item map, and the totals were written FROM that map, so
+ * the map alone reproduces them. Reading the totals as a second source would
+ * hand the fold two figures that can disagree, and nothing here could say
+ * which one the provider actually reported.
+ */
 export function governanceCostRollupStateFromRow(
   row: GovernanceCostRollupRow,
 ): GovernanceCostRollupState {
-  const pulledItems = decodePulledItems(row.PulledItemsJson);
-  const pulledAmount = Object.values(pulledItems).reduce(
-    (sum, item) => sum + item.amountNanoMinor,
-    0,
-  );
-  const pulledTokens = Object.values(pulledItems).reduce(
-    (acc, item) => ({
-      input: acc.input + item.tokensInput,
-      output: acc.output + item.tokensOutput,
-      cacheRead: acc.cacheRead + item.tokensCacheRead,
-      cacheWrite: acc.cacheWrite + item.tokensCacheWrite,
-    }),
-    { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-  );
-  const pulledCount = Object.keys(pulledItems).length;
   return {
     day: row.Day,
     costSource: row.CostSource as GovernanceCostSource,
@@ -112,17 +105,7 @@ export function governanceCostRollupStateFromRow(
     organizationId: row.OrganizationId,
     exactOrEstimate:
       row.ExactOrEstimate as GovernanceCostRollupState["exactOrEstimate"],
-    // The gateway lane's share is what the row's totals hold beyond the pulled
-    // items it also carries. The two lanes never share a row (CostSource is in
-    // the key), so exactly one of these is non-zero on any real row; the
-    // subtraction is what makes the round-trip exact either way.
-    gatewayAmountNanoMinor: row.AmountNanoMinor - pulledAmount,
-    gatewayTokensInput: row.TokensInput - pulledTokens.input,
-    gatewayTokensOutput: row.TokensOutput - pulledTokens.output,
-    gatewayTokensCacheRead: row.TokensCacheRead - pulledTokens.cacheRead,
-    gatewayTokensCacheWrite: row.TokensCacheWrite - pulledTokens.cacheWrite,
-    gatewayRequestCount: row.RequestCount - pulledCount,
-    pulledItems,
+    pulledItems: decodePulledItems(row.PulledItemsJson),
     revisionCount: row.RevisionCount,
     previousAmountNanoUsd: row.PreviousAmountNanoUsd,
     revisedAt: row.RevisedAt === null ? null : fromUnixSeconds(row.RevisedAt),

--- a/platform/app/ee/governance/routers/governanceCost.ts
+++ b/platform/app/ee/governance/routers/governanceCost.ts
@@ -91,6 +91,8 @@ export const governanceCostRouter = createTRPCRouter({
         prisma: ctx.prisma,
         costRollup: getApp().governance.costRollup,
         ocsfEvents: getApp().governance.ocsfEvents,
+        gatewaySpend: getApp().governance.gatewaySpend,
+        projects: getApp().governance.projects,
       });
       return await service.summary({
         organizationId: input.organizationId,
@@ -119,6 +121,8 @@ export const governanceCostRouter = createTRPCRouter({
         prisma: ctx.prisma,
         costRollup: getApp().governance.costRollup,
         ocsfEvents: getApp().governance.ocsfEvents,
+        gatewaySpend: getApp().governance.gatewaySpend,
+        projects: getApp().governance.projects,
       });
       return await service.dailyByProvider({
         organizationId: input.organizationId,
@@ -147,6 +151,8 @@ export const governanceCostRouter = createTRPCRouter({
         prisma: ctx.prisma,
         costRollup: getApp().governance.costRollup,
         ocsfEvents: getApp().governance.ocsfEvents,
+        gatewaySpend: getApp().governance.gatewaySpend,
+        projects: getApp().governance.projects,
       });
       return await service.spendByModel({
         organizationId: input.organizationId,
@@ -196,6 +202,8 @@ export const governanceCostRouter = createTRPCRouter({
         prisma: ctx.prisma,
         costRollup: getApp().governance.costRollup,
         ocsfEvents: getApp().governance.ocsfEvents,
+        gatewaySpend: getApp().governance.gatewaySpend,
+        projects: getApp().governance.projects,
       });
       return await service.periodRecords({
         organizationId: input.organizationId,
@@ -224,6 +232,8 @@ export const governanceCostRouter = createTRPCRouter({
         prisma: ctx.prisma,
         costRollup: getApp().governance.costRollup,
         ocsfEvents: getApp().governance.ocsfEvents,
+        gatewaySpend: getApp().governance.gatewaySpend,
+        projects: getApp().governance.projects,
       });
       return await service.spenderBreakdown({
         organizationId: input.organizationId,

--- a/platform/app/ee/governance/services/__tests__/costRollupComparator.service.integration.test.ts
+++ b/platform/app/ee/governance/services/__tests__/costRollupComparator.service.integration.test.ts
@@ -48,100 +48,26 @@ let repo: GovernanceCostRollupClickHouseRepository;
 let comparator: CostRollupComparatorService;
 let tenantId: string;
 
-function confirmedData({
-  costNanoUsd,
-  requestId,
-  occurredAt = DAY_MS,
-}: {
-  costNanoUsd: number;
-  requestId: string;
-  occurredAt?: number;
-}) {
-  return {
-    gateway_request_id: requestId,
-    occurred_at: occurredAt,
-    tenantId,
-    organization_id: "org_acme",
-    virtual_key_id: "vk_1",
-    principal_user_id: "user_ada",
-    end_user_id: "",
-    trace_id: "",
-    request_type: "chat",
-    labels: [],
-    metadata: "",
-    admitted_at: occurredAt,
-    team_id: "",
-    model: "openai/gpt-5-mini",
-    model_provider_id: "openai",
-    usage: {
-      input_tokens: 100,
-      output_tokens: 20,
-      cache_read_input_tokens: 0,
-      cache_creation_input_tokens: 0,
-      reasoning_tokens: 0,
-      input_audio_tokens: 0,
-      output_audio_tokens: 0,
-      input_chars: 0,
-    },
-    rate_version: "registry@2026-08-01",
-    duration_ms: 120,
-    cost_nano_usd: costNanoUsd,
-  };
-}
-
 /**
- * Puts one gateway outcome on the durable log, the way the ingest seam does.
- *
- * `EventOccurredAt` is set to the same value as the payload's `occurred_at`
- * because that is what the write path does: spendCommands.ts passes
- * `occurredAt: data.occurred_at` into every spend event, and
- * eventStoreUtils.ts:71 writes that envelope field to the column verbatim. The
- * append clock lands on `EventTimestamp` instead. Seeding these two apart
- * would be testing a system we do not have.
+ * Writes the day's summary at whatever figure the test wants it to claim, by
+ * folding one dollar-billed observation through the real projection.
  */
-async function appendConfirmed({
-  costNanoUsd,
-  occurredAt = DAY_MS,
-}: {
-  costNanoUsd: number;
-  occurredAt?: number;
-}): Promise<void> {
-  const requestId = `gwreq-${nanoid()}`;
-  await ch.insert({
-    table: "event_log",
-    values: [
-      {
-        TenantId: tenantId,
-        IdempotencyKey: `idem-${requestId}`,
-        AggregateType: "gateway_request",
-        AggregateId: requestId,
-        EventId: `evt-${nanoid()}`,
-        EventType: "lw.gateway.spend.confirmed",
-        EventVersion: "2026-07-29",
-        EventTimestamp: Date.now(),
-        EventPayload: JSON.stringify(
-          confirmedData({ costNanoUsd, requestId, occurredAt }),
-        ),
-        EventOccurredAt: occurredAt,
-      },
-    ],
-    format: "JSONEachRow",
-    clickhouse_settings: { async_insert: 0, wait_for_async_insert: 0 },
-  });
-}
-
-/** Writes the day's summary at whatever figure the test wants it to claim. */
 async function writeSummary(amountNanoUsd: number): Promise<void> {
   const projection = new GovernanceCostRollupFoldProjection({
     store: { store: async () => undefined, get: async () => null },
   });
   const state: GovernanceCostRollupState = projection.apply(projection.init(), {
     id: `evt-${nanoid()}`,
-    type: "lw.gateway.spend.confirmed",
+    type: "lw.obs.pulled_usage.observed",
     tenantId,
     aggregateId: "seed",
     occurredAt: DAY_MS,
-    data: confirmedData({ costNanoUsd: amountNanoUsd, requestId: "seed" }),
+    data: observedData({
+      costNanoMinor: amountNanoUsd,
+      currencyCode: "USD",
+      observedAtMs: DAY_MS,
+      restatementKey: "seed",
+    }),
   } as never);
   await repo.upsert(
     projectGovernanceCostRollupStateToRow({
@@ -153,16 +79,25 @@ async function writeSummary(amountNanoUsd: number): Promise<void> {
   );
 }
 
-/** One pulled observation's payload, as the puller worker writes it. */
+/**
+ * One pulled observation's payload, as the puller worker writes it.
+ *
+ * `occurredAtMs` is the provider's business time, which is what the fold
+ * buckets the item by; the envelope time the comparator selects by is set
+ * separately in `appendPulled`, and the two only agree because every test
+ * here passes the same instant to both.
+ */
 function observedData({
   costNanoMinor,
   currencyCode,
   observedAtMs,
+  occurredAtMs = DAY_MS,
   restatementKey = "bucket-hash",
 }: {
   costNanoMinor: number;
   currencyCode: string;
   observedAtMs: number;
+  occurredAtMs?: number;
   restatementKey?: string;
 }) {
   return {
@@ -185,9 +120,38 @@ function observedData({
     rateVersion: "registry@2026-08-01",
     costBasis: "computed",
     costStatus: "estimate",
-    occurredAtMs: DAY_MS,
+    occurredAtMs,
     observedAtMs,
   };
+}
+
+/**
+ * Puts one dollar-billed observation on the durable log, dated to the day
+ * its business time falls in: the puller sets the envelope's `occurredAt` to
+ * the item's own `occurredAtMs` (pullerWorker.ts), and the store writes that
+ * envelope field to `EventOccurredAt` verbatim. Seeding the two apart would
+ * be testing a system we do not have.
+ */
+async function appendObserved({
+  costNanoMinor,
+  occurredAtMs = DAY_MS,
+  restatementKey = `bucket-${nanoid(6)}`,
+}: {
+  costNanoMinor: number;
+  occurredAtMs?: number;
+  restatementKey?: string;
+}): Promise<void> {
+  await appendPulled({
+    type: "lw.obs.pulled_usage.observed",
+    data: observedData({
+      costNanoMinor,
+      currencyCode: "USD",
+      observedAtMs: occurredAtMs,
+      occurredAtMs,
+      restatementKey,
+    }),
+    occurredAt: occurredAtMs,
+  });
 }
 
 /**
@@ -317,10 +281,26 @@ async function mismatchCount(): Promise<number> {
   const values = (await metric!.get()).values;
   return values
     .filter(
-      (value) => value.labels.cost_source === GOVERNANCE_COST_SOURCE.GATEWAY,
+      (value) => value.labels.cost_source === GOVERNANCE_COST_SOURCE.PULLED,
     )
     .reduce((sum, value) => sum + value.value, 0);
 }
+
+describe("COST_SOURCE_EVENT_TYPES", () => {
+  // The comparator checks the billed lane alone. The metered lane is read
+  // straight off its own per-request ledger and never reaches a rollup row,
+  // so a gateway entry here would re-derive cells the summary is never
+  // written with and report drift that is entirely its own.
+  it("covers the billed lane and no gateway event", () => {
+    expect(Object.keys(COST_SOURCE_EVENT_TYPES)).toEqual([
+      GOVERNANCE_COST_SOURCE.PULLED,
+    ]);
+    const gatewayTypes = Object.values(COST_SOURCE_EVENT_TYPES)
+      .flat()
+      .filter((type) => type.startsWith("lw.gateway."));
+    expect(gatewayTypes).toEqual([]);
+  });
+});
 
 describe("CostRollupComparatorService", () => {
   beforeAll(() => {
@@ -342,8 +322,8 @@ describe("CostRollupComparatorService", () => {
   describe("given a summary row that no longer matches the sum of its events", () => {
     /** @scenario "The comparator counts a summary that drifted from its events" */
     it("counts the mismatch on the drift metric and names both figures in the log", async () => {
-      await appendConfirmed({ costNanoUsd: 5_000_000_000 });
-      await appendConfirmed({ costNanoUsd: 7_340_000_000 });
+      await appendObserved({ costNanoMinor: 5_000_000_000 });
+      await appendObserved({ costNanoMinor: 7_340_000_000 });
       // The summary claims a figure the events do not add up to.
       await writeSummary(9_999_000_000);
 
@@ -351,7 +331,7 @@ describe("CostRollupComparatorService", () => {
       const comparison = await comparator.compareDay({
         tenantId,
         day: DAY,
-        costSource: GOVERNANCE_COST_SOURCE.GATEWAY,
+        costSource: GOVERNANCE_COST_SOURCE.PULLED,
       });
 
       expect(await mismatchCount()).toBe(before + 1);
@@ -364,13 +344,13 @@ describe("CostRollupComparatorService", () => {
     });
 
     it("leaves the drifted row exactly as it found it", async () => {
-      await appendConfirmed({ costNanoUsd: 5_000_000_000 });
+      await appendObserved({ costNanoMinor: 5_000_000_000 });
       await writeSummary(9_999_000_000);
 
       await comparator.compareDay({
         tenantId,
         day: DAY,
-        costSource: GOVERNANCE_COST_SOURCE.GATEWAY,
+        costSource: GOVERNANCE_COST_SOURCE.PULLED,
       });
 
       const cells = await repo.findCellsForDay({ tenantId, day: DAY });
@@ -382,15 +362,15 @@ describe("CostRollupComparatorService", () => {
     // The counter has to be quiet on the healthy path, or the alerting it
     // exists for is noise from the first day.
     it("counts nothing", async () => {
-      await appendConfirmed({ costNanoUsd: 5_000_000_000 });
-      await appendConfirmed({ costNanoUsd: 7_340_000_000 });
+      await appendObserved({ costNanoMinor: 5_000_000_000 });
+      await appendObserved({ costNanoMinor: 7_340_000_000 });
       await writeSummary(12_340_000_000);
 
       const before = await mismatchCount();
       const comparison = await comparator.compareDay({
         tenantId,
         day: DAY,
-        costSource: GOVERNANCE_COST_SOURCE.GATEWAY,
+        costSource: GOVERNANCE_COST_SOURCE.PULLED,
       });
 
       expect(comparison.mismatches).toEqual([]);
@@ -401,13 +381,12 @@ describe("CostRollupComparatorService", () => {
   describe("given two events either side of midnight", () => {
     /**
      * The comparator selects its events by `event_log.EventOccurredAt` while
-     * the fold buckets them by the payload's own `occurred_at`. That is only
-     * safe while the two carry the same value, and today they do: every spend
-     * command sets `occurredAt: data.occurred_at`
-     * (spendCommands.ts:81/129/177/224) and the store writes the envelope
-     * field to the column unchanged (eventStoreUtils.ts:71), with the append
-     * clock going to `EventTimestamp` instead. The puller lane matches
-     * (pullerWorker.ts:753).
+     * the fold buckets them by the payload's own `occurredAtMs`. That is only
+     * safe while the two carry the same value, and today they do: the puller
+     * sets the envelope's `occurredAt` to the item's business time
+     * (pullerWorker.ts) and the store writes the envelope field to the column
+     * unchanged (eventStoreUtils.ts:71), with the append clock going to
+     * `EventTimestamp` instead.
      *
      * So this is a pin, not a repair. A producer that ever set the envelope to
      * wall-clock time would put an event in one query's day and the other's
@@ -417,10 +396,13 @@ describe("CostRollupComparatorService", () => {
     it("assigns each to the day its own business time falls in", async () => {
       const lastMs = Date.parse(`${DAY}T23:59:59.999Z`);
       const firstMsNextDay = Date.parse("2026-08-02T00:00:00.000Z");
-      await appendConfirmed({ costNanoUsd: 5_000_000_000, occurredAt: lastMs });
-      await appendConfirmed({
-        costNanoUsd: 7_340_000_000,
-        occurredAt: firstMsNextDay,
+      await appendObserved({
+        costNanoMinor: 5_000_000_000,
+        occurredAtMs: lastMs,
+      });
+      await appendObserved({
+        costNanoMinor: 7_340_000_000,
+        occurredAtMs: firstMsNextDay,
       });
 
       // The summary for DAY claims only the event whose business day is DAY.
@@ -429,7 +411,7 @@ describe("CostRollupComparatorService", () => {
       const sameDay = await comparator.compareDay({
         tenantId,
         day: DAY,
-        costSource: GOVERNANCE_COST_SOURCE.GATEWAY,
+        costSource: GOVERNANCE_COST_SOURCE.PULLED,
       });
       // The 00:00:00.000 event next door was not pulled into this day.
       expect(sameDay.mismatches).toEqual([]);
@@ -439,7 +421,7 @@ describe("CostRollupComparatorService", () => {
       const nextDay = await comparator.compareDay({
         tenantId,
         day: "2026-08-02",
-        costSource: GOVERNANCE_COST_SOURCE.GATEWAY,
+        costSource: GOVERNANCE_COST_SOURCE.PULLED,
       });
       expect(nextDay.mismatches).toHaveLength(1);
       expect(nextDay.mismatches[0]!.derivedNanoMinor).toBe(7_340_000_000);
@@ -457,7 +439,7 @@ describe("CostRollupComparatorService", () => {
       const comparison = await comparator.compareDay({
         tenantId,
         day: DAY,
-        costSource: GOVERNANCE_COST_SOURCE.GATEWAY,
+        costSource: GOVERNANCE_COST_SOURCE.PULLED,
       });
 
       expect(comparison.mismatches).toHaveLength(1);
@@ -468,12 +450,12 @@ describe("CostRollupComparatorService", () => {
 
   describe("when the comparator runs", () => {
     it("measures how far the summary is behind the log", async () => {
-      await appendConfirmed({ costNanoUsd: 5_000_000_000 });
+      await appendObserved({ costNanoMinor: 5_000_000_000 });
 
       const comparison = await comparator.compareDay({
         tenantId,
         day: DAY,
-        costSource: GOVERNANCE_COST_SOURCE.GATEWAY,
+        costSource: GOVERNANCE_COST_SOURCE.PULLED,
       });
 
       // Nothing summarized, one event at 09:30 on the sampled day: the summary

--- a/platform/app/ee/governance/services/__tests__/costRollupComparatorSchedule.integration.test.ts
+++ b/platform/app/ee/governance/services/__tests__/costRollupComparatorSchedule.integration.test.ts
@@ -8,19 +8,23 @@
  * This is the half of the wiring that was missing: the handler was registered
  * for its targetType and no `ScheduledJob` row in the fleet ever carried it,
  * so the comparator could not fire. What is asserted here is existence — a
- * governance project ends up with a row per lane — plus the two properties
- * that make running this on every pod safe: it does not duplicate, and it does
- * not switch back on something an operator turned off.
+ * governance project ends up with a row for the billed lane — plus the
+ * properties that make running this on every pod safe: it does not duplicate,
+ * it does not switch back on something an operator turned off, and it retires
+ * the metered lane's entry that older builds minted without ever recreating it.
  *
+ * Spec: specs/governance/governance-cost-rollup.feature
  * Decision: ADR-128.
  */
 import { nanoid } from "nanoid";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 import type { Organization, Project } from "~/generated/prisma/client";
+import { computeNextRunAt } from "~/server/app-layer/scheduler/nextRunAt";
 import { PrismaScheduledJobRepository } from "~/server/app-layer/scheduler/scheduled-job.repository";
 import { prisma } from "~/server/db";
 
+import { GOVERNANCE_COST_SOURCE } from "../../projections/governanceCostRollup.constants";
 import { COST_ROLLUP_COMPARATOR_TARGET_TYPE } from "../costRollupComparator.service";
 import {
   COST_ROLLUP_COMPARATOR_CRON,
@@ -59,6 +63,48 @@ async function entriesForGovProject() {
   });
 }
 
+function pulledTargetId() {
+  return costRollupComparatorTargetId({
+    tenantId: govProject.id,
+    costSource: GOVERNANCE_COST_SOURCE.PULLED,
+  });
+}
+
+/**
+ * The row an older build minted for the metered lane. Written the way that
+ * build wrote it — through the scheduler repository, active, with a real
+ * forward marker — rather than by hand, so what the reconciler meets is the
+ * row production actually holds.
+ */
+function leftoverGatewayTargetId() {
+  return `${govProject.id}:${GOVERNANCE_COST_SOURCE.GATEWAY}`;
+}
+
+async function seedLeftoverGatewayEntry() {
+  await scheduledJobs.upsertForTarget({
+    projectId: govProject.id,
+    targetType: COST_ROLLUP_COMPARATOR_TARGET_TYPE,
+    targetId: leftoverGatewayTargetId(),
+    cron: COST_ROLLUP_COMPARATOR_CRON,
+    timezone: COST_ROLLUP_COMPARATOR_TIMEZONE,
+    nextRunAt: computeNextRunAt({
+      cron: COST_ROLLUP_COMPARATOR_CRON,
+      timezone: COST_ROLLUP_COMPARATOR_TIMEZONE,
+      after: new Date(),
+    }),
+  });
+}
+
+async function deleteLeftoverGatewayEntry() {
+  await prisma.scheduledJob.deleteMany({
+    where: {
+      projectId: govProject.id,
+      targetType: COST_ROLLUP_COMPARATOR_TARGET_TYPE,
+      targetId: leftoverGatewayTargetId(),
+    },
+  });
+}
+
 describe("cost rollup comparator schedules", () => {
   beforeAll(async () => {
     scheduledJobs = new PrismaScheduledJobRepository(prisma);
@@ -90,32 +136,26 @@ describe("cost rollup comparator schedules", () => {
       .catch(() => undefined);
   });
 
-  describe("given an organization with a governance project", () => {
-    it("gives it one calendar entry per cost source", async () => {
+  describe("given an organization with a fresh governance project", () => {
+    it("gives it one calendar entry, for the billed lane, and none for the metered lane", async () => {
       await reconcile();
 
       const entries = await entriesForGovProject();
       expect(entries.map((entry) => entry.targetId)).toEqual([
-        costRollupComparatorTargetId({
-          tenantId: govProject.id,
-          costSource: "gateway",
-        }),
-        costRollupComparatorTargetId({
-          tenantId: govProject.id,
-          costSource: "pulled",
-        }),
+        pulledTargetId(),
       ]);
-      for (const entry of entries) {
-        expect(entry.active).toBe(true);
-        expect(entry.cron).toBe(COST_ROLLUP_COMPARATOR_CRON);
-        expect(entry.timezone).toBe(COST_ROLLUP_COMPARATOR_TIMEZONE);
-        // The forward marker has to be in the future or the due-scan fires it
-        // immediately and then every pass after that.
-        expect(entry.nextRunAt.getTime()).toBeGreaterThan(Date.now());
-        // The handler reads the lane back out of this, so the round trip is
-        // the contract that makes the entry useful rather than merely present.
-        expect(costSourceFromTargetId(entry.targetId)).not.toBeNull();
-      }
+      const [entry] = entries;
+      expect(entry!.active).toBe(true);
+      expect(entry!.cron).toBe(COST_ROLLUP_COMPARATOR_CRON);
+      expect(entry!.timezone).toBe(COST_ROLLUP_COMPARATOR_TIMEZONE);
+      // The forward marker has to be in the future or the due-scan fires it
+      // immediately and then every pass after that.
+      expect(entry!.nextRunAt.getTime()).toBeGreaterThan(Date.now());
+      // The handler reads the lane back out of this, so the round trip is
+      // the contract that makes the entry useful rather than merely present.
+      expect(costSourceFromTargetId(entry!.targetId)).toBe(
+        GOVERNANCE_COST_SOURCE.PULLED,
+      );
     });
 
     it("adds nothing on a second pass, so every pod can run it", async () => {
@@ -128,7 +168,7 @@ describe("cost rollup comparator schedules", () => {
 
       const after = await entriesForGovProject();
       expect(after).toEqual(before);
-      expect(after).toHaveLength(2);
+      expect(after).toHaveLength(1);
     });
 
     it("leaves an entry an operator paused switched off", async () => {
@@ -138,10 +178,7 @@ describe("cost rollup comparator schedules", () => {
         where: {
           projectId: govProject.id,
           targetType: COST_ROLLUP_COMPARATOR_TARGET_TYPE,
-          targetId: costRollupComparatorTargetId({
-            tenantId: govProject.id,
-            costSource: "gateway",
-          }),
+          targetId: pulledTargetId(),
         },
         data: { active: false },
       });
@@ -149,13 +186,89 @@ describe("cost rollup comparator schedules", () => {
       await reconcile();
 
       const entries = await entriesForGovProject();
-      expect(entries).toHaveLength(2);
-      expect(entries.find((e) => e.targetId.endsWith(":gateway"))?.active).toBe(
-        false,
-      );
-      expect(entries.find((e) => e.targetId.endsWith(":pulled"))?.active).toBe(
-        true,
-      );
+      expect(entries).toHaveLength(1);
+      expect(entries[0]!.active).toBe(false);
+
+      // Restored so the pause does not leak into the assertions below.
+      await prisma.scheduledJob.updateMany({
+        where: {
+          projectId: govProject.id,
+          targetType: COST_ROLLUP_COMPARATOR_TARGET_TYPE,
+          targetId: pulledTargetId(),
+        },
+        data: { active: true },
+      });
+    });
+  });
+
+  describe("given a scheduled check of the metered lane left over from before", () => {
+    /** @scenario "The nightly rollup check covers the billed lane alone" */
+    it("marks it inactive at start, keeps it inactive on a later start, and leaves the billed check active", async () => {
+      await seedLeftoverGatewayEntry();
+      const seeded = await entriesForGovProject();
+      // Self-check: the leftover really is live before the boot step runs, or
+      // "marked inactive" below would be asserting against a row that was
+      // never switched on.
+      expect(
+        seeded.find((entry) => entry.targetId === leftoverGatewayTargetId())
+          ?.active,
+      ).toBe(true);
+
+      await reconcile();
+
+      const afterFirstStart = await entriesForGovProject();
+      expect(
+        afterFirstStart.find(
+          (entry) => entry.targetId === leftoverGatewayTargetId(),
+        )?.active,
+      ).toBe(false);
+      expect(
+        afterFirstStart.find((entry) => entry.targetId === pulledTargetId())
+          ?.active,
+      ).toBe(true);
+
+      await reconcile();
+
+      const afterLaterStart = await entriesForGovProject();
+      // Still there, still off: retired rather than deleted, so an operator
+      // can see what the older build had scheduled, and never recreated.
+      expect(
+        afterLaterStart.filter(
+          (entry) => entry.targetId === leftoverGatewayTargetId(),
+        ),
+      ).toHaveLength(1);
+      expect(
+        afterLaterStart.find(
+          (entry) => entry.targetId === leftoverGatewayTargetId(),
+        )?.active,
+      ).toBe(false);
+      expect(
+        afterLaterStart.find((entry) => entry.targetId === pulledTargetId())
+          ?.active,
+      ).toBe(true);
+
+      await deleteLeftoverGatewayEntry();
+    });
+
+    it("leaves a metered check that is already inactive exactly as it is", async () => {
+      await seedLeftoverGatewayEntry();
+      await prisma.scheduledJob.updateMany({
+        where: {
+          projectId: govProject.id,
+          targetType: COST_ROLLUP_COMPARATOR_TARGET_TYPE,
+          targetId: leftoverGatewayTargetId(),
+        },
+        data: { active: false },
+      });
+      const before = await entriesForGovProject();
+
+      await reconcile();
+
+      // Byte-for-byte the same rows: an inactive leftover is not switched off
+      // again (no write, no bumped `updatedAt`) and not recreated.
+      expect(await entriesForGovProject()).toEqual(before);
+
+      await deleteLeftoverGatewayEntry();
     });
   });
 
@@ -176,7 +289,7 @@ describe("cost rollup comparator schedules", () => {
       await reconcile();
 
       const entries = await entriesForGovProject();
-      expect(entries).toHaveLength(2);
+      expect(entries.length).toBeGreaterThan(0);
       expect(entries.every((entry) => entry.active)).toBe(false);
 
       // Restored so the archived state does not leak into other assertions.
@@ -194,15 +307,26 @@ describe("costSourceFromTargetId", () => {
       costSourceFromTargetId(
         costRollupComparatorTargetId({
           tenantId: "proj_abc",
-          costSource: "pulled",
+          costSource: GOVERNANCE_COST_SOURCE.PULLED,
         }),
       ),
-    ).toBe("pulled");
+    ).toBe(GOVERNANCE_COST_SOURCE.PULLED);
   });
 
   it("returns null for a lane we do not have", () => {
     // Rather than guessing: comparing the wrong lane would report drift
     // between two things never meant to match.
     expect(costSourceFromTargetId("proj_abc:seats")).toBeNull();
+  });
+
+  /** @scenario "A leftover metered check that fires anyway settles quietly" */
+  it("names no lane for a metered check, which is what lets the handler settle it without comparing", () => {
+    // A leftover row can fire in the window between the loop's due-scan and
+    // the boot step that retires it. The handler answers a null lane by
+    // logging and returning — delivered, not thrown — so the slot is not
+    // retried. That null is the whole mechanism, and this pins it.
+    expect(
+      costSourceFromTargetId(`proj_abc:${GOVERNANCE_COST_SOURCE.GATEWAY}`),
+    ).toBeNull();
   });
 });

--- a/platform/app/ee/governance/services/__tests__/costRollupComparatorSchedule.integration.test.ts
+++ b/platform/app/ee/governance/services/__tests__/costRollupComparatorSchedule.integration.test.ts
@@ -17,15 +17,21 @@
  * Decision: ADR-128.
  */
 import { nanoid } from "nanoid";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 
 import type { Organization, Project } from "~/generated/prisma/client";
 import { computeNextRunAt } from "~/server/app-layer/scheduler/nextRunAt";
 import { PrismaScheduledJobRepository } from "~/server/app-layer/scheduler/scheduled-job.repository";
 import { prisma } from "~/server/db";
 
-import { GOVERNANCE_COST_SOURCE } from "../../projections/governanceCostRollup.constants";
-import { COST_ROLLUP_COMPARATOR_TARGET_TYPE } from "../costRollupComparator.service";
+import {
+  GOVERNANCE_COST_SOURCE,
+  type GovernanceCostSource,
+} from "../../projections/governanceCostRollup.constants";
+import {
+  COST_ROLLUP_COMPARATOR_TARGET_TYPE,
+  costRollupComparatorFireHandler,
+} from "../costRollupComparator.service";
 import {
   COST_ROLLUP_COMPARATOR_CRON,
   COST_ROLLUP_COMPARATOR_TIMEZONE,
@@ -319,14 +325,91 @@ describe("costSourceFromTargetId", () => {
     expect(costSourceFromTargetId("proj_abc:seats")).toBeNull();
   });
 
-  /** @scenario "A leftover metered check that fires anyway settles quietly" */
-  it("names no lane for a metered check, which is what lets the handler settle it without comparing", () => {
-    // A leftover row can fire in the window between the loop's due-scan and
-    // the boot step that retires it. The handler answers a null lane by
-    // logging and returning — delivered, not thrown — so the slot is not
-    // retried. That null is the whole mechanism, and this pins it.
+  it("names no lane for a metered check", () => {
     expect(
       costSourceFromTargetId(`proj_abc:${GOVERNANCE_COST_SOURCE.GATEWAY}`),
     ).toBeNull();
+  });
+});
+
+/**
+ * The handler the scheduler runs, driven directly with a fire shaped the way
+ * `SchedulerService` hands it over. The scheduler's own contract is: a handler
+ * that RESOLVES has its slot settled as delivered (the calendar advances, the
+ * retry counter resets); a handler that THROWS is retried up to the cap. So
+ * "settles quietly" is asserted here as "resolves without comparing", and the
+ * scheduler's bookkeeping of a resolved handler is covered by its own tests.
+ */
+describe("costRollupComparatorFireHandler", () => {
+  const fireFor = ({
+    tenantId,
+    costSource,
+    slot,
+  }: {
+    tenantId: string;
+    costSource: GovernanceCostSource;
+    slot: Date;
+  }) => ({
+    projectId: tenantId,
+    targetType: COST_ROLLUP_COMPARATOR_TARGET_TYPE,
+    targetId: costRollupComparatorTargetId({ tenantId, costSource }),
+    slot,
+  });
+
+  const harness = () => {
+    const compareDay = vi.fn(async () => ({}));
+    const warn = vi.fn();
+    const handler = costRollupComparatorFireHandler({
+      comparator: { compareDay },
+      logger: { warn },
+    });
+    return { compareDay, warn, handler };
+  };
+
+  /** @scenario "A leftover metered check that fires anyway settles quietly" */
+  it("settles a metered fire without comparing, warning once with the target named", async () => {
+    // A leftover row can fire in the window between the loop's due-scan and
+    // the boot step that retires it. Comparing the wrong lane would report
+    // drift between two things never meant to match, and throwing would have
+    // the scheduler retry a check that has nothing to check.
+    const tenantId = `proj_${nanoid(8)}`;
+    const { compareDay, warn, handler } = harness();
+    const fire = fireFor({
+      tenantId,
+      costSource: GOVERNANCE_COST_SOURCE.GATEWAY,
+      slot: new Date("2026-03-02T03:00:00.000Z"),
+    });
+
+    await expect(handler(fire)).resolves.toBeUndefined();
+
+    expect(compareDay).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(
+      expect.objectContaining({ targetId: fire.targetId, tenantId }),
+      expect.any(String),
+    );
+  });
+
+  it("compares yesterday's UTC day for a billed fire", async () => {
+    const tenantId = `proj_${nanoid(8)}`;
+    const { compareDay, warn, handler } = harness();
+
+    await handler(
+      fireFor({
+        tenantId,
+        costSource: GOVERNANCE_COST_SOURCE.PULLED,
+        // Just past midnight UTC on the 2nd: "yesterday" is the 1st, and the
+        // day must come from the slot, not from the wall clock.
+        slot: new Date("2026-03-02T00:05:00.000Z"),
+      }),
+    );
+
+    expect(compareDay).toHaveBeenCalledTimes(1);
+    expect(compareDay).toHaveBeenCalledWith({
+      tenantId,
+      day: "2026-03-01",
+      costSource: GOVERNANCE_COST_SOURCE.PULLED,
+    });
+    expect(warn).not.toHaveBeenCalled();
   });
 });

--- a/platform/app/ee/governance/services/__tests__/erasureFoldSubstitution.unit.test.ts
+++ b/platform/app/ee/governance/services/__tests__/erasureFoldSubstitution.unit.test.ts
@@ -138,28 +138,6 @@ function inMemoryPrisma() {
   } as unknown as PrismaClient;
 }
 
-/** One priced gateway outcome, keyed on whoever spent the money. */
-function spendEvent(principalUserId: string) {
-  return {
-    type: "lw.gateway.spend.confirmed",
-    tenantId: TENANT,
-    data: {
-      occurred_at: Date.UTC(2026, 7, 20),
-      model: "openai/gpt-5-mini",
-      model_provider_id: "openai",
-      principal_user_id: principalUserId,
-      end_user_id: "",
-    } as Record<string, unknown>,
-  };
-}
-
-/** The actor id the real fold would address a money row under. */
-function actorTheFoldWouldWrite(principalUserId: string): string {
-  return decodeGovernanceCostRollupKey(
-    governanceCostRollupKey(spendEvent(principalUserId)),
-  ).rawActorId;
-}
-
 /** One priced pulled item naming its spender (ADR-129). */
 function pulledSpendEvent(rawActorId: string) {
   return {
@@ -180,11 +158,13 @@ function pulledSpendEvent(rawActorId: string) {
 }
 
 /**
- * Same question, pulled lane. The two lanes substitute through one helper, but
- * only these lines prove the pulled branch actually calls it — the gateway
- * cases above would stay green if it silently wrote `""` or the raw id.
+ * The actor id the real fold would address a money row under.
+ *
+ * The pulled lane is the only lane this fold writes: the metered lane is read
+ * straight off its own per-request ledger and never reaches a rollup row, so
+ * the substitution has exactly one branch to prove.
  */
-function actorThePulledFoldWouldWrite(rawActorId: string): string {
+function actorTheFoldWouldWrite(rawActorId: string): string {
   return decodeGovernanceCostRollupKey(
     governanceCostRollupKey(pulledSpendEvent(rawActorId)),
   ).rawActorId;
@@ -248,20 +228,18 @@ describe("given an erasure that has to change what the money fold writes", () =>
     });
 
     /** @scenario "Pulled spend is erased by the same substitution as gateway spend" */
-    it("substitutes on the pulled lane too, and leaves blank pulled rows blank", async () => {
+    it("leaves blank pulled rows blank", async () => {
       const prisma = inMemoryPrisma();
       installGovernanceSuppressionSnapshot(prisma);
 
-      const outcome = await buildErasure(prisma).erase({
+      await buildErasure(prisma).erase({
         organizationId: ORG,
         discoveredPersonId: PERSON,
       });
 
-      expect(actorThePulledFoldWouldWrite(ERASED)).toBe(outcome.pseudonym);
-      expect(actorThePulledFoldWouldWrite(STAYS)).toBe(STAYS);
       // Blank is "provider named nobody", not an identifier; a pseudonym for
       // it would sweep every unattributed row into one fake person.
-      expect(actorThePulledFoldWouldWrite("")).toBe("");
+      expect(actorTheFoldWouldWrite("")).toBe("");
     });
 
     /** @scenario "The rebuild the erasure asks for cannot re-derive the identifier" */

--- a/platform/app/ee/governance/services/__tests__/governanceCost.service.unit.test.ts
+++ b/platform/app/ee/governance/services/__tests__/governanceCost.service.unit.test.ts
@@ -12,13 +12,47 @@
  * Spec: specs/governance/governance-cost-screen.feature
  */
 import { describe, expect, it, vi } from "vitest";
+import type { ProjectRepository } from "~/server/app-layer/projects/repositories/project.repository";
 import { GovernanceCostService } from "../governanceCost.service";
 import type { GovernanceCostRollupClickHouseRepository } from "../governanceCostRollup.clickhouse.repository";
+import type { GovernanceGatewaySpendClickHouseRepository } from "../governanceGatewaySpend.clickhouse.repository";
 import type { GovernanceOcsfEventsClickHouseRepository } from "../governanceOcsfEvents.clickhouse.repository";
 
 type LaneRow = Awaited<
   ReturnType<GovernanceCostRollupClickHouseRepository["sumDaysByLane"]>
 >[number];
+
+type GatewayDayRow = Awaited<
+  ReturnType<
+    GovernanceGatewaySpendClickHouseRepository["sumDaysForOrganizationProjects"]
+  >
+>[number];
+
+/** One metered day, priced and complete unless said otherwise. */
+function gatewayDay(overrides: Partial<GatewayDayRow> = {}): GatewayDayRow {
+  return {
+    day: "2026-08-01",
+    amountNanoUsd: 0,
+    requestCount: 0,
+    requestsWithoutAmount: 0,
+    ...overrides,
+  };
+}
+
+/**
+ * The metered-lane ledger read, absent unless a test supplies days. Defaults
+ * to no metered spend, which is the shape of every test that says nothing
+ * about the gateway.
+ */
+function gatewayReturning(
+  days: GatewayDayRow[] = [],
+): GovernanceGatewaySpendClickHouseRepository {
+  return {
+    sumDaysForOrganizationProjects: vi.fn().mockResolvedValue(days),
+    sumWindowByModel: vi.fn().mockResolvedValue([]),
+    sumWindowByVirtualKey: vi.fn().mockResolvedValue([]),
+  } as unknown as GovernanceGatewaySpendClickHouseRepository;
+}
 
 /**
  * One currency's window total for a lane, as the per-currency read answers it.
@@ -102,13 +136,38 @@ function ocsfReturning(rows: SeatRow[]) {
   } as unknown as GovernanceOcsfEventsClickHouseRepository;
 }
 
-/** The service with the seat read absent unless a test supplies one. */
+/**
+ * The project repository, answering the organization's project ids — the
+ * scope of the metered ledger read. Defaults to two projects, so a test that
+ * says nothing about scope still exercises the multi-project fan-out. Only the
+ * one method the service calls is stubbed.
+ */
+function projectsReturning(
+  organizationProjectIds: string[] = ["proj-a", "proj-b"],
+): ProjectRepository {
+  return {
+    findAllIdsByOrganization: vi.fn().mockResolvedValue(organizationProjectIds),
+  } as unknown as ProjectRepository;
+}
+
+/**
+ * The service with the seat read absent unless a test supplies one, and the
+ * metered ledger defaulting to no spend. A test that only cares about the
+ * billed lane gets an empty gateway read for free.
+ */
 function createService(deps: {
   prisma: Parameters<typeof GovernanceCostService.create>[0]["prisma"];
   costRollup: GovernanceCostRollupClickHouseRepository | undefined;
   ocsfEvents?: GovernanceOcsfEventsClickHouseRepository | undefined;
+  gatewaySpend?: GovernanceGatewaySpendClickHouseRepository | undefined;
+  projects?: ProjectRepository;
 }) {
-  return GovernanceCostService.create({ ocsfEvents: undefined, ...deps });
+  return GovernanceCostService.create({
+    ocsfEvents: undefined,
+    gatewaySpend: deps.costRollup ? gatewayReturning() : undefined,
+    projects: projectsReturning(),
+    ...deps,
+  });
 }
 
 /**
@@ -321,15 +380,22 @@ describe("GovernanceCostService.summary", () => {
   describe("given both lanes reporting different totals", () => {
     describe("when requesting the summary", () => {
       it("keeps each lane's figure in its own lane", async () => {
+        // The billed lane comes from the rollup; the metered lane comes from
+        // the gateway's own ledger, NOT the rollup. A gateway row left in the
+        // rollup must never reach the metered figure.
         const rollup = rollupReturning({
-          rows: [
-            laneRow({ costSource: "pulled", amountNanoUsd: 12 * NANO }),
-            laneRow({ costSource: "gateway", amountNanoUsd: 7 * NANO }),
-          ],
+          rows: [laneRow({ costSource: "pulled", amountNanoUsd: 12 * NANO })],
         });
         const service = createService({
           prisma: prismaWithGovProject("gov-1"),
           costRollup: rollup,
+          gatewaySpend: gatewayReturning([
+            gatewayDay({
+              day: "2026-08-01",
+              amountNanoUsd: 7 * NANO,
+              requestCount: 1,
+            }),
+          ]),
         });
 
         const result = await service.summary({
@@ -384,10 +450,13 @@ describe("GovernanceCostService.summary", () => {
           now: new Date("2026-08-10T00:00:00.000Z"),
         });
 
+        // Pulled only: the billed day series must never count a gateway row
+        // the retired fold left in the rollup.
         expect(rollup.sumDaysByLane).toHaveBeenCalledWith({
           tenantId: "gov-1",
           fromDay: "2026-08-04",
           toDay: "2026-08-10",
+          costSource: "pulled",
         });
       });
     });
@@ -516,11 +585,6 @@ describe("GovernanceCostService.summary", () => {
                 amountNanoUsd: 60 * NANO,
                 cellsWithoutAmount: 2,
               }),
-              laneRow({
-                day: "2026-08-01",
-                costSource: "gateway",
-                amountNanoUsd: 7 * NANO,
-              }),
               // The same shape of day under the new rule: every cell carries
               // an amount, some of them in euros. The dollar figure is real
               // and stands, and the day says the euros are not in it.
@@ -533,6 +597,15 @@ describe("GovernanceCostService.summary", () => {
               }),
             ],
           }),
+          // The metered lane's day, from the ledger — a complete point that
+          // keeps its figure while the billed day beside it is gapped.
+          gatewaySpend: gatewayReturning([
+            gatewayDay({
+              day: "2026-08-01",
+              amountNanoUsd: 7 * NANO,
+              requestCount: 1,
+            }),
+          ]),
         });
 
         const result = await service.summary({
@@ -763,6 +836,135 @@ describe("GovernanceCostService.summary", () => {
           day.billedByCurrency.map((line) => line.previousAmount),
         ).not.toContain(22);
       });
+    });
+  });
+
+  describe("given metered spend recorded in the gateway ledger", () => {
+    /** @scenario "The metered lane counts gateway spend from every project of the organization" */
+    it("reads the ledger across every project tenant of the organization", async () => {
+      const gateway = gatewayReturning([
+        gatewayDay({
+          day: "2026-08-01",
+          amountNanoUsd: 3 * NANO,
+          requestCount: 1,
+        }),
+        gatewayDay({
+          day: "2026-08-02",
+          amountNanoUsd: 4 * NANO,
+          requestCount: 1,
+        }),
+      ]);
+      const projects = projectsReturning(["proj-a", "proj-b"]);
+      const service = createService({
+        prisma: prismaWithGovProject("gov-1"),
+        costRollup: rollupReturning({ rows: [] }),
+        gatewaySpend: gateway,
+        projects,
+      });
+
+      const result = await service.summary({
+        organizationId: "org-1",
+        windowDays: 7,
+        now: new Date("2026-08-07T12:00:00.000Z"),
+      });
+
+      // The lane is the sum of the ledger's days, across the org's projects —
+      // NOT the governance tenant the rollup reads under. The ids come from
+      // the project repository, never from Prisma in this layer.
+      expect(result.gateway.amountUsd).toBe(7);
+      expect(projects.findAllIdsByOrganization).toHaveBeenCalledWith({
+        organizationId: "org-1",
+      });
+      expect(gateway.sumDaysForOrganizationProjects).toHaveBeenCalledWith({
+        tenantIds: ["proj-a", "proj-b"],
+        fromDay: "2026-08-01",
+        toDay: "2026-08-07",
+      });
+      // Both lanes keep their own figure in their own place.
+      expect(result.series).toEqual([
+        expect.objectContaining({ day: "2026-08-01", gatewayUsd: 3 }),
+        expect.objectContaining({ day: "2026-08-02", gatewayUsd: 4 }),
+      ]);
+    });
+
+    /** @scenario "Requests with no dollar amount are counted beside the metered total, not inside it" */
+    it("shows the priced total and counts the requests with no dollar amount beside it", async () => {
+      const service = createService({
+        prisma: prismaWithGovProject("gov-1"),
+        costRollup: rollupReturning({ rows: [] }),
+        gatewaySpend: gatewayReturning([
+          gatewayDay({
+            day: "2026-08-01",
+            amountNanoUsd: 10 * NANO,
+            requestCount: 3,
+            requestsWithoutAmount: 2,
+          }),
+        ]),
+      });
+
+      const result = await service.summary({
+        organizationId: "org-1",
+        windowDays: 30,
+        now: new Date("2026-08-01T12:00:00.000Z"),
+      });
+
+      // The total is the priced requests only. The count rides beside it,
+      // never inside it, and the metered lane still shows its total when the
+      // count is above zero — the deliberate deviation from the billed lane's
+      // withhold rule.
+      expect(result.gateway.amountUsd).toBe(10);
+      expect(result.gateway.requestsWithoutAmount).toBe(2);
+      // The gateway never withholds a currency total, so it names no unpriced
+      // cells and no foreign currency.
+      expect(result.gateway.cellsWithoutAmount).toBe(0);
+      expect(result.gateway.currenciesWithoutUsdAmount).toEqual([]);
+    });
+
+    it("holds no total for a metered lane whose every request carries no dollar amount", async () => {
+      const service = createService({
+        prisma: prismaWithGovProject("gov-1"),
+        costRollup: rollupReturning({ rows: [] }),
+        gatewaySpend: gatewayReturning([
+          gatewayDay({
+            day: "2026-08-01",
+            amountNanoUsd: 0,
+            requestCount: 0,
+            requestsWithoutAmount: 3,
+          }),
+        ]),
+      });
+
+      const result = await service.summary({
+        organizationId: "org-1",
+        windowDays: 30,
+        now: new Date("2026-08-01T12:00:00.000Z"),
+      });
+
+      // No charged request, so no figure — null, never $0.00, which would be a
+      // claim that nothing was spent when the truth is we do not know.
+      expect(result.gateway.amountUsd).toBeNull();
+      expect(result.gateway.requestsWithoutAmount).toBe(3);
+    });
+
+    /** @scenario "A failed gateway ledger read never renders the metered lane as zero" */
+    it("rejects the whole summary when the ledger read fails while the rollup resolves", async () => {
+      const gateway = gatewayReturning();
+      vi.mocked(gateway.sumDaysForOrganizationProjects).mockRejectedValue(
+        new Error("gateway ledger is down"),
+      );
+      const service = createService({
+        prisma: prismaWithGovProject("gov-1"),
+        costRollup: rollupReturning({
+          rows: [laneRow({ costSource: "pulled", amountNanoUsd: 12 * NANO })],
+        }),
+        gatewaySpend: gateway,
+      });
+
+      // A metered read that swallowed its failure would render an absence as a
+      // measurement. It fails the summary, exactly as the rollup read does.
+      await expect(
+        service.summary({ organizationId: "org-1", windowDays: 30 }),
+      ).rejects.toThrow("gateway ledger is down");
     });
   });
 
@@ -1443,10 +1645,11 @@ describe("GovernanceCostService.summary trust markers", () => {
   /** Unix seconds, the unit both `DateTime` markers arrive in. */
   const seconds = (iso: string) => Math.floor(Date.parse(iso) / 1000);
 
-  async function seriesFor(rows: LaneRow[]) {
+  async function seriesFor(rows: LaneRow[], gatewayDays: GatewayDayRow[] = []) {
     const service = createService({
       prisma: prismaWithGovProject("gov-1"),
       costRollup: rollupReturning({ rows }),
+      gatewaySpend: gatewayReturning(gatewayDays),
     });
     const result = await service.summary({
       organizationId: "org-1",
@@ -1520,13 +1723,19 @@ describe("GovernanceCostService.summary trust markers", () => {
   describe("given a gateway day metered a moment ago", () => {
     /** @scenario "Gateway days never claim they might change" */
     it("never marks it as able to still change", async () => {
-      const [day] = await seriesFor([
-        laneRow({
-          costSource: "gateway",
-          amountNanoUsd: 7 * NANO,
-          lastObservedAt: seconds("2026-08-31T11:00:00.000Z"),
-        }),
-      ]);
+      // The metered day comes from the ledger now. It carries no §15 markers
+      // at all — we metered it ourselves and nobody restates it — so the day's
+      // billed markers stay null and it is never provisional.
+      const [day] = await seriesFor(
+        [],
+        [
+          gatewayDay({
+            day: "2026-08-31",
+            amountNanoUsd: 7 * NANO,
+            requestCount: 1,
+          }),
+        ],
+      );
 
       // We metered these ourselves and nobody restates them. Left in the
       // general rule they would carry "can still move" for thirty days on the

--- a/platform/app/ee/governance/services/__tests__/governanceCost.service.unit.test.ts
+++ b/platform/app/ee/governance/services/__tests__/governanceCost.service.unit.test.ts
@@ -28,12 +28,17 @@ type GatewayDayRow = Awaited<
   >
 >[number];
 
-/** One metered day, priced and complete unless said otherwise. */
+/**
+ * One metered day, empty unless said otherwise. A test that wants the day to
+ * hold a figure says how many of its requests were priced: the service reads
+ * `pricedRequestCount`, not the money, to decide whether a figure stands.
+ */
 function gatewayDay(overrides: Partial<GatewayDayRow> = {}): GatewayDayRow {
   return {
     day: "2026-08-01",
     amountNanoUsd: 0,
     requestCount: 0,
+    pricedRequestCount: 0,
     requestsWithoutAmount: 0,
     ...overrides,
   };
@@ -847,11 +852,13 @@ describe("GovernanceCostService.summary", () => {
           day: "2026-08-01",
           amountNanoUsd: 3 * NANO,
           requestCount: 1,
+          pricedRequestCount: 1,
         }),
         gatewayDay({
           day: "2026-08-02",
           amountNanoUsd: 4 * NANO,
           requestCount: 1,
+          pricedRequestCount: 1,
         }),
       ]);
       const projects = projectsReturning(["proj-a", "proj-b"]);
@@ -897,6 +904,7 @@ describe("GovernanceCostService.summary", () => {
             day: "2026-08-01",
             amountNanoUsd: 10 * NANO,
             requestCount: 3,
+            pricedRequestCount: 1,
             requestsWithoutAmount: 2,
           }),
         ]),
@@ -914,13 +922,17 @@ describe("GovernanceCostService.summary", () => {
       // withhold rule.
       expect(result.gateway.amountUsd).toBe(10);
       expect(result.gateway.requestsWithoutAmount).toBe(2);
+      expect(result.series).toEqual([
+        expect.objectContaining({ day: "2026-08-01", gatewayUsd: 10 }),
+      ]);
       // The gateway never withholds a currency total, so it names no unpriced
       // cells and no foreign currency.
       expect(result.gateway.cellsWithoutAmount).toBe(0);
       expect(result.gateway.currenciesWithoutUsdAmount).toEqual([]);
     });
 
-    it("holds no total for a metered lane whose every request carries no dollar amount", async () => {
+    /** @scenario "A window of only requests with no dollar amount still shows the metered lane" */
+    it("holds no figure for a day of only charged requests the ledger could not price", async () => {
       const service = createService({
         prisma: prismaWithGovProject("gov-1"),
         costRollup: rollupReturning({ rows: [] }),
@@ -928,7 +940,10 @@ describe("GovernanceCostService.summary", () => {
           gatewayDay({
             day: "2026-08-01",
             amountNanoUsd: 0,
-            requestCount: 0,
+            // Three requests, all charged, all priced at zero with tokens
+            // consumed: the ledger cannot tell free from unpriced.
+            requestCount: 3,
+            pricedRequestCount: 0,
             requestsWithoutAmount: 3,
           }),
         ]),
@@ -940,10 +955,45 @@ describe("GovernanceCostService.summary", () => {
         now: new Date("2026-08-01T12:00:00.000Z"),
       });
 
-      // No charged request, so no figure — null, never $0.00, which would be a
-      // claim that nothing was spent when the truth is we do not know.
+      // Charged requests alone do not make a figure. Every one of these is
+      // in the unpriced count, so the zero sum is not a measurement — null,
+      // never $0.00, which would say "free" where the ledger says "unknown".
       expect(result.gateway.amountUsd).toBeNull();
       expect(result.gateway.requestsWithoutAmount).toBe(3);
+      expect(result.series).toEqual([
+        expect.objectContaining({ day: "2026-08-01", gatewayUsd: null }),
+      ]);
+    });
+
+    it("states $0.00 for a day of only requests that consumed nothing and cost nothing", async () => {
+      const service = createService({
+        prisma: prismaWithGovProject("gov-1"),
+        costRollup: rollupReturning({ rows: [] }),
+        gatewaySpend: gatewayReturning([
+          gatewayDay({
+            day: "2026-08-01",
+            amountNanoUsd: 0,
+            // Two failures before any token was consumed: charged, priced at
+            // zero, and nothing about them is unknown.
+            requestCount: 2,
+            pricedRequestCount: 0,
+            requestsWithoutAmount: 0,
+          }),
+        ]),
+      });
+
+      const result = await service.summary({
+        organizationId: "org-1",
+        windowDays: 30,
+        now: new Date("2026-08-01T12:00:00.000Z"),
+      });
+
+      // Nothing spent and nothing unknown: zero is the honest figure.
+      expect(result.gateway.amountUsd).toBe(0);
+      expect(result.gateway.requestsWithoutAmount).toBe(0);
+      expect(result.series).toEqual([
+        expect.objectContaining({ day: "2026-08-01", gatewayUsd: 0 }),
+      ]);
     });
 
     /** @scenario "A failed gateway ledger read never renders the metered lane as zero" */

--- a/platform/app/ee/governance/services/__tests__/governanceCostModels.unit.test.ts
+++ b/platform/app/ee/governance/services/__tests__/governanceCostModels.unit.test.ts
@@ -16,6 +16,7 @@
  * Decision: ADR-128 §1 (the model is a wave 1 "where" dimension).
  */
 import { describe, expect, it, vi } from "vitest";
+import { NullProjectRepository } from "~/server/app-layer/projects/repositories/project.repository";
 
 import { GovernanceCostService } from "../governanceCost.service";
 import type { GovernanceCostRollupClickHouseRepository } from "../governanceCostRollup.clickhouse.repository";
@@ -59,6 +60,8 @@ function serviceOver(rows: ModelRow[]) {
     prisma: prismaWith("gov-1"),
     costRollup: rollupReturning(rows),
     ocsfEvents: undefined,
+    gatewaySpend: undefined,
+    projects: new NullProjectRepository(),
   });
 }
 
@@ -162,6 +165,8 @@ describe("GovernanceCostService.spendByModel", () => {
         prisma: prismaWith(null),
         costRollup: rollupReturning([]),
         ocsfEvents: undefined,
+        gatewaySpend: undefined,
+        projects: new NullProjectRepository(),
       });
 
       const result = await service.spendByModel({

--- a/platform/app/ee/governance/services/__tests__/governanceCostRollupReads.integration.test.ts
+++ b/platform/app/ee/governance/services/__tests__/governanceCostRollupReads.integration.test.ts
@@ -428,4 +428,43 @@ describe("the governance cost aggregate reads", () => {
       expect(day.amountNanoUsd).toBe(30 * NANO);
     });
   });
+
+  describe("given a gateway row the retired fold left in the rollup", () => {
+    /** @scenario "Gateway rows left in the rollup are counted nowhere" */
+    it("reads the pulled lane only and never the leftover gateway row", async () => {
+      await repo.upsert(
+        cell({
+          currencyCode: "USD",
+          amountNanoUsd: 100 * NANO,
+          amountNanoMinor: 100 * NANO,
+        }),
+      );
+      // A cell the retired gateway fold wrote under this same tenant and day.
+      // The metered lane reads the gateway ledger now, so this row must reach
+      // no figure on the screen — the pulled-only predicate is what keeps it
+      // out.
+      await repo.upsert({
+        ...cell({
+          currencyCode: "USD",
+          amountNanoUsd: 50 * NANO,
+          amountNanoMinor: 50 * NANO,
+          model: "gpt-5-mini",
+        }),
+        CostSource: GOVERNANCE_COST_SOURCE.GATEWAY,
+      });
+
+      const lanes = await repo.sumDaysByLane({
+        tenantId,
+        fromDay: DAY,
+        toDay: DAY,
+        costSource: GOVERNANCE_COST_SOURCE.PULLED,
+      });
+
+      // One lane row, pulled, at the pulled amount. The gateway row is not in
+      // reach of a pulled-only read at all.
+      expect(lanes).toHaveLength(1);
+      expect(lanes[0]?.costSource).toBe(GOVERNANCE_COST_SOURCE.PULLED);
+      expect(lanes[0]?.amountNanoUsd).toBe(100 * NANO);
+    });
+  });
 });

--- a/platform/app/ee/governance/services/__tests__/governanceCostSpenders.unit.test.ts
+++ b/platform/app/ee/governance/services/__tests__/governanceCostSpenders.unit.test.ts
@@ -17,6 +17,7 @@
  * Decision: ADR-128 §14 / ADR-129.
  */
 import { describe, expect, it, vi } from "vitest";
+import { NullProjectRepository } from "~/server/app-layer/projects/repositories/project.repository";
 
 import { GovernanceCostService } from "../governanceCost.service";
 import type { GovernanceCostRollupClickHouseRepository } from "../governanceCostRollup.clickhouse.repository";
@@ -76,6 +77,8 @@ function serviceOver(rows: SpenderRow[], people: PersonRow[] = []) {
     prisma: prismaWith("gov-1", people),
     costRollup: rollupReturning(rows),
     ocsfEvents: undefined,
+    gatewaySpend: undefined,
+    projects: new NullProjectRepository(),
   });
 }
 
@@ -308,6 +311,8 @@ describe("GovernanceCostService.spenderBreakdown", () => {
         prisma: prismaWith("gov-1"),
         costRollup: undefined,
         ocsfEvents: undefined,
+        gatewaySpend: undefined,
+        projects: new NullProjectRepository(),
       });
 
       const result = await service.spenderBreakdown({

--- a/platform/app/ee/governance/services/__tests__/governanceGatewaySpend.integration.test.ts
+++ b/platform/app/ee/governance/services/__tests__/governanceGatewaySpend.integration.test.ts
@@ -369,6 +369,43 @@ describe("the governance gateway spend read", () => {
       expect(day?.requestsWithoutAmount).toBe(2);
       // requestCount is the priced-or-charged confirmed+failed rows.
       expect(day?.requestCount).toBe(2);
+      // Of those, only the $10 one is priced.
+      expect(day?.pricedRequestCount).toBe(1);
+    });
+  });
+
+  describe("given a day of only zero-cost requests that consumed tokens", () => {
+    /** @scenario "A window of only requests with no dollar amount still shows the metered lane" */
+    it("reports the requests as charged but none of them as priced", async () => {
+      await insert([
+        spendRow({
+          tenantId: projectA,
+          status: "confirmed",
+          costNanoUsd: 0,
+          tokensInput: 100,
+          tokensOutput: 20,
+        }),
+        spendRow({
+          tenantId: projectA,
+          status: "confirmed",
+          costNanoUsd: 0,
+          tokensInput: 300,
+          tokensOutput: 40,
+        }),
+      ]);
+
+      const [day] = await repo.sumDaysForOrganizationProjects({
+        tenantIds: [projectA],
+        ...WINDOW,
+      });
+
+      // Charged, tokens consumed, priced at nothing: the ledger does not know
+      // what these cost. The priced count is what lets the service say so
+      // instead of rendering the zero sum as a figure.
+      expect(day?.amountNanoUsd).toBe(0);
+      expect(day?.requestCount).toBe(2);
+      expect(day?.pricedRequestCount).toBe(0);
+      expect(day?.requestsWithoutAmount).toBe(2);
     });
   });
 

--- a/platform/app/ee/governance/services/__tests__/governanceGatewaySpend.integration.test.ts
+++ b/platform/app/ee/governance/services/__tests__/governanceGatewaySpend.integration.test.ts
@@ -271,6 +271,47 @@ describe("the governance gateway spend read", () => {
     });
   });
 
+  describe("given a request whose late admission moved its start days before the window", () => {
+    /** @scenario "A request written into two months is counted once" */
+    it("contributes nothing, however far back the start moved", async () => {
+      const requestId = `req-late-admit-${nanoid(8)}`;
+      // The outcome folded first with a start inside the window; the
+      // admission folded three days later in ledger order and set the start
+      // three days before the window. Nothing bounds that gap — the brokered
+      // path admits on one emitter and confirms on another — so no widened
+      // prefilter on the raw rows is safe. Only the collapsed request's own
+      // start time can decide the window.
+      await insert([
+        spendRow({
+          tenantId: projectA,
+          gatewayRequestId: requestId,
+          status: "confirmed",
+          costNanoUsd: 5 * NANO,
+          occurredAtMs: Date.parse("2026-08-01T10:00:00.000Z"),
+          eventTimestampOverride: 10,
+        }),
+        spendRow({
+          tenantId: projectA,
+          gatewayRequestId: requestId,
+          status: "confirmed",
+          costNanoUsd: 7 * NANO,
+          occurredAtMs: Date.parse("2026-07-29T10:00:00.000Z"),
+          eventTimestampOverride: 20,
+        }),
+      ]);
+
+      const days = await repo.sumDaysForOrganizationProjects({
+        tenantIds: [projectA],
+        ...WINDOW,
+      });
+
+      const total = days.reduce((sum, day) => sum + day.amountNanoUsd, 0);
+      const requests = days.reduce((sum, day) => sum + day.requestCount, 0);
+      expect(total).toBe(0);
+      expect(requests).toBe(0);
+    });
+  });
+
   describe("given a request whose latest version moved its start into the window", () => {
     /** @scenario "A request written into two months is counted once" */
     it("counts the request once, at the cost its latest version carries", async () => {

--- a/platform/app/ee/governance/services/__tests__/governanceGatewaySpend.integration.test.ts
+++ b/platform/app/ee/governance/services/__tests__/governanceGatewaySpend.integration.test.ts
@@ -1,0 +1,387 @@
+// SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+
+/**
+ * @vitest-environment node
+ *
+ * The metered lane's ledger read against real ClickHouse.
+ *
+ * The rules under test live entirely in the SQL, so no stubbed client can see
+ * them: that the read spans every project tenant it is handed and no other,
+ * that a failed request priced for its tokens counts, that a request written
+ * into two monthly partitions is counted once, that a request is placed on the
+ * UTC day it started, and that requests with no dollar amount are counted
+ * beside the total rather than inside it.
+ *
+ * Rows are written straight to `gateway_spend` rather than folded from events:
+ * what is under test is what the READ does with a given set of rows, which is
+ * a property of the query and not of the fold.
+ *
+ * Spec: specs/governance/governance-cost-screen.feature
+ *   ("THE METERED LANE READS THE GATEWAY'S OWN LEDGER")
+ */
+import type { ClickHouseClient } from "@clickhouse/client";
+import { nanoid } from "nanoid";
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+import { getTestClickHouseClient } from "~/server/event-sourcing/__tests__/integration/testContainers";
+import { GovernanceGatewaySpendClickHouseRepository } from "../governanceGatewaySpend.clickhouse.repository";
+
+const NANO = 1_000_000_000;
+
+let ch: ClickHouseClient;
+let repo: GovernanceGatewaySpendClickHouseRepository;
+
+/** Two projects of the viewer's org, and one of a different org's. */
+let projectA: string;
+let projectB: string;
+let projectOther: string;
+
+/** Well inside the ledger's 13-month TTL, so nothing is swept mid-test. */
+const AUG_1 = Date.parse("2026-08-01T12:00:00.000Z");
+
+let eventTimestamp = 1;
+
+/** One `gateway_spend` row. Only the columns these tests read are meaningful. */
+function spendRow({
+  tenantId,
+  gatewayRequestId = `req-${nanoid(12)}`,
+  virtualKeyId = "vk_a",
+  model = "gpt-5-mini",
+  status,
+  costNanoUsd,
+  tokensInput = 100,
+  tokensOutput = 50,
+  occurredAtMs = AUG_1,
+  eventTimestampOverride,
+}: {
+  tenantId: string;
+  gatewayRequestId?: string;
+  virtualKeyId?: string;
+  model?: string;
+  status: "confirmed" | "failed" | "settled" | "admitted";
+  costNanoUsd: number;
+  tokensInput?: number;
+  tokensOutput?: number;
+  occurredAtMs?: number;
+  eventTimestampOverride?: number;
+}): Record<string, unknown> {
+  return {
+    TenantId: tenantId,
+    GatewayRequestId: gatewayRequestId,
+    OrganizationId: "org_ignored_by_read",
+    VirtualKeyId: virtualKeyId,
+    PrincipalUserId: "",
+    EndUserId: "",
+    TraceId: "",
+    Model: model,
+    ProviderKey: "pk-openai",
+    RequestType: "chat",
+    Status: status,
+    ErrorClass: "",
+    HttpStatus: status === "failed" ? 500 : 200,
+    NeedsReconciliation: status === "settled" ? 1 : 0,
+    SettleReason: status === "settled" ? "timeout" : "",
+    TokensInput: tokensInput,
+    TokensOutput: tokensOutput,
+    TokensCacheRead: 0,
+    TokensCacheWrite: 0,
+    TokensReasoning: 0,
+    CostNanoUSD: costNanoUsd,
+    RateVersion: "v1",
+    Labels: [],
+    Metadata: "",
+    PodId: "",
+    PodSeq: 0,
+    DurationMS: 250,
+    OccurredAt: new Date(occurredAtMs),
+    Version: "",
+    CreatedAt: 0,
+    LastEventOccurredAt: 0,
+    EventTimestamp: eventTimestampOverride ?? eventTimestamp++,
+  };
+}
+
+async function insert(rows: Record<string, unknown>[]): Promise<void> {
+  await ch.insert({
+    table: "gateway_spend",
+    values: rows,
+    format: "JSONEachRow",
+    clickhouse_settings: { async_insert: 0, wait_for_async_insert: 0 },
+  });
+}
+
+/** The window covering the whole seeded month, inclusive at both ends. */
+const WINDOW = { fromDay: "2026-08-01", toDay: "2026-08-31" };
+
+describe("the governance gateway spend read", () => {
+  beforeAll(() => {
+    const client = getTestClickHouseClient();
+    if (!client) throw new Error("Test ClickHouse is not available");
+    ch = client;
+    repo = new GovernanceGatewaySpendClickHouseRepository(async () => ch);
+  });
+
+  beforeEach(() => {
+    // Fresh tenants per test: the table is shared, so no test sees another's
+    // rows and no hardcoded id can collide with a parallel suite's.
+    const run = nanoid(8);
+    projectA = `proj-gw-a-${run}`;
+    projectB = `proj-gw-b-${run}`;
+    projectOther = `proj-gw-other-${run}`;
+  });
+
+  describe("given gateway requests under two projects of the org and one of another", () => {
+    /** @scenario "The metered lane counts gateway spend from every project of the organization" */
+    it("sums both of the org's projects and nothing from the other org", async () => {
+      await insert([
+        spendRow({
+          tenantId: projectA,
+          status: "confirmed",
+          costNanoUsd: 3 * NANO,
+        }),
+        spendRow({
+          tenantId: projectB,
+          status: "confirmed",
+          costNanoUsd: 4 * NANO,
+        }),
+        spendRow({
+          tenantId: projectOther,
+          status: "confirmed",
+          costNanoUsd: 99 * NANO,
+        }),
+      ]);
+
+      const days = await repo.sumDaysForOrganizationProjects({
+        tenantIds: [projectA, projectB],
+        ...WINDOW,
+      });
+
+      const total = days.reduce((sum, day) => sum + day.amountNanoUsd, 0);
+      expect(total).toBe(7 * NANO);
+      // The other org's request is not in reach of this read at all.
+      expect(total).not.toBe(106 * NANO);
+    });
+  });
+
+  describe("given a confirmed request and a failed one priced for its tokens", () => {
+    /** @scenario "A failed request that consumed tokens still counts as metered spend" */
+    it("puts both amounts in the metered total", async () => {
+      await insert([
+        spendRow({
+          tenantId: projectA,
+          status: "confirmed",
+          costNanoUsd: 5 * NANO,
+        }),
+        spendRow({
+          tenantId: projectA,
+          status: "failed",
+          costNanoUsd: 2 * NANO,
+        }),
+      ]);
+
+      const [day] = await repo.sumDaysForOrganizationProjects({
+        tenantIds: [projectA],
+        ...WINDOW,
+      });
+
+      expect(day?.amountNanoUsd).toBe(7 * NANO);
+      expect(day?.requestCount).toBe(2);
+      expect(day?.requestsWithoutAmount).toBe(0);
+    });
+  });
+
+  describe("given a request written into two months with different start times", () => {
+    /** @scenario "A request written into two months is counted once" */
+    it("counts the request's amount exactly once", async () => {
+      const requestId = `req-split-${nanoid(8)}`;
+      // Outcome recorded first, in July, then admission moved the start into
+      // August. Two rows, two partitions, one request — the newer
+      // EventTimestamp is the one the read keeps.
+      await insert([
+        spendRow({
+          tenantId: projectA,
+          gatewayRequestId: requestId,
+          status: "confirmed",
+          costNanoUsd: 8 * NANO,
+          occurredAtMs: Date.parse("2026-07-31T23:00:00.000Z"),
+          eventTimestampOverride: 10,
+        }),
+        spendRow({
+          tenantId: projectA,
+          gatewayRequestId: requestId,
+          status: "confirmed",
+          costNanoUsd: 8 * NANO,
+          occurredAtMs: AUG_1,
+          eventTimestampOverride: 20,
+        }),
+      ]);
+
+      const days = await repo.sumDaysForOrganizationProjects({
+        tenantIds: [projectA],
+        fromDay: "2026-07-01",
+        toDay: "2026-08-31",
+      });
+
+      const total = days.reduce((sum, day) => sum + day.amountNanoUsd, 0);
+      const requests = days.reduce((sum, day) => sum + day.requestCount, 0);
+      expect(total).toBe(8 * NANO);
+      // 16 is the request counted once per partition it landed in.
+      expect(total).not.toBe(16 * NANO);
+      expect(requests).toBe(1);
+    });
+  });
+
+  describe("given a stream admitted before midnight whose answer finished after", () => {
+    /** @scenario "A stream crossing midnight belongs to the day it started" */
+    it("places the whole amount on the day the request started", async () => {
+      await insert([
+        spendRow({
+          tenantId: projectA,
+          status: "confirmed",
+          costNanoUsd: 6 * NANO,
+          occurredAtMs: Date.parse("2026-08-10T23:50:00.000Z"),
+        }),
+      ]);
+
+      const days = await repo.sumDaysForOrganizationProjects({
+        tenantIds: [projectA],
+        ...WINDOW,
+      });
+
+      expect(days).toHaveLength(1);
+      expect(days[0]?.day).toBe("2026-08-10");
+      expect(days[0]?.amountNanoUsd).toBe(6 * NANO);
+    });
+  });
+
+  describe("given priced requests, token-only zero-cost requests, and a settled one", () => {
+    /** @scenario "Requests with no dollar amount are counted beside the metered total, not inside it" */
+    it("totals only the priced requests and counts the rest beside them", async () => {
+      await insert([
+        spendRow({
+          tenantId: projectA,
+          status: "confirmed",
+          costNanoUsd: 10 * NANO,
+        }),
+        // Consumed tokens, priced at nothing — free or unpriced, the ledger
+        // cannot tell which, so it is "no dollar amount" rather than a zero
+        // in the total.
+        spendRow({
+          tenantId: projectA,
+          status: "confirmed",
+          costNanoUsd: 0,
+          tokensInput: 100,
+          tokensOutput: 20,
+        }),
+        // Settled: admitted, never confirmed, cost unknown.
+        spendRow({
+          tenantId: projectA,
+          status: "settled",
+          costNanoUsd: 0,
+          tokensInput: 0,
+          tokensOutput: 0,
+        }),
+      ]);
+
+      const [day] = await repo.sumDaysForOrganizationProjects({
+        tenantIds: [projectA],
+        ...WINDOW,
+      });
+
+      expect(day?.amountNanoUsd).toBe(10 * NANO);
+      // Two carry no dollar amount: the zero-cost-with-tokens one and the
+      // settled one.
+      expect(day?.requestsWithoutAmount).toBe(2);
+      // requestCount is the priced-or-charged confirmed+failed rows.
+      expect(day?.requestCount).toBe(2);
+    });
+  });
+
+  describe("given requests from two virtual keys against two models", () => {
+    /** @scenario "Metered spend is grouped by model and by virtual key, never by person" */
+    it("totals each model and each virtual key on its own", async () => {
+      await insert([
+        spendRow({
+          tenantId: projectA,
+          model: "gpt-5-mini",
+          virtualKeyId: "vk_1",
+          status: "confirmed",
+          costNanoUsd: 3 * NANO,
+        }),
+        spendRow({
+          tenantId: projectA,
+          model: "claude-sonnet-5",
+          virtualKeyId: "vk_2",
+          status: "confirmed",
+          costNanoUsd: 4 * NANO,
+        }),
+      ]);
+
+      const byModel = await repo.sumWindowByModel({
+        tenantIds: [projectA],
+        ...WINDOW,
+      });
+      const byKey = await repo.sumWindowByVirtualKey({
+        tenantIds: [projectA],
+        ...WINDOW,
+      });
+
+      expect(
+        byModel.find((row) => row.model === "gpt-5-mini")?.amountNanoUsd,
+      ).toBe(3 * NANO);
+      expect(
+        byModel.find((row) => row.model === "claude-sonnet-5")?.amountNanoUsd,
+      ).toBe(4 * NANO);
+      expect(
+        byKey.find((row) => row.virtualKeyId === "vk_1")?.amountNanoUsd,
+      ).toBe(3 * NANO);
+      expect(
+        byKey.find((row) => row.virtualKeyId === "vk_2")?.amountNanoUsd,
+      ).toBe(4 * NANO);
+    });
+  });
+
+  describe("given two models where the smaller amount is the larger string", () => {
+    /** @scenario "Metered spend is grouped by model and by virtual key, never by person" */
+    it("ranks the larger amount first, in money order not text order", async () => {
+      // "88986800" > "7619357500" as strings; $0.089 < $7.62 as money. The
+      // production ranking had these the wrong way round.
+      const small = 88_986_800;
+      const large = 7_619_357_500;
+      await insert([
+        spendRow({
+          tenantId: projectA,
+          model: "small-as-money",
+          virtualKeyId: "vk_small",
+          status: "confirmed",
+          costNanoUsd: small,
+        }),
+        spendRow({
+          tenantId: projectA,
+          model: "large-as-money",
+          virtualKeyId: "vk_large",
+          status: "confirmed",
+          costNanoUsd: large,
+        }),
+      ]);
+
+      const byModel = await repo.sumWindowByModel({
+        tenantIds: [projectA],
+        ...WINDOW,
+      });
+      const byKey = await repo.sumWindowByVirtualKey({
+        tenantIds: [projectA],
+        ...WINDOW,
+      });
+
+      expect(byModel.map((row) => row.model)).toEqual([
+        "large-as-money",
+        "small-as-money",
+      ]);
+      expect(byKey.map((row) => row.virtualKeyId)).toEqual([
+        "vk_large",
+        "vk_small",
+      ]);
+    });
+  });
+});

--- a/platform/app/ee/governance/services/__tests__/governanceGatewaySpend.integration.test.ts
+++ b/platform/app/ee/governance/services/__tests__/governanceGatewaySpend.integration.test.ts
@@ -231,6 +231,81 @@ describe("the governance gateway spend read", () => {
     });
   });
 
+  describe("given a request whose latest version moved its start out of the window", () => {
+    /** @scenario "A request written into two months is counted once" */
+    it("contributes nothing to a window the request left", async () => {
+      const requestId = `req-left-${nanoid(8)}`;
+      // Version 1 started inside the window; version 2, the one the ledger
+      // now holds as the request, moved the start two hours before it. A
+      // window filter on the raw rows keeps version 1 alone — the version
+      // 2 row fails it — and counts a request that is no longer in the
+      // window, at a cost the ledger has since replaced.
+      await insert([
+        spendRow({
+          tenantId: projectA,
+          gatewayRequestId: requestId,
+          status: "confirmed",
+          costNanoUsd: 5 * NANO,
+          occurredAtMs: Date.parse("2026-08-01T10:00:00.000Z"),
+          eventTimestampOverride: 10,
+        }),
+        spendRow({
+          tenantId: projectA,
+          gatewayRequestId: requestId,
+          status: "confirmed",
+          costNanoUsd: 7 * NANO,
+          occurredAtMs: Date.parse("2026-07-31T22:00:00.000Z"),
+          eventTimestampOverride: 20,
+        }),
+      ]);
+
+      const days = await repo.sumDaysForOrganizationProjects({
+        tenantIds: [projectA],
+        ...WINDOW,
+      });
+
+      const total = days.reduce((sum, day) => sum + day.amountNanoUsd, 0);
+      const requests = days.reduce((sum, day) => sum + day.requestCount, 0);
+      expect(total).toBe(0);
+      expect(requests).toBe(0);
+    });
+  });
+
+  describe("given a request whose latest version moved its start into the window", () => {
+    /** @scenario "A request written into two months is counted once" */
+    it("counts the request once, at the cost its latest version carries", async () => {
+      const requestId = `req-entered-${nanoid(8)}`;
+      await insert([
+        spendRow({
+          tenantId: projectA,
+          gatewayRequestId: requestId,
+          status: "confirmed",
+          costNanoUsd: 5 * NANO,
+          occurredAtMs: Date.parse("2026-07-31T22:00:00.000Z"),
+          eventTimestampOverride: 10,
+        }),
+        spendRow({
+          tenantId: projectA,
+          gatewayRequestId: requestId,
+          status: "confirmed",
+          costNanoUsd: 7 * NANO,
+          occurredAtMs: Date.parse("2026-08-01T10:00:00.000Z"),
+          eventTimestampOverride: 20,
+        }),
+      ]);
+
+      const days = await repo.sumDaysForOrganizationProjects({
+        tenantIds: [projectA],
+        ...WINDOW,
+      });
+
+      expect(days).toHaveLength(1);
+      expect(days[0]?.day).toBe("2026-08-01");
+      expect(days[0]?.amountNanoUsd).toBe(7 * NANO);
+      expect(days[0]?.requestCount).toBe(1);
+    });
+  });
+
   describe("given a stream admitted before midnight whose answer finished after", () => {
     /** @scenario "A stream crossing midnight belongs to the day it started" */
     it("places the whole amount on the day the request started", async () => {

--- a/platform/app/ee/governance/services/__tests__/governanceGatewaySpend.repository.unit.test.ts
+++ b/platform/app/ee/governance/services/__tests__/governanceGatewaySpend.repository.unit.test.ts
@@ -149,30 +149,28 @@ describe("GovernanceGatewaySpendClickHouseRepository", () => {
       await read(repo, WINDOW);
 
       const call = callOf(client);
-      // The raw rows are prefiltered on OccurredAt so partitions still prune,
-      // but the lower bound is widened by a day: a request's latest version
-      // may have moved its start time out of the window while an older
-      // version's start still sits inside it, and a WHERE on the raw rows
-      // would keep the stale version alone and count it.
-      expect(call.query).toMatch(
-        /WHERE[\s\S]*\sOccurredAt >= fromUnixTimestamp64Milli\(\{prefilterFromMs:Int64\}\)/,
+      // No time predicate on the raw rows at all. A request's latest version
+      // may have moved its start time any distance out of the window while
+      // an older version's start still sits inside it — the fold sets the
+      // start on admission, and nothing bounds how late an admission can
+      // fold after its outcome — so any WHERE on the raw OccurredAt, however
+      // widened, can keep a stale version alone and count it. The inner
+      // WHERE is the tenant fence and nothing else.
+      const where = call.query.slice(
+        call.query.indexOf("WHERE"),
+        call.query.indexOf("GROUP BY TenantId"),
       );
-      expect(call.query).toMatch(
-        /WHERE[\s\S]*\sOccurredAt < fromUnixTimestamp64Milli\(\{toMs:Int64\}\)/,
-      );
-      expect(call.query).not.toMatch(
-        /\sOccurredAt >= fromUnixTimestamp64Milli\(\{fromMs:Int64\}\)/,
-      );
-      // The window itself is decided AFTER argMax, on the surviving version.
+      expect(where).not.toMatch(/OccurredAt/);
+      expect(where).not.toMatch(/prefilter/);
+      // The window is decided AFTER argMax, on the surviving version, and it
+      // is the read's only time predicate.
       expect(call.query).toMatch(
         /HAVING\s+RequestOccurredAt >= fromUnixTimestamp64Milli\(\{fromMs:Int64\}\)\s+AND RequestOccurredAt < fromUnixTimestamp64Milli\(\{toMs:Int64\}\)/,
       );
       expect(call.query_params.fromMs).toBe(
         Date.parse("2026-08-01T00:00:00.000Z"),
       );
-      expect(call.query_params.prefilterFromMs).toBe(
-        Date.parse("2026-07-31T00:00:00.000Z"),
-      );
+      expect(call.query_params).not.toHaveProperty("prefilterFromMs");
       // Inclusive of the last day: midnight AFTER it, exclusive.
       expect(call.query_params.toMs).toBe(
         Date.parse("2026-08-08T00:00:00.000Z"),

--- a/platform/app/ee/governance/services/__tests__/governanceGatewaySpend.repository.unit.test.ts
+++ b/platform/app/ee/governance/services/__tests__/governanceGatewaySpend.repository.unit.test.ts
@@ -200,6 +200,24 @@ describe("GovernanceGatewaySpendClickHouseRepository", () => {
         },
       ]);
     });
+
+    it("refuses a day past the safe integer range rather than rounding it", async () => {
+      // 2^53 + 1: a Number would silently become 2^53 and a money figure would
+      // lose a digit. The guarded parser throws instead, the same rule the
+      // gateway's own ledger reads apply.
+      const { repo } = repositoryOver([
+        {
+          Day: "2026-08-01",
+          AmountNanoUsd: "9007199254740993",
+          RequestCount: "1",
+          RequestsWithoutAmount: "0",
+        },
+      ]);
+
+      await expect(repo.sumDaysForOrganizationProjects(WINDOW)).rejects.toThrow(
+        /safe integer range/,
+      );
+    });
   });
 
   describe("when reading the breakdowns", () => {

--- a/platform/app/ee/governance/services/__tests__/governanceGatewaySpend.repository.unit.test.ts
+++ b/platform/app/ee/governance/services/__tests__/governanceGatewaySpend.repository.unit.test.ts
@@ -119,6 +119,20 @@ describe("GovernanceGatewaySpendClickHouseRepository", () => {
       expect(query).toContain("AS RequestsWithoutAmount");
     });
 
+    it("counts the priced requests apart from the charged ones", async () => {
+      const { client, repo } = repositoryOver([]);
+      await read(repo, WINDOW);
+
+      // A charged request priced at zero with tokens consumed is charged but
+      // not priced. The service needs the priced count on its own to tell a
+      // day that spent nothing from a day whose cost is unknown; the charged
+      // count alone cannot, and subtracting the unpriced count would fold the
+      // settled requests into it.
+      expect(queryOf(client)).toContain(
+        "countIf(RequestStatus IN ('confirmed', 'failed') AND RequestCostNanoUSD > 0) AS PricedRequestCount",
+      );
+    });
+
     it("never selects a person column", async () => {
       const { client, repo } = repositoryOver([]);
       await read(repo, WINDOW);
@@ -200,6 +214,7 @@ describe("GovernanceGatewaySpendClickHouseRepository", () => {
           Day: "2026-08-01",
           AmountNanoUsd: "3500000",
           RequestCount: "3",
+          PricedRequestCount: "1",
           RequestsWithoutAmount: "2",
         },
       ]);
@@ -211,6 +226,7 @@ describe("GovernanceGatewaySpendClickHouseRepository", () => {
           day: "2026-08-01",
           amountNanoUsd: 3_500_000,
           requestCount: 3,
+          pricedRequestCount: 1,
           requestsWithoutAmount: 2,
         },
       ]);
@@ -242,6 +258,7 @@ describe("GovernanceGatewaySpendClickHouseRepository", () => {
           Model: "gpt-5-mini",
           AmountNanoUsd: "10",
           RequestCount: "1",
+          PricedRequestCount: "1",
           RequestsWithoutAmount: "0",
         },
       ]);
@@ -250,6 +267,7 @@ describe("GovernanceGatewaySpendClickHouseRepository", () => {
           VirtualKeyId: "vk_1",
           AmountNanoUsd: "10",
           RequestCount: "1",
+          PricedRequestCount: "1",
           RequestsWithoutAmount: "0",
         },
       ]);
@@ -259,6 +277,7 @@ describe("GovernanceGatewaySpendClickHouseRepository", () => {
           model: "gpt-5-mini",
           amountNanoUsd: 10,
           requestCount: 1,
+          pricedRequestCount: 1,
           requestsWithoutAmount: 0,
         },
       ]);
@@ -269,6 +288,7 @@ describe("GovernanceGatewaySpendClickHouseRepository", () => {
           virtualKeyId: "vk_1",
           amountNanoUsd: 10,
           requestCount: 1,
+          pricedRequestCount: 1,
           requestsWithoutAmount: 0,
         },
       ]);

--- a/platform/app/ee/governance/services/__tests__/governanceGatewaySpend.repository.unit.test.ts
+++ b/platform/app/ee/governance/services/__tests__/governanceGatewaySpend.repository.unit.test.ts
@@ -130,19 +130,34 @@ describe("GovernanceGatewaySpendClickHouseRepository", () => {
       expect(query).not.toContain("EndUserId");
     });
 
-    it("prunes partitions on the admission time and buckets days in UTC", async () => {
+    it("applies the window to the collapsed request, not to its versions", async () => {
       const { client, repo } = repositoryOver([]);
       await read(repo, WINDOW);
 
       const call = callOf(client);
-      expect(call.query).toContain(
-        "OccurredAt >= fromUnixTimestamp64Milli({fromMs:Int64})",
+      // The raw rows are prefiltered on OccurredAt so partitions still prune,
+      // but the lower bound is widened by a day: a request's latest version
+      // may have moved its start time out of the window while an older
+      // version's start still sits inside it, and a WHERE on the raw rows
+      // would keep the stale version alone and count it.
+      expect(call.query).toMatch(
+        /WHERE[\s\S]*\sOccurredAt >= fromUnixTimestamp64Milli\(\{prefilterFromMs:Int64\}\)/,
       );
-      expect(call.query).toContain(
-        "OccurredAt < fromUnixTimestamp64Milli({toMs:Int64})",
+      expect(call.query).toMatch(
+        /WHERE[\s\S]*\sOccurredAt < fromUnixTimestamp64Milli\(\{toMs:Int64\}\)/,
+      );
+      expect(call.query).not.toMatch(
+        /\sOccurredAt >= fromUnixTimestamp64Milli\(\{fromMs:Int64\}\)/,
+      );
+      // The window itself is decided AFTER argMax, on the surviving version.
+      expect(call.query).toMatch(
+        /HAVING\s+RequestOccurredAt >= fromUnixTimestamp64Milli\(\{fromMs:Int64\}\)\s+AND RequestOccurredAt < fromUnixTimestamp64Milli\(\{toMs:Int64\}\)/,
       );
       expect(call.query_params.fromMs).toBe(
         Date.parse("2026-08-01T00:00:00.000Z"),
+      );
+      expect(call.query_params.prefilterFromMs).toBe(
+        Date.parse("2026-07-31T00:00:00.000Z"),
       );
       // Inclusive of the last day: midnight AFTER it, exclusive.
       expect(call.query_params.toMs).toBe(

--- a/platform/app/ee/governance/services/__tests__/governanceGatewaySpend.repository.unit.test.ts
+++ b/platform/app/ee/governance/services/__tests__/governanceGatewaySpend.repository.unit.test.ts
@@ -1,0 +1,259 @@
+// SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+
+/**
+ * @vitest-environment node
+ *
+ * The shape of the metered lane's ledger read, against a stubbed client.
+ *
+ * What a stub can see is the SQL text and the parameters: that the read is
+ * fenced to the organization's tenants, that it collapses the ledger to one
+ * row per request before it sums anything, that it never names a person
+ * column, and that it carries a deadline under the wire limit. What a stub
+ * cannot see — the arithmetic — is in the integration test beside this one.
+ *
+ * Spec: specs/governance/governance-cost-screen.feature
+ *   ("THE METERED LANE READS THE GATEWAY'S OWN LEDGER")
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import { GovernanceGatewaySpendClickHouseRepository } from "../governanceGatewaySpend.clickhouse.repository";
+
+function makeClient(rows: unknown[]) {
+  return {
+    query: vi.fn().mockResolvedValue({ json: async () => rows }),
+  };
+}
+
+function repositoryOver(rows: unknown[]) {
+  const client = makeClient(rows);
+  return {
+    client,
+    repo: new GovernanceGatewaySpendClickHouseRepository(
+      async () => client as never,
+    ),
+  };
+}
+
+function queryOf(client: { query: ReturnType<typeof vi.fn> }): string {
+  return String(client.query.mock.calls[0]?.[0]?.query ?? "");
+}
+
+function callOf(client: { query: ReturnType<typeof vi.fn> }) {
+  return client.query.mock.calls[0]?.[0] as {
+    query: string;
+    query_params: Record<string, unknown>;
+    clickhouse_settings?: Record<string, unknown>;
+  };
+}
+
+const WINDOW = {
+  tenantIds: ["proj_a", "proj_b"],
+  fromDay: "2026-08-01",
+  toDay: "2026-08-07",
+};
+
+/** The three reads, so a rule every one of them must obey is asserted once. */
+type ReadInput = typeof WINDOW;
+const READS = [
+  [
+    "by day",
+    (repo: GovernanceGatewaySpendClickHouseRepository, input: ReadInput) =>
+      repo.sumDaysForOrganizationProjects(input),
+  ],
+  [
+    "by model",
+    (repo: GovernanceGatewaySpendClickHouseRepository, input: ReadInput) =>
+      repo.sumWindowByModel(input),
+  ],
+  [
+    "by virtual key",
+    (repo: GovernanceGatewaySpendClickHouseRepository, input: ReadInput) =>
+      repo.sumWindowByVirtualKey(input),
+  ],
+] as const;
+
+describe("GovernanceGatewaySpendClickHouseRepository", () => {
+  describe.each(READS)("when reading the ledger %s", (_label, read) => {
+    it("fences the read to the organization's tenants, tenant first", async () => {
+      const { client, repo } = repositoryOver([]);
+      await read(repo, WINDOW);
+
+      const call = callOf(client);
+      expect(call.query).toContain("TenantId IN {tenantIds:Array(String)}");
+      expect(call.query_params.tenantIds).toEqual(["proj_a", "proj_b"]);
+      // The tenant predicate leads: nothing else in this table is unique
+      // across tenants, and it is the first sort key.
+      const where = call.query.indexOf("WHERE");
+      const tenant = call.query.indexOf("TenantId IN");
+      expect(where).toBeGreaterThan(-1);
+      expect(tenant).toBeGreaterThan(where);
+      expect(call.query.slice(where, tenant)).not.toMatch(/AND/);
+    });
+
+    it("collapses the ledger to one row per request before summing", async () => {
+      const { client, repo } = repositoryOver([]);
+      await read(repo, WINDOW);
+
+      const query = queryOf(client);
+      // FINAL is not enough: a request folded outcome-first and admitted
+      // later sits in two monthly partitions with two OccurredAt values, and
+      // FINAL dedups within a partition. The version column decides which
+      // row is the request.
+      expect(query).not.toMatch(/\bFINAL\b/);
+      expect(query).toContain("GROUP BY TenantId, GatewayRequestId");
+      expect(query).toContain("argMax(Status, EventTimestamp)");
+      expect(query).toContain("argMax(CostNanoUSD, EventTimestamp)");
+      expect(query).toContain("argMax(OccurredAt, EventTimestamp)");
+    });
+
+    it("counts confirmed and failed requests as spend, and settled ones as unknown", async () => {
+      const { client, repo } = repositoryOver([]);
+      await read(repo, WINDOW);
+
+      const query = queryOf(client);
+      // A failed request with partial usage is priced and charged.
+      expect(query).toContain("IN ('confirmed', 'failed')");
+      // An admission whose confirmation never arrived: cost unknown, so it is
+      // counted beside the total and adds nothing to it.
+      expect(query).toContain("= 'settled'");
+      expect(query).toContain("AS RequestsWithoutAmount");
+    });
+
+    it("never selects a person column", async () => {
+      const { client, repo } = repositoryOver([]);
+      await read(repo, WINDOW);
+
+      // The ledger sits outside erasure. A person's identifier read from it
+      // would outlive a deletion the rest of the product honoured.
+      const query = queryOf(client);
+      expect(query).not.toContain("PrincipalUserId");
+      expect(query).not.toContain("EndUserId");
+    });
+
+    it("prunes partitions on the admission time and buckets days in UTC", async () => {
+      const { client, repo } = repositoryOver([]);
+      await read(repo, WINDOW);
+
+      const call = callOf(client);
+      expect(call.query).toContain(
+        "OccurredAt >= fromUnixTimestamp64Milli({fromMs:Int64})",
+      );
+      expect(call.query).toContain(
+        "OccurredAt < fromUnixTimestamp64Milli({toMs:Int64})",
+      );
+      expect(call.query_params.fromMs).toBe(
+        Date.parse("2026-08-01T00:00:00.000Z"),
+      );
+      // Inclusive of the last day: midnight AFTER it, exclusive.
+      expect(call.query_params.toMs).toBe(
+        Date.parse("2026-08-08T00:00:00.000Z"),
+      );
+    });
+
+    it("gives the read a deadline under the wire limit", async () => {
+      const { client, repo } = repositoryOver([]);
+      await read(repo, WINDOW);
+
+      // The managed client abandons a request at 30 s. A query deadline past
+      // that is a deadline nothing ever reaches; one under it is the
+      // difference between a screen that says it failed and one that hangs.
+      expect(callOf(client).clickhouse_settings?.max_execution_time).toBe(20);
+    });
+
+    it("issues no query for an organization with no projects", async () => {
+      const { client, repo } = repositoryOver([]);
+      const rows = await read(repo, { ...WINDOW, tenantIds: [] });
+
+      expect(rows).toEqual([]);
+      expect(client.query).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when reading the ledger by day", () => {
+    it("buckets on the day the request STARTED, in UTC", async () => {
+      const { client, repo } = repositoryOver([]);
+      await repo.sumDaysForOrganizationProjects(WINDOW);
+
+      // A streamed answer running across midnight is one request, on the day
+      // the caller asked. The server's own timezone must not move it.
+      expect(queryOf(client)).toContain("toDate(RequestOccurredAt, 'UTC')");
+    });
+
+    it("decodes the driver's string integers into numbers", async () => {
+      const { repo } = repositoryOver([
+        {
+          Day: "2026-08-01",
+          AmountNanoUsd: "3500000",
+          RequestCount: "3",
+          RequestsWithoutAmount: "2",
+        },
+      ]);
+
+      const rows = await repo.sumDaysForOrganizationProjects(WINDOW);
+
+      expect(rows).toEqual([
+        {
+          day: "2026-08-01",
+          amountNanoUsd: 3_500_000,
+          requestCount: 3,
+          requestsWithoutAmount: 2,
+        },
+      ]);
+    });
+  });
+
+  describe("when reading the breakdowns", () => {
+    it("groups by the model and by the virtual key, as the ledger names them", async () => {
+      const byModel = repositoryOver([
+        {
+          Model: "gpt-5-mini",
+          AmountNanoUsd: "10",
+          RequestCount: "1",
+          RequestsWithoutAmount: "0",
+        },
+      ]);
+      const byKey = repositoryOver([
+        {
+          VirtualKeyId: "vk_1",
+          AmountNanoUsd: "10",
+          RequestCount: "1",
+          RequestsWithoutAmount: "0",
+        },
+      ]);
+
+      expect(await byModel.repo.sumWindowByModel(WINDOW)).toEqual([
+        {
+          model: "gpt-5-mini",
+          amountNanoUsd: 10,
+          requestCount: 1,
+          requestsWithoutAmount: 0,
+        },
+      ]);
+      expect(queryOf(byModel.client)).toContain("GROUP BY RequestModel");
+
+      expect(await byKey.repo.sumWindowByVirtualKey(WINDOW)).toEqual([
+        {
+          virtualKeyId: "vk_1",
+          amountNanoUsd: 10,
+          requestCount: 1,
+          requestsWithoutAmount: 0,
+        },
+      ]);
+      expect(queryOf(byKey.client)).toContain("GROUP BY RequestVirtualKeyId");
+    });
+
+    it("ranks by the numeric amount, never by the string the driver ships", async () => {
+      // `AmountNanoUsd` is a `toString(...)` alias so the wire never rounds a
+      // wide Int64. Ordering on that alias sorts money as TEXT — seen on
+      // production: "88986800" ranked above "7619357500". The ORDER BY must
+      // go through a numeric expression.
+      for (const [, read] of READS.slice(1)) {
+        const { client, repo } = repositoryOver([]);
+        await read(repo, WINDOW);
+        const query = queryOf(client);
+        expect(query).not.toMatch(/ORDER BY\s+AmountNanoUsd\b/);
+        expect(query).toMatch(/ORDER BY\s+toInt64\(AmountNanoUsd\) DESC/);
+      }
+    });
+  });
+});

--- a/platform/app/ee/governance/services/costRollupComparator.service.ts
+++ b/platform/app/ee/governance/services/costRollupComparator.service.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
 
 import { createLogger } from "@langwatch/observability";
+import type { SchedulerHandler } from "~/server/app-layer/scheduler/scheduler.types";
 import {
   incrementGovernanceCostRollupMismatch,
   setGovernanceCostRollupLagSeconds,
@@ -19,7 +20,10 @@ import {
   governanceCostRollupKey,
   governanceCostRollupTotals,
 } from "../projections/governanceCostRollup.foldProjection";
-import type { ComparedCostSource } from "./costRollupComparatorSchedule";
+import {
+  type ComparedCostSource,
+  costSourceFromTargetId,
+} from "./costRollupComparatorSchedule";
 import type {
   GovernanceCostRollupClickHouseRepository,
   GovernanceCostRollupRow,
@@ -228,4 +232,62 @@ function governanceCostRollupKeyOfRow(row: GovernanceCostRollupRow): string {
     currencyCode: row.CurrencyCode,
     rawActorId: row.RawActorId,
   });
+}
+
+/** The slice of the comparator the scheduled fire needs. */
+export interface CostRollupComparatorDayComparer {
+  compareDay(params: {
+    tenantId: string;
+    day: string;
+    costSource: ComparedCostSource;
+  }): Promise<unknown>;
+}
+
+interface CostRollupComparatorFireLogger {
+  warn(context: Record<string, unknown>, message: string): void;
+}
+
+/**
+ * The handler the scheduler runs when a comparator calendar entry comes due.
+ *
+ * The fire is a tiny trigger — the lane is read back out of `targetId`, the
+ * day derived from the slot — so everything is re-derived at fire time rather
+ * than acted on from a payload minted when the schedule was written. It
+ * samples YESTERDAY, not today: a day still being written to is expected to
+ * disagree with its own summary, and a watchdog that fires on that is a
+ * watchdog nobody reads.
+ *
+ * A fire naming a lane we no longer compare (a leftover metered entry from
+ * before that lane read the ledger directly) is logged and settled as
+ * delivered — the handler resolves, so the scheduler advances the slot rather
+ * than retrying a comparison that has nothing to compare against.
+ */
+export function costRollupComparatorFireHandler({
+  comparator,
+  logger,
+}: {
+  comparator: CostRollupComparatorDayComparer;
+  logger: CostRollupComparatorFireLogger;
+}): SchedulerHandler {
+  return async (fire) => {
+    const costSource = costSourceFromTargetId(fire.targetId);
+    if (!costSource) {
+      // A row naming a lane we do not have. Comparing the wrong lane would
+      // report drift between two things never meant to match, so say so
+      // and do nothing.
+      logger.warn(
+        { targetId: fire.targetId, tenantId: fire.projectId },
+        "Cost rollup comparator fired for an unknown cost source; skipping",
+      );
+      return;
+    }
+    const sampled = new Date(fire.slot.getTime() - 86_400_000)
+      .toISOString()
+      .slice(0, 10);
+    await comparator.compareDay({
+      tenantId: fire.projectId,
+      day: sampled,
+      costSource,
+    });
+  };
 }

--- a/platform/app/ee/governance/services/costRollupComparator.service.ts
+++ b/platform/app/ee/governance/services/costRollupComparator.service.ts
@@ -19,6 +19,7 @@ import {
   governanceCostRollupKey,
   governanceCostRollupTotals,
 } from "../projections/governanceCostRollup.foldProjection";
+import type { ComparedCostSource } from "./costRollupComparatorSchedule";
 import type {
   GovernanceCostRollupClickHouseRepository,
   GovernanceCostRollupRow,
@@ -31,15 +32,19 @@ const logger = createLogger("langwatch:governance:cost-rollup:comparator");
 export const COST_ROLLUP_COMPARATOR_TARGET_TYPE =
   "governanceCostRollupComparator" as const;
 
-/** Which events each lane is derived from. */
+/**
+ * Which events each compared lane is derived from.
+ *
+ * Keyed by `ComparedCostSource` rather than by every lane the table knows:
+ * the compiler then refuses a lane that gets an entry but no events, and a
+ * lane with events but no entry, so the schedule and the check cannot drift
+ * apart. The metered lane is absent on purpose — the summary is never written
+ * with its cells, so there is nothing to hold its events against.
+ */
 export const COST_SOURCE_EVENT_TYPES: Record<
-  GovernanceCostSource,
+  ComparedCostSource,
   readonly string[]
 > = {
-  [GOVERNANCE_COST_SOURCE.GATEWAY]: [
-    "lw.gateway.spend.confirmed",
-    "lw.gateway.spend.failed",
-  ],
   // The retraction is here for the same reason the observation is: the check
   // re-derives a day by folding the events that fall inside it, and a fold
   // that never sees the retraction re-derives the amount the retraction
@@ -71,7 +76,7 @@ export interface CostRollupCellMismatch {
 
 export interface CostRollupComparison {
   day: string;
-  costSource: GovernanceCostSource;
+  costSource: ComparedCostSource;
   mismatches: CostRollupCellMismatch[];
   lagMs: number;
 }
@@ -101,7 +106,7 @@ export class CostRollupComparatorService {
   }: {
     tenantId: string;
     day: string;
-    costSource: GovernanceCostSource;
+    costSource: ComparedCostSource;
   }): Promise<CostRollupComparison> {
     const eventTypes = COST_SOURCE_EVENT_TYPES[costSource];
 

--- a/platform/app/ee/governance/services/costRollupComparatorSchedule.ts
+++ b/platform/app/ee/governance/services/costRollupComparatorSchedule.ts
@@ -52,11 +52,36 @@ export const COST_ROLLUP_COMPARATOR_CRON = "23 4 * * *";
  */
 export const COST_ROLLUP_COMPARATOR_TIMEZONE = "UTC";
 
-/** The lanes that get their own entry. Both, for every tenant. */
-const COMPARED_COST_SOURCES: readonly GovernanceCostSource[] = [
+/**
+ * The lanes that get their own entry: the pulled lane, for every tenant.
+ *
+ * The metered lane is not compared. The cost screen reads it straight off the
+ * per-request ledger, and the rollup fold no longer writes gateway cells, so
+ * a gateway comparison would re-derive cells the summary is never written
+ * with and always find nothing on both sides — a check that could not fail.
+ *
+ * Exported as a tuple so the comparator's event-type map can be typed by it:
+ * the compiler then proves the map covers exactly the lanes that get an
+ * entry, no more and no fewer.
+ */
+export const COMPARED_COST_SOURCES = [GOVERNANCE_COST_SOURCE.PULLED] as const;
+export type ComparedCostSource = (typeof COMPARED_COST_SOURCES)[number];
+
+/**
+ * The lanes older builds scheduled and this one no longer compares. An
+ * ACTIVE entry for one of these is switched off at boot and never recreated;
+ * an inactive one is left exactly as it is, retired rather than deleted so an
+ * operator can still see what the older build had scheduled.
+ */
+const RETIRED_COST_SOURCES: readonly GovernanceCostSource[] = [
   GOVERNANCE_COST_SOURCE.GATEWAY,
-  GOVERNANCE_COST_SOURCE.PULLED,
 ];
+
+function isRetiredTargetId(targetId: string): boolean {
+  return RETIRED_COST_SOURCES.some((costSource) =>
+    targetId.endsWith(`:${costSource}`),
+  );
+}
 
 /**
  * The scheduler's target identity for one tenant's lane.
@@ -90,7 +115,7 @@ export function costRollupComparatorTargetId({
  */
 export function costSourceFromTargetId(
   targetId: string,
-): GovernanceCostSource | null {
+): ComparedCostSource | null {
   return (
     COMPARED_COST_SOURCES.find((costSource) =>
       targetId.endsWith(`:${costSource}`),
@@ -136,13 +161,20 @@ async function findEntriesForTenant({
 }
 
 /**
- * One tenant's missing entries, created.
+ * One tenant's missing entries created, and its retired ones switched off.
  *
  * Create-if-missing, like the report reconciler: an entry that already exists
  * is left exactly as it is, INCLUDING an inactive one, because an operator who
  * paused a noisy comparator must not have it switched back on by the next
  * deploy. Safe on every pod — `upsertForTarget` is race-hardened on the
  * unique.
+ *
+ * Retire-if-active for the lanes this build no longer compares: the row
+ * stays, marked inactive, and is never recreated because it is not among the
+ * compared lanes. Only an ACTIVE one is written to, so a second boot is a
+ * no-op rather than a re-deactivation. A retired row that fires before this
+ * reaches it lands in the handler as a lane it does not have, which the
+ * handler settles with a warning rather than a retry.
  *
  * A failure is logged and counted rather than thrown, so one bad tenant cannot
  * stop the rest of the fleet from being scheduled.
@@ -157,7 +189,7 @@ async function ensureEntriesForTenant({
   targetType: string;
   tenantId: string;
   logger: { warn: (context: unknown, message: string) => void };
-}): Promise<{ created: number; failed: number }> {
+}): Promise<{ created: number; deactivated: number; failed: number }> {
   const existing = await findEntriesForTenant({
     scheduledJobs,
     targetType,
@@ -165,7 +197,7 @@ async function ensureEntriesForTenant({
     logger,
   });
   // One unreadable tenant, counted and stepped over.
-  if (existing === null) return { created: 0, failed: 1 };
+  if (existing === null) return { created: 0, deactivated: 0, failed: 1 };
   const existingTargetIds = new Set(existing.map((job) => job.targetId));
 
   const missing = COMPARED_COST_SOURCES.filter(
@@ -175,8 +207,20 @@ async function ensureEntriesForTenant({
       ),
   );
 
+  const retired = await switchOffEntries({
+    scheduledJobs,
+    targetType,
+    tenantId,
+    logger,
+    jobs: existing.filter(
+      (row) => row.active && isRetiredTargetId(row.targetId),
+    ),
+    failureMessage:
+      "Retiring the cost rollup comparator entry for a lane no longer compared failed; the next boot retries it",
+  });
+
   let created = 0;
-  let failed = 0;
+  let failed = retired.failed;
   for (const costSource of missing) {
     try {
       await scheduledJobs.upsertForTarget({
@@ -206,7 +250,58 @@ async function ensureEntriesForTenant({
       );
     }
   }
-  return { created, failed };
+  return { created, deactivated: retired.deactivated, failed };
+}
+
+/**
+ * The given entries, switched off one by one.
+ *
+ * The caller decides WHICH rows — an archived tenant's live ones, a live
+ * tenant's retired lane — and this only does the writes, so the two paths
+ * cannot drift on how a switch-off is counted or how its failure is reported.
+ *
+ * Failures are logged and counted, never thrown, for the same reason as the
+ * creation path: a tenant whose rows will not switch off must not cost the
+ * tenants behind it their schedule.
+ */
+async function switchOffEntries({
+  scheduledJobs,
+  targetType,
+  tenantId,
+  logger,
+  jobs,
+  failureMessage,
+}: {
+  scheduledJobs: ScheduledJobRepository;
+  targetType: string;
+  tenantId: string;
+  logger: { warn: (context: unknown, message: string) => void };
+  jobs: ScheduledJobRecord[];
+  failureMessage: string;
+}): Promise<{ deactivated: number; failed: number }> {
+  let deactivated = 0;
+  let failed = 0;
+  for (const job of jobs) {
+    try {
+      await scheduledJobs.deactivateForTarget({
+        projectId: tenantId,
+        targetType,
+        targetId: job.targetId,
+      });
+      deactivated += 1;
+    } catch (error) {
+      failed += 1;
+      logger.warn(
+        {
+          tenantId,
+          targetId: job.targetId,
+          error: error instanceof Error ? error.message : String(error),
+        },
+        failureMessage,
+      );
+    }
+  }
+  return { deactivated, failed };
 }
 
 /**
@@ -214,10 +309,6 @@ async function ensureEntriesForTenant({
  *
  * Only what is actually there and still active, so the count reports work done
  * rather than no-op writes against tenants that never had an entry.
- *
- * Failures are logged and counted, never thrown, for the same reason as the
- * creation path: an archived tenant whose rows will not switch off must not
- * cost the live tenants behind it their schedule.
  */
 async function deactivateEntriesForTenant({
   scheduledJobs,
@@ -238,35 +329,26 @@ async function deactivateEntriesForTenant({
   });
   if (existing === null) return { deactivated: 0, failed: 1 };
 
-  let deactivated = 0;
-  let failed = 0;
-  for (const job of existing.filter((row) => row.active)) {
-    try {
-      await scheduledJobs.deactivateForTarget({
-        projectId: tenantId,
-        targetType,
-        targetId: job.targetId,
-      });
-      deactivated += 1;
-    } catch (error) {
-      failed += 1;
-      logger.warn(
-        {
-          tenantId,
-          targetId: job.targetId,
-          error: error instanceof Error ? error.message : String(error),
-        },
-        "Switching off the cost rollup comparator for this archived tenant failed; the next boot retries it",
-      );
-    }
-  }
-  return { deactivated, failed };
+  return switchOffEntries({
+    scheduledJobs,
+    targetType,
+    tenantId,
+    logger,
+    jobs: existing.filter((row) => row.active),
+    failureMessage:
+      "Switching off the cost rollup comparator for this archived tenant failed; the next boot retries it",
+  });
 }
 
 /**
- * Give every governance project its comparator entries, and take them away
- * from projects that have been archived — a comparator firing daily at a dead
+ * Give every governance project its comparator entries, retire the entries
+ * for lanes this build no longer compares, and take everything away from
+ * projects that have been archived — a comparator firing daily at a dead
  * tenant is pure noise on the mismatch counter.
+ *
+ * `deactivated` counts both kinds of switch-off: the retired lane on a live
+ * tenant and every entry on an archived one. Either way it is an entry that
+ * was firing and now is not, which is what the boot log line reports.
  */
 export async function reconcileCostRollupComparatorSchedules({
   prisma,
@@ -305,6 +387,7 @@ export async function reconcileCostRollupComparatorSchedules({
       logger,
     });
     created += result.created;
+    deactivated += result.deactivated;
     failed += result.failed;
   }
 

--- a/platform/app/ee/governance/services/governanceCost.service.ts
+++ b/platform/app/ee/governance/services/governanceCost.service.ts
@@ -34,6 +34,10 @@
 import { DiscoveredPersonRepository } from "@ee/governance/repositories/governanceIdentity.repository";
 import type { GovernanceCostRollupClickHouseRepository } from "@ee/governance/services/governanceCostRollup.clickhouse.repository";
 import type {
+  GovernanceGatewaySpendClickHouseRepository,
+  GovernanceGatewaySpendDayRow,
+} from "@ee/governance/services/governanceGatewaySpend.clickhouse.repository";
+import type {
   GovernanceOcsfEventsClickHouseRepository,
   GovernanceSeatReportRow,
 } from "@ee/governance/services/governanceOcsfEvents.clickhouse.repository";
@@ -41,6 +45,7 @@ import { resolveGovProjectId } from "@ee/governance/services/govProject";
 import { noDataSinceNotice } from "@ee/governance/services/pullers/sourceHealth";
 import { createLogger } from "@langwatch/observability";
 import type { PrismaClient } from "~/generated/prisma/client";
+import type { ProjectRepository } from "~/server/app-layer/projects/repositories/project.repository";
 import {
   nanoMinorToDecimalString,
   nanoUsdToDecimalString,
@@ -114,6 +119,19 @@ export interface GovernanceCostLaneDto {
    * nobody was charged (ADR-128 §3).
    */
   currencyTotals: GovernanceCostCurrencyTotalDto[];
+  /**
+   * The METERED LANE ONLY: how many requests over the window carry no dollar
+   * amount — priced at zero with tokens consumed (free or unpriced, the ledger
+   * cannot tell which), or settled with the cost never confirmed.
+   *
+   * Optional because it is a gateway-only concept and the other lanes never
+   * set it. Unlike the billed lane's `cellsWithoutAmount`, a count here does
+   * NOT withhold the total: the metered lane marks instead of withholding
+   * (ADR-128), so `amountUsd` still states the priced requests and this rides
+   * beside it. The screen renders "N requests with no dollar amount" when N is
+   * above zero.
+   */
+  requestsWithoutAmount?: number;
 }
 
 /**
@@ -487,6 +505,19 @@ export class GovernanceCostService {
        * what awaiting says.
        */
       ocsfEvents: GovernanceOcsfEventsClickHouseRepository | undefined;
+      /**
+       * The metered lane's source: the gateway's own per-request ledger.
+       * `undefined` on the same deployment the rollup is absent from, and the
+       * metered lane then holds no figure — the screen is already UNAVAILABLE
+       * for want of a cost store, so the lane never has to stand on its own.
+       */
+      gatewaySpend: GovernanceGatewaySpendClickHouseRepository | undefined;
+      /**
+       * Where the metered lane's tenant scope comes from: every project of
+       * the organization, since `gateway_spend.TenantId` is the traffic's own
+       * project id rather than the hidden governance tenant.
+       */
+      projects: ProjectRepository;
     },
   ) {}
 
@@ -494,12 +525,22 @@ export class GovernanceCostService {
     prisma,
     costRollup,
     ocsfEvents,
+    gatewaySpend,
+    projects,
   }: {
     prisma: PrismaClient;
     costRollup: GovernanceCostRollupClickHouseRepository | undefined;
     ocsfEvents: GovernanceOcsfEventsClickHouseRepository | undefined;
+    gatewaySpend: GovernanceGatewaySpendClickHouseRepository | undefined;
+    projects: ProjectRepository;
   }): GovernanceCostService {
-    return new GovernanceCostService({ prisma, costRollup, ocsfEvents });
+    return new GovernanceCostService({
+      prisma,
+      costRollup,
+      ocsfEvents,
+      gatewaySpend,
+      projects,
+    });
   }
 
   /**
@@ -517,7 +558,7 @@ export class GovernanceCostService {
     windowDays: number;
     now?: Date;
   }): Promise<GovernanceCostSummaryDto> {
-    const { costRollup, prisma } = this.deps;
+    const { costRollup, prisma, projects } = this.deps;
     if (!costRollup) {
       return unavailable({ reason: "no_cost_store", windowDays });
     }
@@ -528,6 +569,16 @@ export class GovernanceCostService {
     if (!tenantId) {
       return unavailable({ reason: "no_governance_project", windowDays });
     }
+
+    // The metered lane reads the gateway's per-request ledger, which is keyed
+    // by the traffic's own PROJECT tenant, not the hidden governance tenant
+    // the rollup reads under. So it is scoped to every project of the
+    // organization, archived ones included — the one place the two lanes'
+    // tenant scopes differ, and the whole reason the metered lane used to
+    // read empty.
+    const gatewayTenantIds = await projects.findAllIdsByOrganization({
+      organizationId,
+    });
 
     const toDay = utcDay(now);
     const fromDay = utcDay(
@@ -544,6 +595,7 @@ export class GovernanceCostService {
     // measurement.
     const [
       rows,
+      gatewayDays,
       seats,
       staleSources,
       azureBilling,
@@ -551,7 +603,17 @@ export class GovernanceCostService {
       providers,
       billedCurrencies,
     ] = await Promise.all([
-      costRollup.sumDaysByLane({ tenantId, fromDay, toDay }),
+      // PULLED ONLY. The metered lane no longer lives in the rollup, and the
+      // fold's leftover gateway rows must be read by nothing — so the billed
+      // day series asks for pulled rows by predicate, not by a filter the
+      // caller could forget.
+      costRollup.sumDaysByLane({
+        tenantId,
+        fromDay,
+        toDay,
+        costSource: GOVERNANCE_COST_SOURCE.PULLED,
+      }),
+      this.readGatewayDays({ tenantIds: gatewayTenantIds, fromDay, toDay }),
       this.readSeats({ tenantId }),
       this.readStaleSources({ organizationId }),
       this.readAzureBillingNote({ organizationId, tenantId, fromDay, toDay }),
@@ -588,14 +650,43 @@ export class GovernanceCostService {
         provider: row.provider,
         ...spenderFigure([row]),
       })),
-      gateway: totalFor(rows, GOVERNANCE_COST_SOURCE.GATEWAY),
+      gateway: gatewayLaneFrom(gatewayDays),
       azureBilling,
       seats,
-      series: seriesFrom(rows, now),
+      series: seriesFrom(rows, gatewayDays, now),
       windowDays,
       staleSources,
       unpricedWindow,
     };
+  }
+
+  /**
+   * The metered lane's days from the gateway ledger, or none when the ledger
+   * store is absent.
+   *
+   * A broken ledger read fails here, not silently: the metered lane is money,
+   * and a lane that swallowed its own failure would render an absence as a
+   * measurement — the same rule the pulled read at the top of `summary` obeys.
+   * The absent-store case is different: no gateway repository means no cost
+   * store at all, and the screen is already UNAVAILABLE for that reason, so
+   * this simply reports no metered days rather than inventing a zero.
+   */
+  private async readGatewayDays({
+    tenantIds,
+    fromDay,
+    toDay,
+  }: {
+    tenantIds: string[];
+    fromDay: string;
+    toDay: string;
+  }): Promise<GovernanceGatewaySpendDayRow[]> {
+    const { gatewaySpend } = this.deps;
+    if (!gatewaySpend) return [];
+    return gatewaySpend.sumDaysForOrganizationProjects({
+      tenantIds,
+      fromDay,
+      toDay,
+    });
   }
 
   /**
@@ -1371,44 +1462,6 @@ function currencyTotalsFrom(
 }
 
 /**
- * A lane's per-currency window totals folded from its own DAY rows.
- *
- * Used for the gateway lane, whose headline is folded from the same rows, so
- * the lines and the figure over them describe one snapshot. The billed lane
- * takes its lines from the window read instead, for exactly the same reason —
- * see the comment on that read in `summary`.
- */
-function currencyTotalsFoldedFrom(
-  rows: readonly LaneRow[],
-): GovernanceCostCurrencyTotalDto[] {
-  const byCode = new Map<
-    string,
-    { amountNanoMinor: number | null; cellsWithoutAmount: number }
-  >();
-  for (const row of rows) {
-    for (const line of row.byCurrency) {
-      const held = byCode.get(line.currencyCode) ?? {
-        amountNanoMinor: null,
-        cellsWithoutAmount: 0,
-      };
-      byCode.set(line.currencyCode, {
-        amountNanoMinor:
-          line.amountNanoMinor === null
-            ? held.amountNanoMinor
-            : (held.amountNanoMinor ?? 0) + line.amountNanoMinor,
-        cellsWithoutAmount: held.cellsWithoutAmount + line.cellsWithoutAmount,
-      });
-    }
-  }
-  return currencyTotalsFrom(
-    [...byCode.entries()].map(([currencyCode, held]) => ({
-      currencyCode,
-      ...held,
-    })),
-  );
-}
-
-/**
  * The billed day's currency lines, and what each held before its revision.
  *
  * A day whose read answers no currency lines at all falls back to the single
@@ -1450,28 +1503,63 @@ function dayCurrencyLinesFrom(
 }
 
 /**
- * One lane's window total.
+ * A day's metered figure, or null when the day charged nothing.
  *
- * A lane with no rows at all, a lane whose every row holds no figure, and a
- * lane holding a mix all come back null; `cellsWithoutAmount` is what tells
- * the three apart, and the currencies say what the unpriced part was billed
- * in.
+ * Null when no confirmed or failed request landed on the day — a day of only
+ * settled requests has an unknown cost, and $0.00 would claim it was free.
+ * When a request DID charge, the sum stands even at zero (a refund day), and
+ * the requests carrying no dollar amount are the marker beside it, never a
+ * reason to withhold it.
  */
-function totalFor(
-  rows: readonly LaneRow[],
-  costSource: string,
+function gatewayDayUsd(day: GovernanceGatewaySpendDayRow): number | null {
+  if (day.requestCount === 0) return null;
+  return Number(nanoUsdToDecimalString(BigInt(day.amountNanoUsd)));
+}
+
+/**
+ * The metered lane's window total, from the gateway ledger's days.
+ *
+ * DELIBERATE DEVIATION from the billed lane's withhold rule (ADR-128): a
+ * request with no dollar amount is COUNTED beside the total, never allowed to
+ * withhold it. The ledger names exactly what is left out — the count is the
+ * caveat — where the billed lane's unpriced cell hides an unknown share of a
+ * bill and so withholds. So `cellsWithoutAmount` is always 0 here (the gateway
+ * withholds nothing) and `requestsWithoutAmount` carries the count instead.
+ *
+ * `amountUsd` is null only when no charged request landed at all — a window of
+ * only settled requests has an unknown cost, not a zero one.
+ */
+function gatewayLaneFrom(
+  days: readonly GovernanceGatewaySpendDayRow[],
 ): GovernanceCostLaneDto {
-  const lane = rows.filter((row) => row.costSource === costSource);
+  const requestCount = days.reduce((n, day) => n + day.requestCount, 0);
+  const requestsWithoutAmount = days.reduce(
+    (n, day) => n + day.requestsWithoutAmount,
+    0,
+  );
+  // Summed in BigInt, per ADR-128 §3, so a window past 2^53 nano-USD keeps
+  // every digit.
+  const totalNanoUsd = days.reduce(
+    (sum, day) => sum + BigInt(day.amountNanoUsd),
+    0n,
+  );
+  const amountUsd =
+    requestCount > 0 ? Number(nanoUsdToDecimalString(totalNanoUsd)) : null;
   return {
-    amountUsd: figureFor(lane),
-    cellsWithoutAmount: lane.reduce(
-      (count, row) => count + row.cellsWithoutAmount,
-      0,
-    ),
-    currenciesWithoutUsdAmount: [
-      ...new Set(lane.flatMap((row) => row.currenciesWithoutUsdAmount)),
-    ].sort(),
-    currencyTotals: currencyTotalsFoldedFrom(lane),
+    amountUsd,
+    cellsWithoutAmount: 0,
+    currenciesWithoutUsdAmount: [],
+    currencyTotals:
+      amountUsd === null
+        ? []
+        : [
+            {
+              currencyCode: GOVERNANCE_COST_CURRENCY_USD,
+              amount: amountUsd,
+              cellsWithoutAmount: 0,
+            },
+          ],
+    requestsWithoutAmount,
   };
 }
 
@@ -1489,12 +1577,15 @@ function totalFor(
  */
 function seriesFrom(
   rows: readonly LaneRow[],
+  gatewayDays: readonly GovernanceGatewaySpendDayRow[],
   now: Date,
 ): GovernanceCostDayDto[] {
   const byDay = new Map<string, GovernanceCostDayDto>();
-  for (const row of rows) {
-    const entry = byDay.get(row.day) ?? {
-      day: row.day,
+  const entryFor = (day: string): GovernanceCostDayDto => {
+    const existing = byDay.get(day);
+    if (existing) return existing;
+    const fresh: GovernanceCostDayDto = {
+      day,
       billedUsd: null,
       gatewayUsd: null,
       billedCellsWithoutAmount: 0,
@@ -1504,33 +1595,44 @@ function seriesFrom(
       billedCurrenciesWithoutUsdAmount: [],
       billedProvisional: false,
     };
-    if (row.costSource === GOVERNANCE_COST_SOURCE.PULLED) {
-      entry.billedUsd = figureFor([row]);
-      entry.billedCellsWithoutAmount = row.cellsWithoutAmount;
-      entry.billedRevisedAt =
-        row.revisedAt === null ? null : row.revisedAt * 1000;
-      entry.billedByCurrency = dayCurrencyLinesFrom(row);
-      entry.billedCurrenciesWithoutUsdAmount = row.currenciesWithoutUsdAmount;
-      // The settling window is per SOURCE, and this row spans every source the
-      // billed lane holds that day. Every source runs on the default today —
-      // only Anthropic's window has been measured, and the rest are provisional
-      // constants until they are — so the default is exactly right here rather
-      // than an approximation. It stops being so the day a source is measured
-      // to differ, and that is the day this read has to group by source.
-      entry.billedProvisional = isWithinSettlingWindow({
-        lastObservedAtSeconds: row.lastObservedAt,
-        windowDays: GOVERNANCE_SETTLING_WINDOW_DAYS,
-        now,
-      });
-    } else if (row.costSource === GOVERNANCE_COST_SOURCE.GATEWAY) {
-      entry.gatewayUsd = figureFor([row]);
-      entry.gatewayCellsWithoutAmount = row.cellsWithoutAmount;
-      // The gateway lane is EXEMPT from both markers (§15). We metered these
-      // rows ourselves in real time and no provider restates them, so "can
-      // still move" on the product's most-viewed and most-final numbers would
-      // be a warning about a thing that cannot happen.
-    }
-    byDay.set(row.day, entry);
+    byDay.set(day, fresh);
+    return fresh;
+  };
+
+  // The billed lane, from the pulled rollup. The read is already pulled-only,
+  // so a leftover gateway row cannot reach here — but the guard stays, so a
+  // future unfiltered caller cannot quietly fold gateway money into the billed
+  // series.
+  for (const row of rows) {
+    if (row.costSource !== GOVERNANCE_COST_SOURCE.PULLED) continue;
+    const entry = entryFor(row.day);
+    entry.billedUsd = figureFor([row]);
+    entry.billedCellsWithoutAmount = row.cellsWithoutAmount;
+    entry.billedRevisedAt =
+      row.revisedAt === null ? null : row.revisedAt * 1000;
+    entry.billedByCurrency = dayCurrencyLinesFrom(row);
+    entry.billedCurrenciesWithoutUsdAmount = row.currenciesWithoutUsdAmount;
+    // The settling window is per SOURCE, and this row spans every source the
+    // billed lane holds that day. Every source runs on the default today —
+    // only Anthropic's window has been measured, and the rest are provisional
+    // constants until they are — so the default is exactly right here rather
+    // than an approximation. It stops being so the day a source is measured to
+    // differ, and that is the day this read has to group by source.
+    entry.billedProvisional = isWithinSettlingWindow({
+      lastObservedAtSeconds: row.lastObservedAt,
+      windowDays: GOVERNANCE_SETTLING_WINDOW_DAYS,
+      now,
+    });
   }
+
+  // The metered lane, from the gateway ledger. EXEMPT from both §15 markers:
+  // we metered these ourselves in real time and no provider restates them, so
+  // "can still move" on the product's most-viewed and most-final numbers would
+  // be a warning about a thing that cannot happen. The lane never withholds a
+  // day's figure, so `gatewayCellsWithoutAmount` stays zero.
+  for (const day of gatewayDays) {
+    entryFor(day.day).gatewayUsd = gatewayDayUsd(day);
+  }
+
   return [...byDay.values()].sort((a, b) => a.day.localeCompare(b.day));
 }

--- a/platform/app/ee/governance/services/governanceCost.service.ts
+++ b/platform/app/ee/governance/services/governanceCost.service.ts
@@ -1537,8 +1537,9 @@ function gatewayLaneFrom(
     (n, day) => n + day.requestsWithoutAmount,
     0,
   );
-  // Summed in BigInt, per ADR-128 §3, so a window past 2^53 nano-USD keeps
-  // every digit.
+  // Each day is guarded to the safe integer range at the repository; the
+  // BigInt fold, per ADR-128 §3, keeps the window sum exact when the days
+  // together pass 2^53 nano-USD.
   const totalNanoUsd = days.reduce(
     (sum, day) => sum + BigInt(day.amountNanoUsd),
     0n,

--- a/platform/app/ee/governance/services/governanceCost.service.ts
+++ b/platform/app/ee/governance/services/governanceCost.service.ts
@@ -1503,16 +1503,42 @@ function dayCurrencyLinesFrom(
 }
 
 /**
- * A day's metered figure, or null when the day charged nothing.
+ * Whether a set of metered requests supports a dollar figure at all.
  *
- * Null when no confirmed or failed request landed on the day — a day of only
- * settled requests has an unknown cost, and $0.00 would claim it was free.
- * When a request DID charge, the sum stands even at zero (a refund day), and
- * the requests carrying no dollar amount are the marker beside it, never a
- * reason to withhold it.
+ * THE RULE, applied to a day and to the window alike: the figure stands when
+ * at least one charged request was priced, or when requests were charged and
+ * none of them lacks an amount — every charged request priced at zero with
+ * nothing consumed, so nothing was spent and nothing is unknown, and $0.00 is
+ * honest. Otherwise null: no charged request at all (a day of only settled
+ * requests), or charged requests that are ALL in the unpriced count (priced
+ * at zero with tokens consumed — free or unpriced, the ledger cannot tell
+ * which). In that last case the zero sum is not a measurement, and a "$0.00"
+ * beside "N requests with no dollar amount" would claim free where the ledger
+ * says unknown.
+ *
+ * `pricedRequestCount` is the ledger's own count, never charged minus
+ * unpriced: the unpriced count also holds settled requests, which are not
+ * charged.
+ */
+function gatewayFigureStands(counts: {
+  requestCount: number;
+  pricedRequestCount: number;
+  requestsWithoutAmount: number;
+}): boolean {
+  if (counts.pricedRequestCount > 0) return true;
+  return counts.requestCount > 0 && counts.requestsWithoutAmount === 0;
+}
+
+/**
+ * A day's metered figure, or null when the day cannot state one.
+ *
+ * Null by the rule in `gatewayFigureStands`: no charged request, or charged
+ * requests the ledger could not price. When the figure stands, the sum is
+ * shown even at zero, and the requests carrying no dollar amount are the
+ * marker beside it, never a reason to withhold it.
  */
 function gatewayDayUsd(day: GovernanceGatewaySpendDayRow): number | null {
-  if (day.requestCount === 0) return null;
+  if (!gatewayFigureStands(day)) return null;
   return Number(nanoUsdToDecimalString(BigInt(day.amountNanoUsd)));
 }
 
@@ -1526,13 +1552,19 @@ function gatewayDayUsd(day: GovernanceGatewaySpendDayRow): number | null {
  * bill and so withholds. So `cellsWithoutAmount` is always 0 here (the gateway
  * withholds nothing) and `requestsWithoutAmount` carries the count instead.
  *
- * `amountUsd` is null only when no charged request landed at all — a window of
- * only settled requests has an unknown cost, not a zero one.
+ * `amountUsd` is null by the rule in `gatewayFigureStands`, applied to the
+ * window's summed counts: no charged request at all, or charged requests the
+ * ledger could not price — a window of only such requests has an unknown
+ * cost, not a zero one.
  */
 function gatewayLaneFrom(
   days: readonly GovernanceGatewaySpendDayRow[],
 ): GovernanceCostLaneDto {
   const requestCount = days.reduce((n, day) => n + day.requestCount, 0);
+  const pricedRequestCount = days.reduce(
+    (n, day) => n + day.pricedRequestCount,
+    0,
+  );
   const requestsWithoutAmount = days.reduce(
     (n, day) => n + day.requestsWithoutAmount,
     0,
@@ -1544,8 +1576,13 @@ function gatewayLaneFrom(
     (sum, day) => sum + BigInt(day.amountNanoUsd),
     0n,
   );
-  const amountUsd =
-    requestCount > 0 ? Number(nanoUsdToDecimalString(totalNanoUsd)) : null;
+  const amountUsd = gatewayFigureStands({
+    requestCount,
+    pricedRequestCount,
+    requestsWithoutAmount,
+  })
+    ? Number(nanoUsdToDecimalString(totalNanoUsd))
+    : null;
   return {
     amountUsd,
     cellsWithoutAmount: 0,

--- a/platform/app/ee/governance/services/governanceCostRollup.clickhouse.repository.ts
+++ b/platform/app/ee/governance/services/governanceCostRollup.clickhouse.repository.ts
@@ -643,6 +643,14 @@ export class GovernanceCostRollupClickHouseRepository {
     fromDay: string;
     /** Inclusive, `YYYY-MM-DD`. */
     toDay: string;
+    /**
+     * Which lane to read. The metered lane now reads the gateway ledger
+     * directly, so the cost screen passes `pulled` and the fold's leftover
+     * gateway rows in this table are counted by nothing. Optional so a caller
+     * wanting every lane (a diagnostic, a test) still can; unset means no
+     * `CostSource` predicate.
+     */
+    costSource?: string;
   }): Promise<
     Array<{
       day: string;
@@ -837,6 +845,7 @@ export class GovernanceCostRollupClickHouseRepository {
                   AND Day >= {fromday:Date}
                   AND Day <= {today:Date}
                   AND Version = {version:String}
+                  ${input.costSource ? "AND CostSource = {costsource:String}" : ""}
                 GROUP BY ${KEY_COLUMNS.join(", ")}
               )
             )
@@ -852,6 +861,7 @@ export class GovernanceCostRollupClickHouseRepository {
         today: input.toDay,
         version: GOVERNANCE_COST_ROLLUP_PROJECTION_VERSION_LATEST,
         usd: GOVERNANCE_COST_CURRENCY_USD,
+        ...(input.costSource ? { costsource: input.costSource } : {}),
       },
       format: "JSONEachRow",
     });

--- a/platform/app/ee/governance/services/governanceGatewaySpend.clickhouse.repository.ts
+++ b/platform/app/ee/governance/services/governanceGatewaySpend.clickhouse.repository.ts
@@ -122,15 +122,21 @@ const LATEST_REQUEST_SUBQUERY = `
  * grouping.
  *
  * `AmountNanoUsd` sums only the charged requests. `RequestCount` is the charged
- * requests. `RequestsWithoutAmount` is counted BESIDE the total, never inside
- * it: a charged request that consumed tokens yet priced at zero (free or
- * unpriced — the ledger cannot tell which), plus a settled request whose
- * confirmation never arrived so its cost is unknown. Settled rows add nothing
- * to the money sum.
+ * requests. `PricedRequestCount` is the charged requests that carry a positive
+ * cost — counted on its own, NOT derived as charged minus unpriced, because
+ * the unpriced count also holds settled requests, which are not charged at
+ * all. The service reads it to tell a day that spent nothing from a day whose
+ * cost is unknown: a charged request priced at zero with tokens consumed is in
+ * `RequestCount` but not here. `RequestsWithoutAmount` is counted BESIDE the
+ * total, never inside it: a charged request that consumed tokens yet priced
+ * at zero (free or unpriced — the ledger cannot tell which), plus a settled
+ * request whose confirmation never arrived so its cost is unknown. Settled
+ * rows add nothing to the money sum.
  */
 const METERED_FIGURE_COLUMNS = `
           toString(sumIf(RequestCostNanoUSD, RequestStatus IN ${CHARGED_STATUSES})) AS AmountNanoUsd,
           countIf(RequestStatus IN ${CHARGED_STATUSES}) AS RequestCount,
+          countIf(RequestStatus IN ${CHARGED_STATUSES} AND RequestCostNanoUSD > 0) AS PricedRequestCount,
           countIf(
             RequestStatus IN ${CHARGED_STATUSES}
             AND RequestCostNanoUSD = 0
@@ -170,6 +176,9 @@ export interface GovernanceGatewaySpendDayRow {
   amountNanoUsd: number;
   /** Charged (confirmed + failed) requests on the day. */
   requestCount: number;
+  /** Charged requests with a positive cost. Zero with `requestCount` above
+   *  zero means every charged request priced at zero. */
+  pricedRequestCount: number;
   /** Requests carrying no dollar amount: zero-cost-with-tokens plus settled. */
   requestsWithoutAmount: number;
 }
@@ -179,6 +188,7 @@ export interface GovernanceGatewaySpendModelRow {
   model: string;
   amountNanoUsd: number;
   requestCount: number;
+  pricedRequestCount: number;
   requestsWithoutAmount: number;
 }
 
@@ -186,6 +196,7 @@ export interface GovernanceGatewaySpendVirtualKeyRow {
   virtualKeyId: string;
   amountNanoUsd: number;
   requestCount: number;
+  pricedRequestCount: number;
   requestsWithoutAmount: number;
 }
 
@@ -221,6 +232,7 @@ export class GovernanceGatewaySpendClickHouseRepository {
       day: String(row.Day ?? ""),
       amountNanoUsd: parseSummedNanoUsd(row.AmountNanoUsd),
       requestCount: int(row.RequestCount),
+      pricedRequestCount: int(row.PricedRequestCount),
       requestsWithoutAmount: int(row.RequestsWithoutAmount),
     }));
   }
@@ -245,6 +257,7 @@ export class GovernanceGatewaySpendClickHouseRepository {
       model: String(row.Model ?? ""),
       amountNanoUsd: parseSummedNanoUsd(row.AmountNanoUsd),
       requestCount: int(row.RequestCount),
+      pricedRequestCount: int(row.PricedRequestCount),
       requestsWithoutAmount: int(row.RequestsWithoutAmount),
     }));
   }
@@ -263,6 +276,7 @@ export class GovernanceGatewaySpendClickHouseRepository {
       virtualKeyId: String(row.VirtualKeyId ?? ""),
       amountNanoUsd: parseSummedNanoUsd(row.AmountNanoUsd),
       requestCount: int(row.RequestCount),
+      pricedRequestCount: int(row.PricedRequestCount),
       requestsWithoutAmount: int(row.RequestsWithoutAmount),
     }));
   }

--- a/platform/app/ee/governance/services/governanceGatewaySpend.clickhouse.repository.ts
+++ b/platform/app/ee/governance/services/governanceGatewaySpend.clickhouse.repository.ts
@@ -50,9 +50,10 @@ const TABLE = "gateway_spend" as const;
  * (`CLICKHOUSE_REQUEST_TIMEOUT_MS` in `clickhouse/managedClient.ts`). A query
  * deadline at or past that limit is one nothing ever reaches — the client
  * abandons the request first and the screen hangs where it should have shown
- * its error state. This read is a single grouped scan over at most a month of
- * one organization's requests, so 20 s is generous headroom and still leaves
- * the wire limit as the real ceiling.
+ * its error state. This read is a single grouped scan over at most a year of
+ * one organization's requests — the screen's frame is clamped to a 365-day
+ * ceiling — so 20 s is generous headroom and still leaves the wire limit as
+ * the real ceiling.
  */
 const METERED_READ_MAX_EXECUTION_SECONDS = 20;
 
@@ -243,8 +244,10 @@ export class GovernanceGatewaySpendClickHouseRepository {
    * disagree about what a metered figure is.
    *
    * The client is resolved by the FIRST tenant, matching every other multi-
-   * tenant read on this schema (`spendScope` orders projects so this is stable):
-   * one organization's projects route to the same ClickHouse.
+   * tenant read on this schema. The caller hands the ids in the order
+   * `ProjectRepository.findAllIdsByOrganization` returns them — ascending by
+   * id — so the first is the same project on every read: one organization's
+   * projects route to the same ClickHouse.
    */
   private async run(
     input: GovernanceGatewaySpendWindow,

--- a/platform/app/ee/governance/services/governanceGatewaySpend.clickhouse.repository.ts
+++ b/platform/app/ee/governance/services/governanceGatewaySpend.clickhouse.repository.ts
@@ -27,14 +27,24 @@
  * SELECT's WHERE, so `argMax(OccurredAt, EventTimestamp) AS OccurredAt` would
  * put an aggregate in the WHERE clause and the read would fail.
  *
- * THE WINDOW IS APPLIED TO THE REQUEST, NOT TO ITS VERSIONS. For the same
- * reason, the window cannot be a plain WHERE on the raw rows: if an older
- * version's start time sits inside the window and the latest version moved it
- * outside, a raw filter keeps the stale version alone and counts a request
- * that has left the window, at a cost the ledger has since replaced. The raw
- * rows are only PREFILTERED on `OccurredAt` — wide enough that every version
- * of any request in the window survives to the collapse — and the window is
+ * THE WINDOW IS THE ONLY TIME PREDICATE, AND IT IS APPLIED TO THE REQUEST,
+ * NOT TO ITS VERSIONS. For the same reason, the window cannot be a WHERE on
+ * the raw rows: if an older version's start time sits inside the window and
+ * the latest version moved it outside, a raw filter keeps the stale version
+ * alone and counts a request that has left the window, at a cost the ledger
+ * has since replaced. Nor can a raw prefilter be widened to a safe margin:
+ * the fold sets the start time on admission unconditionally and outcomes keep
+ * whatever is set (`gatewaySpend.foldProjection.ts`), so when the outcome
+ * folds first the start later moves back by the outcome-to-admission gap, and
+ * nothing bounds that gap — the brokered path admits on one emitter and
+ * confirms on another. So the raw rows carry NO time predicate; the window is
  * decided in a HAVING on the collapsed `RequestOccurredAt`.
+ *
+ * The price is that the read scans the organization's whole ledger history
+ * rather than the window's months: the partition key (`toYYYYMM(OccurredAt)`)
+ * is not used by this read. What keeps it to one organization's requests is
+ * the table's ORDER BY `(TenantId, GatewayRequestId)` (migration 00067): the
+ * primary index prunes to the organization's own rows in every partition.
  *
  * NO PERSON COLUMN is ever selected. The ledger sits outside erasure, so a
  * `PrincipalUserId` or `EndUserId` read from it would outlive a deletion the
@@ -71,29 +81,18 @@ const METERED_READ_MAX_EXECUTION_SECONDS = 20;
 const CHARGED_STATUSES = "('confirmed', 'failed')";
 
 /**
- * How far below the window's lower bound the raw prefilter reaches, so that a
- * request's older version inside the window never survives the collapse
- * without its latest version outside it.
- *
- * Only the lower bound needs widening. The upper bound is midnight after the
- * last day of a frame that ends today, so no version lies beyond it. Below,
- * a start time can only move by the request's own duration — the gap between
- * its outcome being recorded and its admission arriving — which the gateway
- * bounds far under a day. One day of slack therefore covers every version of
- * every request the window can hold, and the partition key (the month the
- * row started in) still prunes on it.
- */
-const WINDOW_PREFILTER_SLACK_MS = 86_400_000;
-
-/**
  * One request collapsed to its surviving version, named apart from the columns
  * it aggregates so no alias leaks into the WHERE.
  *
- * The WHERE only prefilters the raw rows, on `OccurredAt` widened below by
- * `WINDOW_PREFILTER_SLACK_MS`, so partitions prune and every version of a
- * request in the window reaches the collapse. The window itself is the
- * HAVING on `RequestOccurredAt`: the start time the ledger currently holds
- * for the request, not the one some older version of it carried.
+ * The WHERE is the tenant fence alone. There is deliberately no `OccurredAt`
+ * predicate on the raw rows, not even a widened one: a request's latest
+ * version can carry a start time any distance before an older version's, so
+ * every version of every request of the organization must reach the collapse
+ * for the survivor to be the right one. The window is the HAVING on
+ * `RequestOccurredAt`: the start time the ledger currently holds for the
+ * request, not the one some older version of it carried. The tenant index
+ * (the table's ORDER BY) is what bounds the scan; the month partition key is
+ * not used here.
  */
 const LATEST_REQUEST_SUBQUERY = `
   SELECT
@@ -110,8 +109,6 @@ const LATEST_REQUEST_SUBQUERY = `
     argMax(TokensReasoning, EventTimestamp)  AS RequestTokensReasoning
   FROM ${TABLE}
   WHERE TenantId IN {tenantIds:Array(String)}
-    AND OccurredAt >= fromUnixTimestamp64Milli({prefilterFromMs:Int64})
-    AND OccurredAt < fromUnixTimestamp64Milli({toMs:Int64})
   GROUP BY TenantId, GatewayRequestId
   HAVING RequestOccurredAt >= fromUnixTimestamp64Milli({fromMs:Int64})
     AND RequestOccurredAt < fromUnixTimestamp64Milli({toMs:Int64})
@@ -306,7 +303,6 @@ export class GovernanceGatewaySpendClickHouseRepository {
     },
   ): Promise<Record<string, unknown>[]> {
     const client = await this.resolveClient(input.tenantIds[0]!);
-    const fromMs = dayStartMs(input.fromDay);
     const result = await client.query({
       query: `
         SELECT
@@ -318,10 +314,9 @@ export class GovernanceGatewaySpendClickHouseRepository {
       `,
       query_params: {
         tenantIds: input.tenantIds,
-        fromMs,
-        // The raw-row prefilter reaches a day below the window; the window
-        // itself is decided on the collapsed request.
-        prefilterFromMs: fromMs - WINDOW_PREFILTER_SLACK_MS,
+        // Both bounds apply to the collapsed request's start time, in the
+        // HAVING — never to the raw rows.
+        fromMs: dayStartMs(input.fromDay),
         // Inclusive of the last day: midnight AFTER it, exclusive.
         toMs: dayStartMs(input.toDay) + 86_400_000,
       },

--- a/platform/app/ee/governance/services/governanceGatewaySpend.clickhouse.repository.ts
+++ b/platform/app/ee/governance/services/governanceGatewaySpend.clickhouse.repository.ts
@@ -34,11 +34,14 @@
  *
  * MONEY is integer nano-USD (`CostNanoUSD`), summed in ClickHouse as Int64 and
  * read out via `toString` so the JSON step never rounds a figure past 2^53.
+ * Each figure then passes through the gateway's own guarded parser, which
+ * refuses anything past the safe integer range rather than rounding it.
  *
  * Spec: specs/governance/governance-cost-screen.feature
  *   ("THE METERED LANE READS THE GATEWAY'S OWN LEDGER")
  */
 import type { ClickHouseClient } from "@clickhouse/client";
+import { parseSummedNanoUsd } from "~/server/gateway/spendEvents.clickhouse.repository";
 
 const TABLE = "gateway_spend" as const;
 
@@ -114,13 +117,6 @@ const METERED_FIGURE_COLUMNS = `
  */
 const AMOUNT_DESC = "toInt64(AmountNanoUsd) DESC";
 
-/** ClickHouse renders a summed Int64 as a string in JSONEachRow; parse the
- *  whole thing through BigInt so the one Number conversion never drops a low
- *  digit on a wide money figure. */
-function nano(value: unknown): number {
-  return Number(BigInt(String(value ?? 0)));
-}
-
 function int(value: unknown): number {
   return Number(value ?? 0);
 }
@@ -192,7 +188,7 @@ export class GovernanceGatewaySpendClickHouseRepository {
     });
     return rows.map((row) => ({
       day: String(row.Day ?? ""),
-      amountNanoUsd: nano(row.AmountNanoUsd),
+      amountNanoUsd: parseSummedNanoUsd(row.AmountNanoUsd),
       requestCount: int(row.RequestCount),
       requestsWithoutAmount: int(row.RequestsWithoutAmount),
     }));
@@ -216,7 +212,7 @@ export class GovernanceGatewaySpendClickHouseRepository {
     });
     return rows.map((row) => ({
       model: String(row.Model ?? ""),
-      amountNanoUsd: nano(row.AmountNanoUsd),
+      amountNanoUsd: parseSummedNanoUsd(row.AmountNanoUsd),
       requestCount: int(row.RequestCount),
       requestsWithoutAmount: int(row.RequestsWithoutAmount),
     }));
@@ -234,7 +230,7 @@ export class GovernanceGatewaySpendClickHouseRepository {
     });
     return rows.map((row) => ({
       virtualKeyId: String(row.VirtualKeyId ?? ""),
-      amountNanoUsd: nano(row.AmountNanoUsd),
+      amountNanoUsd: parseSummedNanoUsd(row.AmountNanoUsd),
       requestCount: int(row.RequestCount),
       requestsWithoutAmount: int(row.RequestsWithoutAmount),
     }));

--- a/platform/app/ee/governance/services/governanceGatewaySpend.clickhouse.repository.ts
+++ b/platform/app/ee/governance/services/governanceGatewaySpend.clickhouse.repository.ts
@@ -1,0 +1,288 @@
+// SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+
+/**
+ * The metered lane's read side: the gateway's own per-request billing ledger,
+ * `gateway_spend` (migration 00067).
+ *
+ * WHY THIS EXISTS RATHER THAN THE ROLLUP. The metered lane used to read the
+ * same daily rollup the billed lane reads. A fold wrote the gateway's cells
+ * there under the tenant of the project whose traffic it was, while the screen
+ * read them under the hidden governance project's tenant — so for real traffic
+ * the lane was always empty and only fixtures ever filled it. The fold is gone
+ * rather than repaired: the lane reads the ledger directly, scoped to every
+ * project tenant of the viewer's organization, and the rollup's leftover
+ * gateway rows are read by nothing (`governanceCostRollup.clickhouse.repository`
+ * filters every read to pulled).
+ *
+ * A REQUEST IS THE UNIT. `gateway_spend` keeps one aggregate per gateway
+ * request, partitioned by the month it STARTED in. The same request can hold
+ * rows in two monthly partitions — its outcome recorded before its admission,
+ * the admission then moving the start time — so a sum that trusts the table to
+ * have merged them counts the request twice. FINAL cannot fix it: FINAL dedups
+ * a ReplacingMergeTree within a partition, and these two rows are in different
+ * partitions. So every read collapses the ledger to one row per
+ * `(TenantId, GatewayRequestId)` with `argMax(..., EventTimestamp)` first, and
+ * aggregates only those survivors. The aliases are deliberately NOT the column
+ * names they aggregate: ClickHouse resolves an alias back into the same
+ * SELECT's WHERE, so `argMax(OccurredAt, EventTimestamp) AS OccurredAt` would
+ * put an aggregate in the WHERE clause and the read would fail.
+ *
+ * NO PERSON COLUMN is ever selected. The ledger sits outside erasure, so a
+ * `PrincipalUserId` or `EndUserId` read from it would outlive a deletion the
+ * rest of the product honoured. The lane groups by model and by virtual key
+ * only.
+ *
+ * MONEY is integer nano-USD (`CostNanoUSD`), summed in ClickHouse as Int64 and
+ * read out via `toString` so the JSON step never rounds a figure past 2^53.
+ *
+ * Spec: specs/governance/governance-cost-screen.feature
+ *   ("THE METERED LANE READS THE GATEWAY'S OWN LEDGER")
+ */
+import type { ClickHouseClient } from "@clickhouse/client";
+
+const TABLE = "gateway_spend" as const;
+
+/**
+ * The read's deadline, comfortably under the managed client's 30 s wire limit
+ * (`CLICKHOUSE_REQUEST_TIMEOUT_MS` in `clickhouse/managedClient.ts`). A query
+ * deadline at or past that limit is one nothing ever reaches — the client
+ * abandons the request first and the screen hangs where it should have shown
+ * its error state. This read is a single grouped scan over at most a month of
+ * one organization's requests, so 20 s is generous headroom and still leaves
+ * the wire limit as the real ceiling.
+ */
+const METERED_READ_MAX_EXECUTION_SECONDS = 20;
+
+/** Statuses that were priced and charged: a failed request with partial usage
+ *  is billed for what it consumed, so it counts as spend. */
+const CHARGED_STATUSES = "('confirmed', 'failed')";
+
+/**
+ * One request collapsed to its surviving version, named apart from the columns
+ * it aggregates so no alias leaks into the WHERE. The window filter lives in
+ * the WHERE of this inner query; a request straddling the window boundary is
+ * counted once either way, which is acceptable at the edge.
+ */
+const LATEST_REQUEST_SUBQUERY = `
+  SELECT
+    GatewayRequestId,
+    argMax(Status, EventTimestamp)           AS RequestStatus,
+    argMax(CostNanoUSD, EventTimestamp)      AS RequestCostNanoUSD,
+    argMax(OccurredAt, EventTimestamp)       AS RequestOccurredAt,
+    argMax(Model, EventTimestamp)            AS RequestModel,
+    argMax(VirtualKeyId, EventTimestamp)     AS RequestVirtualKeyId,
+    argMax(TokensInput, EventTimestamp)      AS RequestTokensInput,
+    argMax(TokensOutput, EventTimestamp)     AS RequestTokensOutput,
+    argMax(TokensCacheRead, EventTimestamp)  AS RequestTokensCacheRead,
+    argMax(TokensCacheWrite, EventTimestamp) AS RequestTokensCacheWrite,
+    argMax(TokensReasoning, EventTimestamp)  AS RequestTokensReasoning
+  FROM ${TABLE}
+  WHERE TenantId IN {tenantIds:Array(String)}
+    AND OccurredAt >= fromUnixTimestamp64Milli({fromMs:Int64})
+    AND OccurredAt < fromUnixTimestamp64Milli({toMs:Int64})
+  GROUP BY TenantId, GatewayRequestId
+`;
+
+/**
+ * The metered total for a set of requests, expressed once and reused by every
+ * grouping.
+ *
+ * `AmountNanoUsd` sums only the charged requests. `RequestCount` is the charged
+ * requests. `RequestsWithoutAmount` is counted BESIDE the total, never inside
+ * it: a charged request that consumed tokens yet priced at zero (free or
+ * unpriced — the ledger cannot tell which), plus a settled request whose
+ * confirmation never arrived so its cost is unknown. Settled rows add nothing
+ * to the money sum.
+ */
+const METERED_FIGURE_COLUMNS = `
+          toString(sumIf(RequestCostNanoUSD, RequestStatus IN ${CHARGED_STATUSES})) AS AmountNanoUsd,
+          countIf(RequestStatus IN ${CHARGED_STATUSES}) AS RequestCount,
+          countIf(
+            RequestStatus IN ${CHARGED_STATUSES}
+            AND RequestCostNanoUSD = 0
+            AND (
+              RequestTokensInput + RequestTokensOutput + RequestTokensCacheRead
+              + RequestTokensCacheWrite + RequestTokensReasoning
+            ) > 0
+          ) + countIf(RequestStatus = 'settled') AS RequestsWithoutAmount`;
+
+/**
+ * The breakdowns rank by money, largest first. `AmountNanoUsd` is the
+ * `toString(...)` alias above, and ordering on it sorts as TEXT: "88986800"
+ * ranks above "7619357500". Cast back to the number for the sort; the sum of
+ * an Int64 column is Int64, so nothing is lost.
+ */
+const AMOUNT_DESC = "toInt64(AmountNanoUsd) DESC";
+
+/** ClickHouse renders a summed Int64 as a string in JSONEachRow; parse the
+ *  whole thing through BigInt so the one Number conversion never drops a low
+ *  digit on a wide money figure. */
+function nano(value: unknown): number {
+  return Number(BigInt(String(value ?? 0)));
+}
+
+function int(value: unknown): number {
+  return Number(value ?? 0);
+}
+
+export interface GovernanceGatewaySpendWindow {
+  /** Every project tenant of the viewer's organization. Empty resolves to
+   *  no query and no rows, never to an unfiltered read. */
+  tenantIds: string[];
+  /** Inclusive, `YYYY-MM-DD`. */
+  fromDay: string;
+  /** Inclusive, `YYYY-MM-DD`. */
+  toDay: string;
+}
+
+/** One UTC day of metered spend. */
+export interface GovernanceGatewaySpendDayRow {
+  /** `YYYY-MM-DD`, the day the requests STARTED in UTC. */
+  day: string;
+  /** Nano-USD summed over the day's charged requests. */
+  amountNanoUsd: number;
+  /** Charged (confirmed + failed) requests on the day. */
+  requestCount: number;
+  /** Requests carrying no dollar amount: zero-cost-with-tokens plus settled. */
+  requestsWithoutAmount: number;
+}
+
+/** One model's or one virtual key's window total. */
+export interface GovernanceGatewaySpendModelRow {
+  model: string;
+  amountNanoUsd: number;
+  requestCount: number;
+  requestsWithoutAmount: number;
+}
+
+export interface GovernanceGatewaySpendVirtualKeyRow {
+  virtualKeyId: string;
+  amountNanoUsd: number;
+  requestCount: number;
+  requestsWithoutAmount: number;
+}
+
+/** Midnight UTC of a `YYYY-MM-DD` day. */
+function dayStartMs(day: string): number {
+  return Date.parse(`${day}T00:00:00.000Z`);
+}
+
+export class GovernanceGatewaySpendClickHouseRepository {
+  constructor(
+    private readonly resolveClient: (
+      tenantId: string,
+    ) => Promise<ClickHouseClient>,
+  ) {}
+
+  /**
+   * Per-day metered spend across every project tenant of the organization.
+   *
+   * The day is `toDate(RequestOccurredAt, 'UTC')` — admission time, the day the
+   * caller asked — so a streamed answer running across midnight lands whole on
+   * the day it started rather than being split by the server's own timezone.
+   */
+  async sumDaysForOrganizationProjects(
+    input: GovernanceGatewaySpendWindow,
+  ): Promise<GovernanceGatewaySpendDayRow[]> {
+    if (input.tenantIds.length === 0) return [];
+    const rows = await this.run(input, {
+      dimension: "toDate(RequestOccurredAt, 'UTC') AS Day",
+      grouping: "Day",
+      ordering: "Day",
+    });
+    return rows.map((row) => ({
+      day: String(row.Day ?? ""),
+      amountNanoUsd: nano(row.AmountNanoUsd),
+      requestCount: int(row.RequestCount),
+      requestsWithoutAmount: int(row.RequestsWithoutAmount),
+    }));
+  }
+
+  /**
+   * The window's metered spend per model, exactly as the ledger named it.
+   *
+   * A breakdown reader today, not wired into the screen: ADR-128 reserves the
+   * metered breakdowns and this is the read they will use. Grouped on the model
+   * string verbatim — nothing is re-cut here.
+   */
+  async sumWindowByModel(
+    input: GovernanceGatewaySpendWindow,
+  ): Promise<GovernanceGatewaySpendModelRow[]> {
+    if (input.tenantIds.length === 0) return [];
+    const rows = await this.run(input, {
+      dimension: "RequestModel AS Model",
+      grouping: "RequestModel",
+      ordering: `${AMOUNT_DESC}, Model`,
+    });
+    return rows.map((row) => ({
+      model: String(row.Model ?? ""),
+      amountNanoUsd: nano(row.AmountNanoUsd),
+      requestCount: int(row.RequestCount),
+      requestsWithoutAmount: int(row.RequestsWithoutAmount),
+    }));
+  }
+
+  /** The window's metered spend per virtual key. Never by person. */
+  async sumWindowByVirtualKey(
+    input: GovernanceGatewaySpendWindow,
+  ): Promise<GovernanceGatewaySpendVirtualKeyRow[]> {
+    if (input.tenantIds.length === 0) return [];
+    const rows = await this.run(input, {
+      dimension: "RequestVirtualKeyId AS VirtualKeyId",
+      grouping: "RequestVirtualKeyId",
+      ordering: `${AMOUNT_DESC}, VirtualKeyId`,
+    });
+    return rows.map((row) => ({
+      virtualKeyId: String(row.VirtualKeyId ?? ""),
+      amountNanoUsd: nano(row.AmountNanoUsd),
+      requestCount: int(row.RequestCount),
+      requestsWithoutAmount: int(row.RequestsWithoutAmount),
+    }));
+  }
+
+  /**
+   * One grouped read over the deduped requests. The three public methods differ
+   * only in the dimension they group on; the dedup, the window fence, the
+   * figures and the deadline are one shape shared here so no two of them can
+   * disagree about what a metered figure is.
+   *
+   * The client is resolved by the FIRST tenant, matching every other multi-
+   * tenant read on this schema (`spendScope` orders projects so this is stable):
+   * one organization's projects route to the same ClickHouse.
+   */
+  private async run(
+    input: GovernanceGatewaySpendWindow,
+    {
+      dimension,
+      grouping,
+      ordering,
+    }: {
+      dimension: string;
+      grouping: string;
+      ordering: string;
+    },
+  ): Promise<Record<string, unknown>[]> {
+    const client = await this.resolveClient(input.tenantIds[0]!);
+    const result = await client.query({
+      query: `
+        SELECT
+          ${dimension},
+          ${METERED_FIGURE_COLUMNS}
+        FROM (${LATEST_REQUEST_SUBQUERY})
+        GROUP BY ${grouping}
+        ORDER BY ${ordering}
+      `,
+      query_params: {
+        tenantIds: input.tenantIds,
+        fromMs: dayStartMs(input.fromDay),
+        // Inclusive of the last day: midnight AFTER it, exclusive.
+        toMs: dayStartMs(input.toDay) + 86_400_000,
+      },
+      format: "JSONEachRow",
+      clickhouse_settings: {
+        max_execution_time: METERED_READ_MAX_EXECUTION_SECONDS,
+      },
+    });
+    return (await result.json()) as Record<string, unknown>[];
+  }
+}

--- a/platform/app/ee/governance/services/governanceGatewaySpend.clickhouse.repository.ts
+++ b/platform/app/ee/governance/services/governanceGatewaySpend.clickhouse.repository.ts
@@ -27,6 +27,15 @@
  * SELECT's WHERE, so `argMax(OccurredAt, EventTimestamp) AS OccurredAt` would
  * put an aggregate in the WHERE clause and the read would fail.
  *
+ * THE WINDOW IS APPLIED TO THE REQUEST, NOT TO ITS VERSIONS. For the same
+ * reason, the window cannot be a plain WHERE on the raw rows: if an older
+ * version's start time sits inside the window and the latest version moved it
+ * outside, a raw filter keeps the stale version alone and counts a request
+ * that has left the window, at a cost the ledger has since replaced. The raw
+ * rows are only PREFILTERED on `OccurredAt` — wide enough that every version
+ * of any request in the window survives to the collapse — and the window is
+ * decided in a HAVING on the collapsed `RequestOccurredAt`.
+ *
  * NO PERSON COLUMN is ever selected. The ledger sits outside erasure, so a
  * `PrincipalUserId` or `EndUserId` read from it would outlive a deletion the
  * rest of the product honoured. The lane groups by model and by virtual key
@@ -62,10 +71,29 @@ const METERED_READ_MAX_EXECUTION_SECONDS = 20;
 const CHARGED_STATUSES = "('confirmed', 'failed')";
 
 /**
+ * How far below the window's lower bound the raw prefilter reaches, so that a
+ * request's older version inside the window never survives the collapse
+ * without its latest version outside it.
+ *
+ * Only the lower bound needs widening. The upper bound is midnight after the
+ * last day of a frame that ends today, so no version lies beyond it. Below,
+ * a start time can only move by the request's own duration — the gap between
+ * its outcome being recorded and its admission arriving — which the gateway
+ * bounds far under a day. One day of slack therefore covers every version of
+ * every request the window can hold, and the partition key (the month the
+ * row started in) still prunes on it.
+ */
+const WINDOW_PREFILTER_SLACK_MS = 86_400_000;
+
+/**
  * One request collapsed to its surviving version, named apart from the columns
- * it aggregates so no alias leaks into the WHERE. The window filter lives in
- * the WHERE of this inner query; a request straddling the window boundary is
- * counted once either way, which is acceptable at the edge.
+ * it aggregates so no alias leaks into the WHERE.
+ *
+ * The WHERE only prefilters the raw rows, on `OccurredAt` widened below by
+ * `WINDOW_PREFILTER_SLACK_MS`, so partitions prune and every version of a
+ * request in the window reaches the collapse. The window itself is the
+ * HAVING on `RequestOccurredAt`: the start time the ledger currently holds
+ * for the request, not the one some older version of it carried.
  */
 const LATEST_REQUEST_SUBQUERY = `
   SELECT
@@ -82,9 +110,11 @@ const LATEST_REQUEST_SUBQUERY = `
     argMax(TokensReasoning, EventTimestamp)  AS RequestTokensReasoning
   FROM ${TABLE}
   WHERE TenantId IN {tenantIds:Array(String)}
-    AND OccurredAt >= fromUnixTimestamp64Milli({fromMs:Int64})
+    AND OccurredAt >= fromUnixTimestamp64Milli({prefilterFromMs:Int64})
     AND OccurredAt < fromUnixTimestamp64Milli({toMs:Int64})
   GROUP BY TenantId, GatewayRequestId
+  HAVING RequestOccurredAt >= fromUnixTimestamp64Milli({fromMs:Int64})
+    AND RequestOccurredAt < fromUnixTimestamp64Milli({toMs:Int64})
 `;
 
 /**
@@ -262,6 +292,7 @@ export class GovernanceGatewaySpendClickHouseRepository {
     },
   ): Promise<Record<string, unknown>[]> {
     const client = await this.resolveClient(input.tenantIds[0]!);
+    const fromMs = dayStartMs(input.fromDay);
     const result = await client.query({
       query: `
         SELECT
@@ -273,7 +304,10 @@ export class GovernanceGatewaySpendClickHouseRepository {
       `,
       query_params: {
         tenantIds: input.tenantIds,
-        fromMs: dayStartMs(input.fromDay),
+        fromMs,
+        // The raw-row prefilter reaches a day below the window; the window
+        // itself is decided on the collapsed request.
+        prefilterFromMs: fromMs - WINDOW_PREFILTER_SLACK_MS,
         // Inclusive of the last day: midnight AFTER it, exclusive.
         toMs: dayStartMs(input.toDay) + 86_400_000,
       },

--- a/platform/app/src/components/governance/CostLanePanel.tsx
+++ b/platform/app/src/components/governance/CostLanePanel.tsx
@@ -40,6 +40,7 @@ export function CostLanePanel({
   currenciesWithoutUsdAmount,
   currencyTotals,
   laneNote,
+  belowTotalNote,
   trendPct,
   sample = false,
   testId,
@@ -72,6 +73,15 @@ export function CostLanePanel({
    * copy about money, it shows what the read side decided to say.
    */
   laneNote?: string | null;
+  /**
+   * A note pinned UNDER THE TOTAL, on the face of the card — the metered
+   * lane's "N requests with no dollar amount". Distinct from `laneNote`, which
+   * lives behind the (i): this is a caveat on the figure beside it and a reader
+   * needs it in front of them, not on a hover. Shown only when the lane states
+   * a figure it does not withhold (`cellsWithoutAmount` is zero); a withheld
+   * lane's own note takes the slot.
+   */
+  belowTotalNote?: string | null;
   /**
    * Which way this lane is running, already measured. Measured by the caller
    * on the UNFOLDED series, not derived from anything drawn here: a calendar
@@ -179,6 +189,18 @@ export function CostLanePanel({
             data-testid={`${testId}-note`}
           >
             {laneWithheldTotalNote()}
+          </Text>
+        ) : belowTotalNote ? (
+          // A stated figure with a caveat beside it — the metered lane's count
+          // of requests carrying no dollar amount. Not a withheld total: the
+          // figure above it stands.
+          <Text
+            fontSize="xs"
+            color="fg.subtle"
+            marginTop="auto"
+            data-testid={`${testId}-note`}
+          >
+            {belowTotalNote}
           </Text>
         ) : null}
       </VStack>

--- a/platform/app/src/components/governance/costLaneFormat.ts
+++ b/platform/app/src/components/governance/costLaneFormat.ts
@@ -224,6 +224,24 @@ export function laneWithheldTotalNote(): string {
 }
 
 /**
+ * The metered lane's note: how many requests carry no dollar amount.
+ *
+ * DELIBERATELY BESIDE the total, not in place of it. Unlike the billed lane,
+ * the metered lane marks rather than withholds — the gateway priced every
+ * request it could and this counts the rest (free or unpriced, or settled with
+ * the cost never confirmed), so the total still stands and this rides under it.
+ * Null below one, so a lane with nothing left out says nothing. "request" is
+ * spelled out, singular at one.
+ */
+export function meteredRequestsWithoutAmountNote(
+  count: number | undefined,
+): string | null {
+  if (!count || count <= 0) return null;
+  const noun = count === 1 ? "request" : "requests";
+  return `${count} ${noun} with no dollar amount`;
+}
+
+/**
  * One currency total's digits, with the currency named rather than symbolised.
  *
  * The code, not a symbol: a symbol table is a thing that has to be exhaustive

--- a/platform/app/src/components/governance/costs/__tests__/costSampleMode.unit.test.ts
+++ b/platform/app/src/components/governance/costs/__tests__/costSampleMode.unit.test.ts
@@ -123,6 +123,29 @@ describe("reading the headline summary as a real-data read", () => {
     });
   });
 
+  describe("given a metered window of only requests with no dollar amount", () => {
+    /** @scenario "A window of only requests with no dollar amount still shows the metered lane" */
+    it("counts the request count as real data with no dollar figure and no unpriced cells", () => {
+      // The metered lane never marks a CELL as unpriced: it keeps its total
+      // and counts the requests with no amount beside it. A window of only
+      // settled or zero-priced requests therefore has a null dollar figure,
+      // no unpriced cell and no currency total — and a count of three. The
+      // lane reported; the screen must not say nothing was recorded.
+      const read = summaryAsRead(
+        summary({
+          gateway: {
+            amountUsd: null,
+            cellsWithoutAmount: 0,
+            currenciesWithoutUsdAmount: [],
+            currencyTotals: [],
+            requestsWithoutAmount: 3,
+          },
+        }),
+      );
+      expect(read?.length).toBeGreaterThan(0);
+    });
+  });
+
   describe("given every lane answered with nothing", () => {
     it("reads as measured and empty", () => {
       expect(summaryAsRead(summary())).toEqual({ length: 0 });

--- a/platform/app/src/components/governance/costs/costSampleMode.ts
+++ b/platform/app/src/components/governance/costs/costSampleMode.ts
@@ -1,5 +1,8 @@
 /** Classify real cost reads for their loading, empty and permission states. */
-import type { GovernanceCostSummaryDto } from "@ee/governance/services/governanceCost.service";
+import type {
+  GovernanceCostLaneDto,
+  GovernanceCostSummaryDto,
+} from "@ee/governance/services/governanceCost.service";
 
 /**
  * What the real-data check reads off the headline summary — derived from the
@@ -19,29 +22,41 @@ export function isRefusedRead(
   return code === "FORBIDDEN" || code === "UNAUTHORIZED";
 }
 
+/** What a lane must show before it counts as having reported. */
+type LaneForSampleDecision = Pick<
+  GovernanceCostLaneDto,
+  | "amountUsd"
+  | "cellsWithoutAmount"
+  | "currencyTotals"
+  | "requestsWithoutAmount"
+>;
+
 /**
- * Count lanes holding money, unpriced cells, a total in any currency, or
- * reported seats.
+ * Count lanes holding money, unpriced cells, a total in any currency, a count
+ * of requests with no dollar amount, or reported seats.
  *
  * A lane billed ONLY in a currency nobody converted has a null dollar figure
  * and no unpriced cell at all — every cell holds an amount, in euros — so the
  * first two tests both say "nothing". The currency totals are the third way a
  * lane reports, and the one this used to miss: a real euro bill read as no
  * bill, and the screen fell back to invented figures over the top of it.
+ *
+ * The request count is the fourth. The metered lane never marks a cell as
+ * unpriced — it keeps its total and counts the requests with no amount beside
+ * it — so a window of only settled or zero-priced requests arrives with a
+ * null dollar figure, no unpriced cell, no currency total, and a count. Read
+ * on the first three alone, three real requests became "nothing recorded".
  */
 export function summaryAsRead(
   data: SummaryForSampleDecision | undefined,
 ): { length: number } | null {
   if (data === undefined) return null;
   if (data.unavailableReason !== null) return { length: 0 };
-  const laneReported = (lane: {
-    amountUsd: number | null;
-    cellsWithoutAmount: number;
-    currencyTotals: readonly unknown[];
-  }) =>
+  const laneReported = (lane: LaneForSampleDecision) =>
     lane.amountUsd !== null ||
     lane.cellsWithoutAmount > 0 ||
-    lane.currencyTotals.length > 0;
+    lane.currencyTotals.length > 0 ||
+    (lane.requestsWithoutAmount ?? 0) > 0;
   const reported =
     (laneReported(data.billed) ? 1 : 0) +
     (laneReported(data.gateway) ? 1 : 0) +

--- a/platform/app/src/pages/governance/__tests__/costScreen.integration.test.tsx
+++ b/platform/app/src/pages/governance/__tests__/costScreen.integration.test.tsx
@@ -656,6 +656,47 @@ describe("the governance cost screen", () => {
     });
   });
 
+  describe("given a metered window of only requests with no dollar amount", () => {
+    /** @scenario "A window of only requests with no dollar amount still shows the metered lane" */
+    it("shows the metered lane with its count and does not say nothing was recorded", () => {
+      harness.query = {
+        data: summaryFixture({
+          billed: {
+            amountUsd: null,
+            cellsWithoutAmount: 0,
+            currenciesWithoutUsdAmount: [],
+            currencyTotals: [],
+          },
+          gateway: {
+            // Every request in the window settled or priced at zero: no money
+            // to total, no cell marked unpriced, and three requests counted.
+            amountUsd: null,
+            cellsWithoutAmount: 0,
+            currenciesWithoutUsdAmount: [],
+            currencyTotals: [],
+            requestsWithoutAmount: 3,
+          },
+          seats: { status: "awaiting_data" },
+          series: [],
+        }),
+        isLoading: false,
+        isError: false,
+      };
+      renderScreen();
+
+      // The count IS the lane's report. Reading it as "nothing recorded"
+      // hides three real requests behind the empty-organization alert.
+      expect(
+        screen.queryByTestId("cost-lanes-unavailable"),
+      ).not.toBeInTheDocument();
+      const gateway = screen.getByTestId("cost-lane-gateway");
+      expect(within(gateway).queryByText(/\$\d/)).not.toBeInTheDocument();
+      expect(
+        within(gateway).getByTestId("cost-lane-gateway-note"),
+      ).toHaveTextContent("3 requests with no dollar amount");
+    });
+  });
+
   describe("given a window billed in two currencies", () => {
     /** @scenario "A window billed in two currencies shows one total per currency" */
     it("shows one total per currency, combines neither, and applies no rate", () => {

--- a/platform/app/src/pages/governance/__tests__/costScreen.integration.test.tsx
+++ b/platform/app/src/pages/governance/__tests__/costScreen.integration.test.tsx
@@ -600,6 +600,62 @@ describe("the governance cost screen", () => {
     });
   });
 
+  describe("given the metered lane counts requests with no dollar amount", () => {
+    /** @scenario "Requests with no dollar amount are counted beside the metered total, not inside it" */
+    it("shows the priced total and, beside it, how many requests carry no dollar amount", () => {
+      harness.query = {
+        data: summaryFixture({
+          gateway: {
+            amountUsd: 67.89,
+            cellsWithoutAmount: 0,
+            currenciesWithoutUsdAmount: [],
+            currencyTotals: [
+              { currencyCode: "USD", amount: 67.89, cellsWithoutAmount: 0 },
+            ],
+            requestsWithoutAmount: 4,
+          },
+        }),
+        isLoading: false,
+        isError: false,
+      };
+      renderScreen();
+
+      const gateway = screen.getByTestId("cost-lane-gateway");
+      // The total still stands — the metered lane marks, it does not withhold.
+      expect(within(gateway).getByText("$67.89")).toBeInTheDocument();
+      // And the count is on the face of the card, not hidden behind the (i):
+      // a reader needs it in front of them.
+      expect(
+        within(gateway).getByTestId("cost-lane-gateway-note"),
+      ).toHaveTextContent("4 requests with no dollar amount");
+    });
+
+    it("says nothing when every metered request carries a dollar amount", () => {
+      harness.query = {
+        data: summaryFixture({
+          gateway: {
+            amountUsd: 67.89,
+            cellsWithoutAmount: 0,
+            currenciesWithoutUsdAmount: [],
+            currencyTotals: [
+              { currencyCode: "USD", amount: 67.89, cellsWithoutAmount: 0 },
+            ],
+            requestsWithoutAmount: 0,
+          },
+        }),
+        isLoading: false,
+        isError: false,
+      };
+      renderScreen();
+
+      expect(
+        within(screen.getByTestId("cost-lane-gateway")).queryByTestId(
+          "cost-lane-gateway-note",
+        ),
+      ).not.toBeInTheDocument();
+    });
+  });
+
   describe("given a window billed in two currencies", () => {
     /** @scenario "A window billed in two currencies shows one total per currency" */
     it("shows one total per currency, combines neither, and applies no rate", () => {

--- a/platform/app/src/pages/governance/costs.tsx
+++ b/platform/app/src/pages/governance/costs.tsx
@@ -33,6 +33,7 @@ import {
 import {
   azureBillingNoteSentence,
   laneTrendPct,
+  meteredRequestsWithoutAmountNote,
 } from "~/components/governance/costLaneFormat";
 import {
   CostDonut,
@@ -830,6 +831,9 @@ function CostLanes({
           cellsWithoutAmount={data.gateway.cellsWithoutAmount}
           currenciesWithoutUsdAmount={data.gateway.currenciesWithoutUsdAmount}
           currencyTotals={data.gateway.currencyTotals}
+          belowTotalNote={meteredRequestsWithoutAmountNote(
+            data.gateway.requestsWithoutAmount,
+          )}
           trendPct={trendPctOf((day) => day.gatewayUsd)}
           sample={sample}
         />

--- a/platform/app/src/server/app-layer/dependencies.ts
+++ b/platform/app/src/server/app-layer/dependencies.ts
@@ -17,6 +17,7 @@ import type { BillableEventsClickHouseRepository } from "../../../ee/billing/ser
 import type { WebhookService } from "../../../ee/billing/services/webhookService";
 import type { ActivityMonitorClickHouseRepository } from "../../../ee/governance/services/activity-monitor/activityMonitor.clickhouse.repository";
 import type { GovernanceCostRollupClickHouseRepository } from "../../../ee/governance/services/governanceCostRollup.clickhouse.repository";
+import type { GovernanceGatewaySpendClickHouseRepository } from "../../../ee/governance/services/governanceGatewaySpend.clickhouse.repository";
 import type { GovernanceKpisClickHouseRepository } from "../../../ee/governance/services/governanceKpis.clickhouse.repository";
 import type { GovernanceOcsfEventsClickHouseRepository } from "../../../ee/governance/services/governanceOcsfEvents.clickhouse.repository";
 import type { GovernanceTraceActivityClickHouseRepository } from "../../../ee/governance/services/governanceTraceActivity.clickhouse.repository";
@@ -72,6 +73,7 @@ import type { OrganizationService } from "./organizations/organization.service";
 import type { PermissionsService } from "./permissions/permissions.service";
 import type { PresenceService } from "./presence/presence.service";
 import type { ProjectService } from "./projects/project.service";
+import type { ProjectRepository } from "./projects/repositories/project.repository";
 import type { ShareService } from "./share/share.service";
 import type { SharedTracePayloadCache } from "./share/shared-trace-cache.service";
 import type { ResultAtomsService } from "./simulations/result-atoms/result-atoms.service";
@@ -298,6 +300,14 @@ export interface AppDependencies {
     /** ADR-128's daily cost rollup — the fold's write side and the read both
      *  the screen and the drift comparator go through. */
     costRollup: GovernanceCostRollupClickHouseRepository | undefined;
+    /** ADR-128's metered lane: the gateway's per-request billing ledger
+     *  (`gateway_spend`), read scoped to every project of the organization.
+     *  Undefined on a deployment without ClickHouse. */
+    gatewaySpend: GovernanceGatewaySpendClickHouseRepository | undefined;
+    /** The metered lane's tenant scope: every project of the organization,
+     *  archived ones included, since `gateway_spend.TenantId` is the traffic's
+     *  own project id. The same instance the ProjectService reads through. */
+    projects: ProjectRepository;
     /** ADR-128 §9: erasing a discovered person from the governance data —
      *  the suppression list, the account links, the person row and the
      *  money rows. Undefined on a deployment without ClickHouse, which has

--- a/platform/app/src/server/app-layer/presets.ts
+++ b/platform/app/src/server/app-layer/presets.ts
@@ -14,11 +14,9 @@ import { resolveSourceNonBillable } from "@ee/governance/services/costAttributio
 import {
   COST_ROLLUP_COMPARATOR_TARGET_TYPE,
   CostRollupComparatorService,
+  costRollupComparatorFireHandler,
 } from "@ee/governance/services/costRollupComparator.service";
-import {
-  costSourceFromTargetId,
-  reconcileCostRollupComparatorSchedules,
-} from "@ee/governance/services/costRollupComparatorSchedule";
+import { reconcileCostRollupComparatorSchedules } from "@ee/governance/services/costRollupComparatorSchedule";
 import { installGovernanceSuppressionSnapshot } from "@ee/governance/services/erasureSuppression.service";
 import { GovernanceCostRollupClickHouseRepository } from "@ee/governance/services/governanceCostRollup.clickhouse.repository";
 import { GovernanceGatewaySpendClickHouseRepository } from "@ee/governance/services/governanceGatewaySpend.clickhouse.repository";
@@ -1259,27 +1257,10 @@ export function initializeDefaultApp(options?: {
     );
     schedulerRegistry.register({
       targetType: COST_ROLLUP_COMPARATOR_TARGET_TYPE,
-      handler: async (fire) => {
-        const costSource = costSourceFromTargetId(fire.targetId);
-        if (!costSource) {
-          // A row naming a lane we do not have. Comparing the wrong lane would
-          // report drift between two things never meant to match, so say so
-          // and do nothing.
-          comparatorLogger.warn(
-            { targetId: fire.targetId, tenantId: fire.projectId },
-            "Cost rollup comparator fired for an unknown cost source; skipping",
-          );
-          return;
-        }
-        const sampled = new Date(fire.slot.getTime() - 86_400_000)
-          .toISOString()
-          .slice(0, 10);
-        await comparator.compareDay({
-          tenantId: fire.projectId,
-          day: sampled,
-          costSource,
-        });
-      },
+      handler: costRollupComparatorFireHandler({
+        comparator,
+        logger: comparatorLogger,
+      }),
     });
 
     // Registering the handler is only half of it: without calendar entries

--- a/platform/app/src/server/app-layer/presets.ts
+++ b/platform/app/src/server/app-layer/presets.ts
@@ -21,6 +21,7 @@ import {
 } from "@ee/governance/services/costRollupComparatorSchedule";
 import { installGovernanceSuppressionSnapshot } from "@ee/governance/services/erasureSuppression.service";
 import { GovernanceCostRollupClickHouseRepository } from "@ee/governance/services/governanceCostRollup.clickhouse.repository";
+import { GovernanceGatewaySpendClickHouseRepository } from "@ee/governance/services/governanceGatewaySpend.clickhouse.repository";
 import { GovernanceKpisClickHouseRepository } from "@ee/governance/services/governanceKpis.clickhouse.repository";
 import { GovernanceOcsfEventsClickHouseRepository } from "@ee/governance/services/governanceOcsfEvents.clickhouse.repository";
 import { GovernanceRollupErasureClickHouseRepository } from "@ee/governance/services/governanceRollupErasure.clickhouse.repository";
@@ -477,9 +478,12 @@ export function initializeDefaultApp(options?: {
   });
 
   const broadcast = new BroadcastService(redis);
+  // One instance, shared with the governance cost screen's metered-lane scope
+  // below, so both read projects through the same repository.
+  const projectRepository = new PrismaProjectRepository(prisma);
   const projects = traced(
     new ProjectService(
-      new PrismaProjectRepository(prisma),
+      projectRepository,
       new LwqlKeyMapClickHouseRepository(resolveClickHouseClient),
     ),
     "ProjectService",
@@ -1053,7 +1057,8 @@ export function initializeDefaultApp(options?: {
     : undefined;
 
   // ADR-128's daily cost rollup. One instance for the whole App: the fold
-  // writes through it on BOTH pipelines (gateway spend and pulled usage), the
+  // writes through it on the pulled-usage pipeline (the metered lane reads
+  // the gateway ledger directly and never reaches this table), the
   // comparator reads through it, and `app.governance.costRollup` hands out the
   // same reference — so the watchdog can never be reading a different table
   // from the one the product shows.
@@ -1062,6 +1067,13 @@ export function initializeDefaultApp(options?: {
     : undefined;
   const governanceCostRollupStore = governanceCostRollupRepository
     ? new GovernanceCostRollupStore(governanceCostRollupRepository)
+    : undefined;
+
+  // ADR-128's metered lane reads the gateway's own per-request ledger rather
+  // than the rollup, scoped to every project of the organization. One instance
+  // for the whole App, resolving its ClickHouse the same way the rollup does.
+  const governanceGatewaySpendRepository = clickhouseEnabled
+    ? new GovernanceGatewaySpendClickHouseRepository(resolveClickHouseClient)
     : undefined;
 
   // ADR-128 §9 step 5. The fold substitutes a pseudonym for an erased
@@ -2064,6 +2076,8 @@ export function initializeDefaultApp(options?: {
       personalUsage: personalUsageRepository,
       activityMonitor: activityMonitorRepository,
       costRollup: governanceCostRollupRepository,
+      gatewaySpend: governanceGatewaySpendRepository,
+      projects: projectRepository,
       identityErasure: governanceIdentityErasure,
       identityMatch: governanceIdentityMatch,
     },
@@ -2218,11 +2232,9 @@ export function createTestApp(overrides?: TestAppOverrides): App {
     } as unknown as PromptTagRepository),
     "OrganizationService",
   );
+  const nullProjectRepository = new NullProjectRepository();
   const nullProjects = traced(
-    new ProjectService(
-      new NullProjectRepository(),
-      new NullLwqlKeyMapRepository(),
-    ),
+    new ProjectService(nullProjectRepository, new NullLwqlKeyMapRepository()),
     "ProjectService",
   );
 
@@ -2437,6 +2449,8 @@ export function createTestApp(overrides?: TestAppOverrides): App {
       personalUsage: undefined,
       activityMonitor: undefined,
       costRollup: undefined,
+      gatewaySpend: undefined,
+      projects: nullProjectRepository,
       identityErasure: undefined,
       // Real rather than a double: it is Postgres-only, and a test that drives
       // the review surface wants the actual evidence rules, not a stub that

--- a/platform/app/src/server/app-layer/projects/__tests__/projectIdsByOrganization.integration.test.ts
+++ b/platform/app/src/server/app-layer/projects/__tests__/projectIdsByOrganization.integration.test.ts
@@ -110,10 +110,14 @@ describe("ProjectRepository.findAllIdsByOrganization", () => {
       // The organization's three, whatever their state or kind.
       const mine = seeded.slice(0, 3);
       expect(ids).toEqual([...mine].sort());
-      // Ordered by id ascending so downstream client routing by the first
-      // tenant is stable, the way `spendScope` orders them.
+      // Ordered by id ascending — this repository's own `orderBy`, not a
+      // property of the caller — so the metered lane's ledger read, which
+      // resolves its ClickHouse client by the FIRST id, routes one
+      // organization's reads to the same client every time.
       expect(ids).toEqual([...ids].sort());
-      // The other organization's project is not in reach at all.
+      // This is the tenancy boundary. The metered lane's ledger read takes
+      // these ids as its whole scope, so an id leaking across organizations
+      // here is a cross-organization money read there.
       expect(ids).not.toContain(seeded[3]);
     });
   });

--- a/platform/app/src/server/app-layer/projects/__tests__/projectIdsByOrganization.integration.test.ts
+++ b/platform/app/src/server/app-layer/projects/__tests__/projectIdsByOrganization.integration.test.ts
@@ -1,0 +1,137 @@
+/**
+ * @vitest-environment node
+ * @integration
+ *
+ * Every project id of an organization, against the real Postgres rows: the
+ * scope of the governance cost screen's metered lane, which reads the gateway
+ * ledger keyed by the traffic's own project tenant.
+ *
+ * INCLUDING archived projects and every kind. A project archived last month
+ * still has gateway spend inside a thirty-day window, and leaving it out would
+ * make the metered lane fall the day someone tidied the project list.
+ *
+ * @see specs/governance/governance-cost-screen.feature
+ *   ("The metered lane counts gateway spend from every project of the organization")
+ */
+import { nanoid } from "nanoid";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { prisma } from "~/server/db";
+import { cleanupTestRows } from "~/test-utils/cleanupTestRows";
+import { PrismaProjectRepository } from "../repositories/project.prisma.repository";
+
+const tag = nanoid(8);
+
+let organizationId: string;
+let otherOrganizationId: string;
+const seeded: string[] = [];
+
+const repository = new PrismaProjectRepository(prisma);
+
+async function seedOrganization(label: string): Promise<{
+  organizationId: string;
+  teamId: string;
+}> {
+  const organization = await prisma.organization.create({
+    data: { name: `ids-${label}-${tag}`, slug: `ids-${label}-${tag}` },
+  });
+  const team = await prisma.team.create({
+    data: {
+      name: `ids-${label}-${tag}`,
+      slug: `ids-${label}-${tag}`,
+      organizationId: organization.id,
+    },
+  });
+  return { organizationId: organization.id, teamId: team.id };
+}
+
+async function seedProject({
+  teamId,
+  label,
+  archivedAt = null,
+  kind,
+}: {
+  teamId: string;
+  label: string;
+  archivedAt?: Date | null;
+  kind?: string;
+}): Promise<string> {
+  const project = await prisma.project.create({
+    data: {
+      name: `ids-${label}-${tag}`,
+      slug: `ids-${label}-${tag}`,
+      apiKey: `ids-${label}-${tag}`,
+      teamId,
+      language: "typescript",
+      framework: "other",
+      archivedAt,
+      ...(kind ? { kind } : {}),
+    },
+  });
+  seeded.push(project.id);
+  return project.id;
+}
+
+beforeAll(async () => {
+  const mine = await seedOrganization("mine");
+  organizationId = mine.organizationId;
+  await seedProject({ teamId: mine.teamId, label: "live" });
+  await seedProject({
+    teamId: mine.teamId,
+    label: "archived",
+    archivedAt: new Date("2026-08-01T00:00:00.000Z"),
+  });
+  await seedProject({
+    teamId: mine.teamId,
+    label: "governance",
+    kind: "internal_governance",
+  });
+
+  const other = await seedOrganization("other");
+  otherOrganizationId = other.organizationId;
+  await seedProject({ teamId: other.teamId, label: "elsewhere" });
+});
+
+afterAll(async () => {
+  for (const orgId of [organizationId, otherOrganizationId]) {
+    if (!orgId) continue;
+    await cleanupTestRows(prisma, [
+      ["project", { team: { organizationId: orgId } }],
+      ["team", { organizationId: orgId }],
+      ["organization", { id: orgId }],
+    ]);
+  }
+});
+
+describe("ProjectRepository.findAllIdsByOrganization", () => {
+  describe("given live, archived and governance projects across two organizations", () => {
+    it("returns every project of the organization, archived and every kind, ordered by id, and none of another's", async () => {
+      const ids = await repository.findAllIdsByOrganization({ organizationId });
+
+      // The organization's three, whatever their state or kind.
+      const mine = seeded.slice(0, 3);
+      expect(ids).toEqual([...mine].sort());
+      // Ordered by id ascending so downstream client routing by the first
+      // tenant is stable, the way `spendScope` orders them.
+      expect(ids).toEqual([...ids].sort());
+      // The other organization's project is not in reach at all.
+      expect(ids).not.toContain(seeded[3]);
+    });
+  });
+
+  describe("given an organization with no projects", () => {
+    it("answers an empty list, never an unfiltered one", async () => {
+      const empty = await prisma.organization.create({
+        data: { name: `ids-empty-${tag}`, slug: `ids-empty-${tag}` },
+      });
+      try {
+        expect(
+          await repository.findAllIdsByOrganization({
+            organizationId: empty.id,
+          }),
+        ).toEqual([]);
+      } finally {
+        await prisma.organization.delete({ where: { id: empty.id } });
+      }
+    });
+  });
+});

--- a/platform/app/src/server/app-layer/projects/__tests__/projectIdsByOrganization.integration.test.ts
+++ b/platform/app/src/server/app-layer/projects/__tests__/projectIdsByOrganization.integration.test.ts
@@ -44,19 +44,29 @@ async function seedOrganization(label: string): Promise<{
   return { organizationId: organization.id, teamId: team.id };
 }
 
+/**
+ * Ids are given, not generated, and differ only in a final digit after a
+ * shared prefix. Postgres orders ids by the database's collation, where a
+ * punctuation-led nanoid ("_Cwh...") can sort before a digit-led one; the
+ * test's own sort compares code units and puts it last. With a single digit
+ * as the only difference, every collation and the code-unit sort agree.
+ */
 async function seedProject({
   teamId,
   label,
+  position,
   archivedAt = null,
   kind,
 }: {
   teamId: string;
   label: string;
+  position: number;
   archivedAt?: Date | null;
   kind?: string;
 }): Promise<string> {
   const project = await prisma.project.create({
     data: {
+      id: `ids-${tag}-${position}`,
       name: `ids-${label}-${tag}`,
       slug: `ids-${label}-${tag}`,
       apiKey: `ids-${label}-${tag}`,
@@ -74,21 +84,25 @@ async function seedProject({
 beforeAll(async () => {
   const mine = await seedOrganization("mine");
   organizationId = mine.organizationId;
-  await seedProject({ teamId: mine.teamId, label: "live" });
+  // Seeded OUT of id order, so a read that merely returned rows as they
+  // were inserted could not pass the ordering assertion.
+  await seedProject({ teamId: mine.teamId, label: "live", position: 2 });
   await seedProject({
     teamId: mine.teamId,
     label: "archived",
+    position: 1,
     archivedAt: new Date("2026-08-01T00:00:00.000Z"),
   });
   await seedProject({
     teamId: mine.teamId,
     label: "governance",
+    position: 3,
     kind: "internal_governance",
   });
 
   const other = await seedOrganization("other");
   otherOrganizationId = other.organizationId;
-  await seedProject({ teamId: other.teamId, label: "elsewhere" });
+  await seedProject({ teamId: other.teamId, label: "elsewhere", position: 4 });
 });
 
 afterAll(async () => {
@@ -107,14 +121,14 @@ describe("ProjectRepository.findAllIdsByOrganization", () => {
     it("returns every project of the organization, archived and every kind, ordered by id, and none of another's", async () => {
       const ids = await repository.findAllIdsByOrganization({ organizationId });
 
-      // The organization's three, whatever their state or kind.
+      // The organization's three, whatever their state or kind, ordered by
+      // id ascending — this repository's own `orderBy`, not a property of
+      // the caller — so the metered lane's ledger read, which resolves its
+      // ClickHouse client by the FIRST id, routes one organization's reads
+      // to the same client every time. Insertion order was 2, 1, 3.
       const mine = seeded.slice(0, 3);
       expect(ids).toEqual([...mine].sort());
-      // Ordered by id ascending — this repository's own `orderBy`, not a
-      // property of the caller — so the metered lane's ledger read, which
-      // resolves its ClickHouse client by the FIRST id, routes one
-      // organization's reads to the same client every time.
-      expect(ids).toEqual([...ids].sort());
+      expect(ids).not.toEqual(mine);
       // This is the tenancy boundary. The metered lane's ledger read takes
       // these ids as its whole scope, so an id leaking across organizations
       // here is a cross-organization money read there.

--- a/platform/app/src/server/app-layer/projects/repositories/project.prisma.repository.ts
+++ b/platform/app/src/server/app-layer/projects/repositories/project.prisma.repository.ts
@@ -253,6 +253,20 @@ export class PrismaProjectRepository implements ProjectRepository {
     return { data, pagination: { page, limit, total } };
   }
 
+  async findAllIdsByOrganization({
+    organizationId,
+  }: {
+    organizationId: string;
+  }): Promise<string[]> {
+    // No `archivedAt` or `kind` filter on purpose — see the interface doc.
+    const projects = await this.prisma.project.findMany({
+      where: { team: { organizationId } },
+      select: { id: true },
+      orderBy: { id: "asc" },
+    });
+    return projects.map((project) => project.id);
+  }
+
   async findBySlugInTeam({
     slug,
     teamId,

--- a/platform/app/src/server/app-layer/projects/repositories/project.repository.ts
+++ b/platform/app/src/server/app-layer/projects/repositories/project.repository.ts
@@ -145,6 +145,15 @@ export interface ProjectRepository {
      */
     projectIds?: string[];
   }): Promise<PaginatedResult<Project>>;
+  /**
+   * Every project id of the organization, ordered by id ascending: archived
+   * ones and every kind INCLUDED. This is the tenant scope for reads keyed by
+   * the traffic's own project (the gateway spend ledger), where a project
+   * archived last month still has spend inside the window.
+   */
+  findAllIdsByOrganization(params: {
+    organizationId: string;
+  }): Promise<string[]>;
   findBySlugInTeam(params: {
     slug: string;
     teamId: string;
@@ -235,6 +244,12 @@ export class NullProjectRepository implements ProjectRepository {
     projectIds?: string[];
   }): Promise<PaginatedResult<Project>> {
     return { data: [], pagination: { page: 1, limit: 50, total: 0 } };
+  }
+
+  async findAllIdsByOrganization(_params: {
+    organizationId: string;
+  }): Promise<string[]> {
+    return [];
   }
 
   async findBySlugInTeam(_params: {

--- a/platform/app/src/server/event-sourcing/pipelineRegistry.ts
+++ b/platform/app/src/server/event-sourcing/pipelineRegistry.ts
@@ -1102,7 +1102,6 @@ export class PipelineRegistry {
         // committed events through its transactional inbox.
         webhookDelivery: this.deps.webhookDelivery,
         gatewayDebits: this.deps.gatewayDebits,
-        costRollupStore: this.deps.governanceCostRollupStore,
         settlement: {
           // Lazy: the pipeline is being built by this very call, so the
           // sweeper resolves the command sender at execution time.

--- a/platform/app/src/server/event-sourcing/pipelines/gateway-spend-processing/pipeline.ts
+++ b/platform/app/src/server/event-sourcing/pipelines/gateway-spend-processing/pipeline.ts
@@ -3,11 +3,6 @@ import {
   type GatewayDebitsProcessDeps,
   gatewayDebitsPM,
 } from "@ee/governance/process-manager/gatewayDebits.process";
-import { GOVERNANCE_COST_ROLLUP_PROJECTION_NAME } from "@ee/governance/projections/governanceCostRollup.constants";
-import {
-  GovernanceCostRollupFoldProjection,
-  type GovernanceCostRollupState,
-} from "@ee/governance/projections/governanceCostRollup.foldProjection";
 import {
   WEBHOOK_DELIVERY_PROCESS_NAME,
   type WebhookDeliveryProcessDeps,
@@ -47,9 +42,6 @@ export interface GatewaySpendProcessingPipelineDeps {
   /** The M2 settlement sweeper: settles admissions whose confirmation
    *  never arrived inside the grace window. */
   settlement?: SpendSettlementProcessDeps;
-  /** ADR-128's daily cost rollup, the gateway half. Absent without the
-   *  ClickHouse rollup table (the per-request ledger is unaffected). */
-  costRollupStore?: FoldProjectionStore<GovernanceCostRollupState>;
 }
 
 /**
@@ -87,15 +79,10 @@ export function createGatewaySpendProcessingPipeline(
     .withCommand("confirmSpend", ConfirmSpendCommand)
     .withCommand("failSpend", FailSpendCommand)
     .withCommand("settleSpend", SettleSpendCommand);
-  // The daily cost rollup's gateway half (ADR-128). Optional for the same
-  // reason the debits process manager is: a deployment without the rollup
-  // table still records every request, it just does not summarize it.
-  if (deps.costRollupStore) {
-    pipeline = pipeline.withFoldProjection(
-      GOVERNANCE_COST_ROLLUP_PROJECTION_NAME,
-      new GovernanceCostRollupFoldProjection({ store: deps.costRollupStore }),
-    );
-  }
+  // No daily cost rollup here, on purpose. The governance cost screen reads
+  // the metered lane straight off `gateway_spend` (the per-request ledger this
+  // pipeline projects), so a rollup half for it summarized cells nothing ever
+  // read. The rollup fold stays on the pulled-usage pipeline alone.
   if (deps.webhookDelivery) {
     pipeline = pipeline.withProcessManager(
       WEBHOOK_DELIVERY_PROCESS_NAME,

--- a/platform/app/src/test-utils/clickhouseTestApp.ts
+++ b/platform/app/src/test-utils/clickhouseTestApp.ts
@@ -2,6 +2,7 @@ import type { ClickHouseClient } from "@clickhouse/client";
 import { BillableEventsClickHouseRepository } from "@ee/billing/services/billableEvents.clickhouse.repository";
 import { ActivityMonitorClickHouseRepository } from "@ee/governance/services/activity-monitor/activityMonitor.clickhouse.repository";
 import { GovernanceCostRollupClickHouseRepository } from "@ee/governance/services/governanceCostRollup.clickhouse.repository";
+import { GovernanceGatewaySpendClickHouseRepository } from "@ee/governance/services/governanceGatewaySpend.clickhouse.repository";
 import { GovernanceKpisClickHouseRepository } from "@ee/governance/services/governanceKpis.clickhouse.repository";
 import { GovernanceOcsfEventsClickHouseRepository } from "@ee/governance/services/governanceOcsfEvents.clickhouse.repository";
 import { GovernanceTraceActivityClickHouseRepository } from "@ee/governance/services/governanceTraceActivity.clickhouse.repository";
@@ -11,6 +12,7 @@ import { WebhookEventsClickHouseRepository } from "@ee/webhooks/webhookEvents.cl
 import type { RedisConnection } from "@langwatch/redis-client";
 import { globalForApp, resetApp } from "~/server/app-layer/app";
 import { createTestApp } from "~/server/app-layer/presets";
+import { PrismaProjectRepository } from "~/server/app-layer/projects/repositories/project.prisma.repository";
 import type { ClickHouseClientResolver } from "~/server/clickhouse/clickhouseClient";
 import { prisma } from "~/server/db";
 
@@ -108,6 +110,10 @@ export function installClickHouseTestApp({
       personalUsage: new PersonalUsageClickHouseRepository(required),
       activityMonitor: new ActivityMonitorClickHouseRepository(required),
       costRollup: new GovernanceCostRollupClickHouseRepository(required),
+      gatewaySpend: new GovernanceGatewaySpendClickHouseRepository(required),
+      // Real: the metered lane scopes the ledger read by the organization's
+      // project ids, which a route test seeds in the same Postgres.
+      projects: new PrismaProjectRepository(prisma),
       // The erasure needs Postgres repositories and the ops replay service,
       // neither of which this ClickHouse-only harness composes. A suite that
       // drives an erasure builds it directly.

--- a/specs/governance/governance-cost-rollup.feature
+++ b/specs/governance/governance-cost-rollup.feature
@@ -135,6 +135,27 @@ Feature: Daily cost rollup that can always be rebuilt and never lies
     Then the drift metric counts the mismatch
     And the mismatch details are in the log
 
+  # The comparator checks the billed lane alone. It once checked the
+  # gateway lane too, and the scheduled rows it created for that half are
+  # still in the database; they are marked inactive at start and a start
+  # never recreates them. A row that fires anyway, racing that boot step,
+  # settles as delivered so the scheduler does not retry the slot.
+
+  @integration
+  Scenario: The nightly rollup check covers the billed lane alone
+    Given a scheduled check of the metered lane left over from before
+    When the app starts
+    Then that scheduled check is marked inactive
+    And a later start leaves it inactive
+    And the billed lane's check stays active
+
+  @integration
+  Scenario: A leftover metered check that fires anyway settles quietly
+    Given a scheduled check of the metered lane that fires after all
+    When it runs
+    Then it completes without an error
+    And that slot is not retried
+
   @unit
   Scenario: The summary's lag behind the event log is measured
     Given events newer than the latest summarized moment

--- a/specs/governance/governance-cost-screen.feature
+++ b/specs/governance/governance-cost-screen.feature
@@ -541,6 +541,15 @@ Feature: One cost screen, three honest lanes
     And beside it says how many requests carry no dollar amount
 
   @integration
+  Scenario: A window of only requests with no dollar amount still shows the metered lane
+    Given a window whose every gateway request carries no dollar amount
+    And nothing billed and no seats reported
+    When a permitted viewer opens the cost screen
+    Then the metered lane is shown with no dollar figure
+    And beside it says how many requests carry no dollar amount
+    And the screen does not say nothing was recorded
+
+  @integration
   Scenario: A failed gateway ledger read never renders the metered lane as zero
     # The ledger read failing while the rollup read succeeds still rejects
     # the whole summary, per the rule at the top of the service.

--- a/specs/governance/governance-cost-screen.feature
+++ b/specs/governance/governance-cost-screen.feature
@@ -454,8 +454,110 @@ Feature: One cost screen, three honest lanes
     # must assert the two fixture values differ before asserting placement.
     # "Never summed into one figure" is a universal negative no test can
     # prove; ADR-128 assigns it to the code-review gate in wave 1.
-    # "Matches its own source" end to end is a datastore-lane concern
-    # covered by the rollup spec, not this component test.
+    # "Matches its own source" end to end is a datastore-lane concern:
+    # the billed lane's is covered by the rollup spec, the metered lane's
+    # by the ledger scenarios in the section directly below.
+
+  # =========================================================================
+  # THE METERED LANE READS THE GATEWAY'S OWN LEDGER.
+  #
+  # The metered lane used to read the same daily rollup the billed lane
+  # reads. A fold wrote the gateway's cells there under the tenant of the
+  # project whose traffic it was, while the screen read them under the
+  # hidden governance project's tenant, so for real traffic the lane was
+  # always empty and only fixtures ever filled it. Two writers on one table
+  # is what made that possible, so the fold is gone rather than repaired:
+  # the lane reads the gateway's per-request ledger directly, the rows the
+  # fold already wrote stay where they are and no read counts them, and
+  # every read of the rollup asks for pulled rows only. The nightly check
+  # that compared the rollup against its sources checks the billed lane
+  # alone now, and what happens to the gateway half's leftover scheduled
+  # rows is specified beside the comparator in governance-cost-rollup.feature.
+  #
+  # A request is the unit. The ledger keeps one row per gateway request,
+  # partitioned by the month it started in, and the same request can sit
+  # in two months when its outcome landed before its admission and the
+  # admission moved the start time. A sum that trusts the table to have
+  # merged those rows counts that request twice. The day a request belongs
+  # to is the day it STARTED, in UTC: a streamed answer running across
+  # midnight is one request, on the day the caller asked.
+  #
+  # A failed request that consumed tokens is still priced, so it counts.
+  # The lane groups by model and by virtual key only: the ledger sits
+  # outside erasure, so a person's identifier read from it would outlive
+  # a deletion the rest of the product honoured.
+  #
+  # Requests with no dollar amount are counted beside the total rather
+  # than blanking it, unlike the billed lane's rule further down. There a
+  # cell with no amount hides an unknown share of a bill; here the count
+  # beside the figure names exactly what is left out — marked, not
+  # withheld, the same choice the provider breakdown makes for a euro
+  # bill. The ledger cannot tell a request nobody priced from a free one,
+  # so both are "no dollar amount", and a request that settled with its
+  # cost never confirmed is counted among them rather than left out.
+  # =========================================================================
+
+  @integration
+  Scenario: The metered lane counts gateway spend from every project of the organization
+    Given gateway requests recorded under two projects of the viewer's organization
+    And gateway requests recorded under a project of another organization
+    When a permitted viewer opens the cost screen
+    Then the metered lane total is the sum of both of the organization's projects
+    And the other organization's requests contribute nothing
+
+  @integration
+  Scenario: A failed request that consumed tokens still counts as metered spend
+    Given a confirmed gateway request and a failed one priced for the tokens it consumed
+    When the metered lane is read
+    Then both requests' amounts are in the metered total
+
+  @integration
+  Scenario: A request written into two months is counted once
+    Given a gateway request whose outcome was recorded before its admission
+    And the admission moved its start time into the previous month
+    When the metered lane is read
+    Then that request's amount is in the total exactly once
+
+  @integration
+  Scenario: A stream crossing midnight belongs to the day it started
+    Given a gateway request admitted ten minutes before midnight UTC whose answer finished after it
+    When the metered day series is read
+    Then the whole amount is on the day the request started
+    And nothing is on the day it finished
+
+  @integration
+  Scenario: Metered spend is grouped by model and by virtual key, never by person
+    Given gateway requests from two virtual keys against two models
+    When the metered breakdowns are read
+    Then each model's requests total under that model
+    And each key's requests total under that key
+    And the metered read offers model and virtual key as its only groupings
+
+  @integration
+  Scenario: Requests with no dollar amount are counted beside the metered total, not inside it
+    Given priced gateway requests, requests that consumed tokens but carry no dollar amount, and a request whose cost was never confirmed
+    When a permitted viewer opens the cost screen
+    Then the metered lane shows the total of the priced requests
+    And beside it says how many requests carry no dollar amount
+
+  @integration
+  Scenario: A failed gateway ledger read never renders the metered lane as zero
+    # The ledger read failing while the rollup read succeeds still rejects
+    # the whole summary, per the rule at the top of the service.
+    Given the gateway ledger read fails despite gateway spend existing
+    When a permitted viewer opens the cost screen
+    Then the cost screen shows its error state
+    And no lane displays a zero amount
+
+  @integration
+  Scenario: Gateway rows left in the rollup are counted nowhere
+    Given gateway rows the retired fold wrote into the rollup
+    And pulled rows for the same days
+    When the billed total, the provider, model and spender breakdowns and the day series are read
+    Then every figure counts the pulled rows only
+
+  # The nightly rollup check and its leftover gateway rows are specified in
+  # governance-cost-rollup.feature, beside the comparator.
 
   # =========================================================================
   # A LANE CARD ANSWERS ONE QUESTION AND RAISES ANOTHER. The money cards
@@ -693,8 +795,10 @@ Feature: One cost screen, three honest lanes
     # screen says how much was left out. A lane we cannot total is a lane
     # with no total, and the screen would rather say nothing than
     # understate what an organization spent. The per-currency lines shown
-    # beside it follow the same rule, one currency at a time.
-    Given one lane has spend we hold no dollar figure for
+    # beside it follow the same rule, one currency at a time. The billed
+    # lane only: the metered lane marks instead of withholding, see the
+    # ledger section above.
+    Given the billed lane has spend we hold no dollar figure for
     And that same lane also has spend stated in US dollars
     When the cost screen reads that window
     Then that lane holds no dollar total
@@ -1159,10 +1263,10 @@ Feature: One cost screen, three honest lanes
     # one person read as two. A spender discovery has not seen is shown as
     # the id itself, which is all anybody knows.
     #
-    # The breakdown reads the PULLED lane only. The gateway lane writes actor
-    # ids into the same table under a different provider vocabulary; letting
-    # them in would both mislabel and cross-sum the lanes the screen keeps
-    # apart.
+    # The breakdown reads the PULLED lane only. The gateway lane used to
+    # write actor ids into the same table under a different provider
+    # vocabulary; those rows were never deleted, so letting them in would
+    # both mislabel and cross-sum the lanes the screen keeps apart.
 
     @unit
     Scenario: Pulled spend is grouped by who spent it
@@ -1172,10 +1276,11 @@ Feature: One cost screen, three honest lanes
 
     @unit
     Scenario: Gateway rows never enter the spender breakdown
-      # The rollup holds both lanes. An unfiltered read would satisfy every
-      # other scenario here while quietly summing gateway money into a
-      # spender's pulled total — the cross-lane sum this screen exists to
-      # refuse.
+      # The rollup holds the pulled lane plus the gateway rows an earlier
+      # fold left behind, which nobody counts. An unfiltered read would
+      # satisfy every other scenario here while quietly summing that
+      # leftover gateway money into a spender's pulled total — the
+      # cross-lane sum this screen exists to refuse.
       Given pulled cost and gateway cost recorded for the same day
       When the spender breakdown is read
       Then only the pulled rows are counted
@@ -1335,9 +1440,10 @@ Feature: One cost screen, three honest lanes
     # figures a reader may need apart.
     #
     # The breakdown reads the PULLED lane only, for the reason the spender
-    # breakdown does: the gateway lane writes a different provider vocabulary
-    # into the same table, and an unfiltered read would cross-sum the two
-    # lanes this screen keeps apart.
+    # breakdown does: the gateway lane used to write a different provider
+    # vocabulary into the same table, its leftover rows are still there,
+    # and an unfiltered read would cross-sum the two lanes this screen
+    # keeps apart.
 
     @unit
     Scenario: Pulled spend is grouped by the model the provider named


### PR DESCRIPTION
Closes langwatch/langwatch-saas#1228. Follow-on to #8067. ADR-128.

## For humans

The governance cost screen has two money lanes side by side: what the provider billed, and what the gateway metered. The metered lane has shown zero for every real organization since it shipped. Only test fixtures ever filled it.

The gateway was writing its daily totals into the same summary table the billed lane uses, but filed under the project whose traffic it was. The screen read that table under a hidden bookkeeping project instead. The rows landed in one drawer and the screen opened another. A nightly check that was supposed to catch drift in that lane compared empty against empty and passed every night.

This change stops the gateway from writing into the shared summary table at all. The metered lane now reads the gateway's own per-request ledger directly, across every project of the organization. The billed lane is untouched. The two lanes are still never added together. The nightly check now covers the billed lane alone, and the leftover gateway checks are switched off at app start. Requests the gateway could not put a dollar amount on are counted next to the total instead of being hidden or shown as free.

Who is affected: any organization on the governance cost screen that sends traffic through the gateway. They see real metered spend for the first time. Nobody loses anything; the old summary rows stay in the database and no read counts them.

## Why

The metered lane read the daily rollup under the governance project's tenant. The gateway pipeline's fold wrote gateway cells to that rollup under the trace project's tenant. Nothing ever landed where the screen looked. Two writers on one table made that possible, so the gateway writer is removed rather than repaired. Full trace in the issue.

## What changed

Three blocks, one PR, no migration, no new route, no new event.

**A. Clean up.** The rollup fold is no longer registered on the gateway spend pipeline and the store is no longer passed to it. The fold's two gateway handlers, the gateway branch of its cell addressing and its six gateway state fields are deleted; addressing an undeclared event type now throws. The store no longer derives gateway figures by subtraction. The comparator's compared-sources list is pulled-only; its gateway half is a retired source. At app start, active scheduled rows for the gateway check are switched off and never recreated. A retired row that fires anyway is skipped by the existing unknown-source branch of the handler and settles as delivered.

**B. Reroute.** A new repository reads `gateway_spend` for a set of tenant ids: one row per request via an inner `argMax` over `(TenantId, GatewayRequestId)`, confirmed and failed statuses charged, day is the request's start day in UTC, own execution limit of 20 seconds under the 30-second wire limit. Three reads: per day, by model, by virtual key. No person column is ever selected. The cost service resolves the organization's project ids through the project repository, reads the ledger in the same `Promise.all` as the rollup, and builds the metered lane from it. The rollup's day-by-lane read now takes a cost source and the service passes pulled; every other rollup read was already pulled-only. The lane DTO gains an optional `requestsWithoutAmount` count, and the lane card shows "N requests with no dollar amount" under the total.

**C. Prove it.** Eleven new scenarios, all bound (see test plan). The spec's billed-lane withholding rule is narrowed to the billed lane, and four stale comments about "the rollup holds both lanes" now say the gateway rows are leftovers nobody counts.

## How it works

The ledger is partitioned by month and the same request can sit in two partitions when its outcome landed before its admission moved the start time. A plain `FINAL` sum counts that request twice, so the reader dedupes per request first and sums after. The window is applied to the collapsed request, not to its versions: the only time predicate on the read is a `HAVING` on the start time the ledger currently holds for the request. No raw-row time filter at all, because an admission that lands after its outcome moves the start time back by a gap nothing bounds, and any prefilter would drop that newer version and count the stale one. The table's sort key leads with the tenant, so the read stays pruned to the organization's own rows; it scans that organization's whole ledger history rather than the window's months. Production cross-check over the largest organization's last 365 days: the new read and a plain `FINAL` sum differ by one request, the one live at that moment; cross-month duplicates found: zero.

The ledger cannot tell a request nobody priced from a free one, so both are "no dollar amount". A request that settled with its cost never confirmed is counted among them. The metered figure stands when at least one request was priced, or when requests were charged and none lacks an amount; otherwise the day and the window read null, not $0, and the screen shows the lane with a dash and the count beside it. A screen-level error, not a zero lane, when the ledger read fails.

Grouping by principal or end user is deliberately absent: the ledger sits outside erasure, so a person's identifier read from it would outlive a deletion the rest of the product honoured. Model and virtual key only, until erasure covers the ledger.

Deviation from the issue's wording: "unpriced" became "requests with no dollar amount" for the reason above, and confirmed-only became confirmed-plus-failed because a failed request that consumed tokens is still priced.

## Test plan

Every scenario failed before its code landed. Samples, verbatim:

Block A, fold unit, before the handlers were removed:

```
AssertionError: expected [ 'gateway.spend.confirmed', … ] to deeply equal [ 'governance.cost.pulled.…' ]
AssertionError: expected [Function] to throw an error
 Tests  3 failed | 40 passed (43)
```

Block A, schedule integration, before retirement:

```
AssertionError: expected true to be false   // leftover :gateway entry still active
AssertionError: expected 2 to be 1          // fresh tenant got a gateway entry
 Tests  6 failed | 31 passed (37)
```

Block B, service unit, before the lane switched source:

```
AssertionError: expected undefined to be 7
 Tests  8 failed | 38 passed (46)
```

Block B, by-model ranking, before the numeric sort:

```
AssertionError: expected 'ORDER BY AmountNanoUsd DESC' not to contain …
 Tests  1 failed | 24 passed (25)
```

After, on the quiet tree:

| Check | Result |
|---|---|
| `npx tsc --noEmit --project ./tsconfig.tsgo.all.json` | 0 errors |
| Biome new-violations gate vs `origin/main` | 0 new (3350 base, 3350 head) |
| `check:feature-parity` | all bound |
| Unit suite, whole app | 2567 files, 36653 passed, 0 failed |
| Integration, `ee/governance` + gateway pipeline + `src/server/gateway` + project repository, after round one | 86 files, 764 passed, 1 skipped |
| Integration, `ee/governance` + project repository, after round two | 56 files, 482 passed, 1 skipped |
| Component, cost screen | 26 passed |

New tests: `governanceGatewaySpend.repository.unit.test.ts` (26), `governanceGatewaySpend.integration.test.ts` (10, real ClickHouse), `projectIdsByOrganization.integration.test.ts` (2, real Postgres). Rewritten: fold unit and integration, restatement unit, erasure-substitution unit, comparator service and schedule integration, cost service unit, cost screen component, sample-mode classifier unit.

## Review round

A self-review pass with a convention scan and an independent refuter found no P0 or P1. Two P2 were fixed, one commit each, both red before the fix. The screen's "did any lane report" rule did not know about the new request count, so a window of only requests with no dollar amount showed the empty-organization alert over real requests; the refuter reproduced it at unit and screen level, and the count is now the fourth way a lane reports, with a new scenario bound at both levels. The ledger reader had its own money parser without the shared helper's safe-integer guard; it now uses the guarded helper, which throws past 2^53 instead of rounding. Two comments in the reader that described the wrong window size and the wrong ordering source were reworded. Three P3 notes stay in the review comment.

CodeRabbit then posted four findings, all real, all fixed one commit each. The window predicate ran on raw version rows before the per-request collapse, so a request whose latest version moved its start time out of the window could still be counted from a stale version; the window is now decided on the collapsed request, with regressions both ways. The null-figure decision counted zero-priced requests as evidence of a figure, so a day of only unpriced requests rendered $0.00; a separate priced-request count now drives the decision. The scenario for a leftover gateway check that fires anyway was bound to a lookup test rather than the handler; the handler moved out of the app preset into an exported factory and the test drives it. A test comment that restated its assertion now says why the boundary matters. Running that last file also surfaced a real flake in the previous round's project-ids ordering assertion, which compared code units against the database's collation; the seeds now use explicit ids that every collation orders the same way. A third pass pointed out that the one-day slack on the raw-row prefilter was an assumption nothing in the fold enforces; the prefilter is gone and the window is the read's only time predicate.

Production, read-only, largest organization, 365 days: per-day read 0.15 s wall, 128,628 rows scanned. Metered total matched the ledger sum to the one request in flight.

## Anything surprising?

- The by-model and by-key ranking sorted money as text on the first cut because the amount column is a string alias. Caught on the production check, fixed with a numeric cast in the `ORDER BY`, and pinned by a test that reproduces the text order.
- The cost service called Prisma directly for the organization's projects in the first cut. Moved into the project repository per the route → service → repository → Prisma rule. Same rule is still broken by the pre-existing governance-project resolver in `govProject.ts`; not touched here.
- The ledger read no longer uses the table's month partition key. It is pruned by the tenant-led sort key instead and scans the organization's full history on every screen load. Measured at 0.15 s on the largest production organization over 365 days, which today is that organization's full history; worth re-timing once the ledger is a few years deep.
- The boot log's `deactivated` count now includes retired gateway checks. A separate field would need a log change in the app preset; left as is.
- Erasure does not yet cover `gateway_spend`. Deferred, tracked separately. This is why the metered lane has no per-person grouping.
- The by-model and by-virtual-key reads exist and are tested but no screen calls them yet.
- Rows written before this change with cost source gateway stay in the rollup. No read counts them; a test proves it. No cleanup ships here.
- ADR-128 gains revision v3.16 in this PR: the one-line summary is marked, the write-path diagram shows one registration, the read-path diagram gains the ledger as the metered lane's store. The team's architecture notes were updated alongside.

## Deployment Impact

No environment variable, helm value, migration, schema, route, event or job is added, removed or changed. A vanilla `helm install` behaves exactly as today except for the two runtime changes below.

On first boot with the new image, the app marks every active scheduled gateway comparator row inactive. This is a reversible data write on the `ScheduledJob` table; rolling back the image leaves the rows inactive, and the old image would recreate them on its next boot. The gateway spend pipeline stops writing to the rollup table the moment the new image is running.

The metered lane's read hits `gateway_spend` once per screen load, per organization, with its own 20-second cap. Measured on the largest production organization at 0.15 seconds.

BYOC dataplane: unaffected. Safe to roll back.
