### PR TITLE
fix(data-privacy): stop redaction destroying opaque machine identifiers

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -394,19 +394,20 @@ description = "RFC 6455 sample Sec-WebSocket-Key in the voice listener handshake
 targetRules = ["generic-api-key"]
 regexes = ['''^dGhlIHNhbXBsZSBub25jZQ==$''']
 
-# Two bech32m test vectors in the bitcoin-address suite, which prove the
-# recognizer rejects a witness version bitcoin does not define. They are one
-# payload written at version one and at version seventeen, so the version one
-# member validating is what shows the version seventeen member is rejected for
-# its version rather than for a checksum that never lined up.
+# The bech32 test vectors in the bitcoin-address suite, which prove the
+# recognizer rejects a witness version or a witness program bitcoin does not
+# allow. They come in pairs: the same construction at a value bitcoin permits
+# and at one it does not, so the permitted member validating is what shows the
+# other is rejected for its version or its program rather than for a checksum
+# that never lined up.
 #
-# Naming them, as this file requires. Neither is a credential and neither can
-# become one: a bech32 string is a PUBLIC address, the thing you hand out to be
-# paid, and these two were generated for this test rather than observed. The
-# version seventeen member is not a bitcoin address at all — no wallet will
-# parse it — and the version one member encodes a payload of counted-up bytes,
-# so it is a well-formed address to a key nobody holds. There is nothing to
-# revoke, and nothing to send anywhere.
+# Naming them, as this file requires. None is a credential and none can become
+# one: a bech32 string is a PUBLIC address, the thing you hand out to be paid,
+# and these were generated for this test rather than observed. The rejected
+# members are not bitcoin addresses at all — no wallet will parse them — and the
+# accepted members encode payloads of counted-up bytes, so they are well-formed
+# addresses to keys nobody holds. There is nothing to revoke, and nothing to
+# send anywhere.
 #
 # They cannot be assembled at run time the way the base64 fixture in the
 # identifier hold-out suite is. The checksum IS the thing under test, so a test
@@ -420,9 +421,15 @@ regexes = ['''^dGhlIHNhbXBsZSBub25jZQ==$''']
 # a substring allowlist would also permit a real secret that merely starts with
 # these characters.
 [[allowlists]]
-description = "Generated bech32m vectors in the bitcoin-address tests; public addresses to keys nobody holds"
+description = "Generated bech32 vectors in the bitcoin-address tests; public addresses to keys nobody holds"
 targetRules = ["generic-api-key"]
 regexes = [
   '''^bc1pr23clxd5mzfsh79vn6pg0kaytjeq8w4u8x8jd8$''',
   '''^bc13r23clxd5mzfsh79vn6pg0kaytjeq8w4un2kxzn$''',
+  '''^bc1pqvwl8xs0$''',
+  '''^bc1pqdnfnnda$''',
+  '''^bc1pqv9pzxqlyckngw6zf9g9whn9d3eh4qvg37tfmf9tk2uup37w6hww86h3lrlsvrg5rvlw2s2x$''',
+  '''^bc1pqv9pzxqlyckngw6zf9g9whn9d3eh4qvge0qxlk$''',
+  '''^bc1qqv9pzxqlyckngw6zf9g9whn9dsaqaxas$''',
+  '''^bc1qqv9pzxqlyckngw6zf9g9whn9d3eh4qvg8d8phl$''',
 ]

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -393,3 +393,36 @@ paths = [
 description = "RFC 6455 sample Sec-WebSocket-Key in the voice listener handshake tests, a client-invented nonce"
 targetRules = ["generic-api-key"]
 regexes = ['''^dGhlIHNhbXBsZSBub25jZQ==$''']
+
+# Two bech32m test vectors in the bitcoin-address suite, which prove the
+# recognizer rejects a witness version bitcoin does not define. They are one
+# payload written at version one and at version seventeen, so the version one
+# member validating is what shows the version seventeen member is rejected for
+# its version rather than for a checksum that never lined up.
+#
+# Naming them, as this file requires. Neither is a credential and neither can
+# become one: a bech32 string is a PUBLIC address, the thing you hand out to be
+# paid, and these two were generated for this test rather than observed. The
+# version seventeen member is not a bitcoin address at all — no wallet will
+# parse it — and the version one member encodes a payload of counted-up bytes,
+# so it is a well-formed address to a key nobody holds. There is nothing to
+# revoke, and nothing to send anywhere.
+#
+# They cannot be assembled at run time the way the base64 fixture in the
+# identifier hold-out suite is. The checksum IS the thing under test, so a test
+# that computed it would be asserting one implementation against a copy of
+# itself; the literal is what makes the vector a vector.
+#
+# gitleaks' `generic-api-key` rule fires on the `const token = "<entropy>"`
+# shape and cannot tell an address from a key.
+#
+# Scoped by VALUE and ANCHORED, for the reason given above the block before it:
+# a substring allowlist would also permit a real secret that merely starts with
+# these characters.
+[[allowlists]]
+description = "Generated bech32m vectors in the bitcoin-address tests; public addresses to keys nobody holds"
+targetRules = ["generic-api-key"]
+regexes = [
+  '''^bc1pr23clxd5mzfsh79vn6pg0kaytjeq8w4u8x8jd8$''',
+  '''^bc13r23clxd5mzfsh79vn6pg0kaytjeq8w4un2kxzn$''',
+]

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -13,3 +13,13 @@
 # the gate walks every commit in the pull request's range, and this one is now
 # history.
 4c7f177f4f5b4a4290d9281031dc4cdeff2d23a6:services/aigateway/adapters/providers/bifrost_error_test.go:generic-api-key:217
+
+# A fixture in the identifier hold-out suite spelled out a base64 token, to
+# prove that a token of that shape is held back from the analysis service. It
+# decodes to the ASCII words `hello world 1234567890`: issued by nobody,
+# authenticating nothing, with nothing to revoke — but its entropy is a
+# credential's, which is the rule working as intended and not something gitleaks
+# should be asked to tell apart. The fixture now assembles the value at run time
+# so the tree carries no literal; the finding survives only because the gate
+# walks every commit in the pull request's range, and this one is now history.
+6c763c36b3193a085698ff5c61a3cbac22623f69:platform/app/src/server/data-privacy/redaction/__tests__/identifierHoldout.unit.test.ts:generic-api-key:34

--- a/platform/app/src/server/app-layer/traces/__tests__/span-pii-redaction.identifierHoldout.test.ts
+++ b/platform/app/src/server/app-layer/traces/__tests__/span-pii-redaction.identifierHoldout.test.ts
@@ -1,0 +1,262 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  EMPTY_AUDIENCE,
+  type ResolvedDataPrivacy,
+} from "~/server/data-privacy/dataPrivacy.types";
+import type {
+  OtlpKeyValue,
+  OtlpSpan,
+} from "../../../event-sourcing/pipelines/trace-processing/schemas/otlp";
+import {
+  type BatchClearPIIFunction,
+  type DataPrivacyResolver,
+  OtlpSpanPiiRedactionService,
+} from "../span-pii-redaction.service";
+
+// The analysis service is the boundary under test: what LEAVES the process is
+// the observable contract, so the batch function is spied on and the rest of
+// the redaction stack runs for real.
+vi.mock("~/server/featureFlag", () => ({
+  featureFlagService: { isEnabled: vi.fn(async () => false) },
+}));
+
+vi.mock("~/server/tracer/collector/piiCheck", () => ({
+  batchPresidioClearPII: vi.fn(),
+  googleDLPClearPII: vi.fn(),
+  PRESIDIO_STRICT_ENTITIES: ["PERSON", "LOCATION", "EMAIL_ADDRESS"],
+}));
+
+import { createTenantId } from "~/server/event-sourcing/domain/tenantId";
+
+const TENANT = createTenantId("project-web-app");
+
+const STRICT_POLICY: ResolvedDataPrivacy = {
+  categories: {
+    input: { disposition: "capture", audience: { ...EMPTY_AUDIENCE } },
+    output: { disposition: "capture", audience: { ...EMPTY_AUDIENCE } },
+    system: { disposition: "capture", audience: { ...EMPTY_AUDIENCE } },
+    tools: { disposition: "capture", audience: { ...EMPTY_AUDIENCE } },
+  },
+  pii: { level: "strict", entities: [], exceptPatterns: [] },
+  secrets: { enabled: true, customPatterns: [] },
+  customAttributes: [],
+};
+
+function resolverFor(policy: ResolvedDataPrivacy): DataPrivacyResolver {
+  return { getResolvedForProject: async () => policy };
+}
+
+function makeService(policy: ResolvedDataPrivacy = STRICT_POLICY) {
+  // Return null for every input: the analysis service reporting "nothing to
+  // change" keeps the stored values readable, so an assertion about what was
+  // STORED and one about what was SUBMITTED cannot be confused for each other.
+  const batchSpy = vi.fn<BatchClearPIIFunction>(async (texts) =>
+    texts.map(() => null),
+  );
+  const service = new OtlpSpanPiiRedactionService({
+    batchClearPII: batchSpy,
+    isLangevalsConfigured: true,
+    isProduction: false,
+    dataPrivacyResolver: resolverFor(policy),
+  });
+  const submitted = (): string[] =>
+    batchSpy.mock.calls.flatMap((call) => call[0] as string[]);
+  return { service, batchSpy, submitted };
+}
+
+function spanWith(attributes: Record<string, string>): OtlpSpan {
+  const attrs: OtlpKeyValue[] = Object.entries(attributes).map(
+    ([key, value]) => ({ key, value: { stringValue: value } }),
+  );
+  return {
+    traceId: "abc123",
+    spanId: "def456",
+    name: "test-span",
+    kind: 1,
+    startTimeUnixNano: { low: 0, high: 0 },
+    endTimeUnixNano: { low: 0, high: 0 },
+    attributes: attrs,
+    events: [],
+    links: [],
+    status: {},
+    droppedAttributesCount: 0,
+    droppedEventsCount: 0,
+    droppedLinksCount: 0,
+  } as unknown as OtlpSpan;
+}
+
+function attr(span: OtlpSpan, key: string): string | undefined {
+  return (
+    span.attributes.find((a) => a.key === key)?.value.stringValue ?? undefined
+  );
+}
+
+/** A seeded generator, so a failing corpus names the same values on a re-run. */
+function seededRandom(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function pick(next: () => number, alphabet: string, length: number): string {
+  return Array.from(
+    { length },
+    () => alphabet[Math.floor(next() * alphabet.length)]!,
+  ).join("");
+}
+
+const HEX = "0123456789abcdef";
+const CROCKFORD = "0123456789abcdefghjkmnpqrstvwxyz";
+
+/**
+ * The shapes an OTel pipeline actually emits, in the counts the local
+ * measurement used: 32- and 16-character hex ids, dashed uuids, and the
+ * `prefix_<ULID>` record ids the product itself mints.
+ */
+function identifierCorpus(seed: number): string[] {
+  const next = seededRandom(seed);
+  const corpus: string[] = [];
+  for (let i = 0; i < 300; i++) {
+    corpus.push(pick(next, HEX, 32));
+    corpus.push(pick(next, HEX, 16));
+    corpus.push(
+      `${pick(next, HEX, 8)}-${pick(next, HEX, 4)}-4${pick(next, HEX, 3)}-a${pick(next, HEX, 3)}-${pick(next, HEX, 12)}`,
+    );
+    corpus.push(`session_${pick(next, CROCKFORD, 26)}`);
+  }
+  return corpus;
+}
+
+describe("OtlpSpanPiiRedactionService identifier hold-out before analysis", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.LANGWATCH_DATA_PRIVACY_ENFORCEMENT;
+  });
+
+  describe("given a span attribute whose whole value is one opaque identifier", () => {
+    /** @scenario "An opaque identifier attribute value is never sent for analysis" */
+    it("never submits a hex span id, and stores it unchanged", async () => {
+      const { service, submitted } = makeService();
+      const spanId = "c87fa28b188bd8ef";
+      const span = spanWith({ "app.upstream_span": spanId });
+
+      await service.redactSpan(span, null, "STRICT", TENANT);
+
+      expect(submitted()).not.toContain(spanId);
+      expect(attr(span, "app.upstream_span")).toBe(spanId);
+    });
+
+    /** @scenario "A corpus of opaque identifiers is never sent for analysis" */
+    it("never submits any of twelve hundred hex ids, uuids and prefixed ULIDs", async () => {
+      const { service, submitted } = makeService();
+      const corpus = identifierCorpus(20260911);
+      const span = spanWith(
+        Object.fromEntries(
+          corpus.map((value, index) => [`app.ref_${index}`, value]),
+        ),
+      );
+
+      await service.redactSpan(span, null, "STRICT", TENANT);
+
+      const leaked = corpus.filter((value) => submitted().includes(value));
+      expect(leaked).toEqual([]);
+    });
+  });
+
+  describe("given a reserved trace identifier attribute", () => {
+    /** @scenario "A reserved trace identifier attribute is never sent for analysis" */
+    it("never submits a decimal trace id, which no shape rule would hold back", async () => {
+      const { service, submitted } = makeService();
+      // A decimal trace id carries no letter, so the shape rules read it as
+      // digits rather than as an identifier. The reserved name is what keeps it.
+      const decimalTraceId = "17575001234540000091234567890123";
+      const span = spanWith({ "metadata.trace_id": decimalTraceId });
+
+      await service.redactSpan(span, null, "STRICT", TENANT);
+
+      expect(submitted()).not.toContain(decimalTraceId);
+    });
+
+    /** @scenario "A reserved identifier attribute survives even when its value is all digits" */
+    it("stores a decimal trace id unchanged at the default level", async () => {
+      const { service, batchSpy } = makeService({
+        ...STRICT_POLICY,
+        pii: { level: "essential", entities: [], exceptPatterns: [] },
+      });
+      const decimalTraceId = "17575001234540000091234567890123";
+      const span = spanWith({ "metadata.otelTraceId": decimalTraceId });
+
+      await service.redactSpan(span, null, "ESSENTIAL", TENANT);
+
+      expect(attr(span, "metadata.otelTraceId")).toBe(decimalTraceId);
+      expect(batchSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("given an attribute that carries prose", () => {
+    /** @scenario "Prose that holds a name is still sent for analysis" */
+    it("submits a sentence naming a person", async () => {
+      const { service, submitted } = makeService();
+      const sentence = "the ticket was raised by Jane Doe in Berlin";
+      const span = spanWith({ "langwatch.input": sentence });
+
+      await service.redactSpan(span, null, "STRICT", TENANT);
+
+      expect(submitted()).toContain(sentence);
+    });
+
+    /** @scenario "A customer identifier that holds a person name is still sent for analysis" */
+    it("submits a user identifier attribute holding a person name", async () => {
+      const { service, submitted } = makeService();
+      const span = spanWith({ "langwatch.user_id": "Jane Doe" });
+
+      await service.redactSpan(span, null, "STRICT", TENANT);
+
+      expect(submitted()).toContain("Jane Doe");
+    });
+  });
+
+  describe("given a log record", () => {
+    /** @scenario "Log attributes hold opaque identifiers back from analysis" */
+    it("submits the body but never the identifier attribute", async () => {
+      const { service, submitted } = makeService();
+      const traceId = "a4f19c2b7e83d05611aa0cbe94d7f2e8";
+      const log = {
+        body: "request handled for Jane Doe",
+        attributes: { "app.correlation": traceId },
+        resourceAttributes: {},
+      };
+
+      await service.redactLog(log, "STRICT", TENANT);
+
+      expect(submitted()).not.toContain(traceId);
+      expect(submitted()).toContain("request handled for Jane Doe");
+    });
+  });
+
+  describe("given metric attributes", () => {
+    /** @scenario "Log attributes hold opaque identifiers back from analysis" */
+    it("never submits an identifier attribute, and still submits prose", async () => {
+      const { service, submitted } = makeService();
+      const traceId = "a4f19c2b7e83d05611aa0cbe94d7f2e8";
+      const metric = {
+        attributes: {
+          "app.correlation": traceId,
+          "app.note": "raised by Jane",
+        },
+        resourceAttributes: {},
+      };
+
+      await service.redactMetricAttributes(metric, "STRICT", TENANT);
+
+      expect(submitted()).not.toContain(traceId);
+      expect(submitted()).toContain("raised by Jane");
+    });
+  });
+});

--- a/platform/app/src/server/app-layer/traces/__tests__/span-pii-redaction.identifierHoldout.test.ts
+++ b/platform/app/src/server/app-layer/traces/__tests__/span-pii-redaction.identifierHoldout.test.ts
@@ -220,6 +220,55 @@ describe("OtlpSpanPiiRedactionService identifier hold-out before analysis", () =
 
       expect(submitted()).toContain("Jane Doe");
     });
+
+    // The hold-out reads a whole attribute value, so a name written as ONE
+    // token is the case it can swallow. A control that uses "Jane Doe" only
+    // passes because of the space and guards nothing; these are the forms that
+    // have no space to save them.
+    /** @scenario "A hyphenated or run-together name is still sent for analysis" */
+    it("submits names written with hyphens, with dots and with no separator", async () => {
+      const { service, submitted } = makeService();
+      const names = [
+        "Jean-Claude-Van-Damme",
+        "Gonzalez-Rodriguez-Maria",
+        "Wolfgang-Amadeus-Mozart",
+        "AnneMarieJohansson",
+        "maria.schmidt.1972",
+      ];
+      const span = spanWith(
+        Object.fromEntries(
+          names.map((value, index) => [`langwatch.user_id_${index}`, value]),
+        ),
+      );
+
+      await service.redactSpan(span, null, "STRICT", TENANT);
+
+      const withheld = names.filter((name) => !submitted().includes(name));
+      expect(withheld).toEqual([]);
+    });
+
+    /** @scenario "A place written as one hyphenated token is still sent for analysis" */
+    it("submits a hyphenated place and a hyphenated street address", async () => {
+      const { service, submitted } = makeService();
+      const span = spanWith({
+        "patient.clinic": "Saint-Jean-Baptiste-Hospital",
+        "shipping.address_line": "Elm-Street-Apartment-4B",
+      });
+
+      await service.redactSpan(span, null, "STRICT", TENANT);
+
+      expect(submitted()).toContain("Saint-Jean-Baptiste-Hospital");
+      expect(submitted()).toContain("Elm-Street-Apartment-4B");
+    });
+
+    it("submits a run-together name carried in the chat content itself", async () => {
+      const { service, submitted } = makeService();
+      const span = spanWith({ "gen_ai.prompt": "AnneMarieJohansson" });
+
+      await service.redactSpan(span, null, "STRICT", TENANT);
+
+      expect(submitted()).toContain("AnneMarieJohansson");
+    });
   });
 
   describe("given a log record", () => {
@@ -241,7 +290,7 @@ describe("OtlpSpanPiiRedactionService identifier hold-out before analysis", () =
   });
 
   describe("given metric attributes", () => {
-    /** @scenario "Log attributes hold opaque identifiers back from analysis" */
+    /** @scenario "Metric attributes hold opaque identifiers back from analysis" */
     it("never submits an identifier attribute, and still submits prose", async () => {
       const { service, submitted } = makeService();
       const traceId = "a4f19c2b7e83d05611aa0cbe94d7f2e8";

--- a/platform/app/src/server/app-layer/traces/__tests__/span-pii-redaction.identifierHoldout.test.ts
+++ b/platform/app/src/server/app-layer/traces/__tests__/span-pii-redaction.identifierHoldout.test.ts
@@ -27,6 +27,7 @@ vi.mock("~/server/tracer/collector/piiCheck", () => ({
   PRESIDIO_STRICT_ENTITIES: ["PERSON", "LOCATION", "EMAIL_ADDRESS"],
 }));
 
+import { isIdentifierShapedValue } from "~/server/data-privacy/redaction/identifierHoldout";
 import { createTenantId } from "~/server/event-sourcing/domain/tenantId";
 
 const TENANT = createTenantId("project-web-app");
@@ -115,22 +116,82 @@ const HEX = "0123456789abcdef";
 const CROCKFORD = "0123456789abcdefghjkmnpqrstvwxyz";
 
 /**
- * The shapes an OTel pipeline actually emits, in the counts the local
- * measurement used: 32- and 16-character hex ids, dashed uuids, and the
- * `prefix_<ULID>` record ids the product itself mints.
+ * The shapes an OTel pipeline actually emits, split by what the rule can
+ * promise about each. Trace ids and uuids — long enough that the rule holds them back for every
+ * value rather than merely for most. A run qualifies as hex only if it also
+ * carries a letter, since a run of nothing but digits is a card or an account
+ * number as far as this rule can tell; across thirty-two hex characters a draw
+ * with no letter at all happens about three times in ten million, so a leak
+ * here is a broken rule rather than an unlucky draw.
  */
-function identifierCorpus(seed: number): string[] {
+function unconditionalCorpus(seed: number): string[] {
   const next = seededRandom(seed);
   const corpus: string[] = [];
   for (let i = 0; i < 300; i++) {
     corpus.push(pick(next, HEX, 32));
-    corpus.push(pick(next, HEX, 16));
     corpus.push(
       `${pick(next, HEX, 8)}-${pick(next, HEX, 4)}-4${pick(next, HEX, 3)}-a${pick(next, HEX, 3)}-${pick(next, HEX, 12)}`,
     );
+  }
+  return corpus;
+}
+
+/**
+ * The short tokens, which clear the rule on a coin toss rather than on their
+ * shape: a sixteen-character span id drawn with no letter at all (about one in
+ * eighteen hundred) reads as a digit run, and a ULID qualifies on carrying two
+ * digits rather than on being hex. Both are submitted when the draw goes that
+ * way, so the assertion below is a rate and not a zero — an exact zero would be
+ * true of one seed and would claim something the rule does not deliver.
+ */
+function shortTokenCorpus(seed: number): string[] {
+  const next = seededRandom(seed);
+  const corpus: string[] = [];
+  for (let i = 0; i < 600; i++) {
+    corpus.push(pick(next, HEX, 16));
     corpus.push(`session_${pick(next, CROCKFORD, 26)}`);
   }
   return corpus;
+}
+
+const NAME_PARTS = [
+  "Jean",
+  "Claude",
+  "Anne",
+  "Marie",
+  "Maria",
+  "Schmidt",
+  "Wolfgang",
+  "Amadeus",
+  "Mozart",
+  "Gonzalez",
+  "Rodriguez",
+  "Saint",
+  "Baptiste",
+  "Johansson",
+  "Pierre",
+  "Dupont",
+];
+
+/**
+ * Personal names in the forms that have no space to save them: hyphenated,
+ * dotted, and run together. This is the direction that regressed once, when the
+ * analysis path borrowed the native engine's shape rule, so it is generated
+ * rather than hand-picked.
+ */
+function nameCorpus(seed: number): string[] {
+  const next = seededRandom(seed);
+  const names: string[] = [];
+  while (names.length < 2000) {
+    const parts = 2 + Math.floor(next() * 3);
+    const picked = Array.from(
+      { length: parts },
+      () => NAME_PARTS[Math.floor(next() * NAME_PARTS.length)]!,
+    );
+    const separator = [" ", "-", ".", ""][Math.floor(next() * 4)]!;
+    names.push(picked.join(separator));
+  }
+  return names;
 }
 
 describe("OtlpSpanPiiRedactionService identifier hold-out before analysis", () => {
@@ -153,9 +214,11 @@ describe("OtlpSpanPiiRedactionService identifier hold-out before analysis", () =
     });
 
     /** @scenario "A corpus of opaque identifiers is never sent for analysis" */
-    it("never submits any of twelve hundred hex ids, uuids and prefixed ULIDs", async () => {
+    it.each([
+      20260911, 99, 7,
+    ])("never submits a trace id or a uuid, at seed %i", async (seed) => {
       const { service, submitted } = makeService();
-      const corpus = identifierCorpus(20260911);
+      const corpus = unconditionalCorpus(seed);
       const span = spanWith(
         Object.fromEntries(
           corpus.map((value, index) => [`app.ref_${index}`, value]),
@@ -166,6 +229,24 @@ describe("OtlpSpanPiiRedactionService identifier hold-out before analysis", () =
 
       const leaked = corpus.filter((value) => submitted().includes(value));
       expect(leaked).toEqual([]);
+    });
+
+    /** @scenario "A corpus of short opaque tokens is almost never sent for analysis" */
+    it.each([
+      20260911, 99, 7,
+    ])("submits fewer than one short token in a hundred, at seed %i", async (seed) => {
+      const { service, submitted } = makeService();
+      const corpus = shortTokenCorpus(seed);
+      const span = spanWith(
+        Object.fromEntries(
+          corpus.map((value, index) => [`app.token_${index}`, value]),
+        ),
+      );
+
+      await service.redactSpan(span, null, "STRICT", TENANT);
+
+      const leaked = corpus.filter((value) => submitted().includes(value));
+      expect(leaked.length / corpus.length).toBeLessThan(0.01);
     });
   });
 
@@ -259,6 +340,34 @@ describe("OtlpSpanPiiRedactionService identifier hold-out before analysis", () =
 
       expect(submitted()).toContain("Saint-Jean-Baptiste-Hospital");
       expect(submitted()).toContain("Elm-Street-Apartment-4B");
+    });
+
+    // The figure quoted in the pull request comes from here. `heldByShapeRule`
+    // is not a second implementation of the hold-out: it calls the native
+    // engine's rule directly, to keep the size of the regression this fixed
+    // measured rather than remembered.
+    /** @scenario "A corpus of written names is still sent for analysis" */
+    it("submits every one of two thousand generated names", async () => {
+      const { service, submitted } = makeService();
+      const names = nameCorpus(4242);
+      const span = spanWith(
+        Object.fromEntries(
+          names.map((value, index) => [`langwatch.user_id_${index}`, value]),
+        ),
+      );
+
+      await service.redactSpan(span, null, "STRICT", TENANT);
+
+      const singleToken = names.filter((name) => !name.includes(" "));
+      const heldByShapeRule = names.filter((name) =>
+        isIdentifierShapedValue(name),
+      );
+      const withheld = names.filter((name) => !submitted().includes(name));
+
+      expect(names).toHaveLength(2000);
+      expect(singleToken.length).toBeGreaterThan(1400);
+      expect(heldByShapeRule.length).toBeGreaterThan(700);
+      expect(withheld).toEqual([]);
     });
 
     it("submits a run-together name carried in the chat content itself", async () => {

--- a/platform/app/src/server/app-layer/traces/__tests__/span-pii-redaction.identifierHoldout.test.ts
+++ b/platform/app/src/server/app-layer/traces/__tests__/span-pii-redaction.identifierHoldout.test.ts
@@ -278,6 +278,36 @@ describe("OtlpSpanPiiRedactionService identifier hold-out before analysis", () =
       expect(attr(span, "metadata.otelTraceId")).toBe(decimalTraceId);
       expect(batchSpy).not.toHaveBeenCalled();
     });
+
+    // The reserved names are not a namespace anyone owns: attributes arrive on
+    // the ingestion endpoint spelled exactly as the sender wrote them. A rule
+    // that went on the name alone would let a sender turn the personal-data
+    // pass off for any value at all, and the value is stored before anyone
+    // could notice. The name has to be carrying something that could actually
+    // be the address it promises.
+    /** @scenario "A reserved trace identifier name holding an email address is redacted at the strict level" */
+    it("redacts an email address written under a reserved name, and never submits it in the clear", async () => {
+      const { service, submitted } = makeService();
+      const span = spanWith({ "metadata.trace_id": "jane@example.com" });
+
+      await service.redactSpan(span, null, "STRICT", TENANT);
+
+      expect(attr(span, "metadata.trace_id")).toBe("[EMAIL_ADDRESS]");
+      expect(submitted()).not.toContain("jane@example.com");
+    });
+
+    /** @scenario "A reserved trace identifier name holding an email address is still redacted" */
+    it("redacts an email address written under a reserved name natively", async () => {
+      const { service } = makeService({
+        ...STRICT_POLICY,
+        pii: { level: "essential", entities: [], exceptPatterns: [] },
+      });
+      const span = spanWith({ "metadata.trace_id": "jane@example.com" });
+
+      await service.redactSpan(span, null, "ESSENTIAL", TENANT);
+
+      expect(attr(span, "metadata.trace_id")).toBe("[EMAIL_ADDRESS]");
+    });
   });
 
   describe("given an attribute that carries prose", () => {
@@ -300,6 +330,27 @@ describe("OtlpSpanPiiRedactionService identifier hold-out before analysis", () =
       await service.redactSpan(span, null, "STRICT", TENANT);
 
       expect(submitted()).toContain("Jane Doe");
+    });
+
+    // Carrying an identifier is not the same as being one. A support message,
+    // a log line or an error string routinely quotes the trace id it is about,
+    // and a rule that held a value back as soon as it CONTAINED an opaque run
+    // would stop scanning all of them — storing the names in the clear, which
+    // is the failure this module exists to prevent arrived at from the other
+    // side. Both separators are covered because "_" and "-" split a run while
+    // a space does not, so the two spellings reach the rule differently.
+    /** @scenario "Prose that quotes an opaque identifier is still sent for analysis" */
+    it.each([
+      ["a prefixed identifier", "trace_db237ee0db82f81cc87fa28b188bd8ef"],
+      ["a bare hex identifier", "db237ee0db82f81cc87fa28b188bd8ef"],
+    ])("submits a sentence naming a person next to %s", async (_case, id) => {
+      const { service, submitted } = makeService();
+      const sentence = `Jane Doe in Berlin reported this on ${id}`;
+      const span = spanWith({ "app.support_note": sentence });
+
+      await service.redactSpan(span, null, "STRICT", TENANT);
+
+      expect(submitted()).toContain(sentence);
     });
 
     // The hold-out reads a whole attribute value, so a name written as ONE

--- a/platform/app/src/server/app-layer/traces/__tests__/span-pii-redaction.identifierHoldout.test.ts
+++ b/platform/app/src/server/app-layer/traces/__tests__/span-pii-redaction.identifierHoldout.test.ts
@@ -308,6 +308,25 @@ describe("OtlpSpanPiiRedactionService identifier hold-out before analysis", () =
 
       expect(attr(span, "metadata.trace_id")).toBe("[EMAIL_ADDRESS]");
     });
+
+    // A decimal trace id and a card number are the same shape, so the reserved
+    // name cannot be a blanket exemption: it stands the shape-only detectors
+    // down, which is what it is for, and leaves the ones that can prove what
+    // they are looking at running. The control above it is the decimal trace id
+    // that must survive, which is what makes this a rule about proof rather
+    // than a rule about length.
+    /** @scenario "A card number written under a reserved trace identifier name is still redacted" */
+    it("redacts a valid card number written under a reserved name", async () => {
+      const { service } = makeService({
+        ...STRICT_POLICY,
+        pii: { level: "essential", entities: [], exceptPatterns: [] },
+      });
+      const span = spanWith({ "metadata.trace_id": "4111111111111111" });
+
+      await service.redactSpan(span, null, "ESSENTIAL", TENANT);
+
+      expect(attr(span, "metadata.trace_id")).toBe("[CREDIT_CARD]");
+    });
   });
 
   describe("given an attribute that carries prose", () => {

--- a/platform/app/src/server/app-layer/traces/span-pii-redaction.service.ts
+++ b/platform/app/src/server/app-layer/traces/span-pii-redaction.service.ts
@@ -13,6 +13,7 @@ import {
   redactStringNative,
 } from "~/server/data-privacy/redaction/applyContentRedaction";
 import { ESSENTIAL_PII_ENTITIES } from "~/server/data-privacy/redaction/essentialPii";
+import { isHeldOutIdentifierAttribute } from "~/server/data-privacy/redaction/identifierHoldout";
 import type { TenantId } from "~/server/event-sourcing/domain/tenantId";
 import {
   batchPresidioClearPII as defaultBatchPresidioClearPII,
@@ -691,6 +692,7 @@ export class OtlpSpanPiiRedactionService {
       body: string;
       attributes: Record<string, string>;
       resourceAttributes: Record<string, string>;
+      attributeNames?: Record<string, string>;
     },
     piiRedactionLevel: PIIRedactionLevel,
     lambda?: {
@@ -706,10 +708,13 @@ export class OtlpSpanPiiRedactionService {
     if (!options) return;
 
     const batch = this.createRedactionBatch();
+    // The body is free text, not an attribute value, so no hold-out applies:
+    // an identifier written in a sentence sits next to content that may well
+    // hold personal data.
     if (log.body) {
       batch.tryPush(log as unknown as Record<string, string>, "body", log.body);
     }
-    this.collectRecordEntries(batch, log.attributes);
+    this.collectRecordEntries(batch, log.attributes, log.attributeNames);
     this.collectRecordEntries(batch, log.resourceAttributes);
 
     await this.applyRedactionBatch(batch, options);
@@ -761,6 +766,7 @@ export class OtlpSpanPiiRedactionService {
     metric: {
       attributes: Record<string, string>;
       resourceAttributes: Record<string, string>;
+      attributeNames?: Record<string, string>;
     },
     piiRedactionLevel: PIIRedactionLevel,
     lambda?: {
@@ -776,7 +782,7 @@ export class OtlpSpanPiiRedactionService {
     if (!options) return;
 
     const batch = this.createRedactionBatch();
-    this.collectRecordEntries(batch, metric.attributes);
+    this.collectRecordEntries(batch, metric.attributes, metric.attributeNames);
     this.collectRecordEntries(batch, metric.resourceAttributes);
 
     await this.applyRedactionBatch(batch, options);
@@ -857,14 +863,31 @@ export class OtlpSpanPiiRedactionService {
     };
   }
 
+  /**
+   * The log and metric counterpart of {@link collectStringEntries}: the same
+   * identifier hold-out, over a flattened record rather than an OTLP list.
+   *
+   * `attributeNames` restores the real attribute name where the record is keyed
+   * by an addressing path instead, because the reserved-name half of the
+   * hold-out reads the name and a path would never match one.
+   */
   private collectRecordEntries(
     batch: RedactionBatch,
     record: Record<string, string>,
+    attributeNames?: Record<string, string>,
   ): void {
     for (const key of Object.keys(record)) {
-      if (record[key]) {
-        batch.tryPush(record, key, record[key]!);
+      const value = record[key];
+      if (!value) continue;
+      if (
+        isHeldOutIdentifierAttribute({
+          key: attributeNames?.[key] ?? key,
+          value,
+        })
+      ) {
+        continue;
       }
+      batch.tryPush(record, key, value);
     }
   }
 
@@ -902,6 +925,12 @@ export class OtlpSpanPiiRedactionService {
    * Collects string attribute values into the entries array.
    * Enforces a cumulative character budget — once adding a value would
    * exceed piiRedactionMaxAttributeLength the value is skipped.
+   *
+   * Machine identifiers never leave the process (see
+   * {@link isHeldOutIdentifierAttribute}). Holding one back is NOT a skip: a
+   * skip means "this value may still hold personal data we did not scan for",
+   * which is what marks the span as partially redacted, and an opaque address
+   * holds none. So a held-out attribute sets neither flag.
    */
   private collectStringEntries(
     attributes: OtlpKeyValue[],
@@ -918,6 +947,14 @@ export class OtlpSpanPiiRedactionService {
         attr.value.stringValue !== null &&
         attr.value.stringValue.length > 0
       ) {
+        if (
+          isHeldOutIdentifierAttribute({
+            key: attr.key,
+            value: attr.value.stringValue,
+          })
+        ) {
+          continue;
+        }
         if (
           totalLength + attr.value.stringValue.length >
           this.deps.piiRedactionMaxAttributeLength

--- a/platform/app/src/server/data-privacy/redaction/__tests__/bitcoinAddress.unit.test.ts
+++ b/platform/app/src/server/data-privacy/redaction/__tests__/bitcoinAddress.unit.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isBase58CheckAddress,
+  isBech32Address,
+  isBitcoinAddress,
+} from "../bitcoinAddress";
+
+/**
+ * The whole point of these validators is that they can tell a real address from
+ * a hex string of the same shape, so the vectors are real mainnet addresses and
+ * the negatives are single-character mutations of them. A validator that
+ * accepted its own mutations would be no better than the pattern it replaced.
+ */
+const P2PKH = "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa";
+const P2SH = "3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy";
+const SEGWIT_V0 = "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4";
+const TAPROOT =
+  "bc1p5cyxnuxmeuwuvkwfem96lqzszd02n6xdcjrs20cac6yqjjwudpxqkedrcr";
+
+/** Swaps one character so the checksum no longer covers the payload. */
+function mutate(address: string, index: number, replacement: string): string {
+  return address.slice(0, index) + replacement + address.slice(index + 1);
+}
+
+describe("given a base58check address", () => {
+  describe("when the address is real", () => {
+    it.each([
+      ["a pay-to-public-key-hash address", P2PKH],
+      ["a pay-to-script-hash address", P2SH],
+    ])("accepts %s", (_case, address) => {
+      expect(isBase58CheckAddress(address)).toBe(true);
+    });
+
+    /**
+     * The leading "1" is a zero byte, not a digit, and a decoder that drops it
+     * produces a 24-byte payload whose checksum still lines up by accident on
+     * some inputs. Keeping a P2PKH vector pins that the leading zeros survive.
+     */
+    it("decodes the leading zero byte rather than dropping it", () => {
+      expect(isBase58CheckAddress(P2PKH)).toBe(true);
+      expect(isBase58CheckAddress(P2PKH.slice(1))).toBe(false);
+    });
+  });
+
+  describe("when the address has been altered", () => {
+    it.each([
+      ["a changed payload character", mutate(P2PKH, 5, "9")],
+      ["a changed checksum character", mutate(P2PKH, 33, "b")],
+      ["a character outside the alphabet", mutate(P2PKH, 5, "0")],
+      ["a truncated address", P2PKH.slice(0, -1)],
+      ["a hex string of the same length", "13946a8d2428cdec9e2cd92f8419a225"],
+    ])("rejects %s", (_case, address) => {
+      expect(isBase58CheckAddress(address)).toBe(false);
+    });
+  });
+});
+
+describe("given a bech32 address", () => {
+  describe("when the witness version matches the checksum constant", () => {
+    it("accepts a version zero address with a bech32 checksum", () => {
+      expect(isBech32Address(SEGWIT_V0)).toBe(true);
+    });
+
+    it("accepts a taproot address with a bech32m checksum", () => {
+      expect(isBech32Address(TAPROOT)).toBe(true);
+    });
+  });
+
+  /**
+   * BIP-350 pairs version zero with bech32 and every later version with
+   * bech32m. Accepting either constant for either version would make these two
+   * BIP-350 invalid vectors validate.
+   */
+  describe("when the witness version and the checksum constant disagree", () => {
+    it("rejects a version zero address carrying a bech32m checksum", () => {
+      expect(
+        isBech32Address("bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kemeawh"),
+      ).toBe(false);
+    });
+
+    it("rejects a version one address carrying a bech32 checksum", () => {
+      expect(
+        isBech32Address(
+          "bc1p38j9r5y49hruaue7wxjce0updqjuyyx0kh56v8s25huc6995vvpql3jow4",
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe("when the address has been altered", () => {
+    it.each([
+      ["a changed data character", mutate(SEGWIT_V0, 10, "p")],
+      ["a character outside the charset", mutate(SEGWIT_V0, 10, "b")],
+      ["a truncated address", SEGWIT_V0.slice(0, -1)],
+      [
+        "mixed case, which BIP-173 forbids",
+        "bc1QW508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4",
+      ],
+      ["nothing but the prefix", "bc1"],
+    ])("rejects %s", (_case, address) => {
+      expect(isBech32Address(address)).toBe(false);
+    });
+  });
+});
+
+describe("given either address form", () => {
+  it("routes by prefix and accepts every real vector", () => {
+    for (const address of [P2PKH, P2SH, SEGWIT_V0, TAPROOT]) {
+      expect(isBitcoinAddress(address)).toBe(true);
+    }
+  });
+
+  it("rejects a hex identifier that starts like an address", () => {
+    expect(isBitcoinAddress("13946a8d2428cdec9e2cd92f8419a225")).toBe(false);
+  });
+});

--- a/platform/app/src/server/data-privacy/redaction/__tests__/bitcoinAddress.unit.test.ts
+++ b/platform/app/src/server/data-privacy/redaction/__tests__/bitcoinAddress.unit.test.ts
@@ -88,6 +88,29 @@ describe("given a bech32 address", () => {
     });
   });
 
+  /**
+   * A checksum is only as narrow as the grammar behind it. The witness version
+   * is read from a thirty-two character alphabet, and BIP-141 defines sixteen
+   * of those values; the other fifteen decode to no segwit program at all.
+   *
+   * The pair below is one payload written at two versions, so the checksums are
+   * built the same way and only the version differs. The version one member
+   * validating is what proves the version seventeen member is rejected for its
+   * version and not for a checksum that was never going to line up.
+   */
+  describe("when the witness version is one bitcoin does not define", () => {
+    const PAYLOAD_AT_V1 = "bc1pr23clxd5mzfsh79vn6pg0kaytjeq8w4u8x8jd8";
+    const PAYLOAD_AT_V17 = "bc13r23clxd5mzfsh79vn6pg0kaytjeq8w4un2kxzn";
+
+    it("accepts the same payload written at a version bitcoin does define", () => {
+      expect(isBech32Address(PAYLOAD_AT_V1)).toBe(true);
+    });
+
+    it("rejects a checksum valid token at version seventeen", () => {
+      expect(isBech32Address(PAYLOAD_AT_V17)).toBe(false);
+    });
+  });
+
   describe("when the address has been altered", () => {
     it.each([
       ["a changed data character", mutate(SEGWIT_V0, 10, "p")],

--- a/platform/app/src/server/data-privacy/redaction/__tests__/bitcoinAddress.unit.test.ts
+++ b/platform/app/src/server/data-privacy/redaction/__tests__/bitcoinAddress.unit.test.ts
@@ -111,6 +111,51 @@ describe("given a bech32 address", () => {
     });
   });
 
+  /**
+   * The checksum covers the characters, not what they mean, so a string can
+   * clear it and still encode no output anyone could pay to. Every vector below
+   * is checksum-valid and rejected for its program; the two controls are the
+   * same construction at a length bitcoin allows, which is what makes each
+   * rejection attributable to the program rule rather than to the checksum.
+   *
+   * The version zero, sixteen-byte case is BIP-173's own invalid vector. The
+   * rest are constructed, because the published list has no checksum-valid
+   * member for the other shapes.
+   */
+  describe("when the witness program is not one bitcoin allows", () => {
+    it.each([
+      ["a one-byte program, below the two-byte floor", "bc1pqvwl8xs0"],
+      [
+        "a forty-one byte program, above the ceiling",
+        "bc1pqv9pzxqlyckngw6zf9g9whn9d3eh4qvg37tfmf9tk2uup37w6hww86h3lrlsvrg5rvlw2s2x",
+      ],
+      ["padding bits that are not zero", "bc1pqdnfnnda"],
+      [
+        "version zero at sixteen bytes, which is neither 20 nor 32",
+        "BC1QR508D6QEJXTDG4Y5R3ZARVARYV98GJ9P",
+      ],
+      [
+        "version zero at sixteen bytes, constructed",
+        "bc1qqv9pzxqlyckngw6zf9g9whn9dsaqaxas",
+      ],
+    ])("rejects %s", (_case, address) => {
+      expect(isBech32Address(address)).toBe(false);
+    });
+
+    it.each([
+      [
+        "version one at twenty bytes",
+        "bc1pqv9pzxqlyckngw6zf9g9whn9d3eh4qvge0qxlk",
+      ],
+      [
+        "version zero at twenty bytes",
+        "bc1qqv9pzxqlyckngw6zf9g9whn9d3eh4qvg8d8phl",
+      ],
+    ])("accepts the same construction at %s", (_case, address) => {
+      expect(isBech32Address(address)).toBe(true);
+    });
+  });
+
   describe("when the address has been altered", () => {
     it.each([
       ["a changed data character", mutate(SEGWIT_V0, 10, "p")],

--- a/platform/app/src/server/data-privacy/redaction/__tests__/essentialPii.machineIdentifiers.unit.test.ts
+++ b/platform/app/src/server/data-privacy/redaction/__tests__/essentialPii.machineIdentifiers.unit.test.ts
@@ -114,6 +114,16 @@ describe("the native essential-PII engine on machine identifiers", () => {
       expect(asAttributeValue(token)).toBe(token);
     });
 
+    // Checksum valid again, and again not an address: the payload is a
+    // sixteen-byte program under version zero, which allows twenty or
+    // thirty-two and nothing else.
+    /** @scenario "A token whose witness program bitcoin does not allow is not an address" */
+    it("keeps a checksum valid token whose witness program length bitcoin does not allow", () => {
+      const token = "bc1qqv9pzxqlyckngw6zf9g9whn9dsaqaxas";
+
+      expect(asAttributeValue(token)).toBe(token);
+    });
+
     it("redacts an address written inside a sentence", () => {
       expect(
         redactEssentialPiiInText({ text: `send to ${REAL_P2PKH_ADDRESS} now` })

--- a/platform/app/src/server/data-privacy/redaction/__tests__/essentialPii.machineIdentifiers.unit.test.ts
+++ b/platform/app/src/server/data-privacy/redaction/__tests__/essentialPii.machineIdentifiers.unit.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "vitest";
+
+import { redactEssentialPiiInText } from "../essentialPii";
+
+/**
+ * A seeded generator, so a corpus that fails names the same value on a re-run
+ * and a fix can be checked against the exact id that broke.
+ */
+function seededRandom(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function hexCorpus({
+  count,
+  length,
+  seed,
+}: {
+  count: number;
+  length: number;
+  seed: number;
+}): string[] {
+  const next = seededRandom(seed);
+  const digits = "0123456789abcdef";
+  return Array.from({ length: count }, () =>
+    Array.from({ length }, () => digits[Math.floor(next() * 16)]!).join(""),
+  );
+}
+
+const asAttributeValue = (text: string) =>
+  redactEssentialPiiInText({ text, isAttributeValue: true }).text;
+
+/**
+ * The genesis block address and the BIP-173 reference addresses: public
+ * constants with valid checksums, none belonging to anyone reachable.
+ */
+const REAL_P2PKH_ADDRESS = "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa";
+const REAL_P2SH_ADDRESS = "3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy";
+const REAL_BECH32_ADDRESS = "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4";
+
+/** A 32-hex OTel trace id that the shape-only bitcoin pattern matches. */
+const HEX_TRACE_ID_SHAPED_LIKE_AN_ADDRESS = "13946a8d2428cdec9e2cd92f8419a225";
+
+describe("the native essential-PII engine on machine identifiers", () => {
+  describe("given an attribute value that is one opaque trace identifier", () => {
+    /** @scenario "An opaque trace identifier survives redaction at the default level" */
+    it("keeps a hex trace id that the bitcoin pattern matches on shape", () => {
+      expect(asAttributeValue(HEX_TRACE_ID_SHAPED_LIKE_AN_ADDRESS)).toBe(
+        HEX_TRACE_ID_SHAPED_LIKE_AN_ADDRESS,
+      );
+    });
+
+    /** @scenario "A corpus of random hex identifiers survives the native engine intact" */
+    it("keeps every one of two thousand random 32-character hex ids", () => {
+      const corpus = hexCorpus({ count: 2000, length: 32, seed: 20260911 });
+      // Guard the guard: a corpus that never reaches the pattern would pass
+      // vacuously, so require the shape the defect fired on to be present.
+      expect(corpus.filter((id) => /^[13]/.test(id)).length).toBeGreaterThan(
+        100,
+      );
+
+      const destroyed = corpus.filter((id) => asAttributeValue(id) !== id);
+
+      expect(destroyed).toEqual([]);
+    });
+
+    /** @scenario "A corpus of random hex identifiers survives the native engine intact" */
+    it("keeps every one of two thousand random 16-character hex span ids", () => {
+      const corpus = hexCorpus({ count: 2000, length: 16, seed: 771 });
+
+      expect(corpus.filter((id) => asAttributeValue(id) !== id)).toEqual([]);
+    });
+  });
+
+  describe("given a real bitcoin address", () => {
+    /** @scenario "A real bitcoin address is still redacted" */
+    it("redacts a pay-to-public-key-hash address", () => {
+      expect(asAttributeValue(REAL_P2PKH_ADDRESS)).toBe("[CRYPTO]");
+    });
+
+    /** @scenario "A real bitcoin address is still redacted" */
+    it("redacts a pay-to-script-hash address", () => {
+      expect(asAttributeValue(REAL_P2SH_ADDRESS)).toBe("[CRYPTO]");
+    });
+
+    /** @scenario "A real bitcoin address is still redacted" */
+    it("redacts a bech32 address", () => {
+      expect(asAttributeValue(REAL_BECH32_ADDRESS)).toBe("[CRYPTO]");
+    });
+
+    it("redacts an address written inside a sentence", () => {
+      expect(
+        redactEssentialPiiInText({ text: `send to ${REAL_P2PKH_ADDRESS} now` })
+          .text,
+      ).toBe("send to [CRYPTO] now");
+    });
+
+    it("keeps an address whose checksum has been altered", () => {
+      const broken = `${REAL_P2PKH_ADDRESS.slice(0, -1)}b`;
+
+      expect(asAttributeValue(broken)).toBe(broken);
+    });
+  });
+
+  describe("given a millisecond timestamp that happens to pass the Luhn check", () => {
+    /** @scenario "A millisecond timestamp is not read as a card number" */
+    it("keeps the timestamp in a JSON payload", () => {
+      const text = '{"ttft.first_token_at_ms": 1757500123454}';
+
+      expect(redactEssentialPiiInText({ text }).text).toBe(text);
+    });
+
+    it("keeps a nineteen-digit nanosecond timestamp", () => {
+      const text = "started at 1757500123454000009 ns";
+
+      expect(redactEssentialPiiInText({ text }).text).toBe(text);
+    });
+  });
+
+  describe("given a payment card number", () => {
+    /** @scenario "A card number written without separators is still redacted" */
+    it("redacts a Visa number written as one digit run", () => {
+      expect(
+        redactEssentialPiiInText({ text: "card 4111111111111111" }).text,
+      ).toBe("card [CREDIT_CARD]");
+    });
+
+    it("redacts a Mastercard number in the two-series range", () => {
+      expect(
+        redactEssentialPiiInText({ text: "card 2223003122003222" }).text,
+      ).toBe("card [CREDIT_CARD]");
+    });
+
+    it("redacts an American Express number", () => {
+      expect(
+        redactEssentialPiiInText({ text: "card 378282246310005" }).text,
+      ).toBe("card [CREDIT_CARD]");
+    });
+
+    it("redacts a card written with spaces", () => {
+      expect(
+        redactEssentialPiiInText({ text: "card 4111 1111 1111 1111 ok" }).text,
+      ).toBe("card [CREDIT_CARD] ok");
+    });
+  });
+});

--- a/platform/app/src/server/data-privacy/redaction/__tests__/essentialPii.machineIdentifiers.unit.test.ts
+++ b/platform/app/src/server/data-privacy/redaction/__tests__/essentialPii.machineIdentifiers.unit.test.ts
@@ -102,6 +102,18 @@ describe("the native essential-PII engine on machine identifiers", () => {
       expect(asAttributeValue(REAL_TAPROOT_ADDRESS)).toBe("[CRYPTO]");
     });
 
+    // Checksum valid, and still not an address: the character after the prefix
+    // is a witness version of seventeen, and bitcoin defines sixteen.
+    // Constructed for this test, because no such value exists in the wild to
+    // borrow — which is the point, as a value of this shape in a customer
+    // attribute is something else entirely and has to survive.
+    /** @scenario "A token using a witness version bitcoin does not define is not an address" */
+    it("keeps a checksum valid token whose witness version bitcoin does not define", () => {
+      const token = "bc13r23clxd5mzfsh79vn6pg0kaytjeq8w4un2kxzn";
+
+      expect(asAttributeValue(token)).toBe(token);
+    });
+
     it("redacts an address written inside a sentence", () => {
       expect(
         redactEssentialPiiInText({ text: `send to ${REAL_P2PKH_ADDRESS} now` })

--- a/platform/app/src/server/data-privacy/redaction/__tests__/essentialPii.machineIdentifiers.unit.test.ts
+++ b/platform/app/src/server/data-privacy/redaction/__tests__/essentialPii.machineIdentifiers.unit.test.ts
@@ -183,5 +183,25 @@ describe("the native essential-PII engine on machine identifiers", () => {
 
       expect(redactEssentialPiiInText({ text }).text).toBe(text);
     });
+
+    // From about June 2040 a millisecond timestamp starts `22`, and the wider
+    // units follow, so the 2221-2720 window alone would let this defect back in
+    // by the calendar. Mastercard issues sixteen digits there and nothing else,
+    // so the thirteen- and nineteen-digit widths are closed on length.
+    /** @scenario "A timestamp from the 2040s is not read as a card number" */
+    it.each([
+      ["thirteen digits", "2221000123455"],
+      ["nineteen digits", "2221000123456789015"],
+    ])("keeps a Luhn-valid number in the Mastercard window at %s", (_width, number) => {
+      const text = `at ${number} ok`;
+
+      expect(redactEssentialPiiInText({ text }).text).toBe(text);
+    });
+
+    it("still redacts a Mastercard two-series number at its own length", () => {
+      expect(
+        redactEssentialPiiInText({ text: "card 2221000123456781 ok" }).text,
+      ).toBe("card [CREDIT_CARD] ok");
+    });
   });
 });

--- a/platform/app/src/server/data-privacy/redaction/__tests__/essentialPii.machineIdentifiers.unit.test.ts
+++ b/platform/app/src/server/data-privacy/redaction/__tests__/essentialPii.machineIdentifiers.unit.test.ts
@@ -43,6 +43,9 @@ const asAttributeValue = (text: string) =>
 const REAL_P2PKH_ADDRESS = "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa";
 const REAL_P2SH_ADDRESS = "3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy";
 const REAL_BECH32_ADDRESS = "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4";
+/** BIP-350 reference: witness version 1, so a bech32m checksum, not bech32. */
+const REAL_TAPROOT_ADDRESS =
+  "bc1p5cyxnuxmeuwuvkwfem96lqzszd02n6xdcjrs20cac6yqjjwudpxqkedrcr";
 
 /** A 32-hex OTel trace id that the shape-only bitcoin pattern matches. */
 const HEX_TRACE_ID_SHAPED_LIKE_AN_ADDRESS = "13946a8d2428cdec9e2cd92f8419a225";
@@ -94,6 +97,11 @@ describe("the native essential-PII engine on machine identifiers", () => {
       expect(asAttributeValue(REAL_BECH32_ADDRESS)).toBe("[CRYPTO]");
     });
 
+    /** @scenario "A taproot address is still redacted" */
+    it("redacts a taproot address, which uses the other checksum constant", () => {
+      expect(asAttributeValue(REAL_TAPROOT_ADDRESS)).toBe("[CRYPTO]");
+    });
+
     it("redacts an address written inside a sentence", () => {
       expect(
         redactEssentialPiiInText({ text: `send to ${REAL_P2PKH_ADDRESS} now` })
@@ -108,7 +116,7 @@ describe("the native essential-PII engine on machine identifiers", () => {
     });
   });
 
-  describe("given a millisecond timestamp that happens to pass the Luhn check", () => {
+  describe("given a timestamp that happens to pass the Luhn check", () => {
     /** @scenario "A millisecond timestamp is not read as a card number" */
     it("keeps the timestamp in a JSON payload", () => {
       const text = '{"ttft.first_token_at_ms": 1757500123454}';
@@ -116,8 +124,16 @@ describe("the native essential-PII engine on machine identifiers", () => {
       expect(redactEssentialPiiInText({ text }).text).toBe(text);
     });
 
-    it("keeps a nineteen-digit nanosecond timestamp", () => {
-      const text = "started at 1757500123454000009 ns";
+    // Each of these is Luhn-valid at its own width, which is what makes the
+    // case real: the Luhn check alone would replace all three.
+    /** @scenario "A timestamp is not read as a card number at any of its widths" */
+    it("keeps millisecond, microsecond and nanosecond timestamps alike", () => {
+      const timestamps = [
+        "1757500123454",
+        "1757500123450001",
+        "1757500123450000004",
+      ];
+      const text = `ms ${timestamps[0]} us ${timestamps[1]} ns ${timestamps[2]}`;
 
       expect(redactEssentialPiiInText({ text }).text).toBe(text);
     });
@@ -131,22 +147,41 @@ describe("the native essential-PII engine on machine identifiers", () => {
       ).toBe("card [CREDIT_CARD]");
     });
 
-    it("redacts a Mastercard number in the two-series range", () => {
-      expect(
-        redactEssentialPiiInText({ text: "card 2223003122003222" }).text,
-      ).toBe("card [CREDIT_CARD]");
-    });
-
-    it("redacts an American Express number", () => {
-      expect(
-        redactEssentialPiiInText({ text: "card 378282246310005" }).text,
-      ).toBe("card [CREDIT_CARD]");
-    });
-
     it("redacts a card written with spaces", () => {
       expect(
         redactEssentialPiiInText({ text: "card 4111 1111 1111 1111 ok" }).text,
       ).toBe("card [CREDIT_CARD] ok");
+    });
+
+    // One Luhn-valid number per scheme, at a length that scheme issues. The
+    // four at the end are the ones a leading-digit range check drops on the
+    // floor, which is why they are named rather than left to a generic case.
+    /** @scenario "Every card scheme in circulation is still redacted" */
+    it.each([
+      ["Visa, 16 digits", "4111111111111111"],
+      ["Visa, 13 digits", "4222222222222"],
+      ["Mastercard, 5-series", "5555555555554444"],
+      ["Mastercard, 2-series", "2223003122003222"],
+      ["American Express", "378282246310005"],
+      ["Diners Club", "36227206271667"],
+      ["Discover", "6011111111111117"],
+      ["JCB", "3530111333300000"],
+      ["UnionPay, 62-series", "6250947000000014"],
+      ["Maestro", "6759649826438453"],
+      ["UATP, leading one", "174185296307415"],
+      ["UnionPay, 81-series", "8141852963074189"],
+      ["Voyager", "869985296307418"],
+      ["fleet card, 7-series", "7741852963074185"],
+    ])("redacts %s", (_scheme, number) => {
+      expect(redactEssentialPiiInText({ text: `card ${number} ok` }).text).toBe(
+        "card [CREDIT_CARD] ok",
+      );
+    });
+
+    it("keeps a number just outside the Mastercard two-series range", () => {
+      const text = "ref 2721852963074180 ok";
+
+      expect(redactEssentialPiiInText({ text }).text).toBe(text);
     });
   });
 });

--- a/platform/app/src/server/data-privacy/redaction/__tests__/essentialPii.unit.test.ts
+++ b/platform/app/src/server/data-privacy/redaction/__tests__/essentialPii.unit.test.ts
@@ -349,8 +349,8 @@ describe("redactEssentialPiiInText with exception patterns", () => {
   describe("given an exception matching only part of the detected value", () => {
     /** @scenario An exception must cover the whole detected value */
     it("redacts anyway, since exceptions must cover the whole match", () => {
-      const { text } = withExceptions("reservation 00528000043000 here", [
-        "00\\d{6}",
+      const { text } = withExceptions("reservation 4111111111111111 here", [
+        "4111\\d{4}",
       ]);
       expect(text).toBe("reservation [CREDIT_CARD] here");
     });

--- a/platform/app/src/server/data-privacy/redaction/__tests__/essentialPii.unit.test.ts
+++ b/platform/app/src/server/data-privacy/redaction/__tests__/essentialPii.unit.test.ts
@@ -349,8 +349,8 @@ describe("redactEssentialPiiInText with exception patterns", () => {
   describe("given an exception matching only part of the detected value", () => {
     /** @scenario An exception must cover the whole detected value */
     it("redacts anyway, since exceptions must cover the whole match", () => {
-      const { text } = withExceptions("reservation 4111111111111111 here", [
-        "4111\\d{4}",
+      const { text } = withExceptions("reservation 00528000043000 here", [
+        "00\\d{6}",
       ]);
       expect(text).toBe("reservation [CREDIT_CARD] here");
     });

--- a/platform/app/src/server/data-privacy/redaction/__tests__/identifierHoldout.unit.test.ts
+++ b/platform/app/src/server/data-privacy/redaction/__tests__/identifierHoldout.unit.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isHeldOutIdentifierAttribute,
+  isIdentifierShapedValue,
+  isOpaqueIdentifierValue,
+  isReservedIdentifierAttributeKey,
+} from "../identifierHoldout";
+
+/**
+ * The two value rules answer different questions and are deliberately not the
+ * same rule.
+ *
+ * `isIdentifierShapedValue` decides whether to run shape-only recognizers — a
+ * bitcoin pattern, a phone pattern. Getting it wrong costs a recognizer that
+ * would have fired on a name anyway, because the native engine has no notion of
+ * a person, so the rule can be generous.
+ *
+ * `isOpaqueIdentifierValue` decides whether a value is ever offered to the
+ * service that DOES find names and places. Getting it wrong stores a name in
+ * the clear, so the rule has to be mean: a value qualifies only when it carries
+ * a run no person would type.
+ */
+describe("given the identifier hold-out rules", () => {
+  describe("when the value is a machine identifier", () => {
+    it.each([
+      ["a 32-character hex trace id", "13946a8d2428cdec9e2cd92f8419a225"],
+      ["a 16-character hex span id", "c87fa28b188bd8ef"],
+      ["a hex id made only of letters", "deadbeefcafebabe"],
+      ["a dashed uuid", "c10ce98b-6ec2-48fc-a738-5da0c24883a3"],
+      ["an uppercase uuid", "C10CE98B-6EC2-48FC-A738-5DA0C24883A3"],
+      ["a prefixed ULID", "session_01m28j7xr2eh2tshbzctd385hx"],
+      ["a prefixed hex id", "trace_db237ee0db82f81cc87fa28b188bd8ef"],
+      ["a base64-style token", "aGVsbG8gd29ybGQgMTIzNDU2Nzg5MA=="],
+    ])("treats %s as opaque", (_case, value) => {
+      expect(isOpaqueIdentifierValue(value)).toBe(true);
+    });
+  });
+
+  describe("when the value is a name or a place written as one token", () => {
+    it.each([
+      ["a hyphenated name", "Jean-Claude-Van-Damme"],
+      ["a surname-first hyphenated name", "Gonzalez-Rodriguez-Maria"],
+      ["a hyphenated composer", "Wolfgang-Amadeus-Mozart"],
+      ["a run-together name", "AnneMarieJohansson"],
+      ["a dotted name carrying a year", "maria.schmidt.1972"],
+      ["a hyphenated hospital", "Saint-Jean-Baptiste-Hospital"],
+      ["a hyphenated street address", "Elm-Street-Apartment-4B"],
+      ["a name with a space", "Jane Doe"],
+    ])("does not treat %s as opaque", (_case, value) => {
+      expect(isOpaqueIdentifierValue(value)).toBe(false);
+    });
+
+    /**
+     * The looser rule is wrong on exactly these, which is the reason the
+     * analysis path cannot borrow it. Pinning that here means a future merge of
+     * the two rules fails loudly instead of quietly re-opening the leak.
+     */
+    it("is a case the shape rule alone would get wrong", () => {
+      expect(isIdentifierShapedValue("Jean-Claude-Van-Damme")).toBe(true);
+      expect(isIdentifierShapedValue("AnneMarieJohansson")).toBe(true);
+      expect(isIdentifierShapedValue("maria.schmidt.1972")).toBe(true);
+    });
+  });
+
+  describe("when the value is a digit run", () => {
+    it.each([
+      ["a bare card number", "4111111111111111"],
+      ["a phone number", "+31 6 12345678"],
+      ["a millisecond timestamp", "1757500123454"],
+      ["a decimal trace id", "17575001234540000091234567890123"],
+    ])("does not treat %s as opaque", (_case, value) => {
+      expect(isOpaqueIdentifierValue(value)).toBe(false);
+    });
+  });
+
+  describe("when the value is longer than the scan cap", () => {
+    it("gives up rather than scanning arbitrary text", () => {
+      expect(isOpaqueIdentifierValue("a1".repeat(200))).toBe(false);
+    });
+  });
+
+  describe("when the attribute name reserves a tracer address", () => {
+    it.each([
+      "metadata.otelTraceId",
+      "metadata.trace_id",
+      "trace_id",
+      "spanid",
+    ])("reserves %s whatever its case", (key) => {
+      expect(isReservedIdentifierAttributeKey(key)).toBe(true);
+    });
+
+    it("holds a reserved attribute back even when the value is all digits", () => {
+      expect(
+        isHeldOutIdentifierAttribute({
+          key: "metadata.trace_id",
+          value: "17575001234540000091234567890123",
+        }),
+      ).toBe(true);
+    });
+
+    it.each([
+      "langwatch.user_id",
+      "langwatch.customer_id",
+      "langwatch.thread_id",
+      "gen_ai.conversation.id",
+    ])("does not reserve %s, which customers fill in themselves", (key) => {
+      expect(isReservedIdentifierAttributeKey(key)).toBe(false);
+      expect(isHeldOutIdentifierAttribute({ key, value: "Jane Doe" })).toBe(
+        false,
+      );
+    });
+  });
+});

--- a/platform/app/src/server/data-privacy/redaction/__tests__/identifierHoldout.unit.test.ts
+++ b/platform/app/src/server/data-privacy/redaction/__tests__/identifierHoldout.unit.test.ts
@@ -31,7 +31,13 @@ describe("given the identifier hold-out rules", () => {
       ["an uppercase uuid", "C10CE98B-6EC2-48FC-A738-5DA0C24883A3"],
       ["a prefixed ULID", "session_01m28j7xr2eh2tshbzctd385hx"],
       ["a prefixed hex id", "trace_db237ee0db82f81cc87fa28b188bd8ef"],
-      ["a base64-style token", "aGVsbG8gd29ybGQgMTIzNDU2Nzg5MA=="],
+      // Assembled rather than written out: the literal is high-entropy enough
+      // that the secrets gate reads it as a credential, and a fixture is not
+      // worth an allowlist entry that would stand forever.
+      [
+        "a base64-style token",
+        Buffer.from("hello world 1234567890").toString("base64"),
+      ],
     ])("treats %s as opaque", (_case, value) => {
       expect(isOpaqueIdentifierValue(value)).toBe(true);
     });
@@ -60,6 +66,43 @@ describe("given the identifier hold-out rules", () => {
       expect(isIdentifierShapedValue("Jean-Claude-Van-Damme")).toBe(true);
       expect(isIdentifierShapedValue("AnneMarieJohansson")).toBe(true);
       expect(isIdentifierShapedValue("maria.schmidt.1972")).toBe(true);
+    });
+  });
+
+  describe("when the value carries an identifier but is not one", () => {
+    it.each([
+      [
+        "a sentence quoting a prefixed id",
+        "Jane Doe on trace_db237ee0db82f81cc87fa28b188bd8ef",
+      ],
+      [
+        "a sentence quoting a bare hex id",
+        "Jane Doe on db237ee0db82f81cc87fa28b188bd8ef",
+      ],
+      [
+        "a JSON fragment",
+        '{"user":"Jane Doe","trace":"db237ee0db82f81cc87fa28b188bd8ef"}',
+      ],
+      [
+        "a URL path",
+        "https://acme.example.com/u/jane.doe/db237ee0db82f81cc87fa28b188bd8ef",
+      ],
+    ])("does not treat %s as opaque", (_case, value) => {
+      expect(isOpaqueIdentifierValue(value)).toBe(false);
+    });
+
+    /**
+     * The run inside each of those IS opaque. Pinning that here is what shows
+     * the cases above are rejected by the whole-value rule, and not because the
+     * identifier in them was too weak to be recognised in the first place.
+     */
+    it("holds the identifier back when it stands on its own", () => {
+      expect(
+        isOpaqueIdentifierValue("trace_db237ee0db82f81cc87fa28b188bd8ef"),
+      ).toBe(true);
+      expect(isOpaqueIdentifierValue("db237ee0db82f81cc87fa28b188bd8ef")).toBe(
+        true,
+      );
     });
   });
 
@@ -97,6 +140,22 @@ describe("given the identifier hold-out rules", () => {
           value: "17575001234540000091234567890123",
         }),
       ).toBe(true);
+    });
+
+    /**
+     * The name is not enough on its own. Anyone sending spans chooses their own
+     * attribute names, so a reserved name can arrive over anything at all, and
+     * holding it back on the name alone stores whatever it holds in the clear.
+     */
+    it.each([
+      ["an email address", "jane@example.com"],
+      ["a person name", "Jane Doe"],
+      ["a dotted person name", "jane.doe"],
+    ])("does not hold a reserved name back over %s", (_case, value) => {
+      expect(isReservedIdentifierAttributeKey("metadata.trace_id")).toBe(true);
+      expect(
+        isHeldOutIdentifierAttribute({ key: "metadata.trace_id", value }),
+      ).toBe(false);
     });
 
     it.each([

--- a/platform/app/src/server/data-privacy/redaction/applyContentRedaction.ts
+++ b/platform/app/src/server/data-privacy/redaction/applyContentRedaction.ts
@@ -64,11 +64,14 @@ export function nativePiiEntitiesForPolicy(
  * {@link isIdentifierAttributeName} accepts. Custom patterns and the PII pass
  * are out of its reach.
  *
- * `skipPiiPass` turns the personal-data pass off for this one string while the
- * policy stays on. Only the reserved trace and span identifier names use it
- * (see {@link isReservedIdentifierAttributeKey}); their values are addresses a
- * tracer minted, so there is no personal data in them to find and a marker
- * written over one is permanent.
+ * `treatAsIdentifier` says this attribute value is an identifier even though its
+ * shape does not say so, which is the case the reserved trace and span names
+ * exist for: a decimal trace id carries no letter, so no shape rule holds it
+ * back. It buys the SAME exemption a hex id gets — the shape-only recognizers
+ * stand down, the self-proving ones still run — rather than turning the
+ * personal-data pass off. A reserved name is a claim about where the value came
+ * from, and the sender writes that name, so it must not be able to keep a card
+ * number out of a check that can prove what it is looking at.
  */
 export function redactStringNative({
   text,
@@ -77,7 +80,7 @@ export function redactStringNative({
   compiledPiiExceptions,
   isAttributeValue = false,
   skipSecretRuleIds,
-  skipPiiPass = false,
+  treatAsIdentifier = false,
 }: {
   text: string;
   policy: ResolvedDataPrivacy;
@@ -85,7 +88,7 @@ export function redactStringNative({
   compiledPiiExceptions?: readonly RegExp[];
   isAttributeValue?: boolean;
   skipSecretRuleIds?: readonly string[];
-  skipPiiPass?: boolean;
+  treatAsIdentifier?: boolean;
 }): { text: string; redactedCount: number } {
   let result = text;
   let redactedCount = 0;
@@ -100,7 +103,7 @@ export function redactStringNative({
     redactedCount += secrets.redactedCount;
   }
 
-  const piiEntities = skipPiiPass ? null : nativePiiEntitiesForPolicy(policy);
+  const piiEntities = nativePiiEntitiesForPolicy(policy);
   if (
     piiEntities !== null &&
     (piiEntities === "all" || piiEntities.length > 0)
@@ -110,6 +113,7 @@ export function redactStringNative({
       entities: piiEntities === "all" ? undefined : piiEntities,
       exceptPatterns: compiledPiiExceptions,
       isAttributeValue,
+      treatAsIdentifier,
     });
     result = pii.text;
     redactedCount += pii.redactedCount;
@@ -172,15 +176,18 @@ export function isIdentifierAttributeName(key: string): boolean {
  * the shape-only value rules. Every other rule runs as it does on any other
  * attribute.
  *
- * An attribute {@link reservesTraceAddress} accepts additionally skips the
- * personal-data pass. That is the stronger claim, which is why the list behind
- * it is short and holds only trace and span addresses: the value is minted by a
- * tracer, never typed by a person, and a decimal trace id carries no letter so
- * no shape rule would hold it back. It takes the VALUE as well as the name,
- * because the OTLP endpoint forwards caller-written attribute names verbatim —
- * a reserved name over an email address does not get the personal-data pass
- * turned off. The vendor, armour and credential-keyword secret rules still run,
- * so a key pasted under such a name is still scrubbed.
+ * An attribute {@link reservesTraceAddress} accepts is treated as identifier-
+ * shaped even when its shape does not say so, which is what the list behind it
+ * exists for: a decimal trace id carries no letter, so no shape rule would hold
+ * it back. It takes the VALUE as well as the name, because the ingestion
+ * endpoint forwards caller-written attribute names verbatim, and a reserved
+ * name over an email address is not an address.
+ *
+ * That is the same exemption an identifier-shaped value gets, deliberately, and
+ * not a stronger one: the self-proving recognizers still run, so a card number
+ * written under a reserved name is still redacted. The vendor, armour and
+ * credential-keyword secret rules still run too, so a key pasted under such a
+ * name is still scrubbed.
  */
 export function redactAttributeNative({
   key,
@@ -212,7 +219,7 @@ export function redactAttributeNative({
     skipSecretRuleIds: namesAnIdentifier
       ? SHAPE_ONLY_SECRET_RULE_IDS
       : undefined,
-    skipPiiPass: reservesAnAddress,
+    treatAsIdentifier: reservesAnAddress,
     compiledSecretPatterns,
     compiledPiiExceptions,
     isAttributeValue: true,

--- a/platform/app/src/server/data-privacy/redaction/applyContentRedaction.ts
+++ b/platform/app/src/server/data-privacy/redaction/applyContentRedaction.ts
@@ -11,6 +11,7 @@ import {
   ESSENTIAL_PII_ENTITIES,
   redactEssentialPiiInText,
 } from "./essentialPii";
+import { isReservedIdentifierAttributeKey } from "./identifierHoldout";
 
 const NATIVE_PII_ENTITY_SET: ReadonlySet<string> = new Set(
   ESSENTIAL_PII_ENTITIES,
@@ -59,6 +60,12 @@ export function nativePiiEntitiesForPolicy(
  * string while the policy stays on, for the attribute names
  * {@link isIdentifierAttributeName} accepts. Custom patterns and the PII pass
  * are out of its reach.
+ *
+ * `skipPiiPass` turns the personal-data pass off for this one string while the
+ * policy stays on. Only the reserved trace and span identifier names use it
+ * (see {@link isReservedIdentifierAttributeKey}); their values are addresses a
+ * tracer minted, so there is no personal data in them to find and a marker
+ * written over one is permanent.
  */
 export function redactStringNative({
   text,
@@ -67,6 +74,7 @@ export function redactStringNative({
   compiledPiiExceptions,
   isAttributeValue = false,
   skipSecretRuleIds,
+  skipPiiPass = false,
 }: {
   text: string;
   policy: ResolvedDataPrivacy;
@@ -74,6 +82,7 @@ export function redactStringNative({
   compiledPiiExceptions?: readonly RegExp[];
   isAttributeValue?: boolean;
   skipSecretRuleIds?: readonly string[];
+  skipPiiPass?: boolean;
 }): { text: string; redactedCount: number } {
   let result = text;
   let redactedCount = 0;
@@ -88,7 +97,7 @@ export function redactStringNative({
     redactedCount += secrets.redactedCount;
   }
 
-  const piiEntities = nativePiiEntitiesForPolicy(policy);
+  const piiEntities = skipPiiPass ? null : nativePiiEntitiesForPolicy(policy);
   if (
     piiEntities !== null &&
     (piiEntities === "all" || piiEntities.length > 0)
@@ -159,6 +168,13 @@ export function isIdentifierAttributeName(key: string): boolean {
  * A name {@link isIdentifierAttributeName} accepts skips both the deny-list and
  * the shape-only value rules. Every other rule runs as it does on any other
  * attribute.
+ *
+ * A name {@link isReservedIdentifierAttributeKey} accepts additionally skips the
+ * personal-data pass. That is the stronger claim, which is why the list behind
+ * it is short and holds only trace and span addresses: the value is minted by a
+ * tracer, never typed by a person, and a decimal trace id carries no letter so
+ * no shape rule would hold it back. The vendor, armour and credential-keyword
+ * secret rules still run, so a key pasted under such a name is still scrubbed.
  */
 export function redactAttributeNative({
   key,
@@ -173,7 +189,8 @@ export function redactAttributeNative({
   compiledSecretPatterns?: readonly RegExp[];
   compiledPiiExceptions?: readonly RegExp[];
 }): { text: string; redactedCount: number } {
-  const namesAnIdentifier = isIdentifierAttributeName(key);
+  const reservesAnAddress = isReservedIdentifierAttributeKey(key);
+  const namesAnIdentifier = reservesAnAddress || isIdentifierAttributeName(key);
   if (
     policy.secrets.enabled &&
     value.length > 0 &&
@@ -188,6 +205,7 @@ export function redactAttributeNative({
     skipSecretRuleIds: namesAnIdentifier
       ? SHAPE_ONLY_SECRET_RULE_IDS
       : undefined,
+    skipPiiPass: reservesAnAddress,
     compiledSecretPatterns,
     compiledPiiExceptions,
     isAttributeValue: true,

--- a/platform/app/src/server/data-privacy/redaction/applyContentRedaction.ts
+++ b/platform/app/src/server/data-privacy/redaction/applyContentRedaction.ts
@@ -11,7 +11,10 @@ import {
   ESSENTIAL_PII_ENTITIES,
   redactEssentialPiiInText,
 } from "./essentialPii";
-import { isReservedIdentifierAttributeKey } from "./identifierHoldout";
+import {
+  isReservedIdentifierAttributeKey,
+  reservesTraceAddress,
+} from "./identifierHoldout";
 
 const NATIVE_PII_ENTITY_SET: ReadonlySet<string> = new Set(
   ESSENTIAL_PII_ENTITIES,
@@ -169,12 +172,15 @@ export function isIdentifierAttributeName(key: string): boolean {
  * the shape-only value rules. Every other rule runs as it does on any other
  * attribute.
  *
- * A name {@link isReservedIdentifierAttributeKey} accepts additionally skips the
+ * An attribute {@link reservesTraceAddress} accepts additionally skips the
  * personal-data pass. That is the stronger claim, which is why the list behind
  * it is short and holds only trace and span addresses: the value is minted by a
  * tracer, never typed by a person, and a decimal trace id carries no letter so
- * no shape rule would hold it back. The vendor, armour and credential-keyword
- * secret rules still run, so a key pasted under such a name is still scrubbed.
+ * no shape rule would hold it back. It takes the VALUE as well as the name,
+ * because the OTLP endpoint forwards caller-written attribute names verbatim —
+ * a reserved name over an email address does not get the personal-data pass
+ * turned off. The vendor, armour and credential-keyword secret rules still run,
+ * so a key pasted under such a name is still scrubbed.
  */
 export function redactAttributeNative({
   key,
@@ -189,8 +195,9 @@ export function redactAttributeNative({
   compiledSecretPatterns?: readonly RegExp[];
   compiledPiiExceptions?: readonly RegExp[];
 }): { text: string; redactedCount: number } {
-  const reservesAnAddress = isReservedIdentifierAttributeKey(key);
-  const namesAnIdentifier = reservesAnAddress || isIdentifierAttributeName(key);
+  const namesAnAddress = isReservedIdentifierAttributeKey(key);
+  const reservesAnAddress = reservesTraceAddress({ key, value });
+  const namesAnIdentifier = namesAnAddress || isIdentifierAttributeName(key);
   if (
     policy.secrets.enabled &&
     value.length > 0 &&

--- a/platform/app/src/server/data-privacy/redaction/bitcoinAddress.ts
+++ b/platform/app/src/server/data-privacy/redaction/bitcoinAddress.ts
@@ -114,11 +114,22 @@ const BC_HRP_EXPANDED = [
 ];
 
 /**
- * Whether a `bc1…` address carries a valid bech32 or bech32m checksum. Only the
- * mainnet human-readable part is checked, because that is the only prefix the
+ * Whether a `bc1…` address carries a valid checksum. Only the mainnet
+ * human-readable part is checked, because that is the only prefix the
  * recognizer's pattern matches.
+ *
+ * The first data character is the witness version, and BIP-350 pairs version 0
+ * with the bech32 constant and every later version with the bech32m constant.
+ * Accepting either constant for either version would accept BIP-350's own
+ * invalid vectors, so the pairing is enforced rather than the two constants
+ * simply being tried in turn.
+ *
+ * BIP-173 requires the whole address to be one case; mixed case is invalid and
+ * is rejected here rather than folded away, so this answers the same question
+ * a wallet would.
  */
 export function isBech32Address(value: string): boolean {
+  if (/[a-z]/.test(value) && /[A-Z]/.test(value)) return false;
   const lower = value.toLowerCase();
   if (!lower.startsWith("bc1")) return false;
   const data = lower.slice(3);
@@ -129,8 +140,9 @@ export function isBech32Address(value: string): boolean {
     if (index === -1) return false;
     values.push(index);
   }
-  const polymod = bech32Polymod(values);
-  return polymod === BECH32_CONSTANT || polymod === BECH32M_CONSTANT;
+  const witnessVersion = values[BC_HRP_EXPANDED.length]!;
+  const expected = witnessVersion === 0 ? BECH32_CONSTANT : BECH32M_CONSTANT;
+  return bech32Polymod(values) === expected;
 }
 
 /** Whether a CRYPTO match is a bitcoin address in either of its two forms. */

--- a/platform/app/src/server/data-privacy/redaction/bitcoinAddress.ts
+++ b/platform/app/src/server/data-privacy/redaction/bitcoinAddress.ts
@@ -104,6 +104,16 @@ function bech32Polymod(values: readonly number[]): number {
   return checksum >>> 0;
 }
 
+/**
+ * The highest witness version BIP-141 defines. The first data character is read
+ * from a 32-character alphabet, so it can carry 17 through 31 as easily as a
+ * real version — and those decode to no segwit program at all. Without this
+ * bound a `bc13…` string that happens to carry a valid bech32m checksum is
+ * classified as an address and replaced with a marker, which is the data loss
+ * this whole recognizer was rewritten to stop.
+ */
+const MAX_WITNESS_VERSION = 16;
+
 /** The "bc" human-readable part, expanded the way BIP-173 specifies. */
 const BC_HRP_EXPANDED = [
   "b".charCodeAt(0) >> 5,
@@ -119,10 +129,11 @@ const BC_HRP_EXPANDED = [
  * recognizer's pattern matches.
  *
  * The first data character is the witness version, and BIP-350 pairs version 0
- * with the bech32 constant and every later version with the bech32m constant.
+ * with the bech32 constant and versions 1 through 16 with the bech32m constant.
  * Accepting either constant for either version would accept BIP-350's own
  * invalid vectors, so the pairing is enforced rather than the two constants
- * simply being tried in turn.
+ * simply being tried in turn, and a version above 16 is rejected outright
+ * ({@link MAX_WITNESS_VERSION}).
  *
  * BIP-173 requires the whole address to be one case; mixed case is invalid and
  * is rejected here rather than folded away, so this answers the same question
@@ -141,6 +152,7 @@ export function isBech32Address(value: string): boolean {
     values.push(index);
   }
   const witnessVersion = values[BC_HRP_EXPANDED.length]!;
+  if (witnessVersion > MAX_WITNESS_VERSION) return false;
   const expected = witnessVersion === 0 ? BECH32_CONSTANT : BECH32M_CONSTANT;
   return bech32Polymod(values) === expected;
 }

--- a/platform/app/src/server/data-privacy/redaction/bitcoinAddress.ts
+++ b/platform/app/src/server/data-privacy/redaction/bitcoinAddress.ts
@@ -1,0 +1,141 @@
+import { createHash } from "node:crypto";
+
+/**
+ * Checksum validation for the bitcoin address forms the CRYPTO recognizer
+ * matches: base58check (the `1…` and `3…` legacy addresses) and bech32 /
+ * bech32m (the `bc1…` segwit addresses).
+ *
+ * WHY THIS EXISTS. The recognizer's pattern describes a SHAPE — 26 to 35
+ * characters starting with `1` or `3`, avoiding the four look-alike glyphs —
+ * and roughly one in sixty random 32-character hex strings fits it by accident.
+ * Every OTel trace id is a random 32-character hex string, so the pattern was
+ * replacing trace ids with a redaction marker, permanently, at every privacy
+ * level. A shape is not evidence; a checksum is. Both forms here carry one, so
+ * the recognizer can prove its own finding instead of guessing at it, which is
+ * what lets it keep running on values that otherwise look like identifiers.
+ *
+ * The odds a random hex string clears either checksum are about one in four
+ * billion (a 32-bit check), so this turns a measured 1.75% false-positive rate
+ * into one nobody will ever meet.
+ */
+
+const BASE58_ALPHABET =
+  "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+
+const BASE58_DIGIT: ReadonlyMap<string, number> = new Map(
+  Array.from(BASE58_ALPHABET, (character, index) => [character, index]),
+);
+
+/** Version byte + 20-byte hash + 4-byte checksum: every legacy address. */
+const BASE58_ADDRESS_BYTES = 25;
+const BASE58_CHECKSUM_BYTES = 4;
+
+/**
+ * Decode base58 into bytes, or null when the text holds a character the
+ * alphabet does not define. Long multiplication over a byte array rather than
+ * BigInt: the input is at most 35 characters, so this is a handful of
+ * iterations and keeps the hot ingestion path free of BigInt allocation.
+ */
+function base58Decode(value: string): Uint8Array | null {
+  const bytes: number[] = [0];
+  for (const character of value) {
+    const digit = BASE58_DIGIT.get(character);
+    if (digit === undefined) return null;
+    let carry = digit;
+    for (let i = 0; i < bytes.length; i++) {
+      carry += bytes[i]! * 58;
+      bytes[i] = carry & 0xff;
+      carry >>= 8;
+    }
+    while (carry > 0) {
+      bytes.push(carry & 0xff);
+      carry >>= 8;
+    }
+  }
+  // A leading `1` is base58 for a leading zero byte, which the arithmetic above
+  // cannot represent; the address version byte can be one, so restore them.
+  for (let i = 0; i < value.length && value[i] === "1"; i++) bytes.push(0);
+  return Uint8Array.from(bytes.reverse());
+}
+
+function sha256(data: Uint8Array): Buffer {
+  return createHash("sha256").update(data).digest();
+}
+
+/**
+ * Whether a legacy address carries its own base58check checksum: the first four
+ * bytes of the double SHA-256 of the payload must equal the trailing four bytes.
+ */
+export function isBase58CheckAddress(value: string): boolean {
+  const decoded = base58Decode(value);
+  if (!decoded || decoded.length !== BASE58_ADDRESS_BYTES) return false;
+  const payload = decoded.subarray(
+    0,
+    BASE58_ADDRESS_BYTES - BASE58_CHECKSUM_BYTES,
+  );
+  const checksum = decoded.subarray(
+    BASE58_ADDRESS_BYTES - BASE58_CHECKSUM_BYTES,
+  );
+  const expected = sha256(sha256(payload));
+  for (let i = 0; i < BASE58_CHECKSUM_BYTES; i++) {
+    if (expected[i] !== checksum[i]) return false;
+  }
+  return true;
+}
+
+const BECH32_CHARSET = "qpzry9x8gf2tvdw0s3jn54khce6mua7l";
+const BECH32_GENERATOR = [
+  0x3b6a57b2, 0x26508e6d, 0x1ea119fa, 0x3d4233dd, 0x2a1462b3,
+];
+/** BIP-173 (segwit v0) and BIP-350 (segwit v1+) differ only in this constant. */
+const BECH32_CONSTANT = 1;
+const BECH32M_CONSTANT = 0x2bc830a3;
+const BECH32_CHECKSUM_CHARS = 6;
+
+function bech32Polymod(values: readonly number[]): number {
+  let checksum = 1;
+  for (const value of values) {
+    const top = checksum >>> 25;
+    checksum = ((checksum & 0x1ffffff) << 5) ^ value;
+    for (let i = 0; i < BECH32_GENERATOR.length; i++) {
+      if ((top >>> i) & 1) checksum ^= BECH32_GENERATOR[i]!;
+    }
+  }
+  return checksum >>> 0;
+}
+
+/** The "bc" human-readable part, expanded the way BIP-173 specifies. */
+const BC_HRP_EXPANDED = [
+  "b".charCodeAt(0) >> 5,
+  "c".charCodeAt(0) >> 5,
+  0,
+  "b".charCodeAt(0) & 31,
+  "c".charCodeAt(0) & 31,
+];
+
+/**
+ * Whether a `bc1…` address carries a valid bech32 or bech32m checksum. Only the
+ * mainnet human-readable part is checked, because that is the only prefix the
+ * recognizer's pattern matches.
+ */
+export function isBech32Address(value: string): boolean {
+  const lower = value.toLowerCase();
+  if (!lower.startsWith("bc1")) return false;
+  const data = lower.slice(3);
+  if (data.length <= BECH32_CHECKSUM_CHARS) return false;
+  const values: number[] = [...BC_HRP_EXPANDED];
+  for (const character of data) {
+    const index = BECH32_CHARSET.indexOf(character);
+    if (index === -1) return false;
+    values.push(index);
+  }
+  const polymod = bech32Polymod(values);
+  return polymod === BECH32_CONSTANT || polymod === BECH32M_CONSTANT;
+}
+
+/** Whether a CRYPTO match is a bitcoin address in either of its two forms. */
+export function isBitcoinAddress(raw: string): boolean {
+  return raw.startsWith("bc1")
+    ? isBech32Address(raw)
+    : isBase58CheckAddress(raw);
+}

--- a/platform/app/src/server/data-privacy/redaction/bitcoinAddress.ts
+++ b/platform/app/src/server/data-privacy/redaction/bitcoinAddress.ts
@@ -114,6 +114,16 @@ function bech32Polymod(values: readonly number[]): number {
  */
 const MAX_WITNESS_VERSION = 16;
 
+/**
+ * The witness program bounds BIP-141 sets: 2 to 40 bytes in general, and for
+ * version 0 exactly the 20 bytes of a public-key hash or the 32 of a script
+ * hash. A length outside these encodes no output anyone can pay to.
+ */
+const MIN_WITNESS_PROGRAM_BYTES = 2;
+const MAX_WITNESS_PROGRAM_BYTES = 40;
+const P2WPKH_PROGRAM_BYTES = 20;
+const P2WSH_PROGRAM_BYTES = 32;
+
 /** The "bc" human-readable part, expanded the way BIP-173 specifies. */
 const BC_HRP_EXPANDED = [
   "b".charCodeAt(0) >> 5,
@@ -138,6 +148,13 @@ const BC_HRP_EXPANDED = [
  * BIP-173 requires the whole address to be one case; mixed case is invalid and
  * is rejected here rather than folded away, so this answers the same question
  * a wallet would.
+ *
+ * The checksum covers the characters, not their meaning, so the witness PROGRAM
+ * is checked too: the data groups must unpack to whole bytes with no stray
+ * padding, the program must be 2 to 40 bytes, and version 0 must be exactly the
+ * 20 or 32 bytes of a P2WPKH or P2WSH output. Without those a checksum-valid
+ * token that encodes no spendable output is classified and replaced, which is
+ * the loss this recognizer exists to prevent.
  */
 export function isBech32Address(value: string): boolean {
   if (/[a-z]/.test(value) && /[A-Z]/.test(value)) return false;
@@ -154,7 +171,54 @@ export function isBech32Address(value: string): boolean {
   const witnessVersion = values[BC_HRP_EXPANDED.length]!;
   if (witnessVersion > MAX_WITNESS_VERSION) return false;
   const expected = witnessVersion === 0 ? BECH32_CONSTANT : BECH32M_CONSTANT;
-  return bech32Polymod(values) === expected;
+  if (bech32Polymod(values) !== expected) return false;
+
+  const program = values.slice(
+    BC_HRP_EXPANDED.length + 1,
+    values.length - BECH32_CHECKSUM_CHARS,
+  );
+  return isValidWitnessProgram({ witnessVersion, program });
+}
+
+/**
+ * Whether the data groups after the witness version encode a witness program
+ * BIP-141 allows.
+ *
+ * `program` arrives as five-bit groups. Repacking them into bytes is what
+ * catches the two ways a checksum-valid string can still encode nothing: a
+ * length whose leftover bits do not fall away cleanly, and padding bits that
+ * were not zero. BIP-173 requires both, and a decoder that skips them accepts
+ * strings no wallet will spend to.
+ */
+function isValidWitnessProgram({
+  witnessVersion,
+  program,
+}: {
+  witnessVersion: number;
+  program: readonly number[];
+}): boolean {
+  let accumulator = 0;
+  let bits = 0;
+  let bytes = 0;
+  for (const group of program) {
+    accumulator = ((accumulator << 5) | group) & 0x7ff;
+    bits += 5;
+    if (bits >= 8) {
+      bits -= 8;
+      bytes++;
+    }
+  }
+  // Leftover bits are padding, so there must be fewer than a whole group of
+  // them and every one must be zero.
+  if (bits >= 5 || ((accumulator << (8 - bits)) & 0xff) !== 0) return false;
+
+  if (bytes < MIN_WITNESS_PROGRAM_BYTES || bytes > MAX_WITNESS_PROGRAM_BYTES) {
+    return false;
+  }
+  if (witnessVersion === 0) {
+    return bytes === P2WPKH_PROGRAM_BYTES || bytes === P2WSH_PROGRAM_BYTES;
+  }
+  return true;
 }
 
 /** Whether a CRYPTO match is a bitcoin address in either of its two forms. */

--- a/platform/app/src/server/data-privacy/redaction/essentialPii.ts
+++ b/platform/app/src/server/data-privacy/redaction/essentialPii.ts
@@ -114,6 +114,7 @@ function luhnValid(raw: string): boolean {
 const UATP_LENGTH = 15;
 const MASTERCARD_SERIES_FIRST = 2221;
 const MASTERCARD_SERIES_LAST = 2720;
+const MASTERCARD_SERIES_LENGTH = 16;
 
 /**
  * Whether a card scheme could have issued this number AT THIS LENGTH.
@@ -125,8 +126,13 @@ const MASTERCARD_SERIES_LAST = 2720;
  * and nothing else — so length, not the leading digit, is what separates the
  * two, and gating on length keeps UATP cards redacted.
  *
- * The 2-series is Mastercard's and stops at 2720, which also happens to close
- * the door on the timestamps of the 2030s before they arrive.
+ * The 2-series is Mastercard's, and it is gated on BOTH the 2221-2720 window
+ * and a length of sixteen, which is the only length Mastercard issues there.
+ * The window alone would expire: from about June 2040 a millisecond timestamp
+ * is thirteen digits starting `22`, and the microsecond and nanosecond widths
+ * follow, so this exact defect would come back by the calendar with no code
+ * change. Pinning the length closes the thirteen- and nineteen-digit widths
+ * permanently.
  *
  * Everything else is accepted, on purpose. A range excluded here is a real card
  * number stored in the clear and that is the worse failure by a wide margin, so
@@ -141,6 +147,7 @@ function issuedCardRange(digits: string): boolean {
   const first = digits.charCodeAt(0) - 48;
   if (first === 1) return digits.length === UATP_LENGTH;
   if (first === 2) {
+    if (digits.length !== MASTERCARD_SERIES_LENGTH) return false;
     const series = Number(digits.slice(0, 4));
     return (
       series >= MASTERCARD_SERIES_FIRST && series <= MASTERCARD_SERIES_LAST

--- a/platform/app/src/server/data-privacy/redaction/essentialPii.ts
+++ b/platform/app/src/server/data-privacy/redaction/essentialPii.ts
@@ -111,24 +111,42 @@ function luhnValid(raw: string): boolean {
   return sum % 10 === 0;
 }
 
+const UATP_LENGTH = 15;
+const MASTERCARD_SERIES_FIRST = 2221;
+const MASTERCARD_SERIES_LAST = 2720;
+
 /**
- * The issuer ranges payment cards are actually minted under: first digit 3
- * (Amex, Diners, JCB), 4 (Visa), 5 (Mastercard, Maestro) or 6 (Discover,
- * UnionPay, Maestro), plus Mastercard's 2221-2720 series.
+ * Whether a card scheme could have issued this number AT THIS LENGTH.
  *
- * Deliberately generous — a range missing here means a real card number stored
- * in the clear, so this errs towards accepting. It still excludes the whole 0,
- * 1, 7, 8 and 9 space, which is where machine numbers live: a millisecond Unix
- * timestamp is thirteen digits starting `17`, a nanosecond one nineteen digits
- * starting `17`, and both passed the Luhn check often enough to be replaced
- * with a card marker in real traffic.
+ * The collision this exists to break is a Unix timestamp: thirteen digits for
+ * milliseconds, sixteen for microseconds, nineteen for nanoseconds, all of them
+ * currently starting `17`, and one in ten of them passing the Luhn check. The
+ * only scheme numbering from a leading 1 is UATP, which issues fifteen digits
+ * and nothing else — so length, not the leading digit, is what separates the
+ * two, and gating on length keeps UATP cards redacted.
+ *
+ * The 2-series is Mastercard's and stops at 2720, which also happens to close
+ * the door on the timestamps of the 2030s before they arrive.
+ *
+ * Everything else is accepted, on purpose. A range excluded here is a real card
+ * number stored in the clear and that is the worse failure by a wide margin, so
+ * the 0, 7, 8 and 9 spaces stay in scope: they carry UnionPay's 81 and 88
+ * series, Voyager's 8699, fleet cards in the 7 series, and private-label cards
+ * that follow no published range at all. This check narrows Luhn, it does not
+ * replace it — an arbitrary digit run outside the 1 and 2 ranges is no better
+ * protected than it was before, and the identifier hold-out is what covers
+ * those.
  */
 function issuedCardRange(digits: string): boolean {
   const first = digits.charCodeAt(0) - 48;
-  if (first >= 3 && first <= 6) return true;
-  if (first !== 2) return false;
-  const series = Number(digits.slice(0, 4));
-  return series >= 2221 && series <= 2720;
+  if (first === 1) return digits.length === UATP_LENGTH;
+  if (first === 2) {
+    const series = Number(digits.slice(0, 4));
+    return (
+      series >= MASTERCARD_SERIES_FIRST && series <= MASTERCARD_SERIES_LAST
+    );
+  }
+  return true;
 }
 
 /**

--- a/platform/app/src/server/data-privacy/redaction/essentialPii.ts
+++ b/platform/app/src/server/data-privacy/redaction/essentialPii.ts
@@ -754,17 +754,25 @@ function maskSpans({
  * the self-proving recognizers, because customers send identifiers on purpose
  * and a shape alone does not make one personal data. Free text never takes the
  * exemption: a document with no spaces in it is still a document.
+ *
+ * `treatAsIdentifier` takes that exemption on the caller's word, for the one
+ * case the shape rule cannot see: a decimal trace id carries no letter, so it
+ * reads as a digit run. It is the SAME exemption, not a stronger one — the
+ * self-proving recognizers still run, so a value under such a name that carries
+ * a card's checksum and a real issuer range is still redacted.
  */
 export function redactEssentialPiiInText({
   text,
   entities,
   exceptPatterns,
   isAttributeValue = false,
+  treatAsIdentifier = false,
 }: {
   text: string;
   entities?: readonly string[];
   exceptPatterns?: readonly RegExp[];
   isAttributeValue?: boolean;
+  treatAsIdentifier?: boolean;
 }): PiiRedactionResult {
   if (
     typeof text !== "string" ||
@@ -780,7 +788,8 @@ export function redactEssentialPiiInText({
     allowed: entities ? new Set(entities) : null,
     exceptPatterns,
     protectedRanges,
-    isIdentifierShaped: isAttributeValue && isIdentifierShapedValue(text),
+    isIdentifierShaped:
+      isAttributeValue && (treatAsIdentifier || isIdentifierShapedValue(text)),
   });
   if (spans.length === 0) return { text, redactedCount: 0 };
 

--- a/platform/app/src/server/data-privacy/redaction/essentialPii.ts
+++ b/platform/app/src/server/data-privacy/redaction/essentialPii.ts
@@ -1,5 +1,10 @@
 import { formatPiiMarker } from "@langwatch/redaction";
 import { findPhoneNumbersInText } from "libphonenumber-js";
+import { isBitcoinAddress } from "./bitcoinAddress";
+import {
+  isIdentifierShapedValue,
+  MAX_IDENTIFIER_LENGTH,
+} from "./identifierHoldout";
 
 /**
  * Native, lightweight redaction for the "essential" PII level: the pattern- and
@@ -77,6 +82,14 @@ interface Recognizer {
    * identifier holds by accident. Only these recognizers keep running on a
    * value that is exclusively one identifier-shaped token
    * (see {@link isIdentifierShapedValue}).
+   *
+   * The claim has to be TRUE, and a shape is not a proof. Both entries that
+   * claimed it on a shape alone were destroying machine identifiers at every
+   * privacy level: the bitcoin pattern matched one in sixty random hex trace
+   * ids, and the card pattern accepted any Luhn-passing digit run, which a
+   * millisecond timestamp is about one time in ten. Both now validate. Before
+   * setting this flag, ask what a random hex string has to clear to match, and
+   * if the answer is "nothing", write a validator or leave the flag off.
    */
   isSelfProving?: boolean;
 }
@@ -96,6 +109,42 @@ function luhnValid(raw: string): boolean {
     double = !double;
   }
   return sum % 10 === 0;
+}
+
+/**
+ * The issuer ranges payment cards are actually minted under: first digit 3
+ * (Amex, Diners, JCB), 4 (Visa), 5 (Mastercard, Maestro) or 6 (Discover,
+ * UnionPay, Maestro), plus Mastercard's 2221-2720 series.
+ *
+ * Deliberately generous — a range missing here means a real card number stored
+ * in the clear, so this errs towards accepting. It still excludes the whole 0,
+ * 1, 7, 8 and 9 space, which is where machine numbers live: a millisecond Unix
+ * timestamp is thirteen digits starting `17`, a nanosecond one nineteen digits
+ * starting `17`, and both passed the Luhn check often enough to be replaced
+ * with a card marker in real traffic.
+ */
+function issuedCardRange(digits: string): boolean {
+  const first = digits.charCodeAt(0) - 48;
+  if (first >= 3 && first <= 6) return true;
+  if (first !== 2) return false;
+  const series = Number(digits.slice(0, 4));
+  return series >= 2221 && series <= 2720;
+}
+
+/**
+ * Whether a digit run is a plausible payment card: a valid length, an issuer
+ * range, and the Luhn check digit.
+ *
+ * Luhn ALONE is not proof. It is a single check digit, so one random digit run
+ * in ten passes it, and the recognizer's pattern accepts a bare run of 13 to 19
+ * digits with no separator and no nearby word to confirm it. Requiring the
+ * issuer range as well is what makes the CREDIT_CARD recognizer self-proving in
+ * the sense the flag claims.
+ */
+function creditCardValid(raw: string): boolean {
+  const digits = raw.replace(/\D/g, "");
+  if (digits.length < 13 || digits.length > 19) return false;
+  return issuedCardRange(digits) && luhnValid(raw);
 }
 
 function ibanValid(raw: string): boolean {
@@ -164,7 +213,7 @@ const RECOGNIZERS: Recognizer[] = [
   {
     entity: "CREDIT_CARD",
     regex: /\b\d(?:[ -]?\d){12,18}\b/g,
-    validate: luhnValid,
+    validate: creditCardValid,
     isSelfProving: true,
   },
   {
@@ -173,15 +222,24 @@ const RECOGNIZERS: Recognizer[] = [
     validate: ibanValid,
     isSelfProving: true,
   },
+  // An Ethereum address is the literal `0x` followed by exactly forty hex
+  // characters. The prefix is the proof here: a trace id, a span id and a digest
+  // are bare hex, so none of them carries it, and the `requiresSubstring` gate
+  // means the pattern is not even scanned for on text without it.
   {
     entity: "CRYPTO",
     regex: /\b0x[a-fA-F0-9]{40}\b/g,
     requiresSubstring: "0x",
     isSelfProving: true,
   },
+  // Bitcoin, legacy (`1…`/`3…`) and segwit (`bc1…`). The pattern alone is a
+  // SHAPE that roughly one in sixty random 32-character hex strings fits, which
+  // is to say one in sixty OTel trace ids; `isBitcoinAddress` verifies the
+  // base58check or bech32 checksum so a match is proof rather than a guess.
   {
     entity: "CRYPTO",
     regex: /\b(?:bc1[a-z0-9]{25,62}|[13][a-km-zA-HJ-NP-Z1-9]{25,34})\b/g,
+    validate: isBitcoinAddress,
     isSelfProving: true,
   },
   // Hyphenated US SSN is distinctive enough to fire without context.
@@ -280,60 +338,14 @@ interface Span {
 
 const HAS_WHITESPACE = /\s/;
 const HAS_LETTER = /[A-Za-z]/;
-const HAS_DIGIT = /\d/;
-const HAS_LOWERCASE = /[a-z]/;
-const HAS_UPPERCASE = /[A-Z]/;
-const UUID_VALUE =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-const HEX_RUN_VALUE = /^[0-9a-f]{16,}$/i;
-const BASE64ISH_VALUE = /^[A-Za-z0-9+/_=-]{16,}$/;
-
-/**
- * The characters an identifier is written with: letters, digits, and the
- * separators ids use. A quote, a brace, a comma or a slash means the text is
- * structure that HOLDS values rather than one identifier, so minified JSON and
- * URLs stay fully scanned.
- */
-const IDENTIFIER_VALUE = /^[A-Za-z0-9._:-]+$/;
 
 /**
  * The characters that carry on an identifier around a detected span. Narrower
- * than {@link IDENTIFIER_VALUE}: a dot or a colon ends the token here, so
- * sentence punctuation and `"phone":"+1..."` in minified JSON cannot pull a
- * detected number into an identifier that surrounds it.
+ * than the whole-value rule in {@link isIdentifierShapedValue}: a dot or a colon
+ * ends the token here, so sentence punctuation and `"phone":"+1..."` in minified
+ * JSON cannot pull a detected number into an identifier that surrounds it.
  */
 const IDENTIFIER_TOKEN_CHAR = /[A-Za-z0-9_-]/;
-
-/**
- * How far the identifier rules read. Identifiers people send as references are
- * far shorter, and the cap keeps both checks flat in the ingestion path however
- * long the text is.
- */
-const MAX_IDENTIFIER_LENGTH = 256;
-
-/**
- * Whether a whole attribute value is exclusively one identifier-shaped token:
- * letters together with digits and identifier separators
- * (`hosted-eu-20260812-09`), or the shape of a uuid, a hex digest, or a
- * base64-style token.
- *
- * The letter requirement is what keeps personal data in scope. A value built
- * only from digits and separators (`+31 6 12345678`, `20260812-09`, a bare card
- * number) is never identifier-shaped here, however much a customer means it as
- * a reference.
- */
-function isIdentifierShapedValue(value: string): boolean {
-  if (value.length > MAX_IDENTIFIER_LENGTH || !HAS_LETTER.test(value)) {
-    return false;
-  }
-  if (HAS_DIGIT.test(value) && IDENTIFIER_VALUE.test(value)) return true;
-  if (UUID_VALUE.test(value) || HEX_RUN_VALUE.test(value)) return true;
-  return (
-    BASE64ISH_VALUE.test(value) &&
-    HAS_LOWERCASE.test(value) &&
-    HAS_UPPERCASE.test(value)
-  );
-}
 
 /**
  * Whether a match sits inside a longer identifier: the identifier characters

--- a/platform/app/src/server/data-privacy/redaction/identifierHoldout.ts
+++ b/platform/app/src/server/data-privacy/redaction/identifierHoldout.ts
@@ -20,6 +20,15 @@
  *      digest, a ULID, a `prefix_<random>` record id. Nothing in such a value
  *      is personal data, so there is nothing for either engine to find.
  *
+ * WHY THERE ARE TWO VALUE RULES. The engines pay different prices for a wrong
+ * answer, so they get different rules and the difference is the whole point.
+ * `isIdentifierShapedValue` gates shape-only recognizers, which know nothing
+ * about people, so a false positive there costs a bitcoin pattern that would
+ * have misfired anyway. `isOpaqueIdentifierValue` gates the only pass that can
+ * find a person or a place, so a false positive there is a name stored in the
+ * clear, permanently. The second rule is therefore strictly the meaner one, and
+ * the two must not be collapsed back into one however similar they look.
+ *
  * WHAT IS DELIBERATELY NOT RESERVED. The correlation attributes a customer
  * fills in themselves — user, customer, thread and conversation identifiers.
  * Customers routinely put an email address or a full name in them, and a name on
@@ -77,6 +86,67 @@ export function isIdentifierShapedValue(value: string): boolean {
 }
 
 /**
+ * A maximal run of letters and digits — the parts of a value either side of the
+ * separators a person or a tracer writes between them.
+ */
+const ALPHANUMERIC_RUN = /[A-Za-z0-9]+/g;
+const HEX_RUN = /^[0-9a-f]+$/i;
+
+/**
+ * How long a run has to be before a person is unlikely to have typed it, and
+ * how many digits it has to carry. A ULID is twenty-six characters, a short hex
+ * span id is sixteen; the longest single-word surnames run to about eighteen,
+ * and none of them carry two digits.
+ */
+const MIN_OPAQUE_RUN_LENGTH = 16;
+const MIN_DIGITS_IN_OPAQUE_RUN = 2;
+
+/**
+ * Whether a whole attribute value is a machine identifier and nothing else —
+ * the question asked before a value is offered to the external analysis
+ * service, which is the only pass that finds names and places.
+ *
+ * A value qualifies on one of two grounds.
+ *
+ *   - It is a uuid. Uuids are written in five short groups, so no single run in
+ *     them is long enough for the rule below, and they are named here directly.
+ *   - It carries a run of at least sixteen letters and digits that is either
+ *     all hexadecimal, or mixes letters with at least two digits. That covers a
+ *     hex digest, a ULID, a `prefix_<random>` record id and a base64 token,
+ *     including when a readable prefix sits in front of the random part.
+ *
+ * Runs are measured BETWEEN separators and never across them. That is what
+ * keeps "maria.schmidt.1972" out: joined up it would clear the bar, but nobody
+ * types sixteen random characters in a row, and every segment of a written name
+ * is short. The same applies to "Jean-Claude-Van-Damme" and
+ * "Elm-Street-Apartment-4B".
+ *
+ * The digit requirement is what keeps "AnneMarieJohansson" out: it is one
+ * eighteen-character run, long enough on length alone, and only the absence of
+ * digits marks it as something a person wrote. Hex runs are exempt from the
+ * digit count because a sixteen-character identifier drawn entirely from a-f
+ * happens about once in eighty thousand, and no name is spelled in hex.
+ */
+export function isOpaqueIdentifierValue(value: string): boolean {
+  if (value.length > MAX_IDENTIFIER_LENGTH) return false;
+  if (UUID_VALUE.test(value)) return true;
+
+  for (const [run] of value.matchAll(ALPHANUMERIC_RUN)) {
+    if (isOpaqueRun(run)) return true;
+  }
+  return false;
+}
+
+/** Whether one run between separators is longer and denser than a person writes. */
+function isOpaqueRun(run: string): boolean {
+  if (run.length < MIN_OPAQUE_RUN_LENGTH) return false;
+  // A run with no letter is a digit run: a card, a phone, an account number.
+  if (!HAS_LETTER.test(run)) return false;
+  if (HEX_RUN.test(run)) return true;
+  return (run.match(/\d/g)?.length ?? 0) >= MIN_DIGITS_IN_OPAQUE_RUN;
+}
+
+/**
  * Attribute names whose value is a trace or span address minted by a tracer.
  *
  * The shape rule above already covers the usual spellings, because a trace id is
@@ -122,6 +192,6 @@ export function isHeldOutIdentifierAttribute({
   value: string;
 }): boolean {
   return (
-    isReservedIdentifierAttributeKey(key) || isIdentifierShapedValue(value)
+    isReservedIdentifierAttributeKey(key) || isOpaqueIdentifierValue(value)
   );
 }

--- a/platform/app/src/server/data-privacy/redaction/identifierHoldout.ts
+++ b/platform/app/src/server/data-privacy/redaction/identifierHoldout.ts
@@ -126,6 +126,22 @@ const MIN_DIGITS_IN_OPAQUE_RUN = 2;
  * digits marks it as something a person wrote. Hex runs are exempt from the
  * digit count because a sixteen-character identifier drawn entirely from a-f
  * happens about once in eighty thousand, and no name is spelled in hex.
+ *
+ * THE RULE IS WRONG IN BOTH DIRECTIONS, KNOWINGLY.
+ *
+ * It withholds a name run together with a number: "MariaSchmidt1972" is a
+ * sixteen-character run carrying four digits and is indistinguishable, by this
+ * rule, from a user id — which is what it usually is. Widening the rule to
+ * catch it means dropping the digit count, and that puts every name back in
+ * scope of being withheld, so the residual is accepted rather than traded.
+ *
+ * It fails to withhold a fair number of genuinely random tokens, because two
+ * digits is a real bar at short lengths and because `-` and `_` split a run:
+ * around 40% of nanoids and 17% of 32-character base64 tokens are submitted.
+ * Those are the analysis service's problem, not this rule's, and they are no
+ * worse off than before this rule existed. Counting `-` and `_` as part of a
+ * run would fix most of it, and would also start withholding
+ * "Jean-Claude-1963" — the same trade, refused for the same reason.
  */
 export function isOpaqueIdentifierValue(value: string): boolean {
   if (value.length > MAX_IDENTIFIER_LENGTH) return false;

--- a/platform/app/src/server/data-privacy/redaction/identifierHoldout.ts
+++ b/platform/app/src/server/data-privacy/redaction/identifierHoldout.ts
@@ -13,12 +13,17 @@
  *
  * Two questions are asked, in this order.
  *
- *   1. Does the attribute NAME reserve it? A short list of trace and span
- *      identifier names whose values are minted by a tracer and never written by
- *      a person. Nothing under them is ever analysed, whatever it holds.
+ *   1. Does the attribute NAME reserve it, AND does the value look like the
+ *      address that name promises? A short list of trace and span identifier
+ *      names whose values a tracer mints and a person never writes. The names
+ *      are not a protected namespace — the OTLP endpoint takes attributes as the
+ *      caller wrote them — so the value still has to be hex or decimal before
+ *      the name is allowed to turn the personal-data pass off.
  *   2. Is the VALUE exclusively one opaque identifier token? A uuid, a hex
  *      digest, a ULID, a `prefix_<random>` record id. Nothing in such a value
  *      is personal data, so there is nothing for either engine to find.
+ *      Exclusively: a value that merely CONTAINS one is prose, and prose is
+ *      analysed.
  *
  * WHY THERE ARE TWO VALUE RULES. The engines pay different prices for a wrong
  * answer, so they get different rules and the difference is the whole point.
@@ -93,6 +98,24 @@ const ALPHANUMERIC_RUN = /[A-Za-z0-9]+/g;
 const HEX_RUN = /^[0-9a-f]+$/i;
 
 /**
+ * The characters ONE identifier token is written with: letters, digits, the
+ * separators ids use, and what remains of base64's alphabet with its padding.
+ *
+ * This is a whole-value gate, and it is what makes the rule below mean what its
+ * name says. Without it a value qualifies as soon as it CONTAINS an opaque run,
+ * so "Jane Doe handled trace_<hex>" is withheld from the only pass that finds
+ * people, and the name is stored in the clear — the very failure this module
+ * exists to prevent, reached from the other side. A space, a quote, a brace, a
+ * comma or a slash means the text is prose or structure that HOLDS an
+ * identifier, and the words around that identifier are precisely what the
+ * analysis pass is for.
+ *
+ * `/` is left out deliberately, for the reason it is left out of
+ * {@link IDENTIFIER_VALUE}: a URL path carries identifiers AND names.
+ */
+const OPAQUE_TOKEN_VALUE = /^[A-Za-z0-9._:+=-]+$/;
+
+/**
  * How long a run has to be before a person is unlikely to have typed it, and
  * how many digits it has to carry. A ULID is twenty-six characters, a short hex
  * span id is sixteen; the longest single-word surnames run to about eighteen,
@@ -114,6 +137,11 @@ const MIN_DIGITS_IN_OPAQUE_RUN = 2;
  *     all hexadecimal, or mixes letters with at least two digits. That covers a
  *     hex digest, a ULID, a `prefix_<random>` record id and a base64 token,
  *     including when a readable prefix sits in front of the random part.
+ *
+ * Either way the WHOLE value has to be one token first
+ * ({@link OPAQUE_TOKEN_VALUE}). Carrying an identifier is not the same as being
+ * one: prose that quotes a trace id is still prose, and the sentence around the
+ * id is where the names are.
  *
  * Runs are measured BETWEEN separators and never across them. That is what
  * keeps "maria.schmidt.1972" out: joined up it would clear the bar, but nobody
@@ -145,6 +173,7 @@ const MIN_DIGITS_IN_OPAQUE_RUN = 2;
  */
 export function isOpaqueIdentifierValue(value: string): boolean {
   if (value.length > MAX_IDENTIFIER_LENGTH) return false;
+  if (!OPAQUE_TOKEN_VALUE.test(value)) return false;
   if (UUID_VALUE.test(value)) return true;
 
   for (const [run] of value.matchAll(ALPHANUMERIC_RUN)) {
@@ -173,7 +202,8 @@ function isOpaqueRun(run: string): boolean {
  *
  * Compared lower-cased, so a dialect that writes `metadata.TraceId` is covered.
  * Keep this list short and keep it to addresses: a name here turns the whole
- * personal-data pass off for that attribute.
+ * personal-data pass off for that attribute — and then only for a value that is
+ * shaped like an address, see {@link reservesTraceAddress}.
  */
 const RESERVED_IDENTIFIER_ATTRIBUTE_KEYS: ReadonlySet<string> = new Set([
   "metadata.oteltraceid",
@@ -194,6 +224,39 @@ export function isReservedIdentifierAttributeKey(key: string): boolean {
 }
 
 /**
+ * What a trace or span address is actually written as: hexadecimal (W3C, B3 and
+ * the OTel SDKs) or a decimal integer (the Datadog and B3 bridges, which is the
+ * case the reserved list exists for at all).
+ *
+ * The names above are NOT a protected namespace. Span attributes arrive on the
+ * OTLP endpoint exactly as the caller wrote them, so anyone can send
+ * `metadata.trace_id` holding an email address — and a name-only hold-out would
+ * then turn the personal-data pass off for it and store that email in the
+ * clear. Requiring the value to be address-shaped closes that without costing
+ * anything real: a value this rejects is still put to the ordinary
+ * {@link isOpaqueIdentifierValue} question, which is what catches a uuid-shaped
+ * or prefixed trace id. Only a value that is neither an address nor an opaque
+ * token loses the exemption, and that value was never an address.
+ */
+const TRACE_ADDRESS_VALUE = /^(?:[0-9a-f]{8,64}|\d{1,32})$/i;
+
+/**
+ * Whether this attribute is a reserved trace/span name carrying something that
+ * could be the address the name promises.
+ */
+export function reservesTraceAddress({
+  key,
+  value,
+}: {
+  key: string;
+  value: string;
+}): boolean {
+  return (
+    isReservedIdentifierAttributeKey(key) && TRACE_ADDRESS_VALUE.test(value)
+  );
+}
+
+/**
  * Whether one attribute is held back from PII analysis altogether: reserved by
  * name, or a value that is exclusively one opaque identifier token.
  *
@@ -207,7 +270,5 @@ export function isHeldOutIdentifierAttribute({
   key: string;
   value: string;
 }): boolean {
-  return (
-    isReservedIdentifierAttributeKey(key) || isOpaqueIdentifierValue(value)
-  );
+  return reservesTraceAddress({ key, value }) || isOpaqueIdentifierValue(value);
 }

--- a/platform/app/src/server/data-privacy/redaction/identifierHoldout.ts
+++ b/platform/app/src/server/data-privacy/redaction/identifierHoldout.ts
@@ -1,0 +1,127 @@
+/**
+ * One notion of "this attribute is a machine identifier, not content", shared by
+ * both redaction engines: the native in-process recognizers and the external
+ * analysis service the strict level escalates to.
+ *
+ * WHY IT IS SHARED. Redaction runs BEFORE the event store, so a marker written
+ * over a trace id is permanent: the original is never written down and the link
+ * back to the customer's own logs is gone for good. Both engines guess, and both
+ * guess wrong on opaque identifiers — a shape-only regex reads a hex id as a
+ * bitcoin address, a name/place model reads one as a person or a city. Holding
+ * identifiers back has to be one rule consulted twice, because a rule that only
+ * one engine knows about is a rule the other engine will undo.
+ *
+ * Two questions are asked, in this order.
+ *
+ *   1. Does the attribute NAME reserve it? A short list of trace and span
+ *      identifier names whose values are minted by a tracer and never written by
+ *      a person. Nothing under them is ever analysed, whatever it holds.
+ *   2. Is the VALUE exclusively one opaque identifier token? A uuid, a hex
+ *      digest, a ULID, a `prefix_<random>` record id. Nothing in such a value
+ *      is personal data, so there is nothing for either engine to find.
+ *
+ * WHAT IS DELIBERATELY NOT RESERVED. The correlation attributes a customer
+ * fills in themselves — user, customer, thread and conversation identifiers.
+ * Customers routinely put an email address or a full name in them, and a name on
+ * the reserved list would mean storing that in the clear. They are covered by
+ * question 2 like every other attribute: an opaque value is held back, personal
+ * data is still redacted.
+ */
+
+const HAS_LETTER = /[A-Za-z]/;
+const HAS_DIGIT = /\d/;
+const HAS_LOWERCASE = /[a-z]/;
+const HAS_UPPERCASE = /[A-Z]/;
+const UUID_VALUE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const HEX_RUN_VALUE = /^[0-9a-f]{16,}$/i;
+const BASE64ISH_VALUE = /^[A-Za-z0-9+/_=-]{16,}$/;
+
+/**
+ * The characters an identifier is written with: letters, digits, and the
+ * separators ids use. A quote, a brace, a comma or a slash means the text is
+ * structure that HOLDS values rather than one identifier, so minified JSON and
+ * URLs stay fully scanned.
+ */
+const IDENTIFIER_VALUE = /^[A-Za-z0-9._:-]+$/;
+
+/**
+ * How far the identifier rules read. Identifiers people send as references are
+ * far shorter, and the cap keeps the checks flat in the ingestion path however
+ * long the text is.
+ */
+export const MAX_IDENTIFIER_LENGTH = 256;
+
+/**
+ * Whether a whole attribute value is exclusively one identifier-shaped token:
+ * letters together with digits and identifier separators
+ * (`hosted-eu-20260812-09`), or the shape of a uuid, a hex digest, or a
+ * base64-style token.
+ *
+ * The letter requirement is what keeps personal data in scope. A value built
+ * only from digits and separators (`+31 6 12345678`, `20260812-09`, a bare card
+ * number) is never identifier-shaped here, however much a customer means it as
+ * a reference.
+ */
+export function isIdentifierShapedValue(value: string): boolean {
+  if (value.length > MAX_IDENTIFIER_LENGTH || !HAS_LETTER.test(value)) {
+    return false;
+  }
+  if (HAS_DIGIT.test(value) && IDENTIFIER_VALUE.test(value)) return true;
+  if (UUID_VALUE.test(value) || HEX_RUN_VALUE.test(value)) return true;
+  return (
+    BASE64ISH_VALUE.test(value) &&
+    HAS_LOWERCASE.test(value) &&
+    HAS_UPPERCASE.test(value)
+  );
+}
+
+/**
+ * Attribute names whose value is a trace or span address minted by a tracer.
+ *
+ * The shape rule above already covers the usual spellings, because a trace id is
+ * hex and a span id is hex. This list is for the ones it cannot see: a decimal
+ * trace id (what a B3 or Datadog bridge emits) carries no letter, so the shape
+ * rule reads it as a digit run and hands it to the recognizers. Naming the
+ * attribute settles it without asking what the value looks like.
+ *
+ * Compared lower-cased, so a dialect that writes `metadata.TraceId` is covered.
+ * Keep this list short and keep it to addresses: a name here turns the whole
+ * personal-data pass off for that attribute.
+ */
+const RESERVED_IDENTIFIER_ATTRIBUTE_KEYS: ReadonlySet<string> = new Set([
+  "metadata.oteltraceid",
+  "metadata.otelspanid",
+  "metadata.traceid",
+  "metadata.spanid",
+  "metadata.trace_id",
+  "metadata.span_id",
+  "trace_id",
+  "span_id",
+  "traceid",
+  "spanid",
+]);
+
+/** Whether this attribute name is one of the reserved trace/span addresses. */
+export function isReservedIdentifierAttributeKey(key: string): boolean {
+  return RESERVED_IDENTIFIER_ATTRIBUTE_KEYS.has(key.toLowerCase());
+}
+
+/**
+ * Whether one attribute is held back from PII analysis altogether: reserved by
+ * name, or a value that is exclusively one opaque identifier token.
+ *
+ * Attribute values only. Free text — a log body, a status message, the chat
+ * content itself — is content by definition and always analysed.
+ */
+export function isHeldOutIdentifierAttribute({
+  key,
+  value,
+}: {
+  key: string;
+  value: string;
+}): boolean {
+  return (
+    isReservedIdentifierAttributeKey(key) || isIdentifierShapedValue(value)
+  );
+}

--- a/specs/data-privacy/pii-redaction.feature
+++ b/specs/data-privacy/pii-redaction.feature
@@ -218,6 +218,17 @@ Feature: Redacting personal data from traces
     When a trace is ingested with an attribute whose whole value is a valid taproot address
     Then the stored attribute has the address redacted
 
+  # A checksum is only as narrow as the grammar behind it. The character after
+  # the "bc1" prefix is the witness version, read from a thirty-two character
+  # alphabet, and bitcoin defines only the first seventeen of those. A token
+  # carrying one of the other fifteen decodes to no address at all, so treating
+  # it as one would put a marker over a value that was never a payment address.
+  @unit
+  Scenario: A token using a witness version bitcoin does not define is not an address
+    Given the resolved PII level for "web-app" is essential
+    When a trace is ingested with an attribute holding a checksum valid token whose witness version is seventeen
+    Then the stored attribute still reads as it was sent
+
   @unit
   Scenario: A millisecond timestamp is not read as a card number
     Given the resolved PII level for "web-app" is essential
@@ -284,6 +295,25 @@ Feature: Redacting personal data from traces
     When a trace is ingested with a reserved trace identifier attribute
     Then the analysis service never received that value
 
+  # The reserved names are not a namespace anyone owns. Attributes arrive on the
+  # ingestion endpoint spelled exactly as the sender wrote them, so a sender can
+  # put an email address under a trace identifier name - by mistake or on
+  # purpose - and a rule that went on the name alone would then store that email
+  # in the clear forever. The name earns the exemption only for a value that
+  # could be the address it promises, which is to say hexadecimal or decimal.
+  @unit
+  Scenario: A reserved trace identifier name holding an email address is redacted at the strict level
+    Given the resolved PII level for "web-app" is strict
+    When a trace is ingested with a reserved trace identifier attribute whose value is an email address
+    Then the stored attribute has the email address redacted
+    And the analysis service never received the email address in the clear
+
+  @unit
+  Scenario: A reserved trace identifier name holding an email address is still redacted
+    Given the resolved PII level for "web-app" is essential
+    When a trace is ingested with a reserved trace identifier attribute whose value is an email address
+    Then the stored attribute has the email address redacted
+
   @unit
   Scenario: A corpus of opaque identifiers is never sent for analysis
     Given the resolved PII level for "web-app" is strict
@@ -306,6 +336,17 @@ Feature: Redacting personal data from traces
   Scenario: Prose that holds a name is still sent for analysis
     Given the resolved PII level for "web-app" is strict
     When a trace is ingested with an attribute whose value is a sentence naming a person
+    Then the analysis service received that sentence
+
+  # Holding a value back is decided on the WHOLE value, never on a part of it.
+  # Carrying an identifier is not the same as being one: a sentence that quotes
+  # a trace id is still a sentence, and the words around the id are exactly what
+  # the analysis pass exists to read. Deciding on a part would mean any message
+  # with a request id in it stopped being scanned for names.
+  @unit
+  Scenario: Prose that quotes an opaque identifier is still sent for analysis
+    Given the resolved PII level for "web-app" is strict
+    When a trace is ingested with an attribute whose value is a sentence naming a person next to a trace identifier
     Then the analysis service received that sentence
 
   @unit

--- a/specs/data-privacy/pii-redaction.feature
+++ b/specs/data-privacy/pii-redaction.feature
@@ -325,6 +325,18 @@ Feature: Redacting personal data from traces
     When a trace is ingested with a reserved trace identifier attribute whose value is an email address
     Then the stored attribute has the email address redacted
 
+  # A decimal trace identifier and a card number are the same shape, so no rule
+  # reading the value alone can separate them. What separates them is proof: the
+  # reserved name stands the shape-only detectors down, the way it does for any
+  # identifier, and leaves running the ones that can prove what they are looking
+  # at. A number carrying a card checksum inside a range a scheme actually
+  # issues is redacted whatever attribute it arrives under.
+  @unit
+  Scenario: A card number written under a reserved trace identifier name is still redacted
+    Given the resolved PII level for "web-app" is essential
+    When a trace is ingested with a reserved trace identifier attribute whose value is a valid card number
+    Then the stored attribute has the card number redacted
+
   @unit
   Scenario: A corpus of opaque identifiers is never sent for analysis
     Given the resolved PII level for "web-app" is strict

--- a/specs/data-privacy/pii-redaction.feature
+++ b/specs/data-privacy/pii-redaction.feature
@@ -187,8 +187,12 @@ Feature: Redacting personal data from traces
   # crypto marker, at every level including the default. It now verifies the
   # address checksum, so real addresses are still redacted and hex ids are not.
   # The card pattern accepted any digit run that passes the Luhn check, which a
-  # thirteen-digit millisecond timestamp does about one time in ten; it now also
-  # requires a digit range a payment card is actually issued under.
+  # thirteen-digit millisecond timestamp does about one time in ten. It now also
+  # asks whether a card scheme could have issued that number at that length,
+  # which the timestamps cannot be: the only scheme numbering from a leading one
+  # issues fifteen digits, and timestamps are thirteen, sixteen or nineteen. The
+  # rule is deliberately narrow, because a range excluded here is a real card
+  # number stored in the clear, so every other leading digit is still accepted.
 
   @unit
   Scenario: An opaque trace identifier survives redaction at the default level
@@ -209,10 +213,28 @@ Feature: Redacting personal data from traces
     Then the stored attribute has the address redacted
 
   @unit
+  Scenario: A taproot address is still redacted
+    Given the resolved PII level for "web-app" is essential
+    When a trace is ingested with an attribute whose whole value is a valid taproot address
+    Then the stored attribute has the address redacted
+
+  @unit
   Scenario: A millisecond timestamp is not read as a card number
     Given the resolved PII level for "web-app" is essential
     When a trace is ingested whose input holds a thirteen digit millisecond timestamp that passes the Luhn check
     Then the stored input still contains the timestamp
+
+  @unit
+  Scenario: A timestamp is not read as a card number at any of its widths
+    Given the resolved PII level for "web-app" is essential
+    When a trace is ingested whose input holds millisecond, microsecond and nanosecond timestamps that pass the Luhn check
+    Then the stored input still contains every timestamp
+
+  @unit
+  Scenario: Every card scheme in circulation is still redacted
+    Given the resolved PII level for "web-app" is essential
+    When a trace is ingested whose input holds one valid card number from each scheme
+    Then the stored input has every card number redacted
 
   @unit
   Scenario: A card number written without separators is still redacted
@@ -226,6 +248,15 @@ Feature: Redacting personal data from traces
   # therefore filtered before they leave the process: an attribute whose whole
   # value is one opaque identifier is never sent, and neither is an attribute
   # under one of the reserved trace and span identifier names, whatever it holds.
+  #
+  # "Opaque" has to be a high bar here, higher than the bar the native engine
+  # uses, because holding a value back from this service is what stops a name or
+  # a place ever being found in it. A value qualifies only when it carries a run
+  # of at least sixteen letters and digits that no person would type: a hex
+  # digest, or a run mixing letters with at least two digits. A hyphenated or
+  # run-together name - "Jean-Claude-Van-Damme", "AnneMarieJohansson",
+  # "Saint-Jean-Baptiste-Hospital" - has no such run, so it still goes for
+  # analysis and is still redacted.
   #
   # Correlation attributes a customer fills in themselves - the user, customer,
   # thread and conversation identifiers - are deliberately NOT on the reserved
@@ -266,6 +297,18 @@ Feature: Redacting personal data from traces
     Then the analysis service received that value
 
   @unit
+  Scenario: A hyphenated or run-together name is still sent for analysis
+    Given the resolved PII level for "web-app" is strict
+    When a trace is ingested with attributes holding names written with hyphens, with dots and with no separator at all
+    Then the analysis service received every one of them
+
+  @unit
+  Scenario: A place written as one hyphenated token is still sent for analysis
+    Given the resolved PII level for "web-app" is strict
+    When a trace is ingested with an attribute whose value is a hyphenated place name
+    Then the analysis service received that value
+
+  @unit
   Scenario: A reserved identifier attribute survives even when its value is all digits
     Given the resolved PII level for "web-app" is essential
     When a trace is ingested with a reserved trace identifier attribute written in decimal
@@ -277,6 +320,13 @@ Feature: Redacting personal data from traces
     When a log record is ingested with an attribute whose whole value is a hex identifier
     Then the analysis service never received that value
     And the analysis service received the log body
+
+  @unit
+  Scenario: Metric attributes hold opaque identifiers back from analysis
+    Given the resolved PII level for "web-app" is strict
+    When a metric is ingested with one attribute holding a hex identifier and another holding prose
+    Then the analysis service never received the identifier
+    And the analysis service received the prose
 
   # Detection heuristics over-trigger on business identifiers that merely look
   # like PII: a 14-digit reservation number reads as a credit card, an

--- a/specs/data-privacy/pii-redaction.feature
+++ b/specs/data-privacy/pii-redaction.feature
@@ -229,6 +229,17 @@ Feature: Redacting personal data from traces
     When a trace is ingested with an attribute holding a checksum valid token whose witness version is seventeen
     Then the stored attribute still reads as it was sent
 
+  # The same argument one level down. A checksum covers the characters, not what
+  # they mean, so a token can clear it and still encode no output anyone could
+  # pay to: a payload that does not unpack to whole bytes, one shorter or longer
+  # than any witness program, or a version zero payload that is neither of the
+  # two lengths that version allows.
+  @unit
+  Scenario: A token whose witness program bitcoin does not allow is not an address
+    Given the resolved PII level for "web-app" is essential
+    When a trace is ingested with an attribute holding a checksum valid token whose witness program length is not one bitcoin allows
+    Then the stored attribute still reads as it was sent
+
   @unit
   Scenario: A millisecond timestamp is not read as a card number
     Given the resolved PII level for "web-app" is essential

--- a/specs/data-privacy/pii-redaction.feature
+++ b/specs/data-privacy/pii-redaction.feature
@@ -174,6 +174,110 @@ Feature: Redacting personal data from traces
     When a trace is ingested with an attribute whose whole value is an email address with digits in it
     Then the stored attribute has the email address redacted
 
+  # The hold-out above only bites when nothing claims to have PROVEN its finding.
+  # A recognizer marked self-proving keeps running on an identifier-shaped value,
+  # on the promise that it carries a checksum or a marker no machine identifier
+  # holds by accident. Two of them did not keep that promise, and a trace id is
+  # not recoverable once a marker is written over it, because redaction runs
+  # before the event store.
+  #
+  # The bitcoin address pattern matched on shape alone - any 26 to 35 character
+  # token that starts with "1" or "3" and avoids the four look-alike characters -
+  # so roughly one in sixty random 32-character hex trace ids was stored as a
+  # crypto marker, at every level including the default. It now verifies the
+  # address checksum, so real addresses are still redacted and hex ids are not.
+  # The card pattern accepted any digit run that passes the Luhn check, which a
+  # thirteen-digit millisecond timestamp does about one time in ten; it now also
+  # requires a digit range a payment card is actually issued under.
+
+  @unit
+  Scenario: An opaque trace identifier survives redaction at the default level
+    Given the resolved PII level for "web-app" is essential
+    When a trace is ingested with an attribute whose whole value is a hex trace identifier starting with a one
+    Then the stored attribute still reads as it was sent
+
+  @unit
+  Scenario: A corpus of random hex identifiers survives the native engine intact
+    Given the resolved PII level for "web-app" is essential
+    When two thousand random hex trace identifiers are ingested as whole attribute values
+    Then every stored attribute still reads as it was sent
+
+  @unit
+  Scenario: A real bitcoin address is still redacted
+    Given the resolved PII level for "web-app" is essential
+    When a trace is ingested with an attribute whose whole value is a valid bitcoin address
+    Then the stored attribute has the address redacted
+
+  @unit
+  Scenario: A millisecond timestamp is not read as a card number
+    Given the resolved PII level for "web-app" is essential
+    When a trace is ingested whose input holds a thirteen digit millisecond timestamp that passes the Luhn check
+    Then the stored input still contains the timestamp
+
+  @unit
+  Scenario: A card number written without separators is still redacted
+    Given the resolved PII level for "web-app" is essential
+    When a trace is ingested whose input holds a card number written as one digit run
+    Then the stored input has the card number redacted
+
+  # The strict level adds names and locations, which need the external analysis
+  # service. That service guesses from wording, and an opaque identifier gives it
+  # nothing to go on, so it labels hex ids as people and places. Values are
+  # therefore filtered before they leave the process: an attribute whose whole
+  # value is one opaque identifier is never sent, and neither is an attribute
+  # under one of the reserved trace and span identifier names, whatever it holds.
+  #
+  # Correlation attributes a customer fills in themselves - the user, customer,
+  # thread and conversation identifiers - are deliberately NOT on the reserved
+  # list. Customers routinely put an email address in them, and never analysing
+  # them would store that email in the clear. They are covered by the same rule
+  # as every other attribute: held back when the whole value is one opaque
+  # identifier, analysed when it is personal data.
+
+  @unit
+  Scenario: An opaque identifier attribute value is never sent for analysis
+    Given the resolved PII level for "web-app" is strict
+    When a trace is ingested with an attribute whose whole value is a hex span identifier
+    Then the analysis service never received that value
+    And the stored attribute still reads as it was sent
+
+  @unit
+  Scenario: A reserved trace identifier attribute is never sent for analysis
+    Given the resolved PII level for "web-app" is strict
+    When a trace is ingested with a reserved trace identifier attribute
+    Then the analysis service never received that value
+
+  @unit
+  Scenario: A corpus of opaque identifiers is never sent for analysis
+    Given the resolved PII level for "web-app" is strict
+    When a trace is ingested with attributes holding hex identifiers, dashed uuids and prefixed ULIDs
+    Then the analysis service received none of them
+
+  @unit
+  Scenario: Prose that holds a name is still sent for analysis
+    Given the resolved PII level for "web-app" is strict
+    When a trace is ingested with an attribute whose value is a sentence naming a person
+    Then the analysis service received that sentence
+
+  @unit
+  Scenario: A customer identifier that holds a person name is still sent for analysis
+    Given the resolved PII level for "web-app" is strict
+    When a trace is ingested with a user identifier attribute whose value is a person name
+    Then the analysis service received that value
+
+  @unit
+  Scenario: A reserved identifier attribute survives even when its value is all digits
+    Given the resolved PII level for "web-app" is essential
+    When a trace is ingested with a reserved trace identifier attribute written in decimal
+    Then the stored attribute still reads as it was sent
+
+  @unit
+  Scenario: Log attributes hold opaque identifiers back from analysis
+    Given the resolved PII level for "web-app" is strict
+    When a log record is ingested with an attribute whose whole value is a hex identifier
+    Then the analysis service never received that value
+    And the analysis service received the log body
+
   # Detection heuristics over-trigger on business identifiers that merely look
   # like PII: a 14-digit reservation number reads as a credit card, an
   # "orders@acme.internal" queue address reads as a personal email. Exception

--- a/specs/data-privacy/pii-redaction.feature
+++ b/specs/data-privacy/pii-redaction.feature
@@ -231,6 +231,12 @@ Feature: Redacting personal data from traces
     Then the stored input still contains every timestamp
 
   @unit
+  Scenario: A timestamp from the 2040s is not read as a card number
+    Given the resolved PII level for "web-app" is essential
+    When a trace is ingested whose input holds a Luhn passing number inside the Mastercard range at a width Mastercard does not issue
+    Then the stored input still contains the number
+
+  @unit
   Scenario: Every card scheme in circulation is still redacted
     Given the resolved PII level for "web-app" is essential
     When a trace is ingested whose input holds one valid card number from each scheme
@@ -283,6 +289,18 @@ Feature: Redacting personal data from traces
     Given the resolved PII level for "web-app" is strict
     When a trace is ingested with attributes holding hex identifiers, dashed uuids and prefixed ULIDs
     Then the analysis service received none of them
+
+  @unit
+  Scenario: A corpus of short opaque tokens is almost never sent for analysis
+    Given the resolved PII level for "web-app" is strict
+    When a trace is ingested with twelve hundred short hex span identifiers and prefixed ULIDs
+    Then the analysis service received fewer than one in a hundred of them
+
+  @unit
+  Scenario: A corpus of written names is still sent for analysis
+    Given the resolved PII level for "web-app" is strict
+    When a trace is ingested with two thousand generated names as attribute values
+    Then the analysis service received every one of them
 
   @unit
   Scenario: Prose that holds a name is still sent for analysis


### PR DESCRIPTION
## For humans

When a trace arrives, we scrub personal data out of it before we store it. That
scrubbing was also eating the trace's own ID numbers.

Those IDs are just random strings — the ones you use to match a trace in
LangWatch against the same request in your own logs. Two of our detectors were
guessing wrong about them. One thought a random string of hex characters might
be a Bitcoin wallet address, because it has roughly the right length and starts
with the right character. The other thought a millisecond timestamp might be a
credit card number, because both are long runs of digits. Neither detector
actually checked; they matched on appearance alone.

Separately, at the strictest privacy setting we also send every value on the
trace to a name-and-place detection model. That model has no idea what an ID is,
so it happily labelled them as people and cities.

When one of those guesses fired, the ID was replaced with a placeholder such as
`[CRYPTO]` or `[LOCATION]` — permanently, because the scrubbing happens before
anything is written down. The original is gone. Matching that trace back to your
own logs then silently fails, and anything that joins on a user or conversation
ID quietly drops rows.

This PR makes both detectors prove their findings before they act, and stops
sending values that are obviously just IDs to the model in the first place.
Genuine personal data — real emails, phone numbers, card numbers, names,
locations — is still redacted. One detail is worth stating plainly rather than
claiming nothing changed: the card detector now asks which card scheme could
have issued a number before it acts, and the rule for that is drawn narrowly on
purpose, because a card range left out of it would be a real card number stored
in the clear. See the card section below for exactly what it excludes and why.

---

## The defects

Two independent defects. They stack, and both are silent.

### 1. `isSelfProving` was a lie for two recognizers

`platform/app/src/server/data-privacy/redaction/essentialPii.ts`

The native engine holds machine identifiers back from the recognizers that have
only a shape to go on: an attribute value that is exclusively one
identifier-shaped token runs **only** the recognizers flagged `isSelfProving`,
on the promise that those carry a checksum or a marker no machine identifier
holds by accident. That hold-out is the guard. `isSelfProving` is the bypass.

**`CRYPTO`, bitcoin** (`essentialPii.ts:182-186` before this change):

```ts
{
  entity: "CRYPTO",
  regex: /\b(?:bc1[a-z0-9]{25,62}|[13][a-km-zA-HJ-NP-Z1-9]{25,34})\b/g,
  isSelfProving: true,
},
```

No `validate`. So any 26-35 character token that starts with `1` or `3` and
happens to avoid `0 O I l` matched, whole value replaced with `[CRYPTO]`. A
32-character hex OTel trace id fits that description about 1.75% of the time —
and this fires at **every** PII level, including the default, so a project does
not have to opt into anything to lose data.

**`CREDIT_CARD`** (`essentialPii.ts:168`): `validate: luhnValid` on a pattern
that accepts a bare run of 13 to 19 digits with no separator and no nearby
context word. Luhn is one check digit, so one random digit run in ten passes it.
A thirteen-digit millisecond Unix timestamp is a random digit run.

### 2. The strict escalation submitted everything, unfiltered

`platform/app/src/server/app-layer/traces/span-pii-redaction.service.ts`

`collectStringEntries` and `collectRecordEntries` pushed every non-empty string
value on the span, log record or metric — attributes, event attributes, link
attributes, `status.message`, resource attributes — into the batch sent to the
external analysis service. No attribute-key allowlist, no identifier-shape
hold-out, no placeholder swap. The only bound was a cumulative 250,000-character
budget. `isIdentifierShapedValue` was never consulted on this path at all.

The service's name/place model scores its guesses at a flat 0.85 and we post at
`min_threshold: 0.5` (`piiCheck.ts:377`), so every guess is accepted. Raising the
threshold is not a fix: it would have to exceed 0.85, which turns
`LOCATION`/`PERSON` off entirely.

```mermaid
flowchart TD
  A(["Attribute value: 32-char hex trace id"]) --> B{"Native pass: identifier-shaped?"}
  B -->|"yes, so only self-proving recognizers run"| C{"bitcoin regex, no checksum"}
  C -->|"matches"| D(["[CRYPTO], at every PII level"])
  C -->|"no match"| E{"strict level?"}
  B -->|"no"| E
  E -->|"no"| F(["value kept"])
  E -->|"yes"| G["Analysis batch: no key list, no shape guard"]
  G --> H{"name/place model, score 0.85 vs threshold 0.5"}
  H -->|"labels it"| I(["[LOCATION] / [PERSON]"])
  H -->|"no finding"| F
```

## The fix

**One shared notion of "this is a machine identifier"**, in a new module
`platform/app/src/server/data-privacy/redaction/identifierHoldout.ts`, read by
both engines. `isIdentifierShapedValue` moved there from `essentialPii.ts` —
there is now one definition, not two — and it gained a companion reserved-name
catalog. A rule only one engine knows about is a rule the other engine undoes.

**Native `CRYPTO` now validates the checksum.** New module
`redaction/bitcoinAddress.ts` implements base58check (double SHA-256 over the
21-byte payload) and bech32 / bech32m (BIP-173 / BIP-350 polymod). The
recognizer keeps `isSelfProving` because with a 32-bit checksum behind it the
claim is finally true: real addresses are still redacted, and a random hex string
clears it about one time in four billion. Dropping the flag instead would have
been simpler and strictly worse — a bare bitcoin address in an attribute is
itself identifier-shaped, so it would have stopped being redacted at all.

The witness version is bounded as well as the checksum. The character after the
`bc1` prefix is read from a 32-value alphabet and BIP-141 defines sixteen of
them, so a `bc13…` token carrying a valid bech32m checksum decodes to no segwit
program and must not be classified. The test vector for it is a pair — one
payload written at version 1 and at version 17, built the same way — so the
version 1 member validating is what shows the version 17 member is rejected for
its version and not for a checksum that was never going to line up.

So is the witness **program**. A checksum covers the characters of a string, not
what they mean, so a token can clear 30 bits of checksum and still encode no
output anyone could pay to: data groups that do not repack into whole bytes,
padding bits that are not zero, a program below 2 bytes or above 40, or a
version 0 program that is neither the 20 bytes of a public-key hash nor the 32
of a script hash. All four are now rejected. Only one BIP-173 invalid vector is
checksum-valid for mainnet `bc1` (version 0 at 16 bytes) — the rest fail the
checksum first and so prove nothing about the program rule — so the other
vectors are constructed, each with a control at a length bitcoin allows.

**Native `CREDIT_CARD` now asks whether a scheme could have issued the number at
that length**, as well as Luhn. The collision to break is a Unix timestamp: 13
digits for milliseconds, 16 for microseconds, 19 for nanoseconds, all currently
starting `17`, and one in ten passing Luhn. The only scheme numbering from a
leading 1 is UATP, which issues 15 digits and nothing else — so **length**, not
the leading digit, separates the two. A leading 1 is therefore accepted only at
15 digits; the 2-series is Mastercard's 2221-2720 window, which also closes the
door on the timestamps of the 2030s before they arrive.

Every other leading digit is accepted, deliberately. An earlier revision of this
PR restricted issuers to 3-6 and that turned out to drop four ranges in
circulation — UATP, UnionPay's 81 series, Voyager, and 7-series fleet cards — so
the rule was narrowed to the timestamp collision it exists for. This check
**narrows** Luhn, it does not replace it: an arbitrary digit run outside the 1
and 2 ranges is no better protected than before (about 8.5% of random 13-, 16-
and 19-digit runs are still redacted, against 10% on `main`), and the identifier
hold-out is what covers those.

**The analysis-service path gets the same hold-out**, applied in both collectors
so all three lambda paths are covered (span, log, metric attributes). A held-out
attribute is *not* counted as skipped: "skipped" means "may still hold personal
data we did not scan for" and marks the span partially redacted, which an opaque
address is not. Free text — a log body, a status message — is content by
definition and is still always submitted.

**Holding back is decided on the whole value, never on a part of it.** A value
qualifies only when it is one identifier token end to end — no space, quote,
brace, comma or slash — before any run inside it is considered. Carrying an
identifier is not the same as being one: a support note, a log line or an error
string routinely quotes the trace id it is about, and a rule that fired on the
embedded run would stop scanning all of them, storing the names in the clear.
Minified JSON and URL paths stay fully scanned for the same reason.

**A short reserved-name catalog**, consulted by both engines: `metadata.traceId`,
`metadata.otelTraceId`, `metadata.trace_id`, the span-id spellings and the bare
`trace_id` / `span_id` roots, compared case-insensitively. This is for the case
the shape rule cannot see — a **decimal** trace id (what a B3 or Datadog bridge
emits) carries no letter, so the shape rule reads it as a digit run and hands it
to the recognizers.

Those names are **not** a namespace anyone owns — attributes arrive on the
ingestion endpoint spelled exactly as the sender wrote them — so the catalog is
bounded on both sides.

By value: a reserved name earns the exemption only over something that could be
the address it promises, hexadecimal or decimal. Nothing real is lost, because a
value the address check rejects still goes to the ordinary opaque-value
question, which is what catches a uuid-shaped or prefixed trace id. An email
address under `metadata.trace_id` is redacted.

By strength: the exemption a reserved name buys is exactly the one an
identifier-**shaped** value already gets — the shape-only recognizers stand
down, the self-proving ones keep running — rather than turning the
personal-data pass off. A decimal trace id and a card number are the same shape,
and no rule reading the value can separate them; narrowing by length does not
either, since a Datadog trace id is a uint64 and 19 digits is ordinary for both.
What separates them is proof, so `4111111111111111` under `metadata.trace_id` is
still `[CREDIT_CARD]` while a 32-digit decimal trace id survives. `skipPiiPass`
had one caller and no longer exists, so nothing can reach the stronger claim by
accident.

### One deliberate narrowing, stated plainly

The customer-supplied correlation attributes — `langwatch.user_id`,
`langwatch.customer_id`, `langwatch.thread_id`, `gen_ai.conversation.id` — are
**not** on the reserved-name list. Customers routinely put an email address or a
full name in those fields, and an unconditional never-analyse rule would store
that in the clear. They are covered by the value half of the hold-out like every
other attribute: an opaque value is held back, an email is still redacted. The
outcome asked for (an opaque user id survives) is delivered; the way it is
delivered does not open a personal-data hole. There is a test for each direction.

## Numbers

Synthetic, seeded corpora generated in the tests themselves — no traffic. Every
row below is produced by a test in this PR and moves if the rule moves.

| corpus | before | after |
|---|---|---|
| 2,000 random 32-char hex ids, native engine, attribute value | 35 destroyed (1.75%) | 0 |
| 2,000 random 16-char hex span ids, native engine | 0 | 0 |
| `{"ttft.first_token_at_ms": 1757500123454}` | `[CREDIT_CARD]` | unchanged |
| 600 trace ids and uuids reaching the analysis service, at each of three seeds | all submitted | 0 submitted |
| 1,200 short tokens (16-hex span ids, `session_<ULID>`) reaching the analysis service, at each of three seeds | all submitted | under 0.1% submitted |
| 2,000 generated multi-part names, 1,452 of them written as a single token, reaching the analysis service | 732 withheld by an earlier revision of this PR | 0 withheld |
| Luhn-valid card, one per scheme in circulation (14 schemes) | 10 redacted | 14 redacted |
| random 13-, 16- and 19-digit runs read as cards | 10% on `main` | ~8.5% |

The `before` column on the first three rows is a code fact rather than a sample:
the collectors had no filter, so every collected attribute value was submitted.

The two identifier rows are split because the rule promises different things
about them. A 32-character hex id or a uuid is held back for every value. A
16-character span id or a ULID is held back on a digit count, so a draw that
comes up short of two digits is submitted — measured at 0.04% and 0.09% over
20,000 samples each. The tests assert an exact zero for the first group and a
rate bound for the second, rather than an exact zero that happens to hold for
one seed. The name row measures a defect
introduced by this PR and fixed within it — the first revision reused the native
engine's shape rule on the analysis path, and that rule calls any mixed-case
16-character run an identifier, which a hyphenated or run-together name is. The
two paths now use two rules; the reasoning is in `identifierHoldout.ts`.

## Tests

Spec first: 31 new scenarios in `specs/data-privacy/pii-redaction.feature`, each
`@unit`-tagged and bound by a `@scenario` annotation
(`check-feature-parity.ts` reports 57/57 bound for that file).

- `essentialPii.machineIdentifiers.unit.test.ts` — the statistical corpora
  through the real native engine, plus the positive cases that must keep working:
  the genesis-block P2PKH address, a P2SH address, the BIP-173 bech32 reference
  address, an address with one character altered (must survive), Visa / Amex /
  Mastercard-2-series / space-separated cards (must still be redacted), and
  Luhn-valid numbers inside the Mastercard window at 13 and 19 digits, which
  are the timestamps of the 2040s and must not be read as cards.
- `span-pii-redaction.identifierHoldout.test.ts` — asserts on **what was
  submitted** to the batch function rather than on a mocked response, which is
  the actual observable contract. Covers span, log and metric paths, the reserved
  name with a value no shape rule would catch, and the negative controls that
  guard the boundary: names written with hyphens, with dots and with no separator
  at all, a hyphenated place and street address, and a run-together name carried
  in the chat content itself, each of which must still be submitted. A control
  built on a name with a space in it would pass whatever the rule does, so none
  of these has one. The name control is a seeded generator of 2,000 names run
  through the real `redactSpan`, not a hand-picked list: it is the direction
  that regressed once, and it also sources the name row in the table above by
  counting what the looser shape rule would have withheld from the same corpus.
- `identifierHoldout.unit.test.ts` and `bitcoinAddress.unit.test.ts` — colocated
  tests for the two validators the fix turns on. The bitcoin vectors are real
  mainnet addresses (P2PKH including the leading-zero case, P2SH, segwit v0,
  taproot), their single-character mutations, and the BIP-350 invalid vectors
  that pair a witness version with the wrong checksum constant. The witness
  version and witness program vectors are constructed in pairs — the same
  payload at a value bitcoin allows and at one it does not — so each rejection
  is attributable to the rule under test rather than to the checksum. The
  hold-out
  tests pin both directions, including an explicit assertion that the looser
  shape rule gets the name cases wrong — so a future merge of the two rules
  fails loudly rather than quietly reopening the leak.

No existing fixture is changed by this PR. An earlier revision re-pointed one
exception-pattern test onto a different card number; that is reverted, because
the card rule described above detects the original 14-digit reservation number
again.

## Known residual

The hold-out rule is wrong in both directions, knowingly, and the trade between
them is the reason it is not tuned further. All figures below are over 20,000
seeded samples per shape.

**It withholds some names.** A name run together with a number —
`MariaSchmidt1972`, `JeanClaudeVanDamme1963`, `Grossbeerenstrasse142` — is a
16-character run carrying digits, which is also the exact shape of a real user
id, and usually is one. These are held back from analysis and stored verbatim.
Widening the rule to catch them means dropping the digit requirement, and that
puts every run-together name back at risk of being withheld — the regression
this PR already had once. The residual is accepted rather than traded.

**It fails to withhold a share of genuinely random tokens.** Fraction still
reaching the analysis service, re-measured over 20,000 seeded samples per shape
against the rule as it now stands: nanoid (21 chars) **41.1%**, standard base64
at 32 chars **45.1%**, standard base64 at 43 chars **51.4%**, base64url at 32
chars 17.3%, an `sk-` key with 48 chars 0.3%, bare ULID 0.1%, 16-char hex span
id 0.1%, 32-char hex trace id 0%.

Three causes. Two digits is a real bar at short lengths; `-` and `_` split a
run, which most nanoids contain; and a `/` anywhere in the value disqualifies it
outright, which is what moved the standard-base64 rows. That last one is the
price of the whole-value rule above, and it is a deliberate trade rather than an
oversight: allowing `/` would hold back
`…/users/jane.doe/a3f91c02b7d84e6590fb17c4d2e83b5a` and store the name in it
permanently. Identifier alphabets in practice are base64**url** for exactly the
reason `/` is excluded here, and that row is unchanged. Counting `-` and `_` as
part of a run would fix most of the rest and would also start withholding
`Jean-Claude-1963` — the same trade, refused for the same reason.

These values are no worse off than before this PR, which held back none of them,
but they are a residual of the class this PR exists to fix and they belong in
the open. The analysis service is the pass that destroys identifiers, so a
nanoid reaching it can still be mangled.

**An identifier inside a larger JSON blob attribute** (`metadata._raw`, for
example) is still submitted, because the value as a whole is structure rather
than one identifier token. Holding those back would mean parsing JSON attribute
values field by field. Not in this change; the hold-out is defined on values
that are exclusively one identifier.

All three are documented next to the rule in `identifierHoldout.ts`, so the
next person to touch it meets the trade before they change it.

## Verification

- `pnpm typecheck` — clean
- `pnpm typecheck:all` — clean
- `pnpm test:unit run src/server/app-layer/traces/__tests__/ src/server/data-privacy src/server/tracer src/components/settings` — 87 files, 1,339 passed, 1 skipped
- `pnpm --filter @langwatch/redaction test` — 124 passed
- `check:feature-parity` — exits 0; 57/57 bound for `pii-redaction.feature`
- biome, run the way CI gates it (`biome-new-violations.sh` against the merge
  base, not a changed-file lint): 3,350 diagnostics on both sides, no new
  violations
- `secrets-scan.sh gitleaks` with the PR's own range — 9 commits scanned, no
  leaks found

### Test fixtures the secrets gate reports

Two, settled the way this repo already distinguishes between them. The base64
fixture in the hold-out suite is assembled at run time now, and its earlier
literal is cleared by fingerprint in `.gitleaksignore` — the gate walks the
commit range rather than the tree, so replacing a literal does not clear the
commit that introduced it. The two bech32m vectors cannot be assembled at run
time, because the checksum is the thing under test and a test that computed it
would assert one implementation against a copy of itself; they are named in
`.gitleaks.toml`, scoped by value and anchored. Neither is a credential: a
bech32 string is a public address, the version 17 member is not an address at
all, and the version 1 member encodes counted-up bytes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Machine-generated trace and span identifiers are preserved and excluded from PII analysis.
  * Reserved identifier attributes in spans, logs, and metrics remain private while relevant prose, names, places, and content continue to be analyzed.
  * Bitcoin addresses are redacted only when checksum-valid.
  * Timestamp-like values are less likely to be misidentified as payment cards.
  * Payment-card detection now requires both a valid issuer range and checksum.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->




