### PR TITLE
fix(redaction): keep stored-object media URLs out of shaped_api_key

### DIFF
--- a/packages/redaction/src/__tests__/secrets.unit.test.ts
+++ b/packages/redaction/src/__tests__/secrets.unit.test.ts
@@ -1200,3 +1200,55 @@ describe("detectSecretsInText", () => {
     });
   });
 });
+
+describe("redactSecretsInText, stored-object media URLs (#8077)", () => {
+  const STORED_OBJECT_ID = "so_000000000002Ckax9GYtOrWQlpTOa";
+
+  describe("given an /api/files reference whose project id has no allowlisted prefix", () => {
+    it("keeps the URL intact instead of eating the path as one token", () => {
+      const url = `/api/files/local-dev-project/${STORED_OBJECT_ID}`;
+
+      const { text, redactedCount } = redactSecretsInText({ text: url });
+
+      expect(text).toBe(url);
+      expect(redactedCount).toBe(0);
+    });
+
+    it("keeps it intact inside span content too", () => {
+      const content = `{"type":"audio","url":"/api/files/local-dev-project/${STORED_OBJECT_ID}"}`;
+
+      const { text } = redactSecretsInText({ text: content });
+
+      expect(text).toBe(content);
+    });
+  });
+
+  describe("given the production and legacy URL shapes", () => {
+    it("keeps a project_-prefixed reference intact", () => {
+      const url = `/api/files/project_awkQTIH4hwMYdL8KsHbo1/${STORED_OBJECT_ID}`;
+
+      const { text } = redactSecretsInText({ text: url });
+
+      expect(text).toBe(url);
+    });
+
+    it("keeps a legacy id-only reference intact", () => {
+      const url = `/api/files/${STORED_OBJECT_ID}`;
+
+      const { text } = redactSecretsInText({ text: url });
+
+      expect(text).toBe(url);
+    });
+  });
+
+  describe("given a shaped key that carries a slash but no record-id tail", () => {
+    it("still redacts it, so the guard costs no recall", () => {
+      const input = "creds acme_Zx9Qm2Lp7Rt4Vw8s/Yb3Ke6Ng1Jd5Hf0Cu here";
+
+      const { text, redactedCount } = redactSecretsInText({ text: input });
+
+      expect(text).toContain("[SECRET]");
+      expect(redactedCount).toBeGreaterThanOrEqual(1);
+    });
+  });
+});

--- a/packages/redaction/src/secrets.ts
+++ b/packages/redaction/src/secrets.ts
@@ -366,6 +366,10 @@ const RECORD_ID_PREFIXES = new Set([
   "acct",
   "cus",
   "sub",
+  // Stored objects: edge media extraction rewrites span media to
+  // `/api/files/{projectId}/so_<id>` references, and that id is a record id
+  // like any other minted here (#8077).
+  "so",
 ]);
 
 /**
@@ -696,9 +700,27 @@ const VALUE_RULES: ValueRule[] = [
       `${TOKEN_START}([A-Za-z][A-Za-z0-9]{1,11})[_-]([A-Za-z0-9_+/-]{${SHAPED_TOKEN_MIN_BODY},})${TOKEN_END}`,
       "g",
     ),
-    accept: (groups) =>
-      !isNonCredentialPrefix(groups[1] ?? "") &&
-      isKeyShapedBody(groups[2] ?? ""),
+    accept: (groups) => {
+      if (isNonCredentialPrefix(groups[1] ?? "")) return false;
+      const body = groups[2] ?? "";
+      // The body class crosses `/`, so a URL path can be swallowed as one
+      // token: `/api/files/local-dev-project/so_<id>` matches with prefix
+      // `local` and a body that runs across the slash, and eating it turns a
+      // media reference into a 404 (#8077). A span whose LAST path segment
+      // names itself a record id is a reference to that record, not a
+      // credential, whatever the earlier segments look like. The guard stays
+      // narrow on purpose: a real key containing `/` keeps its protection
+      // unless its terminal segment carries an allowlisted record prefix,
+      // which key material has no reason to do.
+      const lastSlash = body.lastIndexOf("/");
+      if (lastSlash !== -1) {
+        const tailPrefix = /^([A-Za-z][A-Za-z0-9]{1,11})[_-]/.exec(
+          body.slice(lastSlash + 1),
+        )?.[1];
+        if (tailPrefix && isNonCredentialPrefix(tailPrefix)) return false;
+      }
+      return isKeyShapedBody(body);
+    },
     precondition: (text) => text.includes("_") || text.includes("-"),
   },
   {


### PR DESCRIPTION
## Problem

`shaped_api_key`'s body class crosses `/`, so a media reference like `/api/files/local-dev-project/so_<id>` matches as one token: prefix `local` isn't an allowlisted record prefix, the body inherits the stored-object id's entropy, and the whole `<project>/<so_id>` segment becomes `[SECRET]`. Redaction is irreversible at ingestion, so the media 404s and the trace drawer's MediaPart renders `media-part-missing`. Production `project_` ids survive only because `project` is allowlisted — self-hosted and dev/test slugs get eaten.

Fixes #8077

## Approach (kept narrow on purpose — this is a security-sensitive control)

Per the issue's caution, this is not a blanket `/api/files/` allowlist:

- `shaped_api_key` now **declines a match whose last path segment names itself an allowlisted record id** (`/^([A-Za-z][A-Za-z0-9]{1,11})[_-]/` tail whose prefix passes `isNonCredentialPrefix`). A span whose terminal segment is a product record id is a *reference to that record*, whatever the earlier segments look like — eating it destroys a reference and protects nothing.
- Recall is preserved: a real key containing `/` keeps its protection unless its terminal segment carries a record prefix, which key material has no reason to do. A dedicated test pins that (`acme_…/…` base64-ish body still redacts).
- `so` joins `RECORD_ID_PREFIXES`: stored-object ids are record ids minted by this product exactly like `span_`/`trace_`/`scenario_`.

## Testing

- New tests pin the reported repro exactly: the non-allowlisted slug URL survives bare and inside span content; the production `project_…` and legacy id-only shapes keep working; and the recall guard above.
- The two repro tests **fail on the previous code** (verified by stash-and-run); full redaction suite: 129 passed, zero regressions across the existing corpus cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stored-object media URLs are now preserved in text and JSON content.
  * Secret redaction now avoids masking valid file references while continuing to redact credential-like strings, including paths with record identifiers.
  * Credentials followed by record references remain fully redacted, including paths ending in supported `sha_` or `uuid-` identifiers.
* **Tests**
  * Added coverage for supported stored-object URL formats and credential-like edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->