### PR TITLE
fix(governance): keep the pages a refused OpenAI cost pull already read

### DIFF
--- a/platform/app/ee/event-sourcing/pipelines/ingestion-pull-processing/process-manager/ingestionPullEffects.ts
+++ b/platform/app/ee/event-sourcing/pipelines/ingestion-pull-processing/process-manager/ingestionPullEffects.ts
@@ -60,6 +60,12 @@ export interface IngestionPullRunPort {
      * source row, where it reads as unknown rather than as either answer.
      */
     completeness?: "complete" | "truncated";
+    /**
+     * Set when the run banked progress over a page it could not read at all.
+     * Optional for the same reason as the field above, and absent means the
+     * errors were input the run deliberately stepped over.
+     */
+    unreadPage?: true;
     readThroughAt?: number | null;
   }>;
 }
@@ -124,6 +130,7 @@ export interface IngestionPullOutcomeCommands {
     eventCount: number;
     errorCount: number;
     completeness?: "complete" | "truncated";
+    unreadPage?: true;
     readThroughAt?: number | null;
   }): Promise<void>;
   recordRunFailed(args: {

--- a/platform/app/ee/event-sourcing/pipelines/ingestion-pull-processing/projections/__tests__/ingestionPullRunStatus.foldProjection.unit.test.ts
+++ b/platform/app/ee/event-sourcing/pipelines/ingestion-pull-processing/projections/__tests__/ingestionPullRunStatus.foldProjection.unit.test.ts
@@ -518,6 +518,96 @@ describe("IngestionPullRunStatusFoldProjection", () => {
       });
     });
 
+    /**
+     * A completion that kept its progress AND could not read a page at all.
+     *
+     * The adapter banks the pages it already read rather than throwing them
+     * away, so the run ends as a completion -- but a page nobody could read is
+     * the same failure it would have been had it arrived first, and the source
+     * has to show it.
+     */
+    const bankUnreadPage = ({
+      state,
+      scheduledFor,
+      occurredAt,
+    }: {
+      state: IngestionPullRunStatusData;
+      scheduledFor: number;
+      occurredAt: number;
+    }) =>
+      projection.apply(
+        state,
+        event(
+          "lw.obs.ingestion_pull.run_completed",
+          {
+            sourceId: "source-1",
+            runId: String(scheduledFor),
+            scheduledFor,
+            nextCursor: `cursor-${scheduledFor}`,
+            eventCount: 3,
+            errorCount: 1,
+            completeness: "truncated",
+            unreadPage: true,
+          },
+          occurredAt,
+        ),
+      );
+
+    describe("when a completed run could not read one of its pages", () => {
+      /** @scenario "A refusal part-way through a window still counts against the source" */
+      it("counts the run as a failure while keeping its progress", () => {
+        const banked = bankUnreadPage({
+          state: configured,
+          scheduledFor: 1_000,
+          occurredAt: 1_100,
+        });
+
+        expect(banked.ConsecutiveErrors).toBe(1);
+        expect(banked.LastSuccessAt).toBeNull();
+        // The progress is the whole reason the run completed rather than
+        // failed, so counting the failure must not cost the advance.
+        expect(banked.Cursor).toBe("cursor-1000");
+      });
+    });
+
+    describe("when every run in a row banks progress over an unread page", () => {
+      /** @scenario "A source refused part-way through every run reads as failing" */
+      it("reads as unhealthy after three of them", () => {
+        let state = configured;
+        for (const scheduledFor of [1_000, 2_000, 3_000]) {
+          state = bankUnreadPage({
+            state,
+            scheduledFor,
+            occurredAt: scheduledFor + 100,
+          });
+        }
+
+        expect(state.ConsecutiveErrors).toBe(3);
+        expect(
+          deriveSourceHealth({ consecutiveFailures: state.ConsecutiveErrors }),
+        ).toBe("unhealthy");
+      });
+    });
+
+    describe("when a clean run follows one that banked an unread page", () => {
+      it("clears the count the banked run raised", () => {
+        const banked = bankUnreadPage({
+          state: configured,
+          scheduledFor: 1_000,
+          occurredAt: 1_100,
+        });
+
+        const recovered = succeed({
+          state: banked,
+          scheduledFor: 2_000,
+          occurredAt: 2_100,
+        });
+
+        expect(recovered.ConsecutiveErrors).toBe(0);
+        expect(recovered.LastSuccessAt).toBe(2_100);
+      });
+    });
+
     describe("when a completion predates runs reporting an error count", () => {
       it("folds as the clean run it was", () => {
         // succeed() writes the pre-change event shape -- no errorCount key at

--- a/platform/app/ee/event-sourcing/pipelines/ingestion-pull-processing/projections/ingestionPullRunStatus.foldProjection.ts
+++ b/platform/app/ee/event-sourcing/pipelines/ingestion-pull-processing/projections/ingestionPullRunStatus.foldProjection.ts
@@ -210,6 +210,39 @@ function readThroughOf(event: IngestionPullRunCompletedEvent): {
   };
 }
 
+/**
+ * The failure count a completion leaves behind, in its three shapes.
+ *
+ * A clean run clears it: reaching the provider and being answered is the proof
+ * the source works, including when the answer is "no usage".
+ *
+ * A run that delivered something but also stepped over input it could not read
+ * neither clears it nor adds to it, and stamps no success. Counting that as a
+ * success wrote a fresh one over exactly the signals meant to be loud; counting
+ * it as a failure would turn a source working around one bad row red.
+ *
+ * A run that could not read a PAGE adds to it, even though it completed. That
+ * is the difference between working around input and not reading the window at
+ * all. Holding the count still here let a source refused part-way through every
+ * run sit at zero failures forever: it never reached the threshold that shows
+ * pulls as failing, showed the amber partly-collected line instead, and
+ * collected a fraction of its spend every hour while reading as healthy. The
+ * progress it banked is kept either way — the cursor advances above, and it is
+ * only the source's health this answers.
+ */
+function consecutiveErrorsAfterCompletion({
+  previous,
+  partlySucceeded,
+  pageUnread,
+}: {
+  previous: number;
+  partlySucceeded: boolean;
+  pageUnread: boolean;
+}): number {
+  if (pageUnread) return previous + 1;
+  return partlySucceeded ? previous : 0;
+}
+
 export class IngestionPullRunStatusFoldProjection
   extends AbstractFoldProjection<
     IngestionPullRunStatusData,
@@ -353,10 +386,15 @@ export class IngestionPullRunStatusFoldProjection
   ): IngestionPullRunStatusData {
     if (this.isSuperseded({ state, scheduledFor: event.data.scheduledFor }))
       return state;
+    // A page this run could not read AT ALL, as opposed to rows it read and
+    // stepped over. The adapter banks the pages it already had rather than
+    // throwing them away, so this failure arrives on a COMPLETION -- and it is
+    // still the failure it would have been had it arrived on the first page.
+    const pageUnread = event.data.unreadPage === true;
     // Absent on every completion written before runs reported an error count,
     // and reading that as a clean run is correct: those producers failed the
     // whole run rather than returning partial progress.
-    const partlySucceeded = (event.data.errorCount ?? 0) > 0;
+    const partlySucceeded = (event.data.errorCount ?? 0) > 0 || pageUnread;
     return {
       ...state,
       SourceId: event.data.sourceId,
@@ -366,13 +404,11 @@ export class IngestionPullRunStatusFoldProjection
       LastRunEventCount: event.data.eventCount,
       LastRunError: null,
       LastRunErrorCode: null,
-      // A run that delivered something but also stepped over rows it could not
-      // read, or refused a next-page link, is not the clean run that proves the
-      // source works -- so it neither clears the failure count nor adds to it,
-      // and it stamps no success. Counting it as one wrote a fresh success over
-      // exactly the signals that were meant to be loud, and a source could
-      // launder itself healthy forever while never reading a whole page.
-      ConsecutiveErrors: partlySucceeded ? state.ConsecutiveErrors : 0,
+      ConsecutiveErrors: consecutiveErrorsAfterCompletion({
+        previous: state.ConsecutiveErrors,
+        partlySucceeded,
+        pageUnread,
+      }),
       LastRunScheduledFor: event.data.scheduledFor,
       // Stamped on every clean completion, including one that found nothing
       // new: reaching the provider and being told "no usage" is a working

--- a/platform/app/ee/event-sourcing/pipelines/ingestion-pull-processing/projections/ingestionPullRunStatus.foldProjection.ts
+++ b/platform/app/ee/event-sourcing/pipelines/ingestion-pull-processing/projections/ingestionPullRunStatus.foldProjection.ts
@@ -232,15 +232,15 @@ function readThroughOf(event: IngestionPullRunCompletedEvent): {
  */
 function consecutiveErrorsAfterCompletion({
   previous,
-  partlySucceeded,
-  pageUnread,
+  hasPartialSuccess,
+  hasUnreadPage,
 }: {
   previous: number;
-  partlySucceeded: boolean;
-  pageUnread: boolean;
+  hasPartialSuccess: boolean;
+  hasUnreadPage: boolean;
 }): number {
-  if (pageUnread) return previous + 1;
-  return partlySucceeded ? previous : 0;
+  if (hasUnreadPage) return previous + 1;
+  return hasPartialSuccess ? previous : 0;
 }
 
 export class IngestionPullRunStatusFoldProjection
@@ -390,11 +390,11 @@ export class IngestionPullRunStatusFoldProjection
     // stepped over. The adapter banks the pages it already had rather than
     // throwing them away, so this failure arrives on a COMPLETION -- and it is
     // still the failure it would have been had it arrived on the first page.
-    const pageUnread = event.data.unreadPage === true;
+    const hasUnreadPage = event.data.unreadPage === true;
     // Absent on every completion written before runs reported an error count,
     // and reading that as a clean run is correct: those producers failed the
     // whole run rather than returning partial progress.
-    const partlySucceeded = (event.data.errorCount ?? 0) > 0 || pageUnread;
+    const hasPartialSuccess = (event.data.errorCount ?? 0) > 0 || hasUnreadPage;
     return {
       ...state,
       SourceId: event.data.sourceId,
@@ -406,14 +406,14 @@ export class IngestionPullRunStatusFoldProjection
       LastRunErrorCode: null,
       ConsecutiveErrors: consecutiveErrorsAfterCompletion({
         previous: state.ConsecutiveErrors,
-        partlySucceeded,
-        pageUnread,
+        hasPartialSuccess,
+        hasUnreadPage,
       }),
       LastRunScheduledFor: event.data.scheduledFor,
       // Stamped on every clean completion, including one that found nothing
       // new: reaching the provider and being told "no usage" is a working
       // puller.
-      LastSuccessAt: partlySucceeded ? state.LastSuccessAt : event.occurredAt,
+      LastSuccessAt: hasPartialSuccess ? state.LastSuccessAt : event.occurredAt,
       ...readThroughOf(event),
     };
   }

--- a/platform/app/ee/event-sourcing/pipelines/ingestion-pull-processing/schemas/events.ts
+++ b/platform/app/ee/event-sourcing/pipelines/ingestion-pull-processing/schemas/events.ts
@@ -108,6 +108,25 @@ export const ingestionPullRunCompletedEventDataSchema = sourceEnvelope.extend({
    */
   completeness: z.enum(["complete", "truncated"]).optional(),
   /**
+   * Whether this run's `errorCount` includes a page it could not read AT ALL,
+   * as opposed to rows it read and stepped over.
+   *
+   * The two are the same number and opposite news. Skipped input is a run that
+   * did its job around a bad row, so the failure count holds still. A page
+   * nobody could read is a failure that happens to arrive on a completion,
+   * because the adapter banked the pages it had already read rather than
+   * throwing them away — and without this field the fold cannot tell them
+   * apart, so a source refused part-way through every run sits at zero
+   * failures forever, never turns red, and collects a fraction of its spend
+   * every hour with nothing to say so.
+   *
+   * Optional, like the two fields above and for the same reason: the fold
+   * reads events straight off the log, and no completion written before this
+   * existed has the key. Absent means skipped input, which is what every
+   * producer before this meant.
+   */
+  unreadPage: z.boolean().optional(),
+  /**
    * The instant the source is known to have been read up to, epoch ms.
    *
    * Deliberately NOT the instant the run finished. The run clock advances on

--- a/platform/app/ee/governance/services/pullers/__tests__/openaiAdminPuller.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/openaiAdminPuller.unit.test.ts
@@ -201,6 +201,74 @@ describe("given an OpenAI Admin cost source", () => {
     });
   });
 
+  describe("when a page is refused part-way through a window", () => {
+    /**
+     * The pages already read are worth more than the provider's Retry-After.
+     *
+     * A refusal used to throw straight out of the run, so the events from
+     * every page before it were dropped and the durable cursor never moved.
+     * The next run asked for page one of the same window, was refused at the
+     * same page again, and a source that met a rate limit mid-backfill could
+     * never get past it on any number of retries.
+     */
+    it("keeps the pages already read and resumes at the refused page", async () => {
+      fetchMock
+        .mockResolvedValueOnce(
+          jsonResponse(page({ nextPage: "page_2", hasMore: true })),
+        )
+        .mockResolvedValueOnce(
+          new Response("private upstream payload", {
+            status: 429,
+            headers: { "retry-after": "120" },
+          }),
+        );
+
+      const result = await new OpenAiAdminPuller().runOnce(RUN_OPTIONS, CONFIG);
+
+      expect(result.events).toHaveLength(1);
+      expect(result.errorCount).toBe(1);
+      expect(result.completeness).toBe("truncated");
+      expect(result.cursor).not.toBeNull();
+      expect(JSON.parse(result.cursor!)).toMatchObject({ page: "page_2" });
+    });
+
+    /** The same for a page lost to the transport rather than to a refusal. */
+    it("keeps the pages already read when a later page fails on the transport", async () => {
+      fetchMock
+        .mockResolvedValueOnce(
+          jsonResponse(page({ nextPage: "page_2", hasMore: true })),
+        )
+        .mockRejectedValueOnce(new Error("socket hang up"));
+
+      const result = await new OpenAiAdminPuller().runOnce(RUN_OPTIONS, CONFIG);
+
+      expect(result.events).toHaveLength(1);
+      expect(result.errorCount).toBe(1);
+      expect(result.completeness).toBe("truncated");
+      expect(result.cursor).not.toBeNull();
+      expect(JSON.parse(result.cursor!)).toMatchObject({ page: "page_2" });
+    });
+
+    /**
+     * A refusal on the FIRST page of a run is a different thing. Nothing was
+     * read, so there is no progress to bank, and the wait the provider asked
+     * for is the most valuable thing the run has: it must still reach the
+     * scheduler rather than be swallowed into an error count.
+     */
+    it("still surrenders the rate-limit wait when the first page is refused", async () => {
+      fetchMock.mockResolvedValue(
+        new Response("private upstream payload", {
+          status: 429,
+          headers: { "retry-after": "120" },
+        }),
+      );
+
+      await expect(
+        new OpenAiAdminPuller().runOnce(RUN_OPTIONS, CONFIG),
+      ).rejects.toMatchObject({ retryAfterMs: 120_000 });
+    });
+  });
+
   describe("when the provider reports a day's spend", () => {
     /** @scenario "A day's spend is recorded as the dollars the provider reported" */
     it("records the provider's dollars without converting them", async () => {

--- a/platform/app/ee/governance/services/pullers/__tests__/openaiAdminPuller.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/openaiAdminPuller.unit.test.ts
@@ -211,6 +211,7 @@ describe("given an OpenAI Admin cost source", () => {
      * same page again, and a source that met a rate limit mid-backfill could
      * never get past it on any number of retries.
      */
+    /** @scenario "A page that cannot be read part-way through a window keeps the ones already read" */
     it("keeps the pages already read and resumes at the refused page", async () => {
       fetchMock
         .mockResolvedValueOnce(
@@ -232,7 +233,33 @@ describe("given an OpenAI Admin cost source", () => {
       expect(JSON.parse(result.cursor!)).toMatchObject({ page: "page_2" });
     });
 
+    /**
+     * Keeping the progress must not also make the source look well. The run
+     * completes, so nothing in the failure count moves on its own -- a source
+     * refused part-way through every run would sit at zero failures forever,
+     * never reach the threshold that shows pulls as failing, and quietly
+     * collect a fraction of its spend every hour.
+     */
+    /** @scenario "A refusal part-way through a window still counts against the source" */
+    it("reports the unread page so the source can still show the failure", async () => {
+      fetchMock
+        .mockResolvedValueOnce(
+          jsonResponse(page({ nextPage: "page_2", hasMore: true })),
+        )
+        .mockResolvedValueOnce(
+          new Response("private upstream payload", {
+            status: 429,
+            headers: { "retry-after": "120" },
+          }),
+        );
+
+      const result = await new OpenAiAdminPuller().runOnce(RUN_OPTIONS, CONFIG);
+
+      expect(result.unreadPage).toBe(true);
+    });
+
     /** The same for a page lost to the transport rather than to a refusal. */
+    /** @scenario "A page that cannot be read part-way through a window keeps the ones already read" */
     it("keeps the pages already read when a later page fails on the transport", async () => {
       fetchMock
         .mockResolvedValueOnce(
@@ -255,6 +282,7 @@ describe("given an OpenAI Admin cost source", () => {
      * for is the most valuable thing the run has: it must still reach the
      * scheduler rather than be swallowed into an error count.
      */
+    /** @scenario "A failed read leaves the source where it was" */
     it("still surrenders the rate-limit wait when the first page is refused", async () => {
       fetchMock.mockResolvedValue(
         new Response("private upstream payload", {
@@ -266,6 +294,75 @@ describe("given an OpenAI Admin cost source", () => {
       await expect(
         new OpenAiAdminPuller().runOnce(RUN_OPTIONS, CONFIG),
       ).rejects.toMatchObject({ retryAfterMs: 120_000 });
+    });
+  });
+
+  describe("when the provider refuses the key part-way through a window", () => {
+    /**
+     * A refused key answers the same way on every page, so there is no window
+     * to resume: banking the pages already read would record the run as a
+     * completion, leave the source looking healthy, and hide the one failure an
+     * admin can actually act on. The sibling adapter for another provider
+     * classifies these two statuses the same way.
+     */
+    /** @scenario "A refused key fails the run rather than banking part of a window" */
+    it("fails the run rather than keeping what it read", async () => {
+      fetchMock
+        .mockResolvedValueOnce(
+          jsonResponse(page({ nextPage: "page_2", hasMore: true })),
+        )
+        .mockResolvedValueOnce(
+          new Response("private upstream payload", { status: 401 }),
+        );
+
+      await expect(
+        new OpenAiAdminPuller().runOnce(RUN_OPTIONS, CONFIG),
+      ).rejects.toMatchObject({
+        retryable: false,
+        customerMessage:
+          "OpenAI refused this key. Check the admin key and its permissions.",
+      });
+    });
+
+    /** @scenario "A refused key fails the run rather than banking part of a window" */
+    it("does not quote the provider's reply back to the customer", async () => {
+      fetchMock.mockResolvedValue(
+        new Response("private upstream payload", { status: 403 }),
+      );
+
+      await expect(
+        new OpenAiAdminPuller().runOnce(RUN_OPTIONS, CONFIG),
+      ).rejects.toMatchObject({
+        retryable: false,
+        message: expect.not.stringContaining("private upstream payload"),
+      });
+    });
+  });
+
+  describe("when the provider faults part-way through a window", () => {
+    /**
+     * A 5xx is the provider having a bad minute rather than an answer about
+     * this source, so it is treated like the transport failure it resembles:
+     * the pages already read are banked and the run resumes at the one that
+     * faulted. It carries no wait of the provider's own, so there is nothing a
+     * dispatch error could hold here that a plain one cannot.
+     */
+    /** @scenario "A page that cannot be read part-way through a window keeps the ones already read" */
+    it("keeps the pages already read and resumes at the faulted page", async () => {
+      fetchMock
+        .mockResolvedValueOnce(
+          jsonResponse(page({ nextPage: "page_2", hasMore: true })),
+        )
+        .mockResolvedValueOnce(
+          new Response("upstream unavailable", { status: 503 }),
+        );
+
+      const result = await new OpenAiAdminPuller().runOnce(RUN_OPTIONS, CONFIG);
+
+      expect(result.errorCount).toBe(1);
+      expect(result.completeness).toBe("truncated");
+      expect(result.unreadPage).toBe(true);
+      expect(JSON.parse(result.cursor!)).toMatchObject({ page: "page_2" });
     });
   });
 
@@ -1003,17 +1100,20 @@ describe("given an OpenAI Admin cost source", () => {
         }),
       );
 
-      const result = await new OpenAiAdminPuller().runOnce(RUN_OPTIONS, CONFIG);
-
-      expect(result.errorCount).toBe(1);
-      // The reason is logged and shown on the source, so it is read by people
-      // who were never given the credential.
-      expect(logged.error).toHaveBeenCalled();
-      for (const call of logged.error.mock.calls) {
-        expect(JSON.stringify(call)).not.toContain(
-          RUN_OPTIONS.credentials.token,
-        );
-      }
+      // A refused key leaves as a refusal rather than an error count: the same
+      // answer arrives on every page, so there is no window to resume and
+      // nothing to gain by keeping part of one.
+      await expect(
+        new OpenAiAdminPuller().runOnce(RUN_OPTIONS, CONFIG),
+      ).rejects.toMatchObject({
+        retryable: false,
+        // The reason is logged and shown on the source, so it is read by people
+        // who were never given the credential -- and the provider's own reply
+        // echoes a fragment of the key, so the body is drained and never
+        // quoted. "sk-a" is the opening of both the real key and that echo.
+        message: expect.not.stringContaining("sk-a"),
+        customerMessage: expect.not.stringContaining("sk-a"),
+      });
     });
 
     it("fails a run with no admin key rather than reporting an empty organization", async () => {

--- a/platform/app/ee/governance/services/pullers/__tests__/openaiAdminPuller.unit.test.ts
+++ b/platform/app/ee/governance/services/pullers/__tests__/openaiAdminPuller.unit.test.ts
@@ -364,6 +364,35 @@ describe("given an OpenAI Admin cost source", () => {
       expect(result.unreadPage).toBe(true);
       expect(JSON.parse(result.cursor!)).toMatchObject({ page: "page_2" });
     });
+
+    /**
+     * A rejected request is not a bad minute: the same request earns the same
+     * rejection on every retry, so resuming AT the rejected page would park the
+     * position on a page nothing will ever read past. The pages already read
+     * still come back -- they are restated on the next run, which re-asks for
+     * the same window -- but the position does not move onto the rejection.
+     */
+    /** @scenario "A request the provider rejects outright is not banked part-way" */
+    it("holds the position when a later page is rejected as a bad request", async () => {
+      fetchMock
+        .mockResolvedValueOnce(
+          jsonResponse(page({ nextPage: "page_2", hasMore: true })),
+        )
+        .mockResolvedValueOnce(
+          errorResponse({
+            status: 400,
+            param: null,
+            code: "invalid_request_error",
+            message: "Unknown parameter: 'group_by[]'.",
+          }),
+        );
+
+      const result = await new OpenAiAdminPuller().runOnce(RUN_OPTIONS, CONFIG);
+
+      expect(result.errorCount).toBe(1);
+      expect(result.cursor).toBe(RUN_OPTIONS.cursor);
+      expect(result.unreadPage).toBeUndefined();
+    });
   });
 
   describe("when the provider reports a day's spend", () => {

--- a/platform/app/ee/governance/services/pullers/openaiAdmin.puller.ts
+++ b/platform/app/ee/governance/services/pullers/openaiAdmin.puller.ts
@@ -510,6 +510,48 @@ function reportUrl({
 }
 
 /**
+ * The error a provider's refusal carries, or null when the status is not one.
+ *
+ * Two refusals, and the difference between them is the whole of what the caller
+ * does next. A rate limit is the provider asking for time: retryable, and it
+ * carries the wait it asked for. A refused key is the provider answering about
+ * this source: the same answer on every page and every retry, so it is NOT
+ * retryable — which is what stops the ladder and keeps a run from banking half
+ * a window it will never be allowed to finish.
+ *
+ * The body is drained best-effort and never read. A rejected `cancel()` must
+ * not escape in place of the error built here, or the refusal degrades to a
+ * generic failure and the wait never reaches the scheduler; and a refusal from
+ * this endpoint can echo a fragment of the key, so nothing it says is quoted.
+ */
+async function providerRefusal(response: {
+  status: number;
+  headers: { get(name: string): string | null };
+  body?: { cancel(): Promise<unknown> } | null;
+}): Promise<DispatchError | null> {
+  if (
+    response.status !== 429 &&
+    response.status !== 401 &&
+    response.status !== 403
+  )
+    return null;
+  await response.body?.cancel().catch(() => void 0);
+  if (response.status === 429) {
+    return new DispatchError({
+      message: "OpenAI rate limit exceeded (HTTP 429).",
+      retryable: true,
+      retryAfterMs: parseRetryAfterMs(response.headers.get("retry-after")),
+    });
+  }
+  return new DispatchError({
+    message: `HTTP ${response.status} (openai cost report): key refused`,
+    retryable: false,
+    customerMessage:
+      "OpenAI refused this key. Check the admin key and its permissions.",
+  });
+}
+
+/**
  * Whether a page refused mid-run should be ANSWERED with the progress already
  * made, rather than thrown out of the run.
  *
@@ -524,9 +566,20 @@ function reportUrl({
  * the pipeline already handles; a window that can never be read past is not
  * recoverable at all.
  *
- * Only a RETRYABLE refusal qualifies. A malformed body, a contract that moved
- * and a provider refusing outright are not windows to retry: each still throws,
- * so the run is recorded as the failure it is.
+ * A NON-RETRYABLE refusal never qualifies. A key the provider refuses (HTTP 401
+ * or 403) answers the same way on every page, so there is no window to resume
+ * and nothing to gain by keeping part of one: it still throws, and the run is
+ * recorded as the refusal it is. A malformed body throws from the parse below
+ * for the same reason — a shape we do not recognise is a contract that moved.
+ *
+ * Everything else with pages in hand banks: a rate limit, a dropped socket, a
+ * provider having a bad minute (5xx). Each is transient and carries no answer
+ * about this source, so the pages already read are worth more than starting the
+ * window over.
+ *
+ * Banking is never the same as succeeding. The result carries `unreadPage`, so
+ * the run status counts the failure while keeping the progress — without it a
+ * source refused on every run would read as healthy forever.
  */
 function mustBankRefusal({
   error,
@@ -581,7 +634,8 @@ function pageUnread({
   stoppedShort: () => PullResult;
   incomingCursor: string | null;
 }): PullResult {
-  if (banked) return { ...stoppedShort(), errorCount: 1 };
+  if (banked)
+    return { ...stoppedShort(), errorCount: 1, unreadPage: true as const };
   return { events, cursor: incomingCursor, errorCount: 1 };
 }
 
@@ -885,17 +939,12 @@ export class OpenAiAdminPuller implements PullerAdapter<OpenAiAdminPullConfig> {
       },
       signal,
     });
-    if (response.status === 429) {
-      // Best-effort drain, for the reason spelled out in the Anthropic
-      // puller's matching branch: a rejected cancel must not replace the
-      // DispatchError, or the Retry-After never reaches the scheduler.
-      await response.body?.cancel().catch(() => void 0);
-      throw new DispatchError({
-        message: "OpenAI rate limit exceeded (HTTP 429).",
-        retryable: true,
-        retryAfterMs: parseRetryAfterMs(response.headers.get("retry-after")),
-      });
-    }
+    // A rate limit or a refused key, classified the way the Anthropic puller
+    // classifies the same two statuses. Both leave as a DispatchError so the
+    // caller can tell a window worth resuming from a key that will never be
+    // allowed to finish one.
+    const refusal = await providerRefusal(response);
+    if (refusal) throw refusal;
     if (!response.ok) {
       const detail = await safeResponseText(response);
       if (response.status === 400 && isKeyGroupingRefusal(detail)) {

--- a/platform/app/ee/governance/services/pullers/openaiAdmin.puller.ts
+++ b/platform/app/ee/governance/services/pullers/openaiAdmin.puller.ts
@@ -552,6 +552,39 @@ async function providerRefusal(response: {
 }
 
 /**
+ * A non-OK response that is not one of the refusals `providerRefusal` names,
+ * carrying the status so the banking rule can tell an answer about the request
+ * from a provider having a bad minute.
+ *
+ * The status is what a plain `Error` lost. Reconstructing it from the message
+ * would be reading our own prose back, so it rides the error instead.
+ */
+class UnexpectedStatusError extends Error {
+  readonly status: number;
+
+  constructor({ status, message }: { status: number; message: string }) {
+    super(message);
+    this.name = "UnexpectedStatusError";
+    this.status = status;
+  }
+}
+
+/**
+ * Whether a status is the provider answering about THIS REQUEST rather than
+ * about the minute it is having.
+ *
+ * A 4xx is an answer: the same request earns the same answer on every page and
+ * every retry, so there is no window to resume. 408 and 425 ask to be sent
+ * again, which makes them bad minutes like a 5xx. 429, 401 and 403 never reach
+ * here — `providerRefusal` names them first, because a rate limit carries a wait
+ * worth keeping.
+ */
+function isRequestRefused(status: number): boolean {
+  if (status === 408 || status === 425) return false;
+  return status >= 400 && status < 500;
+}
+
+/**
  * Whether a page refused mid-run should be ANSWERED with the progress already
  * made, rather than thrown out of the run.
  *
@@ -577,17 +610,21 @@ async function providerRefusal(response: {
  * about this source, so the pages already read are worth more than starting the
  * window over.
  *
- * One thing banks here that is NOT transient. A 4xx this adapter does not
- * classify — a 400 that is not the key-breakdown cutoff, a 404, a 422 — leaves
- * `fetchPage` as a plain error on the same line a 5xx does, so pages in hand
- * bank it too. That keeps pages the old code threw away, so it is not a
- * regression, but the window still never completes: the next run starts AT the
- * refused page, reads nothing, and reports the failure with the cursor held,
- * which HOLDS the consecutive count rather than raising it. A source wedged
- * that way reads as partly collected rather than failing. Pinning those
- * statuses as refusals would overturn the cases already fixing a
- * differently-shaped 400 to a counted failure rather than a throw, so it is a
- * change of its own.
+ * A 4xx this adapter does not classify by name — a 400 that is not the
+ * key-breakdown cutoff, a 404, a 422 — is an answer about the REQUEST, so it is
+ * not banked either. It reaches here as an `UnexpectedStatusError` carrying the
+ * status, because a plain error told the rule only that it was not a
+ * `DispatchError` and a 404 then banked as readily as a 503: the cursor advanced
+ * onto a page nothing will ever read past. 408 and 425 are the two 4xx that ask
+ * to be sent again, so they count as bad minutes rather than answers.
+ *
+ * Refusing to bank is NOT the same as failing the run here. What is thrown is
+ * unchanged, so a rejected request still ends the run the way it always did —
+ * the events read so far, the cursor where it was, the failure reported — and
+ * the next run asks for the same window rather than for a page it cannot get
+ * past. Turning these into non-retryable dispatch errors instead would
+ * dead-letter them and would overturn the two cases covering a
+ * differently-shaped 400 on the first page.
  *
  * Banking is never the same as succeeding. The result carries `unreadPage`, so
  * the run status counts the failure while keeping the progress — without it a
@@ -603,7 +640,10 @@ function mustBankRefusal({
   if (pageCount === 0) return false;
   // A provider refusing outright is not a window to retry. Let that one travel,
   // so the run is recorded as the refusal it is.
-  return !(error instanceof DispatchError) || error.retryable;
+  if (error instanceof DispatchError) return error.retryable;
+  if (error instanceof UnexpectedStatusError)
+    return !isRequestRefused(error.status);
+  return true;
 }
 
 /**
@@ -966,9 +1006,10 @@ export class OpenAiAdminPuller implements PullerAdapter<OpenAiAdminPullConfig> {
       }
       // The body can echo the request but never the credential — the key rides
       // in a header the provider does not reflect.
-      throw new Error(
-        `HTTP ${response.status} (openai cost report)${detail ? `: ${detail}` : ""}`,
-      );
+      throw new UnexpectedStatusError({
+        status: response.status,
+        message: `HTTP ${response.status} (openai cost report)${detail ? `: ${detail}` : ""}`,
+      });
     }
     return { ok: true, body: await response.json() };
   }

--- a/platform/app/ee/governance/services/pullers/openaiAdmin.puller.ts
+++ b/platform/app/ee/governance/services/pullers/openaiAdmin.puller.ts
@@ -509,6 +509,109 @@ function reportUrl({
   return url;
 }
 
+/**
+ * Whether a page refused mid-run should be ANSWERED with the progress already
+ * made, rather than thrown out of the run.
+ *
+ * A provider asking to be left alone (HTTP 429) arrives as a throw so the
+ * durable outbox keeps its `Retry-After`. On the FIRST page of a run that wait
+ * is the most valuable thing the run has and there is no progress to lose, so
+ * it keeps travelling. Once earlier pages have been read the trade inverts:
+ * holding the cursor still ended the run with no forward progress at all, so
+ * the next run asked for page one of the same window, was refused at the same
+ * page again, and a source that met a rate limit mid-backfill could never get
+ * past it on any number of retries. Buckets banked twice are restated, which
+ * the pipeline already handles; a window that can never be read past is not
+ * recoverable at all.
+ *
+ * Only a RETRYABLE refusal qualifies. A malformed body, a contract that moved
+ * and a provider refusing outright are not windows to retry: each still throws,
+ * so the run is recorded as the failure it is.
+ */
+function mustBankRefusal({
+  error,
+  pageCount,
+}: {
+  error: unknown;
+  pageCount: number;
+}): boolean {
+  if (pageCount === 0) return false;
+  // A provider refusing outright is not a window to retry. Let that one travel,
+  // so the run is recorded as the refusal it is.
+  return !(error instanceof DispatchError) || error.retryable;
+}
+
+/**
+ * One page, read or refused. `banked` says whether the refusal arrived with
+ * earlier pages of the same run already read — see `mustBankRefusal`.
+ */
+type PageRead =
+  | {
+      ok: true;
+      events: NormalizedPullEvent[];
+      nextPage: string | null;
+      watermark: string | null;
+      hasKeyGrouping: boolean;
+    }
+  | { ok: false; banked: boolean };
+
+/**
+ * What a run returns when a page could not be read.
+ *
+ * With earlier pages banked it returns what a run stopped short by the deadline
+ * returns — the events read so far, and a cursor resuming at the page still
+ * owed — with the refusal counted. `errorCount: 1` beside an ADVANCED cursor is
+ * what the worker reads as a partial success: the events are written, the
+ * cursor is persisted, and it says so loudly (`assertRunMadeProgress`).
+ *
+ * With nothing banked the INCOMING cursor comes back unchanged, which is what
+ * fails the run so the outbox retries the same window. Returning it in BOTH
+ * cases was the bug: a refusal on page three ended every run with no forward
+ * progress at all, so the next run asked for page one again and was refused at
+ * page three again, for as long as the window needed more than one page.
+ */
+function pageUnread({
+  banked,
+  events,
+  stoppedShort,
+  incomingCursor,
+}: {
+  banked: boolean;
+  events: NormalizedPullEvent[];
+  stoppedShort: () => PullResult;
+  incomingCursor: string | null;
+}): PullResult {
+  if (banked) return { ...stoppedShort(), errorCount: 1 };
+  return { events, cursor: incomingCursor, errorCount: 1 };
+}
+
+/**
+ * The line a page nobody could read leaves behind, which says what it cost: a
+ * window held for a retry, or a window banked up to the page that failed.
+ */
+function logPageUnread({
+  adapter,
+  pageCount,
+  banked,
+  error,
+}: {
+  adapter: string;
+  pageCount: number;
+  banked: boolean;
+  error: unknown;
+}): void {
+  logger.error(
+    {
+      adapter,
+      pageCount,
+      error: error instanceof Error ? error.message : String(error),
+    },
+    banked
+      ? "openai admin page refused mid-window; keeping the pages already read and resuming at the refused one"
+      : "openai admin fetch failed; leaving the cursor where it was",
+  );
+}
+
 export class OpenAiAdminPuller implements PullerAdapter<OpenAiAdminPullConfig> {
   readonly id: string = OPENAI_ADMIN_ADAPTER_ID;
 
@@ -584,11 +687,18 @@ export class OpenAiAdminPuller implements PullerAdapter<OpenAiAdminPullConfig> {
         page,
         hasKeyGrouping,
         options,
+        pageCount,
       });
       if (!read.ok) {
-        // The unadvanced cursor is what makes the window get retried instead
-        // of skipped. Never return a partial window as if it were complete.
-        return { events, cursor: options.cursor, errorCount: 1 };
+        // Resumes AT the page that failed when this run read any, and holds the
+        // window for a retry when it read none. Never returns a partial window
+        // as if it were complete.
+        return pageUnread({
+          banked: read.banked,
+          events,
+          stoppedShort,
+          incomingCursor: options.cursor,
+        });
       }
       events.push(...read.events);
       if (!read.hasKeyGrouping) hasLostKeyAttribution = true;
@@ -625,30 +735,25 @@ export class OpenAiAdminPuller implements PullerAdapter<OpenAiAdminPullConfig> {
    * One page: fetched, parsed, and mapped to events.
    *
    * A transport failure is a returned `ok: false` rather than a throw, because
-   * the caller has to answer it by holding the cursor still. A malformed
-   * response still throws: a shape we do not recognise is not a window to
-   * retry, it is a contract that moved.
+   * the caller has to answer it by deciding what the window is worth — which is
+   * why the failure carries `banked`. A malformed response still throws: a
+   * shape we do not recognise is not a window to retry, it is a contract that
+   * moved.
    */
   private async readPage({
     startingAt,
     page,
     hasKeyGrouping,
     options,
+    pageCount,
   }: {
     startingAt: string;
     page: string | null;
     hasKeyGrouping: boolean;
     options: PullRunOptions;
-  }): Promise<
-    | {
-        ok: true;
-        events: NormalizedPullEvent[];
-        nextPage: string | null;
-        watermark: string | null;
-        hasKeyGrouping: boolean;
-      }
-    | { ok: false }
-  > {
+    /** Pages this run has already read. Decides what a refusal costs. */
+    pageCount: number;
+  }): Promise<PageRead> {
     let fetched: { body: unknown; hasKeyGrouping: boolean } | null;
     try {
       fetched = await this.fetchWithKeyGroupingFallback({
@@ -658,18 +763,14 @@ export class OpenAiAdminPuller implements PullerAdapter<OpenAiAdminPullConfig> {
         options,
       });
     } catch (error) {
-      // Let the durable outbox retain Retry-After instead of losing it in errorCount.
-      if (error instanceof DispatchError) throw error;
-      logger.error(
-        {
-          adapter: this.id,
-          error: error instanceof Error ? error.message : String(error),
-        },
-        "openai admin fetch failed; leaving the cursor where it was",
-      );
-      return { ok: false };
+      const banked = mustBankRefusal({ error, pageCount });
+      // Let the durable outbox retain Retry-After instead of losing it in
+      // errorCount — unless the pages already read are worth more than the wait.
+      if (!banked && error instanceof DispatchError) throw error;
+      logPageUnread({ adapter: this.id, pageCount, banked, error });
+      return { ok: false, banked };
     }
-    if (fetched === null) return { ok: false };
+    if (fetched === null) return { ok: false, banked: pageCount > 0 };
     const usedKeyGrouping = fetched.hasKeyGrouping;
 
     const parsed = pageSchema.parse(fetched.body);

--- a/platform/app/ee/governance/services/pullers/openaiAdmin.puller.ts
+++ b/platform/app/ee/governance/services/pullers/openaiAdmin.puller.ts
@@ -577,6 +577,18 @@ async function providerRefusal(response: {
  * about this source, so the pages already read are worth more than starting the
  * window over.
  *
+ * One thing banks here that is NOT transient. A 4xx this adapter does not
+ * classify — a 400 that is not the key-breakdown cutoff, a 404, a 422 — leaves
+ * `fetchPage` as a plain error on the same line a 5xx does, so pages in hand
+ * bank it too. That keeps pages the old code threw away, so it is not a
+ * regression, but the window still never completes: the next run starts AT the
+ * refused page, reads nothing, and reports the failure with the cursor held,
+ * which HOLDS the consecutive count rather than raising it. A source wedged
+ * that way reads as partly collected rather than failing. Pinning those
+ * statuses as refusals would overturn the cases already fixing a
+ * differently-shaped 400 to a counted failure rather than a throw, so it is a
+ * change of its own.
+ *
  * Banking is never the same as succeeding. The result carries `unreadPage`, so
  * the run status counts the failure while keeping the progress — without it a
  * source refused on every run would read as healthy forever.

--- a/platform/app/ee/governance/services/pullers/openaiAdmin.puller.ts
+++ b/platform/app/ee/governance/services/pullers/openaiAdmin.puller.ts
@@ -595,8 +595,9 @@ function mustBankRefusal({
 }
 
 /**
- * One page, read or refused. `banked` says whether the refusal arrived with
- * earlier pages of the same run already read — see `mustBankRefusal`.
+ * One page, read or refused. `hasBankedProgress` says whether the refusal
+ * arrived with earlier pages of the same run already read — see
+ * `mustBankRefusal`.
  */
 type PageRead =
   | {
@@ -606,7 +607,7 @@ type PageRead =
       watermark: string | null;
       hasKeyGrouping: boolean;
     }
-  | { ok: false; banked: boolean };
+  | { ok: false; hasBankedProgress: boolean };
 
 /**
  * What a run returns when a page could not be read.
@@ -624,17 +625,17 @@ type PageRead =
  * page three again, for as long as the window needed more than one page.
  */
 function pageUnread({
-  banked,
+  hasBankedProgress,
   events,
   stoppedShort,
   incomingCursor,
 }: {
-  banked: boolean;
+  hasBankedProgress: boolean;
   events: NormalizedPullEvent[];
   stoppedShort: () => PullResult;
   incomingCursor: string | null;
 }): PullResult {
-  if (banked)
+  if (hasBankedProgress)
     return { ...stoppedShort(), errorCount: 1, unreadPage: true as const };
   return { events, cursor: incomingCursor, errorCount: 1 };
 }
@@ -646,12 +647,12 @@ function pageUnread({
 function logPageUnread({
   adapter,
   pageCount,
-  banked,
+  hasBankedProgress,
   error,
 }: {
   adapter: string;
   pageCount: number;
-  banked: boolean;
+  hasBankedProgress: boolean;
   error: unknown;
 }): void {
   logger.error(
@@ -660,7 +661,7 @@ function logPageUnread({
       pageCount,
       error: error instanceof Error ? error.message : String(error),
     },
-    banked
+    hasBankedProgress
       ? "openai admin page refused mid-window; keeping the pages already read and resuming at the refused one"
       : "openai admin fetch failed; leaving the cursor where it was",
   );
@@ -748,7 +749,7 @@ export class OpenAiAdminPuller implements PullerAdapter<OpenAiAdminPullConfig> {
         // window for a retry when it read none. Never returns a partial window
         // as if it were complete.
         return pageUnread({
-          banked: read.banked,
+          hasBankedProgress: read.hasBankedProgress,
           events,
           stoppedShort,
           incomingCursor: options.cursor,
@@ -790,9 +791,9 @@ export class OpenAiAdminPuller implements PullerAdapter<OpenAiAdminPullConfig> {
    *
    * A transport failure is a returned `ok: false` rather than a throw, because
    * the caller has to answer it by deciding what the window is worth — which is
-   * why the failure carries `banked`. A malformed response still throws: a
-   * shape we do not recognise is not a window to retry, it is a contract that
-   * moved.
+   * why the failure carries `hasBankedProgress`. A malformed response still
+   * throws: a shape we do not recognise is not a window to retry, it is a
+   * contract that moved.
    */
   private async readPage({
     startingAt,
@@ -817,14 +818,15 @@ export class OpenAiAdminPuller implements PullerAdapter<OpenAiAdminPullConfig> {
         options,
       });
     } catch (error) {
-      const banked = mustBankRefusal({ error, pageCount });
+      const hasBankedProgress = mustBankRefusal({ error, pageCount });
       // Let the durable outbox retain Retry-After instead of losing it in
       // errorCount — unless the pages already read are worth more than the wait.
-      if (!banked && error instanceof DispatchError) throw error;
-      logPageUnread({ adapter: this.id, pageCount, banked, error });
-      return { ok: false, banked };
+      if (!hasBankedProgress && error instanceof DispatchError) throw error;
+      logPageUnread({ adapter: this.id, pageCount, hasBankedProgress, error });
+      return { ok: false, hasBankedProgress };
     }
-    if (fetched === null) return { ok: false, banked: pageCount > 0 };
+    if (fetched === null)
+      return { ok: false, hasBankedProgress: pageCount > 0 };
     const usedKeyGrouping = fetched.hasKeyGrouping;
 
     const parsed = pageSchema.parse(fetched.body);

--- a/platform/app/ee/governance/services/pullers/pullerAdapter.ts
+++ b/platform/app/ee/governance/services/pullers/pullerAdapter.ts
@@ -210,6 +210,23 @@ export interface PullResult {
    */
   completeness?: "complete" | "truncated";
   /**
+   * Set when this run's `errorCount` includes a page it could not read AT ALL.
+   *
+   * The contract above has two shapes for a nonzero `errorCount`, and this is
+   * the third thing that can happen: an adapter that could not read a page but
+   * HAD already read earlier ones may bank them — return the advanced cursor,
+   * the events it has, and this flag — rather than throw the lot away. The
+   * events are written and the position is persisted, exactly like skipped
+   * input, but the source must NOT read as working: without this flag a source
+   * refused part-way through every run holds a failure count of zero forever
+   * and never turns red. Say so here and the fold counts the failure while
+   * keeping the progress.
+   *
+   * Only for a page nobody could read. Input an adapter deliberately steps
+   * over belongs in `errorCount` alone.
+   */
+  unreadPage?: true;
+  /**
    * The instant this run is known to have read up to, ISO 8601.
    *
    * Distinct from the instant the run finished, and that distinction is the

--- a/platform/app/ee/governance/services/pullers/pullerWorker.ts
+++ b/platform/app/ee/governance/services/pullers/pullerWorker.ts
@@ -335,6 +335,15 @@ export type IngestionPullRunReport = {
    */
   completeness: "complete" | "truncated";
   /**
+   * Set when the adapter banked progress over a page it could not read at all.
+   *
+   * Carried up unchanged, and absent stays absent. It is what lets the run
+   * status count the failure while keeping the advance: a completion is the
+   * only way the banked events and cursor survive, so without this the source
+   * would read as working while collecting a fraction of its window.
+   */
+  unreadPage?: true;
+  /**
    * The instant the source is known to have been read up to, or null when the
    * adapter states none.
    *
@@ -463,6 +472,10 @@ export async function runIngestionPull(params: {
     eventCount: result.events.length,
     errorCount: result.errorCount,
     completeness: result.completeness ?? "complete",
+    // Absent unless the adapter says so, for the reason the two fields above
+    // are optional: a report that invents an answer is worse than one that
+    // says nothing.
+    ...(result.unreadPage === true ? { unreadPage: true as const } : {}),
     readThroughAt: readThroughInstant(result),
   };
 }

--- a/specs/ai-governance/puller-framework/openai-admin-cost.feature
+++ b/specs/ai-governance/puller-framework/openai-admin-cost.feature
@@ -251,6 +251,17 @@ Feature: OpenAI Admin cost puller
       # record a completion and leave the source looking healthy while it
       # collected nothing.
 
+    @unit
+    Scenario: A request the provider rejects outright is not banked part-way
+      Given a run that has already read earlier pages of a window
+      When the provider rejects a later page as a bad request
+      Then the source's position is unchanged
+      And the failure is reported
+      # A rejected request is an answer about the request itself, earning the
+      # same answer on every page and every retry. Resuming at it would leave
+      # the position on a page nothing will ever read past, so this is weighed
+      # like a refused key rather than like a provider having a bad minute.
+
     @integration
     Scenario: Every page of a window is read
       Given a window spanning more days than one page can carry

--- a/specs/ai-governance/puller-framework/openai-admin-cost.feature
+++ b/specs/ai-governance/puller-framework/openai-admin-cost.feature
@@ -201,11 +201,55 @@ Feature: OpenAI Admin cost puller
 
     @integration
     Scenario: A failed read leaves the source where it was
-      Given a run whose request to the provider fails
+      Given a run whose first request to the provider fails
       When the run ends
       Then the source's position is unchanged
       And the failure is reported
       And the next run reads that window again
+      # Only when nothing was read. There is no progress to weigh against the
+      # retry, the whole window is still owed, and the wait the provider named
+      # is the most valuable thing the run has. A failure that arrives once
+      # pages HAVE been read is answered the other way round, below.
+
+    @unit
+    Scenario: A page that cannot be read part-way through a window keeps the ones already read
+      Given a run that has already read earlier pages of a window
+      When a later page cannot be read
+      Then the spend from the pages already read is kept
+      And the source resumes at the page that could not be read
+      And the window is reported as not fully collected
+      # Holding the position still instead cost the run every page it had
+      # already read, so the next run asked for the first page again and was
+      # stopped at the same one. A window needing more than one page could
+      # never be got past, on any number of retries.
+
+    @unit
+    Scenario: A refusal part-way through a window still counts against the source
+      Given a run that kept the pages it read before a later one was refused
+      When the run ends
+      Then the run counts as a failure for the source's health
+      And the spend and position it kept are still kept
+
+    @unit
+    Scenario: A source refused part-way through every run reads as failing
+      Given a source refused part-way through each of its last three runs
+      When an admin looks at it
+      Then its pulls are shown as failing
+      # Every one of those runs ends as a completion, because that is how the
+      # pages it did read survive. Reading a completion as proof the source
+      # works lets one collecting a fraction of its spend every hour say
+      # nothing at all about it.
+
+    @unit
+    Scenario: A refused key fails the run rather than banking part of a window
+      Given a run whose key the provider refuses part-way through a window
+      When the run ends
+      Then the run fails
+      And the refusal names what an admin can fix
+      # A refused key answers the same way on every page, so there is no window
+      # to resume and nothing to gain by keeping part of one. Banking here would
+      # record a completion and leave the source looking healthy while it
+      # collected nothing.
 
     @integration
     Scenario: Every page of a window is read


### PR DESCRIPTION
A cost pull that got rate-limited half-way through used to throw away everything it had already read, and then fail the same way forever. Now it keeps what it read and carries on from the page it was refused at — and a source this keeps happening to is shown as failing rather than healthy.

## For humans

Reading a provider's spend is done a page at a time. If the provider said "slow down" on page three, we used to bin pages one and two and forget where we were. Next hour we started at page one, got told to slow down at page three again, and that repeated forever. Nobody was ever going to get that spend without a person stepping in.

Now we keep pages one and two, write down that page three is where to carry on, and mark the window as not finished. We also count it as a failure, so a source this happens to every hour turns red instead of quietly looking fine while collecting a fraction of the spend.

Two kinds of refusal are told apart. "Slow down" and "I'm having a bad minute" are worth resuming from. "Your key is refused" and "that request is wrong" are not — the same answer comes back every time, so there is nothing to resume and we leave the position where it was.

## Why

The OpenAI admin cost puller reads a time window one page at a time. When the provider refused a page mid-window with a rate limit, the refusal was thrown straight out of the run. Two things were lost with it: the events already read from earlier pages, and the durable cursor, which was never written.

The consequence is worse than a slow recovery. Every following hourly run restarted at the first page of the same window and was refused at the same page again. A source that hit a rate limit part-way through a backfill window could never get past it, on any number of retries. It needed a person to notice.

No issue filed; found while reading the puller alongside a parallel change to the Anthropic one.

## What changed

**Keeping the pages already read.** A mid-run refusal now behaves like a run that the deadline stopped short, which the puller already handled correctly. When earlier pages of the same run have been read, the run keeps the events read so far, returns a cursor resuming at the page that was refused, marks the window `truncated` so nothing downstream treats it as complete, and counts one error.

When nothing has been read yet, behaviour is unchanged. The rate-limit error still travels out of the run carrying the provider's `Retry-After`, so the scheduler waits as asked and the window is retried.

**Counting it against the source's health.** Banking the pages made a refusing source look healthy: a completion carrying errors held the consecutive-error count instead of raising it, so a source collecting a fraction of its spend every hour sat at zero failures forever and showed the amber partly-collected line. A completion now tells two failures apart — a page nobody could read, which raises the count and stamps no success, and rows the run read and stepped over, which does not. Three refused runs in a row now show the source as failing.

**Telling a refusal from a bad minute.** Only a transient failure is worth resuming from:

| Provider says | Treated as | Result |
|---|---|---|
| 429 rate limit | bad minute | pages kept, resume at the refused page |
| Dropped socket, 5xx | bad minute | pages kept, resume at the refused page |
| 401 / 403 refused key | answer about the source | run fails, nothing banked |
| 400 / 404 / 422 rejected request | answer about the request | position held, nothing banked |

A refused key fails the run as a non-retryable error rather than banking a window it will never be allowed to finish. A rejected request is the same shape of answer: it earns the same response on every page and every retry, so resuming at it would park the position on a page nothing will ever read past. A non-OK response now carries its status so the banking rule can tell these apart; previously both a 404 and a 503 arrived as plain errors and banked alike. 408 and 425 stay bad minutes, since both ask to be sent again.

## How it works

The decision is one small predicate, `mustBankRefusal`, reading the page count the run has got through and the kind of failure it met. Zero pages read means no progress to protect, so the wait is the most valuable thing the run has and it keeps travelling. One or more pages read inverts the trade, because holding the cursor still ended the run with no forward progress at all.

Re-reading a bucket that was already banked is safe: the pipeline restates it. A window nothing can read past is not recoverable at all. That asymmetry is the whole argument.

`errorCount: 1` beside an advanced cursor is what the worker already reads as a partial success, so the events are written and the cursor is persisted without any new plumbing. The result also carries `unreadPage`, which is what the run-status projection reads to raise the consecutive-error count.

## Test plan

| Check | Result |
|---|---|
| `pnpm test:unit run ee/governance/services/pullers/__tests__/openaiAdminPuller.unit.test.ts` | 49 passed |
| `pnpm test:unit run ee/governance/services/pullers/` | 43 files, 720 passed |
| `pnpm test:unit run ee/event-sourcing/pipelines/ingestion-pull-processing/` | 12 files, 161 passed |
| `pnpm typecheck:all` | exit 0 |
| Biome new-violations gate vs the merge base | no new violations |
| `check-feature-parity.ts` for this feature file | 31/31 scenarios bound |

Cases that failed before their fix: a rate limit on page two escaped the run instead of being banked; the run returned the original cursor and did not report the window as truncated; three refused runs in a row left the source reading as healthy; a rejected request on page two advanced the position onto the rejected page.

One case passed before and after, deliberately. It guards against over-correcting: it would fail if the fix swallowed the provider's wait when there was no progress to keep.

## Anything surprising?

**One trade-off, stated plainly.** A banked refusal is reported as a completed run carrying one error and a truncated window, rather than as a failed run. The cost is that a mid-window rate limit no longer floors the retry delay with the provider's `Retry-After`, so recovery waits for the next scheduled pull instead of a fast retry.

That was judged acceptable because the fast retry was not recovering anything. It re-read the first page and died at the same place. Nothing re-dispatches on a truncated window, so this does not hammer a provider that asked to be left alone.

**Two follow-ups, deliberately out of scope here.**

- `platform/app/ee/governance/services/pullers/anthropicAdmin.puller.ts` around lines 945-948 has the identical defect by both routes, and needs its own test file. This is the obvious next change.
- `platform/app/ee/governance/services/pullers/httpPollingPullerAdapter.ts` around line 211 is the same shape and slightly worse, because its cursor advances per page inside the run and the failure path throws that advance away too.

**One pre-existing defect, not fixed here.** Once a run is recorded as not finished the projection never clears that stamp, and the health rule tests it before it tests failures, so old wording can outlive a later real failure. It predates this branch and is worth its own change.

**A second pre-existing gap, found while settling review.** A run that ends with an error count and the position held holds the consecutive-error count rather than raising it. So a source wedged on a rejected request reads as partly collected rather than failing, even now. This change narrowed that hole for the mid-window case and did not widen it anywhere, but closing it properly means revisiting how a held-position failure is counted — its own change.

**Base branch.** This was opened on top of `worktree-anthropic-source-ui`. That branch has since landed in `main` as #8082 and was deleted, so this is now rebased straight onto `main` and carries only its own five commits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Partial data imports now preserve successfully read pages when a later page fails, resuming from the unread page on the next attempt.
  - Failed pages are clearly marked, improving source health and completeness reporting.
  - Initial request failures and invalid requests leave the source position unchanged for safe retry.
  - Invalid provider credentials now fail clearly without exposing sensitive provider responses.
  - Repeated unread pages are reflected as an unhealthy source until a clean run completes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
