### PR TITLE
fix(voice): put cloudflared on PATH for the SDK tunnel and surface tunnel failures in the run error

### DIFF
--- a/platform/app/src/server/scenarios/execution/child-environment.ts
+++ b/platform/app/src/server/scenarios/execution/child-environment.ts
@@ -21,6 +21,7 @@ import {
   NLP_FETCH_MAX_TIMEOUT_ENV,
   NLPGO_ENGINE_CODE_BLOCK_TIMEOUT_SECONDS_ENV,
 } from "../../nlpgo/timeouts";
+import { VOICE_PUBLIC_BASE_URL_UNAVAILABLE_REASON_ENV } from "../voice/voice-public-url-env";
 import {
   encodeScenarioLogContext,
   SCENARIO_LOG_CONTEXT_ENV,
@@ -176,6 +177,12 @@ export function buildChildEnvironment({
     ...(jobData.target.type === "voice"
       ? {
           VOICE_PUBLIC_BASE_URL: process.env.VOICE_PUBLIC_BASE_URL,
+          // Why the worker has no public URL (its cloudflared tunnel mint
+          // failed), forwarded so the child's phone-run error can name the real
+          // cause instead of a generic "no public media URL". Filtered out when
+          // unset by `buildChildProcessEnv`.
+          [VOICE_PUBLIC_BASE_URL_UNAVAILABLE_REASON_ENV]:
+            process.env[VOICE_PUBLIC_BASE_URL_UNAVAILABLE_REASON_ENV],
           BASE_HOST: env.BASE_HOST,
         }
       : {}),

--- a/platform/app/src/server/scenarios/voice/__tests__/voice-cloudflared-binary.unit.test.ts
+++ b/platform/app/src/server/scenarios/voice/__tests__/voice-cloudflared-binary.unit.test.ts
@@ -1,0 +1,146 @@
+/**
+ * @vitest-environment node
+ * @see specs/features/agents/voice-phone.feature
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import {
+  type CloudflaredModule,
+  ensureCloudflaredOnPath,
+  VoiceTunnelBinaryError,
+} from "../voice-cloudflared-binary";
+
+const BIN = "/pkg/cloudflared/bin/cloudflared";
+const BIN_DIR = "/pkg/cloudflared/bin";
+
+/** A cloudflared module fake with a spyable installer. */
+function fakeModule(
+  install: CloudflaredModule["install"] = vi.fn(async () => BIN),
+): CloudflaredModule {
+  return { bin: BIN, install };
+}
+
+describe("ensureCloudflaredOnPath", () => {
+  describe("given cloudflared is already on PATH", () => {
+    describe("when the binary is ensured", () => {
+      /** @scenario "cloudflared already on PATH is used as-is" */
+      it("short-circuits without resolving or installing anything", async () => {
+        const resolveModule = vi.fn(() => fakeModule());
+        const env: NodeJS.ProcessEnv = { PATH: "/usr/bin" };
+
+        await ensureCloudflaredOnPath({
+          isOnPath: () => true,
+          resolveModule,
+          env,
+        });
+
+        expect(resolveModule).not.toHaveBeenCalled();
+        expect(env.PATH).toBe("/usr/bin");
+      });
+    });
+  });
+
+  describe("given cloudflared is not on PATH but its binary is present on disk", () => {
+    describe("when the binary is ensured", () => {
+      /** @scenario "A present cloudflared binary is put on PATH without downloading" */
+      it("prepends the binary's directory to PATH and never downloads", async () => {
+        const install = vi.fn(async () => BIN);
+        const env: NodeJS.ProcessEnv = { PATH: "/usr/bin" };
+
+        await ensureCloudflaredOnPath({
+          isOnPath: () => false,
+          resolveModule: () => fakeModule(install),
+          binaryExists: () => true,
+          env,
+        });
+
+        expect(install).not.toHaveBeenCalled();
+        expect(env.PATH).toBe(`${BIN_DIR}:/usr/bin`);
+      });
+    });
+  });
+
+  describe("given cloudflared is not on PATH and its binary is missing", () => {
+    describe("when the binary is ensured", () => {
+      /** @scenario "A missing cloudflared binary is downloaded then put on PATH" */
+      it("downloads the binary, then prepends its directory to PATH", async () => {
+        const install = vi.fn(async () => BIN);
+        // Missing before install, present after.
+        const binaryExists = vi
+          .fn<(binPath: string) => boolean>()
+          .mockReturnValueOnce(false)
+          .mockReturnValueOnce(true);
+        const env: NodeJS.ProcessEnv = { PATH: "/usr/bin" };
+
+        await ensureCloudflaredOnPath({
+          isOnPath: () => false,
+          resolveModule: () => fakeModule(install),
+          binaryExists,
+          env,
+        });
+
+        expect(install).toHaveBeenCalledWith(BIN);
+        expect(env.PATH).toBe(`${BIN_DIR}:/usr/bin`);
+      });
+    });
+
+    describe("when the download fails", () => {
+      /** @scenario "A cloudflared download failure surfaces as a tunnel binary error" */
+      it("throws a tunnel binary error carrying the underlying cause", async () => {
+        const install = vi.fn(async () => {
+          throw new Error("spawn cloudflared ENOENT");
+        });
+        const env: NodeJS.ProcessEnv = { PATH: "/usr/bin" };
+
+        const run = ensureCloudflaredOnPath({
+          isOnPath: () => false,
+          resolveModule: () => fakeModule(install),
+          binaryExists: () => false,
+          env,
+        });
+
+        await expect(run).rejects.toBeInstanceOf(VoiceTunnelBinaryError);
+        await expect(run).rejects.toThrow(/spawn cloudflared ENOENT/);
+        // PATH is left untouched on failure.
+        expect(env.PATH).toBe("/usr/bin");
+      });
+    });
+
+    describe("when the download hangs past the timeout", () => {
+      /** @scenario "A cloudflared download that hangs is abandoned" */
+      it("abandons the download and throws a tunnel binary error", async () => {
+        // Never resolves — only the timeout can end it.
+        const install = vi.fn(() => new Promise<string>(() => {}));
+
+        await expect(
+          ensureCloudflaredOnPath({
+            isOnPath: () => false,
+            resolveModule: () => fakeModule(install),
+            binaryExists: () => false,
+            installTimeoutMs: 10,
+            env: { PATH: "/usr/bin" },
+          }),
+        ).rejects.toThrow(/timed out after 10ms/);
+      });
+    });
+  });
+
+  describe("given the cloudflared package cannot be resolved", () => {
+    describe("when the binary is ensured", () => {
+      /** @scenario "An unresolvable cloudflared package surfaces as a tunnel binary error" */
+      it("throws a tunnel binary error naming the resolution failure", async () => {
+        const resolveModule = vi.fn(() => {
+          throw new Error("Cannot find module 'cloudflared'");
+        });
+
+        await expect(
+          ensureCloudflaredOnPath({
+            isOnPath: () => false,
+            resolveModule,
+            env: { PATH: "/usr/bin" },
+          }),
+        ).rejects.toThrow(/could not resolve the cloudflared package/);
+      });
+    });
+  });
+});

--- a/platform/app/src/server/scenarios/voice/__tests__/voice-cloudflared-binary.unit.test.ts
+++ b/platform/app/src/server/scenarios/voice/__tests__/voice-cloudflared-binary.unit.test.ts
@@ -6,7 +6,9 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   type CloudflaredModule,
+  type CloudflaredScope,
   ensureCloudflaredOnPath,
+  resolveCloudflaredFromScopes,
   VoiceTunnelBinaryError,
 } from "../voice-cloudflared-binary";
 
@@ -18,6 +20,28 @@ function fakeModule(
   install: CloudflaredModule["install"] = vi.fn(async () => BIN),
 ): CloudflaredModule {
   return { bin: BIN, install };
+}
+
+/**
+ * A fake `require` for one scope: `resolves` says whether it can resolve
+ * `cloudflared/package.json`, and loading `cloudflared` returns `mod`.
+ */
+function fakeScopeRequire(opts: {
+  resolves: boolean;
+  mod?: Partial<CloudflaredModule>;
+}): NodeRequire {
+  const req = ((specifier: string): unknown => {
+    if (specifier === "cloudflared") return opts.mod;
+    throw new Error(`unexpected require(${specifier})`);
+  }) as unknown as NodeRequire;
+  req.resolve = ((specifier: string): string => {
+    if (specifier === "cloudflared/package.json") {
+      if (opts.resolves) return "/pkg/cloudflared/package.json";
+      throw new Error("Cannot find module 'cloudflared/package.json'");
+    }
+    throw new Error(`unexpected resolve(${specifier})`);
+  }) as NodeRequire["resolve"];
+  return req;
 }
 
 describe("ensureCloudflaredOnPath", () => {
@@ -126,6 +150,73 @@ describe("ensureCloudflaredOnPath", () => {
   });
 
   describe("given the cloudflared package cannot be resolved", () => {
+    describe("when the langwatch SDK scope resolves it", () => {
+      /** @scenario "cloudflared resolves through the langwatch SDK scope first" */
+      it("returns the module from the langwatch scope without trying later scopes", () => {
+        const langwatchMod = fakeModule();
+        const scopes: CloudflaredScope[] = [
+          {
+            name: "langwatch",
+            require: fakeScopeRequire({ resolves: true, mod: langwatchMod }),
+          },
+          {
+            name: "@langwatch/scenario",
+            require: fakeScopeRequire({ resolves: true, mod: fakeModule() }),
+          },
+          {
+            name: "app scope",
+            require: fakeScopeRequire({ resolves: true, mod: fakeModule() }),
+          },
+        ];
+
+        const scenarioResolve = vi.spyOn(scopes[1]!.require!, "resolve");
+
+        const mod = resolveCloudflaredFromScopes(scopes);
+
+        expect(mod.bin).toBe(BIN);
+        expect(mod.install).toBe(langwatchMod.install);
+        expect(scenarioResolve).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("when the langwatch scope fails but the scenario scope resolves it", () => {
+      /** @scenario "cloudflared falls back to the scenario scope when the langwatch scope fails" */
+      it("returns the module from the scenario scope", () => {
+        const scenarioMod = fakeModule();
+        const scopes: CloudflaredScope[] = [
+          // Anchor unresolved: this scope is skipped entirely.
+          { name: "langwatch", require: null },
+          {
+            name: "@langwatch/scenario",
+            require: fakeScopeRequire({ resolves: true, mod: scenarioMod }),
+          },
+          { name: "app scope", require: fakeScopeRequire({ resolves: false }) },
+        ];
+
+        const mod = resolveCloudflaredFromScopes(scopes);
+
+        expect(mod.install).toBe(scenarioMod.install);
+      });
+    });
+
+    describe("when no scope can resolve it", () => {
+      /** @scenario "cloudflared unresolvable from every scope names all tried scopes" */
+      it("throws naming all three tried scopes", () => {
+        const scopes: CloudflaredScope[] = [
+          { name: "langwatch", require: null },
+          {
+            name: "@langwatch/scenario",
+            require: fakeScopeRequire({ resolves: false }),
+          },
+          { name: "app scope", require: fakeScopeRequire({ resolves: false }) },
+        ];
+
+        expect(() => resolveCloudflaredFromScopes(scopes)).toThrow(
+          /could not resolve the cloudflared package from any of: langwatch, @langwatch\/scenario, app scope/,
+        );
+      });
+    });
+
     describe("when the binary is ensured", () => {
       /** @scenario "An unresolvable cloudflared package surfaces as a tunnel binary error" */
       it("throws a tunnel binary error naming the resolution failure", async () => {

--- a/platform/app/src/server/scenarios/voice/__tests__/voice-public-url-tunnel.unit.test.ts
+++ b/platform/app/src/server/scenarios/voice/__tests__/voice-public-url-tunnel.unit.test.ts
@@ -109,6 +109,7 @@ describe("openVoicePublicUrlTunnel", () => {
       port: 3300,
       openTunnel,
       resolveHost,
+      ensureBinaryOnPath: async () => {},
       ...FAST,
     });
 
@@ -118,6 +119,53 @@ describe("openVoicePublicUrlTunnel", () => {
       provider: "cloudflared",
     });
     expect(close).not.toHaveBeenCalled();
+  });
+
+  /** @scenario "A voice worker puts cloudflared on PATH before opening its quick tunnel" */
+  it("puts the cloudflared binary on PATH before opening the tunnel", async () => {
+    const events: string[] = [];
+    const ensureBinaryOnPath = vi.fn(async () => {
+      events.push("ensure");
+    });
+    const openTunnel = vi.fn(async () => {
+      events.push("open");
+      return {
+        url: "https://ready.trycloudflare.com",
+        provider: "cloudflared" as const,
+        close: vi.fn().mockResolvedValue(undefined),
+      };
+    });
+    const resolveHost = vi.fn().mockResolvedValue(true);
+
+    await openVoicePublicUrlTunnel({
+      port: 3300,
+      openTunnel,
+      resolveHost,
+      ensureBinaryOnPath,
+      ...FAST,
+    });
+
+    // The binary must be on PATH before the SDK's bare `spawn("cloudflared")`.
+    expect(events).toEqual(["ensure", "open"]);
+  });
+
+  /** @scenario "A voice worker's tunnel fails to open when the cloudflared binary is unavailable" */
+  it("never opens the tunnel when putting the binary on PATH fails", async () => {
+    const openTunnel = vi.fn();
+    const ensureBinaryOnPath = vi.fn(async () => {
+      throw new Error("cloudflared tunnel binary unavailable: spawn ENOENT");
+    });
+
+    await expect(
+      openVoicePublicUrlTunnel({
+        port: 3300,
+        openTunnel,
+        resolveHost: vi.fn().mockResolvedValue(true),
+        ensureBinaryOnPath,
+        ...FAST,
+      }),
+    ).rejects.toThrow(/cloudflared tunnel binary unavailable/);
+    expect(openTunnel).not.toHaveBeenCalled();
   });
 
   /** @scenario "A voice worker's public URL tunnel fails fast when it never becomes reachable" */
@@ -135,6 +183,7 @@ describe("openVoicePublicUrlTunnel", () => {
         port: 3300,
         openTunnel,
         resolveHost,
+        ensureBinaryOnPath: async () => {},
         ...FAST,
       }),
     ).rejects.toThrow(VoiceTunnelNotReadyError);
@@ -155,6 +204,7 @@ describe("openVoicePublicUrlTunnel", () => {
       port: 3300,
       openTunnel,
       resolveHost,
+      ensureBinaryOnPath: async () => {},
       ...FAST,
     });
     await tunnel.close();

--- a/platform/app/src/server/scenarios/voice/transports/__tests__/phone.transport.unit.test.ts
+++ b/platform/app/src/server/scenarios/voice/transports/__tests__/phone.transport.unit.test.ts
@@ -20,6 +20,7 @@ import {
   type TwilioAdapterLike,
   type TwilioAgentFactory,
   VoicePhoneTransportUnavailableError,
+  VoicePublicBaseUrlMissingError,
 } from "../phone.transport";
 
 const twilioAgentMock = vi.hoisted(() => vi.fn());
@@ -565,8 +566,11 @@ describe("phoneTransport", () => {
     });
 
     describe("when VOICE_PUBLIC_BASE_URL is unset", () => {
-      /** @scenario "VOICE_PUBLIC_BASE_URL is optional and falls back to the app's public base host" */
-      it("falls back to the app's own base host", () => {
+      // The resolver HELPER still reports BASE_HOST (and its source), which is
+      // how the phone transport detects and then refuses it — see the
+      // "no public media URL" fail-fast block below. This asserts the helper's
+      // reporting behavior, not that a real call is allowed to use it.
+      it("still reports the app's own base host from the resolver helper", () => {
         expect(
           resolvePublicBaseUrl({ BASE_HOST: "https://app.example.com" }),
         ).toBe("https://app.example.com");
@@ -642,6 +646,59 @@ describe("phoneTransport", () => {
     });
   });
 
+  describe("given a phone target but no public media URL the worker answers", () => {
+    describe("when only the app's BASE_HOST is set", () => {
+      /** @scenario "A phone run fails fast when only the app's base host is available" */
+      it("refuses to build the adapter, naming VOICE_PUBLIC_BASE_URL and the cloudflared remedy, and never dials", () => {
+        const adapter = fakeAdapter();
+        const { transport, factoryOptions } = buildTransport({
+          adapter,
+          processEnv: { BASE_HOST: "https://app.langwatch.ai" },
+        });
+
+        let thrown: unknown;
+        try {
+          transport.createAgentAdapter({
+            agentId: TARGET,
+            credential: TWILIO_CREDENTIAL,
+            maxCallSeconds: 120,
+          });
+        } catch (error) {
+          thrown = error;
+        }
+
+        expect(thrown).toBeInstanceOf(VoicePublicBaseUrlMissingError);
+        expect((thrown as Error).message).toContain("VOICE_PUBLIC_BASE_URL");
+        expect((thrown as Error).message).toContain("cloudflared");
+        // The adapter was never built, so the SDK factory never ran and no dial
+        // could have gone out against the app's own host.
+        expect(factoryOptions).toHaveLength(0);
+        expect(adapter.placeCallArgs).toHaveLength(0);
+      });
+    });
+
+    describe("when neither VOICE_PUBLIC_BASE_URL nor BASE_HOST is set", () => {
+      /** @scenario "A phone run fails fast when no public base URL is available at all" */
+      it("refuses to build the adapter rather than dialling a URL nothing answers", () => {
+        const adapter = fakeAdapter();
+        const { transport, factoryOptions } = buildTransport({
+          adapter,
+          processEnv: {},
+        });
+
+        expect(() =>
+          transport.createAgentAdapter({
+            agentId: TARGET,
+            credential: TWILIO_CREDENTIAL,
+            maxCallSeconds: 120,
+          }),
+        ).toThrow(VoicePublicBaseUrlMissingError);
+        expect(factoryOptions).toHaveLength(0);
+        expect(adapter.placeCallArgs).toHaveLength(0);
+      });
+    });
+  });
+
   describe("given the child's SDK adapter http port", () => {
     describe("when the phone transport builds the SDK adapter", () => {
       /** @scenario "A phone call's scenario child never binds the worker's media port" */
@@ -675,6 +732,7 @@ describe("phoneTransport", () => {
         twilioAgentMock.mockReturnValue(sdkAdapter);
 
         const transport = createPhoneTransport({
+          processEnv: { VOICE_PUBLIC_BASE_URL: "https://voice.example.com" },
           registerNonce: autoAckRegisterNonce,
           raceUpgradeRefusal: identityRaceUpgradeRefusal,
         });
@@ -698,6 +756,7 @@ describe("phoneTransport", () => {
         twilioAgentMock.mockReturnValue(sdkAdapter);
 
         const transport = createPhoneTransport({
+          processEnv: { VOICE_PUBLIC_BASE_URL: "https://voice.example.com" },
           registerNonce: autoAckRegisterNonce,
           raceUpgradeRefusal: identityRaceUpgradeRefusal,
         });
@@ -724,6 +783,7 @@ describe("phoneTransport", () => {
         twilioAgentMock.mockReturnValue(sdkAdapter);
 
         const transport = createPhoneTransport({
+          processEnv: { VOICE_PUBLIC_BASE_URL: "https://voice.example.com" },
           registerNonce: autoAckRegisterNonce,
           raceUpgradeRefusal: identityRaceUpgradeRefusal,
         });
@@ -757,6 +817,7 @@ describe("phoneTransport", () => {
         twilioAgentMock.mockReturnValue(sdkAdapter);
 
         const transport = createPhoneTransport({
+          processEnv: { VOICE_PUBLIC_BASE_URL: "https://voice.example.com" },
           registerNonce: autoAckRegisterNonce,
           raceUpgradeRefusal: identityRaceUpgradeRefusal,
         });

--- a/platform/app/src/server/scenarios/voice/transports/__tests__/phone.transport.unit.test.ts
+++ b/platform/app/src/server/scenarios/voice/transports/__tests__/phone.transport.unit.test.ts
@@ -5,6 +5,7 @@
 import type { Socket } from "node:net";
 import { AgentRole } from "@langwatch/scenario";
 import { describe, expect, it, vi } from "vitest";
+import { VOICE_PUBLIC_BASE_URL_UNAVAILABLE_REASON_ENV } from "../../voice-public-url-env";
 import type {
   ReceivedVoiceSocket,
   VoiceSocketReceiver,
@@ -695,6 +696,37 @@ describe("phoneTransport", () => {
         ).toThrow(VoicePublicBaseUrlMissingError);
         expect(factoryOptions).toHaveLength(0);
         expect(adapter.placeCallArgs).toHaveLength(0);
+      });
+    });
+
+    describe("when the worker recorded why its tunnel mint failed", () => {
+      /** @scenario "A phone run's missing-URL error names the worker's tunnel failure reason" */
+      it("names that reason in the run's error instead of a generic message", () => {
+        const adapter = fakeAdapter();
+        const { transport } = buildTransport({
+          adapter,
+          processEnv: {
+            [VOICE_PUBLIC_BASE_URL_UNAVAILABLE_REASON_ENV]:
+              "cloudflared tunnel binary unavailable: spawn cloudflared ENOENT",
+          },
+        });
+
+        let thrown: unknown;
+        try {
+          transport.createAgentAdapter({
+            agentId: TARGET,
+            credential: TWILIO_CREDENTIAL,
+            maxCallSeconds: 120,
+          });
+        } catch (error) {
+          thrown = error;
+        }
+
+        expect(thrown).toBeInstanceOf(VoicePublicBaseUrlMissingError);
+        // The specific cause the worker recorded flows into the run error.
+        expect((thrown as Error).message).toContain("spawn cloudflared ENOENT");
+        // The base guidance is still present.
+        expect((thrown as Error).message).toContain("VOICE_PUBLIC_BASE_URL");
       });
     });
   });

--- a/platform/app/src/server/scenarios/voice/transports/phone.transport.ts
+++ b/platform/app/src/server/scenarios/voice/transports/phone.transport.ts
@@ -536,7 +536,12 @@ function buildPhoneAgentAdapter(
           reason && reason.length > 0 ? reason : undefined,
         );
       }
-      span.setAttribute("voice.twilio.stream_base_url", resolvedBaseUrl.value);
+      // Record only the URL origin in telemetry and logs — never the full
+      // resolved URL, which may carry credentials or query parameters (CWE-532
+      // sensitive-data exposure). The functional value handed to Twilio below
+      // stays complete.
+      const streamBaseUrlOrigin = new URL(resolvedBaseUrl.value).origin;
+      span.setAttribute("voice.twilio.stream_base_url", streamBaseUrlOrigin);
       span.setAttribute(
         "voice.twilio.stream_base_url_source",
         resolvedBaseUrl.source,
@@ -547,7 +552,7 @@ function buildPhoneAgentAdapter(
       logger.info(
         {
           agentId,
-          streamBaseUrl: resolvedBaseUrl.value,
+          streamBaseUrl: streamBaseUrlOrigin,
           streamBaseUrlSource: resolvedBaseUrl.source,
         },
         "resolved Twilio media-stream base URL for outbound call",

--- a/platform/app/src/server/scenarios/voice/transports/phone.transport.ts
+++ b/platform/app/src/server/scenarios/voice/transports/phone.transport.ts
@@ -31,6 +31,7 @@ import {
   raceAgainstUpgradeRefusal,
   requestNonceRegistration,
 } from "../voice-nonce-handoff";
+import { VOICE_PUBLIC_BASE_URL_UNAVAILABLE_REASON_ENV } from "../voice-public-url-env";
 import {
   createVoiceSocketReceiver,
   type VoiceSocketReceiver,
@@ -235,14 +236,20 @@ export class VoicePublicBaseUrlInvalidError extends Error {
  * matching {@link VoicePublicBaseUrlInvalidError} directly above.
  */
 export class VoicePublicBaseUrlMissingError extends Error {
-  constructor(source: PublicBaseUrlSource | "none") {
+  constructor(source: PublicBaseUrlSource | "none", reason?: string) {
+    // When the worker recorded WHY it minted no tunnel (its cloudflared tunnel
+    // boot failed), name that real cause — otherwise the run error is a generic
+    // "no public media URL" that hides a "spawn cloudflared ENOENT" behind it.
+    const reasonSuffix = reason
+      ? ` The worker's public URL tunnel failed to open: ${reason}`
+      : "";
     super(
       `No public media URL for the outbound phone call (VOICE_PUBLIC_BASE_URL ` +
         `unset, resolved source: ${source}). The app's BASE_HOST runs no voice ` +
         `media listener, so Twilio would dial a URL nothing answers and the ` +
         `call would fail with error 31920 after a 120s timeout. Set ` +
         `VOICE_PUBLIC_BASE_URL, or ensure cloudflared is installed so the ` +
-        `worker can mint a tunnel at boot.`,
+        `worker can mint a tunnel at boot.${reasonSuffix}`,
     );
     this.name = "VoicePublicBaseUrlMissingError";
   }
@@ -514,11 +521,20 @@ function buildPhoneAgentAdapter(
       // rather than dial into a 120s timeout.
       if (!resolvedBaseUrl || resolvedBaseUrl.source === "BASE_HOST") {
         const source = resolvedBaseUrl?.source ?? "none";
+        // The worker threads WHY its tunnel mint failed through this env var
+        // (set at boot, forwarded by child-environment.ts), read from the same
+        // env the base URL was resolved from so a test's injected env is honored.
+        const reason = (deps.processEnv ?? process.env)[
+          VOICE_PUBLIC_BASE_URL_UNAVAILABLE_REASON_ENV
+        ]?.trim();
         logger.error(
-          { agentId, streamBaseUrlSource: source },
+          { agentId, streamBaseUrlSource: source, reason },
           "no voice public base URL for outbound call; refusing to dial",
         );
-        throw new VoicePublicBaseUrlMissingError(source);
+        throw new VoicePublicBaseUrlMissingError(
+          source,
+          reason && reason.length > 0 ? reason : undefined,
+        );
       }
       span.setAttribute("voice.twilio.stream_base_url", resolvedBaseUrl.value);
       span.setAttribute(

--- a/platform/app/src/server/scenarios/voice/transports/phone.transport.ts
+++ b/platform/app/src/server/scenarios/voice/transports/phone.transport.ts
@@ -26,6 +26,7 @@ import { HandledError } from "@langwatch/handled-error";
 import { createLogger } from "@langwatch/observability";
 import type { AgentAdapter } from "@langwatch/scenario";
 import { AgentRole, voice as scenarioVoice } from "@langwatch/scenario";
+import { getLangWatchTracer } from "langwatch";
 import {
   raceAgainstUpgradeRefusal,
   requestNonceRegistration,
@@ -40,6 +41,14 @@ import type {
 } from "../voice-transport.registry";
 
 const logger = createLogger("langwatch:scenarios:voice:phone");
+
+/**
+ * Traces the outbound-adapter build so a public-URL failure lands on the run's
+ * OWN trace as a recorded exception + ERROR span, not just a Twilio 120s
+ * timeout with nothing attached. `withActiveSpan` records the throw and marks
+ * the span ERROR automatically, the same pattern the code-agent adapter uses.
+ */
+const tracer = getLangWatchTracer("langwatch.scenarios.voice.phone");
 
 /**
  * Shown when a phone target's project has no Twilio credentials. Surfaced by
@@ -202,6 +211,40 @@ export class VoicePublicBaseUrlInvalidError extends Error {
         "as an invalid stream URL and the call fails with error 11100.",
     );
     this.name = "VoicePublicBaseUrlInvalidError";
+  }
+}
+
+/**
+ * Thrown when a phone run is about to dial but there is no public media URL the
+ * WORKER's own listener answers: `VOICE_PUBLIC_BASE_URL` is unset (the worker
+ * minted no quick tunnel — most often because the `cloudflared` binary is
+ * missing, so the mint failed with ENOENT at worker boot) and the only value
+ * left is the app's own `BASE_HOST`, which runs no voice media listener.
+ *
+ * Dialling `BASE_HOST` is the exact production failure this guards: Twilio
+ * opens the media stream against `app.langwatch.ai`, the handshake never
+ * completes, and the call dies with Twilio error 31920 after a 120-second
+ * timeout with no trace attached. Failing HERE — at adapter-build time, on the
+ * run's own trace — turns that silent timeout into an immediate, actionable
+ * run error naming the remedy.
+ *
+ * A plain {@link Error}, not a {@link HandledError}: the remedy is an OPERATOR
+ * action (set the env var, ship the binary), not one the customer can take, so
+ * per ADR-045 it degrades to a generic "unknown" plus a trace id at the API
+ * boundary rather than promising the caller an action they do not have —
+ * matching {@link VoicePublicBaseUrlInvalidError} directly above.
+ */
+export class VoicePublicBaseUrlMissingError extends Error {
+  constructor(source: PublicBaseUrlSource | "none") {
+    super(
+      `No public media URL for the outbound phone call (VOICE_PUBLIC_BASE_URL ` +
+        `unset, resolved source: ${source}). The app's BASE_HOST runs no voice ` +
+        `media listener, so Twilio would dial a URL nothing answers and the ` +
+        `call would fail with error 31920 after a 120s timeout. Set ` +
+        `VOICE_PUBLIC_BASE_URL, or ensure cloudflared is installed so the ` +
+        `worker can mint a tunnel at boot.`,
+    );
+    this.name = "VoicePublicBaseUrlMissingError";
   }
 }
 
@@ -422,6 +465,123 @@ function withOutboundDial(
   return adapter;
 }
 
+/** The resolved (defaults applied) dependencies the adapter build reads. */
+interface ResolvedPhoneDeps {
+  twilioAgentFactory: TwilioAgentFactory;
+  processEnv: NodeJS.ProcessEnv | undefined;
+  registerNonce: NonceRegistrar;
+  mintNonce: () => string;
+  raceUpgradeRefusal: <T>(promise: Promise<T>) => Promise<T>;
+  socketReceiver: VoiceSocketReceiver;
+}
+
+/**
+ * Build one outbound SDK adapter for a phone call, wrapped in a span so a
+ * missing public media URL is recorded as an ERROR span + exception on the
+ * run's OWN trace, instead of only ever surfacing as Twilio's 120s
+ * media-stream timeout (error 31920) with nothing attached. `withActiveSpan`
+ * records the throw and marks the span ERROR automatically.
+ *
+ * Extracted from {@link createPhoneTransport} so that factory stays a thin
+ * dependency-wiring shell and this build is its own unit.
+ */
+function buildPhoneAgentAdapter(
+  args: {
+    agentId: string;
+    credential: VoiceTransportCredential;
+    maxCallSeconds: number;
+  },
+  deps: ResolvedPhoneDeps,
+): AgentAdapter {
+  const { agentId, credential, maxCallSeconds } = args;
+  return tracer.withActiveSpan(
+    "phone.transport.build_outbound_adapter",
+    { attributes: { "scenario.agent.id": agentId } },
+    (span): AgentAdapter => {
+      const twilio = twilioCredentialOf(credential);
+      // The SDK caps an a-leg call at 300s and throws above it; a project
+      // whose VOICE_CALL_MAX_SECONDS is higher is clamped down to the cap.
+      const maxCallDurationSeconds = Math.min(
+        maxCallSeconds,
+        TWILIO_MAX_CALL_DURATION_CAP_SECONDS,
+      );
+      const resolvedBaseUrl = resolvePublicBaseUrlWithSource(deps.processEnv);
+      // A phone call MUST route Twilio's media stream to a URL the WORKER's own
+      // listener answers. That is only ever VOICE_PUBLIC_BASE_URL (an explicit
+      // config, or the worker's minted quick tunnel). BASE_HOST is the app's
+      // origin, which runs no voice media listener, so dialling it hands Twilio
+      // a dead URL — the exact prod 31920 failure. Refuse to build the adapter
+      // rather than dial into a 120s timeout.
+      if (!resolvedBaseUrl || resolvedBaseUrl.source === "BASE_HOST") {
+        const source = resolvedBaseUrl?.source ?? "none";
+        logger.error(
+          { agentId, streamBaseUrlSource: source },
+          "no voice public base URL for outbound call; refusing to dial",
+        );
+        throw new VoicePublicBaseUrlMissingError(source);
+      }
+      span.setAttribute("voice.twilio.stream_base_url", resolvedBaseUrl.value);
+      span.setAttribute(
+        "voice.twilio.stream_base_url_source",
+        resolvedBaseUrl.source,
+      );
+      // Log which base URL and env var this run's Twilio media stream is routed
+      // to, so a later failure (e.g. error 11100) can be traced back to what
+      // URL Twilio actually received.
+      logger.info(
+        {
+          agentId,
+          streamBaseUrl: resolvedBaseUrl.value,
+          streamBaseUrlSource: resolvedBaseUrl.source,
+        },
+        "resolved Twilio media-stream base URL for outbound call",
+      );
+      const adapter = deps.twilioAgentFactory({
+        accountSid: twilio.accountSid,
+        authToken: twilio.authToken,
+        phoneNumber: twilio.fromNumber,
+        publicBaseUrl: resolvedBaseUrl.value,
+        // Always OS-assigned: the parent worker owns the public media port and
+        // hands the child an already-upgraded socket over IPC (below), so the
+        // child's own SDK server never needs a reachable port. Binding a fixed
+        // port here would race the parent for the same listener.
+        httpPort: 0,
+        // Only the dialled target is allowlisted, so the SDK's deny-by-default
+        // a-leg guard passes for exactly this number and nothing else. There is
+        // no user-facing allowlist; this guard is internal to the SDK.
+        allowedCallees: [agentId],
+        role: AgentRole.AGENT,
+      });
+      // The other half of the nonce-registration handshake: once Twilio dials
+      // back, the PARENT worker's listener accepts the upgrade (it owns the
+      // public port) and hands the raw socket to this child over IPC
+      // (`handOffVoiceSocket`/`voice-ws-listener.ts`). Without this wiring the
+      // child would register the nonce and dial correctly, but the arriving
+      // socket would have nowhere to go and the call would still never connect.
+      // One scenario child handles exactly one call, so the receiver lives for
+      // the process's lifetime — no unsubscribe needed.
+      deps.socketReceiver.onVoiceSocket(({ message, socket, head }) => {
+        adapter.receiveExternalMediaSocket?.({
+          req: {
+            method: message.method,
+            url: message.url,
+            headers: message.headers,
+          },
+          socket,
+          head,
+        });
+      });
+      return withOutboundDial(adapter, {
+        to: agentId,
+        maxCallDurationSeconds,
+        registerNonce: deps.registerNonce,
+        mintNonce: deps.mintNonce,
+        raceUpgradeRefusal: deps.raceUpgradeRefusal,
+      }) as unknown as AgentAdapter;
+    },
+  );
+}
+
 /**
  * Build the phone transport runner from its dependencies. `phoneTransport` is
  * the production instance; tests build their own with a fake adapter factory.
@@ -464,72 +624,15 @@ export function createPhoneTransport(
       await (adapter as { disconnect?: () => Promise<void> }).disconnect?.();
     },
 
-    createAgentAdapter({ agentId, credential, maxCallSeconds }): AgentAdapter {
-      const twilio = twilioCredentialOf(credential);
-      // The SDK caps an a-leg call at 300s and throws above it; a project whose
-      // VOICE_CALL_MAX_SECONDS is higher is clamped down to the cap.
-      const maxCallDurationSeconds = Math.min(
-        maxCallSeconds,
-        TWILIO_MAX_CALL_DURATION_CAP_SECONDS,
-      );
-      const resolvedBaseUrl = resolvePublicBaseUrlWithSource(deps.processEnv);
-      // Log which base URL and env var this run's Twilio media stream is
-      // routed to. There is no span available at this point to stamp
-      // `voice.twilio.stream_base_url` on directly, so a failed call (error
-      // 11100, zero duration) can still be traced back to what URL Twilio
-      // actually received via this log line.
-      if (resolvedBaseUrl) {
-        logger.info(
-          {
-            agentId,
-            streamBaseUrl: resolvedBaseUrl.value,
-            streamBaseUrlSource: resolvedBaseUrl.source,
-          },
-          "resolved Twilio media-stream base URL for outbound call",
-        );
-      }
-      const adapter = twilioAgentFactory({
-        accountSid: twilio.accountSid,
-        authToken: twilio.authToken,
-        phoneNumber: twilio.fromNumber,
-        publicBaseUrl: resolvedBaseUrl?.value,
-        // Always OS-assigned: the parent worker owns the public media port
-        // and hands the child an already-upgraded socket over IPC (below), so
-        // the child's own SDK server never needs a reachable port. Binding a
-        // fixed port here would race the parent for the same listener.
-        httpPort: 0,
-        // Only the dialled target is allowlisted, so the SDK's deny-by-default
-        // a-leg guard passes for exactly this number and nothing else. There is
-        // no user-facing allowlist; this guard is internal to the SDK.
-        allowedCallees: [agentId],
-        role: AgentRole.AGENT,
-      });
-      // The other half of the nonce-registration handshake: once Twilio dials
-      // back, the PARENT worker's listener accepts the upgrade (it owns the
-      // public port) and hands the raw socket to this child over IPC
-      // (`handOffVoiceSocket`/`voice-ws-listener.ts`). Without this wiring the
-      // child would register the nonce and dial correctly, but the arriving
-      // socket would have nowhere to go and the call would still never
-      // connect. One scenario child handles exactly one call, so the receiver
-      // lives for the process's lifetime — no unsubscribe needed.
-      socketReceiver.onVoiceSocket(({ message, socket, head }) => {
-        adapter.receiveExternalMediaSocket?.({
-          req: {
-            method: message.method,
-            url: message.url,
-            headers: message.headers,
-          },
-          socket,
-          head,
-        });
-      });
-      return withOutboundDial(adapter, {
-        to: agentId,
-        maxCallDurationSeconds,
+    createAgentAdapter(params): AgentAdapter {
+      return buildPhoneAgentAdapter(params, {
+        twilioAgentFactory,
+        processEnv: deps.processEnv,
         registerNonce,
         mintNonce,
         raceUpgradeRefusal,
-      }) as unknown as AgentAdapter;
+        socketReceiver,
+      });
     },
   };
 }

--- a/platform/app/src/server/scenarios/voice/voice-cloudflared-binary.ts
+++ b/platform/app/src/server/scenarios/voice/voice-cloudflared-binary.ts
@@ -1,0 +1,234 @@
+/**
+ * Puts the `cloudflared` binary on PATH before the vendored `@langwatch/scenario`
+ * SDK spawns it.
+ *
+ * WHY this exists. The SDK's own `openTwilioTunnel` (cloudflared provider) opens
+ * its quick tunnel with a BARE-command spawn — `spawn("cloudflared", ["tunnel",
+ * "--url", ..., "--no-autoupdate"])` — a plain PATH lookup. It does NOT use the
+ * npm `cloudflared` package's `Tunnel` class, does NOT read a `CLOUDFLARED_BIN`
+ * env, and does NOT call the package's `install()`. So even though
+ * `onlyBuiltDependencies: [cloudflared]` in `pnpm-workspace.yaml` correctly
+ * downloads the binary into the npm package's own `bin/` at image-build time,
+ * nothing puts that directory on PATH for the child the SDK spawns, and the dial
+ * fails with `spawn cloudflared ENOENT`. The `voice-triage-survey` dev worktree
+ * only "worked" because it has an unrelated system `/usr/local/bin/cloudflared`
+ * on PATH — CI and prod have neither that nor a system cloudflared in
+ * `Dockerfile.runtime`.
+ *
+ * This module bridges that gap: it locates the npm package's binary (installing
+ * it as a fallback only if the build-time download did not run) and prepends its
+ * directory to PATH, so the SDK's later bare spawn resolves it. The common case
+ * is cheap — the binary is already on disk from the build-time postinstall, so
+ * this only reads a path and prepends it; the `install()` call is a fallback for
+ * an image that shipped without the binary.
+ */
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+
+/**
+ * The slice of the npm `cloudflared` package this module drives: the resolved
+ * binary path and the lazy installer. Both are re-exported from the package
+ * root (`lib/lib.js`), the same surface the SDK's own CLI reaches via
+ * `import("cloudflared")`.
+ */
+export interface CloudflaredModule {
+  /** Absolute path the binary lives at: `<pkg root>/bin/cloudflared`. */
+  bin: string;
+  /** Downloads the architecture-appropriate binary to `to`. */
+  install: (to: string, version?: string) => Promise<string>;
+}
+
+/**
+ * How long the fallback download may take before it is abandoned. A hung
+ * download must not park worker boot forever; the binary is normally already
+ * present from the build-time postinstall, so this only bounds the rare
+ * fallback fetch.
+ */
+export const CLOUDFLARED_INSTALL_TIMEOUT_MS_DEFAULT = 60_000;
+
+/** The dependencies {@link ensureCloudflaredOnPath} is built from. Injected in
+ *  tests so a fake resolver/installer/probe stands in for the real filesystem,
+ *  network and PATH. */
+export interface EnsureCloudflaredOnPathDeps {
+  /** Cheap probe: is `cloudflared` already runnable on PATH? Defaults to a
+   *  `spawnSync("cloudflared", ["--version"])`. */
+  isOnPath?: () => boolean;
+  /** Resolves the npm `cloudflared` package's binary path and installer.
+   *  Defaults to a require scoped to where `@langwatch/scenario` resolved. */
+  resolveModule?: () => CloudflaredModule;
+  /** Whether the binary already exists on disk. Defaults to `fs.existsSync`. */
+  binaryExists?: (binPath: string) => boolean;
+  /** The env whose `PATH` is prepended. Defaults to `process.env`. */
+  env?: NodeJS.ProcessEnv;
+  /** How long the fallback download may run before it is abandoned. */
+  installTimeoutMs?: number;
+}
+
+/**
+ * Thrown when `cloudflared` is neither on PATH nor installable: the package
+ * could not be resolved, the fallback download failed or timed out, or it
+ * reported success yet left no binary. A plain {@link Error} (not a
+ * `HandledError`): the remedy is an OPERATOR action (ship the binary in the
+ * image, fix egress to the GitHub release), not one a customer can take, so per
+ * ADR-045 it degrades to a generic "unknown" plus a trace id at the API
+ * boundary — matching `VoicePublicBaseUrlMissingError`. The message carries the
+ * full cause chain (the underlying ENOENT/EACCES/HTTP text) so the eventual
+ * run error names the real failure rather than "tunnel binary unavailable".
+ */
+export class VoiceTunnelBinaryError extends Error {
+  constructor(summary: string, cause?: unknown) {
+    const causeText = cause === undefined ? "" : `: ${describeCause(cause)}`;
+    super(`cloudflared tunnel binary unavailable: ${summary}${causeText}`);
+    this.name = "VoiceTunnelBinaryError";
+    if (cause !== undefined) {
+      (this as { cause?: unknown }).cause = cause;
+    }
+  }
+}
+
+/** Flatten an error (and any nested `cause`) into a single readable string. */
+function describeCause(cause: unknown): string {
+  if (!(cause instanceof Error)) return String(cause);
+  const nested = (cause as { cause?: unknown }).cause;
+  const head = cause.message.length > 0 ? cause.message : cause.name;
+  return nested === undefined ? head : `${head}: ${describeCause(nested)}`;
+}
+
+/** Default on-PATH probe: `cloudflared --version` exits 0 iff it is runnable. */
+function defaultIsOnPath(): boolean {
+  try {
+    const result = spawnSync("cloudflared", ["--version"], {
+      stdio: "ignore",
+    });
+    return result.error === undefined && result.status === 0;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Resolves the npm `cloudflared` package's `bin`/`install`, scoped to where the
+ * vendored `@langwatch/scenario` SDK resolved.
+ *
+ * The SDK is what actually spawns cloudflared, and under pnpm's strict
+ * `node_modules` layout `cloudflared` is the SDK's own (transitive) dependency
+ * and may not be resolvable from the app's scope. So resolve from the SDK's
+ * scope first, falling back to the app's own scope if that throws.
+ */
+function defaultResolveModule(): CloudflaredModule {
+  const appRequire = createRequire(import.meta.url);
+  let scopedRequire = appRequire;
+  try {
+    scopedRequire = createRequire(appRequire.resolve("@langwatch/scenario"));
+  } catch {
+    // @langwatch/scenario not resolvable from here; keep the app-scoped require.
+    scopedRequire = appRequire;
+  }
+  // Resolve the package.json first as the robust presence check, then load the
+  // package root (its `main`, `lib/lib.js`), which re-exports `bin` + `install`.
+  scopedRequire.resolve("cloudflared/package.json");
+  const mod = scopedRequire("cloudflared") as Partial<CloudflaredModule>;
+  if (typeof mod.bin !== "string" || typeof mod.install !== "function") {
+    throw new Error("the cloudflared package did not export bin/install");
+  }
+  return { bin: mod.bin, install: mod.install };
+}
+
+/** Reject once `ms` elapses, so a hung download cannot park worker boot. */
+function withTimeout<T>(
+  promise: Promise<T>,
+  ms: number,
+  message: string,
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(message)), ms);
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (error) => {
+        clearTimeout(timer);
+        reject(error);
+      },
+    );
+  });
+}
+
+/** Prepend `dir` to `env.PATH`, unless it is already the leading entry. */
+function prependToPath(env: NodeJS.ProcessEnv, dir: string): void {
+  const current = env.PATH ?? "";
+  if (current.split(path.delimiter)[0] === dir) return;
+  env.PATH = current ? `${dir}${path.delimiter}${current}` : dir;
+}
+
+/**
+ * Downloads the binary as a fallback if it is missing on disk. No-op when it is
+ * already present (the common case: the build-time postinstall put it there).
+ * Throws {@link VoiceTunnelBinaryError} on a failed/timed-out download, or when
+ * the download reports success yet leaves no binary.
+ */
+async function ensureBinaryPresent(
+  mod: CloudflaredModule,
+  binaryExists: (binPath: string) => boolean,
+  installTimeoutMs: number,
+): Promise<void> {
+  if (binaryExists(mod.bin)) return;
+  try {
+    await withTimeout(
+      mod.install(mod.bin),
+      installTimeoutMs,
+      `cloudflared install timed out after ${installTimeoutMs}ms`,
+    );
+  } catch (error) {
+    throw new VoiceTunnelBinaryError(
+      `failed to install the cloudflared binary to ${mod.bin}`,
+      error,
+    );
+  }
+  if (!binaryExists(mod.bin)) {
+    throw new VoiceTunnelBinaryError(
+      `cloudflared install reported success but ${mod.bin} is still missing`,
+    );
+  }
+}
+
+/**
+ * Ensures a `cloudflared` binary is resolvable on PATH for the SDK's later bare
+ * spawn. No-op when one is already on PATH. Otherwise resolves the npm package,
+ * downloads the binary as a fallback if it is missing, and prepends its
+ * directory to PATH. Throws {@link VoiceTunnelBinaryError} (carrying the cause
+ * chain) on any failure — the worker boot catches it and threads the reason
+ * into the run's error.
+ */
+export async function ensureCloudflaredOnPath(
+  deps: EnsureCloudflaredOnPathDeps = {},
+): Promise<void> {
+  const isOnPath = deps.isOnPath ?? defaultIsOnPath;
+  const env = deps.env ?? process.env;
+
+  // A system cloudflared already on PATH (some dev boxes, some images) needs
+  // nothing further — and this short-circuit costs one cheap subprocess.
+  if (isOnPath()) return;
+
+  const resolveModule = deps.resolveModule ?? defaultResolveModule;
+  const binaryExists = deps.binaryExists ?? fs.existsSync;
+  const installTimeoutMs =
+    deps.installTimeoutMs ?? CLOUDFLARED_INSTALL_TIMEOUT_MS_DEFAULT;
+
+  let mod: CloudflaredModule;
+  try {
+    mod = resolveModule();
+  } catch (error) {
+    throw new VoiceTunnelBinaryError(
+      "could not resolve the cloudflared package",
+      error,
+    );
+  }
+
+  await ensureBinaryPresent(mod, binaryExists, installTimeoutMs);
+  prependToPath(env, path.dirname(mod.bin));
+}

--- a/platform/app/src/server/scenarios/voice/voice-cloudflared-binary.ts
+++ b/platform/app/src/server/scenarios/voice/voice-cloudflared-binary.ts
@@ -189,11 +189,15 @@ function defaultResolveModule(): CloudflaredModule {
 }
 
 /** Reject once `ms` elapses, so a hung download cannot park worker boot. */
-function withTimeout<T>(
-  promise: Promise<T>,
-  ms: number,
-  message: string,
-): Promise<T> {
+function withTimeout<T>({
+  promise,
+  ms,
+  message,
+}: {
+  promise: Promise<T>;
+  ms: number;
+  message: string;
+}): Promise<T> {
   return new Promise<T>((resolve, reject) => {
     const timer = setTimeout(() => reject(new Error(message)), ms);
     promise.then(
@@ -210,7 +214,13 @@ function withTimeout<T>(
 }
 
 /** Prepend `dir` to `env.PATH`, unless it is already the leading entry. */
-function prependToPath(env: NodeJS.ProcessEnv, dir: string): void {
+function prependToPath({
+  env,
+  dir,
+}: {
+  env: NodeJS.ProcessEnv;
+  dir: string;
+}): void {
   const current = env.PATH ?? "";
   if (current.split(path.delimiter)[0] === dir) return;
   env.PATH = current ? `${dir}${path.delimiter}${current}` : dir;
@@ -222,18 +232,22 @@ function prependToPath(env: NodeJS.ProcessEnv, dir: string): void {
  * Throws {@link VoiceTunnelBinaryError} on a failed/timed-out download, or when
  * the download reports success yet leaves no binary.
  */
-async function ensureBinaryPresent(
-  mod: CloudflaredModule,
-  binaryExists: (binPath: string) => boolean,
-  installTimeoutMs: number,
-): Promise<void> {
+async function ensureBinaryPresent({
+  mod,
+  binaryExists,
+  installTimeoutMs,
+}: {
+  mod: CloudflaredModule;
+  binaryExists: (binPath: string) => boolean;
+  installTimeoutMs: number;
+}): Promise<void> {
   if (binaryExists(mod.bin)) return;
   try {
-    await withTimeout(
-      mod.install(mod.bin),
-      installTimeoutMs,
-      `cloudflared install timed out after ${installTimeoutMs}ms`,
-    );
+    await withTimeout({
+      promise: mod.install(mod.bin),
+      ms: installTimeoutMs,
+      message: `cloudflared install timed out after ${installTimeoutMs}ms`,
+    });
   } catch (error) {
     throw new VoiceTunnelBinaryError(
       `failed to install the cloudflared binary to ${mod.bin}`,
@@ -280,6 +294,6 @@ export async function ensureCloudflaredOnPath(
     );
   }
 
-  await ensureBinaryPresent(mod, binaryExists, installTimeoutMs);
-  prependToPath(env, path.dirname(mod.bin));
+  await ensureBinaryPresent({ mod, binaryExists, installTimeoutMs });
+  prependToPath({ env, dir: path.dirname(mod.bin) });
 }

--- a/platform/app/src/server/scenarios/voice/voice-cloudflared-binary.ts
+++ b/platform/app/src/server/scenarios/voice/voice-cloudflared-binary.ts
@@ -21,6 +21,16 @@
  * is cheap — the binary is already on disk from the build-time postinstall, so
  * this only reads a path and prepends it; the `install()` call is a fallback for
  * an image that shipped without the binary.
+ *
+ * WHERE the `cloudflared` npm package lives. It is a prod dependency of the
+ * workspace `langwatch` SDK package (`sdks/typescript/package.json`), NOT of
+ * `@langwatch/scenario`. `@langwatch/web` depends on `langwatch: workspace:*`,
+ * so that edge survives the prod-filtered install (`--prod --filter
+ * "@langwatch/web..."`), and under pnpm's strict `node_modules` layout the
+ * binary is only resolvable by scoping the require to where `langwatch`
+ * resolved. So the resolution below searches scopes in order — the `langwatch`
+ * SDK scope first (the real dependency edge), then `@langwatch/scenario` as a
+ * secondary fallback in case packaging changes, then the app's own scope.
  */
 
 import { spawnSync } from "node:child_process";
@@ -57,7 +67,9 @@ export interface EnsureCloudflaredOnPathDeps {
    *  `spawnSync("cloudflared", ["--version"])`. */
   isOnPath?: () => boolean;
   /** Resolves the npm `cloudflared` package's binary path and installer.
-   *  Defaults to a require scoped to where `@langwatch/scenario` resolved. */
+   *  Defaults to a require scoped to where the `langwatch` SDK resolved (the
+   *  real dependency edge), falling back to `@langwatch/scenario` then the app
+   *  scope. */
   resolveModule?: () => CloudflaredModule;
   /** Whether the binary already exists on disk. Defaults to `fs.existsSync`. */
   binaryExists?: (binPath: string) => boolean;
@@ -110,31 +122,70 @@ function defaultIsOnPath(): boolean {
 }
 
 /**
- * Resolves the npm `cloudflared` package's `bin`/`install`, scoped to where the
- * vendored `@langwatch/scenario` SDK resolved.
- *
- * The SDK is what actually spawns cloudflared, and under pnpm's strict
- * `node_modules` layout `cloudflared` is the SDK's own (transitive) dependency
- * and may not be resolvable from the app's scope. So resolve from the SDK's
- * scope first, falling back to the app's own scope if that throws.
+ * One named candidate scope to search for the npm `cloudflared` package. The
+ * `require` is `null` when the scope's own anchor did not resolve (e.g. the
+ * `langwatch` specifier itself threw), so it is simply skipped.
+ */
+export interface CloudflaredScope {
+  /** Human-readable scope name, surfaced in the all-scopes-failed error. */
+  name: string;
+  /** The require to resolve/load `cloudflared` from, or `null` if the scope's
+   *  anchor did not resolve. */
+  require: NodeRequire | null;
+}
+
+/**
+ * Loads the npm `cloudflared` package's `bin`/`install` from the first
+ * {@link CloudflaredScope} that can resolve `cloudflared/package.json`. Resolving
+ * the `package.json` is the robust presence check; the package root
+ * (`lib/lib.js`) then re-exports `bin` + `install`. Throws naming every tried
+ * scope when none can resolve it.
+ */
+export function resolveCloudflaredFromScopes(
+  scopes: CloudflaredScope[],
+): CloudflaredModule {
+  for (const scope of scopes) {
+    if (scope.require === null) continue;
+    try {
+      scope.require.resolve("cloudflared/package.json");
+    } catch {
+      continue;
+    }
+    const mod = scope.require("cloudflared") as Partial<CloudflaredModule>;
+    if (typeof mod.bin !== "string" || typeof mod.install !== "function") {
+      throw new Error("the cloudflared package did not export bin/install");
+    }
+    return { bin: mod.bin, install: mod.install };
+  }
+  throw new Error(
+    `could not resolve the cloudflared package from any of: ${scopes
+      .map((scope) => scope.name)
+      .join(", ")}`,
+  );
+}
+
+/**
+ * Resolves the npm `cloudflared` package's `bin`/`install`, searching scopes in
+ * dependency-truth order: the `langwatch` SDK scope (which actually depends on
+ * `cloudflared`), then `@langwatch/scenario` as a secondary fallback, then the
+ * app's own scope. Under pnpm's strict `node_modules` layout `cloudflared` is
+ * only reachable from the `langwatch` scope, so that scope must be tried first.
  */
 function defaultResolveModule(): CloudflaredModule {
   const appRequire = createRequire(import.meta.url);
-  let scopedRequire = appRequire;
-  try {
-    scopedRequire = createRequire(appRequire.resolve("@langwatch/scenario"));
-  } catch {
-    // @langwatch/scenario not resolvable from here; keep the app-scoped require.
-    scopedRequire = appRequire;
-  }
-  // Resolve the package.json first as the robust presence check, then load the
-  // package root (its `main`, `lib/lib.js`), which re-exports `bin` + `install`.
-  scopedRequire.resolve("cloudflared/package.json");
-  const mod = scopedRequire("cloudflared") as Partial<CloudflaredModule>;
-  if (typeof mod.bin !== "string" || typeof mod.install !== "function") {
-    throw new Error("the cloudflared package did not export bin/install");
-  }
-  return { bin: mod.bin, install: mod.install };
+  const scopeFrom = (specifier: string): NodeRequire | null => {
+    try {
+      return createRequire(appRequire.resolve(specifier));
+    } catch {
+      // Anchor specifier not resolvable from here; skip this scope.
+      return null;
+    }
+  };
+  return resolveCloudflaredFromScopes([
+    { name: "langwatch", require: scopeFrom("langwatch") },
+    { name: "@langwatch/scenario", require: scopeFrom("@langwatch/scenario") },
+    { name: "app scope", require: appRequire },
+  ]);
 }
 
 /** Reject once `ms` elapses, so a hung download cannot park worker boot. */

--- a/platform/app/src/server/scenarios/voice/voice-public-url-env.ts
+++ b/platform/app/src/server/scenarios/voice/voice-public-url-env.ts
@@ -1,0 +1,15 @@
+/**
+ * The env var a voice worker uses to thread WHY it has no public media URL —
+ * its cloudflared tunnel mint failed at boot — from the worker process down to
+ * the scenario child, so the child's eventual phone-run error can name the real
+ * cause (e.g. "spawn cloudflared ENOENT") instead of a generic "no public media
+ * URL".
+ *
+ * A leaf with NO imports on purpose: the worker boot that writes it
+ * (`startWorkers.ts`), the child-env forwarder (`child-environment.ts`), and the
+ * phone transport that reads it (`phone.transport.ts`) all import this name,
+ * and only a dependency-free leaf can be shared across the parent/child
+ * boundary without dragging a heavy graph through `child-environment.ts`.
+ */
+export const VOICE_PUBLIC_BASE_URL_UNAVAILABLE_REASON_ENV =
+  "VOICE_PUBLIC_BASE_URL_UNAVAILABLE_REASON";

--- a/platform/app/src/server/scenarios/voice/voice-public-url-tunnel.ts
+++ b/platform/app/src/server/scenarios/voice/voice-public-url-tunnel.ts
@@ -28,6 +28,7 @@
  */
 
 import { voice as scenarioVoice } from "@langwatch/scenario";
+import { ensureCloudflaredOnPath } from "./voice-cloudflared-binary";
 
 type OpenedTunnel = Awaited<ReturnType<typeof scenarioVoice.openTwilioTunnel>>;
 
@@ -187,8 +188,21 @@ export async function openVoicePublicUrlTunnel(params: {
     provider: "cloudflared";
   }) => Promise<OpenedTunnel>;
   resolveHost?: (host: string) => Promise<boolean>;
+  /** Puts the cloudflared binary on PATH before `openTunnel` spawns it.
+   *  Injectable so a test with a fake opener stays hermetic; defaults to the
+   *  real {@link ensureCloudflaredOnPath}. */
+  ensureBinaryOnPath?: () => Promise<void>;
 }): Promise<VoicePublicUrlTunnel> {
   const openTunnel = params.openTunnel ?? defaultOpenTunnel;
+  // The SDK's cloudflared provider opens the tunnel with a BARE `spawn(
+  // "cloudflared", ...)` — a PATH lookup — so the binary's directory must be on
+  // PATH BEFORE openTunnel runs (see voice-cloudflared-binary.ts). A failure
+  // here (binary missing and the fallback install failed) throws
+  // VoiceTunnelBinaryError, which the worker boot catches and threads into the
+  // run's error.
+  const ensureBinaryOnPath =
+    params.ensureBinaryOnPath ?? (() => ensureCloudflaredOnPath());
+  await ensureBinaryOnPath();
   const tunnel = await openTunnel({
     port: params.port,
     provider: "cloudflared",

--- a/platform/app/src/server/workers/__tests__/voice-boot-non-fatal.unit.test.ts
+++ b/platform/app/src/server/workers/__tests__/voice-boot-non-fatal.unit.test.ts
@@ -9,6 +9,7 @@
  * processing. Pins the non-fatal guard directly at the two boot steps.
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { VOICE_PUBLIC_BASE_URL_UNAVAILABLE_REASON_ENV } from "~/server/scenarios/voice/voice-public-url-env";
 
 vi.mock("~/server/scenarios/voice/voice-public-url-tunnel", () => ({
   openVoicePublicUrlTunnel: vi.fn(async () => {
@@ -29,6 +30,7 @@ vi.mock("~/server/scenarios/voice/voice-nonce-registry", () => ({
 describe("voice boot non-fatal guards", () => {
   afterEach(() => {
     vi.clearAllMocks();
+    delete process.env[VOICE_PUBLIC_BASE_URL_UNAVAILABLE_REASON_ENV];
   });
 
   /** @scenario "A worker's own voice boot failure does not take the worker down" */
@@ -44,6 +46,21 @@ describe("voice boot non-fatal guards", () => {
 
     expect(result).toBeUndefined();
     expect(shutdownHandles).toHaveLength(0);
+  });
+
+  /** @scenario "A failed voice tunnel boot records its reason for the phone run error" */
+  it("bootVoicePublicUrlTunnel records the failure reason in the child env var", async () => {
+    const { bootVoicePublicUrlTunnel } = await import("../startWorkers");
+
+    await bootVoicePublicUrlTunnel([], {
+      voiceWsPort: 3300,
+      voicePublicBaseUrl: undefined,
+      voiceTunnelEnabled: true,
+    });
+
+    expect(process.env[VOICE_PUBLIC_BASE_URL_UNAVAILABLE_REASON_ENV]).toBe(
+      "cloudflared failed to start",
+    );
   });
 
   /** @scenario "A worker's own voice boot failure does not take the worker down" */

--- a/platform/app/src/server/workers/__tests__/worker-boot-plan.unit.test.ts
+++ b/platform/app/src/server/workers/__tests__/worker-boot-plan.unit.test.ts
@@ -11,6 +11,7 @@ describe("resolveWorkerBootPlan", () => {
     const plan = resolveWorkerBootPlan({ shouldStartMetricsServer: true });
 
     expect(plan).toEqual([
+      "metrics",
       "storage-stats",
       "voice-ws-listener",
       "scenario-processor",
@@ -19,7 +20,6 @@ describe("resolveWorkerBootPlan", () => {
       "spend-spike-anomaly",
       "usage-stats",
       "realtime-session-poller",
-      "metrics",
     ]);
   });
 
@@ -41,6 +41,21 @@ describe("resolveWorkerBootPlan", () => {
       expect(
         resolveWorkerBootPlan({ shouldStartMetricsServer: false }),
       ).not.toContain("metrics");
+    });
+  });
+
+  describe("given the voice tunnel can take minutes to mint on a cold binary download", () => {
+    /** @scenario "The liveness server boots before every other stage, including the voice tunnel" */
+    it("puts the metrics stage first in the plan", () => {
+      // startWorkers boots the "metrics" stage (the kubelet liveness thread)
+      // as soon as it appears in the plan, before it resolves the voice
+      // public URL tunnel — a slow cloudflared download or slow trycloudflare
+      // DNS must not leave /healthz unanswered past the kubelet's liveness
+      // budget (prod: ~90s) or the pod is killed mid-mint, crash-looping the
+      // rollout. Pinning "metrics" first here is what makes that true.
+      const plan = resolveWorkerBootPlan({ shouldStartMetricsServer: true });
+
+      expect(plan[0]).toBe("metrics");
     });
   });
 });

--- a/platform/app/src/server/workers/startWorkers.ts
+++ b/platform/app/src/server/workers/startWorkers.ts
@@ -237,6 +237,30 @@ export async function bootVoicePublicUrlTunnel(
   );
 }
 
+// Reads the voice worker env and resolves its public base URL (opening a
+// tunnel if needed), in that order: the tunnel/listener boot need the env's
+// port and tunnel settings, and the URL must be resolved (and
+// process.env.VOICE_PUBLIC_BASE_URL set) before the scenario-processor stage
+// can spawn its first child. Split out of `startWorkers` only to keep that
+// function under the line-count lint budget; see bootVoicePublicUrlTunnel's
+// own doc comment for why this can block for minutes and why that's now safe
+// for the kubelet probe (metrics boots before this runs).
+async function resolveVoiceEnv(shutdownHandles: ShutdownHandles): Promise<{
+  voiceWsPort: number;
+  voicePublicBaseUrl: string | undefined;
+  voiceTunnelEnabled: boolean;
+}> {
+  const { readVoiceWorkerEnv } = await import(
+    "~/server/scenarios/voice/voice-worker-env"
+  );
+  const rawVoiceEnv = readVoiceWorkerEnv();
+  const resolvedPublicBaseUrl = await bootVoicePublicUrlTunnel(
+    shutdownHandles,
+    rawVoiceEnv,
+  );
+  return { ...rawVoiceEnv, voicePublicBaseUrl: resolvedPublicBaseUrl };
+}
+
 // The Twilio media listener: its own HTTP+WS server on VOICE_WS_PORT, booted
 // on every worker. It authenticates the per-call nonce and hands the raw
 // upgrade socket to the scenario child that owns the call.
@@ -640,30 +664,27 @@ export async function startWorkers(
   await assertRedisReady();
   await verifyDatabaseReady();
 
-  // Read the voice worker env FIRST: the tunnel/listener boot below need its
-  // port and tunnel settings. Never throws (see voice-worker-env.ts).
-  const { readVoiceWorkerEnv } = await import(
-    "~/server/scenarios/voice/voice-worker-env"
-  );
-  const rawVoiceEnv = readVoiceWorkerEnv();
-
-  // Resolve the public base URL BEFORE the boot plan runs: a quick tunnel
-  // (when needed) must be open and process.env.VOICE_PUBLIC_BASE_URL set
-  // before the scenario-processor stage can spawn its first child.
-  const resolvedPublicBaseUrl = await bootVoicePublicUrlTunnel(
-    shutdownHandles,
-    rawVoiceEnv,
-  );
-  const voiceEnv = {
-    ...rawVoiceEnv,
-    voicePublicBaseUrl: resolvedPublicBaseUrl,
-  };
-
   const { resolveWorkerBootPlan } = await import("./worker-boot-plan");
   const plan = resolveWorkerBootPlan({ shouldStartMetricsServer });
   logger.info({ plan }, "worker boot plan");
 
+  const remainingPlan = plan.filter((stage) => stage !== "metrics");
+
   try {
+    // Boot metrics (the liveness thread that answers the kubelet's /healthz)
+    // BEFORE the voice tunnel below: a cold cloudflared binary download or
+    // slow trycloudflare DNS can take minutes, far past the kubelet's
+    // liveness budget, and a pod whose /healthz isn't listening yet gets
+    // killed and restarted mid-mint — crash-looping the whole rollout. The
+    // liveness thread depends on nothing the tunnel or any other stage sets
+    // up, so running it first is free. Run only the "metrics" stage here and
+    // filter it out of the loop below so it isn't booted twice.
+    if (plan.includes("metrics")) {
+      await bootMetricsServer(shutdownHandles);
+    }
+
+    const voiceEnv = await resolveVoiceEnv(shutdownHandles);
+
     // Ingestion pulls self-drive through durable process wakes and the
     // transactional process outbox; there is no separate queue worker to boot.
     // Topic clustering self-drives (ADR-051): the process wake worker and
@@ -678,7 +699,7 @@ export async function startWorkers(
     // NOT booted here: they are a worker-only background loop like the
     // scheduler, so the app layer starts them and the App's graceful
     // closeables stop them (see presets.ts).
-    for (const stage of plan) {
+    for (const stage of remainingPlan) {
       switch (stage) {
         case "storage-stats":
           await bootStorageStatsCollection(shutdownHandles);
@@ -705,7 +726,8 @@ export async function startWorkers(
           await bootVoiceListener(shutdownHandles, voiceEnv);
           break;
         case "metrics":
-          await bootMetricsServer(shutdownHandles);
+          // Already booted above, before the voice tunnel — see the
+          // metrics-first comment near the top of this function.
           break;
       }
     }

--- a/platform/app/src/server/workers/startWorkers.ts
+++ b/platform/app/src/server/workers/startWorkers.ts
@@ -1,10 +1,12 @@
 import { Worker } from "node:worker_threads";
 import { createLogger } from "@langwatch/observability";
+import { SpanStatusCode } from "@opentelemetry/api";
 import type { IncomingMessage, RequestListener, ServerResponse } from "http";
 import http from "http";
 import { register } from "prom-client";
 import { assertRedisReady } from "~/server/app-layer/redis-readiness";
 import { getWorkerMetricsPort, isMetricsAuthorized } from "~/server/metrics";
+import { VOICE_PUBLIC_BASE_URL_UNAVAILABLE_REASON_ENV } from "~/server/scenarios/voice/voice-public-url-env";
 
 const logger = createLogger("langwatch:workers");
 
@@ -188,24 +190,51 @@ export async function bootVoicePublicUrlTunnel(
   ) {
     return voiceEnv.voicePublicBaseUrl;
   }
-  try {
-    const { openVoicePublicUrlTunnel } = await import(
-      "~/server/scenarios/voice/voice-public-url-tunnel"
-    );
-    const tunnel = await openVoicePublicUrlTunnel({
-      port: voiceEnv.voiceWsPort,
-    });
-    process.env.VOICE_PUBLIC_BASE_URL = tunnel.url;
-    shutdownHandles.push(() => tunnel.close());
-    logger.info({ url: tunnel.url }, "voice public URL tunnel ready");
-    return tunnel.url;
-  } catch (error) {
-    logger.error(
-      { error },
-      "voice public URL tunnel failed to open; voice runs on this worker will fail until it restarts",
-    );
-    return undefined;
-  }
+  // Trace the tunnel-mint boot so a failure lands as a recorded exception on a
+  // span, and thread the specific reason into the child's env — the eventual
+  // phone-run error then names the real cause (e.g. "spawn cloudflared ENOENT")
+  // instead of a generic "no public media URL". Lazy import to keep this file's
+  // env-load ordering intact (see startWorkers' doc comment).
+  const { getLangWatchTracer } = await import("langwatch");
+  const tracer = getLangWatchTracer("langwatch.workers.voice");
+  return tracer.withActiveSpan(
+    "voice.public_url_tunnel.boot",
+    { attributes: { "voice.ws_port": voiceEnv.voiceWsPort } },
+    async (span): Promise<string | undefined> => {
+      try {
+        const { openVoicePublicUrlTunnel } = await import(
+          "~/server/scenarios/voice/voice-public-url-tunnel"
+        );
+        const tunnel = await openVoicePublicUrlTunnel({
+          port: voiceEnv.voiceWsPort,
+        });
+        process.env.VOICE_PUBLIC_BASE_URL = tunnel.url;
+        // A prior failed boot may have left a stale reason; clear it now that a
+        // tunnel is live so a later run reads no misleading cause.
+        delete process.env[VOICE_PUBLIC_BASE_URL_UNAVAILABLE_REASON_ENV];
+        shutdownHandles.push(() => tunnel.close());
+        logger.info({ url: tunnel.url }, "voice public URL tunnel ready");
+        return tunnel.url;
+      } catch (error) {
+        // Non-fatal: voice boots on EVERY worker now, so one Cloudflare/binary
+        // hiccup must not down the whole fleet's job processing. Record the
+        // cause on the span and stash it for the child so the phone-run error
+        // can name it — then continue with no public URL (voice runs on this
+        // process fail individually).
+        const reason = error instanceof Error ? error.message : String(error);
+        span.recordException(
+          error instanceof Error ? error : new Error(reason),
+        );
+        span.setStatus({ code: SpanStatusCode.ERROR, message: reason });
+        process.env[VOICE_PUBLIC_BASE_URL_UNAVAILABLE_REASON_ENV] = reason;
+        logger.error(
+          { error },
+          "voice public URL tunnel failed to open; voice runs on this worker will fail until it restarts",
+        );
+        return undefined;
+      }
+    },
+  );
 }
 
 // The Twilio media listener: its own HTTP+WS server on VOICE_WS_PORT, booted

--- a/platform/app/src/server/workers/startWorkers.ts
+++ b/platform/app/src/server/workers/startWorkers.ts
@@ -725,10 +725,12 @@ export async function startWorkers(
         case "voice-ws-listener":
           await bootVoiceListener(shutdownHandles, voiceEnv);
           break;
-        case "metrics":
-          // Already booted above, before the voice tunnel — see the
-          // metrics-first comment near the top of this function.
-          break;
+        // "metrics" is deliberately absent: TypeScript's inferred type
+        // predicate on the `remainingPlan` filter above already narrows
+        // "metrics" out of `stage`'s type here, so a case for it is
+        // unreachable (and TS errors on it as such). It's already booted,
+        // before the voice tunnel — see the metrics-first comment near the
+        // top of this function.
       }
     }
   } catch (error) {

--- a/platform/app/src/server/workers/worker-boot-plan.ts
+++ b/platform/app/src/server/workers/worker-boot-plan.ts
@@ -30,6 +30,17 @@ export type WorkerStageName =
  * ones (the scenario processor registers the pool a later stage reads), and
  * teardown runs newest-first.
  *
+ * metrics first: the liveness thread must answer the kubelet while the voice
+ * tunnel boot, which can take minutes on a cold binary download, is still in
+ * flight. `startWorkers` boots the tunnel between this plan's resolution and
+ * its execution (see its own doc comment), so putting `metrics` at the head
+ * here is what lets the liveness thread be listening before that wait even
+ * starts — a pod whose `/healthz` isn't up within the kubelet's liveness
+ * budget (prod: 30s initial delay + 6 * 10s period ≈ 90s) gets killed and
+ * restarted mid-tunnel-mint, crash-looping the whole rollout on a slow
+ * GitHub download or slow trycloudflare DNS. `metrics` depends on nothing
+ * else in the plan, so moving it first costs nothing.
+ *
  * `voice-ws-listener` deliberately precedes `scenario-processor`. The processor
  * starts claiming queued jobs the moment it boots, and a voice job builds TwiML
  * naming this process's media socket. With the listener behind the processor,
@@ -46,6 +57,7 @@ export function resolveWorkerBootPlan(params: {
     : [];
 
   return [
+    ...metrics,
     "storage-stats",
     "voice-ws-listener",
     "scenario-processor",
@@ -54,6 +66,5 @@ export function resolveWorkerBootPlan(params: {
     "spend-spike-anomaly",
     "usage-stats",
     "realtime-session-poller",
-    ...metrics,
   ];
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -332,12 +332,21 @@ packageExtensions:
 
 # Union of the three roots' allowlists. node-pty is skills/ and mcp/typescript's;
 # the rest came from platform/app/.
+#
+# cloudflared's postinstall downloads the actual `cloudflared` binary into its
+# own bin/ (`node lib/cloudflared.js bin install latest`). pnpm 10 runs a
+# dependency's build/postinstall ONLY when it is allowlisted here, so without
+# this entry the binary is never fetched, the voice worker's quick-tunnel mint
+# spawns a non-existent path (ENOENT), no VOICE_PUBLIC_BASE_URL is set, and
+# phone calls dial a URL nothing answers (Twilio error 31920). See
+# specs/features/agents/voice-phone.feature.
 onlyBuiltDependencies:
   - "@prisma/client"
   - "@prisma/engines"
   - "@scarf/scarf"
   - bcrypt
   - bufferutil
+  - cloudflared
   - core-js
   - cpu-features
   - esbuild

--- a/specs/features/agents/voice-phone.feature
+++ b/specs/features/agents/voice-phone.feature
@@ -357,6 +357,24 @@ Feature: Voice agents: reach an agent by phone
     Then it fails with a tunnel binary error naming the resolution failure
 
   @unit
+  Scenario: cloudflared resolves through the langwatch SDK scope first
+    Given the langwatch SDK scope can resolve the cloudflared package
+    When the worker resolves cloudflared across its scopes
+    Then it uses the langwatch scope's package and tries no later scope
+
+  @unit
+  Scenario: cloudflared falls back to the scenario scope when the langwatch scope fails
+    Given the langwatch scope cannot resolve cloudflared but the scenario scope can
+    When the worker resolves cloudflared across its scopes
+    Then it uses the scenario scope's package
+
+  @unit
+  Scenario: cloudflared unresolvable from every scope names all tried scopes
+    Given no scope can resolve the cloudflared package
+    When the worker resolves cloudflared across its scopes
+    Then it fails with an error naming every scope it tried
+
+  @unit
   Scenario: A voice worker puts cloudflared on PATH before opening its quick tunnel
     Given a voice worker about to open its quick tunnel
     When it opens the tunnel

--- a/specs/features/agents/voice-phone.feature
+++ b/specs/features/agents/voice-phone.feature
@@ -99,10 +99,16 @@ Feature: Voice agents: reach an agent by phone
     Then it returns nothing and the drawer shows no whole-call player
 
   @unit
-  Scenario: VOICE_PUBLIC_BASE_URL is optional and falls back to the app's public base host
-    Given VOICE_PUBLIC_BASE_URL is not set
-    When the runner resolves the public base URL
-    Then it uses the app's own public base host, and a set VOICE_PUBLIC_BASE_URL overrides it
+  Scenario: A phone run fails fast when only the app's base host is available
+    Given VOICE_PUBLIC_BASE_URL is not set but the app's BASE_HOST is
+    When the phone transport builds the outbound adapter
+    Then it refuses to build the adapter and fails the run, naming the missing VOICE_PUBLIC_BASE_URL and the cloudflared tunnel remedy rather than dialling the app's own host, which runs no voice media listener
+
+  @unit
+  Scenario: A phone run fails fast when no public base URL is available at all
+    Given neither VOICE_PUBLIC_BASE_URL nor BASE_HOST is set
+    When the phone transport builds the outbound adapter
+    Then it refuses to build the adapter and fails the run rather than dialling a URL nothing answers
 
   @unit
   Scenario: A phone call's scenario child never binds the worker's media port

--- a/specs/features/agents/voice-phone.feature
+++ b/specs/features/agents/voice-phone.feature
@@ -311,3 +311,71 @@ Feature: Voice agents: reach an agent by phone
     And a nonce registered to that child
     When an upgrade arrives on that nonce's media path
     Then the child receives the socket handle and the bytes read during the upgrade
+
+  # ---------------------------------------------------------------------------
+  # Cloudflared binary on PATH (the SDK spawns a bare `cloudflared`)
+  # ---------------------------------------------------------------------------
+  # The scenario SDK opens its quick tunnel with a bare-command spawn, a PATH
+  # lookup. Before the worker opens a tunnel it makes the cloudflared binary
+  # reachable on PATH, downloading it only as a fallback, and surfaces any
+  # failure so the run error names the real cause.
+
+  @unit
+  Scenario: cloudflared already on PATH is used as-is
+    Given a cloudflared binary is already reachable on PATH
+    When the worker ensures cloudflared is available
+    Then it uses the one on PATH and downloads nothing
+
+  @unit
+  Scenario: A present cloudflared binary is put on PATH without downloading
+    Given no cloudflared is on PATH but its binary is already present on disk
+    When the worker ensures cloudflared is available
+    Then it makes that binary reachable on PATH without downloading
+
+  @unit
+  Scenario: A missing cloudflared binary is downloaded then put on PATH
+    Given no cloudflared is on PATH and its binary is missing from disk
+    When the worker ensures cloudflared is available
+    Then it downloads the binary and makes it reachable on PATH
+
+  @unit
+  Scenario: A cloudflared download failure surfaces as a tunnel binary error
+    Given no cloudflared is on PATH and the fallback download fails
+    When the worker ensures cloudflared is available
+    Then it fails with a tunnel binary error naming the underlying cause
+
+  @unit
+  Scenario: A cloudflared download that hangs is abandoned
+    Given no cloudflared is on PATH and the fallback download never completes
+    When the worker ensures cloudflared is available
+    Then it abandons the download after the timeout and fails with a tunnel binary error
+
+  @unit
+  Scenario: An unresolvable cloudflared package surfaces as a tunnel binary error
+    Given the cloudflared package cannot be resolved
+    When the worker ensures cloudflared is available
+    Then it fails with a tunnel binary error naming the resolution failure
+
+  @unit
+  Scenario: A voice worker puts cloudflared on PATH before opening its quick tunnel
+    Given a voice worker about to open its quick tunnel
+    When it opens the tunnel
+    Then it makes cloudflared reachable on PATH before spawning the tunnel
+
+  @unit
+  Scenario: A voice worker's tunnel fails to open when the cloudflared binary is unavailable
+    Given cloudflared cannot be made reachable on PATH
+    When a voice worker tries to open its quick tunnel
+    Then it never spawns the tunnel and the open fails
+
+  @unit
+  Scenario: A failed voice tunnel boot records its reason for the phone run error
+    Given a voice worker whose quick tunnel fails to open
+    When the worker boots
+    Then it records why the tunnel failed for a later phone run to read
+
+  @unit
+  Scenario: A phone run's missing-URL error names the worker's tunnel failure reason
+    Given the worker recorded why its public URL tunnel failed to open
+    When the phone transport builds the outbound adapter with no public base URL
+    Then the run error names that recorded reason rather than a generic message

--- a/specs/server/worker-liveness-probe.feature
+++ b/specs/server/worker-liveness-probe.feature
@@ -122,6 +122,26 @@ Feature: Worker liveness probe endpoint
       Then the response status is 503
       # A stalled loop fails the scrape, never the probe.
 
+  Rule: Liveness boots before any stage that can block for minutes
+
+    # The voice public URL tunnel (cloudflared quick tunnel) can take up to
+    # CLOUDFLARED_INSTALL_TIMEOUT_MS_DEFAULT + TUNNEL_READY_TIMEOUT_MS_DEFAULT
+    # to mint on a cold binary download or slow trycloudflare DNS — minutes,
+    # far past the kubelet's liveness budget (prod: ~90s). Before this rule,
+    # the tunnel boot ran before the boot plan and /healthz didn't answer
+    # until the plan's LAST stage, so a slow tunnel crash-looped every new
+    # worker pod during a rollout. The liveness thread now boots first and
+    # depends on nothing any other stage sets up, so a slow tunnel no longer
+    # risks the probe.
+
+    @unit
+    Scenario: The liveness server boots before every other stage, including the voice tunnel
+      Given the worker boot plan is resolved
+      Then the metrics stage is first in the plan
+      # startWorkers boots exactly this "metrics" stage, before it resolves
+      # the voice public URL tunnel, so /healthz is answering the kubelet
+      # for the entire duration of a slow tunnel mint.
+
   Rule: The chart probes the liveness endpoint, not the metrics endpoint
 
     @e2e @unimplemented


### PR DESCRIPTION
## Summary

Prod phone calls have been failing with Twilio error 31920 since #8071. Root cause, confirmed firsthand:

- Production's tunnel-mint call chain (`voice-public-url-tunnel.ts` → the vendored `@langwatch/scenario` SDK's `openTwilioTunnel`, cloudflared provider) opens its quick tunnel with a **bare `spawn("cloudflared", ...)`** — a plain PATH lookup. It does not use the npm `cloudflared` package's `Tunnel` class, does not read a `CLOUDFLARED_BIN` env, and does not call that package's `install()`.
- `cloudflared` was also missing from `onlyBuiltDependencies`, so under pnpm 10 its postinstall (which downloads the npm package's own binary) never ran anywhere, including CI — confirmed via `node_modules/.modules.yaml`'s `ignoredBuilds` list and a missing `bin/` directory in an already-installed worktree.
- Fixing only the allowlist (this PR's original commit) is **not sufficient**: even with the npm package's binary downloaded, nothing puts its directory on PATH for the SDK's bare spawn, so the dial still fails with `spawn cloudflared ENOENT`.
- At worker boot, the failed mint was swallowed — logged, but not recorded on any trace, and the specific cause was discarded. The worker then kept claiming voice jobs and the phone transport silently fell back to `BASE_HOST` (the app's own origin, `https://app.langwatch.ai`), which runs no voice media listener — hence Twilio dialing a URL nothing answers, error 31920 after a 120s timeout, with nothing attached to the run's own trace.

Fix, now four parts:

1. **`onlyBuiltDependencies: cloudflared`** in `pnpm-workspace.yaml` — still valuable: it means the npm package's binary is normally already on disk at image-build time.
2. **`ensureCloudflaredOnPath()`** (new `voice-cloudflared-binary.ts`), run before the SDK's `openTunnel`: short-circuits if `cloudflared` is already resolvable on PATH; otherwise resolves the npm package (searching scopes in dependency-truth order — the `langwatch` SDK scope first, since that's the real dependency edge, then `@langwatch/scenario`, then the app's own scope), installs the binary as a fallback only if the build-time postinstall didn't produce it (bounded by a 60s timeout), then prepends its directory to PATH so the SDK's bare spawn finds it. Any failure throws `VoiceTunnelBinaryError` with the full cause chain.
3. **Fail fast, with the real cause, visibly** — `startWorkers.ts`'s tunnel-mint boot is now traced under the `voice.public_url_tunnel.boot` span (`tracer.withActiveSpan`), records the exception + ERROR status on that span, and threads the specific failure reason (e.g. `spawn cloudflared ENOENT`) through a new env var into the child process the same way `VOICE_PUBLIC_BASE_URL` already is. `phone.transport.ts` refuses to build the outbound adapter when only `BASE_HOST` (or nothing) resolves, throwing `VoicePublicBaseUrlMissingError` whose message now names that real cause instead of a generic "no public media URL" (e.g. `"cloudflared tunnel binary unavailable: ... spawn cloudflared ENOENT"`) — and this too is recorded as an exception + ERROR span on the run's own trace via `tracer.withActiveSpan`.
4. **Telemetry hygiene** — the resolved Twilio media-stream base URL is now recorded on spans/logs as its origin only, never the full URL (which could carry credentials/query params), per CWE-532.

Spec (`specs/features/agents/voice-phone.feature`) and unit tests updated/extended to cover the PATH-fixup module, the scope-resolution order, the reason-propagation, and both fail-fast paths.

## Human verification

1. Deploy this branch and confirm the built image has `node_modules/.pnpm/cloudflared@*/node_modules/cloudflared/bin/cloudflared` present (nonzero size, ~30MB), resolvable via the `langwatch` SDK scope.
2. On **Drew's Sandbox**, call `POST /api/v1/run-plans/run` targeting a voice (phone) agent and confirm the run reaches actual conversation messages — no Twilio error 31920, no silent 120s timeout.
3. Temporarily break tunnel minting (e.g. no network egress to the cloudflared release, or delete/rename the binary before boot) and confirm:
   - (a) the `voice.public_url_tunnel.boot` span on worker boot records the exception (ERROR status, real cause attached — e.g. `spawn cloudflared ENOENT`);
   - (b) a phone run against that worker fails immediately with a `VoicePublicBaseUrlMissingError` whose message reads `"cloudflared tunnel binary unavailable: ..."` and names the real cause (`spawn cloudflared ENOENT` or equivalent) rather than a generic "no public media URL";
   - (c) that error is recorded as an exception + ERROR span on the run's own trace — not a silent Twilio timeout.


**Hardening added after review (HEAD `8951909`): liveness-before-tunnel boot order.** The voice tunnel boot (up to 60s cloudflared install + up to 300s DoH readiness wait) previously ran before the worker's `/healthz` liveness thread was listening, and `metrics` was the LAST boot-plan stage. In prod (`infrastructure/langwatch_workers.tf:505-539`: liveness initial_delay 30s, period 10s, failure_threshold 6 -> ~90s budget), a slow tunnel mint left `/healthz` silent past that budget and the kubelet killed the pod mid-mint, crash-looping a fleet rollout. Fixed by moving `metrics` to the head of `resolveWorkerBootPlan` and booting it in `startWorkers` before the voice env/tunnel resolve. **Post-deploy human check:** watch `kubectl get pods -l app=langwatch-workers` during the rollout and confirm no restarts/CrashLoopBackOff while pods come up (this is the scenario the fix targets and cannot be proven from this sandbox).
**Note:** step 3 requires a live deploy and cannot be executed from this sandbox (its dev-worktree equivalent was run instead — see "How I can prove I was successful" below). **Step 2's dev-equivalent has now been executed for real** (not from Drew's Sandbox, but from a locally-booted worker at this PR's actual HEAD against the real dev Postgres/Redis/ClickHouse and a real outbound Twilio call, no mocks): `scenariorun_0006wkfkzB2fzNBkWIUOOXfnYWmR1` reached `status: SUCCESS` with real conversation messages and Twilio CallSid `CAdcb8e51558dad17ac19ed8f393b86388` — no 31920, no silent timeout. The Drew's Sandbox / prod run itself is still the human step to perform after deploy; its run id will be added here as evidence at that time.

**Verified in production (2026-09-13, post-merge/post-deploy):** confirmed via `gh api` that the deployed prod tag (`git-def043b`) contains this PR's merge commit (`4b419d56d1ac50305de71657174dc06d84eecd38` is an ancestor of the deployed `langwatch` submodule sha, 0 ahead / 21 behind). Triggered a real run against **Drew's Sandbox** (`POST /api/v1/run-plans/run`, `scenario_00055j7tSm8PVITUm8GjWUiSfQjP3`, target `agent_IaJuRYY8MdHsW-fjd1uo3`): `scenariorun_0006gNDRmHoghqSv5jKHSeXpk8lW7` reached `status: SUCCESS`, verdict `success`, both criteria met, `trace_id: 09ab796601649bfd18f0b220d1872190`, `durationInMs: 59101`, no error. Cross-checked directly against the Twilio REST API: call `CA06182b2d8e183e5b46507e6f6eb26cd7`, status `completed`, duration `53s`, and zero Twilio Alerts in the surrounding window. This is the human-verification step 2 above, now completed for real against prod. Full detail: https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-8081/proof.txt

## How I can prove I was successful

- `pnpm-workspace.yaml`: `cloudflared` added to `onlyBuiltDependencies`.
- `voice-cloudflared-binary.ts` + its unit tests: BDD tests covering the PATH short-circuit, existsSync short-circuit, install-fallback success/failure/timeout paths, and the scope-resolution order (langwatch SDK scope tried first, falls back to `@langwatch/scenario` then app scope, throws naming all tried scopes if none resolve) — all with injected fs/install/spawn/require.
- `phone.transport.ts`, `startWorkers.ts`, `child-environment.ts`, `voice-public-url-tunnel.ts`: unit tests across `phone.transport.unit.test.ts` (34 passed), `voice-public-url-tunnel.unit.test.ts`, `voice-boot-non-fatal.unit.test.ts`, `child-environment.unit.test.ts`, `voice-cloudflared-binary.unit.test.ts` (20 passed across the tunnel/binary pair) — log output confirms the reason threading end-to-end (`"reason":"cloudflared tunnel binary unavailable: spawn cloudflared ENOENT"`).
- Resolver behavior verified empirically (not just mocked) against a real installed `node_modules` tree in a sibling worktree: the `langwatch` scope resolves cloudflared's real `bin` path; the `@langwatch/scenario` scope does not (confirming it is not a valid primary resolution path).
- **Live worker-boot proof against this PR's actual HEAD (`8793d2edb`), real install, real failure — not mocks**: ran `src/workers.ts` from this branch with `/usr/local/bin` stripped from `PATH` (so the system `cloudflared` at `/usr/local/bin/cloudflared` was unreachable) and `VOICE_PUBLIC_BASE_URL`/`VOICE_WS_PORT`/`CLOUDFLARED_BIN` unset, against the real dev Postgres/Redis/ClickHouse.
  - **Positive path (real download, not the already-present fallback)**: `ensureCloudflaredOnPath()` resolved `cloudflared` via the `langwatch` SDK scope and ran the npm package's real `install()` — the binary `.../node_modules/.pnpm/cloudflared@0.7.1/node_modules/cloudflared/bin/cloudflared` was freshly created on disk (37,466,252 bytes, birth timestamp mid-boot, confirmed via `stat`) rather than already existing. Boot log: `INFO (langwatch:workers): voice public URL tunnel ready {"url":"https://emotions-valid-disk-refined.trycloudflare.com"}`, followed by `voice media listener ready on port 3300` — no exception on the `voice.public_url_tunnel.boot` span, worker reached steady state.
  - **Negative path (binary unresolvable from every scope)**: with the installed `cloudflared` npm package directory renamed out of the pnpm store (so `require.resolve` fails for `langwatch`, `@langwatch/scenario`, and the app's own scope alike) and the worker restarted, boot failed with the exact designed error: `ERROR (langwatch:workers): voice public URL tunnel failed to open; voice runs on this worker will fail until it restarts` — `VoiceTunnelBinaryError: cloudflared tunnel binary unavailable: could not resolve the cloudflared package: could not resolve the cloudflared package from any of: langwatch, @langwatch/scenario, app scope`, stack through `ensureCloudflaredOnPath` → `resolveCloudflaredFromScopes` → `openVoicePublicUrlTunnel`. Critically, this failed **non-fatally** — the worker process stayed up and continued booting its other components (matches `voice-boot-non-fatal.unit.test.ts`), rather than crashing the whole worker.
  - Cleanup: worker killed, renamed package directory restored, binary restored, all symlinks used to wire this sibling worktree's `node_modules`/`.env` into this PR's worktree removed, no changes left in this worktree's git status.
  - This exercises the actual mechanism the prod incident needed (real binary resolution/download/failure through this PR's code, against a real running worker).
  - **Update: real end-to-end Twilio phone call placed (no mocks, real spend)** — re-booted the worker the same way (binary was already present from the run above, so this boot exercised the "already present" branch), then triggered a real run via `POST /api/v1/run-plans/run` against the banked dev scenario (`scenario_0006lLQuwntHPvNBhdHy42UBgY6Lr`, target `agent_V9LbNjn1mAxGl6cAFZl_Q`, phone `+3197010223578`). Polled `GET /api/simulation-runs/<id>` to terminal: **`status: SUCCESS`**, verdict `success`, both criteria met, **4 messages** with real `input_audio` WAV attachments, `trace_id: 92e6c355944c5ceafbb7bbfa44056657`, `durationInMs: 146825`. Cross-checked the OTel spans for that trace in ClickHouse (server-emitted, not fixtures): `voice.adapter.dial` span shows `voice.twilio.direction: outbound`, **`voice.twilio.call_sid: CAdcb8e51558dad17ac19ed8f393b86388`**, `voice.twilio.phone_number_sid: PNf7bc825e9bd759115bee95923db014cd`, `voice.twilio.record: true`; two `TwilioAgentAdapter.call` spans covering the two conversation turns (52,679 ms + 37,000 ms = ~89.7s of live call audio, well over 1s). Could **not** additionally cross-check this CallSid against the Twilio REST API or the `monitor.twilio.com` Alerts console directly — the 1Password CLI in this sandbox has no signed-in account and no Twilio account SID/auth token were found in the worktree `.env`/`.env.portless`/Postgres/Agent config; this gap is called out rather than fabricated. Full detail in the proof file linked below.
  - Cleanup performed after both passes: worker killed and confirmed dead by PID, ports 3300/2999 confirmed free, renamed/moved package directories and binary restored, all `node_modules`/`.env` symlinks used to wire the sibling worktree into this PR's worktree removed, `git status` clean in this PR's worktree.
  - Full boot-log + real-call excerpt (both paths, verbatim): https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-8081/proof.txt
- **Liveness-before-tunnel fix (HEAD `8951909`)**: `resolveWorkerBootPlan` now puts `metrics` first (`worker-boot-plan.ts`), and `startWorkers` boots it before resolving the voice env / opening the tunnel, filtering `metrics` out of the main stage loop so it isn't booted twice. `worker-boot-plan.unit.test.ts`: added a test pinning `plan[0] === "metrics"` and updated the full-plan assertion to the new order — 4/4 tests pass. Bound to a new scenario in `specs/server/worker-liveness-probe.feature` ("The liveness server boots before every other stage, including the voice tunnel"). Ran the full `src/server/workers/__tests__/` suite: 6 files, 30/30 tests pass. `biome check` on the 3 touched files: clean, 0 diagnostics (also split a helper out of `startWorkers` to stay under the line-count lint budget). `npx tsx scripts/check-feature-parity.ts`: exit 0, 12576 enforced scenarios bound, the new scenario included.
- `biome check` on all touched TypeScript files: clean, 0 diagnostics.
- `npx tsx scripts/check-feature-parity.ts` (run from `platform/app`): exit 0, `56/56 scenarios bound` in `voice-phone.feature`, no dangling/unknown `@scenario` annotations.
- CodeRabbit review: both flagged findings addressed — the CWE-532 telemetry leak (full URL → origin-only) and the named-parameter-object style nit (`withTimeout`, `prependToPath`, `ensureBinaryPresent`) — both threads replied to and resolved.
- Did not run `pnpm typecheck`/`tsc` or `pnpm install`/build locally (disk/OOM constraints on this box) — covered by CI instead.
- **Prod proof is post-deploy**: the human-verification steps above (2 and 3) require a live deploy against Drew's Sandbox. A real prod/sandbox run id demonstrating a successful voice run (and, ideally, one demonstrating the fail-fast error path) will be added to this section after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Phone calls now stop before dialing when a publicly reachable media URL is unavailable.
  - Errors identify missing URL configuration and tunnel startup failures instead of falling back to an internal host.

- **Reliability**
  - Voice workers ensure cloudflared is available before opening a tunnel.
  - Existing, installed, or downloadable binaries are supported, with clear errors for resolution, download, and timeout failures.
  - Liveness checks start before potentially lengthy tunnel setup.

- **Observability**
  - Phone setup records public URL sources and tunnel failure details for improved diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->




