### PR TITLE
langwatch ollama: instrument a local Ollama server from the CLI

### DIFF
--- a/sdks/typescript/src/cli/__tests__/help-footer.unit.test.ts
+++ b/sdks/typescript/src/cli/__tests__/help-footer.unit.test.ts
@@ -30,11 +30,11 @@ function helpOutput(program: Command): string {
   return out;
 }
 
-/** First word of each line in the footer section, until the blank line. */
-function footerEntries(help: string): string[] {
+/** First word of each line in a named footer section, until the blank line. */
+function footerEntries(help: string, section = "Coding assistants:"): string[] {
   const lines = help.split("\n");
-  const start = lines.findIndex((l) => l.trim() === "Coding assistants:");
-  expect(start, "the Coding assistants footer section is missing").toBeGreaterThan(-1);
+  const start = lines.findIndex((l) => l.trim() === section);
+  expect(start, `the ${section} footer section is missing`).toBeGreaterThan(-1);
   const entries: string[] = [];
   for (const line of lines.slice(start + 1)) {
     if (line.trim() === "") break;
@@ -60,11 +60,20 @@ describe("the coding-assistants help footer", () => {
     ]);
   });
 
+  it("lists the local-model launcher in its own section", () => {
+    const help = helpOutput(buildProgram());
+
+    // `ollama` runs a local model server, not a coding assistant, and the
+    // one thing a reader of --help must not conclude is that wrapping it
+    // routes anything through the gateway.
+    expect(footerEntries(help, "Local models:")).toEqual(["ollama"]);
+  });
+
   it("names only registered commands, every one of them hidden", () => {
     const program = buildProgram();
     const help = helpOutput(program);
 
-    for (const name of footerEntries(help)) {
+    for (const name of [...footerEntries(help), ...footerEntries(help, "Local models:")]) {
       const cmd = program.commands.find((c) => c.name() === name);
       expect(cmd, `the footer names '${name}' but no such command is registered`).toBeDefined();
       // Hidden keeps the command out of commander's own Commands section,

--- a/sdks/typescript/src/cli/commands/__tests__/ollama.unit.test.ts
+++ b/sdks/typescript/src/cli/commands/__tests__/ollama.unit.test.ts
@@ -1,0 +1,298 @@
+/**
+ * `langwatch ollama` as a launcher: what it starts, what it refuses, where it
+ * decides the captured calls go, and what it does when there is nowhere to
+ * send them. The proxy's own behaviour is covered against real sockets in
+ * ollama-proxy.integration.test.ts; here the proxy is a stub, because the
+ * questions are about the command.
+ */
+import { EventEmitter } from "node:events";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const spawnMock = vi.hoisted(() => vi.fn());
+vi.mock("node:child_process", () => ({ spawn: spawnMock }));
+
+const loadConfigMock = vi.hoisted(() => vi.fn());
+const isLoggedInMock = vi.hoisted(() => vi.fn());
+vi.mock("../../utils/governance/config", () => ({
+  loadConfig: loadConfigMock,
+  isLoggedIn: isLoggedInMock,
+}));
+
+const resolveIngestionCredentialMock = vi.hoisted(() => vi.fn());
+vi.mock("../../utils/governance/telemetry-refresh", () => ({
+  resolveIngestionCredential: resolveIngestionCredentialMock,
+  otlpEndpointFor: (base: string) => `${base.replace(/\/+$/, "")}/api/otel`,
+}));
+
+const startProxyMock = vi.hoisted(() => vi.fn());
+vi.mock("../../utils/governance/ollama-proxy", () => ({
+  DEFAULT_OLLAMA_ORIGIN: "http://127.0.0.1:11434",
+  resolveUpstreamOrigin: () => "http://127.0.0.1:11434",
+  startOllamaCaptureProxy: startProxyMock,
+}));
+
+const createEmitterMock = vi.hoisted(() => vi.fn());
+const createDiscardingEmitterMock = vi.hoisted(() => vi.fn());
+vi.mock("../../utils/governance/ollama-emitter", () => ({
+  createOllamaSpanEmitter: createEmitterMock,
+  createDiscardingSpanEmitter: createDiscardingEmitterMock,
+}));
+
+import { ollamaCommand, resolveOllamaCaptureScope } from "../ollama";
+
+class Exited extends Error {
+  constructor(readonly code: number) {
+    super(`exit ${code}`);
+  }
+}
+
+/** A child process that ends the way the test says, on the next tick. */
+function fakeChild({ code = 0, error }: { code?: number; error?: NodeJS.ErrnoException } = {}) {
+  const child = new EventEmitter();
+  setTimeout(() => {
+    if (error) child.emit("error", error);
+    child.emit("close", error ? null : code);
+  }, 0);
+  return child;
+}
+
+function stubEmitter(sent = 0) {
+  return { add: vi.fn(), flush: vi.fn(), close: vi.fn(), sent: () => sent };
+}
+
+describe("the langwatch ollama launcher", () => {
+  let stderr: string;
+  let stdout: string;
+
+  beforeEach(() => {
+    stderr = "";
+    stdout = "";
+    vi.spyOn(process.stderr, "write").mockImplementation((chunk: unknown) => {
+      stderr += String(chunk);
+      return true;
+    });
+    vi.spyOn(process.stdout, "write").mockImplementation((chunk: unknown) => {
+      stdout += String(chunk);
+      return true;
+    });
+    vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Exited(code ?? 0);
+    }) as never);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("{}", { status: 200 })),
+    );
+
+    loadConfigMock.mockReturnValue({ control_plane_url: "https://app.langwatch.ai" });
+    isLoggedInMock.mockReturnValue(true);
+    resolveIngestionCredentialMock.mockResolvedValue({
+      token: "ik-lw-personal",
+      endpoint: "https://app.langwatch.ai/api/otel",
+      minted: false,
+      scope: "personal",
+    });
+    createEmitterMock.mockReturnValue(stubEmitter());
+    createDiscardingEmitterMock.mockReturnValue(stubEmitter());
+    startProxyMock.mockResolvedValue({ url: "http://127.0.0.1:54321", close: vi.fn() });
+    spawnMock.mockReturnValue(fakeChild());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  describe("when a command is wrapped", () => {
+    /** @scenario "Arguments are forwarded in the order they were written" */
+    it("starts ollama with the arguments as written, pointed at the proxy", async () => {
+      await expect(ollamaCommand(["run", "llama3", "--verbose"])).rejects.toBeInstanceOf(Exited);
+
+      expect(spawnMock).toHaveBeenCalledTimes(1);
+      const [binary, args, options] = spawnMock.mock.calls[0]!;
+      expect(binary).toBe("ollama");
+      expect(args).toEqual(["run", "llama3", "--verbose"]);
+      expect((options as { env: Record<string, string> }).env.OLLAMA_HOST).toBe(
+        "http://127.0.0.1:54321",
+      );
+    });
+
+    /** @scenario "The exit code is the wrapped command's own" */
+    it("exits with the code ollama exited with", async () => {
+      spawnMock.mockReturnValue(fakeChild({ code: 3 }));
+
+      await expect(ollamaCommand(["run", "llama3"])).rejects.toMatchObject({ code: 3 });
+    });
+
+    it("closes the proxy and the emitter before it exits", async () => {
+      const close = vi.fn();
+      const emitter = stubEmitter(2);
+      startProxyMock.mockResolvedValue({ url: "http://127.0.0.1:54321", close });
+      createEmitterMock.mockReturnValue(emitter);
+
+      await expect(ollamaCommand(["run", "llama3"])).rejects.toBeInstanceOf(Exited);
+
+      expect(close).toHaveBeenCalled();
+      expect(emitter.close).toHaveBeenCalled();
+      expect(stdout).toContain("reported 2 ollama calls");
+    });
+
+    it("says nothing about reporting when the session made no model calls", async () => {
+      await expect(ollamaCommand(["list"])).rejects.toBeInstanceOf(Exited);
+
+      expect(stdout).not.toContain("reported");
+    });
+  });
+
+  describe("when ollama is not installed", () => {
+    /** @scenario "A missing ollama binary is reported as a missing install" */
+    it("says so and where to get it", async () => {
+      const error: NodeJS.ErrnoException = new Error("spawn ollama ENOENT");
+      error.code = "ENOENT";
+      spawnMock.mockReturnValue(fakeChild({ error }));
+
+      await expect(ollamaCommand(["run", "llama3"])).rejects.toMatchObject({ code: 127 });
+
+      expect(stderr).toContain("ollama is not installed");
+      expect(stderr).toContain("https://ollama.com/download");
+    });
+  });
+
+  describe("when the server itself is being started", () => {
+    /** @scenario "Starting the server through the wrapper is refused" */
+    it("refuses before anything is started and says what to do instead", async () => {
+      await expect(ollamaCommand(["serve"])).rejects.toMatchObject({ code: 1 });
+
+      expect(spawnMock).not.toHaveBeenCalled();
+      expect(startProxyMock).not.toHaveBeenCalled();
+      expect(stderr).toContain("OLLAMA_HOST");
+      expect(stderr).toContain("Run `ollama serve` directly");
+    });
+
+    it("still wraps a command whose arguments merely mention serving", async () => {
+      await expect(ollamaCommand(["run", "llama3", "serve me a haiku"])).rejects.toBeInstanceOf(
+        Exited,
+      );
+
+      expect(spawnMock).toHaveBeenCalled();
+    });
+  });
+
+  describe("when the configured server does not answer", () => {
+    /** @scenario "An unreachable server is named before the command starts" */
+    it("names the address and runs the command anyway", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () => {
+          throw new Error("ECONNREFUSED");
+        }),
+      );
+
+      await expect(ollamaCommand(["run", "llama3"])).rejects.toBeInstanceOf(Exited);
+
+      expect(stderr).toContain("no ollama server answered at http://127.0.0.1:11434");
+      expect(spawnMock).toHaveBeenCalled();
+    });
+  });
+
+  describe("when the device has no LangWatch scope", () => {
+    /** @scenario "Without a scope the command says what to do and runs anyway" */
+    it("says how to get one and runs ollama uncaptured", async () => {
+      isLoggedInMock.mockReturnValue(false);
+      delete process.env.LANGWATCH_INGEST_KEY;
+
+      await expect(ollamaCommand(["run", "llama3"])).rejects.toBeInstanceOf(Exited);
+
+      expect(stderr).toContain("langwatch login --device");
+      expect(stderr).toContain("LANGWATCH_INGEST_KEY");
+      expect(createEmitterMock).not.toHaveBeenCalled();
+      expect(createDiscardingEmitterMock).toHaveBeenCalled();
+      expect(spawnMock).toHaveBeenCalled();
+    });
+  });
+});
+
+describe("deciding where the captured calls go", () => {
+  beforeEach(() => {
+    resolveIngestionCredentialMock.mockReset();
+    isLoggedInMock.mockReset();
+  });
+
+  /** @scenario "A pinned project key sends the session to that project" */
+  it("uses the pinned project key and its instance", async () => {
+    resolveIngestionCredentialMock.mockResolvedValue({
+      token: "ik-lw-project",
+      endpoint: "https://self-hosted.example.com/api/otel",
+      minted: false,
+      scope: "project",
+      projectLabel: "my-project",
+    });
+
+    const scope = await resolveOllamaCaptureScope({
+      cfg: {
+        control_plane_url: "https://app.langwatch.ai",
+        gateway_url: "https://gateway.langwatch.ai",
+        tool_project_keys: { ollama: { secret: "ik-lw-project" } },
+      },
+      env: {},
+    });
+
+    expect(scope).toEqual({
+      tracesEndpoint: "https://self-hosted.example.com/api/otel/v1/traces",
+      token: "ik-lw-project",
+      label: "project my-project",
+    });
+  });
+
+  /** @scenario "A pasted ingest key in the environment is used as-is" */
+  it("uses a pasted key without asking the platform for one", async () => {
+    const scope = await resolveOllamaCaptureScope({
+      cfg: {
+        control_plane_url: "https://app.langwatch.ai",
+        gateway_url: "https://gateway.langwatch.ai",
+      },
+      env: { LANGWATCH_INGEST_KEY: "ik-lw-pasted" },
+    });
+
+    expect(scope?.token).toBe("ik-lw-pasted");
+    expect(scope?.tracesEndpoint).toBe("https://app.langwatch.ai/api/otel/v1/traces");
+    expect(resolveIngestionCredentialMock).not.toHaveBeenCalled();
+  });
+
+  /** @scenario "Otherwise the signed-in personal workspace receives the session" */
+  it("falls back to the signed-in personal workspace", async () => {
+    isLoggedInMock.mockReturnValue(true);
+    resolveIngestionCredentialMock.mockResolvedValue({
+      token: "ik-lw-personal",
+      endpoint: "https://app.langwatch.ai/api/otel",
+      minted: true,
+      scope: "personal",
+    });
+
+    const scope = await resolveOllamaCaptureScope({
+      cfg: {
+        control_plane_url: "https://app.langwatch.ai",
+        gateway_url: "https://gateway.langwatch.ai",
+      },
+      env: {},
+    });
+
+    expect(scope?.label).toBe("your personal workspace");
+    expect(scope?.token).toBe("ik-lw-personal");
+  });
+
+  it("has no scope at all when the device is not signed in and nothing is pasted", async () => {
+    isLoggedInMock.mockReturnValue(false);
+
+    const scope = await resolveOllamaCaptureScope({
+      cfg: {
+        control_plane_url: "https://app.langwatch.ai",
+        gateway_url: "https://gateway.langwatch.ai",
+      },
+      env: {},
+    });
+
+    expect(scope).toBeNull();
+    expect(resolveIngestionCredentialMock).not.toHaveBeenCalled();
+  });
+});

--- a/sdks/typescript/src/cli/commands/ollama.ts
+++ b/sdks/typescript/src/cli/commands/ollama.ts
@@ -1,0 +1,191 @@
+/**
+ * `langwatch ollama <args...>` — run an Ollama command with every model call
+ * it makes reported to LangWatch. Ollama has no telemetry configuration, so
+ * the capture is a loopback proxy pointed at by the child's `OLLAMA_HOST`
+ * alone: nothing is written to disk and nothing outlives the command.
+ */
+
+import { spawn } from "node:child_process";
+
+import { lwTag } from "../utils/governance/brand";
+import { type GovernanceConfig, isLoggedIn, loadConfig } from "../utils/governance/config";
+import {
+  createDiscardingSpanEmitter,
+  createOllamaSpanEmitter,
+  type OllamaSpanEmitter,
+} from "../utils/governance/ollama-emitter";
+import {
+  DEFAULT_OLLAMA_ORIGIN,
+  resolveUpstreamOrigin,
+  startOllamaCaptureProxy,
+} from "../utils/governance/ollama-proxy";
+import { otlpEndpointFor, resolveIngestionCredential } from "../utils/governance/telemetry-refresh";
+import { normalizeEndpoint } from "../../internal/endpoint";
+
+/** Ingestion source slug for calls captured from a local Ollama server. */
+export const OLLAMA_SOURCE_TYPE = "ollama";
+
+/** The config key the project pin and the cached personal key live under. */
+export const OLLAMA_TOOL = "ollama";
+
+const KEY_ENV_VAR = "LANGWATCH_INGEST_KEY";
+
+/** How long the reachability check waits before it gives up and warns. */
+const PREFLIGHT_TIMEOUT_MS = 1_500;
+
+export interface OllamaCaptureScope {
+  /** Full OTLP traces URL the spans are POSTed to. */
+  tracesEndpoint: string;
+  token: string;
+  /** How the destination is named in the one line printed at startup. */
+  label: string;
+}
+
+/**
+ * Where this session's calls are reported, or null when the device has no
+ * scope to report them to. A pin is an explicit earlier decision and wins; a
+ * pasted key is the shared-machine path and needs no login; the signed-in
+ * personal workspace is the default.
+ */
+export async function resolveOllamaCaptureScope({
+  cfg,
+  env = process.env,
+}: {
+  cfg: GovernanceConfig;
+  env?: NodeJS.ProcessEnv;
+}): Promise<OllamaCaptureScope | null> {
+  const pinned = cfg.tool_project_keys?.[OLLAMA_TOOL];
+  const pastedKey = env[KEY_ENV_VAR]?.trim();
+
+  if (!pinned?.secret && pastedKey) {
+    return {
+      tracesEndpoint: `${otlpEndpointFor(cfg.control_plane_url)}/v1/traces`,
+      token: pastedKey,
+      label: `the ingest key in ${KEY_ENV_VAR}`,
+    };
+  }
+
+  if (!pinned?.secret && !isLoggedIn(cfg)) return null;
+
+  const credential = await resolveIngestionCredential({
+    cfg,
+    tool: OLLAMA_TOOL,
+    sourceType: OLLAMA_SOURCE_TYPE,
+  });
+  return {
+    tracesEndpoint: `${normalizeEndpoint(credential.endpoint)}/v1/traces`,
+    token: credential.token,
+    label:
+      credential.scope === "project"
+        ? `project ${credential.projectLabel ?? "(pinned)"}`
+        : "your personal workspace",
+  };
+}
+
+/**
+ * The one Ollama command this wrapper cannot run: `ollama serve` reads the
+ * same `OLLAMA_HOST` the wrapper points at its own proxy, so the server would
+ * bind the proxy's address or fail trying. Refusing by name is clearer.
+ */
+function isServeInvocation(args: string[]): boolean {
+  return args.find((arg) => !arg.startsWith("-")) === "serve";
+}
+
+function write(stream: NodeJS.WriteStream, message: string): void {
+  stream.write(`${lwTag()} ${message}\n`);
+}
+
+/** Whether the configured Ollama server answers at all, for the warning. */
+async function upstreamAnswers(origin: string): Promise<boolean> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), PREFLIGHT_TIMEOUT_MS);
+  try {
+    await fetch(`${origin}/api/version`, { signal: controller.signal });
+    return true;
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export async function ollamaCommand(args: string[]): Promise<void> {
+  if (isServeInvocation(args)) {
+    write(
+      process.stderr,
+      "`langwatch ollama serve` is not supported: the wrapper points OLLAMA_HOST at its own capture proxy, " +
+        "and the server would try to listen there. Run `ollama serve` directly, then wrap the commands that talk to it.",
+    );
+    process.exit(1);
+  }
+
+  const cfg = loadConfig();
+  const upstreamOrigin = resolveUpstreamOrigin(process.env.OLLAMA_HOST);
+
+  let scope: OllamaCaptureScope | null = null;
+  try {
+    scope = await resolveOllamaCaptureScope({ cfg });
+  } catch (error) {
+    write(
+      process.stderr,
+      `could not resolve a LangWatch scope (${(error as Error).message}); running ollama uncaptured.`,
+    );
+  }
+
+  const emitter: OllamaSpanEmitter = scope
+    ? createOllamaSpanEmitter({ tracesEndpoint: scope.tracesEndpoint, token: scope.token })
+    : createDiscardingSpanEmitter();
+
+  if (scope) {
+    write(process.stdout, `capturing ollama calls to ${scope.label}.`);
+  } else {
+    write(
+      process.stderr,
+      `not capturing: run \`langwatch login --device\`, or set ${KEY_ENV_VAR} to an ingest key. Running ollama anyway.`,
+    );
+  }
+
+  if (!(await upstreamAnswers(upstreamOrigin))) {
+    write(
+      process.stderr,
+      `no ollama server answered at ${upstreamOrigin}${
+        upstreamOrigin === DEFAULT_OLLAMA_ORIGIN ? "" : " (from OLLAMA_HOST)"
+      }. Starting anyway; ollama will report the failure itself.`,
+    );
+  }
+
+  const proxy = await startOllamaCaptureProxy({ upstreamOrigin, emitter });
+
+  const child = spawn("ollama", args, {
+    stdio: "inherit",
+    env: { ...process.env, OLLAMA_HOST: proxy.url },
+    shell: process.platform === "win32",
+  });
+
+  let spawnFailed = false;
+  child.on("error", (error: NodeJS.ErrnoException) => {
+    spawnFailed = true;
+    if (error.code === "ENOENT") {
+      write(
+        process.stderr,
+        "ollama is not installed, or not on your PATH. Get it from https://ollama.com/download.",
+      );
+      return;
+    }
+    write(process.stderr, `could not run ollama: ${error.message}`);
+  });
+
+  const exitCode = await new Promise<number>((resolve) => {
+    child.on("close", (code) => resolve(code ?? 1));
+  });
+
+  await proxy.close();
+  await emitter.close();
+
+  const sent = emitter.sent();
+  if (sent > 0) {
+    write(process.stdout, `reported ${sent} ollama ${sent === 1 ? "call" : "calls"}.`);
+  }
+
+  process.exit(spawnFailed && exitCode === 1 ? 127 : exitCode);
+}

--- a/sdks/typescript/src/cli/program.ts
+++ b/sdks/typescript/src/cli/program.ts
@@ -484,6 +484,25 @@ export function buildProgram({ bin }: { bin?: string } = {}): Command {
     });
 
   program
+    .command("ollama", { hidden: true })
+    .description(
+      "Run an `ollama` command with every model call it makes captured by LangWatch. Ollama has no telemetry settings, so the capture runs as a loopback proxy in front of the server for this command only; nothing is written to disk.",
+    )
+    .allowUnknownOption(true)
+    .allowExcessArguments(true)
+    .helpOption(false)
+    .action(async (_opts, cmd: { args?: string[] }) => {
+      try {
+        const { ollamaCommand } = await import("./commands/ollama.js");
+        await ollamaCommand(cmd.args ?? []);
+      } catch (error) {
+        const { reportCommandError } = await import("./utils/errorOutput.js");
+        reportCommandError({ error });
+        process.exit(1);
+      }
+    });
+
+  program
     .command("opencode", { hidden: true })
     .description(
       "Run `opencode` routed through the LangWatch gateway (multi-provider; injects both Anthropic and OpenAI env vars).",
@@ -518,6 +537,9 @@ export function buildProgram({ bin }: { bin?: string } = {}): Command {
       "  opencode        Run `opencode` (multi-provider) routed through the gateway",
       "  copilot-app     Set up capture for the standalone GitHub Copilot app",
       "  instrument      Write persistent telemetry wiring for a tool without launching it",
+      "",
+      "Local models:",
+      "  ollama          Run an `ollama` command with its model calls captured",
       "",
       "`lw` and `langwatch` are the same binary: use whichever you prefer.",
       "",

--- a/sdks/typescript/src/cli/utils/__tests__/output-command-tree.unit.test.ts
+++ b/sdks/typescript/src/cli/utils/__tests__/output-command-tree.unit.test.ts
@@ -161,7 +161,17 @@ describe("the real command tree", () => {
 
       // Launchers and passthroughs: they exec another tool and own its stdio.
       ...(
-        ["claude", "codex", "cursor", "gemini", "opencode", "copilot", "code", "open"] as const
+        [
+          "claude",
+          "codex",
+          "cursor",
+          "gemini",
+          "ollama",
+          "opencode",
+          "copilot",
+          "code",
+          "open",
+        ] as const
       ).map((n) => [n, "launches another tool and owns its stdio"] as const),
       // Local machine setup: mints a key and installs an OS login agent;
       // progress prose, no structured result document.

--- a/sdks/typescript/src/cli/utils/commandCatalog.ts
+++ b/sdks/typescript/src/cli/utils/commandCatalog.ts
@@ -89,6 +89,9 @@ export const PLUMBING_COMMANDS: ReadonlySet<string> = new Set([
   "gemini",
   "opencode",
   "copilot",
+  // Local-model wrapper: `ollama` execs the ollama CLI behind a capture
+  // proxy rather than returning a LangWatch result.
+  "ollama",
   // VS Code launcher: `code` execs VS Code with Copilot Chat telemetry env,
   // returning no LangWatch result. ADR-039 §Extension #2.
   "code",

--- a/sdks/typescript/src/cli/utils/governance/__tests__/ollama-emitter.unit.test.ts
+++ b/sdks/typescript/src/cli/utils/governance/__tests__/ollama-emitter.unit.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Shipping captured Ollama calls: one upload per batch, a failed upload kept
+ * for the next one, and nothing that can end the session it belongs to.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import { createDiscardingSpanEmitter, createOllamaSpanEmitter } from "../ollama-emitter";
+import type { OtlpSpan } from "../ollama-trace";
+
+function span(name: string): OtlpSpan {
+  return {
+    traceId: "a".repeat(32),
+    spanId: "b".repeat(16),
+    name,
+    kind: 1,
+    startTimeUnixNano: "1000000",
+    endTimeUnixNano: "2000000",
+    attributes: [],
+    status: {},
+  };
+}
+
+function spanNamesOf(call: [string, RequestInit] | undefined): string[] {
+  const body = JSON.parse(String(call?.[1]?.body)) as {
+    resourceSpans: { scopeSpans: { spans: { name: string }[] }[] }[];
+  };
+  return body.resourceSpans[0]!.scopeSpans[0]!.spans.map((s) => s.name);
+}
+
+describe("given an emitter pointed at a reachable control plane", () => {
+  it("sends everything buffered in one upload, authenticated with the ingest key", async () => {
+    const fetchImpl = vi.fn(async () => new Response("", { status: 200 }));
+    const emitter = createOllamaSpanEmitter({
+      tracesEndpoint: "https://app.langwatch.ai/api/otel/v1/traces",
+      token: "ik-lw-test",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    emitter.add(span("ollama.chat"));
+    emitter.add(span("ollama.generate"));
+    await emitter.close();
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const call = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    expect(call[0]).toBe("https://app.langwatch.ai/api/otel/v1/traces");
+    expect((call[1].headers as Record<string, string>).authorization).toBe("Bearer ik-lw-test");
+    expect(spanNamesOf(call)).toEqual(["ollama.chat", "ollama.generate"]);
+    expect(emitter.sent()).toBe(2);
+  });
+
+  it("sends nothing when nothing was captured", async () => {
+    const fetchImpl = vi.fn(async () => new Response("", { status: 200 }));
+    const emitter = createOllamaSpanEmitter({
+      tracesEndpoint: "https://app.langwatch.ai/api/otel/v1/traces",
+      token: "ik-lw-test",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    await emitter.close();
+
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+});
+
+describe("given a control plane that is not answering", () => {
+  it("keeps the calls for the next attempt and warns once", async () => {
+    let answering = false;
+    const fetchImpl = vi.fn(async () => {
+      if (!answering) throw new Error("ECONNREFUSED");
+      return new Response("", { status: 200 });
+    });
+    const warn = vi.fn();
+    const emitter = createOllamaSpanEmitter({
+      tracesEndpoint: "https://app.langwatch.ai/api/otel/v1/traces",
+      token: "ik-lw-test",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      warn,
+    });
+
+    emitter.add(span("ollama.chat"));
+    await emitter.flush();
+    expect(emitter.sent()).toBe(0);
+    expect(warn).toHaveBeenCalledTimes(1);
+
+    answering = true;
+    emitter.add(span("ollama.generate"));
+    await emitter.flush();
+
+    // The retried call leads: the order it happened in is the order it lands.
+    expect(spanNamesOf(fetchImpl.mock.calls[1] as unknown as [string, RequestInit])).toEqual([
+      "ollama.chat",
+      "ollama.generate",
+    ]);
+    expect(emitter.sent()).toBe(2);
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  it("treats a rejection from the platform as a failure to retry, not a success", async () => {
+    const fetchImpl = vi.fn(async () => new Response("nope", { status: 401 }));
+    const emitter = createOllamaSpanEmitter({
+      tracesEndpoint: "https://app.langwatch.ai/api/otel/v1/traces",
+      token: "ik-lw-wrong",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      warn: vi.fn(),
+    });
+
+    emitter.add(span("ollama.chat"));
+    await emitter.close();
+
+    expect(emitter.sent()).toBe(0);
+  });
+});
+
+describe("given no LangWatch scope", () => {
+  it("accepts calls and does nothing with them", async () => {
+    const emitter = createDiscardingSpanEmitter();
+
+    emitter.add(span("ollama.chat"));
+    await emitter.flush();
+    await emitter.close();
+
+    expect(emitter.sent()).toBe(0);
+  });
+});

--- a/sdks/typescript/src/cli/utils/governance/__tests__/ollama-proxy.integration.test.ts
+++ b/sdks/typescript/src/cli/utils/governance/__tests__/ollama-proxy.integration.test.ts
@@ -1,0 +1,282 @@
+/**
+ * The capture proxy against a real Ollama-shaped server. Real sockets, not a
+ * mocked http module: a mock cannot tell you that a streamed token still
+ * reaches the caller the moment the server produced it, and that is the one
+ * property a proxy can quietly break.
+ */
+
+import { createServer, type Server, type ServerResponse } from "node:http";
+import type { AddressInfo } from "node:net";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { OllamaSpanEmitter } from "../ollama-emitter";
+import {
+  DEFAULT_OLLAMA_ORIGIN,
+  resolveUpstreamOrigin,
+  startOllamaCaptureProxy,
+  type OllamaCaptureProxy,
+} from "../ollama-proxy";
+import type { OtlpSpan } from "../ollama-trace";
+
+/** An emitter that keeps every span so the test can read it. */
+function recordingEmitter(): OllamaSpanEmitter & { spans: OtlpSpan[] } {
+  const spans: OtlpSpan[] = [];
+  return {
+    spans,
+    add: (span) => spans.push(span),
+    flush: async () => undefined,
+    close: async () => undefined,
+    sent: () => spans.length,
+  };
+}
+
+function attributes(span: OtlpSpan): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const attribute of span.attributes) out[attribute.key] = Object.values(attribute.value)[0];
+  return out;
+}
+
+/** Requests the fake Ollama server saw, in order. */
+interface SeenRequest {
+  method: string;
+  url: string;
+  body: string;
+  headers: Record<string, string | string[] | undefined>;
+}
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+describe("given a capture proxy in front of an ollama server", () => {
+  let upstream: Server;
+  let upstreamOrigin: string;
+  let proxy: OllamaCaptureProxy;
+  let emitter: ReturnType<typeof recordingEmitter>;
+  let seen: SeenRequest[];
+  /** Set per test to decide what the fake server answers. */
+  let respond: (request: SeenRequest, res: ServerResponse) => void;
+
+  beforeEach(async () => {
+    seen = [];
+    emitter = recordingEmitter();
+    upstream = createServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on("data", (chunk: Buffer) => chunks.push(chunk));
+      req.on("end", () => {
+        const request: SeenRequest = {
+          method: req.method ?? "",
+          url: req.url ?? "",
+          body: Buffer.concat(chunks).toString("utf8"),
+          headers: req.headers,
+        };
+        seen.push(request);
+        respond(request, res);
+      });
+    });
+    await new Promise<void>((resolve) => upstream.listen(0, "127.0.0.1", resolve));
+    upstreamOrigin = `http://127.0.0.1:${(upstream.address() as AddressInfo).port}`;
+    proxy = await startOllamaCaptureProxy({ upstreamOrigin, emitter });
+  });
+
+  afterEach(async () => {
+    await proxy.close();
+    await new Promise<void>((resolve) => upstream.close(() => resolve()));
+  });
+
+  describe("when a chat request is answered in one piece", () => {
+    /** @scenario "A chat call is reported as one LangWatch call" */
+    it("returns the server's answer and reports one model call", async () => {
+      respond = (_request, res) => {
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(
+          JSON.stringify({
+            model: "llama3",
+            message: { role: "assistant", content: "blue light scatters" },
+            done: true,
+            prompt_eval_count: 9,
+            eval_count: 4,
+          }),
+        );
+      };
+
+      const response = await fetch(`${proxy.url}/api/chat`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          model: "llama3",
+          stream: false,
+          messages: [{ role: "user", content: "why is the sky blue?" }],
+        }),
+      });
+      const body = (await response.json()) as { message: { content: string } };
+
+      expect(response.status).toBe(200);
+      expect(body.message.content).toBe("blue light scatters");
+      // The server saw the request the caller wrote, unchanged.
+      expect(JSON.parse(seen[0]!.body)).toMatchObject({ model: "llama3" });
+
+      expect(emitter.spans).toHaveLength(1);
+      const read = attributes(emitter.spans[0]!);
+      expect(read["langwatch.output"]).toBe("blue light scatters");
+      expect(read["gen_ai.usage.input_tokens"]).toBe("9");
+    });
+  });
+
+  describe("when a chat request is answered one chunk at a time", () => {
+    /** @scenario "A streamed reply reaches the caller as it arrives" */
+    it("passes each chunk through as it is produced and reports the whole reply", async () => {
+      respond = (_request, res) => {
+        res.writeHead(200, { "content-type": "application/x-ndjson" });
+        res.write('{"model":"llama3","message":{"role":"assistant","content":"one "}}\n');
+        setTimeout(() => {
+          res.end(
+            '{"model":"llama3","message":{"role":"assistant","content":"two"},"done":true,"eval_count":2}\n',
+          );
+        }, 120);
+      };
+
+      const startedAt = Date.now();
+      const response = await fetch(`${proxy.url}/api/chat`, {
+        method: "POST",
+        body: JSON.stringify({ model: "llama3", messages: [{ role: "user", content: "count" }] }),
+      });
+      const reader = response.body!.getReader();
+      const arrivals: number[] = [];
+      let text = "";
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        arrivals.push(Date.now() - startedAt);
+        text += Buffer.from(value).toString("utf8");
+      }
+
+      // The first chunk landed well before the server had finished: the proxy
+      // is forwarding as it goes, not buffering the whole generation.
+      expect(arrivals.length).toBeGreaterThan(1);
+      expect(arrivals[0]!).toBeLessThan(100);
+      expect(text).toContain("one ");
+      expect(text).toContain("two");
+
+      expect(emitter.spans).toHaveLength(1);
+      expect(attributes(emitter.spans[0]!)["langwatch.output"]).toBe("one two");
+    });
+  });
+
+  describe("when the request is one the proxy does not read", () => {
+    /** @scenario "A request the proxy does not report still reaches the server untouched" */
+    it("forwards it and reports nothing", async () => {
+      respond = (_request, res) => {
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify({ models: [{ name: "llama3" }] }));
+      };
+
+      const response = await fetch(`${proxy.url}/api/tags`);
+
+      expect(await response.json()).toEqual({ models: [{ name: "llama3" }] });
+      expect(seen[0]!.url).toBe("/api/tags");
+      expect(emitter.spans).toEqual([]);
+    });
+
+    it("forwards a POST body it does not read", async () => {
+      respond = (_request, res) => {
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end("{}");
+      };
+
+      await fetch(`${proxy.url}/api/pull`, {
+        method: "POST",
+        body: JSON.stringify({ model: "llama3" }),
+      });
+
+      expect(JSON.parse(seen[0]!.body)).toEqual({ model: "llama3" });
+      expect(emitter.spans).toEqual([]);
+    });
+  });
+
+  describe("when the server rejects the request", () => {
+    /** @scenario "A server error is returned to the caller and reported as a failed call" */
+    it("returns the server's status and body, and reports a failed call", async () => {
+      respond = (_request, res) => {
+        res.writeHead(404, { "content-type": "application/json" });
+        res.end(JSON.stringify({ error: "model 'ghost' not found" }));
+      };
+
+      const response = await fetch(`${proxy.url}/api/chat`, {
+        method: "POST",
+        body: JSON.stringify({ model: "ghost", messages: [] }),
+      });
+
+      expect(response.status).toBe(404);
+      expect(await response.json()).toEqual({ error: "model 'ghost' not found" });
+      expect(emitter.spans[0]!.status.code).toBe(2);
+    });
+  });
+
+  describe("when the session makes no model calls", () => {
+    /** @scenario "A session with no model calls reports nothing" */
+    it("reports nothing", async () => {
+      expect(emitter.spans).toEqual([]);
+    });
+  });
+});
+
+describe("when no ollama server is listening", () => {
+  it("answers the caller with a message naming the address that did not answer", async () => {
+    // Port 1 on loopback: reserved, never bound by anything a test can race.
+    const upstreamOrigin = "http://127.0.0.1:1";
+    const proxy = await startOllamaCaptureProxy({ upstreamOrigin, emitter: recordingEmitter() });
+    try {
+      const response = await fetch(`${proxy.url}/api/chat`, {
+        method: "POST",
+        body: JSON.stringify({ model: "llama3", messages: [] }),
+      });
+      const body = (await response.json()) as { error: string };
+
+      expect(response.status).toBe(502);
+      expect(body.error).toContain(upstreamOrigin);
+    } finally {
+      await proxy.close();
+    }
+  });
+});
+
+describe("reading OLLAMA_HOST", () => {
+  /** @scenario "The proxy forwards to the address OLLAMA_HOST names" */
+  it("takes a full URL as written", () => {
+    expect(resolveUpstreamOrigin("http://192.168.1.9:11434")).toBe("http://192.168.1.9:11434");
+    expect(resolveUpstreamOrigin("https://ollama.internal")).toBe("https://ollama.internal");
+  });
+
+  /** @scenario "An OLLAMA_HOST written without a scheme is understood" */
+  it("adds the scheme to a host and port written without one", () => {
+    expect(resolveUpstreamOrigin("127.0.0.1:11434")).toBe("http://127.0.0.1:11434");
+  });
+
+  it("uses ollama's own default port for a bare host", () => {
+    expect(resolveUpstreamOrigin("my-box")).toBe("http://my-box:11434");
+  });
+
+  /** @scenario "With OLLAMA_HOST unset the default local server is used" */
+  it("falls back to the local server when it is unset, empty, or unreadable", () => {
+    expect(resolveUpstreamOrigin(undefined)).toBe(DEFAULT_OLLAMA_ORIGIN);
+    expect(resolveUpstreamOrigin("   ")).toBe(DEFAULT_OLLAMA_ORIGIN);
+    expect(resolveUpstreamOrigin("http://")).toBe(DEFAULT_OLLAMA_ORIGIN);
+  });
+});
+
+describe("the proxy's own lifetime", () => {
+  it("stops answering once it is closed", async () => {
+    const upstream = createServer((_req, res) => res.end("{}"));
+    await new Promise<void>((resolve) => upstream.listen(0, "127.0.0.1", resolve));
+    const proxy = await startOllamaCaptureProxy({
+      upstreamOrigin: `http://127.0.0.1:${(upstream.address() as AddressInfo).port}`,
+      emitter: recordingEmitter(),
+    });
+    const url = proxy.url;
+
+    await proxy.close();
+    await sleep(10);
+
+    await expect(fetch(`${url}/api/tags`)).rejects.toThrow();
+    await new Promise<void>((resolve) => upstream.close(() => resolve()));
+  });
+});

--- a/sdks/typescript/src/cli/utils/governance/__tests__/ollama-trace.unit.test.ts
+++ b/sdks/typescript/src/cli/utils/governance/__tests__/ollama-trace.unit.test.ts
@@ -1,0 +1,306 @@
+/**
+ * What one observed Ollama exchange becomes.
+ *
+ * The bodies here are the shapes Ollama actually puts on the wire — a single
+ * JSON answer, newline-delimited chunks, and the Server-Sent Events framing
+ * of the OpenAI-compatible route — because the three framings are the only
+ * reason this module is not a one-liner.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  buildOllamaExportRequest,
+  buildOllamaSpan,
+  ollamaRouteFor,
+  parseResponseRecords,
+  type OllamaExchange,
+  type SpanIdGenerator,
+} from "../ollama-trace";
+
+const ids: SpanIdGenerator = {
+  traceId: () => "a".repeat(32),
+  spanId: () => "b".repeat(16),
+};
+
+function attributes(span: NonNullable<ReturnType<typeof buildOllamaSpan>>) {
+  const out: Record<string, unknown> = {};
+  for (const attribute of span.attributes) {
+    out[attribute.key] = Object.values(attribute.value)[0];
+  }
+  return out;
+}
+
+function exchange(overrides: Partial<OllamaExchange>): OllamaExchange {
+  return {
+    route: "chat",
+    requestBody: "{}",
+    responseBody: "",
+    status: 200,
+    startedAtMs: 1_000,
+    endedAtMs: 2_000,
+    ...overrides,
+  };
+}
+
+describe("reading an ollama request path", () => {
+  it("recognises the two native prompt routes and the OpenAI-compatible one", () => {
+    expect(ollamaRouteFor("/api/chat")).toBe("chat");
+    expect(ollamaRouteFor("/api/generate")).toBe("generate");
+    expect(ollamaRouteFor("/v1/chat/completions")).toBe("openai-chat");
+  });
+
+  it("ignores a query string and a trailing slash", () => {
+    expect(ollamaRouteFor("/api/chat/")).toBe("chat");
+    expect(ollamaRouteFor("/api/chat?stream=true")).toBe("chat");
+  });
+
+  it("leaves every other route unread", () => {
+    expect(ollamaRouteFor("/api/tags")).toBeNull();
+    expect(ollamaRouteFor("/api/pull")).toBeNull();
+    expect(ollamaRouteFor("/")).toBeNull();
+  });
+});
+
+describe("reading a response body", () => {
+  it("reads one JSON object", () => {
+    expect(parseResponseRecords('{"done":true}')).toEqual([{ done: true }]);
+  });
+
+  it("reads newline-delimited chunks", () => {
+    expect(parseResponseRecords('{"a":1}\n{"a":2}\n')).toEqual([{ a: 1 }, { a: 2 }]);
+  });
+
+  it("reads Server-Sent Events and drops the terminator", () => {
+    expect(parseResponseRecords('data: {"a":1}\n\ndata: [DONE]\n\n')).toEqual([{ a: 1 }]);
+  });
+
+  it("keeps the complete chunks of a stream that was cut off", () => {
+    expect(parseResponseRecords('{"a":1}\n{"a":2}\n{"a":')).toEqual([{ a: 1 }, { a: 2 }]);
+  });
+});
+
+describe("building the span for a chat call", () => {
+  describe("when the answer arrived in one piece", () => {
+    /** @scenario "A chat call is reported as one LangWatch call" */
+    it("carries the conversation, the reply, the model and the token counts", () => {
+      const span = buildOllamaSpan(
+        exchange({
+          requestBody: JSON.stringify({
+            model: "llama3",
+            stream: false,
+            messages: [{ role: "user", content: "why is the sky blue?" }],
+            options: { temperature: 0.2 },
+          }),
+          responseBody: JSON.stringify({
+            model: "llama3",
+            message: { role: "assistant", content: "Rayleigh scattering." },
+            done: true,
+            done_reason: "stop",
+            prompt_eval_count: 12,
+            eval_count: 5,
+          }),
+        }),
+        ids,
+      );
+
+      expect(span).not.toBeNull();
+      const read = attributes(span!);
+      expect(read["langwatch.span.type"]).toBe("llm");
+      expect(read["gen_ai.provider.name"]).toBe("ollama");
+      expect(read["gen_ai.operation.name"]).toBe("chat");
+      expect(JSON.parse(String(read["langwatch.input"]))).toEqual({
+        type: "chat_messages",
+        value: [{ role: "user", content: "why is the sky blue?" }],
+      });
+      expect(read["langwatch.output"]).toBe("Rayleigh scattering.");
+      expect(read["gen_ai.request.model"]).toBe("llama3");
+      expect(read["gen_ai.response.model"]).toBe("llama3");
+      expect(read["gen_ai.usage.input_tokens"]).toBe("12");
+      expect(read["gen_ai.usage.output_tokens"]).toBe("5");
+      expect(read["gen_ai.request.stream"]).toBe(false);
+      expect(read["gen_ai.request.temperature"]).toBe(0.2);
+      expect(read["gen_ai.response.finish_reasons"]).toBe("stop");
+      expect(span!.status).toEqual({});
+    });
+
+    it("spans the time the call took", () => {
+      const span = buildOllamaSpan(
+        exchange({
+          requestBody: JSON.stringify({ model: "llama3", messages: [] }),
+          startedAtMs: 1_700_000_000_000,
+          endedAtMs: 1_700_000_002_500,
+        }),
+        ids,
+      );
+
+      expect(span!.startTimeUnixNano).toBe("1700000000000000000");
+      expect(span!.endTimeUnixNano).toBe("1700000002500000000");
+    });
+  });
+
+  describe("when the answer arrived one chunk at a time", () => {
+    /** @scenario "A streamed reply reaches the caller as it arrives" */
+    it("reports the whole assembled answer", () => {
+      const span = buildOllamaSpan(
+        exchange({
+          requestBody: JSON.stringify({
+            model: "llama3",
+            messages: [{ role: "user", content: "count" }],
+          }),
+          responseBody: [
+            '{"model":"llama3","message":{"role":"assistant","content":"one "},"done":false}',
+            '{"model":"llama3","message":{"role":"assistant","content":"two"},"done":false}',
+            '{"model":"llama3","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":3,"eval_count":2}',
+          ].join("\n"),
+        }),
+        ids,
+      );
+
+      const read = attributes(span!);
+      expect(read["langwatch.output"]).toBe("one two");
+      expect(read["gen_ai.usage.output_tokens"]).toBe("2");
+      // Native Ollama streams unless told not to, so an absent `stream` is
+      // a streamed call, not a non-streamed one.
+      expect(read["gen_ai.request.stream"]).toBe(true);
+    });
+  });
+
+  describe("when the conversation carried an image", () => {
+    it("records that an image was sent without carrying the image", () => {
+      const span = buildOllamaSpan(
+        exchange({
+          requestBody: JSON.stringify({
+            model: "llava",
+            messages: [{ role: "user", content: "what is this?", images: ["QUJD".repeat(400)] }],
+          }),
+        }),
+        ids,
+      );
+
+      const input = String(attributes(span!)["langwatch.input"]);
+      expect(input).not.toContain("QUJDQUJD");
+      expect(input).toContain("<image omitted, 1600 characters>");
+    });
+  });
+});
+
+describe("building the span for a completion call", () => {
+  /** @scenario "A completion call is reported with its prompt and its answer" */
+  it("carries the prompt as text and the assembled answer", () => {
+    const span = buildOllamaSpan(
+      exchange({
+        route: "generate",
+        requestBody: JSON.stringify({ model: "llama3", prompt: "haiku about ports" }),
+        responseBody: ['{"response":"small "}', '{"response":"ships","done":true}'].join("\n"),
+      }),
+      ids,
+    );
+
+    const read = attributes(span!);
+    expect(JSON.parse(String(read["langwatch.input"]))).toEqual({
+      type: "text",
+      value: "haiku about ports",
+    });
+    expect(read["langwatch.output"]).toBe("small ships");
+    expect(read["gen_ai.operation.name"]).toBe("text_completion");
+  });
+});
+
+describe("building the span for an OpenAI-compatible call", () => {
+  /** @scenario "A call made through the OpenAI-compatible endpoint is reported the same way" */
+  it("reads the streamed deltas and the usage block", () => {
+    const span = buildOllamaSpan(
+      exchange({
+        route: "openai-chat",
+        requestBody: JSON.stringify({
+          model: "llama3",
+          stream: true,
+          temperature: 0.7,
+          messages: [{ role: "user", content: "hello" }],
+        }),
+        responseBody: [
+          'data: {"model":"llama3","choices":[{"delta":{"content":"hi"}}]}',
+          'data: {"model":"llama3","choices":[{"delta":{"content":" there"},"finish_reason":"stop"}],"usage":{"prompt_tokens":4,"completion_tokens":2}}',
+          "data: [DONE]",
+        ].join("\n\n"),
+      }),
+      ids,
+    );
+
+    const read = attributes(span!);
+    expect(read["langwatch.output"]).toBe("hi there");
+    expect(read["gen_ai.usage.input_tokens"]).toBe("4");
+    expect(read["gen_ai.usage.output_tokens"]).toBe("2");
+    expect(read["gen_ai.response.finish_reasons"]).toBe("stop");
+    expect(read["gen_ai.request.temperature"]).toBe(0.7);
+  });
+
+  it("reads a non-streamed answer from the message body", () => {
+    const span = buildOllamaSpan(
+      exchange({
+        route: "openai-chat",
+        requestBody: JSON.stringify({
+          model: "llama3",
+          messages: [{ role: "user", content: "x" }],
+        }),
+        responseBody: JSON.stringify({
+          model: "llama3",
+          choices: [{ message: { role: "assistant", content: "y" } }],
+          usage: { prompt_tokens: 1, completion_tokens: 1 },
+        }),
+      }),
+      ids,
+    );
+
+    expect(attributes(span!)["langwatch.output"]).toBe("y");
+    // The OpenAI-compatible route does not stream unless asked.
+    expect(attributes(span!)["gen_ai.request.stream"]).toBe(false);
+  });
+});
+
+describe("when the server refused the call", () => {
+  /** @scenario "A server error is returned to the caller and reported as a failed call" */
+  it("marks the span failed and keeps the reason", () => {
+    const span = buildOllamaSpan(
+      exchange({
+        requestBody: JSON.stringify({ model: "missing", messages: [] }),
+        responseBody: '{"error":"model \'missing\' not found"}',
+        status: 404,
+      }),
+      ids,
+    );
+
+    expect(span!.status.code).toBe(2);
+    expect(span!.status.message).toContain("not found");
+    expect(attributes(span!)["http.response.status_code"]).toBe("404");
+  });
+});
+
+describe("when the request said nothing a span could carry", () => {
+  it("produces no span for a body that is not JSON", () => {
+    expect(buildOllamaSpan(exchange({ requestBody: "not json at all" }), ids)).toBeNull();
+  });
+
+  it("produces no span for JSON with neither a model nor a prompt", () => {
+    expect(buildOllamaSpan(exchange({ requestBody: '{"keep_alive":0}' }), ids)).toBeNull();
+  });
+});
+
+describe("the export envelope", () => {
+  it("names the ollama service under a langwatch scope", () => {
+    const request = buildOllamaExportRequest([]) as {
+      resourceSpans: {
+        resource: { attributes: { key: string; value: { stringValue: string } }[] };
+        scopeSpans: { scope: { name: string }; spans: unknown[] }[];
+      }[];
+    };
+
+    expect(request.resourceSpans[0]!.resource.attributes[0]).toEqual({
+      key: "service.name",
+      value: { stringValue: "ollama" },
+    });
+    // A langwatch.* scope keeps these content spans clear of the ingestion
+    // side's infrastructure-span filter, the same way the codex harvest does.
+    expect(request.resourceSpans[0]!.scopeSpans[0]!.scope.name).toBe("langwatch.ollama");
+  });
+});

--- a/sdks/typescript/src/cli/utils/governance/ollama-emitter.ts
+++ b/sdks/typescript/src/cli/utils/governance/ollama-emitter.ts
@@ -1,0 +1,142 @@
+/**
+ * Ship captured Ollama spans to LangWatch. A local model answers fast and
+ * often, so spans are buffered and flushed on a timer (and once more when the
+ * session ends), which is also what lets a failed upload retry. Nothing here
+ * may end a session: every failure is swallowed, reported once, and the
+ * buffer is bounded so a control plane that is down cannot grow the process.
+ */
+
+import { buildOllamaExportRequest, type OtlpSpan } from "./ollama-trace";
+
+/** Spans held for a retry. Past this, the oldest are dropped. */
+const MAX_BUFFERED_SPANS = 500;
+
+/** How long a flush may take before it is abandoned. */
+const FLUSH_TIMEOUT_MS = 5_000;
+
+export interface OllamaSpanEmitter {
+  add(span: OtlpSpan): void;
+  /** Send whatever is buffered. Never rejects. */
+  flush(): Promise<void>;
+  /** Stop the timer and send the remainder. Never rejects. */
+  close(): Promise<void>;
+  /** How many spans this emitter has handed to a successful flush. */
+  sent(): number;
+}
+
+export interface OllamaSpanEmitterOptions {
+  /** Full OTLP traces URL, e.g. `https://app.langwatch.ai/api/otel/v1/traces`. */
+  tracesEndpoint: string;
+  token: string;
+  flushIntervalMs?: number;
+  fetchImpl?: typeof fetch;
+  /** Where the one-time failure note goes. Defaults to stderr. */
+  warn?: (message: string) => void;
+}
+
+/**
+ * An emitter that accepts spans and does nothing with them, for a session
+ * with no LangWatch scope. The proxy still runs, so the wrapped command
+ * behaves identically whether or not anything is being captured.
+ */
+export function createDiscardingSpanEmitter(): OllamaSpanEmitter {
+  return {
+    add: () => undefined,
+    flush: async () => undefined,
+    close: async () => undefined,
+    sent: () => 0,
+  };
+}
+
+export function createOllamaSpanEmitter(options: OllamaSpanEmitterOptions): OllamaSpanEmitter {
+  const {
+    tracesEndpoint,
+    token,
+    flushIntervalMs = 2_000,
+    fetchImpl,
+    warn = (message: string) => process.stderr.write(`${message}\n`),
+  } = options;
+
+  let buffered: OtlpSpan[] = [];
+  let sentCount = 0;
+  let warnedOnce = false;
+
+  const post = async (spans: OtlpSpan[]): Promise<boolean> => {
+    const doFetch = fetchImpl ?? fetch;
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), FLUSH_TIMEOUT_MS);
+    try {
+      const response = await doFetch(tracesEndpoint, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify(buildOllamaExportRequest(spans)),
+        signal: controller.signal,
+      });
+      return response.ok;
+    } catch {
+      return false;
+    } finally {
+      clearTimeout(timeout);
+    }
+  };
+
+  const sendBuffered = async (): Promise<void> => {
+    if (buffered.length === 0) return;
+    const batch = buffered;
+    buffered = [];
+    const landed = await post(batch);
+    if (landed) {
+      sentCount += batch.length;
+      return;
+    }
+    // Put the batch back in front of anything captured while it was in
+    // flight, so the retry keeps the calls in the order they happened.
+    buffered = [...batch, ...buffered].slice(-MAX_BUFFERED_SPANS);
+    if (!warnedOnce) {
+      warnedOnce = true;
+      warn(
+        "[langwatch] could not reach LangWatch; ollama calls will be retried in the background.",
+      );
+    }
+  };
+
+  /**
+   * Flushes run one at a time, in order. Two overlapping ones would each take
+   * a copy of the buffer and send the same calls twice under different span
+   * ids — a duplicate in the UI rather than a retry — and a `close` racing a
+   * timer tick would return before the tick it is waiting on had finished.
+   */
+  let pending: Promise<void> = Promise.resolve();
+  const flush = (): Promise<void> => {
+    pending = pending.then(sendBuffered);
+    return pending;
+  };
+
+  const timer = setInterval(() => {
+    void flush();
+  }, flushIntervalMs);
+  // The wrapped command owns the process lifetime; the flush timer must never
+  // be the thing keeping it alive.
+  timer.unref?.();
+
+  return {
+    add(span: OtlpSpan): void {
+      buffered.push(span);
+      if (buffered.length > MAX_BUFFERED_SPANS) {
+        buffered = buffered.slice(-MAX_BUFFERED_SPANS);
+      }
+    },
+    flush,
+    async close(): Promise<void> {
+      clearInterval(timer);
+      // One retry: the common failure at this point is a flush that raced the
+      // command's own exit, and the spans are back on the buffer.
+      await flush();
+      await flush();
+    },
+    sent: () => sentCount,
+  };
+}

--- a/sdks/typescript/src/cli/utils/governance/ollama-proxy.ts
+++ b/sdks/typescript/src/cli/utils/governance/ollama-proxy.ts
@@ -1,0 +1,254 @@
+/**
+ * The loopback proxy `langwatch ollama` puts in front of the Ollama server.
+ * It is a forwarder first and an observer second: every request reaches the
+ * server and every answer reaches the caller, byte for byte and chunk for
+ * chunk, whether or not the exchange is one this build reports. Only the
+ * three prompt-carrying routes are read (see ollama-trace.ts).
+ */
+
+import {
+  createServer,
+  request as httpRequest,
+  type ClientRequest,
+  type IncomingMessage,
+  type Server,
+  type ServerResponse,
+} from "node:http";
+import { request as httpsRequest } from "node:https";
+import type { AddressInfo } from "node:net";
+import type { OllamaSpanEmitter } from "./ollama-emitter";
+import { buildOllamaSpan, ollamaRouteFor, type OllamaRoute } from "./ollama-trace";
+
+/** Where Ollama listens when nothing says otherwise. */
+export const DEFAULT_OLLAMA_ORIGIN = "http://127.0.0.1:11434";
+
+const DEFAULT_OLLAMA_PORT = "11434";
+
+/**
+ * Read an `OLLAMA_HOST` the way Ollama does: a bare host, a host and port, or
+ * a full URL. An unparseable value falls back to the default rather than
+ * failing the launch — the server gets to complain about an address it does
+ * not like, in its own words.
+ */
+export function resolveUpstreamOrigin(raw: string | undefined): string {
+  const value = raw?.trim();
+  if (!value) return DEFAULT_OLLAMA_ORIGIN;
+  try {
+    const written = value.includes("://");
+    const url = new URL(written ? value : `http://${value}`);
+    // A scheme-less `host` means the default Ollama port, not the HTTP one:
+    // `OLLAMA_HOST=my-box` reaches my-box:11434.
+    if (!written && !url.port) url.port = DEFAULT_OLLAMA_PORT;
+    return url.origin;
+  } catch {
+    return DEFAULT_OLLAMA_ORIGIN;
+  }
+}
+
+export interface OllamaCaptureProxy {
+  /** The address to hand the child as `OLLAMA_HOST`. */
+  url: string;
+  /** Stop accepting connections and wait for the ones in flight. */
+  close(): Promise<void>;
+}
+
+export interface OllamaCaptureProxyOptions {
+  /** Origin of the real Ollama server, from `resolveUpstreamOrigin`. */
+  upstreamOrigin: string;
+  emitter: OllamaSpanEmitter;
+  /** Clock seam, so a test can assert on span timings. */
+  now?: () => number;
+}
+
+/** Everything a captured exchange accumulates while it is in flight. */
+interface Capture {
+  route: OllamaRoute;
+  requestBody: Buffer;
+  responseBody: Buffer[];
+  startedAtMs: number;
+}
+
+/** The one upstream every request of this proxy is forwarded to. */
+interface Upstream {
+  origin: string;
+  url: URL;
+  send: typeof httpRequest;
+  emitter: OllamaSpanEmitter;
+  now: () => number;
+}
+
+async function readBody(req: IncomingMessage): Promise<Buffer> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) chunks.push(chunk as Buffer);
+  return Buffer.concat(chunks);
+}
+
+/** Which prompt-carrying route this request is, if any. */
+function routeOf(req: IncomingMessage): OllamaRoute | null {
+  if (req.method !== "POST") return null;
+  return ollamaRouteFor(new URL(req.url ?? "/", "http://proxy").pathname);
+}
+
+/**
+ * The headers for the forwarded hop. A captured exchange asks for an
+ * uncompressed answer, because a compressed one is unreadable to the tee; a
+ * re-sent body carries the one length this hop knows, whatever framing the
+ * caller used.
+ */
+function forwardHeaders(
+  req: IncomingMessage,
+  upstream: Upstream,
+  capture: Capture | null,
+  body: Buffer | null,
+): Record<string, string | string[]> {
+  const headers: Record<string, string | string[]> = {};
+  for (const [key, value] of Object.entries(req.headers)) {
+    if (value !== undefined) headers[key] = value;
+  }
+  headers.host = upstream.url.host;
+  if (capture) headers["accept-encoding"] = "identity";
+  if (body) {
+    delete headers["transfer-encoding"];
+    headers["content-length"] = String(body.byteLength);
+  }
+  return headers;
+}
+
+/** Read the finished exchange and hand the emitter its span. */
+function report(upstream: Upstream, capture: Capture, status: number): void {
+  try {
+    const span = buildOllamaSpan({
+      route: capture.route,
+      requestBody: capture.requestBody.toString("utf8"),
+      responseBody: Buffer.concat(capture.responseBody).toString("utf8"),
+      status,
+      startedAtMs: capture.startedAtMs,
+      endedAtMs: upstream.now(),
+    });
+    if (span) upstream.emitter.add(span);
+  } catch {
+    // A call that could not be read is still a call that worked; the session
+    // must not notice that its span was lost.
+    return;
+  }
+}
+
+/** Pipe the upstream answer back, teeing it when the exchange is captured. */
+function relayAnswer(
+  upstream: Upstream,
+  capture: Capture | null,
+  proxyRes: IncomingMessage,
+  res: ServerResponse,
+): void {
+  res.writeHead(proxyRes.statusCode ?? 502, proxyRes.headers);
+  if (capture) {
+    proxyRes.on("data", (chunk: Buffer) => capture.responseBody.push(chunk));
+    proxyRes.on("end", () => report(upstream, capture, proxyRes.statusCode ?? 0));
+  }
+  proxyRes.pipe(res);
+}
+
+/** Answer the caller when the Ollama server could not be reached at all. */
+function answerUnreachable(upstream: Upstream, res: ServerResponse, error: Error): void {
+  if (!res.headersSent) res.writeHead(502, { "content-type": "application/json" });
+  res.end(
+    JSON.stringify({
+      error: `langwatch could not reach the ollama server at ${upstream.origin}: ${error.message}`,
+    }),
+  );
+}
+
+function forward(
+  upstream: Upstream,
+  req: IncomingMessage,
+  res: ServerResponse,
+  capture: Capture | null,
+  body: Buffer | null,
+): void {
+  const proxyReq: ClientRequest = upstream.send(
+    {
+      protocol: upstream.url.protocol,
+      hostname: upstream.url.hostname,
+      port: upstream.url.port,
+      path: req.url ?? "/",
+      method: req.method,
+      headers: forwardHeaders(req, upstream, capture, body),
+    },
+    (proxyRes) => relayAnswer(upstream, capture, proxyRes, res),
+  );
+
+  proxyReq.on("error", (error: Error) => answerUnreachable(upstream, res, error));
+
+  // The caller gave up (Ctrl-C mid-generation): stop the upstream work rather
+  // than leaving the model running for an answer nobody reads.
+  res.on("close", () => {
+    if (!res.writableFinished) proxyReq.destroy();
+  });
+
+  if (body) {
+    proxyReq.end(body);
+  } else {
+    req.pipe(proxyReq);
+  }
+}
+
+function handle(upstream: Upstream, req: IncomingMessage, res: ServerResponse): void {
+  const route = routeOf(req);
+  if (!route) {
+    forward(upstream, req, res, null, null);
+    return;
+  }
+  // A prompt body is small and the span needs it whole, so it is buffered
+  // before the hop; the answer is teed while it streams.
+  void readBody(req)
+    .then((body) => {
+      const capture: Capture = {
+        route,
+        requestBody: body,
+        responseBody: [],
+        startedAtMs: upstream.now(),
+      };
+      forward(upstream, req, res, capture, body);
+    })
+    .catch(() => {
+      if (!res.headersSent) res.writeHead(400, { "content-type": "application/json" });
+      res.end(JSON.stringify({ error: "langwatch could not read the request body" }));
+    });
+}
+
+export async function startOllamaCaptureProxy(
+  options: OllamaCaptureProxyOptions,
+): Promise<OllamaCaptureProxy> {
+  const url = new URL(options.upstreamOrigin);
+  const upstream: Upstream = {
+    origin: options.upstreamOrigin,
+    url,
+    send: url.protocol === "https:" ? httpsRequest : httpRequest,
+    emitter: options.emitter,
+    now: options.now ?? (() => Date.now()),
+  };
+
+  const server = createServer((req, res) => handle(upstream, req, res));
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.removeListener("error", reject);
+      resolve();
+    });
+  });
+
+  const address = server.address() as AddressInfo;
+  return {
+    url: `http://127.0.0.1:${address.port}`,
+    close: () => closeServer(server),
+  };
+}
+
+function closeServer(server: Server): Promise<void> {
+  return new Promise<void>((resolve) => {
+    // Keep-alive sockets the child left open would hold the close open past
+    // the command it belongs to; the child is gone by now, so drop them.
+    server.closeIdleConnections?.();
+    server.close(() => resolve());
+  });
+}

--- a/sdks/typescript/src/cli/utils/governance/ollama-trace.ts
+++ b/sdks/typescript/src/cli/utils/governance/ollama-trace.ts
@@ -1,0 +1,389 @@
+/**
+ * Turn one observed Ollama HTTP exchange into one LangWatch LLM span. Ollama
+ * has no telemetry configuration, so the wire between its CLI and its server
+ * is the only place a prompt and its completion are both visible; the proxy
+ * reads them there (ollama-proxy.ts) and this module decides what they mean.
+ * Pure: bodies in, an OTLP/JSON payload out.
+ */
+
+import { randomBytes } from "node:crypto";
+
+/** The request shapes this module knows how to read. */
+export type OllamaRoute = "chat" | "generate" | "openai-chat";
+
+/**
+ * Which route a request path belongs to, or null for everything else. The
+ * rest of the API — pulls, pushes, the model list, blob uploads — carries no
+ * prompt and is forwarded unread.
+ */
+export function ollamaRouteFor(pathname: string): OllamaRoute | null {
+  const path = pathname.split("?")[0]?.replace(/\/+$/, "") ?? "";
+  if (path === "/api/chat") return "chat";
+  if (path === "/api/generate") return "generate";
+  if (path === "/v1/chat/completions") return "openai-chat";
+  return null;
+}
+
+/** One request/response pair the proxy watched go by. */
+export interface OllamaExchange {
+  route: OllamaRoute;
+  /** Verbatim request body. */
+  requestBody: string;
+  /** Verbatim response body, streamed chunks included, in arrival order. */
+  responseBody: string;
+  status: number;
+  startedAtMs: number;
+  endedAtMs: number;
+}
+
+/** OTLP/JSON attribute, in the one encoding the exporter accepts. */
+type OtlpAttribute = {
+  key: string;
+  value:
+    | { stringValue: string }
+    | { intValue: string }
+    | { boolValue: boolean }
+    | { doubleValue: number };
+};
+
+export interface OtlpSpan {
+  traceId: string;
+  spanId: string;
+  name: string;
+  kind: number;
+  startTimeUnixNano: string;
+  endTimeUnixNano: string;
+  attributes: OtlpAttribute[];
+  status: { code?: number; message?: string };
+}
+
+export interface OtlpExportRequest {
+  resourceSpans: unknown[];
+}
+
+/**
+ * The ceiling on a captured prompt or completion, in characters. Past this a
+ * span is one nobody can render and an upload nobody wants, so the value is
+ * truncated with a marker rather than dropped.
+ */
+const MAX_CAPTURED_CHARS = 128_000;
+
+/** Longest error body kept as the span's status message. */
+const MAX_STATUS_MESSAGE_CHARS = 1_000;
+
+/** Marks where a chat message's base64 image data was left out. */
+const IMAGE_PLACEHOLDER_PREFIX = "<image omitted, ";
+
+/** 2 is ERROR in the OTLP status enum; a healthy span names no status. */
+const OTLP_STATUS_ERROR = 2;
+
+function stringAttr(key: string, value: string): OtlpAttribute {
+  return { key, value: { stringValue: value } };
+}
+
+function intAttr(key: string, value: number): OtlpAttribute {
+  return { key, value: { intValue: String(Math.trunc(value)) } };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function truncate(value: string): string {
+  if (value.length <= MAX_CAPTURED_CHARS) return value;
+  return `${value.slice(0, MAX_CAPTURED_CHARS)}… [truncated by langwatch at ${MAX_CAPTURED_CHARS} characters]`;
+}
+
+function numberOrNull(value: unknown): number | null {
+  return typeof value === "number" ? value : null;
+}
+
+/** One JSON object, or null when the text is not one. */
+function tryParseRecord(text: string): Record<string, unknown> | null {
+  try {
+    const value: unknown = JSON.parse(text);
+    return isRecord(value) ? value : null;
+  } catch {
+    // Not one object: the caller falls through to the line framings.
+    return null;
+  }
+}
+
+/**
+ * Read a response body as a list of JSON records, whichever framing Ollama
+ * used: one object (not streamed), newline-delimited JSON (streamed native),
+ * or Server-Sent Events (streamed OpenAI-compatible). A line that does not
+ * parse is skipped, so a stream cut off mid-chunk still reports every
+ * complete chunk before the cut.
+ */
+export function parseResponseRecords(body: string): Record<string, unknown>[] {
+  const trimmed = body.trim();
+  if (trimmed === "") return [];
+  const single = tryParseRecord(trimmed);
+  if (single) return [single];
+
+  const records: Record<string, unknown>[] = [];
+  for (const rawLine of trimmed.split("\n")) {
+    const line = rawLine.trim();
+    const payload = line.startsWith("data:") ? line.slice("data:".length).trim() : line;
+    if (payload === "" || payload === "[DONE]") continue;
+    const record = tryParseRecord(payload);
+    if (record) records.push(record);
+  }
+  return records;
+}
+
+/** Replace base64 image payloads in a chat message list with a size note. */
+function redactImages(messages: unknown[]): unknown[] {
+  return messages.map((message) => {
+    const carriesImages = isRecord(message) && Array.isArray(message.images);
+    if (!carriesImages) return message;
+    return {
+      ...message,
+      images: (message.images as unknown[]).map((image) =>
+        typeof image === "string"
+          ? `${IMAGE_PLACEHOLDER_PREFIX}${image.length} characters>`
+          : image,
+      ),
+    };
+  });
+}
+
+/** What the caller asked for, as the span records it. */
+interface RequestReading {
+  model: string | null;
+  /** The `langwatch.input` value, already JSON-encoded. */
+  input: string | null;
+  stream: boolean | null;
+  temperature: number | null;
+}
+
+const EMPTY_REQUEST: RequestReading = {
+  model: null,
+  input: null,
+  stream: null,
+  temperature: null,
+};
+
+/** The prompt, in the envelope the LangWatch receiver reads. */
+function readInput(route: OllamaRoute, parsed: Record<string, unknown>): string | null {
+  if (route === "generate") {
+    const prompt = parsed.prompt;
+    if (typeof prompt !== "string") return null;
+    return JSON.stringify({ type: "text", value: truncate(prompt) });
+  }
+  const messages = parsed.messages;
+  if (!Array.isArray(messages)) return null;
+  return truncate(JSON.stringify({ type: "chat_messages", value: redactImages(messages) }));
+}
+
+/**
+ * Native Ollama streams unless told not to and nests sampling under
+ * `options`; the OpenAI-compatible surface does neither. Reading both here
+ * keeps the difference out of the span.
+ */
+function readRequest(route: OllamaRoute, body: string): RequestReading {
+  const parsed = tryParseRecord(body);
+  if (!parsed) return EMPTY_REQUEST;
+
+  const nativeOptions = isRecord(parsed.options) ? parsed.options : {};
+  const streamedByDefault = route !== "openai-chat";
+  return {
+    model: typeof parsed.model === "string" ? parsed.model : null,
+    input: readInput(route, parsed),
+    stream: typeof parsed.stream === "boolean" ? parsed.stream : streamedByDefault,
+    temperature: numberOrNull(
+      route === "openai-chat" ? parsed.temperature : nativeOptions.temperature,
+    ),
+  };
+}
+
+/** What came back, assembled across however many chunks carried it. */
+interface ResponseReading {
+  model: string | null;
+  output: string;
+  inputTokens: number | null;
+  outputTokens: number | null;
+  finishReason: string | null;
+}
+
+/** One chunk of an OpenAI-compatible answer: deltas, or the whole message. */
+function readOpenAiRecord(
+  record: Record<string, unknown>,
+  reading: ResponseReading,
+  parts: string[],
+): void {
+  for (const choice of Array.isArray(record.choices) ? record.choices : []) {
+    if (!isRecord(choice)) continue;
+    const delta = isRecord(choice.delta) ? choice.delta : null;
+    const message = isRecord(choice.message) ? choice.message : null;
+    const content = delta?.content ?? message?.content;
+    if (typeof content === "string") parts.push(content);
+    if (typeof choice.finish_reason === "string") reading.finishReason = choice.finish_reason;
+  }
+  // Present on a non-streamed answer, and on the last chunk of a streamed one
+  // when the caller asked for usage.
+  const usage = isRecord(record.usage) ? record.usage : null;
+  reading.inputTokens = numberOrNull(usage?.prompt_tokens) ?? reading.inputTokens;
+  reading.outputTokens = numberOrNull(usage?.completion_tokens) ?? reading.outputTokens;
+}
+
+/** One chunk of a native answer, from either native route. */
+function readNativeRecord(
+  route: OllamaRoute,
+  record: Record<string, unknown>,
+  reading: ResponseReading,
+  parts: string[],
+): void {
+  if (route === "generate") {
+    if (typeof record.response === "string") parts.push(record.response);
+  } else {
+    const message = isRecord(record.message) ? record.message : null;
+    if (typeof message?.content === "string") parts.push(message.content);
+    const toolCalls = message?.tool_calls;
+    if (Array.isArray(toolCalls) && toolCalls.length > 0) {
+      parts.push(JSON.stringify({ tool_calls: toolCalls }));
+    }
+  }
+  reading.inputTokens = numberOrNull(record.prompt_eval_count) ?? reading.inputTokens;
+  reading.outputTokens = numberOrNull(record.eval_count) ?? reading.outputTokens;
+  if (typeof record.done_reason === "string") reading.finishReason = record.done_reason;
+}
+
+function readResponse(route: OllamaRoute, body: string): ResponseReading {
+  const reading: ResponseReading = {
+    model: null,
+    output: "",
+    inputTokens: null,
+    outputTokens: null,
+    finishReason: null,
+  };
+  const parts: string[] = [];
+
+  for (const record of parseResponseRecords(body)) {
+    if (typeof record.model === "string") reading.model = record.model;
+    if (route === "openai-chat") {
+      readOpenAiRecord(record, reading, parts);
+    } else {
+      readNativeRecord(route, record, reading, parts);
+    }
+  }
+
+  reading.output = truncate(parts.join(""));
+  return reading;
+}
+
+/** Randomly generated OTLP ids; overridable so a test can assert on them. */
+export interface SpanIdGenerator {
+  traceId(): string;
+  spanId(): string;
+}
+
+const defaultIdGenerator: SpanIdGenerator = {
+  traceId: () => randomBytes(16).toString("hex"),
+  spanId: () => randomBytes(8).toString("hex"),
+};
+
+const SPAN_NAME_BY_ROUTE: Record<OllamaRoute, string> = {
+  chat: "ollama.chat",
+  generate: "ollama.generate",
+  "openai-chat": "ollama.chat",
+};
+
+const OPERATION_BY_ROUTE: Record<OllamaRoute, string> = {
+  chat: "chat",
+  generate: "text_completion",
+  "openai-chat": "chat",
+};
+
+/** The attributes describing what was asked and what came back. */
+function spanAttributes(
+  route: OllamaRoute,
+  request: RequestReading,
+  response: ResponseReading,
+  status: number,
+): OtlpAttribute[] {
+  const attributes: OtlpAttribute[] = [
+    stringAttr("langwatch.span.type", "llm"),
+    stringAttr("gen_ai.provider.name", "ollama"),
+    stringAttr("gen_ai.operation.name", OPERATION_BY_ROUTE[route]),
+  ];
+  const responseModel = response.model ?? request.model;
+
+  if (request.input !== null) attributes.push(stringAttr("langwatch.input", request.input));
+  if (response.output !== "") attributes.push(stringAttr("langwatch.output", response.output));
+  if (request.model !== null) attributes.push(stringAttr("gen_ai.request.model", request.model));
+  if (responseModel !== null) attributes.push(stringAttr("gen_ai.response.model", responseModel));
+  if (request.stream !== null) {
+    attributes.push({ key: "gen_ai.request.stream", value: { boolValue: request.stream } });
+  }
+  if (request.temperature !== null) {
+    attributes.push({
+      key: "gen_ai.request.temperature",
+      value: { doubleValue: request.temperature },
+    });
+  }
+  if (response.inputTokens !== null) {
+    attributes.push(intAttr("gen_ai.usage.input_tokens", response.inputTokens));
+  }
+  if (response.outputTokens !== null) {
+    attributes.push(intAttr("gen_ai.usage.output_tokens", response.outputTokens));
+  }
+  if (response.finishReason !== null) {
+    attributes.push(stringAttr("gen_ai.response.finish_reasons", response.finishReason));
+  }
+  if (status >= 400) attributes.push(intAttr("http.response.status_code", status));
+
+  return attributes;
+}
+
+/**
+ * Build the span for one exchange, or null when the exchange said nothing a
+ * span could carry — a request body that was not JSON, or one naming neither
+ * a model nor a prompt. A refused call still produces a span: a failed
+ * generation is a fact about the session, and the status carries the reason.
+ */
+export function buildOllamaSpan(
+  exchange: OllamaExchange,
+  ids: SpanIdGenerator = defaultIdGenerator,
+): OtlpSpan | null {
+  const request = readRequest(exchange.route, exchange.requestBody);
+  const saidNothing = request.input === null && request.model === null;
+  if (saidNothing) return null;
+
+  const response = readResponse(exchange.route, exchange.responseBody);
+  const failed = exchange.status >= 400;
+  const endMs = Math.max(exchange.startedAtMs, exchange.endedAtMs);
+
+  return {
+    traceId: ids.traceId(),
+    spanId: ids.spanId(),
+    name: SPAN_NAME_BY_ROUTE[exchange.route],
+    kind: 1,
+    startTimeUnixNano: `${exchange.startedAtMs}000000`,
+    endTimeUnixNano: `${endMs}000000`,
+    attributes: spanAttributes(exchange.route, request, response, exchange.status),
+    status: failed
+      ? {
+          code: OTLP_STATUS_ERROR,
+          message: exchange.responseBody.trim().slice(0, MAX_STATUS_MESSAGE_CHARS),
+        }
+      : {},
+  };
+}
+
+/**
+ * Wrap spans in the OTLP export envelope. The scope is a `langwatch.*` name
+ * for the same reason the codex harvest uses one: the ingestion side filters
+ * infrastructure spans by scope, and these carry the content.
+ */
+export function buildOllamaExportRequest(spans: OtlpSpan[]): OtlpExportRequest {
+  return {
+    resourceSpans: [
+      {
+        resource: { attributes: [stringAttr("service.name", "ollama")] },
+        scopeSpans: [{ scope: { name: "langwatch.ollama" }, spans }],
+      },
+    ],
+  };
+}

--- a/specs/typescript-sdk/cli-ollama-instrumentation.feature
+++ b/specs/typescript-sdk/cli-ollama-instrumentation.feature
@@ -1,0 +1,141 @@
+@cli @observability
+Feature: Ollama instrumentation through the LangWatch CLI
+  As a developer running models locally with Ollama
+  I want to prefix my ollama command with langwatch
+  So that every prompt, completion and token count from that session lands in LangWatch
+
+  # Ollama exposes no telemetry configuration: there is no environment variable
+  # that makes the server emit OpenTelemetry, and the CLI talks to the server
+  # over HTTP. So the only place a prompt and its completion are both visible is
+  # the wire between them. `langwatch ollama` starts a loopback proxy in front
+  # of the configured Ollama server, points the child's OLLAMA_HOST at it, and
+  # reports what passes through. The proxy is a forwarder first: an unrecognised
+  # request reaches the server byte for byte and its answer reaches the caller
+  # byte for byte, whether or not anything is reported.
+
+  Background:
+    Given the `langwatch` CLI is available
+    And an Ollama server is running at the address OLLAMA_HOST names
+
+  Rule: The session is captured without changing what the user sees
+
+    @integration
+    Scenario: A chat call is reported as one LangWatch call
+      Given a captured session
+      When a chat request is answered by the server
+      Then LangWatch receives one model call
+      And it carries the conversation that was sent and the reply that came back
+      And it names the model, the provider Ollama, and the tokens the server counted
+
+    @integration
+    Scenario: A streamed reply reaches the caller as it arrives
+      Given a captured session
+      When a chat request is answered one chunk at a time
+      Then the caller receives each chunk as the server sends it
+      And the reported reply is the whole assembled answer
+
+    @integration
+    Scenario: A completion call is reported with its prompt and its answer
+      Given a captured session
+      When a completion request is answered by the server
+      Then LangWatch receives one model call carrying that prompt and that answer
+
+    @integration
+    Scenario: A call made through the OpenAI-compatible endpoint is reported the same way
+      Given a captured session
+      When a chat request is sent to the OpenAI-compatible endpoint
+      Then LangWatch receives one model call carrying the conversation and the reply
+
+    @integration
+    Scenario: A request the proxy does not report still reaches the server untouched
+      Given a captured session
+      When the model list is requested
+      Then the server's own answer is returned unchanged
+      And LangWatch receives no model call for it
+
+    @integration
+    Scenario: A server error is returned to the caller and reported as a failed call
+      Given a captured session
+      When the server rejects a chat request
+      Then the caller receives the server's status and body
+      And the reported call is marked failed
+
+    @integration
+    Scenario: A session with no model calls reports nothing
+      Given a captured session
+      When the session ends without any request
+      Then LangWatch receives nothing
+
+  Rule: The wrapped command behaves like the command it wraps
+
+    @unit
+    Scenario: Arguments are forwarded in the order they were written
+      When I run "langwatch ollama run llama3 --verbose"
+      Then `ollama` is started with "run llama3 --verbose"
+
+    @unit
+    Scenario: The exit code is the wrapped command's own
+      Given the wrapped command exits with a failure code
+      Then `langwatch ollama` exits with that same code
+
+    @unit
+    Scenario: A missing ollama binary is reported as a missing install
+      Given `ollama` is not on the PATH
+      When I run "langwatch ollama run llama3"
+      Then the error says ollama is not installed and where to get it
+
+    @unit
+    Scenario: Starting the server through the wrapper is refused
+      When I run "langwatch ollama serve"
+      Then the command is refused before anything starts
+      And the message explains the server would be told to listen on the proxy's own address
+      And it says to run "ollama serve" directly and wrap the commands that talk to it
+
+  Rule: The server the user configured is the server that answers
+
+    @unit
+    Scenario: The proxy forwards to the address OLLAMA_HOST names
+      Given OLLAMA_HOST is "http://127.0.0.1:11434"
+      Then requests are forwarded to that address
+
+    @unit
+    Scenario: An OLLAMA_HOST written without a scheme is understood
+      Given OLLAMA_HOST is "127.0.0.1:11434"
+      Then requests are forwarded to "http://127.0.0.1:11434"
+
+    @unit
+    Scenario: With OLLAMA_HOST unset the default local server is used
+      Given OLLAMA_HOST is not set
+      Then requests are forwarded to "http://127.0.0.1:11434"
+
+    @integration
+    Scenario: An unreachable server is named before the command starts
+      Given no Ollama server is listening at the configured address
+      When I run "langwatch ollama run llama3"
+      Then a warning names the address that did not answer
+      And the command still runs, so ollama reports the failure in its own words
+
+  Rule: Where the calls land follows the scope the device already has
+
+    @unit
+    Scenario: A pinned project key sends the session to that project
+      Given a project ingest key is pinned for ollama
+      Then the calls are reported with that key, to that project's instance
+
+    @unit
+    Scenario: A pasted ingest key in the environment is used as-is
+      Given no project is pinned and LANGWATCH_INGEST_KEY is set
+      Then the calls are reported with that key
+
+    @unit
+    Scenario: Otherwise the signed-in personal workspace receives the session
+      Given no project is pinned and no ingest key is in the environment
+      And the device is signed in
+      Then the calls are reported to the personal workspace
+
+    @unit
+    Scenario: Without a scope the command says what to do and runs anyway
+      Given no project is pinned, no ingest key is in the environment, and the device is not signed in
+      When I run "langwatch ollama run llama3"
+      Then the message says to sign in or pass an ingest key
+      And ollama still runs, uncaptured


### PR DESCRIPTION
## What

`langwatch ollama <args...>` — run any Ollama command with every model call it makes reported to LangWatch.

```bash
langwatch ollama run llama3
✦ langwatch capturing ollama calls to your personal workspace.
…
✦ langwatch reported 4 ollama calls.
```

## Why a proxy, and not the usual wiring

The other wrapped tools take one of two shapes: a base-URL swap onto the gateway (Path A), or an OpenTelemetry environment block the tool reads for itself (Path B). **Ollama offers neither** — there is no variable that makes the server emit OTel, and the `ollama` CLI reaches its server over HTTP. The wire between them is the only place a prompt and its completion are both visible.

So `langwatch ollama` starts a loopback proxy, points the child's `OLLAMA_HOST` at it for that launch only, and reads what passes through. It is a **forwarder first**: every request reaches the server and every answer reaches the caller byte for byte and chunk for chunk, whether or not the exchange is one this build reports. Nothing is written to disk and nothing outlives the command.

## What is captured

| Route | Framings handled |
| --- | --- |
| `/api/chat` | one JSON object, newline-delimited JSON |
| `/api/generate` | one JSON object, newline-delimited JSON |
| `/v1/chat/completions` | one JSON object, Server-Sent Events |

Each becomes one LLM span with `langwatch.input` / `langwatch.output`, `gen_ai.request.model`, `gen_ai.response.model`, provider `ollama`, token counts, finish reason, stream flag and temperature. Everything else — pulls, pushes, the model list, blob uploads — is forwarded unread.

Base64 image data in chat messages is replaced by a size note, and prompts and completions are capped at 128k characters with a truncation marker.

## Scope

Follows what the device already has: a pinned project key, then `LANGWATCH_INGEST_KEY`, then the signed-in personal workspace. **With no scope at all the command says so once and runs ollama anyway** — a developer asking for a model wants the model, and a missing login is not a reason to withhold it.

`ollama serve` is refused by name: it reads the same `OLLAMA_HOST` the wrapper just pointed at the proxy, so the server would try to bind the proxy's address.

## Deliberately not in `SOURCE_TYPE_BY_TOOL`

That table drives `langwatch instrument`, which writes *persistent* OTel wiring. There is no persistent wiring for a tool that reads no OTel environment — listing ollama there would offer a setup command that writes variables ollama ignores. The source type (`ollama`) is defined in the command module instead.

## On the Go SDK

`sdks/go/instrumentation/ollama` already does this extraction, and more completely — embeddings, a generic fallback for unknown `/api/*`, bounded capture off the critical path. It was not reused here because it is an `http.RoundTripper` for a Go *client*, while this is a subcommand of an npm package whose published `files` are `dist` JS only; shipping a Go binary means per-platform optional dependencies plus re-reading the TS CLI's credential store from Go.

**Known convergence point:** if a standalone, long-lived Ollama capture is ever wanted — one any application points at, rather than one wrapped command — it belongs in Go beside the other services and should reuse that package rather than growing a second extractor.

## Tests

`specs/typescript-sdk/cli-ollama-instrumentation.feature`, 19 scenarios, all bound (`check:feature-parity` reports `19/19 scenarios bound`).

- **78 tests pass**, including the two pre-existing suites this touches (`help-footer`, `output-command-tree`).
- The proxy suite drives **real sockets** against a fake Ollama-shaped server — a mocked `http` module cannot show that a streamed token still reaches the caller the moment the server produced it, which is the one property a proxy can quietly break.
- `pnpm typecheck:one langwatch` clean.

## One known lint finding

`ollama-proxy.ts` trips `langwatch/temporal-only` on its `Date.now()` clock default. The rule wants `nowInstant()` from `@langwatch/time`, which is `private: true` and so cannot be a dependency of the published SDK — 89 sibling files under `sdks/typescript` are baselined for exactly this. I did not add a baseline entry, since that ratchet is meant to shrink. Say the word if you'd rather it be baselined.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
