### PR TITLE
feat(governance): simpler source composer for Anthropic and OpenAI admin pulls

### DIFF
--- a/platform/app/ee/governance/dashboard/components/__tests__/AddIngestionSourceMenu.integration.test.tsx
+++ b/platform/app/ee/governance/dashboard/components/__tests__/AddIngestionSourceMenu.integration.test.tsx
@@ -65,7 +65,7 @@ describe("given the Add source menu", () => {
         "Workato",
         "Microsoft Copilot Studio",
         "OpenAI Admin",
-        "Anthropic Admin API (usage & cost)",
+        "Anthropic Admin API",
         "Databricks AI/BI Genie",
         "Custom S3 audit log",
         "Custom HTTP audit-log API",
@@ -90,6 +90,19 @@ describe("given the Add source menu", () => {
       ]) {
         expect(screen.queryByText(withheld)).toBeNull();
       }
+    });
+
+    /** @scenario "A type is named after the product, not after what it returns" */
+    it("names the Anthropic type after the product, not after its reports", async () => {
+      renderMenu({ isEnterprise: true });
+      await openMenu();
+
+      // The label was "Anthropic Admin API (usage & cost)". A menu is for
+      // picking a product; which report a source pulls is a question the
+      // composer asks two fields later, where the admin can actually answer
+      // it. The parenthetical was an answer offered where no choice was.
+      expect(screen.getByText("Anthropic Admin API")).toBeTruthy();
+      expect(screen.queryByText(/usage\s*&\s*cost/i)).toBeNull();
     });
 
     /** @scenario "Add source menu lists every type by vendor, grouped in plain language" */

--- a/platform/app/ee/governance/dashboard/components/ingestionSourceCatalog.tsx
+++ b/platform/app/ee/governance/dashboard/components/ingestionSourceCatalog.tsx
@@ -222,7 +222,11 @@ export const SOURCE_TYPE_OPTIONS = [
   },
   {
     value: "anthropic_admin",
-    label: "Anthropic Admin API (usage & cost)",
+    // Named after the product. Which report a source pulls is a question the
+    // composer asks two fields later, where the admin can actually answer it;
+    // the old "(usage & cost)" put the answer in a menu that offered no
+    // choice between them.
+    label: "Anthropic Admin API",
     mode: "pull",
     blurb:
       "Polls Anthropic's organization usage/cost reports with an Admin API key (sk-ant-admin-...). Pick ONE report per source: usage (token counts, we price them) or cost (Anthropic's reported spend, excludes Priority Tier). Never create both for the same org — the same spend would be counted twice.",
@@ -413,10 +417,14 @@ export function SourceTypeIconGlyph({
   const icon = SOURCE_TYPE_OPTIONS.find((o) => o.value === sourceType)?.icon;
   if (!icon) return null;
   return (
-    <IconGlyph
-      icon={icon}
-      monochrome={MONOCHROME_SOURCE_ICONS.has(sourceType)}
-      size={size}
-    />
+    // The mark carries no text, so a test asserting a header shows the vendor
+    // has nothing else to find it by.
+    <span data-testid="source-type-icon">
+      <IconGlyph
+        icon={icon}
+        monochrome={MONOCHROME_SOURCE_ICONS.has(sourceType)}
+        size={size}
+      />
+    </span>
   );
 }

--- a/platform/app/ee/governance/dashboard/components/ingestionSourceCatalog.tsx
+++ b/platform/app/ee/governance/dashboard/components/ingestionSourceCatalog.tsx
@@ -417,14 +417,11 @@ export function SourceTypeIconGlyph({
   const icon = SOURCE_TYPE_OPTIONS.find((o) => o.value === sourceType)?.icon;
   if (!icon) return null;
   return (
-    // The mark carries no text, so a test asserting a header shows the vendor
-    // has nothing else to find it by.
-    <span data-testid="source-type-icon">
-      <IconGlyph
-        icon={icon}
-        monochrome={MONOCHROME_SOURCE_ICONS.has(sourceType)}
-        size={size}
-      />
-    </span>
+    <IconGlyph
+      icon={icon}
+      monochrome={MONOCHROME_SOURCE_ICONS.has(sourceType)}
+      size={size}
+      testId="source-type-icon"
+    />
   );
 }

--- a/platform/app/ee/governance/dashboard/components/ingestionSourceCatalog.tsx
+++ b/platform/app/ee/governance/dashboard/components/ingestionSourceCatalog.tsx
@@ -410,9 +410,17 @@ const MONOCHROME_SOURCE_ICONS = new Set<SourceType>([
 export function SourceTypeIconGlyph({
   sourceType,
   size = "16px",
+  testId,
 }: {
   sourceType: SourceType;
   size?: string | number;
+  /**
+   * Named by the caller rather than fixed here: this renders on the menu, the
+   * composer, the list rows and the edit title, and one id shared by all of
+   * them would make `getByTestId` ambiguous the first time two appear on one
+   * screen. Callers that nothing queries pass nothing.
+   */
+  testId?: string;
 }) {
   const icon = SOURCE_TYPE_OPTIONS.find((o) => o.value === sourceType)?.icon;
   if (!icon) return null;
@@ -421,7 +429,7 @@ export function SourceTypeIconGlyph({
       icon={icon}
       monochrome={MONOCHROME_SOURCE_ICONS.has(sourceType)}
       size={size}
-      testId="source-type-icon"
+      testId={testId}
     />
   );
 }

--- a/platform/app/ee/governance/dashboard/logic/pullCadence.ts
+++ b/platform/app/ee/governance/dashboard/logic/pullCadence.ts
@@ -90,6 +90,58 @@ export const PULL_SCHEDULE_DEFAULTS: Record<string, string> = {
   http_polling: "*/15 * * * *",
 };
 
+/**
+ * How many months of history a NEWLY added source proposes to read, per source
+ * type.
+ *
+ * A source added with no start date reads only the last few days, so the
+ * Activity Monitor shows a flat line on the day the admin finishes setting it
+ * up — the moment they are most likely to conclude the integration is broken.
+ * The form therefore proposes a start rather than leaving the field empty. It
+ * is a proposal and nothing more: the admin can move it, and clearing it still
+ * means the adapter's own default.
+ *
+ * The figures differ because the providers do, and because reading further
+ * back is not free — every extra month is more pages on the first run. OpenAI
+ * serves four years, so a year is a deliberate choice rather than a limit:
+ * enough to show a year-on-year trend on day one without a first run that
+ * reads four years of days, and it fits in a single run. Six months of
+ * Anthropic is about six pages at the adapter's daily bucket, well inside
+ * `MAX_PAGES_PER_RUN`.
+ *
+ * Beside the cadence defaults and in one table for the same reason they are:
+ * the proposal and any copy describing it have to read one source, or the form
+ * proposes one span while the hint beside it names another.
+ */
+export const SOURCE_BACKFILL_MONTHS: Partial<Record<SourceType, number>> = {
+  openai_admin: 12,
+  anthropic_admin: 6,
+};
+
+/**
+ * The instant a new source of this type proposes to read history from:
+ * midnight UTC, that many months before today.
+ *
+ * Midnight UTC because every one of these reports is bucketed by UTC day, so a
+ * start in the middle of one asks for a partial bucket the provider will not
+ * serve. Undefined for a source type with no proposal, which leaves the field
+ * empty and the adapter's own default in charge.
+ */
+export function defaultBackfillStart(
+  sourceType: SourceType,
+): string | undefined {
+  const months = SOURCE_BACKFILL_MONTHS[sourceType];
+  if (months === undefined) return undefined;
+  const now = new Date();
+  return new Date(
+    Date.UTC(
+      now.getUTCFullYear(),
+      now.getUTCMonth() - months,
+      now.getUTCDate(),
+    ),
+  ).toISOString();
+}
+
 /** The recommended schedule for a source type, or null when it has no
  *  pull adapter (push and s3 sources carry no cadence). */
 export function recommendedPullSchedule(sourceType: SourceType): string | null {

--- a/platform/app/ee/governance/dashboard/logic/pullCadence.ts
+++ b/platform/app/ee/governance/dashboard/logic/pullCadence.ts
@@ -128,6 +128,13 @@ export const SOURCE_BACKFILL_MONTHS: Partial<Record<SourceType, number>> = {
  * start in the middle of one asks for a partial bucket the provider will not
  * serve. Undefined for a source type with no proposal, which leaves the field
  * empty and the adapter's own default in charge.
+ *
+ * The day is clamped to the target month's last, because `Date.UTC` rolls an
+ * impossible day forward instead of refusing it: six months before the 31st of
+ * August is the 31st of February, which arrives as the 3rd of March. The
+ * proposal would then be five months back on a form whose hint says six.
+ * Clamping lands on the 28th, which is what "six months before" means for a
+ * month that has no 31st.
  */
 export function defaultBackfillStart(
   sourceType: SourceType,
@@ -135,13 +142,13 @@ export function defaultBackfillStart(
   const months = SOURCE_BACKFILL_MONTHS[sourceType];
   if (months === undefined) return undefined;
   const now = new Date();
-  return new Date(
-    Date.UTC(
-      now.getUTCFullYear(),
-      now.getUTCMonth() - months,
-      now.getUTCDate(),
-    ),
-  ).toISOString();
+  const year = now.getUTCFullYear();
+  const month = now.getUTCMonth() - months;
+  // Day 0 of the following month is the last day of this one, and Date.UTC
+  // normalizes a month outside 0-11 into the right year on the way.
+  const lastDayOfTarget = new Date(Date.UTC(year, month + 1, 0)).getUTCDate();
+  const day = Math.min(now.getUTCDate(), lastDayOfTarget);
+  return new Date(Date.UTC(year, month, day)).toISOString();
 }
 
 /** The recommended schedule for a source type, or null when it has no

--- a/platform/app/ee/governance/dashboard/logic/pullCadence.ts
+++ b/platform/app/ee/governance/dashboard/logic/pullCadence.ts
@@ -105,9 +105,11 @@ export const PULL_SCHEDULE_DEFAULTS: Record<string, string> = {
  * back is not free — every extra month is more pages on the first run. OpenAI
  * serves four years, so a year is a deliberate choice rather than a limit:
  * enough to show a year-on-year trend on day one without a first run that
- * reads four years of days, and it fits in a single run. Six months of
- * Anthropic is about six pages at the adapter's daily bucket, well inside
- * `MAX_PAGES_PER_RUN`.
+ * reads four years of days. Neither figure is sized against a page count:
+ * the Anthropic adapter asks for no page size, so how many pages a span
+ * costs is the provider's to decide. A first read may well take several runs,
+ * and that is fine — a run that reaches its page cap saves the cursor and the
+ * next one resumes from it.
  *
  * Beside the cadence defaults and in one table for the same reason they are:
  * the proposal and any copy describing it have to read one source, or the form

--- a/platform/app/ee/governance/dashboard/pages/__tests__/anthropicAdminPullConfig.unit.test.ts
+++ b/platform/app/ee/governance/dashboard/pages/__tests__/anthropicAdminPullConfig.unit.test.ts
@@ -68,18 +68,10 @@ describe("buildAnthropicAdminPullConfig", () => {
     expect(parsed.bucketWidth).toBe("1h");
   });
 
-  it("given an invalid report, bucket width, or start date, refuses to build", () => {
+  it("given an invalid report or start date, refuses to build", () => {
     const base = { credentialsToken: "sk-ant-admin-test", report: "cost" };
     expect(
       buildAnthropicAdminPullConfig(composer({ ...base, report: "both" })),
-    ).toBeNull();
-    // Deliberately `usage`, not the `cost` of `base`: on a cost report the
-    // usage-only gate rejects any width first, so this assertion would pass
-    // with the value check deleted and prove nothing about "2h".
-    expect(
-      buildAnthropicAdminPullConfig(
-        composer({ ...base, report: "usage", bucketWidth: "2h" }),
-      ),
     ).toBeNull();
     expect(
       buildAnthropicAdminPullConfig(
@@ -91,19 +83,25 @@ describe("buildAnthropicAdminPullConfig", () => {
     ).toBeNull();
   });
 
-  it("given a bucket width on a cost report, refuses to build", () => {
-    // The puller sends COST_REPORT_BUCKET_WIDTH and ignores config.bucketWidth,
-    // so saving one on a cost source records a setting that never applies —
-    // which is the opposite of what the field's own hint promises.
+  it("given a bucket width it cannot honour, drops it instead of refusing", () => {
+    // The form stopped asking for a width, so a refusal here would block the
+    // save over a control that is not on the screen. Both of these are widths
+    // the adapter would not honour as given: `2h` is not in its domain at all,
+    // and on a cost report the puller sends COST_REPORT_BUCKET_WIDTH and
+    // ignores the setting, so any width there was never in effect.
+    const base = { credentialsToken: "sk-ant-admin-test" };
+
     expect(
       buildAnthropicAdminPullConfig(
-        composer({
-          credentialsToken: "sk-ant-admin-test",
-          report: "cost",
-          bucketWidth: "1h",
-        }),
+        composer({ ...base, report: "usage", bucketWidth: "2h" }),
       ),
-    ).toBeNull();
+    ).toMatchObject({ bucketWidth: "1d" });
+
+    const onCost = buildAnthropicAdminPullConfig(
+      composer({ ...base, report: "cost", bucketWidth: "1h" }),
+    );
+    expect(onCost).not.toBeNull();
+    expect(onCost).not.toHaveProperty("bucketWidth");
   });
 
   it("given a start date that is impossible or timezone-less, refuses to build", () => {

--- a/platform/app/ee/governance/dashboard/pages/__tests__/anthropicFormControls.unit.test.ts
+++ b/platform/app/ee/governance/dashboard/pages/__tests__/anthropicFormControls.unit.test.ts
@@ -360,6 +360,10 @@ describe("Anthropic composer controls", () => {
       expect(hint).toMatch(/first day/i);
       expect(hint).toMatch(/forward|where the last/i);
       expect(hint).toMatch(/clear/i);
+      // Said here, where the date is still a choice. The edit drawer explains
+      // the lock too, but by then the admin has already made the choice it
+      // constrains.
+      expect(hint).toMatch(/fixed once the source has pulled/i);
     });
 
     // @scenario "A new Anthropic source proposes six months of history"

--- a/platform/app/ee/governance/dashboard/pages/__tests__/anthropicFormControls.unit.test.ts
+++ b/platform/app/ee/governance/dashboard/pages/__tests__/anthropicFormControls.unit.test.ts
@@ -1,28 +1,32 @@
 // SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
 
 /**
- * The Anthropic composer's three closed-domain fields, and the one place their
- * domains are allowed to be written down.
+ * The Anthropic composer's three adapter settings, and the one place each of
+ * them is allowed to be written down.
  *
- * `report` and `bucketWidth` are enums the puller already declares; `startingAt`
- * is an instant. Rendering them as free text meant the domain lived in a hint,
- * and the admin found out they had mistyped it from a rejected save. Rendering
- * them as pickers moves the domain into the form — which is only an improvement
- * while the form's list and the adapter's schema still say the same thing, so
- * the option lists are asserted against `anthropicAdminPullConfigSchema` rather
- * than against a second hand-written copy of themselves.
+ * All three used to be asked the same way — a picker, or a free-text box with
+ * the domain in a hint — and all three were the wrong shape for the question.
+ * `report` has two states and a right answer for almost everyone, which is a
+ * toggle. `bucketWidth` has one correct answer for every screen that reads the
+ * data, so it is no longer asked at all. `startingAt` is a date, and the word
+ * for it on the form is now the admin's word rather than ours.
  *
- * The startingAt field carries the subtler risk. Every value that reaches
- * storage has been through `normalizeStartingAt`, which returns an ISO instant
- * — so the edit form always seeds an instant, never a calendar date, and a
- * plain `<input type="date">` handed one renders blank. Blank on an edit form
- * reads as "no backfill start configured", and saving from there would drop a
- * setting the admin never touched. The date control therefore shows the
- * instant's calendar date and leaves the underlying value alone until the
- * admin actually picks a new one.
+ * Two risks survive that rework and are what most of this file measures.
+ *
+ * The toggle stores "cost" and "usage", not "true" and "false", because the
+ * adapter's schema is unchanged and every source already saved holds those
+ * words. A switch that wrote the boolean strings would open every existing
+ * usage source in the on position and save it as cost on the next unrelated
+ * edit, so the two values a switch reads and writes are declared on the field.
+ *
+ * The bucket width is withdrawn from the form without being withdrawn from the
+ * sources already reading at one. It stays declared and hidden rather than
+ * deleted: the seed and the edit-save path both walk the declared fields, so a
+ * field the form stops declaring is a field the edit path silently drops — an
+ * hourly source migrated to daily by opening its drawer and changing its name.
  */
 
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { anthropicAdminPullConfigSchema } from "../../../services/pullers/anthropicAdmin.puller";
 import {
   ANTHROPIC_BUCKET_WIDTHS,
@@ -31,9 +35,13 @@ import {
   dateInputValue,
   defaultParserValues,
   fieldControl,
+  missingRequiredParserFieldKeys,
   PARSER_FIELDS,
   reconcileParserValues,
   seedComposerParserConfig,
+  switchFieldIsOn,
+  switchReadOnlyLabel,
+  visibleParserFields,
 } from "../inventory";
 
 const fieldFor = (key: string) => {
@@ -42,12 +50,12 @@ const fieldFor = (key: string) => {
   return field;
 };
 
-const selectOptionsFor = (key: string, values: Record<string, string>) => {
+const switchControlFor = (key: string, values: Record<string, string>) => {
   const control = fieldControl({ field: fieldFor(key), values });
-  if (control.kind !== "select") {
-    throw new Error(`${key} is rendered as ${control.kind}, not a select`);
+  if (control.kind !== "switch") {
+    throw new Error(`${key} is rendered as ${control.kind}, not a switch`);
   }
-  return control.options;
+  return control;
 };
 
 const composerWith = (parserConfig: Record<string, string>): ComposerState => ({
@@ -62,90 +70,221 @@ const composerWith = (parserConfig: Record<string, string>): ComposerState => ({
   traceProjectId: null,
 });
 
-describe("Anthropic composer controls", () => {
-  describe("the report field", () => {
-    // @scenario "The report offers the two reports that exist and nothing else"
-    it("offers exactly the reports the adapter schema declares", () => {
-      const offered = selectOptionsFor("report", {})
-        .map((o) => o.value)
-        .filter((v) => v !== "");
+/** What the report toggle holds when it is on, and when it is off. */
+const reportWhenOn = () => switchControlFor("report", {}).onValue;
+const reportWhenOff = () => switchControlFor("report", {}).offValue;
 
-      expect(offered).toEqual([
-        ...anthropicAdminPullConfigSchema.shape.report.options,
-      ]);
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("Anthropic composer controls", () => {
+  describe("the report toggle", () => {
+    // @scenario "The report is one toggle named for what the admin gets"
+    it("is a toggle, named for what the admin gets rather than for a report", () => {
+      expect(switchControlFor("report", {}).kind).toBe("switch");
+      expect(fieldFor("report").label).toBe("Use Anthropic's reported cost");
     });
 
-    // @scenario "The report opens on the one almost every organization wants"
-    it("opens on the cost report rather than on nothing", () => {
-      // Through the seeding path the drawer actually uses, not off the field
-      // definition: a default that only exists on the FieldDef and is never
-      // seeded shows an answer the builder is not handed.
-      expect(defaultParserValues("anthropic_admin").report).toBe("cost");
+    // @scenario "The toggle explains both sides in plain words"
+    it("explains both sides, and that a source records one of them only", () => {
+      // A toggle's label can only name one side. Everything the old two-entry
+      // picker conveyed by listing both reports now has to be in the hint, or
+      // the admin turning it off is not told what they are turning it on to.
+      const hint = fieldFor("report").hint ?? "";
 
-      // And it has to be a report that is really offered, or the picker
-      // displays a value with no matching option and shows nothing at all.
-      expect(selectOptionsFor("report", {}).map((o) => o.value)).toContain(
-        "cost",
+      expect(hint).toMatch(/spend/i);
+      expect(hint).toMatch(/token|counts/i);
+      expect(hint).toMatch(/price/i);
+      expect(hint).toMatch(/one report|never both|not both/i);
+    });
+
+    // @scenario "A new source opens on the provider's own cost figure"
+    it("opens on the cost report, through the path the drawer actually seeds", () => {
+      // Off the seeding path rather than off the field definition: a default
+      // that exists only on the FieldDef and is never seeded shows one answer
+      // and hands the builder another.
+      expect(defaultParserValues("anthropic_admin").report).toBe("cost");
+      expect(switchControlFor("report", {}).defaultOn).toBe(true);
+
+      const built = buildAnthropicAdminPullConfig(
+        composerWith(defaultParserValues("anthropic_admin")),
+      );
+
+      expect(built).toMatchObject({ report: "cost" });
+    });
+
+    // @scenario "Turning the toggle off records the usage report"
+    it("records the usage report when it is turned off", () => {
+      // The values the switch reads and writes are the adapter's own words.
+      // `anthropicAdmin.puller.ts` is untouched by this rework and every
+      // source already saved holds one of these two strings.
+      expect(reportWhenOn()).toBe("cost");
+      expect(reportWhenOff()).toBe("usage");
+
+      const built = buildAnthropicAdminPullConfig(
+        composerWith({ report: reportWhenOff() }),
+      );
+
+      expect(built).toMatchObject({ report: "usage" });
+    });
+
+    // @scenario "A source saved on the usage report opens with the toggle off"
+    it("opens off for a source saved on the usage report", () => {
+      const seeded = seedComposerParserConfig({
+        sourceType: "anthropic_admin",
+        storedParserConfig: { report: "usage", bucketWidth: "1d" },
+      });
+      const control = switchControlFor("report", seeded);
+
+      // The whole reason the two values are declared. Read as "true"/"false",
+      // "usage" is neither, so the field would fall back to its default and
+      // open ON — and the next unrelated edit would save this source as cost.
+      expect(
+        switchFieldIsOn({
+          value: seeded.report,
+          defaultOn: control.defaultOn,
+          onValue: control.onValue,
+          offValue: control.offValue,
+        }),
+      ).toBe(false);
+
+      expect(
+        buildAnthropicAdminPullConfig(
+          composerWith({ ...seeded, credentialsToken: "sk-ant-admin-test" }),
+        ),
+      ).toMatchObject({ report: "usage" });
+    });
+
+    // @scenario "The report can no longer be left unanswered"
+    it("has no empty state left to refuse a save over", () => {
+      // The picker carried an entry with no value so a cleared field could be
+      // refused rather than quietly refilled. A toggle is one of two states,
+      // so the field is never empty and the refusal has nothing to fire on.
+      expect(
+        missingRequiredParserFieldKeys({
+          sourceType: "anthropic_admin",
+          values: {},
+        }),
+      ).not.toContain("report");
+
+      // Which is only safe while the seed really does answer it. A required
+      // flag removed from a field the form can still leave blank is how a
+      // save gets refused with nothing marked on the form.
+      expect(defaultParserValues("anthropic_admin").report).toBeTruthy();
+    });
+
+    // @scenario "A locked report names the report rather than a switch position"
+    it("names the report it holds when it is locked, rather than a position", () => {
+      const control = switchControlFor("report", {});
+
+      // "Off" is the position of a control the admin can no longer see. The
+      // question a locked field has to answer is which report this source
+      // records.
+      expect(switchReadOnlyLabel({ control, value: "usage" })).toBe(
+        "Usage report",
+      );
+      expect(switchReadOnlyLabel({ control, value: "cost" })).toBe(
+        "Cost report",
       );
     });
 
-    // @scenario "The report opens on the one almost every organization wants"
-    it("still offers an entry carrying no value, so the choice can be cleared", () => {
-      const options = selectOptionsFor("report", {});
+    // @scenario "A locked report names the report rather than a switch position"
+    it("still reads On and Off for a switch that declares no labels of its own", () => {
+      // The report is the only switch on any composer whose two states have
+      // names of their own. Every other one is a plain on/off, and the labels
+      // are optional precisely so those are left alone.
+      const plain = fieldControl({
+        field: {
+          key: "x",
+          label: "x",
+          // Required on every field, and meaningless on a switch — which has
+          // no empty state for a placeholder to describe.
+          placeholder: "",
+          control: "switch",
+          defaultOn: true,
+        },
+        values: {},
+      });
+      if (plain.kind !== "switch") throw new Error("expected a switch");
 
-      // The default answers the field; it does not lock it. Clearing the
-      // picker has to remain possible, and the form then refuses the save and
-      // marks the field rather than quietly reinstating cost.
-      expect(options[0]?.value).toBe("");
-      expect(fieldFor("report").required).toBe(true);
+      expect(switchReadOnlyLabel({ control: plain, value: "true" })).toBe("On");
+      expect(switchReadOnlyLabel({ control: plain, value: "false" })).toBe(
+        "Off",
+      );
     });
   });
 
-  describe("the bucket width field", () => {
-    // @scenario "The bucket width is daily whichever report is chosen"
+  describe("the bucket width, which is no longer asked", () => {
+    // @scenario "The form offers no bucket width, on either report"
+    it("appears on neither report", () => {
+      for (const report of [reportWhenOn(), reportWhenOff()]) {
+        const shown = visibleParserFields({
+          sourceType: "anthropic_admin",
+          values: { report },
+        }).map((f) => f.key);
+
+        expect(shown).not.toContain("bucketWidth");
+      }
+    });
+
+    // @scenario "The form offers no bucket width, on either report"
+    it("is still declared, because the edit path only carries what is declared", () => {
+      // Deleting the field would look like the same change and would not be.
+      // `seedComposerParserConfig` and `buildEditedParserConfig` both walk
+      // `PARSER_FIELDS`, so an undeclared width is never seeded from storage
+      // and is stripped from the stored config on the next save.
+      expect(fieldFor("bucketWidth").hidden).toBe(true);
+      expect(
+        seedComposerParserConfig({
+          sourceType: "anthropic_admin",
+          storedParserConfig: { report: "usage", bucketWidth: "1h" },
+        }).bucketWidth,
+      ).toBe("1h");
+    });
+
+    // @scenario "The form offers no bucket width, on either report"
     it("knows the same widths the adapter schema accepts, and no others", () => {
-      // `ANTHROPIC_BUCKET_WIDTHS` is what the form will hand back to an old
-      // source and what `validBucketWidth` measures a stored width against.
-      // Both readings are only correct while the list is a projection of the
-      // schema — let it drift and the form either refuses a width the adapter
-      // would have honoured, or keeps offering one the adapter has dropped.
+      // Still a projection of the schema even though nothing offers a choice
+      // any more: the list is what a held width is measured against before it
+      // is carried forward, so drift would either drop a width the adapter
+      // honours or preserve one it has stopped accepting.
       expect([...ANTHROPIC_BUCKET_WIDTHS]).toEqual([
         ...anthropicAdminPullConfigSchema.shape.bucketWidth.removeDefault()
           .options,
       ]);
     });
 
-    // @scenario "The bucket width is daily whichever report is chosen"
-    it("offers the daily entry alone on a usage source", () => {
-      const options = selectOptionsFor("bucketWidth", { report: "usage" });
+    // @scenario "A usage source is written down as daily"
+    it("is written down as daily on a usage source that holds nothing", () => {
+      const built = buildAnthropicAdminPullConfig(
+        composerWith({ report: reportWhenOff() }),
+      );
 
-      expect(options.map((o) => o.value)).toEqual([""]);
-      expect(options[0]?.label).toContain("daily");
+      // Explicit rather than omitted. The adapter defaults to daily too, but a
+      // stored config that says nothing cannot be told from one saved before
+      // the field existed.
+      expect(built).toMatchObject({ bucketWidth: "1d" });
+      expect(
+        anthropicAdminPullConfigSchema.shape.bucketWidth.parse(undefined),
+      ).toBe("1d");
     });
 
-    // @scenario "The bucket width is daily whichever report is chosen"
-    it("says daily because the adapter's own default is daily", () => {
-      // The entry carries no value, so what the source is actually read at is
-      // whatever the schema defaults to. If that default ever moves off `1d`,
-      // the form's label becomes a claim nothing backs — which is the drift
-      // this pins, and the reason the label is not just asserted against
-      // itself.
-      const bucketWidth =
-        anthropicAdminPullConfigSchema.shape.bucketWidth.parse(undefined);
+    // @scenario "A cost source carries no bucket width"
+    it("is left out entirely on a cost source", () => {
+      const built = buildAnthropicAdminPullConfig(
+        composerWith({ report: reportWhenOn() }),
+      );
 
-      expect(bucketWidth).toBe("1d");
-      expect(
-        selectOptionsFor("bucketWidth", { report: "usage" })[0]?.label,
-      ).toBe("1d — daily");
+      expect(built).not.toBeNull();
+      expect(built).not.toHaveProperty("bucketWidth");
     });
 
     // @scenario "A source already reading hourly keeps reading hourly"
-    it("keeps offering the width an existing usage source is read at", () => {
-      // Through the whole edit path, not the builder alone. The builder was
-      // never the risk: `reconcileParserValues` drops any held value the
-      // picker does not offer, so a picker offering daily alone would have
-      // cleared this source's width before the builder ever saw it — a
-      // migration to daily performed by opening the drawer.
+    it("keeps the hourly width of a source edited for something else", () => {
+      // Through the whole edit path rather than the builder alone. Seeding
+      // has to carry the stored width and reconcile has to leave it alone;
+      // either one dropping it is a migration performed by opening a drawer.
       const seeded = seedComposerParserConfig({
         sourceType: "anthropic_admin",
         storedParserConfig: {
@@ -161,158 +300,83 @@ describe("Anthropic composer controls", () => {
 
       expect(reconciled.bucketWidth).toBe("1h");
       expect(
-        selectOptionsFor("bucketWidth", reconciled).map((o) => o.value),
-      ).toEqual(["", "1h"]);
-      // Built with the token supplied rather than with the seeded values as
-      // they stand: seeding deliberately returns a blank secret, so every edit
-      // of this source needs the token retyped whatever the width does (#7777).
-      // That is a separate problem and not what this test is measuring.
-      expect(
-        (
-          buildAnthropicAdminPullConfig(
-            composerWith({
-              ...reconciled,
-              credentialsToken: "sk-ant-admin-test",
-            }),
-          ) as Record<string, unknown>
-        ).bucketWidth,
-      ).toBe("1h");
+        buildAnthropicAdminPullConfig(
+          composerWith({
+            ...reconciled,
+            credentialsToken: "sk-ant-admin-test",
+          }),
+        ),
+      ).toMatchObject({ bucketWidth: "1h" });
     });
 
     // @scenario "A source already reading hourly keeps reading hourly"
-    it("offers daily beside it, so the admin can still move off the finer width", () => {
-      const options = selectOptionsFor("bucketWidth", {
-        report: "usage",
-        bucketWidth: "1h",
-      });
-
-      // The retention is not a lock-in. Daily stays first and still carries no
-      // value, so choosing it is how a source leaves the finer width behind.
-      expect(options[0]?.value).toBe("");
-      expect(options[0]?.label).toBe("1d — daily");
-      expect(options[1]?.label).toBe("1h — hourly");
-    });
-
-    // @scenario "A width the cost report would reject is not kept either"
-    it("keeps nothing on a cost source, whose width was never in effect", () => {
-      const options = selectOptionsFor("bucketWidth", {
-        report: "cost",
-        bucketWidth: "1h",
-      });
-
-      // The puller pins the cost report to daily and ignores the setting, so
-      // the stored `1h` was doing nothing. Offering it back would show the
-      // admin a control with no effect, and the builder refuses it anyway.
-      expect(options.map((o) => o.value)).toEqual([""]);
-      expect(
-        buildAnthropicAdminPullConfig(
-          composerWith({ report: "cost", bucketWidth: "1h" }),
-        ),
-      ).toBeNull();
-    });
-
-    // @scenario "Clearing the report to re-pick it does not cost the source its width"
-    it("keeps the width while the report field sits empty between picks", () => {
-      // The report picker keeps an empty entry on purpose, so clearing it is a
-      // state the admin passes through rather than an answer. Reconcile runs on
-      // every keystroke, so a picker that read "not usage" as "retire the
-      // width" would take `1h` away the moment the field went blank — and
-      // choosing usage again would not bring it back.
-      const cleared = reconcileParserValues({
-        sourceType: "anthropic_admin",
-        values: { report: "", bucketWidth: "1h" },
-      });
-
-      expect(cleared.bucketWidth).toBe("1h");
-      expect(
-        selectOptionsFor("bucketWidth", cleared).map((o) => o.value),
-      ).toEqual(["", "1h"]);
-
-      // And it survives the round trip back to usage.
-      expect(
-        reconcileParserValues({
-          sourceType: "anthropic_admin",
-          values: { ...cleared, report: "usage" },
-        }).bucketWidth,
-      ).toBe("1h");
-    });
-
-    // @scenario "Clearing the report to re-pick it does not cost the source its width"
-    it("still refuses to save from the state it is holding the width through", () => {
-      // Retaining the width is a form concern only. An empty report is not a
-      // configuration, and the builder turns it down before it reads a width,
-      // so nothing can reach the adapter from here.
-      expect(
-        buildAnthropicAdminPullConfig(
-          composerWith({ report: "", bucketWidth: "1h" }),
-        ),
-      ).toBeNull();
-    });
-
-    // @scenario "The bucket width is daily whichever report is chosen"
-    it("refuses a width no version of the form ever offered", () => {
-      // Retention reaches only as far as the schema does. A `2h` that arrived
-      // from somewhere other than this form is neither offered back nor built.
-      expect(
-        selectOptionsFor("bucketWidth", {
-          report: "usage",
-          bucketWidth: "2h",
-        }).map((o) => o.value),
-      ).toEqual([""]);
-      expect(
-        buildAnthropicAdminPullConfig(
-          composerWith({ report: "usage", bucketWidth: "2h" }),
-        ),
-      ).toBeNull();
-    });
-
-    // @scenario "The cost report offers no width to choose between"
-    it("collapses to the default entry on a cost source", () => {
-      const options = selectOptionsFor("bucketWidth", { report: "cost" });
-
-      expect(options.map((o) => o.value)).toEqual([""]);
-      expect(
-        fieldControl({
-          field: fieldFor("bucketWidth"),
-          values: { report: "cost" },
-        }),
-      ).toMatchObject({ hint: expect.stringContaining("always daily") });
-    });
-
-    // @scenario "Switching to the cost report drops a width already chosen"
-    it("clears a width the cost report would refuse", () => {
-      const reconciled = reconcileParserValues({
-        sourceType: "anthropic_admin",
-        values: { report: "cost", bucketWidth: "1h" },
-      });
-
-      expect(reconciled.bucketWidth).toBe("");
-      expect(
-        buildAnthropicAdminPullConfig(composerWith(reconciled)),
-      ).not.toBeNull();
-    });
-
-    // @scenario "Leaving the bucket width alone still means the adapter default"
-    it("submits no bucket width when the default entry is left in place", () => {
+    it("carries forward only a width the adapter would still accept", () => {
+      // Retention reaches as far as the schema and no further. A `2h` that
+      // arrived from somewhere other than this form is not preserved — and
+      // must not refuse the save either, since nothing on the form shows it.
       const built = buildAnthropicAdminPullConfig(
-        composerWith({ report: "usage", bucketWidth: "" }),
+        composerWith({ report: reportWhenOff(), bucketWidth: "2h" }),
+      );
+
+      expect(built).toMatchObject({ bucketWidth: "1d" });
+    });
+
+    // @scenario "An hourly width on a cost source is dropped rather than refusing the save"
+    it("drops an hourly width held on a cost source instead of refusing", () => {
+      // The width was never in effect on a cost source — the puller pins that
+      // report to daily — so there is nothing to preserve. Refusing the save
+      // would block it over a field the form does not show.
+      const built = buildAnthropicAdminPullConfig(
+        composerWith({ report: reportWhenOn(), bucketWidth: "1h" }),
       );
 
       expect(built).not.toBeNull();
       expect(built).not.toHaveProperty("bucketWidth");
     });
+
+    // @scenario "An hourly width on a cost source is dropped rather than refusing the save"
+    it("is left alone by reconcile, which no longer has a control to match it against", () => {
+      // Reconcile clears a held value its own picker stopped offering. With
+      // nothing offered at all, a width on a usage source would be cleared on
+      // the first keystroke after the drawer opened.
+      expect(
+        reconcileParserValues({
+          sourceType: "anthropic_admin",
+          values: { report: "usage", bucketWidth: "1h" },
+        }).bucketWidth,
+      ).toBe("1h");
+    });
   });
 
-  describe("the backfill start field", () => {
-    // @scenario "The backfill start is a date control"
-    it("is a date control rather than free text", () => {
-      expect(
-        fieldControl({ field: fieldFor("startingAt"), values: {} }).kind,
-      ).toBe("date");
+  describe("the date history is read from", () => {
+    // @scenario "The backfill start asks in plain words when to start reading"
+    it("asks when to start reading, on a calendar", () => {
+      const field = fieldFor("startingAt");
+
+      expect(field.label).toBe("Read history from");
+      expect(fieldControl({ field, values: {} }).kind).toBe("date");
+
+      const hint = field.hint ?? "";
+      expect(hint).toMatch(/first day/i);
+      expect(hint).toMatch(/forward|where the last/i);
+      expect(hint).toMatch(/clear/i);
     });
 
-    // @scenario "A stored instant is shown as its calendar date"
-    it("shows a seeded instant as the date a date input can display", () => {
+    // @scenario "A new Anthropic source proposes six months of history"
+    it("proposes midnight UTC six months back on a new source", () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-09-15T10:30:00.000Z"));
+
+      expect(defaultParserValues("anthropic_admin").startingAt).toBe(
+        "2026-03-15T00:00:00.000Z",
+      );
+    });
+
+    // @scenario "Editing shows the stored date rather than proposing a new one"
+    it("shows the stored day on an edit, and is not re-seeded", () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-09-15T10:30:00.000Z"));
+
       const seeded = seedComposerParserConfig({
         sourceType: "anthropic_admin",
         storedParserConfig: {
@@ -321,30 +385,41 @@ describe("Anthropic composer controls", () => {
         },
       });
 
+      expect(seeded.startingAt).toBe("2026-08-01T00:00:00.000Z");
       expect(dateInputValue(seeded.startingAt ?? "")).toBe("2026-08-01");
+    });
+
+    // @scenario "Clearing the proposed date still means the adapter's own default"
+    it("carries no start at all once the admin clears it", () => {
+      const built = buildAnthropicAdminPullConfig(
+        composerWith({ report: reportWhenOff(), startingAt: "" }),
+      );
+
+      expect(built).not.toBeNull();
+      expect(built).not.toHaveProperty("startingAt");
     });
 
     // @scenario "Showing an instant on a date control does not rewrite it"
     it("keeps an untouched instant intact through a save", () => {
-      const built = buildAnthropicAdminPullConfig(
-        composerWith({
-          report: "usage",
-          startingAt: "2026-08-01T13:45:00.000Z",
-        }),
-      );
-
-      // The display truncates to the calendar date; the value must not.
+      // The display truncates to the calendar date; the held value must not.
       expect(dateInputValue("2026-08-01T13:45:00.000Z")).toBe("2026-08-01");
-      expect(built).toMatchObject({ startingAt: "2026-08-01T13:45:00.000Z" });
+      expect(
+        buildAnthropicAdminPullConfig(
+          composerWith({
+            report: reportWhenOff(),
+            startingAt: "2026-08-01T13:45:00.000Z",
+          }),
+        ),
+      ).toMatchObject({ startingAt: "2026-08-01T13:45:00.000Z" });
     });
 
     // @scenario "A picked date is still normalized to an instant before saving"
     it("normalizes a freshly picked date to an instant", () => {
-      const built = buildAnthropicAdminPullConfig(
-        composerWith({ report: "usage", startingAt: "2026-08-01" }),
-      );
-
-      expect(built).toMatchObject({ startingAt: "2026-08-01T00:00:00.000Z" });
+      expect(
+        buildAnthropicAdminPullConfig(
+          composerWith({ report: reportWhenOff(), startingAt: "2026-08-01" }),
+        ),
+      ).toMatchObject({ startingAt: "2026-08-01T00:00:00.000Z" });
     });
   });
 });

--- a/platform/app/ee/governance/dashboard/pages/__tests__/anthropicFormControls.unit.test.ts
+++ b/platform/app/ee/governance/dashboard/pages/__tests__/anthropicFormControls.unit.test.ts
@@ -79,7 +79,7 @@ afterEach(() => {
 });
 
 describe("Anthropic composer controls", () => {
-  describe("the report toggle", () => {
+  describe("given the report is asked as a toggle", () => {
     // @scenario "The report is one toggle named for what the admin gets"
     it("is a toggle, named for what the admin gets rather than for a report", () => {
       expect(switchControlFor("report", {}).kind).toBe("switch");
@@ -215,7 +215,7 @@ describe("Anthropic composer controls", () => {
     });
   });
 
-  describe("the bucket width, which is no longer asked", () => {
+  describe("given the bucket width is hidden from the form", () => {
     // @scenario "The form offers no bucket width, on either report"
     it("appears on neither report", () => {
       for (const report of [reportWhenOn(), reportWhenOff()]) {
@@ -348,7 +348,7 @@ describe("Anthropic composer controls", () => {
     });
   });
 
-  describe("the date history is read from", () => {
+  describe("given the admin is asked what date to read history from", () => {
     // @scenario "The backfill start asks in plain words when to start reading"
     it("asks when to start reading, on a calendar", () => {
       const field = fieldFor("startingAt");

--- a/platform/app/ee/governance/dashboard/pages/__tests__/backfillStartDefaults.unit.test.ts
+++ b/platform/app/ee/governance/dashboard/pages/__tests__/backfillStartDefaults.unit.test.ts
@@ -60,81 +60,89 @@ afterEach(() => {
   vi.useRealTimers();
 });
 
-describe("the date history is read from", () => {
-  // @scenario "The field asks when to start reading, not for a backfill start"
-  it("asks when to start reading, and keeps what only OpenAI can say", () => {
-    const field = fieldFor("openai_admin", "startingAt");
+describe("given the date a scheduled source reads history from", () => {
+  describe("when the form describes the field", () => {
+    /** @scenario "The field asks when to start reading, not for a backfill start" */
+    it("asks when to start reading, and keeps what only OpenAI can say", () => {
+      const field = fieldFor("openai_admin", "startingAt");
 
-    // "Backfill start (optional)" was our word for it plus a description of
-    // the form rather than of the setting.
-    expect(field.label).toBe("Read history from");
-    expect(fieldControl({ field, values: {} }).kind).toBe("date");
+      // "Backfill start (optional)" was our word for it plus a description of
+      // the form rather than of the setting.
+      expect(field.label).toBe("Read history from");
+      expect(fieldControl({ field, values: {} }).kind).toBe("date");
 
-    const hint = field.hint ?? "";
-    expect(hint).toMatch(/first day/i);
-    expect(hint).toMatch(/forward|where the last/i);
-    expect(hint).toMatch(/clear/i);
-    // The provider-specific caveat is not general plain-words copy and is the
-    // one thing an admin picking a date a year back has to know here.
-    expect(hint).toMatch(/December 2025/);
-    expect(hint).toMatch(/API key/i);
+      const hint = field.hint ?? "";
+      expect(hint).toMatch(/first day/i);
+      expect(hint).toMatch(/forward|where the last/i);
+      expect(hint).toMatch(/clear/i);
+      // The provider-specific caveat is not general plain-words copy and is the
+      // one thing an admin picking a date a year back has to know here.
+      expect(hint).toMatch(/December 2025/);
+      expect(hint).toMatch(/API key/i);
+    });
   });
 
-  // @scenario "A new OpenAI source proposes a year of history"
-  it("proposes midnight UTC one year back for a new OpenAI source", () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-09-15T10:30:00.000Z"));
+  describe("when a new source is added", () => {
+    /** @scenario "A new OpenAI source proposes a year of history" */
+    it("proposes midnight UTC one year back for a new OpenAI source", () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-09-15T10:30:00.000Z"));
 
-    expect(defaultParserValues("openai_admin").startingAt).toBe(
-      "2025-09-15T00:00:00.000Z",
-    );
-  });
-
-  // @scenario "A new OpenAI source proposes a year of history"
-  it("reads the figure from the one declared table, per source type", () => {
-    // Two source types, two numbers, one place. A second copy of either
-    // figure is how the proposal and the sentence describing it drift apart.
-    expect(SOURCE_BACKFILL_MONTHS.openai_admin).toBe(12);
-    expect(SOURCE_BACKFILL_MONTHS.anthropic_admin).toBe(6);
-  });
-
-  // @scenario "Editing an existing source shows what it holds"
-  it("shows the stored day on an edit rather than proposing a new one", () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-09-15T10:30:00.000Z"));
-
-    const seeded = seedComposerParserConfig({
-      sourceType: "openai_admin",
-      storedParserConfig: { startingAt: "2026-02-03T00:00:00.000Z" },
+      expect(defaultParserValues("openai_admin").startingAt).toBe(
+        "2025-09-15T00:00:00.000Z",
+      );
     });
 
-    expect(seeded.startingAt).toBe("2026-02-03T00:00:00.000Z");
-    expect(dateInputValue(seeded.startingAt ?? "")).toBe("2026-02-03");
+    /** @scenario "A new OpenAI source proposes a year of history" */
+    it("reads the figure from the one declared table, per source type", () => {
+      // Two source types, two numbers, one place. A second copy of either
+      // figure is how the proposal and the sentence describing it drift apart.
+      expect(SOURCE_BACKFILL_MONTHS.openai_admin).toBe(12);
+      expect(SOURCE_BACKFILL_MONTHS.anthropic_admin).toBe(6);
+    });
   });
 
-  // @scenario "Editing an existing source shows what it holds"
-  it("leaves an edited source with no start date empty rather than proposing one", () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-09-15T10:30:00.000Z"));
+  describe("when an existing source is opened for editing", () => {
+    /** @scenario "Editing an existing source shows what it holds" */
+    it("shows the stored day rather than proposing a new one", () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-09-15T10:30:00.000Z"));
 
-    // A source saved before the field had a default, or one whose admin
-    // deliberately cleared it. Seeding the proposal here would hand it a year
-    // of history it was never configured to read.
-    expect(
-      seedComposerParserConfig({
+      const seeded = seedComposerParserConfig({
         sourceType: "openai_admin",
-        storedParserConfig: { model: "gpt-4o" },
-      }),
-    ).not.toHaveProperty("startingAt");
+        storedParserConfig: { startingAt: "2026-02-03T00:00:00.000Z" },
+      });
+
+      expect(seeded.startingAt).toBe("2026-02-03T00:00:00.000Z");
+      expect(dateInputValue(seeded.startingAt ?? "")).toBe("2026-02-03");
+    });
+
+    /** @scenario "Editing an existing source shows what it holds" */
+    it("leaves a source with no start date empty rather than proposing one", () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-09-15T10:30:00.000Z"));
+
+      // A source saved before the field had a default, or one whose admin
+      // deliberately cleared it. Seeding the proposal here would hand it a year
+      // of history it was never configured to read.
+      expect(
+        seedComposerParserConfig({
+          sourceType: "openai_admin",
+          storedParserConfig: { model: "gpt-4o" },
+        }),
+      ).not.toHaveProperty("startingAt");
+    });
   });
 
-  // @scenario "Clearing the proposal still means the adapter's own default"
-  it("carries no start date once the admin clears the proposal", () => {
-    const built = buildOpenAiAdminPullConfig(
-      openAiComposerWith({ startingAt: "" }),
-    );
+  describe("when the admin clears the proposed date", () => {
+    /** @scenario "Clearing the proposal still means the adapter's own default" */
+    it("carries no start date into the saved config", () => {
+      const built = buildOpenAiAdminPullConfig(
+        openAiComposerWith({ startingAt: "" }),
+      );
 
-    expect(built).not.toBeNull();
-    expect(built).not.toHaveProperty("startingAt");
+      expect(built).not.toBeNull();
+      expect(built).not.toHaveProperty("startingAt");
+    });
   });
 });

--- a/platform/app/ee/governance/dashboard/pages/__tests__/backfillStartDefaults.unit.test.ts
+++ b/platform/app/ee/governance/dashboard/pages/__tests__/backfillStartDefaults.unit.test.ts
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+
+/**
+ * How far back a newly added scheduled source proposes to read, and the one
+ * table that decides it per source type.
+ *
+ * A source added with no start date reads only the last few days, so the
+ * Activity Monitor shows a flat line on the day an admin finishes setting it
+ * up — the moment they are most likely to conclude the integration does not
+ * work. The form therefore proposes a start instead of leaving the field
+ * empty.
+ *
+ * The number differs per provider because the providers do: OpenAI serves four
+ * years of daily spend, Anthropic considerably less. It is a proposal, not a
+ * limit, so the figure is a product decision rather than an API one — a year
+ * for OpenAI shows a year-on-year trend on day one without a first run that
+ * reads four years of days, and six months of Anthropic is about six pages at
+ * the adapter's daily bucket, well inside `MAX_PAGES_PER_RUN`.
+ *
+ * Declared in one table beside the cadence defaults so the proposal and any
+ * copy describing it read the same source. The risk this file exists for is
+ * the proposal leaking onto the edit form, where it would move a date that has
+ * already been read from, on a drawer the admin opened to change a name.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  buildOpenAiAdminPullConfig,
+  type ComposerState,
+  dateInputValue,
+  defaultParserValues,
+  fieldControl,
+  PARSER_FIELDS,
+  SOURCE_BACKFILL_MONTHS,
+  seedComposerParserConfig,
+} from "../inventory";
+
+const fieldFor = (
+  sourceType: "openai_admin" | "anthropic_admin",
+  key: string,
+) => {
+  const field = PARSER_FIELDS[sourceType].find((f) => f.key === key);
+  if (!field) throw new Error(`no ${sourceType} field named ${key}`);
+  return field;
+};
+
+const openAiComposerWith = (
+  parserConfig: Record<string, string>,
+): ComposerState => ({
+  sourceType: "openai_admin",
+  name: "OpenAI org",
+  description: "",
+  parserConfig: { credentialsToken: "sk-admin-test", ...parserConfig },
+  pullSchedule: "0 * * * *",
+  ottlStatements: [],
+  traceProjectId: null,
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("the date history is read from", () => {
+  // @scenario "The field asks when to start reading, not for a backfill start"
+  it("asks when to start reading, and keeps what only OpenAI can say", () => {
+    const field = fieldFor("openai_admin", "startingAt");
+
+    // "Backfill start (optional)" was our word for it plus a description of
+    // the form rather than of the setting.
+    expect(field.label).toBe("Read history from");
+    expect(fieldControl({ field, values: {} }).kind).toBe("date");
+
+    const hint = field.hint ?? "";
+    expect(hint).toMatch(/first day/i);
+    expect(hint).toMatch(/forward|where the last/i);
+    expect(hint).toMatch(/clear/i);
+    // The provider-specific caveat is not general plain-words copy and is the
+    // one thing an admin picking a date a year back has to know here.
+    expect(hint).toMatch(/December 2025/);
+    expect(hint).toMatch(/API key/i);
+  });
+
+  // @scenario "A new OpenAI source proposes a year of history"
+  it("proposes midnight UTC one year back for a new OpenAI source", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-09-15T10:30:00.000Z"));
+
+    expect(defaultParserValues("openai_admin").startingAt).toBe(
+      "2025-09-15T00:00:00.000Z",
+    );
+  });
+
+  // @scenario "A new OpenAI source proposes a year of history"
+  it("reads the figure from the one declared table, per source type", () => {
+    // Two source types, two numbers, one place. A second copy of either
+    // figure is how the proposal and the sentence describing it drift apart.
+    expect(SOURCE_BACKFILL_MONTHS.openai_admin).toBe(12);
+    expect(SOURCE_BACKFILL_MONTHS.anthropic_admin).toBe(6);
+  });
+
+  // @scenario "Editing an existing source shows what it holds"
+  it("shows the stored day on an edit rather than proposing a new one", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-09-15T10:30:00.000Z"));
+
+    const seeded = seedComposerParserConfig({
+      sourceType: "openai_admin",
+      storedParserConfig: { startingAt: "2026-02-03T00:00:00.000Z" },
+    });
+
+    expect(seeded.startingAt).toBe("2026-02-03T00:00:00.000Z");
+    expect(dateInputValue(seeded.startingAt ?? "")).toBe("2026-02-03");
+  });
+
+  // @scenario "Editing an existing source shows what it holds"
+  it("leaves an edited source with no start date empty rather than proposing one", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-09-15T10:30:00.000Z"));
+
+    // A source saved before the field had a default, or one whose admin
+    // deliberately cleared it. Seeding the proposal here would hand it a year
+    // of history it was never configured to read.
+    expect(
+      seedComposerParserConfig({
+        sourceType: "openai_admin",
+        storedParserConfig: { model: "gpt-4o" },
+      }),
+    ).not.toHaveProperty("startingAt");
+  });
+
+  // @scenario "Clearing the proposal still means the adapter's own default"
+  it("carries no start date once the admin clears the proposal", () => {
+    const built = buildOpenAiAdminPullConfig(
+      openAiComposerWith({ startingAt: "" }),
+    );
+
+    expect(built).not.toBeNull();
+    expect(built).not.toHaveProperty("startingAt");
+  });
+});

--- a/platform/app/ee/governance/dashboard/pages/__tests__/backfillStartDefaults.unit.test.ts
+++ b/platform/app/ee/governance/dashboard/pages/__tests__/backfillStartDefaults.unit.test.ts
@@ -24,6 +24,7 @@
  */
 
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { SOURCE_BACKFILL_MONTHS } from "../../logic/pullCadence";
 import {
   buildOpenAiAdminPullConfig,
   type ComposerState,
@@ -31,7 +32,6 @@ import {
   defaultParserValues,
   fieldControl,
   PARSER_FIELDS,
-  SOURCE_BACKFILL_MONTHS,
   seedComposerParserConfig,
 } from "../inventory";
 

--- a/platform/app/ee/governance/dashboard/pages/__tests__/backfillStartDefaults.unit.test.ts
+++ b/platform/app/ee/governance/dashboard/pages/__tests__/backfillStartDefaults.unit.test.ts
@@ -24,7 +24,10 @@
  */
 
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { SOURCE_BACKFILL_MONTHS } from "../../logic/pullCadence";
+import {
+  defaultBackfillStart,
+  SOURCE_BACKFILL_MONTHS,
+} from "../../logic/pullCadence";
 import {
   buildOpenAiAdminPullConfig,
   type ComposerState,
@@ -99,6 +102,44 @@ describe("given the date a scheduled source reads history from", () => {
       // figure is how the proposal and the sentence describing it drift apart.
       expect(SOURCE_BACKFILL_MONTHS.openai_admin).toBe(12);
       expect(SOURCE_BACKFILL_MONTHS.anthropic_admin).toBe(6);
+    });
+  });
+
+  describe("when today is a day the target month does not have", () => {
+    /** @scenario "A proposal from a day the target month does not have lands in that month" */
+    it("clamps the end of August back to the end of February", () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-08-31T10:30:00.000Z"));
+
+      // Six months before the 31st of August is the 31st of February, which
+      // Date rolls forward into March. The proposal would then be five months
+      // back and three days, on a form whose hint says six.
+      expect(defaultBackfillStart("anthropic_admin")).toBe(
+        "2026-02-28T00:00:00.000Z",
+      );
+    });
+
+    /** @scenario "A proposal from a day the target month does not have lands in that month" */
+    it("clamps the end of March back to the end of September", () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-03-31T10:30:00.000Z"));
+
+      expect(defaultBackfillStart("anthropic_admin")).toBe(
+        "2025-09-30T00:00:00.000Z",
+      );
+    });
+
+    /** @scenario "A proposal from a day the target month does not have lands in that month" */
+    it("clamps a leap day back to the last day of a common February", () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2024-02-29T10:30:00.000Z"));
+
+      // A year back from the 29th only exists every fourth year, so this is
+      // the same rollover with the target month a year away rather than six
+      // months.
+      expect(defaultBackfillStart("openai_admin")).toBe(
+        "2023-02-28T00:00:00.000Z",
+      );
     });
   });
 

--- a/platform/app/ee/governance/dashboard/pages/__tests__/editPullSourceConfig.builders.unit.test.ts
+++ b/platform/app/ee/governance/dashboard/pages/__tests__/editPullSourceConfig.builders.unit.test.ts
@@ -79,10 +79,26 @@ describe("buildAnthropicAdminPullConfig on the edit path", () => {
     });
   });
 
-  it("given an invalid bucket width, refuses the save on the edit path too", () => {
+  it("given an unparseable start date, refuses the save on the edit path too", () => {
     // A real token, deliberately: with a blank one this would return null
-    // whether or not the bucket width was ever checked, and the test would
-    // keep passing with the validation removed.
+    // whether or not the start date was ever checked, and the test would keep
+    // passing with the validation removed.
+    const config = buildAnthropicAdminPullConfig(
+      composer({
+        credentialsToken: "sk-ant-admin-test",
+        report: "usage",
+        startingAt: "not-a-date",
+      }),
+      { shouldRequireCredentials: false },
+    );
+
+    expect(config).toBeNull();
+  });
+
+  it("given a bucket width it cannot honour, saves without it rather than refusing", () => {
+    // The form no longer asks for a width, so refusing here would block an
+    // edit over a control the admin cannot see to correct. `5m` is outside the
+    // adapter's domain, and daily is what this source runs at either way.
     const config = buildAnthropicAdminPullConfig(
       composer({
         credentialsToken: "sk-ant-admin-test",
@@ -92,7 +108,7 @@ describe("buildAnthropicAdminPullConfig on the edit path", () => {
       { shouldRequireCredentials: false },
     );
 
-    expect(config).toBeNull();
+    expect(config).toMatchObject({ bucketWidth: "1d" });
   });
 
   it("still requires the secret on the create path", () => {
@@ -119,9 +135,9 @@ describe("buildEditedParserConfig", () => {
   it("clears a field the admin emptied instead of leaving the old value", () => {
     // The regression this exists for: merging the rebuilt config over the
     // stored one with a plain spread leaves an omitted key untouched, so
-    // clearing a bucket width saved successfully and changed nothing.
+    // clearing a start date saved successfully and changed nothing.
     const rebuilt = buildAnthropicAdminPullConfig(
-      composer({ credentialsToken: "", report: "usage", bucketWidth: "" }),
+      composer({ credentialsToken: "", report: "usage", startingAt: "" }),
       { shouldRequireCredentials: false },
     );
 
@@ -132,8 +148,28 @@ describe("buildEditedParserConfig", () => {
       ottlStatements: [],
     });
 
-    expect(next).not.toHaveProperty("bucketWidth");
     expect(next).not.toHaveProperty("startingAt");
+  });
+
+  it("keeps carrying the hourly width of a source that already reads at one", () => {
+    // The same merge, in the direction that matters now the form has stopped
+    // asking. The width is a declared-but-hidden field, so it is seeded from
+    // storage, deleted from the stored config before the re-spread, and put
+    // back only because the builder carried it — and an admin editing a name
+    // has not asked to be moved to daily.
+    const rebuilt = buildAnthropicAdminPullConfig(
+      composer({ credentialsToken: "", report: "usage", bucketWidth: "1h" }),
+      { shouldRequireCredentials: false },
+    );
+
+    expect(
+      buildEditedParserConfig({
+        sourceType: "anthropic_admin",
+        storedParserConfig: stored,
+        rebuiltPullConfig: rebuilt,
+        ottlStatements: [],
+      }),
+    ).toMatchObject({ bucketWidth: "1h" });
   });
 
   it("keeps adapter bookkeeping the form does not own", () => {
@@ -248,14 +284,14 @@ describe("buildEditSubmission", () => {
   });
 
   it("given a pull field the adapter cannot parse, refuses the save", () => {
-    // Nothing validates pullConfig server-side, so a bad bucket width saved
-    // here would sit in the row looking fine and fail on every pull.
+    // Nothing validates pullConfig server-side, so a bad start date saved here
+    // would sit in the row looking fine and fail on every pull.
     expect(
       submit({
         parserConfig: {
           credentialsToken: "",
           report: "usage",
-          bucketWidth: "5m",
+          startingAt: "not-a-date",
         },
       }),
     ).toBeNull();

--- a/platform/app/ee/governance/dashboard/pages/__tests__/editSourceNotes.unit.test.ts
+++ b/platform/app/ee/governance/dashboard/pages/__tests__/editSourceNotes.unit.test.ts
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+
+/**
+ * Which explanations the edit drawer owes an admin about settings its adapter
+ * can no longer change.
+ *
+ * The marker beside the edit title shows whatever this list holds, so what the
+ * list holds for a given source is the whole of the behaviour — the drawer
+ * adds only a popover around it. Pinning all four combinations of pulled and
+ * report here costs four function calls; pinning them through the drawer costs
+ * four renders and still tests the same decision.
+ *
+ * The risk worth a test: the three notes must never all apply at once. A start
+ * date that is fixed and a start date worth moving are the two halves of one
+ * condition, and a source shown both is being told its start is frozen and
+ * that moving it will restate its figures.
+ */
+
+import { describe, expect, it } from "vitest";
+import { editSourceNotes } from "../inventory";
+
+/** What each note is recognisable by, independent of its exact wording. */
+const REPORT_NOTE = /the report is fixed/i;
+const START_FIXED_NOTE = /the start date is fixed/i;
+const RESTATE_NOTE = /restates the figures/i;
+
+const notesFor = (hasPulled: boolean, report: string | undefined) =>
+  editSourceNotes({ hasPulled, report });
+
+describe("given the notes an edit drawer owes about locked settings", () => {
+  describe("when the source has never pulled", () => {
+    /** @scenario "A source that has never pulled is owed no note on either report" */
+    it("owes nothing on the usage report", () => {
+      // No cursor exists yet, so no setting contradicts an edit and there is
+      // nothing to explain. A marker here would open onto an empty popover.
+      expect(notesFor(false, "usage")).toEqual([]);
+    });
+
+    /** @scenario "A source that has never pulled is owed no note on either report" */
+    it("owes nothing on the cost report", () => {
+      expect(notesFor(false, "cost")).toEqual([]);
+    });
+
+    /** @scenario "A source that has never pulled is owed no note on either report" */
+    it("owes nothing when the report has not been answered", () => {
+      // The create form no longer allows this, but a row saved before the
+      // switch existed can still reach the edit drawer without a report.
+      expect(notesFor(false, undefined)).toEqual([]);
+    });
+  });
+
+  describe("when the source has pulled on the usage report", () => {
+    /** @scenario "A pulled usage source is owed the two notes that lock it" */
+    it("owes the report note and the start-date note, in that order", () => {
+      const notes = notesFor(true, "usage");
+
+      expect(notes).toHaveLength(2);
+      expect(notes[0]).toMatch(REPORT_NOTE);
+      expect(notes[1]).toMatch(START_FIXED_NOTE);
+    });
+
+    /** @scenario "A pulled usage source is owed the two notes that lock it" */
+    it("does not offer to restate cost history", () => {
+      // A repair the usage cursor cannot perform: it never rewinds, so this
+      // sentence would describe a lever that is not there.
+      expect(notesFor(true, "usage").join(" ")).not.toMatch(RESTATE_NOTE);
+    });
+  });
+
+  describe("when the source has pulled on the cost report", () => {
+    /** @scenario "A pulled cost source is owed the report note and the restate note" */
+    it("owes the report note and the restate note, in that order", () => {
+      const notes = notesFor(true, "cost");
+
+      expect(notes).toHaveLength(2);
+      expect(notes[0]).toMatch(REPORT_NOTE);
+      expect(notes[1]).toMatch(RESTATE_NOTE);
+    });
+
+    /** @scenario "A pulled cost source is owed the report note and the restate note" */
+    it("does not say the start date is fixed, because on cost it is not", () => {
+      // The cost cursor binds `startingAt` into its identity, so moving the
+      // start is the deliberate repair lever rather than a setting to lock.
+      expect(notesFor(true, "cost").join(" ")).not.toMatch(START_FIXED_NOTE);
+    });
+  });
+
+  describe("when every combination is taken together", () => {
+    /** @scenario "No source is ever owed all three notes" */
+    it("never owes more than two notes", () => {
+      const everyCombination = [true, false].flatMap((hasPulled) =>
+        ["usage", "cost", undefined].map((report) => ({
+          hasPulled,
+          report,
+          notes: notesFor(hasPulled, report),
+        })),
+      );
+
+      for (const { hasPulled, report, notes } of everyCombination) {
+        expect(
+          notes.length,
+          `hasPulled=${hasPulled} report=${report}`,
+        ).toBeLessThanOrEqual(2);
+      }
+    });
+
+    /** @scenario "No source is ever owed all three notes" */
+    it("never pairs a fixed start with an invitation to move it", () => {
+      for (const hasPulled of [true, false]) {
+        for (const report of ["usage", "cost", undefined]) {
+          const joined = notesFor(hasPulled, report).join(" ");
+          const saysFixed = START_FIXED_NOTE.test(joined);
+          const saysMovable = RESTATE_NOTE.test(joined);
+
+          expect(
+            saysFixed && saysMovable,
+            `hasPulled=${hasPulled} report=${report}`,
+          ).toBe(false);
+        }
+      }
+    });
+  });
+});

--- a/platform/app/ee/governance/dashboard/pages/__tests__/sourceComposerAdvanced.integration.test.tsx
+++ b/platform/app/ee/governance/dashboard/pages/__tests__/sourceComposerAdvanced.integration.test.tsx
@@ -244,6 +244,23 @@ describe("given the create drawer for a pull-mode conversation source", () => {
 
       expect(screen.getAllByText("Advanced")).toHaveLength(1);
     });
+
+    /** @scenario "The description field asks for a description" */
+    it("asks for the name and the description in the same shape", () => {
+      renderComposer();
+
+      // The description used to prompt "What this fleet covers + who owns it":
+      // two particular facts, asked for with a word that appears nowhere else
+      // an admin can see. The two fields sit on top of each other, so the
+      // mismatched shape was visible without reading either of them.
+      expect(
+        screen.getByPlaceholderText("Display name for this source"),
+      ).toBeTruthy();
+      expect(
+        screen.getByPlaceholderText("Description for this source"),
+      ).toBeTruthy();
+      expect(screen.queryByPlaceholderText(/fleet/i)).toBeNull();
+    });
   });
 
   describe("when the source type declares no advanced parser fields of its own", () => {

--- a/platform/app/ee/governance/dashboard/pages/__tests__/sourceEditHeader.integration.test.tsx
+++ b/platform/app/ee/governance/dashboard/pages/__tests__/sourceEditHeader.integration.test.tsx
@@ -134,7 +134,13 @@ const openNotes = async (): Promise<string> => {
   if (!contentId) throw new Error("the marker controls no popover");
   return (await waitFor(() => {
     const content = document.getElementById(contentId);
-    if (!content?.textContent) throw new Error("the popover is still empty");
+    // Chakra mounts the content closed, already holding its text, so waiting
+    // for text alone is satisfied before the click has done anything. The
+    // open state is the part that actually has to settle.
+    if (content?.getAttribute("data-state") !== "open") {
+      throw new Error("the popover has not opened");
+    }
+    if (!content.textContent) throw new Error("the popover is still empty");
     return content.textContent;
   })) as string;
 };

--- a/platform/app/ee/governance/dashboard/pages/__tests__/sourceEditHeader.integration.test.tsx
+++ b/platform/app/ee/governance/dashboard/pages/__tests__/sourceEditHeader.integration.test.tsx
@@ -146,100 +146,110 @@ const openNotes = async (): Promise<string> => {
 };
 
 describe("given the edit drawer's title", () => {
-  /** @scenario "The edit title names the provider and shows its logo" */
-  it("names the provider it is editing", () => {
-    renderDrawer(anthropicSource({ report: "cost", hasPulled: false }));
+  describe("when it opens on a source type the catalog knows", () => {
+    /** @scenario "The edit title names the provider and shows its logo" */
+    it("names the provider it is editing", () => {
+      renderDrawer(anthropicSource({ report: "cost", hasPulled: false }));
 
-    expect(
-      screen.getByRole("heading", { name: "Edit Anthropic Admin API" }),
-    ).toBeTruthy();
-    expect(screen.queryByRole("heading", { name: "Edit source" })).toBeNull();
+      expect(
+        screen.getByRole("heading", { name: "Edit Anthropic Admin API" }),
+      ).toBeTruthy();
+      expect(screen.queryByRole("heading", { name: "Edit source" })).toBeNull();
+    });
+
+    /** @scenario "The edit title names the provider and shows its logo" */
+    it("shows the provider's glyph beside the name", () => {
+      renderDrawer(anthropicSource({ report: "cost", hasPulled: false }));
+
+      // The same mark the Add source menu and the create composer show for this
+      // type. A header that names the provider in words alone is a different
+      // header from the one an admin just came through.
+      expect(screen.getByTestId("source-type-icon")).toBeTruthy();
+    });
   });
 
-  /** @scenario "The edit title names the provider and shows its logo" */
-  it("shows the provider's glyph beside the name", () => {
-    renderDrawer(anthropicSource({ report: "cost", hasPulled: false }));
+  describe("when it opens on a type the catalog has no entry for", () => {
+    /** @scenario "An unrecognised source type still gets a title" */
+    it("falls back to a plain title", () => {
+      // Every lookup on this drawer is keyed by `SourceType` and simply misses
+      // for a row written by a newer deploy. A missed lookup must leave a title
+      // rather than "Edit undefined" or a blank header.
+      renderDrawer(sourceOfAnUnknownType);
 
-    // The same mark the Add source menu and the create composer show for this
-    // type. A header that names the provider in words alone is a different
-    // header from the one an admin just came through.
-    expect(screen.getByTestId("source-type-icon")).toBeTruthy();
-  });
-
-  /** @scenario "An unrecognised source type still gets a title" */
-  it("falls back to a plain title for a type it has no entry for", () => {
-    // Every lookup on this drawer is keyed by `SourceType` and simply misses
-    // for a row written by a newer deploy. A missed lookup must leave a title
-    // rather than "Edit undefined" or a blank header.
-    renderDrawer(sourceOfAnUnknownType);
-
-    expect(screen.getByRole("heading", { name: "Edit source" })).toBeTruthy();
+      expect(screen.getByRole("heading", { name: "Edit source" })).toBeTruthy();
+    });
   });
 });
 
 describe("given a source with settings its adapter can no longer change", () => {
-  /** @scenario "A pulled usage source carries the two notes that apply to it" */
-  it("puts the usage source's two notes behind the one marker", async () => {
-    renderDrawer(anthropicSource({ report: "usage", hasPulled: true }));
-    const notes = await openNotes();
+  describe("when the admin opens the marker beside the title", () => {
+    /** @scenario "A pulled usage source carries the two notes that apply to it" */
+    it("puts the usage source's two notes behind the one marker", async () => {
+      renderDrawer(anthropicSource({ report: "usage", hasPulled: true }));
+      const notes = await openNotes();
 
-    // The usage cursor never rewinds, so both of this source's settings are
-    // fixed once it has pulled.
-    expect(notes).toMatch(/report/i);
-    expect(notes).toMatch(/start/i);
-    // Restating cost history is a cost-source sentence. Shown here it would
-    // describe a repair this source cannot perform.
-    expect(notes).not.toMatch(/restate/i);
+      // The usage cursor never rewinds, so both of this source's settings are
+      // fixed once it has pulled.
+      expect(notes).toMatch(/report/i);
+      expect(notes).toMatch(/start/i);
+      // Restating cost history is a cost-source sentence. Shown here it would
+      // describe a repair this source cannot perform.
+      expect(notes).not.toMatch(/restate/i);
+    });
+
+    /** @scenario "A pulled cost source carries a different two" */
+    it("puts the cost source's different two behind the same marker", async () => {
+      renderDrawer(anthropicSource({ report: "cost", hasPulled: true }));
+      const notes = await openNotes();
+
+      expect(notes).toMatch(/report/i);
+      // The cost cursor binds `startingAt` into its own identity, so moving the
+      // start is the deliberate repair lever rather than a setting to lock. The
+      // three notes never all apply at once: a fixed start and a start worth
+      // moving are the two halves of one condition.
+      expect(notes).toMatch(/restate|re-read/i);
+      expect(notes).not.toMatch(/start date is fixed/i);
+    });
   });
 
-  /** @scenario "A pulled cost source carries a different two" */
-  it("puts the cost source's different two behind the same marker", async () => {
-    renderDrawer(anthropicSource({ report: "cost", hasPulled: true }));
-    const notes = await openNotes();
+  describe("when nothing about the source is locked yet", () => {
+    /** @scenario "A source with nothing locked shows no marker at all" */
+    it("shows no marker on a source that has never pulled", () => {
+      // Nothing is locked before a cursor exists, so every note would be
+      // inapplicable — and a marker opening onto an empty popover is worse than
+      // no marker, because it invites a click that answers nothing.
+      renderDrawer(anthropicSource({ report: "cost", hasPulled: false }));
 
-    expect(notes).toMatch(/report/i);
-    // The cost cursor binds `startingAt` into its own identity, so moving the
-    // start is the deliberate repair lever rather than a setting to lock. The
-    // three notes never all apply at once: a fixed start and a start worth
-    // moving are the two halves of one condition.
-    expect(notes).toMatch(/restate|re-read/i);
-    expect(notes).not.toMatch(/start date is fixed/i);
+      expect(screen.queryByTestId("edit-source-notes")).toBeNull();
+    });
   });
 
-  /** @scenario "A source with nothing locked shows no marker at all" */
-  it("shows no marker on a source that has never pulled", () => {
-    // Nothing is locked before a cursor exists, so every note would be
-    // inapplicable — and a marker opening onto an empty popover is worse than
-    // no marker, because it invites a click that answers nothing.
-    renderDrawer(anthropicSource({ report: "cost", hasPulled: false }));
+  describe("when the drawer is drawn, before anything is opened", () => {
+    /** @scenario "The locked-field notes move behind an information marker" */
+    it("keeps the notes out of the body, where they used to sit", () => {
+      renderDrawer(anthropicSource({ report: "usage", hasPulled: true }));
 
-    expect(screen.queryByTestId("edit-source-notes")).toBeNull();
-  });
+      // Chakra keeps popover content mounted and hidden while closed, so only a
+      // visibility matcher tells "behind the marker" from "in the body".
+      expect(screen.getByTestId("edit-source-notes")).toBeVisible();
+      expect(
+        screen.getByText(/is fixed once a source has pulled/i),
+      ).not.toBeVisible();
+    });
 
-  /** @scenario "The locked-field notes move behind an information marker" */
-  it("keeps the notes out of the body, where they used to sit", () => {
-    renderDrawer(anthropicSource({ report: "usage", hasPulled: true }));
+    /** @scenario "A locked report is still readable and still reachable" */
+    it("leaves a locked report readable and in the tab order", () => {
+      renderDrawer(anthropicSource({ report: "cost", hasPulled: true }));
 
-    // Chakra keeps popover content mounted and hidden while closed, so only a
-    // visibility matcher tells "behind the marker" from "in the body".
-    expect(screen.getByTestId("edit-source-notes")).toBeVisible();
-    expect(
-      screen.getByText(/is fixed once a source has pulled/i),
-    ).not.toBeVisible();
-  });
+      const report = screen.getByLabelText("Use Anthropic's reported cost");
 
-  /** @scenario "A locked report is still readable and still reachable" */
-  it("leaves a locked report readable and in the tab order", () => {
-    renderDrawer(anthropicSource({ report: "cost", hasPulled: true }));
-
-    const report = screen.getByLabelText("Use Anthropic's reported cost");
-
-    // readOnly, never disabled: a disabled control drops out of the tab order,
-    // where a keyboard or screen-reader user cannot read what it holds. And
-    // what it holds has to be the report's own name — "Off" is the position of
-    // a control this admin can no longer see.
-    expect(report).toHaveProperty("readOnly", true);
-    expect((report as HTMLInputElement).disabled).toBe(false);
-    expect((report as HTMLInputElement).value).toBe("Cost report");
+      // readOnly, never disabled: a disabled control drops out of the tab order,
+      // where a keyboard or screen-reader user cannot read what it holds. And
+      // what it holds has to be the report's own name — "Off" is the position of
+      // a control this admin can no longer see.
+      expect(report).toHaveProperty("readOnly", true);
+      expect((report as HTMLInputElement).disabled).toBe(false);
+      expect((report as HTMLInputElement).value).toBe("Cost report");
+    });
   });
 });

--- a/platform/app/ee/governance/dashboard/pages/__tests__/sourceEditHeader.integration.test.tsx
+++ b/platform/app/ee/governance/dashboard/pages/__tests__/sourceEditHeader.integration.test.tsx
@@ -203,7 +203,7 @@ describe("given a source with settings its adapter can no longer change", () => 
     // three notes never all apply at once: a fixed start and a start worth
     // moving are the two halves of one condition.
     expect(notes).toMatch(/restate|re-read/i);
-    expect(notes).not.toMatch(/start date can no longer/i);
+    expect(notes).not.toMatch(/start date is fixed/i);
   });
 
   /** @scenario "A source with nothing locked shows no marker at all" */

--- a/platform/app/ee/governance/dashboard/pages/__tests__/sourceEditHeader.integration.test.tsx
+++ b/platform/app/ee/governance/dashboard/pages/__tests__/sourceEditHeader.integration.test.tsx
@@ -1,0 +1,239 @@
+// SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+// @vitest-environment jsdom
+/**
+ * What the edit drawer's header says, and what sits behind it.
+ *
+ * Spec: specs/ai-gateway/governance/ingestion-sources.feature
+ * Spec: specs/governance/anthropic-source-form-controls.feature
+ *
+ * Two changes with one cause. The title read "Edit source" for every source
+ * type, so an admin who reached the drawer from a row action, a detail page or
+ * a restored browser tab had nothing in the header telling them which of their
+ * sources they were about to change. And the notes explaining why a field is
+ * locked were body paragraphs sitting above the fields, which put three
+ * sentences of adapter reasoning between the admin and the form every time
+ * they opened a source that had already pulled.
+ *
+ * The create composer had already solved both — provider glyph, provider name,
+ * and the long explanation behind a (i) beside the heading. This is the edit
+ * drawer being given the same header rather than a second design for it.
+ *
+ * Drives the real `SourceEditDrawer` for the same reason
+ * `sourceEditDestination.integration.test.tsx` does: a harness that rebuilt
+ * the header would only prove the copy agrees with itself.
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { SourceEditDrawer } from "../inventory";
+
+/** Same minimal stub as the destination test: OTTL is not what this covers. */
+vi.mock("~/utils/api", () => ({
+  api: {
+    ingestionSources: {
+      ottlStarter: {
+        useQuery: () => ({ data: undefined, isLoading: false, error: null }),
+      },
+      validateOttl: {
+        useMutation: () => ({
+          mutate: vi.fn(),
+          mutateAsync: vi.fn(),
+          isPending: false,
+          data: undefined,
+          error: null,
+          reset: vi.fn(),
+        }),
+      },
+    },
+  },
+}));
+
+vi.mock("~/components/ui/toaster", () => ({
+  toaster: { create: vi.fn() },
+}));
+
+const ORG_ID = "org_acme";
+
+const DESTINATION_CTX = {
+  organizationId: ORG_ID,
+  organizationName: "Acme",
+  availableTeams: [],
+  availableProjects: [],
+};
+
+type DrawerSource = Parameters<typeof SourceEditDrawer>[0]["source"];
+
+/**
+ * An Anthropic source in a given state.
+ *
+ * `hasPollerCursor` is what decides every lock on this form — the row's own
+ * answer to "has this ever pulled", rather than an inference from `status`,
+ * which is wrong in both directions.
+ */
+const anthropicSource = ({
+  report,
+  hasPulled,
+}: {
+  report: string;
+  hasPulled: boolean;
+}) =>
+  ({
+    id: "src_anthropic",
+    name: "Anthropic org",
+    description: "",
+    sourceType: "anthropic_admin",
+    parserConfig: {
+      report,
+      startingAt: "2026-03-15T00:00:00.000Z",
+    },
+    pullSchedule: "0 * * * *",
+    hasPollerCursor: hasPulled,
+    traceProjectId: null,
+    traceProjectArchived: false,
+  }) as unknown as DrawerSource;
+
+/** A row written by a newer deploy than the one serving this page. */
+const sourceOfAnUnknownType = {
+  id: "src_future",
+  name: "Something new",
+  description: "",
+  sourceType: "quantum_ledger",
+  parserConfig: {},
+  traceProjectId: null,
+  traceProjectArchived: false,
+} as unknown as DrawerSource;
+
+const renderDrawer = (source: DrawerSource) =>
+  render(
+    <ChakraProvider value={defaultSystem}>
+      <SourceEditDrawer
+        organizationId={ORG_ID}
+        destinationCtx={DESTINATION_CTX}
+        source={source}
+        onClose={vi.fn()}
+        onSubmit={vi.fn()}
+        isPending={false}
+      />
+    </ChakraProvider>,
+  );
+
+/**
+ * Opens the marker and returns what it holds.
+ *
+ * By the trigger's own `aria-controls` rather than by role: the drawer around
+ * it is a dialog too, so asking for one by role finds both and cannot say
+ * which of them the note is in — which is the whole claim being made here.
+ */
+const openNotes = async (): Promise<string> => {
+  const user = userEvent.setup();
+  const trigger = screen.getByTestId("edit-source-notes");
+  await user.click(trigger);
+
+  const contentId = trigger.getAttribute("aria-controls");
+  if (!contentId) throw new Error("the marker controls no popover");
+  return (await waitFor(() => {
+    const content = document.getElementById(contentId);
+    if (!content?.textContent) throw new Error("the popover is still empty");
+    return content.textContent;
+  })) as string;
+};
+
+describe("given the edit drawer's title", () => {
+  /** @scenario "The edit title names the provider and shows its logo" */
+  it("names the provider it is editing", () => {
+    renderDrawer(anthropicSource({ report: "cost", hasPulled: false }));
+
+    expect(
+      screen.getByRole("heading", { name: "Edit Anthropic Admin API" }),
+    ).toBeTruthy();
+    expect(screen.queryByRole("heading", { name: "Edit source" })).toBeNull();
+  });
+
+  /** @scenario "The edit title names the provider and shows its logo" */
+  it("shows the provider's glyph beside the name", () => {
+    renderDrawer(anthropicSource({ report: "cost", hasPulled: false }));
+
+    // The same mark the Add source menu and the create composer show for this
+    // type. A header that names the provider in words alone is a different
+    // header from the one an admin just came through.
+    expect(screen.getByTestId("source-type-icon")).toBeTruthy();
+  });
+
+  /** @scenario "An unrecognised source type still gets a title" */
+  it("falls back to a plain title for a type it has no entry for", () => {
+    // Every lookup on this drawer is keyed by `SourceType` and simply misses
+    // for a row written by a newer deploy. A missed lookup must leave a title
+    // rather than "Edit undefined" or a blank header.
+    renderDrawer(sourceOfAnUnknownType);
+
+    expect(screen.getByRole("heading", { name: "Edit source" })).toBeTruthy();
+  });
+});
+
+describe("given a source with settings its adapter can no longer change", () => {
+  /** @scenario "A pulled usage source carries the two notes that apply to it" */
+  it("puts the usage source's two notes behind the one marker", async () => {
+    renderDrawer(anthropicSource({ report: "usage", hasPulled: true }));
+    const notes = await openNotes();
+
+    // The usage cursor never rewinds, so both of this source's settings are
+    // fixed once it has pulled.
+    expect(notes).toMatch(/report/i);
+    expect(notes).toMatch(/start/i);
+    // Restating cost history is a cost-source sentence. Shown here it would
+    // describe a repair this source cannot perform.
+    expect(notes).not.toMatch(/restate/i);
+  });
+
+  /** @scenario "A pulled cost source carries a different two" */
+  it("puts the cost source's different two behind the same marker", async () => {
+    renderDrawer(anthropicSource({ report: "cost", hasPulled: true }));
+    const notes = await openNotes();
+
+    expect(notes).toMatch(/report/i);
+    // The cost cursor binds `startingAt` into its own identity, so moving the
+    // start is the deliberate repair lever rather than a setting to lock. The
+    // three notes never all apply at once: a fixed start and a start worth
+    // moving are the two halves of one condition.
+    expect(notes).toMatch(/restate|re-read/i);
+    expect(notes).not.toMatch(/start date can no longer/i);
+  });
+
+  /** @scenario "A source with nothing locked shows no marker at all" */
+  it("shows no marker on a source that has never pulled", () => {
+    // Nothing is locked before a cursor exists, so every note would be
+    // inapplicable — and a marker opening onto an empty popover is worse than
+    // no marker, because it invites a click that answers nothing.
+    renderDrawer(anthropicSource({ report: "cost", hasPulled: false }));
+
+    expect(screen.queryByTestId("edit-source-notes")).toBeNull();
+  });
+
+  /** @scenario "The locked-field notes move behind an information marker" */
+  it("keeps the notes out of the body, where they used to sit", () => {
+    renderDrawer(anthropicSource({ report: "usage", hasPulled: true }));
+
+    // Chakra keeps popover content mounted and hidden while closed, so only a
+    // visibility matcher tells "behind the marker" from "in the body".
+    expect(screen.getByTestId("edit-source-notes")).toBeVisible();
+    expect(
+      screen.getByText(/is fixed once a source has pulled/i),
+    ).not.toBeVisible();
+  });
+
+  /** @scenario "A locked report is still readable and still reachable" */
+  it("leaves a locked report readable and in the tab order", () => {
+    renderDrawer(anthropicSource({ report: "cost", hasPulled: true }));
+
+    const report = screen.getByLabelText("Use Anthropic's reported cost");
+
+    // readOnly, never disabled: a disabled control drops out of the tab order,
+    // where a keyboard or screen-reader user cannot read what it holds. And
+    // what it holds has to be the report's own name — "Off" is the position of
+    // a control this admin can no longer see.
+    expect(report).toHaveProperty("readOnly", true);
+    expect((report as HTMLInputElement).disabled).toBe(false);
+    expect((report as HTMLInputElement).value).toBe("Cost report");
+  });
+});

--- a/platform/app/ee/governance/dashboard/pages/inventory.tsx
+++ b/platform/app/ee/governance/dashboard/pages/inventory.tsx
@@ -2760,21 +2760,21 @@ export function visibleParserFields({
  * The composer values with any select field cleared whose held value is not
  * among the choices its own control offers.
  *
- * The case this exists for: an admin picks a bucket width of `1h`, then
- * switches the report to `cost`. The width is now a value `validBucketWidth`
- * refuses outright — not ignores — so leaving it in place would reject the
- * whole save for a field the form no longer even offers. Clearing it is the
- * only outcome that matches what the admin is being shown.
+ * The shape this exists for: a select whose choices narrow when another field
+ * is answered, leaving a previously valid pick outside the list the admin is
+ * now looking at. A form showing one thing and submitting another is the bug;
+ * clearing the stale pick is the only outcome that matches the screen.
  *
  * Deliberately narrow: text, date and switch fields are never touched,
  * because their domains are not enumerable and "not in the list" means nothing
  * there — for a switch it would mean silently turning a deliberate off back on.
  *
- * Narrow in one more direction since the bucket width was withdrawn: a field
- * the form does not ask about has no control whose list a held value could be
- * stale against. Measured anyway, an hourly source would be cleared to daily
- * on the first render after its drawer opened — a migration performed by
- * looking at a source.
+ * Narrow in one more direction, and the reason no field exercises this today:
+ * only fields the form actually shows are measured. The bucket width was the
+ * one case, and the form no longer asks it — a held width is now decided at
+ * save time by `bucketWidthToStore` instead. Measured here anyway, an hourly
+ * source would be cleared to daily on the first render after its drawer
+ * opened, a migration performed by looking at a source.
  */
 export function reconcileParserValues({
   sourceType,
@@ -2832,8 +2832,9 @@ export type ParserConfigMode = "create" | "edit";
  * Nothing offers a choice between them any more — every screen that reads this
  * data reads it by day, so a finer width multiplies the rows a day costs and
  * changes no figure the pillar shows. The list survives the withdrawal because
- * `validBucketWidth` still measures a stored width against it: the finer
- * widths are withdrawn from new sources, not taken away from the sources
+ * `bucketWidthToStore` still measures a stored width against it, to decide
+ * whether a usage source keeps what it holds or is written down as daily: the
+ * finer widths are withdrawn from new sources, not taken away from the sources
  * already being read at one.
  *
  * The adapter's own `anthropicAdminPullConfigSchema` declares the same domain

--- a/platform/app/ee/governance/dashboard/pages/inventory.tsx
+++ b/platform/app/ee/governance/dashboard/pages/inventory.tsx
@@ -50,7 +50,6 @@ import {
   PULL_ADAPTER_FOR_SOURCE,
   PULL_SCHEDULE_DEFAULTS,
   recommendedPullSchedule,
-  SOURCE_BACKFILL_MONTHS,
 } from "@ee/governance/dashboard/logic/pullCadence";
 import { NON_ENTERPRISE_INGESTION_SOURCE_CAP } from "@ee/governance/services/activity-monitor/ingestionSource.constants";
 import { isOttlEnabledSourceType } from "@ee/governance/services/activity-monitor/ottlStarterTemplates";
@@ -2156,36 +2155,30 @@ function PullConfigEditFields({
    */
   destinationField?: ReactNode;
 }) {
-  const isStartLocked = isBackfillStartLocked({
-    hasPulled,
-    report: parserConfig.report,
-  });
   const lockedKeys = lockedParserKeys({
     hasPulled,
     report: parserConfig.report,
   });
   return (
-    <>
-      <ParserConfigFields
-        sourceType={sourceType}
-        values={parserConfig}
-        onChange={onParserConfigChange}
-        mode="edit"
-        readOnlyKeys={lockedKeys.length > 0 ? lockedKeys : undefined}
-        // Same group, same order as the create drawer: the two forms edit the
-        // same source and must not disagree about where a setting lives.
-        advancedExtras={
-          <>
-            <PullCadenceField
-              sourceType={sourceType}
-              value={pullSchedule}
-              onChange={onPullScheduleChange}
-            />
-            {destinationField}
-          </>
-        }
-      />
-    </>
+    <ParserConfigFields
+      sourceType={sourceType}
+      values={parserConfig}
+      onChange={onParserConfigChange}
+      mode="edit"
+      readOnlyKeys={lockedKeys.length > 0 ? lockedKeys : undefined}
+      // Same group, same order as the create drawer: the two forms edit the
+      // same source and must not disagree about where a setting lives.
+      advancedExtras={
+        <>
+          <PullCadenceField
+            sourceType={sourceType}
+            value={pullSchedule}
+            onChange={onPullScheduleChange}
+          />
+          {destinationField}
+        </>
+      }
+    />
   );
 }
 

--- a/platform/app/ee/governance/dashboard/pages/inventory.tsx
+++ b/platform/app/ee/governance/dashboard/pages/inventory.tsx
@@ -188,10 +188,6 @@ export function defaultParserValues(
   return values;
 }
 
-// Re-exported so the composer's own tests read the table through the module
-// they are testing, rather than reaching past it into the cadence logic.
-export { defaultBackfillStart, SOURCE_BACKFILL_MONTHS };
-
 const blankComposer = (): ComposerState => ({
   sourceType: "otel_generic",
   name: "",

--- a/platform/app/ee/governance/dashboard/pages/inventory.tsx
+++ b/platform/app/ee/governance/dashboard/pages/inventory.tsx
@@ -46,9 +46,11 @@ import type { ToolCard } from "@ee/governance/dashboard/components/toolCatalog/t
 import { inventorySummaryItems } from "@ee/governance/dashboard/logic/inventorySummary";
 import {
   composerCadenceError,
+  defaultBackfillStart,
   PULL_ADAPTER_FOR_SOURCE,
   PULL_SCHEDULE_DEFAULTS,
   recommendedPullSchedule,
+  SOURCE_BACKFILL_MONTHS,
 } from "@ee/governance/dashboard/logic/pullCadence";
 import { NON_ENTERPRISE_INGESTION_SOURCE_CAP } from "@ee/governance/services/activity-monitor/ingestionSource.constants";
 import { isOttlEnabledSourceType } from "@ee/governance/services/activity-monitor/ottlStarterTemplates";
@@ -174,10 +176,21 @@ export function defaultParserValues(
 ): Record<string, string> {
   const values: Record<string, string> = {};
   for (const field of PARSER_FIELDS[sourceType] ?? []) {
-    if (field.defaultValue) values[field.key] = field.defaultValue;
+    // A function default is evaluated once, here, rather than at each render:
+    // a date relative to today read twice either side of midnight would show
+    // one day and save another.
+    const seeded =
+      typeof field.defaultValue === "function"
+        ? field.defaultValue()
+        : field.defaultValue;
+    if (seeded) values[field.key] = seeded;
   }
   return values;
 }
+
+// Re-exported so the composer's own tests read the table through the module
+// they are testing, rather than reaching past it into the cadence logic.
+export { defaultBackfillStart, SOURCE_BACKFILL_MONTHS };
 
 const blankComposer = (): ComposerState => ({
   sourceType: "otel_generic",
@@ -1851,7 +1864,10 @@ export function SourceComposerDrawer({
                 onChange={(e) =>
                   setComposer({ ...composer, description: e.target.value })
                 }
-                placeholder="What this fleet covers + who owns it"
+                // Asks in the same shape as the display name directly above
+                // it. The old prompt asked for two particular facts and used a
+                // word ("fleet") that appears nowhere else an admin can see.
+                placeholder="Description for this source"
               />
             </VStack>
 
@@ -2069,6 +2085,53 @@ export function lockedParserKeys({
 }
 
 /**
+ * What the edit drawer has to explain about settings the adapter can no longer
+ * change, in the order it explains them.
+ *
+ * These were three paragraphs printed in the drawer body above the fields they
+ * describe, which pushed the form below the fold on every source that had
+ * pulled and were scrolled past by everyone who had read them once. They go
+ * behind a (i) beside the title instead — the same place the create composer
+ * already keeps its setup prose. See `dev/docs/best_practices/copywriting.md`.
+ *
+ * Empty for a source with nothing locked, and the header renders no marker at
+ * all in that case: a (i) opening onto nothing is a promise of an explanation
+ * that is not there.
+ *
+ * At most two ever apply. The report locks for any pulled source; of the other
+ * two, the usage cursor never rewinds so its start is fixed, while the cost
+ * cursor binds `startingAt` into its own identity so moving the start is the
+ * deliberate repair lever for figures that are wrong. A fixed start and a
+ * start worth moving are the two halves of one condition, and the report
+ * decides which half this admin is looking at.
+ */
+export function editSourceNotes({
+  hasPulled,
+  report,
+}: {
+  hasPulled: boolean;
+  report: string | undefined;
+}): string[] {
+  const notes: string[] = [];
+  if (lockedParserKeys({ hasPulled, report }).includes("report")) {
+    notes.push(
+      "The report is fixed once a source has pulled: usage and cost describe the same spend, so recording both for one source would count it twice. To switch, archive this source and create a new one.",
+    );
+  }
+  if (isBackfillStartLocked({ hasPulled, report })) {
+    notes.push(
+      "The start date is fixed once a source has pulled: the cursor has already moved past it and never rewinds. To re-read older data, archive this source and create a new one with an earlier start.",
+    );
+  }
+  if (hasPulled && report === "cost") {
+    notes.push(
+      "Moving the start date re-reads cost history from the new date and restates the figures already recorded for that window.",
+    );
+  }
+  return notes;
+}
+
+/**
  * The adapter half of the edit form: the pull config fields plus the cadence,
  * rendered only for a source type the form knows how to rebuild.
  */
@@ -2105,7 +2168,6 @@ function PullConfigEditFields({
     hasPulled,
     report: parserConfig.report,
   });
-  const isReportLocked = lockedKeys.includes("report");
   return (
     <>
       <ParserConfigFields
@@ -2127,26 +2189,6 @@ function PullConfigEditFields({
           </>
         }
       />
-      {isReportLocked && (
-        <Text fontSize="xs" color="fg.muted">
-          The report is fixed once a source has pulled: usage and cost describe
-          the same spend, so recording both for one source would count it twice.
-          To switch, archive this source and create a new one.
-        </Text>
-      )}
-      {isStartLocked && (
-        <Text fontSize="xs" color="fg.muted">
-          The backfill start is fixed once a source has pulled: the cursor has
-          already moved past it and never rewinds. To re-read older data,
-          archive this source and create a new one with an earlier start.
-        </Text>
-      )}
-      {hasPulled && parserConfig.report === "cost" && (
-        <Text fontSize="xs" color="fg.muted">
-          Moving the backfill start re-reads cost history from the new date and
-          restates the figures already recorded for that window.
-        </Text>
-      )}
     </>
   );
 }
@@ -2228,6 +2270,14 @@ export function SourceEditDrawer({
   // a source disabled before its first run never minted one.
   const hasPulled = source?.hasPollerCursor ?? false;
 
+  // Misses for a type this deploy has no entry for, which is why the title
+  // below carries a fallback rather than reading the label straight off.
+  const editMeta = SOURCE_TYPE_OPTIONS.find((o) => o.value === sourceType);
+  const lockNotes = editSourceNotes({
+    hasPulled,
+    report: form.parserConfig.report,
+  });
+
   if (!source) {
     return (
       <Drawer.Root open={false} placement="end" onOpenChange={() => onClose()}>
@@ -2265,9 +2315,31 @@ export function SourceEditDrawer({
       <Drawer.Content>
         <Drawer.Header>
           <Drawer.CloseTrigger />
-          <Heading as="h2" size="md">
-            Edit source
-          </Heading>
+          {/* The same header shape the create composer uses, for the same
+              reason: an admin reaching this drawer from a row action, a detail
+              page or a restored browser tab had nothing telling them which of
+              their sources they were about to change. The fallback covers a
+              row written by a newer deploy, whose type misses every lookup
+              here — a missed lookup has to leave a title rather than "Edit
+              undefined". */}
+          <HStack gap={3}>
+            {sourceType && (
+              <SourceTypeIconGlyph sourceType={sourceType} size="24px" />
+            )}
+            <Heading as="h2" size="md">
+              Edit {editMeta?.label ?? "source"}
+            </Heading>
+            {/* Why a setting is locked, behind the (i) rather than printed
+                above the fields it describes. Rendered only when something
+                actually is: an empty marker promises an explanation that is
+                not there. */}
+            {lockNotes.length > 0 && (
+              <FieldInfoTooltip
+                description={lockNotes.join(" ")}
+                testId="edit-source-notes"
+              />
+            )}
+          </HStack>
         </Drawer.Header>
         <Drawer.Body>
           <SourceEditBody
@@ -2445,6 +2517,24 @@ interface FieldDef {
    */
   visibleWhen?: (values: Record<string, string>) => boolean;
   /**
+   * True for a setting the form carries but never asks about.
+   *
+   * Different from `visibleWhen`, which hides a field for some sibling states
+   * and shows it for others. This one is never shown to anybody, and exists
+   * for a setting that has stopped being a question without ceasing to be a
+   * value — the Anthropic bucket width, withdrawn from new sources while the
+   * sources already reading at a finer one keep doing so.
+   *
+   * Declared rather than deleted because the edit path only carries what is
+   * declared: `seedComposerParserConfig` walks these fields to read a stored
+   * config into the form, and `buildEditedParserConfig` deletes every declared
+   * key before re-spreading what the builder produced. An undeclared field is
+   * therefore not "left alone" — it is dropped from the stored config on the
+   * next save of any other field. Its builder has to decide what to do with
+   * the held value, since nothing on the form will.
+   */
+  hidden?: boolean;
+  /**
    * How the field is rendered. Absent means a text input.
    *
    * A field only earns a `select` when its domain is closed and small enough
@@ -2467,7 +2557,36 @@ interface FieldDef {
    */
   defaultOn?: boolean;
   /**
-   * What a `control: "select"` holds on a form nobody has touched yet.
+   * The two values a `control: "switch"` writes, on and off. Default
+   * `"true"`/`"false"`.
+   *
+   * Declarable because a toggle is a way of ASKING a question, not a change to
+   * what the answer is stored as. The Anthropic report has two states and one
+   * right answer for almost everyone, which is a toggle — but the adapter's
+   * schema reads `"cost"` and `"usage"`, and every source already saved holds
+   * one of those two words. A switch hard-wired to the boolean strings would
+   * open every existing usage source in the on position, because `"usage"` is
+   * neither `"true"` nor `"false"` and the field would fall back to its
+   * default — and the next unrelated edit would save that source as cost.
+   *
+   * Read by `switchFieldIsOn` and by `ParserSwitchInput`, which is the whole
+   * of it: nothing downstream of the form learns that this field is a toggle.
+   */
+  onValue?: string;
+  offValue?: string;
+  /**
+   * What a locked `control: "switch"` reads instead of "On" and "Off".
+   *
+   * Only for a switch whose two states have names of their own. A locked field
+   * is rendered precisely so the admin can read what it holds, and "Off" is
+   * the position of a control they can no longer see — for the Anthropic
+   * report, the question they actually have is which report this source
+   * records. Absent leaves the plain On/Off every other switch wants.
+   */
+  onLabel?: string;
+  offLabel?: string;
+  /**
+   * What a field holds on a form nobody has touched yet.
    *
    * Only for a choice that has a right answer for almost everyone. A required
    * picker with no default asks the admin to read every option to discover
@@ -2475,8 +2594,16 @@ interface FieldDef {
    * only written into `startComposer` would show one answer on create and
    * another on edit. Declared on the field, so the seed and the option list
    * cannot drift.
+   *
+   * A function for a default that cannot be written down ahead of time — a
+   * date relative to today. Called once, when a NEW composer is seeded, so
+   * the value the admin sees and the value the builder is handed are the same
+   * string rather than two evaluations either side of midnight. Never called
+   * on the edit path: `seedComposerParserConfig` reads the stored config and
+   * nothing else, because re-proposing a start here would move a date this
+   * source has already read from, on a drawer opened to change a name.
    */
-  defaultValue?: string;
+  defaultValue?: string | (() => string);
   /**
    * The choices, for `control: "select"`.
    *
@@ -2512,7 +2639,17 @@ export type FieldControl =
   | { kind: "text"; hint?: string }
   | { kind: "date"; hint?: string }
   | { kind: "select"; options: readonly FieldOption[]; hint?: string }
-  | { kind: "switch"; defaultOn: boolean; hint?: string };
+  | {
+      kind: "switch";
+      defaultOn: boolean;
+      /** The two values this switch writes — see `FieldDef.onValue`. */
+      onValue: string;
+      offValue: string;
+      /** What it reads when locked — see `FieldDef.onLabel`. */
+      onLabel: string;
+      offLabel: string;
+      hint?: string;
+    };
 
 export function fieldControl({
   field,
@@ -2524,7 +2661,15 @@ export function fieldControl({
   const hint = field.contextHint?.(values);
   if (field.control === "date") return { kind: "date", hint };
   if (field.control === "switch") {
-    return { kind: "switch", defaultOn: field.defaultOn ?? false, hint };
+    return {
+      kind: "switch",
+      defaultOn: field.defaultOn ?? false,
+      onValue: field.onValue ?? "true",
+      offValue: field.offValue ?? "false",
+      onLabel: field.onLabel ?? "On",
+      offLabel: field.offLabel ?? "Off",
+      hint,
+    };
   }
   if (field.control === "select") {
     return { kind: "select", options: field.options?.(values) ?? [], hint };
@@ -2535,11 +2680,17 @@ export function fieldControl({
 /**
  * Whether a switch field is on, given what the form holds for it.
  *
- * The switch writes "true" or "false" and nothing else, so anything else is a
- * value no control produced — an unset field, a source created before the
+ * A switch writes one of exactly two values and nothing else, so anything else
+ * is a value no control produced — an unset field, a source created before the
  * field existed, a hand-edited config — and says nothing about what the admin
  * chose. The field's own declared default is the answer for all of them, which
  * is what keeps an untouched form and the config it saves agreeing.
+ *
+ * The two values default to "true"/"false" and are overridable because a
+ * toggle is a way of asking, not a change to what is stored: the Anthropic
+ * report is a switch over "cost" and "usage". Pass the field's own pair, or a
+ * source saved on the usage report opens in the ON position — `"usage"` is
+ * neither boolean string, so it would read as unset and take the default.
  *
  * Read by the render and by the builders, deliberately: a second answer to
  * "is this on" is how a toggle ends up showing one state and saving the other.
@@ -2547,13 +2698,68 @@ export function fieldControl({
 export function switchFieldIsOn({
   value,
   defaultOn,
+  onValue = "true",
+  offValue = "false",
 }: {
   value: string | undefined;
   defaultOn: boolean;
+  onValue?: string;
+  offValue?: string;
 }): boolean {
-  if (value === "true") return true;
-  if (value === "false") return false;
+  if (value === onValue) return true;
+  if (value === offValue) return false;
   return defaultOn;
+}
+
+/**
+ * What a locked switch reads, in the words of the setting rather than of the
+ * control.
+ *
+ * A locked field is rendered read-only precisely so the admin can read what it
+ * holds, and for a switch whose two states have names — the Anthropic report —
+ * "Off" answers a question nobody asked. The admin's question is which report
+ * this source records.
+ *
+ * Pure, and separate from the render, so what a locked switch says can be held
+ * against the values it says it about without mounting a drawer.
+ */
+export function switchReadOnlyLabel({
+  control,
+  value,
+}: {
+  control: Extract<FieldControl, { kind: "switch" }>;
+  value: string | undefined;
+}): string {
+  const on = switchFieldIsOn({
+    value,
+    defaultOn: control.defaultOn,
+    onValue: control.onValue,
+    offValue: control.offValue,
+  });
+  return on ? control.onLabel : control.offLabel;
+}
+
+/**
+ * The fields of a source type the form actually asks about: everything not
+ * withdrawn outright, and everything its sibling values leave applicable.
+ *
+ * One predicate because three readers need the same answer — the render, the
+ * required-field check, and the staleness reconcile. A field the render skips
+ * but the required check still demands is a save refused over a control that
+ * is not on the screen; a field the render skips but reconcile still measures
+ * is a held value cleared because nothing offers it any more, which for the
+ * withdrawn bucket width would silently migrate an hourly source to daily.
+ */
+export function visibleParserFields({
+  sourceType,
+  values,
+}: {
+  sourceType: SourceType;
+  values: Record<string, string>;
+}): FieldDef[] {
+  return (PARSER_FIELDS[sourceType] ?? []).filter(
+    (field) => !field.hidden && (field.visibleWhen?.(values) ?? true),
+  );
 }
 
 /**
@@ -2569,6 +2775,12 @@ export function switchFieldIsOn({
  * Deliberately narrow: text, date and switch fields are never touched,
  * because their domains are not enumerable and "not in the list" means nothing
  * there — for a switch it would mean silently turning a deliberate off back on.
+ *
+ * Narrow in one more direction since the bucket width was withdrawn: a field
+ * the form does not ask about has no control whose list a held value could be
+ * stale against. Measured anyway, an hourly source would be cleared to daily
+ * on the first render after its drawer opened — a migration performed by
+ * looking at a source.
  */
 export function reconcileParserValues({
   sourceType,
@@ -2578,7 +2790,7 @@ export function reconcileParserValues({
   values: Record<string, string>;
 }): Record<string, string> {
   let next = values;
-  for (const field of PARSER_FIELDS[sourceType] ?? []) {
+  for (const field of visibleParserFields({ sourceType, values })) {
     const held = values[field.key];
     if (!held) continue;
     const control = fieldControl({ field, values });
@@ -2623,12 +2835,12 @@ export type ParserConfigMode = "create" | "edit";
 /**
  * The bucket widths Anthropic's usage report accepts, newest-grained first.
  *
- * `validBucketWidth` reads it directly. The picker reads it through the type of
- * `ANTHROPIC_BUCKET_WIDTH_LABELS`, which is keyed off this list: it offers daily
- * to everyone and additionally whichever of these a source is already being read
- * at, so opening an old source to edit it does not silently move it to daily.
- * Adding a width here without labelling it there is a build error, which is what
- * keeps the two from parting company.
+ * Nothing offers a choice between them any more — every screen that reads this
+ * data reads it by day, so a finer width multiplies the rows a day costs and
+ * changes no figure the pillar shows. The list survives the withdrawal because
+ * `validBucketWidth` still measures a stored width against it: the finer
+ * widths are withdrawn from new sources, not taken away from the sources
+ * already being read at one.
  *
  * The adapter's own `anthropicAdminPullConfigSchema` declares the same domain
  * server-side and `anthropicFormControls.unit.test.ts` asserts the two still
@@ -2636,90 +2848,6 @@ export type ParserConfigMode = "create" | "edit";
  * second source of truth.
  */
 export const ANTHROPIC_BUCKET_WIDTHS = ["1m", "1h", "1d"] as const;
-
-/**
- * What each width in `ANTHROPIC_BUCKET_WIDTHS` is called on the form.
- *
- * Keyed off that list rather than `string`, so adding a width there without a
- * label here is a build error instead of a picker entry reading `2h`.
- *
- * Daily is deliberately absent: `ANTHROPIC_DAILY_BUCKET_OPTION` owns that
- * wording, and the only reader of this map has already returned for a held
- * `1d` before it gets here. A second copy could only drift from the first.
- */
-const ANTHROPIC_BUCKET_WIDTH_LABELS: Record<
-  Exclude<(typeof ANTHROPIC_BUCKET_WIDTHS)[number], "1d">,
-  string
-> = {
-  "1m": "1m — per minute",
-  "1h": "1h — hourly",
-};
-
-/**
- * The one bucket width either report is read at.
- *
- * Daily on both, and the same entry on both. The cost report has never had a
- * choice — the puller pins `COST_REPORT_BUCKET_WIDTH` and ignores
- * `config.bucketWidth` — and the usage report no longer offers one either: the
- * finer widths multiply the rows a day costs without changing any figure the
- * pillar shows, since every screen that reads this data reads it by day.
- *
- * It carries no value on purpose. Empty means "say nothing", which leaves the
- * adapter's own `1d` default to apply, so the form is not a second place daily
- * is written down and cannot come to disagree with the schema.
- */
-const ANTHROPIC_DAILY_BUCKET_OPTION: FieldOption = {
-  value: "",
-  label: "1d — daily",
-};
-
-/**
- * The bucket widths offered: daily, plus the one this source is already read at
- * if that is something else.
- *
- * Daily alone would have been a silent migration rather than a narrowing.
- * `reconcileParserValues` drops any held value the picker does not offer, so a
- * usage source saved back when `1m` and `1h` were offered would have had its
- * width cleared the next time anyone opened its drawer — for an unrelated
- * change, with nothing on screen saying so. The finer widths are withdrawn from
- * new sources; they are not taken away from the sources already using them.
- *
- * The retained entry is the held value verbatim, so choosing daily is still how
- * you move off it. `1d` is not retained — the daily entry already means daily,
- * and two entries saying so is a choice between identical answers.
- *
- * Exactly two things retire a held width, and both are stated positively here
- * rather than deferred to `validBucketWidth`. That function answers a different
- * question — what the builder may store — and its "anything but `usage`"
- * includes the empty report, which on this side of the form is not a verdict
- * but a state the admin passes through: the report picker keeps an empty entry
- * so a cleared field is refused rather than refilled, so clearing it to re-pick
- * it is an ordinary gesture. Reading a drop out of that would take the width
- * away mid-gesture and not give it back — the silent migration this function
- * exists to prevent, arriving by a second route. Nothing can be saved from that
- * state regardless: the builder refuses an empty report before it reads a width.
- */
-function anthropicBucketWidthOptions(
-  values: Record<string, string>,
-): readonly FieldOption[] {
-  const held = (values.bucketWidth ?? "").trim();
-  if (held === "" || held === "1d") return [ANTHROPIC_DAILY_BUCKET_OPTION];
-
-  // Positively cost: the puller pins `COST_REPORT_BUCKET_WIDTH` and ignores the
-  // setting, so a width stored here was never in effect.
-  const report = (values.report ?? "").trim().toLowerCase();
-  if (report === "cost") return [ANTHROPIC_DAILY_BUCKET_OPTION];
-
-  // Not a width the adapter knows — a hand-edited config, or one saved before
-  // the domain changed. There is nothing to offer and nothing to keep.
-  const label =
-    ANTHROPIC_BUCKET_WIDTH_LABELS[
-      held as keyof typeof ANTHROPIC_BUCKET_WIDTH_LABELS
-    ];
-  if (!label) return [ANTHROPIC_DAILY_BUCKET_OPTION];
-
-  return [ANTHROPIC_DAILY_BUCKET_OPTION, { value: held, label }];
-}
 
 /**
  * Whether a Copilot Studio source reads the tenant's seat licences when nobody
@@ -3008,10 +3136,11 @@ export const PARSER_FIELDS: Record<SourceType, FieldDef[]> = {
     },
     {
       key: "startingAt",
-      label: "Backfill start (optional)",
+      label: "Read history from",
       placeholder: "",
-      hint: "The day the first run reads from. Later runs follow on from where the last one stopped. Empty = 3 calendar days back at midnight UTC. Spend broken down by API key is only available from December 2025 onward; earlier days are still read and still name the person, just not the key.",
+      hint: "The first day we read data for. Later runs continue forward from where the last one stopped. Clear it to read only the last few days. Spend broken down by API key is only available from December 2025 onward; earlier days are still read and still name the person, just not the key.",
       control: "date",
+      defaultValue: () => defaultBackfillStart("openai_admin") ?? "",
     },
   ],
   claude_compliance: [
@@ -3047,44 +3176,62 @@ export const PARSER_FIELDS: Record<SourceType, FieldDef[]> = {
     },
     {
       key: "report",
-      label: "Report",
+      // Named for what the admin gets rather than for the setting. A toggle's
+      // label can only name one side, so it names the side that is on.
+      label: "Use Anthropic's reported cost",
       placeholder: "",
-      hint: "Exactly one per source. `cost` carries Anthropic's own reported spend (Priority Tier usage is excluded, so it is close to but not the invoice); `usage` pulls token counts that we price ourselves. Never create both reports for the same organization — the same spend would be counted twice.",
-      required: true,
-      control: "select",
-      // Cost, because it is what almost every organization adds this source
-      // for: it is the provider's own figure for what was spent, and the usage
-      // report is the specialist choice made by someone who wants our pricing
-      // applied to raw token counts instead.
+      // Everything the two-entry picker conveyed by listing both reports has
+      // to live here instead, or an admin turning this off is not told what
+      // they are turning it on to.
+      hint: "On: Anthropic's own daily spend figure, which is what almost everyone wants (Priority Tier usage is excluded, so it is close to but not the invoice). Off: raw token counts that we price ourselves. A source records one report only, never both — pointing two sources at the same organization would count the same spend twice.",
+      // Two states, and one of them right for almost every organization: the
+      // provider's own figure for what was spent. The usage report is the
+      // specialist choice, made by someone who wants our pricing applied to
+      // raw token counts instead. A two-entry picker asked the admin to read
+      // both lines to discover it had already been decided for them.
+      control: "switch",
+      defaultOn: true,
+      // The adapter's own words, unchanged. `anthropicAdmin.puller.ts` still
+      // reads "cost" and "usage", and every source already saved holds one of
+      // them — this is a different way of asking the same question, not a
+      // change to what any source stores.
+      onValue: "cost",
+      offValue: "usage",
+      // What it reads once it locks. "Off" is the position of a control the
+      // admin can no longer see; the question they have is which report this
+      // source records.
+      onLabel: "Cost report",
+      offLabel: "Usage report",
+      // Not required, because a toggle has no empty state to refuse: it is one
+      // of two values from the moment the composer seeds it, and the seed is
+      // what makes dropping the flag safe.
       defaultValue: "cost",
-      // The empty first entry stays even though the field now opens on an
-      // answer: an admin who clears the picker has said something, and the
-      // form refuses the save and marks the field rather than quietly
-      // reinstating the default they just removed.
-      options: () => [
-        { value: "", label: "Select a report…" },
-        { value: "usage", label: "Usage — token counts, priced by us" },
-        { value: "cost", label: "Cost — Anthropic's reported spend" },
-      ],
     },
     {
       key: "bucketWidth",
       label: "Bucket width",
       placeholder: "",
-      hint: "How finely the usage report is bucketed. Only the usage report reads this; cost is always daily.",
-      control: "select",
-      options: anthropicBucketWidthOptions,
-      contextHint: (values) =>
-        (values.report ?? "").trim().toLowerCase() === "cost"
-          ? "The cost report is always daily — Anthropic buckets it that way and the puller pins it, so there is nothing to choose here."
-          : undefined,
+      hint: "How finely the usage report is bucketed.",
+      // Never asked. Every screen that reads this data reads it by day, so the
+      // finer widths multiply the rows a day costs and change no figure the
+      // pillar shows — the answer was always daily and asking was the mistake.
+      //
+      // Declared rather than deleted, because the edit path only carries what
+      // is declared: `seedComposerParserConfig` would not read a stored `1h`
+      // into the form and `buildEditedParserConfig` would delete it from the
+      // stored config, so an hourly source would be migrated to daily by an
+      // admin opening its drawer to change its name.
+      // `buildAnthropicAdminPullConfig` is what decides the held value's fate,
+      // since nothing on the form will.
+      hidden: true,
     },
     {
       key: "startingAt",
-      label: "Backfill start (optional)",
+      label: "Read history from",
       placeholder: "",
-      hint: "The day the first run reads from. Later runs follow the cursor instead. Empty = 3 calendar days back at midnight UTC for cost, 1 calendar day back at midnight UTC for usage.",
+      hint: "The first day we read data for. Later runs continue forward from where the last one stopped. Clear it to read only the last few days.",
       control: "date",
+      defaultValue: () => defaultBackfillStart("anthropic_admin") ?? "",
     },
   ],
   databricks_genie: [
@@ -3420,8 +3567,10 @@ export function buildAnthropicAdminPullConfig(
   if (!token && shouldRequireCredentials) return null;
   if (report !== "usage" && report !== "cost") return null;
 
-  const bucketWidth = validBucketWidth(trimmedField(p, "bucketWidth"), report);
-  if (bucketWidth === null) return null;
+  const bucketWidth = bucketWidthToStore(
+    trimmedField(p, "bucketWidth"),
+    report,
+  );
 
   const startingAt = normalizeStartingAt(trimmedField(p, "startingAt"));
   if (startingAt === null) return null;
@@ -3482,24 +3631,30 @@ function trimmedField(p: Record<string, string>, key: string): string {
 }
 
 /**
- * The bucket width to store, or null when it is one the adapter will not honour.
+ * The bucket width to store, or undefined to leave the key out entirely.
  *
- * Only the usage report reads this. The cost report pins `1d` — the puller sends
- * `COST_REPORT_BUCKET_WIDTH` and deliberately ignores `config.bucketWidth` — so
- * saving `1m` on a cost source writes a setting that silently never applies, and
- * the form's own hint already promises the opposite.
+ * The form stopped asking, so this is the only thing deciding what happens to a
+ * width a source is already holding — and it can no longer refuse one. A
+ * refusal would block the save over a control that is not on the screen, which
+ * on the old picker was at least a field the admin could see and correct.
  *
- * Empty yields undefined (the field is optional); rejected yields null.
+ * Cost drops any held width. The puller sends `COST_REPORT_BUCKET_WIDTH` and
+ * deliberately ignores `config.bucketWidth`, so a width stored on a cost source
+ * was never in effect and there is nothing to preserve.
+ *
+ * Usage keeps a width the adapter still honours, and otherwise writes daily.
+ * Keeping it is what makes withdrawing the question safe: the finer widths are
+ * taken off new sources, not off the sources already being read at one, and an
+ * admin editing a name has not asked for a settings change. Writing `1d` rather
+ * than omitting it is deliberate — the adapter defaults to daily too, but a
+ * stored config that says nothing cannot be told from one saved before the
+ * field existed, and this source runs daily either way.
  */
-function validBucketWidth(
-  raw: string,
-  report: string,
-): string | null | undefined {
-  if (!raw) return undefined;
-  if (report !== "usage") return null;
+function bucketWidthToStore(raw: string, report: string): string | undefined {
+  if (report !== "usage") return undefined;
   return (ANTHROPIC_BUCKET_WIDTHS as readonly string[]).includes(raw)
     ? raw
-    : null;
+    : "1d";
 }
 
 /** Whether y-m-d is a date that exists, rather than one Date would roll forward. */
@@ -3891,31 +4046,46 @@ function ParserSelectInput({
  */
 function ParserSwitchInput({
   ariaLabel,
-  defaultOn,
+  control,
   fieldKey,
   readOnly,
   value,
   onChange,
 }: {
   ariaLabel: string;
-  defaultOn: boolean;
+  /**
+   * The resolved switch control, rather than its parts.
+   *
+   * It carries four things that have to agree — the default, the two values
+   * written, and the two labels shown when locked — and passing them
+   * separately is how a caller comes to hand this one field's default beside
+   * another's values.
+   */
+  control: Extract<FieldControl, { kind: "switch" }>;
   fieldKey: string;
   readOnly: boolean;
   value: string;
   onChange: (next: string) => void;
 }) {
-  const on = switchFieldIsOn({ value, defaultOn });
+  const on = switchFieldIsOn({
+    value,
+    defaultOn: control.defaultOn,
+    onValue: control.onValue,
+    offValue: control.offValue,
+  });
 
   // Same reasoning as the select branch below: a switch has no readOnly
   // either, and `disabled` would drop it out of the tab order where a keyboard
   // or screen-reader user could not read what it holds. So a locked toggle is
-  // shown as its own state in a readOnly input instead.
+  // shown as its own state in a readOnly input instead — in the words of the
+  // setting where it has any, since "Off" is the position of a control this
+  // admin can no longer see.
   if (readOnly) {
     return (
       <Input
         size="sm"
         aria-label={ariaLabel}
-        value={on ? "On" : "Off"}
+        value={switchReadOnlyLabel({ control, value })}
         readOnly
       />
     );
@@ -3925,8 +4095,12 @@ function ParserSwitchInput({
     <Switch
       checked={on}
       // Never blank: blank means the field's declared default, which is not
-      // always off, so writing it back would flip a deliberate choice.
-      onCheckedChange={({ checked }) => onChange(checked ? "true" : "false")}
+      // always off, so writing it back would flip a deliberate choice. And the
+      // field's own two values, not the boolean strings — the Anthropic report
+      // is a toggle over "cost" and "usage".
+      onCheckedChange={({ checked }) =>
+        onChange(checked ? control.onValue : control.offValue)
+      }
       // The field label beside this is a heading, not a bound <label>, so the
       // accessible name has to come from the control itself.
       inputProps={{
@@ -4014,7 +4188,7 @@ function ParserFieldInput({
     return (
       <ParserSwitchInput
         ariaLabel={ariaLabel}
-        defaultOn={control.defaultOn}
+        control={control}
         fieldKey={fieldKey}
         readOnly={readOnly}
         value={value}
@@ -4268,8 +4442,7 @@ export function missingRequiredParserFieldKeys({
   values: Record<string, string>;
   mode?: ParserConfigMode;
 }): string[] {
-  return (PARSER_FIELDS[sourceType] ?? [])
-    .filter((field) => field.visibleWhen?.(values) ?? true)
+  return visibleParserFields({ sourceType, values })
     .filter((field) => parserFieldPresentation({ field, mode }).isRequired)
     .filter((field) => (values[field.key] ?? "").trim() === "")
     .map((field) => field.key);
@@ -4328,10 +4501,9 @@ export function ParserConfigFields({
     if (reconciled !== values) onChange(reconciled);
   }, [sourceType, values, onChange]);
 
-  const fields = PARSER_FIELDS[sourceType];
-  const isVisible = (f: FieldDef) => f.visibleWhen?.(values) ?? true;
-  const primaryFields = fields.filter((f) => !f.advanced && isVisible(f));
-  const advancedFields = fields.filter((f) => f.advanced && isVisible(f));
+  const fields = visibleParserFields({ sourceType, values });
+  const primaryFields = fields.filter((f) => !f.advanced);
+  const advancedFields = fields.filter((f) => f.advanced);
   const isInvalid = (key: string) => invalidKeys?.includes(key) ?? false;
   // A refusal opens the group rather than merely marking what is inside it.
   // Left closed, the admin is told the save failed and shown a form on which

--- a/platform/app/ee/governance/dashboard/pages/inventory.tsx
+++ b/platform/app/ee/governance/dashboard/pages/inventory.tsx
@@ -2314,7 +2314,11 @@ export function SourceEditDrawer({
               undefined". */}
           <HStack gap={3}>
             {sourceType && (
-              <SourceTypeIconGlyph sourceType={sourceType} size="24px" />
+              <SourceTypeIconGlyph
+                sourceType={sourceType}
+                size="24px"
+                testId="source-type-icon"
+              />
             )}
             <Heading as="h2" size="md">
               Edit {editLabel}

--- a/platform/app/ee/governance/dashboard/pages/inventory.tsx
+++ b/platform/app/ee/governance/dashboard/pages/inventory.tsx
@@ -2262,7 +2262,7 @@ export function SourceEditDrawer({
   // Misses for a type this deploy has no entry for — a row written by a newer
   // one — so the title falls back to the generic word rather than to
   // "Edit undefined".
-  const editLabel = SOURCE_TYPE_LABEL[sourceType] ?? "source";
+  const editLabel = (sourceType && SOURCE_TYPE_LABEL[sourceType]) ?? "source";
   const lockNotes = editSourceNotes({
     hasPulled,
     report: form.parserConfig.report,

--- a/platform/app/ee/governance/dashboard/pages/inventory.tsx
+++ b/platform/app/ee/governance/dashboard/pages/inventory.tsx
@@ -279,8 +279,8 @@ function resolvePullConfig(
         buildAnthropicAdminPullConfig(composer, { shouldRequireCredentials }),
       "Missing or invalid Anthropic fields",
       shouldRequireCredentials
-        ? "Admin API key is required, report must be `usage` or `cost`, bucket width is usage-only and must be 1m/1h/1d, and the backfill start must be a calendar date (2026-08-01) or an instant carrying a timezone (2026-08-01T00:00:00Z)."
-        : "Report must be `usage` or `cost`, bucket width is usage-only and must be 1m/1h/1d, and the backfill start must be a calendar date (2026-08-01) or an instant carrying a timezone (2026-08-01T00:00:00Z). Leave the admin API key blank to keep the current one.",
+        ? "Admin API key is required, report must be `usage` or `cost`, and the backfill start must be a calendar date (2026-08-01) or an instant carrying a timezone (2026-08-01T00:00:00Z)."
+        : "Report must be `usage` or `cost`, and the backfill start must be a calendar date (2026-08-01) or an instant carrying a timezone (2026-08-01T00:00:00Z). Leave the admin API key blank to keep the current one.",
     ],
   };
 

--- a/platform/app/ee/governance/dashboard/pages/inventory.tsx
+++ b/platform/app/ee/governance/dashboard/pages/inventory.tsx
@@ -4418,8 +4418,9 @@ function AdvancedSettingsGroup({
 /**
  * The required fields this form is showing that hold nothing.
  *
- * Visibility first: a field hidden by `visibleWhen` is not something the admin
- * can answer, and marking one red points at a control that is not on screen.
+ * Visibility first, in the `visibleParserFields` sense — `hidden` as well as
+ * `visibleWhen`: a field the form never puts on screen is not something the
+ * admin can answer, and marking one red points at a control that is not there.
  * Requiredness comes from `parserFieldPresentation`, the same answer the label
  * beside the input renders its asterisk from, so the form cannot mark a field
  * required and then refuse to complain about it — or complain about one it

--- a/platform/app/ee/governance/dashboard/pages/inventory.tsx
+++ b/platform/app/ee/governance/dashboard/pages/inventory.tsx
@@ -3547,8 +3547,8 @@ export function buildClaudeCompliancePullConfig(
  * key with an empty one and break the source on its next run.
  *
  * Every other check stays shared. Forking a second builder for the edit form
- * is how the two paths would drift into disagreeing about what a valid bucket
- * width is.
+ * is how the two paths would drift into disagreeing about which reports the
+ * adapter accepts, or which start dates it can read.
  */
 export function buildAnthropicAdminPullConfig(
   c: ComposerState,

--- a/platform/app/ee/governance/dashboard/pages/inventory.tsx
+++ b/platform/app/ee/governance/dashboard/pages/inventory.tsx
@@ -2259,9 +2259,10 @@ export function SourceEditDrawer({
   // a source disabled before its first run never minted one.
   const hasPulled = source?.hasPollerCursor ?? false;
 
-  // Misses for a type this deploy has no entry for, which is why the title
-  // below carries a fallback rather than reading the label straight off.
-  const editMeta = SOURCE_TYPE_OPTIONS.find((o) => o.value === sourceType);
+  // Misses for a type this deploy has no entry for — a row written by a newer
+  // one — so the title falls back to the generic word rather than to
+  // "Edit undefined".
+  const editLabel = SOURCE_TYPE_LABEL[sourceType] ?? "source";
   const lockNotes = editSourceNotes({
     hasPulled,
     report: form.parserConfig.report,
@@ -2316,7 +2317,7 @@ export function SourceEditDrawer({
               <SourceTypeIconGlyph sourceType={sourceType} size="24px" />
             )}
             <Heading as="h2" size="md">
-              Edit {editMeta?.label ?? "source"}
+              Edit {editLabel}
             </Heading>
             {/* Why a setting is locked, behind the (i) rather than printed
                 above the fields it describes. Rendered only when something

--- a/platform/app/ee/governance/dashboard/pages/inventory.tsx
+++ b/platform/app/ee/governance/dashboard/pages/inventory.tsx
@@ -3178,7 +3178,7 @@ export const PARSER_FIELDS: Record<SourceType, FieldDef[]> = {
       // Everything the two-entry picker conveyed by listing both reports has
       // to live here instead, or an admin turning this off is not told what
       // they are turning it on to.
-      hint: "On: Anthropic's own daily spend figure, which is what almost everyone wants (Priority Tier usage is excluded, so it is close to but not the invoice). Off: raw token counts that we price ourselves. A source records one report only, never both — pointing two sources at the same organization would count the same spend twice.",
+      hint: "On: Anthropic's own daily spend figure, which is what almost everyone wants (Priority Tier usage is excluded, so it is close to but not the invoice). Off: raw token counts that we price ourselves. A source records one report only, never both: pointing two sources at the same organization would count the same spend twice.",
       // Two states, and one of them right for almost every organization: the
       // provider's own figure for what was spent. The usage report is the
       // specialist choice, made by someone who wants our pricing applied to
@@ -3224,7 +3224,7 @@ export const PARSER_FIELDS: Record<SourceType, FieldDef[]> = {
       key: "startingAt",
       label: "Read history from",
       placeholder: "",
-      hint: "The first day we read data for. Later runs continue forward from where the last one stopped. Clear it to read only the last few days.",
+      hint: "The first day we read data for. Later runs continue forward from where the last one stopped. Clear it to read only the last few days. On the usage report this date is fixed once the source has pulled.",
       control: "date",
       defaultValue: () => defaultBackfillStart("anthropic_admin") ?? "",
     },

--- a/platform/app/specs/governance/edit-pull-source-config.feature
+++ b/platform/app/specs/governance/edit-pull-source-config.feature
@@ -36,16 +36,19 @@ Feature: Edit the configuration of a pull-mode ingestion source
 
   Rule: Adapter settings are validated before they reach the database
 
-    Scenario: A backfill start date is normalized before saving
-      When the admin enters a backfill start of "2026-08-01"
+    Scenario: A date read from history is normalized before saving
+      When the admin picks a "Read history from" date of "2026-08-01"
       And saves the form
-      Then the stored backfill start is a timezone-carrying instant
+      Then the stored start is a timezone-carrying instant
 
-    Scenario: An invalid bucket width is rejected at save time
-      When the admin enters a bucket width of "5m"
-      And saves the form
-      Then the form reports the value as invalid
-      And the source configuration is left unchanged
+    # The adapter reads usage in daily buckets and prices cost in daily
+    # buckets, so a width is a question with one answer. Asking it only gave
+    # an admin a way to answer it wrongly and have the save refused.
+
+    Scenario: The bucket width is decided for the admin, not asked of them
+      When the admin opens the edit form
+      Then no bucket width field is shown
+      And saving a usage source stores a bucket width of "1d"
 
     Scenario: An invalid cron expression is rejected at save time
       When the admin enters a pull schedule of "not a cron"
@@ -55,26 +58,39 @@ Feature: Edit the configuration of a pull-mode ingestion source
 
   Rule: A setting that can no longer take effect is not offered as editable
 
-    # The usage cursor deliberately never rewinds, so a backfill start edited
+    # The usage cursor deliberately never rewinds, so a start date edited
     # after the first successful run is accepted and then ignored. An input
-    # that silently does nothing is worse than no input.
+    # that silently does nothing is worse than no input. The cost cursor is a
+    # different animal: it binds the start into its own identity, so moving
+    # the start there is the deliberate lever for repairing wrong figures and
+    # locking it would hide the only repair an admin has.
 
-    Scenario: Backfill start is editable before the source has run
+    Scenario: The start date is editable before the source has run
       Given the source has not yet completed a pull
       When the admin opens the edit form
-      Then the backfill start is editable
+      Then "Read history from" is editable
 
-    Scenario: Backfill start is not editable once the cursor has moved
+    Scenario: A usage source's start date is fixed once the cursor has moved
       Given the source has completed at least one pull
       When the admin opens the edit form
-      Then the backfill start is shown but cannot be changed
-      And the form explains that the cursor has already moved past it
+      Then "Read history from" is shown but cannot be changed
+      And the drawer title carries an information marker explaining why
+      # The explanation sits behind that marker rather than as a paragraph
+      # under the fields, where three of them pushed the fields below the
+      # fold. See dev/docs/best_practices/copywriting.md.
+
+    Scenario: A cost source's start date stays editable after it has pulled
+      Given the source reads the cost report
+      And the source has completed at least one pull
+      When the admin opens the edit form
+      Then "Read history from" is editable
+      And the marker says moving it re-reads and restates cost history
 
   Rule: The report kind is fixed once a source has pulled
 
     # The adapter's two reports price the same spend twice over, and its own
     # header states the rule as "Never both". A changed report no longer
-    # matches the stored cursor, so the new report replays from the backfill
+    # matches the stored cursor, so the new report replays from the configured
     # start and its events land beside the old ones under different ids —
     # nothing collides, nothing complains, and the same money is counted twice.
 

--- a/platform/app/src/components/governance/people/UnifiedPeopleTable.tsx
+++ b/platform/app/src/components/governance/people/UnifiedPeopleTable.tsx
@@ -64,13 +64,17 @@ const EVIDENCE_LABEL: Record<string, string> = {
 /**
  * The provider's own name where we have one, its identifier where we do not.
  *
- * The catalog's labels carry a parenthetical qualifier for the sources that
- * come in more than one flavour ("Anthropic Admin API (usage & cost)"). That
- * qualifier tells an administrator which connector to pick on the inventory
- * screen; on a person's row it is three extra words about a source they did
- * not choose, and it is what pushed the badge onto a line of its own and made
- * one row twice the height of its neighbours. Dropping it shortens the label
- * without abbreviating any word in it.
+ * Some of the catalog's labels carry a parenthetical qualifier — "Claude Code
+ * (Anthropic OAuth)", "Anthropic Claude (Cowork)". That qualifier tells an
+ * administrator which connector to pick on the inventory screen; on a person's
+ * row it is extra words about a source they did not choose, and it is what
+ * pushed the badge onto a line of its own and made one row twice the height of
+ * its neighbours. Dropping it shortens the label without abbreviating any word
+ * in it.
+ *
+ * The Anthropic Admin API label used to be the worst of these ("...(usage &
+ * cost)") and no longer is: it names the product now, and which report a
+ * source pulls is asked in the composer. The trim stays for the rest.
  */
 export function providerLabel(provider: string): string {
   const label =

--- a/platform/app/src/components/ui/IconGlyph.tsx
+++ b/platform/app/src/components/ui/IconGlyph.tsx
@@ -14,13 +14,22 @@ export function IconGlyph({
   icon,
   monochrome = false,
   size = "16px",
+  testId,
 }: {
   icon: React.ReactNode;
   monochrome?: boolean;
   size?: string | number;
+  /**
+   * The mark carries no text, so a test asserting a surface shows a vendor
+   * has nothing else to find it by. Goes on this Box rather than a wrapper:
+   * a wrapper would become the flex item in every render site and swallow
+   * the flexShrink and inline-flex below.
+   */
+  testId?: string;
 }) {
   return (
     <Box
+      data-testid={testId}
       width={size}
       height={size}
       flexShrink={0}

--- a/specs/ai-gateway/governance/ingestion-sources.feature
+++ b/specs/ai-gateway/governance/ingestion-sources.feature
@@ -73,6 +73,15 @@ Feature: IngestionSource — admin configuration of cross-platform feeds
       is not a mode word)
 
   @integration
+  Scenario: A type is named after the product, not after what it returns
+    When the admin opens the "Add source" menu
+    Then the Anthropic entry reads "Anthropic Admin API"
+    And it does not list in its own name the reports it can pull
+    # The old label was "Anthropic Admin API (usage & cost)". A menu is for
+    # picking a product, and the parenthetical answered a question the
+    # composer asks two fields later — where the admin can actually choose.
+
+  @integration
   Scenario: Non-enterprise plans see locked source types they cannot pick
     Given the org is on a non-enterprise plan
     When the admin opens the "Add source" menu
@@ -120,6 +129,120 @@ Feature: IngestionSource — admin configuration of cross-platform feeds
     And the composer offers no source-type dropdown
     And the composer starts from a blank configuration for the picked type,
       even when a different type was being composed moments before
+
+  Rule: The two fields every source shares ask for the same thing the same way
+
+    @integration
+    Scenario: The description field asks for a description
+      When the admin opens the composer for any source type
+      Then the empty description field reads "Description for this source"
+      And the empty display name field reads "Display name for this source"
+      # The description used to prompt "What this fleet covers + who owns it",
+      # which asked for two particular facts and used a word ("fleet") that
+      # appears nowhere else the admin can see. The two fields sit on top of
+      # each other and now ask in the same shape.
+
+  Rule: A scheduled source proposes how far back to read, in plain words
+
+    A new source with no history is worth almost nothing on the day it is
+    added, so the form proposes a start rather than leaving it empty. The
+    proposal is per source type, because providers differ in how far back
+    they will serve. Both are declared in one table beside the cadence
+    defaults, so the proposal and any copy describing it read one source.
+
+    @unit
+    Scenario: The field asks when to start reading, not for a backfill start
+      When the admin looks at the field on an OpenAI Admin source
+      Then it is labelled "Read history from"
+      And the hint says this is the first day we read data for
+      And that later runs continue forward from where the last one stopped
+      And that clearing it reads only the last few days
+      And it still notes that spend broken down by API key is only available
+        from December 2025 onward, with earlier days still read and still
+        naming the person
+
+    @unit
+    Scenario: A new OpenAI source proposes a year of history
+      When the admin opens the composer on the OpenAI Admin type
+      Then the field holds midnight UTC one year before today
+      # The provider serves four years back, so a year is a deliberate choice
+      # rather than a limit: enough to show a year-on-year trend on day one
+      # without a first run that reads four years of days.
+
+    @unit
+    Scenario: Editing an existing source shows what it holds
+      Given an OpenAI Admin source was saved reading history from a
+        particular day
+      When the admin opens it to edit
+      Then the field shows that day
+      And it is not replaced by one year before today
+
+    @unit
+    Scenario: Clearing the proposal still means the adapter's own default
+      When the admin clears the field on a new source and creates it
+      Then the stored configuration carries no start date
+      And the adapter's own default decides how far back the first run reads
+
+  Rule: The edit drawer names the source it is editing
+
+    @integration
+    Scenario: The edit title names the provider and shows its logo
+      When the admin opens an "Anthropic Admin API" source for editing
+      Then the drawer title reads "Edit Anthropic Admin API"
+      And the provider's logo sits beside it
+      And the same is true for every other source type, each naming its own
+      # The title used to read "Edit source" for all of them. An admin who
+      # reached the drawer from a row, a detail page or a browser tab had
+      # nothing in the header telling them which source they were changing.
+
+    @integration
+    Scenario: An unrecognised source type still gets a title
+      Given a source whose type the composer has no entry for
+      When the admin opens it for editing
+      Then the drawer title reads "Edit source"
+
+  Rule: Notes about why a field is locked sit behind the title, not above the fields
+
+    @integration
+    Scenario: The locked-field notes move behind an information marker
+      Given an Anthropic Admin API source that has already pulled
+      When the admin opens it for editing
+      Then the note explaining that the report is fixed once a source has
+        pulled is not a paragraph under the fields
+      And it is reachable from an information marker beside the drawer title
+      # Same rule the create drawer's prerequisites already follow: three
+      # paragraphs of explanation printed in the body push the fields they
+      # describe below the fold, and are scrolled past by everyone who read
+      # them once. See dev/docs/best_practices/copywriting.md.
+
+    @integration
+    Scenario: A pulled usage source carries the two notes that apply to it
+      Given an Anthropic Admin API source on the usage report that has
+        already pulled
+      When the admin opens it for editing
+      Then the marker carries the note that the report is fixed and the note
+        that the start date is fixed
+      And it does not carry the note about restating cost history
+
+    @integration
+    Scenario: A pulled cost source carries a different two
+      Given an Anthropic Admin API source on the cost report that has
+        already pulled
+      When the admin opens it for editing
+      Then the marker carries the note that the report is fixed and the note
+        that moving the start re-reads and restates cost history
+      And it does not say the start date is fixed, because on a cost source
+        it is not: moving it is the deliberate lever for repairing figures
+      # The three notes never all apply at once. A fixed start and a start
+      # worth moving are the two halves of one condition, and which half an
+      # admin sees is decided by the report.
+
+    @integration
+    Scenario: A source with nothing locked shows no marker at all
+      Given an Anthropic Admin API source that has never pulled
+      When the admin opens it for editing
+      Then no information marker appears beside the drawer title
+      # An empty marker is a promise of an explanation that is not there.
 
   Rule: The Genie composer leads with the credential that survives a schedule
 
@@ -302,7 +425,7 @@ Feature: IngestionSource — admin configuration of cross-platform feeds
 
     @integration
     Scenario: A source that pulls counts is offered no destination
-      When the admin composes an "Anthropic Admin API (usage & cost)" source,
+      When the admin composes an "Anthropic Admin API" source,
         which pulls usage totals rather than conversations
       Then no destination picker appears in the drawer
       And the same is true when editing it
@@ -367,7 +490,7 @@ Feature: IngestionSource — admin configuration of cross-platform feeds
 
     @unit
     Scenario: A counts-pulling source with a destination still routes nothing
-      Given an "Anthropic Admin API (usage & cost)" source has a
+      Given an "Anthropic Admin API" source has a
         destination project stored on it, which its own drawer never
         offered and nothing on the way in refused
       When a run pulls its usage and cost totals

--- a/specs/governance/anthropic-source-form-controls.feature
+++ b/specs/governance/anthropic-source-form-controls.feature
@@ -143,8 +143,11 @@ Feature: Choose Anthropic adapter settings instead of typing them
       And the hint says this is the first day we read data for
       And that later runs continue forward from where the last one stopped
       And that clearing it reads only the last few days
+      And that on the usage report the date is fixed once the source has pulled
       # "Backfill start" is our word for it, and "optional" described the form
       # rather than the setting. The admin's question is how far back to read.
+      # The lock is said here, on the form where the date is still a choice,
+      # because by the time the edit drawer explains it the choice is made.
 
     @unit
     Scenario: A new Anthropic source proposes six months of history

--- a/specs/governance/anthropic-source-form-controls.feature
+++ b/specs/governance/anthropic-source-form-controls.feature
@@ -1,127 +1,181 @@
 # SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
 Feature: Choose Anthropic adapter settings instead of typing them
   As an organization admin adding or editing an Anthropic Admin API source
-  I want the fields whose answers come from a fixed list to be pickers
+  I want each setting rendered as the shape of its own answer — a toggle for a
+  two-state choice, a calendar for a day — and settings with one right answer
+  not asked at all
   So that I choose from what the adapter accepts rather than recalling it from
   a hint and learning I was wrong from a rejected save
 
   Background:
     Given an organization with the ingestionSources:manage permission
-    And the source composer is open on the anthropic_admin adapter
+    And the source composer or the edit drawer is open on the anthropic_admin
+      adapter — the create form unless a scenario opens an existing source
 
-  Rule: A field with a closed set of answers is chosen, not typed
+  Rule: A setting with two states and a right answer for almost everyone is a toggle
 
     @unit
-    Scenario: The report offers the two reports that exist and nothing else
+    Scenario: The report is one toggle named for what the admin gets
       When the admin looks at the report field
-      Then the choices are exactly the usage report and the cost report
+      Then it is rendered as a toggle rather than a list
+      And the toggle is labelled "Use Anthropic's reported cost"
+      # The old picker asked the admin to read two report names and work out
+      # which one they were always going to choose. There are exactly two
+      # states and one of them is right for almost every organization, which
+      # is the case a toggle exists for.
 
     @unit
-    Scenario: The bucket width is daily whichever report is chosen
-      Given the report is set to usage
-      When the admin looks at the bucket width field
-      Then the only entry offered is the daily one
-      And it carries no value, so the adapter's own default decides
-      And that default is daily, so the entry does not name a width the
-        source will not be read at
-      # The finer widths multiply the rows a day costs and change no
-      # figure the pillar shows, because every screen that reads this data
-      # reads it by day. The entry stays empty rather than spelling "1d"
-      # out, so daily is written down once, in the adapter's schema.
+    Scenario: The toggle explains both sides in plain words
+      When the admin reads the hint beside the report toggle
+      Then it says that on records the provider's own daily spend figure,
+        which is what almost everyone wants
+      And that off records raw token counts that we price ourselves
+      And that one source records one report only, never both
+
+    @unit
+    Scenario: A new source opens on the provider's own cost figure
+      When the admin opens the form without touching the report toggle
+      Then the toggle is on
+      And saving without touching it records the cost report
+
+    @unit
+    Scenario: Turning the toggle off records the usage report
+      When the admin turns the report toggle off
+      And saves
+      Then the submitted configuration records the usage report
+      # The stored words are unchanged: the adapter still reads "cost" and
+      # "usage", so the toggle is a different way of asking the same question
+      # and not a change to what any existing source holds.
+
+    @unit
+    Scenario: A source saved on the usage report opens with the toggle off
+      Given a source was saved on the usage report
+      When the admin opens that source to edit it
+      Then the report toggle is off
+      And saving an unrelated change still records the usage report
+
+    @unit
+    Scenario: The report can no longer be left unanswered
+      When the admin works through the whole form
+      Then there is no way to put the report back to no report at all
+      And the save is never refused for a missing report
+      # The picker carried an empty entry so a cleared field could be refused
+      # rather than quietly refilled. A toggle has no empty state, so the
+      # whole "no report yet" detour it existed for is gone.
+
+  Rule: A locked setting still says what it holds, in the words of the setting
+
+    @unit
+    Scenario: A locked report names the report rather than a switch position
+      Given a usage source has already pulled
+      When the admin opens that source to edit it
+      Then the report reads "Usage report"
+      And a cost source that has already pulled reads "Cost report"
+      # "Off" is the position of a control the admin can no longer see. The
+      # locked field has to answer the question the admin actually has, which
+      # is which report this source records.
+
+    @integration
+    Scenario: A locked report is still readable and still reachable
+      Given a cost source has already pulled
+      When the admin reaches the report field with the keyboard
+      Then the field is reachable and its value readable
+      And it cannot be changed
+      # Same rule the locked picker already kept: a disabled control drops out
+      # of the tab order, where a keyboard or screen-reader user cannot read
+      # what it holds.
+
+  Rule: A setting with one correct answer is not offered at all
+
+    @unit
+    Scenario: The form offers no bucket width, on either report
+      When the admin works through the whole form with the toggle on
+      And again with the toggle off
+      Then no bucket width field appears in either
+      # Every screen that reads this data reads it by day, so a finer width
+      # multiplies the rows a day costs and changes no figure the pillar
+      # shows. Asking was the mistake; the answer was always daily.
+      # The setting itself is still carried by the form, just never asked:
+      # a source saved at an hourly width has to survive an edit, and a
+      # field the form has stopped declaring is a field the edit path drops.
+
+    @unit
+    Scenario: A usage source is written down as daily
+      When the admin turns the report toggle off and saves
+      Then the submitted configuration records a daily bucket width
+      # Written explicitly rather than left out: the adapter defaults to daily
+      # too, but a source whose stored config says nothing cannot be told from
+      # one saved before the field existed, and daily is what this source runs
+      # at either way.
+
+    @unit
+    Scenario: A cost source carries no bucket width
+      When the admin saves with the report toggle on
+      Then the submitted configuration carries no bucket width at all
+      # The puller pins the cost report to daily and ignores anything else, so
+      # writing a width there would record a setting that does nothing.
 
     @unit
     Scenario: A source already reading hourly keeps reading hourly
       Given a usage source was saved with an hourly bucket width
-      When the admin opens that source to edit it
-      Then the hourly width is offered alongside the daily one
-      And the field still holds hourly
-      # The form drops any held value its picker does not offer, so
-      # offering daily alone would have moved this source to daily the
-      # next time anyone opened it for an unrelated change -- a settings
-      # change nobody asked for and nothing announced. The finer widths
-      # are withdrawn from new sources, not taken off the ones already
-      # reading at them; the admin can still move to daily by choosing it.
+      When the admin opens that source, changes its name and saves
+      Then the submitted configuration still records the hourly width
+      # The finer widths are withdrawn from new sources, not taken off the
+      # ones already reading at them. An admin editing a name has not asked
+      # for a settings change, and nothing here would have announced one.
 
     @unit
-    Scenario: A width the cost report would reject is not kept either
-      Given a cost source was somehow saved with an hourly bucket width
-      When the admin opens that source to edit it
-      Then the only entry offered is the daily one
-      # The puller ignores the width on a cost source, so the stored one
-      # was never in effect. Keeping it would show the admin a setting
-      # that does nothing, and the builder refuses it anyway.
-
-    @unit
-    Scenario: Clearing the report to re-pick it does not cost the source its width
-      Given a usage source was saved with an hourly bucket width
-      When the admin clears the report field before choosing one again
-      Then the hourly width is still offered alongside the daily one
-      And the field still holds hourly
-      # The report picker keeps an empty entry so a cleared field is
-      # refused rather than quietly refilled, which makes "no report yet"
-      # a state the admin passes through on the way to re-picking one.
-      # Only the cost report retires the finer widths; an empty report
-      # has not retired anything, and treating it as if it had would drop
-      # the width mid-gesture -- the same silent migration, by a second
-      # route. The save is refused meanwhile because the report is
-      # required, so nothing can reach the adapter from this state.
-
-    @unit
-    Scenario: The report opens on the one almost every organization wants
-      When the admin opens the form without touching the report field
-      Then the report field holds the cost report
-      And the form still marks the report as required
-      And an unselected entry carrying no value is still offered
-      # Cost is the provider's own figure for what was spent, which is
-      # what this source is added for; usage is the specialist choice made
-      # by someone who wants our pricing applied to raw token counts. The
-      # empty entry remains so clearing the field is possible — the form
-      # then refuses the save and marks the field rather than quietly
-      # putting the default back.
-
-  Rule: A setting the cost report would reject is not offered on a cost source
-
-    @unit
-    Scenario: The cost report offers no width to choose between
-      Given the report is set to cost
-      When the admin looks at the bucket width field
-      Then the only entry offered carries no value
-      And the field explains that the cost report is always daily
-
-    @unit
-    Scenario: Switching to the cost report drops a width already chosen
-      Given the report is set to usage
-      And the admin has chosen a bucket width of 1h
-      When the admin changes the report to cost
-      Then the bucket width is cleared
-      And the configuration builds instead of refusing the unusable width
+    Scenario: An hourly width on a cost source is dropped rather than refusing the save
+      Given a source holds an hourly bucket width
+      When the admin leaves the report toggle on and saves
+      Then the configuration builds
+      And it carries no bucket width
+      # The width was never in effect on a cost source, so there is nothing to
+      # preserve and no reason to refuse a save over it.
 
   Rule: A date is picked on a calendar, and an instant survives being shown on one
 
     @unit
-    Scenario: The backfill start is a date control
+    Scenario: The backfill start asks in plain words when to start reading
       When the admin looks at the backfill start field
-      Then it is rendered as a date control rather than a free-text field
+      Then it is labelled "Read history from"
+      And it is rendered as a date control rather than a free-text field
+      And the hint says this is the first day we read data for
+      And that later runs continue forward from where the last one stopped
+      And that clearing it reads only the last few days
+      # "Backfill start" is our word for it, and "optional" described the form
+      # rather than the setting. The admin's question is how far back to read.
 
     @unit
-    Scenario: A stored instant is shown as its calendar date
+    Scenario: A new Anthropic source proposes six months of history
+      When the admin opens the form for a new source
+      Then the backfill start holds midnight UTC six months before today
+      # Far enough back to show a trend the day the source is added, and
+      # inside what this provider serves. The number lives in one declared
+      # table beside the cadence defaults, so the proposal and any hint that
+      # describes it cannot drift apart.
+
+    @unit
+    Scenario: Editing shows the stored date rather than proposing a new one
       Given the source was saved with a backfill start of "2026-08-01T00:00:00.000Z"
       When the admin opens the edit form
       Then the backfill start shows the 1st of August 2026
+      And it is not replaced by six months before today
+      # The proposal is a starting point for a source that does not exist yet.
+      # Re-seeding an existing one would move a date that has already been
+      # read from, on a form the admin opened for something else.
+
+    @unit
+    Scenario: Clearing the proposed date still means the adapter's own default
+      When the admin clears the backfill start and saves
+      Then the submitted configuration carries no backfill start at all
+      And the adapter's own default decides how far back the first run reads
 
     @unit
     Scenario: Showing an instant on a date control does not rewrite it
       Given the source was saved with a backfill start of "2026-08-01T13:45:00.000Z"
       When the admin edits another field and saves
       Then the submitted backfill start is still that same instant
-
-  Rule: Replacing the control does not change what is stored
-
-    @unit
-    Scenario: Leaving the bucket width alone still means the adapter default
-      Given the report is set to usage
-      When the admin saves without choosing a bucket width
-      Then the submitted configuration carries no bucket width at all
 
     @unit
     Scenario: A picked date is still normalized to an instant before saving

--- a/specs/governance/anthropic-source-form-controls.feature
+++ b/specs/governance/anthropic-source-form-controls.feature
@@ -182,3 +182,41 @@ Feature: Choose Anthropic adapter settings instead of typing them
       When the admin picks a backfill start of "2026-08-01"
       And saves the form
       Then the submitted backfill start is a timezone-carrying instant
+
+  Rule: Which notes the edit drawer owes an admin is decided before it is drawn
+
+    The marker beside the edit title shows whatever the note list holds, so
+    what that list holds for a given source is the whole of the behaviour.
+    Deciding it in a pure function lets all four combinations be pinned at
+    once, rather than one drawer render at a time.
+
+    @unit
+    Scenario: A source that has never pulled is owed no note on either report
+      Given a source that has not yet pulled
+      When the notes for its edit drawer are worked out
+      Then there are none, whichever report it is set to
+      # Nothing is locked before a cursor exists, and a marker opening onto
+      # an empty popover invites a click that answers nothing.
+
+    @unit
+    Scenario: A pulled usage source is owed the two notes that lock it
+      Given a source on the usage report that has already pulled
+      When the notes for its edit drawer are worked out
+      Then they are the report note and the start-date note, in that order
+      And the note about restating cost history is not among them
+
+    @unit
+    Scenario: A pulled cost source is owed the report note and the restate note
+      Given a source on the cost report that has already pulled
+      When the notes for its edit drawer are worked out
+      Then they are the report note and the restate note, in that order
+      And the note saying the start date is fixed is not among them
+      # On a cost source the start is not fixed: moving it is the lever that
+      # repairs the figures, so calling it fixed would be a lie.
+
+    @unit
+    Scenario: No source is ever owed all three notes
+      When the notes are worked out for every combination of pulled and report
+      Then no combination yields more than two
+      # A fixed start and a start worth moving are the two halves of one
+      # condition, and the report decides which half applies.

--- a/specs/governance/anthropic-source-form-controls.feature
+++ b/specs/governance/anthropic-source-form-controls.feature
@@ -159,6 +159,16 @@ Feature: Choose Anthropic adapter settings instead of typing them
       # describes it cannot drift apart.
 
     @unit
+    Scenario: A proposal from a day the target month does not have lands in that month
+      Given today is the 31st of August
+      When the admin opens the form for a new Anthropic source
+      Then the proposed date is the last day of February, six months back
+      # Counting back by month from the 31st asks for a day February does not
+      # have, and a date built from one rolls forward into March instead of
+      # refusing. The proposal would then be five months back on a form whose
+      # hint promises six.
+
+    @unit
     Scenario: Editing shows the stored date rather than proposing a new one
       Given the source was saved with a backfill start of "2026-08-01T00:00:00.000Z"
       When the admin opens the edit form


### PR DESCRIPTION
## Why

The ingestion source composer for the Anthropic and OpenAI admin pulls exposed configuration the operator should not have to think about, and its wording did not match the rest of the form. The menu label carried a parenthetical, the description placeholder read as a prompt rather than a field label, the backfill date had no default so every new source started with an empty date, the report was a select where a switch is the natural control, the bucket width was a form field with only one sensible value, and the edit drawer showed three paragraphs of advanced notes in the body under a generic "Edit source" title.

This is a UI-only change and no server code moves. The stored config keeps the same keys and value types. Two rows gain keys they may not have had before: new sources store a `startingAt` because the date now defaults, and a usage source edited after this change stores `bucketWidth: "1d"` where it may have been absent. Both match what the puller already assumed, so the usage cursor identity does not change and nothing is invalidated.

## What changed

- Menu label is now `Anthropic Admin API`.
- Description placeholder is now `Description for this source`, matching the name field's `Display name for this source`.
- Backfill date label is now `Read history from`. On create it defaults to 6 months back for Anthropic and 1 year back for OpenAI, at midnight UTC. The limits live in one table beside the pull schedule defaults. Edit shows the stored date and clearing it is still allowed.
- Report is a switch, on by default, labelled `Use Anthropic's reported cost`. On stores `cost`, off stores `usage`. Once a source has pulled, the switch renders read-only and names the report it is locked to.
- Bucket width is no longer a form field. The builder writes `1d` for usage pulls and omits it for cost pulls, where the puller already fixes it at `1d`.
- The edit drawer's advanced notes moved out of the body into an info tooltip next to the title, shown only when a note applies to that source.
- The edit drawer title is the provider icon plus `Edit {provider label}`.

## How it works

Fields can now be marked `hidden` on their definition. Hidden fields keep their place in the parser field list so seeding and config rebuilding still see them, but the form does not render them and required-field checks skip them. This is how `bucketWidth` stays in the stored config without a control.

Switch fields carry `onValue` and `offValue` so a boolean control can store a string pair. The report field uses `cost` / `usage`.

`IconGlyph` accepts an optional `testId` applied on its root box so tests can target the provider icon without a wrapper element that would break flex layout.

## Test plan

- `specs/governance/anthropic-source-form-controls.feature` grew from 13 to 24 scenarios, all bound to unit tests. The last five cover the edit-header note set and the month-end clamp on the default start date.
- `specs/ai-gateway/governance/ingestion-sources.feature` gained 13 scenarios, all bound to component tests.
- `platform/app/specs/governance/edit-pull-source-config.feature` updated to match the new field name and lock rule. That folder is not scanned by the parity check.
- Red first: 22 failed and 7 passed before the implementation, all green after. The review fixes each went red first too.
- New tests: `backfillStartDefaults.unit.test.ts`, `editSourceNotes.unit.test.ts`, `sourceEditHeader.integration.test.tsx`. Rewritten: `anthropicFormControls.unit.test.ts`. Four stale assertions updated in the pull config builder tests, the menu label test, and the composer description test.
- `typecheck:all`, `check:feature-parity` (24/24 and 82/82 bound), `ee/governance/dashboard` unit suite (279), and the component suite all pass. CI is green on `b63fad94e0`.

## Anything surprising?

- The cost report's backfill date stays editable after a pull. The cost cursor binds the start date into its query identity, so moving the date is the operator's repair lever. The usage report locks it once pulled, as before. That lock now also covers the proposed default, so a usage source created with the untouched six-month default cannot move that date after its first pull. The create hint says so.
- The edit drawer still never passes `invalidKeys` to the parser fields, so a stored config missing `report` leaves Save enabled and the submit does nothing. Pre-existing, not touched here.
- The component suite has a pre-existing intermittent failure in `inventoryEnvironments.integration.test.tsx` where a table lookup times out under parallel load. It passes alone and no commit here touches that file. Left as-is to keep this change scoped.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Anthropic Admin API is now labeled consistently without the “usage & cost” suffix.
  - New sources receive provider-specific history start-date suggestions, including a six-month default where applicable.
  - Anthropic reports can be selected with a clearer cost/usage toggle.
  - Edit drawers now show provider-specific titles, icons, and contextual information markers.
  - Field prompts and history-date labels have been clarified.

- **Changes**
  - Bucket width is no longer user-configurable for Anthropic sources; usage defaults to daily while existing valid widths are preserved.
  - Usage start dates become fixed after pulling, while cost start dates remain editable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->